### PR TITLE
feat(party): add Dockerfile for Party service

### DIFF
--- a/services/party/adapters/persistence/repository.go
+++ b/services/party/adapters/persistence/repository.go
@@ -185,9 +185,10 @@ func (r *Repository) Delete(partyID uuid.UUID) error {
 
 // Ping checks database connectivity without triggering record-not-found logging.
 // This is used by health checks to verify the database is reachable.
-func (r *Repository) Ping() error {
+// The context is used for cancellation and timeout support.
+func (r *Repository) Ping(ctx context.Context) error {
 	var result int
-	return r.db.Raw("SELECT 1").Scan(&result).Error
+	return r.db.WithContext(ctx).Raw("SELECT 1").Scan(&result).Error
 }
 
 // toEntity converts domain model to database entity

--- a/services/party/adapters/persistence/repository_test.go
+++ b/services/party/adapters/persistence/repository_test.go
@@ -435,7 +435,7 @@ func TestPing(t *testing.T) {
 
 	repo := NewRepository(db)
 
-	err := repo.Ping()
+	err := repo.Ping(context.Background())
 	assert.NoError(t, err)
 }
 

--- a/services/party/cmd/Dockerfile
+++ b/services/party/cmd/Dockerfile
@@ -1,0 +1,60 @@
+# Party Service - Multi-Stage Dockerfile
+# Optimized for security, size, and performance
+
+# Build stage
+FROM golang:1.25-alpine AS builder
+
+# Install build dependencies
+RUN apk add --no-cache \
+    git \
+    ca-certificates \
+    tzdata
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum* ./
+RUN go mod download && go mod verify
+
+# Copy source code
+COPY . .
+
+# Build static binary with optimizations
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-arm64} go build \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -a -installsuffix cgo \
+    -o party \
+    ./services/party/cmd
+
+# Verify the binary exists and is executable
+RUN test -x party && echo "Binary built successfully"
+
+# Runtime stage - distroless for minimal attack surface
+FROM gcr.io/distroless/static:nonroot
+
+# Copy CA certificates from builder
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy timezone data from builder
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary from builder
+COPY --from=builder /build/party /party
+
+# Use non-root user (distroless default: 65532:65532)
+USER nonroot:nonroot
+
+# Expose gRPC port
+EXPOSE 50055
+
+# Note: Health checks handled by gRPC health check service
+# HEALTHCHECK not needed in distroless image (lacks grpcurl)
+
+# Run the binary
+ENTRYPOINT ["/party"]

--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -31,9 +32,10 @@ var (
 )
 
 func main() {
-	// Initialize structured logging
+	// Initialize structured logging with configurable log level
+	logLevel := parseLogLevel(os.Getenv("LOG_LEVEL"))
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: logLevel,
 	}))
 	slog.SetDefault(logger)
 
@@ -289,4 +291,19 @@ func getEnvAsDuration(key string, defaultValue time.Duration) time.Duration {
 		return defaultValue
 	}
 	return value
+}
+
+// parseLogLevel converts a string log level to slog.Level.
+// Supports: debug, info, warn, error (case-insensitive). Defaults to info.
+func parseLogLevel(levelStr string) slog.Level {
+	switch strings.ToLower(levelStr) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
 }

