### PR TITLE
feat(security): add OPA policy to block LOCAL_DEV_MODE in production

### DIFF
--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -65,7 +65,9 @@ jobs:
           # Enable nullglob so patterns that don't match any files expand to nothing
           shopt -s nullglob
           for pattern in "${SERVICE_PROD_PATTERNS[@]}"; do
-            for dir in $pattern; do
+            # Expand glob into array for safe iteration
+            dirs=($pattern)
+            for dir in "${dirs[@]}"; do
               if [ -d "$dir" ]; then
                 echo "Scanning: $dir"
                 if grep -rn --include="*.yaml" --include="*.yml" -E 'LOCAL_DEV_MODE[[:space:]]*[:=][[:space:]]*"?true"?' "$dir"; then
@@ -141,14 +143,15 @@ jobs:
           PYTHON
 
           # Find YAML files in production directories
-          YAML_FILES=$(find deployments/k8s/overlays/production deployments/k8s/overlays/staging -name "*.yaml" -o -name "*.yml" 2>/dev/null || true)
-
-          if [ -z "$YAML_FILES" ]; then
-            echo "No production YAML files found to validate"
-            exit 0
+          # Use -print0 and xargs -0 to safely handle filenames with spaces
+          if ! find deployments/k8s/overlays/production deployments/k8s/overlays/staging \( -name "*.yaml" -o -name "*.yml" \) -print0 2>/dev/null | xargs -0 python3 /tmp/validate_yaml.py; then
+            # Check if directories don't exist (find returns empty)
+            if [ ! -d "deployments/k8s/overlays/production" ] && [ ! -d "deployments/k8s/overlays/staging" ]; then
+              echo "No production YAML files found to validate"
+              exit 0
+            fi
+            exit 1
           fi
-
-          python3 /tmp/validate_yaml.py $YAML_FILES
 
       - name: Verify Rego policy sync
         run: |

--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'deployments/k8s/**'
       - 'services/*/k8s/**'
+      - '.github/workflows/validate-manifests.yml'
   pull_request:
     branches: [develop, main]
     paths:
       - 'deployments/k8s/**'
       - 'services/*/k8s/**'
+      - '.github/workflows/validate-manifests.yml'
 
 permissions:
   contents: read
@@ -60,6 +62,8 @@ jobs:
           done
 
           # Check service-level production directories using glob patterns
+          # Enable nullglob so patterns that don't match any files expand to nothing
+          shopt -s nullglob
           for pattern in "${SERVICE_PROD_PATTERNS[@]}"; do
             for dir in $pattern; do
               if [ -d "$dir" ]; then
@@ -145,3 +149,58 @@ jobs:
           fi
 
           python3 /tmp/validate_yaml.py $YAML_FILES
+
+      - name: Verify Rego policy sync
+        run: |
+          echo "Verifying Rego policy files are in sync..."
+
+          CONSTRAINT_TEMPLATE="deployments/k8s/policies/gateway-dev-mode-block.yaml"
+          REGO_FILE="deployments/k8s/policies/tests/blockdevmodeinproduction.rego"
+
+          if [ ! -f "$CONSTRAINT_TEMPLATE" ]; then
+            echo "ConstraintTemplate not found: $CONSTRAINT_TEMPLATE"
+            exit 1
+          fi
+
+          if [ ! -f "$REGO_FILE" ]; then
+            echo "Rego test file not found: $REGO_FILE"
+            exit 1
+          fi
+
+          # Extract Rego from ConstraintTemplate (between 'rego: |' and the next '---')
+          # Skip comment lines at the top of the standalone .rego file for comparison
+          EMBEDDED_REGO=$(sed -n '/rego: |/,/^---$/p' "$CONSTRAINT_TEMPLATE" | \
+            sed '1d;$d' | \
+            sed 's/^        //')
+
+          # Get standalone Rego, skipping the header comments
+          STANDALONE_REGO=$(sed -n '/^package blockdevmodeinproduction/,$p' "$REGO_FILE")
+
+          # Compare the two (normalize whitespace for comparison)
+          EMBEDDED_NORMALIZED=$(echo "$EMBEDDED_REGO" | sed '/^$/d' | sed 's/[[:space:]]*$//')
+          STANDALONE_NORMALIZED=$(echo "$STANDALONE_REGO" | sed '/^$/d' | sed 's/[[:space:]]*$//')
+
+          if [ "$EMBEDDED_NORMALIZED" != "$STANDALONE_NORMALIZED" ]; then
+            echo "ERROR: Rego policy in ConstraintTemplate differs from standalone test file!"
+            echo ""
+            echo "The Rego embedded in $CONSTRAINT_TEMPLATE must match $REGO_FILE"
+            echo "(excluding header comments)"
+            echo ""
+            echo "To fix: Update both files to have identical Rego policy content."
+            exit 1
+          fi
+
+          echo "Rego policy files are in sync."
+
+      - name: Run OPA policy tests
+        run: |
+          echo "Running OPA policy tests..."
+
+          # Install OPA
+          curl -L -o /tmp/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
+          chmod +x /tmp/opa
+
+          # Run tests with v0-compatible flag for Gatekeeper compatibility
+          /tmp/opa test deployments/k8s/policies/tests/ -v --v0-compatible
+
+          echo "All OPA policy tests passed."

--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -176,17 +176,29 @@ jobs:
           # Get standalone Rego, skipping the header comments
           STANDALONE_REGO=$(sed -n '/^package blockdevmodeinproduction/,$p' "$REGO_FILE")
 
-          # Compare the two (normalize whitespace for comparison)
-          EMBEDDED_NORMALIZED=$(echo "$EMBEDDED_REGO" | sed '/^$/d' | sed 's/[[:space:]]*$//')
-          STANDALONE_NORMALIZED=$(echo "$STANDALONE_REGO" | sed '/^$/d' | sed 's/[[:space:]]*$//')
+          # Normalize for comparison:
+          # 1. Remove blank lines
+          # 2. Normalize all leading whitespace to single spaces for each indentation level
+          # 3. Remove trailing whitespace
+          normalize_rego() {
+            sed '/^$/d' | \
+            sed 's/^[[:space:]]*//' | \
+            sed 's/[[:space:]]*$//'
+          }
+
+          EMBEDDED_NORMALIZED=$(echo "$EMBEDDED_REGO" | normalize_rego)
+          STANDALONE_NORMALIZED=$(echo "$STANDALONE_REGO" | normalize_rego)
 
           if [ "$EMBEDDED_NORMALIZED" != "$STANDALONE_NORMALIZED" ]; then
             echo "ERROR: Rego policy in ConstraintTemplate differs from standalone test file!"
             echo ""
             echo "The Rego embedded in $CONSTRAINT_TEMPLATE must match $REGO_FILE"
-            echo "(excluding header comments)"
+            echo "(excluding header comments and indentation differences)"
             echo ""
-            echo "To fix: Update both files to have identical Rego policy content."
+            echo "To fix: Update both files to have identical Rego policy logic."
+            echo ""
+            echo "=== Differences (ignoring indentation) ==="
+            diff <(echo "$EMBEDDED_NORMALIZED") <(echo "$STANDALONE_NORMALIZED") | head -30 || true
             exit 1
           fi
 

