### PR TITLE
fix: add error handling for HTTP response writes in health endpoints

### DIFF
--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -310,22 +310,42 @@ func run(logger *slog.Logger) error {
 		resp, err := healthChecker.Check(r.Context(), &grpc_health_v1.HealthCheckRequest{})
 		if err != nil || resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte("NOT_SERVING"))
+			if _, err := w.Write([]byte("NOT_SERVING")); err != nil {
+				logger.Warn("failed to write health response",
+					"error", err,
+					"endpoint", r.URL.Path,
+					"remote_addr", r.RemoteAddr)
+			}
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("SERVING"))
+		if _, err := w.Write([]byte("SERVING")); err != nil {
+			logger.Warn("failed to write health response",
+				"error", err,
+				"endpoint", r.URL.Path,
+				"remote_addr", r.RemoteAddr)
+		}
 	})
 	httpMux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
 		// Readiness endpoint - checks database connectivity
 		resp, err := healthChecker.Check(r.Context(), &grpc_health_v1.HealthCheckRequest{Service: "database"})
 		if err != nil || resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte("NOT_READY"))
+			if _, err := w.Write([]byte("NOT_READY")); err != nil {
+				logger.Warn("failed to write readiness response",
+					"error", err,
+					"endpoint", r.URL.Path,
+					"remote_addr", r.RemoteAddr)
+			}
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("READY"))
+		if _, err := w.Write([]byte("READY")); err != nil {
+			logger.Warn("failed to write readiness response",
+				"error", err,
+				"endpoint", r.URL.Path,
+				"remote_addr", r.RemoteAddr)
+		}
 	})
 
 	httpServer := &http.Server{

--- a/services/gateway/server.go
+++ b/services/gateway/server.go
@@ -118,20 +118,30 @@ func (s *Server) registerRoutes() {
 // handleHealth is the liveness probe endpoint.
 // Returns 200 OK if the server is alive.
 // This endpoint does NOT require tenant context.
-func (s *Server) handleHealth(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("OK"))
+	if _, err := w.Write([]byte("OK")); err != nil {
+		s.logger.Warn("failed to write health response",
+			"error", err,
+			"endpoint", r.URL.Path,
+			"remote_addr", r.RemoteAddr)
+	}
 }
 
 // handleReady is the readiness probe endpoint.
 // Returns 200 OK if the server is ready to accept traffic.
 // This endpoint does NOT require tenant context.
-func (s *Server) handleReady(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 	// TODO: Add actual readiness checks (database, redis, backends)
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("READY"))
+	if _, err := w.Write([]byte("READY")); err != nil {
+		s.logger.Warn("failed to write readiness response",
+			"error", err,
+			"endpoint", r.URL.Path,
+			"remote_addr", r.RemoteAddr)
+	}
 }
 
 // handleAPI is a placeholder handler for API routes.
@@ -145,7 +155,12 @@ func (s *Server) handleAPI(w http.ResponseWriter, r *http.Request) {
 	// Placeholder response - actual routing will be implemented in future tasks
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusNotImplemented)
-	_, _ = w.Write([]byte(`{"error":"gateway routing not yet implemented"}`))
+	if _, err := w.Write([]byte(`{"error":"gateway routing not yet implemented"}`)); err != nil {
+		s.logger.Warn("failed to write API response",
+			"error", err,
+			"endpoint", r.URL.Path,
+			"remote_addr", r.RemoteAddr)
+	}
 }
 
 // Start starts the HTTP server and blocks until the server stops.

--- a/services/gateway/server_test.go
+++ b/services/gateway/server_test.go
@@ -304,3 +304,138 @@ func TestServer_ShutdownWithoutStart(t *testing.T) {
 	err := server.Shutdown(context.Background())
 	assert.NoError(t, err)
 }
