### PR TITLE
docs: Rebrand as professional core banking engine

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,9 +5,9 @@
 Meridian is a professional software project focused on building a modern banking platform. This Code of Conduct
 establishes expectations for participation in our community to foster productive technical collaboration.
 
-As a learning project, we welcome questions and view mistakes as opportunities for growth and improvement. This is an
-environment where developers can explore banking platform architecture, ask clarifying questions, and learn from both
-successes and failures.
+As an open source project, we welcome questions and value diverse perspectives. This is an environment where developers
+collaborate on banking platform architecture, ask clarifying questions, and continuously improve through feedback and
+iteration.
 
 ## Our Standards
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1208,8 +1208,8 @@ Place ADRs in `docs/adr/` with numbering:
 
 ## Code of Conduct
 
-Be respectful, professional, and collaborative. This is a learning project—questions and mistakes are opportunities for
-growth.
+Be respectful, professional, and collaborative. We value diverse perspectives and view questions and feedback as
+opportunities for continuous improvement.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Meridian - BIAN-Compliant Open Banking Ledger
 
-A learning-focused reference implementation of an open banking ledger following BIAN (Banking Industry Architecture
-Network) standards.
+An open source, cloud-native core banking engine following BIAN (Banking Industry Architecture Network) standards.
 
 **What it demonstrates:**
 
@@ -12,8 +11,11 @@ Network) standards.
 - Event-driven architecture with Kafka
 - Kubernetes-native deployment
 
-**Note**: This is a learning tool, not production-ready software. It's designed as an architectural reference for
-building BIAN-compliant banking systems.
+**Features**:
+
+- Production-grade architecture patterns for financial systems
+- Comprehensive API design with Protocol Buffers
+- Distributed transaction handling and event-driven workflows
 
 ## Project Structure
 
@@ -158,7 +160,7 @@ For setup and development issues, see:
 
 ## Contributing
 
-Contributions welcome! This is a learning project - questions and mistakes are opportunities for growth.
+Contributions welcome! We value collaboration and view questions and feedback as opportunities for continuous improvement.
 
 **Quick start**:
 
@@ -194,6 +196,6 @@ Apache License 2.0 - See LICENSE file for details.
 
 ## Disclaimer
 
-This software is for educational and reference purposes only. It is not audited, tested, or designed for production use
-in financial systems. Do not use this code in production environments without thorough review, testing, and compliance
-verification.
+This software is provided "as-is" under the Apache License 2.0. Before deploying in production environments, ensure
+thorough security audits, compliance verification, and testing appropriate for your regulatory requirements and risk
+profile.

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -21,8 +21,8 @@ instructions: |
 **When to use this runbook**: Complete infrastructure failure, data corruption, regional outage, or catastrophic events
 requiring full system recovery.
 
-> **⚠️ Note for Learning Environment**: This is a template runbook for the Meridian learning project. In a production
-deployment, you would customize this with your specific:
+> **⚠️ Customization Note**: This is a template runbook for Meridian. In a production deployment, you should customize
+this with your specific:
 >
 > - Backup locations and credentials
 > - Recovery time objectives (RTO) and recovery point objectives (RPO)

--- a/docs/runbooks/incident-response.md
+++ b/docs/runbooks/incident-response.md
@@ -19,8 +19,8 @@ instructions: |
 
 **When to use this runbook**: Active security incident, service degradation, or production outage.
 
-> **⚠️ Note for Learning Environment**: This is a template runbook for the Meridian learning project. In a production
-deployment, you would customize this with your specific:
+> **⚠️ Customization Note**: This is a template runbook for Meridian. In a production deployment, you should customize
+this with your specific:
 >
 > - Contact details and escalation paths
 > - Monitoring dashboards and log locations


### PR DESCRIPTION
Remove "learning project" disclaimers and rebrand Meridian as "An Open Source, Cloud-Native Core Banking Engine." Key changes:

- README: Update tagline and remove educational disclaimers
- README: Replace learning tool note with professional features section
- README: Modernize disclaimer to focus on standard due diligence
- CONTRIBUTING: Update language to emphasize collaboration over learning
- CODE_OF_CONDUCT: Rebrand as open source project vs learning project
- Runbooks: Update template notes to remove "learning environment" language

The project now presents itself as a production-grade banking platform while maintaining welcoming language about questions and continuous improvement.