### PR TITLE
docs: Add documentation and tests for per-service database configuration (task 7)

### DIFF
--- a/shared/platform/db/db.go
+++ b/shared/platform/db/db.go
@@ -7,6 +7,31 @@
 // - Automatic transaction retry logic
 // - Connection pooling with health checks
 // - Context-aware operations for timeout and cancellation
+// - Per-service database isolation via connection string configuration
+//
+// # Database-per-Service Architecture
+//
+// This package supports the database-per-service pattern where each microservice connects
+// to its own isolated database. The database name is specified as part of the connection
+// string (ConnectionString field in Config), not as a separate configuration parameter.
+//
+// Connection string format:
+//
+//	postgresql://user:password@host:port/database_name?sslmode=require
+//
+// Example connection strings for different services:
+//
+//	# Current Account service
+//	postgresql://meridian:secret@cockroachdb:26257/meridian_current_account?sslmode=require
+//
+//	# Position Keeping service
+//	postgresql://meridian:secret@cockroachdb:26257/meridian_position_keeping?sslmode=require
+//
+//	# Financial Accounting service
+//	postgresql://meridian:secret@cockroachdb:26257/meridian_financial_accounting?sslmode=require
+//
+// Services should read the connection string from the DATABASE_URL environment variable,
+// which is configured via Kubernetes secrets for each service deployment.
 //
 // The core DB interface is implemented by both PostgresPool (connection pooling) and Tx
 // (transaction wrapper), allowing the same repository methods to work with either.
@@ -54,8 +79,22 @@ type DB interface {
 }
 
 // Config holds the configuration for database connection pooling.
+//
+// The database name MUST be included in the ConnectionString field. This enables the
+// database-per-service architecture where each service connects to its own isolated database.
+// There is no separate Database field - the database name is always part of the connection URL.
+//
+// Example:
+//
+//	cfg := &Config{
+//	    ConnectionString: "postgresql://user:pass@host:26257/meridian_current_account?sslmode=require",
+//	    MaxConnections: 25,
+//	}
 type Config struct {
-	// ConnectionString is the PostgreSQL connection URL (e.g., "postgresql://user:pass@host:26257/db?sslmode=require")
+	// ConnectionString is the PostgreSQL connection URL including the database name.
+	// Format: postgresql://user:pass@host:port/database_name?sslmode=require
+	// The database name in the URL determines which database the pool connects to.
+	// This is typically read from the DATABASE_URL environment variable.
 	ConnectionString string
 
 	// MaxConnections is the maximum number of connections in the pool (default: 50)

--- a/shared/platform/db/integration_test.go
+++ b/shared/platform/db/integration_test.go
@@ -729,3 +729,221 @@ func TestPostgresPool_Integration_ReadOnlyTransaction(t *testing.T) {
 	})
 	assert.Error(t, err)
 }
