### PR TITLE
feat: Add observability to financial-accounting service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	ariga.io/atlas-provider-gorm v0.6.0
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.10-20250912141014-52f32327d4b0.1
 	buf.build/go/protovalidate v1.0.1
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/confluentinc/confluent-kafka-go/v2 v2.12.0
 	github.com/golang-jwt/jwt/v5 v5.3.0

--- a/go.sum
+++ b/go.sum
@@ -650,6 +650,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mx
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3 h1:2afWGsMzkIcN8Qm4mgPJKZWyroE5QBszMiDMYEBrnfw=
 github.com/GoogleCloudPlatform/grpc-gcp-go/grpcgcp v1.5.3/go.mod h1:dppbR7CwXD4pgtV9t3wD1812RaLDcBjtblcDF5f1vI0=
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 h1:UQUsRi8WTzhZntp5313l+CHIAT95ojUI2lpP/ExlZa4=

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -224,12 +224,14 @@ func run(logger *slog.Logger) error {
 		Addr:              fmt.Sprintf(":%s", metricsPort),
 		Handler:           httpMux,
 		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      30 * time.Second,
 	}
 
 	go func() {
 		logger.Info("starting HTTP server for metrics", "address", httpServer.Addr)
 		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Error("HTTP server error", "error", err)
+			serverErrors <- fmt.Errorf("HTTP server error: %w", err)
 		}
 	}()
 

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -7,16 +7,18 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
+	serviceobs "github.com/meridianhub/meridian/services/financial-accounting/observability"
 	"github.com/meridianhub/meridian/services/financial-accounting/service"
 	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 	"gorm.io/driver/postgres"
@@ -158,21 +160,24 @@ func run(logger *slog.Logger) error {
 	// This will be completed in a follow-up commit once the gRPC service wrapper is created
 	_ = postingService // Placeholder until we create the gRPC service wrapper
 
-	// Register health check service
-	healthServer := health.NewServer()
-	// Set health status for both the default service name (used by K8s probes) and the named service
-	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_SERVING)
-	healthServer.SetServingStatus("financial-accounting", grpc_health_v1.HealthCheckResponse_SERVING)
-	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+	// Register health check service with database connectivity check
+	healthChecker := serviceobs.NewHealthChecker(serviceobs.HealthCheckerConfig{
+		DB:           db,
+		Logger:       logger,
+		ServiceName:  "financial-accounting",
+		CheckTimeout: 5 * time.Second,
+	})
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthChecker)
 
 	// Register reflection service for debugging
 	reflection.Register(grpcServer)
 
 	logger.Info("gRPC services registered")
 
-	// Get port from environment
+	// Get ports from environment
 	port := getEnvOrDefault("GRPC_PORT", "50052")
 	address := fmt.Sprintf(":%s", port)
+	metricsPort := getEnvOrDefault("METRICS_PORT", "8082")
 
 	// Create listener
 	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", address)
@@ -186,6 +191,45 @@ func run(logger *slog.Logger) error {
 		logger.Info("starting gRPC server", "address", address)
 		if err := grpcServer.Serve(listener); err != nil {
 			serverErrors <- err
+		}
+	}()
+
+	// Start HTTP server for metrics and health endpoints
+	httpMux := http.NewServeMux()
+	httpMux.Handle("/metrics", promhttp.Handler())
+	httpMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		// Simple health endpoint for HTTP probes
+		resp, err := healthChecker.Check(r.Context(), &grpc_health_v1.HealthCheckRequest{})
+		if err != nil || resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte("NOT_SERVING"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("SERVING"))
+	})
+	httpMux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		// Readiness endpoint - checks database connectivity
+		resp, err := healthChecker.Check(r.Context(), &grpc_health_v1.HealthCheckRequest{Service: "database"})
+		if err != nil || resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte("NOT_READY"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("READY"))
+	})
+
+	httpServer := &http.Server{
+		Addr:              fmt.Sprintf(":%s", metricsPort),
+		Handler:           httpMux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		logger.Info("starting HTTP server for metrics", "address", httpServer.Addr)
+		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error("HTTP server error", "error", err)
 		}
 	}()
 
