### PR TITLE
feat: Add database migration for liens table

### DIFF
--- a/internal/current-account/adapters/persistence/lien_entity.go
+++ b/internal/current-account/adapters/persistence/lien_entity.go
@@ -12,7 +12,7 @@ type LienEntity struct {
 	// Primary key
 	ID uuid.UUID `gorm:"primaryKey"`
 
-	// Foreign key to current_accounts
+	// Foreign key to current_account.accounts
 	AccountID uuid.UUID `gorm:"not null;index:idx_liens_account_status"`
 
 	// Monetary amount

--- a/internal/current-account/adapters/persistence/lien_entity.go
+++ b/internal/current-account/adapters/persistence/lien_entity.go
@@ -37,7 +37,7 @@ type LienEntity struct {
 	Version   int       `gorm:"not null;default:1"`
 }
 
-// TableName overrides the default table name
+// TableName overrides the default table name with schema prefix
 func (LienEntity) TableName() string {
-	return "liens"
+	return "current_account.liens"
 }

--- a/internal/platform/testdb/schema_validation_test.go
+++ b/internal/platform/testdb/schema_validation_test.go
@@ -114,12 +114,8 @@ func TestMigrationsMatchEntities(t *testing.T) {
 		testCurrentAccountEntity(t, gormDB)
 	})
 
