### PR TITLE
feat(tenant): add worker configuration via environment variables

### DIFF
--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -558,6 +558,17 @@ func getEnvInt(key string, defaultValue int) int {
 	return value
 }
 
+// loadWorkerConfig loads worker configuration from environment variables with defaults.
+func loadWorkerConfig() WorkerConfig {
+	return WorkerConfig{
+		PollInterval:   getEnvDuration("PROVISIONING_WORKER_POLL_INTERVAL", 10*time.Second),
+		MaxRetries:     getEnvInt("PROVISIONING_MAX_RETRIES", 5),
+		RetryBaseDelay: getEnvDuration("PROVISIONING_RETRY_BASE_DELAY", 2*time.Second),
+		RetryMaxDelay:  getEnvDuration("PROVISIONING_RETRY_MAX_DELAY", 30*time.Second),
+		MaxConcurrent:  getEnvInt("PROVISIONING_MAX_CONCURRENT", 5),
+	}
+}
+
 // createRedisClient creates and initializes a Redis client from environment configuration.
 func createRedisClient(logger *slog.Logger) (*redis.Client, error) {
 	redisURL := getEnvOrDefault("REDIS_URL", "redis://localhost:6379")

--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -215,12 +215,18 @@ func run(logger *slog.Logger) error {
 	// Initialize provisioning worker (only if schema provisioning is enabled)
 	var provisioningWorker *worker.ProvisioningWorker
 	if provisioningEnabled == envValueTrue && schemaProvisioner != nil {
-		pollInterval := getEnvAsDuration("PROVISIONING_POLL_INTERVAL", 30*time.Second)
+		config := loadWorkerConfig()
 		var err error
 		provisioningWorker, err = worker.NewProvisioningWorker(
 			repo,
 			schemaProvisioner,
-			pollInterval,
+			worker.Config{
+				PollInterval:   config.PollInterval,
+				MaxRetries:     config.MaxRetries,
+				RetryBaseDelay: config.RetryBaseDelay,
+				RetryMaxDelay:  config.RetryMaxDelay,
+				MaxConcurrent:  config.MaxConcurrent,
+			},
 			logger,
 		)
 		if err != nil {
@@ -231,7 +237,11 @@ func run(logger *slog.Logger) error {
 		go provisioningWorker.Start(ctx)
 
 		logger.Info("provisioning worker started",
-			"poll_interval", pollInterval)
+			"poll_interval", config.PollInterval,
+			"max_retries", config.MaxRetries,
+			"retry_base_delay", config.RetryBaseDelay,
+			"retry_max_delay", config.RetryMaxDelay,
+			"max_concurrent", config.MaxConcurrent)
 	} else {
 		logger.Info("provisioning worker disabled",
 			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable background provisioning")

--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -42,8 +42,16 @@ var (
 // envValueTrue is the string value for enabled environment variables.
 const envValueTrue = "true"
 
-// ErrJWKSURLRequired is returned when AUTH_ENABLED is true but AUTH_JWKS_URL is not set.
-var ErrJWKSURLRequired = errors.New("AUTH_JWKS_URL is required when AUTH_ENABLED=true")
+// Errors returned during configuration and startup.
+var (
+	ErrJWKSURLRequired        = errors.New("AUTH_JWKS_URL is required when AUTH_ENABLED=true")
+	ErrInvalidPollInterval    = errors.New("poll interval must be >= 1s")
+	ErrInvalidMaxRetries      = errors.New("max retries must be >= 0 and <= 20")
+	ErrInvalidRetryBaseDelay  = errors.New("retry base delay must be > 0")
+	ErrInvalidRetryMaxDelay   = errors.New("retry max delay must be > 0")
+	ErrInvalidRetryDelayRange = errors.New("retry base delay must be < retry max delay")
+	ErrInvalidMaxConcurrent   = errors.New("max concurrent must be >= 1 and <= 100")
+)
 
 // WorkerConfig holds configuration for the provisioning worker behavior.
 type WorkerConfig struct {
@@ -52,6 +60,30 @@ type WorkerConfig struct {
 	RetryBaseDelay time.Duration
 	RetryMaxDelay  time.Duration
 	MaxConcurrent  int
+}
+
+// Validate checks if the WorkerConfig has valid values.
+// Returns an error if any configuration value is invalid.
+func (c WorkerConfig) Validate() error {
+	if c.PollInterval < 1*time.Second {
+		return fmt.Errorf("%w: got %s", ErrInvalidPollInterval, c.PollInterval)
+	}
+	if c.MaxRetries < 0 || c.MaxRetries > 20 {
+		return fmt.Errorf("%w: got %d", ErrInvalidMaxRetries, c.MaxRetries)
+	}
+	if c.RetryBaseDelay <= 0 {
+		return fmt.Errorf("%w: got %s", ErrInvalidRetryBaseDelay, c.RetryBaseDelay)
+	}
+	if c.RetryMaxDelay <= 0 {
+		return fmt.Errorf("%w: got %s", ErrInvalidRetryMaxDelay, c.RetryMaxDelay)
+	}
+	if c.RetryBaseDelay >= c.RetryMaxDelay {
+		return fmt.Errorf("%w: base=%s, max=%s", ErrInvalidRetryDelayRange, c.RetryBaseDelay, c.RetryMaxDelay)
+	}
+	if c.MaxConcurrent < 1 || c.MaxConcurrent > 100 {
+		return fmt.Errorf("%w: got %d", ErrInvalidMaxConcurrent, c.MaxConcurrent)
+	}
+	return nil
 }
 
 func main() {
@@ -215,8 +247,11 @@ func run(logger *slog.Logger) error {
 	// Initialize provisioning worker (only if schema provisioning is enabled)
 	var provisioningWorker *worker.ProvisioningWorker
 	if provisioningEnabled == envValueTrue && schemaProvisioner != nil {
-		config := loadWorkerConfig()
-		var err error
+		config, err := loadWorkerConfig()
+		if err != nil {
+			return fmt.Errorf("failed to load worker configuration: %w", err)
+		}
+
 		provisioningWorker, err = worker.NewProvisioningWorker(
 			repo,
 			schemaProvisioner,
@@ -236,12 +271,7 @@ func run(logger *slog.Logger) error {
 		// Start worker in background goroutine
 		go provisioningWorker.Start(ctx)
 
-		logger.Info("provisioning worker started",
-			"poll_interval", config.PollInterval,
-			"max_retries", config.MaxRetries,
-			"retry_base_delay", config.RetryBaseDelay,
-			"retry_max_delay", config.RetryMaxDelay,
-			"max_concurrent", config.MaxConcurrent)
+		logger.Info("provisioning worker started")
 	} else {
 		logger.Info("provisioning worker disabled",
 			"hint", "set SCHEMA_PROVISIONING_ENABLED=true to enable background provisioning")
@@ -569,14 +599,43 @@ func getEnvInt(key string, defaultValue int) int {
 }
 
 // loadWorkerConfig loads worker configuration from environment variables with defaults.
-func loadWorkerConfig() WorkerConfig {
-	return WorkerConfig{
+// It validates the configuration and returns an error if any value is invalid.
+func loadWorkerConfig() (WorkerConfig, error) {
+	config := WorkerConfig{
 		PollInterval:   getEnvDuration("PROVISIONING_WORKER_POLL_INTERVAL", 10*time.Second),
 		MaxRetries:     getEnvInt("PROVISIONING_MAX_RETRIES", 5),
 		RetryBaseDelay: getEnvDuration("PROVISIONING_RETRY_BASE_DELAY", 2*time.Second),
 		RetryMaxDelay:  getEnvDuration("PROVISIONING_RETRY_MAX_DELAY", 30*time.Second),
 		MaxConcurrent:  getEnvInt("PROVISIONING_MAX_CONCURRENT", 5),
 	}
+
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return WorkerConfig{}, fmt.Errorf("invalid worker configuration: %w", err)
+	}
+
+	// Log loaded configuration with sources
+	slog.Info("worker configuration loaded",
+		"poll_interval", config.PollInterval,
+		"poll_interval_source", getConfigSource("PROVISIONING_WORKER_POLL_INTERVAL"),
+		"max_retries", config.MaxRetries,
+		"max_retries_source", getConfigSource("PROVISIONING_MAX_RETRIES"),
+		"retry_base_delay", config.RetryBaseDelay,
+		"retry_base_delay_source", getConfigSource("PROVISIONING_RETRY_BASE_DELAY"),
+		"retry_max_delay", config.RetryMaxDelay,
+		"retry_max_delay_source", getConfigSource("PROVISIONING_RETRY_MAX_DELAY"),
+		"max_concurrent", config.MaxConcurrent,
+		"max_concurrent_source", getConfigSource("PROVISIONING_MAX_CONCURRENT"))
+
+	return config, nil
+}
+
+// getConfigSource returns "env" if the environment variable is set, "default" otherwise.
+func getConfigSource(key string) string {
+	if os.Getenv(key) != "" {
+		return "env"
+	}
+	return "default"
 }
 
 // createRedisClient creates and initializes a Redis client from environment configuration.

--- a/services/tenant/cmd/main.go
+++ b/services/tenant/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -43,6 +44,15 @@ const envValueTrue = "true"
 
 // ErrJWKSURLRequired is returned when AUTH_ENABLED is true but AUTH_JWKS_URL is not set.
 var ErrJWKSURLRequired = errors.New("AUTH_JWKS_URL is required when AUTH_ENABLED=true")
+
+// WorkerConfig holds configuration for the provisioning worker behavior.
+type WorkerConfig struct {
+	PollInterval   time.Duration
+	MaxRetries     int
+	RetryBaseDelay time.Duration
+	RetryMaxDelay  time.Duration
+	MaxConcurrent  int
+}
 
 func main() {
 	// Initialize structured logging
@@ -503,6 +513,46 @@ func getEnvAsDuration(key string, defaultValue time.Duration) time.Duration {
 
 	value, err := time.ParseDuration(valueStr)
 	if err != nil {
+		return defaultValue
+	}
+	return value
+}
+
+// getEnvDuration returns the environment variable value as duration or default with logging.
+// Logs a warning via slog.Warn when falling back to default value.
+func getEnvDuration(key string, defaultValue time.Duration) time.Duration {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	value, err := time.ParseDuration(valueStr)
+	if err != nil {
+		slog.Warn("invalid duration environment variable, using default",
+			"key", key,
+			"value", valueStr,
+			"error", err,
+			"default", defaultValue)
+		return defaultValue
+	}
+	return value
+}
+
+// getEnvInt returns the environment variable value as int or default with logging.
+// Logs a warning via slog.Warn when falling back to default value.
+func getEnvInt(key string, defaultValue int) int {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	value, err := strconv.Atoi(valueStr)
+	if err != nil {
+		slog.Warn("invalid int environment variable, using default",
+			"key", key,
+			"value", valueStr,
+			"error", err,
+			"default", defaultValue)
 		return defaultValue
 	}
 	return value

--- a/services/tenant/cmd/main_test.go
+++ b/services/tenant/cmd/main_test.go
@@ -182,6 +182,7 @@ func TestLoadWorkerConfig(t *testing.T) {
 		name    string
 		envVars map[string]string
 		want    WorkerConfig
+		wantErr bool
 	}{
 		{
 			name:    "returns all defaults when no env vars set",
@@ -193,6 +194,7 @@ func TestLoadWorkerConfig(t *testing.T) {
 				RetryMaxDelay:  30 * time.Second,
 				MaxConcurrent:  5,
 			},
+			wantErr: false,
 		},
 		{
 			name: "returns custom values when env vars set",
@@ -210,6 +212,7 @@ func TestLoadWorkerConfig(t *testing.T) {
 				RetryMaxDelay:  60 * time.Second,
 				MaxConcurrent:  20,
 			},
+			wantErr: false,
 		},
 		{
 			name: "returns defaults for invalid values",
@@ -224,6 +227,7 @@ func TestLoadWorkerConfig(t *testing.T) {
 				RetryMaxDelay:  30 * time.Second,
 				MaxConcurrent:  5,
 			},
+			wantErr: false,
 		},
 		{
 			name: "returns partial custom values with defaults",
@@ -238,6 +242,29 @@ func TestLoadWorkerConfig(t *testing.T) {
 				RetryMaxDelay:  30 * time.Second,
 				MaxConcurrent:  5,
 			},
+			wantErr: false,
+		},
+		{
+			name: "returns error for invalid poll interval",
+			envVars: map[string]string{
+				"PROVISIONING_WORKER_POLL_INTERVAL": "500ms",
+			},
+			wantErr: true,
+		},
+		{
+			name: "returns error for invalid max retries",
+			envVars: map[string]string{
+				"PROVISIONING_MAX_RETRIES": "25",
+			},
+			wantErr: true,
+		},
+		{
+			name: "returns error when retry base delay >= retry max delay",
+			envVars: map[string]string{
+				"PROVISIONING_RETRY_BASE_DELAY": "40s",
+				"PROVISIONING_RETRY_MAX_DELAY":  "30s",
+			},
+			wantErr: true,
 		},
 	}
 
@@ -255,7 +282,21 @@ func TestLoadWorkerConfig(t *testing.T) {
 				t.Setenv(key, value)
 			}
 
-			got := loadWorkerConfig()
+			got, err := loadWorkerConfig()
+
+			// Check error expectation
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("loadWorkerConfig() expected error, got nil")
+				}
+				return
+			}
+
+			// No error expected
+			if err != nil {
+				t.Errorf("loadWorkerConfig() unexpected error: %v", err)
+				return
+			}
 
 			// Compare each field
 			if got.PollInterval != tt.want.PollInterval {
@@ -272,6 +313,207 @@ func TestLoadWorkerConfig(t *testing.T) {
 			}
 			if got.MaxConcurrent != tt.want.MaxConcurrent {
 				t.Errorf("loadWorkerConfig().MaxConcurrent = %d, want %d", got.MaxConcurrent, tt.want.MaxConcurrent)
+			}
+		})
+	}
+}
+
+func TestWorkerConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  WorkerConfig
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid configuration",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  10,
+			},
+			wantErr: false,
+		},
+		{
+			name: "poll interval too small",
+			config: WorkerConfig{
+				PollInterval:   500 * time.Millisecond,
+				MaxRetries:     5,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  10,
+			},
+			wantErr: true,
+			errMsg:  "poll interval must be >= 1s",
+		},
+		{
+			name: "poll interval exactly 1s (boundary)",
+			config: WorkerConfig{
+				PollInterval:   1 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  10,
+			},
+			wantErr: false,
+		},
+		{
+			name: "max retries negative",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     -1,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  10,
+			},
+			wantErr: true,
+			errMsg:  "max retries must be >= 0",
+		},
+		{
+			name: "max retries zero (boundary)",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     0,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  10,
+			},
+			wantErr: false,
+		},
+		{
+			name: "max retries too high",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     21,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  10,
+			},
+			wantErr: true,
+			errMsg:  "max retries must be >= 0 and <= 20",
+		},
+		{
+			name: "max retries exactly 20 (boundary)",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     20,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  10,
+			},
+			wantErr: false,
+		},
+		{
+			name: "retry base delay zero",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 0,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  10,
+			},
+			wantErr: true,
+			errMsg:  "retry base delay must be > 0",
+		},
+		{
+			name: "retry max delay zero",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  0,
+				MaxConcurrent:  10,
+			},
+			wantErr: true,
+			errMsg:  "retry max delay must be > 0",
+		},
+		{
+			name: "retry base delay >= retry max delay (equal)",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 30 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  10,
+			},
+			wantErr: true,
+			errMsg:  "retry base delay",
+		},
+		{
+			name: "retry base delay > retry max delay",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 40 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  10,
+			},
+			wantErr: true,
+			errMsg:  "retry base delay",
+		},
+		{
+			name: "max concurrent zero",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  0,
+			},
+			wantErr: true,
+			errMsg:  "max concurrent must be >= 1",
+		},
+		{
+			name: "max concurrent exactly 1 (boundary)",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "max concurrent too high",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  101,
+			},
+			wantErr: true,
+			errMsg:  "max concurrent must be >= 1 and <= 100",
+		},
+		{
+			name: "max concurrent exactly 100 (boundary)",
+			config: WorkerConfig{
+				PollInterval:   5 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  100,
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Validate() expected error, got nil")
+				} else if tt.errMsg != "" && !bytes.Contains([]byte(err.Error()), []byte(tt.errMsg)) {
+					t.Errorf("Validate() error = %v, want substring %q", err, tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
 			}
 		})
 	}