@@ -203,13 +247,16 @@ func run(logger *slog.Logger) error {
 	// Graceful shutdown
 	logger.Info("shutting down server...")
 
-	// Mark service as not serving (both default and named service)
-	healthServer.SetServingStatus("", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
-	healthServer.SetServingStatus("financial-accounting", grpc_health_v1.HealthCheckResponse_NOT_SERVING)
-
 	// Create shutdown context with timeout
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+
+	// Shutdown HTTP server first (faster, allows metrics scraping during gRPC drain)
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		logger.Error("HTTP server shutdown error", "error", err)
+	} else {
+		logger.Info("HTTP server stopped")
+	}
 
 	// Gracefully stop gRPC server
 	stopped := make(chan struct{})
@@ -221,7 +268,7 @@ func run(logger *slog.Logger) error {
 	// Wait for graceful stop or timeout
 	select {
 	case <-stopped:
-		logger.Info("server stopped gracefully")
+		logger.Info("gRPC server stopped gracefully")
 	case <-shutdownCtx.Done():
 		logger.Warn("graceful shutdown timeout, forcing stop")
 		grpcServer.Stop()

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -228,7 +228,7 @@ func run(logger *slog.Logger) error {
 
 	go func() {
 		logger.Info("starting HTTP server for metrics", "address", httpServer.Addr)
-		if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			logger.Error("HTTP server error", "error", err)
 		}
 	}()

--- a/services/financial-accounting/observability/health.go
+++ b/services/financial-accounting/observability/health.go
@@ -96,12 +96,14 @@ func (h *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthChe
 		for _, comp := range report.Components {
 			var status string
 			switch comp.Status {
+			case health.StatusHealthy:
+				status = "healthy"
 			case health.StatusUnhealthy:
 				status = "unhealthy"
 			case health.StatusDegraded:
 				status = "degraded"
-			default:
-				status = "healthy"
+			case health.StatusUnknown:
+				status = "unknown"
 			}
 			RecordHealthCheck(comp.Name, status)
 		}

--- a/services/financial-accounting/observability/health.go
+++ b/services/financial-accounting/observability/health.go
@@ -127,10 +127,17 @@ func (h *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthChe
 			"response_time_ms", componentResult.ResponseTime.Milliseconds(),
 			"message", componentResult.Message)
 
-		// Record metric
-		status := "healthy"
-		if componentResult.Status == health.StatusUnhealthy {
+		// Record metric (use same exhaustive switch as all-components check)
+		var status string
+		switch componentResult.Status {
+		case health.StatusHealthy:
+			status = "healthy"
+		case health.StatusUnhealthy:
 			status = "unhealthy"
+		case health.StatusDegraded:
+			status = "degraded"
+		case health.StatusUnknown:
+			status = "unknown"
 		}
 		RecordHealthCheck(componentResult.Name, status)
 

--- a/services/financial-accounting/observability/health.go
+++ b/services/financial-accounting/observability/health.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -306,14 +307,12 @@ func (d *GormDatabaseHealthChecker) Check(ctx context.Context) health.ComponentR
 
 	if err != nil {
 		status = health.StatusUnhealthy
-		message = fmt.Sprintf("database ping failed: %v", err)
-	}
-
-	// Check context cancellation (timeout)
-	if checkCtx.Err() != nil {
-		status = health.StatusUnhealthy
-		message = fmt.Sprintf("database check timeout after %s", d.timeout)
-		err = checkCtx.Err()
+		// Prefer timeout message if context was cancelled, otherwise show the ping error
+		if errors.Is(checkCtx.Err(), context.DeadlineExceeded) {
+			message = fmt.Sprintf("database check timeout after %s", d.timeout)
+		} else {
+			message = fmt.Sprintf("database ping failed: %v", err)
+		}
 	}
 
 	return health.ComponentResult{

--- a/services/financial-accounting/observability/health.go
+++ b/services/financial-accounting/observability/health.go
@@ -1,0 +1,318 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"gorm.io/gorm"
+)
+
+// HealthChecker implements gRPC health check protocol for FinancialAccounting service.
+// It checks the health of critical dependencies including the database.
+type HealthChecker struct {
+	grpc_health_v1.UnimplementedHealthServer
+	aggregator   *health.Aggregator
+	logger       *slog.Logger
+	serviceName  string
+	checkTimeout time.Duration
+}
+
+// HealthCheckerConfig contains configuration for creating a new HealthChecker.
+type HealthCheckerConfig struct {
+	DB           *gorm.DB
+	Logger       *slog.Logger
+	ServiceName  string        // Defaults to "financial-accounting"
+	CheckTimeout time.Duration // Defaults to 5 seconds
+}
+
+// NewHealthChecker creates a new health checker with dependency checking.
+//
+// The health checker evaluates:
+//   - Database connectivity (critical)
+//
+// Health states:
+//   - SERVING: All critical dependencies healthy (database)
+//   - NOT_SERVING: Any critical dependency down (database unreachable)
+//   - UNKNOWN: Unable to determine health (should not occur in normal operation)
+func NewHealthChecker(config HealthCheckerConfig) *HealthChecker {
+	if config.DB == nil {
+		panic("health checker requires non-nil database")
+	}
+
+	// Apply defaults
+	if config.ServiceName == "" {
+		config.ServiceName = "financial-accounting"
+	}
+	if config.CheckTimeout == 0 {
+		config.CheckTimeout = 5 * time.Second
+	}
+	if config.Logger == nil {
+		config.Logger = slog.Default()
+	}
+
+	// Build list of health checkers
+	checkers := []health.Checker{
+		NewGormDatabaseHealthChecker(config.DB, config.CheckTimeout),
+	}
+
+	aggregator := health.NewAggregator(checkers)
+
+	return &HealthChecker{
+		aggregator:   aggregator,
+		logger:       config.Logger,
+		serviceName:  config.ServiceName,
+		checkTimeout: config.CheckTimeout,
+	}
+}
+
+// Check implements gRPC health check protocol.
+// It performs synchronous health checks on all dependencies and returns the overall status.
+//
+// Service-specific behavior:
+//   - Empty service name or "financial-accounting": Check overall service health
+//   - Named component (e.g., "database"): Check specific component
+func (h *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	// Apply timeout to health check context
+	checkCtx, cancel := context.WithTimeout(ctx, h.checkTimeout)
+	defer cancel()
+
+	// Empty service name or matching service name: check all components
+	if req.Service == "" || req.Service == h.serviceName {
+		// Perform health check on all components
+		report := h.aggregator.CheckAll(checkCtx)
+		overallStatus := report.OverallStatus()
+
+		// Map health status to gRPC health check status
+		grpcStatus := h.mapStatusToGRPC(overallStatus)
+
+		// Log health check result
+		h.logHealthCheck(report, overallStatus, grpcStatus)
+
+		// Record health check metrics
+		for _, comp := range report.Components {
+			var status string
+			switch comp.Status {
+			case health.StatusUnhealthy:
+				status = "unhealthy"
+			case health.StatusDegraded:
+				status = "degraded"
+			default:
+				status = "healthy"
+			}
+			RecordHealthCheck(comp.Name, status)
+		}
+
+		return &grpc_health_v1.HealthCheckResponse{
+			Status: grpcStatus,
+		}, nil
+	}
+
+	// Check if request is for a specific component
+	componentResult, found := h.aggregator.CheckByName(checkCtx, req.Service)
+	if found {
+		// Component found - return its specific health status
+		grpcStatus := h.mapStatusToGRPC(componentResult.Status)
+
+		// Log component health check
+		h.logger.Info("component health check completed",
+			"component", componentResult.Name,
+			"status", componentResult.Status.String(),
+			"grpc_status", grpcStatus.String(),
+			"response_time_ms", componentResult.ResponseTime.Milliseconds(),
+			"message", componentResult.Message)
+
+		// Record metric
+		status := "healthy"
+		if componentResult.Status == health.StatusUnhealthy {
+			status = "unhealthy"
+		}
+		RecordHealthCheck(componentResult.Name, status)
+
+		return &grpc_health_v1.HealthCheckResponse{
+			Status: grpcStatus,
+		}, nil
+	}
+
+	// Service name doesn't match and component not found - return UNKNOWN
+	h.logger.Debug("health check for unknown service or component",
+		"requested", req.Service,
+		"service_name", h.serviceName)
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_UNKNOWN,
+	}, nil
+}
+
+// Watch implements streaming health checks.
+// It sends periodic health updates to the client over a stream.
+func (h *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, stream grpc_health_v1.Health_WatchServer) error {
+	ctx := stream.Context()
+
+	// Send immediate health check
+	resp, err := h.Check(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if err := stream.Send(resp); err != nil {
+		h.logger.Error("failed to send initial health check",
+			"error", err)
+		return fmt.Errorf("failed to send initial health status: %w", err)
+	}
+
+	// Stream periodic updates
+	ticker := time.NewTicker(h.checkTimeout)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			h.logger.Debug("health watch stream closed", "reason", ctx.Err())
+			return fmt.Errorf("health watch context cancelled: %w", ctx.Err())
+
+		case <-ticker.C:
+			resp, err := h.Check(ctx, req)
+			if err != nil {
+				h.logger.Error("health check failed during watch",
+					"error", err)
+				return err
+			}
+
+			if err := stream.Send(resp); err != nil {
+				h.logger.Error("failed to send health check update",
+					"error", err)
+				return fmt.Errorf("failed to send health status update: %w", err)
+			}
+		}
+	}
+}
+
+// mapStatusToGRPC converts internal health status to gRPC health check status.
+func (h *HealthChecker) mapStatusToGRPC(status health.Status) grpc_health_v1.HealthCheckResponse_ServingStatus {
+	switch status {
+	case health.StatusHealthy:
+		return grpc_health_v1.HealthCheckResponse_SERVING
+
+	case health.StatusDegraded:
+		// Degraded still serves requests (optional dependencies may be down)
+		return grpc_health_v1.HealthCheckResponse_SERVING
+
+	case health.StatusUnhealthy:
+		return grpc_health_v1.HealthCheckResponse_NOT_SERVING
+
+	case health.StatusUnknown:
+		return grpc_health_v1.HealthCheckResponse_UNKNOWN
+
+	default:
+		return grpc_health_v1.HealthCheckResponse_UNKNOWN
+	}
+}
+
+// logHealthCheck logs the health check result with structured details.
+func (h *HealthChecker) logHealthCheck(report *health.Report, overallStatus health.Status, grpcStatus grpc_health_v1.HealthCheckResponse_ServingStatus) {
+	// Build component status map for structured logging
+	componentStatuses := make(map[string]string)
+	for _, comp := range report.Components {
+		componentStatuses[comp.Name] = comp.Status.String()
+	}
+
+	// Log at appropriate level based on status
+	switch overallStatus {
+	case health.StatusHealthy, health.StatusDegraded:
+		h.logger.Info("health check completed",
+			"overall_status", overallStatus.String(),
+			"grpc_status", grpcStatus.String(),
+			"component_count", len(report.Components),
+			"components", componentStatuses)
+
+	case health.StatusUnhealthy, health.StatusUnknown:
+		h.logger.Warn("health check detected issues",
+			"overall_status", overallStatus.String(),
+			"grpc_status", grpcStatus.String(),
+			"component_count", len(report.Components),
+			"components", componentStatuses)
+
+		// Log individual component failures
+		for _, comp := range report.Components {
+			if comp.Status == health.StatusUnhealthy || comp.Status == health.StatusUnknown {
+				h.logger.Error("component unhealthy",
+					"component", comp.Name,
+					"status", comp.Status.String(),
+					"message", comp.Message,
+					"response_time_ms", comp.ResponseTime.Milliseconds(),
+					"error", comp.Error)
+			}
+		}
+	}
+}
+
+// GormDatabaseHealthChecker checks database connectivity using GORM.
+type GormDatabaseHealthChecker struct {
+	db      *gorm.DB
+	timeout time.Duration
+}
+
+// NewGormDatabaseHealthChecker creates a new database health checker for GORM.
+func NewGormDatabaseHealthChecker(db *gorm.DB, timeout time.Duration) *GormDatabaseHealthChecker {
+	return &GormDatabaseHealthChecker{
+		db:      db,
+		timeout: timeout,
+	}
+}
+
+// Name returns the component name.
+func (d *GormDatabaseHealthChecker) Name() string {
+	return "database"
+}
+
+// Check performs a database health check by executing a simple query.
+func (d *GormDatabaseHealthChecker) Check(ctx context.Context) health.ComponentResult {
+	start := time.Now()
+
+	// Create timeout context
+	checkCtx, cancel := context.WithTimeout(ctx, d.timeout)
+	defer cancel()
+
+	// Get underlying sql.DB and ping
+	sqlDB, err := d.db.DB()
+	if err != nil {
+		return health.ComponentResult{
+			Name:         d.Name(),
+			Status:       health.StatusUnhealthy,
+			Message:      fmt.Sprintf("failed to get database instance: %v", err),
+			ResponseTime: time.Since(start),
+			CheckedAt:    start,
+			Error:        err,
+		}
+	}
+
+	err = sqlDB.PingContext(checkCtx)
+	responseTime := time.Since(start)
+
+	status := health.StatusHealthy
+	message := "database connection successful"
+
+	if err != nil {
+		status = health.StatusUnhealthy
+		message = fmt.Sprintf("database ping failed: %v", err)
+	}
+
+	// Check context cancellation (timeout)
+	if checkCtx.Err() != nil {
+		status = health.StatusUnhealthy
+		message = fmt.Sprintf("database check timeout after %s", d.timeout)
+		err = checkCtx.Err()
+	}
+
+	return health.ComponentResult{
+		Name:         d.Name(),
+		Status:       status,
+		Message:      message,
+		ResponseTime: responseTime,
+		CheckedAt:    start,
+		Error:        err,
+	}
+}

--- a/services/financial-accounting/observability/health.go
+++ b/services/financial-accounting/observability/health.go
@@ -181,7 +181,7 @@ func (h *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, stream grp
 		select {
 		case <-ctx.Done():
 			h.logger.Debug("health watch stream closed", "reason", ctx.Err())
-			return fmt.Errorf("health watch context cancelled: %w", ctx.Err())
+			return nil // Per gRPC health protocol, client disconnect is not an error
 
 		case <-ticker.C:
 			resp, err := h.Check(ctx, req)

--- a/services/financial-accounting/observability/health_test.go
+++ b/services/financial-accounting/observability/health_test.go
@@ -1,0 +1,210 @@
+package observability
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+func setupMockDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	db, mock, err := sqlmock.New(sqlmock.MonitorPingsOption(true))
+	require.NoError(t, err)
+
+	// GORM pings the database on Open, so we need to expect it
+	mock.ExpectPing()
+
+	dialector := postgres.New(postgres.Config{
+		Conn:       db,
+		DriverName: "postgres",
+	})
+
+	gormDB, err := gorm.Open(dialector, &gorm.Config{})
+	require.NoError(t, err)
+
+	return gormDB, mock
+}
+
+func TestGormDatabaseHealthChecker_Check_Healthy(t *testing.T) {
+	gormDB, mock := setupMockDB(t)
+
+	// Expect ping to succeed
+	mock.ExpectPing()
+
+	checker := NewGormDatabaseHealthChecker(gormDB, 5*time.Second)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, "database", result.Name)
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Equal(t, "database connection successful", result.Message)
+	assert.Nil(t, result.Error)
+	assert.NotZero(t, result.ResponseTime)
+	assert.NotZero(t, result.CheckedAt)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGormDatabaseHealthChecker_Check_Unhealthy(t *testing.T) {
+	gormDB, mock := setupMockDB(t)
+
+	// Expect ping to fail
+	mock.ExpectPing().WillReturnError(assert.AnError)
+
+	checker := NewGormDatabaseHealthChecker(gormDB, 5*time.Second)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, "database", result.Name)
+	assert.Equal(t, health.StatusUnhealthy, result.Status)
+	assert.Contains(t, result.Message, "database ping failed")
+	assert.NotNil(t, result.Error)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGormDatabaseHealthChecker_Name(t *testing.T) {
+	gormDB, _ := setupMockDB(t)
+	checker := NewGormDatabaseHealthChecker(gormDB, 5*time.Second)
+
+	assert.Equal(t, "database", checker.Name())
+}
+
+func TestHealthChecker_Check_Healthy(t *testing.T) {
+	gormDB, mock := setupMockDB(t)
+	mock.ExpectPing()
+
+	healthChecker := NewHealthChecker(HealthCheckerConfig{
+		DB:           gormDB,
+		CheckTimeout: 5 * time.Second,
+	})
+
+	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHealthChecker_Check_Unhealthy(t *testing.T) {
+	gormDB, mock := setupMockDB(t)
+	mock.ExpectPing().WillReturnError(assert.AnError)
+
+	healthChecker := NewHealthChecker(HealthCheckerConfig{
+		DB:           gormDB,
+		CheckTimeout: 5 * time.Second,
+	})
+
+	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING, resp.Status)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHealthChecker_Check_SpecificService(t *testing.T) {
+	gormDB, mock := setupMockDB(t)
+	mock.ExpectPing()
+
+	healthChecker := NewHealthChecker(HealthCheckerConfig{
+		DB:          gormDB,
+		ServiceName: "financial-accounting",
+	})
+
+	// Check with explicit service name
+	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: "financial-accounting",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHealthChecker_Check_SpecificComponent(t *testing.T) {
+	gormDB, mock := setupMockDB(t)
+	mock.ExpectPing()
+
+	healthChecker := NewHealthChecker(HealthCheckerConfig{
+		DB: gormDB,
+	})
+
+	// Check database component specifically
+	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: "database",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHealthChecker_Check_UnknownService(t *testing.T) {
+	gormDB, _ := setupMockDB(t)
+
+	healthChecker := NewHealthChecker(HealthCheckerConfig{
+		DB: gormDB,
+	})
+
+	// Check unknown service
+	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: "unknown-service",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_UNKNOWN, resp.Status)
+}
+
+func TestHealthChecker_DefaultConfig(t *testing.T) {
+	gormDB, _ := setupMockDB(t)
+
+	healthChecker := NewHealthChecker(HealthCheckerConfig{
+		DB: gormDB,
+	})
+
+	assert.Equal(t, "financial-accounting", healthChecker.serviceName)
+	assert.Equal(t, 5*time.Second, healthChecker.checkTimeout)
+	assert.NotNil(t, healthChecker.logger)
+	assert.NotNil(t, healthChecker.aggregator)
+}
+
+func TestHealthChecker_PanicOnNilDB(t *testing.T) {
+	assert.Panics(t, func() {
+		NewHealthChecker(HealthCheckerConfig{
+			DB: nil,
+		})
+	})
+}
+
+func TestMapStatusToGRPC(t *testing.T) {
+	gormDB, _ := setupMockDB(t)
+	healthChecker := NewHealthChecker(HealthCheckerConfig{
+		DB: gormDB,
+	})
+
+	tests := []struct {
+		status   health.Status
+		expected grpc_health_v1.HealthCheckResponse_ServingStatus
+	}{
+		{health.StatusHealthy, grpc_health_v1.HealthCheckResponse_SERVING},
+		{health.StatusDegraded, grpc_health_v1.HealthCheckResponse_SERVING},
+		{health.StatusUnhealthy, grpc_health_v1.HealthCheckResponse_NOT_SERVING},
+		{health.StatusUnknown, grpc_health_v1.HealthCheckResponse_UNKNOWN},
+	}
+
+	for _, tt := range tests {
+		result := healthChecker.mapStatusToGRPC(tt.status)
+		assert.Equal(t, tt.expected, result, "status %v should map to %v", tt.status, tt.expected)
+	}
+}

--- a/services/financial-accounting/observability/metrics.go
+++ b/services/financial-accounting/observability/metrics.go
@@ -195,9 +195,11 @@ func DecOperationsInFlight(operation string) {
 }
 
 // OperationTimer provides a convenient way to time operations and record metrics.
+// It protects against double-observation which would cause incorrect gauge values.
 type OperationTimer struct {
 	operation string
 	start     time.Time
+	observed  bool
 }
 
 // NewOperationTimer creates a new timer and increments the in-flight gauge.
@@ -206,17 +208,28 @@ func NewOperationTimer(operation string) *OperationTimer {
 	return &OperationTimer{
 		operation: operation,
 		start:     time.Now(),
+		observed:  false,
 	}
 }
 
 // ObserveSuccess records a successful operation and decrements in-flight gauge.
+// Safe to call multiple times; only the first call has effect.
 func (t *OperationTimer) ObserveSuccess() {
+	if t.observed {
+		return
+	}
+	t.observed = true
 	DecOperationsInFlight(t.operation)
 	RecordOperationDuration(t.operation, StatusSuccess, time.Since(t.start))
 }
 
 // ObserveError records a failed operation with error category and decrements in-flight gauge.
+// Safe to call multiple times; only the first call has effect.
 func (t *OperationTimer) ObserveError(errorCategory string) {
+	if t.observed {
+		return
+	}
+	t.observed = true
 	DecOperationsInFlight(t.operation)
 	RecordOperationDuration(t.operation, StatusError, time.Since(t.start))
 	RecordError(errorCategory, t.operation)

--- a/services/financial-accounting/observability/metrics.go
+++ b/services/financial-accounting/observability/metrics.go
@@ -1,0 +1,223 @@
+// Package observability provides Prometheus metrics and monitoring for the FinancialAccounting service.
+package observability
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Error category constants for bounded label cardinality.
+// Using constants prevents metric cardinality explosion from arbitrary error messages.
+const (
+	ErrorCategoryValidation     = "validation"
+	ErrorCategoryNotFound       = "not_found"
+	ErrorCategoryDuplicate      = "duplicate"
+	ErrorCategoryInternal       = "internal"
+	ErrorCategoryDatabase       = "database"
+	ErrorCategoryEventPublisher = "event_publisher"
+)
+
+// Operation name constants for consistent metric labeling.
+const (
+	OperationCaptureLedgerPosting    = "capture_ledger_posting"
+	OperationRetrieveLedgerPosting   = "retrieve_ledger_posting"
+	OperationUpdateLedgerPosting     = "update_ledger_posting"
+	OperationListLedgerPostings      = "list_ledger_postings"
+	OperationProcessDeposit          = "process_deposit"
+	OperationInitiateBookingLog      = "initiate_booking_log"
+	OperationUpdateBookingLog        = "update_booking_log"
+	OperationRetrieveBookingLog      = "retrieve_booking_log"
+	OperationListBookingLogs         = "list_booking_logs"
+	OperationValidateDoubleEntry     = "validate_double_entry"
+	OperationSavePostingsTransaction = "save_postings_transaction"
+)
+
+// Status constants for operation outcomes.
+const (
+	StatusSuccess = "success"
+	StatusError   = "error"
+)
+
+// Posting direction constants for metric labels.
+const (
+	DirectionDebit  = "debit"
+	DirectionCredit = "credit"
+)
+
+var (
+	// Operation duration metrics
+	operationDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "financial_accounting_operation_duration_seconds",
+			Help:    "Duration of financial accounting operations in seconds",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		},
+		[]string{"operation", "status"},
+	)
+
+	// Ledger posting metrics
+	postingsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "financial_accounting_postings_total",
+			Help: "Total number of ledger postings created",
+		},
+		[]string{"direction", "currency"},
+	)
+
+	postingAmountTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "financial_accounting_posting_amount_cents_total",
+			Help: "Total amount posted in cents by currency and direction",
+		},
+		[]string{"direction", "currency"},
+	)
+
+	// Booking log metrics
+	bookingLogsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "financial_accounting_booking_logs_total",
+			Help: "Total number of booking logs created",
+		},
+		[]string{"status"},
+	)
+
+	// Double-entry validation metrics
+	doubleEntryValidationsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "financial_accounting_double_entry_validations_total",
+			Help: "Total number of double-entry balance validations",
+		},
+		[]string{"result"},
+	)
+
+	// Error metrics
+	errorsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "financial_accounting_errors_total",
+			Help: "Total number of errors by category and operation",
+		},
+		[]string{"category", "operation"},
+	)
+
+	// Deposit processing metrics (for Kafka consumer)
+	depositsProcessedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "financial_accounting_deposits_processed_total",
+			Help: "Total number of deposit events processed",
+		},
+		[]string{"currency", "status"},
+	)
+
+	// Health check metrics
+	healthCheckTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "financial_accounting_health_check_total",
+			Help: "Total number of health checks by component and status",
+		},
+		[]string{"component", "status"},
+	)
+
+	// External service error metrics
+	externalServiceErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "financial_accounting_external_service_errors_total",
+			Help: "Total number of external service errors",
+		},
+		[]string{"service", "operation"},
+	)
+
+	// In-flight operations gauge
+	operationsInFlight = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "financial_accounting_operations_in_flight",
+			Help: "Number of operations currently being processed",
+		},
+		[]string{"operation"},
+	)
+)
+
+// RecordOperationDuration records the duration of a financial accounting operation.
+func RecordOperationDuration(operation, status string, duration time.Duration) {
+	operationDuration.WithLabelValues(operation, status).Observe(duration.Seconds())
+}
+
+// RecordPosting records a ledger posting creation with direction and currency.
+func RecordPosting(direction, currency string) {
+	postingsTotal.WithLabelValues(direction, currency).Inc()
+}
+
+// RecordPostingAmount records the amount of a posting in cents for tracking total volume.
+func RecordPostingAmount(direction, currency string, amountCents int64) {
+	postingAmountTotal.WithLabelValues(direction, currency).Add(float64(amountCents))
+}
+
+// RecordBookingLog records a booking log creation with status.
+func RecordBookingLog(status string) {
+	bookingLogsTotal.WithLabelValues(status).Inc()
+}
+
+// RecordDoubleEntryValidation records the result of a double-entry balance validation.
+// result should be "balanced" or "unbalanced".
+func RecordDoubleEntryValidation(result string) {
+	doubleEntryValidationsTotal.WithLabelValues(result).Inc()
+}
+
+// RecordError records an error with category and operation context.
+func RecordError(category, operation string) {
+	errorsTotal.WithLabelValues(category, operation).Inc()
+}
+
+// RecordDepositProcessed records processing of a deposit event.
+func RecordDepositProcessed(currency, status string) {
+	depositsProcessedTotal.WithLabelValues(currency, status).Inc()
+}
+
+// RecordHealthCheck records a health check result.
+func RecordHealthCheck(component, status string) {
+	healthCheckTotal.WithLabelValues(component, status).Inc()
+}
+
+// RecordExternalServiceError records an external service error.
+func RecordExternalServiceError(service, operation string) {
+	externalServiceErrors.WithLabelValues(service, operation).Inc()
+}
+
+// IncOperationsInFlight increments the in-flight gauge for an operation.
+func IncOperationsInFlight(operation string) {
+	operationsInFlight.WithLabelValues(operation).Inc()
+}
+
+// DecOperationsInFlight decrements the in-flight gauge for an operation.
+func DecOperationsInFlight(operation string) {
+	operationsInFlight.WithLabelValues(operation).Dec()
+}
+
+// OperationTimer provides a convenient way to time operations and record metrics.
+type OperationTimer struct {
+	operation string
+	start     time.Time
+}
+
+// NewOperationTimer creates a new timer and increments the in-flight gauge.
+func NewOperationTimer(operation string) *OperationTimer {
+	IncOperationsInFlight(operation)
+	return &OperationTimer{
+		operation: operation,
+		start:     time.Now(),
+	}
+}
+
+// ObserveSuccess records a successful operation and decrements in-flight gauge.
+func (t *OperationTimer) ObserveSuccess() {
+	DecOperationsInFlight(t.operation)
+	RecordOperationDuration(t.operation, StatusSuccess, time.Since(t.start))
+}
+
+// ObserveError records a failed operation with error category and decrements in-flight gauge.
+func (t *OperationTimer) ObserveError(errorCategory string) {
+	DecOperationsInFlight(t.operation)
+	RecordOperationDuration(t.operation, StatusError, time.Since(t.start))
+	RecordError(errorCategory, t.operation)
+}

