### PR TITLE
feat: Implement audit log insertion in worker

### DIFF
--- a/internal/domain/models/audit.go
+++ b/internal/domain/models/audit.go
@@ -56,6 +56,28 @@ func (AuditOutbox) TableName() string {
 	return "current_account_audit.audit_outbox"
 }
 
+// AuditLog represents a permanent audit log entry.
+// Records are moved from the audit_outbox to audit_log by the background worker.
+// Once written, audit log entries are immutable and provide a permanent audit trail.
+type AuditLog struct {
+	ID            uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	Table         string    `gorm:"column:table_name;type:varchar(100);not null;index" json:"table_name"`
+	Operation     string    `gorm:"type:varchar(10);not null;index" json:"operation"` // INSERT, UPDATE, DELETE
+	RecordID      uuid.UUID `gorm:"type:uuid;not null;index" json:"record_id"`
+	OldValues     string    `gorm:"type:text" json:"old_values,omitempty"` // JSON representation of old values
+	NewValues     string    `gorm:"type:text" json:"new_values,omitempty"` // JSON representation of new values
+	CreatedAt     time.Time `gorm:"not null;default:CURRENT_TIMESTAMP" json:"created_at"`
+	ChangedBy     *string   `gorm:"type:varchar(100)" json:"changed_by,omitempty"`
+	TransactionID *string   `gorm:"type:varchar(100)" json:"transaction_id,omitempty"`
+	ClientIP      *string   `gorm:"type:varchar(45)" json:"client_ip,omitempty"`
+	UserAgent     *string   `gorm:"type:text" json:"user_agent,omitempty"`
+}
+
+// TableName overrides the table name for AuditLog.
+func (AuditLog) TableName() string {
+	return "current_account_audit.audit_log"
+}
+
 // recordAudit writes an audit outbox entry within the current transaction.
 // This function is called by GORM hooks (AfterCreate, AfterUpdate, AfterDelete).
 //

--- a/internal/platform/audit/worker.go
+++ b/internal/platform/audit/worker.go
@@ -256,17 +256,8 @@ func (w *Worker) processEntry(ctx context.Context, entry *models.AuditOutbox) er
 		return fmt.Errorf("failed to mark entry as processing: %w", err)
 	}
 
-	// TODO: Implement actual audit log insertion (follow-up PR after #88)
-	// Next step: Create AuditLog model and insert into audit_log table
-	// This will complete the async audit flow:
-	//   Business operation → audit_outbox (Phase 2) → worker processes (this PR) → audit_log (next PR)
-	// Real implementation:
-	//   1. Create models.AuditLog from entry data
-	//   2. Insert into current_account_audit.audit_log table
-	//   3. Handle any errors from the insert
-
-	// Simulate processing (temporary - replaced in next PR)
-	err := w.simulateProcessing(entry)
+	// Insert audit log entry into permanent audit_log table
+	err := w.insertAuditLog(ctx, entry)
 	if err != nil {
 		return w.handleProcessingError(ctx, entry, err)
 	}
@@ -288,32 +279,29 @@ func (w *Worker) processEntry(ctx context.Context, entry *models.AuditOutbox) er
 	return nil
 }
 
-// simulateProcessing is a placeholder for the actual audit log insertion logic.
-// TODO: Replace this function in a follow-up PR with actual audit_log table insertion.
+// insertAuditLog creates a permanent audit log entry from an outbox entry.
+// This completes the async audit flow: business operation → audit_outbox → worker → audit_log.
 //
