### PR TITLE
feat: Replace offset-based with cursor-based pagination in ListPaymentOrders

### DIFF
--- a/internal/payment-order/adapters/persistence/repository.go
+++ b/internal/payment-order/adapters/persistence/repository.go
@@ -1,9 +1,11 @@
 package persistence
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	cadomain "github.com/meridianhub/meridian/internal/current-account/domain"
@@ -16,14 +18,61 @@ var (
 	ErrPaymentOrderNotFound           = errors.New("payment order not found")
 	ErrPaymentOrderVersionConflict    = errors.New("version conflict: payment order was modified by another transaction")
 	ErrIdempotencyKeyConflict         = errors.New("payment order with this idempotency key already exists")
+	ErrInvalidCursor                  = errors.New("invalid pagination cursor")
 	errUniqueConstraintIdempotencyKey = "payment_orders_idempotency_key_key" // PostgreSQL constraint name
 )
+
+// Cursor represents a pagination cursor for cursor-based pagination.
+// It uses created_at + id as a composite cursor to handle ties (items with same created_at).
+type Cursor struct {
+	CreatedAt time.Time
+	ID        uuid.UUID
+}
+
+// EncodeCursor encodes a cursor to a base64 string for use as an opaque page token.
+// Format: RFC3339Nano timestamp + "|" + UUID
+func EncodeCursor(c Cursor) string {
+	data := c.CreatedAt.Format(time.RFC3339Nano) + "|" + c.ID.String()
+	return base64.URLEncoding.EncodeToString([]byte(data))
+}
+
+// DecodeCursor decodes a base64 page token back to a Cursor.
+// Returns ErrInvalidCursor if the token is malformed.
+func DecodeCursor(token string) (Cursor, error) {
+	if token == "" {
+		return Cursor{}, nil
+	}
+
+	data, err := base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		return Cursor{}, ErrInvalidCursor
+	}
+
+	parts := strings.SplitN(string(data), "|", 2)
+	if len(parts) != 2 {
+		return Cursor{}, ErrInvalidCursor
+	}
+
+	createdAt, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return Cursor{}, ErrInvalidCursor
+	}
+
+	id, err := uuid.Parse(parts[1])
+	if err != nil {
+		return Cursor{}, ErrInvalidCursor
+	}
+
+	return Cursor{CreatedAt: createdAt, ID: id}, nil
+}
 
 // PaginatedResult holds paginated query results
 type PaginatedResult struct {
 	PaymentOrders []*domain.PaymentOrder
 	TotalCount    int64
 	HasMore       bool
+	// NextCursor is the cursor for fetching the next page (empty if no more results)
+	NextCursor string
 }
 
 // Repository defines the contract for payment order persistence.
@@ -34,7 +83,9 @@ type Repository interface {
 	FindByIdempotencyKey(key string) (*domain.PaymentOrder, error)
 	FindByGatewayReferenceID(gatewayRefID string) (*domain.PaymentOrder, error)
 	FindByDebtorAccountID(accountID string) ([]*domain.PaymentOrder, error)
-	FindByDebtorAccountIDPaginated(accountID string, limit, offset int) (*PaginatedResult, error)
+	// FindByDebtorAccountIDWithCursor retrieves payment orders using cursor-based pagination.
+	// Pass an empty cursor for the first page. Results are ordered by created_at DESC, id DESC.
+	FindByDebtorAccountIDWithCursor(accountID string, limit int, cursor Cursor) (*PaginatedResult, error)
 	Update(po *domain.PaymentOrder) error
 }
 
@@ -131,11 +182,18 @@ func (r *PaymentOrderRepository) FindByDebtorAccountID(accountID string) ([]*dom
 	return paymentOrders, nil
 }
 
