### PR TITLE
feat: implement idempotency response serialization for CaptureLedgerPosting

### DIFF
--- a/services/financial-accounting/service/financial_accounting_service.go
+++ b/services/financial-accounting/service/financial_accounting_service.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/shopspring/decimal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
@@ -161,10 +163,22 @@ func (s *FinancialAccountingService) CaptureLedgerPosting(
 		result, err := s.idempotency.Check(ctx, idempotencyKey)
 		if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
 			if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
-				if result != nil && result.Status == idempotency.StatusCompleted {
-					// TODO(tech-debt-cleanup#2): Deserialize cached response from result.Data
-					return nil, status.Error(codes.AlreadyExists, "request with this idempotency key already processed")
+				if result != nil && result.Status == idempotency.StatusCompleted && len(result.Data) > 0 {
+					// Deserialize cached response from protobuf
+					var cachedResponse financialaccountingv1.CaptureLedgerPostingResponse
+					if unmarshalErr := proto.Unmarshal(result.Data, &cachedResponse); unmarshalErr != nil {
+						// Log deserialization error but fall back to generic AlreadyExists response
+						slog.Error("failed to deserialize cached idempotency response",
+							"error", unmarshalErr,
+							"idempotency_key", req.IdempotencyKey.Key,
+							"operation", "capture-posting")
+						return nil, status.Error(codes.AlreadyExists, "request with this idempotency key already processed")
+					}
+					// Return cached response for idempotent behavior
+					return &cachedResponse, nil
 				}
+				// No cached data available - return generic AlreadyExists
+				return nil, status.Error(codes.AlreadyExists, "request with this idempotency key already processed")
 			}
 			return nil, status.Errorf(codes.Internal, "failed to check idempotency: %v", err)
 		}
@@ -246,17 +260,31 @@ func (s *FinancialAccountingService) CaptureLedgerPosting(
 			ttl = time.Duration(req.IdempotencyKey.TtlSeconds) * time.Second
 		}
 
-		// TODO(tech-debt-cleanup#2): Serialize response to bytes for storage
-		result := idempotency.Result{
-			Key:         idempotencyKey,
-			Status:      idempotency.StatusCompleted,
-			Data:        nil, // TODO(tech-debt-cleanup#2): Serialize response
-			CompletedAt: time.Now(),
-			TTL:         ttl,
-		}
+		// Serialize response using protobuf for idempotent storage
+		responseData, marshalErr := proto.Marshal(response)
+		if marshalErr != nil {
+			// Log serialization error but don't fail the operation - response was successful
+			slog.Error("failed to serialize response for idempotency cache",
+				"error", marshalErr,
+				"idempotency_key", req.IdempotencyKey.Key,
+				"operation", "capture-posting")
+		} else {
+			result := idempotency.Result{
+				Key:         idempotencyKey,
+				Status:      idempotency.StatusCompleted,
+				Data:        responseData,
+				CompletedAt: time.Now(),
+				TTL:         ttl,
+			}
 
-		// Store result in idempotency cache (best-effort, failures are logged but don't fail request)
-		_ = s.idempotency.StoreResult(ctx, result)
+			// Store result in idempotency cache (best-effort, failures are logged but don't fail request)
+			if storeErr := s.idempotency.StoreResult(ctx, result); storeErr != nil {
+				slog.Error("failed to store idempotency result",
+					"error", storeErr,
+					"idempotency_key", req.IdempotencyKey.Key,
+					"operation", "capture-posting")
+			}
+		}
 	}
 
 	return response, nil

--- a/services/financial-accounting/service/financial_accounting_service_test.go
+++ b/services/financial-accounting/service/financial_accounting_service_test.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
@@ -153,10 +154,11 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 
 // mockIdempotencyService is a test double for idempotency.Service
 type mockIdempotencyService struct {
-	checkResult *idempotency.Result
-	checkErr    error
-	markErr     error
-	storeErr    error
+	checkResult  *idempotency.Result
+	checkErr     error
+	markErr      error
+	storeErr     error
+	storedResult *idempotency.Result // Captured for verification in tests
 }
 
 // Checker interface methods
