### PR TITLE
feat: Add server-side organization extraction interceptor

### DIFF
--- a/shared/platform/auth/organization_interceptor.go
+++ b/shared/platform/auth/organization_interceptor.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/meridianhub/meridian/shared/platform/organization"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// OrganizationExtractionInterceptor extracts organization ID from gRPC metadata.
+// This works alongside JWT auth interceptor for service-to-service calls.
+// If organization is already in context (from JWT auth), this is a no-op.
+//
+// Use case: Service A calls Service B with organization in metadata. Service B
+// extracts the org from metadata and injects it into context, enabling multi-hop
+// call chains to propagate organization context.
+func OrganizationExtractionInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		_ *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		// Check if organization is already in context (from JWT auth)
+		if _, ok := organization.FromContext(ctx); ok {
+			return handler(ctx, req)
+		}
+
+		// Extract from incoming metadata
+		md, ok := metadata.FromIncomingContext(ctx)
+		if ok {
+			if vals := md.Get(organization.OrgIDKey); len(vals) > 0 {
+				orgID := organization.OrganizationID(vals[0])
+				ctx = organization.WithOrganization(ctx, orgID)
+			}
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// OrganizationExtractionStreamInterceptor extracts organization ID from gRPC
+// metadata for streaming RPCs. This is the streaming equivalent of
+// OrganizationExtractionInterceptor.
+//
+// If organization is already in context (from JWT auth), this is a no-op.
+func OrganizationExtractionStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		_ *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		ctx := ss.Context()
+
+		// Check if organization is already in context (from JWT auth)
+		if _, ok := organization.FromContext(ctx); ok {
+			return handler(srv, ss)
+		}
+
+		// Extract from incoming metadata
+		md, ok := metadata.FromIncomingContext(ctx)
+		if ok {
+			if vals := md.Get(organization.OrgIDKey); len(vals) > 0 {
+				orgID := organization.OrganizationID(vals[0])
+				ctx = organization.WithOrganization(ctx, orgID)
+
+				// Wrap stream with the new context containing organization
+				wrappedStream := &wrappedServerStream{
+					ServerStream: ss,
+					ctx:          ctx,
+				}
+
+				return handler(srv, wrappedStream)
+			}
+		}
+
+		return handler(srv, ss)
+	}
+}