-	// Note: LienEntity test is skipped because the liens table migration doesn't exist yet.
-	// The LienEntity is defined in internal/current-account/adapters/persistence/lien_entity.go
-	// but there's no corresponding migration in migrations/current_account/
-	// TODO: Add migration for liens table (separate issue)
 	t.Run("CurrentAccount/LienEntity", func(t *testing.T) {
-		t.Skip("Skipping: liens table migration not yet created")
+		testLienEntity(t, gormDB)
 	})
 
 	t.Run("PaymentOrder/PaymentOrderEntity", func(t *testing.T) {
@@ -198,6 +194,76 @@ func applyMigrations(ctx context.Context, t *testing.T, db *sql.DB) {
 
 		t.Logf("Applied migration: [%s] %s", mig.schema, mig.filename)
 	}
+}
+
+// testLienEntity tests that LienEntity works with the migrated schema
+func testLienEntity(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	// First create a customer (accounts have FK to customers)
+	customerID := uuid.New()
+	customerSQL := `
+		INSERT INTO current_account.customers
+		(id, customer_number, first_name, last_name, email, status, created_by, updated_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+	err := db.Exec(customerSQL, customerID, "CUST-LIEN-001", "Lien", "Test", "lien@example.com", "active", "system", "system").Error
+	require.NoError(t, err, "Failed to create test customer for lien test")
+
+	// Then create an account (liens have FK to accounts)
+	accountID := uuid.New()
+	account := &capersistence.CurrentAccountEntity{
+		ID:                    accountID,
+		AccountID:             "ACC-LIEN-001",
+		AccountIdentification: "GB82WEST12345698765433",
+		AccountType:           "current",
+		Currency:              "GBP",
+		Status:                "active",
+		CustomerID:            customerID,
+		Balance:               50000,
+		AvailableBalance:      40000,
+		OverdraftLimit:        5000,
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+		CreatedBy:             "system",
+		UpdatedBy:             "system",
+	}
+	err = db.Create(account).Error
+	require.NoError(t, err, "Failed to create test account for lien test")
+
+	// Now create a lien
+	expiresAt := time.Now().Add(24 * time.Hour)
+	entity := &capersistence.LienEntity{
+		ID:                    uuid.New(),
+		AccountID:             accountID,
+		AmountCents:           10000,
+		Currency:              "GBP",
+		Status:                "ACTIVE",
+		PaymentOrderReference: "PO-LIEN-TEST-001",
+		ExpiresAt:             &expiresAt,
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+		Version:               1,
+	}
+
+	// Create - will fail if columns don't match
+	err = db.Create(entity).Error
+	if err != nil {
+		t.Fatalf("Failed to create LienEntity - schema mismatch detected: %v", err)
+	}
+
+	// Read back - will fail if columns don't match
+	var retrieved capersistence.LienEntity
+	err = db.First(&retrieved, "id = ?", entity.ID).Error
+	if err != nil {
+		t.Fatalf("Failed to read LienEntity - schema mismatch detected: %v", err)
+	}
+
+	// Verify data integrity
+	assert.Equal(t, entity.AccountID, retrieved.AccountID)
+	assert.Equal(t, entity.AmountCents, retrieved.AmountCents)
+	assert.Equal(t, entity.Currency, retrieved.Currency)
+	assert.Equal(t, entity.Status, retrieved.Status)
+	assert.Equal(t, entity.PaymentOrderReference, retrieved.PaymentOrderReference)
 }
 
 // testCurrentAccountEntity tests that CurrentAccountEntity works with the migrated schema

--- a/internal/platform/testdb/schema_validation_test.go
+++ b/internal/platform/testdb/schema_validation_test.go
@@ -264,6 +264,8 @@ func testLienEntity(t *testing.T, db *gorm.DB) {
 	assert.Equal(t, entity.Currency, retrieved.Currency)
 	assert.Equal(t, entity.Status, retrieved.Status)
 	assert.Equal(t, entity.PaymentOrderReference, retrieved.PaymentOrderReference)
+	assert.NotNil(t, retrieved.ExpiresAt)
+	assert.WithinDuration(t, *entity.ExpiresAt, *retrieved.ExpiresAt, time.Second)
 
 	// Update - verify status transitions work (ACTIVE -> EXECUTED)
 	retrieved.Status = "EXECUTED"
@@ -279,8 +281,27 @@ func testLienEntity(t *testing.T, db *gorm.DB) {
 	require.NoError(t, err)
 	assert.Equal(t, "EXECUTED", updated.Status)
 
+	// Test TERMINATED status transition with termination reason
+	terminatedLien := &capersistence.LienEntity{
+		ID:                    uuid.New(),
+		AccountID:             accountID,
+		AmountCents:           5000,
+		Currency:              "GBP",
+		Status:                "ACTIVE",
+		PaymentOrderReference: "PO-LIEN-TEST-TERM",
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+		Version:               1,
+	}
+	err = db.Create(terminatedLien).Error
+	require.NoError(t, err)
+	terminatedLien.Status = "TERMINATED"
+	terminatedLien.TerminationReason = "Payment order cancelled by user"
+	err = db.Save(terminatedLien).Error
+	assert.NoError(t, err, "TERMINATED status transition should succeed")
+
 	// Constraint validation: amount_cents must be > 0
-	invalidLien := &capersistence.LienEntity{
+	invalidAmountLien := &capersistence.LienEntity{
 		ID:                    uuid.New(),
 		AccountID:             accountID,
 		AmountCents:           0, // Invalid: must be > 0
@@ -291,8 +312,38 @@ func testLienEntity(t *testing.T, db *gorm.DB) {
 		UpdatedAt:             time.Now(),
 		Version:               1,
 	}
-	err = db.Create(invalidLien).Error
+	err = db.Create(invalidAmountLien).Error
 	assert.Error(t, err, "Expected error for amount_cents <= 0 constraint violation")
+
+	// Constraint validation: unique payment_order_reference
+	duplicateLien := &capersistence.LienEntity{
+		ID:                    uuid.New(),
+		AccountID:             accountID,
+		AmountCents:           5000,
+		Currency:              "GBP",
+		Status:                "ACTIVE",
+		PaymentOrderReference: "PO-LIEN-TEST-001", // Duplicate of first lien
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+		Version:               1,
+	}
+	err = db.Create(duplicateLien).Error
+	assert.Error(t, err, "Expected error for duplicate payment_order_reference")
+
+	// Constraint validation: FK to non-existent account
+	orphanLien := &capersistence.LienEntity{
+		ID:                    uuid.New(),
+		AccountID:             uuid.New(), // Non-existent account
+		AmountCents:           5000,
+		Currency:              "GBP",
+		Status:                "ACTIVE",
+		PaymentOrderReference: "PO-LIEN-TEST-003",
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+		Version:               1,
+	}
+	err = db.Create(orphanLien).Error
+	assert.Error(t, err, "Expected error for FK constraint violation")
 }
 
 // testCurrentAccountEntity tests that CurrentAccountEntity works with the migrated schema

--- a/internal/platform/testdb/schema_validation_test.go
+++ b/internal/platform/testdb/schema_validation_test.go
@@ -264,6 +264,35 @@ func testLienEntity(t *testing.T, db *gorm.DB) {
 	assert.Equal(t, entity.Currency, retrieved.Currency)
 	assert.Equal(t, entity.Status, retrieved.Status)
 	assert.Equal(t, entity.PaymentOrderReference, retrieved.PaymentOrderReference)
+
+	// Update - verify status transitions work (ACTIVE -> EXECUTED)
+	retrieved.Status = "EXECUTED"
+	retrieved.UpdatedAt = time.Now()
+	err = db.Save(&retrieved).Error
+	if err != nil {
+		t.Fatalf("Failed to update LienEntity - schema mismatch detected: %v", err)
+	}
+
+	// Verify update persisted
+	var updated capersistence.LienEntity
+	err = db.First(&updated, "id = ?", entity.ID).Error
+	require.NoError(t, err)
+	assert.Equal(t, "EXECUTED", updated.Status)
+
+	// Constraint validation: amount_cents must be > 0
+	invalidLien := &capersistence.LienEntity{
+		ID:                    uuid.New(),
+		AccountID:             accountID,
+		AmountCents:           0, // Invalid: must be > 0
+		Currency:              "GBP",
+		Status:                "ACTIVE",
+		PaymentOrderReference: "PO-LIEN-TEST-002",
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+		Version:               1,
+	}
+	err = db.Create(invalidLien).Error
+	assert.Error(t, err, "Expected error for amount_cents <= 0 constraint violation")
 }
 
 // testCurrentAccountEntity tests that CurrentAccountEntity works with the migrated schema

--- a/migrations/current_account/20251204204800_create_liens_table.sql
+++ b/migrations/current_account/20251204204800_create_liens_table.sql
@@ -1,0 +1,24 @@
+-- Create "liens" table for tracking holds on account balances
+CREATE TABLE "current_account"."liens" (
+  "id" uuid NOT NULL,
+  "account_id" uuid NOT NULL,
+  "amount_cents" bigint NOT NULL,
+  "currency" character varying(3) NOT NULL,
+  "status" character varying(20) NOT NULL,
+  "payment_order_reference" character varying(255) NOT NULL,
+  "termination_reason" character varying(1000) NULL,
+  "expires_at" timestamptz NULL,
+  "created_at" timestamptz NOT NULL,
+  "updated_at" timestamptz NOT NULL,
+  "version" integer NOT NULL DEFAULT 1,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "chk_liens_amount_cents" CHECK (amount_cents > 0),
+  CONSTRAINT "chk_liens_status" CHECK (status IN ('ACTIVE', 'EXECUTED', 'TERMINATED')),
+  CONSTRAINT "fk_liens_account" FOREIGN KEY ("account_id") REFERENCES "current_account"."accounts" ("id") ON UPDATE NO ACTION ON DELETE RESTRICT
+);
+-- Create index "idx_liens_account_status" for account + status lookups
+CREATE INDEX "idx_liens_account_status" ON "current_account"."liens" ("account_id", "status");
+-- Create unique index "idx_liens_payment_order" for payment order reference uniqueness
+CREATE UNIQUE INDEX "idx_liens_payment_order" ON "current_account"."liens" ("payment_order_reference");
+-- Create index "idx_liens_expires_at" for expiration queries
+CREATE INDEX "idx_liens_expires_at" ON "current_account"."liens" ("expires_at");

--- a/migrations/current_account/atlas.sum
+++ b/migrations/current_account/atlas.sum
@@ -1,7 +1,8 @@
-h1:aI2CO98j98tbDPO1J+ich9U/CbXQD8sWMJEBtzZiFGU=
+h1:hfph2+3VjLzAEyrwW9BxRMdpSpgusn5p70iV6cdrZMs=
 20251103181626_initial.sql h1:h/E+atJE/78Q5siTomcLIzYZMRACtxiIVRQgemMtax4=
 20251103181700_audit_system.sql h1:QLSvHru32NeU2bNflvmF8JWG8Fcmv8GJdvxv9QCJ7PU=
 20251204130000_add_account_id.sql h1:5RWRS5Tx0wchOUWpXniGRAm4GisEAl1PzoHFsZw6M28=
 20251204130001_populate_account_id.sql h1:PfWe8Xb5FTW85N7IOlSh5Sm1aMB1ViNoTv+RfZyVeyk=
 20251204130002_account_id_constraints.sql h1:Qvj3rH//0mHzBw7k2QnwG+xT9Hfnc3WsQT454v1mDnM=
 20251204143000_rename_account_number.sql h1:0hImX23U6qP+Zi8iTKu1syTDgwUECN3chAiTdiZCpDo=
+20251204204800_create_liens_table.sql h1:ER5Rb9LgyAAB20aVAymptmRbs3S+o8rvsln28RjJ6VI=


### PR DESCRIPTION
## Summary

- Create `liens` table migration in `current_account` schema
- Fix `LienEntity.TableName()` to include schema prefix
- Add schema validation test coverage for `LienEntity`

## Changes Made

1. **New migration** (`20251204204800_create_liens_table.sql`):
   - Creates `current_account.liens` table matching `LienEntity` struct
   - Foreign key to `accounts` table with RESTRICT on delete
   - Check constraint: `amount_cents > 0`
   - Check constraint: `status IN ('ACTIVE', 'EXECUTED', 'TERMINATED')`
   - Composite index on `(account_id, status)` for query performance
   - Unique index on `payment_order_reference`
   - Index on `expires_at` for expiration queries

2. **Entity fix** (`lien_entity.go`):
   - Updated `TableName()` to return `"current_account.liens"` (was `"liens"`)
   - Consistent with `CurrentAccountEntity` pattern

3. **Test coverage** (`schema_validation_test.go`):
   - Removed skip for `LienEntity` test
   - Added `testLienEntity()` function validating CRUD operations against migrated schema

## Technical Details

The liens table stores holds on account balances for pending payment orders:

| Column | Type | Constraints |
|--------|------|-------------|
| `id` | uuid | PRIMARY KEY |
| `account_id` | uuid | FK → accounts, NOT NULL |
| `amount_cents` | bigint | NOT NULL, CHECK > 0 |
| `currency` | varchar(3) | NOT NULL |
| `status` | varchar(20) | NOT NULL, CHECK valid values |
| `payment_order_reference` | varchar(255) | NOT NULL, UNIQUE |
| `termination_reason` | varchar(1000) | nullable |
| `expires_at` | timestamptz | nullable, indexed |
| `created_at` | timestamptz | NOT NULL |
| `updated_at` | timestamptz | NOT NULL |
| `version` | integer | NOT NULL, DEFAULT 1 |

## Testing

```bash
# Schema validation test passes
go test -v -run TestMigrationsMatchEntities ./internal/platform/testdb/...

# Lien service tests pass
go test -v -run TestLien ./internal/current-account/service/...

# Full build succeeds
make build
```

## Risk Assessment

Low risk - additive change only:
- New table creation (no existing data affected)
- Entity fix aligns with existing pattern
- Test coverage ensures schema/entity compatibility

Closes #205