### PR TITLE
chore: remove unused error sentinels from shared/pkg/clients

### DIFF
--- a/shared/pkg/clients/errors.go
+++ b/shared/pkg/clients/errors.go
@@ -38,17 +38,11 @@ var (
 )
 
 // Service-specific client configuration errors.
-// These wrap ErrConfigClientNil with service-specific context.
+// These provide service-specific context for nil dependency validation.
 var (
 	// ErrConfigPositionKeepingClientNil indicates the position keeping client is nil.
 	ErrConfigPositionKeepingClientNil = errors.New("config: position keeping client cannot be nil")
 
 	// ErrConfigFinancialAccountingClientNil indicates the financial accounting client is nil.
 	ErrConfigFinancialAccountingClientNil = errors.New("config: financial accounting client cannot be nil")
-
-	// ErrConfigCurrentAccountClientNil indicates the current account client is nil.
-	ErrConfigCurrentAccountClientNil = errors.New("config: current account client cannot be nil")
-
-	// ErrConfigPaymentGatewayNil indicates the payment gateway is nil.
-	ErrConfigPaymentGatewayNil = errors.New("config: payment gateway cannot be nil")
 )


### PR DESCRIPTION
## Summary

Remove unused error sentinel values from `shared/pkg/clients/errors.go`:
- `ErrConfigCurrentAccountClientNil` - zero references across codebase
- `ErrConfigPaymentGatewayNil` - zero references across codebase

**Lines removed: 6**

## Context

Follow-up to PR #474 (BasePartyClient cleanup). Dead code audit identified these unused sentinels that were planned for service validation but services evolved a different pattern.

## Verification

```bash
rg "ErrConfigCurrentAccountClientNil|ErrConfigPaymentGatewayNil" --type go
# Only found in errors.go definition - zero usage
```

## Kept (in use)

These are used by `current-account` orchestrators and remain:
- `ErrConfigPositionKeepingClientNil` 
- `ErrConfigFinancialAccountingClientNil`

## Test Plan

- [x] `go build ./shared/pkg/clients` passes
- [x] `go test ./shared/pkg/clients/...` passes (all 76 tests)
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)