### PR TITLE
fix: correct TestAlertCheckIntegration to set updated_at for alert query

### DIFF
--- a/services/tenant/worker/provisioning_worker_integration_test.go
+++ b/services/tenant/worker/provisioning_worker_integration_test.go
@@ -657,6 +657,11 @@ func TestAlertCheckIntegration(t *testing.T) {
 	}
 	require.NoError(t, repo.Create(tc.ctx, testTenant))
 
+	// GORM's autoUpdateTime sets updated_at to now() on create, but ListByStatusOlderThan
+	// queries by updated_at. Update it to match created_at for the test to work correctly.
+	err := tc.db.Exec("UPDATE tenant SET updated_at = created_at WHERE id = ?", testTenant.ID.String()).Error
+	require.NoError(t, err)
+
 	// Capture log output to verify alert is logged
 	var logBuffer safeBuffer
 	testLogger := slog.New(slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
@@ -676,8 +681,10 @@ func TestAlertCheckIntegration(t *testing.T) {
 
 	go worker.Start(ctx)
 
-	// Wait for alert check to execute (should happen within 1 second + buffer)
-	err = await.AtMost(3 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+	// Wait for alert check to execute. The ticker fires after AlertInterval (1s),
+	// then the check runs (database query + logging). On CI with resource contention,
+	// this can take longer than expected, so we use a generous 5s timeout.
+	err = await.AtMost(5 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
 		logOutput := logBuffer.String()
 		return strings.Contains(logOutput, "tenant provisioning failure alert") &&
 			strings.Contains(logOutput, "failed_alert_tenant")


### PR DESCRIPTION
## Summary

- Fixes the nightly build failure in `TestAlertCheckIntegration`
- The test was setting `CreatedAt` to 2 hours ago, but GORM's `autoUpdateTime` was still setting `updated_at` to `now()`
- Since `ListByStatusOlderThan` queries by `updated_at`, the test tenant was never found

## Changes Made

- Added raw SQL update after tenant creation to set `updated_at = created_at` (consistent with patterns in `repository_test.go`)
- Increased await timeout from 3s to 5s for additional CI reliability margin

## Root Cause

The `TenantEntity` has:
```go
UpdatedAt time.Time `gorm:"column:updated_at;not null;autoUpdateTime"`
```

When the test called `repo.Create()` with `CreatedAt` set to 2 hours ago, GORM still set `updated_at` to the current time. The `ListByStatusOlderThan` query:
```go
Where("status = ? AND updated_at < ?", status, cutoff)
```
...never matched the tenant because `updated_at` was too recent.

## Test Plan

- [x] `TestAlertCheckIntegration` now passes locally
- [x] Pre-commit checks pass (gofumpt, golangci-lint)