### PR TITLE
feat: Add PaymentOrder uniqueness verification for Horizon integrity proof

### DIFF
--- a/cmd/horizon-demo/audit_lien.go
+++ b/cmd/horizon-demo/audit_lien.go
@@ -1,0 +1,219 @@
+// Package main provides lien verification for the Horizon Integrity Proof demo.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+)
+
+// LienAuditConfig holds configuration for the lien verification audit.
+type LienAuditConfig struct {
+	// LienID is the lien to verify (obtained from PaymentOrder)
+	LienID string
+	// AccountID is the expected account for the lien
+	AccountID string
+	// Logger for structured logging
+	Logger *slog.Logger
+}
+
+// LienAuditResult captures the outcome of the lien verification.
+type LienAuditResult struct {
+	// LienID is the audited lien
+	LienID string
+	// AccountID is the lien's account
+	AccountID string
+	// LienStatus is the current status of the lien
+	LienStatus string
+	// ExpectedStatus is what the status should be (EXECUTED for completed payments)
+	ExpectedStatus string
+	// IsOrphaned indicates if the lien is still ACTIVE (orphaned reservation)
+	IsOrphaned bool
+	// Verdict is the audit determination for this check
+	Verdict AuditVerdict
+	// Error captures any error during audit (nil on success)
+	Error error
+}
+
+// Lien audit errors.
+var (
+	ErrLienAuditConfigInvalid    = errors.New("invalid lien audit configuration")
+	ErrLienAuditRetrieveFailed   = errors.New("failed to retrieve lien")
+	ErrLienAuditOrphaned         = errors.New("orphaned lien detected: lien still ACTIVE after payment completion")
+	ErrLienAuditUnexpectedStatus = errors.New("lien in unexpected status")
+)
+
+// RunLienAudit executes the lien verification.
+// This retrieves the lien by ID and verifies it is in EXECUTED status (not ACTIVE).
+//
+// Assertion branches:
+// 1. Lien status == EXECUTED: PASS - lien was properly converted to debit
+// 2. Lien status == ACTIVE: WARN - orphaned lien (reservation not released)
+// 3. Lien status == TERMINATED: INFO - lien was released without execution (saga compensation)
+// 4. Lien not found or error: ERROR - cannot verify
+//
+// This is a non-blocking check - orphaned liens are logged as warnings but don't fail the demo.
+func RunLienAudit(ctx context.Context, clients *Clients, cfg *LienAuditConfig) (*LienAuditResult, error) {
+	if err := validateLienAuditConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	result := &LienAuditResult{
+		LienID:         cfg.LienID,
+		AccountID:      cfg.AccountID,
+		ExpectedStatus: currentaccountv1.LienStatus_LIEN_STATUS_EXECUTED.String(),
+	}
+
+	logger.Info("lien audit: starting verification",
+		"lien_id", cfg.LienID,
+		"account_id", cfg.AccountID,
+	)
+
+	// Retrieve lien details
+	retrieveResp, err := clients.CurrentAccount.RetrieveLien(ctx, &currentaccountv1.RetrieveLienRequest{
+		LienId: cfg.LienID,
+	})
+	if err != nil {
+		result.Error = fmt.Errorf("%w: %w", ErrLienAuditRetrieveFailed, err)
+		result.Verdict = AuditVerdictError
+		logger.Error("lien audit: failed to retrieve lien",
+			"lien_id", cfg.LienID,
+			"error", err,
+		)
+		return result, result.Error
+	}
+
+	lien := retrieveResp.GetLien()
+	if lien == nil {
+		result.Error = fmt.Errorf("%w: response has nil lien", ErrLienAuditRetrieveFailed)
+		result.Verdict = AuditVerdictError
+		logger.Error("lien audit: nil lien in response", "lien_id", cfg.LienID)
+		return result, result.Error
+	}
+
+	result.LienStatus = lien.GetStatus().String()
+
+	// Verify lien belongs to expected account
+	if lien.GetAccountId() != cfg.AccountID {
+		logger.Warn("lien audit: lien account mismatch",
+			"lien_id", cfg.LienID,
+			"expected_account", cfg.AccountID,
+			"actual_account", lien.GetAccountId(),
+		)
+	}
+
+	logger.Info("lien audit: retrieved lien",
+		"lien_id", cfg.LienID,
+		"status", result.LienStatus,
+		"account_id", lien.GetAccountId(),
+	)
+
+	// Perform assertion branches
+	switch lien.GetStatus() {
+	case currentaccountv1.LienStatus_LIEN_STATUS_EXECUTED:
+		// PASS: Lien was properly converted to debit
+		result.IsOrphaned = false
+		result.Verdict = AuditVerdictPass
+
+		logger.Info("lien audit: PASS - lien executed correctly",
+			"lien_id", cfg.LienID,
+			"status", result.LienStatus,
+		)
+
+	case currentaccountv1.LienStatus_LIEN_STATUS_ACTIVE:
+		// WARN: Orphaned lien - reservation not released
+		result.IsOrphaned = true
+		result.Verdict = AuditVerdictPass // Non-blocking, just informational
+		result.Error = ErrLienAuditOrphaned
+
+		logger.Warn("lien audit: WARN - orphaned lien detected",
+			"lien_id", cfg.LienID,
+			"status", result.LienStatus,
+			"message", "lien still ACTIVE after payment, may indicate saga compensation bug",
+		)
+
+	case currentaccountv1.LienStatus_LIEN_STATUS_TERMINATED:
+		// INFO: Lien was released without execution (saga compensation path)
+		result.IsOrphaned = false
+		result.Verdict = AuditVerdictPass // Valid state for compensated transactions
+
+		logger.Info("lien audit: INFO - lien terminated (saga compensation)",
+			"lien_id", cfg.LienID,
+			"status", result.LienStatus,
+		)
+
+	case currentaccountv1.LienStatus_LIEN_STATUS_UNSPECIFIED:
+		// WARN: Unspecified status (should not occur in practice)
+		result.IsOrphaned = false
+		result.Verdict = AuditVerdictPass // Non-blocking
+		result.Error = fmt.Errorf("%w: got %s", ErrLienAuditUnexpectedStatus, result.LienStatus)
+
+		logger.Warn("lien audit: WARN - unexpected lien status",
+			"lien_id", cfg.LienID,
+			"status", result.LienStatus,
+		)
+	}
+
+	return result, nil // Return nil error for non-blocking checks
+}
+
+// validateLienAuditConfig validates the lien audit configuration.
+func validateLienAuditConfig(cfg *LienAuditConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("%w: config is nil", ErrLienAuditConfigInvalid)
+	}
+
+	if cfg.LienID == "" {
+		return fmt.Errorf("%w: LienID is required", ErrLienAuditConfigInvalid)
+	}
+
+	if cfg.AccountID == "" {
+		return fmt.Errorf("%w: AccountID is required", ErrLienAuditConfigInvalid)
+	}
+
+	return nil
+}
+
+// NewLienAuditConfig creates a LienAuditConfig with the given parameters.
+func NewLienAuditConfig(lienID, accountID string, logger *slog.Logger) *LienAuditConfig {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &LienAuditConfig{
+		LienID:    lienID,
+		AccountID: accountID,
+		Logger:    logger,
+	}
+}
+
+// NewLienAuditConfigFromOrderAudit creates a LienAuditConfig from an OrderAuditResult.
+// Returns nil if no matching orders were found or if the order has no lien ID.
+func NewLienAuditConfigFromOrderAudit(orderResult *OrderAuditResult, logger *slog.Logger) *LienAuditConfig {
+	if orderResult == nil || len(orderResult.MatchingOrders) == 0 {
+		return nil
+	}
+
+	// Use the first matching order's lien ID
+	lienID := orderResult.MatchingOrders[0].LienID
+	if lienID == "" {
+		return nil
+	}
+
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &LienAuditConfig{
+		LienID:    lienID,
+		AccountID: orderResult.AccountID,
+		Logger:    logger,
+	}
+}

