### PR TITLE
fix: Capture Docker image digest from build step for Trivy scanner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -88,7 +89,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: aquasecurity/trivy-action@0.28.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.meta.outputs.digest }}
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
           format: 'sarif'
           output: 'trivy-image-results.sarif'
 


### PR DESCRIPTION
## Summary
Fixes the Trivy scanner failure in the Build workflow where it was unable to parse the image reference due to an empty digest.

## Problem
The Trivy scanner was referencing `steps.meta.outputs.digest`, but the `docker/metadata-action` doesn't output the digest—only the `docker/build-push-action` does.

Error:
```
image scan error: could not parse reference: ghcr.io/meridianhub/meridian@
```

## Solution
- Added `id: build` to the `docker/build-push-action` step
- Changed Trivy `image-ref` from `steps.meta.outputs.digest` to `steps.build.outputs.digest`
- This correctly captures the digest from the build step that actually produces it

## Testing
- Workflow syntax validated
- The `docker/build-push-action` [documentation](https://github.com/docker/build-push-action#outputs) confirms `digest` is an available output

## Related Issues
Resolves the Build / Build Docker Image workflow failure on develop branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build pipeline configuration to streamline Docker image creation and security scanning processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->