### PR TITLE
refactor: replace panic() with error returns in service constructors

### DIFF
--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -184,7 +184,7 @@ func run(logger *slog.Logger) error {
 
 	// Register health check service with dependency checking
 	// Health clients bypass the circuit breaker used for business operations
-	healthChecker := service.NewHealthChecker(service.HealthCheckerConfig{
+	healthChecker, err := service.NewHealthChecker(service.HealthCheckerConfig{
 		Repository:                      repo,
 		PositionKeepingClient:           svcClients.positionKeeping,
 		PositionKeepingHealthClient:     svcClients.positionKeepingHealth,
@@ -194,6 +194,9 @@ func run(logger *slog.Logger) error {
 		ServiceName:                     "current-account",
 		CheckTimeout:                    5 * time.Second,
 	})
+	if err != nil {
+		return fmt.Errorf("failed to create health checker: %w", err)
+	}
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthChecker)
 
 	// Register reflection service for debugging

--- a/services/current-account/service/errors.go
+++ b/services/current-account/service/errors.go
@@ -11,6 +11,8 @@ var (
 	ErrRepositoryNil                       = errors.New("repository cannot be nil")
 	ErrPositionKeepingServiceNameEmpty     = errors.New("position keeping service name cannot be empty")
 	ErrFinancialAccountingServiceNameEmpty = errors.New("financial accounting service name cannot be empty")
+	// ErrHealthCheckerRepositoryNil is returned when attempting to create a health checker with a nil repository
+	ErrHealthCheckerRepositoryNil = errors.New("health checker requires non-nil repository")
 )
 
 // Saga orchestration errors for compensation and state tracking

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -91,29 +91,31 @@ type Config struct {
 
 // NewService creates a new current account service with minimal dependencies.
 // This is primarily used for testing. For production use, prefer NewServiceWithClients.
-func NewService(repo *persistence.Repository, lienRepo *persistence.LienRepository) *Service {
+// Returns an error if repository is nil.
+func NewService(repo *persistence.Repository, lienRepo *persistence.LienRepository) (*Service, error) {
 	if repo == nil {
-		panic("repository cannot be nil")
+		return nil, ErrRepositoryNil
 	}
 	return &Service{
 		repo:     repo,
 		lienRepo: lienRepo,
 		logger:   slog.New(slog.NewJSONHandler(os.Stdout, nil)),
-	}
+	}, nil
 }
 
 // NewServiceWithIdempotency creates a new current account service with idempotency support.
 // This is primarily used for testing idempotency paths.
-func NewServiceWithIdempotency(repo *persistence.Repository, lienRepo *persistence.LienRepository, idempotencyService idempotency.Service) *Service {
+// Returns an error if repository is nil.
+func NewServiceWithIdempotency(repo *persistence.Repository, lienRepo *persistence.LienRepository, idempotencyService idempotency.Service) (*Service, error) {
 	if repo == nil {
-		panic("repository cannot be nil")
+		return nil, ErrRepositoryNil
 	}
 	return &Service{
 		repo:               repo,
 		lienRepo:           lienRepo,
 		idempotencyService: idempotencyService,
 		logger:             slog.New(slog.NewJSONHandler(os.Stdout, nil)),
-	}
+	}, nil
 }
 
 // NewServiceWithExistingClients creates a new service with pre-created client instances.

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -850,7 +850,7 @@ func TestExecuteDeposit_WithoutClients_BackwardCompatibility(t *testing.T) {
 	_ = createTestAccount(t, ctx, repo, "ACC-006")
 
 	// Create service WITHOUT clients (backward compatibility mode)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	// Execute deposit
 	req := createTestDepositRequest("ACC-006", 200, 0) // £200.00

--- a/services/current-account/service/grpc_service_party_integration_test.go
+++ b/services/current-account/service/grpc_service_party_integration_test.go
@@ -432,7 +432,7 @@ func TestInitiateCurrentAccount_WithoutPartyClient_BackwardCompatibility(t *test
 	repo := persistence.NewRepository(db)
 
 	// Create service WITHOUT party client (backward compatibility mode)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	// Execute account creation with valid UUID party ID
 	partyID := newTestPartyID()

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -24,6 +24,22 @@ import (
 	"gorm.io/gorm"
 )
 
+// mustNewService creates a Service and fails the test if an error occurs.
+func mustNewService(t *testing.T, repo *persistence.Repository, lienRepo *persistence.LienRepository) *Service {
+	t.Helper()
+	svc, err := NewService(repo, lienRepo)
+	require.NoError(t, err, "unexpected error creating service")
+	return svc
+}
+
+// mustNewServiceWithIdempotency creates a Service with idempotency and fails the test if an error occurs.
+func mustNewServiceWithIdempotency(t *testing.T, repo *persistence.Repository, lienRepo *persistence.LienRepository, idempotencyService idempotency.Service) *Service {
+	t.Helper()
+	svc, err := NewServiceWithIdempotency(repo, lienRepo, idempotencyService)
+	require.NoError(t, err, "unexpected error creating service")
+	return svc
+}
+
 // mustNewMoney is a test helper that creates Money or panics
 func mustNewMoney(currency string, amountCents int64) domain.Money {
 	m, err := domain.NewMoney(currency, amountCents)
@@ -76,7 +92,7 @@ func TestInitiateCurrentAccount(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	req := &pb.InitiateCurrentAccountRequest{
 		AccountIdentification: "GB82WEST12345698765432",
@@ -111,7 +127,7 @@ func TestExecuteDeposit(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	// Create account first
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
@@ -166,7 +182,7 @@ func TestExecuteDepositAccountNotFound(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	req := &pb.ExecuteDepositRequest{
 		AccountId: "ACC-NONEXISTENT",
@@ -199,7 +215,7 @@ func TestExecuteDepositInvalidAmount(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	// Create account first
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
@@ -240,7 +256,7 @@ func TestRetrieveCurrentAccount(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	// Create account first
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
@@ -277,7 +293,7 @@ func TestRetrieveCurrentAccountNotFound(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	req := &pb.RetrieveCurrentAccountRequest{
 		AccountId: "ACC-NONEXISTENT",
@@ -326,7 +342,7 @@ func TestExecuteDepositCurrencyMismatch(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	// Create GBP account
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
@@ -371,7 +387,7 @@ func TestInitiateCurrentAccountUnsupportedCurrency(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	req := &pb.InitiateCurrentAccountRequest{
 		AccountIdentification: "GB82WEST12345698765432",
@@ -465,7 +481,7 @@ func TestExecuteDeposit_OverflowPrevention_UnitsTooCents(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	// Create account
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
@@ -530,7 +546,7 @@ func TestExecuteDeposit_SafeAddition_UnitsAndNanos(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo, nil)
+	svc := mustNewService(t, repo, nil)
 
 	// Create account
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
@@ -689,7 +705,7 @@ func TestExecuteDeposit_IdempotencyReturnsCachedResponse(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	mockIdemp := newMockIdempotencyService()
-	svc := NewServiceWithIdempotency(repo, nil, mockIdemp)
+	svc := mustNewServiceWithIdempotency(t, repo, nil, mockIdemp)
 
 	// Create account
 	account, err := domain.NewCurrentAccount("ACC-IDEMP-001", "ACC-IDEMP-001", uuid.New().String(), "GBP")
@@ -739,7 +755,7 @@ func TestExecuteDeposit_IdempotencyReturnsAbortedWhenInProgress(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	mockIdemp := newMockIdempotencyService()
-	svc := NewServiceWithIdempotency(repo, nil, mockIdemp)
+	svc := mustNewServiceWithIdempotency(t, repo, nil, mockIdemp)
 
 	// Create account
 	account, err := domain.NewCurrentAccount("ACC-IDEMP-002", "ACC-IDEMP-002", uuid.New().String(), "GBP")
@@ -779,7 +795,7 @@ func TestExecuteDeposit_IdempotencyProceedsWithoutKey(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	mockIdemp := newMockIdempotencyService()
-	svc := NewServiceWithIdempotency(repo, nil, mockIdemp)
+	svc := mustNewServiceWithIdempotency(t, repo, nil, mockIdemp)
 
 	// Create account
 	account, err := domain.NewCurrentAccount("ACC-IDEMP-003", "ACC-IDEMP-003", uuid.New().String(), "GBP")
@@ -807,7 +823,7 @@ func TestExecuteDeposit_IdempotencyCleanupOnFailure(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	mockIdemp := newMockIdempotencyService()
-	svc := NewServiceWithIdempotency(repo, nil, mockIdemp)
+	svc := mustNewServiceWithIdempotency(t, repo, nil, mockIdemp)
 
 	// Create account but with wrong currency
 	account, err := domain.NewCurrentAccount("ACC-IDEMP-004", "ACC-IDEMP-004", uuid.New().String(), "GBP")

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -40,6 +40,135 @@ func mustNewServiceWithIdempotency(t *testing.T, repo *persistence.Repository, l
 	return svc
 }
 
+// TestNewService_DefensiveTests verifies nil dependency validation for NewService.
+// Per ADR-0008: Constructors must validate dependencies and return errors instead of panicking.
+func TestNewService_DefensiveTests(t *testing.T) {
+	db, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	validRepo := persistence.NewRepository(db)
+	validLienRepo := persistence.NewLienRepository(db)
+
+	tests := []struct {
+		name         string
+		repo         *persistence.Repository
+		lienRepo     *persistence.LienRepository
+		wantErr      bool
+		wantSentinel error
+		rationale    string
+	}{
+		{
+			name:         "valid dependencies - both repos provided",
+			repo:         validRepo,
+			lienRepo:     validLienRepo,
+			wantErr:      false,
+			wantSentinel: nil,
+			rationale:    "Valid initialization with all dependencies",
+		},
+		{
+			name:         "valid dependencies - lienRepo is optional",
+			repo:         validRepo,
+			lienRepo:     nil,
+			wantErr:      false,
+			wantSentinel: nil,
+			rationale:    "LienRepo is optional for NewService",
+		},
+		{
+			name:         "nil repository returns ErrRepositoryNil",
+			repo:         nil,
+			lienRepo:     validLienRepo,
+			wantErr:      true,
+			wantSentinel: ErrRepositoryNil,
+			rationale:    "Repository is essential - nil would cause panic on first use",
+		},
+		{
+			name:         "all nil returns ErrRepositoryNil",
+			repo:         nil,
+			lienRepo:     nil,
+			wantErr:      true,
+			wantSentinel: ErrRepositoryNil,
+			rationale:    "Should error on first nil check (repository)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, err := NewService(tt.repo, tt.lienRepo)
+			if tt.wantErr {
+				require.Error(t, err, tt.rationale)
+				require.Nil(t, svc, "Service should be nil when error occurs")
+				require.ErrorIs(t, err, tt.wantSentinel, "Should return the expected sentinel error")
+			} else {
+				require.NoError(t, err, tt.rationale)
+				require.NotNil(t, svc, tt.rationale)
+			}
+		})
+	}
+}
+
+// TestNewServiceWithIdempotency_DefensiveTests verifies nil dependency validation.
+// Note: IdempotencyService is optional in current-account (unlike financial-accounting/position-keeping).
+func TestNewServiceWithIdempotency_DefensiveTests(t *testing.T) {
+	db, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	validRepo := persistence.NewRepository(db)
+	validLienRepo := persistence.NewLienRepository(db)
+	mockIdemp := &mockIdempotencyService{}
+
+	tests := []struct {
+		name               string
+		repo               *persistence.Repository
+		lienRepo           *persistence.LienRepository
+		idempotencyService idempotency.Service
+		wantErr            bool
+		wantSentinel       error
+		rationale          string
+	}{
+		{
+			name:               "valid dependencies - all provided",
+			repo:               validRepo,
+			lienRepo:           validLienRepo,
+			idempotencyService: mockIdemp,
+			wantErr:            false,
+			wantSentinel:       nil,
+			rationale:          "Valid initialization with all dependencies",
+		},
+		{
+			name:               "valid - idempotency is optional",
+			repo:               validRepo,
+			lienRepo:           nil,
+			idempotencyService: nil,
+			wantErr:            false,
+			wantSentinel:       nil,
+			rationale:          "IdempotencyService is optional in current-account",
+		},
+		{
+			name:               "nil repository returns ErrRepositoryNil",
+			repo:               nil,
+			lienRepo:           validLienRepo,
+			idempotencyService: mockIdemp,
+			wantErr:            true,
+			wantSentinel:       ErrRepositoryNil,
+			rationale:          "Repository is essential - nil would cause panic on first use",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, err := NewServiceWithIdempotency(tt.repo, tt.lienRepo, tt.idempotencyService)
+			if tt.wantErr {
+				require.Error(t, err, tt.rationale)
+				require.Nil(t, svc, "Service should be nil when error occurs")
+				require.ErrorIs(t, err, tt.wantSentinel, "Should return the expected sentinel error")
+			} else {
+				require.NoError(t, err, tt.rationale)
+				require.NotNil(t, svc, tt.rationale)
+			}
+		})
+	}
+}
+
 // mustNewMoney is a test helper that creates Money or panics
 func mustNewMoney(currency string, amountCents int64) domain.Money {
 	m, err := domain.NewMoney(currency, amountCents)

--- a/services/current-account/service/health.go
+++ b/services/current-account/service/health.go
@@ -49,9 +49,11 @@ type HealthCheckerConfig struct {
 // - SERVING: All critical dependencies healthy (database)
 // - NOT_SERVING: Any critical dependency down (database unreachable)
 // - UNKNOWN: Unable to determine health (should not occur in normal operation)
-func NewHealthChecker(config HealthCheckerConfig) *HealthChecker {
+//
+// Returns an error if Repository is nil.
+func NewHealthChecker(config HealthCheckerConfig) (*HealthChecker, error) {
 	if config.Repository == nil {
-		panic("health checker requires non-nil repository")
+		return nil, ErrHealthCheckerRepositoryNil
 	}
 
 	// Apply defaults
@@ -95,7 +97,7 @@ func NewHealthChecker(config HealthCheckerConfig) *HealthChecker {
 		aggregator:       aggregator,
 		serviceName:      config.ServiceName,
 		checkTimeout:     config.CheckTimeout,
-	}
+	}, nil
 }
 
 // Check implements gRPC health check protocol.

--- a/services/current-account/service/health_example_test.go
+++ b/services/current-account/service/health_example_test.go
@@ -25,7 +25,7 @@ func ExampleHealthChecker() {
 	var finAcctClient clients.FinancialAccountingClient
 
 	// Create health checker
-	healthChecker := service.NewHealthChecker(service.HealthCheckerConfig{
+	healthChecker, err := service.NewHealthChecker(service.HealthCheckerConfig{
 		Repository:                repo,
 		PositionKeepingClient:     posKeepingClient,
 		FinancialAccountingClient: finAcctClient,
@@ -33,6 +33,9 @@ func ExampleHealthChecker() {
 		ServiceName:               "current-account",
 		CheckTimeout:              5 * time.Second,
 	})
+	if err != nil {
+		log.Fatalf("Failed to create health checker: %v", err)
+	}
 
 	// Register health checker with gRPC server
 	grpcServer := grpc.NewServer()

--- a/services/current-account/service/health_test.go
+++ b/services/current-account/service/health_test.go
@@ -32,11 +32,19 @@ func setupTestRepository(t *testing.T) *persistence.Repository {
 	return persistence.NewRepository(db)
 }
 
+// mustNewHealthChecker creates a HealthChecker and fails the test if an error occurs.
+func mustNewHealthChecker(t *testing.T, config HealthCheckerConfig) *HealthChecker {
+	t.Helper()
+	checker, err := NewHealthChecker(config)
+	require.NoError(t, err, "unexpected error creating health checker")
+	return checker
+}
+
 func TestNewHealthChecker(t *testing.T) {
 	tests := []struct {
-		name      string
-		config    HealthCheckerConfig
-		wantPanic bool
+		name    string
+		config  HealthCheckerConfig
+		wantErr bool
 	}{
 		{
 			name: "valid configuration with all dependencies",
@@ -50,46 +58,44 @@ func TestNewHealthChecker(t *testing.T) {
 				ServiceName:                     "test-service",
 				CheckTimeout:                    3 * time.Second,
 			},
-			wantPanic: false,
+			wantErr: false,
 		},
 		{
 			name: "valid configuration with defaults",
 			config: HealthCheckerConfig{
 				Repository: setupTestRepository(t),
 			},
-			wantPanic: false,
+			wantErr: false,
 		},
 		{
-			name: "missing repository panics",
+			name: "missing repository returns error",
 			config: HealthCheckerConfig{
 				PositionKeepingClient:           &mockPositionKeepingClient{},
 				PositionKeepingHealthClient:     &mockGRPCHealthClient{status: grpc_health_v1.HealthCheckResponse_SERVING},
 				FinancialAccountingClient:       &mockFinancialAccountingClient{},
 				FinancialAccountingHealthClient: &mockGRPCHealthClient{status: grpc_health_v1.HealthCheckResponse_SERVING},
 			},
-			wantPanic: true,
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.wantPanic {
-				assert.Panics(t, func() {
-					NewHealthChecker(tt.config)
-				})
+			checker, err := NewHealthChecker(tt.config)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, checker)
 			} else {
-				assert.NotPanics(t, func() {
-					checker := NewHealthChecker(tt.config)
-					assert.NotNil(t, checker)
+				require.NoError(t, err)
+				assert.NotNil(t, checker)
 
-					// Verify defaults applied
-					if tt.config.ServiceName == "" {
-						assert.Equal(t, "current-account", checker.serviceName)
-					}
-					if tt.config.CheckTimeout == 0 {
-						assert.Equal(t, 5*time.Second, checker.checkTimeout)
-					}
-				})
+				// Verify defaults applied
+				if tt.config.ServiceName == "" {
+					assert.Equal(t, "current-account", checker.serviceName)
+				}
+				if tt.config.CheckTimeout == 0 {
+					assert.Equal(t, 5*time.Second, checker.checkTimeout)
+				}
 			}
 		})
 	}
@@ -110,7 +116,7 @@ func TestHealthChecker_Check_AllHealthy(t *testing.T) {
 		status: grpc_health_v1.HealthCheckResponse_SERVING,
 	}
 
-	checker := NewHealthChecker(HealthCheckerConfig{
+	checker := mustNewHealthChecker(t, HealthCheckerConfig{
 		Repository:                      repo,
 		PositionKeepingClient:           posClient,
 		PositionKeepingHealthClient:     posHealthClient,
@@ -134,7 +140,7 @@ func TestHealthChecker_Check_AllHealthy(t *testing.T) {
 func TestHealthChecker_Check_DatabaseOnly(t *testing.T) {
 	repo := setupTestRepository(t)
 
-	checker := NewHealthChecker(HealthCheckerConfig{
+	checker := mustNewHealthChecker(t, HealthCheckerConfig{
 		Repository: repo,
 		Logger:     slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	})
@@ -168,7 +174,7 @@ func TestHealthChecker_Check_ExternalServiceDegraded(t *testing.T) {
 	// We need to add listError fields to the existing mocks
 	// For now, the test will pass because the mocks don't fail by default
 
-	checker := NewHealthChecker(HealthCheckerConfig{
+	checker := mustNewHealthChecker(t, HealthCheckerConfig{
 		Repository:                repo,
 		PositionKeepingClient:     posClient,
 		FinancialAccountingClient: finClient,
@@ -189,7 +195,7 @@ func TestHealthChecker_Check_ExternalServiceDegraded(t *testing.T) {
 func TestHealthChecker_Check_WrongService(t *testing.T) {
 	repo := setupTestRepository(t)
 
-	checker := NewHealthChecker(HealthCheckerConfig{
+	checker := mustNewHealthChecker(t, HealthCheckerConfig{
 		Repository: repo,
 		Logger:     slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	})
@@ -206,7 +212,7 @@ func TestHealthChecker_Check_WrongService(t *testing.T) {
 func TestHealthChecker_Check_EmptyServiceName(t *testing.T) {
 	repo := setupTestRepository(t)
 
-	checker := NewHealthChecker(HealthCheckerConfig{
+	checker := mustNewHealthChecker(t, HealthCheckerConfig{
 		Repository: repo,
 		Logger:     slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	})
@@ -230,7 +236,7 @@ func TestHealthChecker_Check_ComponentSpecificDatabase(t *testing.T) {
 		failOnCapture: false,
 	}
 
-	checker := NewHealthChecker(HealthCheckerConfig{
+	checker := mustNewHealthChecker(t, HealthCheckerConfig{
 		Repository:                repo,
 		PositionKeepingClient:     posClient,
 		FinancialAccountingClient: finClient,
@@ -264,7 +270,7 @@ func TestHealthChecker_Check_ComponentSpecificPositionKeeping(t *testing.T) {
 		status: grpc_health_v1.HealthCheckResponse_SERVING,
 	}
 
-	checker := NewHealthChecker(HealthCheckerConfig{
+	checker := mustNewHealthChecker(t, HealthCheckerConfig{
 		Repository:                      repo,
 		PositionKeepingClient:           posClient,
 		PositionKeepingHealthClient:     posHealthClient,
@@ -300,7 +306,7 @@ func TestHealthChecker_Check_ComponentSpecificFinancialAccounting(t *testing.T) 
 		status: grpc_health_v1.HealthCheckResponse_SERVING,
 	}
 
-	checker := NewHealthChecker(HealthCheckerConfig{
+	checker := mustNewHealthChecker(t, HealthCheckerConfig{
 		Repository:                      repo,
 		PositionKeepingClient:           posClient,
 		PositionKeepingHealthClient:     posHealthClient,
@@ -324,7 +330,7 @@ func TestHealthChecker_Check_ComponentSpecificFinancialAccounting(t *testing.T) 
 func TestHealthChecker_Check_ComponentNotFound(t *testing.T) {
 	repo := setupTestRepository(t)
 
-	checker := NewHealthChecker(HealthCheckerConfig{
+	checker := mustNewHealthChecker(t, HealthCheckerConfig{
 		Repository: repo,
 		Logger:     slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	})
@@ -431,7 +437,7 @@ func TestFinancialAccountingHealthChecker_Healthy(t *testing.T) {
 func TestHealthChecker_Watch(t *testing.T) {
 	repo := setupTestRepository(t)
 
-	checker := NewHealthChecker(HealthCheckerConfig{
+	checker := mustNewHealthChecker(t, HealthCheckerConfig{
 		Repository:   repo,
 		Logger:       slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 		CheckTimeout: 100 * time.Millisecond, // Short timeout for test

--- a/services/current-account/service/health_test.go
+++ b/services/current-account/service/health_test.go
@@ -42,9 +42,10 @@ func mustNewHealthChecker(t *testing.T, config HealthCheckerConfig) *HealthCheck
 
 func TestNewHealthChecker(t *testing.T) {
 	tests := []struct {
-		name    string
-		config  HealthCheckerConfig
-		wantErr bool
+		name         string
+		config       HealthCheckerConfig
+		wantErr      bool
+		wantSentinel error
 	}{
 		{
 			name: "valid configuration with all dependencies",
@@ -58,24 +59,27 @@ func TestNewHealthChecker(t *testing.T) {
 				ServiceName:                     "test-service",
 				CheckTimeout:                    3 * time.Second,
 			},
-			wantErr: false,
+			wantErr:      false,
+			wantSentinel: nil,
 		},
 		{
 			name: "valid configuration with defaults",
 			config: HealthCheckerConfig{
 				Repository: setupTestRepository(t),
 			},
-			wantErr: false,
+			wantErr:      false,
+			wantSentinel: nil,
 		},
 		{
-			name: "missing repository returns error",
+			name: "missing repository returns ErrHealthCheckerRepositoryNil",
 			config: HealthCheckerConfig{
 				PositionKeepingClient:           &mockPositionKeepingClient{},
 				PositionKeepingHealthClient:     &mockGRPCHealthClient{status: grpc_health_v1.HealthCheckResponse_SERVING},
 				FinancialAccountingClient:       &mockFinancialAccountingClient{},
 				FinancialAccountingHealthClient: &mockGRPCHealthClient{status: grpc_health_v1.HealthCheckResponse_SERVING},
 			},
-			wantErr: true,
+			wantErr:      true,
+			wantSentinel: ErrHealthCheckerRepositoryNil,
 		},
 	}
 
@@ -83,8 +87,10 @@ func TestNewHealthChecker(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			checker, err := NewHealthChecker(tt.config)
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, checker)
+				// Verify the specific sentinel error using errors.Is()
+				assert.ErrorIs(t, err, tt.wantSentinel, "Should return the expected sentinel error")
 			} else {
 				require.NoError(t, err)
 				assert.NotNil(t, checker)

--- a/services/current-account/service/lien_service_test.go
+++ b/services/current-account/service/lien_service_test.go
@@ -104,7 +104,7 @@ func TestInitiateLien_Success(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	// Create account with £1000 balance
 	createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-001", 100000) // 100000 cents = £1000
@@ -138,7 +138,7 @@ func TestInitiateLien_InsufficientFunds(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	// Create account with £100 balance
 	createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-002", 10000) // £100
@@ -169,7 +169,7 @@ func TestInitiateLien_AccountNotFound(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	req := &pb.InitiateLienRequest{
 		AccountId: "NON-EXISTENT-ACC",
@@ -196,7 +196,7 @@ func TestInitiateLien_CurrencyMismatch(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	// Create GBP account
 	createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-003", 100000)
@@ -227,7 +227,7 @@ func TestInitiateLien_Idempotent(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	// Create account with £1000 balance
 	createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-IDEMP", 100000)
@@ -264,7 +264,7 @@ func TestExecuteLien_Success(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	// Create account with £1000 balance
 	account := createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-004", 100000)
@@ -296,7 +296,7 @@ func TestExecuteLien_Idempotent(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	// Create account with £1000 balance
 	account := createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-005", 100000)
@@ -328,7 +328,7 @@ func TestExecuteLien_NotFound(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	req := &pb.ExecuteLienRequest{
 		LienId: uuid.New().String(),
@@ -347,7 +347,7 @@ func TestTerminateLien_Success(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	// Create account with £1000 balance
 	account := createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-006", 100000)
@@ -379,7 +379,7 @@ func TestTerminateLien_Idempotent(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	// Create account with £1000 balance
 	account := createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-007", 100000)
@@ -413,7 +413,7 @@ func TestRetrieveLien_Success(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	// Create account
 	account := createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-008", 100000)
@@ -443,7 +443,7 @@ func TestRetrieveLien_NotFound(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	req := &pb.RetrieveLienRequest{
 		LienId: uuid.New().String(),
@@ -461,7 +461,7 @@ func TestLienOperations_LienRepoNotConfigured(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := NewService(repo, nil) // No lien repo
+	svc := mustNewService(t, repo, nil) // No lien repo
 
 	t.Run("InitiateLien", func(t *testing.T) {
 		req := &pb.InitiateLienRequest{
@@ -512,7 +512,7 @@ func TestMultipleLiens_AvailableBalanceCalculation(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
-	svc := NewService(repo, lienRepo)
+	svc := mustNewService(t, repo, lienRepo)
 
 	// Create account with £1000 balance
 	createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-MULTI", 100000)
@@ -689,7 +689,7 @@ func TestExecuteLien_IdempotencyReturnsCachedResponse(t *testing.T) {
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
 	mockIdemp := newLienMockIdempotencyService()
-	svc := NewServiceWithIdempotency(repo, lienRepo, mockIdemp)
+	svc := mustNewServiceWithIdempotency(t, repo, lienRepo, mockIdemp)
 
 	// Create account with £1000 balance
 	account := createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-IDEMP-001", 100000)
@@ -743,7 +743,7 @@ func TestExecuteLien_IdempotencyReturnsAbortedWhenInProgress(t *testing.T) {
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
 	mockIdemp := newLienMockIdempotencyService()
-	svc := NewServiceWithIdempotency(repo, lienRepo, mockIdemp)
+	svc := mustNewServiceWithIdempotency(t, repo, lienRepo, mockIdemp)
 
 	// Create account with £1000 balance
 	account := createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-IDEMP-002", 100000)
@@ -786,7 +786,7 @@ func TestExecuteLien_IdempotencyProceedsWithoutKey(t *testing.T) {
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
 	mockIdemp := newLienMockIdempotencyService()
-	svc := NewServiceWithIdempotency(repo, lienRepo, mockIdemp)
+	svc := mustNewServiceWithIdempotency(t, repo, lienRepo, mockIdemp)
 
 	// Create account with £1000 balance
 	account := createTestAccountWithBalance(t, ctx, repo, "ACC-LIEN-IDEMP-003", 100000)
@@ -817,7 +817,7 @@ func TestExecuteLien_IdempotencyCleanupOnFailure(t *testing.T) {
 	repo := persistence.NewRepository(db)
 	lienRepo := persistence.NewLienRepository(db)
 	mockIdemp := newLienMockIdempotencyService()
-	svc := NewServiceWithIdempotency(repo, lienRepo, mockIdemp)
+	svc := mustNewServiceWithIdempotency(t, repo, lienRepo, mockIdemp)
 
 	idempKey := idempotency.Key{
 		TenantID:  lienSvcTestTenantID,

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -171,7 +171,10 @@ func run(logger *slog.Logger) error {
 	logger.Info("event publisher initialized (noop mode)")
 
 	// Create Financial Accounting service
-	financialAccountingSvc := service.NewFinancialAccountingService(ledgerRepo, eventPublisher, idempotencySvc)
+	financialAccountingSvc, err := service.NewFinancialAccountingService(ledgerRepo, eventPublisher, idempotencySvc)
+	if err != nil {
+		return fmt.Errorf("failed to create financial accounting service: %w", err)
+	}
 
 	logger.Info("financial accounting service initialized")
 	_ = postingService // Available for internal use
@@ -216,12 +219,15 @@ func run(logger *slog.Logger) error {
 	financialaccountingv1.RegisterFinancialAccountingServiceServer(grpcServer, financialAccountingSvc)
 
 	// Register health check service with database connectivity check
-	healthChecker := serviceobs.NewHealthChecker(serviceobs.HealthCheckerConfig{
+	healthChecker, err := serviceobs.NewHealthChecker(serviceobs.HealthCheckerConfig{
 		DB:           db,
 		Logger:       logger,
 		ServiceName:  "financial-accounting",
 		CheckTimeout: 5 * time.Second,
 	})
+	if err != nil {
+		return fmt.Errorf("failed to create health checker: %w", err)
+	}
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthChecker)
 
 	// Register reflection service for debugging

--- a/services/financial-accounting/observability/health.go
+++ b/services/financial-accounting/observability/health.go
@@ -12,6 +12,12 @@ import (
 	"gorm.io/gorm"
 )
 
+// Health checker initialization errors
+var (
+	// ErrDatabaseNil is returned when attempting to create a health checker with a nil database
+	ErrDatabaseNil = errors.New("health checker requires non-nil database")
+)
+
 // HealthChecker implements gRPC health check protocol for FinancialAccounting service.
 // It checks the health of critical dependencies including the database.
 type HealthChecker struct {
@@ -39,9 +45,11 @@ type HealthCheckerConfig struct {
 //   - SERVING: All critical dependencies healthy (database)
 //   - NOT_SERVING: Any critical dependency down (database unreachable)
 //   - UNKNOWN: Unable to determine health (should not occur in normal operation)
-func NewHealthChecker(config HealthCheckerConfig) *HealthChecker {
+//
+// Returns an error if DB is nil.
+func NewHealthChecker(config HealthCheckerConfig) (*HealthChecker, error) {
 	if config.DB == nil {
-		panic("health checker requires non-nil database")
+		return nil, ErrDatabaseNil
 	}
 
 	// Apply defaults
@@ -67,7 +75,7 @@ func NewHealthChecker(config HealthCheckerConfig) *HealthChecker {
 		logger:       config.Logger,
 		serviceName:  config.ServiceName,
 		checkTimeout: config.CheckTimeout,
-	}
+	}, nil
 }
 
 // Check implements gRPC health check protocol.

--- a/services/financial-accounting/observability/health_test.go
+++ b/services/financial-accounting/observability/health_test.go
@@ -189,8 +189,10 @@ func TestHealthChecker_ErrorOnNilDB(t *testing.T) {
 	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
 		DB: nil,
 	})
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, healthChecker)
+	// Verify the specific sentinel error using errors.Is()
+	assert.ErrorIs(t, err, ErrDatabaseNil, "Should return ErrDatabaseNil sentinel error")
 }
 
 func TestMapStatusToGRPC(t *testing.T) {

--- a/services/financial-accounting/observability/health_test.go
+++ b/services/financial-accounting/observability/health_test.go
@@ -81,10 +81,11 @@ func TestHealthChecker_Check_Healthy(t *testing.T) {
 	gormDB, mock := setupMockDB(t)
 	mock.ExpectPing()
 
-	healthChecker := NewHealthChecker(HealthCheckerConfig{
+	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
 		DB:           gormDB,
 		CheckTimeout: 5 * time.Second,
 	})
+	require.NoError(t, err)
 
 	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
 
@@ -98,10 +99,11 @@ func TestHealthChecker_Check_Unhealthy(t *testing.T) {
 	gormDB, mock := setupMockDB(t)
 	mock.ExpectPing().WillReturnError(assert.AnError)
 
-	healthChecker := NewHealthChecker(HealthCheckerConfig{
+	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
 		DB:           gormDB,
 		CheckTimeout: 5 * time.Second,
 	})
+	require.NoError(t, err)
 
 	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
 
@@ -115,10 +117,11 @@ func TestHealthChecker_Check_SpecificService(t *testing.T) {
 	gormDB, mock := setupMockDB(t)
 	mock.ExpectPing()
 
-	healthChecker := NewHealthChecker(HealthCheckerConfig{
+	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
 		DB:          gormDB,
 		ServiceName: "financial-accounting",
 	})
+	require.NoError(t, err)
 
 	// Check with explicit service name
 	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
@@ -135,9 +138,10 @@ func TestHealthChecker_Check_SpecificComponent(t *testing.T) {
 	gormDB, mock := setupMockDB(t)
 	mock.ExpectPing()
 
-	healthChecker := NewHealthChecker(HealthCheckerConfig{
+	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
 		DB: gormDB,
 	})
+	require.NoError(t, err)
 
 	// Check database component specifically
 	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
@@ -153,9 +157,10 @@ func TestHealthChecker_Check_SpecificComponent(t *testing.T) {
 func TestHealthChecker_Check_UnknownService(t *testing.T) {
 	gormDB, _ := setupMockDB(t)
 
-	healthChecker := NewHealthChecker(HealthCheckerConfig{
+	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
 		DB: gormDB,
 	})
+	require.NoError(t, err)
 
 	// Check unknown service
 	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
@@ -169,9 +174,10 @@ func TestHealthChecker_Check_UnknownService(t *testing.T) {
 func TestHealthChecker_DefaultConfig(t *testing.T) {
 	gormDB, _ := setupMockDB(t)
 
-	healthChecker := NewHealthChecker(HealthCheckerConfig{
+	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
 		DB: gormDB,
 	})
+	require.NoError(t, err)
 
 	assert.Equal(t, "financial-accounting", healthChecker.serviceName)
 	assert.Equal(t, 5*time.Second, healthChecker.checkTimeout)
@@ -179,19 +185,20 @@ func TestHealthChecker_DefaultConfig(t *testing.T) {
 	assert.NotNil(t, healthChecker.aggregator)
 }
 
-func TestHealthChecker_PanicOnNilDB(t *testing.T) {
-	assert.Panics(t, func() {
-		NewHealthChecker(HealthCheckerConfig{
-			DB: nil,
-		})
+func TestHealthChecker_ErrorOnNilDB(t *testing.T) {
+	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
+		DB: nil,
 	})
+	assert.Error(t, err)
+	assert.Nil(t, healthChecker)
 }
 
 func TestMapStatusToGRPC(t *testing.T) {
 	gormDB, _ := setupMockDB(t)
-	healthChecker := NewHealthChecker(HealthCheckerConfig{
+	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
 		DB: gormDB,
 	})
+	require.NoError(t, err)
 
 	tests := []struct {
 		status   health.Status

--- a/services/financial-accounting/service/financial_accounting_service.go
+++ b/services/financial-accounting/service/financial_accounting_service.go
@@ -26,6 +26,16 @@ const (
 	defaultIdempotencyTTL = 1 * time.Hour
 )
 
+// Service initialization errors
+var (
+	// ErrRepositoryNil is returned when attempting to create a service with a nil repository
+	ErrRepositoryNil = errors.New("financial accounting service: repository cannot be nil")
+	// ErrEventPublisherNil is returned when attempting to create a service with a nil event publisher
+	ErrEventPublisherNil = errors.New("financial accounting service: event publisher cannot be nil")
+	// ErrIdempotencyServiceNil is returned when attempting to create a service with a nil idempotency service
+	ErrIdempotencyServiceNil = errors.New("financial accounting service: idempotency service cannot be nil")
+)
+
 // DomainEvent is a marker interface for all financial accounting domain events.
 // Concrete event types will be defined in domain/events.go in subsequent subtasks.
 //
@@ -99,7 +109,7 @@ type FinancialAccountingService struct {
 // default "Unimplemented" responses for all gRPC methods. Methods will be implemented incrementally
 // in subsequent subtasks (9.2, 9.3, 9.4, 9.5).
 //
-// Panics if any dependency is nil (defensive programming per ADR-0008).
+// Returns an error if any dependency is nil.
 //
 // Example usage:
 //
@@ -107,27 +117,30 @@ type FinancialAccountingService struct {
 //	publisher := messaging.NewKafkaEventPublisher(kafkaProducer)
 //	idempotencySvc := idempotency.NewRedisService(redisClient)
 //
-//	service := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+//	service, err := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+//	if err != nil {
+//	    return fmt.Errorf("failed to create financial accounting service: %w", err)
+//	}
 func NewFinancialAccountingService(
 	repository *persistence.LedgerRepository,
 	eventPublisher EventPublisher,
 	idempotencySvc idempotency.Service,
-) *FinancialAccountingService {
+) (*FinancialAccountingService, error) {
 	if repository == nil {
-		panic("financial accounting service: repository cannot be nil")
+		return nil, ErrRepositoryNil
 	}
 	if eventPublisher == nil {
-		panic("financial accounting service: event publisher cannot be nil")
+		return nil, ErrEventPublisherNil
 	}
 	if idempotencySvc == nil {
-		panic("financial accounting service: idempotency service cannot be nil")
+		return nil, ErrIdempotencyServiceNil
 	}
 
 	return &FinancialAccountingService{
 		repository:     repository,
 		eventPublisher: eventPublisher,
 		idempotency:    idempotencySvc,
-	}
+	}, nil
 }
 
 // CaptureLedgerPosting creates a new ledger posting with validation and event publishing.

--- a/services/financial-accounting/service/financial_accounting_service_test.go
+++ b/services/financial-accounting/service/financial_accounting_service_test.go
@@ -86,6 +86,7 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 		eventPub       EventPublisher
 		idempotencySvc idempotency.Service
 		wantErr        bool
+		wantSentinel   error // Expected sentinel error for errors.Is() verification
 		rationale      string
 	}{
 		// Happy path - covered by TestNewFinancialAccountingService
@@ -95,6 +96,7 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 			eventPub:       &mockEventPublisher{},
 			idempotencySvc: &mockIdempotencyService{},
 			wantErr:        false,
+			wantSentinel:   nil,
 			rationale:      "Standard valid initialization with all dependencies",
 		},
 
@@ -105,6 +107,7 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 			eventPub:       &mockEventPublisher{},
 			idempotencySvc: &mockIdempotencyService{},
 			wantErr:        true,
+			wantSentinel:   ErrRepositoryNil,
 			rationale:      "Repository is essential - nil would cause panic on first use",
 		},
 		{
@@ -113,6 +116,7 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 			eventPub:       nil,
 			idempotencySvc: &mockIdempotencyService{},
 			wantErr:        true,
+			wantSentinel:   ErrEventPublisherNil,
 			rationale:      "Event publisher is essential - nil would cause panic when publishing events",
 		},
 		{
@@ -121,6 +125,7 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 			eventPub:       &mockEventPublisher{},
 			idempotencySvc: nil,
 			wantErr:        true,
+			wantSentinel:   ErrIdempotencyServiceNil,
 			rationale:      "Idempotency service is essential - nil would cause panic on idempotent operations",
 		},
 
@@ -131,6 +136,7 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 			eventPub:       nil,
 			idempotencySvc: nil,
 			wantErr:        true,
+			wantSentinel:   ErrRepositoryNil,
 			rationale:      "Should error on first nil check (repository)",
 		},
 	}
@@ -139,8 +145,10 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			service, err := NewFinancialAccountingService(tt.repository, tt.eventPub, tt.idempotencySvc)
 			if tt.wantErr {
-				assert.Error(t, err, tt.rationale)
+				require.Error(t, err, tt.rationale)
 				assert.Nil(t, service, "Service should be nil when error occurs")
+				// Verify the specific sentinel error using errors.Is()
+				assert.ErrorIs(t, err, tt.wantSentinel, "Should return the expected sentinel error")
 			} else {
 				require.NoError(t, err, tt.rationale)
 				assert.NotNil(t, service, tt.rationale)

--- a/services/financial-accounting/service/financial_accounting_service_test.go
+++ b/services/financial-accounting/service/financial_accounting_service_test.go
@@ -51,9 +51,10 @@ func TestNewFinancialAccountingService(t *testing.T) {
 	idempotencySvc := &mockIdempotencyService{}
 
 	// Act
-	service := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+	service, err := NewFinancialAccountingService(repo, publisher, idempotencySvc)
 
 	// Assert
+	require.NoError(t, err, "Should create service without error")
 	assert.NotNil(t, service, "Service should not be nil")
 	assert.NotNil(t, service.repository, "Repository should be injected")
 	assert.NotNil(t, service.eventPublisher, "Event publisher should be injected")
@@ -61,14 +62,15 @@ func TestNewFinancialAccountingService(t *testing.T) {
 }
 
 // TestFinancialAccountingService_ImplementsInterface verifies the service implements the gRPC interface.
-func TestFinancialAccountingService_ImplementsInterface(_ *testing.T) {
+func TestFinancialAccountingService_ImplementsInterface(t *testing.T) {
 	// Arrange
 	repo := persistence.NewLedgerRepository(&gorm.DB{})
 	publisher := &mockEventPublisher{}
 	idempotencySvc := &mockIdempotencyService{}
 
 	// Act
-	service := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+	service, err := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+	require.NoError(t, err)
 
 	// Assert - compile-time check that service implements the interface
 	var _ financialaccountingv1.FinancialAccountingServiceServer = service
@@ -83,7 +85,7 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 		repository     *persistence.LedgerRepository
 		eventPub       EventPublisher
 		idempotencySvc idempotency.Service
-		shouldPanic    bool
+		wantErr        bool
 		rationale      string
 	}{
 		// Happy path - covered by TestNewFinancialAccountingService
@@ -92,7 +94,7 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 			repository:     persistence.NewLedgerRepository(&gorm.DB{}),
 			eventPub:       &mockEventPublisher{},
 			idempotencySvc: &mockIdempotencyService{},
-			shouldPanic:    false,
+			wantErr:        false,
 			rationale:      "Standard valid initialization with all dependencies",
 		},
 
@@ -102,7 +104,7 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 			repository:     nil,
 			eventPub:       &mockEventPublisher{},
 			idempotencySvc: &mockIdempotencyService{},
-			shouldPanic:    true,
+			wantErr:        true,
 			rationale:      "Repository is essential - nil would cause panic on first use",
 		},
 		{
@@ -110,7 +112,7 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 			repository:     persistence.NewLedgerRepository(&gorm.DB{}),
 			eventPub:       nil,
 			idempotencySvc: &mockIdempotencyService{},
-			shouldPanic:    true,
+			wantErr:        true,
 			rationale:      "Event publisher is essential - nil would cause panic when publishing events",
 		},
 		{
@@ -118,7 +120,7 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 			repository:     persistence.NewLedgerRepository(&gorm.DB{}),
 			eventPub:       &mockEventPublisher{},
 			idempotencySvc: nil,
-			shouldPanic:    true,
+			wantErr:        true,
 			rationale:      "Idempotency service is essential - nil would cause panic on idempotent operations",
 		},
 
@@ -128,28 +130,35 @@ func TestNewFinancialAccountingService_DefensiveTests(t *testing.T) {
 			repository:     nil,
 			eventPub:       nil,
 			idempotencySvc: nil,
-			shouldPanic:    true,
-			rationale:      "Should panic on first nil check (repository)",
+			wantErr:        true,
+			rationale:      "Should error on first nil check (repository)",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.shouldPanic {
-				assert.Panics(t, func() {
-					NewFinancialAccountingService(tt.repository, tt.eventPub, tt.idempotencySvc)
-				}, tt.rationale)
+			service, err := NewFinancialAccountingService(tt.repository, tt.eventPub, tt.idempotencySvc)
+			if tt.wantErr {
+				assert.Error(t, err, tt.rationale)
+				assert.Nil(t, service, "Service should be nil when error occurs")
 			} else {
-				assert.NotPanics(t, func() {
-					service := NewFinancialAccountingService(tt.repository, tt.eventPub, tt.idempotencySvc)
-					assert.NotNil(t, service, tt.rationale)
-					assert.NotNil(t, service.repository, "Repository should be injected")
-					assert.NotNil(t, service.eventPublisher, "Event publisher should be injected")
-					assert.NotNil(t, service.idempotency, "Idempotency service should be injected")
-				}, tt.rationale)
+				require.NoError(t, err, tt.rationale)
+				assert.NotNil(t, service, tt.rationale)
+				assert.NotNil(t, service.repository, "Repository should be injected")
+				assert.NotNil(t, service.eventPublisher, "Event publisher should be injected")
+				assert.NotNil(t, service.idempotency, "Idempotency service should be injected")
 			}
 		})
 	}
+}
+
+// mustNewFinancialAccountingService creates a service and fails the test if an error occurs.
+// Use this for tests where the service should always be created successfully.
+func mustNewFinancialAccountingService(t *testing.T, repo *persistence.LedgerRepository, publisher EventPublisher, idempotencySvc idempotency.Service) *FinancialAccountingService {
+	t.Helper()
+	service, err := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+	require.NoError(t, err, "unexpected error creating service")
+	return service
 }
 
 // mockIdempotencyService is a test double for idempotency.Service
@@ -1209,7 +1218,7 @@ func TestCaptureLedgerPosting_IdempotencyResponseSerialization(t *testing.T) {
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
 
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.CaptureLedgerPostingRequest{
 			FinancialBookingLogId: validBookingLogID.String(),
@@ -1250,7 +1259,7 @@ func TestCaptureLedgerPosting_IdempotencyResponseSerialization(t *testing.T) {
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
 
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.CaptureLedgerPostingRequest{
 			FinancialBookingLogId: validBookingLogID.String(),
@@ -1291,7 +1300,7 @@ func TestCaptureLedgerPosting_IdempotencyResponseSerialization(t *testing.T) {
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
 
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.CaptureLedgerPostingRequest{
 			FinancialBookingLogId: validBookingLogID.String(),
@@ -1421,7 +1430,7 @@ func TestUpdateLedgerPosting_IdempotencyRequired(t *testing.T) {
 			repo := persistence.NewLedgerRepository(&gorm.DB{})
 			publisher := &mockEventPublisher{}
 			mockIdem := &mockIdempotencyService{}
-			service := NewFinancialAccountingService(repo, publisher, mockIdem)
+			service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 			req := &financialaccountingv1.UpdateLedgerPostingRequest{
 				Id:             validPostingID.String(),
@@ -1481,7 +1490,7 @@ func TestUpdateLedgerPosting_IdempotencyCaching(t *testing.T) {
 		}
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.UpdateLedgerPostingRequest{
 			Id:            validPostingID.String(),
@@ -1512,7 +1521,7 @@ func TestUpdateLedgerPosting_IdempotencyCaching(t *testing.T) {
 		}
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.UpdateLedgerPostingRequest{
 			Id:            validPostingID.String(),
@@ -1544,7 +1553,7 @@ func TestUpdateLedgerPosting_IdempotencyCaching(t *testing.T) {
 		}
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.UpdateLedgerPostingRequest{
 			Id:            validPostingID.String(),
@@ -1572,7 +1581,7 @@ func TestUpdateLedgerPosting_IdempotencyCaching(t *testing.T) {
 		}
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.UpdateLedgerPostingRequest{
 			Id:            validPostingID.String(),
@@ -1600,7 +1609,7 @@ func TestUpdateLedgerPosting_IdempotencyCaching(t *testing.T) {
 		}
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.UpdateLedgerPostingRequest{
 			Id:            validPostingID.String(),
@@ -1654,7 +1663,7 @@ func TestUpdateFinancialBookingLog_IdempotencyRequired(t *testing.T) {
 			repo := persistence.NewLedgerRepository(&gorm.DB{})
 			publisher := &mockEventPublisher{}
 			mockIdem := &mockIdempotencyService{}
-			service := NewFinancialAccountingService(repo, publisher, mockIdem)
+			service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 			req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
 				Id:                   validBookingLogID.String(),
@@ -1709,7 +1718,7 @@ func TestUpdateFinancialBookingLog_IdempotencyCaching(t *testing.T) {
 		}
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
 			Id:     validBookingLogID.String(),
@@ -1739,7 +1748,7 @@ func TestUpdateFinancialBookingLog_IdempotencyCaching(t *testing.T) {
 		}
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
 			Id:     validBookingLogID.String(),
@@ -1770,7 +1779,7 @@ func TestUpdateFinancialBookingLog_IdempotencyCaching(t *testing.T) {
 		}
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
 			Id:     validBookingLogID.String(),
@@ -1797,7 +1806,7 @@ func TestUpdateFinancialBookingLog_IdempotencyCaching(t *testing.T) {
 		}
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
 			Id:     validBookingLogID.String(),
@@ -1824,7 +1833,7 @@ func TestUpdateFinancialBookingLog_IdempotencyCaching(t *testing.T) {
 		}
 		repo := persistence.NewLedgerRepository(&gorm.DB{})
 		publisher := &mockEventPublisher{}
-		service := NewFinancialAccountingService(repo, publisher, mockIdem)
+		service := mustNewFinancialAccountingService(t, repo, publisher, mockIdem)
 
 		req := &financialaccountingv1.UpdateFinancialBookingLogRequest{
 			Id:     validBookingLogID.String(),

--- a/services/financial-accounting/service/grpc_integration_test.go
+++ b/services/financial-accounting/service/grpc_integration_test.go
@@ -149,7 +149,8 @@ func setupIntegrationTest(t *testing.T) (*testServer, context.Context) {
 	}
 
 	// Create the financial accounting service
-	service := NewFinancialAccountingService(repo, eventPublisher, idempotencySvc)
+	service, err := NewFinancialAccountingService(repo, eventPublisher, idempotencySvc)
+	require.NoError(t, err, "Failed to create financial accounting service")
 
 	// Create gRPC server with tenant interceptor
 	grpcServer := grpc.NewServer(

--- a/services/financial-accounting/service/list_booking_logs_test.go
+++ b/services/financial-accounting/service/list_booking_logs_test.go
@@ -177,7 +177,10 @@ func TestListFinancialBookingLogs_DefensiveTests(t *testing.T) {
 			publisher := &mockEventPublisher{}
 			idempotencySvc := &mockIdempotencyService{}
 
-			service := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+			service, svcErr := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+			if svcErr != nil {
+				t.Fatalf("failed to create service: %v", svcErr)
+			}
 
 			// Act
 			resp, err := service.ListFinancialBookingLogs(ctx, tt.request)
@@ -274,7 +277,10 @@ func TestListFinancialBookingLogs_PaginationBehavior(t *testing.T) {
 			repo := persistence.NewLedgerRepository(db)
 			publisher := &mockEventPublisher{}
 			idempotencySvc := &mockIdempotencyService{}
-			service := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+			service, svcErr := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+			if svcErr != nil {
+				t.Fatalf("failed to create service: %v", svcErr)
+			}
 
 			req := &financialaccountingv1.ListFinancialBookingLogsRequest{
 				Pagination: &commonv1.Pagination{PageSize: tt.pageSize},

--- a/services/financial-accounting/service/list_ledger_postings_test.go
+++ b/services/financial-accounting/service/list_ledger_postings_test.go
@@ -324,7 +324,10 @@ func TestListLedgerPostings_DefensiveTests(t *testing.T) {
 			publisher := &mockEventPublisher{}
 			idempotencySvc := &mockIdempotencyService{}
 
-			service := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+			service, svcErr := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+			if svcErr != nil {
+				t.Fatalf("failed to create service: %v", svcErr)
+			}
 
 			// Act
 			resp, err := service.ListLedgerPostings(ctx, tt.request)
@@ -402,7 +405,10 @@ func TestListLedgerPostings_MultipleFilters(t *testing.T) {
 	repo := persistence.NewLedgerRepository(db)
 	publisher := &mockEventPublisher{}
 	idempotencySvc := &mockIdempotencyService{}
-	service := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+	service, err := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
 
 	req := &financialaccountingv1.ListLedgerPostingsRequest{
 		Pagination:            &commonv1.Pagination{PageSize: 50},

--- a/services/financial-accounting/service/retrieve_list_service_test.go
+++ b/services/financial-accounting/service/retrieve_list_service_test.go
@@ -110,7 +110,10 @@ func TestRetrieveLedgerPosting_DefensiveTests(t *testing.T) {
 			publisher := &mockEventPublisher{}
 			idempotencySvc := &mockIdempotencyService{}
 
-			service := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+			service, err := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+			if err != nil {
+				t.Fatalf("failed to create service: %v", err)
+			}
 
 			req := &financialaccountingv1.RetrieveLedgerPostingRequest{
 				Id: tt.requestID,
@@ -261,7 +264,10 @@ func TestRetrieveLedgerPosting_EdgeCases(t *testing.T) {
 			publisher := &mockEventPublisher{}
 			idempotencySvc := &mockIdempotencyService{}
 
-			service := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+			service, err := NewFinancialAccountingService(repo, publisher, idempotencySvc)
+			if err != nil {
+				t.Fatalf("failed to create service: %v", err)
+			}
 
 			req := &financialaccountingv1.RetrieveLedgerPostingRequest{
 				Id: postingID.String(),

--- a/services/position-keeping/cmd/main.go
+++ b/services/position-keeping/cmd/main.go
@@ -131,11 +131,14 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Create gRPC service
-	positionKeepingService := service.NewPositionKeepingService(
+	positionKeepingService, err := service.NewPositionKeepingService(
 		container.PositionLogRepository,
 		container.EventPublisher,
 		idempotencySvc,
 	)
+	if err != nil {
+		return fmt.Errorf("failed to create position keeping service: %w", err)
+	}
 
 	logger.Info("position keeping service initialized")
 

--- a/services/position-keeping/service/adapters_test.go
+++ b/services/position-keeping/service/adapters_test.go
@@ -1011,7 +1011,10 @@ func callToProtoFinancialPositionLog(log *domain.FinancialPositionLog) *position
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc, err := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	if err != nil {
+		return nil
+	}
 
 	// Call RetrieveFinancialPositionLog which will convert using our adapter functions
 	resp, err := svc.RetrieveFinancialPositionLog(context.Background(), &positionkeepingv1.RetrieveFinancialPositionLogRequest{

--- a/services/position-keeping/service/initiate_batch_test.go
+++ b/services/position-keeping/service/initiate_batch_test.go
@@ -18,7 +18,6 @@ import (
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
-	"github.com/meridianhub/meridian/services/position-keeping/service"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 )
 
@@ -495,7 +494,7 @@ func BenchmarkInitiateFinancialPositionLogBatch_SmallBatch(b *testing.B) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(b, mockRepo, mockEventPublisher, mockIdempotency)
 
 	mockRepo.On("CreateBatch", ctx, mock.Anything).Return(nil)
 
@@ -522,7 +521,7 @@ func BenchmarkInitiateFinancialPositionLogBatch_MediumBatch(b *testing.B) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(b, mockRepo, mockEventPublisher, mockIdempotency)
 
 	mockRepo.On("CreateBatch", ctx, mock.Anything).Return(nil)
 
@@ -549,7 +548,7 @@ func BenchmarkInitiateFinancialPositionLogBatch_LargeBatch(b *testing.B) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(b, mockRepo, mockEventPublisher, mockIdempotency)
 
 	mockRepo.On("CreateBatch", ctx, mock.Anything).Return(nil)
 

--- a/services/position-keeping/service/initiate_batch_test.go
+++ b/services/position-keeping/service/initiate_batch_test.go
@@ -35,7 +35,7 @@ func TestInitiateFinancialPositionLogBatch_Success(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.InitiateFinancialPositionLogBatchRequest{
 		Requests: []*positionkeepingv1.BatchInitiateRequest{
@@ -83,7 +83,7 @@ func TestInitiateFinancialPositionLogBatch_WithInitialEntry(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.InitiateFinancialPositionLogBatchRequest{
 		Requests: []*positionkeepingv1.BatchInitiateRequest{
@@ -160,7 +160,7 @@ func TestInitiateFinancialPositionLogBatch_EmptyRequest(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.InitiateFinancialPositionLogBatchRequest{
 		Requests: []*positionkeepingv1.BatchInitiateRequest{},
@@ -187,7 +187,7 @@ func TestInitiateFinancialPositionLogBatch_ExceedsMaxSize(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	// Create 10,001 requests (exceeds max of 10,000)
 	requests := make([]*positionkeepingv1.BatchInitiateRequest, 10001)
@@ -222,7 +222,7 @@ func TestInitiateFinancialPositionLogBatch_PartialValidationFailures(t *testing.
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.InitiateFinancialPositionLogBatchRequest{
 		Requests: []*positionkeepingv1.BatchInitiateRequest{
@@ -260,7 +260,7 @@ func TestInitiateFinancialPositionLogBatch_Idempotency(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	batchID := uuid.NewString()
 	idempotencyKey := uuid.NewString()
@@ -317,7 +317,7 @@ func TestInitiateFinancialPositionLogBatch_LargeBatch(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	// Create 1,000 requests
 	requests := make([]*positionkeepingv1.BatchInitiateRequest, 1000)
@@ -356,7 +356,7 @@ func TestInitiateFinancialPositionLogBatch_CustomBatchID(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	customBatchID := uuid.NewString()
 	req := &positionkeepingv1.InitiateFinancialPositionLogBatchRequest{
@@ -389,7 +389,7 @@ func TestInitiateFinancialPositionLogBatch_InvalidBatchID(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.InitiateFinancialPositionLogBatchRequest{
 		Requests: []*positionkeepingv1.BatchInitiateRequest{
@@ -419,7 +419,7 @@ func TestInitiateFinancialPositionLogBatch_IdempotencyRequiresBatchID(t *testing
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.InitiateFinancialPositionLogBatchRequest{
 		Requests: []*positionkeepingv1.BatchInitiateRequest{
@@ -456,7 +456,7 @@ func TestInitiateFinancialPositionLogBatch_ConcurrentBatches(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	// Mock CreateBatch to be concurrent-safe
 	mockRepo.On("CreateBatch", mock.Anything, mock.AnythingOfType("[]*domain.FinancialPositionLog")).
@@ -495,7 +495,7 @@ func BenchmarkInitiateFinancialPositionLogBatch_SmallBatch(b *testing.B) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	mockRepo.On("CreateBatch", ctx, mock.Anything).Return(nil)
 
@@ -522,7 +522,7 @@ func BenchmarkInitiateFinancialPositionLogBatch_MediumBatch(b *testing.B) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	mockRepo.On("CreateBatch", ctx, mock.Anything).Return(nil)
 
@@ -549,7 +549,7 @@ func BenchmarkInitiateFinancialPositionLogBatch_LargeBatch(b *testing.B) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	mockRepo.On("CreateBatch", ctx, mock.Anything).Return(nil)
 
@@ -577,7 +577,7 @@ func TestInitiateFinancialPositionLogBatch_DatabaseFailureWithIdempotencyCleanup
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	batchID := uuid.New()
 	idempotencyKey := uuid.NewString()
@@ -634,7 +634,7 @@ func TestInitiateFinancialPositionLogBatch_ContextCancellation(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	// Create a context that's already cancelled
 	ctx, cancel := context.WithCancel(context.Background())

--- a/services/position-keeping/service/initiate_batch_test.go
+++ b/services/position-keeping/service/initiate_batch_test.go
@@ -18,6 +18,7 @@ import (
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/services/position-keeping/service"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 )
 
@@ -674,7 +675,8 @@ func TestInitiateFinancialPositionLogBatch_NilPointerRegressionOnValidationFailu
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc, err := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	require.NoError(t, err)
 
 	// Create a batch with alternating valid and invalid entries to maximize
 	// the chance of triggering race conditions in the parallel processing

--- a/services/position-keeping/service/initiate_test.go
+++ b/services/position-keeping/service/initiate_test.go
@@ -22,10 +22,11 @@ import (
 
 // mustNewPositionKeepingService creates a service and fails the test if an error occurs.
 // Use this for tests where the service should always be created successfully.
-func mustNewPositionKeepingService(t *testing.T, repo domain.FinancialPositionLogRepository, publisher domain.EventPublisher, idempotencySvc idempotency.Service) *service.PositionKeepingService {
-	t.Helper()
+// Accepts testing.TB to work with both *testing.T and *testing.B.
+func mustNewPositionKeepingService(tb testing.TB, repo domain.FinancialPositionLogRepository, publisher domain.EventPublisher, idempotencySvc idempotency.Service) *service.PositionKeepingService {
+	tb.Helper()
 	svc, err := service.NewPositionKeepingService(repo, publisher, idempotencySvc)
-	require.NoError(t, err, "unexpected error creating service")
+	require.NoError(tb, err, "unexpected error creating service")
 	return svc
 }
 

--- a/services/position-keeping/service/initiate_test.go
+++ b/services/position-keeping/service/initiate_test.go
@@ -20,6 +20,15 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 )
 
+// mustNewPositionKeepingService creates a service and fails the test if an error occurs.
+// Use this for tests where the service should always be created successfully.
+func mustNewPositionKeepingService(t *testing.T, repo domain.FinancialPositionLogRepository, publisher domain.EventPublisher, idempotencySvc idempotency.Service) *service.PositionKeepingService {
+	t.Helper()
+	svc, err := service.NewPositionKeepingService(repo, publisher, idempotencySvc)
+	require.NoError(t, err, "unexpected error creating service")
+	return svc
+}
+
 // MockRepository is a mock implementation of FinancialPositionLogRepository
 type MockRepository struct {
 	mock.Mock
@@ -127,7 +136,7 @@ func TestInitiateFinancialPositionLog_Success(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.InitiateFinancialPositionLogRequest{
 		AccountId: "test-account-123",
@@ -198,7 +207,7 @@ func TestInitiateFinancialPositionLog_IdempotencyCheck(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	idempotencyKey := uuid.NewString()
 	req := &positionkeepingv1.InitiateFinancialPositionLogRequest{
@@ -301,7 +310,7 @@ func TestInitiateFinancialPositionLog_ValidationErrors(t *testing.T) {
 			mockEventPublisher := domain.NewInMemoryEventPublisher()
 			mockIdempotency := new(MockIdempotencyService)
 
-			svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+			svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 			// Act
 			resp, err := svc.InitiateFinancialPositionLog(ctx, tt.req)
@@ -325,7 +334,7 @@ func TestInitiateFinancialPositionLog_RepositoryError(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.InitiateFinancialPositionLogRequest{
 		AccountId: "test-account-123",
@@ -372,7 +381,7 @@ func TestInitiateFinancialPositionLog_MarkPendingError(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.InitiateFinancialPositionLogRequest{
 		AccountId: "test-account-123",
@@ -411,7 +420,7 @@ func TestInitiateFinancialPositionLog_StoreResultError(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.InitiateFinancialPositionLogRequest{
 		AccountId: "test-account-123",

--- a/services/position-keeping/service/list_test.go
+++ b/services/position-keeping/service/list_test.go
@@ -25,7 +25,7 @@ func TestListFinancialPositionLogs_ByAccountID(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	accountID := "ACC-12345"
 	now := time.Now().UTC()
@@ -87,7 +87,7 @@ func TestListFinancialPositionLogs_ByStatus(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	status := domain.TransactionStatusPending
 	now := time.Now().UTC()
@@ -138,7 +138,7 @@ func TestListFinancialPositionLogs_Pagination(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	now := time.Now().UTC()
 	expectedLogs := []*domain.FinancialPositionLog{
@@ -185,7 +185,7 @@ func TestListFinancialPositionLogs_DateRange(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	fromDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	// ToDate is start of next day (exclusive upper bound)
@@ -241,7 +241,7 @@ func TestListFinancialPositionLogs_EmptyResults(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	// Setup mock to return empty results
 	mockRepo.On("List", ctx, domain.PositionLogFilter{
@@ -301,7 +301,7 @@ func TestListFinancialPositionLogs_InvalidPagination(t *testing.T) {
 			mockEventPublisher := domain.NewInMemoryEventPublisher()
 			mockIdempotency := new(MockIdempotencyService)
 
-			svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+			svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 			req := &positionkeepingv1.ListFinancialPositionLogsRequest{
 				Pagination: &commonv1.Pagination{
@@ -333,7 +333,7 @@ func TestListFinancialPositionLogs_InvalidDateRange(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.ListFinancialPositionLogsRequest{
 		DateRange: &commonv1.DateRange{
@@ -367,7 +367,7 @@ func TestListFinancialPositionLogs_RepositoryError(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	// Setup mock to return error
 	mockRepo.On("List", ctx, domain.PositionLogFilter{

--- a/services/position-keeping/service/list_test.go
+++ b/services/position-keeping/service/list_test.go
@@ -14,7 +14,6 @@ import (
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
-	"github.com/meridianhub/meridian/services/position-keeping/service"
 )
 
 // TestListFinancialPositionLogs_ByAccountID tests filtering by account ID

--- a/services/position-keeping/service/retrieve_test.go
+++ b/services/position-keeping/service/retrieve_test.go
@@ -24,7 +24,7 @@ func TestRetrieveFinancialPositionLog_Success(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	logID := uuid.New()
 	now := time.Now().UTC()
@@ -65,7 +65,7 @@ func TestRetrieveFinancialPositionLog_NotFound(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	logID := uuid.New()
 	mockRepo.On("FindByID", ctx, logID).Return(nil, domain.ErrNotFound)
@@ -97,7 +97,7 @@ func TestRetrieveFinancialPositionLog_InvalidID(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.RetrieveFinancialPositionLogRequest{
 		LogId: "not-a-valid-uuid",
@@ -126,7 +126,7 @@ func TestRetrieveFinancialPositionLog_EmptyID(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.RetrieveFinancialPositionLogRequest{
 		LogId: "",
@@ -154,7 +154,7 @@ func TestRetrieveFinancialPositionLog_RepositoryError(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	logID := uuid.New()
 	mockRepo.On("FindByID", ctx, logID).Return(nil, assert.AnError)

--- a/services/position-keeping/service/retrieve_test.go
+++ b/services/position-keeping/service/retrieve_test.go
@@ -13,7 +13,6 @@ import (
 
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
-	"github.com/meridianhub/meridian/services/position-keeping/service"
 )
 
 // TestRetrieveFinancialPositionLog_Success tests successful retrieval by ID

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -15,6 +15,16 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 )
 
+// Service initialization errors
+var (
+	// ErrRepositoryNil is returned when attempting to create a service with a nil repository
+	ErrRepositoryNil = errors.New("position keeping service: repository cannot be nil")
+	// ErrEventPublisherNil is returned when attempting to create a service with a nil event publisher
+	ErrEventPublisherNil = errors.New("position keeping service: event publisher cannot be nil")
+	// ErrIdempotencyServiceNil is returned when attempting to create a service with a nil idempotency service
+	ErrIdempotencyServiceNil = errors.New("position keeping service: idempotency service cannot be nil")
+)
+
 // PositionKeepingService implements the gRPC service for Position Keeping operations.
 type PositionKeepingService struct {
 	positionkeepingv1.UnimplementedPositionKeepingServiceServer
@@ -30,27 +40,27 @@ type PositionKeepingService struct {
 //   - eventPublisher: Publishes domain events (must not be nil)
 //   - idempotencySvc: Ensures exactly-once processing of idempotent operations (must not be nil)
 //
-// Panics if any dependency is nil (defensive programming per ADR-0008).
+// Returns an error if any dependency is nil.
 func NewPositionKeepingService(
 	repository domain.FinancialPositionLogRepository,
 	eventPublisher domain.EventPublisher,
 	idempotencySvc idempotency.Service,
-) *PositionKeepingService {
+) (*PositionKeepingService, error) {
 	if repository == nil {
-		panic("position keeping service: repository cannot be nil")
+		return nil, ErrRepositoryNil
 	}
 	if eventPublisher == nil {
-		panic("position keeping service: event publisher cannot be nil")
+		return nil, ErrEventPublisherNil
 	}
 	if idempotencySvc == nil {
-		panic("position keeping service: idempotency service cannot be nil")
+		return nil, ErrIdempotencyServiceNil
 	}
 
 	return &PositionKeepingService{
 		repository:     repository,
 		eventPublisher: eventPublisher,
 		idempotency:    idempotencySvc,
-	}
+	}, nil
 }
 
 // RetrieveFinancialPositionLog retrieves a financial position log by ID.

--- a/services/position-keeping/service/service_test.go
+++ b/services/position-keeping/service/service_test.go
@@ -17,8 +17,10 @@ func TestNewPositionKeepingService(t *testing.T) {
 		publisher := domain.NewInMemoryEventPublisher()
 		idempotencySvc := new(MockIdempotencyService)
 
-		svc := service.NewPositionKeepingService(repo, publisher, idempotencySvc)
-
+		svc, err := service.NewPositionKeepingService(repo, publisher, idempotencySvc)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
 		if svc == nil {
 			t.Fatal("Expected non-nil service")
 		}
@@ -34,7 +36,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 		repository     domain.FinancialPositionLogRepository
 		eventPub       domain.EventPublisher
 		idempotencySvc idempotency.Service
-		shouldPanic    bool
+		wantErr        bool
 		rationale      string
 	}{
 		{
@@ -42,7 +44,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			repository:     new(MockRepository),
 			eventPub:       domain.NewInMemoryEventPublisher(),
 			idempotencySvc: new(MockIdempotencyService),
-			shouldPanic:    false,
+			wantErr:        false,
 			rationale:      "Standard valid initialization with all dependencies",
 		},
 		{
@@ -50,7 +52,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			repository:     nil,
 			eventPub:       domain.NewInMemoryEventPublisher(),
 			idempotencySvc: new(MockIdempotencyService),
-			shouldPanic:    true,
+			wantErr:        true,
 			rationale:      "Repository is essential - nil would cause panic on first use",
 		},
 		{
@@ -58,7 +60,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			repository:     new(MockRepository),
 			eventPub:       nil,
 			idempotencySvc: new(MockIdempotencyService),
-			shouldPanic:    true,
+			wantErr:        true,
 			rationale:      "Event publisher is essential - nil would cause panic when publishing events",
 		},
 		{
@@ -66,7 +68,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			repository:     new(MockRepository),
 			eventPub:       domain.NewInMemoryEventPublisher(),
 			idempotencySvc: nil,
-			shouldPanic:    true,
+			wantErr:        true,
 			rationale:      "Idempotency service is essential - nil would cause panic on idempotent operations",
 		},
 		{
@@ -74,34 +76,35 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			repository:     nil,
 			eventPub:       nil,
 			idempotencySvc: nil,
-			shouldPanic:    true,
-			rationale:      "Should panic on first nil check (repository)",
+			wantErr:        true,
+			rationale:      "Should error on first nil check (repository)",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.shouldPanic {
-				assert.Panics(t, func() {
-					service.NewPositionKeepingService(tt.repository, tt.eventPub, tt.idempotencySvc)
-				}, tt.rationale)
+			svc, err := service.NewPositionKeepingService(tt.repository, tt.eventPub, tt.idempotencySvc)
+			if tt.wantErr {
+				assert.Error(t, err, tt.rationale)
+				assert.Nil(t, svc, "Service should be nil when error occurs")
 			} else {
-				assert.NotPanics(t, func() {
-					svc := service.NewPositionKeepingService(tt.repository, tt.eventPub, tt.idempotencySvc)
-					assert.NotNil(t, svc, tt.rationale)
-				}, tt.rationale)
+				assert.NoError(t, err, tt.rationale)
+				assert.NotNil(t, svc, tt.rationale)
 			}
 		})
 	}
 }
 
 func TestServiceImplementsGRPCInterface(t *testing.T) {
-	t.Run("service implements PositionKeepingServiceServer", func(_ *testing.T) {
+	t.Run("service implements PositionKeepingServiceServer", func(t *testing.T) {
 		repo := new(MockRepository)
 		publisher := domain.NewInMemoryEventPublisher()
 		idempotencySvc := new(MockIdempotencyService)
 
-		svc := service.NewPositionKeepingService(repo, publisher, idempotencySvc)
+		svc, err := service.NewPositionKeepingService(repo, publisher, idempotencySvc)
+		if err != nil {
+			t.Fatalf("unexpected error creating service: %v", err)
+		}
 
 		// This will fail to compile if service doesn't implement the interface
 		var _ positionkeepingv1.PositionKeepingServiceServer = svc

--- a/services/position-keeping/service/service_test.go
+++ b/services/position-keeping/service/service_test.go
@@ -37,6 +37,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 		eventPub       domain.EventPublisher
 		idempotencySvc idempotency.Service
 		wantErr        bool
+		wantSentinel   error // Expected sentinel error for errors.Is() verification
 		rationale      string
 	}{
 		{
@@ -45,6 +46,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			eventPub:       domain.NewInMemoryEventPublisher(),
 			idempotencySvc: new(MockIdempotencyService),
 			wantErr:        false,
+			wantSentinel:   nil,
 			rationale:      "Standard valid initialization with all dependencies",
 		},
 		{
@@ -53,6 +55,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			eventPub:       domain.NewInMemoryEventPublisher(),
 			idempotencySvc: new(MockIdempotencyService),
 			wantErr:        true,
+			wantSentinel:   service.ErrRepositoryNil,
 			rationale:      "Repository is essential - nil would cause panic on first use",
 		},
 		{
@@ -61,6 +64,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			eventPub:       nil,
 			idempotencySvc: new(MockIdempotencyService),
 			wantErr:        true,
+			wantSentinel:   service.ErrEventPublisherNil,
 			rationale:      "Event publisher is essential - nil would cause panic when publishing events",
 		},
 		{
@@ -69,6 +73,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			eventPub:       domain.NewInMemoryEventPublisher(),
 			idempotencySvc: nil,
 			wantErr:        true,
+			wantSentinel:   service.ErrIdempotencyServiceNil,
 			rationale:      "Idempotency service is essential - nil would cause panic on idempotent operations",
 		},
 		{
@@ -77,6 +82,7 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			eventPub:       nil,
 			idempotencySvc: nil,
 			wantErr:        true,
+			wantSentinel:   service.ErrRepositoryNil,
 			rationale:      "Should error on first nil check (repository)",
 		},
 	}
@@ -87,6 +93,8 @@ func TestNewPositionKeepingService_DefensiveTests(t *testing.T) {
 			if tt.wantErr {
 				assert.Error(t, err, tt.rationale)
 				assert.Nil(t, svc, "Service should be nil when error occurs")
+				// Verify the specific sentinel error using errors.Is()
+				assert.ErrorIs(t, err, tt.wantSentinel, "Should return the expected sentinel error")
 			} else {
 				assert.NoError(t, err, tt.rationale)
 				assert.NotNil(t, svc, tt.rationale)

--- a/services/position-keeping/service/update_test.go
+++ b/services/position-keeping/service/update_test.go
@@ -31,7 +31,7 @@ func TestUpdateFinancialPositionLog_AddNewEntry(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	logID := uuid.New()
 	accountID := testAccountID
@@ -120,7 +120,7 @@ func TestUpdateFinancialPositionLog_UpdateStatus(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	logID := uuid.New()
 	accountID := testAccountID
@@ -179,7 +179,7 @@ func TestUpdateFinancialPositionLog_VersionConflict(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	logID := uuid.New()
 	accountID := testAccountID
@@ -231,7 +231,7 @@ func TestUpdateFinancialPositionLog_LogNotFound(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	logID := uuid.New()
 
@@ -270,7 +270,7 @@ func TestUpdateFinancialPositionLog_InvalidLogID(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	req := &positionkeepingv1.UpdateFinancialPositionLogRequest{
 		LogId: "invalid-uuid",
@@ -301,7 +301,7 @@ func TestUpdateFinancialPositionLog_MissingAuditEntry(t *testing.T) {
 	mockEventPublisher := domain.NewInMemoryEventPublisher()
 	mockIdempotency := new(MockIdempotencyService)
 
-	svc := service.NewPositionKeepingService(mockRepo, mockEventPublisher, mockIdempotency)
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
 
 	logID := uuid.New()
 	existingLog := &domain.FinancialPositionLog{

--- a/services/position-keeping/service/update_test.go
+++ b/services/position-keeping/service/update_test.go
@@ -16,7 +16,6 @@ import (
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
-	"github.com/meridianhub/meridian/services/position-keeping/service"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 )
 


### PR DESCRIPTION
## Summary
- Replace `panic()` calls with proper error returns in service constructors across financial-accounting, position-keeping, and current-account services
- Update all callers (main entry points and test files) to handle constructor errors appropriately
- Add comprehensive unit tests verifying sentinel errors are returned for nil dependency injection

## Task Master Reference
- **Tag**: tech-debt-cleanup
- **Task ID**: 15

## Changes Made
- `79b5f6f` - Define sentinel errors and update constructor signatures in 6 files
- `420f12b` - Update 3 main.go files and 19 test files to handle error returns
- `631a9dc` - Add nil validation tests using `errors.Is()` for all constructors

## Test Plan
- Unit tests verify each constructor returns correct sentinel error when nil dependencies passed
- All tests pass with `go test ./...`
- Services fail gracefully with clear error messages on misconfiguration (no panic stack traces)