### PR TITLE
feat(auth): add tenant context validation in auth interceptor

### DIFF
--- a/shared/pkg/interceptors/doc.go
+++ b/shared/pkg/interceptors/doc.go
@@ -20,8 +20,29 @@
 //
 //  1. Metrics (first to capture all requests)
 //  2. Tracing (for observability)
-//  3. Auth (authentication/authorization)
+//  3. Auth (authentication/authorization) - see SECURITY NOTE below
 //  4. Recovery (last to catch all panics from above layers)
+//
+// # SECURITY NOTE: Tenant Context Validation
+//
+// The auth package provides two complementary interceptors for tenant context:
+//
+//   - auth.Interceptor.UnaryInterceptor(): Validates JWT and extracts tenant_id claim.
+//     ALSO validates that x-tenant-id header (if present) matches the JWT tenant claim.
+//     This prevents cross-tenant attacks where a user with a valid JWT for tenant A
+//     attempts to access tenant B's resources via header manipulation.
+//
+//   - auth.TenantExtractionInterceptor(): Extracts tenant from x-tenant-id header ONLY.
+//     Used when auth is disabled (development/testing). Does NOT validate against JWT.
+//
+// IMPORTANT: These interceptors are MUTUALLY EXCLUSIVE in the chain:
+//   - With AUTH_ENABLED=true: Use auth.Interceptor.UnaryInterceptor() (validates header vs JWT)
+//   - With AUTH_ENABLED=false: Use auth.TenantExtractionInterceptor() (header extraction only)
+//
+// The x-tenant-id header is set by the API gateway's TenantResolverMiddleware based on
+// the subdomain (e.g., "acme.api.meridian.io" -> x-tenant-id: "org_acme_uuid").
+// The auth interceptor's double-check ensures a user's JWT tenant matches the subdomain
+// they're accessing, preventing subdomain hopping attacks.
 //
 // Example usage:
 //

--- a/shared/platform/auth/grpc_interceptor.go
+++ b/shared/platform/auth/grpc_interceptor.go
@@ -39,7 +39,24 @@ const (
 	ClaimsContextKey contextKey = "claims"
 )
 
