### PR TITLE
feat: Add authentication interceptor to all BIAN services

### DIFF
--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -16,6 +18,7 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/clients"
 	"github.com/meridianhub/meridian/services/current-account/service"
 	"github.com/meridianhub/meridian/shared/pkg/interceptors"
+	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -119,17 +122,35 @@ func run(logger *slog.Logger) error {
 
 	logger.Info("service initialized with external clients")
 
+	// Initialize auth interceptor (optional - based on AUTH_ENABLED)
+	authInterceptor, err := initAuth(ctx, logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+
 	// Create gRPC server with interceptor chain
-	// Order: tracing → recovery (recovery last to catch all panics)
+	// Order: tracing → auth → recovery (recovery last to catch all panics)
+	var unaryInterceptors []grpc.UnaryServerInterceptor
+	var streamInterceptors []grpc.StreamServerInterceptor
+
+	// 1. Tracing (always first for full request coverage)
+	unaryInterceptors = append(unaryInterceptors, tracer.UnaryServerInterceptor())
+	streamInterceptors = append(streamInterceptors, tracer.StreamServerInterceptor())
+
+	// 2. Auth (JWT validation with JWKS - optional)
+	if authInterceptor != nil {
+		unaryInterceptors = append(unaryInterceptors, authInterceptor.UnaryInterceptor())
+		streamInterceptors = append(streamInterceptors, authInterceptor.StreamInterceptor())
+		logger.Info("auth interceptor enabled in chain")
+	}
+
+	// 3. Recovery (last in chain to catch all panics)
+	unaryInterceptors = append(unaryInterceptors, interceptors.RecoveryUnaryInterceptor(logger))
+	streamInterceptors = append(streamInterceptors, interceptors.RecoveryStreamInterceptor(logger))
+
 	grpcServer := grpc.NewServer(
-		grpc.ChainUnaryInterceptor(
-			tracer.UnaryServerInterceptor(),
-			interceptors.RecoveryUnaryInterceptor(logger),
-		),
-		grpc.ChainStreamInterceptor(
-			tracer.StreamServerInterceptor(),
-			interceptors.RecoveryStreamInterceptor(logger),
-		),
+		grpc.ChainUnaryInterceptor(unaryInterceptors...),
+		grpc.ChainStreamInterceptor(streamInterceptors...),
 	)
 
 	// Register services
@@ -400,4 +421,96 @@ func createServiceWithClients(
 
 	// Return the service and the clients for use in health checking
 	return svc, resilientPosKeepingClient, resilientFinAcctClient, nil
+}
+
+// getEnvAsBool returns the environment variable value as bool or default
+func getEnvAsBool(key string, defaultValue bool) bool {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	switch strings.ToLower(valueStr) {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	default:
+		return defaultValue
+	}
+}
+
+// initAuth initializes the JWT authentication interceptor if enabled.
+// Returns nil if AUTH_ENABLED is false (default), allowing unauthenticated requests.
+//
+// Environment variables:
+//   - AUTH_ENABLED: Set to "true" to enable JWT authentication (default: false)
+//   - JWKS_URL: JWKS endpoint URL for JWT validation (required when enabled)
+//   - JWKS_CACHE_TTL: How long to cache JWKS keys (default: 1h)
+//   - JWKS_REFRESH_TTL: Background refresh interval for JWKS (default: 30m)
+//   - JWKS_HTTP_TIMEOUT: HTTP client timeout for JWKS fetch (default: 10s)
+//   - MULTI_ORG_MODE: Set to "true" to require organization_id claim in JWT
+//     (read directly by interceptor via auth.MultiOrgModeEnvVar at request time)
+func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, error) {
+	enabled := getEnvAsBool("AUTH_ENABLED", false)
+	if !enabled {
+		logger.Info("auth disabled (set AUTH_ENABLED=true to enable)")
+		return nil, nil //nolint:nilnil // Disabled mode intentionally returns no interceptor and no error
+	}
+
+	// Load JWKS configuration
+	jwksURL := getEnvOrDefault("JWKS_URL", "http://localhost:18080/realms/meridian/protocol/openid-connect/certs")
+	cacheTTL := getEnvAsDuration("JWKS_CACHE_TTL", 1*time.Hour)
+	refreshTTL := getEnvAsDuration("JWKS_REFRESH_TTL", 30*time.Minute)
+
+	// Create JWKS provider with HTTP client
+	httpTimeout := getEnvAsDuration("JWKS_HTTP_TIMEOUT", 10*time.Second)
+	httpClient := &http.Client{
+		Timeout: httpTimeout,
+	}
+	jwksConfig := &auth.JWKSProviderConfig{
+		URL:        jwksURL,
+		Client:     httpClient,
+		CacheTTL:   cacheTTL,
+		RefreshTTL: refreshTTL,
+	}
+
+	provider, err := auth.NewJWKSProvider(ctx, jwksConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWKS provider: %w", err)
+	}
+
+	// Create JWT validator
+	validator, err := auth.NewJWTValidatorWithJWKS(provider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWT validator: %w", err)
+	}
+
+	// Create interceptor with bypass methods for health checks and reflection
+	interceptorConfig := &auth.InterceptorConfig{
+		JWKSValidator: validator,
+		BypassMethods: []string{
+			"/grpc.health.v1.Health/Check",
+			"/grpc.health.v1.Health/Watch",
+			"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+			"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
+		},
+	}
+
+	interceptor, err := auth.NewAuthInterceptor(interceptorConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth interceptor: %w", err)
+	}
+
+	// Log multi-org mode status for visibility.
+	multiOrgMode := getEnvAsBool("MULTI_ORG_MODE", false)
+	logger.Debug("auth interceptor initialized",
+		"jwks_url", jwksURL,
+		"cache_ttl", cacheTTL,
+		"refresh_ttl", refreshTTL,
+		"http_timeout", httpTimeout,
+		"multi_org_mode", multiOrgMode,
+		"bypass_methods", len(interceptorConfig.BypassMethods))
+
+	return interceptor, nil
 }

--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -425,7 +425,7 @@ func createServiceWithClients(
 
 // getEnvAsBool returns the environment variable value as bool or default
 func getEnvAsBool(key string, defaultValue bool) bool {
-	valueStr := os.Getenv(key)
+	valueStr := strings.TrimSpace(os.Getenv(key))
 	if valueStr == "" {
 		return defaultValue
 	}

--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -451,6 +451,10 @@ func getEnvAsBool(key string, defaultValue bool) bool {
 //   - JWKS_HTTP_TIMEOUT: HTTP client timeout for JWKS fetch (default: 10s)
 //   - MULTI_ORG_MODE: Set to "true" to require organization_id claim in JWT
 //     (read directly by interceptor via auth.MultiOrgModeEnvVar at request time)
+//
+// Note: The JWKS provider starts a background refresh goroutine. This follows the
+// existing pattern in other services (e.g., position-keeping) where the provider
+// is not explicitly closed during shutdown, relying on process termination.
 func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, error) {
 	enabled := getEnvAsBool("AUTH_ENABLED", false)
 	if !enabled {

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/meridianhub/meridian/services/financial-accounting/service"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/pkg/interceptors"
+	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
@@ -143,17 +145,35 @@ func run(logger *slog.Logger) error {
 	logger.Info("financial accounting service initialized")
 	_ = postingService // Available for internal use
 
+	// Initialize auth interceptor (optional - based on AUTH_ENABLED)
+	authInterceptor, err := initAuth(ctx, logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+
 	// Create gRPC server with interceptor chain
-	// Order: tracing → recovery (recovery last to catch all panics)
+	// Order: tracing → auth → recovery (recovery last to catch all panics)
+	var unaryInterceptors []grpc.UnaryServerInterceptor
+	var streamInterceptors []grpc.StreamServerInterceptor
+
+	// 1. Tracing (always first for full request coverage)
+	unaryInterceptors = append(unaryInterceptors, tracer.UnaryServerInterceptor())
+	streamInterceptors = append(streamInterceptors, tracer.StreamServerInterceptor())
+
+	// 2. Auth (JWT validation with JWKS - optional)
+	if authInterceptor != nil {
+		unaryInterceptors = append(unaryInterceptors, authInterceptor.UnaryInterceptor())
+		streamInterceptors = append(streamInterceptors, authInterceptor.StreamInterceptor())
+		logger.Info("auth interceptor enabled in chain")
+	}
+
+	// 3. Recovery (last in chain to catch all panics)
+	unaryInterceptors = append(unaryInterceptors, interceptors.RecoveryUnaryInterceptor(logger))
+	streamInterceptors = append(streamInterceptors, interceptors.RecoveryStreamInterceptor(logger))
+
 	grpcServer := grpc.NewServer(
-		grpc.ChainUnaryInterceptor(
-			tracer.UnaryServerInterceptor(),
-			interceptors.RecoveryUnaryInterceptor(logger),
-		),
-		grpc.ChainStreamInterceptor(
-			tracer.StreamServerInterceptor(),
-			interceptors.RecoveryStreamInterceptor(logger),
-		),
+		grpc.ChainUnaryInterceptor(unaryInterceptors...),
+		grpc.ChainStreamInterceptor(streamInterceptors...),
 	)
 
 	// Register Financial Accounting gRPC service
@@ -432,4 +452,96 @@ func (p *noopEventPublisher) Publish(_ context.Context, _ service.DomainEvent) e
 
 func (p *noopEventPublisher) PublishBatch(_ context.Context, _ []service.DomainEvent) error {
 	return nil
+}
+
+// getEnvAsBool returns the environment variable value as bool or default
+func getEnvAsBool(key string, defaultValue bool) bool {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	switch strings.ToLower(valueStr) {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	default:
+		return defaultValue
+	}
+}
+
+// initAuth initializes the JWT authentication interceptor if enabled.
+// Returns nil if AUTH_ENABLED is false (default), allowing unauthenticated requests.
+//
+// Environment variables:
+//   - AUTH_ENABLED: Set to "true" to enable JWT authentication (default: false)
+//   - JWKS_URL: JWKS endpoint URL for JWT validation (required when enabled)
+//   - JWKS_CACHE_TTL: How long to cache JWKS keys (default: 1h)
+//   - JWKS_REFRESH_TTL: Background refresh interval for JWKS (default: 30m)
+//   - JWKS_HTTP_TIMEOUT: HTTP client timeout for JWKS fetch (default: 10s)
+//   - MULTI_ORG_MODE: Set to "true" to require organization_id claim in JWT
+//     (read directly by interceptor via auth.MultiOrgModeEnvVar at request time)
+func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, error) {
+	enabled := getEnvAsBool("AUTH_ENABLED", false)
+	if !enabled {
+		logger.Info("auth disabled (set AUTH_ENABLED=true to enable)")
+		return nil, nil //nolint:nilnil // Disabled mode intentionally returns no interceptor and no error
+	}
+
+	// Load JWKS configuration
+	jwksURL := getEnvOrDefault("JWKS_URL", "http://localhost:18080/realms/meridian/protocol/openid-connect/certs")
+	cacheTTL := getEnvAsDuration("JWKS_CACHE_TTL", 1*time.Hour)
+	refreshTTL := getEnvAsDuration("JWKS_REFRESH_TTL", 30*time.Minute)
+
+	// Create JWKS provider with HTTP client
+	httpTimeout := getEnvAsDuration("JWKS_HTTP_TIMEOUT", 10*time.Second)
+	httpClient := &http.Client{
+		Timeout: httpTimeout,
+	}
+	jwksConfig := &auth.JWKSProviderConfig{
+		URL:        jwksURL,
+		Client:     httpClient,
+		CacheTTL:   cacheTTL,
+		RefreshTTL: refreshTTL,
+	}
+
+	provider, err := auth.NewJWKSProvider(ctx, jwksConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWKS provider: %w", err)
+	}
+
+	// Create JWT validator
+	validator, err := auth.NewJWTValidatorWithJWKS(provider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWT validator: %w", err)
+	}
+
+	// Create interceptor with bypass methods for health checks and reflection
+	interceptorConfig := &auth.InterceptorConfig{
+		JWKSValidator: validator,
+		BypassMethods: []string{
+			"/grpc.health.v1.Health/Check",
+			"/grpc.health.v1.Health/Watch",
+			"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+			"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
+		},
+	}
+
+	interceptor, err := auth.NewAuthInterceptor(interceptorConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth interceptor: %w", err)
+	}
+
+	// Log multi-org mode status for visibility.
+	multiOrgMode := getEnvAsBool("MULTI_ORG_MODE", false)
+	logger.Debug("auth interceptor initialized",
+		"jwks_url", jwksURL,
+		"cache_ttl", cacheTTL,
+		"refresh_ttl", refreshTTL,
+		"http_timeout", httpTimeout,
+		"multi_org_mode", multiOrgMode,
+		"bypass_methods", len(interceptorConfig.BypassMethods))
+
+	return interceptor, nil
 }

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -482,6 +482,10 @@ func getEnvAsBool(key string, defaultValue bool) bool {
 //   - JWKS_HTTP_TIMEOUT: HTTP client timeout for JWKS fetch (default: 10s)
 //   - MULTI_ORG_MODE: Set to "true" to require organization_id claim in JWT
 //     (read directly by interceptor via auth.MultiOrgModeEnvVar at request time)
+//
+// Note: The JWKS provider starts a background refresh goroutine. This follows the
+// existing pattern in other services (e.g., position-keeping) where the provider
+// is not explicitly closed during shutdown, relying on process termination.
 func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, error) {
 	enabled := getEnvAsBool("AUTH_ENABLED", false)
 	if !enabled {

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -456,7 +456,7 @@ func (p *noopEventPublisher) PublishBatch(_ context.Context, _ []service.DomainE
 
 // getEnvAsBool returns the environment variable value as bool or default
 func getEnvAsBool(key string, defaultValue bool) bool {
-	valueStr := os.Getenv(key)
+	valueStr := strings.TrimSpace(os.Getenv(key))
 	if valueStr == "" {
 		return defaultValue
 	}

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -20,6 +22,7 @@ import (
 	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
 	"github.com/meridianhub/meridian/services/payment-order/service"
 	"github.com/meridianhub/meridian/shared/pkg/interceptors"
+	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/kafka"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
@@ -134,17 +137,35 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("failed to create payment order service: %w", err)
 	}
 
+	// Initialize auth interceptor (optional - based on AUTH_ENABLED)
+	authInterceptor, err := initAuth(ctx, logger)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+
 	// Create gRPC server with interceptor chain
-	// Order: tracing → recovery (recovery last to catch all panics)
+	// Order: tracing → auth → recovery (recovery last to catch all panics)
+	var unaryInterceptors []grpc.UnaryServerInterceptor
+	var streamInterceptors []grpc.StreamServerInterceptor
+
+	// 1. Tracing (always first for full request coverage)
+	unaryInterceptors = append(unaryInterceptors, tracer.UnaryServerInterceptor())
+	streamInterceptors = append(streamInterceptors, tracer.StreamServerInterceptor())
+
+	// 2. Auth (JWT validation with JWKS - optional)
+	if authInterceptor != nil {
+		unaryInterceptors = append(unaryInterceptors, authInterceptor.UnaryInterceptor())
+		streamInterceptors = append(streamInterceptors, authInterceptor.StreamInterceptor())
+		logger.Info("auth interceptor enabled in chain")
+	}
+
+	// 3. Recovery (last in chain to catch all panics)
+	unaryInterceptors = append(unaryInterceptors, interceptors.RecoveryUnaryInterceptor(logger))
+	streamInterceptors = append(streamInterceptors, interceptors.RecoveryStreamInterceptor(logger))
+
 	grpcServer := grpc.NewServer(
-		grpc.ChainUnaryInterceptor(
-			tracer.UnaryServerInterceptor(),
-			interceptors.RecoveryUnaryInterceptor(logger),
-		),
-		grpc.ChainStreamInterceptor(
-			tracer.StreamServerInterceptor(),
-			interceptors.RecoveryStreamInterceptor(logger),
-		),
+		grpc.ChainUnaryInterceptor(unaryInterceptors...),
+		grpc.ChainStreamInterceptor(streamInterceptors...),
 	)
 
 	// Register gRPC services
@@ -514,4 +535,96 @@ func getEnvAsDuration(key string, defaultValue time.Duration) time.Duration {
 		return defaultValue
 	}
 	return value
+}
+
+// getEnvAsBool returns the environment variable value as bool or default
+func getEnvAsBool(key string, defaultValue bool) bool {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	switch strings.ToLower(valueStr) {
+	case "true", "1", "yes":
+		return true
+	case "false", "0", "no":
+		return false
+	default:
+		return defaultValue
+	}
+}
+
+// initAuth initializes the JWT authentication interceptor if enabled.
+// Returns nil if AUTH_ENABLED is false (default), allowing unauthenticated requests.
+//
+// Environment variables:
+//   - AUTH_ENABLED: Set to "true" to enable JWT authentication (default: false)
+//   - JWKS_URL: JWKS endpoint URL for JWT validation (required when enabled)
+//   - JWKS_CACHE_TTL: How long to cache JWKS keys (default: 1h)
+//   - JWKS_REFRESH_TTL: Background refresh interval for JWKS (default: 30m)
+//   - JWKS_HTTP_TIMEOUT: HTTP client timeout for JWKS fetch (default: 10s)
+//   - MULTI_ORG_MODE: Set to "true" to require organization_id claim in JWT
+//     (read directly by interceptor via auth.MultiOrgModeEnvVar at request time)
+func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, error) {
+	enabled := getEnvAsBool("AUTH_ENABLED", false)
+	if !enabled {
+		logger.Info("auth disabled (set AUTH_ENABLED=true to enable)")
+		return nil, nil //nolint:nilnil // Disabled mode intentionally returns no interceptor and no error
+	}
+
+	// Load JWKS configuration
+	jwksURL := getEnvOrDefault("JWKS_URL", "http://localhost:18080/realms/meridian/protocol/openid-connect/certs")
+	cacheTTL := getEnvAsDuration("JWKS_CACHE_TTL", 1*time.Hour)
+	refreshTTL := getEnvAsDuration("JWKS_REFRESH_TTL", 30*time.Minute)
+
+	// Create JWKS provider with HTTP client
+	httpTimeout := getEnvAsDuration("JWKS_HTTP_TIMEOUT", 10*time.Second)
+	httpClient := &http.Client{
+		Timeout: httpTimeout,
+	}
+	jwksConfig := &auth.JWKSProviderConfig{
+		URL:        jwksURL,
+		Client:     httpClient,
+		CacheTTL:   cacheTTL,
+		RefreshTTL: refreshTTL,
+	}
+
+	provider, err := auth.NewJWKSProvider(ctx, jwksConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWKS provider: %w", err)
+	}
+
+	// Create JWT validator
+	validator, err := auth.NewJWTValidatorWithJWKS(provider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create JWT validator: %w", err)
+	}
+
+	// Create interceptor with bypass methods for health checks and reflection
+	interceptorConfig := &auth.InterceptorConfig{
+		JWKSValidator: validator,
+		BypassMethods: []string{
+			"/grpc.health.v1.Health/Check",
+			"/grpc.health.v1.Health/Watch",
+			"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+			"/grpc.reflection.v1.ServerReflection/ServerReflectionInfo",
+		},
+	}
+
+	interceptor, err := auth.NewAuthInterceptor(interceptorConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create auth interceptor: %w", err)
+	}
+
+	// Log multi-org mode status for visibility.
+	multiOrgMode := getEnvAsBool("MULTI_ORG_MODE", false)
+	logger.Debug("auth interceptor initialized",
+		"jwks_url", jwksURL,
+		"cache_ttl", cacheTTL,
+		"refresh_ttl", refreshTTL,
+		"http_timeout", httpTimeout,
+		"multi_org_mode", multiOrgMode,
+		"bypass_methods", len(interceptorConfig.BypassMethods))
+
+	return interceptor, nil
 }

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -565,6 +565,10 @@ func getEnvAsBool(key string, defaultValue bool) bool {
 //   - JWKS_HTTP_TIMEOUT: HTTP client timeout for JWKS fetch (default: 10s)
 //   - MULTI_ORG_MODE: Set to "true" to require organization_id claim in JWT
 //     (read directly by interceptor via auth.MultiOrgModeEnvVar at request time)
+//
+// Note: The JWKS provider starts a background refresh goroutine. This follows the
+// existing pattern in other services (e.g., position-keeping) where the provider
+// is not explicitly closed during shutdown, relying on process termination.
 func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, error) {
 	enabled := getEnvAsBool("AUTH_ENABLED", false)
 	if !enabled {

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -539,7 +539,7 @@ func getEnvAsDuration(key string, defaultValue time.Duration) time.Duration {
 
 // getEnvAsBool returns the environment variable value as bool or default
 func getEnvAsBool(key string, defaultValue bool) bool {
-	valueStr := os.Getenv(key)
+	valueStr := strings.TrimSpace(os.Getenv(key))
 	if valueStr == "" {
 		return defaultValue
 	}


### PR DESCRIPTION
## Summary
- Add JWT authentication interceptor (with JWKS support) to Current Account, Payment Order, and Financial Accounting services
- Ensures consistent authentication across all BIAN services, closing security gap identified in Task 49
- Auth is disabled by default (`AUTH_ENABLED=false`) for backward compatibility

## Task Master Reference
- **Tag**: 8-multi-tenancy  
- **Task ID**: 49

## Changes Made
- Added `initAuth()` function to each service's `cmd/main.go`
- Updated gRPC server interceptor chain: tracing → auth → recovery
- Added `getEnvAsBool()` helper function for environment variable parsing
- Configured bypass methods for health checks and reflection endpoints

### Services Updated
- `services/current-account/cmd/main.go`
- `services/payment-order/cmd/main.go`
- `services/financial-accounting/cmd/main.go`

### Services Already Configured (verified)
- Party Service ✅
- Position Keeping Service ✅
- Tenant Service (skip - bootstrap service)

## Test Plan
- [x] Build succeeds for all three services
- [x] Unit tests pass
- [x] Linting passes (golangci-lint)
- [ ] Integration test: Request without auth → expect `codes.Unauthenticated` (when `AUTH_ENABLED=true`)
- [ ] Integration test: Request with valid JWT → success
- [ ] Regression test: Existing functionality works with auth disabled (default)

## Environment Variables
When `AUTH_ENABLED=true`, these are available:
- `JWKS_URL` - JWKS endpoint URL (default: local Keycloak)
- `JWKS_CACHE_TTL` - Cache TTL (default: 1h)
- `JWKS_REFRESH_TTL` - Refresh interval (default: 30m)
- `JWKS_HTTP_TIMEOUT` - HTTP timeout (default: 10s)
- `MULTI_ORG_MODE` - Require organization_id claim (default: false)