### PR TITLE
Add resilient client patterns to payment-order service

### DIFF
--- a/services/payment-order/clients/current_account_client.go
+++ b/services/payment-order/clients/current_account_client.go
@@ -1,0 +1,160 @@
+// Package clients provides gRPC client wrappers with resilience patterns.
+//
+// This package provides resilient client wrappers that delegate to the shared
+// implementation in github.com/meridianhub/meridian/shared/pkg/clients.
+package clients
+
+import (
+	"context"
+	"fmt"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	"google.golang.org/grpc"
+)
+
+// CurrentAccountClient defines the interface for current-account service operations.
+// This interface allows for easy mocking in tests.
+type CurrentAccountClient interface {
+	InitiateLien(ctx context.Context, req *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error)
+	TerminateLien(ctx context.Context, req *currentaccountv1.TerminateLienRequest) (*currentaccountv1.TerminateLienResponse, error)
+	ExecuteLien(ctx context.Context, req *currentaccountv1.ExecuteLienRequest) (*currentaccountv1.ExecuteLienResponse, error)
+	Close() error
+}
+
+// ResilientCurrentAccountClient wraps the gRPC client with resilience patterns.
+// It provides circuit breaker protection and retry capabilities for all operations
+// against the current-account service.
+type ResilientCurrentAccountClient struct {
+	client          currentAccountGRPCClient
+	resilientClient *sharedclients.ResilientClient
+}
+
+// currentAccountGRPCClient is the internal interface for the gRPC client.
+// This allows us to inject mocks for testing.
+type currentAccountGRPCClient interface {
+	InitiateLien(ctx context.Context, in *currentaccountv1.InitiateLienRequest, opts ...grpc.CallOption) (*currentaccountv1.InitiateLienResponse, error)
+	TerminateLien(ctx context.Context, in *currentaccountv1.TerminateLienRequest, opts ...grpc.CallOption) (*currentaccountv1.TerminateLienResponse, error)
+	ExecuteLien(ctx context.Context, in *currentaccountv1.ExecuteLienRequest, opts ...grpc.CallOption) (*currentaccountv1.ExecuteLienResponse, error)
+	Close() error
+}
+
+// grpcClientWrapper wraps the generated gRPC client and connection
+type grpcClientWrapper struct {
+	conn   *grpc.ClientConn
+	client currentaccountv1.CurrentAccountServiceClient
+}
+
+func (w *grpcClientWrapper) InitiateLien(ctx context.Context, in *currentaccountv1.InitiateLienRequest, opts ...grpc.CallOption) (*currentaccountv1.InitiateLienResponse, error) {
+	return w.client.InitiateLien(ctx, in, opts...)
+}
+
+func (w *grpcClientWrapper) TerminateLien(ctx context.Context, in *currentaccountv1.TerminateLienRequest, opts ...grpc.CallOption) (*currentaccountv1.TerminateLienResponse, error) {
+	return w.client.TerminateLien(ctx, in, opts...)
+}
+
+func (w *grpcClientWrapper) ExecuteLien(ctx context.Context, in *currentaccountv1.ExecuteLienRequest, opts ...grpc.CallOption) (*currentaccountv1.ExecuteLienResponse, error) {
+	return w.client.ExecuteLien(ctx, in, opts...)
+}
+
+func (w *grpcClientWrapper) Close() error {
+	return w.conn.Close()
+}
+
+// NewResilientCurrentAccountClient creates a resilient wrapper around the
+// CurrentAccount gRPC client. The connection must be established before
+// calling this function.
+func NewResilientCurrentAccountClient(
+	conn *grpc.ClientConn,
+	config sharedclients.ResilientClientConfig,
+) *ResilientCurrentAccountClient {
+	// Apply default name if not provided
+	if config.CircuitBreakerName == "" {
+		config.CircuitBreakerName = "current-account"
+	}
+
+	wrapper := &grpcClientWrapper{
+		conn:   conn,
+		client: currentaccountv1.NewCurrentAccountServiceClient(conn),
+	}
+
+	return &ResilientCurrentAccountClient{
+		client:          wrapper,
+		resilientClient: sharedclients.NewResilientClient(config),
+	}
+}
+
+// InitiateLien creates a fund reservation on an account with resilience patterns.
+// This operation is idempotent (same request produces same result), so retries
+// are enabled.
+func (c *ResilientCurrentAccountClient) InitiateLien(
+	ctx context.Context,
+	req *currentaccountv1.InitiateLienRequest,
+) (*currentaccountv1.InitiateLienResponse, error) {
+	return sharedclients.ExecuteWithResilience(
+		ctx,
+		c.resilientClient,
+		"InitiateLien",
+		func() (*currentaccountv1.InitiateLienResponse, error) {
+			return c.client.InitiateLien(ctx, req)
+		},
+	)
+}
+
+// TerminateLien releases a reservation without executing it with resilience patterns.
+// This operation is idempotent (terminating an already terminated lien is a no-op),
+// so retries are enabled.
+func (c *ResilientCurrentAccountClient) TerminateLien(
+	ctx context.Context,
+	req *currentaccountv1.TerminateLienRequest,
+) (*currentaccountv1.TerminateLienResponse, error) {
+	return sharedclients.ExecuteWithResilience(
+		ctx,
+		c.resilientClient,
+		"TerminateLien",
+		func() (*currentaccountv1.TerminateLienResponse, error) {
+			return c.client.TerminateLien(ctx, req)
+		},
+	)
+}
+
+// ExecuteLien converts a reservation to an actual debit with resilience patterns.
+// This operation is idempotent (executing an already executed lien returns the
+// existing result), so retries are enabled.
+func (c *ResilientCurrentAccountClient) ExecuteLien(
+	ctx context.Context,
+	req *currentaccountv1.ExecuteLienRequest,
+) (*currentaccountv1.ExecuteLienResponse, error) {
+	return sharedclients.ExecuteWithResilience(
+		ctx,
+		c.resilientClient,
+		"ExecuteLien",
+		func() (*currentaccountv1.ExecuteLienResponse, error) {
+			return c.client.ExecuteLien(ctx, req)
+		},
+	)
+}
+
+// Close closes the underlying gRPC connection.
+func (c *ResilientCurrentAccountClient) Close() error {
+	if err := c.client.Close(); err != nil {
+		return fmt.Errorf("failed to close current-account client connection: %w", err)
+	}
+	return nil
+}
+
+// newResilientCurrentAccountClientForTesting creates a resilient client with a mock
+// gRPC client for testing purposes. This function is not exported to prevent misuse.
+func newResilientCurrentAccountClientForTesting(
+	mockClient currentAccountGRPCClient,
+	config sharedclients.ResilientClientConfig,
+) *ResilientCurrentAccountClient {
+	if config.CircuitBreakerName == "" {
+		config.CircuitBreakerName = "current-account"
+	}
+
+	return &ResilientCurrentAccountClient{
+		client:          mockClient,
+		resilientClient: sharedclients.NewResilientClient(config),
+	}
+}

