### PR TITLE
feat(db): implement PostgreSQL schema routing with SET LOCAL search_path

### DIFF
--- a/shared/platform/db/organization_scope.go
+++ b/shared/platform/db/organization_scope.go
@@ -1,0 +1,65 @@
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lib/pq"
+	"github.com/meridianhub/meridian/shared/platform/organization"
+)
+
+// WithOrganizationScope sets the PostgreSQL search_path to the organization's schema.
+// This must be called INSIDE a transaction (within a WithTransaction callback) to ensure
+// the search_path is transaction-scoped via SET LOCAL.
+//
+// The function:
+//  1. Extracts the organization ID from context using organization.FromContext
+//  2. Returns ErrMissingOrganizationContext if organization is missing (fail-fast)
+//  3. Generates schema name via orgID.SchemaName() (returns "org_{id}")
+//  4. Executes SET LOCAL search_path TO <schema>, public
+//  5. Returns the same DB for chaining
+//
+// SET LOCAL ensures the search_path automatically reverts when the transaction
+// commits or rolls back - no manual cleanup needed.
+//
+// The public schema is included in search_path to allow read access to shared
+// reference data.
+//
+// Example usage:
+//
+//	err := db.WithTransaction(ctx, pool, func(tx db.DB) error {
+//	    if _, err := db.WithOrganizationScope(ctx, tx); err != nil {
+//	        return err
+//	    }
+//	    // All queries now target the organization's schema
+//	    return repository.Save(tx, entity)
+//	})
+func WithOrganizationScope(ctx context.Context, db DB) (DB, error) {
+	orgID, ok := organization.FromContext(ctx)
+	if !ok {
+		return nil, organization.ErrMissingOrganizationContext
+	}
+
+	// Quote the schema name to prevent SQL injection
+	// pq.QuoteIdentifier handles special characters safely
+	schemaName := pq.QuoteIdentifier(orgID.SchemaName())
+
+	// SET LOCAL is transaction-scoped - automatically reverts on commit/rollback
+	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	if _, err := db.ExecContext(ctx, query); err != nil {
+		return nil, fmt.Errorf("failed to set organization schema scope: %w", err)
+	}
+
+	return db, nil
+}
+
+// MustWithOrganizationScope is like WithOrganizationScope but panics on error.
+// Use only when organization context is guaranteed to be present (e.g., after
+// middleware validation).
+func MustWithOrganizationScope(ctx context.Context, db DB) DB {
+	result, err := WithOrganizationScope(ctx, db)
+	if err != nil {
+		panic(fmt.Sprintf("organization scope failed: %v", err))
+	}
+	return result
+}

