### PR TITLE
fix: Add storage limits to prevent disk exhaustion in local dev

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -230,7 +230,15 @@ spec:
 # 4. Verify leadership transfer: kubectl exec kafka-0 -- kafka-topics --describe --topic test --bootstrap-server localhost:9092
 # 5. Produce/consume messages to verify data persists
 #
-# Resource Usage: ~1.5GB total (512MB per broker)
+# Resource Usage: ~1.5GB RAM total (512MB per broker)
+#
+# Storage Limits (prevent disk exhaustion):
+# - 512MB per topic partition (log.retention.bytes=536870912)
+# - 128MB segment size (log.segment.bytes=134217728)
+# - 24h time-based retention
+# - Log cleanup runs every 60 seconds
+# - LZ4 compression enabled (~50% reduction)
+# - Estimated max: ~1.5GB per broker for active topics
 #
 # Resource-Constrained Development (8GB RAM machines):
 # For machines with limited RAM, you can reduce to single-broker mode by:
@@ -360,10 +368,14 @@ spec:
           socket.receive.buffer.bytes=102400
           socket.request.max.bytes=104857600
 
-          # Log Retention
-          log.retention.hours=168
-          log.segment.bytes=1073741824
-          log.retention.check.interval.ms=300000
+          # Log Retention (aggressive for local dev to prevent disk exhaustion)
+          log.retention.hours=24
+          log.retention.bytes=536870912
+          log.segment.bytes=134217728
+          log.retention.check.interval.ms=60000
+          log.cleanup.policy=delete
+          log.cleaner.enable=true
+          compression.type=lz4
           EOF
 
           # Format KRaft storage if not already formatted
@@ -950,6 +962,13 @@ Fast Startup Mode:
   • Enable: export TILT_FAST_STARTUP=true && tilt up
   • Skips automatic test execution on startup for faster iteration
   • Manually trigger tests: tilt trigger test
+
+Storage Limits (prevent disk exhaustion):
+  • Observability stack: ~7Gi max (Tempo 2Gi, Loki 2Gi, Prometheus 3Gi)
+  • Kafka: ~1.5Gi per broker (512MB/partition, 24h retention)
+  • Docker daemon logs: Configure in ~/.docker/daemon.json:
+    {{"log-driver": "json-file", "log-opts": {{"max-size": "10m", "max-file": "3"}}}}
+  • Kind cluster: Restart Kind to reclaim emptyDir space
 
 ========================================
 """.format(fast_startup_msg))

--- a/deployments/k8s/observability/grafana-stack.yaml
+++ b/deployments/k8s/observability/grafana-stack.yaml
@@ -2,11 +2,18 @@
 # Grafana Observability Stack - Development Configuration
 #
 # This configuration is optimized for local development with Tilt.
+#
+# Storage Limits (prevent disk exhaustion during extended Tilt sessions):
+#   - Tempo:      2Gi storage, 1h block retention
+#   - Loki:       2Gi storage, 24h retention
+#   - Prometheus: 3Gi storage, 24h retention (or 2GB size limit)
+#   - Total:      ~7Gi maximum for observability data
+#
 # For production deployments, add security hardening:
 #   - Set securityContext.runAsNonRoot: true
 #   - Set securityContext.allowPrivilegeEscalation: false
 #   - Set securityContext.runAsUser to non-root UID
-#   - Add resource limits and requests
+#   - Use persistent volumes instead of emptyDir
 #   - Use secrets for sensitive configuration
 ---
 # Grafana Alloy - OpenTelemetry Collector
@@ -229,7 +236,8 @@ spec:
         configMap:
           name: tempo-config
       - name: storage
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 2Gi
 ---
 # Grafana Loki - Log Aggregation
 apiVersion: v1
@@ -267,7 +275,7 @@ data:
             period: 24h
 
     limits_config:
-      retention_period: 168h
+      retention_period: 24h
 ---
 apiVersion: v1
 kind: Service
@@ -323,7 +331,8 @@ spec:
         configMap:
           name: loki-config
       - name: storage
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 2Gi
 ---
 # Prometheus - Metrics Collection and Storage
 apiVersion: v1
@@ -408,7 +417,8 @@ spec:
         args:
         - --config.file=/etc/prometheus/prometheus.yml
         - --storage.tsdb.path=/prometheus
-        - --storage.tsdb.retention.time=7d
+        - --storage.tsdb.retention.time=24h
+        - --storage.tsdb.retention.size=2GB
         - --web.enable-remote-write-receiver
         ports:
         - containerPort: 9090
@@ -430,7 +440,8 @@ spec:
         configMap:
           name: prometheus-config
       - name: storage
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 3Gi
 ---
 # Grafana - Visualization and Dashboards
 apiVersion: v1


### PR DESCRIPTION
## Summary

- Configure storage limits and aggressive retention to prevent disk space exhaustion during extended Tilt sessions
- Add documentation for Docker daemon log rotation configuration
- Reduce observability retention periods from 7 days to 24 hours for local development

## Changes Made

### Observability Stack (`grafana-stack.yaml`)
- **Tempo**: Added 2Gi emptyDir sizeLimit (existing 1h block retention)
- **Loki**: Added 2Gi emptyDir sizeLimit, reduced retention from 168h to 24h
- **Prometheus**: Added 3Gi emptyDir sizeLimit, reduced retention from 7d to 24h, added 2GB size-based retention
- Total observability storage capped at ~7Gi

### Kafka (`Tiltfile`)
- Reduced log retention from 168h to 24h
- Added per-partition size limit of 512MB (`log.retention.bytes`)
- Reduced log segment size from 1GB to 128MB for faster cleanup
- Increased cleanup frequency from 5min to 60sec
- Estimated max ~1.5Gi per broker

### Documentation
- Added storage limits section to Tilt startup banner
- Documented Docker daemon log rotation configuration

## Test plan

- [ ] Run `tilt up` and verify the startup banner shows the new storage limits section
- [ ] Verify observability stack pods start correctly with the new volume configurations
- [ ] Verify Kafka brokers start with the new retention settings

## Risk Assessment

Low risk - affects only local development environment. Changes are additive (size limits) or reduce retention periods which improves local dev experience.