### PR TITLE
feat(multi-tenancy): Add search_path scoping to remaining 3 service repositories

### DIFF
--- a/services/financial-accounting/adapters/persistence/repository.go
+++ b/services/financial-accounting/adapters/persistence/repository.go
@@ -10,6 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/meridianhub/meridian/services/financial-accounting/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
 )
@@ -45,28 +47,72 @@ type LedgerRepository struct {
 }
 
 // NewLedgerRepository creates a new repository instance
-func NewLedgerRepository(db *gorm.DB) *LedgerRepository {
-	return &LedgerRepository{db: db}
+func NewLedgerRepository(gormDB *gorm.DB) *LedgerRepository {
+	return &LedgerRepository{db: gormDB}
 }
 
-// SavePosting persists a ledger posting
+// hasTenantContext checks if tenant context is present (multi-tenant mode).
+func (r *LedgerRepository) hasTenantContext(ctx context.Context) bool {
+	_, ok := tenant.FromContext(ctx)
+	return ok
+}
+
+// withTenantScope returns a GORM DB instance scoped to the tenant from context.
+// If tenant context is present (multi-tenant mode), it sets the PostgreSQL search_path.
+// If tenant context is missing (single-tenant mode), it returns the DB unchanged.
+//
+// This must be called within a transaction for the search_path setting to work correctly.
+func (r *LedgerRepository) withTenantScope(ctx context.Context, tx *gorm.DB) (*gorm.DB, error) {
+	if r.hasTenantContext(ctx) {
+		return db.WithGormTenantScope(ctx, tx)
+	}
+	// Single-tenant mode: no tenant scope needed
+	return tx, nil
+}
+
+// withOptionalOrgScope executes the given function with optional tenant scoping.
+// In single-tenant mode (no tenant context), it runs the function directly without a transaction.
+// In multi-tenant mode, it wraps the function in a transaction and sets the search_path.
+// This helper reduces code duplication across repository methods.
+func (r *LedgerRepository) withOptionalOrgScope(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if !r.hasTenantContext(ctx) {
+		// Single-tenant mode: run directly without transaction overhead
+		return fn(r.db.WithContext(ctx))
+	}
+	// Multi-tenant mode: use the shared helper that handles transaction + tenant scope
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// SavePosting persists a ledger posting.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *LedgerRepository) SavePosting(ctx context.Context, posting *domain.LedgerPosting) error {
 	entity, err := toPostingEntity(posting)
 	if err != nil {
 		return err
 	}
-	return r.db.WithContext(ctx).Create(&entity).Error
+	return r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		return tx.Create(&entity).Error
+	})
 }
 
-// SavePostingsInTransaction persists multiple postings atomically within a transaction
+// SavePostingsInTransaction persists multiple postings atomically within a transaction.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *LedgerRepository) SavePostingsInTransaction(ctx context.Context, postings []*domain.LedgerPosting) error {
 	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Set tenant scope if in multi-tenant mode
+		var scopedTx *gorm.DB
+		var scopeErr error
+		scopedTx, scopeErr = r.withTenantScope(ctx, tx)
+		if scopeErr != nil {
+			return scopeErr
+		}
+
 		for _, posting := range postings {
 			entity, err := toPostingEntity(posting)
 			if err != nil {
 				return err
 			}
-			if err := tx.Create(&entity).Error; err != nil {
+			if err := scopedTx.Create(&entity).Error; err != nil {
 				return err
 			}
 		}
@@ -78,63 +124,79 @@ func (r *LedgerRepository) SavePostingsInTransaction(ctx context.Context, postin
 	return nil
 }
 
-// GetPosting retrieves a posting by ID
+// GetPosting retrieves a posting by ID.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *LedgerRepository) GetPosting(ctx context.Context, id uuid.UUID) (*domain.LedgerPosting, error) {
-	var entity LedgerPostingEntity
-	err := r.db.WithContext(ctx).First(&entity, "id = ?", id).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, ErrPostingNotFound
-	}
+	var posting *domain.LedgerPosting
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		var entity LedgerPostingEntity
+		result := tx.First(&entity, "id = ?", id)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrPostingNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		posting = toPostingDomain(&entity)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	return toPostingDomain(&entity), nil
+	return posting, nil
 }
 
-// GetPostingsByBookingLogID retrieves all postings for a booking log
+// GetPostingsByBookingLogID retrieves all postings for a booking log.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *LedgerRepository) GetPostingsByBookingLogID(ctx context.Context, bookingLogID uuid.UUID) ([]*domain.LedgerPosting, error) {
-	var entities []LedgerPostingEntity
-	err := r.db.WithContext(ctx).
-		Where("financial_booking_log_id = ?", bookingLogID).
-		Order("created_at ASC").
-		Find(&entities).Error
+	var postings []*domain.LedgerPosting
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		var entities []LedgerPostingEntity
+		result := tx.Where("financial_booking_log_id = ?", bookingLogID).
+			Order("created_at ASC").
+			Find(&entities)
+		if result.Error != nil {
+			return result.Error
+		}
+
+		postings = make([]*domain.LedgerPosting, len(entities))
+		for i, entity := range entities {
+			postings[i] = toPostingDomain(&entity)
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	postings := make([]*domain.LedgerPosting, len(entities))
-	for i, entity := range entities {
-		postings[i] = toPostingDomain(&entity)
-	}
-
 	return postings, nil
 }
 
-// UpdatePosting updates an existing ledger posting
+// UpdatePosting updates an existing ledger posting.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *LedgerRepository) UpdatePosting(ctx context.Context, posting *domain.LedgerPosting) error {
 	entity, err := toPostingEntity(posting)
 	if err != nil {
 		return err
 	}
 
-	result := r.db.WithContext(ctx).
-		Model(&LedgerPostingEntity{}).
-		Where("id = ?", entity.ID).
-		Updates(map[string]interface{}{
-			"status":         entity.Status,
-			"posting_result": entity.PostingResult,
-		})
+	return r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		result := tx.Model(&LedgerPostingEntity{}).
+			Where("id = ?", entity.ID).
+			Updates(map[string]interface{}{
+				"status":         entity.Status,
+				"posting_result": entity.PostingResult,
+			})
 
-	if result.Error != nil {
-		return result.Error
-	}
+		if result.Error != nil {
+			return result.Error
+		}
 
-	if result.RowsAffected == 0 {
-		return ErrPostingNotFound
-	}
+		if result.RowsAffected == 0 {
+			return ErrPostingNotFound
+		}
 
-	return nil
+		return nil
+	})
 }
 
 // toPostingEntity converts domain model to database entity
@@ -184,59 +246,72 @@ func toPostingDomain(entity *LedgerPostingEntity) *domain.LedgerPosting {
 	}
 }
 
-// GetBookingLog retrieves a booking log by ID
+// GetBookingLog retrieves a booking log by ID.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *LedgerRepository) GetBookingLog(ctx context.Context, id uuid.UUID) (*domain.FinancialBookingLog, error) {
-	var entity FinancialBookingLogEntity
-	err := r.db.WithContext(ctx).First(&entity, "id = ?", id).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil, ErrBookingLogNotFound
-	}
+	var bookingLog *domain.FinancialBookingLog
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		var entity FinancialBookingLogEntity
+		result := tx.First(&entity, "id = ?", id)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrBookingLogNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		bookingLog = toBookingLogDomain(&entity)
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	return toBookingLogDomain(&entity), nil
+	return bookingLog, nil
 }
 
 // SaveBookingLog persists a new financial booking log.
 // Returns ErrDuplicateIdempotencyKey if a booking log with the same idempotency key already exists.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *LedgerRepository) SaveBookingLog(ctx context.Context, log *domain.FinancialBookingLog, idempotencyKey string) error {
 	entity := toBookingLogEntity(log, idempotencyKey)
-	err := r.db.WithContext(ctx).Create(&entity).Error
-	if err != nil {
-		// Check for unique constraint violation using PostgreSQL error code
-		// 23505 is the SQLSTATE for unique_violation
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			if strings.Contains(pgErr.ConstraintName, "idempotency_key") {
-				return ErrDuplicateIdempotencyKey
+	return r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		err := tx.Create(&entity).Error
+		if err != nil {
+			// Check for unique constraint violation using PostgreSQL error code
+			// 23505 is the SQLSTATE for unique_violation
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				if strings.Contains(pgErr.ConstraintName, "idempotency_key") {
+					return ErrDuplicateIdempotencyKey
+				}
 			}
+			return err
 		}
-		return err
-	}
-	return nil
+		return nil
+	})
 }
 
-// UpdateBookingLog updates an existing financial booking log
+// UpdateBookingLog updates an existing financial booking log.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *LedgerRepository) UpdateBookingLog(ctx context.Context, log *domain.FinancialBookingLog) error {
-	result := r.db.WithContext(ctx).
-		Model(&FinancialBookingLogEntity{}).
-		Where("id = ?", log.ID).
-		Updates(map[string]interface{}{
-			"status":                  string(log.Status),
-			"chart_of_accounts_rules": log.ChartOfAccountsRules,
-			"updated_at":              log.UpdatedAt,
-		})
+	return r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		result := tx.Model(&FinancialBookingLogEntity{}).
+			Where("id = ?", log.ID).
+			Updates(map[string]interface{}{
+				"status":                  string(log.Status),
+				"chart_of_accounts_rules": log.ChartOfAccountsRules,
+				"updated_at":              log.UpdatedAt,
+			})
 
-	if result.Error != nil {
-		return result.Error
-	}
+		if result.Error != nil {
+			return result.Error
+		}
 
-	if result.RowsAffected == 0 {
-		return ErrBookingLogNotFound
-	}
+		if result.RowsAffected == 0 {
+			return ErrBookingLogNotFound
+		}
 
-	return nil
+		return nil
+	})
 }
 
 // toBookingLogEntity converts domain model to database entity
@@ -279,6 +354,7 @@ type ListBookingLogsResult struct {
 }
 
 // ListBookingLogs lists booking logs with optional filtering and pagination.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 //
 // LIMITATION: Page token parsing is not yet implemented. Pagination currently
 // uses OFFSET-based queries which may show inconsistent results if data changes
@@ -295,65 +371,73 @@ func (r *LedgerRepository) ListBookingLogs(ctx context.Context, params ListBooki
 		pageSize = MaxPageSize
 	}
 
