### PR TITLE
feat: Add BIAN Control operations for Position Keeping and Financial Accounting

### DIFF
--- a/api/proto/meridian/common/v1/error.proto
+++ b/api/proto/meridian/common/v1/error.proto
@@ -69,6 +69,12 @@ enum ErrorCode {
   ERROR_CODE_BEHAVIOR_QUALIFIER_INVALID = 3001;
   // ERROR_CODE_SERVICE_DOMAIN_UNAVAILABLE means the BIAN service domain is unavailable.
   ERROR_CODE_SERVICE_DOMAIN_UNAVAILABLE = 3002;
+
+  // Control operation errors (4000-4999)
+  // ERROR_CODE_RESOURCE_SUSPENDED means the resource (log, account) is temporarily suspended.
+  ERROR_CODE_RESOURCE_SUSPENDED = 4000;
+  // ERROR_CODE_RESOURCE_TERMINATED means the resource has been permanently terminated.
+  ERROR_CODE_RESOURCE_TERMINATED = 4001;
 }
 
 // Error represents a structured error response.

--- a/api/proto/meridian/events/v1/financial_accounting_events.proto
+++ b/api/proto/meridian/events/v1/financial_accounting_events.proto
@@ -527,6 +527,13 @@ message BookingLogStatusChangedEvent {
     max_len: 255
   }];
 
+  // business_unit_reference identifies the business unit responsible for this booking log.
+  // Provides context for downstream consumers similar to account_id in PositionLogStatusChangedEvent.
+  string business_unit_reference = 11 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
   // previous_status is the status before the change
   string previous_status = 2 [(buf.validate.field).string = {
     in: [

--- a/api/proto/meridian/events/v1/financial_accounting_events.proto
+++ b/api/proto/meridian/events/v1/financial_accounting_events.proto
@@ -517,3 +517,81 @@ message BalanceValidationFailedEvent {
   // version is the aggregate version for optimistic locking
   int64 version = 9 [(buf.validate.field).int64 = {gte: 1}];
 }
+
+// BookingLogStatusChangedEvent represents a status change in a financial booking log.
+// Published when control actions (SUSPEND, RESUME, TERMINATE) are applied.
+message BookingLogStatusChangedEvent {
+  // booking_log_id uniquely identifies the financial booking log
+  string booking_log_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // previous_status is the status before the change
+  string previous_status = 2 [(buf.validate.field).string = {
+    in: [
+      "PENDING",
+      "RECONCILED",
+      "POSTED",
+      "FAILED",
+      "REJECTED",
+      "AMENDED",
+      "CANCELLED",
+      "REVERSED",
+      "SUSPENDED",
+      "TERMINATED"
+    ]
+  }];
+
+  // new_status is the status after the change
+  string new_status = 3 [(buf.validate.field).string = {
+    in: [
+      "PENDING",
+      "RECONCILED",
+      "POSTED",
+      "FAILED",
+      "REJECTED",
+      "AMENDED",
+      "CANCELLED",
+      "REVERSED",
+      "SUSPENDED",
+      "TERMINATED"
+    ]
+  }];
+
+  // control_action is the action that triggered the change
+  string control_action = 4 [(buf.validate.field).string = {
+    in: [
+      "SUSPEND",
+      "RESUME",
+      "TERMINATE"
+    ]
+  }];
+
+  // reason provides context for the status change
+  string reason = 5 [(buf.validate.field).string = {max_len: 500}];
+
+  // operator_id identifies who performed the action
+  string operator_id = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+  }];
+
+  // correlation_id links related events across services
+  string correlation_id = 7 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // causation_id identifies the event or command that caused this event
+  string causation_id = 8 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // timestamp when the event was created
+  google.protobuf.Timestamp timestamp = 9 [(buf.validate.field).required = true];
+
+  // version is the aggregate version for optimistic locking
+  int64 version = 10 [(buf.validate.field).int64 = {gte: 1}];
+}

--- a/api/proto/meridian/events/v1/position_keeping_events.proto
+++ b/api/proto/meridian/events/v1/position_keeping_events.proto
@@ -349,3 +349,78 @@ message BulkTransactionCapturedEvent {
   // version supports optimistic concurrency control
   int64 version = 7 [(buf.validate.field).int64 = {gte: 1}];
 }
+
+// PositionLogStatusChangedEvent represents a status change in a financial position log.
+// Published when control actions (SUSPEND, RESUME, TERMINATE) are applied.
+message PositionLogStatusChangedEvent {
+  // log_id uniquely identifies the financial position log
+  string log_id = 1 [(buf.validate.field).string = {uuid: true}];
+
+  // account_id identifies the account this log affects
+  string account_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+  }];
+
+  // previous_status is the status before the change
+  string previous_status = 3 [(buf.validate.field).string = {
+    in: [
+      "PENDING",
+      "RECONCILED",
+      "POSTED",
+      "FAILED",
+      "REJECTED",
+      "AMENDED",
+      "CANCELLED",
+      "REVERSED",
+      "SUSPENDED",
+      "TERMINATED"
+    ]
+  }];
+
+  // new_status is the status after the change
+  string new_status = 4 [(buf.validate.field).string = {
+    in: [
+      "PENDING",
+      "RECONCILED",
+      "POSTED",
+      "FAILED",
+      "REJECTED",
+      "AMENDED",
+      "CANCELLED",
+      "REVERSED",
+      "SUSPENDED",
+      "TERMINATED"
+    ]
+  }];
+
+  // control_action is the action that triggered the change
+  string control_action = 5 [(buf.validate.field).string = {
+    in: [
+      "SUSPEND",
+      "RESUME",
+      "TERMINATE"
+    ]
+  }];
+
+  // reason provides context for the status change
+  string reason = 6 [(buf.validate.field).string = {max_len: 500}];
+
+  // operator_id identifies who performed the action
+  string operator_id = 7 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+  }];
+
+  // correlation_id links related events across services
+  string correlation_id = 8 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // timestamp when the event was created
+  google.protobuf.Timestamp timestamp = 9 [(buf.validate.field).required = true];
+
+  // version is the aggregate version for optimistic locking
+  int64 version = 10 [(buf.validate.field).int64 = {gte: 1}];
+}

--- a/api/proto/meridian/financial_accounting/v1/financial_accounting.proto
+++ b/api/proto/meridian/financial_accounting/v1/financial_accounting.proto
@@ -11,6 +11,30 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1;financialaccountingv1";
 
+// BookingLogStatus defines the lifecycle state of a financial booking log.
+enum BookingLogStatus {
+  // BOOKING_LOG_STATUS_UNSPECIFIED means the status is unknown.
+  BOOKING_LOG_STATUS_UNSPECIFIED = 0;
+  // BOOKING_LOG_STATUS_ACTIVE means the log is active and processing postings.
+  BOOKING_LOG_STATUS_ACTIVE = 1;
+  // BOOKING_LOG_STATUS_SUSPENDED means the log is temporarily suspended.
+  BOOKING_LOG_STATUS_SUSPENDED = 2;
+  // BOOKING_LOG_STATUS_TERMINATED means the log has been permanently terminated.
+  BOOKING_LOG_STATUS_TERMINATED = 3;
+}
+
+// ControlAction defines the control operations for log lifecycle management.
+enum ControlAction {
+  // CONTROL_ACTION_UNSPECIFIED means no action specified.
+  CONTROL_ACTION_UNSPECIFIED = 0;
+  // CONTROL_ACTION_SUSPEND temporarily suspends log processing.
+  CONTROL_ACTION_SUSPEND = 1;
+  // CONTROL_ACTION_RESUME resumes a suspended log.
+  CONTROL_ACTION_RESUME = 2;
+  // CONTROL_ACTION_TERMINATE permanently terminates the log.
+  CONTROL_ACTION_TERMINATE = 3;
+}
+
 // OpenAPI specification metadata for Financial Accounting Service
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
@@ -429,6 +453,54 @@ message ListLedgerPostingsResponse {
   meridian.common.v1.PaginationResponse pagination = 2;
 }
 
+// ControlFinancialBookingLogRequest controls the lifecycle of a financial booking log.
+message ControlFinancialBookingLogRequest {
+  // log_id is the identifier of the booking log to control.
+  string log_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 255
+    }
+  ];
+
+  // control_action is the action to perform on the log.
+  ControlAction control_action = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0] /* Disallow UNSPECIFIED */
+  }];
+
+  // reason provides context for the control action.
+  string reason = 3 [(buf.validate.field).string.max_len = 500];
+
+  // operator_id identifies who performed the control action (optional).
+  string operator_id = 4 [(buf.validate.field).string = {
+    max_len: 255
+    pattern: "^[a-zA-Z0-9_-]*$"
+  }];
+}
+
+// ControlFinancialBookingLogResponse returns the result of the control action.
+message ControlFinancialBookingLogResponse {
+  // log_id is the identifier of the controlled booking log.
+  string log_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // status is the new status of the log after the control action.
+  BookingLogStatus status = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0] /* Disallow UNSPECIFIED */
+  }];
+
+  // timestamp is when the control action was applied.
+  google.protobuf.Timestamp timestamp = 3 [(buf.validate.field).required = true];
+
+  // previous_status is the status before the control action.
+  BookingLogStatus previous_status = 4 [(buf.validate.field).enum.defined_only = true];
+}
+
 // FinancialAccountingService provides the BIAN Financial Accounting service interface.
 service FinancialAccountingService {
   // InitiateFinancialBookingLog creates a new financial booking log.
@@ -504,6 +576,23 @@ service FinancialAccountingService {
   rpc ListLedgerPostings(ListLedgerPostingsRequest) returns (ListLedgerPostingsResponse) {
     option (google.api.http) = {
       get: "/v1/postings"
+    };
+  }
+
+  // ControlFinancialBookingLog controls the lifecycle of a financial booking log.
+  // Supports SUSPEND, RESUME, and TERMINATE actions for log processing lifecycle management.
+  rpc ControlFinancialBookingLog(ControlFinancialBookingLogRequest) returns (ControlFinancialBookingLogResponse) {
+    option (google.api.http) = {
+      post: "/v1/booking-logs/{log_id}/control"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "200"
+        value: {
+          description: "Control action applied successfully"
+        }
+      }
     };
   }
 }

--- a/api/proto/meridian/position_keeping/v1/position_keeping.proto
+++ b/api/proto/meridian/position_keeping/v1/position_keeping.proto
@@ -10,6 +10,30 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1;positionkeepingv1";
 
+// PositionLogStatus defines the lifecycle state of a financial position log.
+enum PositionLogStatus {
+  // POSITION_LOG_STATUS_UNSPECIFIED means the status is unknown.
+  POSITION_LOG_STATUS_UNSPECIFIED = 0;
+  // POSITION_LOG_STATUS_ACTIVE means the log is active and processing transactions.
+  POSITION_LOG_STATUS_ACTIVE = 1;
+  // POSITION_LOG_STATUS_SUSPENDED means the log is temporarily suspended.
+  POSITION_LOG_STATUS_SUSPENDED = 2;
+  // POSITION_LOG_STATUS_TERMINATED means the log has been permanently terminated.
+  POSITION_LOG_STATUS_TERMINATED = 3;
+}
+
+// ControlAction defines the control operations for log lifecycle management.
+enum ControlAction {
+  // CONTROL_ACTION_UNSPECIFIED means no action specified.
+  CONTROL_ACTION_UNSPECIFIED = 0;
+  // CONTROL_ACTION_SUSPEND temporarily suspends log processing.
+  CONTROL_ACTION_SUSPEND = 1;
+  // CONTROL_ACTION_RESUME resumes a suspended log.
+  CONTROL_ACTION_RESUME = 2;
+  // CONTROL_ACTION_TERMINATE permanently terminates the log.
+  CONTROL_ACTION_TERMINATE = 3;
+}
+
 // OpenAPI specification metadata for Position Keeping Service
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
   info: {
@@ -395,6 +419,48 @@ message ListFinancialPositionLogsResponse {
   meridian.common.v1.PaginationResponse pagination = 2;
 }
 
+// ControlFinancialPositionLogRequest controls the lifecycle of a financial position log.
+message ControlFinancialPositionLogRequest {
+  // log_id is the identifier of the log to control.
+  string log_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // control_action is the action to perform on the log.
+  ControlAction control_action = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0] /* Disallow UNSPECIFIED */
+  }];
+
+  // reason provides context for the control action.
+  string reason = 3 [(buf.validate.field).string.max_len = 500];
+
+  // operator_id identifies who performed the control action (optional).
+  string operator_id = 4 [(buf.validate.field).string = {
+    max_len: 255
+    pattern: "^[a-zA-Z0-9_-]*$"
+  }];
+}
+
+// ControlFinancialPositionLogResponse returns the result of the control action.
+message ControlFinancialPositionLogResponse {
+  // log_id is the identifier of the controlled log.
+  string log_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // status is the new status of the log after the control action.
+  PositionLogStatus status = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0] /* Disallow UNSPECIFIED */
+  }];
+
+  // timestamp is when the control action was applied.
+  google.protobuf.Timestamp timestamp = 3 [(buf.validate.field).required = true];
+
+  // previous_status is the status before the control action.
+  PositionLogStatus previous_status = 4 [(buf.validate.field).enum.defined_only = true];
+}
+
 // PositionKeepingService provides operations for managing financial position logs.
 service PositionKeepingService {
   // InitiateFinancialPositionLog creates a new financial position log.
@@ -456,6 +522,23 @@ service PositionKeepingService {
   rpc ListFinancialPositionLogs(ListFinancialPositionLogsRequest) returns (ListFinancialPositionLogsResponse) {
     option (google.api.http) = {
       get: "/v1/position-logs"
+    };
+  }
+
+  // ControlFinancialPositionLog controls the lifecycle of a financial position log.
+  // Supports SUSPEND, RESUME, and TERMINATE actions for log processing lifecycle management.
+  rpc ControlFinancialPositionLog(ControlFinancialPositionLogRequest) returns (ControlFinancialPositionLogResponse) {
+    option (google.api.http) = {
+      post: "/v1/position-logs/{log_id}/control"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "200"
+        value: {
+          description: "Control action applied successfully"
+        }
+      }
     };
   }
 }

--- a/services/current-account/service/deposit_orchestrator.go
+++ b/services/current-account/service/deposit_orchestrator.go
@@ -157,6 +157,13 @@ func (o *DepositOrchestrator) Orchestrate(ctx context.Context, account domain.Cu
 			"compensated_steps", result.CompensatedSteps,
 			"error", result.Error)
 
+		// Check if failure was due to suspended/terminated service (FailedPrecondition)
+		// Return user-friendly maintenance message for graceful degradation
+		if st, ok := status.FromError(result.Error); ok && st.Code() == codes.FailedPrecondition {
+			return nil, status.Error(codes.Unavailable,
+				"Transaction unavailable due to system maintenance. Please try again later.")
+		}
+
 		return nil, status.Errorf(codes.Internal,
 			"deposit transaction failed at step %s: %v (compensated %d/%d steps)",
 			result.FailedStep, result.Error, result.CompensatedSteps, result.CompletedSteps)

--- a/services/current-account/service/deposit_orchestrator.go
+++ b/services/current-account/service/deposit_orchestrator.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -159,11 +158,9 @@ func (o *DepositOrchestrator) Orchestrate(ctx context.Context, account domain.Cu
 			"error", result.Error)
 
 		// Check if failure was due to suspended/terminated service (FailedPrecondition)
