### PR TITLE
Add organization scoping to LienRepository read-only methods

### DIFF
--- a/services/current-account/adapters/persistence/lien_repository.go
+++ b/services/current-account/adapters/persistence/lien_repository.go
@@ -2,12 +2,15 @@
 package persistence
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/current-account/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/meridianhub/meridian/shared/platform/organization"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -35,23 +38,50 @@ func (r *LienRepository) WithTx(tx *gorm.DB) *LienRepository {
 	return &LienRepository{db: tx}
 }
 
+// hasOrganizationContext checks if organization context is present (multi-org mode).
+func (r *LienRepository) hasOrganizationContext(ctx context.Context) bool {
+	_, ok := organization.FromContext(ctx)
+	return ok
+}
+
+// withOptionalOrgScope executes the given function with optional organization scoping.
+// In single-tenant mode (no org context), it runs the function directly without a transaction.
+// In multi-org mode, it wraps the function in a transaction and sets the search_path.
+// This helper reduces code duplication across repository methods.
+func (r *LienRepository) withOptionalOrgScope(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if !r.hasOrganizationContext(ctx) {
+		// Single-tenant mode: run directly without transaction overhead
+		return fn(r.db.WithContext(ctx))
+	}
+	// Multi-org mode: use the shared helper that handles transaction + org scope
+	return db.WithGormOrganizationTransaction(ctx, r.db, fn)
+}
+
 // Create inserts a new lien
 func (r *LienRepository) Create(lien *domain.Lien) error {
 	entity := toLienEntity(lien)
 	return r.db.Create(entity).Error
 }
 
-// FindByID retrieves a lien by its UUID
-func (r *LienRepository) FindByID(id uuid.UUID) (*domain.Lien, error) {
+// FindByID retrieves a lien by its UUID.
+// In multi-org mode, this query is scoped to the organization from context.
+func (r *LienRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.Lien, error) {
 	var entity LienEntity
-	result := r.db.Where("id = ?", id).First(&entity)
+	var queryErr error
 
-	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		return nil, ErrLienNotFound
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("id = ?", id).First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, ErrLienNotFound
+		}
+		return nil, err
 	}
 
 	return toLienDomain(&entity)
@@ -122,17 +152,25 @@ func (r *LienRepository) FindActiveByAccountID(accountID uuid.UUID) ([]*domain.L
 	return liens, nil
 }
 
-// FindByPaymentOrderReference retrieves a lien by its payment order reference
-func (r *LienRepository) FindByPaymentOrderReference(reference string) (*domain.Lien, error) {
+// FindByPaymentOrderReference retrieves a lien by its payment order reference.
+// In multi-org mode, this query is scoped to the organization from context.
+func (r *LienRepository) FindByPaymentOrderReference(ctx context.Context, reference string) (*domain.Lien, error) {
 	var entity LienEntity
-	result := r.db.Where("payment_order_reference = ?", reference).First(&entity)
+	var queryErr error
 
-	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		return nil, ErrLienNotFound
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("payment_order_reference = ?", reference).First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, ErrLienNotFound
+		}
+		return nil, err
 	}
 
 	return toLienDomain(&entity)
