### PR TITLE
fix: Resolve duplicate constant declarations in horizon-demo

### DIFF
--- a/cmd/horizon-demo/report.go
+++ b/cmd/horizon-demo/report.go
@@ -65,17 +65,17 @@ type VerificationReport struct {
 	NoDoubleSpend bool `json:"no_double_spend"`
 }
 
-// Verdict constants for report outcome.
+// Report verdict string constants for JSON output.
 const (
-	VerdictPassed = "PASSED"
-	VerdictFailed = "FAILED"
+	ReportVerdictPassed = "PASSED"
+	ReportVerdictFailed = "FAILED"
 )
 
-// Attempt status constants.
+// Attempt status string constants for JSON output.
 const (
-	StatusClientTimeout = "CLIENT_TIMEOUT"
-	StatusSuccess       = "SUCCESS"
-	StatusError         = "ERROR"
+	AttemptStatusClientTimeout = "CLIENT_TIMEOUT"
+	AttemptStatusSuccess       = "SUCCESS"
+	AttemptStatusError         = "ERROR"
 )
 
 // NewReport creates a new Report with a unique demo ID and current timestamp.
@@ -89,18 +89,18 @@ func NewReport() *Report {
 }
 
 // CalculateVerdict determines the verdict based on verification results.
-// Returns VerdictPassed if:
+// Returns ReportVerdictPassed if:
 // - BalanceCorrect is true
 // - TransactionsRecorded equals 1
 // - NoDoubleSpend is true
-// Otherwise returns VerdictFailed.
+// Otherwise returns ReportVerdictFailed.
 func (r *Report) CalculateVerdict() string {
 	if r.Verification.BalanceCorrect &&
 		r.Verification.TransactionsRecorded == 1 &&
 		r.Verification.NoDoubleSpend {
-		return VerdictPassed
+		return ReportVerdictPassed
 	}
-	return VerdictFailed
+	return ReportVerdictFailed
 }
 
 // AddAttempt adds a payment attempt to the report.

--- a/cmd/horizon-demo/report_test.go
+++ b/cmd/horizon-demo/report_test.go
@@ -45,7 +45,7 @@ func TestReport_CalculateVerdict_Passed(t *testing.T) {
 	}
 
 	verdict := report.CalculateVerdict()
-	assert.Equal(t, VerdictPassed, verdict)
+	assert.Equal(t, ReportVerdictPassed, verdict)
 }
 
 func TestReport_CalculateVerdict_Failed(t *testing.T) {
@@ -95,7 +95,7 @@ func TestReport_CalculateVerdict_Failed(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			report := &Report{Verification: tt.verification}
 			verdict := report.CalculateVerdict()
-			assert.Equal(t, VerdictFailed, verdict)
+			assert.Equal(t, ReportVerdictFailed, verdict)
 		})
 	}
 }
