### PR TITLE
Add Redis idempotency to Current-Account service critical operations

### DIFF
--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -327,6 +327,9 @@ message ExecuteDepositRequest {
 
   // reference is optional reference
   string reference = 4 [(buf.validate.field).string = {max_len: 100}];
+
+  // idempotency_key ensures exactly-once deposit execution for retry scenarios
+  meridian.common.v1.IdempotencyKey idempotency_key = 5;
 }
 
 // Response for deposit execution
@@ -405,6 +408,9 @@ message ExecuteLienRequest {
     max_len: 100
     pattern: "^[a-zA-Z0-9_-]+$"
   }];
+
+  // idempotency_key ensures exactly-once lien execution for retry scenarios
+  meridian.common.v1.IdempotencyKey idempotency_key = 2;
 }
 
 // Response for executing a lien

--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -104,17 +104,21 @@ func run(logger *slog.Logger) error {
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
 
-	// Create Redis client and idempotency service
+	// Create Redis client and idempotency service (optional - graceful degradation)
+	var idempotencyService idempotency.Service
 	redisClient, err := createRedisClient(logger)
 	if err != nil {
-		return fmt.Errorf("failed to create Redis client: %w", err)
+		logger.Warn("Redis not available, idempotency protection disabled",
+			"error", err)
+	} else {
+		defer func() {
+			if err := redisClient.Close(); err != nil {
+				logger.Error("failed to close Redis client", "error", err)
+			}
+		}()
+		idempotencyService = idempotency.NewRedisService(redisClient)
+		logger.Info("idempotency protection enabled with Redis")
 	}
-	defer func() {
-		if err := redisClient.Close(); err != nil {
-			logger.Error("failed to close Redis client", "error", err)
-		}
-	}()
-	idempotencyService := idempotency.NewRedisService(redisClient)
 
 	// Get Kubernetes namespace from environment (defaults to "default")
 	namespace := getEnvOrDefault("K8S_NAMESPACE", "default")

--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -19,9 +19,11 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/config"
 	"github.com/meridianhub/meridian/services/current-account/service"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/pkg/interceptors"
 	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/redis/go-redis/v9"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
@@ -102,6 +104,18 @@ func run(logger *slog.Logger) error {
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
 
+	// Create Redis client and idempotency service
+	redisClient, err := createRedisClient(logger)
+	if err != nil {
+		return fmt.Errorf("failed to create Redis client: %w", err)
+	}
+	defer func() {
+		if err := redisClient.Close(); err != nil {
+			logger.Error("failed to close Redis client", "error", err)
+		}
+	}()
+	idempotencyService := idempotency.NewRedisService(redisClient)
+
 	// Get Kubernetes namespace from environment (defaults to "default")
 	namespace := getEnvOrDefault("K8S_NAMESPACE", "default")
 
@@ -117,6 +131,7 @@ func run(logger *slog.Logger) error {
 		namespace,
 		logger,
 		tracer,
+		idempotencyService,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create service: %w", err)
@@ -363,6 +378,7 @@ func createServiceWithClients(
 	namespace string,
 	logger *slog.Logger,
 	tracer *observability.Tracer,
+	idempotencyService idempotency.Service,
 ) (*service.Service, *serviceClients, error) {
 	// Load account configuration for clearing accounts
 	// This is optional - if not configured, deposits will use single-entry mode (backward compatible)
@@ -445,6 +461,7 @@ func createServiceWithClients(
 		resilientFinAcctClient,
 		resilientPartyClient,
 		accountConfig,
+		idempotencyService,
 		logger,
 		tracer,
 	)
@@ -554,4 +571,51 @@ func initAuth(ctx context.Context, logger *slog.Logger) (*auth.Interceptor, erro
 		"bypass_methods", len(interceptorConfig.BypassMethods))
 
 	return interceptor, nil
+}
+
+// createRedisClient creates and validates a Redis client connection.
+// Environment variables:
+//   - REDIS_URL: Redis connection URL (default: redis://localhost:6379)
+//   - REDIS_PASSWORD: Redis password (optional)
+//   - REDIS_DB: Redis database number (default: 0)
+//   - REDIS_POOL_SIZE: Connection pool size (default: 10)
+//   - REDIS_MIN_IDLE_CONNS: Minimum idle connections (default: 2)
+func createRedisClient(logger *slog.Logger) (*redis.Client, error) {
+	redisURL := getEnvOrDefault("REDIS_URL", "redis://localhost:6379")
+	redisPassword := getEnvOrDefault("REDIS_PASSWORD", "")
+	redisDB := getEnvAsInt("REDIS_DB", 0)
+	poolSize := getEnvAsInt("REDIS_POOL_SIZE", 10)
+	minIdleConns := getEnvAsInt("REDIS_MIN_IDLE_CONNS", 2)
+
+	opt, err := redis.ParseURL(redisURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid REDIS_URL: %w", err)
+	}
+
+	// Override with explicit config if set
+	if redisPassword != "" {
+		opt.Password = redisPassword
+	}
+	opt.DB = redisDB
+	opt.PoolSize = poolSize
+	opt.MinIdleConns = minIdleConns
+
+	client := redis.NewClient(opt)
+
+	// Verify connection
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("failed to ping Redis: %w", err)
+	}
+
+	// Log sanitized address to avoid exposing credentials
+	logger.Info("Redis client connected",
+		"addr", opt.Addr,
+		"db", redisDB,
+		"pool_size", poolSize,
+		"min_idle_conns", minIdleConns)
+
+	return client, nil
 }

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -21,10 +21,13 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/observability"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -46,19 +49,33 @@ var (
 const (
 	operationStatusSuccess         = "success"
 	operationStatusInvalidCurrency = "invalid_currency"
+	opStatusIdempotent             = "idempotent"
+)
+
+// Redis idempotency constants
+const (
+	// idempotencyNamespace is the Redis key namespace for current-account idempotency
+	idempotencyNamespace = "current-account"
+
+	// idempotencyPendingTTL is how long a pending idempotency record remains valid
+	idempotencyPendingTTL = 5 * time.Minute
+
+	// idempotencyResultTTL is how long completed results are cached
+	idempotencyResultTTL = 24 * time.Hour
 )
 
 // Service implements the CurrentAccountService gRPC service
 type Service struct {
 	pb.UnimplementedCurrentAccountServiceServer
-	repo             *persistence.Repository
-	lienRepo         *persistence.LienRepository
-	posKeepingClient clients.PositionKeepingClient
-	finAcctClient    clients.FinancialAccountingClient
-	partyClient      clients.PartyClient
-	accountConfig    *config.AccountConfig
-	logger           *slog.Logger
-	tracer           *observability.Tracer
+	repo               *persistence.Repository
+	lienRepo           *persistence.LienRepository
+	posKeepingClient   clients.PositionKeepingClient
+	finAcctClient      clients.FinancialAccountingClient
+	partyClient        clients.PartyClient
+	accountConfig      *config.AccountConfig
+	idempotencyService idempotency.Service
+	logger             *slog.Logger
+	tracer             *observability.Tracer
 }
 
 // Config contains configuration for creating a new Service with external clients
@@ -106,6 +123,7 @@ func NewServiceWithExistingClients(
 	finAcctClient clients.FinancialAccountingClient,
 	partyClient clients.PartyClient,
 	accountConfig *config.AccountConfig,
+	idempotencyService idempotency.Service,
 	logger *slog.Logger,
 	tracer *observability.Tracer,
 ) (*Service, error) {
@@ -119,14 +137,15 @@ func NewServiceWithExistingClients(
 	}
 
 	return &Service{
-		repo:             repo,
-		lienRepo:         lienRepo,
-		posKeepingClient: posKeepingClient,
-		finAcctClient:    finAcctClient,
-		partyClient:      partyClient,
-		accountConfig:    accountConfig,
-		logger:           logger,
-		tracer:           tracer,
+		repo:               repo,
+		lienRepo:           lienRepo,
+		posKeepingClient:   posKeepingClient,
+		finAcctClient:      finAcctClient,
+		partyClient:        partyClient,
+		accountConfig:      accountConfig,
+		idempotencyService: idempotencyService,
+		logger:             logger,
+		tracer:             tracer,
 	}, nil
 }
 
@@ -309,13 +328,58 @@ func (s *Service) InitiateCurrentAccount(ctx context.Context, req *pb.InitiateCu
 	}, nil
 }
 
-// ExecuteDeposit processes a deposit transaction
+// ExecuteDeposit processes a deposit transaction with Redis-based idempotency protection
 func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequest) (*pb.ExecuteDepositResponse, error) {
 	start := time.Now()
 	operationStatus := operationStatusSuccess
 	defer func() {
 		caobservability.RecordOperationDuration("execute_deposit", operationStatus, time.Since(start))
 	}()
+
+	// Get idempotency key if provided
+	var idempotencyKey string
+	if req.IdempotencyKey != nil && req.IdempotencyKey.Key != "" {
+		idempotencyKey = req.IdempotencyKey.Key
+	}
+
+	// Build idempotency key structure for Redis
+	var idempKey idempotency.Key
+	if idempotencyKey != "" && s.idempotencyService != nil {
+		tenantID, _ := tenant.FromContext(ctx)
+		idempKey = idempotency.Key{
+			TenantID:  string(tenantID),
+			Namespace: idempotencyNamespace,
+			Operation: "deposit",
+			EntityID:  req.AccountId,
+			RequestID: idempotencyKey,
+		}
+
+		// Check Redis for existing result
+		result, err := s.idempotencyService.Check(ctx, idempKey)
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) && result != nil && result.Data != nil {
+			var cachedResp pb.ExecuteDepositResponse
+			unmarshalErr := proto.Unmarshal(result.Data, &cachedResp)
+			if unmarshalErr == nil {
+				s.logger.Info("returning cached deposit response from Redis",
+					"account_id", req.AccountId,
+					"transaction_id", cachedResp.TransactionId,
+					"idempotency_key", idempotencyKey)
+				operationStatus = opStatusIdempotent
+				return &cachedResp, nil
+			}
+			s.logger.Warn("failed to unmarshal cached idempotency result",
+				"error", unmarshalErr)
+		} else if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
+			s.logger.Error("idempotency check failed", "error", err)
+			return nil, status.Error(codes.Internal, "failed to check idempotency")
+		}
+
+		// Mark operation as pending (distributed lock)
+		if err := s.idempotencyService.MarkPending(ctx, idempKey, idempotencyPendingTTL); err != nil {
+			s.logger.Error("failed to mark operation pending", "error", err)
+			return nil, status.Error(codes.Internal, "failed to acquire idempotency lock")
+		}
+	}
 
 	// Retrieve account (context carries organization for multi-tenant routing)
 	account, err := s.repo.FindByID(ctx, req.AccountId)
