### PR TITLE
feat: Add Lien Control Record to CurrentAccount proto

### DIFF
--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -212,10 +212,15 @@ message Lien {
     pattern: "^[a-zA-Z0-9_-]+$"
   }];
 
-  // amount is the reserved amount
+  // amount is the reserved amount (must be positive, validated at service layer)
   meridian.common.v1.MoneyAmount amount = 3 [(buf.validate.field).required = true];
 
   // status is the current lien lifecycle state
+  // State transitions:
+  //   ACTIVE → EXECUTED (via ExecuteLien - idempotent)
+  //   ACTIVE → TERMINATED (via TerminateLien)
+  //   EXECUTED → no further transitions allowed
+  //   TERMINATED → no further transitions allowed
   LienStatus status = 4 [(buf.validate.field).enum = {
     defined_only: true
     not_in: [0]
@@ -331,11 +336,15 @@ message InitiateLienRequest {
   meridian.common.v1.MoneyAmount amount = 2 [(buf.validate.field).required = true];
 
   // payment_order_reference identifies the Payment Order creating this lien
+  // Forward slash allowed for hierarchical Payment Order references
   string payment_order_reference = 3 [(buf.validate.field).string = {
     min_len: 1
     max_len: 255
     pattern: "^[a-zA-Z0-9_/-]+$"
   }];
+
+  // idempotency_key ensures exactly-once lien creation for retry scenarios
+  meridian.common.v1.IdempotencyKey idempotency_key = 4;
 }
 
 // Response for initiating a lien

--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -225,6 +225,7 @@ message Lien {
   string payment_order_reference = 5 [(buf.validate.field).string = {
     min_len: 1
     max_len: 255
+    pattern: "^[a-zA-Z0-9_/-]+$"
   }];
 
   // created_at is when the lien was created
@@ -333,6 +334,7 @@ message InitiateLienRequest {
   string payment_order_reference = 3 [(buf.validate.field).string = {
     min_len: 1
     max_len: 255
+    pattern: "^[a-zA-Z0-9_/-]+$"
   }];
 }
 
@@ -371,6 +373,7 @@ message ExecuteLienResponse {
   string transaction_id = 4 [(buf.validate.field).string = {
     min_len: 1
     max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
   }];
 }
 
@@ -383,6 +386,9 @@ message TerminateLienRequest {
     max_len: 100
     pattern: "^[a-zA-Z0-9_-]+$"
   }];
+
+  // reason is an optional explanation for termination (for audit trail)
+  string reason = 2 [(buf.validate.field).string = {max_len: 500}];
 }
 
 // Response for terminating a lien

--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -34,6 +34,19 @@ enum TransactionStatus {
   TRANSACTION_STATUS_REVERSED = 4;
 }
 
+// LienStatus defines the lifecycle state of a fund reservation (lien)
+// A lien is a hold placed on funds to reserve them for a pending payment
+enum LienStatus {
+  // LIEN_STATUS_UNSPECIFIED is the default value and should not be used
+  LIEN_STATUS_UNSPECIFIED = 0;
+  // LIEN_STATUS_ACTIVE means the funds are currently reserved
+  LIEN_STATUS_ACTIVE = 1;
+  // LIEN_STATUS_EXECUTED means the lien was converted to an actual debit
+  LIEN_STATUS_EXECUTED = 2;
+  // LIEN_STATUS_TERMINATED means the lien was released without execution
+  LIEN_STATUS_TERMINATED = 3;
+}
+
 // CurrentAccountFacility represents a BIAN-compliant current account facility
 // Task 5.1: Define CurrentAccountFacility message with account identification and status management
 message CurrentAccountFacility {
@@ -181,6 +194,46 @@ message TransactionHistory {
   google.protobuf.Timestamp last_updated = 4;
 }
 
+// Lien represents a fund reservation (hold) on an account
+// Used by Payment Order to reserve funds before executing external payments
+// Invariant: Available Balance = Current Balance - Sum(Active Liens)
+message Lien {
+  // lien_id is the unique identifier for this lien
+  string lien_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // account_id is the account this lien belongs to
+  string account_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // amount is the reserved amount
+  meridian.common.v1.MoneyAmount amount = 3 [(buf.validate.field).required = true];
+
+  // status is the current lien lifecycle state
+  LienStatus status = 4 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // payment_order_reference is the Payment Order that created this lien
+  string payment_order_reference = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // created_at is when the lien was created
+  google.protobuf.Timestamp created_at = 6 [(buf.validate.field).required = true];
+
+  // updated_at is when the lien was last modified
+  google.protobuf.Timestamp updated_at = 7 [(buf.validate.field).required = true];
+}
+
 // Request to initiate a new current account
 message InitiateCurrentAccountRequest {
   // customer_id is the customer who owns this account
@@ -263,6 +316,100 @@ message RetrieveCurrentAccountResponse {
   CurrentAccountFacility facility = 1;
 }
 
+// Request to initiate a lien (reserve funds) on an account
+// BQ: Initiate - Creates a new fund reservation
+message InitiateLienRequest {
+  // account_id is the account to place the lien on
+  string account_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // amount is the amount to reserve
+  meridian.common.v1.MoneyAmount amount = 2 [(buf.validate.field).required = true];
+
+  // payment_order_reference identifies the Payment Order creating this lien
+  string payment_order_reference = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+}
+
+// Response for initiating a lien
+message InitiateLienResponse {
+  // lien is the created lien with ACTIVE status
+  Lien lien = 1 [(buf.validate.field).required = true];
+
+  // available_balance is the updated available balance after reservation
+  meridian.common.v1.MoneyAmount available_balance = 2 [(buf.validate.field).required = true];
+}
+
+// Request to execute a lien (convert reservation to actual debit)
+// BQ: Execute - Atomically converts lien to debit and removes reservation
+message ExecuteLienRequest {
+  // lien_id is the lien to execute
+  string lien_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+}
+
+// Response for executing a lien
+message ExecuteLienResponse {
+  // lien is the executed lien with EXECUTED status
+  Lien lien = 1 [(buf.validate.field).required = true];
+
+  // new_balance is the account balance after the debit
+  meridian.common.v1.MoneyAmount new_balance = 2 [(buf.validate.field).required = true];
+
+  // available_balance is the updated available balance
+  meridian.common.v1.MoneyAmount available_balance = 3 [(buf.validate.field).required = true];
+
+  // transaction_id is the debit transaction created
+  string transaction_id = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+  }];
+}
+
+// Request to terminate a lien (release reserved funds)
+// BQ: Terminate - Releases the reservation without executing
+message TerminateLienRequest {
+  // lien_id is the lien to terminate
+  string lien_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+}
+
+// Response for terminating a lien
+message TerminateLienResponse {
+  // lien is the terminated lien with TERMINATED status
+  Lien lien = 1 [(buf.validate.field).required = true];
+
+  // available_balance is the updated available balance after release
+  meridian.common.v1.MoneyAmount available_balance = 2 [(buf.validate.field).required = true];
+}
+
+// Request to retrieve a lien
+message RetrieveLienRequest {
+  // lien_id is the lien to retrieve
+  string lien_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+}
+
+// Response for retrieving a lien
+message RetrieveLienResponse {
+  // lien is the requested lien
+  Lien lien = 1 [(buf.validate.field).required = true];
+}
+
 // CurrentAccountService provides BIAN-compliant current account operations
 service CurrentAccountService {
   // InitiateCurrentAccount creates a new current account facility
@@ -273,4 +420,19 @@ service CurrentAccountService {
 
   // RetrieveCurrentAccount gets current account details
   rpc RetrieveCurrentAccount(RetrieveCurrentAccountRequest) returns (RetrieveCurrentAccountResponse);
+
+  // InitiateLien creates a fund reservation on an account
+  // Used by Payment Order to reserve funds before external payment execution
+  rpc InitiateLien(InitiateLienRequest) returns (InitiateLienResponse);
+
+  // ExecuteLien converts a reservation to an actual debit atomically
+  // Called when the external payment is confirmed as settled
+  rpc ExecuteLien(ExecuteLienRequest) returns (ExecuteLienResponse);
+
+  // TerminateLien releases a reservation without executing
+  // Called when the external payment fails or is cancelled
+  rpc TerminateLien(TerminateLienRequest) returns (TerminateLienResponse);
+
+  // RetrieveLien gets lien details
+  rpc RetrieveLien(RetrieveLienRequest) returns (RetrieveLienResponse);
 }


### PR DESCRIPTION
## Summary

- Add fund reservation (lien) capability to CurrentAccount service
- Supports Payment Order saga orchestration pattern
- Allows reserving funds before external payment execution

## Changes Made

### New Proto Definitions

**Enum:**
- `LienStatus`: ACTIVE, EXECUTED, TERMINATED

**Message:**
- `Lien`: lien_id, account_id, amount, status, payment_order_reference, timestamps

**RPCs added to CurrentAccountService:**
- `InitiateLien` - Reserve funds (reduces available balance)
- `ExecuteLien` - Atomically convert reservation to debit  
- `TerminateLien` - Release reservation without execution
- `RetrieveLien` - Query lien details

### Key Invariant

```
Available Balance = Current Balance - Sum(Active Liens)
```

## Technical Details

- All fields use appropriate `buf.validate` rules
- Follows existing CurrentAccount proto patterns
- No breaking changes to existing messages/RPCs
- 162 lines added to `current_account.proto`

## Testing

- [x] `buf lint` passes
- [x] `buf breaking` passes (no breaking changes)
- [x] `buf generate` produces valid Go code
- [x] Pre-commit hooks pass

## Task Master

Part of **7-payment-order** tag, Task 3: "Extend CurrentAccount Proto with Lien Operations"

This enables Tasks 4-5 (Lien implementation) and Task 9 (Payment Order Saga Orchestrator).

## Risk Assessment

**Low risk** - Proto-only changes, no implementation code. Purely additive to existing service.