### PR TITLE
feat: Extract tenant context for Position-Keeping audit trails

### DIFF
--- a/services/position-keeping/adapters/persistence/postgres_repository.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/shared/platform/audit"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 )
@@ -57,7 +58,7 @@ func (r *PostgresRepository) Create(ctx context.Context, log *domain.FinancialPo
 	}()
 
 	// Insert main financial_position_log
-	// TODO: Consider extracting user ID from context for proper audit trails instead of hardcoding "system"
+	userID := audit.GetUserFromContext(ctx)
 	logQuery := `
 		INSERT INTO position_keeping.financial_position_logs (
 			id, created_at, created_by, updated_at, updated_by,
@@ -73,7 +74,7 @@ func (r *PostgresRepository) Create(ctx context.Context, log *domain.FinancialPo
 
 	var dbID uuid.UUID
 	err = tx.QueryRow(ctx, logQuery,
-		log.CreatedAt, "system", log.UpdatedAt, "system",
+		log.CreatedAt, userID, log.UpdatedAt, userID,
 		log.LogID, log.AccountID, log.Version,
 		log.StatusTracking.CurrentStatus.String(), nullString(log.StatusTracking.PreviousStatus),
 		log.StatusTracking.StatusUpdatedAt, log.StatusTracking.StatusReason,
@@ -128,6 +129,7 @@ func (r *PostgresRepository) CreateBatch(ctx context.Context, logs []*domain.Fin
 	}()
 
 	// Use COPY for bulk insert of financial_position_logs
+	userID := audit.GetUserFromContext(ctx)
 	copyCount, err := tx.CopyFrom(
 		ctx,
 		pgx.Identifier{"position_keeping", "financial_position_logs"},
@@ -141,7 +143,7 @@ func (r *PostgresRepository) CreateBatch(ctx context.Context, logs []*domain.Fin
 			log := logs[i]
 			return []any{
 				uuid.New(), // Generate new DB ID
-				log.CreatedAt, "system", log.UpdatedAt, "system",
+				log.CreatedAt, userID, log.UpdatedAt, userID,
 				log.LogID, log.AccountID, log.Version,
 				log.StatusTracking.CurrentStatus.String(), nullString(log.StatusTracking.PreviousStatus),
 				log.StatusTracking.StatusUpdatedAt, log.StatusTracking.StatusReason,
@@ -304,6 +306,7 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 	// Note: The domain layer increments the version, so we check against the previous version
 	// (log.Version - 1) and set to the current version (log.Version)
 	previousVersion := log.Version - 1
+	userID := audit.GetUserFromContext(ctx)
 
 	updateQuery := `
 		UPDATE position_keeping.financial_position_logs
@@ -313,7 +316,7 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 		WHERE id = $10 AND version = $11 AND deleted_at IS NULL`
 
 	result, err := tx.Exec(ctx, updateQuery,
-		log.UpdatedAt, "system", log.Version,
+		log.UpdatedAt, userID, log.Version,
 		log.StatusTracking.CurrentStatus.String(), nullString(log.StatusTracking.PreviousStatus),
 		log.StatusTracking.StatusUpdatedAt, log.StatusTracking.StatusReason,
 		nullStringValue(log.StatusTracking.FailureReason),
@@ -484,13 +487,14 @@ func (r *PostgresRepository) insertTransactionLogEntries(ctx context.Context, tx
 		)`
 
 	batch := &pgx.Batch{}