--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -1,0 +1,147 @@
+name: Validate Kubernetes Manifests
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - 'deployments/k8s/**'
+      - 'services/*/k8s/**'
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - 'deployments/k8s/**'
+      - 'services/*/k8s/**'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-production-safety:
+    name: Production Safety Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for LOCAL_DEV_MODE in production manifests
+        run: |
+          echo "Checking for LOCAL_DEV_MODE=true in production manifests..."
+          echo ""
+
+          # Define production directories to scan
+          PROD_DIRS=(
+            "deployments/k8s/overlays/production"
+            "deployments/k8s/overlays/prod"
+          )
+
+          # Also check service-level production manifests
+          SERVICE_PROD_PATTERNS=(
+            "services/*/k8s/production"
+            "services/*/k8s/prod"
+            "services/*/k8s/overlays/production"
+            "services/*/k8s/overlays/prod"
+          )
+
+          VIOLATIONS_FOUND=0
+
+          # Check production overlay directories
+          for dir in "${PROD_DIRS[@]}"; do
+            if [ -d "$dir" ]; then
+              echo "Scanning: $dir"
+              # Search for LOCAL_DEV_MODE set to true in YAML files
+              # Match patterns like: LOCAL_DEV_MODE: "true", LOCAL_DEV_MODE=true, value: "true" after LOCAL_DEV_MODE
+              if grep -rn --include="*.yaml" --include="*.yml" -E 'LOCAL_DEV_MODE[[:space:]]*[:=][[:space:]]*"?true"?' "$dir"; then
+                echo ""
+                echo "ERROR: Found LOCAL_DEV_MODE=true in production manifests!"
+                VIOLATIONS_FOUND=1
+              fi
+            fi
+          done
+
+          # Check service-level production directories using glob patterns
+          for pattern in "${SERVICE_PROD_PATTERNS[@]}"; do
+            for dir in $pattern; do
+              if [ -d "$dir" ]; then
+                echo "Scanning: $dir"
+                if grep -rn --include="*.yaml" --include="*.yml" -E 'LOCAL_DEV_MODE[[:space:]]*[:=][[:space:]]*"?true"?' "$dir"; then
+                  echo ""
+                  echo "ERROR: Found LOCAL_DEV_MODE=true in production manifests!"
+                  VIOLATIONS_FOUND=1
+                fi
+              fi
+            done
+          done
+
+          # Also scan for ConfigMap entries that might set LOCAL_DEV_MODE in staging
+          # (staging should also not have LOCAL_DEV_MODE=true as a security measure)
+          STAGING_DIRS=(
+            "deployments/k8s/overlays/staging"
+          )
+
+          for dir in "${STAGING_DIRS[@]}"; do
+            if [ -d "$dir" ]; then
+              echo "Scanning staging: $dir"
+              if grep -rn --include="*.yaml" --include="*.yml" -E 'LOCAL_DEV_MODE[[:space:]]*[:=][[:space:]]*"?true"?' "$dir"; then
+                echo ""
+                echo "WARNING: Found LOCAL_DEV_MODE=true in staging manifests"
+                echo "This is allowed but should be reviewed for security implications."
+              fi
+            fi
+          done
+
+          echo ""
+          if [ $VIOLATIONS_FOUND -eq 1 ]; then
+            echo "=============================================="
+            echo "ERROR: LOCAL_DEV_MODE=true detected in production manifests!"
+            echo "=============================================="
+            echo ""
+            echo "LOCAL_DEV_MODE is a development-only setting that bypasses"
+            echo "tenant resolution security checks. It must NEVER be enabled"
+            echo "in production environments."
+            echo ""
+            echo "To fix:"
+            echo "  1. Remove LOCAL_DEV_MODE from production ConfigMaps, or"
+            echo "  2. Set LOCAL_DEV_MODE to 'false' explicitly"
+            echo ""
+            exit 1
+          fi
+
+          echo "All production manifests are safe - no LOCAL_DEV_MODE violations found."
+
+      - name: Validate YAML syntax in production manifests
+        run: |
+          echo "Validating YAML syntax in production manifests..."
+          pip install --quiet pyyaml
+
+          # Create a simple YAML validator script
+          cat > /tmp/validate_yaml.py << 'PYTHON'
+          import sys
+          import yaml
+
+          errors = []
+          for filepath in sys.argv[1:]:
+              try:
+                  with open(filepath, 'r') as f:
+                      list(yaml.safe_load_all(f))
+              except yaml.YAMLError as e:
+                  errors.append(f"ERROR: {filepath}: {e}")
+              except Exception as e:
+                  errors.append(f"ERROR: {filepath}: {e}")
+
+          if errors:
+              for error in errors:
+                  print(error)
+              sys.exit(1)
+          print(f"Validated {len(sys.argv[1:])} YAML files successfully.")
+          PYTHON
+
+          # Find YAML files in production directories
+          YAML_FILES=$(find deployments/k8s/overlays/production deployments/k8s/overlays/staging -name "*.yaml" -o -name "*.yml" 2>/dev/null || true)
+
+          if [ -z "$YAML_FILES" ]; then
+            echo "No production YAML files found to validate"
+            exit 0
+          fi
+
+          python3 /tmp/validate_yaml.py $YAML_FILES

--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -153,6 +153,11 @@ jobs:
             exit 1
           fi
 
+      - name: Install OPA
+        uses: open-policy-agent/setup-opa@v2
+        with:
+          version: '0.71.0'
+
       - name: Verify Rego policy sync
         run: |
           echo "Verifying Rego policy files are in sync..."
@@ -172,36 +177,30 @@ jobs:
 
           # Extract Rego from ConstraintTemplate (between 'rego: |' and the next '---')
           # Skip comment lines at the top of the standalone .rego file for comparison
-          EMBEDDED_REGO=$(sed -n '/rego: |/,/^---$/p' "$CONSTRAINT_TEMPLATE" | \
+          YAML_REGO_FILE=$(mktemp)
+          sed -n '/rego: |/,/^---$/p' "$CONSTRAINT_TEMPLATE" | \
             sed '1d;$d' | \
-            sed 's/^        //')
+            sed 's/^        //' > "$YAML_REGO_FILE"
 
           # Get standalone Rego, skipping the header comments
-          STANDALONE_REGO=$(sed -n '/^package blockdevmodeinproduction/,$p' "$REGO_FILE")
+          TEST_REGO_FILE=$(mktemp)
+          sed -n '/^package blockdevmodeinproduction/,$p' "$REGO_FILE" > "$TEST_REGO_FILE"
 
-          # Normalize for comparison:
-          # 1. Remove blank lines
-          # 2. Normalize all leading whitespace to single spaces for each indentation level
-          # 3. Remove trailing whitespace
-          normalize_rego() {
-            sed '/^$/d' | \
-            sed 's/^[[:space:]]*//' | \
-            sed 's/[[:space:]]*$//'
-          }
+          # Use opa fmt to normalize both files before comparing
+          # This is more robust than sed-based normalization
+          opa fmt "$YAML_REGO_FILE" > /tmp/yaml_rego_formatted.rego
+          opa fmt "$TEST_REGO_FILE" > /tmp/test_rego_formatted.rego
 
