### PR TITLE
fix: correct Prometheus metric names in audit documentation

### DIFF
--- a/docs/adr/0009-application-level-audit-logging.md
+++ b/docs/adr/0009-application-level-audit-logging.md
@@ -788,10 +788,10 @@ The async audit system has been fully implemented across all 6 services with a d
 ### Monitoring
 
 Prometheus metrics exposed:
-- `meridian_audit_kafka_events_published_total` - Primary path usage
-- `meridian_audit_kafka_fallback_total` - Fallback path usage
-- `meridian_audit_outbox_depth_total` - Outbox queue depth
-- `meridian_audit_consumer_messages_processed_total` - Consumer throughput
+- `meridian_audit_kafka_events_published_total` - Primary path usage (counter)
+- `meridian_audit_kafka_fallback_used_total` - Fallback path usage (counter)
+- `meridian_audit_worker_outbox_depth` - Outbox queue depth (gauge)
+- `meridian_audit_kafka_events_consumed_total` - Consumer throughput (counter)
 
 ## Decision Review
 

--- a/services/audit-worker/README.md
+++ b/services/audit-worker/README.md
@@ -38,7 +38,7 @@ entries written during Kafka outages.
 
 **Worker-specific metrics:**
 
-- `meridian_audit_worker_outbox_depth_total` - Current number of entries in outbox (gauge)
+- `meridian_audit_worker_outbox_depth` - Current number of entries in outbox (gauge)
 - `meridian_audit_worker_outbox_processed_total` - Total entries processed (counter)
 - `meridian_audit_worker_outbox_failed_total` - Total entries failed (counter)
 - `meridian_audit_worker_processing_duration_seconds` - Batch processing duration (histogram)
@@ -46,13 +46,13 @@ entries written during Kafka outages.
 
 **System-wide metrics** (for overall audit health):
 
-- `meridian_audit_kafka_events_published_total` - Primary path usage (Kafka)
-- `meridian_audit_kafka_fallback_total` - Fallback path activations
-- `meridian_audit_consumer_messages_processed_total` - Consumer throughput
+- `meridian_audit_kafka_events_published_total` - Primary path usage (Kafka) (counter)
+- `meridian_audit_kafka_fallback_used_total` - Fallback path activations (counter)
+- `meridian_audit_kafka_events_consumed_total` - Consumer throughput (counter)
 
 **Alerting thresholds:**
 
-- Alert if `outbox_depth_total` > 1000 for 5 minutes (indicates Kafka outage or worker lag)
+- Alert if `meridian_audit_worker_outbox_depth` > 1000 for 5 minutes (indicates Kafka outage or worker lag)
 - Alert if `entry_age_seconds` p99 > 60s (indicates processing delays)
 
 See [ADR-0009](../../docs/adr/0009-application-level-audit-logging.md) for complete Prometheus metrics

--- a/shared/platform/audit/README.md
+++ b/shared/platform/audit/README.md
@@ -215,10 +215,10 @@ For operators monitoring the audit system, see:
 
 **Key Prometheus metrics:**
 
-- `meridian_audit_kafka_events_published_total` - Primary path usage (Kafka)
-- `meridian_audit_kafka_fallback_total` - Fallback path activations
-- `meridian_audit_outbox_depth_total` - Queue depth (alert if > 1000)
-- `meridian_audit_consumer_messages_processed_total` - Consumer throughput
+- `meridian_audit_kafka_events_published_total` - Primary path usage (Kafka) (counter)
+- `meridian_audit_kafka_fallback_used_total` - Fallback path activations (counter)
+- `meridian_audit_worker_outbox_depth` - Queue depth (gauge, alert if > 1000)
+- `meridian_audit_kafka_events_consumed_total` - Consumer throughput (counter)
 
 See ADR-0009 for complete metrics reference and alerting thresholds.
 


### PR DESCRIPTION
## Summary

Follow-up fix to PR #416 - corrects Prometheus metric names in audit documentation to match the actual implementation in `shared/platform/audit/metrics.go`.

## Changes

| Incorrect | Correct |
|-----------|---------|
| `meridian_audit_worker_outbox_depth_total` | `meridian_audit_worker_outbox_depth` (gauge) |
| `meridian_audit_kafka_fallback_total` | `meridian_audit_kafka_fallback_used_total` |
| `meridian_audit_consumer_messages_processed_total` | `meridian_audit_kafka_events_consumed_total` |
| `meridian_audit_outbox_depth_total` | `meridian_audit_worker_outbox_depth` (gauge) |

## Files Updated

- `docs/adr/0009-application-level-audit-logging.md`
- `services/audit-worker/README.md`
- `shared/platform/audit/README.md`

## Test Plan

- Verified metric names match definitions in `shared/platform/audit/metrics.go`
- markdownlint passed