### PR TITLE
fix: Automatically install npm dependencies in install-tools.sh

### DIFF
--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -191,6 +191,21 @@ echo " Installation Complete"
 echo "═══════════════════════════════════════"
 echo ""
 
+# Install Node.js dependencies if package.json exists
+if [ -f "package.json" ] && command -v npm &> /dev/null; then
+    echo -e "${YELLOW}Installing Node.js dependencies...${NC}"
+    echo ""
+
+    if npm install; then
+        echo -e "${GREEN}✓${NC} Node.js dependencies installed successfully"
+        echo ""
+    else
+        echo -e "${RED}✗${NC} Failed to install Node.js dependencies"
+        echo "  You can try manually later: npm install"
+        echo ""
+    fi
+fi
+
 # Create Kind cluster if ctlptl and kind are installed and Docker is running
 if command -v ctlptl &> /dev/null && command -v kind &> /dev/null; then
     echo -e "${YELLOW}Setting up local Kubernetes cluster...${NC}"
@@ -224,9 +239,8 @@ fi
 echo "Next steps:"
 echo "  1. Verify installation: ./scripts/setup-check.sh"
 echo "  2. Clone the repository and run: go mod download"
-echo "  3. Install Node.js dependencies: npm install"
-echo "  4. Install git hooks: .githooks/install.sh"
-echo "  5. Start developing: tilt up"
+echo "  3. Install git hooks: .githooks/install.sh"
+echo "  4. Start developing: tilt up"
 echo ""
 echo -e "${BLUE}Tip:${NC} Your local cluster is ready! Just run ${BLUE}tilt up${NC} to start developing"
 echo ""


### PR DESCRIPTION
## Summary

- Fixes inconsistency where `install-tools.sh` installs node/npm but doesn't run `npm install`
- Prevents `setup-check.sh` from failing with missing `markdownlint-cli2` error
- Automates npm dependency installation for a smoother setup experience

## Problem

The current workflow has a gap:
1. `install-tools.sh` installs `node` and `npm` via Homebrew
2. Script lists "Install Node.js dependencies: npm install" in "Next steps"
3. User runs `setup-check.sh` before manually running `npm install`
4. Check fails: "⚠ markdownlint-cli2 not installed"

This creates confusion because the setup verification fails even after following the automated installer.

## Changes Made

**scripts/install-tools.sh:**
- Added automatic `npm install` after tool installation completes
- Only executes if `package.json` exists and npm is available
- Provides clear feedback: "Installing Node.js dependencies..."
- Handles errors gracefully with fallback instructions
- Removed redundant "Install Node.js dependencies" from Next Steps list (now step 4 instead of 5)

## Technical Details

The npm install logic:
- Runs after system tools are installed but before Kubernetes cluster setup
- Checks both file existence (`package.json`) and command availability (`npm`)
- Uses standard bash error handling with clear user messaging
- Non-blocking: Script continues even if npm install fails

## Testing

Verified that:
- Script syntax is valid (pre-commit hook passed)
- Logic only triggers when appropriate (package.json exists + npm available)
- Error handling provides clear guidance for manual recovery
- Next steps now match actual automation level

## Risk Assessment

**Risk Level:** Low

- Changes are additive and defensive (checks before acting)
- Existing functionality unchanged
- Failure doesn't block subsequent setup steps
- Clear error messages guide manual recovery if needed

**Compatibility:**
- Works for both first-time setup and re-running the script
- npm install is idempotent (safe to run multiple times)
- No impact on CI/CD pipelines

## Performance Considerations

- Adds ~10-30 seconds to install-tools.sh runtime (typical npm install duration)
- Eliminates need for separate manual npm install step
- Net improvement: Reduces total setup steps from 5 to 4

## Deployment Notes

- No deployment changes required
- Developers can run script immediately without migration steps
- Existing environments unaffected (npm dependencies may already be installed)