### PR TITLE
Add compensation logic for payment ledger postings (task 8)

### DIFF
--- a/services/payment-order/service/grpc_service.go
+++ b/services/payment-order/service/grpc_service.go
@@ -794,6 +794,10 @@ func (s *Service) storeIdempotencyFailure(ctx context.Context, key idempotency.K
 // Returns an error if the state transition or persistence fails. Callers in synchronous paths
 // (e.g., UpdatePaymentOrder) should propagate this error to clients. Callers in async paths
 // (e.g., saga orchestration) may log and swallow the error.
+//
+// Compensation logic:
+// - Reverses ledger entries if LedgerBookingID exists (defensive - normally empty on failure)
+// - Releases lien if payment was in RESERVED or EXECUTING state
 func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder, reason string, errorCode string) error {
 	// Capture original status before transitioning (for event)
 	failedAtStatus := po.Status
@@ -801,6 +805,21 @@ func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder,
 	// Check if lien needs to be released before transitioning
 	needsLienRelease := po.RequiresLienRelease()
 	lienID := po.LienID
+	originalLedgerBookingID := po.LedgerBookingID
+
+	// Reverse ledger posting if it exists (defensive - normally empty before COMPLETED)
+	// This handles edge cases where ledger posting succeeded but state transition failed
+	if originalLedgerBookingID != "" {
+		_, err := s.reverseLedgerPosting(ctx, po, fmt.Sprintf("Payment failure: %s", reason))
+		if err != nil {
+			// Log but continue - ledger reversal failure shouldn't block payment failure
+			// The orphaned booking log will be flagged for reconciliation
+			s.logger.Error("failed to reverse ledger posting on payment failure",
+				"error", err,
+				"payment_order_id", po.ID.String(),
+				"original_ledger_booking_id", originalLedgerBookingID)
+		}
+	}
 
 	// Transition to FAILED
 	if err := po.Fail(reason, errorCode); err != nil {
@@ -852,6 +871,7 @@ func (s *Service) failPaymentOrder(ctx context.Context, po *domain.PaymentOrder,
 		"payment_order_id", po.ID.String(),
 		"reason", reason,
 		"error_code", errorCode,
+		"original_ledger_booking_id", originalLedgerBookingID,
 		"idempotency_key", po.IdempotencyKey,
 		"correlation_id", po.CorrelationID)
 
@@ -1392,6 +1412,194 @@ func (s *Service) postLedgerEntries(ctx context.Context, po *domain.PaymentOrder
 	return bookingLogID, nil
 }
 
+// reverseLedgerPosting creates compensating journal entries for a payment that needs reversal.
+// This reverses the original posting by swapping debit and credit directions:
+//   - CREDIT: Customer's account (funds returning to their account)
+//   - DEBIT: Gateway's contra-account (reducing liability to payment processor)
+//
+// The function is idempotent: using a deterministic idempotency key based on the original
+// payment's IdempotencyKey ensures multiple calls for the same reversal produce the same result.
+//
+// Parameters:
+//   - po: The payment order with the original LedgerBookingID to reverse
+//   - reason: The reason for reversal (for audit purposes in the BookingLog)
+//
+// Returns:
+//   - string: The new compensating booking log ID
+//   - error: Any error encountered during the reversal process
+//
+// Idempotency:
+//   - BookingLog: Uses "reversal-booking-log-{original-idempotency-key}"
+//   - Credit posting: Uses "reversal-credit-{original-idempotency-key}"
+//   - Debit posting: Uses "reversal-debit-{original-idempotency-key}"
+//
+// If the payment has no LedgerBookingID (failed before ledger posting), returns empty string and nil.
+// If the financial accounting client is not configured, returns empty string and nil (ledger reversal skipped).
+func (s *Service) reverseLedgerPosting(ctx context.Context, po *domain.PaymentOrder, reason string) (string, error) {
+	// No ledger entry to reverse if LedgerBookingID is empty
+	if po.LedgerBookingID == "" {
+		s.logger.Debug("no ledger entry to reverse - payment had no ledger posting",
+			"payment_order_id", po.ID.String())
+		return "", nil
+	}
+
+	// Skip ledger reversal if financial accounting client is not configured
+	// This allows the service to operate without FA integration for testing
+	if s.financialAccountingClient == nil || s.gatewayAccountConfig == nil {
+		s.logger.Warn("skipping ledger reversal - financial accounting client not configured",
+			"payment_order_id", po.ID.String(),
+			"ledger_booking_id", po.LedgerBookingID)
+		return "", nil
+	}
+
+	// Get the gateway contra-account from configuration
+	gatewayID := extractGatewayIDFromRef(po.GatewayReferenceID)
+	contraAccountID, err := s.gatewayAccountConfig.GetContraAccount(gatewayID)
+	if err != nil {
+		return "", fmt.Errorf("failed to get contra-account for gateway %s: %w", gatewayID, err)
+	}
+
+	// Convert domain currency to proto currency
+	protoCurrency := domainCurrencyToProto(po.Amount.Currency())
+	if protoCurrency == commonpb.Currency_CURRENCY_UNSPECIFIED {
+		s.logger.Warn("unsupported currency for reversal posting",
+			"currency", string(po.Amount.Currency()),
+			"payment_order_id", po.ID.String())
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedCurrency, po.Amount.Currency())
+	}
+
+	// Step 1: Create a BookingLog in PENDING status for the reversal
+	reversalBookingLogIDempKey := fmt.Sprintf("reversal-booking-log-%s", po.IdempotencyKey)
+	bookingLogResp, err := s.financialAccountingClient.InitiateFinancialBookingLog(ctx, &financialaccountingv1.InitiateFinancialBookingLogRequest{
+		FinancialAccountType:    commonpb.AccountType_ACCOUNT_TYPE_CURRENT,
+		ProductServiceReference: "payment-order-reversal",
+		BusinessUnitReference:   "payment-order-service",
+		ChartOfAccountsRules:    "payment-reversal",
+		BaseCurrency:            protoCurrency,
+		IdempotencyKey: &commonpb.IdempotencyKey{
+			Key: reversalBookingLogIDempKey,
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create reversal booking log: %w", err)
+	}
+	reversalBookingLogID := bookingLogResp.FinancialBookingLog.Id
+
+	s.logger.Debug("created reversal booking log",
+		"reversal_booking_log_id", reversalBookingLogID,
+		"original_booking_log_id", po.LedgerBookingID,
+		"payment_order_id", po.ID.String(),
+		"reason", reason)
+
+	// Convert amount from cents to google.type.Money format
+	amountCents, err := po.Amount.ToMinorUnits()
+	if err != nil {
+		return "", fmt.Errorf("amount overflow for reversal posting: %w", err)
+	}
+	postingAmount := &money.Money{
+		CurrencyCode: string(po.Amount.Currency()),
+		Units:        amountCents / 100,
+		Nanos:        int32((amountCents % 100) * 10000000),
+	}
+	valueDate := timestamppb.Now()
+
+	// Step 2: Create CREDIT posting (customer account - funds returning)
+	// This reverses the original DEBIT on the customer account
+	reversalCreditIdempKey := fmt.Sprintf("reversal-credit-%s", po.IdempotencyKey)
+	_, err = s.financialAccountingClient.CaptureLedgerPosting(ctx, &financialaccountingv1.CaptureLedgerPostingRequest{
+		FinancialBookingLogId: reversalBookingLogID,
+		PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_CREDIT,
+		PostingAmount:         postingAmount,
+		AccountId:             po.DebtorAccountID,
+		ValueDate:             valueDate,
+		IdempotencyKey: &commonpb.IdempotencyKey{
+			Key: reversalCreditIdempKey,
+		},
+	})
+	if err != nil {
+		s.logger.Error("RECONCILIATION_REQUIRED: reversal booking log orphaned after credit posting failure",
+			"reversal_booking_log_id", reversalBookingLogID,
+			"original_booking_log_id", po.LedgerBookingID,
+			"booking_log_status", "PENDING",
+			"payment_order_id", po.ID.String(),
+			"failed_step", "reversal_credit_posting",
+			"debtor_account", po.DebtorAccountID,
+			"error", err.Error())
+		return "", fmt.Errorf("failed to create reversal credit posting for account %s: %w", po.DebtorAccountID, err)
+	}
+
+	s.logger.Debug("created reversal credit posting",
+		"reversal_booking_log_id", reversalBookingLogID,
+		"account_id", po.DebtorAccountID,
+		"amount_cents", amountCents,
+		"payment_order_id", po.ID.String())
+
+	// Step 3: Create DEBIT posting (gateway contra-account - reducing liability)
+	// This reverses the original CREDIT on the gateway contra-account
+	reversalDebitIdempKey := fmt.Sprintf("reversal-debit-%s", po.IdempotencyKey)
+	_, err = s.financialAccountingClient.CaptureLedgerPosting(ctx, &financialaccountingv1.CaptureLedgerPostingRequest{
+		FinancialBookingLogId: reversalBookingLogID,
+		PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_DEBIT,
+		PostingAmount:         postingAmount,
+		AccountId:             contraAccountID,
+		ValueDate:             valueDate,
+		IdempotencyKey: &commonpb.IdempotencyKey{
+			Key: reversalDebitIdempKey,
+		},
+	})
+	if err != nil {
+		s.logger.Error("RECONCILIATION_REQUIRED: reversal booking log orphaned after debit posting failure",
+			"reversal_booking_log_id", reversalBookingLogID,
+			"original_booking_log_id", po.LedgerBookingID,
+			"booking_log_status", "PENDING",
+			"payment_order_id", po.ID.String(),
+			"failed_step", "reversal_debit_posting",
+			"debtor_account", po.DebtorAccountID,
+			"contra_account", contraAccountID,
+			"has_credit_posting", true,
+			"error", err.Error())
+		return "", fmt.Errorf("failed to create reversal debit posting for account %s: %w", contraAccountID, err)
+	}
+
+	s.logger.Debug("created reversal debit posting",
+		"reversal_booking_log_id", reversalBookingLogID,
+		"account_id", contraAccountID,
+		"amount_cents", amountCents,
+		"payment_order_id", po.ID.String())
+
+	// Step 4: Update BookingLog status to POSTED
+	_, err = s.financialAccountingClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
+		Id:     reversalBookingLogID,
+		Status: commonpb.TransactionStatus_TRANSACTION_STATUS_POSTED,
+	})
+	if err != nil {
+		s.logger.Error("RECONCILIATION_REQUIRED: reversal booking log status update failed after successful postings",
+			"reversal_booking_log_id", reversalBookingLogID,
+			"original_booking_log_id", po.LedgerBookingID,
+			"booking_log_status", "PENDING",
+			"target_status", "POSTED",
+			"payment_order_id", po.ID.String(),
+			"failed_step", "reversal_status_update",
+			"has_credit_posting", true,
+			"has_debit_posting", true,
+			"resolution", "manually update booking log status to POSTED",
+			"error", err.Error())
+		return "", fmt.Errorf("failed to update reversal booking log to POSTED: %w", err)
+	}
+
+	s.logger.Info("reversal ledger posting completed successfully",
+		"reversal_booking_log_id", reversalBookingLogID,
+		"original_booking_log_id", po.LedgerBookingID,
+		"payment_order_id", po.ID.String(),
+		"debtor_account", po.DebtorAccountID,
+		"contra_account", contraAccountID,
+		"amount_cents", amountCents,
+		"currency", string(po.Amount.Currency()),
+		"reason", reason)
+
+	return reversalBookingLogID, nil
+}
+
 // extractGatewayIDFromRef extracts the gateway identifier from a gateway reference ID.
 //
 // Gateway Reference ID Format:
@@ -1654,6 +1862,18 @@ func (s *Service) ReversePaymentOrder(ctx context.Context, req *pb.ReversePaymen
 	// Store original ledger booking ID for the event
 	originalLedgerBookingID := po.LedgerBookingID
 
+	// Create compensating ledger entries if original posting exists
+	// This must happen before state transition to ensure ledger consistency
+	compensatingBookingID, err := s.reverseLedgerPosting(ctx, po, req.ReversalReason)
+	if err != nil {
+		s.logger.Error("failed to create compensating ledger entries for reversal",
+			"payment_order_id", po.ID.String(),
+			"original_ledger_booking_id", originalLedgerBookingID,
+			"error", err)
+		// Don't cache internal errors - allow retry on recovery
+		return nil, status.Errorf(codes.Internal, "failed to create compensating ledger entries: %v", err)
+	}
+
 	// Reverse the payment order
 	if err := po.Reverse(req.ReversalReason); err != nil {
 		// Don't cache internal errors - allow retry on recovery
@@ -1666,10 +1886,7 @@ func (s *Service) ReversePaymentOrder(ctx context.Context, req *pb.ReversePaymen
 		return nil, status.Error(codes.Internal, "failed to update payment order")
 	}
 
-	// Publish PaymentOrderReversed event
-	// Note: In a full implementation, this would trigger compensating ledger entries
-	// via FinancialAccounting service. For now, we publish the event for downstream
-	// consumers to handle the compensation.
+	// Publish PaymentOrderReversed event with compensating booking ID
 	s.publishEvent(ctx, TopicPaymentOrderReversed, po.ID.String(), &eventsv1.PaymentOrderReversedEvent{
 		EventId:                     uuid.New().String(),
 		PaymentOrderId:              po.ID.String(),
@@ -1678,7 +1895,7 @@ func (s *Service) ReversePaymentOrder(ctx context.Context, req *pb.ReversePaymen
 		ReversalReason:              req.ReversalReason,
 		ReversedBy:                  req.ReversedBy,
 		OriginalLedgerBookingId:     originalLedgerBookingID,
-		CompensatingLedgerBookingId: "", // Will be populated when FA service creates compensating entry
+		CompensatingLedgerBookingId: compensatingBookingID,
 		CorrelationId:               po.CorrelationID,
 		CausationId:                 po.ID.String(),
 		Timestamp:                   timestamppb.Now(),
@@ -1693,6 +1910,7 @@ func (s *Service) ReversePaymentOrder(ctx context.Context, req *pb.ReversePaymen
 		"amount_cents", safeMinorUnits(po.Amount),
 		"currency", string(po.Amount.Currency()),
 		"original_ledger_booking_id", originalLedgerBookingID,
+		"compensating_booking_id", compensatingBookingID,
 		"correlation_id", po.CorrelationID)
 
 	// Store successful result in Redis for future idempotency checks

--- a/services/payment-order/service/grpc_service_test.go
+++ b/services/payment-order/service/grpc_service_test.go
@@ -750,6 +750,9 @@ var ErrDatabaseError = errors.New("database error")
 // ErrLienServiceUnavailable is a test error for lien service failures
 var ErrLienServiceUnavailable = errors.New("lien service unavailable")
 
+// ErrFAServiceUnavailable is a test error for financial accounting service failures
+var ErrFAServiceUnavailable = errors.New("FA service unavailable")
+
 func TestInitiatePaymentOrder_RepositoryError(t *testing.T) {
 	repo := NewMockRepository()
 	repo.createErr = ErrDatabaseError
@@ -1659,6 +1662,190 @@ func TestReversePaymentOrder_InvalidID(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, st.Code())
 	assert.Contains(t, st.Message(), "invalid payment order ID")
+}
+
+// Test ledger reversal on ReversePaymentOrder
+func TestReversePaymentOrder_WithLedgerReversal(t *testing.T) {
+	repo := NewMockRepository()
+	faClient := &MockFinancialAccountingClient{}
+	gatewayConfig, _ := config.NewGatewayAccountConfig(map[string]*config.GatewayAccountMapping{
+		"mock": {GatewayID: "mock", ContraAccountID: "CONTRA-123", AccountType: config.AccountTypeNostro},
+	})
+
+	svc, err := NewServiceWithConfig(Config{
+		Repository:                repo,
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		FinancialAccountingClient: faClient,
+		PaymentGateway:            &MockPaymentGateway{response: gateway.PaymentResponse{Status: gateway.StatusAccepted, GatewayReferenceID: "GW-123"}},
+		GatewayAccountConfig:      gatewayConfig,
+		IdempotencyService:        NewMockIdempotencyService(),
+	})
+	require.NoError(t, err)
+
+	// Create a completed payment order with ledger booking ID
+	amount, _ := domain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("GW-ref-123")
+	_ = po.Complete("ledger-booking-123")
+	_ = repo.Create(context.Background(), po)
+
+	req := &pb.ReversePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		ReversalReason: "Customer requested refund",
+		ReversedBy:     "support@example.com",
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "reverse-key"},
+	}
+
+	resp, err := svc.ReversePaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_REVERSED, resp.PaymentOrder.Status)
+
+	// Verify FA client was called with reversal entries
+	assert.True(t, faClient.initiateCalled, "InitiateFinancialBookingLog should be called for reversal")
+	assert.True(t, faClient.captureCalled, "CaptureLedgerPosting should be called for reversal")
+	assert.Equal(t, 2, faClient.captureCallCount, "Should capture 2 postings (credit + debit)")
+	assert.True(t, faClient.updateCalled, "UpdateFinancialBookingLog should be called to mark as POSTED")
+}
+
+// Test that reversal without LedgerBookingID skips ledger reversal
+func TestReversePaymentOrder_NoLedgerBooking_SkipsReversal(t *testing.T) {
+	repo := NewMockRepository()
+	faClient := &MockFinancialAccountingClient{}
+	gatewayConfig, _ := config.NewGatewayAccountConfig(map[string]*config.GatewayAccountMapping{
+		"mock": {GatewayID: "mock", ContraAccountID: "CONTRA-123", AccountType: config.AccountTypeNostro},
+	})
+
+	svc, err := NewServiceWithConfig(Config{
+		Repository:                repo,
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		FinancialAccountingClient: faClient,
+		PaymentGateway:            &MockPaymentGateway{response: gateway.PaymentResponse{Status: gateway.StatusAccepted, GatewayReferenceID: "GW-123"}},
+		GatewayAccountConfig:      gatewayConfig,
+		IdempotencyService:        NewMockIdempotencyService(),
+	})
+	require.NoError(t, err)
+
+	// Create a completed payment order WITHOUT ledger booking ID
+	amount, _ := domain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("GW-ref-123")
+	_ = po.Complete("") // Empty ledger booking ID
+	_ = repo.Create(context.Background(), po)
+
+	req := &pb.ReversePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		ReversalReason: "Customer requested refund",
+		ReversedBy:     "support@example.com",
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "reverse-key"},
+	}
+
+	resp, err := svc.ReversePaymentOrder(context.Background(), req)
+
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_REVERSED, resp.PaymentOrder.Status)
+
+	// Verify FA client was NOT called (no ledger entry to reverse)
+	assert.False(t, faClient.initiateCalled, "InitiateFinancialBookingLog should NOT be called when no ledger booking exists")
+	assert.False(t, faClient.captureCalled, "CaptureLedgerPosting should NOT be called when no ledger booking exists")
+}
+
+// Test reversal ledger posting failure returns error
+func TestReversePaymentOrder_LedgerReversalFailure(t *testing.T) {
+	repo := NewMockRepository()
+	faClient := &MockFinancialAccountingClient{
+		initiateErr: ErrFAServiceUnavailable,
+	}
+	gatewayConfig, _ := config.NewGatewayAccountConfig(map[string]*config.GatewayAccountMapping{
+		"mock": {GatewayID: "mock", ContraAccountID: "CONTRA-123", AccountType: config.AccountTypeNostro},
+	})
+
+	svc, err := NewServiceWithConfig(Config{
+		Repository:                repo,
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		FinancialAccountingClient: faClient,
+		PaymentGateway:            &MockPaymentGateway{response: gateway.PaymentResponse{Status: gateway.StatusAccepted, GatewayReferenceID: "GW-123"}},
+		GatewayAccountConfig:      gatewayConfig,
+		IdempotencyService:        NewMockIdempotencyService(),
+	})
+	require.NoError(t, err)
+
+	// Create a completed payment order with ledger booking ID
+	amount, _ := domain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("GW-ref-123")
+	_ = po.Complete("ledger-booking-123")
+	_ = repo.Create(context.Background(), po)
+
+	req := &pb.ReversePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		ReversalReason: "Customer requested refund",
+		ReversedBy:     "support@example.com",
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "reverse-key"},
+	}
+
+	_, err = svc.ReversePaymentOrder(context.Background(), req)
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "failed to create compensating ledger entries")
+
+	// Verify payment was NOT reversed (still COMPLETED)
+	retrieved, _ := repo.FindByID(context.Background(), po.ID)
+	assert.Equal(t, domain.PaymentOrderStatusCompleted, retrieved.Status)
+}
+
+// Test reversal creates correct idempotent entries
+func TestReversePaymentOrder_LedgerReversalIdempotency(t *testing.T) {
+	repo := NewMockRepository()
+	faClient := &MockFinancialAccountingClient{}
+	gatewayConfig, _ := config.NewGatewayAccountConfig(map[string]*config.GatewayAccountMapping{
+		"mock": {GatewayID: "mock", ContraAccountID: "CONTRA-123", AccountType: config.AccountTypeNostro},
+	})
+
+	svc, err := NewServiceWithConfig(Config{
+		Repository:                repo,
+		CurrentAccountClient:      &MockCurrentAccountClient{},
+		FinancialAccountingClient: faClient,
+		PaymentGateway:            &MockPaymentGateway{response: gateway.PaymentResponse{Status: gateway.StatusAccepted, GatewayReferenceID: "GW-123"}},
+		GatewayAccountConfig:      gatewayConfig,
+		IdempotencyService:        NewMockIdempotencyService(),
+	})
+	require.NoError(t, err)
+
+	// Create a completed payment order
+	amount, _ := domain.NewMoney("GBP", 10000)
+	po, _ := domain.NewPaymentOrder("ACC-12345678", "GB82WEST12345698765432", amount, "test-key-123", uuid.New().String())
+	_ = po.Reserve("lien-123")
+	_ = po.Execute("GW-ref-123")
+	_ = po.Complete("ledger-booking-123")
+	_ = repo.Create(context.Background(), po)
+
+	req := &pb.ReversePaymentOrderRequest{
+		PaymentOrderId: po.ID.String(),
+		ReversalReason: "Customer requested refund",
+		ReversedBy:     "support@example.com",
+		IdempotencyKey: &commonpb.IdempotencyKey{Key: "reverse-key"},
+	}
+
+	// First reversal call
+	resp1, err := svc.ReversePaymentOrder(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_REVERSED, resp1.PaymentOrder.Status)
+
+	// Second reversal call (idempotent - payment already reversed)
+	resp2, err := svc.ReversePaymentOrder(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_REVERSED, resp2.PaymentOrder.Status)
+
+	// FA client should only be called once (first reversal creates the entries,
+	// second call returns early because payment is already reversed)
+	assert.Equal(t, 1, faClient.captureCallCount/2, "FA client should only be called once for multiple reversal attempts")
 }
 
 // Test proto conversion helpers


