### PR TITLE
Design schema provisioning architecture and service interface

### DIFF
--- a/services/tenant/migrations/20251212100000_create_tenant_provisioning.sql
+++ b/services/tenant/migrations/20251212100000_create_tenant_provisioning.sql
@@ -1,0 +1,47 @@
+-- Tenant provisioning status table for tracking schema provisioning lifecycle.
+-- Stored in 'platform' schema alongside tenants table (shared infrastructure).
+--
+-- This table tracks the state of org_{tenant_id} schema creation and
+-- service migration application for each tenant.
+--
+-- Design notes:
+--  - One row per tenant, created when provisioning starts
+--  - service_schemas JSONB stores per-service status for debugging
+--  - Idempotent: safe to query and update during retry scenarios
+--  - Deleted when tenant is fully deprovisioned
+
+CREATE TABLE platform.tenant_provisioning (
+    -- Foreign key to tenants table (same ID format)
+    tenant_id VARCHAR(50) PRIMARY KEY REFERENCES platform.tenants(id) ON DELETE CASCADE,
+
+    -- Provisioning lifecycle state
+    -- Values: 'pending', 'in_progress', 'active', 'failed'
+    state VARCHAR(20) NOT NULL DEFAULT 'pending',
+
+    -- Per-service provisioning status
+    -- Structure: [{"service_name": "party", "schema_name": "org_acme", "state": "migrated", "migration_version": "20251208...", "error_message": ""}]
+    service_schemas JSONB NOT NULL DEFAULT '[]',
+
+    -- Error details if state = 'failed'
+    error_message TEXT,
+
+    -- Timestamps
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    -- Constraints
+    CONSTRAINT valid_provisioning_state CHECK (state IN ('pending', 'in_progress', 'active', 'failed'))
+);
+
+-- Index for finding tenants by provisioning state (e.g., "find all failed provisioning")
+CREATE INDEX idx_tenant_provisioning_state ON platform.tenant_provisioning(state);
+
+-- Index for finding recently updated provisioning (monitoring/debugging)
+CREATE INDEX idx_tenant_provisioning_updated_at ON platform.tenant_provisioning(updated_at DESC);
+
+-- Comments for documentation
+COMMENT ON TABLE platform.tenant_provisioning IS 'Tracks schema provisioning state for multi-tenant isolation';
+COMMENT ON COLUMN platform.tenant_provisioning.tenant_id IS 'Organization ID, references platform.tenants';
+COMMENT ON COLUMN platform.tenant_provisioning.state IS 'Provisioning lifecycle: pending → in_progress → active/failed';
+COMMENT ON COLUMN platform.tenant_provisioning.service_schemas IS 'JSONB array of per-service provisioning status';
+COMMENT ON COLUMN platform.tenant_provisioning.error_message IS 'Error details when state is failed';

--- a/services/tenant/migrations/20251212100000_create_tenant_provisioning.sql
+++ b/services/tenant/migrations/20251212100000_create_tenant_provisioning.sql
@@ -8,14 +8,18 @@
 --  - One row per tenant, created when provisioning starts
 --  - service_schemas JSONB stores per-service status for debugging
 --  - Idempotent: safe to query and update during retry scenarios
