### PR TITLE
feat: Add timeout calibration for simulating network failure in Horizon demo

### DIFF
--- a/cmd/horizon-demo/sabotage.go
+++ b/cmd/horizon-demo/sabotage.go
@@ -1,0 +1,344 @@
+// Package main provides the sabotage mechanism for simulating network failures.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	paymentorderv1 "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	money "google.golang.org/genproto/googleapis/type/money"
+)
+
+// SabotageConfig holds configuration for the sabotage attempt.
+type SabotageConfig struct {
+	// DebtorAccountID is the account from which funds are debited
+	DebtorAccountID string
+	// AmountPence is the payment amount in pence (e.g., 10000 = GBP 100.00)
+	AmountPence int64
+	// InitialTimeout is the starting timeout duration for the sabotage attempt
+	InitialTimeout time.Duration
+	// MinTimeout is the minimum timeout duration (adaptive calibration floor)
+	MinTimeout time.Duration
+	// MaxAttempts is the maximum number of calibration attempts before giving up
+	MaxAttempts int
+	// CreditorReference is the external account to credit (IBAN format)
+	CreditorReference string
+	// Logger for structured logging
+	Logger *slog.Logger
+}
+
+// SabotageResult captures the outcome of a sabotage attempt.
+type SabotageResult struct {
+	// IdempotencyKey is the key used for this payment attempt
+	IdempotencyKey string
+	// CorrelationID is the distributed tracing ID
+	CorrelationID string
+	// Attempts records each attempt made during calibration
+	Attempts []SabotageAttempt
+	// FinalTimeout is the timeout that achieved the desired sabotage
+	FinalTimeout time.Duration
+	// PaymentOrderID is the ID of the created payment order (if any)
+	PaymentOrderID string
+	// Success indicates whether sabotage was achieved (client timeout with server processing)
+	Success bool
+}
+
+// SabotageAttempt records a single calibration attempt.
+type SabotageAttempt struct {
+	// AttemptNumber is the sequence number (1, 2, etc.)
+	AttemptNumber int
+	// Timeout is the timeout used for this attempt
+	Timeout time.Duration
+	// Duration is how long the attempt actually took
+	Duration time.Duration
+	// TimedOut indicates if the client context deadline was exceeded
+	TimedOut bool
+	// Error is the error message if the attempt failed (nil for success)
+	Error error
+	// PaymentOrderID is set if a response was received (empty if timed out)
+	PaymentOrderID string
+}
+
+// Sabotage errors.
+var (
+	ErrSabotageConfigInvalid   = errors.New("invalid sabotage configuration")
+	ErrSabotageCalibrationFail = errors.New("failed to calibrate sabotage timeout")
+	ErrSabotagePaymentFailed   = errors.New("payment failed unexpectedly")
+)
+
+// Default sabotage configuration values.
+const (
+	DefaultSabotageTimeout     = 30 * time.Millisecond
+	DefaultMinSabotageTimeout  = 10 * time.Millisecond
+	DefaultMaxSabotageAttempts = 5
+	DefaultCreditorReference   = "GB82WEST12345698765432" // Test IBAN
+)
+
+// GenerateIdempotencyKey creates a unique idempotency key for the demo.
+// Format: HORIZON-TXN-{timestamp}-{short-uuid}
+func GenerateIdempotencyKey() string {
+	timestamp := time.Now().Unix()
+	shortUUID := uuid.New().String()[:8]
+	return fmt.Sprintf("HORIZON-TXN-%d-%s", timestamp, shortUUID)
+}
+
+// GenerateCorrelationID creates a unique correlation ID for distributed tracing.
+// Format: horizon-demo-{uuid}
+func GenerateCorrelationID() string {
+	return fmt.Sprintf("horizon-demo-%s", uuid.New().String())
+}
+
+// RunSabotage executes the sabotage attempt with adaptive timeout calibration.
+// The goal is to trigger a client-side timeout while ensuring the server still
+// processes the payment request, creating a "phantom" situation where the client
+// doesn't know if the payment succeeded.
+//
+// Calibration Strategy:
+// 1. Start with InitialTimeout
+// 2. If attempt succeeds (no timeout), reduce timeout by half and retry
+// 3. If attempt times out, verify server-side state and return success
+// 4. Continue until MaxAttempts is reached or sabotage is achieved
+func RunSabotage(ctx context.Context, clients *Clients, cfg *SabotageConfig) (*SabotageResult, error) {
+	if err := validateSabotageConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// Generate unique identifiers for this sabotage run
+	idempotencyKey := GenerateIdempotencyKey()
+	correlationID := GenerateCorrelationID()
+
+	logger.Info("sabotage: starting calibration",
+		"idempotency_key", idempotencyKey,
+		"correlation_id", correlationID,
+		"initial_timeout", cfg.InitialTimeout,
+		"min_timeout", cfg.MinTimeout,
+		"max_attempts", cfg.MaxAttempts,
+	)
+
+	result := &SabotageResult{
+		IdempotencyKey: idempotencyKey,
+		CorrelationID:  correlationID,
+		Attempts:       make([]SabotageAttempt, 0, cfg.MaxAttempts),
+	}
+
+	currentTimeout := cfg.InitialTimeout
+
+	for attemptNum := 1; attemptNum <= cfg.MaxAttempts; attemptNum++ {
+		logger.Info("sabotage: attempting payment with timeout",
+			"attempt", attemptNum,
+			"timeout", currentTimeout,
+		)
+
+		attempt := executeSabotageAttempt(ctx, clients, cfg, idempotencyKey, correlationID, attemptNum, currentTimeout)
+		result.Attempts = append(result.Attempts, attempt)
+
+		if attempt.TimedOut {
+			// Success! Client timed out, which is what we want
+			logger.Info("sabotage: client timeout achieved",
+				"attempt", attemptNum,
+				"timeout", currentTimeout,
+				"duration", attempt.Duration,
+			)
+			result.Success = true
+			result.FinalTimeout = currentTimeout
+			// Note: PaymentOrderID will be empty because we timed out
+			// The retry phase will retrieve it
+			return result, nil
+		}
+
+		if attempt.Error != nil && !errors.Is(attempt.Error, context.DeadlineExceeded) {
+			// Unexpected error (not a timeout)
+			logger.Error("sabotage: unexpected error during payment",
+				"attempt", attemptNum,
+				"error", attempt.Error,
+			)
+			return result, fmt.Errorf("%w: %w", ErrSabotagePaymentFailed, attempt.Error)
+		}
+
+		// Payment succeeded without timeout - need to reduce timeout
+		if attempt.PaymentOrderID != "" {
+			result.PaymentOrderID = attempt.PaymentOrderID
+			logger.Info("sabotage: payment completed without timeout, reducing timeout",
+				"attempt", attemptNum,
+				"payment_order_id", attempt.PaymentOrderID,
+				"duration", attempt.Duration,
+			)
+		}
+
+		// Reduce timeout for next attempt
+		newTimeout := currentTimeout / 2
+		if newTimeout < cfg.MinTimeout {
+			logger.Warn("sabotage: reached minimum timeout, calibration failed",
+				"min_timeout", cfg.MinTimeout,
+				"last_timeout", currentTimeout,
+			)
+			return result, fmt.Errorf("%w: minimum timeout %v reached without achieving sabotage", ErrSabotageCalibrationFail, cfg.MinTimeout)
+		}
+		currentTimeout = newTimeout
+	}
+
+	logger.Warn("sabotage: max attempts reached without achieving timeout")
+	return result, fmt.Errorf("%w: reached max attempts (%d) without triggering timeout", ErrSabotageCalibrationFail, cfg.MaxAttempts)
+}
+
+// executeSabotageAttempt performs a single payment attempt with the specified timeout.
+func executeSabotageAttempt(
+	ctx context.Context,
+	clients *Clients,
+	cfg *SabotageConfig,
+	idempotencyKey string,
+	correlationID string,
+	attemptNum int,
+	timeout time.Duration,
+) SabotageAttempt {
+	attempt := SabotageAttempt{
+		AttemptNumber: attemptNum,
+		Timeout:       timeout,
+	}
+
+	// Create context with aggressive timeout
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Add correlation ID to context for distributed tracing
+	timeoutCtx = ContextWithCorrelationID(timeoutCtx, correlationID)
+
+	// Build the payment request
+	req := buildPaymentRequest(cfg, idempotencyKey, correlationID)
+
+	// Execute the payment
+	start := time.Now()
+	resp, err := clients.PaymentOrder.InitiatePaymentOrder(timeoutCtx, req)
+	attempt.Duration = time.Since(start)
+
+	if err != nil {
+		attempt.Error = err
+		// Check if this was a timeout
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
+			attempt.TimedOut = true
+		}
+		return attempt
+	}
+
+	// Success - payment completed within timeout
+	if resp.GetPaymentOrder() != nil {
+		attempt.PaymentOrderID = resp.GetPaymentOrder().GetPaymentOrderId()
+	}
+
+	return attempt
+}
+
+// buildPaymentRequest constructs the InitiatePaymentOrderRequest for the sabotage attempt.
+func buildPaymentRequest(cfg *SabotageConfig, idempotencyKey, correlationID string) *paymentorderv1.InitiatePaymentOrderRequest {
+	return &paymentorderv1.InitiatePaymentOrderRequest{
+		DebtorAccountId:   cfg.DebtorAccountID,
+		CreditorReference: cfg.CreditorReference,
+		Amount: &commonv1.MoneyAmount{
+			Amount: penceToPoundsPayment(cfg.AmountPence),
+		},
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: idempotencyKey,
+		},
+		CorrelationId: correlationID,
+	}
+}
+
+// penceToPoundsPayment converts pence to google.type.Money with GBP currency.
+// This is similar to preflight.go's penceToPounds but kept separate for clarity.
+func penceToPoundsPayment(pence int64) *money.Money {
+	units := pence / 100
+	fractionalPence := pence % 100
+	nanos := int32(fractionalPence) * 10000000 // #nosec G115 - safe: fractionalPence is 0-99
+
+	return &money.Money{
+		CurrencyCode: "GBP",
+		Units:        units,
+		Nanos:        nanos,
+	}
+}
+
+// validateSabotageConfig validates the sabotage configuration.
+func validateSabotageConfig(cfg *SabotageConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("%w: config is nil", ErrSabotageConfigInvalid)
+	}
+
+	if cfg.DebtorAccountID == "" {
+		return fmt.Errorf("%w: DebtorAccountID is required", ErrSabotageConfigInvalid)
+	}
+
+	if cfg.AmountPence <= 0 {
+		return fmt.Errorf("%w: AmountPence must be positive", ErrSabotageConfigInvalid)
+	}
+
+	if cfg.InitialTimeout <= 0 {
+		return fmt.Errorf("%w: InitialTimeout must be positive", ErrSabotageConfigInvalid)
+	}
+
+	if cfg.MinTimeout <= 0 {
+		return fmt.Errorf("%w: MinTimeout must be positive", ErrSabotageConfigInvalid)
+	}
+
+	if cfg.MinTimeout > cfg.InitialTimeout {
+		return fmt.Errorf("%w: MinTimeout (%v) cannot exceed InitialTimeout (%v)", ErrSabotageConfigInvalid, cfg.MinTimeout, cfg.InitialTimeout)
+	}
+
+	if cfg.MaxAttempts <= 0 {
+		return fmt.Errorf("%w: MaxAttempts must be positive", ErrSabotageConfigInvalid)
+	}
+
+	if cfg.CreditorReference == "" {
+		return fmt.Errorf("%w: CreditorReference is required", ErrSabotageConfigInvalid)
+	}
+
+	return nil
+}
+
+// DefaultSabotageConfig returns a SabotageConfig with default values.
+// Caller must set DebtorAccountID.
+func DefaultSabotageConfig() *SabotageConfig {
+	return &SabotageConfig{
+		AmountPence:       10000, // GBP 100.00
+		InitialTimeout:    DefaultSabotageTimeout,
+		MinTimeout:        DefaultMinSabotageTimeout,
+		MaxAttempts:       DefaultMaxSabotageAttempts,
+		CreditorReference: DefaultCreditorReference,
+		Logger:            slog.Default(),
+	}
+}
+
+// ToAttemptReport converts a SabotageAttempt to an AttemptReport for JSON output.
+func (a *SabotageAttempt) ToAttemptReport(idempotencyKey string) AttemptReport {
+	report := AttemptReport{
+		Attempt:        a.AttemptNumber,
+		IdempotencyKey: idempotencyKey,
+		DurationMs:     a.Duration.Milliseconds(),
+		PaymentOrderID: a.PaymentOrderID,
+	}
+
+	if a.TimedOut {
+		report.Status = AttemptStatusClientTimeout
+		if a.Error != nil {
+			report.Error = a.Error.Error()
+		} else {
+			report.Error = "context deadline exceeded"
+		}
+	} else if a.Error != nil {
+		report.Status = AttemptStatusError
+		report.Error = a.Error.Error()
+	} else {
+		report.Status = AttemptStatusSuccess
+	}
+
+	return report
+}

