### PR TITLE
feat: add idempotency protection to update operations

### DIFF
--- a/api/proto/meridian/financial_accounting/v1/financial_accounting.proto
+++ b/api/proto/meridian/financial_accounting/v1/financial_accounting.proto
@@ -220,6 +220,9 @@ message UpdateFinancialBookingLogRequest {
   // If empty, the existing rules are preserved (optional update).
   // Validation: Min length is enforced only if the field is provided (service layer).
   string chart_of_accounts_rules = 3;
+
+  // idempotency_key ensures exactly-once processing.
+  meridian.common.v1.IdempotencyKey idempotency_key = 4 [(buf.validate.field).required = true];
 }
 
 // UpdateFinancialBookingLogResponse returns the updated booking log.
@@ -316,6 +319,9 @@ message UpdateLedgerPostingRequest {
   // posting_result describes the outcome of the posting operation.
   // If empty, the existing result is preserved (optional update).
   string posting_result = 3 [(buf.validate.field).string = {max_len: 1000}];
+
+  // idempotency_key ensures exactly-once processing.
+  meridian.common.v1.IdempotencyKey idempotency_key = 4 [(buf.validate.field).required = true];
 }
 
 // UpdateLedgerPostingResponse returns the updated posting.

--- a/services/financial-accounting/service/financial_accounting_service.go
+++ b/services/financial-accounting/service/financial_accounting_service.go
@@ -543,16 +543,18 @@ func (s *FinancialAccountingService) ListLedgerPostings(
 // UpdateLedgerPosting updates an existing ledger posting's status and result.
 //
 // Workflow:
-// 1. Parse and validate request fields
-// 2. Retrieve existing posting by ID
-// 3. Validate state transition rules (e.g., cannot change POSTED status)
-// 4. Apply update using domain methods (Post/Fail)
-// 5. Persist updated posting
-// 6. Publish domain event (LedgerPostingUpdatedEvent)
-// 7. Return updated posting
+// 1. Check idempotency using request's IdempotencyKey
+// 2. Parse and validate request fields
+// 3. Retrieve existing posting by ID
+// 4. Validate state transition rules (e.g., cannot change POSTED status)
+// 5. Apply update using domain methods (Post/Fail)
+// 6. Persist updated posting
+// 7. Publish domain event (LedgerPostingUpdatedEvent)
+// 8. Return updated posting
 //
 // Error mapping:
 // - Invalid request fields -> codes.InvalidArgument
+// - Duplicate idempotency key -> codes.AlreadyExists
 // - Posting not found -> codes.NotFound
 // - Invalid state transition -> codes.FailedPrecondition
 // - Internal errors -> codes.Internal
@@ -560,6 +562,46 @@ func (s *FinancialAccountingService) UpdateLedgerPosting(
 	ctx context.Context,
 	req *financialaccountingv1.UpdateLedgerPostingRequest,
 ) (*financialaccountingv1.UpdateLedgerPostingResponse, error) {
+	// Validate idempotency key is provided
+	if req.IdempotencyKey == nil || req.IdempotencyKey.Key == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	idempotencyKey := idempotency.Key{
+		Namespace: "financial-accounting",
+		Operation: "update-posting",
+		EntityID:  req.GetId(),
+		RequestID: req.IdempotencyKey.Key,
+	}
+
+	// Check idempotency (skip if service not configured - e.g., Redis unavailable in dev)
+	if s.idempotency != nil {
+		result, err := s.idempotency.Check(ctx, idempotencyKey)
+		if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
+			if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+				if result != nil && result.Status == idempotency.StatusCompleted && len(result.Data) > 0 {
+					// Deserialize cached response from protobuf
+					var cachedResponse financialaccountingv1.UpdateLedgerPostingResponse
+					if unmarshalErr := proto.Unmarshal(result.Data, &cachedResponse); unmarshalErr != nil {
+						slog.Error("failed to deserialize cached idempotency response",
+							"error", unmarshalErr,
+							"idempotency_key", req.IdempotencyKey.Key,
+							"operation", "update-posting")
+						return nil, status.Error(codes.AlreadyExists, "request with this idempotency key already processed")
+					}
+					return &cachedResponse, nil
+				}
+				return nil, status.Error(codes.AlreadyExists, "request with this idempotency key already processed")
+			}
+			return nil, status.Errorf(codes.Internal, "failed to check idempotency: %v", err)
+		}
+
+		// Mark as pending to prevent concurrent processing
+		if err := s.idempotency.MarkPending(ctx, idempotencyKey, defaultIdempotencyTTL); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to mark operation as pending: %v", err)
+		}
+	}
+
 	// Parse posting ID
 	postingID, err := parseUUID(req.GetId())
 	if err != nil {
@@ -636,9 +678,43 @@ func (s *FinancialAccountingService) UpdateLedgerPosting(
 	// TODO(75-async-audit#5): Implement LedgerPostingUpdatedEvent and publish it
 
 	// Convert to proto response
-	return &financialaccountingv1.UpdateLedgerPostingResponse{
+	response := &financialaccountingv1.UpdateLedgerPostingResponse{
 		LedgerPosting: toProtoLedgerPosting(posting),
-	}, nil
+	}
+
+	// Store idempotency result (only if service configured)
+	if s.idempotency != nil {
+		ttl := defaultIdempotencyTTL
+		if req.IdempotencyKey.TtlSeconds > 0 {
+			ttl = time.Duration(req.IdempotencyKey.TtlSeconds) * time.Second
+		}
+
+		// Serialize response using protobuf for idempotent storage
+		responseData, marshalErr := proto.Marshal(response)
+		if marshalErr != nil {
+			slog.Error("failed to serialize response for idempotency cache",
+				"error", marshalErr,
+				"idempotency_key", req.IdempotencyKey.Key,
+				"operation", "update-posting")
+		} else {
+			result := idempotency.Result{
+				Key:         idempotencyKey,
+				Status:      idempotency.StatusCompleted,
+				Data:        responseData,
+				CompletedAt: time.Now(),
+				TTL:         ttl,
+			}
+
+			if storeErr := s.idempotency.StoreResult(ctx, result); storeErr != nil {
+				slog.Error("failed to store idempotency result",
+					"error", storeErr,
+					"idempotency_key", req.IdempotencyKey.Key,
+					"operation", "update-posting")
+			}
+		}
+	}
+
+	return response, nil
 }
 
 // isValidCurrencyCode validates that a currency code matches ISO 4217 format.
@@ -810,15 +886,17 @@ func (s *FinancialAccountingService) RetrieveFinancialBookingLog(
 // UpdateFinancialBookingLog updates an existing booking log's status and rules.
 //
 // Workflow:
-// 1. Parse and validate request fields
-// 2. Retrieve existing booking log by ID
-// 3. Validate state transition rules
-// 4. Apply updates using domain methods
-// 5. Persist updated booking log
-// 6. Return updated booking log
+// 1. Check idempotency using request's IdempotencyKey
+// 2. Parse and validate request fields
+// 3. Retrieve existing booking log by ID
+// 4. Validate state transition rules
+// 5. Apply updates using domain methods
+// 6. Persist updated booking log
+// 7. Return updated booking log
 //
 // Error mapping:
 // - Invalid request fields -> codes.InvalidArgument
+// - Duplicate idempotency key -> codes.AlreadyExists
 // - Booking log not found -> codes.NotFound
 // - Invalid state transition -> codes.FailedPrecondition
 // - Internal errors -> codes.Internal
@@ -826,6 +904,46 @@ func (s *FinancialAccountingService) UpdateFinancialBookingLog(
 	ctx context.Context,
 	req *financialaccountingv1.UpdateFinancialBookingLogRequest,
 ) (*financialaccountingv1.UpdateFinancialBookingLogResponse, error) {
+	// Validate idempotency key is provided
+	if req.IdempotencyKey == nil || req.IdempotencyKey.Key == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+
+	idempotencyKey := idempotency.Key{
+		Namespace: "financial-accounting",
+		Operation: "update-booking-log",
+		EntityID:  req.GetId(),
+		RequestID: req.IdempotencyKey.Key,
+	}
+
+	// Check idempotency (skip if service not configured - e.g., Redis unavailable in dev)
+	if s.idempotency != nil {
+		result, err := s.idempotency.Check(ctx, idempotencyKey)
+		if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
+			if errors.Is(err, idempotency.ErrOperationAlreadyProcessed) {
+				if result != nil && result.Status == idempotency.StatusCompleted && len(result.Data) > 0 {
+					// Deserialize cached response from protobuf
+					var cachedResponse financialaccountingv1.UpdateFinancialBookingLogResponse
+					if unmarshalErr := proto.Unmarshal(result.Data, &cachedResponse); unmarshalErr != nil {
+						slog.Error("failed to deserialize cached idempotency response",
+							"error", unmarshalErr,
+							"idempotency_key", req.IdempotencyKey.Key,
+							"operation", "update-booking-log")
+						return nil, status.Error(codes.AlreadyExists, "request with this idempotency key already processed")
+					}
+					return &cachedResponse, nil
+				}
+				return nil, status.Error(codes.AlreadyExists, "request with this idempotency key already processed")
+			}
+			return nil, status.Errorf(codes.Internal, "failed to check idempotency: %v", err)
+		}
+
+		// Mark as pending to prevent concurrent processing
+		if err := s.idempotency.MarkPending(ctx, idempotencyKey, defaultIdempotencyTTL); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to mark operation as pending: %v", err)
+		}
+	}
+
 	// Parse booking log ID
 	bookingLogID, err := parseUUID(req.GetId())
 	if err != nil {
@@ -935,9 +1053,43 @@ func (s *FinancialAccountingService) UpdateFinancialBookingLog(
 	// TODO(75-async-audit#5): Publish FinancialBookingLogUpdatedEvent for inter-service coordination
 
 	// Convert to proto response
-	return &financialaccountingv1.UpdateFinancialBookingLogResponse{
+	response := &financialaccountingv1.UpdateFinancialBookingLogResponse{
 		FinancialBookingLog: toProtoFinancialBookingLog(&updated),
-	}, nil
+	}
+
+	// Store idempotency result (only if service configured)
+	if s.idempotency != nil {
+		ttl := defaultIdempotencyTTL
+		if req.IdempotencyKey.TtlSeconds > 0 {
+			ttl = time.Duration(req.IdempotencyKey.TtlSeconds) * time.Second
+		}
+
+		// Serialize response using protobuf for idempotent storage
+		responseData, marshalErr := proto.Marshal(response)
+		if marshalErr != nil {
+			slog.Error("failed to serialize response for idempotency cache",
+				"error", marshalErr,
+				"idempotency_key", req.IdempotencyKey.Key,
+				"operation", "update-booking-log")
+		} else {
+			result := idempotency.Result{
+				Key:         idempotencyKey,
+				Status:      idempotency.StatusCompleted,
+				Data:        responseData,
+				CompletedAt: time.Now(),
+				TTL:         ttl,
+			}
+
+			if storeErr := s.idempotency.StoreResult(ctx, result); storeErr != nil {
+				slog.Error("failed to store idempotency result",
+					"error", storeErr,
+					"idempotency_key", req.IdempotencyKey.Key,
+					"operation", "update-booking-log")
+			}
+		}
+	}
+
+	return response, nil
 }
 
 // isValidBookingLogTransition validates that a status transition is allowed.

--- a/services/financial-accounting/service/financial_accounting_service.go
+++ b/services/financial-accounting/service/financial_accounting_service.go
@@ -552,6 +552,12 @@ func (s *FinancialAccountingService) ListLedgerPostings(
 // 7. Publish domain event (LedgerPostingUpdatedEvent)
 // 8. Return updated posting
 //
+// Idempotency Note:
+// Unlike CaptureLedgerPosting where idempotency is optional (create operations
+// naturally fail on duplicate IDs), update operations REQUIRE idempotency keys
+// because state-machine transitions must be exactly-once. A duplicate update
+// could incorrectly transition an entity through multiple states.
+//
 // Error mapping:
 // - Invalid request fields -> codes.InvalidArgument
 // - Duplicate idempotency key -> codes.AlreadyExists
@@ -574,7 +580,9 @@ func (s *FinancialAccountingService) UpdateLedgerPosting(
 		RequestID: req.IdempotencyKey.Key,
 	}
 
-	// Check idempotency (skip if service not configured - e.g., Redis unavailable in dev)
+	// Check idempotency - defensive nil check (constructor requires non-nil service)
+	// TODO(ledger-integrity#15): If an error occurs after MarkPending but before StoreResult,
+	// the pending marker is left orphaned until TTL expiry. Consider adding cleanup on error.
 	if s.idempotency != nil {
 		result, err := s.idempotency.Check(ctx, idempotencyKey)
 		if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
@@ -589,6 +597,10 @@ func (s *FinancialAccountingService) UpdateLedgerPosting(
 							"operation", "update-posting")
 						return nil, status.Error(codes.AlreadyExists, "request with this idempotency key already processed")
 					}
+					slog.Info("returning cached idempotent response",
+						"idempotency_key", req.IdempotencyKey.Key,
+						"operation", "update-posting",
+						"posting_id", req.GetId())
 					return &cachedResponse, nil
 				}
 				return nil, status.Error(codes.AlreadyExists, "request with this idempotency key already processed")
@@ -894,6 +906,12 @@ func (s *FinancialAccountingService) RetrieveFinancialBookingLog(
 // 6. Persist updated booking log
 // 7. Return updated booking log
 //
+// Idempotency Note:
+// Unlike InitiateFinancialBookingLog where idempotency is optional (create operations
+// naturally fail on duplicate IDs), update operations REQUIRE idempotency keys
+// because state-machine transitions must be exactly-once. A duplicate update
+// could incorrectly transition an entity through multiple states.
+//
 // Error mapping:
 // - Invalid request fields -> codes.InvalidArgument
 // - Duplicate idempotency key -> codes.AlreadyExists
@@ -916,7 +934,9 @@ func (s *FinancialAccountingService) UpdateFinancialBookingLog(
 		RequestID: req.IdempotencyKey.Key,
 	}
 
-	// Check idempotency (skip if service not configured - e.g., Redis unavailable in dev)
+	// Check idempotency - defensive nil check (constructor requires non-nil service)
+	// TODO(ledger-integrity#15): If an error occurs after MarkPending but before StoreResult,
+	// the pending marker is left orphaned until TTL expiry. Consider adding cleanup on error.
 	if s.idempotency != nil {
 		result, err := s.idempotency.Check(ctx, idempotencyKey)
 		if err != nil && !errors.Is(err, idempotency.ErrResultNotFound) {
@@ -931,6 +951,10 @@ func (s *FinancialAccountingService) UpdateFinancialBookingLog(
 							"operation", "update-booking-log")
 						return nil, status.Error(codes.AlreadyExists, "request with this idempotency key already processed")
 					}
+					slog.Info("returning cached idempotent response",
+						"idempotency_key", req.IdempotencyKey.Key,
+						"operation", "update-booking-log",
+						"booking_log_id", req.GetId())
 					return &cachedResponse, nil
 				}
 				return nil, status.Error(codes.AlreadyExists, "request with this idempotency key already processed")

--- a/services/financial-accounting/service/financial_accounting_service_test.go
+++ b/services/financial-accounting/service/financial_accounting_service_test.go
@@ -1389,3 +1389,459 @@ func TestCaptureLedgerPosting_IdempotencySerializationRoundTrip(t *testing.T) {
 		assert.NotNil(t, deserializedResponse.LedgerPosting, "posting should not be nil")
 	})
 }
+
+// TestUpdateLedgerPosting_IdempotencyRequired tests that idempotency key is required for UpdateLedgerPosting.
+// Per task 14: Add idempotency protection to state-machine update operations.
+func TestUpdateLedgerPosting_IdempotencyRequired(t *testing.T) {
+	validPostingID := uuid.New()
+
+	tests := []struct {
+		name           string
+		idempotencyKey *commonv1.IdempotencyKey
+		wantCode       codes.Code
+		rationale      string
+	}{
+		{
+			name:           "nil idempotency key",
+			idempotencyKey: nil,
+			wantCode:       codes.InvalidArgument,
+			rationale:      "State-machine mutations require idempotency to prevent duplicate transitions",
+		},
+		{
+			name:           "empty idempotency key",
+			idempotencyKey: &commonv1.IdempotencyKey{Key: ""},
+			wantCode:       codes.InvalidArgument,
+			rationale:      "Empty key is equivalent to no key - must be rejected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			repo := persistence.NewLedgerRepository(&gorm.DB{})
+			publisher := &mockEventPublisher{}
+			mockIdem := &mockIdempotencyService{}
+			service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+			req := &financialaccountingv1.UpdateLedgerPostingRequest{
+				Id:             validPostingID.String(),
+				Status:         commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+				PostingResult:  "test",
+				IdempotencyKey: tt.idempotencyKey,
+			}
+
+			// Act
+			resp, err := service.UpdateLedgerPosting(context.Background(), req)
+
+			// Assert
+			require.Error(t, err, tt.rationale)
+			require.Nil(t, resp)
+			st, ok := status.FromError(err)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantCode, st.Code(), tt.rationale)
+			assert.Contains(t, st.Message(), "idempotency_key is required")
+		})
+	}
+}
+
+// TestUpdateLedgerPosting_IdempotencyCaching tests cached response handling for UpdateLedgerPosting.
+func TestUpdateLedgerPosting_IdempotencyCaching(t *testing.T) {
+	validPostingID := uuid.New()
+	validBookingLogID := uuid.New()
+	now := time.Now()
+
+	t.Run("cached response returned for duplicate request", func(t *testing.T) {
+		// Arrange - Create cached response
+		cachedResponse := &financialaccountingv1.UpdateLedgerPostingResponse{
+			LedgerPosting: &financialaccountingv1.LedgerPosting{
+				Id:                    validPostingID.String(),
+				FinancialBookingLogId: validBookingLogID.String(),
+				PostingDirection:      commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+				PostingAmount: &money.Money{
+					CurrencyCode: "GBP",
+					Units:        100,
+					Nanos:        0,
+				},
+				AccountId:     "ACC-123",
+				ValueDate:     timestamppb.New(now),
+				Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+				PostingResult: "Posted successfully",
+				CreatedAt:     timestamppb.New(now),
+			},
+		}
+		cachedData, err := proto.Marshal(cachedResponse)
+		require.NoError(t, err)
+
+		mockIdem := &mockIdempotencyService{
+			checkResult: &idempotency.Result{
+				Status: idempotency.StatusCompleted,
+				Data:   cachedData,
+			},
+			checkErr: idempotency.ErrOperationAlreadyProcessed,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.UpdateLedgerPostingRequest{
+			Id:            validPostingID.String(),
+			Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			PostingResult: "Posted successfully",
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "duplicate-update-key",
+			},
+		}
+
+		// Act
+		resp, err := service.UpdateLedgerPosting(context.Background(), req)
+
+		// Assert
+		require.NoError(t, err, "should return cached response without error")
+		require.NotNil(t, resp)
+		assert.Equal(t, validPostingID.String(), resp.LedgerPosting.Id)
+		assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED, resp.LedgerPosting.Status)
+	})
+
+	t.Run("corrupted cached data returns AlreadyExists", func(t *testing.T) {
+		mockIdem := &mockIdempotencyService{
+			checkResult: &idempotency.Result{
+				Status: idempotency.StatusCompleted,
+				Data:   []byte("invalid-protobuf-data"),
+			},
+			checkErr: idempotency.ErrOperationAlreadyProcessed,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.UpdateLedgerPostingRequest{
+			Id:            validPostingID.String(),
+			Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			PostingResult: "test",
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "corrupted-key",
+			},
+		}
+
+		// Act
+		resp, err := service.UpdateLedgerPosting(context.Background(), req)
+
+		// Assert
+		require.Error(t, err)
+		require.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.AlreadyExists, st.Code())
+	})
+
+	t.Run("empty cached data returns AlreadyExists", func(t *testing.T) {
+		mockIdem := &mockIdempotencyService{
+			checkResult: &idempotency.Result{
+				Status: idempotency.StatusCompleted,
+				Data:   nil,
+			},
+			checkErr: idempotency.ErrOperationAlreadyProcessed,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.UpdateLedgerPostingRequest{
+			Id:            validPostingID.String(),
+			Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			PostingResult: "test",
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "empty-data-key",
+			},
+		}
+
+		// Act
+		resp, err := service.UpdateLedgerPosting(context.Background(), req)
+
+		// Assert
+		require.Error(t, err)
+		require.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.AlreadyExists, st.Code())
+	})
+
+	t.Run("idempotency check internal error returns Internal", func(t *testing.T) {
+		mockIdem := &mockIdempotencyService{
+			checkErr: errTestRedisConnectionFailed,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.UpdateLedgerPostingRequest{
+			Id:            validPostingID.String(),
+			Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			PostingResult: "test",
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "error-key",
+			},
+		}
+
+		// Act
+		resp, err := service.UpdateLedgerPosting(context.Background(), req)
+
+		// Assert
+		require.Error(t, err)
+		require.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("mark pending failure returns Internal", func(t *testing.T) {
+		mockIdem := &mockIdempotencyService{
+			markErr: errTestCannotMarkPending,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.UpdateLedgerPostingRequest{
+			Id:            validPostingID.String(),
+			Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			PostingResult: "test",
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "pending-fail-key",
+			},
+		}
+
+		// Act
+		resp, err := service.UpdateLedgerPosting(context.Background(), req)
+
+		// Assert
+		require.Error(t, err)
+		require.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}
+
+// TestUpdateFinancialBookingLog_IdempotencyRequired tests that idempotency key is required for UpdateFinancialBookingLog.
+// Per task 14: Add idempotency protection to state-machine update operations.
+func TestUpdateFinancialBookingLog_IdempotencyRequired(t *testing.T) {
+	validBookingLogID := uuid.New()
+
+	tests := []struct {
+		name           string
+		idempotencyKey *commonv1.IdempotencyKey
+		wantCode       codes.Code
+		rationale      string
+	}{
+		{
+			name:           "nil idempotency key",
+			idempotencyKey: nil,
+			wantCode:       codes.InvalidArgument,
+			rationale:      "State-machine mutations require idempotency to prevent duplicate transitions",
+		},
+		{
+			name:           "empty idempotency key",
+			idempotencyKey: &commonv1.IdempotencyKey{Key: ""},
+			wantCode:       codes.InvalidArgument,
+			rationale:      "Empty key is equivalent to no key - must be rejected",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			repo := persistence.NewLedgerRepository(&gorm.DB{})
+			publisher := &mockEventPublisher{}
+			mockIdem := &mockIdempotencyService{}
+			service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+			req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
+				Id:                   validBookingLogID.String(),
+				Status:               commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+				ChartOfAccountsRules: "GAAP-2024",
+				IdempotencyKey:       tt.idempotencyKey,
+			}
+
+			// Act
+			resp, err := service.UpdateFinancialBookingLog(context.Background(), req)
+
+			// Assert
+			require.Error(t, err, tt.rationale)
+			require.Nil(t, resp)
+			st, ok := status.FromError(err)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantCode, st.Code(), tt.rationale)
+			assert.Contains(t, st.Message(), "idempotency_key is required")
+		})
+	}
+}
+
+// TestUpdateFinancialBookingLog_IdempotencyCaching tests cached response handling for UpdateFinancialBookingLog.
+func TestUpdateFinancialBookingLog_IdempotencyCaching(t *testing.T) {
+	validBookingLogID := uuid.New()
+	now := time.Now()
+
+	t.Run("cached response returned for duplicate request", func(t *testing.T) {
+		// Arrange - Create cached response
+		cachedResponse := &financialaccountingv1.UpdateFinancialBookingLogResponse{
+			FinancialBookingLog: &financialaccountingv1.FinancialBookingLog{
+				Id:                      validBookingLogID.String(),
+				FinancialAccountType:    commonv1.AccountType_ACCOUNT_TYPE_CURRENT,
+				ProductServiceReference: "DEPOSIT-001",
+				BusinessUnitReference:   "RETAIL-UK",
+				ChartOfAccountsRules:    "GAAP-2024",
+				BaseCurrency:            commonv1.Currency_CURRENCY_GBP,
+				Status:                  commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+				CreatedAt:               timestamppb.New(now),
+				UpdatedAt:               timestamppb.New(now),
+			},
+		}
+		cachedData, err := proto.Marshal(cachedResponse)
+		require.NoError(t, err)
+
+		mockIdem := &mockIdempotencyService{
+			checkResult: &idempotency.Result{
+				Status: idempotency.StatusCompleted,
+				Data:   cachedData,
+			},
+			checkErr: idempotency.ErrOperationAlreadyProcessed,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
+			Id:     validBookingLogID.String(),
+			Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "duplicate-update-booking-log-key",
+			},
+		}
+
+		// Act
+		resp, err := service.UpdateFinancialBookingLog(context.Background(), req)
+
+		// Assert
+		require.NoError(t, err, "should return cached response without error")
+		require.NotNil(t, resp)
+		assert.Equal(t, validBookingLogID.String(), resp.FinancialBookingLog.Id)
+		assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED, resp.FinancialBookingLog.Status)
+	})
+
+	t.Run("corrupted cached data returns AlreadyExists", func(t *testing.T) {
+		mockIdem := &mockIdempotencyService{
+			checkResult: &idempotency.Result{
+				Status: idempotency.StatusCompleted,
+				Data:   []byte("invalid-protobuf-data"),
+			},
+			checkErr: idempotency.ErrOperationAlreadyProcessed,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
+			Id:     validBookingLogID.String(),
+			Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "corrupted-booking-log-key",
+			},
+		}
+
+		// Act
+		resp, err := service.UpdateFinancialBookingLog(context.Background(), req)
+
+		// Assert
+		require.Error(t, err)
+		require.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.AlreadyExists, st.Code())
+	})
+
+	t.Run("empty cached data returns AlreadyExists", func(t *testing.T) {
+		mockIdem := &mockIdempotencyService{
+			checkResult: &idempotency.Result{
+				Status: idempotency.StatusCompleted,
+				Data:   nil,
+			},
+			checkErr: idempotency.ErrOperationAlreadyProcessed,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
+			Id:     validBookingLogID.String(),
+			Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "empty-data-booking-log-key",
+			},
+		}
+
+		// Act
+		resp, err := service.UpdateFinancialBookingLog(context.Background(), req)
+
+		// Assert
+		require.Error(t, err)
+		require.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.AlreadyExists, st.Code())
+	})
+
+	t.Run("idempotency check internal error returns Internal", func(t *testing.T) {
+		mockIdem := &mockIdempotencyService{
+			checkErr: errTestRedisConnectionFailed,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
+			Id:     validBookingLogID.String(),
+			Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "error-booking-log-key",
+			},
+		}
+
+		// Act
+		resp, err := service.UpdateFinancialBookingLog(context.Background(), req)
+
+		// Assert
+		require.Error(t, err)
+		require.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("mark pending failure returns Internal", func(t *testing.T) {
+		mockIdem := &mockIdempotencyService{
+			markErr: errTestCannotMarkPending,
+		}
+		repo := persistence.NewLedgerRepository(&gorm.DB{})
+		publisher := &mockEventPublisher{}
+		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+
+		req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
+			Id:     validBookingLogID.String(),
+			Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+			IdempotencyKey: &commonv1.IdempotencyKey{
+				Key: "pending-fail-booking-log-key",
+			},
+		}
+
+		// Act
+		resp, err := service.UpdateFinancialBookingLog(context.Background(), req)
+
+		// Assert
+		require.Error(t, err)
+		require.Nil(t, resp)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.Internal, st.Code())
+	})
+}

