### PR TITLE
feat(tenant): add exponential backoff retry logic for ProvisionSchemas

### DIFF
--- a/services/tenant/worker/provisioning_worker.go
+++ b/services/tenant/worker/provisioning_worker.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"math"
+	"math/rand"
+	"strings"
 	"sync"
 	"time"
 
@@ -150,10 +153,20 @@ func (w *ProvisioningWorker) processPendingTenants(ctx context.Context) {
 	}
 }
 
-// provisionTenantWithRetry provisions a tenant's schema with retry logic.
-// It includes panic recovery to prevent crashes and proper goroutine lifecycle management.
-// This is a stub implementation - actual retry logic and provisioning will be completed in task 71.
-func (w *ProvisioningWorker) provisionTenantWithRetry(_ context.Context, tenantID tenant.TenantID) {
+// Retry configuration constants for provisioning with exponential backoff.
+const (
+	maxRetries = 5
+	baseDelay  = 2 * time.Second
+	maxDelay   = 30 * time.Second
+)
+
+// provisionTenantWithRetry provisions a tenant's schema with exponential backoff retry logic.
+// It handles transient failures (like Atlas lock timeouts or DB connection issues) by retrying
+// with increasing delays. On success, marks the tenant as active. On permanent failure or
+// exhausted retries, marks the tenant as provisioning_failed with error details.
+//
+// The function includes panic recovery to prevent crashes and proper goroutine lifecycle management.
+func (w *ProvisioningWorker) provisionTenantWithRetry(ctx context.Context, tenantID tenant.TenantID) {
 	// Ensure we decrement the WaitGroup when this goroutine completes
 	defer w.wg.Done()
 
@@ -166,13 +179,238 @@ func (w *ProvisioningWorker) provisionTenantWithRetry(_ context.Context, tenantI
 		}
 	}()
 
-	w.logger.Info("provisioning tenant (stub)", "tenant_id", tenantID)
+	lastErr := w.executeProvisioningWithRetry(ctx, tenantID)
+	if lastErr == nil {
+		return // Success
+	}
 
-	// TODO(task-71): Implement actual provisioning logic with retry mechanism
-	// This stub will be expanded to:
-	// 1. Call w.provisioner.ProvisionSchema(ctx, tenantID) with the context parameter
-	// 2. Implement exponential backoff retry logic
-	// 3. Update tenant status to ACTIVE on success
-	// 4. Update tenant status to PROVISIONING_FAILED on final failure
-	// 5. Store error details in tenant.ErrorMessage field
+	// Mark as failed
+	w.markTenantAsFailed(ctx, tenantID, lastErr)
+}
+
+// executeProvisioningWithRetry performs the provisioning with retry loop.
+// Returns nil on success, or the last error on failure.
+func (w *ProvisioningWorker) executeProvisioningWithRetry(ctx context.Context, tenantID tenant.TenantID) error {
+	var lastErr error
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if cancelled := w.checkContextCancellation(ctx, tenantID, attempt+1); cancelled {
+			return nil // Context cancelled, don't mark as failed
+		}
+
+		err := w.provisioner.ProvisionSchemas(ctx, tenantID)
+		if err == nil {
+			w.markTenantAsActive(ctx, tenantID, attempt+1)
+			return nil
+		}
+
+		lastErr = err
+		if !isRetryableError(err) {
+			w.logger.Error("provisioning failed with non-retryable error",
+				"tenant_id", tenantID,
+				"attempt", attempt+1,
+				"error", err)
+			break // Permanent error, don't retry
+		}
+
+		if cancelled := w.waitWithBackoff(ctx, tenantID, attempt); cancelled {
+			return nil // Context cancelled, don't mark as failed
+		}
+	}
+
+	return lastErr
+}
+
+// checkContextCancellation checks if context is cancelled and logs appropriately.
+// Returns true if cancelled, false otherwise.
+func (w *ProvisioningWorker) checkContextCancellation(ctx context.Context, tenantID tenant.TenantID, attempt int) bool {
+	select {
+	case <-ctx.Done():
+		w.logger.Warn("provisioning cancelled",
+			"tenant_id", tenantID,
+			"attempt", attempt,
+			"error", ctx.Err())
+		return true
+	default:
+		return false
+	}
+}
+
+// markTenantAsActive updates tenant status to active after successful provisioning.
+func (w *ProvisioningWorker) markTenantAsActive(ctx context.Context, tenantID tenant.TenantID, attempt int) {
+	w.logger.Info("provisioning succeeded",
+		"tenant_id", tenantID,
+		"attempt", attempt)
+
+	tenant, getErr := w.repo.GetByID(ctx, tenantID)
+	if getErr != nil {
+		w.logger.Error("failed to get tenant after successful provisioning",
+			"tenant_id", tenantID,
+			"error", getErr)
+		return
+	}
+
+	_, updateErr := w.repo.UpdateStatus(ctx, tenantID, domain.StatusActive, tenant.Version)
+	if updateErr != nil {
+		w.logger.Error("failed to mark tenant active",
+			"tenant_id", tenantID,
+			"version", tenant.Version,
+			"error", updateErr)
+	}
+}
+
+// markTenantAsFailed updates tenant status to provisioning_failed with error details.
+func (w *ProvisioningWorker) markTenantAsFailed(ctx context.Context, tenantID tenant.TenantID, lastErr error) {
+	tenant, getErr := w.repo.GetByID(ctx, tenantID)
+	if getErr != nil {
+		w.logger.Error("failed to get tenant for failure update",
+			"tenant_id", tenantID,
+			"error", getErr)
+		return
+	}
+
+	_, updateErr := w.repo.UpdateStatusWithError(ctx, tenantID, domain.StatusProvisioningFailed, lastErr.Error(), tenant.Version)
+	if updateErr != nil {
+		w.logger.Error("failed to mark tenant as provisioning_failed",
+			"tenant_id", tenantID,
+			"version", tenant.Version,
+			"error", updateErr)
+	}
+
+	w.logger.Error("provisioning failed after retries",
+		"tenant_id", tenantID,
+		"attempts", maxRetries,
+		"error", lastErr)
+}
+
+// waitWithBackoff waits for the calculated backoff duration with context cancellation support.
+// Returns true if cancelled, false otherwise.
+func (w *ProvisioningWorker) waitWithBackoff(ctx context.Context, tenantID tenant.TenantID, attempt int) bool {
+	delay := calculateBackoffDelay(attempt)
+
+	w.logger.Warn("provisioning failed, retrying",
+		"tenant_id", tenantID,
+		"attempt", attempt+1,
+		"delay", delay,
+		"error", "retryable error")
+
+	select {
+	case <-ctx.Done():
+		w.logger.Warn("provisioning cancelled during backoff",
+			"tenant_id", tenantID,
+			"attempt", attempt+1,
+			"error", ctx.Err())
+		return true
+	case <-time.After(delay):
+		return false
+	}
+}
+
+// calculateBackoffDelay calculates exponential backoff delay with jitter.
+func calculateBackoffDelay(attempt int) time.Duration {
+	delay := time.Duration(float64(baseDelay) * math.Pow(2, float64(attempt)))
+	if delay > maxDelay {
+		delay = maxDelay
+	}
+	jitter := time.Duration(rand.Int63n(int64(delay / 4))) // Add jitter (up to 25% of delay)
+	return delay + jitter
+}
+
+// retryablePatterns are substrings in error messages that indicate transient errors
+// that are worth retrying. These typically include:
+//   - Lock contention: Atlas migration locks, database row locks, etc.
+//   - Connection issues: Pool exhaustion, network timeouts, etc.
+//   - Temporary failures: Service temporarily unavailable, resource exhausted, etc.
+var retryablePatterns = []string{
+	"timeout",     // Connection timeout, lock timeout, query timeout
+	"connection",  // Connection refused, connection reset, connection pool exhausted
+	"lock",        // Atlas lock timeout, database row lock, advisory lock
+	"temporary",   // Temporary failure, temporary unavailable
+	"unavailable", // Service unavailable, resource unavailable
+	"reset",       // Connection reset by peer
+	"refused",     // Connection refused
+	"pool",        // Connection pool exhausted
+	"exhausted",   // Resource exhausted
+	"retry",       // Explicit retry suggestion in error
+}
+
+// permanentPatterns are substrings in error messages that indicate permanent errors
+// that should NOT be retried. These typically include:
+//   - Validation errors: Invalid input, constraint violations
+//   - Authorization errors: Permission denied, access denied
+//   - Schema conflicts: Already exists (may or may not be an error depending on context)
+var permanentPatterns = []string{
+	"invalid",        // Invalid argument, invalid input, invalid tenant ID
+	"permission",     // Permission denied
+	"denied",         // Access denied
+	"not allowed",    // Operation not allowed
+	"constraint",     // Constraint violation, unique constraint
+	"foreign key",    // Foreign key violation
+	"duplicate",      // Duplicate key, duplicate entry
+	"syntax",         // SQL syntax error
+	"does not exist", // Table does not exist, column does not exist
+	"not found",      // Resource not found (usually permanent)
+	"unauthorized",   // Unauthorized access
+	"authentication", // Authentication failed
+	"invalid tenant", // Specific provisioner validation error
+	"already active", // Tenant already provisioned
+	"deprovisioned",  // Tenant is deprovisioned
+}
+
+// isRetryableError determines if a provisioning error is transient and worth retrying.
+//
+// Classification rules:
+//  1. Nil errors are never retryable (no error to retry)
+//  2. Context errors (Canceled, DeadlineExceeded) are never retryable
+//  3. Errors matching permanent patterns are never retryable
+//  4. Errors matching retryable patterns are retryable
+//  5. Unknown errors default to non-retryable (fail-safe behavior)
+//
+// The function uses case-insensitive substring matching on error messages.
+// For structured errors, it checks the full error chain via Error() string.
+//
+// Examples of retryable errors:
+//   - "connection timeout waiting for lock"
+//   - "unable to acquire advisory lock: timeout"
+//   - "connection pool exhausted"
+//   - "service temporarily unavailable"
+//
+// Examples of non-retryable errors:
+//   - "invalid tenant ID format"
+//   - "permission denied: insufficient privileges"
+//   - "foreign key constraint violation"
+//   - "duplicate key value violates unique constraint"
+func isRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Context errors are never retryable - the operation was explicitly cancelled
+	// or the deadline was exceeded. Retrying won't help.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Convert error to lowercase string for case-insensitive matching.
+	// This handles wrapped errors since Error() returns the full chain.
+	errStr := strings.ToLower(err.Error())
+
+	// Check permanent patterns first - these should never be retried
+	for _, pattern := range permanentPatterns {
+		if strings.Contains(errStr, pattern) {
+			return false
+		}
+	}
+
+	// Check for retryable patterns
+	for _, pattern := range retryablePatterns {
+		if strings.Contains(errStr, pattern) {
+			return true
+		}
+	}
+
+	// Default to non-retryable for unknown errors.
+	// This is a fail-safe: we'd rather fail fast on an unknown error
+	// than waste time retrying something that will never succeed.
+	return false
 }

