### PR TITLE
fix: Use localhost:5000 for Tilt registry instead of container name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GOMOD=$(GOCMD) mod
 GOGET=$(GOCMD) get
 GOFMT=$(GOCMD) fmt
 
-.PHONY: all help build test lint clean proto proto-v1 proto-v2 proto-lint proto-breaking docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info
+.PHONY: all help build test lint clean proto proto-v1 proto-v2 proto-lint proto-breaking docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt
 
 # Default target
 all: help
@@ -42,7 +42,8 @@ help:
 	@echo "Available targets:"
 	@echo "  make build             - Compile all Go services"
 	@echo "  make test              - Run tests with coverage"
-	@echo "  make lint              - Run golangci-lint"
+	@echo "  make lint              - Run golangci-lint and validate Tiltfile"
+	@echo "  make validate-tilt     - Validate Tiltfile configuration"
 	@echo "  make fmt               - Format Go code"
 	@echo "  make clean             - Remove build artifacts"
 	@echo "  make proto             - Generate code from all protobuf versions"
@@ -91,11 +92,15 @@ coverage: test
 	@echo "Opening coverage report..."
 	@open $(COVERAGE_DIR)/coverage.html 2>/dev/null || xdg-open $(COVERAGE_DIR)/coverage.html 2>/dev/null || echo "Please open $(COVERAGE_DIR)/coverage.html manually"
 
-## lint: Run golangci-lint
-lint:
+## lint: Run golangci-lint and validate Tiltfile
+lint: validate-tilt
 	@echo "Running golangci-lint..."
 	@which $(GOLANGCI_LINT) > /dev/null || (echo "golangci-lint not installed. Run 'make install'"; exit 1)
 	$(GOLANGCI_LINT) run --timeout 5m ./...
+
+## validate-tilt: Validate Tiltfile configuration
+validate-tilt:
+	@./scripts/validate-tiltfile.sh Tiltfile
 
 ## fmt: Format Go code
 fmt:

--- a/Tiltfile
+++ b/Tiltfile
@@ -20,12 +20,16 @@ if k8s_context() == 'kind-meridian-local':
     # Default: ctlptl-registry (matches ctlptl's default behavior)
     registry_name = os.getenv('TILT_REGISTRY_NAME', 'ctlptl-registry')
 
+    # Registry URL that Tilt expects (host:port format)
+    # ctlptl configures the registry to be accessible at localhost:5000
+    registry_url = os.getenv('TILT_REGISTRY_URL', 'localhost:5000')
+
     # Validate that registry container exists
     registry_check = str(local('docker ps --filter name=%s --format "{{.Names}}" 2>/dev/null || true' % registry_name, quiet=True)).strip()
 
     if registry_check == registry_name:
-        default_registry(registry_name)
-        print('✓ Using local registry: %s' % registry_name)
+        default_registry(registry_url)
+        print('✓ Using local registry: %s (%s)' % (registry_name, registry_url))
     else:
         print('⚠️  Warning: Local registry "%s" not found' % registry_name)
         print('   Images will be loaded via "kind load" (slower)')

--- a/scripts/validate-tiltfile.sh
+++ b/scripts/validate-tiltfile.sh
@@ -34,16 +34,16 @@ while IFS= read -r call; do
     # Extract the argument (variable name or literal value)
     arg=$(echo "$call" | sed -E "s/default_registry\(([^)]+)\)/\1/" | tr -d "\"'" | xargs)
 
-    # Check if it looks like a variable reference
-    if [[ ! "$arg" =~ : ]]; then
+    # Check if it looks like a variable reference (doesn't match host:port pattern)
+    if [[ ! "$arg" =~ ^[a-zA-Z0-9\.\-]+:[0-9]+$ ]]; then
         # Try to find the variable assignment
         if grep -q "${arg}.*=.*os\.getenv" "$TILTFILE"; then
             # Extract default value from os.getenv('VAR', 'default')
             default_value=$(grep "${arg}.*=.*os\.getenv" "$TILTFILE" | sed -E "s/.*os\.getenv\([^,]+, *['\"]([^'\"]+)['\"].*/\1/")
             echo "Found variable $arg = os.getenv(..., '$default_value')"
 
-            # Check if default value contains host:port
-            if [[ "$default_value" =~ : ]] || [[ "$default_value" =~ localhost ]]; then
+            # Check if default value is in host:port format
+            if [[ "$default_value" =~ ^[a-zA-Z0-9\.\-]+:[0-9]+$ ]]; then
                 echo "✓ Registry configuration valid: $arg -> $default_value"
             else
                 echo "✗ Invalid registry format: $arg = '$default_value' (must be host:port)" >&2
@@ -54,7 +54,8 @@ while IFS= read -r call; do
             value=$(grep "${arg}.*=" "$TILTFILE" | head -1 | sed -E "s/.*= *['\"]([^'\"]+)['\"].*/\1/")
             echo "Found variable $arg = '$value'"
 
-            if [[ "$value" =~ : ]] || [[ "$value" =~ localhost ]]; then
+            # Check if value is in host:port format
+            if [[ "$value" =~ ^[a-zA-Z0-9\.\-]+:[0-9]+$ ]]; then
                 echo "✓ Registry configuration valid: $arg -> $value"
             else
                 echo "✗ Invalid registry format: $arg = '$value' (must be host:port)" >&2
@@ -66,12 +67,7 @@ while IFS= read -r call; do
         fi
     else
         # It's a literal value, validate directly
-        if [[ "$arg" =~ ^[a-zA-Z0-9\.\-]+:[0-9]+$ ]]; then
-            echo "✓ Registry configuration valid: $arg"
-        else
-            echo "✗ Invalid registry format: '$arg' (expected host:port)" >&2
-            errors=$((errors + 1))
-        fi
+        echo "✓ Registry configuration valid: $arg"
     fi
 done <<< "$registry_calls"
 

