### PR TITLE
fix: add rows.Err() checks after database query loops in position-keeping

### DIFF
--- a/services/position-keeping/adapters/persistence/postgres_repository.go
+++ b/services/position-keeping/adapters/persistence/postgres_repository.go
@@ -769,6 +769,10 @@ func (r *PostgresRepository) loadTransactionLogEntriesTx(ctx context.Context, tx
 		entries = append(entries, &entry)
 	}
 
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error iterating transaction log entries: %w", err)
+	}
+
 	log.TransactionLogEntries = entries
 	return nil
 }
@@ -893,6 +897,10 @@ func (r *PostgresRepository) loadAuditTrailEntriesTx(ctx context.Context, tx pgx
 		}
 
 		entries = append(entries, &entry)
+	}
+
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error iterating audit trail entries: %w", err)
 	}
 
 	log.AuditTrail = entries
@@ -1205,6 +1213,10 @@ func (r *PostgresRepository) getLogIDMap(ctx context.Context, tx pgx.Tx, logs []
 			return nil, fmt.Errorf("failed to scan log ID mapping: %w", err)
 		}
 		idMap[logID] = dbID
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating log ID mappings: %w", err)
 	}
 
 	return idMap, nil


### PR DESCRIPTION
## Summary
- Add missing `rows.Err()` checks after 3 database query loops in position-keeping repository
- Prevents silent failures when row iteration errors occur
- Follows pgx documentation best practices

## Task Master Reference
- **Tag**: tech-debt-cleanup
- **Task ID**: 16

## Changes Made
- `loadTransactionLogEntriesTx`: Added error check after transaction log entries iteration
- `loadAuditTrailEntriesTx`: Added error check after audit trail entries iteration
- `getLogIDMap`: Added error check after log ID mappings iteration

## Test Plan
- All existing position-keeping persistence tests pass
- Changes are defensive additions with no behavioral changes to happy path