### PR TITLE
feat(party): add GORM persistence layer with repository pattern

### DIFF
--- a/services/party/adapters/persistence/party_entity.go
+++ b/services/party/adapters/persistence/party_entity.go
@@ -1,0 +1,39 @@
+// Package persistence provides database persistence for the party domain
+package persistence
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// PartyEntity represents the database persistence model for parties.
+// This entity MUST match the schema defined in migrations/party/*.sql
+// The mapping between domain model and entity is handled by toEntity/toDomain functions.
+type PartyEntity struct {
+	// Primary key
+	ID uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+
+	// Business fields
+	PartyType             string  `gorm:"column:party_type;type:varchar(20);not null"`
+	LegalName             string  `gorm:"column:legal_name;type:varchar(255);not null"`
+	DisplayName           *string `gorm:"column:display_name;type:varchar(255)"`
+	Status                string  `gorm:"column:status;type:varchar(20);not null;default:'ACTIVE'"`
+	ExternalReference     *string `gorm:"column:external_reference;type:varchar(50);uniqueIndex:idx_party_external_ref,where:external_reference IS NOT NULL"`
+	ExternalReferenceType *string `gorm:"column:external_reference_type;type:varchar(30)"`
+
+	// Optimistic locking
+	Version int64 `gorm:"column:version;not null;default:1"`
+
+	// Audit fields
+	CreatedAt time.Time  `gorm:"column:created_at;not null;default:now()"`
+	CreatedBy string     `gorm:"column:created_by;type:varchar(100);not null"`
+	UpdatedAt time.Time  `gorm:"column:updated_at;not null;default:now()"`
+	UpdatedBy string     `gorm:"column:updated_by;type:varchar(100);not null"`
+	DeletedAt *time.Time `gorm:"column:deleted_at;index"`
+}
+
+// TableName overrides the default table name with schema prefix
+func (PartyEntity) TableName() string {
+	return "party.parties"
+}