+
+// failingResponseWriter is a mock that fails on Write to test error handling.
+type failingResponseWriter struct {
+	header     http.Header
+	statusCode int
+	writeErr   error
+}
+
+func newFailingResponseWriter(writeErr error) *failingResponseWriter {
+	return &failingResponseWriter{
+		header:   make(http.Header),
+		writeErr: writeErr,
+	}
+}
+
+func (w *failingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingResponseWriter) Write(_ []byte) (int, error) {
+	return 0, w.writeErr
+}
+
+func (w *failingResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+// logCapture captures log messages for testing.
+type logCapture struct {
+	entries []map[string]any
+}
+
+func (c *logCapture) Handle(_ context.Context, r slog.Record) error {
+	entry := make(map[string]any)
+	entry["level"] = r.Level.String()
+	entry["msg"] = r.Message
+	r.Attrs(func(a slog.Attr) bool {
+		entry[a.Key] = a.Value.Any()
+		return true
+	})
+	c.entries = append(c.entries, entry)
+	return nil
+}
+
+func (c *logCapture) Enabled(_ context.Context, _ slog.Level) bool {
+	return true
+}
+
+func (c *logCapture) WithAttrs(_ []slog.Attr) slog.Handler {
+	return c
+}
+
+func (c *logCapture) WithGroup(_ string) slog.Handler {
+	return c
+}
+
+// TestHealthEndpoints_WriteErrorLogging verifies that write errors are logged as warnings.
+func TestHealthEndpoints_WriteErrorLogging(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+	}{
+		{
+			name:     "/health endpoint logs write errors",
+			endpoint: "/health",
+		},
+		{
+			name:     "/ready endpoint logs write errors",
+			endpoint: "/ready",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create log capture
+			logHandler := &logCapture{}
+			logger := slog.New(logHandler)
+
+			// Create server
+			config := &Config{
+				Port:        8080,
+				BaseDomain:  "api.example.com",
+				DatabaseURL: "postgres://localhost/test",
+			}
+			server := NewServer(config, logger, nil)
+
+			// Create failing response writer
+			writeErr := io.ErrClosedPipe
+			w := newFailingResponseWriter(writeErr)
+			req := httptest.NewRequest(http.MethodGet, tt.endpoint, nil)
+			req.RemoteAddr = "192.168.1.100:54321"
+
+			// Execute - should NOT panic
+			server.mux.ServeHTTP(w, req)
+
+			// Verify warning was logged
+			require.GreaterOrEqual(t, len(logHandler.entries), 1, "expected at least one log entry")
+
+			lastEntry := logHandler.entries[len(logHandler.entries)-1]
+			assert.Equal(t, "WARN", lastEntry["level"])
+			assert.Contains(t, lastEntry["msg"].(string), "failed to write")
+			assert.Equal(t, tt.endpoint, lastEntry["endpoint"])
+			assert.Contains(t, lastEntry["remote_addr"].(string), "192.168.1.100")
+		})
+	}
+}
+
+// TestHealthEndpoints_NoPanicOnWriteError verifies handlers don't panic when Write fails.
+func TestHealthEndpoints_NoPanicOnWriteError(t *testing.T) {
+	endpoints := []string{"/health", "/ready", "/healthz", "/readyz"}
+
+	for _, endpoint := range endpoints {
+		t.Run(endpoint, func(t *testing.T) {
+			config := &Config{
+				Port:        8080,
+				BaseDomain:  "api.example.com",
+				DatabaseURL: "postgres://localhost/test",
+			}
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			server := NewServer(config, logger, nil)
+
+			// Create failing response writer
+			w := newFailingResponseWriter(io.ErrUnexpectedEOF)
+			req := httptest.NewRequest(http.MethodGet, endpoint, nil)
+
+			// Execute - should NOT panic
+			assert.NotPanics(t, func() {
+				server.mux.ServeHTTP(w, req)
+			})
+
+			// Verify WriteHeader was still called (status set before Write attempt)
+			assert.Equal(t, http.StatusOK, w.statusCode)
+		})
+	}
+}

--- a/services/payment-order/adapters/http/server.go
+++ b/services/payment-order/adapters/http/server.go
@@ -168,10 +168,15 @@ func (s *Server) StartWithListener(listener net.Listener) error {
 }
 
 // healthHandler provides a simple health check endpoint.