-          EMBEDDED_NORMALIZED=$(echo "$EMBEDDED_REGO" | normalize_rego)
-          STANDALONE_NORMALIZED=$(echo "$STANDALONE_REGO" | normalize_rego)
-
-          if [ "$EMBEDDED_NORMALIZED" != "$STANDALONE_NORMALIZED" ]; then
+          if ! diff /tmp/yaml_rego_formatted.rego /tmp/test_rego_formatted.rego > /dev/null; then
             echo "ERROR: Rego policy in ConstraintTemplate differs from standalone test file!"
             echo ""
             echo "The Rego embedded in $CONSTRAINT_TEMPLATE must match $REGO_FILE"
-            echo "(excluding header comments and indentation differences)"
+            echo "(excluding header comments and formatting differences)"
             echo ""
             echo "To fix: Update both files to have identical Rego policy logic."
             echo ""
-            echo "=== Differences (ignoring indentation) ==="
-            diff <(echo "$EMBEDDED_NORMALIZED") <(echo "$STANDALONE_NORMALIZED") | head -30 || true
+            echo "=== Differences (after opa fmt normalization) ==="
+            diff /tmp/yaml_rego_formatted.rego /tmp/test_rego_formatted.rego | head -30 || true
             exit 1
           fi
 
@@ -211,11 +210,7 @@ jobs:
         run: |
           echo "Running OPA policy tests..."
 
-          # Install OPA
-          curl -L -o /tmp/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static
-          chmod +x /tmp/opa
-
           # Run tests with v0-compatible flag for Gatekeeper compatibility
-          /tmp/opa test deployments/k8s/policies/tests/ -v --v0-compatible
+          opa test deployments/k8s/policies/tests/ -v --v0-compatible
 
           echo "All OPA policy tests passed."

--- a/.github/workflows/validate-manifests.yml
+++ b/.github/workflows/validate-manifests.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Install OPA
         uses: open-policy-agent/setup-opa@v2
         with:
-          version: '0.71.0'
+          version: '1.12.1'
 
       - name: Verify Rego policy sync
         run: |

--- a/deployments/k8s/policies/gateway-dev-mode-block.yaml
+++ b/deployments/k8s/policies/gateway-dev-mode-block.yaml
@@ -1,0 +1,68 @@
+# OPA Gatekeeper policy to prevent LOCAL_DEV_MODE=true in production namespaces
+# This policy ensures that development-only configurations cannot be deployed to production
+---
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: blockdevmodeinproduction
+  annotations:
+    description: Blocks ConfigMaps with LOCAL_DEV_MODE=true in production namespaces
+spec:
+  crd:
+    spec:
+      names:
+        kind: BlockDevModeInProduction
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package blockdevmodeinproduction
+
+        violation[{"msg": msg}] {
+          # Check if the object is a ConfigMap
+          input.review.object.kind == "ConfigMap"
+
+          # Check if LOCAL_DEV_MODE is set to "true"
+          input.review.object.data.LOCAL_DEV_MODE == "true"
+
+          # Get namespace name
+          ns := input.review.object.metadata.namespace
+
+          # Check if namespace matches production patterns (prod* or *production*)
+          is_production_namespace(ns)
+
+          msg := sprintf("ConfigMap '%s' in namespace '%s' cannot have LOCAL_DEV_MODE=true. Development mode is not allowed in production namespaces.", [input.review.object.metadata.name, ns])
+        }
+
+        # Match namespaces starting with 'prod'
+        is_production_namespace(ns) {
+          startswith(ns, "prod")
+        }
+
+        # Match namespaces containing 'production'
+        is_production_namespace(ns) {
+          contains(ns, "production")
+        }
+---
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: BlockDevModeInProduction
+metadata:
+  name: gateway-dev-mode-constraint
+  annotations:
+    description: Prevents gateway ConfigMaps with LOCAL_DEV_MODE=true in production
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["ConfigMap"]
+    # Note: The Rego policy handles namespace pattern matching (prod*, *production*)
+    # This namespaceSelector provides an additional layer using namespace labels.
+    # Namespaces should be labeled with environment=production for this constraint to apply.
+    # The Rego pattern matching is the primary defense regardless of labels.
+    namespaceSelector:
+      matchExpressions:
+        - key: environment
+          operator: In
+          values:
+            - production
+            - prod

--- a/deployments/k8s/policies/gateway-dev-mode-block.yaml
+++ b/deployments/k8s/policies/gateway-dev-mode-block.yaml
@@ -143,6 +143,8 @@ metadata:
   annotations:
     description: Prevents LOCAL_DEV_MODE=true in ConfigMaps and container env vars in production
 spec:
+  # For gradual rollout, use 'dryrun' (audit only) or 'warn' (allow but warn)
+  # before switching to 'deny' (block) in production
   enforcementAction: deny
   match:
     kinds:

--- a/deployments/k8s/policies/gateway-dev-mode-block.yaml
+++ b/deployments/k8s/policies/gateway-dev-mode-block.yaml
@@ -1,12 +1,13 @@
 # OPA Gatekeeper policy to prevent LOCAL_DEV_MODE=true in production namespaces
 # This policy ensures that development-only configurations cannot be deployed to production
+# It checks both ConfigMaps and container environment variables in all workload types.
 ---
 apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
   name: blockdevmodeinproduction
   annotations:
-    description: Blocks ConfigMaps with LOCAL_DEV_MODE=true in production namespaces
+    description: Blocks LOCAL_DEV_MODE=true in ConfigMaps and container env vars in production namespaces
 spec:
   crd:
     spec:
@@ -16,6 +17,10 @@ spec:
     - target: admission.k8s.gatekeeper.sh
       rego: |
         package blockdevmodeinproduction
+
+        # =============================================================================
+        # ConfigMap violation rule
+        # =============================================================================
 
         violation[{"msg": msg}] {
           # Check if the object is a ConfigMap
@@ -36,6 +41,91 @@ spec:
           msg := sprintf("ConfigMap '%s' in namespace '%s' cannot have LOCAL_DEV_MODE=true. Development mode is not allowed in production namespaces.", [input.review.object.metadata.name, ns])
         }
 
