### PR TITLE
fix: align repository SQL table names with migration schema (task 12)

### DIFF
--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -357,11 +357,11 @@ atlas migrate diff initial \
 # Review generated SQL in services/{service}/migrations/
 # Verify: tables, constraints, indexes, enums
 
-# Apply migration locally
+# Apply migration locally (uses credentials from Task 5)
 atlas migrate apply \
   --env local \
   --config file://services/{service}/atlas/atlas.hcl \
-  --url "postgres://meridian_{service}_user@localhost:26257/meridian_{service}?sslmode=disable"
+  --url "postgres://{service}_svc@localhost:26257/meridian_{service}?sslmode=disable"
 ```
 
 **Migration file naming**: `YYYYMMDDHHMMSS_description.sql`
@@ -369,8 +369,8 @@ atlas migrate apply \
 **Verification:**
 
 ```bash
-# Query database to confirm schema
-psql -h localhost -p 26257 -U meridian_{service}_user -d meridian_{service} -c "\dt"
+# Query database to confirm schema (uses credentials from Task 5)
+psql -h localhost -p 26257 -U {service}_svc -d meridian_{service} -c "\dt"
 ```
 
 ---

--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -282,7 +282,65 @@ atlas migrate status --env local --config file://services/{service}/atlas/atlas.
 
 ---
 
-### Task 5: Generate Initial Schema Migration
+### Task 5: Database Setup (Database-Per-Service Architecture)
+
+**Location**: PostgreSQL/CockroachDB administration
+
+Set up the dedicated database for the new service following the database-per-service architecture.
+
+**Steps:**
+
+#### Step 5.1: Create Service Database
+
+```sql
+-- Connect as admin user
+CREATE DATABASE meridian_{service};
+```
+
+#### Step 5.2: Create Service User
+
+```sql
+-- Create dedicated user with restricted access
+CREATE USER {service}_svc WITH PASSWORD '<secure-password>';
+
+-- Grant access only to this service's database
+GRANT ALL ON DATABASE meridian_{service} TO {service}_svc;
+```
+
+#### Step 5.3: Verify Isolation
+
+```sql
+-- As {service}_svc, verify cannot access other databases
+\c meridian_party
+-- Should fail: permission denied
+```
+
+**Table naming convention:**
+
+Use **singular, unqualified** table names:
+
+```go
+// Entity TableName() method - REQUIRED
+func (EntityName) TableName() string {
+    return "entity_name"  // singular, no schema prefix
+}
+```
+
+**Why singular**: Natural SQL syntax (`FROM account` not `FROM accounts`)
+**Why unqualified**: Allows PostgreSQL `search_path` to route to tenant schemas
+
+**Reference**: [Database-Per-Service Migration Runbook](../runbooks/database-per-service-migration.md)
+
+**Verification:**
+
+```bash
+# Verify database exists and user can connect
+psql -h localhost -U {service}_svc -d meridian_{service} -c "SELECT current_database();"
+```
+
+---
+
+### Task 6: Generate Initial Schema Migration
 
 **Location**: `services/{service}/migrations/`
 
@@ -317,7 +375,7 @@ psql -h localhost -p 26257 -U meridian_{service}_user -d meridian_{service} -c "
 
 ---
 
-### Task 6: gRPC Service Handler
+### Task 7: gRPC Service Handler
 
 **Location**: `services/{service}/service/`
 
@@ -386,7 +444,7 @@ go test ./services/{service}/service/... -v
 
 ---
 
-### Task 7: Health Check Implementation
+### Task 8: Health Check Implementation
 
 **Location**: `services/{service}/service/health.go`
 
@@ -435,7 +493,7 @@ grpcurl -plaintext localhost:50055 grpc.health.v1.Health/Check
 
 ---
 
-### Task 8: Service Entry Point
+### Task 9: Service Entry Point
 
 **Location**: `services/{service}/cmd/`
 
@@ -502,7 +560,7 @@ grpcurl -plaintext localhost:50055 list
 
 ---
 
-### Task 9: Dockerfile
+### Task 10: Dockerfile
 
 **Location**: `services/{service}/cmd/Dockerfile`
 
@@ -550,7 +608,7 @@ docker run --rm -e DATABASE_URL="postgres://..." {service}:dev
 
 ---
 
-### Task 10: Kubernetes Manifests
+### Task 11: Kubernetes Manifests
 
 **Location**: `services/{service}/k8s/`
 
@@ -627,7 +685,7 @@ kubectl apply --dry-run=client -f services/{service}/k8s/
 
 ---
 
-### Task 11: Tilt Integration
+### Task 12: Tilt Integration
 
 **Location**: `Tiltfile` (root)
 
@@ -672,7 +730,7 @@ tilt up
 
 ---
 
-### Task 12: Integration Tests
+### Task 13: Integration Tests
 
 **Location**: `services/{service}/service/` or `tests/`
 
@@ -748,14 +806,15 @@ Follow [ADR-009](../adr/0009-application-level-audit-logging.md) for application
 
 This checklist can be used to generate Task Master tasks:
 
-1. Each numbered task (1-12) becomes a Task Master task
+1. Each numbered task (1-13) becomes a Task Master task
 2. Dependencies follow the logical order:
    - Task 2 depends on Task 1 (domain needs proto types)
    - Task 3 depends on Task 2 (persistence needs domain)
-   - Task 5 depends on Task 4 (migration needs atlas config)
-   - Task 6 depends on Tasks 2, 3 (service needs domain and persistence)
-   - Tasks 8-11 depend on Task 6 (deployment needs service)
-   - Task 12 depends on all previous tasks
+   - Task 5 depends on Task 4 (database setup needs atlas config)
+   - Task 6 depends on Tasks 4, 5 (migration needs atlas and database)
+   - Task 7 depends on Tasks 2, 3 (service needs domain and persistence)
+   - Tasks 9-12 depend on Task 7 (deployment needs service)
+   - Task 13 depends on all previous tasks
 
 3. To generate tasks for a new service:
 
@@ -777,3 +836,4 @@ task-master parse-prd docs/guides/new-{service}-service-checklist.md
 - [ADR-015: Standard Service Directory Structure](../adr/0015-standard-service-directory-structure.md)
 - [Circuit Breaker Usage Guide](circuit-breaker-usage.md)
 - [Testcontainers Usage Guide](testcontainers-usage.md)
+- [Database-Per-Service Migration Runbook](../runbooks/database-per-service-migration.md)

--- a/services/financial-accounting/adapters/persistence/repository_test.go
+++ b/services/financial-accounting/adapters/persistence/repository_test.go
@@ -41,10 +41,12 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		business_unit_reference VARCHAR(255) NOT NULL,
 		chart_of_accounts_rules TEXT NOT NULL,
 		base_currency VARCHAR(3) NOT NULL,
-		status VARCHAR(20) NOT NULL,
+		status VARCHAR(50) NOT NULL,
 		idempotency_key VARCHAR(255) NOT NULL UNIQUE,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(255),
+		updated_by VARCHAR(255),
 		version BIGINT NOT NULL DEFAULT 1,
 		deleted_at TIMESTAMP WITH TIME ZONE
 	)`, schemaName)).Error