-// Interceptor provides gRPC interceptors for JWT authentication
+// Interceptor provides gRPC interceptors for JWT authentication.
+//
+// IMPORTANT: This interceptor performs tenant context validation as a security measure.
+// When processing requests, it:
+//
+//  1. Validates the JWT and extracts the tenant_id claim
+//  2. Checks if an x-tenant-id header exists in gRPC metadata (set by API gateway)
+//  3. If the header exists, validates that it matches the JWT tenant_id claim
+//  4. Rejects requests where header and JWT tenant don't match (codes.PermissionDenied)
+//
+// This double-check prevents "subdomain hopping" attacks where a user with a valid JWT
+// for tenant A attempts to access tenant B's data by navigating to tenant B's subdomain.
+// The API gateway sets x-tenant-id based on the subdomain, so this validation ensures
+// users can only access the tenant they're authorized for via their JWT.
+//
+// The TenantExtractionInterceptor is provided for development/testing when auth is
+// disabled, but it should NEVER be used in production as it trusts the header without
+// JWT validation.
 type Interceptor struct {
 	validator     *JWTValidator
 	jwksValidator *JWTValidatorWithJWKS
@@ -135,6 +152,16 @@ func (a *Interceptor) StreamInterceptor() grpc.StreamServerInterceptor {
 
 // authenticate extracts and validates the JWT token, returning an enriched context.
 // This is for tenant-layer services that REQUIRE tenant_id claims.
+//
+// SECURITY: This method performs a critical double-check of tenant context:
+//   - The JWT contains the user's authorized tenant_id claim
+//   - The x-tenant-id header (if present) contains the subdomain-derived tenant
+//   - If both exist, they MUST match or the request is rejected
+//
+// This prevents "subdomain hopping" attacks where a user with a valid JWT for
+// tenant A navigates to tenant B's subdomain to access their data. The API gateway
+// sets x-tenant-id based on the subdomain, so this validation ensures users stay
+// within their authorized tenant boundaries.
 func (a *Interceptor) authenticate(ctx context.Context) (context.Context, error) {
 	claims, err := a.validateToken(ctx)
 	if err != nil {

--- a/shared/platform/auth/grpc_interceptor.go
+++ b/shared/platform/auth/grpc_interceptor.go
@@ -163,16 +163,27 @@ func (a *Interceptor) authenticate(ctx context.Context) (context.Context, error)
 			headerTenantID, err := tenant.NewTenantID(vals[0])
 			if err == nil && headerTenantID != tenantID {
 				// Tenant mismatch: user accessing wrong subdomain
+				// This is a SECURITY event - log with full context and record metric
 				span := trace.SpanFromContext(ctx)
 				span.SetAttributes(
 					attribute.String("security.tenant_mismatch.jwt", tenantID.String()),
 					attribute.String("security.tenant_mismatch.header", headerTenantID.String()),
 				)
+
+				// Extract client IP for security logging
+				clientIP := extractClientIP(ctx)
+
+				// Structured security logging with all contextual fields
 				a.logger.Warn("tenant context mismatch",
-					"jwt_tenant", tenantID,
-					"header_tenant", headerTenantID,
+					"jwt_tenant", tenantID.String(),
+					"header_tenant", headerTenantID.String(),
 					"user_id", claims.UserID,
+					"client_ip", clientIP,
 				)
+
+				// Record metric for monitoring and alerting
+				RecordTenantMismatch(tenantID.String(), headerTenantID.String())
+
 				return nil, status.Error(codes.PermissionDenied, "tenant context mismatch")
 			}
 		}

--- a/shared/platform/auth/grpc_interceptor.go
+++ b/shared/platform/auth/grpc_interceptor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -44,6 +45,7 @@ type Interceptor struct {
 	jwksValidator *JWTValidatorWithJWKS
 	bypassMethods map[string]bool
 	useJWKS       bool
+	logger        *slog.Logger
 }
 
 // InterceptorConfig holds configuration for the auth interceptor
@@ -51,6 +53,7 @@ type InterceptorConfig struct {
 	Validator     *JWTValidator         // Standard JWT validator
 	JWKSValidator *JWTValidatorWithJWKS // JWKS-based validator
 	BypassMethods []string              // Methods to bypass authentication (e.g., health checks)
+	Logger        *slog.Logger          // Logger for security events (optional, uses slog.Default if nil)
 }
 
 // NewAuthInterceptor creates a new authentication interceptor
@@ -64,11 +67,17 @@ func NewAuthInterceptor(cfg *InterceptorConfig) (*Interceptor, error) {
 		bypassMap[method] = true
 	}
 
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	return &Interceptor{
 		validator:     cfg.Validator,
 		jwksValidator: cfg.JWKSValidator,
 		bypassMethods: bypassMap,
 		useJWKS:       cfg.JWKSValidator != nil,
+		logger:        logger,
 	}, nil
 }
 
@@ -145,6 +154,30 @@ func (a *Interceptor) authenticate(ctx context.Context) (context.Context, error)
 		}
 		return nil, status.Error(codes.InvalidArgument, "invalid tenant_id format")
 	}
+
+	// SECURITY: Double-check tenant context vs JWT claims
+	// If x-tenant-id header exists (from gateway), it MUST match JWT
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		if vals := md.Get(tenant.TenantIDKey); len(vals) > 0 {
+			headerTenantID, err := tenant.NewTenantID(vals[0])
+			if err == nil && headerTenantID != tenantID {
+				// Tenant mismatch: user accessing wrong subdomain
+				span := trace.SpanFromContext(ctx)
+				span.SetAttributes(
+					attribute.String("security.tenant_mismatch.jwt", tenantID.String()),
+					attribute.String("security.tenant_mismatch.header", headerTenantID.String()),
+				)
+				a.logger.Warn("tenant context mismatch",
+					"jwt_tenant", tenantID,
+					"header_tenant", headerTenantID,
+					"user_id", claims.UserID,
+				)
+				return nil, status.Error(codes.PermissionDenied, "tenant context mismatch")
+			}
+		}
+	}
+
 	ctx = tenant.WithTenant(ctx, tenantID)
 
 	// Add tenant to OpenTelemetry span attributes

--- a/shared/platform/auth/grpc_interceptor_test.go
+++ b/shared/platform/auth/grpc_interceptor_test.go
@@ -1120,3 +1120,283 @@ func TestPlatformStreamInterceptor(t *testing.T) {
 		assert.Equal(t, codes.Unauthenticated, st.Code())
 	})
 }
