### PR TITLE
feat(gateway): add in-memory slug cache for local development

### DIFF
--- a/shared/platform/gateway/inmemory_cache.go
+++ b/shared/platform/gateway/inmemory_cache.go
@@ -1,0 +1,199 @@
+// Package gateway provides HTTP middleware for API gateway functionality.
+package gateway
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// DefaultCacheTTL is the default time-to-live for cache entries.
+const DefaultCacheTTL = 5 * time.Minute
+
+// DefaultCleanupInterval is the default interval for background cleanup of expired entries.
+const DefaultCleanupInterval = 1 * time.Minute
+
+// cacheEntry holds a cached tenant ID with its expiration time.
+type cacheEntry struct {
+	tenantID  tenant.TenantID
+	expiresAt time.Time
+}
+
+// isExpired returns true if the cache entry has expired.
+func (e cacheEntry) isExpired() bool {
+	return time.Now().After(e.expiresAt)
+}
+
+// InMemorySlugCache is a thread-safe in-memory cache for slug-to-tenant-ID mappings.
+// It implements the slugCache interface and provides TTL-based expiration with
+// automatic background cleanup of expired entries.
+//
+// This cache is intended for local development without Redis dependency.
+// For production use, consider a distributed cache like Redis.
+type InMemorySlugCache struct {
+	mu              sync.RWMutex
+	cache           map[string]cacheEntry
+	ttl             time.Duration
+	cleanupInterval time.Duration
+	stopCleanup     chan struct{}
+	cleanupDone     chan struct{}
+}
+
+// InMemoryCacheOption is a functional option for configuring InMemorySlugCache.
+type InMemoryCacheOption func(*InMemorySlugCache)
+
+// WithTTL sets the time-to-live for cache entries.
+func WithTTL(ttl time.Duration) InMemoryCacheOption {
+	return func(c *InMemorySlugCache) {
+		if ttl > 0 {
+			c.ttl = ttl
+		}
+	}
+}
+
+// WithCleanupInterval sets the interval for background cleanup of expired entries.
+func WithCleanupInterval(interval time.Duration) InMemoryCacheOption {
+	return func(c *InMemorySlugCache) {
+		if interval > 0 {
+			c.cleanupInterval = interval
+		}
+	}
+}
+
+// NewInMemorySlugCache creates a new in-memory slug cache with the given options.
+// It starts a background goroutine to periodically clean up expired entries.
+// Call Stop() to release resources when the cache is no longer needed.
+func NewInMemorySlugCache(opts ...InMemoryCacheOption) *InMemorySlugCache {
+	c := &InMemorySlugCache{
+		cache:           make(map[string]cacheEntry),
+		ttl:             DefaultCacheTTL,
+		cleanupInterval: DefaultCleanupInterval,
+		stopCleanup:     make(chan struct{}),
+		cleanupDone:     make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	// Start background cleanup goroutine
+	go c.cleanupLoop()
+
+	return c
+}
+
+// Get retrieves a tenant ID for the given slug from the cache.
+// Returns an empty TenantID for cache miss (not an error).
+// Context cancellation is respected.
+func (c *InMemorySlugCache) Get(ctx context.Context, slug string) (tenant.TenantID, error) {
+	// Check context first
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+	}
+
+	if slug == "" {
+		return "", nil
+	}
+
+	c.mu.RLock()
+	entry, ok := c.cache[slug]
+	c.mu.RUnlock()
+
+	if !ok {
+		return "", nil
+	}
+
+	// Check if entry has expired
+	if entry.isExpired() {
+		// Entry expired - treat as cache miss
+		// Cleanup goroutine will eventually remove it
+		return "", nil
+	}
+
+	return entry.tenantID, nil
+}
+
+// Set stores a tenant ID for the given slug in the cache.
+// The entry will expire after the configured TTL.
+// Context cancellation is respected.
+func (c *InMemorySlugCache) Set(ctx context.Context, slug string, tenantID tenant.TenantID) error {
+	// Check context first
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	if slug == "" {
+		return nil
+	}
+
+	c.mu.Lock()
+	c.cache[slug] = cacheEntry{
+		tenantID:  tenantID,
+		expiresAt: time.Now().Add(c.ttl),
+	}
+	c.mu.Unlock()
+
+	return nil
+}
+
+// Stop stops the background cleanup goroutine and releases resources.
+// It blocks until the cleanup goroutine has exited.
+// Safe to call multiple times.
+func (c *InMemorySlugCache) Stop() {
+	select {
+	case <-c.stopCleanup:
+		// Already stopped
+		return
+	default:
+		close(c.stopCleanup)
+	}
+
+	// Wait for cleanup goroutine to finish
+	<-c.cleanupDone
+}
+
+// cleanupLoop runs in the background and periodically removes expired entries.
+func (c *InMemorySlugCache) cleanupLoop() {
+	defer close(c.cleanupDone)
+
+	ticker := time.NewTicker(c.cleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.stopCleanup:
+			return
+		case <-ticker.C:
+			c.removeExpiredEntries()
+		}
+	}
+}
+
+// removeExpiredEntries removes all expired entries from the cache.
+func (c *InMemorySlugCache) removeExpiredEntries() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for slug, entry := range c.cache {
+		if now.After(entry.expiresAt) {
+			delete(c.cache, slug)
+		}
+	}
+}
+
+// Size returns the number of entries in the cache (for testing).
+func (c *InMemorySlugCache) Size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.cache)
+}
+
+// Compile-time interface check.
+var _ slugCache = (*InMemorySlugCache)(nil)

