### PR TITLE
fix: Enable ruok command for Zookeeper health probes

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -231,6 +231,8 @@ spec:
           value: "true"
         - name: ZOO_ADMINSERVER_ENABLED
           value: "false"
+        - name: ZOO_4LW_COMMANDS_WHITELIST
+          value: "ruok,srvr,stat,mntr"
         readinessProbe:
           exec:
             command:
@@ -426,14 +428,14 @@ k8s_resource(
 k8s_resource(
   'zookeeper',
   port_forwards='2181:2181',
-  labels=['infrastructure', 'messaging'],
+  labels=['messaging'],
   resource_deps=[],
 )
 
 k8s_resource(
   'kafka',
   port_forwards='9092:9092',
-  labels=['infrastructure', 'messaging'],
+  labels=['messaging'],
   resource_deps=['zookeeper'],
 )
 


### PR DESCRIPTION
## Summary

Fixes Zookeeper restart loops caused by failing readiness and liveness probes.

## Problem

Zookeeper 3.9.3 introduced stricter security by restricting four-letter commands by default. Only `srvr` was enabled, but the health probes use `ruok`, causing them to fail continuously:

```
Warning  Unhealthy  Liveness probe failed
Warning  Unhealthy  Readiness probe failed
Normal   Killing    Container zookeeper failed liveness probe, will be restarted
```

## Changes Made

### 1. Enable Four-Letter Commands
Added `ZOO_4LW_COMMANDS_WHITELIST` environment variable to enable:
- `ruok` - Health check (used by readiness/liveness probes)
- `srvr` - Server status information
- `stat` - Server and client statistics  
- `mntr` - Monitoring metrics

### 2. Simplified Tilt Labels
Removed redundant `infrastructure` label from Zookeeper and Kafka resources. The `messaging` label is more specific and sufficient for grouping in Tilt UI.

## Technical Details

Zookeeper 3.9+ restricts commands via the `4lw.commands.whitelist` property for security (prevents unauthorized access to cluster information). The probes send `echo ruok` to port 2181, expecting `imok` response, but this was blocked by default.

Reference: [Zookeeper AdminServer](https://zookeeper.apache.org/doc/r3.9.3/zookeeperAdmin.html#sc_4lw)

## Test Plan

- [x] Verified Zookeeper starts without restart loops
- [x] Confirmed readiness probe succeeds
- [x] Confirmed liveness probe succeeds
- [x] Tested with `kubectl get pods` - shows Ready status
- [x] Verified Kafka can connect to Zookeeper

## Risk Assessment

**Low** - Configuration change only, whitelisting specific commands needed for operations. These commands don't expose sensitive data or allow cluster modifications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated resource configuration labels for messaging services.
  * Added environment variable configuration to service deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->