--- a/shared/platform/auth/organization_interceptor.go
+++ b/shared/platform/auth/organization_interceptor.go
@@ -15,6 +15,9 @@ import (
 // Use case: Service A calls Service B with organization in metadata. Service B
 // extracts the org from metadata and injects it into context, enabling multi-hop
 // call chains to propagate organization context.
+//
+// Security: The organization ID is validated before being added to context.
+// Invalid org IDs are silently ignored (context remains unchanged).
 func OrganizationExtractionInterceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
@@ -31,8 +34,12 @@ func OrganizationExtractionInterceptor() grpc.UnaryServerInterceptor {
 		md, ok := metadata.FromIncomingContext(ctx)
 		if ok {
 			if vals := md.Get(organization.OrgIDKey); len(vals) > 0 {
-				orgID := organization.OrganizationID(vals[0])
-				ctx = organization.WithOrganization(ctx, orgID)
+				// Validate org ID to prevent malformed values from untrusted callers
+				orgID, err := organization.NewOrganizationID(vals[0])
+				if err == nil {
+					ctx = organization.WithOrganization(ctx, orgID)
+				}
+				// Invalid org IDs are silently ignored - context unchanged
 			}
 		}
 
@@ -45,6 +52,9 @@ func OrganizationExtractionInterceptor() grpc.UnaryServerInterceptor {
 // OrganizationExtractionInterceptor.
 //
 // If organization is already in context (from JWT auth), this is a no-op.
+//
+// Security: The organization ID is validated before being added to context.
+// Invalid org IDs are silently ignored (context remains unchanged).
 func OrganizationExtractionStreamInterceptor() grpc.StreamServerInterceptor {
 	return func(
 		srv interface{},
@@ -63,16 +73,20 @@ func OrganizationExtractionStreamInterceptor() grpc.StreamServerInterceptor {
 		md, ok := metadata.FromIncomingContext(ctx)
 		if ok {
 			if vals := md.Get(organization.OrgIDKey); len(vals) > 0 {
-				orgID := organization.OrganizationID(vals[0])
-				ctx = organization.WithOrganization(ctx, orgID)
+				// Validate org ID to prevent malformed values from untrusted callers
+				orgID, err := organization.NewOrganizationID(vals[0])
+				if err == nil {
+					ctx = organization.WithOrganization(ctx, orgID)
 
-				// Wrap stream with the new context containing organization
-				wrappedStream := &wrappedServerStream{
-					ServerStream: ss,
-					ctx:          ctx,
+					// Wrap stream with the new context containing organization
+					wrappedStream := &wrappedServerStream{
+						ServerStream: ss,
+						ctx:          ctx,
+					}
+
+					return handler(srv, wrappedStream)
 				}
-
-				return handler(srv, wrappedStream)
+				// Invalid org IDs are silently ignored - use original stream
 			}
 		}
 

--- a/shared/platform/auth/organization_interceptor_test.go
+++ b/shared/platform/auth/organization_interceptor_test.go
@@ -1,0 +1,244 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/organization"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestOrganizationExtractionInterceptor(t *testing.T) {
+	t.Run("extracts org from metadata when not in context", func(t *testing.T) {
+		md := metadata.Pairs(organization.OrgIDKey, "acme_bank")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		interceptor := OrganizationExtractionInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify organization was extracted into context
+		resultCtx := resp.(context.Context)
+		orgID, ok := organization.FromContext(resultCtx)
+		assert.True(t, ok)
+		assert.Equal(t, organization.OrganizationID("acme_bank"), orgID)
+	})
+
+	t.Run("is no-op when org already in context", func(t *testing.T) {
+		// Set org in context directly (simulating JWT auth having set it)
+		ctx := organization.WithOrganization(context.Background(), "jwt_org")
+
+		// Also set a different org in metadata
+		md := metadata.Pairs(organization.OrgIDKey, "metadata_org")
+		ctx = metadata.NewIncomingContext(ctx, md)
+
+		interceptor := OrganizationExtractionInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify original org from context is preserved (JWT takes precedence)
+		resultCtx := resp.(context.Context)
+		orgID, ok := organization.FromContext(resultCtx)
+		assert.True(t, ok)
+		assert.Equal(t, organization.OrganizationID("jwt_org"), orgID)
+	})
+
+	t.Run("context unchanged when no org in metadata", func(t *testing.T) {
+		// No org in context and no org in metadata
+		md := metadata.Pairs("other-header", "value")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		interceptor := OrganizationExtractionInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify no org in context
+		resultCtx := resp.(context.Context)
+		_, ok := organization.FromContext(resultCtx)
+		assert.False(t, ok)
+	})
+
+	t.Run("context unchanged when no metadata present", func(t *testing.T) {
+		// No metadata at all
+		ctx := context.Background()
+
+		interceptor := OrganizationExtractionInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify no org in context
+		resultCtx := resp.(context.Context)
+		_, ok := organization.FromContext(resultCtx)
+		assert.False(t, ok)
+	})
+
+	t.Run("extracts first org value when multiple present", func(t *testing.T) {
+		// Multiple org values in metadata (edge case)
+		md := metadata.Pairs(
+			organization.OrgIDKey, "first_org",
+			organization.OrgIDKey, "second_org",
+		)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		interceptor := OrganizationExtractionInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Should use the first value
+		resultCtx := resp.(context.Context)
+		orgID, ok := organization.FromContext(resultCtx)
+		assert.True(t, ok)
+		assert.Equal(t, organization.OrganizationID("first_org"), orgID)
+	})
+}
+
+func TestOrganizationExtractionStreamInterceptor(t *testing.T) {
+	t.Run("extracts org from metadata when not in context", func(t *testing.T) {
+		md := metadata.Pairs(organization.OrgIDKey, "acme_bank")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		stream := &mockServerStream{ctx: ctx}
+		info := &grpc.StreamServerInfo{FullMethod: "/test.Service/StreamMethod"}
+
+		var capturedCtx context.Context
+		handler := func(_ interface{}, ss grpc.ServerStream) error {
+			capturedCtx = ss.Context()
+			return nil
+		}
+
+		interceptor := OrganizationExtractionStreamInterceptor()
+		err := interceptor(nil, stream, info, handler)
+
+		assert.NoError(t, err)
+
+		// Verify organization was extracted into context
+		orgID, ok := organization.FromContext(capturedCtx)
+		assert.True(t, ok)
+		assert.Equal(t, organization.OrganizationID("acme_bank"), orgID)
+	})
+
+	t.Run("is no-op when org already in context", func(t *testing.T) {
+		// Set org in context directly (simulating JWT auth having set it)
+		ctx := organization.WithOrganization(context.Background(), "jwt_org")
+
+		// Also set a different org in metadata
+		md := metadata.Pairs(organization.OrgIDKey, "metadata_org")
+		ctx = metadata.NewIncomingContext(ctx, md)
+
+		stream := &mockServerStream{ctx: ctx}
+		info := &grpc.StreamServerInfo{FullMethod: "/test.Service/StreamMethod"}
+
+		var capturedCtx context.Context
+		handler := func(_ interface{}, ss grpc.ServerStream) error {
+			capturedCtx = ss.Context()
+			return nil
+		}
+
+		interceptor := OrganizationExtractionStreamInterceptor()
+		err := interceptor(nil, stream, info, handler)
+
+		assert.NoError(t, err)
+
+		// Verify original org from context is preserved (JWT takes precedence)
+		orgID, ok := organization.FromContext(capturedCtx)
+		assert.True(t, ok)
+		assert.Equal(t, organization.OrganizationID("jwt_org"), orgID)
+	})
+
+	t.Run("context unchanged when no org in metadata", func(t *testing.T) {
+		// No org in context and no org in metadata
+		md := metadata.Pairs("other-header", "value")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		stream := &mockServerStream{ctx: ctx}
+		info := &grpc.StreamServerInfo{FullMethod: "/test.Service/StreamMethod"}
+
+		var capturedCtx context.Context
+		handler := func(_ interface{}, ss grpc.ServerStream) error {
+			capturedCtx = ss.Context()
+			return nil
+		}
+
+		interceptor := OrganizationExtractionStreamInterceptor()
+		err := interceptor(nil, stream, info, handler)
+
+		assert.NoError(t, err)
+
+		// Verify no org in context
+		_, ok := organization.FromContext(capturedCtx)
+		assert.False(t, ok)
+	})
+
+	t.Run("context unchanged when no metadata present", func(t *testing.T) {
+		// No metadata at all
+		ctx := context.Background()
+
+		stream := &mockServerStream{ctx: ctx}
+		info := &grpc.StreamServerInfo{FullMethod: "/test.Service/StreamMethod"}
+
+		var capturedCtx context.Context
+		handler := func(_ interface{}, ss grpc.ServerStream) error {
+			capturedCtx = ss.Context()
+			return nil
+		}
+
+		interceptor := OrganizationExtractionStreamInterceptor()
+		err := interceptor(nil, stream, info, handler)
+
+		assert.NoError(t, err)
+
+		// Verify no org in context
+		_, ok := organization.FromContext(capturedCtx)
+		assert.False(t, ok)
+	})
+
+	t.Run("extracts first org value when multiple present", func(t *testing.T) {
+		// Multiple org values in metadata (edge case)
+		md := metadata.Pairs(
+			organization.OrgIDKey, "first_org",
+			organization.OrgIDKey, "second_org",
+		)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		stream := &mockServerStream{ctx: ctx}
+		info := &grpc.StreamServerInfo{FullMethod: "/test.Service/StreamMethod"}
+
+		var capturedCtx context.Context
+		handler := func(_ interface{}, ss grpc.ServerStream) error {
+			capturedCtx = ss.Context()
+			return nil
+		}
+
+		interceptor := OrganizationExtractionStreamInterceptor()
+		err := interceptor(nil, stream, info, handler)
+
+		assert.NoError(t, err)
+
+		// Should use the first value
+		orgID, ok := organization.FromContext(capturedCtx)
+		assert.True(t, ok)
+		assert.Equal(t, organization.OrganizationID("first_org"), orgID)
+	})
+}

--- a/shared/platform/auth/organization_interceptor_test.go
+++ b/shared/platform/auth/organization_interceptor_test.go
@@ -112,6 +112,25 @@ func TestOrganizationExtractionInterceptor(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, organization.OrganizationID("first_org"), orgID)
 	})
+
+	t.Run("ignores invalid org ID format in metadata", func(t *testing.T) {
+		// Invalid org ID with special characters (validation fails)
+		md := metadata.Pairs(organization.OrgIDKey, "invalid org!")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		interceptor := OrganizationExtractionInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Org should NOT be in context due to validation failure
+		resultCtx := resp.(context.Context)
+		_, ok := organization.FromContext(resultCtx)
+		assert.False(t, ok)
+	})
 }
 
 func TestOrganizationExtractionStreamInterceptor(t *testing.T) {
@@ -240,5 +259,29 @@ func TestOrganizationExtractionStreamInterceptor(t *testing.T) {
 		orgID, ok := organization.FromContext(capturedCtx)
 		assert.True(t, ok)
 		assert.Equal(t, organization.OrganizationID("first_org"), orgID)
+	})
+
+	t.Run("ignores invalid org ID format in metadata", func(t *testing.T) {
+		// Invalid org ID with special characters (validation fails)
+		md := metadata.Pairs(organization.OrgIDKey, "invalid org!")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		stream := &mockServerStream{ctx: ctx}
+		info := &grpc.StreamServerInfo{FullMethod: "/test.Service/StreamMethod"}
+
+		var capturedCtx context.Context
+		handler := func(_ interface{}, ss grpc.ServerStream) error {
+			capturedCtx = ss.Context()
+			return nil
+		}
+
+		interceptor := OrganizationExtractionStreamInterceptor()
+		err := interceptor(nil, stream, info, handler)
+
+		assert.NoError(t, err)
+
+		// Org should NOT be in context due to validation failure
+		_, ok := organization.FromContext(capturedCtx)
+		assert.False(t, ok)
 	})
 }


### PR DESCRIPTION
## Summary
- Add `OrganizationExtractionInterceptor` for unary RPCs that extracts organization ID from incoming gRPC metadata
- Add `OrganizationExtractionStreamInterceptor` for streaming RPCs
- Enables multi-hop service-to-service calls to propagate organization context

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 44

## Changes Made
- `shared/platform/auth/organization_interceptor.go` - New interceptors for extracting org from metadata
- `shared/platform/auth/organization_interceptor_test.go` - Comprehensive unit tests

## Design Notes
- **Idempotent**: If organization is already in context (from JWT auth), interceptor is a no-op
- **Security**: JWT auth takes precedence over metadata extraction
- **Graceful**: Missing org header leaves context unchanged (no error)
- Reuses existing `wrappedServerStream` type from grpc_interceptor.go

## Test Plan
- Unit test: Incoming metadata with x-org-id → verify context populated ✅
- Unit test: Org already in context → verify interceptor is no-op ✅
- Unit test: Missing org header → verify context unchanged (graceful) ✅
- Unit test: Multiple org values in metadata → verify first value used ✅
- Unit test: Stream RPC with org metadata → verify context propagates to stream handler ✅