### PR TITLE
feat(tenant): Integrate schema provisioning into InitiateTenant workflow

### DIFF
--- a/api/proto/meridian/tenant/v1/tenant.proto
+++ b/api/proto/meridian/tenant/v1/tenant.proto
@@ -58,6 +58,10 @@ enum TenantStatus {
   TENANT_STATUS_SUSPENDED = 2;
   // TENANT_STATUS_DEPROVISIONED means the tenant has been deprovisioned.
   TENANT_STATUS_DEPROVISIONED = 3;
+  // TENANT_STATUS_PROVISIONING means the tenant is being provisioned (schemas being created).
+  TENANT_STATUS_PROVISIONING = 4;
+  // TENANT_STATUS_PROVISIONING_FAILED means schema provisioning failed.
+  TENANT_STATUS_PROVISIONING_FAILED = 5;
 }
 
 // Tenant represents a platform tenant for multi-tenant infrastructure.
@@ -114,6 +118,10 @@ message Tenant {
     pattern: "^[a-zA-Z0-9_-]*$"
     max_len: 100
   }];
+
+  // error_message contains details if status is PROVISIONING_FAILED.
+  // Empty string for successfully provisioned tenants.
+  string error_message = 11 [(buf.validate.field).string = {max_len: 2000}];
 }
 
 // InitiateTenantRequest is the request to create a new tenant (BIAN: Initiate).