@@ -391,6 +455,8 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 	// Generate transaction ID (full UUID required by position-keeping service)
 	transactionID := uuid.New().String()
 
+	var resp *pb.ExecuteDepositResponse
+
 	// If clients are not configured, fall back to simple save (backward compatibility)
 	if s.posKeepingClient == nil || s.finAcctClient == nil {
 		s.logger.Info("executing deposit without transaction orchestration (clients not configured)",
@@ -406,25 +472,45 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 		caobservability.RecordDeposit(string(account.Balance().Currency()))
 		caobservability.RecordBalance(safeMinorUnits(account.Balance()), string(account.Balance().Currency()))
 
-		return &pb.ExecuteDepositResponse{
+		resp = &pb.ExecuteDepositResponse{
 			AccountId:        account.AccountID(),
 			TransactionId:    transactionID,
 			NewBalance:       toMoneyAmount(account.Balance()),
 			AvailableBalance: toMoneyAmount(account.AvailableBalance()),
 			Status:           pb.TransactionStatus_TRANSACTION_STATUS_COMPLETED,
-		}, nil
+		}
+	} else {
+		// Orchestrate transaction with saga pattern
+		resp, err = s.orchestrateDeposit(ctx, account, amount, transactionID)
+		if err != nil {
+			operationStatus = "saga_failed"
+			return nil, err
+		}
+
+		// Record business metrics on success
+		caobservability.RecordDeposit(string(account.Balance().Currency()))
+		caobservability.RecordBalance(safeMinorUnits(account.Balance()), string(account.Balance().Currency()))
 	}
 
-	// Orchestrate transaction with saga pattern
-	resp, err := s.orchestrateDeposit(ctx, account, amount, transactionID)
-	if err != nil {
-		operationStatus = "saga_failed"
-		return nil, err
+	// Store successful result in Redis for future idempotency checks
+	if idempotencyKey != "" && s.idempotencyService != nil {
+		responseData, marshalErr := proto.Marshal(resp)
+		if marshalErr == nil {
+			storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
+				Key:         idempKey,
+				Status:      idempotency.StatusCompleted,
+				Data:        responseData,
+				CompletedAt: time.Now(),
+				TTL:         idempotencyResultTTL,
+			})
+			if storeErr != nil {
+				s.logger.Error("failed to store idempotency result", "error", storeErr)
+				// Continue - operation succeeded, caching is optimization
+			}
+		} else {
+			s.logger.Error("failed to marshal response for idempotency cache", "error", marshalErr)
+		}
 	}