--- a/services/financial-accounting/observability/metrics_test.go
+++ b/services/financial-accounting/observability/metrics_test.go
@@ -1,0 +1,207 @@
+package observability
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecordOperationDuration(_ *testing.T) {
+	// Record a successful operation - this should not panic
+	RecordOperationDuration(OperationCaptureLedgerPosting, StatusSuccess, 100*time.Millisecond)
+
+	// For histograms, we verify by checking the overall metric has been registered
+	// and doesn't panic when used. The actual histogram values are tested through
+	// integration tests with Prometheus scraping.
+}
+
+func TestRecordPosting(t *testing.T) {
+	// Get initial count
+	initialDebit := testutil.ToFloat64(postingsTotal.WithLabelValues(DirectionDebit, "GBP"))
+
+	// Record a debit posting
+	RecordPosting(DirectionDebit, "GBP")
+
+	// Verify counter incremented
+	newCount := testutil.ToFloat64(postingsTotal.WithLabelValues(DirectionDebit, "GBP"))
+	assert.Equal(t, initialDebit+1, newCount, "posting counter should increment by 1")
+}
+
+func TestRecordPostingAmount(t *testing.T) {
+	// Get initial amount
+	initialAmount := testutil.ToFloat64(postingAmountTotal.WithLabelValues(DirectionCredit, "USD"))
+
+	// Record posting amount
+	RecordPostingAmount(DirectionCredit, "USD", 10000) // 100.00 in cents
+
+	// Verify counter added correct amount
+	newAmount := testutil.ToFloat64(postingAmountTotal.WithLabelValues(DirectionCredit, "USD"))
+	assert.Equal(t, initialAmount+10000, newAmount, "posting amount should increase by 10000")
+}
+
+func TestRecordBookingLog(t *testing.T) {
+	// Get initial count
+	initial := testutil.ToFloat64(bookingLogsTotal.WithLabelValues("pending"))
+
+	// Record a booking log
+	RecordBookingLog("pending")
+
+	// Verify counter incremented
+	newCount := testutil.ToFloat64(bookingLogsTotal.WithLabelValues("pending"))
+	assert.Equal(t, initial+1, newCount, "booking log counter should increment by 1")
+}
+
+func TestRecordDoubleEntryValidation(t *testing.T) {
+	// Get initial counts
+	initialBalanced := testutil.ToFloat64(doubleEntryValidationsTotal.WithLabelValues("balanced"))
+	initialUnbalanced := testutil.ToFloat64(doubleEntryValidationsTotal.WithLabelValues("unbalanced"))
+
+	// Record validations
+	RecordDoubleEntryValidation("balanced")
+	RecordDoubleEntryValidation("unbalanced")
+
+	// Verify counters
+	assert.Equal(t, initialBalanced+1, testutil.ToFloat64(doubleEntryValidationsTotal.WithLabelValues("balanced")))
+	assert.Equal(t, initialUnbalanced+1, testutil.ToFloat64(doubleEntryValidationsTotal.WithLabelValues("unbalanced")))
+}
+
+func TestRecordError(t *testing.T) {
+	// Get initial count
+	initial := testutil.ToFloat64(errorsTotal.WithLabelValues(ErrorCategoryValidation, OperationCaptureLedgerPosting))
+
+	// Record an error
+	RecordError(ErrorCategoryValidation, OperationCaptureLedgerPosting)
+
+	// Verify counter incremented
+	newCount := testutil.ToFloat64(errorsTotal.WithLabelValues(ErrorCategoryValidation, OperationCaptureLedgerPosting))
+	assert.Equal(t, initial+1, newCount, "error counter should increment by 1")
+}
+
+func TestRecordDepositProcessed(t *testing.T) {
+	// Get initial count
+	initial := testutil.ToFloat64(depositsProcessedTotal.WithLabelValues("GBP", StatusSuccess))
+
+	// Record a deposit
+	RecordDepositProcessed("GBP", StatusSuccess)
+
+	// Verify counter incremented
+	newCount := testutil.ToFloat64(depositsProcessedTotal.WithLabelValues("GBP", StatusSuccess))
+	assert.Equal(t, initial+1, newCount, "deposit counter should increment by 1")
+}
+
+func TestRecordHealthCheck(t *testing.T) {
+	// Get initial count
+	initial := testutil.ToFloat64(healthCheckTotal.WithLabelValues("database", "healthy"))
+
+	// Record a health check
+	RecordHealthCheck("database", "healthy")
+
+	// Verify counter incremented
+	newCount := testutil.ToFloat64(healthCheckTotal.WithLabelValues("database", "healthy"))
+	assert.Equal(t, initial+1, newCount, "health check counter should increment by 1")
+}
+
+func TestRecordExternalServiceError(t *testing.T) {
+	// Get initial count
+	initial := testutil.ToFloat64(externalServiceErrors.WithLabelValues("kafka", "publish"))
+
+	// Record an external service error
+	RecordExternalServiceError("kafka", "publish")
+
+	// Verify counter incremented
+	newCount := testutil.ToFloat64(externalServiceErrors.WithLabelValues("kafka", "publish"))
+	assert.Equal(t, initial+1, newCount, "external service error counter should increment by 1")
+}
+
+func TestOperationsInFlight(t *testing.T) {
+	// Get initial value
+	initial := testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationProcessDeposit))
+
+	// Increment
+	IncOperationsInFlight(OperationProcessDeposit)
+	assert.Equal(t, initial+1, testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationProcessDeposit)))
+
+	// Decrement
+	DecOperationsInFlight(OperationProcessDeposit)
+	assert.Equal(t, initial, testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationProcessDeposit)))
+}
+
+func TestOperationTimer(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		// Get initial in-flight
+		initialInFlight := testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationRetrieveLedgerPosting))
+
+		// Start timer
+		timer := NewOperationTimer(OperationRetrieveLedgerPosting)
+
+		// Verify in-flight incremented
+		assert.Equal(t, initialInFlight+1, testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationRetrieveLedgerPosting)))
+
+		// Simulate some work
+		time.Sleep(5 * time.Millisecond)
+
+		// Record success
+		timer.ObserveSuccess()
+
+		// Verify in-flight decremented back
+		assert.Equal(t, initialInFlight, testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationRetrieveLedgerPosting)))
+	})
+
+	t.Run("error", func(t *testing.T) {
+		// Get initial values
+		initialInFlight := testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationUpdateLedgerPosting))
+		initialErrors := testutil.ToFloat64(errorsTotal.WithLabelValues(ErrorCategoryDatabase, OperationUpdateLedgerPosting))
+
+		// Start timer
+		timer := NewOperationTimer(OperationUpdateLedgerPosting)
+
+		// Verify in-flight incremented
+		assert.Equal(t, initialInFlight+1, testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationUpdateLedgerPosting)))
+
+		// Record error
+		timer.ObserveError(ErrorCategoryDatabase)
+
+		// Verify in-flight decremented and error recorded
+		assert.Equal(t, initialInFlight, testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationUpdateLedgerPosting)))
+		assert.Equal(t, initialErrors+1, testutil.ToFloat64(errorsTotal.WithLabelValues(ErrorCategoryDatabase, OperationUpdateLedgerPosting)))
+	})
+}
+
+func TestErrorCategoryConstants(t *testing.T) {
+	// Verify all error category constants are non-empty
+	categories := []string{
+		ErrorCategoryValidation,
+		ErrorCategoryNotFound,
+		ErrorCategoryDuplicate,
+		ErrorCategoryInternal,
+		ErrorCategoryDatabase,
+		ErrorCategoryEventPublisher,
+	}
+
+	for _, cat := range categories {
+		assert.NotEmpty(t, cat, "error category constant should not be empty")
+	}
+}
+
+func TestOperationNameConstants(t *testing.T) {
+	// Verify all operation name constants are non-empty
+	operations := []string{
+		OperationCaptureLedgerPosting,
+		OperationRetrieveLedgerPosting,
+		OperationUpdateLedgerPosting,
+		OperationListLedgerPostings,
+		OperationProcessDeposit,
+		OperationInitiateBookingLog,
+		OperationUpdateBookingLog,
+		OperationRetrieveBookingLog,
+		OperationListBookingLogs,
+		OperationValidateDoubleEntry,
+		OperationSavePostingsTransaction,
+	}
+
+	for _, op := range operations {
+		assert.NotEmpty(t, op, "operation name constant should not be empty")
+	}
+}

