### PR TITLE
Load meridian-db secret in Tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -571,6 +571,7 @@ docker_build(
 
 # Deploy Kubernetes manifests
 k8s_yaml(kustomize('deployments/k8s/base'))
+k8s_yaml('deployments/k8s/base/secret.yaml')
 
 # Set resource dependencies
 k8s_resource(

--- a/Tiltfile
+++ b/Tiltfile
@@ -571,7 +571,12 @@ docker_build(
 
 # Deploy Kubernetes manifests
 k8s_yaml(kustomize('deployments/k8s/base'))
-k8s_yaml('deployments/k8s/base/secret.yaml')
+
+# Load secret if it exists (generated locally by scripts/setup-local-secrets.sh)
+# This file is excluded from git and won't exist in CI environments
+secret_path = 'deployments/k8s/base/secret.yaml'
+if os.path.exists(secret_path):
+  k8s_yaml(secret_path)
 
 # Set resource dependencies
 k8s_resource(


### PR DESCRIPTION
## Summary
- Add explicit `k8s_yaml()` call to load `deployments/k8s/base/secret.yaml` in Tiltfile
- Matches the pattern used for microservice secrets (current-account, financial-accounting)
- Ensures meridian-db secret is available without breaking CI builds

## Technical Details

**Problem**: After PR #121, the `meridian-db` secret is generated locally by `scripts/setup-local-secrets.sh` and excluded from git. However, it was removed from `kustomization.yaml` to prevent CI failures. This meant Tilt wasn't loading it, causing pods to fail with `CreateContainerConfigError`.

**Solution**: Load the secret explicitly in Tiltfile using `k8s_yaml('deployments/k8s/base/secret.yaml')`, matching the established pattern for microservice secrets.

**Files Changed**:
- `Tiltfile`: Added `k8s_yaml('deployments/k8s/base/secret.yaml')` after kustomize() call

## Testing

Tested locally with Tilt:
1. Run `./scripts/setup-local-secrets.sh` to generate secret.yaml
2. Start Tilt with `tilt up`
3. Verify meridian-db secret created: `kubectl get secret meridian-db -n default`
4. Verify pods no longer show CreateContainerConfigError

## Related

- PR #121: Added DATABASE_URL configuration and secret template system
- Follow-up: Need to recreate meridian database/user in CockroachDB (separate from this change)