### PR TITLE
feat: Add Payment-Order microservice deployment infrastructure

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -737,6 +737,40 @@ k8s_resource(
   labels=['microservices'],
 )
 
+# Payment-Order Service - gRPC microservice for payment order management with saga orchestration
+docker_build(
+  'payment-order',
+  context='.',
+  dockerfile='cmd/payment-order/Dockerfile',
+  build_args={
+    'VERSION': 'dev',
+    'COMMIT': local('git rev-parse --short HEAD'),
+    'BUILD_DATE': get_build_date(),
+  },
+)
+
+# Deploy Payment-Order Kubernetes manifests
+k8s_yaml('deployments/k8s/payment-order/secret.yaml')
+k8s_yaml('deployments/k8s/payment-order/configmap.yaml')
+k8s_yaml('deployments/k8s/payment-order/deployment.yaml')
+k8s_yaml('deployments/k8s/payment-order/service.yaml')
+
+# Set resource dependencies for Payment-Order
+k8s_resource(
+  'payment-order',
+  port_forwards=[
+    '50054:50054',  # gRPC API
+  ],
+  resource_deps=[
+    'generate-proto',
+    'cockroachdb',
+    'kafka-cluster',
+    'current-account',  # Depends on current-account for lien operations
+    'migrate-payment-order',
+  ],
+  labels=['microservices'],
+)
+
 # =============================================================================
 # Resource Configuration
 # =============================================================================
@@ -875,6 +909,15 @@ local_resource(
   trigger_mode=TRIGGER_MODE_MANUAL,
 )
 
