### PR TITLE
feat: Add Kubernetes base manifests (task 1.5)

### DIFF
--- a/deployments/k8s/base/configmap.yaml
+++ b/deployments/k8s/base/configmap.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: meridian-config
+  labels:
+    app: meridian
+    component: ledger
+data:
+  log_level: "info"
+  log_format: "json"
+  port: "8080"
+  grpc_port: "9090"
+  metrics_enabled: "true"
+  metrics_path: "/metrics"
+  health_check_path: "/health"
+  readiness_check_path: "/health/ready"
+  liveness_check_path: "/health/live"
+  startup_check_path: "/health/startup"

--- a/deployments/k8s/base/deployment.yaml
+++ b/deployments/k8s/base/deployment.yaml
@@ -1,0 +1,138 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: meridian
+  labels:
+    app: meridian
+    component: ledger
+    tier: backend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: meridian
+      component: ledger
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: meridian
+        component: ledger
+        tier: backend
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: meridian
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: meridian
+        image: meridian:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        - name: grpc
+          containerPort: 9090
+          protocol: TCP
+        env:
+        - name: PORT
+          value: "8080"
+        - name: GRPC_PORT
+          value: "9090"
+        - name: LOG_LEVEL
+          valueFrom:
+            configMapKeyRef:
+              name: meridian-config
+              key: log_level
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        startupProbe:
+          httpGet:
+            path: /health/startup
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 2
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 30
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        - name: config
+          mountPath: /etc/meridian
+          readOnly: true
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      - name: config
+        configMap:
+          name: meridian-config
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - meridian
+              topologyKey: kubernetes.io/hostname
+      terminationGracePeriodSeconds: 30

--- a/deployments/k8s/base/kustomization.yaml
+++ b/deployments/k8s/base/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+metadata:
+  name: meridian-base
+
+namespace: default
+
+labels:
+- pairs:
+    app: meridian
+    managed-by: kustomize
+
+resources:
+- serviceaccount.yaml
+- configmap.yaml
+- deployment.yaml
+- service.yaml
+
+images:
+- name: meridian
+  newTag: latest
+
+configMapGenerator:
+- name: meridian-version
+  literals:
+  - version=dev
+  - commit=unknown
+  - build_date=unknown
+
+generatorOptions:
+  disableNameSuffixHash: false
+  labels:
+    app: meridian

--- a/deployments/k8s/base/service.yaml
+++ b/deployments/k8s/base/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: meridian
+  labels:
+    app: meridian
+    component: ledger
+    tier: backend
+spec:
+  type: ClusterIP
+  selector:
+    app: meridian
+    component: ledger
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+    protocol: TCP
+  - name: grpc
+    port: 9090
+    targetPort: grpc
+    protocol: TCP
+  sessionAffinity: None

--- a/deployments/k8s/base/serviceaccount.yaml
+++ b/deployments/k8s/base/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: meridian
+  labels:
+    app: meridian
+    component: ledger
+automountServiceAccountToken: true


### PR DESCRIPTION
Implements Task Master task 1.5 from Epic #1

## Changes
- Created Kubernetes deployment with 3 replicas and rolling updates
- Configured comprehensive health probes (liveness, readiness, startup)
- Implemented security contexts (non-root user, read-only filesystem, drop ALL capabilities)
- Added service with HTTP (8080) and gRPC (9090) ports
- Created ConfigMap for application configuration
- Added dedicated ServiceAccount
- Configured Kustomize base with proper resource management

## Security Features
- Non-root user (UID 65532)
- Read-only root filesystem
- seccomp profile (RuntimeDefault)
- Pod anti-affinity for high availability
- Resource limits and requests

## Configuration
- 3 replicas for high availability
- Rolling updates with maxSurge: 1, maxUnavailable: 0
- Prometheus annotations for metrics scraping

Part of https://github.com/bjcoombs/meridian/issues/1