-// FindByDebtorAccountIDPaginated retrieves payment orders for a debtor account with pagination.
-// Uses database-level LIMIT/OFFSET for efficient queries on large datasets.
-// Results are ordered by created_at DESC (newest first) for consistent pagination.
-func (r *PaymentOrderRepository) FindByDebtorAccountIDPaginated(accountID string, limit, offset int) (*PaginatedResult, error) {
-	// Get total count first (single COUNT query, very efficient with index)
+// FindByDebtorAccountIDWithCursor retrieves payment orders for a debtor account with cursor-based pagination.
+// This provides consistent results even when items are inserted/deleted during pagination.
+// Results are ordered by created_at DESC, id DESC (newest first) for deterministic ordering.
+//
+// The cursor uses (created_at, id) as a composite key to handle ties when multiple records
+// have the same created_at timestamp. The query uses:
+//
+//	WHERE (created_at < cursor_time) OR (created_at = cursor_time AND id < cursor_id)
+//
+// This ensures stable pagination even with concurrent inserts.
+func (r *PaymentOrderRepository) FindByDebtorAccountIDWithCursor(accountID string, limit int, cursor Cursor) (*PaginatedResult, error) {
+	// Get total count (for UI purposes - this is still useful for showing "X of Y" in pagination)
 	var totalCount int64
 	countResult := r.db.Model(&PaymentOrderEntity{}).
 		Where("debtor_account_id = ?", accountID).
@@ -151,19 +209,38 @@ func (r *PaymentOrderRepository) FindByDebtorAccountIDPaginated(accountID string
 			PaymentOrders: []*domain.PaymentOrder{},
 			TotalCount:    0,
 			HasMore:       false,
+			NextCursor:    "",
 		}, nil
 	}
 
-	// Query with pagination
+	// Build query with cursor-based pagination
+	// Request one extra to determine if there are more results
+	query := r.db.Where("debtor_account_id = ?", accountID)
+
+	// Apply cursor condition if provided (not first page)
+	if !cursor.CreatedAt.IsZero() {
+		// Use composite cursor: (created_at < cursor_time) OR (created_at = cursor_time AND id < cursor_id)
+		// This handles ties when multiple records have the same created_at
+		query = query.Where(
+			"(created_at < ?) OR (created_at = ? AND id < ?)",
+			cursor.CreatedAt, cursor.CreatedAt, cursor.ID,
+		)
+	}
+
 	var entities []PaymentOrderEntity
-	result := r.db.Where("debtor_account_id = ?", accountID).
-		Order("created_at DESC").
-		Limit(limit).
-		Offset(offset).
+	result := query.
+		Order("created_at DESC, id DESC").
+		Limit(limit + 1). // Fetch one extra to check for more
 		Find(&entities)
 
 	if result.Error != nil {
 		return nil, result.Error
+	}
+
+	// Determine if there are more results
+	hasMore := len(entities) > limit
+	if hasMore {
+		entities = entities[:limit] // Trim to requested limit
 	}
 
 	paymentOrders := make([]*domain.PaymentOrder, 0, len(entities))
@@ -175,12 +252,21 @@ func (r *PaymentOrderRepository) FindByDebtorAccountIDPaginated(accountID string
 		paymentOrders = append(paymentOrders, po)
 	}
 
-	hasMore := int64(offset+len(entities)) < totalCount
+	// Build next cursor from the last item if there are more results
+	var nextCursor string
+	if hasMore && len(paymentOrders) > 0 {
+		lastPO := paymentOrders[len(paymentOrders)-1]
+		nextCursor = EncodeCursor(Cursor{
+			CreatedAt: lastPO.CreatedAt,
+			ID:        lastPO.ID,
+		})
+	}
 
 	return &PaginatedResult{
 		PaymentOrders: paymentOrders,
 		TotalCount:    totalCount,
 		HasMore:       hasMore,
+		NextCursor:    nextCursor,
 	}, nil
 }
 

--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -912,7 +911,8 @@ func (s *Service) CancelPaymentOrder(ctx context.Context, req *pb.CancelPaymentO
 }
 
 // ListPaymentOrders returns a paginated list of payment orders.
