### PR TITLE
feat(db): drop customers table and FK constraint from current-account

### DIFF
--- a/services/current-account/migrations/20251208180700_remove_customers_table.sql
+++ b/services/current-account/migrations/20251208180700_remove_customers_table.sql
@@ -1,0 +1,15 @@
+-- Migration: Remove customers table and FK constraint
+-- This migration removes the local customers table as customer data is now managed
+-- by the Party Service (accessed via gRPC). The customer_id column is kept for now
+-- and will be renamed to party_id in a subsequent migration along with Go code updates.
+
+-- Drop FK constraint from accounts table
+ALTER TABLE "current_account"."accounts"
+    DROP CONSTRAINT "fk_current_account_customers_accounts";
+
+-- Add comment documenting that customer_id now references Party Service via gRPC (not FK)
+COMMENT ON COLUMN "current_account"."accounts"."customer_id" IS
+    'References a party in the Party Service (accessed via gRPC). Not a foreign key constraint as Party Service is a separate microservice. Will be renamed to party_id in a future migration.';
+
+-- Drop the customers table and its indexes (indexes are dropped automatically with the table)
+DROP TABLE "current_account"."customers";

--- a/services/current-account/migrations/README_rollback_20251208180700.md
+++ b/services/current-account/migrations/README_rollback_20251208180700.md
@@ -1,0 +1,49 @@
+# Rollback Reference: 20251208180700_remove_customers_table.sql
+
+This document contains the SQL needed to rollback migration `20251208180700_remove_customers_table.sql`.
+
+**IMPORTANT**: Atlas does not use `.down.sql` files. To rollback:
+1. Create a new migration with the reversed changes
+2. Or manually execute the SQL below after verification
+
+---
+
+## Rollback SQL
+
+```sql
+-- Recreate the customers table with original schema
+CREATE TABLE "current_account"."customers" (
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    "created_by" character varying(100) NOT NULL,
+    "updated_at" timestamptz NOT NULL DEFAULT now(),
+    "updated_by" character varying(100) NOT NULL,
+    "deleted_at" timestamptz NULL,
+    "customer_number" character varying(50) NOT NULL,
+    "first_name" character varying(100) NOT NULL,
+    "last_name" character varying(100) NOT NULL,
+    "email" character varying(255) NULL,
+    "phone" character varying(20) NULL,
+    "status" character varying(20) NOT NULL DEFAULT 'active',
+    PRIMARY KEY ("id")
+);
+
+-- Recreate indexes on customers table
+CREATE UNIQUE INDEX "idx_current_account_customers_customer_number"
+    ON "current_account"."customers" ("customer_number");
+CREATE INDEX "idx_current_account_customers_deleted_at"
+    ON "current_account"."customers" ("deleted_at");
+CREATE UNIQUE INDEX "idx_current_account_customers_email"
+    ON "current_account"."customers" ("email");
+
+-- Remove comment from customer_id column
+COMMENT ON COLUMN "current_account"."accounts"."customer_id" IS NULL;
+
+-- Note: FK constraint cannot be restored as there is no customer data in the table.
+-- The customer records would need to be re-populated before restoring the FK constraint.
+-- To restore FK after populating customers:
+-- ALTER TABLE "current_account"."accounts"
+--     ADD CONSTRAINT "fk_current_account_customers_accounts"
+--     FOREIGN KEY ("customer_id") REFERENCES "current_account"."customers" ("id")
+--     ON UPDATE NO ACTION ON DELETE RESTRICT;
+```

--- a/services/current-account/migrations/atlas.sum
+++ b/services/current-account/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:E3m2Fn8EM5SSWdD7jTFMI/Qv9YawcI5QNtcaQCJV5GQ=
+h1:XuAqHbAAmDsdboA8dWjS2plWcVwQuD3JWAA7GRARdF4=
 20251103181626_initial.sql h1:h/E+atJE/78Q5siTomcLIzYZMRACtxiIVRQgemMtax4=
 20251103181700_audit_system.sql h1:QLSvHru32NeU2bNflvmF8JWG8Fcmv8GJdvxv9QCJ7PU=
 20251204130000_add_account_id.sql h1:5RWRS5Tx0wchOUWpXniGRAm4GisEAl1PzoHFsZw6M28=
@@ -9,3 +9,4 @@ h1:E3m2Fn8EM5SSWdD7jTFMI/Qv9YawcI5QNtcaQCJV5GQ=
 20251204160001_add_version_column.sql h1:REznhd5N1aWOeuaraoR0+ZonkoXCGKIqoSfFWAS8qVc=
 20251204204800_create_liens_table.sql h1:4ZdOqXNJoGxGEE287jlBzm5exDKr85CDGA1/IusT6FU=
 20251207150000_backfill_balance_updated_at.sql h1:XQyXF2cB5qlv3p8zOwt21EQGJbmzxq+lRxsg2/xeHm0=
