### PR TITLE
fix: Replace panic() with error returns in NewPaymentOrchestrator

### DIFF
--- a/services/payment-order/service/grpc_service.go
+++ b/services/payment-order/service/grpc_service.go
@@ -213,10 +213,13 @@ func NewService(repo persistence.Repository, idempotencyService idempotency.Serv
 
 	// Create minimal orchestrator for testing - external clients may be nil
 	// but orchestrator methods check for nil before use
-	orchestrator := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
 		Logger: logger,
 		Repo:   repo,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create payment orchestrator: %w", err)
+	}
 
 	return &Service{
 		repo:                    repo,
@@ -282,7 +285,7 @@ func NewServiceWithConfig(cfg Config) (*Service, error) {
 	}
 
 	// Create the payment orchestrator with all dependencies
-	orchestrator := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
 		Logger:                    logger,
 		Repo:                      cfg.Repository,
 		CurrentAccountClient:      cfg.CurrentAccountClient,
@@ -292,6 +295,9 @@ func NewServiceWithConfig(cfg Config) (*Service, error) {
 		KafkaPublisher:            cfg.KafkaPublisher,
 		LienExecutionRetryConfig:  cfg.LienExecutionRetryConfig,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create payment orchestrator: %w", err)
+	}
 
 	return &Service{
 		repo:                      cfg.Repository,

--- a/services/payment-order/service/grpc_service_test.go
+++ b/services/payment-order/service/grpc_service_test.go
@@ -669,14 +669,19 @@ func testGatewayAccountConfig() *config.GatewayAccountConfig {
 
 // testOrchestrator creates a PaymentOrchestrator with the provided dependencies for testing.
 // This helper ensures tests that directly construct Service{} also get an orchestrator.
+// Panics on error since test setup failures should fail fast.
 func testOrchestrator(repo persistence.Repository, caClient CurrentAccountClient, faClient FinancialAccountingClient, gwConfig *config.GatewayAccountConfig) *PaymentOrchestrator {
-	return NewPaymentOrchestrator(PaymentOrchestratorConfig{
+	o, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
 		Logger:                    testLogger(),
 		Repo:                      repo,
 		CurrentAccountClient:      caClient,
 		FinancialAccountingClient: faClient,
 		GatewayAccountConfig:      gwConfig,
 	})
+	if err != nil {
+		panic(fmt.Sprintf("testOrchestrator: %v", err))
+	}
+	return o
 }
 
 // Test InitiatePaymentOrder
@@ -2053,12 +2058,13 @@ func TestSagaOrchestration_HappyPath(t *testing.T) {
 	}
 
 	// Create orchestrator with all dependencies
-	orchestrator := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
 		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		Repo:                 repo,
 		CurrentAccountClient: caClient,
 		PaymentGateway:       gwMock,
 	})
+	require.NoError(t, err)
 
 	// Create service with all dependencies configured
 	svc := &Service{
@@ -2123,12 +2129,13 @@ func TestSagaOrchestration_LienFailure(t *testing.T) {
 	gwMock := &MockPaymentGateway{}
 
 	// Create orchestrator with dependencies
-	orchestrator := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
 		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		Repo:                 repo,
 		CurrentAccountClient: caClient,
 		PaymentGateway:       gwMock,
 	})
+	require.NoError(t, err)
 
 	svc := &Service{
 		repo:                    repo,
@@ -2190,12 +2197,13 @@ func TestSagaOrchestration_GatewayFailure(t *testing.T) {
 	}
 
 	// Create orchestrator with dependencies
-	orchestrator := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
 		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		Repo:                 repo,
 		CurrentAccountClient: caClient,
 		PaymentGateway:       gwMock,
 	})
+	require.NoError(t, err)
 
 	svc := &Service{
 		repo:                    repo,
@@ -2283,12 +2291,13 @@ func TestSagaOrchestration_Timeout(t *testing.T) {
 	gwMock := &MockPaymentGateway{}
 
 	// Create orchestrator with dependencies
-	orchestrator := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
 		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		Repo:                 repo,
 		CurrentAccountClient: caClient,
 		PaymentGateway:       gwMock,
 	})