--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -1,0 +1,292 @@
+// Package main is the entry point for the Party service.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/services/party/service"
+	"github.com/meridianhub/meridian/shared/pkg/interceptors"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+)
+
+// Build information set via ldflags during compilation
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+func main() {
+	// Initialize structured logging
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting party service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	// Run the service
+	if err := run(logger); err != nil {
+		logger.Error("service failed", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	ctx := context.Background()
+
+	// Initialize OpenTelemetry tracer
+	tracerConfig, err := observability.DefaultConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load tracer config: %w", err)
+	}
+
+	// Override service name and version from build info
+	tracerConfig = tracerConfig.
+		WithServiceName("party-service").
+		WithServiceVersion(Version)
+
+	tracer, err := observability.NewTracer(ctx, tracerConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := tracer.Shutdown(shutdownCtx); err != nil {
+			logger.Error("failed to shutdown tracer", "error", err)
+		}
+	}()
+
+	logger.Info("tracer initialized",
+		"service_name", tracerConfig.ServiceName,
+		"environment", tracerConfig.Environment,
+		"otlp_endpoint", tracerConfig.OTLPEndpoint,
+		"sampling_rate", tracerConfig.SamplingRate)
+
+	// Initialize database connection
+	db, err := initDatabase(logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize database: %w", err)
+	}
+	defer closeDatabase(db, logger)
+
+	logger.Info("database connection established")
+
+	// Create repository
+	repo := persistence.NewRepository(db)
+
+	// Create party service
+	partyService, err := service.NewService(repo, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create party service: %w", err)
+	}
+
+	logger.Info("party service initialized")
+
+	// Create gRPC server with interceptor chain
+	// Order: tracing → recovery (recovery last to catch all panics)
+	grpcServer := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(
+			tracer.UnaryServerInterceptor(),
+			interceptors.RecoveryUnaryInterceptor(logger),
+		),
+		grpc.ChainStreamInterceptor(
+			tracer.StreamServerInterceptor(),
+			interceptors.RecoveryStreamInterceptor(logger),
+		),
+	)
+
+	// Register services
+	pb.RegisterPartyServiceServer(grpcServer, partyService)
+
+	// Register health check service
+	healthChecker := service.NewHealthChecker(service.HealthCheckerConfig{
+		Repository:   repo,
+		Logger:       logger,
+		ServiceName:  "party",
+		CheckTimeout: 5 * time.Second,
+	})
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthChecker)
+
+	// Register reflection service for debugging
+	reflection.Register(grpcServer)
+
+	logger.Info("gRPC services registered")
+
+	// Get port from environment (default 50055 per task spec)
+	port := getEnvOrDefault("GRPC_PORT", "50055")
+	address := fmt.Sprintf(":%s", port)
+
+	// Create listener
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", address)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", address, err)
+	}
+
+	// Start gRPC server in background
+	serverErrors := make(chan error, 1)
+	go func() {
+		logger.Info("starting gRPC server", "address", address)
+		if err := grpcServer.Serve(listener); err != nil {
+			serverErrors <- err
+		}
+	}()
+
+	// Wait for interrupt signal or server error
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case sig := <-sigChan:
+		logger.Info("received signal", "signal", sig)
+	case err := <-serverErrors:
+		return fmt.Errorf("server error: %w", err)
+	}
+
+	// Graceful shutdown
+	logger.Info("shutting down server...")
+
+	// Create shutdown context with timeout
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Gracefully stop gRPC server
+	stopped := make(chan struct{})
+	go func() {
+		grpcServer.GracefulStop()
+		close(stopped)
+	}()
+
+	// Wait for graceful stop or timeout
+	select {
+	case <-stopped:
+		logger.Info("server stopped gracefully")
+	case <-shutdownCtx.Done():
+		logger.Warn("graceful shutdown timeout, forcing stop")
+		grpcServer.Stop()
+	}
+
+	return nil
+}
+
+// initDatabase initializes the database connection with connection pooling
+func initDatabase(logger *slog.Logger) (*gorm.DB, error) {
+	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable")
+
+	// Open database connection
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		// Disable default transaction for better performance
+		SkipDefaultTransaction: true,
+		// Prepare statements for better performance
+		PrepareStmt: true,
+		Logger:      nil, // Use slog instead of gorm's default logger
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to database: %w", err)
+	}
+
+	// Configure connection pool
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get database instance: %w", err)
+	}
+
+	// Connection pool settings
+	maxOpenConns := getEnvAsInt("DB_MAX_OPEN_CONNS", 25)
+	maxIdleConns := getEnvAsInt("DB_MAX_IDLE_CONNS", 5)
+	connMaxLifetime := getEnvAsDuration("DB_CONN_MAX_LIFETIME", 5*time.Minute)
+	connMaxIdleTime := getEnvAsDuration("DB_CONN_MAX_IDLE_TIME", 10*time.Minute)
+
+	sqlDB.SetMaxOpenConns(maxOpenConns)
+	sqlDB.SetMaxIdleConns(maxIdleConns)
+	sqlDB.SetConnMaxLifetime(connMaxLifetime)
+	sqlDB.SetConnMaxIdleTime(connMaxIdleTime)
+
+	logger.Info("database connection pool configured",
+		"max_open_conns", maxOpenConns,
+		"max_idle_conns", maxIdleConns,
+		"conn_max_lifetime", connMaxLifetime,
+		"conn_max_idle_time", connMaxIdleTime)
+
+	// Verify connection
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := sqlDB.PingContext(ctx); err != nil {
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	return db, nil
+}
+
+// closeDatabase closes the database connection gracefully
+func closeDatabase(db *gorm.DB, logger *slog.Logger) {
+	sqlDB, err := db.DB()
+	if err != nil {
+		logger.Error("failed to get database instance for closing", "error", err)
+		return
+	}
+
+	if err := sqlDB.Close(); err != nil {
+		logger.Error("failed to close database connection", "error", err)
+	} else {
+		logger.Info("database connection closed")
+	}
+}
+
+// getEnvOrDefault returns the environment variable value or default
+func getEnvOrDefault(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+// getEnvAsInt returns the environment variable value as int or default
+func getEnvAsInt(key string, defaultValue int) int {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	var value int
+	if _, err := fmt.Sscanf(valueStr, "%d", &value); err != nil {
+		return defaultValue
+	}
+	return value
+}
+
+// getEnvAsDuration returns the environment variable value as duration or default
+func getEnvAsDuration(key string, defaultValue time.Duration) time.Duration {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	value, err := time.ParseDuration(valueStr)
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}

--- a/services/party/service/health.go
+++ b/services/party/service/health.go
@@ -148,9 +148,8 @@ func (h *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, stream grp
 	for {
 		select {
 		case <-ctx.Done():
-			// Client disconnected - this is normal behavior, not an error
 			h.logger.Debug("health watch stream closed", "reason", ctx.Err())
-			return nil
+			return fmt.Errorf("health watch context cancelled: %w", ctx.Err())
 
 		case <-ticker.C:
 			resp, err := h.Check(ctx, req)

--- a/services/party/service/health.go
+++ b/services/party/service/health.go
@@ -255,7 +255,7 @@ func (d *DatabaseHealthChecker) Check(ctx context.Context) health.ComponentResul
 	defer cancel()
 
 	// Use Ping() which executes SELECT 1 - no record-not-found logging
-	err := d.repo.Ping()
+	err := d.repo.Ping(checkCtx)
 
 	responseTime := time.Since(start)
 

--- a/services/party/service/health.go
+++ b/services/party/service/health.go
@@ -1,0 +1,285 @@
+// Package service implements gRPC services for the party reference data domain
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// HealthChecker implements gRPC health check protocol for the Party service.
+// It checks the health of critical dependencies (database).
+type HealthChecker struct {
+	grpc_health_v1.UnimplementedHealthServer
+	repo         *persistence.Repository
+	logger       *slog.Logger
+	aggregator   *health.Aggregator
+	serviceName  string
+	checkTimeout time.Duration
+}
+
+// HealthCheckerConfig contains configuration for creating a new HealthChecker.
+type HealthCheckerConfig struct {
+	Repository   *persistence.Repository
+	Logger       *slog.Logger
+	ServiceName  string        // Defaults to "party"
+	CheckTimeout time.Duration // Defaults to 5 seconds
+}
+
+// NewHealthChecker creates a new health checker with dependency checking.
+//
+// The health checker evaluates:
+// - Database connectivity (critical)
+//
+// Health states:
+// - SERVING: Database is healthy
+// - NOT_SERVING: Database unreachable
+// - UNKNOWN: Unable to determine health
+func NewHealthChecker(config HealthCheckerConfig) *HealthChecker {
+	if config.Repository == nil {
+		panic("health checker requires non-nil repository")
+	}
+
+	// Apply defaults
+	if config.ServiceName == "" {
+		config.ServiceName = "party"
+	}
+	if config.CheckTimeout == 0 {
+		config.CheckTimeout = 5 * time.Second
+	}
+	if config.Logger == nil {
+		config.Logger = slog.Default()
+	}
+
+	// Build list of health checkers
+	checkers := []health.Checker{
+		NewDatabaseHealthChecker(config.Repository, config.CheckTimeout),
+	}
+
+	aggregator := health.NewAggregator(checkers)
+
+	return &HealthChecker{
+		repo:         config.Repository,
+		logger:       config.Logger,
+		aggregator:   aggregator,
+		serviceName:  config.ServiceName,
+		checkTimeout: config.CheckTimeout,
+	}
+}
+
+// Check implements gRPC health check protocol.
+// It performs synchronous health checks on all dependencies and returns the overall status.
+func (h *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	// Apply timeout to health check context
+	checkCtx, cancel := context.WithTimeout(ctx, h.checkTimeout)
+	defer cancel()
+
+	// Empty service name or matching service name: check all components
+	if req.Service == "" || req.Service == h.serviceName {
+		// Perform health check on all components
+		report := h.aggregator.CheckAll(checkCtx)
+		overallStatus := report.OverallStatus()
+
+		// Map health status to gRPC health check status
+		grpcStatus := h.mapStatusToGRPC(overallStatus)
+
+		// Log health check result
+		h.logHealthCheck(report, overallStatus, grpcStatus)
+
+		return &grpc_health_v1.HealthCheckResponse{
+			Status: grpcStatus,
+		}, nil
+	}
+
+	// Check if request is for a specific component
+	componentResult, found := h.aggregator.CheckByName(checkCtx, req.Service)
+	if found {
+		// Component found - return its specific health status
+		grpcStatus := h.mapStatusToGRPC(componentResult.Status)
+
+		// Log component health check
+		h.logger.Info("component health check completed",
+			"component", componentResult.Name,
+			"status", componentResult.Status.String(),
+			"grpc_status", grpcStatus.String(),
+			"response_time_ms", componentResult.ResponseTime.Milliseconds(),
+			"message", componentResult.Message)
+
+		return &grpc_health_v1.HealthCheckResponse{
+			Status: grpcStatus,
+		}, nil
+	}
+
+	// Service name doesn't match and component not found - return UNKNOWN
+	h.logger.Debug("health check for unknown service or component",
+		"requested", req.Service,
+		"service_name", h.serviceName)
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_UNKNOWN,
+	}, nil
+}
+
+// Watch implements streaming health checks.
+// It sends periodic health updates to the client over a stream.
+func (h *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, stream grpc_health_v1.Health_WatchServer) error {
+	ctx := stream.Context()
+
+	// Send immediate health check
+	resp, err := h.Check(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if err := stream.Send(resp); err != nil {
+		h.logger.Error("failed to send initial health check",
+			"error", err)
+		return fmt.Errorf("failed to send initial health status: %w", err)
+	}
+
+	// Stream periodic updates
+	ticker := time.NewTicker(h.checkTimeout)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			h.logger.Debug("health watch stream closed", "reason", ctx.Err())
+			return fmt.Errorf("health watch context cancelled: %w", ctx.Err())
+
+		case <-ticker.C:
+			resp, err := h.Check(ctx, req)
+			if err != nil {
+				h.logger.Error("health check failed during watch",
+					"error", err)
+				return err
+			}
+
+			if err := stream.Send(resp); err != nil {
+				h.logger.Error("failed to send health check update",
+					"error", err)
+				return fmt.Errorf("failed to send health status update: %w", err)
+			}
+		}
+	}
+}
+
+// mapStatusToGRPC converts internal health status to gRPC health check status.
+func (h *HealthChecker) mapStatusToGRPC(status health.Status) grpc_health_v1.HealthCheckResponse_ServingStatus {
+	switch status {
+	case health.StatusHealthy:
+		return grpc_health_v1.HealthCheckResponse_SERVING
+
+	case health.StatusDegraded:
+		// Degraded still serves requests
+		return grpc_health_v1.HealthCheckResponse_SERVING
+
+	case health.StatusUnhealthy:
+		return grpc_health_v1.HealthCheckResponse_NOT_SERVING
+
+	case health.StatusUnknown:
+		return grpc_health_v1.HealthCheckResponse_UNKNOWN
+
+	default:
+		return grpc_health_v1.HealthCheckResponse_UNKNOWN
+	}
+}
+
+// logHealthCheck logs the health check result with structured details.
+func (h *HealthChecker) logHealthCheck(report *health.Report, overallStatus health.Status, grpcStatus grpc_health_v1.HealthCheckResponse_ServingStatus) {
+	// Build component status map for structured logging
+	componentStatuses := make(map[string]string)
+	for _, comp := range report.Components {
+		componentStatuses[comp.Name] = comp.Status.String()
+	}
+
+	// Log at appropriate level based on status
+	switch overallStatus {
+	case health.StatusHealthy, health.StatusDegraded:
+		h.logger.Info("health check completed",
+			"overall_status", overallStatus.String(),
+			"grpc_status", grpcStatus.String(),
+			"component_count", len(report.Components),
+			"components", componentStatuses)
+
+	case health.StatusUnhealthy, health.StatusUnknown:
+		h.logger.Warn("health check detected issues",
+			"overall_status", overallStatus.String(),
+			"grpc_status", grpcStatus.String(),
+			"component_count", len(report.Components),
+			"components", componentStatuses)
+
+		// Log individual component failures
+		for _, comp := range report.Components {
+			if comp.Status == health.StatusUnhealthy || comp.Status == health.StatusUnknown {
+				h.logger.Error("component unhealthy",
+					"component", comp.Name,
+					"status", comp.Status.String(),
+					"message", comp.Message,
+					"response_time_ms", comp.ResponseTime.Milliseconds(),
+					"error", comp.Error)
+			}
+		}
+	}
+}
+
+// DatabaseHealthChecker checks database connectivity.
+type DatabaseHealthChecker struct {
+	repo    *persistence.Repository
+	timeout time.Duration
+}
+
+// NewDatabaseHealthChecker creates a new database health checker.
+func NewDatabaseHealthChecker(repo *persistence.Repository, timeout time.Duration) *DatabaseHealthChecker {
+	return &DatabaseHealthChecker{
+		repo:    repo,
+		timeout: timeout,
+	}
+}
+
+// Name returns the component name.
+func (d *DatabaseHealthChecker) Name() string {
+	return "database"
+}
+
+// Check performs a database health check by executing a simple query.
+func (d *DatabaseHealthChecker) Check(ctx context.Context) health.ComponentResult {
+	start := time.Now()
+
+	// Create timeout context
+	checkCtx, cancel := context.WithTimeout(ctx, d.timeout)
+	defer cancel()
+
+	// Use Ping() which executes SELECT 1 - no record-not-found logging
+	err := d.repo.Ping()
+
+	responseTime := time.Since(start)
+
+	status := health.StatusHealthy
+	message := "database connection successful"
+
+	if err != nil {
+		status = health.StatusUnhealthy
+		message = fmt.Sprintf("database check failed: %v", err)
+	}
+
+	// Check context cancellation (timeout)
+	if checkCtx.Err() != nil {
+		status = health.StatusUnhealthy
+		message = fmt.Sprintf("database check timeout after %s", d.timeout)
+		err = checkCtx.Err()
+	}
+
+	return health.ComponentResult{
+		Name:         d.Name(),
+		Status:       status,
+		Message:      message,
+		ResponseTime: responseTime,
+		CheckedAt:    start,
+		Error:        err,
+	}
+}

--- a/services/party/service/health.go
+++ b/services/party/service/health.go
@@ -148,8 +148,9 @@ func (h *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, stream grp
 	for {
 		select {
 		case <-ctx.Done():
+			// Client disconnected - this is normal behavior, not an error
 			h.logger.Debug("health watch stream closed", "reason", ctx.Err())
-			return fmt.Errorf("health watch context cancelled: %w", ctx.Err())
+			return nil
 
 		case <-ticker.C:
 			resp, err := h.Check(ctx, req)


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile for Party service
- Follow current-account service patterns for consistency
- Use distroless base for minimal attack surface

## Changes Made
- Create `services/party/cmd/Dockerfile` with:
  - Build stage using `golang:1.25-alpine`
  - Runtime stage using `gcr.io/distroless/static:nonroot`
  - CA certificates and timezone data copying
  - Build metadata injection via ldflags
  - Non-root user enforcement

## Technical Details
The Dockerfile follows the established pattern from current-account service:
- Multi-arch support via TARGETARCH build arg
- Static binary with CGO disabled
- Non-root user (65532:65532) for security
- Exposed gRPC port 50055

## Test plan
- [ ] CI builds Docker image successfully
- [ ] Image runs and serves gRPC on port 50055
- [ ] Verify nonroot user with `docker inspect`

## Dependencies
- Depends on PR #270 (Party service entry point)