### PR TITLE
feat: add Slug field to Tenant domain and entity with validation

### DIFF
--- a/api/proto/meridian/tenant/v1/tenant.proto
+++ b/api/proto/meridian/tenant/v1/tenant.proto
@@ -166,12 +166,12 @@ message InitiateTenantRequest {
   // slug is a URL-friendly identifier for the tenant (e.g., acme-bank).
   // This field is optional and will be auto-generated from display_name if not provided.
   // Must be a valid DNS label (RFC 1123): lowercase alphanumeric with hyphens,
-  // starting and ending with alphanumeric. Maximum length is 63 characters
-  // per DNS label specification. Used for subdomain construction and API routing.
+  // starting and ending with alphanumeric. When provided, minimum 3 characters.
+  // Maximum length is 63 characters per DNS label specification.
+  // Used for subdomain construction and API routing.
   string slug = 6 [(buf.validate.field).string = {
-    min_len: 3
     max_len: 63
-    pattern: "^[a-z0-9][a-z0-9-]*[a-z0-9]$"
+    pattern: "^([a-z0-9]([a-z0-9-]*[a-z0-9])?)?$"
   }];
 }
 

--- a/api/proto/meridian/tenant/v1/tenant.proto
+++ b/api/proto/meridian/tenant/v1/tenant.proto
@@ -129,6 +129,7 @@ message Tenant {
   // Must be a valid DNS label (RFC 1123): lowercase alphanumeric with hyphens,
   // starting and ending with alphanumeric. Maximum length is 63 characters
   // per DNS label specification. Used for subdomain construction and API routing.
+  // This field is immutable after creation (no Update RPC for tenant fields other than status).
   string slug = 12 [(buf.validate.field).string = {
     min_len: 3
     max_len: 63
@@ -169,6 +170,9 @@ message InitiateTenantRequest {
   // starting and ending with alphanumeric. When provided, minimum 3 characters.
   // Maximum length is 63 characters per DNS label specification.
   // Used for subdomain construction and API routing.
+  //
+  // Note: Proto validation allows empty or 1-2 char slugs (for optional field support).
+  // Domain validation (ValidateSlug) is authoritative and enforces strict 3-char minimum.
   string slug = 6 [(buf.validate.field).string = {
     max_len: 63
     pattern: "^([a-z0-9]([a-z0-9-]*[a-z0-9])?)?$"

--- a/services/tenant/adapters/persistence/entity.go
+++ b/services/tenant/adapters/persistence/entity.go
@@ -18,6 +18,7 @@ type TenantEntity struct {
 	DisplayName     string     `gorm:"column:display_name;not null"`
 	SettlementAsset string     `gorm:"column:settlement_asset;not null"`
 	Subdomain       *string    `gorm:"column:subdomain;uniqueIndex:idx_tenant_subdomain"`
+	Slug            *string    `gorm:"column:slug;uniqueIndex:idx_tenant_slug"`
 	Status          string     `gorm:"column:status;not null;default:provisioning"`
 	CreatedAt       time.Time  `gorm:"column:created_at;not null;autoCreateTime;index:idx_tenant_created_at,sort:desc"`
 	DeprovisionedAt *time.Time `gorm:"column:deprovisioned_at"`

--- a/services/tenant/adapters/persistence/repository.go
+++ b/services/tenant/adapters/persistence/repository.go
@@ -18,6 +18,7 @@ var (
 	ErrTenantExists    = errors.New("tenant already exists")
 	ErrVersionConflict = errors.New("version conflict: tenant was modified by another transaction")
 	ErrSubdomainTaken  = errors.New("subdomain already taken by another tenant")
+	ErrSlugTaken       = errors.New("slug already taken by another tenant")
 )
 
 // Repository provides persistence operations for tenants.
@@ -46,6 +47,9 @@ func (r *Repository) Create(ctx context.Context, tenant *domain.Tenant) error {
 
 	if err := r.db.WithContext(ctx).Create(&entity).Error; err != nil {
 		if isDuplicateKeyError(err) {
+			if strings.Contains(err.Error(), "slug") {
+				return ErrSlugTaken
+			}
 			if strings.Contains(err.Error(), "subdomain") {
 				return ErrSubdomainTaken
 			}

--- a/services/tenant/adapters/persistence/repository.go
+++ b/services/tenant/adapters/persistence/repository.go
@@ -272,6 +272,10 @@ func toEntity(tenant *domain.Tenant) *TenantEntity {
 		entity.Subdomain = &tenant.Subdomain
 	}
 
+	if tenant.Slug != "" {
+		entity.Slug = &tenant.Slug
+	}
+
 	if tenant.PartyID != "" {
 		entity.PartyID = &tenant.PartyID
 	}
@@ -303,6 +307,10 @@ func toDomain(entity *TenantEntity) (*domain.Tenant, error) {
 
 	if entity.Subdomain != nil {
 		tenant.Subdomain = *entity.Subdomain
+	}
+
+	if entity.Slug != nil {
+		tenant.Slug = *entity.Slug
 	}
 
 	if entity.PartyID != nil {

--- a/services/tenant/adapters/persistence/repository_test.go
+++ b/services/tenant/adapters/persistence/repository_test.go
@@ -136,6 +136,26 @@ func TestRepository_Create_DuplicateSubdomain(t *testing.T) {
 	assert.True(t, errors.Is(err, ErrSubdomainTaken), "Expected ErrSubdomainTaken, got %v", err)
 }
 
+func TestRepository_Create_DuplicateSlug(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// Create first tenant with slug
+	tenant1 := newTestTenant("tenant_one")
+	tenant1.Slug = "shared-slug"
+	err := repo.Create(ctx, tenant1)
+	require.NoError(t, err)
+
+	// Create second tenant with same slug
+	tenant2 := newTestTenant("tenant_two")
+	tenant2.Slug = "shared-slug"
+	err = repo.Create(ctx, tenant2)
+	assert.True(t, errors.Is(err, ErrSlugTaken), "Expected ErrSlugTaken, got %v", err)
+}
+
 func TestRepository_GetByID_NotFound(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()

--- a/services/tenant/adapters/persistence/repository_test.go
+++ b/services/tenant/adapters/persistence/repository_test.go
@@ -410,3 +410,68 @@ func TestRepository_Create_WithMetadata(t *testing.T) {
 	assert.Equal(t, "enterprise", retrieved.Metadata["tier"])
 	assert.Equal(t, float64(10000), retrieved.Metadata["max_accounts"])
 }
+
+func TestRepository_Create_WithSlug(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+	tenant := newTestTenant("acme_bank")
+	tenant.Slug = "acme-bank"
+
+	err := repo.Create(ctx, tenant)
+	require.NoError(t, err)
+
+	// Verify slug was saved
+	retrieved, err := repo.GetByID(ctx, tenant.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "acme-bank", retrieved.Slug)
+}
+
+func TestRepository_Create_WithoutSlug(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	ctx := context.Background()
+	tenant := newTestTenant("acme_bank")
+	tenant.Slug = "" // Explicitly empty
+
+	err := repo.Create(ctx, tenant)
+	require.NoError(t, err)
+
+	// Verify slug is empty
+	retrieved, err := repo.GetByID(ctx, tenant.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "", retrieved.Slug)
+}
+
+func TestAdapterMapping_SlugRoundTrip(t *testing.T) {
+	// Test toEntity with non-empty slug
+	domainTenant := newTestTenant("test_tenant")
+	domainTenant.Slug = "test-slug"
+
+	entity := toEntity(domainTenant)
+	require.NotNil(t, entity.Slug, "entity.Slug should not be nil for non-empty domain.Slug")
+	assert.Equal(t, "test-slug", *entity.Slug)
+
+	// Test toDomain with non-nil slug
+	backToDomain, err := toDomain(entity)
+	require.NoError(t, err)
+	assert.Equal(t, "test-slug", backToDomain.Slug)
+}
+
+func TestAdapterMapping_EmptySlugMapsToNil(t *testing.T) {
+	// Test toEntity with empty slug
+	domainTenant := newTestTenant("test_tenant")
+	domainTenant.Slug = ""
+
+	entity := toEntity(domainTenant)
+	assert.Nil(t, entity.Slug, "entity.Slug should be nil for empty domain.Slug")
+
+	// Test toDomain with nil slug
+	backToDomain, err := toDomain(entity)
+	require.NoError(t, err)
+	assert.Equal(t, "", backToDomain.Slug)
+}

--- a/services/tenant/domain/tenant.go
+++ b/services/tenant/domain/tenant.go
@@ -43,6 +43,10 @@ type Tenant struct {
 	// Used for schema routing (org_{id} schema) and API subdomain.
 	ID tenant.TenantID
 
+	// Slug is the URL-friendly unique identifier (lowercase alphanumeric + hyphens).
+	// Used for user-facing URLs and subdomain routing.
+	Slug string
+
 	// DisplayName is the human-readable name of the tenant.
 	DisplayName string
 

--- a/services/tenant/domain/tenant.go
+++ b/services/tenant/domain/tenant.go
@@ -46,8 +46,10 @@ type Tenant struct {
 	// Used for schema routing (org_{id} schema) and API subdomain.
 	ID tenant.TenantID
 
-	// Slug is the URL-friendly unique identifier (lowercase alphanumeric + hyphens).
-	// Used for user-facing URLs and subdomain routing.
+	// Slug is the URL-friendly unique identifier (lowercase alphanumeric + hyphens, 3-63 chars).
+	// Used for branded API endpoints (e.g., acme.meridian.app) where the slug becomes part of the DNS name.
+	// This is distinct from Subdomain which is used for tenant isolation and routing in multi-tenant deployments.
+	// Slug is customer-facing and branding-focused; Subdomain is infrastructure-focused.
 	Slug string
 
 	// DisplayName is the human-readable name of the tenant.
@@ -135,9 +137,12 @@ func (t *Tenant) CanTransitionTo(newStatus Status) bool {
 
 var (
 	// slugPattern enforces lowercase alphanumeric with hyphens, no leading/trailing hyphens.
+	// Note: This regex allows 2-character slugs technically (start + end char with empty middle),
+	// but ValidateSlug enforces a minimum of 3 characters via explicit length check.
 	slugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
 
 	// reservedSlugs contains system-reserved slugs that cannot be used for tenants.
+	// These are common infrastructure subdomains that must remain available for platform services.
 	reservedSlugs = map[string]bool{
 		"api":      true,
 		"health":   true,
@@ -148,6 +153,11 @@ var (
 		"internal": true,
 		"system":   true,
 		"platform": true,
+		"app":      true,
+		"mail":     true,
+		"cdn":      true,
+		"auth":     true,
+		"graphql":  true,
 	}
 
 	// ErrSlugTooShort is returned when a slug is shorter than the minimum required length.

--- a/services/tenant/domain/tenant.go
+++ b/services/tenant/domain/tenant.go
@@ -2,6 +2,9 @@
 package domain
 
 import (
+	"errors"
+	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -128,4 +131,64 @@ func (t *Tenant) CanTransitionTo(newStatus Status) bool {
 	default:
 		return false
 	}
+}
+
+var (
+	// slugPattern enforces lowercase alphanumeric with hyphens, no leading/trailing hyphens.
+	slugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
+
+	// reservedSlugs contains system-reserved slugs that cannot be used for tenants.
+	reservedSlugs = map[string]bool{
+		"api":      true,
+		"health":   true,
+		"admin":    true,
+		"www":      true,
+		"status":   true,
+		"docs":     true,
+		"internal": true,
+		"system":   true,
+		"platform": true,
+	}
+
+	// ErrSlugTooShort is returned when a slug is shorter than the minimum required length.
+	ErrSlugTooShort = errors.New("slug must be at least 3 characters long")
+	// ErrSlugTooLong is returned when a slug exceeds the maximum allowed length.
+	ErrSlugTooLong = errors.New("slug must be at most 63 characters long")
+	// ErrSlugInvalidFormat is returned when a slug contains invalid characters or format.
+	ErrSlugInvalidFormat = errors.New("slug must contain only lowercase alphanumeric characters and hyphens, and cannot start or end with a hyphen")
+	// ErrSlugReserved is returned when a slug matches a system-reserved word.
+	ErrSlugReserved = errors.New("slug is reserved and cannot be used")
+)
+
+// ValidateSlug validates a tenant slug according to platform constraints.
+// Returns nil for empty slug (optional field).
+// Validation rules:
+//   - Length: 3-63 characters
+//   - Format: lowercase alphanumeric with hyphens, no leading/trailing hyphens
+//   - Reserved words: api, health, admin, www, status, docs, internal, system, platform
+func ValidateSlug(slug string) error {
+	// Empty slug is valid (optional field)
+	if slug == "" {
+		return nil
+	}
+
+	// Check length constraints
+	if len(slug) < 3 {
+		return fmt.Errorf("%w, got %d", ErrSlugTooShort, len(slug))
+	}
+	if len(slug) > 63 {
+		return fmt.Errorf("%w, got %d", ErrSlugTooLong, len(slug))
+	}
+
+	// Check format with regex
+	if !slugPattern.MatchString(slug) {
+		return ErrSlugInvalidFormat
+	}
+
+	// Check reserved words
+	if reservedSlugs[slug] {
+		return fmt.Errorf("%w: '%s'", ErrSlugReserved, slug)
+	}
+
+	return nil
 }

--- a/services/tenant/domain/tenant.go
+++ b/services/tenant/domain/tenant.go
@@ -169,6 +169,13 @@ var (
 		"webhooks":   true,
 		"metrics":    true,
 		"prometheus": true,
+		"ftp":        true,
+		"smtp":       true,
+		"imap":       true,
+		"test":       true,
+		"staging":    true,
+		"dev":        true,
+		"prod":       true,
 	}
 
 	// ErrSlugTooShort is returned when a slug is shorter than the minimum required length.

--- a/services/tenant/domain/tenant.go
+++ b/services/tenant/domain/tenant.go
@@ -137,27 +137,38 @@ func (t *Tenant) CanTransitionTo(newStatus Status) bool {
 
 var (
 	// slugPattern enforces lowercase alphanumeric with hyphens, no leading/trailing hyphens.
-	// Note: This regex allows 2-character slugs technically (start + end char with empty middle),
-	// but ValidateSlug enforces a minimum of 3 characters via explicit length check.
+	// Regex breakdown: ^[a-z0-9] (start char) + [a-z0-9-]* (middle, 0+ chars) + [a-z0-9]$ (end char)
+	// This technically allows 2-character slugs (start + end with empty middle) but ValidateSlug
+	// enforces a strict 3-character minimum via explicit length check before the regex.
 	slugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*[a-z0-9]$`)
 
 	// reservedSlugs contains system-reserved slugs that cannot be used for tenants.
 	// These are common infrastructure subdomains that must remain available for platform services.
 	reservedSlugs = map[string]bool{
-		"api":      true,
-		"health":   true,
-		"admin":    true,
-		"www":      true,
-		"status":   true,
-		"docs":     true,
-		"internal": true,
-		"system":   true,
-		"platform": true,
-		"app":      true,
-		"mail":     true,
-		"cdn":      true,
-		"auth":     true,
-		"graphql":  true,
+		"api":        true,
+		"health":     true,
+		"admin":      true,
+		"www":        true,
+		"status":     true,
+		"docs":       true,
+		"internal":   true,
+		"system":     true,
+		"platform":   true,
+		"app":        true,
+		"mail":       true,
+		"cdn":        true,
+		"auth":       true,
+		"graphql":    true,
+		"ws":         true,
+		"websocket":  true,
+		"static":     true,
+		"assets":     true,
+		"login":      true,
+		"logout":     true,
+		"webhook":    true,
+		"webhooks":   true,
+		"metrics":    true,
+		"prometheus": true,
 	}
 
 	// ErrSlugTooShort is returned when a slug is shorter than the minimum required length.

--- a/services/tenant/domain/tenant_test.go
+++ b/services/tenant/domain/tenant_test.go
@@ -357,6 +357,21 @@ func TestValidateSlug(t *testing.T) {
 			errMsg:  "is reserved and cannot be used",
 		},
 
+		// Edge cases - uppercase reserved words fail regex check first (not ErrSlugReserved)
+		// This documents the validation order: length → format (regex) → reserved words
+		{
+			name:    "uppercase reserved word fails format check",
+			slug:    "API",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+		{
+			name:    "mixed case reserved word fails format check",
+			slug:    "Admin",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+
 		// Edge cases - single character with hyphen
 		{
 			name:    "single hyphen",

--- a/services/tenant/domain/tenant_test.go
+++ b/services/tenant/domain/tenant_test.go
@@ -232,6 +232,24 @@ func TestValidateSlug(t *testing.T) {
 			wantErr: true,
 			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
 		},
+		{
+			name:    "unicode characters - accented",
+			slug:    "café",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+		{
+			name:    "unicode characters - japanese",
+			slug:    "日本",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+		{
+			name:    "unicode characters - emoji",
+			slug:    "test🚀",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
 
 		// Edge cases - length
 		{
@@ -305,6 +323,36 @@ func TestValidateSlug(t *testing.T) {
 		{
 			name:    "reserved - platform",
 			slug:    "platform",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - app",
+			slug:    "app",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - mail",
+			slug:    "mail",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - cdn",
+			slug:    "cdn",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - auth",
+			slug:    "auth",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - graphql",
+			slug:    "graphql",
 			wantErr: true,
 			errMsg:  "is reserved and cannot be used",
 		},

--- a/services/tenant/domain/tenant_test.go
+++ b/services/tenant/domain/tenant_test.go
@@ -132,3 +132,225 @@ func TestTenant_CanTransitionTo(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateSlug(t *testing.T) {
+	tests := []struct {
+		name    string
+		slug    string
+		wantErr bool
+		errMsg  string
+	}{
+		// Valid slugs
+		{
+			name:    "valid simple slug",
+			slug:    "acme",
+			wantErr: false,
+		},
+		{
+			name:    "valid slug with numbers",
+			slug:    "bank-123",
+			wantErr: false,
+		},
+		{
+			name:    "valid slug with multiple hyphens",
+			slug:    "my-org",
+			wantErr: false,
+		},
+		{
+			name:    "valid slug all lowercase",
+			slug:    "testcompany",
+			wantErr: false,
+		},
+		{
+			name:    "valid slug with numbers at start",
+			slug:    "123bank",
+			wantErr: false,
+		},
+		{
+			name:    "valid slug minimum length",
+			slug:    "abc",
+			wantErr: false,
+		},
+		{
+			name:    "valid slug maximum length",
+			slug:    "a123456789012345678901234567890123456789012345678901234567890ab",
+			wantErr: false,
+		},
+		{
+			name:    "empty slug is valid",
+			slug:    "",
+			wantErr: false,
+		},
+
+		// Invalid formats
+		{
+			name:    "uppercase letters",
+			slug:    "ACME",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+		{
+			name:    "mixed case",
+			slug:    "AcMeBaNk",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+		{
+			name:    "leading hyphen",
+			slug:    "-start",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+		{
+			name:    "trailing hyphen",
+			slug:    "end-",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+		{
+			name:    "special characters",
+			slug:    "special!",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+		{
+			name:    "underscores",
+			slug:    "with_underscore",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+		{
+			name:    "spaces",
+			slug:    "with space",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+		{
+			name:    "dots",
+			slug:    "with.dot",
+			wantErr: true,
+			errMsg:  "must contain only lowercase alphanumeric characters and hyphens",
+		},
+
+		// Edge cases - length
+		{
+			name:    "too short - 2 chars",
+			slug:    "ab",
+			wantErr: true,
+			errMsg:  "must be at least 3 characters long",
+		},
+		{
+			name:    "too short - 1 char",
+			slug:    "a",
+			wantErr: true,
+			errMsg:  "must be at least 3 characters long",
+		},
+		{
+			name:    "too long - 64 chars",
+			slug:    "a1234567890123456789012345678901234567890123456789012345678901234",
+			wantErr: true,
+			errMsg:  "must be at most 63 characters long",
+		},
+
+		// Reserved words
+		{
+			name:    "reserved - api",
+			slug:    "api",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - admin",
+			slug:    "admin",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - www",
+			slug:    "www",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - health",
+			slug:    "health",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - status",
+			slug:    "status",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - docs",
+			slug:    "docs",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - internal",
+			slug:    "internal",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - system",
+			slug:    "system",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+		{
+			name:    "reserved - platform",
+			slug:    "platform",
+			wantErr: true,
+			errMsg:  "is reserved and cannot be used",
+		},
+
+		// Edge cases - single character with hyphen
+		{
+			name:    "single hyphen",
+			slug:    "-",
+			wantErr: true,
+			errMsg:  "must be at least 3 characters long",
+		},
+		{
+			name:    "double hyphen",
+			slug:    "a--b",
+			wantErr: false, // Multiple consecutive hyphens are allowed
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSlug(tt.slug)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ValidateSlug(%q) expected error containing %q, got nil", tt.slug, tt.errMsg)
+					return
+				}
+				if tt.errMsg != "" && !containsString(err.Error(), tt.errMsg) {
+					t.Errorf("ValidateSlug(%q) error = %q, want error containing %q", tt.slug, err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ValidateSlug(%q) unexpected error: %v", tt.slug, err)
+				}
+			}
+		})
+	}
+}
+
+// containsString checks if s contains substr (case-sensitive).
+func containsString(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
+		func() bool {
+			for i := 0; i <= len(s)-len(substr); i++ {
+				if s[i:i+len(substr)] == substr {
+					return true
+				}
+			}
+			return false
+		}())
+}

--- a/services/tenant/domain/tenant_test.go
+++ b/services/tenant/domain/tenant_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -330,7 +331,7 @@ func TestValidateSlug(t *testing.T) {
 					t.Errorf("ValidateSlug(%q) expected error containing %q, got nil", tt.slug, tt.errMsg)
 					return
 				}
-				if tt.errMsg != "" && !containsString(err.Error(), tt.errMsg) {
+				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
 					t.Errorf("ValidateSlug(%q) error = %q, want error containing %q", tt.slug, err.Error(), tt.errMsg)
 				}
 			} else {
@@ -340,17 +341,4 @@ func TestValidateSlug(t *testing.T) {
 			}
 		})
 	}
-}
-
-// containsString checks if s contains substr (case-sensitive).
-func containsString(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(substr) == 0 ||
-		func() bool {
-			for i := 0; i <= len(s)-len(substr); i++ {
-				if s[i:i+len(substr)] == substr {
-					return true
-				}
-			}
-			return false
-		}())
 }

--- a/services/tenant/service/grpc_service.go
+++ b/services/tenant/service/grpc_service.go
@@ -127,6 +127,9 @@ func (s *Service) InitiateTenant(ctx context.Context, req *pb.InitiateTenantRequ
 		if errors.Is(err, persistence.ErrSubdomainTaken) {
 			return nil, status.Errorf(codes.AlreadyExists, "subdomain %s is already taken", req.Subdomain)
 		}
+		if errors.Is(err, persistence.ErrSlugTaken) {
+			return nil, status.Errorf(codes.AlreadyExists, "slug %s is already taken", req.Slug)
+		}
 		s.logger.Error("failed to create tenant",
 			"tenant_id", req.TenantId,
 			"error", err)
@@ -278,6 +281,7 @@ func (s *Service) ListTenants(ctx context.Context, req *pb.ListTenantsRequest) (
 func (s *Service) toProto(tenant *domain.Tenant) *pb.Tenant {
 	proto := &pb.Tenant{
 		TenantId:        tenant.ID.String(),
+		Slug:            tenant.Slug,
 		DisplayName:     tenant.DisplayName,
 		SettlementAsset: tenant.SettlementAsset,
 		Subdomain:       tenant.Subdomain,

--- a/services/tenant/service/grpc_service.go
+++ b/services/tenant/service/grpc_service.go
@@ -71,9 +71,17 @@ func (s *Service) InitiateTenant(ctx context.Context, req *pb.InitiateTenantRequ
 		initialStatus = domain.StatusProvisioningPending
 	}
 
+	// Validate slug if provided
+	if req.Slug != "" {
+		if err := domain.ValidateSlug(req.Slug); err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid slug: %v", err)
+		}
+	}
+
 	// Create domain tenant
 	tenant := &domain.Tenant{
 		ID:              tenantID,
+		Slug:            req.Slug,
 		DisplayName:     req.DisplayName,
 		SettlementAsset: req.SettlementAsset,
 		Subdomain:       req.Subdomain,


### PR DESCRIPTION
## Summary
- Added Slug field to Tenant domain model and entity for branded API endpoints (e.g., acme.meridian.app)
- Implemented comprehensive slug validation with DNS label rules, reserved word protection, and regex enforcement
- Updated persistence layer adapters to handle slug field mapping with proper null handling

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 59

## Changes Made
- Added `Slug string` field to `domain.Tenant` struct
- Implemented `ValidateSlug()` function with:
  - Length validation (3-63 characters)
  - DNS label regex (lowercase alphanumeric with hyphens)
  - Reserved word protection (api, admin, www, etc.)
  - Comprehensive unit tests covering valid/invalid/reserved cases
- Added `Slug *string` field to `TenantEntity` with:
  - GORM column tags and unique index constraint
  - Nullable string pointer for optional slugs
- Updated `toEntity()` and `toDomain()` adapter functions with:
  - Proper null handling for optional slugs
  - Bidirectional mapping tests

## Test Plan
1. Unit tests for ValidateSlug:
   - Valid slugs: "acme", "bank-123", "my-org"
   - Invalid: "AB", "a", "-start", "end-", "special!", "UPPERCASE"
   - Reserved: "api", "admin", "www"
2. Test entity mapping: domain ↔ entity conversions
3. Test GORM constraints: unique slug enforcement
4. Test nullable behavior: entity with nil slug