### PR TITLE
fix: address second round of PR review feedback for double-entry bookkeeping

### DIFF
--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -365,18 +365,15 @@ func createServiceWithClients(
 ) (*service.Service, *serviceClients, error) {
 	// Load account configuration for clearing accounts
 	// This is optional - if not configured, deposits will use single-entry mode (backward compatible)
-	var accountConfig *service.AccountConfig
-	cfg, err := config.LoadAccountConfig()
-	if err != nil {
+	accountConfig, cfgErr := config.LoadAccountConfig()
+	if cfgErr != nil {
 		// Log warning but continue - double-entry is optional for backward compatibility
 		logger.Warn("account configuration not loaded, double-entry bookkeeping disabled",
-			"error", err)
+			"error", cfgErr)
+		accountConfig = nil // Explicit nil for clarity
 	} else {
-		accountConfig = &service.AccountConfig{
-			DepositClearingAccountID: cfg.DepositClearingAccountID,
-		}
 		logger.Info("account configuration loaded",
-			"deposit_clearing_account_id", cfg.DepositClearingAccountID)
+			"deposit_clearing_account_id", accountConfig.DepositClearingAccountID)
 	}
 
 	// Create Position Keeping client with DNS-based load balancing

--- a/services/current-account/observability/metrics.go
+++ b/services/current-account/observability/metrics.go
@@ -61,6 +61,16 @@ var (
 		[]string{"operation", "step"},
 	)
 
+	// Inline compensation metrics - for compensations that happen within a step
+	// due to saga pattern limitations (step fails after side effects)
+	inlineCompensationFailuresTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "current_account_inline_compensation_failures_total",
+			Help: "Total number of inline compensation failures (requires manual intervention)",
+		},
+		[]string{"operation", "leg"},
+	)
+
 	sagaDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "current_account_saga_duration_seconds",
@@ -118,6 +128,13 @@ func RecordSagaFailure(operation, failedStep string) {
 // RecordSagaCompensation records a saga compensation
 func RecordSagaCompensation(operation, step string) {
 	sagaCompensationsTotal.WithLabelValues(operation, step).Inc()
+}
+
+// RecordInlineCompensationFailure records an inline compensation failure.
+// These failures indicate that a compensating entry could not be created,
+// requiring manual intervention to restore ledger integrity.
+func RecordInlineCompensationFailure(operation, leg string) {
+	inlineCompensationFailuresTotal.WithLabelValues(operation, leg).Inc()
 }
 
 // RecordSagaDuration records the duration of a saga execution

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -19,6 +19,7 @@ import (
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/clients"
+	"github.com/meridianhub/meridian/services/current-account/config"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
 	"github.com/meridianhub/meridian/shared/platform/observability"
@@ -56,16 +57,9 @@ type Service struct {
 	posKeepingClient clients.PositionKeepingClient
 	finAcctClient    clients.FinancialAccountingClient
 	partyClient      clients.PartyClient
-	accountConfig    *AccountConfig
+	accountConfig    *config.AccountConfig
 	logger           *slog.Logger
 	tracer           *observability.Tracer
-}
-
-// AccountConfig holds configuration for internal accounts used in transaction routing.
-// This is used for deposits to route the debit side to the clearing account.
-type AccountConfig struct {
-	// DepositClearingAccountID is the account ID for deposit clearing (debit side).
-	DepositClearingAccountID string
 }
 
 // Config contains configuration for creating a new Service with external clients
@@ -101,7 +95,7 @@ func NewServiceWithExistingClients(
 	posKeepingClient clients.PositionKeepingClient,
 	finAcctClient clients.FinancialAccountingClient,
 	partyClient clients.PartyClient,
-	accountConfig *AccountConfig,
+	accountConfig *config.AccountConfig,
 	logger *slog.Logger,
 	tracer *observability.Tracer,
 ) (*Service, error) {
@@ -533,6 +527,11 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 	// Step 2: Post to ledger in FinancialAccounting service with double-entry bookkeeping
 	// Creates a BookingLog, posts DEBIT to clearing account, posts CREDIT to customer account,
 	// then transitions BookingLog to POSTED (triggering balance validation).
+	// These variables are intentionally declared outside the saga step closures to allow
+	// data sharing between the action and compensation functions. When a closure captures
+	// a variable (e.g., bookingLogID), both the action and compensation closures reference
+	// the same memory location, allowing the action to set values that the compensation
+	// can later read if rollback is needed.
 	var debitPostingID string
 	var creditPostingID string
 	var bookingLogID string
@@ -627,6 +626,55 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 			)
 			if err != nil {
 				caobservability.RecordExternalServiceError("financial_accounting", "capture_credit_posting")
+
+				// CRITICAL: If debit was posted but credit fails, we must compensate the debit inline.
+				// The saga won't consider this step complete, so saga compensation won't run.
+				if debitPosted {
+					s.logger.Warn("credit posting failed after debit succeeded, creating inline compensation",
+						"clearing_account_id", clearingAccountID,
+						"transaction_id", transactionID,
+						"error", err)
+
+					// Compensate debit: Create CREDIT to clearing account
+					compDebitID := fmt.Sprintf("COMP-%s-debit", transactionID)
+					_, compErr := s.finAcctClient.CaptureLedgerPosting(stepCtx,
+						&financialaccountingv1.CaptureLedgerPostingRequest{
+							FinancialBookingLogId: bookingLogID,
+							PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_CREDIT,
+							PostingAmount:         moneyAmt.Amount,
+							AccountId:             clearingAccountID,
+							ValueDate:             timestamppb.Now(),
+							IdempotencyKey:        &commonpb.IdempotencyKey{Key: compDebitID},
+						},
+					)
+					if compErr != nil {
+						s.logger.Error("failed to compensate debit posting after credit failure",
+							"booking_log_id", bookingLogID,
+							"clearing_account_id", clearingAccountID,
+							"transaction_id", transactionID,
+							"error", compErr)
+						caobservability.RecordInlineCompensationFailure("deposit", "debit")
+					}
+
+					// Try to transition BookingLog to CANCELLED
+					_, cancelErr := s.finAcctClient.UpdateFinancialBookingLog(stepCtx,
+						&financialaccountingv1.UpdateFinancialBookingLogRequest{
+							Id:     bookingLogID,
+							Status: commonpb.TransactionStatus_TRANSACTION_STATUS_CANCELLED,
+						},
+					)
+					if cancelErr != nil {
+						s.logger.Warn("failed to transition booking log to CANCELLED after credit failure",
+							"booking_log_id", bookingLogID,
+							"transaction_id", transactionID,
+							"error", cancelErr)
+					} else {
+						s.logger.Info("booking log transitioned to CANCELLED after credit failure",
+							"booking_log_id", bookingLogID,
+							"transaction_id", transactionID)
+					}
+				}
+
 				return fmt.Errorf("failed to post credit to customer account: %w", err)
 			}
 			creditPostingID = creditResp.LedgerPosting.Id
@@ -672,7 +720,11 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 					)
 					if compErr != nil {
 						s.logger.Error("failed to compensate credit posting inline",
+							"booking_log_id", bookingLogID,
+							"account_id", account.AccountID,
+							"transaction_id", transactionID,
 							"error", compErr)
+						caobservability.RecordInlineCompensationFailure("deposit", "credit")
 					}
 				}
 
