### PR TITLE
Fix audit_outbox status constraint migration bug

### DIFF
--- a/services/current-account/migrations/20251217000001_fix_audit_status_constraint.sql
+++ b/services/current-account/migrations/20251217000001_fix_audit_status_constraint.sql
@@ -1,0 +1,8 @@
+-- Fix audit_outbox status constraint to include 'completed' status
+-- The worker sets status to 'completed' after successful processing
+-- but the original constraint only allowed 'pending', 'processing', 'failed'
+
+-- Drop the existing constraint and add updated one with 'completed'
+ALTER TABLE audit_outbox DROP CONSTRAINT IF EXISTS audit_outbox_status_check;
+ALTER TABLE audit_outbox ADD CONSTRAINT audit_outbox_status_check
+    CHECK (status IN ('pending', 'processing', 'completed', 'failed'));

--- a/services/current-account/migrations/atlas.sum
+++ b/services/current-account/migrations/atlas.sum
@@ -1,3 +1,4 @@
-h1:NcwyoTlRt41He5h2sw0Dz+pMhGrzxQ9YKlxVIkDKf+s=
+h1:fw2GyRfsnte7GUJukjjNq7AkaVKOUNu7O6xzUBm6CP4=
 20251216000001_initial.sql h1:nyRf35O3eYNJqShAvOEhvliXKLIR6e/V8B9JhOHde9w=
 20251216000002_audit_system.sql h1:X/0ZHt9cGTYmFbUUvKAkBgEiGw9fYEqfnbMB8I4SCR8=
+20251217000001_fix_audit_status_constraint.sql h1:yQxsHxbUp5g+ehkKFjOhZs59SbfaQIPw4/sA2xE2rwU=


### PR DESCRIPTION
## Summary
- Add 'completed' status to audit_outbox CHECK constraint
- Worker code sets `statusCompleted = "completed"` but the original migration only allowed 'pending', 'processing', 'failed'
- This caused runtime failures when entries were successfully processed

## Task Master Reference
- **Tag**: 75-async-audit
- **Task ID**: 7

## Changes Made
- New migration `20251217000001_fix_audit_status_constraint.sql` that:
  - Drops the existing constraint
  - Adds updated constraint with 'completed' status included
- Updated atlas.sum checksum file

## Test Plan
- Integration test: Create audit entry, run worker, verify entry transitions to 'completed' status without constraint violation
- Unit test: Verify constraint allows all four status values
- Existing audit worker tests pass (except pre-existing unrelated failures)