### PR TITLE
Update GORM TableName methods to singular unqualified names (task 4)

### DIFF
--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -192,8 +192,9 @@ type {Entity}Entity struct {
     UpdatedBy string         `gorm:"not null"`
 }
 
+// TableName uses singular unqualified name to allow PostgreSQL search_path routing.
 func ({Entity}Entity) TableName() string {
-    return "{schema}.{table}"
+    return "{entity}"  // singular, unqualified (e.g., "party", "account")
 }
 ```
 

--- a/services/tenant/provisioner/postgres_provisioner.go
+++ b/services/tenant/provisioner/postgres_provisioner.go
@@ -590,8 +590,10 @@ type provisioningEntity struct {
 	Version         int        `gorm:"column:version"`
 }
 
+// TableName specifies the table name for GORM.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
 func (provisioningEntity) TableName() string {
-	return "platform.tenant_provisioning"
+	return "tenant_provisioning"
 }
 
 // getProvisioningStatusLocked retrieves the status without acquiring the mutex.
@@ -619,8 +621,9 @@ func (p *PostgresProvisioner) saveProvisioningStatus(ctx context.Context, status
 
 	// Use PostgreSQL UPSERT (ON CONFLICT DO UPDATE)
 	// This is atomic and handles both insert and update cases
+	// Uses unqualified table name (tenant_provisioning) for search_path routing
 	upsertSQL := `
-		INSERT INTO platform.tenant_provisioning
+		INSERT INTO tenant_provisioning
 			(tenant_id, state, service_schemas, error_message, created_at, updated_at, deprovisioned_at, version)
 		VALUES
 			(?, ?, ?, ?, ?, ?, ?, 1)
@@ -630,7 +633,7 @@ func (p *PostgresProvisioner) saveProvisioningStatus(ctx context.Context, status
 			error_message = EXCLUDED.error_message,
 			updated_at = EXCLUDED.updated_at,
 			deprovisioned_at = EXCLUDED.deprovisioned_at,
-			version = platform.tenant_provisioning.version + 1
+			version = tenant_provisioning.version + 1
 	`
 
 	return p.db.WithContext(ctx).Exec(

--- a/services/tenant/provisioner/postgres_provisioner_test.go
+++ b/services/tenant/provisioner/postgres_provisioner_test.go
@@ -98,13 +98,9 @@ func (tc *testContainer) cleanup(t *testing.T) {
 func setupPlatformSchema(t *testing.T, db *gorm.DB) {
 	t.Helper()
 
-	// Create platform schema
-	err := db.Exec("CREATE SCHEMA IF NOT EXISTS platform").Error
-	require.NoError(t, err)
-
-	// Create tenants table (simplified for tests)
-	err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS platform.tenants (
+	// Create tenant table (singular, unqualified - matches migration)
+	err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS tenant (
 			id VARCHAR(50) PRIMARY KEY,
 			display_name VARCHAR(255) NOT NULL,
 			status VARCHAR(20) NOT NULL DEFAULT 'active',
@@ -113,10 +109,10 @@ func setupPlatformSchema(t *testing.T, db *gorm.DB) {
 	`).Error
 	require.NoError(t, err)
 
