### PR TITLE
refactor: make CurrentAccount domain model immutable

### DIFF
--- a/services/current-account/adapters/persistence/repository.go
+++ b/services/current-account/adapters/persistence/repository.go
@@ -127,7 +127,7 @@ func (r *Repository) withForUpdateScope(ctx context.Context, fn func(tx *gorm.DB
 //
 // Alternative: Use FindByIDForUpdate() with SELECT FOR UPDATE for pessimistic locking
 // within a transaction when you need guaranteed exclusive access.
-func (r *Repository) Save(ctx context.Context, account *domain.CurrentAccount) error {
+func (r *Repository) Save(ctx context.Context, account domain.CurrentAccount) error {
 	entity, err := toEntity(ctx, account)
 	if err != nil {
 		return err
@@ -175,9 +175,6 @@ func (r *Repository) Save(ctx context.Context, account *domain.CurrentAccount) e
 				return ErrVersionConflict
 			}
 
-			// Update the domain model's version to reflect the new database state
-			account.Version = account.Version + 1
-
 			return nil
 		}
 
@@ -199,8 +196,8 @@ func (r *Repository) Save(ctx context.Context, account *domain.CurrentAccount) e
 
 // FindByID retrieves an account by its internal account ID (e.g., "ACC-xxx").
 // In multi-org mode, the context must contain the organization ID for schema routing.
-func (r *Repository) FindByID(ctx context.Context, accountID string) (*domain.CurrentAccount, error) {
-	var account *domain.CurrentAccount
+func (r *Repository) FindByID(ctx context.Context, accountID string) (domain.CurrentAccount, error) {
+	var account domain.CurrentAccount
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		var entity CurrentAccountEntity
 		result := tx.Where("account_id = ? AND deleted_at IS NULL", accountID).First(&entity)
@@ -217,7 +214,7 @@ func (r *Repository) FindByID(ctx context.Context, accountID string) (*domain.Cu
 		return err
 	})
 	if err != nil {
-		return nil, err
+		return domain.CurrentAccount{}, err
 	}
 	return account, nil
 }
@@ -230,8 +227,8 @@ func (r *Repository) FindByID(ctx context.Context, accountID string) (*domain.Cu
 // has the organization scope set. When using WithTx(), the caller is responsible for setting
 // the org scope on the outer transaction. This method will set the org scope if not already
 // in a transaction, but when called via WithTx(), it uses the existing transaction directly.
-func (r *Repository) FindByIDForUpdate(ctx context.Context, accountID string) (*domain.CurrentAccount, error) {
-	var account *domain.CurrentAccount
+func (r *Repository) FindByIDForUpdate(ctx context.Context, accountID string) (domain.CurrentAccount, error) {
+	var account domain.CurrentAccount
 
 	// Perform the FOR UPDATE query, wrapping in org-scoped transaction if needed
 	err := r.withForUpdateScope(ctx, func(tx *gorm.DB) error {
@@ -253,15 +250,15 @@ func (r *Repository) FindByIDForUpdate(ctx context.Context, accountID string) (*
 		return err
 	})
 	if err != nil {
-		return nil, err
+		return domain.CurrentAccount{}, err
 	}
 	return account, nil
 }
 
 // FindByIBAN retrieves an account by its IBAN (stored in account_identification column).
 // In multi-org mode, the context must contain the organization ID for schema routing.
-func (r *Repository) FindByIBAN(ctx context.Context, iban string) (*domain.CurrentAccount, error) {
-	var account *domain.CurrentAccount
+func (r *Repository) FindByIBAN(ctx context.Context, iban string) (domain.CurrentAccount, error) {
+	var account domain.CurrentAccount
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		var entity CurrentAccountEntity
 		result := tx.Where("account_identification = ? AND deleted_at IS NULL", iban).First(&entity)
@@ -278,15 +275,15 @@ func (r *Repository) FindByIBAN(ctx context.Context, iban string) (*domain.Curre
 		return err
 	})
 	if err != nil {
-		return nil, err
+		return domain.CurrentAccount{}, err
 	}
 	return account, nil
 }
 
 // FindByUUID retrieves an account by its internal UUID.
 // In multi-org mode, the context must contain the organization ID for schema routing.
-func (r *Repository) FindByUUID(ctx context.Context, id uuid.UUID) (*domain.CurrentAccount, error) {
-	var account *domain.CurrentAccount
+func (r *Repository) FindByUUID(ctx context.Context, id uuid.UUID) (domain.CurrentAccount, error) {
+	var account domain.CurrentAccount
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		var entity CurrentAccountEntity
 		result := tx.Where("id = ? AND deleted_at IS NULL", id).First(&entity)
@@ -303,7 +300,7 @@ func (r *Repository) FindByUUID(ctx context.Context, id uuid.UUID) (*domain.Curr
 		return err
 	})
 	if err != nil {
-		return nil, err
+		return domain.CurrentAccount{}, err
 	}
 	return account, nil
 }
@@ -316,8 +313,8 @@ func (r *Repository) FindByUUID(ctx context.Context, id uuid.UUID) (*domain.Curr
 // has the organization scope set. When using WithTx(), the caller is responsible for setting
 // the org scope on the outer transaction. This method will set the org scope if not already
 // in a transaction, but when called via WithTx(), it uses the existing transaction directly.
-func (r *Repository) FindByUUIDForUpdate(ctx context.Context, id uuid.UUID) (*domain.CurrentAccount, error) {
-	var account *domain.CurrentAccount
+func (r *Repository) FindByUUIDForUpdate(ctx context.Context, id uuid.UUID) (domain.CurrentAccount, error) {
+	var account domain.CurrentAccount
 
 	// Perform the FOR UPDATE query, wrapping in org-scoped transaction if needed
 	err := r.withForUpdateScope(ctx, func(tx *gorm.DB) error {
@@ -339,15 +336,15 @@ func (r *Repository) FindByUUIDForUpdate(ctx context.Context, id uuid.UUID) (*do
 		return err
 	})
 	if err != nil {
-		return nil, err
+		return domain.CurrentAccount{}, err
 	}
 	return account, nil
 }
 
 // FindByPartyID retrieves all accounts for a party.
 // In multi-org mode, the context must contain the organization ID for schema routing.
-func (r *Repository) FindByPartyID(ctx context.Context, partyID string) ([]*domain.CurrentAccount, error) {
-	var accounts []*domain.CurrentAccount
+func (r *Repository) FindByPartyID(ctx context.Context, partyID string) ([]domain.CurrentAccount, error) {
+	var accounts []domain.CurrentAccount
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		var entities []CurrentAccountEntity
 		result := tx.Where("party_id = ? AND deleted_at IS NULL", partyID).Find(&entities)
@@ -356,7 +353,7 @@ func (r *Repository) FindByPartyID(ctx context.Context, partyID string) ([]*doma
 			return result.Error
 		}
 
-		accounts = make([]*domain.CurrentAccount, 0, len(entities))
+		accounts = make([]domain.CurrentAccount, 0, len(entities))
 		for _, entity := range entities {
 			account, err := toDomain(&entity)
 			if err != nil {
@@ -392,54 +389,56 @@ func (r *Repository) Ping() error {
 // toEntity converts domain model to database entity
 // Note: The entity schema matches migrations/current_account/*.sql
 // OverdraftEnabled is derived from OverdraftLimit > 0
-func toEntity(ctx context.Context, account *domain.CurrentAccount) (*CurrentAccountEntity, error) {
+func toEntity(ctx context.Context, account domain.CurrentAccount) (*CurrentAccountEntity, error) {
 	// Parse PartyID as UUID - domain model uses string for flexibility
-	partyUUID, err := uuid.Parse(account.PartyID)
+	partyUUID, err := uuid.Parse(account.PartyID())
 	if err != nil {
-		return nil, fmt.Errorf("invalid party ID %q: %w", account.PartyID, err)
+		return nil, fmt.Errorf("invalid party ID %q: %w", account.PartyID(), err)
 	}
 
 	// Extract audit user from context (falls back to "system" if not available)
 	auditUser := audit.GetUserFromContext(ctx)
 
+	balanceUpdatedAt := account.BalanceUpdatedAt()
+
 	return &CurrentAccountEntity{
-		ID:                    account.ID,
-		AccountID:             account.AccountID,             // Business account identifier
-		AccountIdentification: account.AccountIdentification, // IBAN stored in account_identification
-		AccountType:           "current",                     // Default for current accounts
-		Currency:              string(account.Balance.Currency()),
-		Status:                string(account.Status),
+		ID:                    account.ID(),
+		AccountID:             account.AccountID(),             // Business account identifier
+		AccountIdentification: account.AccountIdentification(), // IBAN stored in account_identification
+		AccountType:           "current",                       // Default for current accounts
+		Currency:              string(account.Balance().Currency()),
+		Status:                string(account.Status()),
 		PartyID:               partyUUID,
-		Balance:               account.Balance.AmountCents(),
-		AvailableBalance:      account.AvailableBalance.AmountCents(),
-		OverdraftLimit:        account.OverdraftLimit.AmountCents(),
-		OverdraftRate:         account.OverdraftRate,
-		BalanceUpdatedAt:      &account.BalanceUpdatedAt,
-		Version:               account.Version,
-		CreatedAt:             account.CreatedAt,
-		UpdatedAt:             account.UpdatedAt,
+		Balance:               account.Balance().AmountCents(),
+		AvailableBalance:      account.AvailableBalance().AmountCents(),
+		OverdraftLimit:        account.OverdraftLimit().AmountCents(),
+		OverdraftRate:         account.OverdraftRate(),
+		BalanceUpdatedAt:      &balanceUpdatedAt,
+		Version:               account.Version(),
+		CreatedAt:             account.CreatedAt(),
+		UpdatedAt:             account.UpdatedAt(),
 		CreatedBy:             auditUser,
 		UpdatedBy:             auditUser,
 	}, nil
 }
 
-// toDomain converts database entity to domain model
+// toDomain converts database entity to domain model using the builder pattern.
 // Note: OverdraftEnabled is derived from OverdraftLimit > 0
-func toDomain(entity *CurrentAccountEntity) (*domain.CurrentAccount, error) {
+func toDomain(entity *CurrentAccountEntity) (domain.CurrentAccount, error) {
 	// Use NewMoney constructor - errors indicate data corruption
 	balance, err := domain.NewMoney(entity.Currency, entity.Balance)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create balance from database: %w", err)
+		return domain.CurrentAccount{}, fmt.Errorf("failed to create balance from database: %w", err)
 	}
 
 	availableBalance, err := domain.NewMoney(entity.Currency, entity.AvailableBalance)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create available balance from database: %w", err)
+		return domain.CurrentAccount{}, fmt.Errorf("failed to create available balance from database: %w", err)
 	}
 
 	overdraftLimit, err := domain.NewMoney(entity.Currency, entity.OverdraftLimit)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create overdraft limit from database: %w", err)
+		return domain.CurrentAccount{}, fmt.Errorf("failed to create overdraft limit from database: %w", err)
 	}
 
 	// Derive overdraft enabled from limit > 0
@@ -451,22 +450,23 @@ func toDomain(entity *CurrentAccountEntity) (*domain.CurrentAccount, error) {
 		balanceUpdatedAt = *entity.BalanceUpdatedAt
 	}
 
-	return &domain.CurrentAccount{
-		ID:                    entity.ID,
-		AccountID:             entity.AccountID,             // Business account identifier
-		AccountIdentification: entity.AccountIdentification, // IBAN stored in account_identification
-		PartyID:               entity.PartyID.String(),
-		Balance:               balance,
-		AvailableBalance:      availableBalance,
-		Status:                domain.AccountStatus(entity.Status),
-		OverdraftLimit:        overdraftLimit,
-		OverdraftEnabled:      overdraftEnabled,
-		OverdraftRate:         entity.OverdraftRate,
-		BalanceUpdatedAt:      balanceUpdatedAt,
-		Version:               entity.Version,
-		CreatedAt:             entity.CreatedAt,
-		UpdatedAt:             entity.UpdatedAt,
-	}, nil
+	// Use builder pattern to construct immutable domain model
+	return domain.NewCurrentAccountBuilder().
+		WithID(entity.ID).
+		WithAccountID(entity.AccountID).
+		WithAccountIdentification(entity.AccountIdentification).
+		WithPartyID(entity.PartyID.String()).
+		WithBalance(balance).
+		WithAvailableBalance(availableBalance).
+		WithStatus(domain.AccountStatus(entity.Status)).
+		WithOverdraftLimit(overdraftLimit).
+		WithOverdraftEnabled(overdraftEnabled).
+		WithOverdraftRate(entity.OverdraftRate).
+		WithBalanceUpdatedAt(balanceUpdatedAt).
+		WithVersion(entity.Version).
+		WithCreatedAt(entity.CreatedAt).
+		WithUpdatedAt(entity.UpdatedAt).
+		Build(), nil
 }
 
 // isDuplicateKeyError checks if the error is a PostgreSQL unique constraint violation.

--- a/services/current-account/adapters/persistence/repository.go
+++ b/services/current-account/adapters/persistence/repository.go
@@ -151,9 +151,11 @@ func (r *Repository) Save(ctx context.Context, account domain.CurrentAccount) er
 			entity.CreatedAt = existing.CreatedAt
 			entity.CreatedBy = existing.CreatedBy
 
-			// Optimistic locking: only update if version matches, then increment
+			// Optimistic locking: domain already incremented version during mutation.
+			// Check against original version (entity.Version - 1), then set to new version.
+			originalVersion := entity.Version - 1
 			updateResult := tx.Model(&CurrentAccountEntity{}).
-				Where("account_identification = ? AND version = ?", entity.AccountIdentification, entity.Version).
+				Where("account_identification = ? AND version = ?", entity.AccountIdentification, originalVersion).
 				Updates(map[string]interface{}{
 					"balance":            entity.Balance,
 					"available_balance":  entity.AvailableBalance,
@@ -161,7 +163,7 @@ func (r *Repository) Save(ctx context.Context, account domain.CurrentAccount) er
 					"overdraft_limit":    entity.OverdraftLimit,
 					"overdraft_rate":     entity.OverdraftRate,
 					"balance_updated_at": entity.BalanceUpdatedAt,
-					"version":            entity.Version + 1,
+					"version":            entity.Version,
 					"updated_at":         entity.UpdatedAt,
 					"updated_by":         entity.UpdatedBy,
 				})

--- a/services/current-account/adapters/persistence/repository_contract_test.go
+++ b/services/current-account/adapters/persistence/repository_contract_test.go
@@ -48,8 +48,8 @@ func TestFindByID_UsesAccountID(t *testing.T) {
 	// FindByID should find by account_id (ACC-xxx), NOT account_identification (IBAN)
 	found, err := repo.FindByID(ctx, accountID)
 	require.NoError(t, err, "FindByID with account_id should succeed")
-	assert.Equal(t, accountID, found.AccountID)
-	assert.Equal(t, accountIdentification, found.AccountIdentification)
+	assert.Equal(t, accountID, found.AccountID())
+	assert.Equal(t, accountIdentification, found.AccountIdentification())
 
 	// FindByID with IBAN should NOT find the account (it's not searching that column)
 	_, err = repo.FindByID(ctx, accountIdentification)
@@ -78,7 +78,7 @@ func TestFindByIDForUpdate_UsesAccountID(t *testing.T) {
 	// FindByIDForUpdate should find by account_id
 	found, err := repo.FindByIDForUpdate(ctx, accountID)
 	require.NoError(t, err, "FindByIDForUpdate with account_id should succeed")
-	assert.Equal(t, accountID, found.AccountID)
+	assert.Equal(t, accountID, found.AccountID())
 }
 
 // TestDelete_UsesAccountID validates Delete uses the correct column.

--- a/services/current-account/adapters/persistence/repository_test.go
+++ b/services/current-account/adapters/persistence/repository_test.go
@@ -90,8 +90,8 @@ func TestSaveNewAccount(t *testing.T) {
 		t.Fatalf("FindByID failed: %v", err)
 	}
 
-	if retrieved.AccountID != accountID {
-		t.Errorf("Expected %s, got %s", accountID, retrieved.AccountID)
+	if retrieved.AccountID() != accountID {
+		t.Errorf("Expected %s, got %s", accountID, retrieved.AccountID())
 	}
 }
 
@@ -115,7 +115,7 @@ func TestSaveNewAccount_InitialVersion(t *testing.T) {
 	retrieved, err := repo.FindByID(ctx, accountID)
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(1), retrieved.Version, "New account should have version 1")
+	assert.Equal(t, int64(1), retrieved.Version(), "New account should have version 1")
 }
 
 func TestSaveUpdateExisting(t *testing.T) {
@@ -137,9 +137,9 @@ func TestSaveUpdateExisting(t *testing.T) {
 		t.Fatalf("Initial save failed: %v", err)
 	}
 
-	// Modify and save again
+	// Modify and save again (immutable: capture returned value)
 	depositMoney, _ := domain.NewMoney("GBP", 10000)
-	err = account.Deposit(depositMoney)
+	account, err = account.Deposit(depositMoney)
 	if err != nil {
 		t.Fatalf("Deposit failed: %v", err)
 	}
@@ -154,13 +154,13 @@ func TestSaveUpdateExisting(t *testing.T) {
 		t.Fatalf("FindByID failed: %v", err)
 	}
 
-	if retrieved.Balance.AmountCents() != 10000 {
-		t.Errorf("Expected balance 10000, got %d", retrieved.Balance.AmountCents())
+	if retrieved.Balance().AmountCents() != 10000 {
+		t.Errorf("Expected balance 10000, got %d", retrieved.Balance().AmountCents())
 	}
 
 	// Version should be incremented after update
-	if retrieved.Version != 2 {
-		t.Errorf("Expected version 2, got %d", retrieved.Version)
+	if retrieved.Version() != 2 {
+		t.Errorf("Expected version 2, got %d", retrieved.Version())
 	}
 }
 
@@ -200,11 +200,11 @@ func TestFindByIBAN(t *testing.T) {
 		t.Fatalf("FindByIBAN failed: %v", err)
 	}
 
-	if retrieved.AccountID != accountID {
-		t.Errorf("Expected AccountID %s, got %s", accountID, retrieved.AccountID)
+	if retrieved.AccountID() != accountID {
+		t.Errorf("Expected AccountID %s, got %s", accountID, retrieved.AccountID())
 	}
-	if retrieved.AccountIdentification != iban {
-		t.Errorf("Expected IBAN %s, got %s", iban, retrieved.AccountIdentification)
+	if retrieved.AccountIdentification() != iban {
+		t.Errorf("Expected IBAN %s, got %s", iban, retrieved.AccountIdentification())
 	}
 }
 
@@ -303,13 +303,14 @@ func TestOptimisticLocking(t *testing.T) {
 	}
 
 	// Both should have same version
-	if account2.Version != account3.Version {
-		t.Errorf("Expected same version, got %d and %d", account2.Version, account3.Version)
+	if account2.Version() != account3.Version() {
+		t.Errorf("Expected same version, got %d and %d", account2.Version(), account3.Version())
 	}
 
-	// First transaction modifies and saves successfully
+	// First transaction modifies and saves successfully (immutable: capture returned value)
 	deposit1, _ := domain.NewMoney("GBP", 5000)
-	if err := account2.Deposit(deposit1); err != nil {
+	account2, err = account2.Deposit(deposit1)
+	if err != nil {
 		t.Fatalf("Deposit failed: %v", err)
 	}
 
@@ -317,9 +318,10 @@ func TestOptimisticLocking(t *testing.T) {
 		t.Fatalf("First save failed: %v", err)
 	}
 
-	// Second transaction tries to save with stale version
+	// Second transaction tries to save with stale version (immutable: capture returned value)
 	deposit2, _ := domain.NewMoney("GBP", 10000)
-	if err := account3.Deposit(deposit2); err != nil {
+	account3, err = account3.Deposit(deposit2)
+	if err != nil {
 		t.Fatalf("Deposit failed: %v", err)
 	}
 
@@ -334,13 +336,13 @@ func TestOptimisticLocking(t *testing.T) {
 		t.Fatalf("Final FindByID failed: %v", err)
 	}
 
-	if final.Balance.AmountCents() != 5000 {
-		t.Errorf("Expected balance 5000, got %d", final.Balance.AmountCents())
+	if final.Balance().AmountCents() != 5000 {
+		t.Errorf("Expected balance 5000, got %d", final.Balance().AmountCents())
 	}
 
 	// Version should be incremented
-	if final.Version != 2 {
-		t.Errorf("Expected version 2, got %d", final.Version)
+	if final.Version() != 2 {
+		t.Errorf("Expected version 2, got %d", final.Version())
 	}
 }
 
@@ -550,7 +552,7 @@ func TestSave_UpdatePreservesCreatedByButUpdatesUpdatedBy(t *testing.T) {
 	user2 := "user-updater"
 	ctx2 := context.WithValue(ctx, auth.UserIDContextKey, user2)
 	depositMoney, _ := domain.NewMoney("GBP", 5000)
-	err = account.Deposit(depositMoney)
+	account, err = account.Deposit(depositMoney)
 	require.NoError(t, err)
 
 	err = repo.Save(ctx2, account)

--- a/services/current-account/domain/account.go
+++ b/services/current-account/domain/account.go
@@ -27,189 +27,393 @@ const (
 	AccountStatusClosed AccountStatus = "CLOSED"
 )
 
-// CurrentAccount represents a BIAN current account facility domain model
-// TODO(tech-debt-cleanup#7): Phase 2 - refactor to value semantics with value receivers
-// See docs/archive/immutability-audit.md for full refactoring plan
+// CurrentAccount represents a BIAN current account facility domain model.
+// This type is immutable: all fields are unexported and all methods return
+// new instances rather than mutating the receiver.
 type CurrentAccount struct {
-	ID                    uuid.UUID
-	AccountID             string
-	AccountIdentification string // IBAN
-	PartyID               string
-	Balance               Money
-	AvailableBalance      Money
-	Status                AccountStatus
-	OverdraftLimit        Money
-	OverdraftEnabled      bool
-	OverdraftRate         float64
-	BalanceUpdatedAt      time.Time
-	Version               int64
-	CreatedAt             time.Time
-	UpdatedAt             time.Time
+	id                    uuid.UUID
+	accountID             string
+	accountIdentification string // IBAN
+	partyID               string
+	balance               Money
+	availableBalance      Money
+	status                AccountStatus
+	overdraftLimit        Money
+	overdraftEnabled      bool
+	overdraftRate         float64
+	balanceUpdatedAt      time.Time
+	version               int64
+	createdAt             time.Time
+	updatedAt             time.Time
 }
 
-// NewCurrentAccount creates a new current account
-func NewCurrentAccount(accountID, iban, partyID, currency string) (*CurrentAccount, error) {
+// NewCurrentAccount creates a new current account with the given parameters.
+// Returns a value type (not pointer) following immutability principles.
+func NewCurrentAccount(accountID, iban, partyID, currency string) (CurrentAccount, error) {
 	now := time.Now()
 	zeroMoney, err := NewMoney(currency, 0)
 	if err != nil {
-		return nil, err
+		return CurrentAccount{}, err
 	}
 
-	return &CurrentAccount{
-		ID:                    uuid.New(),
-		AccountID:             accountID,
-		AccountIdentification: iban,
-		PartyID:               partyID,
-		Balance:               zeroMoney,
-		AvailableBalance:      zeroMoney,
-		Status:                AccountStatusActive,
-		OverdraftLimit:        zeroMoney,
-		OverdraftEnabled:      false,
-		OverdraftRate:         0,
-		BalanceUpdatedAt:      now,
-		Version:               1,
-		CreatedAt:             now,
-		UpdatedAt:             now,
+	return CurrentAccount{
+		id:                    uuid.New(),
+		accountID:             accountID,
+		accountIdentification: iban,
+		partyID:               partyID,
+		balance:               zeroMoney,
+		availableBalance:      zeroMoney,
+		status:                AccountStatusActive,
+		overdraftLimit:        zeroMoney,
+		overdraftEnabled:      false,
+		overdraftRate:         0,
+		balanceUpdatedAt:      now,
+		version:               1,
+		createdAt:             now,
+		updatedAt:             now,
 	}, nil
 }
 
-// Deposit adds funds to the account
-func (a *CurrentAccount) Deposit(amount Money) error {
+// Deposit adds funds to the account and returns a new account with the updated balance.
+// The original account is not modified.
+func (a CurrentAccount) Deposit(amount Money) (CurrentAccount, error) {
 	if !amount.IsPositive() {
-		return ErrInvalidAmount
+		return CurrentAccount{}, ErrInvalidAmount
 	}
 
-	if a.Status == AccountStatusFrozen {
-		return ErrAccountFrozen
+	if a.status == AccountStatusFrozen {
+		return CurrentAccount{}, ErrAccountFrozen
 	}
 
-	if a.Status == AccountStatusClosed {
-		return ErrAccountClosed
+	if a.status == AccountStatusClosed {
+		return CurrentAccount{}, ErrAccountClosed
 	}
 
-	if amount.Currency() != a.Balance.Currency() {
-		return ErrCurrencyMismatch
+	if amount.Currency() != a.balance.Currency() {
+		return CurrentAccount{}, ErrCurrencyMismatch
 	}
 
 	// Use immutable Add method
-	newBalance, err := a.Balance.Add(amount)
+	newBalance, err := a.balance.Add(amount)
 	if err != nil {
-		return err
+		return CurrentAccount{}, err
 	}
-
-	a.Balance = newBalance
-	a.calculateAvailableBalance()
 
 	now := time.Now()
-	a.BalanceUpdatedAt = now
-	a.UpdatedAt = now
+	newAvailableBalance := calculateAvailableBalance(newBalance, a.overdraftLimit, a.overdraftEnabled)
 
-	return nil
+	return CurrentAccount{
+		id:                    a.id,
+		accountID:             a.accountID,
+		accountIdentification: a.accountIdentification,
+		partyID:               a.partyID,
+		balance:               newBalance,
+		availableBalance:      newAvailableBalance,
+		status:                a.status,
+		overdraftLimit:        a.overdraftLimit,
+		overdraftEnabled:      a.overdraftEnabled,
+		overdraftRate:         a.overdraftRate,
+		balanceUpdatedAt:      now,
+		version:               a.version + 1,
+		createdAt:             a.createdAt,
+		updatedAt:             now,
+	}, nil
 }
 
-// Withdraw removes funds from the account
-func (a *CurrentAccount) Withdraw(amount Money) error {
+// Withdraw removes funds from the account and returns a new account with the updated balance.
+// The original account is not modified.
+func (a CurrentAccount) Withdraw(amount Money) (CurrentAccount, error) {
 	if !amount.IsPositive() {
-		return ErrInvalidAmount
+		return CurrentAccount{}, ErrInvalidAmount
 	}
 
-	if a.Status == AccountStatusFrozen {
-		return ErrAccountFrozen
+	if a.status == AccountStatusFrozen {
+		return CurrentAccount{}, ErrAccountFrozen
 	}
 
-	if a.Status == AccountStatusClosed {
-		return ErrAccountClosed
+	if a.status == AccountStatusClosed {
+		return CurrentAccount{}, ErrAccountClosed
 	}
 
-	if amount.Currency() != a.Balance.Currency() {
-		return ErrCurrencyMismatch
+	if amount.Currency() != a.balance.Currency() {
+		return CurrentAccount{}, ErrCurrencyMismatch
 	}
 
 	// Check if sufficient funds (including overdraft)
-	cmp, _ := amount.Compare(a.AvailableBalance) // Same currency already verified above
+	cmp, _ := amount.Compare(a.availableBalance) // Same currency already verified above
 	if cmp > 0 {
-		return ErrInsufficientFunds
+		return CurrentAccount{}, ErrInsufficientFunds
 	}
 
 	// Use immutable Subtract method
-	newBalance, err := a.Balance.Subtract(amount)
+	newBalance, err := a.balance.Subtract(amount)
 	if err != nil {
-		return err
+		return CurrentAccount{}, err
 	}
 
-	a.Balance = newBalance
-	a.calculateAvailableBalance()
-
 	now := time.Now()
-	a.BalanceUpdatedAt = now
-	a.UpdatedAt = now
+	newAvailableBalance := calculateAvailableBalance(newBalance, a.overdraftLimit, a.overdraftEnabled)
 
-	return nil
+	return CurrentAccount{
+		id:                    a.id,
+		accountID:             a.accountID,
+		accountIdentification: a.accountIdentification,
+		partyID:               a.partyID,
+		balance:               newBalance,
+		availableBalance:      newAvailableBalance,
+		status:                a.status,
+		overdraftLimit:        a.overdraftLimit,
+		overdraftEnabled:      a.overdraftEnabled,
+		overdraftRate:         a.overdraftRate,
+		balanceUpdatedAt:      now,
+		version:               a.version + 1,
+		createdAt:             a.createdAt,
+		updatedAt:             now,
+	}, nil
 }
 
-// calculateAvailableBalance updates available balance based on overdraft settings
-func (a *CurrentAccount) calculateAvailableBalance() {
-	if a.OverdraftEnabled {
+// calculateAvailableBalance is a pure function that computes available balance
+// based on current balance and overdraft settings.
+func calculateAvailableBalance(balance, overdraftLimit Money, overdraftEnabled bool) Money {
+	if overdraftEnabled {
 		// Use immutable Add method; should never fail if SetOverdraftLimit validated correctly
-		newAvail, err := a.Balance.Add(a.OverdraftLimit)
+		newAvail, err := balance.Add(overdraftLimit)
 		if err != nil {
 			// This indicates a bug: either currency mismatch or overflow that bypassed validation
 			panic("BUG: OverdraftLimit currency mismatch or overflow detected in calculateAvailableBalance: " + err.Error())
 		}
-		a.AvailableBalance = newAvail
-	} else {
-		a.AvailableBalance = a.Balance
+		return newAvail
+	}
+	return balance
+}
+
+// withStatus returns a new account with the given status.
+// This is a helper method to reduce duplication in status transition methods.
+func (a CurrentAccount) withStatus(status AccountStatus) CurrentAccount {
+	return CurrentAccount{
+		id:                    a.id,
+		accountID:             a.accountID,
+		accountIdentification: a.accountIdentification,
+		partyID:               a.partyID,
+		balance:               a.balance,
+		availableBalance:      a.availableBalance,
+		status:                status,
+		overdraftLimit:        a.overdraftLimit,
+		overdraftEnabled:      a.overdraftEnabled,
+		overdraftRate:         a.overdraftRate,
+		balanceUpdatedAt:      a.balanceUpdatedAt,
+		version:               a.version + 1,
+		createdAt:             a.createdAt,
+		updatedAt:             time.Now(),
 	}
 }
 
-// Freeze suspends the account
-func (a *CurrentAccount) Freeze() error {
-	if a.Status == AccountStatusClosed {
-		return ErrInvalidStatusTransition
+// Freeze suspends the account and returns a new account with frozen status.
+// The original account is not modified.
+func (a CurrentAccount) Freeze() (CurrentAccount, error) {
+	if a.status == AccountStatusClosed {
+		return CurrentAccount{}, ErrInvalidStatusTransition
 	}
 
-	a.Status = AccountStatusFrozen
-	a.UpdatedAt = time.Now()
-	return nil
+	return a.withStatus(AccountStatusFrozen), nil
 }
 
-// Activate restores the account to active status
-func (a *CurrentAccount) Activate() error {
-	if a.Status == AccountStatusClosed {
-		return ErrInvalidStatusTransition
+// Activate restores the account to active status and returns a new account.
+// The original account is not modified.
+func (a CurrentAccount) Activate() (CurrentAccount, error) {
+	if a.status == AccountStatusClosed {
+		return CurrentAccount{}, ErrInvalidStatusTransition
 	}
 
-	a.Status = AccountStatusActive
-	a.UpdatedAt = time.Now()
-	return nil
+	return a.withStatus(AccountStatusActive), nil
 }
 
-// Close permanently closes the account
-func (a *CurrentAccount) Close() error {
-	a.Status = AccountStatusClosed
-	a.UpdatedAt = time.Now()
-	return nil
+// Close permanently closes the account and returns a new account with closed status.
+// The original account is not modified.
+func (a CurrentAccount) Close() (CurrentAccount, error) {
+	return a.withStatus(AccountStatusClosed), nil
 }
 
-// SetOverdraftLimit configures the overdraft facility
-func (a *CurrentAccount) SetOverdraftLimit(limit Money, rate float64, enabled bool) error {
-	if limit.Currency() != a.Balance.Currency() {
-		return ErrCurrencyMismatch
+// SetOverdraftLimit configures the overdraft facility and returns a new account.
+// The original account is not modified.
+func (a CurrentAccount) SetOverdraftLimit(limit Money, rate float64, enabled bool) (CurrentAccount, error) {
+	if limit.Currency() != a.balance.Currency() {
+		return CurrentAccount{}, ErrCurrencyMismatch
 	}
 
 	// Validate that Balance + OverdraftLimit won't overflow if enabled
 	if enabled {
-		_, err := a.Balance.Add(limit)
+		_, err := a.balance.Add(limit)
 		if err != nil {
-			return err // Return overflow error to caller
+			return CurrentAccount{}, err // Return overflow error to caller
 		}
 	}
 
-	a.OverdraftLimit = limit
-	a.OverdraftRate = rate
-	a.OverdraftEnabled = enabled
-	a.calculateAvailableBalance()
-	a.UpdatedAt = time.Now()
+	newAvailableBalance := calculateAvailableBalance(a.balance, limit, enabled)
 
-	return nil
+	return CurrentAccount{
+		id:                    a.id,
+		accountID:             a.accountID,
+		accountIdentification: a.accountIdentification,
+		partyID:               a.partyID,
+		balance:               a.balance,
+		availableBalance:      newAvailableBalance,
+		status:                a.status,
+		overdraftLimit:        limit,
+		overdraftEnabled:      enabled,
+		overdraftRate:         rate,
+		balanceUpdatedAt:      a.balanceUpdatedAt,
+		version:               a.version + 1,
+		createdAt:             a.createdAt,
+		updatedAt:             time.Now(),
+	}, nil
+}
+
+// Accessor methods for unexported fields.
+// These return copies of values, preserving immutability.
+
+// ID returns the internal UUID of the account.
+func (a CurrentAccount) ID() uuid.UUID { return a.id }
+
+// AccountID returns the business account identifier (e.g., "ACC-xxx").
+func (a CurrentAccount) AccountID() string { return a.accountID }
+
+// AccountIdentification returns the IBAN.
+func (a CurrentAccount) AccountIdentification() string { return a.accountIdentification }
+
+// PartyID returns the party (customer) identifier.
+func (a CurrentAccount) PartyID() string { return a.partyID }
+
+// Balance returns the current balance.
+func (a CurrentAccount) Balance() Money { return a.balance }
+
+// AvailableBalance returns the available balance (including overdraft if enabled).
+func (a CurrentAccount) AvailableBalance() Money { return a.availableBalance }
+
+// Status returns the account status.
+func (a CurrentAccount) Status() AccountStatus { return a.status }
+
+// OverdraftLimit returns the configured overdraft limit.
+func (a CurrentAccount) OverdraftLimit() Money { return a.overdraftLimit }
+
+// OverdraftEnabled returns whether overdraft is enabled.
+func (a CurrentAccount) OverdraftEnabled() bool { return a.overdraftEnabled }
+
+// OverdraftRate returns the overdraft interest rate.
+func (a CurrentAccount) OverdraftRate() float64 { return a.overdraftRate }
+
+// BalanceUpdatedAt returns when the balance was last updated.
+func (a CurrentAccount) BalanceUpdatedAt() time.Time { return a.balanceUpdatedAt }
+
+// Version returns the optimistic locking version.
+func (a CurrentAccount) Version() int64 { return a.version }
+
+// CreatedAt returns when the account was created.
+func (a CurrentAccount) CreatedAt() time.Time { return a.createdAt }
+
+// UpdatedAt returns when the account was last updated.
+func (a CurrentAccount) UpdatedAt() time.Time { return a.updatedAt }
+
+// Builder pattern for reconstructing accounts from persistence layer.
+// This is needed because the persistence layer needs to set all fields
+// when loading from the database.
+
+// CurrentAccountBuilder provides a fluent API for constructing CurrentAccount instances.
+// This is primarily used by the persistence layer to reconstruct accounts from database rows.
+type CurrentAccountBuilder struct {
+	account CurrentAccount
+}
+
+// NewCurrentAccountBuilder creates a new builder instance.
+func NewCurrentAccountBuilder() *CurrentAccountBuilder {
+	return &CurrentAccountBuilder{}
+}
+
+// WithID sets the account UUID.
+func (b *CurrentAccountBuilder) WithID(id uuid.UUID) *CurrentAccountBuilder {
+	b.account.id = id
+	return b
+}
+
+// WithAccountID sets the business account identifier.
+func (b *CurrentAccountBuilder) WithAccountID(accountID string) *CurrentAccountBuilder {
+	b.account.accountID = accountID
+	return b
+}
+
+// WithAccountIdentification sets the IBAN.
+func (b *CurrentAccountBuilder) WithAccountIdentification(iban string) *CurrentAccountBuilder {
+	b.account.accountIdentification = iban
+	return b
+}
+
+// WithPartyID sets the party identifier.
+func (b *CurrentAccountBuilder) WithPartyID(partyID string) *CurrentAccountBuilder {
+	b.account.partyID = partyID
+	return b
+}
+
+// WithBalance sets the balance.
+func (b *CurrentAccountBuilder) WithBalance(balance Money) *CurrentAccountBuilder {
+	b.account.balance = balance
+	return b
+}
+
+// WithAvailableBalance sets the available balance.
+func (b *CurrentAccountBuilder) WithAvailableBalance(availableBalance Money) *CurrentAccountBuilder {
+	b.account.availableBalance = availableBalance
+	return b
+}
+
+// WithStatus sets the account status.
+func (b *CurrentAccountBuilder) WithStatus(status AccountStatus) *CurrentAccountBuilder {
+	b.account.status = status
+	return b
+}
+
+// WithOverdraftLimit sets the overdraft limit.
+func (b *CurrentAccountBuilder) WithOverdraftLimit(limit Money) *CurrentAccountBuilder {
+	b.account.overdraftLimit = limit
+	return b
+}
+
+// WithOverdraftEnabled sets whether overdraft is enabled.
+func (b *CurrentAccountBuilder) WithOverdraftEnabled(enabled bool) *CurrentAccountBuilder {
+	b.account.overdraftEnabled = enabled
+	return b
+}
+
+// WithOverdraftRate sets the overdraft interest rate.
+func (b *CurrentAccountBuilder) WithOverdraftRate(rate float64) *CurrentAccountBuilder {
+	b.account.overdraftRate = rate
+	return b
+}
+
+// WithBalanceUpdatedAt sets when the balance was last updated.
+func (b *CurrentAccountBuilder) WithBalanceUpdatedAt(t time.Time) *CurrentAccountBuilder {
+	b.account.balanceUpdatedAt = t
+	return b
+}
+
+// WithVersion sets the optimistic locking version.
+func (b *CurrentAccountBuilder) WithVersion(version int64) *CurrentAccountBuilder {
+	b.account.version = version
+	return b
+}
+
+// WithCreatedAt sets when the account was created.
+func (b *CurrentAccountBuilder) WithCreatedAt(t time.Time) *CurrentAccountBuilder {
+	b.account.createdAt = t
+	return b
+}
+
+// WithUpdatedAt sets when the account was last updated.
+func (b *CurrentAccountBuilder) WithUpdatedAt(t time.Time) *CurrentAccountBuilder {
+	b.account.updatedAt = t
+	return b
+}
+
+// Build returns the constructed CurrentAccount.
+func (b *CurrentAccountBuilder) Build() CurrentAccount {
+	return b.account
 }

--- a/services/current-account/domain/account_test.go
+++ b/services/current-account/domain/account_test.go
@@ -3,6 +3,7 @@ package domain
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,11 +13,11 @@ func TestNewCurrentAccount(t *testing.T) {
 	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
 	require.NoError(t, err)
 
-	assert.Equal(t, "ACC-001", account.AccountID)
-	assert.Equal(t, "PARTY-001", account.PartyID)
-	assert.Equal(t, int64(0), account.Balance.AmountCents())
-	assert.Equal(t, CurrencyGBP, account.Balance.Currency())
-	assert.Equal(t, AccountStatusActive, account.Status)
+	assert.Equal(t, "ACC-001", account.AccountID())
+	assert.Equal(t, "PARTY-001", account.PartyID())
+	assert.Equal(t, int64(0), account.Balance().AmountCents())
+	assert.Equal(t, CurrencyGBP, account.Balance().Currency())
+	assert.Equal(t, AccountStatusActive, account.Status())
 }
 
 func TestDeposit(t *testing.T) {
@@ -52,22 +53,32 @@ func TestDeposit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
-			require.NoError(t, err)
-			// Set initial balance using immutable Money
-			account.Balance, _ = NewMoney("GBP", tt.initialBal)
-			account.AvailableBalance, _ = NewMoney("GBP", tt.initialBal)
+			// Build account with initial balance using builder
+			initialBalance, _ := NewMoney("GBP", tt.initialBal)
+			account := NewCurrentAccountBuilder().
+				WithAccountID("ACC-001").
+				WithAccountIdentification("GB82WEST12345698765432").
+				WithPartyID("PARTY-001").
+				WithBalance(initialBalance).
+				WithAvailableBalance(initialBalance).
+				WithStatus(AccountStatusActive).
+				WithVersion(1).
+				Build()
 
 			depositMoney, _ := NewMoney("GBP", tt.depositAmt)
-			err = account.Deposit(depositMoney)
+			updatedAccount, err := account.Deposit(depositMoney)
 
 			if tt.wantErr {
 				assert.Error(t, err)
+				// Original account should be unchanged on error
+				assert.Equal(t, tt.initialBal, account.Balance().AmountCents())
 			} else {
 				assert.NoError(t, err)
+				// Updated account should have new balance
+				assert.Equal(t, tt.wantBalance, updatedAccount.Balance().AmountCents())
+				// Original account should be unchanged (immutability)
+				assert.Equal(t, tt.initialBal, account.Balance().AmountCents())
 			}
-
-			assert.Equal(t, tt.wantBalance, account.Balance.AmountCents())
 		})
 	}
 }
@@ -75,10 +86,10 @@ func TestDeposit(t *testing.T) {
 func TestDepositWhenFrozen(t *testing.T) {
 	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
 	require.NoError(t, err)
-	_ = account.Freeze()
+	account, _ = account.Freeze()
 
 	depositMoney, _ := NewMoney("GBP", 1000)
-	err = account.Deposit(depositMoney)
+	_, err = account.Deposit(depositMoney)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrAccountFrozen)
@@ -87,10 +98,10 @@ func TestDepositWhenFrozen(t *testing.T) {
 func TestDepositWhenClosed(t *testing.T) {
 	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
 	require.NoError(t, err)
-	_ = account.Close()
+	account, _ = account.Close()
 
 	depositMoney, _ := NewMoney("GBP", 1000)
-	err = account.Deposit(depositMoney)
+	_, err = account.Deposit(depositMoney)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrAccountClosed)
@@ -131,45 +142,66 @@ func TestWithdraw(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
-			require.NoError(t, err)
-			account.Balance, _ = NewMoney("GBP", tt.initialBal)
-			account.AvailableBalance, _ = NewMoney("GBP", tt.initialBal)
+			// Build account with initial balance using builder
+			initialBalance, _ := NewMoney("GBP", tt.initialBal)
+			account := NewCurrentAccountBuilder().
+				WithAccountID("ACC-001").
+				WithAccountIdentification("GB82WEST12345698765432").
+				WithPartyID("PARTY-001").
+				WithBalance(initialBalance).
+				WithAvailableBalance(initialBalance).
+				WithStatus(AccountStatusActive).
+				WithVersion(1).
+				Build()
 
 			withdrawMoney, _ := NewMoney("GBP", tt.withdrawAmt)
-			err = account.Withdraw(withdrawMoney)
+			updatedAccount, err := account.Withdraw(withdrawMoney)
 
 			if tt.wantErr {
 				assert.Error(t, err)
+				// Original account should be unchanged on error
+				assert.Equal(t, tt.initialBal, account.Balance().AmountCents())
 			} else {
 				assert.NoError(t, err)
+				// Updated account should have new balance
+				assert.Equal(t, tt.wantBalance, updatedAccount.Balance().AmountCents())
+				// Original account should be unchanged (immutability)
+				assert.Equal(t, tt.initialBal, account.Balance().AmountCents())
 			}
 
 			if tt.expectedError != nil {
 				assert.ErrorIs(t, err, tt.expectedError)
 			}
-
-			assert.Equal(t, tt.wantBalance, account.Balance.AmountCents())
 		})
 	}
 }
 
 func TestWithdrawWithOverdraft(t *testing.T) {
-	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
-	require.NoError(t, err)
-	account.Balance, _ = NewMoney("GBP", 1000)
+	// Build account with initial balance using builder
+	initialBalance, _ := NewMoney("GBP", 1000)
+	zeroMoney, _ := NewMoney("GBP", 0)
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("PARTY-001").
+		WithBalance(initialBalance).
+		WithAvailableBalance(initialBalance).
+		WithOverdraftLimit(zeroMoney).
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		Build()
 
 	// Set overdraft limit of £500
 	overdraftLimit, _ := NewMoney("GBP", 500)
-	err = account.SetOverdraftLimit(overdraftLimit, 19.9, true)
+	account, err := account.SetOverdraftLimit(overdraftLimit, 19.9, true)
 	assert.NoError(t, err)
 
 	// Should be able to withdraw £1200 (balance + overdraft)
 	withdrawMoney, _ := NewMoney("GBP", 1200)
-	err = account.Withdraw(withdrawMoney)
+	updatedAccount, err := account.Withdraw(withdrawMoney)
 	assert.NoError(t, err)
 
-	assert.Equal(t, int64(-200), account.Balance.AmountCents())
+	assert.Equal(t, int64(-200), updatedAccount.Balance().AmountCents())
 }
 
 func TestStatusTransitions(t *testing.T) {
@@ -177,39 +209,53 @@ func TestStatusTransitions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Active -> Frozen
-	err = account.Freeze()
+	account, err = account.Freeze()
 	assert.NoError(t, err)
-	assert.Equal(t, AccountStatusFrozen, account.Status)
+	assert.Equal(t, AccountStatusFrozen, account.Status())
 
 	// Frozen -> Active
-	err = account.Activate()
+	account, err = account.Activate()
 	assert.NoError(t, err)
-	assert.Equal(t, AccountStatusActive, account.Status)
+	assert.Equal(t, AccountStatusActive, account.Status())
 
 	// Active -> Closed
-	err = account.Close()
+	account, err = account.Close()
 	assert.NoError(t, err)
-	assert.Equal(t, AccountStatusClosed, account.Status)
+	assert.Equal(t, AccountStatusClosed, account.Status())
 
 	// Closed -> Active (should fail)
-	err = account.Activate()
+	_, err = account.Activate()
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrInvalidStatusTransition)
 }
 
 func TestSetOverdraftLimit(t *testing.T) {
-	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
-	require.NoError(t, err)
-	account.Balance, _ = NewMoney("GBP", 1000)
+	// Build account with initial balance using builder
+	initialBalance, _ := NewMoney("GBP", 1000)
+	zeroMoney, _ := NewMoney("GBP", 0)
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("PARTY-001").
+		WithBalance(initialBalance).
+		WithAvailableBalance(initialBalance).
+		WithOverdraftLimit(zeroMoney).
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		Build()
 
 	overdraftLimit, _ := NewMoney("GBP", 500)
-	err = account.SetOverdraftLimit(overdraftLimit, 19.9, true)
+	updatedAccount, err := account.SetOverdraftLimit(overdraftLimit, 19.9, true)
 	assert.NoError(t, err)
 
-	assert.Equal(t, int64(500), account.OverdraftLimit.AmountCents())
-	assert.Equal(t, 19.9, account.OverdraftRate)
-	assert.True(t, account.OverdraftEnabled)
-	assert.Equal(t, int64(1500), account.AvailableBalance.AmountCents())
+	assert.Equal(t, int64(500), updatedAccount.OverdraftLimit().AmountCents())
+	assert.Equal(t, 19.9, updatedAccount.OverdraftRate())
+	assert.True(t, updatedAccount.OverdraftEnabled())
+	assert.Equal(t, int64(1500), updatedAccount.AvailableBalance().AmountCents())
+
+	// Original account should be unchanged (immutability)
+	assert.Equal(t, int64(0), account.OverdraftLimit().AmountCents())
+	assert.False(t, account.OverdraftEnabled())
 }
 
 func TestCurrencyMismatch(t *testing.T) {
@@ -217,7 +263,7 @@ func TestCurrencyMismatch(t *testing.T) {
 	require.NoError(t, err)
 
 	depositMoney, _ := NewMoney("USD", 1000)
-	err = account.Deposit(depositMoney)
+	_, err = account.Deposit(depositMoney)
 
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrCurrencyMismatch)
@@ -265,63 +311,254 @@ func TestNewCurrentAccount_InvalidCurrency_ReturnsError(t *testing.T) {
 // operations like int64 did. Overflow is now checked when converting to minor units.
 
 func TestSetOverdraftLimit_LargeValues(t *testing.T) {
-	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
-	require.NoError(t, err)
-
-	// Set a large balance (in minor units - cents/pence)
+	// Build account with large balance using builder
 	largeBalance, err := NewMoney("GBP", 1000000000000) // 10 billion cents = 100 million GBP
 	require.NoError(t, err)
-	account.Balance = largeBalance
-	account.AvailableBalance = largeBalance
+	zeroMoney, _ := NewMoney("GBP", 0)
+
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("PARTY-001").
+		WithBalance(largeBalance).
+		WithAvailableBalance(largeBalance).
+		WithOverdraftLimit(zeroMoney).
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		Build()
 
 	// Set overdraft
 	overdraftLimit, err := NewMoney("GBP", 100000000000) // 1 billion cents
 	require.NoError(t, err)
 
-	err = account.SetOverdraftLimit(overdraftLimit, 0.1, true)
+	updatedAccount, err := account.SetOverdraftLimit(overdraftLimit, 0.1, true)
 	assert.NoError(t, err, "Large values should be handled correctly")
 
 	// Available balance should be sum
-	assert.Equal(t, int64(1100000000000), account.AvailableBalance.AmountCents())
+	assert.Equal(t, int64(1100000000000), updatedAccount.AvailableBalance().AmountCents())
 }
 
 func TestSetOverdraftLimit_DisabledDoesNotAddToAvailable(t *testing.T) {
-	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
-	require.NoError(t, err)
-
-	// Set balance
+	// Build account with balance using builder
 	balance, err := NewMoney("GBP", 100000)
 	require.NoError(t, err)
-	account.Balance = balance
-	account.AvailableBalance = balance
+	zeroMoney, _ := NewMoney("GBP", 0)
+
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("PARTY-001").
+		WithBalance(balance).
+		WithAvailableBalance(balance).
+		WithOverdraftLimit(zeroMoney).
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		Build()
 
 	// Set overdraft disabled
 	overdraftLimit, err := NewMoney("GBP", 50000)
 	require.NoError(t, err)
 
-	err = account.SetOverdraftLimit(overdraftLimit, 0.1, false)
+	updatedAccount, err := account.SetOverdraftLimit(overdraftLimit, 0.1, false)
 	assert.NoError(t, err)
 
 	// Available balance should NOT include overdraft when disabled
-	assert.Equal(t, int64(100000), account.AvailableBalance.AmountCents())
+	assert.Equal(t, int64(100000), updatedAccount.AvailableBalance().AmountCents())
 }
 
 // Tests for large deposits
 func TestDeposit_LargeValues(t *testing.T) {
-	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
-	require.NoError(t, err)
-
-	// Set initial balance
+	// Build account with large balance using builder
 	balance, err := NewMoney("GBP", 1000000000000)
 	require.NoError(t, err)
-	account.Balance = balance
-	account.AvailableBalance = balance
+	zeroMoney, _ := NewMoney("GBP", 0)
+
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("PARTY-001").
+		WithBalance(balance).
+		WithAvailableBalance(balance).
+		WithOverdraftLimit(zeroMoney).
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		Build()
 
 	// Large deposit
 	deposit, err := NewMoney("GBP", 1000000000000)
 	require.NoError(t, err)
 
-	err = account.Deposit(deposit)
+	updatedAccount, err := account.Deposit(deposit)
 	assert.NoError(t, err, "Large deposits should be handled correctly")
-	assert.Equal(t, int64(2000000000000), account.Balance.AmountCents())
+	assert.Equal(t, int64(2000000000000), updatedAccount.Balance().AmountCents())
+}
+
+// Immutability tests
+
+func TestImmutability_DepositDoesNotModifyOriginal(t *testing.T) {
+	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
+	require.NoError(t, err)
+
+	originalBalance := account.Balance().AmountCents()
+	originalVersion := account.Version()
+
+	deposit, _ := NewMoney("GBP", 10000)
+	_, err = account.Deposit(deposit)
+	require.NoError(t, err)
+
+	// Original should be unchanged
+	assert.Equal(t, originalBalance, account.Balance().AmountCents())
+	assert.Equal(t, originalVersion, account.Version())
+}
+
+func TestImmutability_WithdrawDoesNotModifyOriginal(t *testing.T) {
+	balance, _ := NewMoney("GBP", 10000)
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithBalance(balance).
+		WithAvailableBalance(balance).
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		Build()
+
+	originalBalance := account.Balance().AmountCents()
+	originalVersion := account.Version()
+
+	withdrawal, _ := NewMoney("GBP", 5000)
+	_, err := account.Withdraw(withdrawal)
+	require.NoError(t, err)
+
+	// Original should be unchanged
+	assert.Equal(t, originalBalance, account.Balance().AmountCents())
+	assert.Equal(t, originalVersion, account.Version())
+}
+
+func TestImmutability_FreezeDoesNotModifyOriginal(t *testing.T) {
+	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
+	require.NoError(t, err)
+
+	originalStatus := account.Status()
+
+	_, err = account.Freeze()
+	require.NoError(t, err)
+
+	// Original should be unchanged
+	assert.Equal(t, originalStatus, account.Status())
+}
+
+func TestImmutability_ChainedOperations(t *testing.T) {
+	// Create initial account
+	original, _ := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
+
+	// Perform multiple operations, capturing each result
+	deposit1, _ := NewMoney("GBP", 10000)
+	afterDeposit1, _ := original.Deposit(deposit1)
+
+	deposit2, _ := NewMoney("GBP", 5000)
+	afterDeposit2, _ := afterDeposit1.Deposit(deposit2)
+
+	withdrawal, _ := NewMoney("GBP", 3000)
+	afterWithdrawal, _ := afterDeposit2.Withdraw(withdrawal)
+
+	// Verify each instance has independent state
+	assert.Equal(t, int64(0), original.Balance().AmountCents())
+	assert.Equal(t, int64(10000), afterDeposit1.Balance().AmountCents())
+	assert.Equal(t, int64(15000), afterDeposit2.Balance().AmountCents())
+	assert.Equal(t, int64(12000), afterWithdrawal.Balance().AmountCents())
+
+	// Verify versions are incrementally updated
+	assert.Equal(t, int64(1), original.Version())
+	assert.Equal(t, int64(2), afterDeposit1.Version())
+	assert.Equal(t, int64(3), afterDeposit2.Version())
+	assert.Equal(t, int64(4), afterWithdrawal.Version())
+}
+
+func TestImmutability_FailedOperationDoesNotModify(t *testing.T) {
+	balance, _ := NewMoney("GBP", 10000)
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithBalance(balance).
+		WithAvailableBalance(balance).
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		Build()
+
+	originalBalance := account.Balance().AmountCents()
+	originalVersion := account.Version()
+
+	// Attempt an operation that will fail
+	excessiveWithdrawal, _ := NewMoney("GBP", 99999)
+	_, err := account.Withdraw(excessiveWithdrawal)
+
+	// Verify original is unchanged despite the failed operation
+	require.Error(t, err)
+	assert.Equal(t, originalBalance, account.Balance().AmountCents())
+	assert.Equal(t, originalVersion, account.Version())
+}
+
+// Builder tests
+
+func TestCurrentAccountBuilder(t *testing.T) {
+	balance, _ := NewMoney("GBP", 10000)
+	available, _ := NewMoney("GBP", 15000)
+	overdraft, _ := NewMoney("GBP", 5000)
+	now := time.Now()
+
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("party-123").
+		WithBalance(balance).
+		WithAvailableBalance(available).
+		WithStatus(AccountStatusActive).
+		WithOverdraftLimit(overdraft).
+		WithOverdraftEnabled(true).
+		WithOverdraftRate(0.15).
+		WithVersion(5).
+		WithCreatedAt(now).
+		WithUpdatedAt(now).
+		WithBalanceUpdatedAt(now).
+		Build()
+
+	assert.Equal(t, "ACC-001", account.AccountID())
+	assert.Equal(t, "GB82WEST12345698765432", account.AccountIdentification())
+	assert.Equal(t, "party-123", account.PartyID())
+	assert.Equal(t, int64(10000), account.Balance().AmountCents())
+	assert.Equal(t, int64(15000), account.AvailableBalance().AmountCents())
+	assert.Equal(t, AccountStatusActive, account.Status())
+	assert.Equal(t, int64(5000), account.OverdraftLimit().AmountCents())
+	assert.True(t, account.OverdraftEnabled())
+	assert.Equal(t, 0.15, account.OverdraftRate())
+	assert.Equal(t, int64(5), account.Version())
+}
+
+// calculateAvailableBalance tests
+
+func TestCalculateAvailableBalance(t *testing.T) {
+	t.Run("without overdraft returns balance", func(t *testing.T) {
+		balance, _ := NewMoney("GBP", 10000)
+		overdraft, _ := NewMoney("GBP", 5000)
+
+		result := calculateAvailableBalance(balance, overdraft, false)
+
+		assert.Equal(t, balance, result)
+	})
+
+	t.Run("with overdraft returns balance plus limit", func(t *testing.T) {
+		balance, _ := NewMoney("GBP", 10000)
+		overdraft, _ := NewMoney("GBP", 5000)
+
+		result := calculateAvailableBalance(balance, overdraft, true)
+
+		assert.Equal(t, int64(15000), result.AmountCents())
+	})
+
+	t.Run("negative balance with overdraft", func(t *testing.T) {
+		balance, _ := NewMoney("GBP", -3000)
+		overdraft, _ := NewMoney("GBP", 5000)
+
+		result := calculateAvailableBalance(balance, overdraft, true)
+
+		assert.Equal(t, int64(2000), result.AmountCents())
+	})
 }

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -265,7 +265,7 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 			"account_id", accountID)
 	}
 
-	// Create domain model
+	// Create domain model (now returns value, not pointer)
 	account, err := domain.NewCurrentAccount(
 		accountID,
 		req.AccountIdentification,
@@ -284,7 +284,7 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 	}
 
 	// Record initial balance
-	caobservability.RecordBalance(account.Balance.AmountCents(), currency)
+	caobservability.RecordBalance(account.Balance().AmountCents(), currency)
 
 	// Convert to proto response
 	return &pb.InitiateCurrentAccountResponse{
@@ -313,11 +313,11 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 	}
 
 	// Validate currency matches account currency
-	if req.Amount.Amount.CurrencyCode != account.Balance.CurrencyCode() {
+	if req.Amount.Amount.CurrencyCode != account.Balance().CurrencyCode() {
 		operationStatus = "currency_mismatch"
 		return nil, status.Errorf(codes.InvalidArgument,
 			"currency mismatch: expected %s, got %s",
-			account.Balance.CurrencyCode(), req.Amount.Amount.CurrencyCode)
+			account.Balance().CurrencyCode(), req.Amount.Amount.CurrencyCode)
 	}
 
 	// Convert amount from proto (MoneyAmount wraps google.type.Money)
@@ -359,8 +359,9 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 			"deposit amount must be positive, got %d cents", amount.AmountCents())
 	}
 
-	// Execute deposit on domain model
-	if err := account.Deposit(amount); err != nil {
+	// Execute deposit on domain model (returns new account, original unchanged)
+	account, err = account.Deposit(amount)
+	if err != nil {
 		operationStatus = "deposit_failed"
 		return nil, status.Errorf(codes.InvalidArgument, "deposit failed: %v", err)
 	}
@@ -371,7 +372,7 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 	// If clients are not configured, fall back to simple save (backward compatibility)
 	if s.posKeepingClient == nil || s.finAcctClient == nil {
 		s.logger.Info("executing deposit without transaction orchestration (clients not configured)",
-			"account_id", account.AccountID,
+			"account_id", account.AccountID(),
 			"transaction_id", transactionID)
 
 		if err := s.repo.Save(ctx, account); err != nil {
@@ -380,14 +381,14 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 		}
 
 		// Record business metrics
-		caobservability.RecordDeposit(string(account.Balance.Currency()))
-		caobservability.RecordBalance(account.Balance.AmountCents(), string(account.Balance.Currency()))
+		caobservability.RecordDeposit(string(account.Balance().Currency()))
+		caobservability.RecordBalance(account.Balance().AmountCents(), string(account.Balance().Currency()))
 
 		return &pb.ExecuteDepositResponse{
-			AccountId:        account.AccountID,
+			AccountId:        account.AccountID(),
 			TransactionId:    transactionID,
-			NewBalance:       toMoneyAmount(account.Balance),
-			AvailableBalance: toMoneyAmount(account.AvailableBalance),
+			NewBalance:       toMoneyAmount(account.Balance()),
+			AvailableBalance: toMoneyAmount(account.AvailableBalance()),
 			Status:           pb.TransactionStatus_TRANSACTION_STATUS_COMPLETED,
 		}, nil
 	}
@@ -400,14 +401,14 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 	}
 
 	// Record business metrics on success
-	caobservability.RecordDeposit(string(account.Balance.Currency()))
-	caobservability.RecordBalance(account.Balance.AmountCents(), string(account.Balance.Currency()))
+	caobservability.RecordDeposit(string(account.Balance().Currency()))
+	caobservability.RecordBalance(account.Balance().AmountCents(), string(account.Balance().Currency()))
 
 	return resp, nil
 }
 
 // orchestrateDeposit orchestrates the distributed transaction using saga pattern
-func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.CurrentAccount, amount domain.Money, transactionID string) (*pb.ExecuteDepositResponse, error) {
+func (s *Service) orchestrateDeposit(ctx context.Context, account domain.CurrentAccount, amount domain.Money, transactionID string) (*pb.ExecuteDepositResponse, error) {
 	sagaStart := time.Now()
 	sagaStatus := operationStatusSuccess
 	defer func() {
@@ -434,7 +435,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 		// Action: Create position log entry
 		func(stepCtx context.Context) error {
 			s.logger.Info("executing log_position step",
-				"account_id", account.AccountID,
+				"account_id", account.AccountID(),
 				"transaction_id", transactionID)
 
 			// Propagate correlation ID
@@ -444,18 +445,18 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 			// with the initial transaction entry
 			resp, err := s.posKeepingClient.InitiateFinancialPositionLog(stepCtx,
 				&positionkeepingv1.InitiateFinancialPositionLogRequest{
-					AccountId: account.AccountIdentification, // Use IBAN for FK constraint
+					AccountId: account.AccountIdentification(), // Use IBAN for FK constraint
 					InitialEntry: &positionkeepingv1.TransactionLogEntry{
 						EntryId:       uuid.New().String(),
 						TransactionId: transactionID,
-						AccountId:     account.AccountIdentification,
+						AccountId:     account.AccountIdentification(),
 						Amount:        toMoneyAmount(amount),
 						Direction:     commonpb.PostingDirection_POSTING_DIRECTION_CREDIT,
 						Timestamp:     timestamppb.Now(),
-						Description:   fmt.Sprintf("Deposit to account %s", account.AccountID),
+						Description:   fmt.Sprintf("Deposit to account %s", account.AccountID()),
 					},
 					IdempotencyKey: &commonpb.IdempotencyKey{
-						Key: fmt.Sprintf("deposit-%s-%s", account.AccountID, transactionID),
+						Key: fmt.Sprintf("deposit-%s-%s", account.AccountID(), transactionID),
 					},
 				},
 			)
@@ -505,7 +506,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 						Details:   fmt.Sprintf("Cancelled position log due to deposit saga failure for transaction %s", transactionID),
 					},
 					IdempotencyKey: &commonpb.IdempotencyKey{
-						Key: fmt.Sprintf("compensate-deposit-%s-%s", account.AccountID, transactionID),
+						Key: fmt.Sprintf("compensate-deposit-%s-%s", account.AccountID(), transactionID),
 					},
 				},
 			)
@@ -548,7 +549,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 		// Action: Create booking log and dual ledger postings (debit clearing, credit customer)
 		func(stepCtx context.Context) error {
 			s.logger.Info("executing post_ledger step",
-				"account_id", account.AccountID,
+				"account_id", account.AccountID(),
 				"clearing_account_id", clearingAccountID,
 				"transaction_id", transactionID)
 
@@ -562,7 +563,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 			bookingLogResp, err := s.finAcctClient.InitiateFinancialBookingLog(stepCtx,
 				&financialaccountingv1.InitiateFinancialBookingLogRequest{
 					FinancialAccountType:    commonpb.AccountType_ACCOUNT_TYPE_CURRENT,
-					ProductServiceReference: account.AccountID,
+					ProductServiceReference: account.AccountID(),
 					BusinessUnitReference:   "current-account-service",
 					ChartOfAccountsRules:    "DEPOSIT",
 					BaseCurrency:            commonpb.Currency_CURRENCY_GBP,
@@ -617,7 +618,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 					FinancialBookingLogId: bookingLogID,
 					PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_CREDIT,
 					PostingAmount:         moneyAmt.Amount,
-					AccountId:             account.AccountID,
+					AccountId:             account.AccountID(),
 					ValueDate:             timestamppb.Now(),
 					IdempotencyKey: &commonpb.IdempotencyKey{
 						Key: fmt.Sprintf("%s-credit", transactionID),
@@ -682,7 +683,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 
 			s.logger.Info("credit posting to customer account completed",
 				"credit_posting_id", creditPostingID,
-				"account_id", account.AccountID,
+				"account_id", account.AccountID(),
 				"booking_log_id", bookingLogID,
 				"transaction_id", transactionID)
 
@@ -713,7 +714,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 							FinancialBookingLogId: bookingLogID,
 							PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_DEBIT,
 							PostingAmount:         moneyAmt.Amount,
-							AccountId:             account.AccountID,
+							AccountId:             account.AccountID(),
 							ValueDate:             timestamppb.Now(),
 							IdempotencyKey:        &commonpb.IdempotencyKey{Key: compCreditID},
 						},
@@ -721,7 +722,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 					if compErr != nil {
 						s.logger.Error("failed to compensate credit posting inline",
 							"booking_log_id", bookingLogID,
-							"account_id", account.AccountID,
+							"account_id", account.AccountID(),
 							"transaction_id", transactionID,
 							"error", compErr)
 						caobservability.RecordInlineCompensationFailure("deposit", "credit")
@@ -812,7 +813,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 						FinancialBookingLogId: bookingLogID,
 						PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_DEBIT,
 						PostingAmount:         moneyAmt.Amount,
-						AccountId:             account.AccountID,
+						AccountId:             account.AccountID(),
 						ValueDate:             timestamppb.Now(),
 						IdempotencyKey: &commonpb.IdempotencyKey{
 							Key: compCreditTransactionID,
@@ -825,7 +826,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 				}
 				s.logger.Info("compensated credit posting",
 					"credit_posting_id", creditPostingID,
-					"account_id", account.AccountID)
+					"account_id", account.AccountID())
 			}
 
 			// Compensate debit leg: Create CREDIT to clearing account (if debit was posted)
@@ -889,24 +890,24 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 		// Action: Persist the updated account balance
 		func(stepCtx context.Context) error {
 			s.logger.Info("executing save_account step",
-				"account_id", account.AccountID,
+				"account_id", account.AccountID(),
 				"transaction_id", transactionID,
-				"new_balance", account.Balance.AmountCents())
+				"new_balance", account.Balance().AmountCents())
 
 			if err := s.repo.Save(stepCtx, account); err != nil {
 				return fmt.Errorf("failed to save account: %w", err)
 			}
 
 			s.logger.Info("save_account step completed",
-				"account_id", account.AccountID,
-				"new_balance", account.Balance.AmountCents())
+				"account_id", account.AccountID(),
+				"new_balance", account.Balance().AmountCents())
 
 			return nil
 		},
 		// Compensate: No database save needed - account never persisted
 		func(_ context.Context) error {
 			s.logger.Info("compensating save_account step (no-op)",
-				"account_id", account.AccountID,
+				"account_id", account.AccountID(),
 				"reason", "external services failed before persisting balance")
 
 			// No action needed - if we reach here, it means the save failed
@@ -923,7 +924,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 
 	// Execute saga
 	s.logger.Info("executing deposit saga",
-		"account_id", account.AccountID,
+		"account_id", account.AccountID(),
 		"transaction_id", transactionID,
 		"correlation_id", correlationID,
 		"steps", saga.StepCount())
@@ -936,7 +937,7 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 		caobservability.RecordSagaFailure("deposit", result.FailedStep)
 
 		s.logger.Error("deposit saga failed",
-			"account_id", account.AccountID,
+			"account_id", account.AccountID(),
 			"transaction_id", transactionID,
 			"failed_step", result.FailedStep,
 			"completed_steps", result.CompletedSteps,
@@ -949,17 +950,17 @@ func (s *Service) orchestrateDeposit(ctx context.Context, account *domain.Curren
 	}
 
 	s.logger.Info("deposit saga completed successfully",
-		"account_id", account.AccountID,
+		"account_id", account.AccountID(),
 		"transaction_id", transactionID,
 		"correlation_id", correlationID,
 		"completed_steps", result.CompletedSteps)
 
 	// Return successful response
 	return &pb.ExecuteDepositResponse{
-		AccountId:        account.AccountID,
+		AccountId:        account.AccountID(),
 		TransactionId:    transactionID,
-		NewBalance:       toMoneyAmount(account.Balance),
-		AvailableBalance: toMoneyAmount(account.AvailableBalance),
+		NewBalance:       toMoneyAmount(account.Balance()),
+		AvailableBalance: toMoneyAmount(account.AvailableBalance()),
 		Status:           pb.TransactionStatus_TRANSACTION_STATUS_COMPLETED,
 	}, nil
 }
@@ -990,25 +991,25 @@ func (s *Service) RetrieveCurrentAccount(ctx context.Context, req *pb.RetrieveCu
 
 // Helper functions
 
-func toProtoFacility(account *domain.CurrentAccount) *pb.CurrentAccountFacility {
+func toProtoFacility(account domain.CurrentAccount) *pb.CurrentAccountFacility {
 	return &pb.CurrentAccountFacility{
-		AccountId:             account.AccountID,
-		AccountIdentification: account.AccountIdentification,
-		AccountStatus:         mapStatusToProto(account.Status),
-		BaseCurrency:          mapCurrencyToProto(string(account.Balance.Currency())),
-		CreatedAt:             timestamppb.New(account.CreatedAt),
-		UpdatedAt:             timestamppb.New(account.UpdatedAt),
+		AccountId:             account.AccountID(),
+		AccountIdentification: account.AccountIdentification(),
+		AccountStatus:         mapStatusToProto(account.Status()),
+		BaseCurrency:          mapCurrencyToProto(string(account.Balance().Currency())),
+		CreatedAt:             timestamppb.New(account.CreatedAt()),
+		UpdatedAt:             timestamppb.New(account.UpdatedAt()),
 		// #nosec G115 - Version is bounded by database constraints
-		Version: int32(account.Version),
+		Version: int32(account.Version()),
 		CurrentBalance: &pb.AccountBalance{
-			CurrentBalance:   toMoneyAmount(account.Balance),
-			AvailableBalance: toMoneyAmount(account.AvailableBalance),
-			LastUpdated:      timestamppb.New(account.BalanceUpdatedAt),
+			CurrentBalance:   toMoneyAmount(account.Balance()),
+			AvailableBalance: toMoneyAmount(account.AvailableBalance()),
+			LastUpdated:      timestamppb.New(account.BalanceUpdatedAt()),
 		},
 		OverdraftLimit: &pb.OverdraftConfiguration{
-			OverdraftLimit: toMoneyAmount(account.OverdraftLimit),
-			InterestRate:   account.OverdraftRate,
-			IsEnabled:      account.OverdraftEnabled,
+			OverdraftLimit: toMoneyAmount(account.OverdraftLimit()),
+			InterestRate:   account.OverdraftRate(),
+			IsEnabled:      account.OverdraftEnabled(),
 			LastUpdated:    timestamppb.New(time.Now()),
 		},
 	}

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -331,7 +331,7 @@ func setupIntegrationTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	return db, ctx, cleanup
 }
 
-func createTestAccount(t *testing.T, ctx context.Context, repo *persistence.Repository, accountID string) *domain.CurrentAccount {
+func createTestAccount(t *testing.T, ctx context.Context, repo *persistence.Repository, accountID string) domain.CurrentAccount {
 	t.Helper()
 	// Use accountID as AccountIdentification (stored in account_number column) for lookup compatibility.
 	// The repository's FindByID searches by account_number, so AccountIdentification must match the lookup key.
@@ -404,7 +404,7 @@ func TestExecuteDeposit_WithOrchestration_Success(t *testing.T) {
 	// Verify account persisted correctly
 	updatedAccount, err := repo.FindByID(ctx, "ACC-001")
 	require.NoError(t, err)
-	assert.Equal(t, int64(10050), updatedAccount.Balance.AmountCents(), "Balance should be £100.50 = 10050 cents")
+	assert.Equal(t, int64(10050), updatedAccount.Balance().AmountCents(), "Balance should be £100.50 = 10050 cents")
 
 	// Verify service calls
 	assert.Equal(t, 1, mockPosKeeping.initiateCalls, "PositionKeeping InitiateFinancialPositionLog should be called once")
@@ -433,7 +433,7 @@ func TestExecuteDeposit_WithOrchestration_PositionKeepingFailure(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	account := createTestAccount(t, ctx, repo, "ACC-002")
-	originalBalance := account.Balance.AmountCents()
+	originalBalance := account.Balance().AmountCents()
 
 	// Create mock clients - PositionKeeping configured to fail on initiate
 	mockPosKeeping := &mockPositionKeepingClient{
@@ -471,7 +471,7 @@ func TestExecuteDeposit_WithOrchestration_PositionKeepingFailure(t *testing.T) {
 	updatedAccount, err := repo.FindByID(ctx, "ACC-002")
 	require.NoError(t, err)
 	// Account balance should be unchanged because save_account is the final step
-	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
+	assert.Equal(t, originalBalance, updatedAccount.Balance().AmountCents(),
 		"Account balance should remain unchanged when external services fail")
 
 	// Verify service calls
@@ -502,7 +502,7 @@ func TestExecuteDeposit_WithOrchestration_FinancialAccountingFailure(t *testing.
 
 	repo := persistence.NewRepository(db)
 	account := createTestAccount(t, ctx, repo, "ACC-003")
-	originalBalance := account.Balance.AmountCents()
+	originalBalance := account.Balance().AmountCents()
 
 	// Create mock clients - FinancialAccounting configured to fail
 	mockPosKeeping := &mockPositionKeepingClient{}
@@ -539,7 +539,7 @@ func TestExecuteDeposit_WithOrchestration_FinancialAccountingFailure(t *testing.
 	// so the balance should remain unchanged
 	updatedAccount, err := repo.FindByID(ctx, "ACC-003")
 	require.NoError(t, err)
-	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
+	assert.Equal(t, originalBalance, updatedAccount.Balance().AmountCents(),
 		"Account balance should remain unchanged when external services fail")
 
 	// Verify service calls
@@ -716,7 +716,7 @@ func TestExecuteDeposit_WithOrchestration_CompensationOrder(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	account := createTestAccount(t, ctx, repo, "ACC-004")
-	originalBalance := account.Balance.AmountCents()
+	originalBalance := account.Balance().AmountCents()
 
 	// Create mock that tracks compensation
 	mockPosKeeping := &mockPositionKeepingClient{}
@@ -748,7 +748,7 @@ func TestExecuteDeposit_WithOrchestration_CompensationOrder(t *testing.T) {
 	// With the fixed saga ordering, the account is never saved if external services fail
 	updatedAccount, err := repo.FindByID(ctx, "ACC-004")
 	require.NoError(t, err)
-	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
+	assert.Equal(t, originalBalance, updatedAccount.Balance().AmountCents(),
 		"Account balance should remain unchanged when external services fail")
 }
 
@@ -824,7 +824,7 @@ func TestExecuteDeposit_WithoutClients_BackwardCompatibility(t *testing.T) {
 	// Verify account persisted
 	updatedAccount, err := repo.FindByID(ctx, "ACC-006")
 	require.NoError(t, err)
-	assert.Equal(t, int64(20000), updatedAccount.Balance.AmountCents())
+	assert.Equal(t, int64(20000), updatedAccount.Balance().AmountCents())
 }
 
 // Double-Entry Bookkeeping Tests (with AccountConfig)
@@ -941,7 +941,7 @@ func TestExecuteDeposit_DoubleEntry_CompensatesOnFailure(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	account := createTestAccount(t, ctx, repo, "ACC-DE-003")
-	originalBalance := account.Balance.AmountCents()
+	originalBalance := account.Balance().AmountCents()
 
 	mockPosKeeping := &mockPositionKeepingClient{}
 
@@ -987,7 +987,7 @@ func TestExecuteDeposit_DoubleEntry_CompensatesOnFailure(t *testing.T) {
 	// Verify account balance unchanged (compensation should have reversed)
 	updatedAccount, err := repo.FindByID(ctx, "ACC-DE-003")
 	require.NoError(t, err)
-	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
+	assert.Equal(t, originalBalance, updatedAccount.Balance().AmountCents(),
 		"Account balance should remain unchanged after compensation")
 }
 
@@ -1002,7 +1002,7 @@ func TestExecuteDeposit_DoubleEntry_DebitPostingFailure(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	account := createTestAccount(t, ctx, repo, "ACC-DE-005")
-	originalBalance := account.Balance.AmountCents()
+	originalBalance := account.Balance().AmountCents()
 
 	mockPosKeeping := &mockPositionKeepingClient{}
 
@@ -1050,7 +1050,7 @@ func TestExecuteDeposit_DoubleEntry_DebitPostingFailure(t *testing.T) {
 	// Verify account balance unchanged
 	updatedAccount, err := repo.FindByID(ctx, "ACC-DE-005")
 	require.NoError(t, err)
-	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
+	assert.Equal(t, originalBalance, updatedAccount.Balance().AmountCents(),
 		"Account balance should remain unchanged")
 }
 
@@ -1063,7 +1063,7 @@ func TestExecuteDeposit_DoubleEntry_CreditPostingFailure(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	account := createTestAccount(t, ctx, repo, "ACC-DE-006")
-	originalBalance := account.Balance.AmountCents()
+	originalBalance := account.Balance().AmountCents()
 
 	mockPosKeeping := &mockPositionKeepingClient{}
 
@@ -1114,7 +1114,7 @@ func TestExecuteDeposit_DoubleEntry_CreditPostingFailure(t *testing.T) {
 	// Verify account balance unchanged
 	updatedAccount, err := repo.FindByID(ctx, "ACC-DE-006")
 	require.NoError(t, err)
-	assert.Equal(t, originalBalance, updatedAccount.Balance.AmountCents(),
+	assert.Equal(t, originalBalance, updatedAccount.Balance().AmountCents(),
 		"Account balance should remain unchanged after failure and compensation")
 }
 

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -120,29 +120,30 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 
 		// Retrieve account with FOR UPDATE lock to prevent concurrent modifications
 		var txErr error
-		account, txErr = txRepo.FindByIDForUpdate(ctx, req.AccountId)
+		accountResult, txErr := txRepo.FindByIDForUpdate(ctx, req.AccountId)
 		if txErr != nil {
 			return txErr
 		}
+		account = &accountResult
 
 		// Validate account is active
-		if account.Status != domain.AccountStatusActive {
+		if account.Status() != domain.AccountStatusActive {
 			return errTxAccountNotActive
 		}
 
 		// Validate currency matches account
-		if lienAmount.Currency() != account.Balance.Currency() {
+		if lienAmount.Currency() != account.Balance().Currency() {
 			return errTxCurrencyMismatch
 		}
 
 		// Calculate available balance (within the lock)
-		activeLiensTotal, err := txLienRepo.SumActiveAmountByAccountID(ctx, account.ID)
+		activeLiensTotal, err := txLienRepo.SumActiveAmountByAccountID(ctx, account.ID())
 		if err != nil {
 			return fmt.Errorf("%w: %w", errTxSumLiensFailed, err)
 		}
 
 		// Available = Current Balance - Active Liens
-		availableBalance = account.Balance.AmountCents() - activeLiensTotal
+		availableBalance = account.Balance().AmountCents() - activeLiensTotal
 
 		// Check sufficient funds
 		if lienAmount.AmountCents() > availableBalance {
@@ -150,7 +151,7 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		}
 
 		// Create lien domain object
-		lien, err = domain.NewLien(account.ID, lienAmount, req.PaymentOrderReference, nil)
+		lien, err = domain.NewLien(account.ID(), lienAmount, req.PaymentOrderReference, nil)
 		if err != nil {
 			return fmt.Errorf("%w: %w", errTxDomainError, err)
 		}
@@ -192,13 +193,13 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 
 	s.logger.Info("lien created",
 		"lien_id", lien.ID.String(),
-		"account_id", account.AccountID,
+		"account_id", account.AccountID(),
 		"amount_cents", lienAmount.AmountCents(),
 		"payment_order_ref", req.PaymentOrderReference)
 
 	// Calculate new available balance after this lien
 	newAvailableBalance := availableBalance - lienAmount.AmountCents()
-	availableMoney, err := domain.NewMoney(string(account.Balance.Currency()), newAvailableBalance)
+	availableMoney, err := domain.NewMoney(string(account.Balance().Currency()), newAvailableBalance)
 	if err != nil {
 		// This should never happen if validation passed - log and return without available balance
 		s.logger.Error("failed to create available balance money", "error", err)
@@ -279,7 +280,7 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		}
 
 		// Retrieve account with FOR UPDATE lock to prevent concurrent modifications
-		account, txErr = txRepo.FindByUUIDForUpdate(ctx, lien.AccountID)
+		accountResult, txErr := txRepo.FindByUUIDForUpdate(ctx, lien.AccountID)
 		if txErr != nil {
 			return fmt.Errorf("%w: %w", errTxSaveAccount, txErr)
 		}
@@ -289,10 +290,12 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 			return fmt.Errorf("%w: %w", errTxExecuteFailed, err)
 		}
 
-		// Debit the account
-		if err := account.Withdraw(lien.Amount); err != nil {
+		// Debit the account (immutable: capture returned value)
+		accountResult, err := accountResult.Withdraw(lien.Amount)
+		if err != nil {
 			return fmt.Errorf("%w: %w", errTxWithdrawFailed, err)
 		}
+		account = &accountResult
 
 		// Update lien status
 		if err := txLienRepo.Update(lien); err != nil {
@@ -300,7 +303,7 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		}
 
 		// Save account with balance change (context carries audit user info)
-		if err := txRepo.Save(ctx, account); err != nil {
+		if err := txRepo.Save(ctx, accountResult); err != nil {
 			return fmt.Errorf("%w: %w", errTxSaveAccount, err)
 		}
 
@@ -354,14 +357,14 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 	transactionID := fmt.Sprintf("TXN-LIEN-%s", lien.ID.String()[:8])
 	s.logger.Info("lien executed",
 		"lien_id", lien.ID.String(),
-		"account_id", account.AccountID,
+		"account_id", account.AccountID(),
 		"amount_cents", lien.Amount.AmountCents(),
 		"transaction_id", transactionID)
 
-	availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance)
+	availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance())
 	return &pb.ExecuteLienResponse{
 		Lien:             toLienProto(lien),
-		NewBalance:       toMoneyAmount(account.Balance),
+		NewBalance:       toMoneyAmount(account.Balance()),
 		AvailableBalance: toMoneyAmount(availableMoney),
 		TransactionId:    transactionID,
 	}, nil
@@ -411,7 +414,7 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 			s.logger.Error("failed to find account for idempotent response", "error", acctErr)
 			return &pb.TerminateLienResponse{Lien: toLienProto(lien)}, nil
 		}
-		availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance)
+		availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance())
 		return &pb.TerminateLienResponse{
 			Lien:             toLienProto(lien),
 			AvailableBalance: toMoneyAmount(availableMoney),
@@ -498,7 +501,7 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
 	}
 
-	availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance)
+	availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance())
 	return &pb.TerminateLienResponse{
 		Lien:             toLienProto(lien),
 		AvailableBalance: toMoneyAmount(availableMoney),
@@ -601,10 +604,10 @@ func (s *Service) buildExecuteLienIdempotentResponse(ctx context.Context, lien *
 		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
 	}
 
-	availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance)
+	availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance())
 	return &pb.ExecuteLienResponse{
 		Lien:             toLienProto(lien),
-		NewBalance:       toMoneyAmount(account.Balance),
+		NewBalance:       toMoneyAmount(account.Balance()),
 		AvailableBalance: toMoneyAmount(availableMoney),
 		TransactionId:    fmt.Sprintf("TXN-LIEN-%s", lien.ID.String()[:8]),
 	}, nil
@@ -637,7 +640,7 @@ func (s *Service) checkLienIdempotency(ctx context.Context, paymentOrderRef stri
 		s.logger.Error("failed to retrieve account for idempotent response", "error", acctErr)
 		return &pb.InitiateLienResponse{Lien: toLienProto(existingLien)}, true, nil
 	}
-	availableMoney := s.calculateAvailableBalance(ctx, existingLien.AccountID, account.Balance)
+	availableMoney := s.calculateAvailableBalance(ctx, existingLien.AccountID, account.Balance())
 	return &pb.InitiateLienResponse{
 		Lien:             toLienProto(existingLien),
 		AvailableBalance: toMoneyAmount(availableMoney),

--- a/services/current-account/service/lien_service_test.go
+++ b/services/current-account/service/lien_service_test.go
@@ -76,7 +76,7 @@ func setupLienTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 	return db, ctx, cleanup
 }
 
-func createTestAccountWithBalance(t *testing.T, ctx context.Context, repo *persistence.Repository, accountID string, balanceCents int64) *domain.CurrentAccount {
+func createTestAccountWithBalance(t *testing.T, ctx context.Context, repo *persistence.Repository, accountID string, balanceCents int64) domain.CurrentAccount {
 	t.Helper()
 	// Use accountID as AccountIdentification (stored in account_number column) for lookup compatibility.
 	// The repository's FindByID searches by account_number, so AccountIdentification must match the lookup key.
@@ -86,7 +86,8 @@ func createTestAccountWithBalance(t *testing.T, ctx context.Context, repo *persi
 	if balanceCents > 0 {
 		depositAmount, err := domain.NewMoney("GBP", balanceCents)
 		require.NoError(t, err)
-		require.NoError(t, account.Deposit(depositAmount))
+		account, err = account.Deposit(depositAmount)
+		require.NoError(t, err)
 	}
 
 	require.NoError(t, repo.Save(ctx, account))
@@ -267,7 +268,7 @@ func TestExecuteLien_Success(t *testing.T) {
 	// Create lien for £500
 	lienAmount, err := domain.NewMoney("GBP", 50000)
 	require.NoError(t, err)
-	lien, err := domain.NewLien(account.ID, lienAmount, "PO-127", nil)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "PO-127", nil)
 	require.NoError(t, err)
 	require.NoError(t, lienRepo.Create(lien))
 
@@ -299,7 +300,7 @@ func TestExecuteLien_Idempotent(t *testing.T) {
 	// Create and execute a lien
 	lienAmount, err := domain.NewMoney("GBP", 50000)
 	require.NoError(t, err)
-	lien, err := domain.NewLien(account.ID, lienAmount, "PO-128", nil)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "PO-128", nil)
 	require.NoError(t, err)
 	require.NoError(t, lienRepo.Create(lien))
 
@@ -350,7 +351,7 @@ func TestTerminateLien_Success(t *testing.T) {
 	// Create lien for £500
 	lienAmount, err := domain.NewMoney("GBP", 50000)
 	require.NoError(t, err)
-	lien, err := domain.NewLien(account.ID, lienAmount, "PO-129", nil)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "PO-129", nil)
 	require.NoError(t, err)
 	require.NoError(t, lienRepo.Create(lien))
 
@@ -382,7 +383,7 @@ func TestTerminateLien_Idempotent(t *testing.T) {
 	// Create lien
 	lienAmount, err := domain.NewMoney("GBP", 50000)
 	require.NoError(t, err)
-	lien, err := domain.NewLien(account.ID, lienAmount, "PO-130", nil)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "PO-130", nil)
 	require.NoError(t, err)
 	require.NoError(t, lienRepo.Create(lien))
 
@@ -416,7 +417,7 @@ func TestRetrieveLien_Success(t *testing.T) {
 	// Create lien
 	lienAmount, err := domain.NewMoney("GBP", 25000)
 	require.NoError(t, err)
-	lien, err := domain.NewLien(account.ID, lienAmount, "PO-131", nil)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "PO-131", nil)
 	require.NoError(t, err)
 	require.NoError(t, lienRepo.Create(lien))
 


### PR DESCRIPTION
## Summary
- Converts CurrentAccount to an immutable domain model following functional patterns
- All state-changing operations now return new instances rather than modifying in place
- Ensures thread-safety and prevents accidental state corruption

## Changes Made
- **Domain layer** (`domain/account.go`):
  - Unexport all struct fields (id, accountID, balance, status, etc.)
  - Add accessor methods for all fields (ID(), AccountID(), Balance(), etc.)
  - Change all mutating methods to value receivers returning new instances
  - Add `CurrentAccountBuilder` for persistence layer reconstruction from DB records
  - Convert `calculateAvailableBalance` to a pure function

- **Persistence layer** (`adapters/persistence/repository.go`):
  - Update `Save()` to accept value type instead of pointer
  - Update all `Find*` methods to return value types
  - Use `CurrentAccountBuilder` to reconstruct domain objects from entities

- **Service layer** (`service/grpc_service.go`, `service/lien_service.go`):
  - Capture returned values from all mutation operations (Deposit, Withdraw, Freeze, etc.)
  - Update all field access to use accessor methods

- **Tests**:
  - Add comprehensive immutability verification tests
  - Update all existing tests to use new immutable API

## Technical Details
The immutable pattern ensures:
```go
// Old mutable pattern (no longer compiles)
account.Deposit(amount)  // Modified in place

// New immutable pattern
account, err = account.Deposit(amount)  // Returns new instance
```

Builder pattern for persistence:
```go
account, err := domain.NewCurrentAccountBuilder().
    WithID(entity.ID).
    WithAccountID(entity.AccountID).
    WithBalance(balance).
    // ...
    Build()
```

## Test Plan
- [x] All domain tests pass (40+ tests including new immutability tests)
- [ ] CI pipeline passes
- [ ] Integration tests pass

## Risk Assessment
Low risk - this is an internal refactoring that maintains the same external API contract. All tests have been updated to verify the new pattern works correctly.