### PR TITLE
ci: Make Claude code review wait for CI checks to pass

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,8 +24,38 @@ jobs:
       pull-requests: read
       issues: read
       id-token: write
+      checks: read
+      actions: read
 
     steps:
+      # Wait for critical CI checks to complete before reviewing
+      - name: Wait for Tests
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Run Tests'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          allowed-conclusions: success
+
+      - name: Wait for Build
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Build Docker Image'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          allowed-conclusions: success
+
+      - name: Wait for Linting
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'golangci-lint'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          allowed-conclusions: success
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
Make Claude Code Review workflow wait for critical CI checks (Tests, Build, Linting) to pass before reviewing code.

## Problem
Currently, Claude reviews run immediately on every commit, even if tests are failing or the build is broken. This wastes review cycles and provides feedback on code that may not be working.

## Solution
Add `wait-on-check-action` steps that wait for:
- **Run Tests** - Ensures code functionality
- **Build Docker Image** - Ensures build succeeds  
- **golangci-lint** - Ensures code quality standards

## Benefits
✅ Claude only reviews working code  
✅ No wasted reviews on failing builds  
✅ Faster feedback loop (tests fail fast, Claude reviews passing code)  
✅ CodeRabbit still provides immediate incremental feedback  
✅ Still reviews on every commit iteration (as requested)

## Trade-offs
⏱️ Claude reviews come ~2-5 minutes later (after tests complete)  
📊 Better quality reviews since Claude sees passing code

## Testing
- Will test on this PR itself
- Claude should wait for all checks before reviewing

## Risk Assessment
**Low** - Only changes workflow timing, no functional changes to review logic