--- a/services/tenant/cmd/main_test.go
+++ b/services/tenant/cmd/main_test.go
@@ -176,3 +176,103 @@ func TestGetEnvInt(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadWorkerConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVars map[string]string
+		want    WorkerConfig
+	}{
+		{
+			name:    "returns all defaults when no env vars set",
+			envVars: nil,
+			want: WorkerConfig{
+				PollInterval:   10 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  5,
+			},
+		},
+		{
+			name: "returns custom values when env vars set",
+			envVars: map[string]string{
+				"PROVISIONING_WORKER_POLL_INTERVAL": "1s",
+				"PROVISIONING_MAX_RETRIES":          "10",
+				"PROVISIONING_RETRY_BASE_DELAY":     "5s",
+				"PROVISIONING_RETRY_MAX_DELAY":      "60s",
+				"PROVISIONING_MAX_CONCURRENT":       "20",
+			},
+			want: WorkerConfig{
+				PollInterval:   1 * time.Second,
+				MaxRetries:     10,
+				RetryBaseDelay: 5 * time.Second,
+				RetryMaxDelay:  60 * time.Second,
+				MaxConcurrent:  20,
+			},
+		},
+		{
+			name: "returns defaults for invalid values",
+			envVars: map[string]string{
+				"PROVISIONING_WORKER_POLL_INTERVAL": "invalid",
+				"PROVISIONING_MAX_RETRIES":          "not-a-number",
+			},
+			want: WorkerConfig{
+				PollInterval:   10 * time.Second,
+				MaxRetries:     5,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  5,
+			},
+		},
+		{
+			name: "returns partial custom values with defaults",
+			envVars: map[string]string{
+				"PROVISIONING_WORKER_POLL_INTERVAL": "15s",
+				"PROVISIONING_MAX_RETRIES":          "7",
+			},
+			want: WorkerConfig{
+				PollInterval:   15 * time.Second,
+				MaxRetries:     7,
+				RetryBaseDelay: 2 * time.Second,
+				RetryMaxDelay:  30 * time.Second,
+				MaxConcurrent:  5,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up logger to avoid noise in test output
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+				Level: slog.LevelWarn,
+			}))
+			slog.SetDefault(logger)
+
+			// Set environment variables
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
+			got := loadWorkerConfig()
+
+			// Compare each field
+			if got.PollInterval != tt.want.PollInterval {
+				t.Errorf("loadWorkerConfig().PollInterval = %v, want %v", got.PollInterval, tt.want.PollInterval)
+			}
+			if got.MaxRetries != tt.want.MaxRetries {
+				t.Errorf("loadWorkerConfig().MaxRetries = %d, want %d", got.MaxRetries, tt.want.MaxRetries)
+			}
+			if got.RetryBaseDelay != tt.want.RetryBaseDelay {
+				t.Errorf("loadWorkerConfig().RetryBaseDelay = %v, want %v", got.RetryBaseDelay, tt.want.RetryBaseDelay)
+			}
+			if got.RetryMaxDelay != tt.want.RetryMaxDelay {
+				t.Errorf("loadWorkerConfig().RetryMaxDelay = %v, want %v", got.RetryMaxDelay, tt.want.RetryMaxDelay)
+			}
+			if got.MaxConcurrent != tt.want.MaxConcurrent {
+				t.Errorf("loadWorkerConfig().MaxConcurrent = %d, want %d", got.MaxConcurrent, tt.want.MaxConcurrent)
+			}
+		})
+	}
+}

