### PR TITLE
feat: Add local registry support for faster Tilt builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ tilt up
 tilt down
 ```
 
-See [docs/tilt.md](docs/tilt.md) for detailed Tilt usage.
+See [docs/skills/tilt.md](docs/skills/tilt.md) for detailed Tilt usage.
 
 ### Working with Protocol Buffers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,10 @@ sudo sh get-docker.sh
 
 **Kubernetes Cluster**:
 ```bash
-# Option 1: Kind with ctlptl (Recommended)
+# Option 1: Kind with ctlptl and local registry (Recommended)
 brew install kind
 brew install tilt-dev/tap/ctlptl
-ctlptl create cluster kind --name=kind-meridian-local
+ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
 
 # Option 2: Docker Desktop
 # Enable Kubernetes in Docker Desktop settings

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ kubectl config current-context
 kubectl get nodes
 ```
 
-See [docs/docker.md](docs/docker.md) and [docs/tilt.md](docs/tilt.md) for detailed troubleshooting.
+See [docs/skills/docker.md](docs/skills/docker.md) and [docs/skills/tilt.md](docs/skills/tilt.md) for detailed troubleshooting.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -82,10 +82,10 @@ Install missing tools automatically (macOS/Linux):
    .githooks/install.sh  # Install pre-commit hooks
    ```
 
-2. **Create local Kubernetes cluster**:
+2. **Create local Kubernetes cluster with local registry**:
    ```bash
    # Ensure Docker Desktop is running
-   ctlptl create cluster kind --name=kind-meridian-local
+   ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
    ```
 
 3. **Start local environment**:
@@ -223,8 +223,8 @@ Errors are categorized for different domains:
 # Check cluster status
 kubectl cluster-info
 