---  - Deleted when tenant is fully deprovisioned
+--  - Soft delete via 'deprovisioned' state - records are NEVER hard deleted for audit trail
+--  - Schema data retention: deprovisioned schemas are NOT dropped automatically;
+--    a separate purge process handles schema deletion after retention period
 
 CREATE TABLE platform.tenant_provisioning (
     -- Foreign key to tenants table (same ID format)
-    tenant_id VARCHAR(50) PRIMARY KEY REFERENCES platform.tenants(id) ON DELETE CASCADE,
+    -- ON DELETE RESTRICT: Cannot delete tenant while provisioning record exists (audit trail)
+    tenant_id VARCHAR(50) PRIMARY KEY REFERENCES platform.tenants(id) ON DELETE RESTRICT,
 
     -- Provisioning lifecycle state
-    -- Values: 'pending', 'in_progress', 'active', 'failed'
+    -- Values: 'pending', 'in_progress', 'active', 'failed', 'deprovisioned'
+    -- Note: 'deprovisioned' is a terminal state - schema marked for eventual cleanup
     state VARCHAR(20) NOT NULL DEFAULT 'pending',
 
     -- Per-service provisioning status
@@ -28,9 +32,14 @@ CREATE TABLE platform.tenant_provisioning (
     -- Timestamps
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deprovisioned_at TIMESTAMPTZ,
 
     -- Constraints
-    CONSTRAINT valid_provisioning_state CHECK (state IN ('pending', 'in_progress', 'active', 'failed'))
+    CONSTRAINT valid_provisioning_state CHECK (state IN ('pending', 'in_progress', 'active', 'failed', 'deprovisioned')),
+    CONSTRAINT deprovisioned_at_required CHECK (
+        (state = 'deprovisioned' AND deprovisioned_at IS NOT NULL) OR
+        (state != 'deprovisioned' AND deprovisioned_at IS NULL)
+    )
 );
 
 -- Index for finding tenants by provisioning state (e.g., "find all failed provisioning")

--- a/services/tenant/migrations/20251212100000_create_tenant_provisioning.sql
+++ b/services/tenant/migrations/20251212100000_create_tenant_provisioning.sql
@@ -34,6 +34,9 @@ CREATE TABLE platform.tenant_provisioning (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     deprovisioned_at TIMESTAMPTZ,
 
+    -- Optimistic locking version to prevent concurrent update conflicts
+    version INTEGER NOT NULL DEFAULT 1,
+
     -- Constraints
     CONSTRAINT valid_provisioning_state CHECK (state IN ('pending', 'in_progress', 'active', 'failed', 'deprovisioned')),
     CONSTRAINT deprovisioned_at_required CHECK (

--- a/services/tenant/provisioner/errors.go
+++ b/services/tenant/provisioner/errors.go
@@ -1,0 +1,40 @@
+package provisioner
+
+import "errors"
+
+// Provisioner errors.
+var (
+	// ErrTestDatabaseConnectionFailed is a test error for simulating database failures.
+	ErrTestDatabaseConnectionFailed = errors.New("test: database connection failed")
+
+	// ErrTestGeneric is a test error for simulating generic failures.
+	ErrTestGeneric = errors.New("test: generic error")
+	// ErrProvisioningStatusNotFound indicates no provisioning record exists for the tenant.
+	// This occurs when:
+	//  - The tenant has never been provisioned
+	//  - The tenant was fully deprovisioned (status record removed)
+	ErrProvisioningStatusNotFound = errors.New("provisioning status not found")
+
+	// ErrProvisioningInProgress indicates provisioning is already running for this tenant.
+	// Wait for the current provisioning to complete before retrying.
+	ErrProvisioningInProgress = errors.New("provisioning already in progress")
+
+	// ErrSchemaCreationFailed indicates the org_{tenant_id} schema could not be created.
+	// Check PostgreSQL permissions and connection.
+	ErrSchemaCreationFailed = errors.New("failed to create tenant schema")
+
+	// ErrMigrationFailed indicates one or more service migrations failed.
+	// Check ServiceSchemaStatus.ErrorMessage for details.
+	ErrMigrationFailed = errors.New("failed to apply service migrations")
+
+	// ErrDeprovisioningFailed indicates the schema could not be dropped.
+	// The schema may contain objects owned by other roles.
+	ErrDeprovisioningFailed = errors.New("failed to deprovision tenant schema")
+
+	// ErrInvalidTenantID indicates the tenant ID doesn't meet naming requirements.
+	// Tenant IDs must be alphanumeric with underscores, 1-50 characters.
+	ErrInvalidTenantID = errors.New("invalid tenant ID format")
+
+	// ErrProvisioningTimeout indicates the provisioning operation exceeded the configured timeout.
+	ErrProvisioningTimeout = errors.New("provisioning operation timed out")
+)

--- a/services/tenant/provisioner/errors.go
+++ b/services/tenant/provisioner/errors.go
@@ -37,4 +37,16 @@ var (
 
 	// ErrProvisioningTimeout indicates the provisioning operation exceeded the configured timeout.
 	ErrProvisioningTimeout = errors.New("provisioning operation timed out")
+
+	// ErrNotDeprovisioned indicates an operation requires the tenant to be deprovisioned first.
+	// For example, PurgeSchemas requires the tenant to be in 'deprovisioned' state.
+	ErrNotDeprovisioned = errors.New("tenant must be deprovisioned before this operation")
+
+	// ErrRetentionPeriodNotElapsed indicates the data retention period has not yet passed.
+	// Schema data cannot be purged until the retention period (e.g., 7 years) has elapsed.
+	ErrRetentionPeriodNotElapsed = errors.New("data retention period has not elapsed")
+
+	// ErrAlreadyDeprovisioned indicates the tenant has already been deprovisioned.
+	// This is informational - deprovisioning is idempotent.
+	ErrAlreadyDeprovisioned = errors.New("tenant is already deprovisioned")
 )

--- a/services/tenant/provisioner/errors.go
+++ b/services/tenant/provisioner/errors.go
@@ -4,11 +4,6 @@ import "errors"
 
 // Provisioner errors.
 var (
-	// ErrTestDatabaseConnectionFailed is a test error for simulating database failures.
-	ErrTestDatabaseConnectionFailed = errors.New("test: database connection failed")
-
-	// ErrTestGeneric is a test error for simulating generic failures.
-	ErrTestGeneric = errors.New("test: generic error")
 	// ErrProvisioningStatusNotFound indicates no provisioning record exists for the tenant.
 	// This occurs when:
 	//  - The tenant has never been provisioned
@@ -49,4 +44,21 @@ var (
 	// ErrAlreadyDeprovisioned indicates the tenant has already been deprovisioned.
 	// This is informational - deprovisioning is idempotent.
 	ErrAlreadyDeprovisioned = errors.New("tenant is already deprovisioned")
+
+	// Config validation errors.
+
+	// ErrNoServicesConfigured indicates no services were configured for provisioning.
+	ErrNoServicesConfigured = errors.New("at least one service must be configured")
+
+	// ErrInvalidProvisioningTimeout indicates the provisioning timeout is not positive.
+	ErrInvalidProvisioningTimeout = errors.New("provisioning timeout must be positive")
+
+	// ErrInvalidRetentionPeriod indicates the data retention period is negative.
+	ErrInvalidRetentionPeriod = errors.New("data retention period cannot be negative")
+
+	// ErrEmptyServiceName indicates a service has an empty name.
+	ErrEmptyServiceName = errors.New("service has empty name")
+
+	// ErrEmptyMigrationPath indicates a service has an empty migration path.
+	ErrEmptyMigrationPath = errors.New("service has empty migration path")
 )

--- a/services/tenant/provisioner/errors_test.go
+++ b/services/tenant/provisioner/errors_test.go
@@ -1,0 +1,13 @@
+package provisioner
+
+import "errors"
+
+// Test-specific sentinel errors for mock provisioner.
+// Kept separate from public API to avoid polluting the exported error set.
+var (
+	// ErrTestDatabaseConnectionFailed simulates database connection failures in tests.
+	ErrTestDatabaseConnectionFailed = errors.New("test: database connection failed")
+
+	// ErrTestGeneric is a generic test error for failure simulation.
+	ErrTestGeneric = errors.New("test: generic error")
+)

--- a/services/tenant/provisioner/mock_provisioner.go
+++ b/services/tenant/provisioner/mock_provisioner.go
@@ -183,9 +183,9 @@ func (m *MockProvisioner) PurgeSchemas(_ context.Context, tenantID organization.
 		}
 	}
 
-	// In real implementation, this would DROP SCHEMA CASCADE
-	// For mock, we just leave the status as is (marking purge complete)
-	// A real implementation might add a "purged" state or timestamp
+	// Remove the status record - matches interface contract:
+	// "Removes the provisioning status record (purge completes the lifecycle)"
+	delete(m.statuses, tenantID.String())
 
 	return nil
 }

--- a/services/tenant/provisioner/mock_provisioner.go
+++ b/services/tenant/provisioner/mock_provisioner.go
@@ -1,0 +1,177 @@
+package provisioner
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/organization"
+)
+
+// MockProvisioner is an in-memory implementation of SchemaProvisioner for testing.
+// It simulates schema provisioning without actually creating database schemas.
+//
+// Thread-safe for concurrent access.
+type MockProvisioner struct {
+	mu sync.RWMutex
+
+	// statuses stores provisioning status by tenant ID
+	statuses map[string]*ProvisioningStatus
+
+	// services is the list of services to simulate provisioning for
+	services []ServiceConfig
+
+	// ProvisioningDelay simulates time spent provisioning (for timeout testing)
+	ProvisioningDelay time.Duration
+
+	// FailProvisioningFor lists tenant IDs that should fail during provisioning
+	FailProvisioningFor map[string]error
+
+	// FailDeprovisioningFor lists tenant IDs that should fail during deprovisioning
+	FailDeprovisioningFor map[string]error
+
+	// ProvisioningCalls tracks calls to ProvisionSchemas for verification
+	ProvisioningCalls []organization.OrganizationID
+
+	// DeprovisioningCalls tracks calls to DeprovisionSchemas for verification
+	DeprovisioningCalls []organization.OrganizationID
+}
+
+// NewMockProvisioner creates a new mock provisioner with the given service configuration.
+func NewMockProvisioner(services []ServiceConfig) *MockProvisioner {
+	return &MockProvisioner{
+		statuses:              make(map[string]*ProvisioningStatus),
+		services:              services,
+		FailProvisioningFor:   make(map[string]error),
+		FailDeprovisioningFor: make(map[string]error),
+		ProvisioningCalls:     make([]organization.OrganizationID, 0),
+		DeprovisioningCalls:   make([]organization.OrganizationID, 0),
+	}
+}
+
+// ProvisionSchemas simulates schema provisioning for the tenant.
+func (m *MockProvisioner) ProvisionSchemas(ctx context.Context, tenantID organization.OrganizationID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Record the call
+	m.ProvisioningCalls = append(m.ProvisioningCalls, tenantID)
+
+	// Simulate delay if configured
+	if m.ProvisioningDelay > 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(m.ProvisioningDelay):
+		}
+	}
+
+	// Check for simulated failure
+	if err, shouldFail := m.FailProvisioningFor[tenantID.String()]; shouldFail {
+		// Create failed status
+		m.statuses[tenantID.String()] = &ProvisioningStatus{
+			TenantID:     tenantID,
+			State:        StateFailed,
+			Services:     m.createServiceStatuses(tenantID, ServiceStateFailed),
+			ErrorMessage: err.Error(),
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
+		}
+		return err
+	}
+
+	// Check if already provisioned
+	if status, exists := m.statuses[tenantID.String()]; exists && status.State == StateActive {
+		// Idempotent: already provisioned, no-op
+		return nil
+	}
+
+	// Simulate successful provisioning
+	m.statuses[tenantID.String()] = &ProvisioningStatus{
+		TenantID:  tenantID,
+		State:     StateActive,
+		Services:  m.createServiceStatuses(tenantID, ServiceStateMigrated),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	return nil
+}
+
+// DeprovisionSchemas simulates schema deprovisioning for the tenant.
+func (m *MockProvisioner) DeprovisionSchemas(_ context.Context, tenantID organization.OrganizationID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Record the call
+	m.DeprovisioningCalls = append(m.DeprovisioningCalls, tenantID)
+
+	// Check for simulated failure
+	if err, shouldFail := m.FailDeprovisioningFor[tenantID.String()]; shouldFail {
+		return err
+	}
+
+	// Remove the status (idempotent: no error if not found)
+	delete(m.statuses, tenantID.String())
+
+	return nil
+}
+
+// GetProvisioningStatus retrieves the current provisioning state for a tenant.
+func (m *MockProvisioner) GetProvisioningStatus(_ context.Context, tenantID organization.OrganizationID) (*ProvisioningStatus, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	status, exists := m.statuses[tenantID.String()]
+	if !exists {
+		return nil, ErrProvisioningStatusNotFound
+	}
+
+	// Return a copy to prevent external mutation
+	copyStatus := *status
+	copyStatus.Services = make([]ServiceSchemaStatus, len(status.Services))
+	copy(copyStatus.Services, status.Services)
+
+	return &copyStatus, nil
+}
+
+// createServiceStatuses creates service status entries for all configured services.
+func (m *MockProvisioner) createServiceStatuses(tenantID organization.OrganizationID, state ServiceProvisioningState) []ServiceSchemaStatus {
+	statuses := make([]ServiceSchemaStatus, len(m.services))
+	schemaName := tenantID.SchemaName()
+
+	for i, svc := range m.services {
+		statuses[i] = ServiceSchemaStatus{
+			ServiceName:      svc.Name,
+			SchemaName:       schemaName,
+			State:            state,
+			MigrationVersion: "mock-v1",
+		}
+	}
+
+	return statuses
+}
+
+// Reset clears all state for testing.
+func (m *MockProvisioner) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.statuses = make(map[string]*ProvisioningStatus)
+	m.ProvisioningCalls = make([]organization.OrganizationID, 0)
+	m.DeprovisioningCalls = make([]organization.OrganizationID, 0)
+	m.FailProvisioningFor = make(map[string]error)
+	m.FailDeprovisioningFor = make(map[string]error)
+	m.ProvisioningDelay = 0
+}
+
+// SetStatus allows tests to manually set the provisioning status for a tenant.
+func (m *MockProvisioner) SetStatus(status *ProvisioningStatus) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.statuses[status.TenantID.String()] = status
+}
+
+// Ensure MockProvisioner implements SchemaProvisioner.
+var _ SchemaProvisioner = (*MockProvisioner)(nil)

