### PR TITLE
feat: Extract shared client patterns (circuit breaker, retry, saga)

### DIFF
--- a/services/current-account/clients/circuitbreaker.go
+++ b/services/current-account/clients/circuitbreaker.go
@@ -1,104 +1,49 @@
+// Package clients provides gRPC client wrappers with resilience patterns.
+//
+// This package re-exports types from shared/pkg/clients for backward compatibility.
+// New code should import directly from github.com/meridianhub/meridian/shared/pkg/clients.
 package clients
 
 import (
-	"context"
-	"fmt"
-	"log/slog"
-	"time"
-
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/sony/gobreaker/v2"
 )
 
-// CircuitBreakerConfig holds configuration for circuit breaker
-type CircuitBreakerConfig struct {
-	Name          string
-	MaxRequests   uint32
-	Interval      time.Duration
-	Timeout       time.Duration
-	ReadyToTrip   func(counts gobreaker.Counts) bool
-	OnStateChange func(name string, from gobreaker.State, to gobreaker.State)
-}
+// CircuitBreakerConfig is an alias to the shared implementation.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
+type CircuitBreakerConfig = sharedclients.CircuitBreakerConfig
 
-// CircuitBreaker wraps sony/gobreaker with context support and logging
-type CircuitBreaker struct {
-	cb     *gobreaker.CircuitBreaker[any]
-	logger *slog.Logger
-}
+// CircuitBreaker is an alias to the shared implementation.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
+type CircuitBreaker = sharedclients.CircuitBreaker
 
-// DefaultCircuitBreakerConfig returns a circuit breaker configuration with sensible defaults
+// DefaultCircuitBreakerConfig returns a circuit breaker configuration with sensible defaults.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
 func DefaultCircuitBreakerConfig(name string) CircuitBreakerConfig {
-	return CircuitBreakerConfig{
-		Name:        name,
-		MaxRequests: 1,
-		Interval:    60 * time.Second,
-		Timeout:     30 * time.Second,
-		ReadyToTrip: func(counts gobreaker.Counts) bool {
-			// Trip circuit after 5 consecutive failures
-			return counts.ConsecutiveFailures >= 5
-		},
-		OnStateChange: nil, // No default callback
-	}
+	return sharedclients.DefaultCircuitBreakerConfig(name)
 }
 
-// NewCircuitBreaker creates a new circuit breaker with the given configuration
-func NewCircuitBreaker(config CircuitBreakerConfig, logger *slog.Logger) *CircuitBreaker {
-	settings := gobreaker.Settings{
-		Name:        config.Name,
-		MaxRequests: config.MaxRequests,
-		Interval:    config.Interval,
-		Timeout:     config.Timeout,
-		ReadyToTrip: config.ReadyToTrip,
-		OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
-			logger.Info("circuit breaker state changed",
-				"name", name,
-				"from", from.String(),
-				"to", to.String(),
-			)
-			if config.OnStateChange != nil {
-				config.OnStateChange(name, from, to)
-			}
-		},
-	}
+// NewCircuitBreaker creates a new circuit breaker with the given configuration.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
+var NewCircuitBreaker = sharedclients.NewCircuitBreaker
 
-	return &CircuitBreaker{
-		cb:     gobreaker.NewCircuitBreaker[any](settings),
-		logger: logger,
-	}
-}
+// Re-export gobreaker types for convenience
+type (
+	// State is the circuit breaker state type from gobreaker.
+	State = gobreaker.State
+	// Counts holds circuit breaker statistics.
+	Counts = gobreaker.Counts
+)
 
-// Execute wraps a function with circuit breaker protection and context awareness
-// It respects context cancellation and deadlines before executing the function
-func (cb *CircuitBreaker) Execute(ctx context.Context, fn func() (any, error)) (any, error) {
-	// Check context before executing
-	if err := ctx.Err(); err != nil {
-		return nil, fmt.Errorf("context error before execution: %w", err)
-	}
+// Circuit breaker states
+const (
+	StateClosed   = gobreaker.StateClosed
+	StateHalfOpen = gobreaker.StateHalfOpen
+	StateOpen     = gobreaker.StateOpen
+)
 
-	// Create a channel to receive the result
-	type result struct {
-		value any
-		err   error
-	}
-	resultChan := make(chan result, 1)
-
-	// Execute the function with circuit breaker protection
-	go func() {
-		value, err := cb.cb.Execute(fn)
-		resultChan <- result{value: value, err: err}
-	}()
-
-	// Wait for either the result or context cancellation
-	select {
-	case <-ctx.Done():
-		// Context cancelled or timed out
-		return nil, fmt.Errorf("context cancelled during execution: %w", ctx.Err())
-	case res := <-resultChan:
-		// Function completed
-		return res.value, res.err
-	}
-}
-
-// State returns the current state of the circuit breaker
-func (cb *CircuitBreaker) State() gobreaker.State {
-	return cb.cb.State()
-}
+// Circuit breaker errors
+var (
+	ErrOpenState       = gobreaker.ErrOpenState
+	ErrTooManyRequests = gobreaker.ErrTooManyRequests
+)

--- a/services/current-account/clients/common.go
+++ b/services/current-account/clients/common.go
@@ -1,60 +1,31 @@
+// Package clients provides gRPC client wrappers with resilience patterns.
+//
+// This package re-exports types from shared/pkg/clients for backward compatibility.
+// New code should import directly from github.com/meridianhub/meridian/shared/pkg/clients.
 package clients
 
 import (
 	"context"
 	"time"
 
-	"google.golang.org/grpc/metadata"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 )
 
-// PropagateCorrelationID extracts correlation ID from context and adds it to gRPC metadata
+// PropagateCorrelationID extracts correlation ID from context and adds it to gRPC metadata.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
 func PropagateCorrelationID(ctx context.Context) context.Context {
-	correlationID := ExtractCorrelationID(ctx)
-	if correlationID == "" {
-		return ctx
-	}
-
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		md = metadata.New(nil)
-	} else {
-		md = md.Copy()
-	}
-
-	md.Set("x-correlation-id", correlationID)
-	return metadata.NewOutgoingContext(ctx, md)
+	return sharedclients.PropagateCorrelationID(ctx)
 }
 
-// ExtractCorrelationID attempts to extract correlation ID from context
-// It checks multiple common keys used for correlation/request tracking
+// ExtractCorrelationID attempts to extract correlation ID from context.
+// It checks multiple common keys used for correlation/request tracking.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
 func ExtractCorrelationID(ctx context.Context) string {
-	keys := []string{"correlation-id", "x-correlation-id", "x-request-id", "request-id"}
-
-	// Check context values first
-	for _, key := range keys {
-		if val := ctx.Value(key); val != nil {
-			if id, ok := val.(string); ok && id != "" {
-				return id
-			}
-		}
-	}
-
-	// Check incoming metadata as fallback
-	if md, ok := metadata.FromIncomingContext(ctx); ok {
-		for _, key := range keys {
-			if vals := md.Get(key); len(vals) > 0 && vals[0] != "" {
-				return vals[0]
-			}
-		}
-	}
-
-	return ""
+	return sharedclients.ExtractCorrelationID(ctx)
 }
 
-// WithTimeout applies a timeout to the context if one isn't already set
+// WithTimeout applies a timeout to the context if one isn't already set.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
 func WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	if _, hasDeadline := ctx.Deadline(); !hasDeadline && timeout > 0 {
-		return context.WithTimeout(ctx, timeout)
-	}
-	return ctx, func() {}
+	return sharedclients.WithTimeout(ctx, timeout)
 }

--- a/services/current-account/clients/resilient_client.go
+++ b/services/current-account/clients/resilient_client.go
@@ -9,61 +9,36 @@ import (
 
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/sony/gobreaker/v2"
 )
 
-var (
-	// ErrTypeAssertion is returned when a type assertion fails in executeWithResilience
-	ErrTypeAssertion = errors.New("type assertion failed")
-
-	// noRetryConfig disables retries for non-idempotent operations
-	noRetryConfig = RetryConfig{
-		MaxRetries:          0,
-		InitialInterval:     0,
-		MaxInterval:         0,
-		Multiplier:          1.0,
-		RandomizationFactor: 0,
-	}
-)
+// ErrTypeAssertion is returned when a type assertion fails in executeWithResilience.
+// Re-exported from shared package for backward compatibility.
+var ErrTypeAssertion = sharedclients.ErrTypeAssertion
 
 // ResilientPositionKeepingClient wraps PositionKeepingClient with resilience patterns
 type ResilientPositionKeepingClient struct {
 	client         PositionKeepingClient
-	circuitBreaker *CircuitBreaker
-	retryConfig    RetryConfig
+	circuitBreaker *sharedclients.CircuitBreaker
+	retryConfig    sharedclients.RetryConfig
 	logger         *slog.Logger
 }
 
 // ResilientFinancialAccountingClient wraps FinancialAccountingClient with resilience patterns
 type ResilientFinancialAccountingClient struct {
 	client         FinancialAccountingClient
-	circuitBreaker *CircuitBreaker
-	retryConfig    RetryConfig
+	circuitBreaker *sharedclients.CircuitBreaker
+	retryConfig    sharedclients.RetryConfig
 	logger         *slog.Logger
 }
 
-// ResilientClientConfig holds configuration for resilient service clients
-type ResilientClientConfig struct {
-	// Circuit breaker configuration
-	CircuitBreakerName     string
-	CircuitBreakerTimeout  time.Duration
-	CircuitBreakerInterval time.Duration
-	MaxRequests            uint32
-	FailureThreshold       uint32
-
-	// Retry configuration
-	MaxRetries          int
-	InitialInterval     time.Duration
-	MaxInterval         time.Duration
-	Multiplier          float64
-	RandomizationFactor float64
-
-	// Observability
-	Logger *slog.Logger
-}
+// ResilientClientConfig is an alias to the shared implementation.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
+type ResilientClientConfig = sharedclients.ResilientClientConfig
 
 // applyConfigDefaults applies default values to ResilientClientConfig and returns circuit breaker and retry configs
