### PR TITLE
feat: Add horizon-demo CLI scaffold for resilience demonstration

### DIFF
--- a/cmd/horizon-demo/main.go
+++ b/cmd/horizon-demo/main.go
@@ -1,0 +1,184 @@
+// Package main implements the Horizon Integrity Proof CLI tool.
+// This tool demonstrates Meridian's resilience against phantom transactions
+// by simulating network failures and verifying idempotency guarantees.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// Build information set via ldflags during compilation.
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+// Configuration validation errors.
+var (
+	ErrTargetEmpty        = errors.New("target address cannot be empty")
+	ErrTimeoutNotPositive = errors.New("timeout must be positive")
+	ErrTimeoutTooShort    = errors.New("timeout too short (minimum 5ms)")
+	ErrTimeoutTooLong     = errors.New("timeout too long for sabotage simulation (maximum 10s)")
+	ErrAmountNotPositive  = errors.New("amount must be positive")
+	ErrAmountTooLarge     = errors.New("amount exceeds maximum (1000000 GBP)")
+	ErrOutputEmpty        = errors.New("output path cannot be empty")
+)
+
+// Config holds the CLI configuration parsed from flags.
+type Config struct {
+	// Target is the gRPC target address for services
+	Target string
+	// Timeout is the client-side timeout for the sabotage attempt
+	Timeout time.Duration
+	// Amount is the payment amount in pence
+	Amount int64
+	// Output is the path for the JSON report
+	Output string
+	// Verbose enables debug logging
+	Verbose bool
+	// NoCleanup skips test account cleanup after demo
+	NoCleanup bool
+}
+
+// DefaultConfig returns the default configuration.
+func DefaultConfig() *Config {
+	return &Config{
+		Target:    "localhost:50051",
+		Timeout:   30 * time.Millisecond,
+		Amount:    10000, // GBP 100.00 in pence
+		Output:    "./integrity_report.json",
+		Verbose:   false,
+		NoCleanup: false,
+	}
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	cfg := DefaultConfig()
+
+	rootCmd := &cobra.Command{
+		Use:   "horizon-demo",
+		Short: "Horizon Integrity Proof - Resilience Demonstration",
+		Long: `Horizon Integrity Proof demonstrates Meridian's resilience against
+phantom transactions (the "Post Office Horizon" problem).
+
+This tool simulates a network failure during payment processing and verifies
+that idempotency guarantees prevent double-spending. It proves that even when
+a client loses connection, retrying with the same idempotency key returns the
+original result without creating duplicate transactions.
+
+The demo:
+1. Creates a test account with GBP 1,000.00
+2. Initiates a GBP 100.00 payment with an aggressive timeout (simulated network cut)
+3. Retries the same payment with the same idempotency key
+4. Verifies: balance is GBP 900.00 (not GBP 800.00 from double-spend)
+5. Generates a forensic audit report`,
+		Version: fmt.Sprintf("%s (commit: %s, built: %s)", Version, Commit, BuildDate),
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return runDemo(cfg)
+		},
+	}
+
+	// Define flags
+	flags := rootCmd.Flags()
+	flags.StringVar(&cfg.Target, "target", cfg.Target,
+		"gRPC target address for CurrentAccount and PaymentOrder services")
+	flags.DurationVar(&cfg.Timeout, "timeout", cfg.Timeout,
+		"client-side timeout for sabotage attempt (simulated network failure)")
+	flags.Int64Var(&cfg.Amount, "amount", cfg.Amount,
+		"payment amount in pence (default 10000 = GBP 100.00)")
+	flags.StringVarP(&cfg.Output, "output", "o", cfg.Output,
+		"path for JSON integrity report")
+	flags.BoolVarP(&cfg.Verbose, "verbose", "v", cfg.Verbose,
+		"enable verbose/debug logging")
+	flags.BoolVar(&cfg.NoCleanup, "no-cleanup", cfg.NoCleanup,
+		"skip test account cleanup after demo (useful for debugging)")
+
+	return rootCmd.Execute()
+}
+
+// runDemo executes the Horizon integrity proof demonstration.
+func runDemo(cfg *Config) error {
+	// Initialize logger based on verbosity
+	logLevel := slog.LevelInfo
+	if cfg.Verbose {
+		logLevel = slog.LevelDebug
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting Horizon Integrity Proof",
+		"version", Version,
+		"target", cfg.Target,
+		"timeout", cfg.Timeout,
+		"amount_pence", cfg.Amount,
+		"output", cfg.Output,
+		"verbose", cfg.Verbose,
+		"no_cleanup", cfg.NoCleanup,
+	)
+
+	// Validate configuration
+	if err := validateConfig(cfg); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	// TODO: Implement demo logic in subsequent tasks
+	// Task 2: gRPC client setup
+	// Task 3: Pre-flight setup (create account, deposit)
+	// Task 4: Sabotage attempt with timeout
+	// Task 5: Idempotency retry
+	// Task 6-7: Forensic audit
+	// Task 9-10: Report generation
+
+	logger.Info("demo completed successfully")
+	return nil
+}
+
+// validateConfig validates the CLI configuration.
+func validateConfig(cfg *Config) error {
+	if cfg.Target == "" {
+		return ErrTargetEmpty
+	}
+
+	if cfg.Timeout <= 0 {
+		return fmt.Errorf("%w: got %v", ErrTimeoutNotPositive, cfg.Timeout)
+	}
+
+	if cfg.Timeout < 5*time.Millisecond {
+		return fmt.Errorf("%w: got %v", ErrTimeoutTooShort, cfg.Timeout)
+	}
+
+	if cfg.Timeout > 10*time.Second {
+		return fmt.Errorf("%w: got %v", ErrTimeoutTooLong, cfg.Timeout)
+	}
+
+	if cfg.Amount <= 0 {
+		return fmt.Errorf("%w: got %d", ErrAmountNotPositive, cfg.Amount)
+	}
+
+	if cfg.Amount > 100000000 { // GBP 1,000,000.00 max
+		return fmt.Errorf("%w: got %d pence", ErrAmountTooLarge, cfg.Amount)
+	}
+
+	if cfg.Output == "" {
+		return ErrOutputEmpty
+	}
+
+	return nil
+}

