### PR TITLE
Wire ValidateDoubleEntry into UpdateFinancialBookingLog

### DIFF
--- a/services/financial-accounting/service/financial_accounting_service.go
+++ b/services/financial-accounting/service/financial_accounting_service.go
@@ -3,8 +3,10 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
+	"github.com/shopspring/decimal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -12,6 +14,7 @@ import (
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
 	"github.com/meridianhub/meridian/services/financial-accounting/domain"
+	"github.com/meridianhub/meridian/services/financial-accounting/observability"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 )
 
@@ -821,6 +824,42 @@ func (s *FinancialAccountingService) UpdateFinancialBookingLog(
 	if !isValidBookingLogTransition(bookingLog.Status, newStatus) {
 		return nil, status.Errorf(codes.FailedPrecondition,
 			"invalid status transition from %s to %s", bookingLog.Status, newStatus)
+	}
+
+	// Enforce double-entry bookkeeping constraint when transitioning to POSTED
+	if newStatus == domain.TransactionStatusPosted {
+		postings, err := s.repository.GetPostingsByBookingLogID(ctx, bookingLogID)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to retrieve postings for balance validation: %v", err)
+		}
+
+		// Empty postings are not allowed for POSTED status
+		if len(postings) == 0 {
+			observability.RecordDoubleEntryValidation("unbalanced")
+			return nil, status.Error(codes.FailedPrecondition,
+				"cannot post booking log with no postings")
+		}
+
+		// Calculate debit and credit totals
+		debitTotal := decimal.Zero
+		creditTotal := decimal.Zero
+		for _, posting := range postings {
+			switch posting.Direction {
+			case domain.PostingDirectionDebit:
+				debitTotal = debitTotal.Add(posting.Amount.Amount())
+			case domain.PostingDirectionCredit:
+				creditTotal = creditTotal.Add(posting.Amount.Amount())
+			}
+		}
+
+		// Validate double-entry balance
+		if !debitTotal.Equal(creditTotal) {
+			imbalance := debitTotal.Sub(creditTotal)
+			observability.RecordDoubleEntryValidation("unbalanced")
+			return nil, status.Error(codes.FailedPrecondition,
+				fmt.Sprintf("cannot post unbalanced booking log: debits=%s credits=%s imbalance=%s",
+					debitTotal.String(), creditTotal.String(), imbalance.String()))
+		}
 	}
 
 	// Apply status update

--- a/services/financial-accounting/service/grpc_integration_test.go
+++ b/services/financial-accounting/service/grpc_integration_test.go
@@ -1225,3 +1225,219 @@ func TestEndToEnd_PostingLifecycle(t *testing.T) {
 	assert.Equal(t, postingID, listResp.LedgerPostings[0].Id)
 	assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED, listResp.LedgerPostings[0].Status)
 }
