### PR TITLE
refactor: Rename meridian service to audit-worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,15 @@ coverage.out
 *.out
 __debug_bin
 
+# Service binaries (built from services/*/)
+/audit-worker
+/current-account
+/financial-accounting
+/party
+/payment-order
+/position-keeping
+/tenant
+
 # Generated protobuf files (regenerate with buf or make proto)
 *.pb.go
 *.pb.validate.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Meridian - Multi-Stage Dockerfile for Production Images
+# audit-worker - Multi-Stage Dockerfile for Production Images
 # Optimized for security, size, and performance
 
 # Build stage
@@ -29,11 +29,11 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
     -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
     -a -installsuffix cgo \
-    -o meridian \
-    ./utilities/meridian
+    -o audit-worker \
+    ./services/audit-worker
 
 # Verify the binary exists and is executable
-RUN test -x meridian && echo "Binary built successfully"
+RUN test -x audit-worker && echo "Binary built successfully"
 
 # Runtime stage - distroless for minimal attack surface
 FROM gcr.io/distroless/static:nonroot
@@ -45,7 +45,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
 
 # Copy binary from builder
-COPY --from=builder /build/meridian /meridian
+COPY --from=builder /build/audit-worker /audit-worker
 
 # Use non-root user (distroless default: 65532:65532)
 USER nonroot:nonroot
@@ -57,4 +57,4 @@ EXPOSE 8080
 # HEALTHCHECK not needed in distroless image (lacks curl/wget)
 
 # Run the binary
