### PR TITLE
test: Add testfixtures for payment-order domain

### DIFF
--- a/services/payment-order/domain/testfixtures/fixtures.go
+++ b/services/payment-order/domain/testfixtures/fixtures.go
@@ -1,0 +1,345 @@
+// Package testfixtures provides factory functions and fixtures for creating
+// test data consistently across the payment-order test suite.
+//
+// Usage:
+//
+//	// Create a default payment order for testing
+//	po := testfixtures.NewPaymentOrder(t)
+//
+//	// Create with custom options
+//	po := testfixtures.NewPaymentOrder(t,
+//	    testfixtures.WithDebtorAccountID("ACC-123"),
+//	    testfixtures.WithAmountCents(50000),
+//	)
+//
+//	// Create a payment order in a specific state
+//	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusReserved)
+package testfixtures
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+)
+
+// PaymentOrderOption is a function that configures a PaymentOrder for testing.
+type PaymentOrderOption func(*paymentOrderConfig)
+
+type paymentOrderConfig struct {
+	id                uuid.UUID
+	debtorAccountID   string
+	creditorReference string
+	amountCents       int64
+	currency          string
+	idempotencyKey    string
+	correlationID     string
+	lienID            string
+	gatewayRefID      string
+	ledgerBookingID   string
+	failureReason     string
+	errorCode         string
+}
+
+// WithID sets a specific payment order ID.
+func WithID(id uuid.UUID) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.id = id
+	}
+}
+
+// WithDebtorAccountID sets the debtor account ID.
+func WithDebtorAccountID(accountID string) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.debtorAccountID = accountID
+	}
+}
+
+// WithCreditorReference sets the creditor reference.
+func WithCreditorReference(ref string) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.creditorReference = ref
+	}
+}
+
+// WithAmountCents sets the payment amount in cents.
+func WithAmountCents(cents int64) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.amountCents = cents
+	}
+}
+
+// WithCurrency sets the currency code.
+func WithCurrency(currency string) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.currency = currency
+	}
+}
+
+// WithIdempotencyKey sets the idempotency key.
+func WithIdempotencyKey(key string) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.idempotencyKey = key
+	}
+}
+
+// WithCorrelationID sets the correlation ID.
+func WithCorrelationID(id string) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.correlationID = id
+	}
+}
+
+// WithLienID sets the lien ID.
+func WithLienID(lienID string) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.lienID = lienID
+	}
+}
+
+// WithGatewayReferenceID sets the gateway reference ID.
+func WithGatewayReferenceID(refID string) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.gatewayRefID = refID
+	}
+}
+
+// WithLedgerBookingID sets the ledger booking ID.
+func WithLedgerBookingID(bookingID string) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.ledgerBookingID = bookingID
+	}
+}
+
+// WithFailureReason sets the failure reason.
+func WithFailureReason(reason string) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.failureReason = reason
+	}
+}
+
+// WithErrorCode sets the error code.
+func WithErrorCode(code string) PaymentOrderOption {
+	return func(cfg *paymentOrderConfig) {
+		cfg.errorCode = code
+	}
+}
+
+// NewPaymentOrder creates a PaymentOrder in INITIATED status with sensible defaults for testing.
+// Use options to customize specific fields.
+func NewPaymentOrder(t *testing.T, opts ...PaymentOrderOption) *domain.PaymentOrder {
+	t.Helper()
+
+	// Defaults
+	cfg := &paymentOrderConfig{
+		debtorAccountID:   "TEST-DEBTOR-001",
+		creditorReference: "GB82WEST12345698765432",
+		amountCents:       10000, // £100.00
+		currency:          "GBP",
+		idempotencyKey:    "idem-" + uuid.New().String(),
+		correlationID:     "corr-" + uuid.New().String(),
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Create money
+	amount, err := domain.NewMoney(cfg.currency, cfg.amountCents)
+	if err != nil {
+		t.Fatalf("Failed to create money: %v", err)
+	}
+
+	// Create payment order using domain constructor
+	po, err := domain.NewPaymentOrder(
+		cfg.debtorAccountID,
+		cfg.creditorReference,
+		amount,
+		cfg.idempotencyKey,
+		cfg.correlationID,
+	)
+	if err != nil {
+		t.Fatalf("Failed to create payment order: %v", err)
+	}
+
+	// Override ID if specified
+	if cfg.id != uuid.Nil {
+		po.ID = cfg.id
+	}
+
+	return po
+}
+
+// NewPaymentOrderInStatus creates a PaymentOrder in the specified status with all
+// required fields populated for that state. Use this to create payment orders
+// in non-initial states for testing specific scenarios.
+func NewPaymentOrderInStatus(t *testing.T, status domain.PaymentOrderStatus, opts ...PaymentOrderOption) *domain.PaymentOrder {
+	t.Helper()
+
+	// Defaults that vary by status
+	cfg := &paymentOrderConfig{
+		debtorAccountID:   "TEST-DEBTOR-001",
+		creditorReference: "GB82WEST12345698765432",
+		amountCents:       10000,
+		currency:          "GBP",
+		idempotencyKey:    "idem-" + uuid.New().String(),
+		correlationID:     "corr-" + uuid.New().String(),
+		lienID:            "lien-" + uuid.New().String(),
+		gatewayRefID:      "gw-ref-" + uuid.New().String(),
+		ledgerBookingID:   "ledger-" + uuid.New().String(),
+		failureReason:     "Test failure",
+		errorCode:         "TEST_ERROR",
+	}
+
+	// Apply options
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Create money
+	amount, err := domain.NewMoney(cfg.currency, cfg.amountCents)
+	if err != nil {
+		t.Fatalf("Failed to create money: %v", err)
+	}
+
+	// Build payment order struct directly for non-initial states
+	now := time.Now()
+	po := &domain.PaymentOrder{
+		ID:                uuid.New(),
+		DebtorAccountID:   cfg.debtorAccountID,
+		CreditorReference: cfg.creditorReference,
+		Amount:            amount,
+		Status:            status,
+		IdempotencyKey:    cfg.idempotencyKey,
+		CorrelationID:     cfg.correlationID,
+		Version:           1,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+
+	// Override ID if specified
+	if cfg.id != uuid.Nil {
+		po.ID = cfg.id
+	}
+
+	// Set status-specific fields
+	switch status {
+	case domain.PaymentOrderStatusInitiated:
+		// No additional fields needed for INITIATED status
+
+	case domain.PaymentOrderStatusReserved:
+		po.LienID = cfg.lienID
+		po.ReservedAt = &now
+
+	case domain.PaymentOrderStatusExecuting:
+		po.LienID = cfg.lienID
+		po.GatewayReferenceID = cfg.gatewayRefID
+		po.ReservedAt = &now
+		po.ExecutingAt = &now
+
+	case domain.PaymentOrderStatusCompleted:
+		po.LienID = cfg.lienID
+		po.GatewayReferenceID = cfg.gatewayRefID
+		po.LedgerBookingID = cfg.ledgerBookingID
+		po.ReservedAt = &now
+		po.ExecutingAt = &now
+		po.CompletedAt = &now
+
+	case domain.PaymentOrderStatusFailed:
+		po.FailureReason = cfg.failureReason
+		po.ErrorCode = cfg.errorCode
+		po.FailedAt = &now
+		// Optionally set lien if failed after reservation
+		if cfg.lienID != "" {
+			po.LienID = cfg.lienID
+			po.ReservedAt = &now
+		}
+
+	case domain.PaymentOrderStatusCancelled:
+		po.FailureReason = cfg.failureReason
+		po.CancelledAt = &now
+		// Optionally set lien if cancelled after reservation
+		if cfg.lienID != "" {
+			po.LienID = cfg.lienID
+			po.ReservedAt = &now
+		}
+
+	case domain.PaymentOrderStatusReversed:
+		po.LienID = cfg.lienID
+		po.GatewayReferenceID = cfg.gatewayRefID
+		po.LedgerBookingID = cfg.ledgerBookingID
+		po.FailureReason = cfg.failureReason
+		po.ReservedAt = &now
+		po.ExecutingAt = &now
+		po.CompletedAt = &now
+		po.ReversedAt = &now
+	}
+
+	return po
+}
+
+// NewMoney creates a Money instance with the specified amount in cents and currency.
+func NewMoney(t *testing.T, amountCents int64, currency string) domain.Money {
+	t.Helper()
+	m, err := domain.NewMoney(currency, amountCents)
+	if err != nil {
+		t.Fatalf("Failed to create money: %v", err)
+	}
+	return m
+}
+
+// DefaultGBPMoney returns 100 GBP (10000 cents) for testing.
+func DefaultGBPMoney(t *testing.T) domain.Money {
+	t.Helper()
+	return NewMoney(t, 10000, "GBP")
+}
+
+// DefaultUSDMoney returns 100 USD (10000 cents) for testing.
+func DefaultUSDMoney(t *testing.T) domain.Money {
+	t.Helper()
+	return NewMoney(t, 10000, "USD")
+}
+
+// LargeGBPMoney returns 100,000 GBP (10,000,000 cents) for testing high-value payments.
+func LargeGBPMoney(t *testing.T) domain.Money {
+	t.Helper()
+	return NewMoney(t, 10000000, "GBP")
+}
+
+// SmallGBPMoney returns 1 GBP (100 cents) for testing small payments.
+func SmallGBPMoney(t *testing.T) domain.Money {
+	t.Helper()
+	return NewMoney(t, 100, "GBP")
+}
+
+// TestAccountID returns a consistent test account ID.
+func TestAccountID() string {
+	return "TEST-DEBTOR-001"
+}
+
+// TestCreditorReference returns a valid IBAN-style creditor reference for testing.
+func TestCreditorReference() string {
+	return "GB82WEST12345698765432"
+}
+
+// TestLienID returns a consistent test lien ID.
+func TestLienID() string {
+	return "lien-test-001"
+}
+
+// TestGatewayReferenceID returns a consistent test gateway reference ID.
+func TestGatewayReferenceID() string {
+	return "gw-ref-test-001"
+}
+
+// RandomIdempotencyKey generates a unique idempotency key for testing.
+func RandomIdempotencyKey() string {
+	return "idem-" + uuid.New().String()
+}
+
+// RandomCorrelationID generates a unique correlation ID for testing.
+func RandomCorrelationID() string {
+	return "corr-" + uuid.New().String()
+}

--- a/services/payment-order/domain/testfixtures/fixtures_test.go
+++ b/services/payment-order/domain/testfixtures/fixtures_test.go
@@ -1,0 +1,196 @@
+package testfixtures_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/services/payment-order/domain/testfixtures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPaymentOrder_Defaults(t *testing.T) {
+	po := testfixtures.NewPaymentOrder(t)
+
+	assert.NotEqual(t, uuid.Nil, po.ID)
+	assert.Equal(t, "TEST-DEBTOR-001", po.DebtorAccountID)
+	assert.Equal(t, "GB82WEST12345698765432", po.CreditorReference)
+	assert.Equal(t, domain.PaymentOrderStatusInitiated, po.Status)
+	assert.NotEmpty(t, po.IdempotencyKey)
+	assert.NotEmpty(t, po.CorrelationID)
+	assert.Equal(t, 1, po.Version)
+}
+
+func TestNewPaymentOrder_WithOptions(t *testing.T) {
+	customID := uuid.New()
+	po := testfixtures.NewPaymentOrder(t,
+		testfixtures.WithID(customID),
+		testfixtures.WithDebtorAccountID("CUSTOM-ACC-001"),
+		testfixtures.WithCreditorReference("CUSTOM-CRED-REF"),
+		testfixtures.WithAmountCents(50000),
+		testfixtures.WithCurrency("USD"),
+		testfixtures.WithIdempotencyKey("custom-idem-key"),
+		testfixtures.WithCorrelationID("custom-corr-id"),
+	)
+
+	assert.Equal(t, customID, po.ID)
+	assert.Equal(t, "CUSTOM-ACC-001", po.DebtorAccountID)
+	assert.Equal(t, "CUSTOM-CRED-REF", po.CreditorReference)
+	assert.Equal(t, "custom-idem-key", po.IdempotencyKey)
+	assert.Equal(t, "custom-corr-id", po.CorrelationID)
+	assert.True(t, po.Amount.IsPositive())
+}
+
+func TestNewPaymentOrderInStatus_Initiated(t *testing.T) {
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusInitiated)
+
+	assert.Equal(t, domain.PaymentOrderStatusInitiated, po.Status)
+	assert.Empty(t, po.LienID)
+	assert.Empty(t, po.GatewayReferenceID)
+	assert.Nil(t, po.ReservedAt)
+	assert.Nil(t, po.ExecutingAt)
+	assert.Nil(t, po.CompletedAt)
+}
+
+func TestNewPaymentOrderInStatus_Reserved(t *testing.T) {
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusReserved)
+
+	assert.Equal(t, domain.PaymentOrderStatusReserved, po.Status)
+	assert.NotEmpty(t, po.LienID)
+	assert.NotNil(t, po.ReservedAt)
+	assert.Empty(t, po.GatewayReferenceID)
+	assert.Nil(t, po.ExecutingAt)
+}
+
+func TestNewPaymentOrderInStatus_Executing(t *testing.T) {
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusExecuting)
+
+	assert.Equal(t, domain.PaymentOrderStatusExecuting, po.Status)
+	assert.NotEmpty(t, po.LienID)
+	assert.NotEmpty(t, po.GatewayReferenceID)
+	assert.NotNil(t, po.ReservedAt)
+	assert.NotNil(t, po.ExecutingAt)
+	assert.Nil(t, po.CompletedAt)
+}
+
+func TestNewPaymentOrderInStatus_Completed(t *testing.T) {
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCompleted)
+
+	assert.Equal(t, domain.PaymentOrderStatusCompleted, po.Status)
+	assert.NotEmpty(t, po.LienID)
+	assert.NotEmpty(t, po.GatewayReferenceID)
+	assert.NotEmpty(t, po.LedgerBookingID)
+	assert.NotNil(t, po.ReservedAt)
+	assert.NotNil(t, po.ExecutingAt)
+	assert.NotNil(t, po.CompletedAt)
+}
+
+func TestNewPaymentOrderInStatus_Failed(t *testing.T) {
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusFailed)
+
+	assert.Equal(t, domain.PaymentOrderStatusFailed, po.Status)
+	assert.NotEmpty(t, po.FailureReason)
+	assert.NotEmpty(t, po.ErrorCode)
+	assert.NotNil(t, po.FailedAt)
+}
+
+func TestNewPaymentOrderInStatus_Cancelled(t *testing.T) {
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusCancelled)
+
+	assert.Equal(t, domain.PaymentOrderStatusCancelled, po.Status)
+	assert.NotEmpty(t, po.FailureReason)
+	assert.NotNil(t, po.CancelledAt)
+}
+
+func TestNewPaymentOrderInStatus_Reversed(t *testing.T) {
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusReversed)
+
+	assert.Equal(t, domain.PaymentOrderStatusReversed, po.Status)
+	assert.NotEmpty(t, po.LienID)
+	assert.NotEmpty(t, po.GatewayReferenceID)
+	assert.NotEmpty(t, po.LedgerBookingID)
+	assert.NotNil(t, po.CompletedAt)
+	assert.NotNil(t, po.ReversedAt)
+}
+
+func TestNewPaymentOrderInStatus_WithCustomOptions(t *testing.T) {
+	customLienID := "custom-lien-123"
+	po := testfixtures.NewPaymentOrderInStatus(t, domain.PaymentOrderStatusReserved,
+		testfixtures.WithLienID(customLienID),
+		testfixtures.WithDebtorAccountID("CUSTOM-ACC"),
+	)
+
+	assert.Equal(t, domain.PaymentOrderStatusReserved, po.Status)
+	assert.Equal(t, customLienID, po.LienID)
+	assert.Equal(t, "CUSTOM-ACC", po.DebtorAccountID)
+}
+
+func TestNewMoney(t *testing.T) {
+	m := testfixtures.NewMoney(t, 5000, "GBP")
+
+	assert.True(t, m.IsPositive())
+	assert.Equal(t, domain.CurrencyGBP, m.Currency())
+}
+
+func TestDefaultGBPMoney(t *testing.T) {
+	m := testfixtures.DefaultGBPMoney(t)
+
+	assert.True(t, m.IsPositive())
+	assert.Equal(t, domain.CurrencyGBP, m.Currency())
+}
+
+func TestDefaultUSDMoney(t *testing.T) {
+	m := testfixtures.DefaultUSDMoney(t)
+
+	assert.True(t, m.IsPositive())
+	assert.Equal(t, domain.CurrencyUSD, m.Currency())
+}
+
+func TestLargeGBPMoney(t *testing.T) {
+	m := testfixtures.LargeGBPMoney(t)
+
+	assert.True(t, m.IsPositive())
+	assert.Equal(t, domain.CurrencyGBP, m.Currency())
+}
+
+func TestSmallGBPMoney(t *testing.T) {
+	m := testfixtures.SmallGBPMoney(t)
+
+	assert.True(t, m.IsPositive())
+	assert.Equal(t, domain.CurrencyGBP, m.Currency())
+}
+
+func TestHelperFunctions(t *testing.T) {
+	assert.Equal(t, "TEST-DEBTOR-001", testfixtures.TestAccountID())
+	assert.Equal(t, "GB82WEST12345698765432", testfixtures.TestCreditorReference())
+	assert.Equal(t, "lien-test-001", testfixtures.TestLienID())
+	assert.Equal(t, "gw-ref-test-001", testfixtures.TestGatewayReferenceID())
+}
+
+func TestRandomIdempotencyKey_Uniqueness(t *testing.T) {
+	key1 := testfixtures.RandomIdempotencyKey()
+	key2 := testfixtures.RandomIdempotencyKey()
+
+	assert.NotEqual(t, key1, key2)
+	assert.Contains(t, key1, "idem-")
+	assert.Contains(t, key2, "idem-")
+}
+
+func TestRandomCorrelationID_Uniqueness(t *testing.T) {
+	id1 := testfixtures.RandomCorrelationID()
+	id2 := testfixtures.RandomCorrelationID()
+
+	assert.NotEqual(t, id1, id2)
+	assert.Contains(t, id1, "corr-")
+	assert.Contains(t, id2, "corr-")
+}
+
+func TestNewPaymentOrder_UniqueIDs(t *testing.T) {
+	po1 := testfixtures.NewPaymentOrder(t)
+	po2 := testfixtures.NewPaymentOrder(t)
+
+	require.NotEqual(t, po1.ID, po2.ID, "Each payment order should have a unique ID")
+	require.NotEqual(t, po1.IdempotencyKey, po2.IdempotencyKey, "Each payment order should have a unique idempotency key")
+	require.NotEqual(t, po1.CorrelationID, po2.CorrelationID, "Each payment order should have a unique correlation ID")
+}


