### PR TITLE
feat: add audit infrastructure for financial-accounting service (task 11)

### DIFF
--- a/services/financial-accounting/adapters/messaging/deposit_consumer_test.go
+++ b/services/financial-accounting/adapters/messaging/deposit_consumer_test.go
@@ -22,7 +22,11 @@ const testTenantID = "test_tenant"
 func setupTestServices(t *testing.T) (*service.PostingService, context.Context, func()) {
 	t.Helper()
 
-	db, cleanup := testdb.SetupPostgres(t, []interface{}{&persistence.LedgerPostingEntity{}, &persistence.FinancialBookingLogEntity{}})
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{
+		&persistence.LedgerPostingEntity{},
+		&persistence.FinancialBookingLogEntity{},
+		&persistence.AuditOutbox{},
+	})
 
 	// Create the tenant schema for tests
 	tid := tenant.TenantID(testTenantID)
@@ -30,8 +34,8 @@ func setupTestServices(t *testing.T) (*service.PostingService, context.Context, 
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
 	require.NoError(t, err)
 
-	// Create tables in tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.financial_booking_logs (
+	// Create tables in tenant schema (singular names to match production)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.financial_booking_log (
 		id UUID PRIMARY KEY,
 		financial_account_type VARCHAR(50) NOT NULL,
 		product_service_reference VARCHAR(255) NOT NULL,
@@ -42,12 +46,14 @@ func setupTestServices(t *testing.T) (*service.PostingService, context.Context, 
 		idempotency_key VARCHAR(255) NOT NULL UNIQUE,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(255),
+		updated_by VARCHAR(255),
 		version BIGINT NOT NULL DEFAULT 1,
 		deleted_at TIMESTAMP WITH TIME ZONE
 	)`, schemaName)).Error
 	require.NoError(t, err)
 
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.ledger_postings (
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.ledger_posting (
 		id UUID PRIMARY KEY,
 		financial_booking_log_id UUID NOT NULL,
 		posting_direction VARCHAR(20) NOT NULL,
@@ -55,11 +61,33 @@ func setupTestServices(t *testing.T) (*service.PostingService, context.Context, 
 		currency VARCHAR(3) NOT NULL,
 		account_id VARCHAR(255) NOT NULL,
 		value_date TIMESTAMP WITH TIME ZONE NOT NULL,
-		posting_result TEXT NOT NULL,
+		posting_result TEXT,
 		status VARCHAR(20) NOT NULL,
-		correlation_id VARCHAR(255) NOT NULL,
+		correlation_id VARCHAR(255),
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(255),
+		updated_by VARCHAR(255),
 		deleted_at TIMESTAMP WITH TIME ZONE
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create audit_outbox table for GORM hooks
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.audit_outbox (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+		record_id UUID NOT NULL,
+		old_values JSONB,
+		new_values JSONB,
+		status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		retry_count INT NOT NULL DEFAULT 0,
+		last_error TEXT,
+		changed_by VARCHAR(100),
+		transaction_id VARCHAR(100),
+		client_ip INET,
+		user_agent TEXT
 	)`, schemaName)).Error
 	require.NoError(t, err)
 

--- a/services/financial-accounting/adapters/persistence/booking_log_entity.go
+++ b/services/financial-accounting/adapters/persistence/booking_log_entity.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -59,8 +60,6 @@ var (
 	ErrNilTransaction = errors.New("tx cannot be nil for audit recording")
 	// ErrOldValueType is returned when old value has incorrect type in context
 	ErrOldValueType = errors.New("failed to retrieve old values from context: invalid type")
-	// ErrOldValueNotFound is returned when old value is not found in context
-	ErrOldValueNotFound = errors.New("old values not found in context")
 )
 
 // AuditOutbox represents an audit record waiting to be processed by the background worker.
@@ -226,6 +225,10 @@ func (e *FinancialBookingLogEntity) AfterUpdate(tx *gorm.DB) error {
 
 	// Skip if old values weren't captured (happens with partial updates via db.Model().Update())
 	if old == nil {
+		slog.Warn("audit skipped: old values not captured for booking log update",
+			"table", "financial_booking_log",
+			"record_id", e.ID,
+			"reason", "partial update via db.Model().Update() bypasses BeforeUpdate hook")
 		return nil
 	}
 

--- a/services/financial-accounting/adapters/persistence/booking_log_entity.go
+++ b/services/financial-accounting/adapters/persistence/booking_log_entity.go
@@ -3,9 +3,14 @@
 package persistence
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/auth"
 	"gorm.io/gorm"
 )
 
