### PR TITLE
fix: address second round of PR review feedback for double-entry bookkeeping

### DIFF
--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/clients"
+	"github.com/meridianhub/meridian/services/current-account/config"
 	"github.com/meridianhub/meridian/services/current-account/service"
 	"github.com/meridianhub/meridian/shared/pkg/interceptors"
 	"github.com/meridianhub/meridian/shared/platform/auth"
@@ -362,6 +363,22 @@ func createServiceWithClients(
 	logger *slog.Logger,
 	tracer *observability.Tracer,
 ) (*service.Service, *serviceClients, error) {
+	// Load account configuration for clearing accounts
+	// This is optional - if not configured, deposits will use single-entry mode (backward compatible)
+	var accountConfig *service.AccountConfig
+	cfg, err := config.LoadAccountConfig()
+	if err != nil {
+		// Log warning but continue - double-entry is optional for backward compatibility
+		logger.Warn("account configuration not loaded, double-entry bookkeeping disabled",
+			"error", err)
+	} else {
+		accountConfig = &service.AccountConfig{
+			DepositClearingAccountID: cfg.DepositClearingAccountID,
+		}
+		logger.Info("account configuration loaded",
+			"deposit_clearing_account_id", cfg.DepositClearingAccountID)
+	}
+
 	// Create Position Keeping client with DNS-based load balancing
 	posKeepingGRPCClient, err := clients.NewPositionKeepingClient(&clients.PositionKeepingClientConfig{
 		ServiceName: "position-keeping",
@@ -429,6 +446,7 @@ func createServiceWithClients(
 		resilientPosKeepingClient,
 		resilientFinAcctClient,
 		resilientPartyClient,
+		accountConfig,
 		logger,
 		tracer,
 	)

--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -365,18 +365,15 @@ func createServiceWithClients(
 ) (*service.Service, *serviceClients, error) {
 	// Load account configuration for clearing accounts
 	// This is optional - if not configured, deposits will use single-entry mode (backward compatible)
-	var accountConfig *service.AccountConfig
-	cfg, err := config.LoadAccountConfig()
-	if err != nil {
+	accountConfig, cfgErr := config.LoadAccountConfig()
+	if cfgErr != nil {
 		// Log warning but continue - double-entry is optional for backward compatibility
 		logger.Warn("account configuration not loaded, double-entry bookkeeping disabled",
-			"error", err)
+			"error", cfgErr)
+		accountConfig = nil // Explicit nil for clarity
 	} else {
-		accountConfig = &service.AccountConfig{
-			DepositClearingAccountID: cfg.DepositClearingAccountID,
-		}
 		logger.Info("account configuration loaded",
-			"deposit_clearing_account_id", cfg.DepositClearingAccountID)
+			"deposit_clearing_account_id", accountConfig.DepositClearingAccountID)
 	}
 
 	// Create Position Keeping client with DNS-based load balancing

--- a/services/current-account/observability/metrics.go
+++ b/services/current-account/observability/metrics.go
@@ -61,6 +61,16 @@ var (
 		[]string{"operation", "step"},
 	)
 
+	// Inline compensation metrics - for compensations that happen within a step
+	// due to saga pattern limitations (step fails after side effects)
+	inlineCompensationFailuresTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "current_account_inline_compensation_failures_total",
+			Help: "Total number of inline compensation failures (requires manual intervention)",
+		},
+		[]string{"operation", "leg"},
+	)
+
 	sagaDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "current_account_saga_duration_seconds",
@@ -118,6 +128,13 @@ func RecordSagaFailure(operation, failedStep string) {
 // RecordSagaCompensation records a saga compensation
 func RecordSagaCompensation(operation, step string) {
 	sagaCompensationsTotal.WithLabelValues(operation, step).Inc()
+}
+
+// RecordInlineCompensationFailure records an inline compensation failure.
+// These failures indicate that a compensating entry could not be created,
+// requiring manual intervention to restore ledger integrity.
+func RecordInlineCompensationFailure(operation, leg string) {
+	inlineCompensationFailuresTotal.WithLabelValues(operation, leg).Inc()
 }
 
 // RecordSagaDuration records the duration of a saga execution

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -648,6 +648,63 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 			)
 			if err != nil {
 				caobservability.RecordExternalServiceError("financial_accounting", "update_booking_log")
+
+				// CRITICAL: If we fail here, postings have already been made but step won't be
+				// considered "complete" by saga, so saga compensation won't run. We must
+				// create compensating entries inline before returning the error.
+				s.logger.Warn("UpdateFinancialBookingLog failed, creating inline compensating entries",
+					"debit_posted", debitPosted,
+					"credit_posted", creditPosted,
+					"error", err)
+
+				// Compensate credit leg: Create DEBIT to customer account (if credit was posted)
+				if creditPosted {
+					compCreditID := fmt.Sprintf("COMP-%s-credit", transactionID)
+					_, compErr := s.finAcctClient.CaptureLedgerPosting(stepCtx,
+						&financialaccountingv1.CaptureLedgerPostingRequest{
+							FinancialBookingLogId: bookingLogID,
+							PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_DEBIT,
+							PostingAmount:         moneyAmt.Amount,
+							AccountId:             account.AccountID,
+							ValueDate:             timestamppb.Now(),
+							IdempotencyKey:        &commonpb.IdempotencyKey{Key: compCreditID},
+						},
+					)
+					if compErr != nil {
+						s.logger.Error("failed to compensate credit posting inline",
+							"error", compErr)
+					}
+				}
+
+				// Compensate debit leg: Create CREDIT to clearing account (if debit was posted)
+				if debitPosted {
+					compDebitID := fmt.Sprintf("COMP-%s-debit", transactionID)
+					_, compErr := s.finAcctClient.CaptureLedgerPosting(stepCtx,
+						&financialaccountingv1.CaptureLedgerPostingRequest{
+							FinancialBookingLogId: bookingLogID,
+							PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_CREDIT,
+							PostingAmount:         moneyAmt.Amount,
+							AccountId:             clearingAccountID,
+							ValueDate:             timestamppb.Now(),
+							IdempotencyKey:        &commonpb.IdempotencyKey{Key: compDebitID},
+						},
+					)
+					if compErr != nil {
+						s.logger.Error("failed to compensate debit posting inline",
+							"error", compErr)
+					}
+				}
+
+				// Try to transition BookingLog to CANCELLED
+				if debitPosted || creditPosted {
+					_, _ = s.finAcctClient.UpdateFinancialBookingLog(stepCtx,
+						&financialaccountingv1.UpdateFinancialBookingLogRequest{
+							Id:     bookingLogID,
+							Status: commonpb.TransactionStatus_TRANSACTION_STATUS_CANCELLED,
+						},
+					)
+				}
+
 				return fmt.Errorf("failed to transition booking log to POSTED: %w", err)
 			}
 
@@ -705,7 +762,8 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 			}
 
 			// Compensate debit leg: Create CREDIT to clearing account (if debit was posted)
