### PR TITLE
feat: Integrate Kafka event publisher with organization headers in Position-Keeping service

### DIFF
--- a/services/position-keeping/adapters/messaging/kafka_event_publisher.go
+++ b/services/position-keeping/adapters/messaging/kafka_event_publisher.go
@@ -14,8 +14,9 @@ import (
 // This interface allows the KafkaEventPublisher to be unit-tested without
 // requiring a real Kafka connection.
 type protoPublisher interface {
-	// Publish publishes a protobuf message to a topic with a partition key
-	Publish(ctx context.Context, topic, key string, msg proto.Message) error
+	// PublishWithOrganization publishes a protobuf message with organization context
+	// extracted from ctx and injected as a Kafka header (x-org-id).
+	PublishWithOrganization(ctx context.Context, topic, key string, msg proto.Message) error
 	// Flush waits for outstanding messages to be delivered
 	Flush(timeoutMs int) int
 	// Close closes the producer
@@ -127,8 +128,8 @@ func (p *KafkaEventPublisher) Publish(ctx context.Context, event domain.DomainEv
 	// Use aggregate ID as partition key for ordering
 	partitionKey := event.AggregateID()
 
-	// Publish to Kafka
-	if err := p.producer.Publish(ctx, topic, partitionKey, protoMsg); err != nil {
+	// Publish with organization headers (extracted from context)
+	if err := p.producer.PublishWithOrganization(ctx, topic, partitionKey, protoMsg); err != nil {
 		return fmt.Errorf("failed to publish event %s to topic %s: %w", event.EventType(), topic, err)
 	}
 

--- a/services/position-keeping/adapters/messaging/kafka_event_publisher_test.go
+++ b/services/position-keeping/adapters/messaging/kafka_event_publisher_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/meridianhub/meridian/services/position-keeping/adapters/messaging"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/shared/platform/kafka"
+	"github.com/meridianhub/meridian/shared/platform/organization"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -28,7 +29,7 @@ type publishedMessage struct {
 	msg   proto.Message
 }
 
-func (m *mockProtoPublisher) Publish(_ context.Context, topic, key string, msg proto.Message) error {
+func (m *mockProtoPublisher) PublishWithOrganization(_ context.Context, topic, key string, msg proto.Message) error {
 	m.publishedMessages = append(m.publishedMessages, publishedMessage{
 		topic: topic,
 		key:   key,
@@ -44,6 +45,12 @@ func (m *mockProtoPublisher) Flush(_ int) int {
 
 func (m *mockProtoPublisher) Close() {
 	m.closed = true
+}
+
+// testOrgContext creates a context with organization for testing
+func testOrgContext() context.Context {
+	orgID := organization.MustNewOrganizationID("test_org")
+	return organization.WithOrganization(context.Background(), orgID)
 }
 
 func TestDefaultTopicConfig(t *testing.T) {
@@ -326,8 +333,8 @@ func TestKafkaEventPublisher_TopicMapping(t *testing.T) {
 			publisher, err := messaging.NewKafkaEventPublisher(mock, topicConfig)
 			require.NoError(t, err)
 
-			// Publish event
-			ctx := context.Background()
+			// Publish event with organization context
+			ctx := testOrgContext()
 			err = publisher.Publish(ctx, tt.event)
 			require.NoError(t, err)
 
@@ -355,7 +362,7 @@ func TestKafkaEventPublisher_UnknownEventType(t *testing.T) {
 	publisher, err := messaging.NewKafkaEventPublisher(mock, topicConfig)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := testOrgContext()
 	err = publisher.Publish(ctx, unknownEvent)
 
 	assert.Error(t, err)
@@ -369,7 +376,7 @@ func TestKafkaEventPublisher_NilEvent(t *testing.T) {
 	publisher, err := messaging.NewKafkaEventPublisher(mock, topicConfig)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := testOrgContext()
 	err = publisher.Publish(ctx, nil)
 
 	assert.Error(t, err)
@@ -412,7 +419,7 @@ func TestKafkaEventPublisher_PublishBatch(t *testing.T) {
 	publisher, err := messaging.NewKafkaEventPublisher(mock, topicConfig)
 	require.NoError(t, err)
 
-	ctx := context.Background()
+	ctx := testOrgContext()
 	err = publisher.PublishBatch(ctx, events)
 	require.NoError(t, err)
 

--- a/services/position-keeping/app/container.go
+++ b/services/position-keeping/app/container.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/position-keeping/adapters/messaging"
 	"github.com/meridianhub/meridian/services/position-keeping/adapters/persistence"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/kafka"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"github.com/redis/go-redis/v9"
 )
@@ -23,6 +26,7 @@ type Container struct {
 	RedisClient     *redis.Client
 	Tracer          *observability.Tracer
 	AuthInterceptor *auth.Interceptor
+	kafkaProducer   *kafka.ProtoProducer // internal, for cleanup
 
 	// Adapters
 	EventPublisher domain.EventPublisher
@@ -228,10 +232,37 @@ func (c *Container) initializeEventPublisher() {
 		return
 	}
 
-	// For now, use no-op publisher until Kafka integration is fully wired
-	// TODO: Implement Kafka producer initialization when Kafka config is ready
-	c.Logger.Info("kafka producer not yet implemented, using no-op event publisher")
-	c.EventPublisher = domain.NewNoOpEventPublisher()
+	// Create Kafka producer with organization header support
+	producerConfig := kafka.ProducerConfig{
+		BootstrapServers: strings.Join(c.Config.Kafka.Brokers, ","),
+		ClientID:         "position-keeping-service",
+		Acks:             "all",    // Wait for full replication
+		Retries:          3,        // Retry failed sends
+		Compression:      "snappy", // Efficient compression
+	}
+
+	kafkaProducer, err := kafka.NewProtoProducer(producerConfig)
+	if err != nil {
+		c.Logger.Error("failed to create kafka producer, using no-op publisher", "error", err)
+		c.EventPublisher = domain.NewNoOpEventPublisher()
+		return
+	}
+
+	// Wrap with Position-Keeping event publisher adapter
+	topicConfig := messaging.DefaultTopicConfig()
+	eventPublisher, err := messaging.NewKafkaEventPublisher(kafkaProducer, topicConfig)
+	if err != nil {
+		c.Logger.Error("failed to create event publisher, using no-op publisher", "error", err)
+		kafkaProducer.Close()
+		c.EventPublisher = domain.NewNoOpEventPublisher()
+		return
+	}
+
+	c.kafkaProducer = kafkaProducer
+	c.EventPublisher = eventPublisher
+	c.Logger.Info("kafka event publisher initialized",
+		"brokers", c.Config.Kafka.Brokers,
+		"client_id", producerConfig.ClientID)
 }
 
 // initializeRepositories initializes domain repositories
@@ -247,6 +278,16 @@ func (c *Container) Close(ctx context.Context) error {
 	c.Logger.Info("closing container resources...")
 
 	var errs []error
+
+	// Close Kafka producer (flush outstanding messages first)
+	if c.kafkaProducer != nil {
+		remaining := c.kafkaProducer.Flush(5000) // 5 second timeout
+		if remaining > 0 {
+			c.Logger.Warn("kafka producer flush incomplete", "remaining_messages", remaining)
+		}
+		c.kafkaProducer.Close()
+		c.Logger.Info("kafka producer closed")
+	}
 
 	// Close database pool
 	if c.DBPool != nil {


### PR DESCRIPTION
## Summary

- Replace no-op Kafka publisher with actual shared Kafka infrastructure in Position-Keeping service
- Enable organization-scoped event publishing for all FinancialPositionLog domain events
- Events published to Kafka will now include `x-org-id` header extracted from request context

## Changes Made

1. **kafka_event_publisher.go**: Updated `protoPublisher` interface to use `PublishWithOrganization` method instead of plain `Publish`
2. **container.go**: Wire real Kafka producer with organization header support
   - Initialize `kafka.ProtoProducer` with service-specific configuration
   - Graceful fallback to no-op publisher if Kafka initialization fails
   - Add Kafka producer cleanup during container shutdown (flush + close)
3. **kafka_event_publisher_test.go**: Update tests to include organization context

## Technical Details

- Uses shared platform Kafka infrastructure (`shared/platform/kafka/producer.go`)
- Organization ID is extracted from context via `organization.MustFromContext(ctx)` and injected as Kafka header
- Events are published to topic-specific Kafka topics (e.g., `position-keeping.transaction-posted.v1`)
- Partition key uses aggregate ID for event ordering guarantees

## Test Plan

- [x] Build compiles successfully
- [x] Unit tests pass for messaging adapter
- [x] App package tests pass
- [ ] Integration test in Tilt environment (manual verification)

## Related

Task Master: #53 (8-multi-tenancy tag)