--- a/services/tenant/worker/provisioning_worker.go
+++ b/services/tenant/worker/provisioning_worker.go
@@ -4,6 +4,7 @@ package worker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"math"
 	"math/rand"
@@ -28,12 +29,13 @@ type ProvisioningWorker struct {
 	wg           sync.WaitGroup // Tracks in-flight provisioning goroutines
 }
 
-// Errors returned by NewProvisioningWorker.
+// Errors returned by NewProvisioningWorker and provisioning operations.
 var (
-	ErrNilRepository       = errors.New("repository cannot be nil")
-	ErrNilProvisioner      = errors.New("provisioner cannot be nil")
-	ErrNilLogger           = errors.New("logger cannot be nil")
-	ErrInvalidPollInterval = errors.New("pollInterval must be greater than zero")
+	ErrNilRepository        = errors.New("repository cannot be nil")
+	ErrNilProvisioner       = errors.New("provisioner cannot be nil")
+	ErrNilLogger            = errors.New("logger cannot be nil")
+	ErrInvalidPollInterval  = errors.New("pollInterval must be greater than zero")
+	ErrPanicDuringProvision = errors.New("panic during provisioning")
 )
 
 // NewProvisioningWorker creates a new ProvisioningWorker.
@@ -176,49 +178,54 @@ func (w *ProvisioningWorker) provisionTenantWithRetry(ctx context.Context, tenan
 			w.logger.Error("panic during tenant provisioning",
 				"tenant_id", tenantID,
 				"panic", r)
+			// Mark tenant as failed to prevent it from being stuck in PROVISIONING status
+			panicErr := fmt.Errorf("%w: %v", ErrPanicDuringProvision, r)
+			w.markTenantAsFailed(ctx, tenantID, panicErr, 1)
 		}
 	}()
 
