### PR TITLE
feat(tenant): Implement production alerting integration

### DIFF
--- a/services/tenant/clients/pagerduty_client.go
+++ b/services/tenant/clients/pagerduty_client.go
@@ -1,0 +1,236 @@
+// Package clients provides HTTP and gRPC client wrappers for external service communication.
+package clients
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/meridianhub/meridian/services/tenant/config"
+)
+
+// PagerDuty Events API v2 endpoint.
+const pagerDutyEventsURL = "https://events.pagerduty.com/v2/enqueue"
+
+// PagerDuty event actions.
+const (
+	// EventActionTrigger creates a new incident or adds to an existing one.
+	EventActionTrigger = "trigger"
+	// EventActionAcknowledge acknowledges an existing incident.
+	EventActionAcknowledge = "acknowledge"
+	// EventActionResolve resolves an existing incident.
+	EventActionResolve = "resolve"
+)
+
+// Severity levels for PagerDuty alerts.
+type Severity string
+
+const (
+	// SeverityCritical indicates an urgent issue requiring immediate attention.
+	SeverityCritical Severity = "critical"
+	// SeverityWarning indicates a potential issue that should be investigated.
+	SeverityWarning Severity = "warning"
+	// SeverityInfo indicates an informational alert.
+	SeverityInfo Severity = "info"
+	// SeverityError indicates an error condition (maps to PagerDuty "error" severity).
+	SeverityError Severity = "error"
+)
+
+// PagerDuty client errors.
+var (
+	// ErrPagerDutyNotConfigured is returned when attempting to use PagerDuty without configuration.
+	ErrPagerDutyNotConfigured = errors.New("PagerDuty client not configured")
+	// ErrPagerDutyAPIError is returned when the PagerDuty API returns an error.
+	ErrPagerDutyAPIError = errors.New("PagerDuty API error")
+	// ErrPagerDutyRateLimited is returned when rate limited by PagerDuty.
+	ErrPagerDutyRateLimited = errors.New("PagerDuty rate limited")
+	// ErrPagerDutyInvalidRequest is returned when the request is malformed.
+	ErrPagerDutyInvalidRequest = errors.New("PagerDuty invalid request")
+)
+
+// PagerDutyEvent represents the Events API v2 request payload.
+type PagerDutyEvent struct {
+	RoutingKey  string                `json:"routing_key"`
+	EventAction string                `json:"event_action"`
+	DedupKey    string                `json:"dedup_key,omitempty"`
+	Payload     PagerDutyEventPayload `json:"payload"`
+}
+
+// PagerDutyEventPayload contains the alert details.
+type PagerDutyEventPayload struct {
+	Summary       string         `json:"summary"`
+	Severity      string         `json:"severity"`
+	Source        string         `json:"source"`
+	Timestamp     string         `json:"timestamp,omitempty"`
+	Component     string         `json:"component,omitempty"`
+	Group         string         `json:"group,omitempty"`
+	Class         string         `json:"class,omitempty"`
+	CustomDetails map[string]any `json:"custom_details,omitempty"`
+}
+
+// PagerDutyResponse represents the Events API v2 response.
+type PagerDutyResponse struct {
+	Status   string `json:"status"`
+	Message  string `json:"message"`
+	DedupKey string `json:"dedup_key,omitempty"`
+}
+
+// PagerDutyClient sends alerts to PagerDuty using Events API v2.
+type PagerDutyClient struct {
+	config     config.PagerDutyConfig
+	httpClient *http.Client
+	eventsURL  string // Allow override for testing
+}
+
+// PagerDutyClientOption configures the PagerDuty client.
+type PagerDutyClientOption func(*PagerDutyClient)
+
+// WithHTTPClient sets a custom HTTP client for the PagerDuty client.
+func WithHTTPClient(client *http.Client) PagerDutyClientOption {
+	return func(c *PagerDutyClient) {
+		c.httpClient = client
+	}
+}
+
+// WithEventsURL sets a custom events URL for testing.
+func WithEventsURL(url string) PagerDutyClientOption {
+	return func(c *PagerDutyClient) {
+		c.eventsURL = url
+	}
+}
+
+// NewPagerDutyClient creates a new PagerDuty client.
+// Returns nil if PagerDuty is not enabled in the configuration.
+func NewPagerDutyClient(cfg config.PagerDutyConfig, opts ...PagerDutyClientOption) *PagerDutyClient {
+	if !cfg.Enabled {
+		return nil
+	}
+
+	client := &PagerDutyClient{
+		config: cfg,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		eventsURL: pagerDutyEventsURL,
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	return client
+}
+
+// TriggerAlert sends a trigger event to PagerDuty.
+// The dedupKey is used for deduplication - alerts with the same key are grouped.
+func (c *PagerDutyClient) TriggerAlert(ctx context.Context, summary, dedupKey string, severity Severity, customDetails map[string]any) error {
+	if c == nil {
+		return ErrPagerDutyNotConfigured
+	}
+
+	event := PagerDutyEvent{
+		RoutingKey:  c.config.RoutingKey,
+		EventAction: EventActionTrigger,
+		DedupKey:    dedupKey,
+		Payload: PagerDutyEventPayload{
+			Summary:       summary,
+			Severity:      string(severity),
+			Source:        c.config.Source,
+			Timestamp:     time.Now().UTC().Format(time.RFC3339),
+			CustomDetails: customDetails,
+		},
+	}
+
+	return c.sendEvent(ctx, event)
+}
+
+// ResolveAlert sends a resolve event to PagerDuty.
+// The dedupKey must match the original trigger event to resolve the correct incident.
+func (c *PagerDutyClient) ResolveAlert(ctx context.Context, dedupKey string) error {
+	if c == nil {
+		return ErrPagerDutyNotConfigured
+	}
+
+	event := PagerDutyEvent{
+		RoutingKey:  c.config.RoutingKey,
+		EventAction: EventActionResolve,
+		DedupKey:    dedupKey,
+	}
+
+	return c.sendEvent(ctx, event)
+}
+
+// sendEvent sends an event to the PagerDuty Events API.
+func (c *PagerDutyClient) sendEvent(ctx context.Context, event PagerDutyEvent) error {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal PagerDuty event: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.eventsURL, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("failed to create PagerDuty request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send PagerDuty event: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read PagerDuty response: %w", err)
+	}
+
+	// Parse response
+	var pdResp PagerDutyResponse
+	if err := json.Unmarshal(body, &pdResp); err != nil {
+		// Include raw body in error for debugging
+		return fmt.Errorf("%w: status %d, body: %s", ErrPagerDutyAPIError, resp.StatusCode, string(body))
+	}
+
+	// Handle response status codes
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusAccepted:
+		// Success
+		return nil
+	case http.StatusBadRequest:
+		return fmt.Errorf("%w: %s", ErrPagerDutyInvalidRequest, pdResp.Message)
+	case http.StatusTooManyRequests:
+		return ErrPagerDutyRateLimited
+	default:
+		return fmt.Errorf("%w: status %d, message: %s", ErrPagerDutyAPIError, resp.StatusCode, pdResp.Message)
+	}
+}
+
+// MapAlertSeverity converts an alert severity string to PagerDuty severity.
+// Supports: CRITICAL, WARNING, INFO (case-insensitive).
+// Unknown severities default to "warning".
+func MapAlertSeverity(severity string) Severity {
+	switch strings.ToUpper(severity) {
+	case "CRITICAL":
+		return SeverityCritical
+	case "WARNING":
+		return SeverityWarning
+	case "INFO":
+		return SeverityInfo
+	case "ERROR":
+		return SeverityError
+	default:
+		return SeverityWarning
+	}
+}
+
+// IsEnabled returns true if the PagerDuty client is configured and enabled.
+func (c *PagerDutyClient) IsEnabled() bool {
+	return c != nil && c.config.Enabled
+}