@@ -171,7 +173,8 @@ func (m *mockIdempotencyService) MarkPending(_ context.Context, _ idempotency.Ke
 	return m.markErr
 }
 
-func (m *mockIdempotencyService) StoreResult(_ context.Context, _ idempotency.Result) error {
+func (m *mockIdempotencyService) StoreResult(_ context.Context, result idempotency.Result) error {
+	m.storedResult = &result
 	return m.storeErr
 }
 
@@ -1161,4 +1164,228 @@ func TestUpdateLedgerPosting_DefensiveTests(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCaptureLedgerPosting_IdempotencyResponseSerialization tests the protobuf serialization
+// and deserialization of idempotent responses per tech-debt-cleanup#2.
+func TestCaptureLedgerPosting_IdempotencyResponseSerialization(t *testing.T) {
+	validBookingLogID := uuid.New()
+	validAccountID := "ACC-123"
+	validValueDate := time.Now()
+
+	t.Run("cached response is deserialized and returned for duplicate request", func(t *testing.T) {
+		// Arrange - Create a properly serialized cached response
+		cachedPostingID := uuid.New()
+		cachedResponse := &financialaccountingv1.CaptureLedgerPostingResponse{
+			LedgerPosting: &financialaccountingv1.LedgerPosting{
+				Id:                    cachedPostingID.String(),
+				FinancialBookingLogId: validBookingLogID.String(),
+				PostingDirection:      commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+				PostingAmount: &money.Money{
+					CurrencyCode: "GBP",
+					Units:        100,
+					Nanos:        500000000,
+				},
+				AccountId: validAccountID,
+				ValueDate: timestamppb.New(validValueDate),
+				Status:    commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING,
+				CreatedAt: timestamppb.Now(),
+			},
+		}
+
+		// Serialize the response just like the production code does
+		cachedData, err := proto.Marshal(cachedResponse)
+		require.NoError(t, err, "serialization should succeed")
+		require.NotEmpty(t, cachedData, "serialized data should not be empty")
+
+		// Set up the mock to return the cached result
+		mockIdem := &mockIdempotencyService{
+			checkResult: &idempotency.Result{
+				Status: idempotency.StatusCompleted,
+				Data:   cachedData,
+			},
+			checkErr: idempotency.ErrOperationAlreadyProcessed,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.CaptureLedgerPostingRequest{
+			FinancialBookingLogId: validBookingLogID.String(),
+			PostingDirection:      commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+			PostingAmount: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        100,
+				Nanos:        500000000,
+			},
+			AccountId: validAccountID,
+			ValueDate: timestamppb.New(validValueDate),
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "duplicate-key",
+			},
+		}
+
+		// Act
+		resp, err := service.CaptureLedgerPosting(context.Background(), req)
+
+		// Assert - Should return the cached response, not an error
+		require.NoError(t, err, "should return cached response without error")
+		require.NotNil(t, resp, "response should not be nil")
+		require.NotNil(t, resp.LedgerPosting, "ledger posting should not be nil")
+		assert.Equal(t, cachedPostingID.String(), resp.LedgerPosting.Id, "should return the cached posting ID")
+		assert.Equal(t, validBookingLogID.String(), resp.LedgerPosting.FinancialBookingLogId)
+		assert.Equal(t, commonv1.PostingDirection_POSTING_DIRECTION_DEBIT, resp.LedgerPosting.PostingDirection)
+	})
+
+	t.Run("corrupted cached data returns AlreadyExists error", func(t *testing.T) {
+		// Arrange - Use invalid protobuf data
+		mockIdem := &mockIdempotencyService{
+			checkResult: &idempotency.Result{
+				Status: idempotency.StatusCompleted,
+				Data:   []byte("invalid-protobuf-garbage-data"),
+			},
+			checkErr: idempotency.ErrOperationAlreadyProcessed,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.CaptureLedgerPostingRequest{
+			FinancialBookingLogId: validBookingLogID.String(),
+			PostingDirection:      commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+			PostingAmount: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        100,
+				Nanos:        0,
+			},
+			AccountId: validAccountID,
+			ValueDate: timestamppb.New(validValueDate),
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "corrupted-cache-key",
+			},
+		}
+
+		// Act
+		resp, err := service.CaptureLedgerPosting(context.Background(), req)
+
+		// Assert - Should return AlreadyExists error when deserialization fails
+		require.Error(t, err, "should return error for corrupted cache")
+		require.Nil(t, resp, "response should be nil")
+		st, ok := status.FromError(err)
+		require.True(t, ok, "should be a gRPC status error")
+		assert.Equal(t, codes.AlreadyExists, st.Code(), "should return AlreadyExists for corrupted cache")
+		assert.Contains(t, st.Message(), "already processed", "message should indicate duplicate processing")
+	})
+
+	t.Run("empty cached data returns AlreadyExists error", func(t *testing.T) {
+		// Arrange - Empty data but completed status
+		mockIdem := &mockIdempotencyService{
+			checkResult: &idempotency.Result{
+				Status: idempotency.StatusCompleted,
+				Data:   nil, // No cached data
+			},
+			checkErr: idempotency.ErrOperationAlreadyProcessed,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.CaptureLedgerPostingRequest{
+			FinancialBookingLogId: validBookingLogID.String(),
+			PostingDirection:      commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+			PostingAmount: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        100,
+				Nanos:        0,
+			},
+			AccountId: validAccountID,
+			ValueDate: timestamppb.New(validValueDate),
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "empty-cache-key",
+			},
+		}
+
+		// Act
+		resp, err := service.CaptureLedgerPosting(context.Background(), req)
+
+		// Assert - Should return AlreadyExists error when no cached data
+		require.Error(t, err, "should return error for empty cache")
+		require.Nil(t, resp, "response should be nil")
+		st, ok := status.FromError(err)
+		require.True(t, ok, "should be a gRPC status error")
+		assert.Equal(t, codes.AlreadyExists, st.Code(), "should return AlreadyExists for empty cache")
+	})
+}
+
+// TestCaptureLedgerPosting_IdempotencySerializationRoundTrip verifies the full round-trip
+// of response serialization by using proto.Marshal and proto.Unmarshal directly.
+func TestCaptureLedgerPosting_IdempotencySerializationRoundTrip(t *testing.T) {
+	t.Run("protobuf serialization round-trip preserves all fields", func(t *testing.T) {
+		// Arrange - Create a response with all fields populated
+		postingID := uuid.New()
+		bookingLogID := uuid.New()
+		now := time.Now()
+
+		originalResponse := &financialaccountingv1.CaptureLedgerPostingResponse{
+			LedgerPosting: &financialaccountingv1.LedgerPosting{
+				Id:                    postingID.String(),
+				FinancialBookingLogId: bookingLogID.String(),
+				PostingDirection:      commonv1.PostingDirection_POSTING_DIRECTION_CREDIT,
+				PostingAmount: &money.Money{
+					CurrencyCode: "EUR",
+					Units:        999,
+					Nanos:        123456789,
+				},
+				AccountId:     "ACC-456",
+				ValueDate:     timestamppb.New(now),
+				Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING,
+				PostingResult: "test-result",
+				CreatedAt:     timestamppb.New(now),
+			},
+		}
+
+		// Act - Serialize
+		data, err := proto.Marshal(originalResponse)
+		require.NoError(t, err, "serialization should succeed")
+		require.NotEmpty(t, data, "serialized data should not be empty")
+
+		// Act - Deserialize
+		var deserializedResponse financialaccountingv1.CaptureLedgerPostingResponse
+		err = proto.Unmarshal(data, &deserializedResponse)
+		require.NoError(t, err, "deserialization should succeed")
+
+		// Assert - All fields preserved
+		require.NotNil(t, deserializedResponse.LedgerPosting, "posting should not be nil")
+		assert.Equal(t, postingID.String(), deserializedResponse.LedgerPosting.Id)
+		assert.Equal(t, bookingLogID.String(), deserializedResponse.LedgerPosting.FinancialBookingLogId)
+		assert.Equal(t, commonv1.PostingDirection_POSTING_DIRECTION_CREDIT, deserializedResponse.LedgerPosting.PostingDirection)
+		assert.Equal(t, "EUR", deserializedResponse.LedgerPosting.PostingAmount.CurrencyCode)
+		assert.Equal(t, int64(999), deserializedResponse.LedgerPosting.PostingAmount.Units)
+		assert.Equal(t, int32(123456789), deserializedResponse.LedgerPosting.PostingAmount.Nanos)
+		assert.Equal(t, "ACC-456", deserializedResponse.LedgerPosting.AccountId)
+		assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING, deserializedResponse.LedgerPosting.Status)
+		assert.Equal(t, "test-result", deserializedResponse.LedgerPosting.PostingResult)
+	})
+
+	t.Run("protobuf serialization handles empty response gracefully", func(t *testing.T) {
+		// Arrange - Empty response
+		originalResponse := &financialaccountingv1.CaptureLedgerPostingResponse{
+			LedgerPosting: &financialaccountingv1.LedgerPosting{},
+		}
+
+		// Act - Serialize
+		data, err := proto.Marshal(originalResponse)
+		require.NoError(t, err, "serialization of empty response should succeed")
+
+		// Act - Deserialize
+		var deserializedResponse financialaccountingv1.CaptureLedgerPostingResponse
+		err = proto.Unmarshal(data, &deserializedResponse)
+		require.NoError(t, err, "deserialization of empty response should succeed")
+
+		// Assert
+		assert.NotNil(t, deserializedResponse.LedgerPosting, "posting should not be nil")
+	})
 }

