### PR TITLE
feat: Create shared audit hook generator (task 15)

### DIFF
--- a/services/party/adapters/persistence/party_entity.go
+++ b/services/party/adapters/persistence/party_entity.go
@@ -2,35 +2,12 @@
 package persistence
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/shared/platform/audit"
 	"gorm.io/gorm"
 )
-
-// Audit-related errors
-var (
-	// ErrNilTransaction is returned when a nil transaction is passed to recordAudit
-	ErrNilTransaction = errors.New("tx cannot be nil for audit recording")
-
-	// ErrOldValueType is returned when old value has incorrect type in context
-	ErrOldValueType = errors.New("failed to retrieve old party values from context: invalid type")
-
-	// ErrOldValueNotFound is returned when old value is not found in context
-	ErrOldValueNotFound = errors.New("old party values not found in context")
-)
-
-// contextKey is a private type for context keys to avoid collisions
-type contextKey string
-
-// auditOldValueKey is the context key used to store old values before an UPDATE operation.
-// This allows BeforeUpdate hook to capture the old state and pass it to AfterUpdate hook.
-const auditOldValueKey contextKey = "audit:old_party_value"
 
 // PartyEntity represents the database persistence model for parties.
 // This entity MUST match the schema defined in migrations/party/*.sql
@@ -64,90 +41,22 @@ func (PartyEntity) TableName() string {
 	return "party"
 }
 
