### PR TITLE
feat: Add PropagateOrganization for inter-service gRPC calls

### DIFF
--- a/shared/pkg/clients/common.go
+++ b/shared/pkg/clients/common.go
@@ -61,16 +61,20 @@ func WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, c
 }
 
 // PropagateOrganization extracts organization ID from context and adds it to gRPC metadata.
-// Returns the same context if org is missing (graceful degradation for single-tenant or bootstrap calls).
+// Returns the same context if org is missing or empty (graceful degradation for single-tenant or bootstrap calls).
 // Usage pattern:
 //
 //	ctx = clients.PropagateCorrelationID(ctx)
 //	ctx = clients.PropagateOrganization(ctx)
 //	resp, err := client.SomeMethod(ctx, req)
 func PropagateOrganization(ctx context.Context) context.Context {
+	if ctx == nil {
+		return nil
+	}
+
 	orgID, ok := organization.FromContext(ctx)
-	if !ok {
-		// No org in context - return unchanged (single-tenant or bootstrap call)
+	if !ok || orgID.IsEmpty() {
+		// No org in context or empty org - return unchanged (single-tenant or bootstrap call)
 		return ctx
 	}
 

--- a/shared/pkg/clients/common.go
+++ b/shared/pkg/clients/common.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/meridianhub/meridian/shared/platform/organization"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -57,4 +58,30 @@ func WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, c
 		return context.WithTimeout(ctx, timeout)
 	}
 	return ctx, func() {}
+}
+
+// PropagateOrganization extracts organization ID from context and adds it to gRPC metadata.
+// Returns the same context if org is missing (graceful degradation for single-tenant or bootstrap calls).
+// Usage pattern:
+//
+//	ctx = clients.PropagateCorrelationID(ctx)
+//	ctx = clients.PropagateOrganization(ctx)
+//	resp, err := client.SomeMethod(ctx, req)
+func PropagateOrganization(ctx context.Context) context.Context {
+	orgID, ok := organization.FromContext(ctx)
+	if !ok {
+		// No org in context - return unchanged (single-tenant or bootstrap call)
+		return ctx
+	}
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if !ok {
+		md = metadata.New(nil)
+	} else {
+		md = md.Copy()
+	}
+
+	// Add org to outgoing metadata using standard header name
+	md.Set(organization.OrgIDKey, orgID.String())
+	return metadata.NewOutgoingContext(ctx, md)
 }

--- a/shared/pkg/clients/common_test.go
+++ b/shared/pkg/clients/common_test.go
@@ -330,6 +330,36 @@ func TestPropagateOrganization_NoOrganization(t *testing.T) {
 	assert.False(t, ok, "should not have outgoing metadata")
 }
 
+// TestPropagateOrganization_NilContext verifies nil context does not panic
+func TestPropagateOrganization_NilContext(t *testing.T) {
+	t.Parallel()
+
+	//nolint:staticcheck // Testing nil context handling intentionally
+	var nilCtx context.Context
+
+	assert.NotPanics(t, func() {
+		result := clients.PropagateOrganization(nilCtx)
+		assert.Nil(t, result, "should return nil for nil context")
+	})
+}
+
+// TestPropagateOrganization_EmptyOrganizationID verifies empty org ID returns unchanged context
+func TestPropagateOrganization_EmptyOrganizationID(t *testing.T) {
+	t.Parallel()
+
+	// Create context with empty organization ID
+	ctx := organization.WithOrganization(context.Background(), organization.OrganizationID(""))
+
+	result := clients.PropagateOrganization(ctx)
+
+	// Context should be returned unchanged (empty org ID treated as missing)
+	assert.Equal(t, ctx, result)
+
+	// Should not have outgoing metadata with org ID
+	_, ok := metadata.FromOutgoingContext(result)
+	assert.False(t, ok, "should not have outgoing metadata for empty org ID")
+}
+
 // TestPropagateOrganization_ExistingMetadata verifies existing metadata is preserved
 func TestPropagateOrganization_ExistingMetadata(t *testing.T) {
 	t.Parallel()

--- a/shared/pkg/clients/common_test.go
+++ b/shared/pkg/clients/common_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/platform/organization"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
 )
