### PR TITLE
feat: Integrate auth interceptor in Party Service gRPC server

### DIFF
--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/meridianhub/meridian/services/party/adapters/persistence"
 	"github.com/meridianhub/meridian/services/party/service"
 	"github.com/meridianhub/meridian/shared/pkg/interceptors"
+	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -105,17 +106,35 @@ func run(logger *slog.Logger) error {
 
 	logger.Info("party service initialized")
 
+	// Initialize auth interceptor (optional - based on AUTH_ENABLED)
+	authInterceptor, err := initAuth(ctx, logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+
 	// Create gRPC server with interceptor chain
-	// Order: tracing → recovery (recovery last to catch all panics)
+	// Order: tracing → auth → recovery (recovery last to catch all panics)
+	var unaryInterceptors []grpc.UnaryServerInterceptor
+	var streamInterceptors []grpc.StreamServerInterceptor
+
+	// 1. Tracing (always first for full request coverage)
+	unaryInterceptors = append(unaryInterceptors, tracer.UnaryServerInterceptor())
+	streamInterceptors = append(streamInterceptors, tracer.StreamServerInterceptor())
+
+	// 2. Auth (JWT validation with JWKS - optional)
+	if authInterceptor != nil {
+		unaryInterceptors = append(unaryInterceptors, authInterceptor.UnaryInterceptor())
+		streamInterceptors = append(streamInterceptors, authInterceptor.StreamInterceptor())
+		logger.Info("auth interceptor enabled in chain")
+	}
+
+	// 3. Recovery (last in chain to catch all panics)
+	unaryInterceptors = append(unaryInterceptors, interceptors.RecoveryUnaryInterceptor(logger))
+	streamInterceptors = append(streamInterceptors, interceptors.RecoveryStreamInterceptor(logger))
+
 	grpcServer := grpc.NewServer(
-		grpc.ChainUnaryInterceptor(
-			tracer.UnaryServerInterceptor(),
-			interceptors.RecoveryUnaryInterceptor(logger),
-		),
-		grpc.ChainStreamInterceptor(
-			tracer.StreamServerInterceptor(),
-			interceptors.RecoveryStreamInterceptor(logger),
-		),
+		grpc.ChainUnaryInterceptor(unaryInterceptors...),
+		grpc.ChainStreamInterceptor(streamInterceptors...),
 	)
 
 	// Register services
@@ -306,4 +325,87 @@ func parseLogLevel(levelStr string) slog.Level {
 	default:
 		return slog.LevelInfo
 	}
+}
+
+// getEnvAsBool returns the environment variable value as bool or default
+func getEnvAsBool(key string, defaultValue bool) bool {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	switch strings.ToLower(valueStr) {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	default:
+		return defaultValue
+	}
+}
+
+// initAuth initializes the JWT authentication interceptor if enabled.
+// Returns nil if AUTH_ENABLED is false (default), allowing unauthenticated requests.
+//
+// Environment variables:
+// - AUTH_ENABLED: Set to "true" to enable JWT authentication (default: false)
+// - JWKS_URL: JWKS endpoint URL for JWT validation (required when enabled)
+// - JWKS_CACHE_TTL: How long to cache JWKS keys (default: 1h)
+// - JWKS_REFRESH_TTL: Background refresh interval for JWKS (default: 30m)
+// - MULTI_ORG_MODE: Set to "true" to require organization_id claim in JWT
+func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, error) {
+	enabled := getEnvAsBool("AUTH_ENABLED", false)
+	if !enabled {
+		logger.Info("auth disabled (set AUTH_ENABLED=true to enable)")
+		return nil, nil //nolint:nilnil // Disabled mode intentionally returns no interceptor and no error
+	}
+
+	// Load JWKS configuration
+	jwksURL := getEnvOrDefault("JWKS_URL", "http://localhost:18080/realms/meridian/protocol/openid-connect/certs")
+	cacheTTL := getEnvAsDuration("JWKS_CACHE_TTL", 1*time.Hour)
+	refreshTTL := getEnvAsDuration("JWKS_REFRESH_TTL", 30*time.Minute)
+
+	// Create JWKS provider
+	jwksConfig := &auth.JWKSProviderConfig{
+		URL:        jwksURL,
+		CacheTTL:   cacheTTL,
+		RefreshTTL: refreshTTL,
+	}
+
+	provider, err := auth.NewJWKSProvider(ctx, jwksConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWKS provider: %w", err)
+	}
+
+	// Create JWT validator
+	validator, err := auth.NewJWTValidatorWithJWKS(provider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWT validator: %w", err)
+	}
+
+	// Create interceptor with bypass methods for health checks and reflection
+	interceptorConfig := &auth.InterceptorConfig{
+		JWKSValidator: validator,
+		BypassMethods: []string{
+			"/grpc.health.v1.Health/Check",
+			"/grpc.health.v1.Health/Watch",
+			"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+		},
+	}
+
+	interceptor, err := auth.NewAuthInterceptor(interceptorConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth interceptor: %w", err)
+	}
+
+	// Log multi-org mode status (this is checked in the interceptor itself via env var)
+	multiOrgMode := getEnvAsBool("MULTI_ORG_MODE", false)
+	logger.Info("auth interceptor initialized",
+		"jwks_url", jwksURL,
+		"cache_ttl", cacheTTL,
+		"refresh_ttl", refreshTTL,
+		"multi_org_mode", multiOrgMode,
+		"bypass_methods", len(interceptorConfig.BypassMethods))
+
+	return interceptor, nil
 }

--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strings"
@@ -365,9 +366,13 @@ func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, erro
 	cacheTTL := getEnvAsDuration("JWKS_CACHE_TTL", 1*time.Hour)
 	refreshTTL := getEnvAsDuration("JWKS_REFRESH_TTL", 30*time.Minute)
 
-	// Create JWKS provider
+	// Create JWKS provider with HTTP client
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+	}
 	jwksConfig := &auth.JWKSProviderConfig{
 		URL:        jwksURL,
+		Client:     httpClient,
 		CacheTTL:   cacheTTL,
 		RefreshTTL: refreshTTL,
 	}