-// PartyAuditOutbox represents an audit record waiting to be processed by the background worker.
-// Records are written to the outbox within the same transaction as the business operation,
-// ensuring atomicity and preventing lost audit records.
-type PartyAuditOutbox struct {
-	ID            uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
-	Table         string    `gorm:"column:table_name;type:varchar(100);not null;index"`
-	Operation     string    `gorm:"type:varchar(10);not null;index"` // INSERT, UPDATE, DELETE
-	RecordID      uuid.UUID `gorm:"type:uuid;not null;index"`
-	OldValues     string    `gorm:"type:text"`                                         // JSON representation of old values
-	NewValues     string    `gorm:"type:text"`                                         // JSON representation of new values
-	Status        string    `gorm:"type:varchar(20);not null;default:'pending';index"` // pending, processing, completed, failed
-	CreatedAt     time.Time `gorm:"not null;default:CURRENT_TIMESTAMP"`
-	RetryCount    int       `gorm:"not null;default:0"`
-	LastError     *string   `gorm:"type:text"`
-	ChangedBy     *string   `gorm:"type:varchar(100)"`
-	TransactionID *string   `gorm:"type:varchar(100)"`
-	ClientIP      *string   `gorm:"type:varchar(45)"` // Pointer for NULL support
-	UserAgent     *string   `gorm:"type:text"`
+// AuditID returns the record ID as a string for audit logging.
+// Implements the audit.Auditable interface.
+func (p PartyEntity) AuditID() string {
+	return p.ID.String()
 }
 
-// TableName overrides the table name for PartyAuditOutbox.
-// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
-func (PartyAuditOutbox) TableName() string {
-	return "audit_outbox"
-}
-
-// recordPartyAudit writes an audit outbox entry within the current transaction.
-// This function is called by GORM hooks (AfterCreate, AfterUpdate, AfterDelete).
-func recordPartyAudit(tx *gorm.DB, tableName, operation string, recordID uuid.UUID, oldValue, newValue interface{}) error {
-	if tx == nil {
-		return ErrNilTransaction
-	}
-
-	// Serialize old and new values to JSON
-	var oldJSON, newJSON string
-
-	if oldValue != nil {
-		oldBytes, err := json.Marshal(oldValue)
-		if err != nil {
-			return fmt.Errorf("failed to marshal old value: %w", err)
-		}
-		oldJSON = string(oldBytes)
-	}
-
-	if newValue != nil {
-		newBytes, err := json.Marshal(newValue)
-		if err != nil {
-			return fmt.Errorf("failed to marshal new value: %w", err)
-		}
-		newJSON = string(newBytes)
-	}
-
-	// Extract user ID from context
-	var changedBy *string
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		userID := audit.GetUserFromContext(tx.Statement.Context)
-		changedBy = &userID
-	}
-	if changedBy == nil {
-		defaultUser := audit.DefaultAuditUser
-		changedBy = &defaultUser
-	}
-
-	// Create audit outbox entry
-	outbox := PartyAuditOutbox{
-		ID:        uuid.New(),
-		Table:     tableName,
-		Operation: operation,
-		RecordID:  recordID,
-		OldValues: oldJSON,
-		NewValues: newJSON,
-		Status:    "pending",
-		ChangedBy: changedBy,
-		CreatedAt: time.Now(),
-	}
-
-	// Write to outbox within the same transaction
-	return tx.Create(&outbox).Error
+// AuditTableName returns the table name for audit logging.
+// Implements the audit.Auditable interface.
+func (p PartyEntity) AuditTableName() string {
+	return p.TableName()
 }
 
 // AfterCreate is a GORM hook that runs after INSERT operations on PartyEntity.
 // It writes an audit outbox entry with the new party data.
 func (p *PartyEntity) AfterCreate(tx *gorm.DB) error {
-	return recordPartyAudit(tx, "party", "INSERT", p.ID, nil, p)
+	return audit.RecordCreate(tx, *p)
 }
 
 // BeforeUpdate is a GORM hook that runs before UPDATE operations on PartyEntity.
@@ -157,26 +66,7 @@ func (p *PartyEntity) AfterCreate(tx *gorm.DB) error {
 // - The entity ID is not set (map-based updates via Model(&Entity{}).Updates(map...))
 // - These patterns bypass hooks in GORM; the repository uses them for optimistic locking
 func (p *PartyEntity) BeforeUpdate(tx *gorm.DB) error {
-	// Skip if ID is not set - this happens with map-based updates
-	// where the model is an empty struct used only for table name resolution
-	if p.ID == uuid.Nil {
-		return nil
-	}
-
-	// Capture old values before the update
-	// Use Unscoped() to find records even if soft-deleted (for audit completeness)
-	var old PartyEntity
-	if err := tx.Unscoped().First(&old, p.ID).Error; err != nil {
-		return fmt.Errorf("failed to fetch old party values: %w", err)
-	}
-
-	// Store old values in transaction context for AfterUpdate to access
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		ctx := context.WithValue(tx.Statement.Context, auditOldValueKey, &old)
-		tx.Statement.Context = ctx
-	}
-
-	return nil
+	return audit.CaptureOldValue(tx, *p)
 }
 
 // AfterUpdate is a GORM hook that runs after UPDATE operations on PartyEntity.
@@ -186,33 +76,15 @@ func (p *PartyEntity) BeforeUpdate(tx *gorm.DB) error {
 // - The entity ID is not set (map-based updates bypass hooks)
 // - Old values are not in context (BeforeUpdate was skipped)
 func (p *PartyEntity) AfterUpdate(tx *gorm.DB) error {
-	// Skip if ID is not set - this happens with map-based updates
-	if p.ID == uuid.Nil {
-		return nil
-	}
-
-	// Retrieve old values from context (captured in BeforeUpdate)
-	var old *PartyEntity
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		if oldValue := tx.Statement.Context.Value(auditOldValueKey); oldValue != nil {
-			var ok bool
-			old, ok = oldValue.(*PartyEntity)
-			if !ok {
-				return ErrOldValueType
-			}
-		}
-	}
-
-	// Skip audit if old values are not available (BeforeUpdate was skipped)
-	if old == nil {
-		return nil
-	}
-
-	return recordPartyAudit(tx, "party", "UPDATE", p.ID, old, p)
+	return audit.RecordUpdate(tx, *p)
 }
 
 // AfterDelete is a GORM hook that runs after DELETE operations on PartyEntity.
 // It writes an audit outbox entry with the deleted party data.
 func (p *PartyEntity) AfterDelete(tx *gorm.DB) error {
-	return recordPartyAudit(tx, "party", "DELETE", p.ID, p, nil)
+	return audit.RecordDelete(tx, *p)
 }
+
+// PartyAuditOutbox is an alias for the shared audit.AuditOutbox type.
+// Kept for backward compatibility with existing tests and migrations.
+type PartyAuditOutbox = audit.AuditOutbox

--- a/services/party/adapters/persistence/repository_test.go
+++ b/services/party/adapters/persistence/repository_test.go
@@ -710,7 +710,7 @@ func TestAudit_CreateParty_WritesAuditOutboxEntry(t *testing.T) {
 	auditEntry := auditEntries[0]
 	assert.Equal(t, "party", auditEntry.Table, "Table name should be 'party'")
 	assert.Equal(t, "INSERT", auditEntry.Operation, "Operation should be INSERT")
-	assert.Equal(t, party.ID(), auditEntry.RecordID, "Record ID should match party ID")
+	assert.Equal(t, party.ID().String(), auditEntry.RecordID, "Record ID should match party ID")
 	assert.Equal(t, "pending", auditEntry.Status, "Status should be pending")
 	assert.Empty(t, auditEntry.OldValues, "Old values should be empty for INSERT")
 	assert.NotEmpty(t, auditEntry.NewValues, "New values should contain party data")

--- a/services/tenant/adapters/persistence/audit.go
+++ b/services/tenant/adapters/persistence/audit.go
@@ -2,46 +2,20 @@
 package persistence
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/meridianhub/meridian/shared/platform/audit"
 	"gorm.io/gorm"
 )
 
-const (
-	// systemUser is the default user ID for background jobs and migrations
-	systemUser = "system"
-)
-
-var (
-	// ErrNilTransaction is returned when a nil transaction is passed to recordAudit
-	ErrNilTransaction = errors.New("tx cannot be nil for audit recording")
-
-	// ErrOldValueType is returned when old value has incorrect type in context
-	ErrOldValueType = errors.New("failed to retrieve old tenant values from context: invalid type")
-
-	// ErrOldValueNotFound is returned when old value is not found in context
-	ErrOldValueNotFound = errors.New("old tenant values not found in context")
-)
-
-// contextKey is a private type for context keys to avoid collisions
-type contextKey string
-
-// auditOldValueKey is the context key used to store old values before an UPDATE operation.
-// This allows BeforeUpdate hook to capture the old state and pass it to AfterUpdate hook.
-const auditOldValueKey contextKey = "audit:old_value"
-
-// AuditOutbox represents an audit record waiting to be processed by the background worker.
+// TenantAuditOutbox represents an audit record waiting to be processed by the background worker.
 // Records are written to the outbox within the same transaction as the business operation,
 // ensuring atomicity and preventing lost audit records.
 //
-// Note: Tenant service uses string IDs (varchar(50)) for record_id, not UUIDs.
-type AuditOutbox struct {
+// Note: This is a service-specific type kept for backward compatibility with existing migrations.
+// Uses string IDs (varchar(50)) for record_id since tenants use string IDs.
+type TenantAuditOutbox struct {
 	ID            uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
 	Table         string    `gorm:"column:table_name;type:varchar(100);not null;index" json:"table_name"`
 	Operation     string    `gorm:"type:varchar(10);not null;index" json:"operation"` // INSERT, UPDATE, DELETE
@@ -58,18 +32,18 @@ type AuditOutbox struct {
 	UserAgent     *string   `gorm:"type:text" json:"user_agent,omitempty"`
 }
 
-// TableName overrides the table name for AuditOutbox.
+// TableName overrides the table name for TenantAuditOutbox.
 // Uses singular unqualified name to allow PostgreSQL search_path to route queries.
-func (AuditOutbox) TableName() string {
+func (TenantAuditOutbox) TableName() string {
 	return "audit_outbox"
 }
 
-// AuditLog represents a permanent audit log entry.
+// TenantAuditLog represents a permanent audit log entry.
 // Records are moved from the audit_outbox to audit_log by the background worker.
 // Once written, audit log entries are immutable and provide a permanent audit trail.
 //
-// Note: Tenant service uses string IDs (varchar(50)) for record_id, not UUIDs.
-type AuditLog struct {
+// Note: Uses string IDs (varchar(50)) for record_id since tenants use string IDs.
+type TenantAuditLog struct {
 	ID            uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
 	Table         string    `gorm:"column:table_name;type:varchar(100);not null;index" json:"table_name"`
 	Operation     string    `gorm:"type:varchar(10);not null;index" json:"operation"` // INSERT, UPDATE, DELETE
@@ -83,108 +57,16 @@ type AuditLog struct {
 	UserAgent     *string   `gorm:"type:text" json:"user_agent,omitempty"`
 }
 
-// TableName overrides the table name for AuditLog.
+// TableName overrides the table name for TenantAuditLog.
 // Uses singular unqualified name to allow PostgreSQL search_path to route queries.
-func (AuditLog) TableName() string {
+func (TenantAuditLog) TableName() string {
 	return "audit_log"
-}
-
-// recordAudit writes an audit outbox entry within the current transaction.
-// This function is called by GORM hooks (AfterCreate, AfterUpdate, AfterDelete).
-//
-// Parameters:
-//   - tx: The GORM transaction (must be non-nil)
-//   - tableName: The table being audited (e.g., "tenant")
-//   - operation: The operation type ("INSERT", "UPDATE", "DELETE")
-//   - recordID: The string ID of the record being audited (tenant ID)
-//   - oldValue: The old state (nil for INSERT, populated for UPDATE/DELETE)
-//   - newValue: The new state (populated for INSERT/UPDATE, nil for DELETE)
-//
-// Returns:
-//   - error: Any error encountered during audit recording
-func recordAudit(tx *gorm.DB, tableName, operation, recordID string, oldValue, newValue interface{}) error {
-	if tx == nil {
-		return ErrNilTransaction
-	}
-
-	// Serialize old and new values to JSON
-	var oldJSON, newJSON string
-
-	if oldValue != nil {
-		oldBytes, err := json.Marshal(oldValue)
-		if err != nil {
-			return fmt.Errorf("failed to marshal old value: %w", err)
-		}
-		oldJSON = string(oldBytes)
-	}
-
-	if newValue != nil {
-		newBytes, err := json.Marshal(newValue)
-		if err != nil {
-			return fmt.Errorf("failed to marshal new value: %w", err)
-		}
-		newJSON = string(newBytes)
-	}
-
-	// Extract user ID from context
-	var changedBy *string
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		if userID := getUserIDFromContext(tx.Statement.Context); userID != "" {
-			changedBy = &userID
-		}
-	}
-	if changedBy == nil {
-		// Default to system
-		user := systemUser
-		changedBy = &user
-	}
-
-	// Create audit outbox entry
-	outbox := AuditOutbox{
-		ID:        uuid.New(),
-		Table:     tableName,
-		Operation: operation,
-		RecordID:  recordID,
-		OldValues: oldJSON,
-		NewValues: newJSON,
-		Status:    "pending",
-		ChangedBy: changedBy,
-		CreatedAt: time.Now(),
-	}
-
-	// Write to outbox within the same transaction
-	return tx.Create(&outbox).Error
-}
-
-// getUserIDFromContext extracts the user ID from the context.
-// Returns empty string if not found or if type assertion fails.
-func getUserIDFromContext(ctx any) string {
-	if ctx == nil {
-		return ""
-	}
-
-	// Safely convert to context.Context interface
-	stdCtx, ok := ctx.(context.Context)
-	if !ok {
-		return ""
-	}
-
-	// Try to extract user_id from context (set by JWT auth interceptor)
-	if userID, ok := stdCtx.Value(auth.UserIDContextKey).(string); ok {
-		return userID
-	}
-
-	return ""
 }
 
 // AfterCreate is a GORM hook that runs after INSERT operations on TenantEntity.
 // It writes an audit outbox entry with the new tenant data.
 func (t *TenantEntity) AfterCreate(tx *gorm.DB) error {
-	// Skip if entity ID is not set (shouldn't happen for Create, but defensive)
-	if t.ID == "" {
-		return nil
-	}
-	return recordAudit(tx, "tenant", "INSERT", t.ID, nil, t)
+	return audit.RecordCreate(tx, *t)
 }
 
 // BeforeUpdate is a GORM hook that runs before UPDATE operations on TenantEntity.
@@ -193,25 +75,7 @@ func (t *TenantEntity) AfterCreate(tx *gorm.DB) error {
 // Note: This hook only runs for model-based updates (Save) where t.ID is populated.
 // Map-based updates (Updates(map)) via Repository methods bypass this hook.
 func (t *TenantEntity) BeforeUpdate(tx *gorm.DB) error {
-	// Skip if entity ID is not set (happens with map-based updates like Updates(map))
-	// Map-based updates don't trigger hooks on the actual entity instance
-	if t.ID == "" {
-		return nil
-	}
-
-	// Capture old values before the update
-	var old TenantEntity
-	if err := tx.First(&old, "id = ?", t.ID).Error; err != nil {
-		return fmt.Errorf("failed to fetch old tenant values: %w", err)
-	}
-
-	// Store old values in transaction context for AfterUpdate to access
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		ctx := context.WithValue(tx.Statement.Context, auditOldValueKey, &old)
-		tx.Statement.Context = ctx
-	}
-
-	return nil
+	return audit.CaptureOldValue(tx, *t)
 }
 
 // AfterUpdate is a GORM hook that runs after UPDATE operations on TenantEntity.
@@ -220,37 +84,18 @@ func (t *TenantEntity) BeforeUpdate(tx *gorm.DB) error {
 // Note: This hook only runs for model-based updates (Save) where BeforeUpdate captured old values.
 // Map-based updates (Updates(map)) via Repository methods bypass audit recording.
 func (t *TenantEntity) AfterUpdate(tx *gorm.DB) error {
-	// Skip if entity ID is not set (happens with map-based updates like Updates(map))
-	if t.ID == "" {
-		return nil
-	}
-
-	// Retrieve old values from context (captured in BeforeUpdate)
-	var old *TenantEntity
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		if oldValue := tx.Statement.Context.Value(auditOldValueKey); oldValue != nil {
-			var ok bool
-			old, ok = oldValue.(*TenantEntity)
-			if !ok {
-				return ErrOldValueType
-			}
-		}
-	}
-
-	// Skip audit if old values weren't captured (map-based update)
-	if old == nil {
-		return nil
-	}
-
-	return recordAudit(tx, "tenant", "UPDATE", t.ID, old, t)
+	return audit.RecordUpdate(tx, *t)
 }
 
 // AfterDelete is a GORM hook that runs after DELETE operations on TenantEntity.
 // It writes an audit outbox entry with the deleted tenant data.
 func (t *TenantEntity) AfterDelete(tx *gorm.DB) error {
-	// Skip if entity ID is not set (shouldn't happen for Delete, but defensive)
-	if t.ID == "" {
-		return nil
-	}
-	return recordAudit(tx, "tenant", "DELETE", t.ID, t, nil)
+	return audit.RecordDelete(tx, *t)
 }
+
+// systemUser is an alias for audit.DefaultAuditUser for backward compatibility with tests.
+const systemUser = audit.DefaultAuditUser
+
+// AuditOutbox is an alias for the shared audit.AuditOutbox type.
+// Kept for backward compatibility with existing tests.
+type AuditOutbox = audit.AuditOutbox

--- a/services/tenant/adapters/persistence/entity.go
+++ b/services/tenant/adapters/persistence/entity.go
@@ -33,6 +33,18 @@ func (TenantEntity) TableName() string {
 	return "tenant"
 }
 
+// AuditID returns the record ID as a string for audit logging.
+// Implements the audit.Auditable interface.
+func (t TenantEntity) AuditID() string {
+	return t.ID
+}
+
+// AuditTableName returns the table name for audit logging.
+// Implements the audit.Auditable interface.
+func (t TenantEntity) AuditTableName() string {
+	return t.TableName()
+}
+
 // JSONMap is a custom type for JSONB columns.
 type JSONMap map[string]interface{}
 

--- a/shared/domain/models/account.go
+++ b/shared/domain/models/account.go
@@ -2,11 +2,10 @@
 package models
 
 import (
-	"context"
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/audit"
 	"gorm.io/gorm"
 )
 
@@ -44,10 +43,22 @@ func (Account) TableName() string {
 	return "account"
 }
 
+// AuditID returns the record ID as a string for audit logging.
+// Implements the audit.Auditable interface.
+func (a Account) AuditID() string {
+	return a.ID.String()
+}
+
+// AuditTableName returns the table name for audit logging.
+// Implements the audit.Auditable interface.
+func (a Account) AuditTableName() string {
+	return a.TableName()
+}
+
 // AfterCreate is a GORM hook that runs after INSERT operations on Account.
 // It writes an audit outbox entry with the new account data.
 func (a *Account) AfterCreate(tx *gorm.DB) error {
-	return recordAudit(tx, "account", "INSERT", a.ID, nil, a)
+	return audit.RecordCreate(tx, *a)
 }
 
 // BeforeUpdate is a GORM hook that runs before UPDATE operations on Account.
@@ -57,46 +68,17 @@ func (a *Account) BeforeUpdate(tx *gorm.DB) error {
 	if err := a.BaseModel.BeforeUpdate(tx); err != nil {
 		return err
 	}
-
-	// Capture old values before the update
-	var old Account
-	if err := tx.First(&old, a.ID).Error; err != nil {
-		return fmt.Errorf("failed to fetch old account values: %w", err)
-	}
-
-	// Store old values in transaction context for AfterUpdate to access
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		ctx := context.WithValue(tx.Statement.Context, auditAccountOldValueKey, &old)
-		tx.Statement.Context = ctx
-	}
-
-	return nil
+	return audit.CaptureOldValue(tx, *a)
 }
 
 // AfterUpdate is a GORM hook that runs after UPDATE operations on Account.
 // It retrieves the old values from context and writes an audit outbox entry.
 func (a *Account) AfterUpdate(tx *gorm.DB) error {
-	// Retrieve old values from context (captured in BeforeUpdate)
-	var old *Account
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		if oldValue := tx.Statement.Context.Value(auditAccountOldValueKey); oldValue != nil {
-			var ok bool
-			old, ok = oldValue.(*Account)
-			if !ok {
-				return ErrAccountOldValueType
-			}
-		}
-	}
-
-	if old == nil {
-		return ErrAccountOldValueNotFound
-	}
-
-	return recordAudit(tx, "account", "UPDATE", a.ID, old, a)
+	return audit.RecordUpdate(tx, *a)
 }
 
 // AfterDelete is a GORM hook that runs after DELETE operations on Account.
 // It writes an audit outbox entry with the deleted account data.
 func (a *Account) AfterDelete(tx *gorm.DB) error {
-	return recordAudit(tx, "account", "DELETE", a.ID, a, nil)
+	return audit.RecordDelete(tx, *a)
 }

--- a/shared/domain/models/audit.go
+++ b/shared/domain/models/audit.go
@@ -1,49 +1,20 @@
+// Package models provides legacy audit types for backward compatibility.
+// New code should use the audit helpers from shared/platform/audit package.
 package models
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
-	"gorm.io/gorm"
 )
-
-var (
-	// ErrNilTransaction is returned when a nil transaction is passed to recordAudit
-	ErrNilTransaction = errors.New("tx cannot be nil for audit recording")
-
-	// ErrOldValueType is returned when old value has incorrect type in context
-	ErrOldValueType = errors.New("failed to retrieve old customer values from context: invalid type")
-
-	// ErrOldValueNotFound is returned when old value is not found in context
-	ErrOldValueNotFound = errors.New("old customer values not found in context")
-
-	// ErrAccountOldValueType is returned when old account value has incorrect type in context
-	ErrAccountOldValueType = errors.New("failed to retrieve old account values from context: invalid type")
-
-	// ErrAccountOldValueNotFound is returned when old account value is not found in context
-	ErrAccountOldValueNotFound = errors.New("old account values not found in context")
-)
-
-// contextKey is a private type for context keys to avoid collisions
-type contextKey string
-
-// auditOldValueKey is the context key used to store old Customer values before an UPDATE operation.
-// This allows BeforeUpdate hook to capture the old state and pass it to AfterUpdate hook.
-const auditOldValueKey contextKey = "audit:old_value:customer"
-
-// auditAccountOldValueKey is the context key used to store old Account values before an UPDATE operation.
-// This allows BeforeUpdate hook to capture the old state and pass it to AfterUpdate hook.
-const auditAccountOldValueKey contextKey = "audit:old_value:account"
 
 // AuditOutbox represents an audit record waiting to be processed by the background worker.
 // Records are written to the outbox within the same transaction as the business operation,
 // ensuring atomicity and preventing lost audit records.
 //
-// The background worker (Phase 3) will asynchronously move records from outbox to audit_log.
+// Note: This is a legacy type kept for backward compatibility with existing migrations.
+// The canonical AuditOutbox is now in shared/platform/audit.AuditOutbox (uses string RecordID).
+// This version uses uuid.UUID for RecordID for compatibility with UUID-based entities.
 type AuditOutbox struct {
 	ID            uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
 	Table         string    `gorm:"column:table_name;type:varchar(100);not null;index" json:"table_name"`
@@ -88,128 +59,4 @@ type AuditLog struct {
 // Uses singular unqualified name to allow PostgreSQL search_path to route queries.
 func (AuditLog) TableName() string {
 	return "audit_log"
-}
-
-// recordAudit writes an audit outbox entry within the current transaction.
-// This function is called by GORM hooks (AfterCreate, AfterUpdate, AfterDelete).
-//
-// Parameters:
-//   - tx: The GORM transaction (must be non-nil)
-//   - tableName: The table being audited (e.g., "customer")
-//   - operation: The operation type ("INSERT", "UPDATE", "DELETE")
-//   - recordID: The UUID of the record being audited
-//   - oldValue: The old state (nil for INSERT, populated for UPDATE/DELETE)
-//   - newValue: The new state (populated for INSERT/UPDATE, nil for DELETE)
-//
-// Returns:
-//   - error: Any error encountered during audit recording
-func recordAudit(tx *gorm.DB, tableName, operation string, recordID uuid.UUID, oldValue, newValue interface{}) error {
-	if tx == nil {
-		return ErrNilTransaction
-	}
-
-	// Serialize old and new values to JSON
-	var oldJSON, newJSON string
-
-	if oldValue != nil {
-		oldBytes, err := json.Marshal(oldValue)
-		if err != nil {
-			return fmt.Errorf("failed to marshal old value: %w", err)
-		}
-		oldJSON = string(oldBytes)
-	}
-
-	if newValue != nil {
-		newBytes, err := json.Marshal(newValue)
-		if err != nil {
-			return fmt.Errorf("failed to marshal new value: %w", err)
-		}
-		newJSON = string(newBytes)
-	}
-
-	// Extract user ID from context
-	var changedBy *string
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		if userID := getUserIDFromContext(tx.Statement.Context); userID != "" {
-			changedBy = &userID
-		}
-	}
-	if changedBy == nil {
-		// Default to system
-		systemUser := SystemUser
-		changedBy = &systemUser
-	}
-
-	// Create audit outbox entry
-	outbox := AuditOutbox{
-		ID:        uuid.New(),
-		Table:     tableName,
-		Operation: operation,
-		RecordID:  recordID,
-		OldValues: oldJSON,
-		NewValues: newJSON,
-		Status:    "pending",
-		ChangedBy: changedBy,
-		CreatedAt: time.Now(),
-	}
-
-	// Write to outbox within the same transaction
-	return tx.Create(&outbox).Error
-}
-
-// AfterCreate is a GORM hook that runs after INSERT operations on Customer.
-// It writes an audit outbox entry with the new customer data.
-func (c *Customer) AfterCreate(tx *gorm.DB) error {
-	return recordAudit(tx, "customer", "INSERT", c.ID, nil, c)
-}
-
-// BeforeUpdate is a GORM hook that runs before UPDATE operations on Customer.
-// It captures the old values BEFORE the update happens and stores them in the transaction context.
-func (c *Customer) BeforeUpdate(tx *gorm.DB) error {
-	// First, call the base model's BeforeUpdate to handle UpdatedBy
-	if err := c.BaseModel.BeforeUpdate(tx); err != nil {
-		return err
-	}
-
-	// Capture old values before the update
-	var old Customer
-	if err := tx.First(&old, c.ID).Error; err != nil {
-		return fmt.Errorf("failed to fetch old customer values: %w", err)
-	}
-
-	// Store old values in transaction context for AfterUpdate to access
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		ctx := context.WithValue(tx.Statement.Context, auditOldValueKey, &old)
-		tx.Statement.Context = ctx
-	}
-
-	return nil
-}
-
-// AfterUpdate is a GORM hook that runs after UPDATE operations on Customer.
-// It retrieves the old values from context and writes an audit outbox entry.
-func (c *Customer) AfterUpdate(tx *gorm.DB) error {
-	// Retrieve old values from context (captured in BeforeUpdate)
-	var old *Customer
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		if oldValue := tx.Statement.Context.Value(auditOldValueKey); oldValue != nil {
-			var ok bool
-			old, ok = oldValue.(*Customer)
-			if !ok {
-				return ErrOldValueType
-			}
-		}
-	}
-
-	if old == nil {
-		return ErrOldValueNotFound
-	}
-
-	return recordAudit(tx, "customer", "UPDATE", c.ID, old, c)
-}
-
-// AfterDelete is a GORM hook that runs after DELETE operations on Customer.
-// It writes an audit outbox entry with the deleted customer data.
-func (c *Customer) AfterDelete(tx *gorm.DB) error {
-	return recordAudit(tx, "customer", "DELETE", c.ID, c, nil)
 }

--- a/shared/domain/models/customer.go
+++ b/shared/domain/models/customer.go
@@ -1,6 +1,11 @@
 // Package models defines domain models for the Meridian banking platform.
 package models
 
+import (
+	"github.com/meridianhub/meridian/shared/platform/audit"
+	"gorm.io/gorm"
+)
+
 // Customer represents a bank customer in the system
 type Customer struct {
 	BaseModel
@@ -24,4 +29,44 @@ type Customer struct {
 // to tenant-specific schemas (e.g., tenant_acme_bank.customer).
 func (Customer) TableName() string {
 	return "customer"
+}
+
+// AuditID returns the record ID as a string for audit logging.
+// Implements the audit.Auditable interface.
+func (c Customer) AuditID() string {
+	return c.ID.String()
+}
+
+// AuditTableName returns the table name for audit logging.
+// Implements the audit.Auditable interface.
+func (c Customer) AuditTableName() string {
+	return c.TableName()
+}
+
+// AfterCreate is a GORM hook that runs after INSERT operations on Customer.
+// It writes an audit outbox entry with the new customer data.
+func (c *Customer) AfterCreate(tx *gorm.DB) error {
+	return audit.RecordCreate(tx, *c)
+}
+
+// BeforeUpdate is a GORM hook that runs before UPDATE operations on Customer.
+// It captures the old values BEFORE the update happens and stores them in the transaction context.
+func (c *Customer) BeforeUpdate(tx *gorm.DB) error {
+	// First, call the base model's BeforeUpdate to handle UpdatedBy
+	if err := c.BaseModel.BeforeUpdate(tx); err != nil {
+		return err
+	}
+	return audit.CaptureOldValue(tx, *c)
+}
+
+// AfterUpdate is a GORM hook that runs after UPDATE operations on Customer.
+// It retrieves the old values from context and writes an audit outbox entry.
+func (c *Customer) AfterUpdate(tx *gorm.DB) error {
+	return audit.RecordUpdate(tx, *c)
+}
+
+// AfterDelete is a GORM hook that runs after DELETE operations on Customer.
+// It writes an audit outbox entry with the deleted customer data.
+func (c *Customer) AfterDelete(tx *gorm.DB) error {
+	return audit.RecordDelete(tx, *c)
 }

--- a/shared/domain/models/financial_position_log.go
+++ b/shared/domain/models/financial_position_log.go
@@ -1,11 +1,10 @@
 package models
 
 import (
-	"context"
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/audit"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
@@ -118,32 +117,22 @@ func (AuditTrailEntry) TableName() string {
 	return "audit_trail_entry"
 }
 
-// Context keys for storing old values during UPDATE operations.
-// These allow BeforeUpdate hooks to pass old state to AfterUpdate hooks.
-const (
-	financialPositionLogOldValueKey contextKey = "audit:financial_position_log:old_value"
-	transactionLogEntryOldValueKey  contextKey = "audit:transaction_log_entry:old_value"
-)
+// AuditID returns the record ID as a string for audit logging.
+// Implements the audit.Auditable interface.
+func (f FinancialPositionLog) AuditID() string {
+	return f.ID.String()
+}
 
-// Audit hook errors for FinancialPositionLog and TransactionLogEntry
-var (
-	// ErrFinancialPositionLogOldValueType is returned when old value has incorrect type in context
-	ErrFinancialPositionLogOldValueType = fmt.Errorf("failed to retrieve old financial_position_log values from context: invalid type")
-
-	// ErrFinancialPositionLogOldValueNotFound is returned when old value is not found in context
-	ErrFinancialPositionLogOldValueNotFound = fmt.Errorf("old financial_position_log values not found in context")
-
-	// ErrTransactionLogEntryOldValueType is returned when old value has incorrect type in context
-	ErrTransactionLogEntryOldValueType = fmt.Errorf("failed to retrieve old transaction_log_entry values from context: invalid type")
-
-	// ErrTransactionLogEntryOldValueNotFound is returned when old value is not found in context
-	ErrTransactionLogEntryOldValueNotFound = fmt.Errorf("old transaction_log_entry values not found in context")
-)
+// AuditTableName returns the table name for audit logging.
+// Implements the audit.Auditable interface.
+func (f FinancialPositionLog) AuditTableName() string {
+	return f.TableName()
+}
 
 // AfterCreate is a GORM hook that runs after INSERT operations on FinancialPositionLog.
 // It writes an audit outbox entry with the new financial position log data.
 func (f *FinancialPositionLog) AfterCreate(tx *gorm.DB) error {
-	return recordAudit(tx, "financial_position_log", "INSERT", f.ID, nil, f)
+	return audit.RecordCreate(tx, *f)
 }
 
 // BeforeUpdate is a GORM hook that runs before UPDATE operations on FinancialPositionLog.
@@ -153,54 +142,37 @@ func (f *FinancialPositionLog) BeforeUpdate(tx *gorm.DB) error {
 	if err := f.BaseModel.BeforeUpdate(tx); err != nil {
 		return err
 	}
-
-	// Capture old values before the update
-	var old FinancialPositionLog
-	if err := tx.First(&old, f.ID).Error; err != nil {
-		return fmt.Errorf("failed to fetch old financial_position_log values: %w", err)
-	}
-
-	// Store old values in transaction context for AfterUpdate to access
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		ctx := context.WithValue(tx.Statement.Context, financialPositionLogOldValueKey, &old)
-		tx.Statement.Context = ctx
-	}
-
-	return nil
+	return audit.CaptureOldValue(tx, *f)
 }
 
 // AfterUpdate is a GORM hook that runs after UPDATE operations on FinancialPositionLog.
 // It retrieves the old values from context and writes an audit outbox entry.
 func (f *FinancialPositionLog) AfterUpdate(tx *gorm.DB) error {
-	// Retrieve old values from context (captured in BeforeUpdate)
-	var old *FinancialPositionLog
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		if oldValue := tx.Statement.Context.Value(financialPositionLogOldValueKey); oldValue != nil {
-			var ok bool
-			old, ok = oldValue.(*FinancialPositionLog)
-			if !ok {
-				return ErrFinancialPositionLogOldValueType
-			}
-		}
-	}
-
-	if old == nil {
-		return ErrFinancialPositionLogOldValueNotFound
-	}
-
-	return recordAudit(tx, "financial_position_log", "UPDATE", f.ID, old, f)
+	return audit.RecordUpdate(tx, *f)
 }
 
 // AfterDelete is a GORM hook that runs after DELETE operations on FinancialPositionLog.
 // It writes an audit outbox entry with the deleted financial position log data.
 func (f *FinancialPositionLog) AfterDelete(tx *gorm.DB) error {
-	return recordAudit(tx, "financial_position_log", "DELETE", f.ID, f, nil)
+	return audit.RecordDelete(tx, *f)
+}
+
+// AuditID returns the record ID as a string for audit logging.
+// Implements the audit.Auditable interface.
+func (t TransactionLogEntry) AuditID() string {
+	return t.ID.String()
+}
+
+// AuditTableName returns the table name for audit logging.
+// Implements the audit.Auditable interface.
+func (t TransactionLogEntry) AuditTableName() string {
+	return t.TableName()
 }
 
 // AfterCreate is a GORM hook that runs after INSERT operations on TransactionLogEntry.
 // It writes an audit outbox entry with the new transaction log entry data.
 func (t *TransactionLogEntry) AfterCreate(tx *gorm.DB) error {
-	return recordAudit(tx, "transaction_log_entry", "INSERT", t.ID, nil, t)
+	return audit.RecordCreate(tx, *t)
 }
 
 // BeforeUpdate is a GORM hook that runs before UPDATE operations on TransactionLogEntry.
@@ -210,46 +182,17 @@ func (t *TransactionLogEntry) BeforeUpdate(tx *gorm.DB) error {
 	if err := t.BaseModel.BeforeUpdate(tx); err != nil {
 		return err
 	}
-
-	// Capture old values before the update
-	var old TransactionLogEntry
-	if err := tx.First(&old, t.ID).Error; err != nil {
-		return fmt.Errorf("failed to fetch old transaction_log_entry values: %w", err)
-	}
-
-	// Store old values in transaction context for AfterUpdate to access
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		ctx := context.WithValue(tx.Statement.Context, transactionLogEntryOldValueKey, &old)
-		tx.Statement.Context = ctx
-	}
-
-	return nil
+	return audit.CaptureOldValue(tx, *t)
 }
 
 // AfterUpdate is a GORM hook that runs after UPDATE operations on TransactionLogEntry.
 // It retrieves the old values from context and writes an audit outbox entry.
 func (t *TransactionLogEntry) AfterUpdate(tx *gorm.DB) error {
-	// Retrieve old values from context (captured in BeforeUpdate)
-	var old *TransactionLogEntry
-	if tx.Statement != nil && tx.Statement.Context != nil {
-		if oldValue := tx.Statement.Context.Value(transactionLogEntryOldValueKey); oldValue != nil {
-			var ok bool
-			old, ok = oldValue.(*TransactionLogEntry)
-			if !ok {
-				return ErrTransactionLogEntryOldValueType
-			}
-		}
-	}
-
-	if old == nil {
-		return ErrTransactionLogEntryOldValueNotFound
-	}
-
-	return recordAudit(tx, "transaction_log_entry", "UPDATE", t.ID, old, t)
+	return audit.RecordUpdate(tx, *t)
 }
 
 // AfterDelete is a GORM hook that runs after DELETE operations on TransactionLogEntry.
 // It writes an audit outbox entry with the deleted transaction log entry data.
 func (t *TransactionLogEntry) AfterDelete(tx *gorm.DB) error {
-	return recordAudit(tx, "transaction_log_entry", "DELETE", t.ID, t, nil)
+	return audit.RecordDelete(tx, *t)
 }

--- a/shared/platform/audit/README.md
+++ b/shared/platform/audit/README.md
@@ -1,0 +1,173 @@
+# Audit Hook Helpers
+
+This package provides reusable generic helper functions for adding audit logging to GORM entities.
+Instead of copying the same hook patterns to each model, you can implement a simple interface
+and call the helper functions.
+
+## Quick Start
+
+### 1. Implement the `Auditable` interface on your entity
+
+```go
+import "github.com/meridianhub/meridian/shared/platform/audit"
+
+type MyEntity struct {
+    ID   uuid.UUID `gorm:"type:uuid;primaryKey"`
+    Name string
+    // ... other fields
+}
+
+// TableName returns the GORM table name
+func (MyEntity) TableName() string {
+    return "my_entity"
+}
+
+// AuditID returns the record ID as a string for audit logging.
+// For UUID-based entities, return id.String().
+// For string-based entities, return the ID directly.
+func (e MyEntity) AuditID() string {
+    return e.ID.String()
+}
+
+// AuditTableName returns the table name for audit logging.
+func (e MyEntity) AuditTableName() string {
+    return "my_entity"
+}
+```
+
+### 2. Add GORM hooks that call the helpers
+
+```go
+import (
+    "github.com/meridianhub/meridian/shared/platform/audit"
+    "gorm.io/gorm"
+)
+
+// AfterCreate records an INSERT audit entry
+func (e *MyEntity) AfterCreate(tx *gorm.DB) error {
+    return audit.RecordCreate(tx, *e)
+}
+
+// BeforeUpdate captures old values for audit
+func (e *MyEntity) BeforeUpdate(tx *gorm.DB) error {
+    // If your entity embeds BaseModel, call its BeforeUpdate first:
+    // if err := e.BaseModel.BeforeUpdate(tx); err != nil {
+    //     return err
+    // }
+    return audit.CaptureOldValue(tx, *e)
+}
+
+// AfterUpdate records an UPDATE audit entry with old and new values
+func (e *MyEntity) AfterUpdate(tx *gorm.DB) error {
+    return audit.RecordUpdate(tx, *e)
+}
+
+// AfterDelete records a DELETE audit entry
+func (e *MyEntity) AfterDelete(tx *gorm.DB) error {
+    return audit.RecordDelete(tx, *e)
+}
+```
+
+## API Reference
+
+### Types
+
+#### `Auditable` interface
+
+```go
+type Auditable interface {
+    // AuditID returns the record ID as a string for audit logging.
+    AuditID() string
+
+    // AuditTableName returns the table name for audit logging.
+    AuditTableName() string
+}
+```
+
+#### `AuditOutbox` struct
+
+Represents an audit record waiting to be processed by the background worker. Records are written
+to the outbox within the same transaction as the business operation, ensuring atomicity.
+
+#### `AuditLog` struct
+
+Represents a permanent audit log entry. Records are moved from the audit_outbox to audit_log
+by the background worker.
+
+### Functions
+
+#### `RecordCreate[T Auditable](tx *gorm.DB, entity T) error`
+
+Writes an audit outbox entry for an INSERT operation. Call from your `AfterCreate` hook.
+
+#### `CaptureOldValue[T Auditable](tx *gorm.DB, entity T) error`
+
+Fetches and stores the old entity values before an update. Call from your `BeforeUpdate` hook. The function:
+
+- Queries the database for the current record state
+- Stores it in the transaction context for later retrieval
+- Skips silently if the entity ID is empty (handles map-based updates)
+
+#### `RecordUpdate[T Auditable](tx *gorm.DB, entity T) error`
+
+Writes an audit outbox entry for an UPDATE operation with both old and new values.
+Call from your `AfterUpdate` hook. The function:
+
+- Retrieves the old values captured by `CaptureOldValue`
+- Skips silently if old values are not available
+
+#### `RecordDelete[T Auditable](tx *gorm.DB, entity T) error`
+
+Writes an audit outbox entry for a DELETE operation. Call from your `AfterDelete` hook.
+
+## Behavior Notes
+
+### Empty IDs
+
+The helpers skip audit recording when the entity ID is empty or nil. This handles:
+
+- Map-based updates (`db.Model(&Entity{}).Updates(map...)`) which don't populate the model
+- Defensive programming for edge cases
+
+### Context Keys
+
+Each entity type gets its own context key for storing old values, based on the table name.
+This allows multiple entity types to be updated in the same transaction without key collisions.
+
+### Error Handling
+
+- `ErrNilTransaction`: Returned when `tx` is nil
+- `ErrOldValueType`: Returned when the stored old value has an unexpected type
+- `ErrOldValueNotFound`: Returned when old values are expected but not found
+
+## Migration from Manual Hooks
+
+Before (repeated in each entity):
+
+```go
+// 100+ lines of recordAudit function
+// 50+ lines of context handling
+// Error variables
+// Context key definitions
+```
+
+After (per entity):
+
+```go
+func (e MyEntity) AuditID() string       { return e.ID.String() }
+func (e MyEntity) AuditTableName() string { return "my_entity" }
+
+func (e *MyEntity) AfterCreate(tx *gorm.DB) error  { return audit.RecordCreate(tx, *e) }
+func (e *MyEntity) BeforeUpdate(tx *gorm.DB) error { return audit.CaptureOldValue(tx, *e) }
+func (e *MyEntity) AfterUpdate(tx *gorm.DB) error  { return audit.RecordUpdate(tx, *e) }
+func (e *MyEntity) AfterDelete(tx *gorm.DB) error  { return audit.RecordDelete(tx, *e) }
+```
+
+## Examples
+
+See the following files for real-world usage:
+
+- `shared/domain/models/customer.go` - UUID-based entity
+- `shared/domain/models/account.go` - UUID-based entity
+- `services/party/adapters/persistence/party_entity.go` - Service-level entity
+- `services/tenant/adapters/persistence/entity.go` - String ID entity

--- a/shared/platform/audit/hooks.go
+++ b/shared/platform/audit/hooks.go
@@ -1,0 +1,275 @@
+// Package audit provides utilities for audit logging including reusable GORM hook helpers.
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Errors returned by audit hook helpers.
+var (
+	// ErrNilTransaction is returned when a nil transaction is passed to RecordAudit.
+	ErrNilTransaction = errors.New("tx cannot be nil for audit recording")
+
+	// ErrOldValueType is returned when the old value in context has an incorrect type.
+	ErrOldValueType = errors.New("failed to retrieve old values from context: invalid type")
+
+	// ErrOldValueNotFound is returned when old values are not found in context.
+	ErrOldValueNotFound = errors.New("old values not found in context")
+)
+
+// contextKey is a private type for context keys to avoid collisions.
+type contextKey string
+
+// AuditOutbox represents an audit record waiting to be processed by the background worker.
+// Records are written to the outbox within the same transaction as the business operation,
+// ensuring atomicity and preventing lost audit records.
+//
+// This is a generic struct that works with both UUID and string record IDs.
+// Services should embed or reference this struct, or define their own compatible version.
+//
+//nolint:revive // AuditOutbox naming is intentional for clarity across package boundaries
+type AuditOutbox struct {
+	ID            uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	Table         string    `gorm:"column:table_name;type:varchar(100);not null;index" json:"table_name"`
+	Operation     string    `gorm:"type:varchar(10);not null;index" json:"operation"` // INSERT, UPDATE, DELETE
+	RecordID      string    `gorm:"type:varchar(50);not null;index" json:"record_id"` // String to support both UUID and custom IDs
+	OldValues     string    `gorm:"type:jsonb" json:"old_values,omitempty"`
+	NewValues     string    `gorm:"type:jsonb" json:"new_values,omitempty"`
+	Status        string    `gorm:"type:varchar(20);not null;default:'pending';index" json:"status"`
+	CreatedAt     time.Time `gorm:"not null;default:CURRENT_TIMESTAMP" json:"created_at"`
+	RetryCount    int       `gorm:"not null;default:0" json:"retry_count"`
+	LastError     *string   `gorm:"type:text" json:"last_error,omitempty"`
+	ChangedBy     *string   `gorm:"type:varchar(100)" json:"changed_by,omitempty"`
+	TransactionID *string   `gorm:"type:varchar(100)" json:"transaction_id,omitempty"`
+	ClientIP      *string   `gorm:"type:varchar(45)" json:"client_ip,omitempty"`
+	UserAgent     *string   `gorm:"type:text" json:"user_agent,omitempty"`
+}
+
+// TableName returns the table name for AuditOutbox.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
+func (AuditOutbox) TableName() string {
+	return "audit_outbox"
+}
+
+// AuditLog represents a permanent audit log entry.
+// Records are moved from the audit_outbox to audit_log by the background worker.
+// Once written, audit log entries are immutable and provide a permanent audit trail.
+//
+//nolint:revive // AuditLog naming is intentional for clarity across package boundaries
+type AuditLog struct {
+	ID            uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()" json:"id"`
+	Table         string    `gorm:"column:table_name;type:varchar(100);not null;index" json:"table_name"`
+	Operation     string    `gorm:"type:varchar(10);not null;index" json:"operation"` // INSERT, UPDATE, DELETE
+	RecordID      string    `gorm:"type:varchar(50);not null;index" json:"record_id"` // String to support both UUID and custom IDs
+	OldValues     string    `gorm:"type:jsonb" json:"old_values,omitempty"`
+	NewValues     string    `gorm:"type:jsonb" json:"new_values,omitempty"`
+	CreatedAt     time.Time `gorm:"not null;default:CURRENT_TIMESTAMP" json:"created_at"`
+	ChangedBy     *string   `gorm:"type:varchar(100)" json:"changed_by,omitempty"`
+	TransactionID *string   `gorm:"type:varchar(100)" json:"transaction_id,omitempty"`
+	ClientIP      *string   `gorm:"type:varchar(45)" json:"client_ip,omitempty"`
+	UserAgent     *string   `gorm:"type:text" json:"user_agent,omitempty"`
+}
+
+// TableName returns the table name for AuditLog.
+// Uses singular unqualified name to allow PostgreSQL search_path to route queries.
+func (AuditLog) TableName() string {
+	return "audit_log"
+}
+
+// Auditable defines the interface that an entity must implement to use the generic audit helpers.
+// This interface allows the helpers to extract the record ID from any entity type.
+type Auditable interface {
+	// AuditID returns the record ID as a string for audit logging.
+	// For UUID-based entities, return id.String().
+	// For string-based entities, return the ID directly.
+	AuditID() string
+
+	// AuditTableName returns the table name for audit logging.
+	AuditTableName() string
+}
+
+// oldValueKey generates a unique context key for storing old values during update operations.
+// Each entity type should use its own key to avoid collisions when multiple entities
+// are updated in the same transaction.
+func oldValueKey(tableName string) contextKey {
+	return contextKey("audit:old_value:" + tableName)
+}
+
+// RecordCreate writes an audit outbox entry for an INSERT operation.
+// Call this from your entity's AfterCreate hook.
+//
+// Example:
+//
+//	func (e *MyEntity) AfterCreate(tx *gorm.DB) error {
+//	    return audit.RecordCreate(tx, e)
+//	}
+func RecordCreate[T Auditable](tx *gorm.DB, entity T) error {
+	return recordAudit(tx, entity.AuditTableName(), "INSERT", entity.AuditID(), nil, entity)
+}
+
+// CaptureOldValue fetches and stores the old entity values before an update.
+// Call this from your entity's BeforeUpdate hook after any base model updates.
+//
+// Example:
+//
+//	func (e *MyEntity) BeforeUpdate(tx *gorm.DB) error {
+//	    if err := e.BaseModel.BeforeUpdate(tx); err != nil {
+//	        return err
+//	    }
+//	    return audit.CaptureOldValue(tx, e)
+//	}
+//
+// Parameters:
+//   - tx: The GORM transaction
+//   - entity: The entity being updated (used to determine table name and ID)
+//
+// The function fetches the current database state and stores it in the transaction context
+// for later retrieval by RecordUpdate.
+func CaptureOldValue[T Auditable](tx *gorm.DB, entity T) error {
+	// Get the record ID
+	idStr := entity.AuditID()
+
+	// Skip if ID is empty (happens with map-based updates)
+	if idStr == "" || idStr == uuid.Nil.String() {
+		return nil
+	}
+
+	// Fetch old values using reflection-free approach
+	// We need to query the database directly and unmarshal into a new instance
+	var old T
+	if err := tx.Unscoped().First(&old, "id = ?", idStr).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// Record doesn't exist yet (edge case), skip audit
+			return nil
+		}
+		return fmt.Errorf("failed to fetch old values for audit: %w", err)
+	}
+
+	// Store old values in transaction context
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		key := oldValueKey(entity.AuditTableName())
+		ctx := context.WithValue(tx.Statement.Context, key, old)
+		tx.Statement.Context = ctx
+	}
+
+	return nil
+}
+
+// RecordUpdate writes an audit outbox entry for an UPDATE operation.
+// Call this from your entity's AfterUpdate hook.
+// It retrieves the old values stored by CaptureOldValue and records the change.
+//
+// Example:
+//
+//	func (e *MyEntity) AfterUpdate(tx *gorm.DB) error {
+//	    return audit.RecordUpdate(tx, e)
+//	}
+//
+// Returns nil without error if:
+//   - The entity ID is empty (map-based updates)
+//   - Old values were not captured (CaptureOldValue was skipped)
+func RecordUpdate[T Auditable](tx *gorm.DB, entity T) error {
+	if tx == nil {
+		return ErrNilTransaction
+	}
+
+	// Skip if ID is empty (happens with map-based updates)
+	idStr := entity.AuditID()
+	if idStr == "" || idStr == uuid.Nil.String() {
+		return nil
+	}
+
+	// Retrieve old values from context
+	var old *T
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		key := oldValueKey(entity.AuditTableName())
+		if oldValue := tx.Statement.Context.Value(key); oldValue != nil {
+			typedOld, ok := oldValue.(T)
+			if !ok {
+				return ErrOldValueType
+			}
+			old = &typedOld
+		}
+	}
+
+	// Skip audit if old values are not available (CaptureOldValue was skipped)
+	if old == nil {
+		return nil
+	}
+
+	return recordAudit(tx, entity.AuditTableName(), "UPDATE", idStr, old, entity)
+}
+
+// RecordDelete writes an audit outbox entry for a DELETE operation.
+// Call this from your entity's AfterDelete hook.
+//
+// Example:
+//
+//	func (e *MyEntity) AfterDelete(tx *gorm.DB) error {
+//	    return audit.RecordDelete(tx, e)
+//	}
+func RecordDelete[T Auditable](tx *gorm.DB, entity T) error {
+	return recordAudit(tx, entity.AuditTableName(), "DELETE", entity.AuditID(), entity, nil)
+}
+
+// recordAudit writes an audit outbox entry within the current transaction.
+// This is the internal implementation used by all public helper functions.
+func recordAudit(tx *gorm.DB, tableName, operation, recordID string, oldValue, newValue interface{}) error {
+	if tx == nil {
+		return ErrNilTransaction
+	}
+
+	// Serialize old and new values to JSON
+	var oldJSON, newJSON string
+
+	if oldValue != nil {
+		oldBytes, err := json.Marshal(oldValue)
+		if err != nil {
+			return fmt.Errorf("failed to marshal old value: %w", err)
+		}
+		oldJSON = string(oldBytes)
+	}
+
+	if newValue != nil {
+		newBytes, err := json.Marshal(newValue)
+		if err != nil {
+			return fmt.Errorf("failed to marshal new value: %w", err)
+		}
+		newJSON = string(newBytes)
+	}
+
+	// Extract user ID from context
+	var changedBy *string
+	if tx.Statement != nil && tx.Statement.Context != nil {
+		if userID := GetUserFromContext(tx.Statement.Context); userID != "" {
+			changedBy = &userID
+		}
+	}
+	if changedBy == nil {
+		defaultUser := DefaultAuditUser
+		changedBy = &defaultUser
+	}
+
+	// Create audit outbox entry
+	outbox := AuditOutbox{
+		ID:        uuid.New(),
+		Table:     tableName,
+		Operation: operation,
+		RecordID:  recordID,
+		OldValues: oldJSON,
+		NewValues: newJSON,
+		Status:    "pending",
+		ChangedBy: changedBy,
+		CreatedAt: time.Now(),
+	}
+
+	// Write to outbox within the same transaction
+	return tx.Create(&outbox).Error
+}

