### PR TITLE
feat(gateway): add local dev mode with X-Tenant-Slug header support

### DIFF
--- a/services/gateway/cmd/main.go
+++ b/services/gateway/cmd/main.go
@@ -50,10 +50,17 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
 
+	// Production safety check: LOCAL_DEV_MODE must not be enabled in production namespaces
+	namespace := os.Getenv("POD_NAMESPACE")
+	if err := config.ValidateForNamespace(namespace); err != nil {
+		return err
+	}
+
 	logger.Info("configuration loaded",
 		"port", config.Port,
 		"base_domain", config.BaseDomain,
 		"local_dev_mode", config.LocalDevMode,
+		"namespace", namespace,
 		"redis_enabled", config.RedisURL != "",
 		"backend_routes", len(config.Backends))
 

--- a/services/gateway/config.go
+++ b/services/gateway/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/meridianhub/meridian/shared/platform/env"
 )
@@ -59,6 +60,9 @@ var (
 
 	// ErrInvalidBackendRoute is returned when a backend route has empty prefix or target.
 	ErrInvalidBackendRoute = errors.New("backend route must have non-empty prefix and target")
+
+	// ErrLocalDevModeInProduction is returned when LOCAL_DEV_MODE is enabled in a production namespace.
+	ErrLocalDevModeInProduction = errors.New("LOCAL_DEV_MODE cannot be enabled in production namespace")
 )
 
 // LoadConfig loads configuration from environment variables.
@@ -111,5 +115,14 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	return nil
+}
+
+// ValidateForNamespace checks if the configuration is safe for the given namespace.
+// Returns an error if LOCAL_DEV_MODE is enabled in a production namespace.
+func (c *Config) ValidateForNamespace(namespace string) error {
+	if c.LocalDevMode && strings.HasPrefix(namespace, "prod") {
+		return fmt.Errorf("%w: %s", ErrLocalDevModeInProduction, namespace)
+	}
 	return nil
 }

--- a/services/gateway/config_test.go
+++ b/services/gateway/config_test.go
@@ -296,6 +296,111 @@ func TestConfig_Validate(t *testing.T) {
 	}
 }
 