--- a/cmd/horizon-demo/audit_lien_test.go
+++ b/cmd/horizon-demo/audit_lien_test.go
@@ -1,0 +1,447 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Test errors for lien audit tests.
+var errLienServiceUnavailable = errors.New("lien service unavailable")
+
+// mockCurrentAccountLienClient implements CurrentAccountServiceClient for lien audit testing.
+type mockCurrentAccountLienClient struct {
+	currentaccountv1.CurrentAccountServiceClient
+	retrieveLienResponse *currentaccountv1.RetrieveLienResponse
+	retrieveLienError    error
+}
+
+func (m *mockCurrentAccountLienClient) RetrieveLien(
+	_ context.Context,
+	_ *currentaccountv1.RetrieveLienRequest,
+	_ ...grpc.CallOption,
+) (*currentaccountv1.RetrieveLienResponse, error) {
+	if m.retrieveLienError != nil {
+		return nil, m.retrieveLienError
+	}
+	return m.retrieveLienResponse, nil
+}
+
+func TestValidateLienAuditConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *LienAuditConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantErr: true,
+			errMsg:  "config is nil",
+		},
+		{
+			name: "empty LienID",
+			cfg: &LienAuditConfig{
+				AccountID: "test-account",
+			},
+			wantErr: true,
+			errMsg:  "LienID is required",
+		},
+		{
+			name: "empty AccountID",
+			cfg: &LienAuditConfig{
+				LienID: "test-lien",
+			},
+			wantErr: true,
+			errMsg:  "AccountID is required",
+		},
+		{
+			name: "valid config",
+			cfg: &LienAuditConfig{
+				LienID:    "test-lien",
+				AccountID: "test-account",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateLienAuditConfig(tt.cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.True(t, errors.Is(err, ErrLienAuditConfigInvalid))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRunLienAudit_LienExecuted(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockCurrentAccountLienClient{
+		retrieveLienResponse: &currentaccountv1.RetrieveLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId:    "lien-123",
+				AccountId: "test-account",
+				Status:    currentaccountv1.LienStatus_LIEN_STATUS_EXECUTED,
+				CreatedAt: timestamppb.Now(),
+				UpdatedAt: timestamppb.Now(),
+			},
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         logger,
+	}
+
+	cfg := &LienAuditConfig{
+		LienID:    "lien-123",
+		AccountID: "test-account",
+		Logger:    logger,
+	}
+
+	result, err := RunLienAudit(ctx, clients, cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "lien-123", result.LienID)
+	assert.Equal(t, "test-account", result.AccountID)
+	assert.Equal(t, "LIEN_STATUS_EXECUTED", result.LienStatus)
+	assert.False(t, result.IsOrphaned)
+	assert.Equal(t, AuditVerdictPass, result.Verdict)
+	assert.Nil(t, result.Error)
+}
+
+func TestRunLienAudit_LienActive_Orphaned(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockCurrentAccountLienClient{
+		retrieveLienResponse: &currentaccountv1.RetrieveLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId:    "lien-123",
+				AccountId: "test-account",
+				Status:    currentaccountv1.LienStatus_LIEN_STATUS_ACTIVE,
+				CreatedAt: timestamppb.Now(),
+				UpdatedAt: timestamppb.Now(),
+			},
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         logger,
+	}
+
+	cfg := &LienAuditConfig{
+		LienID:    "lien-123",
+		AccountID: "test-account",
+		Logger:    logger,
+	}
+
+	result, err := RunLienAudit(ctx, clients, cfg)
+
+	// Non-blocking check returns nil error but sets IsOrphaned
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "LIEN_STATUS_ACTIVE", result.LienStatus)
+	assert.True(t, result.IsOrphaned)
+	assert.Equal(t, AuditVerdictPass, result.Verdict) // Non-blocking
+	assert.True(t, errors.Is(result.Error, ErrLienAuditOrphaned))
+}
+
+func TestRunLienAudit_LienTerminated(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockCurrentAccountLienClient{
+		retrieveLienResponse: &currentaccountv1.RetrieveLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId:    "lien-123",
+				AccountId: "test-account",
+				Status:    currentaccountv1.LienStatus_LIEN_STATUS_TERMINATED,
+				CreatedAt: timestamppb.Now(),
+				UpdatedAt: timestamppb.Now(),
+			},
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         logger,
+	}
+
+	cfg := &LienAuditConfig{
+		LienID:    "lien-123",
+		AccountID: "test-account",
+		Logger:    logger,
+	}
+
+	result, err := RunLienAudit(ctx, clients, cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "LIEN_STATUS_TERMINATED", result.LienStatus)
+	assert.False(t, result.IsOrphaned)
+	assert.Equal(t, AuditVerdictPass, result.Verdict)
+	assert.Nil(t, result.Error)
+}
+
+func TestRunLienAudit_RetrieveError(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockCurrentAccountLienClient{
+		retrieveLienError: errLienServiceUnavailable,
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         logger,
+	}
+
+	cfg := &LienAuditConfig{
+		LienID:    "lien-123",
+		AccountID: "test-account",
+		Logger:    logger,
+	}
+
+	result, err := RunLienAudit(ctx, clients, cfg)
+
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, AuditVerdictError, result.Verdict)
+	assert.True(t, errors.Is(result.Error, ErrLienAuditRetrieveFailed))
+}
+
+func TestRunLienAudit_NilLienInResponse(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockCurrentAccountLienClient{
+		retrieveLienResponse: &currentaccountv1.RetrieveLienResponse{
+			Lien: nil, // nil lien
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         logger,
+	}
+
+	cfg := &LienAuditConfig{
+		LienID:    "lien-123",
+		AccountID: "test-account",
+		Logger:    logger,
+	}
+
+	result, err := RunLienAudit(ctx, clients, cfg)
+
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, AuditVerdictError, result.Verdict)
+	assert.True(t, errors.Is(result.Error, ErrLienAuditRetrieveFailed))
+}
+
+func TestRunLienAudit_AccountMismatch(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockCurrentAccountLienClient{
+		retrieveLienResponse: &currentaccountv1.RetrieveLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId:    "lien-123",
+				AccountId: "different-account", // Different from config
+				Status:    currentaccountv1.LienStatus_LIEN_STATUS_EXECUTED,
+				CreatedAt: timestamppb.Now(),
+				UpdatedAt: timestamppb.Now(),
+			},
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         logger,
+	}
+
+	cfg := &LienAuditConfig{
+		LienID:    "lien-123",
+		AccountID: "test-account",
+		Logger:    logger,
+	}
+
+	result, err := RunLienAudit(ctx, clients, cfg)
+
+	// Should still pass but logs a warning about account mismatch
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, AuditVerdictPass, result.Verdict)
+}
+
+func TestRunLienAudit_NilConfig(t *testing.T) {
+	ctx := context.Background()
+	clients := &Clients{
+		logger: slog.Default(),
+	}
+
+	result, err := RunLienAudit(ctx, clients, nil)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.True(t, errors.Is(err, ErrLienAuditConfigInvalid))
+}
+
+func TestRunLienAudit_NilLogger(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockCurrentAccountLienClient{
+		retrieveLienResponse: &currentaccountv1.RetrieveLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId:    "lien-123",
+				AccountId: "test-account",
+				Status:    currentaccountv1.LienStatus_LIEN_STATUS_EXECUTED,
+				CreatedAt: timestamppb.Now(),
+				UpdatedAt: timestamppb.Now(),
+			},
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         slog.Default(),
+	}
+
+	cfg := &LienAuditConfig{
+		LienID:    "lien-123",
+		AccountID: "test-account",
+		Logger:    nil, // nil logger should default to slog.Default()
+	}
+
+	result, err := RunLienAudit(ctx, clients, cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, AuditVerdictPass, result.Verdict)
+}
+
+func TestNewLienAuditConfig(t *testing.T) {
+	logger := slog.Default()
+
+	cfg := NewLienAuditConfig("lien-123", "account-456", logger)
+
+	require.NotNil(t, cfg)
+	assert.Equal(t, "lien-123", cfg.LienID)
+	assert.Equal(t, "account-456", cfg.AccountID)
+	assert.Equal(t, logger, cfg.Logger)
+}
+
+func TestNewLienAuditConfig_NilLogger(t *testing.T) {
+	cfg := NewLienAuditConfig("lien-123", "account-456", nil)
+
+	require.NotNil(t, cfg)
+	assert.Equal(t, "lien-123", cfg.LienID)
+	assert.Equal(t, "account-456", cfg.AccountID)
+	assert.NotNil(t, cfg.Logger) // Should default to slog.Default()
+}
+
+func TestNewLienAuditConfigFromOrderAudit(t *testing.T) {
+	logger := slog.Default()
+
+	orderResult := &OrderAuditResult{
+		AccountID: "test-account",
+		MatchingOrders: []PaymentOrderSummary{
+			{
+				PaymentOrderID: "order-123",
+				LienID:         "lien-456",
+			},
+		},
+	}
+
+	cfg := NewLienAuditConfigFromOrderAudit(orderResult, logger)
+
+	require.NotNil(t, cfg)
+	assert.Equal(t, "lien-456", cfg.LienID)
+	assert.Equal(t, "test-account", cfg.AccountID)
+	assert.Equal(t, logger, cfg.Logger)
+}
+
+func TestNewLienAuditConfigFromOrderAudit_NilResult(t *testing.T) {
+	cfg := NewLienAuditConfigFromOrderAudit(nil, slog.Default())
+	assert.Nil(t, cfg)
+}
+
+func TestNewLienAuditConfigFromOrderAudit_NoMatchingOrders(t *testing.T) {
+	orderResult := &OrderAuditResult{
+		AccountID:      "test-account",
+		MatchingOrders: []PaymentOrderSummary{},
+	}
+
+	cfg := NewLienAuditConfigFromOrderAudit(orderResult, slog.Default())
+	assert.Nil(t, cfg)
+}
+
+func TestNewLienAuditConfigFromOrderAudit_EmptyLienID(t *testing.T) {
+	orderResult := &OrderAuditResult{
+		AccountID: "test-account",
+		MatchingOrders: []PaymentOrderSummary{
+			{
+				PaymentOrderID: "order-123",
+				LienID:         "", // Empty lien ID
+			},
+		},
+	}
+
+	cfg := NewLienAuditConfigFromOrderAudit(orderResult, slog.Default())
+	assert.Nil(t, cfg)
+}
+
+func TestRunLienAudit_UnexpectedStatus(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockCurrentAccountLienClient{
+		retrieveLienResponse: &currentaccountv1.RetrieveLienResponse{
+			Lien: &currentaccountv1.Lien{
+				LienId:    "lien-123",
+				AccountId: "test-account",
+				Status:    currentaccountv1.LienStatus_LIEN_STATUS_UNSPECIFIED, // Unexpected
+				CreatedAt: timestamppb.Now(),
+				UpdatedAt: timestamppb.Now(),
+			},
+		},
+	}
+
+	clients := &Clients{
+		CurrentAccount: mockClient,
+		logger:         logger,
+	}
+
+	cfg := &LienAuditConfig{
+		LienID:    "lien-123",
+		AccountID: "test-account",
+		Logger:    logger,
+	}
+
+	result, err := RunLienAudit(ctx, clients, cfg)
+
+	require.NoError(t, err) // Non-blocking
+	require.NotNil(t, result)
+	assert.Equal(t, "LIEN_STATUS_UNSPECIFIED", result.LienStatus)
+	assert.False(t, result.IsOrphaned)
+	assert.Equal(t, AuditVerdictPass, result.Verdict) // Non-blocking
+	assert.True(t, errors.Is(result.Error, ErrLienAuditUnexpectedStatus))
+}

