### PR TITLE
feat: Implement PaymentOrder gRPC service with saga orchestration

### DIFF
--- a/internal/payment-order/adapters/persistence/repository.go
+++ b/internal/payment-order/adapters/persistence/repository.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	cadomain "github.com/meridianhub/meridian/internal/current-account/domain"
@@ -12,8 +13,10 @@ import (
 
 // Repository errors
 var (
-	ErrPaymentOrderNotFound        = errors.New("payment order not found")
-	ErrPaymentOrderVersionConflict = errors.New("version conflict: payment order was modified by another transaction")
+	ErrPaymentOrderNotFound           = errors.New("payment order not found")
+	ErrPaymentOrderVersionConflict    = errors.New("version conflict: payment order was modified by another transaction")
+	ErrIdempotencyKeyConflict         = errors.New("payment order with this idempotency key already exists")
+	errUniqueConstraintIdempotencyKey = "payment_orders_idempotency_key_key" // PostgreSQL constraint name
 )
 
 // PaginatedResult holds paginated query results
@@ -48,10 +51,15 @@ func NewPaymentOrderRepository(db *gorm.DB) *PaymentOrderRepository {
 	return &PaymentOrderRepository{db: db}
 }
 
-// Create inserts a new payment order
+// Create inserts a new payment order.
+// Returns ErrIdempotencyKeyConflict if a payment order with the same idempotency key exists.
 func (r *PaymentOrderRepository) Create(po *domain.PaymentOrder) error {
 	entity := toEntity(po)
-	return r.db.Create(entity).Error
+	err := r.db.Create(entity).Error
+	if err != nil && strings.Contains(err.Error(), errUniqueConstraintIdempotencyKey) {
+		return ErrIdempotencyKeyConflict
+	}
+	return err
 }
 
 // FindByID retrieves a payment order by its UUID

--- a/internal/payment-order/adapters/persistence/repository.go
+++ b/internal/payment-order/adapters/persistence/repository.go
@@ -16,6 +16,13 @@ var (
 	ErrPaymentOrderVersionConflict = errors.New("version conflict: payment order was modified by another transaction")
 )
 
+// PaginatedResult holds paginated query results
+type PaginatedResult struct {
+	PaymentOrders []*domain.PaymentOrder
+	TotalCount    int64
+	HasMore       bool
+}
+
 // Repository defines the contract for payment order persistence.
 // This interface enables mocking in service-layer tests.
 type Repository interface {
@@ -24,6 +31,7 @@ type Repository interface {
 	FindByIdempotencyKey(key string) (*domain.PaymentOrder, error)
 	FindByGatewayReferenceID(gatewayRefID string) (*domain.PaymentOrder, error)
 	FindByDebtorAccountID(accountID string) ([]*domain.PaymentOrder, error)
+	FindByDebtorAccountIDPaginated(accountID string, limit, offset int) (*PaginatedResult, error)
 	Update(po *domain.PaymentOrder) error
 }
 
@@ -113,6 +121,59 @@ func (r *PaymentOrderRepository) FindByDebtorAccountID(accountID string) ([]*dom
 	}
 
 	return paymentOrders, nil
+}
+
+// FindByDebtorAccountIDPaginated retrieves payment orders for a debtor account with pagination.
+// Uses database-level LIMIT/OFFSET for efficient queries on large datasets.
+// Results are ordered by created_at DESC (newest first) for consistent pagination.
+func (r *PaymentOrderRepository) FindByDebtorAccountIDPaginated(accountID string, limit, offset int) (*PaginatedResult, error) {
+	// Get total count first (single COUNT query, very efficient with index)
+	var totalCount int64
+	countResult := r.db.Model(&PaymentOrderEntity{}).
+		Where("debtor_account_id = ?", accountID).
+		Count(&totalCount)
+
+	if countResult.Error != nil {
+		return nil, countResult.Error
+	}
+
+	// Return early if no results
+	if totalCount == 0 {
+		return &PaginatedResult{
+			PaymentOrders: []*domain.PaymentOrder{},
+			TotalCount:    0,
+			HasMore:       false,
+		}, nil
+	}
+
+	// Query with pagination
+	var entities []PaymentOrderEntity
+	result := r.db.Where("debtor_account_id = ?", accountID).
+		Order("created_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&entities)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	paymentOrders := make([]*domain.PaymentOrder, 0, len(entities))
+	for i := range entities {
+		po, err := toDomain(&entities[i])
+		if err != nil {
+			return nil, err
+		}
+		paymentOrders = append(paymentOrders, po)
+	}
+
+	hasMore := int64(offset+len(entities)) < totalCount
+
+	return &PaginatedResult{
+		PaymentOrders: paymentOrders,
+		TotalCount:    totalCount,
+		HasMore:       hasMore,
+	}, nil
 }
 
 // Update updates an existing payment order with optimistic locking

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -237,6 +237,18 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 	// The saga runs in the background after returning the response
 	// nolint:contextcheck // Intentionally using background context for async saga orchestration
 	go func() {
+		// Recover from panics to prevent silent goroutine termination
+		defer func() {
+			if r := recover(); r != nil {
+				s.logger.Error("panic in payment saga orchestration",
+					"panic", r,
+					"payment_order_id", po.ID.String(),
+					"correlation_id", correlationID)
+				// Attempt to fail the payment order so it doesn't remain in limbo
+				failCtx := context.Background()
+				s.failPaymentOrder(failCtx, po, "internal panic during saga orchestration", "INTERNAL_ERROR")
+			}
+		}()
 		sagaCtx := context.Background()
 		if s.tracer != nil {
 			sagaCtx = observability.WithCorrelationID(sagaCtx, correlationID)

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -265,6 +265,8 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 		"payment_order_id", po.ID.String(),
 		"debtor_account_id", po.DebtorAccountID,
 		"amount_cents", po.Amount.AmountCents(),
+		"currency", po.Amount.Currency(),
+		"idempotency_key", po.IdempotencyKey,
 		"correlation_id", correlationID)
 
 	// Publish PaymentOrderInitiated event to Kafka
@@ -343,7 +345,6 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 }
 
 // orchestratePayment executes the payment saga with compensation on failure.
-// nolint:gocognit // Complex saga orchestration requires multiple nested steps
 func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrder) {
 	s.logger.Info("starting payment saga",
 		"payment_order_id", po.ID.String(),
@@ -362,13 +363,21 @@ func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrde
 		return
 	}
 
-	// Create saga orchestrator
+	// Create saga orchestrator and track lien state for compensation
 	saga := clients.NewSagaOrchestrator(s.logger)
-
-	// Track saga state for compensation
 	var lienID string
 
-	// Step 1: Reserve funds via CurrentAccount.InitiateLien
+	// Add saga steps
+	s.addReserveFundsStep(saga, po, &lienID)
+	s.addSendToGatewayStep(saga, po)
+
+	// Execute saga
+	result := saga.Execute(ctx)
+	s.handleSagaResult(ctx, po, result)
+}
+
+// addReserveFundsStep adds the reserve_funds saga step that creates a lien to reserve funds.
+func (s *Service) addReserveFundsStep(saga *clients.SagaOrchestrator, po *domain.PaymentOrder, lienID *string) {
 	saga.AddStep("reserve_funds",
 		// Action: Create lien to reserve funds
 		func(stepCtx context.Context) error {
@@ -385,10 +394,10 @@ func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrde
 				return fmt.Errorf("failed to reserve funds: %w", err)
 			}
 
-			lienID = resp.Lien.LienId
+			*lienID = resp.Lien.LienId
 
 			// Update payment order with lien ID and transition to RESERVED
-			if err := po.Reserve(lienID); err != nil {
+			if err := po.Reserve(*lienID); err != nil {
 				return fmt.Errorf("failed to transition to RESERVED: %w", err)
 			}
 
@@ -398,14 +407,14 @@ func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrde
 
 			s.logger.Info("reserve_funds step completed",
 				"payment_order_id", po.ID.String(),
-				"lien_id", lienID)
+				"lien_id", *lienID)
 
 			// Publish PaymentOrderReserved event
 			s.publishEvent(stepCtx, TopicPaymentOrderReserved, po.ID.String(), &eventsv1.PaymentOrderReservedEvent{
 				EventId:         uuid.New().String(),
 				PaymentOrderId:  po.ID.String(),
 				DebtorAccountId: po.DebtorAccountID,
-				LienId:          lienID,
+				LienId:          *lienID,
 				Amount:          toMoneyAmount(po.Amount),
 				CorrelationId:   po.CorrelationID,
 				CausationId:     po.ID.String(),
@@ -418,34 +427,36 @@ func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrde
 		},
 		// Compensate: Release lien
 		func(stepCtx context.Context) error {
-			if lienID == "" {
+			if *lienID == "" {
 				s.logger.Warn("no lien to release in compensation")
 				return nil
 			}
 
 			s.logger.Info("compensating reserve_funds step",
 				"payment_order_id", po.ID.String(),
-				"lien_id", lienID)
+				"lien_id", *lienID)
 
 			_, err := s.currentAccountClient.TerminateLien(stepCtx, &currentaccountv1.TerminateLienRequest{
-				LienId: lienID,
+				LienId: *lienID,
 				Reason: fmt.Sprintf("Payment order %s saga compensation", po.ID.String()),
 			})
 			if err != nil {
 				s.logger.Error("failed to release lien in compensation",
 					"error", err,
-					"lien_id", lienID)
+					"lien_id", *lienID)
 				return err
 			}
 
 			s.logger.Info("reserve_funds compensation completed",
-				"lien_id", lienID)
+				"lien_id", *lienID)
 
 			return nil
 		},
 	)
+}
 
-	// Step 2: Send to payment gateway
+// addSendToGatewayStep adds the send_to_gateway saga step that sends payment to the external gateway.
+func (s *Service) addSendToGatewayStep(saga *clients.SagaOrchestrator, po *domain.PaymentOrder) {
 	saga.AddStep("send_to_gateway",
 		// Action: Send payment to gateway
 		func(stepCtx context.Context) error {
@@ -463,55 +474,59 @@ func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrde
 				return fmt.Errorf("failed to send payment to gateway: %w", err)
 			}
 
-			// Check gateway response status
-			switch resp.Status {
-			case gateway.StatusAccepted, gateway.StatusPending:
-				// Transition to EXECUTING
-				if err := po.Execute(resp.GatewayReferenceID); err != nil {
-					return fmt.Errorf("failed to transition to EXECUTING: %w", err)
-				}
-
-				if err := s.repo.Update(po); err != nil {
-					return fmt.Errorf("failed to update payment order: %w", err)
-				}
-
-				s.logger.Info("send_to_gateway step completed",
-					"payment_order_id", po.ID.String(),
-					"gateway_reference_id", resp.GatewayReferenceID,
-					"gateway_status", resp.Status)
-
-				// Publish PaymentOrderExecuting event
-				s.publishEvent(stepCtx, TopicPaymentOrderExecuting, po.ID.String(), &eventsv1.PaymentOrderExecutingEvent{
-					EventId:            uuid.New().String(),
-					PaymentOrderId:     po.ID.String(),
-					GatewayReferenceId: resp.GatewayReferenceID,
-					CorrelationId:      po.CorrelationID,
-					CausationId:        po.ID.String(),
-					Timestamp:          timestamppb.Now(),
-					Version:            int64(po.Version),
-					IdempotencyKey:     po.IdempotencyKey,
-				})
-
-				return nil
-
-			case gateway.StatusRejected:
-				return fmt.Errorf("%w: %s", ErrPaymentRejected, resp.Message)
-
-			default:
-				return fmt.Errorf("%w: %s", ErrUnexpectedGatewayStatus, resp.Status)
-			}
+			return s.processGatewayResponse(stepCtx, po, resp)
 		},
-		// Compensate: Mark as failed (lien will be released by previous step's compensation)
+		// Compensate: No-op (lien will be released by reserve_funds compensation)
 		func(_ context.Context) error {
 			s.logger.Info("send_to_gateway compensation (no-op - lien released by reserve_funds compensation)",
 				"payment_order_id", po.ID.String())
 			return nil
 		},
 	)
+}
 
-	// Execute saga
-	result := saga.Execute(ctx)
+// processGatewayResponse handles the gateway response and transitions payment order state.
+func (s *Service) processGatewayResponse(ctx context.Context, po *domain.PaymentOrder, resp gateway.PaymentResponse) error {
+	switch resp.Status {
+	case gateway.StatusAccepted, gateway.StatusPending:
+		// Transition to EXECUTING
+		if err := po.Execute(resp.GatewayReferenceID); err != nil {
+			return fmt.Errorf("failed to transition to EXECUTING: %w", err)
+		}
 
+		if err := s.repo.Update(po); err != nil {
+			return fmt.Errorf("failed to update payment order: %w", err)
+		}
+
+		s.logger.Info("send_to_gateway step completed",
+			"payment_order_id", po.ID.String(),
+			"gateway_reference_id", resp.GatewayReferenceID,
+			"gateway_status", resp.Status)
+
+		// Publish PaymentOrderExecuting event
+		s.publishEvent(ctx, TopicPaymentOrderExecuting, po.ID.String(), &eventsv1.PaymentOrderExecutingEvent{
+			EventId:            uuid.New().String(),
+			PaymentOrderId:     po.ID.String(),
+			GatewayReferenceId: resp.GatewayReferenceID,
+			CorrelationId:      po.CorrelationID,
+			CausationId:        po.ID.String(),
+			Timestamp:          timestamppb.Now(),
+			Version:            int64(po.Version),
+			IdempotencyKey:     po.IdempotencyKey,
+		})
+
+		return nil
+
+	case gateway.StatusRejected:
+		return fmt.Errorf("%w: %s", ErrPaymentRejected, resp.Message)
+
+	default:
+		return fmt.Errorf("%w: %s", ErrUnexpectedGatewayStatus, resp.Status)
+	}
+}
+
+// handleSagaResult processes the saga execution result and handles failure scenarios.
+func (s *Service) handleSagaResult(ctx context.Context, po *domain.PaymentOrder, result clients.SagaResult) {
 	if !result.Success {
 		s.logger.Error("payment saga failed",
 			"payment_order_id", po.ID.String(),
@@ -605,7 +620,9 @@ func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder,
 	s.logger.Info("payment order failed",
 		"payment_order_id", po.ID.String(),
 		"reason", reason,
-		"error_code", errorCode)
+		"error_code", errorCode,
+		"idempotency_key", po.IdempotencyKey,
+		"correlation_id", po.CorrelationID)
 
 	return nil
 }
@@ -721,7 +738,11 @@ func (s *Service) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentO
 
 		s.logger.Info("payment order completed",
 			"payment_order_id", po.ID.String(),
-			"gateway_reference_id", po.GatewayReferenceID)
+			"gateway_reference_id", po.GatewayReferenceID,
+			"amount_cents", po.Amount.AmountCents(),
+			"currency", po.Amount.Currency(),
+			"idempotency_key", po.IdempotencyKey,
+			"correlation_id", po.CorrelationID)
 
 	case pb.GatewayStatus_GATEWAY_STATUS_REJECTED:
 		// Fail the payment - synchronous path: propagate error to client
@@ -823,7 +844,11 @@ func (s *Service) CancelPaymentOrder(ctx context.Context, req *pb.CancelPaymentO
 	s.logger.Info("payment order cancelled",
 		"payment_order_id", po.ID.String(),
 		"reason", req.CancellationReason,
-		"cancelled_by", req.CancelledBy)
+		"cancelled_by", req.CancelledBy,
+		"amount_cents", po.Amount.AmountCents(),
+		"currency", po.Amount.Currency(),
+		"idempotency_key", po.IdempotencyKey,
+		"correlation_id", po.CorrelationID)
 
 	return &pb.CancelPaymentOrderResponse{
 		PaymentOrder: toProto(po),

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -905,10 +905,15 @@ func protoToMoney(amount *commonpb.MoneyAmount) (cadomain.Money, error) {
 		return cadomain.Money{}, ErrAmountRequired
 	}
 
-	// Convert to cents
+	// Convert to cents with symmetric rounding (round half away from zero)
 	unitsCents := amount.Amount.Units * 100
-	nanosCents := (amount.Amount.Nanos + 5000000) / 10000000
-	totalCents := unitsCents + int64(nanosCents)
+	var nanosCents int64
+	if amount.Amount.Nanos >= 0 {
+		nanosCents = int64((amount.Amount.Nanos + 5000000) / 10000000)
+	} else {
+		nanosCents = int64((amount.Amount.Nanos - 5000000) / 10000000)
+	}
+	totalCents := unitsCents + nanosCents
 
 	return cadomain.NewMoney(amount.Amount.CurrencyCode, totalCents)
 }

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -236,17 +236,25 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 	// Start saga orchestration asynchronously
 	// The saga runs in the background after returning the response
 	// nolint:contextcheck // Intentionally using background context for async saga orchestration
-	go func() {
+	go func(paymentOrderID uuid.UUID) {
 		// Recover from panics to prevent silent goroutine termination
 		defer func() {
 			if r := recover(); r != nil {
 				s.logger.Error("panic in payment saga orchestration",
 					"panic", r,
-					"payment_order_id", po.ID.String(),
+					"payment_order_id", paymentOrderID.String(),
 					"correlation_id", correlationID)
-				// Attempt to fail the payment order so it doesn't remain in limbo
+				// Reload fresh state before failing - the original po may be stale
+				// if the saga made state transitions before panicking
 				failCtx := context.Background()
-				s.failPaymentOrder(failCtx, po, "internal panic during saga orchestration", "INTERNAL_ERROR")
+				freshPO, err := s.repo.FindByID(paymentOrderID)
+				if err != nil {
+					s.logger.Error("failed to reload payment order after panic",
+						"payment_order_id", paymentOrderID.String(),
+						"error", err)
+					return
+				}
+				s.failPaymentOrder(failCtx, freshPO, "internal panic during saga orchestration", "INTERNAL_ERROR")
 			}
 		}()
 		sagaCtx := context.Background()
@@ -254,7 +262,7 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 			sagaCtx = observability.WithCorrelationID(sagaCtx, correlationID)
 		}
 		s.orchestratePayment(sagaCtx, po)
-	}()
+	}(po.ID)
 
 	return &pb.InitiatePaymentOrderResponse{
 		PaymentOrder: responseProto,

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -229,6 +229,10 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 		}
 	}
 
+	// Convert to proto BEFORE starting the async goroutine to avoid data race
+	// The saga may modify po while toProto reads from it
+	responseProto := toProto(po)
+
 	// Start saga orchestration asynchronously
 	// The saga runs in the background after returning the response
 	// nolint:contextcheck // Intentionally using background context for async saga orchestration
@@ -241,7 +245,7 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 	}()
 
 	return &pb.InitiatePaymentOrderResponse{
-		PaymentOrder: toProto(po),
+		PaymentOrder: responseProto,
 	}, nil
 }
 

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -40,6 +40,7 @@ var (
 	ErrPaymentRejected         = errors.New("payment rejected by gateway")
 	ErrUnexpectedGatewayStatus = errors.New("unexpected gateway status")
 	ErrIdempotencyKeyTooLong   = errors.New("idempotency key exceeds maximum length")
+	ErrMalformedLienResponse   = errors.New("current account service returned empty or malformed lien response")
 )
 
 // Kafka topic constants
@@ -200,6 +201,7 @@ func NewServiceWithConfig(config Config) (*Service, error) {
 }
 
 // InitiatePaymentOrder creates a new payment order and begins the saga.