-func applyConfigDefaults(config *ResilientClientConfig, defaultName string) (CircuitBreakerConfig, RetryConfig) {
+func applyConfigDefaults(config *ResilientClientConfig, defaultName string) (sharedclients.CircuitBreakerConfig, sharedclients.RetryConfig) {
 	// Apply logger default
 	if config.Logger == nil {
 		config.Logger = slog.Default()
@@ -87,7 +62,7 @@ func applyConfigDefaults(config *ResilientClientConfig, defaultName string) (Cir
 	}
 
 	// Create circuit breaker config
-	cbConfig := CircuitBreakerConfig{
+	cbConfig := sharedclients.CircuitBreakerConfig{
 		Name:        config.CircuitBreakerName,
 		MaxRequests: config.MaxRequests,
 		Interval:    config.CircuitBreakerInterval,
@@ -121,7 +96,7 @@ func applyConfigDefaults(config *ResilientClientConfig, defaultName string) (Cir
 	}
 
 	// Create retry config
-	retryConfig := RetryConfig{
+	retryConfig := sharedclients.RetryConfig{
 		MaxRetries:          config.MaxRetries,
 		InitialInterval:     config.InitialInterval,
 		MaxInterval:         config.MaxInterval,
@@ -138,7 +113,7 @@ func NewResilientPositionKeepingClient(
 	config ResilientClientConfig,
 ) *ResilientPositionKeepingClient {
 	cbConfig, retryConfig := applyConfigDefaults(&config, "position-keeping")
-	cb := NewCircuitBreaker(cbConfig, config.Logger)
+	cb := sharedclients.NewCircuitBreaker(cbConfig, config.Logger)
 
 	return &ResilientPositionKeepingClient{
 		client:         client,
@@ -154,7 +129,7 @@ func NewResilientFinancialAccountingClient(
 	config ResilientClientConfig,
 ) *ResilientFinancialAccountingClient {
 	cbConfig, retryConfig := applyConfigDefaults(&config, "financial-accounting")
-	cb := NewCircuitBreaker(cbConfig, config.Logger)
+	cb := sharedclients.NewCircuitBreaker(cbConfig, config.Logger)
 
 	return &ResilientFinancialAccountingClient{
 		client:         client,
@@ -167,8 +142,8 @@ func NewResilientFinancialAccountingClient(
 // executeWithResilience wraps a call with circuit breaker and retry logic
 func executeWithResilience[T any](
 	ctx context.Context,
-	cb *CircuitBreaker,
-	retryConfig RetryConfig,
+	cb *sharedclients.CircuitBreaker,
+	retryConfig sharedclients.RetryConfig,
 	logger *slog.Logger,
 	operationName string,
 	fn func() (T, error),
@@ -176,7 +151,7 @@ func executeWithResilience[T any](
 	var result T
 
 	// Wrap the operation with retry logic
-	err := Retry(ctx, retryConfig, func() error {
+	err := sharedclients.Retry(ctx, retryConfig, func() error {
 		// Execute through circuit breaker
 		res, err := cb.Execute(ctx, func() (any, error) {
 			return fn()
@@ -269,7 +244,7 @@ func (r *ResilientPositionKeepingClient) BulkImportTransactions(
 	return executeWithResilience(
 		ctx,
 		r.circuitBreaker,
-		noRetryConfig, // No retries - not idempotent
+		sharedclients.NoRetryConfig(), // No retries - not idempotent
 		r.logger,
 		"BulkImportTransactions",
 		func() (*positionkeepingv1.BulkImportTransactionsResponse, error) {
@@ -330,7 +305,7 @@ func (r *ResilientFinancialAccountingClient) UpdateFinancialBookingLog(
 	return executeWithResilience(
 		ctx,
 		r.circuitBreaker,
-		noRetryConfig, // No retries - not idempotent
+		sharedclients.NoRetryConfig(), // No retries - not idempotent
 		r.logger,
 		"UpdateFinancialBookingLog",
 		func() (*financialaccountingv1.UpdateFinancialBookingLogResponse, error) {
@@ -384,7 +359,7 @@ func (r *ResilientFinancialAccountingClient) CaptureLedgerPosting(
 	return executeWithResilience(
 		ctx,
 		r.circuitBreaker,
-		noRetryConfig, // No retries - server-side idempotency not yet confirmed
+		sharedclients.NoRetryConfig(), // No retries - server-side idempotency not yet confirmed
 		r.logger,
 		"CaptureLedgerPosting",
 		func() (*financialaccountingv1.CaptureLedgerPostingResponse, error) {

--- a/services/current-account/clients/retry.go
+++ b/services/current-account/clients/retry.go
@@ -41,137 +41,44 @@
 //
 // Recommendation: Use Option 1 (Circuit Breaker wraps Retry) for most cases.
 // This prevents overwhelming a failing service with retries and provides faster failure detection.
+//
+// This package re-exports types from shared/pkg/clients for backward compatibility.
+// New code should import directly from github.com/meridianhub/meridian/shared/pkg/clients.
 package clients
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"time"
 
-	"github.com/cenkalti/backoff/v4"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 )
 
-// RetryConfig holds retry configuration
-type RetryConfig struct {
-	// MaxRetries is the maximum number of retry attempts (excluding the initial attempt)
-	MaxRetries int
+// RetryConfig is an alias to the shared implementation.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
+type RetryConfig = sharedclients.RetryConfig
 
-	// InitialInterval is the initial delay before the first retry
-	InitialInterval time.Duration
-
-	// MaxInterval is the maximum delay between retries
-	MaxInterval time.Duration
-
-	// Multiplier is the factor by which the interval increases after each retry
-	Multiplier float64
-
-	// RandomizationFactor adds jitter to prevent thundering herd (0.0 = no jitter, 1.0 = max jitter)
-	RandomizationFactor float64
-}
-
-// DefaultRetryConfig returns a retry configuration with sensible defaults
+// DefaultRetryConfig returns a retry configuration with sensible defaults.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
 func DefaultRetryConfig() RetryConfig {
-	return RetryConfig{
-		MaxRetries:          3,
-		InitialInterval:     100 * time.Millisecond,
-		MaxInterval:         10 * time.Second,
-		Multiplier:          2.0,
-		RandomizationFactor: 0.5, // ±50% jitter
-	}
+	return sharedclients.DefaultRetryConfig()
 }
 
-// IsRetryable determines if an error should be retried
+// NoRetryConfig returns a configuration that disables retries.
+// Use this for non-idempotent operations.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
+func NoRetryConfig() RetryConfig {
+	return sharedclients.NoRetryConfig()
+}
+
+// IsRetryable determines if an error should be retried.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
 func IsRetryable(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	// Never retry context errors
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return false
-	}
-
-	// Check if it's a gRPC status error
-	st, ok := status.FromError(err)
-	if !ok {
-		// Generic errors are not retryable by default
-		return false
-	}
-
-	// Classify gRPC codes
-	switch st.Code() {
-	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Internal:
-		// Transient errors that may succeed on retry
-		return true
-	case codes.InvalidArgument, codes.NotFound, codes.AlreadyExists, codes.PermissionDenied,
-		codes.Unauthenticated, codes.FailedPrecondition, codes.Aborted, codes.OutOfRange,
-		codes.Unimplemented, codes.DataLoss:
-		// Permanent errors that won't succeed on retry
-		return false
-	case codes.OK, codes.Canceled, codes.Unknown:
-		// OK means no error, Canceled is handled above, Unknown is not retried
-		return false
-	default:
-		// Unknown codes are not retried by default
-		return false
-	}
+	return sharedclients.IsRetryable(err)
 }
 
-// Retry wraps a function with retry logic using exponential backoff with jitter
-// The function is retried if it returns a retryable error (see IsRetryable)
-// Retry respects context cancellation and deadlines
+// Retry wraps a function with retry logic using exponential backoff with jitter.
+// The function is retried if it returns a retryable error (see IsRetryable).
+// Retry respects context cancellation and deadlines.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
 func Retry(ctx context.Context, config RetryConfig, fn func() error) error {
-	// Configure exponential backoff
-	b := backoff.NewExponentialBackOff()
-	b.InitialInterval = config.InitialInterval
-	b.MaxInterval = config.MaxInterval
-	b.Multiplier = config.Multiplier
-	b.RandomizationFactor = config.RandomizationFactor
-	b.MaxElapsedTime = 0 // No max elapsed time, we use MaxRetries instead
-	b.Reset()
-
-	// Wrap with context
-	backoffWithContext := backoff.WithContext(b, ctx)
-
-	// Track number of attempts
-	attempt := 0
-	maxAttempts := config.MaxRetries + 1 // Initial attempt + retries
-
-	operation := func() error {
-		// Check context before each attempt
-		if err := ctx.Err(); err != nil {
-			return backoff.Permanent(err)
-		}
-
-		attempt++
-
-		// Execute the function
-		err := fn()
-
-		// If no error, we're done
-		if err == nil {
-			return nil
-		}
-
-		// If we've exhausted retries, return permanent error
-		if attempt >= maxAttempts {
-			return backoff.Permanent(err)
-		}
-
-		// If error is not retryable, return permanent error
-		if !IsRetryable(err) {
-			return backoff.Permanent(err)
-		}
-
-		// Return the error to trigger retry
-		return err
-	}
-
-	if err := backoff.Retry(operation, backoffWithContext); err != nil {
-		return fmt.Errorf("retry failed: %w", err)
-	}
-	return nil
+	return sharedclients.Retry(ctx, config, fn)
 }

--- a/services/current-account/clients/saga.go
+++ b/services/current-account/clients/saga.go
@@ -1,131 +1,29 @@
+// Package clients provides gRPC client wrappers with resilience patterns.
+//
+// This package re-exports types from shared/pkg/clients for backward compatibility.
+// New code should import directly from github.com/meridianhub/meridian/shared/pkg/clients.
 package clients
 
 import (
-	"context"
-	"fmt"
 	"log/slog"
+
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 )
 
-// SagaStep represents a single step in a saga transaction
-type SagaStep struct {
-	Name       string
-	Action     func(ctx context.Context) error
-	Compensate func(ctx context.Context) error
-}
+// SagaStep is an alias to the shared implementation.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
+type SagaStep = sharedclients.SagaStep
 
-// SagaOrchestrator manages distributed transactions with compensation
-type SagaOrchestrator struct {
-	steps  []SagaStep
-	logger *slog.Logger
-}
+// SagaOrchestrator is an alias to the shared implementation.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
+type SagaOrchestrator = sharedclients.SagaOrchestrator
 
-// SagaResult contains the outcome of a saga execution
-type SagaResult struct {
-	Success          bool
-	CompletedSteps   int
-	FailedStep       string
-	CompensatedSteps int
-	Error            error
-}
+// SagaResult is an alias to the shared implementation.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
+type SagaResult = sharedclients.SagaResult
 
-// NewSagaOrchestrator creates a new saga orchestrator
+// NewSagaOrchestrator creates a new saga orchestrator.
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
 func NewSagaOrchestrator(logger *slog.Logger) *SagaOrchestrator {
-	if logger == nil {
-		logger = slog.Default()
-	}
-
-	return &SagaOrchestrator{
-		steps:  make([]SagaStep, 0),
-		logger: logger,
-	}
-}
-
-// AddStep adds a step to the saga
-func (s *SagaOrchestrator) AddStep(name string, action, compensate func(ctx context.Context) error) {
-	s.steps = append(s.steps, SagaStep{
-		Name:       name,
-		Action:     action,
-		Compensate: compensate,
-	})
-}
-
-// Execute runs the saga, performing compensation on failure
-func (s *SagaOrchestrator) Execute(ctx context.Context) SagaResult {
-	result := SagaResult{
-		Success: true,
-	}
-
-	// Execute steps in order
-	for i, step := range s.steps {
-		s.logger.Info("executing saga step",
-			"step", step.Name,
-			"index", i+1,
-			"total", len(s.steps))
-
-		if err := step.Action(ctx); err != nil {
-			s.logger.Error("saga step failed",
-				"step", step.Name,
-				"error", err)
-
-			result.Success = false
-			result.CompletedSteps = i
-			result.FailedStep = step.Name
-			result.Error = fmt.Errorf("step %s failed: %w", step.Name, err)
-
-			// Compensate completed steps in reverse order
-			s.compensate(ctx, i, &result)
-
-			return result
-		}
-
-		result.CompletedSteps++
-	}
-
-	s.logger.Info("saga completed successfully",
-		"total_steps", len(s.steps))
-
-	return result
-}
-
-// compensate performs compensation for completed steps in reverse order
-func (s *SagaOrchestrator) compensate(ctx context.Context, failedAtIndex int, result *SagaResult) {
-	s.logger.Info("starting compensation",
-		"completed_steps", failedAtIndex)
-
-	// Compensate in reverse order (LIFO)
-	for i := failedAtIndex - 1; i >= 0; i-- {
-		step := s.steps[i]
-
-		if step.Compensate == nil {
-			s.logger.Warn("no compensation defined for step",
-				"step", step.Name)
-			continue
-		}
-
-		s.logger.Info("compensating step",
-			"step", step.Name,
-			"index", i+1)
-
-		if err := step.Compensate(ctx); err != nil {
-			s.logger.Error("compensation failed",
-				"step", step.Name,
-				"error", err)
-			// Continue compensating remaining steps despite error
-		} else {
-			result.CompensatedSteps++
-		}
-	}
-
-	s.logger.Info("compensation completed",
-		"compensated_steps", result.CompensatedSteps)
-}
-
-// Reset clears all steps from the orchestrator
-func (s *SagaOrchestrator) Reset() {
-	s.steps = make([]SagaStep, 0)
-}
-
-// StepCount returns the number of steps in the saga
-func (s *SagaOrchestrator) StepCount() int {
-	return len(s.steps)
+	return sharedclients.NewSagaOrchestrator(logger)
 }

--- a/shared/pkg/clients/circuitbreaker.go
+++ b/shared/pkg/clients/circuitbreaker.go
@@ -1,0 +1,111 @@
+// Package clients provides shared client resilience patterns including
+// circuit breakers, retry logic, and saga orchestration for inter-service
+// communication within the Meridian platform.
+package clients
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/sony/gobreaker/v2"
+)
+
+// CircuitBreakerConfig holds configuration for circuit breaker
+type CircuitBreakerConfig struct {
+	Name          string
+	MaxRequests   uint32
+	Interval      time.Duration
+	Timeout       time.Duration
+	ReadyToTrip   func(counts gobreaker.Counts) bool
+	OnStateChange func(name string, from gobreaker.State, to gobreaker.State)
+}
+
+// CircuitBreaker wraps sony/gobreaker with context support and logging
+type CircuitBreaker struct {
+	cb     *gobreaker.CircuitBreaker[any]
+	logger *slog.Logger
+}
+
+// DefaultCircuitBreakerConfig returns a circuit breaker configuration with sensible defaults
+func DefaultCircuitBreakerConfig(name string) CircuitBreakerConfig {
+	return CircuitBreakerConfig{
+		Name:        name,
+		MaxRequests: 1,
+		Interval:    60 * time.Second,
+		Timeout:     30 * time.Second,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			// Trip circuit after 5 consecutive failures
+			return counts.ConsecutiveFailures >= 5
+		},
+		OnStateChange: nil, // No default callback
+	}
+}
+
+// NewCircuitBreaker creates a new circuit breaker with the given configuration
+func NewCircuitBreaker(config CircuitBreakerConfig, logger *slog.Logger) *CircuitBreaker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	settings := gobreaker.Settings{
+		Name:        config.Name,
+		MaxRequests: config.MaxRequests,
+		Interval:    config.Interval,
+		Timeout:     config.Timeout,
+		ReadyToTrip: config.ReadyToTrip,
+		OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
+			logger.Info("circuit breaker state changed",
+				"name", name,
+				"from", from.String(),
+				"to", to.String(),
+			)
+			if config.OnStateChange != nil {
+				config.OnStateChange(name, from, to)
+			}
+		},
+	}
+
+	return &CircuitBreaker{
+		cb:     gobreaker.NewCircuitBreaker[any](settings),
+		logger: logger,
+	}
+}
+
+// Execute wraps a function with circuit breaker protection and context awareness
+// It respects context cancellation and deadlines before executing the function
+func (cb *CircuitBreaker) Execute(ctx context.Context, fn func() (any, error)) (any, error) {
+	// Check context before executing
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("context error before execution: %w", err)
+	}
+
+	// Create a channel to receive the result
+	type result struct {
+		value any
+		err   error
+	}
+	resultChan := make(chan result, 1)
+
+	// Execute the function with circuit breaker protection
+	go func() {
+		value, err := cb.cb.Execute(fn)
+		resultChan <- result{value: value, err: err}
+	}()
+
+	// Wait for either the result or context cancellation
+	select {
+	case <-ctx.Done():
+		// Context cancelled or timed out
+		return nil, fmt.Errorf("context cancelled during execution: %w", ctx.Err())
+	case res := <-resultChan:
+		// Function completed
+		return res.value, res.err
+	}
+}
+
+// State returns the current state of the circuit breaker
+func (cb *CircuitBreaker) State() gobreaker.State {
+	return cb.cb.State()
+}

--- a/shared/pkg/clients/circuitbreaker.go
+++ b/shared/pkg/clients/circuitbreaker.go
@@ -73,8 +73,14 @@ func NewCircuitBreaker(config CircuitBreakerConfig, logger *slog.Logger) *Circui
 	}
 }
 
-// Execute wraps a function with circuit breaker protection and context awareness
-// It respects context cancellation and deadlines before executing the function
+// Execute wraps a function with circuit breaker protection and context awareness.
+// It respects context cancellation and deadlines before executing the function.
+//
+// Goroutine behavior: When the context is cancelled, Execute returns immediately
+// with the context error. However, the underlying function continues to run in a
+// background goroutine until it completes. The goroutine will exit after fn()
+// returns, but will not be interrupted. Callers should ensure that fn respects
+// context cancellation if early termination is required.
 func (cb *CircuitBreaker) Execute(ctx context.Context, fn func() (any, error)) (any, error) {
 	// Check context before executing
 	if err := ctx.Err(); err != nil {

--- a/shared/pkg/clients/circuitbreaker_test.go
+++ b/shared/pkg/clients/circuitbreaker_test.go
@@ -1,0 +1,440 @@
+package clients_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/sony/gobreaker/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	errOperationFailed = errors.New("operation failed")
+	errStillFailing    = errors.New("still failing")
+	successString      = "success"
+)
+
+// TestNewCircuitBreaker_WithDefaultConfig verifies circuit breaker is created with default configuration
+func TestNewCircuitBreaker_WithDefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.DefaultCircuitBreakerConfig("test-service")
+
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	assert.NotNil(t, cb)
+	assert.Equal(t, gobreaker.StateClosed, cb.State())
+}
+
+// TestNewCircuitBreaker_WithCustomConfig verifies circuit breaker respects custom configuration
+func TestNewCircuitBreaker_WithCustomConfig(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.CircuitBreakerConfig{
+		Name:        "custom-service",
+		MaxRequests: 5,
+		Interval:    30 * time.Second,
+		Timeout:     15 * time.Second,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 3
+		},
+		OnStateChange: func(_ string, _ gobreaker.State, _ gobreaker.State) {
+			// Custom state change handler
+		},
+	}
+
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	assert.NotNil(t, cb)
+	assert.Equal(t, gobreaker.StateClosed, cb.State())
+}
+
+// TestNewCircuitBreaker_NilLogger verifies default logger is used when nil provided
+func TestNewCircuitBreaker_NilLogger(t *testing.T) {
+	t.Parallel()
+
+	config := clients.DefaultCircuitBreakerConfig("test-service")
+	cb := clients.NewCircuitBreaker(config, nil)
+
+	assert.NotNil(t, cb)
+	assert.Equal(t, gobreaker.StateClosed, cb.State())
+}
+
+// TestCircuitBreaker_Execute_Success verifies successful execution returns result
+func TestCircuitBreaker_Execute_Success(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.DefaultCircuitBreakerConfig("test-service")
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	ctx := context.Background()
+
+	result, err := cb.Execute(ctx, func() (any, error) {
+		return successString, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, successString, result)
+	assert.Equal(t, gobreaker.StateClosed, cb.State())
+}
+
+// TestCircuitBreaker_Execute_Failure verifies failure is propagated
+func TestCircuitBreaker_Execute_Failure(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.DefaultCircuitBreakerConfig("test-service")
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	ctx := context.Background()
+
+	result, err := cb.Execute(ctx, func() (any, error) {
+		return nil, errOperationFailed
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, errOperationFailed, err)
+	assert.Nil(t, result)
+	assert.Equal(t, gobreaker.StateClosed, cb.State(), "should remain closed after single failure")
+}
+
+// TestCircuitBreaker_OpensAfterThresholdFailures verifies circuit opens after consecutive failures
+func TestCircuitBreaker_OpensAfterThresholdFailures(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.DefaultCircuitBreakerConfig("test-service")
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	ctx := context.Background()
+
+	// Execute 5 consecutive failures (default threshold)
+	for i := 0; i < 5; i++ {
+		_, err := cb.Execute(ctx, func() (any, error) {
+			return nil, errOperationFailed
+		})
+		require.Error(t, err)
+	}
+
+	// Circuit should now be open
+	assert.Equal(t, gobreaker.StateOpen, cb.State())
+
+	// Next request should fail immediately with circuit breaker error
+	_, err := cb.Execute(ctx, func() (any, error) {
+		t.Fatal("should not execute function when circuit is open")
+		return nil, nil
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, gobreaker.ErrOpenState)
+}
+
+// TestCircuitBreaker_TransitionsToHalfOpen verifies circuit transitions to half-open after timeout
+func TestCircuitBreaker_TransitionsToHalfOpen(t *testing.T) {
+	// Not parallel - uses time-sensitive operations
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.CircuitBreakerConfig{
+		Name:        "test-service",
+		MaxRequests: 1,
+		Interval:    60 * time.Second,
+		Timeout:     100 * time.Millisecond, // Short timeout for test
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 3
+		},
+	}
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	ctx := context.Background()
+
+	// Trigger circuit to open (3 consecutive failures)
+	for i := 0; i < 3; i++ {
+		_, err := cb.Execute(ctx, func() (any, error) {
+			return nil, errOperationFailed
+		})
+		require.Error(t, err)
+	}
+
+	assert.Equal(t, gobreaker.StateOpen, cb.State())
+
+	// Wait for timeout to transition to half-open
+	time.Sleep(150 * time.Millisecond)
+
+	// Next request should transition to half-open and execute
+	_, err := cb.Execute(ctx, func() (any, error) {
+		return successString, nil
+	})
+
+	require.NoError(t, err)
+	// After successful request in half-open, circuit should close
+	assert.Equal(t, gobreaker.StateClosed, cb.State())
+}
+
+// TestCircuitBreaker_ClosesAfterSuccessInHalfOpen verifies circuit closes after successful requests in half-open
+func TestCircuitBreaker_ClosesAfterSuccessInHalfOpen(t *testing.T) {
+	// Not parallel - uses time-sensitive operations
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.CircuitBreakerConfig{
+		Name:        "test-service",
+		MaxRequests: 2, // Allow 2 requests in half-open
+		Interval:    60 * time.Second,
+		Timeout:     100 * time.Millisecond,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 3
+		},
+	}
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	ctx := context.Background()
+
+	// Trigger circuit to open
+	for i := 0; i < 3; i++ {
+		_, _ = cb.Execute(ctx, func() (any, error) {
+			return nil, errOperationFailed
+		})
+	}
+
+	assert.Equal(t, gobreaker.StateOpen, cb.State())
+
+	// Wait for timeout
+	time.Sleep(150 * time.Millisecond)
+
+	// Execute successful requests in half-open
+	for i := 0; i < 2; i++ {
+		_, err := cb.Execute(ctx, func() (any, error) {
+			return successString, nil
+		})
+		require.NoError(t, err)
+	}
+
+	// Circuit should be closed after consecutive successes
+	assert.Equal(t, gobreaker.StateClosed, cb.State())
+}
+
+// TestCircuitBreaker_ReopensOnFailureInHalfOpen verifies circuit reopens if request fails in half-open
+func TestCircuitBreaker_ReopensOnFailureInHalfOpen(t *testing.T) {
+	// Not parallel - uses time-sensitive operations
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.CircuitBreakerConfig{
+		Name:        "test-service",
+		MaxRequests: 1,
+		Interval:    60 * time.Second,
+		Timeout:     100 * time.Millisecond,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 3
+		},
+	}
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	ctx := context.Background()
+
+	// Trigger circuit to open
+	for i := 0; i < 3; i++ {
+		_, _ = cb.Execute(ctx, func() (any, error) {
+			return nil, errOperationFailed
+		})
+	}
+
+	assert.Equal(t, gobreaker.StateOpen, cb.State())
+
+	// Wait for timeout
+	time.Sleep(150 * time.Millisecond)
+
+	// Execute failing request in half-open
+	_, err := cb.Execute(ctx, func() (any, error) {
+		return nil, errStillFailing
+	})
+
+	require.Error(t, err)
+	// Circuit should reopen after failure in half-open
+	assert.Equal(t, gobreaker.StateOpen, cb.State())
+}
+
+// TestCircuitBreaker_StateChangeCallback verifies state change callback is invoked
+func TestCircuitBreaker_StateChangeCallback(t *testing.T) {
+	// Not parallel - uses time-sensitive operations
+
+	stateChanges := make([]string, 0)
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.CircuitBreakerConfig{
+		Name:        "test-service",
+		MaxRequests: 1,
+		Interval:    60 * time.Second,
+		Timeout:     100 * time.Millisecond,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 2
+		},
+		OnStateChange: func(_ string, from gobreaker.State, to gobreaker.State) {
+			stateChanges = append(stateChanges, from.String()+"->"+to.String())
+		},
+	}
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	ctx := context.Background()
+
+	// Trigger state transitions: closed -> open -> half-open -> closed
+	// Closed -> Open
+	for i := 0; i < 2; i++ {
+		_, _ = cb.Execute(ctx, func() (any, error) {
+			return nil, errOperationFailed
+		})
+	}
+
+	// Open -> Half-Open
+	time.Sleep(150 * time.Millisecond)
+
+	// Half-Open -> Closed
+	_, _ = cb.Execute(ctx, func() (any, error) {
+		return successString, nil
+	})
+
+	// Verify state changes were recorded
+	require.GreaterOrEqual(t, len(stateChanges), 2, "should have at least closed->open and half-open->closed transitions")
+	assert.Contains(t, stateChanges[0], "closed")
+	assert.Contains(t, stateChanges[0], "open")
+}
+
+// TestCircuitBreaker_ContextCancellation verifies context cancellation is respected
+func TestCircuitBreaker_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.DefaultCircuitBreakerConfig("test-service")
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	_, err := cb.Execute(ctx, func() (any, error) {
+		return "should not execute", nil
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+// TestCircuitBreaker_ContextTimeout verifies context timeout is respected
+func TestCircuitBreaker_ContextTimeout(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.DefaultCircuitBreakerConfig("test-service")
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := cb.Execute(ctx, func() (any, error) {
+		time.Sleep(100 * time.Millisecond) // Longer than timeout
+		return "should timeout", nil
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// TestDefaultCircuitBreakerConfig verifies default configuration values
+func TestDefaultCircuitBreakerConfig(t *testing.T) {
+	t.Parallel()
+
+	config := clients.DefaultCircuitBreakerConfig("test-service")
+
+	assert.Equal(t, "test-service", config.Name)
+	assert.Equal(t, uint32(1), config.MaxRequests)
+	assert.Equal(t, 60*time.Second, config.Interval)
+	assert.Equal(t, 30*time.Second, config.Timeout)
+	assert.NotNil(t, config.ReadyToTrip)
+	assert.Nil(t, config.OnStateChange)
+
+	// Test default ReadyToTrip function
+	assert.False(t, config.ReadyToTrip(gobreaker.Counts{ConsecutiveFailures: 4}))
+	assert.True(t, config.ReadyToTrip(gobreaker.Counts{ConsecutiveFailures: 5}))
+}
+
+// TestCircuitBreaker_ConcurrentExecution verifies circuit breaker works with concurrent requests
+func TestCircuitBreaker_ConcurrentExecution(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.DefaultCircuitBreakerConfig("test-service")
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	ctx := context.Background()
+	numGoroutines := 10
+	done := make(chan bool, numGoroutines)
+
+	// Execute concurrent successful requests
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			_, err := cb.Execute(ctx, func() (any, error) {
+				time.Sleep(10 * time.Millisecond)
+				return successString, nil
+			})
+			done <- err == nil
+		}()
+	}
+
+	// Wait for all goroutines to complete
+	successCount := 0
+	for i := 0; i < numGoroutines; i++ {
+		if <-done {
+			successCount++
+		}
+	}
+
+	// All should succeed when circuit is closed
+	assert.Equal(t, numGoroutines, successCount)
+	assert.Equal(t, gobreaker.StateClosed, cb.State())
+}
+
+// TestCircuitBreaker_ResetAfterInterval verifies circuit resets counts after interval in closed state
+func TestCircuitBreaker_ResetAfterInterval(t *testing.T) {
+	// Not parallel - uses time-sensitive operations
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	config := clients.CircuitBreakerConfig{
+		Name:        "test-service",
+		MaxRequests: 1,
+		Interval:    200 * time.Millisecond, // Short interval for test
+		Timeout:     30 * time.Second,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= 5
+		},
+	}
+	cb := clients.NewCircuitBreaker(config, logger)
+
+	ctx := context.Background()
+
+	// Execute 3 failures (below threshold)
+	for i := 0; i < 3; i++ {
+		_, _ = cb.Execute(ctx, func() (any, error) {
+			return nil, errOperationFailed
+		})
+	}
+
+	assert.Equal(t, gobreaker.StateClosed, cb.State(), "should remain closed below threshold")
+
+	// Wait for interval to reset counts
+	time.Sleep(250 * time.Millisecond)
+
+	// Execute 3 more failures (should not trip because counts were reset)
+	for i := 0; i < 3; i++ {
+		_, _ = cb.Execute(ctx, func() (any, error) {
+			return nil, errOperationFailed
+		})
+	}
+
+	// Circuit should still be closed because counts were reset after interval
+	assert.Equal(t, gobreaker.StateClosed, cb.State(), "should remain closed after interval reset")
+}

--- a/shared/pkg/clients/common.go
+++ b/shared/pkg/clients/common.go
@@ -1,0 +1,60 @@
+package clients
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// PropagateCorrelationID extracts correlation ID from context and adds it to gRPC metadata
+func PropagateCorrelationID(ctx context.Context) context.Context {
+	correlationID := ExtractCorrelationID(ctx)
+	if correlationID == "" {
+		return ctx
+	}
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	} else {
+		md = md.Copy()
+	}
+
+	md.Set("x-correlation-id", correlationID)
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+// ExtractCorrelationID attempts to extract correlation ID from context
+// It checks multiple common keys used for correlation/request tracking
+func ExtractCorrelationID(ctx context.Context) string {
+	keys := []string{"correlation-id", "x-correlation-id", "x-request-id", "request-id"}
+
+	// Check context values first
+	for _, key := range keys {
+		if val := ctx.Value(key); val != nil {
+			if id, ok := val.(string); ok && id != "" {
+				return id
+			}
+		}
+	}
+
+	// Check incoming metadata as fallback
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		for _, key := range keys {
+			if vals := md.Get(key); len(vals) > 0 && vals[0] != "" {
+				return vals[0]
+			}
+		}
+	}
+
+	return ""
+}
+
+// WithTimeout applies a timeout to the context if one isn't already set
+func WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline && timeout > 0 {
+		return context.WithTimeout(ctx, timeout)
+	}
+	return ctx, func() {}
+}

--- a/shared/pkg/clients/common_test.go
+++ b/shared/pkg/clients/common_test.go
@@ -1,0 +1,299 @@
+package clients_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+)
+
+// TestExtractCorrelationID_FromContextValue verifies extraction from context value
+func TestExtractCorrelationID_FromContextValue(t *testing.T) {
+	t.Parallel()
+
+	//nolint:revive,staticcheck // Using string key as expected by ExtractCorrelationID implementation
+	ctx := context.WithValue(context.Background(), "x-correlation-id", "test-123")
+
+	result := clients.ExtractCorrelationID(ctx)
+
+	assert.Equal(t, "test-123", result)
+}
+
+// TestExtractCorrelationID_FromIncomingMetadata verifies extraction from gRPC incoming metadata
+func TestExtractCorrelationID_FromIncomingMetadata(t *testing.T) {
+	t.Parallel()
+
+	md := metadata.New(map[string]string{
+		"x-correlation-id": "metadata-456",
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	result := clients.ExtractCorrelationID(ctx)
+
+	assert.Equal(t, "metadata-456", result)
+}
+
+// TestExtractCorrelationID_MultipleKeys tests all supported correlation ID keys
+func TestExtractCorrelationID_MultipleKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		key      string
+		value    string
+		expected string
+	}{
+		{
+			name:     "correlation-id key",
+			key:      "correlation-id",
+			value:    "corr-123",
+			expected: "corr-123",
+		},
+		{
+			name:     "x-correlation-id key",
+			key:      "x-correlation-id",
+			value:    "x-corr-456",
+			expected: "x-corr-456",
+		},
+		{
+			name:     "x-request-id key",
+			key:      "x-request-id",
+			value:    "x-req-789",
+			expected: "x-req-789",
+		},
+		{
+			name:     "request-id key",
+			key:      "request-id",
+			value:    "req-012",
+			expected: "req-012",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Test from context value
+			//nolint:revive,staticcheck // Using string key as expected by ExtractCorrelationID implementation
+			ctx := context.WithValue(context.Background(), tt.key, tt.value)
+			result := clients.ExtractCorrelationID(ctx)
+			assert.Equal(t, tt.expected, result, "should extract from context value")
+
+			// Test from incoming metadata
+			md := metadata.New(map[string]string{tt.key: tt.value})
+			ctxMD := metadata.NewIncomingContext(context.Background(), md)
+			resultMD := clients.ExtractCorrelationID(ctxMD)
+			assert.Equal(t, tt.expected, resultMD, "should extract from incoming metadata")
+		})
+	}
+}
+
+// TestExtractCorrelationID_NotFound verifies empty string is returned when no correlation ID exists
+func TestExtractCorrelationID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	result := clients.ExtractCorrelationID(ctx)
+
+	assert.Equal(t, "", result)
+}
+
+// TestExtractCorrelationID_EmptyValue verifies empty correlation ID values are ignored
+func TestExtractCorrelationID_EmptyValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ctx  context.Context
+	}{
+		{
+			name: "empty string in context value",
+			//nolint:revive,staticcheck // Using string key as expected by ExtractCorrelationID implementation
+			ctx: context.WithValue(context.Background(), "x-correlation-id", ""),
+		},
+		{
+			name: "empty string in metadata",
+			ctx: metadata.NewIncomingContext(
+				context.Background(),
+				metadata.New(map[string]string{"x-correlation-id": ""}),
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := clients.ExtractCorrelationID(tt.ctx)
+
+			assert.Equal(t, "", result)
+		})
+	}
+}
+
+// TestExtractCorrelationID_ContextValuePriority verifies context values are checked before metadata
+func TestExtractCorrelationID_ContextValuePriority(t *testing.T) {
+	t.Parallel()
+
+	// Create context with both context value and metadata
+	md := metadata.New(map[string]string{
+		"x-correlation-id": "metadata-value",
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	//nolint:revive,staticcheck // Using string key as expected by ExtractCorrelationID implementation
+	ctx = context.WithValue(ctx, "x-correlation-id", "context-value")
+
+	result := clients.ExtractCorrelationID(ctx)
+
+	// Should prefer context value over metadata
+	assert.Equal(t, "context-value", result)
+}
+
+// TestExtractCorrelationID_NonStringValue verifies non-string values are ignored
+func TestExtractCorrelationID_NonStringValue(t *testing.T) {
+	t.Parallel()
+
+	//nolint:revive,staticcheck // Using string key as expected by ExtractCorrelationID implementation
+	ctx := context.WithValue(context.Background(), "x-correlation-id", 12345)
+
+	result := clients.ExtractCorrelationID(ctx)
+
+	assert.Equal(t, "", result)
+}
+
+// TestPropagateCorrelationID_Success verifies correlation ID is added to outgoing metadata
+func TestPropagateCorrelationID_Success(t *testing.T) {
+	t.Parallel()
+
+	//nolint:revive,staticcheck // Using string key as expected by ExtractCorrelationID implementation
+	ctx := context.WithValue(context.Background(), "x-correlation-id", "test-789")
+
+	result := clients.PropagateCorrelationID(ctx)
+
+	// Verify correlation ID was added to outgoing metadata
+	md, ok := metadata.FromOutgoingContext(result)
+	assert.True(t, ok, "should have outgoing metadata")
+	assert.Equal(t, []string{"test-789"}, md.Get("x-correlation-id"))
+}
+
+// TestPropagateCorrelationID_NoCorrelationID verifies context is unchanged when no correlation ID exists
+func TestPropagateCorrelationID_NoCorrelationID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	result := clients.PropagateCorrelationID(ctx)
+
+	// Context should be returned unchanged
+	assert.Equal(t, ctx, result)
+}
+
+// TestPropagateCorrelationID_ExistingMetadata verifies existing metadata is preserved
+func TestPropagateCorrelationID_ExistingMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Create context with existing outgoing metadata
+	existingMD := metadata.New(map[string]string{
+		"existing-key": "existing-value",
+	})
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMD)
+	//nolint:revive,staticcheck // Using string key as expected by ExtractCorrelationID implementation
+	ctx = context.WithValue(ctx, "x-correlation-id", "test-999")
+
+	result := clients.PropagateCorrelationID(ctx)
+
+	// Verify both existing metadata and correlation ID are present
+	md, ok := metadata.FromOutgoingContext(result)
+	assert.True(t, ok, "should have outgoing metadata")
+	assert.Equal(t, []string{"existing-value"}, md.Get("existing-key"), "should preserve existing metadata")
+	assert.Equal(t, []string{"test-999"}, md.Get("x-correlation-id"), "should add correlation ID")
+}
+
+// TestPropagateCorrelationID_OverwritesExistingCorrelationID verifies correlation ID is updated if it already exists
+func TestPropagateCorrelationID_OverwritesExistingCorrelationID(t *testing.T) {
+	t.Parallel()
+
+	// Create context with existing correlation ID in outgoing metadata
+	existingMD := metadata.New(map[string]string{
+		"x-correlation-id": "old-id",
+	})
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMD)
+	//nolint:revive,staticcheck // Using string key as expected by ExtractCorrelationID implementation
+	ctx = context.WithValue(ctx, "x-correlation-id", "new-id")
+
+	result := clients.PropagateCorrelationID(ctx)
+
+	// Verify correlation ID was updated
+	md, ok := metadata.FromOutgoingContext(result)
+	assert.True(t, ok, "should have outgoing metadata")
+	assert.Equal(t, []string{"new-id"}, md.Get("x-correlation-id"), "should update correlation ID")
+}
+
+// TestWithTimeout_AppliesTimeout verifies timeout is applied when context has no deadline
+func TestWithTimeout_AppliesTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	timeout := 5 * time.Second
+
+	resultCtx, cancel := clients.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	deadline, ok := resultCtx.Deadline()
+	assert.True(t, ok, "should have deadline")
+	assert.WithinDuration(t, time.Now().Add(timeout), deadline, 100*time.Millisecond)
+}
+
+// TestWithTimeout_PreservesExistingDeadline verifies existing deadline is not changed
+func TestWithTimeout_PreservesExistingDeadline(t *testing.T) {
+	t.Parallel()
+
+	existingDeadline := time.Now().Add(10 * time.Second)
+	ctx, cancel := context.WithDeadline(context.Background(), existingDeadline)
+	defer cancel()
+
+	resultCtx, resultCancel := clients.WithTimeout(ctx, 5*time.Second)
+	defer resultCancel()
+
+	deadline, ok := resultCtx.Deadline()
+	assert.True(t, ok, "should have deadline")
+	assert.Equal(t, existingDeadline, deadline, "should preserve existing deadline")
+}
+
+// TestWithTimeout_ZeroTimeout verifies context is unchanged with zero timeout
+func TestWithTimeout_ZeroTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	resultCtx, cancel := clients.WithTimeout(ctx, 0)
+	defer cancel()
+
+	// Context should be returned unchanged
+	assert.Equal(t, ctx, resultCtx)
+
+	// Should not have a deadline
+	_, ok := resultCtx.Deadline()
+	assert.False(t, ok, "should not have deadline")
+}
+
+// TestWithTimeout_NegativeTimeout verifies negative timeout is treated as zero
+func TestWithTimeout_NegativeTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	resultCtx, cancel := clients.WithTimeout(ctx, -5*time.Second)
+	defer cancel()
+
+	// Context should be returned unchanged (negative timeout treated as no timeout)
+	assert.Equal(t, ctx, resultCtx)
+
+	// Should not have a deadline
+	_, ok := resultCtx.Deadline()
+	assert.False(t, ok, "should not have deadline")
+}

--- a/shared/pkg/clients/doc.go
+++ b/shared/pkg/clients/doc.go
@@ -1,0 +1,81 @@
+// Package clients provides shared resilience patterns for inter-service
+// communication within the Meridian platform.
+//
+// This package offers reusable implementations of:
+//   - Circuit breaker pattern (wrapping sony/gobreaker)
+//   - Retry with exponential backoff and jitter
+//   - Saga pattern for distributed transaction coordination
+//   - Resilient client wrapper combining circuit breaker and retry
+//   - Utilities for correlation ID propagation and timeout handling
+//
+// # Circuit Breaker
+//
+// The circuit breaker prevents cascading failures by failing fast when a
+// downstream service is unhealthy. Use [NewCircuitBreaker] to create one:
+//
+//	config := clients.DefaultCircuitBreakerConfig("my-service")
+//	cb := clients.NewCircuitBreaker(config, logger)
+//
+//	result, err := cb.Execute(ctx, func() (any, error) {
+//		return myClient.Call(ctx, req)
+//	})
+//
+// # Retry
+//
+// The retry logic uses exponential backoff with jitter to handle transient
+// failures. Only gRPC status codes indicating transient errors are retried
+// (Unavailable, DeadlineExceeded, ResourceExhausted, Internal).
+//
+//	config := clients.DefaultRetryConfig()
+//	err := clients.Retry(ctx, config, func() error {
+//		_, err := myClient.Call(ctx, req)
+//		return err
+//	})
+//
+// # Resilient Client
+//
+// For most use cases, [ResilientClient] combines circuit breaker and retry
+// in a convenient wrapper:
+//
+//	config := clients.DefaultResilientClientConfig("my-service")
+//	resilient := clients.NewResilientClient(config)
+//
+//	result, err := clients.ExecuteWithResilience(ctx, resilient, "operation", func() (*Response, error) {
+//		return myClient.Call(ctx, req)
+//	})
+//
+// For non-idempotent operations, use [ExecuteWithResilienceNoRetry]:
+//
+//	result, err := clients.ExecuteWithResilienceNoRetry(ctx, resilient, "create", func() (*Response, error) {
+//		return myClient.Create(ctx, req)
+//	})
+//
+// # Saga Pattern
+//
+// For distributed transactions requiring compensation on failure:
+//
+//	saga := clients.NewSagaOrchestrator(logger)
+//	saga.AddStep("create-order",
+//		func(ctx context.Context) error { return createOrder(ctx) },
+//		func(ctx context.Context) error { return cancelOrder(ctx) },
+//	)
+//	saga.AddStep("reserve-inventory",
+//		func(ctx context.Context) error { return reserveInventory(ctx) },
+//		func(ctx context.Context) error { return releaseInventory(ctx) },
+//	)
+//	result := saga.Execute(ctx)
+//
+// # Migration from Service-Specific Clients
+//
+// Services that previously defined their own circuit breaker, retry, or saga
+// implementations should migrate to this shared package:
+//
+//	// Old import (deprecated)
+//	import "github.com/meridianhub/meridian/services/current-account/clients"
+//
+//	// New import (recommended)
+//	import "github.com/meridianhub/meridian/shared/pkg/clients"
+//
+// The service-specific packages re-export these types with deprecation notices
+// to maintain backward compatibility during migration.
+package clients

--- a/shared/pkg/clients/resilient.go
+++ b/shared/pkg/clients/resilient.go
@@ -1,0 +1,240 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/sony/gobreaker/v2"
+)
+
+// ErrTypeAssertion is returned when a type assertion fails in ExecuteWithResilience
+var ErrTypeAssertion = errors.New("type assertion failed")
+
+// ResilientClientConfig holds configuration for resilient service clients
+type ResilientClientConfig struct {
+	// Circuit breaker configuration
+	CircuitBreakerName     string
+	CircuitBreakerTimeout  time.Duration
+	CircuitBreakerInterval time.Duration
+	MaxRequests            uint32
+	FailureThreshold       uint32
+
+	// Retry configuration
+	MaxRetries          int
+	InitialInterval     time.Duration
+	MaxInterval         time.Duration
+	Multiplier          float64
+	RandomizationFactor float64
+
+	// Observability
+	Logger *slog.Logger
+}
+
+// DefaultResilientClientConfig returns a ResilientClientConfig with sensible defaults
+func DefaultResilientClientConfig(name string) ResilientClientConfig {
+	return ResilientClientConfig{
+		CircuitBreakerName:     name,
+		CircuitBreakerTimeout:  30 * time.Second,
+		CircuitBreakerInterval: 60 * time.Second,
+		MaxRequests:            1,
+		FailureThreshold:       5,
+		MaxRetries:             3,
+		InitialInterval:        100 * time.Millisecond,
+		MaxInterval:            5 * time.Second,
+		Multiplier:             2.0,
+		RandomizationFactor:    0.5,
+		Logger:                 nil, // Will use slog.Default()
+	}
+}
+
+// ResilientClient provides circuit breaker and retry capabilities for any client
+type ResilientClient struct {
+	circuitBreaker *CircuitBreaker
+	retryConfig    RetryConfig
+	logger         *slog.Logger
+}
+
+// NewResilientClient creates a new resilient client wrapper
+func NewResilientClient(config ResilientClientConfig) *ResilientClient {
+	cbConfig, retryConfig := applyConfigDefaults(&config)
+	cb := NewCircuitBreaker(cbConfig, config.Logger)
+
+	logger := config.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &ResilientClient{
+		circuitBreaker: cb,
+		retryConfig:    retryConfig,
+		logger:         logger,
+	}
+}
+
+// applyConfigDefaults applies default values to ResilientClientConfig
+func applyConfigDefaults(config *ResilientClientConfig) (CircuitBreakerConfig, RetryConfig) {
+	// Apply logger default
+	if config.Logger == nil {
+		config.Logger = slog.Default()
+	}
+
+	// Apply circuit breaker defaults
+	if config.CircuitBreakerName == "" {
+		config.CircuitBreakerName = "default"
+	}
+	if config.CircuitBreakerTimeout == 0 {
+		config.CircuitBreakerTimeout = 30 * time.Second
+	}
+	if config.CircuitBreakerInterval == 0 {
+		config.CircuitBreakerInterval = 60 * time.Second
+	}
+	if config.MaxRequests == 0 {
+		config.MaxRequests = 1
+	}
+	if config.FailureThreshold == 0 {
+		config.FailureThreshold = 5
+	}
+
+	// Create circuit breaker config
+	cbConfig := CircuitBreakerConfig{
+		Name:        config.CircuitBreakerName,
+		MaxRequests: config.MaxRequests,
+		Interval:    config.CircuitBreakerInterval,
+		Timeout:     config.CircuitBreakerTimeout,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= config.FailureThreshold
+		},
+		OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
+			config.Logger.Info("circuit breaker state changed",
+				"service", name,
+				"from", from.String(),
+				"to", to.String())
+		},
+	}
+
+	// Apply retry defaults
+	if config.MaxRetries == 0 {
+		config.MaxRetries = 3
+	}
+	if config.InitialInterval == 0 {
+		config.InitialInterval = 100 * time.Millisecond
+	}
+	if config.MaxInterval == 0 {
+		config.MaxInterval = 5 * time.Second
+	}
+	if config.Multiplier == 0 {
+		config.Multiplier = 2.0
+	}
+	if config.RandomizationFactor == 0 {
+		config.RandomizationFactor = 0.5
+	}
+
+	// Create retry config
+	retryConfig := RetryConfig{
+		MaxRetries:          config.MaxRetries,
+		InitialInterval:     config.InitialInterval,
+		MaxInterval:         config.MaxInterval,
+		Multiplier:          config.Multiplier,
+		RandomizationFactor: config.RandomizationFactor,
+	}
+
+	return cbConfig, retryConfig
+}
+
+// CircuitBreaker returns the underlying circuit breaker for state inspection
+func (r *ResilientClient) CircuitBreaker() *CircuitBreaker {
+	return r.circuitBreaker
+}
+
+// RetryConfig returns the retry configuration
+func (r *ResilientClient) RetryConfig() RetryConfig {
+	return r.retryConfig
+}
+
+// Logger returns the configured logger
+func (r *ResilientClient) Logger() *slog.Logger {
+	return r.logger
+}
+
+// ExecuteWithResilience wraps a call with circuit breaker and retry logic
+// This is a generic function that can be used with any return type
+func ExecuteWithResilience[T any](
+	ctx context.Context,
+	r *ResilientClient,
+	operationName string,
+	fn func() (T, error),
+) (T, error) {
+	return executeWithResilienceConfig(
+		ctx,
+		r.circuitBreaker,
+		r.retryConfig,
+		r.logger,
+		operationName,
+		fn,
+	)
+}
+
+// ExecuteWithResilienceNoRetry wraps a call with circuit breaker but no retry
+// Use this for non-idempotent operations
+func ExecuteWithResilienceNoRetry[T any](
+	ctx context.Context,
+	r *ResilientClient,
+	operationName string,
+	fn func() (T, error),
+) (T, error) {
+	return executeWithResilienceConfig(
+		ctx,
+		r.circuitBreaker,
+		NoRetryConfig(),
+		r.logger,
+		operationName,
+		fn,
+	)
+}
+
+// executeWithResilienceConfig is the internal implementation with explicit config
+func executeWithResilienceConfig[T any](
+	ctx context.Context,
+	cb *CircuitBreaker,
+	retryConfig RetryConfig,
+	logger *slog.Logger,
+	operationName string,
+	fn func() (T, error),
+) (T, error) {
+	var result T
+
+	// Wrap the operation with retry logic
+	err := Retry(ctx, retryConfig, func() error {
+		// Execute through circuit breaker
+		res, cbErr := cb.Execute(ctx, func() (any, error) {
+			return fn()
+		})
+		if cbErr != nil {
+			logger.Debug("operation failed",
+				"operation", operationName,
+				"error", cbErr)
+			return fmt.Errorf("circuit breaker execution failed: %w", cbErr)
+		}
+
+		// Type assertion with check
+		var ok bool
+		result, ok = res.(T)
+		if !ok {
+			return fmt.Errorf("%w: expected %T, got %T", ErrTypeAssertion, result, res)
+		}
+		return nil
+	})
+	if err != nil {
+		// Check if circuit breaker is open
+		if errors.Is(err, gobreaker.ErrOpenState) || errors.Is(err, gobreaker.ErrTooManyRequests) {
+			logger.Warn("circuit breaker open",
+				"operation", operationName)
+		}
+		return result, fmt.Errorf("resilient operation failed for %s: %w", operationName, err)
+	}
+
+	return result, nil
+}

--- a/shared/pkg/clients/resilient_test.go
+++ b/shared/pkg/clients/resilient_test.go
@@ -11,6 +11,11 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var (
+	errGenericTest = errors.New("generic error")
+	errTestFailure = errors.New("error")
+)
+
 func TestNewResilientClient(t *testing.T) {
 	t.Run("creates client with default config", func(t *testing.T) {
 		config := DefaultResilientClientConfig("test-service")
@@ -73,7 +78,6 @@ func TestExecuteWithResilience(t *testing.T) {
 		result, err := ExecuteWithResilience(ctx, client, "test-op", func() (string, error) {
 			return "success", nil
 		})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -103,7 +107,6 @@ func TestExecuteWithResilience(t *testing.T) {
 			}
 			return 42, nil
 		})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -159,7 +162,7 @@ func TestExecuteWithResilience(t *testing.T) {
 		// Generic Go errors are NOT retryable
 		_, err := ExecuteWithResilience(ctx, client, "no-retry-op", func() (string, error) {
 			atomic.AddInt32(&attempts, 1)
-			return "", errors.New("generic error")
+			return "", errGenericTest
 		})
 
 		if err == nil {
@@ -199,7 +202,6 @@ func TestExecuteWithResilience(t *testing.T) {
 		result, err := ExecuteWithResilience(ctx, client, "struct-op", func() (Response, error) {
 			return Response{ID: 1, Name: "test"}, nil
 		})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -222,7 +224,7 @@ func TestExecuteWithResilienceNoRetry(t *testing.T) {
 		var attempts int32
 		_, err := ExecuteWithResilienceNoRetry(ctx, client, "no-retry-op", func() (string, error) {
 			atomic.AddInt32(&attempts, 1)
-			return "", errors.New("error")
+			return "", errTestFailure
 		})
 
 		if err == nil {
@@ -241,7 +243,6 @@ func TestExecuteWithResilienceNoRetry(t *testing.T) {
 		result, err := ExecuteWithResilienceNoRetry(ctx, client, "success-op", func() (int, error) {
 			return 100, nil
 		})
-
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/shared/pkg/clients/resilient_test.go
+++ b/shared/pkg/clients/resilient_test.go
@@ -1,0 +1,311 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNewResilientClient(t *testing.T) {
+	t.Run("creates client with default config", func(t *testing.T) {
+		config := DefaultResilientClientConfig("test-service")
+		client := NewResilientClient(config)
+
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+		if client.CircuitBreaker() == nil {
+			t.Error("expected non-nil circuit breaker")
+		}
+		if client.Logger() == nil {
+			t.Error("expected non-nil logger")
+		}
+	})
+
+	t.Run("creates client with nil logger uses default", func(t *testing.T) {
+		config := ResilientClientConfig{
+			CircuitBreakerName: "test",
+			Logger:             nil,
+		}
+		client := NewResilientClient(config)
+
+		if client.Logger() == nil {
+			t.Error("expected default logger when nil provided")
+		}
+	})
+
+	t.Run("creates client with custom config", func(t *testing.T) {
+		config := ResilientClientConfig{
+			CircuitBreakerName:     "custom-service",
+			CircuitBreakerTimeout:  10 * time.Second,
+			CircuitBreakerInterval: 30 * time.Second,
+			MaxRequests:            5,
+			FailureThreshold:       3,
+			MaxRetries:             5,
+			InitialInterval:        200 * time.Millisecond,
+			MaxInterval:            10 * time.Second,
+			Multiplier:             1.5,
+			RandomizationFactor:    0.3,
+		}
+		client := NewResilientClient(config)
+
+		retryConfig := client.RetryConfig()
+		if retryConfig.MaxRetries != 5 {
+			t.Errorf("expected MaxRetries=5, got %d", retryConfig.MaxRetries)
+		}
+		if retryConfig.InitialInterval != 200*time.Millisecond {
+			t.Errorf("expected InitialInterval=200ms, got %v", retryConfig.InitialInterval)
+		}
+	})
+}
+
+func TestExecuteWithResilience(t *testing.T) {
+	t.Run("successful execution returns result", func(t *testing.T) {
+		config := DefaultResilientClientConfig("test")
+		client := NewResilientClient(config)
+		ctx := context.Background()
+
+		result, err := ExecuteWithResilience(ctx, client, "test-op", func() (string, error) {
+			return "success", nil
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != "success" {
+			t.Errorf("expected 'success', got '%s'", result)
+		}
+	})
+
+	t.Run("retries on transient gRPC failure", func(t *testing.T) {
+		config := ResilientClientConfig{
+			CircuitBreakerName:  "retry-test",
+			MaxRetries:          3,
+			InitialInterval:     1 * time.Millisecond,
+			MaxInterval:         10 * time.Millisecond,
+			Multiplier:          2.0,
+			RandomizationFactor: 0,
+		}
+		client := NewResilientClient(config)
+		ctx := context.Background()
+
+		var attempts int32
+		// Use gRPC Unavailable status - this is retryable
+		result, err := ExecuteWithResilience(ctx, client, "retry-op", func() (int, error) {
+			count := atomic.AddInt32(&attempts, 1)
+			if count < 3 {
+				return 0, status.Error(codes.Unavailable, "service unavailable")
+			}
+			return 42, nil
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != 42 {
+			t.Errorf("expected 42, got %d", result)
+		}
+		if attempts != 3 {
+			t.Errorf("expected 3 attempts, got %d", attempts)
+		}
+	})
+
+	t.Run("fails after max retries exhausted with gRPC error", func(t *testing.T) {
+		config := ResilientClientConfig{
+			CircuitBreakerName:  "fail-test",
+			MaxRetries:          2,
+			InitialInterval:     1 * time.Millisecond,
+			MaxInterval:         10 * time.Millisecond,
+			Multiplier:          2.0,
+			RandomizationFactor: 0,
+		}
+		client := NewResilientClient(config)
+		ctx := context.Background()
+
+		var attempts int32
+		// Use gRPC Unavailable status - this is retryable
+		_, err := ExecuteWithResilience(ctx, client, "fail-op", func() (string, error) {
+			atomic.AddInt32(&attempts, 1)
+			return "", status.Error(codes.Unavailable, "service unavailable")
+		})
+
+		if err == nil {
+			t.Fatal("expected error after retries exhausted")
+		}
+		// MaxRetries=2 means initial attempt + 2 retries = 3 total attempts
+		if attempts != 3 {
+			t.Errorf("expected 3 attempts (1 initial + 2 retries), got %d", attempts)
+		}
+	})
+
+	t.Run("does not retry non-gRPC errors", func(t *testing.T) {
+		config := ResilientClientConfig{
+			CircuitBreakerName:  "no-retry-generic",
+			MaxRetries:          3,
+			InitialInterval:     1 * time.Millisecond,
+			MaxInterval:         10 * time.Millisecond,
+			Multiplier:          2.0,
+			RandomizationFactor: 0,
+		}
+		client := NewResilientClient(config)
+		ctx := context.Background()
+
+		var attempts int32
+		// Generic Go errors are NOT retryable
+		_, err := ExecuteWithResilience(ctx, client, "no-retry-op", func() (string, error) {
+			atomic.AddInt32(&attempts, 1)
+			return "", errors.New("generic error")
+		})
+
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		// Generic errors should not be retried
+		if attempts != 1 {
+			t.Errorf("expected 1 attempt (no retries for generic errors), got %d", attempts)
+		}
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		config := DefaultResilientClientConfig("ctx-test")
+		client := NewResilientClient(config)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		_, err := ExecuteWithResilience(ctx, client, "ctx-op", func() (string, error) {
+			return "should not reach", nil
+		})
+
+		if err == nil {
+			t.Fatal("expected error from cancelled context")
+		}
+	})
+
+	t.Run("works with different types", func(t *testing.T) {
+		config := DefaultResilientClientConfig("type-test")
+		client := NewResilientClient(config)
+		ctx := context.Background()
+
+		// Test with struct type
+		type Response struct {
+			ID   int
+			Name string
+		}
+		result, err := ExecuteWithResilience(ctx, client, "struct-op", func() (Response, error) {
+			return Response{ID: 1, Name: "test"}, nil
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.ID != 1 || result.Name != "test" {
+			t.Errorf("unexpected result: %+v", result)
+		}
+	})
+}
+
+func TestExecuteWithResilienceNoRetry(t *testing.T) {
+	t.Run("does not retry on failure", func(t *testing.T) {
+		config := ResilientClientConfig{
+			CircuitBreakerName: "no-retry-test",
+			MaxRetries:         5, // This should be ignored
+			InitialInterval:    1 * time.Millisecond,
+		}
+		client := NewResilientClient(config)
+		ctx := context.Background()
+
+		var attempts int32
+		_, err := ExecuteWithResilienceNoRetry(ctx, client, "no-retry-op", func() (string, error) {
+			atomic.AddInt32(&attempts, 1)
+			return "", errors.New("error")
+		})
+
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if attempts != 1 {
+			t.Errorf("expected exactly 1 attempt (no retries), got %d", attempts)
+		}
+	})
+
+	t.Run("successful execution returns result", func(t *testing.T) {
+		config := DefaultResilientClientConfig("no-retry-success")
+		client := NewResilientClient(config)
+		ctx := context.Background()
+
+		result, err := ExecuteWithResilienceNoRetry(ctx, client, "success-op", func() (int, error) {
+			return 100, nil
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result != 100 {
+			t.Errorf("expected 100, got %d", result)
+		}
+	})
+}
+
+func TestDefaultResilientClientConfig(t *testing.T) {
+	config := DefaultResilientClientConfig("my-service")
+
+	if config.CircuitBreakerName != "my-service" {
+		t.Errorf("expected name 'my-service', got '%s'", config.CircuitBreakerName)
+	}
+	if config.CircuitBreakerTimeout != 30*time.Second {
+		t.Errorf("expected timeout 30s, got %v", config.CircuitBreakerTimeout)
+	}
+	if config.CircuitBreakerInterval != 60*time.Second {
+		t.Errorf("expected interval 60s, got %v", config.CircuitBreakerInterval)
+	}
+	if config.MaxRequests != 1 {
+		t.Errorf("expected MaxRequests=1, got %d", config.MaxRequests)
+	}
+	if config.FailureThreshold != 5 {
+		t.Errorf("expected FailureThreshold=5, got %d", config.FailureThreshold)
+	}
+	if config.MaxRetries != 3 {
+		t.Errorf("expected MaxRetries=3, got %d", config.MaxRetries)
+	}
+	if config.InitialInterval != 100*time.Millisecond {
+		t.Errorf("expected InitialInterval=100ms, got %v", config.InitialInterval)
+	}
+	if config.MaxInterval != 5*time.Second {
+		t.Errorf("expected MaxInterval=5s, got %v", config.MaxInterval)
+	}
+	if config.Multiplier != 2.0 {
+		t.Errorf("expected Multiplier=2.0, got %f", config.Multiplier)
+	}
+	if config.RandomizationFactor != 0.5 {
+		t.Errorf("expected RandomizationFactor=0.5, got %f", config.RandomizationFactor)
+	}
+}
+
+func TestResilientClientAccessors(t *testing.T) {
+	config := DefaultResilientClientConfig("accessor-test")
+	client := NewResilientClient(config)
+
+	t.Run("CircuitBreaker returns non-nil", func(t *testing.T) {
+		if client.CircuitBreaker() == nil {
+			t.Error("expected non-nil circuit breaker")
+		}
+	})
+
+	t.Run("RetryConfig returns configured values", func(t *testing.T) {
+		rc := client.RetryConfig()
+		if rc.MaxRetries != 3 {
+			t.Errorf("expected MaxRetries=3, got %d", rc.MaxRetries)
+		}
+	})
+
+	t.Run("Logger returns non-nil", func(t *testing.T) {
+		if client.Logger() == nil {
+			t.Error("expected non-nil logger")
+		}
+	})
+}

--- a/shared/pkg/clients/retry.go
+++ b/shared/pkg/clients/retry.go
@@ -1,0 +1,146 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// RetryConfig holds retry configuration
+type RetryConfig struct {
+	// MaxRetries is the maximum number of retry attempts (excluding the initial attempt)
+	MaxRetries int
+
+	// InitialInterval is the initial delay before the first retry
+	InitialInterval time.Duration
+
+	// MaxInterval is the maximum delay between retries
+	MaxInterval time.Duration
+
+	// Multiplier is the factor by which the interval increases after each retry
+	Multiplier float64
+
+	// RandomizationFactor adds jitter to prevent thundering herd (0.0 = no jitter, 1.0 = max jitter)
+	RandomizationFactor float64
+}
+
+// DefaultRetryConfig returns a retry configuration with sensible defaults
+func DefaultRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxRetries:          3,
+		InitialInterval:     100 * time.Millisecond,
+		MaxInterval:         10 * time.Second,
+		Multiplier:          2.0,
+		RandomizationFactor: 0.5, // ±50% jitter
+	}
+}
+
+// NoRetryConfig returns a configuration that disables retries
+// Use this for non-idempotent operations
+func NoRetryConfig() RetryConfig {
+	return RetryConfig{
+		MaxRetries:          0,
+		InitialInterval:     0,
+		MaxInterval:         0,
+		Multiplier:          1.0,
+		RandomizationFactor: 0,
+	}
+}
+
+// IsRetryable determines if an error should be retried
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Never retry context errors
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Check if it's a gRPC status error
+	st, ok := status.FromError(err)
+	if !ok {
+		// Generic errors are not retryable by default
+		return false
+	}
+
+	// Classify gRPC codes
+	switch st.Code() {
+	case codes.Unavailable, codes.DeadlineExceeded, codes.ResourceExhausted, codes.Internal:
+		// Transient errors that may succeed on retry
+		return true
+	case codes.InvalidArgument, codes.NotFound, codes.AlreadyExists, codes.PermissionDenied,
+		codes.Unauthenticated, codes.FailedPrecondition, codes.Aborted, codes.OutOfRange,
+		codes.Unimplemented, codes.DataLoss:
+		// Permanent errors that won't succeed on retry
+		return false
+	case codes.OK, codes.Canceled, codes.Unknown:
+		// OK means no error, Canceled is handled above, Unknown is not retried
+		return false
+	default:
+		// Unknown codes are not retried by default
+		return false
+	}
+}
+
+// Retry wraps a function with retry logic using exponential backoff with jitter
+// The function is retried if it returns a retryable error (see IsRetryable)
+// Retry respects context cancellation and deadlines
+func Retry(ctx context.Context, config RetryConfig, fn func() error) error {
+	// Configure exponential backoff
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = config.InitialInterval
+	b.MaxInterval = config.MaxInterval
+	b.Multiplier = config.Multiplier
+	b.RandomizationFactor = config.RandomizationFactor
+	b.MaxElapsedTime = 0 // No max elapsed time, we use MaxRetries instead
+	b.Reset()
+
+	// Wrap with context
+	backoffWithContext := backoff.WithContext(b, ctx)
+
+	// Track number of attempts
+	attempt := 0
+	maxAttempts := config.MaxRetries + 1 // Initial attempt + retries
+
+	operation := func() error {
+		// Check context before each attempt
+		if err := ctx.Err(); err != nil {
+			return backoff.Permanent(err)
+		}
+
+		attempt++
+
+		// Execute the function
+		err := fn()
+
+		// If no error, we're done
+		if err == nil {
+			return nil
+		}
+
+		// If we've exhausted retries, return permanent error
+		if attempt >= maxAttempts {
+			return backoff.Permanent(err)
+		}
+
+		// If error is not retryable, return permanent error
+		if !IsRetryable(err) {
+			return backoff.Permanent(err)
+		}
+
+		// Return the error to trigger retry
+		return err
+	}
+
+	if err := backoff.Retry(operation, backoffWithContext); err != nil {
+		return fmt.Errorf("retry failed: %w", err)
+	}
+	return nil
+}

--- a/shared/pkg/clients/retry_test.go
+++ b/shared/pkg/clients/retry_test.go
@@ -1,0 +1,468 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var errSomeError = errors.New("some error")
+
+func TestDefaultRetryConfig(t *testing.T) {
+	config := DefaultRetryConfig()
+
+	if config.MaxRetries != 3 {
+		t.Errorf("expected MaxRetries = 3, got %d", config.MaxRetries)
+	}
+	if config.InitialInterval != 100*time.Millisecond {
+		t.Errorf("expected InitialInterval = 100ms, got %v", config.InitialInterval)
+	}
+	if config.MaxInterval != 10*time.Second {
+		t.Errorf("expected MaxInterval = 10s, got %v", config.MaxInterval)
+	}
+	if config.Multiplier != 2.0 {
+		t.Errorf("expected Multiplier = 2.0, got %f", config.Multiplier)
+	}
+	if config.RandomizationFactor != 0.5 {
+		t.Errorf("expected RandomizationFactor = 0.5, got %f", config.RandomizationFactor)
+	}
+}
+
+func TestNoRetryConfig(t *testing.T) {
+	config := NoRetryConfig()
+
+	if config.MaxRetries != 0 {
+		t.Errorf("expected MaxRetries = 0, got %d", config.MaxRetries)
+	}
+	if config.InitialInterval != 0 {
+		t.Errorf("expected InitialInterval = 0, got %v", config.InitialInterval)
+	}
+	if config.MaxInterval != 0 {
+		t.Errorf("expected MaxInterval = 0, got %v", config.MaxInterval)
+	}
+	if config.Multiplier != 1.0 {
+		t.Errorf("expected Multiplier = 1.0, got %f", config.Multiplier)
+	}
+	if config.RandomizationFactor != 0 {
+		t.Errorf("expected RandomizationFactor = 0, got %f", config.RandomizationFactor)
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		// Retryable errors
+		{
+			name:     "unavailable error",
+			err:      status.Error(codes.Unavailable, "service unavailable"),
+			expected: true,
+		},
+		{
+			name:     "deadline exceeded error",
+			err:      status.Error(codes.DeadlineExceeded, "deadline exceeded"),
+			expected: true,
+		},
+		{
+			name:     "resource exhausted error",
+			err:      status.Error(codes.ResourceExhausted, "resource exhausted"),
+			expected: true,
+		},
+		{
+			name:     "internal error",
+			err:      status.Error(codes.Internal, "internal error"),
+			expected: true,
+		},
+
+		// Non-retryable errors
+		{
+			name:     "invalid argument error",
+			err:      status.Error(codes.InvalidArgument, "invalid argument"),
+			expected: false,
+		},
+		{
+			name:     "not found error",
+			err:      status.Error(codes.NotFound, "not found"),
+			expected: false,
+		},
+		{
+			name:     "already exists error",
+			err:      status.Error(codes.AlreadyExists, "already exists"),
+			expected: false,
+		},
+		{
+			name:     "permission denied error",
+			err:      status.Error(codes.PermissionDenied, "permission denied"),
+			expected: false,
+		},
+
+		// Context errors (never retry)
+		{
+			name:     "context canceled",
+			err:      context.Canceled,
+			expected: false,
+		},
+		{
+			name:     "context deadline exceeded",
+			err:      context.DeadlineExceeded,
+			expected: false,
+		},
+
+		// Generic errors
+		{
+			name:     "generic error",
+			err:      errSomeError,
+			expected: false,
+		},
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsRetryable(tt.err)
+			if result != tt.expected {
+				t.Errorf("IsRetryable(%v) = %v, expected %v", tt.err, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRetrySuccessOnFirstAttempt(t *testing.T) {
+	config := DefaultRetryConfig()
+	ctx := context.Background()
+
+	attempts := 0
+	fn := func() error {
+		attempts++
+		return nil
+	}
+
+	err := Retry(ctx, config, fn)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt, got %d", attempts)
+	}
+}
+
+func TestRetrySuccessAfterTransientFailure(t *testing.T) {
+	config := DefaultRetryConfig()
+	config.InitialInterval = 10 * time.Millisecond // Speed up test
+	ctx := context.Background()
+
+	attempts := 0
+	fn := func() error {
+		attempts++
+		if attempts < 3 {
+			return status.Error(codes.Unavailable, "service unavailable")
+		}
+		return nil
+	}
+
+	start := time.Now()
+	err := Retry(ctx, config, fn)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+	// Verify exponential backoff occurred (at least 2 delays)
+	// First retry: ~10ms, second retry: ~20ms (with jitter)
+	// Conservative check: at least 15ms total
+	if elapsed < 15*time.Millisecond {
+		t.Errorf("expected delays from backoff, got %v", elapsed)
+	}
+}
+
+func TestRetryMaxRetriesExhausted(t *testing.T) {
+	config := DefaultRetryConfig()
+	config.MaxRetries = 2
+	config.InitialInterval = 10 * time.Millisecond // Speed up test
+	ctx := context.Background()
+
+	attempts := 0
+	fn := func() error {
+		attempts++
+		return status.Error(codes.Unavailable, "service unavailable")
+	}
+
+	err := Retry(ctx, config, fn)
+
+	if err == nil {
+		t.Error("expected error after max retries, got nil")
+	}
+	// Max retries = 2 means initial attempt + 2 retries = 3 total attempts
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts (initial + 2 retries), got %d", attempts)
+	}
+}
+
+func TestRetryNonRetryableError(t *testing.T) {
+	config := DefaultRetryConfig()
+	ctx := context.Background()
+
+	attempts := 0
+	fn := func() error {
+		attempts++
+		return status.Error(codes.InvalidArgument, "invalid argument")
+	}
+
+	err := Retry(ctx, config, fn)
+
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt (no retries for non-retryable error), got %d", attempts)
+	}
+}
+
+func TestRetryContextCancellation(t *testing.T) {
+	config := DefaultRetryConfig()
+	config.InitialInterval = 100 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+
+	attempts := 0
+	fn := func() error {
+		attempts++
+		if attempts == 2 {
+			cancel() // Cancel context on second attempt
+		}
+		return status.Error(codes.Unavailable, "service unavailable")
+	}
+
+	err := Retry(ctx, config, fn)
+
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got %v", err)
+	}
+	// Should stop retrying after context is cancelled
+	if attempts > 2 {
+		t.Errorf("expected at most 2 attempts before cancellation, got %d", attempts)
+	}
+}
+
+func TestRetryContextDeadlineExceeded(t *testing.T) {
+	config := DefaultRetryConfig()
+	config.InitialInterval = 50 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	attempts := 0
+	fn := func() error {
+		attempts++
+		time.Sleep(30 * time.Millisecond) // Simulate slow operation
+		return status.Error(codes.Unavailable, "service unavailable")
+	}
+
+	err := Retry(ctx, config, fn)
+
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded error, got %v", err)
+	}
+	// Should stop when context deadline is exceeded
+	if attempts > 3 {
+		t.Errorf("expected limited attempts due to context deadline, got %d", attempts)
+	}
+}
+
+func TestRetryExponentialBackoff(t *testing.T) {
+	// Skip timing-sensitive tests in short mode (e.g., CI environments)
+	// These tests can be flaky due to CPU scheduling variance
+	if testing.Short() {
+		t.Skip("Skipping timing-sensitive test in short mode")
+	}
+
+	config := RetryConfig{
+		MaxRetries:          3,
+		InitialInterval:     50 * time.Millisecond,
+		MaxInterval:         1 * time.Second,
+		Multiplier:          2.0,
+		RandomizationFactor: 0.0, // No jitter for predictable timing
+	}
+	ctx := context.Background()
+
+	attempts := 0
+	attemptTimes := []time.Time{}
+	fn := func() error {
+		attempts++
+		attemptTimes = append(attemptTimes, time.Now())
+		return status.Error(codes.Unavailable, "service unavailable")
+	}
+
+	_ = Retry(ctx, config, fn)
+
+	// Verify exponential backoff intervals
+	// Attempt 1: immediate
+	// Attempt 2: after ~50ms
+	// Attempt 3: after ~100ms (50ms * 2)
+	// Attempt 4: after ~200ms (100ms * 2)
+
+	if len(attemptTimes) != 4 {
+		t.Fatalf("expected 4 attempts, got %d", len(attemptTimes))
+	}
+
+	// Check interval between attempt 1 and 2 (should be ~50ms with no jitter)
+	// Increased tolerance to ±30% to account for CI runner variance
+	interval1 := attemptTimes[1].Sub(attemptTimes[0])
+	if interval1 < 35*time.Millisecond || interval1 > 65*time.Millisecond {
+		t.Errorf("expected first retry interval ~50ms (±30%%), got %v", interval1)
+	}
+
+	// Check interval between attempt 2 and 3 (should be ~100ms)
+	// Increased tolerance to ±30% to account for CI runner variance
+	interval2 := attemptTimes[2].Sub(attemptTimes[1])
+	if interval2 < 70*time.Millisecond || interval2 > 130*time.Millisecond {
+		t.Errorf("expected second retry interval ~100ms (±30%%), got %v", interval2)
+	}
+
+	// Check interval between attempt 3 and 4 (should be ~200ms)
+	// Increased tolerance to ±30% to account for CI runner variance
+	interval3 := attemptTimes[3].Sub(attemptTimes[2])
+	if interval3 < 140*time.Millisecond || interval3 > 260*time.Millisecond {
+		t.Errorf("expected third retry interval ~200ms (±30%%), got %v", interval3)
+	}
+}
+
+func TestRetryJitterIsApplied(t *testing.T) {
+	// Skip timing-sensitive tests in short mode (e.g., CI environments)
+	if testing.Short() {
+		t.Skip("Skipping timing-sensitive test in short mode")
+	}
+
+	config := RetryConfig{
+		MaxRetries:          2,
+		InitialInterval:     100 * time.Millisecond,
+		MaxInterval:         1 * time.Second,
+		Multiplier:          2.0,
+		RandomizationFactor: 0.5, // ±50% jitter
+	}
+	ctx := context.Background()
+
+	// Run multiple times to verify jitter varies
+	intervals := []time.Duration{}
+	for i := 0; i < 5; i++ {
+		attempts := 0
+		var firstAttempt, secondAttempt time.Time
+		fn := func() error {
+			attempts++
+			switch attempts {
+			case 1:
+				firstAttempt = time.Now()
+			case 2:
+				secondAttempt = time.Now()
+			}
+			return status.Error(codes.Unavailable, "service unavailable")
+		}
+
+		_ = Retry(ctx, config, fn)
+		if !firstAttempt.IsZero() && !secondAttempt.IsZero() {
+			intervals = append(intervals, secondAttempt.Sub(firstAttempt))
+		}
+	}
+
+	// Verify that intervals vary (jitter is working)
+	// With ±50% jitter, intervals should be between 50ms and 150ms
+	allSame := true
+	for i := 1; i < len(intervals); i++ {
+		if intervals[i] != intervals[0] {
+			allSame = false
+			break
+		}
+	}
+
+	if allSame {
+		t.Error("expected intervals to vary due to jitter, but all were the same")
+	}
+
+	// Verify all intervals are within expected range
+	// Wider tolerance (±60% vs ±30% in exponential backoff test) because:
+	// 1. Test uses 50% randomization factor (±50% jitter by design)
+	// 2. CI scheduler variance compounds with intentional randomization
+	// Expected: 100ms ± 50% jitter ± CI variance = 40-160ms range
+	for _, interval := range intervals {
+		if interval < 40*time.Millisecond || interval > 160*time.Millisecond {
+			t.Errorf("expected interval between 40ms and 160ms with jitter, got %v", interval)
+		}
+	}
+}
+
+func TestRetryWithContextError(t *testing.T) {
+	config := DefaultRetryConfig()
+	ctx := context.Background()
+
+	attempts := 0
+	fn := func() error {
+		attempts++
+		return context.Canceled
+	}
+
+	err := Retry(ctx, config, fn)
+
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got %v", err)
+	}
+	if attempts != 1 {
+		t.Errorf("expected 1 attempt (no retries for context errors), got %d", attempts)
+	}
+}
+
+func TestRetryWithCircuitBreakerIntegration(t *testing.T) {
+	// This test demonstrates the recommended pattern: Circuit Breaker wraps Retry
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	cbConfig := DefaultCircuitBreakerConfig("test-service")
+	cbConfig.Timeout = 1 * time.Second
+	cb := NewCircuitBreaker(cbConfig, logger)
+
+	retryConfig := DefaultRetryConfig()
+	retryConfig.MaxRetries = 2
+	retryConfig.InitialInterval = 10 * time.Millisecond
+
+	ctx := context.Background()
+
+	// Simulate a service that fails twice then succeeds
+	attempts := 0
+	_, err := cb.Execute(ctx, func() (any, error) {
+		return nil, Retry(ctx, retryConfig, func() error {
+			attempts++
+			if attempts < 3 {
+				return status.Error(codes.Unavailable, "service unavailable")
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+	if cb.State() != 0 { // 0 = Closed state
+		t.Errorf("expected circuit breaker to be closed, got state %v", cb.State())
+	}
+}

--- a/shared/pkg/clients/saga.go
+++ b/shared/pkg/clients/saga.go
@@ -26,6 +26,9 @@ type SagaResult struct {
 	FailedStep       string
 	CompensatedSteps int
 	Error            error
+	// CompensationErrors contains errors from failed compensation attempts.
+	// Even if some compensations fail, the saga continues compensating remaining steps.
+	CompensationErrors []error
 }
 
 // NewSagaOrchestrator creates a new saga orchestrator
@@ -110,7 +113,9 @@ func (s *SagaOrchestrator) compensate(ctx context.Context, failedAtIndex int, re
 			s.logger.Error("compensation failed",
 				"step", step.Name,
 				"error", err)
-			// Continue compensating remaining steps despite error
+			// Track compensation error and continue with remaining steps
+			result.CompensationErrors = append(result.CompensationErrors,
+				fmt.Errorf("compensation for step %s failed: %w", step.Name, err))
 		} else {
 			result.CompensatedSteps++
 		}

--- a/shared/pkg/clients/saga.go
+++ b/shared/pkg/clients/saga.go
@@ -1,0 +1,131 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+// SagaStep represents a single step in a saga transaction
+type SagaStep struct {
+	Name       string
+	Action     func(ctx context.Context) error
+	Compensate func(ctx context.Context) error
+}
+
+// SagaOrchestrator manages distributed transactions with compensation
+type SagaOrchestrator struct {
+	steps  []SagaStep
+	logger *slog.Logger
+}
+
+// SagaResult contains the outcome of a saga execution
+type SagaResult struct {
+	Success          bool
+	CompletedSteps   int
+	FailedStep       string
+	CompensatedSteps int
+	Error            error
+}
+
+// NewSagaOrchestrator creates a new saga orchestrator
+func NewSagaOrchestrator(logger *slog.Logger) *SagaOrchestrator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &SagaOrchestrator{
+		steps:  make([]SagaStep, 0),
+		logger: logger,
+	}
+}
+
+// AddStep adds a step to the saga
+func (s *SagaOrchestrator) AddStep(name string, action, compensate func(ctx context.Context) error) {
+	s.steps = append(s.steps, SagaStep{
+		Name:       name,
+		Action:     action,
+		Compensate: compensate,
+	})
+}
+
+// Execute runs the saga, performing compensation on failure
+func (s *SagaOrchestrator) Execute(ctx context.Context) SagaResult {
+	result := SagaResult{
+		Success: true,
+	}
+
+	// Execute steps in order
+	for i, step := range s.steps {
+		s.logger.Info("executing saga step",
+			"step", step.Name,
+			"index", i+1,
+			"total", len(s.steps))
+
+		if err := step.Action(ctx); err != nil {
+			s.logger.Error("saga step failed",
+				"step", step.Name,
+				"error", err)
+
+			result.Success = false
+			result.CompletedSteps = i
+			result.FailedStep = step.Name
+			result.Error = fmt.Errorf("step %s failed: %w", step.Name, err)
+
+			// Compensate completed steps in reverse order
+			s.compensate(ctx, i, &result)
+
+			return result
+		}
+
+		result.CompletedSteps++
+	}
+
+	s.logger.Info("saga completed successfully",
+		"total_steps", len(s.steps))
+
+	return result
+}
+
+// compensate performs compensation for completed steps in reverse order
+func (s *SagaOrchestrator) compensate(ctx context.Context, failedAtIndex int, result *SagaResult) {
+	s.logger.Info("starting compensation",
+		"completed_steps", failedAtIndex)
+
+	// Compensate in reverse order (LIFO)
+	for i := failedAtIndex - 1; i >= 0; i-- {
+		step := s.steps[i]
+
+		if step.Compensate == nil {
+			s.logger.Warn("no compensation defined for step",
+				"step", step.Name)
+			continue
+		}
+
+		s.logger.Info("compensating step",
+			"step", step.Name,
+			"index", i+1)
+
+		if err := step.Compensate(ctx); err != nil {
+			s.logger.Error("compensation failed",
+				"step", step.Name,
+				"error", err)
+			// Continue compensating remaining steps despite error
+		} else {
+			result.CompensatedSteps++
+		}
+	}
+
+	s.logger.Info("compensation completed",
+		"compensated_steps", result.CompensatedSteps)
+}
+
+// Reset clears all steps from the orchestrator
+func (s *SagaOrchestrator) Reset() {
+	s.steps = make([]SagaStep, 0)
+}
+
+// StepCount returns the number of steps in the saga
+func (s *SagaOrchestrator) StepCount() int {
+	return len(s.steps)
+}

--- a/shared/pkg/clients/saga_test.go
+++ b/shared/pkg/clients/saga_test.go
@@ -92,6 +92,7 @@ func TestSagaOrchestrator_Execute_AllStepsSucceed(t *testing.T) {
 	assert.Equal(t, "", result.FailedStep)
 	assert.Equal(t, 0, result.CompensatedSteps)
 	assert.NoError(t, result.Error)
+	assert.Nil(t, result.CompensationErrors)
 	assert.Equal(t, []string{"step1", "step2", "step3"}, executed)
 }
 
@@ -262,6 +263,11 @@ func TestSagaOrchestrator_Execute_CompensationFails(t *testing.T) {
 
 	// Verify both compensations were attempted despite failure
 	assert.Equal(t, []string{"compensate2", "compensate1"}, compensated)
+
+	// Verify compensation errors are tracked
+	assert.Len(t, result.CompensationErrors, 1)
+	assert.Contains(t, result.CompensationErrors[0].Error(), "step2")
+	assert.ErrorIs(t, result.CompensationErrors[0], errCompensationFailed)
 }
 
 // TestSagaOrchestrator_Execute_ContextCancellation verifies handling of context cancellation

--- a/shared/pkg/clients/saga_test.go
+++ b/shared/pkg/clients/saga_test.go
@@ -1,0 +1,416 @@
+package clients_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	errStep1Failed        = errors.New("step1 failed")
+	errStep2Failed        = errors.New("step2 failed")
+	errStep3Failed        = errors.New("step3 failed")
+	errStep7Failed        = errors.New("step7 failed")
+	errCompensationFailed = errors.New("compensation failed")
+)
+
+// TestNewSagaOrchestrator_Success verifies orchestrator creation
+func TestNewSagaOrchestrator_Success(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.Default()
+	orchestrator := clients.NewSagaOrchestrator(logger)
+
+	require.NotNil(t, orchestrator)
+	assert.Equal(t, 0, orchestrator.StepCount())
+}
+
+// TestNewSagaOrchestrator_NilLogger verifies default logger is used when nil provided
+func TestNewSagaOrchestrator_NilLogger(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(nil)
+
+	require.NotNil(t, orchestrator)
+	assert.Equal(t, 0, orchestrator.StepCount())
+}
+
+// TestSagaOrchestrator_AddStep verifies adding steps
+func TestSagaOrchestrator_AddStep(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(slog.Default())
+
+	action := func(_ context.Context) error { return nil }
+	compensate := func(_ context.Context) error { return nil }
+
+	orchestrator.AddStep("step1", action, compensate)
+	assert.Equal(t, 1, orchestrator.StepCount())
+
+	orchestrator.AddStep("step2", action, compensate)
+	assert.Equal(t, 2, orchestrator.StepCount())
+
+	orchestrator.AddStep("step3", action, compensate)
+	assert.Equal(t, 3, orchestrator.StepCount())
+}
+
+// TestSagaOrchestrator_Execute_AllStepsSucceed verifies successful saga execution
+func TestSagaOrchestrator_Execute_AllStepsSucceed(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(slog.Default())
+
+	executed := []string{}
+
+	step1 := func(_ context.Context) error {
+		executed = append(executed, "step1")
+		return nil
+	}
+	step2 := func(_ context.Context) error {
+		executed = append(executed, "step2")
+		return nil
+	}
+	step3 := func(_ context.Context) error {
+		executed = append(executed, "step3")
+		return nil
+	}
+
+	orchestrator.AddStep("step1", step1, nil)
+	orchestrator.AddStep("step2", step2, nil)
+	orchestrator.AddStep("step3", step3, nil)
+
+	result := orchestrator.Execute(context.Background())
+
+	assert.True(t, result.Success)
+	assert.Equal(t, 3, result.CompletedSteps)
+	assert.Equal(t, "", result.FailedStep)
+	assert.Equal(t, 0, result.CompensatedSteps)
+	assert.NoError(t, result.Error)
+	assert.Equal(t, []string{"step1", "step2", "step3"}, executed)
+}
+
+// TestSagaOrchestrator_Execute_StepFails verifies compensation on failure
+func TestSagaOrchestrator_Execute_StepFails(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(slog.Default())
+
+	executed := []string{}
+	compensated := []string{}
+
+	step1 := func(_ context.Context) error {
+		executed = append(executed, "step1")
+		return nil
+	}
+	compensate1 := func(_ context.Context) error {
+		compensated = append(compensated, "compensate1")
+		return nil
+	}
+
+	step2 := func(_ context.Context) error {
+		executed = append(executed, "step2")
+		return nil
+	}
+	compensate2 := func(_ context.Context) error {
+		compensated = append(compensated, "compensate2")
+		return nil
+	}
+
+	step3 := func(_ context.Context) error {
+		executed = append(executed, "step3")
+		return errStep3Failed
+	}
+	compensate3 := func(_ context.Context) error {
+		compensated = append(compensated, "compensate3")
+		return nil
+	}
+
+	orchestrator.AddStep("step1", step1, compensate1)
+	orchestrator.AddStep("step2", step2, compensate2)
+	orchestrator.AddStep("step3", step3, compensate3)
+
+	result := orchestrator.Execute(context.Background())
+
+	assert.False(t, result.Success)
+	assert.Equal(t, 2, result.CompletedSteps)
+	assert.Equal(t, "step3", result.FailedStep)
+	assert.Equal(t, 2, result.CompensatedSteps)
+	assert.Error(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "step3 failed")
+
+	// Verify execution order
+	assert.Equal(t, []string{"step1", "step2", "step3"}, executed)
+
+	// Verify compensation order (reverse)
+	assert.Equal(t, []string{"compensate2", "compensate1"}, compensated)
+}
+
+// TestSagaOrchestrator_Execute_FirstStepFails verifies no compensation when first step fails
+func TestSagaOrchestrator_Execute_FirstStepFails(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(slog.Default())
+
+	executed := []string{}
+	compensated := []string{}
+
+	step1 := func(_ context.Context) error {
+		executed = append(executed, "step1")
+		return errStep1Failed
+	}
+	compensate1 := func(_ context.Context) error {
+		compensated = append(compensated, "compensate1")
+		return nil
+	}
+
+	orchestrator.AddStep("step1", step1, compensate1)
+
+	result := orchestrator.Execute(context.Background())
+
+	assert.False(t, result.Success)
+	assert.Equal(t, 0, result.CompletedSteps)
+	assert.Equal(t, "step1", result.FailedStep)
+	assert.Equal(t, 0, result.CompensatedSteps)
+	assert.Error(t, result.Error)
+
+	// First step failed, so no compensation should occur
+	assert.Equal(t, []string{"step1"}, executed)
+	assert.Empty(t, compensated)
+}
+
+// TestSagaOrchestrator_Execute_NoCompensationDefined verifies behavior when compensation is nil
+func TestSagaOrchestrator_Execute_NoCompensationDefined(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(slog.Default())
+
+	executed := []string{}
+
+	step1 := func(_ context.Context) error {
+		executed = append(executed, "step1")
+		return nil
+	}
+
+	step2 := func(_ context.Context) error {
+		executed = append(executed, "step2")
+		return errStep2Failed
+	}
+
+	orchestrator.AddStep("step1", step1, nil) // No compensation function
+	orchestrator.AddStep("step2", step2, nil)
+
+	result := orchestrator.Execute(context.Background())
+
+	assert.False(t, result.Success)
+	assert.Equal(t, 1, result.CompletedSteps)
+	assert.Equal(t, "step2", result.FailedStep)
+	assert.Equal(t, 0, result.CompensatedSteps) // No compensation because nil
+	assert.Error(t, result.Error)
+
+	assert.Equal(t, []string{"step1", "step2"}, executed)
+}
+
+// TestSagaOrchestrator_Execute_CompensationFails verifies saga continues compensating despite failures
+func TestSagaOrchestrator_Execute_CompensationFails(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(slog.Default())
+
+	executed := []string{}
+	compensated := []string{}
+
+	step1 := func(_ context.Context) error {
+		executed = append(executed, "step1")
+		return nil
+	}
+	compensate1 := func(_ context.Context) error {
+		compensated = append(compensated, "compensate1")
+		return nil
+	}
+
+	step2 := func(_ context.Context) error {
+		executed = append(executed, "step2")
+		return nil
+	}
+	compensate2 := func(_ context.Context) error {
+		compensated = append(compensated, "compensate2")
+		return errCompensationFailed
+	}
+
+	step3 := func(_ context.Context) error {
+		executed = append(executed, "step3")
+		return errStep3Failed
+	}
+
+	orchestrator.AddStep("step1", step1, compensate1)
+	orchestrator.AddStep("step2", step2, compensate2)
+	orchestrator.AddStep("step3", step3, nil)
+
+	result := orchestrator.Execute(context.Background())
+
+	assert.False(t, result.Success)
+	assert.Equal(t, 2, result.CompletedSteps)
+	assert.Equal(t, "step3", result.FailedStep)
+	assert.Equal(t, 1, result.CompensatedSteps) // Only step1 compensated successfully
+	assert.Error(t, result.Error)
+
+	// Verify both compensations were attempted despite failure
+	assert.Equal(t, []string{"compensate2", "compensate1"}, compensated)
+}
+
+// TestSagaOrchestrator_Execute_ContextCancellation verifies handling of context cancellation
+func TestSagaOrchestrator_Execute_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(slog.Default())
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	executed := []string{}
+	compensated := []string{}
+
+	step1 := func(_ context.Context) error {
+		executed = append(executed, "step1")
+		return nil
+	}
+	compensate1 := func(_ context.Context) error {
+		compensated = append(compensated, "compensate1")
+		return nil
+	}
+
+	step2 := func(_ context.Context) error {
+		executed = append(executed, "step2")
+		cancel() // Cancel context during execution
+		return ctx.Err()
+	}
+	compensate2 := func(_ context.Context) error {
+		compensated = append(compensated, "compensate2")
+		return nil
+	}
+
+	orchestrator.AddStep("step1", step1, compensate1)
+	orchestrator.AddStep("step2", step2, compensate2)
+
+	result := orchestrator.Execute(ctx)
+
+	assert.False(t, result.Success)
+	assert.Equal(t, 1, result.CompletedSteps)
+	assert.Equal(t, "step2", result.FailedStep)
+	assert.Equal(t, 1, result.CompensatedSteps)
+	assert.Error(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "context canceled")
+
+	assert.Equal(t, []string{"step1", "step2"}, executed)
+	assert.Equal(t, []string{"compensate1"}, compensated)
+}
+
+// TestSagaOrchestrator_Reset verifies clearing all steps
+func TestSagaOrchestrator_Reset(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(slog.Default())
+
+	action := func(_ context.Context) error { return nil }
+	compensate := func(_ context.Context) error { return nil }
+
+	orchestrator.AddStep("step1", action, compensate)
+	orchestrator.AddStep("step2", action, compensate)
+	assert.Equal(t, 2, orchestrator.StepCount())
+
+	orchestrator.Reset()
+	assert.Equal(t, 0, orchestrator.StepCount())
+}
+
+// TestSagaOrchestrator_Execute_EmptySaga verifies executing saga with no steps
+func TestSagaOrchestrator_Execute_EmptySaga(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(slog.Default())
+
+	result := orchestrator.Execute(context.Background())
+
+	assert.True(t, result.Success)
+	assert.Equal(t, 0, result.CompletedSteps)
+	assert.Equal(t, "", result.FailedStep)
+	assert.Equal(t, 0, result.CompensatedSteps)
+	assert.NoError(t, result.Error)
+}
+
+// TestSagaOrchestrator_Execute_MultipleFailures verifies only first failure is reported
+func TestSagaOrchestrator_Execute_MultipleFailures(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(slog.Default())
+
+	step1 := func(_ context.Context) error {
+		return nil
+	}
+
+	step2 := func(_ context.Context) error {
+		return errStep2Failed
+	}
+
+	step3 := func(_ context.Context) error {
+		return errStep3Failed
+	}
+
+	orchestrator.AddStep("step1", step1, nil)
+	orchestrator.AddStep("step2", step2, nil)
+	orchestrator.AddStep("step3", step3, nil)
+
+	result := orchestrator.Execute(context.Background())
+
+	assert.False(t, result.Success)
+	assert.Equal(t, 1, result.CompletedSteps)
+	assert.Equal(t, "step2", result.FailedStep) // First failure reported
+	assert.Error(t, result.Error)
+	assert.Contains(t, result.Error.Error(), "step2 failed")
+}
+
+// TestSagaOrchestrator_Execute_LongSaga verifies handling of many steps
+func TestSagaOrchestrator_Execute_LongSaga(t *testing.T) {
+	t.Parallel()
+
+	orchestrator := clients.NewSagaOrchestrator(slog.Default())
+
+	executed := []string{}
+	compensated := []string{}
+
+	// Add 10 steps
+	for i := 1; i <= 10; i++ {
+		stepName := fmt.Sprintf("step%d", i)
+		step := func(_ context.Context) error {
+			executed = append(executed, stepName)
+			// Fail at step 7
+			if stepName == "step7" {
+				return errStep7Failed
+			}
+			return nil
+		}
+		compensate := func(_ context.Context) error {
+			compensated = append(compensated, "compensate-"+stepName)
+			return nil
+		}
+		orchestrator.AddStep(stepName, step, compensate)
+	}
+
+	result := orchestrator.Execute(context.Background())
+
+	assert.False(t, result.Success)
+	assert.Equal(t, 6, result.CompletedSteps)
+	assert.Equal(t, "step7", result.FailedStep)
+	assert.Equal(t, 6, result.CompensatedSteps)
+	assert.Error(t, result.Error)
+
+	// Verify 7 executions (including failed step)
+	assert.Equal(t, 7, len(executed))
+
+	// Verify 6 compensations in reverse order
+	assert.Equal(t, 6, len(compensated))
+}


### PR DESCRIPTION
## Summary

- Extract circuit breaker, retry, saga, and resilient client patterns from `current-account` to `shared/pkg/clients/`
- Update `current-account/clients` to re-export from shared for backward compatibility
- Add comprehensive test coverage for all shared patterns

## Changes Made

### New Files in `shared/pkg/clients/`

| File | Description |
|------|-------------|
| `circuitbreaker.go` | Generic circuit breaker wrapper around sony/gobreaker with context support |
| `retry.go` | Exponential backoff with jitter, gRPC error code classification |
| `saga.go` | Saga pattern orchestrator for distributed transaction coordination |
| `resilient.go` | Generic resilient client combining circuit breaker + retry |
| `common.go` | Shared utilities (correlation ID propagation, timeout helpers) |
| `*_test.go` | Comprehensive tests for all patterns |

### Updated Files in `services/current-account/clients/`

All files now re-export from `shared/pkg/clients` for backward compatibility. Functions marked as deprecated with guidance to import from shared directly.

## Technical Details

**Circuit Breaker**: Wraps sony/gobreaker v2 with:
- Context cancellation/timeout support
- State change logging
- Configurable failure thresholds

**Retry**: Exponential backoff using cenkalti/backoff with:
- gRPC error code classification (retryable vs permanent)
- Jitter for thundering herd prevention
- Context-aware cancellation

**Saga**: Distributed transaction coordinator with:
- Step registration with actions and compensations
- Automatic LIFO compensation on failure
- Progress tracking and error reporting

## Usage Example

```go
import sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"

// Create resilient client
config := sharedclients.DefaultResilientClientConfig("my-service")
client := sharedclients.NewResilientClient(config)

// Execute with resilience
result, err := sharedclients.ExecuteWithResilience(ctx, client, "operation", func() (MyResult, error) {
    return myGRPCCall(ctx)
})
```

## Test Plan

- [x] Shared package tests pass (`go test ./shared/pkg/clients/...`)
- [ ] CI passes with proto generation
- [ ] Current-account service builds and tests pass with shared imports

Closes #223