### PR TITLE
Clean up old shared meridian database references (task 9)

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -621,7 +621,7 @@ metadata:
 type: Opaque
 stringData:
   # Local development connection string - CockroachDB in insecure mode
-  DATABASE_URL: "postgres://meridian@cockroachdb:26257/meridian?sslmode=disable"
+  DATABASE_URL: "postgres://meridian_platform_user@cockroachdb:26257/meridian_platform?sslmode=disable"
 '''))
 
 # Set resource dependencies

--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -303,7 +303,7 @@ atlas migrate diff initial \
 atlas migrate apply \
   --env local \
   --config file://services/{service}/atlas/atlas.hcl \
-  --url "postgres://meridian:meridian@localhost:26257/{service}?sslmode=disable"
+  --url "postgres://meridian_{service}_user@localhost:26257/meridian_{service}?sslmode=disable"
 ```
 
 **Migration file naming**: `YYYYMMDDHHMMSS_description.sql`
@@ -312,7 +312,7 @@ atlas migrate apply \
 
 ```bash
 # Query database to confirm schema
-psql -h localhost -p 26257 -U meridian -d meridian -c "\dt {schema}.*"
+psql -h localhost -p 26257 -U meridian_{service}_user -d meridian_{service} -c "\dt"
 ```
 
 ---

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -123,11 +123,17 @@ this with your specific:
 
    # Example using CockroachDB backup:
 
-   cockroach sql --execute="RESTORE DATABASE meridian FROM 's3://backups/latest';"
+   # Restore all service databases from backup
+   cockroach sql --execute="RESTORE DATABASE meridian_current_account FROM 's3://backups/latest/current_account';"
+   cockroach sql --execute="RESTORE DATABASE meridian_financial_accounting FROM 's3://backups/latest/financial_accounting';"
+   cockroach sql --execute="RESTORE DATABASE meridian_position_keeping FROM 's3://backups/latest/position_keeping';"
+   cockroach sql --execute="RESTORE DATABASE meridian_payment_order FROM 's3://backups/latest/payment_order';"
+   cockroach sql --execute="RESTORE DATABASE meridian_party FROM 's3://backups/latest/party';"
+   cockroach sql --execute="RESTORE DATABASE meridian_platform FROM 's3://backups/latest/platform';"
 
-   # Verify data integrity
-
-   cockroach sql --execute="SELECT COUNT(*) FROM meridian.transactions;"
+   # Verify data integrity for each service database
+   cockroach sql --execute="SELECT COUNT(*) FROM meridian_current_account.accounts;"
+   cockroach sql --execute="SELECT COUNT(*) FROM meridian_position_keeping.financial_position_logs;"
 ```
 
 1. **Verify and test** (150-180 minutes)
@@ -191,7 +197,13 @@ this with your specific:
 
    # Restore to point in time before corruption
 
-   cockroach sql --execute="RESTORE DATABASE meridian FROM 's3://backups/2025-10-28-00-00';"
+   # Restore each service database to point in time before corruption
+   cockroach sql --execute="RESTORE DATABASE meridian_current_account FROM 's3://backups/2025-10-28-00-00/current_account';"
+   cockroach sql --execute="RESTORE DATABASE meridian_financial_accounting FROM 's3://backups/2025-10-28-00-00/financial_accounting';"
+   cockroach sql --execute="RESTORE DATABASE meridian_position_keeping FROM 's3://backups/2025-10-28-00-00/position_keeping';"
+   cockroach sql --execute="RESTORE DATABASE meridian_payment_order FROM 's3://backups/2025-10-28-00-00/payment_order';"
+   cockroach sql --execute="RESTORE DATABASE meridian_party FROM 's3://backups/2025-10-28-00-00/party';"
+   cockroach sql --execute="RESTORE DATABASE meridian_platform FROM 's3://backups/2025-10-28-00-00/platform';"
 ```
 
 1. **Verify data integrity**
@@ -204,7 +216,7 @@ this with your specific:
 
    # Validate critical data
 
-   cockroach sql --execute="SELECT COUNT(*) FROM meridian.accounts;"
+   cockroach sql --execute="SELECT COUNT(*) FROM meridian_current_account.accounts;"
 
 ```text
 
@@ -257,7 +269,9 @@ this with your specific:
 
    # Verify database replication
 
-   cockroach sql --execute="SHOW RANGES FROM DATABASE meridian;"
+   # Verify replication for all service databases
+   cockroach sql --execute="SHOW RANGES FROM DATABASE meridian_current_account;"
+   cockroach sql --execute="SHOW RANGES FROM DATABASE meridian_platform;"
 ```
 
 1. **Monitor switchover** (60-120 minutes)
@@ -383,7 +397,10 @@ aws s3 ls s3://meridian-backups/production/ --recursive | grep $(date +%Y-%m-%d)
 
 # Monthly: Restore to staging
 
-cockroach sql --database=staging --execute="RESTORE DATABASE meridian FROM 's3://backups/latest';"
+# Restore all service databases to staging
+cockroach sql --database=staging --execute="RESTORE DATABASE meridian_current_account FROM 's3://backups/latest/current_account';"
+cockroach sql --database=staging --execute="RESTORE DATABASE meridian_platform FROM 's3://backups/latest/platform';"
+# Repeat for other service databases as needed
 
 # Quarterly: Full DR drill
 

--- a/docs/secrets-management.md
+++ b/docs/secrets-management.md
@@ -23,7 +23,7 @@ metadata:
   name: current-account-db
 type: Opaque
 stringData:
-  DATABASE_URL: "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable"
+  DATABASE_URL: "postgres://meridian_current_account_user@cockroachdb:26257/meridian_current_account?sslmode=disable"
 ```
 
 **⚠️ WARNING:** These secrets contain development-only credentials. **NEVER** use these credentials in production.
@@ -253,7 +253,7 @@ kind: Secret
 metadata:
   name: current-account-db
 stringData:
-  DATABASE_URL: "postgres://meridian:meridian@localhost:5432/meridian"
+  DATABASE_URL: "postgres://meridian_current_account_user@localhost:5432/meridian_current_account"
 ```
 
 **After (Production):**

--- a/scripts/setup-local-secrets.sh
+++ b/scripts/setup-local-secrets.sh
@@ -27,9 +27,10 @@ setup_secret() {
 
     echo "Creating $secret_file from template..."
 
-    # For local dev, use the meridian user/database
+    # For local dev, use service-specific database connections
     # CockroachDB runs in insecure mode (no passwords), so omit password from connection string
-    sed 's|<REPLACE_WITH_DATABASE_URL>|postgres://meridian@cockroachdb:26257/meridian?sslmode=disable|g' \
+    # audit-worker uses the platform database
+    sed 's|<REPLACE_WITH_DATABASE_URL>|postgres://meridian_platform_user@cockroachdb:26257/meridian_platform?sslmode=disable|g' \
         "$example_file" > "$secret_file"
 
     echo "✓ Created $secret_file"

--- a/services/audit-worker/main.go
+++ b/services/audit-worker/main.go
@@ -83,7 +83,7 @@ func getDBConnectionString() string {
 	if connStr == "" {
 		// Default for local development (matches Tiltfile)
 		// #nosec G101 -- Local development credential only, overridden by DATABASE_URL in production
-		connStr = "postgres://meridian:meridian@localhost:26257/meridian?sslmode=disable"
+		connStr = "postgres://meridian_platform_user@localhost:26257/meridian_platform?sslmode=disable"
 	}
 	return connStr
 }

--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -241,7 +241,7 @@ func run(logger *slog.Logger) error {
 
 // initDatabase initializes the database connection with connection pooling
 func initDatabase(logger *slog.Logger) (*gorm.DB, error) {
-	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable")
+	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian_current_account_user@cockroachdb:26257/meridian_current_account?sslmode=disable")
 
 	// Open database connection
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -305,7 +305,7 @@ func run(logger *slog.Logger) error {
 
 // initDatabase initializes the database connection with connection pooling
 func initDatabase(logger *slog.Logger) (*gorm.DB, error) {
-	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable")
+	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian_financial_accounting_user@cockroachdb:26257/meridian_financial_accounting?sslmode=disable")
 
 	// Open database connection
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{

--- a/services/party/cmd/main.go
+++ b/services/party/cmd/main.go
@@ -218,7 +218,7 @@ func run(logger *slog.Logger) error {
 
 // initDatabase initializes the database connection with connection pooling
 func initDatabase(logger *slog.Logger) (*gorm.DB, error) {
-	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable")
+	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian_party_user@cockroachdb:26257/meridian_party?sslmode=disable")
 
 	// Open database connection
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -425,7 +425,7 @@ func createKafkaProducer(logger *slog.Logger) (*kafka.ProtoProducer, error) {
 
 // initDatabase initializes the database connection with connection pooling.
 func initDatabase(logger *slog.Logger) (*gorm.DB, error) {
-	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable")
+	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian_payment_order_user@cockroachdb:26257/meridian_payment_order?sslmode=disable")
 
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		SkipDefaultTransaction: true,

--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -332,7 +332,7 @@ func run(logger *slog.Logger) error {
 
 // initDatabase initializes the database connection with connection pooling.
 func initDatabase(logger *slog.Logger) (*gorm.DB, error) {
-	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian:meridian@cockroachdb:26257/meridian?sslmode=disable")
+	dsn := getEnvOrDefault("DATABASE_URL", "postgres://meridian_platform_user@cockroachdb:26257/meridian_platform?sslmode=disable")
 
 	// Open database connection
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{


### PR DESCRIPTION
## Summary

- Remove all references to the deprecated shared `meridian` database
- Update fallback DSN values in service main.go files to use service-specific databases
- Update documentation and scripts to reflect database-per-service architecture

## Task Master Reference

- **Tag**: database-per-service
- **Task ID**: 9

## Changes Made

### Service Database URLs Updated

| Service | Old Database | New Database |
|---------|-------------|--------------|
| current-account | `meridian` | `meridian_current_account` |
| financial-accounting | `meridian` | `meridian_financial_accounting` |
| position-keeping | `meridian` | `meridian_position_keeping` |
| payment-order | `meridian` | `meridian_payment_order` |
| party | `meridian` | `meridian_party` |
| tenant | `meridian` | `meridian_platform` |
| audit-worker | `meridian` | `meridian_platform` |

### Files Modified

1. **Service main.go files** (5 files) - Updated fallback DATABASE_URL defaults
2. **services/audit-worker/main.go** - Updated to use platform database
3. **Tiltfile** - Updated audit-worker database secret
4. **docs/secrets-management.md** - Updated example connection strings
5. **docs/runbooks/disaster-recovery.md** - Updated backup/restore commands for multiple databases
6. **docs/guides/new-bian-service-checklist.md** - Updated migration example URLs
7. **scripts/setup-local-secrets.sh** - Updated to use platform database

## Test Plan

1. ✅ Verified no remaining references to `postgres://meridian@` or `postgres://meridian:meridian@` in Go code
2. ✅ Verified all Go packages build successfully
3. ✅ Ran unit tests for modified services
4. Documentation changes reflect the database-per-service architecture

## Notes

This completes the database-per-service migration by removing the last references to the old shared database. The actual database (`meridian`) can now be dropped in production after verifying all services work correctly with their dedicated databases.