+// nolint:gocognit // Complexity justified by validation, idempotency handling (TOCTOU), event publishing, and saga startup
 func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaymentOrderRequest) (*pb.InitiatePaymentOrderResponse, error) {
 	start := time.Now()
 	defer func() {
@@ -269,6 +271,23 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 
 	// Persist to database
 	if err := s.repo.Create(po); err != nil {
+		// Handle idempotency key conflict (TOCTOU race): another request won the race
+		// Reload and return the existing payment order for idempotent behavior
+		if errors.Is(err, persistence.ErrIdempotencyKeyConflict) {
+			existingPO, findErr := s.repo.FindByIdempotencyKey(idempotencyKey)
+			if findErr != nil {
+				s.logger.Error("failed to retrieve existing payment order after idempotency conflict",
+					"error", findErr,
+					"idempotency_key", idempotencyKey)
+				return nil, status.Error(codes.Internal, "failed to retrieve payment order")
+			}
+			s.logger.Info("returning existing payment order (idempotency race)",
+				"payment_order_id", existingPO.ID.String(),
+				"idempotency_key", idempotencyKey)
+			return &pb.InitiatePaymentOrderResponse{
+				PaymentOrder: toProto(existingPO),
+			}, nil
+		}
 		s.logger.Error("failed to save payment order", "error", err)
 		return nil, status.Error(codes.Internal, "failed to save payment order")
 	}
@@ -413,6 +432,11 @@ func (s *Service) addReserveFundsStep(saga *clients.SagaOrchestrator, po *domain
 			})
 			if err != nil {
 				return fmt.Errorf("failed to reserve funds: %w", err)
+			}
+
+			// Defensive check: ensure response is well-formed to avoid panics
+			if resp == nil || resp.Lien == nil || resp.Lien.LienId == "" {
+				return ErrMalformedLienResponse
 			}
 
 			*lienID = resp.Lien.LienId

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -63,6 +63,10 @@ type CurrentAccountClient interface {
 	Close() error
 }
 
+// DefaultSagaTimeout is the default timeout for payment saga orchestration.
+// This allows for typical payment gateway latency plus retries.
+const DefaultSagaTimeout = 5 * time.Minute
+
 // Service implements the PaymentOrderService gRPC service
 type Service struct {
 	pb.UnimplementedPaymentOrderServiceServer
@@ -72,6 +76,7 @@ type Service struct {
 	kafkaProducer        *kafka.ProtoProducer
 	logger               *slog.Logger
 	tracer               *observability.Tracer
+	sagaTimeout          time.Duration
 }
 
 // Config contains configuration for creating a new Service
@@ -82,6 +87,9 @@ type Config struct {
 	KafkaProducer        *kafka.ProtoProducer
 	Logger               *slog.Logger
 	Tracer               *observability.Tracer
+	// SagaTimeout is the maximum duration for saga orchestration.
+	// If zero, DefaultSagaTimeout is used.
+	SagaTimeout time.Duration
 }
 
 // NewService creates a new payment order service with minimal dependencies.
@@ -92,8 +100,9 @@ func NewService(repo persistence.Repository) (*Service, error) {
 		return nil, ErrRepositoryNil
 	}
 	return &Service{
-		repo:   repo,
-		logger: slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+		repo:        repo,
+		logger:      slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+		sagaTimeout: DefaultSagaTimeout,
 	}, nil
 }
 
@@ -120,6 +129,12 @@ func NewServiceWithConfig(config Config) (*Service, error) {
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	}
 
+	// Apply default saga timeout if not provided
+	sagaTimeout := config.SagaTimeout
+	if sagaTimeout == 0 {
+		sagaTimeout = DefaultSagaTimeout
+	}
+
 	return &Service{
 		repo:                 config.Repository,
 		currentAccountClient: config.CurrentAccountClient,
@@ -127,6 +142,7 @@ func NewServiceWithConfig(config Config) (*Service, error) {
 		kafkaProducer:        config.KafkaProducer,
 		logger:               logger,
 		tracer:               config.Tracer,
+		sagaTimeout:          sagaTimeout,
 	}, nil
 }
 
@@ -264,8 +280,7 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 			}
 		}()
 		// Create saga context with timeout to prevent indefinite hangs
-		// 5 minutes allows for typical payment gateway latency plus retries
-		sagaCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		sagaCtx, cancel := context.WithTimeout(context.Background(), s.sagaTimeout)
 		defer cancel()
 		if s.tracer != nil {
 			sagaCtx = observability.WithCorrelationID(sagaCtx, correlationID)

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -255,10 +255,18 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 						"error", err)
 					return
 				}
-				s.failPaymentOrder(failCtx, freshPO, "internal panic during saga orchestration", "INTERNAL_ERROR")
+				// Async path: log and swallow error - best effort failure handling
+				if err := s.failPaymentOrder(failCtx, freshPO, "internal panic during saga orchestration", "INTERNAL_ERROR"); err != nil {
+					s.logger.Error("failed to mark payment order as failed after panic",
+						"payment_order_id", paymentOrderID.String(),
+						"error", err)
+				}
 			}
 		}()
-		sagaCtx := context.Background()
+		// Create saga context with timeout to prevent indefinite hangs
+		// 5 minutes allows for typical payment gateway latency plus retries
+		sagaCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
 		if s.tracer != nil {
 			sagaCtx = observability.WithCorrelationID(sagaCtx, correlationID)
 		}
@@ -281,7 +289,12 @@ func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrde
 	if s.currentAccountClient == nil || s.paymentGateway == nil {
 		s.logger.Error("saga dependencies not configured",
 			"payment_order_id", po.ID.String())
-		s.failPaymentOrder(ctx, po, "service configuration error", "INTERNAL_ERROR")
+		// Async path: log and swallow error - best effort failure handling
+		if err := s.failPaymentOrder(ctx, po, "service configuration error", "INTERNAL_ERROR"); err != nil {
+			s.logger.Error("failed to mark payment order as failed",
+				"payment_order_id", po.ID.String(),
+				"error", err)
+		}
 		return
 	}
 
@@ -460,7 +473,12 @@ func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrde
 			return
 		}
 
-		s.failPaymentOrder(ctx, latestPO, result.Error.Error(), "SAGA_FAILED")
+		// Async path: log and swallow error - best effort failure handling
+		if err := s.failPaymentOrder(ctx, latestPO, result.Error.Error(), "SAGA_FAILED"); err != nil {
+			s.logger.Error("failed to mark payment order as failed after saga failure",
+				"payment_order_id", po.ID.String(),
+				"error", err)
+		}
 		return
 	}
 
@@ -473,7 +491,10 @@ func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrde
 }
 
 // failPaymentOrder handles payment order failure with proper state transition and event publishing.
-func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder, reason string, errorCode string) {
+// Returns an error if the state transition or persistence fails. Callers in synchronous paths
+// (e.g., UpdatePaymentOrder) should propagate this error to clients. Callers in async paths
+// (e.g., saga orchestration) may log and swallow the error.
+func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder, reason string, errorCode string) error {
 	// Capture original status before transitioning (for event)
 	failedAtStatus := po.Status
 
@@ -486,14 +507,14 @@ func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder,
 		s.logger.Error("failed to transition to FAILED state",
 			"error", err,
 			"payment_order_id", po.ID.String())
-		return
+		return fmt.Errorf("failed to transition to FAILED state: %w", err)
 	}
 
 	if err := s.repo.Update(po); err != nil {
 		s.logger.Error("failed to persist FAILED state",
 			"error", err,
 			"payment_order_id", po.ID.String())
-		return
+		return fmt.Errorf("failed to persist FAILED state: %w", err)
 	}
 
 	// Release lien if needed
@@ -536,6 +557,8 @@ func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder,
 		"payment_order_id", po.ID.String(),
 		"reason", reason,
 		"error_code", errorCode)
+
+	return nil
 }
 
 // RetrievePaymentOrder gets payment order details by ID.
@@ -657,8 +680,10 @@ func (s *Service) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentO
 			"gateway_reference_id", po.GatewayReferenceID)
 
 	case pb.GatewayStatus_GATEWAY_STATUS_REJECTED:
-		// Fail the payment
-		s.failPaymentOrder(ctx, po, req.GatewayMessage, "GATEWAY_REJECTED")
+		// Fail the payment - synchronous path: propagate error to client
+		if err := s.failPaymentOrder(ctx, po, req.GatewayMessage, "GATEWAY_REJECTED"); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to mark payment as rejected: %v", err)
+		}
 
 	case pb.GatewayStatus_GATEWAY_STATUS_PENDING:
 		// No state change needed - still waiting

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -25,19 +25,20 @@ import (
 	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Service errors
 var (
-	ErrRepositoryNil             = errors.New("repository cannot be nil")
-	ErrCurrentAccountClientNil   = errors.New("current account client cannot be nil")
-	ErrPaymentGatewayNil         = errors.New("payment gateway cannot be nil")
-	ErrKafkaProducerNil          = errors.New("kafka producer cannot be nil")
-	ErrCurrentAccountTargetEmpty = errors.New("current account target cannot be empty")
-	ErrAmountRequired            = errors.New("amount is required")
-	ErrPaymentRejected           = errors.New("payment rejected by gateway")
-	ErrUnexpectedGatewayStatus   = errors.New("unexpected gateway status")
+	ErrRepositoryNil           = errors.New("repository cannot be nil")
+	ErrCurrentAccountClientNil = errors.New("current account client cannot be nil")
+	ErrPaymentGatewayNil       = errors.New("payment gateway cannot be nil")
+	ErrKafkaProducerNil        = errors.New("kafka producer cannot be nil")
+	ErrAmountRequired          = errors.New("amount is required")
+	ErrPaymentRejected         = errors.New("payment rejected by gateway")
+	ErrUnexpectedGatewayStatus = errors.New("unexpected gateway status")
+	ErrIdempotencyKeyTooLong   = errors.New("idempotency key exceeds maximum length")
 )
 
 // Kafka topic constants
@@ -63,20 +64,35 @@ type CurrentAccountClient interface {
 	Close() error
 }
 
-// DefaultSagaTimeout is the default timeout for payment saga orchestration.
-// This allows for typical payment gateway latency plus retries.
-const DefaultSagaTimeout = 5 * time.Minute
+// Configuration defaults
+const (
+	// DefaultSagaTimeout is the default timeout for payment saga orchestration.
+	// This allows for typical payment gateway latency plus retries.
+	DefaultSagaTimeout = 5 * time.Minute
+
+	// DefaultPageSize is the default number of items per page for list operations.
+	DefaultPageSize = 50
+
+	// DefaultMaxPageSize is the maximum allowed page size for list operations.
+	DefaultMaxPageSize = 1000
+
+	// DefaultMaxIdempotencyKeyLength is the maximum allowed length for idempotency keys.
+	DefaultMaxIdempotencyKeyLength = 256
+)
 
 // Service implements the PaymentOrderService gRPC service
 type Service struct {
 	pb.UnimplementedPaymentOrderServiceServer
-	repo                 persistence.Repository
-	currentAccountClient CurrentAccountClient
-	paymentGateway       gateway.PaymentGateway
-	kafkaProducer        *kafka.ProtoProducer
-	logger               *slog.Logger
-	tracer               *observability.Tracer
-	sagaTimeout          time.Duration
+	repo                    persistence.Repository
+	currentAccountClient    CurrentAccountClient
+	paymentGateway          gateway.PaymentGateway
+	kafkaProducer           *kafka.ProtoProducer
+	logger                  *slog.Logger
+	tracer                  *observability.Tracer
+	sagaTimeout             time.Duration
+	defaultPageSize         int
+	maxPageSize             int
+	maxIdempotencyKeyLength int
 }
 
 // Config contains configuration for creating a new Service
@@ -90,6 +106,13 @@ type Config struct {
 	// SagaTimeout is the maximum duration for saga orchestration.
 	// If zero, DefaultSagaTimeout is used.
 	SagaTimeout time.Duration
+	// DefaultPageSize is the default number of items per page. If zero, DefaultPageSize is used.
+	DefaultPageSize int
+	// MaxPageSize is the maximum allowed page size. If zero, DefaultMaxPageSize is used.
+	MaxPageSize int
+	// MaxIdempotencyKeyLength is the maximum allowed idempotency key length.
+	// If zero, DefaultMaxIdempotencyKeyLength is used.
+	MaxIdempotencyKeyLength int
 }
 
 // NewService creates a new payment order service with minimal dependencies.
@@ -100,9 +123,12 @@ func NewService(repo persistence.Repository) (*Service, error) {
 		return nil, ErrRepositoryNil
 	}
 	return &Service{
-		repo:        repo,
-		logger:      slog.New(slog.NewJSONHandler(os.Stdout, nil)),
-		sagaTimeout: DefaultSagaTimeout,
+		repo:                    repo,
+		logger:                  slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+		sagaTimeout:             DefaultSagaTimeout,
+		defaultPageSize:         DefaultPageSize,
+		maxPageSize:             DefaultMaxPageSize,
+		maxIdempotencyKeyLength: DefaultMaxIdempotencyKeyLength,
 	}, nil
 }
 
@@ -129,20 +155,38 @@ func NewServiceWithConfig(config Config) (*Service, error) {
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	}
 
-	// Apply default saga timeout if not provided
+	// Apply defaults for optional config values
 	sagaTimeout := config.SagaTimeout
 	if sagaTimeout == 0 {
 		sagaTimeout = DefaultSagaTimeout
 	}
 
+	defaultPageSize := config.DefaultPageSize
+	if defaultPageSize == 0 {
+		defaultPageSize = DefaultPageSize
+	}
+
+	maxPageSize := config.MaxPageSize
+	if maxPageSize == 0 {
+		maxPageSize = DefaultMaxPageSize
+	}
+
+	maxIdempotencyKeyLength := config.MaxIdempotencyKeyLength
+	if maxIdempotencyKeyLength == 0 {
+		maxIdempotencyKeyLength = DefaultMaxIdempotencyKeyLength
+	}
+
 	return &Service{
-		repo:                 config.Repository,
-		currentAccountClient: config.CurrentAccountClient,
-		paymentGateway:       config.PaymentGateway,
-		kafkaProducer:        config.KafkaProducer,
-		logger:               logger,
-		tracer:               config.Tracer,
-		sagaTimeout:          sagaTimeout,
+		repo:                    config.Repository,
+		currentAccountClient:    config.CurrentAccountClient,
+		paymentGateway:          config.PaymentGateway,
+		kafkaProducer:           config.KafkaProducer,
+		logger:                  logger,
+		tracer:                  config.Tracer,
+		sagaTimeout:             sagaTimeout,
+		defaultPageSize:         defaultPageSize,
+		maxPageSize:             maxPageSize,
+		maxIdempotencyKeyLength: maxIdempotencyKeyLength,
 	}, nil
 }
 
@@ -168,6 +212,9 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 	}
 	if idempotencyKey == "" {
 		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+	if len(idempotencyKey) > s.maxIdempotencyKeyLength {
+		return nil, status.Errorf(codes.InvalidArgument, "idempotency_key exceeds maximum length of %d", s.maxIdempotencyKeyLength)
 	}
 
 	// Check for existing payment order with same idempotency key (idempotent)
@@ -220,31 +267,19 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 		"correlation_id", correlationID)
 
 	// Publish PaymentOrderInitiated event to Kafka
-	if s.kafkaProducer != nil {
-		event := &eventsv1.PaymentOrderInitiatedEvent{
-			EventId:           uuid.New().String(),
-			PaymentOrderId:    po.ID.String(),
-			DebtorAccountId:   po.DebtorAccountID,
-			CreditorReference: po.CreditorReference,
-			Amount:            toMoneyAmount(po.Amount),
-			CorrelationId:     po.CorrelationID,
-			CausationId:       po.ID.String(), // Initial event caused by the order creation
-			Timestamp:         timestamppb.Now(),
-			Version:           int64(po.Version),
-			IdempotencyKey:    po.IdempotencyKey,
-		}
-
-		if err := s.kafkaProducer.Publish(ctx, TopicPaymentOrderInitiated, po.ID.String(), event); err != nil {
-			s.logger.Error("failed to publish PaymentOrderInitiated event",
-				"error", err,
-				"payment_order_id", po.ID.String())
-			// Don't fail the request - event will be recovered via outbox pattern or retry
-		} else {
-			s.logger.Info("published PaymentOrderInitiated event",
-				"payment_order_id", po.ID.String(),
-				"topic", TopicPaymentOrderInitiated)
-		}
-	}
+	// Publish event (publishEvent handles nil kafkaProducer)
+	s.publishEvent(ctx, TopicPaymentOrderInitiated, po.ID.String(), &eventsv1.PaymentOrderInitiatedEvent{
+		EventId:           uuid.New().String(),
+		PaymentOrderId:    po.ID.String(),
+		DebtorAccountId:   po.DebtorAccountID,
+		CreditorReference: po.CreditorReference,
+		Amount:            toMoneyAmount(po.Amount),
+		CorrelationId:     po.CorrelationID,
+		CausationId:       po.ID.String(), // Initial event caused by the order creation
+		Timestamp:         timestamppb.Now(),
+		Version:           int64(po.Version),
+		IdempotencyKey:    po.IdempotencyKey,
+	})
 
 	// Convert to proto BEFORE starting the async goroutine to avoid data race
 	// The saga may modify po while toProto reads from it
@@ -285,7 +320,16 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 		if s.tracer != nil {
 			sagaCtx = observability.WithCorrelationID(sagaCtx, correlationID)
 		}
-		s.orchestratePayment(sagaCtx, po)
+
+		// Reload fresh state to avoid race with caller who may still reference po
+		freshPO, err := s.repo.FindByID(paymentOrderID)
+		if err != nil {
+			s.logger.Error("failed to reload payment order for saga",
+				"payment_order_id", paymentOrderID.String(),
+				"error", err)
+			return
+		}
+		s.orchestratePayment(sagaCtx, freshPO)
 	}(po.ID)
 
 	return &pb.InitiatePaymentOrderResponse{
@@ -352,23 +396,18 @@ func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrde
 				"lien_id", lienID)
 
 			// Publish PaymentOrderReserved event
-			if s.kafkaProducer != nil {
-				event := &eventsv1.PaymentOrderReservedEvent{
-					EventId:         uuid.New().String(),
-					PaymentOrderId:  po.ID.String(),
-					DebtorAccountId: po.DebtorAccountID,
-					LienId:          lienID,
-					Amount:          toMoneyAmount(po.Amount),
-					CorrelationId:   po.CorrelationID,
-					CausationId:     po.ID.String(),
-					Timestamp:       timestamppb.Now(),
-					Version:         int64(po.Version),
-					IdempotencyKey:  po.IdempotencyKey,
-				}
-				if err := s.kafkaProducer.Publish(stepCtx, TopicPaymentOrderReserved, po.ID.String(), event); err != nil {
-					s.logger.Error("failed to publish PaymentOrderReserved event", "error", err)
-				}
-			}
+			s.publishEvent(stepCtx, TopicPaymentOrderReserved, po.ID.String(), &eventsv1.PaymentOrderReservedEvent{
+				EventId:         uuid.New().String(),
+				PaymentOrderId:  po.ID.String(),
+				DebtorAccountId: po.DebtorAccountID,
+				LienId:          lienID,
+				Amount:          toMoneyAmount(po.Amount),
+				CorrelationId:   po.CorrelationID,
+				CausationId:     po.ID.String(),
+				Timestamp:       timestamppb.Now(),
+				Version:         int64(po.Version),
+				IdempotencyKey:  po.IdempotencyKey,
+			})
 
 			return nil
 		},
@@ -437,21 +476,16 @@ func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrde
 					"gateway_status", resp.Status)
 
 				// Publish PaymentOrderExecuting event
-				if s.kafkaProducer != nil {
-					event := &eventsv1.PaymentOrderExecutingEvent{
-						EventId:            uuid.New().String(),
-						PaymentOrderId:     po.ID.String(),
-						GatewayReferenceId: resp.GatewayReferenceID,
-						CorrelationId:      po.CorrelationID,
-						CausationId:        po.ID.String(),
-						Timestamp:          timestamppb.Now(),
-						Version:            int64(po.Version),
-						IdempotencyKey:     po.IdempotencyKey,
-					}
-					if err := s.kafkaProducer.Publish(stepCtx, TopicPaymentOrderExecuting, po.ID.String(), event); err != nil {
-						s.logger.Error("failed to publish PaymentOrderExecuting event", "error", err)
-					}
-				}
+				s.publishEvent(stepCtx, TopicPaymentOrderExecuting, po.ID.String(), &eventsv1.PaymentOrderExecutingEvent{
+					EventId:            uuid.New().String(),
+					PaymentOrderId:     po.ID.String(),
+					GatewayReferenceId: resp.GatewayReferenceID,
+					CorrelationId:      po.CorrelationID,
+					CausationId:        po.ID.String(),
+					Timestamp:          timestamppb.Now(),
+					Version:            int64(po.Version),
+					IdempotencyKey:     po.IdempotencyKey,
+				})
 
 				return nil
 
@@ -547,26 +581,21 @@ func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder,
 	}
 
 	// Publish PaymentOrderFailed event
-	if s.kafkaProducer != nil {
-		event := &eventsv1.PaymentOrderFailedEvent{
-			EventId:         uuid.New().String(),
-			PaymentOrderId:  po.ID.String(),
-			DebtorAccountId: po.DebtorAccountID,
-			Amount:          toMoneyAmount(po.Amount),
-			FailureReason:   reason,
-			ErrorCode:       errorCode,
-			FailedAtStatus:  mapStatusToProto(failedAtStatus),
-			LienId:          lienID,
-			CorrelationId:   po.CorrelationID,
-			CausationId:     po.ID.String(),
-			Timestamp:       timestamppb.Now(),
-			Version:         int64(po.Version),
-			IdempotencyKey:  po.IdempotencyKey,
-		}
-		if err := s.kafkaProducer.Publish(ctx, TopicPaymentOrderFailed, po.ID.String(), event); err != nil {
-			s.logger.Error("failed to publish PaymentOrderFailed event", "error", err)
-		}
-	}
+	s.publishEvent(ctx, TopicPaymentOrderFailed, po.ID.String(), &eventsv1.PaymentOrderFailedEvent{
+		EventId:         uuid.New().String(),
+		PaymentOrderId:  po.ID.String(),
+		DebtorAccountId: po.DebtorAccountID,
+		Amount:          toMoneyAmount(po.Amount),
+		FailureReason:   reason,
+		ErrorCode:       errorCode,
+		FailedAtStatus:  mapStatusToProto(failedAtStatus),
+		LienId:          lienID,
+		CorrelationId:   po.CorrelationID,
+		CausationId:     po.ID.String(),
+		Timestamp:       timestamppb.Now(),
+		Version:         int64(po.Version),
+		IdempotencyKey:  po.IdempotencyKey,
+	})
 
 	s.logger.Info("payment order failed",
 		"payment_order_id", po.ID.String(),
@@ -670,25 +699,20 @@ func (s *Service) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentO
 		}
 
 		// Publish PaymentOrderCompleted event
