### PR TITLE
feat: Add HTTP webhook adapter for payment gateway callbacks

### DIFF
--- a/cmd/payment-order/main.go
+++ b/cmd/payment-order/main.go
@@ -270,9 +270,15 @@ func (s *simpleHealthServer) Check(_ context.Context, _ *grpc_health_v1.HealthCh
 }
 
 func (s *simpleHealthServer) Watch(_ *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
-	return server.Send(&grpc_health_v1.HealthCheckResponse{
+	// Send initial status
+	if err := server.Send(&grpc_health_v1.HealthCheckResponse{
 		Status: grpc_health_v1.HealthCheckResponse_SERVING,
-	})
+	}); err != nil {
+		return err
+	}
+	// Block until context is done to keep stream open
+	<-server.Context().Done()
+	return server.Context().Err()
 }
 
 // currentAccountGRPCClient implements service.CurrentAccountClient using gRPC.

--- a/cmd/payment-order/main.go
+++ b/cmd/payment-order/main.go
@@ -1,0 +1,456 @@
+// Package main is the entry point for the PaymentOrder service.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"time"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	"github.com/meridianhub/meridian/internal/payment-order/adapters/gateway"
+	webhookhttp "github.com/meridianhub/meridian/internal/payment-order/adapters/http"
+	"github.com/meridianhub/meridian/internal/payment-order/adapters/persistence"
+	"github.com/meridianhub/meridian/internal/payment-order/service"
+	"github.com/meridianhub/meridian/internal/platform/kafka"
+	"github.com/meridianhub/meridian/internal/platform/observability"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// Build information set via ldflags during compilation.
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+// ErrMissingHMACSecret is returned when the WEBHOOK_HMAC_SECRET environment variable is not set.
+var ErrMissingHMACSecret = errors.New("WEBHOOK_HMAC_SECRET environment variable is required")
+
+func main() {
+	// Initialize structured logging
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting payment-order service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	// Run the service
+	if err := run(logger); err != nil {
+		logger.Error("service failed", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	ctx := context.Background()
+
+	// Initialize OpenTelemetry tracer
+	tracerConfig, err := observability.DefaultConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load tracer config: %w", err)
+	}
+
+	tracerConfig = tracerConfig.
+		WithServiceName("payment-order-service").
+		WithServiceVersion(Version)
+
+	tracer, err := observability.NewTracer(ctx, tracerConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := tracer.Shutdown(shutdownCtx); err != nil {
+			logger.Error("failed to shutdown tracer", "error", err)
+		}
+	}()
+
+	logger.Info("tracer initialized",
+		"service_name", tracerConfig.ServiceName,
+		"environment", tracerConfig.Environment)
+
+	// Initialize database connection
+	db, err := initDatabase(logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize database: %w", err)
+	}
+	defer closeDatabase(db, logger)
+	logger.Info("database connection established")
+
+	// Create repository
+	repo := persistence.NewPaymentOrderRepository(db)
+
+	// Get Kubernetes namespace from environment
+	namespace := getEnvOrDefault("K8S_NAMESPACE", "default")
+
+	// Create external clients
+	currentAccountClient, cleanup, err := createCurrentAccountClient(namespace, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create current account client: %w", err)
+	}
+	defer cleanup()
+
+	// Create payment gateway
+	paymentGateway := createPaymentGateway(logger)
+
+	// Create Kafka producer
+	kafkaProducer, err := createKafkaProducer(logger)
+	if err != nil {
+		return fmt.Errorf("failed to create Kafka producer: %w", err)
+	}
+	defer kafkaProducer.Close()
+
+	// Create payment order service
+	paymentOrderService, err := service.NewServiceWithConfig(service.Config{
+		Repository:           repo,
+		CurrentAccountClient: currentAccountClient,
+		PaymentGateway:       paymentGateway,
+		KafkaProducer:        kafkaProducer,
+		Logger:               logger,
+		Tracer:               tracer,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create payment order service: %w", err)
+	}
+
+	// Create gRPC server
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(
+			tracer.UnaryServerInterceptor(),
+		),
+		grpc.ChainStreamInterceptor(
+			tracer.StreamServerInterceptor(),
+		),
+	)
+
+	// Register gRPC services
+	pb.RegisterPaymentOrderServiceServer(grpcServer, paymentOrderService)
+	grpc_health_v1.RegisterHealthServer(grpcServer, &simpleHealthServer{})
+	reflection.Register(grpcServer)
+	logger.Info("gRPC services registered")
+
+	// Create HTTP webhook handler
+	hmacSecret := []byte(getEnvOrDefault("WEBHOOK_HMAC_SECRET", ""))
+	if len(hmacSecret) == 0 {
+		return ErrMissingHMACSecret
+	}
+
+	// Create a gRPC client wrapper for the local service
+	localServiceClient := &localPaymentOrderClient{service: paymentOrderService}
+
+	webhookHandler, err := webhookhttp.NewWebhookHandler(webhookhttp.WebhookHandlerConfig{
+		PaymentOrderService: localServiceClient,
+		HMACSecret:          hmacSecret,
+		Logger:              logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create webhook handler: %w", err)
+	}
+
+	// Create HTTP server
+	httpPort := getEnvAsInt("HTTP_PORT", 8080)
+	httpServer, err := webhookhttp.NewServer(webhookhttp.ServerConfig{
+		Port:               httpPort,
+		WebhookHandler:     webhookHandler,
+		Logger:             logger,
+		RateLimitPerSecond: getEnvAsFloat("HTTP_RATE_LIMIT_PER_SECOND", 100),
+		RateLimitBurst:     getEnvAsInt("HTTP_RATE_LIMIT_BURST", 200),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create HTTP server: %w", err)
+	}
+
+	// Get gRPC port
+	grpcPort := getEnvOrDefault("GRPC_PORT", "50054")
+	grpcAddress := fmt.Sprintf(":%s", grpcPort)
+
+	// Create gRPC listener
+	grpcListener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", grpcAddress)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", grpcAddress, err)
+	}
+
+	// Channel to collect server errors
+	serverErrors := make(chan error, 2)
+
+	// Start gRPC server in background
+	go func() {
+		logger.Info("starting gRPC server", "address", grpcAddress)
+		if err := grpcServer.Serve(grpcListener); err != nil {
+			serverErrors <- fmt.Errorf("gRPC server error: %w", err)
+		}
+	}()
+
+	// Start HTTP server in background
+	go func() {
+		logger.Info("starting HTTP server", "port", httpPort)
+		if err := httpServer.Start(); err != nil {
+			serverErrors <- fmt.Errorf("HTTP server error: %w", err)
+		}
+	}()
+
+	// Wait for interrupt signal or server error
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case sig := <-sigChan:
+		logger.Info("received signal", "signal", sig)
+	case err := <-serverErrors:
+		return err
+	}
+
+	// Graceful shutdown
+	logger.Info("shutting down servers...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Shutdown HTTP server first (stop accepting new webhooks)
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		logger.Error("failed to shutdown HTTP server", "error", err)
+	}
+
+	// Gracefully stop gRPC server
+	stopped := make(chan struct{})
+	go func() {
+		grpcServer.GracefulStop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		logger.Info("servers stopped gracefully")
+	case <-shutdownCtx.Done():
+		logger.Warn("graceful shutdown timeout, forcing stop")
+		grpcServer.Stop()
+	}
+
+	return nil
+}
+
+// localPaymentOrderClient wraps the local service to implement the client interface.
+type localPaymentOrderClient struct {
+	service *service.Service
+}
+
+func (c *localPaymentOrderClient) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error) {
+	return c.service.UpdatePaymentOrder(ctx, req)
+}
+
+// simpleHealthServer implements grpc_health_v1.HealthServer with basic checks.
+type simpleHealthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+}
+
+func (s *simpleHealthServer) Check(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+func (s *simpleHealthServer) Watch(_ *grpc_health_v1.HealthCheckRequest, server grpc_health_v1.Health_WatchServer) error {
+	return server.Send(&grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	})
+}
+
+// currentAccountGRPCClient implements service.CurrentAccountClient using gRPC.
+type currentAccountGRPCClient struct {
+	conn   *grpc.ClientConn
+	client currentaccountv1.CurrentAccountServiceClient
+}
+
+func (c *currentAccountGRPCClient) InitiateLien(ctx context.Context, req *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error) {
+	return c.client.InitiateLien(ctx, req)
+}
+
+func (c *currentAccountGRPCClient) TerminateLien(ctx context.Context, req *currentaccountv1.TerminateLienRequest) (*currentaccountv1.TerminateLienResponse, error) {
+	return c.client.TerminateLien(ctx, req)
+}
+
+func (c *currentAccountGRPCClient) ExecuteLien(ctx context.Context, req *currentaccountv1.ExecuteLienRequest) (*currentaccountv1.ExecuteLienResponse, error) {
+	return c.client.ExecuteLien(ctx, req)
+}
+
+func (c *currentAccountGRPCClient) Close() error {
+	return c.conn.Close()
+}
+
+// createCurrentAccountClient creates the CurrentAccount gRPC client.
+func createCurrentAccountClient(namespace string, logger *slog.Logger) (service.CurrentAccountClient, func(), error) {
+	target := fmt.Sprintf("dns:///current-account.%s.svc.cluster.local:50051", namespace)
+	logger.Info("connecting to current-account service", "target", target)
+
+	conn, err := grpc.NewClient(
+		target,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingConfig": [{"round_robin":{}}]}`),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to connect to current-account service: %w", err)
+	}
+
+	client := &currentAccountGRPCClient{
+		conn:   conn,
+		client: currentaccountv1.NewCurrentAccountServiceClient(conn),
+	}
+
+	cleanup := func() {
+		if err := client.Close(); err != nil {
+			logger.Error("failed to close current-account client", "error", err)
+		}
+	}
+
+	return client, cleanup, nil
+}
+
+// createPaymentGateway creates the payment gateway client.
+func createPaymentGateway(logger *slog.Logger) gateway.PaymentGateway {
+	gatewayURL := getEnvOrDefault("PAYMENT_GATEWAY_URL", "")
+	if gatewayURL == "" {
+		logger.Warn("PAYMENT_GATEWAY_URL not set, using mock gateway")
+		return gateway.New(gateway.Config{UseMock: true})
+	}
+
+	return gateway.New(gateway.Config{
+		Timeout:    30 * time.Second,
+		MaxRetries: 3,
+	})
+}
+
+// createKafkaProducer creates the Kafka producer.
+func createKafkaProducer(logger *slog.Logger) (*kafka.ProtoProducer, error) {
+	brokers := getEnvOrDefault("KAFKA_BROKERS", "kafka:9092")
+	logger.Info("connecting to Kafka", "brokers", brokers)
+	return kafka.NewProtoProducer(kafka.ProducerConfig{
+		BootstrapServers: brokers,
+		ClientID:         "payment-order-service",
+	})
+}
+
+// initDatabase initializes the database connection with connection pooling.
+func initDatabase(logger *slog.Logger) (*gorm.DB, error) {
+	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable")
+
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		SkipDefaultTransaction: true,
+		PrepareStmt:            true,
+		Logger:                 nil,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to database: %w", err)
+	}
+
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database instance: %w", err)
+	}
+
+	maxOpenConns := getEnvAsInt("DB_MAX_OPEN_CONNS", 25)
+	maxIdleConns := getEnvAsInt("DB_MAX_IDLE_CONNS", 5)
+	connMaxLifetime := getEnvAsDuration("DB_CONN_MAX_LIFETIME", 5*time.Minute)
+	connMaxIdleTime := getEnvAsDuration("DB_CONN_MAX_IDLE_TIME", 10*time.Minute)
+
+	sqlDB.SetMaxOpenConns(maxOpenConns)
+	sqlDB.SetMaxIdleConns(maxIdleConns)
+	sqlDB.SetConnMaxLifetime(connMaxLifetime)
+	sqlDB.SetConnMaxIdleTime(connMaxIdleTime)
+
+	logger.Info("database connection pool configured",
+		"max_open_conns", maxOpenConns,
+		"max_idle_conns", maxIdleConns)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := sqlDB.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	return db, nil
+}
+
+// closeDatabase closes the database connection gracefully.
+func closeDatabase(db *gorm.DB, logger *slog.Logger) {
+	sqlDB, err := db.DB()
+	if err != nil {
+		logger.Error("failed to get database instance for closing", "error", err)
+		return
+	}
+
+	if err := sqlDB.Close(); err != nil {
+		logger.Error("failed to close database connection", "error", err)
+	} else {
+		logger.Info("database connection closed")
+	}
+}
+
+// Environment variable helpers
+
+func getEnvOrDefault(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+func getEnvAsInt(key string, defaultValue int) int {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}
+
+func getEnvAsFloat(key string, defaultValue float64) float64 {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	value, err := strconv.ParseFloat(valueStr, 64)
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}
+
+func getEnvAsDuration(key string, defaultValue time.Duration) time.Duration {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	value, err := time.ParseDuration(valueStr)
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}

--- a/internal/payment-order/adapters/http/server.go
+++ b/internal/payment-order/adapters/http/server.go
@@ -39,6 +39,12 @@ type ServerConfig struct {
 	RateLimitPerSecond float64
 	// RateLimitBurst is the max burst size for rate limiting.
 	RateLimitBurst int
+	// RateLimitMaxEntries is the max number of IPs to track for rate limiting.
+	// When exceeded, oldest entries are evicted. Defaults to 10000.
+	RateLimitMaxEntries int
+	// TrustProxyHeaders controls whether to trust X-Forwarded-For and X-Real-IP headers.
+	// Only enable this when running behind a trusted reverse proxy.
+	TrustProxyHeaders bool
 	// ReadTimeout for HTTP requests.
 	ReadTimeout time.Duration
 	// WriteTimeout for HTTP responses.
@@ -50,12 +56,14 @@ type ServerConfig struct {
 // DefaultServerConfig returns a ServerConfig with sensible defaults.
 func DefaultServerConfig() ServerConfig {
 	return ServerConfig{
-		Port:               8080,
-		RateLimitPerSecond: 100,
-		RateLimitBurst:     200,
-		ReadTimeout:        10 * time.Second,
-		WriteTimeout:       30 * time.Second,
-		IdleTimeout:        60 * time.Second,
+		Port:                8080,
+		RateLimitPerSecond:  100,
+		RateLimitBurst:      200,
+		RateLimitMaxEntries: 10000,
+		TrustProxyHeaders:   false,
+		ReadTimeout:         10 * time.Second,
+		WriteTimeout:        30 * time.Second,
+		IdleTimeout:         60 * time.Second,
 	}
 }
 
@@ -80,6 +88,9 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	if cfg.RateLimitBurst <= 0 {
 		cfg.RateLimitBurst = 200
 	}
+	if cfg.RateLimitMaxEntries <= 0 {
+		cfg.RateLimitMaxEntries = 10000
+	}
 	if cfg.ReadTimeout <= 0 {
 		cfg.ReadTimeout = 10 * time.Second
 	}
@@ -90,8 +101,8 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		cfg.IdleTimeout = 60 * time.Second
 	}
 
-	// Create rate limiter
-	rateLimiter := newIPRateLimiter(rate.Limit(cfg.RateLimitPerSecond), cfg.RateLimitBurst)
+	// Create rate limiter with max entries to prevent unbounded growth
+	rateLimiter := newIPRateLimiter(rate.Limit(cfg.RateLimitPerSecond), cfg.RateLimitBurst, cfg.RateLimitMaxEntries)
 
 	// Create mux and register handlers
 	mux := http.NewServeMux()
@@ -102,8 +113,8 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	handler := chainMiddleware(
 		mux,
 		requestIDMiddleware(logger),
-		loggingMiddleware(logger),
-		rateLimitMiddleware(rateLimiter, logger),
+		loggingMiddleware(logger, cfg.TrustProxyHeaders),
+		rateLimitMiddleware(rateLimiter, logger, cfg.TrustProxyHeaders),
 		recoveryMiddleware(logger),
 	)
 
@@ -205,7 +216,7 @@ func GetRequestID(ctx context.Context) string {
 }
 
 // loggingMiddleware logs HTTP requests.
-func loggingMiddleware(logger *slog.Logger) middleware {
+func loggingMiddleware(logger *slog.Logger, trustProxyHeaders bool) middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
@@ -224,7 +235,7 @@ func loggingMiddleware(logger *slog.Logger) middleware {
 				"path", r.URL.Path,
 				"status", wrapped.statusCode,
 				"duration_ms", duration.Milliseconds(),
-				"remote_addr", getClientIP(r),
+				"remote_addr", getClientIP(r, trustProxyHeaders),
 				"user_agent", r.UserAgent())
 		})
 	}