@@ -41,4 +46,197 @@ type FinancialBookingLogEntity struct {
 // Uses singular, unqualified name per database-per-service architecture.
 func (FinancialBookingLogEntity) TableName() string {
 	return "financial_booking_log"
+}
+
+// contextKey is a private type for context keys to avoid collisions
+type contextKey string
+
+// bookingLogOldValueKey is the context key for storing old values before UPDATE
+const bookingLogOldValueKey contextKey = "audit:booking_log_old_value"
+
+var (
+	// ErrNilTransaction is returned when a nil transaction is passed to recordAudit
+	ErrNilTransaction = errors.New("tx cannot be nil for audit recording")
+	// ErrOldValueType is returned when old value has incorrect type in context
+	ErrOldValueType = errors.New("failed to retrieve old values from context: invalid type")
+	// ErrOldValueNotFound is returned when old value is not found in context
+	ErrOldValueNotFound = errors.New("old values not found in context")
+)
+
+// AuditOutbox represents an audit record waiting to be processed by the background worker.
+// Uses financial-accounting database's audit_outbox table.
+type AuditOutbox struct {
+	ID            uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	Table         string    `gorm:"column:table_name;type:varchar(100);not null;index" json:"table_name"`
+	Operation     string    `gorm:"type:varchar(10);not null;index" json:"operation"` // INSERT, UPDATE, DELETE
+	RecordID      uuid.UUID `gorm:"type:uuid;not null;index" json:"record_id"`
+	OldValues     *string   `gorm:"type:jsonb" json:"old_values,omitempty"`                          // JSON representation (nullable)
+	NewValues     *string   `gorm:"type:jsonb" json:"new_values,omitempty"`                          // JSON representation (nullable)
+	Status        string    `gorm:"type:varchar(20);not null;default:'pending';index" json:"status"` // pending, processing, completed, failed
+	CreatedAt     time.Time `gorm:"not null;default:CURRENT_TIMESTAMP" json:"created_at"`
+	RetryCount    int       `gorm:"not null;default:0" json:"retry_count"`
+	LastError     *string   `gorm:"type:text" json:"last_error,omitempty"`
+	ChangedBy     *string   `gorm:"type:varchar(100)" json:"changed_by,omitempty"`
+	TransactionID *string   `gorm:"type:varchar(100)" json:"transaction_id,omitempty"`
+	ClientIP      *string   `gorm:"type:varchar(45)" json:"client_ip,omitempty"`
+	UserAgent     *string   `gorm:"type:text" json:"user_agent,omitempty"`
+}
+
+// TableName returns the table name for AuditOutbox.
+func (AuditOutbox) TableName() string {
+	return "audit_outbox"
+}
+
+// AuditLog represents a permanent audit log entry.
+type AuditLog struct {
+	ID            uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	Table         string    `gorm:"column:table_name;type:varchar(100);not null;index" json:"table_name"`
+	Operation     string    `gorm:"type:varchar(10);not null;index" json:"operation"` // INSERT, UPDATE, DELETE
+	RecordID      uuid.UUID `gorm:"type:uuid;not null;index" json:"record_id"`
+	OldValues     *string   `gorm:"type:jsonb" json:"old_values,omitempty"` // JSON representation (nullable)
+	NewValues     *string   `gorm:"type:jsonb" json:"new_values,omitempty"` // JSON representation (nullable)
+	CreatedAt     time.Time `gorm:"not null;default:CURRENT_TIMESTAMP" json:"created_at"`
+	ChangedBy     *string   `gorm:"type:varchar(100)" json:"changed_by,omitempty"`
+	TransactionID *string   `gorm:"type:varchar(100)" json:"transaction_id,omitempty"`
+	ClientIP      *string   `gorm:"type:varchar(45)" json:"client_ip,omitempty"`
+	UserAgent     *string   `gorm:"type:text" json:"user_agent,omitempty"`
+}
+
+// TableName returns the table name for AuditLog.
+func (AuditLog) TableName() string {
+	return "audit_log"
+}
+
+// recordAudit writes an audit outbox entry within the current transaction.
+func recordAudit(tx *gorm.DB, tableName, operation string, recordID uuid.UUID, oldValue, newValue interface{}) error {
+	if tx == nil {
+		return ErrNilTransaction
+	}
+
+	var oldJSON, newJSON *string
+
+	if oldValue != nil {
+		oldBytes, err := json.Marshal(oldValue)
+		if err != nil {
+			return fmt.Errorf("failed to marshal old value: %w", err)
+		}
+		s := string(oldBytes)
+		oldJSON = &s
+	}
+
+	if newValue != nil {
+		newBytes, err := json.Marshal(newValue)
+		if err != nil {
+			return fmt.Errorf("failed to marshal new value: %w", err)
+		}
+		s := string(newBytes)
+		newJSON = &s
+	}
+
+	var changedBy *string
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		if userID := getUserIDFromContext(tx.Statement.Context); userID != "" {
+			changedBy = &userID
+		}
+	}
+	if changedBy == nil {
+		systemUser := "system"
+		changedBy = &systemUser
+	}
+
+	outbox := AuditOutbox{
+		ID:        uuid.New(),
+		Table:     tableName,
+		Operation: operation,
+		RecordID:  recordID,
+		OldValues: oldJSON,
+		NewValues: newJSON,
+		Status:    "pending",
+		ChangedBy: changedBy,
+		CreatedAt: time.Now(),
+	}
+
+	return tx.Create(&outbox).Error
+}
+
+// getUserIDFromContext extracts the user ID from the context.
+func getUserIDFromContext(ctx any) string {
+	if ctx == nil {
+		return ""
+	}
+
+	stdCtx, ok := ctx.(context.Context)
+	if !ok {
+		return ""
+	}
+
+	if userID, ok := stdCtx.Value(auth.UserIDContextKey).(string); ok {
+		return userID
+	}
+
+	return ""
+}
+
+// AfterCreate is a GORM hook that runs after INSERT operations.
+func (e *FinancialBookingLogEntity) AfterCreate(tx *gorm.DB) error {
+	// Skip audit if ID is not set (defensive check for edge cases)
+	if e.ID == uuid.Nil {
+		return nil
+	}
+	return recordAudit(tx, "financial_booking_log", "INSERT", e.ID, nil, e)
+}
+
+// BeforeUpdate is a GORM hook that captures old values before UPDATE.
+func (e *FinancialBookingLogEntity) BeforeUpdate(tx *gorm.DB) error {
+	// Skip audit capture if ID is not set (happens when using db.Model().Update())
+	if e.ID == uuid.Nil {
+		return nil
+	}
+
+	var old FinancialBookingLogEntity
+	if err := tx.First(&old, e.ID).Error; err != nil {
+		return fmt.Errorf("failed to fetch old booking log values: %w", err)
+	}
+
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		ctx := context.WithValue(tx.Statement.Context, bookingLogOldValueKey, &old)
+		tx.Statement.Context = ctx
+	}
+
+	return nil
+}
+
+// AfterUpdate is a GORM hook that runs after UPDATE operations.
+func (e *FinancialBookingLogEntity) AfterUpdate(tx *gorm.DB) error {
+	// Skip audit if ID is not set (defensive check)
+	if e.ID == uuid.Nil {
+		return nil
+	}
+
+	var old *FinancialBookingLogEntity
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		if oldValue := tx.Statement.Context.Value(bookingLogOldValueKey); oldValue != nil {
+			var ok bool
+			old, ok = oldValue.(*FinancialBookingLogEntity)
+			if !ok {
+				return ErrOldValueType
+			}
+		}
+	}
+
+	// Skip if old values weren't captured (happens with partial updates via db.Model().Update())
+	if old == nil {
+		return nil
+	}
+
+	return recordAudit(tx, "financial_booking_log", "UPDATE", e.ID, old, e)
+}
+
+// AfterDelete is a GORM hook that runs after DELETE operations.
+func (e *FinancialBookingLogEntity) AfterDelete(tx *gorm.DB) error {
+	// Skip audit if ID is not set (defensive check)
+	if e.ID == uuid.Nil {
+		return nil
+	}
+	return recordAudit(tx, "financial_booking_log", "DELETE", e.ID, e, nil)
 }