-
-	// Record business metrics on success
-	caobservability.RecordDeposit(string(account.Balance().Currency()))
-	caobservability.RecordBalance(safeMinorUnits(account.Balance()), string(account.Balance().Currency()))
 
 	return resp, nil
 }

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -344,8 +344,13 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 
 	// Build idempotency key structure for Redis
 	var idempKey idempotency.Key
+	var idempotencyLockAcquired bool
 	if idempotencyKey != "" && s.idempotencyService != nil {
-		tenantID, _ := tenant.FromContext(ctx)
+		tenantID, ok := tenant.FromContext(ctx)
+		if !ok {
+			s.logger.Debug("tenant not found in context for idempotency key",
+				"account_id", req.AccountId)
+		}
 		idempKey = idempotency.Key{
 			TenantID:  string(tenantID),
 			Namespace: idempotencyNamespace,
@@ -376,9 +381,27 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 
 		// Mark operation as pending (distributed lock)
 		if err := s.idempotencyService.MarkPending(ctx, idempKey, idempotencyPendingTTL); err != nil {
+			// Check if another request is already processing this operation
+			if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+				s.logger.Info("operation already in progress, please retry",
+					"idempotency_key", idempotencyKey)
+				return nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+			}
 			s.logger.Error("failed to mark operation pending", "error", err)
-			return nil, status.Error(codes.Internal, "failed to acquire idempotency lock")
+			return nil, status.Error(codes.Aborted, "failed to acquire idempotency lock, please retry")
 		}
+		idempotencyLockAcquired = true
+
+		// Cleanup pending state on failure - ensures retries aren't blocked for 5 minutes
+		defer func() {
+			if idempotencyLockAcquired && operationStatus != operationStatusSuccess {
+				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+					s.logger.Warn("failed to cleanup pending idempotency state",
+						"error", delErr,
+						"idempotency_key", idempotencyKey)
+				}
+			}
+		}()
 	}
 
 	// Retrieve account (context carries organization for multi-tenant routing)

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -113,6 +113,20 @@ func NewService(repo *persistence.Repository, lienRepo *persistence.LienReposito
 	}
 }
 