--- a/services/financial-accounting/observability/metrics_test.go
+++ b/services/financial-accounting/observability/metrics_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRecordOperationDuration(_ *testing.T) {
+func TestRecordOperationDuration(t *testing.T) {
+	t.Helper()
+
 	// Record a successful operation - this should not panic
 	RecordOperationDuration(OperationCaptureLedgerPosting, StatusSuccess, 100*time.Millisecond)
 

--- a/services/financial-accounting/service/posting_service.go
+++ b/services/financial-accounting/service/posting_service.go
@@ -120,10 +120,15 @@ func (s *PostingService) ProcessDeposit(ctx context.Context, event DepositEvent)
 
 // GetPostingsByBookingLog retrieves all postings for a booking log
 func (s *PostingService) GetPostingsByBookingLog(ctx context.Context, bookingLogID uuid.UUID) ([]*domain.LedgerPosting, error) {
+	timer := observability.NewOperationTimer(observability.OperationRetrieveLedgerPosting)
+
 	postings, err := s.repo.GetPostingsByBookingLogID(ctx, bookingLogID)
 	if err != nil {
+		timer.ObserveError(observability.ErrorCategoryDatabase)
 		return nil, fmt.Errorf("failed to get postings: %w", err)
 	}
+
+	timer.ObserveSuccess()
 	return postings, nil
 }
 

--- a/services/financial-accounting/service/posting_service.go
+++ b/services/financial-accounting/service/posting_service.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
 	"github.com/meridianhub/meridian/services/financial-accounting/domain"
+	"github.com/meridianhub/meridian/services/financial-accounting/observability"
 	"github.com/shopspring/decimal"
 )
 
@@ -43,12 +44,16 @@ type DepositEvent struct {
 // Debit: Customer account (increases asset)
 // Credit: Bank cash account (increases liability to customer)
 func (s *PostingService) ProcessDeposit(ctx context.Context, event DepositEvent) error {
+	timer := observability.NewOperationTimer(observability.OperationProcessDeposit)
+
 	bookingLogID := uuid.New()
 
 	// Convert cents to decimal
 	amount := decimalFromCents(event.AmountCents)
 	money, err := domain.NewMoney(amount, domain.Currency(event.Currency))
 	if err != nil {
+		timer.ObserveError(observability.ErrorCategoryValidation)
+		observability.RecordDepositProcessed(event.Currency, observability.StatusError)
 		return fmt.Errorf("failed to create money: %w", err)
 	}
 
@@ -62,6 +67,8 @@ func (s *PostingService) ProcessDeposit(ctx context.Context, event DepositEvent)
 		event.CorrelationID,
 	)
 	if err != nil {
+		timer.ObserveError(observability.ErrorCategoryValidation)
+		observability.RecordDepositProcessed(event.Currency, observability.StatusError)
 		return fmt.Errorf("failed to create debit posting: %w", err)
 	}
 
@@ -75,22 +82,38 @@ func (s *PostingService) ProcessDeposit(ctx context.Context, event DepositEvent)
 		event.CorrelationID,
 	)
 	if err != nil {
+		timer.ObserveError(observability.ErrorCategoryValidation)
+		observability.RecordDepositProcessed(event.Currency, observability.StatusError)
 		return fmt.Errorf("failed to create credit posting: %w", err)
 	}
 
 	// Post both entries
 	if err := debitPosting.Post("Deposit processed"); err != nil {
+		timer.ObserveError(observability.ErrorCategoryInternal)
+		observability.RecordDepositProcessed(event.Currency, observability.StatusError)
 		return fmt.Errorf("failed to post debit: %w", err)
 	}
 
 	if err := creditPosting.Post("Deposit processed"); err != nil {
+		timer.ObserveError(observability.ErrorCategoryInternal)
+		observability.RecordDepositProcessed(event.Currency, observability.StatusError)
 		return fmt.Errorf("failed to post credit: %w", err)
 	}
 
 	// Save both postings atomically in a transaction
 	if err := s.repo.SavePostingsInTransaction(ctx, []*domain.LedgerPosting{debitPosting, creditPosting}); err != nil {
+		timer.ObserveError(observability.ErrorCategoryDatabase)
+		observability.RecordDepositProcessed(event.Currency, observability.StatusError)
 		return fmt.Errorf("failed to save postings: %w", err)
 	}
+
+	// Record successful metrics
+	timer.ObserveSuccess()
+	observability.RecordDepositProcessed(event.Currency, observability.StatusSuccess)
+	observability.RecordPosting(observability.DirectionDebit, event.Currency)
+	observability.RecordPosting(observability.DirectionCredit, event.Currency)
+	observability.RecordPostingAmount(observability.DirectionDebit, event.Currency, event.AmountCents)
+	observability.RecordPostingAmount(observability.DirectionCredit, event.Currency, event.AmountCents)
 
 	return nil
 }
