### PR TITLE
feat(auth): integrate organization context in gRPC auth interceptor

### DIFF
--- a/shared/platform/auth/grpc_interceptor.go
+++ b/shared/platform/auth/grpc_interceptor.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
+	"github.com/meridianhub/meridian/shared/platform/organization"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -33,6 +37,10 @@ const (
 	ScopesContextKey contextKey = "scopes"
 	// ClaimsContextKey is the context key for full claims
 	ClaimsContextKey contextKey = "claims"
+
+	// MultiOrgModeEnvVar is the environment variable that enables multi-organization mode.
+	// When set to "true", organization claims are required in JWT tokens.
+	MultiOrgModeEnvVar = "MULTI_ORG_MODE"
 )
 
 // Interceptor provides gRPC interceptors for JWT authentication
@@ -153,6 +161,23 @@ func (a *Interceptor) authenticate(ctx context.Context) (context.Context, error)
 	ctx = context.WithValue(ctx, ScopesContextKey, claims.Scopes)
 	ctx = context.WithValue(ctx, ClaimsContextKey, claims)
 
+	// Organization context injection
+	multiOrgMode := os.Getenv(MultiOrgModeEnvVar) == "true"
+	if multiOrgMode {
+		orgID, err := claims.GetOrganizationID()
+		if err != nil {
+			if errors.Is(err, ErrOrganizationClaimMissing) {
+				return nil, status.Error(codes.Unauthenticated, "organization_id claim required")
+			}
+			return nil, status.Error(codes.InvalidArgument, "invalid organization_id format")
+		}
+		ctx = organization.WithOrganization(ctx, orgID)
+
+		// Add organization to OpenTelemetry span attributes
+		span := trace.SpanFromContext(ctx)
+		span.SetAttributes(attribute.String("organization.id", orgID.String()))
+	}
+
 	return ctx, nil
 }
 
