### PR TITLE
fix: correct malformed markdown code block closing tags

### DIFF
--- a/docs/adr/0005-adapter-pattern-layer-translation.md
+++ b/docs/adr/0005-adapter-pattern-layer-translation.md
@@ -65,7 +65,7 @@ prevent drift.
            ↑ Port (interface)
            │
 ┌──────────┴────────────────────────────┐
-│   Adapters (Translation Layer)       │
+│   Adapters (Translation Layer)        │
 │   - Domain ↔ Entity                   │
 │   - Domain ↔ Event                    │
 │   - Domain ↔ DTO                      │

--- a/docs/adr/0010-grpc-client-side-load-balancing.md
+++ b/docs/adr/0010-grpc-client-side-load-balancing.md
@@ -250,7 +250,7 @@ Load testing confirms:
    creds, err := credentials.NewClientTLSFromFile("ca.pem", "")
    conn, err := grpc.NewClient(cfg, grpc.WithTransportCredentials(creds))
 
-```text
+```
 
 1. **Certificate Management**:
    - Use cert-manager for automatic certificate provisioning

--- a/docs/architecture/api-contracts/current-account-contract.md
+++ b/docs/architecture/api-contracts/current-account-contract.md
@@ -65,7 +65,7 @@ stateDiagram-v2
         Terminal state (irreversible).
         Balance must be zero.
     end note
-```text
+```
 
 ### State Transition Rules
 
@@ -118,7 +118,7 @@ message InitiateCurrentAccountResponse {
   string account_id = 1;                       // Generated account ID
   CurrentAccountFacility facility = 2;         // Complete facility details
 }
-```text
+```
 
 **Behavioral Semantics:**
 
@@ -224,7 +224,7 @@ Response: {
     }
   ]
 }
-```text
+```
 
 ---
 
@@ -251,7 +251,7 @@ message ExecuteDepositResponse {
   meridian.common.v1.MoneyAmount available_balance = 4;    // Updated available
   TransactionStatus status = 5;                // Transaction status
 }
-```text
+```
 
 **Behavioral Semantics:**
 
@@ -360,7 +360,7 @@ sequenceDiagram
         FinancialAccounting-->>CurrentAccount: Error
         CurrentAccount-->>Client: Error (UNAVAILABLE)
     end
-```text
+```
 
 **Compensation Operations:**
 
@@ -456,7 +456,7 @@ Response: {
     }
   ]
 }
-```text
+```
 
 ---
 
@@ -476,7 +476,7 @@ message RetrieveCurrentAccountRequest {
 message RetrieveCurrentAccountResponse {
   CurrentAccountFacility facility = 1;         // Complete facility details
 }
-```text
+```
 
 **Behavioral Semantics:**
 
@@ -616,7 +616,7 @@ Response: {
     }
   ]
 }
-```text
+```
 
 ---
 
@@ -673,7 +673,7 @@ SET
 WHERE
   account_id = $2
   AND version = $3  -- Optimistic lock check
-```text
+```
 
 **Conflict Resolution:**
 

--- a/docs/architecture/api-contracts/financial-accounting-contract.md
+++ b/docs/architecture/api-contracts/financial-accounting-contract.md
@@ -67,7 +67,7 @@ stateDiagram-v2
         Not included in financial reports.
         failure_reason stored for audit.
     end note
-```text
+```
 
 ### Ledger Posting Status State Machine
 
@@ -111,7 +111,7 @@ stateDiagram-v2
         Reversal creates opposite posting.
         Terminal state for original posting.
     end note
-```protobuf
+```
 
 ## Double-Entry Invariants
 
@@ -121,7 +121,7 @@ The FinancialAccounting service enforces fundamental double-entry bookkeeping pr
 
 ```text
 Assets = Liabilities + Equity
-```text
+```
 
 ### Posting Balance Invariant
 
@@ -129,7 +129,7 @@ For every `FinancialBookingLog`, the following MUST hold before transitioning to
 
 ```text
 sum(postings WHERE posting_direction = DEBIT) = sum(postings WHERE posting_direction = CREDIT)
-```protobuf
+```
 
 **Enforcement:**
 
@@ -143,7 +143,7 @@ All posting amounts MUST be positive (> 0):
 
 ```text
 posting_amount.units > 0 || (posting_amount.units == 0 && posting_amount.nanos > 0)
-```sql
+```
 
 **Rationale:**
 
@@ -157,7 +157,7 @@ All postings within a booking log MUST use the same currency:
 
 ```text
 All postings.posting_amount.currency_code = booking_log.base_currency
-```text
+```
 
 ## API Operations
 