--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -390,6 +390,7 @@ func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, erro
 			"/grpc.health.v1.Health/Check",
 			"/grpc.health.v1.Health/Watch",
 			"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+			"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
 		},
 	}
 

--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -349,11 +349,17 @@ func getEnvAsBool(key string, defaultValue bool) bool {
 // Returns nil if AUTH_ENABLED is false (default), allowing unauthenticated requests.
 //
 // Environment variables:
-// - AUTH_ENABLED: Set to "true" to enable JWT authentication (default: false)
-// - JWKS_URL: JWKS endpoint URL for JWT validation (required when enabled)
-// - JWKS_CACHE_TTL: How long to cache JWKS keys (default: 1h)
-// - JWKS_REFRESH_TTL: Background refresh interval for JWKS (default: 30m)
-// - MULTI_ORG_MODE: Set to "true" to require organization_id claim in JWT
+//   - AUTH_ENABLED: Set to "true" to enable JWT authentication (default: false)
+//   - JWKS_URL: JWKS endpoint URL for JWT validation (required when enabled)
+//   - JWKS_CACHE_TTL: How long to cache JWKS keys (default: 1h)
+//   - JWKS_REFRESH_TTL: Background refresh interval for JWKS (default: 30m)
+//   - JWKS_HTTP_TIMEOUT: HTTP client timeout for JWKS fetch (default: 10s)
+//   - MULTI_ORG_MODE: Set to "true" to require organization_id claim in JWT
+//     (read directly by interceptor via auth.MultiOrgModeEnvVar at request time)
+//
+// Note: The JWKS provider starts a background refresh goroutine. This follows the
+// existing pattern in other services (e.g., position-keeping) where the provider
+// is not explicitly closed during shutdown, relying on process termination.
 func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, error) {
 	enabled := getEnvAsBool("AUTH_ENABLED", false)
 	if !enabled {
@@ -367,8 +373,9 @@ func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, erro
 	refreshTTL := getEnvAsDuration("JWKS_REFRESH_TTL", 30*time.Minute)
 
 	// Create JWKS provider with HTTP client
+	httpTimeout := getEnvAsDuration("JWKS_HTTP_TIMEOUT", 10*time.Second)
 	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout: httpTimeout,
 	}
 	jwksConfig := &auth.JWKSProviderConfig{
 		URL:        jwksURL,
@@ -404,12 +411,15 @@ func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, erro
 		return nil, fmt.Errorf("failed to create auth interceptor: %w", err)
 	}
 
-	// Log multi-org mode status (this is checked in the interceptor itself via env var)
+	// Log multi-org mode status for visibility.
+	// Note: The auth interceptor reads MULTI_ORG_MODE directly from the environment
+	// via os.Getenv(auth.MultiOrgModeEnvVar) at request time, not from config passed here.
 	multiOrgMode := getEnvAsBool("MULTI_ORG_MODE", false)
-	logger.Info("auth interceptor initialized",
+	logger.Debug("auth interceptor initialized",
 		"jwks_url", jwksURL,
 		"cache_ttl", cacheTTL,
 		"refresh_ttl", refreshTTL,
+		"http_timeout", httpTimeout,
 		"multi_org_mode", multiOrgMode,
 		"bypass_methods", len(interceptorConfig.BypassMethods))
 

--- a/services/party/cmd/main_test.go
+++ b/services/party/cmd/main_test.go
@@ -1,0 +1,379 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestGetEnvAsBool(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string
+		setEnv       bool
+		defaultValue bool
+		want         bool
+	}{
+		{
+			name:         "returns default when env not set",
+			envValue:     "",
+			setEnv:       false,
+			defaultValue: true,
+			want:         true,
+		},
+		{
+			name:         "returns default when env is empty",
+			envValue:     "",
+			setEnv:       true,
+			defaultValue: false,
+			want:         false,
+		},
+		{
+			name:         "returns true for 'true'",
+			envValue:     "true",
+			setEnv:       true,
+			defaultValue: false,
+			want:         true,
+		},
+		{
+			name:         "returns true for 'TRUE' (case insensitive)",
+			envValue:     "TRUE",
+			setEnv:       true,
+			defaultValue: false,
+			want:         true,
+		},
+		{
+			name:         "returns true for '1'",
+			envValue:     "1",
+			setEnv:       true,
+			defaultValue: false,
+			want:         true,
+		},
+		{
+			name:         "returns true for 'yes'",
+			envValue:     "yes",
+			setEnv:       true,
+			defaultValue: false,
+			want:         true,
+		},
+		{
+			name:         "returns false for 'false'",
+			envValue:     "false",
+			setEnv:       true,
+			defaultValue: true,
+			want:         false,
+		},
+		{
+			name:         "returns false for '0'",
+			envValue:     "0",
+			setEnv:       true,
+			defaultValue: true,
+			want:         false,
+		},
+		{
+			name:         "returns false for 'no'",
+			envValue:     "no",
+			setEnv:       true,
+			defaultValue: true,
+			want:         false,
+		},
+		{
+			name:         "returns default for invalid value",
+			envValue:     "maybe",
+			setEnv:       true,
+			defaultValue: true,
+			want:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const testKey = "TEST_BOOL_VAR"
+			if tt.setEnv {
+				t.Setenv(testKey, tt.envValue)
+			} else {
+				_ = os.Unsetenv(testKey)
+			}
+
+			got := getEnvAsBool(testKey, tt.defaultValue)
+			if got != tt.want {
+				t.Errorf("getEnvAsBool(%q, %v) = %v, want %v", testKey, tt.defaultValue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInitAuth_Disabled(t *testing.T) {
+	// Ensure auth is disabled
+	t.Setenv("AUTH_ENABLED", "false")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelError,
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	interceptor, err := initAuth(ctx, logger)
+	if err != nil {
+		t.Errorf("initAuth() error = %v, want nil", err)
+	}
+
+	if interceptor != nil {
+		t.Errorf("initAuth() returned non-nil interceptor when auth is disabled")
+	}
+}
+
+func TestInitAuth_DisabledByDefault(t *testing.T) {
+	// Ensure AUTH_ENABLED is not set (use empty string to simulate unset)
+	t.Setenv("AUTH_ENABLED", "")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelError,
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	interceptor, err := initAuth(ctx, logger)
+	if err != nil {
+		t.Errorf("initAuth() error = %v, want nil", err)
+	}
+
+	if interceptor != nil {
+		t.Errorf("initAuth() returned non-nil interceptor when AUTH_ENABLED not set")
+	}
+}
+
+func TestInitAuth_EnabledWithInvalidJWKSURL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	// Enable auth but with an invalid JWKS URL
+	t.Setenv("AUTH_ENABLED", "true")
+	t.Setenv("JWKS_URL", "http://invalid-host-that-does-not-exist:9999/jwks")
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelError,
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	interceptor, err := initAuth(ctx, logger)
+
+	// Should fail because JWKS URL is unreachable
+	if err == nil {
+		t.Errorf("initAuth() error = nil, want error for invalid JWKS URL")
+	}
+
+	if interceptor != nil {
+		t.Errorf("initAuth() returned non-nil interceptor on error")
+	}
+}
+
+func TestInitAuth_UsesConfiguredValues(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	// This test verifies that configured values are read from environment
+	// We can't fully test without a real JWKS server, but we can verify
+	// that the environment variables are being read
+
+	t.Setenv("AUTH_ENABLED", "true")
+	t.Setenv("JWKS_URL", "http://localhost:18080/realms/meridian/protocol/openid-connect/certs")
+	t.Setenv("JWKS_CACHE_TTL", "2h")
+	t.Setenv("JWKS_REFRESH_TTL", "45m")
+	t.Setenv("MULTI_ORG_MODE", "true")
+
+	// Verify environment variables are read correctly
+	if jwksURL := getEnvOrDefault("JWKS_URL", ""); jwksURL != "http://localhost:18080/realms/meridian/protocol/openid-connect/certs" {
+		t.Errorf("JWKS_URL = %q, want configured value", jwksURL)
+	}
+
+	cacheTTL := getEnvAsDuration("JWKS_CACHE_TTL", time.Hour)
+	if cacheTTL != 2*time.Hour {
+		t.Errorf("JWKS_CACHE_TTL = %v, want 2h", cacheTTL)
+	}
+
+	refreshTTL := getEnvAsDuration("JWKS_REFRESH_TTL", 30*time.Minute)
+	if refreshTTL != 45*time.Minute {
+		t.Errorf("JWKS_REFRESH_TTL = %v, want 45m", refreshTTL)
+	}
+
+	multiOrgMode := getEnvAsBool("MULTI_ORG_MODE", false)
+	if !multiOrgMode {
+		t.Errorf("MULTI_ORG_MODE = %v, want true", multiOrgMode)
+	}
+}
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"INFO", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"WARN", slog.LevelWarn},
+		{"warning", slog.LevelWarn},
+		{"WARNING", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"ERROR", slog.LevelError},
+		{"", slog.LevelInfo},
+		{"invalid", slog.LevelInfo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseLogLevel(tt.input)
+			if got != tt.want {
+				t.Errorf("parseLogLevel(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetEnvOrDefault(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string
+		setEnv       bool
+		defaultValue string
+		want         string
+	}{
+		{
+			name:         "returns env value when set",
+			envValue:     "custom-value",
+			setEnv:       true,
+			defaultValue: "default",
+			want:         "custom-value",
+		},
+		{
+			name:         "returns default when env empty",
+			envValue:     "",
+			setEnv:       true,
+			defaultValue: "default",
+			want:         "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const testKey = "TEST_STRING_VAR"
+			if tt.setEnv {
+				t.Setenv(testKey, tt.envValue)
+			}
+
+			got := getEnvOrDefault(testKey, tt.defaultValue)
+			if got != tt.want {
+				t.Errorf("getEnvOrDefault(%q, %q) = %q, want %q", testKey, tt.defaultValue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetEnvAsInt(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string
+		setEnv       bool
+		defaultValue int
+		want         int
+	}{
+		{
+			name:         "returns env value when valid int",
+			envValue:     "42",
+			setEnv:       true,
+			defaultValue: 10,
+			want:         42,
+		},
+		{
+			name:         "returns default when env empty",
+			envValue:     "",
+			setEnv:       true,
+			defaultValue: 10,
+			want:         10,
+		},
+		{
+			name:         "returns default when env invalid",
+			envValue:     "not-a-number",
+			setEnv:       true,
+			defaultValue: 10,
+			want:         10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const testKey = "TEST_INT_VAR"
+			if tt.setEnv {
+				t.Setenv(testKey, tt.envValue)
+			}
+
+			got := getEnvAsInt(testKey, tt.defaultValue)
+			if got != tt.want {
+				t.Errorf("getEnvAsInt(%q, %d) = %d, want %d", testKey, tt.defaultValue, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetEnvAsDuration(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string
+		setEnv       bool
+		defaultValue time.Duration
+		want         time.Duration
+	}{
+		{
+			name:         "returns env value when valid duration",
+			envValue:     "5m",
+			setEnv:       true,
+			defaultValue: time.Minute,
+			want:         5 * time.Minute,
+		},
+		{
+			name:         "returns default when env empty",
+			envValue:     "",
+			setEnv:       true,
+			defaultValue: time.Minute,
+			want:         time.Minute,
+		},
+		{
+			name:         "returns default when env invalid",
+			envValue:     "not-a-duration",
+			setEnv:       true,
+			defaultValue: time.Minute,
+			want:         time.Minute,
+		},
+		{
+			name:         "parses hours correctly",
+			envValue:     "2h",
+			setEnv:       true,
+			defaultValue: time.Hour,
+			want:         2 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const testKey = "TEST_DURATION_VAR"
+			if tt.setEnv {
+				t.Setenv(testKey, tt.envValue)
+			}
+
+			got := getEnvAsDuration(testKey, tt.defaultValue)
+			if got != tt.want {
+				t.Errorf("getEnvAsDuration(%q, %v) = %v, want %v", testKey, tt.defaultValue, got, tt.want)
+			}
+		})
+	}
+}

--- a/services/party/cmd/main_test.go
+++ b/services/party/cmd/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -147,14 +149,17 @@ func TestInitAuth_DisabledByDefault(t *testing.T) {
 	}
 }
 
-func TestInitAuth_EnabledWithInvalidJWKSURL(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
+func TestInitAuth_EnabledWithInvalidJWKSResponse(t *testing.T) {
+	// Use httptest server to return invalid JWKS response (deterministic, no network flakiness)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal server error"))
+	}))
+	defer ts.Close()
 
-	// Enable auth but with an invalid JWKS URL
+	// Enable auth with httptest server URL
 	t.Setenv("AUTH_ENABLED", "true")
-	t.Setenv("JWKS_URL", "http://invalid-host-that-does-not-exist:9999/jwks")
+	t.Setenv("JWKS_URL", ts.URL)
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelError,
@@ -165,9 +170,9 @@ func TestInitAuth_EnabledWithInvalidJWKSURL(t *testing.T) {
 
 	interceptor, err := initAuth(ctx, logger)
 
-	// Should fail because JWKS URL is unreachable
+	// Should fail because JWKS response is invalid
 	if err == nil {
-		t.Errorf("initAuth() error = nil, want error for invalid JWKS URL")
+		t.Errorf("initAuth() error = nil, want error for invalid JWKS response")
 	}
 
 	if interceptor != nil {
@@ -176,13 +181,8 @@ func TestInitAuth_EnabledWithInvalidJWKSURL(t *testing.T) {
 }
 
 func TestInitAuth_UsesConfiguredValues(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test in short mode")
-	}
-
 	// This test verifies that configured values are read from environment
-	// We can't fully test without a real JWKS server, but we can verify
-	// that the environment variables are being read
+	// It only exercises cheap environment-parsing helpers, no network calls
 
 	t.Setenv("AUTH_ENABLED", "true")
 	t.Setenv("JWKS_URL", "http://localhost:18080/realms/meridian/protocol/openid-connect/certs")

--- a/services/party/cmd/main_test.go
+++ b/services/party/cmd/main_test.go
@@ -128,8 +128,8 @@ func TestInitAuth_Disabled(t *testing.T) {
 	}
 }
 
-func TestInitAuth_DisabledByDefault(t *testing.T) {
-	// Ensure AUTH_ENABLED is not set (use empty string to simulate unset)
+func TestInitAuth_DisabledWithEmptyValue(t *testing.T) {
+	// Set AUTH_ENABLED to empty string - treated same as unset (defaults to false)
 	t.Setenv("AUTH_ENABLED", "")
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
@@ -145,7 +145,7 @@ func TestInitAuth_DisabledByDefault(t *testing.T) {
 	}
 
 	if interceptor != nil {
-		t.Errorf("initAuth() returned non-nil interceptor when AUTH_ENABLED not set")
+		t.Errorf("initAuth() returned non-nil interceptor when AUTH_ENABLED is empty")
 	}
 }
 
@@ -188,6 +188,7 @@ func TestInitAuth_UsesConfiguredValues(t *testing.T) {
 	t.Setenv("JWKS_URL", "http://localhost:18080/realms/meridian/protocol/openid-connect/certs")
 	t.Setenv("JWKS_CACHE_TTL", "2h")
 	t.Setenv("JWKS_REFRESH_TTL", "45m")
+	t.Setenv("JWKS_HTTP_TIMEOUT", "15s")
 	t.Setenv("MULTI_ORG_MODE", "true")
 
 	// Verify environment variables are read correctly
@@ -203,6 +204,11 @@ func TestInitAuth_UsesConfiguredValues(t *testing.T) {
 	refreshTTL := getEnvAsDuration("JWKS_REFRESH_TTL", 30*time.Minute)
 	if refreshTTL != 45*time.Minute {
 		t.Errorf("JWKS_REFRESH_TTL = %v, want 45m", refreshTTL)
+	}
+
+	httpTimeout := getEnvAsDuration("JWKS_HTTP_TIMEOUT", 10*time.Second)
+	if httpTimeout != 15*time.Second {
+		t.Errorf("JWKS_HTTP_TIMEOUT = %v, want 15s", httpTimeout)
 	}
 
 	multiOrgMode := getEnvAsBool("MULTI_ORG_MODE", false)


### PR DESCRIPTION
## Summary
- Add JWT authentication interceptor to Party Service for multi-tenant auth
- Configure JWKS-based token validation with organization context extraction
- Add comprehensive unit tests for auth configuration

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 41

## Changes Made
- Updated `services/party/cmd/main.go`:
  - Added auth interceptor initialization with `initAuth()` function
  - Wired interceptor into unary and stream interceptor chains (tracing → auth → recovery)
  - Added `getEnvAsBool()` helper for environment variable parsing
- Created `services/party/cmd/main_test.go`:
  - Tests for `initAuth()` disabled/enabled states
  - Tests for all environment variable parsing helpers

## Configuration
The following environment variables control auth behavior:

| Variable | Default | Description |
|----------|---------|-------------|
| `AUTH_ENABLED` | `false` | Enable JWT authentication |
| `JWKS_URL` | `http://localhost:18080/realms/meridian/protocol/openid-connect/certs` | JWKS endpoint for key validation |
| `JWKS_CACHE_TTL` | `1h` | How long to cache JWKS keys |
| `JWKS_REFRESH_TTL` | `30m` | Background refresh interval |
| `MULTI_ORG_MODE` | `false` | Require organization_id claim in JWT |

## Auth Interceptor Behavior
When `AUTH_ENABLED=true`:
- Extracts `Bearer` token from gRPC metadata `authorization` header
- Validates JWT signature and claims against JWKS
- Injects user ID, roles, and scopes into context
- When `MULTI_ORG_MODE=true`, extracts `organization_id` claim and injects into context
- Returns `codes.Unauthenticated` for missing/invalid tokens
- Bypasses health check and reflection endpoints

## Test Plan
- [x] Unit tests for `getEnvAsBool()` with all value variations
- [x] Unit tests for `initAuth()` when disabled (default)
- [x] Unit tests for `initAuth()` with invalid JWKS URL
- [x] Existing auth interceptor tests cover JWT validation flows
- [x] All party service tests pass
- [x] Linter passes