### PR TITLE
fix: Add missing context parameters to ReversePaymentOrder

### DIFF
--- a/internal/payment-order/service/grpc_service.go
+++ b/internal/payment-order/service/grpc_service.go
@@ -1131,7 +1131,7 @@ func (s *Service) ReversePaymentOrder(ctx context.Context, req *pb.ReversePaymen
 	}
 
 	// Retrieve payment order
-	po, err := s.repo.FindByID(poID)
+	po, err := s.repo.FindByID(ctx, poID)
 	if err != nil {
 		if errors.Is(err, persistence.ErrPaymentOrderNotFound) {
 			return nil, status.Errorf(codes.NotFound, "payment order not found: %s", req.PaymentOrderId)
@@ -1159,7 +1159,7 @@ func (s *Service) ReversePaymentOrder(ctx context.Context, req *pb.ReversePaymen
 	}
 
 	// Update in database
-	if err := s.repo.Update(po); err != nil {
+	if err := s.repo.Update(ctx, po); err != nil {
 		return nil, status.Error(codes.Internal, "failed to update payment order")
 	}
 

--- a/internal/payment-order/service/grpc_service_test.go
+++ b/internal/payment-order/service/grpc_service_test.go
@@ -1141,7 +1141,7 @@ func TestReversePaymentOrder_Success(t *testing.T) {
 	_ = po.Reserve("lien-123")
 	_ = po.Execute("gateway-ref-123")
 	_ = po.Complete("ledger-booking-123")
-	_ = repo.Create(po)
+	_ = repo.Create(context.Background(), po)
 
 	req := &pb.ReversePaymentOrderRequest{
 		PaymentOrderId: po.ID.String(),
@@ -1168,7 +1168,7 @@ func TestReversePaymentOrder_AlreadyReversed_Idempotent(t *testing.T) {
 	_ = po.Execute("gateway-ref-123")
 	_ = po.Complete("ledger-booking-123")
 	_ = po.Reverse("Already reversed")
-	_ = repo.Create(po)
+	_ = repo.Create(context.Background(), po)
 
 	req := &pb.ReversePaymentOrderRequest{
 		PaymentOrderId: po.ID.String(),
@@ -1190,7 +1190,7 @@ func TestReversePaymentOrder_NotCompleted(t *testing.T) {
 	// Create a payment order in INITIATED state (cannot be reversed)
 	amount, _ := cadomain.NewMoney("GBP", 10000)
 	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
-	_ = repo.Create(po)
+	_ = repo.Create(context.Background(), po)
 
 	req := &pb.ReversePaymentOrderRequest{
 		PaymentOrderId: po.ID.String(),
@@ -1217,7 +1217,7 @@ func TestReversePaymentOrder_MissingReason(t *testing.T) {
 	_ = po.Reserve("lien-123")
 	_ = po.Execute("gateway-ref-123")
 	_ = po.Complete("ledger-booking-123")
-	_ = repo.Create(po)
+	_ = repo.Create(context.Background(), po)
 
 	req := &pb.ReversePaymentOrderRequest{
 		PaymentOrderId: po.ID.String(),
@@ -1244,7 +1244,7 @@ func TestReversePaymentOrder_MissingReversedBy(t *testing.T) {
 	_ = po.Reserve("lien-123")
 	_ = po.Execute("gateway-ref-123")
 	_ = po.Complete("ledger-booking-123")
-	_ = repo.Create(po)
+	_ = repo.Create(context.Background(), po)
 
 	req := &pb.ReversePaymentOrderRequest{
 		PaymentOrderId: po.ID.String(),


### PR DESCRIPTION
## Summary
- Fix broken develop branch CI by adding missing context parameters to repository calls

## Changes Made
The repository interface was updated to require `context.Context` as the first parameter in PR #173, but the `ReversePaymentOrder` method in PR #175 did not pass context to repository method calls.

**grpc_service.go:**
- `FindByID(poID)` → `FindByID(ctx, poID)`
- `Update(po)` → `Update(ctx, po)`

**grpc_service_test.go:**
- `repo.Create(po)` → `repo.Create(context.Background(), po)` (5 instances)

## Testing
- Local build passes
- golangci-lint passes

## Risk Assessment
Low - trivial fix to pass existing context through to repository methods