### PR TITLE
feat: Add forensic audit balance verification for Horizon integrity proof

### DIFF
--- a/cmd/horizon-demo/audit.go
+++ b/cmd/horizon-demo/audit.go
@@ -171,9 +171,22 @@ func RunAudit(ctx context.Context, clients *Clients, cfg *AuditConfig) (*AuditRe
 	}
 
 	// Extract balance using moneyToPence from preflight.go
-	result.FinalBalancePence = moneyToPence(
-		retrieveResp.GetFacility().GetCurrentBalance().GetCurrentBalance().GetAmount(),
-	)
+	// Defensive nil checks for chained gRPC getters
+	facility := retrieveResp.GetFacility()
+	if facility == nil {
+		result.Error = fmt.Errorf("%w: response has nil facility", ErrAuditBalanceRetrieval)
+		result.Verdict = AuditVerdictError
+		logger.Error("audit: nil facility in response", "account_id", cfg.AccountID)
+		return result, result.Error
+	}
+	accountBalance := facility.GetCurrentBalance()
+	if accountBalance == nil {
+		result.Error = fmt.Errorf("%w: facility has nil current_balance", ErrAuditBalanceRetrieval)
+		result.Verdict = AuditVerdictError
+		logger.Error("audit: nil current_balance in facility", "account_id", cfg.AccountID)
+		return result, result.Error
+	}
+	result.FinalBalancePence = moneyToPence(accountBalance.GetCurrentBalance().GetAmount())
 
 	logger.Info("audit: retrieved final balance",
 		"account_id", cfg.AccountID,
@@ -293,7 +306,11 @@ func DefaultAuditConfig() *AuditConfig {
 
 // NewAuditConfigFromPreFlight creates an AuditConfig from PreFlightResult.
 // This ensures the audit uses the actual values from the pre-flight phase.
+// Returns nil if preflight is nil.
 func NewAuditConfigFromPreFlight(preflight *PreFlightResult, paymentAmountPence int64, logger *slog.Logger) *AuditConfig {
+	if preflight == nil {
+		return nil
+	}
 	if logger == nil {
 		logger = slog.Default()
 	}

--- a/cmd/horizon-demo/audit.go
+++ b/cmd/horizon-demo/audit.go
@@ -1,0 +1,316 @@
+// Package main provides forensic audit functionality for the Horizon Integrity Proof demo.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+)
+
+// AuditConfig holds configuration for the forensic audit phase.
+type AuditConfig struct {
+	// AccountID is the test account to audit
+	AccountID string
+	// InitialBalancePence is the account balance before any payments
+	InitialBalancePence int64
+	// PaymentAmountPence is the expected payment amount
+	PaymentAmountPence int64
+	// Logger for structured logging
+	Logger *slog.Logger
+}
+
+// AuditResult captures the outcome of the forensic audit.
+type AuditResult struct {
+	// AccountID is the audited account
+	AccountID string
+	// InitialBalancePence is the starting balance
+	InitialBalancePence int64
+	// FinalBalancePence is the actual final balance
+	FinalBalancePence int64
+	// ExpectedBalancePence is what the balance should be (initial - payment)
+	ExpectedBalancePence int64
+	// BalanceCorrect indicates if final balance matches expected
+	BalanceCorrect bool
+	// BalanceStatus describes the balance verification outcome
+	BalanceStatus BalanceStatus
+	// TransactionsRecorded is the number of payment orders found (for future use)
+	TransactionsRecorded int
+	// NoDoubleSpend indicates exactly one transaction was recorded
+	NoDoubleSpend bool
+	// Verdict is the final audit determination
+	Verdict AuditVerdict
+	// Error captures any error during audit (nil on success)
+	Error error
+}
+
+// BalanceStatus represents the outcome of balance verification.
+type BalanceStatus int
+
+const (
+	// BalanceStatusCorrect indicates balance is exactly as expected (single payment).
+	BalanceStatusCorrect BalanceStatus = iota
+	// BalanceStatusDoubleSpend indicates balance shows two payments were deducted.
+	BalanceStatusDoubleSpend
+	// BalanceStatusNoPayment indicates no payment was executed.
+	BalanceStatusNoPayment
+	// BalanceStatusUnexpected indicates balance doesn't match any expected pattern.
+	BalanceStatusUnexpected
+)
+
+// String constants for audit status values.
+const (
+	balanceStatusCorrectStr     = "CORRECT"
+	balanceStatusDoubleSpendStr = "DOUBLE_SPEND"
+	balanceStatusNoPaymentStr   = "NO_PAYMENT"
+	balanceStatusUnexpectedStr  = "UNEXPECTED"
+	statusUnknownStr            = "UNKNOWN"
+)
+
+func (s BalanceStatus) String() string {
+	switch s {
+	case BalanceStatusCorrect:
+		return balanceStatusCorrectStr
+	case BalanceStatusDoubleSpend:
+		return balanceStatusDoubleSpendStr
+	case BalanceStatusNoPayment:
+		return balanceStatusNoPaymentStr
+	case BalanceStatusUnexpected:
+		return balanceStatusUnexpectedStr
+	default:
+		return statusUnknownStr
+	}
+}
+
+// AuditVerdict represents the final audit determination.
+type AuditVerdict int
+
+const (
+	// AuditVerdictPass indicates the system behaved correctly.
+	AuditVerdictPass AuditVerdict = iota
+	// AuditVerdictFail indicates an integrity issue was detected.
+	AuditVerdictFail
+	// AuditVerdictError indicates the audit could not complete.
+	AuditVerdictError
+)
+
+// Audit verdict string constants.
+const (
+	auditVerdictPassStr  = "PASS"
+	auditVerdictFailStr  = "FAIL"
+	auditVerdictErrorStr = "ERROR"
+)
+
+func (v AuditVerdict) String() string {
+	switch v {
+	case AuditVerdictPass:
+		return auditVerdictPassStr
+	case AuditVerdictFail:
+		return auditVerdictFailStr
+	case AuditVerdictError:
+		return auditVerdictErrorStr
+	default:
+		return statusUnknownStr
+	}
+}
+
+// Audit errors.
+var (
+	ErrAuditConfigInvalid    = errors.New("invalid audit configuration")
+	ErrAuditBalanceRetrieval = errors.New("failed to retrieve account balance")
+	ErrAuditDoubleSpend      = errors.New("double-spend detected: payment executed twice")
+	ErrAuditNoPayment        = errors.New("no payment executed: saga failed")
+	ErrAuditUnexpectedState  = errors.New("unexpected account state")
+)
+
+// RunAudit executes the forensic audit phase of the demo.
+// This verifies that exactly one payment was executed (no double-spend).
+//
+// Assertion branches:
+// 1. balance == (initial - payment): PASS - correct single deduction
+// 2. balance == (initial - 2*payment): FAIL - double-spend detected
+// 3. balance == initial: FAIL - no payment executed
+// 4. any other balance: FAIL - unexpected state
+func RunAudit(ctx context.Context, clients *Clients, cfg *AuditConfig) (*AuditResult, error) {
+	if err := validateAuditConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	result := &AuditResult{
+		AccountID:            cfg.AccountID,
+		InitialBalancePence:  cfg.InitialBalancePence,
+		ExpectedBalancePence: cfg.InitialBalancePence - cfg.PaymentAmountPence,
+	}
+
+	logger.Info("audit: starting balance verification",
+		"account_id", cfg.AccountID,
+		"initial_balance_pence", cfg.InitialBalancePence,
+		"payment_amount_pence", cfg.PaymentAmountPence,
+		"expected_balance_pence", result.ExpectedBalancePence,
+	)
+
+	// Retrieve current account balance
+	retrieveResp, err := clients.CurrentAccount.RetrieveCurrentAccount(ctx, &currentaccountv1.RetrieveCurrentAccountRequest{
+		AccountId: cfg.AccountID,
+	})
+	if err != nil {
+		result.Error = fmt.Errorf("%w: %w", ErrAuditBalanceRetrieval, err)
+		result.Verdict = AuditVerdictError
+		logger.Error("audit: failed to retrieve account balance",
+			"account_id", cfg.AccountID,
+			"error", err,
+		)
+		return result, result.Error
+	}
+
+	// Extract balance using moneyToPence from preflight.go
+	result.FinalBalancePence = moneyToPence(
+		retrieveResp.GetFacility().GetCurrentBalance().GetCurrentBalance().GetAmount(),
+	)
+
+	logger.Info("audit: retrieved final balance",
+		"account_id", cfg.AccountID,
+		"final_balance_pence", result.FinalBalancePence,
+		"final_balance_gbp", fmt.Sprintf("%.2f", float64(result.FinalBalancePence)/100),
+	)
+
+	// Calculate expected values for assertion branches
+	expectedSinglePayment := cfg.InitialBalancePence - cfg.PaymentAmountPence
+	expectedDoublePayment := cfg.InitialBalancePence - (2 * cfg.PaymentAmountPence)
+	expectedNoPayment := cfg.InitialBalancePence
+
+	// Perform assertion branches
+	switch result.FinalBalancePence {
+	case expectedSinglePayment:
+		// PASS: Correct single deduction
+		result.BalanceCorrect = true
+		result.BalanceStatus = BalanceStatusCorrect
+		result.TransactionsRecorded = 1
+		result.NoDoubleSpend = true
+		result.Verdict = AuditVerdictPass
+
+		logger.Info("audit: PASS - correct single deduction",
+			"account_id", cfg.AccountID,
+			"final_balance_pence", result.FinalBalancePence,
+			"expected_balance_pence", expectedSinglePayment,
+		)
+
+	case expectedDoublePayment:
+		// FAIL: Double-spend detected
+		result.BalanceCorrect = false
+		result.BalanceStatus = BalanceStatusDoubleSpend
+		result.TransactionsRecorded = 2
+		result.NoDoubleSpend = false
+		result.Verdict = AuditVerdictFail
+		result.Error = ErrAuditDoubleSpend
+
+		logger.Error("audit: FAIL - double-spend detected",
+			"account_id", cfg.AccountID,
+			"final_balance_pence", result.FinalBalancePence,
+			"expected_balance_pence", expectedSinglePayment,
+			"double_spend_balance", expectedDoublePayment,
+		)
+
+	case expectedNoPayment:
+		// FAIL: No payment executed
+		result.BalanceCorrect = false
+		result.BalanceStatus = BalanceStatusNoPayment
+		result.TransactionsRecorded = 0
+		result.NoDoubleSpend = true // Technically true, but saga failed
+		result.Verdict = AuditVerdictFail
+		result.Error = ErrAuditNoPayment
+
+		logger.Error("audit: FAIL - no payment executed (saga failed)",
+			"account_id", cfg.AccountID,
+			"final_balance_pence", result.FinalBalancePence,
+			"initial_balance_pence", cfg.InitialBalancePence,
+		)
+
+	default:
+		// FAIL: Unexpected state
+		result.BalanceCorrect = false
+		result.BalanceStatus = BalanceStatusUnexpected
+		result.TransactionsRecorded = -1 // Unknown
+		result.NoDoubleSpend = false
+		result.Verdict = AuditVerdictFail
+		result.Error = fmt.Errorf("%w: balance %d pence does not match any expected value",
+			ErrAuditUnexpectedState, result.FinalBalancePence)
+
+		logger.Error("audit: FAIL - unexpected account state",
+			"account_id", cfg.AccountID,
+			"final_balance_pence", result.FinalBalancePence,
+			"expected_single_payment", expectedSinglePayment,
+			"expected_double_payment", expectedDoublePayment,
+			"expected_no_payment", expectedNoPayment,
+		)
+	}
+
+	return result, result.Error
+}
+
+// validateAuditConfig validates the audit configuration.
+func validateAuditConfig(cfg *AuditConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("%w: config is nil", ErrAuditConfigInvalid)
+	}
+
+	if cfg.AccountID == "" {
+		return fmt.Errorf("%w: AccountID is required", ErrAuditConfigInvalid)
+	}
+
+	if cfg.InitialBalancePence <= 0 {
+		return fmt.Errorf("%w: InitialBalancePence must be positive", ErrAuditConfigInvalid)
+	}
+
+	if cfg.PaymentAmountPence <= 0 {
+		return fmt.Errorf("%w: PaymentAmountPence must be positive", ErrAuditConfigInvalid)
+	}
+
+	if cfg.PaymentAmountPence > cfg.InitialBalancePence {
+		return fmt.Errorf("%w: PaymentAmountPence (%d) cannot exceed InitialBalancePence (%d)",
+			ErrAuditConfigInvalid, cfg.PaymentAmountPence, cfg.InitialBalancePence)
+	}
+
+	return nil
+}
+
+// DefaultAuditConfig returns an AuditConfig with default values.
+// Caller must set AccountID.
+func DefaultAuditConfig() *AuditConfig {
+	return &AuditConfig{
+		InitialBalancePence: 100000, // GBP 1,000.00
+		PaymentAmountPence:  10000,  // GBP 100.00
+		Logger:              slog.Default(),
+	}
+}
+
+// NewAuditConfigFromPreFlight creates an AuditConfig from PreFlightResult.
+// This ensures the audit uses the actual values from the pre-flight phase.
+func NewAuditConfigFromPreFlight(preflight *PreFlightResult, paymentAmountPence int64, logger *slog.Logger) *AuditConfig {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &AuditConfig{
+		AccountID:           preflight.AccountID,
+		InitialBalancePence: preflight.InitialBalancePence,
+		PaymentAmountPence:  paymentAmountPence,
+		Logger:              logger,
+	}
+}
+
+// ToVerificationReport converts an AuditResult to a VerificationReport for the JSON report.
+func (r *AuditResult) ToVerificationReport(requestsSent int) VerificationReport {
+	return VerificationReport{
+		RequestsSent:         requestsSent,
+		TransactionsRecorded: r.TransactionsRecorded,
+		BalanceCorrect:       r.BalanceCorrect,
+		NoDoubleSpend:        r.NoDoubleSpend,
+	}
+}

--- a/cmd/horizon-demo/audit_test.go
+++ b/cmd/horizon-demo/audit_test.go
@@ -386,6 +386,82 @@ func TestRunAudit_ServiceError(t *testing.T) {
 	}
 }
 
+func TestRunAudit_NilFacility(t *testing.T) {
+	mockClient := &mockAuditCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest, _ ...grpc.CallOption) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			// Return response with nil facility
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: nil,
+			}, nil
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+	}
+
+	cfg := &AuditConfig{
+		AccountID:           auditTestAccountID,
+		InitialBalancePence: auditTestInitialBalance,
+		PaymentAmountPence:  auditTestPaymentAmount,
+		Logger:              slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunAudit(ctx, clients, cfg)
+
+	if err == nil {
+		t.Fatal("expected error for nil facility, got nil")
+	}
+
+	if !errors.Is(err, ErrAuditBalanceRetrieval) {
+		t.Errorf("expected ErrAuditBalanceRetrieval, got %v", err)
+	}
+
+	if result.Verdict != AuditVerdictError {
+		t.Errorf("expected Verdict %v, got %v", AuditVerdictError, result.Verdict)
+	}
+}
+
+func TestRunAudit_NilCurrentBalance(t *testing.T) {
+	mockClient := &mockAuditCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest, _ ...grpc.CallOption) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			// Return response with nil current balance
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					CurrentBalance: nil,
+				},
+			}, nil
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+	}
+
+	cfg := &AuditConfig{
+		AccountID:           auditTestAccountID,
+		InitialBalancePence: auditTestInitialBalance,
+		PaymentAmountPence:  auditTestPaymentAmount,
+		Logger:              slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunAudit(ctx, clients, cfg)
+
+	if err == nil {
+		t.Fatal("expected error for nil current balance, got nil")
+	}
+
+	if !errors.Is(err, ErrAuditBalanceRetrieval) {
+		t.Errorf("expected ErrAuditBalanceRetrieval, got %v", err)
+	}
+
+	if result.Verdict != AuditVerdictError {
+		t.Errorf("expected Verdict %v, got %v", AuditVerdictError, result.Verdict)
+	}
+}
+
 func TestRunAudit_InvalidConfig(t *testing.T) {
 	clients := &Clients{}
 
@@ -436,6 +512,14 @@ func TestNewAuditConfigFromPreFlight(t *testing.T) {
 
 	if cfg.Logger == nil {
 		t.Error("expected Logger to be set")
+	}
+}
+
+func TestNewAuditConfigFromPreFlight_NilPreflight(t *testing.T) {
+	cfg := NewAuditConfigFromPreFlight(nil, auditTestPaymentAmount, nil)
+
+	if cfg != nil {
+		t.Errorf("expected nil config for nil preflight, got %+v", cfg)
 	}
 }
 

--- a/cmd/horizon-demo/audit_test.go
+++ b/cmd/horizon-demo/audit_test.go
@@ -1,0 +1,542 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	money "google.golang.org/genproto/googleapis/type/money"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Test constants for audit tests.
+const (
+	auditTestAccountID       = "audit-test-account-123"
+	auditTestInitialBalance  = int64(100000) // GBP 1,000.00
+	auditTestPaymentAmount   = int64(10000)  // GBP 100.00
+	auditTestExpectedBalance = int64(90000)  // GBP 900.00 (single payment)
+	auditTestDoubleSpendBal  = int64(80000)  // GBP 800.00 (double payment)
+)
+
+// Static errors for audit tests.
+var (
+	errAuditServiceUnavailable = errors.New("current account service unavailable")
+)
+
+// mockAuditCurrentAccountClient implements CurrentAccountServiceClient for audit tests.
+type mockAuditCurrentAccountClient struct {
+	currentaccountv1.CurrentAccountServiceClient
+	retrieveFunc func(ctx context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest, opts ...grpc.CallOption) (*currentaccountv1.RetrieveCurrentAccountResponse, error)
+}
+
+func (m *mockAuditCurrentAccountClient) RetrieveCurrentAccount(ctx context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest, opts ...grpc.CallOption) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+	if m.retrieveFunc != nil {
+		return m.retrieveFunc(ctx, req, opts...)
+	}
+	return nil, errNotImplemented
+}
+
+// createMockBalanceResponse creates a RetrieveCurrentAccountResponse with the given balance in pence.
+func createMockBalanceResponse(balancePence int64) *currentaccountv1.RetrieveCurrentAccountResponse {
+	units := balancePence / 100
+	nanos := int32((balancePence % 100) * 10000000)
+
+	return &currentaccountv1.RetrieveCurrentAccountResponse{
+		Facility: &currentaccountv1.CurrentAccountFacility{
+			CurrentBalance: &currentaccountv1.AccountBalance{
+				CurrentBalance: &commonv1.MoneyAmount{
+					Amount: &money.Money{
+						CurrencyCode: "GBP",
+						Units:        units,
+						Nanos:        nanos,
+					},
+				},
+				AvailableBalance: &commonv1.MoneyAmount{
+					Amount: &money.Money{
+						CurrencyCode: "GBP",
+						Units:        units,
+						Nanos:        nanos,
+					},
+				},
+				LastUpdated: timestamppb.Now(),
+			},
+		},
+	}
+}
+
+func TestValidateAuditConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *AuditConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantErr: true,
+			errMsg:  "config is nil",
+		},
+		{
+			name: "missing account ID",
+			cfg: &AuditConfig{
+				InitialBalancePence: auditTestInitialBalance,
+				PaymentAmountPence:  auditTestPaymentAmount,
+			},
+			wantErr: true,
+			errMsg:  "AccountID is required",
+		},
+		{
+			name: "zero initial balance",
+			cfg: &AuditConfig{
+				AccountID:           auditTestAccountID,
+				InitialBalancePence: 0,
+				PaymentAmountPence:  auditTestPaymentAmount,
+			},
+			wantErr: true,
+			errMsg:  "InitialBalancePence must be positive",
+		},
+		{
+			name: "negative initial balance",
+			cfg: &AuditConfig{
+				AccountID:           auditTestAccountID,
+				InitialBalancePence: -1000,
+				PaymentAmountPence:  auditTestPaymentAmount,
+			},
+			wantErr: true,
+			errMsg:  "InitialBalancePence must be positive",
+		},
+		{
+			name: "zero payment amount",
+			cfg: &AuditConfig{
+				AccountID:           auditTestAccountID,
+				InitialBalancePence: auditTestInitialBalance,
+				PaymentAmountPence:  0,
+			},
+			wantErr: true,
+			errMsg:  "PaymentAmountPence must be positive",
+		},
+		{
+			name: "payment exceeds balance",
+			cfg: &AuditConfig{
+				AccountID:           auditTestAccountID,
+				InitialBalancePence: auditTestPaymentAmount,
+				PaymentAmountPence:  auditTestInitialBalance,
+			},
+			wantErr: true,
+			errMsg:  "PaymentAmountPence",
+		},
+		{
+			name: "valid config",
+			cfg: &AuditConfig{
+				AccountID:           auditTestAccountID,
+				InitialBalancePence: auditTestInitialBalance,
+				PaymentAmountPence:  auditTestPaymentAmount,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAuditConfig(tt.cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errMsg)
+					return
+				}
+				if !errors.Is(err, ErrAuditConfigInvalid) {
+					t.Errorf("expected ErrAuditConfigInvalid, got %v", err)
+				}
+				if tt.errMsg != "" && !containsString(err.Error(), tt.errMsg) {
+					t.Errorf("expected error containing %q, got %q", tt.errMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunAudit_CorrectSinglePayment(t *testing.T) {
+	mockClient := &mockAuditCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest, _ ...grpc.CallOption) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			if req.GetAccountId() != auditTestAccountID {
+				t.Errorf("expected account ID %q, got %q", auditTestAccountID, req.GetAccountId())
+			}
+			// Return correct balance (single payment executed)
+			return createMockBalanceResponse(auditTestExpectedBalance), nil
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+	}
+
+	cfg := &AuditConfig{
+		AccountID:           auditTestAccountID,
+		InitialBalancePence: auditTestInitialBalance,
+		PaymentAmountPence:  auditTestPaymentAmount,
+		Logger:              slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunAudit(ctx, clients, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Verdict != AuditVerdictPass {
+		t.Errorf("expected Verdict %v, got %v", AuditVerdictPass, result.Verdict)
+	}
+
+	if !result.BalanceCorrect {
+		t.Error("expected BalanceCorrect to be true")
+	}
+
+	if result.BalanceStatus != BalanceStatusCorrect {
+		t.Errorf("expected BalanceStatus %v, got %v", BalanceStatusCorrect, result.BalanceStatus)
+	}
+
+	if result.TransactionsRecorded != 1 {
+		t.Errorf("expected TransactionsRecorded 1, got %d", result.TransactionsRecorded)
+	}
+
+	if !result.NoDoubleSpend {
+		t.Error("expected NoDoubleSpend to be true")
+	}
+
+	if result.FinalBalancePence != auditTestExpectedBalance {
+		t.Errorf("expected FinalBalancePence %d, got %d", auditTestExpectedBalance, result.FinalBalancePence)
+	}
+}
+
+func TestRunAudit_DoubleSpendDetected(t *testing.T) {
+	mockClient := &mockAuditCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest, _ ...grpc.CallOption) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			// Return double-spend balance (two payments executed)
+			return createMockBalanceResponse(auditTestDoubleSpendBal), nil
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+	}
+
+	cfg := &AuditConfig{
+		AccountID:           auditTestAccountID,
+		InitialBalancePence: auditTestInitialBalance,
+		PaymentAmountPence:  auditTestPaymentAmount,
+		Logger:              slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunAudit(ctx, clients, cfg)
+
+	if err == nil {
+		t.Fatal("expected error for double-spend, got nil")
+	}
+
+	if !errors.Is(err, ErrAuditDoubleSpend) {
+		t.Errorf("expected ErrAuditDoubleSpend, got %v", err)
+	}
+
+	if result.Verdict != AuditVerdictFail {
+		t.Errorf("expected Verdict %v, got %v", AuditVerdictFail, result.Verdict)
+	}
+
+	if result.BalanceCorrect {
+		t.Error("expected BalanceCorrect to be false")
+	}
+
+	if result.BalanceStatus != BalanceStatusDoubleSpend {
+		t.Errorf("expected BalanceStatus %v, got %v", BalanceStatusDoubleSpend, result.BalanceStatus)
+	}
+
+	if result.TransactionsRecorded != 2 {
+		t.Errorf("expected TransactionsRecorded 2, got %d", result.TransactionsRecorded)
+	}
+
+	if result.NoDoubleSpend {
+		t.Error("expected NoDoubleSpend to be false")
+	}
+}
+
+func TestRunAudit_NoPaymentExecuted(t *testing.T) {
+	mockClient := &mockAuditCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest, _ ...grpc.CallOption) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			// Return initial balance (no payment executed)
+			return createMockBalanceResponse(auditTestInitialBalance), nil
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+	}
+
+	cfg := &AuditConfig{
+		AccountID:           auditTestAccountID,
+		InitialBalancePence: auditTestInitialBalance,
+		PaymentAmountPence:  auditTestPaymentAmount,
+		Logger:              slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunAudit(ctx, clients, cfg)
+
+	if err == nil {
+		t.Fatal("expected error for no payment, got nil")
+	}
+
+	if !errors.Is(err, ErrAuditNoPayment) {
+		t.Errorf("expected ErrAuditNoPayment, got %v", err)
+	}
+
+	if result.Verdict != AuditVerdictFail {
+		t.Errorf("expected Verdict %v, got %v", AuditVerdictFail, result.Verdict)
+	}
+
+	if result.BalanceStatus != BalanceStatusNoPayment {
+		t.Errorf("expected BalanceStatus %v, got %v", BalanceStatusNoPayment, result.BalanceStatus)
+	}
+
+	if result.TransactionsRecorded != 0 {
+		t.Errorf("expected TransactionsRecorded 0, got %d", result.TransactionsRecorded)
+	}
+}
+
+func TestRunAudit_UnexpectedBalance(t *testing.T) {
+	mockClient := &mockAuditCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest, _ ...grpc.CallOption) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			// Return unexpected balance (e.g., partial payment or other anomaly)
+			return createMockBalanceResponse(95000), nil // GBP 950.00 - doesn't match any expected
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+	}
+
+	cfg := &AuditConfig{
+		AccountID:           auditTestAccountID,
+		InitialBalancePence: auditTestInitialBalance,
+		PaymentAmountPence:  auditTestPaymentAmount,
+		Logger:              slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunAudit(ctx, clients, cfg)
+
+	if err == nil {
+		t.Fatal("expected error for unexpected balance, got nil")
+	}
+
+	if !errors.Is(err, ErrAuditUnexpectedState) {
+		t.Errorf("expected ErrAuditUnexpectedState, got %v", err)
+	}
+
+	if result.Verdict != AuditVerdictFail {
+		t.Errorf("expected Verdict %v, got %v", AuditVerdictFail, result.Verdict)
+	}
+
+	if result.BalanceStatus != BalanceStatusUnexpected {
+		t.Errorf("expected BalanceStatus %v, got %v", BalanceStatusUnexpected, result.BalanceStatus)
+	}
+
+	if result.TransactionsRecorded != -1 {
+		t.Errorf("expected TransactionsRecorded -1 (unknown), got %d", result.TransactionsRecorded)
+	}
+}
+
+func TestRunAudit_ServiceError(t *testing.T) {
+	mockClient := &mockAuditCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest, _ ...grpc.CallOption) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return nil, errAuditServiceUnavailable
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+	}
+
+	cfg := &AuditConfig{
+		AccountID:           auditTestAccountID,
+		InitialBalancePence: auditTestInitialBalance,
+		PaymentAmountPence:  auditTestPaymentAmount,
+		Logger:              slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunAudit(ctx, clients, cfg)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !errors.Is(err, ErrAuditBalanceRetrieval) {
+		t.Errorf("expected ErrAuditBalanceRetrieval, got %v", err)
+	}
+
+	if result.Verdict != AuditVerdictError {
+		t.Errorf("expected Verdict %v, got %v", AuditVerdictError, result.Verdict)
+	}
+}
+
+func TestRunAudit_InvalidConfig(t *testing.T) {
+	clients := &Clients{}
+
+	result, err := RunAudit(context.Background(), clients, nil)
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+	if result != nil {
+		t.Error("expected nil result for invalid config")
+	}
+}
+
+func TestDefaultAuditConfig(t *testing.T) {
+	cfg := DefaultAuditConfig()
+
+	if cfg.InitialBalancePence != 100000 {
+		t.Errorf("expected InitialBalancePence 100000, got %d", cfg.InitialBalancePence)
+	}
+
+	if cfg.PaymentAmountPence != 10000 {
+		t.Errorf("expected PaymentAmountPence 10000, got %d", cfg.PaymentAmountPence)
+	}
+
+	if cfg.Logger == nil {
+		t.Error("expected Logger to be set")
+	}
+}
+
+func TestNewAuditConfigFromPreFlight(t *testing.T) {
+	preflight := &PreFlightResult{
+		AccountID:           auditTestAccountID,
+		InitialBalancePence: auditTestInitialBalance,
+	}
+
+	cfg := NewAuditConfigFromPreFlight(preflight, auditTestPaymentAmount, nil)
+
+	if cfg.AccountID != auditTestAccountID {
+		t.Errorf("expected AccountID %q, got %q", auditTestAccountID, cfg.AccountID)
+	}
+
+	if cfg.InitialBalancePence != auditTestInitialBalance {
+		t.Errorf("expected InitialBalancePence %d, got %d", auditTestInitialBalance, cfg.InitialBalancePence)
+	}
+
+	if cfg.PaymentAmountPence != auditTestPaymentAmount {
+		t.Errorf("expected PaymentAmountPence %d, got %d", auditTestPaymentAmount, cfg.PaymentAmountPence)
+	}
+
+	if cfg.Logger == nil {
+		t.Error("expected Logger to be set")
+	}
+}
+
+func TestAuditResult_ToVerificationReport(t *testing.T) {
+	result := &AuditResult{
+		BalanceCorrect:       true,
+		TransactionsRecorded: 1,
+		NoDoubleSpend:        true,
+	}
+
+	report := result.ToVerificationReport(2)
+
+	if report.RequestsSent != 2 {
+		t.Errorf("expected RequestsSent 2, got %d", report.RequestsSent)
+	}
+
+	if report.TransactionsRecorded != 1 {
+		t.Errorf("expected TransactionsRecorded 1, got %d", report.TransactionsRecorded)
+	}
+
+	if !report.BalanceCorrect {
+		t.Error("expected BalanceCorrect to be true")
+	}
+
+	if !report.NoDoubleSpend {
+		t.Error("expected NoDoubleSpend to be true")
+	}
+}
+
+func TestBalanceStatus_String(t *testing.T) {
+	tests := []struct {
+		status   BalanceStatus
+		expected string
+	}{
+		{BalanceStatusCorrect, "CORRECT"},
+		{BalanceStatusDoubleSpend, "DOUBLE_SPEND"},
+		{BalanceStatusNoPayment, "NO_PAYMENT"},
+		{BalanceStatusUnexpected, "UNEXPECTED"},
+		{BalanceStatus(99), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.status.String(); got != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestAuditVerdict_String(t *testing.T) {
+	tests := []struct {
+		verdict  AuditVerdict
+		expected string
+	}{
+		{AuditVerdictPass, "PASS"},
+		{AuditVerdictFail, "FAIL"},
+		{AuditVerdictError, "ERROR"},
+		{AuditVerdict(99), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.verdict.String(); got != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestRunAudit_WithFractionalBalance(t *testing.T) {
+	// Test with a balance that has fractional pence (e.g., 90050 pence = GBP 900.50)
+	mockClient := &mockAuditCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest, _ ...grpc.CallOption) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			// GBP 900.50 = 90050 pence
+			return createMockBalanceResponse(90050), nil
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+	}
+
+	cfg := &AuditConfig{
+		AccountID:           auditTestAccountID,
+		InitialBalancePence: 100050, // GBP 1,000.50
+		PaymentAmountPence:  10000,  // GBP 100.00
+		Logger:              slog.Default(),
+	}
+
+	ctx := context.Background()
+	result, err := RunAudit(ctx, clients, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Verdict != AuditVerdictPass {
+		t.Errorf("expected Verdict %v, got %v", AuditVerdictPass, result.Verdict)
+	}
+
+	if result.FinalBalancePence != 90050 {
+		t.Errorf("expected FinalBalancePence 90050, got %d", result.FinalBalancePence)
+	}
+}


### PR DESCRIPTION
## Summary
- Implement balance verification to detect double-spend or failed payment scenarios
- Query final account balance via RetrieveCurrentAccount after payment attempts
- Assert balance matches expected value (initial - payment amount)

## Changes Made
- `cmd/horizon-demo/audit.go`: Core forensic audit logic
  - `AuditConfig` for audit parameters (account ID, initial balance, payment amount)
  - `AuditResult` capturing verdict, balance status, transaction count
  - `RunAudit()` with three assertion branches:
    - PASS: balance = initial - payment (correct single deduction)
    - FAIL: balance = initial - 2*payment (double-spend detected)
    - FAIL: balance = initial (no payment executed)
  - `NewAuditConfigFromPreFlight()` for integration with pre-flight phase
  - `ToVerificationReport()` for JSON report integration
- `cmd/horizon-demo/audit_test.go`: Comprehensive test coverage
  - Config validation tests
  - All assertion branch scenarios (correct, double-spend, no payment, unexpected)
  - Service error handling
  - Fractional balance handling

## Technical Details
- Uses existing `moneyToPence()` from preflight.go for balance conversion
- Balance path: `Facility.GetCurrentBalance().GetCurrentBalance().GetAmount()`
- Integrates with existing Report/VerificationReport structures

## Testing
- All unit tests pass locally
- Lint checks pass

## Risk Assessment
Low risk - new code only, no modifications to existing functionality.

## Deployment Notes
No deployment steps required - CLI tool enhancement.