### PR TITLE
fix: Update OpenTelemetry semconv to v1.37.0 and add version validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GOMOD=$(GOCMD) mod
 GOGET=$(GOCMD) get
 GOFMT=$(GOCMD) fmt
 
-.PHONY: all help build test lint clean proto proto-v1 proto-v2 proto-lint proto-breaking docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all docs
+.PHONY: all help build test lint clean proto proto-v1 proto-v2 proto-lint proto-breaking docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt validate-semconv migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all docs
 
 # Default target
 all: help
@@ -42,7 +42,7 @@ help:
 	@echo "Available targets:"
 	@echo "  make build             - Compile all Go services"
 	@echo "  make test              - Run tests with coverage"
-	@echo "  make lint              - Run golangci-lint and validate Tiltfile"
+	@echo "  make lint              - Run golangci-lint, validate Tiltfile, and validate semconv versions"
 	@echo "  make validate-tilt     - Validate Tiltfile configuration"
 	@echo "  make fmt               - Format Go code"
 	@echo "  make clean             - Remove build artifacts"

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ coverage: test
 	@open $(COVERAGE_DIR)/coverage.html 2>/dev/null || xdg-open $(COVERAGE_DIR)/coverage.html 2>/dev/null || echo "Please open $(COVERAGE_DIR)/coverage.html manually"
 
 ## lint: Run golangci-lint and validate Tiltfile
-lint: validate-tilt
+lint: validate-tilt validate-semconv
 	@echo "Running golangci-lint..."
 	@which $(GOLANGCI_LINT) > /dev/null || (echo "golangci-lint not installed. Run 'make install'"; exit 1)
 	$(GOLANGCI_LINT) run --timeout 5m ./...
@@ -113,6 +113,10 @@ lint: validate-tilt
 ## validate-tilt: Validate Tiltfile configuration
 validate-tilt:
 	@./scripts/validate-tiltfile.sh Tiltfile
+
+## validate-semconv: Validate OpenTelemetry semantic convention versions are consistent
+validate-semconv:
+	@./scripts/validate-semconv-versions.sh
 
 ## fmt: Format Go code
 fmt:

--- a/Tiltfile
+++ b/Tiltfile
@@ -914,14 +914,18 @@ Tilt UI                    → http://localhost:10350
 Hot reload: Edit Go code and see changes in ~3 seconds
 
 Database Migrations:
-  • Migrations run automatically on startup (2 resources):
+  • Migrations run automatically on startup (3 resources):
     1. current_account (customers, accounts, current_account_audit)
-    2. position_keeping (transactions, position_keeping_audit)
+    2. financial_accounting (general_ledger, financial_accounting_audit)
+    3. position_keeping (transactions, position_keeping_audit)
+  • Parallel execution: current_account + financial_accounting run together after init-database
+  • Sequential dependency: position_keeping waits for current_account (Account FK)
   • Each service has its own audit schema for isolation
   • Phase 1: Empty audit tables created (current work)
   • Phase 2: GORM hooks for audit logging (future PR, see ADR-0009)
   • Manual triggers:
     - tilt trigger migrate-current-account
+    - tilt trigger migrate-financial-accounting
     - tilt trigger migrate-position-keeping
   • Check status:
     - make migrate-status-all (requires DATABASE_URL env var)

