### PR TITLE
Add audit infrastructure to Party service (task 12)

### DIFF
--- a/services/party/adapters/persistence/party_entity.go
+++ b/services/party/adapters/persistence/party_entity.go
@@ -2,10 +2,35 @@
 package persistence
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/audit"
+	"gorm.io/gorm"
 )
+
+// Audit-related errors
+var (
+	// ErrNilTransaction is returned when a nil transaction is passed to recordAudit
+	ErrNilTransaction = errors.New("tx cannot be nil for audit recording")
+
+	// ErrOldValueType is returned when old value has incorrect type in context
+	ErrOldValueType = errors.New("failed to retrieve old party values from context: invalid type")
+
+	// ErrOldValueNotFound is returned when old value is not found in context
+	ErrOldValueNotFound = errors.New("old party values not found in context")
+)
+
+// contextKey is a private type for context keys to avoid collisions
+type contextKey string
+
+// auditOldValueKey is the context key used to store old values before an UPDATE operation.
+// This allows BeforeUpdate hook to capture the old state and pass it to AfterUpdate hook.
+const auditOldValueKey contextKey = "audit:old_party_value"
 
 // PartyEntity represents the database persistence model for parties.
 // This entity MUST match the schema defined in migrations/party/*.sql
@@ -37,4 +62,156 @@ type PartyEntity struct {
 // Uses singular, unqualified name per database-per-service architecture.
 func (PartyEntity) TableName() string {
 	return "party"
+}
+
+// PartyAuditOutbox represents an audit record waiting to be processed by the background worker.
+// Records are written to the outbox within the same transaction as the business operation,
+// ensuring atomicity and preventing lost audit records.
+type PartyAuditOutbox struct {
+	ID            uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+	Table         string    `gorm:"column:table_name;type:varchar(100);not null;index"`
+	Operation     string    `gorm:"type:varchar(10);not null;index"` // INSERT, UPDATE, DELETE
+	RecordID      uuid.UUID `gorm:"type:uuid;not null;index"`
+	OldValues     string    `gorm:"type:text"`                                         // JSON representation of old values
+	NewValues     string    `gorm:"type:text"`                                         // JSON representation of new values
+	Status        string    `gorm:"type:varchar(20);not null;default:'pending';index"` // pending, processing, completed, failed
+	CreatedAt     time.Time `gorm:"not null;default:CURRENT_TIMESTAMP"`
+	RetryCount    int       `gorm:"not null;default:0"`
+	LastError     *string   `gorm:"type:text"`
+	ChangedBy     *string   `gorm:"type:varchar(100)"`
+	TransactionID *string   `gorm:"type:varchar(100)"`
+	ClientIP      *string   `gorm:"type:varchar(45)"` // Pointer for NULL support
+	UserAgent     *string   `gorm:"type:text"`
+}
+
+// TableName overrides the table name for PartyAuditOutbox.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
+func (PartyAuditOutbox) TableName() string {
+	return "audit_outbox"
+}
+
+// recordPartyAudit writes an audit outbox entry within the current transaction.
+// This function is called by GORM hooks (AfterCreate, AfterUpdate, AfterDelete).
+func recordPartyAudit(tx *gorm.DB, tableName, operation string, recordID uuid.UUID, oldValue, newValue interface{}) error {
+	if tx == nil {
+		return ErrNilTransaction
+	}
+
+	// Serialize old and new values to JSON
+	var oldJSON, newJSON string
+
+	if oldValue != nil {
+		oldBytes, err := json.Marshal(oldValue)
+		if err != nil {
+			return fmt.Errorf("failed to marshal old value: %w", err)
+		}
+		oldJSON = string(oldBytes)
+	}
+
+	if newValue != nil {
+		newBytes, err := json.Marshal(newValue)
+		if err != nil {
+			return fmt.Errorf("failed to marshal new value: %w", err)
+		}
+		newJSON = string(newBytes)
+	}
+
+	// Extract user ID from context
+	var changedBy *string
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		userID := audit.GetUserFromContext(tx.Statement.Context)
+		changedBy = &userID
+	}
+	if changedBy == nil {
+		defaultUser := audit.DefaultAuditUser
+		changedBy = &defaultUser
+	}
+
+	// Create audit outbox entry
+	outbox := PartyAuditOutbox{
+		ID:        uuid.New(),
+		Table:     tableName,
+		Operation: operation,
+		RecordID:  recordID,
+		OldValues: oldJSON,
+		NewValues: newJSON,
+		Status:    "pending",
+		ChangedBy: changedBy,
+		CreatedAt: time.Now(),
+	}
+
+	// Write to outbox within the same transaction
+	return tx.Create(&outbox).Error
+}
+
+// AfterCreate is a GORM hook that runs after INSERT operations on PartyEntity.
+// It writes an audit outbox entry with the new party data.
+func (p *PartyEntity) AfterCreate(tx *gorm.DB) error {
+	return recordPartyAudit(tx, "party", "INSERT", p.ID, nil, p)
+}
+
+// BeforeUpdate is a GORM hook that runs before UPDATE operations on PartyEntity.
+// It captures the old values BEFORE the update happens and stores them in the transaction context.
+//
+// NOTE: This hook is skipped when:
+// - The entity ID is not set (map-based updates via Model(&Entity{}).Updates(map...))
+// - These patterns bypass hooks in GORM; the repository uses them for optimistic locking
+func (p *PartyEntity) BeforeUpdate(tx *gorm.DB) error {
+	// Skip if ID is not set - this happens with map-based updates
+	// where the model is an empty struct used only for table name resolution
+	if p.ID == uuid.Nil {
+		return nil
+	}
+
+	// Capture old values before the update
+	var old PartyEntity
+	if err := tx.First(&old, p.ID).Error; err != nil {
+		return fmt.Errorf("failed to fetch old party values: %w", err)
+	}
+
+	// Store old values in transaction context for AfterUpdate to access
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		ctx := context.WithValue(tx.Statement.Context, auditOldValueKey, &old)
+		tx.Statement.Context = ctx
+	}
+
+	return nil
+}
+
+// AfterUpdate is a GORM hook that runs after UPDATE operations on PartyEntity.
+// It retrieves the old values from context and writes an audit outbox entry.
+//
+// NOTE: This hook is skipped when:
+// - The entity ID is not set (map-based updates bypass hooks)
+// - Old values are not in context (BeforeUpdate was skipped)
+func (p *PartyEntity) AfterUpdate(tx *gorm.DB) error {
+	// Skip if ID is not set - this happens with map-based updates
+	if p.ID == uuid.Nil {
+		return nil
+	}
+
+	// Retrieve old values from context (captured in BeforeUpdate)
+	var old *PartyEntity
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		if oldValue := tx.Statement.Context.Value(auditOldValueKey); oldValue != nil {
+			var ok bool
+			old, ok = oldValue.(*PartyEntity)
+			if !ok {
+				return ErrOldValueType
+			}
+		}
+	}
+
+	// Skip audit if old values are not available (BeforeUpdate was skipped)
+	if old == nil {
+		return nil
+	}
+
+	return recordPartyAudit(tx, "party", "UPDATE", p.ID, old, p)
+}
+
+// AfterDelete is a GORM hook that runs after DELETE operations on PartyEntity.
+// It writes an audit outbox entry with the deleted party data.
+func (p *PartyEntity) AfterDelete(tx *gorm.DB) error {
+	return recordPartyAudit(tx, "party", "DELETE", p.ID, p, nil)
 }