-# Create a Kind cluster (recommended):
-ctlptl create cluster kind --name=kind-meridian-local
+# Create a Kind cluster with local registry (recommended):
+ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
 
 # Or use alternatives:
 minikube start                   # minikube

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Install missing tools automatically (macOS/Linux):
 2. **Create local Kubernetes cluster with local registry**:
    ```bash
    # Ensure Docker Desktop is running
+   # The --registry flag creates a local registry for faster image builds (no remote push/pull)
    ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
    ```
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -16,11 +16,21 @@ allow_k8s_contexts(['kind-meridian-local', 'kind-kind', 'minikube', 'docker-desk
 # Detect and use local registry if available (created by ctlptl)
 # This speeds up image builds by avoiding remote registry pushes
 if k8s_context() == 'kind-meridian-local':
-    # ctlptl creates a local registry and configures Kind to use it
-    # Registry name must match the --registry flag used during cluster creation:
-    #   ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
-    # Tilt will automatically detect it via the Kind cluster configuration
-    default_registry('ctlptl-registry')
+    # Allow registry name to be configured via environment variable
+    # Default: ctlptl-registry (matches ctlptl's default behavior)
+    registry_name = os.getenv('TILT_REGISTRY_NAME', 'ctlptl-registry')
+
+    # Validate that registry container exists
+    registry_check = local('docker ps --filter name=%s --format "{{.Names}}" 2>/dev/null || true' % registry_name, quiet=True)
+
+    if registry_check.strip() == registry_name:
+        default_registry(registry_name)
+        print('✓ Using local registry: %s' % registry_name)
+    else:
+        print('⚠️  Warning: Local registry "%s" not found' % registry_name)
+        print('   Images will be loaded via "kind load" (slower)')
+        print('   To create cluster with registry:')
+        print('   ctlptl create cluster kind --registry=%s --name=kind-meridian-local' % registry_name)
 
 # Docker image configuration
 docker_registry = os.getenv('DOCKER_REGISTRY', 'ghcr.io/meridianhub')

--- a/Tiltfile
+++ b/Tiltfile
@@ -13,6 +13,13 @@ allow_k8s_contexts(['kind-meridian-local', 'kind-kind', 'minikube', 'docker-desk
 # Configuration
 # =============================================================================
 
+# Detect and use local registry if available (created by ctlptl)
+# This speeds up image builds by avoiding remote registry pushes
+if k8s_context() == 'kind-meridian-local':
+    # ctlptl creates a local registry and configures Kind to use it
+    # Tilt will automatically detect it via the Kind cluster configuration
+    default_registry('ctlptl-registry')
+
 # Docker image configuration
 docker_registry = os.getenv('DOCKER_REGISTRY', 'ghcr.io/meridianhub')
 image_name = 'meridian'

--- a/Tiltfile
+++ b/Tiltfile
@@ -17,6 +17,8 @@ allow_k8s_contexts(['kind-meridian-local', 'kind-kind', 'minikube', 'docker-desk
 # This speeds up image builds by avoiding remote registry pushes
 if k8s_context() == 'kind-meridian-local':
     # ctlptl creates a local registry and configures Kind to use it
+    # Registry name must match the --registry flag used during cluster creation:
+    #   ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
     # Tilt will automatically detect it via the Kind cluster configuration
     default_registry('ctlptl-registry')
 

--- a/docs/adr/0006-tilt-local-development.md
+++ b/docs/adr/0006-tilt-local-development.md
@@ -87,7 +87,7 @@ Chosen option: **"Tilt"**, because:
 - Use **Kind + ctlptl** for fast, reproducible local clusters
 - Provide comprehensive onboarding docs ([docs/tilt.md](../tilt.md))
 - Include setup automation scripts (`scripts/setup-check.sh`, `scripts/install-tools.sh`)
-- Single command cluster creation: `ctlptl create cluster kind --name=kind-meridian-local`
+- Single command cluster creation with local registry: `ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local`
 - Tiltfile comments explain each section
 - Startup banner shows all service URLs
 
@@ -331,8 +331,8 @@ k8s_resource('kafka', port_forwards='9092:9092')
 # 2. Install missing tools (if needed)
 ./scripts/install-tools.sh
 
-# 3. Create local Kubernetes cluster (recommended: Kind with ctlptl)
-ctlptl create cluster kind --name=kind-meridian-local
+# 3. Create local Kubernetes cluster with local registry (recommended: Kind with ctlptl)
+ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
 
 # Verify cluster is ready
 kubectl cluster-info
@@ -503,13 +503,13 @@ Provided scripts make onboarding easy:
 # ✗ Kubernetes cluster not accessible
 #
 # ACTION REQUIRED: Create a local cluster
-# ctlptl create cluster kind --name=kind-meridian-local
+# ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
 
 # Install missing tools
 ./scripts/install-tools.sh
 
-# Create Kind cluster
-ctlptl create cluster kind --name=kind-meridian-local
+# Create Kind cluster with local registry
+ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
 
 # Start development
 tilt up
@@ -531,8 +531,8 @@ We use **Kind (Kubernetes in Docker)** with **ctlptl (Cattle Patrol)** for local
 ### Cluster Creation
 
 ```bash
-# Create cluster optimized for Tilt
-ctlptl create cluster kind --name=kind-meridian-local
+# Create cluster optimized for Tilt with local registry
+ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
 
 # This automatically:
 # - Creates a Kind cluster

--- a/docs/adr/0006-tilt-local-development.md
+++ b/docs/adr/0006-tilt-local-development.md
@@ -85,7 +85,7 @@ Chosen option: **"Tilt"**, because:
 
 **Mitigation:**
 - Use **Kind + ctlptl** for fast, reproducible local clusters
-- Provide comprehensive onboarding docs ([docs/tilt.md](../tilt.md))
+- Provide comprehensive onboarding docs ([docs/skills/tilt.md](../skills/tilt.md))
 - Include setup automation scripts (`scripts/setup-check.sh`, `scripts/install-tools.sh`)
 - Single command cluster creation with local registry: `ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local`
 - Tiltfile comments explain each section
@@ -409,7 +409,7 @@ Only rebuild when relevant directories change.
 
 ### Troubleshooting
 
-See comprehensive troubleshooting guide in [docs/tilt.md](../tilt.md):
+See comprehensive troubleshooting guide in [docs/skills/tilt.md](../skills/tilt.md):
 
 * Resources not starting → Check K8s cluster
 * Slow builds → Clear Tilt cache
@@ -463,7 +463,7 @@ Useful for pre-merge integration tests in GitHub Actions.
 **Learning path:**
 1. Read [CONTRIBUTING.md](../../CONTRIBUTING.md) - Prerequisites section
 2. Run `./scripts/setup-check.sh` - Verify environment
-3. Follow [docs/tilt.md](../tilt.md) - Quick start guide
+3. Follow [docs/skills/tilt.md](../skills/tilt.md) - Quick start guide
 4. Watch Tilt UI to understand resource dependencies
 5. Learn basic kubectl commands (`get pods`, `logs`, `describe`)
 

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -1,0 +1,50 @@
+# Skills Documentation
+
+This directory contains operational skills documentation for AI assistants working with the Meridian codebase.
+
+Each skill document includes:
+- **Frontmatter metadata** (name, description, triggers, instructions)
+- **Detailed guide** for performing the skill
+- **Examples and troubleshooting**
+
+## Available Skills
+
+### Development Workflow
+- **[tilt.md](tilt.md)** - Fast Kubernetes development with Tilt and live reload
+- **[docker.md](docker.md)** - Docker configuration and multi-stage builds
+
+### Deployment
+- **[kustomize.md](kustomize.md)** - Environment-specific Kubernetes deployments
+
+### Security
+- **[security.md](security.md)** - Security scanning and vulnerability management
+
+## Format
+
+Skills follow the same metadata format as ADRs:
+
+```yaml
+---
+name: skill-name
+description: Brief description of what this skill covers
+triggers:
+  - When to use this skill
+  - Situations that require this knowledge
+instructions: |
+  Quick summary of how to use this skill.
+  Key commands and workflows.
+---
+```
+
+## Usage
+
+These skills are designed to be:
+- **Searchable** by AI assistants via triggers and descriptions
+- **Actionable** with concrete commands and examples
+- **Contextual** with enough detail to understand when and how to use them
+
+## Related Documentation
+
+- Main docs (human-focused): `../` (parent directory)
+- Architecture decisions: `../adr/`
+- Claude Code skills config: `../claude-code-skills.md`

--- a/docs/skills/docker.md
+++ b/docs/skills/docker.md
@@ -1,3 +1,16 @@
+---
+name: skill-docker-configuration
+description: Docker setup and multi-stage build configuration for production deployments
+triggers:
+  - Building Docker images
+  - Optimizing Dockerfile
+  - Debugging container issues
+  - Understanding image layers
+instructions: |
+  Multi-stage Dockerfile for Go applications with minimal runtime image.
+  Uses distroless base for security. Build with docker build -t meridian .
+---
+
 # Docker Configuration
 
 This document describes the Docker setup for Meridian, optimized for production deployments.

--- a/docs/skills/kustomize.md
+++ b/docs/skills/kustomize.md
@@ -1,3 +1,16 @@
+---
+name: skill-kustomize-deployments
+description: Kustomize configuration for environment-specific Kubernetes deployments
+triggers:
+  - Deploying to different environments
+  - Managing environment-specific configs
+  - Understanding Kustomize overlays
+instructions: |
+  Use Kustomize for environment-specific Kubernetes manifests.
+  Base configurations in deployments/k8s/base/, overlays in deployments/k8s/overlays/.
+  Deploy with: kubectl apply -k deployments/k8s/overlays/dev
+---
+
 # Kustomize Overlays for Environment-Specific Configuration
 
 This document explains how to use Kustomize overlays to manage environment-specific Kubernetes configurations for Meridian.

--- a/docs/skills/security.md
+++ b/docs/skills/security.md
@@ -1,3 +1,17 @@
+---
+name: skill-security-practices
+description: Security scanning, vulnerability management, and security best practices
+triggers:
+  - Running security scans
+  - Fixing vulnerabilities
+  - Understanding security tools
+  - Configuring security workflows
+instructions: |
+  Use gosec for Go code scanning, Trivy for container and dependency scanning.
+  Generate SBOMs for supply chain security. Run security checks in CI/CD.
+  Fix high/critical vulnerabilities before merging.
+---
+
 # Security Architecture and Hardening
 
 This document outlines the security measures implemented in Meridian to ensure production-grade security and compliance.

--- a/docs/skills/tilt.md
+++ b/docs/skills/tilt.md
@@ -1,3 +1,17 @@
+---
+name: skill-tilt-development
+description: Fast Kubernetes development workflow using Tilt with live reload
+triggers:
+  - Starting local development environment
+  - Setting up Tilt for the first time
+  - Debugging Tilt issues
+  - Configuring local registry for faster builds
+instructions: |
+  Use Tilt for local Kubernetes development with fast rebuilds and live reload.
+  Create Kind cluster with local registry using ctlptl for optimal performance.
+  Access Tilt UI at http://localhost:10350 to monitor all services.
+---
+
 # Tilt Development Guide
 
 This guide covers using Tilt for fast Kubernetes development with Meridian.

--- a/docs/tilt.md
+++ b/docs/tilt.md
@@ -296,6 +296,21 @@ ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
 
 **Note**: The local registry is only used when the Kubernetes context is `kind-meridian-local`. Other contexts (docker-desktop, minikube) will use the default registry.
 
+### Custom Registry Name
+
+If you created your cluster with a different registry name, set the `TILT_REGISTRY_NAME` environment variable:
+
+```bash
+# Create cluster with custom registry name
+ctlptl create cluster kind --registry=my-custom-registry --name=kind-meridian-local
+
+# Tell Tilt to use the custom registry
+export TILT_REGISTRY_NAME=my-custom-registry
+tilt up
+```
+
+The Tiltfile will automatically validate that the registry exists and provide helpful error messages if it's not found.
+
 ## Performance Optimization
 
 ### Fast Rebuilds

--- a/docs/tilt.md
+++ b/docs/tilt.md
@@ -6,7 +6,12 @@ This guide covers using Tilt for fast Kubernetes development with Meridian.
 
 1. **Kubernetes Cluster** (one of):
    - Docker Desktop with Kubernetes enabled
-   - kind (Kubernetes in Docker): `kind create cluster`
+   - kind (Kubernetes in Docker) with local registry (recommended):
+     ```bash
+     # Install ctlptl first: brew install tilt-dev/tap/ctlptl
+     ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
+     ```
+     Or without registry: `kind create cluster`
    - Minikube: `minikube start`
    - Colima: `colima start --kubernetes`
 

--- a/docs/tilt.md
+++ b/docs/tilt.md
@@ -263,6 +263,39 @@ kubectl logs deployment/zookeeper
 
 Kafka depends on Zookeeper being healthy.
 
+### Local Registry Issues
+
+If you see warnings about missing local registry or slow image pushes:
+
+**Symptom**: "Running Kind without a local image registry"
+
+**Solution**: Recreate cluster with registry support:
+```bash
+# Delete existing cluster
+ctlptl delete cluster kind-meridian-local
+
+# Create new cluster with local registry
+ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
+
+# Restart Tilt
+tilt up
+```
+
+**Symptom**: "Error: registry 'ctlptl-registry' not found"
+
+**Diagnosis**: The Tiltfile expects a registry named `ctlptl-registry` but it doesn't exist.
+
+**Solution**: Ensure you created the cluster with the correct registry name:
+```bash
+# Verify registry container exists
+docker ps | grep ctlptl-registry
+
+# If not found, recreate cluster with correct command
+ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local
+```
+
+**Note**: The local registry is only used when the Kubernetes context is `kind-meridian-local`. Other contexts (docker-desktop, minikube) will use the default registry.
+
 ## Performance Optimization
 
 ### Fast Rebuilds


### PR DESCRIPTION
## Summary

Configures Tilt to use the local ctlptl registry when running on the `kind-meridian-local` context. This eliminates the warning about missing local registry and significantly speeds up image builds during local development.

## Changes Made

- Added `default_registry('ctlptl-registry')` configuration to Tiltfile
- Registry is automatically detected when using `kind-meridian-local` context
- No changes required for other Kubernetes contexts (docker-desktop, minikube, etc.)

## Benefits

- **Faster builds**: Images are pushed to localhost instead of remote registries
- **No warning**: Eliminates the "Running Kind without a local image registry" message
- **Zero configuration**: Works automatically after recreating Kind cluster with ctlptl

## Setup Instructions

To use the local registry:

\`\`\`bash
# Delete old cluster (if exists)
ctlptl delete cluster kind-meridian-local

# Create new cluster with registry
ctlptl create cluster kind --registry=ctlptl-registry --name=kind-meridian-local

# Start Tilt (will now use local registry)
tilt up
\`\`\`

The local registry persists across Tilt sessions and cluster restarts.

## Testing

- Verified Tilt no longer shows registry warning
- Confirmed images are pushed to local registry at localhost:54397
- Build performance significantly improved (no remote registry latency)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local registry support for Kind cluster setup with ctlptl integration, improving local development workflow efficiency.

* **Documentation**
  * Reorganized development documentation into a new Skills framework with structured metadata for improved discoverability.
  * Updated cluster creation and troubleshooting guidance to reflect registry-enabled setup as the recommended approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->