-		if s.kafkaProducer != nil {
-			event := &eventsv1.PaymentOrderCompletedEvent{
-				EventId:            uuid.New().String(),
-				PaymentOrderId:     po.ID.String(),
-				DebtorAccountId:    po.DebtorAccountID,
-				Amount:             toMoneyAmount(po.Amount),
-				LienId:             po.LienID,
-				GatewayReferenceId: po.GatewayReferenceID,
-				LedgerBookingId:    po.LedgerBookingID,
-				CorrelationId:      po.CorrelationID,
-				CausationId:        po.ID.String(),
-				Timestamp:          timestamppb.Now(),
-				Version:            int64(po.Version),
-				IdempotencyKey:     po.IdempotencyKey,
-			}
-			if err := s.kafkaProducer.Publish(ctx, TopicPaymentOrderCompleted, po.ID.String(), event); err != nil {
-				s.logger.Error("failed to publish PaymentOrderCompleted event", "error", err)
-			}
-		}
+		s.publishEvent(ctx, TopicPaymentOrderCompleted, po.ID.String(), &eventsv1.PaymentOrderCompletedEvent{
+			EventId:            uuid.New().String(),
+			PaymentOrderId:     po.ID.String(),
+			DebtorAccountId:    po.DebtorAccountID,
+			Amount:             toMoneyAmount(po.Amount),
+			LienId:             po.LienID,
+			GatewayReferenceId: po.GatewayReferenceID,
+			LedgerBookingId:    po.LedgerBookingID,
+			CorrelationId:      po.CorrelationID,
+			CausationId:        po.ID.String(),
+			Timestamp:          timestamppb.Now(),
+			Version:            int64(po.Version),
+			IdempotencyKey:     po.IdempotencyKey,
+		})
 
 		s.logger.Info("payment order completed",
 			"payment_order_id", po.ID.String(),
@@ -771,25 +795,20 @@ func (s *Service) CancelPaymentOrder(ctx context.Context, req *pb.CancelPaymentO
 	}
 
 	// Publish PaymentOrderCancelled event
-	if s.kafkaProducer != nil {
-		event := &eventsv1.PaymentOrderCancelledEvent{
-			EventId:            uuid.New().String(),
-			PaymentOrderId:     po.ID.String(),
-			DebtorAccountId:    po.DebtorAccountID,
-			Amount:             toMoneyAmount(po.Amount),
-			CancellationReason: req.CancellationReason,
-			CancelledBy:        req.CancelledBy,
-			LienId:             lienID,
-			CorrelationId:      po.CorrelationID,
-			CausationId:        po.ID.String(),
-			Timestamp:          timestamppb.Now(),
-			Version:            int64(po.Version),
-			IdempotencyKey:     po.IdempotencyKey,
-		}
-		if err := s.kafkaProducer.Publish(ctx, TopicPaymentOrderCancelled, po.ID.String(), event); err != nil {
-			s.logger.Error("failed to publish PaymentOrderCancelled event", "error", err)
-		}
-	}
+	s.publishEvent(ctx, TopicPaymentOrderCancelled, po.ID.String(), &eventsv1.PaymentOrderCancelledEvent{
+		EventId:            uuid.New().String(),
+		PaymentOrderId:     po.ID.String(),
+		DebtorAccountId:    po.DebtorAccountID,
+		Amount:             toMoneyAmount(po.Amount),
+		CancellationReason: req.CancellationReason,
+		CancelledBy:        req.CancelledBy,
+		LienId:             lienID,
+		CorrelationId:      po.CorrelationID,
+		CausationId:        po.ID.String(),
+		Timestamp:          timestamppb.Now(),
+		Version:            int64(po.Version),
+		IdempotencyKey:     po.IdempotencyKey,
+	})
 
 	s.logger.Info("payment order cancelled",
 		"payment_order_id", po.ID.String(),
@@ -809,14 +828,11 @@ func (s *Service) ListPaymentOrders(_ context.Context, req *pb.ListPaymentOrders
 	}
 
 	// Parse and validate pagination parameters
-	const defaultPageSize = 50
-	const maxPageSize = 1000
-
-	pageSize := defaultPageSize
+	pageSize := s.defaultPageSize
 	if req.Pagination != nil && req.Pagination.PageSize > 0 {
 		pageSize = int(req.Pagination.PageSize)
-		if pageSize > maxPageSize {
-			pageSize = maxPageSize
+		if pageSize > s.maxPageSize {
+			pageSize = s.maxPageSize
 		}
 	}
 
@@ -859,6 +875,24 @@ func (s *Service) ListPaymentOrders(_ context.Context, req *pb.ListPaymentOrders
 }
 
 // Helper functions
+
+// publishEvent publishes a Kafka event if the producer is configured.
+// Logs errors but does not fail the operation - events are recovered via outbox pattern.
+func (s *Service) publishEvent(ctx context.Context, topic string, key string, event proto.Message) {
+	if s.kafkaProducer == nil {
+		return
+	}
+	if err := s.kafkaProducer.Publish(ctx, topic, key, event); err != nil {
+		s.logger.Error("failed to publish event",
+			"topic", topic,
+			"key", key,
+			"error", err)
+	} else {
+		s.logger.Info("published event",
+			"topic", topic,
+			"key", key)
+	}
+}
 
 // toProto converts a domain PaymentOrder to proto PaymentOrder
 func toProto(po *domain.PaymentOrder) *pb.PaymentOrder {

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -1,0 +1,846 @@
+// Package service implements gRPC services for the payment order domain
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	"github.com/meridianhub/meridian/internal/current-account/clients"
+	cadomain "github.com/meridianhub/meridian/internal/current-account/domain"
+	"github.com/meridianhub/meridian/internal/payment-order/adapters/gateway"
+	"github.com/meridianhub/meridian/internal/payment-order/adapters/persistence"
+	"github.com/meridianhub/meridian/internal/payment-order/domain"
+	"github.com/meridianhub/meridian/internal/platform/kafka"
+	"github.com/meridianhub/meridian/internal/platform/observability"
+	"google.golang.org/genproto/googleapis/type/money"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Service errors
+var (
+	ErrRepositoryNil             = errors.New("repository cannot be nil")
+	ErrCurrentAccountClientNil   = errors.New("current account client cannot be nil")
+	ErrPaymentGatewayNil         = errors.New("payment gateway cannot be nil")
+	ErrKafkaProducerNil          = errors.New("kafka producer cannot be nil")
+	ErrCurrentAccountTargetEmpty = errors.New("current account target cannot be empty")
+	ErrAmountRequired            = errors.New("amount is required")
+	ErrPaymentRejected           = errors.New("payment rejected by gateway")
+	ErrUnexpectedGatewayStatus   = errors.New("unexpected gateway status")
+)
+
+// Kafka topic constants
+const (
+	TopicPaymentOrderInitiated = "payment-order.initiated.v1"
+	TopicPaymentOrderReserved  = "payment-order.reserved.v1"
+	TopicPaymentOrderExecuting = "payment-order.executing.v1"
+	TopicPaymentOrderCompleted = "payment-order.completed.v1"
+	TopicPaymentOrderFailed    = "payment-order.failed.v1"
+)
+
+// CurrentAccountClient defines the interface for communicating with the CurrentAccount service
+// for lien operations (fund reservation).
+type CurrentAccountClient interface {
+	// InitiateLien creates a fund reservation on an account
+	InitiateLien(ctx context.Context, req *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error)
+	// TerminateLien releases a reservation without executing
+	TerminateLien(ctx context.Context, req *currentaccountv1.TerminateLienRequest) (*currentaccountv1.TerminateLienResponse, error)
+	// ExecuteLien converts a reservation to an actual debit
+	ExecuteLien(ctx context.Context, req *currentaccountv1.ExecuteLienRequest) (*currentaccountv1.ExecuteLienResponse, error)
+	// Close terminates the client connection
+	Close() error
+}
+
+// Service implements the PaymentOrderService gRPC service
+type Service struct {
+	pb.UnimplementedPaymentOrderServiceServer
+	repo                 persistence.Repository
+	currentAccountClient CurrentAccountClient
+	paymentGateway       gateway.PaymentGateway
+	kafkaProducer        *kafka.ProtoProducer
+	logger               *slog.Logger
+	tracer               *observability.Tracer
+}
+
+// Config contains configuration for creating a new Service
+type Config struct {
+	Repository           persistence.Repository
+	CurrentAccountClient CurrentAccountClient
+	PaymentGateway       gateway.PaymentGateway
+	KafkaProducer        *kafka.ProtoProducer
+	Logger               *slog.Logger
+	Tracer               *observability.Tracer
+}
+
+// NewService creates a new payment order service with minimal dependencies.
+// This is primarily used for testing. For production use, prefer NewServiceWithClients.
+func NewService(repo persistence.Repository) *Service {
+	if repo == nil {
+		panic("repository cannot be nil")
+	}
+	return &Service{
+		repo:   repo,
+		logger: slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}
+}
+
+// NewServiceWithConfig creates a new payment order service with full configuration.
+// Validates all required dependencies and applies defaults where appropriate.
+func NewServiceWithConfig(config Config) (*Service, error) {
+	// Validate required dependencies
+	if config.Repository == nil {
+		return nil, ErrRepositoryNil
+	}
+	if config.CurrentAccountClient == nil {
+		return nil, ErrCurrentAccountClientNil
+	}
+	if config.PaymentGateway == nil {
+		return nil, ErrPaymentGatewayNil
+	}
+	if config.KafkaProducer == nil {
+		return nil, ErrKafkaProducerNil
+	}
+
+	// Apply default logger if not provided
+	logger := config.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+
+	return &Service{
+		repo:                 config.Repository,
+		currentAccountClient: config.CurrentAccountClient,
+		paymentGateway:       config.PaymentGateway,
+		kafkaProducer:        config.KafkaProducer,
+		logger:               logger,
+		tracer:               config.Tracer,
+	}, nil
+}
+
+// InitiatePaymentOrder creates a new payment order and begins the saga.
+func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaymentOrderRequest) (*pb.InitiatePaymentOrderResponse, error) {
+	start := time.Now()
+	defer func() {
+		s.logger.Info("initiate_payment_order completed",
+			"duration_ms", time.Since(start).Milliseconds())
+	}()
+
+	// Extract or generate correlation ID
+	correlationID := req.CorrelationId
+	if correlationID == "" {
+		correlationID = uuid.New().String()
+		s.logger.Info("generated correlation ID", "correlation_id", correlationID)
+	}
+
+	// Get idempotency key
+	idempotencyKey := req.IdempotencyKey.Key
+
+	// Check for existing payment order with same idempotency key (idempotent)
+	existingPO, err := s.repo.FindByIdempotencyKey(idempotencyKey)
+	if err != nil && !errors.Is(err, persistence.ErrPaymentOrderNotFound) {
+		s.logger.Error("failed to check idempotency", "error", err)
+		return nil, status.Error(codes.Internal, "failed to check idempotency")
+	}
+	if existingPO != nil {
+		s.logger.Info("returning existing payment order (idempotent)",
+			"payment_order_id", existingPO.ID.String(),
+			"idempotency_key", idempotencyKey)
+		return &pb.InitiatePaymentOrderResponse{
+			PaymentOrder: toProto(existingPO),
+		}, nil
+	}
+
+	// Validate and convert amount
+	amount, err := protoToMoney(req.Amount)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid amount: %v", err)
+	}
+	if !amount.IsPositive() {
+		return nil, status.Error(codes.InvalidArgument, "amount must be positive")
+	}
+
+	// Create domain payment order
+	po, err := domain.NewPaymentOrder(
+		req.DebtorAccountId,
+		req.CreditorReference,
+		amount,
+		idempotencyKey,
+		correlationID,
+	)
+	if err != nil {
+		s.logger.Error("failed to create payment order", "error", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to create payment order: %v", err)
+	}
+
+	// Persist to database
+	if err := s.repo.Create(po); err != nil {
+		s.logger.Error("failed to save payment order", "error", err)
+		return nil, status.Error(codes.Internal, "failed to save payment order")
+	}
+
+	s.logger.Info("payment order created",
+		"payment_order_id", po.ID.String(),
+		"debtor_account_id", po.DebtorAccountID,
+		"amount_cents", po.Amount.AmountCents(),
+		"correlation_id", correlationID)
+
+	// Publish PaymentOrderInitiated event to Kafka
+	if s.kafkaProducer != nil {
+		event := &eventsv1.PaymentOrderInitiatedEvent{
+			EventId:           uuid.New().String(),
+			PaymentOrderId:    po.ID.String(),
+			DebtorAccountId:   po.DebtorAccountID,
+			CreditorReference: po.CreditorReference,
+			Amount:            toMoneyAmount(po.Amount),
+			CorrelationId:     po.CorrelationID,
+			CausationId:       po.ID.String(), // Initial event caused by the order creation
+			Timestamp:         timestamppb.Now(),
+			Version:           int64(po.Version),
+			IdempotencyKey:    po.IdempotencyKey,
+		}
+
+		if err := s.kafkaProducer.Publish(ctx, TopicPaymentOrderInitiated, po.ID.String(), event); err != nil {
+			s.logger.Error("failed to publish PaymentOrderInitiated event",
+				"error", err,
+				"payment_order_id", po.ID.String())
+			// Don't fail the request - event will be recovered via outbox pattern or retry
+		} else {
+			s.logger.Info("published PaymentOrderInitiated event",
+				"payment_order_id", po.ID.String(),
+				"topic", TopicPaymentOrderInitiated)
+		}
+	}
+
+	// Start saga orchestration asynchronously
+	// The saga runs in the background after returning the response
+	// nolint:contextcheck // Intentionally using background context for async saga orchestration
+	go func() {
+		sagaCtx := context.Background()
+		if s.tracer != nil {
+			sagaCtx = observability.WithCorrelationID(sagaCtx, correlationID)
+		}
+		s.orchestratePayment(sagaCtx, po)
+	}()
+
+	return &pb.InitiatePaymentOrderResponse{
+		PaymentOrder: toProto(po),
+	}, nil
+}
+
+// orchestratePayment executes the payment saga with compensation on failure.
+// nolint:gocognit // Complex saga orchestration requires multiple nested steps
+func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrder) {
+	s.logger.Info("starting payment saga",
+		"payment_order_id", po.ID.String(),
+		"correlation_id", po.CorrelationID)
+
+	// Check if all dependencies are available
+	if s.currentAccountClient == nil || s.paymentGateway == nil {
+		s.logger.Error("saga dependencies not configured",
+			"payment_order_id", po.ID.String())
+		s.failPaymentOrder(ctx, po, "service configuration error", "INTERNAL_ERROR")
+		return
+	}
+
+	// Create saga orchestrator
+	saga := clients.NewSagaOrchestrator(s.logger)
+
+	// Track saga state for compensation
+	var lienID string
+
+	// Step 1: Reserve funds via CurrentAccount.InitiateLien
+	saga.AddStep("reserve_funds",
+		// Action: Create lien to reserve funds
+		func(stepCtx context.Context) error {
+			s.logger.Info("executing reserve_funds step",
+				"payment_order_id", po.ID.String(),
+				"debtor_account_id", po.DebtorAccountID)
+
+			resp, err := s.currentAccountClient.InitiateLien(stepCtx, &currentaccountv1.InitiateLienRequest{
+				AccountId:             po.DebtorAccountID,
+				Amount:                toMoneyAmount(po.Amount),
+				PaymentOrderReference: po.ID.String(),
+			})
+			if err != nil {
+				return fmt.Errorf("failed to reserve funds: %w", err)
+			}
+
+			lienID = resp.Lien.LienId
+
+			// Update payment order with lien ID and transition to RESERVED
+			if err := po.Reserve(lienID); err != nil {
+				return fmt.Errorf("failed to transition to RESERVED: %w", err)
+			}
+
+			if err := s.repo.Update(po); err != nil {
+				return fmt.Errorf("failed to update payment order: %w", err)
+			}
+
+			s.logger.Info("reserve_funds step completed",
+				"payment_order_id", po.ID.String(),
+				"lien_id", lienID)
+
+			// Publish PaymentOrderReserved event
+			if s.kafkaProducer != nil {
+				event := &eventsv1.PaymentOrderReservedEvent{
+					EventId:         uuid.New().String(),
+					PaymentOrderId:  po.ID.String(),
+					DebtorAccountId: po.DebtorAccountID,
+					LienId:          lienID,
+					Amount:          toMoneyAmount(po.Amount),
+					CorrelationId:   po.CorrelationID,
+					CausationId:     po.ID.String(),
+					Timestamp:       timestamppb.Now(),
+					Version:         int64(po.Version),
+					IdempotencyKey:  po.IdempotencyKey,
+				}
+				if err := s.kafkaProducer.Publish(stepCtx, TopicPaymentOrderReserved, po.ID.String(), event); err != nil {
+					s.logger.Error("failed to publish PaymentOrderReserved event", "error", err)
+				}
+			}
+
+			return nil
+		},
+		// Compensate: Release lien
+		func(stepCtx context.Context) error {
+			if lienID == "" {
+				s.logger.Warn("no lien to release in compensation")
+				return nil
+			}
+
+			s.logger.Info("compensating reserve_funds step",
+				"payment_order_id", po.ID.String(),
+				"lien_id", lienID)
+
+			_, err := s.currentAccountClient.TerminateLien(stepCtx, &currentaccountv1.TerminateLienRequest{
+				LienId: lienID,
+				Reason: fmt.Sprintf("Payment order %s saga compensation", po.ID.String()),
+			})
+			if err != nil {
+				s.logger.Error("failed to release lien in compensation",
+					"error", err,
+					"lien_id", lienID)
+				return err
+			}
+
+			s.logger.Info("reserve_funds compensation completed",
+				"lien_id", lienID)
+
+			return nil
+		},
+	)
+
+	// Step 2: Send to payment gateway
+	saga.AddStep("send_to_gateway",
+		// Action: Send payment to gateway
+		func(stepCtx context.Context) error {
+			s.logger.Info("executing send_to_gateway step",
+				"payment_order_id", po.ID.String())
+
+			resp, err := s.paymentGateway.SendPayment(stepCtx, gateway.PaymentRequest{
+				PaymentOrderID:    po.ID,
+				DebtorAccountID:   po.DebtorAccountID,
+				CreditorReference: po.CreditorReference,
+				Amount:            po.Amount,
+				IdempotencyKey:    po.IdempotencyKey,
+			})
+			if err != nil {
+				return fmt.Errorf("failed to send payment to gateway: %w", err)
+			}
+
+			// Check gateway response status
+			switch resp.Status {
+			case gateway.StatusAccepted, gateway.StatusPending:
+				// Transition to EXECUTING
+				if err := po.Execute(resp.GatewayReferenceID); err != nil {
+					return fmt.Errorf("failed to transition to EXECUTING: %w", err)
+				}
+
+				if err := s.repo.Update(po); err != nil {
+					return fmt.Errorf("failed to update payment order: %w", err)
+				}
+
+				s.logger.Info("send_to_gateway step completed",
+					"payment_order_id", po.ID.String(),
+					"gateway_reference_id", resp.GatewayReferenceID,
+					"gateway_status", resp.Status)
+
+				// Publish PaymentOrderExecuting event
+				if s.kafkaProducer != nil {
+					event := &eventsv1.PaymentOrderExecutingEvent{
+						EventId:            uuid.New().String(),
+						PaymentOrderId:     po.ID.String(),
+						GatewayReferenceId: resp.GatewayReferenceID,
+						CorrelationId:      po.CorrelationID,
+						CausationId:        po.ID.String(),
+						Timestamp:          timestamppb.Now(),
+						Version:            int64(po.Version),
+						IdempotencyKey:     po.IdempotencyKey,
+					}
+					if err := s.kafkaProducer.Publish(stepCtx, TopicPaymentOrderExecuting, po.ID.String(), event); err != nil {
+						s.logger.Error("failed to publish PaymentOrderExecuting event", "error", err)
+					}
+				}
+
+				return nil
+
+			case gateway.StatusRejected:
+				return fmt.Errorf("%w: %s", ErrPaymentRejected, resp.Message)
+
+			default:
+				return fmt.Errorf("%w: %s", ErrUnexpectedGatewayStatus, resp.Status)
+			}
+		},
+		// Compensate: Mark as failed (lien will be released by previous step's compensation)
+		func(_ context.Context) error {
+			s.logger.Info("send_to_gateway compensation (no-op - lien released by reserve_funds compensation)",
+				"payment_order_id", po.ID.String())
+			return nil
+		},
+	)
+
+	// Execute saga
+	result := saga.Execute(ctx)
+
+	if !result.Success {
+		s.logger.Error("payment saga failed",
+			"payment_order_id", po.ID.String(),
+			"failed_step", result.FailedStep,
+			"error", result.Error,
+			"completed_steps", result.CompletedSteps,
+			"compensated_steps", result.CompensatedSteps)
+
+		// Reload payment order to get latest state
+		latestPO, err := s.repo.FindByID(po.ID)
+		if err != nil {
+			s.logger.Error("failed to reload payment order for failure handling", "error", err)
+			return
+		}
+
+		s.failPaymentOrder(ctx, latestPO, result.Error.Error(), "SAGA_FAILED")
+		return
+	}
+
+	s.logger.Info("payment saga completed successfully",
+		"payment_order_id", po.ID.String(),
+		"completed_steps", result.CompletedSteps)
+
+	// Note: The payment is now in EXECUTING state, awaiting async gateway callback
+	// via UpdatePaymentOrder to transition to COMPLETED or FAILED
+}
+
+// failPaymentOrder handles payment order failure with proper state transition and event publishing.
+func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder, reason string, errorCode string) {
+	// Check if lien needs to be released before transitioning
+	needsLienRelease := po.RequiresLienRelease()
+	lienID := po.LienID
+
+	// Transition to FAILED
+	if err := po.Fail(reason, errorCode); err != nil {
+		s.logger.Error("failed to transition to FAILED state",
+			"error", err,
+			"payment_order_id", po.ID.String())
+		return
+	}
+
+	if err := s.repo.Update(po); err != nil {
+		s.logger.Error("failed to persist FAILED state",
+			"error", err,
+			"payment_order_id", po.ID.String())
+		return
+	}
+
+	// Release lien if needed
+	if needsLienRelease && lienID != "" && s.currentAccountClient != nil {
+		_, err := s.currentAccountClient.TerminateLien(ctx, &currentaccountv1.TerminateLienRequest{
+			LienId: lienID,
+			Reason: fmt.Sprintf("Payment order %s failed: %s", po.ID.String(), reason),
+		})
+		if err != nil {
+			s.logger.Error("failed to release lien after failure",
+				"error", err,
+				"lien_id", lienID,
+				"payment_order_id", po.ID.String())
+		}
+	}
+
+	// Publish PaymentOrderFailed event
+	if s.kafkaProducer != nil {
+		event := &eventsv1.PaymentOrderFailedEvent{
+			EventId:         uuid.New().String(),
+			PaymentOrderId:  po.ID.String(),
+			DebtorAccountId: po.DebtorAccountID,
+			Amount:          toMoneyAmount(po.Amount),
+			FailureReason:   reason,
+			ErrorCode:       errorCode,
+			FailedAtStatus:  mapStatusToProto(po.Status),
+			LienId:          lienID,
+			CorrelationId:   po.CorrelationID,
+			CausationId:     po.ID.String(),
+			Timestamp:       timestamppb.Now(),
+			Version:         int64(po.Version),
+			IdempotencyKey:  po.IdempotencyKey,
+		}
+		if err := s.kafkaProducer.Publish(ctx, TopicPaymentOrderFailed, po.ID.String(), event); err != nil {
+			s.logger.Error("failed to publish PaymentOrderFailed event", "error", err)
+		}
+	}
+
+	s.logger.Info("payment order failed",
+		"payment_order_id", po.ID.String(),
+		"reason", reason,
+		"error_code", errorCode)
+}
+
+// RetrievePaymentOrder gets payment order details by ID.
+func (s *Service) RetrievePaymentOrder(_ context.Context, req *pb.RetrievePaymentOrderRequest) (*pb.RetrievePaymentOrderResponse, error) {
+	// Parse payment order ID
+	poID, err := uuid.Parse(req.PaymentOrderId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid payment order ID: %v", err)
+	}
+
+	// Retrieve from repository
+	po, err := s.repo.FindByID(poID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrPaymentOrderNotFound) {
+			return nil, status.Errorf(codes.NotFound, "payment order not found: %s", req.PaymentOrderId)
+		}
+		s.logger.Error("failed to retrieve payment order", "error", err)
+		return nil, status.Error(codes.Internal, "failed to retrieve payment order")
+	}
+
+	return &pb.RetrievePaymentOrderResponse{
+		PaymentOrder: toProto(po),
+	}, nil
+}
+
+// UpdatePaymentOrder handles asynchronous gateway callbacks.
+// nolint:gocognit // Gateway callback handling requires multiple state transitions
+func (s *Service) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error) {
+	start := time.Now()
+	defer func() {
+		s.logger.Info("update_payment_order completed",
+			"duration_ms", time.Since(start).Milliseconds())
+	}()
+
+	// Lookup payment order
+	var po *domain.PaymentOrder
+	var err error
+
+	if req.PaymentOrderId != "" {
+		poID, parseErr := uuid.Parse(req.PaymentOrderId)
+		if parseErr != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid payment order ID: %v", parseErr)
+		}
+		po, err = s.repo.FindByID(poID)
+	} else if req.GatewayReferenceId != "" {
+		po, err = s.repo.FindByGatewayReferenceID(req.GatewayReferenceId)
+	} else {
+		return nil, status.Error(codes.InvalidArgument, "either payment_order_id or gateway_reference_id must be provided")
+	}
+
+	if err != nil {
+		if errors.Is(err, persistence.ErrPaymentOrderNotFound) {
+			return nil, status.Error(codes.NotFound, "payment order not found")
+		}
+		s.logger.Error("failed to find payment order", "error", err)
+		return nil, status.Error(codes.Internal, "failed to find payment order")
+	}
+
+	// Process based on gateway status
+	switch req.GatewayStatus {
+	case pb.GatewayStatus_GATEWAY_STATUS_SETTLED:
+		// Complete the payment
+		if err := po.Complete(""); err != nil {
+			if errors.Is(err, domain.ErrInvalidPaymentOrderTransition) {
+				// Already completed (idempotent)
+				if po.Status == domain.PaymentOrderStatusCompleted {
+					return &pb.UpdatePaymentOrderResponse{PaymentOrder: toProto(po)}, nil
+				}
+				return nil, status.Errorf(codes.FailedPrecondition, "cannot complete payment: %v", err)
+			}
+			return nil, status.Errorf(codes.Internal, "failed to complete payment: %v", err)
+		}
+
+		if err := s.repo.Update(po); err != nil {
+			s.logger.Error("failed to update payment order", "error", err)
+			return nil, status.Error(codes.Internal, "failed to update payment order")
+		}
+
+		// Execute lien (convert reservation to actual debit)
+		if s.currentAccountClient != nil && po.LienID != "" {
+			_, execErr := s.currentAccountClient.ExecuteLien(ctx, &currentaccountv1.ExecuteLienRequest{
+				LienId: po.LienID,
+			})
+			if execErr != nil {
+				s.logger.Error("failed to execute lien", "error", execErr, "lien_id", po.LienID)
+				// Continue - the payment is still complete, lien execution can be retried
+			}
+		}
+
+		// Publish PaymentOrderCompleted event
+		if s.kafkaProducer != nil {
+			event := &eventsv1.PaymentOrderCompletedEvent{
+				EventId:            uuid.New().String(),
+				PaymentOrderId:     po.ID.String(),
+				DebtorAccountId:    po.DebtorAccountID,
+				Amount:             toMoneyAmount(po.Amount),
+				LienId:             po.LienID,
+				GatewayReferenceId: po.GatewayReferenceID,
+				LedgerBookingId:    po.LedgerBookingID,
+				CorrelationId:      po.CorrelationID,
+				CausationId:        po.ID.String(),
+				Timestamp:          timestamppb.Now(),
+				Version:            int64(po.Version),
+				IdempotencyKey:     po.IdempotencyKey,
+			}
+			if err := s.kafkaProducer.Publish(ctx, TopicPaymentOrderCompleted, po.ID.String(), event); err != nil {
+				s.logger.Error("failed to publish PaymentOrderCompleted event", "error", err)
+			}
+		}
+
+		s.logger.Info("payment order completed",
+			"payment_order_id", po.ID.String(),
+			"gateway_reference_id", po.GatewayReferenceID)
+
+	case pb.GatewayStatus_GATEWAY_STATUS_REJECTED:
+		// Fail the payment
+		s.failPaymentOrder(ctx, po, req.GatewayMessage, "GATEWAY_REJECTED")
+
+	case pb.GatewayStatus_GATEWAY_STATUS_PENDING:
+		// No state change needed - still waiting
+		s.logger.Info("payment still pending at gateway",
+			"payment_order_id", po.ID.String(),
+			"gateway_reference_id", req.GatewayReferenceId)
+
+	case pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED:
+		return nil, status.Error(codes.InvalidArgument, "gateway status is required")
+	}
+
+	return &pb.UpdatePaymentOrderResponse{
+		PaymentOrder: toProto(po),
+	}, nil
+}
+
+// CancelPaymentOrder cancels a payment order before completion.
+func (s *Service) CancelPaymentOrder(ctx context.Context, req *pb.CancelPaymentOrderRequest) (*pb.CancelPaymentOrderResponse, error) {
+	// Parse payment order ID
+	poID, err := uuid.Parse(req.PaymentOrderId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid payment order ID: %v", err)
+	}
+
+	// Retrieve payment order
+	po, err := s.repo.FindByID(poID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrPaymentOrderNotFound) {
+			return nil, status.Errorf(codes.NotFound, "payment order not found: %s", req.PaymentOrderId)
+		}
+		return nil, status.Error(codes.Internal, "failed to retrieve payment order")
+	}
+
+	// Check if already cancelled (idempotent)
+	if po.Status == domain.PaymentOrderStatusCancelled {
+		return &pb.CancelPaymentOrderResponse{PaymentOrder: toProto(po)}, nil
+	}
+
+	// Check if can be cancelled
+	if !po.CanCancel() {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"payment order cannot be cancelled in status %s", po.Status)
+	}
+
+	// Check if lien needs to be released
+	needsLienRelease := po.RequiresLienRelease()
+	lienID := po.LienID
+
+	// Cancel the payment order
+	if err := po.Cancel(req.CancellationReason); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to cancel payment order: %v", err)
+	}
+
+	if err := s.repo.Update(po); err != nil {
+		return nil, status.Error(codes.Internal, "failed to update payment order")
+	}
+
+	// Release lien if needed
+	if needsLienRelease && lienID != "" && s.currentAccountClient != nil {
+		_, termErr := s.currentAccountClient.TerminateLien(ctx, &currentaccountv1.TerminateLienRequest{
+			LienId: lienID,
+			Reason: fmt.Sprintf("Payment order %s cancelled: %s", po.ID.String(), req.CancellationReason),
+		})
+		if termErr != nil {
+			s.logger.Error("failed to release lien after cancellation",
+				"error", termErr,
+				"lien_id", lienID)
+			// Continue - cancellation succeeded, lien release can be retried
+		}
+	}
+
+	// Publish PaymentOrderCancelled event
+	if s.kafkaProducer != nil {
+		event := &eventsv1.PaymentOrderCancelledEvent{
+			EventId:            uuid.New().String(),
+			PaymentOrderId:     po.ID.String(),
+			DebtorAccountId:    po.DebtorAccountID,
+			Amount:             toMoneyAmount(po.Amount),
+			CancellationReason: req.CancellationReason,
+			CancelledBy:        req.CancelledBy,
+			LienId:             lienID,
+			CorrelationId:      po.CorrelationID,
+			CausationId:        po.ID.String(),
+			Timestamp:          timestamppb.Now(),
+			Version:            int64(po.Version),
+			IdempotencyKey:     po.IdempotencyKey,
+		}
+		if err := s.kafkaProducer.Publish(ctx, "payment-order.cancelled.v1", po.ID.String(), event); err != nil {
+			s.logger.Error("failed to publish PaymentOrderCancelled event", "error", err)
+		}
+	}
+
+	s.logger.Info("payment order cancelled",
+		"payment_order_id", po.ID.String(),
+		"reason", req.CancellationReason,
+		"cancelled_by", req.CancelledBy)
+
+	return &pb.CancelPaymentOrderResponse{
+		PaymentOrder: toProto(po),
+	}, nil
+}
+
+// ListPaymentOrders returns a paginated list of payment orders.
+func (s *Service) ListPaymentOrders(_ context.Context, req *pb.ListPaymentOrdersRequest) (*pb.ListPaymentOrdersResponse, error) {
+	// For now, implement a simple filter by debtor account ID
+	if req.DebtorAccountId == "" {
+		return nil, status.Error(codes.InvalidArgument, "debtor_account_id is required for listing")
+	}
+
+	paymentOrders, err := s.repo.FindByDebtorAccountID(req.DebtorAccountId)
+	if err != nil {
+		s.logger.Error("failed to list payment orders", "error", err)
+		return nil, status.Error(codes.Internal, "failed to list payment orders")
+	}
+
+	// Convert to proto
+	protoOrders := make([]*pb.PaymentOrder, 0, len(paymentOrders))
+	for _, po := range paymentOrders {
+		protoOrders = append(protoOrders, toProto(po))
+	}
+
+	return &pb.ListPaymentOrdersResponse{
+		PaymentOrders: protoOrders,
+		Pagination: &commonpb.PaginationResponse{
+			TotalCount: int64(len(protoOrders)),
+		},
+	}, nil
+}
+
+// Helper functions
+
+// toProto converts a domain PaymentOrder to proto PaymentOrder
+func toProto(po *domain.PaymentOrder) *pb.PaymentOrder {
+	proto := &pb.PaymentOrder{
+		PaymentOrderId:     po.ID.String(),
+		DebtorAccountId:    po.DebtorAccountID,
+		CreditorReference:  po.CreditorReference,
+		Amount:             toMoneyAmount(po.Amount),
+		Status:             mapStatusToProto(po.Status),
+		LienId:             po.LienID,
+		GatewayReferenceId: po.GatewayReferenceID,
+		CorrelationId:      po.CorrelationID,
+		IdempotencyKey:     po.IdempotencyKey,
+		FailureReason:      po.FailureReason,
+		CreatedAt:          timestamppb.New(po.CreatedAt),
+		UpdatedAt:          timestamppb.New(po.UpdatedAt),
+		Version:            int64(po.Version),
+		LedgerBookingId:    po.LedgerBookingID,
+		CausationId:        po.CausationID,
+		ErrorCode:          po.ErrorCode,
+	}
+
+	// Set optional timestamps
+	if po.ReservedAt != nil {
+		proto.ReservedAt = timestamppb.New(*po.ReservedAt)
+	}
+	if po.ExecutingAt != nil {
+		proto.ExecutingAt = timestamppb.New(*po.ExecutingAt)
+	}
+	if po.CompletedAt != nil {
+		proto.CompletedAt = timestamppb.New(*po.CompletedAt)
+	}
+	if po.FailedAt != nil {
+		proto.FailedAt = timestamppb.New(*po.FailedAt)
+	}
+	if po.CancelledAt != nil {
+		proto.CancelledAt = timestamppb.New(*po.CancelledAt)
+	}
+	if po.ReversedAt != nil {
+		proto.ReversedAt = timestamppb.New(*po.ReversedAt)
+	}
+
+	return proto
+}
+
+// toMoneyAmount converts domain Money to proto MoneyAmount
+func toMoneyAmount(m cadomain.Money) *commonpb.MoneyAmount {
+	amountCents := m.AmountCents()
+	units := amountCents / 100
+	remainder := amountCents % 100
+	// #nosec G115 - remainder is always -99 to 99
+	nanos := int32(remainder * 10000000)
+
+	return &commonpb.MoneyAmount{
+		Amount: &money.Money{
+			CurrencyCode: m.Currency(),
+			Units:        units,
+			Nanos:        nanos,
+		},
+	}
+}
+
+// protoToMoney converts proto MoneyAmount to domain Money
+func protoToMoney(amount *commonpb.MoneyAmount) (cadomain.Money, error) {
+	if amount == nil || amount.Amount == nil {
+		return cadomain.Money{}, ErrAmountRequired
+	}
+
+	// Convert to cents
+	unitsCents := amount.Amount.Units * 100
+	nanosCents := (amount.Amount.Nanos + 5000000) / 10000000
+	totalCents := unitsCents + int64(nanosCents)
+
+	return cadomain.NewMoney(amount.Amount.CurrencyCode, totalCents)
+}
+
+// mapStatusToProto maps domain status to proto status
+func mapStatusToProto(status domain.PaymentOrderStatus) pb.PaymentOrderStatus {
+	switch status {
+	case domain.PaymentOrderStatusInitiated:
+		return pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_INITIATED
+	case domain.PaymentOrderStatusReserved:
+		return pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_RESERVED
+	case domain.PaymentOrderStatusExecuting:
+		return pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_EXECUTING
+	case domain.PaymentOrderStatusCompleted:
+		return pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED
+	case domain.PaymentOrderStatusFailed:
+		return pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_FAILED
+	case domain.PaymentOrderStatusCancelled:
+		return pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_CANCELLED
+	case domain.PaymentOrderStatusReversed:
+		return pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_REVERSED
+	default:
+		return pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_UNSPECIFIED
+	}
+}

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -46,6 +47,7 @@ const (
 	TopicPaymentOrderExecuting = "payment-order.executing.v1"
 	TopicPaymentOrderCompleted = "payment-order.completed.v1"
 	TopicPaymentOrderFailed    = "payment-order.failed.v1"
+	TopicPaymentOrderCancelled = "payment-order.cancelled.v1"
 )
 
 // CurrentAccountClient defines the interface for communicating with the CurrentAccount service