--- a/services/financial-accounting/adapters/persistence/ledger_posting_entity.go
+++ b/services/financial-accounting/adapters/persistence/ledger_posting_entity.go
@@ -1,6 +1,8 @@
 package persistence
 
 import (
+	"context"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -40,4 +42,71 @@ type LedgerPostingEntity struct {
 // Uses singular, unqualified name per database-per-service architecture.
 func (LedgerPostingEntity) TableName() string {
 	return "ledger_posting"
+}
+
+// ledgerPostingOldValueKey is the context key for storing old values before UPDATE
+const ledgerPostingOldValueKey contextKey = "audit:ledger_posting_old_value"
+
+// AfterCreate is a GORM hook that runs after INSERT operations.
+func (e *LedgerPostingEntity) AfterCreate(tx *gorm.DB) error {
+	// Skip audit if ID is not set (defensive check for edge cases)
+	if e.ID == uuid.Nil {
+		return nil
+	}
+	return recordAudit(tx, "ledger_posting", "INSERT", e.ID, nil, e)
+}
+
+// BeforeUpdate is a GORM hook that captures old values before UPDATE.
+func (e *LedgerPostingEntity) BeforeUpdate(tx *gorm.DB) error {
+	// Skip audit capture if ID is not set (happens when using db.Model().Update())
+	if e.ID == uuid.Nil {
+		return nil
+	}
+
+	var old LedgerPostingEntity
+	if err := tx.First(&old, e.ID).Error; err != nil {
+		return fmt.Errorf("failed to fetch old ledger posting values: %w", err)
+	}
+
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		ctx := context.WithValue(tx.Statement.Context, ledgerPostingOldValueKey, &old)
+		tx.Statement.Context = ctx
+	}
+
+	return nil
+}
+
+// AfterUpdate is a GORM hook that runs after UPDATE operations.
+func (e *LedgerPostingEntity) AfterUpdate(tx *gorm.DB) error {
+	// Skip audit if ID is not set (defensive check)
+	if e.ID == uuid.Nil {
+		return nil
+	}
+
+	var old *LedgerPostingEntity
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		if oldValue := tx.Statement.Context.Value(ledgerPostingOldValueKey); oldValue != nil {
+			var ok bool
+			old, ok = oldValue.(*LedgerPostingEntity)
+			if !ok {
+				return ErrOldValueType
+			}
+		}
+	}
+
+	// Skip if old values weren't captured (happens with partial updates via db.Model().Update())
+	if old == nil {
+		return nil
+	}
+
+	return recordAudit(tx, "ledger_posting", "UPDATE", e.ID, old, e)
+}
+
+// AfterDelete is a GORM hook that runs after DELETE operations.
+func (e *LedgerPostingEntity) AfterDelete(tx *gorm.DB) error {
+	// Skip audit if ID is not set (defensive check)
+	if e.ID == uuid.Nil {
+		return nil
+	}
+	return recordAudit(tx, "ledger_posting", "DELETE", e.ID, e, nil)
 }