+
+// ============================================================================
+// UpdateFinancialBookingLog Integration Tests - Double-Entry Balance Validation
+// ============================================================================
+
+// createTestBookingLogWithStatus creates a booking log with specified status for testing
+func createTestBookingLogWithStatus(t *testing.T, db *gorm.DB, ctx context.Context, status string) uuid.UUID {
+	t.Helper()
+
+	bookingLogID := uuid.New()
+	bookingLog := &persistence.FinancialBookingLogEntity{
+		ID:                      bookingLogID,
+		FinancialAccountType:    "DEBIT",
+		ProductServiceReference: "PROD-001",
+		BusinessUnitReference:   "BU-001",
+		ChartOfAccountsRules:    "{}",
+		BaseCurrency:            "GBP",
+		Status:                  status,
+		IdempotencyKey:          "test-key-" + uuid.New().String(),
+		CreatedAt:               time.Now(),
+		UpdatedAt:               time.Now(),
+		Version:                 1,
+	}
+	require.NoError(t, db.WithContext(ctx).Create(bookingLog).Error)
+
+	return bookingLogID
+}
+
+// createTestPosting creates a ledger posting for testing double-entry validation
+func createTestPosting(t *testing.T, db *gorm.DB, ctx context.Context, bookingLogID uuid.UUID, direction string, amountCents int64) uuid.UUID {
+	t.Helper()
+
+	postingID := uuid.New()
+	posting := &persistence.LedgerPostingEntity{
+		ID:                    postingID,
+		FinancialBookingLogID: bookingLogID,
+		PostingDirection:      direction,
+		AmountCents:           amountCents,
+		Currency:              "GBP",
+		AccountID:             "ACC-" + uuid.New().String()[:8],
+		ValueDate:             time.Now(),
+		Status:                "PENDING",
+		CreatedAt:             time.Now(),
+		UpdatedAt:             time.Now(),
+	}
+	require.NoError(t, db.WithContext(ctx).Create(posting).Error)
+
+	return postingID
+}
+
+// TestUpdateFinancialBookingLog_Integration_BalancedPostings_Success tests that
+// transitioning to POSTED status succeeds when postings are balanced (debits == credits).
+func TestUpdateFinancialBookingLog_Integration_BalancedPostings_Success(t *testing.T) {
+	ts, _ := setupIntegrationTest(t)
+	defer ts.cleanup()
+
+	ctx, cancel := context.WithTimeout(ts.ctx, 10*time.Second)
+	defer cancel()
+
+	// Create a booking log in PENDING status
+	bookingLogID := createTestBookingLogWithStatus(t, ts.db, ts.ctx, "PENDING")
+
+	// Create balanced postings: 100.00 debit + 100.00 credit
+	createTestPosting(t, ts.db, ts.ctx, bookingLogID, "DEBIT", 10000)  // 100.00
+	createTestPosting(t, ts.db, ts.ctx, bookingLogID, "CREDIT", 10000) // 100.00
+
+	// Attempt to transition to POSTED
+	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
+		Id:     bookingLogID.String(),
+		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+	})
+
+	// Should succeed with balanced postings
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED, resp.FinancialBookingLog.Status)
+}
+
+// TestUpdateFinancialBookingLog_Integration_MultipleBalancedPostings tests that
+// multiple postings that sum to balanced amounts allow POSTED transition.
+func TestUpdateFinancialBookingLog_Integration_MultipleBalancedPostings(t *testing.T) {
+	ts, _ := setupIntegrationTest(t)
+	defer ts.cleanup()
+
+	ctx, cancel := context.WithTimeout(ts.ctx, 10*time.Second)
+	defer cancel()
+
+	// Create a booking log in PENDING status
+	bookingLogID := createTestBookingLogWithStatus(t, ts.db, ts.ctx, "PENDING")
+
+	// Create multiple postings: 2 debits (50 + 50) = 1 credit (100)
+	createTestPosting(t, ts.db, ts.ctx, bookingLogID, "DEBIT", 5000)   // 50.00
+	createTestPosting(t, ts.db, ts.ctx, bookingLogID, "DEBIT", 5000)   // 50.00
+	createTestPosting(t, ts.db, ts.ctx, bookingLogID, "CREDIT", 10000) // 100.00
+
+	// Attempt to transition to POSTED
+	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
+		Id:     bookingLogID.String(),
+		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+	})
+
+	// Should succeed with balanced postings
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED, resp.FinancialBookingLog.Status)
+}
+
+// TestUpdateFinancialBookingLog_Integration_UnbalancedPostings_FailedPrecondition tests that
+// transitioning to POSTED status fails when debits != credits.
+func TestUpdateFinancialBookingLog_Integration_UnbalancedPostings_FailedPrecondition(t *testing.T) {
+	ts, _ := setupIntegrationTest(t)
+	defer ts.cleanup()
+
+	ctx, cancel := context.WithTimeout(ts.ctx, 10*time.Second)
+	defer cancel()
+
+	// Create a booking log in PENDING status
+	bookingLogID := createTestBookingLogWithStatus(t, ts.db, ts.ctx, "PENDING")
+
+	// Create unbalanced postings: 100.00 debit + 50.00 credit
+	createTestPosting(t, ts.db, ts.ctx, bookingLogID, "DEBIT", 10000) // 100.00
+	createTestPosting(t, ts.db, ts.ctx, bookingLogID, "CREDIT", 5000) // 50.00
+
+	// Attempt to transition to POSTED
+	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
+		Id:     bookingLogID.String(),
+		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+	})
+
+	// Should fail with FailedPrecondition
+	require.Error(t, err)
+	require.Nil(t, resp)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "cannot post unbalanced booking log")
+	assert.Contains(t, st.Message(), "debits=")
+	assert.Contains(t, st.Message(), "credits=")
+	assert.Contains(t, st.Message(), "imbalance=")
+}
+
+// TestUpdateFinancialBookingLog_Integration_NoPostings_FailedPrecondition tests that
+// transitioning to POSTED status fails when there are no postings.
+func TestUpdateFinancialBookingLog_Integration_NoPostings_FailedPrecondition(t *testing.T) {
+	ts, _ := setupIntegrationTest(t)
+	defer ts.cleanup()
+
+	ctx, cancel := context.WithTimeout(ts.ctx, 10*time.Second)
+	defer cancel()
+
+	// Create a booking log in PENDING status with no postings
+	bookingLogID := createTestBookingLogWithStatus(t, ts.db, ts.ctx, "PENDING")
+
+	// Attempt to transition to POSTED with no postings
+	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
+		Id:     bookingLogID.String(),
+		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+	})
+
+	// Should fail with FailedPrecondition
+	require.Error(t, err)
+	require.Nil(t, resp)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "cannot post booking log with no postings")
+}
+
+// TestUpdateFinancialBookingLog_Integration_NonPostedTransition_SkipsValidation tests that
+// transitions to non-POSTED statuses (FAILED, CANCELLED) skip balance validation.
+func TestUpdateFinancialBookingLog_Integration_NonPostedTransition_SkipsValidation(t *testing.T) {
+	ts, _ := setupIntegrationTest(t)
+	defer ts.cleanup()
+
+	ctx, cancel := context.WithTimeout(ts.ctx, 10*time.Second)
+	defer cancel()
+
+	// Create a booking log in PENDING status with unbalanced postings
+	bookingLogID := createTestBookingLogWithStatus(t, ts.db, ts.ctx, "PENDING")
+	createTestPosting(t, ts.db, ts.ctx, bookingLogID, "DEBIT", 10000) // 100.00, no credit
+
+	// Transition to FAILED should succeed (balance validation not required)
+	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
+		Id:     bookingLogID.String(),
+		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_FAILED,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_FAILED, resp.FinancialBookingLog.Status)
+}
+
+// TestUpdateFinancialBookingLog_Integration_CancelledTransition_SkipsValidation tests that
+// transitions to CANCELLED skip balance validation.
+func TestUpdateFinancialBookingLog_Integration_CancelledTransition_SkipsValidation(t *testing.T) {
+	ts, _ := setupIntegrationTest(t)
+	defer ts.cleanup()
+
+	ctx, cancel := context.WithTimeout(ts.ctx, 10*time.Second)
+	defer cancel()
+
+	// Create a booking log in PENDING status with no postings
+	bookingLogID := createTestBookingLogWithStatus(t, ts.db, ts.ctx, "PENDING")
+
+	// Transition to CANCELLED should succeed without postings
+	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
+		Id:     bookingLogID.String(),
+		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_CANCELLED,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_CANCELLED, resp.FinancialBookingLog.Status)
+}


### PR DESCRIPTION
## Summary
- Add balance validation guard when transitioning a FinancialBookingLog to POSTED status
- Enforce double-entry bookkeeping constraint (debits must equal credits)
- Prevent posting with zero postings

## Task Master Reference
- **Tag**: ledger-integrity
- **Task ID**: 1

## Changes Made
- Add balance check before POSTED transition in `UpdateFinancialBookingLog` method
- Validate postings exist (cannot post with zero postings)
- Validate debits equal credits using decimal arithmetic
- Return `FailedPrecondition` with detailed error message on failure
- Record `observability.RecordDoubleEntryValidation("unbalanced")` metric on failure

## Test Plan
- [x] Integration test: POSTED transition with balanced postings (1 debit + 1 credit of equal amounts) succeeds
- [x] Integration test: POSTED transition with multiple balanced postings (2 debits + 1 credit where sum(debits) == credit) succeeds  
- [x] Integration test: POSTED transition with unbalanced postings (debit != credit) returns FailedPrecondition
- [x] Integration test: POSTED transition with no postings returns FailedPrecondition
- [x] Integration test: Non-POSTED transitions (FAILED, CANCELLED) skip balance validation
- [x] Error message contains actual debit/credit amounts and imbalance