### PR TITLE
feat: Add pre-flight setup for Horizon integrity proof demo

### DIFF
--- a/cmd/horizon-demo/preflight.go
+++ b/cmd/horizon-demo/preflight.go
@@ -1,0 +1,229 @@
+// Package main provides pre-flight setup for the Horizon Integrity Proof demo.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	money "google.golang.org/genproto/googleapis/type/money"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// PreFlightConfig holds configuration for the pre-flight setup phase.
+type PreFlightConfig struct {
+	// InitialDepositPence is the amount to deposit in the test account (default: 100000 = GBP 1,000.00)
+	InitialDepositPence int64
+	// Logger for structured logging
+	Logger *slog.Logger
+}
+
+// PreFlightResult captures the results of the pre-flight setup.
+type PreFlightResult struct {
+	// AccountID is the unique identifier of the created test account
+	AccountID string
+	// AccountIdentification is the IBAN-style identifier
+	AccountIdentification string
+	// InitialBalancePence is the balance after deposit (should equal InitialDepositPence)
+	InitialBalancePence int64
+	// DepositTransactionID is the ID of the deposit transaction
+	DepositTransactionID string
+	// CreatedAt is when the account was created
+	CreatedAt time.Time
+}
+
+// Pre-flight errors.
+var (
+	ErrAccountCreationFailed     = errors.New("failed to create test account")
+	ErrDepositFailed             = errors.New("failed to deposit funds")
+	ErrBalanceVerificationFailed = errors.New("balance verification failed")
+	ErrInvalidBalanceAmount      = errors.New("balance does not match expected amount")
+)
+
+// GenerateTestAccountID creates a unique account ID for the demo.
+// Format: HORIZON-TEST-{unix-timestamp}
+func GenerateTestAccountID() string {
+	return fmt.Sprintf("HORIZON-TEST-%d", time.Now().Unix())
+}
+
+// GenerateTestIBAN creates a test IBAN for the demo account.
+// Uses a GB test IBAN format.
+func GenerateTestIBAN(timestamp int64) string {
+	// GB82 WEST 1234 5698 7654 32 is a valid test IBAN format
+	// We append timestamp digits to make it unique
+	return fmt.Sprintf("GB82WEST%014d", timestamp%100000000000000)
+}
+
+// RunPreFlight executes the pre-flight setup phase of the demo.
+// This creates a test account and deposits baseline funds.
+//
+// Steps:
+// 1. Generate unique account ID (HORIZON-TEST-{timestamp})
+// 2. Call InitiateCurrentAccount to create the account
+// 3. Call ExecuteDeposit to add baseline funds (GBP 1,000.00)
+// 4. Call RetrieveCurrentAccount to verify the balance
+func RunPreFlight(ctx context.Context, clients *Clients, cfg *PreFlightConfig) (*PreFlightResult, error) {
+	if clients == nil {
+		return nil, fmt.Errorf("%w: clients is nil", ErrAccountCreationFailed)
+	}
+	if cfg == nil {
+		cfg = &PreFlightConfig{
+			InitialDepositPence: 100000, // GBP 1,000.00
+			Logger:              slog.Default(),
+		}
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.InitialDepositPence <= 0 {
+		cfg.InitialDepositPence = 100000
+	}
+
+	logger := cfg.Logger
+	timestamp := time.Now().Unix()
+
+	// Step 1: Generate unique identifiers
+	accountID := GenerateTestAccountID()
+	iban := GenerateTestIBAN(timestamp)
+
+	logger.Info("pre-flight: creating test account",
+		"account_id", accountID,
+		"iban", iban,
+	)
+
+	// Step 2: Create the test account
+	createResp, err := clients.CurrentAccount.InitiateCurrentAccount(ctx, &currentaccountv1.InitiateCurrentAccountRequest{
+		CustomerId:            accountID, // Use account ID as customer ID for demo
+		AccountIdentification: iban,
+		BaseCurrency:          commonv1.Currency_CURRENCY_GBP,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrAccountCreationFailed, err)
+	}
+
+	createdAccountID := createResp.GetAccountId()
+	if createdAccountID == "" {
+		createdAccountID = accountID
+	}
+
+	logger.Info("pre-flight: account created",
+		"account_id", createdAccountID,
+		"status", createResp.GetFacility().GetAccountStatus().String(),
+	)
+
+	// Step 3: Deposit baseline funds
+	depositAmount := penceToPounds(cfg.InitialDepositPence)
+	logger.Info("pre-flight: depositing funds",
+		"account_id", createdAccountID,
+		"amount_pence", cfg.InitialDepositPence,
+		"amount_gbp", fmt.Sprintf("%.2f", float64(cfg.InitialDepositPence)/100),
+	)
+
+	depositResp, err := clients.CurrentAccount.ExecuteDeposit(ctx, &currentaccountv1.ExecuteDepositRequest{
+		AccountId: createdAccountID,
+		Amount: &commonv1.MoneyAmount{
+			Amount: depositAmount,
+		},
+		Description: "Horizon demo initial deposit",
+		Reference:   fmt.Sprintf("HORIZON-DEPOSIT-%d", timestamp),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrDepositFailed, err)
+	}
+
+	if depositResp.GetStatus() != currentaccountv1.TransactionStatus_TRANSACTION_STATUS_COMPLETED {
+		return nil, fmt.Errorf("%w: deposit status is %s, expected COMPLETED",
+			ErrDepositFailed, depositResp.GetStatus().String())
+	}
+
+	logger.Info("pre-flight: deposit completed",
+		"transaction_id", depositResp.GetTransactionId(),
+		"new_balance_units", depositResp.GetNewBalance().GetAmount().GetUnits(),
+	)
+
+	// Step 4: Verify the balance
+	retrieveResp, err := clients.CurrentAccount.RetrieveCurrentAccount(ctx, &currentaccountv1.RetrieveCurrentAccountRequest{
+		AccountId: createdAccountID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrBalanceVerificationFailed, err)
+	}
+
+	actualBalancePence := moneyToPence(retrieveResp.GetFacility().GetCurrentBalance().GetCurrentBalance().GetAmount())
+	if actualBalancePence != cfg.InitialDepositPence {
+		return nil, fmt.Errorf("%w: expected %d pence, got %d pence",
+			ErrInvalidBalanceAmount, cfg.InitialDepositPence, actualBalancePence)
+	}
+
+	logger.Info("pre-flight: balance verified",
+		"account_id", createdAccountID,
+		"balance_pence", actualBalancePence,
+		"balance_gbp", fmt.Sprintf("%.2f", float64(actualBalancePence)/100),
+	)
+
+	createdAt := time.Now()
+	if retrieveResp.GetFacility().GetCreatedAt() != nil {
+		createdAt = retrieveResp.GetFacility().GetCreatedAt().AsTime()
+	}
+
+	return &PreFlightResult{
+		AccountID:             createdAccountID,
+		AccountIdentification: iban,
+		InitialBalancePence:   actualBalancePence,
+		DepositTransactionID:  depositResp.GetTransactionId(),
+		CreatedAt:             createdAt,
+	}, nil
+}
+
+// penceToPounds converts pence to google.type.Money with GBP currency.
+// For example, 100000 pence becomes Money{CurrencyCode: "GBP", Units: 1000, Nanos: 0}
+func penceToPounds(pence int64) *money.Money {
+	units := pence / 100
+	// pence % 100 is always 0-99, so max value is 99 * 10000000 = 990000000
+	// which safely fits in int32 (max ~2.1 billion)
+	fractionalPence := pence % 100
+	nanos := int32(fractionalPence) * 10000000 // #nosec G115 - safe: fractionalPence is 0-99
+
+	return &money.Money{
+		CurrencyCode: "GBP",
+		Units:        units,
+		Nanos:        nanos,
+	}
+}
+
+// moneyToPence converts google.type.Money to pence.
+// Assumes GBP currency where 1 unit = 100 pence.
+func moneyToPence(m *money.Money) int64 {
+	if m == nil {
+		return 0
+	}
+	// Units are whole pounds, nanos are fractional
+	// 1 nano = 0.000000001 pounds
+	// 1 pence = 0.01 pounds = 10,000,000 nanos
+	penceFromUnits := m.GetUnits() * 100
+	penceFromNanos := int64(m.GetNanos() / 10000000)
+	return penceFromUnits + penceFromNanos
+}
+
+// IsRetryableError checks if a gRPC error is transient and should be retried.
+func IsRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+
+	code := st.Code()
+	return code == codes.Unavailable ||
+		code == codes.ResourceExhausted ||
+		code == codes.Aborted ||
+		code == codes.DeadlineExceeded
+}

