### PR TITLE
fix: replace double %w error wrapping with %w: %v for proper errors.Is() unwrapping

### DIFF
--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -140,20 +140,20 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		// Calculate available balance (within the lock)
 		activeLiensTotal, err := txLienRepo.SumActiveAmountByAccountID(ctx, account.ID())
 		if err != nil {
-			return fmt.Errorf("%w: %w", errTxSumLiensFailed, err)
+			return fmt.Errorf("%w: %v", errTxSumLiensFailed, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
 		// Available = Current Balance - Active Liens
 		balanceCents, err := account.Balance().ToMinorUnits()
 		if err != nil {
-			return fmt.Errorf("%w: %w", errTxDomainError, err)
+			return fmt.Errorf("%w: %v", errTxDomainError, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 		availableBalance = balanceCents - activeLiensTotal
 
 		// Check sufficient funds
 		lienCents, err := lienAmount.ToMinorUnits()
 		if err != nil {
-			return fmt.Errorf("%w: %w", errTxDomainError, err)
+			return fmt.Errorf("%w: %v", errTxDomainError, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 		if lienCents > availableBalance {
 			return errTxInsufficientFunds
@@ -162,12 +162,12 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		// Create lien domain object
 		lien, err = domain.NewLien(account.ID(), lienAmount, req.PaymentOrderReference, nil)
 		if err != nil {
-			return fmt.Errorf("%w: %w", errTxDomainError, err)
+			return fmt.Errorf("%w: %v", errTxDomainError, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
 		// Persist lien (within the transaction)
 		if err := txLienRepo.Create(lien); err != nil {
-			return fmt.Errorf("%w: %w", errTxSaveLien, err)
+			return fmt.Errorf("%w: %v", errTxSaveLien, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
 		return nil
@@ -360,29 +360,29 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		// Retrieve account with FOR UPDATE lock to prevent concurrent modifications
 		accountResult, txErr := txRepo.FindByUUIDForUpdate(ctx, lien.AccountID)
 		if txErr != nil {
-			return fmt.Errorf("%w: %w", errTxSaveAccount, txErr)
+			return fmt.Errorf("%w: %v", errTxSaveAccount, txErr) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
 		// Execute lien (domain logic - marks status as executed)
 		if err := lien.Execute(); err != nil {
-			return fmt.Errorf("%w: %w", errTxExecuteFailed, err)
+			return fmt.Errorf("%w: %v", errTxExecuteFailed, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
 		// Debit the account (immutable: capture returned value)
 		accountResult, err := accountResult.Withdraw(lien.Amount)
 		if err != nil {
-			return fmt.Errorf("%w: %w", errTxWithdrawFailed, err)
+			return fmt.Errorf("%w: %v", errTxWithdrawFailed, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 		account = &accountResult
 
 		// Update lien status
 		if err := txLienRepo.Update(lien); err != nil {
-			return fmt.Errorf("%w: %w", errTxUpdateLien, err)
+			return fmt.Errorf("%w: %v", errTxUpdateLien, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
 		// Save account with balance change (context carries audit user info)
 		if err := txRepo.Save(ctx, accountResult); err != nil {
-			return fmt.Errorf("%w: %w", errTxSaveAccount, err)
+			return fmt.Errorf("%w: %v", errTxSaveAccount, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
 		return nil
@@ -550,12 +550,12 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 
 		// Terminate lien (domain logic)
 		if err := lien.Terminate(reason); err != nil {
-			return fmt.Errorf("%w: %w", errTxTerminateFailed, err)
+			return fmt.Errorf("%w: %v", errTxTerminateFailed, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
 		// Update lien status
 		if err := txLienRepo.Update(lien); err != nil {
-			return fmt.Errorf("%w: %w", errTxUpdateLien, err)
+			return fmt.Errorf("%w: %v", errTxUpdateLien, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
 		return nil

--- a/services/payment-order/adapters/gateway/resilient_gateway.go
+++ b/services/payment-order/adapters/gateway/resilient_gateway.go
@@ -173,7 +173,7 @@ func (r *ResilientPaymentGateway) SendPayment(ctx context.Context, req PaymentRe
 					"payment_order_id", req.PaymentOrderID.String(),
 					"attempt", attempt,
 				)
-				return backoff.Permanent(fmt.Errorf("%w: %w", ErrCircuitOpen, err))
+				return backoff.Permanent(fmt.Errorf("%w: %v", ErrCircuitOpen, err)) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 			}
 
 			// Check if we've exhausted retries

--- a/services/tenant/clients/party_client.go
+++ b/services/tenant/clients/party_client.go
@@ -144,13 +144,13 @@ func (c *PartyGRPCClient) RegisterParty(ctx context.Context, req *partyv1.Regist
 				return nil, fmt.Errorf("%w: %s", ErrPartyRegistrationFailed, st.Message())
 			case codes.Unavailable:
 				// Transient error - service temporarily unavailable, may be retried
-				return nil, fmt.Errorf("%w: %w", ErrPartyServiceUnavailable, err)
+				return nil, fmt.Errorf("%w: %v", ErrPartyServiceUnavailable, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 			case codes.DeadlineExceeded:
 				// Transient error - request timed out, may be retried
-				return nil, fmt.Errorf("%w: %w", ErrPartyServiceTimeout, err)
+				return nil, fmt.Errorf("%w: %v", ErrPartyServiceTimeout, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 			}
 		}
-		return nil, fmt.Errorf("%w: %w", ErrPartyRegistrationFailed, err)
+		return nil, fmt.Errorf("%w: %v", ErrPartyRegistrationFailed, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 	}
 
 	return resp.Party, nil

--- a/services/tenant/provisioner/postgres_provisioner.go
+++ b/services/tenant/provisioner/postgres_provisioner.go
@@ -183,7 +183,7 @@ func (p *PostgresProvisioner) ProvisionSchemas(ctx context.Context, tenantID ten
 				"service", svc.Name,
 				"error", err)
 			p.markProvisioningFailed(ctx, status, fmt.Sprintf("create schema in %s: %v", svc.Name, err))
-			return fmt.Errorf("%w: %s: %w", ErrSchemaCreationFailed, svc.Name, err)
+			return fmt.Errorf("%w: %s: %v", ErrSchemaCreationFailed, svc.Name, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 		logger.Debug("schema created in service database", "service", svc.Name)
 	}
@@ -292,7 +292,7 @@ func (p *PostgresProvisioner) provisionAllServices(ctx context.Context, status *
 			status.Services[i].State = ServiceStateFailed
 			status.Services[i].ErrorMessage = err.Error()
 			p.markProvisioningFailed(ctx, status, fmt.Sprintf("%s migrations failed: %v", svc.Name, err))
-			return fmt.Errorf("%w: %s: %w", ErrMigrationFailed, svc.Name, err)
+			return fmt.Errorf("%w: %s: %v", ErrMigrationFailed, svc.Name, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
 		logger.Debug("service migration completed", "service", svc.Name, "version", version)
@@ -371,7 +371,7 @@ func (p *PostgresProvisioner) DeprovisionSchemas(ctx context.Context, tenantID t
 
 	if err := p.saveProvisioningStatus(ctx, status); err != nil {
 		logger.Error("failed to save deprovisioned status", "error", err)
-		return fmt.Errorf("%w: %w", ErrDeprovisioningFailed, err)
+		return fmt.Errorf("%w: %v", ErrDeprovisioningFailed, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 	}
 
 	logger.Info("schema deprovisioning completed")
@@ -418,7 +418,7 @@ func (p *PostgresProvisioner) PurgeSchemas(ctx context.Context, tenantID tenant.
 	schemaName := tenantID.SchemaName()
 	if err := p.dropSchemaInAllDBs(ctx, schemaName); err != nil {
 		logger.Error("failed to drop schemas from service databases", "error", err)
-		return fmt.Errorf("%w: %w", ErrDeprovisioningFailed, err)
+		return fmt.Errorf("%w: %v", ErrDeprovisioningFailed, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 	}
 	logger.Debug("schemas dropped from all service databases")
 
@@ -715,7 +715,7 @@ func (p *PostgresProvisioner) dropSchemaInAllDBs(ctx context.Context, schemaName
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%w: %w", ErrDeprovisioningFailed, errors.Join(errs...))
+		return fmt.Errorf("%w: %v", ErrDeprovisioningFailed, errors.Join(errs...)) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 	}
 	return nil
 }
@@ -1190,7 +1190,7 @@ func (p *PostgresProvisioner) Close() error {
 		}
 	}
 	if len(errs) > 0 {
-		return fmt.Errorf("%w: %w", ErrCloseConnections, errors.Join(errs...))
+		return fmt.Errorf("%w: %v", ErrCloseConnections, errors.Join(errs...)) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Fixed 22 instances of double `%w` error wrapping that broke `errors.Is()` functionality
- Changed `fmt.Errorf("%w: %w", sentinel, err)` to `fmt.Errorf("%w: %v", sentinel, err)` across 4 files
- Sentinel errors now properly unwrappable while preserving error message context

## Task Master Reference
- **Tag**: tech-debt-cleanup
- **Task ID**: 17

## Changes Made
- `services/current-account/service/lien_service.go`: 12 fixes for transaction sentinel errors
- `services/tenant/provisioner/postgres_provisioner.go`: 6 fixes for provisioning errors
- `services/tenant/clients/party_client.go`: 3 fixes for party service errors
- `services/payment-order/adapters/gateway/resilient_gateway.go`: 1 fix for circuit breaker error

## Technical Details
Go's `fmt.Errorf` with multiple `%w` verbs creates an error that wraps multiple errors, but `errors.Is()` only matches the first wrapped error. By using `%v` for the second error, we:
- Preserve `errors.Is(err, sentinelErr)` functionality for error classification
- Maintain full error message context for logging and debugging
- Follow Go best practices for error wrapping

## Test Plan
- [ ] Verify no remaining double `%w` patterns: `rg 'fmt\.Errorf\([^)]*%w.*%w[^)]*\)' services/`
- [ ] Run unit tests for affected services
- [ ] Verify `errors.Is()` checks in switch statements still work