### PR TITLE
feat: Extract panic recovery interceptor to shared library

### DIFF
--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/clients"
 	"github.com/meridianhub/meridian/services/current-account/service"
+	"github.com/meridianhub/meridian/shared/pkg/interceptors"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -118,13 +119,16 @@ func run(logger *slog.Logger) error {
 
 	logger.Info("service initialized with external clients")
 
-	// Create gRPC server with observability interceptors
+	// Create gRPC server with interceptor chain
+	// Order: tracing → recovery (recovery last to catch all panics)
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
 			tracer.UnaryServerInterceptor(),
+			interceptors.RecoveryUnaryInterceptor(logger),
 		),
 		grpc.ChainStreamInterceptor(
 			tracer.StreamServerInterceptor(),
+			interceptors.RecoveryStreamInterceptor(logger),
 		),
 	)
 

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
 	"github.com/meridianhub/meridian/services/financial-accounting/service"
+	"github.com/meridianhub/meridian/shared/pkg/interceptors"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
@@ -143,13 +144,16 @@ func run(logger *slog.Logger) error {
 
 	logger.Info("posting service initialized", "bank_cash_account_id", bankCashAccountID)
 
-	// Create gRPC server with observability interceptors
+	// Create gRPC server with interceptor chain
+	// Order: tracing → recovery (recovery last to catch all panics)
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
 			tracer.UnaryServerInterceptor(),
+			interceptors.RecoveryUnaryInterceptor(logger),
 		),
 		grpc.ChainStreamInterceptor(
 			tracer.StreamServerInterceptor(),
+			interceptors.RecoveryStreamInterceptor(logger),
 		),
 	)
 

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -19,6 +19,7 @@ import (
 	webhookhttp "github.com/meridianhub/meridian/services/payment-order/adapters/http"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
 	"github.com/meridianhub/meridian/services/payment-order/service"
+	"github.com/meridianhub/meridian/shared/pkg/interceptors"
 	"github.com/meridianhub/meridian/shared/platform/kafka"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
@@ -133,13 +134,16 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("failed to create payment order service: %w", err)
 	}
 
-	// Create gRPC server
+	// Create gRPC server with interceptor chain
+	// Order: tracing → recovery (recovery last to catch all panics)
 	grpcServer := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
 			tracer.UnaryServerInterceptor(),
+			interceptors.RecoveryUnaryInterceptor(logger),
 		),
 		grpc.ChainStreamInterceptor(
 			tracer.StreamServerInterceptor(),
+			interceptors.RecoveryStreamInterceptor(logger),
 		),
 	)
 

--- a/services/position-keeping/cmd/main.go
+++ b/services/position-keeping/cmd/main.go
@@ -15,10 +15,10 @@ import (
 
 	pb "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/app"
-	"github.com/meridianhub/meridian/services/position-keeping/interceptors"
 	"github.com/meridianhub/meridian/services/position-keeping/service"
 	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/pkg/interceptors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"

--- a/shared/pkg/interceptors/doc.go
+++ b/shared/pkg/interceptors/doc.go
@@ -1,0 +1,37 @@
+// Package interceptors provides shared gRPC interceptors for all Meridian services.
+//
+// The interceptors in this package provide cross-cutting concerns like panic recovery,
+// logging, and tracing that should be consistently applied across all gRPC services.
+//
+// # Panic Recovery
+//
+// The recovery interceptors prevent service crashes from panics in business logic:
+//
+//   - RecoveryUnaryInterceptor: Recovers from panics in unary RPCs
+//   - RecoveryStreamInterceptor: Recovers from panics in streaming RPCs
+//   - RecoveryStreamInterceptorWithWrappedStream: Provides granular recovery for Send/Recv operations
+//
+// All recovery interceptors log panic details with stack traces for debugging and return
+// codes.Internal to clients without exposing internal error details.
+//
+// # Interceptor Chain Order
+//
+// When building an interceptor chain, the recommended order is:
+//
+//  1. Metrics (first to capture all requests)
+//  2. Tracing (for observability)
+//  3. Auth (authentication/authorization)
+//  4. Recovery (last to catch all panics from above layers)
+//
+// Example usage:
+//
+//	unaryInterceptors := []grpc.UnaryServerInterceptor{
+//	    metricsInterceptor,
+//	    tracer.UnaryServerInterceptor(),
+//	    authInterceptor,
+//	    interceptors.RecoveryUnaryInterceptor(logger),
+//	}
+//	grpcServer := grpc.NewServer(
+//	    grpc.ChainUnaryInterceptor(unaryInterceptors...),
+//	)
+package interceptors

--- a/shared/pkg/interceptors/recovery.go
+++ b/shared/pkg/interceptors/recovery.go
@@ -1,4 +1,4 @@
-// Package interceptors provides gRPC interceptors for the position-keeping service.
+// Package interceptors provides shared gRPC interceptors for all Meridian services.
 package interceptors
 
 import (
@@ -72,14 +72,14 @@ func RecoveryStreamInterceptor(logger *slog.Logger) grpc.StreamServerInterceptor
 	}
 }
 