+// NewServiceWithIdempotency creates a new current account service with idempotency support.
+// This is primarily used for testing idempotency paths.
+func NewServiceWithIdempotency(repo *persistence.Repository, lienRepo *persistence.LienRepository, idempotencyService idempotency.Service) *Service {
+	if repo == nil {
+		panic("repository cannot be nil")
+	}
+	return &Service{
+		repo:               repo,
+		lienRepo:           lienRepo,
+		idempotencyService: idempotencyService,
+		logger:             slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}
+}
+
 // NewServiceWithExistingClients creates a new service with pre-created client instances.
 // This constructor is useful when clients need to be shared with other components
 // (e.g., health checkers) to avoid creating duplicate connections.

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -4,19 +4,23 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"gorm.io/gorm"
 )
 
@@ -559,4 +563,280 @@ func TestExecuteDeposit_SafeAddition_UnitsAndNanos(t *testing.T) {
 	if !strings.Contains(st.Message(), "overflow") && !strings.Contains(st.Message(), "must be positive") {
 		t.Errorf("Error should mention overflow or positivity, got: %s", st.Message())
 	}
+}
+
+// mockIdempotencyService implements idempotency.Service for testing
+type mockIdempotencyService struct {
+	mu        sync.Mutex
+	results   map[string]*idempotency.Result
+	pending   map[string]bool
+	checkErr  error
+	storeErr  error
+	deleteErr error
+}
+
+func newMockIdempotencyService() *mockIdempotencyService {
+	return &mockIdempotencyService{
+		results: make(map[string]*idempotency.Result),
+		pending: make(map[string]bool),
+	}
+}
+
+func (m *mockIdempotencyService) Check(_ context.Context, key idempotency.Key) (*idempotency.Result, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.checkErr != nil {
+		return nil, m.checkErr
+	}
+
+	keyStr := key.String()
+	if result, ok := m.results[keyStr]; ok {
+		// Match Redis behavior: return ErrOperationAlreadyProcessed for completed results
+		if result.Status == idempotency.StatusCompleted {
+			return result, idempotency.ErrOperationAlreadyProcessed
+		}
+		return result, nil
+	}
+	return nil, idempotency.ErrResultNotFound
+}
+
+func (m *mockIdempotencyService) MarkPending(_ context.Context, key idempotency.Key, _ time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	keyStr := key.String()
+	if m.pending[keyStr] {
+		return idempotency.ErrOperationAlreadyProcessed
+	}
+	m.pending[keyStr] = true
+	return nil
+}
+
+func (m *mockIdempotencyService) StoreResult(_ context.Context, result idempotency.Result) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.storeErr != nil {
+		return m.storeErr
+	}
+
+	keyStr := result.Key.String()
+	m.results[keyStr] = &result
+	delete(m.pending, keyStr) // Clear pending when result is stored
+	return nil
+}
+
+func (m *mockIdempotencyService) Delete(_ context.Context, key idempotency.Key) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+
+	keyStr := key.String()
+	delete(m.results, keyStr)
+	delete(m.pending, keyStr)
+	return nil
+}
+
+func (m *mockIdempotencyService) Acquire(_ context.Context, _ idempotency.Key, _ idempotency.LockOptions) error {
+	return nil // Not used in these tests
+}
+
+func (m *mockIdempotencyService) Release(_ context.Context, _ idempotency.Key, _ string) error {
+	return nil // Not used in these tests
+}
+
+func (m *mockIdempotencyService) Refresh(_ context.Context, _ idempotency.Key, _ string, _ time.Duration) error {
+	return nil // Not used in these tests
+}
+
+func (m *mockIdempotencyService) IsHeld(_ context.Context, _ idempotency.Key) (bool, error) {
+	return false, nil // Not used in these tests
+}
+
+// setResult pre-populates a cached result for testing cache hits
+func (m *mockIdempotencyService) setResult(key idempotency.Key, data []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.results[key.String()] = &idempotency.Result{
+		Key:         key,
+		Status:      idempotency.StatusCompleted,
+		Data:        data,
+		CompletedAt: time.Now(),
+	}
+}
+
+// setPending marks a key as pending for testing concurrent request rejection
+func (m *mockIdempotencyService) setPending(key idempotency.Key) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pending[key.String()] = true
+}
+
+// isPending checks if a key is in pending state
+func (m *mockIdempotencyService) isPending(key idempotency.Key) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.pending[key.String()]
+}
+
+func TestExecuteDeposit_IdempotencyReturnsCachedResponse(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	mockIdemp := newMockIdempotencyService()
+	svc := NewServiceWithIdempotency(repo, nil, mockIdemp)
+
+	// Create account
+	account, err := domain.NewCurrentAccount("ACC-IDEMP-001", "ACC-IDEMP-001", uuid.New().String(), "GBP")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, account))
+
+	// Pre-populate cached response
+	idempKey := idempotency.Key{
+		TenantID:  svcTestTenantID,
+		Namespace: "current-account",
+		Operation: "deposit",
+		EntityID:  "ACC-IDEMP-001",
+		RequestID: "req-123",
+	}
+
+	// Create a cached deposit response
+	cachedResp := &pb.ExecuteDepositResponse{
+		AccountId:     "ACC-IDEMP-001",
+		TransactionId: "cached-tx-id",
+		Status:        pb.TransactionStatus_TRANSACTION_STATUS_COMPLETED,
+		NewBalance: &commonpb.MoneyAmount{
+			Amount: &money.Money{CurrencyCode: "GBP", Units: 100, Nanos: 0},
+		},
+	}
+	cachedData, err := proto.Marshal(cachedResp)
+	require.NoError(t, err)
+	mockIdemp.setResult(idempKey, cachedData)
+
+	// Execute deposit with same idempotency key
+	req := &pb.ExecuteDepositRequest{
+		AccountId: "ACC-IDEMP-001",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{CurrencyCode: "GBP", Units: 50, Nanos: 0},
+		},
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "req-123"},
+	}
+
+	resp, err := svc.ExecuteDeposit(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, "cached-tx-id", resp.TransactionId, "should return cached transaction ID")
+	require.Equal(t, int64(100), resp.NewBalance.Amount.Units, "should return cached balance")
+}
+
+func TestExecuteDeposit_IdempotencyReturnsAbortedWhenInProgress(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	mockIdemp := newMockIdempotencyService()
+	svc := NewServiceWithIdempotency(repo, nil, mockIdemp)
+
+	// Create account
+	account, err := domain.NewCurrentAccount("ACC-IDEMP-002", "ACC-IDEMP-002", uuid.New().String(), "GBP")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, account))
+
+	// Mark operation as pending (simulating concurrent request)
+	idempKey := idempotency.Key{
+		TenantID:  svcTestTenantID,
+		Namespace: "current-account",
+		Operation: "deposit",
+		EntityID:  "ACC-IDEMP-002",
+		RequestID: "req-456",
+	}
+	mockIdemp.setPending(idempKey)
+
+	// Execute deposit with same idempotency key
+	req := &pb.ExecuteDepositRequest{
+		AccountId: "ACC-IDEMP-002",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{CurrencyCode: "GBP", Units: 50, Nanos: 0},
+		},
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "req-456"},
+	}
+
+	_, err = svc.ExecuteDeposit(ctx, req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Aborted, st.Code(), "should return Aborted for concurrent request")
+	require.Contains(t, st.Message(), "already in progress")
+}
+
+func TestExecuteDeposit_IdempotencyProceedsWithoutKey(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	mockIdemp := newMockIdempotencyService()
+	svc := NewServiceWithIdempotency(repo, nil, mockIdemp)
+
+	// Create account
+	account, err := domain.NewCurrentAccount("ACC-IDEMP-003", "ACC-IDEMP-003", uuid.New().String(), "GBP")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, account))
+
+	// Execute deposit without idempotency key
+	req := &pb.ExecuteDepositRequest{
+		AccountId: "ACC-IDEMP-003",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{CurrencyCode: "GBP", Units: 50, Nanos: 0},
+		},
+		// No IdempotencyKey
+	}
+
+	resp, err := svc.ExecuteDeposit(ctx, req)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.TransactionId)
+	require.Equal(t, int64(50), resp.NewBalance.Amount.Units)
+}
+
+func TestExecuteDeposit_IdempotencyCleanupOnFailure(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	mockIdemp := newMockIdempotencyService()
+	svc := NewServiceWithIdempotency(repo, nil, mockIdemp)
+
+	// Create account but with wrong currency
+	account, err := domain.NewCurrentAccount("ACC-IDEMP-004", "ACC-IDEMP-004", uuid.New().String(), "GBP")
+	require.NoError(t, err)
+	require.NoError(t, repo.Save(ctx, account))
+
+	idempKey := idempotency.Key{
+		TenantID:  svcTestTenantID,
+		Namespace: "current-account",
+		Operation: "deposit",
+		EntityID:  "ACC-IDEMP-004",
+		RequestID: "req-789",
+	}
+
+	// Execute deposit with currency mismatch (will fail)
+	req := &pb.ExecuteDepositRequest{
+		AccountId: "ACC-IDEMP-004",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{CurrencyCode: "USD", Units: 50, Nanos: 0}, // Wrong currency
+		},
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "req-789"},
+	}
+
+	_, err = svc.ExecuteDeposit(ctx, req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.InvalidArgument, st.Code())
+
+	// Verify pending state was cleaned up
+	require.False(t, mockIdemp.isPending(idempKey), "pending state should be cleaned up after failure")
 }

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -250,8 +250,13 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 
 	// Build idempotency key structure for Redis
 	var idempKey idempotency.Key
