### PR TITLE
docs: Add ADR-0017 Temporal Quality Ladder and ADR-0018 Settlement & Reconciliation

### DIFF
--- a/docs/adr/0017-temporal-quality-ladder.md
+++ b/docs/adr/0017-temporal-quality-ladder.md
@@ -1124,6 +1124,51 @@ func (e PositionEntry) GetAttributes(ctx context.Context, repo MeasurementReposi
 
 For settlement and reconciliation terms, see ADR-0018.
 
+## BIAN v13 Alignment
+
+This ADR's concepts map to BIAN (Banking Industry Architecture Network) v13 service domains:
+
+| Meridian Concept | BIAN Service Domain | BIAN Entity | Notes |
+|-----------------|---------------------|-------------|-------|
+| `MeasurementLog` | Position Keeping | `FinancialPositionLog` (CR) | "Maintain a log of transactions" |
+| `Measurement` | Position Keeping | `FinancialTransactionCapture` (BQ) | Transaction capture behavior |
+| `Period [Start, End]` | Position Keeping | `datetimeperiod` | `FromDateTime` / `ToDateTime` |
+| `TransactionStatus` | Position Keeping | `transactionstatustypevalues` | Initiated, Booked, Confirmed, etc. |
+| `PositionEntry` | Financial Accounting | `LedgerPosting` (BQ) | Ledger posting behavior |
+| Correction booking | Financial Accounting | `UpdateLedgerPosting` | Explicitly for "repair" |
+| `EntryType.ADJUSTMENT` | Position Keeping | `InterestAdjustmentTransaction` | Adjustment transaction type |
+
+**BIAN Types Referenced (from `PositionKeeping.yaml`):**
+
+```yaml
+# Transaction lifecycle status
+transactionstatustypevalues:
+  - Initiated, Executed, Cancelled, Confirmed
+  - Suspended, Pending, Completed, Notified, Booked, Rejected
+
+# Amount quality indicators (partial quality ladder)
+amounttypevalues:
+  - Estimated    # Low quality
+  - Actual       # High quality
+  - Principal, Maximum, Default, Replacement, Reserved, Available
+
+# Adjustment transaction types
+interesttransactiontypevalues:
+  - InterestAllocationTransaction
+  - InterestPaymentTransaction
+  - InterestAdjustmentTransaction  # Correction pattern
+```
+
+**Extensions Beyond BIAN Standard:**
+
+The following Meridian concepts have no direct BIAN equivalent:
+
+- **Quality Ladder / Source Authority Registry**: BIAN's `amounttypevalues` has `Estimated` vs
+  `Actual`, but lacks the full quality ranking hierarchy
+- **Supersession chain** (`superseded_by`): BIAN transactions have status but not supersession
+- **Quality-based precedence rules**: The Delta Engine's decision logic is Meridian-specific
+- **Wash & Reload saga**: BIAN has adjustment transactions but not the atomic correction pattern
+
 ## Links
 
 ### Internal ADRs

--- a/docs/adr/0017-temporal-quality-ladder.md
+++ b/docs/adr/0017-temporal-quality-ladder.md
@@ -264,6 +264,13 @@ CREATE INDEX idx_measurements_tenant ON measurements(tenant_id);
 -- concurrency via position_key_hash. PostgreSQL exclusion constraints cannot
 -- handle the multi-column key (tenant_id, account_id, asset_code, attributes) with JSONB.
 --
+-- APPLICATION-LEVEL ENFORCEMENT IS THE LONG-TERM STRATEGY:
+-- PostgreSQL exclusion constraints with GiST indexes work well for simple TSTZRANGE
+-- overlap detection, but our composite key includes JSONB attributes which cannot
+-- participate in exclusion constraints. Custom operators would add complexity without
+-- proportional benefit. The application layer (DeltaEngine) already evaluates overlap
+-- as part of its supersession logic, making database-level enforcement redundant.
+--
 -- See the Overlap Prevention section in Implementation Notes for details.
 
 CREATE INDEX idx_measurements_lookup

--- a/docs/adr/0017-temporal-quality-ladder.md
+++ b/docs/adr/0017-temporal-quality-ladder.md
@@ -14,7 +14,7 @@ instructions: |
   and reconciliation, see ADR-0018.
 ---
 
-# 17. Temporal Quality Ledger (Data Physics)
+# 17. Temporal Quality Ladder (Data Physics)
 
 Date: 2025-12-14
 
@@ -248,14 +248,11 @@ CREATE TABLE measurements (
     received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     superseded_by UUID REFERENCES measurements(id),
     settlement_run VARCHAR(20),
-    locked_at TIMESTAMPTZ,
-
-    -- Prevent overlapping current positions for same tenant/account/asset/attributes
-    -- See "Overlap Prevention" section below for enforcement details
-    CONSTRAINT no_overlapping_current CHECK (
-        superseded_by IS NOT NULL OR TRUE  -- Placeholder; enforced via application logic
-    )
+    locked_at TIMESTAMPTZ
 );
+
+-- Note: Overlap prevention is NOT enforced via database constraints.
+-- See "Overlap Prevention" section below for application-level enforcement details.
 
 -- Tenant isolation index (critical for performance and security)
 CREATE INDEX idx_measurements_tenant ON measurements(tenant_id);
@@ -483,7 +480,9 @@ type DeltaEngine struct {
 // Evaluate determines what action to take for an incoming measurement.
 // Returns ActionError on failure - callers must check error before using Action.
 func (e *DeltaEngine) Evaluate(ctx context.Context, incoming Measurement) (Action, *Measurement, error) {
-    // Find existing current measurement for this position key
+    // Find existing current measurement for this position key.
+    // Note: tenant_id is extracted from ctx per project conventions (see ADR-0016).
+    // All repository methods enforce tenant isolation via ctx.
     existing, err := e.repo.FindCurrent(ctx,
         incoming.AccountID,
         incoming.AssetCode,

--- a/docs/adr/0017-temporal-quality-ladder.md
+++ b/docs/adr/0017-temporal-quality-ladder.md
@@ -1,0 +1,1138 @@
+---
+name: adr-017-temporal-quality-ladder
+description: Time-bound quality ladder pattern for temporal asset data with supersession and wash/reload corrections
+triggers:
+  - Implementing metered asset tracking (energy, compute, bandwidth)
+  - Handling out-of-order data arrival with quality-based precedence
+  - Storing measurements with audit trail and supersession
+  - Designing correction patterns for financial adjustments
+instructions: |
+  Use the Time-Bound Quality Ladder pattern when tracking assets where the "true" value for a time
+  period is not known immediately and may be revised as higher-quality data arrives. Model all
+  positions as [Start, End] ranges where Start may equal End for point-in-time events. Implement
+  supersession via the Delta Engine, corrections via Wash & Reload saga. For settlement snapshots
+  and reconciliation, see ADR-0018.
+---
+
+# 17. Temporal Quality Ledger (Data Physics)
+
+Date: 2025-12-14
+
+## Status
+
+Proposed
+
+## Context
+
+Meridian must support assets where the "true" value for a time period is not known immediately
+and may be revised over time as higher-quality data becomes available. This pattern appears
+across multiple domains:
+
+| Domain | Low Quality | Medium Quality | High Quality |
+|--------|-------------|----------------|--------------|
+| **Energy** | Profile estimate | Customer read | Smart meter actual |
+| **Advertising** | Impression count | Click reconciliation | Audit-verified |
+| **Aid/NGO** | Estimated delivery | Field report | Verified receipt |
+| **Carbon** | Provisional certificate | Registry confirmed | Auditor validated |
+
+### The Core Problem
+
+For any specific **Time Window** (e.g., 12:00–12:30), there may be multiple conflicting "truths":
+
+1. **Estimate (Low Quality):** 10 kWh (Received T+1 hour)
+2. **Customer Read (Medium Quality):** 11 kWh (Received T+1 day)
+3. **Smart Meter (High Quality):** 10.8 kWh (Received T+3 days)
+
+**The Rule:** The Ledger must store *all* of them (for audit), but the **Financial Position**
+must only reflect the *highest quality* available at the current moment.
+
+### Relationship to Other ADRs
+
+This ADR builds on:
+
+- **ADR-0013 (Universal Quantity Type System):** Provides `Quantity[D]` with dimensional safety
+- **ADR-0014 (Dynamic Asset Registry):** Provides tenant-defined assets with attribute schemas
+- **ADR-0016 (Tenant Isolation):** Provides schema-per-tenant isolation
+
+This ADR defines:
+
+- **Quality-based precedence** for competing measurements
+- **Temporal modeling** with [Start, End] periods
+- **Supersession tracking** for audit trails
+- **Wash & Reload** correction pattern
+
+For settlement snapshots and reconciliation workflows, see **ADR-0018 (Settlement & Reconciliation)**.
+
+## Decision Drivers
+
+* **Immutable audit trail**: All data received must be preserved, corrections via append not update
+* **Financial accuracy**: Positions must reflect best available data
+* **Universal applicability**: Same pattern for energy, advertising, aid, carbon
+* **100k TPS throughput**: Must support high-frequency metering without lock contention
+* **No cross-schema queries**: Services cannot join across tenant schemas
+
+## Considered Options
+
+### Option 1: Event Sourcing with Projection
+
+Store measurements as events, project current positions into read models.
+
+**Rejected because:**
+- Adds complexity (event store + projector + read model)
+- Snapshot management for long histories (14 months of half-hourly = 24k events/meter)
+- Project rules prefer simpler append-only tables over event sourcing infrastructure
+
+### Option 2: Bi-Temporal Tables (Valid Time + Transaction Time)
+
+Track both when data was true (valid time) and when we learned it (transaction time).
+
+**Rejected because:**
+- Over-engineering for this use case—we only need supersession, not time-travel queries
+- PostgreSQL temporal tables (SQL:2011) have limited tooling
+- `superseded_by` pointer achieves the audit goal more simply
+
+### Option 3: Separate Measurement vs Position Tables
+
+Measurements in one table, aggregated positions in another (materialized).
+
+**Partially adopted:**
+- Measurements table is the source of truth (adopted)
+- Position Entries table tracks movements for financial reporting (adopted)
+- Avoided: separate "current position" table (adds sync complexity)
+
+### Option 4: Mutable Positions with Audit Log
+
+Allow position updates, log changes separately.
+
+**Rejected because:**
+- Violates immutability rule
+- Audit log can drift from actual state
+- Harder to reason about during disputes
+
+## Decision Outcome
+
+Implement the **Time-Bound Quality Ladder** pattern with five components:
+
+1. **Universal Time Model**: All positions as [Start, End] ranges
+2. **Source Authority Registry**: Quality rankings for data sources
+3. **Measurement Log**: Append-only record of all inputs
+4. **Delta Engine**: Supersession evaluation logic
+5. **Correction Saga**: Wash & Reload for financial adjustments
+
+### 1. Universal Time Model
+
+**Every position is a time range where Start may equal End.**
+
+This unifies point-in-time events (transactions) with period-based measurements (metering):
+
+| Scenario | Start | End | Interpretation |
+|----------|-------|-----|----------------|
+| Bank transaction | 14:35:22 | 14:35:22 | Instant event |
+| Energy period | 12:00:00 | 12:30:00 | 30-minute consumption |
+| Voucher validity | 2025-01-01 | 2025-12-31 | Year-long validity |
+| Compute usage | 09:00:00 | 09:47:23 | Actual duration |
+
+```go
+// Period represents a time range. For point-in-time events, Start equals End.
+// All timestamps MUST be in UTC to ensure consistent comparisons and storage.
+type Period struct {
+    Start time.Time
+    End   time.Time
+}
+
+// NewPeriod creates a validated Period. Returns error if timestamps are not UTC
+// or if End is before Start.
+func NewPeriod(start, end time.Time) (Period, error) {
+    if start.Location() != time.UTC {
+        return Period{}, errors.New("period start must be in UTC")
+    }
+    if end.Location() != time.UTC {
+        return Period{}, errors.New("period end must be in UTC")
+    }
+    if end.Before(start) {
+        return Period{}, errors.New("period end cannot be before start")
+    }
+    return Period{Start: start, End: end}, nil
+}
+
+// MustPeriod creates a Period, panicking on validation failure.
+// Use only in tests or initialization where failure is fatal.
+func MustPeriod(start, end time.Time) Period {
+    p, err := NewPeriod(start, end)
+    if err != nil {
+        panic(err)
+    }
+    return p
+}
+
+func Instant(t time.Time) (Period, error) {
+    if t.Location() != time.UTC {
+        return Period{}, errors.New("instant must be in UTC")
+    }
+    return Period{Start: t, End: t}, nil
+}
+
+func (p Period) IsInstant() bool {
+    return p.Start.Equal(p.End)
+}
+
+func (p Period) Duration() time.Duration {
+    return p.End.Sub(p.Start)
+}
+
+// Overlaps returns true if this period shares any time with another.
+// Uses closed interval semantics [Start, End] matching the ADR's position model.
+// Two periods overlap if neither starts after the other ends.
+func (p Period) Overlaps(other Period) bool {
+    // Closed-interval overlap: neither period starts after the other's end
+    // This handles all cases uniformly including instants
+    return !p.Start.After(other.End) && !other.Start.After(p.End)
+}
+
+// Contains returns true if the given instant falls within this period.
+// Uses closed interval semantics [Start, End] for point containment.
+func (p Period) Contains(t time.Time) bool {
+    return !t.Before(p.Start) && !t.After(p.End)
+}
+
+// Validate checks period invariants. Prefer NewPeriod() for construction.
+func (p Period) Validate() error {
+    if p.Start.Location() != time.UTC {
+        return errors.New("period start must be in UTC")
+    }
+    if p.End.Location() != time.UTC {
+        return errors.New("period end must be in UTC")
+    }
+    if p.End.Before(p.Start) {
+        return errors.New("period end cannot be before start")
+    }
+    return nil
+}
+```
+
+**Interval Semantics (Closed `[Start, End]`):**
+
+| Method | Semantics | Rationale |
+|--------|-----------|-----------|
+| `Overlaps()` | Closed `[Start, End]` | Inclusive boundaries: `[12:00, 12:30]` overlaps `[12:30, 13:00]` at the shared instant `12:30` |
+| `Contains()` | Closed `[Start, End]` | Boundary instants belong to their period: `12:30` is "in" `[12:00, 12:30]` |
+| Instants | Point `[t, t]` | An instant `[12:30, 12:30]` overlaps itself and any period containing `12:30` |
+
+**Note on PostgreSQL TSTZRANGE:** PostgreSQL's default `[)` bounds differ from this ADR's closed
+intervals. When storing periods, use explicit bounds: `tstzrange(start, end, '[]')` for closed
+semantics. The GiST index handles both efficiently. Alternatively, translate at the repository
+layer if half-open storage is preferred for partitioning.
+
+**Database representation using PostgreSQL range types:**
+
+```sql
+CREATE TABLE measurements (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,          -- Tenant isolation (see ADR-0016)
+    account_id UUID NOT NULL,         -- References current_accounts.id
+    asset_code VARCHAR(32) NOT NULL,  -- References asset_definitions.code
+    quantity DECIMAL(38, 18) NOT NULL,
+
+    -- Time as range (point-in-time has start = end)
+    -- All timestamps MUST be in UTC (enforced at application layer)
+    period TSTZRANGE NOT NULL,
+
+    -- Attributes for fungibility
+    attributes JSONB NOT NULL DEFAULT '{}',
+
+    -- Quality ladder
+    source VARCHAR(50) NOT NULL,
+    quality_score INTEGER NOT NULL,
+
+    -- Lifecycle
+    received_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    superseded_by UUID REFERENCES measurements(id),
+    settlement_run VARCHAR(20),
+    locked_at TIMESTAMPTZ,
+
+    -- Prevent overlapping current positions for same tenant/account/asset/attributes
+    -- See "Overlap Prevention" section below for enforcement details
+    CONSTRAINT no_overlapping_current CHECK (
+        superseded_by IS NOT NULL OR TRUE  -- Placeholder; enforced via application logic
+    )
+);
+
+-- Tenant isolation index (critical for performance and security)
+CREATE INDEX idx_measurements_tenant ON measurements(tenant_id);
+
+-- Overlap prevention is enforced at the application layer using optimistic
+-- concurrency via position_key_hash. PostgreSQL exclusion constraints cannot
+-- handle the multi-column key (tenant_id, account_id, asset_code, attributes) with JSONB.
+--
+-- See the Overlap Prevention section in Implementation Notes for details.
+
+CREATE INDEX idx_measurements_lookup
+    ON measurements(tenant_id, account_id, asset_code, period)
+    WHERE superseded_by IS NULL;
+```
+
+**TSTZRANGE Handling for Instant Events:**
+
+PostgreSQL's `TSTZRANGE` with default bounds `[)` represents `[t, t)` as an empty range.
+To correctly handle instants where `Start == End`:
+
+```sql
+-- Application creates instants with closed-closed bounds
+INSERT INTO measurements (period, ...) VALUES (
+    tstzrange('2025-01-15 12:00:00+00', '2025-01-15 12:00:00+00', '[]'),  -- Instant
+    ...
+);
+
+-- GiST index handles both range and instant queries efficiently
+-- Range containment: period @> tstzrange('2025-01-15 12:00', '2025-01-15 12:30', '[)')
+-- Instant lookup: period @> '2025-01-15 12:15:00+00'::timestamptz
+```
+
+The application's `Instant(t)` function creates closed-closed ranges `[t, t]` which
+PostgreSQL normalizes to a point. The GiST index supports both range overlap queries
+and point containment queries efficiently.
+
+**TSTZRANGE Integration Tests (Required):**
+
+Before production deployment, verify PostgreSQL's TSTZRANGE behavior with integration tests:
+
+```go
+func TestTSTZRANGE_InstantHandling(t *testing.T) {
+    db := setupTestDB(t)
+
+    tests := []struct {
+        name     string
+        setup    string
+        query    string
+        expected bool
+    }{
+        {
+            name:     "point-in-range query works",
+            setup:    "INSERT INTO measurements (period) VALUES (tstzrange('2025-01-15 12:00+00', '2025-01-15 13:00+00', '[)'))",
+            query:    "SELECT EXISTS(SELECT 1 FROM measurements WHERE period @> '2025-01-15 12:30+00'::timestamptz)",
+            expected: true,
+        },
+        {
+            name:     "instant-to-instant overlap detected",
+            setup:    "INSERT INTO measurements (period) VALUES (tstzrange('2025-01-15 12:00+00', '2025-01-15 12:00+00', '[]'))",
+            query:    "SELECT EXISTS(SELECT 1 FROM measurements WHERE period && tstzrange('2025-01-15 12:00+00', '2025-01-15 12:00+00', '[]'))",
+            expected: true,
+        },
+        {
+            name:     "instant at range boundary (exclusive end)",
+            setup:    "INSERT INTO measurements (period) VALUES (tstzrange('2025-01-15 12:00+00', '2025-01-15 13:00+00', '[)'))",
+            query:    "SELECT EXISTS(SELECT 1 FROM measurements WHERE period @> '2025-01-15 13:00+00'::timestamptz)",
+            expected: false, // 13:00 is exclusive end
+        },
+        {
+            name:     "GiST index used for range query",
+            setup:    "INSERT INTO measurements (period) VALUES (tstzrange('2025-01-15 12:00+00', '2025-01-15 13:00+00', '[)'))",
+            query:    "EXPLAIN SELECT * FROM measurements WHERE period && tstzrange('2025-01-15 12:00+00', '2025-01-15 12:30+00', '[)')",
+            expected: true, // Should show "Index Scan using idx_measurements_period"
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            // ... test implementation ...
+        })
+    }
+}
+```
+
+These tests validate:
+1. Point-in-range containment queries work correctly
+2. Instant-to-instant overlap detection (critical for duplicate prevention)
+3. Half-open interval boundary behavior (`[)` excludes end)
+4. GiST index is actually used for range queries (query plan verification)
+
+### 2. Source Authority Registry
+
+The **Source Authority Registry** is the canonical source for quality rankings. Measurements
+MAY carry a denormalized snapshot of the quality score at ingestion for query performance,
+but this cached value can diverge if the registry is updated post-ingestion.
+
+**Important:** All authoritative decisions (supersession, dispute routing) must consult
+the registry rather than relying solely on denormalized measurement values. The denormalized
+`QualityScore` field on measurements is an optimization for read-heavy queries, not the
+source of truth.
+
+```go
+// SourceAuthority defines the quality ranking for a data source.
+// Stored in the Asset Directory service.
+type SourceAuthority struct {
+    Code            string    // "SMETS2_METER", "FORECAST_ML"
+    AssetCode       string    // Source rankings can be asset-specific
+    QualityScore    int       // Higher = more authoritative (0-100)
+    Description     string
+    ValidFrom       time.Time
+    ValidTo         *time.Time // Null = currently valid
+}
+```
+
+**Example Source Quality Rankings:**
+
+| Source Code | Quality Score | Description |
+|-------------|---------------|-------------|
+| `DEFAULT_PROFILE` | 10 | Regulatory default when no data |
+| `ESTIMATED_HISTORIC` | 20 | Same period last year |
+| `ESTIMATED_PROFILE` | 30 | Profile coefficient calculation |
+| `CUSTOMER_READ` | 50 | Customer-submitted reading |
+| `ACTUAL_UNVALIDATED` | 70 | Meter reading, not yet validated |
+| `ACTUAL_VALIDATED` | 90 | Meter reading, passed validation |
+| `ACTUAL_FINAL` | 100 | Final settlement reading |
+
+**Lookup at measurement ingestion:**
+
+```go
+func (r *SourceAuthorityRegistry) GetQualityScore(
+    ctx context.Context,
+    assetCode string,
+    sourceCode string,
+    asOf time.Time,
+) (int, error) {
+    var authority SourceAuthority
+    err := r.db.Where(
+        "asset_code = ? AND code = ? AND valid_from <= ? AND (valid_to IS NULL OR valid_to > ?)",
+        assetCode, sourceCode, asOf, asOf,
+    ).First(&authority).Error
+
+    if err != nil {
+        return 0, fmt.Errorf("unknown source %s for asset %s: %w", sourceCode, assetCode, err)
+    }
+    return authority.QualityScore, nil
+}
+```
+
+**Note:** For temporal authority (forecasts vs actuals based on time context), see ADR-0018.
+
+### 3. Measurement Log
+
+The Measurement Log is an append-only record in Position Keeping. It stores everything
+received, regardless of quality. Nothing is deleted or updated (except supersession pointers).
+
+```go
+// Measurement represents a single data point received for a position.
+// Immutable after creation except for SupersededBy pointer.
+type Measurement struct {
+    ID            uuid.UUID
+    AccountID     uuid.UUID   // References Current Account
+    AssetCode     string      // References Asset Directory
+    Quantity      decimal.Decimal
+
+    // Temporal
+    Period        Period    // [Start, End], Start may equal End
+
+    // Fungibility attributes (from ADR-0014)
+    Attributes    map[string]string
+
+    // Quality ladder
+    Source        string    // Lookup key into Source Authority Registry
+    QualityScore  int       // Denormalized snapshot at ingestion (see Source Authority Registry
+                            // section). May diverge from registry if rankings change post-ingestion.
+                            // Authoritative decisions must consult registry, not this cached value.
+
+    // Lifecycle
+    ReceivedAt    time.Time
+    SupersededBy  *uuid.UUID  // Points to replacement measurement
+
+    // Settlement
+    SettlementRun string      // "D+1", "D+5", "M+14", "FINAL"
+    LockedAt      *time.Time  // Non-null = cannot be superseded
+}
+
+// IsCurrent returns true if this measurement has not been superseded.
+func (m Measurement) IsCurrent() bool {
+    return m.SupersededBy == nil
+}
+
+// IsLocked returns true if this measurement cannot be superseded.
+func (m Measurement) IsLocked() bool {
+    return m.LockedAt != nil
+}
+```
+
+### 4. Delta Engine
+
+The Delta Engine evaluates incoming measurements and determines the appropriate action.
+
+```go
+type Action int
+
+const (
+    ActionError Action = iota - 1    // Sentinel for error state (never returned on success)
+    ActionBookNew                    // No existing data, book this measurement
+    ActionArchiveOnly                // Lower quality, keep for audit only
+    ActionWashAndReload              // Higher quality, trigger correction
+    ActionIgnoreDuplicate            // Same source, same value, idempotent skip
+    ActionCreateDispute              // Position is locked, route to dispute workflow
+)
+
+// DeltaEngine evaluates incoming measurements against existing positions.
+type DeltaEngine struct {
+    repo MeasurementRepository
+}
+
+// Evaluate determines what action to take for an incoming measurement.
+// Returns ActionError on failure - callers must check error before using Action.
+func (e *DeltaEngine) Evaluate(ctx context.Context, incoming Measurement) (Action, *Measurement, error) {
+    // Find existing current measurement for this position key
+    existing, err := e.repo.FindCurrent(ctx,
+        incoming.AccountID,
+        incoming.AssetCode,
+        incoming.Period,
+        incoming.Attributes,
+    )
+    if err != nil && !errors.Is(err, ErrNotFound) {
+        return ActionError, nil, err
+    }
+
+    // Case D: No existing measurement - book as new
+    if existing == nil {
+        return ActionBookNew, nil, nil
+    }
+
+    // Case: Position is locked (final settlement)
+    if existing.IsLocked() {
+        return ActionCreateDispute, existing, nil
+    }
+
+    // Case E: Duplicate detection - must match source, value, period, AND attributes
+    // to be considered a true duplicate (idempotent retry)
+    if incoming.Source == existing.Source &&
+       incoming.Quantity.Equal(existing.Quantity) &&
+       incoming.Period.Start.Equal(existing.Period.Start) &&
+       incoming.Period.End.Equal(existing.Period.End) &&
+       mapsEqual(incoming.Attributes, existing.Attributes) {
+        return ActionIgnoreDuplicate, existing, nil
+    }
+
+    // Case A: New data is lower quality - archive only
+    if incoming.QualityScore < existing.QualityScore {
+        return ActionArchiveOnly, existing, nil
+    }
+
+    // Case B: New data is higher quality - wash and reload
+    if incoming.QualityScore > existing.QualityScore {
+        return ActionWashAndReload, existing, nil
+    }
+
+    // Case C: Same quality, different value - latest wins
+    // Note: For sub-millisecond collision handling, see compareSameQuality()
+    // in the Concurrency Handling section.
+    if incoming.ReceivedAt.After(existing.ReceivedAt) {
+        return ActionWashAndReload, existing, nil
+    }
+
+    // Stale same-quality data
+    return ActionArchiveOnly, existing, nil
+}
+
+// mapsEqual checks if two string maps have identical keys and values.
+func mapsEqual(a, b map[string]string) bool {
+    if len(a) != len(b) {
+        return false
+    }
+    for k, v := range a {
+        if bv, ok := b[k]; !ok || bv != v {
+            return false
+        }
+    }
+    return true
+}
+```
+
+**Decision flow diagram:**
+
+```
+New Measurement Arrives
+         │
+         ▼
+┌─────────────────────┐
+│ Save to Measurement │
+│ Log (always)        │
+└─────────────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│ Find existing       │
+│ current measurement │
+└─────────────────────┘
+         │
+    ┌────┴────┐
+    │ Exists? │
+    └────┬────┘
+    No ──┴── Yes
+    │         │
+    ▼         ▼
+  BOOK    ┌──────────┐
+  NEW     │ Locked?  │
+          └────┬─────┘
+          Yes ─┴─ No
+          │       │
+          ▼       ▼
+       DISPUTE  Compare Quality
+                │
+                ├── New < Existing → ARCHIVE ONLY
+                │
+                ├── New > Existing → WASH & RELOAD
+                │
+                └── New = Existing
+                    │
+                    ├── Same value → IGNORE (duplicate)
+                    │
+                    └── Different → WASH & RELOAD (latest wins)
+```
+
+### 5. Correction Saga: Wash & Reload
+
+When higher-quality data arrives, the Correction Saga creates financial adjustments
+without mutating historical records.
+
+**Scenario:**
+- Current position: 10 units (estimate, settled)
+- New measurement: 12 units (actual)
+- Action: Reverse old, book new, net effect +2 units
+
+```go
+// CorrectionSaga handles the atomic wash and reload of positions.
+type CorrectionSaga struct {
+    db                *gorm.DB
+    measurementRepo   MeasurementRepository
+    positionEntryRepo PositionEntryRepository
+}
+
+// Execute performs an atomic wash (reversal) and reload (booking).
+// Respects context timeout/cancellation for long-running transactions.
+func (s *CorrectionSaga) Execute(
+    ctx context.Context,
+    old *Measurement,
+    new *Measurement,
+) error {
+    return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+        // 1. Mark old measurement as superseded
+        if err := tx.Model(old).Update("superseded_by", new.ID).Error; err != nil {
+            return fmt.Errorf("failed to mark supersession: %w", err)
+        }
+
+        // 2. Create reversal entry (the "Wash")
+        wash := PositionEntry{
+            ID:            uuid.New(),
+            MeasurementID: old.ID,
+            AccountID:     old.AccountID,
+            AssetCode:     old.AssetCode,
+            Period:        old.Period,
+            Quantity:      old.Quantity.Neg(),  // Negative to reverse
+            EntryType:     EntryTypeCorrectionReversal,
+            CorrectionRef: new.ID,
+            CreatedAt:     time.Now(),
+        }
+        if err := tx.Create(&wash).Error; err != nil {
+            return fmt.Errorf("failed to create wash entry: %w", err)
+        }
+
+        // 3. Create booking entry (the "Reload")
+        reload := PositionEntry{
+            ID:            uuid.New(),
+            MeasurementID: new.ID,
+            AccountID:     new.AccountID,
+            AssetCode:     new.AssetCode,
+            Period:        new.Period,
+            Quantity:      new.Quantity,
+            EntryType:     EntryTypeCorrectionBooking,
+            CorrectionRef: old.ID,
+            CreatedAt:     time.Now(),
+        }
+        if err := tx.Create(&reload).Error; err != nil {
+            return fmt.Errorf("failed to create reload entry: %w", err)
+        }
+
+        return nil
+    })
+}
+```
+
+**Audit trail after correction:**
+
+```
+Position Entries for Account METER-001, Period 12:00-12:30:
+
+┌──────────────┬──────────┬───────────────────────┬─────────────────┐
+│ Entry ID     │ Quantity │ Type                  │ Measurement Ref │
+├──────────────┼──────────┼───────────────────────┼─────────────────┤
+│ entry_001    │ +10.00   │ BOOKING               │ meas_001 (est)  │
+│ entry_047    │ -10.00   │ CORRECTION_REVERSAL   │ meas_001 (est)  │
+│ entry_048    │ +12.00   │ CORRECTION_BOOKING    │ meas_089 (act)  │
+├──────────────┼──────────┼───────────────────────┼─────────────────┤
+│ Net Position │ +12.00   │                       │                 │
+└──────────────┴──────────┴───────────────────────┴─────────────────┘
+```
+
+**Defensive Tests (Per ADR-0008):**
+
+The CorrectionSaga requires comprehensive unhappy-path testing:
+
+```go
+func TestCorrectionSaga_Execute_DefensiveTests(t *testing.T) {
+    tests := []struct {
+        name        string
+        scenario    string
+        setup       func(*testing.T, *testDB) (*Measurement, *Measurement)
+        wantErr     error
+        wantRollback bool
+    }{
+        {
+            name:     "old measurement already superseded",
+            scenario: "Prevent double-supersession when concurrent process wins",
+            setup: func(t *testing.T, db *testDB) (*Measurement, *Measurement) {
+                old := createMeasurement(t, db, withSupersededBy(uuid.New()))
+                new := createMeasurement(t, db)
+                return old, new
+            },
+            wantErr:     ErrAlreadySuperseded,
+            wantRollback: true,
+        },
+        {
+            name:     "old and new have different account IDs",
+            scenario: "Cross-account corruption check",
+            setup: func(t *testing.T, db *testDB) (*Measurement, *Measurement) {
+                old := createMeasurement(t, db, withAccountID(uuid.New()))
+                new := createMeasurement(t, db, withAccountID(uuid.New())) // Different!
+                return old, new
+            },
+            wantErr:     ErrCrossAccountCorrection,
+            wantRollback: true,
+        },
+        {
+            name:     "transaction timeout during wash entry creation",
+            scenario: "Ensure full rollback on timeout mid-transaction",
+            setup: func(t *testing.T, db *testDB) (*Measurement, *Measurement) {
+                old := createMeasurement(t, db)
+                new := createMeasurement(t, db)
+                db.setLatency(10 * time.Second) // Trigger timeout
+                return old, new
+            },
+            wantErr:     context.DeadlineExceeded,
+            wantRollback: true,
+        },
+        {
+            name:     "old measurement is locked (final settlement)",
+            scenario: "Cannot correct locked positions",
+            setup: func(t *testing.T, db *testDB) (*Measurement, *Measurement) {
+                old := createMeasurement(t, db, withLockedAt(time.Now()))
+                new := createMeasurement(t, db)
+                return old, new
+            },
+            wantErr:     ErrPositionLocked,
+            wantRollback: true,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+            defer cancel()
+
+            db := newTestDB(t)
+            old, new := tt.setup(t, db)
+
+            saga := NewCorrectionSaga(db)
+            err := saga.Execute(ctx, old, new)
+
+            require.ErrorIs(t, err, tt.wantErr, "scenario: %s", tt.scenario)
+
+            if tt.wantRollback {
+                // Verify no partial state: old not superseded, no entries created
+                assertNotSuperseded(t, db, old.ID)
+                assertNoEntriesFor(t, db, new.ID)
+            }
+        })
+    }
+}
+```
+
+## Service Responsibilities
+
+| Component | Service | Notes |
+|-----------|---------|-------|
+| Source Authority Registry | Asset Directory | Quality rankings per source |
+| Measurement Log | Position Keeping | Append-only, immutable |
+| Delta Engine | Position Keeping | Supersession evaluation |
+| Correction Saga | Position Keeping | Wash & Reload execution |
+| Position Entries | Position Keeping | Net position calculation |
+
+For settlement snapshots and reconciliation service responsibilities, see ADR-0018.
+
+## Consequences
+
+### Positive
+
+* **Complete audit trail**: Every measurement preserved, corrections are explicit entries
+* **Clear lineage**: Supersession chain shows estimate → read → actual progression
+* **Financial accuracy**: Positions reflect best available data at any point in time
+* **Universal pattern**: Same model for energy, advertising, aid, carbon, compute
+
+### Negative
+
+* **Storage growth**: All measurements kept forever (required for audit)
+* **Query complexity**: "Current" position requires filtering superseded records
+* **Materialized views**: May need for performance at scale
+
+## Implementation Notes
+
+### Database Indexes for Performance
+
+```sql
+-- Fast lookup of current measurement for a position
+CREATE INDEX idx_measurements_current
+    ON measurements(account_id, asset_code, period)
+    WHERE superseded_by IS NULL;
+
+-- Period overlap queries
+CREATE INDEX idx_measurements_period
+    ON measurements USING GIST (period);
+
+-- Attribute-based reporting and analytics queries
+CREATE INDEX idx_measurements_attributes
+    ON measurements USING GIN (attributes);
+```
+
+### Overlap Prevention
+
+Preventing overlapping current positions uses **optimistic concurrency** rather than
+pessimistic locking. This is critical for the 100k TPS throughput requirement—SERIALIZABLE
+isolation would cause unacceptable contention.
+
+**Strategy: Position Key Hash with Unique Constraint**
+
+```sql
+-- Helper function for deterministic JSONB hashing (sorted keys)
+CREATE OR REPLACE FUNCTION canonicalize_jsonb(j JSONB) RETURNS TEXT AS $$
+DECLARE
+    result TEXT := '{';
+    key TEXT;
+    val JSONB;
+    first BOOLEAN := TRUE;
+BEGIN
+    FOR key, val IN SELECT * FROM jsonb_each(j) ORDER BY 1
+    LOOP
+        IF NOT first THEN
+            result := result || ',';
+        END IF;
+        result := result || '"' || key || '":' || val::text;
+        first := FALSE;
+    END LOOP;
+    RETURN result || '}';
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Add position key hash for optimistic concurrency
+-- Uses canonicalize_jsonb() for deterministic attribute ordering
+ALTER TABLE measurements ADD COLUMN position_key_hash BYTEA GENERATED ALWAYS AS (
+    sha256(
+        account_id::text || '|' ||
+        asset_code || '|' ||
+        canonicalize_jsonb(COALESCE(attributes, '{}'::jsonb)) || '|' ||
+        lower(period)::text || '|' ||
+        upper(period)::text
+    )
+) STORED;
+
+-- Partial unique index on non-superseded measurements
+CREATE UNIQUE INDEX idx_measurements_position_unique
+    ON measurements(position_key_hash)
+    WHERE superseded_by IS NULL;
+```
+
+### Hash Collision Risk Assessment
+
+> **TL;DR:** SHA-256 collision probability is ~1 in 2^128. You will never see one.
+
+| Factor | Value |
+|--------|-------|
+| Hash algorithm | SHA-256 (256-bit output) |
+| Collision probability (birthday) | ~1 in 2^128 for 2^64 hashes |
+| At 100k TPS | Would take ~5.8 billion years to reach 2^64 measurements |
+| Operational impact if it occurred | `ErrOverlappingPosition` for non-overlapping position |
+| Mitigation | Exact key comparison on collision, escalate to manual review |
+
+```go
+// BookMeasurement uses optimistic concurrency via unique constraint violation.
+// On collision, verifies it's a true overlap vs hash collision before rejecting.
+func (r *MeasurementRepository) BookMeasurement(ctx context.Context, m *Measurement) error {
+    err := r.db.Create(m).Error
+    if err != nil {
+        if isUniqueViolation(err, "idx_measurements_position_unique") {
+            // Verify true overlap vs hash collision (astronomically unlikely)
+            existing, _ := r.findByExactKey(ctx, m.AccountID, m.AssetCode, m.Period, m.Attributes)
+            if existing == nil {
+                // Hash collision! Log for investigation, this should never happen
+                log.Error("SHA-256 hash collision detected", "measurement", m.ID)
+                return fmt.Errorf("%w: possible hash collision, escalate to support", ErrOverlappingPosition)
+            }
+            return ErrOverlappingPosition
+        }
+        return err
+    }
+    return nil
+}
+```
+
+```go
+// Supersede uses optimistic lock on the existing row
+func (r *MeasurementRepository) Supersede(ctx context.Context, oldID, newID uuid.UUID) error {
+    result := r.db.Model(&Measurement{}).
+        Where("id = ? AND superseded_by IS NULL", oldID).
+        Update("superseded_by", newID)
+
+    if result.RowsAffected == 0 {
+        return ErrAlreadySuperseded  // Lost race - caller should retry or archive
+    }
+    return result.Error
+}
+```
+
+**Why not SERIALIZABLE?**
+- At 100k TPS, serialization failures would cause cascading retries
+- Position Key Hash gives O(1) conflict detection via B-tree index
+- Retry logic only needed for actual conflicts, not phantom reads
+
+**Attribute Matching:**
+
+Attributes are included in the position key hash, meaning **exact equality** is required
+for collision detection. This is the correct default—positions with different attributes
+are different positions (e.g., peak vs off-peak tariff periods).
+
+### Concurrency Handling
+
+Supersession uses optimistic locking via the `WHERE superseded_by IS NULL` clause
+(see `Supersede()` in Overlap Prevention section above).
+
+**Retry Strategy for `ErrAlreadySuperseded`:**
+
+When concurrent processes attempt to supersede the same measurement, one wins and
+the other receives `ErrAlreadySuperseded`. The losing caller should:
+
+```go
+func (s *MeasurementIngestionService) IngestWithRetry(ctx context.Context, m *Measurement) error {
+    const maxRetries = 3
+    for attempt := 0; attempt < maxRetries; attempt++ {
+        action, existing, err := s.deltaEngine.Evaluate(ctx, m)
+        if err != nil {
+            return err
+        }
+
+        switch action {
+        case ActionWashAndReload:
+            err = s.correctionSaga.Execute(ctx, existing, m)
+            if errors.Is(err, ErrAlreadySuperseded) {
+                // Another process superseded first - re-evaluate
+                continue
+            }
+            return err
+        // ... other cases ...
+        }
+    }
+    return fmt.Errorf("failed to ingest after %d retries", maxRetries)
+}
+```
+
+This is safe because re-evaluation will see the new current measurement and make
+the correct decision (likely `ActionArchiveOnly` if the winner had higher quality).
+
+**High-Contention Position Locking (Optional):**
+
+For positions with extremely high write frequency (e.g., real-time meter aggregations),
+the optimistic retry loop may cause excessive contention. In these cases, use distributed
+locking before Delta Engine evaluation:
+
+```go
+func (s *MeasurementIngestionService) IngestWithLock(ctx context.Context, m *Measurement) error {
+    // 1. Compute position key hash (same as position_key_hash column)
+    keyHash := computePositionKeyHash(m.AccountID, m.AssetCode, m.Period, m.Attributes)
+
+    // 2. Acquire distributed lock with short TTL
+    lockKey := fmt.Sprintf("position-lock:%x", keyHash)
+    acquired, err := s.distributedLock.TryAcquire(ctx, lockKey, 5*time.Second)
+    if err != nil {
+        return fmt.Errorf("lock acquisition failed: %w", err)
+    }
+    if !acquired {
+        return ErrConcurrentIngestion // Caller should retry with backoff
+    }
+    defer s.distributedLock.Release(ctx, lockKey)
+
+    // 3. Now safe to evaluate - we have exclusive access to this position
+    action, existing, err := s.deltaEngine.Evaluate(ctx, m)
+    if err != nil {
+        return err
+    }
+
+    // 4. Execute action under lock
+    switch action {
+    case ActionWashAndReload:
+        return s.correctionSaga.Execute(ctx, existing, m)
+    // ... other cases ...
+    }
+    return nil
+}
+```
+
+**When to use distributed locking vs optimistic retry:**
+
+| Scenario | Recommended Approach |
+|----------|---------------------|
+| Normal ingestion (<100 writes/sec/position) | Optimistic retry |
+| High-frequency aggregation (>100 writes/sec/position) | Distributed lock |
+| Batch imports | Distributed lock per position key |
+| Settlement run locking | Distributed lock (prevents concurrent finalization) |
+
+**Simultaneous arrival of same-quality measurements:**
+
+When two measurements with identical quality scores arrive at the same millisecond for
+the same position, `ReceivedAt` comparison becomes non-deterministic. Handle this with:
+
+```go
+// Measurement includes optional source-specific sequence for tiebreaking.
+type Measurement struct {
+    // ... existing fields ...
+
+    // SourceSequence provides deterministic ordering when ReceivedAt is identical.
+    // For smart meters: cumulative read count. For APIs: request sequence number.
+    // Null if source doesn't provide sequencing.
+    SourceSequence *int64
+}
+
+// compareSameQuality determines winner when quality scores are equal.
+func compareSameQuality(a, b *Measurement) *Measurement {
+    // Primary: ReceivedAt
+    if !a.ReceivedAt.Equal(b.ReceivedAt) {
+        if a.ReceivedAt.After(b.ReceivedAt) {
+            return a
+        }
+        return b
+    }
+
+    // Secondary: SourceSequence (if both have it)
+    if a.SourceSequence != nil && b.SourceSequence != nil {
+        if *a.SourceSequence > *b.SourceSequence {
+            return a
+        }
+        return b
+    }
+
+    // Tertiary: Lexicographic ID comparison (deterministic fallback)
+    if a.ID.String() > b.ID.String() {
+        return a
+    }
+    return b
+}
+```
+
+## Error Taxonomy
+
+Domain-specific errors for the temporal quality ladder:
+
+```go
+var (
+    // ErrNotFound indicates no measurement exists for the given position key.
+    ErrNotFound = errors.New("measurement not found")
+
+    // ErrAlreadySuperseded indicates the measurement was superseded by another
+    // process between read and write (optimistic lock failure).
+    ErrAlreadySuperseded = errors.New("measurement already superseded")
+
+    // ErrPositionLocked indicates the position is in final settlement and cannot
+    // be modified. New data should route to dispute workflow.
+    ErrPositionLocked = errors.New("position is locked for final settlement")
+
+    // ErrInvalidPeriod indicates the period end is before start.
+    ErrInvalidPeriod = errors.New("invalid period: end before start")
+
+    // ErrUnknownSource indicates the source code is not registered in the
+    // Source Authority Registry.
+    ErrUnknownSource = errors.New("unknown source authority")
+
+    // ErrOverlappingPosition indicates an attempt to book a measurement that
+    // overlaps with an existing non-superseded measurement (same account/asset/attributes).
+    ErrOverlappingPosition = errors.New("overlapping position exists")
+)
+```
+
+## Entry Types
+
+Position entries track all movements including corrections:
+
+```go
+type EntryType string
+
+const (
+    // EntryTypeBooking is the initial booking of a measurement.
+    EntryTypeBooking EntryType = "BOOKING"
+
+    // EntryTypeCorrectionReversal is the "wash" - negates a previous booking.
+    EntryTypeCorrectionReversal EntryType = "CORRECTION_REVERSAL"
+
+    // EntryTypeCorrectionBooking is the "reload" - books the replacement value.
+    EntryTypeCorrectionBooking EntryType = "CORRECTION_BOOKING"
+
+    // EntryTypeTransfer moves quantity between accounts (same asset).
+    EntryTypeTransfer EntryType = "TRANSFER"
+
+    // EntryTypeAdjustment is a manual correction by an operator.
+    EntryTypeAdjustment EntryType = "ADJUSTMENT"
+
+    // EntryTypeDispute is a correction resulting from dispute resolution.
+    EntryTypeDispute EntryType = "DISPUTE"
+)
+
+// PositionEntry represents a single change to an account's position.
+// Note: Attributes are NOT stored on entries - they are always derived from the
+// linked Measurement via MeasurementID. This avoids duplication and ensures
+// attribute changes propagate correctly through the supersession chain.
+type PositionEntry struct {
+    ID            uuid.UUID
+    MeasurementID uuid.UUID       // Source measurement (attributes derivable from here)
+    AccountID     uuid.UUID
+    AssetCode     string
+    Period        Period
+    Quantity      decimal.Decimal // Positive or negative
+    EntryType     EntryType
+    CorrectionRef *uuid.UUID      // Links wash/reload pairs
+    CreatedAt     time.Time
+}
+
+// GetAttributes returns attributes from the source measurement.
+func (e PositionEntry) GetAttributes(ctx context.Context, repo MeasurementRepository) (map[string]string, error) {
+    m, err := repo.FindByID(ctx, e.MeasurementID)
+    if err != nil {
+        return nil, err
+    }
+    return m.Attributes, nil
+}
+```
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| **Quality Ladder** | Hierarchy of data sources ranked by authority (e.g., estimate < customer read < meter actual) |
+| **Wash & Reload** | Correction pattern: reverse old position entry, book new entry, preserving audit trail |
+| **Supersession** | Replacement of one measurement by another of higher quality for the same position |
+| **Position Key** | Composite identifier: (tenant_id, account_id, asset_code, period, attributes) |
+| **Delta Engine** | Decision component that evaluates incoming measurements against current state |
+
+For settlement and reconciliation terms, see ADR-0018.
+
+## Links
+
+### Internal ADRs
+
+* [ADR-0013: Universal Quantity Type System](0013-generic-asset-quantity-types.md) - Quantity and rate types
+* [ADR-0014: Dynamic Asset Registry & Lifecycle](0014-dynamic-asset-registry.md) - Asset definitions and attributes
+* [ADR-0016: Tenant Isolation](0016-tenant-id-naming-strategy.md) - Multi-tenancy and schema separation
+* [ADR-0018: Settlement & Reconciliation](0018-settlement-reconciliation.md) - Settlement snapshots, temporal authority, reconciliation workflows
+
+### External References
+
+* [UK Balancing and Settlement Code (BSC)](https://www.elexon.co.uk/bsc-and-codes/)

--- a/docs/adr/0018-settlement-reconciliation.md
+++ b/docs/adr/0018-settlement-reconciliation.md
@@ -1,0 +1,955 @@
+---
+name: adr-018-settlement-reconciliation
+description: Settlement lifecycle, temporal authority, reconciliation workflows, and dispute handling
+triggers:
+  - Implementing settlement runs with finality windows
+  - Building reconciliation between settled and actual values
+  - Handling provisional vs final settlement states
+  - Managing disputes for locked positions
+instructions: |
+  Use this ADR when implementing settlement workflows that capture measurement state at settlement
+  time, reconcile variances when better data arrives, and manage the transition from provisional
+  to final settlement. For the underlying data model (measurements, supersession, quality ladder),
+  see ADR-0017.
+---
+
+# 18. Settlement & Reconciliation (Lifecycle)
+
+Date: 2025-12-14
+
+## Status
+
+Proposed
+
+## Context
+
+This ADR defines the **lifecycle** aspects of temporal asset management:
+
+- **When** measurements become authoritative (Temporal Authority)
+- **How** financial positions are captured for settlement (Settlement Snapshots)
+- **How** variances are detected and resolved (Reconciliation)
+- **What** happens after final settlement (Disputes)
+
+This ADR builds on **ADR-0017 (Temporal Quality Ledger)** which defines the underlying
+data physics: the measurement log, quality ladder, supersession, and wash/reload correction pattern.
+
+### Real-World Settlement Patterns
+
+Energy industry settlement runs demonstrate the need for lifecycle management:
+
+| Run | Timing | Data Quality | Finality |
+|-----|--------|--------------|----------|
+| D+1 | Day after | Estimates, some actuals | Provisional |
+| D+5 | 5 days after | Most actuals | Provisional |
+| M+3 | 3 months after | Validated actuals | Near-final |
+| M+14 | 14 months after | Fully reconciled | **Final** |
+
+After final settlement, corrections become disputes rather than automatic adjustments.
+
+### The Temporal Authority Problem
+
+Most ledgers treat the database as "The State of Now." Meridian manages the **Entire Timeline
+of Value** - past (audit, integrity, settlement) AND future (forecasts, commitments, hedging).
+
+**The Key Insight:** A Forecast is the **Golden Source** for tomorrow, but **Garbage** for
+yesterday. Without modeling this "Temporal Weighting," you get the classic billing disaster:
+
+1. Bill customer based on Forecast (because Actuals weren't in yet)
+2. Actuals arrive
+3. System overwrites Forecast
+4. **Bug:** You've lost the record of *why* you billed that amount. The variance is inexplicable.
+
+### Relationship to Other ADRs
+
+- **ADR-0017 (Temporal Quality Ledger):** Data model foundation - measurements, quality ladder, supersession
+- **ADR-0013 (Universal Quantity Type System):** `Quantity[D]` with dimensional safety
+- **ADR-0014 (Dynamic Asset Registry):** Tenant-defined assets with attribute schemas
+- **ADR-0016 (Tenant Isolation):** Schema-per-tenant isolation
+
+## Decision Drivers
+
+* **Regulatory compliance**: Settlement run deadlines and finality rules
+* **Reconciliation capability**: Variance detection between settled and actual
+* **Provisional settlement**: Support forward-looking use cases (budgeting, hedging)
+* **Audit trail**: Preserve the basis of financial decisions for variance explanation
+* **Cross-service isolation**: Financial Accounting owns snapshots, Position Keeping owns measurements
+
+## Decision Outcome
+
+Implement settlement lifecycle management with four components:
+
+1. **Temporal Authority**: Quality rankings that vary by time context (past vs future)
+2. **Settlement Snapshots**: Capture measurement state with provenance at settlement
+3. **Reconciliation Service**: Detect and value variances between settlements
+4. **Dispute Workflow**: Handle corrections after final settlement
+
+### 1. Temporal Authority
+
+Authority is relative to time. Source Authority (from ADR-0017) is extended with temporal context:
+
+```go
+// SourceAuthority defines the quality ranking for a data source.
+// Extended with TemporalContext for time-relative authority.
+type SourceAuthority struct {
+    Code            string    // "SMETS2_METER", "FORECAST_ML"
+    AssetCode       string    // Source rankings can be asset-specific
+    QualityScore    int       // Higher = more authoritative (0-100)
+    TemporalContext string    // "PAST", "FUTURE", or "ANY" - when this source is authoritative
+    Description     string
+    ValidFrom       time.Time
+    ValidTo         *time.Time // Null = currently valid
+}
+```
+
+**Source Authority with Temporal Context:**
+
+| Source Code | Quality Score | Temporal Context | Description |
+|-------------|---------------|------------------|-------------|
+| `FORECAST_ML` | 50 | **Future** | ML prediction. Authoritative for T+1 onwards |
+| `FORECAST_BUDGET` | 40 | **Future** | Budget allocation. Authoritative until actual spend |
+| `DEFAULT_PROFILE` | 10 | Past | Regulatory default when no data |
+| `ESTIMATED_HISTORIC` | 20 | Past | Same period last year |
+| `ESTIMATED_PROFILE` | 30 | Past | Profile coefficient calculation |
+| `CUSTOMER_READ` | 50 | Past | Customer-submitted reading |
+| `ACTUAL_UNVALIDATED` | 70 | Past | Meter reading, not yet validated |
+| `ACTUAL_VALIDATED` | 90 | Past | Meter reading, passed validation |
+| `ACTUAL_FINAL` | 100 | Past | Final settlement reading |
+
+**Temporal Authority Rules:**
+
+- For **Past periods** (T ≤ Now): Only `TemporalContext: Past` sources compete. Actuals always win.
+- For **Future periods** (T > Now): Only `TemporalContext: Future` sources are valid. Forecasts win by default.
+- When time advances and Actuals arrive, they supersede Forecasts automatically.
+
+### 2. Provisional Settlement
+
+When a financial action is taken based on non-final data (Forecast, Estimate), we **Freeze**
+the basis of that decision into the Settlement Snapshot. This enables accurate reconciliation:
+
+```go
+// ProvisionalSettlement creates a settlement based on forecast data
+func (s *SettlementService) CreateProvisionalSettlement(
+    ctx context.Context,
+    forecast *Measurement,
+) (*SettlementSnapshot, error) {
+    if forecast.Source != "FORECAST_ML" && forecast.Source != "FORECAST_BUDGET" {
+        return nil, errors.New("provisional settlement requires forecast source")
+    }
+
+    snapshot := &SettlementSnapshot{
+        ID:              uuid.New(),
+        MeasurementID:   forecast.ID,
+        QuantitySettled: forecast.Quantity,
+        QualityAtSettle: forecast.QualityScore,
+        SourceAtSettle:  forecast.Source,        // "FORECAST_ML"
+        SettlementType:  SettlementProvisional,  // Subject to reconciliation
+        CreatedAt:       time.Now(),
+    }
+
+    return snapshot, s.snapshotRepo.Create(ctx, snapshot)
+}
+```
+
+**Cross-Domain Applications:**
+
+This "Provisional Settlement" pattern enables high-value capabilities across all target sectors:
+
+| Domain | Forecast Source | Provisional Action | Reconciliation Trigger |
+|--------|-----------------|-------------------|----------------------|
+| **Energy** | ML demand forecast | Book hedge position | Smart meter actual |
+| **NGO/Gov** | Refugee estimate | Allocate budget | Biometric headcount |
+| **Compute** | Reservation request | Reserve GPU hours | Actual job runtime |
+| **Treasury** | FX rate forecast | Book forward contract | Market settlement rate |
+
+**Example: NGO Budget Allocation**
+
+```
+T-30 (Forecast):
+  Source: FORECAST_BUDGET (Quality 40)
+  Quantity: 1,000 refugees expected
+  Action: Provisional Settlement - Transfer $10,000 to Field Wallet
+  Snapshot: { source: "FORECAST_BUDGET", quantity: 1000, type: "PROVISIONAL" }
+
+T+1 (Actual):
+  Source: BIOMETRIC_COUNT (Quality 95)
+  Quantity: 800 refugees arrived
+  Action: Reconciliation
+    - Current (800) vs Snapshot (1,000)
+    - Variance: -200 refugees = -$2,000
+    - Reason: "FORECAST_DEVIATION"
+  Output: Payment Order - Return $2,000 to HQ
+```
+
+### 3. Settlement Snapshots
+
+When a settlement run executes, it captures which measurements were used. This enables
+reconciliation when better data arrives in subsequent runs.
+
+```go
+// PositionKey uniquely identifies a position for lookup purposes.
+// Includes Attributes per ADR-0014 fungibility requirements.
+type PositionKey struct {
+    AccountID  uuid.UUID
+    AssetCode  string
+    Period     Period
+    Attributes map[string]string // Required: positions with different attributes are distinct
+}
+
+// SettlementSnapshot records which measurement was used for each period in a settlement run.
+// Captures full position context including attributes for reconciliation.
+type SettlementSnapshot struct {
+    ID               uuid.UUID
+    SettlementRunID  uuid.UUID         // References the settlement run
+    AccountID        uuid.UUID         // References Current Account
+    AssetCode        string            // References Asset Directory
+    Period           Period
+    Attributes       map[string]string // Fungibility context at settlement (from ADR-0014)
+    MeasurementID    uuid.UUID         // The measurement used
+    QuantitySettled  decimal.Decimal   // Snapshot of quantity at settlement time
+    QualityAtSettle  int               // Quality score at settlement time
+    CreatedAt        time.Time
+
+    // Provenance (The "Freeze") - enables variance analysis for provisional settlements
+    SourceAtSettle   string            // e.g., "FORECAST_ML", "ACTUAL_VALIDATED"
+    SettlementType   SettlementType    // PROVISIONAL or FINAL
+}
+
+type SettlementType string
+
+const (
+    // SettlementProvisional indicates settlement based on non-final data (forecasts, estimates).
+    // Subject to reconciliation when actuals arrive.
+    SettlementProvisional SettlementType = "PROVISIONAL"
+
+    // SettlementFinal indicates settlement based on final, audited data.
+    // No further reconciliation expected.
+    SettlementFinal SettlementType = "FINAL"
+)
+```
+
+### 4. Reconciliation Service
+
+The Reconciliation Service compares settled positions to current positions and generates variances.
+
+```go
+// ReconciliationService compares settled positions to current positions.
+type ReconciliationService struct {
+    snapshotRepo    SettlementSnapshotRepository
+    measurementRepo MeasurementRepository
+    valuationEngine ValuationEngine
+}
+
+// Reconcile identifies variances between settled and current positions.
+// Uses batch fetching to avoid N+1 query problem on large settlement runs.
+func (s *ReconciliationService) Reconcile(ctx context.Context, runID uuid.UUID) ([]Variance, error) {
+    snapshots, err := s.snapshotRepo.FindByRun(ctx, runID)
+    if err != nil {
+        return nil, err
+    }
+
+    // Extract position keys (including attributes) and batch fetch current measurements
+    keys := make([]PositionKey, len(snapshots))
+    for i, snap := range snapshots {
+        keys[i] = PositionKey{
+            AccountID:  snap.AccountID,
+            AssetCode:  snap.AssetCode,
+            Period:     snap.Period,
+            Attributes: snap.Attributes, // Required for fungibility-aware lookup
+        }
+    }
+
+    currentByKey, err := s.measurementRepo.BatchFindCurrent(ctx, keys)
+    if err != nil {
+        return nil, err
+    }
+
+    // Compare and collect variances
+    var variances []Variance
+    for _, snapshot := range snapshots {
+        key := PositionKey{
+            AccountID:  snapshot.AccountID,
+            AssetCode:  snapshot.AssetCode,
+            Period:     snapshot.Period,
+            Attributes: snapshot.Attributes,
+        }
+        current, ok := currentByKey[key]
+        if !ok {
+            // No current measurement - position may have been fully reversed
+            continue
+        }
+
+        if !current.Quantity.Equal(snapshot.QuantitySettled) {
+            delta := current.Quantity.Sub(snapshot.QuantitySettled)
+
+            // Value the variance using the tariff at the original period
+            value, err := s.valuationEngine.Valuate(ctx, ValuationRequest{
+                AssetCode:  snapshot.AssetCode,
+                Quantity:   delta,
+                Period:     snapshot.Period,
+                Attributes: current.Attributes,
+            })
+            if err != nil {
+                return nil, err
+            }
+
+            variances = append(variances, Variance{
+                SettlementRunID:  runID,
+                Period:           snapshot.Period,
+                QuantitySettled:  snapshot.QuantitySettled,
+                QuantityCurrent:  current.Quantity,
+                QuantityDelta:    delta,
+                ValueDelta:       value.SettlementAmount,
+            })
+        }
+    }
+
+    return variances, nil
+}
+
+// ReconcileProvisional generates adjustments when actuals supersede forecasts
+func (s *ReconciliationService) ReconcileProvisional(
+    ctx context.Context,
+    snapshot *SettlementSnapshot,
+    actual *Measurement,
+) (*Variance, error) {
+    // The snapshot preserves WHY we settled that amount
+    variance := &Variance{
+        SnapshotID:         snapshot.ID,
+        OriginalSource:     snapshot.SourceAtSettle,    // "FORECAST_ML"
+        OriginalQuality:    snapshot.QualityAtSettle,   // 50
+        OriginalQuantity:   snapshot.QuantitySettled,
+
+        ActualSource:       actual.Source,              // "ACTUAL_VALIDATED"
+        ActualQuality:      actual.QualityScore,        // 90
+        ActualQuantity:     actual.Quantity,
+
+        QuantityDelta:      actual.Quantity.Sub(snapshot.QuantitySettled),
+        VarianceReason:     "FORECAST_DEVIATION",       // Audit trail!
+    }
+
+    return variance, nil
+}
+```
+
+**Reconciliation Error Handling:**
+
+The `Reconcile()` function uses fail-fast semantics (immediate return on error).
+This is intentional for settlement reconciliation where partial results could lead
+to incorrect financial adjustments. Alternative strategies considered:
+
+| Strategy | Pros | Cons | Verdict |
+|----------|------|------|---------|
+| Fail-fast | Simple, atomic | No partial results | **Chosen** |
+| Accumulate errors | Partial progress visible | Risk of partial adjustments | Rejected |
+| Skip + log | Maximizes results | Silent failures | Rejected |
+
+For large reconciliation runs, errors are typically transient (API timeouts to Position
+Keeping). The caller should implement retry with exponential backoff at the run level,
+not the individual snapshot level.
+
+**Reconciliation creates adjustments, not mutations:**
+
+```
+Settlement Run D+5 Reconciliation:
+
+┌─────────────────┬─────────────┬─────────────┬───────────┬────────────┐
+│ Period          │ Settled Qty │ Current Qty │ Delta Qty │ Delta Val  │
+├─────────────────┼─────────────┼─────────────┼───────────┼────────────┤
+│ 12:00-12:30     │ 10.00       │ 12.00       │ +2.00     │ +$0.30     │
+│ 12:30-13:00     │ 11.00       │ 10.50       │ -0.50     │ -$0.08     │
+│ 13:00-13:30     │ 9.00        │ 9.00        │ 0.00      │ $0.00      │
+├─────────────────┼─────────────┼─────────────┼───────────┼────────────┤
+│ Total           │ 30.00       │ 31.50       │ +1.50     │ +$0.22     │
+└─────────────────┴─────────────┴─────────────┴───────────┴────────────┘
+
+Action: Create adjustment entry for $0.22
+```
+
+### 5. Settlement Finality
+
+After final settlement (e.g., M+14 for UK energy), positions are locked:
+
+```go
+func (s *SettlementService) FinalizeRun(ctx context.Context, run string, cutoff time.Time) error {
+    return s.db.Model(&Measurement{}).
+        Where("settlement_run = ? AND locked_at IS NULL", run).
+        Where("period && tstzrange(?, ?)", cutoff.AddDate(0, -14, 0), cutoff).
+        Update("locked_at", time.Now()).Error
+}
+```
+
+Once locked, the Delta Engine (ADR-0017) returns `ActionCreateDispute` instead of `ActionWashAndReload`.
+
+### 6. Dispute Workflow
+
+When new data arrives for a locked position, it's routed to the dispute workflow rather than
+automatic correction. Until a full Dispute Resolution system is implemented, use this fail-safe:
+
+```go
+func (s *MeasurementIngestionService) handleDispute(
+    ctx context.Context,
+    incoming *Measurement,
+    existing *Measurement,
+) error {
+    return s.db.Transaction(func(tx *gorm.DB) error {
+        // 1. Archive the incoming measurement (preserve for audit)
+        incoming.SupersededBy = nil  // Not superseded, just disputed
+        if err := tx.Create(incoming).Error; err != nil {
+            return err
+        }
+
+        // 2. Create dispute record for manual review
+        dispute := Dispute{
+            ID:                    uuid.New(),
+            IncomingMeasurementID: incoming.ID,
+            ExistingMeasurementID: existing.ID,
+            Reason:                "Position locked after final settlement",
+            Status:                DisputeStatusPendingReview,
+            CreatedAt:             time.Now(),
+        }
+        if err := tx.Create(&dispute).Error; err != nil {
+            return err
+        }
+
+        // 3. Write event to outbox table (same transaction)
+        // Event will be published asynchronously by outbox processor
+        outboxEvent := OutboxEvent{
+            ID:          uuid.New(),
+            EventType:   "DisputeCreated",
+            Payload:     mustMarshal(DisputeCreatedEvent{DisputeID: dispute.ID}),
+            CreatedAt:   time.Now(),
+            ProcessedAt: nil,
+        }
+        if err := tx.Create(&outboxEvent).Error; err != nil {
+            return err
+        }
+
+        return nil
+    })
+}
+```
+
+**Key principle:** Never silently drop data. If a measurement arrives for a locked position,
+archive it and create a dispute record. The business can then decide to extend the settlement
+window, adjust via dispute resolution, or acknowledge the variance.
+
+**Transaction Boundary and Outbox Pattern:**
+
+The `handleDispute()` function wraps all three operations (measurement, dispute, event) in a
+single database transaction. This ensures atomicity—either all succeed or all roll back.
+
+Events use the **transactional outbox pattern** rather than direct publishing because:
+
+| Approach | Problem |
+|----------|---------|
+| Direct publish after commit | If publish fails, dispute exists but no alert fires |
+| Direct publish before commit | If transaction rolls back, event was already sent (phantom event) |
+| **Outbox table (chosen)** | Event written in same transaction; async processor publishes with at-least-once semantics |
+
+## Service Responsibilities
+
+| Component | Service | Notes |
+|-----------|---------|-------|
+| Settlement Snapshots | Financial Accounting | Owns settlement lifecycle and snapshots |
+| Reconciliation | Financial Accounting | Queries own snapshots, calls Position Keeping API for current measurements |
+| Settlement Finality | Financial Accounting | Triggers position locking via Position Keeping |
+| Adjustment Entry | Payment Order | Financial settlement of variance |
+| Dispute Records | Financial Accounting | Until dedicated Dispute Resolution service exists |
+
+**Note on Cross-Service Queries:** Per project rules (no cross-schema queries), Financial
+Accounting owns Settlement Snapshots in its own schema. Reconciliation fetches current
+measurements via Position Keeping's API, not direct database joins. This maintains service
+isolation at the cost of additional API calls during reconciliation.
+
+## Consequences
+
+### Positive
+
+* **Regulatory compliance**: Settlement runs and finality are first-class concepts
+* **Reconciliation capability**: Clear variance detection between settlement runs
+* **Audit trail**: Snapshots preserve why decisions were made, enabling variance explanation
+* **Unified Treasury & Accounting**: By treating Forecasts as authoritative for future periods and Actuals as authoritative for past periods, the ledger enables real-time **Cashflow/Inventory Forecasting** (Treasury) and **Historical Audit** (Accounting) in a single view
+
+### Negative
+
+* **Storage overhead**: Snapshots duplicate measurement data at settlement time
+* **Cross-service latency**: Reconciliation requires API calls to Position Keeping
+* **Ongoing reconciliation**: Positions are never truly "final" until settlement locked
+
+## Implementation Notes
+
+### Database Indexes for Settlement
+
+```sql
+-- Reconciliation queries
+CREATE INDEX idx_settlement_snapshots_run
+    ON settlement_snapshots(settlement_run_id);
+
+-- Settlement finality queries (FinalizeRun)
+CREATE INDEX idx_measurements_settlement_run
+    ON measurements(settlement_run)
+    WHERE locked_at IS NULL;
+```
+
+### Performance Considerations
+
+For runs with many periods (e.g., 48 half-hours × 365 days = 17,520 snapshots/year):
+
+```go
+// FindByRunPaginated returns snapshots in batches for large settlement runs.
+func (r *SettlementSnapshotRepository) FindByRunPaginated(
+    ctx context.Context,
+    runID uuid.UUID,
+    limit, offset int,
+) ([]SettlementSnapshot, error) {
+    var snapshots []SettlementSnapshot
+    return snapshots, r.db.Where("settlement_run_id = ?", runID).
+        Order("period_start ASC").
+        Limit(limit).
+        Offset(offset).
+        Find(&snapshots).Error
+}
+
+// BatchFindCurrent reduces round trips when checking many positions.
+// Matches on all PositionKey fields including Attributes for fungibility.
+func (r *MeasurementRepository) BatchFindCurrent(
+    ctx context.Context,
+    keys []PositionKey,
+) (map[PositionKey]*Measurement, error) {
+    // Build a single query for all position keys (account, asset, period, attributes)
+    // Uses position_key_hash for efficient matching
+    // Returns map keyed by position for efficient lookup
+}
+```
+
+For most use cases (monthly energy settlements with ~1,440 half-hours),
+the simple iteration approach is sufficient. Consider pagination when:
+- Annual settlement runs exceed 10,000 snapshots
+- Reconciliation jobs process runs in parallel
+
+### Settlement Snapshot Denormalization Justification
+
+Settlement snapshots duplicate `quantity` from measurements. For a UK energy supplier
+with 1M meters, annual snapshots: 1M × 17,520 periods × 32 bytes ≈ **560 GB/year**.
+
+This denormalization is justified because:
+
+1. **Query locality**: Reconciliation needs snapshot + current measurement. Without
+   denormalization, every reconciliation requires joining to measurements table.
+
+2. **Immutability**: Snapshots are write-once. The measurement's quantity at snapshot
+   time is preserved even if the measurement is later superseded.
+
+3. **Cross-service isolation**: Financial Accounting owns snapshots in its schema.
+   Without denormalization, it would need to query Position Keeping for every reconciliation.
+
+4. **Acceptable cost**: 560 GB/year is modest for a financial system handling 1M meters.
+   Storage is cheap; cross-service latency at scale is not.
+
+## Event Contracts
+
+Per ADR-0004 (Event-Driven Architecture), the following domain events are published during
+settlement lifecycle operations. All events include standard envelope fields (event_id,
+timestamp, tenant_id, correlation_id).
+
+### Settlement Events
+
+| Event | Trigger | Payload | Consumers |
+|-------|---------|---------|-----------|
+| `SettlementRunStarted` | Settlement batch begins | run_id, run_type, period_start, period_end | Monitoring, Audit |
+| `SettlementSnapshotCreated` | Position captured for settlement | snapshot_id, run_id, measurement_id | Financial Accounting |
+| `SettlementRunCompleted` | Settlement batch finishes | run_id, positions_settled, total_value | Monitoring, Payment Order |
+| `MeasurementLocked` | Settlement finalized | measurement_id, settlement_run, locked_at | Financial Accounting |
+
+### Reconciliation Events
+
+| Event | Trigger | Payload | Consumers |
+|-------|---------|---------|-----------|
+| `ReconciliationStarted` | Reconciliation batch begins | run_id, comparing_run_id | Monitoring |
+| `VarianceDetected` | Settled vs current differs | variance_id, snapshot_id, delta_quantity, delta_value | Payment Order, Alerting |
+| `ReconciliationCompleted` | Reconciliation batch finishes | run_id, total_variances, total_value | Monitoring |
+
+### Dispute Events
+
+| Event | Trigger | Payload | Consumers |
+|-------|---------|---------|-----------|
+| `DisputeCreated` | Locked position receives new data | dispute_id, incoming_measurement_id, existing_measurement_id | Dispute Resolution, Alerting |
+| `DisputeResolved` | Dispute closed | dispute_id, resolution_type, adjustment_id | Financial Accounting, Audit |
+
+### Event Publishing Pattern
+
+Events are published using the transactional outbox pattern to ensure exactly-once delivery:
+
+```go
+// Example: Publishing SettlementRunCompleted event
+func (s *SettlementService) CompleteRun(ctx context.Context, runID uuid.UUID) error {
+    return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+        // ... settlement completion logic ...
+
+        // Write event to outbox (same transaction)
+        event := OutboxEvent{
+            ID:        uuid.New(),
+            EventType: "SettlementRunCompleted",
+            Payload: mustMarshal(SettlementRunCompletedEvent{
+                RunID:            runID,
+                PositionsSettled: count,
+                TotalValue:       totalValue,
+            }),
+            CreatedAt: time.Now(),
+        }
+        return tx.Create(&event).Error
+    })
+}
+```
+
+## Security Considerations
+
+### Settlement Locking Authorization
+
+The `LockedAt` field controls position finality. Only authorized services may lock positions:
+
+| Actor | Can Lock? | Mechanism |
+|-------|-----------|-----------|
+| Settlement Service | Yes | Automatic after final run (M+14) |
+| Tenant Admin | No | Must request via support ticket |
+| Operator | No | Read-only access to locked positions |
+| System Admin | Emergency only | Requires audit log entry + approval |
+
+```go
+// SettlementService is the only authorized caller
+func (s *SettlementService) FinalizeRun(ctx context.Context, run string) error {
+    // Verify caller identity via context (service account)
+    if !auth.IsSettlementService(ctx) {
+        return ErrUnauthorized
+    }
+    // ... locking logic ...
+}
+```
+
+### Dispute Workflow Security
+
+Dispute creation is rate-limited and audited:
+
+```go
+// Rate limiting per tenant to prevent abuse
+const MaxDisputesPerHour = 100
+
+func (s *MeasurementIngestionService) handleDispute(ctx context.Context, ...) error {
+    tenantID := auth.TenantIDFromContext(ctx)
+
+    // Check rate limit
+    if s.rateLimiter.DisputesThisHour(tenantID) >= MaxDisputesPerHour {
+        return ErrDisputeRateLimitExceeded
+    }
+
+    // ... dispute creation with audit logging ...
+    s.auditLog.Record(ctx, AuditEntry{
+        Action:    "DISPUTE_CREATED",
+        TenantID:  tenantID,
+        ActorID:   auth.ActorIDFromContext(ctx),
+        Details:   map[string]any{"dispute_id": dispute.ID},
+    })
+}
+```
+
+## Observability
+
+### Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `settlement_run_duration_seconds` | Histogram | run_type | Settlement batch processing time |
+| `settlement_snapshots_created_total` | Counter | tenant_id, asset_code | Snapshots created per run |
+| `reconciliation_variance_total` | Gauge | tenant_id, asset_code | Current variance amount |
+| `reconciliation_duration_seconds` | Histogram | run_type | Reconciliation processing time |
+| `disputes_pending_total` | Gauge | tenant_id | Disputes awaiting resolution |
+| `disputes_created_total` | Counter | tenant_id, reason | Disputes created |
+
+### Tracing
+
+Each settlement lifecycle operation should propagate trace context:
+
+```go
+func (s *ReconciliationService) Reconcile(ctx context.Context, runID uuid.UUID) ([]Variance, error) {
+    ctx, span := tracer.Start(ctx, "ReconciliationService.Reconcile",
+        trace.WithAttributes(
+            attribute.String("settlement_run_id", runID.String()),
+        ),
+    )
+    defer span.End()
+
+    // ... reconciliation logic ...
+    span.SetAttributes(
+        attribute.Int("variances_found", len(variances)),
+        attribute.String("total_delta", totalDelta.String()),
+    )
+    return variances, nil
+}
+```
+
+### Alerting Thresholds
+
+| Alert | Condition | Severity | Action |
+|-------|-----------|----------|--------|
+| High Dispute Rate | >10 disputes/hour/tenant | Warning | Investigate data source |
+| Settlement Overdue | Run not completed T+2 hours | Critical | Page on-call |
+| Variance Threshold | Single period variance >$10k | Warning | Review for fraud |
+| Reconciliation Failure | Run fails 3 consecutive times | Critical | Page on-call |
+
+## Placeholder Interfaces
+
+Interfaces referenced but defined in future ADRs:
+
+```go
+// ValuationEngine converts quantities to settlement values.
+// Full specification in ADR-0019 (Valuation Engine).
+type ValuationEngine interface {
+    Valuate(ctx context.Context, req ValuationRequest) (*ValuationResult, error)
+}
+
+type ValuationRequest struct {
+    AssetCode  string
+    Quantity   decimal.Decimal
+    Period     Period
+    Attributes map[string]string
+}
+
+type ValuationResult struct {
+    SettlementAmount decimal.Decimal
+    Currency         string
+    RateApplied      decimal.Decimal
+    RateEffectiveAt  time.Time
+}
+```
+
+## Scope and Boundaries
+
+### In Scope
+
+- Settlement snapshot creation and storage
+- Reconciliation between settlement runs
+- Settlement finality and position locking
+- Dispute creation for locked positions
+- Temporal authority (forecast vs actual)
+- Provisional settlement workflow
+
+### Out of Scope (Future ADRs)
+
+| Topic | Notes |
+|-------|-------|
+| **Dispute Resolution Workflow** | Full investigation, resolution, and manual adjustment flows. Target: ADR-0019 or later. |
+| **Valuation Engine** | Temporal tariff lookup, attribute-based pricing. ADR-0013's `Rate` type provides foundation. |
+| **Real-time Streaming** | This ADR assumes batch-oriented settlement. Streaming ingestion addressed separately. |
+
+## Notes
+
+### Backfill Window
+
+Different industries have different backfill windows:
+
+| Industry | Backfill Window | Final Settlement |
+|----------|-----------------|------------------|
+| UK Energy | 14 months | R3 (M+14) |
+| Advertising | 30-90 days | Varies by network |
+| Banking | T+1 to T+3 | Same day to 3 days |
+| Carbon | Years | Registry-dependent |
+
+**Configuration schema (extends ADR-0014 asset definitions):**
+
+```sql
+-- Settlement rules table linked to asset definitions
+CREATE TABLE asset_settlement_rules (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    asset_code VARCHAR(32) NOT NULL REFERENCES asset_definitions(code),
+
+    -- Backfill limits
+    backfill_window_days INTEGER NOT NULL DEFAULT 365,
+
+    -- Settlement run schedule (cron-like or explicit)
+    settlement_schedule JSONB NOT NULL DEFAULT '["D+1", "D+5", "M+3", "M+14"]',
+
+    -- Finality: after which run positions lock
+    final_settlement_run VARCHAR(20) NOT NULL DEFAULT 'M+14',
+
+    -- Grace period after final before disputes auto-close
+    dispute_window_days INTEGER NOT NULL DEFAULT 30,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    UNIQUE(asset_code)
+);
+
+-- Example: UK half-hourly electricity
+INSERT INTO asset_settlement_rules (asset_code, backfill_window_days, final_settlement_run)
+VALUES ('ELEC_HH_KWH', 425, 'M+14');  -- 14 months = ~425 days
+
+-- Example: Real-time gross settlement (banking)
+INSERT INTO asset_settlement_rules (asset_code, backfill_window_days, final_settlement_run)
+VALUES ('GBP', 0, 'D+0');  -- Same-day finality
+
+-- Example: Compute time (hourly periods)
+INSERT INTO asset_settlement_rules (asset_code, backfill_window_days, final_settlement_run)
+VALUES ('COMPUTE_HOURS', 30, 'M+1');  -- Monthly finality
+```
+
+### Settlement Run Validation
+
+The `settlement_run` field on measurements uses structured identifiers validated at ingestion:
+
+```go
+// SettlementRunID represents a validated settlement run identifier.
+type SettlementRunID string
+
+const (
+    MaxDayOffset   = 30  // D+0 through D+30
+    MaxMonthOffset = 24  // M+1 through M+24 (2 years)
+)
+
+// ParseSettlementRun validates and parses a settlement run string.
+// Valid formats: "D+N" (days, 0-30), "M+N" (months, 1-24), "FINAL"
+func ParseSettlementRun(s string) (SettlementRunID, error) {
+    if s == "FINAL" {
+        return SettlementRunID(s), nil
+    }
+
+    re := regexp.MustCompile(`^(D|M)\+(\d+)$`)
+    matches := re.FindStringSubmatch(s)
+    if matches == nil {
+        return "", fmt.Errorf("invalid settlement run format: %s", s)
+    }
+
+    unit := matches[1]
+    offset, _ := strconv.Atoi(matches[2])
+
+    switch unit {
+    case "D":
+        if offset > MaxDayOffset {
+            return "", fmt.Errorf("day offset %d exceeds maximum %d", offset, MaxDayOffset)
+        }
+    case "M":
+        if offset < 1 || offset > MaxMonthOffset {
+            return "", fmt.Errorf("month offset %d outside valid range 1-%d", offset, MaxMonthOffset)
+        }
+    }
+
+    return SettlementRunID(s), nil
+}
+
+// IsScheduled checks if this run is in the asset's settlement schedule.
+func (r SettlementRunID) IsScheduled(schedule []string) bool {
+    for _, s := range schedule {
+        if s == string(r) {
+            return true
+        }
+    }
+    return false
+}
+```
+
+**Validation at measurement ingestion:**
+
+```go
+func (s *MeasurementIngestionService) Ingest(ctx context.Context, m *Measurement) error {
+    // Validate settlement_run against asset's configured schedule
+    rules, err := s.rulesRepo.FindByAsset(ctx, m.AssetCode)
+    if err != nil {
+        return err
+    }
+
+    runID, err := ParseSettlementRun(m.SettlementRun)
+    if err != nil {
+        return fmt.Errorf("%w: %v", ErrInvalidSettlementRun, err)
+    }
+
+    if !runID.IsScheduled(rules.SettlementSchedule) {
+        return fmt.Errorf("%w: %s not in schedule for %s",
+            ErrInvalidSettlementRun, m.SettlementRun, m.AssetCode)
+    }
+
+    // Validate measurement period is within backfill window
+    backfillCutoff := time.Now().AddDate(0, 0, -rules.BackfillWindowDays)
+    if m.Period.End.Before(backfillCutoff) {
+        return fmt.Errorf("%w: period ends %s, backfill cutoff is %s for asset %s",
+            ErrOutsideBackfillWindow, m.Period.End.Format(time.RFC3339),
+            backfillCutoff.Format(time.RFC3339), m.AssetCode)
+    }
+
+    // Continue with normal ingestion (Delta Engine evaluation, etc.)
+}
+```
+
+### Valuation Integration
+
+The Valuation Engine (future ADR) must support:
+- Temporal rate lookup (rate at settlement period, not current)
+- Attribute-based pricing (peak/off-peak, vintage, grade)
+- Multi-period aggregation with different rates per sub-period
+- **Cross-asset conversion**: Direct value translation between non-monetary asset classes
+  (e.g., compute hours → carbon credits, commodity A → commodity B at market rate)
+
+### Data Retention and Archival
+
+At scale, storage will grow rapidly. Retention strategy for settlement data:
+
+| Data Type | Hot Storage | Warm Storage | Cold/Archive |
+|-----------|-------------|--------------|--------------|
+| Settlement snapshots | Until final + 1 year | 7 years | 10+ years |
+| Dispute records | Until resolved + 1 year | 7 years | 10+ years |
+| Reconciliation results | 2 years | 7 years | 10+ years |
+
+Archival preserves audit trail while keeping hot path performant. Consider partitioning
+by settlement run date for efficient bulk archival operations.
+
+## Error Taxonomy
+
+Domain-specific errors for settlement and reconciliation:
+
+```go
+var (
+    // ErrOutsideBackfillWindow indicates the measurement period is older than
+    // the configured backfill window for this asset.
+    ErrOutsideBackfillWindow = errors.New("measurement outside backfill window")
+
+    // ErrInvalidSettlementRun indicates the settlement run identifier is malformed
+    // or not in the asset's configured schedule.
+    ErrInvalidSettlementRun = errors.New("invalid settlement run identifier")
+
+    // ErrSettlementRunNotFound indicates the requested settlement run does not exist.
+    ErrSettlementRunNotFound = errors.New("settlement run not found")
+
+    // ErrDisputeRateLimitExceeded indicates too many disputes created for this tenant.
+    ErrDisputeRateLimitExceeded = errors.New("dispute rate limit exceeded")
+
+    // ErrUnauthorized indicates the caller is not authorized for this operation.
+    ErrUnauthorized = errors.New("unauthorized")
+)
+```
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| **Temporal Authority** | Principle that source quality depends on time context: Forecasts are authoritative for future periods, Actuals for past |
+| **Provisional Settlement** | Financial action based on non-final data (forecast/estimate), subject to reconciliation when actuals arrive |
+| **Freezing** | Capturing provenance (source, quality) in a snapshot when taking provisional action, enabling variance analysis |
+| **Settlement Run** | Batch process that finalizes positions for a time period (e.g., D+1, M+14) |
+| **Backfill Window** | Maximum age of measurements accepted before rejection |
+| **Final Settlement** | Point after which positions are locked and changes become disputes |
+| **Variance** | Difference between settled quantity and current quantity for a position |
+| **Dispute** | Record created when new data arrives for a locked (finalized) position |
+
+## Links
+
+### Internal ADRs
+
+* [ADR-0004: Event-Driven Architecture](0004-event-schema-evolution.md) - Event contracts and publishing patterns
+* [ADR-0013: Universal Quantity Type System](0013-generic-asset-quantity-types.md) - Quantity and rate types
+* [ADR-0014: Dynamic Asset Registry & Lifecycle](0014-dynamic-asset-registry.md) - Asset definitions and attributes
+* [ADR-0016: Tenant Isolation](0016-tenant-id-naming-strategy.md) - Multi-tenancy and schema separation
+* [ADR-0017: Temporal Quality Ledger](0017-temporal-quality-ladder.md) - Measurement log, quality ladder, supersession, corrections
+
+### External References
+
+* [UK Balancing and Settlement Code (BSC)](https://www.elexon.co.uk/bsc-and-codes/)
+* [ELEXON Settlement Timetable](https://www.elexon.co.uk/operations-settlement/settlement-timetable/)

--- a/docs/adr/0018-settlement-reconciliation.md
+++ b/docs/adr/0018-settlement-reconciliation.md
@@ -939,6 +939,50 @@ var (
 | **Variance** | Difference between settled quantity and current quantity for a position |
 | **Dispute** | Record created when new data arrives for a locked (finalized) position |
 
+## BIAN v13 Alignment
+
+This ADR's concepts map to BIAN (Banking Industry Architecture Network) v13 service domains:
+
+| Meridian Concept | BIAN Service Domain | BIAN Entity | Notes |
+|-----------------|---------------------|-------------|-------|
+| `SettlementSnapshot` | Trade Settlement | `TradeSettlementProcedure` (CR) | "Final movement of cash and securities" |
+| `ReconciliationService` | Account Reconciliation | `AccountReconciliationProcedure` (CR) | "Handles account reconciliation tasks" |
+| Settlement lifecycle | Card Financial Settlement | `CardFinancialSettlement` | "Reconciliation of settlement against cleared charges" |
+| `Variance` detection | Account Reconciliation | Reconciliation operations | Control, Exchange, Execute |
+| Position locking | Position Keeping | `Control` operation | "Control the processing of the log" |
+
+**BIAN Service Domain Descriptions:**
+
+- **Trade Settlement**: "Handles the final movement of cash and securities between depositories
+  as previously confirmed in the clearing process, in order to settle a market trade"
+- **Account Reconciliation**: "Handles account reconciliation tasks" with operations for
+  Control, Exchange, Execute, Initiate, Notify, Request
+- **Card Financial Settlement**: "Orchestrates the settlement of transactions... used by
+  Issuing and Acquiring banks to perform reconciliation of settlement instructions against
+  cleared charges"
+
+**Service Responsibility Alignment:**
+
+| Meridian Service | BIAN Service Domain | Responsibility |
+|-----------------|---------------------|----------------|
+| Financial Accounting | Financial Accounting | `FinancialBookingLog`, `LedgerPosting` |
+| Financial Accounting | Trade Settlement | Settlement snapshots and lifecycle |
+| Financial Accounting | Account Reconciliation | Variance detection and reconciliation |
+| Position Keeping | Position Keeping | `FinancialPositionLog`, position locking |
+| Payment Order | (various) | Financial settlement of variances |
+
+**Extensions Beyond BIAN Standard:**
+
+The following Meridian concepts extend or have no direct BIAN equivalent:
+
+- **Temporal Authority**: BIAN doesn't model time-relative source authority (Forecasts for
+  future, Actuals for past)
+- **Provisional Settlement**: BIAN settlement is typically final; Meridian supports provisional
+  settlement with later reconciliation
+- **Settlement Run scheduling** (D+1, M+14): Industry-specific patterns not in BIAN standard
+- **Dispute workflow for locked positions**: BIAN has case management but not the specific
+  pattern of archiving incoming data and creating disputes for finalized positions
+
 ## Links
 
 ### Internal ADRs

--- a/docs/adr/0018-settlement-reconciliation.md
+++ b/docs/adr/0018-settlement-reconciliation.md
@@ -121,6 +121,22 @@ type SourceAuthority struct {
 - For **Future periods** (T > Now): Only `TemporalContext: Future` sources are valid. Forecasts win by default.
 - When time advances and Actuals arrive, they supersede Forecasts automatically.
 
+**Temporal Authority Evaluation:**
+
+Authority is evaluated **at query time**, not proactively:
+
+- When a measurement is ingested, `DeltaEngine` compares `Period.End` against `time.Now()`
+  to determine temporal context (past vs future)
+- When a settlement run executes, it evaluates authority for each period based on the
+  run's effective date
+- There is no scheduled process to "flip" authority when time advances
+
+**Rationale:** Settlement runs are the natural business boundary where authority matters.
+Proactive re-evaluation would require scheduling infrastructure and produce events that
+may have no consumer. Components querying for "current authoritative value" must evaluate
+temporal context at query time. The `SourceAuthority` registry provides the rules; the
+consumer applies them.
+
 ### 2. Provisional Settlement
 
 When a financial action is taken based on non-final data (Forecast, Estimate), we **Freeze**
@@ -460,6 +476,13 @@ Events use the **transactional outbox pattern** rather than direct publishing be
 Accounting owns Settlement Snapshots in its own schema. Reconciliation fetches current
 measurements via Position Keeping's API, not direct database joins. This maintains service
 isolation at the cost of additional API calls during reconciliation.
+
+**Cross-Tenant Reconciliation:** By design, there is no special backdoor for cross-tenant
+reconciliation. When two organizations need to reconcile positions (e.g., inter-company
+settlements, counterparty reconciliation), they are treated as two external systems
+communicating via standard APIs. Each tenant's data remains isolated per ADR-0016; any
+cross-tenant data exchange happens through explicit integration contracts, not internal
+shortcuts. This ensures tenant isolation guarantees are never compromised for convenience.
 
 ## Consequences
 

--- a/docs/adr/0018-settlement-reconciliation.md
+++ b/docs/adr/0018-settlement-reconciliation.md
@@ -257,6 +257,9 @@ type ReconciliationService struct {
 
 // Reconcile identifies variances between settled and current positions.
 // Uses batch fetching to avoid N+1 query problem on large settlement runs.
+// Reconcile compares settlement snapshots against current measurements.
+// Note: tenant_id is extracted from ctx per project conventions (see ADR-0016).
+// All repository methods and cross-service API calls enforce tenant isolation via ctx.
 func (s *ReconciliationService) Reconcile(ctx context.Context, runID uuid.UUID) ([]Variance, error) {
     snapshots, err := s.snapshotRepo.FindByRun(ctx, runID)
     if err != nil {

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,6 +57,9 @@ Architectural Decision Records) format.
 | [ADR-0014](0014-dynamic-asset-registry.md) | Dynamic Asset Registry & Lifecycle | Proposed | 2025-12-04 |
 | [ADR-0015](0015-standard-service-directory-structure.md) | Standard Service Directory Structure | Accepted | 2025-12-06 |
 | [ADR-0016](0016-tenant-id-naming-strategy.md) | Tenant ID Naming Strategy | Accepted | 2025-12-13 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0017](0017-temporal-quality-ladder.md) | Temporal Quality Ledger (Data Physics) | Proposed | 2025-12-14 |
+| [ADR-0018](0018-settlement-reconciliation.md) | Settlement & Reconciliation (Lifecycle) | Proposed | 2025-12-14 |
 
 ## Categories
 
@@ -75,6 +78,8 @@ Architectural Decision Records) format.
 - [ADR-0012](0012-lien-based-fund-reservation.md) - Lien-Based Fund Reservation for Payment Order Saga
 - [ADR-0013](0013-generic-asset-quantity-types.md) - Universal Quantity Type System
 - [ADR-0014](0014-dynamic-asset-registry.md) - Dynamic Asset Registry & Lifecycle
+- [ADR-0017](0017-temporal-quality-ladder.md) - Temporal Quality Ledger (Data Physics)
+- [ADR-0018](0018-settlement-reconciliation.md) - Settlement & Reconciliation (Lifecycle)
 
 ### Development Environment & Infrastructure
 


### PR DESCRIPTION
## Summary

- Adds ADR-0017 (Temporal Quality Ladder) - defines measurement lifecycle, quality-based supersession, and wash/reload correction patterns
- Adds ADR-0018 (Settlement & Reconciliation) - defines settlement snapshots, variance detection, and dispute handling

## Context

These two ADRs are interconnected and provide a complete framework for handling temporal data with quality ladders. ADR-0018 builds on ADR-0017's concepts.

**Key concepts covered:**
- Universal time model with `[Start, End]` periods
- Source Authority Registry for quality ranking
- Delta Engine for evaluating incoming measurements
- Correction Saga for wash-and-reload workflows
- Settlement snapshots and reconciliation service
- Dispute handling with outbox pattern

**Applicable domains:** Energy metering, advertising impressions, humanitarian aid distribution, carbon credits

## Supersedes

This PR consolidates and supersedes:
- #305 (ADR-0017 with ADR-0018)
- #306 (ADR-0017 standalone attempt)

Both earlier PRs contained the same content but #305's version addressed critical CodeRabbit issues around interval semantics and QualityScore denormalization.

## Test plan

- [ ] Verify ADR content renders correctly in GitHub
- [ ] Verify ADR index links work
- [ ] Review passes CodeRabbit checks