-// Uses database-level pagination for efficient queries on large datasets.
+// Uses cursor-based pagination for consistent results even when items are inserted/deleted.
+// The cursor is an opaque token encoding (created_at, id) for deterministic ordering.
 func (s *Service) ListPaymentOrders(_ context.Context, req *pb.ListPaymentOrdersRequest) (*pb.ListPaymentOrdersResponse, error) {
 	if req.DebtorAccountId == "" {
 		return nil, status.Error(codes.InvalidArgument, "debtor_account_id is required for listing")
@@ -927,18 +927,18 @@ func (s *Service) ListPaymentOrders(_ context.Context, req *pb.ListPaymentOrders
 		}
 	}
 
-	// Parse page token (offset-based)
-	offset := 0
+	// Decode cursor from page token (empty token = first page)
+	var cursor persistence.Cursor
 	if req.Pagination != nil && req.Pagination.PageToken != "" {
-		parsedOffset, parseErr := strconv.Atoi(req.Pagination.PageToken)
-		if parseErr != nil || parsedOffset < 0 {
+		var err error
+		cursor, err = persistence.DecodeCursor(req.Pagination.PageToken)
+		if err != nil {
 			return nil, status.Error(codes.InvalidArgument, "invalid page_token")
 		}
-		offset = parsedOffset
 	}
 
-	// Query with database-level pagination
-	result, err := s.repo.FindByDebtorAccountIDPaginated(req.DebtorAccountId, pageSize, offset)
+	// Query with cursor-based pagination
+	result, err := s.repo.FindByDebtorAccountIDWithCursor(req.DebtorAccountId, pageSize, cursor)
 	if err != nil {
 		s.logger.Error("failed to list payment orders", "error", err)
 		return nil, status.Error(codes.Internal, "failed to list payment orders")
@@ -950,16 +950,10 @@ func (s *Service) ListPaymentOrders(_ context.Context, req *pb.ListPaymentOrders
 		protoOrders = append(protoOrders, toProto(po))
 	}
 
-	// Build next page token if more results exist
-	var nextPageToken string
-	if result.HasMore {
-		nextPageToken = strconv.Itoa(offset + len(result.PaymentOrders))
-	}
-
 	return &pb.ListPaymentOrdersResponse{
 		PaymentOrders: protoOrders,
 		Pagination: &commonpb.PaginationResponse{
-			NextPageToken: nextPageToken,
+			NextPageToken: result.NextCursor,
 			TotalCount:    result.TotalCount,
 		},
 	}, nil

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -159,36 +160,77 @@ func (m *MockRepository) FindByDebtorAccountID(accountID string) ([]*domain.Paym
 	return result, nil
 }
 
-func (m *MockRepository) FindByDebtorAccountIDPaginated(accountID string, limit, offset int) (*persistence.PaginatedResult, error) {
+func (m *MockRepository) FindByDebtorAccountIDWithCursor(accountID string, limit int, cursor persistence.Cursor) (*persistence.PaginatedResult, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	pos := m.debtorAccountIndex[accountID]
 	totalCount := len(pos)
 
-	// Apply pagination bounds
-	if offset >= totalCount {
+	// Sort by created_at DESC, id DESC to match real repository behavior
+	sortedPos := make([]*domain.PaymentOrder, len(pos))
+	copy(sortedPos, pos)
+	// Sort descending by created_at, then by id (use sort.Slice for clarity)
+	sort.Slice(sortedPos, func(i, j int) bool {
+		if !sortedPos[i].CreatedAt.Equal(sortedPos[j].CreatedAt) {
+			return sortedPos[i].CreatedAt.After(sortedPos[j].CreatedAt) // DESC by created_at
+		}
+		return sortedPos[i].ID.String() > sortedPos[j].ID.String() // DESC by id
+	})
+
+	// Filter items that come after the cursor in DESC order
+	// In DESC order, "after" means: created_at < cursor_time OR (created_at == cursor_time AND id < cursor_id)
+	var filtered []*domain.PaymentOrder
+	for _, po := range sortedPos {
+		if cursor.CreatedAt.IsZero() {
+			// No cursor = first page, include all
+			filtered = append(filtered, po)
+		} else if po.CreatedAt.Before(cursor.CreatedAt) {
+			// Item has earlier timestamp - include it
+			filtered = append(filtered, po)
+		} else if po.CreatedAt.Equal(cursor.CreatedAt) && po.ID.String() < cursor.ID.String() {
+			// Same timestamp but smaller ID - include it
+			filtered = append(filtered, po)
+		}
+		// Otherwise skip (item is at or before cursor position)
+	}
+
+	// No results after cursor
+	if len(filtered) == 0 {
 		return &persistence.PaginatedResult{
 			PaymentOrders: []*domain.PaymentOrder{},
 			TotalCount:    int64(totalCount),
 			HasMore:       false,
+			NextCursor:    "",
 		}, nil
 	}
 
-	end := offset + limit
-	if end > totalCount {
-		end = totalCount
+	// Apply limit
+	hasMore := len(filtered) > limit
+	if len(filtered) > limit {
+		filtered = filtered[:limit]
 	}
 
 	// Return copies to simulate database behavior
-	result := make([]*domain.PaymentOrder, 0, end-offset)
-	for i := offset; i < end; i++ {
-		result = append(result, copyPaymentOrder(pos[i]))
+	result := make([]*domain.PaymentOrder, 0, len(filtered))
+	for _, po := range filtered {
+		result = append(result, copyPaymentOrder(po))
+	}
+
+	// Build next cursor from last item if there are more results
+	var nextCursor string
+	if hasMore && len(result) > 0 {
+		lastPO := result[len(result)-1]
+		nextCursor = persistence.EncodeCursor(persistence.Cursor{
+			CreatedAt: lastPO.CreatedAt,
+			ID:        lastPO.ID,
+		})
 	}
 
 	return &persistence.PaginatedResult{
 		PaymentOrders: result,
 		TotalCount:    int64(totalCount),
-		HasMore:       end < totalCount,
+		HasMore:       hasMore,
+		NextCursor:    nextCursor,
 	}, nil
 }
 
@@ -981,7 +1023,7 @@ func TestListPaymentOrders_InvalidPageToken(t *testing.T) {
 	req := &pb.ListPaymentOrdersRequest{
 		DebtorAccountId: "ACC-12345678",
 		Pagination: &commonpb.Pagination{
-			PageToken: "not-a-number",
+			PageToken: "not-valid-base64!@#",
 		},
 	}
 
@@ -994,14 +1036,15 @@ func TestListPaymentOrders_InvalidPageToken(t *testing.T) {
 	assert.Contains(t, st.Message(), "page_token")
 }
 
-func TestListPaymentOrders_NegativePageToken(t *testing.T) {
+func TestListPaymentOrders_MalformedCursor(t *testing.T) {
 	repo := NewMockRepository()
 	svc, _ := NewService(repo)
 
+	// Valid base64 but malformed cursor content (missing UUID)
 	req := &pb.ListPaymentOrdersRequest{
 		DebtorAccountId: "ACC-12345678",
 		Pagination: &commonpb.Pagination{
-			PageToken: "-5",
+			PageToken: "MjAyNC0wMS0wMVQwMDowMDowMFo=", // "2024-01-01T00:00:00Z" - missing UUID part
 		},
 	}
 
@@ -1044,7 +1087,7 @@ func TestListPaymentOrders_PageSizeExceedsMax(t *testing.T) {
 	assert.Len(t, resp.PaymentOrders, 3)
 }
 
-func TestListPaymentOrders_OffsetBeyondResults(t *testing.T) {
+func TestListPaymentOrders_CursorBeyondResults(t *testing.T) {
 	repo := NewMockRepository()
 	svc, _ := NewService(repo)
 
@@ -1061,16 +1104,24 @@ func TestListPaymentOrders_OffsetBeyondResults(t *testing.T) {
 		_ = repo.Create(po)
 	}
 
+	// Create a cursor pointing to a very old timestamp (before all records)
+	oldCursor := persistence.EncodeCursor(persistence.Cursor{
+		CreatedAt: time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC),
+		ID:        uuid.Nil,
+	})
+
 	req := &pb.ListPaymentOrdersRequest{
 		DebtorAccountId: "ACC-12345678",
 		Pagination: &commonpb.Pagination{
-			PageToken: "100", // Offset beyond the 2 results
+			PageToken: oldCursor,
 		},
 	}
 
 	resp, err := svc.ListPaymentOrders(context.Background(), req)
 
 	require.NoError(t, err)
+	// With cursor-based DESC ordering, a cursor from 1970 means "after 1970" which is all records
+	// But the cursor check is "<" so nothing comes after 1970 in DESC order
 	assert.Len(t, resp.PaymentOrders, 0)
 	assert.Empty(t, resp.Pagination.NextPageToken)
 	assert.Equal(t, int64(2), resp.Pagination.TotalCount)


### PR DESCRIPTION
## Summary

- Replaces offset-based pagination with cursor-based pagination in `ListPaymentOrders` RPC
- Uses composite cursor of `(created_at, id)` for deterministic ordering and stable pagination
- Results are ordered by `created_at DESC, id DESC` to ensure consistent results even when items are inserted/deleted during pagination

## Changes Made

**Repository layer (`internal/payment-order/adapters/persistence/repository.go`):**
- Added `Cursor` type with `CreatedAt` and `ID` fields
- Added `EncodeCursor`/`DecodeCursor` helpers for opaque base64 tokens
- Added `ErrInvalidCursor` error for malformed cursor tokens
- Added `NextCursor` field to `PaginatedResult`
- Replaced `FindByDebtorAccountIDPaginated` with `FindByDebtorAccountIDWithCursor`

**Service layer (`internal/payment-order/service/grpc_service.go`):**
- Updated `ListPaymentOrders` to decode cursor from `page_token` and use cursor-based query
- Response now uses `result.NextCursor` directly for `next_page_token`

**Tests (`internal/payment-order/service/grpc_service_test.go`):**
- Updated `MockRepository` to implement cursor-based pagination with proper sorting
- Updated invalid token tests for base64 cursor format
- Renamed `TestListPaymentOrders_OffsetBeyondResults` to `TestListPaymentOrders_CursorBeyondResults`

## Technical Details

The cursor format is: `base64(RFC3339Nano_timestamp|UUID)`

Example: `MjAyNS0xMi0wMlQxNzozMzowMC44NzI1NjJafDI0OTZmZGFlLTNjODktNDNhNC05YjNlLTIwMTE1MDg3OWE1MA==`

The SQL query uses a composite condition for stable cursor-based filtering:
```sql
WHERE (created_at < cursor_time) OR (created_at = cursor_time AND id < cursor_id)
ORDER BY created_at DESC, id DESC
```

## Test Plan

- [x] `TestListPaymentOrders_Success` - Basic list operation works
- [x] `TestListPaymentOrders_Pagination` - Multi-page pagination works correctly
- [x] `TestListPaymentOrders_InvalidPageToken` - Invalid base64 tokens are rejected
- [x] `TestListPaymentOrders_MalformedCursor` - Valid base64 but malformed cursor content is rejected
- [x] `TestListPaymentOrders_PageSizeExceedsMax` - Page size capping works
- [x] `TestListPaymentOrders_CursorBeyondResults` - Cursor pointing past all results returns empty
- [x] All existing payment-order tests pass
- [x] Full test suite passes
- [x] Linter passes

Closes #16