--- a/cmd/horizon-demo/audit_orders.go
+++ b/cmd/horizon-demo/audit_orders.go
@@ -73,6 +73,7 @@ const (
 	orderStatusUniqueFoundStr     = "UNIQUE_FOUND"
 	orderStatusDuplicatesFoundStr = "DUPLICATES_FOUND"
 	orderStatusNoneFoundStr       = "NONE_FOUND"
+	orderStatusUnknownStr         = "UNKNOWN"
 )
 
 func (s OrderStatus) String() string {
@@ -84,7 +85,7 @@ func (s OrderStatus) String() string {
 	case OrderStatusNoneFound:
 		return orderStatusNoneFoundStr
 	default:
-		return statusUnknownStr
+		return orderStatusUnknownStr
 	}
 }
 

--- a/cmd/horizon-demo/audit_orders.go
+++ b/cmd/horizon-demo/audit_orders.go
@@ -1,0 +1,259 @@
+// Package main provides PaymentOrder uniqueness verification for the Horizon Integrity Proof demo.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	paymentorderv1 "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+)
+
+// OrderAuditConfig holds configuration for the PaymentOrder uniqueness audit.
+type OrderAuditConfig struct {
+	// AccountID is the debtor account to query
+	AccountID string
+	// IdempotencyKey is the key used for the demo payment
+	IdempotencyKey string
+	// Logger for structured logging
+	Logger *slog.Logger
+}
+
+// OrderAuditResult captures the outcome of the PaymentOrder uniqueness verification.
+type OrderAuditResult struct {
+	// AccountID is the audited account
+	AccountID string
+	// IdempotencyKey is the key that was verified
+	IdempotencyKey string
+	// OrdersFound is the number of PaymentOrders matching the IdempotencyKey
+	OrdersFound int
+	// MatchingOrders contains details of orders with matching idempotency key
+	MatchingOrders []PaymentOrderSummary
+	// DuplicateOrdersFound indicates if more than one order has the same idempotency key
+	DuplicateOrdersFound bool
+	// OrderStatus describes the uniqueness verification outcome
+	OrderStatus OrderStatus
+	// Verdict is the audit determination for this check
+	Verdict AuditVerdict
+	// Error captures any error during audit (nil on success)
+	Error error
+}
+
+// PaymentOrderSummary holds key fields from a PaymentOrder for audit reporting.
+type PaymentOrderSummary struct {
+	// PaymentOrderID is the unique identifier
+	PaymentOrderID string
+	// Status is the order status (COMPLETED, EXECUTING, etc.)
+	Status string
+	// LienID is the associated reservation ID
+	LienID string
+	// GatewayReferenceID is the external gateway reference
+	GatewayReferenceID string
+	// CreatedAt is when the order was created
+	CreatedAt string
+	// UpdatedAt is when the order was last modified
+	UpdatedAt string
+}
+
+// OrderStatus represents the outcome of PaymentOrder uniqueness verification.
+type OrderStatus int
+
+const (
+	// OrderStatusUniqueFound indicates exactly one order was found (correct).
+	OrderStatusUniqueFound OrderStatus = iota
+	// OrderStatusDuplicatesFound indicates multiple orders with same idempotency key (breach).
+	OrderStatusDuplicatesFound
+	// OrderStatusNoneFound indicates no orders were found (saga never persisted).
+	OrderStatusNoneFound
+)
+
+// OrderStatus string constants.
+const (
+	orderStatusUniqueFoundStr     = "UNIQUE_FOUND"
+	orderStatusDuplicatesFoundStr = "DUPLICATES_FOUND"
+	orderStatusNoneFoundStr       = "NONE_FOUND"
+)
+
+func (s OrderStatus) String() string {
+	switch s {
+	case OrderStatusUniqueFound:
+		return orderStatusUniqueFoundStr
+	case OrderStatusDuplicatesFound:
+		return orderStatusDuplicatesFoundStr
+	case OrderStatusNoneFound:
+		return orderStatusNoneFoundStr
+	default:
+		return statusUnknownStr
+	}
+}
+
+// PaymentOrder audit errors.
+var (
+	ErrOrderAuditConfigInvalid = errors.New("invalid order audit configuration")
+	ErrOrderAuditListFailed    = errors.New("failed to list payment orders")
+	ErrOrderAuditDuplicates    = errors.New("idempotency breach: multiple orders with same key")
+	ErrOrderAuditNoneFound     = errors.New("no payment orders found: saga never persisted")
+)
+
+// RunOrderAudit executes the PaymentOrder uniqueness verification.
+// This queries PaymentOrders by debtor_account_id and filters by IdempotencyKey.
+//
+// Assertion branches:
+// 1. Exactly 1 order found: PASS - idempotency working correctly
+// 2. More than 1 order found: FAIL - idempotency breach detected
+// 3. No orders found: FAIL - saga never persisted the order
+func RunOrderAudit(ctx context.Context, clients *Clients, cfg *OrderAuditConfig) (*OrderAuditResult, error) {
+	if err := validateOrderAuditConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	result := &OrderAuditResult{
+		AccountID:      cfg.AccountID,
+		IdempotencyKey: cfg.IdempotencyKey,
+		MatchingOrders: make([]PaymentOrderSummary, 0),
+	}
+
+	logger.Info("order audit: starting uniqueness verification",
+		"account_id", cfg.AccountID,
+		"idempotency_key", cfg.IdempotencyKey,
+	)
+
+	// Query PaymentOrders for the debtor account
+	listResp, err := clients.PaymentOrder.ListPaymentOrders(ctx, &paymentorderv1.ListPaymentOrdersRequest{
+		DebtorAccountId: cfg.AccountID,
+	})
+	if err != nil {
+		result.Error = fmt.Errorf("%w: %w", ErrOrderAuditListFailed, err)
+		result.Verdict = AuditVerdictError
+		logger.Error("order audit: failed to list payment orders",
+			"account_id", cfg.AccountID,
+			"error", err,
+		)
+		return result, result.Error
+	}
+
+	// Filter orders by idempotency key
+	var matchingOrders []*paymentorderv1.PaymentOrder
+	for _, order := range listResp.GetPaymentOrders() {
+		if order.GetIdempotencyKey() == cfg.IdempotencyKey {
+			matchingOrders = append(matchingOrders, order)
+		}
+	}
+
+	result.OrdersFound = len(matchingOrders)
+
+	// Convert matching orders to summaries
+	for _, order := range matchingOrders {
+		summary := PaymentOrderSummary{
+			PaymentOrderID:     order.GetPaymentOrderId(),
+			Status:             order.GetStatus().String(),
+			LienID:             order.GetLienId(),
+			GatewayReferenceID: order.GetGatewayReferenceId(),
+		}
+		if order.GetCreatedAt() != nil {
+			summary.CreatedAt = order.GetCreatedAt().AsTime().String()
+		}
+		if order.GetUpdatedAt() != nil {
+			summary.UpdatedAt = order.GetUpdatedAt().AsTime().String()
+		}
+		result.MatchingOrders = append(result.MatchingOrders, summary)
+	}
+
+	logger.Info("order audit: found orders with matching idempotency key",
+		"account_id", cfg.AccountID,
+		"idempotency_key", cfg.IdempotencyKey,
+		"orders_found", result.OrdersFound,
+	)
+
+	// Perform assertion branches
+	switch {
+	case result.OrdersFound == 1:
+		// PASS: Exactly one order found - idempotency working correctly
+		result.DuplicateOrdersFound = false
+		result.OrderStatus = OrderStatusUniqueFound
+		result.Verdict = AuditVerdictPass
+
+		order := matchingOrders[0]
+		logger.Info("order audit: PASS - unique order found",
+			"account_id", cfg.AccountID,
+			"idempotency_key", cfg.IdempotencyKey,
+			"payment_order_id", order.GetPaymentOrderId(),
+			"status", order.GetStatus().String(),
+		)
+
+		// Verify order is in a valid state (COMPLETED, EXECUTING, or RESERVED)
+		status := order.GetStatus()
+		if status != paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED &&
+			status != paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_EXECUTING &&
+			status != paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_RESERVED {
+			logger.Warn("order audit: order in unexpected state",
+				"payment_order_id", order.GetPaymentOrderId(),
+				"status", status.String(),
+			)
+		}
+
+	case result.OrdersFound > 1:
+		// FAIL: Multiple orders with same idempotency key - breach detected
+		result.DuplicateOrdersFound = true
+		result.OrderStatus = OrderStatusDuplicatesFound
+		result.Verdict = AuditVerdictFail
+		result.Error = fmt.Errorf("%w: found %d orders with key %s",
+			ErrOrderAuditDuplicates, result.OrdersFound, cfg.IdempotencyKey)
+
+		logger.Error("order audit: FAIL - duplicate orders detected",
+			"account_id", cfg.AccountID,
+			"idempotency_key", cfg.IdempotencyKey,
+			"orders_found", result.OrdersFound,
+		)
+
+	default:
+		// FAIL: No orders found - saga never persisted
+		result.DuplicateOrdersFound = false
+		result.OrderStatus = OrderStatusNoneFound
+		result.Verdict = AuditVerdictFail
+		result.Error = fmt.Errorf("%w: no orders for key %s",
+			ErrOrderAuditNoneFound, cfg.IdempotencyKey)
+
+		logger.Error("order audit: FAIL - no orders found",
+			"account_id", cfg.AccountID,
+			"idempotency_key", cfg.IdempotencyKey,
+		)
+	}
+
+	return result, result.Error
+}
+
+// validateOrderAuditConfig validates the order audit configuration.
+func validateOrderAuditConfig(cfg *OrderAuditConfig) error {
+	if cfg == nil {
+		return fmt.Errorf("%w: config is nil", ErrOrderAuditConfigInvalid)
+	}
+
+	if cfg.AccountID == "" {
+		return fmt.Errorf("%w: AccountID is required", ErrOrderAuditConfigInvalid)
+	}
+
+	if cfg.IdempotencyKey == "" {
+		return fmt.Errorf("%w: IdempotencyKey is required", ErrOrderAuditConfigInvalid)
+	}
+
+	return nil
+}
+
+// NewOrderAuditConfig creates an OrderAuditConfig with the given parameters.
+func NewOrderAuditConfig(accountID, idempotencyKey string, logger *slog.Logger) *OrderAuditConfig {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OrderAuditConfig{
+		AccountID:      accountID,
+		IdempotencyKey: idempotencyKey,
+		Logger:         logger,
+	}
+}