-			if debitPosted && clearingAccountID != "" {
+			// Note: debitPosted can only be true if clearingAccountID was non-empty
+			if debitPosted {
 				compDebitTransactionID := fmt.Sprintf("COMP-%s-debit", transactionID)
 				_, err := s.finAcctClient.CaptureLedgerPosting(stepCtx,
 					&financialaccountingv1.CaptureLedgerPostingRequest{
@@ -726,6 +784,25 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 				s.logger.Info("compensated debit posting",
 					"debit_posting_id", debitPostingID,
 					"clearing_account_id", clearingAccountID)
+			}
+
+			// Transition BookingLog to CANCELLED for clean audit trail
+			if debitPosted || creditPosted {
+				_, err := s.finAcctClient.UpdateFinancialBookingLog(stepCtx,
+					&financialaccountingv1.UpdateFinancialBookingLogRequest{
+						Id:     bookingLogID,
+						Status: commonpb.TransactionStatus_TRANSACTION_STATUS_CANCELLED,
+					},
+				)
+				if err != nil {
+					// Log warning but don't fail compensation - the reversal postings are more important
+					s.logger.Warn("failed to transition BookingLog to CANCELLED during compensation",
+						"booking_log_id", bookingLogID,
+						"error", err)
+				} else {
+					s.logger.Info("BookingLog transitioned to CANCELLED",
+						"booking_log_id", bookingLogID)
+				}
 			}
 
 			// Record compensation

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -19,6 +19,7 @@ import (
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/clients"
+	"github.com/meridianhub/meridian/services/current-account/config"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
 	"github.com/meridianhub/meridian/shared/platform/observability"
@@ -56,16 +57,9 @@ type Service struct {
 	posKeepingClient clients.PositionKeepingClient
 	finAcctClient    clients.FinancialAccountingClient
 	partyClient      clients.PartyClient
-	accountConfig    *AccountConfig
+	accountConfig    *config.AccountConfig
 	logger           *slog.Logger
 	tracer           *observability.Tracer
-}
-
-// AccountConfig holds configuration for internal accounts used in transaction routing.
-// This is used for deposits to route the debit side to the clearing account.
-type AccountConfig struct {
-	// DepositClearingAccountID is the account ID for deposit clearing (debit side).
-	DepositClearingAccountID string
 }
 
 // Config contains configuration for creating a new Service with external clients
@@ -101,7 +95,7 @@ func NewServiceWithExistingClients(
 	posKeepingClient clients.PositionKeepingClient,
 	finAcctClient clients.FinancialAccountingClient,
 	partyClient clients.PartyClient,
-	accountConfig *AccountConfig,
+	accountConfig *config.AccountConfig,
 	logger *slog.Logger,
 	tracer *observability.Tracer,
 ) (*Service, error) {
@@ -533,6 +527,11 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 	// Step 2: Post to ledger in FinancialAccounting service with double-entry bookkeeping
 	// Creates a BookingLog, posts DEBIT to clearing account, posts CREDIT to customer account,
 	// then transitions BookingLog to POSTED (triggering balance validation).
+	// These variables are intentionally declared outside the saga step closures to allow
+	// data sharing between the action and compensation functions. When a closure captures
+	// a variable (e.g., bookingLogID), both the action and compensation closures reference
+	// the same memory location, allowing the action to set values that the compensation
+	// can later read if rollback is needed.
 	var debitPostingID string
 	var creditPostingID string
 	var bookingLogID string
@@ -627,6 +626,55 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 			)
 			if err != nil {
 				caobservability.RecordExternalServiceError("financial_accounting", "capture_credit_posting")
+
+				// CRITICAL: If debit was posted but credit fails, we must compensate the debit inline.
+				// The saga won't consider this step complete, so saga compensation won't run.
+				if debitPosted {
+					s.logger.Warn("credit posting failed after debit succeeded, creating inline compensation",
+						"clearing_account_id", clearingAccountID,
+						"transaction_id", transactionID,
+						"error", err)
+
+					// Compensate debit: Create CREDIT to clearing account
+					compDebitID := fmt.Sprintf("COMP-%s-debit", transactionID)
+					_, compErr := s.finAcctClient.CaptureLedgerPosting(stepCtx,
+						&financialaccountingv1.CaptureLedgerPostingRequest{
+							FinancialBookingLogId: bookingLogID,
+							PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_CREDIT,
+							PostingAmount:         moneyAmt.Amount,
+							AccountId:             clearingAccountID,
+							ValueDate:             timestamppb.Now(),
+							IdempotencyKey:        &commonpb.IdempotencyKey{Key: compDebitID},
+						},
+					)
+					if compErr != nil {
+						s.logger.Error("failed to compensate debit posting after credit failure",
+							"booking_log_id", bookingLogID,
+							"clearing_account_id", clearingAccountID,
+							"transaction_id", transactionID,
+							"error", compErr)
+						caobservability.RecordInlineCompensationFailure("deposit", "debit")
+					}
+
+					// Try to transition BookingLog to CANCELLED
+					_, cancelErr := s.finAcctClient.UpdateFinancialBookingLog(stepCtx,
+						&financialaccountingv1.UpdateFinancialBookingLogRequest{
+							Id:     bookingLogID,
+							Status: commonpb.TransactionStatus_TRANSACTION_STATUS_CANCELLED,
+						},
+					)
+					if cancelErr != nil {
+						s.logger.Warn("failed to transition booking log to CANCELLED after credit failure",
+							"booking_log_id", bookingLogID,
+							"transaction_id", transactionID,
+							"error", cancelErr)
+					} else {
+						s.logger.Info("booking log transitioned to CANCELLED after credit failure",
+							"booking_log_id", bookingLogID,
+							"transaction_id", transactionID)
+					}
+				}
+
 				return fmt.Errorf("failed to post credit to customer account: %w", err)
 			}
 			creditPostingID = creditResp.LedgerPosting.Id
@@ -672,7 +720,11 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 					)
 					if compErr != nil {
 						s.logger.Error("failed to compensate credit posting inline",
+							"booking_log_id", bookingLogID,
+							"account_id", account.AccountID,
+							"transaction_id", transactionID,
 							"error", compErr)
+						caobservability.RecordInlineCompensationFailure("deposit", "credit")
 					}
 				}
 
@@ -691,18 +743,33 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 					)
 					if compErr != nil {
 						s.logger.Error("failed to compensate debit posting inline",
+							"booking_log_id", bookingLogID,
+							"clearing_account_id", clearingAccountID,
+							"transaction_id", transactionID,
 							"error", compErr)
+						caobservability.RecordInlineCompensationFailure("deposit", "debit")
 					}
 				}
 
 				// Try to transition BookingLog to CANCELLED
 				if debitPosted || creditPosted {
-					_, _ = s.finAcctClient.UpdateFinancialBookingLog(stepCtx,
+					_, cancelErr := s.finAcctClient.UpdateFinancialBookingLog(stepCtx,
 						&financialaccountingv1.UpdateFinancialBookingLogRequest{
 							Id:     bookingLogID,
 							Status: commonpb.TransactionStatus_TRANSACTION_STATUS_CANCELLED,
 						},
 					)
+					if cancelErr != nil {
+						// Log but don't fail - the compensating entries are more important
+						s.logger.Warn("failed to transition booking log to CANCELLED during inline compensation",
+							"booking_log_id", bookingLogID,
+							"transaction_id", transactionID,
+							"error", cancelErr)
+					} else {
+						s.logger.Info("booking log transitioned to CANCELLED during inline compensation",
+							"booking_log_id", bookingLogID,
+							"transaction_id", transactionID)
+					}
 				}
 
 				return fmt.Errorf("failed to transition booking log to POSTED: %w", err)

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -56,8 +56,16 @@ type Service struct {
 	posKeepingClient clients.PositionKeepingClient
 	finAcctClient    clients.FinancialAccountingClient
 	partyClient      clients.PartyClient
+	accountConfig    *AccountConfig
 	logger           *slog.Logger
 	tracer           *observability.Tracer
+}
+
+// AccountConfig holds configuration for internal accounts used in transaction routing.
+// This is used for deposits to route the debit side to the clearing account.
+type AccountConfig struct {
+	// DepositClearingAccountID is the account ID for deposit clearing (debit side).
+	DepositClearingAccountID string
 }
 
 // Config contains configuration for creating a new Service with external clients
@@ -93,6 +101,7 @@ func NewServiceWithExistingClients(
 	posKeepingClient clients.PositionKeepingClient,
 	finAcctClient clients.FinancialAccountingClient,
 	partyClient clients.PartyClient,
+	accountConfig *AccountConfig,
 	logger *slog.Logger,
 	tracer *observability.Tracer,
 ) (*Service, error) {
@@ -111,6 +120,7 @@ func NewServiceWithExistingClients(
 		posKeepingClient: posKeepingClient,
 		finAcctClient:    finAcctClient,
 		partyClient:      partyClient,
+		accountConfig:    accountConfig,
 		logger:           logger,
 		tracer:           tracer,
 	}, nil
@@ -520,14 +530,27 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 		},
 	)
 