--- a/services/financial-accounting/adapters/persistence/ledger_posting_entity.go
+++ b/services/financial-accounting/adapters/persistence/ledger_posting_entity.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -96,6 +97,10 @@ func (e *LedgerPostingEntity) AfterUpdate(tx *gorm.DB) error {
 
 	// Skip if old values weren't captured (happens with partial updates via db.Model().Update())
 	if old == nil {
+		slog.Warn("audit skipped: old values not captured for ledger posting update",
+			"table", "ledger_posting",
+			"record_id", e.ID,
+			"reason", "partial update via db.Model().Update() bypasses BeforeUpdate hook")
 		return nil
 	}
 

--- a/services/financial-accounting/adapters/persistence/repository.go
+++ b/services/financial-accounting/adapters/persistence/repository.go
@@ -274,25 +274,25 @@ func (r *LedgerRepository) SaveBookingLog(ctx context.Context, log *domain.Finan
 
 // UpdateBookingLog updates an existing financial booking log.
 // The context must contain the tenant ID for schema routing.
+// Uses Save() to trigger GORM hooks for audit logging.
 func (r *LedgerRepository) UpdateBookingLog(ctx context.Context, log *domain.FinancialBookingLog) error {
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		result := tx.Model(&FinancialBookingLogEntity{}).
-			Where("id = ?", log.ID).
-			Updates(map[string]interface{}{
-				"status":                  string(log.Status),
-				"chart_of_accounts_rules": log.ChartOfAccountsRules,
-				"updated_at":              log.UpdatedAt,
-			})
-
-		if result.Error != nil {
-			return result.Error
+		// Fetch existing entity to apply updates (required for Save() to trigger hooks)
+		var existing FinancialBookingLogEntity
+		if err := tx.First(&existing, "id = ?", log.ID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrBookingLogNotFound
+			}
+			return err
 		}
 
-		if result.RowsAffected == 0 {
-			return ErrBookingLogNotFound
-		}
+		// Apply partial updates
+		existing.Status = string(log.Status)
+		existing.ChartOfAccountsRules = log.ChartOfAccountsRules
+		existing.UpdatedAt = log.UpdatedAt
 
-		return nil
+		// Use Save() to trigger GORM hooks (BeforeUpdate, AfterUpdate)
+		return tx.Save(&existing).Error
 	})
 }
 

--- a/services/financial-accounting/adapters/persistence/repository.go
+++ b/services/financial-accounting/adapters/persistence/repository.go
@@ -154,6 +154,7 @@ func (r *LedgerRepository) GetPostingsByBookingLogID(ctx context.Context, bookin
 
 // UpdatePosting updates an existing ledger posting.
 // The context must contain the tenant ID for schema routing.
+// Uses Save() to trigger GORM hooks for audit logging.
 func (r *LedgerRepository) UpdatePosting(ctx context.Context, posting *domain.LedgerPosting) error {
 	entity, err := toPostingEntity(posting)
 	if err != nil {
@@ -161,22 +162,22 @@ func (r *LedgerRepository) UpdatePosting(ctx context.Context, posting *domain.Le
 	}
 
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		result := tx.Model(&LedgerPostingEntity{}).
-			Where("id = ?", entity.ID).
-			Updates(map[string]interface{}{
-				"status":         entity.Status,
-				"posting_result": entity.PostingResult,
-			})
-
-		if result.Error != nil {
-			return result.Error
+		// Fetch existing entity to apply updates (required for Save() to trigger hooks)
+		var existing LedgerPostingEntity
+		if err := tx.First(&existing, "id = ?", entity.ID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrPostingNotFound
+			}
+			return err
 		}
 
-		if result.RowsAffected == 0 {
-			return ErrPostingNotFound
-		}
+		// Apply partial updates
+		existing.Status = entity.Status
+		existing.PostingResult = entity.PostingResult
+		existing.UpdatedAt = time.Now()
 
-		return nil
+		// Use Save() to trigger GORM hooks (BeforeUpdate, AfterUpdate)
+		return tx.Save(&existing).Error
 	})
 }
 

--- a/services/financial-accounting/adapters/persistence/repository_test.go
+++ b/services/financial-accounting/adapters/persistence/repository_test.go
@@ -25,6 +25,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	db, cleanup := testdb.SetupPostgres(t, []interface{}{
 		&FinancialBookingLogEntity{},
 		&LedgerPostingEntity{},
+		&AuditOutbox{},
 	})
 
 	// Create the tenant schema for tests
