### PR TITLE
fix: increase serverErrors channel buffer to prevent deadlock

### DIFF
--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -294,7 +294,9 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Start gRPC server in background
-	serverErrors := make(chan error, 1)
+	// Buffer size must match number of goroutines writing to this channel
+	// to prevent deadlock on simultaneous failures (gRPC + HTTP = 2)
+	serverErrors := make(chan error, 2)
 	go func() {
 		logger.Info("starting gRPC server", "address", address)
 		if err := grpcServer.Serve(listener); err != nil {


### PR DESCRIPTION
## Summary

Fixes potential deadlock in financial-accounting service startup when both gRPC and HTTP servers fail simultaneously.

**Problem:** The `serverErrors` channel had buffer size 1, but two goroutines write to it. If both fail at the same time, one goroutine blocks forever.

**Fix:** Increased buffer from 1 to 2 to match the number of writing goroutines.

## Changes Made

- `services/financial-accounting/cmd/main.go`: Changed `make(chan error, 1)` to `make(chan error, 2)` with explanatory comment

## Audit Results

Checked all other services for the same pattern:
- **gateway, party, current-account, tenant, utilization-metering-consumer**: Already have correct buffer sizes matching writer counts
- **position-keeping**: Uses separate channels per server (different pattern)
- **audit-worker**: Uses `log.Fatalf` instead of error channels

Only financial-accounting required the fix.

## Test Plan

- [x] `go build ./...` passes
- [x] Service startup/shutdown behavior unchanged
- [ ] CI passes

---
**Task Master**: tech-debt-cleanup.42