@@ -142,8 +144,14 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 		s.logger.Info("generated correlation ID", "correlation_id", correlationID)
 	}
 
-	// Get idempotency key
-	idempotencyKey := req.IdempotencyKey.Key
+	// Get idempotency key (required)
+	var idempotencyKey string
+	if req.IdempotencyKey != nil {
+		idempotencyKey = req.IdempotencyKey.Key
+	}
+	if idempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
 
 	// Check for existing payment order with same idempotency key (idempotent)
 	existingPO, err := s.repo.FindByIdempotencyKey(idempotencyKey)
@@ -441,6 +449,9 @@ func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrde
 
 // failPaymentOrder handles payment order failure with proper state transition and event publishing.
 func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder, reason string, errorCode string) {
+	// Capture original status before transitioning (for event)
+	failedAtStatus := po.Status
+
 	// Check if lien needs to be released before transitioning
 	needsLienRelease := po.RequiresLienRelease()
 	lienID := po.LienID
@@ -483,7 +494,7 @@ func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder,
 			Amount:          toMoneyAmount(po.Amount),
 			FailureReason:   reason,
 			ErrorCode:       errorCode,
-			FailedAtStatus:  mapStatusToProto(po.Status),
+			FailedAtStatus:  mapStatusToProto(failedAtStatus),
 			LienId:          lienID,
 			CorrelationId:   po.CorrelationID,
 			CausationId:     po.ID.String(),
@@ -579,6 +590,11 @@ func (s *Service) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentO
 		}
 
 		// Execute lien (convert reservation to actual debit)
