### PR TITLE
Automate database setup and fix connection string

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -749,9 +749,10 @@ local_resource(
 
 # Initialize CockroachDB database and user - runs automatically after CockroachDB is ready
 # Creates the meridian database and user required for the application
+# Uses dedicated script with pod readiness check and verification
 local_resource(
   'init-database',
-  cmd='kubectl exec cockroachdb-0 -n default -- cockroach sql --insecure -e "CREATE DATABASE IF NOT EXISTS meridian; CREATE USER IF NOT EXISTS meridian; GRANT ALL ON DATABASE meridian TO meridian;"',
+  cmd='./scripts/init-database.sh',
   resource_deps=['cockroachdb'],
   labels=['database'],
   auto_init=True,

--- a/Tiltfile
+++ b/Tiltfile
@@ -756,7 +756,7 @@ local_resource(
   resource_deps=['cockroachdb'],
   labels=['database'],
   auto_init=True,
-  trigger_mode=TRIGGER_MODE_AUTO,
+  trigger_mode=TRIGGER_MODE_MANUAL,  # Manual re-trigger; auto_init runs it on startup
 )
 
 # Run database migrations on startup - uses Atlas to apply schema changes

--- a/Tiltfile
+++ b/Tiltfile
@@ -586,7 +586,7 @@ k8s_resource(
     '9090:9090',  # gRPC API
   ],
   resource_deps=[
-    'cockroachdb',
+    'init-database',  # Ensures database and user are created before app starts
     'redis',
     'kafka-cluster',
     'keycloak',
@@ -747,6 +747,17 @@ local_resource(
   auto_init=False,  # Run manually with 'tilt trigger lint'
 )
 
+# Initialize CockroachDB database and user - runs automatically after CockroachDB is ready
+# Creates the meridian database and user required for the application
+local_resource(
+  'init-database',
+  cmd='kubectl exec cockroachdb-0 -n default -- cockroach sql --insecure -e "CREATE DATABASE IF NOT EXISTS meridian; CREATE USER IF NOT EXISTS meridian; GRANT ALL ON DATABASE meridian TO meridian;"',
+  resource_deps=['cockroachdb'],
+  labels=['database'],
+  auto_init=True,
+  trigger_mode=TRIGGER_MODE_AUTO,
+)
+
 # Run database migrations on startup - uses Atlas to apply schema changes
 # Each service has its own business schema and audit schema
 # Migrations are applied in order:
@@ -757,7 +768,7 @@ local_resource(
 local_resource(
   'migrate-current-account',
   cmd='atlas migrate apply --env local --config file://atlas.current_account.hcl --url "{}"'.format(database_url),
-  resource_deps=['cockroachdb'],
+  resource_deps=['init-database'],  # Database and user must exist before migrations
   labels=['database'],
   auto_init=True,
   trigger_mode=TRIGGER_MODE_MANUAL,

--- a/Tiltfile
+++ b/Tiltfile
@@ -64,7 +64,7 @@ k8s_namespace = 'default'
 # Database configuration
 # SECURITY: Never commit credentials to version control
 # For local development with CockroachDB (insecure mode, no password required)
-database_url = os.getenv('DATABASE_URL', 'postgres://root@localhost:26257/defaultdb?sslmode=disable')
+database_url = os.getenv('DATABASE_URL', 'postgres://meridian@localhost:26257/meridian?sslmode=disable')
 
 # =============================================================================
 # Backing Services

--- a/scripts/init-database.sh
+++ b/scripts/init-database.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Initialize CockroachDB database and user for local development
+#
+# This script:
+# 1. Waits for CockroachDB pod to be ready
+# 2. Creates the meridian database and user
+# 3. Grants necessary permissions
+#
+# IMPORTANT: For LOCAL DEVELOPMENT ONLY
+# Production databases should be initialized through proper migration tooling
+
+set -e
+
+NAMESPACE="${NAMESPACE:-default}"
+POD_NAME="${POD_NAME:-cockroachdb-0}"
+TIMEOUT="${TIMEOUT:-300}"
+
+echo "Initializing CockroachDB database..."
+
+# Wait for CockroachDB pod to be ready
+echo "Waiting for $POD_NAME to be ready (timeout: ${TIMEOUT}s)..."
+if ! kubectl wait pod/"$POD_NAME" \
+  --for=condition=Ready \
+  --timeout="${TIMEOUT}s" \
+  --namespace="$NAMESPACE" 2>/dev/null; then
+  echo "ERROR: $POD_NAME did not become ready within ${TIMEOUT}s"
+  exit 1
+fi
+
+echo "✓ $POD_NAME is ready"
+
+# Create database and user
+echo "Creating meridian database and user..."
+if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+  cockroach sql --insecure -e \
+  "CREATE DATABASE IF NOT EXISTS meridian; \
+   CREATE USER IF NOT EXISTS meridian; \
+   GRANT ALL ON DATABASE meridian TO meridian;" 2>&1 | grep -E "CREATE|GRANT"; then
+  echo "✓ Database and user initialized successfully"
+else
+  echo "✓ Database and user already exist (idempotent)"
+fi
+
+# Verify database exists
+echo "Verifying database setup..."
+if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+  cockroach sql --insecure -e "SHOW DATABASES;" 2>/dev/null | grep -q "meridian"; then
+  echo "✓ Verified: meridian database exists"
+else
+  echo "ERROR: meridian database not found after initialization"
+  exit 1
+fi
+
+echo "✓ Database initialization complete!"

--- a/scripts/init-database.sh
+++ b/scripts/init-database.sh
@@ -9,7 +9,7 @@
 # IMPORTANT: For LOCAL DEVELOPMENT ONLY
 # Production databases should be initialized through proper migration tooling
 
-set -e
+set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-default}"
 POD_NAME="${POD_NAME:-cockroachdb-0}"
@@ -22,8 +22,9 @@ echo "Waiting for $POD_NAME to be ready (timeout: ${TIMEOUT}s)..."
 if ! kubectl wait pod/"$POD_NAME" \
   --for=condition=Ready \
   --timeout="${TIMEOUT}s" \
-  --namespace="$NAMESPACE" 2>/dev/null; then
+  --namespace="$NAMESPACE"; then
   echo "ERROR: $POD_NAME did not become ready within ${TIMEOUT}s"
+  echo "Check pod status with: kubectl get pod $POD_NAME -n $NAMESPACE"
   exit 1
 fi
 
@@ -31,23 +32,41 @@ echo "✓ $POD_NAME is ready"
 
 # Create database and user
 echo "Creating meridian database and user..."
-if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+SQL_OUTPUT=$(kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
   cockroach sql --insecure -e \
   "CREATE DATABASE IF NOT EXISTS meridian; \
    CREATE USER IF NOT EXISTS meridian; \
-   GRANT ALL ON DATABASE meridian TO meridian;" 2>&1 | grep -E "CREATE|GRANT"; then
+   GRANT ALL ON DATABASE meridian TO meridian;" 2>&1) || {
+  echo "ERROR: Failed to initialize database"
+  echo "SQL output: $SQL_OUTPUT"
+  exit 1
+}
+
+if echo "$SQL_OUTPUT" | grep -qE "CREATE|GRANT"; then
   echo "✓ Database and user initialized successfully"
+elif echo "$SQL_OUTPUT" | grep -qiE "error|failed"; then
+  echo "ERROR: Database initialization encountered an error"
+  echo "SQL output: $SQL_OUTPUT"
+  exit 1
 else
   echo "✓ Database and user already exist (idempotent)"
 fi
 
 # Verify database exists
 echo "Verifying database setup..."
-if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
-  cockroach sql --insecure -e "SHOW DATABASES;" 2>/dev/null | grep -q "meridian"; then
+VERIFY_OUTPUT=$(kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+  cockroach sql --insecure -e "SHOW DATABASES;" 2>&1) || {
+  echo "ERROR: Failed to verify database"
+  echo "Output: $VERIFY_OUTPUT"
+  exit 1
+}
+
+if echo "$VERIFY_OUTPUT" | grep -q "meridian"; then
   echo "✓ Verified: meridian database exists"
 else
   echo "ERROR: meridian database not found after initialization"
+  echo "Available databases:"
+  echo "$VERIFY_OUTPUT"
   exit 1
 fi
 

--- a/scripts/setup-local-secrets.sh
+++ b/scripts/setup-local-secrets.sh
@@ -28,8 +28,8 @@ setup_secret() {
     echo "Creating $secret_file from template..."
 
     # For local dev, use the meridian user/database
-    # This matches what setup-check.sh creates in CockroachDB
-    sed 's|<REPLACE_WITH_DATABASE_URL>|postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable|g' \
+    # CockroachDB runs in insecure mode (no passwords), so omit password from connection string
+    sed 's|<REPLACE_WITH_DATABASE_URL>|postgres://meridian@cockroachdb:26257/meridian?sslmode=disable|g' \
         "$example_file" > "$secret_file"
 
     echo "✓ Created $secret_file"

--- a/scripts/test-database-setup.sh
+++ b/scripts/test-database-setup.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Integration test for database setup
+#
+# Validates that the database initialization works correctly:
+# 1. Database exists
+# 2. User exists
+# 3. User has correct permissions
+# 4. Can connect with the configured credentials
+
+set -e
+
+NAMESPACE="${NAMESPACE:-default}"
+POD_NAME="${POD_NAME:-cockroachdb-0}"
+DATABASE_NAME="meridian"
+USER_NAME="meridian"
+
+echo "Testing database setup..."
+echo
+
+# Test 1: Verify database exists
+echo "Test 1: Checking if database exists..."
+if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+  cockroach sql --insecure -e "SHOW DATABASES;" 2>/dev/null | grep -q "$DATABASE_NAME"; then
+  echo "✓ Database '$DATABASE_NAME' exists"
+else
+  echo "✗ FAILED: Database '$DATABASE_NAME' not found"
+  exit 1
+fi
+
+# Test 2: Verify user exists
+echo "Test 2: Checking if user exists..."
+if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+  cockroach sql --insecure -e "SHOW USERS;" 2>/dev/null | grep -q "$USER_NAME"; then
+  echo "✓ User '$USER_NAME' exists"
+else
+  echo "✗ FAILED: User '$USER_NAME' not found"
+  exit 1
+fi
+
+# Test 3: Verify user can connect to database
+echo "Test 3: Testing user connection to database..."
+if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+  cockroach sql --insecure --user="$USER_NAME" --database="$DATABASE_NAME" \
+  -e "SELECT 1;" 2>/dev/null | grep -q "1"; then
+  echo "✓ User can connect to database"
+else
+  echo "✗ FAILED: User cannot connect to database"
+  exit 1
+fi
+
+# Test 4: Verify user has CREATE privilege
+echo "Test 4: Testing user permissions (CREATE TABLE)..."
+if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+  cockroach sql --insecure --user="$USER_NAME" --database="$DATABASE_NAME" \
+  -e "CREATE TABLE IF NOT EXISTS test_permissions (id INT); DROP TABLE test_permissions;" 2>/dev/null; then
+  echo "✓ User has CREATE privilege"
+else
+  echo "✗ FAILED: User lacks CREATE privilege"
+  exit 1
+fi
+
+# Test 5: Verify connection string works (simulate app connection)
+echo "Test 5: Testing connection string format..."
+CONNECTION_STRING="postgres://$USER_NAME@$POD_NAME:26257/$DATABASE_NAME?sslmode=disable"
+if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+  cockroach sql --url="$CONNECTION_STRING" \
+  -e "SELECT current_database();" 2>/dev/null | grep -q "$DATABASE_NAME"; then
+  echo "✓ Connection string format is valid"
+else
+  echo "✗ FAILED: Connection string format invalid"
+  exit 1
+fi
+
+echo
+echo "✓ All database setup tests passed!"
+echo "  - Database: $DATABASE_NAME"
+echo "  - User: $USER_NAME"
+echo "  - Permissions: Verified"
+echo "  - Connection: Working"

--- a/scripts/test-database-setup.sh
+++ b/scripts/test-database-setup.sh
@@ -7,67 +7,105 @@
 # 3. User has correct permissions
 # 4. Can connect with the configured credentials
 
-set -e
+set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-default}"
 POD_NAME="${POD_NAME:-cockroachdb-0}"
 DATABASE_NAME="meridian"
 USER_NAME="meridian"
+TEST_TABLE="test_permissions_$$"  # Include PID for uniqueness
 
 echo "Testing database setup..."
 echo
 
 # Test 1: Verify database exists
 echo "Test 1: Checking if database exists..."
-if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
-  cockroach sql --insecure -e "SHOW DATABASES;" 2>/dev/null | grep -q "$DATABASE_NAME"; then
+DB_OUTPUT=$(kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+  cockroach sql --insecure -e "SHOW DATABASES;" 2>&1) || {
+  echo "✗ FAILED: kubectl exec failed"
+  echo "Output: $DB_OUTPUT"
+  exit 1
+}
+
+if echo "$DB_OUTPUT" | grep -q "$DATABASE_NAME"; then
   echo "✓ Database '$DATABASE_NAME' exists"
 else
   echo "✗ FAILED: Database '$DATABASE_NAME' not found"
+  echo "Available databases:"
+  echo "$DB_OUTPUT"
   exit 1
 fi
 
 # Test 2: Verify user exists
 echo "Test 2: Checking if user exists..."
-if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
-  cockroach sql --insecure -e "SHOW USERS;" 2>/dev/null | grep -q "$USER_NAME"; then
+USER_OUTPUT=$(kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+  cockroach sql --insecure -e "SHOW USERS;" 2>&1) || {
+  echo "✗ FAILED: kubectl exec failed"
+  echo "Output: $USER_OUTPUT"
+  exit 1
+}
+
+if echo "$USER_OUTPUT" | grep -q "$USER_NAME"; then
   echo "✓ User '$USER_NAME' exists"
 else
   echo "✗ FAILED: User '$USER_NAME' not found"
+  echo "Available users:"
+  echo "$USER_OUTPUT"
   exit 1
 fi
 
 # Test 3: Verify user can connect to database
 echo "Test 3: Testing user connection to database..."
-if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+CONNECT_OUTPUT=$(kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
   cockroach sql --insecure --user="$USER_NAME" --database="$DATABASE_NAME" \
-  -e "SELECT 1;" 2>/dev/null | grep -q "1"; then
+  -e "SELECT 1;" 2>&1) || {
+  echo "✗ FAILED: User cannot connect to database"
+  echo "Output: $CONNECT_OUTPUT"
+  exit 1
+}
+
+if echo "$CONNECT_OUTPUT" | grep -q "1"; then
   echo "✓ User can connect to database"
 else
-  echo "✗ FAILED: User cannot connect to database"
+  echo "✗ FAILED: Unexpected connection output"
+  echo "Output: $CONNECT_OUTPUT"
   exit 1
 fi
 
 # Test 4: Verify user has CREATE privilege
 echo "Test 4: Testing user permissions (CREATE TABLE)..."
-if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+CREATE_OUTPUT=$(kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
   cockroach sql --insecure --user="$USER_NAME" --database="$DATABASE_NAME" \
-  -e "CREATE TABLE IF NOT EXISTS test_permissions (id INT); DROP TABLE test_permissions;" 2>/dev/null; then
+  -e "CREATE TABLE IF NOT EXISTS $TEST_TABLE (id INT); DROP TABLE IF EXISTS $TEST_TABLE;" 2>&1) || {
+  echo "✗ FAILED: User lacks CREATE privilege"
+  echo "Output: $CREATE_OUTPUT"
+  exit 1
+}
+
+if echo "$CREATE_OUTPUT" | grep -qE "CREATE TABLE|DROP TABLE"; then
   echo "✓ User has CREATE privilege"
 else
-  echo "✗ FAILED: User lacks CREATE privilege"
+  echo "✗ FAILED: Unexpected CREATE/DROP output"
+  echo "Output: $CREATE_OUTPUT"
   exit 1
 fi
 
 # Test 5: Verify connection string works (simulate app connection)
 echo "Test 5: Testing connection string format..."
 CONNECTION_STRING="postgres://$USER_NAME@$POD_NAME:26257/$DATABASE_NAME?sslmode=disable"
-if kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
+CONN_STRING_OUTPUT=$(kubectl exec "$POD_NAME" -n "$NAMESPACE" -- \
   cockroach sql --url="$CONNECTION_STRING" \
-  -e "SELECT current_database();" 2>/dev/null | grep -q "$DATABASE_NAME"; then
+  -e "SELECT current_database();" 2>&1) || {
+  echo "✗ FAILED: Connection string format invalid"
+  echo "Output: $CONN_STRING_OUTPUT"
+  exit 1
+}
+
+if echo "$CONN_STRING_OUTPUT" | grep -q "$DATABASE_NAME"; then
   echo "✓ Connection string format is valid"
 else
-  echo "✗ FAILED: Connection string format invalid"
+  echo "✗ FAILED: Unexpected connection string output"
+  echo "Output: $CONN_STRING_OUTPUT"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Remove password from database connection string in setup script
- Automate meridian database and user creation in Tiltfile
- Update resource dependencies to ensure proper initialization order

## Problem

After PR #121 and #122, users following the README Quick Start encountered two issues:

1. **Password Authentication Failed**: The setup script generated `postgres://meridian:meridian@cockroachdb...` but CockroachDB runs in insecure mode locally, which doesn't support password authentication
   
2. **Manual Database Setup Required**: Users had to manually run kubectl commands to create the meridian database and user before the application would start

## Solution

### 1. Fixed Connection String (scripts/setup-local-secrets.sh)

**Before:**
```
postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable
```

**After:**
```
postgres://meridian@cockroachdb:26257/meridian?sslmode=disable
```

CockroachDB in insecure mode doesn't use passwords - including one in the connection string causes authentication failures.

### 2. Automated Database Initialization (Tiltfile)

Added `init-database` local_resource that:
- Runs automatically after CockroachDB is ready
- Creates the meridian database and user using `CREATE DATABASE IF NOT EXISTS` and `CREATE USER IF NOT EXISTS`
- Executes via kubectl exec to CockroachDB pod

**Updated Dependencies:**
- `meridian` app now depends on `init-database` (instead of `cockroachdb`)
- `migrate-current-account` now depends on `init-database` (database must exist before migrations)

## Technical Details

**Files Changed:**
- `scripts/setup-local-secrets.sh`: Removed `:meridian` password from connection string
- `Tiltfile`: 
  - Added `init-database` local_resource with auto_init=True
  - Updated meridian resource_deps: `['init-database', 'redis', 'kafka-cluster', 'keycloak']`
  - Updated migrate-current-account resource_deps: `['init-database']`

**Dependency Chain:**
```
cockroachdb → init-database → meridian
                           → migrate-current-account → migrate-position-keeping
```

## Testing

Verified with fresh environment:
1. Delete existing cluster: `tilt down`
2. Run setup script: `./scripts/setup-local-secrets.sh`
3. Start Tilt: `tilt up`
4. Verify:
   - init-database resource runs successfully
   - meridian pods start without CrashLoopBackOff
   - No manual kubectl commands required

Expected output in Tilt UI:
- init-database: ✓ (creates database and user automatically)
- meridian: ✓ (all 3 pods running)

## Impact

**Before this PR:**
Users had to:
1. Run setup-local-secrets.sh
2. Manually fix the generated secret.yaml to remove password
3. Run tilt up
4. Watch pods crash
5. Manually run: `kubectl exec cockroachdb-0 -- cockroach sql --insecure -e "CREATE DATABASE ..."`
6. Wait for pods to restart

**After this PR:**
Users run:
1. `./scripts/setup-local-secrets.sh`
2. `tilt up`
3. Everything works ✓

## Related

- PR #121: Added DATABASE_URL configuration and secret template system
- PR #122: Added conditional secret loading in Tiltfile