### PR TITLE
Fix: Update migration checksums after audit trigger edit

### DIFF
--- a/migrations/shared/atlas.sum
+++ b/migrations/shared/atlas.sum
@@ -1,2 +1,2 @@
-h1:fqnYnd4oFjY1cOYyCvCEfqrAAQGIa0k/2VjUkDBItgo=
-20251103190000_audit_factory.sql h1:L7Ic6QsWhsjE3GDaO2NO2axNhdb+YApUQmXTMC/YTpw=
+h1:w9pgctzlgD4Zz6jIH5UxYGFvC8IgPxWpxU0M6iW0ILY=
+20251103190000_audit_factory.sql h1:tmBJNx/Qgwn0UH7JAhRuR4iKGVVwfzYjrkKR4jwQfHk=


### PR DESCRIPTION
## Summary

Updates migration checksums to match the current state of the audit factory migration file.

## Problem

The audit factory migration (20251103190000_audit_factory.sql) was edited during PR #67 to add COALESCE fallback for NULL changed_by values, but the checksums in atlas.sum were not updated. This caused migration apply to fail with:

```
You have a checksum error in your migration directory.
    L2: 20251103190000_audit_factory.sql was edited
Error: checksum mismatch
```

## Solution

Re-hashed migration checksums using `atlas migrate hash` to match current file content.

## Testing

- [x] Re-hashed shared migrations
- [x] Re-hashed current_account migrations  
- [x] Re-hashed position_keeping migrations
- [ ] Verified migrations apply successfully in local Tilt environment

## Risk Assessment

**Low Risk**

- Only updates checksum file, no code changes
- Required fix for migrations to work post-merge of PR #67