+	var idempotencyLockAcquired bool
 	if idempotencyKeyStr != "" && s.idempotencyService != nil {
-		tenantID, _ := tenant.FromContext(ctx)
+		tenantID, ok := tenant.FromContext(ctx)
+		if !ok {
+			s.logger.Debug("tenant not found in context for idempotency key",
+				"lien_id", req.LienId)
+		}
 		idempKey = idempotency.Key{
 			TenantID:  string(tenantID),
 			Namespace: idempotencyNamespace,
@@ -282,9 +287,27 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 
 		// Mark operation as pending (distributed lock)
 		if err := s.idempotencyService.MarkPending(ctx, idempKey, idempotencyPendingTTL); err != nil {
+			// Check if another request is already processing this operation
+			if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+				s.logger.Info("operation already in progress, please retry",
+					"idempotency_key", idempotencyKeyStr)
+				return nil, status.Error(codes.Aborted, "operation already in progress, please retry")
+			}
 			s.logger.Error("failed to mark operation pending", "error", err)
-			return nil, status.Error(codes.Internal, "failed to acquire idempotency lock")
+			return nil, status.Error(codes.Aborted, "failed to acquire idempotency lock, please retry")
 		}
+		idempotencyLockAcquired = true
+
+		// Cleanup pending state on failure - ensures retries aren't blocked for 5 minutes
+		defer func() {
+			if idempotencyLockAcquired && operationStatus != operationStatusSuccess {
+				if delErr := s.idempotencyService.Delete(ctx, idempKey); delErr != nil {
+					s.logger.Warn("failed to cleanup pending idempotency state",
+						"error", delErr,
+						"idempotency_key", idempotencyKeyStr)
+				}
+			}
+		}()
 	}
 
 	// First, check for idempotency without locking (read-only check)

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -14,8 +14,11 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
 )