+func TestConfig_ValidateForNamespace(t *testing.T) {
+	testCases := []struct {
+		name         string
+		localDevMode bool
+		namespace    string
+		wantError    bool
+	}{
+		// LOCAL_DEV_MODE=true tests
+		{
+			name:         "LOCAL_DEV_MODE=true in production namespace",
+			localDevMode: true,
+			namespace:    "production",
+			wantError:    true,
+		},
+		{
+			name:         "LOCAL_DEV_MODE=true in prod namespace",
+			localDevMode: true,
+			namespace:    "prod",
+			wantError:    true,
+		},
+		{
+			name:         "LOCAL_DEV_MODE=true in prod-eu namespace",
+			localDevMode: true,
+			namespace:    "prod-eu",
+			wantError:    true,
+		},
+		{
+			name:         "LOCAL_DEV_MODE=true in prod-us namespace",
+			localDevMode: true,
+			namespace:    "prod-us",
+			wantError:    true,
+		},
+		{
+			name:         "LOCAL_DEV_MODE=true in staging namespace",
+			localDevMode: true,
+			namespace:    "staging",
+			wantError:    false,
+		},
+		{
+			name:         "LOCAL_DEV_MODE=true in development namespace",
+			localDevMode: true,
+			namespace:    "development",
+			wantError:    false,
+		},
+		{
+			name:         "LOCAL_DEV_MODE=true in dev namespace",
+			localDevMode: true,
+			namespace:    "dev",
+			wantError:    false,
+		},
+		{
+			name:         "LOCAL_DEV_MODE=true with empty namespace",
+			localDevMode: true,
+			namespace:    "",
+			wantError:    false,
+		},
+		// LOCAL_DEV_MODE=false tests (should always pass)
+		{
+			name:         "LOCAL_DEV_MODE=false in production namespace",
+			localDevMode: false,
+			namespace:    "production",
+			wantError:    false,
+		},
+		{
+			name:         "LOCAL_DEV_MODE=false in prod namespace",
+			localDevMode: false,
+			namespace:    "prod",
+			wantError:    false,
+		},
+		{
+			name:         "LOCAL_DEV_MODE=false in staging namespace",
+			localDevMode: false,
+			namespace:    "staging",
+			wantError:    false,
+		},
+		{
+			name:         "LOCAL_DEV_MODE=false with empty namespace",
+			localDevMode: false,
+			namespace:    "",
+			wantError:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &Config{
+				Port:         8080,
+				BaseDomain:   "api.example.com",
+				DatabaseURL:  "postgres://localhost/db",
+				LocalDevMode: tc.localDevMode,
+			}
+
+			err := config.ValidateForNamespace(tc.namespace)
+
+			if tc.wantError {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrLocalDevModeInProduction)
+				assert.Contains(t, err.Error(), tc.namespace)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 // setEnvVars sets environment variables and returns a cleanup function.
 func setEnvVars(t *testing.T, vars map[string]string) func() {
 	t.Helper()

--- a/shared/platform/gateway/tenant_resolver.go
+++ b/shared/platform/gateway/tenant_resolver.go
@@ -24,6 +24,11 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
+// TenantSlugHeader is the header name used for local development mode.
+// When LOCAL_DEV_MODE is enabled, this header can be used to specify
+// the tenant slug directly, bypassing subdomain-based resolution.
+const TenantSlugHeader = "X-Tenant-Slug"
+
 // Configuration errors.
 var (
 	ErrNilSlugCache    = errors.New("slug cache cannot be nil")
@@ -65,24 +70,31 @@ type tenantRepository interface {
 // and injects the tenant ID into the request context.
 //
 // It follows this resolution flow:
-// 1. Extract subdomain slug from Host header (e.g., "acme" from "acme.meridian.com")
-// 2. Check slug cache for tenant ID
-// 3. On cache miss, query tenant repository and populate cache
-// 4. Inject tenant ID into request context via x-tenant-id header
+// 1. In LOCAL_DEV_MODE, check for X-Tenant-Slug header first
+// 2. Extract subdomain slug from Host header (e.g., "acme" from "acme.meridian.com")
+// 3. Check slug cache for tenant ID
+// 4. On cache miss, query tenant repository and populate cache
+// 5. Inject tenant ID into request context via x-tenant-id header
 type TenantResolverMiddleware struct {
-	slugCache  slugCache
-	tenantRepo tenantRepository
-	baseDomain string
-	logger     *slog.Logger
+	slugCache    slugCache
+	tenantRepo   tenantRepository
+	baseDomain   string
+	logger       *slog.Logger
+	localDevMode bool
 }
 
 // NewTenantResolverMiddleware creates a new tenant resolver middleware.
-// All parameters are required and validated.
+// All parameters except localDevMode are required and validated.
+//
+// When localDevMode is true, the middleware will accept the X-Tenant-Slug header
+// for tenant identification, which is useful for local development and testing.
+// In production, this should always be false.
 func NewTenantResolverMiddleware(
 	slugCache slugCache,
 	tenantRepo tenantRepository,
 	baseDomain string,
 	logger *slog.Logger,
+	localDevMode bool,
 ) (*TenantResolverMiddleware, error) {
 	if slugCache == nil {
 		return nil, ErrNilSlugCache
@@ -97,23 +109,53 @@ func NewTenantResolverMiddleware(
 		return nil, ErrNilLogger
 	}
 
+	if localDevMode {
+		logger.Warn("local dev mode enabled - X-Tenant-Slug header will be accepted",
+			slog.String("header", TenantSlugHeader))
+	}
+
 	return &TenantResolverMiddleware{
-		slugCache:  slugCache,
-		tenantRepo: tenantRepo,
-		baseDomain: baseDomain,
-		logger:     logger,
+		slugCache:    slugCache,
+		tenantRepo:   tenantRepo,
+		baseDomain:   baseDomain,
+		logger:       logger,
+		localDevMode: localDevMode,
 	}, nil
 }
 
 // Handler returns an http.Handler that performs tenant resolution.
 // This method will extract the tenant slug from the Host header,
 // resolve it to a tenant ID, and inject it into the request context.
+//
+// In local dev mode (LOCAL_DEV_MODE=true), the X-Tenant-Slug header is checked first.
+// If the header is present, it takes precedence over subdomain-based resolution.
 func (m *TenantResolverMiddleware) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		// Step 1: Extract slug from Host header
-		slug := m.extractSlug(r.Host)
+		// Step 1: Check for X-Tenant-Slug header in local dev mode
+		var slug string
+		if m.localDevMode {
+			slug = r.Header.Get(TenantSlugHeader)
+			if slug != "" {
+				// Validate the slug from header
+				if !isValidSlug(slug) {
+					m.logger.Warn("invalid slug in X-Tenant-Slug header",
+						slog.String("slug", slug),
+					)
+					http.Error(w, "Invalid tenant slug", http.StatusBadRequest)
+					return
+				}
+				m.logger.Debug("using X-Tenant-Slug header (LOCAL_DEV_MODE)",
+					slog.String("slug", slug))
+			}
+		}
+
+		// Step 2: Fall back to subdomain extraction if no header slug
+		if slug == "" {
+			slug = m.extractSlug(r.Host)
+		}
+
 		if slug == "" {
 			m.logger.Warn("invalid subdomain in request",
 				slog.String("host", r.Host),
@@ -122,7 +164,7 @@ func (m *TenantResolverMiddleware) Handler(next http.Handler) http.Handler {
 			return
 		}
 
-		// Step 2: Resolve tenant ID (cache-first with DB fallback)
+		// Step 3: Resolve tenant ID (cache-first with DB fallback)
 		startTime := time.Now()
 		tenantID, err := m.resolveTenant(ctx, slug)
 		resolutionTimeMs := time.Since(startTime).Milliseconds()
@@ -147,23 +189,23 @@ func (m *TenantResolverMiddleware) Handler(next http.Handler) http.Handler {
 			return
 		}
 
-		// Step 3: Log successful resolution
+		// Step 4: Log successful resolution
 		m.logger.Debug("tenant resolved successfully",
 			slog.String("tenant_slug", slug),
 			slog.String("tenant_id", tenantID.String()),
 			slog.Int64("resolution_time_ms", resolutionTimeMs),
 		)
 
-		// Step 4: Inject tenant ID into request header
+		// Step 5: Inject tenant ID into request header
 		r.Header.Set(tenant.TenantIDKey, string(tenantID))
 
-		// Step 5: Add tenant to context
+		// Step 6: Add tenant to context
 		ctx = tenant.WithTenant(ctx, tenantID)
 
-		// Step 6: Update request with new context
+		// Step 7: Update request with new context
 		r = r.WithContext(ctx)
 
-		// Step 7: Call next handler
+		// Step 8: Call next handler
 		next.ServeHTTP(w, r)
 	})
 }

--- a/shared/platform/gateway/tenant_resolver_test.go
+++ b/shared/platform/gateway/tenant_resolver_test.go
@@ -79,6 +79,7 @@ func TestNewTenantResolverMiddleware(t *testing.T) {
 				tt.tenantRepo,
 				tt.baseDomain,
 				tt.logger,
+				false, // localDevMode
 			)
 
 			if tt.wantErr != nil {
@@ -93,6 +94,7 @@ func TestNewTenantResolverMiddleware(t *testing.T) {
 				assert.NotNil(t, middleware.tenantRepo)
 				assert.Equal(t, tt.baseDomain, middleware.baseDomain)
 				assert.Equal(t, tt.logger, middleware.logger)
+				assert.False(t, middleware.localDevMode)
 			}
 		})
 	}
@@ -109,6 +111,7 @@ func TestNewTenantResolverMiddleware_FieldInitialization(t *testing.T) {
 		tenantRepo,
 		baseDomain,
 		logger,
+		true, // localDevMode
 	)
 
 	require.NoError(t, err)
@@ -119,6 +122,7 @@ func TestNewTenantResolverMiddleware_FieldInitialization(t *testing.T) {
 	assert.NotNil(t, middleware.tenantRepo, "tenantRepo field should be set")
 	assert.Equal(t, baseDomain, middleware.baseDomain, "baseDomain should match input")
 	assert.NotNil(t, middleware.logger, "logger field should be set")
+	assert.True(t, middleware.localDevMode, "localDevMode should be true")
 }
 
 func TestExtractSlug(t *testing.T) {
@@ -921,5 +925,272 @@ func TestServeHTTP(t *testing.T) {
 
 		mockCache.AssertExpectations(t)
 		mockRepo.AssertExpectations(t)
+	})
+}
+
+// TestLocalDevMode tests the X-Tenant-Slug header support in local development mode.
+func TestLocalDevMode(t *testing.T) {
+	ctx := context.Background()
+	baseDomain := "api.meridian.io"
+	testSlug := "acme"
+	testTenantID := tenant.MustNewTenantID("tenant_123")
+
+	t.Run("LOCAL_DEV_MODE=true with X-Tenant-Slug header works", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		// Setup: Cache hit for the header-provided slug
+		mockCache.On("Get", ctx, testSlug).Return(testTenantID, nil)
+
+		// Create middleware with localDevMode enabled
+		middleware := &TenantResolverMiddleware{
+			slugCache:    mockCache,
+			tenantRepo:   mockRepo,
+			baseDomain:   baseDomain,
+			logger:       logger,
+			localDevMode: true,
+		}
+
+		// Create test request with X-Tenant-Slug header (no valid subdomain)
+		req := httptest.NewRequest(http.MethodGet, "http://localhost:8080/api/test", nil)
+		req.Header.Set(TenantSlugHeader, testSlug)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		var capturedTenantID tenant.TenantID
+		var capturedTenantOk bool
+
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedTenantID, capturedTenantOk = tenant.FromContext(r.Context())
+			w.WriteHeader(http.StatusOK)
+		})
+
+		// Execute
+		handler := middleware.Handler(next)
+		handler.ServeHTTP(rec, req)
+
+		// Assert
+		assert.Equal(t, http.StatusOK, rec.Code, "should return 200 OK")
+		assert.True(t, capturedTenantOk, "tenant should be in context")
+		assert.Equal(t, testTenantID, capturedTenantID, "tenant ID should match")
+		mockCache.AssertExpectations(t)
+	})
+
+	t.Run("LOCAL_DEV_MODE=false ignores X-Tenant-Slug header", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		// Create middleware with localDevMode disabled
+		middleware := &TenantResolverMiddleware{
+			slugCache:    mockCache,
+			tenantRepo:   mockRepo,
+			baseDomain:   baseDomain,
+			logger:       logger,
+			localDevMode: false,
+		}
+
+		// Create test request with X-Tenant-Slug header but no valid subdomain
+		req := httptest.NewRequest(http.MethodGet, "http://localhost:8080/api/test", nil)
+		req.Header.Set(TenantSlugHeader, testSlug)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		nextCalled := false
+
+		next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			nextCalled = true
+		})
+
+		// Execute
+		handler := middleware.Handler(next)
+		handler.ServeHTTP(rec, req)
+
+		// Assert: Should fail because header is ignored and no valid subdomain
+		assert.Equal(t, http.StatusNotFound, rec.Code, "should return 404 when header is ignored")
+		assert.Contains(t, rec.Body.String(), "Invalid subdomain")
+		assert.False(t, nextCalled, "next handler should not be called")
+		mockCache.AssertNotCalled(t, "Get")
+	})
+
+	t.Run("header takes precedence over subdomain when both present", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		headerSlug := "header-tenant"
+		headerTenantID := tenant.MustNewTenantID("tenant_header")
+
+		// Setup: Cache hit for header slug (NOT subdomain slug)
+		mockCache.On("Get", ctx, headerSlug).Return(headerTenantID, nil)
+
+		// Create middleware with localDevMode enabled
+		middleware := &TenantResolverMiddleware{
+			slugCache:    mockCache,
+			tenantRepo:   mockRepo,
+			baseDomain:   baseDomain,
+			logger:       logger,
+			localDevMode: true,
+		}
+
+		// Create test request with BOTH valid subdomain AND header
+		req := httptest.NewRequest(http.MethodGet, "http://acme.api.meridian.io/api/test", nil)
+		req.Header.Set(TenantSlugHeader, headerSlug)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		var capturedTenantID tenant.TenantID
+
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedTenantID, _ = tenant.FromContext(r.Context())
+			w.WriteHeader(http.StatusOK)
+		})
+
+		// Execute
+		handler := middleware.Handler(next)
+		handler.ServeHTTP(rec, req)
+
+		// Assert: Header tenant should be used, not subdomain tenant
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, headerTenantID, capturedTenantID,
+			"header tenant ID should be used, not subdomain tenant ID")
+		mockCache.AssertExpectations(t)
+		// Verify only header slug was looked up
+		mockCache.AssertCalled(t, "Get", ctx, headerSlug)
+	})
+
+	t.Run("falls back to subdomain when header is empty", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		subdomainSlug := "acme"
+		subdomainTenantID := tenant.MustNewTenantID("tenant_subdomain")
+
+		// Setup: Cache hit for subdomain slug
+		mockCache.On("Get", ctx, subdomainSlug).Return(subdomainTenantID, nil)
+
+		// Create middleware with localDevMode enabled
+		middleware := &TenantResolverMiddleware{
+			slugCache:    mockCache,
+			tenantRepo:   mockRepo,
+			baseDomain:   baseDomain,
+			logger:       logger,
+			localDevMode: true,
+		}
+
+		// Create test request with valid subdomain but no header
+		req := httptest.NewRequest(http.MethodGet, "http://acme.api.meridian.io/api/test", nil)
+		req = req.WithContext(ctx)
+		rec := httptest.NewRecorder()
+
+		var capturedTenantID tenant.TenantID
+
+		next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedTenantID, _ = tenant.FromContext(r.Context())
+			w.WriteHeader(http.StatusOK)
+		})
+
+		// Execute
+		handler := middleware.Handler(next)
+		handler.ServeHTTP(rec, req)
+
+		// Assert: Should use subdomain tenant
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, subdomainTenantID, capturedTenantID)
+		mockCache.AssertExpectations(t)
+	})
+
+	t.Run("invalid slug in header returns 400 Bad Request", func(t *testing.T) {
+		mockCache := new(MockSlugCache)
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		// Create middleware with localDevMode enabled
+		middleware := &TenantResolverMiddleware{
+			slugCache:    mockCache,
+			tenantRepo:   mockRepo,
+			baseDomain:   baseDomain,
+			logger:       logger,
+			localDevMode: true,
+		}
+
+		invalidSlugs := []string{
+			"UPPERCASE",
+			"-invalid",
+			"invalid-",
+			"invalid--slug",
+			"with_underscore",
+			"with spaces",
+		}
+
+		for _, invalidSlug := range invalidSlugs {
+			t.Run(invalidSlug, func(t *testing.T) {
+				req := httptest.NewRequest(http.MethodGet, "http://localhost:8080/api/test", nil)
+				req.Header.Set(TenantSlugHeader, invalidSlug)
+				req = req.WithContext(ctx)
+				rec := httptest.NewRecorder()
+
+				nextCalled := false
+				next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+					nextCalled = true
+				})
+
+				handler := middleware.Handler(next)
+				handler.ServeHTTP(rec, req)
+
+				assert.Equal(t, http.StatusBadRequest, rec.Code,
+					"should return 400 for invalid slug: %s", invalidSlug)
+				assert.Contains(t, rec.Body.String(), "Invalid tenant slug")
+				assert.False(t, nextCalled, "next handler should not be called")
+			})
+		}
+	})
+
+	t.Run("valid slug formats in header work", func(t *testing.T) {
+		mockRepo := new(MockTenantRepository)
+		logger := slog.Default()
+
+		validSlugTenantID := tenant.MustNewTenantID("tenant_valid")
+
+		validSlugs := []string{
+			"acme",
+			"acme123",
+			"acme-corp",
+			"my-company",
+			"tenant1",
+		}
+
+		for _, validSlug := range validSlugs {
+			t.Run(validSlug, func(t *testing.T) {
+				mockCache := new(MockSlugCache)
+				mockCache.On("Get", ctx, validSlug).Return(validSlugTenantID, nil)
+
+				middleware := &TenantResolverMiddleware{
+					slugCache:    mockCache,
+					tenantRepo:   mockRepo,
+					baseDomain:   baseDomain,
+					logger:       logger,
+					localDevMode: true,
+				}
+
+				req := httptest.NewRequest(http.MethodGet, "http://localhost:8080/api/test", nil)
+				req.Header.Set(TenantSlugHeader, validSlug)
+				req = req.WithContext(ctx)
+				rec := httptest.NewRecorder()
+
+				next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				})
+
+				handler := middleware.Handler(next)
+				handler.ServeHTTP(rec, req)
+
+				assert.Equal(t, http.StatusOK, rec.Code,
+					"should accept valid slug: %s", validSlug)
+				mockCache.AssertExpectations(t)
+			})
+		}
 	})
 }


### PR DESCRIPTION
## Summary
- Implement LOCAL_DEV_MODE environment variable to enable X-Tenant-Slug header-based tenant resolution during local development
- Header takes precedence over subdomain-based resolution when LOCAL_DEV_MODE=true
- Add production safety check that fails startup if LOCAL_DEV_MODE=true in prod* namespace

## Task Master Reference
- **Tag**: 8-multi-tenancy
- **Task ID**: 91

## Changes Made
- Modified TenantResolverMiddleware to check X-Tenant-Slug header when LOCAL_DEV_MODE=true
- Header resolution prioritized over subdomain when both are present in dev mode
- Added namespace validation that prevents LOCAL_DEV_MODE from being enabled in production namespaces (prod*)
- Comprehensive test coverage for all scenarios

## Test Plan
**Unit tests:**
- LOCAL_DEV_MODE=true with X-Tenant-Slug header works
- LOCAL_DEV_MODE=false ignores X-Tenant-Slug header  
- Header takes precedence when both header and subdomain present
- Startup fails if LOCAL_DEV_MODE=true in prod* namespace
- Slug validation rejects invalid formats

**Integration test:**
- Local dev request with header succeeds
- Production mode correctly rejects header-based resolution