### PR TITLE
feat(idempotency): add organization scoping to Redis idempotency keys

### DIFF
--- a/shared/pkg/idempotency/idempotency.go
+++ b/shared/pkg/idempotency/idempotency.go
@@ -38,6 +38,11 @@ var (
 
 // Key represents an idempotency key with namespace and operation context
 type Key struct {
+	// OrganizationID is the organization identifier for multi-organization isolation.
+	// When set, keys are prefixed with the organization ID to ensure isolation.
+	// When empty, keys are generated without an organization prefix (single-org mode).
+	OrganizationID string
+
 	// Namespace groups related operations (e.g., "current-account")
 	Namespace string
 
@@ -51,13 +56,20 @@ type Key struct {
 	RequestID string
 }
 
-// String returns the Redis key format: {namespace}:{operation}:{entity}:{request}
+// String returns the Redis key format.
+// With OrganizationID: {org_id}:idempotency:{namespace}:{operation}:{entity}:{request}
+// Without OrganizationID: idempotency:{namespace}:{operation}:{entity}:{request}
 // Note: Field values must not contain colons to avoid ambiguous key representations
 func (k Key) String() string {
-	if k.RequestID != "" {
-		return k.Namespace + ":" + k.Operation + ":" + k.EntityID + ":" + k.RequestID
+	var prefix string
+	if k.OrganizationID != "" {
+		prefix = k.OrganizationID + ":"
 	}
-	return k.Namespace + ":" + k.Operation + ":" + k.EntityID
+
+	if k.RequestID != "" {
+		return prefix + "idempotency:" + k.Namespace + ":" + k.Operation + ":" + k.EntityID + ":" + k.RequestID
+	}
+	return prefix + "idempotency:" + k.Namespace + ":" + k.Operation + ":" + k.EntityID
 }
 
 // Validate checks if the key has all required fields and that none contain colons
@@ -67,8 +79,9 @@ func (k Key) Validate() error {
 	}
 
 	// Prevent colon characters in fields to avoid key collisions
-	if containsColon(k.Namespace) || containsColon(k.Operation) ||
-		containsColon(k.EntityID) || containsColon(k.RequestID) {
+	if containsColon(k.OrganizationID) || containsColon(k.Namespace) ||
+		containsColon(k.Operation) || containsColon(k.EntityID) ||
+		containsColon(k.RequestID) {
 		return ErrInvalidKey
 	}
 

--- a/shared/pkg/idempotency/idempotency.go
+++ b/shared/pkg/idempotency/idempotency.go
@@ -41,6 +41,7 @@ type Key struct {
 	// OrganizationID is the organization identifier for multi-organization isolation.
 	// When set, keys are prefixed with the organization ID to ensure isolation.
 	// When empty, keys are generated without an organization prefix (single-org mode).
+	// Must not contain colons (':') to avoid key parsing ambiguity.
 	OrganizationID string
 
 	// Namespace groups related operations (e.g., "current-account")

--- a/shared/pkg/idempotency/idempotency_test.go
+++ b/shared/pkg/idempotency/idempotency_test.go
@@ -13,33 +13,65 @@ func TestKey_String(t *testing.T) {
 		want string
 	}{
 		{
-			name: "full key with request ID",
+			name: "full key with request ID (no org)",
 			key: Key{
 				Namespace: "current-account",
 				Operation: "deposit",
 				EntityID:  "ACC-12345",
 				RequestID: "req-abc",
 			},
-			want: "current-account:deposit:ACC-12345:req-abc",
+			want: "idempotency:current-account:deposit:ACC-12345:req-abc",
 		},
 		{
-			name: "key without request ID",
+			name: "key without request ID (no org)",
 			key: Key{
 				Namespace: "current-account",
 				Operation: "withdraw",
 				EntityID:  "ACC-67890",
 			},
-			want: "current-account:withdraw:ACC-67890",
+			want: "idempotency:current-account:withdraw:ACC-67890",
 		},
 		{
-			name: "financial accounting namespace",
+			name: "financial accounting namespace (no org)",
 			key: Key{
 				Namespace: "financial-accounting",
 				Operation: "post-ledger",
 				EntityID:  "TXN-999",
 				RequestID: "idempotency-token-123",
 			},
-			want: "financial-accounting:post-ledger:TXN-999:idempotency-token-123",
+			want: "idempotency:financial-accounting:post-ledger:TXN-999:idempotency-token-123",
+		},
+		{
+			name: "with organization ID and request ID",
+			key: Key{
+				OrganizationID: "acme_bank",
+				Namespace:      "payment-order",
+				Operation:      "create",
+				EntityID:       "payment-123",
+				RequestID:      "req-456",
+			},
+			want: "acme_bank:idempotency:payment-order:create:payment-123:req-456",
+		},
+		{
+			name: "with organization ID without request ID",
+			key: Key{
+				OrganizationID: "acme_bank",
+				Namespace:      "current-account",
+				Operation:      "deposit",
+				EntityID:       "ACC-12345",
+			},
+			want: "acme_bank:idempotency:current-account:deposit:ACC-12345",
+		},
+		{
+			name: "different organizations same operation",
+			key: Key{
+				OrganizationID: "other_bank",
+				Namespace:      "payment-order",
+				Operation:      "create",
+				EntityID:       "payment-123",
+				RequestID:      "req-456",
+			},
+			want: "other_bank:idempotency:payment-order:create:payment-123:req-456",
 		},
 	}
 
@@ -50,6 +82,37 @@ func TestKey_String(t *testing.T) {
 				t.Errorf("Key.String() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestKey_String_OrganizationIsolation(t *testing.T) {
+	// Same operation across different organizations should produce different keys
+	keyOrg1 := Key{
+		OrganizationID: "org_alpha",
+		Namespace:      "payment",
+		Operation:      "transfer",
+		EntityID:       "TXN-001",
+		RequestID:      "same-request-id",
+	}
+
+	keyOrg2 := Key{
+		OrganizationID: "org_beta",
+		Namespace:      "payment",
+		Operation:      "transfer",
+		EntityID:       "TXN-001",
+		RequestID:      "same-request-id",
+	}
+
+	if keyOrg1.String() == keyOrg2.String() {
+		t.Error("Keys with different organizations should produce different strings")
+	}
+
+	// Verify the keys contain the organization prefix
+	if keyOrg1.String() != "org_alpha:idempotency:payment:transfer:TXN-001:same-request-id" {
+		t.Errorf("Unexpected key format: %s", keyOrg1.String())
+	}
+	if keyOrg2.String() != "org_beta:idempotency:payment:transfer:TXN-001:same-request-id" {
+		t.Errorf("Unexpected key format: %s", keyOrg2.String())
 	}
 }
 
@@ -221,6 +284,15 @@ func TestKey_Validate_RejectsColons(t *testing.T) {
 		key  Key
 	}{
 		{
+			name: "colon in organization ID",
+			key: Key{
+				OrganizationID: "org:id",
+				Namespace:      "current-account",
+				Operation:      "deposit",
+				EntityID:       "ACC-123",
+			},
+		},
+		{
 			name: "colon in namespace",
 			key: Key{
 				Namespace: "name:space",
@@ -263,6 +335,55 @@ func TestKey_Validate_RejectsColons(t *testing.T) {
 			}
 			if !errors.Is(err, ErrInvalidKey) {
 				t.Errorf("Key.Validate() error = %v, want %v", err, ErrInvalidKey)
+			}
+		})
+	}
+}
+
+func TestKey_Validate_WithOrganizationID(t *testing.T) {
+	tests := []struct {
+		name    string
+		key     Key
+		wantErr bool
+	}{
+		{
+			name: "valid key with organization ID",
+			key: Key{
+				OrganizationID: "acme_bank",
+				Namespace:      "current-account",
+				Operation:      "deposit",
+				EntityID:       "ACC-12345",
+				RequestID:      "req-abc",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid key with organization ID, no request ID",
+			key: Key{
+				OrganizationID: "acme_bank",
+				Namespace:      "current-account",
+				Operation:      "deposit",
+				EntityID:       "ACC-12345",
+			},
+			wantErr: false,
+		},
+		{
+			name: "organization ID is optional (empty is valid)",
+			key: Key{
+				OrganizationID: "",
+				Namespace:      "current-account",
+				Operation:      "deposit",
+				EntityID:       "ACC-12345",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.key.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Key.Validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Adds `OrganizationID` field to idempotency `Key` struct for multi-organization isolation
- Updates key format to include organization prefix when set
- Adds `idempotency:` segment to all keys for clear Redis namespacing

## Key Format

| Mode | Format |
|------|--------|
| Multi-org | `{org_id}:idempotency:{namespace}:{operation}:{entity}:{request}` |
| Single-org | `idempotency:{namespace}:{operation}:{entity}:{request}` |

**Example**: `acme_bank:idempotency:payment-order:create:payment-123:req-456`

## Changes

- `Key.OrganizationID` - new optional field for organization identifier
- `Key.String()` - updated to include organization prefix and `idempotency:` segment
- `Key.Validate()` - extended to reject colons in OrganizationID

## Backward Compatibility

Empty `OrganizationID` generates keys without organization prefix, supporting single-organization deployments.

## Test plan

- [x] Key string generation with/without organization ID
- [x] Organization isolation (same request ID, different orgs = different keys)
- [x] Validation rejects colons in OrganizationID
- [x] All existing Redis service tests pass