--- a/services/tenant/cmd/main_test.go
+++ b/services/tenant/cmd/main_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestGetEnvDuration(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string
+		setEnv       bool
+		defaultValue time.Duration
+		want         time.Duration
+		expectWarn   bool
+	}{
+		{
+			name:         "returns env value when valid duration",
+			envValue:     "10s",
+			setEnv:       true,
+			defaultValue: 5 * time.Second,
+			want:         10 * time.Second,
+			expectWarn:   false,
+		},
+		{
+			name:         "returns default when env empty",
+			envValue:     "",
+			setEnv:       true,
+			defaultValue: 5 * time.Second,
+			want:         5 * time.Second,
+			expectWarn:   false,
+		},
+		{
+			name:         "returns default and warns when env invalid",
+			envValue:     "invalid",
+			setEnv:       true,
+			defaultValue: 5 * time.Second,
+			want:         5 * time.Second,
+			expectWarn:   true,
+		},
+		{
+			name:         "returns default when env not set",
+			envValue:     "",
+			setEnv:       false,
+			defaultValue: 5 * time.Second,
+			want:         5 * time.Second,
+			expectWarn:   false,
+		},
+		{
+			name:         "parses minutes correctly",
+			envValue:     "2m",
+			setEnv:       true,
+			defaultValue: time.Minute,
+			want:         2 * time.Minute,
+			expectWarn:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const testKey = "TEST_DURATION_VAR"
+
+			// Set up logger to capture output
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+				Level: slog.LevelWarn,
+			}))
+			slog.SetDefault(logger)
+
+			if tt.setEnv {
+				t.Setenv(testKey, tt.envValue)
+			}
+
+			got := getEnvDuration(testKey, tt.defaultValue)
+			if got != tt.want {
+				t.Errorf("getEnvDuration(%q, %v) = %v, want %v", testKey, tt.defaultValue, got, tt.want)
+			}
+
+			// Check if warning was logged
+			logOutput := buf.String()
+			hasWarn := len(logOutput) > 0
+			if hasWarn != tt.expectWarn {
+				t.Errorf("getEnvDuration(%q, %v) warning logged = %v, want %v", testKey, tt.defaultValue, hasWarn, tt.expectWarn)
+			}
+		})
+	}
+}
+
+func TestGetEnvInt(t *testing.T) {
+	tests := []struct {
+		name         string
+		envValue     string
+		setEnv       bool
+		defaultValue int
+		want         int
+		expectWarn   bool
+	}{
+		{
+			name:         "returns env value when valid int",
+			envValue:     "5",
+			setEnv:       true,
+			defaultValue: 10,
+			want:         5,
+			expectWarn:   false,
+		},
+		{
+			name:         "returns default when env empty",
+			envValue:     "",
+			setEnv:       true,
+			defaultValue: 10,
+			want:         10,
+			expectWarn:   false,
+		},
+		{
+			name:         "returns default and warns when env invalid",
+			envValue:     "abc",
+			setEnv:       true,
+			defaultValue: 10,
+			want:         10,
+			expectWarn:   true,
+		},
+		{
+			name:         "returns default when env not set",
+			envValue:     "",
+			setEnv:       false,
+			defaultValue: 10,
+			want:         10,
+			expectWarn:   false,
+		},
+		{
+			name:         "parses zero correctly",
+			envValue:     "0",
+			setEnv:       true,
+			defaultValue: 10,
+			want:         0,
+			expectWarn:   false,
+		},
+		{
+			name:         "parses negative int correctly",
+			envValue:     "-5",
+			setEnv:       true,
+			defaultValue: 10,
+			want:         -5,
+			expectWarn:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const testKey = "TEST_INT_VAR"
+
+			// Set up logger to capture output
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+				Level: slog.LevelWarn,
+			}))
+			slog.SetDefault(logger)
+
+			if tt.setEnv {
+				t.Setenv(testKey, tt.envValue)
+			}
+
+			got := getEnvInt(testKey, tt.defaultValue)
+			if got != tt.want {
+				t.Errorf("getEnvInt(%q, %d) = %d, want %d", testKey, tt.defaultValue, got, tt.want)
+			}
+
+			// Check if warning was logged
+			logOutput := buf.String()
+			hasWarn := len(logOutput) > 0
+			if hasWarn != tt.expectWarn {
+				t.Errorf("getEnvInt(%q, %d) warning logged = %v, want %v", testKey, tt.defaultValue, hasWarn, tt.expectWarn)
+			}
+		})
+	}
+}