--- a/scripts/validate-tiltfile.sh
+++ b/scripts/validate-tiltfile.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# validate-tiltfile.sh - Validate Tiltfile registry configuration
+#
+# This script checks that default_registry() is called with a valid
+# host:port format (e.g., localhost:5000) instead of just a container
+# name (e.g., ctlptl-registry).
+#
+# Usage: ./scripts/validate-tiltfile.sh [path-to-Tiltfile]
+#
+
+set -e
+
+TILTFILE="${1:-Tiltfile}"
+
+if [[ ! -f "$TILTFILE" ]]; then
+    echo "Error: Tiltfile not found at $TILTFILE" >&2
+    exit 1
+fi
+
+echo "Validating Tiltfile configuration..."
+
+# Extract default_registry() calls
+registry_calls=$(grep -o 'default_registry([^)]*)' "$TILTFILE" || true)
+
+if [[ -z "$registry_calls" ]]; then
+    echo "✓ No default_registry() calls found (OK)"
+    exit 0
+fi
+
+errors=0
+
+while IFS= read -r call; do
+    # Extract the argument (variable name or literal value)
+    arg=$(echo "$call" | sed -E "s/default_registry\(([^)]+)\)/\1/" | tr -d "\"'" | xargs)
+
+    # Check if it looks like a variable reference
+    if [[ ! "$arg" =~ : ]]; then
+        # Try to find the variable assignment
+        if grep -q "${arg}.*=.*os\.getenv" "$TILTFILE"; then
+            # Extract default value from os.getenv('VAR', 'default')
+            default_value=$(grep "${arg}.*=.*os\.getenv" "$TILTFILE" | sed -E "s/.*os\.getenv\([^,]+, *['\"]([^'\"]+)['\"].*/\1/")
+            echo "Found variable $arg = os.getenv(..., '$default_value')"
+
+            # Check if default value contains host:port
+            if [[ "$default_value" =~ : ]] || [[ "$default_value" =~ localhost ]]; then
+                echo "✓ Registry configuration valid: $arg -> $default_value"
+            else
+                echo "✗ Invalid registry format: $arg = '$default_value' (must be host:port)" >&2
+                errors=$((errors + 1))
+            fi
+        elif grep -q "${arg}.*=" "$TILTFILE"; then
+            # Simple variable assignment
+            value=$(grep "${arg}.*=" "$TILTFILE" | head -1 | sed -E "s/.*= *['\"]([^'\"]+)['\"].*/\1/")
+            echo "Found variable $arg = '$value'"
+
+            if [[ "$value" =~ : ]] || [[ "$value" =~ localhost ]]; then
+                echo "✓ Registry configuration valid: $arg -> $value"
+            else
+                echo "✗ Invalid registry format: $arg = '$value' (must be host:port)" >&2
+                errors=$((errors + 1))
+            fi
+        else
+            echo "✗ Variable '$arg' not found or uses invalid format (must be host:port)" >&2
+            errors=$((errors + 1))
+        fi
+    else
+        # It's a literal value, validate directly
+        if [[ "$arg" =~ ^[a-zA-Z0-9\.\-]+:[0-9]+$ ]]; then
+            echo "✓ Registry configuration valid: $arg"
+        else
+            echo "✗ Invalid registry format: '$arg' (expected host:port)" >&2
+            errors=$((errors + 1))
+        fi
+    fi
+done <<< "$registry_calls"
+
+if [[ $errors -gt 0 ]]; then
+    echo ""
+    echo "✗ Registry configuration errors found: $errors"
+    exit 1
+fi
+
+echo ""
+echo "✓ Tiltfile validation complete"
+exit 0


### PR DESCRIPTION
## Summary

Fixes the Tiltfile registry configuration error when running `tilt up`:
```
Error in default_registry: validating defaultRegistry: host: Invalid value: "ctlptl-registry": repository name must be canonical
```

The `default_registry()` function in Tilt requires a host:port format (e.g., `localhost:5000`) rather than just a container name (e.g., `ctlptl-registry`).

## Changes Made

### Tiltfile
- Introduced `registry_url` variable with proper `localhost:5000` format
- Maintained `registry_name` for container existence validation  
- Updated `default_registry()` call to use `registry_url` instead of `registry_name`
- Enhanced console output to show both container name and URL

### Automated Testing
- Created `scripts/validate-tiltfile.sh` to validate registry configuration
- Integrated validation into `make lint` target
- Added `make validate-tilt` standalone target
- Validation script uses standard shell (no Python/Go dependencies)

## Technical Details

The validation script checks that:
1. Any `default_registry()` calls use variables with `host:port` format
2. Variables defined with `os.getenv()` have proper default values
3. Literal registry values match the `host:port` pattern

This ensures CI will catch similar configuration issues before they reach develop.

## Test Plan

- [x] Validated with both old and new Tiltfile versions
- [x] Tested `make validate-tilt` on original Tiltfile (fails correctly)
- [x] Tested `make validate-tilt` on fixed Tiltfile (passes)
- [x] Verified registry container exists and is accessible at localhost:5000

## Risk Assessment

**Low** - Configuration change only, no runtime code modifications. The registry URL was always meant to be `localhost:5000` based on ctlptl's default behavior. The validation script provides additional safety for future changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented Tiltfile registry configuration validation that inspects registry settings for proper formatting and connectivity.
  * Registry display now includes full URL information, defaulting to localhost:5000 for local development.

* **Chores**
  * Lint command now automatically validates Tiltfile configuration before running standard checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->