@@ -68,6 +69,25 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		created_by VARCHAR(255),
 		updated_by VARCHAR(255),
 		deleted_at TIMESTAMP WITH TIME ZONE
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create audit_outbox table for GORM hooks
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.audit_outbox (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+		record_id UUID NOT NULL,
+		old_values JSONB,
+		new_values JSONB,
+		status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		retry_count INT NOT NULL DEFAULT 0,
+		last_error TEXT,
+		changed_by VARCHAR(100),
+		transaction_id VARCHAR(100),
+		client_ip INET,
+		user_agent TEXT
 	)`, schemaName)).Error
 	require.NoError(t, err)
 
@@ -559,4 +579,390 @@ func TestForeignKeyOnDeleteRestrict(t *testing.T) {
 	var pgErr *pgconn.PgError
 	require.True(t, errors.As(err, &pgErr), "expected Postgres error, got %T: %v", err, err)
 	assert.Equal(t, "23503", pgErr.Code, "expected foreign key violation error code")
+}
+
+// ====================
+// Audit Integration Tests
+// ====================
+
+// setupTestDBWithAudit creates test database with audit tables
+func setupTestDBWithAudit(t *testing.T) (*gorm.DB, context.Context, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{
+		&FinancialBookingLogEntity{},
+		&LedgerPostingEntity{},
+		&AuditOutbox{},
+		&AuditLog{},
+	})
+
+	// Create the tenant schema for tests
+	tid := tenant.TenantID(testTenantID)
+	schemaName := tid.SchemaName()
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
+	require.NoError(t, err)
+
+	// Create tables in tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.financial_booking_log (
+		id UUID PRIMARY KEY,
+		financial_account_type VARCHAR(50) NOT NULL,
+		product_service_reference VARCHAR(255) NOT NULL,
+		business_unit_reference VARCHAR(255) NOT NULL,
+		chart_of_accounts_rules TEXT NOT NULL,
+		base_currency VARCHAR(3) NOT NULL,
+		status VARCHAR(50) NOT NULL,
+		idempotency_key VARCHAR(255) NOT NULL UNIQUE,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(255),
+		updated_by VARCHAR(255),
+		version BIGINT NOT NULL DEFAULT 1,
+		deleted_at TIMESTAMP WITH TIME ZONE
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.ledger_posting (
+		id UUID PRIMARY KEY,
+		financial_booking_log_id UUID NOT NULL,
+		posting_direction VARCHAR(10) NOT NULL,
+		amount_cents BIGINT NOT NULL,
+		currency VARCHAR(3) NOT NULL,
+		account_id VARCHAR(255) NOT NULL,
+		value_date TIMESTAMP WITH TIME ZONE NOT NULL,
+		posting_result VARCHAR(1000),
+		status VARCHAR(50) NOT NULL,
+		correlation_id VARCHAR(255),
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(255),
+		updated_by VARCHAR(255),
+		deleted_at TIMESTAMP WITH TIME ZONE
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create audit tables
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.audit_outbox (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+		record_id UUID NOT NULL,
+		old_values JSONB,
+		new_values JSONB,
+		status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		retry_count INT NOT NULL DEFAULT 0,
+		last_error TEXT,
+		changed_by VARCHAR(100),
+		transaction_id VARCHAR(100),
+		client_ip INET,
+		user_agent TEXT
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.audit_log (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+		record_id UUID NOT NULL,
+		changed_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		changed_by VARCHAR(100),
+		old_values JSONB,
+		new_values JSONB,
+		transaction_id VARCHAR(100),
+		client_ip INET,
+		user_agent TEXT
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Set default search_path to include tenant schema
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	require.NoError(t, err)
+
+	// Create context with tenant
+	ctx := tenant.WithTenant(context.Background(), tid)
+
+	return db, ctx, cleanup
+}
+
+// TestAuditBookingLogCreate verifies that creating a booking log creates an audit outbox entry
+func TestAuditBookingLogCreate(t *testing.T) {
+	db, _, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	// Create a booking log
+	bookingLog := &FinancialBookingLogEntity{
+		ID:                      uuid.New(),
+		FinancialAccountType:    "ASSET",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "PENDING",
+		IdempotencyKey:          "audit-test-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog).Error)
+
+	// Verify audit outbox entry was created
+	var outbox AuditOutbox
+	err := db.Where("record_id = ? AND table_name = ?", bookingLog.ID, "financial_booking_log").First(&outbox).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, "INSERT", outbox.Operation)
+	assert.Equal(t, "pending", outbox.Status)
+	assert.NotNil(t, outbox.NewValues)
+	assert.Nil(t, outbox.OldValues) // No old values for INSERT
+}
+
+// TestAuditBookingLogUpdate verifies that updating a booking log creates an audit outbox entry
+func TestAuditBookingLogUpdate(t *testing.T) {
+	db, _, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	// Create a booking log
+	bookingLog := &FinancialBookingLogEntity{
+		ID:                      uuid.New(),
+		FinancialAccountType:    "ASSET",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "PENDING",
+		IdempotencyKey:          "audit-update-test-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog).Error)
+
+	// Update the booking log
+	bookingLog.Status = "POSTED"
+	bookingLog.UpdatedAt = time.Now()
+	require.NoError(t, db.Save(bookingLog).Error)
+
+	// Verify both INSERT and UPDATE audit outbox entries exist
+	var outboxEntries []AuditOutbox
+	err := db.Where("record_id = ? AND table_name = ?", bookingLog.ID, "financial_booking_log").
+		Order("created_at ASC").
+		Find(&outboxEntries).Error
+	require.NoError(t, err)
+	require.Len(t, outboxEntries, 2, "Expected both INSERT and UPDATE audit entries")
+
+	// Verify INSERT entry
+	assert.Equal(t, "INSERT", outboxEntries[0].Operation)
+
+	// Verify UPDATE entry
+	assert.Equal(t, "UPDATE", outboxEntries[1].Operation)
+	assert.NotNil(t, outboxEntries[1].OldValues) // Old values for UPDATE
+	assert.NotNil(t, outboxEntries[1].NewValues) // New values for UPDATE
+}
+
+// TestAuditBookingLogDelete verifies that deleting a booking log creates an audit outbox entry
+func TestAuditBookingLogDelete(t *testing.T) {
+	db, _, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	// Create a booking log
+	bookingLog := &FinancialBookingLogEntity{
+		ID:                      uuid.New(),
+		FinancialAccountType:    "ASSET",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "PENDING",
+		IdempotencyKey:          "audit-delete-test-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog).Error)
+
+	// Delete the booking log (soft delete via GORM)
+	require.NoError(t, db.Delete(bookingLog).Error)
+
+	// Verify both INSERT and DELETE audit outbox entries exist
+	var outboxEntries []AuditOutbox
+	err := db.Where("record_id = ? AND table_name = ?", bookingLog.ID, "financial_booking_log").
+		Order("created_at ASC").
+		Find(&outboxEntries).Error
+	require.NoError(t, err)
+	require.Len(t, outboxEntries, 2, "Expected both INSERT and DELETE audit entries")
+
+	// Verify DELETE entry
+	assert.Equal(t, "DELETE", outboxEntries[1].Operation)
+	assert.NotNil(t, outboxEntries[1].OldValues) // Old values for DELETE
+	assert.Nil(t, outboxEntries[1].NewValues)    // No new values for DELETE
+}
+
+// TestAuditLedgerPostingCreate verifies that creating a ledger posting creates an audit outbox entry
+func TestAuditLedgerPostingCreate(t *testing.T) {
+	db, _, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	// Create a booking log first (for FK)
+	bookingLogID := uuid.New()
+	bookingLog := &FinancialBookingLogEntity{
+		ID:                      bookingLogID,
+		FinancialAccountType:    "ASSET",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "PENDING",
+		IdempotencyKey:          "audit-posting-test-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog).Error)
+
+	// Create a ledger posting
+	posting := &LedgerPostingEntity{
+		ID:                    uuid.New(),
+		FinancialBookingLogID: bookingLogID,
+		PostingDirection:      "DEBIT",
+		AmountCents:           10050,
+		Currency:              "GBP",
+		AccountID:             "ACC-001",
+		ValueDate:             time.Now(),
+		Status:                "PENDING",
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+	}
+	require.NoError(t, db.Create(posting).Error)
+
+	// Verify audit outbox entry was created for the posting
+	var outbox AuditOutbox
+	err := db.Where("record_id = ? AND table_name = ?", posting.ID, "ledger_posting").First(&outbox).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, "INSERT", outbox.Operation)
+	assert.Equal(t, "pending", outbox.Status)
+}
+
+// TestAuditLedgerPostingUpdate verifies that updating a ledger posting creates an audit outbox entry
+func TestAuditLedgerPostingUpdate(t *testing.T) {
+	db, _, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	// Create a booking log first (for FK)
+	bookingLogID := uuid.New()
+	bookingLog := &FinancialBookingLogEntity{
+		ID:                      bookingLogID,
+		FinancialAccountType:    "ASSET",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "PENDING",
+		IdempotencyKey:          "audit-posting-update-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog).Error)
+
+	// Create a ledger posting
+	posting := &LedgerPostingEntity{
+		ID:                    uuid.New(),
+		FinancialBookingLogID: bookingLogID,
+		PostingDirection:      "DEBIT",
+		AmountCents:           10050,
+		Currency:              "GBP",
+		AccountID:             "ACC-001",
+		ValueDate:             time.Now(),
+		Status:                "PENDING",
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+	}
+	require.NoError(t, db.Create(posting).Error)
+
+	// Update the posting
+	posting.Status = "POSTED"
+	posting.PostingResult = "Success"
+	posting.UpdatedAt = time.Now()
+	require.NoError(t, db.Save(posting).Error)
+
+	// Verify both INSERT and UPDATE audit outbox entries exist
+	var outboxEntries []AuditOutbox
+	err := db.Where("record_id = ? AND table_name = ?", posting.ID, "ledger_posting").
+		Order("created_at ASC").
+		Find(&outboxEntries).Error
+	require.NoError(t, err)
+	require.Len(t, outboxEntries, 2, "Expected both INSERT and UPDATE audit entries")
+
+	// Verify UPDATE entry
+	assert.Equal(t, "UPDATE", outboxEntries[1].Operation)
+	assert.NotNil(t, outboxEntries[1].OldValues)
+	assert.NotNil(t, outboxEntries[1].NewValues)
+}
+
+// TestAuditOutboxStatusValues verifies the status constraint values work correctly
+func TestAuditOutboxStatusValues(t *testing.T) {
+	db, _, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	testCases := []struct {
+		name   string
+		status string
+		valid  bool
+	}{
+		{"pending status", "pending", true},
+		{"processing status", "processing", true},
+		{"completed status", "completed", true},
+		{"failed status", "failed", true},
+		{"invalid status", "invalid", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			outbox := &AuditOutbox{
+				ID:        uuid.New(),
+				Table:     "test_table",
+				Operation: "INSERT",
+				RecordID:  uuid.New(),
+				Status:    tc.status,
+				CreatedAt: time.Now(),
+			}
+
+			err := db.Create(outbox).Error
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+// TestAuditChangedByDefaultsToSystem verifies that changed_by defaults to "system" when no user context
+func TestAuditChangedByDefaultsToSystem(t *testing.T) {
+	db, _, cleanup := setupTestDBWithAudit(t)
+	defer cleanup()
+
+	// Create a booking log without user context
+	bookingLog := &FinancialBookingLogEntity{
+		ID:                      uuid.New(),
+		FinancialAccountType:    "ASSET",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  "PENDING",
+		IdempotencyKey:          "audit-system-user-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.Create(bookingLog).Error)
+
+	// Verify audit entry has "system" as changed_by
+	var outbox AuditOutbox
+	err := db.Where("record_id = ?", bookingLog.ID).First(&outbox).Error
+	require.NoError(t, err)
+
+	require.NotNil(t, outbox.ChangedBy)
+	assert.Equal(t, "system", *outbox.ChangedBy)
 }

--- a/services/financial-accounting/migrations/20251217000001_audit_system.sql
+++ b/services/financial-accounting/migrations/20251217000001_audit_system.sql
@@ -1,0 +1,89 @@
+-- Financial Accounting Audit System
+-- Static audit table creation (CockroachDB compatible)
+-- Audit logging handled at application level via GORM hooks
+-- See ADR-0009 for rationale
+-- Uses unqualified table names (relies on database-per-service architecture)
+
+-- Create audit_log table (unqualified, singular)
+CREATE TABLE IF NOT EXISTS audit_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- What changed
+    table_name VARCHAR(100) NOT NULL,
+    operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+
+    -- Record identification
+    record_id UUID NOT NULL,
+
+    -- Change metadata
+    changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    changed_by VARCHAR(100),
+
+    -- Change details
+    old_values JSONB,
+    new_values JSONB,
+
+    -- Additional context
+    transaction_id VARCHAR(100),
+    client_ip INET,
+    user_agent TEXT
+);
+
+-- Create indexes for efficient audit queries
+CREATE INDEX IF NOT EXISTS idx_audit_log_table_name ON audit_log(table_name);
+CREATE INDEX IF NOT EXISTS idx_audit_log_record_id ON audit_log(record_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_changed_at ON audit_log(changed_at);
+CREATE INDEX IF NOT EXISTS idx_audit_log_changed_by ON audit_log(changed_by);
+CREATE INDEX IF NOT EXISTS idx_audit_log_operation ON audit_log(operation);
+
+-- Create audit_outbox table for async processing (unqualified, singular)
+-- GORM hooks write to outbox, background worker moves to audit_log
+CREATE TABLE IF NOT EXISTS audit_outbox (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- What changed
+    table_name VARCHAR(100) NOT NULL,
+    operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+
+    -- Record identification
+    record_id UUID NOT NULL,
+
+    -- Change details
+    old_values JSONB,
+    new_values JSONB,
+
+    -- Processing status (includes 'completed' for successful processing)
+    status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    retry_count INT NOT NULL DEFAULT 0,
+    last_error TEXT,
+
+    -- Additional context
+    changed_by VARCHAR(100),
+    transaction_id VARCHAR(100),
+    client_ip INET,
+    user_agent TEXT
+);
+
+-- Index for worker to efficiently find pending entries
+CREATE INDEX IF NOT EXISTS idx_audit_outbox_status_created ON audit_outbox(status, created_at);
+
+-- Create helper view for easy audit queries
+CREATE OR REPLACE VIEW change_summary AS
+SELECT
+    id,
+    table_name AS table_full_name,
+    operation,
+    record_id,
+    changed_at,
+    changed_by,
+    CASE
+        WHEN operation = 'UPDATE' THEN
+            (SELECT json_object_agg(key, value)
+             FROM jsonb_each(new_values)
+             WHERE new_values->key IS DISTINCT FROM old_values->key)
+        ELSE NULL
+    END AS changed_fields,
+    transaction_id
+FROM audit_log
+ORDER BY changed_at DESC;

--- a/services/financial-accounting/migrations/atlas.sum
+++ b/services/financial-accounting/migrations/atlas.sum
@@ -1,2 +1,3 @@
-h1:Hq88TFCqpj8wIlzaSmdc1TvH04qZcPnfdK8CQVoOhs8=
+h1:WGqV99o8p/phkw1OZ9h9t5s93Db44sJeLhauT+yNbOM=
 20251216000001_initial.sql h1:QyCFEl6iIRccIm/rlDMmm0p0IrN93AlxtaHZHiWWYq0=
+20251217000001_audit_system.sql h1:yyJlrBFDysy+cDtEsb+QePFjXJSFi8OKO+di10S7tYs=

--- a/services/financial-accounting/service/grpc_integration_test.go
+++ b/services/financial-accounting/service/grpc_integration_test.go
@@ -63,6 +63,7 @@ func setupIntegrationTest(t *testing.T) (*testServer, context.Context) {
 	db, dbCleanup := testdb.SetupPostgres(t, []interface{}{
 		&persistence.FinancialBookingLogEntity{},
 		&persistence.LedgerPostingEntity{},
+		&persistence.AuditOutbox{},
 	})
 
 	// Create tenant schema
@@ -71,8 +72,8 @@ func setupIntegrationTest(t *testing.T) (*testServer, context.Context) {
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
 	require.NoError(t, err)
 
-	// Create tables in tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.financial_booking_logs (
+	// Create tables in tenant schema (singular names to match production)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.financial_booking_log (
 		id UUID PRIMARY KEY,
 		financial_account_type TEXT NOT NULL,
 		product_service_reference TEXT NOT NULL,
@@ -83,13 +84,16 @@ func setupIntegrationTest(t *testing.T) (*testServer, context.Context) {
 		idempotency_key TEXT UNIQUE NOT NULL,
 		created_at TIMESTAMP NOT NULL,
 		updated_at TIMESTAMP NOT NULL,
-		version INT NOT NULL DEFAULT 1
+		created_by VARCHAR(255),
+		updated_by VARCHAR(255),
+		version INT NOT NULL DEFAULT 1,
+		deleted_at TIMESTAMP
 	)`, schemaName)).Error
 	require.NoError(t, err)
 
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.ledger_postings (
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.ledger_posting (
 		id UUID PRIMARY KEY,
-		financial_booking_log_id UUID NOT NULL REFERENCES %q.financial_booking_logs(id) ON DELETE RESTRICT,
+		financial_booking_log_id UUID NOT NULL REFERENCES %q.financial_booking_log(id) ON DELETE RESTRICT,
 		posting_direction TEXT NOT NULL,
 		amount_cents BIGINT NOT NULL,
 		currency TEXT NOT NULL,
@@ -99,8 +103,30 @@ func setupIntegrationTest(t *testing.T) (*testServer, context.Context) {
 		correlation_id TEXT,
 		status TEXT NOT NULL,
 		created_at TIMESTAMP NOT NULL,
-		updated_at TIMESTAMP
+		updated_at TIMESTAMP,
+		created_by VARCHAR(255),
+		updated_by VARCHAR(255),
+		deleted_at TIMESTAMP
 	)`, schemaName, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create audit_outbox table for GORM hooks
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.audit_outbox (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+		record_id UUID NOT NULL,
+		old_values JSONB,
+		new_values JSONB,
+		status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		retry_count INT NOT NULL DEFAULT 0,
+		last_error TEXT,
+		changed_by VARCHAR(100),
+		transaction_id VARCHAR(100),
+		client_ip INET,
+		user_agent TEXT
+	)`, schemaName)).Error
 	require.NoError(t, err)
 
 	// Set search_path to tenant schema

