### PR TITLE
Add Atlas migration infrastructure for financial-accounting service

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -667,7 +667,7 @@ k8s_resource(
   resource_deps=[
     'generate-proto',
     'cockroachdb',
-    'migrate-current-account',  # Financial accounting depends on current account schema
+    'migrate-financial-accounting',  # Financial accounting has its own schema
   ],
   labels=['microservices'],
 )
@@ -808,12 +808,11 @@ local_resource(
 )
 
 # Run database migrations on startup - uses Atlas to apply schema changes
-# Each service has its own business schema and audit schema
+# Each service has its own business schema
 # Migrations are applied in order:
-# 1. current_account (customers, accounts, current_account_audit)
-# 2. position_keeping (transactions, position_keeping_audit) - depends on current_account for FKs
-# Note: Phase 1 creates empty audit tables (current work). Audit logging via GORM hooks
-#       will be implemented in Phase 2 (future PR). See ADR-0009 for rationale and implementation plan.
+# 1. current_account (customers, accounts)
+# 2. position_keeping (transactions) - depends on current_account for FKs
+# 3. financial_accounting (ledger postings, booking logs) - independent schema
 local_resource(
   'migrate-current-account',
   cmd='atlas migrate apply --env local --config file://atlas.current_account.hcl --url "{}"'.format(database_url),
@@ -827,6 +826,15 @@ local_resource(
   'migrate-position-keeping',
   cmd='atlas migrate apply --env local --config file://atlas.position_keeping.hcl --url "{}"'.format(database_url),
   resource_deps=['migrate-current-account'],  # Depends on current_account being migrated first
+  labels=['database'],
+  auto_init=True,
+  trigger_mode=TRIGGER_MODE_MANUAL,
+)
+
+local_resource(
+  'migrate-financial-accounting',
+  cmd='atlas migrate apply --env local --config file://atlas.financial_accounting.hcl --url "{}"'.format(database_url),
+  resource_deps=['init-database'],  # Independent schema, only needs database to exist
   labels=['database'],
   auto_init=True,
   trigger_mode=TRIGGER_MODE_MANUAL,

--- a/atlas.financial_accounting.hcl
+++ b/atlas.financial_accounting.hcl
@@ -1,0 +1,77 @@
+// Atlas configuration for Financial Accounting schema
+// BIAN Service Domain: Financial Accounting
+// Manages ledger postings and financial booking logs
+
+data "external_schema" "gorm" {
+  program = [
+    "go",
+    "run",
+    "-mod=mod",
+    "./cmd/atlas-loader",
+    "--schema=financial_accounting"
+  ]
+}
+
+env "local" {
+  // Schema-specific migration directory
+  migration {
+    dir = "file://migrations/financial_accounting"
+  }
+
+  // Dev database
+  dev = "docker://postgres/16/dev"
+
+  // Source schema from GORM models via external loader
+  src = data.external_schema.gorm.url
+
+  // Schema configuration
+  schemas = ["financial_accounting"]
+
+  // Lint configuration to catch dangerous changes
+  lint {
+    destructive {
+      error = true
+    }
+    data_depend {
+      error = true
+    }
+    incompatible {
+      error = true
+    }
+  }
+}
+
+env "ci" {
+  migration {
+    dir = "file://migrations/financial_accounting"
+  }
+
+  dev = "docker://postgres/16/dev"
+
+  src = data.external_schema.gorm.url
+
+  schemas = ["financial_accounting"]
+
+  lint {
+    destructive {
+      error = true
+    }
+    data_depend {
+      error = true
+    }
+    incompatible {
+      error = true
+    }
+  }
+}
+
+env "production" {
+  // Production environment - apply only, never diff
+  url = getenv("PROD_DATABASE_URL")
+
+  migration {
+    dir = "file://migrations/financial_accounting"
+  }
+
+  schemas = ["financial_accounting"]
+}

--- a/cmd/atlas-loader/main.go
+++ b/cmd/atlas-loader/main.go
@@ -9,16 +9,18 @@ import (
 
 	"ariga.io/atlas-provider-gorm/gormschema"
 	"github.com/meridianhub/meridian/internal/domain/models"
+	fapersistence "github.com/meridianhub/meridian/internal/financial-accounting/adapters/persistence"
 )
 
 const (
-	schemaCurrentAccount  = "current_account"
-	schemaPositionKeeping = "position_keeping"
+	schemaCurrentAccount      = "current_account"
+	schemaPositionKeeping     = "position_keeping"
+	schemaFinancialAccounting = "financial_accounting"
 )
 
 func main() {
 	// Parse schema filter flag
-	schemaFilter := flag.String("schema", "", "Filter models by schema (current_account, position_keeping)")
+	schemaFilter := flag.String("schema", "", "Filter models by schema (current_account, position_keeping, financial_accounting)")
 	flag.Parse()
 
 	// Determine which models to load based on schema filter
@@ -39,6 +41,12 @@ func main() {
 			&models.TransactionLogEntry{},
 			&models.TransactionLineage{},
 			&models.AuditTrailEntry{},
+		}
+	case schemaFinancialAccounting:
+		// Financial accounting has its own schema for ledger and booking logs
+		modelList = []interface{}{
+			&fapersistence.FinancialBookingLogEntity{},
+			&fapersistence.LedgerPostingEntity{},
 		}
 	case "":
 		// No filter - load all models (for backward compatibility)
@@ -64,11 +72,14 @@ func main() {
 	// Prepend CREATE SCHEMA statements for all referenced schemas
 	output := stmts
 	if *schemaFilter != "" {
-		// For position_keeping, we need both schemas since transactions reference accounts
 		var schemaStmt string
-		if *schemaFilter == schemaPositionKeeping {
+		switch *schemaFilter {
+		case schemaPositionKeeping:
+			// For position_keeping, we need both schemas since transactions reference accounts
 			schemaStmt = "CREATE SCHEMA IF NOT EXISTS current_account;\nCREATE SCHEMA IF NOT EXISTS position_keeping;\n\n"
-		} else {
+		case schemaFinancialAccounting:
+			schemaStmt = "CREATE SCHEMA IF NOT EXISTS financial_accounting;\n\n"
+		default:
 			schemaStmt = fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s;\n\n", *schemaFilter)
 		}
 		output = schemaStmt + stmts

--- a/internal/financial-accounting/adapters/persistence/booking_log_entity.go
+++ b/internal/financial-accounting/adapters/persistence/booking_log_entity.go
@@ -36,7 +36,7 @@ type FinancialBookingLogEntity struct {
 	Version int `gorm:"not null"`
 }
 
-// TableName overrides the default table name
+// TableName overrides the default table name with schema prefix
 func (FinancialBookingLogEntity) TableName() string {
-	return "financial_booking_logs"
+	return "financial_accounting.financial_booking_logs"
 }

--- a/internal/financial-accounting/adapters/persistence/booking_log_entity.go
+++ b/internal/financial-accounting/adapters/persistence/booking_log_entity.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 // FinancialBookingLogEntity represents the database persistence model
@@ -26,11 +27,11 @@ type FinancialBookingLogEntity struct {
 	IdempotencyKey string `gorm:"uniqueIndex;not null;size:255"`
 
 	// Audit fields
-	CreatedAt time.Time  `gorm:"not null"`
-	UpdatedAt time.Time  `gorm:"not null"`
-	CreatedBy string     `gorm:"size:255"`
-	UpdatedBy string     `gorm:"size:255"`
-	DeletedAt *time.Time `gorm:"index"` // Soft delete
+	CreatedAt time.Time      `gorm:"not null"`
+	UpdatedAt time.Time      `gorm:"not null"`
+	CreatedBy string         `gorm:"size:255"`
+	UpdatedBy string         `gorm:"size:255"`
+	DeletedAt gorm.DeletedAt `gorm:"index"` // Soft delete
 
 	// Version for optimistic locking
 	Version int `gorm:"not null"`

--- a/internal/financial-accounting/adapters/persistence/ledger_posting_entity.go
+++ b/internal/financial-accounting/adapters/persistence/ledger_posting_entity.go
@@ -35,7 +35,7 @@ type LedgerPostingEntity struct {
 	DeletedAt *time.Time `gorm:"index"` // Soft delete
 }
 
-// TableName overrides the default table name
+// TableName overrides the default table name with schema prefix
 func (LedgerPostingEntity) TableName() string {
-	return "ledger_postings"
+	return "financial_accounting.ledger_postings"
 }

--- a/internal/financial-accounting/adapters/persistence/ledger_posting_entity.go
+++ b/internal/financial-accounting/adapters/persistence/ledger_posting_entity.go
@@ -13,7 +13,7 @@ type LedgerPostingEntity struct {
 	ID uuid.UUID `gorm:"type:uuid;primaryKey"`
 
 	// Foreign key to booking log
-	FinancialBookingLogID uuid.UUID `gorm:"type:uuid;not null;index:idx_booking_log"`
+	FinancialBookingLogID uuid.UUID `gorm:"type:uuid;not null;index:idx_booking_log;constraint:OnDelete:RESTRICT"`
 
 	// Business fields
 	PostingDirection string    `gorm:"not null;size:10"`

--- a/internal/financial-accounting/adapters/persistence/ledger_posting_entity.go
+++ b/internal/financial-accounting/adapters/persistence/ledger_posting_entity.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 // LedgerPostingEntity represents the database persistence model for ledger postings
@@ -28,11 +29,11 @@ type LedgerPostingEntity struct {
 	CorrelationID string `gorm:"size:255;index"` // Links back to originating event
 
 	// Audit fields
-	CreatedAt time.Time  `gorm:"not null"`
-	UpdatedAt time.Time  `gorm:"not null"`
-	CreatedBy string     `gorm:"size:255"`
-	UpdatedBy string     `gorm:"size:255"`
-	DeletedAt *time.Time `gorm:"index"` // Soft delete
+	CreatedAt time.Time      `gorm:"not null"`
+	UpdatedAt time.Time      `gorm:"not null"`
+	CreatedBy string         `gorm:"size:255"`
+	UpdatedBy string         `gorm:"size:255"`
+	DeletedAt gorm.DeletedAt `gorm:"index"` // Soft delete
 }
 
 // TableName overrides the default table name with schema prefix

--- a/internal/financial-accounting/adapters/persistence/ledger_posting_entity.go
+++ b/internal/financial-accounting/adapters/persistence/ledger_posting_entity.go
@@ -13,7 +13,7 @@ type LedgerPostingEntity struct {
 	ID uuid.UUID `gorm:"type:uuid;primaryKey"`
 
 	// Foreign key to booking log
-	FinancialBookingLogID uuid.UUID `gorm:"type:uuid;not null;index:idx_booking_log;constraint:OnDelete:RESTRICT"`
+	FinancialBookingLogID uuid.UUID `gorm:"type:uuid;not null;index:idx_financial_accounting_ledger_postings_booking_log_id;constraint:OnDelete:RESTRICT"`
 
 	// Business fields
 	PostingDirection string    `gorm:"not null;size:10"`

--- a/internal/financial-accounting/adapters/persistence/repository_test.go
+++ b/internal/financial-accounting/adapters/persistence/repository_test.go
@@ -1,0 +1,456 @@
+package persistence
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/internal/financial-accounting/domain"
+	"github.com/meridianhub/meridian/internal/platform/testdb"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) (*gorm.DB, func()) {
+	t.Helper()
+	return testdb.SetupPostgres(t, []interface{}{
+		&FinancialBookingLogEntity{},
+		&LedgerPostingEntity{},
+	})
+}
+
+func TestSavePosting_Success(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewLedgerRepository(db)
+	ctx := context.Background()
+
+	// Create a test booking log first (for FK constraint)
+	bookingLogID := uuid.New()
+	bookingLog := &FinancialBookingLogEntity{
+		ID:                      bookingLogID,
+		FinancialAccountType:    "DEBIT",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "ACTIVE",
+		IdempotencyKey:          "test-key-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog).Error)
+
+	// Create posting
+	money, err := domain.NewMoney(decimal.NewFromFloat(100.50), "GBP")
+	require.NoError(t, err)
+
+	posting := &domain.LedgerPosting{
+		ID:                    uuid.New(),
+		FinancialBookingLogID: bookingLogID,
+		Direction:             domain.PostingDirectionDebit,
+		Amount:                money,
+		AccountID:             "ACC-001",
+		ValueDate:             time.Now(),
+		PostingResult:         "SUCCESS",
+		Status:                domain.TransactionStatusPosted,
+		CorrelationID:         "CORR-001",
+		CreatedAt:             time.Now(),
+	}
+
+	// Save posting
+	err = repo.SavePosting(ctx, posting)
+	assert.NoError(t, err)
+
+	// Verify posting was saved
+	retrieved, err := repo.GetPosting(ctx, posting.ID)
+	require.NoError(t, err)
+	assert.Equal(t, posting.ID, retrieved.ID)
+	assert.Equal(t, posting.AccountID, retrieved.AccountID)
+	assert.Equal(t, int64(10050), retrieved.Amount.Amount().Mul(decimal.NewFromInt(100)).IntPart())
+}
+
+func TestSavePostingsInTransaction_Success(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewLedgerRepository(db)
+	ctx := context.Background()
+
+	// Create booking log
+	bookingLogID := uuid.New()
+	bookingLog := &FinancialBookingLogEntity{
+		ID:                      bookingLogID,
+		FinancialAccountType:    "DEBIT",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "ACTIVE",
+		IdempotencyKey:          "test-key-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog).Error)
+
+	// Create two postings (debit and credit for double-entry)
+	money, _ := domain.NewMoney(decimal.NewFromInt(100), "GBP")
+
+	postings := []*domain.LedgerPosting{
+		{
+			ID:                    uuid.New(),
+			FinancialBookingLogID: bookingLogID,
+			Direction:             domain.PostingDirectionDebit,
+			Amount:                money,
+			AccountID:             "ACC-001",
+			ValueDate:             time.Now(),
+			Status:                domain.TransactionStatusPosted,
+			CorrelationID:         "CORR-001",
+			CreatedAt:             time.Now(),
+		},
+		{
+			ID:                    uuid.New(),
+			FinancialBookingLogID: bookingLogID,
+			Direction:             domain.PostingDirectionCredit,
+			Amount:                money,
+			AccountID:             "ACC-002",
+			ValueDate:             time.Now(),
+			Status:                domain.TransactionStatusPosted,
+			CorrelationID:         "CORR-001",
+			CreatedAt:             time.Now(),
+		},
+	}
+
+	// Save both postings in transaction
+	err := repo.SavePostingsInTransaction(ctx, postings)
+	assert.NoError(t, err)
+
+	// Verify both postings were saved
+	retrieved, err := repo.GetPostingsByBookingLogID(ctx, bookingLogID)
+	require.NoError(t, err)
+	assert.Len(t, retrieved, 2)
+}
+
+func TestSavePostingsInTransaction_RollbackOnError(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewLedgerRepository(db)
+	ctx := context.Background()
+
+	bookingLogID := uuid.New()
+
+	// Create posting with invalid fractional cents (should fail)
+	moneyWithFraction, _ := domain.NewMoney(decimal.NewFromFloat(100.123), "GBP")
+
+	postings := []*domain.LedgerPosting{
+		{
+			ID:                    uuid.New(),
+			FinancialBookingLogID: bookingLogID,
+			Direction:             domain.PostingDirectionDebit,
+			Amount:                moneyWithFraction,
+			AccountID:             "ACC-001",
+			ValueDate:             time.Now(),
+			Status:                domain.TransactionStatusPosted,
+			CreatedAt:             time.Now(),
+		},
+	}
+
+	// Transaction should fail due to fractional cents
+	err := repo.SavePostingsInTransaction(ctx, postings)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrFractionalCents)
+
+	// Verify no postings were saved (rollback)
+	var count int64
+	db.Model(&LedgerPostingEntity{}).Count(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestGetPosting_NotFound(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewLedgerRepository(db)
+	ctx := context.Background()
+
+	_, err := repo.GetPosting(ctx, uuid.New())
+	assert.ErrorIs(t, err, ErrPostingNotFound)
+}
+
+func TestGetPostingsByBookingLogID_OrderedByCreatedAt(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewLedgerRepository(db)
+	ctx := context.Background()
+
+	// Create booking log
+	bookingLogID := uuid.New()
+	bookingLog := &FinancialBookingLogEntity{
+		ID:                      bookingLogID,
+		FinancialAccountType:    "DEBIT",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "ACTIVE",
+		IdempotencyKey:          "test-key-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog).Error)
+
+	// Create postings with different timestamps
+	money, _ := domain.NewMoney(decimal.NewFromInt(100), "GBP")
+	now := time.Now()
+
+	posting1 := &domain.LedgerPosting{
+		ID:                    uuid.New(),
+		FinancialBookingLogID: bookingLogID,
+		Direction:             domain.PostingDirectionDebit,
+		Amount:                money,
+		AccountID:             "ACC-001",
+		ValueDate:             now,
+		Status:                domain.TransactionStatusPosted,
+		CreatedAt:             now,
+	}
+
+	posting2 := &domain.LedgerPosting{
+		ID:                    uuid.New(),
+		FinancialBookingLogID: bookingLogID,
+		Direction:             domain.PostingDirectionCredit,
+		Amount:                money,
+		AccountID:             "ACC-002",
+		ValueDate:             now,
+		Status:                domain.TransactionStatusPosted,
+		CreatedAt:             now.Add(time.Second),
+	}
+
+	require.NoError(t, repo.SavePosting(ctx, posting1))
+	time.Sleep(10 * time.Millisecond) // Ensure different timestamps
+	require.NoError(t, repo.SavePosting(ctx, posting2))
+
+	// Retrieve postings - should be ordered by created_at
+	postings, err := repo.GetPostingsByBookingLogID(ctx, bookingLogID)
+	require.NoError(t, err)
+	require.Len(t, postings, 2)
+
+	// Verify order (first saved should be first in list)
+	assert.Equal(t, posting1.ID, postings[0].ID)
+	assert.Equal(t, posting2.ID, postings[1].ID)
+}
+
+// TestForeignKeyConstraint_ViolationPrevented tests that FK constraint prevents orphan postings
+func TestForeignKeyConstraint_ViolationPrevented(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Try to create a posting without corresponding booking log (FK violation)
+	money, _ := domain.NewMoney(decimal.NewFromInt(100), "GBP")
+	posting := &domain.LedgerPosting{
+		ID:                    uuid.New(),
+		FinancialBookingLogID: uuid.New(), // Non-existent booking log ID
+		Direction:             domain.PostingDirectionDebit,
+		Amount:                money,
+		AccountID:             "ACC-001",
+		ValueDate:             time.Now(),
+		Status:                domain.TransactionStatusPosted,
+		CreatedAt:             time.Now(),
+	}
+
+	repo := NewLedgerRepository(db)
+	err := repo.SavePosting(ctx, posting)
+
+	// Should fail due to FK constraint violation
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "foreign key")
+}
+
+// TestIdempotencyKeyUniqueness verifies that duplicate idempotency keys are rejected
+func TestIdempotencyKeyUniqueness(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	idempotencyKey := "unique-key-" + uuid.New().String()
+
+	// Create first booking log with idempotency key
+	bookingLog1 := &FinancialBookingLogEntity{
+		ID:                      uuid.New(),
+		FinancialAccountType:    "DEBIT",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "ACTIVE",
+		IdempotencyKey:          idempotencyKey,
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog1).Error)
+
+	// Try to create second booking log with same idempotency key
+	bookingLog2 := &FinancialBookingLogEntity{
+		ID:                      uuid.New(),
+		FinancialAccountType:    "CREDIT",
+		ProductServiceReference: "PROD-002",
+		BusinessUnitReference:   "BU-002",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "USD",
+		Status:                  "ACTIVE",
+		IdempotencyKey:          idempotencyKey, // Duplicate!
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+
+	err := db.Create(bookingLog2).Error
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate key")
+}
+
+// TestSoftDelete verifies soft delete functionality
+func TestSoftDelete(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create booking log
+	bookingLogID := uuid.New()
+	bookingLog := &FinancialBookingLogEntity{
+		ID:                      bookingLogID,
+		FinancialAccountType:    "DEBIT",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "ACTIVE",
+		IdempotencyKey:          "test-key-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog).Error)
+
+	// Create posting
+	money, _ := domain.NewMoney(decimal.NewFromInt(100), "GBP")
+	posting := &domain.LedgerPosting{
+		ID:                    uuid.New(),
+		FinancialBookingLogID: bookingLogID,
+		Direction:             domain.PostingDirectionDebit,
+		Amount:                money,
+		AccountID:             "ACC-001",
+		ValueDate:             time.Now(),
+		Status:                domain.TransactionStatusPosted,
+		CreatedAt:             time.Now(),
+	}
+
+	repo := NewLedgerRepository(db)
+	require.NoError(t, repo.SavePosting(ctx, posting))
+
+	// Soft delete the posting
+	now := time.Now()
+	err := db.Model(&LedgerPostingEntity{}).
+		Where("id = ?", posting.ID).
+		Update("deleted_at", now).Error
+	require.NoError(t, err)
+
+	// Verify posting is hidden from normal queries (GORM auto-filters deleted_at IS NULL)
+	_, err = repo.GetPosting(ctx, posting.ID)
+	assert.ErrorIs(t, err, ErrPostingNotFound)
+
+	// Verify posting still exists in database with Unscoped query
+	var entity LedgerPostingEntity
+	err = db.Unscoped().First(&entity, "id = ?", posting.ID).Error
+	require.NoError(t, err)
+	assert.NotNil(t, entity.DeletedAt)
+}
+
+// TestSchemaIsolation verifies that financial_accounting schema is isolated
+func TestSchemaIsolation(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Verify tables exist in financial_accounting schema
+	var tableCount int64
+	err := db.Raw(`
+		SELECT COUNT(*)
+		FROM information_schema.tables
+		WHERE table_schema = 'financial_accounting'
+		AND table_name IN ('financial_booking_logs', 'ledger_postings')
+	`).Scan(&tableCount).Error
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), tableCount, "Both tables should exist in financial_accounting schema")
+
+	// Verify indexes exist with correct naming convention
+	var indexCount int64
+	err = db.Raw(`
+		SELECT COUNT(*)
+		FROM pg_indexes
+		WHERE schemaname = 'financial_accounting'
+		AND tablename = 'ledger_postings'
+		AND indexname LIKE 'idx_financial_accounting_ledger_postings_%'
+	`).Scan(&indexCount).Error
+
+	require.NoError(t, err)
+	assert.Greater(t, indexCount, int64(0), "Indexes should follow naming convention")
+}
+
+// TestForeignKeyOnDeleteRestrict verifies FK constraint prevents cascading deletes
+func TestForeignKeyOnDeleteRestrict(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create booking log and posting
+	bookingLogID := uuid.New()
+	bookingLog := &FinancialBookingLogEntity{
+		ID:                      bookingLogID,
+		FinancialAccountType:    "DEBIT",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "ACTIVE",
+		IdempotencyKey:          "test-key-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog).Error)
+
+	money, _ := domain.NewMoney(decimal.NewFromInt(100), "GBP")
+	posting := &domain.LedgerPosting{
+		ID:                    uuid.New(),
+		FinancialBookingLogID: bookingLogID,
+		Direction:             domain.PostingDirectionDebit,
+		Amount:                money,
+		AccountID:             "ACC-001",
+		ValueDate:             time.Now(),
+		Status:                domain.TransactionStatusPosted,
+		CreatedAt:             time.Now(),
+	}
+
+	repo := NewLedgerRepository(db)
+	require.NoError(t, repo.SavePosting(ctx, posting))
+
+	// Try to delete booking log while posting still references it
+	err := db.Delete(&FinancialBookingLogEntity{}, "id = ?", bookingLogID).Error
+
+	// Should fail due to ON DELETE RESTRICT
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "violates foreign key constraint")
+}

--- a/internal/financial-accounting/adapters/persistence/repository_test.go
+++ b/internal/financial-accounting/adapters/persistence/repository_test.go
@@ -16,10 +16,25 @@ import (
 
 func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 	t.Helper()
-	return testdb.SetupPostgres(t, []interface{}{
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{
 		&FinancialBookingLogEntity{},
 		&LedgerPostingEntity{},
 	})
+
+	// Manually create FK constraint since GORM AutoMigrate doesn't create them
+	// This matches the Atlas migration FK constraint
+	err := db.Exec(`
+		ALTER TABLE financial_accounting.ledger_postings
+		ADD CONSTRAINT fk_ledger_postings_booking_log
+		FOREIGN KEY (financial_booking_log_id)
+		REFERENCES financial_accounting.financial_booking_logs(id)
+		ON DELETE RESTRICT
+	`).Error
+	if err != nil {
+		t.Fatalf("Failed to create FK constraint: %v", err)
+	}
+
+	return db, cleanup
 }
 
 func TestSavePosting_Success(t *testing.T) {
@@ -447,8 +462,9 @@ func TestForeignKeyOnDeleteRestrict(t *testing.T) {
 	repo := NewLedgerRepository(db)
 	require.NoError(t, repo.SavePosting(ctx, posting))
 
-	// Try to delete booking log while posting still references it
-	err := db.Delete(&FinancialBookingLogEntity{}, "id = ?", bookingLogID).Error
+	// Try to hard delete booking log while posting still references it
+	// Use Unscoped to bypass soft delete and trigger FK constraint
+	err := db.Unscoped().Delete(&FinancialBookingLogEntity{}, "id = ?", bookingLogID).Error
 
 	// Should fail due to ON DELETE RESTRICT
 	assert.Error(t, err)

--- a/internal/financial-accounting/adapters/persistence/repository_test.go
+++ b/internal/financial-accounting/adapters/persistence/repository_test.go
@@ -2,10 +2,12 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/meridianhub/meridian/internal/financial-accounting/domain"
 	"github.com/meridianhub/meridian/internal/platform/testdb"
 	"github.com/shopspring/decimal"
@@ -286,9 +288,11 @@ func TestForeignKeyConstraint_ViolationPrevented(t *testing.T) {
 	repo := NewLedgerRepository(db)
 	err := repo.SavePosting(ctx, posting)
 
-	// Should fail due to FK constraint violation
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "foreign key")
+	// Should fail due to FK constraint violation (SQLSTATE 23503)
+	require.Error(t, err)
+	var pgErr *pgconn.PgError
+	require.True(t, errors.As(err, &pgErr), "expected Postgres error, got %T: %v", err, err)
+	assert.Equal(t, "23503", pgErr.Code, "expected foreign key violation error code")
 }
 
 // TestIdempotencyKeyUniqueness verifies that duplicate idempotency keys are rejected
@@ -330,8 +334,10 @@ func TestIdempotencyKeyUniqueness(t *testing.T) {
 	}
 
 	err := db.Create(bookingLog2).Error
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "duplicate key")
+	require.Error(t, err)
+	var pgErr *pgconn.PgError
+	require.True(t, errors.As(err, &pgErr), "expected Postgres error, got %T: %v", err, err)
+	assert.Equal(t, "23505", pgErr.Code, "expected unique constraint violation error code")
 }
 
 // TestSoftDelete verifies soft delete functionality
@@ -389,7 +395,8 @@ func TestSoftDelete(t *testing.T) {
 	var entity LedgerPostingEntity
 	err = db.Unscoped().First(&entity, "id = ?", posting.ID).Error
 	require.NoError(t, err)
-	assert.NotNil(t, entity.DeletedAt)
+	assert.True(t, entity.DeletedAt.Valid, "DeletedAt should be marked valid after soft delete")
+	assert.False(t, entity.DeletedAt.Time.IsZero(), "DeletedAt timestamp should be set after soft delete")
 }
 
 // TestSchemaIsolation verifies that financial_accounting schema is isolated
@@ -466,7 +473,9 @@ func TestForeignKeyOnDeleteRestrict(t *testing.T) {
 	// Use Unscoped to bypass soft delete and trigger FK constraint
 	err := db.Unscoped().Delete(&FinancialBookingLogEntity{}, "id = ?", bookingLogID).Error
 
-	// Should fail due to ON DELETE RESTRICT
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "violates foreign key constraint")
+	// Should fail due to ON DELETE RESTRICT (SQLSTATE 23503)
+	require.Error(t, err)
+	var pgErr *pgconn.PgError
+	require.True(t, errors.As(err, &pgErr), "expected Postgres error, got %T: %v", err, err)
+	assert.Equal(t, "23503", pgErr.Code, "expected foreign key violation error code")
 }

--- a/internal/platform/testdb/postgres.go
+++ b/internal/platform/testdb/postgres.go
@@ -5,6 +5,7 @@ package testdb
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -39,15 +40,10 @@ func extractSchemasFromModels(models []interface{}) map[string]bool {
 		// Check if model has TableName method
 		if tabler, ok := model.(interface{ TableName() string }); ok {
 			tableName := tabler.TableName()
-			// Extract schema from "schema.table" format
-			if len(tableName) > 0 {
-				for i := 0; i < len(tableName); i++ {
-					if tableName[i] == '.' {
-						schemaName := tableName[:i]
-						schemas[schemaName] = true
-						break
-					}
-				}
+			// Extract schema from "schema.table" format using strings.Index
+			if idx := strings.Index(tableName, "."); idx > 0 {
+				schemaName := tableName[:idx]
+				schemas[schemaName] = true
 			}
 		}
 	}

--- a/internal/platform/testdb/postgres.go
+++ b/internal/platform/testdb/postgres.go
@@ -55,6 +55,17 @@ func extractSchemasFromModels(models []interface{}) map[string]bool {
 func createSchemas(t *testing.T, db *gorm.DB, schemas map[string]bool) {
 	t.Helper()
 	for schema := range schemas {
+		// Check for empty schema name
+		if len(schema) == 0 {
+			t.Fatalf("Invalid schema name: empty string")
+		}
+
+		// Validate first character: must be letter or underscore
+		first := schema[0]
+		if (first < 'a' || first > 'z') && (first < 'A' || first > 'Z') && first != '_' {
+			t.Fatalf("Invalid schema name %q: must start with a letter or underscore", schema)
+		}
+
 		// Validate schema name: only alphanumeric and underscore allowed
 		// This prevents SQL injection even though schema names come from TableName()
 		for i := 0; i < len(schema); i++ {

--- a/internal/platform/testdb/postgres.go
+++ b/internal/platform/testdb/postgres.go
@@ -30,6 +30,39 @@ func WithLogLevel(level logger.LogLevel) PostgresOption {
 	}
 }
 
+// extractSchemasFromModels extracts unique schema names from models with TableName() methods.
+// It parses "schema.table" format and returns a set of schema names.
+func extractSchemasFromModels(models []interface{}) map[string]bool {
+	schemas := make(map[string]bool)
+	for _, model := range models {
+		// Check if model has TableName method
+		if tabler, ok := model.(interface{ TableName() string }); ok {
+			tableName := tabler.TableName()
+			// Extract schema from "schema.table" format
+			if len(tableName) > 0 {
+				for i := 0; i < len(tableName); i++ {
+					if tableName[i] == '.' {
+						schemaName := tableName[:i]
+						schemas[schemaName] = true
+						break
+					}
+				}
+			}
+		}
+	}
+	return schemas
+}
+
+// createSchemas creates database schemas if they don't exist.
+func createSchemas(t *testing.T, db *gorm.DB, schemas map[string]bool) {
+	t.Helper()
+	for schema := range schemas {
+		if err := db.Exec("CREATE SCHEMA IF NOT EXISTS " + schema).Error; err != nil {
+			t.Fatalf("Failed to create schema %s: %v", schema, err)
+		}
+	}
+}
+
 // SetupPostgres creates a PostgreSQL testcontainer for integration testing.
 // It returns a configured GORM database connection and a cleanup function.
 //
@@ -92,8 +125,13 @@ func SetupPostgres(t *testing.T, models []interface{}, opts ...PostgresOption) (
 		t.Fatalf("Failed to connect to database: %v", err)
 	}
 
-	// Run migrations for provided models
+	// Create schemas and run migrations for provided models
 	if len(models) > 0 {
+		// Extract and create schemas from model table names
+		schemas := extractSchemasFromModels(models)
+		createSchemas(t, db, schemas)
+
+		// Run migrations for provided models
 		if err := db.AutoMigrate(models...); err != nil {
 			t.Fatalf("Failed to migrate database: %v", err)
 		}

--- a/internal/platform/testdb/postgres.go
+++ b/internal/platform/testdb/postgres.go
@@ -4,6 +4,7 @@ package testdb
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -54,10 +55,23 @@ func extractSchemasFromModels(models []interface{}) map[string]bool {
 }
 
 // createSchemas creates database schemas if they don't exist.
+// Schema names are validated against a strict pattern to prevent SQL injection.
 func createSchemas(t *testing.T, db *gorm.DB, schemas map[string]bool) {
 	t.Helper()
 	for schema := range schemas {
-		if err := db.Exec("CREATE SCHEMA IF NOT EXISTS " + schema).Error; err != nil {
+		// Validate schema name: only alphanumeric and underscore allowed
+		// This prevents SQL injection even though schema names come from TableName()
+		for i := 0; i < len(schema); i++ {
+			c := schema[i]
+			if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') && (c < '0' || c > '9') && c != '_' {
+				t.Fatalf("Invalid schema name %q: must contain only letters, digits, and underscores", schema)
+			}
+		}
+
+		// Use parameterized query with proper identifier quoting
+		// PostgreSQL uses double quotes for identifiers
+		sql := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS \"%s\"", schema)
+		if err := db.Exec(sql).Error; err != nil {
 			t.Fatalf("Failed to create schema %s: %v", schema, err)
 		}
 	}

--- a/migrations/financial_accounting/20251117132848_initial_schema.sql
+++ b/migrations/financial_accounting/20251117132848_initial_schema.sql
@@ -1,7 +1,5 @@
--- Drop schema named "public"
-DROP SCHEMA "public" CASCADE;
 -- Add new schema named "financial_accounting"
-CREATE SCHEMA "financial_accounting";
+CREATE SCHEMA IF NOT EXISTS "financial_accounting";
 -- Create "financial_booking_logs" table
 CREATE TABLE "financial_accounting"."financial_booking_logs" (
   "id" uuid NOT NULL,
@@ -67,3 +65,9 @@ CREATE INDEX "idx_financial_accounting_ledger_postings_deleted_at" ON "financial
 CREATE INDEX "idx_financial_accounting_ledger_postings_status" ON "financial_accounting"."ledger_postings" ("status");
 -- Create index "idx_financial_accounting_ledger_postings_value_date" to table: "ledger_postings"
 CREATE INDEX "idx_financial_accounting_ledger_postings_value_date" ON "financial_accounting"."ledger_postings" ("value_date");
+-- Add foreign key constraint from ledger_postings to financial_booking_logs
+ALTER TABLE "financial_accounting"."ledger_postings"
+  ADD CONSTRAINT "fk_ledger_postings_booking_log"
+  FOREIGN KEY ("financial_booking_log_id")
+  REFERENCES "financial_accounting"."financial_booking_logs" ("id")
+  ON DELETE RESTRICT;

--- a/migrations/financial_accounting/20251117132848_initial_schema.sql
+++ b/migrations/financial_accounting/20251117132848_initial_schema.sql
@@ -51,8 +51,8 @@ CREATE TABLE "financial_accounting"."ledger_postings" (
   "deleted_at" timestamptz NULL,
   PRIMARY KEY ("id")
 );
--- Create index "idx_booking_log" to table: "ledger_postings"
-CREATE INDEX "idx_booking_log" ON "financial_accounting"."ledger_postings" ("financial_booking_log_id");
+-- Create index "idx_financial_accounting_ledger_postings_booking_log_id" to table: "ledger_postings"
+CREATE INDEX "idx_financial_accounting_ledger_postings_booking_log_id" ON "financial_accounting"."ledger_postings" ("financial_booking_log_id");
 -- Create index "idx_financial_accounting_ledger_postings_account_id" to table: "ledger_postings"
 CREATE INDEX "idx_financial_accounting_ledger_postings_account_id" ON "financial_accounting"."ledger_postings" ("account_id");
 -- Create index "idx_financial_accounting_ledger_postings_correlation_id" to table: "ledger_postings"

--- a/migrations/financial_accounting/20251117132848_initial_schema.sql
+++ b/migrations/financial_accounting/20251117132848_initial_schema.sql
@@ -1,0 +1,69 @@
+-- Drop schema named "public"
+DROP SCHEMA "public" CASCADE;
+-- Add new schema named "financial_accounting"
+CREATE SCHEMA "financial_accounting";
+-- Create "financial_booking_logs" table
+CREATE TABLE "financial_accounting"."financial_booking_logs" (
+  "id" uuid NOT NULL,
+  "financial_account_type" character varying(50) NOT NULL,
+  "product_service_reference" character varying(255) NOT NULL,
+  "business_unit_reference" character varying(255) NOT NULL,
+  "chart_of_accounts_rules" text NOT NULL,
+  "base_currency" character varying(3) NOT NULL,
+  "status" character varying(50) NOT NULL,
+  "idempotency_key" character varying(255) NOT NULL,
+  "created_at" timestamptz NOT NULL,
+  "updated_at" timestamptz NOT NULL,
+  "created_by" character varying(255) NULL,
+  "updated_by" character varying(255) NULL,
+  "deleted_at" timestamptz NULL,
+  "version" bigint NOT NULL,
+  PRIMARY KEY ("id")
+);
+-- Create index "idx_financial_accounting_financial_booking_logs_base_currency" to table: "financial_booking_logs"
+CREATE INDEX "idx_financial_accounting_financial_booking_logs_base_currency" ON "financial_accounting"."financial_booking_logs" ("base_currency");
+-- Create index "idx_financial_accounting_financial_booking_logs_businescafac217" to table: "financial_booking_logs"
+CREATE INDEX "idx_financial_accounting_financial_booking_logs_businescafac217" ON "financial_accounting"."financial_booking_logs" ("business_unit_reference");
+-- Create index "idx_financial_accounting_financial_booking_logs_deleted_at" to table: "financial_booking_logs"
+CREATE INDEX "idx_financial_accounting_financial_booking_logs_deleted_at" ON "financial_accounting"."financial_booking_logs" ("deleted_at");
+-- Create index "idx_financial_accounting_financial_booking_logs_financi935e59da" to table: "financial_booking_logs"
+CREATE INDEX "idx_financial_accounting_financial_booking_logs_financi935e59da" ON "financial_accounting"."financial_booking_logs" ("financial_account_type");
+-- Create index "idx_financial_accounting_financial_booking_logs_idempotency_key" to table: "financial_booking_logs"
+CREATE UNIQUE INDEX "idx_financial_accounting_financial_booking_logs_idempotency_key" ON "financial_accounting"."financial_booking_logs" ("idempotency_key");
+-- Create index "idx_financial_accounting_financial_booking_logs_product8d9c65fb" to table: "financial_booking_logs"
+CREATE INDEX "idx_financial_accounting_financial_booking_logs_product8d9c65fb" ON "financial_accounting"."financial_booking_logs" ("product_service_reference");
+-- Create index "idx_financial_accounting_financial_booking_logs_status" to table: "financial_booking_logs"
+CREATE INDEX "idx_financial_accounting_financial_booking_logs_status" ON "financial_accounting"."financial_booking_logs" ("status");
+-- Create "ledger_postings" table
+CREATE TABLE "financial_accounting"."ledger_postings" (
+  "id" uuid NOT NULL,
+  "financial_booking_log_id" uuid NOT NULL,
+  "posting_direction" character varying(10) NOT NULL,
+  "amount_cents" bigint NOT NULL,
+  "currency" character varying(3) NOT NULL,
+  "account_id" character varying(255) NOT NULL,
+  "value_date" timestamptz NOT NULL,
+  "posting_result" character varying(1000) NULL,
+  "status" character varying(50) NOT NULL,
+  "correlation_id" character varying(255) NULL,
+  "created_at" timestamptz NOT NULL,
+  "updated_at" timestamptz NOT NULL,
+  "created_by" character varying(255) NULL,
+  "updated_by" character varying(255) NULL,
+  "deleted_at" timestamptz NULL,
+  PRIMARY KEY ("id")
+);
+-- Create index "idx_booking_log" to table: "ledger_postings"
+CREATE INDEX "idx_booking_log" ON "financial_accounting"."ledger_postings" ("financial_booking_log_id");
+-- Create index "idx_financial_accounting_ledger_postings_account_id" to table: "ledger_postings"
+CREATE INDEX "idx_financial_accounting_ledger_postings_account_id" ON "financial_accounting"."ledger_postings" ("account_id");
+-- Create index "idx_financial_accounting_ledger_postings_correlation_id" to table: "ledger_postings"
+CREATE INDEX "idx_financial_accounting_ledger_postings_correlation_id" ON "financial_accounting"."ledger_postings" ("correlation_id");
+-- Create index "idx_financial_accounting_ledger_postings_currency" to table: "ledger_postings"
+CREATE INDEX "idx_financial_accounting_ledger_postings_currency" ON "financial_accounting"."ledger_postings" ("currency");
+-- Create index "idx_financial_accounting_ledger_postings_deleted_at" to table: "ledger_postings"
+CREATE INDEX "idx_financial_accounting_ledger_postings_deleted_at" ON "financial_accounting"."ledger_postings" ("deleted_at");
+-- Create index "idx_financial_accounting_ledger_postings_status" to table: "ledger_postings"
+CREATE INDEX "idx_financial_accounting_ledger_postings_status" ON "financial_accounting"."ledger_postings" ("status");
+-- Create index "idx_financial_accounting_ledger_postings_value_date" to table: "ledger_postings"
+CREATE INDEX "idx_financial_accounting_ledger_postings_value_date" ON "financial_accounting"."ledger_postings" ("value_date");

--- a/migrations/financial_accounting/atlas.sum
+++ b/migrations/financial_accounting/atlas.sum
@@ -1,0 +1,2 @@
+h1:sQLeqw3yUfJi+nVfSW0ZIZ/LkKoNKahGcHoRNQMGWBc=
+20251117132848_initial_schema.sql h1:OvrqocEDVyWdfYA2C0wN4ogla8xE0hi36Ui4Z1cKngs=


### PR DESCRIPTION
## Summary

Completes the missing database migration infrastructure for the financial-accounting service. The service had GORM entities and repository implementation, but lacked Atlas configuration and migrations, causing incorrect Tiltfile dependencies.

**Changes:**
- Create `atlas.financial_accounting.hcl` configuration file
- Generate initial migration for `financial_booking_logs` and `ledger_postings` tables
- Add `financial_accounting` schema support to atlas-loader
- Add `migrate-financial-accounting` task to Tiltfile
- Fix financial-accounting service dependency (was incorrectly waiting for `migrate-current-account`)
- Add schema prefix to entity `TableName()` methods for proper schema placement

**Database Schema:**
- `financial_accounting.financial_booking_logs` - Financial booking log aggregate root with idempotency support
- `financial_accounting.ledger_postings` - Ledger posting entries with FK to booking logs

## Context

Task Master #7.1 identified that Task #6 ("Repository Interface and Database Schema") was marked complete but only created GORM entities, not the actual Atlas migration infrastructure. This PR fills that gap.

**Related Issue:** #4 - Financial Accounting Service Implementation

## Test Plan

- [x] All commits pass pre-commit hooks (gofumpt, golangci-lint)
- [ ] Run `tilt up` and verify:
  - `migrate-financial-accounting` task runs successfully
  - `financial-accounting` service starts after migration completes
  - Tables exist in `financial_accounting` schema
  - No dependency on `migrate-current-account`
- [ ] Verify migration with: `atlas migrate status --env local --config file://atlas.financial_accounting.hcl`
- [ ] Check database schema: `psql meridian -c "\dt financial_accounting.*"`

## Technical Details

**Atlas Loader Changes:**
- Added `schemaFinancialAccounting` constant
- Imported financial-accounting persistence package
- Added model loading case for financial_accounting schema
- Refactored schema creation logic to use switch statement (staticcheck)

**Entity Changes:**
- Updated `FinancialBookingLogEntity.TableName()` to include schema prefix
- Updated `LedgerPostingEntity.TableName()` to include schema prefix
- Ensures consistency with existing entities (e.g., `current_account.customers`)

**Tiltfile Changes:**
- Added `migrate-financial-accounting` local_resource (depends only on `init-database`)
- Fixed financial-accounting service dependency chain
- Updated migration documentation to reflect all three schemas

## Deployment Notes

- Safe to deploy - only adds new migration infrastructure
- Does not modify existing schemas or tables
- Financial-accounting service can now run migrations independently
- No breaking changes to current-account or position-keeping services