### PR TITLE
feat: implement GetTenantProvisioningStatus gRPC endpoint

### DIFF
--- a/api/proto/meridian/tenant/v1/tenant.proto
+++ b/api/proto/meridian/tenant/v1/tenant.proto
@@ -256,23 +256,26 @@ message InitiateTenantResponse {
   // provisioning_hint provides a simplified status indicator for clients.
   //
   // Possible values:
-  // - "pending": Tenant provisioning is queued/in-progress. Client MUST poll RetrieveTenant.
+  // - "pending": Tenant provisioning is queued/in-progress. Client should poll GetTenantProvisioningStatus.
   // - "active": Tenant is fully provisioned and ready to use. No polling needed.
   //
   // This field simplifies client logic by providing a binary decision point rather than
   // requiring clients to understand the full TenantStatus enum. Clients should use this
   // field to determine their next action:
-  // - "pending" → Poll RetrieveTenant with exponential backoff
+  // - "pending" → Poll GetTenantProvisioningStatus for detailed per-service status
   // - "active" → Proceed to use tenant services immediately
   //
-  // Note: This is a convenience field. The authoritative tenant status is always
-  // available in the tenant.status field for clients that need fine-grained control.
+  // Note: This is a convenience field. For detailed per-service provisioning status,
+  // use the GetTenantProvisioningStatus RPC instead.
+  //
+  // Deprecated: Use GetTenantProvisioningStatus RPC for detailed provisioning status.
   string provisioning_hint = 2 [
+    deprecated = true,
     (buf.validate.field).string = {
       in: ["pending", "active"]
     },
     (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
-      description: "Provisioning status hint. Possible values: 'pending' (tenant provisioning queued/in-progress, client must poll), 'active' (tenant ready immediately)."
+      description: "DEPRECATED: Use GetTenantProvisioningStatus RPC instead. Provisioning status hint. Possible values: 'pending' (tenant provisioning queued/in-progress), 'active' (tenant ready immediately)."
       example: "\"active\""
     }
   ];
@@ -367,6 +370,72 @@ message ReconcileMigrationsResponse {
 
   // errors contains per-tenant error messages (reconciliation continues despite failures).
   repeated string errors = 2;
+}
+
+// ServiceProvisioningStatus represents the provisioning state of a single service for a tenant.
+message ServiceProvisioningStatus {
+  // service_name is the name of the service (e.g., "customer", "transaction", "party").
+  string service_name = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+  }];
+
+  // Status defines the provisioning state of this service.
+  enum Status {
+    // STATUS_UNSPECIFIED means the status is unknown.
+    STATUS_UNSPECIFIED = 0;
+    // STATUS_PENDING means provisioning has not started yet.
+    STATUS_PENDING = 1;
+    // STATUS_IN_PROGRESS means provisioning is currently running.
+    STATUS_IN_PROGRESS = 2;
+    // STATUS_COMPLETED means provisioning completed successfully.
+    STATUS_COMPLETED = 3;
+    // STATUS_FAILED means provisioning failed with an error.
+    STATUS_FAILED = 4;
+  }
+
+  // status is the current provisioning state of this service.
+  Status status = 2 [(buf.validate.field).enum = {defined_only: true}];
+
+  // migration_version is the current migration version applied (e.g., "20240115_001").
+  // Empty if no migrations have been applied yet.
+  string migration_version = 3 [(buf.validate.field).string = {max_len: 100}];
+
+  // error_message contains error details if status is FAILED.
+  // Empty for successful provisioning.
+  string error_message = 4 [(buf.validate.field).string = {max_len: 2000}];
+
+  // started_at is when provisioning started for this service.
+  google.protobuf.Timestamp started_at = 5;
+
+  // completed_at is when provisioning completed (success or failure).
+  google.protobuf.Timestamp completed_at = 6;
+}
+
+// GetTenantProvisioningStatusRequest is the request to query detailed provisioning status.
+message GetTenantProvisioningStatusRequest {
+  // tenant_id is the unique identifier of the tenant.
+  string tenant_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^[a-zA-Z0-9_]+$"
+  }];
+}
+
+// GetTenantProvisioningStatusResponse contains detailed provisioning status for a tenant.
+message GetTenantProvisioningStatusResponse {
+  // tenant_id is the unique identifier of the tenant.
+  string tenant_id = 1;
+
+  // overall_status is the aggregate provisioning status across all services.
+  TenantStatus overall_status = 2;
+
+  // services contains per-service provisioning progress.
+  repeated ServiceProvisioningStatus services = 3;
+
+  // error_message contains overall error details if provisioning failed.
+  // Empty for successful or in-progress provisioning.
+  string error_message = 4 [(buf.validate.field).string = {max_len: 2000}];
 }
 
 // TenantService provides platform tenant lifecycle management.
@@ -464,6 +533,18 @@ service TenantService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Reconcile migrations for tenant schemas"
       description: "Applies new migrations to existing tenant schemas. Safe to call multiple times."
+    };
+  }
+
+  // GetTenantProvisioningStatus retrieves detailed provisioning status for a tenant.
+  // Returns per-service provisioning progress including migration versions and error details.
+  rpc GetTenantProvisioningStatus(GetTenantProvisioningStatusRequest) returns (GetTenantProvisioningStatusResponse) {
+    option (google.api.http) = {
+      get: "/v1/tenants/{tenant_id}/provisioning-status"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get detailed provisioning status"
+      description: "Returns per-service provisioning progress for a tenant including migration versions and errors."
     };
   }
 }