-	// Step 2: Post to ledger in FinancialAccounting service
-	var ledgerPostingID string
+	// Step 2: Post to ledger in FinancialAccounting service with double-entry bookkeeping
+	// Creates a BookingLog, posts DEBIT to clearing account, posts CREDIT to customer account,
+	// then transitions BookingLog to POSTED (triggering balance validation).
+	var debitPostingID string
+	var creditPostingID string
 	var bookingLogID string
+	var debitPosted bool  // Track whether debit leg was successfully posted
+	var creditPosted bool // Track whether credit leg was successfully posted
+
+	// Get clearing account ID from config (required for double-entry bookkeeping)
+	var clearingAccountID string
+	if s.accountConfig != nil {
+		clearingAccountID = s.accountConfig.DepositClearingAccountID
+	}
+
 	saga.AddStep("post_ledger",
-		// Action: Create booking log and ledger posting
+		// Action: Create booking log and dual ledger postings (debit clearing, credit customer)
 		func(stepCtx context.Context) error {
 			s.logger.Info("executing post_ledger step",
 				"account_id", account.AccountID,
+				"clearing_account_id", clearingAccountID,
 				"transaction_id", transactionID)
 
 			// Propagate correlation ID
@@ -536,7 +559,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 			// Convert MoneyAmount to google.type.Money for the request
 			moneyAmt := toMoneyAmount(amount)
 
-			// First, initiate a financial booking log
+			// Step 2a: Initiate a financial booking log
 			bookingLogResp, err := s.finAcctClient.InitiateFinancialBookingLog(stepCtx,
 				&financialaccountingv1.InitiateFinancialBookingLogRequest{
 					FinancialAccountType:    commonpb.AccountType_ACCOUNT_TYPE_CURRENT,
@@ -559,8 +582,38 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 				"booking_log_id", bookingLogID,
 				"transaction_id", transactionID)
 
-			// Then capture the ledger posting with the booking log ID
-			resp, err := s.finAcctClient.CaptureLedgerPosting(stepCtx,
+			// Step 2b: Post DEBIT to clearing account (funds received from external source)
+			// This represents the bank receiving funds that will be credited to the customer.
+			// Only post debit leg if clearing account is configured (double-entry mode).
+			if clearingAccountID != "" {
+				debitResp, err := s.finAcctClient.CaptureLedgerPosting(stepCtx,
+					&financialaccountingv1.CaptureLedgerPostingRequest{
+						FinancialBookingLogId: bookingLogID,
+						PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_DEBIT,
+						PostingAmount:         moneyAmt.Amount,
+						AccountId:             clearingAccountID,
+						ValueDate:             timestamppb.Now(),
+						IdempotencyKey: &commonpb.IdempotencyKey{
+							Key: fmt.Sprintf("%s-debit", transactionID),
+						},
+					},
+				)
+				if err != nil {
+					caobservability.RecordExternalServiceError("financial_accounting", "capture_debit_posting")
+					return fmt.Errorf("failed to post debit to clearing account: %w", err)
+				}
+				debitPostingID = debitResp.LedgerPosting.Id
+				debitPosted = true
+
+				s.logger.Info("debit posting to clearing account completed",
+					"debit_posting_id", debitPostingID,
+					"clearing_account_id", clearingAccountID,
+					"booking_log_id", bookingLogID,
+					"transaction_id", transactionID)
+			}
+
+			// Step 2c: Post CREDIT to customer account (customer balance increased)
+			creditResp, err := s.finAcctClient.CaptureLedgerPosting(stepCtx,
 				&financialaccountingv1.CaptureLedgerPostingRequest{
 					FinancialBookingLogId: bookingLogID,
 					PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_CREDIT,
@@ -568,28 +621,49 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 					AccountId:             account.AccountID,
 					ValueDate:             timestamppb.Now(),
 					IdempotencyKey: &commonpb.IdempotencyKey{
-						Key: transactionID,
+						Key: fmt.Sprintf("%s-credit", transactionID),
 					},
 				},
 			)
 			if err != nil {
-				caobservability.RecordExternalServiceError("financial_accounting", "capture_posting")
-				return fmt.Errorf("failed to post to ledger: %w", err)
+				caobservability.RecordExternalServiceError("financial_accounting", "capture_credit_posting")
+				return fmt.Errorf("failed to post credit to customer account: %w", err)
+			}
+			creditPostingID = creditResp.LedgerPosting.Id
+			creditPosted = true
+
+			s.logger.Info("credit posting to customer account completed",
+				"credit_posting_id", creditPostingID,
+				"account_id", account.AccountID,
+				"booking_log_id", bookingLogID,
+				"transaction_id", transactionID)
+
+			// Step 2d: Transition BookingLog to POSTED (triggers balance validation in FinancialAccounting)
+			// This validates that debit amount == credit amount for the booking log.
+			_, err = s.finAcctClient.UpdateFinancialBookingLog(stepCtx,
+				&financialaccountingv1.UpdateFinancialBookingLogRequest{
+					Id:     bookingLogID,
+					Status: commonpb.TransactionStatus_TRANSACTION_STATUS_POSTED,
+				},
+			)
+			if err != nil {
+				caobservability.RecordExternalServiceError("financial_accounting", "update_booking_log")
+				return fmt.Errorf("failed to transition booking log to POSTED: %w", err)
 			}
 
-			ledgerPostingID = resp.LedgerPosting.Id
-
 			s.logger.Info("post_ledger step completed",
-				"ledger_posting_id", ledgerPostingID,
+				"debit_posting_id", debitPostingID,
+				"credit_posting_id", creditPostingID,
 				"booking_log_id", bookingLogID,
 				"transaction_id", transactionID)
 
 			return nil
 		},
-		// Compensate: Reverse ledger posting
+		// Compensate: Reverse both ledger postings
 		func(stepCtx context.Context) error {
 			s.logger.Info("compensating post_ledger step",
-				"ledger_posting_id", ledgerPostingID,
+				"debit_posting_id", debitPostingID,
+				"credit_posting_id", creditPostingID,
 				"booking_log_id", bookingLogID,
 				"transaction_id", transactionID)
 
@@ -604,30 +678,62 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 			// Convert MoneyAmount to google.type.Money for the request
 			moneyAmt := toMoneyAmount(amount)
 
-			// Create compensating ledger entry (debit to reverse the credit)
-			compTransactionID := fmt.Sprintf("COMP-%s", transactionID)
-			_, err := s.finAcctClient.CaptureLedgerPosting(stepCtx,
-				&financialaccountingv1.CaptureLedgerPostingRequest{
-					FinancialBookingLogId: bookingLogID,
-					PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_DEBIT,
-					PostingAmount:         moneyAmt.Amount,
-					AccountId:             account.AccountID,
-					ValueDate:             timestamppb.Now(),
-					IdempotencyKey: &commonpb.IdempotencyKey{
-						Key: compTransactionID,
+			// Compensation reverses in opposite order: first reverse credit, then debit
+
+			// Compensate credit leg: Create DEBIT to customer account (if credit was posted)
+			if creditPosted {
+				compCreditTransactionID := fmt.Sprintf("COMP-%s-credit", transactionID)
+				_, err := s.finAcctClient.CaptureLedgerPosting(stepCtx,
+					&financialaccountingv1.CaptureLedgerPostingRequest{
+						FinancialBookingLogId: bookingLogID,
+						PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_DEBIT,
+						PostingAmount:         moneyAmt.Amount,
+						AccountId:             account.AccountID,
+						ValueDate:             timestamppb.Now(),
+						IdempotencyKey: &commonpb.IdempotencyKey{
+							Key: compCreditTransactionID,
+						},
 					},
-				},
-			)
-			if err != nil {
-				caobservability.RecordExternalServiceError("financial_accounting", "compensate_posting")
-				return fmt.Errorf("failed to compensate ledger posting: %w", err)
+				)
+				if err != nil {
+					caobservability.RecordExternalServiceError("financial_accounting", "compensate_credit_posting")
+					return fmt.Errorf("failed to compensate credit posting: %w", err)
+				}
+				s.logger.Info("compensated credit posting",
+					"credit_posting_id", creditPostingID,
+					"account_id", account.AccountID)
+			}
+
+			// Compensate debit leg: Create CREDIT to clearing account (if debit was posted)
+			if debitPosted && clearingAccountID != "" {
+				compDebitTransactionID := fmt.Sprintf("COMP-%s-debit", transactionID)
+				_, err := s.finAcctClient.CaptureLedgerPosting(stepCtx,
+					&financialaccountingv1.CaptureLedgerPostingRequest{
+						FinancialBookingLogId: bookingLogID,
+						PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_CREDIT,
+						PostingAmount:         moneyAmt.Amount,
+						AccountId:             clearingAccountID,
+						ValueDate:             timestamppb.Now(),
+						IdempotencyKey: &commonpb.IdempotencyKey{
+							Key: compDebitTransactionID,
+						},
+					},
+				)
+				if err != nil {
+					caobservability.RecordExternalServiceError("financial_accounting", "compensate_debit_posting")
+					return fmt.Errorf("failed to compensate debit posting: %w", err)
+				}
+				s.logger.Info("compensated debit posting",
+					"debit_posting_id", debitPostingID,
+					"clearing_account_id", clearingAccountID)
 			}
 
 			// Record compensation
 			caobservability.RecordSagaCompensation("deposit", "post_ledger")
 
 			s.logger.Info("post_ledger compensation completed",
-				"ledger_posting_id", ledgerPostingID,
+				"debit_posting_id", debitPostingID,
+				"credit_posting_id", creditPostingID,
 				"booking_log_id", bookingLogID)
 
 			return nil

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -148,6 +148,8 @@ type mockFinancialAccountingClient struct {
 	debitCaptureCalls  int // Track debit postings specifically
 	creditCaptureCalls int // Track credit postings specifically
 	failOnCapture      bool
+	failOnDebitCapture bool // Fail specifically on debit postings
+	failOnUpdate       bool // Fail on UpdateFinancialBookingLog
 	failureError       error
 	captureResponses   []*financialaccountingv1.CaptureLedgerPostingResponse
 	compensateCalls    int
@@ -173,10 +175,18 @@ func (m *mockFinancialAccountingClient) InitiateFinancialBookingLog(_ context.Co
 
 func (m *mockFinancialAccountingClient) UpdateFinancialBookingLog(_ context.Context, req *financialaccountingv1.UpdateFinancialBookingLogRequest) (*financialaccountingv1.UpdateFinancialBookingLogResponse, error) {
 	m.updateCalls++
+
+	if m.failOnUpdate {
+		if m.failureError != nil {
+			return nil, m.failureError
+		}
+		return nil, errFinancialAccountingUnavailable
+	}
+
 	return &financialaccountingv1.UpdateFinancialBookingLogResponse{
 		FinancialBookingLog: &financialaccountingv1.FinancialBookingLog{
 			Id:        req.Id,
-			Status:    commonpb.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			Status:    req.Status,
 			CreatedAt: timestamppb.Now(),
 			UpdatedAt: timestamppb.Now(),
 		},
@@ -204,6 +214,14 @@ func (m *mockFinancialAccountingClient) CaptureLedgerPosting(_ context.Context, 
 	m.captureCalls++
 	m.lastCapturedReq = req
 
+	// Check for debit-specific failure before tracking
+	if m.failOnDebitCapture && req.PostingDirection == commonpb.PostingDirection_POSTING_DIRECTION_DEBIT {
+		if m.failureError != nil {
+			return nil, m.failureError
+		}
+		return nil, errFinancialAccountingUnavailable
+	}
+
 	if m.failOnCapture {
 		if m.failureError != nil {
 			return nil, m.failureError
@@ -211,7 +229,7 @@ func (m *mockFinancialAccountingClient) CaptureLedgerPosting(_ context.Context, 
 		return nil, errFinancialAccountingUnavailable
 	}
 
-	// Track debit vs credit postings separately
+	// Track debit vs credit postings separately (only on success)
 	if req.PostingDirection == commonpb.PostingDirection_POSTING_DIRECTION_DEBIT {
 		m.debitCaptureCalls++
 		// Only count as compensation if this is a reversal (idempotency key contains "COMP")
@@ -900,6 +918,9 @@ func TestExecuteDeposit_DoubleEntry_SameBookingLogForBothPostings(t *testing.T) 
 
 // TestExecuteDeposit_DoubleEntry_CompensatesOnFailure verifies that saga compensation
 // reverses both postings when a failure occurs after they're created.
+//
+// Scenario: UpdateFinancialBookingLog fails after both debit and credit postings succeed.
+// Expected: Compensation posts reversal entries (DEBIT to customer, CREDIT to clearing).
 func TestExecuteDeposit_DoubleEntry_CompensatesOnFailure(t *testing.T) {
 	// Setup
 	db, ctx, cleanup := setupIntegrationTestDB(t)
@@ -911,47 +932,113 @@ func TestExecuteDeposit_DoubleEntry_CompensatesOnFailure(t *testing.T) {
 
 	mockPosKeeping := &mockPositionKeepingClient{}
 
-	// Create a mock that fails on the 3rd capture call (after debit and credit, during update)
-	// Actually, let's fail on UpdateFinancialBookingLog to trigger compensation after both postings
-	captureCallCount := 0
-	updateCallCount := 0
-
-	// We need a custom mock that fails on update
-	type failingUpdateMock struct {
-		mockFinancialAccountingClient
-		updateFailCount int
+	// Create mock that fails on UpdateFinancialBookingLog (after both postings succeed)
+	mockFinAcct := &mockFinancialAccountingClient{
+		failOnUpdate: true,
+		failureError: errFinancialAccountingUnavailable,
 	}
-
-	failMock := &failingUpdateMock{
-		mockFinancialAccountingClient: mockFinancialAccountingClient{},
-		updateFailCount:               0,
-	}
-
-	// Override UpdateFinancialBookingLog to fail
-	// Since we can't easily override methods, let's use a different approach
-	// Instead, we'll create a test that verifies compensation logic is correct
-
-	// For this test, let's just verify the compensation counters work correctly
-	// when the service handles a failure after postings succeed
 
 	svc := &Service{
 		repo:             repo,
 		posKeepingClient: mockPosKeeping,
-		finAcctClient:    &failMock.mockFinancialAccountingClient,
+		finAcctClient:    mockFinAcct,
 		accountConfig: &AccountConfig{
 			DepositClearingAccountID: "CLEARING-003",
 		},
 		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
 	}
 
-	_ = svc
-	_ = captureCallCount
-	_ = updateCallCount
-	_ = originalBalance
+	// Execute deposit
+	req := createTestDepositRequest("ACC-DE-003", 100, 0) // £100.00
+	resp, err := svc.ExecuteDeposit(ctx, req)
 
-	// This test would require a more sophisticated mock that fails at a specific point
-	// For now, let's just verify the basic compensation path works
-	t.Log("Compensation test setup validated")
+	// Verify failure
+	require.Error(t, err, "Deposit should fail due to UpdateFinancialBookingLog failure")
+	assert.Nil(t, resp, "Response should be nil on failure")
+
+	// Verify error mentions the failed step
+	st, ok := status.FromError(err)
+	require.True(t, ok, "Error should be gRPC status error")
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "post_ledger", "Error should mention failed step")
+
+	// Verify postings were attempted (2 original postings + 2 compensation postings)
+	// Original: 1 DEBIT to clearing + 1 CREDIT to customer = 2
+	// Compensation: 1 DEBIT to customer (reverses credit) + 1 CREDIT to clearing (reverses debit) = 2
+	// Mock counts by direction: 2 DEBIT total (original + compensation), 2 CREDIT total (original + compensation)
+	assert.Equal(t, 2, mockFinAcct.debitCaptureCalls, "Should have 2 debit postings (1 original + 1 compensation)")
+	assert.Equal(t, 2, mockFinAcct.creditCaptureCalls, "Should have 2 credit postings (1 original + 1 compensation)")
+	assert.Equal(t, 2, mockFinAcct.compensateCalls, "Should have 2 compensation postings (COMP prefix)")
+	assert.Equal(t, 4, mockFinAcct.captureCalls, "Should have 4 total capture calls (2 original + 2 compensation)")
+
+	// Verify account balance unchanged (compensation should have reversed)
+	updatedAccount, err := repo.FindByID(ctx, "ACC-DE-003")
+	require.NoError(t, err)
+	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
+		"Account balance should remain unchanged after compensation")
+}
+
+// TestExecuteDeposit_DoubleEntry_DebitPostingFailure verifies behavior when the debit
+// posting to the clearing account fails.
+//
+// Expected: Credit posting is NOT attempted, no compensation needed.
+func TestExecuteDeposit_DoubleEntry_DebitPostingFailure(t *testing.T) {
+	// Setup
+	db, ctx, cleanup := setupIntegrationTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	account := createTestAccount(t, ctx, repo, "ACC-DE-005")
+	originalBalance := account.Balance.AmountCents()
+
+	mockPosKeeping := &mockPositionKeepingClient{}
+
+	// Create mock that fails specifically on debit postings
+	mockFinAcct := &mockFinancialAccountingClient{
+		failOnDebitCapture: true,
+		failureError:       errFinancialAccountingUnavailable,
+	}
+
+	svc := &Service{
+		repo:             repo,
+		posKeepingClient: mockPosKeeping,
+		finAcctClient:    mockFinAcct,
+		accountConfig: &AccountConfig{
+			DepositClearingAccountID: "CLEARING-005",
+		},
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	// Execute deposit
+	req := createTestDepositRequest("ACC-DE-005", 100, 0) // £100.00
+	resp, err := svc.ExecuteDeposit(ctx, req)
+
+	// Verify failure
+	require.Error(t, err, "Deposit should fail due to debit posting failure")
+	assert.Nil(t, resp, "Response should be nil on failure")
+
+	// Verify error mentions the failed step
+	st, ok := status.FromError(err)
+	require.True(t, ok, "Error should be gRPC status error")
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "post_ledger", "Error should mention failed step")
+	assert.Contains(t, st.Message(), "debit", "Error should mention debit failure")
+
+	// Verify only debit posting was attempted (and failed)
+	assert.Equal(t, 1, mockFinAcct.captureCalls, "Should have only 1 capture call (failed debit)")
+	assert.Equal(t, 0, mockFinAcct.debitCaptureCalls, "Should have 0 successful debit postings")
+	assert.Equal(t, 0, mockFinAcct.creditCaptureCalls, "Credit posting should NOT have been attempted")
+	assert.Equal(t, 0, mockFinAcct.compensateCalls, "No compensation needed")
+
+	// BookingLog was created but no postings succeeded
+	assert.Equal(t, 1, mockFinAcct.initiateCalls, "BookingLog should have been created")
+	assert.Equal(t, 0, mockFinAcct.updateCalls, "BookingLog should NOT have been updated to POSTED")
+
+	// Verify account balance unchanged
+	updatedAccount, err := repo.FindByID(ctx, "ACC-DE-005")
+	require.NoError(t, err)
+	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
+		"Account balance should remain unchanged")
 }
 
 // TestExecuteDeposit_SingleEntry_BackwardCompatibility verifies that deposits work

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -144,16 +144,19 @@ func (m *mockPositionKeepingClient) Close() error {
 // Mock FinancialAccounting Client
 
 type mockFinancialAccountingClient struct {
-	captureCalls      int
-	failOnCapture     bool
-	failureError      error
-	captureResponses  []*financialaccountingv1.CaptureLedgerPostingResponse
-	compensateCalls   int
-	initiateCalls     int
-	updateCalls       int
-	retrieveLogCalls  int
-	listCalls         int
-	retrievePostCalls int
+	captureCalls       int
+	debitCaptureCalls  int // Track debit postings specifically
+	creditCaptureCalls int // Track credit postings specifically
+	failOnCapture      bool
+	failureError       error
+	captureResponses   []*financialaccountingv1.CaptureLedgerPostingResponse
+	compensateCalls    int
+	initiateCalls      int
+	updateCalls        int
+	retrieveLogCalls   int
+	listCalls          int
+	retrievePostCalls  int
+	lastCapturedReq    *financialaccountingv1.CaptureLedgerPostingRequest // Track last capture request
 }
 
 func (m *mockFinancialAccountingClient) InitiateFinancialBookingLog(_ context.Context, _ *financialaccountingv1.InitiateFinancialBookingLogRequest) (*financialaccountingv1.InitiateFinancialBookingLogResponse, error) {
@@ -199,6 +202,7 @@ func (m *mockFinancialAccountingClient) ListFinancialBookingLogs(_ context.Conte
 
 func (m *mockFinancialAccountingClient) CaptureLedgerPosting(_ context.Context, req *financialaccountingv1.CaptureLedgerPostingRequest) (*financialaccountingv1.CaptureLedgerPostingResponse, error) {
 	m.captureCalls++
+	m.lastCapturedReq = req
 
 	if m.failOnCapture {
 		if m.failureError != nil {
@@ -207,9 +211,19 @@ func (m *mockFinancialAccountingClient) CaptureLedgerPosting(_ context.Context, 
 		return nil, errFinancialAccountingUnavailable
 	}
 
-	// Check if this is a compensation call (debit direction indicates reversal)
+	// Track debit vs credit postings separately
 	if req.PostingDirection == commonpb.PostingDirection_POSTING_DIRECTION_DEBIT {
-		m.compensateCalls++
+		m.debitCaptureCalls++
+		// Only count as compensation if this is a reversal (idempotency key contains "COMP")
+		if req.IdempotencyKey != nil && len(req.IdempotencyKey.Key) > 4 && req.IdempotencyKey.Key[:4] == "COMP" {
+			m.compensateCalls++
+		}
+	} else if req.PostingDirection == commonpb.PostingDirection_POSTING_DIRECTION_CREDIT {
+		m.creditCaptureCalls++
+		// Check for compensation credits too
+		if req.IdempotencyKey != nil && len(req.IdempotencyKey.Key) > 4 && req.IdempotencyKey.Key[:4] == "COMP" {
+			m.compensateCalls++
+		}
 	}
 
 	resp := &financialaccountingv1.CaptureLedgerPostingResponse{
@@ -780,4 +794,246 @@ func TestExecuteDeposit_WithoutClients_BackwardCompatibility(t *testing.T) {
 	updatedAccount, err := repo.FindByID(ctx, "ACC-006")
 	require.NoError(t, err)
 	assert.Equal(t, int64(20000), updatedAccount.Balance.AmountCents())
+}
+
+// Double-Entry Bookkeeping Tests (with AccountConfig)
+
+// TestExecuteDeposit_DoubleEntry_CreatesDualPostings verifies that when AccountConfig
+// is provided with a clearing account, the deposit creates both debit and credit postings.
+//
+// Expected behavior:
+// 1. BookingLog is created
+// 2. DEBIT posting is created to clearing account
+// 3. CREDIT posting is created to customer account
+// 4. BookingLog is transitioned to POSTED
+// 5. Both postings share the same BookingLogId
+func TestExecuteDeposit_DoubleEntry_CreatesDualPostings(t *testing.T) {
+	// Setup
+	db, ctx, cleanup := setupIntegrationTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	_ = createTestAccount(t, ctx, repo, "ACC-DE-001")
+
+	// Create mock clients
+	mockPosKeeping := &mockPositionKeepingClient{}
+	mockFinAcct := &mockFinancialAccountingClient{}
+
+	// Create service with AccountConfig (double-entry mode)
+	svc := &Service{
+		repo:             repo,
+		posKeepingClient: mockPosKeeping,
+		finAcctClient:    mockFinAcct,
+		accountConfig: &AccountConfig{
+			DepositClearingAccountID: "CLEARING-001",
+		},
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	// Execute deposit
+	req := createTestDepositRequest("ACC-DE-001", 100, 0) // £100.00
+	resp, err := svc.ExecuteDeposit(ctx, req)
+
+	// Verify success
+	require.NoError(t, err, "Deposit should succeed")
+	assert.Equal(t, "ACC-DE-001", resp.AccountId)
+	assert.Equal(t, pb.TransactionStatus_TRANSACTION_STATUS_COMPLETED, resp.Status)
+
+	// Verify dual postings
+	assert.Equal(t, 2, mockFinAcct.captureCalls, "Should have 2 capture calls (debit + credit)")
+	assert.Equal(t, 1, mockFinAcct.debitCaptureCalls, "Should have 1 debit posting to clearing account")
+	assert.Equal(t, 1, mockFinAcct.creditCaptureCalls, "Should have 1 credit posting to customer account")
+
+	// Verify BookingLog was created and updated to POSTED
+	assert.Equal(t, 1, mockFinAcct.initiateCalls, "Should initiate 1 BookingLog")
+	assert.Equal(t, 1, mockFinAcct.updateCalls, "Should update BookingLog to POSTED")
+
+	// Verify no compensation occurred
+	assert.Equal(t, 0, mockFinAcct.compensateCalls, "No compensation should occur on success")
+}
+
+// TestExecuteDeposit_DoubleEntry_SameBookingLogForBothPostings verifies that both
+// the debit and credit postings are associated with the same BookingLog.
+// This is verified by checking that 2 capture calls are made with the same BookingLogId.
+func TestExecuteDeposit_DoubleEntry_SameBookingLogForBothPostings(t *testing.T) {
+	// Setup
+	db, ctx, cleanup := setupIntegrationTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	_ = createTestAccount(t, ctx, repo, "ACC-DE-002")
+
+	// Create mock clients
+	mockPosKeeping := &mockPositionKeepingClient{}
+	mockFinAcct := &mockFinancialAccountingClient{}
+
+	// Create service with AccountConfig
+	svc := &Service{
+		repo:             repo,
+		posKeepingClient: mockPosKeeping,
+		finAcctClient:    mockFinAcct,
+		accountConfig: &AccountConfig{
+			DepositClearingAccountID: "CLEARING-002",
+		},
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	// Execute deposit
+	req := createTestDepositRequest("ACC-DE-002", 50, 0) // £50.00
+	resp, err := svc.ExecuteDeposit(ctx, req)
+
+	// Verify success
+	require.NoError(t, err, "Deposit should succeed")
+	assert.NotNil(t, resp)
+
+	// Verify both postings happened (1 debit + 1 credit)
+	assert.Equal(t, 2, mockFinAcct.captureCalls, "Should have 2 capture calls")
+	assert.Equal(t, 1, mockFinAcct.debitCaptureCalls, "Should have 1 debit posting")
+	assert.Equal(t, 1, mockFinAcct.creditCaptureCalls, "Should have 1 credit posting")
+
+	// The implementation guarantees both use the same BookingLogId since:
+	// 1. BookingLog is created once at the start
+	// 2. Both postings use the captured bookingLogID
+	// This is verified in the implementation logging: "booking_log_id=BOOK-LOG-001"
+	// appears in both debit and credit log messages
+}
+
+// TestExecuteDeposit_DoubleEntry_CompensatesOnFailure verifies that saga compensation
+// reverses both postings when a failure occurs after they're created.
+func TestExecuteDeposit_DoubleEntry_CompensatesOnFailure(t *testing.T) {
+	// Setup
+	db, ctx, cleanup := setupIntegrationTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	account := createTestAccount(t, ctx, repo, "ACC-DE-003")
+	originalBalance := account.Balance.AmountCents()
+
+	mockPosKeeping := &mockPositionKeepingClient{}
+
+	// Create a mock that fails on the 3rd capture call (after debit and credit, during update)
+	// Actually, let's fail on UpdateFinancialBookingLog to trigger compensation after both postings
+	captureCallCount := 0
+	updateCallCount := 0
+
+	// We need a custom mock that fails on update
+	type failingUpdateMock struct {
+		mockFinancialAccountingClient
+		updateFailCount int
+	}
+
+	failMock := &failingUpdateMock{
+		mockFinancialAccountingClient: mockFinancialAccountingClient{},
+		updateFailCount:               0,
+	}
+
+	// Override UpdateFinancialBookingLog to fail
+	// Since we can't easily override methods, let's use a different approach
+	// Instead, we'll create a test that verifies compensation logic is correct
+
+	// For this test, let's just verify the compensation counters work correctly
+	// when the service handles a failure after postings succeed
+
+	svc := &Service{
+		repo:             repo,
+		posKeepingClient: mockPosKeeping,
+		finAcctClient:    &failMock.mockFinancialAccountingClient,
+		accountConfig: &AccountConfig{
+			DepositClearingAccountID: "CLEARING-003",
+		},
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	_ = svc
+	_ = captureCallCount
+	_ = updateCallCount
+	_ = originalBalance
+
+	// This test would require a more sophisticated mock that fails at a specific point
+	// For now, let's just verify the basic compensation path works
+	t.Log("Compensation test setup validated")
+}
+
+// TestExecuteDeposit_SingleEntry_BackwardCompatibility verifies that deposits work
+// without AccountConfig (backward compatibility - single-entry mode).
+func TestExecuteDeposit_SingleEntry_BackwardCompatibility(t *testing.T) {
+	// Setup
+	db, ctx, cleanup := setupIntegrationTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	_ = createTestAccount(t, ctx, repo, "ACC-SE-001")
+
+	// Create mock clients
+	mockPosKeeping := &mockPositionKeepingClient{}
+	mockFinAcct := &mockFinancialAccountingClient{}
+
+	// Create service WITHOUT AccountConfig (single-entry/backward compatible mode)
+	svc := &Service{
+		repo:             repo,
+		posKeepingClient: mockPosKeeping,
+		finAcctClient:    mockFinAcct,
+		accountConfig:    nil, // No AccountConfig - single-entry mode
+		logger:           slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	// Execute deposit
+	req := createTestDepositRequest("ACC-SE-001", 75, 0) // £75.00
+	resp, err := svc.ExecuteDeposit(ctx, req)
+
+	// Verify success
+	require.NoError(t, err, "Deposit should succeed")
+	assert.Equal(t, "ACC-SE-001", resp.AccountId)
+	assert.Equal(t, pb.TransactionStatus_TRANSACTION_STATUS_COMPLETED, resp.Status)
+
+	// Verify single posting (credit only, no debit)
+	assert.Equal(t, 1, mockFinAcct.captureCalls, "Should have 1 capture call (credit only)")
+	assert.Equal(t, 0, mockFinAcct.debitCaptureCalls, "Should have no debit posting")
+	assert.Equal(t, 1, mockFinAcct.creditCaptureCalls, "Should have 1 credit posting")
+
+	// Verify BookingLog flow
+	assert.Equal(t, 1, mockFinAcct.initiateCalls, "Should initiate 1 BookingLog")
+	assert.Equal(t, 1, mockFinAcct.updateCalls, "Should update BookingLog to POSTED")
+}
+
+// TestExecuteDeposit_DoubleEntry_ClearingAccountUsedForDebit verifies that the debit
+// posting goes to the clearing account from config.
+func TestExecuteDeposit_DoubleEntry_ClearingAccountUsedForDebit(t *testing.T) {
+	// Setup
+	db, ctx, cleanup := setupIntegrationTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	_ = createTestAccount(t, ctx, repo, "ACC-DE-004")
+
+	// Create mock clients
+	mockPosKeeping := &mockPositionKeepingClient{}
+	mockFinAcct := &mockFinancialAccountingClient{}
+
+	clearingAccountID := "CLEARING-SPECIFIC-ID"
+
+	// Create service with specific clearing account
+	svc := &Service{
+		repo:             repo,
+		posKeepingClient: mockPosKeeping,
+		finAcctClient:    mockFinAcct,
+		accountConfig: &AccountConfig{
+			DepositClearingAccountID: clearingAccountID,
+		},
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	// Execute deposit
+	req := createTestDepositRequest("ACC-DE-004", 100, 0) // £100.00
+	resp, err := svc.ExecuteDeposit(ctx, req)
+
+	// Verify success
+	require.NoError(t, err, "Deposit should succeed")
+	assert.NotNil(t, resp)
+
+	// The mock tracks the last request; we can verify the clearing account was used
+	// by checking that debit call count is correct (we verified this happens to clearing account
+	// in the implementation, and the mock tracks debit_capture_calls)
+	assert.Equal(t, 1, mockFinAcct.debitCaptureCalls, "Should have 1 debit posting")
+	assert.Equal(t, 1, mockFinAcct.creditCaptureCalls, "Should have 1 credit posting")
 }

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -15,6 +15,7 @@ import (
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
+	"github.com/meridianhub/meridian/services/current-account/config"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
@@ -144,21 +145,22 @@ func (m *mockPositionKeepingClient) Close() error {
 // Mock FinancialAccounting Client
 
 type mockFinancialAccountingClient struct {
-	captureCalls       int
-	debitCaptureCalls  int // Track debit postings specifically
-	creditCaptureCalls int // Track credit postings specifically
-	failOnCapture      bool
-	failOnDebitCapture bool // Fail specifically on debit postings
-	failOnUpdate       bool // Fail on UpdateFinancialBookingLog
-	failureError       error
-	captureResponses   []*financialaccountingv1.CaptureLedgerPostingResponse
-	compensateCalls    int
-	initiateCalls      int
-	updateCalls        int
-	retrieveLogCalls   int
-	listCalls          int
-	retrievePostCalls  int
-	lastCapturedReq    *financialaccountingv1.CaptureLedgerPostingRequest // Track last capture request
+	captureCalls        int
+	debitCaptureCalls   int // Track debit postings specifically
+	creditCaptureCalls  int // Track credit postings specifically
+	failOnCapture       bool
+	failOnDebitCapture  bool // Fail specifically on debit postings
+	failOnCreditCapture bool // Fail specifically on credit postings (after debit succeeds)
+	failOnUpdate        bool // Fail on UpdateFinancialBookingLog
+	failureError        error
+	captureResponses    []*financialaccountingv1.CaptureLedgerPostingResponse
+	compensateCalls     int
+	initiateCalls       int
+	updateCalls         int
+	retrieveLogCalls    int
+	listCalls           int
+	retrievePostCalls   int
+	lastCapturedReq     *financialaccountingv1.CaptureLedgerPostingRequest // Track last capture request
 }
 
 func (m *mockFinancialAccountingClient) InitiateFinancialBookingLog(_ context.Context, _ *financialaccountingv1.InitiateFinancialBookingLogRequest) (*financialaccountingv1.InitiateFinancialBookingLogResponse, error) {
@@ -220,6 +222,17 @@ func (m *mockFinancialAccountingClient) CaptureLedgerPosting(_ context.Context, 
 			return nil, m.failureError
 		}
 		return nil, errFinancialAccountingUnavailable
+	}
+
+	// Check for credit-specific failure (simulates credit posting failure after debit succeeds)
+	if m.failOnCreditCapture && req.PostingDirection == commonpb.PostingDirection_POSTING_DIRECTION_CREDIT {
+		// Only fail on non-compensation credits (original credit posting, not compensation reversals)
+		if req.IdempotencyKey == nil || len(req.IdempotencyKey.Key) < 4 || req.IdempotencyKey.Key[:4] != "COMP" {
+			if m.failureError != nil {
+				return nil, m.failureError
+			}
+			return nil, errFinancialAccountingUnavailable
+		}
 	}
 
 	if m.failOnCapture {
@@ -842,7 +855,7 @@ func TestExecuteDeposit_DoubleEntry_CreatesDualPostings(t *testing.T) {
 		repo:             repo,
 		posKeepingClient: mockPosKeeping,
 		finAcctClient:    mockFinAcct,
-		accountConfig: &AccountConfig{
+		accountConfig: &config.AccountConfig{
 			DepositClearingAccountID: "CLEARING-001",
 		},
 		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
@@ -890,7 +903,7 @@ func TestExecuteDeposit_DoubleEntry_SameBookingLogForBothPostings(t *testing.T) 
 		repo:             repo,
 		posKeepingClient: mockPosKeeping,
 		finAcctClient:    mockFinAcct,
-		accountConfig: &AccountConfig{
+		accountConfig: &config.AccountConfig{
 			DepositClearingAccountID: "CLEARING-002",
 		},
 		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
@@ -942,7 +955,7 @@ func TestExecuteDeposit_DoubleEntry_CompensatesOnFailure(t *testing.T) {
 		repo:             repo,
 		posKeepingClient: mockPosKeeping,
 		finAcctClient:    mockFinAcct,
-		accountConfig: &AccountConfig{
+		accountConfig: &config.AccountConfig{
 			DepositClearingAccountID: "CLEARING-003",
 		},
 		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
@@ -1003,7 +1016,7 @@ func TestExecuteDeposit_DoubleEntry_DebitPostingFailure(t *testing.T) {
 		repo:             repo,
 		posKeepingClient: mockPosKeeping,
 		finAcctClient:    mockFinAcct,
-		accountConfig: &AccountConfig{
+		accountConfig: &config.AccountConfig{
 			DepositClearingAccountID: "CLEARING-005",
 		},
 		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
@@ -1039,6 +1052,70 @@ func TestExecuteDeposit_DoubleEntry_DebitPostingFailure(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
 		"Account balance should remain unchanged")
+}
+
+// TestExecuteDeposit_DoubleEntry_CreditPostingFailure verifies that when the credit
+// posting fails after debit succeeds, inline compensation creates a reversal for the debit.
+func TestExecuteDeposit_DoubleEntry_CreditPostingFailure(t *testing.T) {
+	// Setup
+	db, ctx, cleanup := setupIntegrationTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	account := createTestAccount(t, ctx, repo, "ACC-DE-006")
+	originalBalance := account.Balance.AmountCents()
+
+	mockPosKeeping := &mockPositionKeepingClient{}
+
+	// Create mock that fails specifically on credit postings (after debit succeeds)
+	mockFinAcct := &mockFinancialAccountingClient{
+		failOnCreditCapture: true,
+		failureError:        errIntentionalTestFailure,
+	}
+
+	svc := &Service{
+		repo:             repo,
+		posKeepingClient: mockPosKeeping,
+		finAcctClient:    mockFinAcct,
+		accountConfig: &config.AccountConfig{
+			DepositClearingAccountID: "CLEARING-006",
+		},
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	// Execute deposit
+	req := createTestDepositRequest("ACC-DE-006", 200, 0) // £200.00
+	resp, err := svc.ExecuteDeposit(ctx, req)
+
+	// Verify failure
+	require.Error(t, err, "Deposit should fail due to credit posting failure")
+	assert.Nil(t, resp, "Response should be nil on failure")
+
+	// Verify error mentions the failed step
+	st, ok := status.FromError(err)
+	require.True(t, ok, "Error should be gRPC status error")
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "post_ledger", "Error should mention failed step")
+	assert.Contains(t, st.Message(), "credit", "Error should mention credit failure")
+
+	// Verify debit succeeded, credit failed, and inline compensation ran
+	// Capture calls: 1 (debit success) + 1 (credit fail) + 1 (compensation credit to clear debit)
+	assert.Equal(t, 3, mockFinAcct.captureCalls, "Should have 3 capture calls total")
+	assert.Equal(t, 1, mockFinAcct.debitCaptureCalls, "Debit posting should have succeeded")
+	assert.Equal(t, 1, mockFinAcct.creditCaptureCalls, "One compensation credit should succeed")
+	assert.Equal(t, 1, mockFinAcct.compensateCalls, "Should have 1 compensation call (to reverse debit)")
+
+	// BookingLog was created but not transitioned to POSTED
+	// (inline compensation should have attempted to transition to CANCELLED)
+	assert.Equal(t, 1, mockFinAcct.initiateCalls, "BookingLog should have been created")
+	// UpdateCalls: 1 for CANCELLED transition attempt after credit fails
+	assert.GreaterOrEqual(t, mockFinAcct.updateCalls, 1, "BookingLog should have update call(s)")
+
+	// Verify account balance unchanged
+	updatedAccount, err := repo.FindByID(ctx, "ACC-DE-006")
+	require.NoError(t, err)
+	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
+		"Account balance should remain unchanged after failure and compensation")
 }
 
 // TestExecuteDeposit_SingleEntry_BackwardCompatibility verifies that deposits work
@@ -1104,7 +1181,7 @@ func TestExecuteDeposit_DoubleEntry_ClearingAccountUsedForDebit(t *testing.T) {
 		repo:             repo,
 		posKeepingClient: mockPosKeeping,
 		finAcctClient:    mockFinAcct,
-		accountConfig: &AccountConfig{
+		accountConfig: &config.AccountConfig{
 			DepositClearingAccountID: clearingAccountID,
 		},
 		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),


### PR DESCRIPTION
## Summary

Follow-up fixes for #354 (double-entry bookkeeping) based on second round of review feedback:

- Unified `AccountConfig` type definitions (use `config.AccountConfig` directly instead of duplicate type)
- Added inline compensation for credit posting failure after debit succeeds
- Added observability metrics for inline compensation failures (`current_account_inline_compensation_failures_total`)
- Added logging for BookingLog CANCELLED transitions during inline compensation
- Added test for credit posting failure scenario
- Added explanatory comment for closure variable capture pattern

## Changes Made

1. **Type Unification**
   - Removed duplicate `service.AccountConfig` type
   - Changed `Service` struct and `NewServiceWithExistingClients` to use `*config.AccountConfig` directly
   - Updated `main.go` to pass config directly without creating intermediate struct

2. **Inline Compensation for Credit Failure**
   - Added compensation logic when credit posting fails after debit succeeds
   - Creates reversal CREDIT to clearing account to compensate the original DEBIT
   - Transitions BookingLog to CANCELLED state

3. **Observability**
   - New metric: `current_account_inline_compensation_failures_total` with labels for operation and leg
   - Added logging for CANCELLED transition success/failure during inline compensation

4. **Testing**
   - Added `TestExecuteDeposit_DoubleEntry_CreditPostingFailure` test case
   - Added `failOnCreditCapture` flag to mock for targeted failure testing

## Test Plan

- [x] All existing double-entry tests pass
- [x] New credit posting failure test passes
- [x] Build compiles without errors
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)