+	require.NoError(t, err)
 
 	// Configure very short saga timeout to trigger timeout
 	svc := &Service{
@@ -2444,12 +2453,13 @@ func TestSagaOrchestration_MalformedLienResponse(t *testing.T) {
 	gwClient := &MockPaymentGateway{}
 
 	// Create orchestrator with dependencies
-	orchestrator := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
 		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		Repo:                 repo,
 		CurrentAccountClient: caClient,
 		PaymentGateway:       gwClient,
 	})
+	require.NoError(t, err)
 
 	// Create service directly to avoid kafka producer requirement
 	svc := &Service{
@@ -2509,12 +2519,13 @@ func TestSagaOrchestration_GatewayPending(t *testing.T) {
 	}
 
 	// Create orchestrator with dependencies
-	orchestrator := NewPaymentOrchestrator(PaymentOrchestratorConfig{
+	orchestrator, err := NewPaymentOrchestrator(PaymentOrchestratorConfig{
 		Logger:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		Repo:                 repo,
 		CurrentAccountClient: caClient,
 		PaymentGateway:       gwClient,
 	})
+	require.NoError(t, err)
 
 	// Create service directly to avoid kafka producer requirement
 	svc := &Service{

--- a/services/payment-order/service/payment_orchestrator.go
+++ b/services/payment-order/service/payment_orchestrator.go
@@ -30,6 +30,8 @@ import (
 
 // Orchestrator configuration errors.
 var (
+	ErrOrchestratorLoggerNil           = errors.New("payment orchestrator: logger cannot be nil")
+	ErrOrchestratorRepoNil             = errors.New("payment orchestrator: repository cannot be nil")
 	ErrGatewayAccountConfigNotSet      = errors.New("gateway account config not configured")
 	ErrFinancialAccountingClientNotSet = errors.New("financial accounting client not configured")
 	ErrNilBookingLogResponse           = errors.New("financial accounting returned nil booking log")
@@ -62,14 +64,14 @@ type PaymentOrchestratorConfig struct {
 }
 
 // NewPaymentOrchestrator creates a new payment orchestrator with the given dependencies.
-// Panics if required dependencies (Logger, Repo) are nil. CurrentAccountClient and
+// Returns an error if required dependencies (Logger, Repo) are nil. CurrentAccountClient and
 // PaymentGateway are validated at runtime in Orchestrate() with graceful error handling.
-func NewPaymentOrchestrator(cfg PaymentOrchestratorConfig) *PaymentOrchestrator {
+func NewPaymentOrchestrator(cfg PaymentOrchestratorConfig) (*PaymentOrchestrator, error) {
 	if cfg.Logger == nil {
-		panic("payment orchestrator: logger cannot be nil")
+		return nil, ErrOrchestratorLoggerNil
 	}
 	if cfg.Repo == nil {
-		panic("payment orchestrator: repository cannot be nil")
+		return nil, ErrOrchestratorRepoNil
 	}
 	return &PaymentOrchestrator{
 		logger:                    cfg.Logger,
@@ -80,7 +82,7 @@ func NewPaymentOrchestrator(cfg PaymentOrchestratorConfig) *PaymentOrchestrator 
 		gatewayAccountConfig:      cfg.GatewayAccountConfig,
 		kafkaPublisher:            cfg.KafkaPublisher,
 		lienExecutionRetryConfig:  cfg.LienExecutionRetryConfig,
-	}
+	}, nil
 }
 
 // Orchestrate executes the payment saga with compensation on failure.


### PR DESCRIPTION
## Summary
- Replaced panic() calls in `NewPaymentOrchestrator` with proper error returns for nil dependencies
- Introduced sentinel errors `ErrOrchestratorLoggerNil` and `ErrOrchestratorRepoNil` for explicit error handling
- Updated all callers and tests to handle the new error return signature

## Task Master Reference
- **Tag**: tech-debt-cleanup
- **Task ID**: 22

## Changes Made
- Modified `NewPaymentOrchestrator` to return `(*PaymentOrchestrator, error)` instead of panicking on nil dependencies
- Added `ErrOrchestratorLoggerNil` and `ErrOrchestratorRepoNil` sentinel errors to `payment_orchestrator.go`
- Updated `grpc_service.go` to handle the error return from `NewPaymentOrchestrator`
- Updated test files to accommodate the new constructor signature

## Test Plan
- All existing tests updated and passing
- Verified nil dependency scenarios return errors instead of panicking