--- a/services/tenant/clients/pagerduty_client_test.go
+++ b/services/tenant/clients/pagerduty_client_test.go
@@ -1,0 +1,402 @@
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/tenant/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapAlertSeverity(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected Severity
+	}{
+		{"critical uppercase", "CRITICAL", SeverityCritical},
+		{"critical lowercase", "critical", SeverityCritical},
+		{"critical mixed case", "Critical", SeverityCritical},
+		{"warning uppercase", "WARNING", SeverityWarning},
+		{"warning lowercase", "warning", SeverityWarning},
+		{"info uppercase", "INFO", SeverityInfo},
+		{"info lowercase", "info", SeverityInfo},
+		{"error uppercase", "ERROR", SeverityError},
+		{"error lowercase", "error", SeverityError},
+		{"unknown defaults to warning", "unknown", SeverityWarning},
+		{"empty defaults to warning", "", SeverityWarning},
+		{"random string defaults to warning", "foobar", SeverityWarning},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MapAlertSeverity(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewPagerDutyClient_Disabled(t *testing.T) {
+	cfg := config.PagerDutyConfig{
+		Enabled:    false,
+		RoutingKey: "test-key",
+		Source:     "test-source",
+	}
+
+	client := NewPagerDutyClient(cfg)
+
+	assert.Nil(t, client, "client should be nil when PagerDuty is disabled")
+}
+
+func TestNewPagerDutyClient_Enabled(t *testing.T) {
+	cfg := config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "test-routing-key",
+		Source:     "test-source",
+	}
+
+	client := NewPagerDutyClient(cfg)
+
+	require.NotNil(t, client)
+	assert.True(t, client.IsEnabled())
+	assert.Equal(t, cfg.RoutingKey, client.config.RoutingKey)
+	assert.Equal(t, cfg.Source, client.config.Source)
+}
+
+func TestPagerDutyClient_IsEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		client   *PagerDutyClient
+		expected bool
+	}{
+		{
+			name:     "nil client",
+			client:   nil,
+			expected: false,
+		},
+		{
+			name: "disabled config",
+			client: &PagerDutyClient{
+				config: config.PagerDutyConfig{Enabled: false},
+			},
+			expected: false,
+		},
+		{
+			name: "enabled config",
+			client: &PagerDutyClient{
+				config: config.PagerDutyConfig{Enabled: true},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.client.IsEnabled()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestPagerDutyClient_TriggerAlert_NilClient(t *testing.T) {
+	var client *PagerDutyClient
+
+	err := client.TriggerAlert(context.Background(), "test summary", "test-key", SeverityCritical, nil)
+
+	assert.ErrorIs(t, err, ErrPagerDutyNotConfigured)
+}
+
+func TestPagerDutyClient_ResolveAlert_NilClient(t *testing.T) {
+	var client *PagerDutyClient
+
+	err := client.ResolveAlert(context.Background(), "test-key")
+
+	assert.ErrorIs(t, err, ErrPagerDutyNotConfigured)
+}
+
+func TestPagerDutyClient_TriggerAlert_Success(t *testing.T) {
+	// Create test server
+	var receivedEvent PagerDutyEvent
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify request
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		// Parse request body
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		err = json.Unmarshal(body, &receivedEvent)
+		require.NoError(t, err)
+
+		// Send success response
+		w.WriteHeader(http.StatusAccepted)
+		resp := PagerDutyResponse{
+			Status:   "success",
+			Message:  "Event processed",
+			DedupKey: receivedEvent.DedupKey,
+		}
+		respBody, _ := json.Marshal(resp)
+		w.Write(respBody)
+	}))
+	defer server.Close()
+
+	// Create client with test server
+	cfg := config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "test-routing-key",
+		Source:     "test-source",
+	}
+	client := NewPagerDutyClient(cfg, WithEventsURL(server.URL))
+
+	// Send alert
+	customDetails := map[string]any{
+		"tenant_id": "tenant-123",
+		"status":    "provisioning_failed",
+	}
+	err := client.TriggerAlert(context.Background(), "Test alert summary", "dedup-key-123", SeverityCritical, customDetails)
+
+	// Verify
+	require.NoError(t, err)
+	assert.Equal(t, "test-routing-key", receivedEvent.RoutingKey)
+	assert.Equal(t, EventActionTrigger, receivedEvent.EventAction)
+	assert.Equal(t, "dedup-key-123", receivedEvent.DedupKey)
+	assert.Equal(t, "Test alert summary", receivedEvent.Payload.Summary)
+	assert.Equal(t, "critical", receivedEvent.Payload.Severity)
+	assert.Equal(t, "test-source", receivedEvent.Payload.Source)
+	assert.NotEmpty(t, receivedEvent.Payload.Timestamp)
+	assert.Equal(t, "tenant-123", receivedEvent.Payload.CustomDetails["tenant_id"])
+	assert.Equal(t, "provisioning_failed", receivedEvent.Payload.CustomDetails["status"])
+}
+
+func TestPagerDutyClient_TriggerAlert_PayloadFormat(t *testing.T) {
+	// Create test server that captures the raw JSON
+	var rawPayload []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		rawPayload, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"status":"success","message":"Event processed"}`))
+	}))
+	defer server.Close()
+
+	// Create client
+	cfg := config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "routing-key-123",
+		Source:     "meridian-prod",
+	}
+	client := NewPagerDutyClient(cfg, WithEventsURL(server.URL))
+
+	// Send alert
+	err := client.TriggerAlert(context.Background(), "Summary text", "my-dedup-key", SeverityWarning, nil)
+	require.NoError(t, err)
+
+	// Verify JSON structure matches PagerDuty Events API v2 spec
+	var parsed map[string]any
+	err = json.Unmarshal(rawPayload, &parsed)
+	require.NoError(t, err)
+
+	// Required top-level fields
+	assert.Equal(t, "routing-key-123", parsed["routing_key"])
+	assert.Equal(t, "trigger", parsed["event_action"])
+	assert.Equal(t, "my-dedup-key", parsed["dedup_key"])
+
+	// Payload structure
+	payload, ok := parsed["payload"].(map[string]any)
+	require.True(t, ok, "payload should be an object")
+	assert.Equal(t, "Summary text", payload["summary"])
+	assert.Equal(t, "warning", payload["severity"])
+	assert.Equal(t, "meridian-prod", payload["source"])
+
+	// Timestamp should be RFC3339 formatted
+	timestamp, ok := payload["timestamp"].(string)
+	require.True(t, ok, "timestamp should be a string")
+	_, err = time.Parse(time.RFC3339, timestamp)
+	assert.NoError(t, err, "timestamp should be RFC3339 formatted")
+}
+
+func TestPagerDutyClient_ResolveAlert_Success(t *testing.T) {
+	var receivedEvent PagerDutyEvent
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		err = json.Unmarshal(body, &receivedEvent)
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"status":"success","message":"Event processed"}`))
+	}))
+	defer server.Close()
+
+	cfg := config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "test-routing-key",
+		Source:     "test-source",
+	}
+	client := NewPagerDutyClient(cfg, WithEventsURL(server.URL))
+
+	err := client.ResolveAlert(context.Background(), "resolve-dedup-key")
+
+	require.NoError(t, err)
+	assert.Equal(t, EventActionResolve, receivedEvent.EventAction)
+	assert.Equal(t, "resolve-dedup-key", receivedEvent.DedupKey)
+	assert.Equal(t, "test-routing-key", receivedEvent.RoutingKey)
+}
+
+func TestPagerDutyClient_TriggerAlert_BadRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"status":"invalid event","message":"Missing routing_key"}`))
+	}))
+	defer server.Close()
+
+	cfg := config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "",
+		Source:     "test-source",
+	}
+	client := NewPagerDutyClient(cfg, WithEventsURL(server.URL))
+
+	err := client.TriggerAlert(context.Background(), "Test", "key", SeverityCritical, nil)
+
+	assert.ErrorIs(t, err, ErrPagerDutyInvalidRequest)
+	assert.Contains(t, err.Error(), "Missing routing_key")
+}
+
+func TestPagerDutyClient_TriggerAlert_RateLimited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"status":"rate limited","message":"Too many requests"}`))
+	}))
+	defer server.Close()
+
+	cfg := config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "test-key",
+		Source:     "test-source",
+	}
+	client := NewPagerDutyClient(cfg, WithEventsURL(server.URL))
+
+	err := client.TriggerAlert(context.Background(), "Test", "key", SeverityCritical, nil)
+
+	assert.ErrorIs(t, err, ErrPagerDutyRateLimited)
+}
+
+func TestPagerDutyClient_TriggerAlert_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"status":"error","message":"Internal server error"}`))
+	}))
+	defer server.Close()
+
+	cfg := config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "test-key",
+		Source:     "test-source",
+	}
+	client := NewPagerDutyClient(cfg, WithEventsURL(server.URL))
+
+	err := client.TriggerAlert(context.Background(), "Test", "key", SeverityCritical, nil)
+
+	assert.ErrorIs(t, err, ErrPagerDutyAPIError)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestPagerDutyClient_TriggerAlert_NetworkError(t *testing.T) {
+	cfg := config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "test-key",
+		Source:     "test-source",
+	}
+	// Use a URL that will fail to connect
+	client := NewPagerDutyClient(cfg, WithEventsURL("http://localhost:1"))
+
+	err := client.TriggerAlert(context.Background(), "Test", "key", SeverityCritical, nil)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to send PagerDuty event")
+}
+
+func TestPagerDutyClient_TriggerAlert_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Delay response to allow context cancellation
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	cfg := config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "test-key",
+		Source:     "test-source",
+	}
+	client := NewPagerDutyClient(cfg, WithEventsURL(server.URL))
+
+	// Create a context that's already cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := client.TriggerAlert(ctx, "Test", "key", SeverityCritical, nil)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "context canceled")
+}
+
+func TestPagerDutyClient_TriggerAlert_InvalidJSONResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`not valid json`))
+	}))
+	defer server.Close()
+
+	cfg := config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "test-key",
+		Source:     "test-source",
+	}
+	client := NewPagerDutyClient(cfg, WithEventsURL(server.URL))
+
+	err := client.TriggerAlert(context.Background(), "Test", "key", SeverityCritical, nil)
+
+	assert.ErrorIs(t, err, ErrPagerDutyAPIError)
+	assert.Contains(t, err.Error(), "not valid json")
+}
+
+func TestPagerDutyClient_WithCustomHTTPClient(t *testing.T) {
+	customClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	cfg := config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "test-key",
+		Source:     "test-source",
+	}
+	client := NewPagerDutyClient(cfg, WithHTTPClient(customClient))
+
+	require.NotNil(t, client)
+	assert.Equal(t, customClient, client.httpClient)
+}
+
+func TestPagerDutyClient_SeverityConstants(t *testing.T) {
+	// Verify severity constants match PagerDuty API values
+	assert.Equal(t, Severity("critical"), SeverityCritical)
+	assert.Equal(t, Severity("warning"), SeverityWarning)
+	assert.Equal(t, Severity("info"), SeverityInfo)
+	assert.Equal(t, Severity("error"), SeverityError)
+}
+
+func TestPagerDutyClient_EventActionConstants(t *testing.T) {
+	// Verify event action constants match PagerDuty API values
+	assert.Equal(t, "trigger", EventActionTrigger)
+	assert.Equal(t, "acknowledge", EventActionAcknowledge)
+	assert.Equal(t, "resolve", EventActionResolve)
+}

--- a/services/tenant/clients/pagerduty_client_test.go
+++ b/services/tenant/clients/pagerduty_client_test.go
@@ -351,7 +351,7 @@ func TestPagerDutyClient_TriggerAlert_ContextCancellation(t *testing.T) {
 }
 
 func TestPagerDutyClient_TriggerAlert_InvalidJSONResponse(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte(`not valid json`))
 	}))

--- a/services/tenant/config/alerting.go
+++ b/services/tenant/config/alerting.go
@@ -1,0 +1,118 @@
+// Package config provides configuration types for the Tenant service.
+package config
+
+import (
+	"errors"
+	"net/url"
+	"os"
+)
+
+// AlertingConfig holds configuration for the alerting subsystem.
+type AlertingConfig struct {
+	// PagerDuty configures PagerDuty integration for critical alerts.
+	PagerDuty PagerDutyConfig
+
+	// Slack configures Slack incoming webhook integration for team notifications.
+	Slack SlackConfig
+}
+
+// PagerDutyConfig holds configuration for PagerDuty Events API v2 integration.
+type PagerDutyConfig struct {
+	// Enabled indicates whether PagerDuty alerting is active.
+	// When false, alerts are logged but not sent to PagerDuty.
+	Enabled bool
+
+	// RoutingKey is the integration key (routing key) from PagerDuty.
+	// This determines which PagerDuty service receives the events.
+	// Required when Enabled is true.
+	RoutingKey string
+
+	// Source identifies the origin of alerts (e.g., "tenant-service", "meridian-prod").
+	// Defaults to "tenant-service" if not set.
+	Source string
+}
+
+// SlackConfig holds configuration for Slack incoming webhook integration.
+type SlackConfig struct {
+	// Enabled indicates whether Slack alerting is active.
+	// When false, alerts are logged but not sent to Slack.
+	Enabled bool
+
+	// WebhookURL is the Slack incoming webhook URL.
+	// Required when Enabled is true.
+	WebhookURL string
+
+	// ServiceName identifies the origin of alerts (e.g., "tenant-service").
+	// Defaults to "tenant-service" if not set.
+	ServiceName string
+}
+
+// Configuration errors.
+var (
+	// ErrPagerDutyRoutingKeyRequired is returned when PagerDuty is enabled but no routing key is set.
+	ErrPagerDutyRoutingKeyRequired = errors.New("PAGERDUTY_ROUTING_KEY is required when PagerDuty alerting is enabled")
+
+	// ErrSlackWebhookURLRequired is returned when Slack is enabled but no webhook URL is set.
+	ErrSlackWebhookURLRequired = errors.New("SLACK_WEBHOOK_URL is required when Slack alerting is enabled")
+
+	// ErrSlackWebhookURLInvalid is returned when the Slack webhook URL is invalid.
+	ErrSlackWebhookURLInvalid = errors.New("SLACK_WEBHOOK_URL is not a valid URL")
+
+	// ErrSlackWebhookURLNotHTTPS is returned when the Slack webhook URL does not use HTTPS.
+	ErrSlackWebhookURLNotHTTPS = errors.New("SLACK_WEBHOOK_URL must use HTTPS")
+)
+
+// LoadAlertingConfig loads alerting configuration from environment variables.
+func LoadAlertingConfig() (*AlertingConfig, error) {
+	config := &AlertingConfig{
+		PagerDuty: PagerDutyConfig{
+			Enabled:    os.Getenv("PAGERDUTY_ENABLED") == "true",
+			RoutingKey: os.Getenv("PAGERDUTY_ROUTING_KEY"),
+			Source:     os.Getenv("PAGERDUTY_SOURCE"),
+		},
+		Slack: SlackConfig{
+			Enabled:     os.Getenv("SLACK_WEBHOOK_URL") != "",
+			WebhookURL:  os.Getenv("SLACK_WEBHOOK_URL"),
+			ServiceName: os.Getenv("SERVICE_NAME"),
+		},
+	}
+
+	// Set default source if not provided
+	if config.PagerDuty.Source == "" {
+		config.PagerDuty.Source = "tenant-service"
+	}
+
+	// Set default service name if not provided
+	if config.Slack.ServiceName == "" {
+		config.Slack.ServiceName = "tenant-service"
+	}
+
+	// Validate configuration
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+// Validate checks that the alerting configuration is valid.
+func (c *AlertingConfig) Validate() error {
+	if c.PagerDuty.Enabled && c.PagerDuty.RoutingKey == "" {
+		return ErrPagerDutyRoutingKeyRequired
+	}
+
+	if c.Slack.Enabled {
+		if c.Slack.WebhookURL == "" {
+			return ErrSlackWebhookURLRequired
+		}
+		parsed, err := url.Parse(c.Slack.WebhookURL)
+		if err != nil || parsed.Host == "" {
+			return ErrSlackWebhookURLInvalid
+		}
+		if parsed.Scheme != "https" {
+			return ErrSlackWebhookURLNotHTTPS
+		}
+	}
+
+	return nil
+}

--- a/services/tenant/config/alerting.go
+++ b/services/tenant/config/alerting.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"net/url"
 	"os"
+	"strconv"
+	"time"
 )
 
 // AlertingConfig holds configuration for the alerting subsystem.
@@ -14,6 +16,35 @@ type AlertingConfig struct {
 
 	// Slack configures Slack incoming webhook integration for team notifications.
 	Slack SlackConfig
+
+	// RateLimit configures rate limiting for alert delivery.
+	RateLimit AlertRateLimitConfig
+}
+
+// AlertRateLimitConfig holds configuration for alert rate limiting using token bucket algorithm.
+type AlertRateLimitConfig struct {
+	// MaxAlertsPerMinute is the maximum number of alerts per alert type per minute.
+	// Defaults to 10 if not set.
+	MaxAlertsPerMinute int
+
+	// BurstSize is the maximum number of alerts that can be sent in a burst.
+	// Defaults to MaxAlertsPerMinute if not set.
+	BurstSize int
+}
+
+// AlertRetryConfig holds configuration for alert retry logic.
+type AlertRetryConfig struct {
+	// MaxRetries is the maximum number of retry attempts.
+	// Defaults to 4 if not set.
+	MaxRetries int
+
+	// InitialBackoff is the initial backoff duration before first retry.
+	// Defaults to 1 second if not set.
+	InitialBackoff time.Duration
+
+	// MaxBackoff is the maximum backoff duration between retries.
+	// Defaults to 8 seconds if not set.
+	MaxBackoff time.Duration
 }
 
 // PagerDutyConfig holds configuration for PagerDuty Events API v2 integration.
@@ -62,6 +93,23 @@ var (
 	ErrSlackWebhookURLNotHTTPS = errors.New("SLACK_WEBHOOK_URL must use HTTPS")
 )
 
+// DefaultAlertRateLimitConfig returns the default rate limit configuration.
+func DefaultAlertRateLimitConfig() AlertRateLimitConfig {
+	return AlertRateLimitConfig{
+		MaxAlertsPerMinute: 10,
+		BurstSize:          10,
+	}
+}
+
+// DefaultAlertRetryConfig returns the default retry configuration.
+func DefaultAlertRetryConfig() AlertRetryConfig {
+	return AlertRetryConfig{
+		MaxRetries:     4,
+		InitialBackoff: 1 * time.Second,
+		MaxBackoff:     8 * time.Second,
+	}
+}
+
 // LoadAlertingConfig loads alerting configuration from environment variables.
 func LoadAlertingConfig() (*AlertingConfig, error) {
 	config := &AlertingConfig{
@@ -75,6 +123,7 @@ func LoadAlertingConfig() (*AlertingConfig, error) {
 			WebhookURL:  os.Getenv("SLACK_WEBHOOK_URL"),
 			ServiceName: os.Getenv("SERVICE_NAME"),
 		},
+		RateLimit: DefaultAlertRateLimitConfig(),
 	}
 
 	// Set default source if not provided
@@ -85,6 +134,15 @@ func LoadAlertingConfig() (*AlertingConfig, error) {
 	// Set default service name if not provided
 	if config.Slack.ServiceName == "" {
 		config.Slack.ServiceName = "tenant-service"
+	}
+
+	// Override rate limit from environment if set
+	if maxAlerts := os.Getenv("ALERT_RATE_LIMIT_PER_MINUTE"); maxAlerts != "" {
+		if n, err := strconv.Atoi(maxAlerts); err == nil && n > 0 {
+			config.RateLimit.MaxAlertsPerMinute = n
+			// Set burst size to match if not explicitly configured
+			config.RateLimit.BurstSize = n
+		}
 	}
 
 	// Validate configuration

--- a/services/tenant/config/alerting.go
+++ b/services/tenant/config/alerting.go
@@ -10,6 +10,19 @@ import (
 )
 
 // AlertingConfig holds configuration for the alerting subsystem.
+//
+// Environment Variables:
+//
+//	PAGERDUTY_ENABLED        - Set to "true" to enable PagerDuty alerting
+//	PAGERDUTY_ROUTING_KEY    - PagerDuty integration/routing key (required if enabled)
+//	PAGERDUTY_SOURCE         - Alert source identifier (default: "tenant-service")
+//	SLACK_WEBHOOK_URL        - Slack incoming webhook URL (presence enables Slack alerts)
+//	SERVICE_NAME             - Service name for Slack alerts (default: "tenant-service")
+//	ALERT_RATE_LIMIT_PER_MINUTE - Max alerts per type per minute (default: 10)
+//	ALERT_DLQ_MAX_SIZE       - Max entries in dead-letter queue (default: 1000)
+//	ALERT_RETRY_MAX_RETRIES  - Max retry attempts (default: 4)
+//	ALERT_RETRY_INITIAL_BACKOFF - Initial retry backoff in seconds (default: 1)
+//	ALERT_RETRY_MAX_BACKOFF  - Max retry backoff in seconds (default: 8)
 type AlertingConfig struct {
 	// PagerDuty configures PagerDuty integration for critical alerts.
 	PagerDuty PagerDutyConfig
@@ -19,6 +32,12 @@ type AlertingConfig struct {
 
 	// RateLimit configures rate limiting for alert delivery.
 	RateLimit AlertRateLimitConfig
+
+	// Retry configures retry behavior for failed alerts.
+	Retry AlertRetryConfig
+
+	// DLQ configures the dead-letter queue for failed alerts.
+	DLQ AlertDLQConfig
 }
 
 // AlertRateLimitConfig holds configuration for alert rate limiting using token bucket algorithm.
@@ -45,6 +64,19 @@ type AlertRetryConfig struct {
 	// MaxBackoff is the maximum backoff duration between retries.
 	// Defaults to 8 seconds if not set.
 	MaxBackoff time.Duration
+}
+
+// AlertDLQConfig holds configuration for the alert dead-letter queue.
+type AlertDLQConfig struct {
+	// Enabled indicates whether the dead-letter queue is active.
+	// When true, failed alerts are stored for manual review.
+	// Defaults to true.
+	Enabled bool
+
+	// MaxSize is the maximum number of entries in the dead-letter queue.
+	// When exceeded, oldest entries are removed.
+	// Defaults to 1000.
+	MaxSize int
 }
 
 // PagerDutyConfig holds configuration for PagerDuty Events API v2 integration.
@@ -110,47 +142,99 @@ func DefaultAlertRetryConfig() AlertRetryConfig {
 	}
 }
 
+// DefaultAlertDLQConfig returns the default dead-letter queue configuration.
+func DefaultAlertDLQConfig() AlertDLQConfig {
+	return AlertDLQConfig{
+		Enabled: true,
+		MaxSize: 1000,
+	}
+}
+
+// getEnvInt parses an environment variable as an integer.
+// Returns the default value if the variable is empty or invalid.
+func getEnvInt(key string, defaultVal int, minVal int) int {
+	val := os.Getenv(key)
+	if val == "" {
+		return defaultVal
+	}
+	n, err := strconv.Atoi(val)
+	if err != nil || n < minVal {
+		return defaultVal
+	}
+	return n
+}
+
 // LoadAlertingConfig loads alerting configuration from environment variables.
 func LoadAlertingConfig() (*AlertingConfig, error) {
 	config := &AlertingConfig{
-		PagerDuty: PagerDutyConfig{
-			Enabled:    os.Getenv("PAGERDUTY_ENABLED") == "true",
-			RoutingKey: os.Getenv("PAGERDUTY_ROUTING_KEY"),
-			Source:     os.Getenv("PAGERDUTY_SOURCE"),
-		},
-		Slack: SlackConfig{
-			Enabled:     os.Getenv("SLACK_WEBHOOK_URL") != "",
-			WebhookURL:  os.Getenv("SLACK_WEBHOOK_URL"),
-			ServiceName: os.Getenv("SERVICE_NAME"),
-		},
-		RateLimit: DefaultAlertRateLimitConfig(),
+		PagerDuty: loadPagerDutyConfig(),
+		Slack:     loadSlackConfig(),
+		RateLimit: loadRateLimitConfig(),
+		Retry:     loadRetryConfig(),
+		DLQ:       loadDLQConfig(),
 	}
 
-	// Set default source if not provided
-	if config.PagerDuty.Source == "" {
-		config.PagerDuty.Source = "tenant-service"
-	}
-
-	// Set default service name if not provided
-	if config.Slack.ServiceName == "" {
-		config.Slack.ServiceName = "tenant-service"
-	}
-
-	// Override rate limit from environment if set
-	if maxAlerts := os.Getenv("ALERT_RATE_LIMIT_PER_MINUTE"); maxAlerts != "" {
-		if n, err := strconv.Atoi(maxAlerts); err == nil && n > 0 {
-			config.RateLimit.MaxAlertsPerMinute = n
-			// Set burst size to match if not explicitly configured
-			config.RateLimit.BurstSize = n
-		}
-	}
-
-	// Validate configuration
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
 
 	return config, nil
+}
+
+// loadPagerDutyConfig loads PagerDuty configuration from environment variables.
+func loadPagerDutyConfig() PagerDutyConfig {
+	source := os.Getenv("PAGERDUTY_SOURCE")
+	if source == "" {
+		source = "tenant-service"
+	}
+	return PagerDutyConfig{
+		Enabled:    os.Getenv("PAGERDUTY_ENABLED") == "true",
+		RoutingKey: os.Getenv("PAGERDUTY_ROUTING_KEY"),
+		Source:     source,
+	}
+}
+
+// loadSlackConfig loads Slack configuration from environment variables.
+func loadSlackConfig() SlackConfig {
+	serviceName := os.Getenv("SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = "tenant-service"
+	}
+	webhookURL := os.Getenv("SLACK_WEBHOOK_URL")
+	return SlackConfig{
+		Enabled:     webhookURL != "",
+		WebhookURL:  webhookURL,
+		ServiceName: serviceName,
+	}
+}
+
+// loadRateLimitConfig loads rate limit configuration from environment variables.
+func loadRateLimitConfig() AlertRateLimitConfig {
+	cfg := DefaultAlertRateLimitConfig()
+	maxAlerts := getEnvInt("ALERT_RATE_LIMIT_PER_MINUTE", cfg.MaxAlertsPerMinute, 1)
+	cfg.MaxAlertsPerMinute = maxAlerts
+	cfg.BurstSize = maxAlerts
+	return cfg
+}
+
+// loadRetryConfig loads retry configuration from environment variables.
+func loadRetryConfig() AlertRetryConfig {
+	cfg := DefaultAlertRetryConfig()
+	cfg.MaxRetries = getEnvInt("ALERT_RETRY_MAX_RETRIES", cfg.MaxRetries, 0)
+	if initialSec := getEnvInt("ALERT_RETRY_INITIAL_BACKOFF", 0, 1); initialSec > 0 {
+		cfg.InitialBackoff = time.Duration(initialSec) * time.Second
+	}
+	if maxSec := getEnvInt("ALERT_RETRY_MAX_BACKOFF", 0, 1); maxSec > 0 {
+		cfg.MaxBackoff = time.Duration(maxSec) * time.Second
+	}
+	return cfg
+}
+
+// loadDLQConfig loads dead-letter queue configuration from environment variables.
+func loadDLQConfig() AlertDLQConfig {
+	cfg := DefaultAlertDLQConfig()
+	cfg.MaxSize = getEnvInt("ALERT_DLQ_MAX_SIZE", cfg.MaxSize, 1)
+	return cfg
 }
 
 // Validate checks that the alerting configuration is valid.

--- a/services/tenant/config/alerting_test.go
+++ b/services/tenant/config/alerting_test.go
@@ -1,0 +1,243 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPagerDutyConfig_Validate_Enabled(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    AlertingConfig
+		wantErr   error
+		errSubstr string
+	}{
+		{
+			name: "valid enabled config",
+			config: AlertingConfig{
+				PagerDuty: PagerDutyConfig{
+					Enabled:    true,
+					RoutingKey: "valid-routing-key",
+					Source:     "test-source",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "enabled without routing key",
+			config: AlertingConfig{
+				PagerDuty: PagerDutyConfig{
+					Enabled:    true,
+					RoutingKey: "",
+					Source:     "test-source",
+				},
+			},
+			wantErr: ErrPagerDutyRoutingKeyRequired,
+		},
+		{
+			name: "disabled without routing key is valid",
+			config: AlertingConfig{
+				PagerDuty: PagerDutyConfig{
+					Enabled:    false,
+					RoutingKey: "",
+					Source:     "",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "disabled with routing key is valid",
+			config: AlertingConfig{
+				PagerDuty: PagerDutyConfig{
+					Enabled:    false,
+					RoutingKey: "some-key",
+					Source:     "some-source",
+				},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSlackConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  AlertingConfig
+		wantErr error
+	}{
+		{
+			name: "valid enabled config",
+			config: AlertingConfig{
+				Slack: SlackConfig{
+					Enabled:     true,
+					WebhookURL:  "https://hooks.slack.com/services/T00/B00/XXX",
+					ServiceName: "test-service",
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "enabled without webhook URL",
+			config: AlertingConfig{
+				Slack: SlackConfig{
+					Enabled:     true,
+					WebhookURL:  "",
+					ServiceName: "test-service",
+				},
+			},
+			wantErr: ErrSlackWebhookURLRequired,
+		},
+		{
+			name: "enabled with invalid URL",
+			config: AlertingConfig{
+				Slack: SlackConfig{
+					Enabled:     true,
+					WebhookURL:  "not-a-url",
+					ServiceName: "test-service",
+				},
+			},
+			wantErr: ErrSlackWebhookURLInvalid,
+		},
+		{
+			name: "enabled with HTTP URL",
+			config: AlertingConfig{
+				Slack: SlackConfig{
+					Enabled:     true,
+					WebhookURL:  "http://hooks.slack.com/services/T00/B00/XXX",
+					ServiceName: "test-service",
+				},
+			},
+			wantErr: ErrSlackWebhookURLNotHTTPS,
+		},
+		{
+			name: "disabled without webhook URL is valid",
+			config: AlertingConfig{
+				Slack: SlackConfig{
+					Enabled:     false,
+					WebhookURL:  "",
+					ServiceName: "",
+				},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestLoadAlertingConfig_Defaults(t *testing.T) {
+	// Clear environment
+	os.Unsetenv("PAGERDUTY_ENABLED")
+	os.Unsetenv("PAGERDUTY_ROUTING_KEY")
+	os.Unsetenv("PAGERDUTY_SOURCE")
+	os.Unsetenv("SLACK_WEBHOOK_URL")
+	os.Unsetenv("SERVICE_NAME")
+
+	config, err := LoadAlertingConfig()
+
+	require.NoError(t, err)
+	assert.False(t, config.PagerDuty.Enabled)
+	assert.Empty(t, config.PagerDuty.RoutingKey)
+	assert.Equal(t, "tenant-service", config.PagerDuty.Source) // Default
+	assert.False(t, config.Slack.Enabled)
+	assert.Empty(t, config.Slack.WebhookURL)
+	assert.Equal(t, "tenant-service", config.Slack.ServiceName) // Default
+}
+
+func TestLoadAlertingConfig_PagerDutyEnabled(t *testing.T) {
+	// Set environment
+	os.Setenv("PAGERDUTY_ENABLED", "true")
+	os.Setenv("PAGERDUTY_ROUTING_KEY", "my-routing-key")
+	os.Setenv("PAGERDUTY_SOURCE", "custom-source")
+	defer func() {
+		os.Unsetenv("PAGERDUTY_ENABLED")
+		os.Unsetenv("PAGERDUTY_ROUTING_KEY")
+		os.Unsetenv("PAGERDUTY_SOURCE")
+	}()
+
+	config, err := LoadAlertingConfig()
+
+	require.NoError(t, err)
+	assert.True(t, config.PagerDuty.Enabled)
+	assert.Equal(t, "my-routing-key", config.PagerDuty.RoutingKey)
+	assert.Equal(t, "custom-source", config.PagerDuty.Source)
+}
+
+func TestLoadAlertingConfig_PagerDutyEnabledMissingKey(t *testing.T) {
+	// Set environment
+	os.Setenv("PAGERDUTY_ENABLED", "true")
+	os.Unsetenv("PAGERDUTY_ROUTING_KEY")
+	defer func() {
+		os.Unsetenv("PAGERDUTY_ENABLED")
+	}()
+
+	_, err := LoadAlertingConfig()
+
+	assert.ErrorIs(t, err, ErrPagerDutyRoutingKeyRequired)
+}
+
+func TestLoadAlertingConfig_SlackEnabled(t *testing.T) {
+	// Set environment
+	os.Setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/services/T00/B00/XXX")
+	os.Setenv("SERVICE_NAME", "custom-service")
+	defer func() {
+		os.Unsetenv("SLACK_WEBHOOK_URL")
+		os.Unsetenv("SERVICE_NAME")
+	}()
+
+	config, err := LoadAlertingConfig()
+
+	require.NoError(t, err)
+	assert.True(t, config.Slack.Enabled)
+	assert.Equal(t, "https://hooks.slack.com/services/T00/B00/XXX", config.Slack.WebhookURL)
+	assert.Equal(t, "custom-service", config.Slack.ServiceName)
+}
+
+func TestLoadAlertingConfig_BothEnabled(t *testing.T) {
+	// Set environment
+	os.Setenv("PAGERDUTY_ENABLED", "true")
+	os.Setenv("PAGERDUTY_ROUTING_KEY", "pd-routing-key")
+	os.Setenv("PAGERDUTY_SOURCE", "pd-source")
+	os.Setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/services/T00/B00/XXX")
+	os.Setenv("SERVICE_NAME", "my-service")
+	defer func() {
+		os.Unsetenv("PAGERDUTY_ENABLED")
+		os.Unsetenv("PAGERDUTY_ROUTING_KEY")
+		os.Unsetenv("PAGERDUTY_SOURCE")
+		os.Unsetenv("SLACK_WEBHOOK_URL")
+		os.Unsetenv("SERVICE_NAME")
+	}()
+
+	config, err := LoadAlertingConfig()
+
+	require.NoError(t, err)
+	assert.True(t, config.PagerDuty.Enabled)
+	assert.Equal(t, "pd-routing-key", config.PagerDuty.RoutingKey)
+	assert.Equal(t, "pd-source", config.PagerDuty.Source)
+	assert.True(t, config.Slack.Enabled)
+	assert.Equal(t, "https://hooks.slack.com/services/T00/B00/XXX", config.Slack.WebhookURL)
+	assert.Equal(t, "my-service", config.Slack.ServiceName)
+}

--- a/services/tenant/notifier/slack.go
+++ b/services/tenant/notifier/slack.go
@@ -1,0 +1,294 @@
+// Package notifier provides alerting integrations for external notification systems.
+package notifier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/tenant/config"
+	"github.com/meridianhub/meridian/services/tenant/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Severity represents the severity level of an alert.
+type Severity string
+
+// Alert severity levels.
+const (
+	SeverityCritical Severity = "critical"
+	SeverityWarning  Severity = "warning"
+	SeverityInfo     Severity = "info"
+)
+
+// Slack notifier errors.
+var (
+	// ErrSlackWebhookFailed is returned when the Slack webhook request fails.
+	ErrSlackWebhookFailed = errors.New("slack webhook request failed")
+
+	// ErrSlackResponseError is returned when Slack returns an error response.
+	ErrSlackResponseError = errors.New("slack returned error response")
+)
+
+// SlackNotifier sends alert notifications to Slack via incoming webhooks.
+type SlackNotifier struct {
+	webhookURL  string
+	serviceName string
+	httpClient  *http.Client
+	logger      *slog.Logger
+}
+
+// SlackNotifierConfig contains configuration for creating a SlackNotifier.
+type SlackNotifierConfig struct {
+	// Config is the Slack configuration.
+	Config config.SlackConfig
+
+	// HTTPClient is an optional HTTP client (defaults to http.DefaultClient with timeout).
+	HTTPClient *http.Client
+
+	// Logger is an optional logger (defaults to slog.Default()).
+	Logger *slog.Logger
+}
+
+// NewSlackNotifier creates a new SlackNotifier.
+// Returns nil if Slack notifications are disabled.
+func NewSlackNotifier(cfg SlackNotifierConfig) *SlackNotifier {
+	if !cfg.Config.Enabled {
+		return nil
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{
+			Timeout: 10 * time.Second,
+		}
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &SlackNotifier{
+		webhookURL:  cfg.Config.WebhookURL,
+		serviceName: cfg.Config.ServiceName,
+		httpClient:  httpClient,
+		logger:      logger,
+	}
+}
+
+// Alert represents an alert to be sent to Slack.
+type Alert struct {
+	// TenantID is the ID of the affected tenant.
+	TenantID tenant.TenantID
+
+	// Severity is the alert severity (critical, warning, info).
+	Severity Severity
+
+	// Title is the alert title/summary.
+	Title string
+
+	// Message is the detailed alert message.
+	Message string
+
+	// Timestamp is when the alert was triggered.
+	Timestamp time.Time
+
+	// Metadata contains additional context fields.
+	Metadata map[string]string
+}
+
+// SendAlert sends an alert notification to Slack.
+func (s *SlackNotifier) SendAlert(ctx context.Context, alert Alert) error {
+	alertID := uuid.New().String()
+
+	// Build the Slack message payload
+	payload := s.buildPayload(alert, alertID)
+
+	// Marshal to JSON
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal slack payload: %w", err)
+	}
+
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to create slack request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	// Send request
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		s.logger.Error("slack webhook request failed",
+			"error", err,
+			"alert_id", alertID,
+			"tenant_id", alert.TenantID)
+		return fmt.Errorf("%w: %w", ErrSlackWebhookFailed, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Check response status
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		s.logger.Error("slack webhook returned error",
+			"status_code", resp.StatusCode,
+			"response", string(respBody),
+			"alert_id", alertID,
+			"tenant_id", alert.TenantID)
+		return fmt.Errorf("%w: status %d", ErrSlackResponseError, resp.StatusCode)
+	}
+
+	s.logger.Info("slack alert sent successfully",
+		"alert_id", alertID,
+		"tenant_id", alert.TenantID,
+		"severity", alert.Severity)
+
+	return nil
+}
+
+// NotifyProvisioningFailure sends a notification for a tenant provisioning failure.
+func (s *SlackNotifier) NotifyProvisioningFailure(ctx context.Context, t *domain.Tenant) error {
+	alert := Alert{
+		TenantID:  t.ID,
+		Severity:  SeverityCritical,
+		Title:     "Tenant Provisioning Failed",
+		Message:   t.ErrorMessage,
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"display_name":     t.DisplayName,
+			"settlement_asset": t.SettlementAsset,
+			"status":           string(t.Status),
+		},
+	}
+
+	return s.SendAlert(ctx, alert)
+}
+
+// slackPayload represents the Slack incoming webhook JSON payload.
+type slackPayload struct {
+	Text   string       `json:"text"`
+	Blocks []slackBlock `json:"blocks"`
+}
+
+// slackBlock represents a Slack block element.
+type slackBlock struct {
+	Type   string         `json:"type"`
+	Text   *slackTextObj  `json:"text,omitempty"`
+	Fields []slackTextObj `json:"fields,omitempty"`
+}
+
+// slackTextObj represents a Slack text object.
+type slackTextObj struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// severityEmoji returns the appropriate emoji for the given severity.
+func severityEmoji(severity Severity) string {
+	switch severity {
+	case SeverityCritical:
+		return "\U0001F534" // Red circle emoji
+	case SeverityWarning:
+		return "\u26A0\uFE0F" // Warning emoji
+	case SeverityInfo:
+		return "\u2139\uFE0F" // Info emoji
+	default:
+		return "\u2139\uFE0F" // Default to info emoji
+	}
+}
+
+// buildPayload constructs the Slack message payload with rich formatting.
+func (s *SlackNotifier) buildPayload(alert Alert, alertID string) slackPayload {
+	emoji := severityEmoji(alert.Severity)
+	headerText := fmt.Sprintf("%s *%s*", emoji, alert.Title)
+
+	// Build the message details
+	details := fmt.Sprintf(
+		"*Tenant ID:* `%s`\n*Service:* %s\n*Timestamp:* %s\n*Alert ID:* `%s`",
+		alert.TenantID,
+		s.serviceName,
+		alert.Timestamp.Format(time.RFC3339),
+		alertID,
+	)
+
+	if alert.Message != "" {
+		details += fmt.Sprintf("\n\n*Error:*\n```%s```", alert.Message)
+	}
+
+	// Add metadata fields if present
+	var metadataFields []slackTextObj
+	for key, value := range alert.Metadata {
+		if value != "" {
+			metadataFields = append(metadataFields, slackTextObj{
+				Type: "mrkdwn",
+				Text: fmt.Sprintf("*%s:* %s", key, value),
+			})
+		}
+	}
+
+	blocks := []slackBlock{
+		{
+			Type: "section",
+			Text: &slackTextObj{
+				Type: "mrkdwn",
+				Text: headerText,
+			},
+		},
+		{
+			Type: "section",
+			Text: &slackTextObj{
+				Type: "mrkdwn",
+				Text: details,
+			},
+		},
+	}
+
+	// Add metadata section if there are fields
+	if len(metadataFields) > 0 {
+		blocks = append(blocks, slackBlock{
+			Type:   "section",
+			Fields: metadataFields,
+		})
+	}
+
+	// Add divider at the end
+	blocks = append(blocks, slackBlock{
+		Type: "divider",
+	})
+
+	// Fallback text for notifications
+	fallbackText := fmt.Sprintf("%s %s - Tenant: %s", emoji, alert.Title, alert.TenantID)
+
+	return slackPayload{
+		Text:   fallbackText,
+		Blocks: blocks,
+	}
+}
+
+// formatProvisioningFailureMessage formats a tenant provisioning failure for Slack.
+// This is kept unexported since slackPayload is unexported.
+func formatProvisioningFailureMessage(t *domain.Tenant, serviceName string, alertID string, timestamp time.Time) slackPayload {
+	notifier := &SlackNotifier{serviceName: serviceName}
+	alert := Alert{
+		TenantID:  t.ID,
+		Severity:  SeverityCritical,
+		Title:     "Tenant Provisioning Failed",
+		Message:   t.ErrorMessage,
+		Timestamp: timestamp,
+		Metadata: map[string]string{
+			"display_name":     t.DisplayName,
+			"settlement_asset": t.SettlementAsset,
+			"status":           string(t.Status),
+		},
+	}
+	return notifier.buildPayload(alert, alertID)
+}

--- a/services/tenant/notifier/slack.go
+++ b/services/tenant/notifier/slack.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -66,8 +67,10 @@ func NewSlackNotifier(cfg SlackNotifierConfig) *SlackNotifier {
 
 	httpClient := cfg.HTTPClient
 	if httpClient == nil {
+		// Use 30s timeout to match PagerDuty client - external services may have
+		// variable latency, especially under load or during incidents.
 		httpClient = &http.Client{
-			Timeout: 10 * time.Second,
+			Timeout: 30 * time.Second,
 		}
 	}
 
@@ -224,14 +227,23 @@ func (s *SlackNotifier) buildPayload(alert Alert, alertID string) slackPayload {
 		details += fmt.Sprintf("\n\n*Error:*\n```%s```", alert.Message)
 	}
 
-	// Add metadata fields if present
+	// Add metadata fields if present, sorted by key for deterministic ordering
 	var metadataFields []slackTextObj
-	for key, value := range alert.Metadata {
-		if value != "" {
-			metadataFields = append(metadataFields, slackTextObj{
-				Type: "mrkdwn",
-				Text: fmt.Sprintf("*%s:* %s", key, value),
-			})
+	if len(alert.Metadata) > 0 {
+		keys := make([]string, 0, len(alert.Metadata))
+		for key := range alert.Metadata {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			value := alert.Metadata[key]
+			if value != "" {
+				metadataFields = append(metadataFields, slackTextObj{
+					Type: "mrkdwn",
+					Text: fmt.Sprintf("*%s:* %s", key, value),
+				})
+			}
 		}
 	}
 

--- a/services/tenant/notifier/slack_test.go
+++ b/services/tenant/notifier/slack_test.go
@@ -1,0 +1,455 @@
+package notifier
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/tenant/config"
+	"github.com/meridianhub/meridian/services/tenant/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSlackNotifier_Disabled(t *testing.T) {
+	cfg := SlackNotifierConfig{
+		Config: config.SlackConfig{
+			Enabled: false,
+		},
+	}
+
+	notifier := NewSlackNotifier(cfg)
+
+	assert.Nil(t, notifier, "should return nil when Slack is disabled")
+}
+
+func TestNewSlackNotifier_Enabled(t *testing.T) {
+	cfg := SlackNotifierConfig{
+		Config: config.SlackConfig{
+			Enabled:     true,
+			WebhookURL:  "https://hooks.slack.com/services/test",
+			ServiceName: "test-service",
+		},
+	}
+
+	notifier := NewSlackNotifier(cfg)
+
+	require.NotNil(t, notifier, "should return notifier when enabled")
+	assert.Equal(t, "https://hooks.slack.com/services/test", notifier.webhookURL)
+	assert.Equal(t, "test-service", notifier.serviceName)
+	assert.NotNil(t, notifier.httpClient)
+	assert.NotNil(t, notifier.logger)
+}
+
+func TestNewSlackNotifier_WithCustomHTTPClient(t *testing.T) {
+	customClient := &http.Client{Timeout: 30 * time.Second}
+	cfg := SlackNotifierConfig{
+		Config: config.SlackConfig{
+			Enabled:    true,
+			WebhookURL: "https://hooks.slack.com/services/test",
+		},
+		HTTPClient: customClient,
+	}
+
+	notifier := NewSlackNotifier(cfg)
+
+	require.NotNil(t, notifier)
+	assert.Equal(t, customClient, notifier.httpClient)
+}
+
+func TestNewSlackNotifier_WithCustomLogger(t *testing.T) {
+	var logBuf bytes.Buffer
+	customLogger := slog.New(slog.NewTextHandler(&logBuf, nil))
+	cfg := SlackNotifierConfig{
+		Config: config.SlackConfig{
+			Enabled:    true,
+			WebhookURL: "https://hooks.slack.com/services/test",
+		},
+		Logger: customLogger,
+	}
+
+	notifier := NewSlackNotifier(cfg)
+
+	require.NotNil(t, notifier)
+	assert.Equal(t, customLogger, notifier.logger)
+}
+
+func TestSeverityEmoji_Critical(t *testing.T) {
+	emoji := severityEmoji(SeverityCritical)
+	assert.Contains(t, emoji, "\U0001F534") // Red circle
+}
+
+func TestSeverityEmoji_Warning(t *testing.T) {
+	emoji := severityEmoji(SeverityWarning)
+	assert.Contains(t, emoji, "\u26A0") // Warning sign
+}
+
+func TestSeverityEmoji_Info(t *testing.T) {
+	emoji := severityEmoji(SeverityInfo)
+	assert.Contains(t, emoji, "\u2139") // Info sign
+}
+
+func TestSeverityEmoji_Unknown(t *testing.T) {
+	emoji := severityEmoji(Severity("unknown"))
+	assert.Contains(t, emoji, "\u2139") // Default to info
+}
+
+func TestBuildPayload_BasicStructure(t *testing.T) {
+	notifier := &SlackNotifier{serviceName: "test-service"}
+	alert := Alert{
+		TenantID:  tenant.TenantID("test-tenant-123"),
+		Severity:  SeverityCritical,
+		Title:     "Test Alert",
+		Message:   "This is a test error message",
+		Timestamp: time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC),
+		Metadata:  map[string]string{"key": "value"},
+	}
+
+	payload := notifier.buildPayload(alert, "alert-id-123")
+
+	// Check fallback text
+	assert.Contains(t, payload.Text, "Test Alert")
+	assert.Contains(t, payload.Text, "test-tenant-123")
+
+	// Check blocks structure
+	require.GreaterOrEqual(t, len(payload.Blocks), 3)
+
+	// First block should be header with emoji
+	headerBlock := payload.Blocks[0]
+	assert.Equal(t, "section", headerBlock.Type)
+	require.NotNil(t, headerBlock.Text)
+	assert.Equal(t, "mrkdwn", headerBlock.Text.Type)
+	assert.Contains(t, headerBlock.Text.Text, "Test Alert")
+	assert.Contains(t, headerBlock.Text.Text, "\U0001F534") // Red circle for critical
+
+	// Second block should be details
+	detailsBlock := payload.Blocks[1]
+	assert.Equal(t, "section", detailsBlock.Type)
+	require.NotNil(t, detailsBlock.Text)
+	assert.Contains(t, detailsBlock.Text.Text, "test-tenant-123")
+	assert.Contains(t, detailsBlock.Text.Text, "test-service")
+	assert.Contains(t, detailsBlock.Text.Text, "alert-id-123")
+	assert.Contains(t, detailsBlock.Text.Text, "This is a test error message")
+}
+
+func TestBuildPayload_WithMetadata(t *testing.T) {
+	notifier := &SlackNotifier{serviceName: "test-service"}
+	alert := Alert{
+		TenantID:  tenant.TenantID("test-tenant"),
+		Severity:  SeverityWarning,
+		Title:     "Warning Alert",
+		Timestamp: time.Now(),
+		Metadata: map[string]string{
+			"display_name": "Acme Corp",
+			"status":       "provisioning_failed",
+		},
+	}
+
+	payload := notifier.buildPayload(alert, "alert-123")
+
+	// Find the fields block
+	var foundMetadata bool
+	for _, block := range payload.Blocks {
+		if len(block.Fields) > 0 {
+			foundMetadata = true
+			// Check metadata fields are present
+			var fieldTexts []string
+			for _, field := range block.Fields {
+				fieldTexts = append(fieldTexts, field.Text)
+			}
+			assert.True(t, containsAny(fieldTexts, "Acme Corp"), "should contain display_name")
+			assert.True(t, containsAny(fieldTexts, "provisioning_failed"), "should contain status")
+		}
+	}
+	assert.True(t, foundMetadata, "should have metadata block")
+}
+
+func TestBuildPayload_EmptyMessage(t *testing.T) {
+	notifier := &SlackNotifier{serviceName: "test-service"}
+	alert := Alert{
+		TenantID:  tenant.TenantID("test-tenant"),
+		Severity:  SeverityInfo,
+		Title:     "Info Alert",
+		Message:   "", // Empty message
+		Timestamp: time.Now(),
+	}
+
+	payload := notifier.buildPayload(alert, "alert-123")
+
+	// Details block should not contain error code block
+	detailsBlock := payload.Blocks[1]
+	assert.NotContains(t, detailsBlock.Text.Text, "```")
+}
+
+func TestBuildPayload_DividerAtEnd(t *testing.T) {
+	notifier := &SlackNotifier{serviceName: "test-service"}
+	alert := Alert{
+		TenantID:  tenant.TenantID("test-tenant"),
+		Severity:  SeverityCritical,
+		Title:     "Test Alert",
+		Timestamp: time.Now(),
+	}
+
+	payload := notifier.buildPayload(alert, "alert-123")
+
+	// Last block should be divider
+	lastBlock := payload.Blocks[len(payload.Blocks)-1]
+	assert.Equal(t, "divider", lastBlock.Type)
+}
+
+func TestFormatProvisioningFailureMessage(t *testing.T) {
+	tenant := &domain.Tenant{
+		ID:              tenant.TenantID("failed-tenant-456"),
+		DisplayName:     "Failed Corp",
+		SettlementAsset: "GBP",
+		Status:          domain.StatusProvisioningFailed,
+		ErrorMessage:    "database connection timeout",
+	}
+
+	timestamp := time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+	payload := formatProvisioningFailureMessage(tenant, "tenant-service", "alert-789", timestamp)
+
+	// Verify critical emoji for provisioning failures
+	assert.Contains(t, payload.Text, "\U0001F534") // Red circle
+
+	// Verify tenant info
+	assert.Contains(t, payload.Text, "failed-tenant-456")
+	assert.Contains(t, payload.Text, "Tenant Provisioning Failed")
+
+	// Verify error message in details
+	detailsBlock := payload.Blocks[1]
+	assert.Contains(t, detailsBlock.Text.Text, "database connection timeout")
+}
+
+func TestSendAlert_Success(t *testing.T) {
+	var receivedPayload slackPayload
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		err = json.Unmarshal(body, &receivedPayload)
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	notifier := &SlackNotifier{
+		webhookURL:  server.URL,
+		serviceName: "test-service",
+		httpClient:  server.Client(),
+		logger:      logger,
+	}
+
+	alert := Alert{
+		TenantID:  tenant.TenantID("test-tenant"),
+		Severity:  SeverityCritical,
+		Title:     "Test Alert",
+		Message:   "Test error",
+		Timestamp: time.Now(),
+	}
+
+	err := notifier.SendAlert(context.Background(), alert)
+
+	require.NoError(t, err)
+	assert.Contains(t, receivedPayload.Text, "test-tenant")
+	assert.Contains(t, logBuf.String(), "slack alert sent successfully")
+}
+
+func TestSendAlert_WebhookError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	notifier := &SlackNotifier{
+		webhookURL:  server.URL,
+		serviceName: "test-service",
+		httpClient:  server.Client(),
+		logger:      logger,
+	}
+
+	alert := Alert{
+		TenantID:  tenant.TenantID("test-tenant"),
+		Severity:  SeverityCritical,
+		Title:     "Test Alert",
+		Timestamp: time.Now(),
+	}
+
+	err := notifier.SendAlert(context.Background(), alert)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSlackResponseError)
+	assert.Contains(t, err.Error(), "500")
+	assert.Contains(t, logBuf.String(), "slack webhook returned error")
+}
+
+func TestSendAlert_ConnectionError(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	notifier := &SlackNotifier{
+		webhookURL:  "https://invalid.host.example.com/webhook",
+		serviceName: "test-service",
+		httpClient:  &http.Client{Timeout: 100 * time.Millisecond},
+		logger:      logger,
+	}
+
+	alert := Alert{
+		TenantID:  tenant.TenantID("test-tenant"),
+		Severity:  SeverityCritical,
+		Title:     "Test Alert",
+		Timestamp: time.Now(),
+	}
+
+	err := notifier.SendAlert(context.Background(), alert)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSlackWebhookFailed)
+	assert.Contains(t, logBuf.String(), "slack webhook request failed")
+}
+
+func TestSendAlert_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(5 * time.Second) // Long delay
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	notifier := &SlackNotifier{
+		webhookURL:  server.URL,
+		serviceName: "test-service",
+		httpClient:  server.Client(),
+		logger:      logger,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	alert := Alert{
+		TenantID:  tenant.TenantID("test-tenant"),
+		Severity:  SeverityCritical,
+		Title:     "Test Alert",
+		Timestamp: time.Now(),
+	}
+
+	err := notifier.SendAlert(ctx, alert)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSlackWebhookFailed)
+}
+
+func TestNotifyProvisioningFailure(t *testing.T) {
+	var receivedPayload slackPayload
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &receivedPayload)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := &SlackNotifier{
+		webhookURL:  server.URL,
+		serviceName: "tenant-service",
+		httpClient:  server.Client(),
+		logger:      slog.Default(),
+	}
+
+	tenant := &domain.Tenant{
+		ID:              tenant.TenantID("provisioning-failed-tenant"),
+		DisplayName:     "Failed Inc",
+		SettlementAsset: "USD",
+		Status:          domain.StatusProvisioningFailed,
+		ErrorMessage:    "schema migration failed: constraint violation",
+	}
+
+	err := notifier.NotifyProvisioningFailure(context.Background(), tenant)
+
+	require.NoError(t, err)
+	assert.Contains(t, receivedPayload.Text, "provisioning-failed-tenant")
+	assert.Contains(t, receivedPayload.Text, "Tenant Provisioning Failed")
+
+	// Verify it's marked as critical
+	headerBlock := receivedPayload.Blocks[0]
+	assert.Contains(t, headerBlock.Text.Text, "\U0001F534") // Red circle
+}
+
+func TestSendAlert_PayloadStructure(t *testing.T) {
+	var receivedBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	notifier := &SlackNotifier{
+		webhookURL:  server.URL,
+		serviceName: "test-service",
+		httpClient:  server.Client(),
+		logger:      slog.Default(),
+	}
+
+	alert := Alert{
+		TenantID:  tenant.TenantID("test-tenant"),
+		Severity:  SeverityWarning,
+		Title:     "Warning Alert",
+		Message:   "Warning message",
+		Timestamp: time.Date(2025, 1, 15, 10, 0, 0, 0, time.UTC),
+		Metadata: map[string]string{
+			"display_name": "Test Corp",
+		},
+	}
+
+	err := notifier.SendAlert(context.Background(), alert)
+	require.NoError(t, err)
+
+	// Verify JSON structure
+	var payload map[string]interface{}
+	err = json.Unmarshal(receivedBody, &payload)
+	require.NoError(t, err)
+
+	// Must have text field (fallback)
+	assert.NotNil(t, payload["text"])
+
+	// Must have blocks array
+	blocks, ok := payload["blocks"].([]interface{})
+	require.True(t, ok, "blocks should be an array")
+	require.GreaterOrEqual(t, len(blocks), 2, "should have at least header and details blocks")
+
+	// First block should be section with text
+	firstBlock := blocks[0].(map[string]interface{})
+	assert.Equal(t, "section", firstBlock["type"])
+	textObj := firstBlock["text"].(map[string]interface{})
+	assert.Equal(t, "mrkdwn", textObj["type"])
+	assert.Contains(t, textObj["text"].(string), "\u26A0") // Warning emoji
+}
+
+// Helper function to check if any string in slice contains substring
+func containsAny(strs []string, substr string) bool {
+	for _, s := range strs {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}

--- a/services/tenant/observability/metrics.go
+++ b/services/tenant/observability/metrics.go
@@ -25,6 +25,26 @@ const (
 	StatusError   = "error"
 )
 
+// Alert status constants for alert metrics.
+const (
+	AlertStatusSuccess     = "success"
+	AlertStatusError       = "error"
+	AlertStatusRateLimited = "rate_limited"
+)
+
+// Alert provider constants.
+const (
+	AlertProviderPagerDuty = "pagerduty"
+	AlertProviderSlack     = "slack"
+)
+
+// Alert severity constants.
+const (
+	AlertSeverityCritical = "critical"
+	AlertSeverityWarning  = "warning"
+	AlertSeverityInfo     = "info"
+)
+
 var (
 	// Provisioning duration histogram with exponential buckets from 0.5s to ~34 minutes
 	// Buckets: 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024 seconds
@@ -64,6 +84,27 @@ var (
 			Help: "Total number of provisioning retry attempts across all tenants",
 		},
 	)
+
+	// Counter for alerts sent to external providers (PagerDuty, Slack).
+	// Labels:
+	//   - provider: "pagerduty", "slack"
+	//   - severity: "critical", "warning", "info"
+	//   - status: "success", "error", "rate_limited"
+	alertsSentTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "alerts_sent_total",
+			Help: "Total number of alerts sent to external providers",
+		},
+		[]string{"provider", "severity", "status"},
+	)
+
+	// Gauge for the number of alerts in the dead-letter queue.
+	alertDLQDepth = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "alerts_dlq_depth",
+			Help: "Number of alerts currently in the dead-letter queue awaiting manual review",
+		},
+	)
 )
 
 // RecordProvisioningDuration records the duration of a tenant provisioning operation.