+		// TODO: ExecuteLien failure creates state inconsistency - payment order is COMPLETED
+		// but lien remains active. Consider:
+		// 1. Implement async retry mechanism with idempotent lien execution
+		// 2. Add LienExecutionStatus field to PaymentOrder for reconciliation
+		// 3. Use transactional outbox pattern to ensure eventual consistency
 		if s.currentAccountClient != nil && po.LienID != "" {
 			_, execErr := s.currentAccountClient.ExecuteLien(ctx, &currentaccountv1.ExecuteLienRequest{
 				LienId: po.LienID,
@@ -586,6 +602,7 @@ func (s *Service) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentO
 			if execErr != nil {
 				s.logger.Error("failed to execute lien", "error", execErr, "lien_id", po.LienID)
 				// Continue - the payment is still complete, lien execution can be retried
+				// via reconciliation process or manual intervention
 			}
 		}
 
@@ -704,7 +721,7 @@ func (s *Service) CancelPaymentOrder(ctx context.Context, req *pb.CancelPaymentO
 			Version:            int64(po.Version),
 			IdempotencyKey:     po.IdempotencyKey,
 		}
-		if err := s.kafkaProducer.Publish(ctx, "payment-order.cancelled.v1", po.ID.String(), event); err != nil {
+		if err := s.kafkaProducer.Publish(ctx, TopicPaymentOrderCancelled, po.ID.String(), event); err != nil {
 			s.logger.Error("failed to publish PaymentOrderCancelled event", "error", err)
 		}
 	}
@@ -726,22 +743,71 @@ func (s *Service) ListPaymentOrders(_ context.Context, req *pb.ListPaymentOrders
 		return nil, status.Error(codes.InvalidArgument, "debtor_account_id is required for listing")
 	}
 
+	// TODO: Implement repository-level pagination for better performance with large datasets
 	paymentOrders, err := s.repo.FindByDebtorAccountID(req.DebtorAccountId)
 	if err != nil {
 		s.logger.Error("failed to list payment orders", "error", err)
 		return nil, status.Error(codes.Internal, "failed to list payment orders")
 	}
 
-	// Convert to proto
-	protoOrders := make([]*pb.PaymentOrder, 0, len(paymentOrders))
-	for _, po := range paymentOrders {
+	totalCount := len(paymentOrders)
+
+	// Apply in-memory pagination
+	const defaultPageSize = 50
+	const maxPageSize = 1000
+
+	pageSize := defaultPageSize
+	if req.Pagination != nil && req.Pagination.PageSize > 0 {
+		pageSize = int(req.Pagination.PageSize)
+		if pageSize > maxPageSize {
+			pageSize = maxPageSize
+		}
+	}
+
+	// Parse page token (offset-based for simplicity)
+	offset := 0
+	if req.Pagination != nil && req.Pagination.PageToken != "" {
+		parsedOffset, parseErr := strconv.Atoi(req.Pagination.PageToken)
+		if parseErr != nil {
+			return nil, status.Error(codes.InvalidArgument, "invalid page_token")
+		}
+		offset = parsedOffset
+	}
+
+	// Apply pagination bounds
+	if offset >= totalCount {
+		// Return empty page if offset is beyond results
+		return &pb.ListPaymentOrdersResponse{
+			PaymentOrders: []*pb.PaymentOrder{},
+			Pagination: &commonpb.PaginationResponse{
+				TotalCount: int64(totalCount),
+			},
+		}, nil
+	}
+
+	end := offset + pageSize
+	if end > totalCount {
+		end = totalCount
+	}
+
+	// Convert paginated slice to proto
+	paginatedOrders := paymentOrders[offset:end]
+	protoOrders := make([]*pb.PaymentOrder, 0, len(paginatedOrders))
+	for _, po := range paginatedOrders {
 		protoOrders = append(protoOrders, toProto(po))
+	}
+
+	// Build next page token if more results exist
+	var nextPageToken string
+	if end < totalCount {
+		nextPageToken = strconv.Itoa(end)
 	}
 
 	return &pb.ListPaymentOrdersResponse{
 		PaymentOrders: protoOrders,
 		Pagination: &commonpb.PaginationResponse{
-			TotalCount: int64(len(protoOrders)),
+			NextPageToken: nextPageToken,
+			TotalCount:    int64(totalCount),
 		},
 	}, nil
 }

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -81,6 +81,14 @@ const (
 	DefaultMaxIdempotencyKeyLength = 256
 )
 
+// Money conversion constants for Google Money proto (nanos have 9 decimal places)
+const (
+	// nanosPerCent is the number of nanos in one cent (1 cent = 0.01 = 10^7 nanos)
+	nanosPerCent = 10000000
+	// nanosRoundingOffset is half a cent in nanos, used for rounding
+	nanosRoundingOffset = 5000000
+)
+
 // Service implements the PaymentOrderService gRPC service
 type Service struct {
 	pb.UnimplementedPaymentOrderServiceServer
@@ -218,7 +226,11 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 		return nil, status.Errorf(codes.InvalidArgument, "idempotency_key exceeds maximum length of %d", s.maxIdempotencyKeyLength)
 	}
 
-	// Check for existing payment order with same idempotency key (idempotent)
+	// Check for existing payment order with same idempotency key (idempotent).
+	// Note: This check has a TOCTOU race window where concurrent requests with the same
+	// idempotency key could both pass this check. The database unique constraint on
+	// idempotency_key is the authoritative guard - concurrent inserts will fail with a
+	// constraint violation and should be handled by returning the existing record.
 	existingPO, err := s.repo.FindByIdempotencyKey(idempotencyKey)
 	if err != nil && !errors.Is(err, persistence.ErrPaymentOrderNotFound) {
 		s.logger.Error("failed to check idempotency", "error", err)
@@ -751,6 +763,12 @@ func (s *Service) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentO
 		}
 
 	case pb.GatewayStatus_GATEWAY_STATUS_PENDING:
+		// Validate that we're still in EXECUTING state - PENDING callbacks for
+		// terminal states (COMPLETED, FAILED, etc.) should be rejected as stale
+		if po.Status != domain.PaymentOrderStatusExecuting {
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"cannot process PENDING callback: payment order is in %s state", po.Status)
+		}
 		// No state change needed - still waiting
 		s.logger.Info("payment still pending at gateway",
 			"payment_order_id", po.ID.String(),
@@ -979,7 +997,7 @@ func toMoneyAmount(m cadomain.Money) *commonpb.MoneyAmount {
 	units := amountCents / 100
 	remainder := amountCents % 100
 	// #nosec G115 - remainder is always -99 to 99
-	nanos := int32(remainder * 10000000)
+	nanos := int32(remainder * nanosPerCent)
 
 	return &commonpb.MoneyAmount{
 		Amount: &money.Money{
@@ -1006,9 +1024,9 @@ func protoToMoney(amount *commonpb.MoneyAmount) (cadomain.Money, error) {
 	unitsCents := amount.Amount.Units * 100
 	var nanosCents int64
 	if amount.Amount.Nanos >= 0 {
-		nanosCents = int64((amount.Amount.Nanos + 5000000) / 10000000)
+		nanosCents = int64((amount.Amount.Nanos + nanosRoundingOffset) / nanosPerCent)
 	} else {
-		nanosCents = int64((amount.Amount.Nanos - 5000000) / 10000000)
+		nanosCents = int64((amount.Amount.Nanos - nanosRoundingOffset) / nanosPerCent)
 	}
 	totalCents := unitsCents + nanosCents
 

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -357,6 +357,10 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 }
 
 // orchestratePayment executes the payment saga with compensation on failure.
+// The saga steps (reserve_funds, send_to_gateway) are executed strictly sequentially by
+// the SagaOrchestrator - there is no concurrent step execution. The same PaymentOrder
+// pointer is safely shared across steps since only one step runs at a time.
+// Compensation is also sequential, running in reverse order (LIFO) on failure.
 func (s *Service) orchestratePayment(ctx context.Context, po *domain.PaymentOrder) {
 	s.logger.Info("starting payment saga",
 		"payment_order_id", po.ID.String(),
@@ -393,6 +397,11 @@ func (s *Service) addReserveFundsStep(saga *clients.SagaOrchestrator, po *domain
 	saga.AddStep("reserve_funds",
 		// Action: Create lien to reserve funds
 		func(stepCtx context.Context) error {
+			// Check context cancellation early to avoid unnecessary work
+			if err := stepCtx.Err(); err != nil {
+				return fmt.Errorf("context cancelled before reserve_funds: %w", err)
+			}
+
 			s.logger.Info("executing reserve_funds step",
 				"payment_order_id", po.ID.String(),
 				"debtor_account_id", po.DebtorAccountID)
@@ -472,6 +481,11 @@ func (s *Service) addSendToGatewayStep(saga *clients.SagaOrchestrator, po *domai
 	saga.AddStep("send_to_gateway",
 		// Action: Send payment to gateway
 		func(stepCtx context.Context) error {
+			// Check context cancellation early to avoid unnecessary work
+			if err := stepCtx.Err(); err != nil {
+				return fmt.Errorf("context cancelled before send_to_gateway: %w", err)
+			}
+
 			s.logger.Info("executing send_to_gateway step",
 				"payment_order_id", po.ID.String())
 
@@ -930,7 +944,9 @@ func (s *Service) ListPaymentOrders(_ context.Context, req *pb.ListPaymentOrders
 // Helper functions
 
 // publishEvent publishes a Kafka event if the producer is configured.
-// Logs errors but does not fail the operation - events are recovered via outbox pattern.
+// This is best-effort/fire-and-forget: errors are logged but not retried or persisted.
+// Failed events are NOT automatically recovered. For guaranteed delivery, consider
+// implementing a transactional outbox pattern in the future.
 func (s *Service) publishEvent(ctx context.Context, topic string, key string, event proto.Message) {
 	if s.kafkaProducer == nil {
 		return
@@ -991,7 +1007,13 @@ func toProto(po *domain.PaymentOrder) *pb.PaymentOrder {
 	return proto
 }
 
-// toMoneyAmount converts domain Money to proto MoneyAmount
+// toMoneyAmount converts domain Money (in cents) to proto MoneyAmount (units + nanos).
+// The conversion splits cents into units (dollars) and nanos:
+//   - units = cents / 100 (integer division)
+//   - nanos = (cents % 100) * 10^7 (remainder converted to nanos)
+//
+// This is a lossless conversion since cents are exact representations.
+// The inverse operation protoToMoney uses symmetric rounding for any sub-cent precision.
 func toMoneyAmount(m cadomain.Money) *commonpb.MoneyAmount {
 	amountCents := m.AmountCents()
 	units := amountCents / 100

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -36,6 +36,7 @@ var (
 	ErrPaymentGatewayNil       = errors.New("payment gateway cannot be nil")
 	ErrKafkaProducerNil        = errors.New("kafka producer cannot be nil")
 	ErrAmountRequired          = errors.New("amount is required")
+	ErrInvalidNanos            = errors.New("nanos must be in range [-999999999, 999999999]")
 	ErrPaymentRejected         = errors.New("payment rejected by gateway")
 	ErrUnexpectedGatewayStatus = errors.New("unexpected gateway status")
 	ErrIdempotencyKeyTooLong   = errors.New("idempotency key exceeds maximum length")
@@ -331,6 +332,10 @@ func (s *Service) InitiatePaymentOrder(ctx context.Context, req *pb.InitiatePaym
 		}
 		s.orchestratePayment(sagaCtx, freshPO)
 	}(po.ID)
+
+	// Prevent accidental access to po after goroutine launch - the goroutine
+	// reloads fresh state from DB, so any access to po here would be stale
+	po = nil //nolint:ineffassign // Intentional: prevent future code from accidentally using stale po
 
 	return &pb.InitiatePaymentOrderResponse{
 		PaymentOrder: responseProto,
@@ -741,6 +746,11 @@ func (s *Service) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentO
 
 // CancelPaymentOrder cancels a payment order before completion.
 func (s *Service) CancelPaymentOrder(ctx context.Context, req *pb.CancelPaymentOrderRequest) (*pb.CancelPaymentOrderResponse, error) {
+	// Validate cancellation reason - required for audit purposes
+	if req.CancellationReason == "" {
+		return nil, status.Error(codes.InvalidArgument, "cancellation_reason is required")
+	}
+
 	// Parse payment order ID
 	poID, err := uuid.Parse(req.PaymentOrderId)
 	if err != nil {
@@ -959,6 +969,12 @@ func toMoneyAmount(m cadomain.Money) *commonpb.MoneyAmount {
 func protoToMoney(amount *commonpb.MoneyAmount) (cadomain.Money, error) {
 	if amount == nil || amount.Amount == nil {
 		return cadomain.Money{}, ErrAmountRequired
+	}
+
+	// Validate nanos is within bounds (per Google Money spec)
+	const maxNanos = 999999999
+	if amount.Amount.Nanos < -maxNanos || amount.Amount.Nanos > maxNanos {
+		return cadomain.Money{}, ErrInvalidNanos
 	}
 
 	// Convert to cents with symmetric rounding (round half away from zero)

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -85,15 +85,16 @@ type Config struct {
 }
 
 // NewService creates a new payment order service with minimal dependencies.
-// This is primarily used for testing. For production use, prefer NewServiceWithClients.
-func NewService(repo persistence.Repository) *Service {
+// This is primarily used for testing. For production use, prefer NewServiceWithConfig.
+// Returns ErrRepositoryNil if the repository is nil.
+func NewService(repo persistence.Repository) (*Service, error) {
 	if repo == nil {
-		panic("repository cannot be nil")
+		return nil, ErrRepositoryNil
 	}
 	return &Service{
 		repo:   repo,
 		logger: slog.New(slog.NewJSONHandler(os.Stdout, nil)),
-	}
+	}, nil
 }
 
 // NewServiceWithConfig creates a new payment order service with full configuration.
@@ -761,22 +762,13 @@ func (s *Service) CancelPaymentOrder(ctx context.Context, req *pb.CancelPaymentO
 }
 
 // ListPaymentOrders returns a paginated list of payment orders.
+// Uses database-level pagination for efficient queries on large datasets.
 func (s *Service) ListPaymentOrders(_ context.Context, req *pb.ListPaymentOrdersRequest) (*pb.ListPaymentOrdersResponse, error) {
-	// For now, implement a simple filter by debtor account ID
 	if req.DebtorAccountId == "" {
 		return nil, status.Error(codes.InvalidArgument, "debtor_account_id is required for listing")
 	}
 
-	// TODO: Implement repository-level pagination for better performance with large datasets
-	paymentOrders, err := s.repo.FindByDebtorAccountID(req.DebtorAccountId)
-	if err != nil {
-		s.logger.Error("failed to list payment orders", "error", err)
-		return nil, status.Error(codes.Internal, "failed to list payment orders")
-	}
-
-	totalCount := len(paymentOrders)
-
-	// Apply in-memory pagination
+	// Parse and validate pagination parameters
 	const defaultPageSize = 50
 	const maxPageSize = 1000
 
@@ -788,50 +780,40 @@ func (s *Service) ListPaymentOrders(_ context.Context, req *pb.ListPaymentOrders
 		}
 	}
 
-	// Parse page token (offset-based for simplicity)
+	// Parse page token (offset-based)
 	offset := 0
 	if req.Pagination != nil && req.Pagination.PageToken != "" {
 		parsedOffset, parseErr := strconv.Atoi(req.Pagination.PageToken)
-		if parseErr != nil {
+		if parseErr != nil || parsedOffset < 0 {
 			return nil, status.Error(codes.InvalidArgument, "invalid page_token")
 		}
 		offset = parsedOffset
 	}
 
-	// Apply pagination bounds
-	if offset >= totalCount {
-		// Return empty page if offset is beyond results
-		return &pb.ListPaymentOrdersResponse{
-			PaymentOrders: []*pb.PaymentOrder{},
-			Pagination: &commonpb.PaginationResponse{
-				TotalCount: int64(totalCount),
-			},
-		}, nil
+	// Query with database-level pagination
+	result, err := s.repo.FindByDebtorAccountIDPaginated(req.DebtorAccountId, pageSize, offset)
+	if err != nil {
+		s.logger.Error("failed to list payment orders", "error", err)
+		return nil, status.Error(codes.Internal, "failed to list payment orders")
 	}
 
-	end := offset + pageSize
-	if end > totalCount {
-		end = totalCount
-	}
-
-	// Convert paginated slice to proto
-	paginatedOrders := paymentOrders[offset:end]
-	protoOrders := make([]*pb.PaymentOrder, 0, len(paginatedOrders))
-	for _, po := range paginatedOrders {
+	// Convert to proto
+	protoOrders := make([]*pb.PaymentOrder, 0, len(result.PaymentOrders))
+	for _, po := range result.PaymentOrders {
 		protoOrders = append(protoOrders, toProto(po))
 	}
 
 	// Build next page token if more results exist
 	var nextPageToken string
-	if end < totalCount {
-		nextPageToken = strconv.Itoa(end)
+	if result.HasMore {
+		nextPageToken = strconv.Itoa(offset + len(result.PaymentOrders))
 	}
 
 	return &pb.ListPaymentOrdersResponse{
 		PaymentOrders: protoOrders,
 		Pagination: &commonpb.PaginationResponse{
 			NextPageToken: nextPageToken,
-			TotalCount:    int64(totalCount),
+			TotalCount:    result.TotalCount,
 		},
 	}, nil
 }

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -201,9 +201,24 @@ func (m *MockRepository) Update(po *domain.PaymentOrder) error {
 	// Store a copy to simulate database behavior
 	stored := copyPaymentOrder(po)
 	m.paymentOrders[po.ID] = stored
+
+	// Update idempotency key index
+	m.idempotencyKeyIndex[po.IdempotencyKey] = stored
+
+	// Update gateway reference index
 	if po.GatewayReferenceID != "" {
 		m.gatewayRefIndex[po.GatewayReferenceID] = stored
 	}
+
+	// Update debtor account index by replacing the stale entry
+	list := m.debtorAccountIndex[po.DebtorAccountID]
+	for i, old := range list {
+		if old.ID == po.ID {
+			list[i] = stored
+			break
+		}
+	}
+
 	return nil
 }
 

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -49,13 +49,50 @@ func NewMockRepository() *MockRepository {
 	}
 }
 
+// copyPaymentOrder creates a deep copy of a PaymentOrder to simulate database behavior
+// where each query returns a fresh object rather than a shared pointer.
+func copyPaymentOrder(po *domain.PaymentOrder) *domain.PaymentOrder {
+	if po == nil {
+		return nil
+	}
+	poCopy := *po // shallow copy of the struct
+	// Deep copy any pointer fields
+	if po.ReservedAt != nil {
+		t := *po.ReservedAt
+		poCopy.ReservedAt = &t
+	}
+	if po.ExecutingAt != nil {
+		t := *po.ExecutingAt
+		poCopy.ExecutingAt = &t
+	}
+	if po.CompletedAt != nil {
+		t := *po.CompletedAt
+		poCopy.CompletedAt = &t
+	}
+	if po.FailedAt != nil {
+		t := *po.FailedAt
+		poCopy.FailedAt = &t
+	}
+	if po.CancelledAt != nil {
+		t := *po.CancelledAt
+		poCopy.CancelledAt = &t
+	}
+	if po.ReversedAt != nil {
+		t := *po.ReversedAt
+		poCopy.ReversedAt = &t
+	}
+	return &poCopy
+}
+
 func (m *MockRepository) Create(po *domain.PaymentOrder) error {
 	if m.createErr != nil {
 		return m.createErr
 	}
-	m.paymentOrders[po.ID] = po
-	m.idempotencyKeyIndex[po.IdempotencyKey] = po
-	m.debtorAccountIndex[po.DebtorAccountID] = append(m.debtorAccountIndex[po.DebtorAccountID], po)
+	// Store a copy to simulate database behavior where the stored object is separate
+	stored := copyPaymentOrder(po)
+	m.paymentOrders[po.ID] = stored
+	m.idempotencyKeyIndex[po.IdempotencyKey] = stored
+	m.debtorAccountIndex[po.DebtorAccountID] = append(m.debtorAccountIndex[po.DebtorAccountID], stored)
 	return nil
 }
 
@@ -67,7 +104,8 @@ func (m *MockRepository) FindByID(id uuid.UUID) (*domain.PaymentOrder, error) {
 	if !ok {
 		return nil, persistence.ErrPaymentOrderNotFound
 	}
-	return po, nil
+	// Return a copy to simulate database behavior
+	return copyPaymentOrder(po), nil
 }
 
 func (m *MockRepository) FindByIdempotencyKey(key string) (*domain.PaymentOrder, error) {
@@ -78,7 +116,8 @@ func (m *MockRepository) FindByIdempotencyKey(key string) (*domain.PaymentOrder,
 	if !ok {
 		return nil, persistence.ErrPaymentOrderNotFound
 	}
-	return po, nil
+	// Return a copy to simulate database behavior
+	return copyPaymentOrder(po), nil
 }
 
 func (m *MockRepository) FindByGatewayReferenceID(gatewayRefID string) (*domain.PaymentOrder, error) {
@@ -86,20 +125,29 @@ func (m *MockRepository) FindByGatewayReferenceID(gatewayRefID string) (*domain.
 	if !ok {
 		return nil, persistence.ErrPaymentOrderNotFound
 	}
-	return po, nil
+	// Return a copy to simulate database behavior
+	return copyPaymentOrder(po), nil
 }
 
 func (m *MockRepository) FindByDebtorAccountID(accountID string) ([]*domain.PaymentOrder, error) {
-	return m.debtorAccountIndex[accountID], nil
+	pos := m.debtorAccountIndex[accountID]
+	// Return copies to simulate database behavior
+	result := make([]*domain.PaymentOrder, len(pos))
+	for i, po := range pos {
+		result[i] = copyPaymentOrder(po)
+	}
+	return result, nil
 }
 
 func (m *MockRepository) Update(po *domain.PaymentOrder) error {
 	if m.updateErr != nil {
 		return m.updateErr
 	}
-	m.paymentOrders[po.ID] = po
+	// Store a copy to simulate database behavior
+	stored := copyPaymentOrder(po)
+	m.paymentOrders[po.ID] = stored
 	if po.GatewayReferenceID != "" {
-		m.gatewayRefIndex[po.GatewayReferenceID] = po
+		m.gatewayRefIndex[po.GatewayReferenceID] = stored
 	}
 	return nil
 }

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -1,0 +1,786 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	cadomain "github.com/meridianhub/meridian/internal/current-account/domain"
+	"github.com/meridianhub/meridian/internal/payment-order/adapters/gateway"
+	"github.com/meridianhub/meridian/internal/payment-order/adapters/persistence"
+	"github.com/meridianhub/meridian/internal/payment-order/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/money"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// testLogger returns a logger that discards output for cleaner test output
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// MockRepository implements persistence.Repository for testing
+type MockRepository struct {
+	paymentOrders        map[uuid.UUID]*domain.PaymentOrder
+	idempotencyKeyIndex  map[string]*domain.PaymentOrder
+	gatewayRefIndex      map[string]*domain.PaymentOrder
+	debtorAccountIndex   map[string][]*domain.PaymentOrder
+	createErr            error
+	findByIDErr          error
+	findByIdempotencyErr error
+	updateErr            error
+}
+
+func NewMockRepository() *MockRepository {
+	return &MockRepository{
+		paymentOrders:       make(map[uuid.UUID]*domain.PaymentOrder),
+		idempotencyKeyIndex: make(map[string]*domain.PaymentOrder),
+		gatewayRefIndex:     make(map[string]*domain.PaymentOrder),
+		debtorAccountIndex:  make(map[string][]*domain.PaymentOrder),
+	}
+}
+
+func (m *MockRepository) Create(po *domain.PaymentOrder) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.paymentOrders[po.ID] = po
+	m.idempotencyKeyIndex[po.IdempotencyKey] = po
+	m.debtorAccountIndex[po.DebtorAccountID] = append(m.debtorAccountIndex[po.DebtorAccountID], po)
+	return nil
+}
+
+func (m *MockRepository) FindByID(id uuid.UUID) (*domain.PaymentOrder, error) {
+	if m.findByIDErr != nil {
+		return nil, m.findByIDErr
+	}
+	po, ok := m.paymentOrders[id]
+	if !ok {
+		return nil, persistence.ErrPaymentOrderNotFound
+	}
+	return po, nil
+}
+
+func (m *MockRepository) FindByIdempotencyKey(key string) (*domain.PaymentOrder, error) {
+	if m.findByIdempotencyErr != nil {
+		return nil, m.findByIdempotencyErr
+	}
+	po, ok := m.idempotencyKeyIndex[key]
+	if !ok {
+		return nil, persistence.ErrPaymentOrderNotFound
+	}
+	return po, nil
+}
+
+func (m *MockRepository) FindByGatewayReferenceID(gatewayRefID string) (*domain.PaymentOrder, error) {
+	po, ok := m.gatewayRefIndex[gatewayRefID]
+	if !ok {
+		return nil, persistence.ErrPaymentOrderNotFound
+	}
+	return po, nil
+}
+
+func (m *MockRepository) FindByDebtorAccountID(accountID string) ([]*domain.PaymentOrder, error) {
+	return m.debtorAccountIndex[accountID], nil
+}
+
+func (m *MockRepository) Update(po *domain.PaymentOrder) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.paymentOrders[po.ID] = po
+	if po.GatewayReferenceID != "" {
+		m.gatewayRefIndex[po.GatewayReferenceID] = po
+	}
+	return nil
+}
+
+// MockCurrentAccountClient implements CurrentAccountClient for testing
+type MockCurrentAccountClient struct {
+	initiateLienResp   *currentaccountv1.InitiateLienResponse
+	initiateLienErr    error
+	terminateLienResp  *currentaccountv1.TerminateLienResponse
+	terminateLienErr   error
+	executeLienResp    *currentaccountv1.ExecuteLienResponse
+	executeLienErr     error
+	initiateLienCalled bool
+	terminateLienCalls int
+	executeLienCalled  bool
+}
+
+func (m *MockCurrentAccountClient) InitiateLien(_ context.Context, _ *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error) {
+	m.initiateLienCalled = true
+	if m.initiateLienErr != nil {
+		return nil, m.initiateLienErr
+	}
+	return m.initiateLienResp, nil
+}
+
+func (m *MockCurrentAccountClient) TerminateLien(_ context.Context, _ *currentaccountv1.TerminateLienRequest) (*currentaccountv1.TerminateLienResponse, error) {
+	m.terminateLienCalls++
+	if m.terminateLienErr != nil {
+		return nil, m.terminateLienErr
+	}
+	return m.terminateLienResp, nil
+}
+
+func (m *MockCurrentAccountClient) ExecuteLien(_ context.Context, _ *currentaccountv1.ExecuteLienRequest) (*currentaccountv1.ExecuteLienResponse, error) {
+	m.executeLienCalled = true
+	if m.executeLienErr != nil {
+		return nil, m.executeLienErr
+	}
+	return m.executeLienResp, nil
+}
+
+func (m *MockCurrentAccountClient) Close() error {
+	return nil
+}
+
+// MockPaymentGateway implements gateway.PaymentGateway for testing
+type MockPaymentGateway struct {
+	response   gateway.PaymentResponse
+	err        error
+	callCount  int
+	lastReqKey string
+}
+
+func (m *MockPaymentGateway) SendPayment(_ context.Context, req gateway.PaymentRequest) (gateway.PaymentResponse, error) {
+	m.callCount++
+	m.lastReqKey = req.IdempotencyKey
+	if m.err != nil {
+		return gateway.PaymentResponse{}, m.err
+	}
+	return m.response, nil
+}
+
+// Helper to create a valid InitiatePaymentOrderRequest
+// nolint:unparam // debtorAccountID is parameterized for test clarity even if currently constant
+func newInitiateRequest(idempotencyKey, debtorAccountID, creditorRef string, amountCents int64) *pb.InitiatePaymentOrderRequest {
+	return &pb.InitiatePaymentOrderRequest{
+		DebtorAccountId:   debtorAccountID,
+		CreditorReference: creditorRef,
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        amountCents / 100,
+				Nanos:        int32((amountCents % 100) * 10000000),
+			},
+		},
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: idempotencyKey},
+	}
+}
+
+// Test NewService constructor
+func TestNewService(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	assert.NotNil(t, svc)
+	assert.NotNil(t, svc.repo)
+	assert.NotNil(t, svc.logger)
+}
+
+func TestNewService_NilRepository_Panics(t *testing.T) {
+	assert.Panics(t, func() {
+		NewService(nil)
+	})
+}
+
+// Test NewServiceWithConfig
+func TestNewServiceWithConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  Config
+		wantErr error
+	}{
+		{
+			name: "nil repository returns error",
+			config: Config{
+				Repository: nil,
+			},
+			wantErr: ErrRepositoryNil,
+		},
+		{
+			name: "nil current account client returns error",
+			config: Config{
+				Repository:           NewMockRepository(),
+				CurrentAccountClient: nil,
+			},
+			wantErr: ErrCurrentAccountClientNil,
+		},
+		{
+			name: "nil payment gateway returns error",
+			config: Config{
+				Repository:           NewMockRepository(),
+				CurrentAccountClient: &MockCurrentAccountClient{},
+				PaymentGateway:       nil,
+			},
+			wantErr: ErrPaymentGatewayNil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewServiceWithConfig(tt.config)
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+// Test InitiatePaymentOrder
+func TestInitiatePaymentOrder_Success(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	req := newInitiateRequest("test-key-1", "ACC-12345678", "GB82WEST12345698765432", 10000)
+
+	resp, err := svc.InitiatePaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.NotEmpty(t, resp.PaymentOrder.PaymentOrderId)
+	assert.Equal(t, "ACC-12345678", resp.PaymentOrder.DebtorAccountId)
+	assert.Equal(t, "GB82WEST12345698765432", resp.PaymentOrder.CreditorReference)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_INITIATED, resp.PaymentOrder.Status)
+	assert.NotEmpty(t, resp.PaymentOrder.CorrelationId)
+}
+
+func TestInitiatePaymentOrder_Idempotent(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	req := newInitiateRequest("idempotent-key", "ACC-12345678", "GB82WEST12345698765432", 10000)
+
+	// First call
+	resp1, err := svc.InitiatePaymentOrder(context.Background(), req)
+	require.NoError(t, err)
+
+	// Second call with same idempotency key
+	resp2, err := svc.InitiatePaymentOrder(context.Background(), req)
+	require.NoError(t, err)
+
+	// Should return the same payment order
+	assert.Equal(t, resp1.PaymentOrder.PaymentOrderId, resp2.PaymentOrder.PaymentOrderId)
+}
+
+func TestInitiatePaymentOrder_InvalidAmount(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	// Zero amount
+	req := newInitiateRequest("test-key", "ACC-12345678", "GB82WEST12345698765432", 0)
+
+	_, err := svc.InitiatePaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "positive")
+}
+
+func TestInitiatePaymentOrder_NegativeAmount(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	// Negative amount
+	req := &pb.InitiatePaymentOrderRequest{
+		DebtorAccountId:   "ACC-12345678",
+		CreditorReference: "GB82WEST12345698765432",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        -100,
+				Nanos:        0,
+			},
+		},
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "test-key"},
+	}
+
+	_, err := svc.InitiatePaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// ErrDatabaseError is a test error for database failures
+var ErrDatabaseError = errors.New("database error")
+
+func TestInitiatePaymentOrder_RepositoryError(t *testing.T) {
+	repo := NewMockRepository()
+	repo.createErr = ErrDatabaseError
+	svc := NewService(repo)
+
+	req := newInitiateRequest("test-key", "ACC-12345678", "GB82WEST12345698765432", 10000)
+
+	_, err := svc.InitiatePaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+// Test RetrievePaymentOrder
+func TestRetrievePaymentOrder_Success(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	// Create a payment order first
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = repo.Create(po)
+
+	req := &pb.RetrievePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+	}
+
+	resp, err := svc.RetrievePaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, po.ID.String(), resp.PaymentOrder.PaymentOrderId)
+	assert.Equal(t, "ACC-12345678", resp.PaymentOrder.DebtorAccountId)
+}
+
+func TestRetrievePaymentOrder_NotFound(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	req := &pb.RetrievePaymentOrderRequest{
+		PaymentOrderId: uuid.New().String(),
+	}
+
+	_, err := svc.RetrievePaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestRetrievePaymentOrder_InvalidID(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	req := &pb.RetrievePaymentOrderRequest{
+		PaymentOrderId: "not-a-uuid",
+	}
+
+	_, err := svc.RetrievePaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// Test CancelPaymentOrder
+func TestCancelPaymentOrder_Success(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	// Create a payment order in INITIATED state
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = repo.Create(po)
+
+	req := &pb.CancelPaymentOrderRequest{
+		PaymentOrderId:     po.ID.String(),
+		CancellationReason: "User requested cancellation",
+		CancelledBy:        "user@example.com",
+		IdempotencyKey:     &commonpb.IdempotencyKey{Key: "cancel-key"},
+	}
+
+	resp, err := svc.CancelPaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_CANCELLED, resp.PaymentOrder.Status)
+}
+
+func TestCancelPaymentOrder_AlreadyCancelled_Idempotent(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	// Create and cancel a payment order
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Cancel("Already cancelled")
+	_ = repo.Create(po)
+
+	req := &pb.CancelPaymentOrderRequest{
+		PaymentOrderId:     po.ID.String(),
+		CancellationReason: "Second cancellation attempt",
+		CancelledBy:        "user@example.com",
+		IdempotencyKey:     &commonpb.IdempotencyKey{Key: "cancel-key"},
+	}
+
+	resp, err := svc.CancelPaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_CANCELLED, resp.PaymentOrder.Status)
+}
+
+func TestCancelPaymentOrder_NotCancellable(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	// Create a payment order and move it to EXECUTING state
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("gateway-ref-123")
+	_ = repo.Create(po)
+
+	req := &pb.CancelPaymentOrderRequest{
+		PaymentOrderId:     po.ID.String(),
+		CancellationReason: "User requested cancellation",
+		CancelledBy:        "user@example.com",
+		IdempotencyKey:     &commonpb.IdempotencyKey{Key: "cancel-key"},
+	}
+
+	_, err := svc.CancelPaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestCancelPaymentOrder_ReleasesLien(t *testing.T) {
+	repo := NewMockRepository()
+	caClient := &MockCurrentAccountClient{
+		terminateLienResp: &currentaccountv1.TerminateLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId: "lien-123",
+				Status: currentaccountv1.LienStatus_LIEN_STATUS_TERMINATED,
+			},
+		},
+	}
+
+	svc := &Service{
+		repo:                 repo,
+		currentAccountClient: caClient,
+		logger:               testLogger(),
+	}
+
+	// Create a payment order in RESERVED state with a lien
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = repo.Create(po)
+
+	req := &pb.CancelPaymentOrderRequest{
+		PaymentOrderId:     po.ID.String(),
+		CancellationReason: "User requested cancellation",
+		CancelledBy:        "user@example.com",
+		IdempotencyKey:     &commonpb.IdempotencyKey{Key: "cancel-key"},
+	}
+
+	resp, err := svc.CancelPaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_CANCELLED, resp.PaymentOrder.Status)
+	assert.Equal(t, 1, caClient.terminateLienCalls)
+}
+
+// Test UpdatePaymentOrder
+func TestUpdatePaymentOrder_Settled(t *testing.T) {
+	repo := NewMockRepository()
+	caClient := &MockCurrentAccountClient{
+		executeLienResp: &currentaccountv1.ExecuteLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId: "lien-123",
+				Status: currentaccountv1.LienStatus_LIEN_STATUS_EXECUTED,
+			},
+		},
+	}
+
+	svc := &Service{
+		repo:                 repo,
+		currentAccountClient: caClient,
+		logger:               testLogger(),
+	}
+
+	// Create a payment order in EXECUTING state
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("gateway-ref-123")
+	_ = repo.Create(po)
+
+	req := &pb.UpdatePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_SETTLED,
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "update-key"},
+	}
+
+	resp, err := svc.UpdatePaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED, resp.PaymentOrder.Status)
+	assert.True(t, caClient.executeLienCalled)
+}
+
+func TestUpdatePaymentOrder_Rejected(t *testing.T) {
+	repo := NewMockRepository()
+	caClient := &MockCurrentAccountClient{
+		terminateLienResp: &currentaccountv1.TerminateLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId: "lien-123",
+				Status: currentaccountv1.LienStatus_LIEN_STATUS_TERMINATED,
+			},
+		},
+	}
+
+	svc := &Service{
+		repo:                 repo,
+		currentAccountClient: caClient,
+		logger:               testLogger(),
+	}
+
+	// Create a payment order in EXECUTING state
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("gateway-ref-123")
+	_ = repo.Create(po)
+
+	req := &pb.UpdatePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_REJECTED,
+		GatewayMessage: "Insufficient funds at destination",
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "update-key"},
+	}
+
+	resp, err := svc.UpdatePaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_FAILED, resp.PaymentOrder.Status)
+	assert.Equal(t, 1, caClient.terminateLienCalls)
+}
+
+func TestUpdatePaymentOrder_ByGatewayReferenceID(t *testing.T) {
+	repo := NewMockRepository()
+	caClient := &MockCurrentAccountClient{
+		executeLienResp: &currentaccountv1.ExecuteLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId: "lien-123",
+				Status: currentaccountv1.LienStatus_LIEN_STATUS_EXECUTED,
+			},
+		},
+	}
+
+	svc := &Service{
+		repo:                 repo,
+		currentAccountClient: caClient,
+		logger:               testLogger(),
+	}
+
+	// Create a payment order in EXECUTING state
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("gateway-ref-123")
+	_ = repo.Create(po)
+	_ = repo.Update(po) // This adds gateway ref to index
+
+	req := &pb.UpdatePaymentOrderRequest{
+		GatewayReferenceId: "gateway-ref-123",
+		GatewayStatus:      pb.GatewayStatus_GATEWAY_STATUS_SETTLED,
+		IdempotencyKey:     &commonpb.IdempotencyKey{Key: "update-key"},
+	}
+
+	resp, err := svc.UpdatePaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED, resp.PaymentOrder.Status)
+}
+
+func TestUpdatePaymentOrder_NotFound(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	req := &pb.UpdatePaymentOrderRequest{
+		PaymentOrderId: uuid.New().String(),
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_SETTLED,
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "update-key"},
+	}
+
+	_, err := svc.UpdatePaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestUpdatePaymentOrder_MissingIdentifier(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	req := &pb.UpdatePaymentOrderRequest{
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_SETTLED,
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "update-key"},
+	}
+
+	_, err := svc.UpdatePaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// Test ListPaymentOrders
+func TestListPaymentOrders_Success(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	// Create some payment orders
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po1, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "key-1", uuid.New().String())
+	po2, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765433", amount, "key-2", uuid.New().String())
+	_ = repo.Create(po1)
+	_ = repo.Create(po2)
+
+	req := &pb.ListPaymentOrdersRequest{
+		DebtorAccountId: "ACC-12345678",
+	}
+
+	resp, err := svc.ListPaymentOrders(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Len(t, resp.PaymentOrders, 2)
+}
+
+func TestListPaymentOrders_EmptyDebtorAccountID(t *testing.T) {
+	repo := NewMockRepository()
+	svc := NewService(repo)
+
+	req := &pb.ListPaymentOrdersRequest{}
+
+	_, err := svc.ListPaymentOrders(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// Test proto conversion helpers
+func TestToProto(t *testing.T) {
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", "correlation-123")
+
+	// Add some state
+	_ = po.Reserve("lien-123")
+	now := time.Now()
+	po.ExecutingAt = &now
+
+	proto := toProto(po)
+
+	assert.Equal(t, po.ID.String(), proto.PaymentOrderId)
+	assert.Equal(t, po.DebtorAccountID, proto.DebtorAccountId)
+	assert.Equal(t, po.CreditorReference, proto.CreditorReference)
+	assert.Equal(t, po.IdempotencyKey, proto.IdempotencyKey)
+	assert.Equal(t, po.CorrelationID, proto.CorrelationId)
+	assert.Equal(t, "lien-123", proto.LienId)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_RESERVED, proto.Status)
+	assert.NotNil(t, proto.ReservedAt)
+}
+
+func TestMapStatusToProto(t *testing.T) {
+	tests := []struct {
+		domain domain.PaymentOrderStatus
+		want   pb.PaymentOrderStatus
+	}{
+		{domain.PaymentOrderStatusInitiated, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_INITIATED},
+		{domain.PaymentOrderStatusReserved, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_RESERVED},
+		{domain.PaymentOrderStatusExecuting, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_EXECUTING},
+		{domain.PaymentOrderStatusCompleted, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED},
+		{domain.PaymentOrderStatusFailed, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_FAILED},
+		{domain.PaymentOrderStatusCancelled, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_CANCELLED},
+		{domain.PaymentOrderStatusReversed, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_REVERSED},
+		{"UNKNOWN", pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.domain), func(t *testing.T) {
+			got := mapStatusToProto(tt.domain)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestProtoToMoney(t *testing.T) {
+	tests := []struct {
+		name      string
+		amount    *commonpb.MoneyAmount
+		wantCents int64
+		wantErr   bool
+	}{
+		{
+			name: "basic amount",
+			amount: &commonpb.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: "GBP",
+					Units:        100,
+					Nanos:        500000000, // 0.50
+				},
+			},
+			wantCents: 10050,
+			wantErr:   false,
+		},
+		{
+			name: "whole units",
+			amount: &commonpb.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: "USD",
+					Units:        50,
+					Nanos:        0,
+				},
+			},
+			wantCents: 5000,
+			wantErr:   false,
+		},
+		{
+			name:      "nil amount",
+			amount:    nil,
+			wantCents: 0,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := protoToMoney(tt.amount)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantCents, got.AmountCents())
+			}
+		})
+	}
+}
+
+func TestToMoneyAmount(t *testing.T) {
+	amount, _ := cadomain.NewMoney("GBP", 10050) // £100.50
+
+	proto := toMoneyAmount(amount)
+
+	assert.Equal(t, "GBP", proto.Amount.CurrencyCode)
+	assert.Equal(t, int64(100), proto.Amount.Units)
+	assert.Equal(t, int32(500000000), proto.Amount.Nanos)
+}

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -1166,6 +1166,7 @@ func TestSagaOrchestration_HappyPath(t *testing.T) {
 		logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		currentAccountClient: caClient,
 		paymentGateway:       gwMock,
+		sagaTimeout:          DefaultSagaTimeout,
 		// kafkaProducer is nil - events won't be published but saga still runs
 	}
 
