### PR TITLE
feat: use unqualified table names for multi-org search_path routing

### DIFF
--- a/services/current-account/adapters/persistence/account_entity.go
+++ b/services/current-account/adapters/persistence/account_entity.go
@@ -40,7 +40,9 @@ type CurrentAccountEntity struct {
 	DeletedAt *time.Time `gorm:"column:deleted_at;index"`
 }
 
-// TableName overrides the default table name with schema prefix
+// TableName overrides the default table name.
+// Uses unqualified name to allow PostgreSQL search_path to route queries
+// to organization-specific schemas (e.g., org_acme_bank.accounts).
 func (CurrentAccountEntity) TableName() string {
-	return "current_account.accounts"
+	return "accounts"
 }

--- a/services/current-account/adapters/persistence/lien_entity.go
+++ b/services/current-account/adapters/persistence/lien_entity.go
@@ -12,7 +12,7 @@ type LienEntity struct {
 	// Primary key
 	ID uuid.UUID `gorm:"primaryKey"`
 
-	// Foreign key to current_account.accounts
+	// Foreign key to accounts table (routed via search_path)
 	AccountID uuid.UUID `gorm:"not null;index:idx_liens_account_status"`
 
 	// Monetary amount

--- a/services/current-account/adapters/persistence/lien_entity.go
+++ b/services/current-account/adapters/persistence/lien_entity.go
@@ -37,7 +37,9 @@ type LienEntity struct {
 	Version   int       `gorm:"not null;default:1"`
 }
 
-// TableName overrides the default table name with schema prefix
+// TableName overrides the default table name.
+// Uses unqualified name to allow PostgreSQL search_path to route queries
+// to organization-specific schemas (e.g., org_acme_bank.liens).
 func (LienEntity) TableName() string {
-	return "current_account.liens"
+	return "liens"
 }

--- a/services/current-account/adapters/persistence/repository_test.go
+++ b/services/current-account/adapters/persistence/repository_test.go
@@ -508,28 +508,21 @@ func TestSave_UpdatePreservesCreatedByButUpdatesUpdatedBy(t *testing.T) {
 	assert.Equal(t, user2, entity.UpdatedBy, "updated_by should reflect the user who made the update")
 }
 
-// Multi-org mode integration tests
+// Multi-org integration tests
 //
-// NOTE: These tests are skipped because the current entity uses a fully-qualified
-// table name ("current_account.accounts") which bypasses PostgreSQL's search_path.
-// For multi-org mode to fully work, the entity would need to use just "accounts"
-// and rely on search_path for schema resolution. This is tracked separately.
+// Comprehensive multi-organization isolation tests are located in:
+// tests/multi_org/isolation_test.go
 //
-// The unit tests in gorm_organization_scope_test.go verify that SET LOCAL search_path
-// is correctly executed. These integration tests would verify end-to-end behavior
-// once the entity table naming is updated.
-
-func TestMultiOrg_SaveAndFindWithOrganizationContext(t *testing.T) {
-	t.Skip("Skipped: Entity uses fully-qualified table name 'current_account.accounts' which bypasses search_path. " +
-		"Multi-org integration requires entity to use unqualified table name 'accounts'.")
-}
-
-func TestMultiOrg_IsolationBetweenOrganizations(t *testing.T) {
-	t.Skip("Skipped: Entity uses fully-qualified table name 'current_account.accounts' which bypasses search_path. " +
-		"Multi-org integration requires entity to use unqualified table name 'accounts'.")
-}
-
-func TestMultiOrg_FindByIDForUpdate_SetsOrgScope(t *testing.T) {
-	t.Skip("Skipped: Entity uses fully-qualified table name 'current_account.accounts' which bypasses search_path. " +
-		"Multi-org integration requires entity to use unqualified table name 'accounts'.")
-}
+// These tests verify:
+// - Organization database isolation via search_path
+// - Cross-organization data isolation
+// - Concurrent access from multiple organizations
+// - Redis key prefixing per organization
+// - Kafka header propagation
+//
+// The entity now uses unqualified table name "accounts" which allows
+// PostgreSQL's search_path mechanism to route queries to organization-specific
+// schemas (e.g., org_acme_bank.accounts, org_motive_corp.accounts).
+//
+// See: shared/platform/db/gorm_organization_scope.go for the implementation
+// See: shared/platform/db/gorm_organization_scope_test.go for unit tests

--- a/shared/domain/models/account.go
+++ b/shared/domain/models/account.go
@@ -34,7 +34,9 @@ type Account struct {
 	ClosedAt *time.Time `gorm:"index" json:"closed_at,omitempty"`
 }
 
-// TableName overrides the table name used by Account to `current_account.accounts`
+// TableName overrides the table name.
+// Uses unqualified name to allow PostgreSQL search_path to route queries
+// to organization-specific schemas (e.g., org_acme_bank.accounts).
 func (Account) TableName() string {
-	return "current_account.accounts"
+	return "accounts"
 }

--- a/shared/domain/models/account_test.go
+++ b/shared/domain/models/account_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestAccount_TableName(t *testing.T) {
 	account := Account{}
-	if account.TableName() != "current_account.accounts" {
-		t.Errorf("TableName() = %v, want %v", account.TableName(), "current_account.accounts")
+	if account.TableName() != "accounts" {
+		t.Errorf("TableName() = %v, want %v", account.TableName(), "accounts")
 	}
 }
 

--- a/shared/platform/testdb/schema_validation_test.go
+++ b/shared/platform/testdb/schema_validation_test.go
@@ -110,11 +110,19 @@ func TestMigrationsMatchEntities(t *testing.T) {
 	// Now test that each entity can operate against the migrated schema
 	// These will fail if columns are missing or misnamed
 
+	// CurrentAccount entities use unqualified table names (accounts, liens) and rely on
+	// PostgreSQL search_path for schema routing. Set search_path to current_account schema.
 	t.Run("CurrentAccount/AccountEntity", func(t *testing.T) {
+		// Set search_path to current_account schema for unqualified table names
+		caDB := gormDB.Exec("SET search_path TO current_account, public")
+		require.NoError(t, caDB.Error, "Failed to set search_path for CurrentAccount tests")
 		testCurrentAccountEntity(t, gormDB)
 	})
 
 	t.Run("CurrentAccount/LienEntity", func(t *testing.T) {
+		// Set search_path to current_account schema for unqualified table names
+		caDB := gormDB.Exec("SET search_path TO current_account, public")
+		require.NoError(t, caDB.Error, "Failed to set search_path for CurrentAccount tests")
 		testLienEntity(t, gormDB)
 	})
 

--- a/utilities/atlas-loader/main_test.go
+++ b/utilities/atlas-loader/main_test.go
@@ -160,9 +160,13 @@ func TestOutputFormat(t *testing.T) {
 		assert.Contains(t, output, "CREATE TABLE", "output should contain CREATE TABLE")
 		assert.Contains(t, output, "PRIMARY KEY", "output should contain PRIMARY KEY")
 
-		// Verify schema qualification (with quotes)
-		assert.Contains(t, output, `"current_account"."customers"`, "table should be schema-qualified")
-		assert.Contains(t, output, `"current_account"."accounts"`, "table should be schema-qualified")
+		// Verify schema qualification for schema-bound tables
+		assert.Contains(t, output, `"current_account"."customers"`, "customers table should be schema-qualified")
+
+		// Verify unqualified table names for multi-org tables (accounts, liens)
+		// These use unqualified names to allow PostgreSQL search_path routing
+		assert.Contains(t, output, `CREATE TABLE "accounts"`, "accounts table should be unqualified for search_path routing")
+		assert.Contains(t, output, `CREATE TABLE "liens"`, "liens table should be unqualified for search_path routing")
 
 		// Verify no SQL syntax errors (basic check)
 		assert.NotContains(t, output, ";;", "should not have double semicolons")


### PR DESCRIPTION
## Summary

- Remove schema-qualified table names from GORM entities to enable PostgreSQL search_path to route queries to organization-specific schemas
- `CurrentAccountEntity.TableName()` now returns `"accounts"` instead of `"current_account.accounts"`
- `LienEntity.TableName()` now returns `"liens"` instead of `"current_account.liens"`
- `Account` (shared model) `TableName()` now returns `"accounts"`

## Technical Details

This enables the `WithGormOrganizationScope()` helper (in `shared/platform/db/gorm_organization_scope.go`) to set search_path at transaction start:

```sql
SET LOCAL search_path TO "org_acme_bank", public
```

With unqualified table names, GORM queries like `SELECT * FROM accounts` will resolve via search_path to the correct organization's schema (e.g., `org_acme_bank.accounts`).

## Test plan

- [x] Build passes (`go build ./...`)
- [x] Unit tests pass (`TestAccount_TableName`, etc.)
- [x] Linting passes (pre-commit hook verified)
- [ ] CI pipeline passes
- [ ] Comprehensive multi-org isolation tests in `tests/multi_org/isolation_test.go` verify end-to-end behavior

## Related

Task Master #33: Remove fully-qualified table name from GORM entity to enable multi-org isolation