### PR TITLE
Update all gRPC clients to propagate organization context

### DIFF
--- a/services/current-account/clients/common.go
+++ b/services/current-account/clients/common.go
@@ -29,3 +29,10 @@ func ExtractCorrelationID(ctx context.Context) string {
 func WithTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	return sharedclients.WithTimeout(ctx, timeout)
 }
+
+// PropagateOrganization extracts organization ID from context and adds it to gRPC metadata.
+// Returns the same context if org is missing or empty (graceful degradation for single-tenant or bootstrap calls).
+// Deprecated: Import directly from github.com/meridianhub/meridian/shared/pkg/clients
+func PropagateOrganization(ctx context.Context) context.Context {
+	return sharedclients.PropagateOrganization(ctx)
+}

--- a/services/current-account/clients/common_test.go
+++ b/services/current-account/clients/common_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/meridianhub/meridian/services/current-account/clients"
+	"github.com/meridianhub/meridian/shared/platform/organization"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/metadata"
 )
@@ -296,4 +297,56 @@ func TestWithTimeout_NegativeTimeout(t *testing.T) {
 	// Should not have a deadline
 	_, ok := resultCtx.Deadline()
 	assert.False(t, ok, "should not have deadline")
+}
+
+// TestPropagateOrganization_Success verifies organization ID is added to outgoing metadata
+func TestPropagateOrganization_Success(t *testing.T) {
+	t.Parallel()
+
+	orgID := organization.MustNewOrganizationID("acme_bank")
+	ctx := organization.WithOrganization(context.Background(), orgID)
+
+	result := clients.PropagateOrganization(ctx)
+
+	// Verify organization ID was added to outgoing metadata
+	md, ok := metadata.FromOutgoingContext(result)
+	assert.True(t, ok, "should have outgoing metadata")
+	assert.Equal(t, []string{"acme_bank"}, md.Get(organization.OrgIDKey))
+}
+
+// TestPropagateOrganization_NoOrganization verifies context is unchanged when no organization exists
+func TestPropagateOrganization_NoOrganization(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	result := clients.PropagateOrganization(ctx)
+
+	// Context should be returned unchanged
+	assert.Equal(t, ctx, result)
+
+	// Should not have outgoing metadata
+	_, ok := metadata.FromOutgoingContext(result)
+	assert.False(t, ok, "should not have outgoing metadata")
+}
+
+// TestPropagateOrganization_ChainWithCorrelationID verifies both propagation functions work together
+func TestPropagateOrganization_ChainWithCorrelationID(t *testing.T) {
+	t.Parallel()
+
+	// Create context with both correlation ID and organization
+	//nolint:revive,staticcheck // Using string key as expected by ExtractCorrelationID implementation
+	ctx := context.WithValue(context.Background(), "x-correlation-id", "corr-123")
+	orgID := organization.MustNewOrganizationID("chain_test")
+	ctx = organization.WithOrganization(ctx, orgID)
+
+	// Apply both propagation functions
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	// Verify both headers are present
+	md, ok := metadata.FromOutgoingContext(ctx)
+	assert.True(t, ok, "should have outgoing metadata")
+	assert.Equal(t, []string{"corr-123"}, md.Get("x-correlation-id"), "should have correlation ID")
+	assert.Equal(t, []string{"chain_test"}, md.Get(organization.OrgIDKey), "should have organization ID")
 }

