### PR TITLE
feat: add migration reconciliation for existing tenant schemas (task 14)

### DIFF
--- a/api/proto/meridian/tenant/v1/tenant.proto
+++ b/api/proto/meridian/tenant/v1/tenant.proto
@@ -232,8 +232,10 @@ message ListTenantsResponse {
 message ReconcileMigrationsRequest {
   // tenant_id is the specific tenant to reconcile (optional).
   // If empty, reconciles all active tenants.
+  // If provided, must match the tenant ID pattern (alphanumeric + underscore).
   string tenant_id = 1 [(buf.validate.field).string = {
     max_len: 50
+    // Pattern allows empty string for "reconcile all active tenants" mode
     pattern: "^[a-zA-Z0-9_]*$"
   }];
 }

--- a/api/proto/meridian/tenant/v1/tenant.proto
+++ b/api/proto/meridian/tenant/v1/tenant.proto
@@ -228,6 +228,25 @@ message ListTenantsResponse {
   string next_page_token = 2;
 }
 
+// ReconcileMigrationsRequest is the request to apply new migrations to existing tenants.
+message ReconcileMigrationsRequest {
+  // tenant_id is the specific tenant to reconcile (optional).
+  // If empty, reconciles all active tenants.
+  string tenant_id = 1 [(buf.validate.field).string = {
+    max_len: 50
+    pattern: "^[a-zA-Z0-9_]*$"
+  }];
+}
+
+// ReconcileMigrationsResponse is the response after reconciling migrations.
+message ReconcileMigrationsResponse {
+  // reconciled_count is the number of tenants that had migrations applied.
+  int32 reconciled_count = 1;
+
+  // errors contains per-tenant error messages (reconciliation continues despite failures).
+  repeated string errors = 2;
+}
+
 // TenantService provides platform tenant lifecycle management.
 //
 // Design Notes:
@@ -271,6 +290,21 @@ service TenantService {
   rpc ListTenants(ListTenantsRequest) returns (ListTenantsResponse) {
     option (google.api.http) = {
       get: "/v1/tenants"
+    };
+  }
+
+  // ReconcileMigrations applies new migrations to existing tenant schemas.
+  // When services add new migrations after tenants are created, existing tenant
+  // schemas may be missing these migrations. This operation detects and applies
+  // new migrations to bring tenant schemas up to date.
+  rpc ReconcileMigrations(ReconcileMigrationsRequest) returns (ReconcileMigrationsResponse) {
+    option (google.api.http) = {
+      post: "/v1/tenants:reconcile-migrations"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Reconcile migrations for tenant schemas"
+      description: "Applies new migrations to existing tenant schemas. Safe to call multiple times."
     };
   }
 }

--- a/services/tenant/provisioner/mock_provisioner.go
+++ b/services/tenant/provisioner/mock_provisioner.go
@@ -249,5 +249,30 @@ func (m *MockProvisioner) SetStatus(status *ProvisioningStatus) {
 	m.statuses[status.TenantID.String()] = status
 }
 
+// ReconcileMigrations simulates reconciling migrations for existing tenants.
+// In the mock, this is a no-op that returns success. Tests can verify calls
+// via ReconciliationCalls if needed.
+func (m *MockProvisioner) ReconcileMigrations(_ context.Context, tenantID *tenant.TenantID) (int, []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if tenantID != nil {
+		// Single tenant reconciliation
+		if status, exists := m.statuses[tenantID.String()]; exists && status.State == StateActive {
+			return 1, nil
+		}
+		return 0, nil
+	}
+
+	// All tenants reconciliation - count active tenants
+	count := 0
+	for _, status := range m.statuses {
+		if status.State == StateActive {
+			count++
+		}
+	}
+	return count, nil
+}
+
 // Ensure MockProvisioner implements SchemaProvisioner.
 var _ SchemaProvisioner = (*MockProvisioner)(nil)

--- a/services/tenant/provisioner/postgres_provisioner.go
+++ b/services/tenant/provisioner/postgres_provisioner.go
@@ -439,6 +439,248 @@ func (p *PostgresProvisioner) GetProvisioningStatus(ctx context.Context, tenantI
 	return p.getProvisioningStatusLocked(ctx, tenantID)
 }
 
+// ReconcileMigrations detects and applies new migrations to existing tenant schemas.
+//
+// This method addresses schema drift that occurs when services add new migrations
+// after tenants are created. It scans migration directories, compares with
+// the recorded MigrationVersion for each service, and applies any newer migrations.
+//
+// If tenantID is nil, all active tenants are reconciled. Individual tenant failures
+// don't stop processing of other tenants - errors are collected and returned.
+func (p *PostgresProvisioner) ReconcileMigrations(ctx context.Context, tenantID *tenant.TenantID) (int, []string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	logger := p.logger.With("operation", "reconcile_migrations")
+
+	// Determine which tenants to reconcile
+	tenantsToReconcile, err := p.getTenantsToReconcile(ctx, tenantID)
+	if err != nil {
+		logger.Error("failed to get tenants to reconcile", "error", err)
+		return 0, []string{fmt.Sprintf("get tenants: %v", err)}
+	}
+
+	if len(tenantsToReconcile) == 0 {
+		logger.Info("no tenants to reconcile")
+		return 0, nil
+	}
+
+	logger.Info("starting migration reconciliation", "tenant_count", len(tenantsToReconcile))
+
+	var (
+		reconciledCount int
+		errors          []string
+	)
+
+	for _, tid := range tenantsToReconcile {
+		if ctx.Err() != nil {
+			errors = append(errors, fmt.Sprintf("context cancelled: %v", ctx.Err()))
+			break
+		}
+
+		applied, err := p.reconcileTenantMigrations(ctx, tid)
+		if err != nil {
+			logger.Error("failed to reconcile tenant",
+				"tenant_id", tid.String(),
+				"error", err)
+			errors = append(errors, fmt.Sprintf("%s: %v", tid.String(), err))
+			continue
+		}
+
+		if applied {
+			reconciledCount++
+			logger.Info("tenant migrations reconciled", "tenant_id", tid.String())
+		}
+	}
+
+	logger.Info("migration reconciliation completed",
+		"reconciled_count", reconciledCount,
+		"error_count", len(errors))
+
+	return reconciledCount, errors
+}
+
+// getTenantsToReconcile returns the list of tenant IDs to reconcile.
+// If tenantID is non-nil, returns just that tenant. Otherwise returns all active tenants.
+func (p *PostgresProvisioner) getTenantsToReconcile(ctx context.Context, tenantID *tenant.TenantID) ([]tenant.TenantID, error) {
+	if tenantID != nil {
+		return []tenant.TenantID{*tenantID}, nil
+	}
+
+	// Query all active tenants from the platform database
+	var entities []provisioningEntity
+	result := p.platformDB.WithContext(ctx).
+		Where("state = ?", string(StateActive)).
+		Find(&entities)
+	if result.Error != nil {
+		return nil, fmt.Errorf("query active tenants: %w", result.Error)
+	}
+
+	tenants := make([]tenant.TenantID, 0, len(entities))
+	for _, entity := range entities {
+		tid, err := tenant.NewTenantID(entity.TenantID)
+		if err != nil {
+			p.logger.Warn("invalid tenant ID in provisioning table",
+				"tenant_id", entity.TenantID,
+				"error", err)
+			continue
+		}
+		tenants = append(tenants, tid)
+	}
+
+	return tenants, nil
+}
+
+// reconcileTenantMigrations applies new migrations to a single tenant.
+// Returns true if any migrations were applied, false otherwise.
+func (p *PostgresProvisioner) reconcileTenantMigrations(ctx context.Context, tenantID tenant.TenantID) (bool, error) {
+	logger := p.logger.With("tenant_id", tenantID.String())
+
+	// Get current provisioning status
+	status, err := p.getProvisioningStatusLocked(ctx, tenantID)
+	if err != nil {
+		return false, fmt.Errorf("get provisioning status: %w", err)
+	}
+
+	// Only reconcile active tenants
+	if status.State != StateActive {
+		logger.Debug("skipping non-active tenant", "state", status.State)
+		return false, nil
+	}
+
+	schemaName := tenantID.SchemaName()
+	anyMigrationsApplied := false
+
+	// Check each service for new migrations
+	for i, svc := range p.config.Services {
+		// Get the current version for this service
+		currentVersion := ""
+		if i < len(status.Services) {
+			currentVersion = status.Services[i].MigrationVersion
+		}
+
+		// Read all migration files
+		migrations, err := p.readMigrationFiles(svc.MigrationPath)
+		if err != nil {
+			return anyMigrationsApplied, fmt.Errorf("read migrations for %s: %w", svc.Name, err)
+		}
+
+		// Filter migrations newer than current version
+		newMigrations := filterMigrationsAfter(migrations, currentVersion)
+
+		if len(newMigrations) == 0 {
+			logger.Debug("no new migrations for service", "service", svc.Name)
+			continue
+		}
+
+		logger.Info("applying new migrations",
+			"service", svc.Name,
+			"current_version", currentVersion,
+			"new_migration_count", len(newMigrations))
+
+		// Get the database connection for this service
+		serviceDB, ok := p.serviceDbs[svc.Name]
+		if !ok {
+			return anyMigrationsApplied, fmt.Errorf("%w: %s", ErrServiceDatabaseNotFound, svc.Name)
+		}
+
+		// Apply new migrations
+		latestVersion, err := p.applyMigrationList(ctx, serviceDB, schemaName, newMigrations)
+		if err != nil {
+			return anyMigrationsApplied, fmt.Errorf("apply migrations for %s: %w", svc.Name, err)
+		}
+
+		// Update service status
+		if i < len(status.Services) {
+			status.Services[i].MigrationVersion = latestVersion
+		}
+		anyMigrationsApplied = true
+
+		logger.Debug("service migrations applied",
+			"service", svc.Name,
+			"new_version", latestVersion)
+	}
+
+	// Save updated status if any migrations were applied
+	if anyMigrationsApplied {
+		status.UpdatedAt = time.Now()
+		if err := p.saveProvisioningStatus(ctx, status); err != nil {
+			return true, fmt.Errorf("save updated status: %w", err)
+		}
+	}
+
+	return anyMigrationsApplied, nil
+}
+
+// filterMigrationsAfter returns migrations with version > currentVersion.
+// Migrations are already sorted by filename/version from readMigrationFiles.
+func filterMigrationsAfter(migrations []migration, currentVersion string) []migration {
+	if currentVersion == "" {
+		// No migrations applied yet - but we're in reconciliation, so the tenant
+		// should already have been provisioned. Return empty to avoid re-applying
+		// all migrations (they should already exist).
+		// This handles edge cases where MigrationVersion wasn't recorded.
+		return nil
+	}
+
+	var result []migration
+	for _, mig := range migrations {
+		if mig.Version > currentVersion {
+			result = append(result, mig)
+		}
+	}
+	return result
+}
+
+// applyMigrationList applies a specific list of migrations to a tenant schema.
+// This is extracted from applyServiceMigrationsToDB to support both initial
+// provisioning (all migrations) and reconciliation (subset of migrations).
+func (p *PostgresProvisioner) applyMigrationList(ctx context.Context, db *gorm.DB, schemaName string, migrations []migration) (string, error) {
+	if len(migrations) == 0 {
+		return "", nil
+	}
+
+	// Set search_path to the tenant schema for unqualified table names
+	setPathQuery := fmt.Sprintf("SET search_path TO %s, public", quoteIdentifier(schemaName))
+
+	var lastVersion string
+	for _, mig := range migrations {
+		if ctx.Err() != nil {
+			return lastVersion, ctx.Err()
+		}
+
+		// Execute migration within a transaction
+		err := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			if err := tx.Exec(setPathQuery).Error; err != nil {
+				return fmt.Errorf("set search_path: %w", err)
+			}
+
+			processedSQL := p.processMigrationSQL(mig.Content, schemaName)
+			statements := splitSQLStatements(processedSQL)
+
+			for _, stmt := range statements {
+				if err := tx.Exec(stmt).Error; err != nil {
+					return fmt.Errorf("execute migration %s: %w", mig.Filename, err)
+				}
+			}
+
+			return nil
+		})
+		if err != nil {
+			// Check if error is due to existing objects (idempotency)
+			if isAlreadyExistsError(err) {
+				lastVersion = mig.Version
+				continue
+			}
+			return lastVersion, err
+		}
+
+		lastVersion = mig.Version
+	}
+
+	return lastVersion, nil
+}
+
 // createSchemaInDB creates the org_{tenant_id} schema in the specified database.
 func (p *PostgresProvisioner) createSchemaInDB(ctx context.Context, db *gorm.DB, schemaName string) error {
 	query := fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", quoteIdentifier(schemaName))

--- a/services/tenant/provisioner/postgres_provisioner.go
+++ b/services/tenant/provisioner/postgres_provisioner.go
@@ -469,12 +469,12 @@ func (p *PostgresProvisioner) ReconcileMigrations(ctx context.Context, tenantID 
 
 	var (
 		reconciledCount int
-		errors          []string
+		errs            []string
 	)
 
 	for _, tid := range tenantsToReconcile {
 		if ctx.Err() != nil {
-			errors = append(errors, fmt.Sprintf("context cancelled: %v", ctx.Err()))
+			errs = append(errs, fmt.Sprintf("context cancelled: %v", ctx.Err()))
 			break
 		}
 
@@ -483,7 +483,7 @@ func (p *PostgresProvisioner) ReconcileMigrations(ctx context.Context, tenantID 
 			logger.Error("failed to reconcile tenant",
 				"tenant_id", tid.String(),
 				"error", err)
-			errors = append(errors, fmt.Sprintf("%s: %v", tid.String(), err))
+			errs = append(errs, fmt.Sprintf("%s: %v", tid.String(), err))
 			continue
 		}
 
@@ -495,9 +495,9 @@ func (p *PostgresProvisioner) ReconcileMigrations(ctx context.Context, tenantID 
 
 	logger.Info("migration reconciliation completed",
 		"reconciled_count", reconciledCount,
-		"error_count", len(errors))
+		"error_count", len(errs))
 
-	return reconciledCount, errors
+	return reconciledCount, errs
 }
 
 // getTenantsToReconcile returns the list of tenant IDs to reconcile.
@@ -552,11 +552,21 @@ func (p *PostgresProvisioner) reconcileTenantMigrations(ctx context.Context, ten
 	anyMigrationsApplied := false
 
 	// Check each service for new migrations
-	for i, svc := range p.config.Services {
-		// Get the current version for this service
+	for _, svc := range p.config.Services {
+		// Get the current version for this service by name (not index)
+		// This handles cases where services are added/removed from config after provisioning
+		svcStatus := status.getServiceStatus(svc.Name)
 		currentVersion := ""
-		if i < len(status.Services) {
-			currentVersion = status.Services[i].MigrationVersion
+		if svcStatus != nil {
+			currentVersion = svcStatus.MigrationVersion
+		}
+
+		// Warn if service has no recorded version - could indicate config drift
+		if currentVersion == "" {
+			logger.Warn("service has no recorded migration version, skipping reconciliation",
+				"service", svc.Name,
+				"hint", "this may indicate the service was added after initial provisioning")
+			continue
 		}
 
 		// Read all migration files
@@ -590,9 +600,9 @@ func (p *PostgresProvisioner) reconcileTenantMigrations(ctx context.Context, ten
 			return anyMigrationsApplied, fmt.Errorf("apply migrations for %s: %w", svc.Name, err)
 		}
 
-		// Update service status
-		if i < len(status.Services) {
-			status.Services[i].MigrationVersion = latestVersion
+		// Update service status by name
+		if svcStatus != nil {
+			svcStatus.MigrationVersion = latestVersion
 		}
 		anyMigrationsApplied = true
 
@@ -614,12 +624,11 @@ func (p *PostgresProvisioner) reconcileTenantMigrations(ctx context.Context, ten
 
 // filterMigrationsAfter returns migrations with version > currentVersion.
 // Migrations are already sorted by filename/version from readMigrationFiles.
+//
+// If currentVersion is empty, returns nil as a safety guard. The caller
+// (reconcileTenantMigrations) handles empty versions explicitly with a warning.
 func filterMigrationsAfter(migrations []migration, currentVersion string) []migration {
 	if currentVersion == "" {
-		// No migrations applied yet - but we're in reconciliation, so the tenant
-		// should already have been provisioned. Return empty to avoid re-applying
-		// all migrations (they should already exist).
-		// This handles edge cases where MigrationVersion wasn't recorded.
 		return nil
 	}
 

--- a/services/tenant/provisioner/postgres_provisioner_test.go
+++ b/services/tenant/provisioner/postgres_provisioner_test.go
@@ -874,3 +874,260 @@ func TestQuoteIdentifier(t *testing.T) {
 		})
 	}
 }
+
+// TestPostgresProvisioner_ReconcileMigrations tests the migration reconciliation feature.
+func TestPostgresProvisioner_ReconcileMigrations(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	// Create test tenant
+	tenantID := tenant.MustNewTenantID("reconcile_test")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	// Create initial migrations
+	svcDir := filepath.Join(tc.migDir, "reconcile-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+	createTestMigration(t, svcDir, "20251201000000_initial.sql", `
+		CREATE TABLE initial_table (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			name VARCHAR(100) NOT NULL
+		);
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "reconcile-service", MigrationPath: svcDir, DatabaseURL: tc.connStr}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	prov, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
+	defer prov.Close()
+
+	// Initial provisioning
+	err = prov.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Verify initial state
+	status, err := prov.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, "20251201000000", status.Services[0].MigrationVersion)
+
+	// Add a new migration
+	createTestMigration(t, svcDir, "20251202000000_add_column.sql", `
+		ALTER TABLE initial_table ADD COLUMN description TEXT;
+	`)
+
+	// Reconcile migrations
+	count, errs := prov.ReconcileMigrations(context.Background(), &tenantID)
+	assert.Empty(t, errs, "Reconciliation should succeed without errors")
+	assert.Equal(t, 1, count, "Should have reconciled 1 tenant")
+
+	// Verify new migration version
+	status, err = prov.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, "20251202000000", status.Services[0].MigrationVersion)
+
+	// Verify column was added
+	var columnExists bool
+	tc.db.Raw(`
+		SELECT EXISTS(
+			SELECT 1 FROM information_schema.columns
+			WHERE table_schema = ? AND table_name = 'initial_table' AND column_name = 'description'
+		)
+	`, tenantID.SchemaName()).Scan(&columnExists)
+	assert.True(t, columnExists, "Column should exist after reconciliation")
+}
+
+// TestPostgresProvisioner_ReconcileMigrations_NoNewMigrations tests that reconciliation
+// is a no-op when there are no new migrations.
+func TestPostgresProvisioner_ReconcileMigrations_NoNewMigrations(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := tenant.MustNewTenantID("no_changes")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "noop-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+	createTestMigration(t, svcDir, "20251201000000_only.sql", `
+		CREATE TABLE only_table (id UUID PRIMARY KEY DEFAULT gen_random_uuid());
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "noop-service", MigrationPath: svcDir, DatabaseURL: tc.connStr}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	prov, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
+	defer prov.Close()
+
+	// Initial provisioning
+	err = prov.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Reconcile - should be a no-op
+	count, errs := prov.ReconcileMigrations(context.Background(), &tenantID)
+	assert.Empty(t, errs)
+	assert.Equal(t, 0, count, "No tenants should have been reconciled")
+
+	// Version should remain unchanged
+	status, err := prov.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, "20251201000000", status.Services[0].MigrationVersion)
+}
+
+// TestPostgresProvisioner_ReconcileMigrations_AllTenants tests reconciling all active tenants.
+func TestPostgresProvisioner_ReconcileMigrations_AllTenants(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	// Create multiple tenants
+	tenant1 := tenant.MustNewTenantID("tenant_one")
+	tenant2 := tenant.MustNewTenantID("tenant_two")
+	createTestTenant(t, tc.db, tenant1.String())
+	createTestTenant(t, tc.db, tenant2.String())
+
+	svcDir := filepath.Join(tc.migDir, "multi-tenant-svc")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+	createTestMigration(t, svcDir, "20251201000000_base.sql", `
+		CREATE TABLE base_table (id UUID PRIMARY KEY DEFAULT gen_random_uuid());
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "multi-tenant-svc", MigrationPath: svcDir, DatabaseURL: tc.connStr}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	prov, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
+	defer prov.Close()
+
+	// Provision both tenants
+	err = prov.ProvisionSchemas(context.Background(), tenant1)
+	require.NoError(t, err)
+	err = prov.ProvisionSchemas(context.Background(), tenant2)
+	require.NoError(t, err)
+
+	// Add a new migration
+	createTestMigration(t, svcDir, "20251203000000_add_index.sql", `
+		CREATE INDEX idx_base_table_id ON base_table(id);
+	`)
+
+	// Reconcile all tenants (pass nil for tenantID)
+	count, errs := prov.ReconcileMigrations(context.Background(), nil)
+	assert.Empty(t, errs)
+	assert.Equal(t, 2, count, "Should have reconciled 2 tenants")
+
+	// Verify both tenants have new version
+	status1, err := prov.GetProvisioningStatus(context.Background(), tenant1)
+	require.NoError(t, err)
+	assert.Equal(t, "20251203000000", status1.Services[0].MigrationVersion)
+
+	status2, err := prov.GetProvisioningStatus(context.Background(), tenant2)
+	require.NoError(t, err)
+	assert.Equal(t, "20251203000000", status2.Services[0].MigrationVersion)
+}
+
+// TestPostgresProvisioner_ReconcileMigrations_SkipsNonActive tests that reconciliation
+// skips tenants that are not in active state.
+func TestPostgresProvisioner_ReconcileMigrations_SkipsNonActive(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	tenantID := tenant.MustNewTenantID("deprovisioned_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	svcDir := filepath.Join(tc.migDir, "skip-service")
+	require.NoError(t, os.MkdirAll(svcDir, 0o755))
+	createTestMigration(t, svcDir, "20251201000000_init.sql", `
+		CREATE TABLE skip_table (id UUID PRIMARY KEY DEFAULT gen_random_uuid());
+	`)
+
+	config := &Config{
+		Services:            []ServiceConfig{{Name: "skip-service", MigrationPath: svcDir, DatabaseURL: tc.connStr}},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	prov, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
+	defer prov.Close()
+
+	// Provision tenant
+	err = prov.ProvisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Deprovision tenant
+	err = prov.DeprovisionSchemas(context.Background(), tenantID)
+	require.NoError(t, err)
+
+	// Add new migration
+	createTestMigration(t, svcDir, "20251202000000_new.sql", `
+		ALTER TABLE skip_table ADD COLUMN foo TEXT;
+	`)
+
+	// Reconcile - should skip deprovisioned tenant
+	count, errs := prov.ReconcileMigrations(context.Background(), &tenantID)
+	assert.Empty(t, errs)
+	assert.Equal(t, 0, count, "Deprovisioned tenant should be skipped")
+
+	// Version should remain at initial
+	status, err := prov.GetProvisioningStatus(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, "20251201000000", status.Services[0].MigrationVersion)
+}
+
+// TestFilterMigrationsAfter tests the filterMigrationsAfter helper function.
+func TestFilterMigrationsAfter(t *testing.T) {
+	tests := []struct {
+		name           string
+		migrations     []migration
+		currentVersion string
+		expectedCount  int
+		expectedFirst  string
+	}{
+		{
+			name: "filters older migrations",
+			migrations: []migration{
+				{Version: "20251201000000", Filename: "20251201000000_a.sql"},
+				{Version: "20251202000000", Filename: "20251202000000_b.sql"},
+				{Version: "20251203000000", Filename: "20251203000000_c.sql"},
+			},
+			currentVersion: "20251201000000",
+			expectedCount:  2,
+			expectedFirst:  "20251202000000",
+		},
+		{
+			name: "returns empty when no newer migrations",
+			migrations: []migration{
+				{Version: "20251201000000", Filename: "20251201000000_a.sql"},
+			},
+			currentVersion: "20251201000000",
+			expectedCount:  0,
+		},
+		{
+			name: "returns empty for empty current version",
+			migrations: []migration{
+				{Version: "20251201000000", Filename: "20251201000000_a.sql"},
+			},
+			currentVersion: "",
+			expectedCount:  0,
+		},
+		{
+			name:           "handles empty migrations list",
+			migrations:     []migration{},
+			currentVersion: "20251201000000",
+			expectedCount:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterMigrationsAfter(tt.migrations, tt.currentVersion)
+			assert.Len(t, result, tt.expectedCount)
+			if tt.expectedCount > 0 {
+				assert.Equal(t, tt.expectedFirst, result[0].Version)
+			}
+		})
+	}
+}

--- a/services/tenant/provisioner/provisioner.go
+++ b/services/tenant/provisioner/provisioner.go
@@ -121,6 +121,25 @@ type SchemaProvisioner interface {
 	// Returns ErrProvisioningStatusNotFound if no provisioning record exists.
 	// Note: Deprovisioned tenants still have a status record (for audit trail).
 	GetProvisioningStatus(ctx context.Context, tenantID tenant.TenantID) (*ProvisioningStatus, error)
+
+	// ReconcileMigrations applies any new migrations that have been added since
+	// tenant provisioning for the specified tenant(s).
+	//
+	// When services add new migrations after tenants are created, existing tenant
+	// schemas may not have these migrations applied. This method detects and applies
+	// new migrations to bring tenant schemas up to date.
+	//
+	// Idempotency: Safe to call multiple times; already-applied migrations are skipped
+	// based on the MigrationVersion recorded in ServiceSchemaStatus.
+	//
+	// Parameters:
+	//   - tenantID: If non-nil, reconciles only that tenant. If nil, reconciles all
+	//     active tenants.
+	//
+	// Returns:
+	//   - reconciledCount: Number of tenants that had migrations applied
+	//   - errors: Per-tenant errors (reconciliation continues despite individual failures)
+	ReconcileMigrations(ctx context.Context, tenantID *tenant.TenantID) (reconciledCount int, errors []string)
 }
 
 // ProvisioningState represents the lifecycle state of schema provisioning.

--- a/services/tenant/provisioner/provisioner.go
+++ b/services/tenant/provisioner/provisioner.go
@@ -214,6 +214,18 @@ type ProvisioningStatus struct {
 	DeprovisionedAt *time.Time
 }
 
+// getServiceStatus returns the status for a specific service by name.
+// Returns nil if the service is not found in the status (e.g., service was added
+// to config after this tenant was provisioned).
+func (s *ProvisioningStatus) getServiceStatus(serviceName string) *ServiceSchemaStatus {
+	for i := range s.Services {
+		if s.Services[i].ServiceName == serviceName {
+			return &s.Services[i]
+		}
+	}
+	return nil
+}
+
 // ServiceSchemaStatus tracks provisioning progress for a single service's schema.
 type ServiceSchemaStatus struct {
 	// ServiceName identifies the BIAN service (e.g., "party", "current-account").

--- a/services/tenant/service/grpc_service.go
+++ b/services/tenant/service/grpc_service.go
@@ -356,3 +356,36 @@ func (s *Service) toDomainStatus(status pb.TenantStatus) (domain.Status, error) 
 		return "", ErrUnknownStatus
 	}
 }
+
+// ReconcileMigrations applies new migrations to existing tenant schemas.
+// When services add new migrations after tenants are created, existing tenant
+// schemas may be missing these migrations. This operation detects and applies
+// new migrations to bring tenant schemas up to date.
+func (s *Service) ReconcileMigrations(ctx context.Context, req *pb.ReconcileMigrationsRequest) (*pb.ReconcileMigrationsResponse, error) {
+	if s.provisioner == nil {
+		return nil, status.Error(codes.FailedPrecondition, "schema provisioning not enabled")
+	}
+
+	// Parse tenant ID if provided
+	var tenantID *tenant.TenantID
+	if req.TenantId != "" {
+		tid, err := tenant.NewTenantID(req.TenantId)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid tenant_id: %v", err)
+		}
+		tenantID = &tid
+	}
+
+	// Perform reconciliation
+	reconciledCount, errs := s.provisioner.ReconcileMigrations(ctx, tenantID)
+
+	s.logger.Info("migration reconciliation completed",
+		"tenant_id", req.TenantId,
+		"reconciled_count", reconciledCount,
+		"error_count", len(errs))
+
+	return &pb.ReconcileMigrationsResponse{
+		ReconciledCount: int32(reconciledCount),
+		Errors:          errs,
+	}, nil
+}

--- a/services/tenant/service/grpc_service.go
+++ b/services/tenant/service/grpc_service.go
@@ -361,6 +361,10 @@ func (s *Service) toDomainStatus(status pb.TenantStatus) (domain.Status, error) 
 // When services add new migrations after tenants are created, existing tenant
 // schemas may be missing these migrations. This operation detects and applies
 // new migrations to bring tenant schemas up to date.
+//
+// TODO: Add authorization check - this is an admin/operator operation that
+// modifies database schemas across tenants and should be restricted to
+// privileged roles (e.g., platform-admin) once the auth framework is in place.
 func (s *Service) ReconcileMigrations(ctx context.Context, req *pb.ReconcileMigrationsRequest) (*pb.ReconcileMigrationsResponse, error) {
 	if s.provisioner == nil {
 		return nil, status.Error(codes.FailedPrecondition, "schema provisioning not enabled")


### PR DESCRIPTION
## Summary

- Add mechanism to detect and apply new migrations to existing tenant schemas
- When services add new migrations after tenants are created, reconciliation brings schemas up to date
- Safe to call multiple times (idempotent) - already-applied migrations are skipped

## Task Master Reference

- **Tag**: database-per-service
- **Task ID**: 14

## Changes Made

### Interface Changes
- Added `ReconcileMigrations(ctx, *tenant.TenantID) (count, errors)` to `SchemaProvisioner` interface
- Updated `MockProvisioner` to implement the new method

### Implementation (`postgres_provisioner.go`)
- `ReconcileMigrations`: Main entry point supporting single tenant or all-active-tenants modes
- `getTenantsToReconcile`: Queries platform DB for active tenants
- `reconcileTenantMigrations`: Applies new migrations to a single tenant
- `filterMigrationsAfter`: Filters migrations newer than current version
- `applyMigrationList`: Refactored migration application for reuse

### gRPC Endpoint
- Added `ReconcileMigrations` RPC to TenantService
- HTTP: `POST /v1/tenants:reconcile-migrations`
- Request: Optional `tenant_id` (empty = all active tenants)
- Response: `reconciled_count` and per-tenant `errors`

### Tests
- `TestPostgresProvisioner_ReconcileMigrations`: Basic reconciliation flow
- `TestPostgresProvisioner_ReconcileMigrations_NoNewMigrations`: No-op case
- `TestPostgresProvisioner_ReconcileMigrations_AllTenants`: Multi-tenant batch
- `TestPostgresProvisioner_ReconcileMigrations_SkipsNonActive`: State validation
- `TestFilterMigrationsAfter`: Helper function unit tests

## Test Plan

- [x] All new reconciliation tests pass
- [x] Existing provisioner tests pass
- [x] golangci-lint passes
- [x] buf lint passes (no breaking proto changes)

## Usage

```bash
# Reconcile all active tenants
grpcurl -d '{}' localhost:9090 meridian.tenant.v1.TenantService/ReconcileMigrations

# Reconcile specific tenant
grpcurl -d '{"tenant_id": "acme_bank"}' localhost:9090 meridian.tenant.v1.TenantService/ReconcileMigrations

# Via REST
curl -X POST localhost:8080/v1/tenants:reconcile-migrations -d '{"tenant_id": ""}'
```