### PR TITLE
refactor: Update atlas-loader to use service-specific entities

### DIFF
--- a/utilities/atlas-loader/main.go
+++ b/utilities/atlas-loader/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"ariga.io/atlas-provider-gorm/gormschema"
+	capersistence "github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	fapersistence "github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
 	"github.com/meridianhub/meridian/shared/domain/models"
 )
@@ -28,9 +29,14 @@ func main() {
 
 	switch *schemaFilter {
 	case schemaCurrentAccount:
+		// Use service-specific entities that match the actual migrations
+		// Customer uses shared model (no service-specific entity yet)
+		// Account uses CurrentAccountEntity which includes Version, OverdraftRate, etc.
+		// Lien uses LienEntity for balance holds
 		modelList = []interface{}{
 			&models.Customer{},
-			&models.Account{},
+			&capersistence.CurrentAccountEntity{},
+			&capersistence.LienEntity{},
 		}
 	case schemaPositionKeeping:
 		// FinancialPositionLog references Account via AccountID, so Account must be included

--- a/utilities/atlas-loader/main_test.go
+++ b/utilities/atlas-loader/main_test.go
@@ -59,6 +59,7 @@ func TestAtlasLoaderBinary(t *testing.T) {
 				"CREATE SCHEMA IF NOT EXISTS current_account",
 				"customers",
 				"accounts",
+				"liens", // LienEntity for balance holds
 			},
 			wantNotStdout: []string{
 				"financial_position_logs", // position_keeping model should not be included


### PR DESCRIPTION
## Summary

- Replace `models.Account` with `CurrentAccountEntity` for current_account schema validation
- Add `LienEntity` to current_account schema (was missing from atlas-loader)
- Service-specific entities include fields added via migrations that shared models lack

## Changes Made

- **utilities/atlas-loader/main.go**: Import current-account persistence package, update current_account case to use `CurrentAccountEntity` and `LienEntity` instead of shared `models.Account`
- **utilities/atlas-loader/main_test.go**: Add assertion that `liens` table is included in current_account schema output

## Technical Details

The shared `models.Account` was missing several fields that exist in the database:
- `account_id` (business identifier)
- `overdraft_rate` (numeric)
- `balance_updated_at` (timestamp)
- `version` (optimistic locking)

Column names also diverged:
- `CurrentAccountEntity.AccountIdentification` vs `models.Account.AccountNumber`

Using service-specific entities ensures atlas-loader generates schema DDL that matches actual migrations.

## Testing

- All atlas-loader tests pass
- Schema validation tests pass (`TestMigrationsMatchEntities`)

## Risk Assessment

Low risk - changes only affect schema validation tooling, not runtime behavior.

Closes #217