### PR TITLE
feat(kafka): add organization header middleware for event isolation

### DIFF
--- a/shared/platform/kafka/consumer.go
+++ b/shared/platform/kafka/consumer.go
@@ -247,9 +247,12 @@ func (c *ProtoConsumer) Subscribe(topics []string) error {
 //
 // Returns:
 // - The organization ID if the header is present and valid
-// - ErrMissingOrganizationHeader if the header is not present
+// - ErrMissingOrganizationHeader if the message is nil or the header is not present
 // - organization.ErrInvalidOrganizationID if the header value is invalid
 func ExtractOrganizationHeader(msg *kafka.Message) (organization.OrganizationID, error) {
+	if msg == nil {
+		return "", ErrMissingOrganizationHeader
+	}
 	for _, h := range msg.Headers {
 		if h.Key == organization.OrgIDKey {
 			return organization.NewOrganizationID(string(h.Value))
@@ -266,6 +269,9 @@ func ExtractOrganizationHeader(msg *kafka.Message) (organization.OrganizationID,
 // 4. Calls the handler with organization context and configured timeout
 //
 // Returns an error if header extraction, deserialization, or handler execution fails.
+// Note: Errors returned here bubble up through processMessageWithRetry, which handles
+// DLQ routing after exhausting retries. Messages with missing/invalid organization
+// headers will eventually be sent to DLQ if configured.
 func (c *ProtoConsumer) processMessage(kafkaMsg *kafka.Message) error {
 	// Extract organization header
 	orgID, err := ExtractOrganizationHeader(kafkaMsg)

--- a/shared/platform/kafka/consumer.go
+++ b/shared/platform/kafka/consumer.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/meridianhub/meridian/shared/platform/organization"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -91,6 +92,8 @@ var (
 	ErrNilHandler = errors.New("message handler cannot be nil")
 	// ErrEmptyTopics is returned when topics list is empty.
 	ErrEmptyTopics = errors.New("topics cannot be empty")
+	// ErrMissingOrganizationHeader is returned when the x-org-id header is missing from a Kafka message.
+	ErrMissingOrganizationHeader = errors.New("missing x-org-id header")
 )
 
 // NewProtoConsumer creates a new Kafka consumer for protobuf messages.
@@ -239,14 +242,37 @@ func (c *ProtoConsumer) Subscribe(topics []string) error {
 	}
 }
 
+// ExtractOrganizationHeader extracts and validates the organization ID from a Kafka message header.
+// It looks for the x-org-id header and validates the organization ID format.
+//
+// Returns:
+// - The organization ID if the header is present and valid
+// - ErrMissingOrganizationHeader if the header is not present
+// - organization.ErrInvalidOrganizationID if the header value is invalid
+func ExtractOrganizationHeader(msg *kafka.Message) (organization.OrganizationID, error) {
+	for _, h := range msg.Headers {
+		if h.Key == organization.OrgIDKey {
+			return organization.NewOrganizationID(string(h.Value))
+		}
+	}
+	return "", ErrMissingOrganizationHeader
+}
+
 // processMessage deserializes and handles a Kafka message.
 // This is an internal method that:
-// 1. Creates a new protobuf message instance using the factory
-// 2. Deserializes the Kafka message value into the proto message
-// 3. Calls the handler with configured timeout context
+// 1. Extracts organization ID from Kafka header
+// 2. Creates a new protobuf message instance using the factory
+// 3. Deserializes the Kafka message value into the proto message
+// 4. Calls the handler with organization context and configured timeout
 //
-// Returns an error if deserialization or handler execution fails.
+// Returns an error if header extraction, deserialization, or handler execution fails.
 func (c *ProtoConsumer) processMessage(kafkaMsg *kafka.Message) error {
+	// Extract organization header
+	orgID, err := ExtractOrganizationHeader(kafkaMsg)
+	if err != nil {
+		return fmt.Errorf("failed to extract organization header: %w", err)
+	}
+
 	// Create new proto message instance
 	protoMsg := c.msgFactory()
 
@@ -255,9 +281,12 @@ func (c *ProtoConsumer) processMessage(kafkaMsg *kafka.Message) error {
 		return fmt.Errorf("failed to unmarshal protobuf message: %w", err)
 	}
 
-	// Call handler with configured timeout
+	// Call handler with organization context and configured timeout
 	ctx, cancel := context.WithTimeout(c.ctx, c.handlerTimeout)
 	defer cancel()
+
+	// Inject organization context
+	ctx = organization.WithOrganization(ctx, orgID)
 
 	if err := c.handler(ctx, kafkaMsg.Key, protoMsg); err != nil {
 		return fmt.Errorf("handler error: %w", err)

--- a/shared/platform/kafka/consumer_test.go
+++ b/shared/platform/kafka/consumer_test.go
@@ -273,4 +273,14 @@ func TestExtractOrganizationHeader(t *testing.T) {
 			t.Errorf("ExtractOrganizationHeader() orgID = %q, want empty", orgID)
 		}
 	})
+
+	t.Run("nil message", func(t *testing.T) {
+		orgID, err := ExtractOrganizationHeader(nil)
+		if !errors.Is(err, ErrMissingOrganizationHeader) {
+			t.Errorf("ExtractOrganizationHeader() error = %v, want ErrMissingOrganizationHeader", err)
+		}
+		if orgID != "" {
+			t.Errorf("ExtractOrganizationHeader() orgID = %q, want empty", orgID)
+		}
+	})
 }

--- a/shared/platform/kafka/consumer_test.go
+++ b/shared/platform/kafka/consumer_test.go
@@ -2,8 +2,11 @@ package kafka
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/meridianhub/meridian/shared/platform/organization"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -166,4 +169,108 @@ func TestProtoConsumer_StopAndClose(t *testing.T) {
 	if err != nil {
 		t.Errorf("Close() error = %v", err)
 	}
+}
+
+func TestExtractOrganizationHeader(t *testing.T) {
+	topic := "test-topic"
+
+	t.Run("valid organization header", func(t *testing.T) {
+		msg := &kafka.Message{
+			TopicPartition: kafka.TopicPartition{Topic: &topic},
+			Headers: []kafka.Header{
+				{Key: organization.OrgIDKey, Value: []byte("acme_bank")},
+			},
+		}
+
+		orgID, err := ExtractOrganizationHeader(msg)
+		if err != nil {
+			t.Errorf("ExtractOrganizationHeader() unexpected error: %v", err)
+		}
+		if orgID.String() != "acme_bank" {
+			t.Errorf("ExtractOrganizationHeader() = %q, want %q", orgID.String(), "acme_bank")
+		}
+	})
+
+	t.Run("missing organization header", func(t *testing.T) {
+		msg := &kafka.Message{
+			TopicPartition: kafka.TopicPartition{Topic: &topic},
+			Headers:        []kafka.Header{},
+		}
+
+		orgID, err := ExtractOrganizationHeader(msg)
+		if !errors.Is(err, ErrMissingOrganizationHeader) {
+			t.Errorf("ExtractOrganizationHeader() error = %v, want ErrMissingOrganizationHeader", err)
+		}
+		if orgID != "" {
+			t.Errorf("ExtractOrganizationHeader() orgID = %q, want empty", orgID)
+		}
+	})
+
+	t.Run("invalid organization header format", func(t *testing.T) {
+		msg := &kafka.Message{
+			TopicPartition: kafka.TopicPartition{Topic: &topic},
+			Headers: []kafka.Header{
+				{Key: organization.OrgIDKey, Value: []byte("invalid-org-id!")},
+			},
+		}
+
+		orgID, err := ExtractOrganizationHeader(msg)
+		if !errors.Is(err, organization.ErrInvalidOrganizationID) {
+			t.Errorf("ExtractOrganizationHeader() error = %v, want ErrInvalidOrganizationID", err)
+		}
+		if orgID != "" {
+			t.Errorf("ExtractOrganizationHeader() orgID = %q, want empty", orgID)
+		}
+	})
+
+	t.Run("organization header with other headers", func(t *testing.T) {
+		msg := &kafka.Message{
+			TopicPartition: kafka.TopicPartition{Topic: &topic},
+			Headers: []kafka.Header{
+				{Key: "correlation-id", Value: []byte("12345")},
+				{Key: organization.OrgIDKey, Value: []byte("motive_financial")},
+				{Key: "trace-id", Value: []byte("abcdef")},
+			},
+		}
+
+		orgID, err := ExtractOrganizationHeader(msg)
+		if err != nil {
+			t.Errorf("ExtractOrganizationHeader() unexpected error: %v", err)
+		}
+		if orgID.String() != "motive_financial" {
+			t.Errorf("ExtractOrganizationHeader() = %q, want %q", orgID.String(), "motive_financial")
+		}
+	})
+
+	t.Run("nil headers", func(t *testing.T) {
+		msg := &kafka.Message{
+			TopicPartition: kafka.TopicPartition{Topic: &topic},
+			Headers:        nil,
+		}
+
+		orgID, err := ExtractOrganizationHeader(msg)
+		if !errors.Is(err, ErrMissingOrganizationHeader) {
+			t.Errorf("ExtractOrganizationHeader() error = %v, want ErrMissingOrganizationHeader", err)
+		}
+		if orgID != "" {
+			t.Errorf("ExtractOrganizationHeader() orgID = %q, want empty", orgID)
+		}
+	})
+
+	t.Run("empty organization header value", func(t *testing.T) {
+		msg := &kafka.Message{
+			TopicPartition: kafka.TopicPartition{Topic: &topic},
+			Headers: []kafka.Header{
+				{Key: organization.OrgIDKey, Value: []byte("")},
+			},
+		}
+
+		orgID, err := ExtractOrganizationHeader(msg)
+		if !errors.Is(err, organization.ErrInvalidOrganizationID) {
+			t.Errorf("ExtractOrganizationHeader() error = %v, want ErrInvalidOrganizationID", err)
+		}
+		if orgID != "" {
+			t.Errorf("ExtractOrganizationHeader() orgID = %q, want empty", orgID)
+		}
+	})
 }

--- a/shared/platform/kafka/producer.go
+++ b/shared/platform/kafka/producer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
+	"github.com/meridianhub/meridian/shared/platform/organization"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -167,4 +168,78 @@ func (p *ProtoProducer) Flush(timeoutMs int) int {
 // messages - call Flush() first if needed.
 func (p *ProtoProducer) Close() {
 	p.producer.Close()
+}
+
+// PublishWithOrganization sends a protobuf message with organization context to the specified Kafka topic.
+// The organization ID is extracted from the context and injected as a Kafka header (x-org-id).
+// This ensures organization isolation for multi-tenant event processing.
+//
+// The key is used for partitioning - messages with the same key go to the same partition.
+// This method blocks until the message is confirmed by the Kafka broker or the context is cancelled.
+//
+// Parameters:
+// - ctx: Context containing organization ID (via organization.WithOrganization) for cancellation and timeout
+// - topic: Target Kafka topic name (must not be empty)
+// - key: Partition key as string (empty key will be null in Kafka)
+// - msg: Protocol Buffer message to serialize and send (must not be nil)
+//
+// Panics if the organization context is missing - this is a fail-fast strategy to prevent
+// events without organization attribution from being published.
+//
+// Returns an error if:
+// - topic is empty
+// - msg is nil
+// - protobuf marshaling fails
+// - message production fails
+// - delivery confirmation indicates failure
+// - context is cancelled before delivery confirmation
+func (p *ProtoProducer) PublishWithOrganization(ctx context.Context, topic string, key string, msg proto.Message) error {
+	// Extract organization from context - panic if missing (fail-fast)
+	orgID := organization.MustFromContext(ctx)
+
+	if topic == "" {
+		return ErrEmptyTopic
+	}
+	if msg == nil {
+		return ErrNilMessage
+	}
+
+	// Serialize protobuf message to bytes
+	data, err := proto.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal protobuf message: %w", err)
+	}
+
+	// Create Kafka message with organization header
+	kafkaMsg := &kafka.Message{
+		TopicPartition: kafka.TopicPartition{Topic: &topic, Partition: kafka.PartitionAny},
+		Key:            []byte(key),
+		Value:          data,
+		Headers: []kafka.Header{
+			{Key: organization.OrgIDKey, Value: []byte(orgID.String())},
+		},
+		Timestamp: time.Now(),
+	}
+
+	// Publish with delivery report channel
+	deliveryChan := make(chan kafka.Event, 1)
+	err = p.producer.Produce(kafkaMsg, deliveryChan)
+	if err != nil {
+		return fmt.Errorf("failed to produce message: %w", err)
+	}
+
+	// Wait for delivery confirmation or context cancellation
+	select {
+	case e := <-deliveryChan:
+		m, ok := e.(*kafka.Message)
+		if !ok {
+			return fmt.Errorf("%w: %T", ErrUnexpectedEvent, e)
+		}
+		if m.TopicPartition.Error != nil {
+			return fmt.Errorf("delivery failed: %w", m.TopicPartition.Error)
+		}
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("publish cancelled: %w", ctx.Err())
+	}
 }

--- a/shared/platform/kafka/producer_test.go
+++ b/shared/platform/kafka/producer_test.go
@@ -2,9 +2,11 @@ package kafka
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/meridianhub/meridian/shared/platform/organization"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -142,4 +144,63 @@ func TestProtoProducer_Close(t *testing.T) {
 
 	// Close should not panic
 	producer.Close()
+}
+
+func TestProtoProducer_PublishWithOrganization(t *testing.T) {
+	producer, err := NewProtoProducer(ProducerConfig{
+		BootstrapServers: "localhost:9092",
+		ClientID:         "test-producer",
+	})
+	if err != nil {
+		t.Skip("Kafka not available, skipping integration test")
+	}
+	defer producer.Close()
+
+	t.Run("empty topic returns error", func(t *testing.T) {
+		orgID := organization.MustNewOrganizationID("acme_bank")
+		ctx := organization.WithOrganization(context.Background(), orgID)
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		err := producer.PublishWithOrganization(ctx, "", "test-key", timestamppb.Now())
+		if !errors.Is(err, ErrEmptyTopic) {
+			t.Errorf("PublishWithOrganization() error = %v, want ErrEmptyTopic", err)
+		}
+	})
+
+	t.Run("nil message returns error", func(t *testing.T) {
+		orgID := organization.MustNewOrganizationID("acme_bank")
+		ctx := organization.WithOrganization(context.Background(), orgID)
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		err := producer.PublishWithOrganization(ctx, "test-topic", "test-key", nil)
+		if !errors.Is(err, ErrNilMessage) {
+			t.Errorf("PublishWithOrganization() error = %v, want ErrNilMessage", err)
+		}
+	})
+}
+
+func TestProtoProducer_PublishWithOrganization_MissingContext(t *testing.T) {
+	producer, err := NewProtoProducer(ProducerConfig{
+		BootstrapServers: "localhost:9092",
+		ClientID:         "test-producer",
+	})
+	if err != nil {
+		t.Skip("Kafka not available, skipping integration test")
+	}
+	defer producer.Close()
+
+	// Test that missing organization context causes panic (fail-fast)
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("PublishWithOrganization did not panic for context without organization")
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// This should panic because organization context is missing
+	_ = producer.PublishWithOrganization(ctx, "test-topic", "test-key", timestamppb.Now())
 }


### PR DESCRIPTION
## Summary

- Adds organization-aware Kafka producer and consumer middleware for multi-tenant event isolation
- Uses the universal `x-org-id` header key established in PR #247
- Messages without valid organization headers route to DLQ via existing retry infrastructure

## Changes Made

### Producer (`shared/platform/kafka/producer.go`)
- `PublishWithOrganization(ctx, topic, key, msg)` - extracts organization from context, injects as `x-org-id` header
- Fail-fast (panic) if organization context missing - prevents events without attribution

### Consumer (`shared/platform/kafka/consumer.go`)
- `ExtractOrganizationHeader(msg)` - extracts and validates organization ID from Kafka header
- `processMessage()` now injects organization context before calling handler
- `ErrMissingOrganizationHeader` sentinel error for missing headers

## Test plan

- [x] `TestExtractOrganizationHeader` - 6 test cases covering valid/invalid/missing headers
- [x] `TestProtoProducer_PublishWithOrganization` - empty topic and nil message errors
- [x] `TestProtoProducer_PublishWithOrganization_MissingContext` - verifies panic on missing context
- [x] golangci-lint passes
- [x] Pre-commit hooks pass