### PR TITLE
Update K8s secrets with service-specific database credentials

### DIFF
--- a/services/current-account/k8s/secret.yaml
+++ b/services/current-account/k8s/secret.yaml
@@ -13,5 +13,5 @@ metadata:
 type: Opaque
 stringData:
   # Local development connection string - CockroachDB in insecure mode
-  # search_path routes unqualified table names to correct schema
-  DATABASE_URL: "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable&search_path=current_account"
+  # Service connects to its own isolated database with dedicated user
+  DATABASE_URL: "postgres://meridian_current_account_user@cockroachdb:26257/meridian_current_account?sslmode=disable"

--- a/services/financial-accounting/k8s/secret.yaml
+++ b/services/financial-accounting/k8s/secret.yaml
@@ -13,5 +13,5 @@ metadata:
 type: Opaque
 stringData:
   # Local development connection string - CockroachDB in insecure mode
-  # search_path routes unqualified table names to correct schema
-  DATABASE_URL: "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable&search_path=financial_accounting"
+  # Service connects to its own isolated database with dedicated user
+  DATABASE_URL: "postgres://meridian_financial_accounting_user@cockroachdb:26257/meridian_financial_accounting?sslmode=disable"

--- a/services/party/k8s/secret.yaml
+++ b/services/party/k8s/secret.yaml
@@ -13,5 +13,5 @@ metadata:
 type: Opaque
 stringData:
   # Local development connection string - CockroachDB in insecure mode
-  # search_path routes unqualified table names to correct schema
-  DATABASE_URL: "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable&search_path=party"
+  # Service connects to its own isolated database with dedicated user
+  DATABASE_URL: "postgres://meridian_party_user@cockroachdb:26257/meridian_party?sslmode=disable"

--- a/services/payment-order/k8s/secret.yaml
+++ b/services/payment-order/k8s/secret.yaml
@@ -13,7 +13,7 @@ metadata:
 type: Opaque
 stringData:
   # Local development connection string - CockroachDB in insecure mode
-  # search_path routes unqualified table names to correct schema
-  DATABASE_URL: "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable&search_path=payment_order"
+  # Service connects to its own isolated database with dedicated user
+  DATABASE_URL: "postgres://meridian_payment_order_user@cockroachdb:26257/meridian_payment_order?sslmode=disable"
   # HMAC secret for webhook signature verification (dev only - use proper secret management in production)
   WEBHOOK_HMAC_SECRET: "dev-webhook-secret-change-in-production"

--- a/services/position-keeping/k8s/secret.yaml
+++ b/services/position-keeping/k8s/secret.yaml
@@ -13,5 +13,5 @@ metadata:
 type: Opaque
 stringData:
   # Local development connection string - CockroachDB in insecure mode
-  # search_path routes unqualified table names to correct schema
-  DATABASE_URL: "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable&search_path=position_keeping"
+  # Service connects to its own isolated database with dedicated user
+  DATABASE_URL: "postgres://meridian_position_keeping_user@cockroachdb:26257/meridian_position_keeping?sslmode=disable"

--- a/services/tenant/k8s/secret.yaml
+++ b/services/tenant/k8s/secret.yaml
@@ -13,5 +13,5 @@ metadata:
 type: Opaque
 stringData:
   # Local development connection string - CockroachDB in insecure mode
-  # search_path routes unqualified table names to correct schema
-  DATABASE_URL: "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable&search_path=platform"
+  # Service connects to its own isolated database with dedicated user
+  DATABASE_URL: "postgres://meridian_platform_user@cockroachdb:26257/meridian_platform?sslmode=disable"


### PR DESCRIPTION
## Summary
- Replace shared database connection strings with service-specific database URLs
- Each service now connects to its own isolated database with dedicated user credentials
- Removes schema-based `search_path` approach in favor of full database isolation

## Task Master Reference
- **Tag**: database-per-service
- **Task ID**: 5

## Changes Made
Updated `k8s/secret.yaml` for all 6 services:
- `current-account`: Uses `meridian_current_account_user` → `meridian_current_account`
- `financial-accounting`: Uses `meridian_financial_accounting_user` → `meridian_financial_accounting`
- `party`: Uses `meridian_party_user` → `meridian_party`
- `payment-order`: Uses `meridian_payment_order_user` → `meridian_payment_order`
- `position-keeping`: Uses `meridian_position_keeping_user` → `meridian_position_keeping`
- `tenant`: Uses `meridian_platform_user` → `meridian_platform`

## Test Plan
1. Deploy each service secret to K8s cluster
2. Verify secret content: `kubectl get secret -o yaml | base64 -d`
3. Test connection from pod: `kubectl exec -- psql $DATABASE_URL -c 'SELECT current_database()'`
4. Verify correct database returned for each service
5. Test permission isolation: Connection with wrong credentials should fail