### PR TITLE
fix: Correct Trivy image tag format in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
           format: 'sarif'
           output: 'trivy-image-results.sarif'
 


### PR DESCRIPTION
## Summary

Fixes the Trivy security scanner failure in the build workflow by using the correct image tag format.

## Problem

The Trivy scanner was failing with:
```
unable to find the specified image "ghcr.io/meridianhub/meridian:84842aa7a07836a70441c0e8ef865d867bc4b71d"
```

The issue was that Trivy was trying to scan an image using the raw commit SHA as a tag, but the `docker/metadata-action` generates tags with a "sha-" prefix.

## Changes Made

- Updated Trivy image-ref from `${{ github.sha }}` to `sha-${{ github.sha }}`
- This matches the actual tag format generated by the metadata action

## Testing

This will be validated when the build workflow runs against this PR.

## Risk Assessment

Low - This is a configuration fix that aligns the Trivy scanner with the actual image tags being generated. No functional changes to the application or build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure for improved container image tagging in security scanning processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->