--- a/api/proto/meridian/tenant/v1/tenant.proto
+++ b/api/proto/meridian/tenant/v1/tenant.proto
@@ -425,7 +425,7 @@ message GetTenantProvisioningStatusRequest {
 // GetTenantProvisioningStatusResponse contains detailed provisioning status for a tenant.
 message GetTenantProvisioningStatusResponse {
   // tenant_id is the unique identifier of the tenant.
-  string tenant_id = 1;
+  string tenant_id = 1 [(buf.validate.field).string = {min_len: 1}];
 
   // overall_status is the aggregate provisioning status across all services.
   TenantStatus overall_status = 2;

--- a/services/tenant/adapters/persistence/entity.go
+++ b/services/tenant/adapters/persistence/entity.go
@@ -46,6 +46,27 @@ func (t TenantEntity) AuditTableName() string {
 	return t.TableName()
 }
 
+// ProvisioningStatusEntity is the database representation of per-service provisioning status.
+// Uses singular, unqualified name per database-per-service architecture.
+type ProvisioningStatusEntity struct {
+	ID               int        `gorm:"column:id;primaryKey;autoIncrement"`
+	TenantID         string     `gorm:"column:tenant_id;not null;index:idx_tenant_provisioning_status_tenant_id"`
+	ServiceName      string     `gorm:"column:service_name;not null;index:idx_tenant_provisioning_status_service_name"`
+	Status           string     `gorm:"column:status;not null;index:idx_tenant_provisioning_status_status"`
+	MigrationVersion *string    `gorm:"column:migration_version"`
+	ErrorMessage     *string    `gorm:"column:error_message"`
+	StartedAt        *time.Time `gorm:"column:started_at"`
+	CompletedAt      *time.Time `gorm:"column:completed_at"`
+	CreatedAt        time.Time  `gorm:"column:created_at;not null;autoCreateTime"`
+	UpdatedAt        time.Time  `gorm:"column:updated_at;not null;autoUpdateTime"`
+}
+
+// TableName returns the table name for GORM.
+// Uses singular, unqualified name per database-per-service architecture.
+func (ProvisioningStatusEntity) TableName() string {
+	return "tenant_provisioning_status"
+}
+
 // JSONMap is a custom type for JSONB columns.
 type JSONMap map[string]interface{}
 

--- a/services/tenant/adapters/persistence/repository.go
+++ b/services/tenant/adapters/persistence/repository.go
@@ -360,7 +360,7 @@ func toDomain(entity *TenantEntity) (*domain.Tenant, error) {
 func provisioningStatusToDomain(entity *ProvisioningStatusEntity) domain.ProvisioningStatus {
 	status := domain.ProvisioningStatus{
 		ServiceName: entity.ServiceName,
-		Status:      entity.Status,
+		Status:      domain.ServiceProvisioningStatus(entity.Status),
 		StartedAt:   entity.StartedAt,
 		CompletedAt: entity.CompletedAt,
 	}

--- a/services/tenant/adapters/persistence/repository.go
+++ b/services/tenant/adapters/persistence/repository.go
@@ -253,6 +253,34 @@ func (r *Repository) GetAll(ctx context.Context) ([]*domain.Tenant, error) {
 	return tenants, nil
 }
 
+// FindProvisioningStatusByTenantID retrieves all per-service provisioning status records for a tenant.
+// Returns an empty slice if no provisioning status records exist (not an error).
+func (r *Repository) FindProvisioningStatusByTenantID(ctx context.Context, tenantID string) ([]domain.ProvisioningStatus, error) {
+	var entities []ProvisioningStatusEntity
+	result := r.db.WithContext(ctx).
+		Where("tenant_id = ?", tenantID).
+		Order("service_name").
+		Find(&entities)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	// Empty result is not an error - tenant may not have any provisioning status records yet
+	if len(entities) == 0 {
+		return []domain.ProvisioningStatus{}, nil
+	}
+
+	// Convert entities to domain models
+	statuses := make([]domain.ProvisioningStatus, 0, len(entities))
+	for i := range entities {
+		status := provisioningStatusToDomain(&entities[i])
+		statuses = append(statuses, status)
+	}
+
+	return statuses, nil
+}
+
 // Ping checks database connectivity.
 func (r *Repository) Ping(ctx context.Context) error {
 	var result int
@@ -326,6 +354,27 @@ func toDomain(entity *TenantEntity) (*domain.Tenant, error) {
 	}
 
 	return tenant, nil
+}
+
+// provisioningStatusToDomain converts database entity to domain model.
+func provisioningStatusToDomain(entity *ProvisioningStatusEntity) domain.ProvisioningStatus {
+	status := domain.ProvisioningStatus{
+		ServiceName: entity.ServiceName,
+		Status:      entity.Status,
+		StartedAt:   entity.StartedAt,
+		CompletedAt: entity.CompletedAt,
+	}
+
+	// Handle optional fields
+	if entity.MigrationVersion != nil {
+		status.MigrationVersion = *entity.MigrationVersion
+	}
+
+	if entity.ErrorMessage != nil {
+		status.ErrorMessage = entity.ErrorMessage
+	}
+
+	return status
 }
 
 // isDuplicateKeyError checks if the error is a PostgreSQL unique constraint violation.

--- a/services/tenant/adapters/persistence/repository_test.go
+++ b/services/tenant/adapters/persistence/repository_test.go
@@ -644,7 +644,7 @@ func TestRepository_FindProvisioningStatusByTenantID_NullHandling(t *testing.T) 
 	entity := ProvisioningStatusEntity{
 		TenantID:         tenant.ID.String(),
 		ServiceName:      "party",
-		Status:           "pending",
+		Status:           string(domain.ServiceStatusPending),
 		MigrationVersion: nil,
 		ErrorMessage:     nil,
 		StartedAt:        nil,

--- a/services/tenant/adapters/persistence/repository_test.go
+++ b/services/tenant/adapters/persistence/repository_test.go
@@ -17,7 +17,7 @@ import (
 func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 	t.Helper()
 
-	db, cleanup := testdb.SetupPostgres(t, []interface{}{&TenantEntity{}})
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{&TenantEntity{}, &ProvisioningStatusEntity{}})
 
 	// Create audit_outbox table (required for GORM hooks)
 	// Note: Tenant service uses string IDs (varchar(50)) for record_id
@@ -494,4 +494,174 @@ func TestAdapterMapping_EmptySlugMapsToNil(t *testing.T) {
 	backToDomain, err := toDomain(entity)
 	require.NoError(t, err)
 	assert.Equal(t, "", backToDomain.Slug)
+}
+
+func TestRepository_FindProvisioningStatusByTenantID(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// Create tenant
+	tenant := newTestTenant("test_tenant")
+	err := repo.Create(ctx, tenant)
+	require.NoError(t, err)
+
+	// Insert provisioning status records
+	now := time.Now()
+	completed := now.Add(5 * time.Minute)
+	migrationVersion := "20251216000001"
+	errorMsg := "connection timeout"
+
+	statuses := []ProvisioningStatusEntity{
+		{
+			TenantID:         tenant.ID.String(),
+			ServiceName:      "party",
+			Status:           "completed",
+			MigrationVersion: &migrationVersion,
+			StartedAt:        &now,
+			CompletedAt:      &completed,
+		},
+		{
+			TenantID:    tenant.ID.String(),
+			ServiceName: "account",
+			Status:      "in_progress",
+			StartedAt:   &now,
+		},
+		{
+			TenantID:     tenant.ID.String(),
+			ServiceName:  "transaction",
+			Status:       "failed",
+			ErrorMessage: &errorMsg,
+			StartedAt:    &now,
+			CompletedAt:  &completed,
+		},
+	}
+
+	for _, status := range statuses {
+		err := db.Create(&status).Error
+		require.NoError(t, err)
+	}
+
+	// Query provisioning status
+	results, err := repo.FindProvisioningStatusByTenantID(ctx, tenant.ID.String())
+	require.NoError(t, err)
+	assert.Len(t, results, 3)
+
+	// Verify results are ordered by service_name
+	assert.Equal(t, "account", results[0].ServiceName)
+	assert.Equal(t, "in_progress", results[0].Status)
+	assert.Nil(t, results[0].ErrorMessage)
+	assert.NotNil(t, results[0].StartedAt)
+	assert.Nil(t, results[0].CompletedAt)
+
+	assert.Equal(t, "party", results[1].ServiceName)
+	assert.Equal(t, "completed", results[1].Status)
+	assert.Equal(t, migrationVersion, results[1].MigrationVersion)
+	assert.NotNil(t, results[1].StartedAt)
+	assert.NotNil(t, results[1].CompletedAt)
+
+	assert.Equal(t, "transaction", results[2].ServiceName)
+	assert.Equal(t, "failed", results[2].Status)
+	assert.NotNil(t, results[2].ErrorMessage)
+	assert.Equal(t, errorMsg, *results[2].ErrorMessage)
+}
+
+func TestRepository_FindProvisioningStatusByTenantID_EmptyResult(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// Create tenant without provisioning status records
+	tenant := newTestTenant("test_tenant")
+	err := repo.Create(ctx, tenant)
+	require.NoError(t, err)
+
+	// Query provisioning status
+	results, err := repo.FindProvisioningStatusByTenantID(ctx, tenant.ID.String())
+	require.NoError(t, err)
+	assert.NotNil(t, results)
+	assert.Len(t, results, 0)
+}
+
+func TestRepository_FindProvisioningStatusByTenantID_VariousStatuses(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// Create tenant
+	tenant := newTestTenant("test_tenant")
+	err := repo.Create(ctx, tenant)
+	require.NoError(t, err)
+
+	// Insert records with different status values
+	statusValues := []string{"pending", "in_progress", "completed", "failed"}
+	for i, statusValue := range statusValues {
+		entity := ProvisioningStatusEntity{
+			TenantID:    tenant.ID.String(),
+			ServiceName: "service_" + string(rune('a'+i)),
+			Status:      statusValue,
+		}
+		err := db.Create(&entity).Error
+		require.NoError(t, err)
+	}
+
+	// Query and verify all statuses
+	results, err := repo.FindProvisioningStatusByTenantID(ctx, tenant.ID.String())
+	require.NoError(t, err)
+	assert.Len(t, results, 4)
+
+	// Verify each status value
+	statusMap := make(map[string]string)
+	for _, result := range results {
+		statusMap[result.ServiceName] = result.Status
+	}
+
+	assert.Equal(t, "pending", statusMap["service_a"])
+	assert.Equal(t, "in_progress", statusMap["service_b"])
+	assert.Equal(t, "completed", statusMap["service_c"])
+	assert.Equal(t, "failed", statusMap["service_d"])
+}
+
+func TestRepository_FindProvisioningStatusByTenantID_NullHandling(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// Create tenant
+	tenant := newTestTenant("test_tenant")
+	err := repo.Create(ctx, tenant)
+	require.NoError(t, err)
+
+	// Insert record with all optional fields as NULL
+	entity := ProvisioningStatusEntity{
+		TenantID:         tenant.ID.String(),
+		ServiceName:      "party",
+		Status:           "pending",
+		MigrationVersion: nil,
+		ErrorMessage:     nil,
+		StartedAt:        nil,
+		CompletedAt:      nil,
+	}
+	err = db.Create(&entity).Error
+	require.NoError(t, err)
+
+	// Query and verify null handling
+	results, err := repo.FindProvisioningStatusByTenantID(ctx, tenant.ID.String())
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+
+	assert.Equal(t, "party", results[0].ServiceName)
+	assert.Equal(t, "pending", results[0].Status)
+	assert.Equal(t, "", results[0].MigrationVersion)
+	assert.Nil(t, results[0].ErrorMessage)
+	assert.Nil(t, results[0].StartedAt)
+	assert.Nil(t, results[0].CompletedAt)
 }

--- a/services/tenant/adapters/persistence/repository_test.go
+++ b/services/tenant/adapters/persistence/repository_test.go
@@ -551,19 +551,19 @@ func TestRepository_FindProvisioningStatusByTenantID(t *testing.T) {
 
 	// Verify results are ordered by service_name
 	assert.Equal(t, "account", results[0].ServiceName)
-	assert.Equal(t, "in_progress", results[0].Status)
+	assert.Equal(t, domain.ServiceStatusInProgress, results[0].Status)
 	assert.Nil(t, results[0].ErrorMessage)
 	assert.NotNil(t, results[0].StartedAt)
 	assert.Nil(t, results[0].CompletedAt)
 
 	assert.Equal(t, "party", results[1].ServiceName)
-	assert.Equal(t, "completed", results[1].Status)
+	assert.Equal(t, domain.ServiceStatusCompleted, results[1].Status)
 	assert.Equal(t, migrationVersion, results[1].MigrationVersion)
 	assert.NotNil(t, results[1].StartedAt)
 	assert.NotNil(t, results[1].CompletedAt)
 
 	assert.Equal(t, "transaction", results[2].ServiceName)
-	assert.Equal(t, "failed", results[2].Status)
+	assert.Equal(t, domain.ServiceStatusFailed, results[2].Status)
 	assert.NotNil(t, results[2].ErrorMessage)
 	assert.Equal(t, errorMsg, *results[2].ErrorMessage)
 }
@@ -617,15 +617,15 @@ func TestRepository_FindProvisioningStatusByTenantID_VariousStatuses(t *testing.
 	assert.Len(t, results, 4)
 
 	// Verify each status value
-	statusMap := make(map[string]string)
+	statusMap := make(map[string]domain.ServiceProvisioningStatus)
 	for _, result := range results {
 		statusMap[result.ServiceName] = result.Status
 	}
 
-	assert.Equal(t, "pending", statusMap["service_a"])
-	assert.Equal(t, "in_progress", statusMap["service_b"])
-	assert.Equal(t, "completed", statusMap["service_c"])
-	assert.Equal(t, "failed", statusMap["service_d"])
+	assert.Equal(t, domain.ServiceStatusPending, statusMap["service_a"])
+	assert.Equal(t, domain.ServiceStatusInProgress, statusMap["service_b"])
+	assert.Equal(t, domain.ServiceStatusCompleted, statusMap["service_c"])
+	assert.Equal(t, domain.ServiceStatusFailed, statusMap["service_d"])
 }
 
 func TestRepository_FindProvisioningStatusByTenantID_NullHandling(t *testing.T) {

--- a/services/tenant/adapters/persistence/repository_test.go
+++ b/services/tenant/adapters/persistence/repository_test.go
@@ -659,7 +659,7 @@ func TestRepository_FindProvisioningStatusByTenantID_NullHandling(t *testing.T) 
 	assert.Len(t, results, 1)
 
 	assert.Equal(t, "party", results[0].ServiceName)
-	assert.Equal(t, "pending", results[0].Status)
+	assert.Equal(t, domain.ServiceStatusPending, results[0].Status)
 	assert.Equal(t, "", results[0].MigrationVersion)
 	assert.Nil(t, results[0].ErrorMessage)
 	assert.Nil(t, results[0].StartedAt)

--- a/services/tenant/domain/tenant.go
+++ b/services/tenant/domain/tenant.go
@@ -220,3 +220,25 @@ func ValidateSlug(slug string) error {
 
 	return nil
 }
+
+// ProvisioningStatus represents the provisioning state of a single service for a tenant.
+// This tracks per-service migration progress during async tenant provisioning.
+type ProvisioningStatus struct {
+	// ServiceName is the name of the service (e.g., "party", "account", "transaction").
+	ServiceName string
+
+	// Status is the provisioning state (pending, in_progress, completed, failed).
+	Status string
+
+	// MigrationVersion is the database migration version applied (e.g., "20251216000001").
+	MigrationVersion string
+
+	// ErrorMessage contains error details if Status is "failed".
+	ErrorMessage *string
+
+	// StartedAt is when provisioning started for this service.
+	StartedAt *time.Time
+
+	// CompletedAt is when provisioning completed (success or failure).
+	CompletedAt *time.Time
+}

--- a/services/tenant/domain/tenant.go
+++ b/services/tenant/domain/tenant.go
@@ -221,6 +221,30 @@ func ValidateSlug(slug string) error {
 	return nil
 }
 
+// ServiceProvisioningStatus represents the provisioning state values for a service.
+type ServiceProvisioningStatus string
+
+const (
+	// ServiceStatusPending means the service schema provisioning is queued.
+	ServiceStatusPending ServiceProvisioningStatus = "pending"
+	// ServiceStatusInProgress means the service schema is being provisioned.
+	ServiceStatusInProgress ServiceProvisioningStatus = "in_progress"
+	// ServiceStatusCompleted means the service schema provisioning completed successfully.
+	ServiceStatusCompleted ServiceProvisioningStatus = "completed"
+	// ServiceStatusFailed means the service schema provisioning failed.
+	ServiceStatusFailed ServiceProvisioningStatus = "failed"
+)
+
+// IsValid returns true if the service provisioning status is valid.
+func (s ServiceProvisioningStatus) IsValid() bool {
+	switch s {
+	case ServiceStatusPending, ServiceStatusInProgress, ServiceStatusCompleted, ServiceStatusFailed:
+		return true
+	default:
+		return false
+	}
+}
+
 // ProvisioningStatus represents the provisioning state of a single service for a tenant.
 // This tracks per-service migration progress during async tenant provisioning.
 type ProvisioningStatus struct {
@@ -228,7 +252,7 @@ type ProvisioningStatus struct {
 	ServiceName string
 
 	// Status is the provisioning state (pending, in_progress, completed, failed).
-	Status string
+	Status ServiceProvisioningStatus
 
 	// MigrationVersion is the database migration version applied (e.g., "20251216000001").
 	MigrationVersion string

--- a/services/tenant/service/grpc_service.go
+++ b/services/tenant/service/grpc_service.go
@@ -449,3 +449,91 @@ func (s *Service) createProvisioningStatusRecords(ctx context.Context, tenantID 
 
 	return nil
 }
+
+// GetTenantProvisioningStatus retrieves detailed provisioning status for a tenant.
+// Returns per-service provisioning progress including migration versions and error details.
+func (s *Service) GetTenantProvisioningStatus(ctx context.Context, req *pb.GetTenantProvisioningStatusRequest) (*pb.GetTenantProvisioningStatusResponse, error) {
+	s.logger.Debug("getting tenant provisioning status",
+		"tenant_id", req.TenantId)
+
+	// Validate tenant ID
+	tenantID, err := tenant.NewTenantID(req.TenantId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid tenant ID: %v", err)
+	}
+
+	// Retrieve tenant to get overall status
+	tenant, err := s.repo.GetByID(ctx, tenantID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrTenantNotFound) {
+			return nil, status.Errorf(codes.NotFound, "tenant %s not found", req.TenantId)
+		}
+		s.logger.Error("failed to retrieve tenant for provisioning status",
+			"tenant_id", req.TenantId,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to retrieve tenant")
+	}
+
+	// Query tenant_provisioning_status table for all service records
+	provisioningStatuses, err := s.repo.FindProvisioningStatusByTenantID(ctx, req.TenantId)
+	if err != nil {
+		s.logger.Error("failed to retrieve provisioning status records",
+			"tenant_id", req.TenantId,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to retrieve provisioning status")
+	}
+
+	// Build ServiceProvisioningStatus slice from database results
+	serviceStatuses := make([]*pb.ServiceProvisioningStatus, 0, len(provisioningStatuses))
+	for _, ps := range provisioningStatuses {
+		serviceStatus := &pb.ServiceProvisioningStatus{
+			ServiceName:      ps.ServiceName,
+			Status:           s.toProtoServiceStatus(ps.Status),
+			MigrationVersion: ps.MigrationVersion,
+		}
+
+		// Set optional error_message
+		if ps.ErrorMessage != nil {
+			serviceStatus.ErrorMessage = *ps.ErrorMessage
+		}
+
+		// Set optional timestamps
+		if ps.StartedAt != nil {
+			serviceStatus.StartedAt = timestamppb.New(*ps.StartedAt)
+		}
+		if ps.CompletedAt != nil {
+			serviceStatus.CompletedAt = timestamppb.New(*ps.CompletedAt)
+		}
+
+		serviceStatuses = append(serviceStatuses, serviceStatus)
+	}
+
+	s.logger.Debug("tenant provisioning status retrieved",
+		"tenant_id", req.TenantId,
+		"overall_status", tenant.Status,
+		"service_count", len(serviceStatuses))
+
+	// Construct response
+	return &pb.GetTenantProvisioningStatusResponse{
+		TenantId:      req.TenantId,
+		OverallStatus: s.toProtoStatus(tenant.Status),
+		Services:      serviceStatuses,
+		ErrorMessage:  tenant.ErrorMessage,
+	}, nil
+}
+
+// toProtoServiceStatus converts domain service provisioning status to protobuf status.
+func (s *Service) toProtoServiceStatus(status string) pb.ServiceProvisioningStatus_Status {
+	switch status {
+	case "pending":
+		return pb.ServiceProvisioningStatus_STATUS_PENDING
+	case "in_progress":
+		return pb.ServiceProvisioningStatus_STATUS_IN_PROGRESS
+	case "completed":
+		return pb.ServiceProvisioningStatus_STATUS_COMPLETED
+	case "failed":
+		return pb.ServiceProvisioningStatus_STATUS_FAILED
+	default:
+		return pb.ServiceProvisioningStatus_STATUS_UNSPECIFIED
+	}
+}

--- a/services/tenant/service/grpc_service.go
+++ b/services/tenant/service/grpc_service.go
@@ -523,15 +523,15 @@ func (s *Service) GetTenantProvisioningStatus(ctx context.Context, req *pb.GetTe
 }
 
 // toProtoServiceStatus converts domain service provisioning status to protobuf status.
-func (s *Service) toProtoServiceStatus(status string) pb.ServiceProvisioningStatus_Status {
+func (s *Service) toProtoServiceStatus(status domain.ServiceProvisioningStatus) pb.ServiceProvisioningStatus_Status {
 	switch status {
-	case "pending":
+	case domain.ServiceStatusPending:
 		return pb.ServiceProvisioningStatus_STATUS_PENDING
-	case "in_progress":
+	case domain.ServiceStatusInProgress:
 		return pb.ServiceProvisioningStatus_STATUS_IN_PROGRESS
-	case "completed":
+	case domain.ServiceStatusCompleted:
 		return pb.ServiceProvisioningStatus_STATUS_COMPLETED
-	case "failed":
+	case domain.ServiceStatusFailed:
 		return pb.ServiceProvisioningStatus_STATUS_FAILED
 	default:
 		return pb.ServiceProvisioningStatus_STATUS_UNSPECIFIED

--- a/services/tenant/service/grpc_service.go
+++ b/services/tenant/service/grpc_service.go
@@ -452,9 +452,38 @@ func (s *Service) createProvisioningStatusRecords(ctx context.Context, tenantID 
 
 // GetTenantProvisioningStatus retrieves detailed provisioning status for a tenant.
 // Returns per-service provisioning progress including migration versions and error details.
+//
+// This endpoint requires either:
+// - Authenticated user with tenant_id claim matching the requested tenant (tenant isolation)
+// - OR platform-admin or super-admin role (cross-tenant access)
 func (s *Service) GetTenantProvisioningStatus(ctx context.Context, req *pb.GetTenantProvisioningStatusRequest) (*pb.GetTenantProvisioningStatusResponse, error) {
 	s.logger.Debug("getting tenant provisioning status",
 		"tenant_id", req.TenantId)
+
+	// Authorization check - must be performed before any business logic.
+	claims, ok := auth.GetClaimsFromContext(ctx)
+	if !ok {
+		s.logger.Warn("provisioning status query attempted without authentication claims")
+		return nil, status.Error(codes.Unauthenticated, "authentication required")
+	}
+
+	// Check authorization: either tenant-scoped access OR platform admin role
+	hasAdminRole := claims.HasRole(auth.RolePlatformAdmin) || claims.HasRole(auth.RoleSuperAdmin)
+	hasTenantAccess := claims.HasTenantID() && claims.TenantID == req.TenantId
+
+	if !hasAdminRole && !hasTenantAccess {
+		s.logger.Warn("unauthorized provisioning status query attempt",
+			"user_id", claims.UserID,
+			"requested_tenant", req.TenantId,
+			"user_tenant", claims.TenantID,
+			"roles", claims.Roles)
+		return nil, status.Error(codes.PermissionDenied, "access denied: must be tenant owner or platform administrator")
+	}
+
+	s.logger.Debug("provisioning status query authorized",
+		"user_id", claims.UserID,
+		"tenant_id", req.TenantId,
+		"admin_access", hasAdminRole)
 
 	// Validate tenant ID
 	tenantID, err := tenant.NewTenantID(req.TenantId)

--- a/services/tenant/service/grpc_service_test.go
+++ b/services/tenant/service/grpc_service_test.go
@@ -1459,32 +1459,32 @@ func TestService_toProtoServiceStatus(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		domainStatus  string
+		domainStatus  domain.ServiceProvisioningStatus
 		expectedProto pb.ServiceProvisioningStatus_Status
 	}{
 		{
 			name:          "pending to proto",
-			domainStatus:  "pending",
+			domainStatus:  domain.ServiceStatusPending,
 			expectedProto: pb.ServiceProvisioningStatus_STATUS_PENDING,
 		},
 		{
 			name:          "in_progress to proto",
-			domainStatus:  "in_progress",
+			domainStatus:  domain.ServiceStatusInProgress,
 			expectedProto: pb.ServiceProvisioningStatus_STATUS_IN_PROGRESS,
 		},
 		{
 			name:          "completed to proto",
-			domainStatus:  "completed",
+			domainStatus:  domain.ServiceStatusCompleted,
 			expectedProto: pb.ServiceProvisioningStatus_STATUS_COMPLETED,
 		},
 		{
 			name:          "failed to proto",
-			domainStatus:  "failed",
+			domainStatus:  domain.ServiceStatusFailed,
 			expectedProto: pb.ServiceProvisioningStatus_STATUS_FAILED,
 		},
 		{
 			name:          "unknown status to unspecified",
-			domainStatus:  "unknown",
+			domainStatus:  domain.ServiceProvisioningStatus("unknown"),
 			expectedProto: pb.ServiceProvisioningStatus_STATUS_UNSPECIFIED,
 		},
 	}

--- a/services/tenant/service/grpc_service_test.go
+++ b/services/tenant/service/grpc_service_test.go
@@ -1267,7 +1267,7 @@ func TestService_GetTenantProvisioningStatus_Success(t *testing.T) {
 	err = db.Create(&persistence.ProvisioningStatusEntity{
 		TenantID:         "provisioning_status_test",
 		ServiceName:      "party",
-		Status:           "completed",
+		Status:           string(domain.ServiceStatusCompleted),
 		MigrationVersion: stringPtr("20240115_001"),
 		StartedAt:        &partyStarted,
 		CompletedAt:      &partyCompleted,
@@ -1277,7 +1277,7 @@ func TestService_GetTenantProvisioningStatus_Success(t *testing.T) {
 	err = db.Create(&persistence.ProvisioningStatusEntity{
 		TenantID:         "provisioning_status_test",
 		ServiceName:      "account",
-		Status:           "in_progress",
+		Status:           string(domain.ServiceStatusInProgress),
 		MigrationVersion: stringPtr("20240120_002"),
 		StartedAt:        &accountStarted,
 	}).Error
@@ -1286,7 +1286,7 @@ func TestService_GetTenantProvisioningStatus_Success(t *testing.T) {
 	err = db.Create(&persistence.ProvisioningStatusEntity{
 		TenantID:    "provisioning_status_test",
 		ServiceName: "transaction",
-		Status:      "pending",
+		Status:      string(domain.ServiceStatusPending),
 	}).Error
 	require.NoError(t, err)
 
@@ -1406,7 +1406,7 @@ func TestService_GetTenantProvisioningStatus_WithFailedService(t *testing.T) {
 	err = db.Create(&persistence.ProvisioningStatusEntity{
 		TenantID:     "failed_provisioning_test",
 		ServiceName:  "party",
-		Status:       "failed",
+		Status:       string(domain.ServiceStatusFailed),
 		ErrorMessage: stringPtr("Migration 003 failed: constraint violation"),
 		StartedAt:    &failedStarted,
 		CompletedAt:  &failedCompleted,

--- a/services/tenant/service/grpc_service_test.go
+++ b/services/tenant/service/grpc_service_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
@@ -1235,4 +1236,268 @@ func TestProvisioningHintFromStatus(t *testing.T) {
 			assert.Equal(t, tt.expectedHint, got, "provisioningHintFromStatus(%s)", tt.status)
 		})
 	}
+}
+
+// Tests for GetTenantProvisioningStatus
+
+func TestService_GetTenantProvisioningStatus_Success(t *testing.T) {
+	svc, db, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create tenant with provisioning status
+	createReq := &pb.InitiateTenantRequest{
+		TenantId:        "provisioning_status_test",
+		DisplayName:     "Provisioning Status Test",
+		SettlementAsset: "GBP",
+	}
+	_, err := svc.InitiateTenant(ctx, createReq)
+	require.NoError(t, err)
+
+	// Auto-migrate the provisioning status table
+	err = db.AutoMigrate(&persistence.ProvisioningStatusEntity{})
+	require.NoError(t, err)
+
+	// Insert test provisioning status records directly via GORM
+	partyStarted := time.Now().Add(-5 * time.Minute)
+	partyCompleted := time.Now().Add(-3 * time.Minute)
+	accountStarted := time.Now().Add(-2 * time.Minute)
+
+	err = db.Create(&persistence.ProvisioningStatusEntity{
+		TenantID:         "provisioning_status_test",
+		ServiceName:      "party",
+		Status:           "completed",
+		MigrationVersion: stringPtr("20240115_001"),
+		StartedAt:        &partyStarted,
+		CompletedAt:      &partyCompleted,
+	}).Error
+	require.NoError(t, err)
+
+	err = db.Create(&persistence.ProvisioningStatusEntity{
+		TenantID:         "provisioning_status_test",
+		ServiceName:      "account",
+		Status:           "in_progress",
+		MigrationVersion: stringPtr("20240120_002"),
+		StartedAt:        &accountStarted,
+	}).Error
+	require.NoError(t, err)
+
+	err = db.Create(&persistence.ProvisioningStatusEntity{
+		TenantID:    "provisioning_status_test",
+		ServiceName: "transaction",
+		Status:      "pending",
+	}).Error
+	require.NoError(t, err)
+
+	// Get provisioning status
+	req := &pb.GetTenantProvisioningStatusRequest{
+		TenantId: "provisioning_status_test",
+	}
+	resp, err := svc.GetTenantProvisioningStatus(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify response structure
+	assert.Equal(t, "provisioning_status_test", resp.TenantId)
+	assert.Equal(t, pb.TenantStatus_TENANT_STATUS_ACTIVE, resp.OverallStatus)
+	assert.Len(t, resp.Services, 3)
+
+	// Verify service statuses are returned in alphabetical order
+	assert.Equal(t, "account", resp.Services[0].ServiceName)
+	assert.Equal(t, pb.ServiceProvisioningStatus_STATUS_IN_PROGRESS, resp.Services[0].Status)
+	assert.Equal(t, "20240120_002", resp.Services[0].MigrationVersion)
+	assert.NotNil(t, resp.Services[0].StartedAt)
+	assert.Nil(t, resp.Services[0].CompletedAt)
+
+	assert.Equal(t, "party", resp.Services[1].ServiceName)
+	assert.Equal(t, pb.ServiceProvisioningStatus_STATUS_COMPLETED, resp.Services[1].Status)
+	assert.Equal(t, "20240115_001", resp.Services[1].MigrationVersion)
+	assert.NotNil(t, resp.Services[1].StartedAt)
+	assert.NotNil(t, resp.Services[1].CompletedAt)
+
+	assert.Equal(t, "transaction", resp.Services[2].ServiceName)
+	assert.Equal(t, pb.ServiceProvisioningStatus_STATUS_PENDING, resp.Services[2].Status)
+	assert.Empty(t, resp.Services[2].MigrationVersion)
+	assert.Nil(t, resp.Services[2].StartedAt)
+	assert.Nil(t, resp.Services[2].CompletedAt)
+}
+
+func TestService_GetTenantProvisioningStatus_TenantNotFound(t *testing.T) {
+	svc, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	req := &pb.GetTenantProvisioningStatusRequest{
+		TenantId: "nonexistent_tenant",
+	}
+
+	_, err := svc.GetTenantProvisioningStatus(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+	assert.Contains(t, st.Message(), "nonexistent_tenant not found")
+}
+
+func TestService_GetTenantProvisioningStatus_EmptyServicesList(t *testing.T) {
+	svc, db, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create tenant
+	createReq := &pb.InitiateTenantRequest{
+		TenantId:        "empty_services_test",
+		DisplayName:     "Empty Services Test",
+		SettlementAsset: "USD",
+	}
+	_, err := svc.InitiateTenant(ctx, createReq)
+	require.NoError(t, err)
+
+	// Auto-migrate the provisioning status table but don't insert any records
+	err = db.AutoMigrate(&persistence.ProvisioningStatusEntity{})
+	require.NoError(t, err)
+
+	// Get provisioning status
+	req := &pb.GetTenantProvisioningStatusRequest{
+		TenantId: "empty_services_test",
+	}
+	resp, err := svc.GetTenantProvisioningStatus(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Should return empty services array, not an error
+	assert.Equal(t, "empty_services_test", resp.TenantId)
+	assert.Equal(t, pb.TenantStatus_TENANT_STATUS_ACTIVE, resp.OverallStatus)
+	assert.Empty(t, resp.Services)
+	assert.Empty(t, resp.ErrorMessage)
+}
+
+func TestService_GetTenantProvisioningStatus_WithFailedService(t *testing.T) {
+	svc, db, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create tenant with provisioning_failed status
+	createReq := &pb.InitiateTenantRequest{
+		TenantId:        "failed_provisioning_test",
+		DisplayName:     "Failed Provisioning Test",
+		SettlementAsset: "EUR",
+	}
+	createResp, err := svc.InitiateTenant(ctx, createReq)
+	require.NoError(t, err)
+
+	// Update tenant status to provisioning_failed
+	tenantID, err := tenant.NewTenantID(createResp.Tenant.TenantId)
+	require.NoError(t, err)
+	_, err = svc.repo.UpdateStatusWithError(ctx, tenantID, domain.StatusProvisioningFailed, "Database connection timeout", int(createResp.Tenant.Version))
+	require.NoError(t, err)
+
+	// Auto-migrate provisioning status table
+	err = db.AutoMigrate(&persistence.ProvisioningStatusEntity{})
+	require.NoError(t, err)
+
+	// Insert failed service status via GORM
+	failedStarted := time.Now().Add(-5 * time.Minute)
+	failedCompleted := time.Now()
+	err = db.Create(&persistence.ProvisioningStatusEntity{
+		TenantID:     "failed_provisioning_test",
+		ServiceName:  "party",
+		Status:       "failed",
+		ErrorMessage: stringPtr("Migration 003 failed: constraint violation"),
+		StartedAt:    &failedStarted,
+		CompletedAt:  &failedCompleted,
+	}).Error
+	require.NoError(t, err)
+
+	// Get provisioning status
+	req := &pb.GetTenantProvisioningStatusRequest{
+		TenantId: "failed_provisioning_test",
+	}
+	resp, err := svc.GetTenantProvisioningStatus(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify overall status is provisioning_failed
+	assert.Equal(t, "failed_provisioning_test", resp.TenantId)
+	assert.Equal(t, pb.TenantStatus_TENANT_STATUS_PROVISIONING_FAILED, resp.OverallStatus)
+	assert.Equal(t, "Database connection timeout", resp.ErrorMessage)
+
+	// Verify failed service details
+	require.Len(t, resp.Services, 1)
+	assert.Equal(t, "party", resp.Services[0].ServiceName)
+	assert.Equal(t, pb.ServiceProvisioningStatus_STATUS_FAILED, resp.Services[0].Status)
+	assert.Equal(t, "Migration 003 failed: constraint violation", resp.Services[0].ErrorMessage)
+	assert.NotNil(t, resp.Services[0].StartedAt)
+	assert.NotNil(t, resp.Services[0].CompletedAt)
+}
+
+func TestService_GetTenantProvisioningStatus_InvalidTenantID(t *testing.T) {
+	svc, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	req := &pb.GetTenantProvisioningStatusRequest{
+		TenantId: "invalid-tenant-id-with-dashes",
+	}
+
+	_, err := svc.GetTenantProvisioningStatus(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid tenant ID")
+}
+
+func TestService_toProtoServiceStatus(t *testing.T) {
+	svc, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	tests := []struct {
+		name          string
+		domainStatus  string
+		expectedProto pb.ServiceProvisioningStatus_Status
+	}{
+		{
+			name:          "pending to proto",
+			domainStatus:  "pending",
+			expectedProto: pb.ServiceProvisioningStatus_STATUS_PENDING,
+		},
+		{
+			name:          "in_progress to proto",
+			domainStatus:  "in_progress",
+			expectedProto: pb.ServiceProvisioningStatus_STATUS_IN_PROGRESS,
+		},
+		{
+			name:          "completed to proto",
+			domainStatus:  "completed",
+			expectedProto: pb.ServiceProvisioningStatus_STATUS_COMPLETED,
+		},
+		{
+			name:          "failed to proto",
+			domainStatus:  "failed",
+			expectedProto: pb.ServiceProvisioningStatus_STATUS_FAILED,
+		},
+		{
+			name:          "unknown status to unspecified",
+			domainStatus:  "unknown",
+			expectedProto: pb.ServiceProvisioningStatus_STATUS_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := svc.toProtoServiceStatus(tt.domainStatus)
+			assert.Equal(t, tt.expectedProto, result)
+		})
+	}
+}
+
+// stringPtr is a helper function to create a pointer to a string.
+func stringPtr(s string) *string {
+	return &s
 }

--- a/services/tenant/service/grpc_service_test.go
+++ b/services/tenant/service/grpc_service_test.go
@@ -1091,15 +1091,15 @@ func TestService_InitiateTenant_ProvisioningHint_AsyncMode(t *testing.T) {
 	// Test case 1: Provisioner configured (async mode)
 	// Tenant is created in PROVISIONING_PENDING state, worker will provision later
 	assert.NotNil(t, resp.Tenant, "response should contain tenant")
-	assert.NotEmpty(t, resp.ProvisioningHint, "provisioning_hint should not be empty")
+	assert.NotEmpty(t, resp.ProvisioningHint, "provisioning_hint should not be empty") //nolint:staticcheck // testing deprecated field
 
 	// With provisioner configured, tenant stays in pending state
 	assert.Equal(t, pb.TenantStatus_TENANT_STATUS_PROVISIONING_PENDING, resp.Tenant.Status)
-	assert.Equal(t, "pending", resp.ProvisioningHint, "hint should be 'pending' when provisioner is configured")
+	assert.Equal(t, "pending", resp.ProvisioningHint, "hint should be 'pending' when provisioner is configured") //nolint:staticcheck // testing deprecated field
 
 	// Verify both fields are present in response
 	assert.NotNil(t, resp.Tenant)
-	assert.NotEmpty(t, resp.ProvisioningHint)
+	assert.NotEmpty(t, resp.ProvisioningHint) //nolint:staticcheck // testing deprecated field
 }
 
 func TestService_InitiateTenant_ProvisioningHint_SyncMode(t *testing.T) {
@@ -1121,7 +1121,7 @@ func TestService_InitiateTenant_ProvisioningHint_SyncMode(t *testing.T) {
 	// Test case 2: No provisioner (sync mode)
 	// Tenant should be active immediately, hint should be "active"
 	assert.Equal(t, pb.TenantStatus_TENANT_STATUS_ACTIVE, resp.Tenant.Status)
-	assert.Equal(t, "active", resp.ProvisioningHint, "hint should be 'active' in sync mode")
+	assert.Equal(t, "active", resp.ProvisioningHint, "hint should be 'active' in sync mode") //nolint:staticcheck // testing deprecated field
 
 	// Verify tenant version is 1 (created directly as active)
 	assert.Equal(t, int32(1), resp.Tenant.Version)
@@ -1179,8 +1179,8 @@ func TestService_InitiateTenant_ProvisioningHint_FieldPresence(t *testing.T) {
 
 			// Test case 3: Verify field presence
 			assert.NotNil(t, resp.Tenant, "tenant field must be present")
-			assert.NotEmpty(t, resp.ProvisioningHint, "provisioning_hint must not be empty string")
-			assert.Equal(t, tt.expectedHint, resp.ProvisioningHint)
+			assert.NotEmpty(t, resp.ProvisioningHint, "provisioning_hint must not be empty string") //nolint:staticcheck // testing deprecated field
+			assert.Equal(t, tt.expectedHint, resp.ProvisioningHint)                                 //nolint:staticcheck // testing deprecated field
 			assert.Equal(t, tt.expectedStatus, resp.Tenant.Status)
 		})
 	}
@@ -1208,7 +1208,7 @@ func TestService_InitiateTenant_ProvisioningHint_ProvisioningStates(t *testing.T
 
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	assert.Equal(t, "pending", resp.ProvisioningHint, "hint should be 'pending' with provisioner")
+	assert.Equal(t, "pending", resp.ProvisioningHint, "hint should be 'pending' with provisioner") //nolint:staticcheck // testing deprecated field
 	assert.Equal(t, pb.TenantStatus_TENANT_STATUS_PROVISIONING_PENDING, resp.Tenant.Status)
 }
 

--- a/services/tenant/service/grpc_service_test.go
+++ b/services/tenant/service/grpc_service_test.go
@@ -1244,7 +1244,12 @@ func TestService_GetTenantProvisioningStatus_Success(t *testing.T) {
 	svc, db, cleanup := setupTest(t)
 	defer cleanup()
 
-	ctx := context.Background()
+	// Create context with platform-admin claims for cross-tenant access
+	claims := &auth.Claims{
+		UserID: "admin-123",
+		Roles:  []string{auth.RolePlatformAdmin},
+	}
+	ctx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
 
 	// Create tenant with provisioning status
 	createReq := &pb.InitiateTenantRequest{
@@ -1327,7 +1332,13 @@ func TestService_GetTenantProvisioningStatus_TenantNotFound(t *testing.T) {
 	svc, _, cleanup := setupTest(t)
 	defer cleanup()
 
-	ctx := context.Background()
+	// Create context with platform-admin claims
+	claims := &auth.Claims{
+		UserID: "admin-123",
+		Roles:  []string{auth.RolePlatformAdmin},
+	}
+	ctx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+
 	req := &pb.GetTenantProvisioningStatusRequest{
 		TenantId: "nonexistent_tenant",
 	}
@@ -1356,15 +1367,22 @@ func TestService_GetTenantProvisioningStatus_EmptyServicesList(t *testing.T) {
 	_, err := svc.InitiateTenant(ctx, createReq)
 	require.NoError(t, err)
 
+	// Create context with platform-admin claims for GetTenantProvisioningStatus
+	claims := &auth.Claims{
+		UserID: "admin-123",
+		Roles:  []string{auth.RolePlatformAdmin},
+	}
+	authCtx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+
 	// Auto-migrate the provisioning status table but don't insert any records
 	err = db.AutoMigrate(&persistence.ProvisioningStatusEntity{})
 	require.NoError(t, err)
 
-	// Get provisioning status
+	// Get provisioning status using authenticated context
 	req := &pb.GetTenantProvisioningStatusRequest{
 		TenantId: "empty_services_test",
 	}
-	resp, err := svc.GetTenantProvisioningStatus(ctx, req)
+	resp, err := svc.GetTenantProvisioningStatus(authCtx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -1390,6 +1408,13 @@ func TestService_GetTenantProvisioningStatus_WithFailedService(t *testing.T) {
 	createResp, err := svc.InitiateTenant(ctx, createReq)
 	require.NoError(t, err)
 
+	// Create context with platform-admin claims for GetTenantProvisioningStatus
+	claims := &auth.Claims{
+		UserID: "admin-123",
+		Roles:  []string{auth.RolePlatformAdmin},
+	}
+	authCtx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+
 	// Update tenant status to provisioning_failed
 	tenantID, err := tenant.NewTenantID(createResp.Tenant.TenantId)
 	require.NoError(t, err)
@@ -1413,11 +1438,11 @@ func TestService_GetTenantProvisioningStatus_WithFailedService(t *testing.T) {
 	}).Error
 	require.NoError(t, err)
 
-	// Get provisioning status
+	// Get provisioning status using authenticated context
 	req := &pb.GetTenantProvisioningStatusRequest{
 		TenantId: "failed_provisioning_test",
 	}
-	resp, err := svc.GetTenantProvisioningStatus(ctx, req)
+	resp, err := svc.GetTenantProvisioningStatus(authCtx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -1439,7 +1464,13 @@ func TestService_GetTenantProvisioningStatus_InvalidTenantID(t *testing.T) {
 	svc, _, cleanup := setupTest(t)
 	defer cleanup()
 
-	ctx := context.Background()
+	// Create context with platform-admin claims
+	claims := &auth.Claims{
+		UserID: "admin-123",
+		Roles:  []string{auth.RolePlatformAdmin},
+	}
+	ctx := context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+
 	req := &pb.GetTenantProvisioningStatusRequest{
 		TenantId: "invalid-tenant-id-with-dashes",
 	}
@@ -1451,6 +1482,126 @@ func TestService_GetTenantProvisioningStatus_InvalidTenantID(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, st.Code())
 	assert.Contains(t, st.Message(), "invalid tenant ID")
+}
+
+// Tests for GetTenantProvisioningStatus Authorization
+
+func TestGetTenantProvisioningStatus_Authorization(t *testing.T) {
+	svc, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	tests := []struct {
+		name         string
+		claims       *auth.Claims
+		tenantID     string
+		expectError  bool
+		expectedCode codes.Code
+		expectedMsg  string
+	}{
+		{
+			name: "platform-admin allowed",
+			claims: &auth.Claims{
+				UserID: "admin-123",
+				Roles:  []string{auth.RolePlatformAdmin},
+			},
+			tenantID:    "test_tenant",
+			expectError: false,
+		},
+		{
+			name: "super-admin allowed",
+			claims: &auth.Claims{
+				UserID: "super-123",
+				Roles:  []string{auth.RoleSuperAdmin},
+			},
+			tenantID:    "test_tenant",
+			expectError: false,
+		},
+		{
+			name: "tenant owner allowed",
+			claims: &auth.Claims{
+				UserID:   "user-123",
+				TenantID: "test_tenant",
+				Roles:    []string{"user"},
+			},
+			tenantID:    "test_tenant",
+			expectError: false,
+		},
+		{
+			name: "different tenant denied",
+			claims: &auth.Claims{
+				UserID:   "user-456",
+				TenantID: "other_tenant",
+				Roles:    []string{"user"},
+			},
+			tenantID:     "test_tenant",
+			expectError:  true,
+			expectedCode: codes.PermissionDenied,
+			expectedMsg:  "access denied",
+		},
+		{
+			name: "user without tenant denied",
+			claims: &auth.Claims{
+				UserID: "user-789",
+				Roles:  []string{"user"},
+			},
+			tenantID:     "test_tenant",
+			expectError:  true,
+			expectedCode: codes.PermissionDenied,
+			expectedMsg:  "access denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create context with claims
+			ctx := context.WithValue(context.Background(), auth.ClaimsContextKey, tt.claims)
+
+			// Execute
+			resp, err := svc.GetTenantProvisioningStatus(ctx, &pb.GetTenantProvisioningStatusRequest{
+				TenantId: tt.tenantID,
+			})
+
+			// Assert
+			if tt.expectError {
+				require.Error(t, err)
+				st, ok := status.FromError(err)
+				require.True(t, ok, "error should be a gRPC status")
+				assert.Equal(t, tt.expectedCode, st.Code())
+				assert.Contains(t, st.Message(), tt.expectedMsg)
+				assert.Nil(t, resp)
+			} else {
+				// Note: Will return NotFound error since test_tenant doesn't exist,
+				// but that proves authorization passed
+				if err != nil {
+					st, ok := status.FromError(err)
+					require.True(t, ok)
+					// Should be NotFound (tenant doesn't exist), not PermissionDenied
+					assert.Equal(t, codes.NotFound, st.Code())
+				}
+			}
+		})
+	}
+}
+
+func TestGetTenantProvisioningStatus_MissingClaims(t *testing.T) {
+	svc, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	// Context without claims
+	ctx := context.Background()
+
+	// Execute
+	resp, err := svc.GetTenantProvisioningStatus(ctx, &pb.GetTenantProvisioningStatusRequest{
+		TenantId: "test_tenant",
+	})
+
+	// Assert
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "error should be a gRPC status")
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+	assert.Contains(t, st.Message(), "authentication required")
+	assert.Nil(t, resp)
 }
 
 func TestService_toProtoServiceStatus(t *testing.T) {


### PR DESCRIPTION
## Summary
- Added GetTenantProvisioningStatus RPC to tenant service for querying overall tenant status and per-service provisioning details
- Implemented repository layer with FindProvisioningStatusByTenantID method to query tenant_provisioning_status table
- Created gRPC handler with proper error handling, status enum conversion, and comprehensive unit tests

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 72

## Changes Made
- **Proto definition**: Added GetTenantProvisioningStatus RPC with ServiceProvisioningStatus message, request/response types, and HTTP gateway annotation for GET /v1/tenants/{tenant_id}/provisioning-status. Restored deprecated provisioning_hint field for backward compatibility.
- **Repository methods**: Implemented FindProvisioningStatusByTenantID with ProvisioningStatus domain struct, proper null handling for optional fields (started_at, completed_at, error_message), and comprehensive unit tests.
- **gRPC handler**: Created GetTenantProvisioningStatus method that queries tenant table for overall status and tenant_provisioning_status for per-service details. Includes NotFound error handling, status enum conversion, structured logging, and unit tests.

## Test Plan
- **Unit tests**: Mock repository queries, verify response structure with multiple services, test NotFound scenarios, validate status enum conversions
- **Integration tests**: Create tenant, insert mock provisioning_status records, call GetTenantProvisioningStatus endpoint, verify per-service details returned correctly, test error handling for non-existent tenants