### PR TITLE
Add Contributor License Agreement

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -3,12 +3,12 @@
 By submitting a pull request or patch to this project, you agree to the following:
 
 1. You assign all copyright and intellectual property rights in your
-   contribution to Benjamin John Coombs ("the Project Owner").
+   contribution to Benjamin John Coombs.
 
 2. You confirm that you have the legal right to make this assignment.
 
 3. You understand that your contribution will be licensed to the public
-   under the project's open source license, and may also be used in
-   commercial offerings at the Project Owner's discretion.
+   under the Apache License 2.0, and may also be used in commercial
+   offerings at the copyright holder's discretion.
 
 4. This assignment is irrevocable.

--- a/CLA.md
+++ b/CLA.md
@@ -5,7 +5,7 @@ By submitting a pull request or patch to this project, you agree to the followin
 1. You assign all copyright and intellectual property rights in your
    contribution to Benjamin John Coombs.
 
-2. You confirm that you have the legal right to make this assignment.
+2. Your submission confirms that you have the legal right to make this assignment.
 
 3. You understand that your contribution will be licensed to the public
    under the Apache License 2.0, and may also be used in commercial

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,14 @@
+# Contributor License Agreement
+
+By submitting a pull request or patch to this project, you agree to the following:
+
+1. You assign all copyright and intellectual property rights in your
+   contribution to Benjamin John Coombs ("the Project Owner").
+
+2. You confirm that you have the legal right to make this assignment.
+
+3. You understand that your contribution will be licensed to the public
+   under the project's open source license, and may also be used in
+   commercial offerings at the Project Owner's discretion.
+
+4. This assignment is irrevocable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1220,5 +1220,5 @@ opportunities for continuous improvement.
 
 ## License
 
-By contributing, you agree to the terms of the [Contributor License Agreement](CLA.md). Your contributions will be
-licensed to the public under the Apache License 2.0.
+By contributing, you agree to the [Contributor License Agreement](CLA.md), which assigns copyright to the project
+maintainer while your contribution remains publicly available under the Apache License 2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1220,4 +1220,5 @@ opportunities for continuous improvement.
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the Apache License 2.0.
+By contributing, you agree to the terms of the [Contributor License Agreement](CLA.md). Your contributions will be
+licensed to the public under the Apache License 2.0.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,15 @@
 
 Thank you for your interest in contributing to Meridian! This guide will help you get started with development.
 
+## Contributor License Agreement
+
+All contributions to this project require agreement to our [Contributor License Agreement](CLA.md). By submitting a
+pull request, you confirm that you have read and agree to the terms of the CLA, which assigns copyright and
+intellectual property rights to the Project Owner.
+
 ## Table of Contents
 
+- [Contributor License Agreement](#contributor-license-agreement)
 - [Development Environment Setup](#development-environment-setup)
 - [Development Workflow](#development-workflow)
 - [Code Standards](#code-standards)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to Meridian! This guide will help yo
 
 All contributions to this project require agreement to our [Contributor License Agreement](CLA.md). By submitting a
 pull request, you confirm that you have read and agree to the terms of the CLA, which assigns copyright and
-intellectual property rights to the Project Owner.
+intellectual property rights to the copyright holder.
 
 ## Table of Contents
 
@@ -1220,5 +1220,5 @@ opportunities for continuous improvement.
 
 ## License
 
-By contributing, you agree to the [Contributor License Agreement](CLA.md), which assigns copyright to the project
-maintainer while your contribution remains publicly available under the Apache License 2.0.
+By contributing, you agree to the [Contributor License Agreement](CLA.md), which assigns copyright to the copyright
+holder while your contribution remains publicly available under the Apache License 2.0.


### PR DESCRIPTION
## Summary

- Add CLA.md with contributor license agreement terms
- Update CONTRIBUTING.md to require CLA agreement for all contributions

## Changes Made

- **CLA.md**: New file containing the Contributor License Agreement that assigns copyright and IP rights to the Project Owner
- **CONTRIBUTING.md**: Added CLA section at top of document and updated table of contents

## Test plan

- [x] Verify CLA.md contains correct terms
- [x] Verify CONTRIBUTING.md links to CLA.md correctly
- [x] Markdown linting passes