### PR TITLE
Define clearing account configuration structure

### DIFF
--- a/services/current-account/config/accounts.go
+++ b/services/current-account/config/accounts.go
@@ -1,0 +1,57 @@
+// Package config provides configuration structures for the current-account service.
+package config
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+// AccountConfig holds configuration for internal accounts used in transaction routing.
+//
+// DepositClearingAccountID identifies the bank's clearing account that receives the
+// debit side of customer deposit transactions. When a customer deposits funds, this
+// clearing account is debited while the customer's account is credited, representing
+// funds received but not yet settled through the banking system.
+type AccountConfig struct {
+	// DepositClearingAccountID is the account ID for deposit clearing (debit side).
+	// This is typically a bank internal clearing account in FinancialAccounting.
+	DepositClearingAccountID string
+
+	// NostroAccountID is the nostro account for external settlements (optional).
+	// Used when funds need to be settled with external banking partners.
+	NostroAccountID string
+}
+
+// Validation errors
+var (
+	ErrEmptyDepositClearingAccountID = errors.New("deposit clearing account ID is required")
+)
+
+// LoadAccountConfig loads account configuration from environment variables.
+//
+// Required environment variables:
+//   - DEPOSIT_CLEARING_ACCOUNT_ID: Account ID for deposit clearing (required)
+//
+// Optional environment variables:
+//   - NOSTRO_ACCOUNT_ID: Nostro account for external settlements
+func LoadAccountConfig() (*AccountConfig, error) {
+	cfg := &AccountConfig{
+		DepositClearingAccountID: strings.TrimSpace(os.Getenv("DEPOSIT_CLEARING_ACCOUNT_ID")),
+		NostroAccountID:          strings.TrimSpace(os.Getenv("NOSTRO_ACCOUNT_ID")),
+	}
+
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// Validate validates the account configuration.
+func (c *AccountConfig) Validate() error {
+	if c.DepositClearingAccountID == "" {
+		return ErrEmptyDepositClearingAccountID
+	}
+	return nil
+}

--- a/services/current-account/config/accounts_test.go
+++ b/services/current-account/config/accounts_test.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestLoadAccountConfig_WithValidEnv(t *testing.T) {
+	clearAccountEnv(t)
+	t.Setenv("DEPOSIT_CLEARING_ACCOUNT_ID", "clearing-account-uuid")
+
+	cfg, err := LoadAccountConfig()
+	if err != nil {
+		t.Fatalf("LoadAccountConfig() error = %v, want nil", err)
+	}
+
+	if cfg.DepositClearingAccountID != "clearing-account-uuid" {
+		t.Errorf("DepositClearingAccountID = %s, want clearing-account-uuid", cfg.DepositClearingAccountID)
+	}
+}
+
+func TestLoadAccountConfig_WithOptionalNostroAccount(t *testing.T) {
+	clearAccountEnv(t)
+	t.Setenv("DEPOSIT_CLEARING_ACCOUNT_ID", "clearing-account-uuid")
+	t.Setenv("NOSTRO_ACCOUNT_ID", "nostro-account-uuid")
+
+	cfg, err := LoadAccountConfig()
+	if err != nil {
+		t.Fatalf("LoadAccountConfig() error = %v, want nil", err)
+	}
+
+	if cfg.DepositClearingAccountID != "clearing-account-uuid" {
+		t.Errorf("DepositClearingAccountID = %s, want clearing-account-uuid", cfg.DepositClearingAccountID)
+	}
+	if cfg.NostroAccountID != "nostro-account-uuid" {
+		t.Errorf("NostroAccountID = %s, want nostro-account-uuid", cfg.NostroAccountID)
+	}
+}
+
+func TestLoadAccountConfig_WithoutEnv(t *testing.T) {
+	clearAccountEnv(t)
+
+	_, err := LoadAccountConfig()
+	if err == nil {
+		t.Error("LoadAccountConfig() error = nil, want error for missing DEPOSIT_CLEARING_ACCOUNT_ID")
+	}
+	if !errors.Is(err, ErrEmptyDepositClearingAccountID) {
+		t.Errorf("LoadAccountConfig() error = %v, want ErrEmptyDepositClearingAccountID", err)
+	}
+}
+
+func TestLoadAccountConfig_WhitespaceOnlyEnv(t *testing.T) {
+	clearAccountEnv(t)
+	t.Setenv("DEPOSIT_CLEARING_ACCOUNT_ID", "   \t\n   ")
+
+	_, err := LoadAccountConfig()
+	if err == nil {
+		t.Error("LoadAccountConfig() error = nil, want error for whitespace-only DEPOSIT_CLEARING_ACCOUNT_ID")
+	}
+}
+
+func TestLoadAccountConfig_TrimsWhitespace(t *testing.T) {
+	clearAccountEnv(t)
+	t.Setenv("DEPOSIT_CLEARING_ACCOUNT_ID", "  clearing-account-uuid  ")
+	t.Setenv("NOSTRO_ACCOUNT_ID", "  nostro-account-uuid  ")
+
+	cfg, err := LoadAccountConfig()
+	if err != nil {
+		t.Fatalf("LoadAccountConfig() error = %v, want nil", err)
+	}
+
+	if cfg.DepositClearingAccountID != "clearing-account-uuid" {
+		t.Errorf("DepositClearingAccountID = %q, want %q (should trim whitespace)", cfg.DepositClearingAccountID, "clearing-account-uuid")
+	}
+	if cfg.NostroAccountID != "nostro-account-uuid" {
+		t.Errorf("NostroAccountID = %q, want %q (should trim whitespace)", cfg.NostroAccountID, "nostro-account-uuid")
+	}
+}
+
+func TestAccountConfig_Validate_ValidConfig(t *testing.T) {
+	cfg := &AccountConfig{
+		DepositClearingAccountID: "clearing-account-uuid",
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestAccountConfig_Validate_EmptyDepositClearingAccountID(t *testing.T) {
+	cfg := &AccountConfig{
+		DepositClearingAccountID: "",
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("Validate() error = nil, want error for empty DepositClearingAccountID")
+	}
+	if !errors.Is(err, ErrEmptyDepositClearingAccountID) {
+		t.Errorf("Validate() error = %v, want ErrEmptyDepositClearingAccountID", err)
+	}
+}
+
+func TestAccountConfig_Validate_WithNostroAccount(t *testing.T) {
+	cfg := &AccountConfig{
+		DepositClearingAccountID: "clearing-account-uuid",
+		NostroAccountID:          "nostro-account-uuid",
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestAccountConfig_Validate_EmptyNostroAccountIsAllowed(t *testing.T) {
+	cfg := &AccountConfig{
+		DepositClearingAccountID: "clearing-account-uuid",
+		NostroAccountID:          "",
+	}
+
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("Validate() error = %v, want nil (empty nostro account should be allowed)", err)
+	}
+}
+
+// clearAccountEnv clears environment variables used in tests
+func clearAccountEnv(t *testing.T) {
+	t.Helper()
+	envVars := []string{
+		"DEPOSIT_CLEARING_ACCOUNT_ID",
+		"NOSTRO_ACCOUNT_ID",
+	}
+	for _, key := range envVars {
+		_ = os.Unsetenv(key)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `AccountConfig` struct to support contra-account routing for deposits
- Configuration includes `DepositClearingAccountID` (required) and `NostroAccountID` (optional)
- Environment variable loading with validation and whitespace trimming

## Task Master Reference
- **Tag**: ledger-integrity
- **Task ID**: 3

## Changes Made
- New file `services/current-account/config/accounts.go` with:
  - `AccountConfig` struct for internal account configuration
  - `LoadAccountConfig()` function to load from environment variables
  - `Validate()` method to ensure required fields are present
- New file `services/current-account/config/accounts_test.go` with comprehensive tests

## Test Plan
- Unit tests verify:
  - Loading config with valid environment variable
  - Loading config with optional nostro account
  - Error when required env var is missing
  - Whitespace-only values are rejected
  - Whitespace is trimmed from values
  - Validation with valid/invalid configs
  - Empty nostro account is allowed (optional field)