-func healthHandler(w http.ResponseWriter, _ *http.Request) {
+func healthHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status":"healthy"}`))
+	if _, err := w.Write([]byte(`{"status":"healthy"}`)); err != nil {
+		slog.Warn("failed to write health response",
+			"error", err,
+			"endpoint", r.URL.Path,
+			"remote_addr", r.RemoteAddr)
+	}
 }
 
 // Middleware types and helpers

--- a/services/payment-order/adapters/http/server_test.go
+++ b/services/payment-order/adapters/http/server_test.go
@@ -412,6 +412,49 @@ func TestMiddlewareChain(t *testing.T) {
 	assert.Equal(t, expected, order)
 }
 
+// failingResponseWriter is a mock that fails on Write to test error handling.
+type failingResponseWriter struct {
+	header     http.Header
+	statusCode int
+	writeErr   error
+}
+
+func newFailingResponseWriter(writeErr error) *failingResponseWriter {
+	return &failingResponseWriter{
+		header:   make(http.Header),
+		writeErr: writeErr,
+	}
+}
+
+func (w *failingResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *failingResponseWriter) Write(_ []byte) (int, error) {
+	return 0, w.writeErr
+}
+
+func (w *failingResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+// TestHealthHandler_NoPanicOnWriteError verifies the handler doesn't panic when Write fails.
+func TestHealthHandler_NoPanicOnWriteError(t *testing.T) {
+	// Create failing response writer
+	w := newFailingResponseWriter(io.ErrUnexpectedEOF)
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.RemoteAddr = "192.168.1.100:54321"
+
+	// Execute - should NOT panic
+	assert.NotPanics(t, func() {
+		healthHandler(w, req)
+	})
+
+	// Verify WriteHeader was still called (status set before Write attempt)
+	assert.Equal(t, http.StatusOK, w.statusCode)
+	assert.Equal(t, "application/json", w.header.Get("Content-Type"))
+}
+
 func TestRecoveryMiddleware(t *testing.T) {
 	panicHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		panic("test panic")

--- a/services/utilization-metering-consumer/cmd/main.go
+++ b/services/utilization-metering-consumer/cmd/main.go
@@ -83,21 +83,36 @@ func run(logger *slog.Logger) error {
 	httpMux := http.NewServeMux()
 
 	// Health check endpoints
-	httpMux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+	httpMux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("OK"))
+		if _, err := w.Write([]byte("OK")); err != nil {
+			logger.Warn("failed to write health response",
+				"error", err,
+				"endpoint", r.URL.Path,
+				"remote_addr", r.RemoteAddr)
+		}
 	})
 
-	httpMux.HandleFunc("/ready", func(w http.ResponseWriter, _ *http.Request) {
+	httpMux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
 		readinessMu.RLock()
 		defer readinessMu.RUnlock()
 		if !readiness.consumerInitialized {
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = w.Write([]byte("NOT_READY"))
+			if _, err := w.Write([]byte("NOT_READY")); err != nil {
+				logger.Warn("failed to write readiness response",
+					"error", err,
+					"endpoint", r.URL.Path,
+					"remote_addr", r.RemoteAddr)
+			}
 			return
 		}
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("READY"))
+		if _, err := w.Write([]byte("READY")); err != nil {
+			logger.Warn("failed to write readiness response",
+				"error", err,
+				"endpoint", r.URL.Path,
+				"remote_addr", r.RemoteAddr)
+		}
 	})
 
 	// Prometheus metrics endpoint


### PR DESCRIPTION
## Summary

- Added proper error handling for `w.Write()` calls in health endpoints across 4 services (financial-accounting, gateway, utilization-metering-consumer, payment-order)
- Errors are now logged using `logger.Warn` instead of being silently ignored
- Added unit tests in gateway and payment-order services to verify error handling behavior

**Task Master**: tech-debt-cleanup.46

## Test plan

- [x] Added unit tests for gateway health endpoint error handling (server_test.go)
- [x] Added unit tests for payment-order health endpoint error handling (server_test.go)
- [ ] Verify all existing tests pass with `go test ./...`
- [ ] Verify linting passes with `golangci-lint run`