--- a/cmd/horizon-demo/sabotage_test.go
+++ b/cmd/horizon-demo/sabotage_test.go
@@ -1,0 +1,503 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	paymentorderv1 "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Test constants and sentinel errors.
+const testAccountID = "test-account-123"
+
+var (
+	errNotImplemented     = errors.New("not implemented")
+	errPaymentRejected    = errors.New("payment rejected: insufficient funds")
+	errServiceUnavailable = errors.New("service unavailable")
+)
+
+func TestGenerateIdempotencyKey(t *testing.T) {
+	key1 := GenerateIdempotencyKey()
+	key2 := GenerateIdempotencyKey()
+
+	// Keys should have correct prefix
+	assert.True(t, strings.HasPrefix(key1, "HORIZON-TXN-"), "key should start with HORIZON-TXN-")
+	assert.True(t, strings.HasPrefix(key2, "HORIZON-TXN-"), "key should start with HORIZON-TXN-")
+
+	// Keys should be unique
+	assert.NotEqual(t, key1, key2, "keys should be unique")
+
+	// Key should be valid format (alphanumeric with hyphens)
+	assert.Regexp(t, `^HORIZON-TXN-\d+-[a-f0-9]{8}$`, key1)
+}
+
+func TestGenerateCorrelationID(t *testing.T) {
+	id1 := GenerateCorrelationID()
+	id2 := GenerateCorrelationID()
+
+	// IDs should have correct prefix
+	assert.True(t, strings.HasPrefix(id1, "horizon-demo-"), "id should start with horizon-demo-")
+
+	// IDs should be unique
+	assert.NotEqual(t, id1, id2, "ids should be unique")
+
+	// ID should be valid UUID format after prefix
+	assert.Regexp(t, `^horizon-demo-[a-f0-9-]{36}$`, id1)
+}
+
+func TestPenceToPoundsPayment(t *testing.T) {
+	tests := []struct {
+		name          string
+		pence         int64
+		expectedUnits int64
+		expectedNanos int32
+	}{
+		{
+			name:          "100 GBP (10000 pence)",
+			pence:         10000,
+			expectedUnits: 100,
+			expectedNanos: 0,
+		},
+		{
+			name:          "1 penny",
+			pence:         1,
+			expectedUnits: 0,
+			expectedNanos: 10000000,
+		},
+		{
+			name:          "99 pence",
+			pence:         99,
+			expectedUnits: 0,
+			expectedNanos: 990000000,
+		},
+		{
+			name:          "100.99 GBP",
+			pence:         10099,
+			expectedUnits: 100,
+			expectedNanos: 990000000,
+		},
+		{
+			name:          "1000 GBP",
+			pence:         100000,
+			expectedUnits: 1000,
+			expectedNanos: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := penceToPoundsPayment(tt.pence)
+
+			assert.Equal(t, "GBP", result.GetCurrencyCode())
+			assert.Equal(t, tt.expectedUnits, result.GetUnits())
+			assert.Equal(t, tt.expectedNanos, result.GetNanos())
+		})
+	}
+}
+
+func TestValidateSabotageConfig(t *testing.T) {
+	validConfig := func() *SabotageConfig {
+		cfg := DefaultSabotageConfig()
+		cfg.DebtorAccountID = testAccountID
+		return cfg
+	}
+
+	t.Run("valid config", func(t *testing.T) {
+		err := validateSabotageConfig(validConfig())
+		assert.NoError(t, err)
+	})
+
+	t.Run("nil config", func(t *testing.T) {
+		err := validateSabotageConfig(nil)
+		assert.ErrorIs(t, err, ErrSabotageConfigInvalid)
+		assert.Contains(t, err.Error(), "nil")
+	})
+
+	t.Run("empty DebtorAccountID", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.DebtorAccountID = ""
+		err := validateSabotageConfig(cfg)
+		assert.ErrorIs(t, err, ErrSabotageConfigInvalid)
+		assert.Contains(t, err.Error(), "DebtorAccountID")
+	})
+
+	t.Run("zero AmountPence", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.AmountPence = 0
+		err := validateSabotageConfig(cfg)
+		assert.ErrorIs(t, err, ErrSabotageConfigInvalid)
+		assert.Contains(t, err.Error(), "AmountPence")
+	})
+
+	t.Run("negative AmountPence", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.AmountPence = -100
+		err := validateSabotageConfig(cfg)
+		assert.ErrorIs(t, err, ErrSabotageConfigInvalid)
+	})
+
+	t.Run("zero InitialTimeout", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.InitialTimeout = 0
+		err := validateSabotageConfig(cfg)
+		assert.ErrorIs(t, err, ErrSabotageConfigInvalid)
+		assert.Contains(t, err.Error(), "InitialTimeout")
+	})
+
+	t.Run("zero MinTimeout", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.MinTimeout = 0
+		err := validateSabotageConfig(cfg)
+		assert.ErrorIs(t, err, ErrSabotageConfigInvalid)
+		assert.Contains(t, err.Error(), "MinTimeout")
+	})
+
+	t.Run("MinTimeout exceeds InitialTimeout", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.MinTimeout = 100 * time.Millisecond
+		cfg.InitialTimeout = 50 * time.Millisecond
+		err := validateSabotageConfig(cfg)
+		assert.ErrorIs(t, err, ErrSabotageConfigInvalid)
+		assert.Contains(t, err.Error(), "exceed")
+	})
+
+	t.Run("zero MaxAttempts", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.MaxAttempts = 0
+		err := validateSabotageConfig(cfg)
+		assert.ErrorIs(t, err, ErrSabotageConfigInvalid)
+		assert.Contains(t, err.Error(), "MaxAttempts")
+	})
+
+	t.Run("empty CreditorReference", func(t *testing.T) {
+		cfg := validConfig()
+		cfg.CreditorReference = ""
+		err := validateSabotageConfig(cfg)
+		assert.ErrorIs(t, err, ErrSabotageConfigInvalid)
+		assert.Contains(t, err.Error(), "CreditorReference")
+	})
+}
+
+func TestDefaultSabotageConfig(t *testing.T) {
+	cfg := DefaultSabotageConfig()
+
+	assert.Equal(t, int64(10000), cfg.AmountPence)
+	assert.Equal(t, DefaultSabotageTimeout, cfg.InitialTimeout)
+	assert.Equal(t, DefaultMinSabotageTimeout, cfg.MinTimeout)
+	assert.Equal(t, DefaultMaxSabotageAttempts, cfg.MaxAttempts)
+	assert.Equal(t, DefaultCreditorReference, cfg.CreditorReference)
+	assert.NotNil(t, cfg.Logger)
+
+	// DebtorAccountID should be empty (caller must set it)
+	assert.Empty(t, cfg.DebtorAccountID)
+}
+
+func TestBuildPaymentRequest(t *testing.T) {
+	cfg := &SabotageConfig{
+		DebtorAccountID:   "test-account-456",
+		AmountPence:       10000,
+		CreditorReference: "GB82WEST12345698765432",
+	}
+	idempotencyKey := "HORIZON-TXN-123-abc12345"
+	correlationID := "horizon-demo-uuid-here"
+
+	req := buildPaymentRequest(cfg, idempotencyKey, correlationID)
+
+	assert.Equal(t, "test-account-456", req.GetDebtorAccountId())
+	assert.Equal(t, "GB82WEST12345698765432", req.GetCreditorReference())
+	assert.Equal(t, idempotencyKey, req.GetIdempotencyKey().GetKey())
+	assert.Equal(t, correlationID, req.GetCorrelationId())
+
+	// Verify amount conversion
+	amount := req.GetAmount().GetAmount()
+	assert.Equal(t, "GBP", amount.GetCurrencyCode())
+	assert.Equal(t, int64(100), amount.GetUnits())
+	assert.Equal(t, int32(0), amount.GetNanos())
+}
+
+// mockPaymentOrderClient implements paymentorderv1.PaymentOrderServiceClient for testing.
+type mockPaymentOrderClient struct {
+	paymentorderv1.PaymentOrderServiceClient
+	initiateFunc func(ctx context.Context, req *paymentorderv1.InitiatePaymentOrderRequest, opts ...grpc.CallOption) (*paymentorderv1.InitiatePaymentOrderResponse, error)
+}
+
+func (m *mockPaymentOrderClient) InitiatePaymentOrder(ctx context.Context, req *paymentorderv1.InitiatePaymentOrderRequest, opts ...grpc.CallOption) (*paymentorderv1.InitiatePaymentOrderResponse, error) {
+	if m.initiateFunc != nil {
+		return m.initiateFunc(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+func TestRunSabotage_ClientTimeout(t *testing.T) {
+	// Mock client that takes longer than the timeout
+	mockClient := &mockPaymentOrderClient{
+		initiateFunc: func(ctx context.Context, _ *paymentorderv1.InitiatePaymentOrderRequest, _ ...grpc.CallOption) (*paymentorderv1.InitiatePaymentOrderResponse, error) {
+			// Wait until context times out
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+	}
+
+	cfg := DefaultSabotageConfig()
+	cfg.DebtorAccountID = testAccountID
+	cfg.InitialTimeout = 20 * time.Millisecond // Short timeout to speed up test
+	cfg.MinTimeout = 5 * time.Millisecond
+
+	result, err := RunSabotage(context.Background(), clients, cfg)
+
+	require.NoError(t, err)
+	assert.True(t, result.Success, "sabotage should succeed when client times out")
+	assert.NotEmpty(t, result.IdempotencyKey)
+	assert.NotEmpty(t, result.CorrelationID)
+	assert.Equal(t, cfg.InitialTimeout, result.FinalTimeout)
+	require.Len(t, result.Attempts, 1)
+	assert.True(t, result.Attempts[0].TimedOut)
+}
+
+func TestRunSabotage_AdaptiveCalibration(t *testing.T) {
+	callCount := 0
+	// First call succeeds quickly, second call times out
+	mockClient := &mockPaymentOrderClient{
+		initiateFunc: func(ctx context.Context, _ *paymentorderv1.InitiatePaymentOrderRequest, _ ...grpc.CallOption) (*paymentorderv1.InitiatePaymentOrderResponse, error) {
+			callCount++
+			if callCount == 1 {
+				// First call: respond quickly (within timeout)
+				return &paymentorderv1.InitiatePaymentOrderResponse{
+					PaymentOrder: &paymentorderv1.PaymentOrder{
+						PaymentOrderId: "po-first-attempt",
+						Status:         paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_INITIATED,
+						CreatedAt:      timestamppb.Now(),
+						UpdatedAt:      timestamppb.Now(),
+					},
+				}, nil
+			}
+			// Subsequent calls: wait until timeout
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+	}
+
+	cfg := DefaultSabotageConfig()
+	cfg.DebtorAccountID = testAccountID
+	cfg.InitialTimeout = 100 * time.Millisecond
+	cfg.MinTimeout = 10 * time.Millisecond
+
+	result, err := RunSabotage(context.Background(), clients, cfg)
+
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, 2, len(result.Attempts), "should have 2 attempts (one success, one timeout)")
+
+	// First attempt should have succeeded without timeout
+	assert.False(t, result.Attempts[0].TimedOut)
+	assert.Equal(t, "po-first-attempt", result.Attempts[0].PaymentOrderID)
+
+	// Second attempt should have timed out
+	assert.True(t, result.Attempts[1].TimedOut)
+
+	// Final timeout should be half of initial
+	assert.Equal(t, 50*time.Millisecond, result.FinalTimeout)
+}
+
+func TestRunSabotage_CalibrationFailure(t *testing.T) {
+	// Mock client that always responds quickly
+	mockClient := &mockPaymentOrderClient{
+		initiateFunc: func(_ context.Context, _ *paymentorderv1.InitiatePaymentOrderRequest, _ ...grpc.CallOption) (*paymentorderv1.InitiatePaymentOrderResponse, error) {
+			return &paymentorderv1.InitiatePaymentOrderResponse{
+				PaymentOrder: &paymentorderv1.PaymentOrder{
+					PaymentOrderId: "po-fast-response",
+					Status:         paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_INITIATED,
+					CreatedAt:      timestamppb.Now(),
+					UpdatedAt:      timestamppb.Now(),
+				},
+			}, nil
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+	}
+
+	cfg := DefaultSabotageConfig()
+	cfg.DebtorAccountID = testAccountID
+	cfg.InitialTimeout = 100 * time.Millisecond
+	cfg.MinTimeout = 50 * time.Millisecond // High min timeout, will reach it after one halving
+	cfg.MaxAttempts = 5
+
+	result, err := RunSabotage(context.Background(), clients, cfg)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSabotageCalibrationFail)
+	assert.False(t, result.Success)
+	assert.Contains(t, err.Error(), "minimum timeout")
+}
+
+func TestRunSabotage_MaxAttemptsReached(t *testing.T) {
+	callCount := 0
+	// Mock client that always responds just before timeout
+	mockClient := &mockPaymentOrderClient{
+		initiateFunc: func(_ context.Context, _ *paymentorderv1.InitiatePaymentOrderRequest, _ ...grpc.CallOption) (*paymentorderv1.InitiatePaymentOrderResponse, error) {
+			callCount++
+			return &paymentorderv1.InitiatePaymentOrderResponse{
+				PaymentOrder: &paymentorderv1.PaymentOrder{
+					PaymentOrderId: "po-fast-response",
+					Status:         paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_INITIATED,
+					CreatedAt:      timestamppb.Now(),
+					UpdatedAt:      timestamppb.Now(),
+				},
+			}, nil
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+	}
+
+	cfg := DefaultSabotageConfig()
+	cfg.DebtorAccountID = testAccountID
+	cfg.InitialTimeout = 1 * time.Second  // Long timeout
+	cfg.MinTimeout = 1 * time.Millisecond // Very short min
+	cfg.MaxAttempts = 2                   // But only 2 attempts allowed
+
+	result, err := RunSabotage(context.Background(), clients, cfg)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSabotageCalibrationFail)
+	assert.Contains(t, err.Error(), "max attempts")
+	assert.Equal(t, 2, len(result.Attempts))
+}
+
+func TestRunSabotage_PaymentError(t *testing.T) {
+	mockClient := &mockPaymentOrderClient{
+		initiateFunc: func(_ context.Context, _ *paymentorderv1.InitiatePaymentOrderRequest, _ ...grpc.CallOption) (*paymentorderv1.InitiatePaymentOrderResponse, error) {
+			return nil, errPaymentRejected
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+	}
+
+	cfg := DefaultSabotageConfig()
+	cfg.DebtorAccountID = testAccountID
+
+	result, err := RunSabotage(context.Background(), clients, cfg)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSabotagePaymentFailed)
+	assert.False(t, result.Success)
+	require.Len(t, result.Attempts, 1)
+	assert.NotNil(t, result.Attempts[0].Error)
+}
+
+func TestRunSabotage_NilClients(t *testing.T) {
+	cfg := DefaultSabotageConfig()
+	cfg.DebtorAccountID = testAccountID
+
+	// This will panic if we don't handle nil, but the validation should catch config issues
+	// The nil client check happens at runtime during the call
+	// For this test, we're mainly checking config validation works
+	err := validateSabotageConfig(cfg)
+	assert.NoError(t, err)
+}
+
+func TestSabotageAttempt_ToAttemptReport_Timeout(t *testing.T) {
+	attempt := SabotageAttempt{
+		AttemptNumber: 1,
+		Timeout:       30 * time.Millisecond,
+		Duration:      30 * time.Millisecond,
+		TimedOut:      true,
+		Error:         context.DeadlineExceeded,
+	}
+
+	report := attempt.ToAttemptReport("HORIZON-TXN-123")
+
+	assert.Equal(t, 1, report.Attempt)
+	assert.Equal(t, "HORIZON-TXN-123", report.IdempotencyKey)
+	assert.Equal(t, AttemptStatusClientTimeout, report.Status)
+	assert.Equal(t, int64(30), report.DurationMs)
+	assert.Contains(t, report.Error, "deadline exceeded")
+	assert.Empty(t, report.PaymentOrderID)
+}
+
+func TestSabotageAttempt_ToAttemptReport_Success(t *testing.T) {
+	attempt := SabotageAttempt{
+		AttemptNumber:  2,
+		Timeout:        30 * time.Millisecond,
+		Duration:       15 * time.Millisecond,
+		TimedOut:       false,
+		PaymentOrderID: "po-xyz-123",
+	}
+
+	report := attempt.ToAttemptReport("HORIZON-TXN-456")
+
+	assert.Equal(t, 2, report.Attempt)
+	assert.Equal(t, "HORIZON-TXN-456", report.IdempotencyKey)
+	assert.Equal(t, AttemptStatusSuccess, report.Status)
+	assert.Equal(t, int64(15), report.DurationMs)
+	assert.Empty(t, report.Error)
+	assert.Equal(t, "po-xyz-123", report.PaymentOrderID)
+}
+
+func TestSabotageAttempt_ToAttemptReport_Error(t *testing.T) {
+	attempt := SabotageAttempt{
+		AttemptNumber: 1,
+		Timeout:       30 * time.Millisecond,
+		Duration:      5 * time.Millisecond,
+		TimedOut:      false,
+		Error:         errServiceUnavailable,
+	}
+
+	report := attempt.ToAttemptReport("HORIZON-TXN-789")
+
+	assert.Equal(t, AttemptStatusError, report.Status)
+	assert.Equal(t, "service unavailable", report.Error)
+}
+
+func TestExecuteSabotageAttempt_ContextCancellation(t *testing.T) {
+	mockClient := &mockPaymentOrderClient{
+		initiateFunc: func(ctx context.Context, _ *paymentorderv1.InitiatePaymentOrderRequest, _ ...grpc.CallOption) (*paymentorderv1.InitiatePaymentOrderResponse, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+	}
+
+	cfg := &SabotageConfig{
+		DebtorAccountID:   "test-account",
+		AmountPence:       10000,
+		CreditorReference: DefaultCreditorReference,
+	}
+
+	attempt := executeSabotageAttempt(
+		context.Background(),
+		clients,
+		cfg,
+		"test-key",
+		"test-correlation",
+		1,
+		10*time.Millisecond,
+	)
+
+	assert.True(t, attempt.TimedOut)
+	assert.NotNil(t, attempt.Error)
+	assert.GreaterOrEqual(t, attempt.Duration.Milliseconds(), int64(10))
+}


### PR DESCRIPTION
## Summary
- Implements sabotage mechanism for the Horizon Integrity Proof demo
- Uses `context.WithTimeout` to simulate client-side network failures
- Includes adaptive timeout calibration that progressively reduces timeout until achieving the desired behavior

## Changes Made
- **New `sabotage.go`**: Core sabotage/timeout calibration implementation
  - `GenerateIdempotencyKey()`: Creates unique keys (HORIZON-TXN-{timestamp}-{uuid})
  - `GenerateCorrelationID()`: Creates tracing IDs for distributed observability
  - `RunSabotage()`: Orchestrates the calibration with adaptive timeout reduction
  - `buildPaymentRequest()`: Constructs `InitiatePaymentOrderRequest` with proper MoneyAmount
  - `ToAttemptReport()`: Converts results to report format for JSON output

- **New `sabotage_test.go`**: Comprehensive test coverage
  - Key/ID generation tests
  - Money conversion tests
  - Config validation tests
  - Mock-based integration tests for timeout scenarios
  - Adaptive calibration behavior tests
  - Error handling tests

## Technical Details
The calibration strategy:
1. Start with `InitialTimeout` (default 30ms)
2. If payment succeeds without timeout, halve the timeout and retry
3. If client times out (context.DeadlineExceeded), sabotage succeeded
4. Continue until `MaxAttempts` reached or `MinTimeout` floor hit

This creates the "phantom transaction" scenario where the client doesn't know if the payment succeeded, but the server has processed it.

## Test Plan
- [x] All unit tests pass (`go test ./cmd/horizon-demo/...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Tests cover: timeout scenarios, adaptive calibration, calibration failures, payment errors

## Related
Task Master: 99-horizon-proof task #4