### PR TITLE
fix: Use image digest for Trivy scanner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.meta.outputs.digest }}
           format: 'sarif'
           output: 'trivy-image-results.sarif'
 


### PR DESCRIPTION
## Summary

Corrects the Trivy scanner configuration to use the image digest instead of a tag reference.

## Problem

PR #38 attempted to fix the Trivy scanner by using `sha-${{ github.sha }}`, but the metadata action actually creates shortened SHA tags (7 characters), not full SHA hashes. This caused Trivy to look for:
- `ghcr.io/meridianhub/meridian:sha-1950201bdecfc92c7da9d728f809f542c98e20dc` (doesn't exist)

When the actual tag created was:
- `ghcr.io/meridianhub/meridian:sha-1950201` (shortened, 7 chars)

## Solution

Use the digest output from `docker/metadata-action` which references the exact image via its content-addressable hash (e.g., `sha256:abc123...`). This is more reliable than tag-based references and ensures we always scan the exact image that was just built.

## Testing

This will be validated when the build workflow runs on this PR and successfully scans the image.

## Risk Assessment

Low - Configuration change only. Uses the standard pattern for referencing Docker images by digest, which is the most reliable method.