### PR TITLE
fix: Disable unparam linter due to Go generics panic

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,9 @@ linters:
     - goconst        # Repeated strings that could be constants
     - gocognit       # Cognitive complexity
     - unconvert      # Remove unnecessary type conversions
-    - unparam        # Unused function parameters
+    # - unparam      # Disabled: panics on Go generics with type constraints (e.g., ~string)
+    #                # See: https://github.com/golangci/golangci-lint/issues/5254
+    #                # revive's unused-parameter rule provides similar coverage
     - nakedret       # Naked returns in long functions
     - prealloc       # Slice preallocation
     - nilerr         # Check for nil error returns
@@ -188,8 +190,7 @@ linters:
     nakedret:
       max-func-lines: 30
 
-    unparam:
-      check-exported: false
+    # unparam settings removed - linter disabled due to Go generics panic
 
     revive:
       confidence: 0.8


### PR DESCRIPTION
## Summary

- Disables unparam linter globally to prevent CI failures when analyzing code using Go generics with type constraints

## Technical Details

The unparam linter panics when analyzing Go code that uses type constraints with union types (e.g., `~string`). This is a known upstream issue in the Go types package used by unparam.

**Error observed:**
```
go/types/gcsizes.go:17: assertion failed
```

**Workaround:** Disable unparam and rely on revive's `unused-parameter` rule for similar coverage.

## References

- https://github.com/golangci/golangci-lint/issues/5254

## Test plan

- CI should pass without unparam-related panics
- Future PRs using Go generics with type constraints will lint successfully