### PR TITLE
refactor: replace time.Sleep with await patterns in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.38.0
 	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/trace v1.38.0
+	go.uber.org/goleak v1.3.0
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 	google.golang.org/grpc v1.75.1
 	google.golang.org/protobuf v1.36.10
@@ -50,7 +51,6 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.uber.org/goleak v1.3.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/mod v0.29.0 // indirect
 )

--- a/services/current-account/webhook/notifier_test.go
+++ b/services/current-account/webhook/notifier_test.go
@@ -245,6 +245,7 @@ func TestHTTPNotifier_FailAfterMaxRetries(t *testing.T) {
 func TestHTTPNotifier_ContextCancellation(t *testing.T) {
 	// Server that waits longer than the context timeout
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Intentional sleep: Simulate slow server to test context timeout handling
 		time.Sleep(1 * time.Second)
 		w.WriteHeader(http.StatusOK)
 	}))

--- a/services/financial-accounting/adapters/persistence/repository_test.go
+++ b/services/financial-accounting/adapters/persistence/repository_test.go
@@ -325,7 +325,6 @@ func TestGetPostingsByBookingLogID_OrderedByCreatedAt(t *testing.T) {
 		AccountID:             "ACC-001",
 		ValueDate:             now,
 		Status:                domain.TransactionStatusPosted,
-		CreatedAt:             now,
 	}
 
 	posting2 := &domain.LedgerPosting{
@@ -336,11 +335,11 @@ func TestGetPostingsByBookingLogID_OrderedByCreatedAt(t *testing.T) {
 		AccountID:             "ACC-002",
 		ValueDate:             now,
 		Status:                domain.TransactionStatusPosted,
-		CreatedAt:             now.Add(time.Second),
 	}
 
 	require.NoError(t, repo.SavePosting(ctx, posting1))
-	// Intentional sleep: Ensure different timestamps for ordering tests
+	// Intentional sleep: DB auto-populates CreatedAt on insert; sleep ensures
+	// distinct timestamps for ordering verification (domain CreatedAt is not persisted)
 	time.Sleep(10 * time.Millisecond)
 	require.NoError(t, repo.SavePosting(ctx, posting2))
 

--- a/services/financial-accounting/adapters/persistence/repository_test.go
+++ b/services/financial-accounting/adapters/persistence/repository_test.go
@@ -340,7 +340,8 @@ func TestGetPostingsByBookingLogID_OrderedByCreatedAt(t *testing.T) {
 	}
 
 	require.NoError(t, repo.SavePosting(ctx, posting1))
-	time.Sleep(10 * time.Millisecond) // Ensure different timestamps
+	// Intentional sleep: Ensure different timestamps for ordering tests
+	time.Sleep(10 * time.Millisecond)
 	require.NoError(t, repo.SavePosting(ctx, posting2))
 
 	// Retrieve postings - should be ordered by created_at

--- a/services/financial-accounting/domain/financial_booking_log_test.go
+++ b/services/financial-accounting/domain/financial_booking_log_test.go
@@ -134,6 +134,7 @@ func TestFinancialBookingLog_WithStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Intentional sleep: Ensure time has advanced for distinct UpdatedAt timestamps
 			time.Sleep(time.Millisecond)
 			beforeUpdate := time.Now().UTC()
 
@@ -219,6 +220,7 @@ func TestFinancialBookingLog_WithChartOfAccountsRules(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Intentional sleep: Ensure time has advanced for distinct UpdatedAt timestamps
 			time.Sleep(time.Millisecond)
 			beforeUpdate := time.Now().UTC()
 

--- a/services/financial-accounting/observability/metrics_test.go
+++ b/services/financial-accounting/observability/metrics_test.go
@@ -175,7 +175,7 @@ func TestOperationTimer(t *testing.T) {
 		// Verify in-flight incremented
 		assert.Equal(t, initialInFlight+1, testutil.ToFloat64(operationsInFlight.WithLabelValues(OperationRetrieveLedgerPosting)))
 
-		// Simulate some work
+		// Intentional sleep: Simulate work to measure elapsed time in metrics
 		time.Sleep(5 * time.Millisecond)
 
 		// Record success

--- a/services/financial-accounting/service/grpc_integration_test.go
+++ b/services/financial-accounting/service/grpc_integration_test.go
@@ -864,7 +864,8 @@ func TestListLedgerPostings_Integration_Success(t *testing.T) {
 			CreatedAt:             time.Now(),
 		}
 		require.NoError(t, ts.repo.SavePosting(ctx, posting))
-		time.Sleep(time.Millisecond) // Ensure different timestamps
+		// Intentional sleep: Ensure different timestamps for ordering tests
+		time.Sleep(time.Millisecond)
 	}
 
 	// List all postings
@@ -1019,6 +1020,7 @@ func TestListLedgerPostings_Integration_Pagination(t *testing.T) {
 			CreatedAt:             time.Now(),
 		}
 		require.NoError(t, ts.repo.SavePosting(ctx, posting))
+		// Intentional sleep: Ensure different timestamps for pagination ordering
 		time.Sleep(time.Millisecond)
 	}
 

--- a/services/financial-accounting/service/idempotency_chaos_test.go
+++ b/services/financial-accounting/service/idempotency_chaos_test.go
@@ -96,7 +96,8 @@ func TestChaos_CrashAfterMarkPending_CleanupWorkerMarksAsFailed(t *testing.T) {
 	// SIMULATED CRASH: We don't call StoreResult or Delete
 	// The key is now orphaned in PENDING state
 
-	// Wait for the key to become stale (short threshold for testing)
+	// Intentional sleep: Wait for the key to become stale (short threshold for testing).
+	// This is testing time-based staleness detection.
 	time.Sleep(100 * time.Millisecond)
 
 	// Configure cleanup worker with short threshold
@@ -444,7 +445,7 @@ func TestConcurrency_RaceBetweenCleanupAndStoreResult(t *testing.T) {
 		err := redisSvc.MarkPending(ctx, raceKey, time.Hour)
 		require.NoError(t, err)
 
-		// Wait just long enough for the key to potentially become stale
+		// Intentional sleep: Wait just long enough for the key to potentially become stale
 		time.Sleep(15 * time.Millisecond)
 
 		// Now try to store result (racing with cleanup worker)
@@ -458,7 +459,7 @@ func TestConcurrency_RaceBetweenCleanupAndStoreResult(t *testing.T) {
 
 		_ = redisSvc.StoreResult(ctx, completedResult) // Ignore error - we're testing the race
 
-		// Wait a bit and check final state
+		// Intentional sleep: Wait a bit and check final state after race condition
 		time.Sleep(50 * time.Millisecond)
 
 		result, err := redisSvc.Check(ctx, raceKey)
@@ -552,7 +553,7 @@ func TestLoad_SustainedTraffic_AllOperationsComplete(t *testing.T) {
 			}
 
 			_, err := executor.Execute(ctx, key, time.Hour, func(_ context.Context) ([]byte, error) {
-				// Simulate variable processing time
+				// Intentional sleep: Simulate variable processing time for load testing
 				time.Sleep(time.Duration(rand.Intn(30)) * time.Millisecond)
 				return []byte(`{"success":true}`), nil
 			})
@@ -630,7 +631,7 @@ func TestLoad_PendingDuration_P99Under1Second(t *testing.T) {
 
 			start := time.Now()
 			_, err := executor.Execute(ctx, key, time.Hour, func(_ context.Context) ([]byte, error) {
-				// Variable processing time: 10-100ms
+				// Intentional sleep: Variable processing time (10-100ms) for p99 latency testing
 				time.Sleep(time.Duration(10+rand.Intn(90)) * time.Millisecond)
 				return []byte(`{"success":true}`), nil
 			})
@@ -719,6 +720,7 @@ func TestMeta_VerifyConcurrencyTestDetectsRaces(t *testing.T) {
 			defer wg.Done()
 			_, _ = executor.Execute(context.Background(), key, time.Hour, func(_ context.Context) ([]byte, error) {
 				atomic.AddInt32(&executionCount, 1)
+				// Intentional sleep: Simulate work to test concurrency behavior
 				time.Sleep(10 * time.Millisecond)
 				return nil, nil
 			})
@@ -769,8 +771,8 @@ func (b *brokenConcurrencyChecker) MarkPending(_ context.Context, key idempotenc
 	// A proper implementation would use atomic compare-and-set (like Redis SETNX),
 	// but this broken version just overwrites, allowing multiple executions.
 
-	// Add delay BEFORE locking to create race window where multiple goroutines
-	// can all pass Check() before any of them complete MarkPending()
+	// Intentional sleep: Add delay BEFORE locking to create race window where multiple
+	// goroutines can all pass Check() before any of them complete MarkPending()
 	time.Sleep(5 * time.Millisecond)
 
 	b.mu.Lock()
@@ -852,7 +854,7 @@ func TestMeta_VerifyMetricsConsistency(t *testing.T) {
 
 	wg.Wait()
 
-	// Give metrics a moment to settle
+	// Intentional sleep: Give metrics a moment to settle after concurrent operations
 	time.Sleep(100 * time.Millisecond)
 
 	// Get metrics

--- a/services/financial-accounting/worker/idempotency_cleanup_worker_test.go
+++ b/services/financial-accounting/worker/idempotency_cleanup_worker_test.go
@@ -81,7 +81,8 @@ func TestCleanupWorker_StaleKeyMarkedAsFailed(t *testing.T) {
 	err = redisSvc.MarkPending(ctx, staleKey, time.Hour)
 	require.NoError(t, err)
 
-	// Wait a bit to ensure the key is stale
+	// Intentional sleep: Wait for the key to become stale (older than threshold).
+	// This is testing time-based staleness detection, not async operations.
 	time.Sleep(50 * time.Millisecond)
 
 	// Configure worker with very short threshold
@@ -168,7 +169,9 @@ func TestCleanupWorker_FreshKeyNotMarked(t *testing.T) {
 		_ = w.Start(workerCtx)
 	}()
 
-	// Wait for a few cleanup iterations
+	// Intentional sleep: Wait for a few cleanup iterations to pass.
+	// We're testing that fresh keys are NOT modified, so we must allow time for the
+	// worker to run multiple cycles without touching them.
 	time.Sleep(300 * time.Millisecond)
 
 	// Verify the key is still PENDING
@@ -203,7 +206,7 @@ func TestCleanupWorker_BatchProcessing(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Wait a bit for keys to become stale
+	// Intentional sleep: Wait for keys to become stale (older than threshold)
 	time.Sleep(50 * time.Millisecond)
 
 	// Configure worker with batch size of 100 (so we need 2 batches)
@@ -269,7 +272,7 @@ func TestCleanupWorker_GracefulShutdown(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Wait for keys to become stale
+	// Intentional sleep: Wait for keys to become stale (older than threshold)
 	time.Sleep(50 * time.Millisecond)
 
 	// Configure worker with short intervals
@@ -296,7 +299,7 @@ func TestCleanupWorker_GracefulShutdown(t *testing.T) {
 	// Wait for worker to start
 	<-startedChan
 
-	// Let it run briefly
+	// Intentional sleep: Let worker run for a few cycles before shutting down
 	time.Sleep(100 * time.Millisecond)
 
 	// Stop the worker gracefully via context cancellation
@@ -425,7 +428,7 @@ func TestCleanupWorker_MetricsRecorded(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	// Wait for keys to become stale
+	// Intentional sleep: Wait for keys to become stale (older than threshold)
 	time.Sleep(50 * time.Millisecond)
 
 	// Configure worker with short threshold

--- a/services/gateway/auth/apikey_middleware_test.go
+++ b/services/gateway/auth/apikey_middleware_test.go
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 // TestAPIKeyMiddleware_ValidKeyAcceptsRequest verifies that a valid API key
@@ -170,15 +172,15 @@ func TestAPIKeyMiddleware_RateLimiterResetsAfterTime(t *testing.T) {
 	handler.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusTooManyRequests, rec.Code)
 
-	// Wait for token refill (100ms = 1 token at 10/sec)
-	time.Sleep(150 * time.Millisecond)
-
-	// Should succeed again
-	req = httptest.NewRequest(http.MethodGet, "/api/test", nil)
-	req.Header.Set(APIKeyHeader, "rate-limited-key")
-	rec = httptest.NewRecorder()
-	handler.ServeHTTP(rec, req)
-	assert.Equal(t, http.StatusOK, rec.Code, "request should succeed after rate limit reset")
+	// Wait for token refill by polling until request succeeds
+	err := await.New().AtMost(2 * time.Second).PollInterval(20 * time.Millisecond).Until(func() bool {
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req.Header.Set(APIKeyHeader, "rate-limited-key")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code == http.StatusOK
+	})
+	require.NoError(t, err, "rate limit should reset and allow request")
 }
 
 // TestAPIKeyMiddleware_MultipleKeysIndependentRateLimits verifies that
@@ -299,11 +301,11 @@ func TestAPIKeyMiddleware_CleanupRemovesIdleLimiters(t *testing.T) {
 	// Verify limiters were created
 	assert.Equal(t, 2, middleware.LimiterCount(), "should have 2 limiters")
 
-	// Wait for cleanup (idle timeout + cleanup interval + buffer)
-	time.Sleep(200 * time.Millisecond)
-
-	// Limiters should be cleaned up
-	assert.Equal(t, 0, middleware.LimiterCount(), "limiters should be cleaned up")
+	// Wait for cleanup by polling until limiters are cleaned up
+	err := await.New().AtMost(2 * time.Second).PollInterval(20 * time.Millisecond).Until(func() bool {
+		return middleware.LimiterCount() == 0
+	})
+	require.NoError(t, err, "limiters should be cleaned up")
 }
 
 // TestAPIKeyMiddleware_GetAPIKeyIdentity verifies context identity retrieval.

--- a/services/gateway/auth/jwt_middleware_test.go
+++ b/services/gateway/auth/jwt_middleware_test.go
@@ -1001,7 +1001,8 @@ func TestJWTMiddleware_IntegrationWithRealToken_ExpirationBoundary(t *testing.T)
 		assert.Equal(t, http.StatusOK, rr.Code)
 	})
 
-	// Wait for token to expire (calculate remaining time + buffer)
+	// Intentional sleep: Wait for token to actually expire to test expiration behavior.
+	// This is testing real-time token expiration, not waiting for async operations.
 	waitTime := time.Until(expiresAt) + 100*time.Millisecond
 	if waitTime > 0 {
 		time.Sleep(waitTime)

--- a/services/party/adapters/persistence/verification_repository_test.go
+++ b/services/party/adapters/persistence/verification_repository_test.go
@@ -299,7 +299,7 @@ func TestListVerificationsByParty(t *testing.T) {
 		}
 		err := repo.CreateVerification(ctx, verification)
 		require.NoError(t, err)
-		// Small delay to ensure ordering
+		// Intentional sleep: Ensure different timestamps for ordering tests
 		time.Sleep(10 * time.Millisecond)
 	}
 

--- a/services/party/verification/provider_test.go
+++ b/services/party/verification/provider_test.go
@@ -121,6 +121,7 @@ func TestMockProvider_SimulatedDelay_RespectsContextCancellation(t *testing.T) {
 
 	// Cancel context after a short time
 	go func() {
+		// Intentional sleep: Delay before cancelling to test cancellation handling
 		time.Sleep(50 * time.Millisecond)
 		cancel()
 	}()

--- a/services/payment-order/adapters/http/server_test.go
+++ b/services/payment-order/adapters/http/server_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	"github.com/meridianhub/meridian/shared/platform/await"
 )
 
 func TestNewServer(t *testing.T) {
@@ -132,14 +133,26 @@ func TestServer_HealthEndpoint(t *testing.T) {
 		close(serverDone)
 	}()
 
-	// Give server time to start
-	time.Sleep(50 * time.Millisecond)
+	// Wait for server to be ready
+	client := &http.Client{Timeout: 5 * time.Second}
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).UntilNoError(func() error {
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+listener.Addr().String()+"/health", nil)
+		if reqErr != nil {
+			return reqErr
+		}
+		resp, respErr := client.Do(req)
+		if respErr != nil {
+			return respErr
+		}
+		_ = resp.Body.Close()
+		return nil
+	})
+	require.NoError(t, err, "server should become ready")
 
 	// Make request to health endpoint
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+listener.Addr().String()+"/health", nil)
 	require.NoError(t, err)
 
-	client := &http.Client{Timeout: 5 * time.Second}
 	resp, err := client.Do(req)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
@@ -196,8 +209,21 @@ func TestServer_WebhookEndpoint(t *testing.T) {
 		close(serverDone)
 	}()
 
-	// Give server time to start
-	time.Sleep(50 * time.Millisecond)
+	// Wait for server to be ready
+	client := &http.Client{Timeout: 5 * time.Second}
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).UntilNoError(func() error {
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+listener.Addr().String()+"/health", nil)
+		if reqErr != nil {
+			return reqErr
+		}
+		resp, respErr := client.Do(req)
+		if respErr != nil {
+			return respErr
+		}
+		_ = resp.Body.Close()
+		return nil
+	})
+	require.NoError(t, err, "server should become ready")
 
 	// Create webhook request
 	webhookReq := WebhookRequest{
@@ -210,7 +236,6 @@ func TestServer_WebhookEndpoint(t *testing.T) {
 
 	signature := GenerateWebhookSignature(body, secret)
 
-	client := &http.Client{Timeout: 5 * time.Second}
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		"http://"+listener.Addr().String()+"/webhook/payment-gateway",
 		&fixedReader{data: body})

--- a/services/position-keeping/cmd/main_test.go
+++ b/services/position-keeping/cmd/main_test.go
@@ -270,7 +270,7 @@ func TestHealthServer_Watch_RespectsContext(t *testing.T) {
 		done <- healthSrv.Watch(&grpc_health_v1.HealthCheckRequest{}, mockStream)
 	}()
 
-	// Give it time to send initial status
+	// Intentional sleep: Give grpc health watch time to send initial status
 	time.Sleep(50 * time.Millisecond)
 
 	// Cancel the context

--- a/services/tenant/adapters/persistence/repository_test.go
+++ b/services/tenant/adapters/persistence/repository_test.go
@@ -384,7 +384,8 @@ func TestRepository_List(t *testing.T) {
 		tenant := newTestTenant(string(rune('a'+i)) + "_tenant")
 		err := repo.Create(ctx, tenant)
 		require.NoError(t, err)
-		// Small delay to ensure distinct created_at timestamps
+		// Intentional sleep: Ensure distinct created_at timestamps for ordering tests.
+		// Database timestamp precision requires actual time to pass.
 		time.Sleep(10 * time.Millisecond)
 	}
 
@@ -439,7 +440,8 @@ func TestRepository_List_Pagination(t *testing.T) {
 		tenant := newTestTenant("page_tenant_" + string(rune('a'+i)))
 		err := repo.Create(ctx, tenant)
 		require.NoError(t, err)
-		time.Sleep(10 * time.Millisecond) // Ensure distinct timestamps
+		// Intentional sleep: Ensure distinct timestamps for pagination ordering
+		time.Sleep(10 * time.Millisecond)
 	}
 
 	// Get first page of 3

--- a/services/tenant/notifier/slack_test.go
+++ b/services/tenant/notifier/slack_test.go
@@ -328,7 +328,8 @@ func TestSendAlert_ConnectionError(t *testing.T) {
 
 func TestSendAlert_ContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		time.Sleep(5 * time.Second) // Long delay
+		// Intentional sleep: Simulate slow server to test context cancellation behavior
+		time.Sleep(5 * time.Second)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()

--- a/services/tenant/pagerduty/client_test.go
+++ b/services/tenant/pagerduty/client_test.go
@@ -327,7 +327,7 @@ func TestClient_TriggerAlert_NetworkError(t *testing.T) {
 
 func TestClient_TriggerAlert_ContextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// Delay response to allow context cancellation
+		// Intentional sleep: Delay response to test context cancellation handling
 		time.Sleep(100 * time.Millisecond)
 		w.WriteHeader(http.StatusAccepted)
 	}))

--- a/services/tenant/service/cached_registry_test.go
+++ b/services/tenant/service/cached_registry_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/meridianhub/meridian/services/tenant/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/platform/await"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 )
 
@@ -42,7 +43,6 @@ func TestCachedRegistry_Start_IsIdempotent(t *testing.T) {
 
 	// Get baseline goroutine count
 	runtime.GC()
-	time.Sleep(10 * time.Millisecond)
 	baselineGoroutines := runtime.NumGoroutine()
 
 	// Call Start() 3 times
@@ -50,11 +50,17 @@ func TestCachedRegistry_Start_IsIdempotent(t *testing.T) {
 	registry.Start(ctx)
 	registry.Start(ctx)
 
-	// Wait a bit for any goroutines to start
-	time.Sleep(20 * time.Millisecond)
+	// Wait for goroutine count to stabilize
+	var currentGoroutines int
+	_ = await.New().AtMost(1 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		runtime.GC()
+		currentGoroutines = runtime.NumGoroutine()
+		// Check it's within expected range (goroutine count stabilized)
+		additionalGoroutines := currentGoroutines - baselineGoroutines
+		return additionalGoroutines >= 1 && additionalGoroutines <= 2
+	})
 
 	// Check goroutine count - should only have 1 additional goroutine
-	currentGoroutines := runtime.NumGoroutine()
 	additionalGoroutines := currentGoroutines - baselineGoroutines
 
 	// Allow for 1-2 additional goroutines (the refresh loop plus potential runtime overhead)
@@ -73,7 +79,6 @@ func TestCachedRegistry_Start_ConcurrentCalls(t *testing.T) {
 
 	// Get baseline goroutine count
 	runtime.GC()
-	time.Sleep(10 * time.Millisecond)
 	baselineGoroutines := runtime.NumGoroutine()
 
 	// Spawn 10 goroutines all calling Start() concurrently
@@ -87,11 +92,17 @@ func TestCachedRegistry_Start_ConcurrentCalls(t *testing.T) {
 	}
 	wg.Wait()
 
-	// Wait a bit for any goroutines to settle
-	time.Sleep(20 * time.Millisecond)
+	// Wait for goroutine count to stabilize
+	var currentGoroutines int
+	_ = await.New().AtMost(1 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		runtime.GC()
+		currentGoroutines = runtime.NumGoroutine()
+		// Check it's within expected range (goroutine count stabilized)
+		additionalGoroutines := currentGoroutines - baselineGoroutines
+		return additionalGoroutines >= 1 && additionalGoroutines <= 2
+	})
 
 	// Check goroutine count - should only have 1 additional goroutine from the refresh loop
-	currentGoroutines := runtime.NumGoroutine()
 	additionalGoroutines := currentGoroutines - baselineGoroutines
 
 	// Allow for 1-2 additional goroutines (the refresh loop plus potential runtime overhead)
@@ -139,13 +150,14 @@ func TestCachedRegistry_RefreshLoopRuns(t *testing.T) {
 		t.Fatal("Expected LastRefresh to be set after Start()")
 	}
 
-	// Wait for at least one refresh cycle (refresh interval is 50ms)
-	time.Sleep(100 * time.Millisecond)
-
-	// Check that refresh has run at least once more
-	latestRefresh := registry.LastRefresh()
-	if !latestRefresh.After(initialRefresh) {
-		t.Errorf("Expected LastRefresh to update after waiting; initial: %v, latest: %v",
+	// Wait for refresh to run by polling LastRefresh()
+	var latestRefresh time.Time
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		latestRefresh = registry.LastRefresh()
+		return latestRefresh.After(initialRefresh)
+	})
+	if err != nil {
+		t.Errorf("Expected LastRefresh to update; initial: %v, latest: %v",
 			initialRefresh, latestRefresh)
 	}
 }
@@ -165,10 +177,11 @@ func TestCachedRegistry_Started_ReturnsFalseAfterContextCancelled(t *testing.T) 
 	// Cancel the context
 	cancel()
 
-	// Wait for the goroutine to exit
-	time.Sleep(100 * time.Millisecond)
-
-	if registry.Started() {
+	// Wait for the goroutine to exit by polling Started()
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return !registry.Started()
+	})
+	if err != nil {
 		t.Error("Expected Started() to return false after context is cancelled")
 	}
 }
@@ -187,9 +200,10 @@ func TestCachedRegistry_CannotRestartAfterCancel(t *testing.T) {
 
 	// Cancel the first context and wait for goroutine to exit
 	cancel1()
-	time.Sleep(100 * time.Millisecond)
-
-	if registry.Started() {
+	err := await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).Until(func() bool {
+		return !registry.Started()
+	})
+	if err != nil {
 		t.Fatal("Expected Started() to return false after context cancelled")
 	}
 

--- a/services/tenant/worker/rate_limiter_test.go
+++ b/services/tenant/worker/rate_limiter_test.go
@@ -73,7 +73,8 @@ func TestAlertRateLimiter_Allow_TokenRefill(t *testing.T) {
 	assert.True(t, limiter.Allow(alertType))
 	assert.False(t, limiter.Allow(alertType))
 
-	// Wait for refill (slightly more than 1 second for one token)
+	// Intentional sleep: Wait for real time to pass so rate limiter can refill.
+	// Rate limiting is fundamentally time-based; we need to wait for token refill.
 	time.Sleep(1100 * time.Millisecond)
 
 	// Should have 1 token refilled

--- a/shared/pkg/clients/retry_test.go
+++ b/shared/pkg/clients/retry_test.go
@@ -270,7 +270,8 @@ func TestRetryContextDeadlineExceeded(t *testing.T) {
 	attempts := 0
 	fn := func() error {
 		attempts++
-		time.Sleep(30 * time.Millisecond) // Simulate slow operation
+		// Intentional sleep: Simulate slow operation to trigger context deadline
+		time.Sleep(30 * time.Millisecond)
 		return status.Error(codes.Unavailable, "service unavailable")
 	}
 

--- a/shared/pkg/idempotency/executor_test.go
+++ b/shared/pkg/idempotency/executor_test.go
@@ -301,7 +301,8 @@ func TestExecutor_Execute_ConcurrentRequests(t *testing.T) {
 			defer wg.Done()
 			_, err := executor.Execute(context.Background(), key, time.Hour, func(_ context.Context) ([]byte, error) {
 				atomic.AddInt32(&executionCount, 1)
-				time.Sleep(10 * time.Millisecond) // Simulate work
+				// Intentional sleep: Simulate work to test concurrent idempotency enforcement
+				time.Sleep(10 * time.Millisecond)
 				return []byte("result"), nil
 			})
 			// Either success or ErrOperationInProgress is acceptable

--- a/shared/pkg/idempotency/metrics_test.go
+++ b/shared/pkg/idempotency/metrics_test.go
@@ -173,7 +173,7 @@ func TestMetricsCollector_FullWorkflow(t *testing.T) {
 	start := time.Now()
 	collector.RecordPending("payment")
 
-	// Simulate some work
+	// Intentional sleep: Simulate work to ensure non-zero duration is recorded in metrics
 	time.Sleep(10 * time.Millisecond)
 
 	// Record completion
@@ -197,7 +197,7 @@ func TestMetricsCollector_FailureWorkflow(t *testing.T) {
 	start := time.Now()
 	collector.RecordPending("refund")
 
-	// Simulate failure
+	// Intentional sleep: Simulate work before failure to ensure non-zero duration
 	time.Sleep(5 * time.Millisecond)
 
 	// Record failure

--- a/shared/platform/auth/jwks_test.go
+++ b/shared/platform/auth/jwks_test.go
@@ -224,7 +224,7 @@ func TestJWKSProvider_GetKey(t *testing.T) {
 		provider, err := NewJWKSProvider(ctx, cfg)
 		require.NoError(t, err)
 
-		// Wait for cache to expire
+		// Intentional sleep: Wait for cache TTL to expire to test cache refresh behavior
 		time.Sleep(10 * time.Millisecond)
 
 		key, err := provider.GetKey(ctx, "test-key-1")
@@ -259,7 +259,7 @@ func TestJWKSProvider_GetKey(t *testing.T) {
 		provider, err := NewJWKSProvider(ctx, cfg)
 		require.NoError(t, err)
 
-		// Wait for cache to expire
+		// Intentional sleep: Wait for cache TTL to expire to test stale cache behavior
 		time.Sleep(10 * time.Millisecond)
 
 		// Should still return cached key even though refresh fails
@@ -485,7 +485,7 @@ func TestJWKSProvider_Close(t *testing.T) {
 		err = provider.Close()
 		assert.NoError(t, err)
 
-		// Give time for goroutine to exit
+		// Intentional sleep: Give time for goroutine to exit after close
 		time.Sleep(200 * time.Millisecond)
 	})
 

--- a/shared/platform/auth/oauth_test.go
+++ b/shared/platform/auth/oauth_test.go
@@ -197,7 +197,8 @@ func TestOAuth2Client_GetToken(t *testing.T) {
 		assert.Equal(t, "refreshed-token", token1)
 		assert.Equal(t, 1, requestCount)
 
-		// Wait for token to expire
+		// Intentional sleep: Wait for token to expire to test token refresh behavior.
+		// OAuth token expiration is time-based by design.
 		time.Sleep(2 * time.Second)
 
 		// Second call should refresh token

--- a/shared/platform/db/integration_test.go
+++ b/shared/platform/db/integration_test.go
@@ -59,6 +59,7 @@ func setupPostgresContainer(ctx context.Context, t *testing.T) (*PostgresPool, f
 			break
 		}
 		t.Logf("Ping attempt %d failed: %v, retrying...", attempt, pingErr)
+		// Intentional sleep: Exponential backoff for database connection retry
 		time.Sleep(time.Duration(attempt) * 500 * time.Millisecond)
 	}
 	require.NoError(t, pingErr, "failed to ping postgres after retries")
@@ -492,7 +493,7 @@ func TestPostgresPool_Integration_ContextCancellation(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
 		defer cancel()
 
-		// Wait a bit to ensure timeout
+		// Intentional sleep: Wait for context timeout to trigger before executing query
 		time.Sleep(10 * time.Millisecond)
 
 		// Query should fail due to timeout
@@ -515,7 +516,7 @@ func TestPostgresPool_Integration_ContextCancellation(t *testing.T) {
 		defer cancel()
 
 		err := WithTransaction(timeoutCtx, pool, func(_ DB) error {
-			// Simulate slow operation
+			// Intentional sleep: Simulate slow operation to trigger context timeout
 			time.Sleep(200 * time.Millisecond)
 			return nil
 		})

--- a/shared/platform/db/pool_leak_test.go
+++ b/shared/platform/db/pool_leak_test.go
@@ -146,7 +146,7 @@ func TestPoolCloseWithContext_TimeoutDuringClose(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
 	defer cancel()
 
-	// Small delay to ensure context likely expires before/during Close
+	// Intentional sleep: Ensure context expires before/during Close to test race handling
 	time.Sleep(1 * time.Millisecond)
 
 	// CloseWithContext may succeed or fail depending on timing

--- a/shared/platform/events/outbox_test.go
+++ b/shared/platform/events/outbox_test.go
@@ -150,7 +150,7 @@ func TestPostgresOutboxRepository_FetchUnprocessed(t *testing.T) {
 	for i := range entries {
 		err := db.Create(&entries[i]).Error
 		require.NoError(t, err)
-		// Small delay to ensure different created_at timestamps
+		// Intentional sleep: Ensure different created_at timestamps for ordering tests
 		time.Sleep(10 * time.Millisecond)
 	}
 


### PR DESCRIPTION
## Summary

Replace `time.Sleep` calls in test files with appropriate await patterns from `shared/platform/await`, improving test reliability and speed. Where sleep is genuinely needed (e.g., testing time-based behavior), add "Intentional sleep:" comments for clarity.

**Task Master**: tech-debt-cleanup.52

## Changes Made

### Await Pattern Migrations

| File | Change |
|------|--------|
| `services/payment-order/adapters/http/server_test.go` | Use `await.UntilNoError` for server startup instead of fixed sleep |
| `services/gateway/auth/apikey_middleware_test.go` | Poll for rate limit reset and cleanup completion |
| `services/tenant/service/cached_registry_test.go` | Poll for goroutine count stabilization and context cancellation effects |

### Intentional Sleep Documentation

Added "Intentional sleep:" comments to tests where sleep is genuinely required:
- Cache TTL expiration tests (must wait for actual expiration)
- Rate limiting tests (testing time-based behavior)
- Token refresh tests (simulating passage of time)
- Concurrent workload simulations

### Client Consolidation (Related Cleanup)

Also includes consolidation of gRPC clients following resilience patterns:
- Moved service-specific clients into `clients/` directories
- Removed duplicate client implementations
- Added `ResilientClient` wrapper with retry and circuit breaker patterns
- Improved test coverage for client behavior

## Files Modified

- **82 files changed**: 3,960 insertions, 3,621 deletions
- **Test files**: Migrated time.Sleep → await patterns
- **Client files**: Consolidated and improved resilience
- **CI workflows**: Updated for new client structure

## Test Plan

- [x] All existing tests pass with new await patterns
- [x] Tests are faster (no unnecessary sleeping)
- [x] Tests are more reliable (polling instead of fixed delays)
- [x] Intentional sleeps are documented with comments
- [ ] CI passes all checks

## Risk Assessment

**Low risk** - This is a refactoring change that:
- Does not change production behavior
- Only modifies test utilities and client organization
- Uses existing, well-tested await patterns
- Adds documentation to clarify intentional sleeps