### PR TITLE
feat: Add missing domain columns to current_account.accounts

### DIFF
--- a/internal/current-account/adapters/persistence/account_entity.go
+++ b/internal/current-account/adapters/persistence/account_entity.go
@@ -24,6 +24,8 @@ type CurrentAccountEntity struct {
 	Balance               int64      `gorm:"column:balance;not null;default:0"`           // in smallest currency unit (pence)
 	AvailableBalance      int64      `gorm:"column:available_balance;not null;default:0"` // after pending transactions
 	OverdraftLimit        int64      `gorm:"column:overdraft_limit;not null;default:0"`   // in smallest currency unit
+	OverdraftRate         float64    `gorm:"column:overdraft_rate;type:numeric(5,4);not null;default:0"`
+	BalanceUpdatedAt      *time.Time `gorm:"column:balance_updated_at"`
 	OpenedAt              *time.Time `gorm:"column:opened_at;index"`
 	ClosedAt              *time.Time `gorm:"column:closed_at;index"`
 

--- a/internal/current-account/adapters/persistence/repository.go
+++ b/internal/current-account/adapters/persistence/repository.go
@@ -70,12 +70,14 @@ func (r *Repository) Save(ctx context.Context, account *domain.CurrentAccount) e
 		updateResult := r.db.WithContext(ctx).Model(&CurrentAccountEntity{}).
 			Where("account_identification = ?", entity.AccountIdentification).
 			Updates(map[string]interface{}{
-				"balance":           entity.Balance,
-				"available_balance": entity.AvailableBalance,
-				"status":            entity.Status,
-				"overdraft_limit":   entity.OverdraftLimit,
-				"updated_at":        entity.UpdatedAt,
-				"updated_by":        entity.UpdatedBy,
+				"balance":            entity.Balance,
+				"available_balance":  entity.AvailableBalance,
+				"status":             entity.Status,
+				"overdraft_limit":    entity.OverdraftLimit,
+				"overdraft_rate":     entity.OverdraftRate,
+				"balance_updated_at": entity.BalanceUpdatedAt,
+				"updated_at":         entity.UpdatedAt,
+				"updated_by":         entity.UpdatedBy,
 			})
 
 		if updateResult.Error != nil {
@@ -217,8 +219,8 @@ func (r *Repository) Ping() error {
 // toEntity converts domain model to database entity
 // Note: The entity schema matches migrations/current_account/*.sql
 // Some domain fields don't have corresponding database columns yet:
-// - AccountID and AccountIdentification both map to account_identification column (IBAN format)
-// - OverdraftEnabled, OverdraftRate, BalanceUpdatedAt, Version need migration
+// - OverdraftEnabled is derived from OverdraftLimit > 0
+// - Version needs migration (tracked in #206)
 func toEntity(ctx context.Context, account *domain.CurrentAccount) (*CurrentAccountEntity, error) {
 	// Parse CustomerID as UUID - domain model uses string for flexibility
 	customerUUID, err := uuid.Parse(account.CustomerID)
@@ -240,6 +242,8 @@ func toEntity(ctx context.Context, account *domain.CurrentAccount) (*CurrentAcco
 		Balance:               account.Balance.AmountCents(),
 		AvailableBalance:      account.AvailableBalance.AmountCents(),
 		OverdraftLimit:        account.OverdraftLimit.AmountCents(),
+		OverdraftRate:         account.OverdraftRate,
+		BalanceUpdatedAt:      &account.BalanceUpdatedAt,
 		CreatedAt:             account.CreatedAt,
 		UpdatedAt:             account.UpdatedAt,
 		CreatedBy:             auditUser,
@@ -248,7 +252,8 @@ func toEntity(ctx context.Context, account *domain.CurrentAccount) (*CurrentAcco
 }
 
 // toDomain converts database entity to domain model
-// Note: Some domain fields are derived or defaulted since they don't exist in DB yet
+// Note: OverdraftEnabled is derived from OverdraftLimit > 0
+// Version field needs migration (tracked in #206)
 func toDomain(entity *CurrentAccountEntity) (*domain.CurrentAccount, error) {
 	// Use NewMoney constructor - errors indicate data corruption
 	balance, err := domain.NewMoney(entity.Currency, entity.Balance)
@@ -269,6 +274,12 @@ func toDomain(entity *CurrentAccountEntity) (*domain.CurrentAccount, error) {
 	// Derive overdraft enabled from limit > 0
 	overdraftEnabled := entity.OverdraftLimit > 0
 
+	// Handle balance_updated_at - fallback to updated_at if null (for legacy rows)
+	balanceUpdatedAt := entity.UpdatedAt
+	if entity.BalanceUpdatedAt != nil {
+		balanceUpdatedAt = *entity.BalanceUpdatedAt
+	}
+
 	return &domain.CurrentAccount{
 		ID:                    entity.ID,
 		AccountID:             entity.AccountID,             // Business account identifier
@@ -279,9 +290,9 @@ func toDomain(entity *CurrentAccountEntity) (*domain.CurrentAccount, error) {
 		Status:                domain.AccountStatus(entity.Status),
 		OverdraftLimit:        overdraftLimit,
 		OverdraftEnabled:      overdraftEnabled,
-		OverdraftRate:         0,                // Default - column doesn't exist in DB yet
-		BalanceUpdatedAt:      entity.UpdatedAt, // Use updated_at as proxy
-		Version:               1,                // Default - column doesn't exist in DB yet
+		OverdraftRate:         entity.OverdraftRate,
+		BalanceUpdatedAt:      balanceUpdatedAt,
+		Version:               1, // Default - column doesn't exist in DB yet (tracked in #206)
 		CreatedAt:             entity.CreatedAt,
 		UpdatedAt:             entity.UpdatedAt,
 	}, nil

--- a/migrations/current_account/20251204160000_add_overdraft_rate_balance_updated_at.sql
+++ b/migrations/current_account/20251204160000_add_overdraft_rate_balance_updated_at.sql
@@ -1,0 +1,11 @@
+-- Add missing domain columns to current_account.accounts
+-- Resolves issue #209: OverdraftRate and BalanceUpdatedAt fields
+
+ALTER TABLE "current_account"."accounts"
+ADD COLUMN "overdraft_rate" numeric(5,4) NOT NULL DEFAULT 0,
+ADD COLUMN "balance_updated_at" timestamptz NULL;
+
+-- Backfill balance_updated_at with updated_at for existing rows
+UPDATE "current_account"."accounts"
+SET "balance_updated_at" = "updated_at"
+WHERE "balance_updated_at" IS NULL;


### PR DESCRIPTION
## Summary

- Add `overdraft_rate` and `balance_updated_at` columns to `current_account.accounts` table
- Update `CurrentAccountEntity` with corresponding GORM fields
- Update `toEntity`/`toDomain` mappings to persist and retrieve these fields properly

## Changes Made

1. **Migration** (`20251204160000_add_overdraft_rate_balance_updated_at.sql`):
   - Adds `overdraft_rate numeric(5,4) NOT NULL DEFAULT 0`
   - Adds `balance_updated_at timestamptz NULL`
   - Backfills existing rows with `updated_at` value

2. **Entity** (`account_entity.go`):
   - Added `OverdraftRate float64` field
   - Added `BalanceUpdatedAt *time.Time` field

3. **Repository** (`repository.go`):
   - Updated `toEntity` to map `OverdraftRate` and `BalanceUpdatedAt`
   - Updated `toDomain` to read from new columns with fallback for legacy rows
   - Updated `Save` to include new fields in update map
   - Removed outdated comments about missing columns

## Test plan

- [x] Persistence package builds successfully
- [x] All persistence tests pass
- [x] All domain tests pass
- [ ] CI validation

## Note

The `version` column is tracked separately in #206 as it's tied to optimistic locking implementation.

Resolves #209