-// wrappedServerStream wraps grpc.ServerStream to add panic recovery to individual stream operations
+// wrappedServerStream wraps grpc.ServerStream to add panic recovery to individual stream operations.
 type wrappedServerStream struct {
 	grpc.ServerStream
 	logger *slog.Logger
 	method string
 }
 
-// SendMsg recovers from panics during message sending
+// SendMsg recovers from panics during message sending.
 func (w *wrappedServerStream) SendMsg(m interface{}) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -93,7 +93,7 @@ func (w *wrappedServerStream) SendMsg(m interface{}) (err error) {
 	return w.ServerStream.SendMsg(m)
 }
 
-// RecvMsg recovers from panics during message receiving
+// RecvMsg recovers from panics during message receiving.
 func (w *wrappedServerStream) RecvMsg(m interface{}) (err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/shared/pkg/interceptors/recovery_test.go
+++ b/shared/pkg/interceptors/recovery_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/meridianhub/meridian/services/position-keeping/interceptors"
+	"github.com/meridianhub/meridian/shared/pkg/interceptors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// TestRecoveryUnaryInterceptor_NoPanic tests normal operation without panics
+// TestRecoveryUnaryInterceptor_NoPanic tests normal operation without panics.
 func TestRecoveryUnaryInterceptor_NoPanic(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	interceptor := interceptors.RecoveryUnaryInterceptor(logger)
@@ -34,7 +34,7 @@ func TestRecoveryUnaryInterceptor_NoPanic(t *testing.T) {
 	assert.Equal(t, expectedResp, resp)
 }
 
-// TestRecoveryUnaryInterceptor_PanicString tests recovery from string panic
+// TestRecoveryUnaryInterceptor_PanicString tests recovery from string panic.
 func TestRecoveryUnaryInterceptor_PanicString(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	interceptor := interceptors.RecoveryUnaryInterceptor(logger)
@@ -58,7 +58,7 @@ func TestRecoveryUnaryInterceptor_PanicString(t *testing.T) {
 	assert.Contains(t, st.Message(), "internal server error")
 }
 
-// TestRecoveryUnaryInterceptor_PanicError tests recovery from error panic
+// TestRecoveryUnaryInterceptor_PanicError tests recovery from error panic.
 func TestRecoveryUnaryInterceptor_PanicError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	interceptor := interceptors.RecoveryUnaryInterceptor(logger)
@@ -81,7 +81,7 @@ func TestRecoveryUnaryInterceptor_PanicError(t *testing.T) {
 	assert.Equal(t, codes.Internal, st.Code())
 }
 
-// TestRecoveryUnaryInterceptor_PanicNil tests recovery from nil panic
+// TestRecoveryUnaryInterceptor_PanicNil tests recovery from nil panic.
 func TestRecoveryUnaryInterceptor_PanicNil(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	interceptor := interceptors.RecoveryUnaryInterceptor(logger)
@@ -105,7 +105,7 @@ func TestRecoveryUnaryInterceptor_PanicNil(t *testing.T) {
 	assert.Equal(t, codes.Internal, st.Code())
 }
 
-// TestRecoveryUnaryInterceptor_HandlerError tests normal error returns are not affected
+// TestRecoveryUnaryInterceptor_HandlerError tests normal error returns are not affected.
 func TestRecoveryUnaryInterceptor_HandlerError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	interceptor := interceptors.RecoveryUnaryInterceptor(logger)
@@ -126,7 +126,7 @@ func TestRecoveryUnaryInterceptor_HandlerError(t *testing.T) {
 	assert.Equal(t, expectedErr, err)
 }
 
-// TestRecoveryStreamInterceptor_NoPanic tests stream handler without panic
+// TestRecoveryStreamInterceptor_NoPanic tests stream handler without panic.
 func TestRecoveryStreamInterceptor_NoPanic(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	interceptor := interceptors.RecoveryStreamInterceptor(logger)
@@ -144,7 +144,7 @@ func TestRecoveryStreamInterceptor_NoPanic(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestRecoveryStreamInterceptor_Panic tests stream handler with panic
+// TestRecoveryStreamInterceptor_Panic tests stream handler with panic.
 func TestRecoveryStreamInterceptor_Panic(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	interceptor := interceptors.RecoveryStreamInterceptor(logger)
@@ -166,7 +166,7 @@ func TestRecoveryStreamInterceptor_Panic(t *testing.T) {
 	assert.Equal(t, codes.Internal, st.Code())
 }
 
-// TestRecoveryStreamInterceptorWithWrappedStream_SendPanic tests panic in SendMsg
+// TestRecoveryStreamInterceptorWithWrappedStream_SendPanic tests panic in SendMsg.
 func TestRecoveryStreamInterceptorWithWrappedStream_SendPanic(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	interceptor := interceptors.RecoveryStreamInterceptorWithWrappedStream(logger)
@@ -193,7 +193,7 @@ func TestRecoveryStreamInterceptorWithWrappedStream_SendPanic(t *testing.T) {
 	assert.Equal(t, codes.Internal, st.Code())
 }
 
-// TestRecoveryStreamInterceptorWithWrappedStream_RecvPanic tests panic in RecvMsg
+// TestRecoveryStreamInterceptorWithWrappedStream_RecvPanic tests panic in RecvMsg.
 func TestRecoveryStreamInterceptorWithWrappedStream_RecvPanic(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	interceptor := interceptors.RecoveryStreamInterceptorWithWrappedStream(logger)
@@ -221,7 +221,7 @@ func TestRecoveryStreamInterceptorWithWrappedStream_RecvPanic(t *testing.T) {
 	assert.Equal(t, codes.Internal, st.Code())
 }
 
-// mockServerStream implements grpc.ServerStream for testing
+// mockServerStream implements grpc.ServerStream for testing.
 type mockServerStream struct {
 	grpc.ServerStream
 	sendPanic bool


### PR DESCRIPTION
## Summary

- Extract panic recovery interceptors from position-keeping to `shared/pkg/interceptors`
- Add recovery interceptors to all services (current-account, financial-accounting, payment-order)
- Ensures panics don't crash gRPC servers and clients receive proper `codes.Internal` errors

## Changes Made

**New shared interceptors package** (`shared/pkg/interceptors/`):
- `RecoveryUnaryInterceptor` - Recovers panics in unary RPCs
- `RecoveryStreamInterceptor` - Recovers panics in streaming RPCs
- `RecoveryStreamInterceptorWithWrappedStream` - Granular Send/Recv panic recovery
- Package documentation with interceptor chain ordering guidance

**Service updates**:
- `position-keeping`: Updated import from local to shared package
- `current-account`: Added recovery interceptors to gRPC server
- `financial-accounting`: Added recovery interceptors to gRPC server
- `payment-order`: Added recovery interceptors to gRPC server

## Technical Details

All interceptors:
- Log panic details with full stack traces via `slog.Logger`
- Return `codes.Internal` to clients (no internal details exposed)
- Placed last in interceptor chain to catch panics from all layers

## Testing

- Unit tests for all interceptor variants (string/error/nil panics)
- Tests for normal operation (no panic) and error pass-through
- Stream interceptor tests including Send/Recv panic recovery

Closes #224