@@ -296,4 +297,97 @@ func TestWithTimeout_NegativeTimeout(t *testing.T) {
 	// Should not have a deadline
 	_, ok := resultCtx.Deadline()
 	assert.False(t, ok, "should not have deadline")
+}
+
+// TestPropagateOrganization_Success verifies organization ID is added to outgoing metadata
+func TestPropagateOrganization_Success(t *testing.T) {
+	t.Parallel()
+
+	orgID := organization.MustNewOrganizationID("acme_bank")
+	ctx := organization.WithOrganization(context.Background(), orgID)
+
+	result := clients.PropagateOrganization(ctx)
+
+	// Verify organization ID was added to outgoing metadata
+	md, ok := metadata.FromOutgoingContext(result)
+	assert.True(t, ok, "should have outgoing metadata")
+	assert.Equal(t, []string{"acme_bank"}, md.Get(organization.OrgIDKey))
+}
+
+// TestPropagateOrganization_NoOrganization verifies context is unchanged when no organization exists
+func TestPropagateOrganization_NoOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	result := clients.PropagateOrganization(ctx)
+
+	// Context should be returned unchanged
+	assert.Equal(t, ctx, result)
+
+	// Should not have outgoing metadata
+	_, ok := metadata.FromOutgoingContext(result)
+	assert.False(t, ok, "should not have outgoing metadata")
+}
+
+// TestPropagateOrganization_ExistingMetadata verifies existing metadata is preserved
+func TestPropagateOrganization_ExistingMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Create context with existing outgoing metadata
+	existingMD := metadata.New(map[string]string{
+		"existing-key": "existing-value",
+	})
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMD)
+	orgID := organization.MustNewOrganizationID("test_org")
+	ctx = organization.WithOrganization(ctx, orgID)
+
+	result := clients.PropagateOrganization(ctx)
+
+	// Verify both existing metadata and organization ID are present
+	md, ok := metadata.FromOutgoingContext(result)
+	assert.True(t, ok, "should have outgoing metadata")
+	assert.Equal(t, []string{"existing-value"}, md.Get("existing-key"), "should preserve existing metadata")
+	assert.Equal(t, []string{"test_org"}, md.Get(organization.OrgIDKey), "should add organization ID")
+}
+
+// TestPropagateOrganization_OverwritesExistingOrgID verifies organization ID is updated if it already exists
+func TestPropagateOrganization_OverwritesExistingOrgID(t *testing.T) {
+	t.Parallel()
+
+	// Create context with existing org ID in outgoing metadata
+	existingMD := metadata.New(map[string]string{
+		organization.OrgIDKey: "old_org",
+	})
+	ctx := metadata.NewOutgoingContext(context.Background(), existingMD)
+	orgID := organization.MustNewOrganizationID("new_org")
+	ctx = organization.WithOrganization(ctx, orgID)
+
+	result := clients.PropagateOrganization(ctx)
+
+	// Verify organization ID was updated
+	md, ok := metadata.FromOutgoingContext(result)
+	assert.True(t, ok, "should have outgoing metadata")
+	assert.Equal(t, []string{"new_org"}, md.Get(organization.OrgIDKey), "should update organization ID")
+}
+
+// TestPropagateOrganization_ChainWithCorrelationID verifies both propagation functions work together
+func TestPropagateOrganization_ChainWithCorrelationID(t *testing.T) {
+	t.Parallel()
+
+	// Create context with both correlation ID and organization
+	//nolint:revive,staticcheck // Using string key as expected by ExtractCorrelationID implementation
+	ctx := context.WithValue(context.Background(), "x-correlation-id", "corr-123")
+	orgID := organization.MustNewOrganizationID("chain_test")
+	ctx = organization.WithOrganization(ctx, orgID)
+
+	// Apply both propagation functions
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	// Verify both headers are present
+	md, ok := metadata.FromOutgoingContext(ctx)
+	assert.True(t, ok, "should have outgoing metadata")
+	assert.Equal(t, []string{"corr-123"}, md.Get("x-correlation-id"), "should have correlation ID")
+	assert.Equal(t, []string{"chain_test"}, md.Get(organization.OrgIDKey), "should have organization ID")
 }


### PR DESCRIPTION
## Summary
- Add `PropagateOrganization` function to `shared/pkg/clients/common.go` for propagating organization context across service-to-service gRPC calls
- Enables multi-tenant isolation by injecting organization ID into outgoing gRPC metadata
- Follows existing `PropagateCorrelationID` pattern for consistency

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 43

## Changes Made
- Added `PropagateOrganization(ctx context.Context) context.Context` function
- Function extracts org ID from context and adds to outgoing gRPC metadata using `x-org-id` header
- Graceful degradation when org context is missing (returns unchanged context)
- Preserves existing outgoing metadata without overwriting
- Added comprehensive unit tests (5 test cases)

## Test Plan
1. Unit test: Context with org → verify x-org-id in outgoing metadata ✅
2. Unit test: Context without org → verify metadata unchanged, no error ✅
3. Unit test: Existing metadata → verify org header added without overwriting ✅
4. Unit test: Overwrite existing org ID → verify new value set ✅
5. Unit test: Chain with PropagateCorrelationID → verify both headers present ✅

## Usage Pattern
```go
// In client methods:
ctx = clients.PropagateCorrelationID(ctx)
ctx = clients.PropagateOrganization(ctx)  // Chain after correlation ID
resp, err := client.SomeMethod(ctx, req)
```