-	// Build base query
-	query := r.db.WithContext(ctx).Model(&FinancialBookingLogEntity{})
+	var result *ListBookingLogsResult
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		// Build base query
+		query := tx.Model(&FinancialBookingLogEntity{})
 
-	// Apply status filter if provided
-	if params.StatusFilter != "" {
-		query = query.Where("status = ?", params.StatusFilter)
-	}
+		// Apply status filter if provided
+		if params.StatusFilter != "" {
+			query = query.Where("status = ?", params.StatusFilter)
+		}
 
-	// Apply business unit filter if provided
-	if params.BusinessUnitFilter != "" {
-		query = query.Where("business_unit_reference = ?", params.BusinessUnitFilter)
-	}
+		// Apply business unit filter if provided
+		if params.BusinessUnitFilter != "" {
+			query = query.Where("business_unit_reference = ?", params.BusinessUnitFilter)
+		}
 
-	// Get total count
-	var totalCount int64
-	if err := query.Count(&totalCount).Error; err != nil {
-		return nil, err
-	}
+		// Get total count
+		var totalCount int64
+		if err := query.Count(&totalCount).Error; err != nil {
+			return err
+		}
 
-	// Apply cursor-based pagination using created_at + id
-	// Page token format: <timestamp>_<uuid>
-	// TODO: Implement proper cursor-based pagination
-	_ = params.PageToken // Unused for now, will be implemented in future iteration
+		// Apply cursor-based pagination using created_at + id
+		// Page token format: <timestamp>_<uuid>
+		// TODO: Implement proper cursor-based pagination
+		_ = params.PageToken // Unused for now, will be implemented in future iteration
 
-	// Fetch results with limit
-	var entities []FinancialBookingLogEntity
-	err := query.
-		Order("created_at DESC, id DESC").
-		Limit(pageSize + 1). // Fetch one extra to determine if there's a next page
-		Find(&entities).Error
+		// Fetch results with limit
+		var entities []FinancialBookingLogEntity
+		err := query.
+			Order("created_at DESC, id DESC").
+			Limit(pageSize + 1). // Fetch one extra to determine if there's a next page
+			Find(&entities).Error
+		if err != nil {
+			return err
+		}
+
+		// Determine if there's a next page
+		hasMore := len(entities) > pageSize
+		if hasMore {
+			entities = entities[:pageSize]
+		}
+
+		// Convert to domain models
+		bookingLogs := make([]*domain.FinancialBookingLog, len(entities))
+		for i, entity := range entities {
+			bookingLogs[i] = toBookingLogDomain(&entity)
+		}
+
+		// Generate next page token if there are more results
+		var nextPageToken string
+		if hasMore && len(entities) > 0 {
+			lastEntity := entities[len(entities)-1]
+			// Simple token format: timestamp_id
+			nextPageToken = fmt.Sprintf("%d_%s", lastEntity.CreatedAt.Unix(), lastEntity.ID)
+		}
+
+		result = &ListBookingLogsResult{
+			BookingLogs:   bookingLogs,
+			NextPageToken: nextPageToken,
+			TotalCount:    totalCount,
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	// Determine if there's a next page
-	hasMore := len(entities) > pageSize
-	if hasMore {
-		entities = entities[:pageSize]
-	}
-
-	// Convert to domain models
-	bookingLogs := make([]*domain.FinancialBookingLog, len(entities))
-	for i, entity := range entities {
-		bookingLogs[i] = toBookingLogDomain(&entity)
-	}
-
-	// Generate next page token if there are more results
-	var nextPageToken string
-	if hasMore && len(entities) > 0 {
-		lastEntity := entities[len(entities)-1]
-		// Simple token format: timestamp_id
-		nextPageToken = fmt.Sprintf("%d_%s", lastEntity.CreatedAt.Unix(), lastEntity.ID)
-	}
-
-	return &ListBookingLogsResult{
-		BookingLogs:   bookingLogs,
-		NextPageToken: nextPageToken,
-		TotalCount:    totalCount,
-	}, nil
+	return result, nil
 }
 
 // toBookingLogDomain converts database entity to domain model.
@@ -415,6 +499,7 @@ type ListPostingsResult struct {
 }
 
 // ListPostings lists ledger postings with optional filtering and pagination.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 //
 // LIMITATION: Page token parsing is not yet implemented. Pagination currently
 // uses OFFSET-based queries which may show inconsistent results if data changes
@@ -431,86 +516,94 @@ func (r *LedgerRepository) ListPostings(ctx context.Context, params ListPostings
 		pageSize = MaxPageSize
 	}
 
-	// Build base query
-	query := r.db.WithContext(ctx).Model(&LedgerPostingEntity{})
+	var result *ListPostingsResult
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		// Build base query
+		query := tx.Model(&LedgerPostingEntity{})
 
-	// Apply booking log filter if provided
-	if params.BookingLogID != nil {
-		query = query.Where("financial_booking_log_id = ?", *params.BookingLogID)
-	}
+		// Apply booking log filter if provided
+		if params.BookingLogID != nil {
+			query = query.Where("financial_booking_log_id = ?", *params.BookingLogID)
+		}
 
-	// Apply account ID filter if provided
-	if params.AccountID != "" {
-		query = query.Where("account_id = ?", params.AccountID)
-	}
+		// Apply account ID filter if provided
+		if params.AccountID != "" {
+			query = query.Where("account_id = ?", params.AccountID)
+		}
 
-	// Apply posting direction filter if provided
-	if params.PostingDirection != "" {
-		query = query.Where("posting_direction = ?", params.PostingDirection)
-	}
+		// Apply posting direction filter if provided
+		if params.PostingDirection != "" {
+			query = query.Where("posting_direction = ?", params.PostingDirection)
+		}
 
-	// Apply value date range filters if provided
-	if params.ValueDateFrom != nil {
-		query = query.Where("value_date >= ?", *params.ValueDateFrom)
-	}
-	if params.ValueDateTo != nil {
-		query = query.Where("value_date <= ?", *params.ValueDateTo)
-	}
+		// Apply value date range filters if provided
+		if params.ValueDateFrom != nil {
+			query = query.Where("value_date >= ?", *params.ValueDateFrom)
+		}
+		if params.ValueDateTo != nil {
+			query = query.Where("value_date <= ?", *params.ValueDateTo)
+		}
 
-	// Apply currency filter if provided
-	if params.Currency != "" {
-		query = query.Where("currency = ?", params.Currency)
-	}
+		// Apply currency filter if provided
+		if params.Currency != "" {
+			query = query.Where("currency = ?", params.Currency)
+		}
 
-	// Apply status filter if provided
-	if params.Status != "" {
-		query = query.Where("status = ?", params.Status)
-	}
+		// Apply status filter if provided
+		if params.Status != "" {
+			query = query.Where("status = ?", params.Status)
+		}
 
-	// Get total count
-	var totalCount int64
-	if err := query.Count(&totalCount).Error; err != nil {
-		return nil, err
-	}
+		// Get total count
+		var totalCount int64
+		if err := query.Count(&totalCount).Error; err != nil {
+			return err
+		}
 
-	// Apply cursor-based pagination using created_at + id
-	// Page token format: <timestamp>_<uuid>
-	// TODO: Implement proper cursor-based pagination
-	_ = params.PageToken // Unused for now, will be implemented in future iteration
+		// Apply cursor-based pagination using created_at + id
+		// Page token format: <timestamp>_<uuid>
+		// TODO: Implement proper cursor-based pagination
+		_ = params.PageToken // Unused for now, will be implemented in future iteration
 
-	// Fetch results with limit
-	var entities []LedgerPostingEntity
-	err := query.
-		Order("created_at DESC, id DESC").
-		Limit(pageSize + 1). // Fetch one extra to determine if there's a next page
-		Find(&entities).Error
+		// Fetch results with limit
+		var entities []LedgerPostingEntity
+		err := query.
+			Order("created_at DESC, id DESC").
+			Limit(pageSize + 1). // Fetch one extra to determine if there's a next page
+			Find(&entities).Error
+		if err != nil {
+			return err
+		}
+
+		// Determine if there's a next page
+		hasMore := len(entities) > pageSize
+		if hasMore {
+			entities = entities[:pageSize]
+		}
+
+		// Convert to domain models
+		postings := make([]*domain.LedgerPosting, len(entities))
+		for i, entity := range entities {
+			postings[i] = toPostingDomain(&entity)
+		}
+
+		// Generate next page token if there are more results
+		var nextPageToken string
+		if hasMore && len(entities) > 0 {
+			lastEntity := entities[len(entities)-1]
+			// Simple token format: timestamp_id
+			nextPageToken = fmt.Sprintf("%d_%s", lastEntity.CreatedAt.Unix(), lastEntity.ID)
+		}
+
+		result = &ListPostingsResult{
+			Postings:      postings,
+			NextPageToken: nextPageToken,
+			TotalCount:    totalCount,
+		}
+		return nil
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	// Determine if there's a next page
-	hasMore := len(entities) > pageSize
-	if hasMore {
-		entities = entities[:pageSize]
-	}
-
-	// Convert to domain models
-	postings := make([]*domain.LedgerPosting, len(entities))
-	for i, entity := range entities {
-		postings[i] = toPostingDomain(&entity)
-	}
-
-	// Generate next page token if there are more results
-	var nextPageToken string
-	if hasMore && len(entities) > 0 {
-		lastEntity := entities[len(entities)-1]
-		// Simple token format: timestamp_id
-		nextPageToken = fmt.Sprintf("%d_%s", lastEntity.CreatedAt.Unix(), lastEntity.ID)
-	}
-
-	return &ListPostingsResult{
-		Postings:      postings,
-		NextPageToken: nextPageToken,
-		TotalCount:    totalCount,
-	}, nil
+	return result, nil
 }

--- a/services/payment-order/adapters/persistence/repository.go
+++ b/services/payment-order/adapters/persistence/repository.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"gorm.io/gorm"
 )
 