-	// Create tenant_provisioning table
+	// Create tenant_provisioning table (singular, unqualified - matches migration)
 	err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS platform.tenant_provisioning (
-			tenant_id VARCHAR(50) PRIMARY KEY REFERENCES platform.tenants(id) ON DELETE RESTRICT,
+		CREATE TABLE IF NOT EXISTS tenant_provisioning (
+			tenant_id VARCHAR(50) PRIMARY KEY REFERENCES tenant(id) ON DELETE RESTRICT,
 			state VARCHAR(20) NOT NULL DEFAULT 'pending',
 			service_schemas JSONB NOT NULL DEFAULT '[]',
 			error_message TEXT,
@@ -134,7 +130,7 @@ func setupPlatformSchema(t *testing.T, db *gorm.DB) {
 func createTestTenant(t *testing.T, db *gorm.DB, tenantID string) {
 	t.Helper()
 	err := db.Exec(
-		"INSERT INTO platform.tenants (id, display_name) VALUES (?, ?)",
+		"INSERT INTO tenant (id, display_name) VALUES (?, ?)",
 		tenantID, "Test Tenant "+tenantID,
 	).Error
 	require.NoError(t, err)
@@ -338,7 +334,7 @@ func TestPostgresProvisioner_ProvisionSchemas_ConcurrentBlocked(t *testing.T) {
 
 	// Pre-create an in_progress status to simulate concurrent provisioning
 	tc.db.Exec(`
-		INSERT INTO platform.tenant_provisioning (tenant_id, state, service_schemas)
+		INSERT INTO tenant_provisioning (tenant_id, state, service_schemas)
 		VALUES (?, 'in_progress', '[]')
 	`, tenantID.String())
 

--- a/shared/domain/models/account.go
+++ b/shared/domain/models/account.go
@@ -35,8 +35,8 @@ type Account struct {
 }
 
 // TableName overrides the table name.
-// Uses unqualified name to allow PostgreSQL search_path to route queries
-// to organization-specific schemas (e.g., org_acme_bank.accounts).
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries
+// to tenant-specific schemas (e.g., tenant_acme_bank.account).
 func (Account) TableName() string {
-	return "accounts"
+	return "account"
 }

--- a/shared/domain/models/account_test.go
+++ b/shared/domain/models/account_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestAccount_TableName(t *testing.T) {
 	account := Account{}
-	if account.TableName() != "accounts" {
-		t.Errorf("TableName() = %v, want %v", account.TableName(), "accounts")
+	if account.TableName() != "account" {
+		t.Errorf("TableName() = %v, want %v", account.TableName(), "account")
 	}
 }
 

--- a/shared/domain/models/audit.go
+++ b/shared/domain/models/audit.go
@@ -52,8 +52,9 @@ type AuditOutbox struct {
 }
 
 // TableName overrides the table name for AuditOutbox.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
 func (AuditOutbox) TableName() string {
-	return "current_account_audit.audit_outbox"
+	return "audit_outbox"
 }
 
 // AuditLog represents a permanent audit log entry.
@@ -74,8 +75,9 @@ type AuditLog struct {
 }
 
 // TableName overrides the table name for AuditLog.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
 func (AuditLog) TableName() string {
-	return "current_account_audit.audit_log"
+	return "audit_log"
 }
 
 // recordAudit writes an audit outbox entry within the current transaction.
@@ -83,7 +85,7 @@ func (AuditLog) TableName() string {
 //
 // Parameters:
 //   - tx: The GORM transaction (must be non-nil)
-//   - tableName: The table being audited (e.g., "customers")
+//   - tableName: The table being audited (e.g., "customer")
 //   - operation: The operation type ("INSERT", "UPDATE", "DELETE")
 //   - recordID: The UUID of the record being audited
 //   - oldValue: The old state (nil for INSERT, populated for UPDATE/DELETE)
@@ -148,7 +150,7 @@ func recordAudit(tx *gorm.DB, tableName, operation string, recordID uuid.UUID, o
 // AfterCreate is a GORM hook that runs after INSERT operations on Customer.
 // It writes an audit outbox entry with the new customer data.
 func (c *Customer) AfterCreate(tx *gorm.DB) error {
-	return recordAudit(tx, "customers", "INSERT", c.ID, nil, c)
+	return recordAudit(tx, "customer", "INSERT", c.ID, nil, c)
 }
 
 // BeforeUpdate is a GORM hook that runs before UPDATE operations on Customer.
@@ -193,11 +195,11 @@ func (c *Customer) AfterUpdate(tx *gorm.DB) error {
 		return ErrOldValueNotFound
 	}
 
-	return recordAudit(tx, "customers", "UPDATE", c.ID, old, c)
+	return recordAudit(tx, "customer", "UPDATE", c.ID, old, c)
 }
 
 // AfterDelete is a GORM hook that runs after DELETE operations on Customer.
 // It writes an audit outbox entry with the deleted customer data.
 func (c *Customer) AfterDelete(tx *gorm.DB) error {
-	return recordAudit(tx, "customers", "DELETE", c.ID, c, nil)
+	return recordAudit(tx, "customer", "DELETE", c.ID, c, nil)
 }

--- a/shared/domain/models/audit_test.go
+++ b/shared/domain/models/audit_test.go
@@ -49,16 +49,10 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 	err = db.Exec("CREATE EXTENSION IF NOT EXISTS pgcrypto").Error
 	require.NoError(t, err, "Failed to enable pgcrypto extension")
 
-	// Create schemas (PostgreSQL supports schemas like CockroachDB)
-	err = db.Exec("CREATE SCHEMA IF NOT EXISTS current_account").Error
-	require.NoError(t, err, "Failed to create current_account schema")
-
-	err = db.Exec("CREATE SCHEMA IF NOT EXISTS current_account_audit").Error
-	require.NoError(t, err, "Failed to create current_account_audit schema")
-
-	// Create audit_outbox table
+	// Create audit_outbox table (unqualified, uses public schema)
+	// TableName method now returns unqualified "audit_outbox" for search_path routing
 	err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS current_account_audit.audit_outbox (
+		CREATE TABLE IF NOT EXISTS audit_outbox (
 			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			table_name VARCHAR(100) NOT NULL,
 			operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
@@ -80,7 +74,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 	// Create indexes
 	err = db.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_audit_outbox_status_created
-		ON current_account_audit.audit_outbox(status, created_at)
+		ON audit_outbox(status, created_at)
 	`).Error
 	require.NoError(t, err, "Failed to create audit_outbox indexes")
 
@@ -126,13 +120,13 @@ func TestAuditOutbox_AtomicCommit(t *testing.T) {
 
 	// Verify outbox entry exists
 	var outbox AuditOutbox
-	err = db.Table("current_account_audit.audit_outbox").
+	err = db.Table("audit_outbox").
 		Where("record_id = ?", customer.ID).
 		First(&outbox).Error
 	require.NoError(t, err, "Audit outbox entry should exist")
 
 	// Verify outbox content
-	assert.Equal(t, "customers", outbox.Table, "Table name should be 'customers'")
+	assert.Equal(t, "customer", outbox.Table, "Table name should be 'customer'")
 	assert.Equal(t, "INSERT", outbox.Operation, "Operation should be 'INSERT'")
 	assert.Equal(t, "pending", outbox.Status, "Status should be 'pending'")
 	assert.NotEmpty(t, outbox.NewValues, "NewValues should contain customer data")
@@ -166,7 +160,7 @@ func TestAuditOutbox_RollbackOnBusinessFailure(t *testing.T) {
 
 		// Verify outbox entry exists within transaction
 		var count int64
-		tx.Table("current_account_audit.audit_outbox").
+		tx.Table("audit_outbox").
 			Where("record_id = ?", customer.ID).
 			Count(&count)
 		assert.Equal(t, int64(1), count, "Outbox entry should exist within transaction")
@@ -179,7 +173,7 @@ func TestAuditOutbox_RollbackOnBusinessFailure(t *testing.T) {
 
 	// Verify outbox entry was rolled back
 	var count int64
-	db.Table("current_account_audit.audit_outbox").Count(&count)
+	db.Table("audit_outbox").Count(&count)
 	assert.Equal(t, int64(0), count, "Outbox should be empty after rollback")
 
 	// Verify customer was also rolled back
@@ -213,7 +207,7 @@ func TestAuditOutbox_CapturesInsertUpdateDelete(t *testing.T) {
 
 	// Verify INSERT audit
 	var insertAudit AuditOutbox
-	err = db.Table("current_account_audit.audit_outbox").
+	err = db.Table("audit_outbox").
 		Where("record_id = ? AND operation = ?", customer.ID, "INSERT").
 		First(&insertAudit).Error
 	require.NoError(t, err, "INSERT audit should exist")
@@ -229,7 +223,7 @@ func TestAuditOutbox_CapturesInsertUpdateDelete(t *testing.T) {
 
 	// Verify UPDATE audit
 	var updateAudit AuditOutbox
-	err = db.Table("current_account_audit.audit_outbox").
+	err = db.Table("audit_outbox").
 		Where("record_id = ? AND operation = ?", customer.ID, "UPDATE").
 		First(&updateAudit).Error
 	require.NoError(t, err, "UPDATE audit should exist")
@@ -243,7 +237,7 @@ func TestAuditOutbox_CapturesInsertUpdateDelete(t *testing.T) {
 
 	// Verify DELETE audit
 	var deleteAudit AuditOutbox
-	err = db.Table("current_account_audit.audit_outbox").
+	err = db.Table("audit_outbox").
 		Where("record_id = ? AND operation = ?", customer.ID, "DELETE").
 		First(&deleteAudit).Error
 	require.NoError(t, err, "DELETE audit should exist")
@@ -253,7 +247,7 @@ func TestAuditOutbox_CapturesInsertUpdateDelete(t *testing.T) {
 
 	// Verify total audit count
 	var totalCount int64
-	db.Table("current_account_audit.audit_outbox").
+	db.Table("audit_outbox").
 		Where("record_id = ?", customer.ID).
 		Count(&totalCount)
 	assert.Equal(t, int64(3), totalCount, "Should have exactly 3 audit records (INSERT, UPDATE, DELETE)")
@@ -284,7 +278,7 @@ func TestAuditOutbox_CapturesChangedBy(t *testing.T) {
 
 	// Verify audit captures changed_by
 	var outbox AuditOutbox
-	err = db.Table("current_account_audit.audit_outbox").
+	err = db.Table("audit_outbox").
 		Where("record_id = ?", customer.ID).
 		First(&outbox).Error
 	require.NoError(t, err, "Audit outbox entry should exist")

--- a/shared/domain/models/customer.go
+++ b/shared/domain/models/customer.go
@@ -19,7 +19,9 @@ type Customer struct {
 	Accounts []Account `gorm:"foreignKey:CustomerID;constraint:OnDelete:RESTRICT" json:"accounts,omitempty"`
 }
 
-// TableName overrides the table name used by Customer to `current_account.customers`
+// TableName overrides the table name.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries
+// to tenant-specific schemas (e.g., tenant_acme_bank.customer).
 func (Customer) TableName() string {
-	return "current_account.customers"
+	return "customer"
 }

--- a/shared/domain/models/customer_test.go
+++ b/shared/domain/models/customer_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestCustomer_TableName(t *testing.T) {
 	customer := Customer{}
-	if customer.TableName() != "current_account.customers" {
-		t.Errorf("TableName() = %v, want %v", customer.TableName(), "current_account.customers")
+	if customer.TableName() != "customer" {
+		t.Errorf("TableName() = %v, want %v", customer.TableName(), "customer")
 	}
 }
 

--- a/shared/domain/models/financial_position_log.go
+++ b/shared/domain/models/financial_position_log.go
@@ -8,7 +8,7 @@ import (
 )
 
 // FinancialPositionLog represents the aggregate root for position keeping.
-// Maps to position_keeping.financial_position_logs table.
+// Maps to financial_position_log table (singular, unqualified for search_path routing).
 type FinancialPositionLog struct {
 	BaseModel
 
@@ -33,12 +33,13 @@ type FinancialPositionLog struct {
 }
 
 // TableName specifies the table name for GORM.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
 func (FinancialPositionLog) TableName() string {
-	return "position_keeping.financial_position_logs"
+	return "financial_position_log"
 }
 
 // TransactionLogEntry represents a single transaction entry in the position log.
-// Maps to position_keeping.transaction_log_entries table.
+// Maps to transaction_log_entry table (singular, unqualified for search_path routing).
 type TransactionLogEntry struct {
 	BaseModel
 
@@ -61,12 +62,13 @@ type TransactionLogEntry struct {
 }
 
 // TableName specifies the table name for GORM.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
 func (TransactionLogEntry) TableName() string {
-	return "position_keeping.transaction_log_entries"
+	return "transaction_log_entry"
 }
 
 // TransactionLineage tracks parent-child relationships between transactions.
-// Maps to position_keeping.transaction_lineages table.
+// Maps to transaction_lineage table (singular, unqualified for search_path routing).
 type TransactionLineage struct {
 	BaseModel
 
@@ -83,12 +85,13 @@ type TransactionLineage struct {
 }
 
 // TableName specifies the table name for GORM.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
 func (TransactionLineage) TableName() string {
-	return "position_keeping.transaction_lineages"
+	return "transaction_lineage"
 }
 
 // AuditTrailEntry captures audit information for compliance.
-// Maps to position_keeping.audit_trail_entries table.
+// Maps to audit_trail_entry table (singular, unqualified for search_path routing).
 type AuditTrailEntry struct {
 	BaseModel
 
@@ -107,6 +110,7 @@ type AuditTrailEntry struct {
 }
 
 // TableName specifies the table name for GORM.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
 func (AuditTrailEntry) TableName() string {
-	return "position_keeping.audit_trail_entries"
+	return "audit_trail_entry"
 }

--- a/shared/platform/audit/worker_test.go
+++ b/shared/platform/audit/worker_test.go
@@ -51,16 +51,10 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	err = db.Exec("CREATE EXTENSION IF NOT EXISTS pgcrypto").Error
 	require.NoError(t, err, "Failed to enable pgcrypto extension")
 
-	// Create schemas (PostgreSQL supports schemas like CockroachDB)
-	err = db.Exec("CREATE SCHEMA IF NOT EXISTS current_account").Error
-	require.NoError(t, err, "Failed to create current_account schema")
-
-	err = db.Exec("CREATE SCHEMA IF NOT EXISTS current_account_audit").Error
-	require.NoError(t, err, "Failed to create current_account_audit schema")
-
-	// Create audit_outbox table
+	// Create audit_outbox table (unqualified, uses public schema)
+	// TableName method now returns unqualified "audit_outbox" for search_path routing
 	err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS current_account_audit.audit_outbox (
+		CREATE TABLE IF NOT EXISTS audit_outbox (
 			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			table_name VARCHAR(100) NOT NULL,
 			operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
@@ -82,13 +76,13 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	// Create indexes for audit_outbox
 	err = db.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_audit_outbox_status_created
-		ON current_account_audit.audit_outbox(status, created_at)
+		ON audit_outbox(status, created_at)
 	`).Error
 	require.NoError(t, err, "Failed to create audit_outbox indexes")
 
-	// Create audit_log table
+	// Create audit_log table (unqualified for search_path routing)
 	err = db.Exec(`
-		CREATE TABLE IF NOT EXISTS current_account_audit.audit_log (
+		CREATE TABLE IF NOT EXISTS audit_log (
 			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
 			table_name VARCHAR(100) NOT NULL,
 			operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
@@ -107,19 +101,19 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	// Create indexes for audit_log
 	err = db.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_audit_log_table_name
-		ON current_account_audit.audit_log(table_name)
+		ON audit_log(table_name)
 	`).Error
 	require.NoError(t, err, "Failed to create audit_log table_name index")
 
 	err = db.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_audit_log_operation
-		ON current_account_audit.audit_log(operation)
+		ON audit_log(operation)
 	`).Error
 	require.NoError(t, err, "Failed to create audit_log operation index")
 
 	err = db.Exec(`
 		CREATE INDEX IF NOT EXISTS idx_audit_log_record_id
-		ON current_account_audit.audit_log(record_id)
+		ON audit_log(record_id)
 	`).Error
 	require.NoError(t, err, "Failed to create audit_log record_id index")
 
@@ -141,7 +135,7 @@ func createTestEntry(t *testing.T, db *gorm.DB, status string) *models.AuditOutb
 
 	entry := &models.AuditOutbox{
 		ID:        uuid.New(),
-		Table:     "customers",
+		Table:     "customer", // singular table name for search_path routing
 		Operation: "INSERT",
 		RecordID:  uuid.New(),
 		NewValues: `{"id": "123", "name": "Test Customer"}`,

--- a/utilities/atlas-loader/main_test.go
+++ b/utilities/atlas-loader/main_test.go
@@ -42,10 +42,10 @@ func TestAtlasLoaderBinary(t *testing.T) {
 			wantExitCode: 0,
 			wantStdout: []string{
 				"CREATE TABLE",
-				"customers",
-				"accounts",                // shared domain models use GORM default plural naming
-				"financial_position_logs", // shared domain models use GORM default plural naming
-				"transaction_log_entries", // shared domain models use GORM default plural naming
+				"customer",               // singular table name for search_path routing
+				"account",                // singular table name for search_path routing
+				"financial_position_log", // singular table name for search_path routing
+				"transaction_log_entry",  // singular table name for search_path routing
 			},
 			wantNotStdout: []string{
 				"CREATE SCHEMA", // No schema statement without filter
@@ -57,13 +57,13 @@ func TestAtlasLoaderBinary(t *testing.T) {
 			wantExitCode: 0,
 			wantStdout: []string{
 				"CREATE SCHEMA IF NOT EXISTS current_account",
-				"customers",
-				"account", // service entity uses singular table name
-				"lien",    // service entity uses singular table name for balance holds
+				"customer", // singular table name for search_path routing
+				"account",  // singular table name for search_path routing
+				"lien",     // singular table name for search_path routing
 			},
 			wantNotStdout: []string{
-				"financial_position_logs", // position_keeping model should not be included
-				"transaction_log_entries", // position_keeping model should not be included
+				"financial_position_log", // position_keeping model should not be included
+				"transaction_log_entry",  // position_keeping model should not be included
 			},
 		},
 		{
@@ -73,12 +73,12 @@ func TestAtlasLoaderBinary(t *testing.T) {
 			wantStdout: []string{
 				"CREATE SCHEMA IF NOT EXISTS current_account",
 				"CREATE SCHEMA IF NOT EXISTS position_keeping",
-				"accounts",                // shared Account model uses GORM default plural naming
-				"financial_position_logs", // shared domain model uses GORM default plural naming
-				"transaction_log_entries", // shared domain model uses GORM default plural naming
-				"transaction_lineages",    // shared domain model uses GORM default plural naming
-				"audit_trail_entries",     // shared domain model uses GORM default plural naming
-				// Note: customers table also included because Account has FK to Customer
+				"account",                // singular table name for search_path routing
+				"financial_position_log", // singular table name for search_path routing
+				"transaction_log_entry",  // singular table name for search_path routing
+				"transaction_lineage",    // singular table name for search_path routing
+				"audit_trail_entry",      // singular table name for search_path routing
+				// Note: customer table also included because Account has FK to Customer
 				// GORM requires the full FK chain for proper constraint generation
 			},
 			wantNotStdout: []string{
@@ -160,11 +160,9 @@ func TestOutputFormat(t *testing.T) {
 		assert.Contains(t, output, "CREATE TABLE", "output should contain CREATE TABLE")
 		assert.Contains(t, output, "PRIMARY KEY", "output should contain PRIMARY KEY")
 
-		// Verify schema qualification for schema-bound tables
-		assert.Contains(t, output, `"current_account"."customers"`, "customers table should be schema-qualified")
-
-		// Verify unqualified table names for multi-org tables (account, lien)
-		// Service-specific entities use singular names for search_path routing
+		// Verify unqualified singular table names for search_path routing
+		// All entities now use singular, unqualified names for database-per-service architecture
+		assert.Contains(t, output, `CREATE TABLE "customer"`, "customer table should be singular and unqualified")
 		assert.Contains(t, output, `CREATE TABLE "account"`, "account table should be singular and unqualified")
 		assert.Contains(t, output, `CREATE TABLE "lien"`, "lien table should be singular and unqualified")
 


### PR DESCRIPTION
## Summary
- Updates all GORM TableName methods to return singular, unqualified table names
- Supports PostgreSQL search_path routing for database-per-service multi-tenancy
- Updates raw SQL in tenant provisioner to use unqualified names
- Updates tests and documentation to reflect new naming convention

## Task Master Reference
- **Tag**: database-per-service
- **Task ID**: 4

## Changes Made

### Entity Files Updated
| File | Old Name | New Name |
|------|----------|----------|
| `shared/domain/models/account.go` | `"accounts"` | `"account"` |
| `shared/domain/models/customer.go` | `"current_account.customers"` | `"customer"` |
| `shared/domain/models/audit.go` | `"current_account_audit.audit_outbox"` | `"audit_outbox"` |
| `shared/domain/models/audit.go` | `"current_account_audit.audit_log"` | `"audit_log"` |
| `shared/domain/models/financial_position_log.go` | `"position_keeping.financial_position_logs"` | `"financial_position_log"` |
| `shared/domain/models/financial_position_log.go` | `"position_keeping.transaction_log_entries"` | `"transaction_log_entry"` |
| `shared/domain/models/financial_position_log.go` | `"position_keeping.transaction_lineages"` | `"transaction_lineage"` |
| `shared/domain/models/financial_position_log.go` | `"position_keeping.audit_trail_entries"` | `"audit_trail_entry"` |
| `services/tenant/provisioner/postgres_provisioner.go` | `"platform.tenant_provisioning"` | `"tenant_provisioning"` |

### Test Updates
- `shared/domain/models/account_test.go`: Updated expected TableName
- `shared/domain/models/customer_test.go`: Updated expected TableName
- `shared/domain/models/audit_test.go`: Updated table references in test setup and assertions
- `services/tenant/provisioner/postgres_provisioner_test.go`: Updated table creation SQL
- `utilities/atlas-loader/main_test.go`: Updated expected output patterns

### Documentation Updates
- `docs/guides/new-bian-service-checklist.md`: Updated TableName example to show singular pattern

## Test Plan
- [x] All `shared/domain/models/...` unit tests pass
- [x] All `services/tenant/...` integration tests pass
- [x] All `utilities/atlas-loader/...` tests pass
- [x] Code compiles with `go build ./...`