### PR TITLE
chore: Upgrade Claude Code review to use Opus 4.5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -89,7 +89,8 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # Using Opus 4.5 for higher quality code reviews
+          claude_args: '--model claude-opus-4-5-20251101 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
       # Always succeed even if Claude Code times out or fails
       # This prevents blocking PRs when Claude Code has service issues

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -62,6 +62,7 @@ jobs:
             Read CONTRIBUTING.md in the repository root for full development guidelines.
 
           # Customize Claude's behavior
+          # Using Opus 4.5 for higher quality responses
           claude_args: |
             --max-input-tokens 50000
-            --model claude-sonnet-4-5
+            --model claude-opus-4-5-20251101


### PR DESCRIPTION
## Summary

Upgrades the Claude Code review GitHub Action from the default Sonnet model to Opus 4.5 (`claude-opus-4-5-20251101`).

## Why Opus 4.5?

| Feature | Benefit |
|---------|---------|
| **SWE-bench Verified** | 80.9% - industry-leading code understanding |
| **Hybrid reasoning** | Better analysis of complex code patterns |
| **200K context window** | Can review larger PRs effectively |

## Changes

- Added `--model claude-opus-4-5-20251101` to `claude_args` in the workflow

## Test Plan

- [ ] Workflow syntax is valid (YAML lint)
- [ ] Next PR will use Opus 4.5 for review (verify in action logs)

## References

- [Claude Opus 4.5 Announcement](https://www.anthropic.com/news/claude-opus-4-5)
- [Claude Code Action Configuration](https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md)