@@ -101,93 +103,153 @@ type PaymentOrderRepository struct {
 var _ Repository = (*PaymentOrderRepository)(nil)
 
 // NewPaymentOrderRepository creates a new payment order repository
-func NewPaymentOrderRepository(db *gorm.DB) *PaymentOrderRepository {
-	return &PaymentOrderRepository{db: db}
+func NewPaymentOrderRepository(gormDB *gorm.DB) *PaymentOrderRepository {
+	return &PaymentOrderRepository{db: gormDB}
+}
+
+// hasTenantContext checks if tenant context is present (multi-tenant mode).
+func (r *PaymentOrderRepository) hasTenantContext(ctx context.Context) bool {
+	_, ok := tenant.FromContext(ctx)
+	return ok
+}
+
+// withOptionalOrgScope executes the given function with optional tenant scoping.
+// In single-tenant mode (no tenant context), it runs the function directly without a transaction.
+// In multi-tenant mode, it wraps the function in a transaction and sets the search_path.
+// This helper reduces code duplication across repository methods.
+func (r *PaymentOrderRepository) withOptionalOrgScope(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if !r.hasTenantContext(ctx) {
+		// Single-tenant mode: run directly without transaction overhead
+		return fn(r.db.WithContext(ctx))
+	}
+	// Multi-tenant mode: use the shared helper that handles transaction + tenant scope
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
 }
 
 // Create inserts a new payment order.
 // Returns ErrIdempotencyKeyConflict if a payment order with the same idempotency key exists.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *PaymentOrderRepository) Create(ctx context.Context, po *domain.PaymentOrder) error {
 	entity := toEntity(po)
-	err := r.db.WithContext(ctx).Create(entity).Error
-	if err != nil && strings.Contains(err.Error(), errUniqueConstraintIdempotencyKey) {
-		return ErrIdempotencyKeyConflict
-	}
-	return err
-}
-
-// FindByID retrieves a payment order by its UUID
-func (r *PaymentOrderRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.PaymentOrder, error) {
-	var entity PaymentOrderEntity
-	result := r.db.WithContext(ctx).Where("id = ?", id).First(&entity)
-
-	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		return nil, ErrPaymentOrderNotFound
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return toDomain(&entity)
-}
-
-// FindByIdempotencyKey retrieves a payment order by its idempotency key
-func (r *PaymentOrderRepository) FindByIdempotencyKey(ctx context.Context, key string) (*domain.PaymentOrder, error) {
-	var entity PaymentOrderEntity
-	result := r.db.WithContext(ctx).Where("idempotency_key = ?", key).First(&entity)
-
-	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		return nil, ErrPaymentOrderNotFound
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return toDomain(&entity)
-}
-
-// FindByGatewayReferenceID retrieves a payment order by its gateway reference ID
-func (r *PaymentOrderRepository) FindByGatewayReferenceID(ctx context.Context, gatewayRefID string) (*domain.PaymentOrder, error) {
-	var entity PaymentOrderEntity
-	result := r.db.WithContext(ctx).Where("gateway_reference_id = ?", gatewayRefID).First(&entity)
-
-	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		return nil, ErrPaymentOrderNotFound
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	return toDomain(&entity)
-}
-
-// FindByDebtorAccountID retrieves all payment orders for a debtor account
-func (r *PaymentOrderRepository) FindByDebtorAccountID(ctx context.Context, accountID string) ([]*domain.PaymentOrder, error) {
-	var entities []PaymentOrderEntity
-	result := r.db.WithContext(ctx).Where("debtor_account_id = ?", accountID).Find(&entities)
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	paymentOrders := make([]*domain.PaymentOrder, 0, len(entities))
-	for i := range entities {
-		po, err := toDomain(&entities[i])
-		if err != nil {
-			return nil, err
+	return r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		err := tx.Create(entity).Error
+		if err != nil && strings.Contains(err.Error(), errUniqueConstraintIdempotencyKey) {
+			return ErrIdempotencyKeyConflict
 		}
-		paymentOrders = append(paymentOrders, po)
-	}
+		return err
+	})
+}
 
