### PR TITLE
feat: add Kafka audit hooks for TransactionLineage and AuditTrailEntry (task 4)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
-    timeout-minutes: 30  # Increased to accommodate wait times for tests (8m) + build (10m) + linting (5m) + review time
+    timeout-minutes: 45  # Increased to accommodate wait times for tests (12m) + build (15m) + linting (8m) + review time
     permissions:
       contents: read
       pull-requests: read
@@ -33,7 +33,7 @@ jobs:
       # Each step has individual timeout to fail fast if checks hang
       - name: Wait for Tests
         uses: lewagon/wait-on-check-action@v1.3.4
-        timeout-minutes: 8  # Tests should complete within 8 minutes
+        timeout-minutes: 12  # Tests may take up to 12 minutes under load
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           check-name: 'Run Tests'
@@ -43,7 +43,7 @@ jobs:
 
       - name: Wait for Build
         uses: lewagon/wait-on-check-action@v1.3.4
-        timeout-minutes: 10  # Docker builds can take up to 10 minutes
+        timeout-minutes: 15  # Docker builds can take up to 15 minutes under load
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           check-name: 'Build Docker Image'
@@ -53,7 +53,7 @@ jobs:
 
       - name: Wait for Linting
         uses: lewagon/wait-on-check-action@v1.3.4
-        timeout-minutes: 5  # Linting should be fast (5 minutes max)
+        timeout-minutes: 8  # Linting may take longer under load
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           check-name: 'golangci-lint'

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -36,6 +36,19 @@ jobs:
           go-version: '1.25'
           cache: true
 
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Install Go proto tools
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+      - name: Generate protobuf code
+        run: make proto
+
       - name: Run schema validation tests
         run: |
           echo "Running schema validation tests..."

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          go install github.com/bufbuild/buf/cmd/buf@latest
 
       - name: Generate protobuf code
         run: make proto

