### PR TITLE
feat(gateway): add HTTP server health endpoints with tenant middleware integration

### DIFF
--- a/services/gateway/cmd/main.go
+++ b/services/gateway/cmd/main.go
@@ -58,7 +58,10 @@ func run(logger *slog.Logger) error {
 		"backend_routes", len(config.Backends))
 
 	// Create server
-	server := gateway.NewServer(config, logger)
+	// Note: Tenant resolver will be initialized in a future task when database connection is available.
+	// For now, pass nil to allow the server to start without tenant resolution.
+	// Health endpoints will work regardless of tenant resolver configuration.
+	server := gateway.NewServer(config, logger, nil)
 
 	// Start server in background
 	serverErrors := make(chan error, 1)

--- a/services/gateway/server.go
+++ b/services/gateway/server.go
@@ -8,24 +8,29 @@ import (
 	"net"
 	"net/http"
 	"time"
+
+	platformgateway "github.com/meridianhub/meridian/shared/platform/gateway"
 )
 
 // Server is the HTTP server for the gateway service.
 type Server struct {
-	config     *Config
-	logger     *slog.Logger
-	httpServer *http.Server
-	mux        *http.ServeMux
+	config         *Config
+	logger         *slog.Logger
+	httpServer     *http.Server
+	mux            *http.ServeMux
+	tenantResolver *platformgateway.TenantResolverMiddleware
 }
 
 // NewServer creates a new gateway HTTP server with the given configuration.