--- a/Tiltfile
+++ b/Tiltfile
@@ -809,10 +809,10 @@ local_resource(
 
 # Run database migrations on startup - uses Atlas to apply schema changes
 # Each service has its own business schema
-# Migrations are applied in order:
-# 1. current_account (customers, accounts)
-# 2. position_keeping (transactions) - depends on current_account for FKs
-# 3. financial_accounting (ledger postings, booking logs) - independent schema
+# Migrations execute in parallel where possible:
+# - Parallel: current_account + financial_accounting (both depend only on init-database)
+# - Sequential: position_keeping waits for current_account (requires Account FK reference)
+# This minimizes total migration time while respecting schema dependencies
 local_resource(
   'migrate-current-account',
   cmd='atlas migrate apply --env local --config file://atlas.current_account.hcl --url "{}"'.format(database_url),

--- a/go.sum
+++ b/go.sum
@@ -654,8 +654,6 @@ github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3 h1:2afWGsMzkIcN8Qm4mgP
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3/go.mod h1:dppbR7CwXD4pgtV9t3wD1812RaLDcBjtblcDF5f1vI0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 h1:UQUsRi8WTzhZntp5313l+CHIAT95ojUI2lpP/ExlZa4=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0/go.mod h1:Cz6ft6Dkn3Et6l2v2a9/RpN7epQ1GtDlO6lj8bEcOvw=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0 h1:sBEjpZlNHzK1voKq9695PJSX2o5NEXl7/OL3coiIY0c=
-github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0/go.mod h1:P4WPRUkOhJC13W//jWpyfJNDAIpvRbAUIYLX/4jtlE0=
 github.com/IBM/sarama v1.42.1 h1:wugyWa15TDEHh2kvq2gAy1IHLjEjuYOYgXz/ruC/OSQ=
 github.com/IBM/sarama v1.42.1/go.mod h1:Xxho9HkHd4K/MDUo/T/sOqwtX/17D33++E9Wib6hUdQ=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
@@ -1352,8 +1350,6 @@ go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/detectors/gcp v1.37.0 h1:B+WbN9RPsvobe6q4vP6KgM8/9plR/HNjgGBrfcOlweA=
 go.opentelemetry.io/contrib/detectors/gcp v1.37.0/go.mod h1:K5zQ3TT7p2ru9Qkzk0bKtCql0RGkPj9pRjpXgZJZ+rU=
-go.opentelemetry.io/contrib/detectors/gcp v1.38.0 h1:ZoYbqX7OaA/TAikspPl3ozPI6iY6LiIY9I8cUfm+pJs=
-go.opentelemetry.io/contrib/detectors/gcp v1.38.0/go.mod h1:SU+iU7nu5ud4oCb3LQOhIZ3nRLj6FNVrKgtflbaf2ts=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0 h1:rbRJ8BBoVMsQShESYZ0FkvcITu8X8QNwJogcLUmDNNw=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.62.0/go.mod h1:ru6KHrNtNHxM4nD/vd6QrLVWgKhxPYgblq4VAtNawTQ=
 go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace v0.46.1 h1:gbhw/u49SS3gkPWiYweQNJGm/uJN5GkI/FrosxSHT7A=

--- a/internal/platform/observability/grpc.go
+++ b/internal/platform/observability/grpc.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"

--- a/internal/platform/observability/helpers.go
+++ b/internal/platform/observability/helpers.go
@@ -152,8 +152,8 @@ func StartKafkaProducerSpan(ctx context.Context, tracer *Tracer, opts KafkaSpanO
 //	}
 func StartKafkaConsumerSpan(ctx context.Context, tracer *Tracer, opts KafkaSpanOptions) (context.Context, trace.Span) {
 	attrs := []attribute.KeyValue{
-		semconv.MessagingSystemKafka,
-		semconv.MessagingOperationTypeReceive,
+		semconv.MessagingSystemKey.String("kafka"),
+		semconv.MessagingOperationTypeKey.String("receive"),
 		semconv.MessagingDestinationNameKey.String(opts.Topic),
 	}
 

--- a/internal/platform/observability/helpers.go
+++ b/internal/platform/observability/helpers.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -42,7 +43,7 @@ type DatabaseSpanOptions struct {
 //	}
 func StartDatabaseSpan(ctx context.Context, tracer *Tracer, opts DatabaseSpanOptions) (context.Context, trace.Span) {
 	attrs := []attribute.KeyValue{
-		semconv.DBSystemKey.String(opts.System),
+		semconv.DBSystemNameKey.String(opts.System),
 		semconv.DBOperationNameKey.String(opts.Operation),
 	}
 
@@ -112,15 +113,14 @@ type KafkaSpanOptions struct {
 //	}
 func StartKafkaProducerSpan(ctx context.Context, tracer *Tracer, opts KafkaSpanOptions) (context.Context, trace.Span) {
 	attrs := []attribute.KeyValue{
-		semconv.MessagingSystemKafka,
-		semconv.MessagingOperationTypePublish,
+		semconv.MessagingSystemKey.String("kafka"),
+		semconv.MessagingOperationTypeKey.String("publish"),
 		semconv.MessagingDestinationNameKey.String(opts.Topic),
 	}
 
 	if opts.Partition >= 0 {
-		// Note: messaging.kafka.destination.partition is not yet standardized in OTel semantic conventions v1.27.0
-		// Using custom attribute until officially added to semconv
-		attrs = append(attrs, attribute.Int("messaging.kafka.destination.partition", int(opts.Partition)))
+		// Use standard messaging.destination.partition.id attribute (available in v1.37.0+)
+		attrs = append(attrs, semconv.MessagingDestinationPartitionIDKey.String(fmt.Sprintf("%d", opts.Partition)))
 	}
 
 	if opts.Key != "" {
@@ -158,9 +158,8 @@ func StartKafkaConsumerSpan(ctx context.Context, tracer *Tracer, opts KafkaSpanO
 	}
 
 	if opts.Partition >= 0 {
-		// Note: messaging.kafka.destination.partition is not yet standardized in OTel semantic conventions v1.27.0
-		// Using custom attribute until officially added to semconv
-		attrs = append(attrs, attribute.Int("messaging.kafka.destination.partition", int(opts.Partition)))
+		// Use standard messaging.destination.partition.id attribute (available in v1.37.0+)
+		attrs = append(attrs, semconv.MessagingDestinationPartitionIDKey.String(fmt.Sprintf("%d", opts.Partition)))
 	}
 
 	if opts.Offset >= 0 {

--- a/internal/platform/observability/tracing.go
+++ b/internal/platform/observability/tracing.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.27.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/credentials"
 )

--- a/scripts/validate-semconv-versions.sh
+++ b/scripts/validate-semconv-versions.sh
@@ -16,7 +16,7 @@ echo "Validating OpenTelemetry semantic convention versions..."
 # Find all semconv import versions in Go files
 SEMCONV_VERSIONS=$(grep -r "go.opentelemetry.io/otel/semconv/v1\." --include="*.go" . 2>/dev/null | \
   grep -oE "semconv/v1\.[0-9]+" | \
-  sort -u || true)
+  sort -u) || SEMCONV_VERSIONS=""
 
 # Count unique versions
 VERSION_COUNT=$(echo "$SEMCONV_VERSIONS" | grep -v "^$" | wc -l | tr -d ' ')
@@ -33,7 +33,7 @@ if [ "$VERSION_COUNT" -eq 1 ]; then
   # List files using this version for transparency
   echo ""
   echo "Files using $VERSION:"
-  grep -r "go.opentelemetry.io/otel/$VERSION" --include="*.go" . 2>/dev/null | \
+  grep -rF "go.opentelemetry.io/otel/$VERSION" --include="*.go" . 2>/dev/null | \
     cut -d: -f1 | \
     sort -u | \
     sed 's/^/  - /'
@@ -54,7 +54,7 @@ echo "Files by version:"
 for version in $SEMCONV_VERSIONS; do
   echo ""
   echo "  $version:"
-  grep -r "go.opentelemetry.io/otel/$version" --include="*.go" . 2>/dev/null | \
+  grep -rF "go.opentelemetry.io/otel/$version" --include="*.go" . 2>/dev/null | \
     cut -d: -f1 | \
     sort -u | \
     sed 's/^/    - /'

--- a/scripts/validate-semconv-versions.sh
+++ b/scripts/validate-semconv-versions.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Validate OpenTelemetry semantic convention versions are consistent
+#
+# This script prevents runtime schema conflicts by ensuring all semconv imports
+# use the same version across the codebase.
+#
+# IMPORTANT: This is a build-time check to catch issues before deployment
+# Exit codes:
+#   0 - All versions consistent
+#   1 - Version mismatch detected
+
+set -euo pipefail
+
+echo "Validating OpenTelemetry semantic convention versions..."
+
+# Find all semconv import versions in Go files
+SEMCONV_VERSIONS=$(grep -r "go.opentelemetry.io/otel/semconv/v1\." --include="*.go" . 2>/dev/null | \
+  grep -oE "semconv/v1\.[0-9]+" | \
+  sort -u || true)
+
+# Count unique versions
+VERSION_COUNT=$(echo "$SEMCONV_VERSIONS" | grep -v "^$" | wc -l | tr -d ' ')
+
+if [ "$VERSION_COUNT" -eq 0 ]; then
+  echo "✓ No semconv imports found (tracing may be disabled)"
+  exit 0
+fi
+
+if [ "$VERSION_COUNT" -eq 1 ]; then
+  VERSION=$(echo "$SEMCONV_VERSIONS" | head -1)
+  echo "✓ All semconv imports use consistent version: $VERSION"
+
+  # List files using this version for transparency
+  echo ""
+  echo "Files using $VERSION:"
+  grep -r "go.opentelemetry.io/otel/$VERSION" --include="*.go" . 2>/dev/null | \
+    cut -d: -f1 | \
+    sort -u | \
+    sed 's/^/  - /'
+
+  exit 0
+fi
+
+# Multiple versions detected - this is an error
+echo "✗ ERROR: Multiple semconv versions detected"
+echo ""
+echo "Found versions:"
+echo "$SEMCONV_VERSIONS" | sed 's/^/  - /'
+echo ""
+echo "This causes runtime errors:"
+echo "  'conflicting Schema URL: https://opentelemetry.io/schemas/...'"
+echo ""
+echo "Files by version:"
+for version in $SEMCONV_VERSIONS; do
+  echo ""
+  echo "  $version:"
+  grep -r "go.opentelemetry.io/otel/$version" --include="*.go" . 2>/dev/null | \
+    cut -d: -f1 | \
+    sort -u | \
+    sed 's/^/    - /'
+done
+echo ""
+echo "ACTION REQUIRED:"
+echo "  1. Check OpenTelemetry SDK version in go.mod"
+echo "  2. Update all semconv imports to match (typically v1.37.0 for SDK v1.38.0)"
+echo "  3. Run 'go mod tidy' to update dependencies"
+echo "  4. Verify with 'make test'"
+echo ""
+
+exit 1


### PR DESCRIPTION
## Summary

Fixes CrashLoopBackOff in `current-account` and `financial-accounting` microservices caused by conflicting OpenTelemetry semantic convention schema versions.

## Problem

Services failed during startup with error:
```
failed to initialize tracer: failed to create resource: failed to merge resources: 
conflicting Schema URL: https://opentelemetry.io/schemas/1.37.0 and https://opentelemetry.io/schemas/1.27.0
```

**Root cause**: Codebase used `semconv v1.27.0` while the OTel SDK (v1.38.0) uses `semconv v1.37.0`. When `resource.Default()` merged with custom resources, the schema conflict prevented tracer initialization.

## Changes

### 1. Update Semantic Conventions (v1.27.0 → v1.37.0)

Updated three observability files to use `semconv v1.37.0`:
- `internal/platform/observability/tracing.go`
- `internal/platform/observability/helpers.go`
- `internal/platform/observability/grpc.go`

**API changes** (v1.37.0 breaking changes):
- `DBSystemKey` → `DBSystemNameKey`
- `MessagingSystemKafka` (constant) → `MessagingSystemKey.String("kafka")`
- `MessagingOperationTypePublish` (constant) → `MessagingOperationTypeKey.String("publish")`
- Now using standard `MessagingDestinationPartitionIDKey` (newly available in v1.37.0)

### 2. Add Automated Version Validation

Created `scripts/validate-semconv-versions.sh` to prevent future conflicts:
- Scans all Go files for semconv imports
- Fails build if multiple versions detected
- Integrated into `make lint` via new `validate-semconv` target
- Provides clear error messages with remediation steps

**Example output:**
```bash
$ make validate-semconv
✓ All semconv imports use consistent version: semconv/v1.37

Files using semconv/v1.37:
  - ./internal/platform/observability/grpc.go
  - ./internal/platform/observability/helpers.go
  - ./internal/platform/observability/tracing.go
```

### 3. Clarify Migration Parallelization

Updated Tiltfile comments to document existing parallel execution:
- `migrate-current-account` + `migrate-financial-accounting` run in parallel (both depend only on `init-database`)
- `migrate-position-keeping` waits for `migrate-current-account` (FK dependency)

**Note**: Migrations were already optimized - this just clarifies the behavior.

## Testing

- ✅ **Build**: All services compile successfully
- ✅ **Lint**: `make lint` passes (includes new semconv validation)
- ✅ **Observability tests**: All tracing tests pass
- ✅ **Dependencies**: `go mod tidy` verified

## Impact

**Affected services:**
- `current-account` (was in CrashLoopBackOff)
- `financial-accounting` (was in CrashLoopBackOff)

**Unaffected services:**
- `meridian` (main service)
- `position-keeping`
- All backing services (CockroachDB, Kafka, Redis, Keycloak, observability stack)

## Prevention

The new `validate-semconv` check will catch this issue at build time in CI, preventing deployment of services with conflicting semconv versions.

## Go Dependency Management Context

For your question about Go's dependency management (like Maven for Java):

**Go Modules** (go.mod):
- `go.mod` ≈ `pom.xml` (declares dependencies)
- `go mod tidy` ≈ `mvn dependency:resolve` (downloads and prunes)
- `go mod verify` ≈ `mvn verify` (checks integrity)
- `go list -m all` ≈ `mvn dependency:tree` (shows all dependencies)

This PR demonstrates Go's semantic import versioning - when we updated from v1.27.0 to v1.37.0, we had to change the import path (`semconv/v1.27.0` → `semconv/v1.37.0`) because they're considered different packages with incompatible APIs.

Generated with Claude Code