### PR TITLE
feat(current-account): rename CustomerID to PartyID in entity and domain

### DIFF
--- a/services/current-account/adapters/persistence/account_entity.go
+++ b/services/current-account/adapters/persistence/account_entity.go
@@ -20,7 +20,7 @@ type CurrentAccountEntity struct {
 	AccountType           string     `gorm:"column:account_type;type:varchar(50);not null"`                       // current, savings, etc.
 	Currency              string     `gorm:"column:currency;type:char(3);not null;default:'GBP'"`                 // ISO 4217
 	Status                string     `gorm:"column:status;type:varchar(20);not null;default:'active'"`
-	CustomerID            uuid.UUID  `gorm:"column:customer_id;type:uuid;not null;index"`
+	PartyID               uuid.UUID  `gorm:"column:party_id;type:uuid;not null;index"`
 	Balance               int64      `gorm:"column:balance;not null;default:0"`           // in smallest currency unit (pence)
 	AvailableBalance      int64      `gorm:"column:available_balance;not null;default:0"` // after pending transactions
 	OverdraftLimit        int64      `gorm:"column:overdraft_limit;not null;default:0"`   // in smallest currency unit

--- a/services/current-account/adapters/persistence/repository.go
+++ b/services/current-account/adapters/persistence/repository.go
@@ -200,10 +200,10 @@ func (r *Repository) FindByUUIDForUpdate(id uuid.UUID) (*domain.CurrentAccount, 
 	return toDomain(&entity)
 }
 
-// FindByCustomerID retrieves all accounts for a customer
-func (r *Repository) FindByCustomerID(customerID string) ([]*domain.CurrentAccount, error) {
+// FindByPartyID retrieves all accounts for a party
+func (r *Repository) FindByPartyID(partyID string) ([]*domain.CurrentAccount, error) {
 	var entities []CurrentAccountEntity
-	result := r.db.Where("customer_id = ? AND deleted_at IS NULL", customerID).Find(&entities)
+	result := r.db.Where("party_id = ? AND deleted_at IS NULL", partyID).Find(&entities)
 
 	if result.Error != nil {
 		return nil, result.Error
@@ -239,10 +239,10 @@ func (r *Repository) Ping() error {
 // Note: The entity schema matches migrations/current_account/*.sql
 // OverdraftEnabled is derived from OverdraftLimit > 0
 func toEntity(ctx context.Context, account *domain.CurrentAccount) (*CurrentAccountEntity, error) {
-	// Parse CustomerID as UUID - domain model uses string for flexibility
-	customerUUID, err := uuid.Parse(account.CustomerID)
+	// Parse PartyID as UUID - domain model uses string for flexibility
+	partyUUID, err := uuid.Parse(account.PartyID)
 	if err != nil {
-		return nil, fmt.Errorf("invalid customer ID %q: %w", account.CustomerID, err)
+		return nil, fmt.Errorf("invalid party ID %q: %w", account.PartyID, err)
 	}
 
 	// Extract audit user from context (falls back to "system" if not available)
@@ -255,7 +255,7 @@ func toEntity(ctx context.Context, account *domain.CurrentAccount) (*CurrentAcco
 		AccountType:           "current",                     // Default for current accounts
 		Currency:              string(account.Balance.Currency()),
 		Status:                string(account.Status),
-		CustomerID:            customerUUID,
+		PartyID:               partyUUID,
 		Balance:               account.Balance.AmountCents(),
 		AvailableBalance:      account.AvailableBalance.AmountCents(),
 		OverdraftLimit:        account.OverdraftLimit.AmountCents(),
@@ -301,7 +301,7 @@ func toDomain(entity *CurrentAccountEntity) (*domain.CurrentAccount, error) {
 		ID:                    entity.ID,
 		AccountID:             entity.AccountID,             // Business account identifier
 		AccountIdentification: entity.AccountIdentification, // IBAN stored in account_identification
-		CustomerID:            entity.CustomerID.String(),
+		PartyID:               entity.PartyID.String(),
 		Balance:               balance,
 		AvailableBalance:      availableBalance,
 		Status:                domain.AccountStatus(entity.Status),

--- a/services/current-account/adapters/persistence/repository_test.go
+++ b/services/current-account/adapters/persistence/repository_test.go
@@ -157,20 +157,20 @@ func TestFindByIBAN(t *testing.T) {
 	}
 }
 
-func TestFindByCustomerID(t *testing.T) {
+func TestFindByPartyID(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
 
 	repo := NewRepository(db)
-	customerID := uuid.New().String()
+	partyID := uuid.New().String()
 
-	// Create two accounts for same customer
+	// Create two accounts for same party
 	iban1 := "GB82WEST12345698765432"
 	iban2 := "GB82WEST98765432123456"
 
-	account1, err := domain.NewCurrentAccount(iban1, iban1, customerID, "GBP")
+	account1, err := domain.NewCurrentAccount(iban1, iban1, partyID, "GBP")
 	require.NoError(t, err)
-	account2, err := domain.NewCurrentAccount(iban2, iban2, customerID, "EUR")
+	account2, err := domain.NewCurrentAccount(iban2, iban2, partyID, "EUR")
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -181,9 +181,9 @@ func TestFindByCustomerID(t *testing.T) {
 		t.Fatalf("Save account2 failed: %v", err)
 	}
 
-	accounts, err := repo.FindByCustomerID(customerID)
+	accounts, err := repo.FindByPartyID(partyID)
 	if err != nil {
-		t.Fatalf("FindByCustomerID failed: %v", err)
+		t.Fatalf("FindByPartyID failed: %v", err)
 	}
 
 	if len(accounts) != 2 {
@@ -297,7 +297,7 @@ func TestToDomain_InvalidCurrency_ReturnsError(t *testing.T) {
 		ID:                    uuid.New(),
 		AccountIdentification: "GB82WEST12345698765432",
 		AccountType:           "current",
-		CustomerID:            uuid.New(),
+		PartyID:               uuid.New(),
 		Balance:               10000,
 		AvailableBalance:      10000,
 		Currency:              "", // Invalid: empty currency
@@ -333,7 +333,7 @@ func TestFindByID_CorruptedData_ReturnsError(t *testing.T) {
 		ID:                    uuid.New(),
 		AccountIdentification: "GB82WEST12345698765432",
 		AccountType:           "current",
-		CustomerID:            uuid.New(),
+		PartyID:               uuid.New(),
 		Balance:               10000,
 		AvailableBalance:      10000,
 		Currency:              "", // Corrupted: empty currency
@@ -355,7 +355,7 @@ func TestFindByID_CorruptedData_ReturnsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "database", "Error should indicate DB corruption")
 }
 
-func TestFindByCustomerID_PartialCorruption_ReturnsError(t *testing.T) {
+func TestFindByPartyID_PartialCorruption_ReturnsError(t *testing.T) {
 	// Note: With the new schema using char(3) for currency, truly empty currencies
 	// are not possible. This test is skipped as database constraints now prevent
 	// the kind of corruption we were testing for.
@@ -366,15 +366,15 @@ func TestFindByCustomerID_PartialCorruption_ReturnsError(t *testing.T) {
 
 	repo := NewRepository(db)
 
-	// Create a shared customer ID for both accounts
-	customerID := uuid.New()
+	// Create a shared party ID for both accounts
+	partyID := uuid.New()
 
 	// Insert one valid account
 	validEntity := &CurrentAccountEntity{
 		ID:                    uuid.New(),
 		AccountIdentification: "GB82WEST12345698765432",
 		AccountType:           "current",
-		CustomerID:            customerID,
+		PartyID:               partyID,
 		Balance:               10000,
 		AvailableBalance:      10000,
 		Currency:              "GBP",
@@ -387,12 +387,12 @@ func TestFindByCustomerID_PartialCorruption_ReturnsError(t *testing.T) {
 	}
 	require.NoError(t, db.Create(validEntity).Error)
 
-	// Manually insert corrupted account with same customer
+	// Manually insert corrupted account with same party
 	corruptedEntity := &CurrentAccountEntity{
 		ID:                    uuid.New(),
 		AccountIdentification: "GB82WEST99999999999999",
 		AccountType:           "current",
-		CustomerID:            customerID, // Same customer
+		PartyID:               partyID, // Same party
 		Balance:               5000,
 		AvailableBalance:      5000,
 		Currency:              "", // Corrupted
@@ -405,10 +405,10 @@ func TestFindByCustomerID_PartialCorruption_ReturnsError(t *testing.T) {
 	}
 	require.NoError(t, db.Create(corruptedEntity).Error)
 
-	// FindByCustomerID should fail on first corrupted record
-	_, err := repo.FindByCustomerID(customerID.String())
+	// FindByPartyID should fail on first corrupted record
+	_, err := repo.FindByPartyID(partyID.String())
 
-	assert.Error(t, err, "FindByCustomerID should fail when any account is corrupted")
+	assert.Error(t, err, "FindByPartyID should fail when any account is corrupted")
 	assert.Contains(t, err.Error(), "database", "Error should indicate DB corruption")
 }
 

--- a/services/current-account/adapters/persistence/repository_test.go
+++ b/services/current-account/adapters/persistence/repository_test.go
@@ -26,11 +26,11 @@ func TestSaveNewAccount(t *testing.T) {
 	defer cleanup()
 
 	repo := NewRepository(db)
-	customerID := uuid.New().String()
+	partyID := uuid.New().String()
 	iban := "GB82WEST12345698765432"
 
 	// AccountID is now mapped to IBAN in the database (account_number column)
-	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	account, err := domain.NewCurrentAccount(iban, iban, partyID, "GBP")
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -56,10 +56,10 @@ func TestSaveNewAccount_InitialVersion(t *testing.T) {
 	defer cleanup()
 
 	repo := NewRepository(db)
-	customerID := uuid.New().String()
+	partyID := uuid.New().String()
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	account, err := domain.NewCurrentAccount(iban, iban, partyID, "GBP")
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -78,10 +78,10 @@ func TestSaveUpdateExisting(t *testing.T) {
 	defer cleanup()
 
 	repo := NewRepository(db)
-	customerID := uuid.New().String()
+	partyID := uuid.New().String()
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	account, err := domain.NewCurrentAccount(iban, iban, partyID, "GBP")
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -135,10 +135,10 @@ func TestFindByIBAN(t *testing.T) {
 	defer cleanup()
 
 	repo := NewRepository(db)
-	customerID := uuid.New().String()
+	partyID := uuid.New().String()
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	account, err := domain.NewCurrentAccount(iban, iban, partyID, "GBP")
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -196,10 +196,10 @@ func TestDeleteAccount(t *testing.T) {
 	defer cleanup()
 
 	repo := NewRepository(db)
-	customerID := uuid.New().String()
+	partyID := uuid.New().String()
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	account, err := domain.NewCurrentAccount(iban, iban, partyID, "GBP")
 	require.NoError(t, err)
 
 	ctx := context.Background()
@@ -224,13 +224,13 @@ func TestOptimisticLocking(t *testing.T) {
 	defer cleanup()
 
 	repo := NewRepository(db)
-	customerID := uuid.New().String()
+	partyID := uuid.New().String()
 	iban := "GB82WEST12345698765432"
 
 	ctx := context.Background()
 
 	// Create initial account
-	account1, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	account1, err := domain.NewCurrentAccount(iban, iban, partyID, "GBP")
 	require.NoError(t, err)
 	if err := repo.Save(ctx, account1); err != nil {
 		t.Fatalf("Initial save failed: %v", err)
@@ -419,10 +419,10 @@ func TestSave_PopulatesAuditFieldsFromContext(t *testing.T) {
 	defer cleanup()
 
 	repo := NewRepository(db)
-	customerID := uuid.New().String()
+	partyID := uuid.New().String()
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	account, err := domain.NewCurrentAccount(iban, iban, partyID, "GBP")
 	require.NoError(t, err)
 
 	// Create context with authenticated user
@@ -447,10 +447,10 @@ func TestSave_UsesSystemWhenNoUserInContext(t *testing.T) {
 	defer cleanup()
 
 	repo := NewRepository(db)
-	customerID := uuid.New().String()
+	partyID := uuid.New().String()
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	account, err := domain.NewCurrentAccount(iban, iban, partyID, "GBP")
 	require.NoError(t, err)
 
 	// Use empty context (no user)
@@ -474,10 +474,10 @@ func TestSave_UpdatePreservesCreatedByButUpdatesUpdatedBy(t *testing.T) {
 	defer cleanup()
 
 	repo := NewRepository(db)
-	customerID := uuid.New().String()
+	partyID := uuid.New().String()
 	iban := "GB82WEST12345698765432"
 
-	account, err := domain.NewCurrentAccount(iban, iban, customerID, "GBP")
+	account, err := domain.NewCurrentAccount(iban, iban, partyID, "GBP")
 	require.NoError(t, err)
 
 	// Create with user1

--- a/services/current-account/domain/account.go
+++ b/services/current-account/domain/account.go
@@ -34,7 +34,7 @@ type CurrentAccount struct {
 	ID                    uuid.UUID
 	AccountID             string
 	AccountIdentification string // IBAN
-	CustomerID            string
+	PartyID               string
 	Balance               Money
 	AvailableBalance      Money
 	Status                AccountStatus
@@ -48,7 +48,7 @@ type CurrentAccount struct {
 }
 
 // NewCurrentAccount creates a new current account
-func NewCurrentAccount(accountID, iban, customerID, currency string) (*CurrentAccount, error) {
+func NewCurrentAccount(accountID, iban, partyID, currency string) (*CurrentAccount, error) {
 	now := time.Now()
 	zeroMoney, err := NewMoney(currency, 0)
 	if err != nil {
@@ -59,7 +59,7 @@ func NewCurrentAccount(accountID, iban, customerID, currency string) (*CurrentAc
 		ID:                    uuid.New(),
 		AccountID:             accountID,
 		AccountIdentification: iban,
-		CustomerID:            customerID,
+		PartyID:               partyID,
 		Balance:               zeroMoney,
 		AvailableBalance:      zeroMoney,
 		Status:                AccountStatusActive,

--- a/services/current-account/migrations/20251209100000_rename_customer_id_to_party_id.sql
+++ b/services/current-account/migrations/20251209100000_rename_customer_id_to_party_id.sql
@@ -1,0 +1,16 @@
+-- Migration: Rename customer_id to party_id
+-- This migration completes the transition from local customer management to Party Service.
+-- The customer_id column is renamed to party_id to better reflect that it references
+-- a party in the Party Service (accessed via gRPC).
+
+-- Rename the column
+ALTER TABLE "current_account"."accounts"
+    RENAME COLUMN "customer_id" TO "party_id";
+
+-- Drop the old index and create a new one with the correct name
+DROP INDEX IF EXISTS "current_account"."idx_current_account_accounts_customer_id";
+CREATE INDEX "idx_current_account_accounts_party_id" ON "current_account"."accounts" ("party_id");
+
+-- Update the column comment
+COMMENT ON COLUMN "current_account"."accounts"."party_id" IS
+    'References a party in the Party Service (accessed via gRPC). Not a foreign key constraint as Party Service is a separate microservice.';

--- a/shared/platform/testdb/schema_validation_test.go
+++ b/shared/platform/testdb/schema_validation_test.go
@@ -201,7 +201,7 @@ func testLienEntity(t *testing.T, db *gorm.DB) {
 	t.Helper()
 
 	// Create an account (liens have FK to accounts)
-	// Note: customer_id is now a reference to Party Service (no FK constraint)
+	// Note: party_id is a reference to Party Service (no FK constraint)
 	accountID := uuid.New()
 	partyID := uuid.New() // References a party in Party Service (no local FK)
 	account := &capersistence.CurrentAccountEntity{
@@ -211,7 +211,7 @@ func testLienEntity(t *testing.T, db *gorm.DB) {
 		AccountType:           "current",
 		Currency:              "GBP",
 		Status:                "active",
-		CustomerID:            partyID,
+		PartyID:               partyID,
 		Balance:               50000,
 		AvailableBalance:      40000,
 		OverdraftLimit:        5000,
@@ -343,7 +343,7 @@ func testLienEntity(t *testing.T, db *gorm.DB) {
 func testCurrentAccountEntity(t *testing.T, db *gorm.DB) {
 	t.Helper()
 
-	// Note: customer_id is now a reference to Party Service (no local FK constraint)
+	// Note: party_id is a reference to Party Service (no local FK constraint)
 	// The customers table has been removed - party data is managed by Party Service
 	partyID := uuid.New() // References a party in Party Service
 
@@ -355,7 +355,7 @@ func testCurrentAccountEntity(t *testing.T, db *gorm.DB) {
 		AccountType:           "current",
 		Currency:              "GBP",
 		Status:                "active",
-		CustomerID:            partyID,
+		PartyID:               partyID,
 		Balance:               10000,
 		AvailableBalance:      8000,
 		OverdraftLimit:        5000,


### PR DESCRIPTION
## Summary
- Renames `customer_id` column to `party_id` in the database schema via migration
- Updates GORM entity and domain model to use `PartyID` instead of `CustomerID`
- Renames `FindByCustomerID` repository method to `FindByPartyID`
- Completes the transition from local customer management to Party Service integration

## Changes Made
- Add migration `20251209100000_rename_customer_id_to_party_id.sql`
- Update `CurrentAccountEntity.CustomerID` → `PartyID` with updated GORM tags
- Update `CurrentAccount.CustomerID` → `PartyID` in domain model
- Update constructor parameter naming in `NewCurrentAccount`
- Rename repository method and update SQL queries
- Update all test fixtures and test method names

## Test plan
- [x] Unit tests pass for domain package
- [x] Integration tests pass for persistence package (testcontainers)
- [x] Pre-commit checks pass (gofumpt, golangci-lint)
- [ ] CI/CD pipeline passes
- [ ] Migration tested against dev database