+
+// TestTenantMismatchValidation tests the double-check validation between JWT tenant and header tenant.
+// This is a SECURITY feature to prevent cross-tenant access attacks.
+func TestTenantMismatchValidation(t *testing.T) {
+	privateKey, publicKey, err := generateTestRSAKeys()
+	require.NoError(t, err)
+
+	validator, err := NewJWTValidator(publicKey)
+	require.NoError(t, err)
+
+	t.Run("success when JWT tenant matches header tenant", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token with tenant claim
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "acme_bank",
+			Roles:    []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		// Create context with both authorization and x-tenant-id header (matching)
+		md := metadata.Pairs(
+			"authorization", "Bearer "+tokenString,
+			tenant.TenantIDKey, "acme_bank",
+		)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		resp, err := interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify tenant was injected into context
+		resultCtx := resp.(context.Context)
+		tenantID, ok := tenant.FromContext(resultCtx)
+		assert.True(t, ok)
+		assert.Equal(t, tenant.TenantID("acme_bank"), tenantID)
+	})
+
+	t.Run("error when JWT tenant differs from header tenant", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token with tenant claim
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "acme_bank",
+			Roles:    []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		// Create context with MISMATCHED tenants (user trying to access wrong tenant)
+		md := metadata.Pairs(
+			"authorization", "Bearer "+tokenString,
+			tenant.TenantIDKey, "other_bank", // Different from JWT's acme_bank
+		)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		resp, err := interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		assert.Contains(t, st.Message(), "tenant context mismatch")
+	})
+
+	t.Run("success when header is missing but JWT tenant exists", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token with tenant claim
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "acme_bank",
+			Roles:    []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		// Create context with ONLY authorization header (no x-tenant-id)
+		// This is for backward compatibility and direct gRPC calls without gateway
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		resp, err := interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify tenant was injected into context from JWT
+		resultCtx := resp.(context.Context)
+		tenantID, ok := tenant.FromContext(resultCtx)
+		assert.True(t, ok)
+		assert.Equal(t, tenant.TenantID("acme_bank"), tenantID)
+	})
+
+	t.Run("error with missing tenant_id claim", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token WITHOUT tenant claim
+		claims := &Claims{
+			UserID: "user-123",
+			Roles:  []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		resp, err := interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+		assert.Contains(t, st.Message(), "tenant_id claim required")
+	})
+
+	t.Run("error with invalid tenant_id format in JWT", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token with INVALID tenant format
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "invalid tenant!", // Invalid format (spaces and special chars)
+			Roles:    []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		md := metadata.Pairs("authorization", "Bearer "+tokenString)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		resp, err := interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		assert.Error(t, err)
+		assert.Nil(t, resp)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "invalid tenant_id format")
+	})
+
+	t.Run("ignores invalid header tenant format and succeeds with JWT tenant", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token with valid tenant claim
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "acme_bank",
+			Roles:    []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		// Create context with invalid header tenant format
+		// Invalid header format is ignored (err != nil from NewTenantID)
+		md := metadata.Pairs(
+			"authorization", "Bearer "+tokenString,
+			tenant.TenantIDKey, "invalid tenant!", // Invalid format
+		)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		resp, err := interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		// Should succeed because header parsing error is ignored
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+
+		// Verify JWT tenant was used
+		resultCtx := resp.(context.Context)
+		tenantID, ok := tenant.FromContext(resultCtx)
+		assert.True(t, ok)
+		assert.Equal(t, tenant.TenantID("acme_bank"), tenantID)
+	})
+
+	t.Run("stream interceptor rejects tenant mismatch", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Create token with tenant claim
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "acme_bank",
+			Roles:    []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		// Create context with MISMATCHED tenants
+		md := metadata.Pairs(
+			"authorization", "Bearer "+tokenString,
+			tenant.TenantIDKey, "other_bank",
+		)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		stream := &mockServerStream{ctx: ctx}
+
+		info := &grpc.StreamServerInfo{FullMethod: "/test.Service/StreamMethod"}
+		err = interceptor.StreamInterceptor()(nil, stream, info, mockStreamHandler)
+
+		assert.Error(t, err)
+		st, ok := status.FromError(err)
+		assert.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+		assert.Contains(t, st.Message(), "tenant context mismatch")
+	})
+}

