### PR TITLE
feat(tenant): Implement PostgresProvisioner for multi-tenant schema creation

### DIFF
--- a/services/tenant/provisioner/postgres_provisioner.go
+++ b/services/tenant/provisioner/postgres_provisioner.go
@@ -1,0 +1,584 @@
+// Package provisioner provides PostgreSQL schema provisioning for multi-tenant isolation.
+package provisioner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/meridianhub/meridian/shared/platform/organization"
+	"gorm.io/gorm"
+)
+
+// errAlreadyProvisioned is an internal sentinel for idempotent provisioning.
+// It's not a public error because it's not an actual error condition.
+var errAlreadyProvisioned = errors.New("already provisioned")
+
+// PostgresProvisioner implements SchemaProvisioner for PostgreSQL databases.
+// It creates org_{tenant_id} schemas and applies service migrations using SQL files.
+//
+// Thread-safe for concurrent use via mutex protection around status operations.
+type PostgresProvisioner struct {
+	db     *gorm.DB
+	config *Config
+
+	// mu protects concurrent access to provisioning operations for the same tenant.
+	// This prevents race conditions when multiple goroutines attempt to provision
+	// the same tenant simultaneously.
+	mu sync.Mutex
+}
+
+// NewPostgresProvisioner creates a new PostgreSQL schema provisioner.
+// The config must be validated before calling this function.
+func NewPostgresProvisioner(db *gorm.DB, config *Config) *PostgresProvisioner {
+	return &PostgresProvisioner{
+		db:     db,
+		config: config,
+	}
+}
+
+// ProvisionSchemas creates the org_{tenant_id} schema and applies all service migrations.
+//
+// The function performs the following steps:
+//  1. Creates or updates the provisioning status record to 'in_progress'
+//  2. Creates the org_{tenant_id} schema (CREATE SCHEMA IF NOT EXISTS)
+//  3. For each configured service, applies migrations to the tenant schema
+//  4. Updates the provisioning status to 'active' on success or 'failed' on error
+//
+// Idempotency: Safe to call multiple times. Already-created schemas are skipped,
+// and migrations are checked against the version recorded in the status.
+func (p *PostgresProvisioner) ProvisionSchemas(ctx context.Context, tenantID organization.OrganizationID) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Validate and prepare provisioning status
+	status, err := p.prepareProvisioningStatus(ctx, tenantID)
+	if errors.Is(err, errAlreadyProvisioned) {
+		return nil // Idempotent: already provisioned
+	}
+	if err != nil {
+		return err
+	}
+
+	// Apply timeout from config
+	if p.config.ProvisioningTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, p.config.ProvisioningTimeout)
+		defer cancel()
+	}
+
+	// Create the schema
+	schemaName := tenantID.SchemaName()
+	if err := p.createSchema(ctx, schemaName); err != nil {
+		p.markProvisioningFailed(ctx, status, fmt.Sprintf("create schema: %v", err))
+		return fmt.Errorf("%w: %w", ErrSchemaCreationFailed, err)
+	}
+
+	// Apply migrations for each service
+	if err := p.provisionAllServices(ctx, status, schemaName); err != nil {
+		return err
+	}
+
+	// Mark as active
+	status.State = StateActive
+	status.UpdatedAt = time.Now()
+	if err := p.saveProvisioningStatus(ctx, status); err != nil {
+		return fmt.Errorf("save final status: %w", err)
+	}
+
+	return nil
+}
+
+// prepareProvisioningStatus validates existing status and prepares for provisioning.
+// Returns nil status if already active (no-op), or error if provisioning cannot proceed.
+func (p *PostgresProvisioner) prepareProvisioningStatus(ctx context.Context, tenantID organization.OrganizationID) (*ProvisioningStatus, error) {
+	status, err := p.getProvisioningStatusLocked(ctx, tenantID)
+	if err != nil && !errors.Is(err, ErrProvisioningStatusNotFound) {
+		return nil, fmt.Errorf("get provisioning status: %w", err)
+	}
+
+	// Check existing state
+	if status != nil {
+		switch status.State {
+		case StateActive:
+			return nil, errAlreadyProvisioned // Idempotent: already provisioned
+		case StateInProgress:
+			return nil, ErrProvisioningInProgress
+		case StateDeprovisioned:
+			return nil, ErrAlreadyDeprovisioned
+		case StatePending, StateFailed:
+			// Can proceed with provisioning/retry
+		}
+	}
+
+	// Create or update status to in_progress
+	now := time.Now()
+	if status == nil {
+		status = &ProvisioningStatus{
+			TenantID:  tenantID,
+			State:     StateInProgress,
+			Services:  p.createInitialServiceStatuses(tenantID),
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+	} else {
+		status.State = StateInProgress
+		status.UpdatedAt = now
+		status.ErrorMessage = ""
+	}
+
+	if err := p.saveProvisioningStatus(ctx, status); err != nil {
+		return nil, fmt.Errorf("save provisioning status: %w", err)
+	}
+
+	return status, nil
+}
+
+// provisionAllServices applies migrations for each configured service.
+func (p *PostgresProvisioner) provisionAllServices(ctx context.Context, status *ProvisioningStatus, schemaName string) error {
+	for i, svc := range p.config.Services {
+		if ctx.Err() != nil {
+			p.markProvisioningFailed(ctx, status, fmt.Sprintf("timeout during %s migrations", svc.Name))
+			return ErrProvisioningTimeout
+		}
+
+		// Update service status to created
+		status.Services[i].State = ServiceStateCreated
+		status.UpdatedAt = time.Now()
+		_ = p.saveProvisioningStatus(ctx, status)
+
+		// Apply migrations
+		version, err := p.applyServiceMigrations(ctx, schemaName, svc)
+		if err != nil {
+			status.Services[i].State = ServiceStateFailed
+			status.Services[i].ErrorMessage = err.Error()
+			p.markProvisioningFailed(ctx, status, fmt.Sprintf("%s migrations failed: %v", svc.Name, err))
+			return fmt.Errorf("%w: %s: %w", ErrMigrationFailed, svc.Name, err)
+		}
+
+		status.Services[i].State = ServiceStateMigrated
+		status.Services[i].MigrationVersion = version
+		status.UpdatedAt = time.Now()
+		_ = p.saveProvisioningStatus(ctx, status)
+	}
+	return nil
+}
+
+// markProvisioningFailed updates status to failed state with error message.
+func (p *PostgresProvisioner) markProvisioningFailed(ctx context.Context, status *ProvisioningStatus, errorMsg string) {
+	status.State = StateFailed
+	status.ErrorMessage = errorMsg
+	status.UpdatedAt = time.Now()
+	_ = p.saveProvisioningStatus(ctx, status) // Best effort save
+}
+
+// DeprovisionSchemas marks the tenant schemas as deprovisioned (soft delete).
+// The actual schema data remains in the database until explicitly purged.
+func (p *PostgresProvisioner) DeprovisionSchemas(ctx context.Context, tenantID organization.OrganizationID) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	status, err := p.getProvisioningStatusLocked(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+
+	// Idempotent: already deprovisioned
+	if status.State == StateDeprovisioned {
+		return nil
+	}
+
+	// Mark as deprovisioned
+	now := time.Now()
+	status.State = StateDeprovisioned
+	status.DeprovisionedAt = &now
+	status.UpdatedAt = now
+
+	if err := p.saveProvisioningStatus(ctx, status); err != nil {
+		return fmt.Errorf("%w: %w", ErrDeprovisioningFailed, err)
+	}
+
+	return nil
+}
+
+// PurgeSchemas permanently drops the org_{tenant_id} schema and all data.
+// This is a DESTRUCTIVE operation that cannot be undone.
+//
+// Prerequisites:
+//   - Tenant must be in 'deprovisioned' state
+//   - Data retention period must have elapsed
+func (p *PostgresProvisioner) PurgeSchemas(ctx context.Context, tenantID organization.OrganizationID) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	status, err := p.getProvisioningStatusLocked(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+
+	// Must be deprovisioned first
+	if status.State != StateDeprovisioned {
+		return ErrNotDeprovisioned
+	}
+
+	// Check retention period
+	if status.DeprovisionedAt != nil && p.config.DataRetentionPeriod > 0 {
+		retentionEnd := status.DeprovisionedAt.Add(p.config.DataRetentionPeriod)
+		if time.Now().Before(retentionEnd) {
+			return ErrRetentionPeriodNotElapsed
+		}
+	}
+
+	// Drop the schema
+	schemaName := tenantID.SchemaName()
+	if err := p.dropSchema(ctx, schemaName); err != nil {
+		return fmt.Errorf("%w: %w", ErrDeprovisioningFailed, err)
+	}
+
+	// Remove the provisioning record
+	if err := p.deleteProvisioningStatus(ctx, tenantID); err != nil {
+		return fmt.Errorf("delete provisioning status: %w", err)
+	}
+
+	return nil
+}
+
+// GetProvisioningStatus retrieves the current provisioning state for a tenant.
+func (p *PostgresProvisioner) GetProvisioningStatus(ctx context.Context, tenantID organization.OrganizationID) (*ProvisioningStatus, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.getProvisioningStatusLocked(ctx, tenantID)
+}
+
+// createSchema creates the org_{tenant_id} schema if it doesn't exist.
+func (p *PostgresProvisioner) createSchema(ctx context.Context, schemaName string) error {
+	// Use quote_ident for proper escaping
+	query := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quoteIdentifier(schemaName))
+	return p.db.WithContext(ctx).Exec(query).Error
+}
+
+// dropSchema drops the org_{tenant_id} schema and all its contents.
+func (p *PostgresProvisioner) dropSchema(ctx context.Context, schemaName string) error {
+	query := fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", quoteIdentifier(schemaName))
+	return p.db.WithContext(ctx).Exec(query).Error
+}
+
+// applyServiceMigrations applies all migration files for a service to the tenant schema.
+// Returns the version string of the last applied migration.
+func (p *PostgresProvisioner) applyServiceMigrations(ctx context.Context, schemaName string, svc ServiceConfig) (string, error) {
+	// Read migration files
+	migrations, err := p.readMigrationFiles(svc.MigrationPath)
+	if err != nil {
+		return "", fmt.Errorf("read migrations: %w", err)
+	}
+
+	if len(migrations) == 0 {
+		return "", nil
+	}
+
+	// Set search_path to the tenant schema for unqualified table names
+	setPathQuery := fmt.Sprintf("SET search_path TO %s, public", quoteIdentifier(schemaName))
+
+	var lastVersion string
+	for _, mig := range migrations {
+		// Check context cancellation
+		if ctx.Err() != nil {
+			return lastVersion, ctx.Err()
+		}
+
+		// Execute migration within a transaction
+		err := p.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			// Set search_path
+			if err := tx.Exec(setPathQuery).Error; err != nil {
+				return fmt.Errorf("set search_path: %w", err)
+			}
+
+			// Process the migration content to remove schema prefixes
+			processedSQL := p.processMigrationSQL(mig.Content, schemaName)
+
+			// Execute migration
+			if err := tx.Exec(processedSQL).Error; err != nil {
+				return fmt.Errorf("execute migration %s: %w", mig.Filename, err)
+			}
+
+			return nil
+		})
+		if err != nil {
+			// Check if error is due to existing objects (idempotency)
+			if isAlreadyExistsError(err) {
+				lastVersion = mig.Version
+				continue
+			}
+			return lastVersion, err
+		}
+
+		lastVersion = mig.Version
+	}
+
+	return lastVersion, nil
+}
+
+// migration represents a single migration file.
+type migration struct {
+	Filename string
+	Version  string
+	Content  string
+}
+
+// readMigrationFiles reads all .sql files from the migration path, sorted by filename.
+func (p *PostgresProvisioner) readMigrationFiles(migrationPath string) ([]migration, error) {
+	entries, err := os.ReadDir(migrationPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil // No migrations directory is valid
+		}
+		return nil, fmt.Errorf("read directory: %w", err)
+	}
+
+	migrations := make([]migration, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sql") {
+			continue
+		}
+
+		content, err := os.ReadFile(filepath.Join(migrationPath, entry.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("read file %s: %w", entry.Name(), err)
+		}
+
+		// Extract version from filename (e.g., "20251208211142_initial.sql" -> "20251208211142")
+		version := strings.TrimSuffix(entry.Name(), ".sql")
+		if idx := strings.Index(version, "_"); idx > 0 {
+			version = version[:idx]
+		}
+
+		migrations = append(migrations, migration{
+			Filename: entry.Name(),
+			Version:  version,
+			Content:  string(content),
+		})
+	}
+
+	// Sort by filename to ensure consistent order
+	sort.Slice(migrations, func(i, j int) bool {
+		return migrations[i].Filename < migrations[j].Filename
+	})
+
+	return migrations, nil
+}
+
+// processMigrationSQL processes migration SQL to work with dynamic schema names.
+// It handles both unqualified table names and hardcoded schema references.
+func (p *PostgresProvisioner) processMigrationSQL(sql, schemaName string) string {
+	// Remove CREATE SCHEMA statements - we already created the schema
+	lines := strings.Split(sql, "\n")
+	filteredLines := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(strings.ToUpper(line))
+		if strings.HasPrefix(trimmed, "CREATE SCHEMA") {
+			continue
+		}
+		filteredLines = append(filteredLines, line)
+	}
+	sql = strings.Join(filteredLines, "\n")
+
+	// Replace hardcoded schema references with the tenant schema
+	// Common patterns in the codebase: "current_account"."table", "party"."table", etc.
+	schemaPatterns := []string{
+		"current_account",
+		"party",
+		"position_keeping",
+		"financial_accounting",
+		"payment_order",
+	}
+
+	for _, pattern := range schemaPatterns {
+		// Replace "schema"."table" with "tenant_schema"."table"
+		sql = strings.ReplaceAll(sql, `"`+pattern+`".`, `"`+schemaName+`".`)
+		// Also handle unquoted references
+		sql = strings.ReplaceAll(sql, pattern+".", schemaName+".")
+	}
+
+	return sql
+}
+
+// createInitialServiceStatuses creates the initial service status list.
+func (p *PostgresProvisioner) createInitialServiceStatuses(tenantID organization.OrganizationID) []ServiceSchemaStatus {
+	statuses := make([]ServiceSchemaStatus, len(p.config.Services))
+	schemaName := tenantID.SchemaName()
+
+	for i, svc := range p.config.Services {
+		statuses[i] = ServiceSchemaStatus{
+			ServiceName: svc.Name,
+			SchemaName:  schemaName,
+			State:       ServiceStatePending,
+		}
+	}
+
+	return statuses
+}
+
+// Database entity for tenant_provisioning table.
+type provisioningEntity struct {
+	TenantID        string     `gorm:"column:tenant_id;primaryKey"`
+	State           string     `gorm:"column:state"`
+	ServiceSchemas  string     `gorm:"column:service_schemas;type:jsonb"`
+	ErrorMessage    *string    `gorm:"column:error_message"`
+	CreatedAt       time.Time  `gorm:"column:created_at"`
+	UpdatedAt       time.Time  `gorm:"column:updated_at"`
+	DeprovisionedAt *time.Time `gorm:"column:deprovisioned_at"`
+	Version         int        `gorm:"column:version"`
+}
+
+func (provisioningEntity) TableName() string {
+	return "platform.tenant_provisioning"
+}
+
+// getProvisioningStatusLocked retrieves the status without acquiring the mutex.
+// Caller must hold the mutex.
+func (p *PostgresProvisioner) getProvisioningStatusLocked(ctx context.Context, tenantID organization.OrganizationID) (*ProvisioningStatus, error) {
+	var entity provisioningEntity
+	result := p.db.WithContext(ctx).Where("tenant_id = ?", tenantID.String()).First(&entity)
+
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, ErrProvisioningStatusNotFound
+	}
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return p.entityToStatus(tenantID, &entity)
+}
+
+// saveProvisioningStatus saves or updates the provisioning status using upsert.
+func (p *PostgresProvisioner) saveProvisioningStatus(ctx context.Context, status *ProvisioningStatus) error {
+	entity, err := p.statusToEntity(status)
+	if err != nil {
+		return err
+	}
+
+	// Use PostgreSQL UPSERT (ON CONFLICT DO UPDATE)
+	// This is atomic and handles both insert and update cases
+	upsertSQL := `
+		INSERT INTO platform.tenant_provisioning
+			(tenant_id, state, service_schemas, error_message, created_at, updated_at, deprovisioned_at, version)
+		VALUES
+			(?, ?, ?, ?, ?, ?, ?, 1)
+		ON CONFLICT (tenant_id) DO UPDATE SET
+			state = EXCLUDED.state,
+			service_schemas = EXCLUDED.service_schemas,
+			error_message = EXCLUDED.error_message,
+			updated_at = EXCLUDED.updated_at,
+			deprovisioned_at = EXCLUDED.deprovisioned_at,
+			version = platform.tenant_provisioning.version + 1
+	`
+
+	return p.db.WithContext(ctx).Exec(
+		upsertSQL,
+		entity.TenantID,
+		entity.State,
+		entity.ServiceSchemas,
+		entity.ErrorMessage,
+		entity.CreatedAt,
+		entity.UpdatedAt,
+		entity.DeprovisionedAt,
+	).Error
+}
+
+// deleteProvisioningStatus removes the provisioning status record.
+func (p *PostgresProvisioner) deleteProvisioningStatus(ctx context.Context, tenantID organization.OrganizationID) error {
+	return p.db.WithContext(ctx).
+		Where("tenant_id = ?", tenantID.String()).
+		Delete(&provisioningEntity{}).Error
+}
+
+// entityToStatus converts database entity to domain model.
+func (p *PostgresProvisioner) entityToStatus(tenantID organization.OrganizationID, entity *provisioningEntity) (*ProvisioningStatus, error) {
+	var services []ServiceSchemaStatus
+	if entity.ServiceSchemas != "" && entity.ServiceSchemas != "[]" {
+		if err := json.Unmarshal([]byte(entity.ServiceSchemas), &services); err != nil {
+			return nil, fmt.Errorf("unmarshal service_schemas: %w", err)
+		}
+	}
+
+	status := &ProvisioningStatus{
+		TenantID:        tenantID,
+		State:           ProvisioningState(entity.State),
+		Services:        services,
+		CreatedAt:       entity.CreatedAt,
+		UpdatedAt:       entity.UpdatedAt,
+		DeprovisionedAt: entity.DeprovisionedAt,
+	}
+
+	if entity.ErrorMessage != nil {
+		status.ErrorMessage = *entity.ErrorMessage
+	}
+
+	return status, nil
+}
+
+// statusToEntity converts domain model to database entity.
+func (p *PostgresProvisioner) statusToEntity(status *ProvisioningStatus) (*provisioningEntity, error) {
+	servicesJSON, err := json.Marshal(status.Services)
+	if err != nil {
+		return nil, fmt.Errorf("marshal services: %w", err)
+	}
+
+	entity := &provisioningEntity{
+		TenantID:        status.TenantID.String(),
+		State:           string(status.State),
+		ServiceSchemas:  string(servicesJSON),
+		CreatedAt:       status.CreatedAt,
+		UpdatedAt:       status.UpdatedAt,
+		DeprovisionedAt: status.DeprovisionedAt,
+		Version:         1, // Will be incremented during update
+	}
+
+	if status.ErrorMessage != "" {
+		entity.ErrorMessage = &status.ErrorMessage
+	}
+
+	return entity, nil
+}
+
+// quoteIdentifier safely quotes a PostgreSQL identifier to prevent SQL injection.
+// Uses double quotes and escapes any embedded double quotes.
+func quoteIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
+}
+
+// isAlreadyExistsError checks if the error indicates an object already exists.
+// This is used for idempotency - if a table/index already exists, we skip it.
+func isAlreadyExistsError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Check for PostgreSQL-specific error codes
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		// 42P07: duplicate_table
+		// 42P06: duplicate_schema
+		// 42710: duplicate_object (for indexes)
+		switch pgErr.Code {
+		case "42P07", "42P06", "42710":
+			return true
+		}
+	}
+
+	// Fallback to string matching
+	errStr := strings.ToLower(err.Error())
+	return strings.Contains(errStr, "already exists") ||
+		strings.Contains(errStr, "duplicate")
+}
+
+// Ensure PostgresProvisioner implements SchemaProvisioner.
+var _ SchemaProvisioner = (*PostgresProvisioner)(nil)

