### PR TITLE
feat: Extend JWT Claims to include meridian_tenant_id

### DIFF
--- a/internal/platform/auth/jwt.go
+++ b/internal/platform/auth/jwt.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/meridianhub/meridian/internal/platform/tenancy"
 )
 
 var (
@@ -20,14 +21,17 @@ var (
 	ErrPublicKeyNil = errors.New("public key cannot be nil")
 	// ErrTokenStringEmpty is returned when an empty token string is provided
 	ErrTokenStringEmpty = errors.New("token string cannot be empty")
+	// ErrTenantClaimMissing is returned when the tenant ID claim is missing from the token
+	ErrTenantClaimMissing = errors.New("meridian_tenant_id claim missing")
 )
 
 // Claims represents the JWT claims extracted from a validated token.
 // It contains standard JWT claims plus custom claims for user identification and authorization.
 type Claims struct {
-	UserID string   `json:"user_id"`
-	Roles  []string `json:"roles"`
-	Scopes []string `json:"scopes"`
+	UserID   string   `json:"user_id"`
+	TenantID string   `json:"meridian_tenant_id"`
+	Roles    []string `json:"roles"`
+	Scopes   []string `json:"scopes"`
 	jwt.RegisteredClaims
 }
 
@@ -88,6 +92,16 @@ func (v *JWTValidator) ValidateToken(tokenString string) (*Claims, error) {
 // Returns an empty string if the user ID claim is not present.
 func (c *Claims) GetUserID() string {
 	return c.UserID
+}
+
+// GetTenantID extracts and validates the tenant ID from the claims.
+// Returns ErrTenantClaimMissing if the meridian_tenant_id claim is absent.
+// Returns tenancy.ErrInvalidTenantID if the format is invalid.
+func (c *Claims) GetTenantID() (tenancy.TenantID, error) {
+	if c.TenantID == "" {
+		return "", ErrTenantClaimMissing
+	}
+	return tenancy.NewTenantID(c.TenantID)
 }
 
 // GetRoles extracts the roles from the validated claims.

--- a/internal/platform/auth/jwt.go
+++ b/internal/platform/auth/jwt.go
@@ -28,7 +28,8 @@ var (
 // Claims represents the JWT claims extracted from a validated token.
 // It contains standard JWT claims plus custom claims for user identification and authorization.
 type Claims struct {
-	UserID   string   `json:"user_id"`
+	UserID string `json:"user_id"`
+	// TenantID is the tenant identifier extracted from the meridian_tenant_id JWT claim.
 	TenantID string   `json:"meridian_tenant_id"`
 	Roles    []string `json:"roles"`
 	Scopes   []string `json:"scopes"`
@@ -102,6 +103,12 @@ func (c *Claims) GetTenantID() (tenancy.TenantID, error) {
 		return "", ErrTenantClaimMissing
 	}
 	return tenancy.NewTenantID(c.TenantID)
+}
+
+// HasTenantID returns true if the tenant ID claim is present.
+// Use this for quick presence checks before calling GetTenantID().
+func (c *Claims) HasTenantID() bool {
+	return c.TenantID != ""
 }
 
 // GetRoles extracts the roles from the validated claims.

--- a/internal/platform/auth/jwt_test.go
+++ b/internal/platform/auth/jwt_test.go
@@ -229,6 +229,47 @@ func TestClaims_GetTenantID(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, tenancy.TenantID("bank123"), tenantID)
 	})
+
+	t.Run("accepts single character tenant ID (min length)", func(t *testing.T) {
+		claims := &Claims{TenantID: "a"}
+		tenantID, err := claims.GetTenantID()
+		assert.NoError(t, err)
+		assert.Equal(t, tenancy.TenantID("a"), tenantID)
+	})
+
+	t.Run("accepts 50 character tenant ID (max length)", func(t *testing.T) {
+		maxLengthID := "a1234567890123456789012345678901234567890123456789"
+		claims := &Claims{TenantID: maxLengthID}
+		tenantID, err := claims.GetTenantID()
+		assert.NoError(t, err)
+		assert.Equal(t, tenancy.TenantID(maxLengthID), tenantID)
+	})
+
+	t.Run("rejects 51 character tenant ID (exceeds max length)", func(t *testing.T) {
+		tooLongID := "a12345678901234567890123456789012345678901234567890"
+		claims := &Claims{TenantID: tooLongID}
+		tenantID, err := claims.GetTenantID()
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, tenancy.ErrInvalidTenantID)
+		assert.Equal(t, tenancy.TenantID(""), tenantID)
+	})
+}
+
+func TestClaims_HasTenantID(t *testing.T) {
+	t.Run("returns true when tenant ID is present", func(t *testing.T) {
+		claims := &Claims{TenantID: "acme_bank"}
+		assert.True(t, claims.HasTenantID())
+	})
+
+	t.Run("returns false when tenant ID is empty", func(t *testing.T) {
+		claims := &Claims{TenantID: ""}
+		assert.False(t, claims.HasTenantID())
+	})
+
+	t.Run("returns false when tenant ID is not set", func(t *testing.T) {
+		claims := &Claims{UserID: "user-123"}
+		assert.False(t, claims.HasTenantID())
+	})
 }
 
 func TestClaims_GetRoles(t *testing.T) {

--- a/internal/platform/auth/jwt_test.go
+++ b/internal/platform/auth/jwt_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/meridianhub/meridian/internal/platform/tenancy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -175,6 +176,61 @@ func TestClaims_GetUserID(t *testing.T) {
 	})
 }
 