--- a/services/tenant/provisioner/mock_provisioner.go
+++ b/services/tenant/provisioner/mock_provisioner.go
@@ -30,11 +30,20 @@ type MockProvisioner struct {
 	// FailDeprovisioningFor lists tenant IDs that should fail during deprovisioning
 	FailDeprovisioningFor map[string]error
 
+	// FailPurgeFor lists tenant IDs that should fail during purging
+	FailPurgeFor map[string]error
+
 	// ProvisioningCalls tracks calls to ProvisionSchemas for verification
 	ProvisioningCalls []organization.OrganizationID
 
 	// DeprovisioningCalls tracks calls to DeprovisionSchemas for verification
 	DeprovisioningCalls []organization.OrganizationID
+
+	// PurgeCalls tracks calls to PurgeSchemas for verification
+	PurgeCalls []organization.OrganizationID
+
+	// DataRetentionPeriod for testing retention enforcement
+	DataRetentionPeriod time.Duration
 }
 
 // NewMockProvisioner creates a new mock provisioner with the given service configuration.
@@ -44,8 +53,11 @@ func NewMockProvisioner(services []ServiceConfig) *MockProvisioner {
 		services:              services,
 		FailProvisioningFor:   make(map[string]error),
 		FailDeprovisioningFor: make(map[string]error),
+		FailPurgeFor:          make(map[string]error),
 		ProvisioningCalls:     make([]organization.OrganizationID, 0),
 		DeprovisioningCalls:   make([]organization.OrganizationID, 0),
+		PurgeCalls:            make([]organization.OrganizationID, 0),
+		DataRetentionPeriod:   0, // No retention period by default for testing
 	}
 }
 
@@ -98,7 +110,7 @@ func (m *MockProvisioner) ProvisionSchemas(ctx context.Context, tenantID organiz
 	return nil
 }
 
-// DeprovisionSchemas simulates schema deprovisioning for the tenant.
+// DeprovisionSchemas simulates schema deprovisioning (soft delete) for the tenant.
 func (m *MockProvisioner) DeprovisionSchemas(_ context.Context, tenantID organization.OrganizationID) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -111,8 +123,61 @@ func (m *MockProvisioner) DeprovisionSchemas(_ context.Context, tenantID organiz
 		return err
 	}
 
-	// Remove the status (idempotent: no error if not found)
-	delete(m.statuses, tenantID.String())
+	// Get existing status
+	status, exists := m.statuses[tenantID.String()]
+	if !exists {
+		return ErrProvisioningStatusNotFound
+	}
+
+	// Idempotent: already deprovisioned
+	if status.State == StateDeprovisioned {
+		return nil
+	}
+
+	// Soft delete: mark as deprovisioned
+	now := time.Now()
+	status.State = StateDeprovisioned
+	status.DeprovisionedAt = &now
+	status.UpdatedAt = now
+
+	return nil
+}
+
+// PurgeSchemas simulates permanent schema deletion after retention period.
+func (m *MockProvisioner) PurgeSchemas(_ context.Context, tenantID organization.OrganizationID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Record the call
+	m.PurgeCalls = append(m.PurgeCalls, tenantID)
+
+	// Check for simulated failure
+	if err, shouldFail := m.FailPurgeFor[tenantID.String()]; shouldFail {
+		return err
+	}
+
+	// Get existing status
+	status, exists := m.statuses[tenantID.String()]
+	if !exists {
+		return ErrProvisioningStatusNotFound
+	}
+
+	// Must be deprovisioned first
+	if status.State != StateDeprovisioned {
+		return ErrNotDeprovisioned
+	}
+
+	// Check retention period
+	if status.DeprovisionedAt != nil && m.DataRetentionPeriod > 0 {
+		retentionEnd := status.DeprovisionedAt.Add(m.DataRetentionPeriod)
+		if time.Now().Before(retentionEnd) {
+			return ErrRetentionPeriodNotElapsed
+		}
+	}
+
+	// In real implementation, this would DROP SCHEMA CASCADE
+	// For mock, we just leave the status as is (marking purge complete)
+	// A real implementation might add a "purged" state or timestamp
 
 	return nil
 }
@@ -160,9 +225,12 @@ func (m *MockProvisioner) Reset() {
 	m.statuses = make(map[string]*ProvisioningStatus)
 	m.ProvisioningCalls = make([]organization.OrganizationID, 0)
 	m.DeprovisioningCalls = make([]organization.OrganizationID, 0)
+	m.PurgeCalls = make([]organization.OrganizationID, 0)
 	m.FailProvisioningFor = make(map[string]error)
 	m.FailDeprovisioningFor = make(map[string]error)
+	m.FailPurgeFor = make(map[string]error)
 	m.ProvisioningDelay = 0
+	m.DataRetentionPeriod = 0
 }
 
 // SetStatus allows tests to manually set the provisioning status for a tenant.

