### PR TITLE
feat: add authorization check to ReconcileMigrations endpoint

### DIFF
--- a/services/tenant/service/grpc_service.go
+++ b/services/tenant/service/grpc_service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/meridianhub/meridian/services/tenant/clients"
 	"github.com/meridianhub/meridian/services/tenant/domain"
 	"github.com/meridianhub/meridian/services/tenant/provisioner"
+	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -362,10 +363,29 @@ func (s *Service) toDomainStatus(status pb.TenantStatus) (domain.Status, error) 
 // schemas may be missing these migrations. This operation detects and applies
 // new migrations to bring tenant schemas up to date.
 //
-// TODO: Add authorization check - this is an admin/operator operation that
-// modifies database schemas across tenants and should be restricted to
-// privileged roles (e.g., platform-admin) once the auth framework is in place.
+// This endpoint requires platform-admin or super-admin role authorization.
+// Migration reconciliation is a platform-layer operation that affects all tenants
+// globally, equivalent to DBA-level privileges.
 func (s *Service) ReconcileMigrations(ctx context.Context, req *pb.ReconcileMigrationsRequest) (*pb.ReconcileMigrationsResponse, error) {
+	// Authorization check - must be performed before any business logic.
+	// ReconcileMigrations is a platform-layer operation requiring elevated privileges.
+	claims, ok := auth.GetClaimsFromContext(ctx)
+	if !ok {
+		s.logger.Warn("migration reconciliation attempted without authentication claims")
+		return nil, status.Error(codes.Unauthenticated, "authentication required")
+	}
+
+	if !claims.HasRole(auth.RolePlatformAdmin) && !claims.HasRole(auth.RoleSuperAdmin) {
+		s.logger.Warn("unauthorized migration reconciliation attempt",
+			"user_id", claims.UserID,
+			"roles", claims.Roles)
+		return nil, status.Error(codes.PermissionDenied, "platform-admin or super-admin role required for migration operations")
+	}
+
+	s.logger.Info("migration reconciliation authorized",
+		"user_id", claims.UserID,
+		"roles", claims.Roles)
+
 	if s.provisioner == nil {
 		return nil, status.Error(codes.FailedPrecondition, "schema provisioning not enabled")
 	}

--- a/services/tenant/service/grpc_service_test.go
+++ b/services/tenant/service/grpc_service_test.go
@@ -12,6 +12,7 @@ import (
 	pb "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
 	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
 	"github.com/meridianhub/meridian/services/tenant/provisioner"
+	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -569,4 +570,224 @@ func TestService_InitiateTenant_WithoutProvisioner(t *testing.T) {
 	// Should be active immediately (no provisioning)
 	assert.Equal(t, pb.TenantStatus_TENANT_STATUS_ACTIVE, resp.Tenant.Status)
 	assert.Equal(t, int32(1), resp.Tenant.Version) // Only one version (created)
+}
+
+// Tests for ReconcileMigrations authorization
+
+func TestReconcileMigrations_Authorization(t *testing.T) {
+	// Create a mock provisioner
+	mockProvisioner := provisioner.NewMockProvisioner([]provisioner.ServiceConfig{
+		{Name: "party", MigrationPath: "/migrations/party"},
+	})
+
+	// Create service with mock provisioner
+	svc := NewService(nil, mockProvisioner, nil, slog.Default())
+
+	tests := []struct {
+		name         string
+		claims       *auth.Claims
+		expectError  bool
+		expectedCode codes.Code
+		expectedMsg  string
+	}{
+		{
+			name: "platform-admin allowed",
+			claims: &auth.Claims{
+				UserID: "admin-123",
+				Roles:  []string{auth.RolePlatformAdmin},
+			},
+			expectError: false,
+		},
+		{
+			name: "super-admin allowed",
+			claims: &auth.Claims{
+				UserID: "admin-456",
+				Roles:  []string{auth.RoleSuperAdmin},
+			},
+			expectError: false,
+		},
+		{
+			name: "platform-admin with other roles allowed",
+			claims: &auth.Claims{
+				UserID: "admin-789",
+				Roles:  []string{"user", auth.RolePlatformAdmin, "viewer"},
+			},
+			expectError: false,
+		},
+		{
+			name: "operator denied",
+			claims: &auth.Claims{
+				UserID: "user-123",
+				Roles:  []string{"operator"},
+			},
+			expectError:  true,
+			expectedCode: codes.PermissionDenied,
+			expectedMsg:  "platform-admin or super-admin role required",
+		},
+		{
+			name: "tenant admin denied",
+			claims: &auth.Claims{
+				UserID: "user-456",
+				Roles:  []string{"admin"}, // tenant-scoped admin, not platform-admin
+			},
+			expectError:  true,
+			expectedCode: codes.PermissionDenied,
+			expectedMsg:  "platform-admin or super-admin role required",
+		},
+		{
+			name: "no roles denied",
+			claims: &auth.Claims{
+				UserID: "user-789",
+				Roles:  []string{},
+			},
+			expectError:  true,
+			expectedCode: codes.PermissionDenied,
+			expectedMsg:  "platform-admin or super-admin role required",
+		},
+		{
+			name: "user role denied",
+			claims: &auth.Claims{
+				UserID: "user-101",
+				Roles:  []string{"user", "viewer", "auditor"},
+			},
+			expectError:  true,
+			expectedCode: codes.PermissionDenied,
+			expectedMsg:  "platform-admin or super-admin role required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create context with claims
+			ctx := context.WithValue(context.Background(), auth.ClaimsContextKey, tt.claims)
+
+			// Execute
+			resp, err := svc.ReconcileMigrations(ctx, &pb.ReconcileMigrationsRequest{})
+
+			// Assert
+			if tt.expectError {
+				require.Error(t, err)
+				st, ok := status.FromError(err)
+				require.True(t, ok, "error should be a gRPC status")
+				assert.Equal(t, tt.expectedCode, st.Code())
+				assert.Contains(t, st.Message(), tt.expectedMsg)
+				assert.Nil(t, resp)
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestReconcileMigrations_MissingClaims(t *testing.T) {
+	// Create a mock provisioner
+	mockProvisioner := provisioner.NewMockProvisioner([]provisioner.ServiceConfig{
+		{Name: "party", MigrationPath: "/migrations/party"},
+	})
+
+	// Create service with mock provisioner
+	svc := NewService(nil, mockProvisioner, nil, slog.Default())
+
+	// Context without claims
+	ctx := context.Background()
+
+	// Execute
+	resp, err := svc.ReconcileMigrations(ctx, &pb.ReconcileMigrationsRequest{})
+
+	// Assert
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "error should be a gRPC status")
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+	assert.Contains(t, st.Message(), "authentication required")
+	assert.Nil(t, resp)
+}
+
+func TestReconcileMigrations_NoProvisioner(t *testing.T) {
+	// Create service without provisioner
+	svc := NewService(nil, nil, nil, slog.Default())
+
+	// Create context with valid claims
+	claims := &auth.Claims{
+		UserID: "admin-123",
+		Roles:  []string{auth.RolePlatformAdmin},
+	}
+	ctx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+
+	// Execute
+	resp, err := svc.ReconcileMigrations(ctx, &pb.ReconcileMigrationsRequest{})
+
+	// Assert - should fail with FailedPrecondition because provisioner is nil
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "error should be a gRPC status")
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "schema provisioning not enabled")
+	assert.Nil(t, resp)
+}
+
+func TestReconcileMigrations_AuthorizationBeforeProvisioner(t *testing.T) {
+	// Test that authorization check happens BEFORE provisioner check.
+	// This is important: we want to reject unauthorized users before
+	// revealing any details about system configuration.
+
+	// Create service WITHOUT provisioner (nil)
+	svc := NewService(nil, nil, nil, slog.Default())
+
+	// Create context with unauthorized claims
+	claims := &auth.Claims{
+		UserID: "user-123",
+		Roles:  []string{"user"},
+	}
+	ctx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+
+	// Execute
+	resp, err := svc.ReconcileMigrations(ctx, &pb.ReconcileMigrationsRequest{})
+
+	// Assert - should fail with PermissionDenied (not FailedPrecondition)
+	// This proves authorization check happens before provisioner check
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "error should be a gRPC status")
+	assert.Equal(t, codes.PermissionDenied, st.Code(), "authorization should be checked before provisioner availability")
+	assert.Contains(t, st.Message(), "platform-admin or super-admin role required")
+	assert.Nil(t, resp)
+}
+
+func TestReconcileMigrations_SuccessfulReconciliation(t *testing.T) {
+	// Create a mock provisioner with some active tenants
+	mockProvisioner := provisioner.NewMockProvisioner([]provisioner.ServiceConfig{
+		{Name: "party", MigrationPath: "/migrations/party"},
+		{Name: "current-account", MigrationPath: "/migrations/current-account"},
+	})
+
+	// Add some tenant statuses that would be reconciled
+	mockProvisioner.SetStatus(&provisioner.ProvisioningStatus{
+		TenantID: "acme_bank",
+		State:    provisioner.StateActive,
+	})
+	mockProvisioner.SetStatus(&provisioner.ProvisioningStatus{
+		TenantID: "beta_corp",
+		State:    provisioner.StateActive,
+	})
+
+	// Create service with mock provisioner
+	svc := NewService(nil, mockProvisioner, nil, slog.Default())
+
+	// Create context with platform-admin claims
+	claims := &auth.Claims{
+		UserID: "admin-123",
+		Roles:  []string{auth.RolePlatformAdmin},
+	}
+	ctx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+
+	// Execute - reconcile all tenants
+	resp, err := svc.ReconcileMigrations(ctx, &pb.ReconcileMigrationsRequest{})
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, int32(2), resp.ReconciledCount, "should have reconciled 2 active tenants")
+	assert.Empty(t, resp.Errors, "should have no errors")
 }


### PR DESCRIPTION
## Summary

- Secure the ReconcileMigrations gRPC endpoint with platform-admin role authorization
- Migration reconciliation is a platform-layer operation that affects all tenants globally
- Only platform-admin or super-admin roles are permitted to execute this operation

## Task Master Reference

- **Tag**: database-per-service
- **Task ID**: 15

## Changes Made

- Added authorization check at the start of `ReconcileMigrations` method in `grpc_service.go`
- Authorization happens BEFORE provisioner availability check (security best practice)
- Returns `codes.Unauthenticated` when claims are missing from context
- Returns `codes.PermissionDenied` when user lacks required role
- Added audit logging for successful and failed authorization attempts
- Added comprehensive unit tests covering all authorization scenarios

## Test Plan

- [x] Unit tests for platform-admin role (allowed)
- [x] Unit tests for super-admin role (allowed)
- [x] Unit tests for unauthorized roles (denied with PermissionDenied)
- [x] Unit tests for missing claims (denied with Unauthenticated)
- [x] Unit tests verifying authorization check happens before provisioner check
- [x] All existing tests continue to pass
- [x] Linter passes with no issues