+// FindByID retrieves a payment order by its UUID.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
+func (r *PaymentOrderRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.PaymentOrder, error) {
+	var paymentOrder *domain.PaymentOrder
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		var entity PaymentOrderEntity
+		result := tx.Where("id = ?", id).First(&entity)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrPaymentOrderNotFound
+		}
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		var domainErr error
+		paymentOrder, domainErr = toDomain(&entity)
+		return domainErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return paymentOrder, nil
+}
+
+// FindByIdempotencyKey retrieves a payment order by its idempotency key.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
+func (r *PaymentOrderRepository) FindByIdempotencyKey(ctx context.Context, key string) (*domain.PaymentOrder, error) {
+	var paymentOrder *domain.PaymentOrder
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		var entity PaymentOrderEntity
+		result := tx.Where("idempotency_key = ?", key).First(&entity)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrPaymentOrderNotFound
+		}
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		var domainErr error
+		paymentOrder, domainErr = toDomain(&entity)
+		return domainErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return paymentOrder, nil
+}
+
+// FindByGatewayReferenceID retrieves a payment order by its gateway reference ID.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
+func (r *PaymentOrderRepository) FindByGatewayReferenceID(ctx context.Context, gatewayRefID string) (*domain.PaymentOrder, error) {
+	var paymentOrder *domain.PaymentOrder
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		var entity PaymentOrderEntity
+		result := tx.Where("gateway_reference_id = ?", gatewayRefID).First(&entity)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrPaymentOrderNotFound
+		}
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		var domainErr error
+		paymentOrder, domainErr = toDomain(&entity)
+		return domainErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return paymentOrder, nil
+}
+
+// FindByDebtorAccountID retrieves all payment orders for a debtor account.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
+func (r *PaymentOrderRepository) FindByDebtorAccountID(ctx context.Context, accountID string) ([]*domain.PaymentOrder, error) {
+	var paymentOrders []*domain.PaymentOrder
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		var entities []PaymentOrderEntity
+		result := tx.Where("debtor_account_id = ?", accountID).Find(&entities)
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		paymentOrders = make([]*domain.PaymentOrder, 0, len(entities))
+		for i := range entities {
+			po, err := toDomain(&entities[i])
+			if err != nil {
+				return err
+			}
+			paymentOrders = append(paymentOrders, po)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
 	return paymentOrders, nil
 }
 
 // FindByDebtorAccountIDWithCursor retrieves payment orders for a debtor account with cursor-based pagination.
 // This provides consistent results even when items are inserted/deleted during pagination.
 // Results are ordered by created_at DESC, id DESC (newest first) for deterministic ordering.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 //
 // The cursor uses (created_at, id) as a composite key to handle ties when multiple records
 // have the same created_at timestamp. The query uses:
@@ -196,117 +258,134 @@ func (r *PaymentOrderRepository) FindByDebtorAccountID(ctx context.Context, acco
 //
 // This ensures stable pagination even with concurrent inserts.
 func (r *PaymentOrderRepository) FindByDebtorAccountIDWithCursor(ctx context.Context, accountID string, limit int, cursor Cursor) (*PaginatedResult, error) {
-	// Get total count (for UI purposes - this is still useful for showing "X of Y" in pagination)
-	var totalCount int64
-	countResult := r.db.WithContext(ctx).Model(&PaymentOrderEntity{}).
-		Where("debtor_account_id = ?", accountID).
-		Count(&totalCount)
+	var paginatedResult *PaginatedResult
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		// Get total count (for UI purposes - this is still useful for showing "X of Y" in pagination)
+		var totalCount int64
+		countResult := tx.Model(&PaymentOrderEntity{}).
+			Where("debtor_account_id = ?", accountID).
+			Count(&totalCount)
 
-	if countResult.Error != nil {
-		return nil, countResult.Error
-	}
-
-	// Return early if no results
-	if totalCount == 0 {
-		return &PaginatedResult{
-			PaymentOrders: []*domain.PaymentOrder{},
-			TotalCount:    0,
-			HasMore:       false,
-			NextCursor:    "",
-		}, nil
-	}
-
-	// Build query with cursor-based pagination
-	// Request one extra to determine if there are more results
-	query := r.db.WithContext(ctx).Where("debtor_account_id = ?", accountID)
-
-	// Apply cursor condition if provided (not first page)
-	if !cursor.CreatedAt.IsZero() {
-		// Use composite cursor: (created_at < cursor_time) OR (created_at = cursor_time AND id < cursor_id)
-		// This handles ties when multiple records have the same created_at
-		query = query.Where(
-			"(created_at < ?) OR (created_at = ? AND id < ?)",
-			cursor.CreatedAt, cursor.CreatedAt, cursor.ID,
-		)
-	}
-
-	var entities []PaymentOrderEntity
-	result := query.
-		Order("created_at DESC, id DESC").
-		Limit(limit + 1). // Fetch one extra to check for more
-		Find(&entities)
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	// Determine if there are more results
-	hasMore := len(entities) > limit
-	if hasMore {
-		entities = entities[:limit] // Trim to requested limit
-	}
-
-	paymentOrders := make([]*domain.PaymentOrder, 0, len(entities))
-	for i := range entities {
-		po, err := toDomain(&entities[i])
-		if err != nil {
-			return nil, err
+		if countResult.Error != nil {
+			return countResult.Error
 		}
-		paymentOrders = append(paymentOrders, po)
-	}
 
-	// Build next cursor from the last item if there are more results
-	var nextCursor string
-	if hasMore && len(paymentOrders) > 0 {
-		lastPO := paymentOrders[len(paymentOrders)-1]
-		nextCursor = EncodeCursor(Cursor{
-			CreatedAt: lastPO.CreatedAt,
-			ID:        lastPO.ID,
-		})
-	}
+		// Return early if no results
+		if totalCount == 0 {
+			paginatedResult = &PaginatedResult{
+				PaymentOrders: []*domain.PaymentOrder{},
+				TotalCount:    0,
+				HasMore:       false,
+				NextCursor:    "",
+			}
+			return nil
+		}
 
-	return &PaginatedResult{
-		PaymentOrders: paymentOrders,
-		TotalCount:    totalCount,
-		HasMore:       hasMore,
-		NextCursor:    nextCursor,
-	}, nil
+		// Build query with cursor-based pagination
+		// Request one extra to determine if there are more results
+		query := tx.Where("debtor_account_id = ?", accountID)
+
+		// Apply cursor condition if provided (not first page)
+		if !cursor.CreatedAt.IsZero() {
+			// Use composite cursor: (created_at < cursor_time) OR (created_at = cursor_time AND id < cursor_id)
+			// This handles ties when multiple records have the same created_at
+			query = query.Where(
+				"(created_at < ?) OR (created_at = ? AND id < ?)",
+				cursor.CreatedAt, cursor.CreatedAt, cursor.ID,
+			)
+		}
+
+		var entities []PaymentOrderEntity
+		result := query.
+			Order("created_at DESC, id DESC").
+			Limit(limit + 1). // Fetch one extra to check for more
+			Find(&entities)
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		// Determine if there are more results
+		hasMore := len(entities) > limit
+		if hasMore {
+			entities = entities[:limit] // Trim to requested limit
+		}
+
+		paymentOrders := make([]*domain.PaymentOrder, 0, len(entities))
+		for i := range entities {
+			po, domainErr := toDomain(&entities[i])
+			if domainErr != nil {
+				return domainErr
+			}
+			paymentOrders = append(paymentOrders, po)
+		}
+
+		// Build next cursor from the last item if there are more results
+		var nextCursor string
+		if hasMore && len(paymentOrders) > 0 {
+			lastPO := paymentOrders[len(paymentOrders)-1]
+			nextCursor = EncodeCursor(Cursor{
+				CreatedAt: lastPO.CreatedAt,
+				ID:        lastPO.ID,
+			})
+		}
+
+		paginatedResult = &PaginatedResult{
+			PaymentOrders: paymentOrders,
+			TotalCount:    totalCount,
+			HasMore:       hasMore,
+			NextCursor:    nextCursor,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return paginatedResult, nil
 }
 
-// Update updates an existing payment order with optimistic locking
+// Update updates an existing payment order with optimistic locking.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *PaymentOrderRepository) Update(ctx context.Context, po *domain.PaymentOrder) error {
 	entity := toEntity(po)
 
-	// Optimistic locking: use WHERE clause with version check
-	result := r.db.WithContext(ctx).Model(&PaymentOrderEntity{}).
-		Where("id = ? AND version = ?", entity.ID, po.Version).
-		Updates(map[string]interface{}{
-			"status":                  entity.Status,
-			"lien_id":                 entity.LienID,
-			"gateway_reference_id":    entity.GatewayReferenceID,
-			"ledger_booking_id":       entity.LedgerBookingID,
-			"causation_id":            entity.CausationID,
-			"failure_reason":          entity.FailureReason,
-			"error_code":              entity.ErrorCode,
-			"lien_execution_status":   entity.LienExecutionStatus,
-			"lien_execution_attempts": entity.LienExecutionAttempts,
-			"lien_execution_error":    entity.LienExecutionError,
-			"updated_at":              entity.UpdatedAt,
-			"reserved_at":             entity.ReservedAt,
-			"executing_at":            entity.ExecutingAt,
-			"completed_at":            entity.CompletedAt,
-			"failed_at":               entity.FailedAt,
-			"cancelled_at":            entity.CancelledAt,
-			"reversed_at":             entity.ReversedAt,
-			"version":                 po.Version + 1,
-		})
+	err := r.withOptionalOrgScope(ctx, func(tx *gorm.DB) error {
+		// Optimistic locking: use WHERE clause with version check
+		result := tx.Model(&PaymentOrderEntity{}).
+			Where("id = ? AND version = ?", entity.ID, po.Version).
+			Updates(map[string]interface{}{
+				"status":                  entity.Status,
+				"lien_id":                 entity.LienID,
+				"gateway_reference_id":    entity.GatewayReferenceID,
+				"ledger_booking_id":       entity.LedgerBookingID,
+				"causation_id":            entity.CausationID,
+				"failure_reason":          entity.FailureReason,
+				"error_code":              entity.ErrorCode,
+				"lien_execution_status":   entity.LienExecutionStatus,
+				"lien_execution_attempts": entity.LienExecutionAttempts,
+				"lien_execution_error":    entity.LienExecutionError,
+				"updated_at":              entity.UpdatedAt,
+				"reserved_at":             entity.ReservedAt,
+				"executing_at":            entity.ExecutingAt,
+				"completed_at":            entity.CompletedAt,
+				"failed_at":               entity.FailedAt,
+				"cancelled_at":            entity.CancelledAt,
+				"reversed_at":             entity.ReversedAt,
+				"version":                 po.Version + 1,
+			})
 
-	if result.Error != nil {
-		return result.Error
-	}
+		if result.Error != nil {
+			return result.Error
+		}
 
-	if result.RowsAffected == 0 {
-		return ErrPaymentOrderVersionConflict
+		if result.RowsAffected == 0 {
+			return ErrPaymentOrderVersionConflict
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	// Update domain model version

--- a/services/position-keeping/adapters/persistence/postgres_repository.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository.go
@@ -899,14 +899,222 @@ func (r *PostgresRepository) loadAuditTrailEntriesTx(ctx context.Context, tx pgx
 	return nil
 }
 
-// scanLogsTx scans log rows and loads related entities using a transaction.
-// This is the transaction-aware version of scanLogs.
-func (r *PostgresRepository) scanLogsTx(ctx context.Context, tx pgx.Tx, rows pgx.Rows) ([]*domain.FinancialPositionLog, error) {
-	type logWithDBID struct {
-		log  *domain.FinancialPositionLog
-		dbID uuid.UUID
+// loadTransactionLogEntriesBatchTx loads transaction log entries for multiple logs in a single query.
+// This avoids N+1 query issues when loading many logs.
+func (r *PostgresRepository) loadTransactionLogEntriesBatchTx(ctx context.Context, tx pgx.Tx, dbIDs []uuid.UUID, dbIDToLog map[uuid.UUID]*domain.FinancialPositionLog) error {
+	if len(dbIDs) == 0 {
+		return nil
 	}
-	logsWithIDs := []logWithDBID{}
+
+	// Build IN clause with placeholders
+	placeholders := make([]string, len(dbIDs))
+	args := make([]any, len(dbIDs))
+	for i, id := range dbIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT financial_position_log_id, entry_id, transaction_id, account_id, amount_cents, currency,
+			direction, timestamp, description, reference, source
+		FROM transaction_log_entries
+		WHERE financial_position_log_id IN (%s) AND deleted_at IS NULL
+		ORDER BY financial_position_log_id, timestamp ASC`, strings.Join(placeholders, ","))
+
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to load transaction log entries batch: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var financialPosLogID uuid.UUID
+		var entry domain.TransactionLogEntry
+		var amountCents int64
+		var currency, direction, source string
+		var description, reference sql.NullString
+
+		err := rows.Scan(
+			&financialPosLogID,
+			&entry.EntryID, &entry.TransactionID, &entry.AccountID,
+			&amountCents, &currency, &direction, &entry.Timestamp,
+			&description, &reference, &source,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to scan transaction log entry in batch: %w", err)
+		}
+
+		// Convert cents to decimal and create Money
+		amount := centsToDecimal(amountCents)
+		money, err := domain.NewMoney(amount, domain.Currency(currency))
+		if err != nil {
+			return fmt.Errorf("failed to create Money value in batch: %w", err)
+		}
+		entry.Amount = money
+		entry.Direction = domain.ParsePostingDirection(direction)
+		entry.Source = domain.ParseTransactionSource(source)
+
+		if description.Valid {
+			entry.Description = description.String
+		}
+		if reference.Valid {
+			entry.Reference = reference.String
+		}
+
+		// Append to the appropriate log
+		if log, ok := dbIDToLog[financialPosLogID]; ok {
+			log.TransactionLogEntries = append(log.TransactionLogEntries, &entry)
+		}
+	}
+
+	return nil
+}
+
+// loadTransactionLineageBatchTx loads transaction lineages for multiple logs in a single query.
+// This avoids N+1 query issues when loading many logs.
+func (r *PostgresRepository) loadTransactionLineageBatchTx(ctx context.Context, tx pgx.Tx, dbIDs []uuid.UUID, dbIDToLog map[uuid.UUID]*domain.FinancialPositionLog) error {
+	if len(dbIDs) == 0 {
+		return nil
+	}
+
+	// Build IN clause with placeholders
+	placeholders := make([]string, len(dbIDs))
+	args := make([]any, len(dbIDs))
+	for i, id := range dbIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT financial_position_log_id, transaction_id, parent_transaction_id, child_transaction_ids,
+			related_transaction_ids, transaction_type
+		FROM transaction_lineages
+		WHERE financial_position_log_id IN (%s) AND deleted_at IS NULL`, strings.Join(placeholders, ","))
+
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to load transaction lineage batch: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var financialPosLogID uuid.UUID
+		var transactionID uuid.UUID
+		var transactionType string
+		var parentID sql.NullString
+		var childIDsJSON, relatedIDsJSON []byte
+
+		err := rows.Scan(
+			&financialPosLogID,
+			&transactionID, &parentID,
+			&childIDsJSON, &relatedIDsJSON, &transactionType,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to scan transaction lineage in batch: %w", err)
+		}
+
+		var parent *uuid.UUID
+		if parentID.Valid {
+			pid, err := uuid.Parse(parentID.String)
+			if err != nil {
+				return fmt.Errorf("failed to parse parent transaction ID in batch: %w", err)
+			}
+			parent = &pid
+		}
+
+		var childIDs []uuid.UUID
+		if err := json.Unmarshal(childIDsJSON, &childIDs); err != nil {
+			return fmt.Errorf("failed to unmarshal child transaction IDs in batch: %w", err)
+		}
+
+		var relatedIDs []uuid.UUID
+		if err := json.Unmarshal(relatedIDsJSON, &relatedIDs); err != nil {
+			return fmt.Errorf("failed to unmarshal related transaction IDs in batch: %w", err)
+		}
+
+		// Create the immutable TransactionLineage
+		lineage, err := domain.NewTransactionLineage(transactionID, transactionType, parent, childIDs, relatedIDs)
+		if err != nil {
+			return fmt.Errorf("failed to create transaction lineage in batch: %w", err)
+		}
+
+		// Assign to the appropriate log
+		if log, ok := dbIDToLog[financialPosLogID]; ok {
+			log.TransactionLineage = lineage
+		}
+	}
+
+	return nil
+}
+
+// loadAuditTrailEntriesBatchTx loads audit trail entries for multiple logs in a single query.
+// This avoids N+1 query issues when loading many logs.
+func (r *PostgresRepository) loadAuditTrailEntriesBatchTx(ctx context.Context, tx pgx.Tx, dbIDs []uuid.UUID, dbIDToLog map[uuid.UUID]*domain.FinancialPositionLog) error {
+	if len(dbIDs) == 0 {
+		return nil
+	}
+
+	// Build IN clause with placeholders
+	placeholders := make([]string, len(dbIDs))
+	args := make([]any, len(dbIDs))
+	for i, id := range dbIDs {
+		placeholders[i] = fmt.Sprintf("$%d", i+1)
+		args[i] = id
+	}
+
+	query := fmt.Sprintf(`
+		SELECT financial_position_log_id, audit_id, timestamp, user_id, action, details, ip_address, system_context
+		FROM audit_trail_entries
+		WHERE financial_position_log_id IN (%s) AND deleted_at IS NULL
+		ORDER BY financial_position_log_id, timestamp ASC`, strings.Join(placeholders, ","))
+
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to load audit trail entries batch: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var financialPosLogID uuid.UUID
+		var entry domain.AuditTrailEntry
+		var details, ipAddress sql.NullString
+		var sysContext []byte
+
+		err := rows.Scan(
+			&financialPosLogID,
+			&entry.AuditID, &entry.Timestamp, &entry.UserID, &entry.Action,
+			&details, &ipAddress, &sysContext,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to scan audit trail entry in batch: %w", err)
+		}
+
+		if details.Valid {
+			entry.Details = details.String
+		}
+		if ipAddress.Valid {
+			entry.IPAddress = ipAddress.String
+		}
+
+		if err := json.Unmarshal(sysContext, &entry.SystemContext); err != nil {
+			return fmt.Errorf("failed to unmarshal system context in batch: %w", err)
+		}
+
+		// Append to the appropriate log
+		if log, ok := dbIDToLog[financialPosLogID]; ok {
+			log.AuditTrail = append(log.AuditTrail, &entry)
+		}
+	}
+
+	return nil
+}
+
+// scanLogsTx scans log rows and loads related entities using a transaction.
+// Uses batch loading to avoid N+1 queries.
+func (r *PostgresRepository) scanLogsTx(ctx context.Context, tx pgx.Tx, rows pgx.Rows) ([]*domain.FinancialPositionLog, error) {
+	logs := []*domain.FinancialPositionLog{}
+	dbIDToLog := make(map[uuid.UUID]*domain.FinancialPositionLog)
+	dbIDs := []uuid.UUID{}
 
 	for rows.Next() {
 		var dbID uuid.UUID
@@ -939,30 +1147,27 @@ func (r *PostgresRepository) scanLogsTx(ctx context.Context, tx pgx.Tx, rows pgx
 
 		log.StatusTracking = &statusTracking
 
-		logsWithIDs = append(logsWithIDs, logWithDBID{log: &log, dbID: dbID})
+		logs = append(logs, &log)
+		dbIDToLog[dbID] = &log
+		dbIDs = append(dbIDs, dbID)
 	}
 
 	// If no logs were found, return early
-	if len(logsWithIDs) == 0 {
-		return []*domain.FinancialPositionLog{}, nil
+	if len(logs) == 0 {
+		return logs, nil
 	}
 
-	// Load related entities for each log using transaction-aware methods
-	logs := make([]*domain.FinancialPositionLog, len(logsWithIDs))
-	for i, item := range logsWithIDs {
-		if err := r.loadTransactionLogEntriesTx(ctx, tx, item.dbID, item.log); err != nil {
-			return nil, err
-		}
+	// Batch load all related entities for all logs to avoid N+1 queries
+	if err := r.loadTransactionLogEntriesBatchTx(ctx, tx, dbIDs, dbIDToLog); err != nil {
+		return nil, err
+	}
 
-		if err := r.loadTransactionLineageTx(ctx, tx, item.dbID, item.log); err != nil {
-			return nil, err
-		}
+	if err := r.loadTransactionLineageBatchTx(ctx, tx, dbIDs, dbIDToLog); err != nil {
+		return nil, err
+	}
 
-		if err := r.loadAuditTrailEntriesTx(ctx, tx, item.dbID, item.log); err != nil {
-			return nil, err
-		}
-
-		logs[i] = item.log
+	if err := r.loadAuditTrailEntriesBatchTx(ctx, tx, dbIDs, dbIDToLog); err != nil {
+		return nil, err
 	}
 
 	return logs, nil

--- a/services/position-keeping/adapters/persistence/postgres_repository.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository.go
@@ -13,8 +13,10 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/shared/platform/audit"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
 )
@@ -42,8 +44,65 @@ func NewPostgresRepository(pool *pgxpool.Pool) *PostgresRepository {
 	return &PostgresRepository{pool: pool}
 }
 
+// setSearchPath sets the PostgreSQL search_path for the transaction.
+// In multi-tenant mode, it sets the search_path to the tenant's schema.
+// In single-tenant mode (no tenant context), it does nothing.
+//
+// This must be called immediately after tx.Begin() to ensure all queries
+// in the transaction are scoped to the correct tenant schema.
+func (r *PostgresRepository) setSearchPath(ctx context.Context, tx pgx.Tx) error {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		// Single-tenant mode: no scoping needed
+		return nil
+	}
+
+	// Quote the schema name to prevent SQL injection
+	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
+
+	// SET LOCAL is transaction-scoped - automatically reverts on commit/rollback
+	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	_, err := tx.Exec(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to set tenant schema scope: %w", err)
+	}
+
+	return nil
+}
+
+// withReadTransaction executes a read-only function within a transaction with tenant scoping.
+// In multi-tenant mode, it wraps the function in a transaction with search_path set.
+// In single-tenant mode, it still uses a transaction for consistency but without search_path.
+// This is necessary because PostgreSQL's SET LOCAL requires a transaction context.
+func (r *PostgresRepository) withReadTransaction(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	// Set tenant scope if in multi-tenant mode
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+
+	// Commit the read-only transaction
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit read transaction: %w", err)
+	}
+
+	return nil
+}
+
 // Create persists a new FinancialPositionLog aggregate to the database.
 // Returns domain.ErrConflict if a log with the same LogID already exists.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *PostgresRepository) Create(ctx context.Context, log *domain.FinancialPositionLog) error {
 	if log == nil {
 		return ErrNilLog
@@ -57,10 +116,15 @@ func (r *PostgresRepository) Create(ctx context.Context, log *domain.FinancialPo
 		_ = tx.Rollback(ctx)
 	}()
 
+	// Set tenant scope if in multi-tenant mode
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
 	// Insert main financial_position_log
 	userID := audit.GetUserFromContext(ctx)
 	logQuery := `
-		INSERT INTO position_keeping.financial_position_logs (
+		INSERT INTO financial_position_logs (
 			id, created_at, created_by, updated_at, updated_by,
 			log_id, account_id, version,
 			current_status, previous_status, status_updated_at, status_reason, failure_reason,
@@ -115,6 +179,7 @@ func (r *PostgresRepository) Create(ctx context.Context, log *domain.FinancialPo
 
 // CreateBatch persists multiple FinancialPositionLog aggregates atomically using efficient bulk operations.
 // If any log fails to persist, the entire batch is rolled back.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *PostgresRepository) CreateBatch(ctx context.Context, logs []*domain.FinancialPositionLog) error {
 	if len(logs) == 0 {
 		return nil
@@ -128,11 +193,16 @@ func (r *PostgresRepository) CreateBatch(ctx context.Context, logs []*domain.Fin
 		_ = tx.Rollback(ctx)
 	}()
 
+	// Set tenant scope if in multi-tenant mode
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
 	// Use COPY for bulk insert of financial_position_logs
 	userID := audit.GetUserFromContext(ctx)
 	copyCount, err := tx.CopyFrom(
 		ctx,
-		pgx.Identifier{"position_keeping", "financial_position_logs"},
+		pgx.Identifier{"financial_position_logs"},
 		[]string{
 			"id", "created_at", "created_by", "updated_at", "updated_by",
 			"log_id", "account_id", "version",
@@ -202,83 +272,106 @@ func (r *PostgresRepository) CreateBatch(ctx context.Context, logs []*domain.Fin
 
 // FindByID retrieves a FinancialPositionLog by its LogID.
 // Returns domain.ErrNotFound if the log doesn't exist.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *PostgresRepository) FindByID(ctx context.Context, logID uuid.UUID) (*domain.FinancialPositionLog, error) {
-	query := `
-		SELECT id, created_at, updated_at, log_id, account_id, version,
-			current_status, previous_status, status_updated_at, status_reason, failure_reason,
-			reconciliation_status
-		FROM position_keeping.financial_position_logs
-		WHERE log_id = $1 AND deleted_at IS NULL`
+	var result *domain.FinancialPositionLog
 
-	var dbID uuid.UUID
-	var log domain.FinancialPositionLog
-	var statusTracking domain.StatusTracking
-	var currentStatus, reconciliationStatus string
-	var previousStatus sql.NullString
-	var failureReason sql.NullString
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, created_at, updated_at, log_id, account_id, version,
+				current_status, previous_status, status_updated_at, status_reason, failure_reason,
+				reconciliation_status
+			FROM financial_position_logs
+			WHERE log_id = $1 AND deleted_at IS NULL`
 
-	err := r.pool.QueryRow(ctx, query, logID).Scan(
-		&dbID, &log.CreatedAt, &log.UpdatedAt, &log.LogID, &log.AccountID, &log.Version,
-		&currentStatus, &previousStatus, &statusTracking.StatusUpdatedAt,
-		&statusTracking.StatusReason, &failureReason,
-		&reconciliationStatus,
-	)
-	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, domain.ErrNotFound
+		var dbID uuid.UUID
+		var log domain.FinancialPositionLog
+		var statusTracking domain.StatusTracking
+		var currentStatus, reconciliationStatus string
+		var previousStatus sql.NullString
+		var failureReason sql.NullString
+
+		err := tx.QueryRow(ctx, query, logID).Scan(
+			&dbID, &log.CreatedAt, &log.UpdatedAt, &log.LogID, &log.AccountID, &log.Version,
+			&currentStatus, &previousStatus, &statusTracking.StatusUpdatedAt,
+			&statusTracking.StatusReason, &failureReason,
+			&reconciliationStatus,
+		)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return domain.ErrNotFound
+			}
+			return fmt.Errorf("failed to query financial position log: %w", err)
 		}
-		return nil, fmt.Errorf("failed to query financial position log: %w", err)
-	}
 
-	// Parse status values
-	statusTracking.CurrentStatus = domain.ParseTransactionStatus(currentStatus)
-	if previousStatus.Valid {
-		prevStatus := domain.ParseTransactionStatus(previousStatus.String)
-		statusTracking.PreviousStatus = &prevStatus
-	}
-	if failureReason.Valid {
-		statusTracking.FailureReason = failureReason.String
-	}
-	statusTracking.ReconciliationStatus = domain.ParseReconciliationStatus(reconciliationStatus)
+		// Parse status values
+		statusTracking.CurrentStatus = domain.ParseTransactionStatus(currentStatus)
+		if previousStatus.Valid {
+			prevStatus := domain.ParseTransactionStatus(previousStatus.String)
+			statusTracking.PreviousStatus = &prevStatus
+		}
+		if failureReason.Valid {
+			statusTracking.FailureReason = failureReason.String
+		}
+		statusTracking.ReconciliationStatus = domain.ParseReconciliationStatus(reconciliationStatus)
 
-	log.StatusTracking = &statusTracking
+		log.StatusTracking = &statusTracking
 
-	// Load related entities
-	if err := r.loadTransactionLogEntries(ctx, dbID, &log); err != nil {
+		// Load related entities using the transaction
+		if err := r.loadTransactionLogEntriesTx(ctx, tx, dbID, &log); err != nil {
+			return err
+		}
+
+		if err := r.loadTransactionLineageTx(ctx, tx, dbID, &log); err != nil {
+			return err
+		}
+
+		if err := r.loadAuditTrailEntriesTx(ctx, tx, dbID, &log); err != nil {
+			return err
+		}
+
+		result = &log
+		return nil
+	})
+	if err != nil {
 		return nil, err
 	}
 
-	if err := r.loadTransactionLineage(ctx, dbID, &log); err != nil {
-		return nil, err
-	}
-
-	if err := r.loadAuditTrailEntries(ctx, dbID, &log); err != nil {
-		return nil, err
-	}
-
-	return &log, nil
+	return result, nil
 }
 
 // FindByAccountID retrieves all FinancialPositionLogs for a specific account.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *PostgresRepository) FindByAccountID(ctx context.Context, accountID string) ([]*domain.FinancialPositionLog, error) {
-	query := `
-		SELECT id, created_at, updated_at, log_id, account_id, version,
-			current_status, previous_status, status_updated_at, status_reason, failure_reason,
-			reconciliation_status
-		FROM position_keeping.financial_position_logs
-		WHERE account_id = $1 AND deleted_at IS NULL
-		ORDER BY created_at DESC`
+	var result []*domain.FinancialPositionLog
 
-	rows, err := r.pool.Query(ctx, query, accountID)
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, created_at, updated_at, log_id, account_id, version,
+				current_status, previous_status, status_updated_at, status_reason, failure_reason,
+				reconciliation_status
+			FROM financial_position_logs
+			WHERE account_id = $1 AND deleted_at IS NULL
+			ORDER BY created_at DESC`
+
+		rows, err := tx.Query(ctx, query, accountID)
+		if err != nil {
+			return fmt.Errorf("failed to query financial position logs: %w", err)
+		}
+		defer rows.Close()
+
+		result, err = r.scanLogsTx(ctx, tx, rows)
+		return err
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to query financial position logs: %w", err)
+		return nil, err
 	}
-	defer rows.Close()
 
-	return r.scanLogs(ctx, rows)
+	return result, nil
 }
 
 // Update updates an existing FinancialPositionLog using optimistic locking.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPositionLog) error {
 	if log == nil {
 		return ErrNilLog
@@ -292,9 +385,14 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 		_ = tx.Rollback(ctx)
 	}()
 
+	// Set tenant scope if in multi-tenant mode
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
 	// Get current database ID
 	var dbID uuid.UUID
-	err = tx.QueryRow(ctx, "SELECT id FROM position_keeping.financial_position_logs WHERE log_id = $1 AND deleted_at IS NULL", log.LogID).Scan(&dbID)
+	err = tx.QueryRow(ctx, "SELECT id FROM financial_position_logs WHERE log_id = $1 AND deleted_at IS NULL", log.LogID).Scan(&dbID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return domain.ErrNotFound
@@ -309,7 +407,7 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 	userID := audit.GetUserFromContext(ctx)
 
 	updateQuery := `
-		UPDATE position_keeping.financial_position_logs
+		UPDATE financial_position_logs
 		SET updated_at = $1, updated_by = $2, version = $3,
 			current_status = $4, previous_status = $5, status_updated_at = $6,
 			status_reason = $7, failure_reason = $8, reconciliation_status = $9
@@ -332,7 +430,7 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 	}
 
 	// Delete and re-insert transaction log entries (simplest approach for aggregate updates)
-	_, err = tx.Exec(ctx, "DELETE FROM position_keeping.transaction_log_entries WHERE financial_position_log_id = $1", dbID)
+	_, err = tx.Exec(ctx, "DELETE FROM transaction_log_entries WHERE financial_position_log_id = $1", dbID)
 	if err != nil {
 		return fmt.Errorf("failed to delete old transaction log entries: %w", err)
 	}
@@ -342,7 +440,7 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 	}
 
 	// Delete and re-insert transaction lineage
-	_, err = tx.Exec(ctx, "DELETE FROM position_keeping.transaction_lineages WHERE financial_position_log_id = $1", dbID)
+	_, err = tx.Exec(ctx, "DELETE FROM transaction_lineages WHERE financial_position_log_id = $1", dbID)
 	if err != nil {
 		return fmt.Errorf("failed to delete old transaction lineage: %w", err)
 	}
@@ -381,91 +479,113 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 }
 
 // List retrieves FinancialPositionLogs matching the given filter with pagination.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *PostgresRepository) List(ctx context.Context, filter domain.PositionLogFilter) ([]*domain.FinancialPositionLog, error) {
 	if filter.Limit <= 0 {
 		return nil, ErrInvalidLimit
 	}
 
-	query := `
-		SELECT id, created_at, updated_at, log_id, account_id, version,
-			current_status, previous_status, status_updated_at, status_reason, failure_reason,
-			reconciliation_status
-		FROM position_keeping.financial_position_logs
-		WHERE deleted_at IS NULL`
+	var result []*domain.FinancialPositionLog
 
-	args := []any{}
-	argPos := 1
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, created_at, updated_at, log_id, account_id, version,
+				current_status, previous_status, status_updated_at, status_reason, failure_reason,
+				reconciliation_status
+			FROM financial_position_logs
+			WHERE deleted_at IS NULL`
 
-	// Build WHERE clauses dynamically
-	if filter.AccountID != nil {
-		query += fmt.Sprintf(" AND account_id = $%d", argPos)
-		args = append(args, *filter.AccountID)
-		argPos++
-	}
+		args := []any{}
+		argPos := 1
 
-	if filter.Status != nil {
-		query += fmt.Sprintf(" AND current_status = $%d", argPos)
-		args = append(args, filter.Status.String())
-		argPos++
-	}
+		// Build WHERE clauses dynamically
+		if filter.AccountID != nil {
+			query += fmt.Sprintf(" AND account_id = $%d", argPos)
+			args = append(args, *filter.AccountID)
+			argPos++
+		}
 
-	if filter.ReconciliationStatus != nil {
-		query += fmt.Sprintf(" AND reconciliation_status = $%d", argPos)
-		args = append(args, filter.ReconciliationStatus.String())
-		argPos++
-	}
+		if filter.Status != nil {
+			query += fmt.Sprintf(" AND current_status = $%d", argPos)
+			args = append(args, filter.Status.String())
+			argPos++
+		}
 
-	if filter.FromDate != nil {
-		query += fmt.Sprintf(" AND updated_at >= $%d", argPos)
-		args = append(args, *filter.FromDate)
-		argPos++
-	}
+		if filter.ReconciliationStatus != nil {
+			query += fmt.Sprintf(" AND reconciliation_status = $%d", argPos)
+			args = append(args, filter.ReconciliationStatus.String())
+			argPos++
+		}
 
-	if filter.ToDate != nil {
-		query += fmt.Sprintf(" AND updated_at <= $%d", argPos)
-		args = append(args, *filter.ToDate)
-		argPos++
-	}
+		if filter.FromDate != nil {
+			query += fmt.Sprintf(" AND updated_at >= $%d", argPos)
+			args = append(args, *filter.FromDate)
+			argPos++
+		}
 
-	// Add pagination
-	query += " ORDER BY created_at DESC"
-	query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argPos, argPos+1)
-	args = append(args, filter.Limit, filter.Offset)
+		if filter.ToDate != nil {
+			query += fmt.Sprintf(" AND updated_at <= $%d", argPos)
+			args = append(args, *filter.ToDate)
+			argPos++
+		}
 
-	rows, err := r.pool.Query(ctx, query, args...)
+		// Add pagination
+		query += " ORDER BY created_at DESC"
+		query += fmt.Sprintf(" LIMIT $%d OFFSET $%d", argPos, argPos+1)
+		args = append(args, filter.Limit, filter.Offset)
+
+		rows, err := tx.Query(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("failed to query financial position logs: %w", err)
+		}
+		defer rows.Close()
+
+		result, err = r.scanLogsTx(ctx, tx, rows)
+		return err
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to query financial position logs: %w", err)
+		return nil, err
 	}
-	defer rows.Close()
 
-	return r.scanLogs(ctx, rows)
+	return result, nil
 }
 
 // FindPendingForReconciliation retrieves logs that are pending reconciliation.
+// In multi-tenant mode, the context must contain the tenant ID for schema routing.
 func (r *PostgresRepository) FindPendingForReconciliation(ctx context.Context, limit int) ([]*domain.FinancialPositionLog, error) {
-	query := `
-		SELECT id, created_at, updated_at, log_id, account_id, version,
-			current_status, previous_status, status_updated_at, status_reason, failure_reason,
-			reconciliation_status
-		FROM position_keeping.financial_position_logs
-		WHERE deleted_at IS NULL
-			AND current_status = 'PENDING'
-			AND reconciliation_status = 'UNRECONCILED'
-		ORDER BY created_at ASC`
+	var result []*domain.FinancialPositionLog
 
-	args := []any{}
-	if limit > 0 {
-		query += " LIMIT $1"
-		args = append(args, limit)
-	}
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, created_at, updated_at, log_id, account_id, version,
+				current_status, previous_status, status_updated_at, status_reason, failure_reason,
+				reconciliation_status
+			FROM financial_position_logs
+			WHERE deleted_at IS NULL
+				AND current_status = 'PENDING'
+				AND reconciliation_status = 'UNRECONCILED'
+			ORDER BY created_at ASC`
 
-	rows, err := r.pool.Query(ctx, query, args...)
+		args := []any{}
+		if limit > 0 {
+			query += " LIMIT $1"
+			args = append(args, limit)
+		}
+
+		rows, err := tx.Query(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("failed to query pending logs: %w", err)
+		}
+		defer rows.Close()
+
+		result, err = r.scanLogsTx(ctx, tx, rows)
+		return err
+	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to query pending logs: %w", err)
+		return nil, err
 	}
