### PR TITLE
docs: Add SECURITY.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,71 @@
+# Code of Conduct
+
+## Purpose
+
+Meridian is a professional software project focused on building a modern banking platform. This Code of Conduct establishes expectations for participation in our community to foster productive technical collaboration.
+
+## Our Standards
+
+### Expected Behavior
+
+- Focus on technical merit and constructive feedback
+- Communicate clearly and professionally
+- Respect differing viewpoints and experiences
+- Accept constructive criticism gracefully
+- Support fellow contributors and maintainers
+
+### Unacceptable Behavior
+
+- Harassment, intimidation, or discriminatory language
+- Personal attacks or inflammatory comments
+- Trolling or deliberate disruption of discussions
+- Publishing others' private information without consent
+- Any conduct that would be inappropriate in a professional setting
+
+## Scope
+
+This Code of Conduct applies to:
+
+- Project repositories and issue trackers
+- Pull request discussions and code reviews
+- Community channels (Slack, Discord, mailing lists, etc.)
+- Project events and meetings
+- Public representation of the project
+
+## Enforcement
+
+### Reporting
+
+If you experience or witness unacceptable behavior:
+
+1. **Direct Resolution**: If comfortable, address the issue directly with the individual
+2. **Maintainer Report**: Contact project maintainers through:
+   - GitHub private message
+   - Project communication channels (marked private)
+   - Email to repository administrators
+
+### Response
+
+Project maintainers will:
+
+- Review reported incidents promptly
+- Investigate with discretion and confidentiality
+- Take appropriate action based on the situation
+- Communicate outcomes to involved parties when appropriate
+
+### Consequences
+
+Depending on the severity and context, consequences may include:
+
+- Private discussion and clarification of expectations
+- Public or private warning
+- Temporary suspension from project participation
+- Permanent ban from the project
+
+## Attribution
+
+This Code of Conduct is adapted from professional open source projects and tailored for technical collaboration in software engineering.
+
+## Questions
+
+For questions about this Code of Conduct, open a GitHub Discussion or contact project maintainers.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,6 +4,8 @@
 
 Meridian is a professional software project focused on building a modern banking platform. This Code of Conduct establishes expectations for participation in our community to foster productive technical collaboration.
 
+As a learning project, we welcome questions and view mistakes as opportunities for growth and improvement. This is an environment where developers can explore banking platform architecture, ask clarifying questions, and learn from both successes and failures.
+
 ## Our Standards
 
 ### Expected Behavior
@@ -28,7 +30,7 @@ This Code of Conduct applies to:
 
 - Project repositories and issue trackers
 - Pull request discussions and code reviews
-- Community channels (Slack, Discord, mailing lists, etc.)
+- GitHub Discussions and community channels (if/when established)
 - Project events and meetings
 - Public representation of the project
 
@@ -43,6 +45,8 @@ If you experience or witness unacceptable behavior:
    - GitHub private message
    - Project communication channels (marked private)
    - Email to repository administrators
+
+**Note**: For security vulnerabilities or security-related concerns, please follow the procedures outlined in [SECURITY.md](SECURITY.md) instead.
 
 ### Response
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,7 +57,7 @@ This security policy applies to:
 
 The following are generally not considered security vulnerabilities:
 
-- Issues requiring physical access to infrastructure
+- Issues requiring unauthorized physical access to infrastructure
 - Social engineering attacks against users
 - Vulnerabilities in third-party dependencies (report to upstream projects)
 - Issues already publicly disclosed or known

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of Meridian seriously. If you discover a security vulnerability, please report it privately through one of the following channels:
+
+### GitHub Security Advisories (Recommended)
+
+Report vulnerabilities using GitHub's private vulnerability reporting:
+
+1. Navigate to the [Security Advisories](https://github.com/meridianhub/meridian/security/advisories) page
+2. Click "Report a vulnerability"
+3. Provide detailed information about the vulnerability
+
+### What to Include
+
+When reporting a vulnerability, please include:
+
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact and severity assessment
+- Any suggested fixes or mitigations (if applicable)
+- Your contact information for follow-up questions
+
+## Response Timeline
+
+- **Acknowledgment**: Within 48 hours of submission
+- **Initial Assessment**: Within 5 business days
+- **Status Updates**: Regular updates as investigation progresses
+- **Resolution**: Timeline depends on severity and complexity
+
+## Disclosure Policy
+
+- Do not publicly disclose vulnerabilities until a fix has been released
+- We will work with you to understand and address the issue
+- Credit will be given to researchers who report vulnerabilities responsibly (if desired)
+
+## Security Best Practices
+
+When contributing to or deploying Meridian:
+
+- Keep dependencies up to date
+- Follow secure coding practices outlined in our contribution guidelines
+- Use environment variables for sensitive configuration
+- Enable authentication and authorization in production deployments
+- Regular security audits of your deployment configuration
+
+## Scope
+
+This security policy applies to:
+
+- The core Meridian platform and all services
+- Official container images and deployment configurations
+- Documentation that affects security posture
+
+## Out of Scope
+
+The following are generally not considered security vulnerabilities:
+
+- Issues requiring physical access to infrastructure
+- Social engineering attacks against users
+- Vulnerabilities in third-party dependencies (report to upstream projects)
+- Issues already publicly disclosed or known
+
+## Questions
+
+For questions about this security policy, open a GitHub Discussion or contact the project maintainers.


### PR DESCRIPTION
## Summary
Adds repository documentation for security vulnerability reporting and community conduct guidelines.

## Changes Made
- **SECURITY.md**: Establishes security vulnerability reporting procedures
  - GitHub Security Advisories as primary reporting channel
  - Response timeline commitments (48hr acknowledgment, 5 day assessment)
  - Disclosure policy and security best practices
  
- **CODE_OF_CONDUCT.md**: Sets professional collaboration standards
  - Focus on technical merit and constructive feedback
  - Minimal enforcement approach suitable for source-available project
  - Clear reporting procedures for maintainers

## Technical Details
- Both documents are tailored for a source-available project
- GitHub Security Advisories leverages GitHub's built-in private reporting
- Code of Conduct emphasizes professional technical collaboration over heavy enforcement

## Testing
N/A - Documentation only

## Risk Assessment
Low - Documentation addition with no code changes

## Performance Considerations
None - Static documentation files

## Deployment Notes
No special deployment required. Files will be visible at repository root after merge.