### PR TITLE
refactor: Remove vestigial service-named schema creation from atlas-loader

### DIFF
--- a/utilities/atlas-loader/main.go
+++ b/utilities/atlas-loader/main.go
@@ -16,6 +16,9 @@ import (
 	"github.com/meridianhub/meridian/shared/domain/models"
 )
 
+// Schema filter constants for selecting service-specific models.
+// With database-per-service architecture, each service has its own database
+// and tenant provisioner creates org_{tenant_id} schemas as needed.
 const (
 	schemaCurrentAccount      = "current_account"
 	schemaPositionKeeping     = "position_keeping"
@@ -96,33 +99,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Prepend CREATE SCHEMA statements for referenced schemas.
-	// With database-per-service architecture, most services use unqualified table names
-	// in the default public schema. Only legacy services (position_keeping, financial_accounting,
-	// current_account) still use schema-qualified names.
-	output := stmts
-	if *schemaFilter != "" {
-		var schemaStmt string
-		switch *schemaFilter {
-		case schemaPositionKeeping:
-			// For position_keeping, we need both schemas since transactions reference accounts
-			schemaStmt = "CREATE SCHEMA IF NOT EXISTS current_account;\nCREATE SCHEMA IF NOT EXISTS position_keeping;\n\n"
-		case schemaFinancialAccounting:
-			schemaStmt = "CREATE SCHEMA IF NOT EXISTS financial_accounting;\n\n"
-		case schemaCurrentAccount:
-			schemaStmt = "CREATE SCHEMA IF NOT EXISTS current_account;\n\n"
-		case schemaParty, schemaPaymentOrder, schemaPlatform:
-			// These services use unqualified table names for multi-tenant schema routing.
-			// Schema is created externally during org provisioning or set via search_path.
-			// No CREATE SCHEMA prepended here.
-			schemaStmt = ""
-		default:
-			schemaStmt = ""
-		}
-		output = schemaStmt + stmts
-	}
-
-	if _, err := io.WriteString(os.Stdout, output); err != nil {
+	// Output table DDL directly without schema creation statements.
+	// With database-per-service architecture:
+	// - Each service has its own database (meridian_current_account, meridian_party, etc.)
+	// - Tenant provisioner creates org_{tenant_id} schemas before running migrations
+	// - Tables use unqualified names with search_path routing to tenant schemas
+	if _, err := io.WriteString(os.Stdout, stmts); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to write schema: %v\n", err)
 		os.Exit(1)
 	}

--- a/utilities/atlas-loader/main_test.go
+++ b/utilities/atlas-loader/main_test.go
@@ -48,7 +48,7 @@ func TestAtlasLoaderBinary(t *testing.T) {
 				"transaction_log_entry",  // singular table name for search_path routing
 			},
 			wantNotStdout: []string{
-				"CREATE SCHEMA", // No schema statement without filter
+				"CREATE SCHEMA", // No schema statements - tenant provisioner creates schemas
 			},
 		},
 		{
@@ -56,12 +56,13 @@ func TestAtlasLoaderBinary(t *testing.T) {
 			args:         []string{"-schema=current_account"},
 			wantExitCode: 0,
 			wantStdout: []string{
-				"CREATE SCHEMA IF NOT EXISTS current_account",
+				"CREATE TABLE",
 				"customer", // singular table name for search_path routing
 				"account",  // singular table name for search_path routing
 				"lien",     // singular table name for search_path routing
 			},
 			wantNotStdout: []string{
+				"CREATE SCHEMA",          // No schema statements - tenant provisioner creates schemas
 				"financial_position_log", // position_keeping model should not be included
 				"transaction_log_entry",  // position_keeping model should not be included
 			},
@@ -71,8 +72,7 @@ func TestAtlasLoaderBinary(t *testing.T) {
 			args:         []string{"-schema=position_keeping"},
 			wantExitCode: 0,
 			wantStdout: []string{
-				"CREATE SCHEMA IF NOT EXISTS current_account",
-				"CREATE SCHEMA IF NOT EXISTS position_keeping",
+				"CREATE TABLE",
 				"account",                // singular table name for search_path routing
 				"financial_position_log", // singular table name for search_path routing
 				"transaction_log_entry",  // singular table name for search_path routing
@@ -82,7 +82,7 @@ func TestAtlasLoaderBinary(t *testing.T) {
 				// GORM requires the full FK chain for proper constraint generation
 			},
 			wantNotStdout: []string{
-				// All necessary models are included for FK integrity
+				"CREATE SCHEMA", // No schema statements - tenant provisioner creates schemas
 			},
 		},
 		{
@@ -155,9 +155,9 @@ func TestOutputFormat(t *testing.T) {
 
 		output := stdout.String()
 
-		// Verify SQL statement format
-		assert.True(t, strings.HasPrefix(output, "CREATE SCHEMA"), "output should start with CREATE SCHEMA")
-		assert.Contains(t, output, "CREATE TABLE", "output should contain CREATE TABLE")
+		// Verify SQL statement format - output contains only table DDL, no schema creation
+		assert.True(t, strings.HasPrefix(output, "CREATE TABLE"), "output should start with CREATE TABLE")
+		assert.NotContains(t, output, "CREATE SCHEMA", "output should not contain CREATE SCHEMA - tenant provisioner handles schema creation")
 		assert.Contains(t, output, "PRIMARY KEY", "output should contain PRIMARY KEY")
 
 		// Verify unqualified singular table names for search_path routing


### PR DESCRIPTION
## Summary
- Remove CREATE SCHEMA statements for service-named schemas (current_account, position_keeping, financial_accounting) from atlas-loader
- These were vestiges from the legacy shared-database architecture
- Tenant provisioner is now the sole authority for schema creation (org_{tenant_id} schemas)

## Task Master Reference
- **Tag**: database-per-service
- **Task ID**: 13
- **Depends on**: Task 11 (Update tenant service provisioner)

## Changes Made
- `utilities/atlas-loader/main.go`: Removed the CREATE SCHEMA prepending logic (lines 99-123)
- `utilities/atlas-loader/main_test.go`: Updated test expectations to verify no CREATE SCHEMA statements in output

## Architecture
With database-per-service:
1. Each service has its own database (meridian_current_account, meridian_party, etc.)
2. Tenant provisioner creates `org_{tenant_id}` schemas before running migrations
3. Tables use unqualified names with `search_path` routing to tenant schemas
4. atlas-loader now outputs only table DDL, no schema creation

## Test Plan
- [x] All atlas-loader unit tests pass
- [x] Verified output for current_account, position_keeping, and financial_accounting filters contains no CREATE SCHEMA
- [x] Verified output starts with CREATE TABLE