--- a/shared/platform/auth/metrics.go
+++ b/shared/platform/auth/metrics.go
@@ -4,6 +4,7 @@ package auth
 
 import (
 	"context"
+	"net"
 	"strings"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -67,11 +68,14 @@ func extractClientIP(ctx context.Context) string {
 
 	// Fallback to peer address (direct gRPC connection)
 	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
-		// Extract just the IP portion (peer address may include port like "192.168.1.1:50051")
 		addr := p.Addr.String()
-		if idx := strings.LastIndex(addr, ":"); idx > 0 {
-			return addr[:idx]
+		// Use net.SplitHostPort to correctly handle both IPv4 and IPv6 addresses
+		// e.g., "192.168.1.1:50051" -> "192.168.1.1"
+		//       "[2001:db8::1]:50051" -> "2001:db8::1"
+		if host, _, err := net.SplitHostPort(addr); err == nil {
+			return host
 		}
+		// If no port separator (unusual for gRPC), return as-is
 		return addr
 	}
 

--- a/shared/platform/auth/metrics.go
+++ b/shared/platform/auth/metrics.go
@@ -1,0 +1,79 @@
+// Package auth provides authentication and authorization utilities.
+// This file contains Prometheus metrics for security monitoring.
+package auth
+
+import (
+	"context"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+// tenantMismatchTotal tracks tenant context mismatch detection events.
+// This is a SECURITY metric - alerts should be configured for non-zero values.
+//
+// A tenant mismatch occurs when a user's JWT contains one tenant_id but they
+// attempt to access resources on a different tenant's subdomain. This could indicate:
+// - A user accidentally accessing the wrong subdomain
+// - A potential cross-tenant access attack
+// - A misconfiguration in the gateway's tenant resolution
+//
+// Labels:
+//   - jwt_tenant: The tenant_id from the JWT claims
+//   - header_tenant: The tenant_id from the x-tenant-id gRPC metadata header
+var tenantMismatchTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "meridian",
+	Subsystem: "auth",
+	Name:      "tenant_mismatch_total",
+	Help:      "Total number of tenant context mismatch detection events (security metric)",
+}, []string{"jwt_tenant", "header_tenant"})
+
+// RecordTenantMismatch increments the tenant mismatch counter.
+// This should be called when the JWT tenant_id does not match the header tenant_id.
+func RecordTenantMismatch(jwtTenant, headerTenant string) {
+	tenantMismatchTotal.WithLabelValues(jwtTenant, headerTenant).Inc()
+}
+
+// extractClientIP extracts the client IP address from gRPC context.
+// It checks standard headers in order of preference:
+//  1. x-forwarded-for (first IP in the chain, set by proxies/load balancers)
+//  2. x-real-ip (set by nginx and other reverse proxies)
+//  3. peer address (direct gRPC connection)
+//
+// Returns empty string if no client IP can be determined.
+func extractClientIP(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+
+	// Check metadata for forwarded IP (common in Kubernetes/Istio environments)
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		// x-forwarded-for may contain multiple IPs (client, proxy1, proxy2...)
+		// First IP is the original client
+		if vals := md.Get("x-forwarded-for"); len(vals) > 0 && vals[0] != "" {
+			// Split on comma and take first IP
+			if ips := strings.Split(vals[0], ","); len(ips) > 0 {
+				return strings.TrimSpace(ips[0])
+			}
+		}
+		// Fallback to x-real-ip header
+		if vals := md.Get("x-real-ip"); len(vals) > 0 && vals[0] != "" {
+			return vals[0]
+		}
+	}
+
+	// Fallback to peer address (direct gRPC connection)
+	if p, ok := peer.FromContext(ctx); ok && p.Addr != nil {
+		// Extract just the IP portion (peer address may include port like "192.168.1.1:50051")
+		addr := p.Addr.String()
+		if idx := strings.LastIndex(addr, ":"); idx > 0 {
+			return addr[:idx]
+		}
+		return addr
+	}
+
+	return ""
+}

--- a/shared/platform/auth/metrics_test.go
+++ b/shared/platform/auth/metrics_test.go
@@ -137,9 +137,22 @@ func TestExtractClientIP(t *testing.T) {
 		assert.Equal(t, "192.168.1.100", ip)
 	})
 
