### PR TITLE
docs: tighten documentation for accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,31 +21,35 @@ An open source, cloud-native core banking engine following BIAN (Banking Industr
 
 ```text
 meridian/
-├── services/                    # BIAN service domains (domain-centric)
+├── services/                    # BIAN service domains
 │   ├── current-account/         # Customer-facing account management
 │   │   ├── cmd/                 # Entry point and Dockerfile
 │   │   ├── domain/              # Business logic and entities
 │   │   ├── adapters/            # Persistence, messaging adapters
 │   │   ├── service/             # gRPC service implementation
 │   │   ├── client/              # Service-owned gRPC client
-│   │   ├── migrations/          # Database migrations
 │   │   ├── atlas/               # Atlas schema config
+│   │   ├── migrations/          # Database migrations
 │   │   └── k8s/                 # Kubernetes manifests
 │   ├── financial-accounting/    # Double-entry general ledger
+│   ├── gateway/                 # API gateway
 │   ├── party/                   # Customer and party reference data
 │   ├── payment-order/           # Payment execution
 │   ├── position-keeping/        # Pre-ledger transaction log
-│   └── tenant/                  # Multi-tenant platform management
+│   ├── tenant/                  # Multi-tenant platform management
+│   ├── audit-worker/            # Audit log processor
+│   └── utilization-metering-consumer/  # Usage metering
 ├── shared/                      # Cross-service shared code
 │   ├── platform/                # Infrastructure (auth, db, kafka, observability)
 │   ├── domain/                  # Shared domain models and primitives
-│   └── pkg/                     # Shared utilities (health, idempotency)
-├── utilities/                   # CLI tools
-│   ├── meridian/                # Main CLI
+│   └── pkg/                     # Shared utilities (health, idempotency, clients)
+├── cmd/                         # CLI tools
+│   └── tenantctl/               # Tenant management CLI
+├── utilities/                   # Development utilities
 │   ├── atlas-loader/            # Migration schema loader
 │   └── horizon-demo/            # Demo utility
 ├── api/proto/                   # Protocol Buffer API definitions
-├── deployments/k8s/             # Shared Kubernetes resources (base, overlays)
+├── deployments/k8s/             # Shared Kubernetes resources
 └── docs/                        # Documentation and ADRs
 ```
 
@@ -80,13 +84,14 @@ Reference specifications: [BIAN Service Landscape 13.0.0](https://github.com/bia
 
 ### Infrastructure Services
 
-| Service | Purpose | Standalone |
-|---------|---------|:----------:|
-| [**Tenant**][svc-tenant] | Multi-tenant platform management with PostgreSQL schema-per-tenant isolation | Yes |
+| Service | Purpose |
+|---------|---------|
+| [**Tenant**][svc-tenant] | Multi-tenant platform management with schema-per-tenant isolation |
+| **Gateway** | API gateway for external access |
+| **audit-worker** | Processes audit log outbox entries |
+| **utilization-metering-consumer** | Usage metering for billing |
 
-The Tenant service is not part of the BIAN standard but is essential for shared-cluster deployments
-requiring data isolation between organizations. It provides schema-based multi-tenancy where each
-tenant's data is isolated in a dedicated PostgreSQL schema (`org_{tenant_id}`).
+These services are not part of the BIAN standard but provide platform infrastructure.
 
 ## Technology Stack
 

--- a/docs/adr/0015-standard-service-directory-structure.md
+++ b/docs/adr/0015-standard-service-directory-structure.md
@@ -12,7 +12,7 @@ instructions: |
   Root layout: api/ for proto/OpenAPI, docs/ for all documentation, services/ for microservices, shared/ for libraries.
   Service structure: cmd/, domain/, adapters/, service/, observability/.
   Place persistence code in adapters/persistence/, messaging in adapters/messaging/.
-  Use observability/ for metrics and health checks. Use clients/ for inter-service clients.
+  Use observability/ for metrics and health checks. Use client/ for service-owned gRPC clients.
   All documentation belongs in docs/ - not scattered in service directories.
 ---
 
@@ -34,7 +34,7 @@ Following the codebase reorganization (#215, #216) that moved from a monolithic 
 | `domain/` | ✓ | ✓ | ✓ | ✓ |
 | `adapters/` | ✓ | ✓ | ✓ | ✓ |
 | `service/` | ✓ | ✓ | ✓ | ✓ |
-| `clients/` | ✓ | ✓ (.gitkeep) | ✗ | ✗ |
+| `client/` | ✓ | ✓ | ✓ | ✗ |
 | `observability/` | ✓ | ✗ (uses `app/`) | ✗ | ✓ |
 | `app/` | ✗ | ✓ | ✗ | ✗ |
 | `interceptors/` | ✗ | ✓ | ✗ | ✗ |
@@ -182,9 +182,8 @@ services/{service-name}/
 │   ├── metrics.go         # Prometheus metrics
 │   └── health.go          # Health check implementations
 │
-├── clients/                # OPTIONAL: Inter-service gRPC clients
-│   ├── {service}_client.go
-│   └── circuitbreaker.go
+├── client/                 # OPTIONAL: Service-owned gRPC client
+│   └── client.go           # Client for other services to import
 │
 ├── app/                    # OPTIONAL: Application bootstrap (complex services)
 │   ├── config.go          # Configuration loading
@@ -220,7 +219,7 @@ services/{service-name}/
 
 | Directory | When to Add | Example Use Case |
 |-----------|-------------|------------------|
-| `clients/` | Service calls other services | current-account calling financial-accounting |
+| `client/` | Service exports client for others | party exporting client for current-account |
 | `app/` | Complex initialization logic | Services needing DI containers, complex config |
 | `adapters/messaging/` | Kafka integration | Event publishing/consuming |
 | `adapters/gateway/` | External API integration | ISO 20022 gateway adapters |

--- a/docs/architecture/bian-service-boundaries.md
+++ b/docs/architecture/bian-service-boundaries.md
@@ -154,7 +154,7 @@ The CurrentAccount service owns:
 - Circuit breaker for downstream service failures
 - Retry logic with exponential backoff
 - Graceful degradation when dependencies are unavailable
-- **Implementation:** `services/current-account/client/resilient_client.go`
+- **Implementation:** `shared/pkg/clients/resilient.go`
 
 **Platform Services:**
 
@@ -1466,7 +1466,7 @@ This section documents the actual communication flows between services based on 
 
 - **Client:** `services/current-account/client/positionkeeping_client.go`
 - **Proto Import:** `meridian/position_keeping/v1/position_keeping.proto`
-- **Resilience:** Circuit breaker via `resilient_client.go`
+- **Resilience:** Circuit breaker via `shared/pkg/clients`
 
 **Usage Pattern:**
 
@@ -1491,7 +1491,7 @@ resp, err := pkClient.ListFinancialPositionLogs(ctx, &pb.ListRequest{
 
 - **Client:** `services/current-account/client/financialaccounting_client.go`
 - **Proto Import:** `meridian/financial_accounting/v1/financial_accounting.proto`
-- **Resilience:** Circuit breaker via `resilient_client.go`
+- **Resilience:** Circuit breaker via `shared/pkg/clients`
 
 **Usage Pattern:**
 

--- a/docs/architecture/bian-service-boundaries.md
+++ b/docs/architecture/bian-service-boundaries.md
@@ -703,83 +703,64 @@ Platform code is currently in `internal/platform/` but is being migrated to `pkg
 - Duplicate request detection
 - Response caching for idempotent operations
 
-### Service-Specific Code (`internal/<service>/` - Private Implementation)
+### Service Structure
 
-Each service follows a layered architecture within its `internal/` directory. Code in `internal/<service>/` is private to that service and must not be imported by other services.
+Each service follows a layered architecture within its `services/<service>/` directory.
 
 #### CurrentAccount Service Structure
 
-```protobuf
-internal/current-account/
+```text
+services/current-account/
 ├── domain/              # Business logic and domain models
-│   ├── account.go       # Account entity and business rules
-│   ├── overdraft.go     # Overdraft limit enforcement
-│   └── transaction.go   # Transaction validation logic
 ├── service/             # gRPC service implementation
-│   ├── grpc_service.go  # CurrentAccountService RPC handlers
-│   └── orchestration.go # Multi-service orchestration logic
-├── clients/             # gRPC clients for downstream services
-│   ├── positionkeeping_client.go      # Position-keeping gRPC client
-│   ├── financialaccounting_client.go  # Financial-accounting gRPC client
-│   └── resilient_client.go            # Circuit breaker wrapper
-└── adapters/
-    └── persistence/     # Database adapters
-        └── repository.go # Audit log persistence
+├── client/              # Service-owned gRPC client (for consumers)
+├── adapters/
+│   └── persistence/     # Database adapters
+├── atlas/               # Schema configuration
+├── migrations/          # Database migrations
+└── k8s/                 # Kubernetes manifests
 ```
 
 **Key Characteristics:**
 
 - Domain models enforce account lifecycle rules
 - Service layer orchestrates cross-service operations
-- Clients implement anti-corruption layer for downstream services
-- Resilience patterns (circuit breaker, retry) protect against failures
+- Resilience patterns via `shared/pkg/clients` (circuit breaker, retry)
 
 #### PositionKeeping Service Structure
 
-```protobuf
-internal/position-keeping/
-├── domain/                  # Business logic and domain models
-│   ├── financial_position_log.go  # Aggregate root
-│   ├── transaction_log_entry.go   # Transaction records
-│   ├── transaction_lineage.go     # Lineage tracking
-│   ├── audit_trail_entry.go       # Audit records
-│   ├── status_tracking.go         # Status lifecycle
-│   └── event_publisher.go         # Domain event interface
-├── service/                 # gRPC service implementation
-│   └── position_keeping_service.go  # PositionKeepingService RPC handlers
+```text
+services/position-keeping/
+├── domain/              # Business logic, aggregate root pattern
+├── service/             # gRPC service implementation
+├── client/              # Service-owned gRPC client
 ├── adapters/
-│   ├── persistence/         # Database adapters
-│   │   └── repository.go    # Position log persistence
-│   └── messaging/           # Event publishing adapters
-│       └── kafka_event_publisher.go  # Kafka event adapter
-└── app/
-    └── container.go         # Dependency injection container
+│   ├── persistence/     # Database adapters
+│   └── messaging/       # Kafka event publisher
+├── atlas/               # Schema configuration
+├── migrations/          # Database migrations
+└── k8s/                 # Kubernetes manifests
 ```
 
 **Key Characteristics:**
 
 - Rich domain model with aggregate root pattern
-- Domain-driven design with clear entity boundaries
-- Event publishing via domain interface + Kafka adapter
+- Event publishing via Kafka adapter
 - Dependency injection for testability
 
 #### FinancialAccounting Service Structure
 
-```protobuf
-internal/financial-accounting/
-├── domain/                     # Business logic and domain models
-│   ├── financial_booking_log.go  # Booking log entity
-│   ├── ledger_posting.go         # Posting entity
-│   └── balance_validator.go      # Double-entry validation
-├── service/                    # gRPC service implementation
-│   ├── booking_service.go      # Booking log operations
-│   └── posting_service.go      # Ledger posting operations
-└── adapters/
-    ├── persistence/            # Database adapters
-    │   └── repository.go       # Booking log and posting persistence
-    └── messaging/              # Event-driven adapters
-        ├── deposit_consumer.go      # Kafka deposit event consumer
-        └── accounting_event_publisher.go  # Accounting event publisher
+```text
+services/financial-accounting/
+├── domain/              # Business logic, double-entry validation
+├── service/             # gRPC service implementation
+├── client/              # Service-owned gRPC client
+├── adapters/
+│   ├── persistence/     # Database adapters
+│   └── messaging/       # Kafka consumer for position-keeping events
+├── atlas/               # Schema configuration
+├── migrations/          # Database migrations
+└── k8s/                 # Kubernetes manifests
 ```
 
 **Key Characteristics:**

--- a/services/README.md
+++ b/services/README.md
@@ -281,12 +281,9 @@ their own client.
 
 ```text
 services/<service-name>/
-├── client/                 # Service-owned client library (NEW)
+├── client/                 # Service-owned client library
 │   ├── client.go           # Client implementation
 │   └── client_test.go      # Client tests
-├── clients/                # Consumer-specific interfaces (DEPRECATED)
-│   ├── DEPRECATED.md       # Migration guide
-│   └── interfaces.go       # Interface definitions for testing
 └── ...
 ```
 
@@ -365,18 +362,6 @@ When `Resilience` is configured, clients automatically include:
 | CurrentAccount | `services/current-account/client` | 50057 |
 | Tenant | `services/tenant/client` | 50056 |
 
-### Migration from Old Clients
-
-The old `services/<service>/clients/` directories are deprecated. See the `DEPRECATED.md` file
-in each directory for migration guidance. Key changes:
-
-| Old Pattern | New Pattern |
-|-------------|-------------|
-| Consumer creates/owns client | Service exports its own client |
-| `clients.NewXxxClient()` | `xxxclient.New()` |
-| Separate resilience wrapper | Built-in via `Config.Resilience` |
-| Manual connection management | Cleanup function returned by `New()` |
-
 ## Service Directory Structure
 
 Each service follows hexagonal architecture:
@@ -384,15 +369,13 @@ Each service follows hexagonal architecture:
 ```text
 services/<service-name>/
 ├── cmd/                    # Entry point, main.go, Dockerfile
-├── app/                    # Application bootstrap, DI container
 ├── domain/                 # Business logic, entities, value objects
-├── service/                # Use cases, gRPC service implementation
+├── service/                # gRPC service implementation
 ├── adapters/               # External adapters
 │   ├── persistence/        # Database repositories
-│   ├── messaging/          # Kafka producers/consumers
-│   └── http/               # HTTP handlers (if applicable)
-├── client/                 # Service-owned client library (for other services)
-├── clients/                # Consumer-specific interfaces (DEPRECATED)
+│   └── messaging/          # Kafka producers/consumers (if applicable)
+├── client/                 # Service-owned client library
+├── atlas/                  # Atlas schema config
 ├── migrations/             # Database migrations
 └── k8s/                    # Kubernetes manifests
 ```


### PR DESCRIPTION
## Summary

Editor-in-chief pass on documentation to ensure factual accuracy and remove stale content.

## Changes Made

**README.md**
- Added missing services: `gateway`, `audit-worker`, `utilization-metering-consumer`
- Fixed utilities structure: `cmd/tenantctl` not `utilities/meridian` (which doesn't exist)
- Added `atlas/` to service structure example
- Tightened Infrastructure Services section

**services/README.md**
- Removed deprecated `clients/` directory from structure examples
- Removed stale "Migration from Old Clients" section (migration complete)
- Updated service directory structure to current reality

**ADR-015 (Standard Service Directory Structure)**
- Changed `clients/` → `client/` pattern throughout
- Updated "When to Add" table to reflect service-owned client pattern

**docs/architecture/bian-service-boundaries.md**
- Updated service structure sections from `internal/` to `services/` paths
- Simplified directory examples to current pattern

## Metrics

- Net reduction: **32 lines removed** while improving accuracy
- Zero new documentation added (editor mode, not author mode)

## Test Plan

- [x] All markdown files pass linting
- [x] Directory structures match actual codebase