@@ -242,10 +253,10 @@ func (rw *responseWriter) WriteHeader(code int) {
 }
 
 // rateLimitMiddleware applies per-IP rate limiting.
-func rateLimitMiddleware(limiter *ipRateLimiter, logger *slog.Logger) middleware {
+func rateLimitMiddleware(limiter *ipRateLimiter, logger *slog.Logger, trustProxyHeaders bool) middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ip := getClientIP(r)
+			ip := getClientIP(r, trustProxyHeaders)
 			if !limiter.allow(ip) {
 				requestID := GetRequestID(r.Context())
 				logger.Warn("rate limit exceeded",
@@ -280,22 +291,25 @@ func recoveryMiddleware(logger *slog.Logger) middleware {
 }
 
 // getClientIP extracts the client IP from the request.
-// Handles X-Forwarded-For and X-Real-IP headers for proxied requests.
-func getClientIP(r *http.Request) string {
-	// Check X-Forwarded-For first (may contain multiple IPs)
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// Take the first IP (original client)
-		for i := 0; i < len(xff); i++ {
-			if xff[i] == ',' {
-				return xff[:i]
+// When trustProxyHeaders is true, it checks X-Forwarded-For and X-Real-IP headers.
+// When false, it only uses RemoteAddr to prevent IP spoofing attacks.
+func getClientIP(r *http.Request, trustProxyHeaders bool) string {
+	if trustProxyHeaders {
+		// Check X-Forwarded-For first (may contain multiple IPs)
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			// Take the first IP (original client)
+			for i := 0; i < len(xff); i++ {
+				if xff[i] == ',' {
+					return xff[:i]
+				}
 			}
+			return xff
 		}
-		return xff
-	}
 
-	// Check X-Real-IP
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return xri
+		// Check X-Real-IP
+		if xri := r.Header.Get("X-Real-IP"); xri != "" {
+			return xri
+		}
 	}
 
 	// Fall back to RemoteAddr
@@ -307,43 +321,72 @@ func getClientIP(r *http.Request) string {
 }
 
 // ipRateLimiter provides per-IP rate limiting using token bucket.
+// It maintains a bounded map of limiters with LRU-style eviction.
 type ipRateLimiter struct {
-	limiters map[string]*rate.Limiter
-	mu       sync.RWMutex
-	r        rate.Limit
-	b        int
+	limiters   map[string]*rateLimiterEntry
+	mu         sync.Mutex
+	r          rate.Limit
+	b          int
+	maxEntries int
 }
 
-// newIPRateLimiter creates a new IP-based rate limiter.
-func newIPRateLimiter(r rate.Limit, b int) *ipRateLimiter {
+// rateLimiterEntry holds a rate limiter and its last access time.
+type rateLimiterEntry struct {
+	limiter    *rate.Limiter
+	lastAccess time.Time
+}
+
+// newIPRateLimiter creates a new IP-based rate limiter with bounded entries.
+func newIPRateLimiter(r rate.Limit, b int, maxEntries int) *ipRateLimiter {
 	return &ipRateLimiter{
-		limiters: make(map[string]*rate.Limiter),
-		r:        r,
-		b:        b,
+		limiters:   make(map[string]*rateLimiterEntry),
+		r:          r,
+		b:          b,
+		maxEntries: maxEntries,
 	}
 }
 
 // getLimiter returns the rate limiter for the given IP.
 func (l *ipRateLimiter) getLimiter(ip string) *rate.Limiter {
-	l.mu.RLock()
-	limiter, exists := l.limiters[ip]
-	l.mu.RUnlock()
-
-	if exists {
-		return limiter
-	}
+	now := time.Now()
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	// Double-check after acquiring write lock
-	if limiter, exists := l.limiters[ip]; exists {
-		return limiter
+	if entry, exists := l.limiters[ip]; exists {
+		entry.lastAccess = now
+		return entry.limiter
 	}
 
-	limiter = rate.NewLimiter(l.r, l.b)
-	l.limiters[ip] = limiter
-	return limiter
+	// Evict oldest entries if at capacity
+	if len(l.limiters) >= l.maxEntries {
+		l.evictOldest()
+	}
+
+	entry := &rateLimiterEntry{
+		limiter:    rate.NewLimiter(l.r, l.b),
+		lastAccess: now,
+	}
+	l.limiters[ip] = entry
+	return entry.limiter
+}
+
+// evictOldest removes the oldest entry from the limiters map.
+// Must be called with write lock held.
+func (l *ipRateLimiter) evictOldest() {
+	var oldestIP string
+	var oldestTime time.Time
+
+	for ip, entry := range l.limiters {
+		if oldestIP == "" || entry.lastAccess.Before(oldestTime) {
+			oldestIP = ip
+			oldestTime = entry.lastAccess
+		}
+	}
+
+	if oldestIP != "" {
+		delete(l.limiters, oldestIP)
+	}
 }
 
 // allow checks if the request from the given IP should be allowed.

--- a/internal/payment-order/adapters/http/server.go
+++ b/internal/payment-order/adapters/http/server.go
@@ -1,0 +1,352 @@
+// Package http provides the HTTP adapter for receiving payment gateway webhooks.
+package http
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/time/rate"
+)
+
+// Configuration errors.
+var (
+	ErrNilWebhookHandler = errors.New("webhook handler cannot be nil")
+	ErrInvalidPort       = errors.New("invalid port number")
+)
+
+// Server wraps an HTTP server with middleware and graceful shutdown.
+type Server struct {
+	httpServer *http.Server
+	logger     *slog.Logger
+}
+
+// ServerConfig contains configuration for creating an HTTP server.
+type ServerConfig struct {
+	// Port is the HTTP port to listen on.
+	Port int
+	// WebhookHandler handles incoming webhooks.
+	WebhookHandler *WebhookHandler
+	// Logger for request logging.
+	Logger *slog.Logger
+	// RateLimitPerSecond is the max requests per second per IP.
+	RateLimitPerSecond float64
+	// RateLimitBurst is the max burst size for rate limiting.
+	RateLimitBurst int
+	// ReadTimeout for HTTP requests.
+	ReadTimeout time.Duration
+	// WriteTimeout for HTTP responses.
+	WriteTimeout time.Duration
+	// IdleTimeout for keep-alive connections.
+	IdleTimeout time.Duration
+}
+
+// DefaultServerConfig returns a ServerConfig with sensible defaults.
+func DefaultServerConfig() ServerConfig {
+	return ServerConfig{
+		Port:               8080,
+		RateLimitPerSecond: 100,
+		RateLimitBurst:     200,
+		ReadTimeout:        10 * time.Second,
+		WriteTimeout:       30 * time.Second,
+		IdleTimeout:        60 * time.Second,
+	}
+}
+
+// NewServer creates a new HTTP server with the provided configuration.
+func NewServer(cfg ServerConfig) (*Server, error) {
+	if cfg.WebhookHandler == nil {
+		return nil, ErrNilWebhookHandler
+	}
+	if cfg.Port <= 0 || cfg.Port > 65535 {
+		return nil, ErrInvalidPort
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// Apply defaults for zero values
+	if cfg.RateLimitPerSecond <= 0 {
+		cfg.RateLimitPerSecond = 100
+	}
+	if cfg.RateLimitBurst <= 0 {
+		cfg.RateLimitBurst = 200
+	}
+	if cfg.ReadTimeout <= 0 {
+		cfg.ReadTimeout = 10 * time.Second
+	}
+	if cfg.WriteTimeout <= 0 {
+		cfg.WriteTimeout = 30 * time.Second
+	}
+	if cfg.IdleTimeout <= 0 {
+		cfg.IdleTimeout = 60 * time.Second
+	}
+
+	// Create rate limiter
+	rateLimiter := newIPRateLimiter(rate.Limit(cfg.RateLimitPerSecond), cfg.RateLimitBurst)
+
+	// Create mux and register handlers
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /webhook/payment-gateway", cfg.WebhookHandler.HandleWebhook)
+	mux.HandleFunc("GET /health", healthHandler)
+
+	// Apply middleware chain
+	handler := chainMiddleware(
+		mux,
+		requestIDMiddleware(logger),
+		loggingMiddleware(logger),
+		rateLimitMiddleware(rateLimiter, logger),
+		recoveryMiddleware(logger),
+	)
+
+	httpServer := &http.Server{
+		Addr:         fmt.Sprintf(":%d", cfg.Port),
+		Handler:      handler,
+		ReadTimeout:  cfg.ReadTimeout,
+		WriteTimeout: cfg.WriteTimeout,
+		IdleTimeout:  cfg.IdleTimeout,
+	}
+
+	return &Server{
+		httpServer: httpServer,
+		logger:     logger,
+	}, nil
+}
+
+// Start begins listening for HTTP requests.
+// This method blocks until the server is stopped.
+func (s *Server) Start() error {
+	s.logger.Info("starting HTTP server", "address", s.httpServer.Addr)
+	err := s.httpServer.ListenAndServe()
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+// Shutdown gracefully stops the HTTP server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.logger.Info("shutting down HTTP server")
+	return s.httpServer.Shutdown(ctx)
+}
+
+// Addr returns the server's address.
+// Only valid after Start() is called with a listener.
+func (s *Server) Addr() string {
+	return s.httpServer.Addr
+}
+
+// StartWithListener starts the server on the provided listener.
+// Useful for testing with dynamically allocated ports.
+func (s *Server) StartWithListener(listener net.Listener) error {
+	s.logger.Info("starting HTTP server", "address", listener.Addr().String())
+	err := s.httpServer.Serve(listener)
+	if errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+// healthHandler provides a simple health check endpoint.
+func healthHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"healthy"}`))
+}
+
+// Middleware types and helpers
+
+type middleware func(http.Handler) http.Handler
+
+// chainMiddleware applies middleware in order (first middleware is outermost).
+func chainMiddleware(handler http.Handler, middlewares ...middleware) http.Handler {
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handler = middlewares[i](handler)
+	}
+	return handler
+}
+
+// requestIDMiddleware adds a unique request ID to each request.
+func requestIDMiddleware(_ *slog.Logger) middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestID := r.Header.Get("X-Request-ID")
+			if requestID == "" {
+				requestID = uuid.New().String()
+			}
+			w.Header().Set("X-Request-ID", requestID)
+
+			// Add request ID to context for downstream use
+			ctx := context.WithValue(r.Context(), requestIDKey, requestID)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// contextKey is a type for context keys to avoid collisions.
+type contextKey string
+
+const requestIDKey contextKey = "request_id"
+
+// GetRequestID retrieves the request ID from context.
+func GetRequestID(ctx context.Context) string {
+	if id, ok := ctx.Value(requestIDKey).(string); ok {
+		return id
+	}
+	return ""
+}
+
+// loggingMiddleware logs HTTP requests.
+func loggingMiddleware(logger *slog.Logger) middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+
+			// Wrap response writer to capture status code
+			wrapped := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+			next.ServeHTTP(wrapped, r)
+
+			duration := time.Since(start)
+			requestID := GetRequestID(r.Context())
+
+			logger.Info("http request",
+				"request_id", requestID,
+				"method", r.Method,
+				"path", r.URL.Path,
+				"status", wrapped.statusCode,
+				"duration_ms", duration.Milliseconds(),
+				"remote_addr", getClientIP(r),
+				"user_agent", r.UserAgent())
+		})
+	}
+}
+
+// responseWriter wraps http.ResponseWriter to capture the status code.
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// rateLimitMiddleware applies per-IP rate limiting.
+func rateLimitMiddleware(limiter *ipRateLimiter, logger *slog.Logger) middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := getClientIP(r)
+			if !limiter.allow(ip) {
+				requestID := GetRequestID(r.Context())
+				logger.Warn("rate limit exceeded",
+					"request_id", requestID,
+					"remote_addr", ip,
+					"path", r.URL.Path)
+				http.Error(w, `{"error":"rate limit exceeded"}`, http.StatusTooManyRequests)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// recoveryMiddleware recovers from panics and returns 500.
+func recoveryMiddleware(logger *slog.Logger) middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() { //nolint:contextcheck // recovery handler cannot accept context in defer
+				if err := recover(); err != nil {
+					requestID := GetRequestID(r.Context())
+					logger.Error("panic recovered",
+						"request_id", requestID,
+						"error", err,
+						"path", r.URL.Path)
+					http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// getClientIP extracts the client IP from the request.
+// Handles X-Forwarded-For and X-Real-IP headers for proxied requests.
+func getClientIP(r *http.Request) string {
+	// Check X-Forwarded-For first (may contain multiple IPs)
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// Take the first IP (original client)
+		for i := 0; i < len(xff); i++ {
+			if xff[i] == ',' {
+				return xff[:i]
+			}
+		}
+		return xff
+	}
+
+	// Check X-Real-IP
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return xri
+	}
+
+	// Fall back to RemoteAddr
+	ip, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return ip
+}
+
+// ipRateLimiter provides per-IP rate limiting using token bucket.
+type ipRateLimiter struct {
+	limiters map[string]*rate.Limiter
+	mu       sync.RWMutex
+	r        rate.Limit
+	b        int
+}
+
+// newIPRateLimiter creates a new IP-based rate limiter.
+func newIPRateLimiter(r rate.Limit, b int) *ipRateLimiter {
+	return &ipRateLimiter{
+		limiters: make(map[string]*rate.Limiter),
+		r:        r,
+		b:        b,
+	}
+}
+
+// getLimiter returns the rate limiter for the given IP.
+func (l *ipRateLimiter) getLimiter(ip string) *rate.Limiter {
+	l.mu.RLock()
+	limiter, exists := l.limiters[ip]
+	l.mu.RUnlock()
+
+	if exists {
+		return limiter
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if limiter, exists := l.limiters[ip]; exists {
+		return limiter
+	}
+
+	limiter = rate.NewLimiter(l.r, l.b)
+	l.limiters[ip] = limiter
+	return limiter
+}
+
+// allow checks if the request from the given IP should be allowed.
+func (l *ipRateLimiter) allow(ip string) bool {
+	return l.getLimiter(ip).Allow()
+}

--- a/internal/payment-order/adapters/http/server_test.go
+++ b/internal/payment-order/adapters/http/server_test.go
@@ -100,6 +100,8 @@ func TestDefaultServerConfig(t *testing.T) {
 	assert.Equal(t, 8080, cfg.Port)
 	assert.Equal(t, float64(100), cfg.RateLimitPerSecond)
 	assert.Equal(t, 200, cfg.RateLimitBurst)
+	assert.Equal(t, 10000, cfg.RateLimitMaxEntries)
+	assert.False(t, cfg.TrustProxyHeaders)
 	assert.Equal(t, 10*time.Second, cfg.ReadTimeout)
 	assert.Equal(t, 30*time.Second, cfg.WriteTimeout)
 	assert.Equal(t, 60*time.Second, cfg.IdleTimeout)
@@ -248,39 +250,59 @@ func (r *fixedReader) Read(p []byte) (n int, err error) {
 
 func TestGetClientIP(t *testing.T) {
 	tests := []struct {
-		name          string
-		xForwardedFor string
-		xRealIP       string
-		remoteAddr    string
-		expectedIP    string
+		name              string
+		xForwardedFor     string
+		xRealIP           string
+		remoteAddr        string
+		trustProxyHeaders bool
+		expectedIP        string
 	}{
 		{
-			name:          "X-Forwarded-For single IP",
-			xForwardedFor: "192.168.1.1",
-			remoteAddr:    "10.0.0.1:12345",
-			expectedIP:    "192.168.1.1",
+			name:              "X-Forwarded-For single IP with trust",
+			xForwardedFor:     "192.168.1.1",
+			remoteAddr:        "10.0.0.1:12345",
+			trustProxyHeaders: true,
+			expectedIP:        "192.168.1.1",
 		},
 		{
-			name:          "X-Forwarded-For multiple IPs",
-			xForwardedFor: "192.168.1.1, 10.0.0.2, 172.16.0.1",
-			remoteAddr:    "10.0.0.1:12345",
-			expectedIP:    "192.168.1.1",
+			name:              "X-Forwarded-For multiple IPs with trust",
+			xForwardedFor:     "192.168.1.1, 10.0.0.2, 172.16.0.1",
+			remoteAddr:        "10.0.0.1:12345",
+			trustProxyHeaders: true,
+			expectedIP:        "192.168.1.1",
 		},
 		{
-			name:       "X-Real-IP",
-			xRealIP:    "192.168.2.2",
-			remoteAddr: "10.0.0.1:12345",
-			expectedIP: "192.168.2.2",
+			name:              "X-Real-IP with trust",
+			xRealIP:           "192.168.2.2",
+			remoteAddr:        "10.0.0.1:12345",
+			trustProxyHeaders: true,
+			expectedIP:        "192.168.2.2",
 		},
 		{
-			name:       "Remote address with port",
-			remoteAddr: "192.168.3.3:54321",
-			expectedIP: "192.168.3.3",
+			name:              "Remote address with port",
+			remoteAddr:        "192.168.3.3:54321",
+			trustProxyHeaders: false,
+			expectedIP:        "192.168.3.3",
 		},
 		{
-			name:       "Remote address without port",
-			remoteAddr: "192.168.4.4",
-			expectedIP: "192.168.4.4",
+			name:              "Remote address without port",
+			remoteAddr:        "192.168.4.4",
+			trustProxyHeaders: false,
+			expectedIP:        "192.168.4.4",
+		},
+		{
+			name:              "X-Forwarded-For ignored without trust",
+			xForwardedFor:     "192.168.1.1",
+			remoteAddr:        "10.0.0.1:12345",
+			trustProxyHeaders: false,
+			expectedIP:        "10.0.0.1",
+		},
+		{
+			name:              "X-Real-IP ignored without trust",
+			xRealIP:           "192.168.2.2",
+			remoteAddr:        "10.0.0.1:12345",
+			trustProxyHeaders: false,
+			expectedIP:        "10.0.0.1",
 		},
 	}
 
@@ -295,7 +317,7 @@ func TestGetClientIP(t *testing.T) {
 			}
 			req.RemoteAddr = tt.remoteAddr
 
-			ip := getClientIP(req)
+			ip := getClientIP(req, tt.trustProxyHeaders)
 			assert.Equal(t, tt.expectedIP, ip)
 		})
 	}
@@ -313,8 +335,8 @@ func TestGetRequestID(t *testing.T) {
 }
 
 func TestIPRateLimiter(t *testing.T) {
-	// Create a rate limiter that allows 2 requests per second with burst of 2
-	limiter := newIPRateLimiter(2, 2)
+	// Create a rate limiter that allows 2 requests per second with burst of 2 and max 100 entries
+	limiter := newIPRateLimiter(2, 2, 100)
 
 	ip := "192.168.1.1"
 
@@ -329,6 +351,30 @@ func TestIPRateLimiter(t *testing.T) {
 	ip2 := "192.168.1.2"
 	assert.True(t, limiter.allow(ip2))
 	assert.True(t, limiter.allow(ip2))
+}
+
+func TestIPRateLimiterEviction(t *testing.T) {
+	// Create a rate limiter with max 2 entries
+	limiter := newIPRateLimiter(100, 100, 2)
+
+	// Add two IPs
+	limiter.allow("192.168.1.1")
+	limiter.allow("192.168.1.2")
+
+	// Verify both exist
+	assert.Equal(t, 2, len(limiter.limiters))
+
+	// Add a third IP - should evict the oldest
+	limiter.allow("192.168.1.3")
+
+	// Should still have only 2 entries
+	assert.Equal(t, 2, len(limiter.limiters))
+
+	// The newest two should exist
+	_, exists2 := limiter.limiters["192.168.1.2"]
+	_, exists3 := limiter.limiters["192.168.1.3"]
+	assert.True(t, exists2)
+	assert.True(t, exists3)
 }
 
 func TestMiddlewareChain(t *testing.T) {

--- a/internal/payment-order/adapters/http/server_test.go
+++ b/internal/payment-order/adapters/http/server_test.go
@@ -1,0 +1,384 @@
+package http
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+)
+
+func TestNewServer(t *testing.T) {
+	webhookHandler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          []byte("secret"),
+	})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		cfg     ServerConfig
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			cfg: ServerConfig{
+				Port:           8080,
+				WebhookHandler: webhookHandler,
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil webhook handler",
+			cfg: ServerConfig{
+				Port:           8080,
+				WebhookHandler: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid port zero",
+			cfg: ServerConfig{
+				Port:           0,
+				WebhookHandler: webhookHandler,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid port negative",
+			cfg: ServerConfig{
+				Port:           -1,
+				WebhookHandler: webhookHandler,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid port too high",
+			cfg: ServerConfig{
+				Port:           65536,
+				WebhookHandler: webhookHandler,
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid config with defaults",
+			cfg: ServerConfig{
+				Port:           8080,
+				WebhookHandler: webhookHandler,
+				// All other fields will use defaults
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server, err := NewServer(tt.cfg)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, server)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, server)
+			}
+		})
+	}
+}
+
+func TestDefaultServerConfig(t *testing.T) {
+	cfg := DefaultServerConfig()
+
+	assert.Equal(t, 8080, cfg.Port)
+	assert.Equal(t, float64(100), cfg.RateLimitPerSecond)
+	assert.Equal(t, 200, cfg.RateLimitBurst)
+	assert.Equal(t, 10*time.Second, cfg.ReadTimeout)
+	assert.Equal(t, 30*time.Second, cfg.WriteTimeout)
+	assert.Equal(t, 60*time.Second, cfg.IdleTimeout)
+}
+
+func TestServer_HealthEndpoint(t *testing.T) {
+	webhookHandler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          []byte("secret"),
+	})
+	require.NoError(t, err)
+
+	server, err := NewServer(ServerConfig{
+		Port:           8080,
+		WebhookHandler: webhookHandler,
+	})
+	require.NoError(t, err)
+
+	// Create a test listener
+	ctx := context.Background()
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// Start server in background
+	serverDone := make(chan struct{})
+	go func() {
+		_ = server.StartWithListener(listener)
+		close(serverDone)
+	}()
+
+	// Give server time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Make request to health endpoint
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+listener.Addr().String()+"/health", nil)
+	require.NoError(t, err)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var healthResp map[string]string
+	err = json.NewDecoder(resp.Body).Decode(&healthResp)
+	require.NoError(t, err)
+	assert.Equal(t, "healthy", healthResp["status"])
+
+	// Shutdown server
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = server.Shutdown(shutdownCtx)
+	require.NoError(t, err)
+
+	<-serverDone
+}
+
+func TestServer_WebhookEndpoint(t *testing.T) {
+	secret := []byte("test-secret")
+
+	webhookHandler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{
+			updateFunc: func(_ context.Context, _ *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error) {
+				return &pb.UpdatePaymentOrderResponse{
+					PaymentOrder: &pb.PaymentOrder{
+						PaymentOrderId: "test-order",
+						Status:         pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					},
+				}, nil
+			},
+		},
+		HMACSecret: secret,
+	})
+	require.NoError(t, err)
+
+	server, err := NewServer(ServerConfig{
+		Port:           8080,
+		WebhookHandler: webhookHandler,
+	})
+	require.NoError(t, err)
+
+	// Create a test listener
+	ctx := context.Background()
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// Start server in background
+	serverDone := make(chan struct{})
+	go func() {
+		_ = server.StartWithListener(listener)
+		close(serverDone)
+	}()
+
+	// Give server time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Create webhook request
+	webhookReq := WebhookRequest{
+		GatewayReferenceID: "gw-123",
+		Status:             "Settled",
+		Timestamp:          time.Now().UTC(),
+	}
+	body, err := json.Marshal(webhookReq)
+	require.NoError(t, err)
+
+	signature := GenerateWebhookSignature(body, secret)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"http://"+listener.Addr().String()+"/webhook/payment-gateway",
+		&fixedReader{data: body})
+	require.NoError(t, err)
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set(WebhookSignatureHeader, signature)
+
+	resp, err := client.Do(httpReq)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Shutdown server
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = server.Shutdown(shutdownCtx)
+	require.NoError(t, err)
+
+	<-serverDone
+}
+
+// fixedReader provides a simple io.Reader for testing
+type fixedReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *fixedReader) Read(p []byte) (n int, err error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n = copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func TestGetClientIP(t *testing.T) {
+	tests := []struct {
+		name          string
+		xForwardedFor string
+		xRealIP       string
+		remoteAddr    string
+		expectedIP    string
+	}{
+		{
+			name:          "X-Forwarded-For single IP",
+			xForwardedFor: "192.168.1.1",
+			remoteAddr:    "10.0.0.1:12345",
+			expectedIP:    "192.168.1.1",
+		},
+		{
+			name:          "X-Forwarded-For multiple IPs",
+			xForwardedFor: "192.168.1.1, 10.0.0.2, 172.16.0.1",
+			remoteAddr:    "10.0.0.1:12345",
+			expectedIP:    "192.168.1.1",
+		},
+		{
+			name:       "X-Real-IP",
+			xRealIP:    "192.168.2.2",
+			remoteAddr: "10.0.0.1:12345",
+			expectedIP: "192.168.2.2",
+		},
+		{
+			name:       "Remote address with port",
+			remoteAddr: "192.168.3.3:54321",
+			expectedIP: "192.168.3.3",
+		},
+		{
+			name:       "Remote address without port",
+			remoteAddr: "192.168.4.4",
+			expectedIP: "192.168.4.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.xForwardedFor != "" {
+				req.Header.Set("X-Forwarded-For", tt.xForwardedFor)
+			}
+			if tt.xRealIP != "" {
+				req.Header.Set("X-Real-IP", tt.xRealIP)
+			}
+			req.RemoteAddr = tt.remoteAddr
+
+			ip := getClientIP(req)
+			assert.Equal(t, tt.expectedIP, ip)
+		})
+	}
+}
+
+func TestGetRequestID(t *testing.T) {
+	// Test with request ID in context
+	ctx := context.WithValue(context.Background(), requestIDKey, "test-request-id")
+	id := GetRequestID(ctx)
+	assert.Equal(t, "test-request-id", id)
+
+	// Test without request ID in context
+	id = GetRequestID(context.Background())
+	assert.Empty(t, id)
+}
+
+func TestIPRateLimiter(t *testing.T) {
+	// Create a rate limiter that allows 2 requests per second with burst of 2
+	limiter := newIPRateLimiter(2, 2)
+
+	ip := "192.168.1.1"
+
+	// First two requests should be allowed (burst)
+	assert.True(t, limiter.allow(ip))
+	assert.True(t, limiter.allow(ip))
+
+	// Third request should be denied (exceeded burst)
+	assert.False(t, limiter.allow(ip))
+
+	// Different IP should have its own limiter
+	ip2 := "192.168.1.2"
+	assert.True(t, limiter.allow(ip2))
+	assert.True(t, limiter.allow(ip2))
+}
+
+func TestMiddlewareChain(t *testing.T) {
+	var order []string
+
+	middleware1 := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			order = append(order, "m1-before")
+			next.ServeHTTP(w, r)
+			order = append(order, "m1-after")
+		})
+	}
+
+	middleware2 := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			order = append(order, "m2-before")
+			next.ServeHTTP(w, r)
+			order = append(order, "m2-after")
+		})
+	}
+
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		order = append(order, "handler")
+	})
+
+	chained := chainMiddleware(handler, middleware1, middleware2)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	chained.ServeHTTP(rr, req)
+
+	// Middleware should execute in order: m1 wraps m2 wraps handler
+	expected := []string{"m1-before", "m2-before", "handler", "m2-after", "m1-after"}
+	assert.Equal(t, expected, order)
+}
+
+func TestRecoveryMiddleware(t *testing.T) {
+	panicHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		panic("test panic")
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	recovered := recoveryMiddleware(logger)(panicHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rr := httptest.NewRecorder()
+
+	// Should not panic
+	recovered.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}

--- a/internal/payment-order/adapters/http/webhook_handler.go
+++ b/internal/payment-order/adapters/http/webhook_handler.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -109,6 +110,9 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Ensure body is closed when we're done
+	defer func() { _ = r.Body.Close() }()
+
 	// Read request body
 	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1MB limit
 	if err != nil {
@@ -116,7 +120,6 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		h.writeErrorResponse(w, http.StatusBadRequest, ErrInvalidRequestBody.Error())
 		return
 	}
-	defer func() { _ = r.Body.Close() }()
 
 	// Validate HMAC signature
 	signature := r.Header.Get(WebhookSignatureHeader)
@@ -197,13 +200,21 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 }
 
 // validateSignature validates the HMAC-SHA256 signature of the request body.
+// The signature is expected to be a hex-encoded HMAC-SHA256 hash.
 func (h *WebhookHandler) validateSignature(body []byte, signature string) bool {
+	// Decode the hex-encoded signature from the request
+	providedMAC, err := hex.DecodeString(signature)
+	if err != nil {
+		return false
+	}
+
+	// Compute the expected MAC
 	mac := hmac.New(sha256.New, h.hmacSecret)
 	mac.Write(body)
 	expectedMAC := mac.Sum(nil)
-	expectedSignature := hex.EncodeToString(expectedMAC)
 
-	return hmac.Equal([]byte(signature), []byte(expectedSignature))
+	// Use constant-time comparison on raw bytes
+	return hmac.Equal(providedMAC, expectedMAC)
 }
 
 // generateIdempotencyKey creates a deterministic idempotency key from webhook data.
@@ -217,13 +228,14 @@ func (h *WebhookHandler) generateIdempotencyKey(req WebhookRequest) string {
 }
 
 // mapGatewayStatus converts the gateway status string to proto enum.
+// Status comparison is case-insensitive.
 func mapGatewayStatus(status string) (pb.GatewayStatus, error) {
-	switch status {
-	case "Settled", "SETTLED", "settled":
+	switch strings.ToUpper(status) {
+	case "SETTLED":
 		return pb.GatewayStatus_GATEWAY_STATUS_SETTLED, nil
-	case "Rejected", "REJECTED", "rejected":
+	case "REJECTED":
 		return pb.GatewayStatus_GATEWAY_STATUS_REJECTED, nil
-	case "Pending", "PENDING", "pending":
+	case "PENDING":
 		return pb.GatewayStatus_GATEWAY_STATUS_PENDING, nil
 	default:
 		return pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED, ErrInvalidGatewayStatus

--- a/internal/payment-order/adapters/http/webhook_handler.go
+++ b/internal/payment-order/adapters/http/webhook_handler.go
@@ -26,6 +26,7 @@ var (
 	ErrInvalidRequestBody     = errors.New("invalid request body")
 	ErrMissingReferenceID     = errors.New("gateway_reference_id is required")
 	ErrInvalidGatewayStatus   = errors.New("invalid gateway_status")
+	ErrTimestampExpired       = errors.New("webhook timestamp expired")
 	ErrPaymentOrderService    = errors.New("payment order service error")
 	ErrNilPaymentOrderService = errors.New("payment order service cannot be nil")
 	ErrEmptyHMACSecret        = errors.New("HMAC secret cannot be empty")
@@ -36,6 +37,9 @@ const WebhookSignatureHeader = "X-Webhook-Signature"
 
 // IdempotencyKeyHeader is the HTTP header containing the gateway-provided idempotency key.
 const IdempotencyKeyHeader = "X-Idempotency-Key"
+
+// DefaultWebhookMaxAge is the default maximum age for webhook timestamps to prevent replay attacks.
+const DefaultWebhookMaxAge = 5 * time.Minute
 
 // PaymentOrderServiceClient defines the interface for calling the PaymentOrder gRPC service.
 type PaymentOrderServiceClient interface {
@@ -150,6 +154,15 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate timestamp freshness to prevent replay attacks
+	if !webhookReq.Timestamp.IsZero() && time.Since(webhookReq.Timestamp) > DefaultWebhookMaxAge {
+		h.logger.Warn("webhook timestamp too old",
+			"timestamp", webhookReq.Timestamp,
+			"age", time.Since(webhookReq.Timestamp))
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrTimestampExpired.Error())
+		return
+	}
+
 	// Map gateway status to proto enum
 	gatewayStatus, err := mapGatewayStatus(webhookReq.Status)
 	if err != nil {
@@ -255,7 +268,9 @@ func (h *WebhookHandler) writeSuccessResponse(w http.ResponseWriter, message str
 		Acknowledged: true,
 		Message:      message,
 	}
-	_ = json.NewEncoder(w).Encode(resp)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		h.logger.Error("failed to encode success response", "error", err)
+	}
 }
 
 // writeErrorResponse writes an error JSON response.
@@ -266,7 +281,9 @@ func (h *WebhookHandler) writeErrorResponse(w http.ResponseWriter, statusCode in
 		Acknowledged: false,
 		Error:        message,
 	}
-	_ = json.NewEncoder(w).Encode(resp)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		h.logger.Error("failed to encode error response", "error", err)
+	}
 }
 
 // GenerateWebhookSignature generates an HMAC-SHA256 signature for a request body.

--- a/internal/payment-order/adapters/http/webhook_handler.go
+++ b/internal/payment-order/adapters/http/webhook_handler.go
@@ -33,6 +33,9 @@ var (
 // WebhookSignatureHeader is the HTTP header containing the HMAC signature.
 const WebhookSignatureHeader = "X-Webhook-Signature"
 
+// IdempotencyKeyHeader is the HTTP header containing the gateway-provided idempotency key.
+const IdempotencyKeyHeader = "X-Idempotency-Key"
+
 // PaymentOrderServiceClient defines the interface for calling the PaymentOrder gRPC service.
 type PaymentOrderServiceClient interface {
 	UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error)
@@ -124,7 +127,7 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if !h.validateSignature(body, signature) {
-		h.logger.Warn("invalid webhook signature", "signature", signature)
+		h.logger.Warn("invalid webhook signature")
 		h.writeErrorResponse(w, http.StatusUnauthorized, ErrInvalidSignature.Error())
 		return
 	}
@@ -152,8 +155,11 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Generate idempotency key from webhook data
-	idempotencyKey := h.generateIdempotencyKey(webhookReq)
+	// Use gateway-provided idempotency key if available, otherwise generate one
+	idempotencyKey := r.Header.Get(IdempotencyKeyHeader)
+	if idempotencyKey == "" {
+		idempotencyKey = h.generateIdempotencyKey(webhookReq)
+	}
 
 	// Build UpdatePaymentOrder request
 	updateReq := &pb.UpdatePaymentOrderRequest{

--- a/internal/payment-order/adapters/http/webhook_handler.go
+++ b/internal/payment-order/adapters/http/webhook_handler.go
@@ -27,6 +27,7 @@ var (
 	ErrMissingReferenceID     = errors.New("gateway_reference_id is required")
 	ErrInvalidGatewayStatus   = errors.New("invalid gateway_status")
 	ErrTimestampExpired       = errors.New("webhook timestamp expired")
+	ErrTimestampFuture        = errors.New("webhook timestamp is in the future")
 	ErrPaymentOrderService    = errors.New("payment order service error")
 	ErrNilPaymentOrderService = errors.New("payment order service cannot be nil")
 	ErrEmptyHMACSecret        = errors.New("HMAC secret cannot be empty")
@@ -40,6 +41,9 @@ const IdempotencyKeyHeader = "X-Idempotency-Key"
 
 // DefaultWebhookMaxAge is the default maximum age for webhook timestamps to prevent replay attacks.
 const DefaultWebhookMaxAge = 5 * time.Minute
+
+// DefaultClockDriftTolerance is the maximum allowed future timestamp to account for clock drift.
+const DefaultClockDriftTolerance = 30 * time.Second
 
 // PaymentOrderServiceClient defines the interface for calling the PaymentOrder gRPC service.
 type PaymentOrderServiceClient interface {
@@ -155,12 +159,27 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Validate timestamp freshness to prevent replay attacks
-	if !webhookReq.Timestamp.IsZero() && time.Since(webhookReq.Timestamp) > DefaultWebhookMaxAge {
-		h.logger.Warn("webhook timestamp too old",
-			"timestamp", webhookReq.Timestamp,
-			"age", time.Since(webhookReq.Timestamp))
-		h.writeErrorResponse(w, http.StatusBadRequest, ErrTimestampExpired.Error())
-		return
+	if !webhookReq.Timestamp.IsZero() {
+		now := time.Now()
+		age := now.Sub(webhookReq.Timestamp)
+
+		// Reject timestamps too far in the past
+		if age > DefaultWebhookMaxAge {
+			h.logger.Warn("webhook timestamp too old",
+				"timestamp", webhookReq.Timestamp,
+				"age", age)
+			h.writeErrorResponse(w, http.StatusBadRequest, ErrTimestampExpired.Error())
+			return
+		}
+
+		// Reject timestamps too far in the future (with small tolerance for clock drift)
+		if age < -DefaultClockDriftTolerance {
+			h.logger.Warn("webhook timestamp too far in the future",
+				"timestamp", webhookReq.Timestamp,
+				"offset", -age)
+			h.writeErrorResponse(w, http.StatusBadRequest, ErrTimestampFuture.Error())
+			return
+		}
 	}
 
 	// Map gateway status to proto enum

--- a/internal/payment-order/adapters/http/webhook_handler.go
+++ b/internal/payment-order/adapters/http/webhook_handler.go
@@ -192,9 +192,14 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	h.logger.Info("webhook processed successfully",
-		"payment_order_id", resp.PaymentOrder.PaymentOrderId,
-		"status", resp.PaymentOrder.Status.String())
+	// Log success with payment order details if available
+	if resp != nil && resp.PaymentOrder != nil {
+		h.logger.Info("webhook processed successfully",
+			"payment_order_id", resp.PaymentOrder.PaymentOrderId,
+			"status", resp.PaymentOrder.Status.String())
+	} else {
+		h.logger.Info("webhook processed successfully")
+	}
 
 	h.writeSuccessResponse(w, "webhook processed successfully")
 }

--- a/internal/payment-order/adapters/http/webhook_handler.go
+++ b/internal/payment-order/adapters/http/webhook_handler.go
@@ -1,0 +1,272 @@
+// Package http provides the HTTP adapter for receiving payment gateway webhooks.
+package http
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+)
+
+// Webhook handler errors.
+var (
+	ErrInvalidSignature       = errors.New("invalid webhook signature")
+	ErrMissingSignature       = errors.New("missing X-Webhook-Signature header")
+	ErrInvalidRequestBody     = errors.New("invalid request body")
+	ErrMissingReferenceID     = errors.New("gateway_reference_id is required")
+	ErrInvalidGatewayStatus   = errors.New("invalid gateway_status")
+	ErrPaymentOrderService    = errors.New("payment order service error")
+	ErrNilPaymentOrderService = errors.New("payment order service cannot be nil")
+	ErrEmptyHMACSecret        = errors.New("HMAC secret cannot be empty")
+)
+
+// WebhookSignatureHeader is the HTTP header containing the HMAC signature.
+const WebhookSignatureHeader = "X-Webhook-Signature"
+
+// PaymentOrderServiceClient defines the interface for calling the PaymentOrder gRPC service.
+type PaymentOrderServiceClient interface {
+	UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error)
+}
+
+// WebhookRequest represents the JSON payload from the payment gateway webhook.
+type WebhookRequest struct {
+	// GatewayReferenceID is the external ID from the payment gateway.
+	GatewayReferenceID string `json:"gateway_reference_id"`
+	// PaymentOrderID is optionally included by some gateways for direct lookup.
+	PaymentOrderID string `json:"payment_order_id,omitempty"`
+	// Status is the payment status from the gateway (Settled, Rejected, Pending).
+	Status string `json:"status"`
+	// Message is optional details from the gateway.
+	Message string `json:"message,omitempty"`
+	// Timestamp is when the gateway processed the payment.
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// WebhookResponse represents the JSON response to the gateway.
+type WebhookResponse struct {
+	// Acknowledged indicates the webhook was successfully processed.
+	Acknowledged bool `json:"acknowledged"`
+	// Message provides additional context.
+	Message string `json:"message,omitempty"`
+	// Error provides error details when acknowledged is false.
+	Error string `json:"error,omitempty"`
+}
+
+// WebhookHandler handles incoming payment gateway webhooks.
+type WebhookHandler struct {
+	paymentOrderService PaymentOrderServiceClient
+	hmacSecret          []byte
+	logger              *slog.Logger
+}
+
+// WebhookHandlerConfig contains configuration for creating a WebhookHandler.
+type WebhookHandlerConfig struct {
+	PaymentOrderService PaymentOrderServiceClient
+	HMACSecret          []byte
+	Logger              *slog.Logger
+}
+
+// NewWebhookHandler creates a new WebhookHandler.
+func NewWebhookHandler(cfg WebhookHandlerConfig) (*WebhookHandler, error) {
+	if cfg.PaymentOrderService == nil {
+		return nil, ErrNilPaymentOrderService
+	}
+	if len(cfg.HMACSecret) == 0 {
+		return nil, ErrEmptyHMACSecret
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &WebhookHandler{
+		paymentOrderService: cfg.PaymentOrderService,
+		hmacSecret:          cfg.HMACSecret,
+		logger:              logger,
+	}, nil
+}
+
+// HandleWebhook processes incoming payment gateway webhooks.
+// It validates the HMAC signature, parses the request, and calls UpdatePaymentOrder.
+func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	// Only accept POST requests
+	if r.Method != http.MethodPost {
+		h.writeErrorResponse(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	// Read request body
+	body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1MB limit
+	if err != nil {
+		h.logger.Error("failed to read request body", "error", err)
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrInvalidRequestBody.Error())
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	// Validate HMAC signature
+	signature := r.Header.Get(WebhookSignatureHeader)
+	if signature == "" {
+		h.logger.Warn("missing webhook signature")
+		h.writeErrorResponse(w, http.StatusUnauthorized, ErrMissingSignature.Error())
+		return
+	}
+
+	if !h.validateSignature(body, signature) {
+		h.logger.Warn("invalid webhook signature", "signature", signature)
+		h.writeErrorResponse(w, http.StatusUnauthorized, ErrInvalidSignature.Error())
+		return
+	}
+
+	// Parse webhook request
+	var webhookReq WebhookRequest
+	if err := json.Unmarshal(body, &webhookReq); err != nil {
+		h.logger.Error("failed to parse webhook request", "error", err)
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrInvalidRequestBody.Error())
+		return
+	}
+
+	// Validate required fields
+	if webhookReq.GatewayReferenceID == "" && webhookReq.PaymentOrderID == "" {
+		h.logger.Warn("missing reference ID in webhook")
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrMissingReferenceID.Error())
+		return
+	}
+
+	// Map gateway status to proto enum
+	gatewayStatus, err := mapGatewayStatus(webhookReq.Status)
+	if err != nil {
+		h.logger.Warn("invalid gateway status", "status", webhookReq.Status)
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrInvalidGatewayStatus.Error())
+		return
+	}
+
+	// Generate idempotency key from webhook data
+	idempotencyKey := h.generateIdempotencyKey(webhookReq)
+
+	// Build UpdatePaymentOrder request
+	updateReq := &pb.UpdatePaymentOrderRequest{
+		GatewayReferenceId: webhookReq.GatewayReferenceID,
+		PaymentOrderId:     webhookReq.PaymentOrderID,
+		GatewayStatus:      gatewayStatus,
+		GatewayMessage:     webhookReq.Message,
+		IdempotencyKey: &commonpb.IdempotencyKey{
+			Key: idempotencyKey,
+		},
+	}
+
+	h.logger.Info("processing webhook",
+		"gateway_reference_id", webhookReq.GatewayReferenceID,
+		"payment_order_id", webhookReq.PaymentOrderID,
+		"status", webhookReq.Status,
+		"idempotency_key", idempotencyKey)
+
+	// Call UpdatePaymentOrder
+	resp, err := h.paymentOrderService.UpdatePaymentOrder(ctx, updateReq)
+	if err != nil {
+		h.logger.Error("failed to update payment order",
+			"error", err,
+			"gateway_reference_id", webhookReq.GatewayReferenceID)
+		// Return 500 to trigger webhook retry
+		h.writeErrorResponse(w, http.StatusInternalServerError, ErrPaymentOrderService.Error())
+		return
+	}
+
+	h.logger.Info("webhook processed successfully",
+		"payment_order_id", resp.PaymentOrder.PaymentOrderId,
+		"status", resp.PaymentOrder.Status.String())
+
+	h.writeSuccessResponse(w, "webhook processed successfully")
+}
+
+// validateSignature validates the HMAC-SHA256 signature of the request body.
+func (h *WebhookHandler) validateSignature(body []byte, signature string) bool {
+	mac := hmac.New(sha256.New, h.hmacSecret)
+	mac.Write(body)
+	expectedMAC := mac.Sum(nil)
+	expectedSignature := hex.EncodeToString(expectedMAC)
+
+	return hmac.Equal([]byte(signature), []byte(expectedSignature))
+}
+
+// generateIdempotencyKey creates a deterministic idempotency key from webhook data.
+// This ensures duplicate webhook deliveries are handled correctly.
+func (h *WebhookHandler) generateIdempotencyKey(req WebhookRequest) string {
+	// Use a combination of gateway reference ID, status, and timestamp
+	// to create a unique, deterministic key
+	data := req.GatewayReferenceID + ":" + req.Status + ":" + req.Timestamp.Format(time.RFC3339)
+	hash := sha256.Sum256([]byte(data))
+	return "webhook:" + hex.EncodeToString(hash[:16]) // Use first 16 bytes
+}
+
+// mapGatewayStatus converts the gateway status string to proto enum.
+func mapGatewayStatus(status string) (pb.GatewayStatus, error) {
+	switch status {
+	case "Settled", "SETTLED", "settled":
+		return pb.GatewayStatus_GATEWAY_STATUS_SETTLED, nil
+	case "Rejected", "REJECTED", "rejected":
+		return pb.GatewayStatus_GATEWAY_STATUS_REJECTED, nil
+	case "Pending", "PENDING", "pending":
+		return pb.GatewayStatus_GATEWAY_STATUS_PENDING, nil
+	default:
+		return pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED, ErrInvalidGatewayStatus
+	}
+}
+
+// writeSuccessResponse writes a success JSON response.
+func (h *WebhookHandler) writeSuccessResponse(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	resp := WebhookResponse{
+		Acknowledged: true,
+		Message:      message,
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// writeErrorResponse writes an error JSON response.
+func (h *WebhookHandler) writeErrorResponse(w http.ResponseWriter, statusCode int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	resp := WebhookResponse{
+		Acknowledged: false,
+		Error:        message,
+	}
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// GenerateWebhookSignature generates an HMAC-SHA256 signature for a request body.
+// This is useful for testing and for gateways that need to sign requests.
+func GenerateWebhookSignature(body []byte, secret []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// NewWebhookRequest creates a WebhookRequest with a generated timestamp.
+// Useful for testing.
+func NewWebhookRequest(gatewayRefID, paymentOrderID, status, message string) WebhookRequest {
+	return WebhookRequest{
+		GatewayReferenceID: gatewayRefID,
+		PaymentOrderID:     paymentOrderID,
+		Status:             status,
+		Message:            message,
+		Timestamp:          time.Now().UTC(),
+	}
+}
+
+// RequestID generates a unique request ID for logging.
+func RequestID() string {
+	return uuid.New().String()
+}

--- a/internal/payment-order/adapters/http/webhook_handler_test.go
+++ b/internal/payment-order/adapters/http/webhook_handler_test.go
@@ -309,25 +309,26 @@ func TestWebhookHandler_HandleWebhook_MethodNotAllowed(t *testing.T) {
 
 func TestMapGatewayStatus(t *testing.T) {
 	tests := []struct {
+		name     string
 		input    string
 		expected pb.GatewayStatus
 		wantErr  bool
 	}{
-		{"Settled", pb.GatewayStatus_GATEWAY_STATUS_SETTLED, false},
-		{"SETTLED", pb.GatewayStatus_GATEWAY_STATUS_SETTLED, false},
-		{"settled", pb.GatewayStatus_GATEWAY_STATUS_SETTLED, false},
-		{"Rejected", pb.GatewayStatus_GATEWAY_STATUS_REJECTED, false},
-		{"REJECTED", pb.GatewayStatus_GATEWAY_STATUS_REJECTED, false},
-		{"rejected", pb.GatewayStatus_GATEWAY_STATUS_REJECTED, false},
-		{"Pending", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
-		{"PENDING", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
-		{"pending", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
-		{"Unknown", pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED, true},
-		{"", pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED, true},
+		{"Settled", "Settled", pb.GatewayStatus_GATEWAY_STATUS_SETTLED, false},
+		{"SETTLED", "SETTLED", pb.GatewayStatus_GATEWAY_STATUS_SETTLED, false},
+		{"settled", "settled", pb.GatewayStatus_GATEWAY_STATUS_SETTLED, false},
+		{"Rejected", "Rejected", pb.GatewayStatus_GATEWAY_STATUS_REJECTED, false},
+		{"REJECTED", "REJECTED", pb.GatewayStatus_GATEWAY_STATUS_REJECTED, false},
+		{"rejected", "rejected", pb.GatewayStatus_GATEWAY_STATUS_REJECTED, false},
+		{"Pending", "Pending", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
+		{"PENDING", "PENDING", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
+		{"pending", "pending", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
+		{"unknown_status", "Unknown", pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED, true},
+		{"empty_status", "", pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED, true},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			result, err := mapGatewayStatus(tt.input)
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/internal/payment-order/adapters/http/webhook_handler_test.go
+++ b/internal/payment-order/adapters/http/webhook_handler_test.go
@@ -450,3 +450,38 @@ func TestWebhookHandler_HandleWebhook_ExpiredTimestamp(t *testing.T) {
 	assert.False(t, resp.Acknowledged)
 	assert.Equal(t, ErrTimestampExpired.Error(), resp.Error)
 }
+
+func TestWebhookHandler_HandleWebhook_FutureTimestamp(t *testing.T) {
+	secret := []byte("test-secret")
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          secret,
+	})
+	require.NoError(t, err)
+
+	// Create a webhook request with a future timestamp (1 hour in the future)
+	webhookReq := WebhookRequest{
+		GatewayReferenceID: "gw-ref-123",
+		Status:             "Settled",
+		Timestamp:          time.Now().Add(1 * time.Hour),
+	}
+	body, err := json.Marshal(webhookReq)
+	require.NoError(t, err)
+
+	signature := GenerateWebhookSignature(body, secret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/payment-gateway", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(WebhookSignatureHeader, signature)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp WebhookResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.False(t, resp.Acknowledged)
+	assert.Equal(t, ErrTimestampFuture.Error(), resp.Error)
+}

--- a/internal/payment-order/adapters/http/webhook_handler_test.go
+++ b/internal/payment-order/adapters/http/webhook_handler_test.go
@@ -1,0 +1,369 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+)
+
+// mockPaymentOrderService implements PaymentOrderServiceClient for testing.
+type mockPaymentOrderService struct {
+	updateFunc func(ctx context.Context, req *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error)
+}
+
+func (m *mockPaymentOrderService) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error) {
+	if m.updateFunc != nil {
+		return m.updateFunc(ctx, req)
+	}
+	return &pb.UpdatePaymentOrderResponse{
+		PaymentOrder: &pb.PaymentOrder{
+			PaymentOrderId: "test-order-id",
+			Status:         pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+		},
+	}, nil
+}
+
+func TestNewWebhookHandler(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     WebhookHandlerConfig
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			cfg: WebhookHandlerConfig{
+				PaymentOrderService: &mockPaymentOrderService{},
+				HMACSecret:          []byte("secret"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil payment order service",
+			cfg: WebhookHandlerConfig{
+				PaymentOrderService: nil,
+				HMACSecret:          []byte("secret"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty HMAC secret",
+			cfg: WebhookHandlerConfig{
+				PaymentOrderService: &mockPaymentOrderService{},
+				HMACSecret:          []byte{},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, err := NewWebhookHandler(tt.cfg)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, handler)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, handler)
+			}
+		})
+	}
+}
+
+func TestWebhookHandler_HandleWebhook_Success(t *testing.T) {
+	secret := []byte("test-secret-key")
+
+	var capturedReq *pb.UpdatePaymentOrderRequest
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{
+			updateFunc: func(_ context.Context, req *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error) {
+				capturedReq = req
+				return &pb.UpdatePaymentOrderResponse{
+					PaymentOrder: &pb.PaymentOrder{
+						PaymentOrderId: "test-order-id",
+						Status:         pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					},
+				}, nil
+			},
+		},
+		HMACSecret: secret,
+	})
+	require.NoError(t, err)
+
+	webhookReq := WebhookRequest{
+		GatewayReferenceID: "gw-ref-123",
+		PaymentOrderID:     "po-456",
+		Status:             "Settled",
+		Message:            "Payment successful",
+		Timestamp:          time.Now().UTC(),
+	}
+	body, err := json.Marshal(webhookReq)
+	require.NoError(t, err)
+
+	signature := GenerateWebhookSignature(body, secret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/payment-gateway", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(WebhookSignatureHeader, signature)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp WebhookResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.True(t, resp.Acknowledged)
+	assert.NotEmpty(t, resp.Message)
+
+	// Verify the captured request
+	require.NotNil(t, capturedReq)
+	assert.Equal(t, "gw-ref-123", capturedReq.GatewayReferenceId)
+	assert.Equal(t, "po-456", capturedReq.PaymentOrderId)
+	assert.Equal(t, pb.GatewayStatus_GATEWAY_STATUS_SETTLED, capturedReq.GatewayStatus)
+	assert.Equal(t, "Payment successful", capturedReq.GatewayMessage)
+	assert.NotNil(t, capturedReq.IdempotencyKey)
+}
+
+func TestWebhookHandler_HandleWebhook_InvalidSignature(t *testing.T) {
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          []byte("correct-secret"),
+	})
+	require.NoError(t, err)
+
+	webhookReq := WebhookRequest{
+		GatewayReferenceID: "gw-ref-123",
+		Status:             "Settled",
+		Timestamp:          time.Now().UTC(),
+	}
+	body, err := json.Marshal(webhookReq)
+	require.NoError(t, err)
+
+	// Generate signature with wrong secret
+	wrongSignature := GenerateWebhookSignature(body, []byte("wrong-secret"))
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/payment-gateway", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(WebhookSignatureHeader, wrongSignature)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+
+	var resp WebhookResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.False(t, resp.Acknowledged)
+	assert.Equal(t, ErrInvalidSignature.Error(), resp.Error)
+}
+
+func TestWebhookHandler_HandleWebhook_MissingSignature(t *testing.T) {
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          []byte("secret"),
+	})
+	require.NoError(t, err)
+
+	webhookReq := WebhookRequest{
+		GatewayReferenceID: "gw-ref-123",
+		Status:             "Settled",
+		Timestamp:          time.Now().UTC(),
+	}
+	body, err := json.Marshal(webhookReq)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/payment-gateway", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// No signature header
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+
+	var resp WebhookResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.False(t, resp.Acknowledged)
+	assert.Equal(t, ErrMissingSignature.Error(), resp.Error)
+}
+
+func TestWebhookHandler_HandleWebhook_InvalidJSON(t *testing.T) {
+	secret := []byte("test-secret")
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          secret,
+	})
+	require.NoError(t, err)
+
+	body := []byte("not valid json")
+	signature := GenerateWebhookSignature(body, secret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/payment-gateway", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(WebhookSignatureHeader, signature)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp WebhookResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.False(t, resp.Acknowledged)
+}
+
+func TestWebhookHandler_HandleWebhook_MissingReferenceID(t *testing.T) {
+	secret := []byte("test-secret")
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          secret,
+	})
+	require.NoError(t, err)
+
+	webhookReq := WebhookRequest{
+		// No GatewayReferenceID or PaymentOrderID
+		Status:    "Settled",
+		Timestamp: time.Now().UTC(),
+	}
+	body, err := json.Marshal(webhookReq)
+	require.NoError(t, err)
+
+	signature := GenerateWebhookSignature(body, secret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/payment-gateway", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(WebhookSignatureHeader, signature)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp WebhookResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.False(t, resp.Acknowledged)
+	assert.Equal(t, ErrMissingReferenceID.Error(), resp.Error)
+}
+
+func TestWebhookHandler_HandleWebhook_InvalidGatewayStatus(t *testing.T) {
+	secret := []byte("test-secret")
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          secret,
+	})
+	require.NoError(t, err)
+
+	webhookReq := WebhookRequest{
+		GatewayReferenceID: "gw-ref-123",
+		Status:             "INVALID_STATUS",
+		Timestamp:          time.Now().UTC(),
+	}
+	body, err := json.Marshal(webhookReq)
+	require.NoError(t, err)
+
+	signature := GenerateWebhookSignature(body, secret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/payment-gateway", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(WebhookSignatureHeader, signature)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp WebhookResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.False(t, resp.Acknowledged)
+	assert.Equal(t, ErrInvalidGatewayStatus.Error(), resp.Error)
+}
+
+func TestWebhookHandler_HandleWebhook_MethodNotAllowed(t *testing.T) {
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          []byte("secret"),
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/webhook/payment-gateway", nil)
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+func TestMapGatewayStatus(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected pb.GatewayStatus
+		wantErr  bool
+	}{
+		{"Settled", pb.GatewayStatus_GATEWAY_STATUS_SETTLED, false},
+		{"SETTLED", pb.GatewayStatus_GATEWAY_STATUS_SETTLED, false},
+		{"settled", pb.GatewayStatus_GATEWAY_STATUS_SETTLED, false},
+		{"Rejected", pb.GatewayStatus_GATEWAY_STATUS_REJECTED, false},
+		{"REJECTED", pb.GatewayStatus_GATEWAY_STATUS_REJECTED, false},
+		{"rejected", pb.GatewayStatus_GATEWAY_STATUS_REJECTED, false},
+		{"Pending", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
+		{"PENDING", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
+		{"pending", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
+		{"Unknown", pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED, true},
+		{"", pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result, err := mapGatewayStatus(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGenerateWebhookSignature(t *testing.T) {
+	body := []byte(`{"gateway_reference_id":"test-123","status":"Settled"}`)
+	secret := []byte("my-secret-key")
+
+	sig1 := GenerateWebhookSignature(body, secret)
+	sig2 := GenerateWebhookSignature(body, secret)
+
+	// Same input should produce same signature
+	assert.Equal(t, sig1, sig2)
+
+	// Different secret should produce different signature
+	sig3 := GenerateWebhookSignature(body, []byte("different-secret"))
+	assert.NotEqual(t, sig1, sig3)
+
+	// Different body should produce different signature
+	sig4 := GenerateWebhookSignature([]byte(`{"other":"data"}`), secret)
+	assert.NotEqual(t, sig1, sig4)
+}
+
+func TestNewWebhookRequest(t *testing.T) {
+	req := NewWebhookRequest("gw-123", "po-456", "Settled", "Success")
+
+	assert.Equal(t, "gw-123", req.GatewayReferenceID)
+	assert.Equal(t, "po-456", req.PaymentOrderID)
+	assert.Equal(t, "Settled", req.Status)
+	assert.Equal(t, "Success", req.Message)
+	assert.False(t, req.Timestamp.IsZero())
+}

--- a/internal/payment-order/adapters/http/webhook_handler_test.go
+++ b/internal/payment-order/adapters/http/webhook_handler_test.go
@@ -415,3 +415,38 @@ func TestWebhookHandler_HandleWebhook_GatewayIdempotencyKey(t *testing.T) {
 	require.NotNil(t, capturedReq.IdempotencyKey)
 	assert.Equal(t, gatewayIdempotencyKey, capturedReq.IdempotencyKey.Key)
 }
+
+func TestWebhookHandler_HandleWebhook_ExpiredTimestamp(t *testing.T) {
+	secret := []byte("test-secret")
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          secret,
+	})
+	require.NoError(t, err)
+
+	// Create a webhook request with an old timestamp (10 minutes ago)
+	webhookReq := WebhookRequest{
+		GatewayReferenceID: "gw-ref-123",
+		Status:             "Settled",
+		Timestamp:          time.Now().Add(-10 * time.Minute),
+	}
+	body, err := json.Marshal(webhookReq)
+	require.NoError(t, err)
+
+	signature := GenerateWebhookSignature(body, secret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/payment-gateway", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(WebhookSignatureHeader, signature)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	var resp WebhookResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.False(t, resp.Acknowledged)
+	assert.Equal(t, ErrTimestampExpired.Error(), resp.Error)
+}

--- a/internal/payment-order/adapters/http/webhook_handler_test.go
+++ b/internal/payment-order/adapters/http/webhook_handler_test.go
@@ -367,3 +367,50 @@ func TestNewWebhookRequest(t *testing.T) {
 	assert.Equal(t, "Success", req.Message)
 	assert.False(t, req.Timestamp.IsZero())
 }
+
+func TestWebhookHandler_HandleWebhook_GatewayIdempotencyKey(t *testing.T) {
+	secret := []byte("test-secret-key")
+	gatewayIdempotencyKey := "gateway-provided-key-123"
+
+	var capturedReq *pb.UpdatePaymentOrderRequest
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{
+			updateFunc: func(_ context.Context, req *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error) {
+				capturedReq = req
+				return &pb.UpdatePaymentOrderResponse{
+					PaymentOrder: &pb.PaymentOrder{
+						PaymentOrderId: "test-order-id",
+						Status:         pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					},
+				}, nil
+			},
+		},
+		HMACSecret: secret,
+	})
+	require.NoError(t, err)
+
+	webhookReq := WebhookRequest{
+		GatewayReferenceID: "gw-ref-123",
+		Status:             "Settled",
+		Timestamp:          time.Now().UTC(),
+	}
+	body, err := json.Marshal(webhookReq)
+	require.NoError(t, err)
+
+	signature := GenerateWebhookSignature(body, secret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhook/payment-gateway", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(WebhookSignatureHeader, signature)
+	req.Header.Set(IdempotencyKeyHeader, gatewayIdempotencyKey)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// Verify the gateway-provided idempotency key was used
+	require.NotNil(t, capturedReq)
+	require.NotNil(t, capturedReq.IdempotencyKey)
+	assert.Equal(t, gatewayIdempotencyKey, capturedReq.IdempotencyKey.Key)
+}


### PR DESCRIPTION
## Summary

- Implement HTTP adapter to receive payment gateway webhook callbacks
- Translate webhooks to UpdatePaymentOrder gRPC calls via local service wrapper
- Add dual-server architecture (gRPC on :50054, HTTP on :8080)

## Changes Made

**New Files:**
- `internal/payment-order/adapters/http/webhook_handler.go` - Core webhook handler with HMAC-SHA256 signature validation
- `internal/payment-order/adapters/http/server.go` - HTTP server with middleware chain and graceful shutdown
- `cmd/payment-order/main.go` - Entry point with dual gRPC/HTTP server setup

**Key Features:**
- HMAC-SHA256 signature validation for webhook authentication
- Per-IP rate limiting using token bucket algorithm (configurable via env vars)
- Middleware chain: request ID tracking, request logging, rate limiting, panic recovery
- Idempotency key generation from webhook data to handle duplicate deliveries
- Graceful shutdown for both HTTP and gRPC servers

## Technical Details

**Webhook Handler:**
- Validates `X-Webhook-Signature` header using HMAC-SHA256
- Parses JSON payload with `gateway_reference_id`, `payment_order_id`, `status`, `message`, `timestamp`
- Maps gateway status strings (Settled/Rejected/Pending) to proto enum
- Generates deterministic idempotency key from webhook data

**HTTP Server:**
- Configurable port, rate limits, and timeouts via environment variables
- Request ID middleware propagates or generates unique request IDs
- Logging middleware records method, path, status, duration, client IP
- Rate limit middleware uses per-IP token bucket (default: 100 req/s, burst 200)
- Recovery middleware catches panics and returns 500

**Dual Server Architecture:**
- gRPC server on `:50054` (configurable via `GRPC_PORT`)
- HTTP server on `:8080` (configurable via `HTTP_PORT`)
- Local service wrapper avoids network hop for webhook → gRPC calls

## Test plan

- [x] Unit tests for webhook handler (21 tests passing)
- [x] Unit tests for HTTP server, middleware, rate limiter
- [x] golangci-lint passes with 0 issues
- [ ] Integration test with full webhook → UpdatePaymentOrder flow
- [ ] Manual test with actual payment gateway webhook

## Risk Assessment

**Low Risk:**
- Self-contained HTTP adapter layer
- Does not modify existing gRPC service logic
- Comprehensive test coverage

## Dependencies

- Builds on top of #164 (PaymentOrder gRPC Service)
- Requires `WEBHOOK_HMAC_SECRET` environment variable