### PR TITLE
feat(party): add Party service Kubernetes manifests and Tiltfile configuration

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -803,6 +803,38 @@ k8s_resource(
   labels=['microservices'],
 )
 
+# Party Service - gRPC microservice for party reference data management
+docker_build(
+  'party',
+  context='.',
+  dockerfile='services/party/cmd/Dockerfile',
+  build_args={
+    'VERSION': 'dev',
+    'COMMIT': local('git rev-parse --short HEAD'),
+    'BUILD_DATE': get_build_date(),
+  },
+)
+
+# Deploy Party Kubernetes manifests
+k8s_yaml('services/party/k8s/secret.yaml')
+k8s_yaml('services/party/k8s/configmap.yaml')
+k8s_yaml('services/party/k8s/deployment.yaml')
+k8s_yaml('services/party/k8s/service.yaml')
+
+# Set resource dependencies for Party
+k8s_resource(
+  'party',
+  port_forwards=[
+    '50055:50055',  # gRPC API
+  ],
+  resource_deps=[
+    'generate-proto',
+    'cockroachdb',
+    'migrate-party',
+  ],
+  labels=['microservices'],
+)
+
 # =============================================================================
 # Resource Configuration
 # =============================================================================
@@ -959,6 +991,15 @@ local_resource(
   trigger_mode=TRIGGER_MODE_MANUAL,
 )
 
+local_resource(
+  'migrate-party',
+  cmd='atlas migrate apply --env local --config file://services/party/atlas/atlas.hcl --url "{}" --allow-dirty'.format(database_url),
+  resource_deps=['init-database'],  # Independent schema, only needs database to exist
+  labels=['database'],
+  auto_init=True,
+  trigger_mode=TRIGGER_MODE_MANUAL,
+)
+
 # Kafka cluster health check - runs automatically after kafka-cluster is ready
 local_resource(
   'kafka-health',
@@ -1016,6 +1057,7 @@ Microservices:
   • Financial-Accounting   → localhost:50052 (gRPC)
   • Position-Keeping       → localhost:50053 (gRPC)
   • Payment-Order          → localhost:50054 (gRPC)
+  • Party                  → localhost:50055 (gRPC)
   • Tenant                 → localhost:50056 (gRPC)
 
 Backing Services:
@@ -1041,13 +1083,14 @@ Tilt UI                    → http://localhost:10350
 Hot reload: Edit Go code and see changes in ~3 seconds
 
 Database Migrations:
-  • Migrations run automatically on startup (5 resources):
+  • Migrations run automatically on startup (6 resources):
     1. current_account (customers, accounts, current_account_audit)
     2. financial_accounting (general_ledger, financial_accounting_audit)
     3. position_keeping (transactions, position_keeping_audit)
     4. payment_order (payment orders, saga state)
-    5. tenant (platform.tenants - platform tenant registry)
-  • Parallel execution: current_account + financial_accounting + tenant run together after init-database
+    5. party (parties, party reference data)
+    6. tenant (platform.tenants - platform tenant registry)
+  • Parallel execution: current_account + financial_accounting + party + tenant run together after init-database
   • Sequential dependencies:
     - position_keeping waits for current_account (Account FK)
     - payment_order waits for current_account (Account FK)
@@ -1059,6 +1102,7 @@ Database Migrations:
     - tilt trigger migrate-financial-accounting
     - tilt trigger migrate-position-keeping
     - tilt trigger migrate-payment-order
+    - tilt trigger migrate-party
     - tilt trigger migrate-tenant
   • Check status:
     - make migrate-status-all (requires DATABASE_URL env var)

--- a/services/current-account/clients/party_client.go
+++ b/services/current-account/clients/party_client.go
@@ -76,7 +76,7 @@ type PartyClientConfig struct {
 	Namespace string
 
 	// Port is the service port number
-	// Party service uses port 50054 (configured in deployments/k8s/party/service.yaml)
+	// Party service uses port 50055 (configured in services/party/k8s/service.yaml)
 	// Only used when ServiceName is specified.
 	Port int
 

--- a/services/party/k8s/configmap.yaml
+++ b/services/party/k8s/configmap.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: party-config
+  labels:
+    app: party
+    component: microservice
+data:
+  # Logging configuration
+  LOG_LEVEL: "info"
+  LOG_FORMAT: "json"
+
+  # Database connection pool settings
+  DB_MAX_OPEN_CONNS: "25"
+  DB_MAX_IDLE_CONNS: "5"
+  DB_CONN_MAX_LIFETIME: "5m"
+  DB_CONN_MAX_IDLE_TIME: "10m"
+
+  # gRPC server configuration
+  GRPC_PORT: "50055"
+  GRPC_MAX_CONCURRENT_STREAMS: "100"
+
+  # OpenTelemetry configuration
+  OTEL_SERVICE_NAME: "party-service"
+  OTEL_SAMPLING_RATE: "0.1"

--- a/services/party/k8s/deployment.yaml
+++ b/services/party/k8s/deployment.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: party
+  labels:
+    app: party
+    component: microservice
+    tier: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: party
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: party
+        component: microservice
+        tier: backend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: party
+        image: party:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grpc
+          containerPort: 50055
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: party-config
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: party-db
+              key: DATABASE_URL
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        livenessProbe:
+          grpc:
+            port: 50055
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          grpc:
+            port: 50055
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        startupProbe:
+          grpc:
+            port: 50055
+          initialDelaySeconds: 0
+          periodSeconds: 2
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 30
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      terminationGracePeriodSeconds: 30

--- a/services/party/k8s/secret.yaml
+++ b/services/party/k8s/secret.yaml
@@ -1,0 +1,16 @@
+# SECURITY NOTE: This secret contains development credentials only.
+# For production deployments:
+# - Use external secret management (e.g., Sealed Secrets, External Secrets Operator)
+# - Rotate credentials regularly
+# - Use RBAC to restrict secret access
+# - Enable encryption at rest for secrets
+apiVersion: v1
+kind: Secret
+metadata:
+  name: party-db
+  labels:
+    app: party
+type: Opaque
+stringData:
+  # Local development connection string - CockroachDB in insecure mode
+  DATABASE_URL: "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable"

--- a/services/party/k8s/service.yaml
+++ b/services/party/k8s/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: party
+  labels:
+    app: party
+    component: microservice
+spec:
+  type: ClusterIP
+  clusterIP: None  # Headless service for gRPC client-side load balancing
+  ports:
+  - name: grpc
+    port: 50055
+    targetPort: grpc
+    protocol: TCP
+  selector:
+    app: party


### PR DESCRIPTION
## Summary

- Add Kubernetes deployment manifests for Party service (secret, configmap, deployment, service)
- Add Party service to Tiltfile with docker_build, k8s_resource, and migrate-party
- Update Tilt UI output to include Party service (port 50055)
- Fix party_client.go port comment to reference correct port 50055

## Test plan

- [ ] Run `tilt up` and verify Party service starts successfully
- [ ] Verify Party service is accessible on port 50055
- [ ] Verify database migrations run correctly with `tilt trigger migrate-party`
- [ ] Verify health check endpoint responds: `grpcurl -plaintext localhost:50055 grpc.health.v1.Health/Check`