### PR TITLE
fix: Use correct CodeRabbit docstring configuration path

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,13 +27,12 @@ reviews:
   auto_review:
     enabled: true
 
-  # Language-specific settings
-  tools:
-    # Go-specific configuration
-    golang:
-      # Adjust docstring coverage threshold to match project practices
-      # Most exported types and functions have comprehensive godoc comments
-      # Lower threshold accounts for internal helpers and test files
-      docstring_coverage:
-        enabled: true
-        threshold: 50
+  # Finishing touches configuration
+  finishing_touches:
+    # Docstring coverage settings
+    # Adjust threshold to match project practices - most exported types
+    # and functions have comprehensive godoc comments
+    # Lower threshold accounts for internal helpers and test files
+    docstrings:
+      enabled: true
+      threshold: 50


### PR DESCRIPTION
## Summary

Fixes the CodeRabbit configuration to use the correct supported configuration path for docstring coverage settings.

## Issue

PR #65 introduced docstring coverage configuration using the path:
```yaml
reviews.tools.golang.docstring_coverage
```

However, this path is **not supported** by CodeRabbit. The correct path is:
```yaml
reviews.finishing_touches.docstrings
```

## Changes Made

Updated `.coderabbit.yaml`:
- Removed unsupported `reviews.tools.golang.docstring_coverage` section
- Added correct `reviews.finishing_touches.docstrings` configuration
- Maintained the 50% threshold and all comments

## Testing

This will be validated when CodeRabbit reviews the next PR after this fix is merged.

## Risk Assessment

**Low Risk**: Configuration-only change that fixes an invalid config path.