+local_resource(
+  'migrate-payment-order',
+  cmd='atlas migrate apply --env local --config file://atlas.payment_order.hcl --url "{}"'.format(database_url),
+  resource_deps=['migrate-current-account'],  # Depends on current_account for account FK reference
+  labels=['database'],
+  auto_init=True,
+  trigger_mode=TRIGGER_MODE_MANUAL,
+)
+
 # Kafka cluster health check - runs automatically after kafka-cluster is ready
 local_resource(
   'kafka-health',
@@ -930,6 +973,8 @@ Services:
 Microservices:
   • Current-Account        → localhost:50051 (gRPC)
   • Financial-Accounting   → localhost:50052 (gRPC)
+  • Position-Keeping       → localhost:50053 (gRPC)
+  • Payment-Order          → localhost:50054 (gRPC)
 
 Backing Services:
   • CockroachDB            → localhost:26257
@@ -954,12 +999,15 @@ Tilt UI                    → http://localhost:10350
 Hot reload: Edit Go code and see changes in ~3 seconds
 
 Database Migrations:
-  • Migrations run automatically on startup (3 resources):
+  • Migrations run automatically on startup (4 resources):
     1. current_account (customers, accounts, current_account_audit)
     2. financial_accounting (general_ledger, financial_accounting_audit)
     3. position_keeping (transactions, position_keeping_audit)
+    4. payment_order (payment orders, saga state)
   • Parallel execution: current_account + financial_accounting run together after init-database
-  • Sequential dependency: position_keeping waits for current_account (Account FK)
+  • Sequential dependencies:
+    - position_keeping waits for current_account (Account FK)
+    - payment_order waits for current_account (Account FK)
   • Each service has its own audit schema for isolation
   • Phase 1: Empty audit tables created (current work)
   • Phase 2: GORM hooks for audit logging (future PR, see ADR-0009)
@@ -967,6 +1015,7 @@ Database Migrations:
     - tilt trigger migrate-current-account
     - tilt trigger migrate-financial-accounting
     - tilt trigger migrate-position-keeping
+    - tilt trigger migrate-payment-order
   • Check status:
     - make migrate-status-all (requires DATABASE_URL env var)
 

--- a/atlas.payment_order.hcl
+++ b/atlas.payment_order.hcl
@@ -1,0 +1,77 @@
+// Atlas configuration for Payment Order schema
+// BIAN Service Domain: Payment Order
+// Manages payment orders and saga orchestration for payment processing
+
+data "external_schema" "gorm" {
+  program = [
+    "go",
+    "run",
+    "-mod=mod",
+    "./cmd/atlas-loader",
+    "--schema=payment_order"
+  ]
+}
+
+env "local" {
+  // Schema-specific migration directory
+  migration {
+    dir = "file://migrations/payment_order"
+  }
+
+  // Dev database - include payment_order schema in search path
+  dev = "docker://postgres/16/dev"
+
+  // Source schema from GORM models via external loader
+  src = data.external_schema.gorm.url
+
+  // Schema configuration
+  schemas = ["payment_order"]
+
+  // Lint configuration to catch dangerous changes
+  lint {
+    destructive {
+      error = true
+    }
+    data_depend {
+      error = true
+    }
+    incompatible {
+      error = true
+    }
+  }
+}
+
+env "ci" {
+  migration {
+    dir = "file://migrations/payment_order"
+  }
+
+  dev = "docker://postgres/16/dev"
+
+  src = data.external_schema.gorm.url
+
+  schemas = ["payment_order"]
+
+  lint {
+    destructive {
+      error = true
+    }
+    data_depend {
+      error = true
+    }
+    incompatible {
+      error = true
+    }
+  }
+}
+
+env "production" {
+  // Production environment - apply only, never diff
+  url = getenv("PROD_DATABASE_URL")
+
+  migration {
+    dir = "file://migrations/payment_order"
+  }
+
+  schemas = ["payment_order"]
+}

--- a/cmd/payment-order/Dockerfile
+++ b/cmd/payment-order/Dockerfile
@@ -1,0 +1,59 @@
+# Payment-Order Service - Multi-Stage Dockerfile
+# Optimized for security, size, and performance
+
+# Build stage
+FROM golang:1.25-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache \
+    git \
+    ca-certificates \
+    tzdata
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum* ./
+RUN go mod download && go mod verify
+
+# Copy source code
+COPY . .
+
+# Build static binary with optimizations
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -a -installsuffix cgo \
+    -o payment-order \
+    ./cmd/payment-order
+
+# Verify the binary exists and is executable
+RUN test -x payment-order && echo "Binary built successfully"
+
+# Runtime stage - distroless for minimal attack surface
+FROM gcr.io/distroless/static:nonroot
+
+# Copy CA certificates from builder
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy timezone data from builder
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary from builder
+COPY --from=builder /build/payment-order /payment-order
+
+# Use non-root user (distroless default: 65532:65532)
+USER nonroot:nonroot
+
+# Expose gRPC port
+EXPOSE 50054
+
+# Note: Health checks handled by gRPC health check service
+# HEALTHCHECK not needed in distroless image (lacks grpcurl)
+
+# Run the binary
+ENTRYPOINT ["/payment-order"]

--- a/cmd/payment-order/main.go
+++ b/cmd/payment-order/main.go
@@ -1,0 +1,387 @@
+// Package main is the entry point for the Payment Order service.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	"github.com/meridianhub/meridian/internal/payment-order/adapters/gateway"
+	"github.com/meridianhub/meridian/internal/payment-order/adapters/persistence"
+	"github.com/meridianhub/meridian/internal/payment-order/service"
+	"github.com/meridianhub/meridian/internal/platform/kafka"
+	"github.com/meridianhub/meridian/internal/platform/observability"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// Build information set via ldflags during compilation
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+func main() {
+	// Initialize structured logging
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting payment-order service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	// Run the service
+	if err := run(logger); err != nil {
+		logger.Error("service failed", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	ctx := context.Background()
+
+	// Initialize OpenTelemetry tracer
+	tracerConfig, err := observability.DefaultConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load tracer config: %w", err)
+	}
+
+	// Override service name and version from build info
+	tracerConfig = tracerConfig.
+		WithServiceName("payment-order-service").
+		WithServiceVersion(Version)
+
+	tracer, err := observability.NewTracer(ctx, tracerConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := tracer.Shutdown(shutdownCtx); err != nil {
+			logger.Error("failed to shutdown tracer", "error", err)
+		}
+	}()
+
+	logger.Info("tracer initialized",
+		"service_name", tracerConfig.ServiceName,
+		"environment", tracerConfig.Environment,
+		"otlp_endpoint", tracerConfig.OTLPEndpoint,
+		"sampling_rate", tracerConfig.SamplingRate)
+
+	// Initialize database connection
+	db, err := initDatabase(logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize database: %w", err)
+	}
+	defer closeDatabase(db, logger)
+
+	logger.Info("database connection established")
+
+	// Create repository
+	repo := persistence.NewPaymentOrderRepository(db)
+
+	// Get Kubernetes namespace from environment (defaults to "default")
+	namespace := getEnvOrDefault("K8S_NAMESPACE", "default")
+
+	// Create Current Account client for lien operations
+	currentAccountClient, err := createCurrentAccountClient(namespace, logger, tracer)
+	if err != nil {
+		return fmt.Errorf("failed to create current account client: %w", err)
+	}
+	defer func() {
+		if err := currentAccountClient.Close(); err != nil {
+			logger.Error("failed to close current account client", "error", err)
+		}
+	}()
+
+	logger.Info("current account client initialized",
+		"service", "current-account."+namespace+".svc.cluster.local:50051")
+
+	// Create Kafka producer for event publishing
+	kafkaBrokers := getEnvOrDefault("KAFKA_BROKERS", "kafka:9092")
+	kafkaProducer, err := kafka.NewProtoProducer(kafka.ProducerConfig{
+		BootstrapServers: kafkaBrokers,
+		ClientID:         "payment-order-service",
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create kafka producer: %w", err)
+	}
+	defer kafkaProducer.Close()
+
+	logger.Info("kafka producer initialized", "brokers", kafkaBrokers)
+
+	// Create payment gateway (mock for now)
+	paymentGateway := gateway.NewMockGateway(gateway.MockGatewayConfig{
+		Latency:     100 * time.Millisecond,
+		FailureRate: 0.0, // No simulated failures in production
+	})
+
+	logger.Info("payment gateway initialized (mock)")
+
+	// Create payment order service
+	paymentOrderService, err := service.NewServiceWithConfig(service.Config{
+		Repository:           repo,
+		CurrentAccountClient: currentAccountClient,
+		PaymentGateway:       paymentGateway,
+		KafkaProducer:        kafkaProducer,
+		Logger:               logger,
+		Tracer:               tracer,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create payment order service: %w", err)
+	}
+
+	logger.Info("payment order service initialized")
+
+	// Create gRPC server with observability interceptors
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(
+			tracer.UnaryServerInterceptor(),
+		),
+		grpc.ChainStreamInterceptor(
+			tracer.StreamServerInterceptor(),
+		),
+	)
+
+	// Register services
+	pb.RegisterPaymentOrderServiceServer(grpcServer, paymentOrderService)
+
+	// Register health check service
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
+	healthServer.SetServingStatus("meridian.payment_order.v1.PaymentOrderService", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+
+	// Register reflection service for debugging
+	reflection.Register(grpcServer)
+
+	logger.Info("gRPC services registered")
+
+	// Get port from environment
+	port := getEnvOrDefault("GRPC_PORT", "50054")
+	address := fmt.Sprintf(":%s", port)
+
+	// Create listener
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", address)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", address, err)
+	}
+
+	// Start gRPC server in background
+	serverErrors := make(chan error, 1)
+	go func() {
+		logger.Info("starting gRPC server", "address", address)
+		if err := grpcServer.Serve(listener); err != nil {
+			serverErrors <- err
+		}
+	}()
+
+	// Wait for interrupt signal or server error
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case sig := <-sigChan:
+		logger.Info("received signal", "signal", sig)
+	case err := <-serverErrors:
+		return fmt.Errorf("server error: %w", err)
+	}
+
+	// Graceful shutdown
+	logger.Info("shutting down server...")
+
+	// Mark health as not serving
+	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
+
+	// Create shutdown context with timeout
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Gracefully stop gRPC server
+	stopped := make(chan struct{})
+	go func() {
+		grpcServer.GracefulStop()
+		close(stopped)
+	}()
+
+	// Wait for graceful stop or timeout
+	select {
+	case <-stopped:
+		logger.Info("server stopped gracefully")
+	case <-shutdownCtx.Done():
+		logger.Warn("graceful shutdown timeout, forcing stop")
+		grpcServer.Stop()
+	}
+
+	return nil
+}
+
+// initDatabase initializes the database connection with connection pooling
+func initDatabase(logger *slog.Logger) (*gorm.DB, error) {
+	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable")
+
+	// Open database connection
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		// Disable default transaction for better performance
+		SkipDefaultTransaction: true,
+		// Prepare statements for better performance
+		PrepareStmt: true,
+		Logger:      nil, // Use slog instead of gorm's default logger
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to database: %w", err)
+	}
+
+	// Configure connection pool
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database instance: %w", err)
+	}
+
+	// Connection pool settings
+	maxOpenConns := getEnvAsInt("DB_MAX_OPEN_CONNS", 25)
+	maxIdleConns := getEnvAsInt("DB_MAX_IDLE_CONNS", 5)
+	connMaxLifetime := getEnvAsDuration("DB_CONN_MAX_LIFETIME", 5*time.Minute)
+	connMaxIdleTime := getEnvAsDuration("DB_CONN_MAX_IDLE_TIME", 10*time.Minute)
+
+	sqlDB.SetMaxOpenConns(maxOpenConns)
+	sqlDB.SetMaxIdleConns(maxIdleConns)
+	sqlDB.SetConnMaxLifetime(connMaxLifetime)
+	sqlDB.SetConnMaxIdleTime(connMaxIdleTime)
+
+	logger.Info("database connection pool configured",
+		"max_open_conns", maxOpenConns,
+		"max_idle_conns", maxIdleConns,
+		"conn_max_lifetime", connMaxLifetime,
+		"conn_max_idle_time", connMaxIdleTime)
+
+	// Verify connection
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := sqlDB.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	return db, nil
+}
+
+// closeDatabase closes the database connection gracefully
+func closeDatabase(db *gorm.DB, logger *slog.Logger) {
+	sqlDB, err := db.DB()
+	if err != nil {
+		logger.Error("failed to get database instance for closing", "error", err)
+		return
+	}
+
+	if err := sqlDB.Close(); err != nil {
+		logger.Error("failed to close database connection", "error", err)
+	} else {
+		logger.Info("database connection closed")
+	}
+}
+
+// currentAccountClient implements service.CurrentAccountClient using gRPC
+type currentAccountClient struct {
+	conn   *grpc.ClientConn
+	client currentaccountv1.CurrentAccountServiceClient
+}
+
+// createCurrentAccountClient creates a gRPC client for the CurrentAccount service
+func createCurrentAccountClient(namespace string, _ *slog.Logger, tracer *observability.Tracer) (service.CurrentAccountClient, error) {
+	// Build the service address using DNS-based service discovery
+	address := fmt.Sprintf("dns:///current-account.%s.svc.cluster.local:50051", namespace)
+
+	// Create gRPC connection with tracing interceptors
+	conn, err := grpc.NewClient(
+		address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultServiceConfig(`{"loadBalancingPolicy":"round_robin"}`),
+		grpc.WithUnaryInterceptor(tracer.UnaryClientInterceptor()),
+		grpc.WithStreamInterceptor(tracer.StreamClientInterceptor()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to current-account service: %w", err)
+	}
+
+	return &currentAccountClient{
+		conn:   conn,
+		client: currentaccountv1.NewCurrentAccountServiceClient(conn),
+	}, nil
+}
+
+// InitiateLien creates a fund reservation on an account
+func (c *currentAccountClient) InitiateLien(ctx context.Context, req *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error) {
+	return c.client.InitiateLien(ctx, req)
+}
+
+// TerminateLien releases a reservation without executing
+func (c *currentAccountClient) TerminateLien(ctx context.Context, req *currentaccountv1.TerminateLienRequest) (*currentaccountv1.TerminateLienResponse, error) {
+	return c.client.TerminateLien(ctx, req)
+}
+
+// ExecuteLien converts a reservation to an actual debit
+func (c *currentAccountClient) ExecuteLien(ctx context.Context, req *currentaccountv1.ExecuteLienRequest) (*currentaccountv1.ExecuteLienResponse, error) {
+	return c.client.ExecuteLien(ctx, req)
+}
+
+// Close terminates the client connection
+func (c *currentAccountClient) Close() error {
+	return c.conn.Close()
+}
+
+// getEnvOrDefault returns the environment variable value or default
+func getEnvOrDefault(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+// getEnvAsInt returns the environment variable value as int or default
+func getEnvAsInt(key string, defaultValue int) int {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	var value int
+	if _, err := fmt.Sscanf(valueStr, "%d", &value); err != nil {
+		return defaultValue
+	}
+	return value
+}
+
+// getEnvAsDuration returns the environment variable value as duration or default
+func getEnvAsDuration(key string, defaultValue time.Duration) time.Duration {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	value, err := time.ParseDuration(valueStr)
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}

--- a/deployments/k8s/payment-order/configmap.yaml
+++ b/deployments/k8s/payment-order/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: payment-order-config
+  labels:
+    app: payment-order
+    component: microservice
+data:
+  # Logging configuration
+  LOG_LEVEL: "info"
+  LOG_FORMAT: "json"
+
+  # Database connection pool settings
+  DB_MAX_OPEN_CONNS: "25"
+  DB_MAX_IDLE_CONNS: "5"
+  DB_CONN_MAX_LIFETIME: "5m"
+  DB_CONN_MAX_IDLE_TIME: "10m"
+
+  # gRPC server configuration
+  GRPC_PORT: "50054"
+  GRPC_MAX_CONCURRENT_STREAMS: "100"
+
+  # Kafka configuration
+  KAFKA_BROKERS: "kafka:9092"
+
+  # OpenTelemetry configuration
+  OTEL_SERVICE_NAME: "payment-order-service"
+  OTEL_SAMPLING_RATE: "0.1"

--- a/deployments/k8s/payment-order/deployment.yaml
+++ b/deployments/k8s/payment-order/deployment.yaml
@@ -1,0 +1,111 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-order
+  labels:
+    app: payment-order
+    component: microservice
+    tier: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: payment-order
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: payment-order
+        component: microservice
+        tier: backend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: payment-order
+        image: payment-order:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grpc
+          containerPort: 50054
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: payment-order-config
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: payment-order-db
+              key: DATABASE_URL
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        livenessProbe:
+          grpc:
+            port: 50054
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          grpc:
+            port: 50054
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        startupProbe:
+          grpc:
+            port: 50054
+          initialDelaySeconds: 0
+          periodSeconds: 2
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 30
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      terminationGracePeriodSeconds: 30

--- a/deployments/k8s/payment-order/secret.yaml
+++ b/deployments/k8s/payment-order/secret.yaml
@@ -1,0 +1,16 @@
+# SECURITY NOTE: This secret contains development credentials only.
+# For production deployments:
+# - Use external secret management (e.g., Sealed Secrets, External Secrets Operator)
+# - Rotate credentials regularly
+# - Use RBAC to restrict secret access
+# - Enable encryption at rest for secrets
+apiVersion: v1
+kind: Secret
+metadata:
+  name: payment-order-db
+  labels:
+    app: payment-order
+type: Opaque
+stringData:
+  # Local development connection string - CockroachDB in insecure mode
+  DATABASE_URL: "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable"

--- a/deployments/k8s/payment-order/service.yaml
+++ b/deployments/k8s/payment-order/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: payment-order
+  labels:
+    app: payment-order
+    component: microservice
+spec:
+  type: ClusterIP
+  clusterIP: None  # Headless service for gRPC client-side load balancing
+  ports:
+  - name: grpc
+    port: 50054
+    targetPort: grpc
+    protocol: TCP
+  selector:
+    app: payment-order


### PR DESCRIPTION
## Summary

- Add Kubernetes deployment configuration for the Payment-Order microservice following established patterns
- Create multi-stage Dockerfile with distroless runtime image (port 50054)
- Add K8s manifests: deployment, headless service, configmap, secret
- Configure Atlas migration with payment_order schema and FK dependency on current_account
- Update Tiltfile with docker_build, k8s_yaml, k8s_resource, and migrate-payment-order

## Test plan

- [ ] Verify `tilt up` starts payment-order service without errors
- [ ] Confirm gRPC health check passes on port 50054
- [ ] Test Atlas migration applies cleanly with `tilt trigger migrate-payment-order`
- [ ] Verify service discovery works for current-account client connection