@@ -107,7 +107,7 @@ func TestReport_AddAttempt(t *testing.T) {
 	attempt1 := AttemptReport{
 		Attempt:        1,
 		IdempotencyKey: "HORIZON-TXN-123",
-		Status:         StatusClientTimeout,
+		Status:         AttemptStatusClientTimeout,
 		Error:          "context deadline exceeded",
 		DurationMs:     45,
 	}
@@ -121,7 +121,7 @@ func TestReport_AddAttempt(t *testing.T) {
 	attempt2 := AttemptReport{
 		Attempt:        2,
 		IdempotencyKey: "HORIZON-TXN-123",
-		Status:         StatusSuccess,
+		Status:         AttemptStatusSuccess,
 		PaymentOrderID: "po_abc123",
 		DurationMs:     120,
 	}
@@ -151,7 +151,7 @@ func TestReport_SetFinalBalance(t *testing.T) {
 		assert.True(t, report.Verification.BalanceCorrect)
 		assert.True(t, report.Verification.NoDoubleSpend)
 		assert.Equal(t, 1, report.Verification.TransactionsRecorded)
-		assert.Equal(t, VerdictPassed, report.Verdict)
+		assert.Equal(t, ReportVerdictPassed, report.Verdict)
 	})
 
 	t.Run("double spend detected", func(t *testing.T) {
@@ -163,7 +163,7 @@ func TestReport_SetFinalBalance(t *testing.T) {
 		assert.False(t, report.Verification.BalanceCorrect)
 		assert.False(t, report.Verification.NoDoubleSpend)
 		assert.Equal(t, 2, report.Verification.TransactionsRecorded)
-		assert.Equal(t, VerdictFailed, report.Verdict)
+		assert.Equal(t, ReportVerdictFailed, report.Verdict)
 	})
 
 	t.Run("no transaction executed", func(t *testing.T) {
@@ -175,7 +175,7 @@ func TestReport_SetFinalBalance(t *testing.T) {
 		assert.False(t, report.Verification.BalanceCorrect)
 		assert.False(t, report.Verification.NoDoubleSpend)
 		assert.Equal(t, 0, report.Verification.TransactionsRecorded)
-		assert.Equal(t, VerdictFailed, report.Verdict)
+		assert.Equal(t, ReportVerdictFailed, report.Verdict)
 	})
 }
 
@@ -193,14 +193,14 @@ func TestReport_ToJSON(t *testing.T) {
 			{
 				Attempt:        1,
 				IdempotencyKey: "HORIZON-TXN-xxx",
-				Status:         StatusClientTimeout,
+				Status:         AttemptStatusClientTimeout,
 				Error:          "context deadline exceeded",
 				DurationMs:     45,
 			},
 			{
 				Attempt:        2,
 				IdempotencyKey: "HORIZON-TXN-xxx",
-				Status:         StatusSuccess,
+				Status:         AttemptStatusSuccess,
 				PaymentOrderID: "po_xxx",
 				DurationMs:     120,
 			},
@@ -211,7 +211,7 @@ func TestReport_ToJSON(t *testing.T) {
 			BalanceCorrect:       true,
 			NoDoubleSpend:        true,
 		},
-		Verdict: VerdictPassed,
+		Verdict: ReportVerdictPassed,
 	}
 
 	data, err := report.ToJSON()
@@ -242,12 +242,12 @@ func TestReport_ToJSON_OmitsEmptyFields(t *testing.T) {
 			{
 				Attempt:        1,
 				IdempotencyKey: "key",
-				Status:         StatusSuccess,
+				Status:         AttemptStatusSuccess,
 				DurationMs:     100,
 				// Error and PaymentOrderID are empty
 			},
 		},
-		Verdict: VerdictPassed,
+		Verdict: ReportVerdictPassed,
 	}
 
 	data, err := report.ToJSON()
@@ -278,7 +278,7 @@ func TestReport_WriteToFile(t *testing.T) {
 			{
 				Attempt:        1,
 				IdempotencyKey: "HORIZON-TXN-test",
-				Status:         StatusSuccess,
+				Status:         AttemptStatusSuccess,
 				PaymentOrderID: "po_test",
 				DurationMs:     100,
 			},
@@ -289,7 +289,7 @@ func TestReport_WriteToFile(t *testing.T) {
 			BalanceCorrect:       true,
 			NoDoubleSpend:        true,
 		},
-		Verdict: VerdictPassed,
+		Verdict: ReportVerdictPassed,
 	}
 
 	outputPath := filepath.Join(tmpDir, "integrity_report.json")
@@ -333,7 +333,7 @@ func TestReport_FullScenario_Passed(t *testing.T) {
 	report.AddAttempt(AttemptReport{
 		Attempt:        1,
 		IdempotencyKey: "HORIZON-TXN-12345",
-		Status:         StatusClientTimeout,
+		Status:         AttemptStatusClientTimeout,
 		Error:          "context deadline exceeded",
 		DurationMs:     45,
 	})
@@ -342,7 +342,7 @@ func TestReport_FullScenario_Passed(t *testing.T) {
 	report.AddAttempt(AttemptReport{
 		Attempt:        2,
 		IdempotencyKey: "HORIZON-TXN-12345",
-		Status:         StatusSuccess,
+		Status:         AttemptStatusSuccess,
 		PaymentOrderID: "po_abc123",
 		DurationMs:     120,
 	})
@@ -351,7 +351,7 @@ func TestReport_FullScenario_Passed(t *testing.T) {
 	report.SetFinalBalance(90000, 1)
 
 	// Assert final state
-	assert.Equal(t, VerdictPassed, report.Verdict)
+	assert.Equal(t, ReportVerdictPassed, report.Verdict)
 	assert.Equal(t, 2, report.Verification.RequestsSent)
 	assert.Equal(t, 1, report.Verification.TransactionsRecorded)
 	assert.True(t, report.Verification.BalanceCorrect)
@@ -367,7 +367,7 @@ func TestReport_FullScenario_DoubleSpend(t *testing.T) {
 	report.AddAttempt(AttemptReport{
 		Attempt:        1,
 		IdempotencyKey: "HORIZON-TXN-12345",
-		Status:         StatusSuccess, // First request succeeded
+		Status:         AttemptStatusSuccess, // First request succeeded
 		PaymentOrderID: "po_abc123",
 		DurationMs:     100,
 	})
@@ -375,8 +375,8 @@ func TestReport_FullScenario_DoubleSpend(t *testing.T) {
 	report.AddAttempt(AttemptReport{
 		Attempt:        2,
 		IdempotencyKey: "HORIZON-TXN-12345",
-		Status:         StatusSuccess, // Second request also succeeded (BAD!)
-		PaymentOrderID: "po_def456",   // Different order ID = double spend
+		Status:         AttemptStatusSuccess, // Second request also succeeded (BAD!)
+		PaymentOrderID: "po_def456",          // Different order ID = double spend
 		DurationMs:     100,
 	})
 
@@ -384,7 +384,7 @@ func TestReport_FullScenario_DoubleSpend(t *testing.T) {
 	report.SetFinalBalance(80000, 2)
 
 	// Assert failure
-	assert.Equal(t, VerdictFailed, report.Verdict)
+	assert.Equal(t, ReportVerdictFailed, report.Verdict)
 	assert.False(t, report.Verification.BalanceCorrect)
 	assert.False(t, report.Verification.NoDoubleSpend)
 }
@@ -398,7 +398,7 @@ func TestReport_FullScenario_NoTransaction(t *testing.T) {
 	report.AddAttempt(AttemptReport{
 		Attempt:        1,
 		IdempotencyKey: "HORIZON-TXN-12345",
-		Status:         StatusClientTimeout,
+		Status:         AttemptStatusClientTimeout,
 		Error:          "context deadline exceeded",
 		DurationMs:     45,
 	})
@@ -406,7 +406,7 @@ func TestReport_FullScenario_NoTransaction(t *testing.T) {
 	report.AddAttempt(AttemptReport{
 		Attempt:        2,
 		IdempotencyKey: "HORIZON-TXN-12345",
-		Status:         StatusError,
+		Status:         AttemptStatusError,
 		Error:          "service unavailable",
 		DurationMs:     200,
 	})
@@ -415,7 +415,7 @@ func TestReport_FullScenario_NoTransaction(t *testing.T) {
 	report.SetFinalBalance(100000, 0)
 
 	// Assert failure
-	assert.Equal(t, VerdictFailed, report.Verdict)
+	assert.Equal(t, ReportVerdictFailed, report.Verdict)
 	assert.False(t, report.Verification.BalanceCorrect)
 	assert.False(t, report.Verification.NoDoubleSpend)
 	assert.Equal(t, 0, report.Verification.TransactionsRecorded)


### PR DESCRIPTION
## Summary

- Fixes CI failures on develop branch caused by duplicate constant declarations in `cmd/horizon-demo/`
- `VerdictPassed`, `VerdictFailed`, and `StatusError` were declared in both `main.go` (as int-based types) and `report.go` (as string constants)

## Changes Made

Renamed string constants in `report.go` to use distinct names:
- `VerdictPassed` → `ReportVerdictPassed`
- `VerdictFailed` → `ReportVerdictFailed`
- `StatusClientTimeout` → `AttemptStatusClientTimeout`
- `StatusSuccess` → `AttemptStatusSuccess`
- `StatusError` → `AttemptStatusError`

Updated all usages in `report.go` and `report_test.go`.

## Technical Details

The `main.go` file defines:
- `type Verdict int` with `VerdictPassed`, `VerdictFailed`, `VerdictError` constants (lines 97-103)
- `type StepStatus int` with `StatusError` constant (lines 42-50)

The `report.go` file needed string constants for JSON serialization, which collided with the type-based constants. The rename disambiguates the purpose: `Report*` prefix for JSON report values, `Attempt*` prefix for attempt status values.

## Testing

- `go build ./cmd/horizon-demo/...` passes
- `go test ./cmd/horizon-demo/...` passes (all 20+ tests)
- `golangci-lint run ./cmd/horizon-demo/...` passes with 0 issues