--- a/services/position-keeping/app/container.go
+++ b/services/position-keeping/app/container.go
@@ -10,6 +10,7 @@ import (
 	"github.com/meridianhub/meridian/services/position-keeping/adapters/messaging"
 	"github.com/meridianhub/meridian/services/position-keeping/adapters/persistence"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/shared/platform/audit"
 	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/kafka"
 	"github.com/meridianhub/meridian/shared/platform/observability"
@@ -27,6 +28,7 @@ type Container struct {
 	Tracer          *observability.Tracer
 	AuthInterceptor *auth.Interceptor
 	kafkaProducer   *kafka.ProtoProducer // internal, for cleanup
+	auditPublisher  *audit.Publisher     // internal, for cleanup
 
 	// Adapters
 	EventPublisher domain.EventPublisher
@@ -58,6 +60,8 @@ func NewContainer(ctx context.Context, config *Config, logger *slog.Logger) (*Co
 	if err := container.initializeRedis(ctx); err != nil {
 		return nil, fmt.Errorf("failed to initialize redis: %w", err)
 	}
+
+	container.initializeAuditPublisher()
 
 	container.initializeEventPublisher()
 
@@ -224,6 +228,39 @@ func (c *Container) initializeRedis(ctx context.Context) error {
 	return nil
 }
 
+// initializeAuditPublisher initializes the audit publisher for Kafka-based audit events.
+// Sets the global schema name and publisher for GORM hook integration.
+func (c *Container) initializeAuditPublisher() {
+	// Always set schema name for audit events (used for outbox fallback routing)
+	audit.SetSchemaName("position_keeping")
+
+	if !c.Config.Kafka.Enabled {
+		c.Logger.Info("audit publisher disabled (kafka disabled), using outbox fallback only")
+		return
+	}
+
+	// Create audit publisher
+	publisher, err := audit.NewPublisher(audit.PublisherConfig{
+		BootstrapServers: strings.Join(c.Config.Kafka.Brokers, ","),
+		Topic:            kafka.AuditEventsTopic,
+		SchemaName:       "position_keeping",
+		ClientID:         "position-keeping-audit",
+	})
+	if err != nil {
+		c.Logger.Info("audit publisher not created, using outbox fallback only",
+			"reason", err.Error())
+		return
+	}
+
+	// Set global publisher for GORM hook integration
+	audit.SetGlobalPublisher(publisher)
+	c.auditPublisher = publisher
+
+	c.Logger.Info("audit publisher initialized",
+		"topic", kafka.AuditEventsTopic,
+		"schema", "position_keeping")
+}
+
 // initializeEventPublisher initializes Kafka event publisher or no-op publisher
 func (c *Container) initializeEventPublisher() {
 	if !c.Config.Kafka.Enabled {
@@ -278,6 +315,18 @@ func (c *Container) Close(ctx context.Context) error {
 	c.Logger.Info("closing container resources...")
 
 	var errs []error
+
+	// Close audit publisher first (flush audit events before closing other resources)
+	if c.auditPublisher != nil {
+		if err := c.auditPublisher.Close(); err != nil {
+			c.Logger.Error("failed to close audit publisher", "error", err)
+			errs = append(errs, fmt.Errorf("audit publisher close: %w", err))
+		} else {
+			c.Logger.Info("audit publisher closed")
+		}
+		// Clear global publisher to prevent use after close
+		audit.SetGlobalPublisher(nil)
+	}
 
 	// Close Kafka producer (flush outstanding messages first)
 	if c.kafkaProducer != nil {

--- a/shared/domain/models/financial_position_log.go
+++ b/shared/domain/models/financial_position_log.go
@@ -98,7 +98,7 @@ type AuditTrailEntry struct {
 	BaseModel
 
 	// Domain Fields
-	AuditID                uuid.UUID      `gorm:"type:uuid;not null;uniqueIndex:idx_position_keeping_audit_trail_entries_audit_id" json:"audit_id"`
+	AuditEntryID           uuid.UUID      `gorm:"column:audit_id;type:uuid;not null;uniqueIndex:idx_position_keeping_audit_trail_entries_audit_id" json:"audit_id"`
 	FinancialPositionLogID uuid.UUID      `gorm:"type:uuid;not null;index:idx_position_keeping_audit_trail_entries_log_id" json:"financial_position_log_id"`
 	Timestamp              time.Time      `gorm:"type:timestamptz;not null;index:idx_position_keeping_audit_trail_entries_timestamp" json:"timestamp"`
 	UserID                 string         `gorm:"type:varchar(100);not null;index:idx_position_keeping_audit_trail_entries_user_id" json:"user_id"`
@@ -195,4 +195,84 @@ func (t *TransactionLogEntry) AfterUpdate(tx *gorm.DB) error {
 // It writes an audit outbox entry with the deleted transaction log entry data.
 func (t *TransactionLogEntry) AfterDelete(tx *gorm.DB) error {
 	return audit.RecordDelete(tx, *t)
+}
+
+// AuditID returns the record ID as a string for audit logging.
+// Implements the audit.Auditable interface.
+func (l TransactionLineage) AuditID() string {
+	return l.ID.String()
+}
+
+// AuditTableName returns the table name for audit logging.
+// Implements the audit.Auditable interface.
+func (l TransactionLineage) AuditTableName() string {
+	return l.TableName()
+}
+
+// AfterCreate is a GORM hook that runs after INSERT operations on TransactionLineage.
+// It writes an audit outbox entry with the new transaction lineage data.
+func (l *TransactionLineage) AfterCreate(tx *gorm.DB) error {
+	return audit.RecordCreate(tx, *l)
+}
+
+// BeforeUpdate is a GORM hook that runs before UPDATE operations on TransactionLineage.
+// It captures the old values BEFORE the update happens and stores them in the transaction context.
+func (l *TransactionLineage) BeforeUpdate(tx *gorm.DB) error {
+	// First, call the base model's BeforeUpdate to handle UpdatedBy
+	if err := l.BaseModel.BeforeUpdate(tx); err != nil {
+		return err
+	}
+	return audit.CaptureOldValue(tx, *l)
+}
+
+// AfterUpdate is a GORM hook that runs after UPDATE operations on TransactionLineage.
+// It retrieves the old values from context and writes an audit outbox entry.
+func (l *TransactionLineage) AfterUpdate(tx *gorm.DB) error {
+	return audit.RecordUpdate(tx, *l)
+}
+
+// AfterDelete is a GORM hook that runs after DELETE operations on TransactionLineage.
+// It writes an audit outbox entry with the deleted transaction lineage data.
+func (l *TransactionLineage) AfterDelete(tx *gorm.DB) error {
+	return audit.RecordDelete(tx, *l)
+}
+
+// AuditID returns the record ID as a string for audit logging.
+// Implements the audit.Auditable interface.
+func (a AuditTrailEntry) AuditID() string {
+	return a.ID.String()
+}
+
+// AuditTableName returns the table name for audit logging.
+// Implements the audit.Auditable interface.
+func (a AuditTrailEntry) AuditTableName() string {
+	return a.TableName()
+}
+
+// AfterCreate is a GORM hook that runs after INSERT operations on AuditTrailEntry.
+// It writes an audit outbox entry with the new audit trail entry data.
+func (a *AuditTrailEntry) AfterCreate(tx *gorm.DB) error {
+	return audit.RecordCreate(tx, *a)
+}
+
+// BeforeUpdate is a GORM hook that runs before UPDATE operations on AuditTrailEntry.
+// It captures the old values BEFORE the update happens and stores them in the transaction context.
+func (a *AuditTrailEntry) BeforeUpdate(tx *gorm.DB) error {
+	// First, call the base model's BeforeUpdate to handle UpdatedBy
+	if err := a.BaseModel.BeforeUpdate(tx); err != nil {
+		return err
+	}
+	return audit.CaptureOldValue(tx, *a)
+}
+
+// AfterUpdate is a GORM hook that runs after UPDATE operations on AuditTrailEntry.
+// It retrieves the old values from context and writes an audit outbox entry.
+func (a *AuditTrailEntry) AfterUpdate(tx *gorm.DB) error {
+	return audit.RecordUpdate(tx, *a)
+}
+
+// AfterDelete is a GORM hook that runs after DELETE operations on AuditTrailEntry.
+// It writes an audit outbox entry with the deleted audit trail entry data.
+func (a *AuditTrailEntry) AfterDelete(tx *gorm.DB) error {
+	return audit.RecordDelete(tx, *a)
 }

--- a/shared/domain/models/financial_position_log_audit_test.go
+++ b/shared/domain/models/financial_position_log_audit_test.go
@@ -535,3 +535,391 @@ func TestFinancialPositionLog_AuditOutbox_AllOperations(t *testing.T) {
 		Pluck("operation", &operations)
 	assert.Equal(t, []string{"INSERT", "UPDATE", "DELETE"}, operations, "Operations should be in correct order")
 }
+
+// createTestTransactionLineage creates a test TransactionLineage with required fields
+func createTestTransactionLineage(logID uuid.UUID) *TransactionLineage {
+	return &TransactionLineage{
+		FinancialPositionLogID: logID,
+		TransactionID:          uuid.New(),
+		TransactionType:        "PAYMENT",
+		ChildTransactionIDs:    []byte("[]"),
+		RelatedTransactionIDs:  []byte("[]"),
+	}
+}
+
+// createTestAuditTrailEntry creates a test AuditTrailEntry with required fields
+func createTestAuditTrailEntry(logID uuid.UUID) *AuditTrailEntry {
+	return &AuditTrailEntry{
+		AuditEntryID:           uuid.New(),
+		FinancialPositionLogID: logID,
+		Timestamp:              time.Now(),
+		UserID:                 "test-user",
+		Action:                 "CREATED",
+	}
+}
+
+// TestTransactionLineage_AuditOutbox_AtomicCommit verifies that audit outbox entry
+// is created atomically with the TransactionLineage insert.
+func TestTransactionLineage_AuditOutbox_AtomicCommit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupPositionKeepingTestDB(t)
+	defer cleanup()
+
+	// Migrate TransactionLineage
+	err := db.AutoMigrate(&TransactionLineage{})
+	require.NoError(t, err, "Failed to migrate TransactionLineage")
+
+	// Create prerequisite Customer, Account, and FinancialPositionLog
+	accountNumber := "GB82WEST12345698765432"
+	customer := createTestCustomer(db, t)
+	createTestAccount(db, t, customer, accountNumber)
+	log := createTestFinancialPositionLog(accountNumber)
+	err = db.Create(log).Error
+	require.NoError(t, err, "Failed to create FinancialPositionLog")
+
+	// Create TransactionLineage
+	lineage := createTestTransactionLineage(log.ID)
+	err = db.Create(lineage).Error
+	require.NoError(t, err, "Failed to create TransactionLineage")
+	assert.NotEqual(t, uuid.Nil, lineage.ID, "TransactionLineage ID should be set")
+
+	// Verify outbox entry exists
+	var outbox AuditOutbox
+	err = db.Table("audit_outbox").
+		Where("record_id = ? AND table_name = ?", lineage.ID, "transaction_lineage").
+		First(&outbox).Error
+	require.NoError(t, err, "Audit outbox entry should exist")
+
+	// Verify outbox content
+	assert.Equal(t, "transaction_lineage", outbox.Table, "Table name should be 'transaction_lineage'")
+	assert.Equal(t, "INSERT", outbox.Operation, "Operation should be 'INSERT'")
+	assert.Equal(t, "pending", outbox.Status, "Status should be 'pending'")
+	assert.NotEmpty(t, outbox.NewValues, "NewValues should contain lineage data")
+	assert.Empty(t, outbox.OldValues, "OldValues should be empty for INSERT")
+}
+
+// TestTransactionLineage_AuditOutbox_CapturesUpdate verifies that UPDATE operations
+// capture both old and new values.
+func TestTransactionLineage_AuditOutbox_CapturesUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupPositionKeepingTestDB(t)
+	defer cleanup()
+
+	// Migrate TransactionLineage
+	err := db.AutoMigrate(&TransactionLineage{})
+	require.NoError(t, err, "Failed to migrate TransactionLineage")
+
+	// Create prerequisite Customer, Account, and FinancialPositionLog
+	accountNumber := "GB82WEST12345698765432"
+	customer := createTestCustomer(db, t)
+	createTestAccount(db, t, customer, accountNumber)
+	log := createTestFinancialPositionLog(accountNumber)
+	err = db.Create(log).Error
+	require.NoError(t, err, "Failed to create FinancialPositionLog")
+
+	// Create TransactionLineage
+	lineage := createTestTransactionLineage(log.ID)
+	err = db.Create(lineage).Error
+	require.NoError(t, err, "Failed to create TransactionLineage")
+
+	// Update the lineage
+	lineage.TransactionType = "REFUND"
+	err = db.Save(lineage).Error
+	require.NoError(t, err, "Failed to update TransactionLineage")
+
+	// Verify UPDATE audit
+	var updateAudit AuditOutbox
+	err = db.Table("audit_outbox").
+		Where("record_id = ? AND operation = ? AND table_name = ?", lineage.ID, "UPDATE", "transaction_lineage").
+		First(&updateAudit).Error
+	require.NoError(t, err, "UPDATE audit should exist")
+	assert.Equal(t, "UPDATE", updateAudit.Operation)
+	assert.NotEmpty(t, updateAudit.OldValues, "UPDATE should capture old values")
+	assert.NotEmpty(t, updateAudit.NewValues, "UPDATE should capture new values")
+	assert.Contains(t, updateAudit.OldValues, "PAYMENT", "Old values should contain original type")
+	assert.Contains(t, updateAudit.NewValues, "REFUND", "New values should contain updated type")
+}
+
+// TestTransactionLineage_AuditOutbox_CapturesDelete verifies that DELETE operations
+// capture the old values.
+func TestTransactionLineage_AuditOutbox_CapturesDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupPositionKeepingTestDB(t)
+	defer cleanup()
+
+	// Migrate TransactionLineage
+	err := db.AutoMigrate(&TransactionLineage{})
+	require.NoError(t, err, "Failed to migrate TransactionLineage")
+
+	// Create prerequisite Customer, Account, and FinancialPositionLog
+	accountNumber := "GB82WEST12345698765432"
+	customer := createTestCustomer(db, t)
+	createTestAccount(db, t, customer, accountNumber)
+	log := createTestFinancialPositionLog(accountNumber)
+	err = db.Create(log).Error
+	require.NoError(t, err, "Failed to create FinancialPositionLog")
+
+	// Create TransactionLineage
+	lineage := createTestTransactionLineage(log.ID)
+	err = db.Create(lineage).Error
+	require.NoError(t, err, "Failed to create TransactionLineage")
+
+	// Delete the lineage
+	err = db.Delete(lineage).Error
+	require.NoError(t, err, "Failed to delete TransactionLineage")
+
+	// Verify DELETE audit
+	var deleteAudit AuditOutbox
+	err = db.Table("audit_outbox").
+		Where("record_id = ? AND operation = ? AND table_name = ?", lineage.ID, "DELETE", "transaction_lineage").
+		First(&deleteAudit).Error
+	require.NoError(t, err, "DELETE audit should exist")
+	assert.Equal(t, "DELETE", deleteAudit.Operation)
+	assert.NotEmpty(t, deleteAudit.OldValues, "DELETE should capture old values")
+	assert.Empty(t, deleteAudit.NewValues, "DELETE should have empty new values")
+}
+
+// TestAuditTrailEntry_AuditOutbox_AtomicCommit verifies that audit outbox entry
+// is created atomically with the AuditTrailEntry insert.
+func TestAuditTrailEntry_AuditOutbox_AtomicCommit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupPositionKeepingTestDB(t)
+	defer cleanup()
+
+	// Migrate AuditTrailEntry
+	err := db.AutoMigrate(&AuditTrailEntry{})
+	require.NoError(t, err, "Failed to migrate AuditTrailEntry")
+
+	// Create prerequisite Customer, Account, and FinancialPositionLog
+	accountNumber := "GB82WEST12345698765432"
+	customer := createTestCustomer(db, t)
+	createTestAccount(db, t, customer, accountNumber)
+	log := createTestFinancialPositionLog(accountNumber)
+	err = db.Create(log).Error
+	require.NoError(t, err, "Failed to create FinancialPositionLog")
+
+	// Create AuditTrailEntry
+	entry := createTestAuditTrailEntry(log.ID)
+	err = db.Create(entry).Error
+	require.NoError(t, err, "Failed to create AuditTrailEntry")
+	assert.NotEqual(t, uuid.Nil, entry.ID, "AuditTrailEntry ID should be set")
+
+	// Verify outbox entry exists
+	var outbox AuditOutbox
+	err = db.Table("audit_outbox").
+		Where("record_id = ? AND table_name = ?", entry.ID, "audit_trail_entry").
+		First(&outbox).Error
+	require.NoError(t, err, "Audit outbox entry should exist")
+
+	// Verify outbox content
+	assert.Equal(t, "audit_trail_entry", outbox.Table, "Table name should be 'audit_trail_entry'")
+	assert.Equal(t, "INSERT", outbox.Operation, "Operation should be 'INSERT'")
+	assert.Equal(t, "pending", outbox.Status, "Status should be 'pending'")
+	assert.NotEmpty(t, outbox.NewValues, "NewValues should contain entry data")
+	assert.Empty(t, outbox.OldValues, "OldValues should be empty for INSERT")
+}
+
+// TestAuditTrailEntry_AuditOutbox_CapturesUpdate verifies that UPDATE operations
+// capture both old and new values.
+func TestAuditTrailEntry_AuditOutbox_CapturesUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupPositionKeepingTestDB(t)
+	defer cleanup()
+
+	// Migrate AuditTrailEntry
+	err := db.AutoMigrate(&AuditTrailEntry{})
+	require.NoError(t, err, "Failed to migrate AuditTrailEntry")
+
+	// Create prerequisite Customer, Account, and FinancialPositionLog
+	accountNumber := "GB82WEST12345698765432"
+	customer := createTestCustomer(db, t)
+	createTestAccount(db, t, customer, accountNumber)
+	log := createTestFinancialPositionLog(accountNumber)
+	err = db.Create(log).Error
+	require.NoError(t, err, "Failed to create FinancialPositionLog")
+
+	// Create AuditTrailEntry
+	entry := createTestAuditTrailEntry(log.ID)
+	err = db.Create(entry).Error
+	require.NoError(t, err, "Failed to create AuditTrailEntry")
+
+	// Update the entry
+	entry.Action = "UPDATED"
+	details := "Modified status to reconciled"
+	entry.Details = &details
+	err = db.Save(entry).Error
+	require.NoError(t, err, "Failed to update AuditTrailEntry")
+
+	// Verify UPDATE audit
+	var updateAudit AuditOutbox
+	err = db.Table("audit_outbox").
+		Where("record_id = ? AND operation = ? AND table_name = ?", entry.ID, "UPDATE", "audit_trail_entry").
+		First(&updateAudit).Error
+	require.NoError(t, err, "UPDATE audit should exist")
+	assert.Equal(t, "UPDATE", updateAudit.Operation)
+	assert.NotEmpty(t, updateAudit.OldValues, "UPDATE should capture old values")
+	assert.NotEmpty(t, updateAudit.NewValues, "UPDATE should capture new values")
+	assert.Contains(t, updateAudit.OldValues, "CREATED", "Old values should contain original action")
+	assert.Contains(t, updateAudit.NewValues, "UPDATED", "New values should contain updated action")
+}
+
+// TestAuditTrailEntry_AuditOutbox_CapturesDelete verifies that DELETE operations
+// capture the old values.
+func TestAuditTrailEntry_AuditOutbox_CapturesDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupPositionKeepingTestDB(t)
+	defer cleanup()
+
+	// Migrate AuditTrailEntry
+	err := db.AutoMigrate(&AuditTrailEntry{})
+	require.NoError(t, err, "Failed to migrate AuditTrailEntry")
+
+	// Create prerequisite Customer, Account, and FinancialPositionLog
+	accountNumber := "GB82WEST12345698765432"
+	customer := createTestCustomer(db, t)
+	createTestAccount(db, t, customer, accountNumber)
+	log := createTestFinancialPositionLog(accountNumber)
+	err = db.Create(log).Error
+	require.NoError(t, err, "Failed to create FinancialPositionLog")
+
+	// Create AuditTrailEntry
+	entry := createTestAuditTrailEntry(log.ID)
+	err = db.Create(entry).Error
+	require.NoError(t, err, "Failed to create AuditTrailEntry")
+
+	// Delete the entry
+	err = db.Delete(entry).Error
+	require.NoError(t, err, "Failed to delete AuditTrailEntry")
+
+	// Verify DELETE audit
+	var deleteAudit AuditOutbox
+	err = db.Table("audit_outbox").
+		Where("record_id = ? AND operation = ? AND table_name = ?", entry.ID, "DELETE", "audit_trail_entry").
+		First(&deleteAudit).Error
+	require.NoError(t, err, "DELETE audit should exist")
+	assert.Equal(t, "DELETE", deleteAudit.Operation)
+	assert.NotEmpty(t, deleteAudit.OldValues, "DELETE should capture old values")
+	assert.Empty(t, deleteAudit.NewValues, "DELETE should have empty new values")
+}
+
+// TestTransactionLineage_AuditOutbox_AllOperations verifies that all CRUD operations
+// are captured correctly for a TransactionLineage lifecycle.
+func TestTransactionLineage_AuditOutbox_AllOperations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupPositionKeepingTestDB(t)
+	defer cleanup()
+
+	// Migrate TransactionLineage
+	err := db.AutoMigrate(&TransactionLineage{})
+	require.NoError(t, err, "Failed to migrate TransactionLineage")
+
+	// Create prerequisite Customer, Account, and FinancialPositionLog
+	accountNumber := "GB82WEST12345698765432"
+	customer := createTestCustomer(db, t)
+	createTestAccount(db, t, customer, accountNumber)
+	log := createTestFinancialPositionLog(accountNumber)
+	err = db.Create(log).Error
+	require.NoError(t, err, "Failed to create FinancialPositionLog")
+
+	// INSERT
+	lineage := createTestTransactionLineage(log.ID)
+	err = db.Create(lineage).Error
+	require.NoError(t, err, "Failed to create TransactionLineage")
+
+	// UPDATE
+	lineage.TransactionType = "REFUND"
+	err = db.Save(lineage).Error
+	require.NoError(t, err, "Failed to update TransactionLineage")
+
+	// DELETE
+	err = db.Delete(lineage).Error
+	require.NoError(t, err, "Failed to delete TransactionLineage")
+
+	// Verify total audit count for this record
+	var totalCount int64
+	db.Table("audit_outbox").
+		Where("record_id = ? AND table_name = ?", lineage.ID, "transaction_lineage").
+		Count(&totalCount)
+	assert.Equal(t, int64(3), totalCount, "Should have exactly 3 audit records (INSERT, UPDATE, DELETE)")
+
+	// Verify each operation exists
+	var operations []string
+	db.Table("audit_outbox").
+		Where("record_id = ? AND table_name = ?", lineage.ID, "transaction_lineage").
+		Order("created_at ASC").
+		Pluck("operation", &operations)
+	assert.Equal(t, []string{"INSERT", "UPDATE", "DELETE"}, operations, "Operations should be in correct order")
+}
+
+// TestAuditTrailEntry_AuditOutbox_AllOperations verifies that all CRUD operations
+// are captured correctly for an AuditTrailEntry lifecycle.
+func TestAuditTrailEntry_AuditOutbox_AllOperations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupPositionKeepingTestDB(t)
+	defer cleanup()
+
+	// Migrate AuditTrailEntry
+	err := db.AutoMigrate(&AuditTrailEntry{})
+	require.NoError(t, err, "Failed to migrate AuditTrailEntry")
+
+	// Create prerequisite Customer, Account, and FinancialPositionLog
+	accountNumber := "GB82WEST12345698765432"
+	customer := createTestCustomer(db, t)
+	createTestAccount(db, t, customer, accountNumber)
+	log := createTestFinancialPositionLog(accountNumber)
+	err = db.Create(log).Error
+	require.NoError(t, err, "Failed to create FinancialPositionLog")
+
+	// INSERT
+	entry := createTestAuditTrailEntry(log.ID)
+	err = db.Create(entry).Error
+	require.NoError(t, err, "Failed to create AuditTrailEntry")
+
+	// UPDATE
+	entry.Action = "UPDATED"
+	err = db.Save(entry).Error
+	require.NoError(t, err, "Failed to update AuditTrailEntry")
+
+	// DELETE
+	err = db.Delete(entry).Error
+	require.NoError(t, err, "Failed to delete AuditTrailEntry")
+
+	// Verify total audit count for this record
+	var totalCount int64
+	db.Table("audit_outbox").
+		Where("record_id = ? AND table_name = ?", entry.ID, "audit_trail_entry").
+		Count(&totalCount)
+	assert.Equal(t, int64(3), totalCount, "Should have exactly 3 audit records (INSERT, UPDATE, DELETE)")
+
+	// Verify each operation exists
+	var operations []string
+	db.Table("audit_outbox").
+		Where("record_id = ? AND table_name = ?", entry.ID, "audit_trail_entry").
+		Order("created_at ASC").
+		Pluck("operation", &operations)
+	assert.Equal(t, []string{"INSERT", "UPDATE", "DELETE"}, operations, "Operations should be in correct order")
+}


### PR DESCRIPTION
## Summary

- Add GORM audit hooks to TransactionLineage and AuditTrailEntry entities for complete audit coverage
- Initialize Kafka audit publisher in position-keeping service container
- Rename AuditTrailEntry.AuditID field to AuditEntryID to avoid method name collision

## Task Master Reference

- **Tag**: 75-async-audit
- **Task ID**: 4

## Changes Made

### 1. GORM Audit Hooks (`shared/domain/models/financial_position_log.go`)
- Added `Auditable` interface implementation to `TransactionLineage` and `AuditTrailEntry`
- Added GORM hooks: `AfterCreate`, `BeforeUpdate`, `AfterUpdate`, `AfterDelete`
- Renamed `AuditTrailEntry.AuditID` → `AuditEntryID` to avoid collision with `AuditID()` method

### 2. Audit Publisher Integration (`services/position-keeping/app/container.go`)
- Added `initializeAuditPublisher()` to set up Kafka publisher with schema name
- Configured proper shutdown handling in `Close()` method
- Publisher uses shared audit platform with outbox fallback

### 3. Integration Tests (`shared/domain/models/financial_position_log_audit_test.go`)
- Added 8 new integration tests for TransactionLineage and AuditTrailEntry audit hooks
- Tests cover: INSERT, UPDATE, DELETE operations and full lifecycle

## Test Plan

- [x] All existing unit tests pass (`go test -short ./...`)
- [x] All existing integration tests pass
- [x] New audit hook integration tests pass with testcontainers
- [x] Build succeeds across all packages
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)