### PR TITLE
feat: Add JSON report generation for Horizon integrity proof

### DIFF
--- a/cmd/horizon-demo/report.go
+++ b/cmd/horizon-demo/report.go
@@ -1,0 +1,147 @@
+// Package main implements the Horizon Integrity Proof CLI tool.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// Report represents the complete integrity proof report.
+// This matches the PRD specification in FR-5.
+type Report struct {
+	// DemoID is a unique identifier for this demo run (e.g., "horizon-proof-{timestamp}")
+	DemoID string `json:"demo_id"`
+	// Timestamp is when the demo was executed in RFC3339 format
+	Timestamp string `json:"timestamp"`
+	// Account holds the test account details and balance verification
+	Account AccountReport `json:"account"`
+	// Attempts records each payment attempt made during the demo
+	Attempts []AttemptReport `json:"attempts"`
+	// Verification contains the forensic audit results
+	Verification VerificationReport `json:"verification"`
+	// Verdict is PASSED if all verification checks pass, otherwise FAILED
+	Verdict string `json:"verdict"`
+}
+
+// AccountReport captures the test account state.
+type AccountReport struct {
+	// ID is the account identifier
+	ID string `json:"id"`
+	// InitialBalanceCents is the balance after initial deposit (e.g., 100000 for GBP 1,000.00)
+	InitialBalanceCents int64 `json:"initial_balance_cents"`
+	// FinalBalanceCents is the balance after all payment attempts
+	FinalBalanceCents int64 `json:"final_balance_cents"`
+	// ExpectedBalanceCents is what the balance should be (initial - payment amount)
+	ExpectedBalanceCents int64 `json:"expected_balance_cents"`
+}
+
+// AttemptReport records details of a single payment attempt.
+type AttemptReport struct {
+	// Attempt is the sequence number (1, 2, etc.)
+	Attempt int `json:"attempt"`
+	// IdempotencyKey is the key used for this attempt
+	IdempotencyKey string `json:"idempotency_key"`
+	// Status is the attempt outcome: "CLIENT_TIMEOUT", "SUCCESS", "ERROR"
+	Status string `json:"status"`
+	// Error contains the error message if the attempt failed (omitted if empty)
+	Error string `json:"error,omitempty"`
+	// DurationMs is how long the attempt took in milliseconds
+	DurationMs int64 `json:"duration_ms"`
+	// PaymentOrderID is the payment order ID on success (omitted if empty)
+	PaymentOrderID string `json:"payment_order_id,omitempty"`
+}
+
+// VerificationReport contains the forensic audit results.
+type VerificationReport struct {
+	// RequestsSent is the total number of payment requests made
+	RequestsSent int `json:"requests_sent"`
+	// TransactionsRecorded is the number of actual transactions created
+	TransactionsRecorded int `json:"transactions_recorded"`
+	// BalanceCorrect is true if final balance matches expected balance
+	BalanceCorrect bool `json:"balance_correct"`
+	// NoDoubleSpend is true if exactly one transaction was recorded
+	NoDoubleSpend bool `json:"no_double_spend"`
+}
+
+// Verdict constants for report outcome.
+const (
+	VerdictPassed = "PASSED"
+	VerdictFailed = "FAILED"
+)
+
+// Attempt status constants.
+const (
+	StatusClientTimeout = "CLIENT_TIMEOUT"
+	StatusSuccess       = "SUCCESS"
+	StatusError         = "ERROR"
+)
+
+// NewReport creates a new Report with a unique demo ID and current timestamp.
+func NewReport() *Report {
+	now := time.Now().UTC()
+	return &Report{
+		DemoID:    fmt.Sprintf("horizon-proof-%d", now.Unix()),
+		Timestamp: now.Format(time.RFC3339),
+		Attempts:  make([]AttemptReport, 0),
+	}
+}
+
+// CalculateVerdict determines the verdict based on verification results.
+// Returns VerdictPassed if:
+// - BalanceCorrect is true
+// - TransactionsRecorded equals 1
+// - NoDoubleSpend is true
+// Otherwise returns VerdictFailed.
+func (r *Report) CalculateVerdict() string {
+	if r.Verification.BalanceCorrect &&
+		r.Verification.TransactionsRecorded == 1 &&
+		r.Verification.NoDoubleSpend {
+		return VerdictPassed
+	}
+	return VerdictFailed
+}
+
+// AddAttempt adds a payment attempt to the report.
+func (r *Report) AddAttempt(attempt AttemptReport) {
+	r.Attempts = append(r.Attempts, attempt)
+	r.Verification.RequestsSent = len(r.Attempts)
+}
+
+// SetAccountInfo sets the account information in the report.
+func (r *Report) SetAccountInfo(id string, initialBalanceCents, expectedBalanceCents int64) {
+	r.Account = AccountReport{
+		ID:                   id,
+		InitialBalanceCents:  initialBalanceCents,
+		ExpectedBalanceCents: expectedBalanceCents,
+	}
+}
+
+// SetFinalBalance sets the final balance and calculates verification results.
+func (r *Report) SetFinalBalance(finalBalanceCents int64, transactionsRecorded int) {
+	r.Account.FinalBalanceCents = finalBalanceCents
+	r.Verification.TransactionsRecorded = transactionsRecorded
+	r.Verification.BalanceCorrect = finalBalanceCents == r.Account.ExpectedBalanceCents
+	r.Verification.NoDoubleSpend = transactionsRecorded == 1
+	r.Verdict = r.CalculateVerdict()
+}
+
+// ToJSON converts the report to a formatted JSON string.
+func (r *Report) ToJSON() ([]byte, error) {
+	return json.MarshalIndent(r, "", "  ")
+}
+
+// WriteToFile writes the report to the specified file path.
+func (r *Report) WriteToFile(path string) error {
+	data, err := r.ToJSON()
+	if err != nil {
+		return fmt.Errorf("marshaling report to JSON: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("writing report to %s: %w", path, err)
+	}
+
+	return nil
+}

--- a/cmd/horizon-demo/report_test.go
+++ b/cmd/horizon-demo/report_test.go
@@ -1,0 +1,489 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewReport(t *testing.T) {
+	before := time.Now().UTC().Truncate(time.Second)
+	report := NewReport()
+	after := time.Now().UTC().Add(time.Second).Truncate(time.Second)
+
+	// Verify demo ID format
+	assert.True(t, strings.HasPrefix(report.DemoID, "horizon-proof-"),
+		"DemoID should start with 'horizon-proof-'")
+
+	// Verify timestamp is RFC3339 and within expected range
+	// Note: RFC3339 has second precision, so we compare truncated times
+	ts, err := time.Parse(time.RFC3339, report.Timestamp)
+	require.NoError(t, err, "Timestamp should be valid RFC3339")
+	assert.True(t, !ts.Before(before) && !ts.After(after),
+		"Timestamp should be within test execution window (before=%v, ts=%v, after=%v)",
+		before, ts, after)
+
+	// Verify attempts slice is initialized
+	assert.NotNil(t, report.Attempts)
+	assert.Empty(t, report.Attempts)
+}
+
+func TestReport_CalculateVerdict_Passed(t *testing.T) {
+	report := &Report{
+		Verification: VerificationReport{
+			RequestsSent:         2,
+			TransactionsRecorded: 1,
+			BalanceCorrect:       true,
+			NoDoubleSpend:        true,
+		},
+	}
+
+	verdict := report.CalculateVerdict()
+	assert.Equal(t, VerdictPassed, verdict)
+}
+
+func TestReport_CalculateVerdict_Failed(t *testing.T) {
+	tests := []struct {
+		name         string
+		verification VerificationReport
+	}{
+		{
+			name: "balance incorrect",
+			verification: VerificationReport{
+				RequestsSent:         2,
+				TransactionsRecorded: 1,
+				BalanceCorrect:       false,
+				NoDoubleSpend:        true,
+			},
+		},
+		{
+			name: "double spend detected",
+			verification: VerificationReport{
+				RequestsSent:         2,
+				TransactionsRecorded: 2, // Double spend!
+				BalanceCorrect:       false,
+				NoDoubleSpend:        false,
+			},
+		},
+		{
+			name: "no transaction recorded",
+			verification: VerificationReport{
+				RequestsSent:         2,
+				TransactionsRecorded: 0, // No transaction executed
+				BalanceCorrect:       false,
+				NoDoubleSpend:        false,
+			},
+		},
+		{
+			name: "all checks fail",
+			verification: VerificationReport{
+				RequestsSent:         2,
+				TransactionsRecorded: 2,
+				BalanceCorrect:       false,
+				NoDoubleSpend:        false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &Report{Verification: tt.verification}
+			verdict := report.CalculateVerdict()
+			assert.Equal(t, VerdictFailed, verdict)
+		})
+	}
+}
+
+func TestReport_AddAttempt(t *testing.T) {
+	report := NewReport()
+
+	// Add first attempt (timeout)
+	attempt1 := AttemptReport{
+		Attempt:        1,
+		IdempotencyKey: "HORIZON-TXN-123",
+		Status:         StatusClientTimeout,
+		Error:          "context deadline exceeded",
+		DurationMs:     45,
+	}
+	report.AddAttempt(attempt1)
+
+	assert.Len(t, report.Attempts, 1)
+	assert.Equal(t, 1, report.Verification.RequestsSent)
+	assert.Equal(t, attempt1, report.Attempts[0])
+
+	// Add second attempt (success)
+	attempt2 := AttemptReport{
+		Attempt:        2,
+		IdempotencyKey: "HORIZON-TXN-123",
+		Status:         StatusSuccess,
+		PaymentOrderID: "po_abc123",
+		DurationMs:     120,
+	}
+	report.AddAttempt(attempt2)
+
+	assert.Len(t, report.Attempts, 2)
+	assert.Equal(t, 2, report.Verification.RequestsSent)
+	assert.Equal(t, attempt2, report.Attempts[1])
+}
+
+func TestReport_SetAccountInfo(t *testing.T) {
+	report := NewReport()
+	report.SetAccountInfo("acc_test123", 100000, 90000)
+
+	assert.Equal(t, "acc_test123", report.Account.ID)
+	assert.Equal(t, int64(100000), report.Account.InitialBalanceCents)
+	assert.Equal(t, int64(90000), report.Account.ExpectedBalanceCents)
+}
+
+func TestReport_SetFinalBalance(t *testing.T) {
+	t.Run("balance correct with single transaction", func(t *testing.T) {
+		report := NewReport()
+		report.SetAccountInfo("acc_test", 100000, 90000)
+		report.SetFinalBalance(90000, 1)
+
+		assert.Equal(t, int64(90000), report.Account.FinalBalanceCents)
+		assert.True(t, report.Verification.BalanceCorrect)
+		assert.True(t, report.Verification.NoDoubleSpend)
+		assert.Equal(t, 1, report.Verification.TransactionsRecorded)
+		assert.Equal(t, VerdictPassed, report.Verdict)
+	})
+
+	t.Run("double spend detected", func(t *testing.T) {
+		report := NewReport()
+		report.SetAccountInfo("acc_test", 100000, 90000)
+		report.SetFinalBalance(80000, 2) // Balance shows double deduction
+
+		assert.Equal(t, int64(80000), report.Account.FinalBalanceCents)
+		assert.False(t, report.Verification.BalanceCorrect)
+		assert.False(t, report.Verification.NoDoubleSpend)
+		assert.Equal(t, 2, report.Verification.TransactionsRecorded)
+		assert.Equal(t, VerdictFailed, report.Verdict)
+	})
+
+	t.Run("no transaction executed", func(t *testing.T) {
+		report := NewReport()
+		report.SetAccountInfo("acc_test", 100000, 90000)
+		report.SetFinalBalance(100000, 0) // Balance unchanged
+
+		assert.Equal(t, int64(100000), report.Account.FinalBalanceCents)
+		assert.False(t, report.Verification.BalanceCorrect)
+		assert.False(t, report.Verification.NoDoubleSpend)
+		assert.Equal(t, 0, report.Verification.TransactionsRecorded)
+		assert.Equal(t, VerdictFailed, report.Verdict)
+	})
+}
+
+func TestReport_ToJSON(t *testing.T) {
+	report := &Report{
+		DemoID:    "horizon-proof-1701607800",
+		Timestamp: "2024-12-03T10:30:00Z",
+		Account: AccountReport{
+			ID:                   "acc_xxx",
+			InitialBalanceCents:  100000,
+			FinalBalanceCents:    90000,
+			ExpectedBalanceCents: 90000,
+		},
+		Attempts: []AttemptReport{
+			{
+				Attempt:        1,
+				IdempotencyKey: "HORIZON-TXN-xxx",
+				Status:         StatusClientTimeout,
+				Error:          "context deadline exceeded",
+				DurationMs:     45,
+			},
+			{
+				Attempt:        2,
+				IdempotencyKey: "HORIZON-TXN-xxx",
+				Status:         StatusSuccess,
+				PaymentOrderID: "po_xxx",
+				DurationMs:     120,
+			},
+		},
+		Verification: VerificationReport{
+			RequestsSent:         2,
+			TransactionsRecorded: 1,
+			BalanceCorrect:       true,
+			NoDoubleSpend:        true,
+		},
+		Verdict: VerdictPassed,
+	}
+
+	data, err := report.ToJSON()
+	require.NoError(t, err)
+
+	// Verify it's valid JSON
+	var parsed Report
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+
+	// Verify content matches
+	assert.Equal(t, report.DemoID, parsed.DemoID)
+	assert.Equal(t, report.Timestamp, parsed.Timestamp)
+	assert.Equal(t, report.Account, parsed.Account)
+	assert.Equal(t, report.Attempts, parsed.Attempts)
+	assert.Equal(t, report.Verification, parsed.Verification)
+	assert.Equal(t, report.Verdict, parsed.Verdict)
+
+	// Verify it's indented (pretty-printed)
+	assert.Contains(t, string(data), "\n  ")
+}
+
+func TestReport_ToJSON_OmitsEmptyFields(t *testing.T) {
+	report := &Report{
+		DemoID:    "test",
+		Timestamp: "2024-12-03T10:30:00Z",
+		Attempts: []AttemptReport{
+			{
+				Attempt:        1,
+				IdempotencyKey: "key",
+				Status:         StatusSuccess,
+				DurationMs:     100,
+				// Error and PaymentOrderID are empty
+			},
+		},
+		Verdict: VerdictPassed,
+	}
+
+	data, err := report.ToJSON()
+	require.NoError(t, err)
+
+	// Verify empty fields are omitted
+	jsonStr := string(data)
+	assert.NotContains(t, jsonStr, `"error"`)
+	assert.NotContains(t, jsonStr, `"payment_order_id"`)
+}
+
+func TestReport_WriteToFile(t *testing.T) {
+	// Create temp directory for test
+	tmpDir, err := os.MkdirTemp("", "horizon-demo-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	report := &Report{
+		DemoID:    "horizon-proof-test",
+		Timestamp: "2024-12-03T10:30:00Z",
+		Account: AccountReport{
+			ID:                   "acc_test",
+			InitialBalanceCents:  100000,
+			FinalBalanceCents:    90000,
+			ExpectedBalanceCents: 90000,
+		},
+		Attempts: []AttemptReport{
+			{
+				Attempt:        1,
+				IdempotencyKey: "HORIZON-TXN-test",
+				Status:         StatusSuccess,
+				PaymentOrderID: "po_test",
+				DurationMs:     100,
+			},
+		},
+		Verification: VerificationReport{
+			RequestsSent:         1,
+			TransactionsRecorded: 1,
+			BalanceCorrect:       true,
+			NoDoubleSpend:        true,
+		},
+		Verdict: VerdictPassed,
+	}
+
+	outputPath := filepath.Join(tmpDir, "integrity_report.json")
+	err = report.WriteToFile(outputPath)
+	require.NoError(t, err)
+
+	// Verify file exists and has correct content
+	data, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+
+	var loaded Report
+	err = json.Unmarshal(data, &loaded)
+	require.NoError(t, err)
+
+	assert.Equal(t, report.DemoID, loaded.DemoID)
+	assert.Equal(t, report.Verdict, loaded.Verdict)
+
+	// Verify file permissions (should be 0600)
+	info, err := os.Stat(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}
+
+func TestReport_WriteToFile_InvalidPath(t *testing.T) {
+	report := NewReport()
+
+	// Try to write to a non-existent directory
+	err := report.WriteToFile("/nonexistent/path/report.json")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "writing report")
+}
+
+func TestReport_FullScenario_Passed(t *testing.T) {
+	// Simulate a complete demo run that passes
+	report := NewReport()
+
+	// Setup account
+	report.SetAccountInfo("acc_horizon_test", 100000, 90000)
+
+	// Attempt 1: Timeout
+	report.AddAttempt(AttemptReport{
+		Attempt:        1,
+		IdempotencyKey: "HORIZON-TXN-12345",
+		Status:         StatusClientTimeout,
+		Error:          "context deadline exceeded",
+		DurationMs:     45,
+	})
+
+	// Attempt 2: Success
+	report.AddAttempt(AttemptReport{
+		Attempt:        2,
+		IdempotencyKey: "HORIZON-TXN-12345",
+		Status:         StatusSuccess,
+		PaymentOrderID: "po_abc123",
+		DurationMs:     120,
+	})
+
+	// Verification
+	report.SetFinalBalance(90000, 1)
+
+	// Assert final state
+	assert.Equal(t, VerdictPassed, report.Verdict)
+	assert.Equal(t, 2, report.Verification.RequestsSent)
+	assert.Equal(t, 1, report.Verification.TransactionsRecorded)
+	assert.True(t, report.Verification.BalanceCorrect)
+	assert.True(t, report.Verification.NoDoubleSpend)
+}
+
+func TestReport_FullScenario_DoubleSpend(t *testing.T) {
+	// Simulate a demo run that detects double-spend
+	report := NewReport()
+
+	report.SetAccountInfo("acc_horizon_test", 100000, 90000)
+
+	report.AddAttempt(AttemptReport{
+		Attempt:        1,
+		IdempotencyKey: "HORIZON-TXN-12345",
+		Status:         StatusSuccess, // First request succeeded
+		PaymentOrderID: "po_abc123",
+		DurationMs:     100,
+	})
+
+	report.AddAttempt(AttemptReport{
+		Attempt:        2,
+		IdempotencyKey: "HORIZON-TXN-12345",
+		Status:         StatusSuccess, // Second request also succeeded (BAD!)
+		PaymentOrderID: "po_def456",   // Different order ID = double spend
+		DurationMs:     100,
+	})
+
+	// Final balance shows double deduction
+	report.SetFinalBalance(80000, 2)
+
+	// Assert failure
+	assert.Equal(t, VerdictFailed, report.Verdict)
+	assert.False(t, report.Verification.BalanceCorrect)
+	assert.False(t, report.Verification.NoDoubleSpend)
+}
+
+func TestReport_FullScenario_NoTransaction(t *testing.T) {
+	// Simulate a demo where no transaction was recorded
+	report := NewReport()
+
+	report.SetAccountInfo("acc_horizon_test", 100000, 90000)
+
+	report.AddAttempt(AttemptReport{
+		Attempt:        1,
+		IdempotencyKey: "HORIZON-TXN-12345",
+		Status:         StatusClientTimeout,
+		Error:          "context deadline exceeded",
+		DurationMs:     45,
+	})
+
+	report.AddAttempt(AttemptReport{
+		Attempt:        2,
+		IdempotencyKey: "HORIZON-TXN-12345",
+		Status:         StatusError,
+		Error:          "service unavailable",
+		DurationMs:     200,
+	})
+
+	// Balance unchanged, no transactions
+	report.SetFinalBalance(100000, 0)
+
+	// Assert failure
+	assert.Equal(t, VerdictFailed, report.Verdict)
+	assert.False(t, report.Verification.BalanceCorrect)
+	assert.False(t, report.Verification.NoDoubleSpend)
+	assert.Equal(t, 0, report.Verification.TransactionsRecorded)
+}
+
+func TestReport_JSONSchema_MatchesPRD(t *testing.T) {
+	// This test verifies the JSON output matches the PRD specification exactly
+	report := &Report{
+		DemoID:    "horizon-proof-1701607800",
+		Timestamp: "2024-12-03T10:30:00Z",
+		Account: AccountReport{
+			ID:                   "acc_xxx",
+			InitialBalanceCents:  100000,
+			FinalBalanceCents:    90000,
+			ExpectedBalanceCents: 90000,
+		},
+		Attempts: []AttemptReport{
+			{
+				Attempt:        1,
+				IdempotencyKey: "HORIZON-TXN-xxx",
+				Status:         "CLIENT_TIMEOUT",
+				Error:          "context deadline exceeded",
+				DurationMs:     45,
+			},
+			{
+				Attempt:        2,
+				IdempotencyKey: "HORIZON-TXN-xxx",
+				Status:         "SUCCESS",
+				PaymentOrderID: "po_xxx",
+				DurationMs:     120,
+			},
+		},
+		Verification: VerificationReport{
+			RequestsSent:         2,
+			TransactionsRecorded: 1,
+			BalanceCorrect:       true,
+			NoDoubleSpend:        true,
+		},
+		Verdict: "PASSED",
+	}
+
+	data, err := report.ToJSON()
+	require.NoError(t, err)
+
+	// Parse back to verify structure
+	var parsed map[string]any
+	err = json.Unmarshal(data, &parsed)
+	require.NoError(t, err)
+
+	// Verify top-level fields exist with correct types
+	assert.IsType(t, "", parsed["demo_id"])
+	assert.IsType(t, "", parsed["timestamp"])
+	assert.IsType(t, map[string]any{}, parsed["account"])
+	assert.IsType(t, []any{}, parsed["attempts"])
+	assert.IsType(t, map[string]any{}, parsed["verification"])
+	assert.IsType(t, "", parsed["verdict"])
+
+	// Verify account fields
+	account := parsed["account"].(map[string]any)
+	assert.Contains(t, account, "id")
+	assert.Contains(t, account, "initial_balance_cents")
+	assert.Contains(t, account, "final_balance_cents")
+	assert.Contains(t, account, "expected_balance_cents")
+
+	// Verify verification fields
+	verification := parsed["verification"].(map[string]any)
+	assert.Contains(t, verification, "requests_sent")
+	assert.Contains(t, verification, "transactions_recorded")
+	assert.Contains(t, verification, "balance_correct")
+	assert.Contains(t, verification, "no_double_spend")
+}


### PR DESCRIPTION
## Summary
- Implements structured JSON report generation matching PRD specification (FR-5)
- Report captures demo execution details: account state, payment attempts, and verification results
- Automatic verdict calculation based on verification checks (balance correct, no double-spend, single transaction)

## Changes Made
- Add `report.go` with Report structs matching PRD schema:
  - `Report`: Top-level with demo_id, timestamp, account, attempts, verification, verdict
  - `AccountReport`: id, initial/final/expected balance in cents
  - `AttemptReport`: attempt number, idempotency_key, status, error, duration, payment_order_id
  - `VerificationReport`: requests_sent, transactions_recorded, balance_correct, no_double_spend
- Add helper methods: `NewReport()`, `AddAttempt()`, `SetAccountInfo()`, `SetFinalBalance()`, `CalculateVerdict()`
- Add `ToJSON()` using MarshalIndent for readable output
- Add `WriteToFile()` with secure permissions (0600)

## Test Plan
- [x] Unit tests for all report methods
- [x] Test scenarios: passing demo, double-spend detection, no-transaction failure
- [x] Test JSON schema matches PRD specification
- [x] Test file writing with correct permissions
- [x] All tests pass locally
- [x] Lint checks pass

## Task Master
Tag: 99-horizon-proof, Task 9