--- a/services/party/adapters/persistence/repository.go
+++ b/services/party/adapters/persistence/repository.go
@@ -1,0 +1,267 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/meridianhub/meridian/shared/platform/audit"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Repository errors
+var (
+	ErrPartyNotFound   = errors.New("party not found")
+	ErrPartyExists     = errors.New("party already exists")
+	ErrVersionConflict = errors.New("version conflict: party was modified by another transaction")
+)
+
+// Repository provides persistence operations for parties
+type Repository struct {
+	db *gorm.DB
+}
+
+// NewRepository creates a new party repository
+func NewRepository(db *gorm.DB) *Repository {
+	return &Repository{db: db}
+}
+
+// DB returns the underlying database connection for transaction support.
+// Use this to wrap multiple repository operations in a single transaction.
+func (r *Repository) DB() *gorm.DB {
+	return r.db
+}
+
+// WithTx returns a new Repository that uses the provided transaction.
+// This enables multiple repository operations within a single transaction.
+func (r *Repository) WithTx(tx *gorm.DB) *Repository {
+	return &Repository{db: tx}
+}
+
+// Save creates or updates a party with optimistic locking.
+// The context is used to extract audit information (user ID) for the created_by/updated_by fields.
+//
+// For updates, the version in the domain model must match the version in the database.
+// If another transaction has modified the record (incremented the version), this save
+// will fail with ErrVersionConflict. The caller should reload the entity and retry.
+func (r *Repository) Save(ctx context.Context, party *domain.Party) error {
+	entity := toEntity(ctx, party)
+
+	// Check if exists by ID
+	var existing PartyEntity
+	result := r.db.WithContext(ctx).Where("id = ? AND deleted_at IS NULL", entity.ID).First(&existing)
+
+	if result.Error == nil {
+		// Update existing with optimistic locking
+		entity.CreatedAt = existing.CreatedAt
+		entity.CreatedBy = existing.CreatedBy
+
+		// The domain model auto-increments version on mutation, so entity.Version
+		// is already the target version. We check that DB still has the previous version.
+		// Example: loaded party with version=1, mutated (now version=2), we check DB has version=1.
+		expectedDBVersion := entity.Version - 1
+
+		// Optimistic locking: only update if version matches expected
+		updateResult := r.db.WithContext(ctx).Model(&PartyEntity{}).
+			Where("id = ? AND version = ? AND deleted_at IS NULL", entity.ID, expectedDBVersion).
+			Updates(map[string]interface{}{
+				"party_type":              entity.PartyType,
+				"legal_name":              entity.LegalName,
+				"display_name":            entity.DisplayName,
+				"status":                  entity.Status,
+				"external_reference":      entity.ExternalReference,
+				"external_reference_type": entity.ExternalReferenceType,
+				"version":                 entity.Version,
+				"updated_at":              entity.UpdatedAt,
+				"updated_by":              entity.UpdatedBy,
+			})
+
+		if updateResult.Error != nil {
+			return updateResult.Error
+		}
+
+		// If no rows were affected, the version didn't match (concurrent modification)
+		if updateResult.RowsAffected == 0 {
+			return ErrVersionConflict
+		}
+
+		return nil
+	}
+
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		// Create new - version starts at 1 (set by toEntity)
+		if err := r.db.WithContext(ctx).Create(&entity).Error; err != nil {
+			// Handle race condition: another transaction created the same external reference
+			if isDuplicateKeyError(err) {
+				return ErrPartyExists
+			}
+			return err
+		}
+		return nil
+	}
+
+	return result.Error
+}
+
+// FindByID retrieves a party by its UUID
+func (r *Repository) FindByID(partyID uuid.UUID) (*domain.Party, error) {
+	var entity PartyEntity
+	result := r.db.Where("id = ? AND deleted_at IS NULL", partyID).First(&entity)
+
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, ErrPartyNotFound
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return toDomain(&entity), nil
+}
+
+// FindByIDForUpdate retrieves a party by its UUID with a pessimistic lock.
+// Use this within a transaction when you need to prevent concurrent modifications.
+func (r *Repository) FindByIDForUpdate(partyID uuid.UUID) (*domain.Party, error) {
+	var entity PartyEntity
+	result := r.db.Clauses(clause.Locking{Strength: "UPDATE"}).
+		Where("id = ? AND deleted_at IS NULL", partyID).
+		First(&entity)
+
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, ErrPartyNotFound
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return toDomain(&entity), nil
+}
+
+// FindByExternalReference retrieves a party by its external reference and type
+func (r *Repository) FindByExternalReference(ref, refType string) (*domain.Party, error) {
+	var entity PartyEntity
+	result := r.db.Where("external_reference = ? AND external_reference_type = ? AND deleted_at IS NULL", ref, refType).First(&entity)
+
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, ErrPartyNotFound
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return toDomain(&entity), nil
+}
+
+// ExistsByID checks if a party exists by its UUID.
+// This is a lightweight check useful for validation without loading the full entity.
+func (r *Repository) ExistsByID(partyID uuid.UUID) (bool, error) {
+	var count int64
+	result := r.db.Model(&PartyEntity{}).
+		Where("id = ? AND deleted_at IS NULL", partyID).
+		Count(&count)
+
+	if result.Error != nil {
+		return false, result.Error
+	}
+
+	return count > 0, nil
+}
+
+// Delete soft deletes a party
+func (r *Repository) Delete(partyID uuid.UUID) error {
+	return r.db.Model(&PartyEntity{}).
+		Where("id = ?", partyID).
+		Update("deleted_at", time.Now()).Error
+}
+
+// Ping checks database connectivity without triggering record-not-found logging.
+// This is used by health checks to verify the database is reachable.
+func (r *Repository) Ping() error {
+	var result int
+	return r.db.Raw("SELECT 1").Scan(&result).Error
+}
+
+// toEntity converts domain model to database entity
+func toEntity(ctx context.Context, party *domain.Party) *PartyEntity {
+	auditUser := audit.GetUserFromContext(ctx)
+
+	entity := &PartyEntity{
+		ID:        party.ID(),
+		PartyType: string(party.PartyType()),
+		LegalName: party.LegalName(),
+		Status:    string(party.Status()),
+		Version:   party.Version(),
+		CreatedAt: party.CreatedAt(),
+		UpdatedAt: party.UpdatedAt(),
+		CreatedBy: auditUser,
+		UpdatedBy: auditUser,
+	}
+
+	// Handle optional display name
+	if displayName := party.DisplayName(); displayName != "" {
+		entity.DisplayName = &displayName
+	}
+
+	// Handle optional external reference
+	if extRef := party.ExternalReference(); extRef != "" {
+		entity.ExternalReference = &extRef
+		extRefType := string(party.ExternalReferenceType())
+		entity.ExternalReferenceType = &extRefType
+	}
+
+	return entity
+}
+
+// toDomain converts database entity to domain model
+func toDomain(entity *PartyEntity) *domain.Party {
+	// Handle optional fields
+	displayName := ""
+	if entity.DisplayName != nil {
+		displayName = *entity.DisplayName
+	}
+
+	externalRef := ""
+	if entity.ExternalReference != nil {
+		externalRef = *entity.ExternalReference
+	}
+
+	var externalRefType domain.ExternalReferenceType
+	if entity.ExternalReferenceType != nil {
+		externalRefType = domain.ExternalReferenceType(*entity.ExternalReferenceType)
+	}
+
+	return domain.ReconstructParty(
+		entity.ID,
+		domain.PartyType(entity.PartyType),
+		entity.LegalName,
+		displayName,
+		domain.PartyStatus(entity.Status),
+		externalRef,
+		externalRefType,
+		entity.CreatedAt,
+		entity.UpdatedAt,
+		entity.Version,
+	)
+}
+
+// isDuplicateKeyError checks if the error is a PostgreSQL unique constraint violation.
+// This handles the race condition where two concurrent creates attempt to insert
+// the same external reference.
+func isDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// PostgreSQL unique violation error code is 23505
+	// GORM wraps this, so we check the error message
+	errStr := err.Error()
+	return errors.Is(err, gorm.ErrDuplicatedKey) ||
+		strings.Contains(errStr, "23505") ||
+		strings.Contains(errStr, "duplicate key") ||
+		strings.Contains(errStr, "unique constraint")
+}

