### PR TITLE
feat(current-account): add Party gRPC client with resilience patterns

### DIFF
--- a/services/current-account/clients/party_client.go
+++ b/services/current-account/clients/party_client.go
@@ -1,0 +1,230 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// Party validation errors
+var (
+	// ErrPartyNotFound is returned when the requested party does not exist
+	ErrPartyNotFound = errors.New("party not found")
+	// ErrPartyNotActive is returned when the party exists but is not in ACTIVE status
+	ErrPartyNotActive = errors.New("party not active")
+	// ErrPartyTargetRequired is returned when target address is not provided
+	ErrPartyTargetRequired = errors.New("target address is required")
+)
+
+// PartyClient defines the interface for communicating with the Party service
+//
+// The Party service manages party reference data (customers, counterparties,
+// legal entities). CurrentAccount uses this service to validate party ownership
+// before account operations.
+type PartyClient interface {
+	// ValidateParty checks if a party exists and is active
+	//
+	// Returns nil if the party exists and has ACTIVE status.
+	// Returns ErrPartyNotFound if the party does not exist.
+	// Returns ErrPartyNotActive if the party exists but is not ACTIVE.
+	ValidateParty(ctx context.Context, partyID string) error
+
+	// GetParty retrieves full party details by ID
+	//
+	// Returns the party data if found, or an error if not found.
+	GetParty(ctx context.Context, partyID string) (*partyv1.Party, error)
+
+	// Close terminates the client connection gracefully
+	Close() error
+}
+
+// PartyGRPCClient implements PartyClient using gRPC
+type PartyGRPCClient struct {
+	conn    *grpc.ClientConn
+	client  partyv1.PartyServiceClient
+	tracer  *observability.Tracer
+	timeout time.Duration
+}
+
+// PartyClientConfig holds configuration for the Party client
+type PartyClientConfig struct {
+	// Target is the gRPC server address (e.g., "localhost:50054" or "party-service:50054")
+	//
+	// Deprecated: Use ServiceName, Namespace, and Port for DNS-based load balancing.
+	// This field is maintained for backward compatibility with tests and local development.
+	// In production, prefer ServiceName-based configuration for automatic load balancing.
+	Target string
+
+	// ServiceName is the Kubernetes service name (e.g., "party-service")
+	// When specified, enables DNS-based client-side load balancing via pkg/platform/grpc.
+	// The client will connect to dns:///party-service.<namespace>.svc.cluster.local:<port>
+	// and use round_robin load balancing across all pod IPs.
+	ServiceName string
+
+	// Namespace is the Kubernetes namespace (e.g., "default", "production")
+	// Defaults to "default" if not specified or empty.
+	// Only used when ServiceName is specified.
+	Namespace string
+
+	// Port is the service port number
+	// Party service uses port 50054 (configured in deployments/k8s/party/service.yaml)
+	// Only used when ServiceName is specified.
+	Port int
+
+	// Timeout is the default timeout for RPC calls
+	// If not specified, defaults to 30 seconds
+	Timeout time.Duration
+
+	// Tracer is an optional observability tracer for distributed tracing
+	// If provided, the client will automatically propagate trace context
+	Tracer *observability.Tracer
+
+	// DialOptions allows custom gRPC dial options
+	// When using ServiceName, these options are passed to the platform gRPC factory
+	DialOptions []grpc.DialOption
+}
+
+// NewPartyClient creates a new Party gRPC client
+//
+// Supports two connection modes:
+//
+// 1. DNS-based load balancing (recommended for Kubernetes):
+//
+//	config := &clients.PartyClientConfig{
+//	    ServiceName: "party-service",
+//	    Namespace:   "default",
+//	    Port:        50054,
+//	    Timeout:     30 * time.Second,
+//	    Tracer:      tracer,
+//	}
+//
+// 2. Legacy direct connection (for backward compatibility):
+//
+//	config := &clients.PartyClientConfig{
+//	    Target:  "party-service:50054",
+//	    Timeout: 30 * time.Second,
+//	    Tracer:  tracer,
+//	}
+func NewPartyClient(cfg *PartyClientConfig) (*PartyGRPCClient, error) {
+	// Set default timeout if not specified
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 30 * time.Second
+	}
+
+	var conn *grpc.ClientConn
+	var err error
+
+	// Use platform gRPC factory when ServiceName is provided (preferred)
+	if cfg.ServiceName != "" {
+		// Prepare dial options for platform factory
+		dialOpts := cfg.DialOptions
+
+		// Add tracing interceptor if tracer is provided
+		if cfg.Tracer != nil {
+			dialOpts = append(dialOpts,
+				grpc.WithUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
+				grpc.WithStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
+			)
+		}
+
+		// Use platform factory for DNS-based load balancing
+		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
+			ServiceName: cfg.ServiceName,
+			Namespace:   cfg.Namespace,
+			Port:        cfg.Port,
+			DialOptions: dialOpts,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gRPC connection via platform factory: %w", err)
+		}
+	} else {
+		// Fallback to legacy direct connection for backward compatibility
+		if cfg.Target == "" {
+			return nil, ErrPartyTargetRequired
+		}
+
+		// Prepare dial options
+		dialOpts := cfg.DialOptions
+		if dialOpts == nil {
+			// Default: insecure credentials for service mesh communication
+			dialOpts = []grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			}
+		}
+
+		// Add tracing interceptor if tracer is provided
+		if cfg.Tracer != nil {
+			dialOpts = append(dialOpts,
+				grpc.WithUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
+				grpc.WithStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
+			)
+		}
+
+		// Establish connection using legacy method
+		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gRPC connection to %s: %w", cfg.Target, err)
+		}
+	}
+
+	return &PartyGRPCClient{
+		conn:    conn,
+		client:  partyv1.NewPartyServiceClient(conn),
+		tracer:  cfg.Tracer,
+		timeout: cfg.Timeout,
+	}, nil
+}
+
+// ValidateParty checks if a party exists and is active
+func (c *PartyGRPCClient) ValidateParty(ctx context.Context, partyID string) error {
+	party, err := c.GetParty(ctx, partyID)
+	if err != nil {
+		return err
+	}
+
+	if party.Status != partyv1.PartyStatus_PARTY_STATUS_ACTIVE {
+		return ErrPartyNotActive
+	}
+
+	return nil
+}
+
+// GetParty retrieves full party details by ID
+func (c *PartyGRPCClient) GetParty(ctx context.Context, partyID string) (*partyv1.Party, error) {
+	ctx, cancel := WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = PropagateCorrelationID(ctx)
+
+	resp, err := c.client.RetrieveParty(ctx, &partyv1.RetrievePartyRequest{
+		PartyId: partyID,
+	})
+	if err != nil {
+		// Check for NOT_FOUND status
+		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+			return nil, ErrPartyNotFound
+		}
+		return nil, fmt.Errorf("failed to retrieve party: %w", err)
+	}
+
+	return resp.Party, nil
+}
+
+// Close terminates the gRPC connection
+func (c *PartyGRPCClient) Close() error {
+	if c.conn != nil {
+		if err := c.conn.Close(); err != nil {
+			return fmt.Errorf("failed to close party client connection: %w", err)
+		}
+	}
+	return nil
+}