--- a/services/financial-accounting/service/grpc_integration_test.go
+++ b/services/financial-accounting/service/grpc_integration_test.go
@@ -720,6 +720,9 @@ func TestUpdateLedgerPosting_Integration_PendingToPosted(t *testing.T) {
 		Id:            posting.ID.String(),
 		Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
 		PostingResult: "Successfully posted to ledger",
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.New().String(),
+		},
 	})
 
 	require.NoError(t, err)
@@ -758,6 +761,9 @@ func TestUpdateLedgerPosting_Integration_PendingToFailed(t *testing.T) {
 		Id:            posting.ID.String(),
 		Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_FAILED,
 		PostingResult: "Insufficient funds",
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.New().String(),
+		},
 	})
 
 	require.NoError(t, err)
@@ -793,6 +799,9 @@ func TestUpdateLedgerPosting_Integration_InvalidTransition(t *testing.T) {
 		Id:            posting.ID.String(),
 		Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_FAILED,
 		PostingResult: "Trying to fail posted",
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.New().String(),
+		},
 	})
 
 	require.Error(t, err)
@@ -812,6 +821,9 @@ func TestUpdateLedgerPosting_Integration_NotFound(t *testing.T) {
 		Id:            uuid.New().String(),
 		Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
 		PostingResult: "test",
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.New().String(),
+		},
 	})
 
 	require.Error(t, err)