--- a/shared/platform/gateway/inmemory_cache.go
+++ b/shared/platform/gateway/inmemory_cache.go
@@ -39,6 +39,7 @@ type InMemorySlugCache struct {
 	cleanupInterval time.Duration
 	stopCleanup     chan struct{}
 	cleanupDone     chan struct{}
+	stopOnce        sync.Once
 }
 
 // InMemoryCacheOption is a functional option for configuring InMemorySlugCache.
@@ -146,14 +147,9 @@ func (c *InMemorySlugCache) Set(ctx context.Context, slug string, tenantID tenan
 // It blocks until the cleanup goroutine has exited.
 // Safe to call multiple times.
 func (c *InMemorySlugCache) Stop() {
-	select {
-	case <-c.stopCleanup:
-		// Already stopped
-		return
-	default:
+	c.stopOnce.Do(func() {
 		close(c.stopCleanup)
-	}
-
+	})
 	// Wait for cleanup goroutine to finish
 	<-c.cleanupDone
 }

--- a/shared/platform/gateway/inmemory_cache_test.go
+++ b/shared/platform/gateway/inmemory_cache_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -306,8 +307,8 @@ func TestInMemorySlugCache_ConcurrentAccess(t *testing.T) {
 			go func(idx int) {
 				defer wg.Done()
 
-				slug := "slug_" + string(rune('a'+idx%26))
-				tenantID := tenant.MustNewTenantID("tenant_" + string(rune('0'+idx%10)))
+				slug := fmt.Sprintf("slug_%d", idx)
+				tenantID := tenant.MustNewTenantID(fmt.Sprintf("tenant_%d", idx))
 
 				err := cache.Set(ctx, slug, tenantID)
 				assert.NoError(t, err)
@@ -360,13 +361,16 @@ func TestInMemorySlugCache_Size(t *testing.T) {
 
 		assert.Equal(t, 0, cache.Size())
 
-		cache.Set(ctx, "a", tenant.MustNewTenantID("t1"))
+		err := cache.Set(ctx, "a", tenant.MustNewTenantID("t1"))
+		require.NoError(t, err)
 		assert.Equal(t, 1, cache.Size())
 
-		cache.Set(ctx, "b", tenant.MustNewTenantID("t2"))
+		err = cache.Set(ctx, "b", tenant.MustNewTenantID("t2"))
+		require.NoError(t, err)
 		assert.Equal(t, 2, cache.Size())
 
-		cache.Set(ctx, "c", tenant.MustNewTenantID("t3"))
+		err = cache.Set(ctx, "c", tenant.MustNewTenantID("t3"))
+		require.NoError(t, err)
 		assert.Equal(t, 3, cache.Size())
 	})
 }

--- a/shared/platform/gateway/inmemory_cache_test.go
+++ b/shared/platform/gateway/inmemory_cache_test.go
@@ -1,0 +1,375 @@
+package gateway
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInMemorySlugCache(t *testing.T) {
+	t.Run("creates cache with default settings", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		assert.NotNil(t, cache)
+		assert.Equal(t, DefaultCacheTTL, cache.ttl)
+		assert.Equal(t, DefaultCleanupInterval, cache.cleanupInterval)
+	})
+
+	t.Run("creates cache with custom TTL", func(t *testing.T) {
+		customTTL := 10 * time.Minute
+		cache := NewInMemorySlugCache(WithTTL(customTTL))
+		defer cache.Stop()
+
+		assert.Equal(t, customTTL, cache.ttl)
+	})
+
+	t.Run("creates cache with custom cleanup interval", func(t *testing.T) {
+		customInterval := 30 * time.Second
+		cache := NewInMemorySlugCache(WithCleanupInterval(customInterval))
+		defer cache.Stop()
+
+		assert.Equal(t, customInterval, cache.cleanupInterval)
+	})
+
+	t.Run("ignores invalid TTL", func(t *testing.T) {
+		cache := NewInMemorySlugCache(WithTTL(0))
+		defer cache.Stop()
+
+		assert.Equal(t, DefaultCacheTTL, cache.ttl)
+	})
+
+	t.Run("ignores invalid cleanup interval", func(t *testing.T) {
+		cache := NewInMemorySlugCache(WithCleanupInterval(-1 * time.Second))
+		defer cache.Stop()
+
+		assert.Equal(t, DefaultCleanupInterval, cache.cleanupInterval)
+	})
+}
+
+func TestInMemorySlugCache_Get(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns empty TenantID for cache miss", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		tenantID, err := cache.Get(ctx, "nonexistent")
+
+		require.NoError(t, err)
+		assert.True(t, tenantID.IsEmpty(), "should return empty TenantID for cache miss")
+	})
+
+	t.Run("returns cached tenant ID on hit", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		expectedTenantID := tenant.MustNewTenantID("tenant_123")
+		err := cache.Set(ctx, "acme", expectedTenantID)
+		require.NoError(t, err)
+
+		tenantID, err := cache.Get(ctx, "acme")
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedTenantID, tenantID)
+	})
+
+	t.Run("returns empty TenantID for empty slug", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		tenantID, err := cache.Get(ctx, "")
+
+		require.NoError(t, err)
+		assert.True(t, tenantID.IsEmpty())
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		tenantID, err := cache.Get(cancelledCtx, "acme")
+
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.True(t, tenantID.IsEmpty())
+	})
+}
+
+func TestInMemorySlugCache_Set(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("stores tenant ID successfully", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		expectedTenantID := tenant.MustNewTenantID("tenant_123")
+		err := cache.Set(ctx, "acme", expectedTenantID)
+		require.NoError(t, err)
+
+		tenantID, err := cache.Get(ctx, "acme")
+		require.NoError(t, err)
+		assert.Equal(t, expectedTenantID, tenantID)
+	})
+
+	t.Run("overwrites existing entry", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		firstTenantID := tenant.MustNewTenantID("tenant_1")
+		secondTenantID := tenant.MustNewTenantID("tenant_2")
+
+		err := cache.Set(ctx, "acme", firstTenantID)
+		require.NoError(t, err)
+
+		err = cache.Set(ctx, "acme", secondTenantID)
+		require.NoError(t, err)
+
+		tenantID, err := cache.Get(ctx, "acme")
+		require.NoError(t, err)
+		assert.Equal(t, secondTenantID, tenantID)
+	})
+
+	t.Run("ignores empty slug", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		err := cache.Set(ctx, "", tenant.MustNewTenantID("tenant_123"))
+		require.NoError(t, err)
+		assert.Equal(t, 0, cache.Size())
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		err := cache.Set(cancelledCtx, "acme", tenant.MustNewTenantID("tenant_123"))
+
+		assert.ErrorIs(t, err, context.Canceled)
+		assert.Equal(t, 0, cache.Size())
+	})
+}
+
+func TestInMemorySlugCache_TTLExpiration(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("expired entries return empty TenantID", func(t *testing.T) {
+		// Use very short TTL for testing
+		cache := NewInMemorySlugCache(
+			WithTTL(50*time.Millisecond),
+			WithCleanupInterval(1*time.Hour), // Disable auto cleanup for this test
+		)
+		defer cache.Stop()
+
+		tenantID := tenant.MustNewTenantID("tenant_123")
+		err := cache.Set(ctx, "acme", tenantID)
+		require.NoError(t, err)
+
+		// Verify entry exists
+		result, err := cache.Get(ctx, "acme")
+		require.NoError(t, err)
+		assert.Equal(t, tenantID, result)
+
+		// Wait for expiration using await
+		err = await.New().
+			AtMost(1 * time.Second).
+			PollInterval(10 * time.Millisecond).
+			Until(func() bool {
+				result, _ := cache.Get(ctx, "acme")
+				return result.IsEmpty()
+			})
+
+		require.NoError(t, err, "entry should have expired")
+	})
+
+	t.Run("non-expired entries are returned", func(t *testing.T) {
+		cache := NewInMemorySlugCache(WithTTL(1 * time.Hour))
+		defer cache.Stop()
+
+		tenantID := tenant.MustNewTenantID("tenant_123")
+		err := cache.Set(ctx, "acme", tenantID)
+		require.NoError(t, err)
+
+		// Should still be valid
+		result, err := cache.Get(ctx, "acme")
+		require.NoError(t, err)
+		assert.Equal(t, tenantID, result)
+	})
+}
+
+func TestInMemorySlugCache_BackgroundCleanup(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("removes expired entries periodically", func(t *testing.T) {
+		cache := NewInMemorySlugCache(
+			WithTTL(50*time.Millisecond),
+			WithCleanupInterval(100*time.Millisecond),
+		)
+		defer cache.Stop()
+
+		tenantID := tenant.MustNewTenantID("tenant_123")
+		err := cache.Set(ctx, "acme", tenantID)
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, cache.Size())
+
+		// Wait for cleanup to remove expired entry
+		err = await.New().
+			AtMost(1 * time.Second).
+			PollInterval(20 * time.Millisecond).
+			Until(func() bool {
+				return cache.Size() == 0
+			})
+
+		require.NoError(t, err, "cleanup should have removed expired entry")
+	})
+
+	t.Run("keeps non-expired entries", func(t *testing.T) {
+		cache := NewInMemorySlugCache(
+			WithTTL(1*time.Hour),
+			WithCleanupInterval(50*time.Millisecond),
+		)
+		defer cache.Stop()
+
+		tenantID := tenant.MustNewTenantID("tenant_123")
+		err := cache.Set(ctx, "acme", tenantID)
+		require.NoError(t, err)
+
+		// Wait for multiple cleanup cycles
+		time.Sleep(150 * time.Millisecond)
+
+		// Entry should still exist
+		assert.Equal(t, 1, cache.Size())
+		result, err := cache.Get(ctx, "acme")
+		require.NoError(t, err)
+		assert.Equal(t, tenantID, result)
+	})
+}
+
+func TestInMemorySlugCache_ConcurrentAccess(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("handles concurrent reads and writes safely", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		const numGoroutines = 100
+		const numOperations = 50
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+
+				slug := "slug"
+				tenantID := tenant.MustNewTenantID("tenant_123")
+
+				for j := 0; j < numOperations; j++ {
+					// Alternate between reads and writes
+					if j%2 == 0 {
+						_, err := cache.Get(ctx, slug)
+						assert.NoError(t, err)
+					} else {
+						err := cache.Set(ctx, slug, tenantID)
+						assert.NoError(t, err)
+					}
+				}
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	t.Run("concurrent writes to different keys", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		const numGoroutines = 100
+
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		for i := 0; i < numGoroutines; i++ {
+			go func(idx int) {
+				defer wg.Done()
+
+				slug := "slug_" + string(rune('a'+idx%26))
+				tenantID := tenant.MustNewTenantID("tenant_" + string(rune('0'+idx%10)))
+
+				err := cache.Set(ctx, slug, tenantID)
+				assert.NoError(t, err)
+
+				result, err := cache.Get(ctx, slug)
+				assert.NoError(t, err)
+				assert.False(t, result.IsEmpty(), "should have cached value")
+			}(i)
+		}
+
+		wg.Wait()
+	})
+}
+
+func TestInMemorySlugCache_Stop(t *testing.T) {
+	t.Run("stops cleanup goroutine", func(t *testing.T) {
+		cache := NewInMemorySlugCache(WithCleanupInterval(10 * time.Millisecond))
+
+		// Stop should complete without hanging
+		done := make(chan struct{})
+		go func() {
+			cache.Stop()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			// Success - Stop returned
+		case <-time.After(1 * time.Second):
+			t.Fatal("Stop() did not return within timeout")
+		}
+	})
+
+	t.Run("is safe to call multiple times", func(_ *testing.T) {
+		cache := NewInMemorySlugCache()
+
+		// Should not panic
+		cache.Stop()
+		cache.Stop()
+		cache.Stop()
+	})
+}
+
+func TestInMemorySlugCache_Size(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns correct count", func(t *testing.T) {
+		cache := NewInMemorySlugCache()
+		defer cache.Stop()
+
+		assert.Equal(t, 0, cache.Size())
+
+		cache.Set(ctx, "a", tenant.MustNewTenantID("t1"))
+		assert.Equal(t, 1, cache.Size())
+
+		cache.Set(ctx, "b", tenant.MustNewTenantID("t2"))
+		assert.Equal(t, 2, cache.Size())
+
+		cache.Set(ctx, "c", tenant.MustNewTenantID("t3"))
+		assert.Equal(t, 3, cache.Size())
+	})
+}
+
+// Compile-time interface check
+var _ slugCache = (*InMemorySlugCache)(nil)


### PR DESCRIPTION
## Summary
- Implement `InMemorySlugCache` as a thread-safe, TTL-based cache adapter for tenant slug-to-ID lookups
- Cache uses `sync.RWMutex` for concurrent access safety with configurable TTL (default 5 minutes) and cleanup interval
- Includes background goroutine for periodic expired entry cleanup with proper context cancellation handling

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 86

## Changes Made
- Add `InMemorySlugCache` implementation in `shared/platform/gateway/inmemory_cache.go`
- Add comprehensive test suite in `shared/platform/gateway/inmemory_cache_test.go`

## Test Plan
- Cache hit/miss scenarios
- TTL expiration (set entry, wait, verify expired using `await` package)
- Concurrent access (100 goroutines reading/writing simultaneously)
- Context cancellation (cleanup goroutine stops properly)
- Empty slug handling