-	lastErr := w.executeProvisioningWithRetry(ctx, tenantID)
+	attempts, lastErr := w.executeProvisioningWithRetry(ctx, tenantID)
 	if lastErr == nil {
 		return // Success
 	}
 
 	// Mark as failed
-	w.markTenantAsFailed(ctx, tenantID, lastErr)
+	w.markTenantAsFailed(ctx, tenantID, lastErr, attempts)
 }
 
 // executeProvisioningWithRetry performs the provisioning with retry loop.
-// Returns nil on success, or the last error on failure.
-func (w *ProvisioningWorker) executeProvisioningWithRetry(ctx context.Context, tenantID tenant.TenantID) error {
+// Returns attempt count and nil on success, or attempt count and error on failure.
+func (w *ProvisioningWorker) executeProvisioningWithRetry(ctx context.Context, tenantID tenant.TenantID) (int, error) {
 	var lastErr error
+	var attempts int
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		if cancelled := w.checkContextCancellation(ctx, tenantID, attempt+1); cancelled {
-			return nil // Context cancelled, don't mark as failed
+		attempts = attempt + 1
+		if cancelled := w.checkContextCancellation(ctx, tenantID, attempts); cancelled {
+			return 0, nil // Context cancelled, don't mark as failed
 		}
 
 		err := w.provisioner.ProvisionSchemas(ctx, tenantID)
 		if err == nil {
-			w.markTenantAsActive(ctx, tenantID, attempt+1)
-			return nil
+			w.markTenantAsActive(ctx, tenantID, attempts)
+			return 0, nil
 		}
 
 		lastErr = err
 		if !isRetryableError(err) {
 			w.logger.Error("provisioning failed with non-retryable error",
 				"tenant_id", tenantID,
-				"attempt", attempt+1,
+				"attempt", attempts,
 				"error", err)
 			break // Permanent error, don't retry
 		}
 
-		if cancelled := w.waitWithBackoff(ctx, tenantID, attempt); cancelled {
-			return nil // Context cancelled, don't mark as failed
+		if cancelled := w.waitWithBackoff(ctx, tenantID, attempt, lastErr); cancelled {
+			return 0, nil // Context cancelled, don't mark as failed
 		}
 	}
 
-	return lastErr
+	return attempts, lastErr
 }
 
 // checkContextCancellation checks if context is cancelled and logs appropriately.
@@ -260,7 +267,7 @@ func (w *ProvisioningWorker) markTenantAsActive(ctx context.Context, tenantID te
 }
 
 // markTenantAsFailed updates tenant status to provisioning_failed with error details.
-func (w *ProvisioningWorker) markTenantAsFailed(ctx context.Context, tenantID tenant.TenantID, lastErr error) {
+func (w *ProvisioningWorker) markTenantAsFailed(ctx context.Context, tenantID tenant.TenantID, lastErr error, attempts int) {
 	tenant, getErr := w.repo.GetByID(ctx, tenantID)
 	if getErr != nil {
 		w.logger.Error("failed to get tenant for failure update",
@@ -279,20 +286,20 @@ func (w *ProvisioningWorker) markTenantAsFailed(ctx context.Context, tenantID te
 
 	w.logger.Error("provisioning failed after retries",
 		"tenant_id", tenantID,
-		"attempts", maxRetries,
+		"attempts", attempts,
 		"error", lastErr)
 }
 
 // waitWithBackoff waits for the calculated backoff duration with context cancellation support.
 // Returns true if cancelled, false otherwise.
-func (w *ProvisioningWorker) waitWithBackoff(ctx context.Context, tenantID tenant.TenantID, attempt int) bool {
+func (w *ProvisioningWorker) waitWithBackoff(ctx context.Context, tenantID tenant.TenantID, attempt int, err error) bool {
 	delay := calculateBackoffDelay(attempt)
 
 	w.logger.Warn("provisioning failed, retrying",
 		"tenant_id", tenantID,
 		"attempt", attempt+1,
 		"delay", delay,
-		"error", "retryable error")
+		"error", err)
 
 	select {
 	case <-ctx.Done():
@@ -307,13 +314,15 @@ func (w *ProvisioningWorker) waitWithBackoff(ctx context.Context, tenantID tenan
 }
 
 // calculateBackoffDelay calculates exponential backoff delay with jitter.
+// The delay is capped at maxDelay (including jitter) to ensure predictable maximum wait times.
 func calculateBackoffDelay(attempt int) time.Duration {
 	delay := time.Duration(float64(baseDelay) * math.Pow(2, float64(attempt)))
+	jitter := time.Duration(rand.Int63n(int64(delay / 4))) // Add jitter (up to 25% of delay)
+	delay = delay + jitter
 	if delay > maxDelay {
 		delay = maxDelay
 	}
-	jitter := time.Duration(rand.Int63n(int64(delay / 4))) // Add jitter (up to 25% of delay)
-	return delay + jitter
+	return delay
 }
 
 // retryablePatterns are substrings in error messages that indicate transient errors

--- a/services/tenant/worker/provisioning_worker_test.go
+++ b/services/tenant/worker/provisioning_worker_test.go
@@ -28,8 +28,17 @@ func testErr(msg string) error {
 
 // setupTestDB creates an in-memory database with the tenant table schema.
 func setupTestDB(t *testing.T) (*gorm.DB, *persistence.Repository) {
-	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	// Use a unique database name per test to ensure isolation, with cache=shared so
+	// all connections within the same test share the same in-memory database.
+	// Without cache=shared, each connection to :memory: creates a separate database.
+	dbName := fmt.Sprintf("file:%s?mode=memory&cache=shared", t.Name())
+	db, err := gorm.Open(sqlite.Open(dbName), &gorm.Config{})
 	require.NoError(t, err)
+
+	// Configure connection pool to avoid connection issues with in-memory DB
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1) // Single connection to ensure consistency
 
 	// Create tenant table
 	err = db.Exec(`
@@ -330,8 +339,10 @@ func TestProcessPendingTenants_Success(t *testing.T) {
 	require.NoError(t, repo.Create(ctx, tenant2))
 	require.NoError(t, repo.Create(ctx, tenant3))
 
-	// Create worker
-	prov := &provisioner.MockProvisioner{}
+	// Create worker with a proper mock that doesn't panic
+	prov := &ControlledMockProvisioner{
+		failureSequence: []error{nil, nil, nil}, // Success for all 3 tenants
+	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	worker, err := NewProvisioningWorker(repo, prov, 5*time.Second, logger)
 	require.NoError(t, err)
@@ -339,24 +350,24 @@ func TestProcessPendingTenants_Success(t *testing.T) {
 	// Execute
 	worker.processPendingTenants(ctx)
 
-	// Give goroutines a moment to spawn
-	time.Sleep(50 * time.Millisecond)
+	// Wait for goroutines to complete provisioning
+	worker.wg.Wait()
 
-	// Verify all tenants were claimed (status updated to PROVISIONING)
+	// Verify all tenants were successfully provisioned (status updated to ACTIVE)
 	updated1, err := repo.GetByID(ctx, tenant1.ID)
 	require.NoError(t, err)
-	assert.Equal(t, domain.StatusProvisioning, updated1.Status)
-	assert.Equal(t, 2, updated1.Version)
+	assert.Equal(t, domain.StatusActive, updated1.Status)
+	assert.Equal(t, 3, updated1.Version) // Initial 1 -> Provisioning 2 -> Active 3
 
 	updated2, err := repo.GetByID(ctx, tenant2.ID)
 	require.NoError(t, err)
-	assert.Equal(t, domain.StatusProvisioning, updated2.Status)
-	assert.Equal(t, 2, updated2.Version)
+	assert.Equal(t, domain.StatusActive, updated2.Status)
+	assert.Equal(t, 3, updated2.Version)
 
 	updated3, err := repo.GetByID(ctx, tenant3.ID)
 	require.NoError(t, err)
-	assert.Equal(t, domain.StatusProvisioning, updated3.Status)
-	assert.Equal(t, 2, updated3.Version)
+	assert.Equal(t, domain.StatusActive, updated3.Status)
+	assert.Equal(t, 3, updated3.Version)
 }
 
 func TestProcessPendingTenants_VersionConflict(t *testing.T) {
@@ -397,8 +408,10 @@ func TestProcessPendingTenants_VersionConflict(t *testing.T) {
 	_, err := repo.UpdateStatus(ctx, tenant2.ID, domain.StatusProvisioning, 1)
 	require.NoError(t, err)
 
-	// Create worker
-	prov := &provisioner.MockProvisioner{}
+	// Create worker with a proper mock that doesn't panic
+	prov := &ControlledMockProvisioner{
+		failureSequence: []error{nil, nil}, // Success for tenant1 and tenant3
+	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	worker, err := NewProvisioningWorker(repo, prov, 5*time.Second, logger)
 	require.NoError(t, err)
@@ -406,12 +419,13 @@ func TestProcessPendingTenants_VersionConflict(t *testing.T) {
 	// Execute - should skip tenant2 (already claimed) and process tenant1 and tenant3
 	worker.processPendingTenants(ctx)
 
-	time.Sleep(50 * time.Millisecond)
+	// Wait for goroutines to complete provisioning
+	worker.wg.Wait()
 
-	// Verify tenant1 and tenant3 were claimed
+	// Verify tenant1 and tenant3 were successfully provisioned (ACTIVE)
 	updated1, err := repo.GetByID(ctx, tenant1.ID)
 	require.NoError(t, err)
-	assert.Equal(t, domain.StatusProvisioning, updated1.Status)
+	assert.Equal(t, domain.StatusActive, updated1.Status)
 
 	// Tenant2 should still be in PROVISIONING status (already claimed by another worker)
 	updated2, err := repo.GetByID(ctx, tenant2.ID)
@@ -420,7 +434,7 @@ func TestProcessPendingTenants_VersionConflict(t *testing.T) {
 
 	updated3, err := repo.GetByID(ctx, tenant3.ID)
 	require.NoError(t, err)
-	assert.Equal(t, domain.StatusProvisioning, updated3.Status)
+	assert.Equal(t, domain.StatusActive, updated3.Status)
 }
 
 func TestProcessPendingTenants_ListByStatusError(t *testing.T) {
@@ -486,8 +500,10 @@ func TestProcessPendingTenants_GoroutinesSpawned(t *testing.T) {
 	require.NoError(t, repo.Create(ctx, tenant1))
 	require.NoError(t, repo.Create(ctx, tenant2))
 
-	// Create worker
-	prov := &provisioner.MockProvisioner{}
+	// Create worker with a proper mock that doesn't panic
+	prov := &ControlledMockProvisioner{
+		failureSequence: []error{nil, nil}, // Success for both tenants
+	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	worker, err := NewProvisioningWorker(repo, prov, 5*time.Second, logger)
 	require.NoError(t, err)
@@ -495,18 +511,21 @@ func TestProcessPendingTenants_GoroutinesSpawned(t *testing.T) {
 	// Execute
 	worker.processPendingTenants(ctx)
 
-	// Give goroutines a moment to spawn
-	time.Sleep(50 * time.Millisecond)
+	// Wait for goroutines to complete provisioning
+	worker.wg.Wait()
 
-	// Verify both tenants were claimed (status updated to PROVISIONING)
-	// This indirectly verifies goroutines were spawned for successfully claimed tenants
+	// Verify both tenants were successfully provisioned (ACTIVE)
+	// This verifies goroutines were spawned and completed for successfully claimed tenants
 	updated1, err := repo.GetByID(ctx, tenant1.ID)
 	require.NoError(t, err)
-	assert.Equal(t, domain.StatusProvisioning, updated1.Status)
+	assert.Equal(t, domain.StatusActive, updated1.Status)
 
 	updated2, err := repo.GetByID(ctx, tenant2.ID)
 	require.NoError(t, err)
-	assert.Equal(t, domain.StatusProvisioning, updated2.Status)
+	assert.Equal(t, domain.StatusActive, updated2.Status)
+
+	// Verify both tenants were provisioned (call count = 2)
+	assert.Equal(t, 2, prov.GetCallCount())
 }
 
 func TestProvisionTenantWithRetry_NoPanic(t *testing.T) {

--- a/services/tenant/worker/provisioning_worker_test.go
+++ b/services/tenant/worker/provisioning_worker_test.go
@@ -2,8 +2,11 @@ package worker
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +19,12 @@ import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
+
+// testErr creates a test error by wrapping a message.
+// This avoids err113 linter warnings about dynamic error creation in tests.
+func testErr(msg string) error {
+	return fmt.Errorf("%s", msg) //nolint:err113 // test helper for dynamic error messages
+}
 
 // setupTestDB creates an in-memory database with the tenant table schema.
 func setupTestDB(t *testing.T) (*gorm.DB, *persistence.Repository) {
@@ -652,4 +661,644 @@ func TestProvisioningWorker_NoGoroutineLeaks(t *testing.T) {
 	// At this point, all goroutines should be cleaned up
 	// We can't easily verify exact goroutine count, but the test passing
 	// without hanging indicates proper cleanup
+}
+
+// Test error sentinels for retry tests (satisfies err113 linter).
+var (
+	errLockTimeout       = errors.New("lock timeout")
+	errDatabaseUnavail   = errors.New("database unavailable")
+	errConnectionTimeout = errors.New("connection timeout")
+	errPermissionDenied  = errors.New("permission denied")
+)
+
+// ControlledMockProvisioner is a mock that allows controlled failure/success sequences.
+type ControlledMockProvisioner struct {
+	mu              sync.Mutex
+	calls           []tenant.TenantID
+	failureSequence []error // nil = success, error = fail with this error
+	callIndex       int
+}
+
+func (m *ControlledMockProvisioner) ProvisionSchemas(_ context.Context, tenantID tenant.TenantID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls = append(m.calls, tenantID)
+
+	if m.callIndex < len(m.failureSequence) {
+		err := m.failureSequence[m.callIndex]
+		m.callIndex++
+		return err
+	}
+
+	// Default to success if no more sequence entries
+	return nil
+}
+
+func (m *ControlledMockProvisioner) DeprovisionSchemas(_ context.Context, _ tenant.TenantID) error {
+	return nil
+}
+
+func (m *ControlledMockProvisioner) PurgeSchemas(_ context.Context, _ tenant.TenantID) error {
+	return nil
+}
+
+func (m *ControlledMockProvisioner) GetProvisioningStatus(_ context.Context, _ tenant.TenantID) (*provisioner.ProvisioningStatus, error) {
+	return nil, nil
+}
+
+func (m *ControlledMockProvisioner) ReconcileMigrations(_ context.Context, _ *tenant.TenantID) (int, []string) {
+	return 0, nil
+}
+
+func (m *ControlledMockProvisioner) GetRequiredSchemas() []string {
+	return []string{"party", "current-account"}
+}
+
+func (m *ControlledMockProvisioner) InitializeProvisioningStatus(_ context.Context, _ tenant.TenantID) error {
+	return nil
+}
+
+func (m *ControlledMockProvisioner) GetCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.calls)
+}
+
+func (m *ControlledMockProvisioner) GetCalls() []tenant.TenantID {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]tenant.TenantID, len(m.calls))
+	copy(result, m.calls)
+	return result
+}
+
+// Ensure ControlledMockProvisioner implements SchemaProvisioner
+var _ provisioner.SchemaProvisioner = (*ControlledMockProvisioner)(nil)
+
+func TestProvisionTenantWithRetry_SuccessOnFirstAttempt(t *testing.T) {
+	_, repo := setupTestDB(t)
+
+	// Create tenant in PROVISIONING status
+	tenantObj := &domain.Tenant{
+		ID:              tenant.MustNewTenantID("test_tenant"),
+		DisplayName:     "Test Tenant",
+		SettlementAsset: "GBP",
+		Status:          domain.StatusProvisioning,
+		CreatedAt:       time.Now(),
+		Version:         1,
+	}
+	ctx := context.Background()
+	require.NoError(t, repo.Create(ctx, tenantObj))
+
+	// Create mock that succeeds immediately
+	mockProv := &ControlledMockProvisioner{
+		failureSequence: []error{nil}, // Success on first call
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	worker, err := NewProvisioningWorker(repo, mockProv, 5*time.Second, logger)
+	require.NoError(t, err)
+
+	// Execute
+	worker.wg.Add(1)
+	worker.provisionTenantWithRetry(ctx, tenantObj.ID)
+
+	// Verify exactly 1 call was made
+	assert.Equal(t, 1, mockProv.GetCallCount())
+
+	// Verify tenant was marked as active
+	updated, err := repo.GetByID(ctx, tenantObj.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.StatusActive, updated.Status)
+}
+
+func TestProvisionTenantWithRetry_SuccessAfterRetries(t *testing.T) {
+	_, repo := setupTestDB(t)
+
+	// Create tenant in PROVISIONING status
+	tenantObj := &domain.Tenant{
+		ID:              tenant.MustNewTenantID("retry_tenant"),
+		DisplayName:     "Retry Tenant",
+		SettlementAsset: "USD",
+		Status:          domain.StatusProvisioning,
+		CreatedAt:       time.Now(),
+		Version:         1,
+	}
+	ctx := context.Background()
+	require.NoError(t, repo.Create(ctx, tenantObj))
+
+	// Create mock that fails 3 times then succeeds
+	mockProv := &ControlledMockProvisioner{
+		failureSequence: []error{errLockTimeout, errLockTimeout, errLockTimeout, nil}, // 3 failures, then success
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	worker, err := NewProvisioningWorker(repo, mockProv, 5*time.Second, logger)
+	require.NoError(t, err)
+
+	// Execute (this will take time due to exponential backoff, but tests use actual delays)
+	// For faster tests, we could inject a clock, but for now we accept the delay
+	start := time.Now()
+	worker.wg.Add(1)
+	worker.provisionTenantWithRetry(ctx, tenantObj.ID)
+	elapsed := time.Since(start)
+
+	// Verify exactly 4 calls were made (3 failures + 1 success)
+	assert.Equal(t, 4, mockProv.GetCallCount())
+
+	// Verify tenant was marked as active
+	updated, err := repo.GetByID(ctx, tenantObj.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.StatusActive, updated.Status)
+
+	// Verify exponential backoff timing (with tolerance for jitter)
+	// 3 retries: 2s + 4s + 8s = 14s base, but with jitter could be up to 14s + 25% = ~17.5s
+	// Minimum is base delays only: 2s + 4s + 8s = 14s
+	// We give generous tolerance due to test environment variability
+	assert.GreaterOrEqual(t, elapsed, 2*time.Second, "should have waited at least 2 seconds for first retry")
+	t.Logf("Elapsed time for 3 retries: %v", elapsed)
+}
+
+func TestProvisionTenantWithRetry_MaxRetriesExhausted(t *testing.T) {
+	_, repo := setupTestDB(t)
+
+	// Create tenant in PROVISIONING status
+	tenantObj := &domain.Tenant{
+		ID:              tenant.MustNewTenantID("fail_tenant"),
+		DisplayName:     "Fail Tenant",
+		SettlementAsset: "EUR",
+		Status:          domain.StatusProvisioning,
+		CreatedAt:       time.Now(),
+		Version:         1,
+	}
+	ctx := context.Background()
+	require.NoError(t, repo.Create(ctx, tenantObj))
+
+	// Create mock that always fails
+	mockProv := &ControlledMockProvisioner{
+		failureSequence: []error{
+			errDatabaseUnavail, errDatabaseUnavail, errDatabaseUnavail, errDatabaseUnavail, errDatabaseUnavail,
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	worker, err := NewProvisioningWorker(repo, mockProv, 5*time.Second, logger)
+	require.NoError(t, err)
+
+	// Execute
+	worker.wg.Add(1)
+	worker.provisionTenantWithRetry(ctx, tenantObj.ID)
+
+	// Verify exactly 5 calls were made (maxRetries = 5)
+	assert.Equal(t, 5, mockProv.GetCallCount())
+
+	// Verify tenant was marked as provisioning_failed
+	updated, err := repo.GetByID(ctx, tenantObj.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.StatusProvisioningFailed, updated.Status)
+	assert.Contains(t, updated.ErrorMessage, "database unavailable")
+}
+
+func TestProvisionTenantWithRetry_ContextCancellation(t *testing.T) {
+	_, repo := setupTestDB(t)
+
+	// Create tenant in PROVISIONING status
+	tenantObj := &domain.Tenant{
+		ID:              tenant.MustNewTenantID("cancel_tenant"),
+		DisplayName:     "Cancel Tenant",
+		SettlementAsset: "GBP",
+		Status:          domain.StatusProvisioning,
+		CreatedAt:       time.Now(),
+		Version:         1,
+	}
+	ctx := context.Background()
+	require.NoError(t, repo.Create(ctx, tenantObj))
+
+	// Create mock that always fails
+	mockProv := &ControlledMockProvisioner{
+		failureSequence: []error{
+			errLockTimeout, errLockTimeout, errLockTimeout, errLockTimeout, errLockTimeout,
+		},
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	worker, err := NewProvisioningWorker(repo, mockProv, 5*time.Second, logger)
+	require.NoError(t, err)
+
+	// Create cancellable context
+	cancelCtx, cancel := context.WithCancel(context.Background())
+
+	// Execute in goroutine
+	done := make(chan struct{})
+	worker.wg.Add(1)
+	go func() {
+		worker.provisionTenantWithRetry(cancelCtx, tenantObj.ID)
+		close(done)
+	}()
+
+	// Wait for first attempt and backoff to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Cancel context
+	cancel()
+
+	// Should stop within a reasonable time (less than full retry cycle)
+	select {
+	case <-done:
+		// Success - stopped early due to cancellation
+	case <-time.After(5 * time.Second):
+		t.Fatal("provisionTenantWithRetry did not respect context cancellation")
+	}
+
+	// Verify fewer than max retries were made (cancelled early)
+	callCount := mockProv.GetCallCount()
+	assert.Less(t, callCount, 5, "should have stopped before max retries due to cancellation")
+	t.Logf("Calls made before cancellation: %d", callCount)
+}
+
+func TestProvisionTenantWithRetry_ExponentialBackoffTiming(t *testing.T) {
+	// This test verifies the exponential backoff timing formula
+	// Expected delays: 2s, 4s, 8s, 16s, 30s (capped)
+	// We only test the first few to avoid long test times
+
+	_, repo := setupTestDB(t)
+
+	// Create tenant
+	tenantObj := &domain.Tenant{
+		ID:              tenant.MustNewTenantID("timing_tenant"),
+		DisplayName:     "Timing Tenant",
+		SettlementAsset: "GBP",
+		Status:          domain.StatusProvisioning,
+		CreatedAt:       time.Now(),
+		Version:         1,
+	}
+	ctx := context.Background()
+	require.NoError(t, repo.Create(ctx, tenantObj))
+
+	// Mock that fails twice then succeeds
+	mockProv := &ControlledMockProvisioner{
+		failureSequence: []error{errLockTimeout, errLockTimeout, nil},
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	worker, err := NewProvisioningWorker(repo, mockProv, 5*time.Second, logger)
+	require.NoError(t, err)
+
+	// Execute and measure time
+	start := time.Now()
+	worker.wg.Add(1)
+	worker.provisionTenantWithRetry(ctx, tenantObj.ID)
+	elapsed := time.Since(start)
+
+	// 2 retries: base delays are 2s + 4s = 6s
+	// With jitter (up to 25%): max = 6s * 1.25 = 7.5s
+	// Allow some tolerance for test environment
+	assert.GreaterOrEqual(t, elapsed, 5*time.Second, "should have waited ~6s total for 2 retries")
+	assert.LessOrEqual(t, elapsed, 10*time.Second, "should not exceed expected delay with jitter")
+
+	t.Logf("Elapsed time for 2 retries: %v (expected ~6-7.5s)", elapsed)
+}
+
+// =============================================================================
+// isRetryableError Tests
+// =============================================================================
+
+// TestIsRetryableError_NilError verifies that nil errors are not retryable.
+func TestIsRetryableError_NilError(t *testing.T) {
+	assert.False(t, isRetryableError(nil), "nil error should not be retryable")
+}
+
+// TestIsRetryableError_ContextErrors verifies that context errors are never retryable.
+func TestIsRetryableError_ContextErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"context.Canceled", context.Canceled},
+		{"context.DeadlineExceeded", context.DeadlineExceeded},
+		{"wrapped context.Canceled", fmt.Errorf("operation failed: %w", context.Canceled)},
+		{"wrapped context.DeadlineExceeded", fmt.Errorf("operation failed: %w", context.DeadlineExceeded)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, isRetryableError(tt.err), "context errors should never be retryable")
+		})
+	}
+}
+
+// TestIsRetryableError_RetryablePatterns verifies that errors containing
+// retryable patterns are correctly identified as transient.
+func TestIsRetryableError_RetryablePatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		errMsg  string
+		comment string
+	}{
+		// Timeout errors
+		{"connection timeout", "connection timeout waiting for response", "Network timeout"},
+		{"lock timeout", "unable to acquire advisory lock: timeout after 30s", "Atlas lock timeout"},
+		{"query timeout", "ERROR: canceling statement due to statement timeout", "PostgreSQL timeout"},
+		{"timeout uppercase", "Connection TIMEOUT", "Case insensitive"},
+
+		// Connection errors
+		{"connection refused", "dial tcp 127.0.0.1:5432: connection refused", "DB down"},
+		{"connection reset", "connection reset by peer", "Network issue"},
+		{"connection pool", "connection pool exhausted", "Pool saturation"},
+
+		// Lock errors
+		{"advisory lock", "could not acquire lock on relation", "PostgreSQL lock"},
+		{"row lock", "could not obtain lock on row in table", "Row-level lock"},
+		{"atlas lock", "acquiring lock on schema: lock timeout", "Atlas migration lock"},
+
+		// Temporary errors
+		{"temporary failure", "temporary failure in name resolution", "DNS issue"},
+		{"temporary unavailable", "resource temporarily unavailable", "Resource busy"},
+
+		// Unavailable errors
+		{"service unavailable", "service temporarily unavailable", "Service down"},
+		{"resource unavailable", "database unavailable", "DB maintenance"},
+
+		// Other transient patterns
+		{"connection pool exhausted", "max pool size reached: exhausted", "Pool full"},
+		{"please retry", "optimistic lock failed, please retry", "Explicit retry hint"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testErr(tt.errMsg)
+			assert.True(t, isRetryableError(err), "error '%s' should be retryable (%s)", tt.errMsg, tt.comment)
+		})
+	}
+}
+
+// TestIsRetryableError_PermanentPatterns verifies that errors containing
+// permanent patterns are correctly identified as non-retryable.
+func TestIsRetryableError_PermanentPatterns(t *testing.T) {
+	tests := []struct {
+		name    string
+		errMsg  string
+		comment string
+	}{
+		// Validation errors
+		{"invalid argument", "invalid argument: tenant_id must not be empty", "Validation"},
+		{"invalid tenant", "invalid tenant ID format: contains special characters", "Specific validation"},
+		{"invalid input", "ERROR: invalid input syntax for type uuid", "Type error"},
+
+		// Permission errors
+		{"permission denied", "permission denied for schema org_acme", "Auth failure"},
+		{"access denied", "access denied to table parties", "Authorization"},
+		{"unauthorized", "unauthorized: token expired", "Auth token"},
+		{"authentication failed", "authentication failed for user meridian", "Login failure"},
+
+		// Constraint violations
+		{"unique constraint", "duplicate key value violates unique constraint", "Duplicate key"},
+		{"foreign key", "foreign key constraint violation on table accounts", "FK violation"},
+		{"constraint violation", "check constraint \"amount_positive\" is violated", "Check constraint"},
+		{"duplicate entry", "Duplicate entry 'test' for key 'name'", "MySQL duplicate"},
+
+		// Schema errors
+		{"does not exist", "table \"parties\" does not exist", "Missing table"},
+		{"not found", "schema org_deleted not found", "Missing schema"},
+		{"syntax error", "ERROR: syntax error at or near \"SELCT\"", "SQL typo"},
+
+		// State errors
+		{"already active", "tenant is already active", "Duplicate provision"},
+		{"deprovisioned", "cannot provision deprovisioned tenant", "State conflict"},
+		{"not allowed", "operation not allowed in current state", "State machine"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testErr(tt.errMsg)
+			assert.False(t, isRetryableError(err), "error '%s' should NOT be retryable (%s)", tt.errMsg, tt.comment)
+		})
+	}
+}
+
+// TestIsRetryableError_UnknownErrors verifies that unknown errors
+// default to non-retryable (fail-safe behavior).
+func TestIsRetryableError_UnknownErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		errMsg string
+	}{
+		{"generic error", "something went wrong"},
+		{"unexpected error", "unexpected state encountered"},
+		{"internal error", "internal server error"},
+		{"unknown status", "unknown status code 500"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testErr(tt.errMsg)
+			assert.False(t, isRetryableError(err), "unknown error '%s' should default to non-retryable", tt.errMsg)
+		})
+	}
+}
+
+// TestIsRetryableError_CaseInsensitive verifies that pattern matching
+// is case-insensitive.
+func TestIsRetryableError_CaseInsensitive(t *testing.T) {
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected bool
+	}{
+		// Retryable - various cases
+		{"TIMEOUT uppercase", "CONNECTION TIMEOUT", true},
+		{"Timeout mixed", "Connection Timeout Exceeded", true},
+		{"timeout lowercase", "connection timeout", true},
+
+		// Permanent - various cases
+		{"INVALID uppercase", "INVALID ARGUMENT", false},
+		{"Invalid mixed", "Invalid Tenant ID", false},
+		{"invalid lowercase", "invalid input", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testErr(tt.errMsg)
+			result := isRetryableError(err)
+			if tt.expected {
+				assert.True(t, result, "error '%s' should be retryable (case-insensitive)", tt.errMsg)
+			} else {
+				assert.False(t, result, "error '%s' should NOT be retryable (case-insensitive)", tt.errMsg)
+			}
+		})
+	}
+}
+
+// TestIsRetryableError_WrappedErrors verifies that wrapped errors
+// are correctly classified by examining the full error chain.
+func TestIsRetryableError_WrappedErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"wrapped retryable", fmt.Errorf("provisioning failed: %w", errConnectionTimeout), true},
+		{"double wrapped retryable", fmt.Errorf("tenant %s: %w", "test", fmt.Errorf("db error: %w", errConnectionTimeout)), true},
+		{"wrapped permanent", fmt.Errorf("provisioning failed: %w", errPermissionDenied), false},
+		{"double wrapped permanent", fmt.Errorf("tenant %s: %w", "test", fmt.Errorf("auth: %w", errPermissionDenied)), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isRetryableError(tt.err)
+			if tt.expected {
+				assert.True(t, result, "wrapped error should be retryable")
+			} else {
+				assert.False(t, result, "wrapped error should NOT be retryable")
+			}
+		})
+	}
+}
+
+// TestIsRetryableError_PermanentTakesPrecedence verifies that when an error
+// contains both retryable and permanent patterns, permanent takes precedence.
+func TestIsRetryableError_PermanentTakesPrecedence(t *testing.T) {
+	tests := []struct {
+		name   string
+		errMsg string
+	}{
+		// Errors that contain both retryable and permanent patterns
+		{"timeout but invalid", "connection timeout due to invalid host address"},
+		{"lock but permission", "could not acquire lock: permission denied"},
+		{"connection but syntax", "connection failed: syntax error in query"},
+		{"timeout but not found", "timeout waiting for resource not found error to resolve"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testErr(tt.errMsg)
+			// Permanent patterns should take precedence over retryable patterns
+			assert.False(t, isRetryableError(err),
+				"permanent pattern should take precedence in '%s'", tt.errMsg)
+		})
+	}
+}
+
+// TestIsRetryableError_AtlasSpecificErrors verifies classification of
+// Atlas migration-specific error messages.
+func TestIsRetryableError_AtlasSpecificErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected bool
+		comment  string
+	}{
+		// Atlas lock timeout (retryable)
+		{
+			"atlas lock timeout",
+			"acquiring lock on schema \"org_test\": context deadline exceeded (timeout: 5s)",
+			true,
+			"Atlas lock wait timeout",
+		},
+		{
+			"atlas advisory lock",
+			"pq: could not obtain lock on \"atlas_schema_revisions\"",
+			true,
+			"Atlas revision table lock",
+		},
+		// Atlas connection issues (retryable)
+		{
+			"atlas connection refused",
+			"dial tcp [::1]:5432: connect: connection refused",
+			true,
+			"DB not available",
+		},
+		// Atlas permanent errors (non-retryable)
+		{
+			"atlas migration syntax",
+			"applying migration \"20240101000000_init.sql\": syntax error at position 42",
+			false,
+			"Bad migration SQL",
+		},
+		{
+			"atlas constraint",
+			"applying migration: violates foreign key constraint \"fk_account_party\"",
+			false,
+			"FK violation",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testErr(tt.errMsg)
+			result := isRetryableError(err)
+			if tt.expected {
+				assert.True(t, result, "Atlas error '%s' should be retryable (%s)", tt.errMsg, tt.comment)
+			} else {
+				assert.False(t, result, "Atlas error '%s' should NOT be retryable (%s)", tt.errMsg, tt.comment)
+			}
+		})
+	}
+}
+
+// TestIsRetryableError_PostgresSpecificErrors verifies classification of
+// PostgreSQL-specific error messages.
+func TestIsRetryableError_PostgresSpecificErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected bool
+		comment  string
+	}{
+		// Connection pool exhaustion (retryable)
+		{
+			"pgx pool exhausted",
+			"unable to acquire connection from pool: all connections are busy or the pool is exhausted",
+			true,
+			"Connection pool saturation",
+		},
+		// Statement timeout (retryable)
+		{
+			"statement timeout",
+			"pq: canceling statement due to statement timeout",
+			true,
+			"Query took too long",
+		},
+		// Lock timeout (retryable)
+		{
+			"lock wait timeout",
+			"pq: canceling statement due to lock timeout",
+			true,
+			"Row-level lock wait",
+		},
+		// Unique constraint violation (non-retryable)
+		{
+			"unique violation",
+			"pq: duplicate key value violates unique constraint \"tenants_slug_key\"",
+			false,
+			"Duplicate slug",
+		},
+		// Foreign key violation (non-retryable)
+		{
+			"fk violation",
+			"pq: insert or update on table \"accounts\" violates foreign key constraint \"fk_party_id\"",
+			false,
+			"Missing parent record",
+		},
+		// Syntax error (non-retryable)
+		{
+			"sql syntax",
+			"pq: syntax error at or near \"SELCT\"",
+			false,
+			"SQL typo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testErr(tt.errMsg)
+			result := isRetryableError(err)
+			if tt.expected {
+				assert.True(t, result, "PostgreSQL error '%s' should be retryable (%s)", tt.errMsg, tt.comment)
+			} else {
+				assert.False(t, result, "PostgreSQL error '%s' should NOT be retryable (%s)", tt.errMsg, tt.comment)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- Add `provisionTenantWithRetry` function with exponential backoff (2s base, 30s max) and jitter
- Implement `isRetryableError` helper for classifying transient vs permanent errors
- Mark tenant as `provisioning_failed` on max retries or permanent error, `active` on success

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 71

## Changes Made
- `services/tenant/worker/provisioning_worker.go`: Add retry logic with exponential backoff, error classification, and status updates
- `services/tenant/worker/provisioning_worker_test.go`: Comprehensive tests for retry behavior and error classification

## Test Plan
- Unit tests verify retry behavior with mocked provisioner
- Tests confirm exponential backoff timing (2s, 4s, 8s...)
- Tests verify context cancellation stops retry loop
- Tests verify isRetryableError pattern matching

## Risk Assessment
Low risk - adds retry logic without changing existing provisioning interface. Backwards compatible.