### PR TITLE
docs: Remove AccountReconciliation from documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -851,10 +851,10 @@ Use [Conventional Commits](https://www.conventionalcommits.org/):
 
 **Examples:**
 ```
-feat: add account reconciliation service
+feat: add position keeping batch operations
 
-Implements BIAN AccountReconciliation domain with transaction
-verification and position checking.
+Implements bulk import for transaction logs with validation
+and audit trail support.
 
 Closes #123
 ```

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ This implementation includes the following BIAN service domains:
 - **FinancialAccounting**: Double-entry general ledger with audit trail
 - **PositionKeeping**: Pre-ledger transaction log and position tracking
 - **CurrentAccount**: Customer-facing account management
-- **AccountReconciliation**: Transaction verification and reconciliation
 
 Each service domain follows BIAN's control record pattern with behavior qualifiers for operations.
 

--- a/docs/adr/0002-microservices-per-bian-domain.md
+++ b/docs/adr/0002-microservices-per-bian-domain.md
@@ -22,7 +22,7 @@ Accepted
 
 ## Context
 
-Meridian implements multiple BIAN (Banking Industry Architecture Network) service domains: FinancialAccounting, PositionKeeping, CurrentAccount, and AccountReconciliation. We need to decide whether to build a modular monolith with all domains in one deployable or separate microservices with one service per BIAN domain.
+Meridian implements multiple BIAN (Banking Industry Architecture Network) service domains: FinancialAccounting, PositionKeeping, and CurrentAccount. We need to decide whether to build a modular monolith with all domains in one deployable or separate microservices with one service per BIAN domain.
 
 BIAN service domains already define clear bounded contexts with well-defined interfaces, making them natural candidates for service boundaries.
 
@@ -54,7 +54,7 @@ Chosen option: "Microservices - One service per BIAN domain", because:
 ### Positive Consequences
 
 * Each BIAN domain can scale independently based on load
-* Failure in one domain (e.g., reconciliation) does not impact critical operations (e.g., transaction logging)
+* Failure in one domain (e.g., financial accounting) does not impact critical operations (e.g., transaction logging)
 * Teams can own and deploy individual domains independently
 * Technology choices can vary per service if needed (though we'll standardize on Go/gRPC initially)
 * Clear audit boundaries aligned with BIAN specification


### PR DESCRIPTION
## Summary

Removes references to AccountReconciliation service domain from documentation as it is not yet implemented.

## Changes

Updated three files to remove AccountReconciliation mentions:

1. **README.md**
   - Removed from BIAN Service Domains list
   - Now only lists implemented services: FinancialAccounting, PositionKeeping, CurrentAccount

2. **CONTRIBUTING.md**
   - Updated commit message example to use PositionKeeping batch operations instead of AccountReconciliation

3. **docs/adr/0002-microservices-per-bian-domain.md**
   - Removed from Context section service domain list
   - Updated example in Positive Consequences to use "financial accounting" instead of "reconciliation"

## Rationale

Documentation should reflect the current state of implementation. AccountReconciliation can be added back when development begins.

## Testing

- [x] Verified no AccountReconciliation proto files exist
- [x] Verified no AccountReconciliation service code exists
- [x] All documentation now accurately reflects implemented services