@@ -106,8 +129,11 @@ func (s *PostingService) GetPostingsByBookingLog(ctx context.Context, bookingLog
 
 // ValidateDoubleEntry checks that debits equal credits for a booking log
 func (s *PostingService) ValidateDoubleEntry(ctx context.Context, bookingLogID uuid.UUID) (bool, error) {
+	timer := observability.NewOperationTimer(observability.OperationValidateDoubleEntry)
+
 	postings, err := s.repo.GetPostingsByBookingLogID(ctx, bookingLogID)
 	if err != nil {
+		timer.ObserveError(observability.ErrorCategoryDatabase)
 		return false, fmt.Errorf("failed to get postings: %w", err)
 	}
 
@@ -123,5 +149,15 @@ func (s *PostingService) ValidateDoubleEntry(ctx context.Context, bookingLogID u
 		}
 	}
 
-	return debitTotal.Equal(creditTotal), nil
+	balanced := debitTotal.Equal(creditTotal)
+
+	// Record validation result
+	timer.ObserveSuccess()
+	if balanced {
+		observability.RecordDoubleEntryValidation("balanced")
+	} else {
+		observability.RecordDoubleEntryValidation("unbalanced")
+	}
+
+	return balanced, nil
 }


### PR DESCRIPTION
## Summary