@@ -214,6 +239,12 @@ func GetScopesFromContext(ctx context.Context) ([]string, bool) {
 func GetClaimsFromContext(ctx context.Context) (*Claims, bool) {
 	claims, ok := ctx.Value(ClaimsContextKey).(*Claims)
 	return claims, ok
+}
+
+// IsMultiOrgModeEnabled returns true if multi-organization mode is enabled.
+// Multi-org mode requires organization claims in JWT tokens.
+func IsMultiOrgModeEnabled() bool {
+	return os.Getenv(MultiOrgModeEnvVar) == "true"
 }
 
 // RequireRole creates an interceptor that requires specific roles

--- a/shared/platform/auth/grpc_interceptor_test.go
+++ b/shared/platform/auth/grpc_interceptor_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/meridianhub/meridian/shared/platform/organization"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -606,5 +607,225 @@ func TestRequireScope(t *testing.T) {
 		st, ok := status.FromError(err)
 		assert.True(t, ok)
 		assert.Equal(t, codes.Internal, st.Code())
+	})
+}
+
+func TestMultiOrgMode(t *testing.T) {
+	privateKey, publicKey, err := generateTestRSAKeys()
+	require.NoError(t, err)
+
+	validator, err := NewJWTValidator(publicKey)
+	require.NoError(t, err)
+
+	t.Run("multi-org mode enabled injects organization into context", func(t *testing.T) {
+		t.Setenv(MultiOrgModeEnvVar, "true")
+
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token with organization claim
+		claims := &Claims{
+			UserID:         "user-123",
+			OrganizationID: "acme_bank",
+			Roles:          []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		resp, err := interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify organization was injected into context
+		resultCtx := resp.(context.Context)
+		orgID, ok := organization.FromContext(resultCtx)
+		assert.True(t, ok)
+		assert.Equal(t, organization.OrganizationID("acme_bank"), orgID)
+	})
+
+	t.Run("multi-org mode enabled rejects token without organization claim", func(t *testing.T) {
+		t.Setenv(MultiOrgModeEnvVar, "true")
+
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token without organization claim
+		claims := &Claims{
+			UserID: "user-123",
+			Roles:  []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		resp, err := interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+		assert.Contains(t, st.Message(), "organization_id claim required")
+	})
+
+	t.Run("multi-org mode enabled rejects token with invalid organization format", func(t *testing.T) {
+		t.Setenv(MultiOrgModeEnvVar, "true")
+
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token with invalid organization format (spaces not allowed)
+		claims := &Claims{
+			UserID:         "user-123",
+			OrganizationID: "invalid org!",
+			Roles:          []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		resp, err := interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "invalid organization_id format")
+	})
+
+	t.Run("single-org mode (default) allows token without organization claim", func(t *testing.T) {
+		// Ensure MULTI_ORG_MODE is not set
+		t.Setenv(MultiOrgModeEnvVar, "false")
+
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token without organization claim
+		claims := &Claims{
+			UserID: "user-123",
+			Roles:  []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		resp, err := interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Organization should not be in context
+		resultCtx := resp.(context.Context)
+		_, ok := organization.FromContext(resultCtx)
+		assert.False(t, ok)
+	})
+
+	t.Run("single-org mode does not inject organization even if present in token", func(t *testing.T) {
+		// Ensure MULTI_ORG_MODE is not set
+		t.Setenv(MultiOrgModeEnvVar, "")
+
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token with organization claim
+		claims := &Claims{
+			UserID:         "user-123",
+			OrganizationID: "acme_bank",
+			Roles:          []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		resp, err := interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Organization should not be in context in single-org mode
+		resultCtx := resp.(context.Context)
+		_, ok := organization.FromContext(resultCtx)
+		assert.False(t, ok)
+	})
+}
+
+func TestIsMultiOrgModeEnabled(t *testing.T) {
+	t.Run("returns true when MULTI_ORG_MODE is true", func(t *testing.T) {
+		t.Setenv(MultiOrgModeEnvVar, "true")
+		assert.True(t, IsMultiOrgModeEnabled())
+	})
+
+	t.Run("returns false when MULTI_ORG_MODE is false", func(t *testing.T) {
+		t.Setenv(MultiOrgModeEnvVar, "false")
+		assert.False(t, IsMultiOrgModeEnabled())
+	})
+
+	t.Run("returns false when MULTI_ORG_MODE is empty", func(t *testing.T) {
+		t.Setenv(MultiOrgModeEnvVar, "")
+		assert.False(t, IsMultiOrgModeEnabled())
+	})
+
+	t.Run("returns false when MULTI_ORG_MODE is not set", func(t *testing.T) {
+		// Unset the env var by setting to empty (t.Setenv doesn't support unsetting)
+		t.Setenv(MultiOrgModeEnvVar, "")
+		assert.False(t, IsMultiOrgModeEnabled())
 	})
 }


### PR DESCRIPTION
## Summary

- Integrate organization ID extraction from JWT claims (`x-org-id`) into the gRPC authentication interceptor
- Add `MULTI_ORG_MODE` environment variable for backward compatibility (single-org vs multi-org operation)
- Add organization ID to OpenTelemetry span attributes for distributed tracing visibility

## Changes Made

- **`shared/platform/auth/grpc_interceptor.go`**:
  - Added organization context injection after JWT validation
  - Added `MultiOrgModeEnvVar` constant (`MULTI_ORG_MODE`)
  - Added `IsMultiOrgModeEnabled()` helper function
  - Multi-org mode extracts `x-org-id` claim and injects via `organization.WithOrganization(ctx, orgID)`
  - Adds `organization.id` attribute to OpenTelemetry spans

- **`shared/platform/auth/grpc_interceptor_test.go`**:
  - Added `TestMultiOrgMode` with 5 test cases covering:
    - Organization injection when multi-org enabled
    - Rejection of tokens without organization claim
    - Rejection of invalid organization format
    - Single-org mode allows missing organization claim
    - Single-org mode doesn't inject organization even if present
  - Added `TestIsMultiOrgModeEnabled` tests

## Technical Details

The interceptor behavior depends on `MULTI_ORG_MODE` environment variable:

| Mode | Behavior |
|------|----------|
| `MULTI_ORG_MODE=true` | Organization claim required, injected into context, added to traces |
| `MULTI_ORG_MODE=false` or unset | Organization extraction skipped (backward compatible) |

Error handling:
- Missing organization claim → `codes.Unauthenticated` with "organization_id claim required"
- Invalid organization format → `codes.InvalidArgument` with "invalid organization_id format"

## Test Plan

- [x] Unit tests for multi-org mode organization injection
- [x] Unit tests for rejection of missing/invalid organization claims
- [x] Unit tests for single-org mode backward compatibility
- [x] Unit tests for `IsMultiOrgModeEnabled()` helper
- [x] All existing auth tests continue to pass

## Risk Assessment

**Low risk**: This is additive functionality behind a feature flag. Single-org mode (default) preserves existing behavior.

## Related

- Task: Task Master #4 (8-multi-tenancy tag)
- Depends on: #247 (organization package), #249 (PostgreSQL schema routing)