### PR TITLE
fix: Correct Keycloak health probe port from 8080 to 9000

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -442,7 +442,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /health/ready
-            port: 8080
+            port: 9000
           initialDelaySeconds: 30
           periodSeconds: 10
           timeoutSeconds: 3
@@ -450,7 +450,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /health/live
-            port: 8080
+            port: 9000
           initialDelaySeconds: 60
           periodSeconds: 30
           timeoutSeconds: 3


### PR DESCRIPTION
## Summary

Fixes Keycloak container restart loop by correcting health probe port configuration from 8080 to 9000.

## Problem Statement

Keycloak was experiencing continuous restarts (119 restarts observed) due to failing health probes. The container would start successfully but was killed repeatedly by Kubernetes.

## Root Cause Analysis

Keycloak 26.0 separates its main HTTP interface and management interface:
- Main HTTP interface: port 8080
- Management interface (health endpoints): port 9000

The health probes were configured to check port 8080, but Keycloak's health endpoints (`/health/ready` and `/health/live`) are only available on the management interface at port 9000.

Log evidence:
```
Management interface listening on http://0.0.0.0:9000
```

Kubernetes events:
```
Readiness probe failed: HTTP probe failed with statuscode: 404
Container keycloak failed liveness probe, will be restarted
```

## Changes Made

Updated `Tiltfile`:
- `readinessProbe.httpGet.port`: 8080 → 9000
- `livenessProbe.httpGet.port`: 8080 → 9000

## Testing

Deployed with Tilt and verified:
- Keycloak starts successfully
- Health probes pass (confirmed via `kubectl describe pod`)
- Container remains stable with 0 restarts after multiple minutes
- No 404 errors in events

Before:
```
keycloak-55c464f674-fqsrt   0/1   CrashLoopBackOff   119 restarts
```

After:
```
keycloak-f858f4fd9-6plcl    1/1   Running            0 restarts
```

## Risk Assessment

**Risk: Low**

This is a configuration-only change that corrects the port for existing health check endpoints. No code changes or new functionality introduced.

## Performance Considerations

No performance impact. Health probes now correctly target the management interface, reducing unnecessary container restarts and improving system stability.

## Deployment Notes

No special deployment requirements. Change takes effect immediately when Tilt reloads or on next Kubernetes deployment.