--- a/services/current-account/clients/party_client_test.go
+++ b/services/current-account/clients/party_client_test.go
@@ -1,0 +1,595 @@
+package clients_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/services/current-account/clients"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+)
+
+// TestNewPartyClient_Success verifies client creation with valid configuration
+func TestNewPartyClient_Success(t *testing.T) {
+	t.Parallel()
+
+	cfg := &clients.PartyClientConfig{
+		Target:  "localhost:50054",
+		Timeout: 10 * time.Second,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.NoError(t, client.Close())
+}
+
+// TestNewPartyClient_RequiresTarget verifies error when target is missing
+func TestNewPartyClient_RequiresTarget(t *testing.T) {
+	t.Parallel()
+
+	cfg := &clients.PartyClientConfig{
+		Target:  "",
+		Timeout: 10 * time.Second,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	assert.ErrorIs(t, err, clients.ErrPartyTargetRequired)
+	assert.Nil(t, client)
+}
+
+// TestNewPartyClient_DefaultTimeout verifies 30s default timeout is applied
+func TestNewPartyClient_DefaultTimeout(t *testing.T) {
+	t.Parallel()
+
+	cfg := &clients.PartyClientConfig{
+		Target:  "localhost:50054",
+		Timeout: 0, // Should default to 30 seconds
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.NoError(t, client.Close())
+}
+
+// TestNewPartyClient_CustomTimeout verifies custom timeout is respected
+func TestNewPartyClient_CustomTimeout(t *testing.T) {
+	t.Parallel()
+
+	customTimeout := 5 * time.Minute
+	cfg := &clients.PartyClientConfig{
+		Target:  "localhost:50054",
+		Timeout: customTimeout,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.NoError(t, client.Close())
+}
+
+// TestNewPartyClient_WithTracer verifies tracer configuration is accepted
+func TestNewPartyClient_WithTracer(t *testing.T) {
+	t.Parallel()
+
+	tracer := &observability.Tracer{}
+	cfg := &clients.PartyClientConfig{
+		Target:  "localhost:50054",
+		Timeout: 10 * time.Second,
+		Tracer:  tracer,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.NoError(t, client.Close())
+}
+
+// TestNewPartyClient_DefaultDialOptions verifies insecure credentials are used by default
+func TestNewPartyClient_DefaultDialOptions(t *testing.T) {
+	t.Parallel()
+
+	cfg := &clients.PartyClientConfig{
+		Target:      "localhost:50054",
+		Timeout:     10 * time.Second,
+		DialOptions: nil, // Should use default insecure credentials
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.NoError(t, client.Close())
+}
+
+// TestNewPartyClient_CustomDialOptions verifies custom dial options are respected
+func TestNewPartyClient_CustomDialOptions(t *testing.T) {
+	t.Parallel()
+
+	customOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+	cfg := &clients.PartyClientConfig{
+		Target:      "localhost:50054",
+		Timeout:     10 * time.Second,
+		DialOptions: customOpts,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.NoError(t, client.Close())
+}
+
+// TestNewPartyClient_EmptyTarget verifies empty target is rejected
+func TestNewPartyClient_EmptyTarget(t *testing.T) {
+	t.Parallel()
+
+	cfg := &clients.PartyClientConfig{
+		Target:  "",
+		Timeout: 10 * time.Second,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	assert.ErrorIs(t, err, clients.ErrPartyTargetRequired)
+	assert.Nil(t, client)
+}
+
+// TestNewPartyClient_ValidTargetFormats verifies various valid target formats
+func TestNewPartyClient_ValidTargetFormats(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		target string
+	}{
+		{
+			name:   "host and port",
+			target: "localhost:50054",
+		},
+		{
+			name:   "IP and port",
+			target: "127.0.0.1:50054",
+		},
+		{
+			name:   "service name",
+			target: "party-service:443",
+		},
+		{
+			name:   "DNS name",
+			target: "party.example.com:443",
+		},
+		{
+			name:   "kubernetes service",
+			target: "party-service.default.svc.cluster.local:50054",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &clients.PartyClientConfig{
+				Target:  tt.target,
+				Timeout: 10 * time.Second,
+			}
+
+			client, err := clients.NewPartyClient(cfg)
+
+			require.NoError(t, err)
+			require.NotNil(t, client)
+			assert.NoError(t, client.Close())
+		})
+	}
+}
+
+// TestPartyClient_Close_Success verifies Close closes the connection without error
+func TestPartyClient_Close_Success(t *testing.T) {
+	t.Parallel()
+
+	cfg := &clients.PartyClientConfig{
+		Target:  "localhost:50054",
+		Timeout: 10 * time.Second,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	err = client.Close()
+
+	assert.NoError(t, err)
+}
+
+// TestPartyClient_Close_Multiple verifies Close behavior when called multiple times
+func TestPartyClient_Close_Multiple(t *testing.T) {
+	t.Parallel()
+
+	cfg := &clients.PartyClientConfig{
+		Target:  "localhost:50054",
+		Timeout: 10 * time.Second,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	// First close
+	err1 := client.Close()
+	assert.NoError(t, err1)
+
+	// Second close returns error (gRPC connection already closed)
+	err2 := client.Close()
+	assert.Error(t, err2, "closing already-closed connection should return error")
+}
+
+// TestNewPartyClient_DNSBasedMode verifies DNS-based client creation
+func TestNewPartyClient_DNSBasedMode(t *testing.T) {
+	t.Parallel()
+
+	cfg := &clients.PartyClientConfig{
+		ServiceName: "party-service",
+		Namespace:   "default",
+		Port:        50054,
+		Timeout:     10 * time.Second,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.NoError(t, client.Close())
+}
+
+// TestNewPartyClient_DNSBasedMode_DefaultNamespace verifies namespace defaults to "default"
+func TestNewPartyClient_DNSBasedMode_DefaultNamespace(t *testing.T) {
+	t.Parallel()
+
+	cfg := &clients.PartyClientConfig{
+		ServiceName: "party-service",
+		Namespace:   "", // Should default to "default"
+		Port:        50054,
+		Timeout:     10 * time.Second,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.NoError(t, client.Close())
+}
+
+// TestNewPartyClient_DNSBasedMode_WithTracer verifies DNS mode with tracer
+func TestNewPartyClient_DNSBasedMode_WithTracer(t *testing.T) {
+	t.Parallel()
+
+	tracer := &observability.Tracer{}
+	cfg := &clients.PartyClientConfig{
+		ServiceName: "party-service",
+		Namespace:   "test-namespace",
+		Port:        50054,
+		Timeout:     10 * time.Second,
+		Tracer:      tracer,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.NoError(t, client.Close())
+}
+
+// TestNewPartyClient_PrefersDNSOverTarget verifies ServiceName takes precedence
+func TestNewPartyClient_PrefersDNSOverTarget(t *testing.T) {
+	t.Parallel()
+
+	// When both ServiceName and Target are provided, ServiceName should be used
+	cfg := &clients.PartyClientConfig{
+		ServiceName: "party-service",
+		Namespace:   "default",
+		Port:        50054,
+		Target:      "ignored:9999", // Should be ignored
+		Timeout:     10 * time.Second,
+	}
+
+	client, err := clients.NewPartyClient(cfg)
+
+	require.NoError(t, err)
+	require.NotNil(t, client)
+	assert.NoError(t, client.Close())
+}
+
+// mockPartyServer is a mock implementation of PartyServiceServer for testing
+type mockPartyServer struct {
+	partyv1.UnimplementedPartyServiceServer
+	retrieveFunc func(ctx context.Context, req *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error)
+}
+
+func (m *mockPartyServer) RetrieveParty(ctx context.Context, req *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+	if m.retrieveFunc != nil {
+		return m.retrieveFunc(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+// startMockPartyServer starts a mock gRPC server for testing
+func startMockPartyServer(t *testing.T, server *mockPartyServer) (string, func()) {
+	t.Helper()
+
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	partyv1.RegisterPartyServiceServer(grpcServer, server)
+
+	go func() {
+		_ = grpcServer.Serve(listener)
+	}()
+
+	return listener.Addr().String(), func() {
+		grpcServer.Stop()
+	}
+}
+
+// TestPartyClient_ValidateParty_ActiveParty verifies successful validation of active party
+func TestPartyClient_ValidateParty_ActiveParty(t *testing.T) {
+	t.Parallel()
+
+	mockServer := &mockPartyServer{
+		retrieveFunc: func(_ context.Context, req *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+			return &partyv1.RetrievePartyResponse{
+				Party: &partyv1.Party{
+					PartyId:   req.PartyId,
+					LegalName: "Test Party",
+					Status:    partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+				},
+			}, nil
+		},
+	}
+
+	addr, cleanup := startMockPartyServer(t, mockServer)
+	defer cleanup()
+
+	client, err := clients.NewPartyClient(&clients.PartyClientConfig{
+		Target:  addr,
+		Timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	err = client.ValidateParty(context.Background(), "party-123")
+
+	assert.NoError(t, err)
+}
+
+// TestPartyClient_ValidateParty_InactiveParty verifies error for inactive party
+func TestPartyClient_ValidateParty_InactiveParty(t *testing.T) {
+	t.Parallel()
+
+	mockServer := &mockPartyServer{
+		retrieveFunc: func(_ context.Context, req *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+			return &partyv1.RetrievePartyResponse{
+				Party: &partyv1.Party{
+					PartyId:   req.PartyId,
+					LegalName: "Test Party",
+					Status:    partyv1.PartyStatus_PARTY_STATUS_RESTRICTED,
+				},
+			}, nil
+		},
+	}
+
+	addr, cleanup := startMockPartyServer(t, mockServer)
+	defer cleanup()
+
+	client, err := clients.NewPartyClient(&clients.PartyClientConfig{
+		Target:  addr,
+		Timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	err = client.ValidateParty(context.Background(), "party-123")
+
+	assert.ErrorIs(t, err, clients.ErrPartyNotActive)
+}
+
+// TestPartyClient_ValidateParty_TerminatedParty verifies error for terminated party
+func TestPartyClient_ValidateParty_TerminatedParty(t *testing.T) {
+	t.Parallel()
+
+	mockServer := &mockPartyServer{
+		retrieveFunc: func(_ context.Context, req *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+			return &partyv1.RetrievePartyResponse{
+				Party: &partyv1.Party{
+					PartyId:   req.PartyId,
+					LegalName: "Test Party",
+					Status:    partyv1.PartyStatus_PARTY_STATUS_TERMINATED,
+				},
+			}, nil
+		},
+	}
+
+	addr, cleanup := startMockPartyServer(t, mockServer)
+	defer cleanup()
+
+	client, err := clients.NewPartyClient(&clients.PartyClientConfig{
+		Target:  addr,
+		Timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	err = client.ValidateParty(context.Background(), "party-123")
+
+	assert.ErrorIs(t, err, clients.ErrPartyNotActive)
+}
+
+// TestPartyClient_ValidateParty_NotFound verifies error for non-existent party
+func TestPartyClient_ValidateParty_NotFound(t *testing.T) {
+	t.Parallel()
+
+	mockServer := &mockPartyServer{
+		retrieveFunc: func(_ context.Context, _ *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+			return nil, status.Error(codes.NotFound, "party not found")
+		},
+	}
+
+	addr, cleanup := startMockPartyServer(t, mockServer)
+	defer cleanup()
+
+	client, err := clients.NewPartyClient(&clients.PartyClientConfig{
+		Target:  addr,
+		Timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	err = client.ValidateParty(context.Background(), "nonexistent-party")
+
+	assert.ErrorIs(t, err, clients.ErrPartyNotFound)
+}
+
+// TestPartyClient_GetParty_Success verifies successful party retrieval
+func TestPartyClient_GetParty_Success(t *testing.T) {
+	t.Parallel()
+
+	expectedParty := &partyv1.Party{
+		PartyId:     "party-123",
+		LegalName:   "Test Company Ltd",
+		DisplayName: "Test Company",
+		//nolint:misspell // ORGANISATION uses British spelling per proto definition
+		PartyType:         partyv1.PartyType_PARTY_TYPE_ORGANISATION,
+		Status:            partyv1.PartyStatus_PARTY_STATUS_ACTIVE,
+		ExternalReference: "CH12345678",
+	}
+
+	mockServer := &mockPartyServer{
+		retrieveFunc: func(_ context.Context, _ *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+			return &partyv1.RetrievePartyResponse{
+				Party: expectedParty,
+			}, nil
+		},
+	}
+
+	addr, cleanup := startMockPartyServer(t, mockServer)
+	defer cleanup()
+
+	client, err := clients.NewPartyClient(&clients.PartyClientConfig{
+		Target:  addr,
+		Timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	party, err := client.GetParty(context.Background(), "party-123")
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedParty.PartyId, party.PartyId)
+	assert.Equal(t, expectedParty.LegalName, party.LegalName)
+	assert.Equal(t, expectedParty.Status, party.Status)
+}
+
+// TestPartyClient_GetParty_NotFound verifies error for non-existent party
+func TestPartyClient_GetParty_NotFound(t *testing.T) {
+	t.Parallel()
+
+	mockServer := &mockPartyServer{
+		retrieveFunc: func(_ context.Context, _ *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+			return nil, status.Error(codes.NotFound, "party not found")
+		},
+	}
+
+	addr, cleanup := startMockPartyServer(t, mockServer)
+	defer cleanup()
+
+	client, err := clients.NewPartyClient(&clients.PartyClientConfig{
+		Target:  addr,
+		Timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	party, err := client.GetParty(context.Background(), "nonexistent-party")
+
+	assert.ErrorIs(t, err, clients.ErrPartyNotFound)
+	assert.Nil(t, party)
+}
+
+// TestPartyClient_GetParty_ServerError verifies handling of server errors
+func TestPartyClient_GetParty_ServerError(t *testing.T) {
+	t.Parallel()
+
+	mockServer := &mockPartyServer{
+		retrieveFunc: func(_ context.Context, _ *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+			return nil, status.Error(codes.Internal, "internal server error")
+		},
+	}
+
+	addr, cleanup := startMockPartyServer(t, mockServer)
+	defer cleanup()
+
+	client, err := clients.NewPartyClient(&clients.PartyClientConfig{
+		Target:  addr,
+		Timeout: 10 * time.Second,
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	party, err := client.GetParty(context.Background(), "party-123")
+
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, clients.ErrPartyNotFound)
+	assert.Nil(t, party)
+}
+
+// TestPartyClient_ContextCancellation verifies context cancellation is handled
+func TestPartyClient_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	mockServer := &mockPartyServer{
+		retrieveFunc: func(ctx context.Context, req *partyv1.RetrievePartyRequest) (*partyv1.RetrievePartyResponse, error) {
+			// Simulate slow response
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(5 * time.Second):
+				return &partyv1.RetrievePartyResponse{
+					Party: &partyv1.Party{PartyId: req.PartyId},
+				}, nil
+			}
+		},
+	}
+
+	addr, cleanup := startMockPartyServer(t, mockServer)
+	defer cleanup()
+
+	client, err := clients.NewPartyClient(&clients.PartyClientConfig{
+		Target:  addr,
+		Timeout: 100 * time.Millisecond, // Short timeout
+	})
+	require.NoError(t, err)
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err = client.GetParty(ctx, "party-123")
+
+	assert.Error(t, err)
+}

--- a/services/current-account/clients/resilient_client.go
+++ b/services/current-account/clients/resilient_client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/sony/gobreaker/v2"
@@ -28,6 +29,14 @@ type ResilientPositionKeepingClient struct {
 // ResilientFinancialAccountingClient wraps FinancialAccountingClient with resilience patterns
 type ResilientFinancialAccountingClient struct {
 	client         FinancialAccountingClient
+	circuitBreaker *sharedclients.CircuitBreaker
+	retryConfig    sharedclients.RetryConfig
+	logger         *slog.Logger
+}
+
+// ResilientPartyClient wraps PartyClient with resilience patterns
+type ResilientPartyClient struct {
+	client         PartyClient
 	circuitBreaker *sharedclients.CircuitBreaker
 	retryConfig    sharedclients.RetryConfig
 	logger         *slog.Logger
@@ -132,6 +141,22 @@ func NewResilientFinancialAccountingClient(
 	cb := sharedclients.NewCircuitBreaker(cbConfig, config.Logger)
 
 	return &ResilientFinancialAccountingClient{
+		client:         client,
+		circuitBreaker: cb,
+		retryConfig:    retryConfig,
+		logger:         config.Logger,
+	}
+}
+
+// NewResilientPartyClient creates a resilient wrapper around PartyClient
+func NewResilientPartyClient(
+	client PartyClient,
+	config ResilientClientConfig,
+) *ResilientPartyClient {
+	cbConfig, retryConfig := applyConfigDefaults(&config, "party")
+	cb := sharedclients.NewCircuitBreaker(cbConfig, config.Logger)
+
+	return &ResilientPartyClient{
 		client:         client,
 		circuitBreaker: cb,
 		retryConfig:    retryConfig,
@@ -389,6 +414,43 @@ func (r *ResilientFinancialAccountingClient) RetrieveLedgerPosting(
 func (r *ResilientFinancialAccountingClient) Close() error {
 	if err := r.client.Close(); err != nil {
 		return fmt.Errorf("failed to close financial accounting client: %w", err)
+	}
+	return nil
+}
+
+// ValidateParty checks if a party exists and is active with resilience
+func (r *ResilientPartyClient) ValidateParty(ctx context.Context, partyID string) error {
+	_, err := executeWithResilience(
+		ctx,
+		r.circuitBreaker,
+		r.retryConfig,
+		r.logger,
+		"ValidateParty",
+		func() (struct{}, error) {
+			return struct{}{}, r.client.ValidateParty(ctx, partyID)
+		},
+	)
+	return err
+}
+
+// GetParty retrieves full party details by ID with resilience
+func (r *ResilientPartyClient) GetParty(ctx context.Context, partyID string) (*partyv1.Party, error) {
+	return executeWithResilience(
+		ctx,
+		r.circuitBreaker,
+		r.retryConfig,
+		r.logger,
+		"GetParty",
+		func() (*partyv1.Party, error) {
+			return r.client.GetParty(ctx, partyID)
+		},
+	)
+}
+
+// Close closes the underlying client connection
+func (r *ResilientPartyClient) Close() error {
+	if err := r.client.Close(); err != nil {
+		return fmt.Errorf("failed to close party client: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Add `PartyClient` interface with `ValidateParty` and `GetParty` methods for party validation
- Implement `PartyGRPCClient` with DNS-based load balancing support (Kubernetes ServiceName) and legacy Target configuration
- Add `ResilientPartyClient` wrapper with circuit breaker and retry logic
- Return domain errors `ErrPartyNotFound` and `ErrPartyNotActive` for clear error handling

## Changes Made

**New Files:**
- `services/current-account/clients/party_client.go` - PartyClient interface and gRPC implementation
- `services/current-account/clients/party_client_test.go` - Comprehensive unit tests (23 test cases)

**Modified Files:**
- `services/current-account/clients/resilient_client.go` - Added `ResilientPartyClient` wrapper

## Technical Details

The Party client follows the same patterns as existing clients (PositionKeeping, FinancialAccounting):
- Supports both legacy `Target` configuration and DNS-based `ServiceName/Namespace/Port` for Kubernetes
- Default timeout of 30 seconds with configurable override
- Optional tracing support via `observability.Tracer`
- Circuit breaker with 5 consecutive failures threshold
- Exponential backoff retry (100ms initial, 5s max, 3 retries)

## Test Plan

- [x] All 23 Party client unit tests passing
- [x] All existing clients tests passing (no regressions)
- [x] golangci-lint passing with no issues
- [ ] CI pipeline passes