@@ -1223,6 +1224,7 @@ func TestSagaOrchestration_LienFailure(t *testing.T) {
 		logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		currentAccountClient: caClient,
 		paymentGateway:       gwMock,
+		sagaTimeout:          DefaultSagaTimeout,
 	}
 
 	ctx := context.Background()
@@ -1278,6 +1280,7 @@ func TestSagaOrchestration_GatewayFailure(t *testing.T) {
 		logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		currentAccountClient: caClient,
 		paymentGateway:       gwMock,
+		sagaTimeout:          DefaultSagaTimeout,
 	}
 
 	ctx := context.Background()

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,8 +30,16 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
-// MockRepository implements persistence.Repository for testing
+// Test errors for mock responses
+var (
+	errInsufficientFunds  = errors.New("insufficient funds")
+	errGatewayUnavailable = errors.New("gateway unavailable")
+)
+
+// MockRepository implements persistence.Repository for testing.
+// Thread-safe for use with async saga tests.
 type MockRepository struct {
+	mu                   sync.RWMutex
 	paymentOrders        map[uuid.UUID]*domain.PaymentOrder
 	idempotencyKeyIndex  map[string]*domain.PaymentOrder
 	gatewayRefIndex      map[string]*domain.PaymentOrder
@@ -86,6 +95,8 @@ func copyPaymentOrder(po *domain.PaymentOrder) *domain.PaymentOrder {
 }
 
 func (m *MockRepository) Create(po *domain.PaymentOrder) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.createErr != nil {
 		return m.createErr
 	}
@@ -98,6 +109,8 @@ func (m *MockRepository) Create(po *domain.PaymentOrder) error {
 }
 
 func (m *MockRepository) FindByID(id uuid.UUID) (*domain.PaymentOrder, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if m.findByIDErr != nil {
 		return nil, m.findByIDErr
 	}
@@ -110,6 +123,8 @@ func (m *MockRepository) FindByID(id uuid.UUID) (*domain.PaymentOrder, error) {
 }
 
 func (m *MockRepository) FindByIdempotencyKey(key string) (*domain.PaymentOrder, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	if m.findByIdempotencyErr != nil {
 		return nil, m.findByIdempotencyErr
 	}
@@ -122,6 +137,8 @@ func (m *MockRepository) FindByIdempotencyKey(key string) (*domain.PaymentOrder,
 }
 
 func (m *MockRepository) FindByGatewayReferenceID(gatewayRefID string) (*domain.PaymentOrder, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	po, ok := m.gatewayRefIndex[gatewayRefID]
 	if !ok {
 		return nil, persistence.ErrPaymentOrderNotFound
@@ -131,6 +148,8 @@ func (m *MockRepository) FindByGatewayReferenceID(gatewayRefID string) (*domain.
 }
 
 func (m *MockRepository) FindByDebtorAccountID(accountID string) ([]*domain.PaymentOrder, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	pos := m.debtorAccountIndex[accountID]
 	// Return copies to simulate database behavior
 	result := make([]*domain.PaymentOrder, len(pos))
@@ -141,6 +160,8 @@ func (m *MockRepository) FindByDebtorAccountID(accountID string) ([]*domain.Paym
 }
 
 func (m *MockRepository) FindByDebtorAccountIDPaginated(accountID string, limit, offset int) (*persistence.PaginatedResult, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	pos := m.debtorAccountIndex[accountID]
 	totalCount := len(pos)
 
@@ -172,6 +193,8 @@ func (m *MockRepository) FindByDebtorAccountIDPaginated(accountID string, limit,
 }
 
 func (m *MockRepository) Update(po *domain.PaymentOrder) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.updateErr != nil {
 		return m.updateErr
 	}
@@ -1113,4 +1136,177 @@ func TestToMoneyAmount(t *testing.T) {
 	assert.Equal(t, "GBP", proto.Amount.CurrencyCode)
 	assert.Equal(t, int64(100), proto.Amount.Units)
 	assert.Equal(t, int32(500000000), proto.Amount.Nanos)
+}
+
+// TestSagaOrchestration_HappyPath tests the full saga flow from InitiatePaymentOrder
+// through to EXECUTING state, exercising the async saga orchestration.
+func TestSagaOrchestration_HappyPath(t *testing.T) {
+	repo := NewMockRepository()
+
+	// Set up mock CurrentAccountClient with successful lien response
+	caClient := &MockCurrentAccountClient{
+		initiateLienResp: &currentaccountv1.InitiateLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId: "test-lien-123",
+			},
+		},
+	}
+
+	// Set up mock PaymentGateway with successful acceptance response
+	gwMock := &MockPaymentGateway{
+		response: gateway.PaymentResponse{
+			Status:             gateway.StatusAccepted,
+			GatewayReferenceID: "gw-ref-456",
+		},
+	}
+
+	// Create service with all dependencies configured
+	svc := &Service{
+		repo:                 repo,
+		logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		currentAccountClient: caClient,
+		paymentGateway:       gwMock,
+		// kafkaProducer is nil - events won't be published but saga still runs
+	}
+
+	// Initiate payment order
+	ctx := context.Background()
+	req := newInitiateRequest("saga-test-key", "debtor-123", "creditor-ref", 5000)
+
+	resp, err := svc.InitiatePaymentOrder(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.PaymentOrder)
+
+	paymentOrderID := resp.PaymentOrder.PaymentOrderId
+
+	// Initial response should show INITIATED status
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_INITIATED, resp.PaymentOrder.Status)
+
+	// Wait for async saga to complete
+	// The saga runs in a goroutine and should reach EXECUTING state
+	// Use polling with timeout to verify final state
+	require.Eventually(t, func() bool {
+		po, err := repo.FindByID(uuid.MustParse(paymentOrderID))
+		if err != nil {
+			return false
+		}
+		return po.Status == domain.PaymentOrderStatusExecuting
+	}, 2*time.Second, 50*time.Millisecond, "payment order should reach EXECUTING state")
+
+	// Verify final state
+	po, err := repo.FindByID(uuid.MustParse(paymentOrderID))
+	require.NoError(t, err)
+
+	assert.Equal(t, domain.PaymentOrderStatusExecuting, po.Status)
+	assert.Equal(t, "test-lien-123", po.LienID)
+	assert.Equal(t, "gw-ref-456", po.GatewayReferenceID)
+	assert.NotNil(t, po.ReservedAt)
+	assert.NotNil(t, po.ExecutingAt)
+}
+
+// TestSagaOrchestration_LienFailure tests saga compensation when lien creation fails.
+func TestSagaOrchestration_LienFailure(t *testing.T) {
+	repo := NewMockRepository()
+
+	// Set up mock CurrentAccountClient to fail lien creation
+	caClient := &MockCurrentAccountClient{
+		initiateLienErr: errInsufficientFunds,
+	}
+
+	// Gateway mock won't be called since lien fails first
+	gwMock := &MockPaymentGateway{}
+
+	svc := &Service{
+		repo:                 repo,
+		logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		currentAccountClient: caClient,
+		paymentGateway:       gwMock,
+	}
+
+	ctx := context.Background()
+	req := newInitiateRequest("saga-fail-key", "debtor-456", "creditor-ref", 5000)
+
+	resp, err := svc.InitiatePaymentOrder(ctx, req)
+
+	require.NoError(t, err) // InitiatePaymentOrder succeeds, saga fails async
+	require.NotNil(t, resp)
+
+	paymentOrderID := resp.PaymentOrder.PaymentOrderId
+
+	// Wait for async saga to fail and mark payment as FAILED
+	require.Eventually(t, func() bool {
+		po, err := repo.FindByID(uuid.MustParse(paymentOrderID))
+		if err != nil {
+			return false
+		}
+		return po.Status == domain.PaymentOrderStatusFailed
+	}, 2*time.Second, 50*time.Millisecond, "payment order should reach FAILED state")
+
+	// Verify failure state
+	po, err := repo.FindByID(uuid.MustParse(paymentOrderID))
+	require.NoError(t, err)
+
+	assert.Equal(t, domain.PaymentOrderStatusFailed, po.Status)
+	assert.Contains(t, po.FailureReason, "insufficient funds")
+	assert.Equal(t, "SAGA_FAILED", po.ErrorCode)
+	assert.Empty(t, po.LienID) // Lien was never created
+	assert.NotNil(t, po.FailedAt)
+}
+
+// TestSagaOrchestration_GatewayFailure tests saga compensation when gateway submission fails.
+func TestSagaOrchestration_GatewayFailure(t *testing.T) {
+	repo := NewMockRepository()
+
+	// Set up mock CurrentAccountClient with successful lien response
+	caClient := &MockCurrentAccountClient{
+		initiateLienResp: &currentaccountv1.InitiateLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId: "test-lien-789",
+			},
+		},
+	}
+
+	// Set up mock PaymentGateway to fail
+	gwMock := &MockPaymentGateway{
+		err: errGatewayUnavailable,
+	}
+
+	svc := &Service{
+		repo:                 repo,
+		logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		currentAccountClient: caClient,
+		paymentGateway:       gwMock,
+	}
+
+	ctx := context.Background()
+	req := newInitiateRequest("saga-gw-fail-key", "debtor-789", "creditor-ref", 5000)
+
+	resp, err := svc.InitiatePaymentOrder(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	paymentOrderID := resp.PaymentOrder.PaymentOrderId
+
+	// Wait for async saga to fail
+	require.Eventually(t, func() bool {
+		po, err := repo.FindByID(uuid.MustParse(paymentOrderID))
+		if err != nil {
+			return false
+		}
+		return po.Status == domain.PaymentOrderStatusFailed
+	}, 2*time.Second, 50*time.Millisecond, "payment order should reach FAILED state")
+
+	// Verify failure state
+	po, err := repo.FindByID(uuid.MustParse(paymentOrderID))
+	require.NoError(t, err)
+
+	assert.Equal(t, domain.PaymentOrderStatusFailed, po.Status)
+	assert.Contains(t, po.FailureReason, "gateway unavailable")
+	assert.Equal(t, "SAGA_FAILED", po.ErrorCode)
+	// Lien was created but should be released by compensation
+	assert.Equal(t, "test-lien-789", po.LienID)
+	assert.NotNil(t, po.FailedAt)
 }

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -808,6 +808,30 @@ func TestProtoToMoney(t *testing.T) {
 			wantCents: 0,
 			wantErr:   true,
 		},
+		{
+			name: "negative amount with nanos",
+			amount: &commonpb.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: "GBP",
+					Units:        -10,
+					Nanos:        -123456789, // -10.123456789 should round to -1012 cents
+				},
+			},
+			wantCents: -1012, // -10.12 (rounded from -10.123456789)
+			wantErr:   false,
+		},
+		{
+			name: "negative amount rounds correctly",
+			amount: &commonpb.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: "USD",
+					Units:        -5,
+					Nanos:        -555000000, // -5.555 should round to -556 cents
+				},
+			},
+			wantCents: -556, // -5.56 (rounded from -5.555)
+			wantErr:   false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -1592,3 +1592,137 @@ func TestConcurrentIdempotentRequests(t *testing.T) {
 
 	assert.Equal(t, numRequests, count)
 }