@@ -87,4 +128,17 @@ func IncrementServiceFailure(serviceName string) {
 // IncrementRetryAttempt increments the retry counter for tenant provisioning operations.
 func IncrementRetryAttempt() {
 	provisioningRetries.Inc()
+}
+
+// RecordAlertSent increments the alerts_sent_total counter.
+// provider: "pagerduty" or "slack"
+// severity: "critical", "warning", or "info"
+// status: "success", "error", or "rate_limited"
+func RecordAlertSent(provider, severity, status string) {
+	alertsSentTotal.WithLabelValues(provider, severity, status).Inc()
+}
+
+// SetAlertDLQDepth sets the current depth of the alert dead-letter queue.
+func SetAlertDLQDepth(depth int) {
+	alertDLQDepth.Set(float64(depth))
 }

--- a/services/tenant/observability/metrics_test.go
+++ b/services/tenant/observability/metrics_test.go
@@ -252,3 +252,154 @@ func TestQueueDepthChanges(t *testing.T) {
 		t.Errorf("Expected queue depth 0, got %v", got)
 	}
 }
+
+// =============================================================================
+// Alerting Metrics Tests
+// =============================================================================
+
+func TestRecordAlertSent(t *testing.T) {
+	alertsSentTotal.Reset()
+
+	RecordAlertSent(AlertProviderPagerDuty, AlertSeverityCritical, AlertStatusSuccess)
+
+	count := testutil.CollectAndCount(alertsSentTotal)
+	if count == 0 {
+		t.Error("Expected alerts_sent_total metric to be recorded")
+	}
+}
+
+func TestRecordAlertSentWithDifferentLabels(t *testing.T) {
+	alertsSentTotal.Reset()
+
+	testCases := []struct {
+		provider string
+		severity string
+		status   string
+	}{
+		{AlertProviderPagerDuty, AlertSeverityCritical, AlertStatusSuccess},
+		{AlertProviderPagerDuty, AlertSeverityWarning, AlertStatusError},
+		{AlertProviderPagerDuty, AlertSeverityInfo, AlertStatusRateLimited},
+		{AlertProviderSlack, AlertSeverityCritical, AlertStatusSuccess},
+		{AlertProviderSlack, AlertSeverityWarning, AlertStatusError},
+		{AlertProviderSlack, AlertSeverityInfo, AlertStatusRateLimited},
+	}
+
+	for _, tc := range testCases {
+		RecordAlertSent(tc.provider, tc.severity, tc.status)
+	}
+
+	count := testutil.CollectAndCount(alertsSentTotal)
+	if count == 0 {
+		t.Error("Expected alerts_sent_total metrics with different labels to be recorded")
+	}
+}
+
+func TestSetAlertDLQDepth(t *testing.T) {
+	SetAlertDLQDepth(0)
+
+	// Set to 10 and verify
+	SetAlertDLQDepth(10)
+	if got := testutil.ToFloat64(alertDLQDepth); got != 10 {
+		t.Errorf("Expected DLQ depth 10, got %v", got)
+	}
+
+	// Set to 100 and verify
+	SetAlertDLQDepth(100)
+	if got := testutil.ToFloat64(alertDLQDepth); got != 100 {
+		t.Errorf("Expected DLQ depth 100, got %v", got)
+	}
+
+	// Set back to 0 and verify
+	SetAlertDLQDepth(0)
+	if got := testutil.ToFloat64(alertDLQDepth); got != 0 {
+		t.Errorf("Expected DLQ depth 0, got %v", got)
+	}
+}
+
+func TestAlertStatusConstants(t *testing.T) {
+	if AlertStatusSuccess != "success" {
+		t.Errorf("Expected AlertStatusSuccess to be 'success', got %q", AlertStatusSuccess)
+	}
+	if AlertStatusError != "error" {
+		t.Errorf("Expected AlertStatusError to be 'error', got %q", AlertStatusError)
+	}
+	if AlertStatusRateLimited != "rate_limited" {
+		t.Errorf("Expected AlertStatusRateLimited to be 'rate_limited', got %q", AlertStatusRateLimited)
+	}
+}
+
+func TestAlertProviderConstants(t *testing.T) {
+	if AlertProviderPagerDuty != "pagerduty" {
+		t.Errorf("Expected AlertProviderPagerDuty to be 'pagerduty', got %q", AlertProviderPagerDuty)
+	}
+	if AlertProviderSlack != "slack" {
+		t.Errorf("Expected AlertProviderSlack to be 'slack', got %q", AlertProviderSlack)
+	}
+}
+
+func TestAlertSeverityConstants(t *testing.T) {
+	if AlertSeverityCritical != "critical" {
+		t.Errorf("Expected AlertSeverityCritical to be 'critical', got %q", AlertSeverityCritical)
+	}
+	if AlertSeverityWarning != "warning" {
+		t.Errorf("Expected AlertSeverityWarning to be 'warning', got %q", AlertSeverityWarning)
+	}
+	if AlertSeverityInfo != "info" {
+		t.Errorf("Expected AlertSeverityInfo to be 'info', got %q", AlertSeverityInfo)
+	}
+}
+
+func TestAlertMetricsAreRegistered(t *testing.T) {
+	// Verify alerting metrics are registered with Prometheus
+	tests := []struct {
+		name   string
+		metric prometheus.Collector
+	}{
+		{
+			name:   "alerts_sent_total",
+			metric: alertsSentTotal,
+		},
+		{
+			name:   "alerts_dlq_depth",
+			metric: alertDLQDepth,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset metric if possible
+			if resettable, ok := tt.metric.(interface{ Reset() }); ok {
+				resettable.Reset()
+			}
+
+			// Verify metric can be collected
+			count := testutil.CollectAndCount(tt.metric)
+			if count < 0 {
+				t.Errorf("%s: metric is not registered", tt.name)
+			}
+		})
+	}
+}
+
+func TestConcurrentAlertMetricUpdates(t *testing.T) {
+	alertsSentTotal.Reset()
+
+	done := make(chan bool)
+	iterations := 100
+
+	for i := 0; i < iterations; i++ {
+		go func() {
+			RecordAlertSent(AlertProviderPagerDuty, AlertSeverityCritical, AlertStatusSuccess)
+			done <- true
+		}()
+	}
+
+	for i := 0; i < iterations; i++ {
+		<-done
+	}
+
+	count := testutil.CollectAndCount(alertsSentTotal)
+	if count == 0 {
+		t.Error("Expected alerts counter to be incremented concurrently")
+	}
+}