@@ -218,7 +221,7 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 	}, nil
 }
 
-// ExecuteLien converts a reservation to an actual debit atomically
+// ExecuteLien converts a reservation to an actual debit atomically with Redis idempotency
 func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (*pb.ExecuteLienResponse, error) {
 	start := time.Now()
 	operationStatus := operationStatusSuccess
@@ -237,6 +240,51 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 	if err != nil {
 		operationStatus = opStatusInvalidLienID
 		return nil, status.Errorf(codes.InvalidArgument, "invalid lien ID: %v", err)
+	}
+
+	// Get idempotency key if provided
+	var idempotencyKeyStr string
+	if req.IdempotencyKey != nil && req.IdempotencyKey.Key != "" {
+		idempotencyKeyStr = req.IdempotencyKey.Key
+	}
+
+	// Build idempotency key structure for Redis
+	var idempKey idempotency.Key
+	if idempotencyKeyStr != "" && s.idempotencyService != nil {
+		tenantID, _ := tenant.FromContext(ctx)
+		idempKey = idempotency.Key{
+			TenantID:  string(tenantID),
+			Namespace: idempotencyNamespace,
+			Operation: "execute_lien",
+			EntityID:  req.LienId,
+			RequestID: idempotencyKeyStr,
+		}
+
+		// Check Redis for existing result
+		result, err := s.idempotencyService.Check(ctx, idempKey)
+		if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) && result != nil && result.Data != nil {
+			var cachedResp pb.ExecuteLienResponse
+			unmarshalErr := proto.Unmarshal(result.Data, &cachedResp)
+			if unmarshalErr == nil {
+				s.logger.Info("returning cached execute lien response from Redis",
+					"lien_id", req.LienId,
+					"transaction_id", cachedResp.TransactionId,
+					"idempotency_key", idempotencyKeyStr)
+				operationStatus = opStatusIdempotent
+				return &cachedResp, nil
+			}
+			s.logger.Warn("failed to unmarshal cached idempotency result",
+				"error", unmarshalErr)
+		} else if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
+			s.logger.Error("idempotency check failed", "error", err)
+			return nil, status.Error(codes.Internal, "failed to check idempotency")
+		}
+
+		// Mark operation as pending (distributed lock)
+		if err := s.idempotencyService.MarkPending(ctx, idempKey, idempotencyPendingTTL); err != nil {
+			s.logger.Error("failed to mark operation pending", "error", err)
+			return nil, status.Error(codes.Internal, "failed to acquire idempotency lock")
+		}
 	}
 
 	// First, check for idempotency without locking (read-only check)
@@ -369,12 +417,34 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		"transaction_id", transactionID)
 
 	availableMoney := s.calculateAvailableBalance(ctx, lien.AccountID, account.Balance())
-	return &pb.ExecuteLienResponse{
+	resp := &pb.ExecuteLienResponse{
 		Lien:             toLienProto(lien),
 		NewBalance:       toMoneyAmount(account.Balance()),
 		AvailableBalance: toMoneyAmount(availableMoney),
 		TransactionId:    transactionID,
-	}, nil
+	}
+
+	// Store successful result in Redis for future idempotency checks
+	if idempotencyKeyStr != "" && s.idempotencyService != nil {
+		responseData, marshalErr := proto.Marshal(resp)
+		if marshalErr == nil {
+			storeErr := s.idempotencyService.StoreResult(ctx, idempotency.Result{
+				Key:         idempKey,
+				Status:      idempotency.StatusCompleted,
+				Data:        responseData,
+				CompletedAt: time.Now(),
+				TTL:         idempotencyResultTTL,
+			})
+			if storeErr != nil {
+				s.logger.Error("failed to store idempotency result", "error", storeErr)
+				// Continue - operation succeeded, caching is optimization
+			}
+		} else {
+			s.logger.Error("failed to marshal response for idempotency cache", "error", marshalErr)
+		}
+	}
+
+	return resp, nil
 }
 
 // TerminateLien releases a reservation without executing