+20251208180700_remove_customers_table.sql h1:XULLiU858MoUYg4WN1ayJy4EUCOeItZMUrZVG/P9mjE=

--- a/shared/platform/testdb/schema_validation_test.go
+++ b/shared/platform/testdb/schema_validation_test.go
@@ -200,17 +200,10 @@ func applyMigrations(ctx context.Context, t *testing.T, db *sql.DB) {
 func testLienEntity(t *testing.T, db *gorm.DB) {
 	t.Helper()
 
-	// First create a customer (accounts have FK to customers)
-	customerID := uuid.New()
-	customerSQL := `
-		INSERT INTO current_account.customers
-		(id, customer_number, first_name, last_name, email, status, created_by, updated_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
-	err := db.Exec(customerSQL, customerID, "CUST-LIEN-001", "Lien", "Test", "lien@example.com", "active", "system", "system").Error
-	require.NoError(t, err, "Failed to create test customer for lien test")
-
-	// Then create an account (liens have FK to accounts)
+	// Create an account (liens have FK to accounts)
+	// Note: customer_id is now a reference to Party Service (no FK constraint)
 	accountID := uuid.New()
+	partyID := uuid.New() // References a party in Party Service (no local FK)
 	account := &capersistence.CurrentAccountEntity{
 		ID:                    accountID,
 		AccountID:             "ACC-LIEN-001",
@@ -218,7 +211,7 @@ func testLienEntity(t *testing.T, db *gorm.DB) {
 		AccountType:           "current",
 		Currency:              "GBP",
 		Status:                "active",
-		CustomerID:            customerID,
+		CustomerID:            partyID,
 		Balance:               50000,
 		AvailableBalance:      40000,
 		OverdraftLimit:        5000,
@@ -227,7 +220,7 @@ func testLienEntity(t *testing.T, db *gorm.DB) {
 		CreatedBy:             "system",
 		UpdatedBy:             "system",
 	}
-	err = db.Create(account).Error
+	err := db.Create(account).Error
 	require.NoError(t, err, "Failed to create test account for lien test")
 
 	// Now create a lien
@@ -350,14 +343,9 @@ func testLienEntity(t *testing.T, db *gorm.DB) {
 func testCurrentAccountEntity(t *testing.T, db *gorm.DB) {
 	t.Helper()
 
-	// First create a customer (accounts have FK to customers)
-	customerID := uuid.New()
-	customerSQL := `
-		INSERT INTO current_account.customers
-		(id, customer_number, first_name, last_name, email, status, created_by, updated_by)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
-	err := db.Exec(customerSQL, customerID, "CUST-TEST-001", "Test", "User", "test@example.com", "active", "system", "system").Error
-	require.NoError(t, err, "Failed to create test customer")
+	// Note: customer_id is now a reference to Party Service (no local FK constraint)
+	// The customers table has been removed - party data is managed by Party Service
+	partyID := uuid.New() // References a party in Party Service
 
 	// Entity fields must match migration schema columns exactly
 	entity := &capersistence.CurrentAccountEntity{
@@ -367,7 +355,7 @@ func testCurrentAccountEntity(t *testing.T, db *gorm.DB) {
 		AccountType:           "current",
 		Currency:              "GBP",
 		Status:                "active",
-		CustomerID:            customerID,
+		CustomerID:            partyID,
 		Balance:               10000,
 		AvailableBalance:      8000,
 		OverdraftLimit:        5000,
@@ -378,7 +366,7 @@ func testCurrentAccountEntity(t *testing.T, db *gorm.DB) {
 	}
 
 	// Create - will fail if columns don't match
-	err = db.Create(entity).Error
+	err := db.Create(entity).Error
 	if err != nil {
 		t.Fatalf("Failed to create CurrentAccountEntity - schema mismatch detected: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Drop FK constraint `fk_current_account_customers_accounts` from accounts table
- Add comment documenting that `customer_id` now references Party Service via gRPC
- Drop the `customers` table (data now managed by Party Service)

**Note**: The column rename from `customer_id` to `party_id` is intentionally deferred to a follow-up migration. This allows the Go code changes (tasks 26/27) to be coordinated with the schema change, avoiding a broken intermediate state.

## Changes Made
- New migration `20251208180700_remove_customers_table.sql`
- Rollback reference documentation `README_rollback_20251208180700.md`
- Updated `atlas.sum`

## Test plan
- [x] Local tests pass (`go test ./services/current-account/...`)
- [ ] CI passes
- [ ] Manual verification in dev environment

## Related Tasks
- Task Master #23 (this PR)
- Task #26 - Update GORM entity to use party_id (depends on this)
- Task #27 - Update domain model to use party_id (depends on this)