### PR TITLE
fix: Add missing permissions and pin Trivy version in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   packages: write
+  security-events: write  # Required for SARIF upload to Security tab
 
 env:
   REGISTRY: ghcr.io
@@ -77,7 +78,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner on image
         if: github.event_name != 'pull_request'
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           format: 'sarif'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pull-requests: read
   checks: write
+  security-events: write  # Required for SARIF upload to Security tab
 
 jobs:
   golangci-lint:
@@ -50,7 +51,7 @@ jobs:
           cache: true
 
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.22.0
         with:
           args: '-no-fail -fmt sarif -out gosec-results.sarif ./...'
 
@@ -60,7 +61,7 @@ jobs:
           sarif_file: gosec-results.sarif
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
## Summary

Fixes failing build and security scan workflows on develop branch by adding missing permissions and pinning action versions across **multiple workflows**.

## Problems Fixed

**1. SARIF Upload Failures (build.yml & lint.yml):**
- Workflows couldn't upload security scan results to GitHub Security tab
- Error: "Resource not accessible by integration"
- Root cause: Missing `security-events: write` permission

**2. Unpinned Action Versions (build.yml & lint.yml):**
- Using `@master` tags (floating, non-reproducible)
- Violates supply chain security best practices
- Inconsistent versions across workflows

## Changes Made

### `.github/workflows/build.yml`

1. **Added `security-events: write` permission** (line 14)
   - Required for `github/codeql-action/upload-sarif@v3`
   - Allows Trivy SARIF results upload to Security tab

2. **Pinned Trivy action to @0.28.0** (line 81)
   - Changed from `aquasecurity/trivy-action@master`
   - Ensures reproducible builds

### `.github/workflows/lint.yml`

3. **Added `security-events: write` permission** (line 13)
   - Required for both gosec and Trivy SARIF uploads
   - Prevents permission errors on security-scan job

4. **Pinned gosec action to @v2.22.0** (line 54)
   - Changed from `securego/gosec@master`
   - Matches version strategy in security.yml

5. **Pinned Trivy action to @0.28.0** (line 64)
   - Changed from `aquasecurity/trivy-action@master`
   - Consistent with build.yml and security.yml

## Testing

- Both workflows built successfully in CI
- No functional changes to scan behavior
- SARIF uploads will now succeed with proper permissions

## Impact

✅ **Build workflow will succeed** on develop branch  
✅ **Lint workflow security scans will upload** results correctly  
✅ **Security tab will show findings** from all workflows  
✅ **Reproducible builds** with pinned action versions  
✅ **Supply chain security** improved across all workflows  
✅ **Consistent versions** (Trivy @0.28.0, gosec @v2.22.0)

## Related Issues

Resolves failing builds:
- https://github.com/meridianhub/meridian/actions/runs/18881685302 (Security Scan)
- https://github.com/meridianhub/meridian/actions/runs/18881685284 (Build)

Prevents similar failures in lint.yml security-scan job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build and lint pipeline security scanning tools to stable, pinned versions for enhanced reliability and consistency.
  * Enhanced integration with GitHub's Security tab to display comprehensive vulnerability scan reports.
  * Improved CI/CD stability through explicit version management of critical tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->