### PR TITLE
feat: Populate audit fields (created_by, updated_by) from request context

### DIFF
--- a/internal/current-account/adapters/persistence/repository.go
+++ b/internal/current-account/adapters/persistence/repository.go
@@ -1,12 +1,14 @@
 package persistence
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/internal/current-account/domain"
+	"github.com/meridianhub/meridian/internal/platform/audit"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -41,21 +43,22 @@ func (r *Repository) WithTx(tx *gorm.DB) *Repository {
 }
 
 // Save creates or updates an account.
+// The context is used to extract audit information (user ID) for the created_by/updated_by fields.
 //
 // NOTE: Optimistic locking via version column is NOT currently implemented because
 // the migration schema doesn't include a version column. The previous code referenced
 // a non-existent 'version' column which would have failed at runtime.
 // TODO: Add version column migration and restore optimistic locking (see ADR-008)
 // For now, use FindByIDForUpdate() with SELECT FOR UPDATE for concurrent modifications.
-func (r *Repository) Save(account *domain.CurrentAccount) error {
-	entity, err := toEntity(account)
+func (r *Repository) Save(ctx context.Context, account *domain.CurrentAccount) error {
+	entity, err := toEntity(ctx, account)
 	if err != nil {
 		return err
 	}
 
 	// Check if exists by account_identification (IBAN)
 	var existing CurrentAccountEntity
-	result := r.db.Where("account_identification = ?", entity.AccountIdentification).First(&existing)
+	result := r.db.WithContext(ctx).Where("account_identification = ?", entity.AccountIdentification).First(&existing)
 
 	if result.Error == nil {
 		// Update existing
@@ -64,7 +67,7 @@ func (r *Repository) Save(account *domain.CurrentAccount) error {
 		entity.CreatedBy = existing.CreatedBy
 
 		// Use WHERE clause for atomic update
-		updateResult := r.db.Model(&CurrentAccountEntity{}).
+		updateResult := r.db.WithContext(ctx).Model(&CurrentAccountEntity{}).
 			Where("account_identification = ?", entity.AccountIdentification).
 			Updates(map[string]interface{}{
 				"balance":           entity.Balance,
@@ -84,7 +87,7 @@ func (r *Repository) Save(account *domain.CurrentAccount) error {
 
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		// Create new
-		return r.db.Create(&entity).Error
+		return r.db.WithContext(ctx).Create(&entity).Error
 	}
 
 	return result.Error
@@ -216,12 +219,15 @@ func (r *Repository) Ping() error {
 // Some domain fields don't have corresponding database columns yet:
 // - AccountID and AccountIdentification both map to account_identification column (IBAN format)
 // - OverdraftEnabled, OverdraftRate, BalanceUpdatedAt, Version need migration
-func toEntity(account *domain.CurrentAccount) (*CurrentAccountEntity, error) {
+func toEntity(ctx context.Context, account *domain.CurrentAccount) (*CurrentAccountEntity, error) {
 	// Parse CustomerID as UUID - domain model uses string for flexibility
 	customerUUID, err := uuid.Parse(account.CustomerID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid customer ID %q: %w", account.CustomerID, err)
 	}
+
+	// Extract audit user from context (falls back to "system" if not available)
+	auditUser := audit.GetUserFromContext(ctx)
 
 	return &CurrentAccountEntity{
 		ID:                    account.ID,
@@ -236,8 +242,8 @@ func toEntity(account *domain.CurrentAccount) (*CurrentAccountEntity, error) {
 		OverdraftLimit:        account.OverdraftLimit.AmountCents(),
 		CreatedAt:             account.CreatedAt,
 		UpdatedAt:             account.UpdatedAt,
-		CreatedBy:             "system", // TODO: Extract from context
-		UpdatedBy:             "system", // TODO: Extract from context
+		CreatedBy:             auditUser,
+		UpdatedBy:             auditUser,
 	}, nil
 }
 

--- a/internal/current-account/adapters/persistence/repository_test.go
+++ b/internal/current-account/adapters/persistence/repository_test.go
@@ -1,12 +1,14 @@
 package persistence
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/internal/current-account/domain"
+	"github.com/meridianhub/meridian/internal/platform/auth"
 	"github.com/meridianhub/meridian/internal/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,7 +32,8 @@ func TestSaveNewAccount(t *testing.T) {
 	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
 	require.NoError(t, err)
 
-	err = repo.Save(account)
+	ctx := context.Background()
+	err = repo.Save(ctx, account)
 	if err != nil {
 		t.Fatalf("Save failed: %v", err)
 	}
@@ -58,8 +61,10 @@ func TestSaveUpdateExisting(t *testing.T) {
 	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
 	require.NoError(t, err)
 
+	ctx := context.Background()
+
 	// Save initial
-	if err := repo.Save(account); err != nil {
+	if err := repo.Save(ctx, account); err != nil {
 		t.Fatalf("Initial save failed: %v", err)
 	}
 
@@ -70,7 +75,7 @@ func TestSaveUpdateExisting(t *testing.T) {
 		t.Fatalf("Deposit failed: %v", err)
 	}
 
-	if err := repo.Save(account); err != nil {
+	if err := repo.Save(ctx, account); err != nil {
 		t.Fatalf("Update save failed: %v", err)
 	}
 
@@ -111,7 +116,8 @@ func TestFindByIBAN(t *testing.T) {
 	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
 	require.NoError(t, err)
 
-	if err := repo.Save(account); err != nil {
+	ctx := context.Background()
+	if err := repo.Save(ctx, account); err != nil {
 		t.Fatalf("Save failed: %v", err)
 	}
 
@@ -142,10 +148,11 @@ func TestFindByCustomerID(t *testing.T) {
 	account2, err := domain.NewCurrentAccount(iban2, iban2, customerID, "EUR")
 	require.NoError(t, err)
 
-	if err := repo.Save(account1); err != nil {
+	ctx := context.Background()
+	if err := repo.Save(ctx, account1); err != nil {
 		t.Fatalf("Save account1 failed: %v", err)
 	}
-	if err := repo.Save(account2); err != nil {
+	if err := repo.Save(ctx, account2); err != nil {
 		t.Fatalf("Save account2 failed: %v", err)
 	}
 
@@ -170,7 +177,8 @@ func TestDeleteAccount(t *testing.T) {
 	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
 	require.NoError(t, err)
 
-	if err := repo.Save(account); err != nil {
+	ctx := context.Background()
+	if err := repo.Save(ctx, account); err != nil {
 		t.Fatalf("Save failed: %v", err)
 	}
 
@@ -199,10 +207,12 @@ func TestOptimisticLocking(t *testing.T) {
 	customerID := uuid.New().String()
 	iban := "GB82WEST12345698765432"
 
+	ctx := context.Background()
+
 	// Create initial account
 	account1, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
 	require.NoError(t, err)
-	if err := repo.Save(account1); err != nil {
+	if err := repo.Save(ctx, account1); err != nil {
 		t.Fatalf("Initial save failed: %v", err)
 	}
 
@@ -228,7 +238,7 @@ func TestOptimisticLocking(t *testing.T) {
 		t.Fatalf("Deposit failed: %v", err)
 	}
 
-	if err := repo.Save(account2); err != nil {
+	if err := repo.Save(ctx, account2); err != nil {
 		t.Fatalf("First save failed: %v", err)
 	}
 
@@ -238,7 +248,7 @@ func TestOptimisticLocking(t *testing.T) {
 		t.Fatalf("Deposit failed: %v", err)
 	}
 
-	err = repo.Save(account3)
+	err = repo.Save(ctx, account3)
 	if !errors.Is(err, ErrVersionConflict) {
 		t.Errorf("Expected ErrVersionConflict, got %v", err)
 	}
@@ -380,4 +390,97 @@ func TestFindByCustomerID_PartialCorruption_ReturnsError(t *testing.T) {
 
 	assert.Error(t, err, "FindByCustomerID should fail when any account is corrupted")
 	assert.Contains(t, err.Error(), "database", "Error should indicate DB corruption")
+}
+
+// Audit context tests
+
+func TestSave_PopulatesAuditFieldsFromContext(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	customerID := uuid.New().String()
+	iban := "GB82WEST12345698765432"
+
+	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	require.NoError(t, err)
+
+	// Create context with authenticated user
+	testUserID := "user-123"
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, testUserID)
+
+	// Save new account
+	err = repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Verify audit fields were set from context
+	var entity CurrentAccountEntity
+	err = db.Where("account_identification = ?", iban).First(&entity).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, testUserID, entity.CreatedBy, "created_by should be set from context")
+	assert.Equal(t, testUserID, entity.UpdatedBy, "updated_by should be set from context")
+}
+
+func TestSave_UsesSystemWhenNoUserInContext(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	customerID := uuid.New().String()
+	iban := "GB82WEST12345698765432"
+
+	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	require.NoError(t, err)
+
+	// Use empty context (no user)
+	ctx := context.Background()
+
+	// Save new account
+	err = repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Verify audit fields default to "system"
+	var entity CurrentAccountEntity
+	err = db.Where("account_identification = ?", iban).First(&entity).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, "system", entity.CreatedBy, "created_by should default to 'system'")
+	assert.Equal(t, "system", entity.UpdatedBy, "updated_by should default to 'system'")
+}
+
+func TestSave_UpdatePreservesCreatedByButUpdatesUpdatedBy(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	customerID := uuid.New().String()
+	iban := "GB82WEST12345698765432"
+
+	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	require.NoError(t, err)
+
+	// Create with user1
+	user1 := "user-creator"
+	ctx1 := context.WithValue(context.Background(), auth.UserIDContextKey, user1)
+	err = repo.Save(ctx1, account)
+	require.NoError(t, err)
+
+	// Update with user2
+	user2 := "user-updater"
+	ctx2 := context.WithValue(context.Background(), auth.UserIDContextKey, user2)
+	depositMoney, _ := domain.NewMoney("GBP", 5000)
+	err = account.Deposit(depositMoney)
+	require.NoError(t, err)
+
+	err = repo.Save(ctx2, account)
+	require.NoError(t, err)
+
+	// Verify created_by preserved but updated_by changed
+	var entity CurrentAccountEntity
+	err = db.Where("account_identification = ?", iban).First(&entity).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, user1, entity.CreatedBy, "created_by should be preserved from original creation")
+	assert.Equal(t, user2, entity.UpdatedBy, "updated_by should reflect the user who made the update")
 }

--- a/internal/current-account/service/grpc_service.go
+++ b/internal/current-account/service/grpc_service.go
@@ -174,7 +174,7 @@ func NewServiceWithClients(config Config) (*Service, error) {
 }
 
 // InitiateCurrentAccount creates a new current account facility
-func (s *Service) InitiateCurrentAccount(_ context.Context, req *pb.InitiateCurrentAccountRequest) (*pb.InitiateCurrentAccountResponse, error) {
+func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCurrentAccountRequest) (*pb.InitiateCurrentAccountResponse, error) {
 	start := time.Now()
 	operationStatus := operationStatusSuccess
 	defer func() {
@@ -203,8 +203,8 @@ func (s *Service) InitiateCurrentAccount(_ context.Context, req *pb.InitiateCurr
 		return nil, status.Errorf(codes.InvalidArgument, "failed to create account: %v", err)
 	}
 
-	// Save to database
-	if err := s.repo.Save(account); err != nil {
+	// Save to database (context carries audit user info for created_by/updated_by fields)
+	if err := s.repo.Save(ctx, account); err != nil {
 		operationStatus = "save_failed"
 		return nil, status.Errorf(codes.Internal, "failed to create account: %v", err)
 	}
@@ -300,7 +300,7 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 			"account_id", account.AccountID,
 			"transaction_id", transactionID)
 
-		if err := s.repo.Save(account); err != nil {
+		if err := s.repo.Save(ctx, account); err != nil {
 			operationStatus = "save_failed"
 			return nil, status.Errorf(codes.Internal, "failed to save account: %v", err)
 		}
@@ -535,13 +535,13 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 	// Step 3: Save account to database (only after external services succeed)
 	saga.AddStep("save_account",
 		// Action: Persist the updated account balance
-		func(_ context.Context) error {
+		func(stepCtx context.Context) error {
 			s.logger.Info("executing save_account step",
 				"account_id", account.AccountID,
 				"transaction_id", transactionID,
 				"new_balance", account.Balance.AmountCents())
 
-			if err := s.repo.Save(account); err != nil {
+			if err := s.repo.Save(stepCtx, account); err != nil {
 				return fmt.Errorf("failed to save account: %w", err)
 			}
 

--- a/internal/current-account/service/grpc_service_integration_test.go
+++ b/internal/current-account/service/grpc_service_integration_test.go
@@ -232,7 +232,7 @@ func createTestAccount(t *testing.T, repo *persistence.Repository, accountID str
 	// The repository's FindByID searches by account_number, so AccountIdentification must match the lookup key.
 	account, err := domain.NewCurrentAccount(accountID, accountID, uuid.New().String(), "GBP")
 	require.NoError(t, err, "Failed to create test account")
-	require.NoError(t, repo.Save(account), "Failed to save test account")
+	require.NoError(t, repo.Save(context.Background(), account), "Failed to save test account")
 	return account
 }
 

--- a/internal/current-account/service/grpc_service_test.go
+++ b/internal/current-account/service/grpc_service_test.go
@@ -77,7 +77,7 @@ func TestExecuteDeposit(t *testing.T) {
 	// Create account first
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
 	require.NoError(t, err)
-	if err := repo.Save(account); err != nil {
+	if err := repo.Save(context.Background(), account); err != nil {
 		t.Fatalf("Failed to create test account: %v", err)
 	}
 
@@ -165,7 +165,7 @@ func TestExecuteDepositInvalidAmount(t *testing.T) {
 	// Create account first
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
 	require.NoError(t, err)
-	if err := repo.Save(account); err != nil {
+	if err := repo.Save(context.Background(), account); err != nil {
 		t.Fatalf("Failed to create test account: %v", err)
 	}
 
@@ -206,7 +206,7 @@ func TestRetrieveCurrentAccount(t *testing.T) {
 	// Create account first
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
 	require.NoError(t, err)
-	if err := repo.Save(account); err != nil {
+	if err := repo.Save(context.Background(), account); err != nil {
 		t.Fatalf("Failed to create test account: %v", err)
 	}
 
@@ -292,7 +292,7 @@ func TestExecuteDepositCurrencyMismatch(t *testing.T) {
 	// Create GBP account
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
 	require.NoError(t, err)
-	if err := repo.Save(account); err != nil {
+	if err := repo.Save(context.Background(), account); err != nil {
 		t.Fatalf("Failed to create test account: %v", err)
 	}
 
@@ -431,7 +431,7 @@ func TestExecuteDeposit_OverflowPrevention_UnitsTooCents(t *testing.T) {
 	// Create account
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
 	require.NoError(t, err)
-	require.NoError(t, repo.Save(account))
+	require.NoError(t, repo.Save(context.Background(), account))
 
 	// Test: Units value that would overflow when multiplied by 100
 	tests := []struct {
@@ -496,7 +496,7 @@ func TestExecuteDeposit_SafeAddition_UnitsAndNanos(t *testing.T) {
 	// Create account
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
 	require.NoError(t, err)
-	require.NoError(t, repo.Save(account))
+	require.NoError(t, repo.Save(context.Background(), account))
 
 	// Test: Large units + nanos uses Money.Add() safely
 	req := &pb.ExecuteDepositRequest{

--- a/internal/current-account/service/lien_service.go
+++ b/internal/current-account/service/lien_service.go
@@ -209,7 +209,7 @@ func (s *Service) InitiateLien(_ context.Context, req *pb.InitiateLienRequest) (
 }
 
 // ExecuteLien converts a reservation to an actual debit atomically
-func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*pb.ExecuteLienResponse, error) {
+func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (*pb.ExecuteLienResponse, error) {
 	start := time.Now()
 	operationStatus := operationStatusSuccess
 	defer func() {
@@ -296,8 +296,8 @@ func (s *Service) ExecuteLien(_ context.Context, req *pb.ExecuteLienRequest) (*p
 			return fmt.Errorf("%w: %w", errTxUpdateLien, err)
 		}
 
-		// Save account with balance change
-		if err := txRepo.Save(account); err != nil {
+		// Save account with balance change (context carries audit user info)
+		if err := txRepo.Save(ctx, account); err != nil {
 			return fmt.Errorf("%w: %w", errTxSaveAccount, err)
 		}
 

--- a/internal/current-account/service/lien_service_test.go
+++ b/internal/current-account/service/lien_service_test.go
@@ -38,7 +38,7 @@ func createTestAccountWithBalance(t *testing.T, repo *persistence.Repository, ac
 		require.NoError(t, account.Deposit(depositAmount))
 	}
 
-	require.NoError(t, repo.Save(account))
+	require.NoError(t, repo.Save(context.Background(), account))
 	return account
 }
 

--- a/internal/platform/audit/context.go
+++ b/internal/platform/audit/context.go
@@ -1,0 +1,30 @@
+// Package audit provides utilities for extracting audit information from request context.
+package audit
+
+import (
+	"context"
+
+	"github.com/meridianhub/meridian/internal/platform/auth"
+)
+
+const (
+	// DefaultAuditUser is used when no user can be extracted from context.
+	// This occurs for system operations, background jobs, or unauthenticated requests.
+	DefaultAuditUser = "system"
+)
+
+// GetUserFromContext extracts the user identifier from the request context.
+// Returns the user ID from JWT claims if available, otherwise returns DefaultAuditUser.
+// This function is safe to call with any context and will never return an empty string.
+func GetUserFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return DefaultAuditUser
+	}
+
+	userID, ok := auth.GetUserIDFromContext(ctx)
+	if !ok || userID == "" {
+		return DefaultAuditUser
+	}
+
+	return userID
+}

--- a/internal/platform/audit/context_test.go
+++ b/internal/platform/audit/context_test.go
@@ -1,0 +1,53 @@
+package audit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/internal/platform/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetUserFromContext_WithUserID(t *testing.T) {
+	userID := "user-12345"
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, userID)
+
+	result := GetUserFromContext(ctx)
+
+	assert.Equal(t, userID, result)
+}
+
+func TestGetUserFromContext_WithNilContext(t *testing.T) {
+	// Test that the function handles nil context gracefully
+	//nolint:staticcheck,revive // intentionally testing nil context handling
+	var nilCtx context.Context
+	result := GetUserFromContext(nilCtx)
+
+	assert.Equal(t, DefaultAuditUser, result)
+}
+
+func TestGetUserFromContext_WithEmptyContext(t *testing.T) {
+	ctx := context.Background()
+
+	result := GetUserFromContext(ctx)
+
+	assert.Equal(t, DefaultAuditUser, result)
+}
+
+func TestGetUserFromContext_WithEmptyUserID(t *testing.T) {
+	// User ID exists but is empty string
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, "")
+
+	result := GetUserFromContext(ctx)
+
+	assert.Equal(t, DefaultAuditUser, result)
+}
+
+func TestGetUserFromContext_WithWrongType(t *testing.T) {
+	// User ID key exists but value is wrong type
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, 12345)
+
+	result := GetUserFromContext(ctx)
+
+	assert.Equal(t, DefaultAuditUser, result)
+}


### PR DESCRIPTION
## Summary

- Add `audit` context helper package that extracts user ID from auth context
- Update `Repository.Save()` to accept `context.Context` and propagate audit user to `toEntity()`
- Extract audit user from JWT claims via existing `auth.GetUserIDFromContext()`
- Falls back to `"system"` for unauthenticated/background operations
- Preserve `created_by` on updates while only updating `updated_by`

## Changes Made

### New Files
- `internal/platform/audit/context.go` - Helper to extract user ID from auth context
- `internal/platform/audit/context_test.go` - Tests for audit context extraction

### Modified Files
- `internal/current-account/adapters/persistence/repository.go` - `Save()` now accepts `ctx` and uses it for audit fields
- `internal/current-account/service/grpc_service.go` - Pass context to repository calls
- `internal/current-account/service/lien_service.go` - Pass context to repository calls
- Various test files updated to pass context to `Save()`

## Technical Details

The implementation follows the existing auth infrastructure:
1. JWT claims are already extracted by `auth.Interceptor` and stored in context with `UserIDContextKey`
2. New `audit.GetUserFromContext()` retrieves this value, defaulting to `"system"` if unavailable
3. `toEntity()` uses the audit user for both `created_by` and `updated_by` fields
4. On updates, `created_by` is preserved from the existing record while `updated_by` reflects the current user

## Test Plan

- [ ] Unit tests for `audit.GetUserFromContext()` with various context states
- [ ] Repository tests verifying audit fields are populated from context
- [ ] Repository tests verifying `created_by` is preserved on updates
- [ ] Repository tests verifying fallback to "system" when no user in context
- [ ] CI passes

Closes #207