-func NewServer(config *Config, logger *slog.Logger) *Server {
+// The tenantResolver parameter is optional - if nil, all routes bypass tenant resolution.
+func NewServer(config *Config, logger *slog.Logger, tenantResolver *platformgateway.TenantResolverMiddleware) *Server {
 	mux := http.NewServeMux()
 
 	s := &Server{
-		config: config,
-		logger: logger,
-		mux:    mux,
+		config:         config,
+		logger:         logger,
+		mux:            mux,
+		tenantResolver: tenantResolver,
 	}
 
 	// Register routes
@@ -35,39 +40,62 @@ func NewServer(config *Config, logger *slog.Logger) *Server {
 }
 
 // registerRoutes sets up the HTTP routes for the gateway.
+//
+// CRITICAL: Health endpoints (/health, /ready) are registered directly on the main mux
+// WITHOUT tenant middleware. This is required for K8s probes which do not provide
+// tenant context (no subdomain/Host header).
+//
+// API routes go through tenant middleware to resolve and inject tenant context.
 func (s *Server) registerRoutes() {
-	// Health check endpoints
-	s.mux.HandleFunc("GET /healthz", s.handleHealthz)
-	s.mux.HandleFunc("GET /readyz", s.handleReadyz)
+	// Health check endpoints - NO tenant middleware (required for K8s probes)
+	s.mux.HandleFunc("GET /health", s.handleHealth)
+	s.mux.HandleFunc("GET /ready", s.handleReady)
 
-	// Root handler for API routing (placeholder for future implementation)
-	s.mux.HandleFunc("/", s.handleRoot)
+	// Legacy health endpoints for backwards compatibility
+	s.mux.HandleFunc("GET /healthz", s.handleHealth)
+	s.mux.HandleFunc("GET /readyz", s.handleReady)
+
+	// API routes - WITH tenant middleware (if tenant resolver is configured)
+	apiMux := http.NewServeMux()
+	apiMux.HandleFunc("/", s.handleAPI)
+
+	if s.tenantResolver != nil {
+		// Wrap API routes with tenant resolution middleware
+		s.mux.Handle("/api/", s.tenantResolver.Handler(http.StripPrefix("/api", apiMux)))
+	} else {
+		// No tenant resolver - direct routing (useful for testing or dev mode)
+		s.mux.Handle("/api/", http.StripPrefix("/api", apiMux))
+	}
 }
 
-// handleHealthz is the liveness probe endpoint.
-func (s *Server) handleHealthz(w http.ResponseWriter, _ *http.Request) {
+// handleHealth is the liveness probe endpoint.
+// Returns 200 OK if the server is alive.
+// This endpoint does NOT require tenant context.
+func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("OK"))
 }
 
-// handleReadyz is the readiness probe endpoint.
-func (s *Server) handleReadyz(w http.ResponseWriter, _ *http.Request) {
+// handleReady is the readiness probe endpoint.
+// Returns 200 OK if the server is ready to accept traffic.
+// This endpoint does NOT require tenant context.
+func (s *Server) handleReady(w http.ResponseWriter, _ *http.Request) {
 	// TODO: Add actual readiness checks (database, redis, backends)
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("OK"))
+	_, _ = w.Write([]byte("READY"))
 }
 
-// handleRoot is a placeholder handler for the root path.
+// handleAPI is a placeholder handler for API routes.
 // This will be replaced with actual routing logic in future tasks.
-func (s *Server) handleRoot(w http.ResponseWriter, r *http.Request) {
-	s.logger.Debug("received request",
+func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request) {
+	s.logger.Debug("received API request",
 		"method", r.Method,
 		"path", r.URL.Path,
 		"host", r.Host)
 
-	// Placeholder response - actual routing will be implemented in Task 88
+	// Placeholder response - actual routing will be implemented in future tasks
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusNotImplemented)
 	_, _ = w.Write([]byte(`{"error":"gateway routing not yet implemented"}`))

--- a/services/gateway/server.go
+++ b/services/gateway/server.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 
 	platformgateway "github.com/meridianhub/meridian/shared/platform/gateway"
@@ -17,6 +18,7 @@ type Server struct {
 	config         *Config
 	logger         *slog.Logger
 	httpServer     *http.Server
+	httpServerMu   sync.RWMutex // Guards httpServer field
 	mux            *http.ServeMux
 	tenantResolver *platformgateway.TenantResolverMiddleware
 }
@@ -106,7 +108,7 @@ func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request) {
 func (s *Server) Start(ctx context.Context) error {
 	address := fmt.Sprintf(":%d", s.config.Port)
 
-	s.httpServer = &http.Server{
+	httpServer := &http.Server{
 		Addr:              address,
 		Handler:           s.mux,
 		ReadHeaderTimeout: 10 * time.Second,
@@ -114,6 +116,11 @@ func (s *Server) Start(ctx context.Context) error {
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
+
+	// Store httpServer with mutex protection
+	s.httpServerMu.Lock()
+	s.httpServer = httpServer
+	s.httpServerMu.Unlock()
 
 	// Create listener first to ensure port binding before signaling ready
 	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", address)
@@ -127,7 +134,7 @@ func (s *Server) Start(ctx context.Context) error {
 		"base_domain", s.config.BaseDomain,
 		"backend_routes", len(s.config.Backends))
 
-	if err := s.httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	if err := httpServer.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		return fmt.Errorf("HTTP server error: %w", err)
 	}
 
@@ -136,13 +143,17 @@ func (s *Server) Start(ctx context.Context) error {
 
 // Shutdown gracefully shuts down the HTTP server.
 func (s *Server) Shutdown(ctx context.Context) error {
-	if s.httpServer == nil {
+	s.httpServerMu.RLock()
+	httpServer := s.httpServer
+	s.httpServerMu.RUnlock()
+
+	if httpServer == nil {
 		return nil
 	}
 
 	s.logger.Info("shutting down HTTP server...")
 
-	if err := s.httpServer.Shutdown(ctx); err != nil {
+	if err := httpServer.Shutdown(ctx); err != nil {
 		return fmt.Errorf("failed to shutdown HTTP server: %w", err)
 	}
 

--- a/services/gateway/server_integration_test.go
+++ b/services/gateway/server_integration_test.go
@@ -1,0 +1,281 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// httpGet performs an HTTP GET request with context.
+func httpGet(ctx context.Context, url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return http.DefaultClient.Do(req)
+}
+
+// getAvailablePort finds an available TCP port on localhost.
+func getAvailablePort(ctx context.Context, t *testing.T) int {
+	t.Helper()
+	lc := &net.ListenConfig{}
+	listener, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	err = listener.Close()
+	require.NoError(t, err)
+	return port
+}
+
+// TestIntegration_HealthEndpoints starts an actual HTTP server and verifies
+// health endpoints respond correctly to real HTTP requests.
+func TestIntegration_HealthEndpoints(t *testing.T) {
+	ctx := context.Background()
+
+	// Find an available port
+	port := getAvailablePort(ctx, t)
+
+	// Create server
+	config := &Config{
+		Port:        port,
+		BaseDomain:  "api.test.io",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := NewServer(config, logger, nil)
+
+	// Start server in background
+	serverCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	serverReady := make(chan struct{})
+	serverErr := make(chan error, 1)
+	go func() {
+		close(serverReady)
+		if err := server.Start(serverCtx); err != nil {
+			serverErr <- err
+		}
+	}()
+
+	<-serverReady
+
+	// Wait for server to be ready using await package
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	err := await.New().
+		AtMost(5 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			resp, err := httpGet(ctx, baseURL+"/health")
+			if err != nil {
+				return false
+			}
+			resp.Body.Close()
+			return resp.StatusCode == http.StatusOK
+		})
+	require.NoError(t, err, "server failed to become ready")
+
+	// Test /health endpoint
+	t.Run("GET /health returns 200 OK", func(t *testing.T) {
+		resp, err := httpGet(ctx, baseURL+"/health")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "OK", string(body))
+	})
+
+	// Test /ready endpoint
+	t.Run("GET /ready returns 200 READY", func(t *testing.T) {
+		resp, err := httpGet(ctx, baseURL+"/ready")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "READY", string(body))
+	})
+
+	// Test /healthz endpoint (legacy)
+	t.Run("GET /healthz returns 200 OK (legacy)", func(t *testing.T) {
+		resp, err := httpGet(ctx, baseURL+"/healthz")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "OK", string(body))
+	})
+
+	// Test /readyz endpoint (legacy)
+	t.Run("GET /readyz returns 200 READY (legacy)", func(t *testing.T) {
+		resp, err := httpGet(ctx, baseURL+"/readyz")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, "READY", string(body))
+	})
+
+	// Test health endpoints work without Host header (K8s probe simulation)
+	t.Run("health endpoints work without Host header", func(t *testing.T) {
+		client := &http.Client{}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/health", nil)
+		require.NoError(t, err)
+		req.Host = "" // Clear Host header
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode,
+			"health endpoint must work without Host header for K8s probes")
+	})
+
+	// Cleanup
+	shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer shutdownCancel()
+	err = server.Shutdown(shutdownCtx)
+	assert.NoError(t, err)
+}
+
+// TestIntegration_APIRoutes_RequiresTenantContext verifies that API routes
+// are separate from health routes and would require tenant context in production.
+func TestIntegration_APIRoutes_RequiresTenantContext(t *testing.T) {
+	ctx := context.Background()
+
+	// Find an available port
+	port := getAvailablePort(ctx, t)
+
+	// Create server without tenant resolver
+	config := &Config{
+		Port:        port,
+		BaseDomain:  "api.test.io",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := NewServer(config, logger, nil)
+
+	// Start server
+	serverCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go func() {
+		_ = server.Start(serverCtx)
+	}()
+
+	// Wait for server to be ready
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	err := await.New().
+		AtMost(5 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			resp, err := httpGet(ctx, baseURL+"/health")
+			if err != nil {
+				return false
+			}
+			resp.Body.Close()
+			return resp.StatusCode == http.StatusOK
+		})
+	require.NoError(t, err)
+
+	// Test API route returns placeholder response
+	t.Run("GET /api/v1/test returns 501 Not Implemented", func(t *testing.T) {
+		resp, err := httpGet(ctx, baseURL+"/api/v1/test")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(body), "gateway routing not yet implemented")
+	})
+
+	// Cleanup
+	shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer shutdownCancel()
+	_ = server.Shutdown(shutdownCtx)
+}
+
+// TestIntegration_ServerGracefulShutdown verifies the server shuts down gracefully.
+func TestIntegration_ServerGracefulShutdown(t *testing.T) {
+	ctx := context.Background()
+
+	// Find an available port
+	port := getAvailablePort(ctx, t)
+
+	// Create server
+	config := &Config{
+		Port:        port,
+		BaseDomain:  "api.test.io",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := NewServer(config, logger, nil)
+
+	// Start server
+	serverCtx, cancel := context.WithCancel(ctx)
+
+	serverDone := make(chan struct{})
+	go func() {
+		_ = server.Start(serverCtx)
+		close(serverDone)
+	}()
+
+	// Wait for server to be ready
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	err := await.New().
+		AtMost(5 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			resp, err := httpGet(ctx, baseURL+"/health")
+			if err != nil {
+				return false
+			}
+			resp.Body.Close()
+			return resp.StatusCode == http.StatusOK
+		})
+	require.NoError(t, err)
+
+	// Cancel context to signal shutdown
+	cancel()
+
+	// Initiate graceful shutdown
+	shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer shutdownCancel()
+
+	err = server.Shutdown(shutdownCtx)
+	assert.NoError(t, err)
+
+	// Wait for server goroutine to complete
+	select {
+	case <-serverDone:
+		// Server shut down cleanly
+	case <-time.After(10 * time.Second):
+		t.Fatal("server did not shut down in time")
+	}
+
+	// Verify server is no longer accepting connections
+	_, err = httpGet(ctx, baseURL+"/health")
+	assert.Error(t, err, "server should not accept connections after shutdown")
+}

--- a/services/gateway/server_test.go
+++ b/services/gateway/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -271,8 +272,11 @@ func TestServer_StartAndShutdown(t *testing.T) {
 		}
 	}()
 
-	// Give server time to start
-	// Note: In production tests, use await package instead of select
+	// Give server time to start and bind the port.
+	// We use a small sleep here because this is a unit test verifying lifecycle.
+	// The mutex in Server ensures thread-safety regardless of timing.
+	time.Sleep(50 * time.Millisecond)
+
 	select {
 	case err := <-serverErr:
 		t.Fatalf("server failed to start: %v", err)

--- a/services/gateway/server_test.go
+++ b/services/gateway/server_test.go
@@ -1,0 +1,294 @@
+package gateway
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHealthEndpoints_NoTenantContext verifies that health endpoints
+// work without any tenant context (Host header, subdomain, etc.).
+// This is critical for K8s probes.
+func TestHealthEndpoints_NoTenantContext(t *testing.T) {
+	tests := []struct {
+		name           string
+		endpoint       string
+		expectedStatus int
+		expectedBody   string
+	}{
+		{
+			name:           "GET /health returns 200 OK",
+			endpoint:       "/health",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "OK",
+		},
+		{
+			name:           "GET /ready returns 200 READY",
+			endpoint:       "/ready",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "READY",
+		},
+		{
+			name:           "GET /healthz returns 200 OK (legacy)",
+			endpoint:       "/healthz",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "OK",
+		},
+		{
+			name:           "GET /readyz returns 200 READY (legacy)",
+			endpoint:       "/readyz",
+			expectedStatus: http.StatusOK,
+			expectedBody:   "READY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create server without tenant resolver
+			config := &Config{
+				Port:        8080,
+				BaseDomain:  "test.example.com",
+				DatabaseURL: "postgres://localhost/test",
+			}
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			server := NewServer(config, logger, nil)
+
+			// Create request WITHOUT Host header (simulating K8s probe)
+			req := httptest.NewRequest(http.MethodGet, tt.endpoint, nil)
+			req.Host = "" // Explicitly clear Host header
+			rec := httptest.NewRecorder()
+
+			// Execute
+			server.mux.ServeHTTP(rec, req)
+
+			// Assert
+			assert.Equal(t, tt.expectedStatus, rec.Code)
+			assert.Equal(t, tt.expectedBody, rec.Body.String())
+			assert.Equal(t, "text/plain; charset=utf-8", rec.Header().Get("Content-Type"))
+		})
+	}
+}
+
+// TestHealthEndpoints_InvalidSubdomain verifies that health endpoints
+// work even when accessed with an invalid subdomain.
+// K8s may route probes through various paths.
+func TestHealthEndpoints_InvalidSubdomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		host     string
+	}{
+		{
+			name:     "/health with invalid subdomain",
+			endpoint: "/health",
+			host:     "invalid-host.wrong-domain.com",
+		},
+		{
+			name:     "/ready with invalid subdomain",
+			endpoint: "/ready",
+			host:     "missing.subdomain.io",
+		},
+		{
+			name:     "/health with IP address",
+			endpoint: "/health",
+			host:     "192.168.1.1",
+		},
+		{
+			name:     "/ready with localhost",
+			endpoint: "/ready",
+			host:     "localhost:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create server without tenant resolver
+			config := &Config{
+				Port:        8080,
+				BaseDomain:  "api.example.com",
+				DatabaseURL: "postgres://localhost/test",
+			}
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			server := NewServer(config, logger, nil)
+
+			// Create request WITH invalid/missing subdomain
+			req := httptest.NewRequest(http.MethodGet, tt.endpoint, nil)
+			req.Host = tt.host
+			rec := httptest.NewRecorder()
+
+			// Execute
+			server.mux.ServeHTTP(rec, req)
+
+			// Assert - health endpoints should ALWAYS return 200
+			assert.Equal(t, http.StatusOK, rec.Code,
+				"health endpoints must succeed regardless of Host header")
+		})
+	}
+}
+
+// TestHealthEndpoints_BypassTenantMiddleware verifies that health endpoints
+// bypass the tenant resolver middleware entirely.
+func TestHealthEndpoints_BypassTenantMiddleware(t *testing.T) {
+	// This test verifies the critical requirement:
+	// Health endpoints must NOT go through tenant middleware.
+	//
+	// We test this by creating a mock tenant resolver that would fail
+	// if called, and verifying health endpoints still succeed.
+
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Create server without tenant resolver (nil)
+	// In production, even with tenant resolver configured,
+	// health endpoints should bypass it.
+	server := NewServer(config, logger, nil)
+
+	endpoints := []string{"/health", "/ready", "/healthz", "/readyz"}
+
+	for _, endpoint := range endpoints {
+		t.Run(endpoint, func(t *testing.T) {
+			// Request with NO Host header - tenant resolution would fail
+			req := httptest.NewRequest(http.MethodGet, endpoint, nil)
+			rec := httptest.NewRecorder()
+
+			server.mux.ServeHTTP(rec, req)
+
+			// Health endpoints should succeed
+			assert.Equal(t, http.StatusOK, rec.Code,
+				"health endpoints must bypass tenant middleware")
+		})
+	}
+}
+
+// TestAPIRoutes_WithoutTenantResolver verifies API routes work when
+// tenant resolver is not configured (nil).
+func TestAPIRoutes_WithoutTenantResolver(t *testing.T) {
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := NewServer(config, logger, nil)
+
+	// Request to API endpoint
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/test", nil)
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	// Should return 501 Not Implemented (placeholder response)
+	assert.Equal(t, http.StatusNotImplemented, rec.Code)
+	assert.Contains(t, rec.Body.String(), "gateway routing not yet implemented")
+}
+
+// TestNewServer_InitializesCorrectly verifies server construction.
+func TestNewServer_InitializesCorrectly(t *testing.T) {
+	config := &Config{
+		Port:        9090,
+		BaseDomain:  "test.meridian.io",
+		DatabaseURL: "postgres://localhost/test",
+		Backends: []BackendRoute{
+			{Prefix: "/v1/party", Target: "party:50051"},
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	server := NewServer(config, logger, nil)
+
+	require.NotNil(t, server)
+	assert.Equal(t, config, server.config)
+	assert.Equal(t, logger, server.logger)
+	assert.NotNil(t, server.mux)
+	assert.Nil(t, server.tenantResolver)
+}
+
+// TestHealthEndpoints_HTTPMethods verifies only GET is allowed for health endpoints.
+func TestHealthEndpoints_HTTPMethods(t *testing.T) {
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := NewServer(config, logger, nil)
+
+	endpoints := []string{"/health", "/ready"}
+	disallowedMethods := []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch}
+
+	for _, endpoint := range endpoints {
+		for _, method := range disallowedMethods {
+			t.Run(method+" "+endpoint, func(t *testing.T) {
+				req := httptest.NewRequest(method, endpoint, nil)
+				rec := httptest.NewRecorder()
+
+				server.mux.ServeHTTP(rec, req)
+
+				// Go 1.22+ ServeMux returns 405 for method mismatch
+				assert.Equal(t, http.StatusMethodNotAllowed, rec.Code,
+					"%s should not be allowed on %s", method, endpoint)
+			})
+		}
+	}
+}
+
+// TestServer_StartAndShutdown tests the server lifecycle.
+func TestServer_StartAndShutdown(t *testing.T) {
+	config := &Config{
+		Port:        0, // Use random available port
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := NewServer(config, logger, nil)
+
+	// Start server in background
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		if err := server.Start(ctx); err != nil {
+			serverErr <- err
+		}
+	}()
+
+	// Give server time to start
+	// Note: In production tests, use await package instead of select
+	select {
+	case err := <-serverErr:
+		t.Fatalf("server failed to start: %v", err)
+	default:
+		// Server started, now shutdown
+	}
+
+	// Shutdown
+	shutdownCtx := context.Background()
+	err := server.Shutdown(shutdownCtx)
+	assert.NoError(t, err)
+}
+
+// TestServer_ShutdownWithoutStart verifies shutdown is safe when server wasn't started.
+func TestServer_ShutdownWithoutStart(t *testing.T) {
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := NewServer(config, logger, nil)
+
+	// Shutdown without start should not panic or error
+	err := server.Shutdown(context.Background())
+	assert.NoError(t, err)
+}

--- a/services/gateway/server_test.go
+++ b/services/gateway/server_test.go
@@ -135,11 +135,19 @@ func TestHealthEndpoints_InvalidSubdomain(t *testing.T) {
 // TestHealthEndpoints_BypassTenantMiddleware verifies that health endpoints
 // bypass the tenant resolver middleware entirely.
 func TestHealthEndpoints_BypassTenantMiddleware(t *testing.T) {
-	// This test verifies the critical requirement:
+	// This test verifies the critical architectural requirement:
 	// Health endpoints must NOT go through tenant middleware.
 	//
-	// We test this by creating a mock tenant resolver that would fail
-	// if called, and verifying health endpoints still succeed.
+	// The server architecture guarantees this by design:
+	// - Health endpoints are registered directly on the main mux
+	// - API routes are registered on a sub-mux wrapped with tenant middleware
+	// - This separation ensures health probes work without valid tenant context
+	//
+	// We pass nil for the tenant resolver because:
+	// 1. Health endpoints don't use the resolver (architectural guarantee)
+	// 2. The concrete type (*gateway.TenantResolverMiddleware) prevents mocking
+	// 3. Other tests (TestHealthEndpoints_NoTenantContext, _InvalidSubdomain)
+	//    verify health endpoints work without tenant context
 
 	config := &Config{
 		Port:        8080,
@@ -148,9 +156,9 @@ func TestHealthEndpoints_BypassTenantMiddleware(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	// Create server without tenant resolver (nil)
-	// In production, even with tenant resolver configured,
-	// health endpoints should bypass it.
+	// Create server without tenant resolver (nil).
+	// Health endpoints are architecturally separated from tenant middleware,
+	// registered directly on the main mux without any middleware wrapping.
 	server := NewServer(config, logger, nil)
 
 	endpoints := []string{"/health", "/ready", "/healthz", "/readyz"}


### PR DESCRIPTION
## Summary
- Add HTTP server with `/health` and `/ready` endpoints that bypass tenant middleware, critical for Kubernetes probes
- Include `/healthz` and `/readyz` as legacy aliases for compatibility
- Health endpoints return 200 OK without requiring Host header or tenant context, while API routes go through tenant middleware when configured

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 88

## Changes Made
- Implement HTTP server with configurable tenant resolver (optional for testing scenarios)
- Add health/ready endpoints registered before tenant middleware to ensure K8s probes work without tenant context
- Support legacy `/healthz` and `/readyz` paths as aliases
- Comprehensive unit tests verifying health endpoints work without Host header or tenant context
- Integration tests using `await` package for reliable polling

## Test Plan
**Unit tests:**
- GET /health returns 200 without Host header
- GET /ready returns 200 without Host header
- Verify health endpoints bypass tenant middleware
- Test with invalid/missing subdomain (should NOT affect /health)

**Integration test:**
- Start server, call /health and /ready
- Verify 200 responses