--- a/services/financial-accounting/service/grpc_integration_test.go
+++ b/services/financial-accounting/service/grpc_integration_test.go
@@ -515,13 +515,17 @@ func TestCaptureLedgerPosting_Integration_WithIdempotencyKey(t *testing.T) {
 	resp1, err := ts.grpcClient.CaptureLedgerPosting(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp1)
+	require.NotNil(t, resp1.LedgerPosting)
+	originalPostingID := resp1.LedgerPosting.Id
 
-	// Second request with same idempotency key should fail
-	_, err = ts.grpcClient.CaptureLedgerPosting(ctx, req)
-	require.Error(t, err)
-	st, ok := status.FromError(err)
-	require.True(t, ok)
-	assert.Equal(t, codes.AlreadyExists, st.Code())
+	// Second request with same idempotency key should return cached response (idempotent)
+	resp2, err := ts.grpcClient.CaptureLedgerPosting(ctx, req)
+	require.NoError(t, err, "idempotent request should succeed with cached response")
+	require.NotNil(t, resp2)
+	require.NotNil(t, resp2.LedgerPosting)
+	assert.Equal(t, originalPostingID, resp2.LedgerPosting.Id, "should return same posting ID from cache")
+	assert.Equal(t, resp1.LedgerPosting.PostingDirection, resp2.LedgerPosting.PostingDirection)
+	assert.Equal(t, resp1.LedgerPosting.AccountId, resp2.LedgerPosting.AccountId)
 }
 
 func TestCaptureLedgerPosting_Integration_InvalidBookingLogID(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add protobuf serialization/deserialization for idempotency cached responses in `CaptureLedgerPosting`
- Enable true idempotent behavior: duplicate requests return cached responses instead of errors
- Add comprehensive unit tests for serialization round-trip and error handling

## Task Master Reference
- **Tag**: tech-debt-cleanup
- **Task ID**: 2

## Changes Made
- `financial_accounting_service.go`: 
  - Add `proto.Marshal` to serialize response when storing in idempotency cache
  - Add `proto.Unmarshal` to deserialize cached response for duplicate requests
  - Add proper error handling with logging for serialization failures
- `financial_accounting_service_test.go`:
  - Add tests for cached response deserialization
  - Add tests for corrupted cache data handling
  - Add tests for empty cache data handling
  - Add protobuf serialization round-trip tests
- `grpc_integration_test.go`:
  - Update integration test to expect idempotent response behavior (success) instead of AlreadyExists error

## Test Plan
- [x] Unit tests for serialization round-trip preserve all fields
- [x] Unit tests for deserialization of cached responses
- [x] Unit tests for corrupted cache data returns AlreadyExists error gracefully
- [x] Unit tests for empty cache data returns AlreadyExists error
- [x] Integration test verifies duplicate requests return same posting ID