### PR TITLE
docs: Update ADR-002 and create database-per-service migration runbook (task 10)

### DIFF
--- a/docs/adr/0002-microservices-per-bian-domain.md
+++ b/docs/adr/0002-microservices-per-bian-domain.md
@@ -574,3 +574,123 @@ Calculates coupling metrics:
 * [BIAN Service Boundaries](../architecture/bian-service-boundaries.md)
 * [Boundary Migration Plan](../architecture/boundary-migration-plan.md)
 * Coupling analysis scripts: `scripts/analyze-coupling.sh`, `scripts/calculate-coupling-metrics.sh`
+
+---
+
+## Amendment: Database Architecture Implementation (2025-12-16)
+
+### Context
+
+ADR-002 specified database-per-service in Rule 4, but didn't detail the actual database architecture. After implementing database migrations (Task Master: database-per-service), we formalized the production database structure.
+
+### Decision
+
+Each microservice has its own CockroachDB database with tenant isolation via schemas:
+
+**Database naming:**
+
+| Service | Database |
+|---------|----------|
+| Tenant Service | `meridian_platform` |
+| Current Account | `meridian_current_account` |
+| Financial Accounting | `meridian_financial_accounting` |
+| Position Keeping | `meridian_position_keeping` |
+| Payment Order | `meridian_payment_order` |
+| Party | `meridian_party` |
+
+### Multi-Tenancy Architecture
+
+**Schema-per-tenant within each service database:**
+
+```text
+Database: meridian_current_account
+  └── Schema: org_acme_bank        (tenant-specific)
+       └── Tables: account, lien, audit_log
+  └── Schema: org_demo_corp        (tenant-specific)
+       └── Tables: account, lien, audit_log
+
+Database: meridian_party
+  └── Schema: org_acme_bank
+       └── Tables: party
+  └── Schema: org_demo_corp
+       └── Tables: party
+```
+
+**Tenant routing via `search_path`:**
+
+```go
+// Connection URL includes tenant schema
+connStr := fmt.Sprintf(
+    "postgres://%s:%s@%s/%s?search_path=%s",
+    user, password, host, database, tenantSchema,
+)
+// Queries use unqualified table names
+db.Query("SELECT * FROM account WHERE id = $1", accountID)
+// PostgreSQL resolves via search_path: org_acme_bank.account
+```
+
+### Table Naming Conventions
+
+**Singular nouns, unqualified:**
+
+| Pattern | Example | Rationale |
+|---------|---------|-----------|
+| Singular | `account` (not `accounts`) | Natural in queries: `SELECT * FROM account` |
+| Unqualified | No schema prefix | Enables transparent tenant routing |
+| Snake_case | `payment_order`, `audit_trail_entry` | Consistent with SQL conventions |
+
+**Compound naming follows `<context>_<entity>`:**
+
+- `payment_order` - an order for payment
+- `ledger_posting` - a posting to a ledger
+- `financial_booking_log` - a log entry for financial bookings
+
+### Database Access Control
+
+**Principle of least privilege:**
+
+```sql
+-- Each service has dedicated database user
+CREATE USER current_account_svc WITH PASSWORD '...';
+
+-- User only has access to its own database
+GRANT ALL ON DATABASE meridian_current_account TO current_account_svc;
+
+-- No cross-database access (CockroachDB enforces this)
+-- current_account_svc CANNOT access meridian_party
+```
+
+**Cross-service data access:**
+
+- **Allowed**: gRPC calls between services
+- **Forbidden**: SQL queries to other service databases
+
+### Migration Strategy
+
+See [Database-Per-Service Migration Runbook](../runbooks/database-per-service-migration.md) for:
+
+- Step-by-step migration guide
+- Rollback procedures
+- Verification checklists
+- Lessons learned
+
+### Consequences
+
+**Positive:**
+
+* ✅ True database-level isolation (not just schema)
+* ✅ Independent scaling per service database
+* ✅ Service failure cannot corrupt other service data
+* ✅ Clear audit boundaries per BIAN domain
+* ✅ Simplified backup/restore per service
+
+**Negative:**
+
+* ❌ More databases to manage (6 instead of 1)
+* ❌ Cannot JOIN across services (must use gRPC)
+* ❌ Distributed transactions require saga pattern
+
+### References
+
+* [ADR-003: Database Schema Migrations](./0003-database-schema-migrations.md)
+* [Migration Runbook](../runbooks/database-per-service-migration.md)

