### PR TITLE
Add position-keeping service to Tilt

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -592,7 +592,7 @@ k8s_resource(
     'kafka-cluster',
     'keycloak',
   ],
-  labels=['app'],
+  labels=['microservices'],
   # Group RBAC and config resources under the main app
   objects=[
     'meridian:serviceaccount',
@@ -668,6 +668,24 @@ k8s_resource(
     'generate-proto',
     'cockroachdb',
     'migrate-current-account',  # Financial accounting depends on current account schema
+  ],
+  labels=['microservices'],
+)
+
+# Position-Keeping Service - gRPC microservice for transaction position management
+# Note: Only service.yaml exists. Deployment, configmap, and secret manifests are not yet created.
+# This service will be fully deployable once those manifests are added to deployments/k8s/position-keeping/
+k8s_yaml('deployments/k8s/position-keeping/service.yaml')
+
+k8s_resource(
+  'position-keeping',
+  port_forwards=[
+    '50053:50053',  # gRPC API
+  ],
+  resource_deps=[
+    'generate-proto',
+    'cockroachdb',
+    'migrate-position-keeping',
   ],
   labels=['microservices'],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -673,10 +673,24 @@ k8s_resource(
 )
 
 # Position-Keeping Service - gRPC microservice for transaction position management
-# Note: Only service.yaml exists. Deployment, configmap, and secret manifests are not yet created.
-# This service will be fully deployable once those manifests are added to deployments/k8s/position-keeping/
+docker_build(
+  'position-keeping',
+  context='.',
+  dockerfile='cmd/position-keeping/Dockerfile',
+  build_args={
+    'VERSION': 'dev',
+    'COMMIT': local('git rev-parse --short HEAD'),
+    'BUILD_DATE': get_build_date(),
+  },
+)
+
+# Deploy Position-Keeping Kubernetes manifests
+k8s_yaml('deployments/k8s/position-keeping/secret.yaml')
+k8s_yaml('deployments/k8s/position-keeping/configmap.yaml')
+k8s_yaml('deployments/k8s/position-keeping/deployment.yaml')
 k8s_yaml('deployments/k8s/position-keeping/service.yaml')
 
+# Set resource dependencies for Position-Keeping
 k8s_resource(
   'position-keeping',
   port_forwards=[

--- a/cmd/position-keeping/Dockerfile
+++ b/cmd/position-keeping/Dockerfile
@@ -1,0 +1,59 @@
+# Position-Keeping Service - Multi-Stage Dockerfile
+# Optimized for security, size, and performance
+
+# Build stage
+FROM golang:1.25-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache \
+    git \
+    ca-certificates \
+    tzdata
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum* ./
+RUN go mod download && go mod verify
+
+# Copy source code
+COPY . .
+
+# Build static binary with optimizations
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -a -installsuffix cgo \
+    -o position-keeping \
+    ./cmd/position-keeping
+
+# Verify the binary exists and is executable
+RUN test -x position-keeping && echo "Binary built successfully"
+
+# Runtime stage - distroless for minimal attack surface
+FROM gcr.io/distroless/static:nonroot
+
+# Copy CA certificates from builder
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy timezone data from builder
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary from builder
+COPY --from=builder /build/position-keeping /position-keeping
+
+# Use non-root user (distroless default: 65532:65532)
+USER nonroot:nonroot
+
+# Expose gRPC port
+EXPOSE 50053
+
+# Note: Health checks handled by gRPC health check service
+# HEALTHCHECK not needed in distroless image (lacks grpcurl)
+
+# Run the binary
+ENTRYPOINT ["/position-keeping"]

--- a/deployments/k8s/position-keeping/configmap.yaml
+++ b/deployments/k8s/position-keeping/configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: position-keeping-config
+  labels:
+    app: position-keeping
+    component: microservice
+data:
+  # Logging configuration
+  LOG_LEVEL: "info"
+  LOG_FORMAT: "json"
+
+  # Database connection pool settings
+  DB_MAX_OPEN_CONNS: "25"
+  DB_MAX_IDLE_CONNS: "5"
+  DB_CONN_MAX_LIFETIME: "5m"
+  DB_CONN_MAX_IDLE_TIME: "10m"
+
+  # gRPC server configuration
+  GRPC_PORT: "50053"
+  GRPC_MAX_CONCURRENT_STREAMS: "100"
+
+  # OpenTelemetry configuration
+  OTEL_SERVICE_NAME: "position-keeping-service"
+  OTEL_SAMPLING_RATE: "0.1"

--- a/deployments/k8s/position-keeping/deployment.yaml
+++ b/deployments/k8s/position-keeping/deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: position-keeping
+  labels:
+    app: position-keeping
+    component: microservice
+    tier: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: position-keeping
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: position-keeping
+        component: microservice
+        tier: backend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: position-keeping
+        image: position-keeping:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grpc
+          containerPort: 50053
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: position-keeping-config
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: position-keeping-db
+              key: DATABASE_URL
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        livenessProbe:
+          grpc:
+            port: 50053
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          grpc:
+            port: 50053
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        startupProbe:
+          grpc:
+            port: 50053
+          initialDelaySeconds: 0
+          periodSeconds: 2
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 30
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      terminationGracePeriodSeconds: 30

--- a/deployments/k8s/position-keeping/secret.yaml
+++ b/deployments/k8s/position-keeping/secret.yaml
@@ -1,0 +1,16 @@
+# SECURITY NOTE: This secret contains development credentials only.
+# For production deployments:
+# - Use external secret management (e.g., Sealed Secrets, External Secrets Operator)
+# - Rotate credentials regularly
+# - Use RBAC to restrict secret access
+# - Enable encryption at rest for secrets
+apiVersion: v1
+kind: Secret
+metadata:
+  name: position-keeping-db
+  labels:
+    app: position-keeping
+type: Opaque
+stringData:
+  # Local development connection string - CockroachDB in insecure mode
+  DATABASE_URL: "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable"


### PR DESCRIPTION
## Summary

Adds complete Kubernetes deployment configuration for the position-keeping microservice to enable local development via Tilt. All microservices (meridian, current-account, financial-accounting, position-keeping) now grouped under 'microservices' label in Tilt UI.

## Changes Made

### New Files
- `cmd/position-keeping/Dockerfile` - Multi-stage build (golang:1.25-alpine → distroless)
- `deployments/k8s/position-keeping/deployment.yaml` - 2 replicas with gRPC health probes
- `deployments/k8s/position-keeping/configmap.yaml` - Logging, DB pool, gRPC, OTel config
- `deployments/k8s/position-keeping/secret.yaml` - Local development DATABASE_URL

### Updated Files
- `Tiltfile` - Added docker_build and K8s manifest deployment for position-keeping
- `Tiltfile` - Changed meridian service label from 'app' to 'microservices'

## Deployment Configuration

**Service**: position-keeping  
**Port**: 50053 (gRPC, port-forwarded)  
**Replicas**: 2  
**Dependencies**: generate-proto → cockroachdb → migrate-position-keeping

### Security Hardening
- Distroless base image (minimal attack surface)
- Non-root user (uid 65532)
- Read-only root filesystem
- All capabilities dropped
- No privilege escalation
- Seccomp RuntimeDefault profile

### Resource Limits
- CPU: 50m request, 200m limit
- Memory: 64Mi request, 256Mi limit

### Health Checks
- Liveness: gRPC probe every 10s
- Readiness: gRPC probe every 5s  
- Startup: gRPC probe every 2s (max 60s)

## Test Plan

- [ ] Start Tilt: `tilt up`
- [ ] Verify position-keeping builds successfully
- [ ] Verify position-keeping pods reach Ready state
- [ ] Verify gRPC health checks pass
- [ ] Verify port forwarding works: `grpcurl -plaintext localhost:50053 list`
- [ ] Verify all microservices grouped under 'microservices' label in Tilt UI
- [ ] Verify database migration runs: `tilt trigger migrate-position-keeping`

## Files Changed

```
Tiltfile                                         |  34 ++++++-
cmd/position-keeping/Dockerfile                  |  59 ++++++++++
deployments/k8s/position-keeping/configmap.yaml  |  25 +++++
deployments/k8s/position-keeping/deployment.yaml | 107 +++++++++++++++++++
deployments/k8s/position-keeping/secret.yaml     |  16 ++++
5 files changed, 240 insertions(+), 1 deletion(-)
```