@@ -183,7 +183,7 @@ message InitiateFinancialBookingLogRequest {
 message InitiateFinancialBookingLogResponse {
   FinancialBookingLog financial_booking_log = 1;  // Created log
 }
-```sql
+```
 
 **Behavioral Semantics:**
 
@@ -267,7 +267,7 @@ Response: {
     "postings": []  // Empty initially
   }
 }
-```text
+```
 
 ---
 
@@ -290,7 +290,7 @@ message UpdateFinancialBookingLogRequest {
 message UpdateFinancialBookingLogResponse {
   FinancialBookingLog financial_booking_log = 1;  // Updated log
 }
-```go
+```
 
 **Behavioral Semantics:**
 
@@ -365,7 +365,7 @@ if debit_sum != credit_sum:
 
 if len(postings) == 0:
   return FAILED_PRECONDITION("Cannot post empty booking log")
-```text
+```
 
 **Concurrency:**
 
@@ -446,7 +446,7 @@ Response: {
     "updated_at": "2025-11-19T13:20:00Z"
   }
 }
-```text
+```
 
 ---
 
@@ -467,7 +467,7 @@ message RetrieveFinancialBookingLogRequest {
 message RetrieveFinancialBookingLogResponse {
   FinancialBookingLog financial_booking_log = 1;  // Complete log
 }
-```text
+```
 
 **Behavioral Semantics:**
 
@@ -535,7 +535,7 @@ message ListFinancialBookingLogsResponse {
   repeated FinancialBookingLog financial_booking_logs = 1;  // Matching logs
   meridian.common.v1.PaginationResponse pagination = 2;     // Next page token
 }
-```sql
+```
 
 **Behavioral Semantics:**
 
@@ -602,7 +602,7 @@ message CaptureLedgerPostingRequest {
 message CaptureLedgerPostingResponse {
   LedgerPosting ledger_posting = 1;           // Created posting
 }
-```protobuf
+```
 
 **Behavioral Semantics:**
 
@@ -775,7 +775,7 @@ Response: {
     }
   ]
 }
-```text
+```
 
 ---
 