--- a/services/party/adapters/persistence/party_entity.go
+++ b/services/party/adapters/persistence/party_entity.go
@@ -164,8 +164,9 @@ func (p *PartyEntity) BeforeUpdate(tx *gorm.DB) error {
 	}
 
 	// Capture old values before the update
+	// Use Unscoped() to find records even if soft-deleted (for audit completeness)
 	var old PartyEntity
-	if err := tx.First(&old, p.ID).Error; err != nil {
+	if err := tx.Unscoped().First(&old, p.ID).Error; err != nil {
 		return fmt.Errorf("failed to fetch old party values: %w", err)
 	}
 

--- a/services/party/adapters/persistence/repository_test.go
+++ b/services/party/adapters/persistence/repository_test.go
@@ -20,7 +20,7 @@ const testTenantID = "test_tenant"
 
 func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	t.Helper()
-	db, cleanup := testdb.SetupPostgres(t, []interface{}{&PartyEntity{}})
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{&PartyEntity{}, &PartyAuditOutbox{}})
 
 	// Create the tenant schema for tests
 	tid := tenant.TenantID(testTenantID)
@@ -28,8 +28,8 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
 	require.NoError(t, err)
 
-	// Create the parties table in the tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.parties (
+	// Create the party table in the tenant schema (note: singular 'party' to match entity)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.party (
 		id UUID PRIMARY KEY,
 		party_type VARCHAR(20) NOT NULL,
 		legal_name VARCHAR(255) NOT NULL,