@@ -170,6 +178,8 @@ message RetrieveTenantResponse {
 // This operation uses optimistic locking. If the tenant was modified by another request,
 // an ABORTED error is returned. Clients should retry the operation in this case.
 // Valid status transitions:
+//   - provisioning -> active, provisioning_failed
+//   - provisioning_failed -> provisioning (retry)
 //   - active -> suspended, deprovisioned
 //   - suspended -> active, deprovisioned
 //   - deprovisioned -> (none, terminal state)

--- a/cmd/tenantctl/cmd/list.go
+++ b/cmd/tenantctl/cmd/list.go
@@ -135,6 +135,10 @@ func parseStatus(s string) (tenantv1.TenantStatus, error) {
 // formatStatus converts protobuf TenantStatus to a display string.
 func formatStatus(s tenantv1.TenantStatus) string {
 	switch s {
+	case tenantv1.TenantStatus_TENANT_STATUS_PROVISIONING:
+		return "provisioning"
+	case tenantv1.TenantStatus_TENANT_STATUS_PROVISIONING_FAILED:
+		return "provisioning_failed"
 	case tenantv1.TenantStatus_TENANT_STATUS_ACTIVE:
 		return "active"
 	case tenantv1.TenantStatus_TENANT_STATUS_SUSPENDED:

--- a/services/tenant/adapters/persistence/entity.go
+++ b/services/tenant/adapters/persistence/entity.go
@@ -18,12 +18,13 @@ type TenantEntity struct {
 	DisplayName     string     `gorm:"column:display_name;not null"`
 	SettlementAsset string     `gorm:"column:settlement_asset;not null"`
 	Subdomain       *string    `gorm:"column:subdomain;uniqueIndex:idx_tenants_subdomain"`
-	Status          string     `gorm:"column:status;not null;default:active"`
+	Status          string     `gorm:"column:status;not null;default:provisioning"`
 	CreatedAt       time.Time  `gorm:"column:created_at;not null;autoCreateTime;index:idx_tenants_created_at,sort:desc"`
 	DeprovisionedAt *time.Time `gorm:"column:deprovisioned_at"`
 	Metadata        JSONMap    `gorm:"column:metadata;type:jsonb;default:'{}'"`
 	Version         int        `gorm:"column:version;not null;default:1"`
 	PartyID         *string    `gorm:"column:party_id;index:idx_tenants_party_id"`
+	ErrorMessage    *string    `gorm:"column:error_message"`
 }
 
 // TableName returns the table name for GORM.

--- a/services/tenant/adapters/persistence/repository.go
+++ b/services/tenant/adapters/persistence/repository.go
@@ -111,6 +111,47 @@ func (r *Repository) UpdateStatus(ctx context.Context, id organization.Organizat
 		updates["deprovisioned_at"] = &now
 	}
 
+	// Clear error message when status is not a failure state
+	if status != domain.StatusProvisioningFailed {
+		updates["error_message"] = nil
+	}
+
+	result := r.db.WithContext(ctx).
+		Model(&TenantEntity{}).
+		Where("id = ? AND version = ?", id.String(), currentVersion).
+		Updates(updates)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		// Check if tenant exists
+		var count int64
+		r.db.WithContext(ctx).
+			Model(&TenantEntity{}).
+			Where("id = ?", id.String()).
+			Count(&count)
+
+		if count == 0 {
+			return nil, ErrTenantNotFound
+		}
+		return nil, ErrVersionConflict
+	}
+
+	// Fetch and return the updated tenant
+	return r.GetByID(ctx, id)
+}
+
+// UpdateStatusWithError changes the tenant status and sets an error message.
+// Used for recording provisioning failures.
+func (r *Repository) UpdateStatusWithError(ctx context.Context, id organization.OrganizationID, status domain.Status, errorMessage string, currentVersion int) (*domain.Tenant, error) {
+	updates := map[string]interface{}{
+		"status":        status,
+		"error_message": errorMessage,
+		"version":       currentVersion + 1,
+	}
+
 	result := r.db.WithContext(ctx).
 		Model(&TenantEntity{}).
 		Where("id = ? AND version = ?", id.String(), currentVersion).
@@ -235,6 +276,10 @@ func toEntity(tenant *domain.Tenant) *TenantEntity {
 		entity.PartyID = &tenant.PartyID
 	}
 
+	if tenant.ErrorMessage != "" {
+		entity.ErrorMessage = &tenant.ErrorMessage
+	}
+
 	return entity
 }
 
@@ -262,6 +307,10 @@ func toDomain(entity *TenantEntity) (*domain.Tenant, error) {
 
 	if entity.PartyID != nil {
 		tenant.PartyID = *entity.PartyID
+	}
+
+	if entity.ErrorMessage != nil {
+		tenant.ErrorMessage = *entity.ErrorMessage
 	}
 
 	return tenant, nil

--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
 	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
 	"github.com/meridianhub/meridian/services/tenant/clients"
+	"github.com/meridianhub/meridian/services/tenant/provisioner"
 	"github.com/meridianhub/meridian/services/tenant/service"
 	"github.com/meridianhub/meridian/shared/pkg/interceptors"
 	"github.com/meridianhub/meridian/shared/platform/observability"
@@ -96,6 +97,24 @@ func run(logger *slog.Logger) error {
 	// Create repository
 	repo := persistence.NewRepository(db)
 
+	// Initialize schema provisioner (optional - skipped if SCHEMA_PROVISIONING_ENABLED is not "true")
+	var schemaProvisioner provisioner.SchemaProvisioner
+	provisioningEnabled := getEnvOrDefault("SCHEMA_PROVISIONING_ENABLED", "false")
+	if provisioningEnabled == "true" {
+		config := provisioner.DefaultConfig()
+		prov, err := provisioner.NewPostgresProvisioner(db, config)
+		if err != nil {
+			return fmt.Errorf("failed to create schema provisioner: %w", err)
+		}
+		schemaProvisioner = prov
+		logger.Info("schema provisioner initialized",
+			"services", len(config.Services),
+			"provisioning_timeout", config.ProvisioningTimeout)
+	} else {
+		logger.Warn("schema provisioning not enabled - tenant creation will not provision schemas",
+			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable schema provisioning")
+	}
+
 	// Initialize Party client (optional - skipped if PARTY_SERVICE_TARGET not set)
 	var partyClient clients.PartyClient
 	partyTarget := getEnvOrDefault("PARTY_SERVICE_TARGET", "")
@@ -121,7 +140,7 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Create gRPC service
-	tenantService := service.NewService(repo, partyClient, logger)
+	tenantService := service.NewService(repo, schemaProvisioner, partyClient, logger)
 
 	// Create cached registry for validation middleware
 	cachedRegistry := service.NewCachedRegistry(repo, service.CachedRegistryConfig{

--- a/services/tenant/domain/tenant.go
+++ b/services/tenant/domain/tenant.go
@@ -11,6 +11,10 @@ import (
 type Status string
 
 const (
+	// StatusProvisioning means the tenant is being provisioned (schemas being created).
+	StatusProvisioning Status = "provisioning"
+	// StatusProvisioningFailed means schema provisioning failed.
+	StatusProvisioningFailed Status = "provisioning_failed"
 	// StatusActive means the tenant is active and can operate.
 	StatusActive Status = "active"
 	// StatusSuspended means the tenant is temporarily suspended.
@@ -22,7 +26,7 @@ const (
 // IsValid returns true if the status is a valid tenant status.
 func (s Status) IsValid() bool {
 	switch s {
-	case StatusActive, StatusSuspended, StatusDeprovisioned:
+	case StatusProvisioning, StatusProvisioningFailed, StatusActive, StatusSuspended, StatusDeprovisioned:
 		return true
 	default:
 		return false
@@ -66,6 +70,10 @@ type Tenant struct {
 	// Automatically populated when the tenant is created via PartyService.RegisterParty.
 	// This links platform infrastructure (Tenant) to BIAN domain entities (Party.Organization).
 	PartyID string
+
+	// ErrorMessage contains details if Status is provisioning_failed.
+	// Empty string for successfully provisioned tenants.
+	ErrorMessage string
 }
 
 // IsActive returns true if the tenant is in active status.
@@ -87,6 +95,8 @@ func (t *Tenant) SchemaName() string {
 
 // CanTransitionTo returns true if the tenant can transition to the given status.
 // Valid transitions:
+//   - provisioning → active, provisioning_failed
+//   - provisioning_failed → provisioning (retry)
 //   - active → suspended, deprovisioned
 //   - suspended → active, deprovisioned
 //   - deprovisioned → (none, terminal state)
@@ -96,6 +106,10 @@ func (t *Tenant) CanTransitionTo(newStatus Status) bool {
 	}
 
 	switch t.Status {
+	case StatusProvisioning:
+		return newStatus == StatusActive || newStatus == StatusProvisioningFailed
+	case StatusProvisioningFailed:
+		return newStatus == StatusProvisioning // Allow retry
 	case StatusActive:
 		return newStatus == StatusSuspended || newStatus == StatusDeprovisioned
 	case StatusSuspended:

--- a/services/tenant/service/grpc_service.go
+++ b/services/tenant/service/grpc_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
 	"github.com/meridianhub/meridian/services/tenant/clients"
 	"github.com/meridianhub/meridian/services/tenant/domain"
+	"github.com/meridianhub/meridian/services/tenant/provisioner"
 	"github.com/meridianhub/meridian/shared/platform/organization"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -26,21 +27,25 @@ var ErrUnknownStatus = errors.New("unspecified or unknown tenant status")
 type Service struct {
 	pb.UnimplementedTenantServiceServer
 	repo        *persistence.Repository
+	provisioner provisioner.SchemaProvisioner
 	partyClient clients.PartyClient
 	logger      *slog.Logger
 }
 
 // NewService creates a new TenantService.
+// The provisioner parameter is optional; if nil, schema provisioning is skipped during tenant creation.
 // The partyClient parameter is optional; if nil, party registration is skipped during tenant creation.
-func NewService(repo *persistence.Repository, partyClient clients.PartyClient, logger *slog.Logger) *Service {
+func NewService(repo *persistence.Repository, prov provisioner.SchemaProvisioner, partyClient clients.PartyClient, logger *slog.Logger) *Service {
 	return &Service{
 		repo:        repo,
+		provisioner: prov,
 		partyClient: partyClient,
 		logger:      logger,
 	}
 }
 
 // InitiateTenant creates a new tenant in the platform registry (BIAN: Initiate).
+// If a provisioner is configured, this also provisions schemas for the tenant.
 // If a Party client is configured, this also registers a corresponding Party in the
 // BIAN Party Reference Data Directory, establishing the link between platform
 // infrastructure (Tenant) and BIAN domain entities (Party.Organization).
@@ -57,13 +62,19 @@ func (s *Service) InitiateTenant(ctx context.Context, req *pb.InitiateTenantRequ
 		metadata = req.Metadata.AsMap()
 	}
 
+	// Determine initial status based on whether provisioning is configured
+	initialStatus := domain.StatusActive
+	if s.provisioner != nil {
+		initialStatus = domain.StatusProvisioning
+	}
+
 	// Create domain tenant
 	tenant := &domain.Tenant{
 		ID:              tenantID,
 		DisplayName:     req.DisplayName,
 		SettlementAsset: req.SettlementAsset,
 		Subdomain:       req.Subdomain,
-		Status:          domain.StatusActive,
+		Status:          initialStatus,
 		CreatedAt:       time.Now(),
 		Metadata:        metadata,
 		Version:         1,
@@ -97,7 +108,7 @@ func (s *Service) InitiateTenant(ctx context.Context, req *pb.InitiateTenantRequ
 			"tenant_id", req.TenantId)
 	}
 
-	// Persist tenant
+	// Persist tenant with initial status (provisioning or active)
 	if err := s.repo.Create(ctx, tenant); err != nil {
 		if errors.Is(err, persistence.ErrTenantExists) {
 			return nil, status.Errorf(codes.AlreadyExists, "tenant %s already exists", req.TenantId)
@@ -115,7 +126,50 @@ func (s *Service) InitiateTenant(ctx context.Context, req *pb.InitiateTenantRequ
 		"tenant_id", tenant.ID.String(),
 		"display_name", tenant.DisplayName,
 		"settlement_asset", tenant.SettlementAsset,
+		"status", tenant.Status,
 		"party_id", tenant.PartyID)
+
+	// Provision schemas if provisioner is configured
+	if s.provisioner != nil {
+		s.logger.Info("provisioning schemas for tenant",
+			"tenant_id", tenant.ID.String())
+
+		provErr := s.provisioner.ProvisionSchemas(ctx, tenant.ID)
+		if provErr != nil {
+			// Mark tenant as provisioning_failed
+			s.logger.Error("schema provisioning failed",
+				"tenant_id", tenant.ID.String(),
+				"error", provErr)
+
+			_, updateErr := s.repo.UpdateStatusWithError(ctx, tenant.ID, domain.StatusProvisioningFailed, provErr.Error(), tenant.Version)
+			if updateErr != nil {
+				s.logger.Error("failed to update tenant status after provisioning failure",
+					"tenant_id", tenant.ID.String(),
+					"error", updateErr)
+			}
+
+			// Update local tenant state for response
+			tenant.Status = domain.StatusProvisioningFailed
+			tenant.ErrorMessage = provErr.Error()
+			tenant.Version++
+
+			return nil, status.Errorf(codes.Internal, "schema provisioning failed: %v", provErr)
+		}
+
+		// Activate tenant after successful provisioning
+		updatedTenant, updateErr := s.repo.UpdateStatus(ctx, tenant.ID, domain.StatusActive, tenant.Version)
+		if updateErr != nil {
+			s.logger.Error("failed to activate tenant after provisioning",
+				"tenant_id", tenant.ID.String(),
+				"error", updateErr)
+			return nil, status.Errorf(codes.Internal, "failed to activate tenant after provisioning")
+		}
+
+		tenant = updatedTenant
+		s.logger.Info("tenant provisioned and activated",
+			"tenant_id", tenant.ID.String(),
+			"status", tenant.Status)
+	}
 
 	return &pb.InitiateTenantResponse{
 		Tenant: s.toProto(tenant),
@@ -249,6 +303,7 @@ func (s *Service) toProto(tenant *domain.Tenant) *pb.Tenant {
 		CreatedAt:       timestamppb.New(tenant.CreatedAt),
 		Version:         int32(tenant.Version),
 		PartyId:         tenant.PartyID,
+		ErrorMessage:    tenant.ErrorMessage,
 	}
 
 	if tenant.DeprovisionedAt != nil {
@@ -267,6 +322,10 @@ func (s *Service) toProto(tenant *domain.Tenant) *pb.Tenant {
 // toProtoStatus converts domain status to protobuf status.
 func (s *Service) toProtoStatus(status domain.Status) pb.TenantStatus {
 	switch status {
+	case domain.StatusProvisioning:
+		return pb.TenantStatus_TENANT_STATUS_PROVISIONING
+	case domain.StatusProvisioningFailed:
+		return pb.TenantStatus_TENANT_STATUS_PROVISIONING_FAILED
 	case domain.StatusActive:
 		return pb.TenantStatus_TENANT_STATUS_ACTIVE
 	case domain.StatusSuspended:
@@ -281,6 +340,10 @@ func (s *Service) toProtoStatus(status domain.Status) pb.TenantStatus {
 // toDomainStatus converts protobuf status to domain status.
 func (s *Service) toDomainStatus(status pb.TenantStatus) (domain.Status, error) {
 	switch status {
+	case pb.TenantStatus_TENANT_STATUS_PROVISIONING:
+		return domain.StatusProvisioning, nil
+	case pb.TenantStatus_TENANT_STATUS_PROVISIONING_FAILED:
+		return domain.StatusProvisioningFailed, nil
 	case pb.TenantStatus_TENANT_STATUS_ACTIVE:
 		return domain.StatusActive, nil
 	case pb.TenantStatus_TENANT_STATUS_SUSPENDED:

--- a/services/tenant/service/grpc_service_test.go
+++ b/services/tenant/service/grpc_service_test.go
@@ -11,6 +11,7 @@ import (
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
 	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
+	"github.com/meridianhub/meridian/services/tenant/provisioner"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,8 +26,8 @@ func setupTest(t *testing.T) (*Service, *gorm.DB, func()) {
 	db, cleanup := testdb.SetupPostgres(t, []interface{}{&persistence.TenantEntity{}})
 	repo := persistence.NewRepository(db)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	// Pass nil for partyClient - party registration is skipped in tests without Party service
-	svc := NewService(repo, nil, logger)
+	// Pass nil for provisioner and partyClient - skipped in basic tests
+	svc := NewService(repo, nil, nil, logger)
 	return svc, db, cleanup
 }
 
@@ -402,7 +403,16 @@ func setupTestWithPartyClient(t *testing.T, partyClient *mockPartyClient) (*Serv
 	db, cleanup := testdb.SetupPostgres(t, []interface{}{&persistence.TenantEntity{}})
 	repo := persistence.NewRepository(db)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	svc := NewService(repo, partyClient, logger)
+	svc := NewService(repo, nil, partyClient, logger)
+	return svc, db, cleanup
+}
+
+func setupTestWithProvisioner(t *testing.T, mockProv *provisioner.MockProvisioner) (*Service, *gorm.DB, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{&persistence.TenantEntity{}})
+	repo := persistence.NewRepository(db)
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	svc := NewService(repo, mockProv, nil, logger)
 	return svc, db, cleanup
 }
 
@@ -468,4 +478,95 @@ func TestService_InitiateTenant_PartyRegistrationFailure(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
 	assert.Contains(t, st.Message(), "failed to register party")
+}
+
+// Tests for schema provisioning integration
+
+func TestService_InitiateTenant_WithProvisioningSuccess(t *testing.T) {
+	// Create mock provisioner that succeeds
+	mockProv := provisioner.NewMockProvisioner([]provisioner.ServiceConfig{
+		{Name: "party", MigrationPath: "testdata/migrations"},
+		{Name: "current-account", MigrationPath: "testdata/migrations"},
+	})
+
+	svc, _, cleanup := setupTestWithProvisioner(t, mockProv)
+	defer cleanup()
+
+	ctx := context.Background()
+	req := &pb.InitiateTenantRequest{
+		TenantId:        "provisioned_tenant",
+		DisplayName:     "Provisioned Tenant",
+		SettlementAsset: "GBP",
+	}
+
+	resp, err := svc.InitiateTenant(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Tenant)
+
+	// Tenant should be active after successful provisioning
+	assert.Equal(t, "provisioned_tenant", resp.Tenant.TenantId)
+	assert.Equal(t, pb.TenantStatus_TENANT_STATUS_ACTIVE, resp.Tenant.Status)
+	assert.Equal(t, int32(2), resp.Tenant.Version) // Created with version 1, updated to active (version 2)
+
+	// Verify provisioner was called
+	require.Len(t, mockProv.ProvisioningCalls, 1)
+	assert.Equal(t, "provisioned_tenant", mockProv.ProvisioningCalls[0].String())
+}
+
+// errProvisioningFailed is a test error for simulating provisioning failures.
+var errProvisioningFailed = errors.New("provisioning failed: database connection error")
+
+func TestService_InitiateTenant_WithProvisioningFailure(t *testing.T) {
+	// Create mock provisioner that fails
+	mockProv := provisioner.NewMockProvisioner([]provisioner.ServiceConfig{
+		{Name: "party", MigrationPath: "testdata/migrations"},
+	})
+	mockProv.FailProvisioningFor["prov_fail_tenant"] = errProvisioningFailed
+
+	svc, db, cleanup := setupTestWithProvisioner(t, mockProv)
+	defer cleanup()
+
+	ctx := context.Background()
+	req := &pb.InitiateTenantRequest{
+		TenantId:        "prov_fail_tenant",
+		DisplayName:     "Provisioning Fail Tenant",
+		SettlementAsset: "GBP",
+	}
+
+	_, err := svc.InitiateTenant(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "schema provisioning failed")
+
+	// Verify the tenant was created with provisioning_failed status
+	var entity persistence.TenantEntity
+	result := db.Where("id = ?", "prov_fail_tenant").First(&entity)
+	require.NoError(t, result.Error)
+	assert.Equal(t, "provisioning_failed", entity.Status)
+	require.NotNil(t, entity.ErrorMessage)
+	assert.Contains(t, *entity.ErrorMessage, "provisioning failed")
+}
+
+func TestService_InitiateTenant_WithoutProvisioner(t *testing.T) {
+	// Service without provisioner - tenant should be created as active directly
+	svc, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	req := &pb.InitiateTenantRequest{
+		TenantId:        "no_prov_tenant",
+		DisplayName:     "No Provisioning Tenant",
+		SettlementAsset: "USD",
+	}
+
+	resp, err := svc.InitiateTenant(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Tenant)
+
+	// Should be active immediately (no provisioning)
+	assert.Equal(t, pb.TenantStatus_TENANT_STATUS_ACTIVE, resp.Tenant.Status)
+	assert.Equal(t, int32(1), resp.Tenant.Version) // Only one version (created)
 }


### PR DESCRIPTION
## Summary
- Add schema provisioning call to Tenant Service's InitiateTenant RPC
- Implement status tracking with provisioning and provisioning_failed states
- Add error handling and reporting for failed provisioning attempts

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 48

## Changes Made
- Extended domain model with `provisioning` and `provisioning_failed` tenant statuses
- Added `ErrorMessage` field to tenant entity for capturing failure details
- Integrated `SchemaProvisioner` into the gRPC service with optional dependency injection
- Modified `InitiateTenant` RPC to:
  1. Create tenant with `provisioning` status when provisioner is configured
  2. Call `ProvisionSchemas` to create org_{tenant_id} schemas
  3. Update to `active` status on success or `provisioning_failed` on failure
- Updated proto definition with new status enums and error_message field
- Added `UpdateStatusWithError` repository method for atomic status + error updates
- Wired provisioner in main.go (enabled via `SCHEMA_PROVISIONING_ENABLED` env var)

## Test Plan
- Unit test: Mock provisioner success → verify tenant status=active
- Unit test: Mock provisioner failure → verify tenant status=provisioning_failed + error stored
- Unit test: No provisioner configured → verify tenant created as active immediately
- All existing tests updated and passing