-ENTRYPOINT ["/meridian"]
+ENTRYPOINT ["/audit-worker"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-# Meridian - Development Dockerfile for Tilt Live Update
+# audit-worker - Development Dockerfile for Tilt Live Update
 # Uses alpine base for shell tools (tar, rm, sh) required by Tilt
 
 FROM golang:1.25-alpine
@@ -30,8 +30,8 @@ ARG BUILD_DATE=unknown
 
 RUN CGO_ENABLED=0 go build \
     -ldflags="-X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
-    -o meridian \
-    ./utilities/meridian
+    -o audit-worker \
+    ./services/audit-worker
 
 # Switch to non-root user
 USER nonroot:nonroot
@@ -40,4 +40,4 @@ USER nonroot:nonroot
 EXPOSE 8080
 
 # Run the binary
-ENTRYPOINT ["/app/meridian"]
+ENTRYPOINT ["/app/audit-worker"]

--- a/Tiltfile
+++ b/Tiltfile
@@ -559,7 +559,7 @@ k8s_resource(
 # Use Dockerfile.dev for local development (has tar/rm for Tilt)
 # Use Dockerfile for production builds (distroless)
 docker_build(
-  'meridian',
+  'audit-worker',
   context='.',
   dockerfile='Dockerfile.dev',
   build_args={
@@ -569,7 +569,6 @@ docker_build(
   },
   live_update=[
     # Sync Go source code
-    sync('./utilities', '/app/utilities'),
     sync('./services', '/app/services'),
     sync('./shared', '/app/shared'),
     sync('./go.mod', '/app/go.mod'),
@@ -577,19 +576,19 @@ docker_build(
 
     # Rebuild binary on changes (fast incremental builds)
     run(
-      'cd /app && go build -o meridian ./utilities/meridian',
-      trigger=['./utilities', './services', './shared'],
+      'cd /app && go build -o audit-worker ./services/audit-worker',
+      trigger=['./services', './shared'],
     ),
 
     # Restart the service using HUP signal
-    run('kill -HUP 1', trigger=['./utilities', './services', './shared']),
+    run('kill -HUP 1', trigger=['./services', './shared']),
   ],
 )
 
 # Deploy Kubernetes manifests
 k8s_yaml(kustomize('deployments/k8s/base'))
 
-# Meridian DB Secret - for local development only
+# audit-worker DB Secret - for local development only
 # Uses the same CockroachDB credentials as other services
 # NOTE: Production deployments must use External Secrets Operator or Sealed Secrets
 secret_path = 'deployments/k8s/base/secret.yaml'
@@ -602,9 +601,9 @@ else:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: meridian-db
+  name: audit-worker-db
   labels:
-    app: meridian
+    app: audit-worker
 type: Opaque
 stringData:
   # Local development connection string - CockroachDB in insecure mode
@@ -613,7 +612,7 @@ stringData:
 
 # Set resource dependencies
 k8s_resource(
-  'meridian',
+  'audit-worker',
   port_forwards=[
     '8080:8080',  # HTTP API
     '9090:9090',  # gRPC API
@@ -628,11 +627,11 @@ k8s_resource(
   labels=['microservices'],
   # Group RBAC and config resources under the main app
   objects=[
-    'meridian:serviceaccount',
-    'meridian:role',
-    'meridian:rolebinding',
-    'meridian-config:configmap',
-    # Note: meridian-version ConfigMap omitted (Kustomize hash suffix changes with content)
+    'audit-worker:serviceaccount',
+    'audit-worker:role',
+    'audit-worker:rolebinding',
+    'audit-worker-config:configmap',
+    # Note: audit-worker-version ConfigMap omitted (Kustomize hash suffix changes with content)
     # Tilt will still deploy it via kustomize, just not explicitly tracked here
   ],
 )

--- a/Tiltfile
+++ b/Tiltfile
@@ -615,7 +615,6 @@ k8s_resource(
   'audit-worker',
   port_forwards=[
     '8080:8080',  # HTTP API
-    '9090:9090',  # gRPC API
   ],
   resource_deps=[
     'generate-proto',  # Ensures proto files are generated before building
@@ -624,7 +623,7 @@ k8s_resource(
     'kafka-cluster',
     'keycloak',
   ],
-  labels=['microservices'],
+  labels=['infrastructure'],
   # Group RBAC and config resources under the main app
   objects=[
     'audit-worker:serviceaccount',

--- a/deployments/k8s/base/configmap.yaml
+++ b/deployments/k8s/base/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: meridian-config
+  name: audit-worker-config
   labels:
-    app: meridian
-    component: ledger
+    app: audit-worker
+    component: audit
 data:
   log_level: "info"
   log_format: "json"

--- a/deployments/k8s/base/deployment.yaml
+++ b/deployments/k8s/base/deployment.yaml
@@ -44,14 +44,9 @@ spec:
         - name: http
           containerPort: 8080
           protocol: TCP
-        - name: grpc
-          containerPort: 9090
-          protocol: TCP
         env:
         - name: PORT
           value: "8080"
-        - name: GRPC_PORT
-          value: "9090"
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/deployments/k8s/base/deployment.yaml
+++ b/deployments/k8s/base/deployment.yaml
@@ -1,17 +1,17 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: meridian
+  name: audit-worker
   labels:
-    app: meridian
-    component: ledger
+    app: audit-worker
+    component: audit
     tier: backend
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: meridian
-      component: ledger
+      app: audit-worker
+      component: audit
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -20,15 +20,15 @@ spec:
   template:
     metadata:
       labels:
-        app: meridian
-        component: ledger
+        app: audit-worker
+        component: audit
         tier: backend
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8080"
         prometheus.io/path: "/metrics"
     spec:
-      serviceAccountName: meridian
+      serviceAccountName: audit-worker
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -37,8 +37,8 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       containers:
-      - name: meridian
-        image: meridian:latest
+      - name: audit-worker
+        image: audit-worker:latest
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -55,12 +55,12 @@ spec:
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:
-              name: meridian-db
+              name: audit-worker-db
               key: DATABASE_URL
         - name: LOG_LEVEL
           valueFrom:
             configMapKeyRef:
-              name: meridian-config
+              name: audit-worker-config
               key: log_level
         - name: POD_NAME
           valueFrom:
@@ -120,14 +120,14 @@ spec:
         - name: tmp
           mountPath: /tmp
         - name: config
-          mountPath: /etc/meridian
+          mountPath: /etc/audit-worker
           readOnly: true
       volumes:
       - name: tmp
         emptyDir: {}
       - name: config
         configMap:
-          name: meridian-config
+          name: audit-worker-config
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -138,6 +138,6 @@ spec:
                 - key: app
                   operator: In
                   values:
-                  - meridian
+                  - audit-worker
               topologyKey: kubernetes.io/hostname
       terminationGracePeriodSeconds: 30

--- a/deployments/k8s/base/kustomization.yaml
+++ b/deployments/k8s/base/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 metadata:
-  name: meridian-base
+  name: audit-worker-base
 
 namespace: default
 
 labels:
 - pairs:
-    app: meridian
+    app: audit-worker
     managed-by: kustomize
 
 resources:
@@ -22,11 +22,11 @@ resources:
 - rolebinding.yaml
 
 images:
-- name: meridian
+- name: audit-worker
   newTag: latest
 
 configMapGenerator:
-- name: meridian-version
+- name: audit-worker-version
   literals:
   - version=dev
   - commit=unknown
@@ -35,4 +35,4 @@ configMapGenerator:
 generatorOptions:
   disableNameSuffixHash: false
   labels:
-    app: meridian
+    app: audit-worker

--- a/deployments/k8s/base/role.yaml
+++ b/deployments/k8s/base/role.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: meridian
+  name: audit-worker
   labels:
-    app: meridian
-    component: ledger
+    app: audit-worker
+    component: audit
     managed-by: kustomize
 rules:
 # Pod metadata (POD_NAME, POD_NAMESPACE, POD_IP) is injected via downward API
@@ -14,14 +14,14 @@ rules:
 - apiGroups: [""]
   resources: ["configmaps"]
   verbs: ["get", "watch"]
-  resourceNames: ["meridian-config", "meridian-build-info"]
+  resourceNames: ["audit-worker-config", "audit-worker-build-info"]
 
 # Allow reading Secrets for database credentials and API keys
 # Note: In production, use external secret management (Vault, AWS Secrets Manager)
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["get"]
-  resourceNames: ["meridian-secrets"]
+  resourceNames: ["audit-worker-secrets"]
 
 # No write permissions - application should not modify Kubernetes resources
 # No access to other namespaces - namespace isolation enforced

--- a/deployments/k8s/base/rolebinding.yaml
+++ b/deployments/k8s/base/rolebinding.yaml
@@ -1,17 +1,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: meridian
+  name: audit-worker
   labels:
-    app: meridian
-    component: ledger
+    app: audit-worker
+    component: audit
     managed-by: kustomize
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: meridian
+  name: audit-worker
 subjects:
 - kind: ServiceAccount
-  name: meridian
+  name: audit-worker
   # namespace field omitted - subject must be in same namespace as RoleBinding
   # Kustomize will apply namespace to both RoleBinding and ServiceAccount

--- a/deployments/k8s/base/secret.yaml.example
+++ b/deployments/k8s/base/secret.yaml.example
@@ -14,9 +14,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: meridian-db
+  name: audit-worker-db
   labels:
-    app: meridian
+    app: audit-worker
 type: Opaque
 stringData:
   # Example: postgres://myuser:mypassword@cockroachdb:26257/mydatabase?sslmode=disable

--- a/deployments/k8s/base/service.yaml
+++ b/deployments/k8s/base/service.yaml
@@ -1,17 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: meridian
+  name: audit-worker
   labels:
-    app: meridian
-    component: ledger
+    app: audit-worker
+    component: audit
     tier: backend
 spec:
   type: ClusterIP
   clusterIP: None  # Headless service for gRPC client-side load balancing
   selector:
-    app: meridian
-    component: ledger
+    app: audit-worker
+    component: audit
   ports:
   - name: http
     port: 8080

--- a/deployments/k8s/base/service.yaml
+++ b/deployments/k8s/base/service.yaml
@@ -8,7 +8,6 @@ metadata:
     tier: backend
 spec:
   type: ClusterIP
-  clusterIP: None  # Headless service for gRPC client-side load balancing
   selector:
     app: audit-worker
     component: audit
@@ -16,9 +15,5 @@ spec:
   - name: http
     port: 8080
     targetPort: http
-    protocol: TCP
-  - name: grpc
-    port: 9090
-    targetPort: grpc
     protocol: TCP
   sessionAffinity: None

--- a/deployments/k8s/base/serviceaccount.yaml
+++ b/deployments/k8s/base/serviceaccount.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: meridian
+  name: audit-worker
   labels:
-    app: meridian
-    component: ledger
+    app: audit-worker
+    component: audit
 automountServiceAccountToken: true

--- a/deployments/k8s/overlays/dev/kustomization.yaml
+++ b/deployments/k8s/overlays/dev/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 metadata:
-  name: meridian-dev
+  name: audit-worker-dev
 
 namespace: dev
 
 labels:
 - pairs:
-    app: meridian
+    app: audit-worker
     environment: dev
     managed-by: kustomize
 
@@ -17,7 +17,7 @@ resources:
 
 # ConfigMap for dev environment
 configMapGenerator:
-- name: meridian-config
+- name: audit-worker-config
   behavior: merge
   literals:
   - log_level=debug
@@ -29,7 +29,7 @@ patches:
 # Reduce replicas for local/dev
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: replace
       path: /spec/replicas
@@ -38,7 +38,7 @@ patches:
 # Relaxed resource limits for dev
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: replace
       path: /spec/template/spec/containers/0/resources
@@ -53,7 +53,7 @@ patches:
 # Faster health check intervals for dev
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: replace
       path: /spec/template/spec/containers/0/livenessProbe/initialDelaySeconds
@@ -71,7 +71,7 @@ patches:
 # Add dev-specific env vars
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: add
       path: /spec/template/spec/containers/0/env/-
@@ -85,5 +85,5 @@ patches:
         value: "true"
 
 images:
-- name: meridian
+- name: audit-worker
   newTag: dev-latest

--- a/deployments/k8s/overlays/production/kustomization.yaml
+++ b/deployments/k8s/overlays/production/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 metadata:
-  name: meridian-production
+  name: audit-worker-production
 
 namespace: production
 
 labels:
 - pairs:
-    app: meridian
+    app: audit-worker
     environment: production
     managed-by: kustomize
 
@@ -18,7 +18,7 @@ resources:
 
 # ConfigMap for production environment
 configMapGenerator:
-- name: meridian-config
+- name: audit-worker-config
   behavior: merge
   literals:
   - log_level=warn
@@ -30,7 +30,7 @@ patches:
 # High availability with 3 replicas minimum
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: replace
       path: /spec/replicas
@@ -39,7 +39,7 @@ patches:
 # Production resource limits (same as base, keeping strict)
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: replace
       path: /spec/template/spec/containers/0/resources
@@ -54,7 +54,7 @@ patches:
 # Stricter rolling update strategy
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: replace
       path: /spec/strategy/rollingUpdate/maxUnavailable
@@ -66,7 +66,7 @@ patches:
 # Production health check settings
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: replace
       path: /spec/template/spec/containers/0/livenessProbe/failureThreshold
@@ -81,7 +81,7 @@ patches:
 # Add production-specific env vars
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: add
       path: /spec/template/spec/containers/0/env/-
@@ -97,24 +97,24 @@ patches:
 # Add monitoring and tracing annotations
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: add
       path: /spec/template/metadata/annotations/datadog.io~1logs
       value: "true"
     - op: add
       path: /spec/template/metadata/annotations/datadog.io~1tags
-      value: "env:production,service:meridian,criticality:high"
+      value: "env:production,service:audit-worker,criticality:high"
 
 # Increase termination grace period for production
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: replace
       path: /spec/template/spec/terminationGracePeriodSeconds
       value: 60
 
 images:
-- name: meridian
+- name: audit-worker
   newTag: stable

--- a/deployments/k8s/overlays/production/networkpolicy.yaml
+++ b/deployments/k8s/overlays/production/networkpolicy.yaml
@@ -1,17 +1,17 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: meridian
+  name: audit-worker
   namespace: production
   labels:
-    app: meridian
-    component: ledger
+    app: audit-worker
+    component: audit
     environment: production
     managed-by: kustomize
 spec:
   podSelector:
     matchLabels:
-      app: meridian
+      app: audit-worker
   policyTypes:
   - Ingress
   - Egress

--- a/deployments/k8s/overlays/staging/kustomization.yaml
+++ b/deployments/k8s/overlays/staging/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 metadata:
-  name: meridian-staging
+  name: audit-worker-staging
 
 namespace: staging
 
 labels:
 - pairs:
-    app: meridian
+    app: audit-worker
     environment: staging
     managed-by: kustomize
 
@@ -17,7 +17,7 @@ resources:
 
 # ConfigMap for staging environment
 configMapGenerator:
-- name: meridian-config
+- name: audit-worker-config
   behavior: merge
   literals:
   - log_level=info
@@ -29,7 +29,7 @@ patches:
 # Production-like replicas (2 for staging)
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: replace
       path: /spec/replicas
@@ -38,7 +38,7 @@ patches:
 # Production-like resource limits
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: replace
       path: /spec/template/spec/containers/0/resources
@@ -53,7 +53,7 @@ patches:
 # Add staging-specific env vars
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: add
       path: /spec/template/spec/containers/0/env/-
@@ -69,15 +69,15 @@ patches:
 # Add monitoring annotations
 - target:
     kind: Deployment
-    name: meridian
+    name: audit-worker
   patch: |-
     - op: add
       path: /spec/template/metadata/annotations/datadog.io~1logs
       value: "true"
     - op: add
       path: /spec/template/metadata/annotations/datadog.io~1tags
-      value: "env:staging,service:meridian"
+      value: "env:staging,service:audit-worker"
 
 images:
-- name: meridian
+- name: audit-worker
   newTag: staging-latest

--- a/docs/demo/ARCHITECTURE.md
+++ b/docs/demo/ARCHITECTURE.md
@@ -189,7 +189,9 @@ CurrentAccount Service (consumer):
 
 ### Kubernetes (Tilt for local dev)
 
-- 3 replicas of meridian service (CurrentAccount + FinancialAccounting)
+- CurrentAccount Service (gRPC microservice)
+- FinancialAccounting Service (gRPC microservice)
+- audit-worker Service (3 replicas - processes audit log entries)
 - 3 Kafka brokers (KRaft cluster with quorum, no Zookeeper)
   - kafka-0, kafka-1, kafka-2 form KRaft quorum
   - Replication factor: 2 (tolerates 1 broker failure)

--- a/services/README.md
+++ b/services/README.md
@@ -27,12 +27,9 @@ flowchart LR
             PO["PaymentOrder<br/>:50054, :8080"]
         end
 
-        subgraph Platform_Services["Platform Services"]
+        subgraph Infrastructure["Infrastructure"]
             Tenant["Tenant<br/>:50056"]
             AW["audit-worker<br/>:8080"]
-        end
-
-        subgraph Infrastructure["Infrastructure"]
             DB[("CockroachDB<br/>:26257")]
             Kafka@{ shape: das, label: "Kafka :9092" }
             Redis@{ shape: das, label: "Redis :6379" }
@@ -76,14 +73,12 @@ flowchart LR
     AW -->|"Write audit log"| DB
 
     classDef service fill:#4a90d9,stroke:#2d5a87,color:#fff
-    classDef platform fill:#607d8b,stroke:#455a64,color:#fff
     classDef storage fill:#50c878,stroke:#2d7a4a,color:#fff
     classDef external fill:#ff9800,stroke:#e65100,color:#fff
     classDef admin fill:#9c27b0,stroke:#6a1b9a,color:#fff
 
     class CA,PK,FA,Party,PO service
-    class Tenant,AW platform
-    class DB,Kafka,Redis storage
+    class Tenant,AW,DB,Kafka,Redis storage
     class User,Gateway external
     class TenantCtl admin
 ```
@@ -93,10 +88,8 @@ flowchart LR
 - Solid arrows (`-->`) = Required runtime dependency
 - Dashed arrows (`-.->`) = Optional runtime dependency
 - Blue boxes = Domain services (BIAN service domains)
-- Grey boxes = Platform services (non-BIAN infrastructure)
+- Green boxes = Infrastructure (platform services, databases, messaging)
 - Purple boxes = Admin tools (CLI)
-- Vertical cylinder `[(" ")]` = Database (CockroachDB)
-- Horizontal cylinder `@{ shape: das }` = Direct access storage (Kafka, Redis)
 - Orange boxes = External systems
 
 ## Communication Protocols

--- a/services/README.md
+++ b/services/README.md
@@ -19,16 +19,16 @@ flowchart LR
     end
 
     subgraph Platform["Meridian Platform"]
-        subgraph Services["Microservices"]
+        subgraph Services["Domain Services"]
             CA["CurrentAccount<br/>:50057"]
             PK["PositionKeeping<br/>:50053"]
             FA["FinancialAccounting<br/>:50052"]
             Party["Party<br/>:50055"]
             PO["PaymentOrder<br/>:50054, :8080"]
-            Tenant["Tenant<br/>:50056"]
         end
 
         subgraph Platform_Services["Platform Services"]
+            Tenant["Tenant<br/>:50056"]
             AW["audit-worker<br/>:8080"]
         end
 
@@ -81,8 +81,8 @@ flowchart LR
     classDef external fill:#ff9800,stroke:#e65100,color:#fff
     classDef admin fill:#9c27b0,stroke:#6a1b9a,color:#fff
 
-    class CA,PK,FA,Party,PO,Tenant service
-    class AW platform
+    class CA,PK,FA,Party,PO service
+    class Tenant,AW platform
     class DB,Kafka,Redis storage
     class User,Gateway external
     class TenantCtl admin
@@ -92,8 +92,8 @@ flowchart LR
 
 - Solid arrows (`-->`) = Required runtime dependency
 - Dashed arrows (`-.->`) = Optional runtime dependency
-- Blue boxes = Microservices (domain services)
-- Grey boxes = Platform services (infrastructure)
+- Blue boxes = Domain services (BIAN service domains)
+- Grey boxes = Platform services (non-BIAN infrastructure)
 - Purple boxes = Admin tools (CLI)
 - Vertical cylinder `[(" ")]` = Database (CockroachDB)
 - Horizontal cylinder `@{ shape: das }` = Direct access storage (Kafka, Redis)

--- a/services/README.md
+++ b/services/README.md
@@ -28,6 +28,10 @@ flowchart LR
             Tenant["Tenant<br/>:50056"]
         end
 
+        subgraph Platform_Services["Platform Services"]
+            AW["audit-worker<br/>:8080"]
+        end
+
         subgraph Infrastructure["Infrastructure"]
             DB[("CockroachDB<br/>:26257")]
             Kafka@{ shape: das, label: "Kafka :9092" }
@@ -67,12 +71,18 @@ flowchart LR
     FA -.->|"Idempotency"| Redis
     PO -.->|"Idempotency"| Redis
 
+    %% audit-worker connections
+    AW -->|"Poll outbox"| DB
+    AW -->|"Write audit log"| DB
+
     classDef service fill:#4a90d9,stroke:#2d5a87,color:#fff
+    classDef platform fill:#607d8b,stroke:#455a64,color:#fff
     classDef storage fill:#50c878,stroke:#2d7a4a,color:#fff
     classDef external fill:#ff9800,stroke:#e65100,color:#fff
     classDef admin fill:#9c27b0,stroke:#6a1b9a,color:#fff
 
     class CA,PK,FA,Party,PO,Tenant service
+    class AW platform
     class DB,Kafka,Redis storage
     class User,Gateway external
     class TenantCtl admin
@@ -82,7 +92,8 @@ flowchart LR
 
 - Solid arrows (`-->`) = Required runtime dependency
 - Dashed arrows (`-.->`) = Optional runtime dependency
-- Blue boxes = Microservices
+- Blue boxes = Microservices (domain services)
+- Grey boxes = Platform services (infrastructure)
 - Purple boxes = Admin tools (CLI)
 - Vertical cylinder `[(" ")]` = Database (CockroachDB)
 - Horizontal cylinder `@{ shape: das }` = Direct access storage (Kafka, Redis)
@@ -202,6 +213,7 @@ Redis provides optional distributed idempotency for exactly-once semantics:
 | Party | 50055 | - | 9090 |
 | PaymentOrder | 50054 | 8080 | 9090 |
 | Tenant | 50056 | - | 9090 |
+| audit-worker | - | 8080 | 8080 |
 
 ## Observability
 
@@ -253,7 +265,7 @@ See [ADR-0009](../docs/adr/0009-application-level-audit-logging.md) for architec
 1. **Audit Schema**: Dedicated `{service}_audit` schema with `audit_log` table
 2. **Outbox Table**: `audit_outbox` table written atomically with business transaction
 3. **GORM Hooks**: `AfterCreate`, `BeforeUpdate`, `AfterUpdate`, `AfterDelete` hooks
-4. **Worker**: Background goroutine processing outbox → audit_log
+4. **Worker**: The `audit-worker` service polls the outbox and moves entries to `audit_log`
 
 **Key Guarantees:**
 

--- a/services/audit-worker/README.md
+++ b/services/audit-worker/README.md
@@ -1,0 +1,57 @@
+# audit-worker
+
+Platform service that processes audit log entries from the outbox table.
+
+## Purpose
+
+The audit-worker implements the worker component of the
+[transactional outbox pattern][adr-0009] for audit logging. It:
+
+[adr-0009]: ../../docs/adr/0009-application-level-audit-logging.md
+
+1. Polls the `audit_outbox` table every 5 seconds
+2. Processes records in batches of 100
+3. Moves entries to the `audit_log` table
+4. Implements retry logic (max 3 retries)
+5. Exposes Prometheus metrics for monitoring
+
+## Endpoints
+
+| Endpoint | Port | Purpose |
+|----------|------|---------|
+| `/health/live` | 8080 | Kubernetes liveness probe |
+| `/health/ready` | 8080 | Kubernetes readiness probe |
+| `/health/startup` | 8080 | Kubernetes startup probe |
+| `/metrics` | 8080 | Prometheus metrics |
+| `/` | 8080 | Version info |
+
+## Metrics
+
+- `audit_outbox_depth` - Current number of entries in outbox
+- `audit_processed_total` - Total entries processed
+- `audit_failed_total` - Total entries failed
+- `audit_processing_duration_seconds` - Processing latency histogram
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `PORT` | `8080` | HTTP server port |
+| `DATABASE_URL` | (local dev default) | PostgreSQL connection string |
+
+## Development
+
+```bash
+# Run locally
+go run ./services/audit-worker
+
+# Run tests
+go test ./services/audit-worker/...
+```
+
+## Deployment
+
+Deployed via Kubernetes manifests in `deployments/k8s/base/`.
+
+- **Replicas**: 3 (production)
+- **Resource limits**: 500m CPU, 512Mi memory

--- a/services/audit-worker/README.md
+++ b/services/audit-worker/README.md
@@ -27,10 +27,11 @@ The audit-worker implements the worker component of the
 
 ## Metrics
 
-- `audit_outbox_depth` - Current number of entries in outbox
-- `audit_processed_total` - Total entries processed
-- `audit_failed_total` - Total entries failed
-- `audit_processing_duration_seconds` - Processing latency histogram
+- `meridian_audit_worker_outbox_depth_total` - Current number of entries in outbox (gauge)
+- `meridian_audit_worker_outbox_processed_total` - Total entries processed (counter)
+- `meridian_audit_worker_outbox_failed_total` - Total entries failed (counter)
+- `meridian_audit_worker_processing_duration_seconds` - Batch processing duration (histogram)
+- `meridian_audit_worker_entry_age_seconds` - Age of entries when processed (histogram)
 
 ## Configuration
 

--- a/services/audit-worker/main.go
+++ b/services/audit-worker/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/meridianhub/meridian/shared/platform/audit"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
@@ -51,6 +52,9 @@ func setupRoutes(mux *http.ServeMux) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = fmt.Fprintf(w, "audit-worker v%s (commit: %s, built: %s)\n", Version, Commit, BuildDate)
 	})
+
+	// Prometheus metrics endpoint
+	mux.Handle("/metrics", promhttp.Handler())
 }
 
 // createServer creates an HTTP server with proper security timeouts

--- a/services/audit-worker/main.go
+++ b/services/audit-worker/main.go
@@ -1,4 +1,6 @@
-// Package main is the entry point for the Meridian open banking ledger service.
+// Package main is the entry point for the audit-worker service.
+// The audit-worker processes audit log entries from the outbox table,
+// moving them to the audit log with retry logic and metrics collection.
 package main
 
 import (
@@ -47,7 +49,7 @@ func setupRoutes(mux *http.ServeMux) {
 	// Root endpoint
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, "Meridian v%s (commit: %s, built: %s)\n", Version, Commit, BuildDate)
+		_, _ = fmt.Fprintf(w, "audit-worker v%s (commit: %s, built: %s)\n", Version, Commit, BuildDate)
 	})
 }
 
@@ -110,7 +112,7 @@ func setupDatabase(_ context.Context) (*gorm.DB, error) {
 }
 
 func main() {
-	log.Printf("Meridian v%s (commit: %s, built: %s)", Version, Commit, BuildDate)
+	log.Printf("audit-worker v%s (commit: %s, built: %s)", Version, Commit, BuildDate)
 
 	// Setup logger
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{

--- a/services/audit-worker/main_test.go
+++ b/services/audit-worker/main_test.go
@@ -63,7 +63,7 @@ func TestRootEndpoint(t *testing.T) {
 		t.Errorf("Expected status 200, got %d", w.Code)
 	}
 
-	expected := "Meridian vtest-version (commit: test-commit, built: test-date)\n"
+	expected := "audit-worker vtest-version (commit: test-commit, built: test-date)\n"
 	if w.Body.String() != expected {
 		t.Errorf("Expected body %q, got %q", expected, w.Body.String())
 	}


### PR DESCRIPTION
## Summary

- Renames the confusingly-named `meridian` service to `audit-worker` for clarity
- Moves from `utilities/meridian` to `services/audit-worker` where it belongs
- The service processes audit log entries from the outbox table - the name now reflects its purpose

## Changes Made

- **Source code**: `utilities/meridian/` → `services/audit-worker/`
- **Dockerfiles**: Updated build paths and binary names
- **Kubernetes manifests**: Renamed all resources (deployment, service, RBAC, configs)
- **Tiltfile**: Updated image name and paths
- **Documentation**: Updated services/README.md and docs/demo/ARCHITECTURE.md
- **New**: Added `services/audit-worker/README.md` documenting the service

## Test plan

- [x] `go build ./services/audit-worker/...` succeeds
- [x] `go test ./services/audit-worker/...` passes
- [ ] CI passes
- [ ] Tilt local dev environment works with new names