--- a/shared/platform/db/organization_scope_integration_test.go
+++ b/shared/platform/db/organization_scope_integration_test.go
@@ -1,0 +1,405 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/organization"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// setupOrgScopeTestContainer creates a PostgreSQL container with organization schemas for testing
+func setupOrgScopeTestContainer(ctx context.Context, t *testing.T) (*PostgresPool, func()) {
+	t.Helper()
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:15-alpine",
+		postgres.WithDatabase("test_db"),
+		postgres.WithUsername("test_user"),
+		postgres.WithPassword("test_password"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	require.NoError(t, err, "failed to start postgres container")
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err, "failed to get connection string")
+
+	cfg := DefaultConfig(connStr)
+	cfg.MaxConnections = 10
+	cfg.MinConnections = 2
+
+	pool, err := NewPostgresPool(ctx, cfg)
+	require.NoError(t, err, "failed to create postgres pool")
+
+	// Create organization schemas with identical table structure
+	schemas := []string{"org_test_a", "org_test_b"}
+	for _, schema := range schemas {
+		_, err = pool.ExecContext(ctx, "CREATE SCHEMA IF NOT EXISTS "+schema)
+		require.NoError(t, err, "failed to create schema %s", schema)
+
+		_, err = pool.ExecContext(ctx, `
+			CREATE TABLE IF NOT EXISTS `+schema+`.accounts (
+				id SERIAL PRIMARY KEY,
+				account_id VARCHAR(50) UNIQUE NOT NULL,
+				name VARCHAR(100) NOT NULL,
+				balance DECIMAL(15,2) NOT NULL DEFAULT 0.00
+			)
+		`)
+		require.NoError(t, err, "failed to create accounts table in schema %s", schema)
+	}
+
+	// Insert different data in each schema
+	_, err = pool.ExecContext(ctx,
+		"INSERT INTO org_test_a.accounts (account_id, name, balance) VALUES ($1, $2, $3)",
+		"ACC-001", "Org A Account", 1000.00)
+	require.NoError(t, err, "failed to insert into org_test_a")
+
+	_, err = pool.ExecContext(ctx,
+		"INSERT INTO org_test_b.accounts (account_id, name, balance) VALUES ($1, $2, $3)",
+		"ACC-001", "Org B Account", 2000.00)
+	require.NoError(t, err, "failed to insert into org_test_b")
+
+	// Create shared reference data in public schema
+	_, err = pool.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS public.currency_codes (
+			code VARCHAR(3) PRIMARY KEY,
+			name VARCHAR(50) NOT NULL
+		)
+	`)
+	require.NoError(t, err, "failed to create public.currency_codes")
+
+	_, err = pool.ExecContext(ctx,
+		"INSERT INTO public.currency_codes (code, name) VALUES ($1, $2)",
+		"USD", "US Dollar")
+	require.NoError(t, err, "failed to insert public reference data")
+
+	cleanup := func() {
+		_ = pool.Close()
+		_ = pgContainer.Terminate(ctx)
+	}
+
+	return pool, cleanup
+}
+
+func TestWithOrganizationScope_Integration_QueryRouting(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+	pool, cleanup := setupOrgScopeTestContainer(ctx, t)
+	defer cleanup()
+
+	t.Run("org_a retrieves org_a data", func(t *testing.T) {
+		orgID := organization.MustNewOrganizationID("test_a")
+		orgCtx := organization.WithOrganization(ctx, orgID)
+
+		var name string
+		var balance float64
+
+		err := WithTransaction(orgCtx, pool, func(tx DB) error {
+			if _, err := WithOrganizationScope(orgCtx, tx); err != nil {
+				return err
+			}
+
+			return tx.QueryRowContext(orgCtx,
+				"SELECT name, balance FROM accounts WHERE account_id = $1",
+				"ACC-001").Scan(&name, &balance)
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "Org A Account", name)
+		assert.Equal(t, 1000.00, balance)
+	})
+
+	t.Run("org_b retrieves org_b data", func(t *testing.T) {
+		orgID := organization.MustNewOrganizationID("test_b")
+		orgCtx := organization.WithOrganization(ctx, orgID)
+
+		var name string
+		var balance float64
+
+		err := WithTransaction(orgCtx, pool, func(tx DB) error {
+			if _, err := WithOrganizationScope(orgCtx, tx); err != nil {
+				return err
+			}
+
+			return tx.QueryRowContext(orgCtx,
+				"SELECT name, balance FROM accounts WHERE account_id = $1",
+				"ACC-001").Scan(&name, &balance)
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "Org B Account", name)
+		assert.Equal(t, 2000.00, balance)
+	})
+}
+
+func TestWithOrganizationScope_Integration_Isolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+	pool, cleanup := setupOrgScopeTestContainer(ctx, t)
+	defer cleanup()
+
+	// Org A should not see Org B's unique data
+	orgID := organization.MustNewOrganizationID("test_a")
+	orgCtx := organization.WithOrganization(ctx, orgID)
+
+	// Insert unique data in org_b
+	_, err := pool.ExecContext(ctx,
+		"INSERT INTO org_test_b.accounts (account_id, name, balance) VALUES ($1, $2, $3)",
+		"ACC-UNIQUE-B", "Org B Only", 5000.00)
+	require.NoError(t, err)
+
+	// Try to query it from org_a context - should return no rows
+	var count int
+	err = WithTransaction(orgCtx, pool, func(tx DB) error {
+		if _, err := WithOrganizationScope(orgCtx, tx); err != nil {
+			return err
+		}
+
+		return tx.QueryRowContext(orgCtx,
+			"SELECT COUNT(*) FROM accounts WHERE account_id = $1",
+			"ACC-UNIQUE-B").Scan(&count)
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "org_a should not see org_b's unique data")
+}
+
+func TestWithOrganizationScope_Integration_SearchPathAutoRevert(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+	pool, cleanup := setupOrgScopeTestContainer(ctx, t)
+	defer cleanup()
+
+	// Get original search_path
+	var originalSearchPath string
+	err := pool.QueryRowContext(ctx, "SHOW search_path").Scan(&originalSearchPath)
+	require.NoError(t, err)
+
+	// Run a transaction with organization scope
+	orgID := organization.MustNewOrganizationID("test_a")
+	orgCtx := organization.WithOrganization(ctx, orgID)
+
+	err = WithTransaction(orgCtx, pool, func(tx DB) error {
+		if _, err := WithOrganizationScope(orgCtx, tx); err != nil {
+			return err
+		}
+
+		// Verify search_path is set within transaction
+		var txSearchPath string
+		if err := tx.QueryRowContext(orgCtx, "SHOW search_path").Scan(&txSearchPath); err != nil {
+			return err
+		}
+		// Should contain org_test_a
+		assert.Contains(t, txSearchPath, "org_test_a")
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Verify search_path reverted after transaction
+	var afterSearchPath string
+	err = pool.QueryRowContext(ctx, "SHOW search_path").Scan(&afterSearchPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalSearchPath, afterSearchPath, "search_path should revert after transaction")
+}
+
+func TestWithOrganizationScope_Integration_PublicSchemaAccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+	pool, cleanup := setupOrgScopeTestContainer(ctx, t)
+	defer cleanup()
+
+	// Both organizations should be able to read from public schema
+	orgs := []string{"test_a", "test_b"}
+
+	for _, org := range orgs {
+		t.Run("org_"+org+"_can_read_public", func(t *testing.T) {
+			orgID := organization.MustNewOrganizationID(org)
+			orgCtx := organization.WithOrganization(ctx, orgID)
+
+			var currencyName string
+			err := WithTransaction(orgCtx, pool, func(tx DB) error {
+				if _, err := WithOrganizationScope(orgCtx, tx); err != nil {
+					return err
+				}
+
+				// Query public schema table
+				return tx.QueryRowContext(orgCtx,
+					"SELECT name FROM public.currency_codes WHERE code = $1",
+					"USD").Scan(&currencyName)
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, "US Dollar", currencyName)
+		})
+	}
+}
+
+func TestWithOrganizationScope_Integration_MissingOrganizationContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+	pool, cleanup := setupOrgScopeTestContainer(ctx, t)
+	defer cleanup()
+
+	// Context without organization
+	err := WithTransaction(ctx, pool, func(tx DB) error {
+		_, err := WithOrganizationScope(ctx, tx) // Missing organization in context
+		return err
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, organization.ErrMissingOrganizationContext)
+}
+
+func TestWithOrganizationScope_Integration_NonExistentSchema(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+	pool, cleanup := setupOrgScopeTestContainer(ctx, t)
+	defer cleanup()
+
+	// Create context with organization that has no schema
+	orgID := organization.MustNewOrganizationID("nonexistent")
+	orgCtx := organization.WithOrganization(ctx, orgID)
+
+	// SET LOCAL should succeed (PostgreSQL allows setting search_path to non-existent schemas)
+	// But querying tables should fail
+	err := WithTransaction(orgCtx, pool, func(tx DB) error {
+		if _, err := WithOrganizationScope(orgCtx, tx); err != nil {
+			return err
+		}
+
+		// This query should fail because the schema doesn't exist
+		var count int
+		return tx.QueryRowContext(orgCtx, "SELECT COUNT(*) FROM accounts").Scan(&count)
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "accounts") // Table not found in search_path
+}
+
+func TestWithOrganizationScope_Integration_SQLInjectionPrevention(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+	pool, cleanup := setupOrgScopeTestContainer(ctx, t)
+	defer cleanup()
+
+	// Attempt SQL injection through organization ID
+	// Note: This test relies on organization.NewOrganizationID rejecting invalid characters
+	// The SQL injection attempt should be blocked at the OrganizationID validation level
+
+	// Valid organization IDs cannot contain SQL injection characters due to validation
+	// So we test that the schema name is properly quoted even for edge cases
+
+	t.Run("schema_name_is_quoted", func(t *testing.T) {
+		orgID := organization.MustNewOrganizationID("test_a")
+		orgCtx := organization.WithOrganization(ctx, orgID)
+
+		err := WithTransaction(orgCtx, pool, func(tx DB) error {
+			if _, err := WithOrganizationScope(orgCtx, tx); err != nil {
+				return err
+			}
+
+			// Verify search_path is properly quoted
+			var searchPath string
+			if err := tx.QueryRowContext(orgCtx, "SHOW search_path").Scan(&searchPath); err != nil {
+				return err
+			}
+
+			// The schema name should be in the search_path
+			assert.Contains(t, searchPath, "org_test_a")
+			return nil
+		})
+
+		require.NoError(t, err)
+	})
+}
+
+func TestWithOrganizationScope_Integration_WriteIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+	pool, cleanup := setupOrgScopeTestContainer(ctx, t)
+	defer cleanup()
+
+	// Write from org_a context
+	orgIDa := organization.MustNewOrganizationID("test_a")
+	orgCtxA := organization.WithOrganization(ctx, orgIDa)
+
+	err := WithTransaction(orgCtxA, pool, func(tx DB) error {
+		if _, err := WithOrganizationScope(orgCtxA, tx); err != nil {
+			return err
+		}
+
+		_, err := tx.ExecContext(orgCtxA,
+			"INSERT INTO accounts (account_id, name, balance) VALUES ($1, $2, $3)",
+			"ACC-WRITE-TEST", "Write Test", 3000.00)
+		return err
+	})
+	require.NoError(t, err)
+
+	// Verify the write is only visible in org_a
+	t.Run("write_visible_in_org_a", func(t *testing.T) {
+		var balance float64
+		err := WithTransaction(orgCtxA, pool, func(tx DB) error {
+			if _, err := WithOrganizationScope(orgCtxA, tx); err != nil {
+				return err
+			}
+
+			return tx.QueryRowContext(orgCtxA,
+				"SELECT balance FROM accounts WHERE account_id = $1",
+				"ACC-WRITE-TEST").Scan(&balance)
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 3000.00, balance)
+	})
+
+	t.Run("write_not_visible_in_org_b", func(t *testing.T) {
+		orgIDb := organization.MustNewOrganizationID("test_b")
+		orgCtxB := organization.WithOrganization(ctx, orgIDb)
+
+		var count int
+		err := WithTransaction(orgCtxB, pool, func(tx DB) error {
+			if _, err := WithOrganizationScope(orgCtxB, tx); err != nil {
+				return err
+			}
+
+			return tx.QueryRowContext(orgCtxB,
+				"SELECT COUNT(*) FROM accounts WHERE account_id = $1",
+				"ACC-WRITE-TEST").Scan(&count)
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 0, count, "org_b should not see org_a's write")
+	})
+}

--- a/shared/platform/db/organization_scope_integration_test.go
+++ b/shared/platform/db/organization_scope_integration_test.go
@@ -2,9 +2,11 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/shared/platform/organization"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,19 +42,21 @@ func setupOrgScopeTestContainer(ctx context.Context, t *testing.T) (*PostgresPoo
 	require.NoError(t, err, "failed to create postgres pool")
 
 	// Create organization schemas with identical table structure
+	// Use pq.QuoteIdentifier for consistency with production code philosophy
 	schemas := []string{"org_test_a", "org_test_b"}
 	for _, schema := range schemas {
-		_, err = pool.ExecContext(ctx, "CREATE SCHEMA IF NOT EXISTS "+schema)
+		quotedSchema := pq.QuoteIdentifier(schema)
+		_, err = pool.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quotedSchema))
 		require.NoError(t, err, "failed to create schema %s", schema)
 
-		_, err = pool.ExecContext(ctx, `
-			CREATE TABLE IF NOT EXISTS `+schema+`.accounts (
+		_, err = pool.ExecContext(ctx, fmt.Sprintf(`
+			CREATE TABLE IF NOT EXISTS %s.accounts (
 				id SERIAL PRIMARY KEY,
 				account_id VARCHAR(50) UNIQUE NOT NULL,
 				name VARCHAR(100) NOT NULL,
 				balance DECIMAL(15,2) NOT NULL DEFAULT 0.00
 			)
-		`)
+		`, quotedSchema))
 		require.NoError(t, err, "failed to create accounts table in schema %s", schema)
 	}
 

--- a/shared/platform/db/organization_scope_test.go
+++ b/shared/platform/db/organization_scope_test.go
@@ -1,0 +1,179 @@
+package db_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/meridianhub/meridian/shared/platform/organization"
+)
+
+// errMockExecFailed is a sentinel error for testing exec failures
+var errMockExecFailed = errors.New("mock exec failed")
+
+// mockDB implements db.DB for unit testing
+type mockDB struct {
+	execCalled bool
+	execQuery  string
+	execErr    error
+}
+
+func (m *mockDB) QueryContext(_ context.Context, _ string, _ ...interface{}) (*sql.Rows, error) {
+	return nil, nil
+}
+
+func (m *mockDB) ExecContext(_ context.Context, query string, _ ...interface{}) (sql.Result, error) {
+	m.execCalled = true
+	m.execQuery = query
+	return nil, m.execErr
+}
+
+func (m *mockDB) QueryRowContext(_ context.Context, _ string, _ ...interface{}) *sql.Row {
+	return nil
+}
+
+func (m *mockDB) BeginTx(_ context.Context, _ *sql.TxOptions) (*sql.Tx, error) {
+	return nil, nil
+}
+
+func (m *mockDB) Ping(_ context.Context) error {
+	return nil
+}
+
+func (m *mockDB) Close() error {
+	return nil
+}
+
+func TestWithOrganizationScope_Success(t *testing.T) {
+	mock := &mockDB{}
+	orgID := organization.MustNewOrganizationID("acme_bank")
+	ctx := organization.WithOrganization(context.Background(), orgID)
+
+	result, err := db.WithOrganizationScope(ctx, mock)
+	if err != nil {
+		t.Fatalf("WithOrganizationScope returned unexpected error: %v", err)
+	}
+	if result != mock {
+		t.Error("WithOrganizationScope should return the same DB instance")
+	}
+	if !mock.execCalled {
+		t.Error("WithOrganizationScope should execute SET LOCAL query")
+	}
+	// Schema name should be quoted and include public
+	expected := `SET LOCAL search_path TO "org_acme_bank", public`
+	if mock.execQuery != expected {
+		t.Errorf("Query = %q, want %q", mock.execQuery, expected)
+	}
+}
+
+func TestWithOrganizationScope_MissingOrganizationContext(t *testing.T) {
+	mock := &mockDB{}
+	ctx := context.Background() // No organization in context
+
+	result, err := db.WithOrganizationScope(ctx, mock)
+
+	if err == nil {
+		t.Fatal("WithOrganizationScope should return error for missing organization context")
+	}
+	if !errors.Is(err, organization.ErrMissingOrganizationContext) {
+		t.Errorf("error = %v, want ErrMissingOrganizationContext", err)
+	}
+	if result != nil {
+		t.Error("WithOrganizationScope should return nil DB on error")
+	}
+	if mock.execCalled {
+		t.Error("WithOrganizationScope should not execute query when organization missing")
+	}
+}
+
+func TestWithOrganizationScope_ExecError(t *testing.T) {
+	mock := &mockDB{execErr: errMockExecFailed}
+	orgID := organization.MustNewOrganizationID("test_org")
+	ctx := organization.WithOrganization(context.Background(), orgID)
+
+	result, err := db.WithOrganizationScope(ctx, mock)
+
+	if err == nil {
+		t.Fatal("WithOrganizationScope should return error when exec fails")
+	}
+	if !errors.Is(err, errMockExecFailed) {
+		t.Errorf("error should wrap exec error, got: %v", err)
+	}
+	if result != nil {
+		t.Error("WithOrganizationScope should return nil DB on error")
+	}
+}
+
+func TestWithOrganizationScope_SchemaNameQuoting(t *testing.T) {
+	tests := []struct {
+		name           string
+		orgID          string
+		expectedSchema string
+	}{
+		{
+			name:           "lowercase",
+			orgID:          "acme",
+			expectedSchema: `"org_acme"`,
+		},
+		{
+			name:           "uppercase_normalized",
+			orgID:          "ACME",
+			expectedSchema: `"org_acme"`, // SchemaName() lowercases
+		},
+		{
+			name:           "with_underscore",
+			orgID:          "acme_bank",
+			expectedSchema: `"org_acme_bank"`,
+		},
+		{
+			name:           "with_numbers",
+			orgID:          "bank123",
+			expectedSchema: `"org_bank123"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockDB{}
+			orgID := organization.MustNewOrganizationID(tt.orgID)
+			ctx := organization.WithOrganization(context.Background(), orgID)
+
+			_, err := db.WithOrganizationScope(ctx, mock)
+			if err != nil {
+				t.Fatalf("WithOrganizationScope returned unexpected error: %v", err)
+			}
+			expected := "SET LOCAL search_path TO " + tt.expectedSchema + ", public"
+			if mock.execQuery != expected {
+				t.Errorf("Query = %q, want %q", mock.execQuery, expected)
+			}
+		})
+	}
+}
+
+func TestMustWithOrganizationScope_Success(t *testing.T) {
+	mock := &mockDB{}
+	orgID := organization.MustNewOrganizationID("test_org")
+	ctx := organization.WithOrganization(context.Background(), orgID)
+
+	// Should not panic
+	result := db.MustWithOrganizationScope(ctx, mock)
+
+	if result != mock {
+		t.Error("MustWithOrganizationScope should return the same DB instance")
+	}
+}
+
+func TestMustWithOrganizationScope_Panics(t *testing.T) {
+	mock := &mockDB{}
+	ctx := context.Background() // No organization
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("MustWithOrganizationScope should panic when organization missing")
+		}
+	}()
+
+	db.MustWithOrganizationScope(ctx, mock)
+}