@@ -1211,6 +1223,9 @@ func TestEndToEnd_PostingLifecycle(t *testing.T) {
 		Id:            postingID,
 		Status:        commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
 		PostingResult: "Posted successfully via lifecycle test",
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.New().String(),
+		},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED, updateResp.LedgerPosting.Status)
@@ -1305,6 +1320,9 @@ func TestUpdateFinancialBookingLog_Integration_BalancedPostings_Success(t *testi
 	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
 		Id:     bookingLogID.String(),
 		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.New().String(),
+		},
 	})
 
 	// Should succeed with balanced postings
@@ -1334,6 +1352,9 @@ func TestUpdateFinancialBookingLog_Integration_MultipleBalancedPostings(t *testi
 	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
 		Id:     bookingLogID.String(),
 		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.New().String(),
+		},
 	})
 
 	// Should succeed with balanced postings
@@ -1362,6 +1383,9 @@ func TestUpdateFinancialBookingLog_Integration_UnbalancedPostings_FailedPrecondi
 	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
 		Id:     bookingLogID.String(),
 		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.New().String(),
+		},
 	})
 
 	// Should fail with FailedPrecondition
@@ -1393,6 +1417,9 @@ func TestUpdateFinancialBookingLog_Integration_NoPostings_FailedPrecondition(t *
 	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
 		Id:     bookingLogID.String(),
 		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.New().String(),
+		},
 	})
 
 	// Should fail with FailedPrecondition