+	userID := audit.GetUserFromContext(ctx)
 
 	for _, entry := range entries {
 		// Convert decimal amount to cents (int64)
 		amountCents := decimalToCents(entry.Amount.Amount())
 
 		batch.Queue(query,
-			entry.CreatedAt, "system", entry.CreatedAt, "system",
+			entry.CreatedAt, userID, entry.CreatedAt, userID,
 			entry.EntryID, financialPosLogID, entry.TransactionID, entry.AccountID,
 			amountCents, entry.Amount.Currency().String(), entry.Direction.String(),
 			entry.Timestamp, nullStringValue(entry.Description), nullStringValue(entry.Reference), entry.Source.String(),
@@ -523,6 +527,7 @@ func (r *PostgresRepository) insertTransactionLineage(ctx context.Context, tx pg
 		return fmt.Errorf("failed to marshal related transaction IDs: %w", err)
 	}
 
+	userID := audit.GetUserFromContext(ctx)
 	query := `
 		INSERT INTO position_keeping.transaction_lineages (
 			id, created_at, created_by, updated_at, updated_by,
@@ -535,7 +540,7 @@ func (r *PostgresRepository) insertTransactionLineage(ctx context.Context, tx pg
 		)`
 
 	_, err = tx.Exec(ctx, query,
-		"system", "system",
+		userID, userID,
 		financialPosLogID, lineage.TransactionID(), lineage.ParentTransactionID(),
 		childIDs, relatedIDs, lineage.TransactionType(),
 	)
@@ -563,6 +568,7 @@ func (r *PostgresRepository) insertAuditTrailEntries(ctx context.Context, tx pgx
 		)`
 
 	batch := &pgx.Batch{}
+	userID := audit.GetUserFromContext(ctx)
 
 	for _, entry := range entries {
 		sysContext, err := json.Marshal(entry.SystemContext)
@@ -571,7 +577,7 @@ func (r *PostgresRepository) insertAuditTrailEntries(ctx context.Context, tx pgx
 		}
 
 		batch.Queue(query,
-			"system", "system",
+			userID, userID,
 			entry.AuditID, financialPosLogID, entry.Timestamp, entry.UserID,
 			entry.Action, nullStringValue(entry.Details), nullStringValue(entry.IPAddress), sysContext,
 		)

--- a/services/position-keeping/service/update.go
+++ b/services/position-keeping/service/update.go
@@ -4,15 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
 	"google.golang.org/grpc/status"
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 )
 
@@ -85,7 +89,7 @@ func (s *PositionKeepingService) UpdateFinancialPositionLog(
 
 	// Update status if provided using domain lifecycle methods
 	if req.StatusUpdate != nil {
-		if err := applyStatusTransition(log, req); err != nil {
+		if err := applyStatusTransition(ctx, log, req); err != nil {
 			return nil, err
 		}
 		statusChanged = true
@@ -93,7 +97,7 @@ func (s *PositionKeepingService) UpdateFinancialPositionLog(
 
 	// Add audit trail entry if provided (and not already added by status lifecycle method)
 	if req.AuditEntry != nil && !statusChanged {
-		auditEntry, err := protoAuditEntryToDomain(req.AuditEntry)
+		auditEntry, err := protoAuditEntryToDomain(ctx, req.AuditEntry)
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid audit_entry: %v", err)
 		}
@@ -224,9 +228,9 @@ func storeUpdateIdempotencyResult(
 }
 
 // applyStatusTransition applies a status transition to the log using domain lifecycle methods
-func applyStatusTransition(log *domain.FinancialPositionLog, req *positionkeepingv1.UpdateFinancialPositionLogRequest) error {
+func applyStatusTransition(ctx context.Context, log *domain.FinancialPositionLog, req *positionkeepingv1.UpdateFinancialPositionLogRequest) error {
 	newStatus := fromProtoTransactionStatus(req.StatusUpdate.CurrentStatus)
-	auditEntry, err := protoAuditEntryToDomain(req.AuditEntry)
+	auditEntry, err := protoAuditEntryToDomain(ctx, req.AuditEntry)
 	if err != nil {
 		return status.Errorf(codes.InvalidArgument, "invalid audit_entry: %v", err)
 	}
@@ -262,17 +266,15 @@ func applyStatusTransition(log *domain.FinancialPositionLog, req *positionkeepin
 }
 
 // protoAuditEntryToDomain converts proto AuditTrailEntry to domain.
+// Extracts IP address and system context from gRPC context for audit trail enrichment.
 // Returns (nil, nil) for nil input to handle optional proto fields.
-func protoAuditEntryToDomain(proto *positionkeepingv1.AuditTrailEntry) (*domain.AuditTrailEntry, error) {
+func protoAuditEntryToDomain(ctx context.Context, proto *positionkeepingv1.AuditTrailEntry) (*domain.AuditTrailEntry, error) {
 	if proto == nil {
 		return nil, nil //nolint:nilnil // Intentional: nil input returns nil output for optional field handling
 	}
 
-	// TODO: Extract IP address from gRPC context/metadata
-	ipAddress := ""
-
-	// TODO: Extract system context from gRPC context/metadata
-	systemContext := make(map[string]string)
+	ipAddress := extractIPAddress(ctx)
+	systemContext := extractSystemContext(ctx)
 
 	return domain.NewAuditTrailEntry(
 		proto.UserId,
@@ -283,6 +285,80 @@ func protoAuditEntryToDomain(proto *positionkeepingv1.AuditTrailEntry) (*domain.
 	)
 }
 
+// extractIPAddress extracts client IP from gRPC context.
+// Checks x-forwarded-for header first (for proxied requests), then falls back to peer address.
+func extractIPAddress(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+
+	// Check metadata for forwarded IP (common in Kubernetes/Istio environments)
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		// x-forwarded-for may contain multiple IPs (client, proxy1, proxy2...)
+		// First IP is the original client
+		if vals := md.Get("x-forwarded-for"); len(vals) > 0 && vals[0] != "" {
+			// Split on comma and take first IP
+			if ips := strings.Split(vals[0], ","); len(ips) > 0 {
+				return strings.TrimSpace(ips[0])
+			}
+		}
+		// Fallback to x-real-ip header
+		if vals := md.Get("x-real-ip"); len(vals) > 0 && vals[0] != "" {
+			return vals[0]
+		}
+	}
+
+	// Fallback to peer address (direct gRPC connection)
+	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
+		// Extract just the IP portion (peer address may include port like "192.168.1.1:50051")
+		addr := p.Addr.String()
+		if idx := strings.LastIndex(addr, ":"); idx > 0 {
+			return addr[:idx]
+		}
+		return addr
+	}
+
+	return "" // Empty string is acceptable for system operations
+}
+
+// extractSystemContext extracts service metadata from gRPC context.
+// Includes service name, correlation ID, and organization ID for multi-tenant tracking.
+func extractSystemContext(ctx context.Context) map[string]string {
+	systemCtx := map[string]string{
+		"service": "position-keeping",
+	}
+
+	if ctx == nil {
+		return systemCtx
+	}
+
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		// Add correlation ID if present
+		if vals := md.Get("x-correlation-id"); len(vals) > 0 && vals[0] != "" {
+			systemCtx["correlation_id"] = vals[0]
+		}
+		// Also check other common correlation ID header names
+		if _, exists := systemCtx["correlation_id"]; !exists {
+			for _, key := range []string{"correlation-id", "x-request-id", "request-id"} {
+				if vals := md.Get(key); len(vals) > 0 && vals[0] != "" {
+					systemCtx["correlation_id"] = vals[0]
+					break
+				}
+			}
+		}
+		// Add organization ID if present (multi-tenant context)
+		if vals := md.Get("x-org-id"); len(vals) > 0 && vals[0] != "" {
+			systemCtx["organization_id"] = vals[0]
+		}
+		// Add user agent if present
+		if vals := md.Get("user-agent"); len(vals) > 0 && vals[0] != "" {
+			systemCtx["user_agent"] = vals[0]
+		}
+	}
+
+	return systemCtx
+}
+
 // publishUpdateEvents publishes domain events for update operations
 func (s *PositionKeepingService) publishUpdateEvents(
 	ctx context.Context,
@@ -291,13 +367,15 @@ func (s *PositionKeepingService) publishUpdateEvents(
 	newEntryAdded *domain.TransactionLogEntry,
 	statusChanged bool,
 ) {
+	correlationID := clients.ExtractCorrelationID(ctx)
+
 	if newEntryAdded != nil {
 		event := &domain.TransactionAmended{
 			LogID:         log.LogID,
 			AccountID:     log.AccountID,
 			Reason:        "Transaction entry added",
 			AmendedBy:     req.AuditEntry.GetUserId(),
-			CorrelationID: "", // TODO: Extract from context
+			CorrelationID: correlationID,
 			Timestamp:     time.Now().UTC(),
 			Version:       log.Version,
 		}
@@ -305,7 +383,7 @@ func (s *PositionKeepingService) publishUpdateEvents(
 	}
 
 	if statusChanged {
-		s.publishStatusChangeEvent(ctx, log, req)
+		s.publishStatusChangeEvent(ctx, log, req, correlationID)
 	}
 }
 
@@ -314,6 +392,7 @@ func (s *PositionKeepingService) publishStatusChangeEvent(
 	ctx context.Context,
 	log *domain.FinancialPositionLog,
 	req *positionkeepingv1.UpdateFinancialPositionLogRequest,
+	correlationID string,
 ) {
 	switch req.StatusUpdate.CurrentStatus {
 	case commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED:
@@ -323,7 +402,7 @@ func (s *PositionKeepingService) publishStatusChangeEvent(
 			PostingReference: "", // TODO: Add to proto if needed
 			Reason:           req.StatusUpdate.StatusReason,
 			PostedBy:         req.AuditEntry.GetUserId(),
-			CorrelationID:    "",
+			CorrelationID:    correlationID,
 			Timestamp:        time.Now().UTC(),
 			Version:          log.Version,
 		}
@@ -334,7 +413,7 @@ func (s *PositionKeepingService) publishStatusChangeEvent(
 			AccountID:     log.AccountID,
 			FailureReason: req.StatusUpdate.StatusReason,
 			ErrorCode:     "", // TODO: Add to proto if needed
-			CorrelationID: "",
+			CorrelationID: correlationID,
 			Timestamp:     time.Now().UTC(),
 			Version:       log.Version,
 		}
@@ -345,7 +424,7 @@ func (s *PositionKeepingService) publishStatusChangeEvent(
 			AccountID:     log.AccountID,
 			Reason:        req.StatusUpdate.StatusReason,
 			CancelledBy:   req.AuditEntry.GetUserId(),
-			CorrelationID: "",
+			CorrelationID: correlationID,
 			Timestamp:     time.Now().UTC(),
 			Version:       log.Version,
 		}


### PR DESCRIPTION
## Summary
- Replace hardcoded "system" audit trail values with proper context extraction for multi-tenant attribution
- Extract user ID from context using `audit.GetUserFromContext()` across all repository methods
- Implement IP address and system context extraction from gRPC metadata for audit enrichment
- Add correlation ID propagation to domain events for distributed tracing

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 52

## Changes Made

### `postgres_repository.go`
- Import `shared/platform/audit` package
- Replace 7 hardcoded `"system"` strings with `audit.GetUserFromContext(ctx)` in:
  - `Create()` method
  - `CreateBatch()` method  
  - `Update()` method
  - `insertTransactionLogEntries()` helper
  - `insertTransactionLineage()` helper
  - `insertAuditTrailEntries()` helper

### `update.go`
- Add `context.Context` parameter to `protoAuditEntryToDomain()` and `applyStatusTransition()`
- Implement `extractIPAddress(ctx)` - extracts client IP from gRPC context:
  - Checks `x-forwarded-for` header first (handles proxy chains)
  - Falls back to `x-real-ip` header
  - Falls back to peer address
- Implement `extractSystemContext(ctx)` - extracts service metadata:
  - Service name (`position-keeping`)
  - Correlation ID from multiple header variants
  - Organization ID (`x-org-id`)
  - User agent
- Extract correlation ID using `clients.ExtractCorrelationID()` and populate in:
  - `TransactionAmended` event
  - `TransactionPosted` event
  - `TransactionFailed` event
  - `TransactionCancelled` event

## Test Plan
- [x] All existing unit tests pass
- [x] All existing integration tests pass (with testcontainers)
- [x] Build succeeds with no lint errors
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)

## Backward Compatibility
- Graceful fallback to `"system"` for unauthenticated/background operations via `audit.GetUserFromContext()`
- Empty string is acceptable for IP address in system operations
- Empty correlation ID is acceptable when not present in context