### PR DESCRIPTION
## Summary

- Add `testfixtures` package to payment-order domain following the established pattern from position-keeping and financial-accounting services
- Completes issue #230 which requested testfixtures directory with reusable test data

## Changes Made

Added `services/payment-order/domain/testfixtures/`:
- `fixtures.go` - Factory functions and helpers for creating test data
- `fixtures_test.go` - Tests for the testfixtures package (19 tests)

### Key Features

- `NewPaymentOrder(t, ...options)` - Creates payment orders with sensible defaults
- `NewPaymentOrderInStatus(t, status, ...options)` - Creates payment orders in specific states with all required fields populated
- Option functions for customizing: ID, debtor account, creditor reference, amount, currency, idempotency key, correlation ID, lien ID, gateway reference ID, etc.
- Helper functions: `DefaultGBPMoney`, `DefaultUSDMoney`, `LargeGBPMoney`, `SmallGBPMoney`, `TestAccountID()`, `TestCreditorReference()`, `RandomIdempotencyKey()`, `RandomCorrelationID()`

## Context

Issue #230 originally requested:
1. ✅ Error path tests for payment processing failures - Already implemented in `grpc_service_test.go` (saga failures, lien failures, validation errors)
2. ✅ Gateway failure scenario tests - Already implemented in `resilient_gateway_test.go` (timeouts, retries, circuit breaker) and `integration_test.go`
3. ✅ Testfixtures directory - **Added in this PR**

The payment-order service already has comprehensive test coverage (12 test files, 4000+ lines of tests). This PR adds the missing testfixtures for consistent test data creation.

## Test plan

- [ ] All 19 testfixtures tests pass
- [ ] Existing payment-order domain tests continue to pass
- [ ] CI pipeline passes

Closes #230