--- a/cmd/horizon-demo/main_test.go
+++ b/cmd/horizon-demo/main_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	assert.Equal(t, "localhost:50051", cfg.Target)
+	assert.Equal(t, 30*time.Millisecond, cfg.Timeout)
+	assert.Equal(t, int64(10000), cfg.Amount)
+	assert.Equal(t, "./integrity_report.json", cfg.Output)
+	assert.False(t, cfg.Verbose)
+	assert.False(t, cfg.NoCleanup)
+}
+
+func TestValidateConfig_Valid(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+	}{
+		{
+			name: "default config",
+			cfg:  DefaultConfig(),
+		},
+		{
+			name: "minimum timeout",
+			cfg: &Config{
+				Target:  "localhost:50051",
+				Timeout: 5 * time.Millisecond,
+				Amount:  100,
+				Output:  "./report.json",
+			},
+		},
+		{
+			name: "maximum timeout",
+			cfg: &Config{
+				Target:  "localhost:50051",
+				Timeout: 10 * time.Second,
+				Amount:  100,
+				Output:  "./report.json",
+			},
+		},
+		{
+			name: "large amount",
+			cfg: &Config{
+				Target:  "localhost:50051",
+				Timeout: 30 * time.Millisecond,
+				Amount:  100000000, // GBP 1,000,000.00
+				Output:  "./report.json",
+			},
+		},
+		{
+			name: "custom target",
+			cfg: &Config{
+				Target:  "payment-order.default.svc.cluster.local:50054",
+				Timeout: 30 * time.Millisecond,
+				Amount:  10000,
+				Output:  "/tmp/integrity_report.json",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(tt.cfg)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateConfig_Invalid(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *Config
+		wantError error
+	}{
+		{
+			name: "empty target",
+			cfg: &Config{
+				Target:  "",
+				Timeout: 30 * time.Millisecond,
+				Amount:  10000,
+				Output:  "./report.json",
+			},
+			wantError: ErrTargetEmpty,
+		},
+		{
+			name: "zero timeout",
+			cfg: &Config{
+				Target:  "localhost:50051",
+				Timeout: 0,
+				Amount:  10000,
+				Output:  "./report.json",
+			},
+			wantError: ErrTimeoutNotPositive,
+		},
+		{
+			name: "negative timeout",
+			cfg: &Config{
+				Target:  "localhost:50051",
+				Timeout: -1 * time.Second,
+				Amount:  10000,
+				Output:  "./report.json",
+			},
+			wantError: ErrTimeoutNotPositive,
+		},
+		{
+			name: "timeout too short",
+			cfg: &Config{
+				Target:  "localhost:50051",
+				Timeout: 1 * time.Millisecond,
+				Amount:  10000,
+				Output:  "./report.json",
+			},
+			wantError: ErrTimeoutTooShort,
+		},
+		{
+			name: "timeout too long",
+			cfg: &Config{
+				Target:  "localhost:50051",
+				Timeout: 11 * time.Second,
+				Amount:  10000,
+				Output:  "./report.json",
+			},
+			wantError: ErrTimeoutTooLong,
+		},
+		{
+			name: "zero amount",
+			cfg: &Config{
+				Target:  "localhost:50051",
+				Timeout: 30 * time.Millisecond,
+				Amount:  0,
+				Output:  "./report.json",
+			},
+			wantError: ErrAmountNotPositive,
+		},
+		{
+			name: "negative amount",
+			cfg: &Config{
+				Target:  "localhost:50051",
+				Timeout: 30 * time.Millisecond,
+				Amount:  -100,
+				Output:  "./report.json",
+			},
+			wantError: ErrAmountNotPositive,
+		},
+		{
+			name: "amount exceeds maximum",
+			cfg: &Config{
+				Target:  "localhost:50051",
+				Timeout: 30 * time.Millisecond,
+				Amount:  100000001, // Over GBP 1,000,000.00
+				Output:  "./report.json",
+			},
+			wantError: ErrAmountTooLarge,
+		},
+		{
+			name: "empty output",
+			cfg: &Config{
+				Target:  "localhost:50051",
+				Timeout: 30 * time.Millisecond,
+				Amount:  10000,
+				Output:  "",
+			},
+			wantError: ErrOutputEmpty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConfig(tt.cfg)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, tt.wantError), "expected error %v, got %v", tt.wantError, err)
+		})
+	}
+}
+
+func TestValidateConfig_BoundaryConditions(t *testing.T) {
+	// Test exact boundary values
+	t.Run("minimum valid timeout boundary", func(t *testing.T) {
+		cfg := &Config{
+			Target:  "localhost:50051",
+			Timeout: 5 * time.Millisecond, // Exact minimum
+			Amount:  1,
+			Output:  "./report.json",
+		}
+		assert.NoError(t, validateConfig(cfg))
+	})
+
+	t.Run("just below minimum timeout", func(t *testing.T) {
+		cfg := &Config{
+			Target:  "localhost:50051",
+			Timeout: 4 * time.Millisecond, // Just below minimum
+			Amount:  1,
+			Output:  "./report.json",
+		}
+		assert.Error(t, validateConfig(cfg))
+	})
+
+	t.Run("maximum valid timeout boundary", func(t *testing.T) {
+		cfg := &Config{
+			Target:  "localhost:50051",
+			Timeout: 10 * time.Second, // Exact maximum
+			Amount:  1,
+			Output:  "./report.json",
+		}
+		assert.NoError(t, validateConfig(cfg))
+	})
+
+	t.Run("just above maximum timeout", func(t *testing.T) {
+		cfg := &Config{
+			Target:  "localhost:50051",
+			Timeout: 10*time.Second + time.Millisecond, // Just above maximum
+			Amount:  1,
+			Output:  "./report.json",
+		}
+		assert.Error(t, validateConfig(cfg))
+	})
+
+	t.Run("minimum valid amount", func(t *testing.T) {
+		cfg := &Config{
+			Target:  "localhost:50051",
+			Timeout: 30 * time.Millisecond,
+			Amount:  1, // Minimum valid (1 pence)
+			Output:  "./report.json",
+		}
+		assert.NoError(t, validateConfig(cfg))
+	})
+
+	t.Run("maximum valid amount", func(t *testing.T) {
+		cfg := &Config{
+			Target:  "localhost:50051",
+			Timeout: 30 * time.Millisecond,
+			Amount:  100000000, // Maximum valid (GBP 1,000,000.00)
+			Output:  "./report.json",
+		}
+		assert.NoError(t, validateConfig(cfg))
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -35,11 +35,14 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/spf13/cobra v1.8.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/mod v0.29.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -41,8 +41,8 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/spf13/cobra v1.10.1 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/mod v0.29.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -772,6 +772,7 @@ github.com/containerd/typeurl/v2 v2.2.0 h1:6NBDbQzr7I5LHgp34xAXYF5DOTQDn05X58lsP
 github.com/containerd/typeurl/v2 v2.2.0/go.mod h1:8XOOxnyatxSWuG8OfsZXVnAF4iZfedjS/8UHSPJnX4g=
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -1251,6 +1252,7 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ruudk/golang-pdf417 v0.0.0-20181029194003-1af4ab5afa58/go.mod h1:6lfFZQK844Gfx8o5WFuvpxWRwnSoipWe/p622j1v06w=
 github.com/ruudk/golang-pdf417 v0.0.0-20201230142125-a7e3863a1245/go.mod h1:pQAZKsJ8yyVxGRWYNEm9oFB8ieLgKFnamEyDmSA0BRk=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=

--- a/go.sum
+++ b/go.sum
@@ -773,6 +773,7 @@ github.com/containerd/typeurl/v2 v2.2.0/go.mod h1:8XOOxnyatxSWuG8OfsZXVnAF4iZfed
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
@@ -1277,8 +1278,13 @@ github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spiffe/go-spiffe/v2 v2.5.0 h1:N2I01KCUkv1FAjZXJMwh95KK1ZIQLYbPfhaxw8WS0hE=
 github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
 github.com/stoewer/go-strcase v1.3.1 h1:iS0MdW+kVTxgMoE1LAZyMiYJFKlOzLooE4MxjirtkAs=


### PR DESCRIPTION
## Summary

Adds `cmd/horizon-demo` CLI tool scaffold for the Horizon Integrity Proof demonstration. This tool will prove Meridian's resilience against phantom transactions (the "Post Office Horizon" problem) by simulating network failures and verifying idempotency guarantees.

## Changes Made

- Created `cmd/horizon-demo/main.go` with Cobra CLI framework
- Implemented CLI flags:
  - `--target`: gRPC target address for services
  - `--timeout`: Client-side timeout for sabotage simulation (5ms-10s)
  - `--amount`: Payment amount in pence (default GBP 100.00)
  - `--output`: JSON report path
  - `--verbose/-v`: Debug logging
  - `--no-cleanup`: Skip test account cleanup
- Added configuration validation with sentinel errors
- Comprehensive unit tests for flag validation and boundary conditions

## Technical Details

This is the foundation (Task 1 of 10) for the Horizon demo tool. The demo will:
1. Create a test account with GBP 1,000.00
2. Initiate a payment with aggressive timeout (simulated network cut)
3. Retry with the same idempotency key
4. Verify exactly one transaction occurred (no double-spend)

## Testing

- Unit tests for config validation pass
- Boundary condition tests for timeout and amount limits
- `go build` compiles successfully
- `--help` displays usage information

## Test plan

- [ ] CI tests pass
- [ ] `go run ./cmd/horizon-demo --help` displays proper usage
- [ ] `go test ./cmd/horizon-demo/...` passes all validation tests