### PR TITLE
docs: clarify CockroachDB usage in new service checklist

### DIFF
--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -284,9 +284,13 @@ atlas migrate status --env local --config file://services/{service}/atlas/atlas.
 
 ### Task 5: Database Setup (Database-Per-Service Architecture)
 
-**Location**: PostgreSQL/CockroachDB administration
+**Location**: CockroachDB administration
 
 Set up the dedicated database for the new service following the database-per-service architecture.
+
+> **Note**: Meridian uses CockroachDB (port 26257) which implements the PostgreSQL wire protocol.
+> This means `postgres://` connection strings and `psql` CLI tools work, but the underlying
+> database is CockroachDB.
 
 **Steps:**
 
@@ -327,15 +331,15 @@ func (EntityName) TableName() string {
 ```
 
 **Why singular**: Natural SQL syntax (`FROM account` not `FROM accounts`)
-**Why unqualified**: Allows PostgreSQL `search_path` to route to tenant schemas
+**Why unqualified**: Allows `search_path` to route queries to tenant schemas
 
 **Reference**: [Database-Per-Service Migration Runbook](../runbooks/database-per-service-migration.md)
 
 **Verification:**
 
 ```bash
-# Verify database exists and user can connect
-psql -h localhost -U {service}_svc -d meridian_{service} -c "SELECT current_database();"
+# Verify database exists and user can connect (CockroachDB on port 26257)
+psql -h localhost -p 26257 -U {service}_svc -d meridian_{service} -c "SELECT current_database();"
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Clarifies that Meridian uses CockroachDB (port 26257) in the new service checklist
- Explains that CockroachDB implements the PostgreSQL wire protocol
- Adds port 26257 to verification command for consistency

## Changes Made

- Updated Task 5 location from "PostgreSQL/CockroachDB administration" to "CockroachDB administration"
- Added note explaining PostgreSQL wire protocol compatibility
- Added `-p 26257` to the psql verification command
- Removed PostgreSQL-specific wording from search_path explanation

## Context

This addresses CodeRabbit feedback from PR #326 about clarifying the database system used.

## Test plan

- [x] Documentation-only change
- [x] Passes markdownlint