@@ -44,6 +44,25 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		created_by VARCHAR(255),
 		updated_by VARCHAR(255),
 		UNIQUE(external_reference, external_reference_type)
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create the audit_outbox table in the tenant schema (required for audit hooks)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.audit_outbox (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL,
+		record_id UUID NOT NULL,
+		old_values TEXT,
+		new_values TEXT,
+		status VARCHAR(20) NOT NULL DEFAULT 'pending',
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		retry_count INT NOT NULL DEFAULT 0,
+		last_error TEXT,
+		changed_by VARCHAR(100),
+		transaction_id VARCHAR(100),
+		client_ip VARCHAR(45),
+		user_agent TEXT
 	)`, schemaName)).Error
 	require.NoError(t, err)
 
@@ -654,3 +673,168 @@ func TestPing_WorksWithoutOrganizationContext(t *testing.T) {
 
 // Note: hasTenantContext tests removed - the system is always multi-tenant.
 // Tenant context is always required for all business service operations.
+
+// Audit Tests
+
+func TestAudit_CreateParty_WritesAuditOutboxEntry(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Create a party using direct GORM to trigger hooks
+	party, err := domain.NewParty(domain.PartyTypePerson, "John Doe Audit Test")
+	require.NoError(t, err)
+
+	entity := &PartyEntity{
+		ID:        party.ID(),
+		PartyType: string(party.PartyType()),
+		LegalName: party.LegalName(),
+		Status:    string(party.Status()),
+		Version:   party.Version(),
+		CreatedAt: party.CreatedAt(),
+		UpdatedAt: party.UpdatedAt(),
+		CreatedBy: "test-user",
+		UpdatedBy: "test-user",
+	}
+
+	// Create using GORM directly to ensure hooks fire
+	err = db.WithContext(ctx).Create(entity).Error
+	require.NoError(t, err)
+
+	// Verify audit outbox entry was created
+	var auditEntries []PartyAuditOutbox
+	err = db.WithContext(ctx).Where("record_id = ?", party.ID()).Find(&auditEntries).Error
+	require.NoError(t, err)
+
+	require.Len(t, auditEntries, 1, "Expected one audit entry for party creation")
+
+	auditEntry := auditEntries[0]
+	assert.Equal(t, "party", auditEntry.Table, "Table name should be 'party'")
+	assert.Equal(t, "INSERT", auditEntry.Operation, "Operation should be INSERT")
+	assert.Equal(t, party.ID(), auditEntry.RecordID, "Record ID should match party ID")
+	assert.Equal(t, "pending", auditEntry.Status, "Status should be pending")
+	assert.Empty(t, auditEntry.OldValues, "Old values should be empty for INSERT")
+	assert.NotEmpty(t, auditEntry.NewValues, "New values should contain party data")
+	assert.NotNil(t, auditEntry.ChangedBy, "ChangedBy should be set")
+}
+
+func TestAudit_CreateParty_AuditContainsPartyFields(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Create a party with specific fields to verify in audit
+	party, err := domain.NewParty(domain.PartyTypeOrganization, "Acme Corp Ltd")
+	require.NoError(t, err)
+
+	displayName := "Acme"
+	extRef := "12345678"
+	extRefType := string(domain.ExternalReferenceTypeCompaniesHouse)
+
+	entity := &PartyEntity{
+		ID:                    party.ID(),
+		PartyType:             string(domain.PartyTypeOrganization),
+		LegalName:             "Acme Corp Ltd",
+		DisplayName:           &displayName,
+		Status:                string(domain.PartyStatusActive),
+		ExternalReference:     &extRef,
+		ExternalReferenceType: &extRefType,
+		Version:               1,
+		CreatedAt:             party.CreatedAt(),
+		UpdatedAt:             party.UpdatedAt(),
+		CreatedBy:             "test-user",
+		UpdatedBy:             "test-user",
+	}
+
+	err = db.WithContext(ctx).Create(entity).Error
+	require.NoError(t, err)
+
+	// Verify audit contains the expected fields
+	var auditEntry PartyAuditOutbox
+	err = db.WithContext(ctx).Where("record_id = ?", party.ID()).First(&auditEntry).Error
+	require.NoError(t, err)
+
+	// The new_values should contain JSON with party fields
+	assert.Contains(t, auditEntry.NewValues, "Acme Corp Ltd", "Audit should contain legal_name")
+	assert.Contains(t, auditEntry.NewValues, "ORGANIZATION", "Audit should contain party_type")
+	assert.Contains(t, auditEntry.NewValues, "ACTIVE", "Audit should contain status")
+	assert.Contains(t, auditEntry.NewValues, "12345678", "Audit should contain external_reference")
+}
+
+func TestAudit_CreateParty_WithUserContext_SetsChangedBy(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Add user to context
+	testUserID := "user-456"
+	ctx = context.WithValue(ctx, auth.UserIDContextKey, testUserID)
+
+	party, err := domain.NewParty(domain.PartyTypePerson, "User Context Test")
+	require.NoError(t, err)
+
+	entity := &PartyEntity{
+		ID:        party.ID(),
+		PartyType: string(party.PartyType()),
+		LegalName: party.LegalName(),
+		Status:    string(party.Status()),
+		Version:   1,
+		CreatedAt: party.CreatedAt(),
+		UpdatedAt: party.UpdatedAt(),
+		CreatedBy: testUserID,
+		UpdatedBy: testUserID,
+	}
+
+	err = db.WithContext(ctx).Create(entity).Error
+	require.NoError(t, err)
+
+	// Verify changed_by was set from context
+	var auditEntry PartyAuditOutbox
+	err = db.WithContext(ctx).Where("record_id = ?", party.ID()).First(&auditEntry).Error
+	require.NoError(t, err)
+
+	require.NotNil(t, auditEntry.ChangedBy, "ChangedBy should be set")
+	assert.Equal(t, testUserID, *auditEntry.ChangedBy, "ChangedBy should match user from context")
+}
+
+func TestAudit_DeleteParty_WritesAuditOutboxEntry(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	// Create a party first
+	party, err := domain.NewParty(domain.PartyTypePerson, "To Be Deleted")
+	require.NoError(t, err)
+
+	entity := &PartyEntity{
+		ID:        party.ID(),
+		PartyType: string(party.PartyType()),
+		LegalName: party.LegalName(),
+		Status:    string(party.Status()),
+		Version:   1,
+		CreatedAt: party.CreatedAt(),
+		UpdatedAt: party.UpdatedAt(),
+		CreatedBy: "test-user",
+		UpdatedBy: "test-user",
+	}
+
+	err = db.WithContext(ctx).Create(entity).Error
+	require.NoError(t, err)
+
+	// Now delete using GORM Delete (which triggers AfterDelete hook)
+	err = db.WithContext(ctx).Delete(entity).Error
+	require.NoError(t, err)
+
+	// Verify audit entries - should have INSERT and DELETE
+	var auditEntries []PartyAuditOutbox
+	err = db.WithContext(ctx).Where("record_id = ?", party.ID()).Order("created_at").Find(&auditEntries).Error
+	require.NoError(t, err)
+
+	require.Len(t, auditEntries, 2, "Expected two audit entries (INSERT and DELETE)")
+
+	// First entry should be INSERT
+	assert.Equal(t, "INSERT", auditEntries[0].Operation)
+
+	// Second entry should be DELETE
+	deleteEntry := auditEntries[1]
+	assert.Equal(t, "DELETE", deleteEntry.Operation, "Operation should be DELETE")
+	assert.Equal(t, "party", deleteEntry.Table)
+	assert.NotEmpty(t, deleteEntry.OldValues, "Old values should contain deleted party data")
+	assert.Empty(t, deleteEntry.NewValues, "New values should be empty for DELETE")
+}

--- a/services/party/migrations/20251217000001_audit_system.sql
+++ b/services/party/migrations/20251217000001_audit_system.sql
@@ -1,0 +1,89 @@
+-- Party Service Audit System
+-- Static audit table creation (CockroachDB compatible)
+-- Audit logging handled at application level via GORM hooks
+-- See ADR-0009 for rationale
+-- Uses unqualified table names (relies on database-per-service architecture)
+
+-- Create audit_log table (unqualified, singular)
+CREATE TABLE IF NOT EXISTS audit_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- What changed
+    table_name VARCHAR(100) NOT NULL,
+    operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+
+    -- Record identification
+    record_id UUID NOT NULL,
+
+    -- Change metadata
+    changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    changed_by VARCHAR(100),
+
+    -- Change details
+    old_values JSONB,
+    new_values JSONB,
+
+    -- Additional context
+    transaction_id VARCHAR(100),
+    client_ip INET,
+    user_agent TEXT
+);
+
+-- Create indexes for efficient audit queries
+CREATE INDEX IF NOT EXISTS idx_audit_log_table_name ON audit_log(table_name);
+CREATE INDEX IF NOT EXISTS idx_audit_log_record_id ON audit_log(record_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_changed_at ON audit_log(changed_at);
+CREATE INDEX IF NOT EXISTS idx_audit_log_changed_by ON audit_log(changed_by);
+CREATE INDEX IF NOT EXISTS idx_audit_log_operation ON audit_log(operation);
+
+-- Create audit_outbox table for async processing (unqualified, singular)
+-- GORM hooks write to outbox, background worker moves to audit_log
+CREATE TABLE IF NOT EXISTS audit_outbox (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- What changed
+    table_name VARCHAR(100) NOT NULL,
+    operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+
+    -- Record identification
+    record_id UUID NOT NULL,
+
+    -- Change details
+    old_values JSONB,
+    new_values JSONB,
+
+    -- Processing status (includes 'completed' for successful processing)
+    status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    retry_count INT NOT NULL DEFAULT 0,
+    last_error TEXT,
+
+    -- Additional context
+    changed_by VARCHAR(100),
+    transaction_id VARCHAR(100),
+    client_ip INET,
+    user_agent TEXT
+);
+
+-- Index for worker to efficiently find pending entries
+CREATE INDEX IF NOT EXISTS idx_audit_outbox_status_created ON audit_outbox(status, created_at);
+
+-- Create helper view for easy audit queries
+CREATE OR REPLACE VIEW change_summary AS
+SELECT
+    id,
+    table_name AS table_full_name,
+    operation,
+    record_id,
+    changed_at,
+    changed_by,
+    CASE
+        WHEN operation = 'UPDATE' THEN
+            (SELECT json_object_agg(key, value)
+             FROM jsonb_each(new_values)
+             WHERE new_values->key IS DISTINCT FROM old_values->key)
+        ELSE NULL
+    END AS changed_fields,
+    transaction_id
+FROM audit_log
+ORDER BY changed_at DESC;

--- a/services/party/migrations/20251217000001_audit_system.sql
+++ b/services/party/migrations/20251217000001_audit_system.sql
@@ -19,13 +19,13 @@ CREATE TABLE IF NOT EXISTS audit_log (
     changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     changed_by VARCHAR(100),
 
-    -- Change details
-    old_values JSONB,
-    new_values JSONB,
+    -- Change details (TEXT to match GORM model - contains JSON strings)
+    old_values TEXT,
+    new_values TEXT,
 
     -- Additional context
     transaction_id VARCHAR(100),
-    client_ip INET,
+    client_ip VARCHAR(45),
     user_agent TEXT
 );
 
@@ -48,9 +48,9 @@ CREATE TABLE IF NOT EXISTS audit_outbox (
     -- Record identification
     record_id UUID NOT NULL,
 
-    -- Change details
-    old_values JSONB,
-    new_values JSONB,
+    -- Change details (TEXT to match GORM model - contains JSON strings)
+    old_values TEXT,
+    new_values TEXT,
 
     -- Processing status (includes 'completed' for successful processing)
     status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS audit_outbox (
     -- Additional context
     changed_by VARCHAR(100),
     transaction_id VARCHAR(100),
-    client_ip INET,
+    client_ip VARCHAR(45),
     user_agent TEXT
 );
 
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS audit_outbox (
 CREATE INDEX IF NOT EXISTS idx_audit_outbox_status_created ON audit_outbox(status, created_at);
 
 -- Create helper view for easy audit queries
+-- Note: old_values and new_values are TEXT containing JSON, cast to JSONB for comparison
 CREATE OR REPLACE VIEW change_summary AS
 SELECT
     id,
@@ -78,10 +79,10 @@ SELECT
     changed_at,
     changed_by,
     CASE
-        WHEN operation = 'UPDATE' THEN
+        WHEN operation = 'UPDATE' AND new_values IS NOT NULL AND old_values IS NOT NULL THEN
             (SELECT json_object_agg(key, value)
-             FROM jsonb_each(new_values)
-             WHERE new_values->key IS DISTINCT FROM old_values->key)
+             FROM jsonb_each(new_values::jsonb)
+             WHERE (new_values::jsonb)->key IS DISTINCT FROM (old_values::jsonb)->key)
         ELSE NULL
     END AS changed_fields,
     transaction_id

--- a/services/party/migrations/atlas.sum
+++ b/services/party/migrations/atlas.sum
@@ -1,3 +1,3 @@
-h1:anG8EvnSNa2gE7vIu5QBklKluZzX5pXDjOS+008w6Lo=
+h1:gEZrWcxxDcuLTROPfP3mANr/4FlwXh4+u4AteZSz2M8=
 20251216000001_initial.sql h1:e2vtJfpgkEvioqxJ1piy7QAbmihqftHOSlkPDLs8jac=
-20251217000001_audit_system.sql h1:Nb9lUAzL+i/yO0/qWX0cU6DVOqzeND0RRfX1Iy2Vfb8=
+20251217000001_audit_system.sql h1:qB+oshTdK74dZ1qX/6Ux9Hz/Ij5yayGpjjSMrgoPIcg=

--- a/services/party/migrations/atlas.sum
+++ b/services/party/migrations/atlas.sum
@@ -1,2 +1,3 @@
-h1:aaQXQSygqJ6FSTvKs+9ZMpmLPmt7hyFt5cd7EfQrJ54=
+h1:anG8EvnSNa2gE7vIu5QBklKluZzX5pXDjOS+008w6Lo=
 20251216000001_initial.sql h1:e2vtJfpgkEvioqxJ1piy7QAbmihqftHOSlkPDLs8jac=
+20251217000001_audit_system.sql h1:Nb9lUAzL+i/yO0/qWX0cU6DVOqzeND0RRfX1Iy2Vfb8=

--- a/services/party/service/grpc_service_integration_test.go
+++ b/services/party/service/grpc_service_integration_test.go
@@ -28,6 +28,7 @@ func setupIntegrationTest(t *testing.T) (*Service, *gorm.DB, context.Context, fu
 
 	db, cleanup := testdb.SetupPostgres(t, []interface{}{
 		&persistence.PartyEntity{},
+		&persistence.PartyAuditOutbox{},
 	})
 
 	// Create the tenant schema for tests
@@ -36,8 +37,8 @@ func setupIntegrationTest(t *testing.T) (*Service, *gorm.DB, context.Context, fu
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
 	require.NoError(t, err)
 
-	// Create the parties table in the tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.parties (
+	// Create the party table in the tenant schema (note: singular 'party' to match entity)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.party (
 		id UUID PRIMARY KEY,
 		party_type VARCHAR(20) NOT NULL,
 		legal_name VARCHAR(255) NOT NULL,
@@ -52,6 +53,25 @@ func setupIntegrationTest(t *testing.T) (*Service, *gorm.DB, context.Context, fu
 		created_by VARCHAR(255),
 		updated_by VARCHAR(255),
 		UNIQUE(external_reference, external_reference_type)
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create the audit_outbox table in the tenant schema (required for audit hooks)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.audit_outbox (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL,
+		record_id UUID NOT NULL,
+		old_values TEXT,
+		new_values TEXT,
+		status VARCHAR(20) NOT NULL DEFAULT 'pending',
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		retry_count INT NOT NULL DEFAULT 0,
+		last_error TEXT,
+		changed_by VARCHAR(100),
+		transaction_id VARCHAR(100),
+		client_ip VARCHAR(45),
+		user_agent TEXT
 	)`, schemaName)).Error
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- Add GORM hooks to PartyEntity for audit logging (AfterCreate, BeforeUpdate/AfterUpdate, AfterDelete)
- Create migration for audit_log and audit_outbox tables in party service
- Add integration tests for party audit functionality

## Task Master Reference
- **Tag**: 75-async-audit
- **Task ID**: 12

## Changes Made
- `services/party/migrations/20251217000001_audit_system.sql` - Migration creating audit_log and audit_outbox tables
- `services/party/adapters/persistence/party_entity.go` - Added PartyAuditOutbox model and GORM audit hooks
- `services/party/adapters/persistence/repository_test.go` - Added audit tests and updated test setup to include audit tables

## Technical Details
The audit hooks write to the `audit_outbox` table within the same transaction as the business operation. The existing audit worker (from task 7) will process these entries and move them to `audit_log`.

**Known Limitation**: Update hooks are skipped when the repository uses map-based `Updates()` for optimistic locking. This is a GORM limitation - only INSERT and DELETE operations create audit records via the repository's Save method.

## Test Plan
- [x] Party creation audited with legal_name, party_type, status fields
- [x] Party deletion audited with old values
- [x] Changed_by field populated from context
- [x] All existing party tests pass with audit infrastructure