--- a/services/tenant/provisioner/mock_provisioner.go
+++ b/services/tenant/provisioner/mock_provisioner.go
@@ -69,7 +69,15 @@ func (m *MockProvisioner) ProvisionSchemas(ctx context.Context, tenantID organiz
 	// Record the call
 	m.ProvisioningCalls = append(m.ProvisioningCalls, tenantID)
 
-	// Simulate delay if configured
+	// Check for concurrent provisioning attempt
+	if status, exists := m.statuses[tenantID.String()]; exists && status.State == StateInProgress {
+		return ErrProvisioningInProgress
+	}
+
+	// Simulate delay if configured.
+	// NOTE: Lock is held during sleep intentionally for test simplicity.
+	// This prevents concurrent test access but may cause test timeouts if delay is long.
+	// For production implementations, consider releasing lock during I/O operations.
 	if m.ProvisioningDelay > 0 {
 		select {
 		case <-ctx.Done():

--- a/services/tenant/provisioner/provisioner.go
+++ b/services/tenant/provisioner/provisioner.go
@@ -107,7 +107,7 @@ type SchemaProvisioner interface {
 	// The function performs:
 	//  1. Validates tenant is deprovisioned and retention period elapsed
 	//  2. DROP SCHEMA org_{tenant_id} CASCADE (removes all objects)
-	//  3. Updates provisioning status to record purge timestamp
+	//  3. Removes the provisioning status record (purge completes the lifecycle)
 	//
 	// Returns ErrRetentionPeriodNotElapsed if called before retention period.
 	// Returns ErrNotDeprovisioned if tenant is still active.
@@ -174,7 +174,7 @@ type ProvisioningStatus struct {
 	State ProvisioningState
 
 	// Services contains the provisioning status for each service's schema.
-	// Key is the service name (e.g., "party", "current-account").
+	// Ordered by provisioning sequence (same order as Config.Services).
 	Services []ServiceSchemaStatus
 
 	// ErrorMessage contains details if State is StateFailed.

--- a/services/tenant/provisioner/provisioner.go
+++ b/services/tenant/provisioner/provisioner.go
@@ -53,6 +53,7 @@ package provisioner
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/meridianhub/meridian/shared/platform/organization"
@@ -152,7 +153,14 @@ func (s ProvisioningState) IsValid() bool {
 	}
 }
 
-// IsTerminal returns true if the state is a final state that cannot transition further.
+// IsTerminal returns true if the state is a final state with no automatic transitions.
+// Terminal states:
+//   - StateActive: provisioning complete, schema is ready (can transition to deprovisioned)
+//   - StateFailed: provisioning failed (can transition to active via ProvisionSchemas retry)
+//   - StateDeprovisioned: soft deleted (permanent, no further transitions)
+//
+// Note: "terminal" refers to the automatic state machine, not immutability.
+// Manual operations like retry (failed→active) or deprovision (active→deprovisioned) are allowed.
 func (s ProvisioningState) IsTerminal() bool {
 	return s == StateActive || s == StateFailed || s == StateDeprovisioned
 }
@@ -248,6 +256,29 @@ type Config struct {
 	// regulations (e.g., financial record keeping requirements).
 	// Default: 7 years (2555 days) for financial services compliance.
 	DataRetentionPeriod time.Duration
+}
+
+// Validate checks that the configuration is valid.
+// Returns an error describing the first invalid field found.
+func (c *Config) Validate() error {
+	if len(c.Services) == 0 {
+		return ErrNoServicesConfigured
+	}
+	if c.ProvisioningTimeout <= 0 {
+		return ErrInvalidProvisioningTimeout
+	}
+	if c.DataRetentionPeriod < 0 {
+		return ErrInvalidRetentionPeriod
+	}
+	for _, svc := range c.Services {
+		if svc.Name == "" {
+			return ErrEmptyServiceName
+		}
+		if svc.MigrationPath == "" {
+			return fmt.Errorf("%w: %s", ErrEmptyMigrationPath, svc.Name)
+		}
+	}
+	return nil
 }
 
 // DefaultConfig returns a configuration with standard BIAN services.

--- a/services/tenant/provisioner/provisioner.go
+++ b/services/tenant/provisioner/provisioner.go
@@ -1,0 +1,221 @@
+// Package provisioner defines interfaces and types for multi-tenant schema provisioning.
+//
+// Schema provisioning automates the creation of org_{tenant_id} PostgreSQL schemas
+// when tenants are registered. Each tenant gets isolated database schemas for all
+// BIAN services (party, current-account, position-keeping, etc.).
+//
+// Architecture Overview:
+//
+//	┌──────────────────────────────────────────────────────────────────────────┐
+//	│                          InitiateTenant RPC                              │
+//	└──────────────────────────┬───────────────────────────────────────────────┘
+//	                           │
+//	                           ▼
+//	┌──────────────────────────────────────────────────────────────────────────┐
+//	│                      SchemaProvisioner                                    │
+//	│  ┌────────────────────────────────────────────────────────────────────┐  │
+//	│  │  ProvisionSchemas(ctx, tenantID)                                   │  │
+//	│  │    1. Create org_{tenant_id} schema                                │  │
+//	│  │    2. Apply service migrations (party, current-account, etc.)      │  │
+//	│  │    3. Update provisioning status                                   │  │
+//	│  └────────────────────────────────────────────────────────────────────┘  │
+//	└──────────────────────────────────────────────────────────────────────────┘
+//	                           │
+//	                           ▼
+//	┌─────────────────┬────────────────┬─────────────────┬────────────────────┐
+//	│   org_acme_bank │  org_beta_corp │  org_gamma_ltd  │       ...          │
+//	│   ├─ parties    │  ├─ parties    │  ├─ parties     │                    │
+//	│   ├─ accounts   │  ├─ accounts   │  ├─ accounts    │                    │
+//	│   └─ positions  │  └─ positions  │  └─ positions   │                    │
+//	└─────────────────┴────────────────┴─────────────────┴────────────────────┘
+//
+// Design Decisions:
+//
+//   - Synchronous provisioning: InitiateTenant blocks until schemas are ready
+//     (simpler architecture, acceptable latency <5s for typical deployments)
+//
+//   - Service-specific migrations: Each service owns its schema template,
+//     provisioner applies them to the new org schema
+//
+//   - Idempotency: CREATE SCHEMA IF NOT EXISTS, migration version tracking
+//     allows safe retries after partial failures
+//
+//   - Rollback strategy: On failure, tenant is marked as provisioning_failed;
+//     manual cleanup via DeprovisionSchemas or retry via ProvisionSchemas
+package provisioner
+
+import (
+	"context"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/organization"
+)
+
+// SchemaProvisioner manages the lifecycle of tenant database schemas.
+// Implementations must be safe for concurrent use.
+type SchemaProvisioner interface {
+	// ProvisionSchemas creates org_{tenant_id} schemas for all configured services.
+	//
+	// The function performs the following steps:
+	//  1. Creates the org_{tenant_id} schema (CREATE SCHEMA IF NOT EXISTS)
+	//  2. Applies baseline migrations for each configured service
+	//  3. Updates provisioning status for tracking
+	//
+	// Idempotency: Safe to call multiple times; already-created schemas and
+	// already-applied migrations are skipped.
+	//
+	// Returns an error if any service migration fails. Partial progress is
+	// recorded in the provisioning status for debugging and retry.
+	ProvisionSchemas(ctx context.Context, tenantID organization.OrganizationID) error
+
+	// DeprovisionSchemas drops all org_{tenant_id} schemas and data.
+	//
+	// WARNING: This permanently deletes all tenant data. Use with caution.
+	// Typically called only during:
+	//  - Tenant deletion (after data export/archival)
+	//  - Cleanup after failed provisioning
+	//  - Development/testing
+	//
+	// The function performs:
+	//  1. DROP SCHEMA org_{tenant_id} CASCADE (removes all objects)
+	//  2. Removes provisioning status record
+	//
+	// Idempotency: Safe to call on non-existent schemas.
+	DeprovisionSchemas(ctx context.Context, tenantID organization.OrganizationID) error
+
+	// GetProvisioningStatus retrieves the current provisioning state for a tenant.
+	//
+	// Returns ErrProvisioningStatusNotFound if no provisioning record exists.
+	// This can indicate the tenant was never provisioned or was fully deprovisioned.
+	GetProvisioningStatus(ctx context.Context, tenantID organization.OrganizationID) (*ProvisioningStatus, error)
+}
+
+// ProvisioningState represents the lifecycle state of schema provisioning.
+type ProvisioningState string
+
+const (
+	// StatePending indicates provisioning has been requested but not started.
+	StatePending ProvisioningState = "pending"
+
+	// StateInProgress indicates provisioning is currently running.
+	StateInProgress ProvisioningState = "in_progress"
+
+	// StateActive indicates all schemas were successfully provisioned.
+	StateActive ProvisioningState = "active"
+
+	// StateFailed indicates provisioning failed. Check ErrorMessage for details.
+	// Failed provisioning can be retried via ProvisionSchemas.
+	StateFailed ProvisioningState = "failed"
+)
+
+// IsValid returns true if the state is a recognized provisioning state.
+func (s ProvisioningState) IsValid() bool {
+	switch s {
+	case StatePending, StateInProgress, StateActive, StateFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsTerminal returns true if the state is a final state (active or permanently failed).
+func (s ProvisioningState) IsTerminal() bool {
+	return s == StateActive || s == StateFailed
+}
+
+// ProvisioningStatus tracks the state of schema provisioning for a tenant.
+type ProvisioningStatus struct {
+	// TenantID is the organization identifier for this provisioning record.
+	TenantID organization.OrganizationID
+
+	// State is the current provisioning lifecycle state.
+	State ProvisioningState
+
+	// Services contains the provisioning status for each service's schema.
+	// Key is the service name (e.g., "party", "current-account").
+	Services []ServiceSchemaStatus
+
+	// ErrorMessage contains details if State is StateFailed.
+	// Empty string for successful provisioning.
+	ErrorMessage string
+
+	// CreatedAt is when provisioning was first initiated.
+	CreatedAt time.Time
+
+	// UpdatedAt is when the status was last modified.
+	UpdatedAt time.Time
+}
+
+// ServiceSchemaStatus tracks provisioning progress for a single service's schema.
+type ServiceSchemaStatus struct {
+	// ServiceName identifies the BIAN service (e.g., "party", "current-account").
+	ServiceName string
+
+	// SchemaName is the PostgreSQL schema created (e.g., "org_acme_bank").
+	SchemaName string
+
+	// State indicates this service's provisioning status.
+	State ServiceProvisioningState
+
+	// MigrationVersion is the highest migration version applied.
+	// Empty string if no migrations have been applied yet.
+	MigrationVersion string
+
+	// ErrorMessage contains details if State is ServiceStateFailed.
+	ErrorMessage string
+}
+
+// ServiceProvisioningState represents the provisioning state for a single service.
+type ServiceProvisioningState string
+
+const (
+	// ServiceStatePending indicates the service schema has not been created yet.
+	ServiceStatePending ServiceProvisioningState = "pending"
+
+	// ServiceStateCreated indicates the schema exists but migrations are pending.
+	ServiceStateCreated ServiceProvisioningState = "created"
+
+	// ServiceStateMigrated indicates all migrations have been successfully applied.
+	ServiceStateMigrated ServiceProvisioningState = "migrated"
+
+	// ServiceStateFailed indicates migration failed for this service.
+	ServiceStateFailed ServiceProvisioningState = "failed"
+)
+
+// ServiceConfig defines a service that needs schema provisioning.
+// Used to configure the provisioner with the list of services to provision.
+type ServiceConfig struct {
+	// Name is the service identifier (e.g., "party", "current-account").
+	// Used for logging and status tracking.
+	Name string
+
+	// MigrationPath is the path to the service's migration files.
+	// These migrations use unqualified table names (no schema prefix).
+	MigrationPath string
+}
+
+// Config holds configuration for the schema provisioner.
+type Config struct {
+	// Services lists the BIAN services that need schema provisioning.
+	// Order matters: services are provisioned in the order listed.
+	// Consider dependency order (e.g., party before current-account).
+	Services []ServiceConfig
+
+	// ProvisioningTimeout is the maximum time allowed for provisioning all schemas.
+	// Default: 30 seconds.
+	ProvisioningTimeout time.Duration
+}
+
+// DefaultConfig returns a configuration with standard BIAN services.
+func DefaultConfig() *Config {
+	return &Config{
+		Services: []ServiceConfig{
+			{Name: "party", MigrationPath: "services/party/migrations"},
+			{Name: "current-account", MigrationPath: "services/current-account/migrations"},
+			{Name: "position-keeping", MigrationPath: "services/position-keeping/migrations"},
+			{Name: "financial-accounting", MigrationPath: "services/financial-accounting/migrations"},
+			{Name: "payment-order", MigrationPath: "services/payment-order/migrations"},
+		},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+}

--- a/services/tenant/provisioner/provisioner.go
+++ b/services/tenant/provisioner/provisioner.go
@@ -42,6 +42,13 @@
 //
 //   - Rollback strategy: On failure, tenant is marked as provisioning_failed;
 //     manual cleanup via DeprovisionSchemas or retry via ProvisionSchemas
+//
+//   - Audit trail: Provisioning records are NEVER hard deleted. Deprovisioning
+//     marks the record as 'deprovisioned' with a timestamp for audit purposes.
+//
+//   - Data retention: Deprovisioned schemas are NOT automatically dropped.
+//     A separate PurgeSchemas operation handles schema deletion after the
+//     configured retention period (for regulatory compliance).
 package provisioner
 
 import (
@@ -68,25 +75,47 @@ type SchemaProvisioner interface {
 	// recorded in the provisioning status for debugging and retry.
 	ProvisionSchemas(ctx context.Context, tenantID organization.OrganizationID) error
 
-	// DeprovisionSchemas drops all org_{tenant_id} schemas and data.
+	// DeprovisionSchemas marks tenant schemas as deprovisioned (soft delete).
 	//
-	// WARNING: This permanently deletes all tenant data. Use with caution.
-	// Typically called only during:
-	//  - Tenant deletion (after data export/archival)
-	//  - Cleanup after failed provisioning
-	//  - Development/testing
+	// This is a SOFT DELETE operation for audit trail compliance:
+	//  - Sets provisioning state to 'deprovisioned'
+	//  - Records deprovisioned_at timestamp
+	//  - Does NOT drop the actual database schema or data
+	//
+	// The org_{tenant_id} schema remains in the database until explicitly purged
+	// via PurgeSchemas after the data retention period.
+	//
+	// Typically called during:
+	//  - Tenant deactivation/offboarding
+	//  - Account closure workflows
+	//
+	// Idempotency: Safe to call multiple times; already-deprovisioned tenants
+	// are unchanged.
+	DeprovisionSchemas(ctx context.Context, tenantID organization.OrganizationID) error
+
+	// PurgeSchemas permanently drops org_{tenant_id} schemas and all data.
+	//
+	// WARNING: This is a DESTRUCTIVE operation that permanently deletes all
+	// tenant data. This action cannot be undone.
+	//
+	// Prerequisites:
+	//  - Tenant must be in 'deprovisioned' state
+	//  - Data retention period must have elapsed (checked by implementation)
+	//  - Data export/archival should be completed before calling
 	//
 	// The function performs:
-	//  1. DROP SCHEMA org_{tenant_id} CASCADE (removes all objects)
-	//  2. Removes provisioning status record
+	//  1. Validates tenant is deprovisioned and retention period elapsed
+	//  2. DROP SCHEMA org_{tenant_id} CASCADE (removes all objects)
+	//  3. Updates provisioning status to record purge timestamp
 	//
-	// Idempotency: Safe to call on non-existent schemas.
-	DeprovisionSchemas(ctx context.Context, tenantID organization.OrganizationID) error
+	// Returns ErrRetentionPeriodNotElapsed if called before retention period.
+	// Returns ErrNotDeprovisioned if tenant is still active.
+	PurgeSchemas(ctx context.Context, tenantID organization.OrganizationID) error
 
 	// GetProvisioningStatus retrieves the current provisioning state for a tenant.
 	//
 	// Returns ErrProvisioningStatusNotFound if no provisioning record exists.
-	// This can indicate the tenant was never provisioned or was fully deprovisioned.
+	// Note: Deprovisioned tenants still have a status record (for audit trail).
 	GetProvisioningStatus(ctx context.Context, tenantID organization.OrganizationID) (*ProvisioningStatus, error)
 }
 
@@ -106,21 +135,26 @@ const (
 	// StateFailed indicates provisioning failed. Check ErrorMessage for details.
 	// Failed provisioning can be retried via ProvisionSchemas.
 	StateFailed ProvisioningState = "failed"
+
+	// StateDeprovisioned indicates the tenant has been deprovisioned (soft deleted).
+	// The schema data still exists but is marked for eventual cleanup.
+	// This is a terminal state - provisioning cannot be retried.
+	StateDeprovisioned ProvisioningState = "deprovisioned"
 )
 
 // IsValid returns true if the state is a recognized provisioning state.
 func (s ProvisioningState) IsValid() bool {
 	switch s {
-	case StatePending, StateInProgress, StateActive, StateFailed:
+	case StatePending, StateInProgress, StateActive, StateFailed, StateDeprovisioned:
 		return true
 	default:
 		return false
 	}
 }
 
-// IsTerminal returns true if the state is a final state (active or permanently failed).
+// IsTerminal returns true if the state is a final state that cannot transition further.
 func (s ProvisioningState) IsTerminal() bool {
-	return s == StateActive || s == StateFailed
+	return s == StateActive || s == StateFailed || s == StateDeprovisioned
 }
 
 // ProvisioningStatus tracks the state of schema provisioning for a tenant.
@@ -144,6 +178,10 @@ type ProvisioningStatus struct {
 
 	// UpdatedAt is when the status was last modified.
 	UpdatedAt time.Time
+
+	// DeprovisionedAt is when the tenant was marked as deprovisioned.
+	// Nil if the tenant is still active. Used for data retention policy enforcement.
+	DeprovisionedAt *time.Time
 }
 
 // ServiceSchemaStatus tracks provisioning progress for a single service's schema.
@@ -204,6 +242,12 @@ type Config struct {
 	// ProvisioningTimeout is the maximum time allowed for provisioning all schemas.
 	// Default: 30 seconds.
 	ProvisioningTimeout time.Duration
+
+	// DataRetentionPeriod is the minimum time that must elapse after deprovisioning
+	// before schema data can be purged. This ensures compliance with data retention
+	// regulations (e.g., financial record keeping requirements).
+	// Default: 7 years (2555 days) for financial services compliance.
+	DataRetentionPeriod time.Duration
 }
 
 // DefaultConfig returns a configuration with standard BIAN services.
@@ -217,5 +261,6 @@ func DefaultConfig() *Config {
 			{Name: "payment-order", MigrationPath: "services/payment-order/migrations"},
 		},
 		ProvisioningTimeout: 30 * time.Second,
+		DataRetentionPeriod: 7 * 365 * 24 * time.Hour, // 7 years
 	}
 }

--- a/services/tenant/provisioner/provisioner_test.go
+++ b/services/tenant/provisioner/provisioner_test.go
@@ -89,7 +89,7 @@ func TestSchemaProvisioner_ProvisionSchemas_Failure(t *testing.T) {
 	assert.Contains(t, status.ErrorMessage, "database connection failed")
 }
 
-func TestSchemaProvisioner_DeprovisionSchemas(t *testing.T) {
+func TestSchemaProvisioner_DeprovisionSchemas_SoftDelete(t *testing.T) {
 	services := []ServiceConfig{
 		{Name: "party", MigrationPath: "services/party/migrations"},
 	}
@@ -101,16 +101,18 @@ func TestSchemaProvisioner_DeprovisionSchemas(t *testing.T) {
 	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
-	// Then deprovision
+	// Then deprovision (soft delete)
 	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
 	// Verify deprovisioning was recorded
 	assert.Len(t, provisioner.DeprovisioningCalls, 1)
 
-	// Verify status is gone
-	_, err = provisioner.GetProvisioningStatus(context.Background(), tenantID)
-	assert.ErrorIs(t, err, ErrProvisioningStatusNotFound)
+	// Verify status still exists but is marked as deprovisioned (soft delete)
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateDeprovisioned, status.State)
+	assert.NotNil(t, status.DeprovisionedAt)
 }
 
 func TestSchemaProvisioner_DeprovisionSchemas_Idempotent(t *testing.T) {
@@ -119,11 +121,90 @@ func TestSchemaProvisioner_DeprovisionSchemas_Idempotent(t *testing.T) {
 	}
 	provisioner := NewMockProvisioner(services)
 
+	tenantID := organization.MustNewOrganizationID("idempotent_deprov")
+
+	// First provision
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Deprovision twice
+	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Both calls should be recorded
+	assert.Len(t, provisioner.DeprovisioningCalls, 2)
+
+	// Status should still be deprovisioned
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateDeprovisioned, status.State)
+}
+
+func TestSchemaProvisioner_DeprovisionSchemas_NotFound(t *testing.T) {
+	provisioner := NewMockProvisioner(nil)
+
 	tenantID := organization.MustNewOrganizationID("never_existed")
 
-	// Deprovision non-existent tenant (should succeed - idempotent)
+	// Deprovision non-existent tenant should fail
 	err := provisioner.DeprovisionSchemas(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrProvisioningStatusNotFound)
+}
+
+func TestSchemaProvisioner_PurgeSchemas(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+
+	tenantID := organization.MustNewOrganizationID("purge_tenant")
+
+	// Provision then deprovision
+	_ = provisioner.ProvisionSchemas(context.Background(), tenantID)
+	_ = provisioner.DeprovisionSchemas(context.Background(), tenantID)
+
+	// Purge should succeed (no retention period configured)
+	err := provisioner.PurgeSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
+
+	// Verify purge was recorded
+	assert.Len(t, provisioner.PurgeCalls, 1)
+}
+
+func TestSchemaProvisioner_PurgeSchemas_NotDeprovisioned(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+
+	tenantID := organization.MustNewOrganizationID("active_tenant")
+
+	// Provision but don't deprovision
+	_ = provisioner.ProvisionSchemas(context.Background(), tenantID)
+
+	// Purge should fail - tenant is still active
+	err := provisioner.PurgeSchemas(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrNotDeprovisioned)
+}
+
+func TestSchemaProvisioner_PurgeSchemas_RetentionPeriodNotElapsed(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+	provisioner.DataRetentionPeriod = 7 * 24 * time.Hour // 7 days
+
+	tenantID := organization.MustNewOrganizationID("retention_tenant")
+
+	// Provision then deprovision
+	_ = provisioner.ProvisionSchemas(context.Background(), tenantID)
+	_ = provisioner.DeprovisionSchemas(context.Background(), tenantID)
+
+	// Purge should fail - retention period not elapsed
+	err := provisioner.PurgeSchemas(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrRetentionPeriodNotElapsed)
 }
 
 func TestSchemaProvisioner_GetProvisioningStatus_NotFound(t *testing.T) {
@@ -163,6 +244,7 @@ func TestProvisioningState_IsValid(t *testing.T) {
 		{StateInProgress, true},
 		{StateActive, true},
 		{StateFailed, true},
+		{StateDeprovisioned, true},
 		{ProvisioningState("unknown"), false},
 		{ProvisioningState(""), false},
 	}
@@ -183,6 +265,7 @@ func TestProvisioningState_IsTerminal(t *testing.T) {
 		{StateInProgress, false},
 		{StateActive, true},
 		{StateFailed, true},
+		{StateDeprovisioned, true},
 	}
 
 	for _, tt := range tests {
@@ -197,6 +280,7 @@ func TestDefaultConfig(t *testing.T) {
 
 	assert.Len(t, config.Services, 5)
 	assert.Equal(t, 30*time.Second, config.ProvisioningTimeout)
+	assert.Equal(t, 7*365*24*time.Hour, config.DataRetentionPeriod) // 7 years
 
 	// Verify expected services
 	serviceNames := make([]string, len(config.Services))

--- a/services/tenant/provisioner/provisioner_test.go
+++ b/services/tenant/provisioner/provisioner_test.go
@@ -121,6 +121,27 @@ func TestSchemaProvisioner_ProvisionSchemas_RetryAfterFailure(t *testing.T) {
 	assert.Equal(t, StateActive, status.State)
 }
 
+func TestSchemaProvisioner_ProvisionSchemas_ConcurrentAttemptBlocked(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+
+	tenantID := organization.MustNewOrganizationID("concurrent_tenant")
+
+	// Manually set status to in_progress to simulate concurrent attempt
+	provisioner.SetStatus(&ProvisioningStatus{
+		TenantID:  tenantID,
+		State:     StateInProgress,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	})
+
+	// Attempt to provision while already in progress
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrProvisioningInProgress)
+}
+
 func TestSchemaProvisioner_DeprovisionSchemas_SoftDelete(t *testing.T) {
 	services := []ServiceConfig{
 		{Name: "party", MigrationPath: "services/party/migrations"},
@@ -203,6 +224,10 @@ func TestSchemaProvisioner_PurgeSchemas(t *testing.T) {
 
 	// Verify purge was recorded
 	assert.Len(t, provisioner.PurgeCalls, 1)
+
+	// Verify status record is removed after purge
+	_, err = provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrProvisioningStatusNotFound)
 }
 
 func TestSchemaProvisioner_PurgeSchemas_NotDeprovisioned(t *testing.T) {

--- a/services/tenant/provisioner/provisioner_test.go
+++ b/services/tenant/provisioner/provisioner_test.go
@@ -89,6 +89,38 @@ func TestSchemaProvisioner_ProvisionSchemas_Failure(t *testing.T) {
 	assert.Contains(t, status.ErrorMessage, "database connection failed")
 }
 
+func TestSchemaProvisioner_ProvisionSchemas_RetryAfterFailure(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+
+	tenantID := organization.MustNewOrganizationID("retry_tenant")
+
+	// Configure initial failure
+	provisioner.FailProvisioningFor[tenantID.String()] = ErrTestDatabaseConnectionFailed
+
+	// First attempt fails
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.Error(t, err)
+
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateFailed, status.State)
+
+	// Remove failure configuration to simulate issue resolved
+	delete(provisioner.FailProvisioningFor, tenantID.String())
+
+	// Retry should succeed
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Verify status is now active
+	status, err = provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateActive, status.State)
+}
+
 func TestSchemaProvisioner_DeprovisionSchemas_SoftDelete(t *testing.T) {
 	services := []ServiceConfig{
 		{Name: "party", MigrationPath: "services/party/migrations"},
@@ -282,6 +314,9 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 30*time.Second, config.ProvisioningTimeout)
 	assert.Equal(t, 7*365*24*time.Hour, config.DataRetentionPeriod) // 7 years
 
+	// Default config should be valid
+	require.NoError(t, config.Validate())
+
 	// Verify expected services
 	serviceNames := make([]string, len(config.Services))
 	for i, svc := range config.Services {
@@ -292,6 +327,56 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Contains(t, serviceNames, "position-keeping")
 	assert.Contains(t, serviceNames, "financial-accounting")
 	assert.Contains(t, serviceNames, "payment-order")
+}
+
+func TestConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr error
+	}{
+		{
+			name:    "empty services",
+			config:  &Config{Services: nil, ProvisioningTimeout: time.Second},
+			wantErr: ErrNoServicesConfigured,
+		},
+		{
+			name:    "zero timeout",
+			config:  &Config{Services: []ServiceConfig{{Name: "test", MigrationPath: "/path"}}, ProvisioningTimeout: 0},
+			wantErr: ErrInvalidProvisioningTimeout,
+		},
+		{
+			name:    "negative retention",
+			config:  &Config{Services: []ServiceConfig{{Name: "test", MigrationPath: "/path"}}, ProvisioningTimeout: time.Second, DataRetentionPeriod: -1},
+			wantErr: ErrInvalidRetentionPeriod,
+		},
+		{
+			name:    "empty service name",
+			config:  &Config{Services: []ServiceConfig{{Name: "", MigrationPath: "/path"}}, ProvisioningTimeout: time.Second},
+			wantErr: ErrEmptyServiceName,
+		},
+		{
+			name:    "empty migration path",
+			config:  &Config{Services: []ServiceConfig{{Name: "test", MigrationPath: ""}}, ProvisioningTimeout: time.Second},
+			wantErr: ErrEmptyMigrationPath,
+		},
+		{
+			name:    "valid config",
+			config:  &Config{Services: []ServiceConfig{{Name: "test", MigrationPath: "/path"}}, ProvisioningTimeout: time.Second},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tt.wantErr)
+			}
+		})
+	}
 }
 
 func TestMockProvisioner_Reset(t *testing.T) {

--- a/services/tenant/provisioner/provisioner_test.go
+++ b/services/tenant/provisioner/provisioner_test.go
@@ -1,0 +1,263 @@
+package provisioner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/organization"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test interface usability by exercising the mock provisioner.
+
+func TestSchemaProvisioner_ProvisionSchemas(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+		{Name: "current-account", MigrationPath: "services/current-account/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+
+	tenantID := organization.MustNewOrganizationID("acme_bank")
+
+	// Provision schemas for tenant
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Verify provisioning was recorded
+	assert.Len(t, provisioner.ProvisioningCalls, 1)
+	assert.Equal(t, tenantID, provisioner.ProvisioningCalls[0])
+
+	// Verify status is active
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateActive, status.State)
+	assert.Len(t, status.Services, 2)
+
+	// Verify service statuses
+	for _, svc := range status.Services {
+		assert.Equal(t, ServiceStateMigrated, svc.State)
+		assert.Equal(t, "org_acme_bank", svc.SchemaName)
+	}
+}
+
+func TestSchemaProvisioner_ProvisionSchemas_Idempotent(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+
+	tenantID := organization.MustNewOrganizationID("beta_corp")
+
+	// Provision twice
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Both calls should be recorded (even if second is no-op)
+	assert.Len(t, provisioner.ProvisioningCalls, 2)
+
+	// Status should still be active
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateActive, status.State)
+}
+
+func TestSchemaProvisioner_ProvisionSchemas_Failure(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+
+	tenantID := organization.MustNewOrganizationID("failing_tenant")
+
+	// Configure failure using sentinel error
+	provisioner.FailProvisioningFor[tenantID.String()] = ErrTestDatabaseConnectionFailed
+
+	// Attempt provisioning
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTestDatabaseConnectionFailed)
+
+	// Verify status is failed
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateFailed, status.State)
+	assert.Contains(t, status.ErrorMessage, "database connection failed")
+}
+
+func TestSchemaProvisioner_DeprovisionSchemas(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+
+	tenantID := organization.MustNewOrganizationID("deprovisioned_tenant")
+
+	// First provision
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Then deprovision
+	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Verify deprovisioning was recorded
+	assert.Len(t, provisioner.DeprovisioningCalls, 1)
+
+	// Verify status is gone
+	_, err = provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrProvisioningStatusNotFound)
+}
+
+func TestSchemaProvisioner_DeprovisionSchemas_Idempotent(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+
+	tenantID := organization.MustNewOrganizationID("never_existed")
+
+	// Deprovision non-existent tenant (should succeed - idempotent)
+	err := provisioner.DeprovisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+}
+
+func TestSchemaProvisioner_GetProvisioningStatus_NotFound(t *testing.T) {
+	services := []ServiceConfig{}
+	provisioner := NewMockProvisioner(services)
+
+	tenantID := organization.MustNewOrganizationID("unknown")
+
+	_, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrProvisioningStatusNotFound)
+}
+
+func TestSchemaProvisioner_Timeout(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+
+	// Configure delay longer than context timeout
+	provisioner.ProvisioningDelay = 500 * time.Millisecond
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	tenantID := organization.MustNewOrganizationID("slow_tenant")
+
+	err := provisioner.ProvisionSchemas(ctx, tenantID)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestProvisioningState_IsValid(t *testing.T) {
+	tests := []struct {
+		state ProvisioningState
+		valid bool
+	}{
+		{StatePending, true},
+		{StateInProgress, true},
+		{StateActive, true},
+		{StateFailed, true},
+		{ProvisioningState("unknown"), false},
+		{ProvisioningState(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			assert.Equal(t, tt.valid, tt.state.IsValid())
+		})
+	}
+}
+
+func TestProvisioningState_IsTerminal(t *testing.T) {
+	tests := []struct {
+		state    ProvisioningState
+		terminal bool
+	}{
+		{StatePending, false},
+		{StateInProgress, false},
+		{StateActive, true},
+		{StateFailed, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			assert.Equal(t, tt.terminal, tt.state.IsTerminal())
+		})
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+
+	assert.Len(t, config.Services, 5)
+	assert.Equal(t, 30*time.Second, config.ProvisioningTimeout)
+
+	// Verify expected services
+	serviceNames := make([]string, len(config.Services))
+	for i, svc := range config.Services {
+		serviceNames[i] = svc.Name
+	}
+	assert.Contains(t, serviceNames, "party")
+	assert.Contains(t, serviceNames, "current-account")
+	assert.Contains(t, serviceNames, "position-keeping")
+	assert.Contains(t, serviceNames, "financial-accounting")
+	assert.Contains(t, serviceNames, "payment-order")
+}
+
+func TestMockProvisioner_Reset(t *testing.T) {
+	services := []ServiceConfig{
+		{Name: "party", MigrationPath: "services/party/migrations"},
+	}
+	provisioner := NewMockProvisioner(services)
+
+	tenantID := organization.MustNewOrganizationID("reset_test")
+
+	// Set up some state
+	_ = provisioner.ProvisionSchemas(context.Background(), tenantID)
+	provisioner.FailProvisioningFor["some_tenant"] = ErrTestGeneric
+	provisioner.ProvisioningDelay = time.Second
+
+	// Reset
+	provisioner.Reset()
+
+	// Verify all state is cleared
+	assert.Empty(t, provisioner.ProvisioningCalls)
+	assert.Empty(t, provisioner.DeprovisioningCalls)
+	assert.Empty(t, provisioner.FailProvisioningFor)
+	assert.Zero(t, provisioner.ProvisioningDelay)
+
+	// Status should no longer exist
+	_, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrProvisioningStatusNotFound)
+}
+
+func TestMockProvisioner_SetStatus(t *testing.T) {
+	provisioner := NewMockProvisioner(nil)
+
+	tenantID := organization.MustNewOrganizationID("manual_status")
+
+	// Manually set a custom status
+	customStatus := &ProvisioningStatus{
+		TenantID: tenantID,
+		State:    StateInProgress,
+		Services: []ServiceSchemaStatus{
+			{ServiceName: "custom", SchemaName: "org_manual", State: ServiceStateCreated},
+		},
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	provisioner.SetStatus(customStatus)
+
+	// Retrieve and verify
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateInProgress, status.State)
+	assert.Len(t, status.Services, 1)
+	assert.Equal(t, "custom", status.Services[0].ServiceName)
+}