--- a/services/tenant/k8s/deployment.yaml
+++ b/services/tenant/k8s/deployment.yaml
@@ -63,6 +63,24 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # Worker configuration for tenant provisioning
+        # Duration format: Valid Go duration strings (e.g., "10s", "1m", "500ms")
+        - name: PROVISIONING_WORKER_POLL_INTERVAL
+          value: "10s"
+        # Maximum number of retry attempts for failed provisioning operations
+        - name: PROVISIONING_MAX_RETRIES
+          value: "5"
+        # Initial delay before first retry (exponential backoff base)
+        # Duration format: Valid Go duration strings (e.g., "2s", "500ms")
+        - name: PROVISIONING_RETRY_BASE_DELAY
+          value: "2s"
+        # Maximum delay between retry attempts (exponential backoff cap)
+        # Duration format: Valid Go duration strings (e.g., "30s", "1m")
+        - name: PROVISIONING_RETRY_MAX_DELAY
+          value: "30s"
+        # Maximum number of concurrent tenant provisioning operations
+        - name: PROVISIONING_MAX_CONCURRENT
+          value: "5"
         resources:
           requests:
             cpu: 50m

--- a/services/tenant/worker/provisioning_worker.go
+++ b/services/tenant/worker/provisioning_worker.go
@@ -21,12 +21,16 @@ import (
 // ProvisioningWorker polls for tenants in PROVISIONING_PENDING status
 // and triggers schema provisioning for them.
 type ProvisioningWorker struct {
-	repo         *persistence.Repository
-	provisioner  provisioner.SchemaProvisioner
-	pollInterval time.Duration
-	logger       *slog.Logger
-	done         chan struct{}
-	wg           sync.WaitGroup // Tracks in-flight provisioning goroutines
+	repo           *persistence.Repository
+	provisioner    provisioner.SchemaProvisioner
+	pollInterval   time.Duration
+	maxRetries     int
+	retryBaseDelay time.Duration
+	retryMaxDelay  time.Duration
+	maxConcurrent  int
+	logger         *slog.Logger
+	done           chan struct{}
+	wg             sync.WaitGroup // Tracks in-flight provisioning goroutines
 }
 
 // Errors returned by NewProvisioningWorker and provisioning operations.
@@ -38,13 +42,22 @@ var (
 	ErrPanicDuringProvision = errors.New("panic during provisioning")
 )
 
+// Config holds configuration for worker behavior.
+type Config struct {
+	PollInterval   time.Duration
+	MaxRetries     int
+	RetryBaseDelay time.Duration
+	RetryMaxDelay  time.Duration
+	MaxConcurrent  int
+}
+
 // NewProvisioningWorker creates a new ProvisioningWorker.
 // All dependencies (repo, provisioner, logger) must be non-nil.
-// pollInterval must be greater than zero.
+// config.PollInterval must be greater than zero.
 func NewProvisioningWorker(
 	repo *persistence.Repository,
 	provisioner provisioner.SchemaProvisioner,
-	pollInterval time.Duration,
+	config Config,
 	logger *slog.Logger,
 ) (*ProvisioningWorker, error) {
 	if repo == nil {
@@ -56,16 +69,20 @@ func NewProvisioningWorker(
 	if logger == nil {
 		return nil, ErrNilLogger
 	}
-	if pollInterval <= 0 {
+	if config.PollInterval <= 0 {
 		return nil, ErrInvalidPollInterval
 	}
 
 	return &ProvisioningWorker{
-		repo:         repo,
-		provisioner:  provisioner,
-		pollInterval: pollInterval,
-		logger:       logger,
-		done:         make(chan struct{}),
+		repo:           repo,
+		provisioner:    provisioner,
+		pollInterval:   config.PollInterval,
+		maxRetries:     config.MaxRetries,
+		retryBaseDelay: config.RetryBaseDelay,
+		retryMaxDelay:  config.RetryMaxDelay,
+		maxConcurrent:  config.MaxConcurrent,
+		logger:         logger,
+		done:           make(chan struct{}),
 	}, nil
 }
 
@@ -114,8 +131,8 @@ func (w *ProvisioningWorker) Stop() {
 func (w *ProvisioningWorker) processPendingTenants(ctx context.Context) {
 	w.logger.Debug("checking for pending tenants to provision")
 
-	// Fetch up to 10 pending tenants
-	tenants, err := w.repo.ListByStatus(ctx, domain.StatusProvisioningPending, 10)
+	// Fetch up to maxConcurrent pending tenants
+	tenants, err := w.repo.ListByStatus(ctx, domain.StatusProvisioningPending, w.maxConcurrent)
 	if err != nil {
 		w.logger.Error("failed to list pending tenants", "error", err)
 		return
@@ -156,6 +173,8 @@ func (w *ProvisioningWorker) processPendingTenants(ctx context.Context) {
 }
 
 // Retry configuration constants for provisioning with exponential backoff.
+// These constants are deprecated in favor of WorkerConfig fields.
+// They remain for backwards compatibility with existing tests.
 const (
 	maxRetries = 5
 	baseDelay  = 2 * time.Second
@@ -199,7 +218,7 @@ func (w *ProvisioningWorker) executeProvisioningWithRetry(ctx context.Context, t
 	var lastErr error
 	var attempts int
 
-	for attempt := 0; attempt < maxRetries; attempt++ {
+	for attempt := 0; attempt < w.maxRetries; attempt++ {
 		attempts = attempt + 1
 		if cancelled := w.checkContextCancellation(ctx, tenantID, attempts); cancelled {
 			return 0, nil // Context cancelled, don't mark as failed
@@ -293,7 +312,7 @@ func (w *ProvisioningWorker) markTenantAsFailed(ctx context.Context, tenantID te
 // waitWithBackoff waits for the calculated backoff duration with context cancellation support.
 // Returns true if cancelled, false otherwise.
 func (w *ProvisioningWorker) waitWithBackoff(ctx context.Context, tenantID tenant.TenantID, attempt int, err error) bool {
-	delay := calculateBackoffDelay(attempt)
+	delay := w.calculateBackoffDelay(attempt)
 
 	w.logger.Warn("provisioning failed, retrying",
 		"tenant_id", tenantID,
@@ -314,13 +333,13 @@ func (w *ProvisioningWorker) waitWithBackoff(ctx context.Context, tenantID tenan
 }
 
 // calculateBackoffDelay calculates exponential backoff delay with jitter.
-// The delay is capped at maxDelay (including jitter) to ensure predictable maximum wait times.
-func calculateBackoffDelay(attempt int) time.Duration {
-	delay := time.Duration(float64(baseDelay) * math.Pow(2, float64(attempt)))
+// The delay is capped at w.retryMaxDelay (including jitter) to ensure predictable maximum wait times.
+func (w *ProvisioningWorker) calculateBackoffDelay(attempt int) time.Duration {
+	delay := time.Duration(float64(w.retryBaseDelay) * math.Pow(2, float64(attempt)))
 	jitter := time.Duration(rand.Int63n(int64(delay / 4))) // Add jitter (up to 25% of delay)
 	delay = delay + jitter
-	if delay > maxDelay {
-		delay = maxDelay
+	if delay > w.retryMaxDelay {
+		delay = w.retryMaxDelay
 	}
 	return delay
 }

--- a/services/tenant/worker/provisioning_worker_test.go
+++ b/services/tenant/worker/provisioning_worker_test.go
@@ -26,6 +26,17 @@ func testErr(msg string) error {
 	return fmt.Errorf("%s", msg) //nolint:err113 // test helper for dynamic error messages
 }
 
+// testWorkerConfig creates a default Config for tests.
+func testWorkerConfig(pollInterval time.Duration) Config {
+	return Config{
+		PollInterval:   pollInterval,
+		MaxRetries:     maxRetries,
+		RetryBaseDelay: baseDelay,
+		RetryMaxDelay:  maxDelay,
+		MaxConcurrent:  10,
+	}
+}
+
 // setupTestDB creates an in-memory database with the tenant table schema.
 func setupTestDB(t *testing.T) (*gorm.DB, *persistence.Repository) {
 	// Use a unique database name per test to ensure isolation, with cache=shared so
@@ -93,9 +104,10 @@ func TestNewProvisioningWorker_Success(t *testing.T) {
 	prov := &provisioner.MockProvisioner{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	pollInterval := 5 * time.Second
+	config := testWorkerConfig(pollInterval)
 
 	// Create worker
-	worker, err := NewProvisioningWorker(repo, prov, pollInterval, logger)
+	worker, err := NewProvisioningWorker(repo, prov, config, logger)
 
 	// Verify
 	require.NoError(t, err)
@@ -110,9 +122,9 @@ func TestNewProvisioningWorker_Success(t *testing.T) {
 func TestNewProvisioningWorker_NilRepository(t *testing.T) {
 	prov := &provisioner.MockProvisioner{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	pollInterval := 5 * time.Second
+	config := testWorkerConfig(5 * time.Second)
 
-	worker, err := NewProvisioningWorker(nil, prov, pollInterval, logger)
+	worker, err := NewProvisioningWorker(nil, prov, config, logger)
 
 	assert.ErrorIs(t, err, ErrNilRepository)
 	assert.Nil(t, worker)
@@ -124,9 +136,9 @@ func TestNewProvisioningWorker_NilProvisioner(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	pollInterval := 5 * time.Second
+	config := testWorkerConfig(5 * time.Second)
 
-	worker, err := NewProvisioningWorker(repo, nil, pollInterval, logger)
+	worker, err := NewProvisioningWorker(repo, nil, config, logger)
 
 	assert.ErrorIs(t, err, ErrNilProvisioner)
 	assert.Nil(t, worker)
@@ -138,9 +150,9 @@ func TestNewProvisioningWorker_NilLogger(t *testing.T) {
 
 	repo := persistence.NewRepository(db)
 	prov := &provisioner.MockProvisioner{}
-	pollInterval := 5 * time.Second
+	config := testWorkerConfig(5 * time.Second)
 
-	worker, err := NewProvisioningWorker(repo, prov, pollInterval, nil)
+	worker, err := NewProvisioningWorker(repo, prov, config, nil)
 
 	assert.ErrorIs(t, err, ErrNilLogger)
 	assert.Nil(t, worker)
@@ -153,8 +165,9 @@ func TestNewProvisioningWorker_ZeroPollInterval(t *testing.T) {
 	repo := persistence.NewRepository(db)
 	prov := &provisioner.MockProvisioner{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	config := testWorkerConfig(0)
 
-	worker, err := NewProvisioningWorker(repo, prov, 0, logger)
+	worker, err := NewProvisioningWorker(repo, prov, config, logger)
 
 	assert.ErrorIs(t, err, ErrInvalidPollInterval)
 	assert.Nil(t, worker)
@@ -167,8 +180,9 @@ func TestNewProvisioningWorker_NegativePollInterval(t *testing.T) {
 	repo := persistence.NewRepository(db)
 	prov := &provisioner.MockProvisioner{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	config := testWorkerConfig(-5 * time.Second)
 
-	worker, err := NewProvisioningWorker(repo, prov, -5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, prov, config, logger)
 
 	assert.ErrorIs(t, err, ErrInvalidPollInterval)
 	assert.Nil(t, worker)
@@ -184,7 +198,7 @@ func TestProvisioningWorker_Start_ContextCancellation(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	pollInterval := 50 * time.Millisecond
 
-	worker, err := NewProvisioningWorker(repo, prov, pollInterval, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(pollInterval), logger)
 	require.NoError(t, err)
 
 	// Start worker with cancellable context
@@ -221,7 +235,7 @@ func TestProvisioningWorker_Start_ExplicitStop(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	pollInterval := 50 * time.Millisecond
 
-	worker, err := NewProvisioningWorker(repo, prov, pollInterval, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(pollInterval), logger)
 	require.NoError(t, err)
 
 	// Start worker
@@ -258,7 +272,7 @@ func TestProvisioningWorker_Stop_MultipleCalls(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	pollInterval := 50 * time.Millisecond
 
-	worker, err := NewProvisioningWorker(repo, prov, pollInterval, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(pollInterval), logger)
 	require.NoError(t, err)
 
 	// Call Stop() multiple times - should not panic
@@ -279,7 +293,7 @@ func TestProvisioningWorker_Start_TickerInterval(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	pollInterval := 50 * time.Millisecond
 
-	worker, err := NewProvisioningWorker(repo, prov, pollInterval, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(pollInterval), logger)
 	require.NoError(t, err)
 
 	// Start worker with short timeout to observe multiple ticks
@@ -344,7 +358,7 @@ func TestProcessPendingTenants_Success(t *testing.T) {
 		failureSequence: []error{nil, nil, nil}, // Success for all 3 tenants
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, prov, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Execute
@@ -413,7 +427,7 @@ func TestProcessPendingTenants_VersionConflict(t *testing.T) {
 		failureSequence: []error{nil, nil}, // Success for tenant1 and tenant3
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, prov, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Execute - should skip tenant2 (already claimed) and process tenant1 and tenant3
@@ -449,7 +463,7 @@ func TestProcessPendingTenants_ListByStatusError(t *testing.T) {
 	repo := persistence.NewRepository(db)
 	prov := &provisioner.MockProvisioner{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, prov, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Execute - should not crash
@@ -465,7 +479,7 @@ func TestProcessPendingTenants_NoTenantsFound(t *testing.T) {
 	// No tenants created - empty database
 	prov := &provisioner.MockProvisioner{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, prov, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Execute
@@ -505,7 +519,7 @@ func TestProcessPendingTenants_GoroutinesSpawned(t *testing.T) {
 		failureSequence: []error{nil, nil}, // Success for both tenants
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, prov, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Execute
@@ -536,7 +550,7 @@ func TestProvisionTenantWithRetry_NoPanic(t *testing.T) {
 	repo := persistence.NewRepository(db)
 	prov := &provisioner.MockProvisioner{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, prov, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Execute - should not panic
@@ -557,7 +571,7 @@ func TestProvisionTenantWithRetry_PanicRecovery(t *testing.T) {
 	repo := persistence.NewRepository(db)
 	prov := &provisioner.MockProvisioner{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, prov, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Override provisionTenantWithRetry to force a panic
@@ -606,7 +620,7 @@ func TestProvisioningWorker_GracefulShutdown(t *testing.T) {
 	// Create worker
 	prov := &provisioner.MockProvisioner{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, prov, 50*time.Millisecond, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(50*time.Millisecond), logger)
 	require.NoError(t, err)
 
 	// Start worker
@@ -653,7 +667,7 @@ func TestProvisioningWorker_NoGoroutineLeaks(t *testing.T) {
 	// Create worker
 	prov := &provisioner.MockProvisioner{}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, prov, 50*time.Millisecond, logger)
+	worker, err := NewProvisioningWorker(repo, prov, testWorkerConfig(50*time.Millisecond), logger)
 	require.NoError(t, err)
 
 	// Start worker
@@ -776,7 +790,7 @@ func TestProvisionTenantWithRetry_SuccessOnFirstAttempt(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, mockProv, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, mockProv, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Execute
@@ -813,7 +827,7 @@ func TestProvisionTenantWithRetry_SuccessAfterRetries(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, mockProv, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, mockProv, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Execute (this will take time due to exponential backoff, but tests use actual delays)
@@ -862,7 +876,7 @@ func TestProvisionTenantWithRetry_MaxRetriesExhausted(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, mockProv, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, mockProv, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Execute
@@ -902,7 +916,7 @@ func TestProvisionTenantWithRetry_ContextCancellation(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, mockProv, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, mockProv, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Create cancellable context
@@ -961,7 +975,7 @@ func TestProvisionTenantWithRetry_ExponentialBackoffTiming(t *testing.T) {
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	worker, err := NewProvisioningWorker(repo, mockProv, 5*time.Second, logger)
+	worker, err := NewProvisioningWorker(repo, mockProv, testWorkerConfig(5*time.Second), logger)
 	require.NoError(t, err)
 
 	// Execute and measure time


### PR DESCRIPTION
## Summary
- Add configurable worker parameters (poll interval, retry settings, concurrency) via environment variables
- Implement validation to catch invalid configuration at startup
- Document all configuration options in Kubernetes deployment

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 79

## Changes Made
- WorkerConfig struct with PollInterval, MaxRetries, RetryBaseDelay, RetryMaxDelay, MaxConcurrent
- Helper functions getEnvDuration and getEnvInt with structured logging on fallback
- loadWorkerConfig function reading from PROVISIONING_* environment variables
- Configuration validation with clear error messages
- Startup logging showing all config values and sources
- Updated ProvisioningWorker to accept and use configuration
- Kubernetes deployment updated with documented environment variables
- All existing worker tests (30+ test cases) updated to use WorkerConfig

## Test Plan
- Unit tests for getEnvDuration/getEnvInt helpers
- Unit tests for loadWorkerConfig with default and custom values
- Unit tests for WorkerConfig.Validate with boundary conditions
- All existing worker tests updated and passing