+
+// TestSagaOrchestration_MalformedLienResponse tests that the saga handles
+// malformed (nil) lien responses gracefully without panicking.
+func TestSagaOrchestration_MalformedLienResponse(t *testing.T) {
+	repo := NewMockRepository()
+	// Mock returns nil lien response (malformed)
+	caClient := &MockCurrentAccountClient{
+		initiateLienResp: nil, // nil response should trigger ErrMalformedLienResponse
+	}
+	gwClient := &MockPaymentGateway{}
+
+	// Create service directly to avoid kafka producer requirement
+	svc := &Service{
+		repo:                    repo,
+		logger:                  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		currentAccountClient:    caClient,
+		paymentGateway:          gwClient,
+		sagaTimeout:             1 * time.Second,
+		maxIdempotencyKeyLength: DefaultMaxIdempotencyKeyLength,
+		// kafkaProducer is nil - events won't be published but saga still runs
+	}
+
+	req := newInitiateRequest("malformed-lien-test", "ACC-12345678", "GB82WEST12345698765432", 10000)
+	resp, err := svc.InitiatePaymentOrder(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	paymentOrderID := resp.PaymentOrder.PaymentOrderId
+
+	// Wait for saga to complete - should fail due to malformed response
+	require.Eventually(t, func() bool {
+		po, findErr := repo.FindByID(uuid.MustParse(paymentOrderID))
+		if findErr != nil {
+			return false
+		}
+		return po.Status == domain.PaymentOrderStatusFailed
+	}, 2*time.Second, 50*time.Millisecond, "payment order should fail due to malformed lien response")
+
+	// Verify failure reason
+	po, err := repo.FindByID(uuid.MustParse(paymentOrderID))
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusFailed, po.Status)
+	assert.Contains(t, po.FailureReason, "malformed lien response")
+}
+
+// TestSagaOrchestration_GatewayPending tests that gateway pending status
+// correctly transitions the payment order to EXECUTING state.
+func TestSagaOrchestration_GatewayPending(t *testing.T) {
+	repo := NewMockRepository()
+	caClient := &MockCurrentAccountClient{
+		initiateLienResp: &currentaccountv1.InitiateLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId: "lien-pending-123",
+			},
+		},
+		executeLienResp: &currentaccountv1.ExecuteLienResponse{},
+	}
+	// Gateway returns pending status (async confirmation expected)
+	gwClient := &MockPaymentGateway{
+		response: gateway.PaymentResponse{
+			Status:             gateway.StatusPending,
+			GatewayReferenceID: "gw-pending-ref-123",
+			Message:            "Payment pending confirmation",
+		},
+	}
+
+	// Create service directly to avoid kafka producer requirement
+	svc := &Service{
+		repo:                    repo,
+		logger:                  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		currentAccountClient:    caClient,
+		paymentGateway:          gwClient,
+		sagaTimeout:             5 * time.Second,
+		maxIdempotencyKeyLength: DefaultMaxIdempotencyKeyLength,
+		// kafkaProducer is nil - events won't be published but saga still runs
+	}
+
+	req := newInitiateRequest("pending-test", "ACC-12345678", "GB82WEST12345698765432", 10000)
+	resp, err := svc.InitiatePaymentOrder(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	paymentOrderID := resp.PaymentOrder.PaymentOrderId
+
+	// Wait for saga to complete - should reach EXECUTING (pending gateway confirmation)
+	require.Eventually(t, func() bool {
+		po, findErr := repo.FindByID(uuid.MustParse(paymentOrderID))
+		if findErr != nil {
+			return false
+		}
+		return po.Status == domain.PaymentOrderStatusExecuting
+	}, 3*time.Second, 50*time.Millisecond, "payment order should reach EXECUTING state")
+
+	// Verify state
+	po, err := repo.FindByID(uuid.MustParse(paymentOrderID))
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentOrderStatusExecuting, po.Status)
+	assert.Equal(t, "gw-pending-ref-123", po.GatewayReferenceID)
+	assert.NotNil(t, po.ExecutingAt)
+}
+
+// TestUpdatePaymentOrder_UnspecifiedStatus tests that GATEWAY_STATUS_UNSPECIFIED
+// returns an appropriate error.
+func TestUpdatePaymentOrder_UnspecifiedStatus(t *testing.T) {
+	repo := NewMockRepository()
+	svc, _ := NewService(repo)
+
+	// Create an executing payment order first
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder(
+		"ACC-12345678",
+		"GB82WEST12345698765432",
+		amount,
+		"unspecified-test",
+		"corr-123",
+	)
+	po.LienID = "lien-123"
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("gw-ref-123")
+	_ = repo.Create(po)
+
+	// Update with unspecified status
+	req := &pb.UpdatePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED,
+	}
+	_, err := svc.UpdatePaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "gateway status is required")
+}

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -1162,11 +1162,12 @@ func TestSagaOrchestration_HappyPath(t *testing.T) {
 
 	// Create service with all dependencies configured
 	svc := &Service{
-		repo:                 repo,
-		logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		currentAccountClient: caClient,
-		paymentGateway:       gwMock,
-		sagaTimeout:          DefaultSagaTimeout,
+		repo:                    repo,
+		logger:                  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		currentAccountClient:    caClient,
+		paymentGateway:          gwMock,
+		sagaTimeout:             DefaultSagaTimeout,
+		maxIdempotencyKeyLength: DefaultMaxIdempotencyKeyLength,
 		// kafkaProducer is nil - events won't be published but saga still runs
 	}
 
@@ -1220,11 +1221,12 @@ func TestSagaOrchestration_LienFailure(t *testing.T) {
 	gwMock := &MockPaymentGateway{}
 
 	svc := &Service{
-		repo:                 repo,
-		logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		currentAccountClient: caClient,
-		paymentGateway:       gwMock,
-		sagaTimeout:          DefaultSagaTimeout,
+		repo:                    repo,
+		logger:                  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		currentAccountClient:    caClient,
+		paymentGateway:          gwMock,
+		sagaTimeout:             DefaultSagaTimeout,
+		maxIdempotencyKeyLength: DefaultMaxIdempotencyKeyLength,
 	}
 
 	ctx := context.Background()
@@ -1276,11 +1278,12 @@ func TestSagaOrchestration_GatewayFailure(t *testing.T) {
 	}
 
 	svc := &Service{
-		repo:                 repo,
-		logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		currentAccountClient: caClient,
-		paymentGateway:       gwMock,
-		sagaTimeout:          DefaultSagaTimeout,
+		repo:                    repo,
+		logger:                  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		currentAccountClient:    caClient,
+		paymentGateway:          gwMock,
+		sagaTimeout:             DefaultSagaTimeout,
+		maxIdempotencyKeyLength: DefaultMaxIdempotencyKeyLength,
 	}
 
 	ctx := context.Background()

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -1378,3 +1378,186 @@ func TestSagaOrchestration_GatewayFailure(t *testing.T) {
 	assert.Equal(t, "test-lien-789", po.LienID)
 	assert.NotNil(t, po.FailedAt)
 }
+
+// SlowCurrentAccountClient implements CurrentAccountClient with configurable delays for timeout testing
+type SlowCurrentAccountClient struct {
+	delay            time.Duration
+	initiateLienResp *currentaccountv1.InitiateLienResponse
+}
+
+func (m *SlowCurrentAccountClient) InitiateLien(ctx context.Context, _ *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error) {
+	select {
+	case <-time.After(m.delay):
+		return m.initiateLienResp, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (m *SlowCurrentAccountClient) TerminateLien(_ context.Context, _ *currentaccountv1.TerminateLienRequest) (*currentaccountv1.TerminateLienResponse, error) {
+	return &currentaccountv1.TerminateLienResponse{}, nil
+}
+
+func (m *SlowCurrentAccountClient) ExecuteLien(_ context.Context, _ *currentaccountv1.ExecuteLienRequest) (*currentaccountv1.ExecuteLienResponse, error) {
+	return &currentaccountv1.ExecuteLienResponse{}, nil
+}
+
+func (m *SlowCurrentAccountClient) Close() error {
+	return nil
+}
+
+// TestSagaOrchestration_Timeout tests that the saga fails gracefully when it times out.
+func TestSagaOrchestration_Timeout(t *testing.T) {
+	repo := NewMockRepository()
+
+	// Set up slow CurrentAccountClient that will exceed saga timeout
+	caClient := &SlowCurrentAccountClient{
+		delay: 500 * time.Millisecond, // Longer than saga timeout
+		initiateLienResp: &currentaccountv1.InitiateLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId: "test-lien-timeout",
+			},
+		},
+	}
+
+	gwMock := &MockPaymentGateway{}
+
+	// Configure very short saga timeout to trigger timeout
+	svc := &Service{
+		repo:                    repo,
+		logger:                  slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		currentAccountClient:    caClient,
+		paymentGateway:          gwMock,
+		sagaTimeout:             100 * time.Millisecond, // Short timeout
+		maxIdempotencyKeyLength: DefaultMaxIdempotencyKeyLength,
+	}
+
+	ctx := context.Background()
+	req := newInitiateRequest("saga-timeout-key", "debtor-timeout", "creditor-ref", 5000)
+
+	resp, err := svc.InitiatePaymentOrder(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	paymentOrderID := resp.PaymentOrder.PaymentOrderId
+
+	// Wait for async saga to timeout and fail
+	require.Eventually(t, func() bool {
+		po, err := repo.FindByID(uuid.MustParse(paymentOrderID))
+		if err != nil {
+			return false
+		}
+		return po.Status == domain.PaymentOrderStatusFailed
+	}, 2*time.Second, 50*time.Millisecond, "payment order should reach FAILED state after timeout")
+
+	// Verify failure state
+	po, err := repo.FindByID(uuid.MustParse(paymentOrderID))
+	require.NoError(t, err)
+
+	assert.Equal(t, domain.PaymentOrderStatusFailed, po.Status)
+	assert.Contains(t, po.FailureReason, "context deadline exceeded")
+	assert.Equal(t, "SAGA_FAILED", po.ErrorCode)
+	assert.NotNil(t, po.FailedAt)
+}
+
+// TestConcurrentPaymentOrders tests that multiple concurrent payment orders
+// are handled correctly without data races or incorrect state.
+func TestConcurrentPaymentOrders(t *testing.T) {
+	repo := NewMockRepository()
+	svc, _ := NewService(repo)
+
+	const numOrders = 10
+	var wg sync.WaitGroup
+	results := make(chan *pb.InitiatePaymentOrderResponse, numOrders)
+	errs := make(chan error, numOrders)
+
+	// Create concurrent payment orders with unique idempotency keys
+	for i := 0; i < numOrders; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			req := newInitiateRequest(
+				fmt.Sprintf("concurrent-key-%d", index),
+				fmt.Sprintf("ACC-%08d", index),
+				"GB82WEST12345698765432",
+				10000,
+			)
+			resp, err := svc.InitiatePaymentOrder(context.Background(), req)
+			if err != nil {
+				errs <- err
+			} else {
+				results <- resp
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	// Verify no errors
+	for err := range errs {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Verify all orders were created with unique IDs
+	ids := make(map[string]bool)
+	count := 0
+	for resp := range results {
+		count++
+		assert.NotNil(t, resp.PaymentOrder)
+		assert.NotEmpty(t, resp.PaymentOrder.PaymentOrderId)
+		// Ensure no duplicate IDs
+		_, exists := ids[resp.PaymentOrder.PaymentOrderId]
+		assert.False(t, exists, "duplicate payment order ID: %s", resp.PaymentOrder.PaymentOrderId)
+		ids[resp.PaymentOrder.PaymentOrderId] = true
+	}
+
+	assert.Equal(t, numOrders, count, "expected %d orders, got %d", numOrders, count)
+}
+
+// TestConcurrentIdempotentRequests tests that concurrent requests with the same
+// idempotency key all return the same payment order (idempotency guarantee).
+func TestConcurrentIdempotentRequests(t *testing.T) {
+	repo := NewMockRepository()
+	svc, _ := NewService(repo)
+
+	const numRequests = 10
+	const idempotencyKey = "same-key-for-all"
+	var wg sync.WaitGroup
+	results := make(chan *pb.InitiatePaymentOrderResponse, numRequests)
+
+	// Fire concurrent requests with the same idempotency key
+	for i := 0; i < numRequests; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := newInitiateRequest(idempotencyKey, "ACC-12345678", "GB82WEST12345698765432", 10000)
+			resp, err := svc.InitiatePaymentOrder(context.Background(), req)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			results <- resp
+		}()
+	}
+
+	wg.Wait()
+	close(results)
+
+	// All responses should return the same payment order ID
+	var firstID string
+	count := 0
+	for resp := range results {
+		count++
+		if firstID == "" {
+			firstID = resp.PaymentOrder.PaymentOrderId
+		} else {
+			assert.Equal(t, firstID, resp.PaymentOrder.PaymentOrderId,
+				"idempotent requests should return same payment order")
+		}
+	}
+
+	assert.Equal(t, numRequests, count)
+}

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -858,6 +858,37 @@ func TestUpdatePaymentOrder_Idempotent_Rejected(t *testing.T) {
 	assert.Equal(t, resp1.PaymentOrder.PaymentOrderId, resp2.PaymentOrder.PaymentOrderId)
 }
 
+func TestUpdatePaymentOrder_PendingRejectsStaleCallbacks(t *testing.T) {
+	repo := NewMockRepository()
+	svc := &Service{
+		repo:   repo,
+		logger: testLogger(),
+	}
+
+	// Create a payment order that has already completed
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", "correlation-123")
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("gateway-ref-123")
+	_ = po.Complete("") // Already completed
+	_ = repo.Create(po)
+
+	// PENDING callback should be rejected for completed orders
+	req := &pb.UpdatePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_PENDING,
+	}
+
+	_, err := svc.UpdatePaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "PENDING callback")
+	assert.Contains(t, st.Message(), "COMPLETED")
+}
+
 // Test ListPaymentOrders
 func TestListPaymentOrders_Success(t *testing.T) {
 	repo := NewMockRepository()

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -577,6 +577,29 @@ func TestCancelPaymentOrder_NotCancellable(t *testing.T) {
 	assert.Equal(t, codes.FailedPrecondition, st.Code())
 }
 
+func TestCancelPaymentOrder_MissingReason(t *testing.T) {
+	repo := NewMockRepository()
+	svc, _ := NewService(repo)
+
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = repo.Create(po)
+
+	req := &pb.CancelPaymentOrderRequest{
+		PaymentOrderId:     po.ID.String(),
+		CancellationReason: "", // Empty - should fail validation
+		CancelledBy:        "user@example.com",
+	}
+
+	_, err := svc.CancelPaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "cancellation_reason is required")
+}
+
 func TestCancelPaymentOrder_ReleasesLien(t *testing.T) {
 	repo := NewMockRepository()
 	caClient := &MockCurrentAccountClient{
@@ -1127,6 +1150,30 @@ func TestProtoToMoney(t *testing.T) {
 			},
 			wantCents: -556, // -5.56 (rounded from -5.555)
 			wantErr:   false,
+		},
+		{
+			name: "nanos exceeds max bounds",
+			amount: &commonpb.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: "GBP",
+					Units:        10,
+					Nanos:        1000000000, // Exceeds max 999999999
+				},
+			},
+			wantCents: 0,
+			wantErr:   true,
+		},
+		{
+			name: "nanos exceeds min bounds",
+			amount: &commonpb.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: "GBP",
+					Units:        -10,
+					Nanos:        -1000000000, // Exceeds min -999999999
+				},
+			},
+			wantCents: 0,
+			wantErr:   true,
 		},
 	}
 

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -139,6 +140,37 @@ func (m *MockRepository) FindByDebtorAccountID(accountID string) ([]*domain.Paym
 	return result, nil
 }
 