--- a/cmd/horizon-demo/audit_orders_test.go
+++ b/cmd/horizon-demo/audit_orders_test.go
@@ -1,0 +1,512 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	paymentorderv1 "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Test errors for order audit tests.
+var errListServiceUnavailable = errors.New("list service unavailable")
+
+// mockPaymentOrderListClient implements PaymentOrderServiceClient for order audit testing.
+type mockPaymentOrderListClient struct {
+	paymentorderv1.PaymentOrderServiceClient
+	listResponse *paymentorderv1.ListPaymentOrdersResponse
+	listError    error
+}
+
+func (m *mockPaymentOrderListClient) ListPaymentOrders(
+	_ context.Context,
+	_ *paymentorderv1.ListPaymentOrdersRequest,
+	_ ...grpc.CallOption,
+) (*paymentorderv1.ListPaymentOrdersResponse, error) {
+	if m.listError != nil {
+		return nil, m.listError
+	}
+	return m.listResponse, nil
+}
+
+func TestValidateOrderAuditConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     *OrderAuditConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil config",
+			cfg:     nil,
+			wantErr: true,
+			errMsg:  "config is nil",
+		},
+		{
+			name: "empty AccountID",
+			cfg: &OrderAuditConfig{
+				IdempotencyKey: "test-key",
+			},
+			wantErr: true,
+			errMsg:  "AccountID is required",
+		},
+		{
+			name: "empty IdempotencyKey",
+			cfg: &OrderAuditConfig{
+				AccountID: "test-account",
+			},
+			wantErr: true,
+			errMsg:  "IdempotencyKey is required",
+		},
+		{
+			name: "valid config",
+			cfg: &OrderAuditConfig{
+				AccountID:      "test-account",
+				IdempotencyKey: "test-key",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOrderAuditConfig(tt.cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.True(t, errors.Is(err, ErrOrderAuditConfigInvalid))
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRunOrderAudit_UniqueOrderFound(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockPaymentOrderListClient{
+		listResponse: &paymentorderv1.ListPaymentOrdersResponse{
+			PaymentOrders: []*paymentorderv1.PaymentOrder{
+				{
+					PaymentOrderId:     "order-123",
+					DebtorAccountId:    "test-account",
+					IdempotencyKey:     "test-key-123",
+					Status:             paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					LienId:             "lien-456",
+					GatewayReferenceId: "gateway-789",
+					CreatedAt:          timestamppb.Now(),
+					UpdatedAt:          timestamppb.Now(),
+				},
+			},
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+		logger:       logger,
+	}
+
+	cfg := &OrderAuditConfig{
+		AccountID:      "test-account",
+		IdempotencyKey: "test-key-123",
+		Logger:         logger,
+	}
+
+	result, err := RunOrderAudit(ctx, clients, cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "test-account", result.AccountID)
+	assert.Equal(t, "test-key-123", result.IdempotencyKey)
+	assert.Equal(t, 1, result.OrdersFound)
+	assert.False(t, result.DuplicateOrdersFound)
+	assert.Equal(t, OrderStatusUniqueFound, result.OrderStatus)
+	assert.Equal(t, AuditVerdictPass, result.Verdict)
+	assert.Nil(t, result.Error)
+
+	// Verify order summary
+	require.Len(t, result.MatchingOrders, 1)
+	assert.Equal(t, "order-123", result.MatchingOrders[0].PaymentOrderID)
+	assert.Equal(t, "PAYMENT_ORDER_STATUS_COMPLETED", result.MatchingOrders[0].Status)
+	assert.Equal(t, "lien-456", result.MatchingOrders[0].LienID)
+	assert.Equal(t, "gateway-789", result.MatchingOrders[0].GatewayReferenceID)
+}
+
+func TestRunOrderAudit_DuplicatesFound(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockPaymentOrderListClient{
+		listResponse: &paymentorderv1.ListPaymentOrdersResponse{
+			PaymentOrders: []*paymentorderv1.PaymentOrder{
+				{
+					PaymentOrderId:  "order-123",
+					DebtorAccountId: "test-account",
+					IdempotencyKey:  "duplicate-key",
+					Status:          paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					CreatedAt:       timestamppb.Now(),
+					UpdatedAt:       timestamppb.Now(),
+				},
+				{
+					PaymentOrderId:  "order-456",
+					DebtorAccountId: "test-account",
+					IdempotencyKey:  "duplicate-key",
+					Status:          paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					CreatedAt:       timestamppb.Now(),
+					UpdatedAt:       timestamppb.Now(),
+				},
+			},
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+		logger:       logger,
+	}
+
+	cfg := &OrderAuditConfig{
+		AccountID:      "test-account",
+		IdempotencyKey: "duplicate-key",
+		Logger:         logger,
+	}
+
+	result, err := RunOrderAudit(ctx, clients, cfg)
+
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 2, result.OrdersFound)
+	assert.True(t, result.DuplicateOrdersFound)
+	assert.Equal(t, OrderStatusDuplicatesFound, result.OrderStatus)
+	assert.Equal(t, AuditVerdictFail, result.Verdict)
+	assert.True(t, errors.Is(result.Error, ErrOrderAuditDuplicates))
+	assert.Len(t, result.MatchingOrders, 2)
+}
+
+func TestRunOrderAudit_NoneFound(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockPaymentOrderListClient{
+		listResponse: &paymentorderv1.ListPaymentOrdersResponse{
+			PaymentOrders: []*paymentorderv1.PaymentOrder{
+				{
+					PaymentOrderId:  "order-999",
+					DebtorAccountId: "test-account",
+					IdempotencyKey:  "other-key", // Different key
+					Status:          paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					CreatedAt:       timestamppb.Now(),
+					UpdatedAt:       timestamppb.Now(),
+				},
+			},
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+		logger:       logger,
+	}
+
+	cfg := &OrderAuditConfig{
+		AccountID:      "test-account",
+		IdempotencyKey: "missing-key",
+		Logger:         logger,
+	}
+
+	result, err := RunOrderAudit(ctx, clients, cfg)
+
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 0, result.OrdersFound)
+	assert.False(t, result.DuplicateOrdersFound)
+	assert.Equal(t, OrderStatusNoneFound, result.OrderStatus)
+	assert.Equal(t, AuditVerdictFail, result.Verdict)
+	assert.True(t, errors.Is(result.Error, ErrOrderAuditNoneFound))
+	assert.Empty(t, result.MatchingOrders)
+}
+
+func TestRunOrderAudit_EmptyResponse(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockPaymentOrderListClient{
+		listResponse: &paymentorderv1.ListPaymentOrdersResponse{
+			PaymentOrders: []*paymentorderv1.PaymentOrder{},
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+		logger:       logger,
+	}
+
+	cfg := &OrderAuditConfig{
+		AccountID:      "test-account",
+		IdempotencyKey: "any-key",
+		Logger:         logger,
+	}
+
+	result, err := RunOrderAudit(ctx, clients, cfg)
+
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 0, result.OrdersFound)
+	assert.Equal(t, OrderStatusNoneFound, result.OrderStatus)
+	assert.Equal(t, AuditVerdictFail, result.Verdict)
+}
+
+func TestRunOrderAudit_ListError(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockPaymentOrderListClient{
+		listError: errListServiceUnavailable,
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+		logger:       logger,
+	}
+
+	cfg := &OrderAuditConfig{
+		AccountID:      "test-account",
+		IdempotencyKey: "test-key",
+		Logger:         logger,
+	}
+
+	result, err := RunOrderAudit(ctx, clients, cfg)
+
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, AuditVerdictError, result.Verdict)
+	assert.True(t, errors.Is(result.Error, ErrOrderAuditListFailed))
+}
+
+func TestRunOrderAudit_FiltersByIdempotencyKey(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	// Response contains multiple orders but only one matches the idempotency key
+	mockClient := &mockPaymentOrderListClient{
+		listResponse: &paymentorderv1.ListPaymentOrdersResponse{
+			PaymentOrders: []*paymentorderv1.PaymentOrder{
+				{
+					PaymentOrderId:  "order-1",
+					DebtorAccountId: "test-account",
+					IdempotencyKey:  "key-A",
+					Status:          paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					CreatedAt:       timestamppb.Now(),
+					UpdatedAt:       timestamppb.Now(),
+				},
+				{
+					PaymentOrderId:  "order-2",
+					DebtorAccountId: "test-account",
+					IdempotencyKey:  "target-key",
+					Status:          paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					CreatedAt:       timestamppb.Now(),
+					UpdatedAt:       timestamppb.Now(),
+				},
+				{
+					PaymentOrderId:  "order-3",
+					DebtorAccountId: "test-account",
+					IdempotencyKey:  "key-B",
+					Status:          paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					CreatedAt:       timestamppb.Now(),
+					UpdatedAt:       timestamppb.Now(),
+				},
+			},
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+		logger:       logger,
+	}
+
+	cfg := &OrderAuditConfig{
+		AccountID:      "test-account",
+		IdempotencyKey: "target-key",
+		Logger:         logger,
+	}
+
+	result, err := RunOrderAudit(ctx, clients, cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, 1, result.OrdersFound)
+	assert.Equal(t, OrderStatusUniqueFound, result.OrderStatus)
+	assert.Equal(t, AuditVerdictPass, result.Verdict)
+	require.Len(t, result.MatchingOrders, 1)
+	assert.Equal(t, "order-2", result.MatchingOrders[0].PaymentOrderID)
+}
+
+func TestRunOrderAudit_ExecutingStatus(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockPaymentOrderListClient{
+		listResponse: &paymentorderv1.ListPaymentOrdersResponse{
+			PaymentOrders: []*paymentorderv1.PaymentOrder{
+				{
+					PaymentOrderId:  "order-123",
+					DebtorAccountId: "test-account",
+					IdempotencyKey:  "test-key",
+					Status:          paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_EXECUTING,
+					CreatedAt:       timestamppb.Now(),
+					UpdatedAt:       timestamppb.Now(),
+				},
+			},
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+		logger:       logger,
+	}
+
+	cfg := &OrderAuditConfig{
+		AccountID:      "test-account",
+		IdempotencyKey: "test-key",
+		Logger:         logger,
+	}
+
+	result, err := RunOrderAudit(ctx, clients, cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, AuditVerdictPass, result.Verdict)
+	assert.Equal(t, "PAYMENT_ORDER_STATUS_EXECUTING", result.MatchingOrders[0].Status)
+}
+
+func TestRunOrderAudit_NilLogger(t *testing.T) {
+	ctx := context.Background()
+
+	mockClient := &mockPaymentOrderListClient{
+		listResponse: &paymentorderv1.ListPaymentOrdersResponse{
+			PaymentOrders: []*paymentorderv1.PaymentOrder{
+				{
+					PaymentOrderId:  "order-123",
+					DebtorAccountId: "test-account",
+					IdempotencyKey:  "test-key",
+					Status:          paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					CreatedAt:       timestamppb.Now(),
+					UpdatedAt:       timestamppb.Now(),
+				},
+			},
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+		logger:       slog.Default(),
+	}
+
+	cfg := &OrderAuditConfig{
+		AccountID:      "test-account",
+		IdempotencyKey: "test-key",
+		Logger:         nil, // nil logger should default to slog.Default()
+	}
+
+	result, err := RunOrderAudit(ctx, clients, cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, AuditVerdictPass, result.Verdict)
+}
+
+func TestOrderStatus_String(t *testing.T) {
+	tests := []struct {
+		status   OrderStatus
+		expected string
+	}{
+		{OrderStatusUniqueFound, "UNIQUE_FOUND"},
+		{OrderStatusDuplicatesFound, "DUPLICATES_FOUND"},
+		{OrderStatusNoneFound, "NONE_FOUND"},
+		{OrderStatus(99), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.status.String())
+		})
+	}
+}
+
+func TestNewOrderAuditConfig(t *testing.T) {
+	logger := slog.Default()
+
+	cfg := NewOrderAuditConfig("account-123", "key-456", logger)
+
+	require.NotNil(t, cfg)
+	assert.Equal(t, "account-123", cfg.AccountID)
+	assert.Equal(t, "key-456", cfg.IdempotencyKey)
+	assert.Equal(t, logger, cfg.Logger)
+}
+
+func TestNewOrderAuditConfig_NilLogger(t *testing.T) {
+	cfg := NewOrderAuditConfig("account-123", "key-456", nil)
+
+	require.NotNil(t, cfg)
+	assert.Equal(t, "account-123", cfg.AccountID)
+	assert.Equal(t, "key-456", cfg.IdempotencyKey)
+	assert.NotNil(t, cfg.Logger) // Should default to slog.Default()
+}
+
+func TestRunOrderAudit_NilConfigReturnsError(t *testing.T) {
+	ctx := context.Background()
+	clients := &Clients{
+		logger: slog.Default(),
+	}
+
+	result, err := RunOrderAudit(ctx, clients, nil)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.True(t, errors.Is(err, ErrOrderAuditConfigInvalid))
+}
+
+func TestRunOrderAudit_OrderWithNilTimestamps(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	mockClient := &mockPaymentOrderListClient{
+		listResponse: &paymentorderv1.ListPaymentOrdersResponse{
+			PaymentOrders: []*paymentorderv1.PaymentOrder{
+				{
+					PaymentOrderId:  "order-123",
+					DebtorAccountId: "test-account",
+					IdempotencyKey:  "test-key",
+					Status:          paymentorderv1.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+					CreatedAt:       nil, // nil timestamp
+					UpdatedAt:       nil, // nil timestamp
+				},
+			},
+		},
+	}
+
+	clients := &Clients{
+		PaymentOrder: mockClient,
+		logger:       logger,
+	}
+
+	cfg := &OrderAuditConfig{
+		AccountID:      "test-account",
+		IdempotencyKey: "test-key",
+		Logger:         logger,
+	}
+
+	result, err := RunOrderAudit(ctx, clients, cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, AuditVerdictPass, result.Verdict)
+	require.Len(t, result.MatchingOrders, 1)
+	assert.Empty(t, result.MatchingOrders[0].CreatedAt)
+	assert.Empty(t, result.MatchingOrders[0].UpdatedAt)
+}

--- a/cmd/horizon-demo/report.go
+++ b/cmd/horizon-demo/report.go
@@ -63,6 +63,21 @@ type VerificationReport struct {
 	BalanceCorrect bool `json:"balance_correct"`
 	// NoDoubleSpend is true if exactly one transaction was recorded
 	NoDoubleSpend bool `json:"no_double_spend"`
+	// LienVerification contains optional lien state verification (omitted if not performed)
+	LienVerification *LienVerificationReport `json:"lien_verification,omitempty"`
+}
+
+// LienVerificationReport contains the optional lien state verification results.
+// This is a stretch goal that verifies no orphaned liens exist after payment completion.
+type LienVerificationReport struct {
+	// LienID is the lien that was verified
+	LienID string `json:"lien_id"`
+	// Status is the current lien status (EXECUTED, ACTIVE, TERMINATED)
+	Status string `json:"status"`
+	// IsOrphaned is true if the lien is still ACTIVE (should have been executed/terminated)
+	IsOrphaned bool `json:"is_orphaned"`
+	// Verified is true if the lien verification completed successfully
+	Verified bool `json:"verified"`
 }
 
 // Report verdict string constants for JSON output.
@@ -125,6 +140,21 @@ func (r *Report) SetFinalBalance(finalBalanceCents int64, transactionsRecorded i
 	r.Verification.BalanceCorrect = finalBalanceCents == r.Account.ExpectedBalanceCents
 	r.Verification.NoDoubleSpend = transactionsRecorded == 1
 	r.Verdict = r.CalculateVerdict()
+}
+
+// SetLienVerification sets the optional lien verification results.
+// This is a non-blocking check that doesn't affect the overall verdict.
+func (r *Report) SetLienVerification(lienResult *LienAuditResult) {
+	if lienResult == nil {
+		return
+	}
+
+	r.Verification.LienVerification = &LienVerificationReport{
+		LienID:     lienResult.LienID,
+		Status:     lienResult.LienStatus,
+		IsOrphaned: lienResult.IsOrphaned,
+		Verified:   lienResult.Verdict != AuditVerdictError,
+	}
 }
 
 // ToJSON converts the report to a formatted JSON string.


### PR DESCRIPTION
## Summary
- Implement forensic audit to verify exactly one PaymentOrder exists for the demo's IdempotencyKey
- Add RunOrderAudit() function that queries PaymentOrders by debtor account and filters by idempotency key
- Three assertion branches: unique found (PASS), duplicates found (FAIL - idempotency breach), none found (FAIL - saga never persisted)

## Changes Made
- **cmd/horizon-demo/audit_orders.go**: New file with PaymentOrder uniqueness verification logic
  - `OrderAuditConfig` and `OrderAuditResult` types
  - `RunOrderAudit()` for querying and validating PaymentOrder uniqueness
  - `PaymentOrderSummary` type for storing order details in audit results
  - `OrderStatus` enum (UNIQUE_FOUND, DUPLICATES_FOUND, NONE_FOUND)
  
- **cmd/horizon-demo/audit_orders_test.go**: Comprehensive test coverage
  - Config validation tests
  - Unique order found (PASS)
  - Duplicate orders detected (FAIL)
  - No orders found (FAIL)
  - Service error handling
  - Idempotency key filtering across multiple orders
  - Nil timestamp handling

## Test plan
- [x] All existing tests pass
- [x] New unit tests cover all assertion branches
- [x] golangci-lint passes with no issues
- [x] Tests verify correct filtering by IdempotencyKey