+        # =============================================================================
+        # Pod/workload environment variable violation rules
+        # Check for LOCAL_DEV_MODE=true in container env vars for:
+        # - Pods, Deployments, StatefulSets, DaemonSets, Jobs, CronJobs
+        # =============================================================================
+
+        # Supported workload kinds that can contain container specs
+        workload_kinds := {"Pod", "Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob", "ReplicaSet"}
+
+        # Helper to get the pod spec from different workload types
+        get_pod_spec(obj) = spec {
+          obj.kind == "Pod"
+          spec := obj.spec
+        }
+
+        get_pod_spec(obj) = spec {
+          workload_kinds[obj.kind]
+          obj.kind != "Pod"
+          obj.kind != "CronJob"
+          spec := obj.spec.template.spec
+        }
+
+        get_pod_spec(obj) = spec {
+          obj.kind == "CronJob"
+          spec := obj.spec.jobTemplate.spec.template.spec
+        }
+
+        # Check containers for LOCAL_DEV_MODE=true env var
+        violation[{"msg": msg}] {
+          obj := input.review.object
+          workload_kinds[obj.kind]
+
+          pod_spec := get_pod_spec(obj)
+          container := pod_spec.containers[_]
+          env_var := container.env[_]
+
+          env_var.name == "LOCAL_DEV_MODE"
+          lower(env_var.value) == "true"
+
+          ns := obj.metadata.namespace
+          is_production_namespace(ns)
+
+          msg := sprintf("%s '%s' in namespace '%s' has container '%s' with LOCAL_DEV_MODE=true environment variable. Development mode is not allowed in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+        }
+
+        # Check initContainers for LOCAL_DEV_MODE=true env var
+        violation[{"msg": msg}] {
+          obj := input.review.object
+          workload_kinds[obj.kind]
+
+          pod_spec := get_pod_spec(obj)
+          container := pod_spec.initContainers[_]
+          env_var := container.env[_]
+
+          env_var.name == "LOCAL_DEV_MODE"
+          lower(env_var.value) == "true"
+
+          ns := obj.metadata.namespace
+          is_production_namespace(ns)
+
+          msg := sprintf("%s '%s' in namespace '%s' has initContainer '%s' with LOCAL_DEV_MODE=true environment variable. Development mode is not allowed in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+        }
+
+        # Check ephemeralContainers for LOCAL_DEV_MODE=true env var
+        violation[{"msg": msg}] {
+          obj := input.review.object
+          workload_kinds[obj.kind]
+
+          pod_spec := get_pod_spec(obj)
+          container := pod_spec.ephemeralContainers[_]
+          env_var := container.env[_]
+
+          env_var.name == "LOCAL_DEV_MODE"
+          lower(env_var.value) == "true"
+
+          ns := obj.metadata.namespace
+          is_production_namespace(ns)
+
+          msg := sprintf("%s '%s' in namespace '%s' has ephemeralContainer '%s' with LOCAL_DEV_MODE=true environment variable. Development mode is not allowed in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+        }
+
+        # =============================================================================
+        # Namespace detection helpers
+        # =============================================================================
+
         # Match namespaces starting with 'prod'
         is_production_namespace(ns) {
           startswith(ns, "prod")
@@ -51,21 +141,20 @@ kind: BlockDevModeInProduction
 metadata:
   name: gateway-dev-mode-constraint
   annotations:
-    description: Prevents gateway ConfigMaps with LOCAL_DEV_MODE=true in production
+    description: Prevents LOCAL_DEV_MODE=true in ConfigMaps and container env vars in production
 spec:
   enforcementAction: deny
   match:
     kinds:
       - apiGroups: [""]
         kinds: ["ConfigMap"]
-    # Note: The Rego policy handles namespace pattern matching (prod*, *production*)
-    # This namespaceSelector provides an additional layer using namespace labels.
-    # Namespaces should be labeled with environment=production for this constraint to apply.
-    # The Rego pattern matching is the primary defense regardless of labels.
-    namespaceSelector:
-      matchExpressions:
-        - key: environment
-          operator: In
-          values:
-            - production
-            - prod
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "StatefulSet", "DaemonSet", "ReplicaSet"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    # Note: Namespace matching is handled entirely by the Rego policy using name patterns
+    # (prod* or *production*). This approach allows flexible matching without requiring
+    # specific namespace labels, and the policy will correctly identify production
+    # namespaces regardless of their labels.

--- a/deployments/k8s/policies/gateway-dev-mode-block.yaml
+++ b/deployments/k8s/policies/gateway-dev-mode-block.yaml
@@ -21,8 +21,11 @@ spec:
           # Check if the object is a ConfigMap
           input.review.object.kind == "ConfigMap"
 
-          # Check if LOCAL_DEV_MODE is set to "true"
-          input.review.object.data.LOCAL_DEV_MODE == "true"
+          # Check if data field exists
+          input.review.object.data
+
+          # Check if LOCAL_DEV_MODE is set to "true" (case-insensitive)
+          lower(input.review.object.data.LOCAL_DEV_MODE) == "true"
 
           # Get namespace name
           ns := input.review.object.metadata.namespace

--- a/deployments/k8s/policies/tests/README.md
+++ b/deployments/k8s/policies/tests/README.md
@@ -152,7 +152,7 @@ Add to your CI pipeline:
 - name: Install OPA
   uses: open-policy-agent/setup-opa@v2
   with:
-    version: '0.71.0'
+    version: '1.12.1'
 
 - name: Test OPA Gatekeeper Policies
   run: |

--- a/deployments/k8s/policies/tests/README.md
+++ b/deployments/k8s/policies/tests/README.md
@@ -149,10 +149,25 @@ The `blockdevmodeinproduction.rego` file is extracted from the ConstraintTemplat
 Add to your CI pipeline:
 
 ```yaml
+- name: Install OPA
+  uses: open-policy-agent/setup-opa@v2
+  with:
+    version: '0.71.0'
+
 - name: Test OPA Gatekeeper Policies
   run: |
-    curl -L -o /usr/local/bin/opa https://github.com/open-policy-agent/opa/releases/download/v1.12.1/opa_linux_amd64_static
-    chmod +x /usr/local/bin/opa
     # --v0-compatible is required because Gatekeeper uses Rego v0 syntax
     opa test deployments/k8s/policies/tests/ --v0-compatible -v
 ```
+
+## Known Limitations
+
+1. **`envFrom` references are not checked at the Pod/Deployment level**: When a container uses
+   `envFrom` to reference a ConfigMap, the policy cannot detect `LOCAL_DEV_MODE=true` at the
+   workload level. However, the ConfigMap itself is validated when created/updated, providing
+   defense-in-depth.
+
+2. **"product" namespace prefix matches are intentional**: Namespaces like `product-catalog` will
+   be flagged as production due to the `prod*` prefix match. This is by design - false positives
+   are safer than false negatives for security policies. If needed, adjust the namespace matching
+   logic in the Rego policy.

--- a/deployments/k8s/policies/tests/README.md
+++ b/deployments/k8s/policies/tests/README.md
@@ -1,0 +1,158 @@
+# OPA Gatekeeper Policy Tests
+
+This directory contains tests for the `BlockDevModeInProduction` OPA Gatekeeper policy
+that prevents `LOCAL_DEV_MODE=true` from being deployed in production namespaces.
+
+## Quick Start
+
+### Run OPA Unit Tests
+
+```bash
+# From repository root
+./deployments/k8s/policies/tests/run_tests.sh
+
+# Or with verbose output
+./deployments/k8s/policies/tests/run_tests.sh -v
+
+# Or directly with opa (--v0-compatible required for OPA 1.x)
+opa test deployments/k8s/policies/tests/ --v0-compatible -v
+```
+
+### Prerequisites
+
+- **opa**: `brew install opa` or download from <https://www.openpolicyagent.org/docs/latest/>
+
+## Test Coverage
+
+The test suite verifies:
+
+| Scenario | Expected Result |
+|----------|-----------------|
+| ConfigMap with `LOCAL_DEV_MODE=true` in `prod` namespace | BLOCKED |
+| ConfigMap with `LOCAL_DEV_MODE=true` in `production` namespace | BLOCKED |
+| ConfigMap with `LOCAL_DEV_MODE=true` in `prod-eu` namespace | BLOCKED |
+| ConfigMap with `LOCAL_DEV_MODE=true` in `prod-us-west` namespace | BLOCKED |
+| ConfigMap with `LOCAL_DEV_MODE=true` in `my-production-service` namespace | BLOCKED |
+| ConfigMap with `LOCAL_DEV_MODE=true` in `dev` namespace | ALLOWED |
+| ConfigMap with `LOCAL_DEV_MODE=true` in `staging` namespace | ALLOWED |
+| ConfigMap with `LOCAL_DEV_MODE=true` in `default` namespace | ALLOWED |
+| ConfigMap with `LOCAL_DEV_MODE=false` in `prod` namespace | ALLOWED |
+| ConfigMap without `LOCAL_DEV_MODE` in `prod` namespace | ALLOWED |
+| Non-ConfigMap objects (Deployment, Secret) in `prod` | ALLOWED |
+
+## Manual Kubernetes Cluster Testing
+
+For full integration testing with an actual Gatekeeper deployment:
+
+### 1. Prerequisites
+
+- Kubernetes cluster (kind, minikube, or cloud)
+- OPA Gatekeeper installed: <https://open-policy-agent.github.io/gatekeeper/website/docs/install/>
+
+### 2. Install Gatekeeper (if not already installed)
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.15.0/deploy/gatekeeper.yaml
+
+# Wait for Gatekeeper to be ready
+kubectl -n gatekeeper-system wait --for=condition=Ready pod -l control-plane=controller-manager --timeout=60s
+```
+
+### 3. Apply the Policy
+
+```bash
+# Apply the ConstraintTemplate and Constraint
+kubectl apply -f deployments/k8s/policies/gateway-dev-mode-block.yaml
+
+# Wait for the constraint to be ready
+kubectl get constraint gateway-dev-mode-constraint -o jsonpath='{.status.byPod}'
+```
+
+### 4. Test: Verify Blocking in Production Namespace
+
+```bash
+# Create production namespace with appropriate label
+kubectl create namespace prod-test --dry-run=client -o yaml | \
+  kubectl label --local -f - environment=production -o yaml | \
+  kubectl apply -f -
+
+# Attempt to create ConfigMap with LOCAL_DEV_MODE=true (should be denied)
+cat <<EOF | kubectl apply -f - 2>&1 || echo "Expected denial"
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-config-test
+  namespace: prod-test
+data:
+  LOCAL_DEV_MODE: "true"
+EOF
+# Expected: denied by gateway-dev-mode-constraint
+
+# Cleanup
+kubectl delete namespace prod-test --ignore-not-found
+```
+
+### 5. Test: Verify Allowing in Dev Namespace
+
+```bash
+# Create dev namespace
+kubectl create namespace dev-test --dry-run=client -o yaml | \
+  kubectl label --local -f - environment=development -o yaml | \
+  kubectl apply -f -
+
+# Create ConfigMap with LOCAL_DEV_MODE=true (should succeed)
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-config-test
+  namespace: dev-test
+data:
+  LOCAL_DEV_MODE: "true"
+EOF
+# Expected: configmap/gateway-config-test created
+
+# Cleanup
+kubectl delete namespace dev-test --ignore-not-found
+```
+
+### 6. Verify Violation Messages
+
+```bash
+# Check constraint status for violations
+kubectl get constraint gateway-dev-mode-constraint -o yaml
+
+# Check audit logs
+kubectl logs -n gatekeeper-system -l control-plane=audit-controller --tail=50
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `blockdevmodeinproduction.rego` | Rego policy extracted from ConstraintTemplate for testing |
+| `policy_test.rego` | OPA unit tests for the policy |
+| `run_tests.sh` | Script to run all tests |
+| `README.md` | This file |
+
+## Keeping Tests in Sync
+
+The `blockdevmodeinproduction.rego` file is extracted from the ConstraintTemplate in
+`gateway-dev-mode-block.yaml`. When updating the policy:
+
+1. Update `gateway-dev-mode-block.yaml` (the canonical source)
+2. Copy the Rego code from the `spec.targets[].rego` field to `blockdevmodeinproduction.rego`
+3. Run the tests to ensure the policy works as expected
+
+## CI Integration
+
+Add to your CI pipeline:
+
+```yaml
+- name: Test OPA Gatekeeper Policies
+  run: |
+    curl -L -o /usr/local/bin/opa https://github.com/open-policy-agent/opa/releases/download/v1.12.1/opa_linux_amd64_static
+    chmod +x /usr/local/bin/opa
+    # --v0-compatible is required because Gatekeeper uses Rego v0 syntax
+    opa test deployments/k8s/policies/tests/ --v0-compatible -v
+```

--- a/deployments/k8s/policies/tests/blockdevmodeinproduction.rego
+++ b/deployments/k8s/policies/tests/blockdevmodeinproduction.rego
@@ -4,6 +4,10 @@
 
 package blockdevmodeinproduction
 
+# =============================================================================
+# ConfigMap violation rule
+# =============================================================================
+
 violation[{"msg": msg}] {
     # Check if the object is a ConfigMap
     input.review.object.kind == "ConfigMap"
@@ -22,6 +26,91 @@ violation[{"msg": msg}] {
 
     msg := sprintf("ConfigMap '%s' in namespace '%s' cannot have LOCAL_DEV_MODE=true. Development mode is not allowed in production namespaces.", [input.review.object.metadata.name, ns])
 }
+
+# =============================================================================
+# Pod/workload environment variable violation rules
+# Check for LOCAL_DEV_MODE=true in container env vars for:
+# - Pods, Deployments, StatefulSets, DaemonSets, Jobs, CronJobs
+# =============================================================================
+
+# Supported workload kinds that can contain container specs
+workload_kinds := {"Pod", "Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob", "ReplicaSet"}
+
+# Helper to get the pod spec from different workload types
+get_pod_spec(obj) = spec {
+    obj.kind == "Pod"
+    spec := obj.spec
+}
+
+get_pod_spec(obj) = spec {
+    workload_kinds[obj.kind]
+    obj.kind != "Pod"
+    obj.kind != "CronJob"
+    spec := obj.spec.template.spec
+}
+
+get_pod_spec(obj) = spec {
+    obj.kind == "CronJob"
+    spec := obj.spec.jobTemplate.spec.template.spec
+}
+
+# Check containers for LOCAL_DEV_MODE=true env var
+violation[{"msg": msg}] {
+    obj := input.review.object
+    workload_kinds[obj.kind]
+
+    pod_spec := get_pod_spec(obj)
+    container := pod_spec.containers[_]
+    env_var := container.env[_]
+
+    env_var.name == "LOCAL_DEV_MODE"
+    lower(env_var.value) == "true"
+
+    ns := obj.metadata.namespace
+    is_production_namespace(ns)
+
+    msg := sprintf("%s '%s' in namespace '%s' has container '%s' with LOCAL_DEV_MODE=true environment variable. Development mode is not allowed in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+}
+
+# Check initContainers for LOCAL_DEV_MODE=true env var
+violation[{"msg": msg}] {
+    obj := input.review.object
+    workload_kinds[obj.kind]
+
+    pod_spec := get_pod_spec(obj)
+    container := pod_spec.initContainers[_]
+    env_var := container.env[_]
+
+    env_var.name == "LOCAL_DEV_MODE"
+    lower(env_var.value) == "true"
+
+    ns := obj.metadata.namespace
+    is_production_namespace(ns)
+
+    msg := sprintf("%s '%s' in namespace '%s' has initContainer '%s' with LOCAL_DEV_MODE=true environment variable. Development mode is not allowed in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+}
+
+# Check ephemeralContainers for LOCAL_DEV_MODE=true env var
+violation[{"msg": msg}] {
+    obj := input.review.object
+    workload_kinds[obj.kind]
+
+    pod_spec := get_pod_spec(obj)
+    container := pod_spec.ephemeralContainers[_]
+    env_var := container.env[_]
+
+    env_var.name == "LOCAL_DEV_MODE"
+    lower(env_var.value) == "true"
+
+    ns := obj.metadata.namespace
+    is_production_namespace(ns)
+
+    msg := sprintf("%s '%s' in namespace '%s' has ephemeralContainer '%s' with LOCAL_DEV_MODE=true environment variable. Development mode is not allowed in production namespaces.", [obj.kind, obj.metadata.name, ns, container.name])
+}
+
+# =============================================================================
+# Namespace detection helpers
+# =============================================================================
 
 # Match namespaces starting with 'prod'
 is_production_namespace(ns) {

--- a/deployments/k8s/policies/tests/blockdevmodeinproduction.rego
+++ b/deployments/k8s/policies/tests/blockdevmodeinproduction.rego
@@ -1,0 +1,31 @@
+# OPA Gatekeeper policy to prevent LOCAL_DEV_MODE=true in production namespaces
+# This file is the Rego policy extracted from the ConstraintTemplate for testing.
+# The canonical source is gateway-dev-mode-block.yaml - keep these in sync.
+
+package blockdevmodeinproduction
+
+violation[{"msg": msg}] {
+    # Check if the object is a ConfigMap
+    input.review.object.kind == "ConfigMap"
+
+    # Check if LOCAL_DEV_MODE is set to "true"
+    input.review.object.data.LOCAL_DEV_MODE == "true"
+
+    # Get namespace name
+    ns := input.review.object.metadata.namespace
+
+    # Check if namespace matches production patterns (prod* or *production*)
+    is_production_namespace(ns)
+
+    msg := sprintf("ConfigMap '%s' in namespace '%s' cannot have LOCAL_DEV_MODE=true. Development mode is not allowed in production namespaces.", [input.review.object.metadata.name, ns])
+}
+
+# Match namespaces starting with 'prod'
+is_production_namespace(ns) {
+    startswith(ns, "prod")
+}
+
+# Match namespaces containing 'production'
+is_production_namespace(ns) {
+    contains(ns, "production")
+}

--- a/deployments/k8s/policies/tests/blockdevmodeinproduction.rego
+++ b/deployments/k8s/policies/tests/blockdevmodeinproduction.rego
@@ -8,8 +8,11 @@ violation[{"msg": msg}] {
     # Check if the object is a ConfigMap
     input.review.object.kind == "ConfigMap"
 
-    # Check if LOCAL_DEV_MODE is set to "true"
-    input.review.object.data.LOCAL_DEV_MODE == "true"
+    # Check if data field exists
+    input.review.object.data
+
+    # Check if LOCAL_DEV_MODE is set to "true" (case-insensitive)
+    lower(input.review.object.data.LOCAL_DEV_MODE) == "true"
 
     # Get namespace name
     ns := input.review.object.metadata.namespace

--- a/deployments/k8s/policies/tests/policy_test.rego
+++ b/deployments/k8s/policies/tests/policy_test.rego
@@ -131,6 +131,70 @@ test_violation_local_dev_mode_true_in_prod_eu {
 }
 
 # =============================================================================
+# Test: Case-insensitive LOCAL_DEV_MODE value checking
+# =============================================================================
+
+test_violation_local_dev_mode_True_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "True"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_local_dev_mode_TRUE_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "TRUE"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_local_dev_mode_TrUe_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "TrUe"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+# =============================================================================
 # Test: ConfigMap with LOCAL_DEV_MODE=true in dev/staging should be allowed
 # =============================================================================
 
@@ -248,6 +312,27 @@ test_no_violation_empty_configmap_in_prod {
                     "namespace": "prod"
                 },
                 "data": {}
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+# Test: ConfigMap with only binaryData (no data field) should not trigger violations
+test_no_violation_configmap_with_only_binarydata_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "prod"
+                },
+                "binaryData": {
+                    "config.bin": "YmluYXJ5IGRhdGE="
+                }
             }
         }
     }

--- a/deployments/k8s/policies/tests/policy_test.rego
+++ b/deployments/k8s/policies/tests/policy_test.rego
@@ -3,9 +3,6 @@
 
 package blockdevmodeinproduction
 
-# Import the policy module
-import data.blockdevmodeinproduction
-
 # =============================================================================
 # Test: Production namespace detection
 # =============================================================================

--- a/deployments/k8s/policies/tests/policy_test.rego
+++ b/deployments/k8s/policies/tests/policy_test.rego
@@ -1,0 +1,372 @@
+# Tests for the BlockDevModeInProduction OPA Gatekeeper policy
+# Run with: opa test deployments/k8s/policies/tests/ -v
+
+package blockdevmodeinproduction
+
+# Import the policy module
+import data.blockdevmodeinproduction
+
+# =============================================================================
+# Test: Production namespace detection
+# =============================================================================
+
+# Test: "prod" namespace is detected as production
+test_is_production_namespace_prod {
+    is_production_namespace("prod")
+}
+
+# Test: "production" namespace is detected as production
+test_is_production_namespace_production {
+    is_production_namespace("production")
+}
+
+# Test: "prod-eu" namespace (starts with prod) is production
+test_is_production_namespace_prod_eu {
+    is_production_namespace("prod-eu")
+}
+
+# Test: "prod-us-west" namespace is production
+test_is_production_namespace_prod_us_west {
+    is_production_namespace("prod-us-west")
+}
+
+# Test: "my-production-service" namespace (contains production) is production
+test_is_production_namespace_contains_production {
+    is_production_namespace("my-production-service")
+}
+
+# Test: "production-critical" namespace is production
+test_is_production_namespace_production_critical {
+    is_production_namespace("production-critical")
+}
+
+# Test: "dev" namespace is NOT production
+test_is_not_production_namespace_dev {
+    not is_production_namespace("dev")
+}
+
+# Test: "staging" namespace is NOT production
+test_is_not_production_namespace_staging {
+    not is_production_namespace("staging")
+}
+
+# Test: "default" namespace is NOT production
+test_is_not_production_namespace_default {
+    not is_production_namespace("default")
+}
+
+# Test: "meridian-dev" namespace is NOT production
+test_is_not_production_namespace_meridian_dev {
+    not is_production_namespace("meridian-dev")
+}
+
+# Test: "product" namespace (starts with "prod" but different word) IS detected
+# Note: This is by design - false positives are safer than false negatives
+test_is_production_namespace_product {
+    is_production_namespace("product")
+}
+
+# =============================================================================
+# Test: ConfigMap with LOCAL_DEV_MODE=true in production should be blocked
+# =============================================================================
+
+test_violation_local_dev_mode_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "true"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_local_dev_mode_true_in_production_namespace {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "production"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "true"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_local_dev_mode_true_in_prod_eu {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "prod-eu"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "true"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+# =============================================================================
+# Test: ConfigMap with LOCAL_DEV_MODE=true in dev/staging should be allowed
+# =============================================================================
+
+test_no_violation_local_dev_mode_true_in_dev {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "dev"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "true"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_local_dev_mode_true_in_staging {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "staging"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "true"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_local_dev_mode_true_in_default {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "default"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "true"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+# =============================================================================
+# Test: ConfigMap without LOCAL_DEV_MODE or with false value should be allowed
+# =============================================================================
+
+test_no_violation_local_dev_mode_false_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "false"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_no_local_dev_mode_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "SOME_OTHER_CONFIG": "value"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_empty_configmap_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "prod"
+                },
+                "data": {}
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+# =============================================================================
+# Test: Non-ConfigMap objects should not trigger violations
+# =============================================================================
+
+test_no_violation_deployment_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "gateway",
+                    "namespace": "prod"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_secret_with_local_dev_mode_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Secret",
+                "metadata": {
+                    "name": "gateway-secret",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "true"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+# =============================================================================
+# Test: Violation message is clear and actionable
+# =============================================================================
+
+test_violation_message_contains_configmap_name {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "my-gateway-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "true"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+    some v
+    violations[v]
+    contains(v.msg, "my-gateway-config")
+}
+
+test_violation_message_contains_namespace {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "prod-eu"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "true"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+    some v
+    violations[v]
+    contains(v.msg, "prod-eu")
+}
+
+test_violation_message_mentions_dev_mode_not_allowed {
+    input := {
+        "review": {
+            "object": {
+                "kind": "ConfigMap",
+                "metadata": {
+                    "name": "gateway-config",
+                    "namespace": "prod"
+                },
+                "data": {
+                    "LOCAL_DEV_MODE": "true"
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+    some v
+    violations[v]
+    contains(v.msg, "LOCAL_DEV_MODE=true")
+    contains(v.msg, "not allowed in production")
+}

--- a/deployments/k8s/policies/tests/policy_test.rego
+++ b/deployments/k8s/policies/tests/policy_test.rego
@@ -455,3 +455,531 @@ test_violation_message_mentions_dev_mode_not_allowed {
     contains(v.msg, "LOCAL_DEV_MODE=true")
     contains(v.msg, "not allowed in production")
 }
+
+# =============================================================================
+# Test: Pod/workload container env var with LOCAL_DEV_MODE=true
+# =============================================================================
+
+test_violation_pod_container_env_local_dev_mode_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "metadata": {
+                    "name": "gateway-pod",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "containers": [{
+                        "name": "gateway",
+                        "image": "gateway:latest",
+                        "env": [{
+                            "name": "LOCAL_DEV_MODE",
+                            "value": "true"
+                        }]
+                    }]
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_deployment_container_env_local_dev_mode_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "gateway-deployment",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "gateway",
+                                "image": "gateway:latest",
+                                "env": [{
+                                    "name": "LOCAL_DEV_MODE",
+                                    "value": "true"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_statefulset_container_env_local_dev_mode_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "StatefulSet",
+                "metadata": {
+                    "name": "gateway-sts",
+                    "namespace": "production"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "gateway",
+                                "image": "gateway:latest",
+                                "env": [{
+                                    "name": "LOCAL_DEV_MODE",
+                                    "value": "True"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_daemonset_container_env_local_dev_mode_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "DaemonSet",
+                "metadata": {
+                    "name": "gateway-ds",
+                    "namespace": "prod-eu"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "gateway",
+                                "image": "gateway:latest",
+                                "env": [{
+                                    "name": "LOCAL_DEV_MODE",
+                                    "value": "TRUE"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_job_container_env_local_dev_mode_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Job",
+                "metadata": {
+                    "name": "gateway-job",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "gateway",
+                                "image": "gateway:latest",
+                                "env": [{
+                                    "name": "LOCAL_DEV_MODE",
+                                    "value": "true"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_cronjob_container_env_local_dev_mode_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "CronJob",
+                "metadata": {
+                    "name": "gateway-cronjob",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "jobTemplate": {
+                        "spec": {
+                            "template": {
+                                "spec": {
+                                    "containers": [{
+                                        "name": "gateway",
+                                        "image": "gateway:latest",
+                                        "env": [{
+                                            "name": "LOCAL_DEV_MODE",
+                                            "value": "true"
+                                        }]
+                                    }]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+# =============================================================================
+# Test: initContainers with LOCAL_DEV_MODE=true
+# =============================================================================
+
+test_violation_pod_initcontainer_env_local_dev_mode_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "metadata": {
+                    "name": "gateway-pod",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "containers": [{
+                        "name": "gateway",
+                        "image": "gateway:latest"
+                    }],
+                    "initContainers": [{
+                        "name": "init-gateway",
+                        "image": "gateway-init:latest",
+                        "env": [{
+                            "name": "LOCAL_DEV_MODE",
+                            "value": "true"
+                        }]
+                    }]
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+test_violation_deployment_initcontainer_env_local_dev_mode_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "gateway-deployment",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "gateway",
+                                "image": "gateway:latest"
+                            }],
+                            "initContainers": [{
+                                "name": "init-gateway",
+                                "image": "gateway-init:latest",
+                                "env": [{
+                                    "name": "LOCAL_DEV_MODE",
+                                    "value": "true"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+# =============================================================================
+# Test: ephemeralContainers with LOCAL_DEV_MODE=true
+# =============================================================================
+
+test_violation_pod_ephemeralcontainer_env_local_dev_mode_true_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "metadata": {
+                    "name": "gateway-pod",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "containers": [{
+                        "name": "gateway",
+                        "image": "gateway:latest"
+                    }],
+                    "ephemeralContainers": [{
+                        "name": "debug-container",
+                        "image": "debug:latest",
+                        "env": [{
+                            "name": "LOCAL_DEV_MODE",
+                            "value": "true"
+                        }]
+                    }]
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+}
+
+# =============================================================================
+# Test: Workloads with LOCAL_DEV_MODE=true in dev/staging should be allowed
+# =============================================================================
+
+test_no_violation_pod_container_env_local_dev_mode_true_in_dev {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "metadata": {
+                    "name": "gateway-pod",
+                    "namespace": "dev"
+                },
+                "spec": {
+                    "containers": [{
+                        "name": "gateway",
+                        "image": "gateway:latest",
+                        "env": [{
+                            "name": "LOCAL_DEV_MODE",
+                            "value": "true"
+                        }]
+                    }]
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_deployment_container_env_local_dev_mode_true_in_staging {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "gateway-deployment",
+                    "namespace": "staging"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "gateway",
+                                "image": "gateway:latest",
+                                "env": [{
+                                    "name": "LOCAL_DEV_MODE",
+                                    "value": "true"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+# =============================================================================
+# Test: Workloads with LOCAL_DEV_MODE=false or missing should be allowed
+# =============================================================================
+
+test_no_violation_pod_container_env_local_dev_mode_false_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "metadata": {
+                    "name": "gateway-pod",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "containers": [{
+                        "name": "gateway",
+                        "image": "gateway:latest",
+                        "env": [{
+                            "name": "LOCAL_DEV_MODE",
+                            "value": "false"
+                        }]
+                    }]
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_pod_container_no_local_dev_mode_env_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Pod",
+                "metadata": {
+                    "name": "gateway-pod",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "containers": [{
+                        "name": "gateway",
+                        "image": "gateway:latest",
+                        "env": [{
+                            "name": "OTHER_ENV",
+                            "value": "some-value"
+                        }]
+                    }]
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+test_no_violation_deployment_container_no_env_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "gateway-deployment",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "gateway",
+                                "image": "gateway:latest"
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 0
+}
+
+# =============================================================================
+# Test: Multiple violations in same workload
+# =============================================================================
+
+test_multiple_violations_multiple_containers_with_local_dev_mode_in_prod {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "gateway-deployment",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "gateway",
+                                    "image": "gateway:latest",
+                                    "env": [{
+                                        "name": "LOCAL_DEV_MODE",
+                                        "value": "true"
+                                    }]
+                                },
+                                {
+                                    "name": "sidecar",
+                                    "image": "sidecar:latest",
+                                    "env": [{
+                                        "name": "LOCAL_DEV_MODE",
+                                        "value": "true"
+                                    }]
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 2
+}
+
+# =============================================================================
+# Test: Workload violation message contains relevant information
+# =============================================================================
+
+test_workload_violation_message_contains_kind_and_name {
+    input := {
+        "review": {
+            "object": {
+                "kind": "Deployment",
+                "metadata": {
+                    "name": "my-gateway-deployment",
+                    "namespace": "prod"
+                },
+                "spec": {
+                    "template": {
+                        "spec": {
+                            "containers": [{
+                                "name": "gateway-container",
+                                "image": "gateway:latest",
+                                "env": [{
+                                    "name": "LOCAL_DEV_MODE",
+                                    "value": "true"
+                                }]
+                            }]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    violations := violation with input as input
+    count(violations) == 1
+    some v
+    violations[v]
+    contains(v.msg, "Deployment")
+    contains(v.msg, "my-gateway-deployment")
+    contains(v.msg, "gateway-container")
+    contains(v.msg, "prod")
+}

--- a/deployments/k8s/policies/tests/run_tests.sh
+++ b/deployments/k8s/policies/tests/run_tests.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Integration tests for the BlockDevModeInProduction OPA Gatekeeper policy
+#
+# Prerequisites:
+#   - opa: brew install opa (or download from https://www.openpolicyagent.org/docs/latest/#running-opa)
+#
+# Usage:
+#   ./run_tests.sh           # Run all tests
+#   ./run_tests.sh -v        # Verbose output
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERBOSE=${1:-""}
+
+echo "=== OPA Policy Tests: BlockDevModeInProduction ==="
+echo ""
+
+# Check for opa command
+if ! command -v opa &> /dev/null; then
+    echo "ERROR: 'opa' command not found."
+    echo "Install with: brew install opa"
+    echo "Or download from: https://www.openpolicyagent.org/docs/latest/#running-opa"
+    exit 1
+fi
+
+echo "Running OPA unit tests..."
+echo ""
+
+# Note: --v0-compatible is required because Gatekeeper ConstraintTemplates
+# use the older Rego v0 syntax. OPA 1.x defaults to Rego v1.
+if [ "$VERBOSE" = "-v" ]; then
+    opa test "$SCRIPT_DIR" --v0-compatible -v
+else
+    opa test "$SCRIPT_DIR" --v0-compatible
+fi
+
+echo ""
+echo "=== All tests passed ==="


### PR DESCRIPTION
## Summary

- Add OPA Gatekeeper policy to block `LOCAL_DEV_MODE=true` in production namespaces
- Add GitHub Actions workflow for CI validation of production manifests
- Add comprehensive OPA policy test suite with 45 unit tests

## Changes

### OPA Gatekeeper Policy (`deployments/k8s/policies/gateway-dev-mode-block.yaml`)
- ConstraintTemplate `BlockDevModeInProduction` with Rego policy logic
- Detects `LOCAL_DEV_MODE=true` in:
  - ConfigMaps (data field)
  - Container env vars (containers, initContainers, ephemeralContainers)
  - All workload types: Pod, Deployment, StatefulSet, DaemonSet, Job, CronJob, ReplicaSet
- **Production namespace detection** by name pattern matching:
  - Namespaces starting with `prod` (e.g., `prod`, `prod-eu`, `prod-us-west`)
  - Namespaces containing `production` (e.g., `my-production-service`)
- Provides clear violation messages for debugging

### CI Validation (`.github/workflows/validate-manifests.yml`)
- Runs on all pushes/PRs affecting Kubernetes manifests or workflow file
- Validates YAML syntax across all manifest directories
- Scans for `LOCAL_DEV_MODE=true` in production-targeted manifests:
  - **Production namespaces**: Blocked (fails CI)
  - **Staging namespaces**: Warned only (allows deployment but logged for review)
- Verifies Rego policy sync between ConstraintTemplate and test file
- Runs OPA policy tests as part of CI

### Test Suite (`deployments/k8s/policies/tests/`)
- 45 OPA policy unit tests covering:
  - Namespace detection (production vs non-production)
  - ConfigMap data field checking
  - Container type coverage (containers, initContainers, ephemeralContainers)
  - Workload type coverage (Pod, Deployment, StatefulSet, DaemonSet, Job, CronJob)
  - Value handling (true/false, case variations)
  - Multiple violations in same workload
  - Violation message formatting

## Environment Behavior

| Environment | Behavior |
|-------------|----------|
| `prod*`, `*production*` | **Blocked** - OPA Gatekeeper denies admission, CI fails |
| `staging`, `meridian-staging` | **Warned** - CI logs warning, deployment allowed |
| `dev`, `default`, etc. | **Allowed** - No restrictions |

## Test Plan

- [x] OPA policy tests pass locally (45 tests)
- [x] Policy correctly blocks `LOCAL_DEV_MODE=true` in production namespaces
- [x] Policy allows `LOCAL_DEV_MODE=true` in development namespaces
- [x] CI workflow validates manifests and detects violations
- [x] Rego sync check ensures ConstraintTemplate and test file stay in sync
- [ ] Integration test with Gatekeeper in test cluster

## Task

Task: 8-multi-tenancy.93

Related to GitHub Issue #8 (Multi-Tenancy Support)