### PR TITLE
feat: Add gRPC client setup for horizon-demo

### DIFF
--- a/cmd/horizon-demo/clients.go
+++ b/cmd/horizon-demo/clients.go
@@ -60,6 +60,10 @@ type ClientsConfig struct {
 // NewClients creates gRPC clients for CurrentAccountService and PaymentOrderService.
 // It establishes connections with insecure credentials suitable for local/Tilt environments.
 func NewClients(cfg *ClientsConfig) (*Clients, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("%w: ClientsConfig is nil", ErrTargetRequired)
+	}
+
 	if cfg.CurrentAccountTarget == "" {
 		return nil, fmt.Errorf("%w: CurrentAccountTarget", ErrTargetRequired)
 	}
@@ -158,20 +162,46 @@ func (c *Clients) CheckHealth(_ context.Context) error {
 // WaitForReady blocks until both services are ready or the context is cancelled.
 // This is useful for startup health checks before beginning the demo.
 func (c *Clients) WaitForReady(ctx context.Context) error {
-	c.logger.Debug("waiting for CurrentAccountService to be ready")
-	if !c.currentAccountConn.WaitForStateChange(ctx, connectivity.Idle) {
-		// If we're still idle, try to connect
-		c.currentAccountConn.Connect()
+	// Wait for CurrentAccountService
+	if err := c.waitForConnReady(ctx, c.currentAccountConn, "CurrentAccountService"); err != nil {
+		return err
 	}
 
-	c.logger.Debug("waiting for PaymentOrderService to be ready")
-	if !c.paymentOrderConn.WaitForStateChange(ctx, connectivity.Idle) {
-		// If we're still idle, try to connect
-		c.paymentOrderConn.Connect()
+	// Wait for PaymentOrderService
+	if err := c.waitForConnReady(ctx, c.paymentOrderConn, "PaymentOrderService"); err != nil {
+		return err
 	}
 
-	// Verify both are now ready
-	return c.CheckHealth(ctx)
+	return nil
+}
+
+// waitForConnReady waits for a single connection to reach Ready state.
+func (c *Clients) waitForConnReady(ctx context.Context, conn *grpc.ClientConn, serviceName string) error {
+	c.logger.Debug("waiting for service to be ready", "service", serviceName)
+
+	// Trigger connection attempt (grpc.NewClient starts in Idle without I/O)
+	conn.Connect()
+
+	for {
+		state := conn.GetState()
+		c.logger.Debug("connection state", "service", serviceName, "state", state.String())
+
+		if state == connectivity.Ready {
+			return nil
+		}
+
+		if state == connectivity.Shutdown {
+			return fmt.Errorf("%w: %s is in state %s",
+				ErrServiceUnreachable, serviceName, state.String())
+		}
+
+		// TransientFailure is temporary; keep waiting unless context expires
+		if !conn.WaitForStateChange(ctx, state) {
+			// Context was cancelled or timed out
+			return fmt.Errorf("%w: context expired while waiting for %s: %w",
+				ErrHealthCheckFailed, serviceName, ctx.Err())
+		}
+	}
 }
 
 // ContextWithCorrelationID creates a new context with the correlation ID set in gRPC metadata.

--- a/cmd/horizon-demo/clients.go
+++ b/cmd/horizon-demo/clients.go
@@ -1,0 +1,229 @@
+// Package main provides gRPC client setup for the Horizon Integrity Proof demo.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	paymentorderv1 "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+)
+
+// Default ports for services in local/Tilt environment.
+const (
+	CurrentAccountPort = 50051
+	PaymentOrderPort   = 50054
+)
+
+// Client errors.
+var (
+	ErrTargetRequired     = errors.New("target address is required")
+	ErrConnectionFailed   = errors.New("failed to establish gRPC connection")
+	ErrHealthCheckFailed  = errors.New("service health check failed")
+	ErrServiceUnreachable = errors.New("service is unreachable")
+)
+
+// Clients holds the gRPC client connections for the demo.
+type Clients struct {
+	// CurrentAccount is the client for CurrentAccountService
+	CurrentAccount currentaccountv1.CurrentAccountServiceClient
+	// PaymentOrder is the client for PaymentOrderService
+	PaymentOrder paymentorderv1.PaymentOrderServiceClient
+
+	// conns holds the underlying connections for cleanup
+	currentAccountConn *grpc.ClientConn
+	paymentOrderConn   *grpc.ClientConn
+
+	logger *slog.Logger
+}
+
+// ClientsConfig holds configuration for creating gRPC clients.
+type ClientsConfig struct {
+	// CurrentAccountTarget is the gRPC target for CurrentAccountService
+	// Format: "host:port" (e.g., "localhost:50051")
+	CurrentAccountTarget string
+
+	// PaymentOrderTarget is the gRPC target for PaymentOrderService
+	// Format: "host:port" (e.g., "localhost:50054")
+	PaymentOrderTarget string
+
+	// Logger is the structured logger for client operations
+	Logger *slog.Logger
+}
+
+// NewClients creates gRPC clients for CurrentAccountService and PaymentOrderService.
+// It establishes connections with insecure credentials suitable for local/Tilt environments.
+func NewClients(cfg *ClientsConfig) (*Clients, error) {
+	if cfg.CurrentAccountTarget == "" {
+		return nil, fmt.Errorf("%w: CurrentAccountTarget", ErrTargetRequired)
+	}
+	if cfg.PaymentOrderTarget == "" {
+		return nil, fmt.Errorf("%w: PaymentOrderTarget", ErrTargetRequired)
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// Create CurrentAccountService connection
+	logger.Debug("connecting to CurrentAccountService", "target", cfg.CurrentAccountTarget)
+	currentAccountConn, err := grpc.NewClient(
+		cfg.CurrentAccountTarget,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("%w to CurrentAccountService at %s: %w",
+			ErrConnectionFailed, cfg.CurrentAccountTarget, err)
+	}
+
+	// Create PaymentOrderService connection
+	logger.Debug("connecting to PaymentOrderService", "target", cfg.PaymentOrderTarget)
+	paymentOrderConn, err := grpc.NewClient(
+		cfg.PaymentOrderTarget,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		// Clean up the first connection on failure
+		if closeErr := currentAccountConn.Close(); closeErr != nil {
+			logger.Warn("failed to close CurrentAccountService connection", "error", closeErr)
+		}
+		return nil, fmt.Errorf("%w to PaymentOrderService at %s: %w",
+			ErrConnectionFailed, cfg.PaymentOrderTarget, err)
+	}
+
+	return &Clients{
+		CurrentAccount:     currentaccountv1.NewCurrentAccountServiceClient(currentAccountConn),
+		PaymentOrder:       paymentorderv1.NewPaymentOrderServiceClient(paymentOrderConn),
+		currentAccountConn: currentAccountConn,
+		paymentOrderConn:   paymentOrderConn,
+		logger:             logger,
+	}, nil
+}
+
+// Close terminates all gRPC connections.
+// It attempts to close all connections and returns the first error encountered.
+func (c *Clients) Close() error {
+	var firstErr error
+
+	if c.currentAccountConn != nil {
+		if err := c.currentAccountConn.Close(); err != nil {
+			c.logger.Warn("failed to close CurrentAccountService connection", "error", err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("failed to close CurrentAccountService connection: %w", err)
+			}
+		}
+	}
+
+	if c.paymentOrderConn != nil {
+		if err := c.paymentOrderConn.Close(); err != nil {
+			c.logger.Warn("failed to close PaymentOrderService connection", "error", err)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("failed to close PaymentOrderService connection: %w", err)
+			}
+		}
+	}
+
+	return firstErr
+}
+
+// CheckHealth verifies that both services are reachable.
+// It returns an error if either service is not in a connectable state.
+func (c *Clients) CheckHealth(_ context.Context) error {
+	// Check CurrentAccountService connection state
+	caState := c.currentAccountConn.GetState()
+	c.logger.Debug("CurrentAccountService connection state", "state", caState.String())
+	if caState == connectivity.Shutdown || caState == connectivity.TransientFailure {
+		return fmt.Errorf("%w: CurrentAccountService is in state %s",
+			ErrServiceUnreachable, caState.String())
+	}
+
+	// Check PaymentOrderService connection state
+	poState := c.paymentOrderConn.GetState()
+	c.logger.Debug("PaymentOrderService connection state", "state", poState.String())
+	if poState == connectivity.Shutdown || poState == connectivity.TransientFailure {
+		return fmt.Errorf("%w: PaymentOrderService is in state %s",
+			ErrServiceUnreachable, poState.String())
+	}
+
+	return nil
+}
+
+// WaitForReady blocks until both services are ready or the context is cancelled.
+// This is useful for startup health checks before beginning the demo.
+func (c *Clients) WaitForReady(ctx context.Context) error {
+	c.logger.Debug("waiting for CurrentAccountService to be ready")
+	if !c.currentAccountConn.WaitForStateChange(ctx, connectivity.Idle) {
+		// If we're still idle, try to connect
+		c.currentAccountConn.Connect()
+	}
+
+	c.logger.Debug("waiting for PaymentOrderService to be ready")
+	if !c.paymentOrderConn.WaitForStateChange(ctx, connectivity.Idle) {
+		// If we're still idle, try to connect
+		c.paymentOrderConn.Connect()
+	}
+
+	// Verify both are now ready
+	return c.CheckHealth(ctx)
+}
+
+// ContextWithCorrelationID creates a new context with the correlation ID set in gRPC metadata.
+// This ensures distributed tracing works across service calls.
+func ContextWithCorrelationID(ctx context.Context, correlationID string) context.Context {
+	if correlationID == "" {
+		return ctx
+	}
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	} else {
+		md = md.Copy()
+	}
+
+	md.Set("x-correlation-id", correlationID)
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+// ExtractCorrelationID attempts to extract a correlation ID from the context.
+// It checks multiple common keys used for correlation/request tracking.
+func ExtractCorrelationID(ctx context.Context) string {
+	keys := []string{"correlation-id", "x-correlation-id", "x-request-id", "request-id"}
+
+	// Check context values first
+	for _, key := range keys {
+		if val := ctx.Value(key); val != nil {
+			if id, ok := val.(string); ok && id != "" {
+				return id
+			}
+		}
+	}
+
+	// Check incoming metadata as fallback
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		for _, key := range keys {
+			if vals := md.Get(key); len(vals) > 0 && vals[0] != "" {
+				return vals[0]
+			}
+		}
+	}
+
+	return ""
+}
+
+// CurrentAccountState returns the current connectivity state of CurrentAccountService.
+func (c *Clients) CurrentAccountState() connectivity.State {
+	return c.currentAccountConn.GetState()
+}
+
+// PaymentOrderState returns the current connectivity state of PaymentOrderService.
+func (c *Clients) PaymentOrderState() connectivity.State {
+	return c.paymentOrderConn.GetState()
+}

--- a/cmd/horizon-demo/clients_test.go
+++ b/cmd/horizon-demo/clients_test.go
@@ -63,6 +63,11 @@ func TestNewClients_ConfigValidation(t *testing.T) {
 		wantError error
 	}{
 		{
+			name:      "nil config",
+			cfg:       nil,
+			wantError: ErrTargetRequired,
+		},
+		{
 			name: "missing CurrentAccountTarget",
 			cfg: &ClientsConfig{
 				CurrentAccountTarget: "",

--- a/cmd/horizon-demo/clients_test.go
+++ b/cmd/horizon-demo/clients_test.go
@@ -1,0 +1,421 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"os"
+	"testing"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	paymentorderv1 "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/metadata"
+)
+
+// mockCurrentAccountServer implements the CurrentAccountService for testing.
+type mockCurrentAccountServer struct {
+	currentaccountv1.UnimplementedCurrentAccountServiceServer
+}
+
+func (m *mockCurrentAccountServer) InitiateCurrentAccount(
+	_ context.Context,
+	_ *currentaccountv1.InitiateCurrentAccountRequest,
+) (*currentaccountv1.InitiateCurrentAccountResponse, error) {
+	return &currentaccountv1.InitiateCurrentAccountResponse{
+		AccountId: "test-account-id",
+	}, nil
+}
+
+// mockPaymentOrderServer implements the PaymentOrderService for testing.
+type mockPaymentOrderServer struct {
+	paymentorderv1.UnimplementedPaymentOrderServiceServer
+}
+
+func (m *mockPaymentOrderServer) RetrievePaymentOrder(
+	_ context.Context,
+	req *paymentorderv1.RetrievePaymentOrderRequest,
+) (*paymentorderv1.RetrievePaymentOrderResponse, error) {
+	return &paymentorderv1.RetrievePaymentOrderResponse{
+		PaymentOrder: &paymentorderv1.PaymentOrder{
+			PaymentOrderId: req.PaymentOrderId,
+		},
+	}, nil
+}
+
+// testListener creates a listener for testing, using context-aware net.ListenConfig.
+func testListener(ctx context.Context, t *testing.T) net.Listener {
+	t.Helper()
+	lc := net.ListenConfig{}
+	listener, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	return listener
+}
+
+func TestNewClients_ConfigValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *ClientsConfig
+		wantError error
+	}{
+		{
+			name: "missing CurrentAccountTarget",
+			cfg: &ClientsConfig{
+				CurrentAccountTarget: "",
+				PaymentOrderTarget:   "localhost:50054",
+			},
+			wantError: ErrTargetRequired,
+		},
+		{
+			name: "missing PaymentOrderTarget",
+			cfg: &ClientsConfig{
+				CurrentAccountTarget: "localhost:50051",
+				PaymentOrderTarget:   "",
+			},
+			wantError: ErrTargetRequired,
+		},
+		{
+			name: "both targets missing",
+			cfg: &ClientsConfig{
+				CurrentAccountTarget: "",
+				PaymentOrderTarget:   "",
+			},
+			wantError: ErrTargetRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clients, err := NewClients(tt.cfg)
+			assert.Nil(t, clients)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, tt.wantError), "expected error %v, got %v", tt.wantError, err)
+		})
+	}
+}
+
+func TestNewClients_ValidConfig(t *testing.T) {
+	ctx := context.Background()
+
+	// Start mock servers
+	caListener := testListener(ctx, t)
+	t.Cleanup(func() { _ = caListener.Close() })
+
+	poListener := testListener(ctx, t)
+	t.Cleanup(func() { _ = poListener.Close() })
+
+	// Start CurrentAccountService mock
+	caServer := grpc.NewServer()
+	currentaccountv1.RegisterCurrentAccountServiceServer(caServer, &mockCurrentAccountServer{})
+	go func() {
+		_ = caServer.Serve(caListener)
+	}()
+	defer caServer.Stop()
+
+	// Start PaymentOrderService mock
+	poServer := grpc.NewServer()
+	paymentorderv1.RegisterPaymentOrderServiceServer(poServer, &mockPaymentOrderServer{})
+	go func() {
+		_ = poServer.Serve(poListener)
+	}()
+	defer poServer.Stop()
+
+	// Create clients
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	cfg := &ClientsConfig{
+		CurrentAccountTarget: caListener.Addr().String(),
+		PaymentOrderTarget:   poListener.Addr().String(),
+		Logger:               logger,
+	}
+
+	clients, err := NewClients(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, clients)
+	defer func() {
+		_ = clients.Close()
+	}()
+
+	// Verify clients are created
+	assert.NotNil(t, clients.CurrentAccount)
+	assert.NotNil(t, clients.PaymentOrder)
+}
+
+func TestClients_Close(t *testing.T) {
+	ctx := context.Background()
+
+	// Start mock servers
+	caListener := testListener(ctx, t)
+	t.Cleanup(func() { _ = caListener.Close() })
+
+	poListener := testListener(ctx, t)
+	t.Cleanup(func() { _ = poListener.Close() })
+
+	caServer := grpc.NewServer()
+	currentaccountv1.RegisterCurrentAccountServiceServer(caServer, &mockCurrentAccountServer{})
+	go func() {
+		_ = caServer.Serve(caListener)
+	}()
+	defer caServer.Stop()
+
+	poServer := grpc.NewServer()
+	paymentorderv1.RegisterPaymentOrderServiceServer(poServer, &mockPaymentOrderServer{})
+	go func() {
+		_ = poServer.Serve(poListener)
+	}()
+	defer poServer.Stop()
+
+	cfg := &ClientsConfig{
+		CurrentAccountTarget: caListener.Addr().String(),
+		PaymentOrderTarget:   poListener.Addr().String(),
+	}
+
+	clients, err := NewClients(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, clients)
+
+	// Close should succeed
+	err = clients.Close()
+	assert.NoError(t, err)
+
+	// Connection state should be shutdown after close
+	assert.Equal(t, connectivity.Shutdown, clients.CurrentAccountState())
+	assert.Equal(t, connectivity.Shutdown, clients.PaymentOrderState())
+}
+
+func TestClients_CheckHealth(t *testing.T) {
+	ctx := context.Background()
+
+	// Start mock servers
+	caListener := testListener(ctx, t)
+	t.Cleanup(func() { _ = caListener.Close() })
+
+	poListener := testListener(ctx, t)
+	t.Cleanup(func() { _ = poListener.Close() })
+
+	caServer := grpc.NewServer()
+	currentaccountv1.RegisterCurrentAccountServiceServer(caServer, &mockCurrentAccountServer{})
+	go func() {
+		_ = caServer.Serve(caListener)
+	}()
+	defer caServer.Stop()
+
+	poServer := grpc.NewServer()
+	paymentorderv1.RegisterPaymentOrderServiceServer(poServer, &mockPaymentOrderServer{})
+	go func() {
+		_ = poServer.Serve(poListener)
+	}()
+	defer poServer.Stop()
+
+	cfg := &ClientsConfig{
+		CurrentAccountTarget: caListener.Addr().String(),
+		PaymentOrderTarget:   poListener.Addr().String(),
+	}
+
+	clients, err := NewClients(cfg)
+	require.NoError(t, err)
+	defer func() {
+		_ = clients.Close()
+	}()
+
+	// Health check should pass initially (connections are in IDLE state)
+	err = clients.CheckHealth(ctx)
+	assert.NoError(t, err)
+}
+
+func TestClients_CheckHealth_AfterClose(t *testing.T) {
+	ctx := context.Background()
+
+	// Start mock servers
+	caListener := testListener(ctx, t)
+	t.Cleanup(func() { _ = caListener.Close() })
+
+	poListener := testListener(ctx, t)
+	t.Cleanup(func() { _ = poListener.Close() })
+
+	caServer := grpc.NewServer()
+	currentaccountv1.RegisterCurrentAccountServiceServer(caServer, &mockCurrentAccountServer{})
+	go func() {
+		_ = caServer.Serve(caListener)
+	}()
+	defer caServer.Stop()
+
+	poServer := grpc.NewServer()
+	paymentorderv1.RegisterPaymentOrderServiceServer(poServer, &mockPaymentOrderServer{})
+	go func() {
+		_ = poServer.Serve(poListener)
+	}()
+	defer poServer.Stop()
+
+	cfg := &ClientsConfig{
+		CurrentAccountTarget: caListener.Addr().String(),
+		PaymentOrderTarget:   poListener.Addr().String(),
+	}
+
+	clients, err := NewClients(cfg)
+	require.NoError(t, err)
+
+	// Close connections
+	err = clients.Close()
+	require.NoError(t, err)
+
+	// Health check should fail after close
+	err = clients.CheckHealth(ctx)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrServiceUnreachable))
+}
+
+func TestContextWithCorrelationID(t *testing.T) {
+	tests := []struct {
+		name          string
+		correlationID string
+		wantInMeta    bool
+	}{
+		{
+			name:          "with correlation ID",
+			correlationID: "test-correlation-123",
+			wantInMeta:    true,
+		},
+		{
+			name:          "empty correlation ID",
+			correlationID: "",
+			wantInMeta:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			newCtx := ContextWithCorrelationID(ctx, tt.correlationID)
+
+			md, ok := metadata.FromOutgoingContext(newCtx)
+			if tt.wantInMeta {
+				require.True(t, ok, "expected metadata in context")
+				vals := md.Get("x-correlation-id")
+				require.Len(t, vals, 1)
+				assert.Equal(t, tt.correlationID, vals[0])
+			} else {
+				// Either no metadata or no correlation ID header
+				if ok {
+					vals := md.Get("x-correlation-id")
+					assert.Empty(t, vals)
+				}
+			}
+		})
+	}
+}
+
+func TestContextWithCorrelationID_PreservesExistingMetadata(t *testing.T) {
+	ctx := context.Background()
+
+	// Add existing metadata
+	existingMD := metadata.Pairs("x-request-id", "existing-request")
+	ctx = metadata.NewOutgoingContext(ctx, existingMD)
+
+	// Add correlation ID
+	newCtx := ContextWithCorrelationID(ctx, "new-correlation-id")
+
+	// Verify both headers are present
+	md, ok := metadata.FromOutgoingContext(newCtx)
+	require.True(t, ok)
+
+	requestIDs := md.Get("x-request-id")
+	require.Len(t, requestIDs, 1)
+	assert.Equal(t, "existing-request", requestIDs[0])
+
+	correlationIDs := md.Get("x-correlation-id")
+	require.Len(t, correlationIDs, 1)
+	assert.Equal(t, "new-correlation-id", correlationIDs[0])
+}
+
+func TestExtractCorrelationID(t *testing.T) {
+	tests := []struct {
+		name     string
+		setupCtx func() context.Context
+		wantID   string
+	}{
+		{
+			name: "from incoming metadata",
+			setupCtx: func() context.Context {
+				md := metadata.Pairs("x-correlation-id", "meta-correlation-789")
+				return metadata.NewIncomingContext(context.Background(), md)
+			},
+			wantID: "meta-correlation-789",
+		},
+		{
+			name: "from x-request-id in metadata",
+			setupCtx: func() context.Context {
+				md := metadata.Pairs("x-request-id", "meta-request-abc")
+				return metadata.NewIncomingContext(context.Background(), md)
+			},
+			wantID: "meta-request-abc",
+		},
+		{
+			name: "empty when no correlation ID",
+			setupCtx: func() context.Context {
+				return context.Background()
+			},
+			wantID: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.setupCtx()
+			got := ExtractCorrelationID(ctx)
+			assert.Equal(t, tt.wantID, got)
+		})
+	}
+}
+
+func TestClients_ConnectionStates(t *testing.T) {
+	ctx := context.Background()
+
+	// Start mock servers
+	caListener := testListener(ctx, t)
+	t.Cleanup(func() { _ = caListener.Close() })
+
+	poListener := testListener(ctx, t)
+	t.Cleanup(func() { _ = poListener.Close() })
+
+	caServer := grpc.NewServer()
+	currentaccountv1.RegisterCurrentAccountServiceServer(caServer, &mockCurrentAccountServer{})
+	go func() {
+		_ = caServer.Serve(caListener)
+	}()
+	defer caServer.Stop()
+
+	poServer := grpc.NewServer()
+	paymentorderv1.RegisterPaymentOrderServiceServer(poServer, &mockPaymentOrderServer{})
+	go func() {
+		_ = poServer.Serve(poListener)
+	}()
+	defer poServer.Stop()
+
+	cfg := &ClientsConfig{
+		CurrentAccountTarget: caListener.Addr().String(),
+		PaymentOrderTarget:   poListener.Addr().String(),
+	}
+
+	clients, err := NewClients(cfg)
+	require.NoError(t, err)
+	defer func() {
+		_ = clients.Close()
+	}()
+
+	// Initially connections are IDLE (grpc.NewClient doesn't connect immediately)
+	caState := clients.CurrentAccountState()
+	poState := clients.PaymentOrderState()
+
+	// States should be valid (not shutdown)
+	assert.NotEqual(t, connectivity.Shutdown, caState)
+	assert.NotEqual(t, connectivity.Shutdown, poState)
+}
+
+func TestDefaultPorts(t *testing.T) {
+	assert.Equal(t, 50051, CurrentAccountPort)
+	assert.Equal(t, 50054, PaymentOrderPort)
+}


### PR DESCRIPTION
## Summary

- Implement gRPC clients for CurrentAccountService and PaymentOrderService to support the Horizon Integrity Proof demonstration
- Add connection management with health checks and state monitoring
- Implement correlation ID propagation via gRPC metadata for distributed tracing

## Changes Made

- `cmd/horizon-demo/clients.go`: Main client implementation
  - `Clients` struct wrapping service clients and connections
  - `NewClients()` factory with target validation
  - `CheckHealth()` for connection state verification
  - `WaitForReady()` for startup health checks
  - `ContextWithCorrelationID()` for outbound correlation ID propagation
  - `ExtractCorrelationID()` for incoming metadata extraction
- `cmd/horizon-demo/clients_test.go`: Comprehensive test suite with mock gRPC servers

## Test plan

- [x] All unit tests pass (13 tests)
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)
- [ ] CI pipeline