--- a/docs/claude-code-skills.md
+++ b/docs/claude-code-skills.md
@@ -35,6 +35,7 @@ For detailed information about creating and using skills, see [docs/skills/READM
 
 - Incident response procedures
 - Disaster recovery procedures
+- Database-per-service migration guide
 
 **Service Documentation** (in `services/*/`):
 

--- a/docs/runbooks/database-per-service-migration.md
+++ b/docs/runbooks/database-per-service-migration.md
@@ -1,0 +1,398 @@
+---
+name: database-per-service-migration
+description: Step-by-step guide for migrating from single shared database to database-per-service architecture
+triggers:
+
+  - Migrating to database-per-service architecture
+  - Setting up new service databases
+  - Database isolation for microservices
+  - Multi-tenant database setup
+
+instructions: |
+  Create separate database per service following naming convention meridian_<service>.
+  Set up schema-per-tenant within each database. Configure dedicated database users
+  with restricted grants. Update Atlas configuration per service. Use gRPC for
+  cross-service data access instead of SQL joins.
+---
+
+# Database-Per-Service Migration Runbook
+
+**When to use this runbook**: Migrating from a shared database to isolated databases per service, or setting up new
+service databases following the database-per-service pattern.
+
+## Overview
+
+This runbook documents the migration from a single shared `meridian` database to six service-specific databases,
+implementing true database-level isolation for each BIAN service domain.
+
+### Architecture Change Summary
+
+**Before (single shared database):**
+
+```text
+Database: meridian
+  └── Schema: org_acme_bank
+       └── Tables: account, party, ledger_posting, position_log, payment_order, ...
+```
+
+**After (database-per-service):**
+
+```text
+Database: meridian_platform           → Tenant Service
+Database: meridian_current_account    → Current Account Service
+Database: meridian_financial_accounting → Financial Accounting Service
+Database: meridian_position_keeping   → Position Keeping Service
+Database: meridian_payment_order      → Payment Order Service
+Database: meridian_party              → Party Service
+```
+
+### Benefits Achieved
+
+- **True isolation**: One service cannot access another service's data
+- **Independent scaling**: Each database can be scaled based on service load
+- **Simplified operations**: Backup, restore, and maintenance per service
+- **Clear ownership**: Each team owns their database schema
+- **Failure isolation**: Database issues in one service don't affect others
+
+## Prerequisites
+
+### Required Access
+
+- [ ] CockroachDB admin credentials (for database/user creation)
+- [ ] Kubernetes cluster access (for updating connection strings)
+- [ ] GitHub repository access (for migration files)
+- [ ] Atlas CLI installed (`brew install ariga/tap/atlas`)
+
+### Pre-Migration Checklist
+
+- [ ] All services healthy and stable
+- [ ] Database backups completed and verified
+- [ ] Migration window scheduled (recommend off-peak hours)
+- [ ] Rollback plan reviewed and ready
+- [ ] Communication sent to stakeholders
+
+## Migration Steps
+
+### Phase 1: Database and User Creation
+
+#### Step 1.1: Create Service Databases
+
+```sql
+-- Connect to CockroachDB as admin
+cockroach sql --certs-dir=/path/to/certs --host=<db-host>
+
+-- Create databases for each service
+CREATE DATABASE meridian_platform;
+CREATE DATABASE meridian_current_account;
+CREATE DATABASE meridian_financial_accounting;
+CREATE DATABASE meridian_position_keeping;
+CREATE DATABASE meridian_payment_order;
+CREATE DATABASE meridian_party;
+```
+
+#### Step 1.2: Create Service-Specific Users
+
+```sql
+-- Create users with secure passwords (use secrets management in production)
+CREATE USER platform_svc WITH PASSWORD '<secure-password>';
+CREATE USER current_account_svc WITH PASSWORD '<secure-password>';
+CREATE USER financial_accounting_svc WITH PASSWORD '<secure-password>';
+CREATE USER position_keeping_svc WITH PASSWORD '<secure-password>';
+CREATE USER payment_order_svc WITH PASSWORD '<secure-password>';
+CREATE USER party_svc WITH PASSWORD '<secure-password>';
+```
+
+#### Step 1.3: Grant Database Access
+
+```sql
+-- Each user can only access their service's database
+GRANT ALL ON DATABASE meridian_platform TO platform_svc;
+GRANT ALL ON DATABASE meridian_current_account TO current_account_svc;
+GRANT ALL ON DATABASE meridian_financial_accounting TO financial_accounting_svc;
+GRANT ALL ON DATABASE meridian_position_keeping TO position_keeping_svc;
+GRANT ALL ON DATABASE meridian_payment_order TO payment_order_svc;
+GRANT ALL ON DATABASE meridian_party TO party_svc;
+
+-- Verify grants
+SHOW GRANTS FOR current_account_svc;
+-- Should only show meridian_current_account
+```
+
+### Phase 2: Tenant Schema Setup
+
+#### Step 2.1: Create Tenant Schemas in Each Database
+
+For each database, create schemas for each tenant:
+
+```sql
+-- Example for current_account database
+USE meridian_current_account;
+
+CREATE SCHEMA org_acme_bank;
+CREATE SCHEMA org_demo_corp;
+-- Add schemas for each tenant
+
+-- Grant schema access to service user
+GRANT ALL ON SCHEMA org_acme_bank TO current_account_svc;
+GRANT ALL ON SCHEMA org_demo_corp TO current_account_svc;
+```
+
+Repeat for each service database with appropriate tenant schemas.
+
+### Phase 3: Atlas Configuration
+
+#### Step 3.1: Create Service-Specific Atlas Config
+
+Each service needs its own `atlas.hcl` configuration:
+
+**services/current-account/atlas/atlas.hcl:**
+
+```hcl
+data "external_schema" "gorm" {
+  program = [
+    "go",
+    "run",
+    "-mod=mod",
+    "../../utilities/atlas-loader",
+    "--service=current-account"
+  ]
+}
+
+env "local" {
+  migration {
+    dir = "file://migrations"
+  }
+  dev = "docker://postgres/16/dev?search_path=public"
+  src = data.external_schema.gorm.url
+
+  lint {
+    destructive {
+      error = true
+    }
+  }
+}
+
+env "production" {
+  migration {
+    dir = "file://migrations"
+  }
+
+  lint {
+    destructive {
+      error = true
+    }
+    data_depend {
+      error = true
+    }
+  }
+}
+```
+
+#### Step 3.2: Generate Initial Migrations
+
+```bash
+# For each service, generate migrations from entities
+cd services/current-account
+atlas migrate diff initial \
+  --env local \
+  --config file://atlas/atlas.hcl
+
+# Verify generated migration
+cat migrations/*.sql
+
+# Verify checksums
+atlas migrate hash --env local --config file://atlas/atlas.hcl
+```
+
+### Phase 4: Data Migration (If Required)
+
+#### Step 4.1: Export Data from Shared Database
+
+If migrating existing data from a shared database:
+
+```bash
+# Export tables belonging to each service
+cockroach dump meridian org_acme_bank.account \
+  --certs-dir=/path/to/certs \
+  > exports/current_account_data.sql
+
+cockroach dump meridian org_acme_bank.party \
+  --certs-dir=/path/to/certs \
+  > exports/party_data.sql
+```
+
+#### Step 4.2: Import Data to Service Databases
+
+```bash
+# Import to service-specific database
+cockroach sql \
+  --database=meridian_current_account \
+  --certs-dir=/path/to/certs \
+  < exports/current_account_data.sql
+```
+
+### Phase 5: Application Configuration
+
+#### Step 5.1: Update Connection Strings
+
+Update each service's connection configuration:
+
+**Kubernetes ConfigMap example:**
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: current-account-config
+data:
+  DATABASE_URL: "postgres://current_account_svc:${PASSWORD}@cockroachdb:26257/meridian_current_account?sslmode=verify-full"
+```
+
+#### Step 5.2: Update Search Path Configuration
+
+Ensure tenant routing uses `search_path`:
+
+```go
+// Example connection with tenant schema
+connStr := fmt.Sprintf(
+    "%s?search_path=%s",
+    baseConnStr,
+    tenantSchema, // e.g., "org_acme_bank"
+)
+```
+
+### Phase 6: Verification
+
+#### Step 6.1: Verify Database Isolation
+
+```sql
+-- As current_account_svc user, try to access party database
+-- This should FAIL
+\c meridian_party
+-- ERROR: permission denied
+
+-- Verify can only access own database
+\c meridian_current_account
+SELECT current_database();
+-- meridian_current_account
+```
+
+#### Step 6.2: Run Service Health Checks
+
+```bash
+# Check each service can connect and query
+kubectl exec -it current-account-pod -- /app/healthcheck
+
+# Check migration status
+atlas migrate status \
+  --env production \
+  --config file://services/current-account/atlas/atlas.hcl \
+  --url "$DATABASE_URL"
+```
+
+#### Step 6.3: Verify Data Integrity
+
+```sql
+-- Verify record counts match expected values
+USE meridian_current_account;
+SET search_path = org_acme_bank;
+SELECT COUNT(*) FROM account;
+
+-- Verify foreign key relationships (within service)
+SELECT COUNT(*) FROM lien WHERE account_id NOT IN (SELECT id FROM account);
+-- Should return 0
+```
+
+## Rollback Procedure
+
+### Emergency Rollback
+
+If critical issues arise during migration:
+
+#### Step R1: Stop Traffic
+
+```bash
+# Scale services to 0 to stop writes
+kubectl scale deployment current-account --replicas=0 -n production
+```
+
+#### Step R2: Restore Connection Strings
+
+```bash
+# Revert to shared database connection
+kubectl apply -f backup/pre-migration-configmaps.yaml
+```
+
+#### Step R3: Verify Shared Database
+
+```sql
+-- Verify shared database is intact
+USE meridian;
+SELECT COUNT(*) FROM org_acme_bank.account;
+```
+
+#### Step R4: Resume Services
+
+```bash
+# Scale services back up
+kubectl scale deployment current-account --replicas=3 -n production
+```
+
+### Rollback Checklist
+
+- [ ] All services stopped
+- [ ] Connection strings reverted
+- [ ] Shared database verified
+- [ ] Services restarted and healthy
+- [ ] Incident documented
+
+## Verification Checklist
+
+### Post-Migration Verification
+
+- [ ] All six databases created and accessible
+- [ ] Service users have correct database grants
+- [ ] Tenant schemas created in each database
+- [ ] Atlas migrations applied successfully
+- [ ] Services connect with correct credentials
+- [ ] Data integrity verified (if data migrated)
+- [ ] Cross-database access blocked (isolation verified)
+- [ ] gRPC inter-service communication working
+- [ ] Monitoring dashboards updated for new databases
+- [ ] Backup jobs configured for new databases
+
+### Performance Verification
+
+- [ ] Query response times within baseline
+- [ ] Connection pool sizes appropriate
+- [ ] No deadlocks or lock contention
+- [ ] Index usage as expected
+
+## Lessons Learned
+
+### What Worked Well
+
+1. **Schema-per-tenant pattern**: Enables transparent routing via `search_path`
+2. **Dedicated service users**: CockroachDB enforces isolation at connection level
+3. **Atlas per-service configs**: Independent schema evolution per service
+4. **Singular table names**: Natural SQL syntax (`FROM account` vs `FROM accounts`)
+
+### Challenges Encountered
+
+1. **Cross-service queries**: Required refactoring to use gRPC instead of JOINs
+2. **Shared reference data**: Tenant registry must be accessible (via gRPC, not SQL)
+3. **Migration coordination**: Required staging all services before production
+
+### Recommendations
+
+1. **Start new projects with database-per-service**: Retrofitting is harder
+2. **Use gRPC from day one**: Avoid SQL dependencies between services
+3. **Automate user/grant creation**: Use infrastructure-as-code
+4. **Test isolation**: Verify users cannot cross database boundaries
+
+## Related Documentation
+
+- [ADR-002: Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
+- [ADR-003: Database Schema Migrations](../adr/0003-database-schema-migrations.md)
+- [Incident Response Runbook](./incident-response.md)
+- [Disaster Recovery Runbook](./disaster-recovery.md)

--- a/docs/tilt-fast-startup.md
+++ b/docs/tilt-fast-startup.md
@@ -61,7 +61,8 @@ tilt up
 
 ### Running Tests Manually
 
-When fast startup mode is enabled, tests are not automatically run on startup. You can trigger them manually in several ways:
+When fast startup mode is enabled, tests are not automatically run on startup. You can trigger them
+manually in several ways:
 
 #### Via Tilt CLI
 


### PR DESCRIPTION
## Summary

- Updated ADR-002 with Database Architecture Implementation amendment documenting the production database structure
- Created comprehensive database-per-service migration runbook for future reference
- Updated claude-code-skills.md to reference the new runbook

## Task Master Reference

- **Tag**: database-per-service
- **Task ID**: 10

## Changes Made

### ADR-002 Amendment: Database Architecture Implementation (2025-12-16)

Documents the implemented database architecture:
- Service-specific database naming (`meridian_<service>`)
- Multi-tenant schema-per-org architecture
- Table naming conventions (singular nouns, unqualified names)
- Database access control principles (dedicated users per service)
- Cross-service data access via gRPC (not SQL joins)

### New Runbook: database-per-service-migration.md

Comprehensive migration guide including:
- Architecture change summary (before/after)
- Step-by-step migration phases (database creation, user setup, tenant schemas, Atlas config)
- Data migration procedures
- Rollback procedures
- Verification checklists
- Lessons learned from implementation

### Other Changes

- Updated `docs/claude-code-skills.md` to list the new migration runbook
- Fixed markdown line length issue in `docs/tilt-fast-startup.md`

## Test Plan

1. Documentation review: Verify ADR-002 is consistent with actual implementation
2. Link validation: All internal documentation links work
3. Runbook verification: Steps are actionable and complete
4. Claude Code skills: New runbook triggers work correctly