--- a/services/party/adapters/persistence/repository_test.go
+++ b/services/party/adapters/persistence/repository_test.go
@@ -1,0 +1,443 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) (*gorm.DB, func()) {
+	t.Helper()
+	return testdb.SetupPostgres(t, []interface{}{&PartyEntity{}})
+}
+
+func TestSaveNewParty(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "John Doe")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	// Verify party was saved
+	retrieved, err := repo.FindByID(party.ID())
+	require.NoError(t, err)
+	assert.Equal(t, party.ID(), retrieved.ID())
+	assert.Equal(t, "John Doe", retrieved.LegalName())
+	assert.Equal(t, domain.PartyTypePerson, retrieved.PartyType())
+	assert.Equal(t, domain.PartyStatusActive, retrieved.Status())
+}
+
+func TestSaveNewParty_InitialVersion(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	party, err := domain.NewParty(domain.PartyTypeOrganization, "Acme Corp")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	// Verify newly created party has version 1
+	retrieved, err := repo.FindByID(party.ID())
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), retrieved.Version(), "New party should have version 1")
+}
+
+func TestSaveUpdateExisting(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "John Doe")
+	require.NoError(t, err)
+
+	// Save initial
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	// Modify and save again
+	err = party.SetDisplayName("Johnny D")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	// Verify display name was updated
+	retrieved, err := repo.FindByID(party.ID())
+	require.NoError(t, err)
+	assert.Equal(t, "Johnny D", retrieved.DisplayName())
+
+	// Version should be incremented after update
+	assert.Equal(t, int64(2), retrieved.Version())
+}
+
+func TestFindByIDNotFound(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	_, err := repo.FindByID(uuid.New())
+	assert.True(t, errors.Is(err, ErrPartyNotFound))
+}
+
+func TestFindByExternalReference(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	party, err := domain.NewParty(domain.PartyTypeOrganization, "Acme Corp Ltd")
+	require.NoError(t, err)
+
+	err = party.SetExternalReference("12345678", domain.ExternalReferenceTypeCompaniesHouse)
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	retrieved, err := repo.FindByExternalReference("12345678", string(domain.ExternalReferenceTypeCompaniesHouse))
+	require.NoError(t, err)
+	assert.Equal(t, party.ID(), retrieved.ID())
+	assert.Equal(t, "12345678", retrieved.ExternalReference())
+}
+
+func TestFindByExternalReferenceNotFound(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	_, err := repo.FindByExternalReference("NONEXISTENT", string(domain.ExternalReferenceTypeCompaniesHouse))
+	assert.True(t, errors.Is(err, ErrPartyNotFound))
+}
+
+func TestExistsByID(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "Jane Doe")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	// Existing party
+	exists, err := repo.ExistsByID(party.ID())
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	// Non-existent party
+	exists, err = repo.ExistsByID(uuid.New())
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestDeleteParty(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "To Be Deleted")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	// Delete party
+	err = repo.Delete(party.ID())
+	require.NoError(t, err)
+
+	// Should not be found after soft delete
+	_, err = repo.FindByID(party.ID())
+	assert.True(t, errors.Is(err, ErrPartyNotFound))
+}
+
+func TestOptimisticLocking(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// Create initial party
+	party1, err := domain.NewParty(domain.PartyTypePerson, "John Doe")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, party1)
+	require.NoError(t, err)
+
+	// Load same party in two "transactions"
+	party2, err := repo.FindByID(party1.ID())
+	require.NoError(t, err)
+
+	party3, err := repo.FindByID(party1.ID())
+	require.NoError(t, err)
+
+	// Both should have same version
+	assert.Equal(t, party2.Version(), party3.Version())
+
+	// First transaction modifies and saves successfully
+	err = party2.SetDisplayName("John D")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, party2)
+	require.NoError(t, err)
+
+	// Second transaction tries to save with stale version
+	err = party3.SetDisplayName("Johnny Doe")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, party3)
+	assert.True(t, errors.Is(err, ErrVersionConflict))
+
+	// Verify first transaction's changes persisted
+	final, err := repo.FindByID(party1.ID())
+	require.NoError(t, err)
+	assert.Equal(t, "John D", final.DisplayName())
+
+	// Version should be incremented
+	assert.Equal(t, int64(2), final.Version())
+}
+
+func TestExternalReferenceUniqueness(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// Create first party with external reference
+	party1, err := domain.NewParty(domain.PartyTypeOrganization, "Company A")
+	require.NoError(t, err)
+
+	err = party1.SetExternalReference("12345678", domain.ExternalReferenceTypeCompaniesHouse)
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, party1)
+	require.NoError(t, err)
+
+	// Create second party with same external reference - should fail
+	// Test at the database level by creating directly with entity
+	entity := &PartyEntity{
+		ID:                    uuid.New(),
+		PartyType:             string(domain.PartyTypeOrganization),
+		LegalName:             "Company B",
+		Status:                string(domain.PartyStatusActive),
+		ExternalReference:     stringPtr("12345678"),
+		ExternalReferenceType: stringPtr(string(domain.ExternalReferenceTypeCompaniesHouse)),
+		Version:               1,
+		CreatedBy:             "system",
+		UpdatedBy:             "system",
+	}
+
+	err = db.Create(entity).Error
+	assert.Error(t, err, "Should fail with duplicate external reference")
+	assert.True(t, isDuplicateKeyError(err), "Should be a duplicate key error")
+}
+
+func TestSoftDeleteVerification(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "Soft Delete Test")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	// Delete party
+	err = repo.Delete(party.ID())
+	require.NoError(t, err)
+
+	// ExistsByID should return false for soft-deleted party
+	exists, err := repo.ExistsByID(party.ID())
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// Direct database query should still find the record with deleted_at set
+	var entity PartyEntity
+	err = db.Unscoped().Where("id = ?", party.ID()).First(&entity).Error
+	require.NoError(t, err)
+	assert.NotNil(t, entity.DeletedAt, "deleted_at should be set")
+}
+
+// Mapper unit tests
+
+func TestToDomain_NullableFields(t *testing.T) {
+	entity := &PartyEntity{
+		ID:                    uuid.New(),
+		PartyType:             string(domain.PartyTypePerson),
+		LegalName:             "Test Person",
+		DisplayName:           nil,
+		Status:                string(domain.PartyStatusActive),
+		ExternalReference:     nil,
+		ExternalReferenceType: nil,
+		Version:               1,
+		CreatedBy:             "system",
+		UpdatedBy:             "system",
+	}
+
+	party := toDomain(entity)
+
+	assert.Equal(t, entity.ID, party.ID())
+	assert.Equal(t, domain.PartyTypePerson, party.PartyType())
+	assert.Equal(t, "Test Person", party.LegalName())
+	assert.Equal(t, "", party.DisplayName())
+	assert.Equal(t, "", party.ExternalReference())
+}
+
+func TestToDomain_WithOptionalFields(t *testing.T) {
+	displayName := "Test Display"
+	extRef := "12345678"
+	extRefType := string(domain.ExternalReferenceTypeCompaniesHouse)
+
+	entity := &PartyEntity{
+		ID:                    uuid.New(),
+		PartyType:             string(domain.PartyTypeOrganization),
+		LegalName:             "Test Corp",
+		DisplayName:           &displayName,
+		Status:                string(domain.PartyStatusRestricted),
+		ExternalReference:     &extRef,
+		ExternalReferenceType: &extRefType,
+		Version:               5,
+		CreatedBy:             "user-123",
+		UpdatedBy:             "user-456",
+	}
+
+	party := toDomain(entity)
+
+	assert.Equal(t, "Test Display", party.DisplayName())
+	assert.Equal(t, "12345678", party.ExternalReference())
+	assert.Equal(t, domain.ExternalReferenceTypeCompaniesHouse, party.ExternalReferenceType())
+	assert.Equal(t, int64(5), party.Version())
+}
+
+// Audit context tests
+
+func TestSave_PopulatesAuditFieldsFromContext(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "Audit Test")
+	require.NoError(t, err)
+
+	// Create context with authenticated user
+	testUserID := "user-123"
+	ctx := context.WithValue(context.Background(), auth.UserIDContextKey, testUserID)
+
+	// Save new party
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	// Verify audit fields were set from context
+	var entity PartyEntity
+	err = db.Where("id = ?", party.ID()).First(&entity).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, testUserID, entity.CreatedBy, "created_by should be set from context")
+	assert.Equal(t, testUserID, entity.UpdatedBy, "updated_by should be set from context")
+}
+
+func TestSave_UsesSystemWhenNoUserInContext(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "System Test")
+	require.NoError(t, err)
+
+	// Use empty context (no user)
+	ctx := context.Background()
+
+	// Save new party
+	err = repo.Save(ctx, party)
+	require.NoError(t, err)
+
+	// Verify audit fields default to "system"
+	var entity PartyEntity
+	err = db.Where("id = ?", party.ID()).First(&entity).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, "system", entity.CreatedBy, "created_by should default to 'system'")
+	assert.Equal(t, "system", entity.UpdatedBy, "updated_by should default to 'system'")
+}
+
+func TestSave_UpdatePreservesCreatedByButUpdatesUpdatedBy(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "Multi User Test")
+	require.NoError(t, err)
+
+	// Create with user1
+	user1 := "user-creator"
+	ctx1 := context.WithValue(context.Background(), auth.UserIDContextKey, user1)
+	err = repo.Save(ctx1, party)
+	require.NoError(t, err)
+
+	// Update with user2
+	user2 := "user-updater"
+	ctx2 := context.WithValue(context.Background(), auth.UserIDContextKey, user2)
+	err = party.SetDisplayName("Updated Name")
+	require.NoError(t, err)
+
+	err = repo.Save(ctx2, party)
+	require.NoError(t, err)
+
+	// Verify created_by preserved but updated_by changed
+	var entity PartyEntity
+	err = db.Where("id = ?", party.ID()).First(&entity).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, user1, entity.CreatedBy, "created_by should be preserved from original creation")
+	assert.Equal(t, user2, entity.UpdatedBy, "updated_by should reflect the user who made the update")
+}
+
+func TestPing(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	err := repo.Ping()
+	assert.NoError(t, err)
+}
+
+// Helper function for creating string pointers
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
## Summary

