### PR TITLE
Configure wildcard subdomain routing with Kubernetes Ingress and Gateway service

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -713,7 +713,7 @@ Services:
 Gateway:
   • Gateway (HTTP)         → http://localhost:8080
     - Local dev mode: Use X-Tenant header (e.g., curl -H "X-Tenant: acme" http://localhost:8080/accounts)
-    - Production: Subdomain routing (e.g., acme.api.meridian.io)
+    - Production: Subdomain routing (e.g., acme.api.meridianhub.cloud)
 
 Microservices:
   • Current-Account        → localhost:50051 (gRPC)

--- a/Tiltfile
+++ b/Tiltfile
@@ -461,6 +461,43 @@ grpc_microservice(
     resource_deps=['cockroachdb', 'migrate-party'],
 )
 
+# Gateway Service - HTTP API gateway with tenant routing and gRPC-to-HTTP bridging
+# Standard build args
+gateway_build_args = {
+    'VERSION': 'dev',
+    'COMMIT': local('git rev-parse --short HEAD'),
+    'BUILD_DATE': get_build_date(),
+}
+
+# Docker build
+docker_build(
+    'gateway',
+    context='.',
+    dockerfile='services/gateway/cmd/Dockerfile',
+    build_args=gateway_build_args,
+)
+
+# K8s manifests
+k8s_yaml('services/gateway/k8s/configmap.yaml')
+k8s_yaml('services/gateway/k8s/deployment.yaml')
+k8s_yaml('services/gateway/k8s/service.yaml')
+
+# K8s resource configuration
+# Gateway depends on all backend services for routing
+k8s_resource(
+    'gateway',
+    port_forwards=['8080:8080'],
+    resource_deps=[
+        'current-account',
+        'financial-accounting',
+        'position-keeping',
+        'payment-order',
+        'party',
+        'tenant',
+    ],
+    labels=['gateway'],
+)
+
 # =============================================================================
 # Resource Configuration
 # =============================================================================
@@ -672,6 +709,11 @@ print("""
 Services:
   • Meridian API           → http://localhost:8080
   • Meridian gRPC          → localhost:9090
+
+Gateway:
+  • Gateway (HTTP)         → http://localhost:8080
+    - Local dev mode: Use X-Tenant header (e.g., curl -H "X-Tenant: acme" http://localhost:8080/accounts)
+    - Production: Subdomain routing (e.g., acme.api.meridian.io)
 
 Microservices:
   • Current-Account        → localhost:50051 (gRPC)

--- a/api/proto/meridian/tenant/v1/tenant.proto
+++ b/api/proto/meridian/tenant/v1/tenant.proto
@@ -90,7 +90,7 @@ message Tenant {
     max_len: 20
   }];
 
-  // subdomain is the API subdomain for this tenant (e.g., acme-bank.demo.meridian.io).
+  // subdomain is the API subdomain for this tenant (e.g., acme-bank.demo.meridianhub.cloud).
   // Optional - not all tenants need a subdomain.
   string subdomain = 4 [(buf.validate.field).string = {max_len: 255}];
 

--- a/cmd/tenantctl/cmd/register.go
+++ b/cmd/tenantctl/cmd/register.go
@@ -79,7 +79,7 @@ Examples:
 
   # Register with subdomain and metadata
   tenantctl register --id=test_org --name="Test Org" --settlement-asset=USD \
-    --subdomain=test.demo.meridian.io --metadata tier=enterprise
+    --subdomain=test.demo.meridianhub.cloud --metadata tier=enterprise
 
   # Register with explicit slug for API subdomain
   tenantctl register --id=acme_bank --name="Acme Bank" --settlement-asset=GBP --slug=acme-bank`,

--- a/deployments/k8s/local/cert-manager-issuer.yaml
+++ b/deployments/k8s/local/cert-manager-issuer.yaml
@@ -1,0 +1,231 @@
+# cert-manager ClusterIssuer for Wildcard TLS Certificates
+#
+# Purpose: Provisions wildcard TLS certificates for *.api.meridian.io using Let's Encrypt
+#
+# Why DNS-01 Challenge?
+# - HTTP-01 challenge does NOT support wildcard certificates (*.domain.com)
+# - DNS-01 is the ONLY ACME challenge type that supports wildcard domains
+# - Requires API access to your DNS provider to create TXT records for validation
+#
+# Architecture:
+# - ClusterIssuer: Cluster-wide resource (not namespaced)
+# - ACME protocol: Automated Certificate Management Environment
+# - Let's Encrypt: Free, automated, and open Certificate Authority
+#
+# Setup Requirements:
+# 1. cert-manager must be installed in the cluster:
+#    kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/cert-manager.yaml
+#
+# 2. DNS provider API credentials must be configured (see secrets below)
+#
+# 3. Update DNS provider configuration in the solver section
+#
+# Environment Selection:
+# - Development/Staging: Use letsencrypt-staging to avoid rate limits (5 certs/hour)
+# - Production: Use letsencrypt-prod (50 certs/week)
+#
+# Testing ClusterIssuer:
+# 1. Apply this file: kubectl apply -f cert-manager-issuer.yaml
+# 2. Verify ready: kubectl get clusterissuer letsencrypt-prod -o yaml
+# 3. Check status: kubectl describe clusterissuer letsencrypt-prod
+# 4. Look for: status.conditions[?(@.type=="Ready")].status == "True"
+#
+# Certificate Validation Process:
+# 1. cert-manager creates Certificate resource
+# 2. ACME server requests DNS TXT record: _acme-challenge.api.meridian.io
+# 3. cert-manager uses DNS provider API to create TXT record
+# 4. ACME server validates TXT record
+# 5. Certificate issued and stored in Kubernetes Secret
+# 6. Ingress automatically uses certificate
+#
+# Troubleshooting:
+# - View challenges: kubectl get challenges --all-namespaces
+# - View orders: kubectl get orders --all-namespaces
+# - Check logs: kubectl logs -n cert-manager deployment/cert-manager
+# - Describe certificate: kubectl describe certificate <cert-name>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudflare-api-token-secret
+  namespace: cert-manager
+type: Opaque
+stringData:
+  # Cloudflare API Token (NOT API Key)
+  # Required permissions: Zone.DNS (Edit), Zone.Zone (Read)
+  # Create at: https://dash.cloudflare.com/profile/api-tokens
+  # Template: "Edit zone DNS" template
+  api-token: "<REPLACE_WITH_CLOUDFLARE_API_TOKEN>"
+---
+# Alternative DNS Provider Secrets (comment out unused providers)
+#
+# AWS Route53 (requires IAM credentials with route53:ChangeResourceRecordSets permission)
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: route53-credentials-secret
+#   namespace: cert-manager
+# type: Opaque
+# stringData:
+#   secret-access-key: "<REPLACE_WITH_AWS_SECRET_ACCESS_KEY>"
+#
+# Google Cloud DNS (requires service account with DNS Administrator role)
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: clouddns-dns01-solver-sa
+#   namespace: cert-manager
+# type: Opaque
+# stringData:
+#   key.json: |
+#     {
+#       "type": "service_account",
+#       "project_id": "your-project-id",
+#       "private_key_id": "...",
+#       "private_key": "...",
+#       "client_email": "...",
+#       "client_id": "...",
+#       "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+#       "token_uri": "https://oauth2.googleapis.com/token"
+#     }
+#
+# Azure DNS (requires service principal with DNS Zone Contributor role)
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: azuredns-config
+#   namespace: cert-manager
+# type: Opaque
+# stringData:
+#   client-secret: "<REPLACE_WITH_AZURE_CLIENT_SECRET>"
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # Let's Encrypt Production Server
+    # Rate limits: 50 certificates per registered domain per week
+    # Certificates are trusted by all major browsers
+    server: https://acme-v02.api.letsencrypt.org/directory
+
+    # Email for urgent renewal and security notices
+    # IMPORTANT: Replace with your actual email address
+    email: admin@meridian.io
+
+    # Secret to store ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+
+    # DNS-01 challenge solver configuration
+    solvers:
+    # Cloudflare DNS-01 solver (default configuration)
+    - dns01:
+        cloudflare:
+          # Cloudflare API Token (recommended over API Key)
+          apiTokenSecretRef:
+            name: cloudflare-api-token-secret
+            key: api-token
+      selector:
+        # This solver applies to both wildcard and apex domain
+        dnsNames:
+        - "*.api.meridian.io"
+        - "api.meridian.io"
+
+    # Alternative DNS Provider Configurations (comment out unused)
+    #
+    # AWS Route53 DNS-01 solver
+    # - dns01:
+    #     route53:
+    #       region: us-east-1
+    #       accessKeyID: <REPLACE_WITH_AWS_ACCESS_KEY_ID>
+    #       secretAccessKeySecretRef:
+    #         name: route53-credentials-secret
+    #         key: secret-access-key
+    #   selector:
+    #     dnsNames:
+    #     - "*.api.meridian.io"
+    #     - "api.meridian.io"
+    #
+    # Google Cloud DNS solver
+    # - dns01:
+    #     cloudDNS:
+    #       project: <REPLACE_WITH_GCP_PROJECT_ID>
+    #       serviceAccountSecretRef:
+    #         name: clouddns-dns01-solver-sa
+    #         key: key.json
+    #   selector:
+    #     dnsNames:
+    #     - "*.api.meridian.io"
+    #     - "api.meridian.io"
+    #
+    # Azure DNS solver
+    # - dns01:
+    #     azureDNS:
+    #       subscriptionID: <REPLACE_WITH_AZURE_SUBSCRIPTION_ID>
+    #       resourceGroupName: <REPLACE_WITH_RESOURCE_GROUP>
+    #       hostedZoneName: meridian.io
+    #       environment: AzurePublicCloud
+    #       # Managed Identity (recommended for AKS)
+    #       managedIdentity:
+    #         clientID: <REPLACE_WITH_MANAGED_IDENTITY_CLIENT_ID>
+    #       # OR Service Principal (alternative)
+    #       # clientID: <REPLACE_WITH_SERVICE_PRINCIPAL_CLIENT_ID>
+    #       # tenantID: <REPLACE_WITH_AZURE_TENANT_ID>
+    #       # clientSecretSecretRef:
+    #       #   name: azuredns-config
+    #       #   key: client-secret
+    #   selector:
+    #     dnsNames:
+    #     - "*.api.meridian.io"
+    #     - "api.meridian.io"
+---
+# Staging ClusterIssuer for testing (recommended before using production)
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # Let's Encrypt Staging Server
+    # Higher rate limits, certificates NOT trusted by browsers (for testing only)
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+
+    email: admin@meridian.io
+
+    privateKeySecretRef:
+      name: letsencrypt-staging-account-key
+
+    solvers:
+    - dns01:
+        cloudflare:
+          apiTokenSecretRef:
+            name: cloudflare-api-token-secret
+            key: api-token
+      selector:
+        dnsNames:
+        - "*.api.meridian.io"
+        - "api.meridian.io"
+---
+# Example Certificate Resource (for testing the ClusterIssuer)
+# This resource can be used to manually test certificate issuance
+# In production, Ingress resources with cert-manager annotations will auto-create certificates
+#
+# apiVersion: cert-manager.io/v1
+# kind: Certificate
+# metadata:
+#   name: wildcard-api-meridian-cert
+#   namespace: default
+# spec:
+#   secretName: wildcard-api-meridian-tls
+#   issuerRef:
+#     name: letsencrypt-prod
+#     kind: ClusterIssuer
+#   dnsNames:
+#   - "*.api.meridian.io"
+#   - "api.meridian.io"
+#
+# Test certificate status:
+# kubectl describe certificate wildcard-api-meridian-cert
+# kubectl get secret wildcard-api-meridian-tls -o yaml

--- a/deployments/k8s/local/cert-manager-issuer.yaml
+++ b/deployments/k8s/local/cert-manager-issuer.yaml
@@ -70,6 +70,9 @@ stringData:
 #   secret-access-key: "<REPLACE_WITH_AWS_SECRET_ACCESS_KEY>"
 #
 # Google Cloud DNS (requires service account with DNS Administrator role)
+# See: https://cert-manager.io/docs/configuration/acme/dns01/google/
+# Create service account key at: https://console.cloud.google.com/iam-admin/serviceaccounts
+#
 # apiVersion: v1
 # kind: Secret
 # metadata:
@@ -77,17 +80,7 @@ stringData:
 #   namespace: cert-manager
 # type: Opaque
 # stringData:
-#   key.json: |
-#     {
-#       "type": "service_account",
-#       "project_id": "your-project-id",
-#       "private_key_id": "...",
-#       "private_key": "...",
-#       "client_email": "...",
-#       "client_id": "...",
-#       "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-#       "token_uri": "https://oauth2.googleapis.com/token"
-#     }
+#   key.json: "<REPLACE_WITH_GCP_SERVICE_ACCOUNT_JSON>"
 #
 # Azure DNS (requires service principal with DNS Zone Contributor role)
 # apiVersion: v1

--- a/deployments/k8s/local/cert-manager-issuer.yaml
+++ b/deployments/k8s/local/cert-manager-issuer.yaml
@@ -1,6 +1,6 @@
 # cert-manager ClusterIssuer for Wildcard TLS Certificates
 #
-# Purpose: Provisions wildcard TLS certificates for *.api.meridian.io using Let's Encrypt
+# Purpose: Provisions wildcard TLS certificates for *.api.meridianhub.cloud using Let's Encrypt
 #
 # Why DNS-01 Challenge?
 # - HTTP-01 challenge does NOT support wildcard certificates (*.domain.com)
@@ -32,7 +32,7 @@
 #
 # Certificate Validation Process:
 # 1. cert-manager creates Certificate resource
-# 2. ACME server requests DNS TXT record: _acme-challenge.api.meridian.io
+# 2. ACME server requests DNS TXT record: _acme-challenge.api.meridianhub.cloud
 # 3. cert-manager uses DNS provider API to create TXT record
 # 4. ACME server validates TXT record
 # 5. Certificate issued and stored in Kubernetes Secret
@@ -105,7 +105,7 @@ spec:
 
     # Email for urgent renewal and security notices
     # IMPORTANT: Replace with your actual email address
-    email: admin@meridian.io
+    email: admin@meridianhub.cloud
 
     # Secret to store ACME account private key
     privateKeySecretRef:
@@ -123,8 +123,8 @@ spec:
       selector:
         # This solver applies to both wildcard and apex domain
         dnsNames:
-        - "*.api.meridian.io"
-        - "api.meridian.io"
+        - "*.api.meridianhub.cloud"
+        - "api.meridianhub.cloud"
 
     # Alternative DNS Provider Configurations (comment out unused)
     #
@@ -138,8 +138,8 @@ spec:
     #         key: secret-access-key
     #   selector:
     #     dnsNames:
-    #     - "*.api.meridian.io"
-    #     - "api.meridian.io"
+    #     - "*.api.meridianhub.cloud"
+    #     - "api.meridianhub.cloud"
     #
     # Google Cloud DNS solver
     # - dns01:
@@ -150,15 +150,15 @@ spec:
     #         key: key.json
     #   selector:
     #     dnsNames:
-    #     - "*.api.meridian.io"
-    #     - "api.meridian.io"
+    #     - "*.api.meridianhub.cloud"
+    #     - "api.meridianhub.cloud"
     #
     # Azure DNS solver
     # - dns01:
     #     azureDNS:
     #       subscriptionID: <REPLACE_WITH_AZURE_SUBSCRIPTION_ID>
     #       resourceGroupName: <REPLACE_WITH_RESOURCE_GROUP>
-    #       hostedZoneName: meridian.io
+    #       hostedZoneName: meridianhub.cloud
     #       environment: AzurePublicCloud
     #       # Managed Identity (recommended for AKS)
     #       managedIdentity:
@@ -171,8 +171,8 @@ spec:
     #       #   key: client-secret
     #   selector:
     #     dnsNames:
-    #     - "*.api.meridian.io"
-    #     - "api.meridian.io"
+    #     - "*.api.meridianhub.cloud"
+    #     - "api.meridianhub.cloud"
 ---
 # Staging ClusterIssuer for testing (recommended before using production)
 apiVersion: cert-manager.io/v1
@@ -185,7 +185,7 @@ spec:
     # Higher rate limits, certificates NOT trusted by browsers (for testing only)
     server: https://acme-staging-v02.api.letsencrypt.org/directory
 
-    email: admin@meridian.io
+    email: admin@meridianhub.cloud
 
     privateKeySecretRef:
       name: letsencrypt-staging-account-key
@@ -198,8 +198,8 @@ spec:
             key: api-token
       selector:
         dnsNames:
-        - "*.api.meridian.io"
-        - "api.meridian.io"
+        - "*.api.meridianhub.cloud"
+        - "api.meridianhub.cloud"
 ---
 # Example Certificate Resource (for testing the ClusterIssuer)
 # This resource can be used to manually test certificate issuance
@@ -216,8 +216,8 @@ spec:
 #     name: letsencrypt-prod
 #     kind: ClusterIssuer
 #   dnsNames:
-#   - "*.api.meridian.io"
-#   - "api.meridian.io"
+#   - "*.api.meridianhub.cloud"
+#   - "api.meridianhub.cloud"
 #
 # Test certificate status:
 # kubectl describe certificate wildcard-api-meridian-cert

--- a/deployments/k8s/local/ingress.yaml
+++ b/deployments/k8s/local/ingress.yaml
@@ -1,0 +1,56 @@
+# Meridian API Gateway Ingress
+# Provides wildcard subdomain routing for multi-tenant access
+# Routes *.api.meridian.io and api.meridian.io to gateway-service
+#
+# Features:
+# - Wildcard TLS certificate via cert-manager
+# - nginx ingress with upstream-vhost for tenant resolution
+# - SSL redirect for secure connections
+#
+# NOTE: This configuration is optimized for LOCAL DEVELOPMENT ONLY.
+# Production deployments require proper DNS configuration and valid TLS certificates.
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: meridian-api-gateway
+  labels:
+    app: gateway
+    component: ingress
+  annotations:
+    # cert-manager will automatically provision TLS certificate
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    # Force HTTPS redirects
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # Pass original host header to upstream for tenant resolution
+    nginx.ingress.kubernetes.io/upstream-vhost: $host
+spec:
+  ingressClassName: nginx
+  tls:
+  - hosts:
+    - "*.api.meridian.io"
+    - "api.meridian.io"
+    secretName: wildcard-meridian-tls
+  rules:
+  # Wildcard subdomain routing (tenant1.api.meridian.io, tenant2.api.meridian.io, etc.)
+  - host: "*.api.meridian.io"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: gateway-service
+            port:
+              number: 8080
+  # Apex domain routing (api.meridian.io)
+  - host: "api.meridian.io"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: gateway-service
+            port:
+              number: 8080

--- a/deployments/k8s/local/ingress.yaml
+++ b/deployments/k8s/local/ingress.yaml
@@ -1,6 +1,6 @@
 # Meridian API Gateway Ingress
 # Provides wildcard subdomain routing for multi-tenant access
-# Routes *.api.meridian.io and api.meridian.io to gateway-service
+# Routes *.api.meridianhub.cloud and api.meridianhub.cloud to gateway-service
 #
 # Features:
 # - Wildcard TLS certificate via cert-manager
@@ -28,12 +28,12 @@ spec:
   ingressClassName: nginx
   tls:
   - hosts:
-    - "*.api.meridian.io"
-    - "api.meridian.io"
+    - "*.api.meridianhub.cloud"
+    - "api.meridianhub.cloud"
     secretName: wildcard-meridian-tls
   rules:
-  # Wildcard subdomain routing (tenant1.api.meridian.io, tenant2.api.meridian.io, etc.)
-  - host: "*.api.meridian.io"
+  # Wildcard subdomain routing (tenant1.api.meridianhub.cloud, tenant2.api.meridianhub.cloud, etc.)
+  - host: "*.api.meridianhub.cloud"
     http:
       paths:
       - path: /
@@ -43,8 +43,8 @@ spec:
             name: gateway-service
             port:
               number: 8080
-  # Apex domain routing (api.meridian.io)
-  - host: "api.meridian.io"
+  # Apex domain routing (api.meridianhub.cloud)
+  - host: "api.meridianhub.cloud"
     http:
       paths:
       - path: /

--- a/deployments/k8s/local/ingress.yaml
+++ b/deployments/k8s/local/ingress.yaml
@@ -1,6 +1,6 @@
 # Meridian API Gateway Ingress
 # Provides wildcard subdomain routing for multi-tenant access
-# Routes *.api.meridianhub.cloud and api.meridianhub.cloud to gateway-service
+# Routes *.api.meridianhub.cloud and api.meridianhub.cloud to gateway service
 #
 # Features:
 # - Wildcard TLS certificate via cert-manager
@@ -19,7 +19,8 @@ metadata:
     component: ingress
   annotations:
     # cert-manager will automatically provision TLS certificate
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    # Use staging for local development to avoid Let's Encrypt rate limits
+    cert-manager.io/cluster-issuer: letsencrypt-staging
     # Force HTTPS redirects
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     # Pass original host header to upstream for tenant resolution
@@ -40,7 +41,7 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: gateway-service
+            name: gateway
             port:
               number: 8080
   # Apex domain routing (api.meridianhub.cloud)
@@ -51,6 +52,6 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: gateway-service
+            name: gateway
             port:
               number: 8080

--- a/deployments/prometheus/alerts/organization-monitoring.yml
+++ b/deployments/prometheus/alerts/organization-monitoring.yml
@@ -19,7 +19,7 @@ groups:
         annotations:
           summary: "Organization {{ $labels.organization }} has error rate > 5%"
           description: "The error rate for organization {{ $labels.organization }} has exceeded 5% over the last 5 minutes. Current rate: {{ $value | humanizePercentage }}"
-          runbook_url: "https://docs.meridian.io/runbooks/organization-high-error-rate"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/organization-high-error-rate"
 
       # Critical error rate threshold
       - alert: OrganizationCriticalErrorRate
@@ -33,7 +33,7 @@ groups:
         annotations:
           summary: "Organization {{ $labels.organization }} has critical error rate > 10%"
           description: "The error rate for organization {{ $labels.organization }} has exceeded 10% over the last 3 minutes. Current rate: {{ $value | humanizePercentage }}. Immediate investigation required."
-          runbook_url: "https://docs.meridian.io/runbooks/organization-critical-error-rate"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/organization-critical-error-rate"
 
       # High latency for a specific organization
       - alert: OrganizationHighLatency
@@ -47,7 +47,7 @@ groups:
         annotations:
           summary: "Organization {{ $labels.organization }} has p99 latency > 1s"
           description: "The p99 latency for organization {{ $labels.organization }} has exceeded 1 second for the last 10 minutes. Current p99: {{ $value | humanizeDuration }}"
-          runbook_url: "https://docs.meridian.io/runbooks/organization-high-latency"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/organization-high-latency"
 
       # Very high latency threshold
       - alert: OrganizationCriticalLatency
@@ -61,7 +61,7 @@ groups:
         annotations:
           summary: "Organization {{ $labels.organization }} has critical p99 latency > 3s"
           description: "The p99 latency for organization {{ $labels.organization }} has exceeded 3 seconds for the last 5 minutes. Service is likely degraded. Current p99: {{ $value | humanizeDuration }}"
-          runbook_url: "https://docs.meridian.io/runbooks/organization-critical-latency"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/organization-critical-latency"
 
       # Noisy neighbor detection - organization generating excessive load
       - alert: NoisyNeighborDetected
@@ -74,7 +74,7 @@ groups:
         annotations:
           summary: "Organization {{ $labels.organization }} is generating 2x average load"
           description: "Organization {{ $labels.organization }} is generating more than twice the average request rate across all organizations. This may impact other tenants. Consider investigating usage patterns or implementing rate limiting."
-          runbook_url: "https://docs.meridian.io/runbooks/noisy-neighbor-detection"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/noisy-neighbor-detection"
 
       # Severe noisy neighbor - organization dominating resources
       - alert: NoisyNeighborCritical
@@ -87,7 +87,7 @@ groups:
         annotations:
           summary: "Organization {{ $labels.organization }} is generating 5x average load"
           description: "Organization {{ $labels.organization }} is generating more than 5 times the average request rate. This is likely impacting other tenants and may indicate a runaway process or misconfiguration."
-          runbook_url: "https://docs.meridian.io/runbooks/noisy-neighbor-critical"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/noisy-neighbor-critical"
 
       # High database query latency for organization
       - alert: OrganizationHighDBLatency
@@ -101,7 +101,7 @@ groups:
         annotations:
           summary: "Organization {{ $labels.organization }} has high DB query latency"
           description: "The p99 database query latency for organization {{ $labels.organization }} has exceeded 500ms for the last 10 minutes. This may indicate missing indexes or heavy queries. Current p99: {{ $value | humanizeDuration }}"
-          runbook_url: "https://docs.meridian.io/runbooks/organization-high-db-latency"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/organization-high-db-latency"
 
       # Kafka message processing issues for organization
       # Minimum traffic guard (0.1 msg/s) prevents alerts from low-traffic noise
@@ -120,7 +120,7 @@ groups:
         annotations:
           summary: "Organization {{ $labels.organization }} has Kafka publishing errors"
           description: "The Kafka message error rate for organization {{ $labels.organization }} has exceeded 1% over the last 5 minutes. This may indicate connectivity issues or message serialization problems."
-          runbook_url: "https://docs.meridian.io/runbooks/organization-kafka-errors"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/organization-kafka-errors"
 
       # Organization suddenly stopped generating traffic (potential outage indicator)
       - alert: OrganizationNoTraffic
@@ -134,4 +134,4 @@ groups:
         annotations:
           summary: "Organization {{ $labels.organization }} has no recent traffic"
           description: "Organization {{ $labels.organization }} had traffic in the previous hour but has had zero requests in the last 15 minutes. This may indicate a client-side issue or planned maintenance."
-          runbook_url: "https://docs.meridian.io/runbooks/organization-no-traffic"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/organization-no-traffic"

--- a/deployments/prometheus/alerts/tenant-provisioning.yml
+++ b/deployments/prometheus/alerts/tenant-provisioning.yml
@@ -19,7 +19,7 @@ groups:
         annotations:
           summary: "Tenant provisioning failures detected for {{ $labels.service_name }}"
           description: "Service {{ $labels.service_name }} has experienced more than 5 provisioning failures in the last 15 minutes. This indicates a persistent issue preventing tenant onboarding. Current failure count: {{ $value }}. Investigate service health, configuration, and resource availability immediately."
-          runbook_url: "https://docs.meridian.io/runbooks/tenant-provisioning-failed"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/tenant-provisioning-failed"
 
       # High provisioning failure rate - warning when failures exceed 20% of attempts
       - alert: TenantProvisioningHighFailureRate
@@ -34,7 +34,7 @@ groups:
         annotations:
           summary: "High provisioning failure rate for {{ $labels.service_name }}"
           description: "Service {{ $labels.service_name }} has a provisioning failure rate exceeding 20% over the last 10 minutes. Current rate: {{ $value | humanizePercentage }}. This may indicate degraded service availability or resource constraints."
-          runbook_url: "https://docs.meridian.io/runbooks/tenant-provisioning-high-failure-rate"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/tenant-provisioning-high-failure-rate"
 
       # Provisioning queue buildup - warning when pending tenants accumulate
       - alert: TenantProvisioningQueueBacklog
@@ -46,7 +46,7 @@ groups:
         annotations:
           summary: "Tenant provisioning queue has {{ $value }} pending tenants"
           description: "The tenant provisioning queue has more than 10 pending tenants for over 10 minutes. This may indicate provisioning throughput issues or worker capacity constraints. Current queue depth: {{ $value }}"
-          runbook_url: "https://docs.meridian.io/runbooks/tenant-provisioning-queue-backlog"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/tenant-provisioning-queue-backlog"
 
       # Excessive retry activity - info alert for visibility into retry load
       - alert: TenantProvisioningHighRetryRate
@@ -58,7 +58,7 @@ groups:
         annotations:
           summary: "High tenant provisioning retry rate detected"
           description: "Tenant provisioning is experiencing more than 0.5 retries per second over the last 15 minutes. Current rate: {{ $value }}. While retries are expected for transient failures, sustained high retry rates may indicate underlying service instability."
-          runbook_url: "https://docs.meridian.io/runbooks/tenant-provisioning-high-retry-rate"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/tenant-provisioning-high-retry-rate"
 
       # Slow provisioning operations - warning when p99 latency exceeds threshold
       - alert: TenantProvisioningSlowOperations
@@ -72,4 +72,4 @@ groups:
         annotations:
           summary: "Tenant provisioning operations are slow (p99 > 2 minutes)"
           description: "The p99 latency for successful tenant provisioning has exceeded 2 minutes for the last 15 minutes. Current p99: {{ $value | humanizeDuration }}. This may indicate resource contention, slow database migrations, or external service delays."
-          runbook_url: "https://docs.meridian.io/runbooks/tenant-provisioning-slow-operations"
+          runbook_url: "https://docs.meridianhub.cloud/runbooks/tenant-provisioning-slow-operations"

--- a/services/gateway/cmd/Dockerfile
+++ b/services/gateway/cmd/Dockerfile
@@ -1,0 +1,63 @@
+# Gateway Service - Multi-Stage Dockerfile
+# Optimized for security, size, and performance
+# HTTP-only gateway (no gRPC, no Kafka dependencies)
+
+# Build stage
+FROM golang:1.25-bookworm AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum* ./
+RUN go mod download && go mod verify
+
+# Copy source code
+COPY . .
+
+# Build binary with CGO disabled (static binary)
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-arm64} go build \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -o gateway \
+    ./services/gateway/cmd
+
+# Verify the binary exists and is executable
+RUN test -x gateway && echo "Binary built successfully"
+
+# Runtime stage - Debian slim
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user for security
+RUN groupadd -g 65532 nonroot && \
+    useradd -u 65532 -g nonroot -s /bin/false nonroot
+
+# Copy binary from builder
+COPY --from=builder /build/gateway /gateway
+
+# Use non-root user
+USER nonroot:nonroot
+
+# Expose HTTP port
+EXPOSE 8080
+
+# Note: Health checks handled by /health and /ready endpoints
+
+# Run the binary
+ENTRYPOINT ["/gateway"]

--- a/services/gateway/cmd/main.go
+++ b/services/gateway/cmd/main.go
@@ -1,0 +1,88 @@
+// Package main is the entry point for the Gateway service.
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/meridianhub/meridian/services/gateway/internal/config"
+	"github.com/meridianhub/meridian/services/gateway/internal/server"
+)
+
+// Build information set via ldflags during compilation.
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+func main() {
+	// Initialize structured logging
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting gateway service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	// Run the service
+	if err := run(logger); err != nil {
+		logger.Error("service failed", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	ctx := context.Background()
+
+	// Load configuration
+	cfg, err := config.LoadFromEnv()
+	if err != nil {
+		return err
+	}
+
+	logger.Info("configuration loaded",
+		"port", cfg.Port,
+		"base_domain", cfg.BaseDomain,
+		"backends", len(cfg.Backends))
+
+	// Log backend routes
+	for _, backend := range cfg.Backends {
+		logger.Info("backend route configured",
+			"name", backend.Name,
+			"path_prefix", backend.PathPrefix,
+			"target", backend.Target)
+	}
+
+	// Create and start server
+	srv, err := server.New(cfg, logger)
+	if err != nil {
+		return err
+	}
+
+	if err := srv.Start(ctx); err != nil {
+		return err
+	}
+
+	// Wait for interrupt signal
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+
+	sig := <-sigChan
+	logger.Info("received signal", "signal", sig)
+
+	// Graceful shutdown
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	return srv.Shutdown(shutdownCtx)
+}

--- a/services/gateway/internal/config/config.go
+++ b/services/gateway/internal/config/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	// Port is the HTTP port to listen on.
 	Port int
 
-	// BaseDomain is the base domain for tenant resolution (e.g., "api.meridian.io").
+	// BaseDomain is the base domain for tenant resolution (e.g., "api.meridianhub.cloud").
 	BaseDomain string
 
 	// Backends is a list of backend service configurations.
@@ -36,7 +36,7 @@ type BackendConfig struct {
 func LoadFromEnv() (*Config, error) {
 	port := getEnvAsInt("GATEWAY_PORT", 8080)
 
-	baseDomain := getEnvOrDefault("GATEWAY_BASE_DOMAIN", "api.meridian.io")
+	baseDomain := getEnvOrDefault("GATEWAY_BASE_DOMAIN", "api.meridianhub.cloud")
 
 	// Load backend configurations from environment
 	backends := loadBackends()

--- a/services/gateway/internal/config/config.go
+++ b/services/gateway/internal/config/config.go
@@ -49,11 +49,11 @@ func LoadFromEnv() (*Config, error) {
 }
 
 // loadBackends loads backend configurations from environment variables.
-// Expected format: BACKEND_{NAME}_TARGET and BACKEND_{NAME}_PATH_PREFIX
+// Expected format: {SERVICE}_SERVICE_TARGET and {SERVICE}_SERVICE_PATH_PREFIX
 // Example:
 //
-//	BACKEND_CURRENT_ACCOUNT_TARGET=current-account:50051
-//	BACKEND_CURRENT_ACCOUNT_PATH_PREFIX=/accounts
+//	CURRENT_ACCOUNT_SERVICE_TARGET=current-account:50051
+//	CURRENT_ACCOUNT_SERVICE_PATH_PREFIX=/accounts
 func loadBackends() []BackendConfig {
 	backends := []BackendConfig{}
 

--- a/services/gateway/internal/config/config.go
+++ b/services/gateway/internal/config/config.go
@@ -1,0 +1,154 @@
+// Package config provides configuration for the gateway service.
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Config holds the gateway service configuration.
+type Config struct {
+	// Port is the HTTP port to listen on.
+	Port int
+
+	// BaseDomain is the base domain for tenant resolution (e.g., "api.meridian.io").
+	BaseDomain string
+
+	// Backends is a list of backend service configurations.
+	Backends []BackendConfig
+}
+
+// BackendConfig describes a backend service route.
+type BackendConfig struct {
+	// Name is the service name for logging/metrics.
+	Name string
+
+	// PathPrefix is the URL path prefix to match (e.g., "/accounts").
+	PathPrefix string
+
+	// Target is the backend service address (e.g., "current-account:50051").
+	Target string
+}
+
+// LoadFromEnv loads configuration from environment variables.
+func LoadFromEnv() (*Config, error) {
+	port := getEnvAsInt("GATEWAY_PORT", 8080)
+
+	baseDomain := getEnvOrDefault("GATEWAY_BASE_DOMAIN", "api.meridian.io")
+
+	// Load backend configurations from environment
+	backends := loadBackends()
+
+	return &Config{
+		Port:       port,
+		BaseDomain: baseDomain,
+		Backends:   backends,
+	}, nil
+}
+
+// loadBackends loads backend configurations from environment variables.
+// Expected format: BACKEND_{NAME}_TARGET and BACKEND_{NAME}_PATH_PREFIX
+// Example:
+//
+//	BACKEND_CURRENT_ACCOUNT_TARGET=current-account:50051
+//	BACKEND_CURRENT_ACCOUNT_PATH_PREFIX=/accounts
+func loadBackends() []BackendConfig {
+	backends := []BackendConfig{}
+
+	// Check for known backends via specific environment variables
+	knownBackends := []struct {
+		envPrefix string
+		name      string
+	}{
+		{"CURRENT_ACCOUNT_SERVICE", "current-account"},
+		{"PARTY_SERVICE", "party"},
+		{"PAYMENT_ORDER_SERVICE", "payment-order"},
+		{"POSITION_KEEPING_SERVICE", "position-keeping"},
+		{"FINANCIAL_ACCOUNTING_SERVICE", "financial-accounting"},
+		{"TENANT_SERVICE", "tenant"},
+	}
+
+	for _, kb := range knownBackends {
+		target := os.Getenv(kb.envPrefix + "_TARGET")
+		pathPrefix := os.Getenv(kb.envPrefix + "_PATH_PREFIX")
+
+		if target != "" && pathPrefix != "" {
+			backends = append(backends, BackendConfig{
+				Name:       kb.name,
+				Target:     target,
+				PathPrefix: pathPrefix,
+			})
+		}
+	}
+
+	// If no specific backends configured, use defaults for Kubernetes
+	if len(backends) == 0 {
+		namespace := getEnvOrDefault("K8S_NAMESPACE", "default")
+		backends = getDefaultBackends(namespace)
+	}
+
+	return backends
+}
+
+// getDefaultBackends returns the default backend configuration for Kubernetes deployment.
+func getDefaultBackends(namespace string) []BackendConfig {
+	suffix := fmt.Sprintf(".%s.svc.cluster.local", namespace)
+
+	return []BackendConfig{
+		{
+			Name:       "current-account",
+			PathPrefix: "/accounts",
+			Target:     "current-account" + suffix + ":50051",
+		},
+		{
+			Name:       "party",
+			PathPrefix: "/parties",
+			Target:     "party" + suffix + ":50055",
+		},
+		{
+			Name:       "payment-order",
+			PathPrefix: "/payments",
+			Target:     "payment-order" + suffix + ":50054",
+		},
+		{
+			Name:       "position-keeping",
+			PathPrefix: "/positions",
+			Target:     "position-keeping" + suffix + ":50053",
+		},
+		{
+			Name:       "financial-accounting",
+			PathPrefix: "/accounting",
+			Target:     "financial-accounting" + suffix + ":50052",
+		},
+		{
+			Name:       "tenant",
+			PathPrefix: "/tenants",
+			Target:     "tenant" + suffix + ":50056",
+		},
+	}
+}
+
+// getEnvOrDefault returns the environment variable value or default.
+func getEnvOrDefault(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}
+
+// getEnvAsInt returns the environment variable value as int or default.
+func getEnvAsInt(key string, defaultValue int) int {
+	valueStr := os.Getenv(key)
+	if valueStr == "" {
+		return defaultValue
+	}
+
+	value, err := strconv.Atoi(strings.TrimSpace(valueStr))
+	if err != nil {
+		return defaultValue
+	}
+	return value
+}

--- a/services/gateway/internal/middleware/errors.go
+++ b/services/gateway/internal/middleware/errors.go
@@ -1,0 +1,12 @@
+package middleware
+
+import "errors"
+
+// Sentinel errors for tenant resolution.
+var (
+	// ErrMissingTenant indicates that no tenant subdomain was provided.
+	ErrMissingTenant = errors.New("tenant subdomain required")
+
+	// ErrInvalidHost indicates that the host does not match the expected base domain.
+	ErrInvalidHost = errors.New("invalid host: does not match expected domain")
+)

--- a/services/gateway/internal/middleware/tenant_resolver.go
+++ b/services/gateway/internal/middleware/tenant_resolver.go
@@ -29,7 +29,8 @@ func NewTenantResolver(baseDomain string, allowedHosts []string) *TenantResolver
 	}
 }
 
-// Middleware returns an HTTP middleware that extracts tenant from subdomain.
+// Middleware returns an HTTP middleware that extracts tenant from subdomain or X-Tenant header.
+// For local development, the X-Tenant header can be used instead of subdomain routing.
 func (tr *TenantResolver) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		host := r.Host
@@ -50,11 +51,19 @@ func (tr *TenantResolver) Middleware(next http.Handler) http.Handler {
 			}
 		}
 
-		// Extract tenant from subdomain
-		tenantSlug, err := tr.extractTenant(host)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
-			return
+		var tenantSlug string
+		var err error
+
+		// Try to extract tenant from X-Tenant header first (for local development)
+		if headerTenant := r.Header.Get("X-Tenant"); headerTenant != "" {
+			tenantSlug = headerTenant
+		} else {
+			// Fall back to subdomain extraction (production mode)
+			tenantSlug, err = tr.extractTenant(host)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
 		}
 
 		// Validate and create tenant ID

--- a/services/gateway/internal/middleware/tenant_resolver.go
+++ b/services/gateway/internal/middleware/tenant_resolver.go
@@ -9,10 +9,10 @@ import (
 )
 
 // TenantResolver extracts the tenant ID from the subdomain and injects it into the request context.
-// It expects hosts in the format: {tenant}.api.meridian.io
-// If no subdomain is found (e.g., api.meridian.io), it returns an error response.
+// It expects hosts in the format: {tenant}.api.meridianhub.cloud
+// If no subdomain is found (e.g., api.meridianhub.cloud), it returns an error response.
 type TenantResolver struct {
-	// BaseDomain is the base domain suffix (e.g., "api.meridian.io").
+	// BaseDomain is the base domain suffix (e.g., "api.meridianhub.cloud").
 	// Requests to this exact domain (without subdomain) are rejected.
 	BaseDomain string
 
@@ -85,7 +85,7 @@ func (tr *TenantResolver) Middleware(next http.Handler) http.Handler {
 }
 
 // extractTenant extracts the tenant identifier from the host subdomain.
-// For example: "acme.api.meridian.io" -> "acme"
+// For example: "acme.api.meridianhub.cloud" -> "acme"
 func (tr *TenantResolver) extractTenant(host string) (string, error) {
 	// Normalize to lowercase for comparison
 	hostLower := strings.ToLower(host)

--- a/services/gateway/internal/middleware/tenant_resolver.go
+++ b/services/gateway/internal/middleware/tenant_resolver.go
@@ -1,0 +1,112 @@
+// Package middleware provides HTTP middleware for the gateway service.
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// TenantResolver extracts the tenant ID from the subdomain and injects it into the request context.
+// It expects hosts in the format: {tenant}.api.meridian.io
+// If no subdomain is found (e.g., api.meridian.io), it returns an error response.
+type TenantResolver struct {
+	// BaseDomain is the base domain suffix (e.g., "api.meridian.io").
+	// Requests to this exact domain (without subdomain) are rejected.
+	BaseDomain string
+
+	// AllowedHosts is a list of hosts that bypass tenant resolution (e.g., health checks on localhost).
+	// These hosts will have requests passed through without tenant context.
+	AllowedHosts []string
+}
+
+// NewTenantResolver creates a new TenantResolver middleware.
+func NewTenantResolver(baseDomain string, allowedHosts []string) *TenantResolver {
+	return &TenantResolver{
+		BaseDomain:   baseDomain,
+		AllowedHosts: allowedHosts,
+	}
+}
+
+// Middleware returns an HTTP middleware that extracts tenant from subdomain.
+func (tr *TenantResolver) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host := r.Host
+
+		// Strip port if present
+		if colonIdx := strings.LastIndex(host, ":"); colonIdx != -1 {
+			// Handle IPv6 addresses which have colons
+			if bracketIdx := strings.LastIndex(host, "]"); colonIdx > bracketIdx {
+				host = host[:colonIdx]
+			}
+		}
+
+		// Check if this host is in the allowed list (bypass tenant resolution)
+		for _, allowed := range tr.AllowedHosts {
+			if host == allowed || strings.HasPrefix(host, allowed+":") {
+				next.ServeHTTP(w, r)
+				return
+			}
+		}
+
+		// Extract tenant from subdomain
+		tenantSlug, err := tr.extractTenant(host)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		// Validate and create tenant ID
+		tenantID, err := tenant.NewTenantID(tenantSlug)
+		if err != nil {
+			http.Error(w, "invalid tenant identifier in subdomain", http.StatusBadRequest)
+			return
+		}
+
+		// Inject tenant into request context
+		ctx := tenant.WithTenant(r.Context(), tenantID)
+		r = r.WithContext(ctx)
+
+		// Also set tenant header for downstream services
+		r.Header.Set(tenant.TenantIDKey, tenantID.String())
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// extractTenant extracts the tenant identifier from the host subdomain.
+// For example: "acme.api.meridian.io" -> "acme"
+func (tr *TenantResolver) extractTenant(host string) (string, error) {
+	// Normalize to lowercase for comparison
+	hostLower := strings.ToLower(host)
+	baseDomainLower := strings.ToLower(tr.BaseDomain)
+
+	// Check if host ends with the base domain
+	if !strings.HasSuffix(hostLower, baseDomainLower) {
+		return "", ErrInvalidHost
+	}
+
+	// Check if host is exactly the base domain (no subdomain)
+	if hostLower == baseDomainLower {
+		return "", ErrMissingTenant
+	}
+
+	// Extract subdomain: host = subdomain.baseDomain
+	// We need to remove the base domain and the preceding dot
+	subdomainPart := host[:len(host)-len(tr.BaseDomain)-1]
+
+	// The subdomain should be a single segment (no additional dots)
+	// e.g., "acme" is valid, "acme.extra" would need different handling
+	if strings.Contains(subdomainPart, ".") {
+		// Take only the first segment as tenant
+		parts := strings.Split(subdomainPart, ".")
+		subdomainPart = parts[0]
+	}
+
+	if subdomainPart == "" {
+		return "", ErrMissingTenant
+	}
+
+	return subdomainPart, nil
+}

--- a/services/gateway/internal/middleware/tenant_resolver_test.go
+++ b/services/gateway/internal/middleware/tenant_resolver_test.go
@@ -287,3 +287,110 @@ func TestTenantResolver_NestedSubdomain(t *testing.T) {
 	// Takes the first subdomain segment
 	assert.Equal(t, "team", capturedTenant.String())
 }
+
+func TestTenantResolver_XTenantHeader(t *testing.T) {
+	tests := []struct {
+		name         string
+		host         string
+		headerValue  string
+		allowedHosts []string
+		expectStatus int
+		expectTenant string
+		expectInCtx  bool
+	}{
+		{
+			name:         "valid X-Tenant header without subdomain",
+			host:         "gateway.local",
+			headerValue:  "localtenant",
+			allowedHosts: nil,
+			expectStatus: http.StatusOK,
+			expectTenant: "localtenant",
+			expectInCtx:  true,
+		},
+		{
+			name:         "valid X-Tenant header with port",
+			host:         "gateway.local:8080",
+			headerValue:  "devtenant",
+			allowedHosts: nil,
+			expectStatus: http.StatusOK,
+			expectTenant: "devtenant",
+			expectInCtx:  true,
+		},
+		{
+			name:         "invalid X-Tenant header with dot",
+			host:         "gateway.local",
+			headerValue:  "invalid.tenant",
+			allowedHosts: nil,
+			expectStatus: http.StatusBadRequest,
+			expectTenant: "",
+			expectInCtx:  false,
+		},
+		{
+			name:         "invalid X-Tenant header with special chars",
+			host:         "gateway.local",
+			headerValue:  "invalid@tenant",
+			allowedHosts: nil,
+			expectStatus: http.StatusBadRequest,
+			expectTenant: "",
+			expectInCtx:  false,
+		},
+		{
+			name:         "invalid X-Tenant header starting with hyphen",
+			host:         "gateway.local",
+			headerValue:  "-invalid",
+			allowedHosts: nil,
+			expectStatus: http.StatusBadRequest,
+			expectTenant: "",
+			expectInCtx:  false,
+		},
+		{
+			name:         "X-Tenant header takes precedence over subdomain",
+			host:         "old.api.meridianhub.cloud",
+			headerValue:  "newtenant",
+			allowedHosts: nil,
+			expectStatus: http.StatusOK,
+			expectTenant: "newtenant",
+			expectInCtx:  true,
+		},
+		{
+			name:         "empty X-Tenant header falls back to subdomain",
+			host:         "acme.api.meridianhub.cloud",
+			headerValue:  "",
+			allowedHosts: nil,
+			expectStatus: http.StatusOK,
+			expectTenant: "acme",
+			expectInCtx:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := middleware.NewTenantResolver("api.meridianhub.cloud", tt.allowedHosts)
+
+			var capturedTenant tenant.TenantID
+			var handlerCalled bool
+			handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+				capturedTenant, _ = tenant.FromContext(r.Context())
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Host = tt.host
+			if tt.headerValue != "" {
+				req.Header.Set("X-Tenant", tt.headerValue)
+			}
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, tt.expectStatus, rec.Code)
+
+			if tt.expectInCtx {
+				assert.True(t, handlerCalled, "handler should be called")
+				assert.Equal(t, tt.expectTenant, capturedTenant.String())
+			} else {
+				assert.False(t, handlerCalled, "handler should not be called for invalid tenant")
+			}
+		})
+	}
+}

--- a/services/gateway/internal/middleware/tenant_resolver_test.go
+++ b/services/gateway/internal/middleware/tenant_resolver_test.go
@@ -125,7 +125,7 @@ func TestTenantResolver_InvalidHost(t *testing.T) {
 		},
 		{
 			name: "different TLD",
-			host: "acme.api.meridian.com",
+			host: "acme.api.example.com",
 		},
 	}
 

--- a/services/gateway/internal/middleware/tenant_resolver_test.go
+++ b/services/gateway/internal/middleware/tenant_resolver_test.go
@@ -20,39 +20,39 @@ func TestTenantResolver_ValidSubdomain(t *testing.T) {
 	}{
 		{
 			name:           "simple tenant",
-			host:           "acme.api.meridian.io",
+			host:           "acme.api.meridianhub.cloud",
 			expectedTenant: "acme",
 		},
 		{
 			name:           "tenant with numbers",
-			host:           "bank123.api.meridian.io",
+			host:           "bank123.api.meridianhub.cloud",
 			expectedTenant: "bank123",
 		},
 		{
 			name:           "tenant with underscore",
-			host:           "acme_bank.api.meridian.io",
+			host:           "acme_bank.api.meridianhub.cloud",
 			expectedTenant: "acme_bank",
 		},
 		{
 			name:           "uppercase tenant",
-			host:           "ACME.api.meridian.io",
+			host:           "ACME.api.meridianhub.cloud",
 			expectedTenant: "ACME",
 		},
 		{
 			name:           "mixed case tenant",
-			host:           "AcmeBank.api.meridian.io",
+			host:           "AcmeBank.api.meridianhub.cloud",
 			expectedTenant: "AcmeBank",
 		},
 		{
 			name:           "host with port",
-			host:           "acme.api.meridian.io:8080",
+			host:           "acme.api.meridianhub.cloud:8080",
 			expectedTenant: "acme",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+			resolver := middleware.NewTenantResolver("api.meridianhub.cloud", nil)
 
 			var capturedTenant tenant.TenantID
 			var tenantFound bool
@@ -81,17 +81,17 @@ func TestTenantResolver_MissingTenant(t *testing.T) {
 	}{
 		{
 			name: "base domain only",
-			host: "api.meridian.io",
+			host: "api.meridianhub.cloud",
 		},
 		{
 			name: "base domain with port",
-			host: "api.meridian.io:8080",
+			host: "api.meridianhub.cloud:8080",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+			resolver := middleware.NewTenantResolver("api.meridianhub.cloud", nil)
 
 			handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 				t.Error("handler should not be called when tenant is missing")
@@ -121,7 +121,7 @@ func TestTenantResolver_InvalidHost(t *testing.T) {
 		},
 		{
 			name: "partial match",
-			host: "acme.meridian.io",
+			host: "acme.meridianhub.cloud",
 		},
 		{
 			name: "different TLD",
@@ -131,7 +131,7 @@ func TestTenantResolver_InvalidHost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+			resolver := middleware.NewTenantResolver("api.meridianhub.cloud", nil)
 
 			handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 				t.Error("handler should not be called for invalid host")
@@ -157,17 +157,17 @@ func TestTenantResolver_InvalidTenantID(t *testing.T) {
 	}{
 		{
 			name: "tenant with hyphen",
-			host: "acme-bank.api.meridian.io",
+			host: "acme-bank.api.meridianhub.cloud",
 		},
 		{
 			name: "tenant with special chars",
-			host: "acme@bank.api.meridian.io",
+			host: "acme@bank.api.meridianhub.cloud",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+			resolver := middleware.NewTenantResolver("api.meridianhub.cloud", nil)
 
 			handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 				t.Error("handler should not be called for invalid tenant ID")
@@ -213,7 +213,7 @@ func TestTenantResolver_AllowedHosts(t *testing.T) {
 		},
 		{
 			name:         "non-allowed host requires tenant",
-			host:         "api.meridian.io",
+			host:         "api.meridianhub.cloud",
 			allowedHosts: []string{"localhost"},
 			expectBypass: false,
 		},
@@ -221,7 +221,7 @@ func TestTenantResolver_AllowedHosts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resolver := middleware.NewTenantResolver("api.meridian.io", tt.allowedHosts)
+			resolver := middleware.NewTenantResolver("api.meridianhub.cloud", tt.allowedHosts)
 
 			handlerCalled := false
 			handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -251,7 +251,7 @@ func TestTenantResolver_AllowedHosts(t *testing.T) {
 }
 
 func TestTenantResolver_SetsHeader(t *testing.T) {
-	resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+	resolver := middleware.NewTenantResolver("api.meridianhub.cloud", nil)
 
 	var capturedHeader string
 	handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -259,7 +259,7 @@ func TestTenantResolver_SetsHeader(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Host = "acme.api.meridian.io"
+	req.Host = "acme.api.meridianhub.cloud"
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)
@@ -270,7 +270,7 @@ func TestTenantResolver_SetsHeader(t *testing.T) {
 
 func TestTenantResolver_NestedSubdomain(t *testing.T) {
 	// When there are multiple subdomains, only the first one is used as tenant
-	resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+	resolver := middleware.NewTenantResolver("api.meridianhub.cloud", nil)
 
 	var capturedTenant tenant.TenantID
 	handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
@@ -278,7 +278,7 @@ func TestTenantResolver_NestedSubdomain(t *testing.T) {
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.Host = "team.acme.api.meridian.io"
+	req.Host = "team.acme.api.meridianhub.cloud"
 	rec := httptest.NewRecorder()
 
 	handler.ServeHTTP(rec, req)

--- a/services/gateway/internal/middleware/tenant_resolver_test.go
+++ b/services/gateway/internal/middleware/tenant_resolver_test.go
@@ -1,0 +1,289 @@
+package middleware_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/gateway/internal/middleware"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantResolver_ValidSubdomain(t *testing.T) {
+	tests := []struct {
+		name           string
+		host           string
+		expectedTenant string
+	}{
+		{
+			name:           "simple tenant",
+			host:           "acme.api.meridian.io",
+			expectedTenant: "acme",
+		},
+		{
+			name:           "tenant with numbers",
+			host:           "bank123.api.meridian.io",
+			expectedTenant: "bank123",
+		},
+		{
+			name:           "tenant with underscore",
+			host:           "acme_bank.api.meridian.io",
+			expectedTenant: "acme_bank",
+		},
+		{
+			name:           "uppercase tenant",
+			host:           "ACME.api.meridian.io",
+			expectedTenant: "ACME",
+		},
+		{
+			name:           "mixed case tenant",
+			host:           "AcmeBank.api.meridian.io",
+			expectedTenant: "AcmeBank",
+		},
+		{
+			name:           "host with port",
+			host:           "acme.api.meridian.io:8080",
+			expectedTenant: "acme",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+
+			var capturedTenant tenant.TenantID
+			var tenantFound bool
+
+			handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				capturedTenant, tenantFound = tenant.FromContext(r.Context())
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Host = tt.host
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.True(t, tenantFound, "tenant should be found in context")
+			assert.Equal(t, tt.expectedTenant, capturedTenant.String())
+		})
+	}
+}
+
+func TestTenantResolver_MissingTenant(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+	}{
+		{
+			name: "base domain only",
+			host: "api.meridian.io",
+		},
+		{
+			name: "base domain with port",
+			host: "api.meridian.io:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+
+			handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				t.Error("handler should not be called when tenant is missing")
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Host = tt.host
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			body, _ := io.ReadAll(rec.Body)
+			assert.Contains(t, string(body), "tenant subdomain required")
+		})
+	}
+}
+
+func TestTenantResolver_InvalidHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+	}{
+		{
+			name: "different domain",
+			host: "acme.example.com",
+		},
+		{
+			name: "partial match",
+			host: "acme.meridian.io",
+		},
+		{
+			name: "different TLD",
+			host: "acme.api.meridian.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+
+			handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				t.Error("handler should not be called for invalid host")
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Host = tt.host
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			body, _ := io.ReadAll(rec.Body)
+			assert.Contains(t, string(body), "invalid host")
+		})
+	}
+}
+
+func TestTenantResolver_InvalidTenantID(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+	}{
+		{
+			name: "tenant with hyphen",
+			host: "acme-bank.api.meridian.io",
+		},
+		{
+			name: "tenant with special chars",
+			host: "acme@bank.api.meridian.io",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+
+			handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				t.Error("handler should not be called for invalid tenant ID")
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Host = tt.host
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			body, _ := io.ReadAll(rec.Body)
+			assert.Contains(t, string(body), "invalid tenant identifier")
+		})
+	}
+}
+
+func TestTenantResolver_AllowedHosts(t *testing.T) {
+	tests := []struct {
+		name         string
+		host         string
+		allowedHosts []string
+		expectBypass bool
+	}{
+		{
+			name:         "localhost bypassed",
+			host:         "localhost",
+			allowedHosts: []string{"localhost"},
+			expectBypass: true,
+		},
+		{
+			name:         "localhost with port bypassed",
+			host:         "localhost:8080",
+			allowedHosts: []string{"localhost"},
+			expectBypass: true,
+		},
+		{
+			name:         "127.0.0.1 bypassed",
+			host:         "127.0.0.1:8080",
+			allowedHosts: []string{"127.0.0.1"},
+			expectBypass: true,
+		},
+		{
+			name:         "non-allowed host requires tenant",
+			host:         "api.meridian.io",
+			allowedHosts: []string{"localhost"},
+			expectBypass: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolver := middleware.NewTenantResolver("api.meridian.io", tt.allowedHosts)
+
+			handlerCalled := false
+			handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				handlerCalled = true
+				// When bypassed, tenant should not be in context
+				if tt.expectBypass {
+					_, found := tenant.FromContext(r.Context())
+					assert.False(t, found, "tenant should not be in context for bypassed hosts")
+				}
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/test", nil)
+			req.Host = tt.host
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			if tt.expectBypass {
+				assert.True(t, handlerCalled, "handler should be called for bypassed hosts")
+				assert.Equal(t, http.StatusOK, rec.Code)
+			} else {
+				assert.False(t, handlerCalled, "handler should not be called for non-bypassed hosts requiring tenant")
+				assert.Equal(t, http.StatusBadRequest, rec.Code)
+			}
+		})
+	}
+}
+
+func TestTenantResolver_SetsHeader(t *testing.T) {
+	resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+
+	var capturedHeader string
+	handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get(tenant.TenantIDKey)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Host = "acme.api.meridian.io"
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "acme", capturedHeader)
+}
+
+func TestTenantResolver_NestedSubdomain(t *testing.T) {
+	// When there are multiple subdomains, only the first one is used as tenant
+	resolver := middleware.NewTenantResolver("api.meridian.io", nil)
+
+	var capturedTenant tenant.TenantID
+	handler := resolver.Middleware(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedTenant, _ = tenant.FromContext(r.Context())
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.Host = "team.acme.api.meridian.io"
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// Takes the first subdomain segment
+	assert.Equal(t, "team", capturedTenant.String())
+}

--- a/services/gateway/internal/server/proxy.go
+++ b/services/gateway/internal/server/proxy.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/meridianhub/meridian/services/gateway/internal/config"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// ErrNoBackendFound is returned when no backend matches the request path.
+var ErrNoBackendFound = errors.New("no backend found for path")
+
+// ProxyHandler handles proxying requests to backend gRPC services.
+// Currently implements basic HTTP proxying; gRPC-web or connect-go can be added later.
+type ProxyHandler struct {
+	config *config.Config
+	client *http.Client
+	logger *slog.Logger
+}
+
+// NewProxyHandler creates a new proxy handler.
+func NewProxyHandler(cfg *config.Config, logger *slog.Logger) *ProxyHandler {
+	return &ProxyHandler{
+		config: cfg,
+		client: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        100,
+				MaxIdleConnsPerHost: 10,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
+		logger: logger,
+	}
+}
+
+// ServeHTTP handles incoming HTTP requests and routes them to backend services.
+func (p *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Get tenant from context (should be set by TenantResolver middleware)
+	tenantID, ok := tenant.FromContext(r.Context())
+	if !ok {
+		http.Error(w, "tenant context required", http.StatusBadRequest)
+		return
+	}
+
+	// Route to appropriate backend based on path
+	backend, err := p.resolveBackend(r.URL.Path)
+	if err != nil {
+		p.logger.Debug("no backend found for path",
+			"path", r.URL.Path,
+			"tenant", tenantID.String())
+		http.Error(w, "service not found", http.StatusNotFound)
+		return
+	}
+
+	// Build target URL
+	targetURL := fmt.Sprintf("http://%s%s", backend.Target, r.URL.Path)
+	if r.URL.RawQuery != "" {
+		targetURL += "?" + r.URL.RawQuery
+	}
+
+	// Create proxied request
+	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, targetURL, r.Body)
+	if err != nil {
+		p.logger.Error("failed to create proxy request",
+			"error", err,
+			"target", targetURL)
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Copy headers from original request
+	for key, values := range r.Header {
+		for _, value := range values {
+			proxyReq.Header.Add(key, value)
+		}
+	}
+
+	// Ensure tenant header is set for downstream services
+	proxyReq.Header.Set(tenant.TenantIDKey, tenantID.String())
+
+	// Add forwarding headers
+	proxyReq.Header.Set("X-Forwarded-For", r.RemoteAddr)
+	proxyReq.Header.Set("X-Forwarded-Host", r.Host)
+	proxyReq.Header.Set("X-Forwarded-Proto", getScheme(r))
+
+	// Execute proxy request
+	resp, err := p.client.Do(proxyReq)
+	if err != nil {
+		p.logger.Error("proxy request failed",
+			"error", err,
+			"target", targetURL,
+			"tenant", tenantID.String())
+		http.Error(w, "backend service unavailable", http.StatusBadGateway)
+		return
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	// Copy response headers
+	for key, values := range resp.Header {
+		for _, value := range values {
+			w.Header().Add(key, value)
+		}
+	}
+
+	// Write status code
+	w.WriteHeader(resp.StatusCode)
+
+	// Copy response body
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		p.logger.Error("failed to copy response body",
+			"error", err,
+			"target", targetURL)
+	}
+}
+
+// resolveBackend finds the appropriate backend for the given path.
+func (p *ProxyHandler) resolveBackend(path string) (*config.BackendConfig, error) {
+	for _, backend := range p.config.Backends {
+		if strings.HasPrefix(path, backend.PathPrefix) {
+			return &backend, nil
+		}
+	}
+	return nil, fmt.Errorf("%w: %s", ErrNoBackendFound, path)
+}
+
+// getScheme determines the request scheme.
+func getScheme(r *http.Request) string {
+	// Check common proxy headers
+	if scheme := r.Header.Get("X-Forwarded-Proto"); scheme != "" {
+		return scheme
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}

--- a/services/gateway/internal/server/server.go
+++ b/services/gateway/internal/server/server.go
@@ -1,0 +1,107 @@
+// Package server provides the HTTP gateway server.
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/meridianhub/meridian/services/gateway/internal/config"
+	"github.com/meridianhub/meridian/services/gateway/internal/middleware"
+)
+
+// Server is the HTTP gateway server.
+type Server struct {
+	httpServer *http.Server
+	listener   net.Listener
+	logger     *slog.Logger
+	config     *config.Config
+}
+
+// New creates a new gateway server.
+func New(cfg *config.Config, logger *slog.Logger) (*Server, error) {
+	// Create tenant resolver middleware
+	tenantResolver := middleware.NewTenantResolver(
+		cfg.BaseDomain,
+		[]string{"localhost", "127.0.0.1"},
+	)
+
+	// Build handler chain
+	mux := http.NewServeMux()
+
+	// Health endpoint (bypasses tenant resolution via allowed hosts)
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"healthy"}`))
+	})
+
+	// Ready endpoint
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ready"}`))
+	})
+
+	// Proxy handler for backend services
+	proxyHandler := NewProxyHandler(cfg, logger)
+	mux.Handle("/", proxyHandler)
+
+	// Wrap with tenant resolver middleware
+	handler := tenantResolver.Middleware(mux)
+
+	// Create HTTP server with timeouts
+	httpServer := &http.Server{
+		Addr:              fmt.Sprintf(":%d", cfg.Port),
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      60 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+
+	return &Server{
+		httpServer: httpServer,
+		logger:     logger,
+		config:     cfg,
+	}, nil
+}
+
+// Start starts the server and blocks until it's ready.
+func (s *Server) Start(ctx context.Context) error {
+	var err error
+	s.listener, err = (&net.ListenConfig{}).Listen(ctx, "tcp", s.httpServer.Addr)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", s.httpServer.Addr, err)
+	}
+
+	s.logger.Info("gateway server started",
+		"address", s.httpServer.Addr,
+		"base_domain", s.config.BaseDomain)
+
+	go func() {
+		if err := s.httpServer.Serve(s.listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error("server error", "error", err)
+		}
+	}()
+
+	return nil
+}
+
+// Shutdown gracefully shuts down the server.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.logger.Info("shutting down gateway server...")
+	return s.httpServer.Shutdown(ctx)
+}
+
+// Addr returns the server's address.
+func (s *Server) Addr() string {
+	if s.listener != nil {
+		return s.listener.Addr().String()
+	}
+	return s.httpServer.Addr
+}

--- a/services/gateway/k8s/configmap.yaml
+++ b/services/gateway/k8s/configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-config
+  labels:
+    app: gateway
+    component: api-gateway
+data:
+  # Gateway server configuration
+  GATEWAY_PORT: "8080"
+  GATEWAY_BASE_DOMAIN: "api.meridian.io"
+
+  # Backend service endpoints
+  # Format: {SERVICE}_TARGET and {SERVICE}_PATH_PREFIX
+  # If not set, defaults to Kubernetes DNS discovery
+
+  # Current Account Service
+  CURRENT_ACCOUNT_SERVICE_TARGET: "current-account:50051"
+  CURRENT_ACCOUNT_SERVICE_PATH_PREFIX: "/accounts"
+
+  # Party Service
+  PARTY_SERVICE_TARGET: "party:50055"
+  PARTY_SERVICE_PATH_PREFIX: "/parties"
+
+  # Payment Order Service
+  PAYMENT_ORDER_SERVICE_TARGET: "payment-order:50054"
+  PAYMENT_ORDER_SERVICE_PATH_PREFIX: "/payments"
+
+  # Position Keeping Service
+  POSITION_KEEPING_SERVICE_TARGET: "position-keeping:50053"
+  POSITION_KEEPING_SERVICE_PATH_PREFIX: "/positions"
+
+  # Financial Accounting Service
+  FINANCIAL_ACCOUNTING_SERVICE_TARGET: "financial-accounting:50052"
+  FINANCIAL_ACCOUNTING_SERVICE_PATH_PREFIX: "/accounting"
+
+  # Tenant Service
+  TENANT_SERVICE_TARGET: "tenant:50056"
+  TENANT_SERVICE_PATH_PREFIX: "/tenants"
+
+  # Logging configuration
+  LOG_LEVEL: "info"
+  LOG_FORMAT: "json"

--- a/services/gateway/k8s/configmap.yaml
+++ b/services/gateway/k8s/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
 data:
   # Gateway server configuration
   GATEWAY_PORT: "8080"
-  GATEWAY_BASE_DOMAIN: "api.meridian.io"
+  GATEWAY_BASE_DOMAIN: "api.meridianhub.cloud"
 
   # Backend service endpoints
   # Format: {SERVICE}_TARGET and {SERVICE}_PATH_PREFIX

--- a/services/gateway/k8s/deployment.yaml
+++ b/services/gateway/k8s/deployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway
+  labels:
+    app: gateway
+    component: api-gateway
+    tier: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: gateway
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: gateway
+        component: api-gateway
+        tier: frontend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: gateway
+        image: gateway:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: gateway-config
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: http
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        startupProbe:
+          httpGet:
+            path: /health
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 2
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 30
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      terminationGracePeriodSeconds: 30

--- a/services/gateway/k8s/service.yaml
+++ b/services/gateway/k8s/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+  labels:
+    app: gateway
+    component: api-gateway
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 8080
+    targetPort: http
+    protocol: TCP
+  selector:
+    app: gateway

--- a/services/tenant/adapters/persistence/repository_test.go
+++ b/services/tenant/adapters/persistence/repository_test.go
@@ -88,7 +88,7 @@ func TestRepository_Create_WithSubdomain(t *testing.T) {
 	repo := NewRepository(db)
 	ctx := context.Background()
 	tenant := newTestTenant("acme_bank")
-	tenant.Subdomain = "acme-bank.demo.meridian.io"
+	tenant.Subdomain = "acme-bank.demo.meridianhub.cloud"
 
 	err := repo.Create(ctx, tenant)
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestRepository_Create_WithSubdomain(t *testing.T) {
 	// Verify subdomain was saved
 	retrieved, err := repo.GetByID(ctx, tenant.ID)
 	require.NoError(t, err)
-	assert.Equal(t, "acme-bank.demo.meridian.io", retrieved.Subdomain)
+	assert.Equal(t, "acme-bank.demo.meridianhub.cloud", retrieved.Subdomain)
 }
 
 func TestRepository_Create_DuplicateTenant(t *testing.T) {
@@ -126,13 +126,13 @@ func TestRepository_Create_DuplicateSubdomain(t *testing.T) {
 
 	// Create first tenant with subdomain
 	tenant1 := newTestTenant("tenant_one")
-	tenant1.Subdomain = "shared-subdomain.demo.meridian.io"
+	tenant1.Subdomain = "shared-subdomain.demo.meridianhub.cloud"
 	err := repo.Create(ctx, tenant1)
 	require.NoError(t, err)
 
 	// Create second tenant with same subdomain
 	tenant2 := newTestTenant("tenant_two")
-	tenant2.Subdomain = "shared-subdomain.demo.meridian.io"
+	tenant2.Subdomain = "shared-subdomain.demo.meridianhub.cloud"
 	err = repo.Create(ctx, tenant2)
 	assert.True(t, errors.Is(err, ErrSubdomainTaken), "Expected ErrSubdomainTaken, got %v", err)
 }
@@ -228,7 +228,7 @@ func TestRepository_GetBySlug_ReturnsAllFields(t *testing.T) {
 	// Create tenant with all fields populated
 	testTenant := newTestTenant("full_tenant")
 	testTenant.Slug = "full-tenant-slug"
-	testTenant.Subdomain = "full-tenant.demo.meridian.io"
+	testTenant.Subdomain = "full-tenant.demo.meridianhub.cloud"
 	testTenant.DisplayName = "Full Tenant Inc."
 	testTenant.SettlementAsset = "EUR"
 	testTenant.Metadata = map[string]interface{}{
@@ -245,7 +245,7 @@ func TestRepository_GetBySlug_ReturnsAllFields(t *testing.T) {
 
 	assert.Equal(t, testTenant.ID.String(), retrieved.ID.String())
 	assert.Equal(t, "full-tenant-slug", retrieved.Slug)
-	assert.Equal(t, "full-tenant.demo.meridian.io", retrieved.Subdomain)
+	assert.Equal(t, "full-tenant.demo.meridianhub.cloud", retrieved.Subdomain)
 	assert.Equal(t, "Full Tenant Inc.", retrieved.DisplayName)
 	assert.Equal(t, "EUR", retrieved.SettlementAsset)
 	assert.Equal(t, domain.StatusActive, retrieved.Status)

--- a/services/tenant/domain/tenant.go
+++ b/services/tenant/domain/tenant.go
@@ -58,7 +58,7 @@ type Tenant struct {
 	// SettlementAsset is the primary asset for this tenant (e.g., GBP, USD, GPU-HOUR).
 	SettlementAsset string
 
-	// Subdomain is the API subdomain for this tenant (e.g., acme-bank.demo.meridian.io).
+	// Subdomain is the API subdomain for this tenant (e.g., acme-bank.demo.meridianhub.cloud).
 	// Optional - not all tenants need a subdomain.
 	Subdomain string
 

--- a/services/tenant/migrations/20251216000001_initial.sql
+++ b/services/tenant/migrations/20251216000001_initial.sql
@@ -19,11 +19,11 @@ CREATE TABLE tenant (
     -- Primary settlement asset (e.g., GBP, USD, GPU-HOUR, RICE-VOUCHER)
     settlement_asset VARCHAR(20) NOT NULL,
 
-    -- API subdomain (e.g., acme-bank.demo.meridian.io)
+    -- API subdomain (e.g., acme-bank.demo.meridianhub.cloud)
     -- Optional - not all tenants need a subdomain
     subdomain VARCHAR(255),
 
-    -- URL-safe slug for branded API endpoints (e.g., acme → acme.api.meridian.io)
+    -- URL-safe slug for branded API endpoints (e.g., acme → acme.api.meridianhub.cloud)
     -- Separate from subdomain to support both legacy subdomain routing and new slug-based routing
     slug VARCHAR(63),
 
@@ -65,7 +65,7 @@ COMMENT ON TABLE tenant IS 'Multi-tenant platform registry';
 COMMENT ON COLUMN tenant.id IS 'Unique tenant identifier, used for schema routing (org_{id})';
 COMMENT ON COLUMN tenant.settlement_asset IS 'Primary asset for this tenant (ISO currency code or custom asset)';
 COMMENT ON COLUMN tenant.subdomain IS 'API subdomain for tenant-specific endpoints';
-COMMENT ON COLUMN tenant.slug IS 'URL-safe slug for branded API endpoints (e.g., acme → acme.api.meridian.io)';
+COMMENT ON COLUMN tenant.slug IS 'URL-safe slug for branded API endpoints (e.g., acme → acme.api.meridianhub.cloud)';
 COMMENT ON COLUMN tenant.party_id IS 'Reference to corresponding Party in BIAN Party Reference Data Directory (auto-populated on tenant creation)';
 COMMENT ON COLUMN tenant.metadata IS 'Flexible JSON storage for features, quotas, and tenant-specific config';
 COMMENT ON COLUMN tenant.version IS 'Optimistic locking version for concurrent updates';

--- a/services/tenant/service/grpc_service_test.go
+++ b/services/tenant/service/grpc_service_test.go
@@ -68,12 +68,12 @@ func TestService_InitiateTenant_WithSubdomain(t *testing.T) {
 		TenantId:        "acme_bank",
 		DisplayName:     "Acme Bank",
 		SettlementAsset: "USD",
-		Subdomain:       "acme-bank.demo.meridian.io",
+		Subdomain:       "acme-bank.demo.meridianhub.cloud",
 	}
 
 	resp, err := svc.InitiateTenant(ctx, req)
 	require.NoError(t, err)
-	assert.Equal(t, "acme-bank.demo.meridian.io", resp.Tenant.Subdomain)
+	assert.Equal(t, "acme-bank.demo.meridianhub.cloud", resp.Tenant.Subdomain)
 }
 
 func TestService_InitiateTenant_WithMetadata(t *testing.T) {

--- a/shared/pkg/interceptors/doc.go
+++ b/shared/pkg/interceptors/doc.go
@@ -40,7 +40,7 @@
 //   - With AUTH_ENABLED=false: Use auth.TenantExtractionInterceptor() (header extraction only)
 //
 // The x-tenant-id header is set by the API gateway's TenantResolverMiddleware based on
-// the subdomain (e.g., "acme.api.meridian.io" -> x-tenant-id: "org_acme_uuid").
+// the subdomain (e.g., "acme.api.meridianhub.cloud" -> x-tenant-id: "org_acme_uuid").
 // The auth interceptor's double-check ensures a user's JWT tenant matches the subdomain
 // they're accessing, preventing subdomain hopping attacks.
 //

--- a/shared/platform/auth/tenant_interceptor.go
+++ b/shared/platform/auth/tenant_interceptor.go
@@ -19,7 +19,7 @@ import (
 //     trusts the x-tenant-id header without JWT validation (development/testing only).
 //
 // The x-tenant-id header is set by the API gateway's TenantResolverMiddleware based on
-// the request subdomain (e.g., "acme.api.meridian.io" -> x-tenant-id: "org_acme_uuid").
+// the request subdomain (e.g., "acme.api.meridianhub.cloud" -> x-tenant-id: "org_acme_uuid").
 //
 // Use case: Service A calls Service B with tenant in metadata. Service B
 // extracts the tenant from metadata and injects it into context, enabling multi-hop

--- a/shared/platform/gateway/tenant_resolver.go
+++ b/shared/platform/gateway/tenant_resolver.go
@@ -2,7 +2,7 @@
 //
 // Example usage:
 //
-//	resolver, err := NewTenantResolverMiddleware(cache, repo, "api.meridian.io", logger)
+//	resolver, err := NewTenantResolverMiddleware(cache, repo, "api.meridianhub.cloud", logger)
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
@@ -171,21 +171,21 @@ func (m *TenantResolverMiddleware) Handler(next http.Handler) http.Handler {
 // extractSlug extracts the subdomain slug from a Host header value.
 //
 // The method:
-// 1. Strips any port number from the host (e.g., "acme.api.meridian.io:8080" → "acme.api.meridian.io")
+// 1. Strips any port number from the host (e.g., "acme.api.meridianhub.cloud:8080" → "acme.api.meridianhub.cloud")
 // 2. Validates the host ends with ".<baseDomain>"
 // 3. Extracts the subdomain slug by removing the base domain suffix
 //
 // Returns an empty string for:
 // - Invalid domain patterns (doesn't match base domain)
-// - No subdomain present (e.g., "api.meridian.io" when baseDomain is "api.meridian.io")
+// - No subdomain present (e.g., "api.meridianhub.cloud" when baseDomain is "api.meridianhub.cloud")
 // - Direct IP addresses (IPv4 or IPv6)
 // - localhost
 //
-// Examples (assuming baseDomain = "api.meridian.io"):
-//   - "acme.api.meridian.io" → "acme"
-//   - "acme.api.meridian.io:8080" → "acme"
-//   - "acme.staging.api.meridian.io" → "acme.staging"
-//   - "api.meridian.io" → "" (no subdomain)
+// Examples (assuming baseDomain = "api.meridianhub.cloud"):
+//   - "acme.api.meridianhub.cloud" → "acme"
+//   - "acme.api.meridianhub.cloud:8080" → "acme"
+//   - "acme.staging.api.meridianhub.cloud" → "acme.staging"
+//   - "api.meridianhub.cloud" → "" (no subdomain)
 //   - "invalid.com" → "" (wrong domain)
 //   - "192.168.1.1" → "" (IP address)
 //   - "localhost" → ""

--- a/shared/platform/gateway/tenant_resolver_test.go
+++ b/shared/platform/gateway/tenant_resolver_test.go
@@ -131,134 +131,134 @@ func TestExtractSlug(t *testing.T) {
 	}{
 		{
 			name:       "valid single subdomain",
-			baseDomain: "api.meridian.io",
-			host:       "acme.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme.api.meridianhub.cloud",
 			want:       "acme",
 			reason:     "should extract single-level subdomain",
 		},
 		{
 			name:       "valid single subdomain with port",
-			baseDomain: "api.meridian.io",
-			host:       "acme.api.meridian.io:8080",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme.api.meridianhub.cloud:8080",
 			want:       "acme",
 			reason:     "should strip port and extract subdomain",
 		},
 		{
 			name:       "valid multi-level subdomain",
-			baseDomain: "api.meridian.io",
-			host:       "acme.staging.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme.staging.api.meridianhub.cloud",
 			want:       "acme.staging",
 			reason:     "should extract multi-level subdomain",
 		},
 		{
 			name:       "valid multi-level subdomain with port",
-			baseDomain: "api.meridian.io",
-			host:       "acme.staging.api.meridian.io:9090",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme.staging.api.meridianhub.cloud:9090",
 			want:       "acme.staging",
 			reason:     "should strip port and extract multi-level subdomain",
 		},
 		{
 			name:       "no subdomain - exact match",
-			baseDomain: "api.meridian.io",
-			host:       "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "api.meridianhub.cloud",
 			want:       "",
 			reason:     "should return empty for direct base domain access",
 		},
 		{
 			name:       "no subdomain - exact match with port",
-			baseDomain: "api.meridian.io",
-			host:       "api.meridian.io:8080",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "api.meridianhub.cloud:8080",
 			want:       "",
 			reason:     "should return empty for direct base domain access with port",
 		},
 		{
 			name:       "wrong domain",
-			baseDomain: "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
 			host:       "invalid.com",
 			want:       "",
 			reason:     "should return empty for non-matching domain",
 		},
 		{
 			name:       "wrong domain with port",
-			baseDomain: "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
 			host:       "invalid.com:8080",
 			want:       "",
 			reason:     "should return empty for non-matching domain with port",
 		},
 		{
 			name:       "IPv4 address",
-			baseDomain: "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
 			host:       "192.168.1.1",
 			want:       "",
 			reason:     "should return empty for IPv4 address",
 		},
 		{
 			name:       "IPv4 address with port",
-			baseDomain: "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
 			host:       "192.168.1.1:8080",
 			want:       "",
 			reason:     "should return empty for IPv4 address with port",
 		},
 		{
 			name:       "IPv6 address",
-			baseDomain: "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
 			host:       "[2001:db8::1]",
 			want:       "",
 			reason:     "should return empty for IPv6 address",
 		},
 		{
 			name:       "IPv6 address with port bracket notation",
-			baseDomain: "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
 			host:       "[2001:db8::1]:8080",
 			want:       "",
 			reason:     "should return empty for IPv6 address with port in bracket notation",
 		},
 		{
 			name:       "IPv6 address without brackets",
-			baseDomain: "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
 			host:       "2001:db8::1",
 			want:       "",
 			reason:     "should return empty for IPv6 address without brackets",
 		},
 		{
 			name:       "localhost",
-			baseDomain: "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
 			host:       "localhost",
 			want:       "",
 			reason:     "should return empty for localhost",
 		},
 		{
 			name:       "localhost with port",
-			baseDomain: "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
 			host:       "localhost:8080",
 			want:       "",
 			reason:     "should return empty for localhost with port",
 		},
 		{
 			name:       "empty host",
-			baseDomain: "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
 			host:       "",
 			want:       "",
 			reason:     "should return empty for empty host",
 		},
 		{
 			name:       "partial domain match",
-			baseDomain: "api.meridian.io",
-			host:       "acme.badapi.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme.badapi.meridianhub.cloud",
 			want:       "",
 			reason:     "should return empty when suffix matches but not exact base domain",
 		},
 		{
 			name:       "domain with hyphen in subdomain",
-			baseDomain: "api.meridian.io",
-			host:       "acme-corp.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme-corp.api.meridianhub.cloud",
 			want:       "acme-corp",
 			reason:     "should handle hyphens in subdomain",
 		},
 		{
 			name:       "domain with number in subdomain",
-			baseDomain: "api.meridian.io",
-			host:       "acme123.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme123.api.meridianhub.cloud",
 			want:       "acme123",
 			reason:     "should handle numbers in subdomain",
 		},
@@ -271,86 +271,86 @@ func TestExtractSlug(t *testing.T) {
 		},
 		{
 			name:       "host shorter than base domain",
-			baseDomain: "api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
 			host:       "short.io",
 			want:       "",
 			reason:     "should return empty when host is shorter than base domain",
 		},
 		{
 			name:       "high port number",
-			baseDomain: "api.meridian.io",
-			host:       "acme.api.meridian.io:65535",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme.api.meridianhub.cloud:65535",
 			want:       "acme",
 			reason:     "should handle high port numbers",
 		},
 		{
 			name:       "port with leading zeros",
-			baseDomain: "api.meridian.io",
-			host:       "acme.api.meridian.io:0080",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme.api.meridianhub.cloud:0080",
 			want:       "acme",
 			reason:     "should handle ports with leading zeros",
 		},
 		// Invalid slug format test cases (security validation)
 		{
 			name:       "slug starting with hyphen",
-			baseDomain: "api.meridian.io",
-			host:       "-acme.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "-acme.api.meridianhub.cloud",
 			want:       "",
 			reason:     "should reject slug starting with hyphen",
 		},
 		{
 			name:       "slug ending with hyphen",
-			baseDomain: "api.meridian.io",
-			host:       "acme-.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme-.api.meridianhub.cloud",
 			want:       "",
 			reason:     "should reject slug ending with hyphen",
 		},
 		{
 			name:       "slug with consecutive hyphens",
-			baseDomain: "api.meridian.io",
-			host:       "acme--corp.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme--corp.api.meridianhub.cloud",
 			want:       "",
 			reason:     "should reject slug with consecutive hyphens",
 		},
 		{
 			name:       "slug starting with period",
-			baseDomain: "api.meridian.io",
-			host:       ".acme.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       ".acme.api.meridianhub.cloud",
 			want:       "",
 			reason:     "should reject slug starting with period",
 		},
 		{
 			name:       "slug ending with period",
-			baseDomain: "api.meridian.io",
-			host:       "acme..api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme..api.meridianhub.cloud",
 			want:       "",
 			reason:     "should reject slug ending with period",
 		},
 		{
 			name:       "slug with uppercase letters",
-			baseDomain: "api.meridian.io",
-			host:       "ACME.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "ACME.api.meridianhub.cloud",
 			want:       "",
 			reason:     "should reject slug with uppercase letters",
 		},
 		{
 			name:       "slug with mixed case",
-			baseDomain: "api.meridian.io",
-			host:       "Acme-Corp.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "Acme-Corp.api.meridianhub.cloud",
 			want:       "",
 			reason:     "should reject slug with mixed case",
 		},
 		{
 			name:       "slug with special characters",
-			baseDomain: "api.meridian.io",
-			host:       "acme_corp.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme_corp.api.meridianhub.cloud",
 			want:       "",
 			reason:     "should reject slug with underscore",
 		},
 		{
 			name:       "slug with consecutive periods",
-			baseDomain: "api.meridian.io",
-			host:       "acme..staging.api.meridian.io",
+			baseDomain: "api.meridianhub.cloud",
+			host:       "acme..staging.api.meridianhub.cloud",
 			want:       "",
 			reason:     "should reject slug with consecutive periods",
 		},
@@ -401,7 +401,7 @@ func TestResolveTenant(t *testing.T) {
 		middleware := &TenantResolverMiddleware{
 			slugCache:  mockCache,
 			tenantRepo: mockRepo,
-			baseDomain: "meridian.io",
+			baseDomain: "meridianhub.cloud",
 			logger:     logger,
 		}
 
@@ -433,7 +433,7 @@ func TestResolveTenant(t *testing.T) {
 		middleware := &TenantResolverMiddleware{
 			slugCache:  mockCache,
 			tenantRepo: mockRepo,
-			baseDomain: "meridian.io",
+			baseDomain: "meridianhub.cloud",
 			logger:     logger,
 		}
 
@@ -462,7 +462,7 @@ func TestResolveTenant(t *testing.T) {
 		middleware := &TenantResolverMiddleware{
 			slugCache:  mockCache,
 			tenantRepo: mockRepo,
-			baseDomain: "meridian.io",
+			baseDomain: "meridianhub.cloud",
 			logger:     logger,
 		}
 
@@ -494,7 +494,7 @@ func TestResolveTenant(t *testing.T) {
 		middleware := &TenantResolverMiddleware{
 			slugCache:  mockCache,
 			tenantRepo: mockRepo,
-			baseDomain: "meridian.io",
+			baseDomain: "meridianhub.cloud",
 			logger:     logger,
 		}
 
@@ -524,7 +524,7 @@ func TestResolveTenant(t *testing.T) {
 		middleware := &TenantResolverMiddleware{
 			slugCache:  mockCache,
 			tenantRepo: mockRepo,
-			baseDomain: "meridian.io",
+			baseDomain: "meridianhub.cloud",
 			logger:     logger,
 		}
 
@@ -553,7 +553,7 @@ func TestResolveTenant(t *testing.T) {
 		middleware := &TenantResolverMiddleware{
 			slugCache:  mockCache,
 			tenantRepo: mockRepo,
-			baseDomain: "meridian.io",
+			baseDomain: "meridianhub.cloud",
 			logger:     logger,
 		}
 
@@ -588,7 +588,7 @@ func TestResolveTenant(t *testing.T) {
 		middleware := &TenantResolverMiddleware{
 			slugCache:  mockCache,
 			tenantRepo: mockRepo,
-			baseDomain: "meridian.io",
+			baseDomain: "meridianhub.cloud",
 			logger:     logger,
 		}
 
@@ -610,9 +610,9 @@ func TestResolveTenant(t *testing.T) {
 // slug extraction, tenant resolution, header injection, and context propagation.
 func TestServeHTTP(t *testing.T) {
 	ctx := context.Background()
-	baseDomain := "api.meridian.io"
+	baseDomain := "api.meridianhub.cloud"
 	testSlug := "acme"
-	testHost := "acme.api.meridian.io"
+	testHost := "acme.api.meridianhub.cloud"
 	testTenantID := tenant.MustNewTenantID("tenant_123")
 	testTenant := &domain.Tenant{
 		ID:          testTenantID,
@@ -688,7 +688,7 @@ func TestServeHTTP(t *testing.T) {
 		}
 
 		// Create test request with no subdomain
-		req := httptest.NewRequest(http.MethodGet, "http://api.meridian.io/api/test", nil)
+		req := httptest.NewRequest(http.MethodGet, "http://api.meridianhub.cloud/api/test", nil)
 		req = req.WithContext(ctx)
 		rec := httptest.NewRecorder()
 
@@ -844,7 +844,7 @@ func TestServeHTTP(t *testing.T) {
 		logger := slog.Default()
 
 		multiLevelSlug := "acme.staging"
-		multiLevelHost := "acme.staging.api.meridian.io"
+		multiLevelHost := "acme.staging.api.meridianhub.cloud"
 		multiLevelTenantID := tenant.MustNewTenantID("tenant_456")
 
 		// Setup: Cache hit for multi-level slug


### PR DESCRIPTION
## Summary

- Configure Kubernetes Ingress with wildcard subdomain routing (`*.api.meridianhub.cloud`)
- Implement gateway service with TenantResolverMiddleware for subdomain-to-tenant resolution
- Set up cert-manager ClusterIssuer for automated wildcard TLS certificates via DNS-01 challenge
- Add Tilt integration for local development with X-Tenant header fallback

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 65

## Changes Made

- `deployments/k8s/local/ingress.yaml` - Wildcard Ingress with TLS termination
- `deployments/k8s/local/cert-manager-issuer.yaml` - Let's Encrypt ClusterIssuers (prod + staging)
- `services/gateway/` - New HTTP gateway service with tenant resolution middleware
- `Tiltfile` - Gateway service integration with port forwarding and dependencies

## Test Plan

1. **DNS verification**: `nslookup <tenant>.api.meridianhub.cloud`
2. **TLS verification**: `curl https://<tenant>.api.meridianhub.cloud/health` with cert validation
3. **Routing tests**: Requests to different subdomains route to gateway
4. **Local development**: `curl -H "X-Tenant: acme" localhost:8080/accounts`
5. **Integration test**: subdomain → gateway → tenant resolution → backend

---

## Known Issues & Follow-up Work

### Architecture Decisions Needed

**Duplicate TenantResolver implementations**

There are now two tenant resolver implementations:
- `services/gateway/internal/middleware/tenant_resolver.go` (new, simpler - no caching, no DB lookup)
- `shared/platform/gateway/tenant_resolver.go` (existing, with caching and DB lookup)

The gateway service implementation is intentionally simpler for the initial ingress routing layer. Consider documenting the relationship between these or consolidating. Question: Should the gateway eventually use the shared implementation for full tenant validation?

**Config validation**

`LoadFromEnv()` in `config/config.go` silently falls back to defaults on parse errors. Consider logging when invalid values are provided so operators know their config is not being applied.

### Potential Bugs or Issues

**Health endpoints require tenant on non-localhost hosts**

In `server.go:54-55`, the tenant resolver middleware wraps the entire mux. This means `/health` and `/ready` endpoints are only accessible when:
- Called from localhost/127.0.0.1 (allowed hosts), OR
- Called with a valid tenant subdomain

For Kubernetes ingress health checks hitting `api.meridianhub.cloud/health`, requests would fail with "tenant subdomain required". The pod-level health checks in `deployment.yaml` use the pod IP so they should work, but external health checks (e.g., load balancer health probes) may fail.

**Inconsistent tenant ID validation**

The TenantResolver in the gateway service uses `tenant.NewTenantID()` for validation, but tests show tenants with hyphens (e.g., "acme-bank") fail validation. However, the shared `tenant_resolver.go` allows hyphens via its slug pattern. This could cause confusion for operators trying to use hyphenated tenant slugs.

**Port stripping logic**

In `tenant_resolver.go:39-44`, the manual port stripping handles IPv6 correctly, but the shared implementation uses `net.SplitHostPort()` which is more robust. Consider using that for consistency.

### Performance Considerations

- **Backend resolution is O(n)**: `resolveBackend()` iterates through all backends on every request. With 6 backends this is fine, but consider documenting the expected scale or using a more efficient structure (e.g., radix tree) if more routes are expected.
- **No request body size limits**: The proxy passes `r.Body` directly to the backend. Consider adding `MaxBytesReader` or similar to prevent memory exhaustion from large request bodies.
- **Response streaming**: `io.Copy(w, resp.Body)` is good for streaming, but errors during copy are only logged. Consider if partial responses should be handled differently.

### Security Concerns

**Secrets in YAML files**

`cert-manager-issuer.yaml` contains placeholder for Cloudflare API token. Should be populated via a secrets management tool (sealed secrets/external-secrets-operator).

**X-Tenant header spoofing**

The gateway accepts tenant from `X-Tenant` header (for local dev), which takes precedence over subdomain extraction. In production, an attacker could bypass subdomain validation by setting this header. Consider:
- Only allowing X-Tenant when a specific env var/config flag is set
- Stripping X-Tenant header from external requests at the ingress level

**X-Forwarded-For header handling**

In `proxy.go:89`, `proxyReq.Header.Set("X-Forwarded-For", r.RemoteAddr)` overwrites any existing X-Forwarded-For header. When behind nginx ingress, the original client IP is already in X-Forwarded-For. Consider appending to the existing header instead of overwriting.

### Test Coverage Gaps

- **Missing tests for `proxy.go` and `server.go`**: The main proxy logic has no unit tests. Consider adding tests for backend resolution, header propagation, and error handling for backend unavailability.
- **Missing tests for `config.go`**: Configuration loading is not tested, including environment variable parsing, default value fallbacks, and backend configuration loading.
- **Integration test gap**: Consider adding an integration test that starts the server and verifies end-to-end tenant resolution and proxying.