--- a/services/payment-order/clients/current_account_client_test.go
+++ b/services/payment-order/clients/current_account_client_test.go
@@ -1,0 +1,356 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var errCloseFailed = errors.New("close failed")
+
+// mockCurrentAccountGRPCClient implements currentAccountGRPCClient for testing
+type mockCurrentAccountGRPCClient struct {
+	initiateLienFn  func(ctx context.Context, req *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error)
+	terminateLienFn func(ctx context.Context, req *currentaccountv1.TerminateLienRequest) (*currentaccountv1.TerminateLienResponse, error)
+	executeLienFn   func(ctx context.Context, req *currentaccountv1.ExecuteLienRequest) (*currentaccountv1.ExecuteLienResponse, error)
+	closeFn         func() error
+}
+
+func (m *mockCurrentAccountGRPCClient) InitiateLien(ctx context.Context, in *currentaccountv1.InitiateLienRequest, _ ...grpc.CallOption) (*currentaccountv1.InitiateLienResponse, error) {
+	if m.initiateLienFn != nil {
+		return m.initiateLienFn(ctx, in)
+	}
+	return &currentaccountv1.InitiateLienResponse{}, nil
+}
+
+func (m *mockCurrentAccountGRPCClient) TerminateLien(ctx context.Context, in *currentaccountv1.TerminateLienRequest, _ ...grpc.CallOption) (*currentaccountv1.TerminateLienResponse, error) {
+	if m.terminateLienFn != nil {
+		return m.terminateLienFn(ctx, in)
+	}
+	return &currentaccountv1.TerminateLienResponse{}, nil
+}
+
+func (m *mockCurrentAccountGRPCClient) ExecuteLien(ctx context.Context, in *currentaccountv1.ExecuteLienRequest, _ ...grpc.CallOption) (*currentaccountv1.ExecuteLienResponse, error) {
+	if m.executeLienFn != nil {
+		return m.executeLienFn(ctx, in)
+	}
+	return &currentaccountv1.ExecuteLienResponse{}, nil
+}
+
+func (m *mockCurrentAccountGRPCClient) Close() error {
+	if m.closeFn != nil {
+		return m.closeFn()
+	}
+	return nil
+}
+
+// TestNewResilientCurrentAccountClient_Success verifies client creation
+func TestNewResilientCurrentAccountClient_Success(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockCurrentAccountGRPCClient{}
+	config := sharedclients.ResilientClientConfig{
+		CircuitBreakerName: "test-service",
+		MaxRequests:        1,
+		FailureThreshold:   5,
+		MaxRetries:         3,
+		InitialInterval:    100 * time.Millisecond,
+		Logger:             slog.Default(),
+	}
+
+	resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+
+	require.NotNil(t, resilientClient)
+	assert.NoError(t, resilientClient.Close())
+}
+
+// TestNewResilientCurrentAccountClient_DefaultConfig verifies defaults are applied
+func TestNewResilientCurrentAccountClient_DefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockCurrentAccountGRPCClient{}
+	config := sharedclients.ResilientClientConfig{}
+
+	resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+
+	require.NotNil(t, resilientClient)
+	assert.NoError(t, resilientClient.Close())
+}
+
+// TestNewResilientCurrentAccountClient_NilLogger verifies default logger is used
+func TestNewResilientCurrentAccountClient_NilLogger(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockCurrentAccountGRPCClient{}
+	config := sharedclients.ResilientClientConfig{
+		Logger: nil,
+	}
+
+	resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+
+	require.NotNil(t, resilientClient)
+	assert.NoError(t, resilientClient.Close())
+}
+
+// TestResilientCurrentAccountClient_Close verifies Close is forwarded
+func TestResilientCurrentAccountClient_Close(t *testing.T) {
+	t.Parallel()
+
+	closed := false
+	mockClient := &mockCurrentAccountGRPCClient{
+		closeFn: func() error {
+			closed = true
+			return nil
+		},
+	}
+
+	config := sharedclients.ResilientClientConfig{}
+	resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+
+	err := resilientClient.Close()
+
+	assert.NoError(t, err)
+	assert.True(t, closed)
+}
+
+// TestResilientCurrentAccountClient_Close_Error verifies error propagation
+func TestResilientCurrentAccountClient_Close_Error(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockCurrentAccountGRPCClient{
+		closeFn: func() error {
+			return errCloseFailed
+		},
+	}
+
+	config := sharedclients.ResilientClientConfig{}
+	resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+
+	err := resilientClient.Close()
+
+	assert.ErrorIs(t, err, errCloseFailed)
+}
+
+// TestResilientCurrentAccountClient_CircuitBreakerIntegration verifies circuit breaker opens after failures
+func TestResilientCurrentAccountClient_CircuitBreakerIntegration(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+
+	mockClient := &mockCurrentAccountGRPCClient{
+		initiateLienFn: func(_ context.Context, _ *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error) {
+			callCount.Add(1)
+			return nil, status.Error(codes.Unavailable, "service unavailable")
+		},
+	}
+
+	config := sharedclients.ResilientClientConfig{
+		MaxRequests:      1,
+		FailureThreshold: 3, // Open after 3 failures
+		MaxRetries:       0, // No retries to test circuit breaker directly
+		Logger:           slog.Default(),
+	}
+
+	resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+	defer func() {
+		assert.NoError(t, resilientClient.Close())
+	}()
+
+	// Make calls until circuit breaker opens
+	ctx := context.Background()
+
+	// First 3 calls should reach the service
+	for i := 0; i < 3; i++ {
+		_, _ = resilientClient.InitiateLien(ctx, &currentaccountv1.InitiateLienRequest{})
+	}
+
+	beforeOpenCount := callCount.Load()
+	assert.Equal(t, int32(3), beforeOpenCount)
+
+	// Circuit breaker should now be open, next calls should fail fast
+	time.Sleep(100 * time.Millisecond) // Allow circuit breaker to transition
+
+	_, err := resilientClient.InitiateLien(ctx, &currentaccountv1.InitiateLienRequest{})
+	assert.Error(t, err)
+
+	// Call count should not increase (circuit breaker blocked the call)
+	afterOpenCount := callCount.Load()
+	assert.Equal(t, beforeOpenCount, afterOpenCount, "circuit breaker should prevent calls from reaching service")
+}
+
+// TestResilientCurrentAccountClient_RetryIntegration verifies retry logic works
+func TestResilientCurrentAccountClient_RetryIntegration(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+
+	mockClient := &mockCurrentAccountGRPCClient{
+		initiateLienFn: func(_ context.Context, _ *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error) {
+			count := callCount.Add(1)
+			// Fail first 2 calls, succeed on 3rd
+			if count < 3 {
+				return nil, status.Error(codes.Unavailable, "service unavailable")
+			}
+			return &currentaccountv1.InitiateLienResponse{}, nil
+		},
+	}
+
+	config := sharedclients.ResilientClientConfig{
+		MaxRequests:         1,
+		FailureThreshold:    10, // High threshold so circuit breaker doesn't open
+		MaxRetries:          3,
+		InitialInterval:     10 * time.Millisecond,
+		MaxInterval:         100 * time.Millisecond,
+		Multiplier:          2.0,
+		RandomizationFactor: 0.1,
+		Logger:              slog.Default(),
+	}
+
+	resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+	defer func() {
+		assert.NoError(t, resilientClient.Close())
+	}()
+
+	ctx := context.Background()
+	resp, err := resilientClient.InitiateLien(ctx, &currentaccountv1.InitiateLienRequest{})
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, int32(3), callCount.Load(), "should retry until success")
+}
+
+// TestResilientCurrentAccountClient_NonRetryableError verifies non-retryable errors fail immediately
+func TestResilientCurrentAccountClient_NonRetryableError(t *testing.T) {
+	t.Parallel()
+
+	var callCount atomic.Int32
+
+	mockClient := &mockCurrentAccountGRPCClient{
+		initiateLienFn: func(_ context.Context, _ *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error) {
+			callCount.Add(1)
+			return nil, status.Error(codes.InvalidArgument, "invalid request")
+		},
+	}
+
+	config := sharedclients.ResilientClientConfig{
+		MaxRetries:      3,
+		InitialInterval: 10 * time.Millisecond,
+		Logger:          slog.Default(),
+	}
+
+	resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+	defer func() {
+		assert.NoError(t, resilientClient.Close())
+	}()
+
+	ctx := context.Background()
+	_, err := resilientClient.InitiateLien(ctx, &currentaccountv1.InitiateLienRequest{})
+
+	assert.Error(t, err)
+	assert.Equal(t, int32(1), callCount.Load(), "should not retry non-retryable errors")
+}
+
+// TestResilientCurrentAccountClient_ContextCancellation verifies context cancellation stops operations
+func TestResilientCurrentAccountClient_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	mockClient := &mockCurrentAccountGRPCClient{
+		initiateLienFn: func(_ context.Context, _ *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error) {
+			// Simulate slow operation
+			time.Sleep(100 * time.Millisecond)
+			return &currentaccountv1.InitiateLienResponse{}, nil
+		},
+	}
+
+	config := sharedclients.ResilientClientConfig{
+		MaxRetries:      3,
+		InitialInterval: 10 * time.Millisecond,
+		Logger:          slog.Default(),
+	}
+
+	resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+	defer func() {
+		assert.NoError(t, resilientClient.Close())
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, err := resilientClient.InitiateLien(ctx, &currentaccountv1.InitiateLienRequest{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+}
+
+// TestResilientCurrentAccountClient_AllOperations verifies all operations work with resilience
+func TestResilientCurrentAccountClient_AllOperations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("InitiateLien_Success", func(t *testing.T) {
+		mockClient := &mockCurrentAccountGRPCClient{
+			initiateLienFn: func(_ context.Context, _ *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error) {
+				return &currentaccountv1.InitiateLienResponse{}, nil
+			},
+		}
+
+		config := sharedclients.ResilientClientConfig{Logger: slog.Default()}
+		resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+		defer func() {
+			assert.NoError(t, resilientClient.Close())
+		}()
+
+		resp, err := resilientClient.InitiateLien(context.Background(), &currentaccountv1.InitiateLienRequest{})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("TerminateLien_Success", func(t *testing.T) {
+		mockClient := &mockCurrentAccountGRPCClient{
+			terminateLienFn: func(_ context.Context, _ *currentaccountv1.TerminateLienRequest) (*currentaccountv1.TerminateLienResponse, error) {
+				return &currentaccountv1.TerminateLienResponse{}, nil
+			},
+		}
+
+		config := sharedclients.ResilientClientConfig{Logger: slog.Default()}
+		resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+		defer func() {
+			assert.NoError(t, resilientClient.Close())
+		}()
+
+		resp, err := resilientClient.TerminateLien(context.Background(), &currentaccountv1.TerminateLienRequest{})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+
+	t.Run("ExecuteLien_Success", func(t *testing.T) {
+		mockClient := &mockCurrentAccountGRPCClient{
+			executeLienFn: func(_ context.Context, _ *currentaccountv1.ExecuteLienRequest) (*currentaccountv1.ExecuteLienResponse, error) {
+				return &currentaccountv1.ExecuteLienResponse{}, nil
+			},
+		}
+
+		config := sharedclients.ResilientClientConfig{Logger: slog.Default()}
+		resilientClient := newResilientCurrentAccountClientForTesting(mockClient, config)
+		defer func() {
+			assert.NoError(t, resilientClient.Close())
+		}()
+
+		resp, err := resilientClient.ExecuteLien(context.Background(), &currentaccountv1.ExecuteLienRequest{})
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+	})
+}

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -15,12 +15,13 @@ import (
 	"syscall"
 	"time"
 
-	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
 	webhookhttp "github.com/meridianhub/meridian/services/payment-order/adapters/http"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
+	payclients "github.com/meridianhub/meridian/services/payment-order/clients"
 	"github.com/meridianhub/meridian/services/payment-order/service"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/interceptors"
 	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/kafka"
@@ -311,29 +312,8 @@ func (s *simpleHealthServer) Watch(_ *grpc_health_v1.HealthCheckRequest, server 
 	return server.Context().Err()
 }
 
-// currentAccountGRPCClient implements service.CurrentAccountClient using gRPC.
-type currentAccountGRPCClient struct {
-	conn   *grpc.ClientConn
-	client currentaccountv1.CurrentAccountServiceClient
-}
-
-func (c *currentAccountGRPCClient) InitiateLien(ctx context.Context, req *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error) {
-	return c.client.InitiateLien(ctx, req)
-}
-
-func (c *currentAccountGRPCClient) TerminateLien(ctx context.Context, req *currentaccountv1.TerminateLienRequest) (*currentaccountv1.TerminateLienResponse, error) {
-	return c.client.TerminateLien(ctx, req)
-}
-
-func (c *currentAccountGRPCClient) ExecuteLien(ctx context.Context, req *currentaccountv1.ExecuteLienRequest) (*currentaccountv1.ExecuteLienResponse, error) {
-	return c.client.ExecuteLien(ctx, req)
-}
-
-func (c *currentAccountGRPCClient) Close() error {
-	return c.conn.Close()
-}
-
-// createCurrentAccountClient creates the CurrentAccount gRPC client.
+// createCurrentAccountClient creates the CurrentAccount gRPC client with resilience patterns.
+// The client is wrapped with circuit breaker and retry logic using shared/pkg/clients.
 func createCurrentAccountClient(namespace string, logger *slog.Logger) (service.CurrentAccountClient, func(), error) {
 	target := fmt.Sprintf("dns:///current-account.%s.svc.cluster.local:50051", namespace)
 	logger.Info("connecting to current-account service", "target", target)
@@ -347,10 +327,32 @@ func createCurrentAccountClient(namespace string, logger *slog.Logger) (service.
 		return nil, nil, fmt.Errorf("failed to connect to current-account service: %w", err)
 	}
 
-	client := &currentAccountGRPCClient{
-		conn:   conn,
-		client: currentaccountv1.NewCurrentAccountServiceClient(conn),
+	// Configure resilience settings from environment
+	resilientConfig := sharedclients.ResilientClientConfig{
+		// Circuit breaker settings
+		CircuitBreakerName:     "current-account",
+		CircuitBreakerTimeout:  getEnvAsDuration("CURRENT_ACCOUNT_CIRCUIT_BREAKER_TIMEOUT", 30*time.Second),
+		CircuitBreakerInterval: getEnvAsDuration("CURRENT_ACCOUNT_CIRCUIT_BREAKER_INTERVAL", 60*time.Second),
+		MaxRequests:            getEnvAsUint32("CURRENT_ACCOUNT_CIRCUIT_BREAKER_MAX_REQUESTS", 1),
+		FailureThreshold:       getEnvAsUint32("CURRENT_ACCOUNT_CIRCUIT_BREAKER_FAILURE_THRESHOLD", 5),
+
+		// Retry settings
+		MaxRetries:          getEnvAsInt("CURRENT_ACCOUNT_MAX_RETRIES", 3),
+		InitialInterval:     getEnvAsDuration("CURRENT_ACCOUNT_RETRY_INITIAL_INTERVAL", 100*time.Millisecond),
+		MaxInterval:         getEnvAsDuration("CURRENT_ACCOUNT_RETRY_MAX_INTERVAL", 5*time.Second),
+		Multiplier:          getEnvAsFloat("CURRENT_ACCOUNT_RETRY_MULTIPLIER", 2.0),
+		RandomizationFactor: getEnvAsFloat("CURRENT_ACCOUNT_RETRY_RANDOMIZATION", 0.5),
+
+		Logger: logger,
 	}
+
+	logger.Info("current-account client configured with resilience patterns",
+		"circuit_breaker_timeout", resilientConfig.CircuitBreakerTimeout,
+		"circuit_breaker_failure_threshold", resilientConfig.FailureThreshold,
+		"max_retries", resilientConfig.MaxRetries,
+	)
+
+	client := payclients.NewResilientCurrentAccountClient(conn, resilientConfig)
 
 	cleanup := func() {
 		if err := client.Close(); err != nil {


### PR DESCRIPTION
## Summary
- Refactor payment-order service to use shared resilient client wrapper from `shared/pkg/clients`
- Implement circuit breaker and retry patterns for CurrentAccount gRPC client
- Add configurable resilience settings via environment variables

## Task Master Reference
- **Tag**: 223-shared-client-patterns
- **Task ID**: 6

## Changes Made
- Create `services/payment-order/clients/` package with `ResilientCurrentAccountClient`
- Update `main.go` to use resilient client with environment-based configuration
- Remove inline `currentAccountGRPCClient` struct from main.go
- Add 10 comprehensive tests covering circuit breaker, retry, and operation behavior

## Configuration
New environment variables for operators:
- `CURRENT_ACCOUNT_CIRCUIT_BREAKER_TIMEOUT` (default: 30s)
- `CURRENT_ACCOUNT_CIRCUIT_BREAKER_INTERVAL` (default: 60s)
- `CURRENT_ACCOUNT_CIRCUIT_BREAKER_MAX_REQUESTS` (default: 1)
- `CURRENT_ACCOUNT_CIRCUIT_BREAKER_FAILURE_THRESHOLD` (default: 5)
- `CURRENT_ACCOUNT_MAX_RETRIES` (default: 3)
- `CURRENT_ACCOUNT_RETRY_INITIAL_INTERVAL` (default: 100ms)
- `CURRENT_ACCOUNT_RETRY_MAX_INTERVAL` (default: 5s)
- `CURRENT_ACCOUNT_RETRY_MULTIPLIER` (default: 2.0)
- `CURRENT_ACCOUNT_RETRY_RANDOMIZATION` (default: 0.5)

## Test Plan
- [x] Run `go test -v ./services/payment-order/clients/...` - 10 tests pass
- [x] Run `go test -v ./services/payment-order/...` - all service tests pass
- [x] Build `go build -o /tmp/payment-order-test ./services/payment-order/cmd/` - compiles successfully
- [x] Pre-commit hooks (gofumpt, golangci-lint) pass