### PR TITLE
feat: add audit infrastructure to PaymentOrder service (task 13)

### DIFF
--- a/services/payment-order/adapters/persistence/audit_test.go
+++ b/services/payment-order/adapters/persistence/audit_test.go
@@ -1,0 +1,429 @@
+package persistence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// setupTestDBWithAudit creates a test database with both payment_order and audit tables.
+func setupTestDBWithAudit(t *testing.T) (*gorm.DB, context.Context, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{&PaymentOrderEntity{}, &AuditOutbox{}})
+
+	// Create tenant schema
+	tid := tenant.TenantID(testTenantID)
+	schemaName := tid.SchemaName()
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
+	require.NoError(t, err)
+
+	// Create payment_order table in tenant schema (singular per entity TableName())
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.payment_order (
+		id UUID PRIMARY KEY,
+		debtor_account_id VARCHAR(255) NOT NULL,
+		creditor_reference VARCHAR(255) NOT NULL,
+		amount_cents BIGINT NOT NULL,
+		currency VARCHAR(3) NOT NULL,
+		status VARCHAR(20) NOT NULL,
+		idempotency_key VARCHAR(255) NOT NULL UNIQUE,
+		correlation_id VARCHAR(255),
+		causation_id VARCHAR(255),
+		lien_id VARCHAR(255),
+		gateway_reference_id VARCHAR(255),
+		ledger_booking_id VARCHAR(255),
+		failure_reason TEXT,
+		error_code VARCHAR(50),
+		version INTEGER NOT NULL DEFAULT 1,
+		lien_execution_status VARCHAR(20),
+		lien_execution_attempts INTEGER DEFAULT 0,
+		lien_execution_error TEXT,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		reserved_at TIMESTAMP WITH TIME ZONE,
+		executing_at TIMESTAMP WITH TIME ZONE,
+		completed_at TIMESTAMP WITH TIME ZONE,
+		failed_at TIMESTAMP WITH TIME ZONE,
+		cancelled_at TIMESTAMP WITH TIME ZONE,
+		reversed_at TIMESTAMP WITH TIME ZONE
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create audit_outbox table in tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.audit_outbox (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+		record_id UUID NOT NULL,
+		old_values JSONB,
+		new_values JSONB,
+		status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+		created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+		retry_count INT NOT NULL DEFAULT 0,
+		last_error TEXT,
+		changed_by VARCHAR(100),
+		transaction_id VARCHAR(100),
+		client_ip VARCHAR(45),
+		user_agent TEXT
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create indexes for audit_outbox
+	err = db.Exec(fmt.Sprintf(`CREATE INDEX IF NOT EXISTS idx_audit_outbox_status_created ON %q.audit_outbox(status, created_at)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Set search_path to tenant schema
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	require.NoError(t, err)
+
+	// Create context with tenant
+	ctx := tenant.WithTenant(context.Background(), tid)
+
+	return db, ctx, cleanup
+}
+
+// getAuditEntries retrieves all audit entries for a specific record from the outbox.
+func getAuditEntries(t *testing.T, db *gorm.DB, recordID uuid.UUID) []AuditOutbox {
+	t.Helper()
+	var entries []AuditOutbox
+	err := db.Where("record_id = ?", recordID).Order("created_at ASC").Find(&entries).Error
+	require.NoError(t, err)
+	return entries
+}
+
+// =============================================================================
+// Audit Tests
+// =============================================================================
+
+func TestAudit_PaymentOrderCreation_IsAudited(t *testing.T) {
+	db, ctx, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	repo := NewPaymentOrderRepository(db)
+	amount, err := domain.NewMoney("GBP", 10000)
+	require.NoError(t, err)
+
+	po, err := domain.NewPaymentOrder(
+		"acc-123",
+		"creditor-ref",
+		amount,
+		"idem-key-audit-001",
+		"corr-001",
+	)
+	require.NoError(t, err)
+
+	err = repo.Create(ctx, po)
+	require.NoError(t, err)
+
+	// Verify audit entry was created
+	entries := getAuditEntries(t, db, po.ID)
+	require.Len(t, entries, 1, "Should have exactly one audit entry for INSERT")
+
+	entry := entries[0]
+	assert.Equal(t, "payment_order", entry.Table)
+	assert.Equal(t, "INSERT", entry.Operation)
+	assert.Equal(t, po.ID, entry.RecordID)
+	assert.Equal(t, "pending", entry.Status)
+	assert.Nil(t, entry.OldValues, "INSERT should have no old values")
+	assert.NotNil(t, entry.NewValues, "INSERT should have new values")
+
+	// Verify ChangedBy defaults to system
+	require.NotNil(t, entry.ChangedBy)
+	assert.Equal(t, "system", *entry.ChangedBy)
+
+	// Verify new values contain expected data
+	var newValues map[string]interface{}
+	err = json.Unmarshal([]byte(*entry.NewValues), &newValues)
+	require.NoError(t, err)
+	assert.Equal(t, "acc-123", newValues["DebtorAccountID"])
+	assert.Equal(t, "INITIATED", newValues["Status"])
+}
+
+func TestAudit_PaymentOrderStatusTransition_CreatesAuditTrail(t *testing.T) {
+	db, ctx, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	repo := NewPaymentOrderRepository(db)
+	amount, err := domain.NewMoney("GBP", 10000)
+	require.NoError(t, err)
+
+	// Create payment order
+	po, err := domain.NewPaymentOrder(
+		"acc-123",
+		"creditor-ref",
+		amount,
+		"idem-key-audit-002",
+		"corr-001",
+	)
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, po))
+
+	// Transition: INITIATED -> RESERVED
+	require.NoError(t, po.Reserve("lien-123"))
+	require.NoError(t, repo.Update(ctx, po))
+
+	// Transition: RESERVED -> EXECUTING
+	require.NoError(t, po.Execute("gateway-ref-001"))
+	require.NoError(t, repo.Update(ctx, po))
+
+	// Transition: EXECUTING -> COMPLETED
+	require.NoError(t, po.Complete("ledger-booking-001"))
+	require.NoError(t, repo.Update(ctx, po))
+
+	// Verify audit trail
+	entries := getAuditEntries(t, db, po.ID)
+	require.Len(t, entries, 4, "Should have 4 audit entries: INSERT + 3 UPDATEs")
+
+	// Verify INSERT
+	assert.Equal(t, "INSERT", entries[0].Operation)
+
+	// Verify INITIATED -> RESERVED
+	assert.Equal(t, "UPDATE", entries[1].Operation)
+	assertStatusTransition(t, entries[1], "INITIATED", "RESERVED")
+
+	// Verify RESERVED -> EXECUTING
+	assert.Equal(t, "UPDATE", entries[2].Operation)
+	assertStatusTransition(t, entries[2], "RESERVED", "EXECUTING")
+
+	// Verify EXECUTING -> COMPLETED
+	assert.Equal(t, "UPDATE", entries[3].Operation)
+	assertStatusTransition(t, entries[3], "EXECUTING", "COMPLETED")
+}
+
+func TestAudit_PaymentOrderFailure_CapturesReasonAndErrorCode(t *testing.T) {
+	db, ctx, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	repo := NewPaymentOrderRepository(db)
+	amount, err := domain.NewMoney("GBP", 10000)
+	require.NoError(t, err)
+
+	// Create payment order
+	po, err := domain.NewPaymentOrder(
+		"acc-123",
+		"creditor-ref",
+		amount,
+		"idem-key-audit-003",
+		"corr-001",
+	)
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, po))
+
+	// Fail the payment order
+	require.NoError(t, po.Fail("Insufficient funds in account", "INSUFFICIENT_FUNDS"))
+	require.NoError(t, repo.Update(ctx, po))
+
+	// Verify audit trail
+	entries := getAuditEntries(t, db, po.ID)
+	require.Len(t, entries, 2, "Should have INSERT + UPDATE")
+
+	// Verify failure audit entry captures critical fields
+	failEntry := entries[1]
+	assert.Equal(t, "UPDATE", failEntry.Operation)
+	require.NotNil(t, failEntry.NewValues)
+
+	var newValues map[string]interface{}
+	err = json.Unmarshal([]byte(*failEntry.NewValues), &newValues)
+	require.NoError(t, err)
+
+	assert.Equal(t, "FAILED", newValues["Status"])
+	assert.Equal(t, "Insufficient funds in account", newValues["FailureReason"])
+	assert.Equal(t, "INSUFFICIENT_FUNDS", newValues["ErrorCode"])
+}
+
+func TestAudit_PaymentOrderLienTracking_CapturesLienExecutionStatus(t *testing.T) {
+	db, ctx, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	repo := NewPaymentOrderRepository(db)
+	amount, err := domain.NewMoney("GBP", 10000)
+	require.NoError(t, err)
+
+	// Create and progress payment order through lifecycle
+	po, err := domain.NewPaymentOrder(
+		"acc-123",
+		"creditor-ref",
+		amount,
+		"idem-key-audit-004",
+		"corr-001",
+	)
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, po))
+
+	// Reserve with lien
+	require.NoError(t, po.Reserve("lien-123"))
+	require.NoError(t, repo.Update(ctx, po))
+
+	// Execute
+	require.NoError(t, po.Execute("gateway-ref-001"))
+	require.NoError(t, repo.Update(ctx, po))
+
+	// Complete
+	require.NoError(t, po.Complete("ledger-booking-001"))
+	require.NoError(t, repo.Update(ctx, po))
+
+	// Mark lien execution as succeeded
+	po.SetLienExecutionSucceeded()
+	require.NoError(t, repo.Update(ctx, po))
+
+	// Verify audit trail captures lien ID and execution status
+	entries := getAuditEntries(t, db, po.ID)
+	require.GreaterOrEqual(t, len(entries), 5, "Should have at least 5 audit entries")
+
+	// Check that the reserved entry captures lien_id
+	reservedEntry := entries[1]
+	require.NotNil(t, reservedEntry.NewValues)
+	var reservedNewValues map[string]interface{}
+	err = json.Unmarshal([]byte(*reservedEntry.NewValues), &reservedNewValues)
+	require.NoError(t, err)
+	assert.Equal(t, "lien-123", reservedNewValues["LienID"])
+
+	// Check final entry captures lien execution status
+	finalEntry := entries[len(entries)-1]
+	require.NotNil(t, finalEntry.NewValues)
+	var finalNewValues map[string]interface{}
+	err = json.Unmarshal([]byte(*finalEntry.NewValues), &finalNewValues)
+	require.NoError(t, err)
+	assert.Equal(t, "SUCCEEDED", finalNewValues["LienExecutionStatus"])
+}
+
+func TestAudit_PaymentOrderDeletion_IsAudited(t *testing.T) {
+	db, _, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	// Create payment order directly via entity
+	entity := &PaymentOrderEntity{
+		ID:                uuid.New(),
+		DebtorAccountID:   "acc-delete-test",
+		CreditorReference: "creditor-ref",
+		AmountCents:       10000,
+		Currency:          "GBP",
+		Status:            "INITIATED",
+		IdempotencyKey:    "idem-key-delete-001",
+		CorrelationID:     "corr-001",
+		Version:           1,
+		CreatedAt:         time.Now(),
+		UpdatedAt:         time.Now(),
+	}
+	require.NoError(t, db.Create(entity).Error)
+
+	// Delete the entity
+	require.NoError(t, db.Delete(entity).Error)
+
+	// Verify audit entries
+	entries := getAuditEntries(t, db, entity.ID)
+	require.Len(t, entries, 2, "Should have INSERT + DELETE")
+
+	// Verify DELETE audit entry
+	deleteEntry := entries[1]
+	assert.Equal(t, "DELETE", deleteEntry.Operation)
+	assert.NotNil(t, deleteEntry.OldValues, "DELETE should have old values")
+	assert.Nil(t, deleteEntry.NewValues, "DELETE should have no new values")
+
+	// Verify old values contain the deleted data
+	var oldValues map[string]interface{}
+	err := json.Unmarshal([]byte(*deleteEntry.OldValues), &oldValues)
+	require.NoError(t, err)
+	assert.Equal(t, "acc-delete-test", oldValues["DebtorAccountID"])
+}
+
+func TestAudit_CriticalFields_AreAlwaysCaptured(t *testing.T) {
+	// Verifies that critical fields mentioned in task requirements are always captured:
+	// Status, AmountCents, DebtorAccountID, LienID, GatewayReferenceID
+	db, ctx, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	repo := NewPaymentOrderRepository(db)
+	amount, err := domain.NewMoney("GBP", 10050) // 100.50 GBP
+	require.NoError(t, err)
+
+	po, err := domain.NewPaymentOrder(
+		"debtor-account-001",
+		"creditor-ref",
+		amount,
+		"idem-key-critical-001",
+		"corr-001",
+	)
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, po))
+
+	// Progress to capture all critical fields
+	require.NoError(t, po.Reserve("critical-lien-123"))
+	require.NoError(t, repo.Update(ctx, po))
+
+	require.NoError(t, po.Execute("critical-gateway-ref-456"))
+	require.NoError(t, repo.Update(ctx, po))
+
+	// Get final entry
+	entries := getAuditEntries(t, db, po.ID)
+	finalEntry := entries[len(entries)-1]
+	require.NotNil(t, finalEntry.NewValues)
+
+	var newValues map[string]interface{}
+	err = json.Unmarshal([]byte(*finalEntry.NewValues), &newValues)
+	require.NoError(t, err)
+
+	// Verify all critical fields are captured
+	assert.Equal(t, "EXECUTING", newValues["Status"], "Status must be captured")
+	assert.Equal(t, float64(10050), newValues["AmountCents"], "AmountCents must be captured")
+	assert.Equal(t, "debtor-account-001", newValues["DebtorAccountID"], "DebtorAccountID must be captured")
+	assert.Equal(t, "critical-lien-123", newValues["LienID"], "LienID must be captured")
+	assert.Equal(t, "critical-gateway-ref-456", newValues["GatewayReferenceID"], "GatewayReferenceID must be captured")
+}
+
+func TestAudit_OutboxStatus_DefaultsToPending(t *testing.T) {
+	db, ctx, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	repo := NewPaymentOrderRepository(db)
+	amount, err := domain.NewMoney("GBP", 10000)
+	require.NoError(t, err)
+
+	po, err := domain.NewPaymentOrder(
+		"acc-123",
+		"creditor-ref",
+		amount,
+		"idem-key-status-001",
+		"corr-001",
+	)
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, po))
+
+	entries := getAuditEntries(t, db, po.ID)
+	require.Len(t, entries, 1)
+
+	// All entries should start as 'pending' for worker processing
+	assert.Equal(t, "pending", entries[0].Status, "Audit entries should default to pending status")
+	assert.Equal(t, 0, entries[0].RetryCount, "RetryCount should start at 0")
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+// assertStatusTransition verifies an audit entry captures a status transition.
+func assertStatusTransition(t *testing.T, entry AuditOutbox, oldStatus, newStatus string) {
+	t.Helper()
+
+	var oldValues, newValues map[string]interface{}
+
+	if entry.OldValues != nil {
+		err := json.Unmarshal([]byte(*entry.OldValues), &oldValues)
+		require.NoError(t, err)
+		assert.Equal(t, oldStatus, oldValues["Status"], "Old status should be %s", oldStatus)
+	}
+
+	require.NotNil(t, entry.NewValues)
+	err := json.Unmarshal([]byte(*entry.NewValues), &newValues)
+	require.NoError(t, err)
+	assert.Equal(t, newStatus, newValues["Status"], "New status should be %s", newStatus)
+}

--- a/services/payment-order/adapters/persistence/payment_order_entity.go
+++ b/services/payment-order/adapters/persistence/payment_order_entity.go
@@ -2,9 +2,15 @@
 package persistence
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"gorm.io/gorm"
 )
 
 // PaymentOrderEntity represents the database persistence model for payment orders.
@@ -68,4 +74,153 @@ type PaymentOrderEntity struct {
 // Uses singular, unqualified name per database-per-service architecture.
 func (PaymentOrderEntity) TableName() string {
 	return "payment_order"
+}
+
+// =============================================================================
+// Audit Infrastructure
+// =============================================================================
+
+// ErrNilTransaction is returned when a nil transaction is passed to recordAudit
+var ErrNilTransaction = errors.New("tx cannot be nil for audit recording")
+
+// systemUser is the default user ID for background jobs and migrations
+const systemUser = "system"
+
+// AuditOutbox represents an audit record waiting to be processed by the background worker.
+// Records are written to the outbox within the same transaction as the business operation,
+// ensuring atomicity and preventing lost audit records.
+//
+// The background worker asynchronously moves records from outbox to audit_log.
+type AuditOutbox struct {
+	ID            uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	Table         string    `gorm:"column:table_name;type:varchar(100);not null;index" json:"table_name"`
+	Operation     string    `gorm:"type:varchar(10);not null;index" json:"operation"` // INSERT, UPDATE, DELETE
+	RecordID      uuid.UUID `gorm:"type:uuid;not null;index" json:"record_id"`
+	OldValues     *string   `gorm:"type:jsonb" json:"old_values,omitempty"`                          // JSONB representation of old values
+	NewValues     *string   `gorm:"type:jsonb" json:"new_values,omitempty"`                          // JSONB representation of new values
+	Status        string    `gorm:"type:varchar(20);not null;default:'pending';index" json:"status"` // pending, processing, completed, failed
+	CreatedAt     time.Time `gorm:"not null;default:CURRENT_TIMESTAMP" json:"created_at"`
+	RetryCount    int       `gorm:"not null;default:0" json:"retry_count"`
+	LastError     *string   `gorm:"type:text" json:"last_error,omitempty"`
+	ChangedBy     *string   `gorm:"type:varchar(100)" json:"changed_by,omitempty"`
+	TransactionID *string   `gorm:"type:varchar(100)" json:"transaction_id,omitempty"`
+	ClientIP      *string   `gorm:"type:varchar(45)" json:"client_ip,omitempty"` // Pointer for NULL support
+	UserAgent     *string   `gorm:"type:text" json:"user_agent,omitempty"`
+}
+
+// TableName overrides the table name for AuditOutbox.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
+func (AuditOutbox) TableName() string {
+	return "audit_outbox"
+}
+
+// recordAudit writes an audit outbox entry within the current transaction.
+// This function is called by GORM hooks (AfterCreate, AfterUpdate, AfterDelete).
+//
+// Parameters:
+//   - tx: The GORM transaction (must be non-nil)
+//   - tableName: The table being audited (e.g., "payment_order")
+//   - operation: The operation type ("INSERT", "UPDATE", "DELETE")
+//   - recordID: The UUID of the record being audited
+//   - oldValue: The old state (nil for INSERT, populated for UPDATE/DELETE)
+//   - newValue: The new state (populated for INSERT/UPDATE, nil for DELETE)
+//
+// Returns:
+//   - error: Any error encountered during audit recording
+func recordAudit(tx *gorm.DB, tableName, operation string, recordID uuid.UUID, oldValue, newValue interface{}) error {
+	if tx == nil {
+		return ErrNilTransaction
+	}
+
+	// Serialize old and new values to JSON
+	var oldJSON, newJSON *string
+
+	if oldValue != nil {
+		oldBytes, err := json.Marshal(oldValue)
+		if err != nil {
+			return fmt.Errorf("failed to marshal old value: %w", err)
+		}
+		s := string(oldBytes)
+		oldJSON = &s
+	}
+
+	if newValue != nil {
+		newBytes, err := json.Marshal(newValue)
+		if err != nil {
+			return fmt.Errorf("failed to marshal new value: %w", err)
+		}
+		s := string(newBytes)
+		newJSON = &s
+	}
+
+	// Extract user ID from context
+	var changedBy *string
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		if userID := getUserIDFromContext(tx.Statement.Context); userID != "" {
+			changedBy = &userID
+		}
+	}
+	if changedBy == nil {
+		// Default to system
+		sysUser := systemUser
+		changedBy = &sysUser
+	}
+
+	// Create audit outbox entry
+	outbox := AuditOutbox{
+		ID:        uuid.New(),
+		Table:     tableName,
+		Operation: operation,
+		RecordID:  recordID,
+		OldValues: oldJSON,
+		NewValues: newJSON,
+		Status:    "pending",
+		ChangedBy: changedBy,
+		CreatedAt: time.Now(),
+	}
+
+	// Write to outbox within the same transaction
+	return tx.Create(&outbox).Error
+}
+
+// getUserIDFromContext extracts the user ID from the context.
+// Returns empty string if not found or if type assertion fails.
+func getUserIDFromContext(ctx any) string {
+	if ctx == nil {
+		return ""
+	}
+
+	// Safely convert to context.Context interface
+	stdCtx, ok := ctx.(context.Context)
+	if !ok {
+		return ""
+	}
+
+	// Try to get user from auth context (set by gRPC interceptors)
+	if claims, exists := auth.GetClaimsFromContext(stdCtx); exists && claims != nil {
+		return claims.Subject
+	}
+
+	return ""
+}
+
+// =============================================================================
+// Payment Order Audit Hooks
+// =============================================================================
+
+// AfterCreate is a GORM hook that runs after INSERT operations on PaymentOrderEntity.
+// It writes an audit outbox entry with the new payment order data.
+func (p *PaymentOrderEntity) AfterCreate(tx *gorm.DB) error {
+	return recordAudit(tx, "payment_order", "INSERT", p.ID, nil, p)
+}
+
+// Note: BeforeUpdate and AfterUpdate hooks are NOT used for PaymentOrderEntity because
+// the repository uses GORM's Model().Updates(map) pattern for optimistic locking,
+// which doesn't trigger struct-based hooks. Update auditing is handled explicitly
+// in PaymentOrderRepository.Update() to ensure atomicity and capture old state.
+
+// AfterDelete is a GORM hook that runs after DELETE operations on PaymentOrderEntity.
+// It writes an audit outbox entry with the deleted payment order data.
+func (p *PaymentOrderEntity) AfterDelete(tx *gorm.DB) error {
+	return recordAudit(tx, "payment_order", "DELETE", p.ID, p, nil)
 }

--- a/services/payment-order/adapters/persistence/repository.go
+++ b/services/payment-order/adapters/persistence/repository.go
@@ -333,31 +333,42 @@ func (r *PaymentOrderRepository) FindByDebtorAccountIDWithCursor(ctx context.Con
 
 // Update updates an existing payment order with optimistic locking.
 // The context must contain the tenant ID for schema routing.
+// Records an audit entry capturing the old and new state for compliance tracking.
 func (r *PaymentOrderRepository) Update(ctx context.Context, po *domain.PaymentOrder) error {
-	entity := toEntity(po)
+	newEntity := toEntity(po)
 
+	//nolint:contextcheck // Context accessed from tx.Statement.Context per GORM audit hook convention
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		// Fetch old entity state for audit trail BEFORE update
+		var oldEntity PaymentOrderEntity
+		if err := tx.Where("id = ?", newEntity.ID).First(&oldEntity).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrPaymentOrderNotFound
+			}
+			return err
+		}
+
 		// Optimistic locking: use WHERE clause with version check
 		result := tx.Model(&PaymentOrderEntity{}).
-			Where("id = ? AND version = ?", entity.ID, po.Version).
+			Where("id = ? AND version = ?", newEntity.ID, po.Version).
 			Updates(map[string]interface{}{
-				"status":                  entity.Status,
-				"lien_id":                 entity.LienID,
-				"gateway_reference_id":    entity.GatewayReferenceID,
-				"ledger_booking_id":       entity.LedgerBookingID,
-				"causation_id":            entity.CausationID,
-				"failure_reason":          entity.FailureReason,
-				"error_code":              entity.ErrorCode,
-				"lien_execution_status":   entity.LienExecutionStatus,
-				"lien_execution_attempts": entity.LienExecutionAttempts,
-				"lien_execution_error":    entity.LienExecutionError,
-				"updated_at":              entity.UpdatedAt,
-				"reserved_at":             entity.ReservedAt,
-				"executing_at":            entity.ExecutingAt,
-				"completed_at":            entity.CompletedAt,
-				"failed_at":               entity.FailedAt,
-				"cancelled_at":            entity.CancelledAt,
-				"reversed_at":             entity.ReversedAt,
+				"status":                  newEntity.Status,
+				"lien_id":                 newEntity.LienID,
+				"gateway_reference_id":    newEntity.GatewayReferenceID,
+				"ledger_booking_id":       newEntity.LedgerBookingID,
+				"causation_id":            newEntity.CausationID,
+				"failure_reason":          newEntity.FailureReason,
+				"error_code":              newEntity.ErrorCode,
+				"lien_execution_status":   newEntity.LienExecutionStatus,
+				"lien_execution_attempts": newEntity.LienExecutionAttempts,
+				"lien_execution_error":    newEntity.LienExecutionError,
+				"updated_at":              newEntity.UpdatedAt,
+				"reserved_at":             newEntity.ReservedAt,
+				"executing_at":            newEntity.ExecutingAt,
+				"completed_at":            newEntity.CompletedAt,
+				"failed_at":               newEntity.FailedAt,
+				"cancelled_at":            newEntity.CancelledAt,
+				"reversed_at":             newEntity.ReversedAt,
 				"version":                 po.Version + 1,
 			})
 
@@ -369,7 +380,10 @@ func (r *PaymentOrderRepository) Update(ctx context.Context, po *domain.PaymentO
 			return ErrPaymentOrderVersionConflict
 		}
 
-		return nil
+		// Record audit entry for the update (explicit audit for Map-based Updates)
+		// Update newEntity version to match what we just wrote to DB
+		newEntity.Version = po.Version + 1
+		return recordAudit(tx, "payment_order", "UPDATE", newEntity.ID, &oldEntity, newEntity)
 	})
 	if err != nil {
 		return err

--- a/services/payment-order/adapters/persistence/repository_test.go
+++ b/services/payment-order/adapters/persistence/repository_test.go
@@ -21,7 +21,7 @@ const testTenantID = "test_tenant"
 
 func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	t.Helper()
-	db, cleanup := testdb.SetupPostgres(t, []interface{}{&PaymentOrderEntity{}})
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{&PaymentOrderEntity{}, &AuditOutbox{}})
 
 	// Create tenant schema
 	tid := tenant.TenantID(testTenantID)
@@ -29,8 +29,8 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
 	require.NoError(t, err)
 
-	// Create payment_orders table in tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.payment_orders (
+	// Create payment_order table in tenant schema (singular per entity TableName())
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.payment_order (
 		id UUID PRIMARY KEY,
 		debtor_account_id VARCHAR(255) NOT NULL,
 		creditor_reference VARCHAR(255) NOT NULL,
@@ -50,12 +50,32 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		lien_execution_attempts INTEGER DEFAULT 0,
 		lien_execution_error TEXT,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
 		reserved_at TIMESTAMP WITH TIME ZONE,
 		executing_at TIMESTAMP WITH TIME ZONE,
 		completed_at TIMESTAMP WITH TIME ZONE,
 		failed_at TIMESTAMP WITH TIME ZONE,
 		cancelled_at TIMESTAMP WITH TIME ZONE,
 		reversed_at TIMESTAMP WITH TIME ZONE
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create audit_outbox table in tenant schema (required for audit hooks)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.audit_outbox (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+		record_id UUID NOT NULL,
+		old_values JSONB,
+		new_values JSONB,
+		status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+		created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+		retry_count INT NOT NULL DEFAULT 0,
+		last_error TEXT,
+		changed_by VARCHAR(100),
+		transaction_id VARCHAR(100),
+		client_ip VARCHAR(45),
+		user_agent TEXT
 	)`, schemaName)).Error
 	require.NoError(t, err)
 
@@ -490,8 +510,8 @@ func TestPaymentOrderRepository_Update_NonExistent_ReturnsError(t *testing.T) {
 	// Try to update non-existent payment order
 	err := repo.Update(ctx, po)
 
-	// Should fail with version conflict (no rows affected)
-	assert.True(t, errors.Is(err, ErrPaymentOrderVersionConflict))
+	// Should fail with not found (audit trail fetch fails before update)
+	assert.True(t, errors.Is(err, ErrPaymentOrderNotFound))
 }
 
 // Defensive tests for toDomain error handling

--- a/services/payment-order/migrations/20251217000001_audit_system.sql
+++ b/services/payment-order/migrations/20251217000001_audit_system.sql
@@ -1,0 +1,89 @@
+-- Payment Order Audit System
+-- Static audit table creation (CockroachDB compatible)
+-- Audit logging handled at application level via GORM hooks
+-- See ADR-0009 for rationale
+-- Uses unqualified table names (relies on database-per-service architecture)
+
+-- Create audit_log table (unqualified, singular)
+CREATE TABLE IF NOT EXISTS audit_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- What changed
+    table_name VARCHAR(100) NOT NULL,
+    operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+
+    -- Record identification
+    record_id UUID NOT NULL,
+
+    -- Change metadata
+    changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    changed_by VARCHAR(100),
+
+    -- Change details
+    old_values JSONB,
+    new_values JSONB,
+
+    -- Additional context
+    transaction_id VARCHAR(100),
+    client_ip INET,
+    user_agent TEXT
+);
+
+-- Create indexes for efficient audit queries
+CREATE INDEX IF NOT EXISTS idx_audit_log_table_name ON audit_log(table_name);
+CREATE INDEX IF NOT EXISTS idx_audit_log_record_id ON audit_log(record_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_changed_at ON audit_log(changed_at);
+CREATE INDEX IF NOT EXISTS idx_audit_log_changed_by ON audit_log(changed_by);
+CREATE INDEX IF NOT EXISTS idx_audit_log_operation ON audit_log(operation);
+
+-- Create audit_outbox table for async processing (unqualified, singular)
+-- GORM hooks write to outbox, background worker moves to audit_log
+CREATE TABLE IF NOT EXISTS audit_outbox (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- What changed
+    table_name VARCHAR(100) NOT NULL,
+    operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+
+    -- Record identification
+    record_id UUID NOT NULL,
+
+    -- Change details
+    old_values JSONB,
+    new_values JSONB,
+
+    -- Processing status (includes 'completed' for worker acknowledgment)
+    status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    retry_count INT NOT NULL DEFAULT 0,
+    last_error TEXT,
+
+    -- Additional context
+    changed_by VARCHAR(100),
+    transaction_id VARCHAR(100),
+    client_ip INET,
+    user_agent TEXT
+);
+
+-- Index for worker to efficiently find pending entries
+CREATE INDEX IF NOT EXISTS idx_audit_outbox_status_created ON audit_outbox(status, created_at);
+
+-- Create helper view for easy audit queries
+CREATE OR REPLACE VIEW change_summary AS
+SELECT
+    id,
+    table_name AS table_full_name,
+    operation,
+    record_id,
+    changed_at,
+    changed_by,
+    CASE
+        WHEN operation = 'UPDATE' THEN
+            (SELECT json_object_agg(key, value)
+             FROM jsonb_each(new_values)
+             WHERE new_values->key IS DISTINCT FROM old_values->key)
+        ELSE NULL
+    END AS changed_fields,
+    transaction_id
+FROM audit_log
+ORDER BY changed_at DESC;

--- a/services/payment-order/migrations/20251217000001_audit_system.sql
+++ b/services/payment-order/migrations/20251217000001_audit_system.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS audit_log (
 
     -- Additional context
     transaction_id VARCHAR(100),
-    client_ip INET,
+    client_ip VARCHAR(45),
     user_agent TEXT
 );
 
@@ -61,7 +61,7 @@ CREATE TABLE IF NOT EXISTS audit_outbox (
     -- Additional context
     changed_by VARCHAR(100),
     transaction_id VARCHAR(100),
-    client_ip INET,
+    client_ip VARCHAR(45),
     user_agent TEXT
 );
 

--- a/services/payment-order/migrations/atlas.sum
+++ b/services/payment-order/migrations/atlas.sum
@@ -1,2 +1,3 @@
-h1:EDHw82Nb12s7hwEjhJsSGoUzu4BMBeuoRMNh7pkZCfY=
+h1:gJZzeRprgoa1EO7am71uGCQ8Liy+1Gqx2BlNiZpBfqM=
 20251216000001_initial.sql h1:9Pt9iC/k1YkmfjyO/F0ioNbPswzzgCP2aHtFlFHnSMY=
+20251217000001_audit_system.sql h1:KJVk0dajDW1uX2Igkq45EfzUgD3MSL9zHrdufnxV904=

--- a/services/payment-order/migrations/atlas.sum
+++ b/services/payment-order/migrations/atlas.sum
@@ -1,3 +1,3 @@
-h1:gJZzeRprgoa1EO7am71uGCQ8Liy+1Gqx2BlNiZpBfqM=
+h1:QIFf9sM1GNKLxU/o3mY2QQuArGesC+imWUek9AXoKLg=
 20251216000001_initial.sql h1:9Pt9iC/k1YkmfjyO/F0ioNbPswzzgCP2aHtFlFHnSMY=
-20251217000001_audit_system.sql h1:KJVk0dajDW1uX2Igkq45EfzUgD3MSL9zHrdufnxV904=
+20251217000001_audit_system.sql h1:YD9HdFm+NRTihCM/PBU7EYEmdttWjvGPCIE408A8HFg=

--- a/services/payment-order/service/integration_test.go
+++ b/services/payment-order/service/integration_test.go
@@ -55,6 +55,7 @@ func setupIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	t.Helper()
 	db, cleanup := testdb.SetupPostgres(t, []interface{}{
 		&persistence.PaymentOrderEntity{},
+		&persistence.AuditOutbox{},
 	})
 
 	// Create tenant schema
@@ -63,8 +64,8 @@ func setupIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
 	require.NoError(t, err)
 
-	// Create payment_orders table in tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.payment_orders (
+	// Create payment_order table in tenant schema (singular per entity TableName())
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.payment_order (
 		id UUID PRIMARY KEY,
 		debtor_account_id VARCHAR(255) NOT NULL,
 		creditor_reference VARCHAR(255) NOT NULL,
@@ -84,12 +85,32 @@ func setupIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		lien_execution_attempts INTEGER DEFAULT 0,
 		lien_execution_error TEXT,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
 		reserved_at TIMESTAMP WITH TIME ZONE,
 		executing_at TIMESTAMP WITH TIME ZONE,
 		completed_at TIMESTAMP WITH TIME ZONE,
 		failed_at TIMESTAMP WITH TIME ZONE,
 		cancelled_at TIMESTAMP WITH TIME ZONE,
 		reversed_at TIMESTAMP WITH TIME ZONE
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create audit_outbox table in tenant schema (required for audit hooks)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.audit_outbox (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+		record_id UUID NOT NULL,
+		old_values JSONB,
+		new_values JSONB,
+		status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+		created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+		retry_count INT NOT NULL DEFAULT 0,
+		last_error TEXT,
+		changed_by VARCHAR(100),
+		transaction_id VARCHAR(100),
+		client_ip VARCHAR(45),
+		user_agent TEXT
 	)`, schemaName)).Error
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- Add async audit trail to payment-order service using `audit_outbox` pattern
- Implements GORM hooks for INSERT/DELETE and explicit audit recording for UPDATE
- Captures all PaymentOrder state changes including status transitions, failure reasons, and lien execution tracking

## Task Master Reference
- **Tag**: 75-async-audit
- **Task ID**: 13

## Changes Made
- New migration `20251217000001_audit_system.sql` creating `audit_log` and `audit_outbox` tables
- `AuditOutbox` GORM model with JSONB columns for old/new values
- `AfterCreate` and `AfterDelete` hooks on `PaymentOrderEntity`
- Explicit audit recording in `PaymentOrderRepository.Update()` (required due to Map-based Updates pattern for optimistic locking)
- 7 integration tests covering:
  - INSERT audit on create
  - UPDATE audit on status transitions (INITIATED→RESERVED→EXECUTING→COMPLETED)
  - Failure capture (status, reason, error code)
  - Lien execution tracking
  - DELETE audit
  - Critical fields capture
  - Outbox status defaults

## Test Plan
- [x] All audit tests pass (`go test ./services/payment-order/adapters/persistence/... -run TestAudit`)
- [x] All existing repository tests pass
- [x] Linter passes (`golangci-lint run`)
- [ ] CI pipeline validates build and tests