--- a/services/financial-accounting/service/posting_service_test.go
+++ b/services/financial-accounting/service/posting_service_test.go
@@ -20,7 +20,11 @@ const testTenantID = "test_tenant"
 
 func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	t.Helper()
-	db, cleanup := testdb.SetupPostgres(t, []interface{}{&persistence.LedgerPostingEntity{}, &persistence.FinancialBookingLogEntity{}})
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{
+		&persistence.LedgerPostingEntity{},
+		&persistence.FinancialBookingLogEntity{},
+		&persistence.AuditOutbox{},
+	})
 
 	// Create the tenant schema for tests
 	tid := tenant.TenantID(testTenantID)
@@ -28,8 +32,8 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
 	require.NoError(t, err)
 
-	// Create tables in tenant schema
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.financial_booking_logs (
+	// Create tables in tenant schema (singular names to match production)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.financial_booking_log (
 		id UUID PRIMARY KEY,
 		financial_account_type VARCHAR(50) NOT NULL,
 		product_service_reference VARCHAR(255) NOT NULL,
@@ -40,12 +44,14 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		idempotency_key VARCHAR(255) NOT NULL UNIQUE,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(255),
+		updated_by VARCHAR(255),
 		version BIGINT NOT NULL DEFAULT 1,
 		deleted_at TIMESTAMP WITH TIME ZONE
 	)`, schemaName)).Error
 	require.NoError(t, err)
 
-	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.ledger_postings (
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.ledger_posting (
 		id UUID PRIMARY KEY,
 		financial_booking_log_id UUID NOT NULL,
 		posting_direction VARCHAR(20) NOT NULL,
@@ -53,11 +59,33 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		currency VARCHAR(3) NOT NULL,
 		account_id VARCHAR(255) NOT NULL,
 		value_date TIMESTAMP WITH TIME ZONE NOT NULL,
-		posting_result TEXT NOT NULL,
+		posting_result TEXT,
 		status VARCHAR(20) NOT NULL,
-		correlation_id VARCHAR(255) NOT NULL,
+		correlation_id VARCHAR(255),
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(255),
+		updated_by VARCHAR(255),
 		deleted_at TIMESTAMP WITH TIME ZONE
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create audit_outbox table for GORM hooks
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.audit_outbox (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL CHECK (operation IN ('INSERT', 'UPDATE', 'DELETE')),
+		record_id UUID NOT NULL,
+		old_values JSONB,
+		new_values JSONB,
+		status VARCHAR(20) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		retry_count INT NOT NULL DEFAULT 0,
+		last_error TEXT,
+		changed_by VARCHAR(100),
+		transaction_id VARCHAR(100),
+		client_ip INET,
+		user_agent TEXT
 	)`, schemaName)).Error
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary
- Add async audit logging infrastructure to financial-accounting service
- Create audit_log and audit_outbox tables via migration
- Add GORM hooks for automatic audit trail on entity changes

