### PR TITLE
feat(current-account): integrate Party client for account creation validation

### DIFF
--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -364,12 +364,33 @@ func createServiceWithClients(
 		},
 	)
 
+	// Create Party client with DNS-based load balancing
+	partyGRPCClient, err := clients.NewPartyClient(&clients.PartyClientConfig{
+		ServiceName: "party",
+		Namespace:   namespace,
+		Port:        50054,
+		Timeout:     30 * time.Second,
+		Tracer:      tracer,
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to create party client: %w", err)
+	}
+
+	// Wrap with resilience patterns (circuit breaker + retry)
+	resilientPartyClient := clients.NewResilientPartyClient(
+		partyGRPCClient,
+		clients.ResilientClientConfig{
+			Logger: logger,
+		},
+	)
+
 	// Create service with the pre-created clients
 	svc, err := service.NewServiceWithExistingClients(
 		repo,
 		lienRepo,
 		resilientPosKeepingClient,
 		resilientFinAcctClient,
+		resilientPartyClient,
 		logger,
 		tracer,
 	)

--- a/services/current-account/observability/metrics.go
+++ b/services/current-account/observability/metrics.go
@@ -78,6 +78,16 @@ var (
 		},
 		[]string{"service", "operation"},
 	)
+
+	// Party validation metrics
+	partyValidationDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "current_account_party_validation_duration_seconds",
+			Help:    "Duration of party validation calls in seconds",
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+		},
+		[]string{"success"},
+	)
 )
 
 // RecordOperationDuration records the duration of a current account operation