--- a/services/current-account/clients/financialaccounting_client.go
+++ b/services/current-account/clients/financialaccounting_client.go
@@ -162,6 +162,7 @@ func (c *FinancialAccountingGRPCClient) InitiateFinancialBookingLog(
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.InitiateFinancialBookingLog(ctx, req)
 	if err != nil {
@@ -180,6 +181,7 @@ func (c *FinancialAccountingGRPCClient) UpdateFinancialBookingLog(
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.UpdateFinancialBookingLog(ctx, req)
 	if err != nil {
@@ -198,6 +200,7 @@ func (c *FinancialAccountingGRPCClient) RetrieveFinancialBookingLog(
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.RetrieveFinancialBookingLog(ctx, req)
 	if err != nil {
@@ -216,6 +219,7 @@ func (c *FinancialAccountingGRPCClient) ListFinancialBookingLogs(
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.ListFinancialBookingLogs(ctx, req)
 	if err != nil {
@@ -234,6 +238,7 @@ func (c *FinancialAccountingGRPCClient) CaptureLedgerPosting(
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.CaptureLedgerPosting(ctx, req)
 	if err != nil {
@@ -252,6 +257,7 @@ func (c *FinancialAccountingGRPCClient) RetrieveLedgerPosting(
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.RetrieveLedgerPosting(ctx, req)
 	if err != nil {

--- a/services/current-account/clients/party_client.go
+++ b/services/current-account/clients/party_client.go
@@ -204,6 +204,7 @@ func (c *PartyGRPCClient) GetParty(ctx context.Context, partyID string) (*partyv
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.RetrieveParty(ctx, &partyv1.RetrievePartyRequest{
 		PartyId: partyID,

--- a/services/current-account/clients/positionkeeping_client.go
+++ b/services/current-account/clients/positionkeeping_client.go
@@ -162,6 +162,7 @@ func (c *PositionKeepingGRPCClient) InitiateFinancialPositionLog(
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.InitiateFinancialPositionLog(ctx, req)
 	if err != nil {
@@ -180,6 +181,7 @@ func (c *PositionKeepingGRPCClient) UpdateFinancialPositionLog(
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.UpdateFinancialPositionLog(ctx, req)
 	if err != nil {
@@ -198,6 +200,7 @@ func (c *PositionKeepingGRPCClient) RetrieveFinancialPositionLog(
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.RetrieveFinancialPositionLog(ctx, req)
 	if err != nil {
@@ -216,6 +219,7 @@ func (c *PositionKeepingGRPCClient) BulkImportTransactions(
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.BulkImportTransactions(ctx, req)
 	if err != nil {
@@ -234,6 +238,7 @@ func (c *PositionKeepingGRPCClient) ListFinancialPositionLogs(
 	defer cancel()
 
 	ctx = PropagateCorrelationID(ctx)
+	ctx = PropagateOrganization(ctx)
 
 	resp, err := c.client.ListFinancialPositionLogs(ctx, req)
 	if err != nil {

--- a/services/tenant/clients/party_client.go
+++ b/services/tenant/clients/party_client.go
@@ -172,6 +172,7 @@ func (c *PartyGRPCClient) RegisterParty(ctx context.Context, req *partyv1.Regist
 	defer cancel()
 
 	ctx = sharedclients.PropagateCorrelationID(ctx)
+	ctx = sharedclients.PropagateOrganization(ctx)
 
 	resp, err := c.client.RegisterParty(ctx, req)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add organization context propagation to all inter-service gRPC clients
- Enable multi-tenant isolation by flowing organization ID through service chains
- Follow standardized pattern: `ctx = PropagateCorrelationID(ctx)` then `ctx = PropagateOrganization(ctx)`

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 45

## Changes Made
- **services/current-account/clients/common.go**: Add `PropagateOrganization` wrapper
- **services/current-account/clients/party_client.go**: Add org propagation to GetParty
- **services/current-account/clients/positionkeeping_client.go**: Add org propagation to 5 methods
- **services/current-account/clients/financialaccounting_client.go**: Add org propagation to 6 methods  
- **services/tenant/clients/party_client.go**: Add org propagation to RegisterParty
- **services/current-account/clients/common_test.go**: Add unit tests for PropagateOrganization

## Test Plan
- [x] Unit tests verify org ID is added to outgoing gRPC metadata
- [x] Unit tests verify graceful handling when org is missing (no error)
- [x] Unit tests verify PropagateOrganization chains correctly with PropagateCorrelationID
- [x] All existing client tests pass
- [x] Linter passes with 0 issues