### PR TITLE
Add nil parameter validation to position-keeping service constructor

### DIFF
--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -23,12 +23,29 @@ type PositionKeepingService struct {
 	idempotency    idempotency.Service
 }
 
-// NewPositionKeepingService creates a new PositionKeepingService.
+// NewPositionKeepingService creates a new PositionKeepingService with dependency injection.
+//
+// Dependencies:
+//   - repository: Persistence layer for financial position logs (must not be nil)
+//   - eventPublisher: Publishes domain events (must not be nil)
+//   - idempotencySvc: Ensures exactly-once processing of idempotent operations (must not be nil)
+//
+// Panics if any dependency is nil (defensive programming per ADR-0008).
 func NewPositionKeepingService(
 	repository domain.FinancialPositionLogRepository,
 	eventPublisher domain.EventPublisher,
 	idempotencySvc idempotency.Service,
 ) *PositionKeepingService {
+	if repository == nil {
+		panic("position keeping service: repository cannot be nil")
+	}
+	if eventPublisher == nil {
+		panic("position keeping service: event publisher cannot be nil")
+	}
+	if idempotencySvc == nil {
+		panic("position keeping service: idempotency service cannot be nil")
+	}
+
 	return &PositionKeepingService{
 		repository:     repository,
 		eventPublisher: eventPublisher,

--- a/services/position-keeping/service/service_test.go
+++ b/services/position-keeping/service/service_test.go
@@ -3,9 +3,12 @@ package service_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/services/position-keeping/service"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 )
 
 func TestNewPositionKeepingService(t *testing.T) {
@@ -20,12 +23,76 @@ func TestNewPositionKeepingService(t *testing.T) {
 			t.Fatal("Expected non-nil service")
 		}
 	})
+}
 
-	t.Run("creates service with nil checks", func(t *testing.T) {
-		// TODO(tech-debt-cleanup#4): Add nil parameter validation in constructor
-		// Currently the constructor accepts nil dependencies
-		t.Skip("Nil validation not yet implemented")
-	})
+// TestNewPositionKeepingService_DefensiveTests verifies nil dependency validation per ADR-0008.
+// Rationale: Financial services must validate all dependencies to prevent runtime panics
+// that could cause service outages or data corruption.
+func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
+	tests := []struct {
+		name           string
+		repository     domain.FinancialPositionLogRepository
+		eventPub       domain.EventPublisher
+		idempotencySvc idempotency.Service
+		shouldPanic    bool
+		rationale      string
+	}{
+		{
+			name:           "valid dependencies",
+			repository:     new(MockRepository),
+			eventPub:       domain.NewInMemoryEventPublisher(),
+			idempotencySvc: new(MockIdempotencyService),
+			shouldPanic:    false,
+			rationale:      "Standard valid initialization with all dependencies",
+		},
+		{
+			name:           "nil repository",
+			repository:     nil,
+			eventPub:       domain.NewInMemoryEventPublisher(),
+			idempotencySvc: new(MockIdempotencyService),
+			shouldPanic:    true,
+			rationale:      "Repository is essential - nil would cause panic on first use",
+		},
+		{
+			name:           "nil event publisher",
+			repository:     new(MockRepository),
+			eventPub:       nil,
+			idempotencySvc: new(MockIdempotencyService),
+			shouldPanic:    true,
+			rationale:      "Event publisher is essential - nil would cause panic when publishing events",
+		},
+		{
+			name:           "nil idempotency service",
+			repository:     new(MockRepository),
+			eventPub:       domain.NewInMemoryEventPublisher(),
+			idempotencySvc: nil,
+			shouldPanic:    true,
+			rationale:      "Idempotency service is essential - nil would cause panic on idempotent operations",
+		},
+		{
+			name:           "all dependencies nil",
+			repository:     nil,
+			eventPub:       nil,
+			idempotencySvc: nil,
+			shouldPanic:    true,
+			rationale:      "Should panic on first nil check (repository)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				assert.Panics(t, func() {
+					service.NewPositionKeepingService(tt.repository, tt.eventPub, tt.idempotencySvc)
+				}, tt.rationale)
+			} else {
+				assert.NotPanics(t, func() {
+					svc := service.NewPositionKeepingService(tt.repository, tt.eventPub, tt.idempotencySvc)
+					assert.NotNil(t, svc, tt.rationale)
+				}, tt.rationale)
+			}
+		})
+	}
 }
 
 func TestServiceImplementsGRPCInterface(t *testing.T) {


### PR DESCRIPTION
## Summary
- Added defensive nil parameter validation with panic() to NewPositionKeepingService constructor
- Follows pattern established in financial-accounting service (ADR-0008)
- Includes comprehensive table-driven tests for all nil scenarios

## Task Master Reference
- **Tag**: tech-debt-cleanup
- **Task ID**: 4

## Changes Made
- services/position-keeping/service/service.go: Added nil validation checks with panic() and documentation
- services/position-keeping/service/service_test.go: Added comprehensive table-driven tests for nil validation

## Test Plan
- Run `go test ./services/position-keeping/service/... -v`
- All existing tests continue to pass
- New nil validation tests verify correct panic behavior