@@ -798,7 +798,7 @@ message UpdateLedgerPostingRequest {
 message UpdateLedgerPostingResponse {
   LedgerPosting ledger_posting = 1;               // Updated posting
 }
-```text
+```
 
 **Behavioral Semantics:**
 
@@ -859,7 +859,7 @@ message RetrieveLedgerPostingRequest {
 message RetrieveLedgerPostingResponse {
   LedgerPosting ledger_posting = 1;  // Complete posting
 }
-```text
+```
 
 **Behavioral Semantics:**
 
@@ -902,7 +902,7 @@ message ListLedgerPostingsResponse {
   repeated LedgerPosting ledger_postings = 1;    // Matching postings
   meridian.common.v1.PaginationResponse pagination = 2;  // Next page token
 }
-```sql
+```
 
 **Behavioral Semantics:**
 
@@ -1024,7 +1024,7 @@ Response: {
   ],
   "pagination": { /* ... */ }
 }
-```sql
+```
 
 ---
 
@@ -1143,7 +1143,7 @@ message DepositEvent {
   string transaction_id = 3;
   google.protobuf.Timestamp timestamp = 4;
 }
-```sql
+```
 
 **Consumer Implementation**: `internal/financial-accounting/adapters/messaging/deposit_consumer.go`
 
@@ -1176,7 +1176,7 @@ message PostingCompleteEvent {
   repeated LedgerPosting postings = 2;
   google.protobuf.Timestamp posted_at = 3;
 }
-```protobuf
+```
 
 **Publisher Implementation**: `internal/financial-accounting/adapters/messaging/accounting_event_publisher.go` (9 usages detected)
 
@@ -1250,13 +1250,13 @@ ListLedgerPostings(status=POSTED)
   → Sum(amount WHERE direction=DEBIT)
   → Sum(amount WHERE direction=CREDIT)
   → Display accounts with non-zero balance
-```text
+```
 
 **Invariant Validation:**
 
 ```text
 Sum(all debit balances) = Sum(all credit balances)
-```text
+```
 
 If this invariant fails, indicates data corruption or unbalanced postings.
 
@@ -1275,7 +1275,7 @@ ListLedgerPostings(
 )
   → Order by value_date DESC
   → Display: date, description, debit, credit, running balance
-```text
+```
 
 ### Balance Sheet
 
@@ -1289,7 +1289,7 @@ Liability accounts: Sum(CREDIT) - Sum(DEBIT)
 Equity accounts: Sum(CREDIT) - Sum(DEBIT)
 
 Invariant: Assets = Liabilities + Equity
-```text
+```
 
 ### Income Statement (Profit & Loss)
 
@@ -1302,7 +1302,7 @@ Revenue accounts: Sum(CREDIT) - Sum(DEBIT) for period
 Expense accounts: Sum(DEBIT) - Sum(CREDIT) for period
 
 Net Income = Revenue - Expenses
-```text
+```
 
 ## Future Enhancements
 

--- a/docs/architecture/api-contracts/position-keeping-contract.md
+++ b/docs/architecture/api-contracts/position-keeping-contract.md
@@ -69,7 +69,7 @@ stateDiagram-v2
         Original remains for audit trail.
         Terminal state.
     end note
-```sql
+```
 
 ### Status Transition Rules
 
@@ -123,7 +123,7 @@ message InitiateFinancialPositionLogRequest {
 message InitiateFinancialPositionLogResponse {
   FinancialPositionLog log = 1;                // Created log (always present)
 }
-```sql
+```
 
 **Behavioral Semantics:**
 
@@ -292,7 +292,7 @@ Response: {
     // ... (same as first response)
   }
 }
-```text
+```
 
 ---
 
@@ -319,7 +319,7 @@ message InitiateFinancialPositionLogBatchResponse {
   int32 success_count = 4;                     // Successful creations
   int32 failure_count = 5;                     // Failed creations
 }
-```sql
+```
 
 **Behavioral Semantics:**
 
@@ -463,7 +463,7 @@ Response: {
   ]
 }
 // Note: No logs created due to atomicity
-```text
+```
 
 ---
 
@@ -489,7 +489,7 @@ message UpdateFinancialPositionLogRequest {
 message UpdateFinancialPositionLogResponse {
   FinancialPositionLog log = 1;                // Updated log
 }
-```sql
+```
 
 **Behavioral Semantics:**
 
@@ -653,7 +653,7 @@ Response: {
     }
   ]
 }
-```text
+```
 
 ---
 
@@ -674,7 +674,7 @@ message RetrieveFinancialPositionLogRequest {
 message RetrieveFinancialPositionLogResponse {
   FinancialPositionLog log = 1;  // Complete log (always present)
 }
-```sql
+```
 
 **Behavioral Semantics:**
 
@@ -770,7 +770,7 @@ Response: {
     }
   ]
 }
-```text
+```
 
 ---
 
@@ -797,7 +797,7 @@ message BulkImportTransactionsResponse {
   int32 failed_count = 3;                      // Failure count
   repeated string failure_details = 4;         // Error descriptions
 }
-```sql
+```
 
 **Behavioral Semantics:**
 
@@ -939,7 +939,7 @@ Response: {
     "Entry[1]: transaction_id 'not-a-uuid' is not a valid UUID"
   ]
 }
-```text
+```
 
 ---
 
@@ -964,7 +964,7 @@ message ListFinancialPositionLogsResponse {
   repeated FinancialPositionLog logs = 1;      // Matching logs
   meridian.common.v1.PaginationResponse pagination = 2;  // Next page token
 }
-```sql
+```
 
 **Behavioral Semantics:**
 
@@ -1083,7 +1083,7 @@ Response: {
   ],
   "pagination": { /* ... */ }
 }
-```sql
+```
 
 ---
 
@@ -1151,7 +1151,7 @@ WHERE
   log_id = $2
   AND version = $3  -- Optimistic lock check
 RETURNING *
-```sql
+```
 
 **Conflict Resolution:**
 
@@ -1210,7 +1210,7 @@ Transaction A (deposit)
 ├─ Transaction B (fee deduction) [child]
 ├─ Transaction C (interest calculation) [child]
 └─ Transaction D (reversal) [related]
-```protobuf
+```
 
 ## Audit Trail Completeness
 
@@ -1264,7 +1264,7 @@ Use `ListFinancialPositionLogs` with `date_range` filter:
   "status": "TRANSACTION_STATUS_POSTED",
   "pagination": { "page_size": 1000 }
 }
-```text
+```
 
 ### Reconciliation Guarantees
 

--- a/docs/architecture/bian-service-boundaries.md
+++ b/docs/architecture/bian-service-boundaries.md
@@ -725,7 +725,7 @@ internal/current-account/
 └── adapters/
     └── persistence/     # Database adapters
         └── repository.go # Audit log persistence
-```text
+```
 
 **Key Characteristics:**
 
@@ -754,7 +754,7 @@ internal/position-keeping/
 │       └── kafka_event_publisher.go  # Kafka event adapter
 └── app/
     └── container.go         # Dependency injection container
-```text
+```
 
 **Key Characteristics:**
 
@@ -780,7 +780,7 @@ internal/financial-accounting/
     └── messaging/              # Event-driven adapters
         ├── deposit_consumer.go      # Kafka deposit event consumer
         └── accounting_event_publisher.go  # Accounting event publisher
-```text
+```
 
 **Key Characteristics:**
 
@@ -827,14 +827,14 @@ import "github.com/meridianhub/meridian/internal/financial-accounting/service"
 // CORRECT - Use proto-defined gRPC client
 import pb "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 import fa_pb "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
-```text
+```
 
 **Detection:**
 
 ```bash
 # Automated detection via coupling analysis
 ./scripts/analyze-coupling.sh | jq '.violations[] | select(.type == "cross-service-internal-import")'
-```sql
+```
 
 #### Rule 2: Proto-Only Inter-Service Communication
 
@@ -880,14 +880,14 @@ publisher.Publish(ctx, event)
 // FORBIDDEN - Direct function call to another service
 import "github.com/meridianhub/meridian/internal/position-keeping/service"
 result := service.CreateTransactionLog(log)  // ❌ NOT ALLOWED
-```text
+```
 
 **Contract Evolution:**
 
 ```bash
 # Validate proto changes for breaking modifications
 buf breaking --against '.git#branch=develop'
-```sql
+```
 
 #### Rule 3: Platform Code in `pkg/platform/` Only
 
@@ -920,7 +920,7 @@ import "github.com/meridianhub/meridian/internal/platform/observability"
 
 // TARGET (COMPLIANT) - Migration target
 import "github.com/meridianhub/meridian/pkg/platform/observability"
-```sql
+```
 
 **Migration Checklist:**
 
@@ -967,7 +967,7 @@ db.Exec("UPDATE financial_accounting.booking_log SET status = ?", status)
 // CORRECT - Use gRPC to query other service's data
 client.RetrieveFinancialPositionLog(ctx, &pb.RetrieveRequest{LogId: logID})
 client.UpdateFinancialBookingLog(ctx, &pb.UpdateRequest{LogId: logID, Status: status})
-```text
+```
 
 **Database Connection Isolation:**
 
@@ -978,7 +978,7 @@ db, err := sql.Open("postgres", os.Getenv("CURRENT_ACCOUNT_DB_URL"))
 
 // internal/position-keeping/app/container.go
 db, err := sql.Open("postgres", os.Getenv("POSITION_KEEPING_DB_URL"))
-```protobuf
+```
 
 #### Rule 5: Service-Specific Business Logic
 
@@ -1032,7 +1032,7 @@ func (a *Account) ValidateOverdraftLimit(amount Money) error {
 // FORBIDDEN - Domain logic in shared package
 // pkg/domain/account.go (THIS SHOULD NOT EXIST)
 func ValidateOverdraft(amount, limit Money) error { ... }
-```sql
+```
 
 ### Allowed Dependency Directions
 
@@ -1125,7 +1125,7 @@ faClient.InitiateBookingLog(...)
 // internal/financial-accounting/service/posting_service.go
 import ca_pb "meridian/current_account/v1"  // ❌ NOT ALLOWED
 caClient.RetrieveAccount(...)
-```protobuf
+```
 
 **Solution:** Introduce events or shared data entities to break the cycle
 
@@ -1145,7 +1145,7 @@ caClient.RetrieveAccount(...)
 // internal/position-keeping/service/position_service.go
 import fa_pb "meridian/financial_accounting/v1"  // ❌ NOT ALLOWED
 faClient.InitiateBookingLog(...)
-```text
+```
 
 **Solution:** Position-keeping publishes events; other services consume and react
 
@@ -1168,7 +1168,7 @@ pkClient.UpdateFinancialPositionLog(ctx, &pb.UpdateRequest{
         Amount: depositAmount,  // ❌ Missing double-entry validation
     },
 })
-```sql
+```
 
 **Solution:** Current-account MUST call financial-accounting first, which then publishes events to position-keeping
 
@@ -1253,7 +1253,7 @@ pkClient.UpdateFinancialPositionLog(ctx, &pb.UpdateRequest{
 
 # Check for violations
 jq '.violations | length' docs/architecture/coupling-metrics.json
-```protobuf
+```
 
 **Detects:**
 
@@ -1276,7 +1276,7 @@ if [[ $violations -gt 0 ]]; then
     ./scripts/analyze-coupling.sh | jq '.violations'
     exit 1
 fi
-```text
+```
 
 **GitHub Actions Workflow:**
 
@@ -1296,7 +1296,7 @@ jobs:
             echo "::error::$violations coupling violations detected"
             exit 1
           fi
-```protobuf
+```
 
 #### Code Review Checklist
 
@@ -1324,7 +1324,7 @@ lint-coupling:
 
 # Integration with existing linting
 make lint-coupling
-```sql
+```
 
 **IDE Integration (IntelliJ IDEA / GoLand):**
 
@@ -1495,7 +1495,7 @@ resp, err := pkClient.ListFinancialPositionLogs(ctx, &pb.ListRequest{
     AccountId: accountID,
     Pagination: &common.Pagination{PageSize: 100},
 })
-```sql
+```
 
 #### CurrentAccount → FinancialAccounting
 
@@ -1522,7 +1522,7 @@ resp, err := faClient.CaptureLedgerPosting(ctx, &pb.CaptureRequest{
     PostingAmount:         amount,
     AccountId:             accountID,
 })
-```sql
+```
 
 ### Asynchronous Communication (Kafka)
 
@@ -1758,7 +1758,7 @@ graph TD
         L9["⚫ Gray: Databases (service-owned)"]
         L10["🔴 Red: Event Streaming (Kafka)"]
     end
-```text
+```
 
 ### Architecture Diagram Interpretation
 

--- a/docs/architecture/event-driven-architecture.md
+++ b/docs/architecture/event-driven-architecture.md
@@ -58,7 +58,7 @@ message ExampleEvent {
   string aggregate_id = 2;                   // ID of the aggregate (account_id, booking_log_id, etc.)
   // ... other business fields
 }
-```text
+```
 
 ### Field Conventions
 
@@ -117,7 +117,7 @@ google.type.Money amount = 4 [
     expression: "this.units > 0 || (this.units == 0 && this.nanos > 0)"
   }
 ];
-```go
+```
 
 **Important**: CEL constraints on `google.type.Money` provide documentation but don't generate runtime validation. Service layer MUST enforce money constraints.
 
@@ -209,7 +209,7 @@ sequenceDiagram
     Kafka-->>FinancialAccounting: TransactionCompletedEvent (async)
     Kafka-->>PositionKeeping: TransactionCompletedEvent (async)
     Kafka-->>Reporting: TransactionCompletedEvent (async)
-```sql
+```
 
 **Publishing Rules:**
 
@@ -242,7 +242,7 @@ sequenceDiagram
     Kafka-->>CurrentAccount: TransactionCapturedEvent
     Note over CurrentAccount: Both confirmations received,<br/>mark transaction complete
     CurrentAccount->>Kafka: Publish TransactionCompletedEvent
-```text
+```
 
 **Choreography Rules:**
 
@@ -278,7 +278,7 @@ sequenceDiagram
 
         OutboxPollingWorker->>Database: UPDATE events as processed
     end
-```sql
+```
 
 **Outbox Pattern Benefits:**
 
@@ -313,7 +313,7 @@ CREATE TABLE audit_outbox (
 
 CREATE INDEX idx_outbox_unprocessed ON audit_outbox (created_at)
 WHERE processed_at IS NULL;
-```text
+```
 
 ### Pattern 4: Idempotent Event Consumption
 
@@ -342,7 +342,7 @@ sequenceDiagram
     Database-->>Consumer: Found (already processed)
     Consumer->>Consumer: Skip processing
     Consumer->>Kafka: Commit offset
-```sql
+```
 
 **Idempotency Implementation:**
 
@@ -364,7 +364,7 @@ CREATE TABLE event_idempotency (
 
 CREATE INDEX idx_idempotency_expiry ON event_idempotency (processed_at);
 -- Cleanup job: DELETE WHERE processed_at < NOW() - INTERVAL '7 days'
-```sql
+```
 
 ---
 
@@ -476,7 +476,7 @@ func (s *AccountService) CreateAccount(ctx context.Context, req *pb.CreateAccoun
     // Event will be published by background outbox worker
     return &pb.AccountResponse{Account: account.ToProto()}, nil
 }
-```text
+```
 
 ---
 
@@ -496,7 +496,7 @@ consumerConfig := kafka.ConsumerConfig{
     PollTimeout:      100 * time.Millisecond,
     HandlerTimeout:   30 * time.Second,
 }
-```protobuf
+```
 
 **Key Settings:**
 
@@ -563,7 +563,7 @@ func (c *TransactionInitiatedConsumer) handleMessage(ctx context.Context, key []
     // 6. Success - Kafka consumer will commit offset automatically
     return nil
 }
-```text
+```
 
 ### Dead Letter Queue (DLQ) Pattern
 
@@ -599,7 +599,7 @@ func (c *ProtoConsumer) processMessage(ctx context.Context, msg *kafka.Message) 
 
     return nil
 }
-```text
+```
 
 **DLQ Topic Naming:**
 
@@ -623,7 +623,7 @@ func (c *ProtoConsumer) processMessage(ctx context.Context, msg *kafka.Message) 
     "causation_id": "event-xyz-456"
   }
 }
-```protobuf
+```
 
 ### Consumer Error Handling Strategy
 
@@ -654,7 +654,7 @@ if err := handler(ctx, key, msg); err != nil {
 
 // Success - commit offset
 consumer.CommitMessage(msg)
-```text
+```
 
 **Implication:** Consumers MUST be idempotent (handle duplicate events safely).
 
@@ -676,7 +676,7 @@ partitionKey := event.AccountId
 
 kafka.Publish(ctx, topic, partitionKey, event)
 // All events for account-1 go to the same partition → ordered delivery
-```text
+```
 
 ### Handling Out-of-Order Events
 
@@ -711,7 +711,7 @@ func (c *AccountConsumer) handleEvent(ctx context.Context, event *eventsv1.Accou
 
     return c.accountRepo.Update(ctx, account)
 }
-```text
+```
 
 ### Partition Strategy
 
@@ -723,7 +723,7 @@ kafka-topics --create \
   --partitions 3 \
   --replication-factor 3 \
   --config retention.ms=604800000  # 7 days
-```text
+```
 
 **Partition Count Guidelines:**
 
@@ -766,7 +766,7 @@ message AccountCreatedEvent {
   string created_by = 4;           // NEW: optional field
   map<string, string> metadata = 5; // NEW: optional field
 }
-```text
+```
 
 **CI Validation:** `buf breaking --against main` passes
 
@@ -781,7 +781,7 @@ message AccountSuspendedEvent {
   google.protobuf.Timestamp suspended_until = 4;
   // ...
 }
-```sql
+```
 
 **Topic Strategy:** New event = new topic (`current-account.account-suspended.v1`)
 
@@ -808,7 +808,7 @@ Examples:
 - current-account.account-created.v1
 - financial-accounting.ledger-posting-captured.v1
 - position-keeping.transaction-captured.v1
-```text
+```
 
 **Version Increments:**
 
@@ -825,7 +825,7 @@ current-account.account-status-changed.v1
 
 # BIAN 14.0 adds "Suspend" behavior qualifier
 current-account.account-suspended.v1  ← New event type, NOT v2 of status-changed
-```text
+```
 
 ### CI/CD Schema Validation
 
@@ -855,7 +855,7 @@ jobs:
 
       - name: Check for breaking changes
         run: buf breaking --against '.git#branch=main'
-```text
+```
 
 **Result:** Pull requests with breaking proto changes fail CI
 
@@ -871,7 +871,7 @@ jobs:
 Service:    current-account | financial-accounting | position-keeping
 Event Name: account-created | ledger-posting-captured | transaction-captured
 Version:    v1 | v2 | v3
-```text
+```
 
 **Examples:**
 
@@ -892,7 +892,7 @@ kafka-topics --create \
   --config cleanup.policy=delete \
   --config compression.type=producer \
   --config min.insync.replicas=2
-```sql
+```
 
 | Setting | Value | Rationale |
 |---------|-------|-----------|
@@ -955,7 +955,7 @@ rate(kafka_producer_publish_errors_total[5m]) > 0
 
 # Outbox lag (oldest unprocessed event)
 kafka_producer_outbox_lag_seconds > 60
-```protobuf
+```
 
 ### Consumer Metrics
 
@@ -977,7 +977,7 @@ kafka_consumer_lag{group="financial-accounting-deposit-consumer"} > 1000
 
 # DLQ messages
 rate(kafka_consumer_dlq_messages_total[5m]) > 0
-```text
+```
 
 ### Distributed Tracing
 
@@ -1018,7 +1018,7 @@ func (c *EventConsumer) handleWithTracing(ctx context.Context, event *eventsv1.A
     // Process event with trace context
     return c.processEvent(ctx, event)
 }
-```text
+```
 
 **Trace Visualization (Jaeger/Tempo):**
 
@@ -1034,7 +1034,7 @@ Trace: Create Account (trace_id=abc123)
 └─ Span: PositionKeeping.ConsumeAccountCreated (100ms)
    ├─ Span: Database.CreatePositionLog (40ms)
    └─ Span: Kafka.Publish TransactionCapturedEvent (10ms)
-```text
+```
 
 ### Logging Standards
 
@@ -1057,7 +1057,7 @@ log.Error("Failed to publish event",
     "error", err,
     "retry_count", retryCount,
 )
-```text
+```
 
 **Consumer Logs:**
 
@@ -1077,7 +1077,7 @@ log.Error("Failed to process event",
     "retry_count", retryCount,
     "will_send_to_dlq", willSendToDLQ,
 )
-```text
+```
 
 ---
 
@@ -1114,7 +1114,7 @@ func TestAccountCreatedEvent_Serialization(t *testing.T) {
     assert.Equal(t, original.AccountId, deserialized.AccountId)
     assert.Equal(t, original.BaseCurrency, deserialized.BaseCurrency)
 }
-```text
+```
 
 ### Integration Tests: End-to-End Event Flow
 
@@ -1149,7 +1149,7 @@ func TestCreateAccount_PublishesEvent(t *testing.T) {
         t.Fatal("Timeout waiting for event")
     }
 }
-```text
+```
 
 ### Contract Tests: Consumer Expectations
 
@@ -1179,7 +1179,7 @@ func TestAccountCreatedConsumer_HandleEvent(t *testing.T) {
     assert.Equal(t, "account-123", bookingLog.AccountID)
     assert.Equal(t, commonv1.Currency_CURRENCY_GBP, bookingLog.BaseCurrency)
 }
-```text
+```
 
 ### Idempotency Tests
 
@@ -1210,7 +1210,7 @@ func TestConsumer_Idempotency(t *testing.T) {
     require.NoError(t, err)
     assert.Len(t, logs, 1)  // Still only 1 booking log
 }
-```sql
+```
 
 ---
 
@@ -1254,7 +1254,7 @@ kafka-consumer-groups --bootstrap-server kafka:9092 \
 # Output:
 # TOPIC                                       PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG
 # current-account.transaction-initiated.v1    0          1000            5000            4000  ← LAG
-```sql
+```
 
 **Resolution:**
 
@@ -1279,7 +1279,7 @@ FROM audit_outbox
 WHERE processed_at IS NULL
 ORDER BY created_at ASC
 LIMIT 10;
-```sql
+```
 
 **Resolution:**
 
@@ -1305,7 +1305,7 @@ log.Warn("Duplicate event detected",
     "idempotency_key", event.IdempotencyKey,
     "account_id", event.AccountId,
 )
-```sql
+```
 
 **Resolution:**
 
@@ -1328,7 +1328,7 @@ log.Warn("Duplicate event detected",
 kafka-console-consumer --bootstrap-server kafka:9092 \
   --topic financial-accounting.ledger-posting-captured.v1.dlq \
   --from-beginning
-```sql
+```
 
 **Resolution:**
 
@@ -1413,7 +1413,7 @@ sequenceDiagram
     Kafka-->>FA: TransactionCompletedEvent
     Kafka-->>PK: TransactionCompletedEvent
     Note over FA,PK: Services update internal state<br/>to mark transaction finalized
-```text
+```
 
 **Event Sequence:**
 
@@ -1434,7 +1434,7 @@ Command: ExecuteDeposit (causation_id = cmd-123)
        ├─> LedgerPostingCapturedEvent (event_id = evt-2, causation_id = evt-1)
        ├─> TransactionCapturedEvent (event_id = evt-3, causation_id = evt-1)
        └─> TransactionCompletedEvent (event_id = evt-4, causation_id = evt-1)
-```text
+```
 
 ---
 

--- a/docs/runbooks/disaster-recovery.md
+++ b/docs/runbooks/disaster-recovery.md
@@ -78,7 +78,7 @@ this with your specific:
 
    # If completely down, proceed to rebuild
 
-```text
+   ```
 
 1. **Deploy new cluster** (15-60 minutes)
 
@@ -95,7 +95,7 @@ this with your specific:
 
    kubectl get nodes
    kubectl get namespaces
-```
+   ```
 
 1. **Restore configurations** (60-90 minutes)
 
@@ -113,7 +113,7 @@ this with your specific:
 
    kubectl get all -n production
 
-```text
+   ```
 
 1. **Restore database** (90-150 minutes)
 
@@ -134,7 +134,7 @@ this with your specific:
    # Verify data integrity for each service database
    cockroach sql --execute="SELECT COUNT(*) FROM meridian_current_account.accounts;"
    cockroach sql --execute="SELECT COUNT(*) FROM meridian_position_keeping.financial_position_logs;"
-```
+   ```
 
 1. **Verify and test** (150-180 minutes)
 
@@ -152,7 +152,7 @@ this with your specific:
 
    stern -n production meridian --since 5m
 
-```text
+   ```
 
 ### Scenario 2: Database Corruption
 
@@ -171,7 +171,7 @@ this with your specific:
    # Verify no active connections
 
    cockroach sql --execute="SHOW SESSIONS;"
-```
+   ```
 
 1. **Assess corruption scope**
 
@@ -185,7 +185,7 @@ this with your specific:
 
    cockroach sql --execute="SELECT * FROM system.range_log WHERE info LIKE '%corruption%';"
 
-```text
+   ```
 
 1. **Restore from backup**
 
@@ -204,7 +204,7 @@ this with your specific:
    cockroach sql --execute="RESTORE DATABASE meridian_payment_order FROM 's3://backups/2025-10-28-00-00/payment_order';"
    cockroach sql --execute="RESTORE DATABASE meridian_party FROM 's3://backups/2025-10-28-00-00/party';"
    cockroach sql --execute="RESTORE DATABASE meridian_platform FROM 's3://backups/2025-10-28-00-00/platform';"
-```
+   ```
 
 1. **Verify data integrity**
 
@@ -218,7 +218,7 @@ this with your specific:
 
    cockroach sql --execute="SELECT COUNT(*) FROM meridian_current_account.accounts;"
 
-```text
+   ```
 
 1. **Resume operations**
 
@@ -231,7 +231,7 @@ this with your specific:
    # Monitor for errors
 
    kubectl logs -n production -l app=meridian --tail=100
-```
+   ```
 
 ### Scenario 3: Regional Outage
 
@@ -253,7 +253,7 @@ this with your specific:
      --hosted-zone-id Z123456 \
      --change-batch file://dns-failover.json
 
-```text
+   ```
 
 1. **Verify DR cluster** (30-60 minutes)
 
@@ -272,7 +272,7 @@ this with your specific:
    # Verify replication for all service databases
    cockroach sql --execute="SHOW RANGES FROM DATABASE meridian_current_account;"
    cockroach sql --execute="SHOW RANGES FROM DATABASE meridian_platform;"
-```
+   ```
 
 1. **Monitor switchover** (60-120 minutes)
 
@@ -290,7 +290,7 @@ this with your specific:
 
    kubectl get events -n production --sort-by='.lastTimestamp'
 
-```text
+   ```
 
 1. **Post-recovery actions** (when primary region recovers)
 
@@ -302,7 +302,7 @@ this with your specific:
 
    # Plan switchback during maintenance window
 
-```
+   ```
 
 ### Scenario 4: Ransomware / Security Breach
 
@@ -336,7 +336,7 @@ this with your specific:
 
    kubectl scale deployment meridian -n production --replicas=0
 
-```text
+   ```
 
 1. **Preserve evidence**
 
@@ -353,7 +353,7 @@ this with your specific:
    # Export network policies and RBAC
 
    kubectl get networkpolicies,roles,rolebindings -n production -o yaml > incident-rbac-$(date +%s).yaml
-```
+   ```
 
 1. **Engage security team**
    - Contact: <security@your-domain.com>
@@ -376,7 +376,7 @@ this with your specific:
 
    # Rotate all secrets, API keys, certificates
 
-```text
+   ```
 
 1. **Post-incident hardening**
    - Review all RBAC permissions

--- a/docs/runbooks/saga-failure-recovery.md
+++ b/docs/runbooks/saga-failure-recovery.md
@@ -314,7 +314,7 @@ compensation failed: timeout
      -d @compensation.json \
      "https://api.positionkeeping/v1/logs/ACC-123/entries"
 
-```text
+   ```
 
 1. **Verify net balance is zero:**
 
@@ -326,7 +326,7 @@ compensation failed: timeout
 
    # Verify: sum(CREDIT) - sum(DEBIT) = 0
 
-```
+   ```
 
 1. **Document in incident log:**
    - Correlation ID
@@ -360,7 +360,7 @@ compensation failed: timeout
 
    curl "https://api.financialaccounting/v1/postings?idempotency_key=TXN-456"
 
-```text
+   ```
 
 1. **Determine actual state:**
    - If external services show entries: Execute compensation manually


### PR DESCRIPTION
## Summary

- Fixed 124 instances of malformed markdown code block closing tags across documentation
- Code blocks were incorrectly closed with language specifiers (e.g., ` ```text `, ` ```sql `, ` ```protobuf `) instead of bare triple backticks (` ``` `)
- This caused markdown rendering issues in IntelliJ, GitHub, and other markdown viewers

## Changes Made

| File | Issues Fixed |
|------|-------------|
| `docs/architecture/event-driven-architecture.md` | 40 |
| `docs/architecture/api-contracts/financial-accounting-contract.md` | 26 |
| `docs/architecture/bian-service-boundaries.md` | 21 |
| `docs/architecture/api-contracts/position-keeping-contract.md` | 16 |
| `docs/architecture/api-contracts/current-account-contract.md` | 9 |
| `docs/runbooks/disaster-recovery.md` | 9 + indentation fixes |
| `docs/runbooks/saga-failure-recovery.md` | 2 + indentation fixes |
| `docs/adr/0010-grpc-client-side-load-balancing.md` | 1 |
| `docs/adr/0005-adapter-pattern-layer-translation.md` | 1 + box alignment |

## Technical Details

**Problem pattern:**
```markdown
` ` `bash
echo "hello"
` ` `text  ← incorrect - language specifier on closing tag
```

**Correct pattern:**
```markdown
` ` `bash
echo "hello"
` ` `  ← correct - bare backticks
```

## Test plan

- [x] Markdown linting passes (`markdownlint-cli2`)
- [ ] Review documentation renders correctly in GitHub PR view
- [ ] Spot check in IntelliJ markdown preview