### PR TITLE
test: Add financial-accounting benchmark tests

### DIFF
--- a/services/financial-accounting/adapters/persistence/repository_bench_test.go
+++ b/services/financial-accounting/adapters/persistence/repository_bench_test.go
@@ -13,6 +13,7 @@ package persistence
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -86,6 +87,7 @@ func BenchmarkSavePosting_Single(b *testing.B) {
 	tc := setupBenchContainer(b)
 	ctx := context.Background()
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StopTimer()
@@ -218,6 +220,7 @@ func BenchmarkGetPostingsByBookingLogID(b *testing.B) {
 		}
 	}
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		postings, err := tc.repo.GetPostingsByBookingLogID(ctx, bookingLogID)
@@ -290,22 +293,6 @@ func BenchmarkUpdatePosting(b *testing.B) {
 // BenchmarkListPostings benchmarks paginated list queries with various filters.
 // Target: P99 < 50ms
 func BenchmarkListPostings(b *testing.B) {
-	tc := setupBenchContainer(b)
-	ctx := context.Background()
-
-	// Setup: create diverse postings
-	for i := 0; i < 100; i++ {
-		bookingLogID := uuid.New()
-		direction := domain.PostingDirectionDebit
-		if i%2 == 1 {
-			direction = domain.PostingDirectionCredit
-		}
-		posting := createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-LIST-%08d", i))
-		if err := tc.repo.SavePosting(ctx, posting); err != nil {
-			b.Fatal(err)
-		}
-	}
-
 	testCases := []struct {
 		name   string
 		params ListPostingsParams
@@ -351,9 +338,9 @@ func BenchmarkListPostings(b *testing.B) {
 		},
 	}
 
-	for _, tc := range testCases {
-		b.Run(tc.name, func(b *testing.B) {
-			container := setupBenchContainer(b)
+	for _, testCase := range testCases {
+		b.Run(testCase.name, func(b *testing.B) {
+			tc := setupBenchContainer(b)
 			ctx := context.Background()
 
 			// Setup data for this sub-benchmark
@@ -364,14 +351,14 @@ func BenchmarkListPostings(b *testing.B) {
 					direction = domain.PostingDirectionCredit
 				}
 				posting := createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-LIST-%08d", i))
-				if err := container.repo.SavePosting(ctx, posting); err != nil {
+				if err := tc.repo.SavePosting(ctx, posting); err != nil {
 					b.Fatal(err)
 				}
 			}
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := container.repo.ListPostings(ctx, tc.params)
+				_, err := tc.repo.ListPostings(ctx, testCase.params)
 				if err != nil {
 					b.Fatal(err)
 				}
@@ -503,13 +490,13 @@ func BenchmarkConcurrentWrites(b *testing.B) {
 	tc := setupBenchContainer(b)
 	ctx := context.Background()
 
-	counter := 0
+	var counter atomic.Int64
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			counter++
+			n := counter.Add(1)
 			bookingLogID := uuid.New()
-			posting := createBenchPosting(b, bookingLogID, domain.PostingDirectionDebit, fmt.Sprintf("ACC-CONC-%08d", counter))
+			posting := createBenchPosting(b, bookingLogID, domain.PostingDirectionDebit, fmt.Sprintf("ACC-CONC-%08d", n))
 			if err := tc.repo.SavePosting(ctx, posting); err != nil {
 				b.Fatal(err)
 			}
@@ -568,29 +555,43 @@ func BenchmarkMixedWorkload(b *testing.B) {
 }
 
 // BenchmarkTransactionThroughput measures maximum transaction throughput.
+// Reports postings/sec as a custom metric to measure bulk insert performance.
 func BenchmarkTransactionThroughput(b *testing.B) {
 	tc := setupBenchContainer(b)
 	ctx := context.Background()
-
 	batchSize := 100
-	bookingLogID := uuid.New()
-	postings := make([]*domain.LedgerPosting, batchSize)
-	for i := 0; i < batchSize; i++ {
-		direction := domain.PostingDirectionDebit
-		if i%2 == 1 {
-			direction = domain.PostingDirectionCredit
-		}
-		postings[i] = createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-THRU-%d", i))
-	}
 
+	b.ReportAllocs()
 	b.ResetTimer()
-	err := tc.repo.SavePostingsInTransaction(ctx, postings)
-	if err != nil {
-		b.Fatal(err)
+
+	totalPostings := 0
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		bookingLogID := uuid.New()
+		postings := make([]*domain.LedgerPosting, batchSize)
+		for j := 0; j < batchSize; j++ {
+			direction := domain.PostingDirectionDebit
+			if j%2 == 1 {
+				direction = domain.PostingDirectionCredit
+			}
+			postings[j] = createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-THRU-%d-%d", i, j))
+		}
+		b.StartTimer()
+
+		err := tc.repo.SavePostingsInTransaction(ctx, postings)
+		if err != nil {
+			b.Fatal(err)
+		}
+		totalPostings += batchSize
 	}
 
-	// Report transactions per second
-	duration := b.Elapsed()
-	txnPerSec := float64(batchSize) / duration.Seconds()
-	b.ReportMetric(txnPerSec, "postings/sec")
+	b.StopTimer()
+	// Report postings per second as a custom metric
+	if b.N > 0 {
+		duration := b.Elapsed()
+		if duration.Seconds() > 0 {
+			postingsPerSec := float64(totalPostings) / duration.Seconds()
+			b.ReportMetric(postingsPerSec, "postings/sec")
+		}
+	}
 }

--- a/services/financial-accounting/adapters/persistence/repository_bench_test.go
+++ b/services/financial-accounting/adapters/persistence/repository_bench_test.go
@@ -1,0 +1,596 @@
+// Package persistence provides performance benchmarks for PostgreSQL repository operations.
+//
+// These benchmarks measure repository persistence operations with real PostgreSQL instances.
+// Target metrics:
+//   - Single posting save: P99 < 20ms
+//   - Batch save (10 postings): P99 < 50ms
+//   - Query by booking log ID: P99 < 10ms
+//   - List with filters: P99 < 50ms
+//
+// Run with: go test -bench=BenchmarkRepository -benchmem -benchtime=10s
+package persistence
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/financial-accounting/domain"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+// benchTestContainer holds test infrastructure for benchmarks
+type benchTestContainer struct {
+	db      *gorm.DB
+	repo    *LedgerRepository
+	cleanup func()
+}
+
+// setupBenchContainer creates a test container for benchmarking.
+func setupBenchContainer(b *testing.B) *benchTestContainer {
+	b.Helper()
+
+	db, cleanup := testdb.SetupPostgres(&testing.T{}, []interface{}{
+		&LedgerPostingEntity{},
+		&FinancialBookingLogEntity{},
+	})
+
+	repo := NewLedgerRepository(db)
+
+	b.Cleanup(func() {
+		cleanup()
+	})
+
+	return &benchTestContainer{
+		db:      db,
+		repo:    repo,
+		cleanup: cleanup,
+	}
+}
+
+// createBenchPosting creates a realistic ledger posting for benchmarking.
+func createBenchPosting(b *testing.B, bookingLogID uuid.UUID, direction domain.PostingDirection, accountID string) *domain.LedgerPosting {
+	b.Helper()
+
+	money, err := domain.NewMoney(decimal.NewFromFloat(100.50), domain.CurrencyGBP)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	posting, err := domain.NewLedgerPosting(
+		bookingLogID,
+		direction,
+		money,
+		accountID,
+		time.Now().UTC(),
+		fmt.Sprintf("corr-%s", uuid.New().String()[:8]),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if err := posting.Post("benchmark"); err != nil {
+		b.Fatal(err)
+	}
+
+	return posting
+}
+
+// BenchmarkSavePosting_Single benchmarks saving a single posting.
+// Target: P99 < 20ms
+func BenchmarkSavePosting_Single(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		bookingLogID := uuid.New()
+		posting := createBenchPosting(b, bookingLogID, domain.PostingDirectionDebit, fmt.Sprintf("ACC-%08d", i))
+		b.StartTimer()
+
+		err := tc.repo.SavePosting(ctx, posting)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkSavePostingsInTransaction_Small benchmarks batch creation with 2 postings.
+// This represents typical double-entry bookkeeping (debit + credit).
+func BenchmarkSavePostingsInTransaction_Small(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		bookingLogID := uuid.New()
+		postings := []*domain.LedgerPosting{
+			createBenchPosting(b, bookingLogID, domain.PostingDirectionDebit, fmt.Sprintf("ACC-D-%08d", i)),
+			createBenchPosting(b, bookingLogID, domain.PostingDirectionCredit, fmt.Sprintf("ACC-C-%08d", i)),
+		}
+		b.StartTimer()
+
+		err := tc.repo.SavePostingsInTransaction(ctx, postings)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkSavePostingsInTransaction_Medium benchmarks batch creation with 10 postings.
+func BenchmarkSavePostingsInTransaction_Medium(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+	batchSize := 10
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		bookingLogID := uuid.New()
+		postings := make([]*domain.LedgerPosting, batchSize)
+		for j := 0; j < batchSize; j++ {
+			direction := domain.PostingDirectionDebit
+			if j%2 == 1 {
+				direction = domain.PostingDirectionCredit
+			}
+			postings[j] = createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-%d-%d", i, j))
+		}
+		b.StartTimer()
+
+		err := tc.repo.SavePostingsInTransaction(ctx, postings)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkSavePostingsInTransaction_Large benchmarks batch creation with 100 postings.
+func BenchmarkSavePostingsInTransaction_Large(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+	batchSize := 100
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		bookingLogID := uuid.New()
+		postings := make([]*domain.LedgerPosting, batchSize)
+		for j := 0; j < batchSize; j++ {
+			direction := domain.PostingDirectionDebit
+			if j%2 == 1 {
+				direction = domain.PostingDirectionCredit
+			}
+			postings[j] = createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-%d-%d", i, j))
+		}
+		b.StartTimer()
+
+		err := tc.repo.SavePostingsInTransaction(ctx, postings)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkGetPosting benchmarks retrieving a single posting by ID.
+func BenchmarkGetPosting(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	// Setup: create a posting to retrieve
+	bookingLogID := uuid.New()
+	posting := createBenchPosting(b, bookingLogID, domain.PostingDirectionDebit, "ACC-GET-TEST")
+	if err := tc.repo.SavePosting(ctx, posting); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := tc.repo.GetPosting(ctx, posting.ID)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkGetPostingsByBookingLogID benchmarks retrieving all postings for a booking log.
+// Target: P99 < 10ms
+func BenchmarkGetPostingsByBookingLogID(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	bookingLogID := uuid.New()
+
+	// Setup: create multiple postings for the same booking log
+	for i := 0; i < 10; i++ {
+		direction := domain.PostingDirectionDebit
+		if i%2 == 1 {
+			direction = domain.PostingDirectionCredit
+		}
+		posting := createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-GROUP-%d", i))
+		if err := tc.repo.SavePosting(ctx, posting); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		postings, err := tc.repo.GetPostingsByBookingLogID(ctx, bookingLogID)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(postings) != 10 {
+			b.Fatalf("expected 10 postings, got %d", len(postings))
+		}
+	}
+}
+
+// BenchmarkGetPostingsByBookingLogID_LargeResultSet benchmarks retrieval with many postings.
+func BenchmarkGetPostingsByBookingLogID_LargeResultSet(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	bookingLogID := uuid.New()
+
+	// Setup: create 100 postings for the same booking log
+	for i := 0; i < 100; i++ {
+		direction := domain.PostingDirectionDebit
+		if i%2 == 1 {
+			direction = domain.PostingDirectionCredit
+		}
+		posting := createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-LARGE-%d", i))
+		if err := tc.repo.SavePosting(ctx, posting); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		postings, err := tc.repo.GetPostingsByBookingLogID(ctx, bookingLogID)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(postings) != 100 {
+			b.Fatalf("expected 100 postings, got %d", len(postings))
+		}
+	}
+}
+
+// BenchmarkUpdatePosting benchmarks updating an existing posting.
+func BenchmarkUpdatePosting(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		// Create a fresh posting for each update
+		bookingLogID := uuid.New()
+		posting := createBenchPosting(b, bookingLogID, domain.PostingDirectionDebit, fmt.Sprintf("ACC-UPDATE-%d", i))
+		if err := tc.repo.SavePosting(ctx, posting); err != nil {
+			b.Fatal(err)
+		}
+
+		// Modify the posting
+		posting.PostingResult = "Updated result"
+		b.StartTimer()
+
+		err := tc.repo.UpdatePosting(ctx, posting)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkListPostings benchmarks paginated list queries with various filters.
+// Target: P99 < 50ms
+func BenchmarkListPostings(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	// Setup: create diverse postings
+	for i := 0; i < 100; i++ {
+		bookingLogID := uuid.New()
+		direction := domain.PostingDirectionDebit
+		if i%2 == 1 {
+			direction = domain.PostingDirectionCredit
+		}
+		posting := createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-LIST-%08d", i))
+		if err := tc.repo.SavePosting(ctx, posting); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	testCases := []struct {
+		name   string
+		params ListPostingsParams
+	}{
+		{
+			name: "NoFilter",
+			params: ListPostingsParams{
+				PageSize: 50,
+			},
+		},
+		{
+			name: "FilterByDirection",
+			params: ListPostingsParams{
+				PostingDirection: "DEBIT",
+				PageSize:         50,
+			},
+		},
+		{
+			name: "FilterByCurrency",
+			params: ListPostingsParams{
+				Currency: "GBP",
+				PageSize: 50,
+			},
+		},
+		{
+			name: "FilterByStatus",
+			params: ListPostingsParams{
+				Status:   "POSTED",
+				PageSize: 50,
+			},
+		},
+		{
+			name: "SmallPage",
+			params: ListPostingsParams{
+				PageSize: 10,
+			},
+		},
+		{
+			name: "LargePage",
+			params: ListPostingsParams{
+				PageSize: 100,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		b.Run(tc.name, func(b *testing.B) {
+			container := setupBenchContainer(b)
+			ctx := context.Background()
+
+			// Setup data for this sub-benchmark
+			for i := 0; i < 100; i++ {
+				bookingLogID := uuid.New()
+				direction := domain.PostingDirectionDebit
+				if i%2 == 1 {
+					direction = domain.PostingDirectionCredit
+				}
+				posting := createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-LIST-%08d", i))
+				if err := container.repo.SavePosting(ctx, posting); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := container.repo.ListPostings(ctx, tc.params)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkListPostings_LargeDataset benchmarks list queries against a large dataset.
+func BenchmarkListPostings_LargeDataset(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	// Setup: create 1000 postings
+	for i := 0; i < 1000; i++ {
+		bookingLogID := uuid.New()
+		direction := domain.PostingDirectionDebit
+		if i%2 == 1 {
+			direction = domain.PostingDirectionCredit
+		}
+		posting := createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-LARGE-DS-%08d", i))
+		if err := tc.repo.SavePosting(ctx, posting); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	params := ListPostingsParams{
+		PageSize: 50,
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := tc.repo.ListPostings(ctx, params)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkListBookingLogs benchmarks listing booking logs.
+func BenchmarkListBookingLogs(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	// Setup: create booking logs
+	for i := 0; i < 100; i++ {
+		entity := &FinancialBookingLogEntity{
+			ID:                      uuid.New(),
+			FinancialAccountType:    "DEBIT",
+			ProductServiceReference: fmt.Sprintf("PROD-%d", i),
+			BusinessUnitReference:   fmt.Sprintf("BU-%d", i%5),
+			ChartOfAccountsRules:    "{}",
+			BaseCurrency:            "GBP",
+			Status:                  "ACTIVE",
+			IdempotencyKey:          fmt.Sprintf("idem-bench-%s", uuid.New().String()),
+			CreatedAt:               time.Now(),
+			UpdatedAt:               time.Now(),
+			Version:                 1,
+		}
+		if err := tc.db.Create(entity).Error; err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	testCases := []struct {
+		name   string
+		params ListBookingLogsParams
+	}{
+		{
+			name: "NoFilter",
+			params: ListBookingLogsParams{
+				PageSize: 50,
+			},
+		},
+		{
+			name: "FilterByStatus",
+			params: ListBookingLogsParams{
+				StatusFilter: "ACTIVE",
+				PageSize:     50,
+			},
+		},
+		{
+			name: "FilterByBusinessUnit",
+			params: ListBookingLogsParams{
+				BusinessUnitFilter: "BU-0",
+				PageSize:           50,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		b.Run(testCase.name, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := tc.repo.ListBookingLogs(ctx, testCase.params)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkConcurrentReads benchmarks concurrent read operations.
+func BenchmarkConcurrentReads(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	// Setup: create test data
+	bookingLogID := uuid.New()
+	posting := createBenchPosting(b, bookingLogID, domain.PostingDirectionDebit, "ACC-CONCURRENT-READ")
+	if err := tc.repo.SavePosting(ctx, posting); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := tc.repo.GetPosting(ctx, posting.ID)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkConcurrentWrites benchmarks concurrent write operations.
+func BenchmarkConcurrentWrites(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	counter := 0
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			counter++
+			bookingLogID := uuid.New()
+			posting := createBenchPosting(b, bookingLogID, domain.PostingDirectionDebit, fmt.Sprintf("ACC-CONC-%08d", counter))
+			if err := tc.repo.SavePosting(ctx, posting); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkMixedWorkload benchmarks a realistic mix of operations.
+// 60% reads, 30% creates, 10% updates.
+func BenchmarkMixedWorkload(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	// Setup: pre-populate some data
+	var postingIDs []uuid.UUID
+	for i := 0; i < 100; i++ {
+		bookingLogID := uuid.New()
+		posting := createBenchPosting(b, bookingLogID, domain.PostingDirectionDebit, fmt.Sprintf("ACC-MIXED-%08d", i))
+		if err := tc.repo.SavePosting(ctx, posting); err != nil {
+			b.Fatal(err)
+		}
+		postingIDs = append(postingIDs, posting.ID)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		operation := i % 10
+
+		switch {
+		case operation < 6: // 60% reads
+			idx := i % len(postingIDs)
+			_, err := tc.repo.GetPosting(ctx, postingIDs[idx])
+			if err != nil {
+				b.Fatal(err)
+			}
+
+		case operation < 9: // 30% creates
+			bookingLogID := uuid.New()
+			posting := createBenchPosting(b, bookingLogID, domain.PostingDirectionDebit, fmt.Sprintf("ACC-NEW-%08d", i))
+			if err := tc.repo.SavePosting(ctx, posting); err != nil {
+				b.Fatal(err)
+			}
+
+		default: // 10% updates
+			idx := i % len(postingIDs)
+			posting, err := tc.repo.GetPosting(ctx, postingIDs[idx])
+			if err != nil {
+				b.Fatal(err)
+			}
+			posting.PostingResult = fmt.Sprintf("Updated at iteration %d", i)
+			if err := tc.repo.UpdatePosting(ctx, posting); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}
+
+// BenchmarkTransactionThroughput measures maximum transaction throughput.
+func BenchmarkTransactionThroughput(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	batchSize := 100
+	bookingLogID := uuid.New()
+	postings := make([]*domain.LedgerPosting, batchSize)
+	for i := 0; i < batchSize; i++ {
+		direction := domain.PostingDirectionDebit
+		if i%2 == 1 {
+			direction = domain.PostingDirectionCredit
+		}
+		postings[i] = createBenchPosting(b, bookingLogID, direction, fmt.Sprintf("ACC-THRU-%d", i))
+	}
+
+	b.ResetTimer()
+	err := tc.repo.SavePostingsInTransaction(ctx, postings)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Report transactions per second
+	duration := b.Elapsed()
+	txnPerSec := float64(batchSize) / duration.Seconds()
+	b.ReportMetric(txnPerSec, "postings/sec")
+}

--- a/services/financial-accounting/adapters/persistence/repository_bench_test.go
+++ b/services/financial-accounting/adapters/persistence/repository_bench_test.go
@@ -474,12 +474,18 @@ func BenchmarkConcurrentReads(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	var hasError atomic.Bool
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
+			if hasError.Load() {
+				return
+			}
 			_, err := tc.repo.GetPosting(ctx, posting.ID)
 			if err != nil {
-				b.Fatal(err)
+				hasError.Store(true)
+				b.Error(err)
+				return
 			}
 		}
 	})
@@ -491,14 +497,20 @@ func BenchmarkConcurrentWrites(b *testing.B) {
 	ctx := context.Background()
 
 	var counter atomic.Int64
+	var hasError atomic.Bool
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
+			if hasError.Load() {
+				return
+			}
 			n := counter.Add(1)
 			bookingLogID := uuid.New()
 			posting := createBenchPosting(b, bookingLogID, domain.PostingDirectionDebit, fmt.Sprintf("ACC-CONC-%08d", n))
 			if err := tc.repo.SavePosting(ctx, posting); err != nil {
-				b.Fatal(err)
+				hasError.Store(true)
+				b.Error(err)
+				return
 			}
 		}
 	})

--- a/services/financial-accounting/service/posting_service_bench_test.go
+++ b/services/financial-accounting/service/posting_service_bench_test.go
@@ -98,14 +98,20 @@ func BenchmarkProcessDeposit_Parallel(b *testing.B) {
 	ctx := context.Background()
 
 	var counter atomic.Int64
+	var hasError atomic.Bool
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
+			if hasError.Load() {
+				return
+			}
 			n := counter.Add(1)
 			event := createBenchDepositEvent(int(n))
 			err := tc.service.ProcessDeposit(ctx, event)
 			if err != nil {
-				b.Fatal(err)
+				hasError.Store(true)
+				b.Error(err)
+				return
 			}
 		}
 	})
@@ -187,9 +193,12 @@ func BenchmarkValidateDoubleEntry_MultiplePostings(b *testing.B) {
 
 	// Create multiple balanced posting pairs
 	for i := 0; i < 10; i++ {
-		money, _ := domain.NewMoney(decimal.NewFromInt(int64(100+i)), domain.CurrencyGBP)
+		money, err := domain.NewMoney(decimal.NewFromInt(int64(100+i)), domain.CurrencyGBP)
+		if err != nil {
+			b.Fatal(err)
+		}
 
-		debit, _ := domain.NewLedgerPosting(
+		debit, err := domain.NewLedgerPosting(
 			bookingLogID,
 			domain.PostingDirectionDebit,
 			money,
@@ -197,12 +206,17 @@ func BenchmarkValidateDoubleEntry_MultiplePostings(b *testing.B) {
 			time.Now().UTC(),
 			fmt.Sprintf("corr-%d", i),
 		)
-		_ = debit.Post("benchmark")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := debit.Post("benchmark"); err != nil {
+			b.Fatal(err)
+		}
 		if err := tc.repo.SavePosting(ctx, debit); err != nil {
 			b.Fatal(err)
 		}
 
-		credit, _ := domain.NewLedgerPosting(
+		credit, err := domain.NewLedgerPosting(
 			bookingLogID,
 			domain.PostingDirectionCredit,
 			money,
@@ -210,7 +224,12 @@ func BenchmarkValidateDoubleEntry_MultiplePostings(b *testing.B) {
 			time.Now().UTC(),
 			fmt.Sprintf("corr-%d", i),
 		)
-		_ = credit.Post("benchmark")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if err := credit.Post("benchmark"); err != nil {
+			b.Fatal(err)
+		}
 		if err := tc.repo.SavePosting(ctx, credit); err != nil {
 			b.Fatal(err)
 		}
@@ -271,13 +290,16 @@ func BenchmarkGetPostingsByBookingLog_ManyPostings(b *testing.B) {
 
 			// Create many postings for the same booking log
 			for i := 0; i < postingCount; i++ {
-				money, _ := domain.NewMoney(decimal.NewFromInt(int64(100)), domain.CurrencyGBP)
+				money, err := domain.NewMoney(decimal.NewFromInt(int64(100)), domain.CurrencyGBP)
+				if err != nil {
+					b.Fatal(err)
+				}
 				direction := domain.PostingDirectionDebit
 				if i%2 == 1 {
 					direction = domain.PostingDirectionCredit
 				}
 
-				posting, _ := domain.NewLedgerPosting(
+				posting, err := domain.NewLedgerPosting(
 					bookingLogID,
 					direction,
 					money,
@@ -285,7 +307,12 @@ func BenchmarkGetPostingsByBookingLog_ManyPostings(b *testing.B) {
 					time.Now().UTC(),
 					fmt.Sprintf("corr-%d", i),
 				)
-				_ = posting.Post("benchmark")
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := posting.Post("benchmark"); err != nil {
+					b.Fatal(err)
+				}
 				if err := tc.repo.SavePosting(ctx, posting); err != nil {
 					b.Fatal(err)
 				}

--- a/services/financial-accounting/service/posting_service_bench_test.go
+++ b/services/financial-accounting/service/posting_service_bench_test.go
@@ -12,6 +12,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -79,6 +80,7 @@ func BenchmarkProcessDeposit_Single(b *testing.B) {
 	tc := setupBenchContainer(b)
 	ctx := context.Background()
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		event := createBenchDepositEvent(i)
@@ -95,12 +97,12 @@ func BenchmarkProcessDeposit_Parallel(b *testing.B) {
 	tc := setupBenchContainer(b)
 	ctx := context.Background()
 
-	counter := 0
+	var counter atomic.Int64
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			counter++
-			event := createBenchDepositEvent(counter)
+			n := counter.Add(1)
+			event := createBenchDepositEvent(int(n))
 			err := tc.service.ProcessDeposit(ctx, event)
 			if err != nil {
 				b.Fatal(err)
@@ -162,6 +164,7 @@ func BenchmarkValidateDoubleEntry(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		balanced, err := tc.service.ValidateDoubleEntry(ctx, entity.FinancialBookingLogID)

--- a/services/financial-accounting/service/posting_service_bench_test.go
+++ b/services/financial-accounting/service/posting_service_bench_test.go
@@ -1,0 +1,361 @@
+// Package service provides performance benchmarks for ledger posting operations.
+//
+// These benchmarks measure service-layer operations with real PostgreSQL instances.
+// Target metrics:
+//   - Single deposit processing: P99 < 50ms (includes double-entry creation)
+//   - Double-entry validation: P99 < 10ms
+//   - Batch retrieval: <1ms per posting
+//
+// Run with: go test -bench=BenchmarkPosting -benchmem -benchtime=10s
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
+	"github.com/meridianhub/meridian/services/financial-accounting/domain"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+// benchTestContainer holds test infrastructure for benchmarks
+type benchTestContainer struct {
+	db      *gorm.DB
+	repo    *persistence.LedgerRepository
+	service *PostingService
+	cleanup func()
+}
+
+// setupBenchContainer creates a test container for benchmarking.
+// The container is reused across benchmark iterations to avoid setup overhead.
+func setupBenchContainer(b *testing.B) *benchTestContainer {
+	b.Helper()
+
+	// Use testing.T for setup since testdb expects *testing.T
+	db, cleanup := testdb.SetupPostgres(&testing.T{}, []interface{}{
+		&persistence.LedgerPostingEntity{},
+		&persistence.FinancialBookingLogEntity{},
+	})
+
+	repo := persistence.NewLedgerRepository(db)
+	service := NewPostingService(repo, "BANK-CASH-BENCH")
+
+	b.Cleanup(func() {
+		cleanup()
+	})
+
+	return &benchTestContainer{
+		db:      db,
+		repo:    repo,
+		service: service,
+		cleanup: cleanup,
+	}
+}
+
+// createBenchDepositEvent creates a realistic deposit event for benchmarking.
+func createBenchDepositEvent(i int) DepositEvent {
+	return DepositEvent{
+		AccountID:     fmt.Sprintf("ACC-BENCH-%08d", i),
+		AmountCents:   int64(10000 + (i % 100000)), // Vary amounts
+		Currency:      "GBP",
+		CorrelationID: fmt.Sprintf("deposit-bench-%s", uuid.New().String()[:8]),
+		ValueDate:     time.Now().UTC(),
+	}
+}
+
+// BenchmarkProcessDeposit_Single benchmarks processing a single deposit.
+// This measures the full double-entry creation flow including:
+//   - Money creation and validation
+//   - Debit/credit posting creation
+//   - Atomic transaction save
+//
+// Target: P99 < 50ms
+func BenchmarkProcessDeposit_Single(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		event := createBenchDepositEvent(i)
+		err := tc.service.ProcessDeposit(ctx, event)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkProcessDeposit_Parallel benchmarks concurrent deposit processing.
+// This tests the system's ability to handle concurrent double-entry transactions.
+func BenchmarkProcessDeposit_Parallel(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	counter := 0
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			counter++
+			event := createBenchDepositEvent(counter)
+			err := tc.service.ProcessDeposit(ctx, event)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkProcessDeposit_VariedAmounts benchmarks deposits with different amounts.
+// Tests that amount processing performance is consistent across value ranges.
+func BenchmarkProcessDeposit_VariedAmounts(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	amounts := []int64{
+		100,         // £1.00
+		10000,       // £100.00
+		100000,      // £1,000.00
+		10000000,    // £100,000.00
+		10000000000, // £100,000,000.00
+	}
+
+	for _, amount := range amounts {
+		b.Run(fmt.Sprintf("Amount_%d", amount), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				event := DepositEvent{
+					AccountID:     fmt.Sprintf("ACC-VAR-%08d", i),
+					AmountCents:   amount,
+					Currency:      "GBP",
+					CorrelationID: fmt.Sprintf("deposit-var-%s", uuid.New().String()[:8]),
+					ValueDate:     time.Now().UTC(),
+				}
+				err := tc.service.ProcessDeposit(ctx, event)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkValidateDoubleEntry benchmarks double-entry validation.
+// Target: P99 < 10ms
+func BenchmarkValidateDoubleEntry(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	// Setup: Create a deposit to validate
+	event := createBenchDepositEvent(0)
+	err := tc.service.ProcessDeposit(ctx, event)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Get the booking log ID from the created posting
+	var entity persistence.LedgerPostingEntity
+	if err := tc.db.First(&entity).Error; err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		balanced, err := tc.service.ValidateDoubleEntry(ctx, entity.FinancialBookingLogID)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !balanced {
+			b.Fatal("expected balanced double entry")
+		}
+	}
+}
+
+// BenchmarkValidateDoubleEntry_MultiplePostings benchmarks validation with many postings.
+// Tests validation performance when booking log has multiple entries.
+func BenchmarkValidateDoubleEntry_MultiplePostings(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	bookingLogID := uuid.New()
+
+	// Create multiple balanced posting pairs
+	for i := 0; i < 10; i++ {
+		money, _ := domain.NewMoney(decimal.NewFromInt(int64(100+i)), domain.CurrencyGBP)
+
+		debit, _ := domain.NewLedgerPosting(
+			bookingLogID,
+			domain.PostingDirectionDebit,
+			money,
+			fmt.Sprintf("ACC-DEBIT-%d", i),
+			time.Now().UTC(),
+			fmt.Sprintf("corr-%d", i),
+		)
+		_ = debit.Post("benchmark")
+		if err := tc.repo.SavePosting(ctx, debit); err != nil {
+			b.Fatal(err)
+		}
+
+		credit, _ := domain.NewLedgerPosting(
+			bookingLogID,
+			domain.PostingDirectionCredit,
+			money,
+			fmt.Sprintf("ACC-CREDIT-%d", i),
+			time.Now().UTC(),
+			fmt.Sprintf("corr-%d", i),
+		)
+		_ = credit.Post("benchmark")
+		if err := tc.repo.SavePosting(ctx, credit); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		balanced, err := tc.service.ValidateDoubleEntry(ctx, bookingLogID)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if !balanced {
+			b.Fatal("expected balanced double entry")
+		}
+	}
+}
+
+// BenchmarkGetPostingsByBookingLog benchmarks retrieval of postings for a booking log.
+func BenchmarkGetPostingsByBookingLog(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	// Setup: Create a deposit
+	event := createBenchDepositEvent(0)
+	err := tc.service.ProcessDeposit(ctx, event)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// Get the booking log ID
+	var entity persistence.LedgerPostingEntity
+	if err := tc.db.First(&entity).Error; err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		postings, err := tc.service.GetPostingsByBookingLog(ctx, entity.FinancialBookingLogID)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(postings) != 2 {
+			b.Fatalf("expected 2 postings, got %d", len(postings))
+		}
+	}
+}
+
+// BenchmarkGetPostingsByBookingLog_ManyPostings benchmarks retrieval with many postings.
+func BenchmarkGetPostingsByBookingLog_ManyPostings(b *testing.B) {
+	testCases := []int{10, 50, 100}
+
+	for _, postingCount := range testCases {
+		b.Run(fmt.Sprintf("Postings_%d", postingCount), func(b *testing.B) {
+			tc := setupBenchContainer(b)
+			ctx := context.Background()
+
+			bookingLogID := uuid.New()
+
+			// Create many postings for the same booking log
+			for i := 0; i < postingCount; i++ {
+				money, _ := domain.NewMoney(decimal.NewFromInt(int64(100)), domain.CurrencyGBP)
+				direction := domain.PostingDirectionDebit
+				if i%2 == 1 {
+					direction = domain.PostingDirectionCredit
+				}
+
+				posting, _ := domain.NewLedgerPosting(
+					bookingLogID,
+					direction,
+					money,
+					fmt.Sprintf("ACC-%d", i),
+					time.Now().UTC(),
+					fmt.Sprintf("corr-%d", i),
+				)
+				_ = posting.Post("benchmark")
+				if err := tc.repo.SavePosting(ctx, posting); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				postings, err := tc.service.GetPostingsByBookingLog(ctx, bookingLogID)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if len(postings) != postingCount {
+					b.Fatalf("expected %d postings, got %d", postingCount, len(postings))
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkMixedServiceWorkload benchmarks a realistic mix of service operations.
+// 50% deposit processing, 30% retrieval, 20% validation
+func BenchmarkMixedServiceWorkload(b *testing.B) {
+	tc := setupBenchContainer(b)
+	ctx := context.Background()
+
+	// Pre-create some deposits for retrieval/validation operations
+	var bookingLogIDs []uuid.UUID
+	for i := 0; i < 20; i++ {
+		event := createBenchDepositEvent(i)
+		if err := tc.service.ProcessDeposit(ctx, event); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	// Get booking log IDs from created postings
+	var entities []persistence.LedgerPostingEntity
+	if err := tc.db.Find(&entities).Error; err != nil {
+		b.Fatal(err)
+	}
+
+	// Collect unique booking log IDs
+	seen := make(map[uuid.UUID]bool)
+	for _, e := range entities {
+		if !seen[e.FinancialBookingLogID] {
+			bookingLogIDs = append(bookingLogIDs, e.FinancialBookingLogID)
+			seen[e.FinancialBookingLogID] = true
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		operation := i % 10
+
+		switch {
+		case operation < 5: // 50% deposits
+			event := createBenchDepositEvent(i + 1000)
+			if err := tc.service.ProcessDeposit(ctx, event); err != nil {
+				b.Fatal(err)
+			}
+
+		case operation < 8: // 30% retrieval
+			idx := i % len(bookingLogIDs)
+			_, err := tc.service.GetPostingsByBookingLog(ctx, bookingLogIDs[idx])
+			if err != nil {
+				b.Fatal(err)
+			}
+
+		default: // 20% validation
+			idx := i % len(bookingLogIDs)
+			_, err := tc.service.ValidateDoubleEntry(ctx, bookingLogIDs[idx])
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `service/posting_service_bench_test.go` for ledger posting operations
- Add `adapters/persistence/repository_bench_test.go` for database operations

## Changes Made

### Service Benchmarks (`posting_service_bench_test.go`)
- `BenchmarkProcessDeposit_Single` - Full double-entry deposit processing
- `BenchmarkProcessDeposit_Parallel` - Concurrent deposit handling
- `BenchmarkProcessDeposit_VariedAmounts` - Performance across value ranges
- `BenchmarkValidateDoubleEntry` - Double-entry validation
- `BenchmarkValidateDoubleEntry_MultiplePostings` - Validation with many postings
- `BenchmarkGetPostingsByBookingLog` - Posting retrieval
- `BenchmarkGetPostingsByBookingLog_ManyPostings` - Large result set retrieval
- `BenchmarkMixedServiceWorkload` - Realistic workload mix (50% deposits, 30% retrieval, 20% validation)

### Repository Benchmarks (`repository_bench_test.go`)
- `BenchmarkSavePosting_Single` - Single posting persistence
- `BenchmarkSavePostingsInTransaction_*` - Batch saves (2, 10, 100 postings)
- `BenchmarkGetPosting` - Single posting retrieval
- `BenchmarkGetPostingsByBookingLogID` - Query by booking log
- `BenchmarkGetPostingsByBookingLogID_LargeResultSet` - Large result handling
- `BenchmarkUpdatePosting` - Update operations
- `BenchmarkListPostings` - Paginated list with various filters
- `BenchmarkListPostings_LargeDataset` - Large dataset pagination
- `BenchmarkListBookingLogs` - Booking log listing
- `BenchmarkConcurrentReads/Writes` - Concurrent access patterns
- `BenchmarkMixedWorkload` - Realistic workload (60% reads, 30% creates, 10% updates)
- `BenchmarkTransactionThroughput` - Throughput measurement

## Testing

```bash
# Run all benchmarks
go test -bench=. -benchmem ./services/financial-accounting/service/
go test -bench=. -benchmem ./services/financial-accounting/adapters/persistence/

# Run specific benchmark
go test -bench=BenchmarkProcessDeposit_Single -benchtime=10s -benchmem ./services/financial-accounting/service/
```

Sample output:
```
BenchmarkProcessDeposit_Single-16    1    11813875 ns/op
BenchmarkSavePosting_Single-16       1     5696417 ns/op
BenchmarkValidateDoubleEntry-16      1     1968250 ns/op
```

## Acceptance Criteria

- ✅ Key hot paths have benchmark coverage
- ✅ Benchmarks follow Go conventions (`Benchmark*` functions)
- ✅ Results establish baseline for performance regression detection

Closes #227