-		// Only return maintenance message for genuinely maintenance-related conditions
+		// Use structured error details instead of fragile string matching
 		if st, ok := status.FromError(result.Error); ok && st.Code() == codes.FailedPrecondition {
-			errMsg := st.Message()
-			// Check for suspended/terminated conditions which indicate system maintenance
-			if strings.Contains(errMsg, "is suspended") || strings.Contains(errMsg, "is terminated") {
+			if isMaintenanceError(st) {
 				return nil, status.Error(codes.Unavailable,
 					"Transaction unavailable due to system maintenance. Please try again later.")
 			}
@@ -663,4 +660,24 @@ func (o *DepositOrchestrator) addSaveAccountStep(
 			return nil
 		},
 	)
+}
+
+// isMaintenanceError checks if the gRPC status contains error details indicating
+// a suspended or terminated resource. This replaces fragile string matching with
+// structured error inspection using the commonv1.Error details.
+//
+// The function inspects the error details for commonv1.Error messages with
+// ERROR_CODE_RESOURCE_SUSPENDED or ERROR_CODE_RESOURCE_TERMINATED codes.
+func isMaintenanceError(st *status.Status) bool {
+	for _, detail := range st.Details() {
+		if errDetail, ok := detail.(*commonpb.Error); ok {
+			//nolint:exhaustive // Only checking for maintenance-related error codes
+			switch errDetail.Code {
+			case commonpb.ErrorCode_ERROR_CODE_RESOURCE_SUSPENDED,
+				commonpb.ErrorCode_ERROR_CODE_RESOURCE_TERMINATED:
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/services/current-account/service/deposit_orchestrator.go
+++ b/services/current-account/service/deposit_orchestrator.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -158,10 +159,17 @@ func (o *DepositOrchestrator) Orchestrate(ctx context.Context, account domain.Cu
 			"error", result.Error)
 
 		// Check if failure was due to suspended/terminated service (FailedPrecondition)
-		// Return user-friendly maintenance message for graceful degradation
+		// Only return maintenance message for genuinely maintenance-related conditions
 		if st, ok := status.FromError(result.Error); ok && st.Code() == codes.FailedPrecondition {
-			return nil, status.Error(codes.Unavailable,
-				"Transaction unavailable due to system maintenance. Please try again later.")
+			errMsg := st.Message()
+			// Check for suspended/terminated conditions which indicate system maintenance
+			if strings.Contains(errMsg, "is suspended") || strings.Contains(errMsg, "is terminated") {
+				return nil, status.Error(codes.Unavailable,
+					"Transaction unavailable due to system maintenance. Please try again later.")
+			}
+			// Other FailedPrecondition errors (invalid state, validation failures) should propagate
+			return nil, status.Errorf(codes.FailedPrecondition,
+				"deposit transaction failed at step %s: %v", result.FailedStep, result.Error)
 		}
 
 		return nil, status.Errorf(codes.Internal,

--- a/services/financial-accounting/domain/control_action.go
+++ b/services/financial-accounting/domain/control_action.go
@@ -1,0 +1,85 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	// ErrInvalidControlAction is returned when an invalid control action is attempted
+	ErrInvalidControlAction = errors.New("invalid control action")
+	// ErrCannotSuspend is returned when suspension is not allowed in current state
+	ErrCannotSuspend = errors.New("cannot suspend log in current state")
+	// ErrCannotResume is returned when resumption is not allowed in current state
+	ErrCannotResume = errors.New("cannot resume log in current state")
+	// ErrCannotTerminate is returned when termination is not allowed in current state
+	ErrCannotTerminate = errors.New("cannot terminate log in current state")
+	// ErrAlreadyTerminated is returned when attempting to modify a terminated log
+	ErrAlreadyTerminated = errors.New("log already terminated")
+	// ErrEmptyOperatorID is returned when operator ID is required but empty
+	ErrEmptyOperatorID = errors.New("operator ID cannot be empty")
+	// ErrInvalidStatusTransition is returned when an invalid status transition is attempted
+	ErrInvalidStatusTransition = errors.New("invalid status transition")
+)
+
+// ControlAction represents the control operations for log lifecycle management.
+type ControlAction string
+
+// Control actions for log lifecycle management.
+const (
+	ControlActionUnspecified ControlAction = ""          // No action specified
+	ControlActionSuspend     ControlAction = "SUSPEND"   // Temporarily suspend log processing
+	ControlActionResume      ControlAction = "RESUME"    // Resume a suspended log
+	ControlActionTerminate   ControlAction = "TERMINATE" // Permanently terminate the log
+)
+
+// IsValid checks if the control action is valid.
+func (c ControlAction) IsValid() bool {
+	switch c {
+	case ControlActionSuspend, ControlActionResume, ControlActionTerminate:
+		return true
+	case ControlActionUnspecified:
+		return false
+	}
+	return false
+}
+
+// String returns the string representation of the control action.
+func (c ControlAction) String() string {
+	return string(c)
+}
+
+// StatusChangeEntry represents a single entry in the status change history.
+// This provides an audit trail for compliance tracking of all status changes.
+type StatusChangeEntry struct {
+	// PreviousStatus is the status before the change
+	PreviousStatus TransactionStatus
+	// NewStatus is the status after the change
+	NewStatus TransactionStatus
+	// Timestamp is when the status change occurred
+	Timestamp time.Time
+	// Reason provides context for the status change
+	Reason string
+	// OperatorID identifies who performed the status change
+	OperatorID string
+	// Action is the control action that triggered the change (if applicable)
+	Action ControlAction
+}
+
+// NewStatusChangeEntry creates a new StatusChangeEntry with validated fields.
+func NewStatusChangeEntry(
+	previousStatus TransactionStatus,
+	newStatus TransactionStatus,
+	reason string,
+	operatorID string,
+	action ControlAction,
+) *StatusChangeEntry {
+	return &StatusChangeEntry{
+		PreviousStatus: previousStatus,
+		NewStatus:      newStatus,
+		Timestamp:      time.Now().UTC(),
+		Reason:         reason,
+		OperatorID:     operatorID,
+		Action:         action,
+	}
+}

--- a/services/financial-accounting/domain/control_action_test.go
+++ b/services/financial-accounting/domain/control_action_test.go
@@ -1,0 +1,484 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestControlAction_IsValid(t *testing.T) {
+	tests := []struct {
+		name   string
+		action ControlAction
+		want   bool
+	}{
+		{"valid suspend", ControlActionSuspend, true},
+		{"valid resume", ControlActionResume, true},
+		{"valid terminate", ControlActionTerminate, true},
+		{"invalid unspecified", ControlActionUnspecified, false},
+		{"invalid empty", ControlAction(""), false},
+		{"invalid arbitrary", ControlAction("INVALID"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.action.IsValid(); got != tt.want {
+				t.Errorf("ControlAction.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestControlAction_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		action   ControlAction
+		expected string
+	}{
+		{"suspend", ControlActionSuspend, "SUSPEND"},
+		{"resume", ControlActionResume, "RESUME"},
+		{"terminate", ControlActionTerminate, "TERMINATE"},
+		{"unspecified", ControlActionUnspecified, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.action.String(); got != tt.expected {
+				t.Errorf("ControlAction.String() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewStatusChangeEntry(t *testing.T) {
+	beforeCreate := time.Now().UTC()
+
+	entry := NewStatusChangeEntry(
+		TransactionStatusPending,
+		TransactionStatusSuspended,
+		"System maintenance",
+		"operator-123",
+		ControlActionSuspend,
+	)
+
+	afterCreate := time.Now().UTC()
+
+	if entry.PreviousStatus != TransactionStatusPending {
+		t.Errorf("Expected PreviousStatus %v, got %v", TransactionStatusPending, entry.PreviousStatus)
+	}
+
+	if entry.NewStatus != TransactionStatusSuspended {
+		t.Errorf("Expected NewStatus %v, got %v", TransactionStatusSuspended, entry.NewStatus)
+	}
+
+	if entry.Reason != "System maintenance" {
+		t.Errorf("Expected Reason 'System maintenance', got %v", entry.Reason)
+	}
+
+	if entry.OperatorID != "operator-123" {
+		t.Errorf("Expected OperatorID 'operator-123', got %v", entry.OperatorID)
+	}
+
+	if entry.Action != ControlActionSuspend {
+		t.Errorf("Expected Action %v, got %v", ControlActionSuspend, entry.Action)
+	}
+
+	if entry.Timestamp.Before(beforeCreate) || entry.Timestamp.After(afterCreate) {
+		t.Errorf("Timestamp %v should be between %v and %v", entry.Timestamp, beforeCreate, afterCreate)
+	}
+
+	if entry.Timestamp.Location() != time.UTC {
+		t.Errorf("Timestamp should be UTC, got %v", entry.Timestamp.Location())
+	}
+}
+
+func TestTransactionStatus_CanSuspend(t *testing.T) {
+	tests := []struct {
+		name   string
+		status TransactionStatus
+		want   bool
+	}{
+		{"pending can suspend", TransactionStatusPending, true},
+		{"posted can suspend", TransactionStatusPosted, true},
+		{"failed cannot suspend", TransactionStatusFailed, false},
+		{"cancelled cannot suspend", TransactionStatusCancelled, false},
+		{"reversed cannot suspend", TransactionStatusReversed, false},
+		{"suspended cannot suspend again", TransactionStatusSuspended, false},
+		{"terminated cannot suspend", TransactionStatusTerminated, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.CanSuspend(); got != tt.want {
+				t.Errorf("TransactionStatus.CanSuspend() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransactionStatus_CanResume(t *testing.T) {
+	tests := []struct {
+		name   string
+		status TransactionStatus
+		want   bool
+	}{
+		{"suspended can resume", TransactionStatusSuspended, true},
+		{"pending cannot resume", TransactionStatusPending, false},
+		{"posted cannot resume", TransactionStatusPosted, false},
+		{"terminated cannot resume", TransactionStatusTerminated, false},
+		{"failed cannot resume", TransactionStatusFailed, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.CanResume(); got != tt.want {
+				t.Errorf("TransactionStatus.CanResume() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransactionStatus_CanTerminate(t *testing.T) {
+	tests := []struct {
+		name   string
+		status TransactionStatus
+		want   bool
+	}{
+		{"suspended can terminate", TransactionStatusSuspended, true},
+		{"pending cannot terminate", TransactionStatusPending, false},
+		{"posted cannot terminate", TransactionStatusPosted, false},
+		{"terminated cannot terminate again", TransactionStatusTerminated, false},
+		{"failed cannot terminate", TransactionStatusFailed, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.CanTerminate(); got != tt.want {
+				t.Errorf("TransactionStatus.CanTerminate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransactionStatus_SuspendedTransitions(t *testing.T) {
+	suspended := TransactionStatusSuspended
+
+	tests := []struct {
+		name   string
+		target TransactionStatus
+		want   bool
+	}{
+		{"can resume to pending", TransactionStatusPending, true},
+		{"can resume to posted", TransactionStatusPosted, true},
+		{"can terminate", TransactionStatusTerminated, true},
+		{"cannot go to failed", TransactionStatusFailed, false},
+		{"cannot go to cancelled", TransactionStatusCancelled, false},
+		{"cannot stay suspended", TransactionStatusSuspended, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := suspended.CanTransitionTo(tt.target); got != tt.want {
+				t.Errorf("SUSPENDED.CanTransitionTo(%v) = %v, want %v", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransactionStatus_TerminatedIsFinal(t *testing.T) {
+	terminated := TransactionStatusTerminated
+
+	if !terminated.IsFinal() {
+		t.Error("TERMINATED should be a final state")
+	}
+
+	// TERMINATED cannot transition to any state
+	targets := []TransactionStatus{
+		TransactionStatusPending,
+		TransactionStatusPosted,
+		TransactionStatusFailed,
+		TransactionStatusSuspended,
+	}
+
+	for _, target := range targets {
+		if terminated.CanTransitionTo(target) {
+			t.Errorf("TERMINATED should not be able to transition to %v", target)
+		}
+	}
+}
+
+func TestFinancialBookingLog_ControlLog_Suspend(t *testing.T) {
+	t.Run("suspend from pending", func(t *testing.T) {
+		log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+
+		updated, err := log.ControlLog(ControlActionSuspend, "System maintenance", "operator-123")
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Original should be unchanged (immutability)
+		if log.Status != TransactionStatusPending {
+			t.Error("Original log should remain PENDING")
+		}
+
+		// Updated should be suspended
+		if updated.Status != TransactionStatusSuspended {
+			t.Errorf("Expected status SUSPENDED, got %v", updated.Status)
+		}
+
+		if updated.StatusHistoryCount() != 1 {
+			t.Errorf("Expected 1 status history entry, got %d", updated.StatusHistoryCount())
+		}
+
+		history := updated.StatusHistory()
+		if history[0].Action != ControlActionSuspend {
+			t.Errorf("Expected action SUSPEND, got %v", history[0].Action)
+		}
+	})
+
+	t.Run("cannot suspend from failed", func(t *testing.T) {
+		log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+		failedLog := log.WithStatus(TransactionStatusFailed)
+
+		_, err := failedLog.ControlLog(ControlActionSuspend, "Cannot happen", "operator-123")
+		if !errors.Is(err, ErrCannotSuspend) {
+			t.Errorf("Expected ErrCannotSuspend, got: %v", err)
+		}
+	})
+
+	t.Run("cannot suspend with empty operator ID", func(t *testing.T) {
+		log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+
+		_, err := log.ControlLog(ControlActionSuspend, "Reason", "")
+		if !errors.Is(err, ErrEmptyOperatorID) {
+			t.Errorf("Expected ErrEmptyOperatorID, got: %v", err)
+		}
+	})
+}
+
+func TestFinancialBookingLog_ControlLog_Resume(t *testing.T) {
+	t.Run("resume to original status", func(t *testing.T) {
+		log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+
+		// Suspend first
+		suspended, err := log.ControlLog(ControlActionSuspend, "Maintenance", "operator-1")
+		if err != nil {
+			t.Fatalf("Failed to suspend: %v", err)
+		}
+
+		// Resume
+		resumed, err := suspended.ControlLog(ControlActionResume, "Maintenance complete", "operator-2")
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if resumed.Status != TransactionStatusPending {
+			t.Errorf("Expected status PENDING (original), got %v", resumed.Status)
+		}
+
+		if resumed.StatusHistoryCount() != 2 {
+			t.Errorf("Expected 2 status history entries, got %d", resumed.StatusHistoryCount())
+		}
+	})
+
+	t.Run("cannot resume from non-suspended state", func(t *testing.T) {
+		log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+
+		_, err := log.ControlLog(ControlActionResume, "Cannot happen", "operator-123")
+		if !errors.Is(err, ErrCannotResume) {
+			t.Errorf("Expected ErrCannotResume, got: %v", err)
+		}
+	})
+}
+
+func TestFinancialBookingLog_ControlLog_Terminate(t *testing.T) {
+	t.Run("terminate from suspended", func(t *testing.T) {
+		log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+
+		// Suspend first
+		suspended, _ := log.ControlLog(ControlActionSuspend, "Maintenance", "operator-1")
+
+		// Terminate
+		terminated, err := suspended.ControlLog(ControlActionTerminate, "No longer needed", "operator-2")
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if terminated.Status != TransactionStatusTerminated {
+			t.Errorf("Expected status TERMINATED, got %v", terminated.Status)
+		}
+
+		if !terminated.IsTerminated() {
+			t.Error("Expected IsTerminated() to return true")
+		}
+	})
+
+	t.Run("cannot terminate from non-suspended state", func(t *testing.T) {
+		log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+
+		_, err := log.ControlLog(ControlActionTerminate, "Cannot happen", "operator-123")
+		if !errors.Is(err, ErrCannotTerminate) {
+			t.Errorf("Expected ErrCannotTerminate, got: %v", err)
+		}
+	})
+
+	t.Run("terminated is truly terminal", func(t *testing.T) {
+		log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+
+		// Suspend and terminate
+		suspended, _ := log.Suspend("Maintenance", "operator-1")
+		terminated, _ := suspended.Terminate("No longer needed", "operator-2")
+
+		// Try to suspend again
+		_, err := terminated.ControlLog(ControlActionSuspend, "Should fail", "operator-3")
+		if !errors.Is(err, ErrAlreadyTerminated) {
+			t.Errorf("Expected ErrAlreadyTerminated, got: %v", err)
+		}
+
+		// Try to resume
+		_, err = terminated.ControlLog(ControlActionResume, "Should fail", "operator-3")
+		if !errors.Is(err, ErrAlreadyTerminated) {
+			t.Errorf("Expected ErrAlreadyTerminated, got: %v", err)
+		}
+	})
+}
+
+func TestFinancialBookingLog_ControlLog_InvalidAction(t *testing.T) {
+	log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+
+	_, err := log.ControlLog(ControlAction("INVALID"), "Reason", "operator-123")
+	if !errors.Is(err, ErrInvalidControlAction) {
+		t.Errorf("Expected ErrInvalidControlAction, got: %v", err)
+	}
+
+	_, err = log.ControlLog(ControlActionUnspecified, "Reason", "operator-123")
+	if !errors.Is(err, ErrInvalidControlAction) {
+		t.Errorf("Expected ErrInvalidControlAction for unspecified, got: %v", err)
+	}
+}
+
+func TestFinancialBookingLog_ConvenienceMethods(t *testing.T) {
+	t.Run("Suspend convenience method", func(t *testing.T) {
+		log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+		suspended, err := log.Suspend("Maintenance", "operator-1")
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if !suspended.IsSuspended() {
+			t.Error("Expected log to be suspended")
+		}
+	})
+
+	t.Run("Resume convenience method", func(t *testing.T) {
+		log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+		suspended, _ := log.Suspend("Maintenance", "operator-1")
+		resumed, err := suspended.Resume("Complete", "operator-2")
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if resumed.IsSuspended() {
+			t.Error("Expected log to not be suspended after resume")
+		}
+	})
+
+	t.Run("Terminate convenience method", func(t *testing.T) {
+		log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+		suspended, _ := log.Suspend("Maintenance", "operator-1")
+		terminated, err := suspended.Terminate("No longer needed", "operator-2")
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if !terminated.IsTerminated() {
+			t.Error("Expected log to be terminated")
+		}
+	})
+}
+
+func TestFinancialBookingLog_StatusHistory_AuditTrail(t *testing.T) {
+	log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+
+	// Perform a series of control actions (chaining immutable updates)
+	step1, _ := log.Suspend("First suspension", "op-1")
+	step2, _ := step1.Resume("First resume", "op-2")
+	step3, _ := step2.Suspend("Second suspension", "op-3")
+	final, _ := step3.Terminate("Final termination", "op-4")
+
+	history := final.StatusHistory()
+
+	if len(history) != 4 {
+		t.Fatalf("Expected 4 history entries, got %d", len(history))
+	}
+
+	// Verify first entry
+	if history[0].PreviousStatus != TransactionStatusPending {
+		t.Errorf("Entry 0: expected previous PENDING, got %v", history[0].PreviousStatus)
+	}
+	if history[0].NewStatus != TransactionStatusSuspended {
+		t.Errorf("Entry 0: expected new SUSPENDED, got %v", history[0].NewStatus)
+	}
+	if history[0].Action != ControlActionSuspend {
+		t.Errorf("Entry 0: expected action SUSPEND, got %v", history[0].Action)
+	}
+	if history[0].OperatorID != "op-1" {
+		t.Errorf("Entry 0: expected operator 'op-1', got %v", history[0].OperatorID)
+	}
+
+	// Verify last entry is termination
+	last := history[len(history)-1]
+	if last.NewStatus != TransactionStatusTerminated {
+		t.Errorf("Last entry should be TERMINATED, got %v", last.NewStatus)
+	}
+}
+
+func TestFinancialBookingLog_StatusHistory_DefensiveCopy(t *testing.T) {
+	log := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+	suspended, _ := log.Suspend("Test", "op-1")
+
+	firstCopy := suspended.StatusHistory()
+	secondCopy := suspended.StatusHistory()
+
+	// Modify first copy
+	firstCopy[0] = nil
+
+	// Second copy should be unaffected
+	if secondCopy[0] == nil {
+		t.Error("Modifying one copy should not affect another")
+	}
+}
+
+func TestFinancialBookingLog_Immutability(t *testing.T) {
+	original := NewFinancialBookingLog("ASSET", "PROD-001", "BU-TREASURY", "UK-GAAP", CurrencyGBP)
+	originalID := original.ID
+
+	suspended, _ := original.Suspend("Maintenance", "op-1")
+	resumed, _ := suspended.Resume("Complete", "op-2")
+
+	// Original should be completely unchanged
+	if original.Status != TransactionStatusPending {
+		t.Error("Original status should remain PENDING")
+	}
+	if original.StatusHistoryCount() != 0 {
+		t.Error("Original should have no status history")
+	}
+
+	// Suspended should have 1 entry
+	if suspended.Status != TransactionStatusSuspended {
+		t.Error("Suspended should be SUSPENDED")
+	}
+	if suspended.StatusHistoryCount() != 1 {
+		t.Error("Suspended should have 1 history entry")
+	}
+
+	// Resumed should have 2 entries
+	if resumed.Status != TransactionStatusPending {
+		t.Error("Resumed should be PENDING")
+	}
+	if resumed.StatusHistoryCount() != 2 {
+		t.Error("Resumed should have 2 history entries")
+	}
+
+	// All should have same ID
+	if suspended.ID != originalID || resumed.ID != originalID {
+		t.Error("ID should be preserved through all transformations")
+	}
+}

--- a/services/financial-accounting/domain/financial_booking_log.go
+++ b/services/financial-accounting/domain/financial_booking_log.go
@@ -16,7 +16,8 @@ import (
 //   - Created in PENDING status via InitiateFinancialBookingLog
 //   - Updated with chart of accounts rules and status transitions
 //   - Transitions to POSTED when all postings balance (debits == credits)
-//   - Cannot be modified once in terminal state (POSTED, FAILED, CANCELLED)
+//   - Cannot be modified once in terminal state (POSTED, FAILED, CANCELLED, TERMINATED)
+//   - Can be SUSPENDED temporarily and then RESUMED or TERMINATED
 type FinancialBookingLog struct {
 	// ID uniquely identifies this booking log
 	ID uuid.UUID
@@ -49,6 +50,13 @@ type FinancialBookingLog struct {
 	// NOTE: Loaded separately via repository to avoid N+1 queries
 	// Access via Postings() method which returns a defensive copy
 	postings []*LedgerPosting
+
+	// statusHistory provides an audit trail for all status changes
+	// Access via StatusHistory() method which returns a defensive copy
+	statusHistory []*StatusChangeEntry
+
+	// preSuspendStatus stores the status before suspension for resumption
+	preSuspendStatus *TransactionStatus
 }
 
 // Postings returns a defensive copy of the postings slice.
@@ -87,6 +95,8 @@ func NewFinancialBookingLog(
 		CreatedAt:               now,
 		UpdatedAt:               now,
 		postings:                make([]*LedgerPosting, 0),
+		statusHistory:           make([]*StatusChangeEntry, 0),
+		preSuspendStatus:        nil,
 	}
 }
 
@@ -96,7 +106,7 @@ func NewFinancialBookingLog(
 //   - PENDING → POSTED (when debits == credits)
 //   - PENDING → FAILED (validation errors)
 //   - PENDING → CANCELLED (business cancellation)
-//   - Terminal states (POSTED, FAILED, CANCELLED) cannot transition
+//   - Terminal states (POSTED, FAILED, CANCELLED, TERMINATED) cannot transition
 //
 // Returns a new instance following immutability guidelines per CONTRIBUTING.md.
 func (l FinancialBookingLog) WithStatus(newStatus TransactionStatus) FinancialBookingLog {
@@ -111,6 +121,8 @@ func (l FinancialBookingLog) WithStatus(newStatus TransactionStatus) FinancialBo
 		CreatedAt:               l.CreatedAt,
 		UpdatedAt:               time.Now().UTC(),
 		postings:                l.postings,
+		statusHistory:           l.statusHistory,
+		preSuspendStatus:        l.preSuspendStatus,
 	}
 }
 
@@ -132,6 +144,8 @@ func (l FinancialBookingLog) WithChartOfAccountsRules(rules string) FinancialBoo
 		CreatedAt:               l.CreatedAt,
 		UpdatedAt:               time.Now().UTC(),
 		postings:                l.postings,
+		statusHistory:           l.statusHistory,
+		preSuspendStatus:        l.preSuspendStatus,
 	}
 }
 
@@ -157,6 +171,8 @@ func (l FinancialBookingLog) WithPosting(posting *LedgerPosting) FinancialBookin
 		CreatedAt:               l.CreatedAt,
 		UpdatedAt:               l.UpdatedAt,
 		postings:                newPostings,
+		statusHistory:           l.statusHistory,
+		preSuspendStatus:        l.preSuspendStatus,
 	}
 }
 
@@ -164,5 +180,162 @@ func (l FinancialBookingLog) WithPosting(posting *LedgerPosting) FinancialBookin
 func (l *FinancialBookingLog) IsTerminal() bool {
 	return l.Status == TransactionStatusPosted ||
 		l.Status == TransactionStatusFailed ||
-		l.Status == TransactionStatusCancelled
+		l.Status == TransactionStatusCancelled ||
+		l.Status == TransactionStatusTerminated
+}
+
+// StatusHistory returns a defensive copy of the status history.
+func (l FinancialBookingLog) StatusHistory() []*StatusChangeEntry {
+	if l.statusHistory == nil {
+		return []*StatusChangeEntry{}
+	}
+	result := make([]*StatusChangeEntry, len(l.statusHistory))
+	copy(result, l.statusHistory)
+	return result
+}
+
+// StatusHistoryCount returns the number of status history entries.
+func (l *FinancialBookingLog) StatusHistoryCount() int {
+	return len(l.statusHistory)
+}
+
+// CanTransitionTo checks if the log can transition to the target status.
+func (l *FinancialBookingLog) CanTransitionTo(target TransactionStatus) error {
+	if l.Status == TransactionStatusTerminated {
+		return ErrAlreadyTerminated
+	}
+
+	if !l.Status.CanTransitionTo(target) {
+		return ErrInvalidStatusTransition
+	}
+
+	return nil
+}
+
+// ControlLog applies a control action (SUSPEND, RESUME, TERMINATE) to the log.
+// It validates the transition using the state machine and returns a new instance
+// with updated status and status history for compliance tracking.
+//
+// Parameters:
+//   - action: The control action to apply (SUSPEND, RESUME, TERMINATE)
+//   - reason: Context explaining why the action is being performed
+//   - operatorID: Identifier of who is performing the action (required)
+//
+// Returns:
+//   - A new FinancialBookingLog with updated status on success
+//   - An error if the action is invalid or the transition is not allowed
+func (l FinancialBookingLog) ControlLog(
+	action ControlAction,
+	reason string,
+	operatorID string,
+) (FinancialBookingLog, error) {
+	// Validate action
+	if !action.IsValid() {
+		return l, ErrInvalidControlAction
+	}
+
+	// Validate operator ID
+	if operatorID == "" {
+		return l, ErrEmptyOperatorID
+	}
+
+	// Check if already terminated
+	if l.Status == TransactionStatusTerminated {
+		return l, ErrAlreadyTerminated
+	}
+
+	var targetStatus TransactionStatus
+	var newPreSuspendStatus *TransactionStatus
+
+	switch action {
+	case ControlActionSuspend:
+		if !l.Status.CanSuspend() {
+			return l, ErrCannotSuspend
+		}
+		// Store current status for later resumption
+		current := l.Status
+		newPreSuspendStatus = &current
+		targetStatus = TransactionStatusSuspended
+
+	case ControlActionResume:
+		if !l.Status.CanResume() {
+			return l, ErrCannotResume
+		}
+		// Determine what status to resume to
+		if l.preSuspendStatus != nil {
+			targetStatus = *l.preSuspendStatus
+		} else {
+			// Default to PENDING if no pre-suspend status recorded
+			targetStatus = TransactionStatusPending
+		}
+		newPreSuspendStatus = nil
+
+	case ControlActionTerminate:
+		if !l.Status.CanTerminate() {
+			return l, ErrCannotTerminate
+		}
+		targetStatus = TransactionStatusTerminated
+		newPreSuspendStatus = l.preSuspendStatus // preserve for audit
+
+	case ControlActionUnspecified:
+		return l, ErrInvalidControlAction
+	}
+
+	// Create status change entry for audit trail
+	statusEntry := NewStatusChangeEntry(
+		l.Status,
+		targetStatus,
+		reason,
+		operatorID,
+		action,
+	)
+
+	// Build new status history
+	newHistory := make([]*StatusChangeEntry, len(l.statusHistory)+1)
+	copy(newHistory, l.statusHistory)
+	newHistory[len(l.statusHistory)] = statusEntry
+
+	// Return new instance (immutability pattern)
+	return FinancialBookingLog{
+		ID:                      l.ID,
+		FinancialAccountType:    l.FinancialAccountType,
+		ProductServiceReference: l.ProductServiceReference,
+		BusinessUnitReference:   l.BusinessUnitReference,
+		ChartOfAccountsRules:    l.ChartOfAccountsRules,
+		BaseCurrency:            l.BaseCurrency,
+		Status:                  targetStatus,
+		CreatedAt:               l.CreatedAt,
+		UpdatedAt:               time.Now().UTC(),
+		postings:                l.postings,
+		statusHistory:           newHistory,
+		preSuspendStatus:        newPreSuspendStatus,
+	}, nil
+}
+
+// Suspend temporarily suspends the log processing.
+// Returns a new instance with SUSPENDED status or an error if suspension is not allowed.
+func (l FinancialBookingLog) Suspend(reason string, operatorID string) (FinancialBookingLog, error) {
+	return l.ControlLog(ControlActionSuspend, reason, operatorID)
+}
+
+// Resume resumes a suspended log.
+// Returns a new instance with the pre-suspend status or an error if resumption is not allowed.
+func (l FinancialBookingLog) Resume(reason string, operatorID string) (FinancialBookingLog, error) {
+	return l.ControlLog(ControlActionResume, reason, operatorID)
+}
+
+// Terminate permanently terminates the log.
+// Returns a new instance with TERMINATED status or an error if termination is not allowed.
+func (l FinancialBookingLog) Terminate(reason string, operatorID string) (FinancialBookingLog, error) {
+	return l.ControlLog(ControlActionTerminate, reason, operatorID)
+}
+
+// IsSuspended returns true if the log is currently suspended.
+func (l *FinancialBookingLog) IsSuspended() bool {
+	return l.Status == TransactionStatusSuspended
+}
+
+// IsTerminated returns true if the log has been terminated.
+func (l *FinancialBookingLog) IsTerminated() bool {
+	return l.Status == TransactionStatusTerminated
 }

--- a/services/financial-accounting/domain/transaction_status.go
+++ b/services/financial-accounting/domain/transaction_status.go
@@ -5,18 +5,21 @@ type TransactionStatus string
 
 // Supported transaction statuses through the transaction lifecycle.
 const (
-	TransactionStatusPending   TransactionStatus = "PENDING"   // Transaction created but not yet posted
-	TransactionStatusPosted    TransactionStatus = "POSTED"    // Transaction successfully posted to ledger
-	TransactionStatusFailed    TransactionStatus = "FAILED"    // Transaction failed validation or posting
-	TransactionStatusCancelled TransactionStatus = "CANCELLED" // Transaction manually cancelled
-	TransactionStatusReversed  TransactionStatus = "REVERSED"  // Transaction reversed with offsetting entry
+	TransactionStatusPending    TransactionStatus = "PENDING"    // Transaction created but not yet posted
+	TransactionStatusPosted     TransactionStatus = "POSTED"     // Transaction successfully posted to ledger
+	TransactionStatusFailed     TransactionStatus = "FAILED"     // Transaction failed validation or posting
+	TransactionStatusCancelled  TransactionStatus = "CANCELLED"  // Transaction manually cancelled
+	TransactionStatusReversed   TransactionStatus = "REVERSED"   // Transaction reversed with offsetting entry
+	TransactionStatusSuspended  TransactionStatus = "SUSPENDED"  // Transaction processing temporarily suspended
+	TransactionStatusTerminated TransactionStatus = "TERMINATED" // Transaction permanently terminated
 )
 
 // IsValid checks if the transaction status is valid.
 func (t TransactionStatus) IsValid() bool {
 	switch t {
 	case TransactionStatusPending, TransactionStatusPosted, TransactionStatusFailed,
-		TransactionStatusCancelled, TransactionStatusReversed:
+		TransactionStatusCancelled, TransactionStatusReversed, TransactionStatusSuspended,
+		TransactionStatusTerminated:
 		return true
 	}
 	return false
@@ -32,5 +35,55 @@ func (t TransactionStatus) IsFinal() bool {
 	return t == TransactionStatusPosted ||
 		t == TransactionStatusFailed ||
 		t == TransactionStatusCancelled ||
-		t == TransactionStatusReversed
+		t == TransactionStatusReversed ||
+		t == TransactionStatusTerminated
+}
+
+// CanTransitionTo checks if a transition to the target status is valid.
+func (t TransactionStatus) CanTransitionTo(target TransactionStatus) bool {
+	// TERMINATED is absolutely terminal - no transitions allowed
+	if t == TransactionStatusTerminated {
+		return false
+	}
+
+	// Other final states cannot transition
+	if t.IsFinal() {
+		return false
+	}
+
+	// SUSPENDED can transition back to PENDING/POSTED or to TERMINATED
+	if t == TransactionStatusSuspended {
+		return target == TransactionStatusPending ||
+			target == TransactionStatusPosted ||
+			target == TransactionStatusTerminated
+	}
+
+	// Valid state transitions from PENDING
+	if t == TransactionStatusPending {
+		return target == TransactionStatusPosted ||
+			target == TransactionStatusFailed ||
+			target == TransactionStatusCancelled ||
+			target == TransactionStatusSuspended
+	}
+
+	return false
+}
+
+// CanSuspend checks if the current status allows suspension.
+// Only PENDING and POSTED states can be suspended.
+// FAILED, CANCELLED, REVERSED, and TERMINATED are not suspendable.
+func (t TransactionStatus) CanSuspend() bool {
+	return t == TransactionStatusPending || t == TransactionStatusPosted
+}
+
+// CanResume checks if the current status allows resumption.
+// Only SUSPENDED status can be resumed.
+func (t TransactionStatus) CanResume() bool {
+	return t == TransactionStatusSuspended
+}
+
+// CanTerminate checks if the current status allows termination.
+// Only SUSPENDED status can be terminated.
+func (t TransactionStatus) CanTerminate() bool {
+	return t == TransactionStatusSuspended
 }

--- a/services/financial-accounting/service/adapters.go
+++ b/services/financial-accounting/service/adapters.go
@@ -133,7 +133,7 @@ func fromProtoTransactionStatus(status commonv1.TransactionStatus) domain.Transa
 
 // toProtoTransactionStatus converts domain TransactionStatus to protobuf.
 func toProtoTransactionStatus(status domain.TransactionStatus) commonv1.TransactionStatus {
-	switch status {
+	switch status { //nolint:exhaustive // SUSPENDED/TERMINATED don't have proto equivalents yet
 	case domain.TransactionStatusPending:
 		return commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING
 	case domain.TransactionStatusPosted:

--- a/services/financial-accounting/service/financial_accounting_service.go
+++ b/services/financial-accounting/service/financial_accounting_service.go
@@ -208,8 +208,26 @@ func (s *FinancialAccountingService) CaptureLedgerPosting(
 		return nil, status.Errorf(codes.InvalidArgument, "invalid financial_booking_log_id: %v", err)
 	}
 
-	// Validate booking log exists (optional check - could be deferred to database constraint)
-	// For now we'll trust the database foreign key constraint
+	// Check if booking log exists and is not suspended or terminated
+	bookingLog, err := s.repository.GetBookingLog(ctx, bookingLogID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrBookingLogNotFound) {
+			return nil, status.Errorf(codes.NotFound, "financial booking log not found: %s", bookingLogID)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to retrieve booking log: %v", err)
+	}
+
+	// Block postings to suspended booking logs
+	if bookingLog.IsSuspended() {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"booking log %s is suspended, cannot accept postings", bookingLogID)
+	}
+
+	// Block postings to terminated booking logs
+	if bookingLog.IsTerminated() {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"booking log %s is terminated, cannot accept postings", bookingLogID)
+	}
 
 	// Parse and validate posting amount
 	postingAmount, err := fromProtoMoney(req.GetPostingAmount())
@@ -683,7 +701,7 @@ func (s *FinancialAccountingService) UpdateLedgerPosting(
 		postingResult = posting.PostingResult // Preserve existing if not provided
 	}
 
-	switch newStatus {
+	switch newStatus { //nolint:exhaustive // SUSPENDED/TERMINATED handled via ControlFinancialBookingLog
 	case domain.TransactionStatusPosted:
 		if err := posting.Post(postingResult); err != nil {
 			if errors.Is(err, domain.ErrAlreadyPosted) {
@@ -1228,6 +1246,137 @@ func (s *FinancialAccountingService) UpdateFinancialBookingLog(
 	return response, nil
 }
 
+// ControlFinancialBookingLog controls the lifecycle of a financial booking log.
+// Supports SUSPEND, RESUME, and TERMINATE actions for log processing lifecycle management.
+//
+// gRPC Error Codes:
+//   - codes.InvalidArgument: Invalid log_id format, unspecified control action, or invalid operator_id
+//   - codes.NotFound: Financial booking log does not exist
+//   - codes.FailedPrecondition: Control action not allowed in current state
+//   - codes.Internal: Database or system errors
+func (s *FinancialAccountingService) ControlFinancialBookingLog(
+	ctx context.Context,
+	req *financialaccountingv1.ControlFinancialBookingLogRequest,
+) (*financialaccountingv1.ControlFinancialBookingLogResponse, error) {
+	// Parse and validate log ID
+	logID, err := parseUUID(req.GetLogId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid log_id: %v", err)
+	}
+
+	// Map proto ControlAction to domain ControlAction
+	var domainAction domain.ControlAction
+	switch req.ControlAction {
+	case financialaccountingv1.ControlAction_CONTROL_ACTION_SUSPEND:
+		domainAction = domain.ControlActionSuspend
+	case financialaccountingv1.ControlAction_CONTROL_ACTION_RESUME:
+		domainAction = domain.ControlActionResume
+	case financialaccountingv1.ControlAction_CONTROL_ACTION_TERMINATE:
+		domainAction = domain.ControlActionTerminate
+	case financialaccountingv1.ControlAction_CONTROL_ACTION_UNSPECIFIED:
+		return nil, status.Error(codes.InvalidArgument, "control_action must be specified")
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unknown control_action: %v", req.ControlAction)
+	}
+
+	// Validate operator_id
+	operatorID := req.GetOperatorId()
+	if operatorID == "" {
+		operatorID = "system" // Default to system if not provided
+	}
+
+	// Retrieve booking log from repository
+	bookingLog, err := s.repository.GetBookingLog(ctx, logID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrBookingLogNotFound) {
+			return nil, status.Errorf(codes.NotFound, "financial booking log not found: %s", logID)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to retrieve financial booking log: %v", err)
+	}
+
+	// Capture previous status before the control action
+	previousStatus := bookingLog.Status
+
+	// Apply control action via domain model
+	updatedLog, err := bookingLog.ControlLog(domainAction, req.GetReason(), operatorID)
+	if err != nil {
+		// Map domain errors to gRPC status codes
+		switch {
+		case errors.Is(err, domain.ErrInvalidControlAction):
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		case errors.Is(err, domain.ErrCannotSuspend):
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot suspend booking log in current state: %s", previousStatus)
+		case errors.Is(err, domain.ErrCannotResume):
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot resume booking log in current state: %s", previousStatus)
+		case errors.Is(err, domain.ErrCannotTerminate):
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot terminate booking log in current state: %s", previousStatus)
+		case errors.Is(err, domain.ErrAlreadyTerminated):
+			return nil, status.Error(codes.FailedPrecondition, "booking log already terminated")
+		case errors.Is(err, domain.ErrEmptyOperatorID):
+			return nil, status.Error(codes.InvalidArgument, "operator_id cannot be empty")
+		default:
+			return nil, status.Errorf(codes.Internal, "control action failed: %v", err)
+		}
+	}
+
+	// Persist updated booking log to database
+	if err := s.repository.UpdateBookingLog(ctx, &updatedLog); err != nil {
+		if errors.Is(err, persistence.ErrBookingLogNotFound) {
+			return nil, status.Errorf(codes.NotFound, "financial booking log not found: %s", logID)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to update financial booking log: %v", err)
+	}
+
+	// Emit BookingLogStatusChangedEvent to Kafka
+	event := &eventsv1.BookingLogStatusChangedEvent{
+		BookingLogId:   updatedLog.ID.String(),
+		PreviousStatus: previousStatus.String(),
+		NewStatus:      updatedLog.Status.String(),
+		ControlAction:  domainAction.String(),
+		Reason:         req.GetReason(),
+		OperatorId:     operatorID,
+		CorrelationId:  logID.String(), // Use log ID as correlation ID
+		CausationId:    logID.String(),
+		Timestamp:      timestamppb.Now(),
+		Version:        1,
+	}
+	if err := s.eventPublisher.Publish(ctx, event); err != nil {
+		slog.Error("failed to publish BookingLogStatusChangedEvent",
+			"error", err,
+			"booking_log_id", updatedLog.ID.String(),
+			"previous_status", previousStatus,
+			"new_status", updatedLog.Status)
+	}
+
+	// Map domain status to proto BookingLogStatus
+	var protoStatus financialaccountingv1.BookingLogStatus
+	var protoPreviousStatus financialaccountingv1.BookingLogStatus
+	switch updatedLog.Status { //nolint:exhaustive // Only mapping to 3 proto values
+	case domain.TransactionStatusSuspended:
+		protoStatus = financialaccountingv1.BookingLogStatus_BOOKING_LOG_STATUS_SUSPENDED
+	case domain.TransactionStatusTerminated:
+		protoStatus = financialaccountingv1.BookingLogStatus_BOOKING_LOG_STATUS_TERMINATED
+	default:
+		protoStatus = financialaccountingv1.BookingLogStatus_BOOKING_LOG_STATUS_ACTIVE
+	}
+
+	switch previousStatus { //nolint:exhaustive // Only mapping to 3 proto values
+	case domain.TransactionStatusSuspended:
+		protoPreviousStatus = financialaccountingv1.BookingLogStatus_BOOKING_LOG_STATUS_SUSPENDED
+	case domain.TransactionStatusTerminated:
+		protoPreviousStatus = financialaccountingv1.BookingLogStatus_BOOKING_LOG_STATUS_TERMINATED
+	default:
+		protoPreviousStatus = financialaccountingv1.BookingLogStatus_BOOKING_LOG_STATUS_ACTIVE
+	}
+
+	return &financialaccountingv1.ControlFinancialBookingLogResponse{
+		LogId:          updatedLog.ID.String(),
+		Status:         protoStatus,
+		Timestamp:      timestamppb.New(updatedLog.UpdatedAt),
+		PreviousStatus: protoPreviousStatus,
+	}, nil
+}
+
 // isValidBookingLogTransition validates that a status transition is allowed.
 //
 // Valid transitions:
@@ -1245,9 +1394,9 @@ func (s *FinancialAccountingService) UpdateFinancialBookingLog(
 //   - PENDING -> REVERSED (must be POSTED first to reverse)
 //   - Any transition from terminal states (FAILED, CANCELLED, REVERSED)
 func isValidBookingLogTransition(from, to domain.TransactionStatus) bool {
-	switch from {
+	switch from { //nolint:exhaustive // SUSPENDED/TERMINATED handled via ControlFinancialBookingLog
 	case domain.TransactionStatusPending:
-		switch to {
+		switch to { //nolint:exhaustive // Only checking valid booking log transitions
 		case domain.TransactionStatusPending, // No-op but valid
 			domain.TransactionStatusPosted,
 			domain.TransactionStatusFailed,

--- a/services/financial-accounting/service/financial_accounting_service.go
+++ b/services/financial-accounting/service/financial_accounting_service.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
@@ -219,14 +220,16 @@ func (s *FinancialAccountingService) CaptureLedgerPosting(
 
 	// Block postings to suspended booking logs
 	if bookingLog.IsSuspended() {
-		return nil, status.Errorf(codes.FailedPrecondition,
-			"booking log %s is suspended, cannot accept postings", bookingLogID)
+		return nil, newMaintenanceError(codes.FailedPrecondition,
+			commonv1.ErrorCode_ERROR_CODE_RESOURCE_SUSPENDED,
+			fmt.Sprintf("booking log %s is suspended, cannot accept postings", bookingLogID))
 	}
 
 	// Block postings to terminated booking logs
 	if bookingLog.IsTerminated() {
-		return nil, status.Errorf(codes.FailedPrecondition,
-			"booking log %s is terminated, cannot accept postings", bookingLogID)
+		return nil, newMaintenanceError(codes.FailedPrecondition,
+			commonv1.ErrorCode_ERROR_CODE_RESOURCE_TERMINATED,
+			fmt.Sprintf("booking log %s is terminated, cannot accept postings", bookingLogID))
 	}
 
 	// Parse and validate posting amount
@@ -1280,9 +1283,14 @@ func (s *FinancialAccountingService) ControlFinancialBookingLog(
 	}
 
 	// Validate operator_id
+	// Design Decision: operator_id defaults to "system" when empty to maintain backward
+	// compatibility with existing clients and to support system-initiated control actions
+	// (e.g., automated lifecycle management, scheduled suspensions). The domain layer
+	// validates ErrEmptyOperatorID, but this defaulting occurs before domain validation
+	// to handle the common case of system-initiated operations gracefully.
 	operatorID := req.GetOperatorId()
 	if operatorID == "" {
-		operatorID = "system" // Default to system if not provided
+		operatorID = "system"
 	}
 
 	// Retrieve booking log from repository
@@ -1329,16 +1337,17 @@ func (s *FinancialAccountingService) ControlFinancialBookingLog(
 
 	// Emit BookingLogStatusChangedEvent to Kafka
 	event := &eventsv1.BookingLogStatusChangedEvent{
-		BookingLogId:   updatedLog.ID.String(),
-		PreviousStatus: previousStatus.String(),
-		NewStatus:      updatedLog.Status.String(),
-		ControlAction:  domainAction.String(),
-		Reason:         req.GetReason(),
-		OperatorId:     operatorID,
-		CorrelationId:  logID.String(), // Use log ID as correlation ID
-		CausationId:    logID.String(),
-		Timestamp:      timestamppb.Now(),
-		Version:        1,
+		BookingLogId:          updatedLog.ID.String(),
+		BusinessUnitReference: updatedLog.BusinessUnitReference,
+		PreviousStatus:        previousStatus.String(),
+		NewStatus:             updatedLog.Status.String(),
+		ControlAction:         domainAction.String(),
+		Reason:                req.GetReason(),
+		OperatorId:            operatorID,
+		CorrelationId:         logID.String(), // Use log ID as correlation ID
+		CausationId:           logID.String(),
+		Timestamp:             timestamppb.Now(),
+		Version:               1,
 	}
 	if err := s.eventPublisher.Publish(ctx, event); err != nil {
 		slog.Error("failed to publish BookingLogStatusChangedEvent",
@@ -1416,4 +1425,49 @@ func isValidBookingLogTransition(from, to domain.TransactionStatus) bool {
 		return false
 	}
 	return false
+}
+
+// newMaintenanceError creates a gRPC error with structured error details for maintenance conditions.
+// The error includes a commonv1.Error in the status details, allowing callers to inspect the
+// error code programmatically without parsing error messages.
+//
+// Usage example (caller side):
+//
+//	st, ok := status.FromError(err)
+//	if ok {
+//	    for _, detail := range st.Details() {
+//	        if errDetail, ok := detail.(*commonv1.Error); ok {
+//	            switch errDetail.Code {
+//	            case commonv1.ErrorCode_ERROR_CODE_RESOURCE_SUSPENDED:
+//	                // Handle suspended resource
+//	            case commonv1.ErrorCode_ERROR_CODE_RESOURCE_TERMINATED:
+//	                // Handle terminated resource
+//	            }
+//	        }
+//	    }
+//	}
+func newMaintenanceError(grpcCode codes.Code, errorCode commonv1.ErrorCode, message string) error {
+	st := status.New(grpcCode, message)
+	errDetail := &commonv1.Error{
+		Code:    errorCode,
+		Message: message,
+		RetryInfo: &commonv1.RetryInfo{
+			Retryable:         errorCode == commonv1.ErrorCode_ERROR_CODE_RESOURCE_SUSPENDED,
+			RetryDelaySeconds: 30, // Suggest retry after 30 seconds for suspended resources
+		},
+	}
+
+	anyDetail, err := anypb.New(errDetail)
+	if err != nil {
+		// Fall back to basic error if we can't create the detail
+		return st.Err()
+	}
+
+	stWithDetails, err := st.WithDetails(anyDetail)
+	if err != nil {
+		// Fall back to basic error if we can't attach details
+		return st.Err()
+	}
+
+	return stWithDetails.Err()
 }

--- a/services/financial-accounting/service/financial_accounting_service_test.go
+++ b/services/financial-accounting/service/financial_accounting_service_test.go
@@ -370,7 +370,7 @@ func (s *testFinancialAccountingService) UpdateLedgerPosting(
 		postingResult = posting.PostingResult
 	}
 
-	switch newStatus {
+	switch newStatus { //nolint:exhaustive // SUSPENDED/TERMINATED handled via ControlFinancialBookingLog
 	case domain.TransactionStatusPosted:
 		if err := posting.Post(postingResult); err != nil {
 			if errors.Is(err, domain.ErrAlreadyPosted) {

--- a/services/position-keeping/adapters/messaging/kafka_event_publisher.go
+++ b/services/position-keeping/adapters/messaging/kafka_event_publisher.go
@@ -52,19 +52,22 @@ type TopicConfig struct {
 	TransactionCancelledTopic string
 	// BulkTransactionCapturedTopic is the topic for bulk transaction captured events
 	BulkTransactionCapturedTopic string
+	// PositionLogStatusChangedTopic is the topic for position log status changed events
+	PositionLogStatusChangedTopic string
 }
 
 // DefaultTopicConfig returns the default topic configuration for position keeping events.
 func DefaultTopicConfig() TopicConfig {
 	return TopicConfig{
-		TransactionCapturedTopic:     "position-keeping.transaction-captured.v1",
-		TransactionAmendedTopic:      "position-keeping.transaction-amended.v1",
-		TransactionReconciledTopic:   "position-keeping.transaction-reconciled.v1",
-		TransactionPostedTopic:       "position-keeping.transaction-posted.v1",
-		TransactionRejectedTopic:     "position-keeping.transaction-rejected.v1",
-		TransactionFailedTopic:       "position-keeping.transaction-failed.v1",
-		TransactionCancelledTopic:    "position-keeping.transaction-cancelled.v1",
-		BulkTransactionCapturedTopic: "position-keeping.bulk-transaction-captured.v1",
+		TransactionCapturedTopic:      "position-keeping.transaction-captured.v1",
+		TransactionAmendedTopic:       "position-keeping.transaction-amended.v1",
+		TransactionReconciledTopic:    "position-keeping.transaction-reconciled.v1",
+		TransactionPostedTopic:        "position-keeping.transaction-posted.v1",
+		TransactionRejectedTopic:      "position-keeping.transaction-rejected.v1",
+		TransactionFailedTopic:        "position-keeping.transaction-failed.v1",
+		TransactionCancelledTopic:     "position-keeping.transaction-cancelled.v1",
+		BulkTransactionCapturedTopic:  "position-keeping.bulk-transaction-captured.v1",
+		PositionLogStatusChangedTopic: "position-keeping.position-log-status-changed.v1",
 	}
 }
 
@@ -87,14 +90,15 @@ func NewKafkaEventPublisher(producer protoPublisher, topicConfig TopicConfig) (*
 
 	// Pre-build topic routing map for O(1) lookups instead of O(n) switch statements
 	topicMap := map[string]string{
-		"position_keeping.transaction_captured.v1":      topicConfig.TransactionCapturedTopic,
-		"position_keeping.transaction_amended.v1":       topicConfig.TransactionAmendedTopic,
-		"position_keeping.transaction_reconciled.v1":    topicConfig.TransactionReconciledTopic,
-		"position_keeping.transaction_posted.v1":        topicConfig.TransactionPostedTopic,
-		"position_keeping.transaction_rejected.v1":      topicConfig.TransactionRejectedTopic,
-		"position_keeping.transaction_failed.v1":        topicConfig.TransactionFailedTopic,
-		"position_keeping.transaction_cancelled.v1":     topicConfig.TransactionCancelledTopic,
-		"position_keeping.bulk_transaction_captured.v1": topicConfig.BulkTransactionCapturedTopic,
+		"position_keeping.transaction_captured.v1":        topicConfig.TransactionCapturedTopic,
+		"position_keeping.transaction_amended.v1":         topicConfig.TransactionAmendedTopic,
+		"position_keeping.transaction_reconciled.v1":      topicConfig.TransactionReconciledTopic,
+		"position_keeping.transaction_posted.v1":          topicConfig.TransactionPostedTopic,
+		"position_keeping.transaction_rejected.v1":        topicConfig.TransactionRejectedTopic,
+		"position_keeping.transaction_failed.v1":          topicConfig.TransactionFailedTopic,
+		"position_keeping.transaction_cancelled.v1":       topicConfig.TransactionCancelledTopic,
+		"position_keeping.bulk_transaction_captured.v1":   topicConfig.BulkTransactionCapturedTopic,
+		"position_keeping.position_log_status_changed.v1": topicConfig.PositionLogStatusChangedTopic,
 	}
 
 	return &KafkaEventPublisher{

--- a/services/position-keeping/domain/control_action.go
+++ b/services/position-keeping/domain/control_action.go
@@ -1,0 +1,83 @@
+package domain
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	// ErrInvalidControlAction is returned when an invalid control action is attempted
+	ErrInvalidControlAction = errors.New("invalid control action")
+	// ErrCannotSuspend is returned when suspension is not allowed in current state
+	ErrCannotSuspend = errors.New("cannot suspend log in current state")
+	// ErrCannotResume is returned when resumption is not allowed in current state
+	ErrCannotResume = errors.New("cannot resume log in current state")
+	// ErrCannotTerminate is returned when termination is not allowed in current state
+	ErrCannotTerminate = errors.New("cannot terminate log in current state")
+	// ErrAlreadyTerminated is returned when attempting to modify a terminated log
+	ErrAlreadyTerminated = errors.New("log already terminated")
+	// ErrEmptyOperatorID is returned when operator ID is required but empty
+	ErrEmptyOperatorID = errors.New("operator ID cannot be empty")
+)
+
+// ControlAction represents the control operations for log lifecycle management.
+type ControlAction string
+
+// Control actions for log lifecycle management.
+const (
+	ControlActionUnspecified ControlAction = ""          // No action specified
+	ControlActionSuspend     ControlAction = "SUSPEND"   // Temporarily suspend log processing
+	ControlActionResume      ControlAction = "RESUME"    // Resume a suspended log
+	ControlActionTerminate   ControlAction = "TERMINATE" // Permanently terminate the log
+)
+
+// IsValid checks if the control action is valid.
+func (c ControlAction) IsValid() bool {
+	switch c {
+	case ControlActionSuspend, ControlActionResume, ControlActionTerminate:
+		return true
+	case ControlActionUnspecified:
+		return false
+	}
+	return false
+}
+
+// String returns the string representation of the control action.
+func (c ControlAction) String() string {
+	return string(c)
+}
+
+// StatusChangeEntry represents a single entry in the status change history.
+// This provides an audit trail for compliance tracking of all status changes.
+type StatusChangeEntry struct {
+	// PreviousStatus is the status before the change
+	PreviousStatus TransactionStatus
+	// NewStatus is the status after the change
+	NewStatus TransactionStatus
+	// Timestamp is when the status change occurred
+	Timestamp time.Time
+	// Reason provides context for the status change
+	Reason string
+	// OperatorID identifies who performed the status change
+	OperatorID string
+	// Action is the control action that triggered the change (if applicable)
+	Action ControlAction
+}
+
+// NewStatusChangeEntry creates a new StatusChangeEntry with validated fields.
+func NewStatusChangeEntry(
+	previousStatus TransactionStatus,
+	newStatus TransactionStatus,
+	reason string,
+	operatorID string,
+	action ControlAction,
+) *StatusChangeEntry {
+	return &StatusChangeEntry{
+		PreviousStatus: previousStatus,
+		NewStatus:      newStatus,
+		Timestamp:      time.Now().UTC(),
+		Reason:         reason,
+		OperatorID:     operatorID,
+		Action:         action,
+	}
+}

--- a/services/position-keeping/domain/control_action_test.go
+++ b/services/position-keeping/domain/control_action_test.go
@@ -1,0 +1,212 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestControlAction_IsValid(t *testing.T) {
+	tests := []struct {
+		name   string
+		action ControlAction
+		want   bool
+	}{
+		{"valid suspend", ControlActionSuspend, true},
+		{"valid resume", ControlActionResume, true},
+		{"valid terminate", ControlActionTerminate, true},
+		{"invalid unspecified", ControlActionUnspecified, false},
+		{"invalid empty", ControlAction(""), false},
+		{"invalid arbitrary", ControlAction("INVALID"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.action.IsValid(); got != tt.want {
+				t.Errorf("ControlAction.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestControlAction_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		action   ControlAction
+		expected string
+	}{
+		{"suspend", ControlActionSuspend, "SUSPEND"},
+		{"resume", ControlActionResume, "RESUME"},
+		{"terminate", ControlActionTerminate, "TERMINATE"},
+		{"unspecified", ControlActionUnspecified, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.action.String(); got != tt.expected {
+				t.Errorf("ControlAction.String() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewStatusChangeEntry(t *testing.T) {
+	beforeCreate := time.Now().UTC()
+
+	entry := NewStatusChangeEntry(
+		TransactionStatusPending,
+		TransactionStatusSuspended,
+		"System maintenance",
+		"operator-123",
+		ControlActionSuspend,
+	)
+
+	afterCreate := time.Now().UTC()
+
+	if entry.PreviousStatus != TransactionStatusPending {
+		t.Errorf("Expected PreviousStatus %v, got %v", TransactionStatusPending, entry.PreviousStatus)
+	}
+
+	if entry.NewStatus != TransactionStatusSuspended {
+		t.Errorf("Expected NewStatus %v, got %v", TransactionStatusSuspended, entry.NewStatus)
+	}
+
+	if entry.Reason != "System maintenance" {
+		t.Errorf("Expected Reason 'System maintenance', got %v", entry.Reason)
+	}
+
+	if entry.OperatorID != "operator-123" {
+		t.Errorf("Expected OperatorID 'operator-123', got %v", entry.OperatorID)
+	}
+
+	if entry.Action != ControlActionSuspend {
+		t.Errorf("Expected Action %v, got %v", ControlActionSuspend, entry.Action)
+	}
+
+	if entry.Timestamp.Before(beforeCreate) || entry.Timestamp.After(afterCreate) {
+		t.Errorf("Timestamp %v should be between %v and %v", entry.Timestamp, beforeCreate, afterCreate)
+	}
+
+	if entry.Timestamp.Location() != time.UTC {
+		t.Errorf("Timestamp should be UTC, got %v", entry.Timestamp.Location())
+	}
+}
+
+func TestTransactionStatus_CanSuspend(t *testing.T) {
+	tests := []struct {
+		name   string
+		status TransactionStatus
+		want   bool
+	}{
+		{"pending can suspend", TransactionStatusPending, true},
+		{"reconciled can suspend", TransactionStatusReconciled, true},
+		{"amended can suspend", TransactionStatusAmended, true},
+		{"posted can suspend", TransactionStatusPosted, true},
+		{"failed cannot suspend", TransactionStatusFailed, false},
+		{"rejected cannot suspend", TransactionStatusRejected, false},
+		{"cancelled cannot suspend", TransactionStatusCancelled, false},
+		{"reversed cannot suspend", TransactionStatusReversed, false},
+		{"suspended cannot suspend again", TransactionStatusSuspended, false},
+		{"terminated cannot suspend", TransactionStatusTerminated, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.CanSuspend(); got != tt.want {
+				t.Errorf("TransactionStatus.CanSuspend() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransactionStatus_CanResume(t *testing.T) {
+	tests := []struct {
+		name   string
+		status TransactionStatus
+		want   bool
+	}{
+		{"suspended can resume", TransactionStatusSuspended, true},
+		{"pending cannot resume", TransactionStatusPending, false},
+		{"posted cannot resume", TransactionStatusPosted, false},
+		{"terminated cannot resume", TransactionStatusTerminated, false},
+		{"failed cannot resume", TransactionStatusFailed, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.CanResume(); got != tt.want {
+				t.Errorf("TransactionStatus.CanResume() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransactionStatus_CanTerminate(t *testing.T) {
+	tests := []struct {
+		name   string
+		status TransactionStatus
+		want   bool
+	}{
+		{"suspended can terminate", TransactionStatusSuspended, true},
+		{"pending cannot terminate", TransactionStatusPending, false},
+		{"posted cannot terminate", TransactionStatusPosted, false},
+		{"terminated cannot terminate again", TransactionStatusTerminated, false},
+		{"failed cannot terminate", TransactionStatusFailed, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.CanTerminate(); got != tt.want {
+				t.Errorf("TransactionStatus.CanTerminate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransactionStatus_SuspendedTransitions(t *testing.T) {
+	suspended := TransactionStatusSuspended
+
+	tests := []struct {
+		name   string
+		target TransactionStatus
+		want   bool
+	}{
+		{"can resume to pending", TransactionStatusPending, true},
+		{"can resume to reconciled", TransactionStatusReconciled, true},
+		{"can resume to posted", TransactionStatusPosted, true},
+		{"can terminate", TransactionStatusTerminated, true},
+		{"cannot go to failed", TransactionStatusFailed, false},
+		{"cannot go to rejected", TransactionStatusRejected, false},
+		{"cannot stay suspended", TransactionStatusSuspended, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := suspended.CanTransitionTo(tt.target); got != tt.want {
+				t.Errorf("SUSPENDED.CanTransitionTo(%v) = %v, want %v", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransactionStatus_TerminatedIsFinal(t *testing.T) {
+	terminated := TransactionStatusTerminated
+
+	if !terminated.IsFinal() {
+		t.Error("TERMINATED should be a final state")
+	}
+
+	// TERMINATED cannot transition to any state
+	targets := []TransactionStatus{
+		TransactionStatusPending,
+		TransactionStatusReconciled,
+		TransactionStatusPosted,
+		TransactionStatusFailed,
+		TransactionStatusSuspended,
+	}
+
+	for _, target := range targets {
+		if terminated.CanTransitionTo(target) {
+			t.Errorf("TERMINATED should not be able to transition to %v", target)
+		}
+	}
+}

--- a/services/position-keeping/domain/control_log_test.go
+++ b/services/position-keeping/domain/control_log_test.go
@@ -1,0 +1,363 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFinancialPositionLog_ControlLog_Suspend(t *testing.T) {
+	t.Run("suspend from pending", func(t *testing.T) {
+		log, err := NewFinancialPositionLog("ACC-001", nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create log: %v", err)
+		}
+
+		initialVersion := log.Version
+
+		err = log.ControlLog(ControlActionSuspend, "System maintenance", "operator-123")
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if log.StatusTracking.CurrentStatus != TransactionStatusSuspended {
+			t.Errorf("Expected status SUSPENDED, got %v", log.StatusTracking.CurrentStatus)
+		}
+
+		if log.PreSuspendStatus == nil || *log.PreSuspendStatus != TransactionStatusPending {
+			t.Error("Expected PreSuspendStatus to be PENDING")
+		}
+
+		if log.Version != initialVersion+1 {
+			t.Errorf("Expected version %d, got %d", initialVersion+1, log.Version)
+		}
+
+		if log.StatusHistoryCount() != 1 {
+			t.Errorf("Expected 1 status history entry, got %d", log.StatusHistoryCount())
+		}
+
+		history := log.GetStatusHistory()
+		if history[0].Action != ControlActionSuspend {
+			t.Errorf("Expected action SUSPEND, got %v", history[0].Action)
+		}
+		if history[0].OperatorID != "operator-123" {
+			t.Errorf("Expected operator 'operator-123', got %v", history[0].OperatorID)
+		}
+	})
+
+	t.Run("suspend from posted", func(t *testing.T) {
+		log, err := NewFinancialPositionLog("ACC-001", nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create log: %v", err)
+		}
+
+		// Move to posted state
+		err = log.StatusTracking.UpdateStatus(TransactionStatusPosted, "All balanced")
+		if err != nil {
+			t.Fatalf("Failed to update status: %v", err)
+		}
+
+		err = log.ControlLog(ControlActionSuspend, "Investigation required", "operator-456")
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if log.StatusTracking.CurrentStatus != TransactionStatusSuspended {
+			t.Errorf("Expected status SUSPENDED, got %v", log.StatusTracking.CurrentStatus)
+		}
+
+		if log.PreSuspendStatus == nil || *log.PreSuspendStatus != TransactionStatusPosted {
+			t.Error("Expected PreSuspendStatus to be POSTED")
+		}
+	})
+
+	t.Run("cannot suspend from failed", func(t *testing.T) {
+		log, err := NewFinancialPositionLog("ACC-001", nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create log: %v", err)
+		}
+
+		// Move to failed state
+		err = log.StatusTracking.MarkFailed("Validation error")
+		if err != nil {
+			t.Fatalf("Failed to update status: %v", err)
+		}
+
+		err = log.ControlLog(ControlActionSuspend, "Cannot happen", "operator-123")
+		if !errors.Is(err, ErrCannotSuspend) {
+			t.Errorf("Expected ErrCannotSuspend, got: %v", err)
+		}
+	})
+
+	t.Run("cannot suspend with empty operator ID", func(t *testing.T) {
+		log, err := NewFinancialPositionLog("ACC-001", nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create log: %v", err)
+		}
+
+		err = log.ControlLog(ControlActionSuspend, "Reason", "")
+		if !errors.Is(err, ErrEmptyOperatorID) {
+			t.Errorf("Expected ErrEmptyOperatorID, got: %v", err)
+		}
+	})
+}
+
+func TestFinancialPositionLog_ControlLog_Resume(t *testing.T) {
+	t.Run("resume to original status", func(t *testing.T) {
+		log, err := NewFinancialPositionLog("ACC-001", nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create log: %v", err)
+		}
+
+		// Suspend first
+		err = log.ControlLog(ControlActionSuspend, "Maintenance", "operator-1")
+		if err != nil {
+			t.Fatalf("Failed to suspend: %v", err)
+		}
+
+		// Resume
+		err = log.ControlLog(ControlActionResume, "Maintenance complete", "operator-2")
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if log.StatusTracking.CurrentStatus != TransactionStatusPending {
+			t.Errorf("Expected status PENDING (original), got %v", log.StatusTracking.CurrentStatus)
+		}
+
+		if log.PreSuspendStatus != nil {
+			t.Error("Expected PreSuspendStatus to be nil after resume")
+		}
+
+		if log.StatusHistoryCount() != 2 {
+			t.Errorf("Expected 2 status history entries, got %d", log.StatusHistoryCount())
+		}
+	})
+
+	t.Run("cannot resume from non-suspended state", func(t *testing.T) {
+		log, err := NewFinancialPositionLog("ACC-001", nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create log: %v", err)
+		}
+
+		err = log.ControlLog(ControlActionResume, "Cannot happen", "operator-123")
+		if !errors.Is(err, ErrCannotResume) {
+			t.Errorf("Expected ErrCannotResume, got: %v", err)
+		}
+	})
+}
+
+func TestFinancialPositionLog_ControlLog_Terminate(t *testing.T) {
+	t.Run("terminate from suspended", func(t *testing.T) {
+		log, err := NewFinancialPositionLog("ACC-001", nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create log: %v", err)
+		}
+
+		// Suspend first
+		err = log.ControlLog(ControlActionSuspend, "Maintenance", "operator-1")
+		if err != nil {
+			t.Fatalf("Failed to suspend: %v", err)
+		}
+
+		// Terminate
+		err = log.ControlLog(ControlActionTerminate, "No longer needed", "operator-2")
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if log.StatusTracking.CurrentStatus != TransactionStatusTerminated {
+			t.Errorf("Expected status TERMINATED, got %v", log.StatusTracking.CurrentStatus)
+		}
+
+		if !log.IsTerminated() {
+			t.Error("Expected IsTerminated() to return true")
+		}
+
+		if log.StatusHistoryCount() != 2 {
+			t.Errorf("Expected 2 status history entries, got %d", log.StatusHistoryCount())
+		}
+	})
+
+	t.Run("cannot terminate from non-suspended state", func(t *testing.T) {
+		log, err := NewFinancialPositionLog("ACC-001", nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create log: %v", err)
+		}
+
+		err = log.ControlLog(ControlActionTerminate, "Cannot happen", "operator-123")
+		if !errors.Is(err, ErrCannotTerminate) {
+			t.Errorf("Expected ErrCannotTerminate, got: %v", err)
+		}
+	})
+
+	t.Run("terminated is truly terminal", func(t *testing.T) {
+		log, err := NewFinancialPositionLog("ACC-001", nil, nil)
+		if err != nil {
+			t.Fatalf("Failed to create log: %v", err)
+		}
+
+		// Suspend and terminate
+		_ = log.ControlLog(ControlActionSuspend, "Maintenance", "operator-1")
+		_ = log.ControlLog(ControlActionTerminate, "No longer needed", "operator-2")
+
+		// Try to suspend again
+		err = log.ControlLog(ControlActionSuspend, "Should fail", "operator-3")
+		if !errors.Is(err, ErrAlreadyTerminated) {
+			t.Errorf("Expected ErrAlreadyTerminated, got: %v", err)
+		}
+
+		// Try to resume
+		err = log.ControlLog(ControlActionResume, "Should fail", "operator-3")
+		if !errors.Is(err, ErrAlreadyTerminated) {
+			t.Errorf("Expected ErrAlreadyTerminated, got: %v", err)
+		}
+
+		// Try to terminate again
+		err = log.ControlLog(ControlActionTerminate, "Should fail", "operator-3")
+		if !errors.Is(err, ErrAlreadyTerminated) {
+			t.Errorf("Expected ErrAlreadyTerminated, got: %v", err)
+		}
+	})
+}
+
+func TestFinancialPositionLog_ControlLog_InvalidAction(t *testing.T) {
+	log, err := NewFinancialPositionLog("ACC-001", nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to create log: %v", err)
+	}
+
+	err = log.ControlLog(ControlAction("INVALID"), "Reason", "operator-123")
+	if !errors.Is(err, ErrInvalidControlAction) {
+		t.Errorf("Expected ErrInvalidControlAction, got: %v", err)
+	}
+
+	err = log.ControlLog(ControlActionUnspecified, "Reason", "operator-123")
+	if !errors.Is(err, ErrInvalidControlAction) {
+		t.Errorf("Expected ErrInvalidControlAction for unspecified, got: %v", err)
+	}
+}
+
+func TestFinancialPositionLog_ConvenienceMethods(t *testing.T) {
+	t.Run("Suspend convenience method", func(t *testing.T) {
+		log, _ := NewFinancialPositionLog("ACC-001", nil, nil)
+		err := log.Suspend("Maintenance", "operator-1")
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if !log.IsSuspended() {
+			t.Error("Expected log to be suspended")
+		}
+	})
+
+	t.Run("Resume convenience method", func(t *testing.T) {
+		log, _ := NewFinancialPositionLog("ACC-001", nil, nil)
+		_ = log.Suspend("Maintenance", "operator-1")
+		err := log.Resume("Complete", "operator-2")
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if log.IsSuspended() {
+			t.Error("Expected log to not be suspended after resume")
+		}
+	})
+
+	t.Run("Terminate convenience method", func(t *testing.T) {
+		log, _ := NewFinancialPositionLog("ACC-001", nil, nil)
+		_ = log.Suspend("Maintenance", "operator-1")
+		err := log.Terminate("No longer needed", "operator-2")
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if !log.IsTerminated() {
+			t.Error("Expected log to be terminated")
+		}
+	})
+}
+
+func TestFinancialPositionLog_StatusHistory_AuditTrail(t *testing.T) {
+	log, _ := NewFinancialPositionLog("ACC-001", nil, nil)
+
+	// Perform a series of control actions
+	_ = log.Suspend("First suspension", "op-1")
+	_ = log.Resume("First resume", "op-2")
+	_ = log.Suspend("Second suspension", "op-3")
+	_ = log.Terminate("Final termination", "op-4")
+
+	history := log.GetStatusHistory()
+
+	if len(history) != 4 {
+		t.Fatalf("Expected 4 history entries, got %d", len(history))
+	}
+
+	// Verify first entry
+	if history[0].PreviousStatus != TransactionStatusPending {
+		t.Errorf("Entry 0: expected previous PENDING, got %v", history[0].PreviousStatus)
+	}
+	if history[0].NewStatus != TransactionStatusSuspended {
+		t.Errorf("Entry 0: expected new SUSPENDED, got %v", history[0].NewStatus)
+	}
+	if history[0].Action != ControlActionSuspend {
+		t.Errorf("Entry 0: expected action SUSPEND, got %v", history[0].Action)
+	}
+	if history[0].OperatorID != "op-1" {
+		t.Errorf("Entry 0: expected operator 'op-1', got %v", history[0].OperatorID)
+	}
+
+	// Verify timestamps are in order
+	for i := 1; i < len(history); i++ {
+		if history[i].Timestamp.Before(history[i-1].Timestamp) {
+			t.Errorf("Entry %d timestamp should be after entry %d", i, i-1)
+		}
+	}
+
+	// Verify last entry is termination
+	last := history[len(history)-1]
+	if last.NewStatus != TransactionStatusTerminated {
+		t.Errorf("Last entry should be TERMINATED, got %v", last.NewStatus)
+	}
+}
+
+func TestFinancialPositionLog_GetStatusHistory_DefensiveCopy(t *testing.T) {
+	log, _ := NewFinancialPositionLog("ACC-001", nil, nil)
+	_ = log.Suspend("Test", "op-1")
+
+	firstCopy := log.GetStatusHistory()
+	secondCopy := log.GetStatusHistory()
+
+	// Modify first copy
+	firstCopy[0] = nil
+
+	// Second copy should be unaffected
+	if secondCopy[0] == nil {
+		t.Error("Modifying one copy should not affect another")
+	}
+}
+
+func TestFinancialPositionLog_CanTransitionTo(t *testing.T) {
+	t.Run("valid transition returns nil", func(t *testing.T) {
+		log, _ := NewFinancialPositionLog("ACC-001", nil, nil)
+		err := log.CanTransitionTo(TransactionStatusSuspended)
+		if err != nil {
+			t.Errorf("Expected no error for valid transition, got: %v", err)
+		}
+	})
+
+	t.Run("invalid transition returns error", func(t *testing.T) {
+		log, _ := NewFinancialPositionLog("ACC-001", nil, nil)
+		err := log.CanTransitionTo(TransactionStatusReversed)
+		if !errors.Is(err, ErrInvalidStatusTransition) {
+			t.Errorf("Expected ErrInvalidStatusTransition, got: %v", err)
+		}
+	})
+
+	t.Run("terminated returns ErrAlreadyTerminated", func(t *testing.T) {
+		log, _ := NewFinancialPositionLog("ACC-001", nil, nil)
+		_ = log.Suspend("Test", "op-1")
+		_ = log.Terminate("Test", "op-1")
+
+		err := log.CanTransitionTo(TransactionStatusPending)
+		if !errors.Is(err, ErrAlreadyTerminated) {
+			t.Errorf("Expected ErrAlreadyTerminated, got: %v", err)
+		}
+	})
+}

--- a/services/position-keeping/domain/events.go
+++ b/services/position-keeping/domain/events.go
@@ -374,6 +374,52 @@ func (e *BulkTransactionCaptured) ToProto() interface{} {
 	}
 }
 
+// PositionLogStatusChanged represents a domain event when a position log status changes.
+// Published when control actions (SUSPEND, RESUME, TERMINATE) are applied.
+type PositionLogStatusChanged struct {
+	LogID          uuid.UUID
+	AccountID      string
+	PreviousStatus TransactionStatus
+	NewStatus      TransactionStatus
+	ControlAction  ControlAction
+	Reason         string
+	OperatorID     string
+	CorrelationID  string
+	Timestamp      time.Time
+	Version        int64
+}
+
+// EventType returns the event type identifier.
+func (e *PositionLogStatusChanged) EventType() string {
+	return "position_keeping.position_log_status_changed.v1"
+}
+
+// AggregateID returns the log ID as the aggregate identifier.
+func (e *PositionLogStatusChanged) AggregateID() string {
+	return e.LogID.String()
+}
+
+// OccurredAt returns when the event occurred.
+func (e *PositionLogStatusChanged) OccurredAt() time.Time {
+	return e.Timestamp
+}
+
+// ToProto converts to protobuf representation.
+func (e *PositionLogStatusChanged) ToProto() interface{} {
+	return &eventsv1.PositionLogStatusChangedEvent{
+		LogId:          e.LogID.String(),
+		AccountId:      e.AccountID,
+		PreviousStatus: e.PreviousStatus.String(),
+		NewStatus:      e.NewStatus.String(),
+		ControlAction:  e.ControlAction.String(),
+		Reason:         e.Reason,
+		OperatorId:     e.OperatorID,
+		CorrelationId:  e.CorrelationID,
+		Timestamp:      timestamppb.New(e.Timestamp),
+		Version:        e.Version,
+	}
+}
+
 // Helper functions for conversions
 
 func currencyToProto(currency Currency) commonv1.Currency {

--- a/services/position-keeping/domain/financial_position_log.go
+++ b/services/position-keeping/domain/financial_position_log.go
@@ -40,7 +40,7 @@ const (
 // in concurrent scenarios. The persistence layer should use this field in UPDATE
 // statements (e.g., WHERE log_id = ? AND version = ?) to detect conflicts.
 // The Version is incremented by all state-changing lifecycle methods that modify
-// StatusTracking (MarkReconciled, MarkPosted, Reject, Amend, Fail, Cancel).
+// StatusTracking (MarkReconciled, MarkPosted, Reject, Amend, Fail, Cancel, ControlLog).
 // AddEntry does NOT increment Version as it represents accumulation within a draft
 // state rather than a lifecycle state transition.
 type FinancialPositionLog struct {
@@ -50,9 +50,12 @@ type FinancialPositionLog struct {
 	TransactionLineage    *TransactionLineage
 	AuditTrail            []*AuditTrailEntry
 	StatusTracking        *StatusTracking
+	StatusHistory         []*StatusChangeEntry // Audit trail for status changes
 	CreatedAt             time.Time
 	UpdatedAt             time.Time
 	Version               int64 // Optimistic lock version, incremented on status transitions
+	// PreSuspendStatus stores the status before suspension to enable proper resumption
+	PreSuspendStatus *TransactionStatus
 }
 
 // NewFinancialPositionLog creates a FinancialPositionLog for the given account, initializing identifiers, timestamps, version, empty entry and audit collections, and status tracking.
@@ -75,9 +78,11 @@ func NewFinancialPositionLog(
 		TransactionLineage:    lineage,
 		AuditTrail:            make([]*AuditTrailEntry, 0),
 		StatusTracking:        NewStatusTracking(),
+		StatusHistory:         make([]*StatusChangeEntry, 0),
 		CreatedAt:             now,
 		UpdatedAt:             now,
 		Version:               1,
+		PreSuspendStatus:      nil,
 	}
 
 	// Add initial entry if provided
@@ -349,4 +354,162 @@ func (l *FinancialPositionLog) EntryCount() int {
 // AuditEntryCount returns the number of audit entries in the log.
 func (l *FinancialPositionLog) AuditEntryCount() int {
 	return len(l.AuditTrail)
+}
+
+// StatusHistoryCount returns the number of status history entries in the log.
+func (l *FinancialPositionLog) StatusHistoryCount() int {
+	return len(l.StatusHistory)
+}
+
+// GetStatusHistory returns a defensive copy of the status history.
+func (l *FinancialPositionLog) GetStatusHistory() []*StatusChangeEntry {
+	if l.StatusHistory == nil {
+		return []*StatusChangeEntry{}
+	}
+	result := make([]*StatusChangeEntry, len(l.StatusHistory))
+	copy(result, l.StatusHistory)
+	return result
+}
+
+// CanTransitionTo checks if the log can transition to the target status.
+func (l *FinancialPositionLog) CanTransitionTo(target TransactionStatus) error {
+	// Check if already terminated
+	if l.StatusTracking.CurrentStatus == TransactionStatusTerminated {
+		return ErrAlreadyTerminated
+	}
+
+	if !l.StatusTracking.CurrentStatus.CanTransitionTo(target) {
+		return ErrInvalidStatusTransition
+	}
+
+	return nil
+}
+
+// ControlLog applies a control action (SUSPEND, RESUME, TERMINATE) to the log.
+// It validates the transition using the state machine, updates status, and records
+// the change in both the audit trail and status history for compliance tracking.
+//
+// Parameters:
+//   - action: The control action to apply (SUSPEND, RESUME, TERMINATE)
+//   - reason: Context explaining why the action is being performed
+//   - operatorID: Identifier of who is performing the action (required)
+//
+// Returns an error if:
+//   - The action is invalid
+//   - The operator ID is empty
+//   - The current state does not allow the requested action
+func (l *FinancialPositionLog) ControlLog(
+	action ControlAction,
+	reason string,
+	operatorID string,
+) error {
+	// Validate action
+	if !action.IsValid() {
+		return ErrInvalidControlAction
+	}
+
+	// Validate operator ID
+	if operatorID == "" {
+		return ErrEmptyOperatorID
+	}
+
+	// Check if already terminated
+	if l.StatusTracking.CurrentStatus == TransactionStatusTerminated {
+		return ErrAlreadyTerminated
+	}
+
+	var targetStatus TransactionStatus
+	var preSuspendStatus *TransactionStatus
+
+	switch action {
+	case ControlActionSuspend:
+		if !l.StatusTracking.CurrentStatus.CanSuspend() {
+			return ErrCannotSuspend
+		}
+		// Store the current status before suspension for later resumption
+		current := l.StatusTracking.CurrentStatus
+		preSuspendStatus = &current
+		targetStatus = TransactionStatusSuspended
+
+	case ControlActionResume:
+		if !l.StatusTracking.CurrentStatus.CanResume() {
+			return ErrCannotResume
+		}
+		// Determine what status to resume to
+		if l.PreSuspendStatus != nil {
+			targetStatus = *l.PreSuspendStatus
+		} else {
+			// Default to PENDING if no pre-suspend status recorded
+			targetStatus = TransactionStatusPending
+		}
+
+	case ControlActionTerminate:
+		if !l.StatusTracking.CurrentStatus.CanTerminate() {
+			return ErrCannotTerminate
+		}
+		targetStatus = TransactionStatusTerminated
+
+	case ControlActionUnspecified:
+		return ErrInvalidControlAction
+	}
+
+	// Record the status change in history before updating
+	previousStatus := l.StatusTracking.CurrentStatus
+	statusEntry := NewStatusChangeEntry(
+		previousStatus,
+		targetStatus,
+		reason,
+		operatorID,
+		action,
+	)
+	l.StatusHistory = append(l.StatusHistory, statusEntry)
+
+	// Update the pre-suspend status field
+	switch action {
+	case ControlActionSuspend:
+		l.PreSuspendStatus = preSuspendStatus
+	case ControlActionResume:
+		l.PreSuspendStatus = nil
+	case ControlActionTerminate, ControlActionUnspecified:
+		// No change to PreSuspendStatus
+	}
+
+	// Update status tracking - bypass normal validation since we already validated
+	l.StatusTracking.CurrentStatus = targetStatus
+	l.StatusTracking.PreviousStatus = &previousStatus
+	l.StatusTracking.StatusUpdatedAt = time.Now().UTC()
+	l.StatusTracking.StatusReason = reason
+
+	l.UpdatedAt = time.Now().UTC()
+	l.Version++
+
+	return nil
+}
+
+// Suspend temporarily suspends the log processing.
+// This is a convenience method that calls ControlLog with ControlActionSuspend.
+func (l *FinancialPositionLog) Suspend(reason string, operatorID string) error {
+	return l.ControlLog(ControlActionSuspend, reason, operatorID)
+}
+
+// Resume resumes a suspended log.
+// This is a convenience method that calls ControlLog with ControlActionResume.
+func (l *FinancialPositionLog) Resume(reason string, operatorID string) error {
+	return l.ControlLog(ControlActionResume, reason, operatorID)
+}
+
+// Terminate permanently terminates the log.
+// This is a convenience method that calls ControlLog with ControlActionTerminate.
+func (l *FinancialPositionLog) Terminate(reason string, operatorID string) error {
+	return l.ControlLog(ControlActionTerminate, reason, operatorID)
+}
+
+// IsSuspended returns true if the log is currently suspended.
+func (l *FinancialPositionLog) IsSuspended() bool {
+	return l.StatusTracking.CurrentStatus == TransactionStatusSuspended
+}
+
+// IsTerminated returns true if the log has been terminated.
+func (l *FinancialPositionLog) IsTerminated() bool {
+	return l.StatusTracking.CurrentStatus == TransactionStatusTerminated
 }

--- a/services/position-keeping/domain/financial_position_log_test.go
+++ b/services/position-keeping/domain/financial_position_log_test.go
@@ -933,6 +933,11 @@ func setLogToStatus(t *testing.T, log *FinancialPositionLog, targetStatus Transa
 		// REVERSED can only be reached from POSTED via StatusTracking.UpdateStatus
 		_ = log.MarkPosted("Setup", audit)
 		_ = log.StatusTracking.UpdateStatus(TransactionStatusReversed, "Setup reversal")
+	case TransactionStatusSuspended:
+		_ = log.Suspend("Setup suspension", "test-operator")
+	case TransactionStatusTerminated:
+		_ = log.Suspend("Setup suspension", "test-operator")
+		_ = log.Terminate("Setup termination", "test-operator")
 	}
 }
 

--- a/services/position-keeping/domain/transaction_status.go
+++ b/services/position-keeping/domain/transaction_status.go
@@ -13,6 +13,8 @@ const (
 	TransactionStatusAmended    TransactionStatus = "AMENDED"    // Transaction amended with new version
 	TransactionStatusCancelled  TransactionStatus = "CANCELLED"  // Transaction manually cancelled
 	TransactionStatusReversed   TransactionStatus = "REVERSED"   // Transaction reversed with offsetting entry
+	TransactionStatusSuspended  TransactionStatus = "SUSPENDED"  // Transaction processing temporarily suspended
+	TransactionStatusTerminated TransactionStatus = "TERMINATED" // Transaction permanently terminated
 )
 
 // IsValid checks if the transaction status is valid.
@@ -20,7 +22,8 @@ func (t TransactionStatus) IsValid() bool {
 	switch t {
 	case TransactionStatusPending, TransactionStatusReconciled, TransactionStatusPosted,
 		TransactionStatusFailed, TransactionStatusRejected, TransactionStatusAmended,
-		TransactionStatusCancelled, TransactionStatusReversed:
+		TransactionStatusCancelled, TransactionStatusReversed, TransactionStatusSuspended,
+		TransactionStatusTerminated:
 		return true
 	}
 	return false
@@ -37,7 +40,8 @@ func (t TransactionStatus) IsFinal() bool {
 		t == TransactionStatusFailed ||
 		t == TransactionStatusRejected ||
 		t == TransactionStatusCancelled ||
-		t == TransactionStatusReversed
+		t == TransactionStatusReversed ||
+		t == TransactionStatusTerminated
 }
 
 // CanTransitionTo checks if a transition to the target status is valid.
@@ -47,9 +51,22 @@ func (t TransactionStatus) CanTransitionTo(target TransactionStatus) bool {
 		return target == TransactionStatusReversed
 	}
 
-	// Other final states cannot transition
+	// TERMINATED is absolutely terminal - no transitions allowed
+	if t == TransactionStatusTerminated {
+		return false
+	}
+
+	// Other final states cannot transition (except POSTED handled above)
 	if t.IsFinal() {
 		return false
+	}
+
+	// SUSPENDED can transition back to original states or to TERMINATED
+	if t == TransactionStatusSuspended {
+		return target == TransactionStatusPending ||
+			target == TransactionStatusReconciled ||
+			target == TransactionStatusPosted ||
+			target == TransactionStatusTerminated
 	}
 
 	// Valid state transitions
@@ -60,16 +77,19 @@ func (t TransactionStatus) CanTransitionTo(target TransactionStatus) bool {
 			TransactionStatusFailed,
 			TransactionStatusRejected,
 			TransactionStatusCancelled,
+			TransactionStatusSuspended,
 		},
 		TransactionStatusReconciled: {
 			TransactionStatusPosted,
 			TransactionStatusAmended,
 			TransactionStatusRejected,
+			TransactionStatusSuspended,
 		},
 		TransactionStatusAmended: {
 			TransactionStatusReconciled,
 			TransactionStatusPosted,
 			TransactionStatusRejected,
+			TransactionStatusSuspended,
 		},
 	}
 
@@ -85,6 +105,28 @@ func (t TransactionStatus) CanTransitionTo(target TransactionStatus) bool {
 	}
 
 	return false
+}
+
+// CanSuspend checks if the current status allows suspension.
+// Only PENDING, RECONCILED, AMENDED, and POSTED states can be suspended.
+// FAILED, REJECTED, CANCELLED, REVERSED, and TERMINATED are not suspendable.
+func (t TransactionStatus) CanSuspend() bool {
+	return t == TransactionStatusPending ||
+		t == TransactionStatusReconciled ||
+		t == TransactionStatusAmended ||
+		t == TransactionStatusPosted
+}
+
+// CanResume checks if the current status allows resumption.
+// Only SUSPENDED status can be resumed.
+func (t TransactionStatus) CanResume() bool {
+	return t == TransactionStatusSuspended
+}
+
+// CanTerminate checks if the current status allows termination.
+// Only SUSPENDED status can be terminated.
+func (t TransactionStatus) CanTerminate() bool {
+	return t == TransactionStatusSuspended
 }
 
 // ParseTransactionStatus converts a string to TransactionStatus.

--- a/services/position-keeping/service/adapters.go
+++ b/services/position-keeping/service/adapters.go
@@ -184,7 +184,7 @@ func toProtoStatusTracking(tracking *domain.StatusTracking) *positionkeepingv1.S
 
 // toProtoTransactionStatus converts a domain TransactionStatus to protobuf.
 func toProtoTransactionStatus(status domain.TransactionStatus) commonv1.TransactionStatus {
-	switch status {
+	switch status { //nolint:exhaustive // SUSPENDED/TERMINATED don't have proto equivalents yet
 	case domain.TransactionStatusPending:
 		return commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING
 	case domain.TransactionStatusPosted:

--- a/services/position-keeping/service/control_test.go
+++ b/services/position-keeping/service/control_test.go
@@ -1,0 +1,341 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+)
+
+func TestControlFinancialPositionLog_Suspend(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+
+	logID := uuid.New()
+
+	// Create existing log in PENDING status
+	existingLog := &domain.FinancialPositionLog{
+		LogID:                 logID,
+		AccountID:             testAccountID,
+		TransactionLogEntries: []*domain.TransactionLogEntry{},
+		AuditTrail:            []*domain.AuditTrailEntry{},
+		StatusTracking:        domain.NewStatusTracking(),
+		CreatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		UpdatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		Version:               1,
+	}
+
+	req := &positionkeepingv1.ControlFinancialPositionLogRequest{
+		LogId:         logID.String(),
+		ControlAction: positionkeepingv1.ControlAction_CONTROL_ACTION_SUSPEND,
+		Reason:        "System maintenance",
+		OperatorId:    "admin@example.com",
+	}
+
+	// Mock repository FindByID
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+
+	// Mock repository Update
+	mockRepo.On("Update", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	// Act
+	resp, err := svc.ControlFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, logID.String(), resp.LogId)
+	assert.Equal(t, positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_SUSPENDED, resp.Status)
+	assert.Equal(t, positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_ACTIVE, resp.PreviousStatus)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestControlFinancialPositionLog_Resume(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+
+	logID := uuid.New()
+
+	// Create existing log in SUSPENDED status
+	suspendedTracking := domain.NewStatusTracking()
+	_ = suspendedTracking.UpdateStatus(domain.TransactionStatusSuspended, "Test suspended")
+	existingLog := &domain.FinancialPositionLog{
+		LogID:                 logID,
+		AccountID:             testAccountID,
+		TransactionLogEntries: []*domain.TransactionLogEntry{},
+		AuditTrail:            []*domain.AuditTrailEntry{},
+		StatusTracking:        suspendedTracking,
+		CreatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		UpdatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		Version:               1,
+	}
+
+	req := &positionkeepingv1.ControlFinancialPositionLogRequest{
+		LogId:         logID.String(),
+		ControlAction: positionkeepingv1.ControlAction_CONTROL_ACTION_RESUME,
+		Reason:        "Maintenance completed",
+		OperatorId:    "admin@example.com",
+	}
+
+	// Mock repository FindByID
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+
+	// Mock repository Update
+	mockRepo.On("Update", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	// Act
+	resp, err := svc.ControlFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, logID.String(), resp.LogId)
+	assert.Equal(t, positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_ACTIVE, resp.Status)
+	assert.Equal(t, positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_SUSPENDED, resp.PreviousStatus)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestControlFinancialPositionLog_Terminate(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+
+	logID := uuid.New()
+
+	// Create existing log in SUSPENDED status (terminate only works from SUSPENDED)
+	suspendedTracking := domain.NewStatusTracking()
+	_ = suspendedTracking.UpdateStatus(domain.TransactionStatusSuspended, "Test suspended")
+	existingLog := &domain.FinancialPositionLog{
+		LogID:                 logID,
+		AccountID:             testAccountID,
+		TransactionLogEntries: []*domain.TransactionLogEntry{},
+		AuditTrail:            []*domain.AuditTrailEntry{},
+		StatusTracking:        suspendedTracking,
+		CreatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		UpdatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		Version:               1,
+	}
+
+	req := &positionkeepingv1.ControlFinancialPositionLogRequest{
+		LogId:         logID.String(),
+		ControlAction: positionkeepingv1.ControlAction_CONTROL_ACTION_TERMINATE,
+		Reason:        "Account closure",
+		OperatorId:    "admin@example.com",
+	}
+
+	// Mock repository FindByID
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+
+	// Mock repository Update
+	mockRepo.On("Update", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	// Act
+	resp, err := svc.ControlFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, logID.String(), resp.LogId)
+	assert.Equal(t, positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_TERMINATED, resp.Status)
+	assert.Equal(t, positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_SUSPENDED, resp.PreviousStatus)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestControlFinancialPositionLog_NotFound(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+
+	logID := uuid.New()
+
+	req := &positionkeepingv1.ControlFinancialPositionLogRequest{
+		LogId:         logID.String(),
+		ControlAction: positionkeepingv1.ControlAction_CONTROL_ACTION_SUSPEND,
+		Reason:        "Test",
+		OperatorId:    "admin@example.com",
+	}
+
+	// Mock repository FindByID to return not found
+	mockRepo.On("FindByID", ctx, logID).Return(nil, domain.ErrNotFound)
+
+	// Act
+	resp, err := svc.ControlFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+	mockRepo.AssertExpectations(t)
+}
+
+func TestControlFinancialPositionLog_InvalidLogID(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+
+	req := &positionkeepingv1.ControlFinancialPositionLogRequest{
+		LogId:         "not-a-valid-uuid",
+		ControlAction: positionkeepingv1.ControlAction_CONTROL_ACTION_SUSPEND,
+		Reason:        "Test",
+		OperatorId:    "admin@example.com",
+	}
+
+	// Act
+	resp, err := svc.ControlFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestControlFinancialPositionLog_UnspecifiedAction(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+
+	req := &positionkeepingv1.ControlFinancialPositionLogRequest{
+		LogId:         uuid.New().String(),
+		ControlAction: positionkeepingv1.ControlAction_CONTROL_ACTION_UNSPECIFIED,
+		Reason:        "Test",
+		OperatorId:    "admin@example.com",
+	}
+
+	// Act
+	resp, err := svc.ControlFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestControlFinancialPositionLog_CannotResumeNonSuspendedLog(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+
+	logID := uuid.New()
+
+	// Create existing log in PENDING status (not SUSPENDED)
+	existingLog := &domain.FinancialPositionLog{
+		LogID:                 logID,
+		AccountID:             testAccountID,
+		TransactionLogEntries: []*domain.TransactionLogEntry{},
+		AuditTrail:            []*domain.AuditTrailEntry{},
+		StatusTracking:        domain.NewStatusTracking(), // PENDING
+		CreatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		UpdatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		Version:               1,
+	}
+
+	req := &positionkeepingv1.ControlFinancialPositionLogRequest{
+		LogId:         logID.String(),
+		ControlAction: positionkeepingv1.ControlAction_CONTROL_ACTION_RESUME,
+		Reason:        "Try to resume non-suspended log",
+		OperatorId:    "admin@example.com",
+	}
+
+	// Mock repository FindByID
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+
+	// Act
+	resp, err := svc.ControlFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	mockRepo.AssertExpectations(t)
+}
+
+func TestControlFinancialPositionLog_CannotSuspendTerminatedLog(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	svc := mustNewPositionKeepingService(t, mockRepo, mockEventPublisher, mockIdempotency)
+
+	logID := uuid.New()
+
+	// Create existing log in TERMINATED status
+	// Since TERMINATED is only reachable from SUSPENDED, we need to set it directly
+	terminatedTracking := &domain.StatusTracking{
+		CurrentStatus: domain.TransactionStatusTerminated,
+	}
+	existingLog := &domain.FinancialPositionLog{
+		LogID:                 logID,
+		AccountID:             testAccountID,
+		TransactionLogEntries: []*domain.TransactionLogEntry{},
+		AuditTrail:            []*domain.AuditTrailEntry{},
+		StatusTracking:        terminatedTracking,
+		CreatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		UpdatedAt:             time.Now().UTC().Add(-1 * time.Hour),
+		Version:               1,
+	}
+
+	req := &positionkeepingv1.ControlFinancialPositionLogRequest{
+		LogId:         logID.String(),
+		ControlAction: positionkeepingv1.ControlAction_CONTROL_ACTION_SUSPEND,
+		Reason:        "Try to suspend terminated log",
+		OperatorId:    "admin@example.com",
+	}
+
+	// Mock repository FindByID
+	mockRepo.On("FindByID", ctx, logID).Return(existingLog, nil)
+
+	// Act (no Update mock needed - domain model should reject before reaching Update)
+	resp, err := svc.ControlFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	mockRepo.AssertExpectations(t)
+}
+
+// mockIdempotencyService is defined in service_test.go and used in multiple test files
+// MockRepository is defined in service_test.go

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -8,6 +8,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
@@ -193,6 +194,134 @@ func (s *PositionKeepingService) ListFinancialPositionLogs(
 	return &positionkeepingv1.ListFinancialPositionLogsResponse{
 		Logs:       protoLogs,
 		Pagination: paginationResp,
+	}, nil
+}
+
+// ControlFinancialPositionLog controls the lifecycle of a financial position log.
+// Supports SUSPEND, RESUME, and TERMINATE actions for log processing lifecycle management.
+//
+// gRPC Error Codes:
+//   - codes.InvalidArgument: Invalid log_id format, unspecified control action, or invalid operator_id
+//   - codes.NotFound: Financial position log does not exist
+//   - codes.FailedPrecondition: Control action not allowed in current state
+//   - codes.Internal: Database or system errors
+func (s *PositionKeepingService) ControlFinancialPositionLog(
+	ctx context.Context,
+	req *positionkeepingv1.ControlFinancialPositionLogRequest,
+) (*positionkeepingv1.ControlFinancialPositionLogResponse, error) {
+	// Parse and validate log ID
+	logID, err := parseUUID(req.GetLogId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid log_id: %v", err)
+	}
+
+	// Map proto ControlAction to domain ControlAction
+	var domainAction domain.ControlAction
+	switch req.ControlAction {
+	case positionkeepingv1.ControlAction_CONTROL_ACTION_SUSPEND:
+		domainAction = domain.ControlActionSuspend
+	case positionkeepingv1.ControlAction_CONTROL_ACTION_RESUME:
+		domainAction = domain.ControlActionResume
+	case positionkeepingv1.ControlAction_CONTROL_ACTION_TERMINATE:
+		domainAction = domain.ControlActionTerminate
+	case positionkeepingv1.ControlAction_CONTROL_ACTION_UNSPECIFIED:
+		return nil, status.Error(codes.InvalidArgument, "control_action must be specified")
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unknown control_action: %v", req.ControlAction)
+	}
+
+	// Validate operator_id
+	operatorID := req.GetOperatorId()
+	if operatorID == "" {
+		operatorID = "system" // Default to system if not provided
+	}
+
+	// Retrieve position log from repository
+	log, err := s.repository.FindByID(ctx, logID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "financial position log not found: %s", logID)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to retrieve financial position log: %v", err)
+	}
+
+	// Capture previous status before the control action
+	previousStatus := log.StatusTracking.CurrentStatus
+
+	// Apply control action via domain model
+	if err := log.ControlLog(domainAction, req.GetReason(), operatorID); err != nil {
+		// Map domain errors to gRPC status codes
+		switch {
+		case errors.Is(err, domain.ErrInvalidControlAction):
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		case errors.Is(err, domain.ErrCannotSuspend):
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot suspend log in current state: %s", previousStatus)
+		case errors.Is(err, domain.ErrCannotResume):
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot resume log in current state: %s", previousStatus)
+		case errors.Is(err, domain.ErrCannotTerminate):
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot terminate log in current state: %s", previousStatus)
+		case errors.Is(err, domain.ErrAlreadyTerminated):
+			return nil, status.Error(codes.FailedPrecondition, "log already terminated")
+		case errors.Is(err, domain.ErrEmptyOperatorID):
+			return nil, status.Error(codes.InvalidArgument, "operator_id cannot be empty")
+		default:
+			return nil, status.Errorf(codes.Internal, "control action failed: %v", err)
+		}
+	}
+
+	// Persist updated log to database
+	if err := s.repository.Update(ctx, log); err != nil {
+		if errors.Is(err, domain.ErrOptimisticLock) {
+			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+		}
+		return nil, status.Errorf(codes.Internal, "failed to update financial position log: %v", err)
+	}
+
+	// Emit PositionLogStatusChanged event to Kafka
+	event := &domain.PositionLogStatusChanged{
+		LogID:          log.LogID,
+		AccountID:      log.AccountID,
+		PreviousStatus: previousStatus,
+		NewStatus:      log.StatusTracking.CurrentStatus,
+		ControlAction:  domainAction,
+		Reason:         req.GetReason(),
+		OperatorID:     operatorID,
+		CorrelationID:  logID.String(), // Use log ID as correlation ID
+		Timestamp:      time.Now().UTC(),
+		Version:        log.Version,
+	}
+	if err := s.eventPublisher.Publish(ctx, event); err != nil {
+		// Event publishing is best-effort - errors are logged but don't fail the operation
+		// The log has already been updated in the database
+		_ = err // Silence lint - TODO: Add structured logging with slog
+	}
+
+	// Map domain status to proto PositionLogStatus
+	var protoStatus positionkeepingv1.PositionLogStatus
+	var protoPreviousStatus positionkeepingv1.PositionLogStatus
+	switch log.StatusTracking.CurrentStatus { //nolint:exhaustive // Only mapping to 3 proto values
+	case domain.TransactionStatusSuspended:
+		protoStatus = positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_SUSPENDED
+	case domain.TransactionStatusTerminated:
+		protoStatus = positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_TERMINATED
+	default:
+		protoStatus = positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_ACTIVE
+	}
+
+	switch previousStatus { //nolint:exhaustive // Only mapping to 3 proto values
+	case domain.TransactionStatusSuspended:
+		protoPreviousStatus = positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_SUSPENDED
+	case domain.TransactionStatusTerminated:
+		protoPreviousStatus = positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_TERMINATED
+	default:
+		protoPreviousStatus = positionkeepingv1.PositionLogStatus_POSITION_LOG_STATUS_ACTIVE
+	}
+
+	return &positionkeepingv1.ControlFinancialPositionLogResponse{
+		LogId:          log.LogID.String(),
+		Status:         protoStatus,
+		Timestamp:      timestamppb.New(log.UpdatedAt),
+		PreviousStatus: protoPreviousStatus,
 	}, nil
 }
 

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -293,7 +294,11 @@ func (s *PositionKeepingService) ControlFinancialPositionLog(
 	if err := s.eventPublisher.Publish(ctx, event); err != nil {
 		// Event publishing is best-effort - errors are logged but don't fail the operation
 		// The log has already been updated in the database
-		_ = err // Silence lint - TODO: Add structured logging with slog
+		slog.Error("failed to publish PositionLogStatusChanged event",
+			"error", err,
+			"log_id", log.LogID.String(),
+			"previous_status", previousStatus,
+			"new_status", log.StatusTracking.CurrentStatus)
 	}
 
 	// Map domain status to proto PositionLogStatus

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -232,9 +232,14 @@ func (s *PositionKeepingService) ControlFinancialPositionLog(
 	}
 
 	// Validate operator_id
+	// Design Decision: operator_id defaults to "system" when empty to maintain backward
+	// compatibility with existing clients and to support system-initiated control actions
+	// (e.g., automated lifecycle management, scheduled suspensions). The domain layer
+	// validates ErrEmptyOperatorID, but this defaulting occurs before domain validation
+	// to handle the common case of system-initiated operations gracefully.
 	operatorID := req.GetOperatorId()
 	if operatorID == "" {
-		operatorID = "system" // Default to system if not provided
+		operatorID = "system"
 	}
 
 	// Retrieve position log from repository

--- a/services/position-keeping/service/update.go
+++ b/services/position-keeping/service/update.go
@@ -235,7 +235,7 @@ func applyStatusTransition(ctx context.Context, log *domain.FinancialPositionLog
 		return status.Errorf(codes.InvalidArgument, "invalid audit_entry: %v", err)
 	}
 
-	switch newStatus {
+	switch newStatus { //nolint:exhaustive // SUSPENDED/TERMINATED handled via ControlFinancialPositionLog
 	case domain.TransactionStatusPosted:
 		if err := log.MarkPosted(req.StatusUpdate.StatusReason, auditEntry); err != nil {
 			return status.Errorf(codes.InvalidArgument, "failed to mark as posted: %v", err)


### PR DESCRIPTION
## Summary
- Implement BIAN Control (CoCR) operations enabling suspend/resume/terminate lifecycle management for financial position logs and booking logs
- Add state machine validation, audit trail support, and Kafka event emission for operational compliance
- Integrate with Current Account saga for graceful failure handling during maintenance windows

## Task Master Reference
- **Tag**: bian-alignment
- **Task ID**: 9

## Changes Made
- **Proto Definitions** (`3d103eb`): Added ControlAction enum (SUSPEND, RESUME, TERMINATE), extended status enums with SUSPENDED/TERMINATED states, added ControlFinancialPositionLog and ControlFinancialBookingLog RPC methods with HTTP annotations
- **Domain State Machine** (`7746083`): Extended domain models with state machine validation, StatusHistory audit trail, and ControlLog methods. Added SUSPENDED/TERMINATED states with proper transition rules
- **Service Integration** (`bf05265`): Implemented gRPC handlers for control operations, Kafka event emission, validation in CaptureLedgerPosting to block suspended logs, and Current Account saga integration for graceful failure handling

## Test Plan
- Unit tests for state machine transitions (valid and invalid)
- Unit tests for service handlers (happy path, NotFound, FailedPrecondition)
- Integration tests for suspended log blocking and saga graceful failure
- Proto validation with buf lint and buf breaking