- Add GORM persistence layer for Party service following current-account patterns
- Implement PartyEntity with fields matching party.parties schema
- Add Repository with optimistic locking (version checking) for concurrent access safety

## Changes Made

**services/party/adapters/persistence/party_entity.go**
- `PartyEntity` struct with GORM tags for `party.parties` table
- Fields: ID (uuid), PartyType, LegalName, DisplayName (nullable), Status, ExternalReference (nullable with unique index), ExternalReferenceType (nullable), Version, audit fields

**services/party/adapters/persistence/repository.go**
- `Repository` struct with `*gorm.DB`
- `Save()` with optimistic locking - domain model auto-increments version on mutation
- `FindByID()`, `FindByIDForUpdate()` (pessimistic lock)
- `FindByExternalReference()` for Companies House/LEI lookups
- `ExistsByID()` lightweight check for validation
- Soft delete support with `deleted_at` filtering
- `toEntity()`/`toDomain()` mappers handling nullable fields

**services/party/adapters/persistence/repository_test.go**
- Integration tests using Testcontainers PostgreSQL
- Tests: save new, save update, find by ID, find by external reference, exists check, delete, optimistic locking conflict, external reference uniqueness, soft delete verification, mapper edge cases, audit context tests

## Technical Details

The Party domain model differs from CurrentAccount in that it auto-increments version on mutation (e.g., `SetDisplayName()`, `Restrict()`). The repository accounts for this by checking `version - 1` against the database when updating.

## Testing

- All 16 integration tests pass using Testcontainers PostgreSQL
- Pre-commit hooks (gofumpt, golangci-lint) pass

## Related

- Task Master: 8-multi-tenancy task 15
- Builds on: #255 (Party domain model)