--- a/cmd/horizon-demo/preflight_test.go
+++ b/cmd/horizon-demo/preflight_test.go
@@ -1,0 +1,548 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	money "google.golang.org/genproto/googleapis/type/money"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// errGenericTest is a static error for testing non-gRPC error handling.
+var errGenericTest = errors.New("generic error")
+
+func TestGenerateTestAccountID(t *testing.T) {
+	id1 := GenerateTestAccountID()
+	id2 := GenerateTestAccountID()
+
+	// Should have the correct prefix
+	assert.True(t, strings.HasPrefix(id1, "HORIZON-TEST-"), "ID should start with HORIZON-TEST-")
+
+	// Should be alphanumeric with hyphens (valid for proto validation)
+	assert.Regexp(t, `^HORIZON-TEST-\d+$`, id1)
+
+	// IDs generated in quick succession may be the same (within same second)
+	// This is acceptable for a demo tool
+	_ = id2
+}
+
+func TestGenerateTestIBAN(t *testing.T) {
+	timestamp := int64(1701607800)
+	iban := GenerateTestIBAN(timestamp)
+
+	// Should start with GB country code
+	assert.True(t, strings.HasPrefix(iban, "GB82WEST"), "IBAN should start with GB82WEST")
+
+	// Should match IBAN pattern (2 letter country + 2 check digits + up to 30 alphanumeric)
+	assert.Regexp(t, `^[A-Z]{2}[0-9]{2}[A-Z0-9]{1,30}$`, iban)
+
+	// Different timestamps should produce different IBANs
+	iban2 := GenerateTestIBAN(timestamp + 1)
+	assert.NotEqual(t, iban, iban2)
+}
+
+func TestPenceToPounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		pence     int64
+		wantUnits int64
+		wantNanos int32
+	}{
+		{
+			name:      "GBP 1,000.00",
+			pence:     100000,
+			wantUnits: 1000,
+			wantNanos: 0,
+		},
+		{
+			name:      "GBP 100.00",
+			pence:     10000,
+			wantUnits: 100,
+			wantNanos: 0,
+		},
+		{
+			name:      "GBP 0.01",
+			pence:     1,
+			wantUnits: 0,
+			wantNanos: 10000000,
+		},
+		{
+			name:      "GBP 123.45",
+			pence:     12345,
+			wantUnits: 123,
+			wantNanos: 450000000,
+		},
+		{
+			name:      "zero",
+			pence:     0,
+			wantUnits: 0,
+			wantNanos: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := penceToPounds(tt.pence)
+			assert.Equal(t, "GBP", result.GetCurrencyCode())
+			assert.Equal(t, tt.wantUnits, result.GetUnits())
+			assert.Equal(t, tt.wantNanos, result.GetNanos())
+		})
+	}
+}
+
+func TestMoneyToPence(t *testing.T) {
+	tests := []struct {
+		name      string
+		money     *money.Money
+		wantPence int64
+	}{
+		{
+			name: "GBP 1,000.00",
+			money: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        1000,
+				Nanos:        0,
+			},
+			wantPence: 100000,
+		},
+		{
+			name: "GBP 123.45",
+			money: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        123,
+				Nanos:        450000000,
+			},
+			wantPence: 12345,
+		},
+		{
+			name: "GBP 0.01",
+			money: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        0,
+				Nanos:        10000000,
+			},
+			wantPence: 1,
+		},
+		{
+			name:      "nil money",
+			money:     nil,
+			wantPence: 0,
+		},
+		{
+			name: "zero",
+			money: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        0,
+				Nanos:        0,
+			},
+			wantPence: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := moneyToPence(tt.money)
+			assert.Equal(t, tt.wantPence, result)
+		})
+	}
+}
+
+func TestMoneyConversionRoundTrip(t *testing.T) {
+	// Test that pence -> money -> pence is lossless
+	testCases := []int64{0, 1, 50, 99, 100, 12345, 100000, 999999}
+
+	for _, pence := range testCases {
+		money := penceToPounds(pence)
+		result := moneyToPence(money)
+		assert.Equal(t, pence, result, "Round trip failed for %d pence", pence)
+	}
+}
+
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantRetry bool
+	}{
+		{
+			name:      "nil error",
+			err:       nil,
+			wantRetry: false,
+		},
+		{
+			name:      "unavailable",
+			err:       status.Error(codes.Unavailable, "service unavailable"),
+			wantRetry: true,
+		},
+		{
+			name:      "resource exhausted",
+			err:       status.Error(codes.ResourceExhausted, "rate limited"),
+			wantRetry: true,
+		},
+		{
+			name:      "aborted",
+			err:       status.Error(codes.Aborted, "transaction aborted"),
+			wantRetry: true,
+		},
+		{
+			name:      "deadline exceeded",
+			err:       status.Error(codes.DeadlineExceeded, "timeout"),
+			wantRetry: true,
+		},
+		{
+			name:      "not found",
+			err:       status.Error(codes.NotFound, "not found"),
+			wantRetry: false,
+		},
+		{
+			name:      "invalid argument",
+			err:       status.Error(codes.InvalidArgument, "bad request"),
+			wantRetry: false,
+		},
+		{
+			name:      "permission denied",
+			err:       status.Error(codes.PermissionDenied, "forbidden"),
+			wantRetry: false,
+		},
+		{
+			name:      "non-grpc error",
+			err:       errGenericTest,
+			wantRetry: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRetryableError(tt.err)
+			assert.Equal(t, tt.wantRetry, result)
+		})
+	}
+}
+
+// mockCurrentAccountClient is a test double for CurrentAccountServiceClient
+type mockCurrentAccountClient struct {
+	currentaccountv1.CurrentAccountServiceClient
+
+	initiateFunc func(ctx context.Context, req *currentaccountv1.InitiateCurrentAccountRequest) (*currentaccountv1.InitiateCurrentAccountResponse, error)
+	depositFunc  func(ctx context.Context, req *currentaccountv1.ExecuteDepositRequest) (*currentaccountv1.ExecuteDepositResponse, error)
+	retrieveFunc func(ctx context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error)
+}
+
+func (m *mockCurrentAccountClient) InitiateCurrentAccount(ctx context.Context, req *currentaccountv1.InitiateCurrentAccountRequest, _ ...grpc.CallOption) (*currentaccountv1.InitiateCurrentAccountResponse, error) {
+	if m.initiateFunc != nil {
+		return m.initiateFunc(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockCurrentAccountClient) ExecuteDeposit(ctx context.Context, req *currentaccountv1.ExecuteDepositRequest, _ ...grpc.CallOption) (*currentaccountv1.ExecuteDepositResponse, error) {
+	if m.depositFunc != nil {
+		return m.depositFunc(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockCurrentAccountClient) RetrieveCurrentAccount(ctx context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest, _ ...grpc.CallOption) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+	if m.retrieveFunc != nil {
+		return m.retrieveFunc(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func TestRunPreFlight_Success(t *testing.T) {
+	mockClient := &mockCurrentAccountClient{
+		initiateFunc: func(_ context.Context, _ *currentaccountv1.InitiateCurrentAccountRequest) (*currentaccountv1.InitiateCurrentAccountResponse, error) {
+			return &currentaccountv1.InitiateCurrentAccountResponse{
+				AccountId: "test-account-123",
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					AccountId:     "test-account-123",
+					AccountStatus: currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
+				},
+			}, nil
+		},
+		depositFunc: func(_ context.Context, req *currentaccountv1.ExecuteDepositRequest) (*currentaccountv1.ExecuteDepositResponse, error) {
+			return &currentaccountv1.ExecuteDepositResponse{
+				AccountId:     req.GetAccountId(),
+				TransactionId: "txn-deposit-123",
+				NewBalance: &commonv1.MoneyAmount{
+					Amount: &money.Money{
+						CurrencyCode: "GBP",
+						Units:        1000,
+						Nanos:        0,
+					},
+				},
+				Status: currentaccountv1.TransactionStatus_TRANSACTION_STATUS_COMPLETED,
+			}, nil
+		},
+		retrieveFunc: func(_ context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					AccountId:     req.GetAccountId(),
+					AccountStatus: currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
+					CurrentBalance: &currentaccountv1.AccountBalance{
+						CurrentBalance: &commonv1.MoneyAmount{
+							Amount: &money.Money{
+								CurrencyCode: "GBP",
+								Units:        1000,
+								Nanos:        0,
+							},
+						},
+						LastUpdated: timestamppb.Now(),
+					},
+					CreatedAt: timestamppb.Now(),
+				},
+			}, nil
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         slog.Default(),
+	}
+
+	ctx := context.Background()
+	cfg := &PreFlightConfig{
+		InitialDepositPence: 100000, // GBP 1,000.00
+		Logger:              slog.Default(),
+	}
+
+	result, err := RunPreFlight(ctx, clients, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "test-account-123", result.AccountID)
+	assert.Equal(t, int64(100000), result.InitialBalancePence)
+	assert.Equal(t, "txn-deposit-123", result.DepositTransactionID)
+	assert.NotEmpty(t, result.AccountIdentification)
+}
+
+func TestRunPreFlight_NilClients(t *testing.T) {
+	ctx := context.Background()
+	result, err := RunPreFlight(ctx, nil, nil)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAccountCreationFailed))
+}
+
+func TestRunPreFlight_AccountCreationFails(t *testing.T) {
+	mockClient := &mockCurrentAccountClient{
+		initiateFunc: func(_ context.Context, _ *currentaccountv1.InitiateCurrentAccountRequest) (*currentaccountv1.InitiateCurrentAccountResponse, error) {
+			return nil, status.Error(codes.Internal, "database error")
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunPreFlight(ctx, clients, nil)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrAccountCreationFailed))
+}
+
+func TestRunPreFlight_DepositFails(t *testing.T) {
+	mockClient := &mockCurrentAccountClient{
+		initiateFunc: func(_ context.Context, _ *currentaccountv1.InitiateCurrentAccountRequest) (*currentaccountv1.InitiateCurrentAccountResponse, error) {
+			return &currentaccountv1.InitiateCurrentAccountResponse{
+				AccountId: "test-account-123",
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					AccountId:     "test-account-123",
+					AccountStatus: currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE,
+				},
+			}, nil
+		},
+		depositFunc: func(_ context.Context, _ *currentaccountv1.ExecuteDepositRequest) (*currentaccountv1.ExecuteDepositResponse, error) {
+			return nil, status.Error(codes.Unavailable, "service unavailable")
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunPreFlight(ctx, clients, nil)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrDepositFailed))
+}
+
+func TestRunPreFlight_DepositNotCompleted(t *testing.T) {
+	mockClient := &mockCurrentAccountClient{
+		initiateFunc: func(_ context.Context, _ *currentaccountv1.InitiateCurrentAccountRequest) (*currentaccountv1.InitiateCurrentAccountResponse, error) {
+			return &currentaccountv1.InitiateCurrentAccountResponse{
+				AccountId: "test-account-123",
+				Facility:  &currentaccountv1.CurrentAccountFacility{},
+			}, nil
+		},
+		depositFunc: func(_ context.Context, _ *currentaccountv1.ExecuteDepositRequest) (*currentaccountv1.ExecuteDepositResponse, error) {
+			return &currentaccountv1.ExecuteDepositResponse{
+				Status: currentaccountv1.TransactionStatus_TRANSACTION_STATUS_PENDING, // Not COMPLETED
+			}, nil
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunPreFlight(ctx, clients, nil)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrDepositFailed))
+	assert.Contains(t, err.Error(), "PENDING")
+}
+
+func TestRunPreFlight_BalanceVerificationFails(t *testing.T) {
+	mockClient := &mockCurrentAccountClient{
+		initiateFunc: func(_ context.Context, _ *currentaccountv1.InitiateCurrentAccountRequest) (*currentaccountv1.InitiateCurrentAccountResponse, error) {
+			return &currentaccountv1.InitiateCurrentAccountResponse{
+				AccountId: "test-account-123",
+				Facility:  &currentaccountv1.CurrentAccountFacility{},
+			}, nil
+		},
+		depositFunc: func(_ context.Context, _ *currentaccountv1.ExecuteDepositRequest) (*currentaccountv1.ExecuteDepositResponse, error) {
+			return &currentaccountv1.ExecuteDepositResponse{
+				TransactionId: "txn-123",
+				Status:        currentaccountv1.TransactionStatus_TRANSACTION_STATUS_COMPLETED,
+			}, nil
+		},
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return nil, status.Error(codes.NotFound, "account not found")
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunPreFlight(ctx, clients, nil)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrBalanceVerificationFailed))
+}
+
+func TestRunPreFlight_BalanceMismatch(t *testing.T) {
+	mockClient := &mockCurrentAccountClient{
+		initiateFunc: func(_ context.Context, _ *currentaccountv1.InitiateCurrentAccountRequest) (*currentaccountv1.InitiateCurrentAccountResponse, error) {
+			return &currentaccountv1.InitiateCurrentAccountResponse{
+				AccountId: "test-account-123",
+				Facility:  &currentaccountv1.CurrentAccountFacility{},
+			}, nil
+		},
+		depositFunc: func(_ context.Context, _ *currentaccountv1.ExecuteDepositRequest) (*currentaccountv1.ExecuteDepositResponse, error) {
+			return &currentaccountv1.ExecuteDepositResponse{
+				TransactionId: "txn-123",
+				Status:        currentaccountv1.TransactionStatus_TRANSACTION_STATUS_COMPLETED,
+			}, nil
+		},
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					CurrentBalance: &currentaccountv1.AccountBalance{
+						CurrentBalance: &commonv1.MoneyAmount{
+							Amount: &money.Money{
+								CurrencyCode: "GBP",
+								Units:        500, // Only 500 GBP instead of 1000
+								Nanos:        0,
+							},
+						},
+						LastUpdated: timestamppb.Now(),
+					},
+				},
+			}, nil
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         slog.Default(),
+	}
+
+	ctx := context.Background()
+	cfg := &PreFlightConfig{
+		InitialDepositPence: 100000, // Expecting 1000 GBP
+		Logger:              slog.Default(),
+	}
+
+	result, err := RunPreFlight(ctx, clients, cfg)
+
+	assert.Nil(t, result)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidBalanceAmount))
+	assert.Contains(t, err.Error(), "expected 100000 pence")
+	assert.Contains(t, err.Error(), "got 50000 pence")
+}
+
+func TestRunPreFlight_DefaultConfig(t *testing.T) {
+	mockClient := &mockCurrentAccountClient{
+		initiateFunc: func(_ context.Context, req *currentaccountv1.InitiateCurrentAccountRequest) (*currentaccountv1.InitiateCurrentAccountResponse, error) {
+			// Verify GBP currency is used
+			assert.Equal(t, commonv1.Currency_CURRENCY_GBP, req.GetBaseCurrency())
+			return &currentaccountv1.InitiateCurrentAccountResponse{
+				AccountId: "test-account",
+				Facility:  &currentaccountv1.CurrentAccountFacility{},
+			}, nil
+		},
+		depositFunc: func(_ context.Context, req *currentaccountv1.ExecuteDepositRequest) (*currentaccountv1.ExecuteDepositResponse, error) {
+			// Verify default deposit amount (1000 GBP = 100000 pence)
+			assert.Equal(t, int64(1000), req.GetAmount().GetAmount().GetUnits())
+			return &currentaccountv1.ExecuteDepositResponse{
+				TransactionId: "txn-123",
+				Status:        currentaccountv1.TransactionStatus_TRANSACTION_STATUS_COMPLETED,
+			}, nil
+		},
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					CurrentBalance: &currentaccountv1.AccountBalance{
+						CurrentBalance: &commonv1.MoneyAmount{
+							Amount: &money.Money{
+								CurrencyCode: "GBP",
+								Units:        1000,
+								Nanos:        0,
+							},
+						},
+						LastUpdated: timestamppb.Now(),
+					},
+				},
+			}, nil
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         slog.Default(),
+	}
+
+	ctx := context.Background()
+	// Pass nil config to use defaults
+	result, err := RunPreFlight(ctx, clients, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, int64(100000), result.InitialBalancePence)
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/redis/go-redis/v9 v9.16.0
 	github.com/shopspring/decimal v1.4.0
 	github.com/sony/gobreaker/v2 v2.0.0