--- a/services/current-account/service/lien_service_test.go
+++ b/services/current-account/service/lien_service_test.go
@@ -3,19 +3,23 @@ package service
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"gorm.io/gorm"
 )
 
@@ -562,4 +566,279 @@ func TestMultipleLiens_AvailableBalanceCalculation(t *testing.T) {
 	resp4, err := svc.InitiateLien(ctx, req4)
 	require.NoError(t, err)
 	require.Equal(t, int64(100), resp4.AvailableBalance.Amount.Units) // £500 - £400 = £100
+}
+
+// lienMockIdempotencyService implements idempotency.Service for testing ExecuteLien
+type lienMockIdempotencyService struct {
+	mu        sync.Mutex
+	results   map[string]*idempotency.Result
+	pending   map[string]bool
+	checkErr  error
+	storeErr  error
+	deleteErr error
+}
+
+func newLienMockIdempotencyService() *lienMockIdempotencyService {
+	return &lienMockIdempotencyService{
+		results: make(map[string]*idempotency.Result),
+		pending: make(map[string]bool),
+	}
+}
+
+func (m *lienMockIdempotencyService) Check(_ context.Context, key idempotency.Key) (*idempotency.Result, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.checkErr != nil {
+		return nil, m.checkErr
+	}
+
+	keyStr := key.String()
+	if result, ok := m.results[keyStr]; ok {
+		if result.Status == idempotency.StatusCompleted {
+			return result, idempotency.ErrOperationAlreadyProcessed
+		}
+		return result, nil
+	}
+	return nil, idempotency.ErrResultNotFound
+}
+
+func (m *lienMockIdempotencyService) MarkPending(_ context.Context, key idempotency.Key, _ time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	keyStr := key.String()
+	if m.pending[keyStr] {
+		return idempotency.ErrOperationAlreadyProcessed
+	}
+	m.pending[keyStr] = true
+	return nil
+}
+
+func (m *lienMockIdempotencyService) StoreResult(_ context.Context, result idempotency.Result) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.storeErr != nil {
+		return m.storeErr
+	}
+
+	keyStr := result.Key.String()
+	m.results[keyStr] = &result
+	delete(m.pending, keyStr)
+	return nil
+}
+
+func (m *lienMockIdempotencyService) Delete(_ context.Context, key idempotency.Key) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+
+	keyStr := key.String()
+	delete(m.results, keyStr)
+	delete(m.pending, keyStr)
+	return nil
+}
+
+func (m *lienMockIdempotencyService) Acquire(_ context.Context, _ idempotency.Key, _ idempotency.LockOptions) error {
+	return nil
+}
+
+func (m *lienMockIdempotencyService) Release(_ context.Context, _ idempotency.Key, _ string) error {
+	return nil
+}
+
+func (m *lienMockIdempotencyService) Refresh(_ context.Context, _ idempotency.Key, _ string, _ time.Duration) error {
+	return nil
+}
+
+func (m *lienMockIdempotencyService) IsHeld(_ context.Context, _ idempotency.Key) (bool, error) {
+	return false, nil
+}
+
+func (m *lienMockIdempotencyService) setResult(key idempotency.Key, data []byte) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.results[key.String()] = &idempotency.Result{
+		Key:         key,
+		Status:      idempotency.StatusCompleted,
+		Data:        data,
+		CompletedAt: time.Now(),
+	}
+}
+
+func (m *lienMockIdempotencyService) setPending(key idempotency.Key) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pending[key.String()] = true
+}
+
+func (m *lienMockIdempotencyService) isPending(key idempotency.Key) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.pending[key.String()]
+}
+
+func TestExecuteLien_IdempotencyReturnsCachedResponse(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	mockIdemp := newLienMockIdempotencyService()
+	svc := NewServiceWithIdempotency(repo, lienRepo, mockIdemp)
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-IDEMP-001", 100000)
+
+	// Create lien for £500
+	lienAmount, err := domain.NewMoney("GBP", 50000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "PO-IDEMP-1", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(lien))
+
+	// Pre-populate cached response
+	idempKey := idempotency.Key{
+		TenantID:  lienSvcTestTenantID,
+		Namespace: "current-account",
+		Operation: "execute_lien",
+		EntityID:  lien.ID.String(),
+		RequestID: "lien-req-123",
+	}
+
+	cachedResp := &pb.ExecuteLienResponse{
+		Lien: &pb.Lien{
+			LienId: lien.ID.String(),
+			Status: pb.LienStatus_LIEN_STATUS_EXECUTED,
+		},
+		TransactionId: "cached-lien-tx-id",
+		NewBalance: &commonpb.MoneyAmount{
+			Amount: &money.Money{CurrencyCode: "GBP", Units: 500, Nanos: 0},
+		},
+	}
+	cachedData, err := proto.Marshal(cachedResp)
+	require.NoError(t, err)
+	mockIdemp.setResult(idempKey, cachedData)
+
+	// Execute lien with same idempotency key
+	req := &pb.ExecuteLienRequest{
+		LienId:         lien.ID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "lien-req-123"},
+	}
+
+	resp, err := svc.ExecuteLien(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, "cached-lien-tx-id", resp.TransactionId, "should return cached transaction ID")
+	require.Equal(t, int64(500), resp.NewBalance.Amount.Units, "should return cached balance")
+}
+
+func TestExecuteLien_IdempotencyReturnsAbortedWhenInProgress(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	mockIdemp := newLienMockIdempotencyService()
+	svc := NewServiceWithIdempotency(repo, lienRepo, mockIdemp)
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-IDEMP-002", 100000)
+
+	// Create lien for £500
+	lienAmount, err := domain.NewMoney("GBP", 50000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "PO-IDEMP-2", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(lien))
+
+	// Mark operation as pending
+	idempKey := idempotency.Key{
+		TenantID:  lienSvcTestTenantID,
+		Namespace: "current-account",
+		Operation: "execute_lien",
+		EntityID:  lien.ID.String(),
+		RequestID: "lien-req-456",
+	}
+	mockIdemp.setPending(idempKey)
+
+	// Execute lien with same idempotency key
+	req := &pb.ExecuteLienRequest{
+		LienId:         lien.ID.String(),
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "lien-req-456"},
+	}
+
+	_, err = svc.ExecuteLien(ctx, req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.Aborted, st.Code(), "should return Aborted for concurrent request")
+	require.Contains(t, st.Message(), "already in progress")
+}
+
+func TestExecuteLien_IdempotencyProceedsWithoutKey(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	mockIdemp := newLienMockIdempotencyService()
+	svc := NewServiceWithIdempotency(repo, lienRepo, mockIdemp)
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-IDEMP-003", 100000)
+
+	// Create lien for £500
+	lienAmount, err := domain.NewMoney("GBP", 50000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "PO-IDEMP-3", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(lien))
+
+	// Execute lien without idempotency key
+	req := &pb.ExecuteLienRequest{
+		LienId: lien.ID.String(),
+		// No IdempotencyKey
+	}
+
+	resp, err := svc.ExecuteLien(ctx, req)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.TransactionId)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_EXECUTED, resp.Lien.Status)
+}
+
+func TestExecuteLien_IdempotencyCleanupOnFailure(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	mockIdemp := newLienMockIdempotencyService()
+	svc := NewServiceWithIdempotency(repo, lienRepo, mockIdemp)
+
+	idempKey := idempotency.Key{
+		TenantID:  lienSvcTestTenantID,
+		Namespace: "current-account",
+		Operation: "execute_lien",
+		EntityID:  uuid.New().String(), // Non-existent lien ID
+		RequestID: "lien-req-789",
+	}
+
+	// Execute lien for non-existent lien (will fail)
+	req := &pb.ExecuteLienRequest{
+		LienId:         idempKey.EntityID,
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "lien-req-789"},
+	}
+
+	_, err := svc.ExecuteLien(ctx, req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, st.Code())
+
+	// Verify pending state was cleaned up
+	require.False(t, mockIdemp.isPending(idempKey), "pending state should be cleaned up after failure")
 }