--- a/services/tenant/worker/alerting.go
+++ b/services/tenant/worker/alerting.go
@@ -13,6 +13,7 @@ import (
 	"github.com/meridianhub/meridian/services/tenant/config"
 	"github.com/meridianhub/meridian/services/tenant/domain"
 	"github.com/meridianhub/meridian/services/tenant/notifier"
+	"github.com/meridianhub/meridian/services/tenant/observability"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -173,17 +174,27 @@ func (a *AlertManager) CheckFailedProvisioningAlerts(ctx context.Context, thresh
 
 // sendPagerDutyAlertWithRetry sends a PagerDuty alert with rate limiting, retry, and DLQ.
 func (a *AlertManager) sendPagerDutyAlertWithRetry(ctx context.Context, tenant *domain.Tenant) {
+	severity := observability.AlertSeverityCritical // Provisioning failures are critical
+
 	// Check rate limit
 	if a.rateLimiter != nil && !a.rateLimiter.Allow(AlertTypePagerDuty) {
 		a.logger.Warn("PagerDuty alert rate limited",
 			"tenant_id", tenant.ID,
 			"alert_type", AlertTypePagerDuty)
+		observability.RecordAlertSent(observability.AlertProviderPagerDuty, severity, observability.AlertStatusRateLimited)
 		return
 	}
 
 	// Build alert payload for potential DLQ storage
 	payload := a.buildAlertPayload(tenant)
 	firstAttempt := time.Now()
+
+	// Log payload at DEBUG level for troubleshooting
+	a.logger.Debug("sending PagerDuty alert",
+		"tenant_id", tenant.ID,
+		"summary", payload.Summary,
+		"dedup_key", payload.DedupKey,
+		"severity", payload.Severity)
 
 	// Create retry config using the shared retry package pattern
 	retryConfig := sharedclients.RetryConfig{
@@ -215,6 +226,7 @@ func (a *AlertManager) sendPagerDutyAlertWithRetry(ctx context.Context, tenant *
 			"tenant_id", tenant.ID,
 			"attempts", attemptCount,
 			"error", lastErr)
+		observability.RecordAlertSent(observability.AlertProviderPagerDuty, severity, observability.AlertStatusError)
 
 		// Send to DLQ if configured
 		if a.dlq != nil {
@@ -230,23 +242,37 @@ func (a *AlertManager) sendPagerDutyAlertWithRetry(ctx context.Context, tenant *
 			a.logger.Info("PagerDuty alert sent to DLQ",
 				"tenant_id", tenant.ID,
 				"attempts", attemptCount)
+			// Update DLQ depth metric
+			observability.SetAlertDLQDepth(a.dlq.Len())
 		}
+	} else {
+		// Success
+		observability.RecordAlertSent(observability.AlertProviderPagerDuty, severity, observability.AlertStatusSuccess)
 	}
 }
 
 // sendSlackAlertWithRetry sends a Slack alert with rate limiting, retry, and DLQ.
 func (a *AlertManager) sendSlackAlertWithRetry(ctx context.Context, tenant *domain.Tenant) {
+	severity := observability.AlertSeverityCritical // Provisioning failures are critical
+
 	// Check rate limit
 	if a.rateLimiter != nil && !a.rateLimiter.Allow(AlertTypeSlack) {
 		a.logger.Warn("Slack alert rate limited",
 			"tenant_id", tenant.ID,
 			"alert_type", AlertTypeSlack)
+		observability.RecordAlertSent(observability.AlertProviderSlack, severity, observability.AlertStatusRateLimited)
 		return
 	}
 
 	// Build alert payload for potential DLQ storage
 	payload := a.buildAlertPayload(tenant)
 	firstAttempt := time.Now()
+
+	// Log payload at DEBUG level for troubleshooting
+	a.logger.Debug("sending Slack alert",
+		"tenant_id", tenant.ID,
+		"summary", payload.Summary,
+		"severity", payload.Severity)
 
 	// Create retry config using the shared retry package pattern
 	retryConfig := sharedclients.RetryConfig{
@@ -278,6 +304,7 @@ func (a *AlertManager) sendSlackAlertWithRetry(ctx context.Context, tenant *doma
 			"tenant_id", tenant.ID,
 			"attempts", attemptCount,
 			"error", lastErr)
+		observability.RecordAlertSent(observability.AlertProviderSlack, severity, observability.AlertStatusError)
 
 		// Send to DLQ if configured
 		if a.dlq != nil {
@@ -293,7 +320,12 @@ func (a *AlertManager) sendSlackAlertWithRetry(ctx context.Context, tenant *doma
 			a.logger.Info("Slack alert sent to DLQ",
 				"tenant_id", tenant.ID,
 				"attempts", attemptCount)
+			// Update DLQ depth metric
+			observability.SetAlertDLQDepth(a.dlq.Len())
 		}
+	} else {
+		// Success
+		observability.RecordAlertSent(observability.AlertProviderSlack, severity, observability.AlertStatusSuccess)
 	}
 }
 

--- a/services/tenant/worker/alerting.go
+++ b/services/tenant/worker/alerting.go
@@ -3,27 +3,55 @@ package worker
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
+	"github.com/meridianhub/meridian/services/tenant/clients"
 	"github.com/meridianhub/meridian/services/tenant/domain"
+	"github.com/meridianhub/meridian/services/tenant/notifier"
 )
 
 // AlertManager monitors and alerts on tenant provisioning failures.
 // It identifies tenants stuck in provisioning_failed state and logs alerts
 // for integration with external alerting systems (PagerDuty, Slack, etc.).
 type AlertManager struct {
-	repo   *persistence.Repository
-	logger *slog.Logger
+	repo            *persistence.Repository
+	logger          *slog.Logger
+	pagerdutyClient *clients.PagerDutyClient
+	slackNotifier   *notifier.SlackNotifier
+}
+
+// AlertManagerOption configures the AlertManager.
+type AlertManagerOption func(*AlertManager)
+
+// WithPagerDutyClient configures the AlertManager to send alerts to PagerDuty.
+func WithPagerDutyClient(client *clients.PagerDutyClient) AlertManagerOption {
+	return func(a *AlertManager) {
+		a.pagerdutyClient = client
+	}
+}
+
+// WithSlackNotifier configures the AlertManager to send alerts to Slack.
+func WithSlackNotifier(slack *notifier.SlackNotifier) AlertManagerOption {
+	return func(a *AlertManager) {
+		a.slackNotifier = slack
+	}
 }
 
 // NewAlertManager creates a new AlertManager.
-func NewAlertManager(repo *persistence.Repository, logger *slog.Logger) *AlertManager {
-	return &AlertManager{
+func NewAlertManager(repo *persistence.Repository, logger *slog.Logger, opts ...AlertManagerOption) *AlertManager {
+	am := &AlertManager{
 		repo:   repo,
 		logger: logger,
 	}
+
+	for _, opt := range opts {
+		opt(am)
+	}
+
+	return am
 }
 
 // CheckFailedProvisioningAlerts queries for tenants in provisioning_failed state
@@ -35,8 +63,9 @@ func NewAlertManager(repo *persistence.Repository, logger *slog.Logger) *AlertMa
 // Typically set to 1 hour to avoid alerting on transient failures that may self-recover.
 //
 // Note: Alerts will repeat every 15 minutes (default alert interval) for the same tenant
-// until the provisioning issue is resolved. Downstream alerting systems (PagerDuty, Slack, etc.)
-// should implement deduplication based on tenant_id to avoid alert fatigue.
+// until the provisioning issue is resolved. PagerDuty deduplication is based on tenant_id
+// to avoid alert fatigue (the dedup_key ensures repeated calls for the same tenant
+// update the existing incident rather than creating new ones).
 func (a *AlertManager) CheckFailedProvisioningAlerts(ctx context.Context, threshold time.Duration) error {
 	// Calculate cutoff time for failed tenants
 	cutoffTime := time.Now().Add(-threshold)
@@ -50,7 +79,7 @@ func (a *AlertManager) CheckFailedProvisioningAlerts(ctx context.Context, thresh
 		return err
 	}
 
-	// Log alert for each failed tenant
+	// Process alerts for each failed tenant
 	for _, tenant := range failedTenants {
 		a.logger.Warn("tenant provisioning failure alert",
 			"alert", "tenant_provisioning_failed",
@@ -64,11 +93,27 @@ func (a *AlertManager) CheckFailedProvisioningAlerts(ctx context.Context, thresh
 			"status", tenant.Status,
 			"threshold_hours", threshold.Hours())
 
-		// TODO: Integrate with PagerDuty API
-		// Example: pagerduty.TriggerIncident(ctx, tenant.ID, tenant.ErrorMessage)
+		// Send alert to PagerDuty if configured
+		if a.pagerdutyClient != nil && a.pagerdutyClient.IsEnabled() {
+			if err := a.sendPagerDutyAlert(ctx, tenant); err != nil {
+				// Log error but continue processing other tenants
+				// PagerDuty failures should not block the alert loop
+				a.logger.Error("failed to send PagerDuty alert",
+					"tenant_id", tenant.ID,
+					"error", err)
+			}
+		}
 
-		// TODO: Integrate with Slack webhook
-		// Example: slack.PostMessage(ctx, alertChannel, formatAlertMessage(tenant))
+		// Send alert to Slack if configured
+		if a.slackNotifier != nil {
+			if err := a.slackNotifier.NotifyProvisioningFailure(ctx, tenant); err != nil {
+				// Log error but continue processing other tenants
+				// Slack failures should not block the alert loop
+				a.logger.Error("failed to send Slack alert",
+					"tenant_id", tenant.ID,
+					"error", err)
+			}
+		}
 	}
 
 	if len(failedTenants) > 0 {
@@ -78,4 +123,33 @@ func (a *AlertManager) CheckFailedProvisioningAlerts(ctx context.Context, thresh
 	}
 
 	return nil
+}
+
+// sendPagerDutyAlert sends a provisioning failure alert to PagerDuty.
+func (a *AlertManager) sendPagerDutyAlert(ctx context.Context, tenant *domain.Tenant) error {
+	// Build alert summary
+	summary := fmt.Sprintf("Tenant provisioning failed: %s", tenant.ID)
+	if tenant.ErrorMessage != "" {
+		// Truncate error message if too long (PagerDuty has summary limits)
+		errMsg := tenant.ErrorMessage
+		if len(errMsg) > 200 {
+			errMsg = errMsg[:197] + "..."
+		}
+		summary = fmt.Sprintf("Tenant provisioning failed: %s - %s", tenant.ID, errMsg)
+	}
+
+	// Use tenant ID as dedup key to group repeated alerts for the same tenant
+	dedupKey := fmt.Sprintf("tenant-provisioning-failed-%s", tenant.ID)
+
+	// Build custom details for the alert payload
+	customDetails := map[string]any{
+		"tenant_id":     tenant.ID.String(),
+		"display_name":  tenant.DisplayName,
+		"status":        string(tenant.Status),
+		"error_message": tenant.ErrorMessage,
+		"created_at":    tenant.CreatedAt.Format(time.RFC3339),
+	}
+
+	// Provisioning failures are critical - they block tenant onboarding
+	return a.pagerdutyClient.TriggerAlert(ctx, summary, dedupKey, clients.SeverityCritical, customDetails)
 }

--- a/services/tenant/worker/alerting.go
+++ b/services/tenant/worker/alerting.go
@@ -25,6 +25,16 @@ const (
 	AlertTypeSlack     = "slack"
 )
 
+// Error message truncation constants.
+// PagerDuty Events API v2 has a 1024 character limit for the summary field.
+// We use a conservative limit to leave room for the tenant ID prefix.
+const (
+	// maxErrorMessageLength is the maximum length for error messages in alert summaries.
+	maxErrorMessageLength = 200
+	// truncatedErrorMessageLength is the length to truncate to (leaving room for "...").
+	truncatedErrorMessageLength = 197
+)
+
 // ErrRateLimited is returned when an alert is blocked by rate limiting.
 var ErrRateLimited = errors.New("alert rate limited")
 
@@ -140,6 +150,11 @@ func (a *AlertManager) CheckFailedProvisioningAlerts(ctx context.Context, thresh
 
 	// Process alerts for each failed tenant
 	for _, tenant := range failedTenants {
+		// Check for context cancellation to enable graceful shutdown
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+
 		a.logger.Warn("tenant provisioning failure alert",
 			"alert", "tenant_provisioning_failed",
 			"tenant_id", tenant.ID,
@@ -334,8 +349,8 @@ func (a *AlertManager) buildAlertPayload(tenant *domain.Tenant) AlertPayload {
 	summary := fmt.Sprintf("Tenant provisioning failed: %s", tenant.ID)
 	if tenant.ErrorMessage != "" {
 		errMsg := tenant.ErrorMessage
-		if len(errMsg) > 200 {
-			errMsg = errMsg[:197] + "..."
+		if len(errMsg) > maxErrorMessageLength {
+			errMsg = errMsg[:truncatedErrorMessageLength] + "..."
 		}
 		summary = fmt.Sprintf("Tenant provisioning failed: %s - %s", tenant.ID, errMsg)
 	}
@@ -391,8 +406,8 @@ func (a *AlertManager) sendPagerDutyAlert(ctx context.Context, tenant *domain.Te
 	if tenant.ErrorMessage != "" {
 		// Truncate error message if too long (PagerDuty has summary limits)
 		errMsg := tenant.ErrorMessage
-		if len(errMsg) > 200 {
-			errMsg = errMsg[:197] + "..."
+		if len(errMsg) > maxErrorMessageLength {
+			errMsg = errMsg[:truncatedErrorMessageLength] + "..."
 		}
 		summary = fmt.Sprintf("Tenant provisioning failed: %s - %s", tenant.ID, errMsg)
 	}

--- a/services/tenant/worker/alerting.go
+++ b/services/tenant/worker/alerting.go
@@ -3,24 +3,46 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
 	"github.com/meridianhub/meridian/services/tenant/clients"
+	"github.com/meridianhub/meridian/services/tenant/config"
 	"github.com/meridianhub/meridian/services/tenant/domain"
 	"github.com/meridianhub/meridian/services/tenant/notifier"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
 )
+
+// Alert type constants for rate limiting.
+const (
+	AlertTypePagerDuty = "pagerduty"
+	AlertTypeSlack     = "slack"
+)
+
+// ErrRateLimited is returned when an alert is blocked by rate limiting.
+var ErrRateLimited = errors.New("alert rate limited")
 
 // AlertManager monitors and alerts on tenant provisioning failures.
 // It identifies tenants stuck in provisioning_failed state and logs alerts
 // for integration with external alerting systems (PagerDuty, Slack, etc.).
+//
+// Features:
+// - Rate limiting: Token bucket algorithm to prevent alert storms
+// - Retry logic: Exponential backoff with configurable retries
+// - Dead-letter queue: Failed alerts are stored for manual review
 type AlertManager struct {
 	repo            *persistence.Repository
 	logger          *slog.Logger
 	pagerdutyClient *clients.PagerDutyClient
 	slackNotifier   *notifier.SlackNotifier
+	rateLimiter     *AlertRateLimiter
+	dlq             *AlertDeadLetterQueue
+	retryConfig     config.AlertRetryConfig
 }
 
 // AlertManagerOption configures the AlertManager.
@@ -40,11 +62,35 @@ func WithSlackNotifier(slack *notifier.SlackNotifier) AlertManagerOption {
 	}
 }
 
+// WithRateLimiter configures alert rate limiting.
+func WithRateLimiter(limiter *AlertRateLimiter) AlertManagerOption {
+	return func(a *AlertManager) {
+		a.rateLimiter = limiter
+	}
+}
+
+// WithDeadLetterQueue configures the dead-letter queue for failed alerts.
+func WithDeadLetterQueue(dlq *AlertDeadLetterQueue) AlertManagerOption {
+	return func(a *AlertManager) {
+		a.dlq = dlq
+	}
+}
+
+// WithRetryConfig configures the retry behavior for failed alerts.
+func WithRetryConfig(cfg config.AlertRetryConfig) AlertManagerOption {
+	return func(a *AlertManager) {
+		a.retryConfig = cfg
+	}
+}
+
 // NewAlertManager creates a new AlertManager.
+// By default, rate limiting and DLQ are disabled. Use WithRateLimiter and
+// WithDeadLetterQueue options to enable them.
 func NewAlertManager(repo *persistence.Repository, logger *slog.Logger, opts ...AlertManagerOption) *AlertManager {
 	am := &AlertManager{
-		repo:   repo,
-		logger: logger,
+		repo:        repo,
+		logger:      logger,
+		retryConfig: config.DefaultAlertRetryConfig(),
 	}
 
 	for _, opt := range opts {
@@ -52,6 +98,12 @@ func NewAlertManager(repo *persistence.Repository, logger *slog.Logger, opts ...
 	}
 
 	return am
+}
+
+// DeadLetterQueue returns the DLQ for external inspection/processing.
+// Returns nil if DLQ is not configured.
+func (a *AlertManager) DeadLetterQueue() *AlertDeadLetterQueue {
+	return a.dlq
 }
 
 // CheckFailedProvisioningAlerts queries for tenants in provisioning_failed state
@@ -66,6 +118,12 @@ func NewAlertManager(repo *persistence.Repository, logger *slog.Logger, opts ...
 // until the provisioning issue is resolved. PagerDuty deduplication is based on tenant_id
 // to avoid alert fatigue (the dedup_key ensures repeated calls for the same tenant
 // update the existing incident rather than creating new ones).
+//
+// Rate limiting: Alerts are rate limited per alert type (PagerDuty, Slack) to prevent
+// alert storms. When rate limited, alerts are logged but not sent.
+//
+// Retry: Failed alerts are retried with exponential backoff (1s, 2s, 4s, 8s).
+// After max retries, alerts are sent to the dead-letter queue for manual review.
 func (a *AlertManager) CheckFailedProvisioningAlerts(ctx context.Context, threshold time.Duration) error {
 	// Calculate cutoff time for failed tenants
 	cutoffTime := time.Now().Add(-threshold)
@@ -95,24 +153,12 @@ func (a *AlertManager) CheckFailedProvisioningAlerts(ctx context.Context, thresh
 
 		// Send alert to PagerDuty if configured
 		if a.pagerdutyClient != nil && a.pagerdutyClient.IsEnabled() {
-			if err := a.sendPagerDutyAlert(ctx, tenant); err != nil {
-				// Log error but continue processing other tenants
-				// PagerDuty failures should not block the alert loop
-				a.logger.Error("failed to send PagerDuty alert",
-					"tenant_id", tenant.ID,
-					"error", err)
-			}
+			a.sendPagerDutyAlertWithRetry(ctx, tenant)
 		}
 
 		// Send alert to Slack if configured
 		if a.slackNotifier != nil {
-			if err := a.slackNotifier.NotifyProvisioningFailure(ctx, tenant); err != nil {
-				// Log error but continue processing other tenants
-				// Slack failures should not block the alert loop
-				a.logger.Error("failed to send Slack alert",
-					"tenant_id", tenant.ID,
-					"error", err)
-			}
+			a.sendSlackAlertWithRetry(ctx, tenant)
 		}
 	}
 
@@ -123,6 +169,187 @@ func (a *AlertManager) CheckFailedProvisioningAlerts(ctx context.Context, thresh
 	}
 
 	return nil
+}
+
+// sendPagerDutyAlertWithRetry sends a PagerDuty alert with rate limiting, retry, and DLQ.
+func (a *AlertManager) sendPagerDutyAlertWithRetry(ctx context.Context, tenant *domain.Tenant) {
+	// Check rate limit
+	if a.rateLimiter != nil && !a.rateLimiter.Allow(AlertTypePagerDuty) {
+		a.logger.Warn("PagerDuty alert rate limited",
+			"tenant_id", tenant.ID,
+			"alert_type", AlertTypePagerDuty)
+		return
+	}
+
+	// Build alert payload for potential DLQ storage
+	payload := a.buildAlertPayload(tenant)
+	firstAttempt := time.Now()
+
+	// Create retry config using the shared retry package pattern
+	retryConfig := sharedclients.RetryConfig{
+		MaxRetries:          a.retryConfig.MaxRetries,
+		InitialInterval:     a.retryConfig.InitialBackoff,
+		MaxInterval:         a.retryConfig.MaxBackoff,
+		Multiplier:          2.0,
+		RandomizationFactor: 0.1, // Small jitter
+	}
+
+	attemptCount := 0
+	var lastErr error
+
+	err := sharedclients.Retry(ctx, retryConfig, func() error {
+		attemptCount++
+		lastErr = a.sendPagerDutyAlert(ctx, tenant)
+		if lastErr != nil {
+			a.logger.Warn("PagerDuty alert attempt failed",
+				"tenant_id", tenant.ID,
+				"attempt", attemptCount,
+				"error", lastErr)
+			// Mark as retryable for the retry logic
+			return a.wrapAsRetryable(lastErr)
+		}
+		return nil
+	})
+	if err != nil {
+		a.logger.Error("failed to send PagerDuty alert after retries",
+			"tenant_id", tenant.ID,
+			"attempts", attemptCount,
+			"error", lastErr)
+
+		// Send to DLQ if configured
+		if a.dlq != nil {
+			a.dlq.Enqueue(FailedAlert{
+				AlertType:      AlertTypePagerDuty,
+				TenantID:       tenant.ID.String(),
+				Payload:        payload,
+				ErrorMessage:   lastErr.Error(),
+				FirstAttemptAt: firstAttempt,
+				LastAttemptAt:  time.Now(),
+				AttemptCount:   attemptCount,
+			})
+			a.logger.Info("PagerDuty alert sent to DLQ",
+				"tenant_id", tenant.ID,
+				"attempts", attemptCount)
+		}
+	}
+}
+
+// sendSlackAlertWithRetry sends a Slack alert with rate limiting, retry, and DLQ.
+func (a *AlertManager) sendSlackAlertWithRetry(ctx context.Context, tenant *domain.Tenant) {
+	// Check rate limit
+	if a.rateLimiter != nil && !a.rateLimiter.Allow(AlertTypeSlack) {
+		a.logger.Warn("Slack alert rate limited",
+			"tenant_id", tenant.ID,
+			"alert_type", AlertTypeSlack)
+		return
+	}
+
+	// Build alert payload for potential DLQ storage
+	payload := a.buildAlertPayload(tenant)
+	firstAttempt := time.Now()
+
+	// Create retry config using the shared retry package pattern
+	retryConfig := sharedclients.RetryConfig{
+		MaxRetries:          a.retryConfig.MaxRetries,
+		InitialInterval:     a.retryConfig.InitialBackoff,
+		MaxInterval:         a.retryConfig.MaxBackoff,
+		Multiplier:          2.0,
+		RandomizationFactor: 0.1, // Small jitter
+	}
+
+	attemptCount := 0
+	var lastErr error
+
+	err := sharedclients.Retry(ctx, retryConfig, func() error {
+		attemptCount++
+		lastErr = a.slackNotifier.NotifyProvisioningFailure(ctx, tenant)
+		if lastErr != nil {
+			a.logger.Warn("Slack alert attempt failed",
+				"tenant_id", tenant.ID,
+				"attempt", attemptCount,
+				"error", lastErr)
+			// Mark as retryable for the retry logic
+			return a.wrapAsRetryable(lastErr)
+		}
+		return nil
+	})
+	if err != nil {
+		a.logger.Error("failed to send Slack alert after retries",
+			"tenant_id", tenant.ID,
+			"attempts", attemptCount,
+			"error", lastErr)
+
+		// Send to DLQ if configured
+		if a.dlq != nil {
+			a.dlq.Enqueue(FailedAlert{
+				AlertType:      AlertTypeSlack,
+				TenantID:       tenant.ID.String(),
+				Payload:        payload,
+				ErrorMessage:   lastErr.Error(),
+				FirstAttemptAt: firstAttempt,
+				LastAttemptAt:  time.Now(),
+				AttemptCount:   attemptCount,
+			})
+			a.logger.Info("Slack alert sent to DLQ",
+				"tenant_id", tenant.ID,
+				"attempts", attemptCount)
+		}
+	}
+}
+
+// buildAlertPayload creates an AlertPayload from a tenant for DLQ storage.
+func (a *AlertManager) buildAlertPayload(tenant *domain.Tenant) AlertPayload {
+	summary := fmt.Sprintf("Tenant provisioning failed: %s", tenant.ID)
+	if tenant.ErrorMessage != "" {
+		errMsg := tenant.ErrorMessage
+		if len(errMsg) > 200 {
+			errMsg = errMsg[:197] + "..."
+		}
+		summary = fmt.Sprintf("Tenant provisioning failed: %s - %s", tenant.ID, errMsg)
+	}
+
+	return AlertPayload{
+		Summary:  summary,
+		DedupKey: fmt.Sprintf("tenant-provisioning-failed-%s", tenant.ID),
+		Severity: string(clients.SeverityCritical),
+		CustomDetails: map[string]any{
+			"tenant_id":     tenant.ID.String(),
+			"display_name":  tenant.DisplayName,
+			"status":        string(tenant.Status),
+			"error_message": tenant.ErrorMessage,
+			"created_at":    tenant.CreatedAt.Format(time.RFC3339),
+		},
+	}
+}
+
+// wrapAsRetryable wraps an error to make it retryable by the shared retry logic.
+// The shared retry.go uses gRPC status codes to determine retryability.
+// For HTTP-based alerts (PagerDuty, Slack), we wrap the error with gRPC Unavailable status.
+func (a *AlertManager) wrapAsRetryable(err error) error {
+	// The shared retry package uses gRPC codes to determine retryability.
+	// For HTTP errors, we wrap them as gRPC Unavailable to trigger retries.
+	// This allows us to reuse the existing retry logic without modification.
+	return grpcUnavailableError{underlying: err}
+}
+
+// grpcUnavailableError wraps an HTTP error as a gRPC Unavailable error
+// so that the shared retry logic treats it as retryable.
+type grpcUnavailableError struct {
+	underlying error
+}
+
+func (e grpcUnavailableError) Error() string {
+	return e.underlying.Error()
+}
+
+func (e grpcUnavailableError) Unwrap() error {
+	return e.underlying
+}
+
+// GRPCStatus implements the interface expected by status.FromError
+// to return a gRPC status that indicates the error is retryable.
+func (e grpcUnavailableError) GRPCStatus() *grpcstatus.Status {
+	return grpcstatus.New(codes.Unavailable, e.underlying.Error())
 }
 
 // sendPagerDutyAlert sends a provisioning failure alert to PagerDuty.

--- a/services/tenant/worker/alerting_mock.go
+++ b/services/tenant/worker/alerting_mock.go
@@ -1,0 +1,361 @@
+// Package worker implements background workers for tenant provisioning.
+package worker
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/meridianhub/meridian/services/tenant/domain"
+)
+
+// AlertRecord represents a single alert that was sent or attempted.
+// Used by mock implementations to capture alerts for testing.
+type AlertRecord struct {
+	// AlertType identifies the provider ("pagerduty" or "slack").
+	AlertType string
+
+	// TenantID is the ID of the tenant the alert relates to.
+	TenantID string
+
+	// Payload contains the alert data.
+	Payload AlertPayload
+
+	// Timestamp is when the alert was sent.
+	Timestamp time.Time
+
+	// Success indicates whether the alert was successfully sent.
+	Success bool
+
+	// Error contains any error that occurred.
+	Error error
+}
+
+// InMemoryAlertStore is a thread-safe store for capturing alerts during testing.
+// It allows tests to verify which alerts were sent without making real API calls.
+type InMemoryAlertStore struct {
+	mu      sync.RWMutex
+	records []AlertRecord
+}
+
+// NewInMemoryAlertStore creates a new in-memory alert store.
+func NewInMemoryAlertStore() *InMemoryAlertStore {
+	return &InMemoryAlertStore{
+		records: make([]AlertRecord, 0),
+	}
+}
+
+// Record stores an alert record.
+func (s *InMemoryAlertStore) Record(record AlertRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = append(s.records, record)
+}
+
+// Records returns all recorded alerts.
+// Returns a copy to prevent external modification.
+func (s *InMemoryAlertStore) Records() []AlertRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]AlertRecord, len(s.records))
+	copy(result, s.records)
+	return result
+}
+
+// Count returns the number of recorded alerts.
+func (s *InMemoryAlertStore) Count() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.records)
+}
+
+// CountByType returns the number of alerts for a specific type.
+func (s *InMemoryAlertStore) CountByType(alertType string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	count := 0
+	for _, r := range s.records {
+		if r.AlertType == alertType {
+			count++
+		}
+	}
+	return count
+}
+
+// CountSuccessful returns the number of successfully sent alerts.
+func (s *InMemoryAlertStore) CountSuccessful() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	count := 0
+	for _, r := range s.records {
+		if r.Success {
+			count++
+		}
+	}
+	return count
+}
+
+// Clear removes all recorded alerts.
+func (s *InMemoryAlertStore) Clear() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = make([]AlertRecord, 0)
+}
+
+// FindByTenantID returns all alerts for a specific tenant.
+func (s *InMemoryAlertStore) FindByTenantID(tenantID string) []AlertRecord {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []AlertRecord
+	for _, r := range s.records {
+		if r.TenantID == tenantID {
+			result = append(result, r)
+		}
+	}
+	return result
+}
+
+// AlertSender is an interface for sending alerts.
+// Implemented by both real clients (PagerDutyClient, SlackNotifier) and mocks.
+type AlertSender interface {
+	// SendAlert sends an alert for the given tenant.
+	// Returns an error if the alert could not be sent.
+	SendAlert(ctx context.Context, tenant *domain.Tenant) error
+
+	// IsEnabled returns true if the sender is enabled.
+	IsEnabled() bool
+}
+
+// MockPagerDutyClient is a mock implementation of PagerDuty client for testing.
+type MockPagerDutyClient struct {
+	mu       sync.Mutex
+	store    *InMemoryAlertStore
+	enabled  bool
+	failNext bool                 // If true, the next call will fail
+	failErr  error                // Error to return when failNext is true
+	calls    int                  // Track number of calls
+	callback func(*domain.Tenant) // Optional callback on each call
+}
+
+// MockPagerDutyOption configures the MockPagerDutyClient.
+type MockPagerDutyOption func(*MockPagerDutyClient)
+
+// WithMockPagerDutyStore sets the alert store for the mock.
+func WithMockPagerDutyStore(store *InMemoryAlertStore) MockPagerDutyOption {
+	return func(m *MockPagerDutyClient) {
+		m.store = store
+	}
+}
+
+// WithMockPagerDutyCallback sets a callback to be invoked on each call.
+func WithMockPagerDutyCallback(fn func(*domain.Tenant)) MockPagerDutyOption {
+	return func(m *MockPagerDutyClient) {
+		m.callback = fn
+	}
+}
+
+// NewMockPagerDutyClient creates a new mock PagerDuty client.
+func NewMockPagerDutyClient(enabled bool, opts ...MockPagerDutyOption) *MockPagerDutyClient {
+	m := &MockPagerDutyClient{
+		enabled: enabled,
+		store:   NewInMemoryAlertStore(),
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+// TriggerAlert mocks triggering a PagerDuty alert.
+func (m *MockPagerDutyClient) TriggerAlert(_ context.Context, summary, dedupKey string, severity interface{}, customDetails map[string]any) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls++
+
+	// Check if we should fail
+	if m.failNext {
+		m.failNext = false
+		return m.failErr
+	}
+
+	// Extract tenant ID from custom details
+	tenantID := ""
+	if id, ok := customDetails["tenant_id"].(string); ok {
+		tenantID = id
+	}
+
+	// Record the alert
+	record := AlertRecord{
+		AlertType: AlertTypePagerDuty,
+		TenantID:  tenantID,
+		Payload: AlertPayload{
+			Summary:       summary,
+			DedupKey:      dedupKey,
+			Severity:      severityToString(severity),
+			CustomDetails: customDetails,
+		},
+		Timestamp: time.Now(),
+		Success:   true,
+	}
+	m.store.Record(record)
+
+	return nil
+}
+
+// severityToString converts a severity value to string.
+func severityToString(severity interface{}) string {
+	switch s := severity.(type) {
+	case string:
+		return s
+	default:
+		// Handle custom severity types (like clients.Severity) by converting to string
+		return fmt.Sprintf("%v", s)
+	}
+}
+
+// IsEnabled returns whether the mock client is enabled.
+func (m *MockPagerDutyClient) IsEnabled() bool {
+	return m.enabled
+}
+
+// SetFailNext configures the mock to fail the next call with the given error.
+func (m *MockPagerDutyClient) SetFailNext(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failNext = true
+	m.failErr = err
+}
+
+// Calls returns the number of times TriggerAlert was called.
+func (m *MockPagerDutyClient) Calls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+// Store returns the underlying alert store.
+func (m *MockPagerDutyClient) Store() *InMemoryAlertStore {
+	return m.store
+}
+
+// Reset clears the mock state.
+func (m *MockPagerDutyClient) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = 0
+	m.failNext = false
+	m.failErr = nil
+	m.store.Clear()
+}
+
+// MockSlackNotifier is a mock implementation of Slack notifier for testing.
+type MockSlackNotifier struct {
+	mu       sync.Mutex
+	store    *InMemoryAlertStore
+	enabled  bool
+	failNext bool
+	failErr  error
+	calls    int
+}
+
+// MockSlackOption configures the MockSlackNotifier.
+type MockSlackOption func(*MockSlackNotifier)
+
+// WithMockSlackStore sets the alert store for the mock.
+func WithMockSlackStore(store *InMemoryAlertStore) MockSlackOption {
+	return func(m *MockSlackNotifier) {
+		m.store = store
+	}
+}
+
+// NewMockSlackNotifier creates a new mock Slack notifier.
+func NewMockSlackNotifier(enabled bool, opts ...MockSlackOption) *MockSlackNotifier {
+	m := &MockSlackNotifier{
+		enabled: enabled,
+		store:   NewInMemoryAlertStore(),
+	}
+
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	return m
+}
+
+// NotifyProvisioningFailure mocks sending a Slack notification.
+func (m *MockSlackNotifier) NotifyProvisioningFailure(_ context.Context, tenant *domain.Tenant) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls++
+
+	// Check if we should fail
+	if m.failNext {
+		m.failNext = false
+		return m.failErr
+	}
+
+	// Record the alert
+	record := AlertRecord{
+		AlertType: AlertTypeSlack,
+		TenantID:  tenant.ID.String(),
+		Payload: AlertPayload{
+			Summary:  "Tenant Provisioning Failed",
+			Severity: "critical",
+			CustomDetails: map[string]any{
+				"tenant_id":     tenant.ID.String(),
+				"display_name":  tenant.DisplayName,
+				"error_message": tenant.ErrorMessage,
+				"status":        string(tenant.Status),
+			},
+		},
+		Timestamp: time.Now(),
+		Success:   true,
+	}
+	m.store.Record(record)
+
+	return nil
+}
+
+// SetFailNext configures the mock to fail the next call with the given error.
+func (m *MockSlackNotifier) SetFailNext(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failNext = true
+	m.failErr = err
+}
+
+// Calls returns the number of times NotifyProvisioningFailure was called.
+func (m *MockSlackNotifier) Calls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+// Store returns the underlying alert store.
+func (m *MockSlackNotifier) Store() *InMemoryAlertStore {
+	return m.store
+}
+
+// Reset clears the mock state.
+func (m *MockSlackNotifier) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = 0
+	m.failNext = false
+	m.failErr = nil
+	m.store.Clear()
+}
+
+// IsEnabled returns whether the mock notifier is enabled.
+func (m *MockSlackNotifier) IsEnabled() bool {
+	return m.enabled
+}

--- a/services/tenant/worker/alerting_mock_test.go
+++ b/services/tenant/worker/alerting_mock_test.go
@@ -1,0 +1,387 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/services/tenant/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockErr creates a test error by wrapping a message.
+// This avoids err113 linter warnings about dynamic error creation in tests.
+func mockErr(msg string) error {
+	return fmt.Errorf("%s", msg) //nolint:err113 // test helper for dynamic error messages
+}
+
+// =============================================================================
+// InMemoryAlertStore Tests
+// =============================================================================
+
+func TestInMemoryAlertStore_Record(t *testing.T) {
+	store := NewInMemoryAlertStore()
+
+	record := AlertRecord{
+		AlertType: AlertTypePagerDuty,
+		TenantID:  "test-tenant-1",
+		Payload: AlertPayload{
+			Summary:  "Test alert",
+			Severity: "critical",
+		},
+		Timestamp: time.Now(),
+		Success:   true,
+	}
+
+	store.Record(record)
+
+	records := store.Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, "test-tenant-1", records[0].TenantID)
+	assert.Equal(t, AlertTypePagerDuty, records[0].AlertType)
+}
+
+func TestInMemoryAlertStore_Count(t *testing.T) {
+	store := NewInMemoryAlertStore()
+
+	assert.Equal(t, 0, store.Count())
+
+	store.Record(AlertRecord{AlertType: AlertTypePagerDuty, TenantID: "t1"})
+	store.Record(AlertRecord{AlertType: AlertTypeSlack, TenantID: "t2"})
+	store.Record(AlertRecord{AlertType: AlertTypePagerDuty, TenantID: "t3"})
+
+	assert.Equal(t, 3, store.Count())
+}
+
+func TestInMemoryAlertStore_CountByType(t *testing.T) {
+	store := NewInMemoryAlertStore()
+
+	store.Record(AlertRecord{AlertType: AlertTypePagerDuty, TenantID: "t1"})
+	store.Record(AlertRecord{AlertType: AlertTypeSlack, TenantID: "t2"})
+	store.Record(AlertRecord{AlertType: AlertTypePagerDuty, TenantID: "t3"})
+
+	assert.Equal(t, 2, store.CountByType(AlertTypePagerDuty))
+	assert.Equal(t, 1, store.CountByType(AlertTypeSlack))
+}
+
+func TestInMemoryAlertStore_CountSuccessful(t *testing.T) {
+	store := NewInMemoryAlertStore()
+
+	store.Record(AlertRecord{AlertType: AlertTypePagerDuty, TenantID: "t1", Success: true})
+	store.Record(AlertRecord{AlertType: AlertTypeSlack, TenantID: "t2", Success: false})
+	store.Record(AlertRecord{AlertType: AlertTypePagerDuty, TenantID: "t3", Success: true})
+
+	assert.Equal(t, 2, store.CountSuccessful())
+}
+
+func TestInMemoryAlertStore_Clear(t *testing.T) {
+	store := NewInMemoryAlertStore()
+
+	store.Record(AlertRecord{AlertType: AlertTypePagerDuty, TenantID: "t1"})
+	store.Record(AlertRecord{AlertType: AlertTypeSlack, TenantID: "t2"})
+
+	assert.Equal(t, 2, store.Count())
+
+	store.Clear()
+
+	assert.Equal(t, 0, store.Count())
+}
+
+func TestInMemoryAlertStore_FindByTenantID(t *testing.T) {
+	store := NewInMemoryAlertStore()
+
+	store.Record(AlertRecord{AlertType: AlertTypePagerDuty, TenantID: "tenant-a"})
+	store.Record(AlertRecord{AlertType: AlertTypeSlack, TenantID: "tenant-b"})
+	store.Record(AlertRecord{AlertType: AlertTypePagerDuty, TenantID: "tenant-a"})
+
+	records := store.FindByTenantID("tenant-a")
+	require.Len(t, records, 2)
+	for _, r := range records {
+		assert.Equal(t, "tenant-a", r.TenantID)
+	}
+
+	records = store.FindByTenantID("tenant-b")
+	require.Len(t, records, 1)
+	assert.Equal(t, "tenant-b", records[0].TenantID)
+
+	records = store.FindByTenantID("nonexistent")
+	assert.Empty(t, records)
+}
+
+func TestInMemoryAlertStore_RecordsCopy(t *testing.T) {
+	store := NewInMemoryAlertStore()
+
+	store.Record(AlertRecord{AlertType: AlertTypePagerDuty, TenantID: "t1"})
+
+	// Get records
+	records := store.Records()
+	require.Len(t, records, 1)
+
+	// Modify the returned slice
+	records[0].TenantID = "modified"
+
+	// Original should be unchanged
+	originalRecords := store.Records()
+	assert.Equal(t, "t1", originalRecords[0].TenantID)
+}
+
+// =============================================================================
+// MockPagerDutyClient Tests
+// =============================================================================
+
+func TestMockPagerDutyClient_TriggerAlert(t *testing.T) {
+	mock := NewMockPagerDutyClient(true)
+
+	ctx := context.Background()
+	customDetails := map[string]any{
+		"tenant_id":    "test-tenant-123",
+		"display_name": "Test Tenant",
+	}
+
+	err := mock.TriggerAlert(ctx, "Test summary", "dedup-key", "critical", customDetails)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, mock.Calls())
+	records := mock.Store().Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, "test-tenant-123", records[0].TenantID)
+	assert.Equal(t, "Test summary", records[0].Payload.Summary)
+	assert.Equal(t, "dedup-key", records[0].Payload.DedupKey)
+	assert.Equal(t, "critical", records[0].Payload.Severity)
+	assert.True(t, records[0].Success)
+}
+
+func TestMockPagerDutyClient_SetFailNext(t *testing.T) {
+	mock := NewMockPagerDutyClient(true)
+	testErr := mockErr("simulated PagerDuty error")
+
+	mock.SetFailNext(testErr)
+
+	ctx := context.Background()
+	err := mock.TriggerAlert(ctx, "Test", "key", "warning", nil)
+	require.Error(t, err)
+	assert.Equal(t, testErr, err)
+
+	// Next call should succeed
+	err = mock.TriggerAlert(ctx, "Test2", "key2", "info", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, mock.Calls())
+	// Only one successful record
+	assert.Equal(t, 1, mock.Store().Count())
+}
+
+func TestMockPagerDutyClient_IsEnabled(t *testing.T) {
+	enabledMock := NewMockPagerDutyClient(true)
+	disabledMock := NewMockPagerDutyClient(false)
+
+	assert.True(t, enabledMock.IsEnabled())
+	assert.False(t, disabledMock.IsEnabled())
+}
+
+func TestMockPagerDutyClient_Reset(t *testing.T) {
+	mock := NewMockPagerDutyClient(true)
+
+	ctx := context.Background()
+	_ = mock.TriggerAlert(ctx, "Test", "key", "info", nil)
+	mock.SetFailNext(mockErr("error"))
+
+	assert.Equal(t, 1, mock.Calls())
+	assert.Equal(t, 1, mock.Store().Count())
+
+	mock.Reset()
+
+	assert.Equal(t, 0, mock.Calls())
+	assert.Equal(t, 0, mock.Store().Count())
+}
+
+func TestMockPagerDutyClient_WithSharedStore(t *testing.T) {
+	sharedStore := NewInMemoryAlertStore()
+
+	mock1 := NewMockPagerDutyClient(true, WithMockPagerDutyStore(sharedStore))
+	mock2 := NewMockPagerDutyClient(true, WithMockPagerDutyStore(sharedStore))
+
+	ctx := context.Background()
+	_ = mock1.TriggerAlert(ctx, "Alert 1", "key1", "critical", nil)
+	_ = mock2.TriggerAlert(ctx, "Alert 2", "key2", "warning", nil)
+
+	// Both should share the same store
+	assert.Equal(t, 2, sharedStore.Count())
+	assert.Equal(t, 2, mock1.Store().Count())
+	assert.Equal(t, 2, mock2.Store().Count())
+}
+
+// =============================================================================
+// MockSlackNotifier Tests
+// =============================================================================
+
+func TestMockSlackNotifier_NotifyProvisioningFailure(t *testing.T) {
+	mock := NewMockSlackNotifier(true)
+
+	ctx := context.Background()
+	tenant := &domain.Tenant{
+		ID:           tenant.TenantID("slack-test-tenant"),
+		DisplayName:  "Slack Test Tenant",
+		Status:       domain.StatusProvisioningFailed,
+		ErrorMessage: "Test error message",
+	}
+
+	err := mock.NotifyProvisioningFailure(ctx, tenant)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, mock.Calls())
+	records := mock.Store().Records()
+	require.Len(t, records, 1)
+	assert.Equal(t, AlertTypeSlack, records[0].AlertType)
+	assert.Equal(t, "slack-test-tenant", records[0].TenantID)
+	assert.True(t, records[0].Success)
+}
+
+func TestMockSlackNotifier_SetFailNext(t *testing.T) {
+	mock := NewMockSlackNotifier(true)
+	testErr := mockErr("simulated Slack error")
+
+	mock.SetFailNext(testErr)
+
+	ctx := context.Background()
+	tenant := &domain.Tenant{
+		ID:          tenant.TenantID("test-tenant"),
+		DisplayName: "Test",
+	}
+
+	err := mock.NotifyProvisioningFailure(ctx, tenant)
+	require.Error(t, err)
+	assert.Equal(t, testErr, err)
+
+	// Next call should succeed
+	err = mock.NotifyProvisioningFailure(ctx, tenant)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, mock.Calls())
+	// Only one successful record
+	assert.Equal(t, 1, mock.Store().Count())
+}
+
+func TestMockSlackNotifier_IsEnabled(t *testing.T) {
+	enabledMock := NewMockSlackNotifier(true)
+	disabledMock := NewMockSlackNotifier(false)
+
+	assert.True(t, enabledMock.IsEnabled())
+	assert.False(t, disabledMock.IsEnabled())
+}
+
+func TestMockSlackNotifier_Reset(t *testing.T) {
+	mock := NewMockSlackNotifier(true)
+
+	ctx := context.Background()
+	tenant := &domain.Tenant{
+		ID:          tenant.TenantID("test"),
+		DisplayName: "Test",
+	}
+	_ = mock.NotifyProvisioningFailure(ctx, tenant)
+	mock.SetFailNext(mockErr("error"))
+
+	assert.Equal(t, 1, mock.Calls())
+	assert.Equal(t, 1, mock.Store().Count())
+
+	mock.Reset()
+
+	assert.Equal(t, 0, mock.Calls())
+	assert.Equal(t, 0, mock.Store().Count())
+}
+
+func TestMockSlackNotifier_WithSharedStore(t *testing.T) {
+	sharedStore := NewInMemoryAlertStore()
+
+	mock1 := NewMockSlackNotifier(true, WithMockSlackStore(sharedStore))
+	mock2 := NewMockSlackNotifier(true, WithMockSlackStore(sharedStore))
+
+	ctx := context.Background()
+	tenant := &domain.Tenant{
+		ID:          tenant.TenantID("test"),
+		DisplayName: "Test",
+	}
+	_ = mock1.NotifyProvisioningFailure(ctx, tenant)
+	_ = mock2.NotifyProvisioningFailure(ctx, tenant)
+
+	// Both should share the same store
+	assert.Equal(t, 2, sharedStore.Count())
+}
+
+// =============================================================================
+// Concurrent Access Tests
+// =============================================================================
+
+func TestInMemoryAlertStore_ConcurrentAccess(t *testing.T) {
+	store := NewInMemoryAlertStore()
+	const goroutines = 100
+
+	done := make(chan bool)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			store.Record(AlertRecord{
+				AlertType: AlertTypePagerDuty,
+				TenantID:  "tenant",
+			})
+			done <- true
+		}()
+	}
+
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+
+	assert.Equal(t, goroutines, store.Count())
+}
+
+func TestMockPagerDutyClient_ConcurrentTriggerAlert(t *testing.T) {
+	mock := NewMockPagerDutyClient(true)
+	const goroutines = 50
+
+	done := make(chan bool)
+	ctx := context.Background()
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			_ = mock.TriggerAlert(ctx, "Summary", "key", "info", nil)
+			done <- true
+		}()
+	}
+
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+
+	assert.Equal(t, goroutines, mock.Calls())
+	assert.Equal(t, goroutines, mock.Store().Count())
+}
+
+func TestMockSlackNotifier_ConcurrentNotify(t *testing.T) {
+	mock := NewMockSlackNotifier(true)
+	const goroutines = 50
+
+	done := make(chan bool)
+	ctx := context.Background()
+	tenant := &domain.Tenant{
+		ID:          tenant.TenantID("test"),
+		DisplayName: "Test",
+	}
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			_ = mock.NotifyProvisioningFailure(ctx, tenant)
+			done <- true
+		}()
+	}
+
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+
+	assert.Equal(t, goroutines, mock.Calls())
+	assert.Equal(t, goroutines, mock.Store().Count())
+}