@@ -1422,6 +1449,9 @@ func TestUpdateFinancialBookingLog_Integration_NonPostedTransition_SkipsValidati
 	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
 		Id:     bookingLogID.String(),
 		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_FAILED,
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.New().String(),
+		},
 	})
 
 	require.NoError(t, err)
@@ -1445,6 +1475,9 @@ func TestUpdateFinancialBookingLog_Integration_CancelledTransition_SkipsValidati
 	resp, err := ts.grpcClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
 		Id:     bookingLogID.String(),
 		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_CANCELLED,
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.New().String(),
+		},
 	})
 
 	require.NoError(t, err)

--- a/tests/proto/validation_test.go
+++ b/tests/proto/validation_test.go
@@ -325,10 +325,13 @@ func TestRetrieveLedgerPostingRequestValidation(t *testing.T) {
 func TestUpdateLedgerPostingRequestValidation(t *testing.T) {
 	validator := testValidator
 
-	// Valid request
+	// Valid request (includes required idempotency_key)
 	validReq := &financialaccountingv1.UpdateLedgerPostingRequest{
 		Id:     "LP-123",
 		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: "test-key-update-posting",
+		},
 	}
 	if err := validator.Validate(validReq); err != nil {
 		t.Errorf("valid request should pass: %v", err)
@@ -338,6 +341,9 @@ func TestUpdateLedgerPostingRequestValidation(t *testing.T) {
 	invalidReq := &financialaccountingv1.UpdateLedgerPostingRequest{
 		Id:     "",
 		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: "test-key-update-posting",
+		},
 	}
 	if err := validator.Validate(invalidReq); err == nil {
 		t.Error("empty id should fail validation")
@@ -347,9 +353,21 @@ func TestUpdateLedgerPostingRequestValidation(t *testing.T) {
 	invalidReq2 := &financialaccountingv1.UpdateLedgerPostingRequest{
 		Id:     "LP-123",
 		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_UNSPECIFIED,
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: "test-key-update-posting",
+		},
 	}
 	if err := validator.Validate(invalidReq2); err == nil {
 		t.Error("UNSPECIFIED status should fail validation")
+	}
+
+	// Invalid: missing idempotency_key (required for state-machine mutations)
+	invalidReq3 := &financialaccountingv1.UpdateLedgerPostingRequest{
+		Id:     "LP-123",
+		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_POSTED,
+	}
+	if err := validator.Validate(invalidReq3); err == nil {
+		t.Error("missing idempotency_key should fail validation")
 	}
 }
 
@@ -394,10 +412,13 @@ func TestPostingDirectionEnumValidation(t *testing.T) {
 func TestTransactionStatusEnumValidation(t *testing.T) {
 	validator := testValidator
 
-	// Valid status
+	// Valid status (includes required idempotency_key)
 	validReq := &financialaccountingv1.UpdateLedgerPostingRequest{
 		Id:     "LP-123",
 		Status: commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING,
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: "test-key-status-validation",
+		},
 	}
 	if err := validator.Validate(validReq); err != nil {
 		t.Errorf("valid status should pass: %v", err)


### PR DESCRIPTION
## Summary

- Add `idempotency_key` fields to `UpdateLedgerPostingRequest` and `UpdateFinancialBookingLogRequest` proto messages
- Implement idempotency check/store pattern in both update handlers
- Ensure exactly-once semantics for state-machine mutations

## Task Master Reference

- **Tag**: ledger-integrity
- **Task ID**: 14

## Changes Made

1. **Proto changes**: Added required `idempotency_key` field to both update request types
2. **UpdateLedgerPosting handler**: Added idempotency check at start, result storage at end
3. **UpdateFinancialBookingLog handler**: Added idempotency check at start, result storage at end
4. **Unit tests**: Added tests for idempotency validation (required key, cached response, error scenarios)
5. **Integration tests**: Updated all integration tests to include idempotency keys

## Test Plan

- [x] All existing unit tests pass
- [x] All existing integration tests pass (updated to include idempotency keys)
- [x] New idempotency tests verify:
  - Missing idempotency key returns InvalidArgument
  - Duplicate request returns cached response
  - Corrupted cache returns AlreadyExists
  - Redis errors return Internal