--- a/shared/platform/audit/hooks_test.go
+++ b/shared/platform/audit/hooks_test.go
@@ -1,0 +1,405 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// testEntity is a mock entity that implements the Auditable interface.
+type testEntity struct {
+	ID        uuid.UUID `gorm:"type:uuid;primaryKey"`
+	Name      string    `gorm:"type:varchar(100)"`
+	Status    string    `gorm:"type:varchar(20)"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func (e testEntity) AuditID() string {
+	return e.ID.String()
+}
+
+func (e testEntity) AuditTableName() string {
+	return "test_entity"
+}
+
+func (testEntity) TableName() string {
+	return "test_entity"
+}
+
+// testStringIDEntity is a mock entity with a string ID.
+type testStringIDEntity struct {
+	ID        string `gorm:"type:varchar(50);primaryKey"`
+	Name      string `gorm:"type:varchar(100)"`
+	CreatedAt time.Time
+}
+
+func (e testStringIDEntity) AuditID() string {
+	return e.ID
+}
+
+func (e testStringIDEntity) AuditTableName() string {
+	return "test_string_entity"
+}
+
+func (testStringIDEntity) TableName() string {
+	return "test_string_entity"
+}
+
+// testAuditOutbox is a SQLite-compatible version of AuditOutbox for testing.
+// SQLite doesn't support PostgreSQL-specific types like uuid, jsonb, or gen_random_uuid().
+type testAuditOutbox struct {
+	ID            string `gorm:"primaryKey"`
+	Table         string `gorm:"column:table_name"`
+	Operation     string
+	RecordID      string
+	OldValues     string
+	NewValues     string
+	Status        string
+	CreatedAt     time.Time
+	RetryCount    int
+	LastError     *string
+	ChangedBy     *string
+	TransactionID *string
+	ClientIP      *string
+	UserAgent     *string
+}
+
+func (testAuditOutbox) TableName() string {
+	return "audit_outbox"
+}
+
+// setupHooksTestDB creates an in-memory SQLite database for testing hooks.
+func setupHooksTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// Create tables - use testAuditOutbox which is SQLite-compatible
+	err = db.AutoMigrate(&testEntity{}, &testStringIDEntity{}, &testAuditOutbox{})
+	require.NoError(t, err)
+
+	return db
+}
+
+func TestRecordCreate(t *testing.T) {
+	db := setupHooksTestDB(t)
+
+	t.Run("records INSERT audit entry", func(t *testing.T) {
+		entity := testEntity{
+			ID:        uuid.New(),
+			Name:      "Test Entity",
+			Status:    "active",
+			CreatedAt: time.Now(),
+		}
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return RecordCreate(tx, entity)
+		})
+		require.NoError(t, err)
+
+		// Verify audit outbox entry was created
+		var outbox testAuditOutbox
+		err = db.First(&outbox).Error
+		require.NoError(t, err)
+
+		assert.Equal(t, "test_entity", outbox.Table)
+		assert.Equal(t, "INSERT", outbox.Operation)
+		assert.Equal(t, entity.ID.String(), outbox.RecordID)
+		assert.Empty(t, outbox.OldValues)
+		assert.NotEmpty(t, outbox.NewValues)
+		assert.Equal(t, "pending", outbox.Status)
+		assert.NotNil(t, outbox.ChangedBy)
+		assert.Equal(t, DefaultAuditUser, *outbox.ChangedBy)
+
+		// Verify new values JSON contains entity data
+		var newVals map[string]interface{}
+		err = json.Unmarshal([]byte(outbox.NewValues), &newVals)
+		require.NoError(t, err)
+		assert.Equal(t, "Test Entity", newVals["Name"])
+	})
+
+	t.Run("records with user from context", func(t *testing.T) {
+		entity := testEntity{
+			ID:     uuid.New(),
+			Name:   "Test with User",
+			Status: "active",
+		}
+
+		ctx := context.WithValue(context.Background(), auth.UserIDContextKey, "user-123")
+
+		err := db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			return RecordCreate(tx, entity)
+		})
+		require.NoError(t, err)
+
+		// Find the most recent audit entry
+		var outbox testAuditOutbox
+		err = db.Order("created_at DESC").First(&outbox).Error
+		require.NoError(t, err)
+
+		assert.NotNil(t, outbox.ChangedBy)
+		assert.Equal(t, "user-123", *outbox.ChangedBy)
+	})
+
+	t.Run("works with string ID entity", func(t *testing.T) {
+		entity := testStringIDEntity{
+			ID:   "tenant-abc",
+			Name: "String ID Entity",
+		}
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return RecordCreate(tx, entity)
+		})
+		require.NoError(t, err)
+
+		var outbox testAuditOutbox
+		err = db.Order("created_at DESC").First(&outbox).Error
+		require.NoError(t, err)
+
+		assert.Equal(t, "test_string_entity", outbox.Table)
+		assert.Equal(t, "tenant-abc", outbox.RecordID)
+	})
+}
+
+func TestRecordDelete(t *testing.T) {
+	db := setupHooksTestDB(t)
+
+	t.Run("records DELETE audit entry", func(t *testing.T) {
+		entity := testEntity{
+			ID:     uuid.New(),
+			Name:   "Entity to Delete",
+			Status: "deleted",
+		}
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return RecordDelete(tx, entity)
+		})
+		require.NoError(t, err)
+
+		var outbox testAuditOutbox
+		err = db.First(&outbox).Error
+		require.NoError(t, err)
+
+		assert.Equal(t, "test_entity", outbox.Table)
+		assert.Equal(t, "DELETE", outbox.Operation)
+		assert.Equal(t, entity.ID.String(), outbox.RecordID)
+		assert.NotEmpty(t, outbox.OldValues)
+		assert.Empty(t, outbox.NewValues)
+		assert.Equal(t, "pending", outbox.Status)
+
+		// Verify old values JSON contains entity data
+		var oldVals map[string]interface{}
+		err = json.Unmarshal([]byte(outbox.OldValues), &oldVals)
+		require.NoError(t, err)
+		assert.Equal(t, "Entity to Delete", oldVals["Name"])
+	})
+}
+
+func TestCaptureOldValue(t *testing.T) {
+	db := setupHooksTestDB(t)
+
+	t.Run("captures old value in context", func(t *testing.T) {
+		// Create an entity in the database first
+		original := testEntity{
+			ID:        uuid.New(),
+			Name:      "Original Name",
+			Status:    "active",
+			CreatedAt: time.Now(),
+		}
+		err := db.Create(&original).Error
+		require.NoError(t, err)
+
+		// Simulate BeforeUpdate: capture old value
+		updated := testEntity{
+			ID:     original.ID,
+			Name:   "Updated Name",
+			Status: "modified",
+		}
+
+		err = db.Transaction(func(tx *gorm.DB) error {
+			if err := CaptureOldValue(tx, updated); err != nil {
+				return err
+			}
+
+			// Verify old value is in context
+			key := oldValueKey(updated.AuditTableName())
+			oldVal := tx.Statement.Context.Value(key)
+			assert.NotNil(t, oldVal)
+
+			typedOld, ok := oldVal.(testEntity)
+			assert.True(t, ok)
+			assert.Equal(t, "Original Name", typedOld.Name)
+			assert.Equal(t, "active", typedOld.Status)
+
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("skips capture for nil UUID", func(t *testing.T) {
+		entity := testEntity{
+			ID:   uuid.Nil,
+			Name: "No ID",
+		}
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return CaptureOldValue(tx, entity)
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("skips capture for empty string ID", func(t *testing.T) {
+		entity := testStringIDEntity{
+			ID:   "",
+			Name: "No ID",
+		}
+
+		err := db.Transaction(func(tx *gorm.DB) error {
+			return CaptureOldValue(tx, entity)
+		})
+		assert.NoError(t, err)
+	})
+}
+
+func TestRecordUpdate(t *testing.T) {
+	db := setupHooksTestDB(t)
+
+	t.Run("records UPDATE with old and new values", func(t *testing.T) {
+		// Create original entity
+		original := testEntity{
+			ID:        uuid.New(),
+			Name:      "Before Update",
+			Status:    "pending",
+			CreatedAt: time.Now(),
+		}
+		err := db.Create(&original).Error
+		require.NoError(t, err)
+
+		// Simulate the full update flow
+		updated := testEntity{
+			ID:        original.ID,
+			Name:      "After Update",
+			Status:    "completed",
+			UpdatedAt: time.Now(),
+		}
+
+		err = db.Transaction(func(tx *gorm.DB) error {
+			// Capture old value (simulates BeforeUpdate)
+			if err := CaptureOldValue(tx, updated); err != nil {
+				return err
+			}
+
+			// Record update (simulates AfterUpdate)
+			return RecordUpdate(tx, updated)
+		})
+		require.NoError(t, err)
+
+		// Verify audit entry
+		var outbox testAuditOutbox
+		err = db.First(&outbox).Error
+		require.NoError(t, err)
+
+		assert.Equal(t, "test_entity", outbox.Table)
+		assert.Equal(t, "UPDATE", outbox.Operation)
+		assert.NotEmpty(t, outbox.OldValues)
+		assert.NotEmpty(t, outbox.NewValues)
+
+		// Verify old values
+		var oldVals map[string]interface{}
+		err = json.Unmarshal([]byte(outbox.OldValues), &oldVals)
+		require.NoError(t, err)
+		assert.Equal(t, "Before Update", oldVals["Name"])
+		assert.Equal(t, "pending", oldVals["Status"])
+
+		// Verify new values
+		var newVals map[string]interface{}
+		err = json.Unmarshal([]byte(outbox.NewValues), &newVals)
+		require.NoError(t, err)
+		assert.Equal(t, "After Update", newVals["Name"])
+		assert.Equal(t, "completed", newVals["Status"])
+	})
+
+	t.Run("skips update for nil UUID", func(t *testing.T) {
+		// Use a fresh database for this test
+		freshDB := setupHooksTestDB(t)
+
+		entity := testEntity{
+			ID:   uuid.Nil,
+			Name: "No ID",
+		}
+
+		err := freshDB.Transaction(func(tx *gorm.DB) error {
+			return RecordUpdate(tx, entity)
+		})
+		assert.NoError(t, err)
+
+		// Verify no audit entry was created
+		var count int64
+		freshDB.Model(&testAuditOutbox{}).Count(&count)
+		assert.Equal(t, int64(0), count)
+	})
+
+	t.Run("skips update when old value not captured", func(t *testing.T) {
+		// Use a fresh database for this test
+		freshDB := setupHooksTestDB(t)
+
+		entity := testEntity{
+			ID:     uuid.New(),
+			Name:   "Missing Old",
+			Status: "active",
+		}
+
+		err := freshDB.Transaction(func(tx *gorm.DB) error {
+			// Call RecordUpdate without calling CaptureOldValue first
+			return RecordUpdate(tx, entity)
+		})
+		assert.NoError(t, err)
+
+		// Verify no audit entry was created
+		var count int64
+		freshDB.Model(&testAuditOutbox{}).Count(&count)
+		assert.Equal(t, int64(0), count)
+	})
+}
+
+func TestOldValueKey(t *testing.T) {
+	t.Run("generates unique keys for different tables", func(t *testing.T) {
+		key1 := oldValueKey("customer")
+		key2 := oldValueKey("account")
+
+		assert.NotEqual(t, key1, key2)
+		assert.Equal(t, contextKey("audit:old_value:customer"), key1)
+		assert.Equal(t, contextKey("audit:old_value:account"), key2)
+	})
+}
+
+func TestRecordAuditNilTransaction(t *testing.T) {
+	entity := testEntity{
+		ID:   uuid.New(),
+		Name: "Test",
+	}
+
+	err := RecordCreate[testEntity](nil, entity)
+	assert.ErrorIs(t, err, ErrNilTransaction)
+
+	err = RecordUpdate[testEntity](nil, entity)
+	assert.ErrorIs(t, err, ErrNilTransaction)
+
+	err = RecordDelete[testEntity](nil, entity)
+	assert.ErrorIs(t, err, ErrNilTransaction)
+}
+
+func TestAuditOutboxTableName(t *testing.T) {
+	outbox := AuditOutbox{}
+	assert.Equal(t, "audit_outbox", outbox.TableName())
+}

--- a/shared/platform/audit/worker.go
+++ b/shared/platform/audit/worker.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/meridianhub/meridian/shared/domain/models"
 	"gorm.io/gorm"
 )
 
@@ -146,7 +145,7 @@ func (w *Worker) resetStuckEntries(ctx context.Context) error {
 	stuckThreshold := time.Now().Add(-defaultProcessingAge)
 
 	result := w.db.WithContext(ctx).
-		Model(&models.AuditOutbox{}).
+		Model(&AuditOutbox{}).
 		Where("status = ?", statusProcessing).
 		Where("created_at < ?", stuckThreshold).
 		Update("status", statusPending)
@@ -176,7 +175,7 @@ func (w *Worker) processBatch(ctx context.Context) error {
 		RecordProcessingDuration(time.Since(start).Seconds())
 	}()
 
-	var entries []models.AuditOutbox
+	var entries []AuditOutbox
 
 	// Fetch pending entries, ordered by creation time for FIFO processing
 	result := w.db.WithContext(ctx).
@@ -192,7 +191,7 @@ func (w *Worker) processBatch(ctx context.Context) error {
 	// Record outbox depth (pending entries count)
 	var pendingCount int64
 	if err := w.db.WithContext(ctx).
-		Model(&models.AuditOutbox{}).
+		Model(&AuditOutbox{}).
 		Where("status = ?", statusPending).
 		Count(&pendingCount).Error; err == nil {
 		RecordOutboxDepth(int(pendingCount))
@@ -246,7 +245,7 @@ func (w *Worker) processBatch(ctx context.Context) error {
 // On success: Status is set to 'completed'
 // On failure with retries remaining: Status is set back to 'pending', RetryCount incremented
 // On failure with retries exhausted: Status is set to 'failed'
-func (w *Worker) processEntry(ctx context.Context, entry *models.AuditOutbox) error {
+func (w *Worker) processEntry(ctx context.Context, entry *AuditOutbox) error {
 	// Record entry age (time from creation to processing)
 	entryAge := time.Since(entry.CreatedAt).Seconds()
 	RecordEntryAge(entryAge)
@@ -284,8 +283,8 @@ func (w *Worker) processEntry(ctx context.Context, entry *models.AuditOutbox) er
 //
 // The function copies all relevant fields from the outbox entry to the audit log,
 // excluding worker-specific fields (status, retry_count, last_error).
-func (w *Worker) insertAuditLog(ctx context.Context, entry *models.AuditOutbox) error {
-	auditLog := &models.AuditLog{
+func (w *Worker) insertAuditLog(ctx context.Context, entry *AuditOutbox) error {
+	auditLog := &AuditLog{
 		Table:         entry.Table,
 		Operation:     entry.Operation,
 		RecordID:      entry.RecordID,
@@ -307,7 +306,7 @@ func (w *Worker) insertAuditLog(ctx context.Context, entry *models.AuditOutbox) 
 
 // handleProcessingError handles failures during entry processing.
 // It implements retry logic with exponential backoff and failure state management.
-func (w *Worker) handleProcessingError(ctx context.Context, entry *models.AuditOutbox, processingErr error) error {
+func (w *Worker) handleProcessingError(ctx context.Context, entry *AuditOutbox, processingErr error) error {
 	entry.RetryCount++
 	errorMsg := processingErr.Error()
 	entry.LastError = &errorMsg
@@ -348,7 +347,7 @@ func (w *Worker) handleProcessingError(ctx context.Context, entry *models.AuditO
 
 // updateStatus updates the status of an audit entry.
 // This is a helper method to encapsulate status updates with error handling.
-func (w *Worker) updateStatus(ctx context.Context, entry *models.AuditOutbox, status string) error {
+func (w *Worker) updateStatus(ctx context.Context, entry *AuditOutbox, status string) error {
 	entry.Status = status
 	result := w.db.WithContext(ctx).
 		Model(entry).

--- a/shared/platform/audit/worker_test.go
+++ b/shared/platform/audit/worker_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/meridianhub/meridian/shared/domain/models"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -130,14 +130,14 @@ func setupTestDB(t *testing.T) *gorm.DB {
 }
 
 // createTestEntry creates a single audit outbox entry for testing.
-func createTestEntry(t *testing.T, db *gorm.DB, status string) *models.AuditOutbox {
+func createTestEntry(t *testing.T, db *gorm.DB, status string) *AuditOutbox {
 	t.Helper()
 
-	entry := &models.AuditOutbox{
+	entry := &AuditOutbox{
 		ID:        uuid.New(),
 		Table:     "customer", // singular table name for search_path routing
 		Operation: "INSERT",
-		RecordID:  uuid.New(),
+		RecordID:  uuid.New().String(),
 		NewValues: `{"id": "123", "name": "Test Customer"}`,
 		Status:    status,
 		CreatedAt: time.Now(),
@@ -169,7 +169,7 @@ func waitForProcessing(t *testing.T, db *gorm.DB, expectedCompleted int, timeout
 
 	for {
 		var count int64
-		err := db.Model(&models.AuditOutbox{}).
+		err := db.Model(&AuditOutbox{}).
 			Where("status = ?", statusCompleted).
 			Count(&count).Error
 		require.NoError(t, err, "Failed to count completed entries")
@@ -211,7 +211,7 @@ func TestAuditWorker_ProcessBatch_Success(t *testing.T) {
 
 	// Verify all have status='completed'
 	var completed int64
-	err := db.Model(&models.AuditOutbox{}).
+	err := db.Model(&AuditOutbox{}).
 		Where("status = ?", statusCompleted).
 		Count(&completed).Error
 	require.NoError(t, err)
@@ -219,7 +219,7 @@ func TestAuditWorker_ProcessBatch_Success(t *testing.T) {
 
 	// Verify no pending entries remain
 	var pending int64
-	err = db.Model(&models.AuditOutbox{}).
+	err = db.Model(&AuditOutbox{}).
 		Where("status = ?", statusPending).
 		Count(&pending).Error
 	require.NoError(t, err)
@@ -248,7 +248,7 @@ func TestAuditWorker_ProcessBatch_BatchSize(t *testing.T) {
 
 	// Verify exactly 100 were processed
 	var completed int64
-	err = db.Model(&models.AuditOutbox{}).
+	err = db.Model(&AuditOutbox{}).
 		Where("status = ?", statusCompleted).
 		Count(&completed).Error
 	require.NoError(t, err)
@@ -256,7 +256,7 @@ func TestAuditWorker_ProcessBatch_BatchSize(t *testing.T) {
 
 	// Verify 150 remain pending
 	var pending int64
-	err = db.Model(&models.AuditOutbox{}).
+	err = db.Model(&AuditOutbox{}).
 		Where("status = ?", statusPending).
 		Count(&pending).Error
 	require.NoError(t, err)
@@ -284,7 +284,7 @@ func TestAuditWorker_ProcessEntry_Idempotency(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify entry is still completed and unchanged
-	var updated models.AuditOutbox
+	var updated AuditOutbox
 	err = db.First(&updated, entry.ID).Error
 	require.NoError(t, err)
 	assert.Equal(t, statusCompleted, updated.Status, "Status should still be completed")
@@ -405,11 +405,11 @@ func TestAuditWorker_ResetStuckEntries(t *testing.T) {
 	db := setupTestDB(t)
 
 	// Create entries with status='processing' and old timestamp
-	stuckEntry := &models.AuditOutbox{
+	stuckEntry := &AuditOutbox{
 		ID:        uuid.New(),
 		Table:     "customers",
 		Operation: "INSERT",
-		RecordID:  uuid.New(),
+		RecordID:  uuid.New().String(),
 		NewValues: `{"id": "123", "name": "Test Customer"}`,
 		Status:    statusProcessing,
 		CreatedAt: time.Now().Add(-10 * time.Minute), // 10 minutes ago (older than defaultProcessingAge)
@@ -418,11 +418,11 @@ func TestAuditWorker_ResetStuckEntries(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create recent processing entry (should not be reset)
-	recentEntry := &models.AuditOutbox{
+	recentEntry := &AuditOutbox{
 		ID:        uuid.New(),
 		Table:     "customers",
 		Operation: "INSERT",
-		RecordID:  uuid.New(),
+		RecordID:  uuid.New().String(),
 		NewValues: `{"id": "456", "name": "Recent Customer"}`,
 		Status:    statusProcessing,
 		CreatedAt: time.Now().Add(-1 * time.Minute), // 1 minute ago (newer than defaultProcessingAge)
@@ -438,13 +438,13 @@ func TestAuditWorker_ResetStuckEntries(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify stuck entry status back to 'pending'
-	var updatedStuckEntry models.AuditOutbox
+	var updatedStuckEntry AuditOutbox
 	err = db.First(&updatedStuckEntry, stuckEntry.ID).Error
 	require.NoError(t, err)
 	assert.Equal(t, statusPending, updatedStuckEntry.Status, "Stuck entry should be reset to pending")
 
 	// Verify recent entry is still 'processing'
-	var updatedRecentEntry models.AuditOutbox
+	var updatedRecentEntry AuditOutbox
 	err = db.First(&updatedRecentEntry, recentEntry.ID).Error
 	require.NoError(t, err)
 	assert.Equal(t, statusProcessing, updatedRecentEntry.Status, "Recent entry should still be processing")
@@ -485,7 +485,7 @@ func TestAuditWorker_ConcurrentSafety(t *testing.T) {
 
 	// Verify all entries are completed
 	var completed int64
-	err := db.Model(&models.AuditOutbox{}).
+	err := db.Model(&AuditOutbox{}).
 		Where("status = ?", statusCompleted).
 		Count(&completed).Error
 	require.NoError(t, err)
@@ -493,7 +493,7 @@ func TestAuditWorker_ConcurrentSafety(t *testing.T) {
 
 	// Verify no entries were left in other states
 	var total int64
-	err = db.Model(&models.AuditOutbox{}).Count(&total).Error
+	err = db.Model(&AuditOutbox{}).Count(&total).Error
 	require.NoError(t, err)
 	assert.Equal(t, int64(100), total, "Total entries should be 100")
 
@@ -521,7 +521,7 @@ func TestAuditWorker_ProcessBatch_EmptyQueue(t *testing.T) {
 
 	// Verify no entries exist
 	var count int64
-	err = db.Model(&models.AuditOutbox{}).Count(&count).Error
+	err = db.Model(&AuditOutbox{}).Count(&count).Error
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count, "No entries should exist")
 }
@@ -670,7 +670,7 @@ func TestAuditWorker_Stop_MultipleCallsSafe(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	var processed int64
-	db.Model(&models.AuditOutbox{}).Where("status = ?", "completed").Count(&processed)
+	db.Model(&AuditOutbox{}).Where("status = ?", "completed").Count(&processed)
 	if processed > 0 {
 		t.Errorf("Worker processed entries after Stop(), expected 0 but got %d", processed)
 	}
@@ -690,7 +690,7 @@ func TestAuditWorker_InsertsIntoAuditLog(t *testing.T) {
 	createTestEntries(t, db, 5)
 
 	// Fetch the created entries for verification later
-	var entries []models.AuditOutbox
+	var entries []AuditOutbox
 	err := db.Where("status = ?", statusPending).Find(&entries).Error
 	if err != nil {
 		t.Fatalf("Failed to fetch outbox entries: %v", err)
@@ -722,7 +722,7 @@ func TestAuditWorker_InsertsIntoAuditLog(t *testing.T) {
 
 	// Verify all outbox entries were processed
 	var completed int64
-	db.Model(&models.AuditOutbox{}).Where("status = ?", "completed").Count(&completed)
+	db.Model(&AuditOutbox{}).Where("status = ?", "completed").Count(&completed)
 	if completed != 5 {
 		t.Errorf("Expected 5 completed outbox entries, got %d", completed)
 	}
@@ -740,13 +740,13 @@ func TestAuditWorker_InsertsIntoAuditLog(t *testing.T) {
 			ID            uuid.UUID
 			Table         string `gorm:"column:table_name"`
 			Operation     string
-			RecordID      uuid.UUID `gorm:"column:record_id"`
-			OldValues     string    `gorm:"column:old_values"`
-			NewValues     string    `gorm:"column:new_values"`
-			ChangedBy     *string   `gorm:"column:changed_by"`
-			TransactionID *string   `gorm:"column:transaction_id"`
-			ClientIP      *string   `gorm:"column:client_ip"`
-			UserAgent     *string   `gorm:"column:user_agent"`
+			RecordID      string  `gorm:"column:record_id"`
+			OldValues     string  `gorm:"column:old_values"`
+			NewValues     string  `gorm:"column:new_values"`
+			ChangedBy     *string `gorm:"column:changed_by"`
+			TransactionID *string `gorm:"column:transaction_id"`
+			ClientIP      *string `gorm:"column:client_ip"`
+			UserAgent     *string `gorm:"column:user_agent"`
 		}
 
 		err := db.Table("current_account_audit.audit_log").


### PR DESCRIPTION
## Summary

- Add reusable generic helper functions for audit logging in `shared/platform/audit`
- Implement `Auditable` interface that entities implement for audit hook helpers
- Provide `RecordCreate[T]`, `CaptureOldValue[T]`, `RecordUpdate[T]`, `RecordDelete[T]` generic functions
- Refactor Customer, Account, Party, Tenant, FinancialPositionLog, and TransactionLogEntry to use shared helpers

## Test plan

- [x] Unit tests for all generic helper functions pass (`go test -short ./shared/platform/audit/...`)
- [x] Existing model tests pass (`go test -short ./shared/domain/models/...`)
- [x] Party service tests pass (`go test -short ./services/party/adapters/persistence/...`)
- [x] Tenant service tests pass (`go test -short ./services/tenant/adapters/persistence/...`)
- [x] Pre-commit hooks pass (golangci-lint, gofumpt, markdownlint)

## Benefits

- ~500 lines of duplicated code removed across models
- Consistent audit behavior across all entities
- Type-safe with Go generics (Go 1.18+)
- Works with both UUID and string IDs
- Context key management for multi-entity transactions

## Related

- Task Master: 75-async-audit, Task 15
- Dependencies: Tasks 8, 10, 11, 12, 13, 14 (audit infrastructure for each service)