--- a/services/tenant/worker/alerting_test.go
+++ b/services/tenant/worker/alerting_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -430,7 +431,17 @@ func TestCheckFailedProvisioningAlerts_SlackErrorHandling(t *testing.T) {
 		Logger:     logger,
 	})
 
-	am := NewAlertManager(repo, logger, WithSlackNotifier(slackNotifier))
+	// Use no-retry config to preserve original test behavior (fast test)
+	retryConfig := config.AlertRetryConfig{
+		MaxRetries:     0, // No retries - just initial attempt
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+	}
+
+	am := NewAlertManager(repo, logger,
+		WithSlackNotifier(slackNotifier),
+		WithRetryConfig(retryConfig),
+	)
 
 	ctx := context.Background()
 
@@ -582,7 +593,17 @@ func TestCheckFailedProvisioningAlerts_PagerDutyError_ContinuesProcessing(t *tes
 	var logBuf safeBuffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	am := NewAlertManager(repo, logger, WithPagerDutyClient(pdClient))
+	// Use no-retry config to preserve original test behavior
+	retryConfig := config.AlertRetryConfig{
+		MaxRetries:     0, // No retries - just initial attempt
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+	}
+
+	am := NewAlertManager(repo, logger,
+		WithPagerDutyClient(pdClient),
+		WithRetryConfig(retryConfig),
+	)
 
 	ctx := context.Background()
 
@@ -609,7 +630,7 @@ func TestCheckFailedProvisioningAlerts_PagerDutyError_ContinuesProcessing(t *tes
 	err := am.CheckFailedProvisioningAlerts(ctx, threshold)
 	require.NoError(t, err)
 
-	// Should have attempted to send alerts for both tenants
+	// Should have attempted to send alerts for both tenants (1 attempt each, no retries)
 	assert.Equal(t, 2, callCount)
 
 	// Should have logged the errors
@@ -715,4 +736,440 @@ func TestCheckFailedProvisioningAlerts_TruncatesLongErrorMessage(t *testing.T) {
 
 	// Verify the full error message is still in custom_details
 	assert.Equal(t, longErrorMsg, receivedEvent.Payload.CustomDetails["error_message"])
+}
+
+// =============================================================================
+// Rate Limiting Integration Tests
+// =============================================================================
+
+func TestCheckFailedProvisioningAlerts_RateLimiting(t *testing.T) {
+	db, repo := setupTestDB(t)
+
+	// Create 15 failed tenants
+	ctx := context.Background()
+	for i := 1; i <= 15; i++ {
+		tenant := &domain.Tenant{
+			ID:              tenant.TenantID(fmt.Sprintf("rate_limit_tenant_%d", i)),
+			DisplayName:     fmt.Sprintf("Tenant %d", i),
+			SettlementAsset: "USD",
+			Status:          domain.StatusProvisioningFailed,
+			ErrorMessage:    "test error",
+			CreatedAt:       time.Now().Add(-2 * time.Hour),
+			Version:         1,
+		}
+		err := repo.Create(ctx, tenant)
+		require.NoError(t, err)
+		err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", tenant.ID.String()).Error
+		require.NoError(t, err)
+	}
+
+	// Track received PagerDuty events
+	var receivedCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		receivedCount++
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer server.Close()
+
+	pdClient := clients.NewPagerDutyClient(
+		config.PagerDutyConfig{
+			Enabled:    true,
+			RoutingKey: "test-key",
+			Source:     "test-source",
+		},
+		clients.WithEventsURL(server.URL),
+	)
+
+	// Create rate limiter with max 10 alerts per minute
+	rateLimiter := NewAlertRateLimiter(10, 10)
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	am := NewAlertManager(repo, logger,
+		WithPagerDutyClient(pdClient),
+		WithRateLimiter(rateLimiter),
+	)
+
+	threshold := 1 * time.Hour
+	err := am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Should have sent exactly 10 alerts (rate limited the rest)
+	assert.Equal(t, 10, receivedCount)
+
+	// Should have rate limit warnings in logs
+	logs := logBuf.String()
+	assert.Contains(t, logs, "rate limited")
+}
+
+func TestCheckFailedProvisioningAlerts_RateLimitMetric(t *testing.T) {
+	db, repo := setupTestDB(t)
+
+	// Create 5 failed tenants
+	ctx := context.Background()
+	for i := 1; i <= 5; i++ {
+		tenant := &domain.Tenant{
+			ID:              tenant.TenantID(fmt.Sprintf("metric_tenant_%d", i)),
+			DisplayName:     fmt.Sprintf("Tenant %d", i),
+			SettlementAsset: "USD",
+			Status:          domain.StatusProvisioningFailed,
+			ErrorMessage:    "test error",
+			CreatedAt:       time.Now().Add(-2 * time.Hour),
+			Version:         1,
+		}
+		err := repo.Create(ctx, tenant)
+		require.NoError(t, err)
+		err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", tenant.ID.String()).Error
+		require.NoError(t, err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer server.Close()
+
+	pdClient := clients.NewPagerDutyClient(
+		config.PagerDutyConfig{
+			Enabled:    true,
+			RoutingKey: "test-key",
+			Source:     "test-source",
+		},
+		clients.WithEventsURL(server.URL),
+	)
+
+	// Track rate limit hits
+	var rateLimitHits int
+	rateLimiter := NewAlertRateLimiter(3, 3, WithRateLimitCallback(func(_ string) {
+		rateLimitHits++
+	}))
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	am := NewAlertManager(repo, logger,
+		WithPagerDutyClient(pdClient),
+		WithRateLimiter(rateLimiter),
+	)
+
+	threshold := 1 * time.Hour
+	err := am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Should have 2 rate limit hits (5 tenants - 3 allowed = 2 blocked)
+	assert.Equal(t, 2, rateLimitHits)
+}
+
+// =============================================================================
+// Retry Logic Integration Tests
+// =============================================================================
+
+func TestCheckFailedProvisioningAlerts_RetryOnFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping timing-sensitive test in short mode")
+	}
+
+	db, repo := setupTestDB(t)
+
+	ctx := context.Background()
+	tenant := &domain.Tenant{
+		ID:              tenant.TenantID("retry_test_tenant"),
+		DisplayName:     "Retry Test Tenant",
+		SettlementAsset: "USD",
+		Status:          domain.StatusProvisioningFailed,
+		ErrorMessage:    "test error",
+		CreatedAt:       time.Now().Add(-2 * time.Hour),
+		Version:         1,
+	}
+	err := repo.Create(ctx, tenant)
+	require.NoError(t, err)
+	err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", tenant.ID.String()).Error
+	require.NoError(t, err)
+
+	// Create a server that fails twice then succeeds
+	var attemptCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attemptCount++
+		if attemptCount < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"status":"error","message":"server error"}`))
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer server.Close()
+
+	pdClient := clients.NewPagerDutyClient(
+		config.PagerDutyConfig{
+			Enabled:    true,
+			RoutingKey: "test-key",
+			Source:     "test-source",
+		},
+		clients.WithEventsURL(server.URL),
+	)
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Use fast retry config for tests
+	retryConfig := config.AlertRetryConfig{
+		MaxRetries:     4,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+	}
+
+	am := NewAlertManager(repo, logger,
+		WithPagerDutyClient(pdClient),
+		WithRetryConfig(retryConfig),
+	)
+
+	threshold := 1 * time.Hour
+	err = am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Server should have been called 3 times (2 failures + 1 success)
+	assert.Equal(t, 3, attemptCount)
+
+	// Logs should show retry attempts
+	logs := logBuf.String()
+	assert.Contains(t, logs, "attempt failed")
+}
+
+func TestCheckFailedProvisioningAlerts_RetryExhausted_SendsToDLQ(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping timing-sensitive test in short mode")
+	}
+
+	db, repo := setupTestDB(t)
+
+	ctx := context.Background()
+	tenant := &domain.Tenant{
+		ID:              tenant.TenantID("dlq_test_tenant"),
+		DisplayName:     "DLQ Test Tenant",
+		SettlementAsset: "GBP",
+		Status:          domain.StatusProvisioningFailed,
+		ErrorMessage:    "test error for DLQ",
+		CreatedAt:       time.Now().Add(-2 * time.Hour),
+		Version:         1,
+	}
+	err := repo.Create(ctx, tenant)
+	require.NoError(t, err)
+	err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", tenant.ID.String()).Error
+	require.NoError(t, err)
+
+	// Create a server that always fails
+	var attemptCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attemptCount++
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"status":"error","message":"persistent failure"}`))
+	}))
+	defer server.Close()
+
+	pdClient := clients.NewPagerDutyClient(
+		config.PagerDutyConfig{
+			Enabled:    true,
+			RoutingKey: "test-key",
+			Source:     "test-source",
+		},
+		clients.WithEventsURL(server.URL),
+	)
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Use fast retry config with 4 retries
+	retryConfig := config.AlertRetryConfig{
+		MaxRetries:     4,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+	}
+
+	dlq := NewAlertDeadLetterQueue()
+
+	am := NewAlertManager(repo, logger,
+		WithPagerDutyClient(pdClient),
+		WithRetryConfig(retryConfig),
+		WithDeadLetterQueue(dlq),
+	)
+
+	threshold := 1 * time.Hour
+	err = am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Server should have been called 5 times (initial + 4 retries)
+	assert.Equal(t, 5, attemptCount)
+
+	// Alert should be in DLQ
+	assert.Equal(t, 1, dlq.Len())
+
+	alerts := dlq.List()
+	assert.Equal(t, AlertTypePagerDuty, alerts[0].AlertType)
+	assert.Equal(t, "dlq_test_tenant", alerts[0].TenantID)
+	assert.Contains(t, alerts[0].ErrorMessage, "error")
+	assert.Equal(t, 5, alerts[0].AttemptCount)
+
+	// Logs should indicate DLQ storage
+	logs := logBuf.String()
+	assert.Contains(t, logs, "sent to DLQ")
+}
+
+// =============================================================================
+// DLQ Integration Tests
+// =============================================================================
+
+func TestCheckFailedProvisioningAlerts_NoDLQ_OnlyLogsError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping timing-sensitive test in short mode")
+	}
+
+	db, repo := setupTestDB(t)
+
+	ctx := context.Background()
+	tenant := &domain.Tenant{
+		ID:              tenant.TenantID("no_dlq_tenant"),
+		DisplayName:     "No DLQ Tenant",
+		SettlementAsset: "EUR",
+		Status:          domain.StatusProvisioningFailed,
+		ErrorMessage:    "error without dlq",
+		CreatedAt:       time.Now().Add(-2 * time.Hour),
+		Version:         1,
+	}
+	err := repo.Create(ctx, tenant)
+	require.NoError(t, err)
+	err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", tenant.ID.String()).Error
+	require.NoError(t, err)
+
+	// Always-failing server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"status":"error"}`))
+	}))
+	defer server.Close()
+
+	pdClient := clients.NewPagerDutyClient(
+		config.PagerDutyConfig{
+			Enabled:    true,
+			RoutingKey: "test-key",
+			Source:     "test-source",
+		},
+		clients.WithEventsURL(server.URL),
+	)
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	retryConfig := config.AlertRetryConfig{
+		MaxRetries:     1,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+	}
+
+	// No DLQ configured
+	am := NewAlertManager(repo, logger,
+		WithPagerDutyClient(pdClient),
+		WithRetryConfig(retryConfig),
+	)
+
+	threshold := 1 * time.Hour
+	err = am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Should log the final error but not crash
+	logs := logBuf.String()
+	assert.Contains(t, logs, "failed to send PagerDuty alert after retries")
+	// Should NOT contain DLQ message since DLQ is not configured
+	assert.NotContains(t, logs, "sent to DLQ")
+}
+
+func TestAlertManager_DeadLetterQueue_Accessor(t *testing.T) {
+	_, repo := setupTestDB(t)
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	t.Run("returns nil when not configured", func(t *testing.T) {
+		am := NewAlertManager(repo, logger)
+		assert.Nil(t, am.DeadLetterQueue())
+	})
+
+	t.Run("returns DLQ when configured", func(t *testing.T) {
+		dlq := NewAlertDeadLetterQueue()
+		am := NewAlertManager(repo, logger, WithDeadLetterQueue(dlq))
+		assert.Equal(t, dlq, am.DeadLetterQueue())
+	})
+}
+
+func TestCheckFailedProvisioningAlerts_SlackWithRetryAndDLQ(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping timing-sensitive test in short mode")
+	}
+
+	db, repo := setupTestDB(t)
+
+	ctx := context.Background()
+	tenant := &domain.Tenant{
+		ID:              tenant.TenantID("slack_dlq_tenant"),
+		DisplayName:     "Slack DLQ Tenant",
+		SettlementAsset: "USD",
+		Status:          domain.StatusProvisioningFailed,
+		ErrorMessage:    "slack test error",
+		CreatedAt:       time.Now().Add(-2 * time.Hour),
+		Version:         1,
+	}
+	err := repo.Create(ctx, tenant)
+	require.NoError(t, err)
+	err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", tenant.ID.String()).Error
+	require.NoError(t, err)
+
+	// Always-failing Slack server
+	var slackAttempts int
+	slackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		slackAttempts++
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer slackServer.Close()
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	slackNotifier := notifier.NewSlackNotifier(notifier.SlackNotifierConfig{
+		Config: config.SlackConfig{
+			Enabled:     true,
+			WebhookURL:  slackServer.URL,
+			ServiceName: "tenant-service",
+		},
+		HTTPClient: slackServer.Client(),
+		Logger:     logger,
+	})
+
+	retryConfig := config.AlertRetryConfig{
+		MaxRetries:     2,
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     50 * time.Millisecond,
+	}
+
+	dlq := NewAlertDeadLetterQueue()
+
+	am := NewAlertManager(repo, logger,
+		WithSlackNotifier(slackNotifier),
+		WithRetryConfig(retryConfig),
+		WithDeadLetterQueue(dlq),
+	)
+
+	threshold := 1 * time.Hour
+	err = am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Should have attempted 3 times (initial + 2 retries)
+	assert.Equal(t, 3, slackAttempts)
+
+	// Should be in DLQ
+	assert.Equal(t, 1, dlq.Len())
+	alerts := dlq.List()
+	assert.Equal(t, AlertTypeSlack, alerts[0].AlertType)
+	assert.Equal(t, "slack_dlq_tenant", alerts[0].TenantID)
 }

