### PR TITLE
fix: remove unused postgres service from nightly workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -88,20 +88,8 @@ jobs:
   slow-integration-tests:
     name: Slow Integration Tests
     runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: postgres:15-alpine
-        env:
-          POSTGRES_USER: test
-          POSTGRES_PASSWORD: test
-          POSTGRES_DB: meridian_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+    # Note: No postgres service container needed - tests use testcontainers
+    # which manage their own ephemeral containers with proper isolation.
 
     steps:
     - name: Checkout code
@@ -127,7 +115,8 @@ jobs:
     - name: Run full test suite (including slow tests)
       env:
         SKIP_KAFKA_TESTS: "1"
-        DATABASE_URL: postgres://test:test@localhost:5432/meridian_test?sslmode=disable
+        # Note: No DATABASE_URL needed - tests that require a database
+        # use testcontainers or mock their own configuration
       run: |
         # Run WITHOUT -short flag to include all timing-sensitive tests
         # Regular CI runs with -short, but nightly runs the full suite


### PR DESCRIPTION
## Summary

Fixes failing nightly build by removing the unused postgres service container that was conflicting with testcontainers.

**Failing run:** https://github.com/meridianhub/meridian/actions/runs/20388335409

## Root Cause

The multi-tenant integration tests (`TestTenantProvisioningCreatesSchemas`, `TestProvisioningIdempotent`, `TestTenantDeprovisionDropsAccess`) use testcontainers-go to create their own PostgreSQL containers. When a GitHub Actions postgres service container was also running on port 5432, testcontainers was probing it during initialization and failing with:

```
FATAL: role "root" does not exist
```

## Changes

- Removed the postgres service container from the nightly workflow
- Removed the unused `DATABASE_URL` environment variable

## Why This Is Safe

Tests that require database access either:
1. Use testcontainers (creates isolated ephemeral containers) - `tests/multi_tenant/e2e_test.go`
2. Mock `DATABASE_URL` in test setup code using `t.Setenv()` - various service tests

No tests depend on the workflow-level postgres service or `DATABASE_URL` env var.

## Test Plan

- [ ] Nightly workflow runs successfully after merge
- [ ] Multi-tenant integration tests pass