-	t.Run("handles IPv6 addresses", func(t *testing.T) {
+	t.Run("handles IPv6 addresses in header", func(t *testing.T) {
 		md := metadata.Pairs("x-forwarded-for", "2001:db8::1")
 		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		ip := extractClientIP(ctx)
+		assert.Equal(t, "2001:db8::1", ip)
+	})
+
+	t.Run("handles IPv6 peer addresses with port", func(t *testing.T) {
+		// IPv6 addresses with port are formatted as "[ip]:port"
+		ctx := peer.NewContext(context.Background(), &peer.Peer{
+			Addr: &net.TCPAddr{
+				IP:   net.ParseIP("2001:db8::1"),
+				Port: 50051,
+			},
+		})
 
 		ip := extractClientIP(ctx)
 		assert.Equal(t, "2001:db8::1", ip)

--- a/shared/platform/auth/metrics_test.go
+++ b/shared/platform/auth/metrics_test.go
@@ -1,0 +1,252 @@
+package auth
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/peer"
+)
+
+func TestRecordTenantMismatch(t *testing.T) {
+	// Reset counter state for each test by recording known values
+	// Note: promauto counters can't be reset, so we test increments
+
+	t.Run("increments counter with correct labels", func(t *testing.T) {
+		// Get initial count
+		initialCount := testutil.ToFloat64(tenantMismatchTotal.WithLabelValues("acme_bank", "other_bank"))
+
+		// Record a mismatch
+		RecordTenantMismatch("acme_bank", "other_bank")
+
+		// Verify count increased by 1
+		newCount := testutil.ToFloat64(tenantMismatchTotal.WithLabelValues("acme_bank", "other_bank"))
+		assert.Equal(t, initialCount+1, newCount)
+	})
+
+	t.Run("tracks different tenant combinations separately", func(t *testing.T) {
+		// Get initial counts
+		initialCount1 := testutil.ToFloat64(tenantMismatchTotal.WithLabelValues("tenant_a", "tenant_b"))
+		initialCount2 := testutil.ToFloat64(tenantMismatchTotal.WithLabelValues("tenant_c", "tenant_d"))
+
+		// Record mismatches for different combinations
+		RecordTenantMismatch("tenant_a", "tenant_b")
+		RecordTenantMismatch("tenant_a", "tenant_b")
+		RecordTenantMismatch("tenant_c", "tenant_d")
+
+		// Verify counts
+		newCount1 := testutil.ToFloat64(tenantMismatchTotal.WithLabelValues("tenant_a", "tenant_b"))
+		newCount2 := testutil.ToFloat64(tenantMismatchTotal.WithLabelValues("tenant_c", "tenant_d"))
+
+		assert.Equal(t, initialCount1+2, newCount1)
+		assert.Equal(t, initialCount2+1, newCount2)
+	})
+}
+
+func TestExtractClientIP(t *testing.T) {
+	t.Run("returns empty string for nil context", func(t *testing.T) {
+		// nolint:staticcheck // SA1012: Intentionally testing nil context behavior
+		var nilCtx context.Context //nolint:staticcheck // SA1012: Intentionally testing nil context behavior
+		ip := extractClientIP(nilCtx)
+		assert.Empty(t, ip)
+	})
+
+	t.Run("returns empty string for context without metadata or peer", func(t *testing.T) {
+		ctx := context.Background()
+		ip := extractClientIP(ctx)
+		assert.Empty(t, ip)
+	})
+
+	t.Run("extracts IP from x-forwarded-for header", func(t *testing.T) {
+		md := metadata.Pairs("x-forwarded-for", "192.168.1.100")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		ip := extractClientIP(ctx)
+		assert.Equal(t, "192.168.1.100", ip)
+	})
+
+	t.Run("extracts first IP from x-forwarded-for chain", func(t *testing.T) {
+		// x-forwarded-for may contain multiple IPs: client, proxy1, proxy2
+		md := metadata.Pairs("x-forwarded-for", "192.168.1.100, 10.0.0.1, 10.0.0.2")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		ip := extractClientIP(ctx)
+		assert.Equal(t, "192.168.1.100", ip)
+	})
+
+	t.Run("extracts IP from x-real-ip header", func(t *testing.T) {
+		md := metadata.Pairs("x-real-ip", "192.168.1.200")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		ip := extractClientIP(ctx)
+		assert.Equal(t, "192.168.1.200", ip)
+	})
+
+	t.Run("prefers x-forwarded-for over x-real-ip", func(t *testing.T) {
+		md := metadata.Pairs(
+			"x-forwarded-for", "192.168.1.100",
+			"x-real-ip", "192.168.1.200",
+		)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		ip := extractClientIP(ctx)
+		assert.Equal(t, "192.168.1.100", ip)
+	})
+
+	t.Run("falls back to x-real-ip when x-forwarded-for is empty", func(t *testing.T) {
+		md := metadata.Pairs(
+			"x-forwarded-for", "",
+			"x-real-ip", "192.168.1.200",
+		)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		ip := extractClientIP(ctx)
+		assert.Equal(t, "192.168.1.200", ip)
+	})
+
+	t.Run("extracts IP from peer address", func(t *testing.T) {
+		ctx := peer.NewContext(context.Background(), &peer.Peer{
+			Addr: &net.TCPAddr{
+				IP:   net.ParseIP("192.168.1.50"),
+				Port: 50051,
+			},
+		})
+
+		ip := extractClientIP(ctx)
+		assert.Equal(t, "192.168.1.50", ip)
+	})
+
+	t.Run("prefers headers over peer address", func(t *testing.T) {
+		md := metadata.Pairs("x-forwarded-for", "192.168.1.100")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+		ctx = peer.NewContext(ctx, &peer.Peer{
+			Addr: &net.TCPAddr{
+				IP:   net.ParseIP("10.0.0.1"),
+				Port: 50051,
+			},
+		})
+
+		ip := extractClientIP(ctx)
+		assert.Equal(t, "192.168.1.100", ip)
+	})
+
+	t.Run("handles IPv6 addresses", func(t *testing.T) {
+		md := metadata.Pairs("x-forwarded-for", "2001:db8::1")
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		ip := extractClientIP(ctx)
+		assert.Equal(t, "2001:db8::1", ip)
+	})
+
+	t.Run("handles peer with nil address", func(t *testing.T) {
+		ctx := peer.NewContext(context.Background(), &peer.Peer{
+			Addr: nil,
+		})
+
+		ip := extractClientIP(ctx)
+		assert.Empty(t, ip)
+	})
+}
+
+// TestTenantMismatchMetricsIntegration verifies that the tenant mismatch
+// detection in the interceptor correctly records metrics.
+func TestTenantMismatchMetricsIntegration(t *testing.T) {
+	privateKey, publicKey, err := generateTestRSAKeys()
+	require.NoError(t, err)
+
+	validator, err := NewJWTValidator(publicKey)
+	require.NoError(t, err)
+
+	t.Run("records metric on tenant mismatch", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Get initial count for this label combination
+		initialCount := testutil.ToFloat64(tenantMismatchTotal.WithLabelValues("acme_bank", "other_bank"))
+
+		// Create token with tenant claim
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "acme_bank",
+			Roles:    []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		// Create context with MISMATCHED tenants
+		md := metadata.Pairs(
+			"authorization", "Bearer "+tokenString,
+			"x-tenant-id", "other_bank",
+		)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		// Call interceptor
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		_, err = interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		// Should fail with permission denied
+		assert.Error(t, err)
+
+		// Verify metric was recorded
+		newCount := testutil.ToFloat64(tenantMismatchTotal.WithLabelValues("acme_bank", "other_bank"))
+		assert.Equal(t, initialCount+1, newCount, "tenant mismatch metric should be incremented")
+	})
+
+	t.Run("no metric on successful validation", func(t *testing.T) {
+		cfg := &InterceptorConfig{
+			Validator: validator,
+		}
+
+		interceptor, err := NewAuthInterceptor(cfg)
+		require.NoError(t, err)
+
+		// Get initial count
+		initialCount := testutil.ToFloat64(tenantMismatchTotal.WithLabelValues("matching_tenant", "matching_tenant"))
+
+		// Create token with tenant claim
+		claims := &Claims{
+			UserID:   "user-123",
+			TenantID: "matching_tenant",
+			Roles:    []string{"admin"},
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+			},
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		tokenString, err := token.SignedString(privateKey)
+		require.NoError(t, err)
+
+		// Create context with MATCHING tenants
+		md := metadata.Pairs(
+			"authorization", "Bearer "+tokenString,
+			"x-tenant-id", "matching_tenant",
+		)
+		ctx := metadata.NewIncomingContext(context.Background(), md)
+
+		// Call interceptor
+		info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+		_, err = interceptor.UnaryInterceptor()(ctx, nil, info, mockUnaryHandler)
+
+		// Should succeed
+		assert.NoError(t, err)
+
+		// Verify metric was NOT recorded (count unchanged)
+		newCount := testutil.ToFloat64(tenantMismatchTotal.WithLabelValues("matching_tenant", "matching_tenant"))
+		assert.Equal(t, initialCount, newCount, "tenant mismatch metric should not be incremented on success")
+	})
+}

--- a/shared/platform/auth/tenant_interceptor.go
+++ b/shared/platform/auth/tenant_interceptor.go
@@ -8,16 +8,27 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// TenantExtractionInterceptor extracts tenant ID from gRPC metadata.
-// This works alongside JWT auth interceptor for service-to-service calls.
-// If tenant is already in context (from JWT auth), this is a no-op.
+// TenantExtractionInterceptor extracts tenant ID from gRPC metadata (x-tenant-id header).
+//
+// IMPORTANT: This interceptor is MUTUALLY EXCLUSIVE with auth.Interceptor.UnaryInterceptor().
+// Do NOT use both in the same interceptor chain.
+//
+//   - With AUTH_ENABLED=true:  Use auth.Interceptor.UnaryInterceptor() which validates
+//     the x-tenant-id header against the JWT tenant_id claim for security.
+//   - With AUTH_ENABLED=false: Use this interceptor (TenantExtractionInterceptor) which
+//     trusts the x-tenant-id header without JWT validation (development/testing only).
+//
+// The x-tenant-id header is set by the API gateway's TenantResolverMiddleware based on
+// the request subdomain (e.g., "acme.api.meridian.io" -> x-tenant-id: "org_acme_uuid").
 //
 // Use case: Service A calls Service B with tenant in metadata. Service B
 // extracts the tenant from metadata and injects it into context, enabling multi-hop
 // call chains to propagate tenant context.
 //
-// Security: The tenant ID is validated before being added to context.
+// Security: The tenant ID format is validated before being added to context.
 // Invalid tenant IDs are silently ignored (context remains unchanged).
+// However, this interceptor does NOT validate tenant ownership - use auth.Interceptor
+// in production to ensure the JWT tenant matches the header.
 func TenantExtractionInterceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
@@ -51,10 +62,15 @@ func TenantExtractionInterceptor() grpc.UnaryServerInterceptor {
 // metadata for streaming RPCs. This is the streaming equivalent of
 // TenantExtractionInterceptor.
 //
+// IMPORTANT: This interceptor is MUTUALLY EXCLUSIVE with auth.Interceptor.StreamInterceptor().
+// Do NOT use both in the same interceptor chain. See TenantExtractionInterceptor docs for details.
+//
 // If tenant is already in context (from JWT auth), this is a no-op.
 //
-// Security: The tenant ID is validated before being added to context.
+// Security: The tenant ID format is validated before being added to context.
 // Invalid tenant IDs are silently ignored (context remains unchanged).
+// However, this interceptor does NOT validate tenant ownership - use auth.Interceptor
+// in production to ensure the JWT tenant matches the header.
 func TenantExtractionStreamInterceptor() grpc.StreamServerInterceptor {
 	return func(
 		srv interface{},


### PR DESCRIPTION
## Summary
- Add double-check validation in auth interceptor to ensure JWT tenant matches gRPC metadata tenant
- Implement Prometheus metrics (`meridian_auth_tenant_mismatch_total`) and structured logging for tenant mismatch detection
- Document interceptor architecture and the mutual exclusivity of auth flows

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 64

## Changes Made

### Subtask 64.1: Tenant Mismatch Validation
- Added tenant context validation in the `authenticate()` method of `grpc_interceptor.go`
- Extracts `x-tenant-id` header from gRPC metadata and validates it matches the JWT tenant claim
- Returns `PermissionDenied` on mismatch for security

### Subtask 64.2: Security Metrics and Logging
- Created `metrics.go` with Prometheus counter `meridian_auth_tenant_mismatch_total` with labels for `jwt_tenant` and `header_tenant`
- Added `extractClientIP()` helper for security logging
- Enhanced mismatch logging with structured fields (jwt_tenant, header_tenant, client_ip, user_id)

### Subtask 64.3: Interceptor Chain Documentation
- Documented the interceptor architecture in `interceptor_ordering.md`
- Clarified that `x-tenant-id` header comes from gateway TenantResolverMiddleware (not an interceptor)
- Documented the mutual exclusivity of `auth.Interceptor` (for external requests with JWTs) and `TenantExtractionInterceptor` (for internal service-to-service calls)

## Test Plan
- Unit tests for tenant mismatch validation scenarios in `grpc_interceptor_test.go`
- Prometheus metrics tests for counter increments in `metrics_test.go`
- Integration test verifying metrics are recorded during mismatch detection