@@ -169,36 +207,40 @@ func (r *LienRepository) Update(lien *domain.Lien) error {
 // SumActiveAmountByAccountID returns the total amount of active non-expired liens for an account in cents.
 // Returns ErrLienCurrencyInconsistent if liens with different currencies exist (indicates data corruption).
 // Currency validation is enforced at the service layer when creating liens (InitiateLien).
-func (r *LienRepository) SumActiveAmountByAccountID(accountID uuid.UUID) (int64, error) {
+// In multi-org mode, this query is scoped to the organization from context.
+func (r *LienRepository) SumActiveAmountByAccountID(ctx context.Context, accountID uuid.UUID) (int64, error) {
 	// Capture timestamp once to ensure consistency between the two queries
 	now := time.Now()
-
-	// First, check for currency consistency (defensive check for data corruption)
 	var currencyCount int64
-	countResult := r.db.Model(&LienEntity{}).
-		Where("account_id = ? AND status = ? AND (expires_at IS NULL OR expires_at > ?)",
-			accountID, string(domain.LienStatusActive), now).
-		Select("COUNT(DISTINCT currency)").
-		Scan(&currencyCount)
-
-	if countResult.Error != nil {
-		return 0, countResult.Error
-	}
-
-	if currencyCount > 1 {
-		return 0, ErrLienCurrencyInconsistent
-	}
-
-	// Sum active non-expired liens
 	var totalCents int64
-	result := r.db.Model(&LienEntity{}).
-		Where("account_id = ? AND status = ? AND (expires_at IS NULL OR expires_at > ?)",
-			accountID, string(domain.LienStatusActive), now).
-		Select("COALESCE(SUM(amount_cents), 0)").
-		Scan(&totalCents)
 
-	if result.Error != nil {
-		return 0, result.Error
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		// First, check for currency consistency (defensive check for data corruption)
+		countResult := tx.Model(&LienEntity{}).
+			Where("account_id = ? AND status = ? AND (expires_at IS NULL OR expires_at > ?)",
+				accountID, string(domain.LienStatusActive), now).
+			Select("COUNT(DISTINCT currency)").
+			Scan(&currencyCount)
+
+		if countResult.Error != nil {
+			return countResult.Error
+		}
+
+		if currencyCount > 1 {
+			return ErrLienCurrencyInconsistent
+		}
+
+		// Sum active non-expired liens
+		result := tx.Model(&LienEntity{}).
+			Where("account_id = ? AND status = ? AND (expires_at IS NULL OR expires_at > ?)",
+				accountID, string(domain.LienStatusActive), now).
+			Select("COALESCE(SUM(amount_cents), 0)").
+			Scan(&totalCents)
+
+		return result.Error
+	})
+	if err != nil {
+		return 0, err
 	}
 
 	return totalCents, nil

--- a/services/current-account/adapters/persistence/lien_repository_test.go
+++ b/services/current-account/adapters/persistence/lien_repository_test.go
@@ -2,6 +2,7 @@
 package persistence
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -35,7 +36,7 @@ func TestLienRepository_Create(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify lien was saved
-	retrieved, err := repo.FindByID(lien.ID)
+	retrieved, err := repo.FindByID(context.Background(), lien.ID)
 	require.NoError(t, err)
 
 	assert.Equal(t, lien.ID, retrieved.ID)
@@ -52,7 +53,7 @@ func TestLienRepository_FindByID_NotFound(t *testing.T) {
 
 	repo := NewLienRepository(db)
 
-	_, err := repo.FindByID(uuid.New())
+	_, err := repo.FindByID(context.Background(), uuid.New())
 	assert.ErrorIs(t, err, ErrLienNotFound)
 }
 
@@ -163,7 +164,7 @@ func TestLienRepository_FindByPaymentOrderReference(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, repo.Create(lien))
 
-	retrieved, err := repo.FindByPaymentOrderReference("PO-UNIQUE-123")
+	retrieved, err := repo.FindByPaymentOrderReference(context.Background(), "PO-UNIQUE-123")
 	require.NoError(t, err)
 
 	assert.Equal(t, lien.ID, retrieved.ID)
@@ -175,7 +176,7 @@ func TestLienRepository_FindByPaymentOrderReference_NotFound(t *testing.T) {
 
 	repo := NewLienRepository(db)
 
-	_, err := repo.FindByPaymentOrderReference("PO-NONEXISTENT")
+	_, err := repo.FindByPaymentOrderReference(context.Background(), "PO-NONEXISTENT")
 	assert.ErrorIs(t, err, ErrLienNotFound)
 }
 
@@ -197,7 +198,7 @@ func TestLienRepository_Update_Execute(t *testing.T) {
 	require.NoError(t, repo.Update(lien))
 
 	// Verify status was updated
-	retrieved, err := repo.FindByID(lien.ID)
+	retrieved, err := repo.FindByID(context.Background(), lien.ID)
 	require.NoError(t, err)
 
 	assert.Equal(t, domain.LienStatusExecuted, retrieved.Status)
@@ -222,7 +223,7 @@ func TestLienRepository_Update_Terminate(t *testing.T) {
 	require.NoError(t, repo.Update(lien))
 
 	// Verify status and reason were updated
-	retrieved, err := repo.FindByID(lien.ID)
+	retrieved, err := repo.FindByID(context.Background(), lien.ID)
 	require.NoError(t, err)
 
 	assert.Equal(t, domain.LienStatusTerminated, retrieved.Status)
@@ -245,10 +246,10 @@ func TestLienRepository_OptimisticLocking(t *testing.T) {
 	require.NoError(t, repo.Create(lien))
 
 	// Load same lien twice (simulating concurrent access)
-	lien1, err := repo.FindByID(lien.ID)
+	lien1, err := repo.FindByID(context.Background(), lien.ID)
 	require.NoError(t, err)
 
-	lien2, err := repo.FindByID(lien.ID)
+	lien2, err := repo.FindByID(context.Background(), lien.ID)
 	require.NoError(t, err)
 
 	// First update succeeds
@@ -261,7 +262,7 @@ func TestLienRepository_OptimisticLocking(t *testing.T) {
 	assert.ErrorIs(t, err, ErrLienVersionConflict)
 
 	// Verify first transaction's changes persisted
-	final, err := repo.FindByID(lien.ID)
+	final, err := repo.FindByID(context.Background(), lien.ID)
 	require.NoError(t, err)
 
 	assert.Equal(t, domain.LienStatusExecuted, final.Status)
@@ -292,7 +293,7 @@ func TestLienRepository_SumActiveAmountByAccountID(t *testing.T) {
 	require.NoError(t, repo.Update(lien3))
 
 	// Sum should only include active non-expired liens
-	total, err := repo.SumActiveAmountByAccountID(accountID)
+	total, err := repo.SumActiveAmountByAccountID(context.Background(), accountID)
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(35000), total) // £200 + £150 = £350
@@ -317,7 +318,7 @@ func TestLienRepository_SumActiveAmountByAccountID_ExcludesExpired(t *testing.T)
 	require.NoError(t, repo.Create(lien2))
 
 	// Sum should only include non-expired active liens
-	total, err := repo.SumActiveAmountByAccountID(accountID)
+	total, err := repo.SumActiveAmountByAccountID(context.Background(), accountID)
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(20000), total) // Only £200, expired lien excluded
@@ -350,7 +351,7 @@ func TestLienRepository_SumActiveAmountByAccountID_CurrencyInconsistency(t *test
 	require.NoError(t, db.Create(corruptedEntity).Error)
 
 	// Sum should return currency inconsistency error
-	_, err := repo.SumActiveAmountByAccountID(accountID)
+	_, err := repo.SumActiveAmountByAccountID(context.Background(), accountID)
 	assert.ErrorIs(t, err, ErrLienCurrencyInconsistent)
 }
 
@@ -361,7 +362,7 @@ func TestLienRepository_SumActiveAmountByAccountID_NoLiens(t *testing.T) {
 	repo := NewLienRepository(db)
 	accountID := uuid.New()
 
-	total, err := repo.SumActiveAmountByAccountID(accountID)
+	total, err := repo.SumActiveAmountByAccountID(context.Background(), accountID)
 	require.NoError(t, err)
 
 	assert.Equal(t, int64(0), total)
@@ -381,7 +382,7 @@ func TestLienRepository_CreateWithExpiration(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, repo.Create(lien))
 
-	retrieved, err := repo.FindByID(lien.ID)
+	retrieved, err := repo.FindByID(context.Background(), lien.ID)
 	require.NoError(t, err)
 
 	require.NotNil(t, retrieved.ExpiresAt)
@@ -429,7 +430,7 @@ func TestLienRepository_FindByID_CorruptedData_ReturnsError(t *testing.T) {
 	}
 	require.NoError(t, db.Create(corruptedEntity).Error)
 
-	_, err := repo.FindByID(corruptedEntity.ID)
+	_, err := repo.FindByID(context.Background(), corruptedEntity.ID)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "database")

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -136,7 +136,7 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		}
 
 		// Calculate available balance (within the lock)
-		activeLiensTotal, err := txLienRepo.SumActiveAmountByAccountID(account.ID)
+		activeLiensTotal, err := txLienRepo.SumActiveAmountByAccountID(ctx, account.ID)
 		if err != nil {
 			return fmt.Errorf("%w: %w", errTxSumLiensFailed, err)
 		}
@@ -232,7 +232,8 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 	}
 
 	// First, check for idempotency without locking (read-only check)
-	lien, err := s.lienRepo.FindByID(lienID)
+	// Note: Context is passed to enable organization scoping in multi-org mode
+	lien, err := s.lienRepo.FindByID(ctx, lienID)
 	if err != nil {
 		if errors.Is(err, persistence.ErrLienNotFound) {
 			operationStatus = opStatusLienNotFound
@@ -357,7 +358,7 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		"amount_cents", lien.Amount.AmountCents(),
 		"transaction_id", transactionID)
 
-	availableMoney := s.calculateAvailableBalance(lien.AccountID, account.Balance)
+	availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance)
 	return &pb.ExecuteLienResponse{
 		Lien:             toLienProto(lien),
 		NewBalance:       toMoneyAmount(account.Balance),
@@ -388,7 +389,8 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 	}
 
 	// First, check for idempotency without locking (read-only check)
-	lien, err := s.lienRepo.FindByID(lienID)
+	// Note: Context is passed to enable organization scoping in multi-org mode
+	lien, err := s.lienRepo.FindByID(ctx, lienID)
 	if err != nil {
 		if errors.Is(err, persistence.ErrLienNotFound) {
 			operationStatus = opStatusLienNotFound
@@ -409,7 +411,7 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 			s.logger.Error("failed to find account for idempotent response", "error", acctErr)
 			return &pb.TerminateLienResponse{Lien: toLienProto(lien)}, nil
 		}
-		availableMoney := s.calculateAvailableBalance(lien.AccountID, account.Balance)
+		availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance)
 		return &pb.TerminateLienResponse{
 			Lien:             toLienProto(lien),
 			AvailableBalance: toMoneyAmount(availableMoney),
@@ -496,7 +498,7 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
 	}
 
-	availableMoney := s.calculateAvailableBalance(lien.AccountID, account.Balance)
+	availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance)
 	return &pb.TerminateLienResponse{
 		Lien:             toLienProto(lien),
 		AvailableBalance: toMoneyAmount(availableMoney),
@@ -504,7 +506,7 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 }
 
 // RetrieveLien gets lien details
-func (s *Service) RetrieveLien(_ context.Context, req *pb.RetrieveLienRequest) (*pb.RetrieveLienResponse, error) {
+func (s *Service) RetrieveLien(ctx context.Context, req *pb.RetrieveLienRequest) (*pb.RetrieveLienResponse, error) {
 	start := time.Now()
 	operationStatus := operationStatusSuccess
 	defer func() {
@@ -524,8 +526,8 @@ func (s *Service) RetrieveLien(_ context.Context, req *pb.RetrieveLienRequest) (
 		return nil, status.Errorf(codes.InvalidArgument, "invalid lien ID: %v", err)
 	}
 
-	// Retrieve lien
-	lien, err := s.lienRepo.FindByID(lienID)
+	// Retrieve lien (context is passed for organization scoping in multi-org mode)
+	lien, err := s.lienRepo.FindByID(ctx, lienID)
 	if err != nil {
 		if errors.Is(err, persistence.ErrLienNotFound) {
 			operationStatus = opStatusLienNotFound
@@ -599,7 +601,7 @@ func (s *Service) buildExecuteLienIdempotentResponse(ctx context.Context, lien *
 		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
 	}
 
-	availableMoney := s.calculateAvailableBalance(lien.AccountID, account.Balance)
+	availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance)
 	return &pb.ExecuteLienResponse{
 		Lien:             toLienProto(lien),
 		NewBalance:       toMoneyAmount(account.Balance),
@@ -616,7 +618,7 @@ func (s *Service) checkLienIdempotency(ctx context.Context, paymentOrderRef stri
 		return nil, false, nil
 	}
 
-	existingLien, err := s.lienRepo.FindByPaymentOrderReference(paymentOrderRef)
+	existingLien, err := s.lienRepo.FindByPaymentOrderReference(ctx, paymentOrderRef)
 	if err != nil {
 		if errors.Is(err, persistence.ErrLienNotFound) {
 			return nil, false, nil // Not found - continue with creation
@@ -635,7 +637,7 @@ func (s *Service) checkLienIdempotency(ctx context.Context, paymentOrderRef stri
 		s.logger.Error("failed to retrieve account for idempotent response", "error", acctErr)
 		return &pb.InitiateLienResponse{Lien: toLienProto(existingLien)}, true, nil
 	}
-	availableMoney := s.calculateAvailableBalance(existingLien.AccountID, account.Balance)
+	availableMoney := s.calculateAvailableBalance(ctx, existingLien.AccountID, account.Balance)
 	return &pb.InitiateLienResponse{
 		Lien:             toLienProto(existingLien),
 		AvailableBalance: toMoneyAmount(availableMoney),
@@ -644,8 +646,9 @@ func (s *Service) checkLienIdempotency(ctx context.Context, paymentOrderRef stri
 
 // calculateAvailableBalance calculates available balance with active liens.
 // Logs errors but returns best-effort values since primary operations already succeeded.
-func (s *Service) calculateAvailableBalance(accountID uuid.UUID, currentBalance domain.Money) domain.Money {
-	activeLiensTotal, err := s.lienRepo.SumActiveAmountByAccountID(accountID)
+// Context is required for organization scoping in multi-org mode.
+func (s *Service) calculateAvailableBalance(ctx context.Context, accountID uuid.UUID, currentBalance domain.Money) domain.Money {
+	activeLiensTotal, err := s.lienRepo.SumActiveAmountByAccountID(ctx, accountID)
 	if err != nil {
 		s.logger.Error("failed to sum active liens for response", "error", err)
 		return currentBalance // Best effort: return current balance if liens can't be summed


### PR DESCRIPTION
## Summary

- Add organization scoping to LienRepository read-only query methods for multi-tenant isolation
- Methods updated: `FindByID`, `FindByPaymentOrderReference`, `SumActiveAmountByAccountID`
- Uses same pattern as main Repository with `withOptionalOrgScope` helper

## Changes Made

- Added `context.Context` parameter to read-only methods
- Added `hasOrganizationContext` and `withOptionalOrgScope` helper methods
- Updated all callsites in `lien_service.go` to pass context
- Updated tests to include context parameter

## Technical Details

The implementation follows the same pattern used in `repository.go`:
- In multi-org mode, queries are scoped to the organization via PostgreSQL `search_path`
- In single-tenant mode (no org context), queries run directly without scoping overhead

## Test plan

- [ ] Verify lien repository tests pass
- [ ] Verify service integration tests pass
- [ ] Test in multi-org environment to confirm tenant isolation