-// Implementation plan for next PR:
-//  1. Create models.AuditLog struct matching audit_log table schema
-//  2. Copy fields from AuditOutbox entry to AuditLog
-//  3. Insert into current_account_audit.audit_log table
-//  4. Return any errors from the insert operation
-//
-// Example implementation:
-//
-//	auditLog := &models.AuditLog{
-//	    Table:         entry.Table,
-//	    Operation:     entry.Operation,
-//	    RecordID:      entry.RecordID,
-//	    OldValues:     entry.OldValues,
-//	    NewValues:     entry.NewValues,
-//	    ChangedBy:     entry.ChangedBy,
-//	    TransactionID: entry.TransactionID,
-//	    ClientIP:      entry.ClientIP,
-//	    UserAgent:     entry.UserAgent,
-//	    CreatedAt:     time.Now(),
-//	}
-//	return w.db.WithContext(ctx).Create(auditLog).Error
-func (w *Worker) simulateProcessing(_ *models.AuditOutbox) error {
-	// Temporary: Always succeed to allow testing of worker infrastructure
+// The function copies all relevant fields from the outbox entry to the audit log,
+// excluding worker-specific fields (status, retry_count, last_error).
+func (w *Worker) insertAuditLog(ctx context.Context, entry *models.AuditOutbox) error {
+	auditLog := &models.AuditLog{
+		Table:         entry.Table,
+		Operation:     entry.Operation,
+		RecordID:      entry.RecordID,
+		OldValues:     entry.OldValues,
+		NewValues:     entry.NewValues,
+		ChangedBy:     entry.ChangedBy,
+		TransactionID: entry.TransactionID,
+		ClientIP:      entry.ClientIP,
+		UserAgent:     entry.UserAgent,
+		CreatedAt:     time.Now(),
+	}
+
+	if err := w.db.WithContext(ctx).Create(auditLog).Error; err != nil {
+		return fmt.Errorf("failed to insert audit log entry: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/platform/audit/worker_test.go
+++ b/internal/platform/audit/worker_test.go
@@ -79,12 +79,49 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	`).Error
 	require.NoError(t, err, "Failed to create audit_outbox table")
 
-	// Create indexes
+	// Create indexes for audit_outbox
 	err = db.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_audit_outbox_status_created
 		ON current_account_audit.audit_outbox(status, created_at)
 	`).Error
 	require.NoError(t, err, "Failed to create audit_outbox indexes")
+
+	// Create audit_log table
+	err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS current_account_audit.audit_log (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			table_name VARCHAR(100) NOT NULL,
+			operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+			record_id UUID NOT NULL,
+			old_values TEXT,
+			new_values TEXT,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			changed_by VARCHAR(100),
+			transaction_id VARCHAR(100),
+			client_ip VARCHAR(45),
+			user_agent TEXT
+		)
+	`).Error
+	require.NoError(t, err, "Failed to create audit_log table")
+
+	// Create indexes for audit_log
+	err = db.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_audit_log_table_name
+		ON current_account_audit.audit_log(table_name)
+	`).Error
+	require.NoError(t, err, "Failed to create audit_log table_name index")
+
+	err = db.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_audit_log_operation
+		ON current_account_audit.audit_log(operation)
+	`).Error
+	require.NoError(t, err, "Failed to create audit_log operation index")
+
+	err = db.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_audit_log_record_id
+		ON current_account_audit.audit_log(record_id)
+	`).Error
+	require.NoError(t, err, "Failed to create audit_log record_id index")
 
 	// Register cleanup
 	t.Cleanup(func() {
@@ -642,5 +679,99 @@ func TestAuditWorker_Stop_MultipleCallsSafe(t *testing.T) {
 	db.Model(&models.AuditOutbox{}).Where("status = ?", "completed").Count(&processed)
 	if processed > 0 {
 		t.Errorf("Worker processed entries after Stop(), expected 0 but got %d", processed)
+	}
+}
+
+// TestAuditWorker_InsertsIntoAuditLog verifies that the worker successfully
+// creates audit_log entries from outbox entries (end-to-end test).
+func TestAuditWorker_InsertsIntoAuditLog(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db := setupTestDB(t)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Create test outbox entries
+	createTestEntries(t, db, 5)
+
+	// Fetch the created entries for verification later
+	var entries []models.AuditOutbox
+	err := db.Where("status = ?", statusPending).Find(&entries).Error
+	if err != nil {
+		t.Fatalf("Failed to fetch outbox entries: %v", err)
+	}
+	if len(entries) != 5 {
+		t.Fatalf("Expected 5 entries, got %d", len(entries))
+	}
+
+	// Verify audit_log table starts empty
+	var initialCount int64
+	db.Table("current_account_audit.audit_log").Count(&initialCount)
+	if initialCount != 0 {
+		t.Fatalf("Expected audit_log to be empty, but found %d entries", initialCount)
+	}
+
+	// Create and start worker
+	worker := NewAuditWorker(db, logger)
+	worker.pollInterval = 100 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	worker.Start(ctx)
+
+	// Wait for processing to complete
+	waitForProcessing(t, db, 5, 5*time.Second)
+
+	worker.Stop()
+
+	// Verify all outbox entries were processed
+	var completed int64
+	db.Model(&models.AuditOutbox{}).Where("status = ?", "completed").Count(&completed)
+	if completed != 5 {
+		t.Errorf("Expected 5 completed outbox entries, got %d", completed)
+	}
+
+	// Verify audit_log entries were created
+	var auditLogCount int64
+	db.Table("current_account_audit.audit_log").Count(&auditLogCount)
+	if auditLogCount != 5 {
+		t.Errorf("Expected 5 audit_log entries, got %d", auditLogCount)
+	}
+
+	// Verify audit_log entries match outbox entries
+	for _, entry := range entries {
+		var auditLog struct {
+			ID            uuid.UUID
+			Table         string `gorm:"column:table_name"`
+			Operation     string
+			RecordID      uuid.UUID `gorm:"column:record_id"`
+			OldValues     string    `gorm:"column:old_values"`
+			NewValues     string    `gorm:"column:new_values"`
+			ChangedBy     *string   `gorm:"column:changed_by"`
+			TransactionID *string   `gorm:"column:transaction_id"`
+			ClientIP      *string   `gorm:"column:client_ip"`
+			UserAgent     *string   `gorm:"column:user_agent"`
+		}
+
+		err := db.Table("current_account_audit.audit_log").
+			Where("record_id = ? AND operation = ?", entry.RecordID, entry.Operation).
+			First(&auditLog).Error
+		if err != nil {
+			t.Errorf("Failed to find audit_log entry for outbox %s: %v", entry.ID, err)
+			continue
+		}
+
+		// Verify key fields match
+		if auditLog.Table != entry.Table {
+			t.Errorf("Table mismatch: expected %s, got %s", entry.Table, auditLog.Table)
+		}
+		if auditLog.Operation != entry.Operation {
+			t.Errorf("Operation mismatch: expected %s, got %s", entry.Operation, auditLog.Operation)
+		}
+		if auditLog.RecordID != entry.RecordID {
+			t.Errorf("RecordID mismatch: expected %s, got %s", entry.RecordID, auditLog.RecordID)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Completes the async audit system by implementing the final step: worker inserts processed outbox entries into permanent audit_log table. This PR builds on PRs #74, #78, and #88 to complete the full async audit trail.

## Changes Made

### Models
- Added `AuditLog` struct in `internal/domain/models/audit.go`
- Model contains 11 fields matching permanent audit_log schema
- Excludes worker-specific fields (status, retry_count, last_error)

### Worker Implementation  
- Implemented `insertAuditLog()` method to copy outbox → audit_log
- Replaced `simulateProcessing()` placeholder with real insertion
- Maintains transaction context for proper error handling

### Testing
- Added `audit_log` table creation in test setup
- Created comprehensive end-to-end test: `TestAuditWorker_InsertsIntoAuditLog`
- Verifies:
  - Entries are inserted into audit_log
  - Field values match between outbox and audit_log
  - Count of processed entries is correct
- All 12 audit worker tests passing with race detector

## Technical Details

### Async Audit Flow (Complete)
```
Business Operation (Customer CRUD)
  ↓ (synchronous, within transaction)
audit_outbox table (PR #78)
  ↓ (asynchronous, background worker)
Worker processes batch (PR #88)  
  ↓ (this PR)
audit_log table (permanent, immutable)
```

### Data Mapping
Fields copied from AuditOutbox to AuditLog:
- `table_name`, `operation`, `record_id`
- `old_values`, `new_values` (JSON)
- `changed_by`, `transaction_id`
- `client_ip`, `user_agent`
- `created_at` (set to current time)

Not copied (worker-specific):
- `status`, `retry_count`, `last_error`

## Test Results
```
$ go test ./internal/platform/audit -v -race
...
--- PASS: TestAuditWorker_InsertsIntoAuditLog (1.30s)
PASS
ok  	github.com/meridianhub/meridian/internal/platform/audit	22.750s
```

All 12 tests passing (1 skipped).

## Risk Assessment
**Low** - Follows established patterns, comprehensive test coverage, no changes to existing functionality.

## Performance Considerations
- Minimal impact: Single INSERT per outbox entry
- Batch processing maintains throughput
- Indexes on audit_log ensure query performance

## Related
- Closes https://github.com/meridianhub/meridian/issues/75
- Builds on PR #74 (schema), #78 (hooks), #88 (worker)
- Part of async audit system implementation

## Next Steps
After merge, the async audit system is complete and operational. The worker will automatically:
1. Poll audit_outbox for pending entries
2. Insert into audit_log 
3. Mark outbox entries as completed
4. Provide permanent immutable audit trail