+func TestClaims_GetTenantID(t *testing.T) {
+	t.Run("returns tenant ID when valid", func(t *testing.T) {
+		claims := &Claims{TenantID: "acme_bank"}
+		tenantID, err := claims.GetTenantID()
+		assert.NoError(t, err)
+		assert.Equal(t, tenancy.TenantID("acme_bank"), tenantID)
+	})
+
+	t.Run("returns error when tenant claim missing", func(t *testing.T) {
+		claims := &Claims{UserID: "user-123"}
+		tenantID, err := claims.GetTenantID()
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrTenantClaimMissing)
+		assert.Equal(t, tenancy.TenantID(""), tenantID)
+	})
+
+	t.Run("returns error when tenant claim empty", func(t *testing.T) {
+		claims := &Claims{TenantID: ""}
+		tenantID, err := claims.GetTenantID()
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrTenantClaimMissing)
+		assert.Equal(t, tenancy.TenantID(""), tenantID)
+	})
+
+	t.Run("returns error for invalid format with spaces", func(t *testing.T) {
+		claims := &Claims{TenantID: "acme bank"}
+		tenantID, err := claims.GetTenantID()
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, tenancy.ErrInvalidTenantID)
+		assert.Equal(t, tenancy.TenantID(""), tenantID)
+	})
+
+	t.Run("returns error for invalid format with special chars", func(t *testing.T) {
+		claims := &Claims{TenantID: "acme-bank!"}
+		tenantID, err := claims.GetTenantID()
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, tenancy.ErrInvalidTenantID)
+		assert.Equal(t, tenancy.TenantID(""), tenantID)
+	})
+
+	t.Run("accepts valid tenant IDs with underscores", func(t *testing.T) {
+		claims := &Claims{TenantID: "acme_bank_corp"}
+		tenantID, err := claims.GetTenantID()
+		assert.NoError(t, err)
+		assert.Equal(t, tenancy.TenantID("acme_bank_corp"), tenantID)
+	})
+
+	t.Run("accepts valid tenant IDs with numbers", func(t *testing.T) {
+		claims := &Claims{TenantID: "bank123"}
+		tenantID, err := claims.GetTenantID()
+		assert.NoError(t, err)
+		assert.Equal(t, tenancy.TenantID("bank123"), tenantID)
+	})
+}
+
 func TestClaims_GetRoles(t *testing.T) {
 	t.Run("returns roles when present", func(t *testing.T) {
 		claims := &Claims{Roles: []string{"admin", "user"}}
@@ -317,9 +373,10 @@ func TestClaims_EdgeCases(t *testing.T) {
 
 	t.Run("claims with all fields populated", func(t *testing.T) {
 		claims := &Claims{
-			UserID: "user-123",
-			Roles:  []string{"admin"},
-			Scopes: []string{"read"},
+			UserID:   "user-123",
+			TenantID: "acme_bank",
+			Roles:    []string{"admin"},
+			Scopes:   []string{"read"},
 			RegisteredClaims: jwt.RegisteredClaims{
 				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
 				IssuedAt:  jwt.NewNumericDate(time.Now()),
@@ -330,10 +387,73 @@ func TestClaims_EdgeCases(t *testing.T) {
 			},
 		}
 		assert.Equal(t, "user-123", claims.GetUserID())
+		tenantID, err := claims.GetTenantID()
+		assert.NoError(t, err)
+		assert.Equal(t, tenancy.TenantID("acme_bank"), tenantID)
 		assert.Equal(t, []string{"admin"}, claims.GetRoles())
 		assert.Equal(t, []string{"read"}, claims.GetScopes())
 		assert.False(t, claims.IsExpired())
 		assert.Equal(t, "test-issuer", claims.Issuer)
 		assert.Equal(t, "test-subject", claims.Subject)
+	})
+}
+
+func TestValidateToken_WithTenantClaim(t *testing.T) {
+	privateKey, publicKey, err := generateTestRSAKeys()
+	require.NoError(t, err)
+
+	validator, err := NewJWTValidator(publicKey)
+	require.NoError(t, err)
+
+	t.Run("extracts tenant claim from valid JWT", func(t *testing.T) {
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "acme_bank",
+			Roles:    []string{"admin"},
+			Scopes:   []string{"read", "write"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+			},
+		}
+
+		tokenString, err := createTestToken(privateKey, claims)
+		require.NoError(t, err)
+
+		extractedClaims, err := validator.ValidateToken(tokenString)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, extractedClaims)
+		assert.Equal(t, "user-123", extractedClaims.UserID)
+		assert.Equal(t, "acme_bank", extractedClaims.TenantID)
+
+		tenantID, err := extractedClaims.GetTenantID()
+		assert.NoError(t, err)
+		assert.Equal(t, tenancy.TenantID("acme_bank"), tenantID)
+	})
+
+	t.Run("backward compatibility - tokens without tenant claim still validate", func(t *testing.T) {
+		claims := &Claims{
+			UserID: "user-123",
+			Roles:  []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+				IssuedAt:  jwt.NewNumericDate(time.Now()),
+			},
+		}
+
+		tokenString, err := createTestToken(privateKey, claims)
+		require.NoError(t, err)
+
+		extractedClaims, err := validator.ValidateToken(tokenString)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, extractedClaims)
+		assert.Equal(t, "user-123", extractedClaims.UserID)
+		assert.Equal(t, "", extractedClaims.TenantID)
+
+		_, err = extractedClaims.GetTenantID()
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrTenantClaimMissing)
 	})
 }


### PR DESCRIPTION
## Summary

- Add `TenantID` field to `auth.Claims` struct with JSON tag `meridian_tenant_id`
- Implement `GetTenantID()` method that validates and returns `tenancy.TenantID`
- Add comprehensive tests for tenant claim extraction and validation

## Changes Made

- `internal/platform/auth/jwt.go`: Added `TenantID` field to Claims struct and `GetTenantID()` method
- `internal/platform/auth/jwt_test.go`: Added tests for tenant ID extraction, validation, and backward compatibility

## Technical Details

- `GetTenantID()` returns `ErrTenantClaimMissing` when claim is absent
- `GetTenantID()` returns `tenancy.ErrInvalidTenantID` for invalid formats (spaces, special chars)
- Integrates with `tenancy.NewTenantID()` for consistent validation across the codebase

## Testing

- Valid tenant ID extraction from JWT
- Missing tenant claim error handling
- Invalid format rejection (spaces, special characters)
- Backward compatibility: tokens without tenant claim still validate

## Risk Assessment

Low risk: This is an additive change. Existing JWTs without tenant claims continue to work; `GetTenantID()` returns an error that callers can handle for gradual migration.