-	defer rows.Close()
 
-	return r.scanLogs(ctx, rows)
+	return result, nil
 }
 
 // Helper methods
@@ -476,7 +596,7 @@ func (r *PostgresRepository) insertTransactionLogEntries(ctx context.Context, tx
 	}
 
 	query := `
-		INSERT INTO position_keeping.transaction_log_entries (
+		INSERT INTO transaction_log_entries (
 			id, created_at, created_by, updated_at, updated_by,
 			entry_id, financial_position_log_id, transaction_id, account_id,
 			amount_cents, currency, direction, timestamp, description, reference, source
@@ -529,7 +649,7 @@ func (r *PostgresRepository) insertTransactionLineage(ctx context.Context, tx pg
 
 	userID := audit.GetUserFromContext(ctx)
 	query := `
-		INSERT INTO position_keeping.transaction_lineages (
+		INSERT INTO transaction_lineages (
 			id, created_at, created_by, updated_at, updated_by,
 			financial_position_log_id, transaction_id, parent_transaction_id,
 			child_transaction_ids, related_transaction_ids, transaction_type
@@ -557,7 +677,7 @@ func (r *PostgresRepository) insertAuditTrailEntries(ctx context.Context, tx pgx
 	}
 
 	query := `
-		INSERT INTO position_keeping.audit_trail_entries (
+		INSERT INTO audit_trail_entries (
 			id, created_at, created_by, updated_at, updated_by,
 			audit_id, financial_position_log_id, timestamp, user_id,
 			action, details, ip_address, system_context
@@ -598,15 +718,16 @@ func (r *PostgresRepository) insertAuditTrailEntries(ctx context.Context, tx pgx
 	return nil
 }
 
-func (r *PostgresRepository) loadTransactionLogEntries(ctx context.Context, financialPosLogID uuid.UUID, log *domain.FinancialPositionLog) error {
+// loadTransactionLogEntriesTx is a transaction-aware version of loadTransactionLogEntries.
+func (r *PostgresRepository) loadTransactionLogEntriesTx(ctx context.Context, tx pgx.Tx, financialPosLogID uuid.UUID, log *domain.FinancialPositionLog) error {
 	query := `
 		SELECT entry_id, transaction_id, account_id, amount_cents, currency,
 			direction, timestamp, description, reference, source
-		FROM position_keeping.transaction_log_entries
+		FROM transaction_log_entries
 		WHERE financial_position_log_id = $1 AND deleted_at IS NULL
 		ORDER BY timestamp ASC`
 
-	rows, err := r.pool.Query(ctx, query, financialPosLogID)
+	rows, err := tx.Query(ctx, query, financialPosLogID)
 	if err != nil {
 		return fmt.Errorf("failed to load transaction log entries: %w", err)
 	}
@@ -652,11 +773,12 @@ func (r *PostgresRepository) loadTransactionLogEntries(ctx context.Context, fina
 	return nil
 }
 
-func (r *PostgresRepository) loadTransactionLineage(ctx context.Context, financialPosLogID uuid.UUID, log *domain.FinancialPositionLog) error {
+// loadTransactionLineageTx is a transaction-aware version of loadTransactionLineage.
+func (r *PostgresRepository) loadTransactionLineageTx(ctx context.Context, tx pgx.Tx, financialPosLogID uuid.UUID, log *domain.FinancialPositionLog) error {
 	query := `
 		SELECT transaction_id, parent_transaction_id, child_transaction_ids,
 			related_transaction_ids, transaction_type
-		FROM position_keeping.transaction_lineages
+		FROM transaction_lineages
 		WHERE financial_position_log_id = $1 AND deleted_at IS NULL`
 
 	var transactionID uuid.UUID
@@ -664,7 +786,7 @@ func (r *PostgresRepository) loadTransactionLineage(ctx context.Context, financi
 	var parentID sql.NullString
 	var childIDsJSON, relatedIDsJSON []byte
 
-	err := r.pool.QueryRow(ctx, query, financialPosLogID).Scan(
+	err := tx.QueryRow(ctx, query, financialPosLogID).Scan(
 		&transactionID, &parentID,
 		&childIDsJSON, &relatedIDsJSON, &transactionType,
 	)
@@ -708,7 +830,7 @@ func (r *PostgresRepository) loadTransactionLineage(ctx context.Context, financi
 func (r *PostgresRepository) getExistingAuditIDs(ctx context.Context, tx pgx.Tx, financialPosLogID uuid.UUID) (map[uuid.UUID]struct{}, error) {
 	query := `
 		SELECT audit_id
-		FROM position_keeping.audit_trail_entries
+		FROM audit_trail_entries
 		WHERE financial_position_log_id = $1 AND deleted_at IS NULL`
 
 	rows, err := tx.Query(ctx, query, financialPosLogID)
@@ -729,14 +851,15 @@ func (r *PostgresRepository) getExistingAuditIDs(ctx context.Context, tx pgx.Tx,
 	return existingIDs, nil
 }
 
-func (r *PostgresRepository) loadAuditTrailEntries(ctx context.Context, financialPosLogID uuid.UUID, log *domain.FinancialPositionLog) error {
+// loadAuditTrailEntriesTx is a transaction-aware version of loadAuditTrailEntries.
+func (r *PostgresRepository) loadAuditTrailEntriesTx(ctx context.Context, tx pgx.Tx, financialPosLogID uuid.UUID, log *domain.FinancialPositionLog) error {
 	query := `
 		SELECT audit_id, timestamp, user_id, action, details, ip_address, system_context
-		FROM position_keeping.audit_trail_entries
+		FROM audit_trail_entries
 		WHERE financial_position_log_id = $1 AND deleted_at IS NULL
 		ORDER BY timestamp ASC`
 
-	rows, err := r.pool.Query(ctx, query, financialPosLogID)
+	rows, err := tx.Query(ctx, query, financialPosLogID)
 	if err != nil {
 		return fmt.Errorf("failed to load audit trail entries: %w", err)
 	}
@@ -776,220 +899,14 @@ func (r *PostgresRepository) loadAuditTrailEntries(ctx context.Context, financia
 	return nil
 }
 
-// loadTransactionLogEntriesBatch loads transaction log entries for multiple logs in a single query.
-// This avoids N+1 query issues when loading many logs.
-func (r *PostgresRepository) loadTransactionLogEntriesBatch(ctx context.Context, dbIDs []uuid.UUID, dbIDToLog map[uuid.UUID]*domain.FinancialPositionLog) error {
-	if len(dbIDs) == 0 {
-		return nil
+// scanLogsTx scans log rows and loads related entities using a transaction.
+// This is the transaction-aware version of scanLogs.
+func (r *PostgresRepository) scanLogsTx(ctx context.Context, tx pgx.Tx, rows pgx.Rows) ([]*domain.FinancialPositionLog, error) {
+	type logWithDBID struct {
+		log  *domain.FinancialPositionLog
+		dbID uuid.UUID
 	}
-
-	// Build IN clause with placeholders
-	placeholders := make([]string, len(dbIDs))
-	args := make([]any, len(dbIDs))
-	for i, id := range dbIDs {
-		placeholders[i] = fmt.Sprintf("$%d", i+1)
-		args[i] = id
-	}
-
-	query := fmt.Sprintf(`
-		SELECT financial_position_log_id, entry_id, transaction_id, account_id, amount_cents, currency,
-			direction, timestamp, description, reference, source
-		FROM position_keeping.transaction_log_entries
-		WHERE financial_position_log_id IN (%s) AND deleted_at IS NULL
-		ORDER BY financial_position_log_id, timestamp ASC`, strings.Join(placeholders, ","))
-
-	rows, err := r.pool.Query(ctx, query, args...)
-	if err != nil {
-		return fmt.Errorf("failed to load transaction log entries batch: %w", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var financialPosLogID uuid.UUID
-		var entry domain.TransactionLogEntry
-		var amountCents int64
-		var currency, direction, source string
-		var description, reference sql.NullString
-
-		err := rows.Scan(
-			&financialPosLogID,
-			&entry.EntryID, &entry.TransactionID, &entry.AccountID,
-			&amountCents, &currency, &direction, &entry.Timestamp,
-			&description, &reference, &source,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to scan transaction log entry in batch: %w", err)
-		}
-
-		// Convert cents to decimal and create Money
-		amount := centsToDecimal(amountCents)
-		money, err := domain.NewMoney(amount, domain.Currency(currency))
-		if err != nil {
-			return fmt.Errorf("failed to create Money value in batch: %w", err)
-		}
-		entry.Amount = money
-		entry.Direction = domain.ParsePostingDirection(direction)
-		entry.Source = domain.ParseTransactionSource(source)
-
-		if description.Valid {
-			entry.Description = description.String
-		}
-		if reference.Valid {
-			entry.Reference = reference.String
-		}
-
-		// Append to the appropriate log
-		if log, ok := dbIDToLog[financialPosLogID]; ok {
-			log.TransactionLogEntries = append(log.TransactionLogEntries, &entry)
-		}
-	}
-
-	return nil
-}
-
-// loadTransactionLineageBatch loads transaction lineages for multiple logs in a single query.
-// This avoids N+1 query issues when loading many logs.
-func (r *PostgresRepository) loadTransactionLineageBatch(ctx context.Context, dbIDs []uuid.UUID, dbIDToLog map[uuid.UUID]*domain.FinancialPositionLog) error {
-	if len(dbIDs) == 0 {
-		return nil
-	}
-
-	// Build IN clause with placeholders
-	placeholders := make([]string, len(dbIDs))
-	args := make([]any, len(dbIDs))
-	for i, id := range dbIDs {
-		placeholders[i] = fmt.Sprintf("$%d", i+1)
-		args[i] = id
-	}
-
-	query := fmt.Sprintf(`
-		SELECT financial_position_log_id, transaction_id, parent_transaction_id, child_transaction_ids,
-			related_transaction_ids, transaction_type
-		FROM position_keeping.transaction_lineages
-		WHERE financial_position_log_id IN (%s) AND deleted_at IS NULL`, strings.Join(placeholders, ","))
-
-	rows, err := r.pool.Query(ctx, query, args...)
-	if err != nil {
-		return fmt.Errorf("failed to load transaction lineage batch: %w", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var financialPosLogID uuid.UUID
-		var transactionID uuid.UUID
-		var transactionType string
-		var parentID sql.NullString
-		var childIDsJSON, relatedIDsJSON []byte
-
-		err := rows.Scan(
-			&financialPosLogID,
-			&transactionID, &parentID,
-			&childIDsJSON, &relatedIDsJSON, &transactionType,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to scan transaction lineage in batch: %w", err)
-		}
-
-		var parent *uuid.UUID
-		if parentID.Valid {
-			pid, err := uuid.Parse(parentID.String)
-			if err != nil {
-				return fmt.Errorf("failed to parse parent transaction ID in batch: %w", err)
-			}
-			parent = &pid
-		}
-
-		var childIDs []uuid.UUID
-		if err := json.Unmarshal(childIDsJSON, &childIDs); err != nil {
-			return fmt.Errorf("failed to unmarshal child transaction IDs in batch: %w", err)
-		}
-
-		var relatedIDs []uuid.UUID
-		if err := json.Unmarshal(relatedIDsJSON, &relatedIDs); err != nil {
-			return fmt.Errorf("failed to unmarshal related transaction IDs in batch: %w", err)
-		}
-
-		// Create the immutable TransactionLineage
-		lineage, err := domain.NewTransactionLineage(transactionID, transactionType, parent, childIDs, relatedIDs)
-		if err != nil {
-			return fmt.Errorf("failed to create transaction lineage in batch: %w", err)
-		}
-
-		// Assign to the appropriate log
-		if log, ok := dbIDToLog[financialPosLogID]; ok {
-			log.TransactionLineage = lineage
-		}
-	}
-
-	return nil
-}
-
-// loadAuditTrailEntriesBatch loads audit trail entries for multiple logs in a single query.
-// This avoids N+1 query issues when loading many logs.
-func (r *PostgresRepository) loadAuditTrailEntriesBatch(ctx context.Context, dbIDs []uuid.UUID, dbIDToLog map[uuid.UUID]*domain.FinancialPositionLog) error {
-	if len(dbIDs) == 0 {
-		return nil
-	}
-
-	// Build IN clause with placeholders
-	placeholders := make([]string, len(dbIDs))
-	args := make([]any, len(dbIDs))
-	for i, id := range dbIDs {
-		placeholders[i] = fmt.Sprintf("$%d", i+1)
-		args[i] = id
-	}
-
-	query := fmt.Sprintf(`
-		SELECT financial_position_log_id, audit_id, timestamp, user_id, action, details, ip_address, system_context
-		FROM position_keeping.audit_trail_entries
-		WHERE financial_position_log_id IN (%s) AND deleted_at IS NULL
-		ORDER BY financial_position_log_id, timestamp ASC`, strings.Join(placeholders, ","))
-
-	rows, err := r.pool.Query(ctx, query, args...)
-	if err != nil {
-		return fmt.Errorf("failed to load audit trail entries batch: %w", err)
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var financialPosLogID uuid.UUID
-		var entry domain.AuditTrailEntry
-		var details, ipAddress sql.NullString
-		var sysContext []byte
-
-		err := rows.Scan(
-			&financialPosLogID,
-			&entry.AuditID, &entry.Timestamp, &entry.UserID, &entry.Action,
-			&details, &ipAddress, &sysContext,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to scan audit trail entry in batch: %w", err)
-		}
-
-		if details.Valid {
-			entry.Details = details.String
-		}
-		if ipAddress.Valid {
-			entry.IPAddress = ipAddress.String
-		}
-
-		if err := json.Unmarshal(sysContext, &entry.SystemContext); err != nil {
-			return fmt.Errorf("failed to unmarshal system context in batch: %w", err)
-		}
-
-		// Append to the appropriate log
-		if log, ok := dbIDToLog[financialPosLogID]; ok {
-			log.AuditTrail = append(log.AuditTrail, &entry)
-		}
-	}
-
-	return nil
-}
-
-func (r *PostgresRepository) scanLogs(ctx context.Context, rows pgx.Rows) ([]*domain.FinancialPositionLog, error) {
-	logs := []*domain.FinancialPositionLog{}
-	dbIDToLog := make(map[uuid.UUID]*domain.FinancialPositionLog)
-	dbIDs := []uuid.UUID{}
+	logsWithIDs := []logWithDBID{}
 
 	for rows.Next() {
 		var dbID uuid.UUID
@@ -1022,27 +939,30 @@ func (r *PostgresRepository) scanLogs(ctx context.Context, rows pgx.Rows) ([]*do
 
 		log.StatusTracking = &statusTracking
 
-		logs = append(logs, &log)
-		dbIDToLog[dbID] = &log
-		dbIDs = append(dbIDs, dbID)
+		logsWithIDs = append(logsWithIDs, logWithDBID{log: &log, dbID: dbID})
 	}
 
 	// If no logs were found, return early
-	if len(logs) == 0 {
-		return logs, nil
+	if len(logsWithIDs) == 0 {
+		return []*domain.FinancialPositionLog{}, nil
 	}
 
-	// Batch load all related entities for all logs to avoid N+1 queries
-	if err := r.loadTransactionLogEntriesBatch(ctx, dbIDs, dbIDToLog); err != nil {
-		return nil, err
-	}
+	// Load related entities for each log using transaction-aware methods
+	logs := make([]*domain.FinancialPositionLog, len(logsWithIDs))
+	for i, item := range logsWithIDs {
+		if err := r.loadTransactionLogEntriesTx(ctx, tx, item.dbID, item.log); err != nil {
+			return nil, err
+		}
 
-	if err := r.loadTransactionLineageBatch(ctx, dbIDs, dbIDToLog); err != nil {
-		return nil, err
-	}
+		if err := r.loadTransactionLineageTx(ctx, tx, item.dbID, item.log); err != nil {
+			return nil, err
+		}
 
-	if err := r.loadAuditTrailEntriesBatch(ctx, dbIDs, dbIDToLog); err != nil {
-		return nil, err
+		if err := r.loadAuditTrailEntriesTx(ctx, tx, item.dbID, item.log); err != nil {
+			return nil, err
+		}
+
+		logs[i] = item.log
 	}
 
 	return logs, nil
@@ -1064,7 +984,7 @@ func (r *PostgresRepository) getLogIDMap(ctx context.Context, tx pgx.Tx, logs []
 
 	query := fmt.Sprintf(`
 		SELECT id, log_id
-		FROM position_keeping.financial_position_logs
+		FROM financial_position_logs
 		WHERE log_id IN (%s)`, strings.Join(placeholders, ","))
 
 	rows, err := tx.Query(ctx, query, args...)

--- a/services/position-keeping/adapters/persistence/postgres_repository_test.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository_test.go
@@ -47,8 +47,8 @@ func setupTestContainer(t *testing.T) *testContainer {
 	)
 	require.NoError(t, err)
 
-	// Get connection string
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	// Get connection string with search_path configured
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping,public")
 	require.NoError(t, err)
 
 	// Create connection pool

--- a/services/position-keeping/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/position-keeping/adapters/persistence/testhelpers/testcontainer.go
@@ -84,8 +84,8 @@ func SetupTestContainer(t *testing.T) *TestContainer {
 	)
 	require.NoError(t, err, "Failed to start PostgreSQL container")
 
-	// Get connection string
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	// Get connection string with search_path configured
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable", "search_path=position_keeping,public")
 	require.NoError(t, err, "Failed to get connection string")
 
 	// Create connection pool


### PR DESCRIPTION
## Summary

- Add PostgreSQL search_path-based tenant isolation to Financial-Accounting, Position-Keeping, and Payment-Order repositories
- Uses the pattern established in Party and Current-Account services
- Completes task 55 from multi-tenancy epic

## Changes Made

### Financial-Accounting (GORM)
- Add `hasTenantContext`, `withTenantScope`, `withOptionalOrgScope` helper methods
- Update all repository methods (`SavePosting`, `GetPosting`, `SaveBookingLog`, etc.) to use tenant scoping

### Payment-Order (GORM)
- Same helper method pattern as Financial-Accounting
- Update all CRUD methods (`Create`, `FindByID`, `Update`, etc.) with tenant context awareness

### Position-Keeping (pgx)
- Add `setSearchPath` for pgx transactions with `SET LOCAL search_path`
- Create `withReadTransaction` helper for read operations requiring tenant scope
- Convert schema-qualified table names to unqualified (now search_path dependent)
- Add transaction-aware versions of internal helper methods (`loadTransactionLogEntriesTx`, `loadTransactionLineageTx`, `loadAuditTrailEntriesTx`, `scanLogsTx`)

## Technical Details

**Pattern used**: `SET LOCAL search_path TO <schema>, public` within transactions
- GORM services use shared `db.WithGormTenantTransaction()` helper
- pgx service (Position-Keeping) uses custom `setSearchPath()` method

**Schema naming**: `org_{tenant_id}` (e.g., `org_123`)

**Backward compatibility**: Methods check for tenant context presence and operate in single-tenant mode when missing

## Testing

- All persistence tests pass for affected services
- golangci-lint passes with no issues

## Risk Assessment

| Service | Risk Level | Notes |
|---------|------------|-------|
| Financial-Accounting | HIGH | Ledger postings - cross-tenant data leak would be critical |
| Position-Keeping | HIGH | Transaction logs - uses pgx directly (more complex) |
| Payment-Order | MEDIUM | Payment records - sensitive financial data |