@@ -691,18 +743,33 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 					)
 					if compErr != nil {
 						s.logger.Error("failed to compensate debit posting inline",
+							"booking_log_id", bookingLogID,
+							"clearing_account_id", clearingAccountID,
+							"transaction_id", transactionID,
 							"error", compErr)
+						caobservability.RecordInlineCompensationFailure("deposit", "debit")
 					}
 				}
 
 				// Try to transition BookingLog to CANCELLED
 				if debitPosted || creditPosted {
-					_, _ = s.finAcctClient.UpdateFinancialBookingLog(stepCtx,
+					_, cancelErr := s.finAcctClient.UpdateFinancialBookingLog(stepCtx,
 						&financialaccountingv1.UpdateFinancialBookingLogRequest{
 							Id:     bookingLogID,
 							Status: commonpb.TransactionStatus_TRANSACTION_STATUS_CANCELLED,
 						},
 					)
+					if cancelErr != nil {
+						// Log but don't fail - the compensating entries are more important
+						s.logger.Warn("failed to transition booking log to CANCELLED during inline compensation",
+							"booking_log_id", bookingLogID,
+							"transaction_id", transactionID,
+							"error", cancelErr)
+					} else {
+						s.logger.Info("booking log transitioned to CANCELLED during inline compensation",
+							"booking_log_id", bookingLogID,
+							"transaction_id", transactionID)
+					}
 				}
 
 				return fmt.Errorf("failed to transition booking log to POSTED: %w", err)

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -15,6 +15,7 @@ import (
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
+	"github.com/meridianhub/meridian/services/current-account/config"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
@@ -144,21 +145,22 @@ func (m *mockPositionKeepingClient) Close() error {
 // Mock FinancialAccounting Client
 
 type mockFinancialAccountingClient struct {
-	captureCalls       int
-	debitCaptureCalls  int // Track debit postings specifically
-	creditCaptureCalls int // Track credit postings specifically
-	failOnCapture      bool
-	failOnDebitCapture bool // Fail specifically on debit postings
-	failOnUpdate       bool // Fail on UpdateFinancialBookingLog
-	failureError       error
-	captureResponses   []*financialaccountingv1.CaptureLedgerPostingResponse
-	compensateCalls    int
-	initiateCalls      int
-	updateCalls        int
-	retrieveLogCalls   int
-	listCalls          int
-	retrievePostCalls  int
-	lastCapturedReq    *financialaccountingv1.CaptureLedgerPostingRequest // Track last capture request
+	captureCalls        int
+	debitCaptureCalls   int // Track debit postings specifically
+	creditCaptureCalls  int // Track credit postings specifically
+	failOnCapture       bool
+	failOnDebitCapture  bool // Fail specifically on debit postings
+	failOnCreditCapture bool // Fail specifically on credit postings (after debit succeeds)
+	failOnUpdate        bool // Fail on UpdateFinancialBookingLog
+	failureError        error
+	captureResponses    []*financialaccountingv1.CaptureLedgerPostingResponse
+	compensateCalls     int
+	initiateCalls       int
+	updateCalls         int
+	retrieveLogCalls    int
+	listCalls           int
+	retrievePostCalls   int
+	lastCapturedReq     *financialaccountingv1.CaptureLedgerPostingRequest // Track last capture request
 }
 
 func (m *mockFinancialAccountingClient) InitiateFinancialBookingLog(_ context.Context, _ *financialaccountingv1.InitiateFinancialBookingLogRequest) (*financialaccountingv1.InitiateFinancialBookingLogResponse, error) {
@@ -220,6 +222,17 @@ func (m *mockFinancialAccountingClient) CaptureLedgerPosting(_ context.Context, 
 			return nil, m.failureError
 		}
 		return nil, errFinancialAccountingUnavailable
+	}
+
+	// Check for credit-specific failure (simulates credit posting failure after debit succeeds)
+	if m.failOnCreditCapture && req.PostingDirection == commonpb.PostingDirection_POSTING_DIRECTION_CREDIT {
+		// Only fail on non-compensation credits (original credit posting, not compensation reversals)
+		if req.IdempotencyKey == nil || len(req.IdempotencyKey.Key) < 4 || req.IdempotencyKey.Key[:4] != "COMP" {
+			if m.failureError != nil {
+				return nil, m.failureError
+			}
+			return nil, errFinancialAccountingUnavailable
+		}
 	}
 
 	if m.failOnCapture {
@@ -842,7 +855,7 @@ func TestExecuteDeposit_DoubleEntry_CreatesDualPostings(t *testing.T) {
 		repo:             repo,
 		posKeepingClient: mockPosKeeping,
 		finAcctClient:    mockFinAcct,
-		accountConfig: &AccountConfig{
+		accountConfig: &config.AccountConfig{
 			DepositClearingAccountID: "CLEARING-001",
 		},
 		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
@@ -890,7 +903,7 @@ func TestExecuteDeposit_DoubleEntry_SameBookingLogForBothPostings(t *testing.T) 
 		repo:             repo,
 		posKeepingClient: mockPosKeeping,
 		finAcctClient:    mockFinAcct,
-		accountConfig: &AccountConfig{
+		accountConfig: &config.AccountConfig{
 			DepositClearingAccountID: "CLEARING-002",
 		},
 		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
@@ -942,7 +955,7 @@ func TestExecuteDeposit_DoubleEntry_CompensatesOnFailure(t *testing.T) {
 		repo:             repo,
 		posKeepingClient: mockPosKeeping,
 		finAcctClient:    mockFinAcct,
-		accountConfig: &AccountConfig{
+		accountConfig: &config.AccountConfig{
 			DepositClearingAccountID: "CLEARING-003",
 		},
 		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
@@ -1003,7 +1016,7 @@ func TestExecuteDeposit_DoubleEntry_DebitPostingFailure(t *testing.T) {
 		repo:             repo,
 		posKeepingClient: mockPosKeeping,
 		finAcctClient:    mockFinAcct,
-		accountConfig: &AccountConfig{
+		accountConfig: &config.AccountConfig{
 			DepositClearingAccountID: "CLEARING-005",
 		},
 		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
@@ -1039,6 +1052,70 @@ func TestExecuteDeposit_DoubleEntry_DebitPostingFailure(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
 		"Account balance should remain unchanged")
+}
+
+// TestExecuteDeposit_DoubleEntry_CreditPostingFailure verifies that when the credit
+// posting fails after debit succeeds, inline compensation creates a reversal for the debit.
+func TestExecuteDeposit_DoubleEntry_CreditPostingFailure(t *testing.T) {
+	// Setup
+	db, ctx, cleanup := setupIntegrationTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	account := createTestAccount(t, ctx, repo, "ACC-DE-006")
+	originalBalance := account.Balance.AmountCents()
+
+	mockPosKeeping := &mockPositionKeepingClient{}
+
+	// Create mock that fails specifically on credit postings (after debit succeeds)
+	mockFinAcct := &mockFinancialAccountingClient{
+		failOnCreditCapture: true,
+		failureError:        errIntentionalTestFailure,
+	}
+
+	svc := &Service{
+		repo:             repo,
+		posKeepingClient: mockPosKeeping,
+		finAcctClient:    mockFinAcct,
+		accountConfig: &config.AccountConfig{
+			DepositClearingAccountID: "CLEARING-006",
+		},
+		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),
+	}
+
+	// Execute deposit
+	req := createTestDepositRequest("ACC-DE-006", 200, 0) // £200.00
+	resp, err := svc.ExecuteDeposit(ctx, req)
+
+	// Verify failure
+	require.Error(t, err, "Deposit should fail due to credit posting failure")
+	assert.Nil(t, resp, "Response should be nil on failure")
+
+	// Verify error mentions the failed step
+	st, ok := status.FromError(err)
+	require.True(t, ok, "Error should be gRPC status error")
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "post_ledger", "Error should mention failed step")
+	assert.Contains(t, st.Message(), "credit", "Error should mention credit failure")
+
+	// Verify debit succeeded, credit failed, and inline compensation ran
+	// Capture calls: 1 (debit success) + 1 (credit fail) + 1 (compensation credit to clear debit)
+	assert.Equal(t, 3, mockFinAcct.captureCalls, "Should have 3 capture calls total")
+	assert.Equal(t, 1, mockFinAcct.debitCaptureCalls, "Debit posting should have succeeded")
+	assert.Equal(t, 1, mockFinAcct.creditCaptureCalls, "One compensation credit should succeed")
+	assert.Equal(t, 1, mockFinAcct.compensateCalls, "Should have 1 compensation call (to reverse debit)")
+
+	// BookingLog was created but not transitioned to POSTED
+	// (inline compensation should have attempted to transition to CANCELLED)
+	assert.Equal(t, 1, mockFinAcct.initiateCalls, "BookingLog should have been created")
+	// UpdateCalls: 1 for CANCELLED transition attempt after credit fails
+	assert.GreaterOrEqual(t, mockFinAcct.updateCalls, 1, "BookingLog should have update call(s)")
+
+	// Verify account balance unchanged
+	updatedAccount, err := repo.FindByID(ctx, "ACC-DE-006")
+	require.NoError(t, err)
+	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
+		"Account balance should remain unchanged after failure and compensation")
 }
 
 // TestExecuteDeposit_SingleEntry_BackwardCompatibility verifies that deposits work
@@ -1104,7 +1181,7 @@ func TestExecuteDeposit_DoubleEntry_ClearingAccountUsedForDebit(t *testing.T) {
 		repo:             repo,
 		posKeepingClient: mockPosKeeping,
 		finAcctClient:    mockFinAcct,
-		accountConfig: &AccountConfig{
+		accountConfig: &config.AccountConfig{
 			DepositClearingAccountID: clearingAccountID,
 		},
 		logger: slog.New(slog.NewTextHandler(os.Stdout, nil)),


### PR DESCRIPTION
## Summary

Follow-up fixes for #354 (double-entry bookkeeping) based on second round of review feedback:

- Unified `AccountConfig` type definitions (use `config.AccountConfig` directly instead of duplicate type)
- Added inline compensation for credit posting failure after debit succeeds
- Added observability metrics for inline compensation failures (`current_account_inline_compensation_failures_total`)
- Added logging for BookingLog CANCELLED transitions during inline compensation
- Added test for credit posting failure scenario
- Added explanatory comment for closure variable capture pattern

## Changes Made

1. **Type Unification**
   - Removed duplicate `service.AccountConfig` type
   - Changed `Service` struct and `NewServiceWithExistingClients` to use `*config.AccountConfig` directly
   - Updated `main.go` to pass config directly without creating intermediate struct

2. **Inline Compensation for Credit Failure**
   - Added compensation logic when credit posting fails after debit succeeds
   - Creates reversal CREDIT to clearing account to compensate the original DEBIT
   - Transitions BookingLog to CANCELLED state

3. **Observability**
   - New metric: `current_account_inline_compensation_failures_total` with labels for operation and leg
   - Added logging for CANCELLED transition success/failure during inline compensation

4. **Testing**
   - Added `TestExecuteDeposit_DoubleEntry_CreditPostingFailure` test case
   - Added `failOnCreditCapture` flag to mock for targeted failure testing

## Test Plan

- [x] All existing double-entry tests pass
- [x] New credit posting failure test passes
- [x] Build compiles without errors
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)