### PR DESCRIPTION
## Summary

- Implements `WithOrganizationScope` function for routing queries to organization-specific PostgreSQL schemas
- Uses transaction-scoped `SET LOCAL search_path` for automatic cleanup
- Prevents SQL injection via `pq.QuoteIdentifier`
- Includes public schema in search_path for shared reference data access

## Changes Made

**New files in `shared/platform/db/`:**
- `organization_scope.go` - Core implementation
- `organization_scope_test.go` - Unit tests
- `organization_scope_integration_test.go` - Integration tests with testcontainers

**API:**
```go
// Route queries to organization schema within a transaction
func WithOrganizationScope(ctx context.Context, db DB) (DB, error)

// Panic variant for guaranteed context scenarios
func MustWithOrganizationScope(ctx context.Context, db DB) DB
```

**Usage pattern:**
```go
err := db.WithTransaction(ctx, pool, func(tx db.DB) error {
    if _, err := db.WithOrganizationScope(ctx, tx); err != nil {
        return err
    }
    // All queries now target org_{id} schema
    return repository.Save(tx, entity)
})
```

## Test plan

- [x] Unit tests for error handling and schema name quoting
- [x] Integration tests with testcontainers PostgreSQL:
  - Query routing to correct organization schema
  - Data isolation between organizations
  - Search path auto-revert after transaction (no pool leakage)
  - Public schema read access from all organizations
  - Write isolation verification
  - Missing organization context returns error
  - Non-existent schema handling