### PR DESCRIPTION
## Summary
- Define SchemaProvisioner interface for multi-tenant schema lifecycle management
- Add ProvisioningStatus and ServiceSchemaStatus types for tracking per-service progress
- Create MockProvisioner for testing with idempotency, timeout, and failure simulation
- Add database migration for platform.tenant_provisioning table

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 46

## Changes Made
- `services/tenant/provisioner/provisioner.go` - SchemaProvisioner interface with architecture documentation
- `services/tenant/provisioner/errors.go` - Domain errors for provisioning operations  
- `services/tenant/provisioner/mock_provisioner.go` - In-memory mock for testing
- `services/tenant/provisioner/provisioner_test.go` - Test suite validating interface usability
- `services/tenant/migrations/20251212100000_create_tenant_provisioning.sql` - Status tracking table

## Design Decisions
- **Synchronous provisioning**: Block InitiateTenant until schemas ready (simpler, <5s latency)
- **Service-specific migrations**: Each service owns its schema template
- **Idempotency**: `CREATE SCHEMA IF NOT EXISTS`, migration version tracking allows safe retries
- **Rollback strategy**: On failure, mark tenant as provisioning_failed; manual cleanup required

## Test Plan
1. Unit tests validate mock provisioner implements interface correctly
2. Tests verify idempotency (ProvisionSchemas can be called multiple times)
3. Tests verify timeout handling via context cancellation
4. Tests verify failure state tracking with error messages
5. All tests pass: `go test ./services/tenant/provisioner/...`