@@ -53,15 +55,18 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.ledger_posting (
 		id UUID PRIMARY KEY,
 		financial_booking_log_id UUID NOT NULL,
-		posting_direction VARCHAR(20) NOT NULL,
+		posting_direction VARCHAR(10) NOT NULL,
 		amount_cents BIGINT NOT NULL,
 		currency VARCHAR(3) NOT NULL,
 		account_id VARCHAR(255) NOT NULL,
 		value_date TIMESTAMP WITH TIME ZONE NOT NULL,
-		posting_result TEXT NOT NULL,
-		status VARCHAR(20) NOT NULL,
-		correlation_id VARCHAR(255) NOT NULL,
+		posting_result VARCHAR(1000),
+		status VARCHAR(50) NOT NULL,
+		correlation_id VARCHAR(255),
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(255),
+		updated_by VARCHAR(255),
 		deleted_at TIMESTAMP WITH TIME ZONE
 	)`, schemaName)).Error
 	require.NoError(t, err)

--- a/services/financial-accounting/adapters/persistence/repository_test.go
+++ b/services/financial-accounting/adapters/persistence/repository_test.go
@@ -33,8 +33,8 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
 	require.NoError(t, err)
 
-	// Create tables in tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.financial_booking_logs (
+	// Create tables in tenant schema (singular to match production migration)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.financial_booking_log (
 		id UUID PRIMARY KEY,
 		financial_account_type VARCHAR(50) NOT NULL,
 		product_service_reference VARCHAR(255) NOT NULL,
@@ -50,7 +50,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	)`, schemaName)).Error
 	require.NoError(t, err)
 
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.ledger_postings (
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.ledger_posting (
 		id UUID PRIMARY KEY,
 		financial_booking_log_id UUID NOT NULL,
 		posting_direction VARCHAR(20) NOT NULL,
@@ -68,20 +68,20 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 
 	// Create FK constraint (ignore if already exists)
 	err = db.Exec(fmt.Sprintf(`
-		ALTER TABLE %q.ledger_postings
-		ADD CONSTRAINT IF NOT EXISTS fk_ledger_postings_booking_log
+		ALTER TABLE %q.ledger_posting
+		ADD CONSTRAINT IF NOT EXISTS fk_ledger_posting_booking_log
 		FOREIGN KEY (financial_booking_log_id)
-		REFERENCES %q.financial_booking_logs(id)
+		REFERENCES %q.financial_booking_log(id)
 		ON DELETE RESTRICT
 	`, schemaName, schemaName)).Error
 	if err != nil {
 		// PostgreSQL before 9.6 doesn't support IF NOT EXISTS for constraints
 		// Try without it and ignore duplicate constraint errors
 		err = db.Exec(fmt.Sprintf(`
-			ALTER TABLE %q.ledger_postings
-			ADD CONSTRAINT fk_ledger_postings_booking_log
+			ALTER TABLE %q.ledger_posting
+			ADD CONSTRAINT fk_ledger_posting_booking_log
 			FOREIGN KEY (financial_booking_log_id)
-			REFERENCES %q.financial_booking_logs(id)
+			REFERENCES %q.financial_booking_log(id)
 			ON DELETE RESTRICT
 		`, schemaName, schemaName)).Error
 		// Ignore duplicate constraint errors (SQLSTATE 42710)
@@ -469,7 +469,7 @@ func TestSchemaIsolation(t *testing.T) {
 		SELECT COUNT(*)
 		FROM information_schema.tables
 		WHERE table_schema = ?
-		AND table_name IN ('financial_booking_logs', 'ledger_postings')
+		AND table_name IN ('financial_booking_log', 'ledger_posting')
 	`, schemaName).Scan(&tableCount).Error
 
 	require.NoError(t, err)
@@ -504,7 +504,7 @@ func TestForeignKeyOnDeleteRestrict(t *testing.T) {
 
 	// Insert directly to tenant schema
 	err := db.Exec(fmt.Sprintf(`
-		INSERT INTO %q.financial_booking_logs
+		INSERT INTO %q.financial_booking_log
 		(id, financial_account_type, product_service_reference, business_unit_reference,
 		 chart_of_accounts_rules, base_currency, status, idempotency_key, created_at, updated_at, version)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -516,7 +516,7 @@ func TestForeignKeyOnDeleteRestrict(t *testing.T) {
 
 	// Verify booking log was inserted
 	var bookingLogCount int64
-	err = db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM %q.financial_booking_logs WHERE id = ?", schemaName), bookingLogID).Scan(&bookingLogCount).Error
+	err = db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM %q.financial_booking_log WHERE id = ?", schemaName), bookingLogID).Scan(&bookingLogCount).Error
 	require.NoError(t, err)
 	require.Equal(t, int64(1), bookingLogCount, "Booking log should be inserted")
 
@@ -541,13 +541,13 @@ func TestForeignKeyOnDeleteRestrict(t *testing.T) {
 
 	// Verify posting was saved
 	var postingCount int64
-	err = db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM %q.ledger_postings WHERE financial_booking_log_id = ?", schemaName), bookingLogID).Scan(&postingCount).Error
+	err = db.Raw(fmt.Sprintf("SELECT COUNT(*) FROM %q.ledger_posting WHERE financial_booking_log_id = ?", schemaName), bookingLogID).Scan(&postingCount).Error
 	require.NoError(t, err)
 	require.Equal(t, int64(1), postingCount, "Posting should be saved before testing FK constraint")
 
 	// Try to hard delete booking log while posting still references it
 	// Use explicit schema-qualified DELETE to bypass soft delete and trigger FK constraint
-	err = db.Exec(fmt.Sprintf("DELETE FROM %q.financial_booking_logs WHERE id = ?", schemaName), bookingLogID).Error
+	err = db.Exec(fmt.Sprintf("DELETE FROM %q.financial_booking_log WHERE id = ?", schemaName), bookingLogID).Error
 
 	// Should fail due to ON DELETE RESTRICT (SQLSTATE 23503)
 	require.Error(t, err)

--- a/services/position-keeping/adapters/persistence/postgres_repository.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository.go
@@ -124,7 +124,7 @@ func (r *PostgresRepository) Create(ctx context.Context, log *domain.FinancialPo
 	// Insert main financial_position_log
 	userID := audit.GetUserFromContext(ctx)
 	logQuery := `
-		INSERT INTO financial_position_logs (
+		INSERT INTO financial_position_log (
 			id, created_at, created_by, updated_at, updated_by,
 			log_id, account_id, version,
 			current_status, previous_status, status_updated_at, status_reason, failure_reason,
@@ -198,11 +198,11 @@ func (r *PostgresRepository) CreateBatch(ctx context.Context, logs []*domain.Fin
 		return err
 	}
 
-	// Use COPY for bulk insert of financial_position_logs
+	// Use COPY for bulk insert of financial_position_log
 	userID := audit.GetUserFromContext(ctx)
 	copyCount, err := tx.CopyFrom(
 		ctx,
-		pgx.Identifier{"financial_position_logs"},
+		pgx.Identifier{"financial_position_log"},
 		[]string{
 			"id", "created_at", "created_by", "updated_at", "updated_by",
 			"log_id", "account_id", "version",
@@ -281,7 +281,7 @@ func (r *PostgresRepository) FindByID(ctx context.Context, logID uuid.UUID) (*do
 			SELECT id, created_at, updated_at, log_id, account_id, version,
 				current_status, previous_status, status_updated_at, status_reason, failure_reason,
 				reconciliation_status
-			FROM financial_position_logs
+			FROM financial_position_log
 			WHERE log_id = $1 AND deleted_at IS NULL`
 
 		var dbID uuid.UUID
@@ -350,7 +350,7 @@ func (r *PostgresRepository) FindByAccountID(ctx context.Context, accountID stri
 			SELECT id, created_at, updated_at, log_id, account_id, version,
 				current_status, previous_status, status_updated_at, status_reason, failure_reason,
 				reconciliation_status
-			FROM financial_position_logs
+			FROM financial_position_log
 			WHERE account_id = $1 AND deleted_at IS NULL
 			ORDER BY created_at DESC`
 
@@ -392,7 +392,7 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 
 	// Get current database ID
 	var dbID uuid.UUID
-	err = tx.QueryRow(ctx, "SELECT id FROM financial_position_logs WHERE log_id = $1 AND deleted_at IS NULL", log.LogID).Scan(&dbID)
+	err = tx.QueryRow(ctx, "SELECT id FROM financial_position_log WHERE log_id = $1 AND deleted_at IS NULL", log.LogID).Scan(&dbID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return domain.ErrNotFound
@@ -407,7 +407,7 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 	userID := audit.GetUserFromContext(ctx)
 
 	updateQuery := `
-		UPDATE financial_position_logs
+		UPDATE financial_position_log
 		SET updated_at = $1, updated_by = $2, version = $3,
 			current_status = $4, previous_status = $5, status_updated_at = $6,
 			status_reason = $7, failure_reason = $8, reconciliation_status = $9
@@ -430,7 +430,7 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 	}
 
 	// Delete and re-insert transaction log entries (simplest approach for aggregate updates)
-	_, err = tx.Exec(ctx, "DELETE FROM transaction_log_entries WHERE financial_position_log_id = $1", dbID)
+	_, err = tx.Exec(ctx, "DELETE FROM transaction_log_entry WHERE financial_position_log_id = $1", dbID)
 	if err != nil {
 		return fmt.Errorf("failed to delete old transaction log entries: %w", err)
 	}
@@ -440,7 +440,7 @@ func (r *PostgresRepository) Update(ctx context.Context, log *domain.FinancialPo
 	}
 
 	// Delete and re-insert transaction lineage
-	_, err = tx.Exec(ctx, "DELETE FROM transaction_lineages WHERE financial_position_log_id = $1", dbID)
+	_, err = tx.Exec(ctx, "DELETE FROM transaction_lineage WHERE financial_position_log_id = $1", dbID)
 	if err != nil {
 		return fmt.Errorf("failed to delete old transaction lineage: %w", err)
 	}
@@ -492,7 +492,7 @@ func (r *PostgresRepository) List(ctx context.Context, filter domain.PositionLog
 			SELECT id, created_at, updated_at, log_id, account_id, version,
 				current_status, previous_status, status_updated_at, status_reason, failure_reason,
 				reconciliation_status
-			FROM financial_position_logs
+			FROM financial_position_log
 			WHERE deleted_at IS NULL`
 
 		args := []any{}
@@ -560,7 +560,7 @@ func (r *PostgresRepository) FindPendingForReconciliation(ctx context.Context, l
 			SELECT id, created_at, updated_at, log_id, account_id, version,
 				current_status, previous_status, status_updated_at, status_reason, failure_reason,
 				reconciliation_status
-			FROM financial_position_logs
+			FROM financial_position_log
 			WHERE deleted_at IS NULL
 				AND current_status = 'PENDING'
 				AND reconciliation_status = 'UNRECONCILED'
@@ -596,7 +596,7 @@ func (r *PostgresRepository) insertTransactionLogEntries(ctx context.Context, tx
 	}
 
 	query := `
-		INSERT INTO transaction_log_entries (
+		INSERT INTO transaction_log_entry (
 			id, created_at, created_by, updated_at, updated_by,
 			entry_id, financial_position_log_id, transaction_id, account_id,
 			amount_cents, currency, direction, timestamp, description, reference, source
@@ -649,7 +649,7 @@ func (r *PostgresRepository) insertTransactionLineage(ctx context.Context, tx pg
 
 	userID := audit.GetUserFromContext(ctx)
 	query := `
-		INSERT INTO transaction_lineages (
+		INSERT INTO transaction_lineage (
 			id, created_at, created_by, updated_at, updated_by,
 			financial_position_log_id, transaction_id, parent_transaction_id,
 			child_transaction_ids, related_transaction_ids, transaction_type
@@ -677,7 +677,7 @@ func (r *PostgresRepository) insertAuditTrailEntries(ctx context.Context, tx pgx
 	}
 
 	query := `
-		INSERT INTO audit_trail_entries (
+		INSERT INTO audit_trail_entry (
 			id, created_at, created_by, updated_at, updated_by,
 			audit_id, financial_position_log_id, timestamp, user_id,
 			action, details, ip_address, system_context
@@ -723,7 +723,7 @@ func (r *PostgresRepository) loadTransactionLogEntriesTx(ctx context.Context, tx
 	query := `
 		SELECT entry_id, transaction_id, account_id, amount_cents, currency,
 			direction, timestamp, description, reference, source
-		FROM transaction_log_entries
+		FROM transaction_log_entry
 		WHERE financial_position_log_id = $1 AND deleted_at IS NULL
 		ORDER BY timestamp ASC`
 
@@ -778,7 +778,7 @@ func (r *PostgresRepository) loadTransactionLineageTx(ctx context.Context, tx pg
 	query := `
 		SELECT transaction_id, parent_transaction_id, child_transaction_ids,
 			related_transaction_ids, transaction_type
-		FROM transaction_lineages
+		FROM transaction_lineage
 		WHERE financial_position_log_id = $1 AND deleted_at IS NULL`
 
 	var transactionID uuid.UUID
@@ -830,7 +830,7 @@ func (r *PostgresRepository) loadTransactionLineageTx(ctx context.Context, tx pg
 func (r *PostgresRepository) getExistingAuditIDs(ctx context.Context, tx pgx.Tx, financialPosLogID uuid.UUID) (map[uuid.UUID]struct{}, error) {
 	query := `
 		SELECT audit_id
-		FROM audit_trail_entries
+		FROM audit_trail_entry
 		WHERE financial_position_log_id = $1 AND deleted_at IS NULL`
 
 	rows, err := tx.Query(ctx, query, financialPosLogID)
@@ -855,7 +855,7 @@ func (r *PostgresRepository) getExistingAuditIDs(ctx context.Context, tx pgx.Tx,
 func (r *PostgresRepository) loadAuditTrailEntriesTx(ctx context.Context, tx pgx.Tx, financialPosLogID uuid.UUID, log *domain.FinancialPositionLog) error {
 	query := `
 		SELECT audit_id, timestamp, user_id, action, details, ip_address, system_context
-		FROM audit_trail_entries
+		FROM audit_trail_entry
 		WHERE financial_position_log_id = $1 AND deleted_at IS NULL
 		ORDER BY timestamp ASC`
 
@@ -917,7 +917,7 @@ func (r *PostgresRepository) loadTransactionLogEntriesBatchTx(ctx context.Contex
 	query := fmt.Sprintf(`
 		SELECT financial_position_log_id, entry_id, transaction_id, account_id, amount_cents, currency,
 			direction, timestamp, description, reference, source
-		FROM transaction_log_entries
+		FROM transaction_log_entry
 		WHERE financial_position_log_id IN (%s) AND deleted_at IS NULL
 		ORDER BY financial_position_log_id, timestamp ASC`, strings.Join(placeholders, ","))
 
@@ -988,7 +988,7 @@ func (r *PostgresRepository) loadTransactionLineageBatchTx(ctx context.Context, 
 	query := fmt.Sprintf(`
 		SELECT financial_position_log_id, transaction_id, parent_transaction_id, child_transaction_ids,
 			related_transaction_ids, transaction_type
-		FROM transaction_lineages
+		FROM transaction_lineage
 		WHERE financial_position_log_id IN (%s) AND deleted_at IS NULL`, strings.Join(placeholders, ","))
 
 	rows, err := tx.Query(ctx, query, args...)
@@ -1064,7 +1064,7 @@ func (r *PostgresRepository) loadAuditTrailEntriesBatchTx(ctx context.Context, t
 
 	query := fmt.Sprintf(`
 		SELECT financial_position_log_id, audit_id, timestamp, user_id, action, details, ip_address, system_context
-		FROM audit_trail_entries
+		FROM audit_trail_entry
 		WHERE financial_position_log_id IN (%s) AND deleted_at IS NULL
 		ORDER BY financial_position_log_id, timestamp ASC`, strings.Join(placeholders, ","))
 
@@ -1189,7 +1189,7 @@ func (r *PostgresRepository) getLogIDMap(ctx context.Context, tx pgx.Tx, logs []
 
 	query := fmt.Sprintf(`
 		SELECT id, log_id
-		FROM financial_position_logs
+		FROM financial_position_log
 		WHERE log_id IN (%s)`, strings.Join(placeholders, ","))
 
 	rows, err := tx.Query(ctx, query, args...)

--- a/services/position-keeping/adapters/persistence/postgres_repository_test.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository_test.go
@@ -94,9 +94,9 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 	_, err := pool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS position_keeping`)
 	require.NoError(t, err)
 
-	// Create financial_position_logs table
+	// Create financial_position_log table (singular to match production migration)
 	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.financial_position_logs (
+		CREATE TABLE position_keeping.financial_position_log (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			created_at timestamptz NOT NULL DEFAULT now(),
 			created_by character varying(100) NOT NULL,
@@ -119,14 +119,14 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 
 	// Create indexes
 	_, err = pool.Exec(ctx, `
-		CREATE UNIQUE INDEX idx_position_keeping_financial_position_logs_log_id
-		ON position_keeping.financial_position_logs (log_id)
+		CREATE UNIQUE INDEX idx_position_keeping_financial_position_log_log_id
+		ON position_keeping.financial_position_log (log_id)
 	`)
 	require.NoError(t, err)
 
-	// Create transaction_log_entries table
+	// Create transaction_log_entry table (singular to match production migration)
 	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.transaction_log_entries (
+		CREATE TABLE position_keeping.transaction_log_entry (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			created_at timestamptz NOT NULL DEFAULT now(),
 			created_by character varying(100) NOT NULL,
@@ -145,17 +145,17 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 			reference character varying(100) NULL,
 			source character varying(50) NOT NULL,
 			PRIMARY KEY (id),
-			CONSTRAINT fk_transaction_log_entries_financial_position_log
+			CONSTRAINT fk_transaction_log_entry_financial_position_log
 				FOREIGN KEY (financial_position_log_id)
-				REFERENCES position_keeping.financial_position_logs(id)
+				REFERENCES position_keeping.financial_position_log(id)
 				ON DELETE CASCADE
 		)
 	`)
 	require.NoError(t, err)
 
-	// Create transaction_lineages table
+	// Create transaction_lineage table (singular to match production migration)
 	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.transaction_lineages (
+		CREATE TABLE position_keeping.transaction_lineage (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			created_at timestamptz NOT NULL DEFAULT now(),
 			created_by character varying(100) NOT NULL,
@@ -169,17 +169,17 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 			related_transaction_ids jsonb NOT NULL DEFAULT '[]',
 			transaction_type character varying(50) NOT NULL,
 			PRIMARY KEY (id),
-			CONSTRAINT fk_transaction_lineages_financial_position_log
+			CONSTRAINT fk_transaction_lineage_financial_position_log
 				FOREIGN KEY (financial_position_log_id)
-				REFERENCES position_keeping.financial_position_logs(id)
+				REFERENCES position_keeping.financial_position_log(id)
 				ON DELETE CASCADE
 		)
 	`)
 	require.NoError(t, err)
 
-	// Create audit_trail_entries table
+	// Create audit_trail_entry table (singular to match production migration)
 	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.audit_trail_entries (
+		CREATE TABLE position_keeping.audit_trail_entry (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			created_at timestamptz NOT NULL DEFAULT now(),
 			created_by character varying(100) NOT NULL,
@@ -195,9 +195,9 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 			ip_address character varying(45) NULL,
 			system_context jsonb NULL,
 			PRIMARY KEY (id),
-			CONSTRAINT fk_audit_trail_entries_financial_position_log
+			CONSTRAINT fk_audit_trail_entry_financial_position_log
 				FOREIGN KEY (financial_position_log_id)
-				REFERENCES position_keeping.financial_position_logs(id)
+				REFERENCES position_keeping.financial_position_log(id)
 				ON DELETE CASCADE
 		)
 	`)

--- a/services/position-keeping/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/position-keeping/adapters/persistence/testhelpers/testcontainer.go
@@ -134,10 +134,10 @@ func (tc *TestContainer) Cleanup(t *testing.T) {
 // loadSchema loads the complete position_keeping schema into the test database.
 // This includes:
 //   - position_keeping schema
-//   - financial_position_logs table with indexes
-//   - transaction_log_entries table with foreign keys
-//   - transaction_lineages table with JSONB columns
-//   - audit_trail_entries table with JSONB columns
+//   - financial_position_log table with indexes
+//   - transaction_log_entry table with foreign keys
+//   - transaction_lineage table with JSONB columns
+//   - audit_trail_entry table with JSONB columns
 //
 // The schema matches the production Atlas migrations but is loaded directly
 // for test speed. This avoids the overhead of running migrations in tests.
@@ -149,9 +149,9 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 	_, err := pool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS position_keeping`)
 	require.NoError(t, err, "Failed to create schema")
 
-	// Create financial_position_logs table
+	// Create financial_position_log table (singular to match production migration)
 	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.financial_position_logs (
+		CREATE TABLE position_keeping.financial_position_log (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			created_at timestamptz NOT NULL DEFAULT now(),
 			created_by character varying(100) NOT NULL,
@@ -170,18 +170,18 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 			PRIMARY KEY (id)
 		)
 	`)
-	require.NoError(t, err, "Failed to create financial_position_logs table")
+	require.NoError(t, err, "Failed to create financial_position_log table")
 
 	// Create indexes
 	_, err = pool.Exec(ctx, `
-		CREATE UNIQUE INDEX idx_position_keeping_financial_position_logs_log_id
-		ON position_keeping.financial_position_logs (log_id)
+		CREATE UNIQUE INDEX idx_position_keeping_financial_position_log_log_id
+		ON position_keeping.financial_position_log (log_id)
 	`)
 	require.NoError(t, err, "Failed to create log_id index")
 
-	// Create transaction_log_entries table
+	// Create transaction_log_entry table (singular to match production migration)
 	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.transaction_log_entries (
+		CREATE TABLE position_keeping.transaction_log_entry (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			created_at timestamptz NOT NULL DEFAULT now(),
 			created_by character varying(100) NOT NULL,
@@ -200,17 +200,17 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 			reference character varying(100) NULL,
 			source character varying(50) NOT NULL,
 			PRIMARY KEY (id),
-			CONSTRAINT fk_transaction_log_entries_financial_position_log
+			CONSTRAINT fk_transaction_log_entry_financial_position_log
 				FOREIGN KEY (financial_position_log_id)
-				REFERENCES position_keeping.financial_position_logs(id)
+				REFERENCES position_keeping.financial_position_log(id)
 				ON DELETE CASCADE
 		)
 	`)
-	require.NoError(t, err, "Failed to create transaction_log_entries table")
+	require.NoError(t, err, "Failed to create transaction_log_entry table")
 
-	// Create transaction_lineages table
+	// Create transaction_lineage table (singular to match production migration)
 	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.transaction_lineages (
+		CREATE TABLE position_keeping.transaction_lineage (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			created_at timestamptz NOT NULL DEFAULT now(),
 			created_by character varying(100) NOT NULL,
@@ -224,17 +224,17 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 			related_transaction_ids jsonb NOT NULL DEFAULT '[]',
 			transaction_type character varying(50) NOT NULL,
 			PRIMARY KEY (id),
-			CONSTRAINT fk_transaction_lineages_financial_position_log
+			CONSTRAINT fk_transaction_lineage_financial_position_log
 				FOREIGN KEY (financial_position_log_id)
-				REFERENCES position_keeping.financial_position_logs(id)
+				REFERENCES position_keeping.financial_position_log(id)
 				ON DELETE CASCADE
 		)
 	`)
-	require.NoError(t, err, "Failed to create transaction_lineages table")
+	require.NoError(t, err, "Failed to create transaction_lineage table")
 
-	// Create audit_trail_entries table
+	// Create audit_trail_entry table (singular to match production migration)
 	_, err = pool.Exec(ctx, `
-		CREATE TABLE position_keeping.audit_trail_entries (
+		CREATE TABLE position_keeping.audit_trail_entry (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			created_at timestamptz NOT NULL DEFAULT now(),
 			created_by character varying(100) NOT NULL,
@@ -250,11 +250,11 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 			ip_address character varying(45) NULL,
 			system_context jsonb NULL,
 			PRIMARY KEY (id),
-			CONSTRAINT fk_audit_trail_entries_financial_position_log
+			CONSTRAINT fk_audit_trail_entry_financial_position_log
 				FOREIGN KEY (financial_position_log_id)
-				REFERENCES position_keeping.financial_position_logs(id)
+				REFERENCES position_keeping.financial_position_log(id)
 				ON DELETE CASCADE
 		)
 	`)
-	require.NoError(t, err, "Failed to create audit_trail_entries table")
+	require.NoError(t, err, "Failed to create audit_trail_entry table")
 }


### PR DESCRIPTION
## Summary
- Fixed table name mismatch between PostgresRepository SQL queries and migration schema in position-keeping service
- Aligned financial-accounting test schema with production migration naming
- Updated new-bian-service-checklist.md with database setup steps

## Task Master Reference
- **Tag**: database-per-service
- **Task ID**: 12

## Changes Made
- **position-keeping/postgres_repository.go**: Changed all SQL queries from plural table names (`financial_position_logs`, `transaction_log_entries`, etc.) to singular (`financial_position_log`, `transaction_log_entry`, etc.)
- **position-keeping test files**: Updated testcontainer.go and postgres_repository_test.go schema definitions to use singular table names
- **financial-accounting test file**: Updated repository_test.go schema to use singular table names (`financial_booking_log`, `ledger_posting`)
- **docs/guides/new-bian-service-checklist.md**: Added Task 5 (Database Setup) documenting database-per-service architecture steps and table naming conventions

## Test Plan
- [x] Code compiles successfully
- [x] Pre-commit hooks pass (markdownlint, gofumpt, golangci-lint)
- [ ] CI pipeline passes
- [ ] Integration tests pass with aligned table names