### PR TITLE
feat: Add PlatformAdminInterceptor for platform-layer services (task 56)

### DIFF
--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -214,25 +214,36 @@ func run(logger *slog.Logger) error {
 			"hint", "set AUTH_ENABLED=true and AUTH_JWKS_URL to enable authentication")
 	}
 
-	// Build interceptor chains based on auth configuration
+	// Build interceptor chains based on auth configuration.
+	//
+	// Interceptor chain order (executed in sequence):
+	//   1. Tracing      - Creates OpenTelemetry span for the request
+	//   2. PlatformAuth - Validates JWT and populates claims in context (no tenant requirement)
+	//   3. PlatformAdmin - Requires platform-admin/super-admin role, rejects tenant-scoped tokens
+	//   4. Recovery     - Catches panics and converts them to gRPC errors
+	//
+	// Order matters because:
+	//   - Tracing must be first to capture the full request lifecycle including auth failures
+	//   - PlatformAuth must precede PlatformAdmin to populate claims that PlatformAdmin validates
+	//   - Recovery must be last to catch panics from any preceding interceptor or handler
 	var unaryInterceptors []grpc.UnaryServerInterceptor
 	var streamInterceptors []grpc.StreamServerInterceptor
 
-	// Tracing first
+	// 1. Tracing - captures full request lifecycle
 	unaryInterceptors = append(unaryInterceptors, tracer.UnaryServerInterceptor())
 	streamInterceptors = append(streamInterceptors, tracer.StreamServerInterceptor())
 
-	// Auth interceptors (if enabled)
+	// 2-3. Auth interceptors (if enabled)
 	if authInterceptor != nil {
-		// Platform auth validates JWT without requiring tenant claims
+		// 2. PlatformAuth - validates JWT without requiring tenant claims, populates claims in context
 		unaryInterceptors = append(unaryInterceptors, authInterceptor.PlatformUnaryInterceptor())
 		streamInterceptors = append(streamInterceptors, authInterceptor.PlatformStreamInterceptor())
-		// Platform admin interceptor validates platform-admin role and rejects tenant-scoped tokens
+		// 3. PlatformAdmin - requires platform-admin/super-admin role, rejects tenant-scoped tokens
 		unaryInterceptors = append(unaryInterceptors, auth.PlatformAdminInterceptor())
 		streamInterceptors = append(streamInterceptors, auth.PlatformAdminStreamInterceptor())
 	}
 
-	// Recovery last to catch all panics
+	// 4. Recovery - catches panics from any preceding interceptor or handler
 	unaryInterceptors = append(unaryInterceptors, interceptors.RecoveryUnaryInterceptor(logger))
 	streamInterceptors = append(streamInterceptors, interceptors.RecoveryStreamInterceptor(logger))
 

--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -169,11 +169,16 @@ func run(logger *slog.Logger) error {
 			return ErrJWKSURLRequired
 		}
 
