### PR TITLE
feat: Add PROVISIONING_PENDING status to tenant lifecycle

### DIFF
--- a/api/proto/meridian/tenant/v1/tenant.proto
+++ b/api/proto/meridian/tenant/v1/tenant.proto
@@ -62,6 +62,8 @@ enum TenantStatus {
   TENANT_STATUS_PROVISIONING = 4;
   // TENANT_STATUS_PROVISIONING_FAILED means schema provisioning failed.
   TENANT_STATUS_PROVISIONING_FAILED = 5;
+  // TENANT_STATUS_PROVISIONING_PENDING means the tenant registration is queued for async provisioning.
+  TENANT_STATUS_PROVISIONING_PENDING = 6;
 }
 
 // Tenant represents a platform tenant for multi-tenant infrastructure.

--- a/cmd/tenantctl/cmd/list.go
+++ b/cmd/tenantctl/cmd/list.go
@@ -120,6 +120,8 @@ func runList(_ *cobra.Command, _ []string) error {
 // parseStatus converts a string status to protobuf TenantStatus.
 func parseStatus(s string) (tenantv1.TenantStatus, error) {
 	switch strings.ToLower(s) {
+	case "provisioning_pending":
+		return tenantv1.TenantStatus_TENANT_STATUS_PROVISIONING_PENDING, nil
 	case "active":
 		return tenantv1.TenantStatus_TENANT_STATUS_ACTIVE, nil
 	case "suspended":
@@ -135,6 +137,8 @@ func parseStatus(s string) (tenantv1.TenantStatus, error) {
 // formatStatus converts protobuf TenantStatus to a display string.
 func formatStatus(s tenantv1.TenantStatus) string {
 	switch s {
+	case tenantv1.TenantStatus_TENANT_STATUS_PROVISIONING_PENDING:
+		return "provisioning_pending"
 	case tenantv1.TenantStatus_TENANT_STATUS_PROVISIONING:
 		return "provisioning"
 	case tenantv1.TenantStatus_TENANT_STATUS_PROVISIONING_FAILED:

--- a/services/tenant/domain/tenant.go
+++ b/services/tenant/domain/tenant.go
@@ -97,7 +97,7 @@ func (t *Tenant) SchemaName() string {
 
 // CanTransitionTo returns true if the tenant can transition to the given status.
 // Valid transitions:
-//   - provisioning_pending → provisioning
+//   - provisioning_pending → provisioning, provisioning_failed
 //   - provisioning → active, provisioning_failed
 //   - provisioning_failed → provisioning (retry)
 //   - active → suspended, deprovisioned
@@ -110,7 +110,7 @@ func (t *Tenant) CanTransitionTo(newStatus Status) bool {
 
 	switch t.Status {
 	case StatusProvisioningPending:
-		return newStatus == StatusProvisioning
+		return newStatus == StatusProvisioning || newStatus == StatusProvisioningFailed
 	case StatusProvisioning:
 		return newStatus == StatusActive || newStatus == StatusProvisioningFailed
 	case StatusProvisioningFailed:

--- a/services/tenant/domain/tenant.go
+++ b/services/tenant/domain/tenant.go
@@ -11,6 +11,8 @@ import (
 type Status string
 
 const (
+	// StatusProvisioningPending means the tenant registration is queued for async provisioning.
+	StatusProvisioningPending Status = "provisioning_pending"
 	// StatusProvisioning means the tenant is being provisioned (schemas being created).
 	StatusProvisioning Status = "provisioning"
 	// StatusProvisioningFailed means schema provisioning failed.
@@ -26,7 +28,7 @@ const (
 // IsValid returns true if the status is a valid tenant status.
 func (s Status) IsValid() bool {
 	switch s {
-	case StatusProvisioning, StatusProvisioningFailed, StatusActive, StatusSuspended, StatusDeprovisioned:
+	case StatusProvisioningPending, StatusProvisioning, StatusProvisioningFailed, StatusActive, StatusSuspended, StatusDeprovisioned:
 		return true
 	default:
 		return false
@@ -95,6 +97,7 @@ func (t *Tenant) SchemaName() string {
 
 // CanTransitionTo returns true if the tenant can transition to the given status.
 // Valid transitions:
+//   - provisioning_pending → provisioning
 //   - provisioning → active, provisioning_failed
 //   - provisioning_failed → provisioning (retry)
 //   - active → suspended, deprovisioned
@@ -106,6 +109,8 @@ func (t *Tenant) CanTransitionTo(newStatus Status) bool {
 	}
 
 	switch t.Status {
+	case StatusProvisioningPending:
+		return newStatus == StatusProvisioning
 	case StatusProvisioning:
 		return newStatus == StatusActive || newStatus == StatusProvisioningFailed
 	case StatusProvisioningFailed:

--- a/services/tenant/domain/tenant_test.go
+++ b/services/tenant/domain/tenant_test.go
@@ -79,6 +79,12 @@ func TestTenant_CanTransitionTo(t *testing.T) {
 			expectedAllowed: true,
 		},
 		{
+			name:            "provisioning_pending can transition to provisioning_failed",
+			currentStatus:   StatusProvisioningPending,
+			targetStatus:    StatusProvisioningFailed,
+			expectedAllowed: true,
+		},
+		{
 			name:            "provisioning_pending cannot transition to active",
 			currentStatus:   StatusProvisioningPending,
 			targetStatus:    StatusActive,

--- a/services/tenant/domain/tenant_test.go
+++ b/services/tenant/domain/tenant_test.go
@@ -1,0 +1,128 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+func TestStatus_IsValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   Status
+		expected bool
+	}{
+		{
+			name:     "provisioning_pending is valid",
+			status:   StatusProvisioningPending,
+			expected: true,
+		},
+		{
+			name:     "provisioning is valid",
+			status:   StatusProvisioning,
+			expected: true,
+		},
+		{
+			name:     "provisioning_failed is valid",
+			status:   StatusProvisioningFailed,
+			expected: true,
+		},
+		{
+			name:     "active is valid",
+			status:   StatusActive,
+			expected: true,
+		},
+		{
+			name:     "suspended is valid",
+			status:   StatusSuspended,
+			expected: true,
+		},
+		{
+			name:     "deprovisioned is valid",
+			status:   StatusDeprovisioned,
+			expected: true,
+		},
+		{
+			name:     "invalid status returns false",
+			status:   Status("invalid_status"),
+			expected: false,
+		},
+		{
+			name:     "empty status returns false",
+			status:   Status(""),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.status.IsValid()
+			if result != tt.expected {
+				t.Errorf("Status(%q).IsValid() = %v, expected %v", tt.status, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTenant_CanTransitionTo(t *testing.T) {
+	tests := []struct {
+		name            string
+		currentStatus   Status
+		targetStatus    Status
+		expectedAllowed bool
+	}{
+		// StatusProvisioningPending transitions
+		{
+			name:            "provisioning_pending can transition to provisioning",
+			currentStatus:   StatusProvisioningPending,
+			targetStatus:    StatusProvisioning,
+			expectedAllowed: true,
+		},
+		{
+			name:            "provisioning_pending cannot transition to active",
+			currentStatus:   StatusProvisioningPending,
+			targetStatus:    StatusActive,
+			expectedAllowed: false,
+		},
+		{
+			name:            "provisioning_pending cannot transition to suspended",
+			currentStatus:   StatusProvisioningPending,
+			targetStatus:    StatusSuspended,
+			expectedAllowed: false,
+		},
+		// StatusProvisioning transitions (existing behavior)
+		{
+			name:            "provisioning can transition to active",
+			currentStatus:   StatusProvisioning,
+			targetStatus:    StatusActive,
+			expectedAllowed: true,
+		},
+		{
+			name:            "provisioning can transition to provisioning_failed",
+			currentStatus:   StatusProvisioning,
+			targetStatus:    StatusProvisioningFailed,
+			expectedAllowed: true,
+		},
+		// No-op transitions
+		{
+			name:            "no-op transition from provisioning_pending to itself",
+			currentStatus:   StatusProvisioningPending,
+			targetStatus:    StatusProvisioningPending,
+			expectedAllowed: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tenant := &Tenant{
+				ID:     tenant.TenantID("test_tenant"),
+				Status: tt.currentStatus,
+			}
+			result := tenant.CanTransitionTo(tt.targetStatus)
+			if result != tt.expectedAllowed {
+				t.Errorf("Tenant with status %q transitioning to %q: got %v, expected %v",
+					tt.currentStatus, tt.targetStatus, result, tt.expectedAllowed)
+			}
+		})
+	}
+}

--- a/services/tenant/service/grpc_service.go
+++ b/services/tenant/service/grpc_service.go
@@ -323,6 +323,8 @@ func (s *Service) toProto(tenant *domain.Tenant) *pb.Tenant {
 // toProtoStatus converts domain status to protobuf status.
 func (s *Service) toProtoStatus(status domain.Status) pb.TenantStatus {
 	switch status {
+	case domain.StatusProvisioningPending:
+		return pb.TenantStatus_TENANT_STATUS_PROVISIONING_PENDING
 	case domain.StatusProvisioning:
 		return pb.TenantStatus_TENANT_STATUS_PROVISIONING
 	case domain.StatusProvisioningFailed:
@@ -341,6 +343,8 @@ func (s *Service) toProtoStatus(status domain.Status) pb.TenantStatus {
 // toDomainStatus converts protobuf status to domain status.
 func (s *Service) toDomainStatus(status pb.TenantStatus) (domain.Status, error) {
 	switch status {
+	case pb.TenantStatus_TENANT_STATUS_PROVISIONING_PENDING:
+		return domain.StatusProvisioningPending, nil
 	case pb.TenantStatus_TENANT_STATUS_PROVISIONING:
 		return domain.StatusProvisioning, nil
 	case pb.TenantStatus_TENANT_STATUS_PROVISIONING_FAILED:

--- a/services/tenant/service/grpc_service_test.go
+++ b/services/tenant/service/grpc_service_test.go
@@ -11,6 +11,7 @@ import (
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
 	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
+	"github.com/meridianhub/meridian/services/tenant/domain"
 	"github.com/meridianhub/meridian/services/tenant/provisioner"
 	"github.com/meridianhub/meridian/shared/platform/auth"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
@@ -820,4 +821,157 @@ func TestReconcileMigrations_SuccessfulReconciliation(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, int32(2), resp.ReconciledCount, "should have reconciled 2 active tenants")
 	assert.Empty(t, resp.Errors, "should have no errors")
+}
+
+// Tests for status conversion functions
+
+func TestService_toProtoStatus(t *testing.T) {
+	svc, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	tests := []struct {
+		name          string
+		domainStatus  domain.Status
+		expectedProto pb.TenantStatus
+	}{
+		{
+			name:          "provisioning_pending to proto",
+			domainStatus:  domain.StatusProvisioningPending,
+			expectedProto: pb.TenantStatus_TENANT_STATUS_PROVISIONING_PENDING,
+		},
+		{
+			name:          "provisioning to proto",
+			domainStatus:  domain.StatusProvisioning,
+			expectedProto: pb.TenantStatus_TENANT_STATUS_PROVISIONING,
+		},
+		{
+			name:          "provisioning_failed to proto",
+			domainStatus:  domain.StatusProvisioningFailed,
+			expectedProto: pb.TenantStatus_TENANT_STATUS_PROVISIONING_FAILED,
+		},
+		{
+			name:          "active to proto",
+			domainStatus:  domain.StatusActive,
+			expectedProto: pb.TenantStatus_TENANT_STATUS_ACTIVE,
+		},
+		{
+			name:          "suspended to proto",
+			domainStatus:  domain.StatusSuspended,
+			expectedProto: pb.TenantStatus_TENANT_STATUS_SUSPENDED,
+		},
+		{
+			name:          "deprovisioned to proto",
+			domainStatus:  domain.StatusDeprovisioned,
+			expectedProto: pb.TenantStatus_TENANT_STATUS_DEPROVISIONED,
+		},
+		{
+			name:          "unknown status to unspecified",
+			domainStatus:  domain.Status("unknown"),
+			expectedProto: pb.TenantStatus_TENANT_STATUS_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := svc.toProtoStatus(tt.domainStatus)
+			assert.Equal(t, tt.expectedProto, result)
+		})
+	}
+}
+
+func TestService_toDomainStatus(t *testing.T) {
+	svc, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	tests := []struct {
+		name           string
+		protoStatus    pb.TenantStatus
+		expectedDomain domain.Status
+		expectError    bool
+	}{
+		{
+			name:           "proto provisioning_pending to domain",
+			protoStatus:    pb.TenantStatus_TENANT_STATUS_PROVISIONING_PENDING,
+			expectedDomain: domain.StatusProvisioningPending,
+			expectError:    false,
+		},
+		{
+			name:           "proto provisioning to domain",
+			protoStatus:    pb.TenantStatus_TENANT_STATUS_PROVISIONING,
+			expectedDomain: domain.StatusProvisioning,
+			expectError:    false,
+		},
+		{
+			name:           "proto provisioning_failed to domain",
+			protoStatus:    pb.TenantStatus_TENANT_STATUS_PROVISIONING_FAILED,
+			expectedDomain: domain.StatusProvisioningFailed,
+			expectError:    false,
+		},
+		{
+			name:           "proto active to domain",
+			protoStatus:    pb.TenantStatus_TENANT_STATUS_ACTIVE,
+			expectedDomain: domain.StatusActive,
+			expectError:    false,
+		},
+		{
+			name:           "proto suspended to domain",
+			protoStatus:    pb.TenantStatus_TENANT_STATUS_SUSPENDED,
+			expectedDomain: domain.StatusSuspended,
+			expectError:    false,
+		},
+		{
+			name:           "proto deprovisioned to domain",
+			protoStatus:    pb.TenantStatus_TENANT_STATUS_DEPROVISIONED,
+			expectedDomain: domain.StatusDeprovisioned,
+			expectError:    false,
+		},
+		{
+			name:           "proto unspecified returns error",
+			protoStatus:    pb.TenantStatus_TENANT_STATUS_UNSPECIFIED,
+			expectedDomain: "",
+			expectError:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := svc.toDomainStatus(tt.protoStatus)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Equal(t, ErrUnknownStatus, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedDomain, result)
+			}
+		})
+	}
+}
+
+func TestService_StatusConversionRoundtrip(t *testing.T) {
+	svc, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	// Test roundtrip: domain -> proto -> domain
+	tests := []struct {
+		name   string
+		status domain.Status
+	}{
+		{name: "provisioning_pending roundtrip", status: domain.StatusProvisioningPending},
+		{name: "provisioning roundtrip", status: domain.StatusProvisioning},
+		{name: "provisioning_failed roundtrip", status: domain.StatusProvisioningFailed},
+		{name: "active roundtrip", status: domain.StatusActive},
+		{name: "suspended roundtrip", status: domain.StatusSuspended},
+		{name: "deprovisioned roundtrip", status: domain.StatusDeprovisioned},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert to proto and back
+			protoStatus := svc.toProtoStatus(tt.status)
+			domainStatus, err := svc.toDomainStatus(protoStatus)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.status, domainStatus, "roundtrip conversion should preserve status")
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Added PROVISIONING_PENDING status to tenant proto and domain model for improved tenant provisioning workflow
- Enabled state transitions from provisioning_pending to both provisioning and provisioning_failed states
- Implemented comprehensive proto/domain conversion with full test coverage

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 68

## Changes Made
- Added `TENANT_STATUS_PROVISIONING_PENDING` enum value (6) to `tenant.proto` for backward compatibility
- Added `StatusProvisioningPending` constant to tenant domain model in `services/tenant/domain/tenant.go`
- Updated `IsValid()` method to recognize new status as valid
- Extended `CanTransitionTo()` state machine to allow:
  - `provisioning_pending → provisioning`
  - `provisioning_pending → provisioning_failed`
- Added bidirectional conversion cases in `toProtoStatus()` and `toDomainStatus()` in `grpc_service.go`
- Regenerated proto code with `buf generate`
- Added comprehensive unit tests for all new functionality

## Test Plan
- Unit tests for domain status validation (IsValid)
- Unit tests for state transitions (CanTransitionTo)
- Unit tests for proto conversion roundtrip (domain→proto→domain)
- All tenant service tests pass