### PR DESCRIPTION
## Summary
- Implement reversal journal entries when PaymentOrder transitions to FAILED or REVERSED status
- Add `reverseLedgerPosting` helper function that creates compensating BookingLog with reversed debit/credit entries
- Wire reversal logic into `ReversePaymentOrder` to create ledger reversals before transitioning to REVERSED status
- Add defensive ledger reversal check in `failPaymentOrder` for edge cases where ledger posting succeeded but state transition failed

## Task Master Reference
- **Tag**: ledger-integrity
- **Task ID**: 8

## Changes Made
- `services/payment-order/service/grpc_service.go`:
  - Added `reverseLedgerPosting` helper function (~150 lines) that creates compensating journal entries by swapping debit/credit directions
  - Updated `ReversePaymentOrder` to call `reverseLedgerPosting` before transitioning to REVERSED status
  - Updated `failPaymentOrder` with defensive ledger reversal check
  - Added nil-safe checks for FA client and gateway config
  
- `services/payment-order/service/grpc_service_test.go`:
  - Added 4 new integration tests for ledger reversal logic
  - Added `ErrFAServiceUnavailable` static error for testing

## Test Plan
- [x] Test payment reversal with ledger booking ID triggers compensating entries (2 postings: credit + debit)
- [x] Test reversal without LedgerBookingID skips ledger reversal
- [x] Test reversal failure blocks payment reversal (atomicity preserved)
- [x] Test idempotent behavior on multiple reversal attempts
- [x] All existing payment-order tests continue to pass