### PR TITLE
refactor(current-account): replace panic() with error return in calculateAvailableBalance

### DIFF
--- a/services/current-account/domain/account.go
+++ b/services/current-account/domain/account.go
@@ -3,6 +3,7 @@ package domain
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -125,7 +126,10 @@ func (a CurrentAccount) Deposit(amount Money) (CurrentAccount, error) {
 	}
 
 	now := time.Now()
-	newAvailableBalance := calculateAvailableBalance(newBalance, a.overdraftLimit, a.overdraftEnabled)
+	newAvailableBalance, err := calculateAvailableBalance(newBalance, a.overdraftLimit, a.overdraftEnabled)
+	if err != nil {
+		return CurrentAccount{}, err
+	}
 
 	return CurrentAccount{
 		id:                    a.id,
@@ -179,7 +183,10 @@ func (a CurrentAccount) Withdraw(amount Money) (CurrentAccount, error) {
 	}
 
 	now := time.Now()
-	newAvailableBalance := calculateAvailableBalance(newBalance, a.overdraftLimit, a.overdraftEnabled)
+	newAvailableBalance, err := calculateAvailableBalance(newBalance, a.overdraftLimit, a.overdraftEnabled)
+	if err != nil {
+		return CurrentAccount{}, err
+	}
 
 	return CurrentAccount{
 		id:                    a.id,
@@ -201,19 +208,21 @@ func (a CurrentAccount) Withdraw(amount Money) (CurrentAccount, error) {
 	}, nil
 }
 
-// calculateAvailableBalance is a pure function that computes available balance
-// based on current balance and overdraft settings.
-func calculateAvailableBalance(balance, overdraftLimit Money, overdraftEnabled bool) Money {
+// ErrAvailableBalanceCalculation indicates a failure to calculate available balance,
+// typically due to currency mismatch or overflow between balance and overdraft limit.
+var ErrAvailableBalanceCalculation = errors.New("failed to calculate available balance")
+
+// calculateAvailableBalance computes available balance based on current balance and overdraft settings.
+// Returns an error if the addition fails (currency mismatch or overflow).
+func calculateAvailableBalance(balance, overdraftLimit Money, overdraftEnabled bool) (Money, error) {
 	if overdraftEnabled {
-		// Use immutable Add method; should never fail if SetOverdraftLimit validated correctly
 		newAvail, err := balance.Add(overdraftLimit)
 		if err != nil {
-			// This indicates a bug: either currency mismatch or overflow that bypassed validation
-			panic("BUG: OverdraftLimit currency mismatch or overflow detected in calculateAvailableBalance: " + err.Error())
+			return Money{}, fmt.Errorf("%w: %w", ErrAvailableBalanceCalculation, err)
 		}
-		return newAvail
+		return newAvail, nil
 	}
-	return balance
+	return balance, nil
 }
 
 // withStatusChange creates a new CurrentAccount with the status changed and history recorded.
@@ -368,7 +377,10 @@ func (a CurrentAccount) SetOverdraftLimit(limit Money, rate float64, enabled boo
 		}
 	}
 
-	newAvailableBalance := calculateAvailableBalance(a.balance, limit, enabled)
+	newAvailableBalance, err := calculateAvailableBalance(a.balance, limit, enabled)
+	if err != nil {
+		return CurrentAccount{}, err
+	}
 
 	return CurrentAccount{
 		id:                    a.id,

--- a/services/current-account/domain/account_test.go
+++ b/services/current-account/domain/account_test.go
@@ -712,8 +712,9 @@ func TestCalculateAvailableBalance(t *testing.T) {
 		balance, _ := NewMoney("GBP", 10000)
 		overdraft, _ := NewMoney("GBP", 5000)
 
-		result := calculateAvailableBalance(balance, overdraft, false)
+		result, err := calculateAvailableBalance(balance, overdraft, false)
 
+		require.NoError(t, err)
 		assert.Equal(t, balance, result)
 	})
 
@@ -721,8 +722,9 @@ func TestCalculateAvailableBalance(t *testing.T) {
 		balance, _ := NewMoney("GBP", 10000)
 		overdraft, _ := NewMoney("GBP", 5000)
 
-		result := calculateAvailableBalance(balance, overdraft, true)
+		result, err := calculateAvailableBalance(balance, overdraft, true)
 
+		require.NoError(t, err)
 		assert.Equal(t, int64(15000), result.AmountCents())
 	})
 
@@ -730,9 +732,20 @@ func TestCalculateAvailableBalance(t *testing.T) {
 		balance, _ := NewMoney("GBP", -3000)
 		overdraft, _ := NewMoney("GBP", 5000)
 
-		result := calculateAvailableBalance(balance, overdraft, true)
+		result, err := calculateAvailableBalance(balance, overdraft, true)
 
+		require.NoError(t, err)
 		assert.Equal(t, int64(2000), result.AmountCents())
+	})
+
+	t.Run("currency mismatch returns error", func(t *testing.T) {
+		balance, _ := NewMoney("GBP", 10000)
+		overdraft, _ := NewMoney("USD", 5000)
+
+		_, err := calculateAvailableBalance(balance, overdraft, true)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrAvailableBalanceCalculation)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Replaced `panic()` call in `calculateAvailableBalance` with proper error handling returning `(Money, error)`
- Updated all three callers (`Deposit`, `Withdraw`, `SetOverdraftLimit`) to propagate the error
- Added new domain error `ErrAvailableBalanceCalculation` for currency mismatch and overflow scenarios

## Task Master Reference
- **Tag**: tech-debt-cleanup
- **Task ID**: 23

## Changes Made
- Changed `calculateAvailableBalance` function signature from `Money` to `(Money, error)`
- Added `ErrAvailableBalanceCalculation` error variable with descriptive message
- Modified `Deposit`, `Withdraw`, and `SetOverdraftLimit` methods to handle and return the calculation error
- Added test case for currency mismatch scenario to verify error handling

## Test Plan
- Run `go test ./services/current-account/...` to verify all tests pass
- Verify no regressions in account operations