- Adds comprehensive observability infrastructure to the financial-accounting service
- Brings it in line with other services (current-account, position-keeping, payment-order)
- Addresses the gap identified during codebase reorganization

## Changes Made

### New Files

**`services/financial-accounting/observability/metrics.go`**
- Operation duration histograms (`financial_accounting_operation_duration_seconds`)
- Ledger posting counters by direction/currency (`financial_accounting_postings_total`)
- Posting amount tracking for volume analysis (`financial_accounting_posting_amount_cents_total`)
- Booking log counters (`financial_accounting_booking_logs_total`)
- Double-entry validation results (`financial_accounting_double_entry_validations_total`)
- Error tracking by category (`financial_accounting_errors_total`)
- Deposit processing metrics (`financial_accounting_deposits_processed_total`)
- Health check results (`financial_accounting_health_check_total`)
- In-flight operations gauge (`financial_accounting_operations_in_flight`)
- `OperationTimer` helper for convenient timing and metric recording

**`services/financial-accounting/observability/health.go`**
- gRPC health check protocol implementation
- Database connectivity checker using GORM
- Integration with shared health package aggregator
- Metrics recording for health check results

### Modified Files

**`services/financial-accounting/cmd/main.go`**
- Uses new `HealthChecker` with database connectivity checks (replaces static health server)
- Adds HTTP server on port 8082 (configurable via `METRICS_PORT`)
- Exposes `/metrics` (Prometheus), `/health` (liveness), and `/ready` (readiness) endpoints
- Graceful shutdown includes HTTP server

**`services/financial-accounting/service/posting_service.go`**
- `ProcessDeposit`: Records operation timing, success/error status, posting counts, and amounts
- `ValidateDoubleEntry`: Records timing and balanced/unbalanced validation results

## Technical Details

- Uses `promauto` for automatic metric registration (consistent with other services)
- Bounded label cardinality via error category constants
- OperationTimer pattern for clean timing and in-flight tracking
- Health checks use shared `health.Aggregator` for concurrent dependency checking

## Test Plan

- [x] All observability package tests pass (`go test ./services/financial-accounting/observability/...`)
- [ ] Verify metrics are scraped by Prometheus after deployment
- [ ] Verify health endpoints respond correctly
- [ ] Verify posting service metrics are recorded during operations

Closes #220