--- a/services/tenant/worker/alerting_test.go
+++ b/services/tenant/worker/alerting_test.go
@@ -3,13 +3,20 @@ package worker
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
+	"github.com/meridianhub/meridian/services/tenant/clients"
+	"github.com/meridianhub/meridian/services/tenant/config"
 	"github.com/meridianhub/meridian/services/tenant/domain"
+	"github.com/meridianhub/meridian/services/tenant/notifier"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -312,4 +319,400 @@ func TestCheckFailedProvisioningAlerts_LogsContainAlertLabel(t *testing.T) {
 		strings.Contains(logs, "alert=tenant_provisioning_failed") ||
 			strings.Contains(logs, `alert="tenant_provisioning_failed"`),
 		"logs should contain alert label")
+}
+
+func TestNewAlertManager_WithSlackNotifier(t *testing.T) {
+	_, repo := setupTestDB(t)
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+
+	slackNotifier := notifier.NewSlackNotifier(notifier.SlackNotifierConfig{
+		Config: config.SlackConfig{
+			Enabled:     true,
+			WebhookURL:  "https://hooks.slack.com/services/test",
+			ServiceName: "test-service",
+		},
+	})
+
+	am := NewAlertManager(repo, logger, WithSlackNotifier(slackNotifier))
+
+	require.NotNil(t, am)
+	assert.NotNil(t, am.slackNotifier)
+}
+
+func TestCheckFailedProvisioningAlerts_WithSlackNotifier(t *testing.T) {
+	db, repo := setupTestDB(t)
+
+	// Create a mock Slack server
+	var receivedPayloads []map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]interface{}
+		_ = json.Unmarshal(body, &payload)
+		receivedPayloads = append(receivedPayloads, payload)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	slackNotifier := notifier.NewSlackNotifier(notifier.SlackNotifierConfig{
+		Config: config.SlackConfig{
+			Enabled:     true,
+			WebhookURL:  server.URL,
+			ServiceName: "tenant-service",
+		},
+		HTTPClient: server.Client(),
+		Logger:     logger,
+	})
+
+	am := NewAlertManager(repo, logger, WithSlackNotifier(slackNotifier))
+
+	ctx := context.Background()
+
+	// Create a failed tenant
+	failedTenant := &domain.Tenant{
+		ID:              tenant.TenantID("slack_test_tenant"),
+		DisplayName:     "Slack Test Tenant",
+		SettlementAsset: "USD",
+		Status:          domain.StatusProvisioningFailed,
+		ErrorMessage:    "database connection timeout",
+		CreatedAt:       time.Now().Add(-2 * time.Hour),
+		Version:         1,
+	}
+	err := repo.Create(ctx, failedTenant)
+	require.NoError(t, err)
+	err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", failedTenant.ID.String()).Error
+	require.NoError(t, err)
+
+	threshold := 1 * time.Hour
+
+	err = am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Verify Slack received the alert
+	require.Len(t, receivedPayloads, 1, "Slack should receive exactly one alert")
+
+	payload := receivedPayloads[0]
+	assert.Contains(t, payload["text"].(string), "slack_test_tenant")
+	assert.Contains(t, payload["text"].(string), "Tenant Provisioning Failed")
+
+	// Verify blocks structure
+	blocks, ok := payload["blocks"].([]interface{})
+	require.True(t, ok, "blocks should be an array")
+	assert.GreaterOrEqual(t, len(blocks), 2, "should have at least header and details blocks")
+
+	// Verify success log
+	logs := logBuf.String()
+	assert.Contains(t, logs, "slack alert sent successfully")
+}
+
+func TestCheckFailedProvisioningAlerts_SlackErrorHandling(t *testing.T) {
+	db, repo := setupTestDB(t)
+
+	// Create a mock Slack server that returns errors
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	slackNotifier := notifier.NewSlackNotifier(notifier.SlackNotifierConfig{
+		Config: config.SlackConfig{
+			Enabled:     true,
+			WebhookURL:  server.URL,
+			ServiceName: "tenant-service",
+		},
+		HTTPClient: server.Client(),
+		Logger:     logger,
+	})
+
+	am := NewAlertManager(repo, logger, WithSlackNotifier(slackNotifier))
+
+	ctx := context.Background()
+
+	// Create a failed tenant
+	failedTenant := &domain.Tenant{
+		ID:              tenant.TenantID("slack_error_tenant"),
+		DisplayName:     "Slack Error Tenant",
+		SettlementAsset: "GBP",
+		Status:          domain.StatusProvisioningFailed,
+		ErrorMessage:    "test error",
+		CreatedAt:       time.Now().Add(-2 * time.Hour),
+		Version:         1,
+	}
+	err := repo.Create(ctx, failedTenant)
+	require.NoError(t, err)
+	err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", failedTenant.ID.String()).Error
+	require.NoError(t, err)
+
+	threshold := 1 * time.Hour
+
+	// CheckFailedProvisioningAlerts should NOT return error even if Slack fails
+	// (Slack failures are logged but don't block the alert loop)
+	err = am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Verify error was logged
+	logs := logBuf.String()
+	assert.Contains(t, logs, "failed to send Slack alert")
+	assert.Contains(t, logs, "slack_error_tenant")
+}
+
+// =============================================================================
+// PagerDuty Integration Tests
+// =============================================================================
+
+func TestNewAlertManager_WithPagerDutyClient(t *testing.T) {
+	_, repo := setupTestDB(t)
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+
+	pdClient := clients.NewPagerDutyClient(config.PagerDutyConfig{
+		Enabled:    true,
+		RoutingKey: "test-key",
+		Source:     "test-source",
+	})
+
+	am := NewAlertManager(repo, logger, WithPagerDutyClient(pdClient))
+
+	require.NotNil(t, am)
+	assert.Equal(t, pdClient, am.pagerdutyClient)
+}
+
+func TestCheckFailedProvisioningAlerts_SendsPagerDutyAlert(t *testing.T) {
+	db, repo := setupTestDB(t)
+
+	// Track received PagerDuty events
+	var receivedEvents []clients.PagerDutyEvent
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		var event clients.PagerDutyEvent
+		err = json.Unmarshal(body, &event)
+		require.NoError(t, err)
+		receivedEvents = append(receivedEvents, event)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"status":"success","message":"Event processed"}`))
+	}))
+	defer server.Close()
+
+	// Create PagerDuty client with test server
+	pdClient := clients.NewPagerDutyClient(
+		config.PagerDutyConfig{
+			Enabled:    true,
+			RoutingKey: "test-routing-key",
+			Source:     "tenant-service-test",
+		},
+		clients.WithEventsURL(server.URL),
+	)
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	am := NewAlertManager(repo, logger, WithPagerDutyClient(pdClient))
+
+	ctx := context.Background()
+
+	// Create a failed tenant
+	failedTenant := &domain.Tenant{
+		ID:              tenant.TenantID("pd_test_tenant"),
+		DisplayName:     "PagerDuty Test Tenant",
+		SettlementAsset: "USD",
+		Status:          domain.StatusProvisioningFailed,
+		ErrorMessage:    "database schema creation failed",
+		CreatedAt:       time.Now().Add(-2 * time.Hour),
+		Version:         1,
+	}
+	err := repo.Create(ctx, failedTenant)
+	require.NoError(t, err)
+	err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", failedTenant.ID.String()).Error
+	require.NoError(t, err)
+
+	threshold := 1 * time.Hour
+
+	err = am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Verify PagerDuty was called
+	require.Len(t, receivedEvents, 1)
+
+	event := receivedEvents[0]
+	assert.Equal(t, "test-routing-key", event.RoutingKey)
+	assert.Equal(t, clients.EventActionTrigger, event.EventAction)
+	assert.Contains(t, event.DedupKey, "tenant-provisioning-failed-pd_test_tenant")
+	assert.Contains(t, event.Payload.Summary, "pd_test_tenant")
+	assert.Contains(t, event.Payload.Summary, "database schema creation failed")
+	assert.Equal(t, "critical", event.Payload.Severity)
+	assert.Equal(t, "tenant-service-test", event.Payload.Source)
+
+	// Verify custom details
+	customDetails := event.Payload.CustomDetails
+	assert.Equal(t, "pd_test_tenant", customDetails["tenant_id"])
+	assert.Equal(t, "PagerDuty Test Tenant", customDetails["display_name"])
+	assert.Equal(t, "provisioning_failed", customDetails["status"])
+	assert.Equal(t, "database schema creation failed", customDetails["error_message"])
+}
+
+func TestCheckFailedProvisioningAlerts_PagerDutyError_ContinuesProcessing(t *testing.T) {
+	db, repo := setupTestDB(t)
+
+	// Create a server that returns errors
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"status":"error","message":"Internal server error"}`))
+	}))
+	defer server.Close()
+
+	pdClient := clients.NewPagerDutyClient(
+		config.PagerDutyConfig{
+			Enabled:    true,
+			RoutingKey: "test-key",
+			Source:     "test-source",
+		},
+		clients.WithEventsURL(server.URL),
+	)
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	am := NewAlertManager(repo, logger, WithPagerDutyClient(pdClient))
+
+	ctx := context.Background()
+
+	// Create two failed tenants
+	for i := 1; i <= 2; i++ {
+		tenantObj := &domain.Tenant{
+			ID:              tenant.TenantID("pd_tenant_" + string(rune('a'+i-1))),
+			DisplayName:     "Test Tenant",
+			SettlementAsset: "USD",
+			Status:          domain.StatusProvisioningFailed,
+			ErrorMessage:    "error",
+			CreatedAt:       time.Now().Add(-2 * time.Hour),
+			Version:         1,
+		}
+		err := repo.Create(ctx, tenantObj)
+		require.NoError(t, err)
+		err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", tenantObj.ID.String()).Error
+		require.NoError(t, err)
+	}
+
+	threshold := 1 * time.Hour
+
+	// Should not return an error even when PagerDuty fails
+	err := am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Should have attempted to send alerts for both tenants
+	assert.Equal(t, 2, callCount)
+
+	// Should have logged the errors
+	logs := logBuf.String()
+	assert.Contains(t, logs, "failed to send PagerDuty alert")
+}
+
+func TestCheckFailedProvisioningAlerts_NoPagerDutyClient_LogsOnly(t *testing.T) {
+	db, repo := setupTestDB(t)
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Create AlertManager without PagerDuty client
+	am := NewAlertManager(repo, logger)
+
+	ctx := context.Background()
+
+	// Create a failed tenant
+	failedTenant := &domain.Tenant{
+		ID:              tenant.TenantID("log_only_tenant"),
+		DisplayName:     "Log Only Tenant",
+		SettlementAsset: "GBP",
+		Status:          domain.StatusProvisioningFailed,
+		ErrorMessage:    "test error",
+		CreatedAt:       time.Now().Add(-2 * time.Hour),
+		Version:         1,
+	}
+	err := repo.Create(ctx, failedTenant)
+	require.NoError(t, err)
+	err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", failedTenant.ID.String()).Error
+	require.NoError(t, err)
+
+	threshold := 1 * time.Hour
+
+	err = am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Should log the alert
+	logs := logBuf.String()
+	assert.Contains(t, logs, "tenant provisioning failure alert")
+	assert.Contains(t, logs, "log_only_tenant")
+
+	// Should NOT attempt to send PagerDuty alert (no error logs about PagerDuty)
+	assert.NotContains(t, logs, "failed to send PagerDuty alert")
+}
+
+func TestCheckFailedProvisioningAlerts_TruncatesLongErrorMessage(t *testing.T) {
+	db, repo := setupTestDB(t)
+
+	var receivedEvent clients.PagerDutyEvent
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		err = json.Unmarshal(body, &receivedEvent)
+		require.NoError(t, err)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"status":"success"}`))
+	}))
+	defer server.Close()
+
+	pdClient := clients.NewPagerDutyClient(
+		config.PagerDutyConfig{
+			Enabled:    true,
+			RoutingKey: "test-key",
+			Source:     "test-source",
+		},
+		clients.WithEventsURL(server.URL),
+	)
+
+	var logBuf safeBuffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	am := NewAlertManager(repo, logger, WithPagerDutyClient(pdClient))
+
+	ctx := context.Background()
+
+	// Create a tenant with a very long error message (>200 chars)
+	longErrorMsg := strings.Repeat("x", 300)
+	failedTenant := &domain.Tenant{
+		ID:              tenant.TenantID("long_error_tenant"),
+		DisplayName:     "Long Error Tenant",
+		SettlementAsset: "USD",
+		Status:          domain.StatusProvisioningFailed,
+		ErrorMessage:    longErrorMsg,
+		CreatedAt:       time.Now().Add(-2 * time.Hour),
+		Version:         1,
+	}
+	err := repo.Create(ctx, failedTenant)
+	require.NoError(t, err)
+	err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", failedTenant.ID.String()).Error
+	require.NoError(t, err)
+
+	threshold := 1 * time.Hour
+
+	err = am.CheckFailedProvisioningAlerts(ctx, threshold)
+	require.NoError(t, err)
+
+	// Verify the summary was truncated (should end with "...")
+	assert.LessOrEqual(t, len(receivedEvent.Payload.Summary), 300, "summary should be truncated")
+	assert.Contains(t, receivedEvent.Payload.Summary, "...")
+
+	// Verify the full error message is still in custom_details
+	assert.Equal(t, longErrorMsg, receivedEvent.Payload.CustomDetails["error_message"])
 }

--- a/services/tenant/worker/alerting_test.go
+++ b/services/tenant/worker/alerting_test.go
@@ -748,7 +748,7 @@ func TestCheckFailedProvisioningAlerts_RateLimiting(t *testing.T) {
 	// Create 15 failed tenants
 	ctx := context.Background()
 	for i := 1; i <= 15; i++ {
-		tenant := &domain.Tenant{
+		testTenant := &domain.Tenant{
 			ID:              tenant.TenantID(fmt.Sprintf("rate_limit_tenant_%d", i)),
 			DisplayName:     fmt.Sprintf("Tenant %d", i),
 			SettlementAsset: "USD",
@@ -757,9 +757,9 @@ func TestCheckFailedProvisioningAlerts_RateLimiting(t *testing.T) {
 			CreatedAt:       time.Now().Add(-2 * time.Hour),
 			Version:         1,
 		}
-		err := repo.Create(ctx, tenant)
+		err := repo.Create(ctx, testTenant)
 		require.NoError(t, err)
-		err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", tenant.ID.String()).Error
+		err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", testTenant.ID.String()).Error
 		require.NoError(t, err)
 	}
 
@@ -810,7 +810,7 @@ func TestCheckFailedProvisioningAlerts_RateLimitMetric(t *testing.T) {
 	// Create 5 failed tenants
 	ctx := context.Background()
 	for i := 1; i <= 5; i++ {
-		tenant := &domain.Tenant{
+		testTenant := &domain.Tenant{
 			ID:              tenant.TenantID(fmt.Sprintf("metric_tenant_%d", i)),
 			DisplayName:     fmt.Sprintf("Tenant %d", i),
 			SettlementAsset: "USD",
@@ -819,9 +819,9 @@ func TestCheckFailedProvisioningAlerts_RateLimitMetric(t *testing.T) {
 			CreatedAt:       time.Now().Add(-2 * time.Hour),
 			Version:         1,
 		}
-		err := repo.Create(ctx, tenant)
+		err := repo.Create(ctx, testTenant)
 		require.NoError(t, err)
-		err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", tenant.ID.String()).Error
+		err = db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", testTenant.ID.String()).Error
 		require.NoError(t, err)
 	}
 

--- a/services/tenant/worker/dead_letter_queue.go
+++ b/services/tenant/worker/dead_letter_queue.go
@@ -106,9 +106,11 @@ func (q *AlertDeadLetterQueue) Enqueue(alert FailedAlert) {
 
 	q.alerts = append(q.alerts, alert)
 
-	// Invoke callback outside of lock to prevent deadlocks
+	// Invoke callback outside of lock to prevent deadlocks.
+	// Pass a copy of the alert to avoid race conditions with slice operations.
 	if q.onEnqueue != nil {
-		go q.onEnqueue(alert)
+		alertCopy := alert
+		go q.onEnqueue(alertCopy)
 	}
 }
 

--- a/services/tenant/worker/dead_letter_queue.go
+++ b/services/tenant/worker/dead_letter_queue.go
@@ -1,0 +1,167 @@
+// Package worker implements background workers for tenant provisioning.
+package worker
+
+import (
+	"sync"
+	"time"
+)
+
+// FailedAlert represents an alert that failed after max retries.
+// Stored in the DLQ for manual review and reprocessing.
+type FailedAlert struct {
+	// AlertType identifies the type of alert (e.g., "pagerduty", "slack").
+	AlertType string
+
+	// TenantID is the tenant this alert relates to.
+	TenantID string
+
+	// Payload contains the alert data that was to be sent.
+	Payload AlertPayload
+
+	// ErrorMessage is the last error encountered when sending.
+	ErrorMessage string
+
+	// FirstAttemptAt is when the first attempt was made.
+	FirstAttemptAt time.Time
+
+	// LastAttemptAt is when the final (failed) attempt was made.
+	LastAttemptAt time.Time
+
+	// AttemptCount is the total number of attempts made.
+	AttemptCount int
+}
+
+// AlertPayload contains the data for an alert to be sent.
+type AlertPayload struct {
+	// Summary is the alert summary/title.
+	Summary string
+
+	// DedupKey is used for deduplication.
+	DedupKey string
+
+	// Severity is the alert severity level.
+	Severity string
+
+	// CustomDetails contains additional context.
+	CustomDetails map[string]any
+}
+
+// AlertDeadLetterQueue stores alerts that failed after max retries.
+// Thread-safe for concurrent access from multiple workers.
+type AlertDeadLetterQueue struct {
+	mu     sync.RWMutex
+	alerts []FailedAlert
+
+	// maxSize limits the DLQ size to prevent unbounded growth.
+	// When exceeded, oldest entries are removed.
+	maxSize int
+
+	// onEnqueue is called when an alert is added to the DLQ.
+	// Useful for metrics and alerting.
+	onEnqueue func(alert FailedAlert)
+}
+
+// DLQOption configures the AlertDeadLetterQueue.
+type DLQOption func(*AlertDeadLetterQueue)
+
+// WithDLQMaxSize sets the maximum number of entries in the DLQ.
+func WithDLQMaxSize(size int) DLQOption {
+	return func(q *AlertDeadLetterQueue) {
+		if size > 0 {
+			q.maxSize = size
+		}
+	}
+}
+
+// WithDLQEnqueueCallback sets a callback for when alerts are added to the DLQ.
+func WithDLQEnqueueCallback(fn func(alert FailedAlert)) DLQOption {
+	return func(q *AlertDeadLetterQueue) {
+		q.onEnqueue = fn
+	}
+}
+
+// NewAlertDeadLetterQueue creates a new dead-letter queue for failed alerts.
+func NewAlertDeadLetterQueue(opts ...DLQOption) *AlertDeadLetterQueue {
+	q := &AlertDeadLetterQueue{
+		alerts:  make([]FailedAlert, 0),
+		maxSize: 1000, // Default max size
+	}
+
+	for _, opt := range opts {
+		opt(q)
+	}
+
+	return q
+}
+
+// Enqueue adds a failed alert to the dead-letter queue.
+func (q *AlertDeadLetterQueue) Enqueue(alert FailedAlert) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	// If at max capacity, remove oldest entry
+	if len(q.alerts) >= q.maxSize {
+		q.alerts = q.alerts[1:]
+	}
+
+	q.alerts = append(q.alerts, alert)
+
+	// Invoke callback outside of lock to prevent deadlocks
+	if q.onEnqueue != nil {
+		go q.onEnqueue(alert)
+	}
+}
+
+// List returns all alerts currently in the DLQ.
+// Returns a copy to prevent external modification.
+func (q *AlertDeadLetterQueue) List() []FailedAlert {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	result := make([]FailedAlert, len(q.alerts))
+	copy(result, q.alerts)
+	return result
+}
+
+// Len returns the number of alerts in the DLQ.
+func (q *AlertDeadLetterQueue) Len() int {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	return len(q.alerts)
+}
+
+// Pop removes and returns the oldest alert from the DLQ.
+// Returns nil if the queue is empty.
+func (q *AlertDeadLetterQueue) Pop() *FailedAlert {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if len(q.alerts) == 0 {
+		return nil
+	}
+
+	alert := q.alerts[0]
+	q.alerts = q.alerts[1:]
+	return &alert
+}
+
+// Clear removes all alerts from the DLQ.
+func (q *AlertDeadLetterQueue) Clear() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.alerts = make([]FailedAlert, 0)
+}
+
+// Remove removes an alert at the specified index.
+// Returns true if removed, false if index out of bounds.
+func (q *AlertDeadLetterQueue) Remove(index int) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if index < 0 || index >= len(q.alerts) {
+		return false
+	}
+
+	q.alerts = append(q.alerts[:index], q.alerts[index+1:]...)
+	return true
+}

--- a/services/tenant/worker/dead_letter_queue_test.go
+++ b/services/tenant/worker/dead_letter_queue_test.go
@@ -1,0 +1,243 @@
+package worker
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAlertDeadLetterQueue(t *testing.T) {
+	t.Run("creates with defaults", func(t *testing.T) {
+		dlq := NewAlertDeadLetterQueue()
+		require.NotNil(t, dlq)
+		assert.Equal(t, 1000, dlq.maxSize)
+		assert.Equal(t, 0, dlq.Len())
+	})
+
+	t.Run("creates with custom max size", func(t *testing.T) {
+		dlq := NewAlertDeadLetterQueue(WithDLQMaxSize(50))
+		assert.Equal(t, 50, dlq.maxSize)
+	})
+}
+
+func TestAlertDeadLetterQueue_Enqueue(t *testing.T) {
+	dlq := NewAlertDeadLetterQueue()
+
+	alert := FailedAlert{
+		AlertType:      AlertTypePagerDuty,
+		TenantID:       "tenant-1",
+		Payload:        AlertPayload{Summary: "test alert"},
+		ErrorMessage:   "connection timeout",
+		FirstAttemptAt: time.Now().Add(-5 * time.Minute),
+		LastAttemptAt:  time.Now(),
+		AttemptCount:   4,
+	}
+
+	dlq.Enqueue(alert)
+
+	assert.Equal(t, 1, dlq.Len())
+
+	alerts := dlq.List()
+	require.Len(t, alerts, 1)
+	assert.Equal(t, "tenant-1", alerts[0].TenantID)
+	assert.Equal(t, "connection timeout", alerts[0].ErrorMessage)
+	assert.Equal(t, 4, alerts[0].AttemptCount)
+}
+
+func TestAlertDeadLetterQueue_EnqueueMaxSize(t *testing.T) {
+	dlq := NewAlertDeadLetterQueue(WithDLQMaxSize(3))
+
+	// Add 5 alerts
+	for i := 1; i <= 5; i++ {
+		dlq.Enqueue(FailedAlert{
+			TenantID: string(rune('a' - 1 + i)),
+		})
+	}
+
+	// Should only have last 3
+	assert.Equal(t, 3, dlq.Len())
+
+	alerts := dlq.List()
+	// Oldest (a, b) should have been removed, leaving c, d, e
+	assert.Equal(t, "c", alerts[0].TenantID)
+	assert.Equal(t, "d", alerts[1].TenantID)
+	assert.Equal(t, "e", alerts[2].TenantID)
+}
+
+func TestAlertDeadLetterQueue_EnqueueCallback(t *testing.T) {
+	var receivedAlert FailedAlert
+	callbackCalled := make(chan struct{})
+
+	dlq := NewAlertDeadLetterQueue(WithDLQEnqueueCallback(func(alert FailedAlert) {
+		receivedAlert = alert
+		close(callbackCalled)
+	}))
+
+	alert := FailedAlert{
+		TenantID:     "callback-tenant",
+		ErrorMessage: "test error",
+	}
+
+	dlq.Enqueue(alert)
+
+	// Wait for callback (it's called in a goroutine)
+	select {
+	case <-callbackCalled:
+		assert.Equal(t, "callback-tenant", receivedAlert.TenantID)
+	case <-time.After(1 * time.Second):
+		t.Fatal("callback was not called within timeout")
+	}
+}
+
+func TestAlertDeadLetterQueue_List(t *testing.T) {
+	dlq := NewAlertDeadLetterQueue()
+
+	// Add multiple alerts
+	dlq.Enqueue(FailedAlert{TenantID: "a"})
+	dlq.Enqueue(FailedAlert{TenantID: "b"})
+	dlq.Enqueue(FailedAlert{TenantID: "c"})
+
+	alerts := dlq.List()
+	require.Len(t, alerts, 3)
+
+	// Verify order (FIFO)
+	assert.Equal(t, "a", alerts[0].TenantID)
+	assert.Equal(t, "b", alerts[1].TenantID)
+	assert.Equal(t, "c", alerts[2].TenantID)
+
+	// Verify List returns a copy (modifying doesn't affect queue)
+	alerts[0].TenantID = "modified"
+	freshAlerts := dlq.List()
+	assert.Equal(t, "a", freshAlerts[0].TenantID)
+}
+
+func TestAlertDeadLetterQueue_Pop(t *testing.T) {
+	dlq := NewAlertDeadLetterQueue()
+
+	// Pop from empty queue
+	alert := dlq.Pop()
+	assert.Nil(t, alert)
+
+	// Add alerts
+	dlq.Enqueue(FailedAlert{TenantID: "first"})
+	dlq.Enqueue(FailedAlert{TenantID: "second"})
+
+	// Pop returns oldest first
+	alert = dlq.Pop()
+	require.NotNil(t, alert)
+	assert.Equal(t, "first", alert.TenantID)
+	assert.Equal(t, 1, dlq.Len())
+
+	alert = dlq.Pop()
+	require.NotNil(t, alert)
+	assert.Equal(t, "second", alert.TenantID)
+	assert.Equal(t, 0, dlq.Len())
+}
+
+func TestAlertDeadLetterQueue_Clear(t *testing.T) {
+	dlq := NewAlertDeadLetterQueue()
+
+	dlq.Enqueue(FailedAlert{TenantID: "a"})
+	dlq.Enqueue(FailedAlert{TenantID: "b"})
+	assert.Equal(t, 2, dlq.Len())
+
+	dlq.Clear()
+	assert.Equal(t, 0, dlq.Len())
+}
+
+func TestAlertDeadLetterQueue_Remove(t *testing.T) {
+	dlq := NewAlertDeadLetterQueue()
+
+	dlq.Enqueue(FailedAlert{TenantID: "a"})
+	dlq.Enqueue(FailedAlert{TenantID: "b"})
+	dlq.Enqueue(FailedAlert{TenantID: "c"})
+
+	// Remove middle element
+	removed := dlq.Remove(1)
+	assert.True(t, removed)
+	assert.Equal(t, 2, dlq.Len())
+
+	alerts := dlq.List()
+	assert.Equal(t, "a", alerts[0].TenantID)
+	assert.Equal(t, "c", alerts[1].TenantID)
+
+	// Remove out of bounds
+	removed = dlq.Remove(5)
+	assert.False(t, removed)
+
+	removed = dlq.Remove(-1)
+	assert.False(t, removed)
+}
+
+func TestAlertDeadLetterQueue_ConcurrentAccess(t *testing.T) {
+	dlq := NewAlertDeadLetterQueue(WithDLQMaxSize(1000))
+
+	var wg sync.WaitGroup
+
+	// Concurrent writers
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			dlq.Enqueue(FailedAlert{TenantID: string(rune('a' + id%26))})
+		}(i)
+	}
+
+	// Concurrent readers
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = dlq.List()
+			_ = dlq.Len()
+		}()
+	}
+
+	wg.Wait()
+
+	// Queue should have received all writes (no panics, race conditions)
+	assert.Equal(t, 100, dlq.Len())
+}
+
+func TestFailedAlert_Fields(t *testing.T) {
+	// Test that all fields are properly stored and retrieved
+	now := time.Now()
+	firstAttempt := now.Add(-1 * time.Minute)
+
+	payload := AlertPayload{
+		Summary:  "Test summary",
+		DedupKey: "dedup-123",
+		Severity: "critical",
+		CustomDetails: map[string]any{
+			"key": "value",
+		},
+	}
+
+	alert := FailedAlert{
+		AlertType:      AlertTypePagerDuty,
+		TenantID:       "tenant-abc",
+		Payload:        payload,
+		ErrorMessage:   "service unavailable",
+		FirstAttemptAt: firstAttempt,
+		LastAttemptAt:  now,
+		AttemptCount:   5,
+	}
+
+	dlq := NewAlertDeadLetterQueue()
+	dlq.Enqueue(alert)
+
+	retrieved := dlq.List()[0]
+	assert.Equal(t, AlertTypePagerDuty, retrieved.AlertType)
+	assert.Equal(t, "tenant-abc", retrieved.TenantID)
+	assert.Equal(t, "Test summary", retrieved.Payload.Summary)
+	assert.Equal(t, "dedup-123", retrieved.Payload.DedupKey)
+	assert.Equal(t, "critical", retrieved.Payload.Severity)
+	assert.Equal(t, "value", retrieved.Payload.CustomDetails["key"])
+	assert.Equal(t, "service unavailable", retrieved.ErrorMessage)
+	assert.WithinDuration(t, firstAttempt, retrieved.FirstAttemptAt, time.Second)
+	assert.WithinDuration(t, now, retrieved.LastAttemptAt, time.Second)
+	assert.Equal(t, 5, retrieved.AttemptCount)
+}

--- a/services/tenant/worker/rate_limiter.go
+++ b/services/tenant/worker/rate_limiter.go
@@ -1,0 +1,136 @@
+// Package worker implements background workers for tenant provisioning.
+package worker
+
+import (
+	"sync"
+	"time"
+)
+
+// AlertRateLimiter implements a token bucket rate limiter for alert delivery.
+// Each alert type has its own bucket to prevent one noisy alert type from
+// exhausting the budget for others.
+type AlertRateLimiter struct {
+	mu             sync.Mutex
+	maxTokens      int
+	refillRate     time.Duration // How often to add a token
+	buckets        map[string]*tokenBucket
+	onRateLimitHit func(alertType string) // Callback when rate limit is hit
+}
+
+// tokenBucket tracks tokens for a single alert type.
+type tokenBucket struct {
+	tokens     int
+	lastRefill time.Time
+}
+
+// RateLimiterOption configures the AlertRateLimiter.
+type RateLimiterOption func(*AlertRateLimiter)
+
+// WithRateLimitCallback sets a callback function invoked when rate limit is hit.
+// Useful for emitting metrics.
+func WithRateLimitCallback(fn func(alertType string)) RateLimiterOption {
+	return func(r *AlertRateLimiter) {
+		r.onRateLimitHit = fn
+	}
+}
+
+// NewAlertRateLimiter creates a new rate limiter for alerts.
+// maxPerMinute: maximum alerts per minute per alert type (e.g., 10)
+// burstSize: maximum burst capacity (typically same as maxPerMinute)
+func NewAlertRateLimiter(maxPerMinute, burstSize int, opts ...RateLimiterOption) *AlertRateLimiter {
+	if maxPerMinute <= 0 {
+		maxPerMinute = 10
+	}
+	if burstSize <= 0 {
+		burstSize = maxPerMinute
+	}
+
+	// Calculate refill rate: 1 token per (60/maxPerMinute) seconds
+	refillRate := time.Minute / time.Duration(maxPerMinute)
+
+	r := &AlertRateLimiter{
+		maxTokens:  burstSize,
+		refillRate: refillRate,
+		buckets:    make(map[string]*tokenBucket),
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// Allow checks if an alert of the given type is allowed.
+// Returns true if the alert can proceed, false if rate limited.
+func (r *AlertRateLimiter) Allow(alertType string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	bucket, exists := r.buckets[alertType]
+	if !exists {
+		// New alert type - create bucket with full tokens
+		bucket = &tokenBucket{
+			tokens:     r.maxTokens,
+			lastRefill: time.Now(),
+		}
+		r.buckets[alertType] = bucket
+	}
+
+	// Refill tokens based on elapsed time
+	r.refillBucket(bucket)
+
+	// Check if we have tokens available
+	if bucket.tokens > 0 {
+		bucket.tokens--
+		return true
+	}
+
+	// Rate limited - invoke callback if set
+	if r.onRateLimitHit != nil {
+		r.onRateLimitHit(alertType)
+	}
+
+	return false
+}
+
+// refillBucket adds tokens based on elapsed time since last refill.
+// Must be called with mutex held.
+func (r *AlertRateLimiter) refillBucket(bucket *tokenBucket) {
+	now := time.Now()
+	elapsed := now.Sub(bucket.lastRefill)
+
+	// Calculate how many tokens to add
+	tokensToAdd := int(elapsed / r.refillRate)
+	if tokensToAdd > 0 {
+		bucket.tokens += tokensToAdd
+		if bucket.tokens > r.maxTokens {
+			bucket.tokens = r.maxTokens
+		}
+		// Advance lastRefill by the number of tokens added (not to now, to avoid losing partial time)
+		bucket.lastRefill = bucket.lastRefill.Add(time.Duration(tokensToAdd) * r.refillRate)
+	}
+}
+
+// Reset clears all rate limit state. Useful for testing.
+func (r *AlertRateLimiter) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.buckets = make(map[string]*tokenBucket)
+}
+
+// TokensRemaining returns the number of tokens remaining for the given alert type.
+// Useful for testing and debugging.
+func (r *AlertRateLimiter) TokensRemaining(alertType string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	bucket, exists := r.buckets[alertType]
+	if !exists {
+		return r.maxTokens
+	}
+
+	// Refill before reporting
+	r.refillBucket(bucket)
+	return bucket.tokens
+}

--- a/services/tenant/worker/rate_limiter_test.go
+++ b/services/tenant/worker/rate_limiter_test.go
@@ -1,0 +1,162 @@
+package worker
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAlertRateLimiter(t *testing.T) {
+	t.Run("creates limiter with specified values", func(t *testing.T) {
+		limiter := NewAlertRateLimiter(10, 10)
+		require.NotNil(t, limiter)
+		assert.Equal(t, 10, limiter.maxTokens)
+	})
+
+	t.Run("uses defaults for invalid values", func(t *testing.T) {
+		limiter := NewAlertRateLimiter(0, 0)
+		require.NotNil(t, limiter)
+		assert.Equal(t, 10, limiter.maxTokens) // Default
+	})
+}
+
+func TestAlertRateLimiter_Allow_BasicOperation(t *testing.T) {
+	// Create a limiter with 10 alerts per minute, burst of 10
+	limiter := NewAlertRateLimiter(10, 10)
+
+	alertType := "test_alert"
+
+	// First 10 alerts should be allowed
+	for i := 0; i < 10; i++ {
+		allowed := limiter.Allow(alertType)
+		assert.True(t, allowed, "Alert %d should be allowed", i+1)
+	}
+
+	// 11th alert should be rate limited
+	allowed := limiter.Allow(alertType)
+	assert.False(t, allowed, "11th alert should be rate limited")
+}
+
+func TestAlertRateLimiter_Allow_DifferentTypes(t *testing.T) {
+	limiter := NewAlertRateLimiter(5, 5)
+
+	// Use all tokens for type A
+	for i := 0; i < 5; i++ {
+		limiter.Allow("type_a")
+	}
+	assert.False(t, limiter.Allow("type_a"), "type_a should be rate limited")
+
+	// Type B should still have full capacity
+	for i := 0; i < 5; i++ {
+		allowed := limiter.Allow("type_b")
+		assert.True(t, allowed, "type_b should be allowed")
+	}
+	assert.False(t, limiter.Allow("type_b"), "type_b should now be rate limited")
+}
+
+func TestAlertRateLimiter_Allow_TokenRefill(t *testing.T) {
+	// Skip in short mode as this test relies on timing
+	if testing.Short() {
+		t.Skip("Skipping timing-sensitive test in short mode")
+	}
+
+	// Create limiter: 60 alerts per minute = 1 per second
+	limiter := NewAlertRateLimiter(60, 2)
+
+	alertType := "refill_test"
+
+	// Use both tokens
+	assert.True(t, limiter.Allow(alertType))
+	assert.True(t, limiter.Allow(alertType))
+	assert.False(t, limiter.Allow(alertType))
+
+	// Wait for refill (slightly more than 1 second for one token)
+	time.Sleep(1100 * time.Millisecond)
+
+	// Should have 1 token refilled
+	assert.True(t, limiter.Allow(alertType))
+	assert.False(t, limiter.Allow(alertType))
+}
+
+func TestAlertRateLimiter_Allow_Callback(t *testing.T) {
+	callbackCount := 0
+	var callbackAlertType string
+	callback := func(alertType string) {
+		callbackCount++
+		callbackAlertType = alertType
+	}
+
+	limiter := NewAlertRateLimiter(2, 2, WithRateLimitCallback(callback))
+
+	// Use all tokens
+	limiter.Allow("callback_test")
+	limiter.Allow("callback_test")
+
+	// This should trigger callback
+	limiter.Allow("callback_test")
+
+	assert.Equal(t, 1, callbackCount)
+	assert.Equal(t, "callback_test", callbackAlertType)
+}
+
+func TestAlertRateLimiter_TokensRemaining(t *testing.T) {
+	limiter := NewAlertRateLimiter(10, 10)
+	alertType := "tokens_test"
+
+	// Initially should have max tokens (new bucket)
+	assert.Equal(t, 10, limiter.TokensRemaining(alertType))
+
+	// After consuming some
+	limiter.Allow(alertType)
+	limiter.Allow(alertType)
+	limiter.Allow(alertType)
+
+	assert.Equal(t, 7, limiter.TokensRemaining(alertType))
+}
+
+func TestAlertRateLimiter_Reset(t *testing.T) {
+	limiter := NewAlertRateLimiter(5, 5)
+	alertType := "reset_test"
+
+	// Use all tokens
+	for i := 0; i < 5; i++ {
+		limiter.Allow(alertType)
+	}
+	assert.False(t, limiter.Allow(alertType))
+
+	// Reset
+	limiter.Reset()
+
+	// Should have full capacity again
+	assert.True(t, limiter.Allow(alertType))
+	assert.Equal(t, 4, limiter.TokensRemaining(alertType))
+}
+
+func TestAlertRateLimiter_ConcurrentAccess(t *testing.T) {
+	limiter := NewAlertRateLimiter(100, 100)
+
+	var wg sync.WaitGroup
+	allowedCount := 0
+	var mu sync.Mutex
+
+	// Launch 200 goroutines trying to send alerts
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if limiter.Allow("concurrent_test") {
+				mu.Lock()
+				allowedCount++
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Exactly 100 should have been allowed
+	assert.Equal(t, 100, allowedCount)
+}


### PR DESCRIPTION
## Summary
- Implement PagerDuty Events API v2 integration with severity mapping and deduplication
- Add Slack Incoming Webhooks with rich Block Kit formatting
- Add rate limiting (token bucket, 10/min per alert type) and retry with exponential backoff
- Implement dead-letter queue for failed alerts
- Add Prometheus metrics for alert observability

## Task Master Reference
Tag: tech-debt-cleanup
Task: 39 - Implement Production Alerting Integration

## Test plan
- [ ] Unit tests pass for PagerDuty client, Slack notifier, rate limiter, retry logic, DLQ
- [ ] Integration tests verify mock implementations capture alerts correctly
- [ ] Manual verification with real PagerDuty/Slack in staging environment