+
+// TestPostgresPool_Integration_DatabaseNameInConnectionString verifies that different
+// database names can be used in connection strings to support per-service database isolation.
+// This test validates the database-per-service architecture pattern where each service
+// connects to its own database (e.g., meridian_current_account, meridian_position_keeping).
+func TestPostgresPool_Integration_DatabaseNameInConnectionString(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	t.Run("pool connects to custom database name", func(t *testing.T) {
+		// Create PostgreSQL container with a custom database name
+		// This simulates a service-specific database like "meridian_current_account"
+		customDBName := "meridian_test_service"
+		pgContainer, err := postgres.Run(ctx,
+			"postgres:15-alpine",
+			postgres.WithDatabase(customDBName),
+			postgres.WithUsername("test_user"),
+			postgres.WithPassword("test_password"),
+			testcontainers.WithWaitStrategy(
+				wait.ForLog("database system is ready to accept connections").
+					WithOccurrence(2).
+					WithStartupTimeout(60*time.Second)),
+		)
+		require.NoError(t, err, "failed to start postgres container")
+		defer func() { _ = pgContainer.Terminate(ctx) }()
+
+		// Get connection string - it will include the custom database name
+		connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+		require.NoError(t, err, "failed to get connection string")
+
+		// Verify the connection string contains our database name
+		assert.Contains(t, connStr, customDBName,
+			"connection string should contain custom database name")
+
+		// Create pool with the connection string
+		cfg := DefaultConfig(connStr)
+		pool, err := NewPostgresPool(ctx, cfg)
+		require.NoError(t, err, "failed to create postgres pool")
+		defer func() { _ = pool.Close() }()
+
+		// Verify we can connect and query the correct database
+		var currentDB string
+		err = pool.QueryRowContext(ctx, "SELECT current_database()").Scan(&currentDB)
+		require.NoError(t, err, "failed to query current database")
+		assert.Equal(t, customDBName, currentDB,
+			"pool should connect to the database specified in connection string")
+	})
+
+	t.Run("Stats works correctly with custom database", func(t *testing.T) {
+		// Create container with service-specific database name
+		serviceName := "meridian_position_keeping"
+		pgContainer, err := postgres.Run(ctx,
+			"postgres:15-alpine",
+			postgres.WithDatabase(serviceName),
+			postgres.WithUsername("test_user"),
+			postgres.WithPassword("test_password"),
+			testcontainers.WithWaitStrategy(
+				wait.ForLog("database system is ready to accept connections").
+					WithOccurrence(2).
+					WithStartupTimeout(60*time.Second)),
+		)
+		require.NoError(t, err)
+		defer func() { _ = pgContainer.Terminate(ctx) }()
+
+		connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+		require.NoError(t, err)
+
+		cfg := DefaultConfig(connStr)
+		cfg.MaxConnections = 10
+		cfg.MinConnections = 2
+
+		pool, err := NewPostgresPool(ctx, cfg)
+		require.NoError(t, err)
+		defer func() { _ = pool.Close() }()
+
+		// Verify Stats() works correctly
+		stats := pool.Stats()
+		assert.Equal(t, 10, stats.MaxOpenConnections,
+			"Stats should reflect configured max connections")
+		assert.GreaterOrEqual(t, stats.OpenConnections, 0,
+			"OpenConnections should be non-negative")
+	})
+
+	t.Run("invalid database name fails during Ping", func(t *testing.T) {
+		// Create container with a valid database
+		pgContainer, err := postgres.Run(ctx,
+			"postgres:15-alpine",
+			postgres.WithDatabase("valid_db"),
+			postgres.WithUsername("test_user"),
+			postgres.WithPassword("test_password"),
+			testcontainers.WithWaitStrategy(
+				wait.ForLog("database system is ready to accept connections").
+					WithOccurrence(2).
+					WithStartupTimeout(60*time.Second)),
+		)
+		require.NoError(t, err)
+		defer func() { _ = pgContainer.Terminate(ctx) }()
+
+		// Get the host and port, but use an invalid database name
+		host, err := pgContainer.Host(ctx)
+		require.NoError(t, err)
+		port, err := pgContainer.MappedPort(ctx, "5432/tcp")
+		require.NoError(t, err)
+
+		// Create connection string with non-existent database
+		invalidConnStr := fmt.Sprintf(
+			"postgres://test_user:test_password@%s:%s/nonexistent_database?sslmode=disable",
+			host, port.Port())
+
+		cfg := DefaultConfig(invalidConnStr)
+		_, err = NewPostgresPool(ctx, cfg)
+		// NewPostgresPool calls Ping internally, so it should fail for invalid database
+		assert.Error(t, err, "should fail when connecting to non-existent database")
+		assert.Contains(t, err.Error(), "failed to ping database",
+			"error should indicate ping failure")
+	})
+}
+
+// TestPostgresPool_Integration_MultiplePools verifies that multiple pools can be
+// created simultaneously for different databases. This validates the per-service
+// database architecture where each microservice maintains its own connection pool.
+func TestPostgresPool_Integration_MultiplePools(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+
+	// Create two separate containers simulating two service databases
+	db1Container, err := postgres.Run(ctx,
+		"postgres:15-alpine",
+		postgres.WithDatabase("meridian_service_a"),
+		postgres.WithUsername("test_user"),
+		postgres.WithPassword("test_password"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	require.NoError(t, err, "failed to start first postgres container")
+	defer func() { _ = db1Container.Terminate(ctx) }()
+
+	db2Container, err := postgres.Run(ctx,
+		"postgres:15-alpine",
+		postgres.WithDatabase("meridian_service_b"),
+		postgres.WithUsername("test_user"),
+		postgres.WithPassword("test_password"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	require.NoError(t, err, "failed to start second postgres container")
+	defer func() { _ = db2Container.Terminate(ctx) }()
+
+	// Get connection strings
+	connStr1, err := db1Container.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	connStr2, err := db2Container.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	// Create pools for both databases
+	pool1, err := NewPostgresPool(ctx, DefaultConfig(connStr1))
+	require.NoError(t, err, "failed to create pool for service_a")
+	defer func() { _ = pool1.Close() }()
+
+	pool2, err := NewPostgresPool(ctx, DefaultConfig(connStr2))
+	require.NoError(t, err, "failed to create pool for service_b")
+	defer func() { _ = pool2.Close() }()
+
+	// Verify each pool connects to its respective database
+	var db1Name, db2Name string
+	err = pool1.QueryRowContext(ctx, "SELECT current_database()").Scan(&db1Name)
+	require.NoError(t, err)
+	assert.Equal(t, "meridian_service_a", db1Name)
+
+	err = pool2.QueryRowContext(ctx, "SELECT current_database()").Scan(&db2Name)
+	require.NoError(t, err)
+	assert.Equal(t, "meridian_service_b", db2Name)
+
+	// Create tables in each database and verify isolation
+	_, err = pool1.ExecContext(ctx, `CREATE TABLE service_a_data (id SERIAL PRIMARY KEY, value TEXT)`)
+	require.NoError(t, err)
+
+	_, err = pool2.ExecContext(ctx, `CREATE TABLE service_b_data (id SERIAL PRIMARY KEY, value TEXT)`)
+	require.NoError(t, err)
+
+	// Insert data into service_a's table
+	_, err = pool1.ExecContext(ctx, `INSERT INTO service_a_data (value) VALUES ('from_service_a')`)
+	require.NoError(t, err)
+
+	// Insert data into service_b's table
+	_, err = pool2.ExecContext(ctx, `INSERT INTO service_b_data (value) VALUES ('from_service_b')`)
+	require.NoError(t, err)
+
+	// Verify data isolation - service_a should not see service_b's table
+	var count int
+	err = pool1.QueryRowContext(ctx, `SELECT COUNT(*) FROM service_a_data`).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "service_a should have its own data")
+
+	// Service_a's pool should not have service_b's table
+	rows, err := pool1.QueryContext(ctx, `SELECT * FROM service_b_data`)
+	if rows != nil {
+		defer func() { _ = rows.Close() }()
+		// Consume rows to get any deferred error
+		for rows.Next() {
+		}
+		if rowsErr := rows.Err(); rowsErr != nil {
+			err = rowsErr
+		}
+	}
+	assert.Error(t, err, "service_a should not see service_b's tables")
+}


### PR DESCRIPTION
## Summary

- Update shared database pool documentation to clarify database names must be in connection string
- Add integration tests verifying pool supports custom database names
- Add test for multiple simultaneous pools with different databases

## Task Master Reference

- **Tag**: database-per-service
- **Task ID**: 7

## Changes Made

### Documentation Updates

- Updated package-level documentation in `shared/platform/db/db.go` with:
  - Database-per-service architecture section
  - Connection string format and examples for each service
  - Clear guidance on DATABASE_URL environment variable

- Updated `Config` struct documentation to clarify:
  - Database name MUST be in ConnectionString
  - No separate Database field exists
  - Typical usage pattern with environment variable

### New Integration Tests

- `TestPostgresPool_Integration_DatabaseNameInConnectionString`:
  - Verifies pool connects to custom database name
  - Tests Stats() works with custom database
  - Tests invalid database name fails during Ping

- `TestPostgresPool_Integration_MultiplePools`:
  - Creates simultaneous pools for different databases
  - Verifies database isolation (tables in one DB not visible to other)

### Verification Audit

Confirmed all 7 services correctly read DATABASE_URL from environment:
- current-account: `getEnvOrDefault("DATABASE_URL", ...)`
- financial-accounting: `getEnvOrDefault("DATABASE_URL", ...)`
- party: `getEnvOrDefault("DATABASE_URL", ...)`
- payment-order: `getEnvOrDefault("DATABASE_URL", ...)`
- position-keeping: `os.Getenv("DATABASE_URL")` with validation
- tenant: `getEnvOrDefault("DATABASE_URL", ...)`
- audit-worker: `os.Getenv("DATABASE_URL")`

## Test Plan

1. Unit tests pass (verified: `go test -v -short`)
2. Integration tests verify:
   - Pool connects to database name from connection string
   - Multiple pools can operate simultaneously
   - Invalid database names fail appropriately
3. No code changes to existing service behavior

## Risk Assessment

Low risk - documentation and test-only changes. No modifications to production code paths.