### PR TITLE
fix: Resolve OpenTelemetry schema conflict by downgrading GCP detector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3 // indirect
-	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 // indirect
+	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0
@@ -138,7 +138,7 @@ require (
 	github.com/zeebo/errs v1.4.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/contrib/detectors/gcp v1.38.0 // indirect
+	go.opentelemetry.io/contrib/detectors/gcp v1.37.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.62.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -652,6 +652,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3 h1:2afWGsMzkIcN8Qm4mgPJKZWyroE5QBszMiDMYEBrnfw=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3/go.mod h1:dppbR7CwXD4pgtV9t3wD1812RaLDcBjtblcDF5f1vI0=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 h1:UQUsRi8WTzhZntp5313l+CHIAT95ojUI2lpP/ExlZa4=
+github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0/go.mod h1:Cz6ft6Dkn3Et6l2v2a9/RpN7epQ1GtDlO6lj8bEcOvw=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 h1:sBEjpZlNHzK1voKq9695PJSX2o5NEXl7/OL3coiIY0c=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/IBM/sarama v1.42.1 h1:wugyWa15TDEHh2kvq2gAy1IHLjEjuYOYgXz/ruC/OSQ=
@@ -1348,6 +1350,8 @@ go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
+go.opentelemetry.io/contrib/detectors/gcp v1.37.0 h1:B+WbN9RPsvobe6q4vP6KgM8/9plR/HNjgGBrfcOlweA=
+go.opentelemetry.io/contrib/detectors/gcp v1.37.0/go.mod h1:K5zQ3TT7p2ru9Qkzk0bKtCql0RGkPj9pRjpXgZJZ+rU=
 go.opentelemetry.io/contrib/detectors/gcp v1.38.0 h1:ZoYbqX7OaA/TAikspPl3ozPI6iY6LiIY9I8cUfm+pJs=
 go.opentelemetry.io/contrib/detectors/gcp v1.38.0/go.mod h1:SU+iU7nu5ud4oCb3LQOhIZ3nRLj6FNVrKgtflbaf2ts=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0 h1:rbRJ8BBoVMsQShESYZ0FkvcITu8X8QNwJogcLUmDNNw=

--- a/internal/platform/observability/tracing_integration_test.go
+++ b/internal/platform/observability/tracing_integration_test.go
@@ -1,0 +1,78 @@
+package observability
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTracer_ResourceCreation_NoSchemaConflict validates that tracer initialization
+// does not fail due to conflicting OpenTelemetry schema versions between dependencies.
+//
+// This test catches schema version conflicts between:
+//   - go.opentelemetry.io/otel (base SDK)
+//   - go.opentelemetry.io/contrib/detectors/gcp (GCP resource detector)
+//   - GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp (transitive dependency)
+//
+// Schema conflicts manifest as errors like:
+//
+//	"failed to merge resources: conflicting Schema URL: https://opentelemetry.io/schemas/1.37.0 and https://opentelemetry.io/schemas/1.27.0"
+//
+// This test ensures dependency versions remain compatible during upgrades.
+func TestTracer_ResourceCreation_NoSchemaConflict(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	cfg := TracerConfig{
+		ServiceName:    "test-service",
+		ServiceVersion: "1.0.0",
+		Environment:    "test",
+		Enabled:        true,
+		OTLPEndpoint:   "localhost:4317",
+		SamplingRate:   1.0,
+		UseTLS:         false,
+	}
+
+	ctx := context.Background()
+
+	// This initialization would fail with schema conflict if dependencies are incompatible
+	tracer, err := NewTracer(ctx, cfg)
+
+	// Assert no schema conflict errors occurred during resource creation
+	require.NoError(t, err, "tracer initialization should not fail with schema conflicts")
+	require.NotNil(t, tracer, "tracer should be initialized")
+
+	// Verify tracer is functional
+	assert.NotNil(t, tracer.tracer, "tracer.tracer should be initialized")
+	assert.NotNil(t, tracer.provider, "tracer.provider should be initialized")
+	assert.Equal(t, cfg.ServiceName, tracer.config.ServiceName)
+
+	// Clean shutdown
+	shutdownCtx := context.Background()
+	err = tracer.Shutdown(shutdownCtx)
+	assert.NoError(t, err, "tracer shutdown should not fail")
+}
+
+// TestTracer_NoSchemaConflict_WhenDisabled verifies that disabled tracer
+// does not attempt resource creation and thus avoids schema conflicts
+func TestTracer_NoSchemaConflict_WhenDisabled(t *testing.T) {
+	cfg := TracerConfig{
+		ServiceName:    "test-service",
+		ServiceVersion: "1.0.0",
+		Environment:    "test",
+		Enabled:        false, // Tracing disabled
+		OTLPEndpoint:   "localhost:4317",
+		SamplingRate:   1.0,
+		UseTLS:         false,
+	}
+
+	ctx := context.Background()
+	tracer, err := NewTracer(ctx, cfg)
+
+	require.NoError(t, err, "disabled tracer initialization should not fail")
+	require.NotNil(t, tracer, "tracer should be initialized")
+	assert.Nil(t, tracer.provider, "disabled tracer should have nil provider")
+}


### PR DESCRIPTION
## Summary
- Fixes OpenTelemetry schema version conflict causing CrashLoopBackOff in current-account and financial-accounting services
- Downgrades `go.opentelemetry.io/contrib/detectors/gcp` from v1.38.0 to v1.37.0
- Forces `GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp` to v1.29.0

## Root Cause
PR #126 upgraded `go.opentelemetry.io/contrib/detectors/gcp` from v1.37.0 to v1.38.0. This pulled in `GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp@v1.30.0`, which uses OpenTelemetry schema 1.27.0. This conflicted with `go.opentelemetry.io/otel@v1.38.0` (schema 1.37.0), causing the error:

```
conflicting Schema URL: https://opentelemetry.io/schemas/1.37.0 
and https://opentelemetry.io/schemas/1.27.0
```

## Solution
Downgrade to the last known working combination:
- `go.opentelemetry.io/contrib/detectors/gcp`: v1.38.0 → v1.37.0  
- `GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp`: v1.30.0 → v1.29.0

This restores the configuration from commit 2217425^ (before PR #125 merged).

## Technical Details
The Google Cloud detector v1.30.0 is the latest version but hasn't been updated to support OTel 1.38.0's schema (1.37.0) yet. Using the older v1.29.0 avoids the conflict.

## Test Plan
- [x] Build passes with cleaned Docker cache
- [ ] current-account service starts without schema conflict
- [ ] financial-accounting service starts without schema conflict  
- [ ] meridian service starts successfully
- [ ] All services remain Running (not CrashLoopBackOff)

## Future Work
Once `GoogleCloudPlatform/opentelemetry-operations-go` releases a version compatible with OTel 1.38.0 (schema 1.37.0), we can upgrade again.