@@ -118,4 +128,13 @@ func RecordSagaDuration(operation, status string, duration time.Duration) {
 // RecordExternalServiceError records an external service error
 func RecordExternalServiceError(service, operation string) {
 	externalServiceErrors.WithLabelValues(service, operation).Inc()
+}
+
+// RecordPartyValidationDuration records the duration of a party validation call
+func RecordPartyValidationDuration(duration time.Duration, success bool) {
+	successLabel := "false"
+	if success {
+		successLabel = "true"
+	}
+	partyValidationDuration.WithLabelValues(successLabel).Observe(duration.Seconds())
 }

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -36,6 +36,10 @@ var (
 	ErrOriginalAccountStateNotFound   = errors.New("original account state not available for compensation")
 	ErrPositionLogIDNotFound          = errors.New("position log ID not available for compensation")
 	ErrLedgerPostingIDNotFound        = errors.New("ledger posting ID not available for compensation")
+
+	// Party validation errors (re-exported from clients package for convenience)
+	ErrPartyNotFound  = clients.ErrPartyNotFound
+	ErrPartyNotActive = clients.ErrPartyNotActive
 )
 
 // Operation status constants for consistency across the service
@@ -51,6 +55,7 @@ type Service struct {
 	lienRepo         *persistence.LienRepository
 	posKeepingClient clients.PositionKeepingClient
 	finAcctClient    clients.FinancialAccountingClient
+	partyClient      clients.PartyClient
 	logger           *slog.Logger
 	tracer           *observability.Tracer
 }
@@ -61,6 +66,7 @@ type Config struct {
 	LienRepository            *persistence.LienRepository
 	PositionKeepingTarget     string // e.g., "positionkeeping-service:50051"
 	FinancialAccountingTarget string // e.g., "financialaccounting-service:50052"
+	PartyServiceTarget        string // e.g., "party-service:50054"
 	Logger                    *slog.Logger
 	Tracer                    *observability.Tracer
 }
@@ -86,6 +92,7 @@ func NewServiceWithExistingClients(
 	lienRepo *persistence.LienRepository,
 	posKeepingClient clients.PositionKeepingClient,
 	finAcctClient clients.FinancialAccountingClient,
+	partyClient clients.PartyClient,
 	logger *slog.Logger,
 	tracer *observability.Tracer,
 ) (*Service, error) {
@@ -103,6 +110,7 @@ func NewServiceWithExistingClients(
 		lienRepo:         lienRepo,
 		posKeepingClient: posKeepingClient,
 		finAcctClient:    finAcctClient,
+		partyClient:      partyClient,
 		logger:           logger,
 		tracer:           tracer,
 	}, nil
@@ -165,11 +173,32 @@ func NewServiceWithClients(config Config) (*Service, error) {
 		},
 	)
 
+	// Create Party client (optional - nil client provides backward compatibility)
+	var resilientPartyClient clients.PartyClient
+	if config.PartyServiceTarget != "" {
+		partyGRPCClient, err := clients.NewPartyClient(&clients.PartyClientConfig{
+			Target:  config.PartyServiceTarget,
+			Timeout: 30 * time.Second,
+			Tracer:  config.Tracer,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create party client: %w", err)
+		}
+
+		resilientPartyClient = clients.NewResilientPartyClient(
+			partyGRPCClient,
+			clients.ResilientClientConfig{
+				Logger: logger,
+			},
+		)
+	}
+
 	return &Service{
 		repo:             config.Repository,
 		lienRepo:         config.LienRepository,
 		posKeepingClient: resilientPosKeepingClient,
 		finAcctClient:    resilientFinAcctClient,
+		partyClient:      resilientPartyClient,
 		logger:           logger,
 		tracer:           config.Tracer,
 	}, nil
@@ -191,6 +220,45 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 	if currency == "" {
 		operationStatus = operationStatusInvalidCurrency
 		return nil, status.Errorf(codes.InvalidArgument, "unsupported currency: %v", req.BaseCurrency)
+	}
+
+	// Validate party exists and is active (if party client is configured)
+	if s.partyClient != nil {
+		partyValidationStart := time.Now()
+		s.logger.Info("validating party for account creation",
+			"party_id", req.PartyId,
+			"account_id", accountID)
+
+		if err := s.partyClient.ValidateParty(ctx, req.PartyId); err != nil {
+			caobservability.RecordPartyValidationDuration(time.Since(partyValidationStart), false)
+
+			if errors.Is(err, ErrPartyNotFound) {
+				operationStatus = "party_not_found"
+				s.logger.Warn("party not found during account creation",
+					"party_id", req.PartyId,
+					"account_id", accountID)
+				return nil, status.Errorf(codes.InvalidArgument, "party not found: %s", req.PartyId)
+			}
+			if errors.Is(err, ErrPartyNotActive) {
+				operationStatus = "party_not_active"
+				s.logger.Warn("party not active during account creation",
+					"party_id", req.PartyId,
+					"account_id", accountID)
+				return nil, status.Errorf(codes.FailedPrecondition, "party not active: %s", req.PartyId)
+			}
+			operationStatus = "party_validation_failed"
+			s.logger.Error("party validation failed during account creation",
+				"party_id", req.PartyId,
+				"account_id", accountID,
+				"error", err)
+			caobservability.RecordExternalServiceError("party", "validate_party")
+			return nil, status.Errorf(codes.Internal, "party validation failed: %v", err)
+		}
+
+		caobservability.RecordPartyValidationDuration(time.Since(partyValidationStart), true)
+		s.logger.Info("party validated successfully",
+			"party_id", req.PartyId,
+			"account_id", accountID)
 	}
 
 	// Create domain model

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -2,12 +2,14 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
@@ -524,4 +526,220 @@ func TestExecuteDeposit_SafeAddition_UnitsAndNanos(t *testing.T) {
 	if !strings.Contains(st.Message(), "overflow") && !strings.Contains(st.Message(), "must be positive") {
 		t.Errorf("Error should mention overflow or positivity, got: %s", st.Message())
 	}
+}
+
+// Mock Party Client for testing party validation scenarios
+
+type mockPartyClient struct {
+	validatePartyFn func(ctx context.Context, partyID string) error
+}
+
+func (m *mockPartyClient) ValidateParty(ctx context.Context, partyID string) error {
+	if m.validatePartyFn != nil {
+		return m.validatePartyFn(ctx, partyID)
+	}
+	return nil
+}
+
+func (m *mockPartyClient) GetParty(_ context.Context, _ string) (*partyv1.Party, error) {
+	return nil, nil
+}
+
+func (m *mockPartyClient) Close() error {
+	return nil
+}
+
+// Party validation tests
+
+func TestInitiateCurrentAccount_WithPartyValidation_Success(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	partyID := uuid.New().String()
+
+	// Create mock party client that validates successfully
+	mockParty := &mockPartyClient{
+		validatePartyFn: func(_ context.Context, id string) error {
+			if id == partyID {
+				return nil
+			}
+			return ErrPartyNotFound
+		},
+	}
+
+	svc, err := NewServiceWithExistingClients(
+		repo,
+		nil, // lienRepo
+		nil, // posKeepingClient
+		nil, // finAcctClient
+		mockParty,
+		nil, // logger
+		nil, // tracer
+	)
+	require.NoError(t, err)
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               partyID,
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+	}
+
+	resp, err := svc.InitiateCurrentAccount(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.AccountId)
+	require.NotNil(t, resp.Facility)
+	require.Equal(t, pb.AccountStatus_ACCOUNT_STATUS_ACTIVE, resp.Facility.AccountStatus)
+}
+
+func TestInitiateCurrentAccount_PartyNotFound(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	partyID := uuid.New().String()
+
+	// Create mock party client that returns party not found
+	mockParty := &mockPartyClient{
+		validatePartyFn: func(_ context.Context, _ string) error {
+			return ErrPartyNotFound
+		},
+	}
+
+	svc, err := NewServiceWithExistingClients(
+		repo,
+		nil,
+		nil,
+		nil,
+		mockParty,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               partyID,
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+	}
+
+	_, err = svc.InitiateCurrentAccount(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "Expected gRPC status error")
+	require.Equal(t, codes.InvalidArgument, st.Code())
+	require.Contains(t, st.Message(), "party not found")
+}
+
+func TestInitiateCurrentAccount_PartyNotActive(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	partyID := uuid.New().String()
+
+	// Create mock party client that returns party not active
+	mockParty := &mockPartyClient{
+		validatePartyFn: func(_ context.Context, _ string) error {
+			return ErrPartyNotActive
+		},
+	}
+
+	svc, err := NewServiceWithExistingClients(
+		repo,
+		nil,
+		nil,
+		nil,
+		mockParty,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               partyID,
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+	}
+
+	_, err = svc.InitiateCurrentAccount(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "Expected gRPC status error")
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+	require.Contains(t, st.Message(), "party not active")
+}
+
+func TestInitiateCurrentAccount_PartyValidationError(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	partyID := uuid.New().String()
+
+	// Create mock party client that returns internal error
+	mockParty := &mockPartyClient{
+		validatePartyFn: func(_ context.Context, _ string) error {
+			return fmt.Errorf("connection timeout: %w", context.DeadlineExceeded)
+		},
+	}
+
+	svc, err := NewServiceWithExistingClients(
+		repo,
+		nil,
+		nil,
+		nil,
+		mockParty,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               partyID,
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+	}
+
+	_, err = svc.InitiateCurrentAccount(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "Expected gRPC status error")
+	require.Equal(t, codes.Internal, st.Code())
+	require.Contains(t, st.Message(), "party validation failed")
+}
+
+func TestInitiateCurrentAccount_NilPartyClient_BackwardCompatibility(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+
+	// Create service with nil party client (backward compatibility)
+	svc, err := NewServiceWithExistingClients(
+		repo,
+		nil,
+		nil,
+		nil,
+		nil, // nil party client - should skip validation
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+
+	req := &pb.InitiateCurrentAccountRequest{
+		AccountIdentification: "GB82WEST12345698765432",
+		PartyId:               uuid.New().String(),
+		BaseCurrency:          commonpb.Currency_CURRENCY_GBP,
+	}
+
+	// Should succeed without party validation
+	resp, err := svc.InitiateCurrentAccount(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotEmpty(t, resp.AccountId)
 }


### PR DESCRIPTION
## Summary
- Add party validation to `InitiateCurrentAccount` to ensure accounts are only created for valid, active parties
- This enforces referential integrity between current accounts and the Party service before account creation

## Changes Made
- Add `PartyClient` field to Service struct and update all constructors (`NewServiceWithExistingClients`, `NewServiceWithClients`)
- Add `PartyServiceTarget` to Config struct for production client creation
- Validate party exists and is active before account creation in `InitiateCurrentAccount()`
- Return appropriate gRPC error codes:
  - `InvalidArgument` for missing party
  - `FailedPrecondition` for inactive party
  - `Internal` for validation failures
- Add party validation duration metrics (`current_account_party_validation_duration_seconds`)
- Support nil party client for backward compatibility during migration

## Technical Details
- Re-exported `ErrPartyNotFound` and `ErrPartyNotActive` from clients package for convenience
- Party client is optional - nil client skips validation (backward compatibility)
- Uses DNS-based load balancing in production (`party:50054`)
- Wrapped with resilience patterns (circuit breaker + retry)

## Test plan
- [x] Unit test: successful account creation with valid party
- [x] Unit test: rejection when party not found (`InvalidArgument`)
- [x] Unit test: rejection when party not active (`FailedPrecondition`)
- [x] Unit test: party validation timeout handling (`Internal`)
- [x] Unit test: backward compatibility with nil party client
- [x] All existing service tests pass