+func (m *MockRepository) FindByDebtorAccountIDPaginated(accountID string, limit, offset int) (*persistence.PaginatedResult, error) {
+	pos := m.debtorAccountIndex[accountID]
+	totalCount := len(pos)
+
+	// Apply pagination bounds
+	if offset >= totalCount {
+		return &persistence.PaginatedResult{
+			PaymentOrders: []*domain.PaymentOrder{},
+			TotalCount:    int64(totalCount),
+			HasMore:       false,
+		}, nil
+	}
+
+	end := offset + limit
+	if end > totalCount {
+		end = totalCount
+	}
+
+	// Return copies to simulate database behavior
+	result := make([]*domain.PaymentOrder, 0, end-offset)
+	for i := offset; i < end; i++ {
+		result = append(result, copyPaymentOrder(pos[i]))
+	}
+
+	return &persistence.PaginatedResult{
+		PaymentOrders: result,
+		TotalCount:    int64(totalCount),
+		HasMore:       end < totalCount,
+	}, nil
+}
+
 func (m *MockRepository) Update(po *domain.PaymentOrder) error {
 	if m.updateErr != nil {
 		return m.updateErr
@@ -230,17 +262,19 @@ func newInitiateRequest(idempotencyKey, debtorAccountID, creditorRef string, amo
 // Test NewService constructor
 func TestNewService(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, err := NewService(repo)
 
+	require.NoError(t, err)
 	assert.NotNil(t, svc)
 	assert.NotNil(t, svc.repo)
 	assert.NotNil(t, svc.logger)
 }
 
-func TestNewService_NilRepository_Panics(t *testing.T) {
-	assert.Panics(t, func() {
-		NewService(nil)
-	})
+func TestNewService_NilRepository_ReturnsError(t *testing.T) {
+	svc, err := NewService(nil)
+
+	assert.Nil(t, svc)
+	assert.ErrorIs(t, err, ErrRepositoryNil)
 }
 
 // Test NewServiceWithConfig
@@ -287,7 +321,7 @@ func TestNewServiceWithConfig(t *testing.T) {
 // Test InitiatePaymentOrder
 func TestInitiatePaymentOrder_Success(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	req := newInitiateRequest("test-key-1", "ACC-12345678", "GB82WEST12345698765432", 10000)
 
@@ -304,7 +338,7 @@ func TestInitiatePaymentOrder_Success(t *testing.T) {
 
 func TestInitiatePaymentOrder_Idempotent(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	req := newInitiateRequest("idempotent-key", "ACC-12345678", "GB82WEST12345698765432", 10000)
 
@@ -322,7 +356,7 @@ func TestInitiatePaymentOrder_Idempotent(t *testing.T) {
 
 func TestInitiatePaymentOrder_InvalidAmount(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	// Zero amount
 	req := newInitiateRequest("test-key", "ACC-12345678", "GB82WEST12345698765432", 0)
@@ -338,7 +372,7 @@ func TestInitiatePaymentOrder_InvalidAmount(t *testing.T) {
 
 func TestInitiatePaymentOrder_NegativeAmount(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	// Negative amount
 	req := &pb.InitiatePaymentOrderRequest{
@@ -368,7 +402,7 @@ var ErrDatabaseError = errors.New("database error")
 func TestInitiatePaymentOrder_RepositoryError(t *testing.T) {
 	repo := NewMockRepository()
 	repo.createErr = ErrDatabaseError
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	req := newInitiateRequest("test-key", "ACC-12345678", "GB82WEST12345698765432", 10000)
 
@@ -383,7 +417,7 @@ func TestInitiatePaymentOrder_RepositoryError(t *testing.T) {
 // Test RetrievePaymentOrder
 func TestRetrievePaymentOrder_Success(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	// Create a payment order first
 	amount, _ := cadomain.NewMoney("GBP", 10000)
@@ -403,7 +437,7 @@ func TestRetrievePaymentOrder_Success(t *testing.T) {
 
 func TestRetrievePaymentOrder_NotFound(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	req := &pb.RetrievePaymentOrderRequest{
 		PaymentOrderId: uuid.New().String(),
@@ -419,7 +453,7 @@ func TestRetrievePaymentOrder_NotFound(t *testing.T) {
 
 func TestRetrievePaymentOrder_InvalidID(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	req := &pb.RetrievePaymentOrderRequest{
 		PaymentOrderId: "not-a-uuid",
@@ -436,7 +470,7 @@ func TestRetrievePaymentOrder_InvalidID(t *testing.T) {
 // Test CancelPaymentOrder
 func TestCancelPaymentOrder_Success(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	// Create a payment order in INITIATED state
 	amount, _ := cadomain.NewMoney("GBP", 10000)
@@ -458,7 +492,7 @@ func TestCancelPaymentOrder_Success(t *testing.T) {
 
 func TestCancelPaymentOrder_AlreadyCancelled_Idempotent(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	// Create and cancel a payment order
 	amount, _ := cadomain.NewMoney("GBP", 10000)
@@ -481,7 +515,7 @@ func TestCancelPaymentOrder_AlreadyCancelled_Idempotent(t *testing.T) {
 
 func TestCancelPaymentOrder_NotCancellable(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	// Create a payment order and move it to EXECUTING state
 	amount, _ := cadomain.NewMoney("GBP", 10000)
@@ -657,7 +691,7 @@ func TestUpdatePaymentOrder_ByGatewayReferenceID(t *testing.T) {
 
 func TestUpdatePaymentOrder_NotFound(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	req := &pb.UpdatePaymentOrderRequest{
 		PaymentOrderId: uuid.New().String(),
@@ -675,7 +709,7 @@ func TestUpdatePaymentOrder_NotFound(t *testing.T) {
 
 func TestUpdatePaymentOrder_MissingIdentifier(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	req := &pb.UpdatePaymentOrderRequest{
 		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_SETTLED,
@@ -690,10 +724,83 @@ func TestUpdatePaymentOrder_MissingIdentifier(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, st.Code())
 }
 
+func TestUpdatePaymentOrder_Idempotent_Settled(t *testing.T) {
+	repo := NewMockRepository()
+	caClient := &MockCurrentAccountClient{
+		executeLienResp: &currentaccountv1.ExecuteLienResponse{},
+	}
+	svc := &Service{
+		repo:                 repo,
+		currentAccountClient: caClient,
+		logger:               testLogger(),
+	}
+
+	// Create a payment order in EXECUTING state
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", "correlation-123")
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("gateway-ref-123")
+	_ = repo.Create(po)
+
+	req := &pb.UpdatePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_SETTLED,
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "update-key"},
+	}
+
+	// First call - should succeed
+	resp1, err := svc.UpdatePaymentOrder(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED, resp1.PaymentOrder.Status)
+
+	// Second call with same request - should be idempotent
+	resp2, err := svc.UpdatePaymentOrder(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED, resp2.PaymentOrder.Status)
+	assert.Equal(t, resp1.PaymentOrder.PaymentOrderId, resp2.PaymentOrder.PaymentOrderId)
+}
+
+func TestUpdatePaymentOrder_Idempotent_Rejected(t *testing.T) {
+	repo := NewMockRepository()
+	caClient := &MockCurrentAccountClient{
+		terminateLienResp: &currentaccountv1.TerminateLienResponse{},
+	}
+	svc := &Service{
+		repo:                 repo,
+		currentAccountClient: caClient,
+		logger:               testLogger(),
+	}
+
+	// Create a payment order in EXECUTING state
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", "correlation-123")
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("gateway-ref-123")
+	_ = repo.Create(po)
+
+	req := &pb.UpdatePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		GatewayStatus:  pb.GatewayStatus_GATEWAY_STATUS_REJECTED,
+		GatewayMessage: "Insufficient funds",
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "update-key"},
+	}
+
+	// First call - should succeed
+	resp1, err := svc.UpdatePaymentOrder(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_FAILED, resp1.PaymentOrder.Status)
+
+	// Second call with same request - should be idempotent
+	resp2, err := svc.UpdatePaymentOrder(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_FAILED, resp2.PaymentOrder.Status)
+	assert.Equal(t, resp1.PaymentOrder.PaymentOrderId, resp2.PaymentOrder.PaymentOrderId)
+}
+
 // Test ListPaymentOrders
 func TestListPaymentOrders_Success(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	// Create some payment orders
 	amount, _ := cadomain.NewMoney("GBP", 10000)
@@ -714,7 +821,7 @@ func TestListPaymentOrders_Success(t *testing.T) {
 
 func TestListPaymentOrders_EmptyDebtorAccountID(t *testing.T) {
 	repo := NewMockRepository()
-	svc := NewService(repo)
+	svc, _ := NewService(repo)
 
 	req := &pb.ListPaymentOrdersRequest{}
 
@@ -724,6 +831,157 @@ func TestListPaymentOrders_EmptyDebtorAccountID(t *testing.T) {
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestListPaymentOrders_Pagination(t *testing.T) {
+	repo := NewMockRepository()
+	svc, _ := NewService(repo)
+
+	// Create 5 payment orders
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	for i := 0; i < 5; i++ {
+		po, _ := domain.NewPaymentOrder(
+			"ACC-12345678",
+			"GB82WEST12345698765432",
+			amount,
+			fmt.Sprintf("key-%d", i),
+			uuid.New().String(),
+		)
+		_ = repo.Create(po)
+	}
+
+	// Test first page with page size 2
+	req := &pb.ListPaymentOrdersRequest{
+		DebtorAccountId: "ACC-12345678",
+		Pagination: &commonpb.Pagination{
+			PageSize: 2,
+		},
+	}
+
+	resp, err := svc.ListPaymentOrders(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Len(t, resp.PaymentOrders, 2)
+	assert.Equal(t, int64(5), resp.Pagination.TotalCount)
+	assert.NotEmpty(t, resp.Pagination.NextPageToken)
+
+	// Test second page
+	req.Pagination.PageToken = resp.Pagination.NextPageToken
+	resp2, err := svc.ListPaymentOrders(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Len(t, resp2.PaymentOrders, 2)
+	assert.NotEmpty(t, resp2.Pagination.NextPageToken)
+
+	// Test last page
+	req.Pagination.PageToken = resp2.Pagination.NextPageToken
+	resp3, err := svc.ListPaymentOrders(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Len(t, resp3.PaymentOrders, 1) // Only 1 remaining
+	assert.Empty(t, resp3.Pagination.NextPageToken)
+}
+
+func TestListPaymentOrders_InvalidPageToken(t *testing.T) {
+	repo := NewMockRepository()
+	svc, _ := NewService(repo)
+
+	req := &pb.ListPaymentOrdersRequest{
+		DebtorAccountId: "ACC-12345678",
+		Pagination: &commonpb.Pagination{
+			PageToken: "not-a-number",
+		},
+	}
+
+	_, err := svc.ListPaymentOrders(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "page_token")
+}
+
+func TestListPaymentOrders_NegativePageToken(t *testing.T) {
+	repo := NewMockRepository()
+	svc, _ := NewService(repo)
+
+	req := &pb.ListPaymentOrdersRequest{
+		DebtorAccountId: "ACC-12345678",
+		Pagination: &commonpb.Pagination{
+			PageToken: "-5",
+		},
+	}
+
+	_, err := svc.ListPaymentOrders(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestListPaymentOrders_PageSizeExceedsMax(t *testing.T) {
+	repo := NewMockRepository()
+	svc, _ := NewService(repo)
+
+	// Create 3 payment orders
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	for i := 0; i < 3; i++ {
+		po, _ := domain.NewPaymentOrder(
+			"ACC-12345678",
+			"GB82WEST12345698765432",
+			amount,
+			fmt.Sprintf("key-%d", i),
+			uuid.New().String(),
+		)
+		_ = repo.Create(po)
+	}
+
+	req := &pb.ListPaymentOrdersRequest{
+		DebtorAccountId: "ACC-12345678",
+		Pagination: &commonpb.Pagination{
+			PageSize: 5000, // Exceeds max of 1000
+		},
+	}
+
+	resp, err := svc.ListPaymentOrders(context.Background(), req)
+
+	require.NoError(t, err)
+	// Should return all 3 (page size capped but we only have 3)
+	assert.Len(t, resp.PaymentOrders, 3)
+}
+
+func TestListPaymentOrders_OffsetBeyondResults(t *testing.T) {
+	repo := NewMockRepository()
+	svc, _ := NewService(repo)
+
+	// Create 2 payment orders
+	amount, _ := cadomain.NewMoney("GBP", 10000)
+	for i := 0; i < 2; i++ {
+		po, _ := domain.NewPaymentOrder(
+			"ACC-12345678",
+			"GB82WEST12345698765432",
+			amount,
+			fmt.Sprintf("key-%d", i),
+			uuid.New().String(),
+		)
+		_ = repo.Create(po)
+	}
+
+	req := &pb.ListPaymentOrdersRequest{
+		DebtorAccountId: "ACC-12345678",
+		Pagination: &commonpb.Pagination{
+			PageToken: "100", // Offset beyond the 2 results
+		},
+	}
+
+	resp, err := svc.ListPaymentOrders(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Len(t, resp.PaymentOrders, 0)
+	assert.Empty(t, resp.Pagination.NextPageToken)
+	assert.Equal(t, int64(2), resp.Pagination.TotalCount)
 }
 
 // Test proto conversion helpers


### PR DESCRIPTION
## Summary

- Implement PaymentOrder gRPC service layer with full saga orchestration for payment processing
- All RPCs from payment_order.proto: InitiatePaymentOrder, RetrievePaymentOrder, UpdatePaymentOrder, CancelPaymentOrder, ListPaymentOrders
- Saga steps: reserve_funds (lien creation), send_to_gateway with automatic compensation on failure
- Kafka event publishing for all payment order lifecycle events

## Changes Made

### Service Implementation (`internal/payment-order/service/grpc_service.go`)
- Service struct with dependencies: Repository, CurrentAccountClient, PaymentGateway, KafkaProducer
- Constructor variants: NewService (testing), NewServiceWithConfig (production with validation)
- InitiatePaymentOrder: Idempotency support, validation, async saga orchestration
- RetrievePaymentOrder: Simple lookup by payment order ID
- UpdatePaymentOrder: Gateway callback handling (settled, rejected, pending states)
- CancelPaymentOrder: Cancellation with lien release when needed
- ListPaymentOrders: Basic listing by debtor account ID

### Saga Orchestration (`orchestratePayment`)
- Uses SagaOrchestrator pattern from current-account/clients
- Step 1: reserve_funds - InitiateLien via CurrentAccountClient with TerminateLien compensation
- Step 2: send_to_gateway - SendPayment via PaymentGateway adapter
- Proper state transitions: INITIATED → RESERVED → EXECUTING
- Comprehensive error handling with failure reason tracking

### Event Publishing
- PaymentOrderInitiatedEvent, PaymentOrderReservedEvent, PaymentOrderExecutingEvent
- PaymentOrderCompletedEvent, PaymentOrderFailedEvent, PaymentOrderCancelledEvent
- Published to appropriate Kafka topics with correlation/causation IDs

### Tests (`internal/payment-order/service/grpc_service_test.go`)
- Mock implementations for Repository, CurrentAccountClient, PaymentGateway
- Tests for all RPCs including success paths and error conditions
- Idempotency tests for InitiatePaymentOrder and CancelPaymentOrder
- Proto conversion helper tests

## Test plan

- [x] Unit tests pass (`go test ./internal/payment-order/service/...`)
- [x] Lint passes (`golangci-lint run ./internal/payment-order/...`)
- [x] Build succeeds (`go build ./...`)
- [ ] CI pipeline passes

Closes #7