### PR DESCRIPTION
## Summary
- Add Redis-based idempotency protection to ExecuteDeposit and ExecuteLien operations
- Follow pattern established in payment-order service (Task 11 / PR #569)
- Support tenant-isolated idempotency keys for multi-tenant operation

## Task Master Reference
- **Tag**: ledger-integrity
- **Task ID**: 12

## Changes Made
- **Proto**: Add `idempotency_key` field to `ExecuteDepositRequest` and `ExecuteLienRequest`
- **main.go**: Add Redis client configuration with environment variable support
  - `REDIS_URL`, `REDIS_PASSWORD`, `REDIS_DB`, `REDIS_POOL_SIZE`, `REDIS_MIN_IDLE_CONNS`
- **grpc_service.go**: 
  - Add idempotency service to Service struct
  - Implement idempotency wrapper for ExecuteDeposit (check → mark pending → execute → store result)
- **lien_service.go**: Implement idempotency wrapper for ExecuteLien

## Implementation Details
- 5-minute TTL for pending operations (distributed lock to prevent concurrent duplicates)
- 24-hour TTL for completed results (response caching)
- Graceful fallback when idempotency_key not provided (backward compatible)
- Uses tenant ID from context for multi-tenant key isolation

## Test Plan
- [x] Build passes: `go build ./services/current-account/...`
- [x] All existing tests pass: `go test ./services/current-account/...`
- [ ] Integration test: Verify Redis idempotency with actual Redis instance
- [ ] Load test: Verify concurrent requests with same idempotency key

## Related
- Task 11 / PR #569: Redis idempotency for payment-order service