+	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.39.0
 	github.com/testcontainers/testcontainers-go/modules/kafka v0.39.0
@@ -41,7 +42,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/spf13/cobra v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
@@ -104,7 +104,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/googleapis/go-gorm-spanner v1.8.6 // indirect
 	github.com/googleapis/go-sql-spanner v1.17.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -156,7 +156,7 @@ require (
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.12.0
 	google.golang.org/api v0.247.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20251103181224-f26f9409b101 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20251103181224-f26f9409b101
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251103181224-f26f9409b101 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/mysql v1.5.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -772,7 +772,6 @@ github.com/containerd/typeurl/v2 v2.2.0 h1:6NBDbQzr7I5LHgp34xAXYF5DOTQDn05X58lsP
 github.com/containerd/typeurl/v2 v2.2.0/go.mod h1:8XOOxnyatxSWuG8OfsZXVnAF4iZfedjS/8UHSPJnX4g=
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
-github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
@@ -1276,12 +1275,8 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/afero v1.3.3/go.mod h1:5KUK8ByomD5Ti5Artl0RtHeI5pTF7MIDuXL3yY520V4=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
-github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
-github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
-github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
-github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=


### PR DESCRIPTION
## Summary
- Implements pre-flight phase (FR-1) for the Horizon integrity proof demo
- Creates unique test account via CurrentAccountService
- Deposits baseline funds (GBP 1,000.00) and verifies balance
- Provides money conversion utilities for google.type.Money

## Changes Made
- Add `preflight.go` with:
  - `RunPreFlight`: orchestrates account creation, deposit, and balance verification
  - `GenerateTestAccountID`: creates `HORIZON-TEST-{timestamp}` identifiers
  - `GenerateTestIBAN`: creates valid test IBAN format
  - `penceToPounds`/`moneyToPence`: conversion utilities for proto Money type
  - `IsRetryableError`: identifies transient gRPC errors for retry logic
- Rename report.go constants to avoid collision with main.go's Verdict enum:
  - `VerdictPassed` -> `ReportVerdictPassed`
  - `StatusClientTimeout` -> `ReportStatusClientTimeout`, etc.

## Test Plan
- [x] Unit tests for ID/IBAN generation
- [x] Unit tests for money conversion (round-trip verification)
- [x] Unit tests for retryable error detection
- [x] Mock-based tests for RunPreFlight success path
- [x] Error scenario tests: account creation, deposit, verification failures
- [x] All tests pass locally
- [x] Lint checks pass

## Task Master
Tag: 99-horizon-proof, Task 3