+		// HTTP client with explicit timeout for JWKS fetches
+		httpClient := &http.Client{
+			Timeout: 10 * time.Second,
+		}
+
 		var err error
 		jwksProvider, err = auth.NewJWKSProvider(ctx, &auth.JWKSProviderConfig{
 			URL:        jwksURL,
 			RefreshTTL: 5 * time.Minute,
-			Client:     http.DefaultClient,
+			Client:     httpClient,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to create JWKS provider: %w", err)

--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -169,6 +169,9 @@ func run(logger *slog.Logger) error {
 			return ErrJWKSURLRequired
 		}
 
+		// JWKS refresh TTL - configurable for key rotation scenarios
+		jwksRefreshTTL := getEnvAsDuration("AUTH_JWKS_REFRESH_TTL", 5*time.Minute)
+
 		// HTTP client with explicit timeout for JWKS fetches
 		httpClient := &http.Client{
 			Timeout: 10 * time.Second,
@@ -177,7 +180,7 @@ func run(logger *slog.Logger) error {
 		var err error
 		jwksProvider, err = auth.NewJWKSProvider(ctx, &auth.JWKSProviderConfig{
 			URL:        jwksURL,
-			RefreshTTL: 5 * time.Minute,
+			RefreshTTL: jwksRefreshTTL,
 			Client:     httpClient,
 		})
 		if err != nil {
@@ -208,7 +211,8 @@ func run(logger *slog.Logger) error {
 
 		logger.Info("platform authentication enabled",
 			"jwks_url", jwksURL,
-			"required_roles", []string{"platform-admin", "super-admin"})
+			"jwks_refresh_ttl", jwksRefreshTTL,
+			"required_roles", []string{auth.RolePlatformAdmin, auth.RoleSuperAdmin})
 	} else {
 		logger.Warn("platform authentication disabled",
 			"hint", "set AUTH_ENABLED=true and AUTH_JWKS_URL to enable authentication")

--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -3,9 +3,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -17,6 +19,7 @@ import (
 	"github.com/meridianhub/meridian/services/tenant/provisioner"
 	"github.com/meridianhub/meridian/services/tenant/service"
 	"github.com/meridianhub/meridian/shared/pkg/interceptors"
+	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -31,6 +34,9 @@ var (
 	Commit    = "unknown"
 	BuildDate = "unknown"
 )
+
+// ErrJWKSURLRequired is returned when AUTH_ENABLED is true but AUTH_JWKS_URL is not set.
+var ErrJWKSURLRequired = errors.New("AUTH_JWKS_URL is required when AUTH_ENABLED=true")
 
 func main() {
 	// Initialize structured logging
@@ -152,17 +158,83 @@ func run(logger *slog.Logger) error {
 	logger.Info("cached tenant registry started",
 		"refresh_interval", "60s")
 
+	// Initialize authentication (optional - disabled by default for development)
+	// In production, set AUTH_JWKS_URL to enable platform-admin authentication.
+	var authInterceptor *auth.Interceptor
+	var jwksProvider *auth.JWKSProvider
+	authEnabled := getEnvOrDefault("AUTH_ENABLED", "false") == "true"
+	if authEnabled {
+		jwksURL := getEnvOrDefault("AUTH_JWKS_URL", "")
+		if jwksURL == "" {
+			return ErrJWKSURLRequired
+		}
+
+		var err error
+		jwksProvider, err = auth.NewJWKSProvider(ctx, &auth.JWKSProviderConfig{
+			URL:        jwksURL,
+			RefreshTTL: 5 * time.Minute,
+			Client:     http.DefaultClient,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create JWKS provider: %w", err)
+		}
+		defer func() {
+			if err := jwksProvider.Close(); err != nil {
+				logger.Error("failed to close JWKS provider", "error", err)
+			}
+		}()
+
+		jwksValidator, err := auth.NewJWTValidatorWithJWKS(jwksProvider)
+		if err != nil {
+			return fmt.Errorf("failed to create JWT validator: %w", err)
+		}
+
+		authInterceptor, err = auth.NewAuthInterceptor(&auth.InterceptorConfig{
+			JWKSValidator: jwksValidator,
+			BypassMethods: []string{
+				"/grpc.health.v1.Health/Check",
+				"/grpc.health.v1.Health/Watch",
+				"/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo",
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to create auth interceptor: %w", err)
+		}
+
+		logger.Info("platform authentication enabled",
+			"jwks_url", jwksURL,
+			"required_roles", []string{"platform-admin", "super-admin"})
+	} else {
+		logger.Warn("platform authentication disabled",
+			"hint", "set AUTH_ENABLED=true and AUTH_JWKS_URL to enable authentication")
+	}
+
+	// Build interceptor chains based on auth configuration
+	var unaryInterceptors []grpc.UnaryServerInterceptor
+	var streamInterceptors []grpc.StreamServerInterceptor
+
+	// Tracing first
+	unaryInterceptors = append(unaryInterceptors, tracer.UnaryServerInterceptor())
+	streamInterceptors = append(streamInterceptors, tracer.StreamServerInterceptor())
+
+	// Auth interceptors (if enabled)
+	if authInterceptor != nil {
+		// Platform auth validates JWT without requiring tenant claims
+		unaryInterceptors = append(unaryInterceptors, authInterceptor.PlatformUnaryInterceptor())
+		streamInterceptors = append(streamInterceptors, authInterceptor.PlatformStreamInterceptor())
+		// Platform admin interceptor validates platform-admin role and rejects tenant-scoped tokens
+		unaryInterceptors = append(unaryInterceptors, auth.PlatformAdminInterceptor())
+		streamInterceptors = append(streamInterceptors, auth.PlatformAdminStreamInterceptor())
+	}
+
+	// Recovery last to catch all panics
+	unaryInterceptors = append(unaryInterceptors, interceptors.RecoveryUnaryInterceptor(logger))
+	streamInterceptors = append(streamInterceptors, interceptors.RecoveryStreamInterceptor(logger))
+
 	// Create gRPC server with interceptor chain
-	// Order: tracing -> recovery (recovery last to catch all panics)
 	grpcServer := grpc.NewServer(
-		grpc.ChainUnaryInterceptor(
-			tracer.UnaryServerInterceptor(),
-			interceptors.RecoveryUnaryInterceptor(logger),
-		),
-		grpc.ChainStreamInterceptor(
-			tracer.StreamServerInterceptor(),
-			interceptors.RecoveryStreamInterceptor(logger),
-		),
+		grpc.ChainUnaryInterceptor(unaryInterceptors...),
+		grpc.ChainStreamInterceptor(streamInterceptors...),
 	)
 
 	// Register services

--- a/shared/platform/auth/grpc_interceptor.go
+++ b/shared/platform/auth/grpc_interceptor.go
@@ -124,37 +124,16 @@ func (a *Interceptor) StreamInterceptor() grpc.StreamServerInterceptor {
 	}
 }
 
-// authenticate extracts and validates the JWT token, returning an enriched context
+// authenticate extracts and validates the JWT token, returning an enriched context.
+// This is for tenant-layer services that REQUIRE tenant_id claims.
 func (a *Interceptor) authenticate(ctx context.Context) (context.Context, error) {
-	// Extract token from metadata
-	token, err := extractTokenFromMetadata(ctx)
+	claims, err := a.validateToken(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("extract token: %w", status.Error(codes.Unauthenticated, err.Error()))
+		return nil, err
 	}
 
-	// Validate token
-	var claims *Claims
-	if a.useJWKS {
-		claims, err = a.jwksValidator.ValidateToken(ctx, token)
-	} else {
-		claims, err = a.validator.ValidateToken(token)
-	}
-
-	if err != nil {
-		if errors.Is(err, ErrTokenExpired) {
-			return nil, fmt.Errorf("validate token: %w", status.Error(codes.Unauthenticated, "token expired"))
-		}
-		if errors.Is(err, ErrInvalidSignature) || errors.Is(err, ErrInvalidToken) {
-			return nil, fmt.Errorf("validate token: %w", status.Error(codes.Unauthenticated, "invalid token"))
-		}
-		return nil, fmt.Errorf("validate token: %w", status.Error(codes.Unauthenticated, "authentication failed"))
-	}
-
-	// Inject claims into context
-	ctx = context.WithValue(ctx, UserIDContextKey, claims.UserID)
-	ctx = context.WithValue(ctx, RolesContextKey, claims.Roles)
-	ctx = context.WithValue(ctx, ScopesContextKey, claims.Scopes)
-	ctx = context.WithValue(ctx, ClaimsContextKey, claims)
+	// Inject base claims into context
+	ctx = injectBaseClaims(ctx, claims)
 
 	// Tenant context injection - ALWAYS required for tenant-layer services.
 	// The system is always multi-tenant (platform schema + 1 to N org_X schemas).
@@ -173,6 +152,44 @@ func (a *Interceptor) authenticate(ctx context.Context) (context.Context, error)
 	span.SetAttributes(attribute.String("tenant.id", tenantID.String()))
 
 	return ctx, nil
+}
+
+// validateToken extracts and validates the JWT token from context metadata.
+// This is the common token validation logic used by both authenticate() and authenticatePlatform().
+func (a *Interceptor) validateToken(ctx context.Context) (*Claims, error) {
+	token, err := extractTokenFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "extract token: %v", err)
+	}
+
+	var claims *Claims
+	if a.useJWKS {
+		claims, err = a.jwksValidator.ValidateToken(ctx, token)
+	} else {
+		claims, err = a.validator.ValidateToken(token)
+	}
+
+	if err != nil {
+		if errors.Is(err, ErrTokenExpired) {
+			return nil, status.Error(codes.Unauthenticated, "token expired")
+		}
+		if errors.Is(err, ErrInvalidSignature) || errors.Is(err, ErrInvalidToken) {
+			return nil, status.Error(codes.Unauthenticated, "invalid token")
+		}
+		return nil, status.Error(codes.Unauthenticated, "authentication failed")
+	}
+
+	return claims, nil
+}
+
+// injectBaseClaims adds user identity claims to the context.
+// This is the common claims injection logic used by both authenticate() and authenticatePlatform().
+func injectBaseClaims(ctx context.Context, claims *Claims) context.Context {
+	ctx = context.WithValue(ctx, UserIDContextKey, claims.UserID)
+	ctx = context.WithValue(ctx, RolesContextKey, claims.Roles)
+	ctx = context.WithValue(ctx, ScopesContextKey, claims.Scopes)
+	ctx = context.WithValue(ctx, ClaimsContextKey, claims)
+	return ctx
 }
 
 // extractTokenFromMetadata extracts the Bearer token from gRPC metadata
@@ -349,35 +366,11 @@ func (a *Interceptor) PlatformStreamInterceptor() grpc.StreamServerInterceptor {
 // Unlike authenticate(), this does NOT require tenant_id claims.
 // Platform services are tenant-agnostic and operate in the platform schema.
 func (a *Interceptor) authenticatePlatform(ctx context.Context) (context.Context, error) {
-	// Extract token from metadata
-	token, err := extractTokenFromMetadata(ctx)
+	claims, err := a.validateToken(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("extract token: %w", status.Error(codes.Unauthenticated, err.Error()))
+		return nil, err
 	}
 
-	// Validate token
-	var claims *Claims
-	if a.useJWKS {
-		claims, err = a.jwksValidator.ValidateToken(ctx, token)
-	} else {
-		claims, err = a.validator.ValidateToken(token)
-	}
-
-	if err != nil {
-		if errors.Is(err, ErrTokenExpired) {
-			return nil, fmt.Errorf("validate token: %w", status.Error(codes.Unauthenticated, "token expired"))
-		}
-		if errors.Is(err, ErrInvalidSignature) || errors.Is(err, ErrInvalidToken) {
-			return nil, fmt.Errorf("validate token: %w", status.Error(codes.Unauthenticated, "invalid token"))
-		}
-		return nil, fmt.Errorf("validate token: %w", status.Error(codes.Unauthenticated, "authentication failed"))
-	}
-
-	// Inject claims into context (no tenant requirement for platform services)
-	ctx = context.WithValue(ctx, UserIDContextKey, claims.UserID)
-	ctx = context.WithValue(ctx, RolesContextKey, claims.Roles)
-	ctx = context.WithValue(ctx, ScopesContextKey, claims.Scopes)
-	ctx = context.WithValue(ctx, ClaimsContextKey, claims)
-
-	return ctx, nil
+	// Inject base claims into context (no tenant requirement for platform services)
+	return injectBaseClaims(ctx, claims), nil
 }

--- a/shared/platform/auth/grpc_interceptor.go
+++ b/shared/platform/auth/grpc_interceptor.go
@@ -288,3 +288,96 @@ func RequireScope(requiredScopes ...string) grpc.UnaryServerInterceptor {
 		return handler(ctx, req)
 	}
 }
+
+// PlatformUnaryInterceptor returns a gRPC unary server interceptor for platform-layer
+// services. Unlike the standard UnaryInterceptor, this does NOT require tenant_id claims.
+// Platform services (like Tenant Service) are tenant-agnostic and operate in the platform
+// schema. Use this in combination with PlatformAdminInterceptor for full authorization.
+func (a *Interceptor) PlatformUnaryInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		// Check if method should bypass authentication
+		if a.bypassMethods[info.FullMethod] {
+			return handler(ctx, req)
+		}
+
+		// Authenticate and inject context (without tenant requirement)
+		newCtx, err := a.authenticatePlatform(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		return handler(newCtx, req)
+	}
+}
+
+// PlatformStreamInterceptor returns a gRPC stream server interceptor for platform-layer
+// services. Unlike the standard StreamInterceptor, this does NOT require tenant_id claims.
+func (a *Interceptor) PlatformStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		// Check if method should bypass authentication
+		if a.bypassMethods[info.FullMethod] {
+			return handler(srv, ss)
+		}
+
+		// Authenticate and inject context (without tenant requirement)
+		newCtx, err := a.authenticatePlatform(ss.Context())
+		if err != nil {
+			return err
+		}
+
+		// Wrap stream with authenticated context
+		wrappedStream := &wrappedServerStream{
+			ServerStream: ss,
+			ctx:          newCtx,
+		}
+
+		return handler(srv, wrappedStream)
+	}
+}
+
+// authenticatePlatform extracts and validates the JWT token for platform services.
+// Unlike authenticate(), this does NOT require tenant_id claims.
+// Platform services are tenant-agnostic and operate in the platform schema.
+func (a *Interceptor) authenticatePlatform(ctx context.Context) (context.Context, error) {
+	// Extract token from metadata
+	token, err := extractTokenFromMetadata(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("extract token: %w", status.Error(codes.Unauthenticated, err.Error()))
+	}
+
+	// Validate token
+	var claims *Claims
+	if a.useJWKS {
+		claims, err = a.jwksValidator.ValidateToken(ctx, token)
+	} else {
+		claims, err = a.validator.ValidateToken(token)
+	}
+
+	if err != nil {
+		if errors.Is(err, ErrTokenExpired) {
+			return nil, fmt.Errorf("validate token: %w", status.Error(codes.Unauthenticated, "token expired"))
+		}
+		if errors.Is(err, ErrInvalidSignature) || errors.Is(err, ErrInvalidToken) {
+			return nil, fmt.Errorf("validate token: %w", status.Error(codes.Unauthenticated, "invalid token"))
+		}
+		return nil, fmt.Errorf("validate token: %w", status.Error(codes.Unauthenticated, "authentication failed"))
+	}
+
+	// Inject claims into context (no tenant requirement for platform services)
+	ctx = context.WithValue(ctx, UserIDContextKey, claims.UserID)
+	ctx = context.WithValue(ctx, RolesContextKey, claims.Roles)
+	ctx = context.WithValue(ctx, ScopesContextKey, claims.Scopes)
+	ctx = context.WithValue(ctx, ClaimsContextKey, claims)
+
+	return ctx, nil
+}

--- a/shared/platform/auth/grpc_interceptor_test.go
+++ b/shared/platform/auth/grpc_interceptor_test.go
@@ -806,3 +806,317 @@ func TestTenantContext(t *testing.T) {
 		assert.Equal(t, "acme_bank", tenantID.String())
 	})
 }
+
+func TestPlatformUnaryInterceptor(t *testing.T) {
+	privateKey, publicKey, err := generateTestRSAKeys()
+	require.NoError(t, err)
+
+	validator, err := NewJWTValidator(publicKey)
+	require.NoError(t, err)
+
+	t.Run("success with valid token without tenant claim", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create valid token WITHOUT tenant_id (platform services don't require it)
+		claims := &Claims{
+			UserID: "admin-123",
+			Roles:  []string{"platform-admin"},
+			Scopes: []string{"read", "write"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor.PlatformUnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify claims were injected into context
+		resultCtx := resp.(context.Context)
+		userID, ok := GetUserIDFromContext(resultCtx)
+		assert.True(t, ok)
+		assert.Equal(t, "admin-123", userID)
+
+		roles, ok := GetRolesFromContext(resultCtx)
+		assert.True(t, ok)
+		assert.Equal(t, []string{"platform-admin"}, roles)
+
+		// Verify NO tenant in context (platform services don't inject tenant)
+		_, hasTenant := tenant.FromContext(resultCtx)
+		assert.False(t, hasTenant, "platform interceptor should not inject tenant context")
+	})
+
+	t.Run("success with token that has tenant claim", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Platform interceptor accepts tokens WITH tenant claims too
+		// (PlatformAdminInterceptor is responsible for rejecting them)
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "acme_bank",
+			Roles:    []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor.PlatformUnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify claims were injected into context
+		resultCtx := resp.(context.Context)
+		claimsFromCtx, ok := GetClaimsFromContext(resultCtx)
+		assert.True(t, ok)
+		assert.Equal(t, "acme_bank", claimsFromCtx.TenantID)
+	})
+
+	t.Run("bypass authentication for whitelisted method", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator:     validator,
+			BypassMethods: []string{"/grpc.health.v1.Health/Check"},
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// No authorization header
+		ctx := context.Background()
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/grpc.health.v1.Health/Check"}
+		resp, err := interceptor.PlatformUnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("error with missing authorization header", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor.PlatformUnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+	})
+
+	t.Run("error with invalid token", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer invalid.token.here")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor.PlatformUnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+	})
+
+	t.Run("error with expired token", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create expired token
+		claims := &Claims{
+			UserID: "admin-123",
+			Roles:  []string{"platform-admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)), // Expired 1 hour ago
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor.PlatformUnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+		assert.Contains(t, st.Message(), "expired")
+	})
+}
+
+func TestPlatformStreamInterceptor(t *testing.T) {
+	privateKey, publicKey, err := generateTestRSAKeys()
+	require.NoError(t, err)
+
+	validator, err := NewJWTValidator(publicKey)
+	require.NoError(t, err)
+
+	t.Run("success with valid token without tenant claim", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create valid token WITHOUT tenant_id
+		claims := &Claims{
+			UserID: "admin-123",
+			Roles:  []string{"platform-admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		stream := &mockServerStream{ctx: ctx}
+
+		info := &grpc.StreamServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/WatchTenants"}
+
+		// Custom handler to verify context
+		var handlerCtx context.Context
+		handler := func(_ interface{}, s grpc.ServerStream) error {
+			handlerCtx = s.Context()
+			return nil
+		}
+
+		err = interceptor.PlatformStreamInterceptor()(nil, stream, info, handler)
+
+		assert.NoError(t, err)
+
+		// Verify claims were injected into context
+		userID, ok := GetUserIDFromContext(handlerCtx)
+		assert.True(t, ok)
+		assert.Equal(t, "admin-123", userID)
+
+		// Verify NO tenant in context
+		_, hasTenant := tenant.FromContext(handlerCtx)
+		assert.False(t, hasTenant, "platform interceptor should not inject tenant context")
+	})
+
+	t.Run("bypass authentication for whitelisted method", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator:     validator,
+			BypassMethods: []string{"/grpc.health.v1.Health/Watch"},
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		stream := &mockServerStream{ctx: ctx}
+
+		info := &grpc.StreamServerInfo{FullMethod: "/grpc.health.v1.Health/Watch"}
+
+		handler := func(_ interface{}, _ grpc.ServerStream) error {
+			return nil
+		}
+
+		err = interceptor.PlatformStreamInterceptor()(nil, stream, info, handler)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("error with missing authorization header", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+		stream := &mockServerStream{ctx: ctx}
+
+		info := &grpc.StreamServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/WatchTenants"}
+
+		handler := func(_ interface{}, _ grpc.ServerStream) error {
+			return nil
+		}
+
+		err = interceptor.PlatformStreamInterceptor()(nil, stream, info, handler)
+
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+	})
+
+	t.Run("error with invalid token", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer invalid.token.here")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		stream := &mockServerStream{ctx: ctx}
+
+		info := &grpc.StreamServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/WatchTenants"}
+
+		handler := func(_ interface{}, _ grpc.ServerStream) error {
+			return nil
+		}
+
+		err = interceptor.PlatformStreamInterceptor()(nil, stream, info, handler)
+
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+	})
+}

--- a/shared/platform/auth/platform_admin_interceptor.go
+++ b/shared/platform/auth/platform_admin_interceptor.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// PlatformAdminInterceptor validates that requests to platform-layer services
+// do NOT contain tenant_id claims. Platform services are tenant-agnostic and
+// should only be accessible to platform administrators.
+//
+// This prevents tenant users from accessing tenant management APIs.
+// The interceptor should be chained AFTER the base auth interceptor which
+// populates claims in context.
+func PlatformAdminInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		_ *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		// Extract claims from context (populated by auth interceptor)
+		claims, ok := ctx.Value(ClaimsContextKey).(*Claims)
+		if !ok {
+			// Auth interceptor should have populated claims
+			return nil, status.Error(codes.Internal, "authentication claims not found")
+		}
+
+		// Platform services MUST NOT receive tenant_id claims
+		_, err := claims.GetTenantID()
+		if err == nil {
+			// Tenant ID present - reject request
+			return nil, status.Error(codes.PermissionDenied,
+				"platform services do not accept tenant-scoped credentials")
+		}
+
+		// Verify platform-admin or super-admin role
+		if !claims.HasRole("platform-admin") && !claims.HasRole("super-admin") {
+			return nil, status.Error(codes.PermissionDenied,
+				"platform-admin or super-admin role required")
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// PlatformAdminStreamInterceptor is the streaming equivalent of PlatformAdminInterceptor.
+func PlatformAdminStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		ss grpc.ServerStream,
+		_ *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		ctx := ss.Context()
+
+		// Extract claims from context (populated by auth interceptor)
+		claims, ok := ctx.Value(ClaimsContextKey).(*Claims)
+		if !ok {
+			return status.Error(codes.Internal, "authentication claims not found")
+		}
+
+		// Platform services MUST NOT receive tenant_id claims
+		_, err := claims.GetTenantID()
+		if err == nil {
+			return status.Error(codes.PermissionDenied,
+				"platform services do not accept tenant-scoped credentials")
+		}
+
+		// Verify platform-admin or super-admin role
+		if !claims.HasRole("platform-admin") && !claims.HasRole("super-admin") {
+			return status.Error(codes.PermissionDenied,
+				"platform-admin or super-admin role required")
+		}
+
+		return handler(srv, ss)
+	}
+}

--- a/shared/platform/auth/platform_admin_interceptor.go
+++ b/shared/platform/auth/platform_admin_interceptor.go
@@ -8,6 +8,35 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// Platform role constants used for authorization checks.
+const (
+	RolePlatformAdmin = "platform-admin"
+	RoleSuperAdmin    = "super-admin"
+)
+
+// validatePlatformAdminClaims extracts claims from context and validates that:
+// 1. Claims exist (populated by auth interceptor)
+// 2. No tenant_id claim is present (platform services are tenant-agnostic)
+// 3. User has platform-admin or super-admin role
+func validatePlatformAdminClaims(ctx context.Context) error {
+	claims, ok := ctx.Value(ClaimsContextKey).(*Claims)
+	if !ok {
+		return status.Error(codes.Internal, "authentication claims not found")
+	}
+
+	if claims.HasTenantID() {
+		return status.Error(codes.PermissionDenied,
+			"platform services do not accept tenant-scoped credentials")
+	}
+
+	if !claims.HasRole(RolePlatformAdmin) && !claims.HasRole(RoleSuperAdmin) {
+		return status.Error(codes.PermissionDenied,
+			"platform-admin or super-admin role required")
+	}
+
+	return nil
+}
+
 // PlatformAdminInterceptor validates that requests to platform-layer services
 // do NOT contain tenant_id claims. Platform services are tenant-agnostic and
 // should only be accessible to platform administrators.
@@ -22,25 +51,9 @@ func PlatformAdminInterceptor() grpc.UnaryServerInterceptor {
 		_ *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
 	) (interface{}, error) {
-		// Extract claims from context (populated by auth interceptor)
-		claims, ok := ctx.Value(ClaimsContextKey).(*Claims)
-		if !ok {
-			// Auth interceptor should have populated claims
-			return nil, status.Error(codes.Internal, "authentication claims not found")
+		if err := validatePlatformAdminClaims(ctx); err != nil {
+			return nil, err
 		}
-
-		// Platform services MUST NOT receive tenant_id claims
-		if claims.HasTenantID() {
-			return nil, status.Error(codes.PermissionDenied,
-				"platform services do not accept tenant-scoped credentials")
-		}
-
-		// Verify platform-admin or super-admin role
-		if !claims.HasRole("platform-admin") && !claims.HasRole("super-admin") {
-			return nil, status.Error(codes.PermissionDenied,
-				"platform-admin or super-admin role required")
-		}
-
 		return handler(ctx, req)
 	}
 }
@@ -53,26 +66,9 @@ func PlatformAdminStreamInterceptor() grpc.StreamServerInterceptor {
 		_ *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
 	) error {
-		ctx := ss.Context()
-
-		// Extract claims from context (populated by auth interceptor)
-		claims, ok := ctx.Value(ClaimsContextKey).(*Claims)
-		if !ok {
-			return status.Error(codes.Internal, "authentication claims not found")
+		if err := validatePlatformAdminClaims(ss.Context()); err != nil {
+			return err
 		}
-
-		// Platform services MUST NOT receive tenant_id claims
-		if claims.HasTenantID() {
-			return status.Error(codes.PermissionDenied,
-				"platform services do not accept tenant-scoped credentials")
-		}
-
-		// Verify platform-admin or super-admin role
-		if !claims.HasRole("platform-admin") && !claims.HasRole("super-admin") {
-			return status.Error(codes.PermissionDenied,
-				"platform-admin or super-admin role required")
-		}
-
 		return handler(srv, ss)
 	}
 }

--- a/shared/platform/auth/platform_admin_interceptor.go
+++ b/shared/platform/auth/platform_admin_interceptor.go
@@ -30,9 +30,7 @@ func PlatformAdminInterceptor() grpc.UnaryServerInterceptor {
 		}
 
 		// Platform services MUST NOT receive tenant_id claims
-		_, err := claims.GetTenantID()
-		if err == nil {
-			// Tenant ID present - reject request
+		if claims.HasTenantID() {
 			return nil, status.Error(codes.PermissionDenied,
 				"platform services do not accept tenant-scoped credentials")
 		}
@@ -64,8 +62,7 @@ func PlatformAdminStreamInterceptor() grpc.StreamServerInterceptor {
 		}
 
 		// Platform services MUST NOT receive tenant_id claims
-		_, err := claims.GetTenantID()
-		if err == nil {
+		if claims.HasTenantID() {
 			return status.Error(codes.PermissionDenied,
 				"platform services do not accept tenant-scoped credentials")
 		}

--- a/shared/platform/auth/platform_admin_interceptor_test.go
+++ b/shared/platform/auth/platform_admin_interceptor_test.go
@@ -14,7 +14,7 @@ func TestPlatformAdminInterceptor(t *testing.T) {
 	t.Run("success with platform-admin role and no tenant claim", func(t *testing.T) {
 		claims := &Claims{
 			UserID: "admin-123",
-			Roles:  []string{"platform-admin"},
+			Roles:  []string{RolePlatformAdmin},
 			// No TenantID - correct for platform-layer services
 		}
 		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
@@ -30,7 +30,7 @@ func TestPlatformAdminInterceptor(t *testing.T) {
 	t.Run("success with super-admin role and no tenant claim", func(t *testing.T) {
 		claims := &Claims{
 			UserID: "admin-123",
-			Roles:  []string{"super-admin"},
+			Roles:  []string{RoleSuperAdmin},
 			// No TenantID - correct for platform-layer services
 		}
 		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
@@ -47,7 +47,7 @@ func TestPlatformAdminInterceptor(t *testing.T) {
 		claims := &Claims{
 			UserID:   "user-123",
 			TenantID: "acme_bank", // Has tenant claim - should be rejected
-			Roles:    []string{"platform-admin"},
+			Roles:    []string{RolePlatformAdmin},
 		}
 		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
 
@@ -124,7 +124,7 @@ func TestPlatformAdminInterceptor(t *testing.T) {
 		claims := &Claims{
 			UserID:   "user-123",
 			TenantID: "acme_bank",
-			Roles:    []string{"platform-admin", "super-admin"}, // Both roles!
+			Roles:    []string{RolePlatformAdmin, RoleSuperAdmin}, // Both roles!
 		}
 		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
 
@@ -145,7 +145,7 @@ func TestPlatformAdminStreamInterceptor(t *testing.T) {
 	t.Run("success with platform-admin role and no tenant claim", func(t *testing.T) {
 		claims := &Claims{
 			UserID: "admin-123",
-			Roles:  []string{"platform-admin"},
+			Roles:  []string{RolePlatformAdmin},
 		}
 		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
 		stream := &mockServerStream{ctx: ctx}
@@ -166,7 +166,7 @@ func TestPlatformAdminStreamInterceptor(t *testing.T) {
 		claims := &Claims{
 			UserID:   "user-123",
 			TenantID: "acme_bank",
-			Roles:    []string{"platform-admin"},
+			Roles:    []string{RolePlatformAdmin},
 		}
 		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
 		stream := &mockServerStream{ctx: ctx}

--- a/shared/platform/auth/platform_admin_interceptor_test.go
+++ b/shared/platform/auth/platform_admin_interceptor_test.go
@@ -1,0 +1,233 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestPlatformAdminInterceptor(t *testing.T) {
+	t.Run("success with platform-admin role and no tenant claim", func(t *testing.T) {
+		claims := &Claims{
+			UserID: "admin-123",
+			Roles:  []string{"platform-admin"},
+			// No TenantID - correct for platform-layer services
+		}
+		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+		interceptor := PlatformAdminInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("success with super-admin role and no tenant claim", func(t *testing.T) {
+		claims := &Claims{
+			UserID: "admin-123",
+			Roles:  []string{"super-admin"},
+			// No TenantID - correct for platform-layer services
+		}
+		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+		interceptor := PlatformAdminInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("rejects request with tenant claim present", func(t *testing.T) {
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "acme_bank", // Has tenant claim - should be rejected
+			Roles:    []string{"platform-admin"},
+		}
+		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+		interceptor := PlatformAdminInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		assert.Contains(t, st.Message(), "platform services do not accept tenant-scoped credentials")
+	})
+
+	t.Run("rejects request without platform-admin or super-admin role", func(t *testing.T) {
+		claims := &Claims{
+			UserID: "user-123",
+			Roles:  []string{"admin", "user"}, // Has other roles but not platform-admin or super-admin
+			// No TenantID
+		}
+		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+		interceptor := PlatformAdminInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		assert.Contains(t, st.Message(), "platform-admin or super-admin role required")
+	})
+
+	t.Run("rejects request with no roles", func(t *testing.T) {
+		claims := &Claims{
+			UserID: "user-123",
+			Roles:  []string{},
+			// No TenantID
+		}
+		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+		interceptor := PlatformAdminInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		assert.Contains(t, st.Message(), "platform-admin or super-admin role required")
+	})
+
+	t.Run("error when claims missing from context", func(t *testing.T) {
+		ctx := context.Background() // No claims in context
+
+		interceptor := PlatformAdminInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+		assert.Contains(t, st.Message(), "authentication claims not found")
+	})
+
+	t.Run("rejects tenant user even with valid roles", func(t *testing.T) {
+		// Scenario: A user has platform-admin role but their token was issued
+		// in tenant context - this should be rejected
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "acme_bank",
+			Roles:    []string{"platform-admin", "super-admin"}, // Both roles!
+		}
+		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+
+		interceptor := PlatformAdminInterceptor()
+		info := &grpc.UnaryServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/InitiateTenant"}
+		resp, err := interceptor(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		assert.Contains(t, st.Message(), "platform services do not accept tenant-scoped credentials")
+	})
+}
+
+func TestPlatformAdminStreamInterceptor(t *testing.T) {
+	t.Run("success with platform-admin role and no tenant claim", func(t *testing.T) {
+		claims := &Claims{
+			UserID: "admin-123",
+			Roles:  []string{"platform-admin"},
+		}
+		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+		stream := &mockServerStream{ctx: ctx}
+
+		interceptor := PlatformAdminStreamInterceptor()
+		info := &grpc.StreamServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/WatchTenants"}
+
+		handler := func(_ interface{}, _ grpc.ServerStream) error {
+			return nil
+		}
+
+		err := interceptor(nil, stream, info, handler)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("rejects stream with tenant claim present", func(t *testing.T) {
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "acme_bank",
+			Roles:    []string{"platform-admin"},
+		}
+		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+		stream := &mockServerStream{ctx: ctx}
+
+		interceptor := PlatformAdminStreamInterceptor()
+		info := &grpc.StreamServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/WatchTenants"}
+
+		handler := func(_ interface{}, _ grpc.ServerStream) error {
+			return nil
+		}
+
+		err := interceptor(nil, stream, info, handler)
+
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		assert.Contains(t, st.Message(), "platform services do not accept tenant-scoped credentials")
+	})
+
+	t.Run("rejects stream without platform-admin role", func(t *testing.T) {
+		claims := &Claims{
+			UserID: "user-123",
+			Roles:  []string{"user"},
+		}
+		ctx := context.WithValue(context.Background(), ClaimsContextKey, claims)
+		stream := &mockServerStream{ctx: ctx}
+
+		interceptor := PlatformAdminStreamInterceptor()
+		info := &grpc.StreamServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/WatchTenants"}
+
+		handler := func(_ interface{}, _ grpc.ServerStream) error {
+			return nil
+		}
+
+		err := interceptor(nil, stream, info, handler)
+
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		assert.Contains(t, st.Message(), "platform-admin or super-admin role required")
+	})
+
+	t.Run("error when claims missing from stream context", func(t *testing.T) {
+		ctx := context.Background()
+		stream := &mockServerStream{ctx: ctx}
+
+		interceptor := PlatformAdminStreamInterceptor()
+		info := &grpc.StreamServerInfo{FullMethod: "/meridian.tenant.v1.TenantService/WatchTenants"}
+
+		handler := func(_ interface{}, _ grpc.ServerStream) error {
+			return nil
+		}
+
+		err := interceptor(nil, stream, info, handler)
+
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+		assert.Contains(t, st.Message(), "authentication claims not found")
+	})
+}


### PR DESCRIPTION
## Summary

Completes task 56 by implementing authentication and authorization for platform-layer services that must reject tenant-scoped credentials.

- Add `PlatformAdminInterceptor` and `PlatformAdminStreamInterceptor` that reject requests with `tenant_id` claims and require `platform-admin` or `super-admin` roles
- Add `PlatformUnaryInterceptor`/`PlatformStreamInterceptor` methods to `Interceptor` for JWT validation without tenant requirement
- Wire auth interceptors into Tenant Service (optional via `AUTH_ENABLED` environment variable)

## Changes Made

### New Files
- `shared/platform/auth/platform_admin_interceptor.go` - Interceptors for platform-layer authorization
- `shared/platform/auth/platform_admin_interceptor_test.go` - Comprehensive tests

### Modified Files
- `shared/platform/auth/grpc_interceptor.go` - Added `PlatformUnaryInterceptor`, `PlatformStreamInterceptor`, and `authenticatePlatform` methods
- `services/tenant/cmd/main.go` - Wired in optional auth with configurable JWKS

## Technical Details

**Architecture Enforcement:**
- Platform-layer services (Tenant Service) operate in the `platform` schema (tenant-agnostic)
- They must NOT accept tenant-scoped JWTs
- Only `platform-admin` or `super-admin` roles can access these services

**Interceptor Chain (when AUTH_ENABLED=true):**
1. `tracer.UnaryServerInterceptor()` - Tracing
2. `authInterceptor.PlatformUnaryInterceptor()` - JWT validation (no tenant requirement)
3. `auth.PlatformAdminInterceptor()` - Rejects tenant-scoped tokens, requires platform-admin role
4. `interceptors.RecoveryUnaryInterceptor()` - Panic recovery

## Test Plan

- [x] All platform admin interceptor unit tests pass
- [x] All existing auth tests pass
- [x] Tenant service builds successfully
- [x] Tenant service tests pass

## Configuration

New environment variables for Tenant Service:
| Variable | Default | Description |
|----------|---------|-------------|
| `AUTH_ENABLED` | `false` | Enable authentication (set to `true` in production) |
| `AUTH_JWKS_URL` | - | JWKS endpoint URL (required when AUTH_ENABLED=true) |