## Task Master Reference
- **Tag**: 75-async-audit
- **Task ID**: 11

## Changes Made
- **Migration**: `20251217000001_audit_system.sql` - Creates audit_log and audit_outbox tables following the pattern from current-account (task 7)
- **FinancialBookingLogEntity hooks**: AfterCreate, BeforeUpdate, AfterUpdate, AfterDelete - automatically audit all entity changes
- **LedgerPostingEntity hooks**: AfterCreate, BeforeUpdate, AfterUpdate, AfterDelete - automatically audit all entity changes  
- **AuditOutbox/AuditLog models**: GORM models with correct TableName() for the audit tables
- **Repository update**: Modified `UpdatePosting` to use `Save()` instead of `Updates()` to trigger GORM hooks
- **Defensive checks**: Hooks skip when entity ID is uuid.Nil (handles edge cases with db.Model().Update())
- **Test updates**: All test fixtures now include audit_outbox table creation

## Test Plan
- [x] All existing financial-accounting tests pass
- [x] New audit integration tests verify:
  - INSERT creates audit_outbox entry with new_values
  - UPDATE creates audit_outbox entry with old_values and new_values
  - DELETE creates audit_outbox entry with old_values
  - Status constraint validation (pending/processing/completed/failed)
  - changed_by defaults to "system" when no user context