### PR TITLE
feat: Implement Lien gRPC service operations

### DIFF
--- a/cmd/current-account/main.go
+++ b/cmd/current-account/main.go
@@ -92,8 +92,9 @@ func run(logger *slog.Logger) error {
 
 	logger.Info("database connection established")
 
-	// Create repository
+	// Create repositories
 	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
 
 	// Get Kubernetes namespace from environment (defaults to "default")
 	namespace := getEnvOrDefault("K8S_NAMESPACE", "default")
@@ -106,6 +107,7 @@ func run(logger *slog.Logger) error {
 	// Create service with external clients and capture the clients for health checking
 	currentAccountService, posKeepingClient, finAcctClient, err := createServiceWithClients(
 		repo,
+		lienRepo,
 		namespace,
 		logger,
 		tracer,
@@ -313,6 +315,7 @@ func getEnvAsDuration(key string, defaultValue time.Duration) time.Duration {
 // Uses DNS-based client-side load balancing for inter-service gRPC communication.
 func createServiceWithClients(
 	repo *persistence.Repository,
+	lienRepo *persistence.LienRepository,
 	namespace string,
 	logger *slog.Logger,
 	tracer *observability.Tracer,
@@ -360,6 +363,7 @@ func createServiceWithClients(
 	// Create service with the pre-created clients
 	svc, err := service.NewServiceWithExistingClients(
 		repo,
+		lienRepo,
 		resilientPosKeepingClient,
 		resilientFinAcctClient,
 		logger,

--- a/internal/current-account/adapters/persistence/lien_repository.go
+++ b/internal/current-account/adapters/persistence/lien_repository.go
@@ -27,6 +27,12 @@ func NewLienRepository(db *gorm.DB) *LienRepository {
 	return &LienRepository{db: db}
 }
 
+// WithTx returns a new LienRepository that uses the provided transaction.
+// This enables multiple repository operations within a single transaction.
+func (r *LienRepository) WithTx(tx *gorm.DB) *LienRepository {
+	return &LienRepository{db: tx}
+}
+
 // Create inserts a new lien
 func (r *LienRepository) Create(lien *domain.Lien) error {
 	entity := toLienEntity(lien)

--- a/internal/current-account/adapters/persistence/lien_repository.go
+++ b/internal/current-account/adapters/persistence/lien_repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/internal/current-account/domain"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // Lien repository errors
@@ -43,6 +44,25 @@ func (r *LienRepository) Create(lien *domain.Lien) error {
 func (r *LienRepository) FindByID(id uuid.UUID) (*domain.Lien, error) {
 	var entity LienEntity
 	result := r.db.Where("id = ?", id).First(&entity)
+
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, ErrLienNotFound
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return toLienDomain(&entity)
+}
+
+// FindByIDForUpdate retrieves a lien by its UUID with a pessimistic lock.
+// Use this within a transaction when you need to prevent concurrent modifications.
+func (r *LienRepository) FindByIDForUpdate(id uuid.UUID) (*domain.Lien, error) {
+	var entity LienEntity
+	result := r.db.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("id = ?", id).
+		First(&entity)
 
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return nil, ErrLienNotFound

--- a/internal/current-account/adapters/persistence/repository.go
+++ b/internal/current-account/adapters/persistence/repository.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/internal/current-account/domain"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // Repository errors
@@ -102,6 +103,25 @@ func (r *Repository) Save(account *domain.CurrentAccount) error {
 func (r *Repository) FindByID(accountID string) (*domain.CurrentAccount, error) {
 	var entity CurrentAccountEntity
 	result := r.db.Where("account_id = ? AND deleted_at IS NULL", accountID).First(&entity)
+
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, ErrAccountNotFound
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return toDomain(&entity)
+}
+
+// FindByIDForUpdate retrieves an account by its account ID with a pessimistic lock.
+// Use this within a transaction when you need to prevent concurrent modifications.
+func (r *Repository) FindByIDForUpdate(accountID string) (*domain.CurrentAccount, error) {
+	var entity CurrentAccountEntity
+	result := r.db.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("account_id = ? AND deleted_at IS NULL", accountID).
+		First(&entity)
 
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return nil, ErrAccountNotFound

--- a/internal/current-account/adapters/persistence/repository.go
+++ b/internal/current-account/adapters/persistence/repository.go
@@ -27,6 +27,18 @@ func NewRepository(db *gorm.DB) *Repository {
 	return &Repository{db: db}
 }
 
+// DB returns the underlying database connection for transaction support.
+// Use this to wrap multiple repository operations in a single transaction.
+func (r *Repository) DB() *gorm.DB {
+	return r.db
+}
+
+// WithTx returns a new Repository that uses the provided transaction.
+// This enables multiple repository operations within a single transaction.
+func (r *Repository) WithTx(tx *gorm.DB) *Repository {
+	return &Repository{db: tx}
+}
+
 // Save creates or updates an account with optimistic locking
 func (r *Repository) Save(account *domain.CurrentAccount) error {
 	entity := toEntity(account)

--- a/internal/current-account/adapters/persistence/repository.go
+++ b/internal/current-account/adapters/persistence/repository.go
@@ -166,6 +166,25 @@ func (r *Repository) FindByUUID(id uuid.UUID) (*domain.CurrentAccount, error) {
 	return toDomain(&entity)
 }
 
+// FindByUUIDForUpdate retrieves an account by its internal UUID with a pessimistic lock.
+// Use this within a transaction when you need to prevent concurrent modifications.
+func (r *Repository) FindByUUIDForUpdate(id uuid.UUID) (*domain.CurrentAccount, error) {
+	var entity CurrentAccountEntity
+	result := r.db.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("id = ? AND deleted_at IS NULL", id).
+		First(&entity)
+
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, ErrAccountNotFound
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return toDomain(&entity)
+}
+
 // FindByCustomerID retrieves all accounts for a customer
 func (r *Repository) FindByCustomerID(customerID string) ([]*domain.CurrentAccount, error) {
 	var entities []CurrentAccountEntity

--- a/internal/current-account/adapters/persistence/repository.go
+++ b/internal/current-account/adapters/persistence/repository.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/internal/current-account/domain"
 	"gorm.io/gorm"
 )
@@ -105,6 +106,22 @@ func (r *Repository) FindByID(accountID string) (*domain.CurrentAccount, error) 
 func (r *Repository) FindByIBAN(iban string) (*domain.CurrentAccount, error) {
 	var entity CurrentAccountEntity
 	result := r.db.Where("account_identification = ? AND deleted_at IS NULL", iban).First(&entity)
+
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, ErrAccountNotFound
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return toDomain(&entity)
+}
+
+// FindByUUID retrieves an account by its internal UUID
+func (r *Repository) FindByUUID(id uuid.UUID) (*domain.CurrentAccount, error) {
+	var entity CurrentAccountEntity
+	result := r.db.Where("id = ? AND deleted_at IS NULL", id).First(&entity)
 
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		return nil, ErrAccountNotFound

--- a/internal/current-account/service/grpc_service.go
+++ b/internal/current-account/service/grpc_service.go
@@ -46,6 +46,7 @@ const (
 type Service struct {
 	pb.UnimplementedCurrentAccountServiceServer
 	repo             *persistence.Repository
+	lienRepo         *persistence.LienRepository
 	posKeepingClient clients.PositionKeepingClient
 	finAcctClient    clients.FinancialAccountingClient
 	logger           *slog.Logger
@@ -55,6 +56,7 @@ type Service struct {
 // Config contains configuration for creating a new Service with external clients
 type Config struct {
 	Repository                *persistence.Repository
+	LienRepository            *persistence.LienRepository
 	PositionKeepingTarget     string // e.g., "positionkeeping-service:50051"
 	FinancialAccountingTarget string // e.g., "financialaccounting-service:50052"
 	Logger                    *slog.Logger
@@ -63,13 +65,14 @@ type Config struct {
 
 // NewService creates a new current account service with minimal dependencies.
 // This is primarily used for testing. For production use, prefer NewServiceWithClients.
-func NewService(repo *persistence.Repository) *Service {
+func NewService(repo *persistence.Repository, lienRepo *persistence.LienRepository) *Service {
 	if repo == nil {
 		panic("repository cannot be nil")
 	}
 	return &Service{
-		repo:   repo,
-		logger: slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+		repo:     repo,
+		lienRepo: lienRepo,
+		logger:   slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	}
 }
 
@@ -78,6 +81,7 @@ func NewService(repo *persistence.Repository) *Service {
 // (e.g., health checkers) to avoid creating duplicate connections.
 func NewServiceWithExistingClients(
 	repo *persistence.Repository,
+	lienRepo *persistence.LienRepository,
 	posKeepingClient clients.PositionKeepingClient,
 	finAcctClient clients.FinancialAccountingClient,
 	logger *slog.Logger,
@@ -94,6 +98,7 @@ func NewServiceWithExistingClients(
 
 	return &Service{
 		repo:             repo,
+		lienRepo:         lienRepo,
 		posKeepingClient: posKeepingClient,
 		finAcctClient:    finAcctClient,
 		logger:           logger,
@@ -160,6 +165,7 @@ func NewServiceWithClients(config Config) (*Service, error) {
 
 	return &Service{
 		repo:             config.Repository,
+		lienRepo:         config.LienRepository,
 		posKeepingClient: resilientPosKeepingClient,
 		finAcctClient:    resilientFinAcctClient,
 		logger:           logger,

--- a/internal/current-account/service/grpc_service_integration_test.go
+++ b/internal/current-account/service/grpc_service_integration_test.go
@@ -710,7 +710,7 @@ func TestExecuteDeposit_WithoutClients_BackwardCompatibility(t *testing.T) {
 	_ = createTestAccount(t, repo, "ACC-006")
 
 	// Create service WITHOUT clients (backward compatibility mode)
-	svc := NewService(repo)
+	svc := NewService(repo, nil)
 
 	// Execute deposit
 	req := createTestDepositRequest("ACC-006", 200, 0) // £200.00

--- a/internal/current-account/service/grpc_service_test.go
+++ b/internal/current-account/service/grpc_service_test.go
@@ -36,7 +36,7 @@ func TestInitiateCurrentAccount(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo)
+	svc := NewService(repo, nil)
 
 	req := &pb.InitiateCurrentAccountRequest{
 		AccountIdentification: "GB82WEST12345698765432",
@@ -71,7 +71,7 @@ func TestExecuteDeposit(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo)
+	svc := NewService(repo, nil)
 
 	// Create account first
 	account, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "CUST-001", "GBP")
@@ -126,7 +126,7 @@ func TestExecuteDepositAccountNotFound(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo)
+	svc := NewService(repo, nil)
 
 	req := &pb.ExecuteDepositRequest{
 		AccountId: "ACC-NONEXISTENT",
@@ -159,7 +159,7 @@ func TestExecuteDepositInvalidAmount(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo)
+	svc := NewService(repo, nil)
 
 	// Create account first
 	account, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "CUST-001", "GBP")
@@ -200,7 +200,7 @@ func TestRetrieveCurrentAccount(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo)
+	svc := NewService(repo, nil)
 
 	// Create account first
 	account, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "CUST-001", "GBP")
@@ -237,7 +237,7 @@ func TestRetrieveCurrentAccountNotFound(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo)
+	svc := NewService(repo, nil)
 
 	req := &pb.RetrieveCurrentAccountRequest{
 		AccountId: "ACC-NONEXISTENT",
@@ -286,7 +286,7 @@ func TestExecuteDepositCurrencyMismatch(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo)
+	svc := NewService(repo, nil)
 
 	// Create GBP account
 	account, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "CUST-001", "GBP")
@@ -331,7 +331,7 @@ func TestInitiateCurrentAccountUnsupportedCurrency(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo)
+	svc := NewService(repo, nil)
 
 	req := &pb.InitiateCurrentAccountRequest{
 		AccountIdentification: "GB82WEST12345698765432",
@@ -425,7 +425,7 @@ func TestExecuteDeposit_OverflowPrevention_UnitsTooCents(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo)
+	svc := NewService(repo, nil)
 
 	// Create account
 	account, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "CUST-001", "GBP")
@@ -490,7 +490,7 @@ func TestExecuteDeposit_SafeAddition_UnitsAndNanos(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo)
+	svc := NewService(repo, nil)
 
 	// Create account
 	account, err := domain.NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "CUST-001", "GBP")

--- a/internal/current-account/service/lien_service.go
+++ b/internal/current-account/service/lien_service.go
@@ -144,7 +144,11 @@ func (s *Service) InitiateLien(_ context.Context, req *pb.InitiateLienRequest) (
 
 	// Calculate new available balance after this lien
 	newAvailableBalance := availableBalance - lienAmount.AmountCents()
-	availableMoney, _ := domain.NewMoney(account.Balance.Currency(), newAvailableBalance)
+	availableMoney, err := domain.NewMoney(account.Balance.Currency(), newAvailableBalance)
+	if err != nil {
+		// This should never happen if validation passed - log and return without available balance
+		s.logger.Error("failed to create available balance money", "error", err)
+	}
 
 	return &pb.InitiateLienResponse{
 		Lien:             toLienProto(lien),
@@ -196,9 +200,15 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 			return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
 		}
 
-		activeLiensTotal, _ := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
+		activeLiensTotal, sumErr := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
+		if sumErr != nil {
+			s.logger.Error("failed to sum active liens for idempotent response", "error", sumErr)
+		}
 		availableBalance := account.Balance.AmountCents() - activeLiensTotal
-		availableMoney, _ := domain.NewMoney(account.Balance.Currency(), availableBalance)
+		availableMoney, moneyErr := domain.NewMoney(account.Balance.Currency(), availableBalance)
+		if moneyErr != nil {
+			s.logger.Error("failed to create available balance for idempotent response", "error", moneyErr)
+		}
 
 		return &pb.ExecuteLienResponse{
 			Lien:             toLienProto(lien),
@@ -259,9 +269,15 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 		"transaction_id", transactionID)
 
 	// Calculate new available balance
-	activeLiensTotal, _ := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
+	activeLiensTotal, sumErr := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
+	if sumErr != nil {
+		s.logger.Error("failed to sum active liens for response", "error", sumErr)
+	}
 	availableBalance := account.Balance.AmountCents() - activeLiensTotal
-	availableMoney, _ := domain.NewMoney(account.Balance.Currency(), availableBalance)
+	availableMoney, moneyErr := domain.NewMoney(account.Balance.Currency(), availableBalance)
+	if moneyErr != nil {
+		s.logger.Error("failed to create available balance for response", "error", moneyErr)
+	}
 
 	return &pb.ExecuteLienResponse{
 		Lien:             toLienProto(lien),
@@ -308,11 +324,21 @@ func (s *Service) TerminateLien(_ context.Context, req *pb.TerminateLienRequest)
 		s.logger.Info("lien already terminated (idempotent)",
 			"lien_id", lien.ID.String())
 
-		// Calculate available balance
-		activeLiensTotal, _ := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
-		account, _ := s.repo.FindByUUID(lien.AccountID)
+		// Calculate available balance - errors logged but don't fail idempotent response
+		activeLiensTotal, sumErr := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
+		if sumErr != nil {
+			s.logger.Error("failed to sum active liens for idempotent response", "error", sumErr)
+		}
+		account, acctErr := s.repo.FindByUUID(lien.AccountID)
+		if acctErr != nil {
+			s.logger.Error("failed to find account for idempotent response", "error", acctErr)
+			return &pb.TerminateLienResponse{Lien: toLienProto(lien)}, nil
+		}
 		availableBalance := account.Balance.AmountCents() - activeLiensTotal
-		availableMoney, _ := domain.NewMoney(account.Balance.Currency(), availableBalance)
+		availableMoney, moneyErr := domain.NewMoney(account.Balance.Currency(), availableBalance)
+		if moneyErr != nil {
+			s.logger.Error("failed to create available balance for idempotent response", "error", moneyErr)
+		}
 
 		return &pb.TerminateLienResponse{
 			Lien:             toLienProto(lien),
@@ -358,9 +384,15 @@ func (s *Service) TerminateLien(_ context.Context, req *pb.TerminateLienRequest)
 		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
 	}
 
-	activeLiensTotal, _ := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
+	activeLiensTotal, sumErr := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
+	if sumErr != nil {
+		s.logger.Error("failed to sum active liens for response", "error", sumErr)
+	}
 	availableBalance := account.Balance.AmountCents() - activeLiensTotal
-	availableMoney, _ := domain.NewMoney(account.Balance.Currency(), availableBalance)
+	availableMoney, moneyErr := domain.NewMoney(account.Balance.Currency(), availableBalance)
+	if moneyErr != nil {
+		s.logger.Error("failed to create available balance for response", "error", moneyErr)
+	}
 
 	return &pb.TerminateLienResponse{
 		Lien:             toLienProto(lien),

--- a/internal/current-account/service/lien_service.go
+++ b/internal/current-account/service/lien_service.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
 )
 
 // Lien-specific errors
@@ -200,16 +201,7 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 			return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
 		}
 
-		activeLiensTotal, sumErr := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
-		if sumErr != nil {
-			s.logger.Error("failed to sum active liens for idempotent response", "error", sumErr)
-		}
-		availableBalance := account.Balance.AmountCents() - activeLiensTotal
-		availableMoney, moneyErr := domain.NewMoney(account.Balance.Currency(), availableBalance)
-		if moneyErr != nil {
-			s.logger.Error("failed to create available balance for idempotent response", "error", moneyErr)
-		}
-
+		availableMoney := s.calculateAvailableBalance(lien.AccountID, account.Balance)
 		return &pb.ExecuteLienResponse{
 			Lien:             toLienProto(lien),
 			NewBalance:       toMoneyAmount(account.Balance),
@@ -244,22 +236,45 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 		return nil, status.Errorf(codes.FailedPrecondition, "failed to debit account: %v", err)
 	}
 
-	// Save account first - this is the critical operation
-	// If this fails, no state has changed. If lien update fails after,
-	// the next idempotent retry will complete the lien status update.
-	if err := s.repo.Save(account); err != nil {
-		operationStatus = opStatusSaveAccountFailed
-		return nil, status.Errorf(codes.Internal, "failed to save account: %v", err)
-	}
+	// Execute both updates atomically in a transaction to prevent double-debit on retry.
+	// If we updated lien first and account save failed, retry would see EXECUTED lien
+	// and return idempotent success without debiting - funds would never be debited.
+	// If we updated account first and lien update failed, retry would see ACTIVE lien
+	// and debit again - resulting in double-debit.
+	// Using a transaction ensures both succeed or both fail together.
+	txErr := s.repo.DB().Transaction(func(tx *gorm.DB) error {
+		txRepo := s.repo.WithTx(tx)
+		txLienRepo := s.lienRepo.WithTx(tx)
 
-	// Update lien status (after account is safely persisted)
-	if err := s.lienRepo.Update(lien); err != nil {
-		if errors.Is(err, persistence.ErrLienVersionConflict) {
+		// Update lien status first (lighter operation)
+		if err := txLienRepo.Update(lien); err != nil {
+			if errors.Is(err, persistence.ErrLienVersionConflict) {
+				return fmt.Errorf("version_conflict: %w", err)
+			}
+			return fmt.Errorf("update_lien: %w", err)
+		}
+
+		// Save account (heavier operation with balance)
+		if err := txRepo.Save(account); err != nil {
+			return fmt.Errorf("save_account: %w", err)
+		}
+
+		return nil
+	})
+
+	if txErr != nil {
+		if errors.Is(txErr, persistence.ErrLienVersionConflict) {
 			operationStatus = opStatusVersionConflict
 			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
 		}
-		operationStatus = opStatusUpdateLienFailed
-		return nil, status.Errorf(codes.Internal, "failed to update lien: %v", err)
+		// Determine which operation failed for proper error reporting
+		errStr := txErr.Error()
+		if len(errStr) > 12 && errStr[:12] == "save_account" {
+			operationStatus = opStatusSaveAccountFailed
+		} else {
+			operationStatus = opStatusUpdateLienFailed
+		}
+		return nil, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
 	}
 
 	transactionID := fmt.Sprintf("TXN-LIEN-%s", lien.ID.String()[:8])
@@ -270,17 +285,7 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 		"amount_cents", lien.Amount.AmountCents(),
 		"transaction_id", transactionID)
 
-	// Calculate new available balance
-	activeLiensTotal, sumErr := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
-	if sumErr != nil {
-		s.logger.Error("failed to sum active liens for response", "error", sumErr)
-	}
-	availableBalance := account.Balance.AmountCents() - activeLiensTotal
-	availableMoney, moneyErr := domain.NewMoney(account.Balance.Currency(), availableBalance)
-	if moneyErr != nil {
-		s.logger.Error("failed to create available balance for response", "error", moneyErr)
-	}
-
+	availableMoney := s.calculateAvailableBalance(lien.AccountID, account.Balance)
 	return &pb.ExecuteLienResponse{
 		Lien:             toLienProto(lien),
 		NewBalance:       toMoneyAmount(account.Balance),
@@ -327,21 +332,12 @@ func (s *Service) TerminateLien(_ context.Context, req *pb.TerminateLienRequest)
 			"lien_id", lien.ID.String())
 
 		// Calculate available balance - errors logged but don't fail idempotent response
-		activeLiensTotal, sumErr := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
-		if sumErr != nil {
-			s.logger.Error("failed to sum active liens for idempotent response", "error", sumErr)
-		}
 		account, acctErr := s.repo.FindByUUID(lien.AccountID)
 		if acctErr != nil {
 			s.logger.Error("failed to find account for idempotent response", "error", acctErr)
 			return &pb.TerminateLienResponse{Lien: toLienProto(lien)}, nil
 		}
-		availableBalance := account.Balance.AmountCents() - activeLiensTotal
-		availableMoney, moneyErr := domain.NewMoney(account.Balance.Currency(), availableBalance)
-		if moneyErr != nil {
-			s.logger.Error("failed to create available balance for idempotent response", "error", moneyErr)
-		}
-
+		availableMoney := s.calculateAvailableBalance(lien.AccountID, account.Balance)
 		return &pb.TerminateLienResponse{
 			Lien:             toLienProto(lien),
 			AvailableBalance: toMoneyAmount(availableMoney),
@@ -386,16 +382,7 @@ func (s *Service) TerminateLien(_ context.Context, req *pb.TerminateLienRequest)
 		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
 	}
 
-	activeLiensTotal, sumErr := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
-	if sumErr != nil {
-		s.logger.Error("failed to sum active liens for response", "error", sumErr)
-	}
-	availableBalance := account.Balance.AmountCents() - activeLiensTotal
-	availableMoney, moneyErr := domain.NewMoney(account.Balance.Currency(), availableBalance)
-	if moneyErr != nil {
-		s.logger.Error("failed to create available balance for response", "error", moneyErr)
-	}
-
+	availableMoney := s.calculateAvailableBalance(lien.AccountID, account.Balance)
 	return &pb.TerminateLienResponse{
 		Lien:             toLienProto(lien),
 		AvailableBalance: toMoneyAmount(availableMoney),
@@ -489,4 +476,21 @@ func mapLienStatusToProto(status domain.LienStatus) pb.LienStatus {
 	default:
 		return pb.LienStatus_LIEN_STATUS_UNSPECIFIED
 	}
+}
+
+// calculateAvailableBalance calculates available balance with active liens.
+// Logs errors but returns best-effort values since primary operations already succeeded.
+func (s *Service) calculateAvailableBalance(accountID uuid.UUID, currentBalance domain.Money) domain.Money {
+	activeLiensTotal, err := s.lienRepo.SumActiveAmountByAccountID(accountID)
+	if err != nil {
+		s.logger.Error("failed to sum active liens for response", "error", err)
+		return currentBalance // Best effort: return current balance if liens can't be summed
+	}
+	availableBalance := currentBalance.AmountCents() - activeLiensTotal
+	availableMoney, err := domain.NewMoney(currentBalance.Currency(), availableBalance)
+	if err != nil {
+		s.logger.Error("failed to create available balance for response", "error", err)
+		return currentBalance // Best effort
+	}
+	return availableMoney
 }

--- a/internal/current-account/service/lien_service.go
+++ b/internal/current-account/service/lien_service.go
@@ -37,6 +37,8 @@ var (
 	errTxSumLiensFailed    = errors.New("sum_liens_failed")
 	errTxInsufficientFunds = errors.New("insufficient_funds")
 	errTxDomainError       = errors.New("domain_error")
+	errTxExecuteFailed     = errors.New("execute_failed")
+	errTxWithdrawFailed    = errors.New("withdraw_failed")
 )
 
 // Lien operation status constants for metrics
@@ -254,48 +256,47 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 		}, nil
 	}
 
-	// Validate lien can be executed
+	// Validate lien can be executed (basic check before acquiring locks)
 	if !lien.CanExecute() {
 		operationStatus = opStatusInvalidLienStatus
 		return nil, status.Errorf(codes.FailedPrecondition,
 			"lien cannot be executed: status=%s, expired=%v", lien.Status, lien.IsExpired())
 	}
 
-	// Retrieve account
-	account, err := s.repo.FindByUUID(lien.AccountID)
-	if err != nil {
-		operationStatus = opStatusRetrieveAccountFailed
-		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
-	}
-
-	// Execute lien (domain logic)
-	if err := lien.Execute(); err != nil {
-		operationStatus = opStatusExecuteFailed
-		return nil, status.Errorf(codes.FailedPrecondition, "failed to execute lien: %v", err)
-	}
-
-	// Debit the account
-	if err := account.Withdraw(lien.Amount); err != nil {
-		operationStatus = opStatusWithdrawFailed
-		return nil, status.Errorf(codes.FailedPrecondition, "failed to debit account: %v", err)
-	}
-
-	// Execute both updates atomically in a transaction to prevent double-debit on retry.
-	// If we updated lien first and account save failed, retry would see EXECUTED lien
-	// and return idempotent success without debiting - funds would never be debited.
-	// If we updated account first and lien update failed, retry would see ACTIVE lien
-	// and debit again - resulting in double-debit.
-	// Using a transaction ensures both succeed or both fail together.
+	// Execute atomically in a transaction with pessimistic locking to prevent race conditions.
+	// We need to:
+	// 1. Lock the account to prevent concurrent modifications
+	// 2. Debit the account balance
+	// 3. Update the lien status
+	// All must succeed or fail together.
+	var account *domain.CurrentAccount
 	txErr := s.repo.DB().Transaction(func(tx *gorm.DB) error {
 		txRepo := s.repo.WithTx(tx)
 		txLienRepo := s.lienRepo.WithTx(tx)
 
-		// Update lien status first (lighter operation)
+		// Retrieve account with FOR UPDATE lock to prevent concurrent modifications
+		var txErr error
+		account, txErr = txRepo.FindByUUIDForUpdate(lien.AccountID)
+		if txErr != nil {
+			return fmt.Errorf("%w: %w", errTxSaveAccount, txErr)
+		}
+
+		// Execute lien (domain logic - marks status as executed)
+		if err := lien.Execute(); err != nil {
+			return fmt.Errorf("%w: %w", errTxExecuteFailed, err)
+		}
+
+		// Debit the account
+		if err := account.Withdraw(lien.Amount); err != nil {
+			return fmt.Errorf("%w: %w", errTxWithdrawFailed, err)
+		}
+
+		// Update lien status
 		if err := txLienRepo.Update(lien); err != nil {
 			return fmt.Errorf("%w: %w", errTxUpdateLien, err)
 		}
 
-		// Save account (heavier operation with balance)
+		// Save account with balance change
 		if err := txRepo.Save(account); err != nil {
 			return fmt.Errorf("%w: %w", errTxSaveAccount, err)
 		}
@@ -305,16 +306,29 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 
 	if txErr != nil {
 		// Determine which operation failed for proper error reporting
-		if errors.Is(txErr, persistence.ErrLienVersionConflict) {
+		switch {
+		case errors.Is(txErr, persistence.ErrLienVersionConflict):
 			operationStatus = opStatusVersionConflict
 			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
-		}
-		if errors.Is(txErr, errTxSaveAccount) {
+		case errors.Is(txErr, persistence.ErrVersionConflict):
+			operationStatus = opStatusVersionConflict
+			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+		case errors.Is(txErr, errTxSaveAccount):
 			operationStatus = opStatusSaveAccountFailed
-		} else {
+			return nil, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
+		case errors.Is(txErr, errTxUpdateLien):
 			operationStatus = opStatusUpdateLienFailed
+			return nil, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
+		case errors.Is(txErr, errTxExecuteFailed):
+			operationStatus = opStatusExecuteFailed
+			return nil, status.Errorf(codes.FailedPrecondition, "failed to execute lien: %v", txErr)
+		case errors.Is(txErr, errTxWithdrawFailed):
+			operationStatus = opStatusWithdrawFailed
+			return nil, status.Errorf(codes.FailedPrecondition, "failed to debit account: %v", txErr)
+		default:
+			operationStatus = opStatusRetrieveAccountFailed
+			return nil, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
 		}
-		return nil, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
 	}
 
 	transactionID := fmt.Sprintf("TXN-LIEN-%s", lien.ID.String()[:8])

--- a/internal/current-account/service/lien_service.go
+++ b/internal/current-account/service/lien_service.go
@@ -229,7 +229,7 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 		return nil, status.Errorf(codes.InvalidArgument, "invalid lien ID: %v", err)
 	}
 
-	// Retrieve lien
+	// First, check for idempotency without locking (read-only check)
 	lien, err := s.lienRepo.FindByID(lienID)
 	if err != nil {
 		if errors.Is(err, persistence.ErrLienNotFound) {
@@ -240,47 +240,42 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 		return nil, status.Errorf(codes.Internal, "failed to retrieve lien: %v", err)
 	}
 
-	// Check if already executed (idempotent)
+	// Check if already executed (idempotent) - no transaction needed for read-only
 	if lien.Status == domain.LienStatusExecuted {
-		s.logger.Info("lien already executed (idempotent)",
-			"lien_id", lien.ID.String())
-
-		// Retrieve account for response
-		account, err := s.repo.FindByUUID(lien.AccountID)
+		s.logger.Info("lien already executed (idempotent)", "lien_id", lien.ID.String())
+		resp, err := s.buildExecuteLienIdempotentResponse(lien)
 		if err != nil {
 			operationStatus = opStatusRetrieveAccountFailed
-			return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+			return nil, err
 		}
-
-		availableMoney := s.calculateAvailableBalance(lien.AccountID, account.Balance)
-		return &pb.ExecuteLienResponse{
-			Lien:             toLienProto(lien),
-			NewBalance:       toMoneyAmount(account.Balance),
-			AvailableBalance: toMoneyAmount(availableMoney),
-			TransactionId:    fmt.Sprintf("TXN-LIEN-%s", lien.ID.String()[:8]),
-		}, nil
-	}
-
-	// Validate lien can be executed (basic check before acquiring locks)
-	if !lien.CanExecute() {
-		operationStatus = opStatusInvalidLienStatus
-		return nil, status.Errorf(codes.FailedPrecondition,
-			"lien cannot be executed: status=%s, expired=%v", lien.Status, lien.IsExpired())
+		return resp, nil
 	}
 
 	// Execute atomically in a transaction with pessimistic locking to prevent race conditions.
-	// We need to:
-	// 1. Lock the account to prevent concurrent modifications
-	// 2. Debit the account balance
-	// 3. Update the lien status
-	// All must succeed or fail together.
+	// We lock both the lien and account to prevent concurrent execute/terminate operations.
 	var account *domain.CurrentAccount
 	txErr := s.repo.DB().Transaction(func(tx *gorm.DB) error {
 		txRepo := s.repo.WithTx(tx)
 		txLienRepo := s.lienRepo.WithTx(tx)
 
-		// Retrieve account with FOR UPDATE lock to prevent concurrent modifications
+		// Retrieve lien with FOR UPDATE lock to prevent concurrent modifications
 		var txErr error
+		lien, txErr = txLienRepo.FindByIDForUpdate(lienID)
+		if txErr != nil {
+			return txErr
+		}
+
+		// Re-check if already executed (could have been executed by concurrent request)
+		if lien.Status == domain.LienStatusExecuted {
+			return nil // Will be handled as idempotent response
+		}
+
+		// Validate lien can be executed
+		if !lien.CanExecute() {
+			return errTxInvalidLienStatus
+		}
+
+		// Retrieve account with FOR UPDATE lock to prevent concurrent modifications
 		account, txErr = txRepo.FindByUUIDForUpdate(lien.AccountID)
 		if txErr != nil {
 			return fmt.Errorf("%w: %w", errTxSaveAccount, txErr)
@@ -312,12 +307,18 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 	if txErr != nil {
 		// Determine which operation failed for proper error reporting
 		switch {
+		case errors.Is(txErr, persistence.ErrLienNotFound):
+			operationStatus = opStatusLienNotFound
+			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
 		case errors.Is(txErr, persistence.ErrLienVersionConflict):
 			operationStatus = opStatusVersionConflict
 			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
 		case errors.Is(txErr, persistence.ErrVersionConflict):
 			operationStatus = opStatusVersionConflict
 			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+		case errors.Is(txErr, errTxInvalidLienStatus):
+			operationStatus = opStatusInvalidLienStatus
+			return nil, status.Errorf(codes.FailedPrecondition, "lien cannot be executed: status=%s, expired=%v", lien.Status, lien.IsExpired())
 		case errors.Is(txErr, errTxSaveAccount):
 			operationStatus = opStatusSaveAccountFailed
 			return nil, status.Errorf(codes.Internal, "failed to execute lien transaction: %v", txErr)
@@ -336,8 +337,18 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 		}
 	}
 
-	transactionID := fmt.Sprintf("TXN-LIEN-%s", lien.ID.String()[:8])
+	// Handle case where lien was already executed by concurrent request
+	if account == nil {
+		s.logger.Info("lien executed by concurrent request (idempotent)", "lien_id", lien.ID.String())
+		resp, err := s.buildExecuteLienIdempotentResponse(lien)
+		if err != nil {
+			operationStatus = opStatusRetrieveAccountFailed
+			return nil, err
+		}
+		return resp, nil
+	}
 
+	transactionID := fmt.Sprintf("TXN-LIEN-%s", lien.ID.String()[:8])
 	s.logger.Info("lien executed",
 		"lien_id", lien.ID.String(),
 		"account_id", account.AccountID,
@@ -577,6 +588,22 @@ func mapLienStatusToProto(status domain.LienStatus) pb.LienStatus {
 	default:
 		return pb.LienStatus_LIEN_STATUS_UNSPECIFIED
 	}
+}
+
+// buildExecuteLienIdempotentResponse builds an idempotent response for an already-executed lien.
+func (s *Service) buildExecuteLienIdempotentResponse(lien *domain.Lien) (*pb.ExecuteLienResponse, error) {
+	account, err := s.repo.FindByUUID(lien.AccountID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+
+	availableMoney := s.calculateAvailableBalance(lien.AccountID, account.Balance)
+	return &pb.ExecuteLienResponse{
+		Lien:             toLienProto(lien),
+		NewBalance:       toMoneyAmount(account.Balance),
+		AvailableBalance: toMoneyAmount(availableMoney),
+		TransactionId:    fmt.Sprintf("TXN-LIEN-%s", lien.ID.String()[:8]),
+	}, nil
 }
 
 // checkLienIdempotency checks if a lien with the given PaymentOrderReference already exists.

--- a/internal/current-account/service/lien_service.go
+++ b/internal/current-account/service/lien_service.go
@@ -39,7 +39,12 @@ var (
 	errTxDomainError       = errors.New("domain_error")
 	errTxExecuteFailed     = errors.New("execute_failed")
 	errTxWithdrawFailed    = errors.New("withdraw_failed")
+	errTxTerminateFailed   = errors.New("terminate_failed")
+	errTxInvalidLienStatus = errors.New("invalid_lien_status")
 )
+
+// Default termination reason when none provided
+const defaultTerminationReason = "Terminated via API"
 
 // Lien operation status constants for metrics
 const (
@@ -369,7 +374,7 @@ func (s *Service) TerminateLien(_ context.Context, req *pb.TerminateLienRequest)
 		return nil, status.Errorf(codes.InvalidArgument, "invalid lien ID: %v", err)
 	}
 
-	// Retrieve lien
+	// First, check for idempotency without locking (read-only check)
 	lien, err := s.lienRepo.FindByID(lienID)
 	if err != nil {
 		if errors.Is(err, persistence.ErrLienNotFound) {
@@ -380,7 +385,7 @@ func (s *Service) TerminateLien(_ context.Context, req *pb.TerminateLienRequest)
 		return nil, status.Errorf(codes.Internal, "failed to retrieve lien: %v", err)
 	}
 
-	// Check if already terminated (idempotent)
+	// Check if already terminated (idempotent) - no transaction needed for read-only
 	if lien.Status == domain.LienStatusTerminated {
 		s.logger.Info("lien already terminated (idempotent)",
 			"lien_id", lien.ID.String())
@@ -398,36 +403,78 @@ func (s *Service) TerminateLien(_ context.Context, req *pb.TerminateLienRequest)
 		}, nil
 	}
 
-	// Validate lien can be terminated
-	if !lien.CanTerminate() {
-		operationStatus = opStatusInvalidLienStatus
-		return nil, status.Errorf(codes.FailedPrecondition,
-			"lien cannot be terminated: status=%s", lien.Status)
-	}
-
-	// Terminate lien (domain logic)
+	// Determine termination reason
 	reason := req.Reason
 	if reason == "" {
-		reason = "Terminated via API"
-	}
-	if err := lien.Terminate(reason); err != nil {
-		operationStatus = opStatusTerminateFailed
-		return nil, status.Errorf(codes.FailedPrecondition, "failed to terminate lien: %v", err)
+		reason = defaultTerminationReason
 	}
 
-	// Update lien status
-	if err := s.lienRepo.Update(lien); err != nil {
-		if errors.Is(err, persistence.ErrLienVersionConflict) {
+	// Terminate atomically in a transaction with pessimistic locking to prevent race conditions.
+	// Without FOR UPDATE, concurrent TerminateLien calls could both pass CanTerminate() checks.
+	txErr := s.repo.DB().Transaction(func(tx *gorm.DB) error {
+		txLienRepo := s.lienRepo.WithTx(tx)
+
+		// Retrieve lien with FOR UPDATE lock to prevent concurrent modifications
+		lien, err = txLienRepo.FindByIDForUpdate(lienID)
+		if err != nil {
+			return err
+		}
+
+		// Re-check if already terminated (could have been terminated by concurrent request)
+		if lien.Status == domain.LienStatusTerminated {
+			return nil // Will be handled as idempotent response
+		}
+
+		// Validate lien can be terminated
+		if !lien.CanTerminate() {
+			return errTxInvalidLienStatus
+		}
+
+		// Terminate lien (domain logic)
+		if err := lien.Terminate(reason); err != nil {
+			return fmt.Errorf("%w: %w", errTxTerminateFailed, err)
+		}
+
+		// Update lien status
+		if err := txLienRepo.Update(lien); err != nil {
+			return fmt.Errorf("%w: %w", errTxUpdateLien, err)
+		}
+
+		return nil
+	})
+
+	if txErr != nil {
+		switch {
+		case errors.Is(txErr, persistence.ErrLienNotFound):
+			operationStatus = opStatusLienNotFound
+			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
+		case errors.Is(txErr, persistence.ErrLienVersionConflict):
 			operationStatus = opStatusVersionConflict
 			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+		case errors.Is(txErr, errTxInvalidLienStatus):
+			operationStatus = opStatusInvalidLienStatus
+			return nil, status.Errorf(codes.FailedPrecondition, "lien cannot be terminated: status=%s", lien.Status)
+		case errors.Is(txErr, errTxTerminateFailed):
+			operationStatus = opStatusTerminateFailed
+			return nil, status.Errorf(codes.FailedPrecondition, "failed to terminate lien: %v", txErr)
+		case errors.Is(txErr, errTxUpdateLien):
+			operationStatus = opStatusUpdateFailed
+			return nil, status.Errorf(codes.Internal, "failed to update lien: %v", txErr)
+		default:
+			operationStatus = opStatusRetrieveFailed
+			return nil, status.Errorf(codes.Internal, "failed to terminate lien: %v", txErr)
 		}
-		operationStatus = opStatusUpdateFailed
-		return nil, status.Errorf(codes.Internal, "failed to update lien: %v", err)
 	}
 
-	s.logger.Info("lien terminated",
-		"lien_id", lien.ID.String(),
-		"reason", reason)
+	// Handle case where lien was already terminated by concurrent request
+	if lien.Status == domain.LienStatusTerminated && lien.TerminationReason != reason {
+		s.logger.Info("lien terminated by concurrent request (idempotent)",
+			"lien_id", lien.ID.String())
+	} else {
+		s.logger.Info("lien terminated",
+			"lien_id", lien.ID.String(),
+			"reason", reason)
+	}
 
 	// Calculate new available balance (funds released)
 	account, err := s.repo.FindByUUID(lien.AccountID)

--- a/internal/current-account/service/lien_service.go
+++ b/internal/current-account/service/lien_service.go
@@ -1,0 +1,455 @@
+// Package service implements gRPC services for the current account domain
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/meridianhub/meridian/internal/current-account/adapters/persistence"
+	"github.com/meridianhub/meridian/internal/current-account/domain"
+	caobservability "github.com/meridianhub/meridian/internal/current-account/observability"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Lien-specific errors
+var (
+	ErrLienRepositoryNil     = errors.New("lien repository cannot be nil")
+	ErrInsufficientFunds     = errors.New("insufficient available balance for lien")
+	ErrLienCurrencyMismatch  = errors.New("lien currency must match account currency")
+	ErrLienAmountNotPositive = errors.New("lien amount must be positive")
+	ErrAmountRequired        = errors.New("amount is required")
+	ErrAmountOverflow        = errors.New("amount too large: would overflow")
+)
+
+// Lien operation status constants for metrics
+const (
+	opStatusLienRepoNil           = "lien_repo_nil"
+	opStatusInvalidLienID         = "invalid_lien_id"
+	opStatusLienNotFound          = "lien_not_found"
+	opStatusRetrieveAccountFailed = "retrieve_account_failed"
+	opStatusAccountNotFound       = "account_not_found"
+	opStatusRetrieveFailed        = "retrieve_failed"
+	opStatusAccountNotActive      = "account_not_active"
+	opStatusInvalidAmount         = "invalid_amount"
+	opStatusCurrencyMismatch      = "currency_mismatch"
+	opStatusSumLiensFailed        = "sum_liens_failed"
+	opStatusInsufficientFunds     = "insufficient_funds"
+	opStatusDomainError           = "domain_error"
+	opStatusSaveFailed            = "save_failed"
+	opStatusInvalidLienStatus     = "invalid_lien_status"
+	opStatusExecuteFailed         = "execute_failed"
+	opStatusWithdrawFailed        = "withdraw_failed"
+	opStatusVersionConflict       = "version_conflict"
+	opStatusUpdateLienFailed      = "update_lien_failed"
+	opStatusSaveAccountFailed     = "save_account_failed"
+	opStatusTerminateFailed       = "terminate_failed"
+	opStatusUpdateFailed          = "update_failed"
+)
+
+// InitiateLien creates a fund reservation on an account
+func (s *Service) InitiateLien(_ context.Context, req *pb.InitiateLienRequest) (*pb.InitiateLienResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		caobservability.RecordOperationDuration("initiate_lien", operationStatus, time.Since(start))
+	}()
+
+	// Validate lien repository is configured
+	if s.lienRepo == nil {
+		operationStatus = opStatusLienRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
+	}
+
+	// Retrieve account
+	account, err := s.repo.FindByID(req.AccountId)
+	if err != nil {
+		if errors.Is(err, persistence.ErrAccountNotFound) {
+			operationStatus = opStatusAccountNotFound
+			return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
+		}
+		operationStatus = opStatusRetrieveFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+
+	// Validate account is active
+	if account.Status != domain.AccountStatusActive {
+		operationStatus = opStatusAccountNotActive
+		return nil, status.Errorf(codes.FailedPrecondition, "account is not active: %s", account.Status)
+	}
+
+	// Convert and validate amount
+	lienAmount, err := s.protoToMoney(req.Amount)
+	if err != nil {
+		operationStatus = opStatusInvalidAmount
+		return nil, status.Errorf(codes.InvalidArgument, "invalid amount: %v", err)
+	}
+
+	if !lienAmount.IsPositive() {
+		operationStatus = opStatusInvalidAmount
+		return nil, status.Error(codes.InvalidArgument, "lien amount must be positive")
+	}
+
+	// Validate currency matches account
+	if lienAmount.Currency() != account.Balance.Currency() {
+		operationStatus = opStatusCurrencyMismatch
+		return nil, status.Errorf(codes.InvalidArgument,
+			"lien currency (%s) must match account currency (%s)",
+			lienAmount.Currency(), account.Balance.Currency())
+	}
+
+	// Calculate available balance
+	activeLiensTotal, err := s.lienRepo.SumActiveAmountByAccountID(account.ID)
+	if err != nil {
+		operationStatus = opStatusSumLiensFailed
+		return nil, status.Errorf(codes.Internal, "failed to calculate active liens: %v", err)
+	}
+
+	// Available = Current Balance - Active Liens
+	availableBalance := account.Balance.AmountCents() - activeLiensTotal
+
+	// Check sufficient funds
+	if lienAmount.AmountCents() > availableBalance {
+		operationStatus = opStatusInsufficientFunds
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"insufficient available balance: requested %d cents, available %d cents",
+			lienAmount.AmountCents(), availableBalance)
+	}
+
+	// Create lien domain object
+	lien, err := domain.NewLien(account.ID, lienAmount, req.PaymentOrderReference, nil)
+	if err != nil {
+		operationStatus = opStatusDomainError
+		return nil, status.Errorf(codes.InvalidArgument, "failed to create lien: %v", err)
+	}
+
+	// Persist lien
+	if err := s.lienRepo.Create(lien); err != nil {
+		operationStatus = opStatusSaveFailed
+		return nil, status.Errorf(codes.Internal, "failed to save lien: %v", err)
+	}
+
+	s.logger.Info("lien created",
+		"lien_id", lien.ID.String(),
+		"account_id", account.AccountID,
+		"amount_cents", lienAmount.AmountCents(),
+		"payment_order_ref", req.PaymentOrderReference)
+
+	// Calculate new available balance after this lien
+	newAvailableBalance := availableBalance - lienAmount.AmountCents()
+	availableMoney, _ := domain.NewMoney(account.Balance.Currency(), newAvailableBalance)
+
+	return &pb.InitiateLienResponse{
+		Lien:             toLienProto(lien),
+		AvailableBalance: toMoneyAmount(availableMoney),
+	}, nil
+}
+
+// ExecuteLien converts a reservation to an actual debit atomically
+func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*pb.ExecuteLienResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		caobservability.RecordOperationDuration("execute_lien", operationStatus, time.Since(start))
+	}()
+
+	// Validate lien repository is configured
+	if s.lienRepo == nil {
+		operationStatus = opStatusLienRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
+	}
+
+	// Parse lien ID
+	lienID, err := uuid.Parse(req.LienId)
+	if err != nil {
+		operationStatus = opStatusInvalidLienID
+		return nil, status.Errorf(codes.InvalidArgument, "invalid lien ID: %v", err)
+	}
+
+	// Retrieve lien
+	lien, err := s.lienRepo.FindByID(lienID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrLienNotFound) {
+			operationStatus = opStatusLienNotFound
+			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
+		}
+		operationStatus = opStatusRetrieveFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve lien: %v", err)
+	}
+
+	// Check if already executed (idempotent)
+	if lien.Status == domain.LienStatusExecuted {
+		s.logger.Info("lien already executed (idempotent)",
+			"lien_id", lien.ID.String())
+
+		// Retrieve account for response
+		account, err := s.repo.FindByUUID(lien.AccountID)
+		if err != nil {
+			operationStatus = opStatusRetrieveAccountFailed
+			return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+		}
+
+		activeLiensTotal, _ := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
+		availableBalance := account.Balance.AmountCents() - activeLiensTotal
+		availableMoney, _ := domain.NewMoney(account.Balance.Currency(), availableBalance)
+
+		return &pb.ExecuteLienResponse{
+			Lien:             toLienProto(lien),
+			NewBalance:       toMoneyAmount(account.Balance),
+			AvailableBalance: toMoneyAmount(availableMoney),
+			TransactionId:    fmt.Sprintf("TXN-LIEN-%s", lien.ID.String()[:8]),
+		}, nil
+	}
+
+	// Validate lien can be executed
+	if !lien.CanExecute() {
+		operationStatus = opStatusInvalidLienStatus
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"lien cannot be executed: status=%s, expired=%v", lien.Status, lien.IsExpired())
+	}
+
+	// Retrieve account
+	account, err := s.repo.FindByUUID(lien.AccountID)
+	if err != nil {
+		operationStatus = opStatusRetrieveAccountFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+
+	// Execute lien (domain logic)
+	if err := lien.Execute(); err != nil {
+		operationStatus = opStatusExecuteFailed
+		return nil, status.Errorf(codes.FailedPrecondition, "failed to execute lien: %v", err)
+	}
+
+	// Debit the account
+	if err := account.Withdraw(lien.Amount); err != nil {
+		operationStatus = opStatusWithdrawFailed
+		return nil, status.Errorf(codes.FailedPrecondition, "failed to debit account: %v", err)
+	}
+
+	// Update lien status
+	if err := s.lienRepo.Update(lien); err != nil {
+		if errors.Is(err, persistence.ErrLienVersionConflict) {
+			operationStatus = opStatusVersionConflict
+			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+		}
+		operationStatus = opStatusUpdateLienFailed
+		return nil, status.Errorf(codes.Internal, "failed to update lien: %v", err)
+	}
+
+	// Save account
+	if err := s.repo.Save(account); err != nil {
+		operationStatus = opStatusSaveAccountFailed
+		return nil, status.Errorf(codes.Internal, "failed to save account: %v", err)
+	}
+
+	transactionID := fmt.Sprintf("TXN-LIEN-%s", lien.ID.String()[:8])
+
+	s.logger.Info("lien executed",
+		"lien_id", lien.ID.String(),
+		"account_id", account.AccountID,
+		"amount_cents", lien.Amount.AmountCents(),
+		"transaction_id", transactionID)
+
+	// Calculate new available balance
+	activeLiensTotal, _ := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
+	availableBalance := account.Balance.AmountCents() - activeLiensTotal
+	availableMoney, _ := domain.NewMoney(account.Balance.Currency(), availableBalance)
+
+	return &pb.ExecuteLienResponse{
+		Lien:             toLienProto(lien),
+		NewBalance:       toMoneyAmount(account.Balance),
+		AvailableBalance: toMoneyAmount(availableMoney),
+		TransactionId:    transactionID,
+	}, nil
+}
+
+// TerminateLien releases a reservation without executing
+func (s *Service) TerminateLien(_ context.Context, req *pb.TerminateLienRequest) (*pb.TerminateLienResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		caobservability.RecordOperationDuration("terminate_lien", operationStatus, time.Since(start))
+	}()
+
+	// Validate lien repository is configured
+	if s.lienRepo == nil {
+		operationStatus = opStatusLienRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
+	}
+
+	// Parse lien ID
+	lienID, err := uuid.Parse(req.LienId)
+	if err != nil {
+		operationStatus = opStatusInvalidLienID
+		return nil, status.Errorf(codes.InvalidArgument, "invalid lien ID: %v", err)
+	}
+
+	// Retrieve lien
+	lien, err := s.lienRepo.FindByID(lienID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrLienNotFound) {
+			operationStatus = opStatusLienNotFound
+			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
+		}
+		operationStatus = opStatusRetrieveFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve lien: %v", err)
+	}
+
+	// Check if already terminated (idempotent)
+	if lien.Status == domain.LienStatusTerminated {
+		s.logger.Info("lien already terminated (idempotent)",
+			"lien_id", lien.ID.String())
+
+		// Calculate available balance
+		activeLiensTotal, _ := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
+		account, _ := s.repo.FindByUUID(lien.AccountID)
+		availableBalance := account.Balance.AmountCents() - activeLiensTotal
+		availableMoney, _ := domain.NewMoney(account.Balance.Currency(), availableBalance)
+
+		return &pb.TerminateLienResponse{
+			Lien:             toLienProto(lien),
+			AvailableBalance: toMoneyAmount(availableMoney),
+		}, nil
+	}
+
+	// Validate lien can be terminated
+	if !lien.CanTerminate() {
+		operationStatus = opStatusInvalidLienStatus
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"lien cannot be terminated: status=%s", lien.Status)
+	}
+
+	// Terminate lien (domain logic)
+	reason := req.Reason
+	if reason == "" {
+		reason = "Terminated via API"
+	}
+	if err := lien.Terminate(reason); err != nil {
+		operationStatus = opStatusTerminateFailed
+		return nil, status.Errorf(codes.FailedPrecondition, "failed to terminate lien: %v", err)
+	}
+
+	// Update lien status
+	if err := s.lienRepo.Update(lien); err != nil {
+		if errors.Is(err, persistence.ErrLienVersionConflict) {
+			operationStatus = opStatusVersionConflict
+			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+		}
+		operationStatus = opStatusUpdateFailed
+		return nil, status.Errorf(codes.Internal, "failed to update lien: %v", err)
+	}
+
+	s.logger.Info("lien terminated",
+		"lien_id", lien.ID.String(),
+		"reason", reason)
+
+	// Calculate new available balance (funds released)
+	account, err := s.repo.FindByUUID(lien.AccountID)
+	if err != nil {
+		operationStatus = opStatusRetrieveAccountFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+
+	activeLiensTotal, _ := s.lienRepo.SumActiveAmountByAccountID(lien.AccountID)
+	availableBalance := account.Balance.AmountCents() - activeLiensTotal
+	availableMoney, _ := domain.NewMoney(account.Balance.Currency(), availableBalance)
+
+	return &pb.TerminateLienResponse{
+		Lien:             toLienProto(lien),
+		AvailableBalance: toMoneyAmount(availableMoney),
+	}, nil
+}
+
+// RetrieveLien gets lien details
+func (s *Service) RetrieveLien(_ context.Context, req *pb.RetrieveLienRequest) (*pb.RetrieveLienResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		caobservability.RecordOperationDuration("retrieve_lien", operationStatus, time.Since(start))
+	}()
+
+	// Validate lien repository is configured
+	if s.lienRepo == nil {
+		operationStatus = opStatusLienRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
+	}
+
+	// Parse lien ID
+	lienID, err := uuid.Parse(req.LienId)
+	if err != nil {
+		operationStatus = opStatusInvalidLienID
+		return nil, status.Errorf(codes.InvalidArgument, "invalid lien ID: %v", err)
+	}
+
+	// Retrieve lien
+	lien, err := s.lienRepo.FindByID(lienID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrLienNotFound) {
+			operationStatus = opStatusLienNotFound
+			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
+		}
+		operationStatus = opStatusRetrieveFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve lien: %v", err)
+	}
+
+	return &pb.RetrieveLienResponse{
+		Lien: toLienProto(lien),
+	}, nil
+}
+
+// Helper functions for lien service
+
+// protoToMoney converts a proto MoneyAmount to domain Money
+func (s *Service) protoToMoney(amount *commonpb.MoneyAmount) (domain.Money, error) {
+	if amount == nil || amount.Amount == nil {
+		return domain.Money{}, ErrAmountRequired
+	}
+
+	// Validate overflow
+	if amount.Amount.Units > math.MaxInt64/100 || amount.Amount.Units < math.MinInt64/100 {
+		return domain.Money{}, ErrAmountOverflow
+	}
+
+	// Convert to cents
+	unitsCents := amount.Amount.Units * 100
+	nanosCents := (amount.Amount.Nanos + 5000000) / 10000000
+
+	totalCents := unitsCents + int64(nanosCents)
+
+	return domain.NewMoney(amount.Amount.CurrencyCode, totalCents)
+}
+
+// toLienProto converts a domain Lien to proto Lien
+func toLienProto(lien *domain.Lien) *pb.Lien {
+	return &pb.Lien{
+		LienId:                lien.ID.String(),
+		AccountId:             lien.AccountID.String(),
+		Amount:                toMoneyAmount(lien.Amount),
+		Status:                mapLienStatusToProto(lien.Status),
+		PaymentOrderReference: lien.PaymentOrderReference,
+		CreatedAt:             timestamppb.New(lien.CreatedAt),
+		UpdatedAt:             timestamppb.New(lien.UpdatedAt),
+	}
+}
+
+// mapLienStatusToProto maps domain LienStatus to proto LienStatus
+func mapLienStatusToProto(status domain.LienStatus) pb.LienStatus {
+	switch status {
+	case domain.LienStatusActive:
+		return pb.LienStatus_LIEN_STATUS_ACTIVE
+	case domain.LienStatusExecuted:
+		return pb.LienStatus_LIEN_STATUS_EXECUTED
+	case domain.LienStatusTerminated:
+		return pb.LienStatus_LIEN_STATUS_TERMINATED
+	default:
+		return pb.LienStatus_LIEN_STATUS_UNSPECIFIED
+	}
+}

--- a/internal/current-account/service/lien_service.go
+++ b/internal/current-account/service/lien_service.go
@@ -29,8 +29,14 @@ var (
 	ErrAmountRequired        = errors.New("amount is required")
 	ErrAmountOverflow        = errors.New("amount too large: would overflow")
 	// Transaction operation errors for error detection
-	errTxSaveAccount = errors.New("save_account")
-	errTxUpdateLien  = errors.New("update_lien")
+	errTxSaveAccount       = errors.New("save_account")
+	errTxUpdateLien        = errors.New("update_lien")
+	errTxSaveLien          = errors.New("save_lien")
+	errTxAccountNotActive  = errors.New("account_not_active")
+	errTxCurrencyMismatch  = errors.New("currency_mismatch")
+	errTxSumLiensFailed    = errors.New("sum_liens_failed")
+	errTxInsufficientFunds = errors.New("insufficient_funds")
+	errTxDomainError       = errors.New("domain_error")
 )
 
 // Lien operation status constants for metrics
@@ -73,51 +79,14 @@ func (s *Service) InitiateLien(_ context.Context, req *pb.InitiateLienRequest) (
 	}
 
 	// Check for idempotency using PaymentOrderReference
-	if req.PaymentOrderReference != "" {
-		existingLien, err := s.lienRepo.FindByPaymentOrderReference(req.PaymentOrderReference)
-		if err == nil && existingLien != nil {
-			// Lien already exists - return idempotent response
-			s.logger.Info("lien already exists (idempotent)",
-				"lien_id", existingLien.ID.String(),
-				"payment_order_ref", req.PaymentOrderReference)
-
-			// Retrieve account for available balance calculation
-			account, acctErr := s.repo.FindByUUID(existingLien.AccountID)
-			if acctErr != nil {
-				s.logger.Error("failed to retrieve account for idempotent response", "error", acctErr)
-				return &pb.InitiateLienResponse{Lien: toLienProto(existingLien)}, nil
-			}
-			availableMoney := s.calculateAvailableBalance(existingLien.AccountID, account.Balance)
-			return &pb.InitiateLienResponse{
-				Lien:             toLienProto(existingLien),
-				AvailableBalance: toMoneyAmount(availableMoney),
-			}, nil
-		}
-		// If ErrLienNotFound, continue with creation. Other errors should fail.
-		if err != nil && !errors.Is(err, persistence.ErrLienNotFound) {
-			operationStatus = opStatusRetrieveFailed
-			return nil, status.Errorf(codes.Internal, "failed to check idempotency: %v", err)
-		}
-	}
-
-	// Retrieve account
-	account, err := s.repo.FindByID(req.AccountId)
-	if err != nil {
-		if errors.Is(err, persistence.ErrAccountNotFound) {
-			operationStatus = opStatusAccountNotFound
-			return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
-		}
+	if idempotentResp, found, err := s.checkLienIdempotency(req.PaymentOrderReference); err != nil {
 		operationStatus = opStatusRetrieveFailed
-		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+		return nil, err
+	} else if found {
+		return idempotentResp, nil
 	}
 
-	// Validate account is active
-	if account.Status != domain.AccountStatusActive {
-		operationStatus = opStatusAccountNotActive
-		return nil, status.Errorf(codes.FailedPrecondition, "account is not active: %s", account.Status)
-	}
-
-	// Convert and validate amount
+	// Convert and validate amount first (before transaction)
 	lienAmount, err := s.protoToMoney(req.Amount)
 	if err != nil {
 		operationStatus = opStatusInvalidAmount
@@ -129,43 +98,87 @@ func (s *Service) InitiateLien(_ context.Context, req *pb.InitiateLienRequest) (
 		return nil, status.Error(codes.InvalidArgument, "lien amount must be positive")
 	}
 
-	// Validate currency matches account
-	if lienAmount.Currency() != account.Balance.Currency() {
-		operationStatus = opStatusCurrencyMismatch
-		return nil, status.Errorf(codes.InvalidArgument,
-			"lien currency (%s) must match account currency (%s)",
-			lienAmount.Currency(), account.Balance.Currency())
-	}
+	// Use a transaction with pessimistic locking to prevent race conditions.
+	// Without FOR UPDATE, concurrent InitiateLien calls could both check available
+	// balance, see sufficient funds, and both create liens - resulting in over-reservation.
+	var lien *domain.Lien
+	var account *domain.CurrentAccount
+	var availableBalance int64
 
-	// Calculate available balance
-	activeLiensTotal, err := s.lienRepo.SumActiveAmountByAccountID(account.ID)
-	if err != nil {
-		operationStatus = opStatusSumLiensFailed
-		return nil, status.Errorf(codes.Internal, "failed to calculate active liens: %v", err)
-	}
+	txErr := s.repo.DB().Transaction(func(tx *gorm.DB) error {
+		txRepo := s.repo.WithTx(tx)
+		txLienRepo := s.lienRepo.WithTx(tx)
 
-	// Available = Current Balance - Active Liens
-	availableBalance := account.Balance.AmountCents() - activeLiensTotal
+		// Retrieve account with FOR UPDATE lock to prevent concurrent modifications
+		var txErr error
+		account, txErr = txRepo.FindByIDForUpdate(req.AccountId)
+		if txErr != nil {
+			return txErr
+		}
 
-	// Check sufficient funds
-	if lienAmount.AmountCents() > availableBalance {
-		operationStatus = opStatusInsufficientFunds
-		return nil, status.Errorf(codes.FailedPrecondition,
-			"insufficient available balance: requested %d cents, available %d cents",
-			lienAmount.AmountCents(), availableBalance)
-	}
+		// Validate account is active
+		if account.Status != domain.AccountStatusActive {
+			return errTxAccountNotActive
+		}
 
-	// Create lien domain object
-	lien, err := domain.NewLien(account.ID, lienAmount, req.PaymentOrderReference, nil)
-	if err != nil {
-		operationStatus = opStatusDomainError
-		return nil, status.Errorf(codes.InvalidArgument, "failed to create lien: %v", err)
-	}
+		// Validate currency matches account
+		if lienAmount.Currency() != account.Balance.Currency() {
+			return errTxCurrencyMismatch
+		}
 
-	// Persist lien
-	if err := s.lienRepo.Create(lien); err != nil {
-		operationStatus = opStatusSaveFailed
-		return nil, status.Errorf(codes.Internal, "failed to save lien: %v", err)
+		// Calculate available balance (within the lock)
+		activeLiensTotal, err := txLienRepo.SumActiveAmountByAccountID(account.ID)
+		if err != nil {
+			return fmt.Errorf("%w: %w", errTxSumLiensFailed, err)
+		}
+
+		// Available = Current Balance - Active Liens
+		availableBalance = account.Balance.AmountCents() - activeLiensTotal
+
+		// Check sufficient funds
+		if lienAmount.AmountCents() > availableBalance {
+			return errTxInsufficientFunds
+		}
+
+		// Create lien domain object
+		lien, err = domain.NewLien(account.ID, lienAmount, req.PaymentOrderReference, nil)
+		if err != nil {
+			return fmt.Errorf("%w: %w", errTxDomainError, err)
+		}
+
+		// Persist lien (within the transaction)
+		if err := txLienRepo.Create(lien); err != nil {
+			return fmt.Errorf("%w: %w", errTxSaveLien, err)
+		}
+
+		return nil
+	})
+
+	// Handle transaction errors with appropriate status codes
+	if txErr != nil {
+		switch {
+		case errors.Is(txErr, persistence.ErrAccountNotFound):
+			operationStatus = opStatusAccountNotFound
+			return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
+		case errors.Is(txErr, errTxAccountNotActive):
+			operationStatus = opStatusAccountNotActive
+			return nil, status.Errorf(codes.FailedPrecondition, "account is not active")
+		case errors.Is(txErr, errTxCurrencyMismatch):
+			operationStatus = opStatusCurrencyMismatch
+			return nil, status.Errorf(codes.InvalidArgument, "lien currency must match account currency")
+		case errors.Is(txErr, errTxInsufficientFunds):
+			operationStatus = opStatusInsufficientFunds
+			return nil, status.Errorf(codes.FailedPrecondition, "insufficient available balance")
+		case errors.Is(txErr, errTxDomainError):
+			operationStatus = opStatusDomainError
+			return nil, status.Errorf(codes.InvalidArgument, "failed to create lien: %v", txErr)
+		case errors.Is(txErr, errTxSaveLien):
+			operationStatus = opStatusSaveFailed
+			return nil, status.Errorf(codes.Internal, "failed to save lien: %v", txErr)
+		default:
+			operationStatus = opStatusRetrieveFailed
+			return nil, status.Errorf(codes.Internal, "failed to create lien: %v", txErr)
+		}
 	}
 
 	s.logger.Info("lien created",
@@ -503,6 +516,40 @@ func mapLienStatusToProto(status domain.LienStatus) pb.LienStatus {
 	default:
 		return pb.LienStatus_LIEN_STATUS_UNSPECIFIED
 	}
+}
+
+// checkLienIdempotency checks if a lien with the given PaymentOrderReference already exists.
+// Returns (response, true) if idempotent response should be returned, (nil, false) otherwise.
+// Returns error status if a non-recoverable error occurs.
+func (s *Service) checkLienIdempotency(paymentOrderRef string) (*pb.InitiateLienResponse, bool, error) {
+	if paymentOrderRef == "" {
+		return nil, false, nil
+	}
+
+	existingLien, err := s.lienRepo.FindByPaymentOrderReference(paymentOrderRef)
+	if err != nil {
+		if errors.Is(err, persistence.ErrLienNotFound) {
+			return nil, false, nil // Not found - continue with creation
+		}
+		return nil, false, status.Errorf(codes.Internal, "failed to check idempotency: %v", err)
+	}
+
+	// Lien already exists - return idempotent response
+	s.logger.Info("lien already exists (idempotent)",
+		"lien_id", existingLien.ID.String(),
+		"payment_order_ref", paymentOrderRef)
+
+	// Retrieve account for available balance calculation
+	account, acctErr := s.repo.FindByUUID(existingLien.AccountID)
+	if acctErr != nil {
+		s.logger.Error("failed to retrieve account for idempotent response", "error", acctErr)
+		return &pb.InitiateLienResponse{Lien: toLienProto(existingLien)}, true, nil
+	}
+	availableMoney := s.calculateAvailableBalance(existingLien.AccountID, account.Balance)
+	return &pb.InitiateLienResponse{
+		Lien:             toLienProto(existingLien),
+		AvailableBalance: toMoneyAmount(availableMoney),
+	}, true, nil
 }
 
 // calculateAvailableBalance calculates available balance with active liens.

--- a/internal/current-account/service/lien_service.go
+++ b/internal/current-account/service/lien_service.go
@@ -28,6 +28,9 @@ var (
 	ErrLienAmountNotPositive = errors.New("lien amount must be positive")
 	ErrAmountRequired        = errors.New("amount is required")
 	ErrAmountOverflow        = errors.New("amount too large: would overflow")
+	// Transaction operation errors for error detection
+	errTxSaveAccount = errors.New("save_account")
+	errTxUpdateLien  = errors.New("update_lien")
 )
 
 // Lien operation status constants for metrics
@@ -67,6 +70,34 @@ func (s *Service) InitiateLien(_ context.Context, req *pb.InitiateLienRequest) (
 	if s.lienRepo == nil {
 		operationStatus = opStatusLienRepoNil
 		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
+	}
+
+	// Check for idempotency using PaymentOrderReference
+	if req.PaymentOrderReference != "" {
+		existingLien, err := s.lienRepo.FindByPaymentOrderReference(req.PaymentOrderReference)
+		if err == nil && existingLien != nil {
+			// Lien already exists - return idempotent response
+			s.logger.Info("lien already exists (idempotent)",
+				"lien_id", existingLien.ID.String(),
+				"payment_order_ref", req.PaymentOrderReference)
+
+			// Retrieve account for available balance calculation
+			account, acctErr := s.repo.FindByUUID(existingLien.AccountID)
+			if acctErr != nil {
+				s.logger.Error("failed to retrieve account for idempotent response", "error", acctErr)
+				return &pb.InitiateLienResponse{Lien: toLienProto(existingLien)}, nil
+			}
+			availableMoney := s.calculateAvailableBalance(existingLien.AccountID, account.Balance)
+			return &pb.InitiateLienResponse{
+				Lien:             toLienProto(existingLien),
+				AvailableBalance: toMoneyAmount(availableMoney),
+			}, nil
+		}
+		// If ErrLienNotFound, continue with creation. Other errors should fail.
+		if err != nil && !errors.Is(err, persistence.ErrLienNotFound) {
+			operationStatus = opStatusRetrieveFailed
+			return nil, status.Errorf(codes.Internal, "failed to check idempotency: %v", err)
+		}
 	}
 
 	// Retrieve account
@@ -248,28 +279,24 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 
 		// Update lien status first (lighter operation)
 		if err := txLienRepo.Update(lien); err != nil {
-			if errors.Is(err, persistence.ErrLienVersionConflict) {
-				return fmt.Errorf("version_conflict: %w", err)
-			}
-			return fmt.Errorf("update_lien: %w", err)
+			return fmt.Errorf("%w: %w", errTxUpdateLien, err)
 		}
 
 		// Save account (heavier operation with balance)
 		if err := txRepo.Save(account); err != nil {
-			return fmt.Errorf("save_account: %w", err)
+			return fmt.Errorf("%w: %w", errTxSaveAccount, err)
 		}
 
 		return nil
 	})
 
 	if txErr != nil {
+		// Determine which operation failed for proper error reporting
 		if errors.Is(txErr, persistence.ErrLienVersionConflict) {
 			operationStatus = opStatusVersionConflict
 			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
 		}
-		// Determine which operation failed for proper error reporting
-		errStr := txErr.Error()
-		if len(errStr) > 12 && errStr[:12] == "save_account" {
+		if errors.Is(txErr, errTxSaveAccount) {
 			operationStatus = opStatusSaveAccountFailed
 		} else {
 			operationStatus = opStatusUpdateLienFailed

--- a/internal/current-account/service/lien_service.go
+++ b/internal/current-account/service/lien_service.go
@@ -244,7 +244,15 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 		return nil, status.Errorf(codes.FailedPrecondition, "failed to debit account: %v", err)
 	}
 
-	// Update lien status
+	// Save account first - this is the critical operation
+	// If this fails, no state has changed. If lien update fails after,
+	// the next idempotent retry will complete the lien status update.
+	if err := s.repo.Save(account); err != nil {
+		operationStatus = opStatusSaveAccountFailed
+		return nil, status.Errorf(codes.Internal, "failed to save account: %v", err)
+	}
+
+	// Update lien status (after account is safely persisted)
 	if err := s.lienRepo.Update(lien); err != nil {
 		if errors.Is(err, persistence.ErrLienVersionConflict) {
 			operationStatus = opStatusVersionConflict
@@ -252,12 +260,6 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 		}
 		operationStatus = opStatusUpdateLienFailed
 		return nil, status.Errorf(codes.Internal, "failed to update lien: %v", err)
-	}
-
-	// Save account
-	if err := s.repo.Save(account); err != nil {
-		operationStatus = opStatusSaveAccountFailed
-		return nil, status.Errorf(codes.Internal, "failed to save account: %v", err)
 	}
 
 	transactionID := fmt.Sprintf("TXN-LIEN-%s", lien.ID.String()[:8])
@@ -445,15 +447,18 @@ func (s *Service) protoToMoney(amount *commonpb.MoneyAmount) (domain.Money, erro
 		return domain.Money{}, ErrAmountRequired
 	}
 
-	// Validate overflow
+	// Validate units won't overflow when multiplied by 100
 	if amount.Amount.Units > math.MaxInt64/100 || amount.Amount.Units < math.MinInt64/100 {
 		return domain.Money{}, ErrAmountOverflow
 	}
 
 	// Convert to cents
+	// unitsCents is safe due to overflow check above
 	unitsCents := amount.Amount.Units * 100
-	nanosCents := (amount.Amount.Nanos + 5000000) / 10000000
 
+	// nanosCents is at most 99 (nanos range 0-999999999, divided by 10000000)
+	// Adding to unitsCents is safe since we checked unitsCents won't overflow
+	nanosCents := (amount.Amount.Nanos + 5000000) / 10000000
 	totalCents := unitsCents + int64(nanosCents)
 
 	return domain.NewMoney(amount.Amount.CurrencyCode, totalCents)

--- a/internal/current-account/service/lien_service_test.go
+++ b/internal/current-account/service/lien_service_test.go
@@ -1,0 +1,474 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/meridianhub/meridian/internal/current-account/adapters/persistence"
+	"github.com/meridianhub/meridian/internal/current-account/domain"
+	"github.com/meridianhub/meridian/internal/platform/testdb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/money"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+func setupLienTestDB(t *testing.T) (*gorm.DB, func()) {
+	t.Helper()
+	return testdb.SetupPostgres(t, []interface{}{
+		&persistence.CurrentAccountEntity{},
+		&persistence.LienEntity{},
+	})
+}
+
+func createTestAccountWithBalance(t *testing.T, repo *persistence.Repository, accountID string, balanceCents int64) *domain.CurrentAccount {
+	t.Helper()
+	account, err := domain.NewCurrentAccount(accountID, "GB82WEST12345698765432", "CUST-001", "GBP")
+	require.NoError(t, err)
+
+	if balanceCents > 0 {
+		depositAmount, err := domain.NewMoney("GBP", balanceCents)
+		require.NoError(t, err)
+		require.NoError(t, account.Deposit(depositAmount))
+	}
+
+	require.NoError(t, repo.Save(account))
+	return account
+}
+
+func TestInitiateLien_Success(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	// Create account with £1000 balance
+	createTestAccountWithBalance(t, repo, "ACC-LIEN-001", 100000) // 100000 cents = £1000
+
+	req := &pb.InitiateLienRequest{
+		AccountId: "ACC-LIEN-001",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        500,
+				Nanos:        0, // £500
+			},
+		},
+		PaymentOrderReference: "PO-123",
+	}
+
+	resp, err := svc.InitiateLien(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Lien)
+	require.NotEmpty(t, resp.Lien.LienId)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_ACTIVE, resp.Lien.Status)
+	require.Equal(t, "PO-123", resp.Lien.PaymentOrderReference)
+
+	// Available balance should be £500 (£1000 - £500 lien)
+	require.Equal(t, int64(500), resp.AvailableBalance.Amount.Units)
+}
+
+func TestInitiateLien_InsufficientFunds(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	// Create account with £100 balance
+	createTestAccountWithBalance(t, repo, "ACC-LIEN-002", 10000) // £100
+
+	req := &pb.InitiateLienRequest{
+		AccountId: "ACC-LIEN-002",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        500,
+				Nanos:        0, // £500 - more than available
+			},
+		},
+		PaymentOrderReference: "PO-124",
+	}
+
+	_, err := svc.InitiateLien(context.Background(), req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+	require.Contains(t, st.Message(), "insufficient available balance")
+}
+
+func TestInitiateLien_AccountNotFound(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	req := &pb.InitiateLienRequest{
+		AccountId: "NON-EXISTENT-ACC",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        100,
+				Nanos:        0,
+			},
+		},
+		PaymentOrderReference: "PO-125",
+	}
+
+	_, err := svc.InitiateLien(context.Background(), req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestInitiateLien_CurrencyMismatch(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	// Create GBP account
+	createTestAccountWithBalance(t, repo, "ACC-LIEN-003", 100000)
+
+	req := &pb.InitiateLienRequest{
+		AccountId: "ACC-LIEN-003",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "USD", // Different currency
+				Units:        100,
+				Nanos:        0,
+			},
+		},
+		PaymentOrderReference: "PO-126",
+	}
+
+	_, err := svc.InitiateLien(context.Background(), req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, st.Code())
+	require.Contains(t, st.Message(), "currency")
+}
+
+func TestExecuteLien_Success(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, repo, "ACC-LIEN-004", 100000)
+
+	// Create lien for £500
+	lienAmount, err := domain.NewMoney("GBP", 50000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID, lienAmount, "PO-127", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(lien))
+
+	// Execute the lien
+	req := &pb.ExecuteLienRequest{
+		LienId: lien.ID.String(),
+	}
+
+	resp, err := svc.ExecuteLien(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_EXECUTED, resp.Lien.Status)
+	require.NotEmpty(t, resp.TransactionId)
+
+	// Balance should be £500 (£1000 - £500 debited)
+	require.Equal(t, int64(500), resp.NewBalance.Amount.Units)
+}
+
+func TestExecuteLien_Idempotent(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, repo, "ACC-LIEN-005", 100000)
+
+	// Create and execute a lien
+	lienAmount, err := domain.NewMoney("GBP", 50000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID, lienAmount, "PO-128", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(lien))
+
+	req := &pb.ExecuteLienRequest{LienId: lien.ID.String()}
+
+	// First execution
+	resp1, err := svc.ExecuteLien(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_EXECUTED, resp1.Lien.Status)
+
+	// Second execution should be idempotent
+	resp2, err := svc.ExecuteLien(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_EXECUTED, resp2.Lien.Status)
+	require.Equal(t, resp1.TransactionId, resp2.TransactionId)
+}
+
+func TestExecuteLien_NotFound(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	req := &pb.ExecuteLienRequest{
+		LienId: uuid.New().String(),
+	}
+
+	_, err := svc.ExecuteLien(context.Background(), req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestTerminateLien_Success(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, repo, "ACC-LIEN-006", 100000)
+
+	// Create lien for £500
+	lienAmount, err := domain.NewMoney("GBP", 50000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID, lienAmount, "PO-129", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(lien))
+
+	// Terminate the lien
+	req := &pb.TerminateLienRequest{
+		LienId: lien.ID.String(),
+		Reason: "Payment cancelled",
+	}
+
+	resp, err := svc.TerminateLien(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_TERMINATED, resp.Lien.Status)
+
+	// Available balance should be restored to £1000
+	require.Equal(t, int64(1000), resp.AvailableBalance.Amount.Units)
+}
+
+func TestTerminateLien_Idempotent(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, repo, "ACC-LIEN-007", 100000)
+
+	// Create lien
+	lienAmount, err := domain.NewMoney("GBP", 50000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID, lienAmount, "PO-130", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(lien))
+
+	req := &pb.TerminateLienRequest{
+		LienId: lien.ID.String(),
+		Reason: "Cancelled",
+	}
+
+	// First termination
+	resp1, err := svc.TerminateLien(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_TERMINATED, resp1.Lien.Status)
+
+	// Second termination should be idempotent
+	resp2, err := svc.TerminateLien(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_TERMINATED, resp2.Lien.Status)
+}
+
+func TestRetrieveLien_Success(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	// Create account
+	account := createTestAccountWithBalance(t, repo, "ACC-LIEN-008", 100000)
+
+	// Create lien
+	lienAmount, err := domain.NewMoney("GBP", 25000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID, lienAmount, "PO-131", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(lien))
+
+	// Retrieve the lien
+	req := &pb.RetrieveLienRequest{
+		LienId: lien.ID.String(),
+	}
+
+	resp, err := svc.RetrieveLien(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, lien.ID.String(), resp.Lien.LienId)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_ACTIVE, resp.Lien.Status)
+	require.Equal(t, "PO-131", resp.Lien.PaymentOrderReference)
+}
+
+func TestRetrieveLien_NotFound(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	req := &pb.RetrieveLienRequest{
+		LienId: uuid.New().String(),
+	}
+
+	_, err := svc.RetrieveLien(context.Background(), req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestLienOperations_LienRepoNotConfigured(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	svc := NewService(repo, nil) // No lien repo
+
+	t.Run("InitiateLien", func(t *testing.T) {
+		req := &pb.InitiateLienRequest{
+			AccountId: "ACC-001",
+			Amount: &commonpb.MoneyAmount{
+				Amount: &money.Money{CurrencyCode: "GBP", Units: 100},
+			},
+			PaymentOrderReference: "PO-001",
+		}
+		_, err := svc.InitiateLien(context.Background(), req)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+
+	t.Run("ExecuteLien", func(t *testing.T) {
+		req := &pb.ExecuteLienRequest{LienId: uuid.New().String()}
+		_, err := svc.ExecuteLien(context.Background(), req)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+
+	t.Run("TerminateLien", func(t *testing.T) {
+		req := &pb.TerminateLienRequest{LienId: uuid.New().String()}
+		_, err := svc.TerminateLien(context.Background(), req)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+
+	t.Run("RetrieveLien", func(t *testing.T) {
+		req := &pb.RetrieveLienRequest{LienId: uuid.New().String()}
+		_, err := svc.RetrieveLien(context.Background(), req)
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+}
+
+func TestMultipleLiens_AvailableBalanceCalculation(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	// Create account with £1000 balance
+	createTestAccountWithBalance(t, repo, "ACC-LIEN-MULTI", 100000)
+
+	// Create first lien for £300
+	req1 := &pb.InitiateLienRequest{
+		AccountId: "ACC-LIEN-MULTI",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{CurrencyCode: "GBP", Units: 300},
+		},
+		PaymentOrderReference: "PO-MULTI-1",
+	}
+	resp1, err := svc.InitiateLien(context.Background(), req1)
+	require.NoError(t, err)
+	require.Equal(t, int64(700), resp1.AvailableBalance.Amount.Units) // £1000 - £300 = £700
+
+	// Create second lien for £200
+	req2 := &pb.InitiateLienRequest{
+		AccountId: "ACC-LIEN-MULTI",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{CurrencyCode: "GBP", Units: 200},
+		},
+		PaymentOrderReference: "PO-MULTI-2",
+	}
+	resp2, err := svc.InitiateLien(context.Background(), req2)
+	require.NoError(t, err)
+	require.Equal(t, int64(500), resp2.AvailableBalance.Amount.Units) // £700 - £200 = £500
+
+	// Try to create third lien for £600 (should fail - only £500 available)
+	req3 := &pb.InitiateLienRequest{
+		AccountId: "ACC-LIEN-MULTI",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{CurrencyCode: "GBP", Units: 600},
+		},
+		PaymentOrderReference: "PO-MULTI-3",
+	}
+	_, err = svc.InitiateLien(context.Background(), req3)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+
+	// Create third lien for £400 (should succeed - £500 available)
+	req4 := &pb.InitiateLienRequest{
+		AccountId: "ACC-LIEN-MULTI",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{CurrencyCode: "GBP", Units: 400},
+		},
+		PaymentOrderReference: "PO-MULTI-4",
+	}
+	resp4, err := svc.InitiateLien(context.Background(), req4)
+	require.NoError(t, err)
+	require.Equal(t, int64(100), resp4.AvailableBalance.Amount.Units) // £500 - £400 = £100
+}

--- a/internal/current-account/service/lien_service_test.go
+++ b/internal/current-account/service/lien_service_test.go
@@ -163,6 +163,43 @@ func TestInitiateLien_CurrencyMismatch(t *testing.T) {
 	require.Contains(t, st.Message(), "currency")
 }
 
+func TestInitiateLien_Idempotent(t *testing.T) {
+	db, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := NewService(repo, lienRepo)
+
+	// Create account with £1000 balance
+	createTestAccountWithBalance(t, repo, "ACC-LIEN-IDEMP", 100000)
+
+	req := &pb.InitiateLienRequest{
+		AccountId: "ACC-LIEN-IDEMP",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        500,
+				Nanos:        0,
+			},
+		},
+		PaymentOrderReference: "PO-IDEMPOTENT-123",
+	}
+
+	// First call creates the lien
+	resp1, err := svc.InitiateLien(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp1.Lien)
+	lienID := resp1.Lien.LienId
+
+	// Second call with same PaymentOrderReference should return the existing lien
+	resp2, err := svc.InitiateLien(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp2.Lien)
+	require.Equal(t, lienID, resp2.Lien.LienId, "idempotent call should return same lien")
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_ACTIVE, resp2.Lien.Status)
+}
+
 func TestExecuteLien_Success(t *testing.T) {
 	db, cleanup := setupLienTestDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

Implements the Lien gRPC service operations as defined in ADR-012 for lien-based fund reservation. This enables the Payment Order saga pattern by allowing funds to be reserved before executing external payments.

- **InitiateLien**: Creates fund reservation with available balance validation
- **ExecuteLien**: Converts reservation to actual debit atomically (idempotent for saga retry)
- **TerminateLien**: Releases reservation without executing (idempotent)
- **RetrieveLien**: Gets lien details by ID

## Changes Made

- Added `LienRepository` to `Service` struct with optional initialization for backward compatibility
- Added `FindByUUID` method to account repository to lookup accounts by internal UUID (required since Lien references account by UUID)
- Implemented all four lien RPCs with proper error handling, metrics, and logging
- Added comprehensive unit tests covering success paths, error conditions, and idempotency
- Updated existing tests to pass new constructor signature

## Technical Details

The lien service enforces the invariant: `Available Balance = Current Balance - Sum(Active Liens)`

Key behaviors:
- Currency validation ensures lien currency matches account currency
- Insufficient funds check against available balance (not current balance)
- Optimistic locking via version field prevents concurrent modification
- Idempotent operations for safe saga retries

## Test Plan

- [x] All existing tests pass
- [x] New unit tests for InitiateLien success/failure scenarios
- [x] New unit tests for ExecuteLien including idempotency
- [x] New unit tests for TerminateLien including idempotency
- [x] New unit tests for RetrieveLien
- [x] Tests for lien operations when repository not configured
- [x] Multiple lien available balance calculation test

Part of: Task Master 7-payment-order, Task 5