--- a/services/tenant/provisioner/postgres_provisioner.go
+++ b/services/tenant/provisioner/postgres_provisioner.go
@@ -88,6 +88,13 @@ func (p *PostgresProvisioner) ProvisionSchemas(ctx context.Context, tenantID org
 		defer cancel()
 	}
 
+	// Check context before expensive operations
+	if ctx.Err() != nil {
+		logger.Warn("context cancelled before schema creation")
+		p.markProvisioningFailed(ctx, status, "cancelled before schema creation")
+		return ErrProvisioningTimeout
+	}
+
 	// Create the schema
 	schemaName := tenantID.SchemaName()
 	if err := p.createSchema(ctx, schemaName); err != nil {
@@ -178,7 +185,9 @@ func (p *PostgresProvisioner) provisionAllServices(ctx context.Context, status *
 		// Update service status to created
 		status.Services[i].State = ServiceStateCreated
 		status.UpdatedAt = time.Now()
-		_ = p.saveProvisioningStatus(ctx, status)
+		if err := p.saveProvisioningStatus(ctx, status); err != nil {
+			logger.Warn("failed to save intermediate status", "error", err, "service", svc.Name)
+		}
 
 		// Apply migrations
 		version, err := p.applyServiceMigrations(ctx, schemaName, svc)
@@ -194,7 +203,9 @@ func (p *PostgresProvisioner) provisionAllServices(ctx context.Context, status *
 		status.Services[i].State = ServiceStateMigrated
 		status.Services[i].MigrationVersion = version
 		status.UpdatedAt = time.Now()
-		_ = p.saveProvisioningStatus(ctx, status)
+		if err := p.saveProvisioningStatus(ctx, status); err != nil {
+			logger.Warn("failed to save migration status", "error", err, "service", svc.Name)
+		}
 	}
 	return nil
 }
@@ -204,7 +215,11 @@ func (p *PostgresProvisioner) markProvisioningFailed(ctx context.Context, status
 	status.State = StateFailed
 	status.ErrorMessage = errorMsg
 	status.UpdatedAt = time.Now()
-	_ = p.saveProvisioningStatus(ctx, status) // Best effort save
+	if err := p.saveProvisioningStatus(ctx, status); err != nil {
+		p.logger.Warn("failed to save failed status",
+			"tenant_id", status.TenantID.String(),
+			"error", err)
+	}
 }
 
 // DeprovisionSchemas marks the tenant schemas as deprovisioned (soft delete).

--- a/services/tenant/provisioner/postgres_provisioner.go
+++ b/services/tenant/provisioner/postgres_provisioner.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -29,6 +30,7 @@ var errAlreadyProvisioned = errors.New("already provisioned")
 type PostgresProvisioner struct {
 	db     *gorm.DB
 	config *Config
+	logger *slog.Logger
 
 	// mu protects concurrent access to provisioning operations for the same tenant.
 	// This prevents race conditions when multiple goroutines attempt to provision
@@ -37,12 +39,17 @@ type PostgresProvisioner struct {
 }
 
 // NewPostgresProvisioner creates a new PostgreSQL schema provisioner.
-// The config must be validated before calling this function.
-func NewPostgresProvisioner(db *gorm.DB, config *Config) *PostgresProvisioner {
+// Returns an error if the config is invalid.
+func NewPostgresProvisioner(db *gorm.DB, config *Config) (*PostgresProvisioner, error) {
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
 	return &PostgresProvisioner{
 		db:     db,
 		config: config,
-	}
+		logger: slog.Default().With("component", "provisioner"),
+	}, nil
 }
 
 // ProvisionSchemas creates the org_{tenant_id} schema and applies all service migrations.
@@ -59,12 +66,18 @@ func (p *PostgresProvisioner) ProvisionSchemas(ctx context.Context, tenantID org
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	startTime := time.Now()
+	logger := p.logger.With("tenant_id", tenantID.String(), "schema", tenantID.SchemaName())
+	logger.Info("starting schema provisioning")
+
 	// Validate and prepare provisioning status
 	status, err := p.prepareProvisioningStatus(ctx, tenantID)
 	if errors.Is(err, errAlreadyProvisioned) {
+		logger.Info("schema already provisioned, skipping")
 		return nil // Idempotent: already provisioned
 	}
 	if err != nil {
+		logger.Error("failed to prepare provisioning status", "error", err)
 		return err
 	}
 
@@ -78,12 +91,15 @@ func (p *PostgresProvisioner) ProvisionSchemas(ctx context.Context, tenantID org
 	// Create the schema
 	schemaName := tenantID.SchemaName()
 	if err := p.createSchema(ctx, schemaName); err != nil {
+		logger.Error("failed to create schema", "error", err)
 		p.markProvisioningFailed(ctx, status, fmt.Sprintf("create schema: %v", err))
 		return fmt.Errorf("%w: %w", ErrSchemaCreationFailed, err)
 	}
+	logger.Debug("schema created successfully")
 
 	// Apply migrations for each service
 	if err := p.provisionAllServices(ctx, status, schemaName); err != nil {
+		logger.Error("failed to provision services", "error", err)
 		return err
 	}
 
@@ -91,9 +107,13 @@ func (p *PostgresProvisioner) ProvisionSchemas(ctx context.Context, tenantID org
 	status.State = StateActive
 	status.UpdatedAt = time.Now()
 	if err := p.saveProvisioningStatus(ctx, status); err != nil {
+		logger.Error("failed to save final status", "error", err)
 		return fmt.Errorf("save final status: %w", err)
 	}
 
+	logger.Info("schema provisioning completed",
+		"duration_ms", time.Since(startTime).Milliseconds(),
+		"services_count", len(p.config.Services))
 	return nil
 }
 
@@ -144,11 +164,16 @@ func (p *PostgresProvisioner) prepareProvisioningStatus(ctx context.Context, ten
 
 // provisionAllServices applies migrations for each configured service.
 func (p *PostgresProvisioner) provisionAllServices(ctx context.Context, status *ProvisioningStatus, schemaName string) error {
+	logger := p.logger.With("tenant_id", status.TenantID.String(), "schema", schemaName)
+
 	for i, svc := range p.config.Services {
 		if ctx.Err() != nil {
+			logger.Warn("provisioning timeout", "service", svc.Name)
 			p.markProvisioningFailed(ctx, status, fmt.Sprintf("timeout during %s migrations", svc.Name))
 			return ErrProvisioningTimeout
 		}
+
+		logger.Debug("provisioning service", "service", svc.Name, "migration_path", svc.MigrationPath)
 
 		// Update service status to created
 		status.Services[i].State = ServiceStateCreated
@@ -158,12 +183,14 @@ func (p *PostgresProvisioner) provisionAllServices(ctx context.Context, status *
 		// Apply migrations
 		version, err := p.applyServiceMigrations(ctx, schemaName, svc)
 		if err != nil {
+			logger.Error("service migration failed", "service", svc.Name, "error", err)
 			status.Services[i].State = ServiceStateFailed
 			status.Services[i].ErrorMessage = err.Error()
 			p.markProvisioningFailed(ctx, status, fmt.Sprintf("%s migrations failed: %v", svc.Name, err))
 			return fmt.Errorf("%w: %s: %w", ErrMigrationFailed, svc.Name, err)
 		}
 
+		logger.Debug("service migration completed", "service", svc.Name, "version", version)
 		status.Services[i].State = ServiceStateMigrated
 		status.Services[i].MigrationVersion = version
 		status.UpdatedAt = time.Now()
@@ -186,13 +213,18 @@ func (p *PostgresProvisioner) DeprovisionSchemas(ctx context.Context, tenantID o
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	logger := p.logger.With("tenant_id", tenantID.String(), "schema", tenantID.SchemaName())
+	logger.Info("starting schema deprovisioning")
+
 	status, err := p.getProvisioningStatusLocked(ctx, tenantID)
 	if err != nil {
+		logger.Error("failed to get provisioning status", "error", err)
 		return err
 	}
 
 	// Idempotent: already deprovisioned
 	if status.State == StateDeprovisioned {
+		logger.Info("schema already deprovisioned, skipping")
 		return nil
 	}
 
@@ -203,9 +235,11 @@ func (p *PostgresProvisioner) DeprovisionSchemas(ctx context.Context, tenantID o
 	status.UpdatedAt = now
 
 	if err := p.saveProvisioningStatus(ctx, status); err != nil {
+		logger.Error("failed to save deprovisioned status", "error", err)
 		return fmt.Errorf("%w: %w", ErrDeprovisioningFailed, err)
 	}
 
+	logger.Info("schema deprovisioning completed")
 	return nil
 }
 
@@ -219,13 +253,18 @@ func (p *PostgresProvisioner) PurgeSchemas(ctx context.Context, tenantID organiz
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
+	logger := p.logger.With("tenant_id", tenantID.String(), "schema", tenantID.SchemaName())
+	logger.Info("starting schema purge")
+
 	status, err := p.getProvisioningStatusLocked(ctx, tenantID)
 	if err != nil {
+		logger.Error("failed to get provisioning status", "error", err)
 		return err
 	}
 
 	// Must be deprovisioned first
 	if status.State != StateDeprovisioned {
+		logger.Warn("cannot purge: tenant not deprovisioned", "current_state", status.State)
 		return ErrNotDeprovisioned
 	}
 
@@ -233,6 +272,9 @@ func (p *PostgresProvisioner) PurgeSchemas(ctx context.Context, tenantID organiz
 	if status.DeprovisionedAt != nil && p.config.DataRetentionPeriod > 0 {
 		retentionEnd := status.DeprovisionedAt.Add(p.config.DataRetentionPeriod)
 		if time.Now().Before(retentionEnd) {
+			logger.Warn("cannot purge: retention period not elapsed",
+				"deprovisioned_at", status.DeprovisionedAt,
+				"retention_ends", retentionEnd)
 			return ErrRetentionPeriodNotElapsed
 		}
 	}
@@ -240,14 +282,18 @@ func (p *PostgresProvisioner) PurgeSchemas(ctx context.Context, tenantID organiz
 	// Drop the schema
 	schemaName := tenantID.SchemaName()
 	if err := p.dropSchema(ctx, schemaName); err != nil {
+		logger.Error("failed to drop schema", "error", err)
 		return fmt.Errorf("%w: %w", ErrDeprovisioningFailed, err)
 	}
+	logger.Debug("schema dropped successfully")
 
 	// Remove the provisioning record
 	if err := p.deleteProvisioningStatus(ctx, tenantID); err != nil {
+		logger.Error("failed to delete provisioning status", "error", err)
 		return fmt.Errorf("delete provisioning status: %w", err)
 	}
 
+	logger.Info("schema purge completed")
 	return nil
 }
 

--- a/services/tenant/provisioner/postgres_provisioner.go
+++ b/services/tenant/provisioner/postgres_provisioner.go
@@ -211,11 +211,22 @@ func (p *PostgresProvisioner) provisionAllServices(ctx context.Context, status *
 }
 
 // markProvisioningFailed updates status to failed state with error message.
-func (p *PostgresProvisioner) markProvisioningFailed(ctx context.Context, status *ProvisioningStatus, errorMsg string) {
+// Uses a fresh context for the save operation since the original context may be
+// cancelled (e.g., due to timeout), and we still want to record the failure.
+func (p *PostgresProvisioner) markProvisioningFailed(_ context.Context, status *ProvisioningStatus, errorMsg string) {
 	status.State = StateFailed
 	status.ErrorMessage = errorMsg
 	status.UpdatedAt = time.Now()
-	if err := p.saveProvisioningStatus(ctx, status); err != nil {
+
+	// Use a fresh context with timeout for cleanup, since the original may be cancelled.
+	// This is intentional - we want to save the failed status even if the parent context
+	// was cancelled due to timeout, so we use context.Background() as the base.
+	//nolint:contextcheck // Intentionally using Background() for cleanup after timeout
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	//nolint:contextcheck // cleanupCtx intentionally derived from Background() for cleanup after timeout
+	if err := p.saveProvisioningStatus(cleanupCtx, status); err != nil {
 		p.logger.Warn("failed to save failed status",
 			"tenant_id", status.TenantID.String(),
 			"error", err)
@@ -438,6 +449,13 @@ func (p *PostgresProvisioner) readMigrationFiles(migrationPath string) ([]migrat
 
 // processMigrationSQL processes migration SQL to work with dynamic schema names.
 // It handles both unqualified table names and hardcoded schema references.
+//
+// Security: The schemaName parameter is derived from OrganizationID.SchemaName(),
+// which is validated at construction to contain only alphanumeric characters and
+// underscores (regex: ^[a-zA-Z0-9_]{1,50}$). The "org_" prefix is added and the
+// string is lowercased, making SQL injection impossible through this path.
+// The string replacement is safe because the schema name cannot contain quotes,
+// semicolons, or other SQL control characters.
 func (p *PostgresProvisioner) processMigrationSQL(sql, schemaName string) string {
 	// Remove CREATE SCHEMA statements - we already created the schema
 	lines := strings.Split(sql, "\n")

--- a/services/tenant/provisioner/postgres_provisioner_test.go
+++ b/services/tenant/provisioner/postgres_provisioner_test.go
@@ -1,0 +1,755 @@
+package provisioner
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/organization"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	gormPG "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// testContainer holds the PostgreSQL container and database connection for tests.
+type testContainer struct {
+	container *postgres.PostgresContainer
+	db        *gorm.DB
+	migDir    string // Temporary directory for test migrations
+}
+
+// setupTestContainer creates a PostgreSQL container with the platform schema.
+func setupTestContainer(t *testing.T) *testContainer {
+	t.Helper()
+
+	ctx := context.Background()
+
+	// Create PostgreSQL container
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("test_tenant"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForAll(
+				wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+				wait.ForListeningPort("5432/tcp"),
+			).WithDeadline(30*time.Second)),
+	)
+	require.NoError(t, err, "Failed to start PostgreSQL container")
+
+	// Get connection string
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err, "Failed to get connection string")
+
+	// Create GORM connection
+	db, err := gorm.Open(gormPG.Open(connStr), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err, "Failed to create GORM connection")
+
+	// Create platform schema and tenant_provisioning table
+	setupPlatformSchema(t, db)
+
+	// Create temporary directory for test migrations
+	migDir, err := os.MkdirTemp("", "test_migrations_*")
+	require.NoError(t, err, "Failed to create temp directory")
+
+	return &testContainer{
+		container: pgContainer,
+		db:        db,
+		migDir:    migDir,
+	}
+}
+
+// cleanup terminates the container and cleans up resources.
+func (tc *testContainer) cleanup(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Remove temp directory
+	if tc.migDir != "" {
+		os.RemoveAll(tc.migDir)
+	}
+
+	// Close DB connection
+	if tc.db != nil {
+		sqlDB, _ := tc.db.DB()
+		if sqlDB != nil {
+			sqlDB.Close()
+		}
+	}
+
+	// Terminate container
+	if tc.container != nil {
+		require.NoError(t, tc.container.Terminate(ctx), "Failed to terminate container")
+	}
+}
+
+// setupPlatformSchema creates the platform schema and required tables.
+func setupPlatformSchema(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	// Create platform schema
+	err := db.Exec("CREATE SCHEMA IF NOT EXISTS platform").Error
+	require.NoError(t, err)
+
+	// Create tenants table (simplified for tests)
+	err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS platform.tenants (
+			id VARCHAR(50) PRIMARY KEY,
+			display_name VARCHAR(255) NOT NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'active',
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`).Error
+	require.NoError(t, err)
+
+	// Create tenant_provisioning table
+	err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS platform.tenant_provisioning (
+			tenant_id VARCHAR(50) PRIMARY KEY REFERENCES platform.tenants(id) ON DELETE RESTRICT,
+			state VARCHAR(20) NOT NULL DEFAULT 'pending',
+			service_schemas JSONB NOT NULL DEFAULT '[]',
+			error_message TEXT,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			deprovisioned_at TIMESTAMPTZ,
+			version INTEGER NOT NULL DEFAULT 1,
+			CONSTRAINT valid_provisioning_state CHECK (state IN ('pending', 'in_progress', 'active', 'failed', 'deprovisioned'))
+		)
+	`).Error
+	require.NoError(t, err)
+}
+
+// createTestTenant creates a tenant record for testing.
+func createTestTenant(t *testing.T, db *gorm.DB, tenantID string) {
+	t.Helper()
+	err := db.Exec(
+		"INSERT INTO platform.tenants (id, display_name) VALUES (?, ?)",
+		tenantID, "Test Tenant "+tenantID,
+	).Error
+	require.NoError(t, err)
+}
+
+// createTestMigration creates a migration file in the temp directory.
+func createTestMigration(t *testing.T, dir, filename, content string) {
+	t.Helper()
+	path := filepath.Join(dir, filename)
+	err := os.WriteFile(path, []byte(content), 0o644)
+	require.NoError(t, err)
+}
+
+func TestPostgresProvisioner_ProvisionSchemas(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	// Create test tenant
+	tenantID := organization.MustNewOrganizationID("acme_corp")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	// Create test migrations
+	svcDir := filepath.Join(tc.migDir, "test-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+	createTestMigration(t, svcDir, "20251201000000_initial.sql", `
+		CREATE TABLE test_table (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			name VARCHAR(100) NOT NULL
+		);
+		CREATE INDEX idx_test_table_name ON test_table(name);
+	`)
+
+	config := &Config{
+		Services: []ServiceConfig{
+			{Name: "test-service", MigrationPath: svcDir},
+		},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	// Provision schemas
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Verify schema was created
+	var schemaExists bool
+	tc.db.Raw("SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name = ?)", tenantID.SchemaName()).Scan(&schemaExists)
+	assert.True(t, schemaExists, "Schema should exist")
+
+	// Verify table was created in tenant schema
+	var tableExists bool
+	tc.db.Raw(`
+		SELECT EXISTS(
+			SELECT 1 FROM information_schema.tables
+			WHERE table_schema = ? AND table_name = 'test_table'
+		)
+	`, tenantID.SchemaName()).Scan(&tableExists)
+	assert.True(t, tableExists, "Table should exist in tenant schema")
+
+	// Verify provisioning status
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateActive, status.State)
+	assert.Len(t, status.Services, 1)
+	assert.Equal(t, ServiceStateMigrated, status.Services[0].State)
+	assert.Equal(t, "20251201000000", status.Services[0].MigrationVersion)
+}
+
+func TestPostgresProvisioner_ProvisionSchemas_Idempotent(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("beta_inc")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "simple-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+	createTestMigration(t, svcDir, "20251201000000_tables.sql", `
+		CREATE TABLE items (id UUID PRIMARY KEY DEFAULT gen_random_uuid());
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "simple-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	// Provision twice
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err, "Second call should succeed (idempotent)")
+
+	// Status should still be active
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateActive, status.State)
+}
+
+func TestPostgresProvisioner_ProvisionSchemas_MultipleServices(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("gamma_ltd")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	// Create migrations for two services
+	partyDir := filepath.Join(tc.migDir, "party")
+	require.NoError(t, os.MkdirAll(partyDir, 0o755))
+	createTestMigration(t, partyDir, "20251201000000_initial.sql", `
+		CREATE TABLE parties (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			name VARCHAR(255) NOT NULL
+		);
+	`)
+
+	accountDir := filepath.Join(tc.migDir, "current-account")
+	require.NoError(t, os.MkdirAll(accountDir, 0o755))
+	createTestMigration(t, accountDir, "20251201000000_initial.sql", `
+		CREATE TABLE accounts (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			account_number VARCHAR(34) NOT NULL
+		);
+	`)
+
+	config := &Config{
+		Services: []ServiceConfig{
+			{Name: "party", MigrationPath: partyDir},
+			{Name: "current-account", MigrationPath: accountDir},
+		},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Verify both tables exist
+	var partiesExists, accountsExists bool
+	tc.db.Raw(`SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = 'parties')`, tenantID.SchemaName()).Scan(&partiesExists)
+	tc.db.Raw(`SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = 'accounts')`, tenantID.SchemaName()).Scan(&accountsExists)
+
+	assert.True(t, partiesExists, "parties table should exist")
+	assert.True(t, accountsExists, "accounts table should exist")
+
+	// Verify status shows both services
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Len(t, status.Services, 2)
+	for _, svc := range status.Services {
+		assert.Equal(t, ServiceStateMigrated, svc.State)
+	}
+}
+
+func TestPostgresProvisioner_ProvisionSchemas_MigrationFailure(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("failing_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "bad-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+	createTestMigration(t, svcDir, "20251201000000_broken.sql", `
+		CREATE TABLE good_table (id UUID PRIMARY KEY);
+		INVALID SQL SYNTAX HERE;
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "bad-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrMigrationFailed)
+
+	// Status should be failed
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateFailed, status.State)
+	assert.NotEmpty(t, status.ErrorMessage)
+}
+
+func TestPostgresProvisioner_ProvisionSchemas_ConcurrentBlocked(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("concurrent_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	// Pre-create an in_progress status to simulate concurrent provisioning
+	tc.db.Exec(`
+		INSERT INTO platform.tenant_provisioning (tenant_id, state, service_schemas)
+		VALUES (?, 'in_progress', '[]')
+	`, tenantID.String())
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "test", MigrationPath: tc.migDir}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrProvisioningInProgress)
+}
+
+func TestPostgresProvisioner_DeprovisionSchemas(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("deprov_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "deprov-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+	createTestMigration(t, svcDir, "20251201000000_init.sql", `
+		CREATE TABLE data (id UUID PRIMARY KEY DEFAULT gen_random_uuid());
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "deprov-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	// Provision first
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Deprovision
+	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Verify status is deprovisioned (soft delete)
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateDeprovisioned, status.State)
+	assert.NotNil(t, status.DeprovisionedAt)
+
+	// Schema should still exist (soft delete)
+	var schemaExists bool
+	tc.db.Raw("SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name = ?)", tenantID.SchemaName()).Scan(&schemaExists)
+	assert.True(t, schemaExists, "Schema should still exist after soft delete")
+}
+
+func TestPostgresProvisioner_DeprovisionSchemas_Idempotent(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("idem_deprov")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "idem-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "idem-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	// Provision and deprovision
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Second deprovision should succeed (idempotent)
+	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateDeprovisioned, status.State)
+}
+
+func TestPostgresProvisioner_PurgeSchemas(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("purge_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "purge-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+	createTestMigration(t, svcDir, "20251201000000_init.sql", `
+		CREATE TABLE to_be_purged (id UUID PRIMARY KEY DEFAULT gen_random_uuid());
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "purge-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 30 * time.Second,
+		DataRetentionPeriod: 0, // No retention for test
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	// Provision
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Deprovision
+	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Purge
+	err = provisioner.PurgeSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Schema should be gone
+	var schemaExists bool
+	tc.db.Raw("SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name = ?)", tenantID.SchemaName()).Scan(&schemaExists)
+	assert.False(t, schemaExists, "Schema should be dropped after purge")
+
+	// Status record should be gone
+	_, err = provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrProvisioningStatusNotFound)
+}
+
+func TestPostgresProvisioner_PurgeSchemas_NotDeprovisioned(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("active_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "active-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "active-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	// Provision but don't deprovision
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Purge should fail
+	err = provisioner.PurgeSchemas(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrNotDeprovisioned)
+}
+
+func TestPostgresProvisioner_PurgeSchemas_RetentionNotElapsed(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("retained_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "retained-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "retained-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 30 * time.Second,
+		DataRetentionPeriod: 7 * 24 * time.Hour, // 7 days
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	// Provision and deprovision
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Purge should fail - retention period not elapsed
+	err = provisioner.PurgeSchemas(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrRetentionPeriodNotElapsed)
+}
+
+func TestPostgresProvisioner_GetProvisioningStatus_NotFound(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	config := &Config{
+		Services:            []ServiceConfig{},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	tenantID := organization.MustNewOrganizationID("unknown_tenant")
+	_, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrProvisioningStatusNotFound)
+}
+
+func TestPostgresProvisioner_ProvisionSchemas_Timeout(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("timeout_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	// Create a slow migration using pg_sleep
+	svcDir := filepath.Join(tc.migDir, "slow-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+	createTestMigration(t, svcDir, "20251201000000_slow.sql", `
+		SELECT pg_sleep(5);
+		CREATE TABLE never_created (id UUID PRIMARY KEY);
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "slow-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 100 * time.Millisecond, // Very short timeout
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	err := provisioner.ProvisionSchemas(ctx, tenantID)
+	assert.Error(t, err) // Should timeout or get context error
+}
+
+func TestPostgresProvisioner_ProvisionSchemas_NoMigrationDirectory(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("no_mig_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "missing-service", MigrationPath: "/nonexistent/path"}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	// Should succeed - missing migrations directory is valid (creates empty schema)
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Schema should still be created
+	var schemaExists bool
+	tc.db.Raw("SELECT EXISTS(SELECT 1 FROM information_schema.schemata WHERE schema_name = ?)", tenantID.SchemaName()).Scan(&schemaExists)
+	assert.True(t, schemaExists)
+}
+
+func TestPostgresProvisioner_ProvisionSchemas_MultipleMigrationFiles(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("multi_mig_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "multi-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+
+	// Create multiple migrations
+	createTestMigration(t, svcDir, "20251201000000_first.sql", `
+		CREATE TABLE first_table (id UUID PRIMARY KEY DEFAULT gen_random_uuid());
+	`)
+	createTestMigration(t, svcDir, "20251202000000_second.sql", `
+		CREATE TABLE second_table (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			first_id UUID REFERENCES first_table(id)
+		);
+	`)
+	createTestMigration(t, svcDir, "20251203000000_third.sql", `
+		ALTER TABLE second_table ADD COLUMN name VARCHAR(100);
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "multi-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Verify all migrations applied
+	var firstExists, secondExists bool
+	var hasNameColumn bool
+	tc.db.Raw(`SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = 'first_table')`, tenantID.SchemaName()).Scan(&firstExists)
+	tc.db.Raw(`SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = 'second_table')`, tenantID.SchemaName()).Scan(&secondExists)
+	tc.db.Raw(`SELECT EXISTS(SELECT 1 FROM information_schema.columns WHERE table_schema = ? AND table_name = 'second_table' AND column_name = 'name')`, tenantID.SchemaName()).Scan(&hasNameColumn)
+
+	assert.True(t, firstExists)
+	assert.True(t, secondExists)
+	assert.True(t, hasNameColumn)
+
+	// Verify version is the last migration
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, "20251203000000", status.Services[0].MigrationVersion)
+}
+
+func TestPostgresProvisioner_ProvisionSchemas_SchemaIsolation(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	// Create two tenants
+	tenant1 := organization.MustNewOrganizationID("tenant_1")
+	tenant2 := organization.MustNewOrganizationID("tenant_2")
+	createTestTenant(t, tc.db, tenant1.String())
+	createTestTenant(t, tc.db, tenant2.String())
+
+	svcDir := filepath.Join(tc.migDir, "isolated-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+	createTestMigration(t, svcDir, "20251201000000_init.sql", `
+		CREATE TABLE isolated_data (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			value TEXT NOT NULL
+		);
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "isolated-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	// Provision both tenants
+	err := provisioner.ProvisionSchemas(context.Background(), tenant1)
+	require.NoError(t, err)
+
+	err = provisioner.ProvisionSchemas(context.Background(), tenant2)
+	require.NoError(t, err)
+
+	// Insert data into tenant1's schema
+	tc.db.Exec(fmt.Sprintf(`INSERT INTO %s.isolated_data (value) VALUES ('tenant1_data')`, tenant1.SchemaName()))
+
+	// Insert different data into tenant2's schema
+	tc.db.Exec(fmt.Sprintf(`INSERT INTO %s.isolated_data (value) VALUES ('tenant2_data')`, tenant2.SchemaName()))
+
+	// Verify isolation - each tenant should only see their own data
+	var count1, count2 int64
+	tc.db.Raw(fmt.Sprintf(`SELECT COUNT(*) FROM %s.isolated_data WHERE value = 'tenant1_data'`, tenant1.SchemaName())).Scan(&count1)
+	tc.db.Raw(fmt.Sprintf(`SELECT COUNT(*) FROM %s.isolated_data WHERE value = 'tenant1_data'`, tenant2.SchemaName())).Scan(&count2)
+
+	assert.Equal(t, int64(1), count1, "tenant1 should have their data")
+	assert.Equal(t, int64(0), count2, "tenant2 should not see tenant1's data")
+}
+
+func TestPostgresProvisioner_RetryAfterFailure(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("retry_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "retry-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+
+	// First, create a broken migration
+	createTestMigration(t, svcDir, "20251201000000_broken.sql", `
+		CREATE TABLE retry_table (id UUID PRIMARY KEY);
+		INVALID SYNTAX;
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "retry-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner := NewPostgresProvisioner(tc.db, config)
+
+	// First attempt fails
+	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	assert.Error(t, err)
+
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateFailed, status.State)
+
+	// Fix the migration
+	createTestMigration(t, svcDir, "20251201000000_broken.sql", `
+		CREATE TABLE IF NOT EXISTS retry_table (id UUID PRIMARY KEY DEFAULT gen_random_uuid());
+	`)
+
+	// Retry should succeed
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	status, err = provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateActive, status.State)
+}
+
+func TestQuoteIdentifier(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"simple", `"simple"`},
+		{"with_underscore", `"with_underscore"`},
+		{"org_acme_bank", `"org_acme_bank"`},
+		{`with"quote`, `"with""quote"`},
+		{`multi"ple"quotes`, `"multi""ple""quotes"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := quoteIdentifier(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/services/tenant/provisioner/postgres_provisioner_test.go
+++ b/services/tenant/provisioner/postgres_provisioner_test.go
@@ -429,6 +429,41 @@ func TestPostgresProvisioner_DeprovisionSchemas_Idempotent(t *testing.T) {
 	assert.Equal(t, StateDeprovisioned, status.State)
 }
 
+func TestPostgresProvisioner_ProvisionSchemas_AfterDeprovisioned(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := organization.MustNewOrganizationID("reprov_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "reprov-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "reprov-service", MigrationPath: svcDir}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
+
+	// Provision and then deprovision
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Attempting to re-provision a deprovisioned tenant should fail
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
+	assert.ErrorIs(t, err, ErrAlreadyDeprovisioned)
+
+	// Status should remain deprovisioned
+	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, StateDeprovisioned, status.State)
+}
+
 func TestPostgresProvisioner_PurgeSchemas(t *testing.T) {
 	tc := setupTestContainer(t)
 	defer tc.cleanup(t)

--- a/services/tenant/provisioner/postgres_provisioner_test.go
+++ b/services/tenant/provisioner/postgres_provisioner_test.go
@@ -174,10 +174,11 @@ func TestPostgresProvisioner_ProvisionSchemas(t *testing.T) {
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
 	// Provision schemas
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
 	// Verify schema was created
@@ -222,10 +223,11 @@ func TestPostgresProvisioner_ProvisionSchemas_Idempotent(t *testing.T) {
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
 	// Provision twice
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
 	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
@@ -271,9 +273,10 @@ func TestPostgresProvisioner_ProvisionSchemas_MultipleServices(t *testing.T) {
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
 	// Verify both tables exist
@@ -312,9 +315,10 @@ func TestPostgresProvisioner_ProvisionSchemas_MigrationFailure(t *testing.T) {
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrMigrationFailed)
 
@@ -343,9 +347,10 @@ func TestPostgresProvisioner_ProvisionSchemas_ConcurrentBlocked(t *testing.T) {
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	assert.ErrorIs(t, err, ErrProvisioningInProgress)
 }
 
@@ -367,10 +372,11 @@ func TestPostgresProvisioner_DeprovisionSchemas(t *testing.T) {
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
 	// Provision first
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
 	// Deprovision
@@ -404,10 +410,11 @@ func TestPostgresProvisioner_DeprovisionSchemas_Idempotent(t *testing.T) {
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
 	// Provision and deprovision
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
 	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
@@ -441,10 +448,11 @@ func TestPostgresProvisioner_PurgeSchemas(t *testing.T) {
 		DataRetentionPeriod: 0, // No retention for test
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
 	// Provision
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
 	// Deprovision
@@ -480,10 +488,11 @@ func TestPostgresProvisioner_PurgeSchemas_NotDeprovisioned(t *testing.T) {
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
 	// Provision but don't deprovision
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
 	// Purge should fail
@@ -507,10 +516,11 @@ func TestPostgresProvisioner_PurgeSchemas_RetentionNotElapsed(t *testing.T) {
 		DataRetentionPeriod: 7 * 24 * time.Hour, // 7 days
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
 	// Provision and deprovision
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
 	err = provisioner.DeprovisionSchemas(context.Background(), tenantID)
@@ -525,15 +535,19 @@ func TestPostgresProvisioner_GetProvisioningStatus_NotFound(t *testing.T) {
 	tc := setupTestContainer(t)
 	defer tc.cleanup(t)
 
+	svcDir := filepath.Join(tc.migDir, "dummy-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+
 	config := &Config{
-		Services:            []ServiceConfig{},
+		Services:            []ServiceConfig{{Name: "dummy-service", MigrationPath: svcDir}},
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
 	tenantID := organization.MustNewOrganizationID("unknown_tenant")
-	_, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
+	_, err = provisioner.GetProvisioningStatus(context.Background(), tenantID)
 	assert.ErrorIs(t, err, ErrProvisioningStatusNotFound)
 }
 
@@ -554,15 +568,16 @@ func TestPostgresProvisioner_ProvisionSchemas_Timeout(t *testing.T) {
 
 	config := &Config{
 		Services:            []ServiceConfig{{Name: "slow-service", MigrationPath: svcDir}},
-		ProvisioningTimeout: 100 * time.Millisecond, // Very short timeout
+		ProvisioningTimeout: 500 * time.Millisecond, // Short timeout to trigger before pg_sleep(5) completes
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	err := provisioner.ProvisionSchemas(ctx, tenantID)
+	err = provisioner.ProvisionSchemas(ctx, tenantID)
 	assert.Error(t, err) // Should timeout or get context error
 }
 
@@ -578,10 +593,11 @@ func TestPostgresProvisioner_ProvisionSchemas_NoMigrationDirectory(t *testing.T)
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
 	// Should succeed - missing migrations directory is valid (creates empty schema)
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
 	// Schema should still be created
@@ -619,9 +635,10 @@ func TestPostgresProvisioner_ProvisionSchemas_MultipleMigrationFiles(t *testing.
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	require.NoError(t, err)
 
 	// Verify all migrations applied
@@ -665,10 +682,11 @@ func TestPostgresProvisioner_ProvisionSchemas_SchemaIsolation(t *testing.T) {
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
 	// Provision both tenants
-	err := provisioner.ProvisionSchemas(context.Background(), tenant1)
+	err = provisioner.ProvisionSchemas(context.Background(), tenant1)
 	require.NoError(t, err)
 
 	err = provisioner.ProvisionSchemas(context.Background(), tenant2)
@@ -710,10 +728,11 @@ func TestPostgresProvisioner_RetryAfterFailure(t *testing.T) {
 		ProvisioningTimeout: 30 * time.Second,
 	}
 
-	provisioner := NewPostgresProvisioner(tc.db, config)
+	provisioner, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
 
 	// First attempt fails
-	err := provisioner.ProvisionSchemas(context.Background(), tenantID)
+	err = provisioner.ProvisionSchemas(context.Background(), tenantID)
 	assert.Error(t, err)
 
 	status, err := provisioner.GetProvisioningStatus(context.Background(), tenantID)
@@ -732,6 +751,58 @@ func TestPostgresProvisioner_RetryAfterFailure(t *testing.T) {
 	status, err = provisioner.GetProvisioningStatus(context.Background(), tenantID)
 	require.NoError(t, err)
 	assert.Equal(t, StateActive, status.State)
+}
+
+func TestNewPostgresProvisioner_InvalidConfig(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tests := []struct {
+		name        string
+		config      *Config
+		expectedErr error
+	}{
+		{
+			name: "no services configured",
+			config: &Config{
+				Services:            []ServiceConfig{},
+				ProvisioningTimeout: 30 * time.Second,
+			},
+			expectedErr: ErrNoServicesConfigured,
+		},
+		{
+			name: "invalid provisioning timeout",
+			config: &Config{
+				Services:            []ServiceConfig{{Name: "test", MigrationPath: "/tmp"}},
+				ProvisioningTimeout: 0,
+			},
+			expectedErr: ErrInvalidProvisioningTimeout,
+		},
+		{
+			name: "empty service name",
+			config: &Config{
+				Services:            []ServiceConfig{{Name: "", MigrationPath: "/tmp"}},
+				ProvisioningTimeout: 30 * time.Second,
+			},
+			expectedErr: ErrEmptyServiceName,
+		},
+		{
+			name: "empty migration path",
+			config: &Config{
+				Services:            []ServiceConfig{{Name: "test", MigrationPath: ""}},
+				ProvisioningTimeout: 30 * time.Second,
+			},
+			expectedErr: ErrEmptyMigrationPath,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPostgresProvisioner(tc.db, tt.config)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, tt.expectedErr)
+		})
+	}
 }
 
 func TestQuoteIdentifier(t *testing.T) {


### PR DESCRIPTION
## Summary
- Implements PostgresProvisioner that creates org_{tenant_id} PostgreSQL schemas and applies service migrations
- Provides full schema lifecycle: provision, deprovision (soft delete), and purge (hard delete with retention)
- Uses GORM and testcontainers for database operations and testing

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 47

## Changes Made
- Added `services/tenant/provisioner/postgres_provisioner.go` - Core implementation with:
  - `createSchema()` - Creates tenant schema with proper identifier escaping
  - `applyServiceMigrations()` - Reads and executes SQL files with schema qualification
  - `processMigrationSQL()` - Rewrites hardcoded schema prefixes to tenant schema
  - Status tracking using `platform.tenant_provisioning` table with PostgreSQL UPSERT
- Added `services/tenant/provisioner/postgres_provisioner_test.go` - Integration tests with testcontainers

## Test Plan
- Unit tests for helper functions (quoteIdentifier)
- Integration tests using testcontainers:
  - Basic provisioning and table creation
  - Multiple services with sequential migrations
  - Idempotent provisioning (calling ProvisionSchemas twice)
  - Migration failure handling and retry after fix
  - Deprovision soft delete (schema preserved)
  - Purge with retention period enforcement
  - Schema isolation between tenants
  - Timeout handling

## Design Decisions
- **GORM instead of Atlas CLI**: Migrations are executed via SQL with search_path, avoiding external tool dependency
- **UPSERT for status**: Atomic insert/update prevents race conditions in status tracking
- **Schema rewriting**: Service-specific prefixes (current_account., party.) are rewritten to tenant schema
- **Error wrapping**: Uses %w verbs for proper error chain inspection