### PR TITLE
feat: lock zero-state contracts for universal asset system

### DIFF
--- a/api/proto/meridian/quantity/v1/quantity.proto
+++ b/api/proto/meridian/quantity/v1/quantity.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package meridian.quantity.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1;quantityv1";
+
+// AttributeEntry represents a key-value attribute for an instrument amount.
+// Uses repeated struct instead of map to support poolability (deterministic ordering).
+message AttributeEntry {
+  // key is the attribute name in snake_case format.
+  string key = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[a-z][a-z0-9_]*$"
+  }];
+
+  // value is the attribute value.
+  string value = 2 [(buf.validate.field).string.max_len = 256];
+}
+
+// InstrumentAmount represents a quantity of a specific instrument with optional attributes.
+// This is the universal representation for any asset type: currencies, energy, commodities, etc.
+message InstrumentAmount {
+  // amount is the decimal quantity as a string for precision (e.g., "1234.567890").
+  // String format preserves arbitrary precision without floating-point errors.
+  string amount = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 40
+    pattern: "^-?[0-9]+(\\.[0-9]+)?$"
+  }];
+
+  // instrument_code is the unique identifier for the instrument (e.g., "USD", "KWH", "CARBON_CREDIT").
+  string instrument_code = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // version is the instrument definition version for schema evolution.
+  int32 version = 3 [(buf.validate.field).int32.gte = 1];
+
+  // attributes contains additional metadata for this amount (e.g., batch_id, location, quality_grade).
+  // Uses repeated instead of map to support deterministic poolability key generation.
+  repeated AttributeEntry attributes = 4;
+
+  // valid_from is when this amount becomes valid (optional, for time-bound assets).
+  google.protobuf.Timestamp valid_from = 5;
+
+  // valid_to is when this amount expires (optional, for time-bound assets).
+  google.protobuf.Timestamp valid_to = 6;
+
+  // source identifies the origin of this amount (e.g., "meter_reading", "manual_entry", "settlement").
+  string source = 7 [(buf.validate.field).string.max_len = 64];
+}

--- a/api/proto/meridian/reference_data/v1/instrument.proto
+++ b/api/proto/meridian/reference_data/v1/instrument.proto
@@ -106,4 +106,7 @@ message InstrumentDefinition {
 
   // activated_at is when this definition became active (null if never activated).
   google.protobuf.Timestamp activated_at = 15;
+
+  // deprecated_at is when this definition was deprecated (null if not deprecated).
+  google.protobuf.Timestamp deprecated_at = 16;
 }

--- a/api/proto/meridian/reference_data/v1/instrument.proto
+++ b/api/proto/meridian/reference_data/v1/instrument.proto
@@ -64,7 +64,11 @@ message InstrumentDefinition {
   int32 version = 4 [(buf.validate.field).int32.gte = 1];
 
   // dimension is the physical or conceptual dimension this instrument measures.
-  Dimension dimension = 5 [(buf.validate.field).enum.defined_only = true];
+  // DIMENSION_UNSPECIFIED (0) is rejected - instruments must have a defined dimension.
+  Dimension dimension = 5 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
 
   // precision is the number of decimal places for this instrument (0-18).
   int32 precision = 6 [(buf.validate.field).int32 = {
@@ -73,7 +77,11 @@ message InstrumentDefinition {
   }];
 
   // status is the lifecycle state of this definition.
-  InstrumentStatus status = 7 [(buf.validate.field).enum.defined_only = true];
+  // INSTRUMENT_STATUS_UNSPECIFIED (0) is rejected - instruments must have a defined status.
+  InstrumentStatus status = 7 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
 
   // validation_expression is a CEL expression to validate instrument amounts.
   // Example: "amount > 0 && (attributes.batch_id != '' || instrument.dimension == 'CURRENCY')"

--- a/api/proto/meridian/reference_data/v1/instrument.proto
+++ b/api/proto/meridian/reference_data/v1/instrument.proto
@@ -49,11 +49,9 @@ message InstrumentDefinition {
   // id is the unique identifier for this definition (UUID).
   string id = 1 [(buf.validate.field).string.uuid = true];
 
-  // tenant_id identifies the tenant that owns this definition.
-  string tenant_id = 2 [(buf.validate.field).string = {
-    min_len: 1
-    max_len: 64
-  }];
+  // Note: tenant_id is NOT included here. Tenant isolation is handled at the
+  // database schema level - each tenant has their own schema. The tenant context
+  // flows through request headers and is extracted by interceptors for schema routing.
 
   // code is the unique instrument code within the tenant (e.g., "USD", "KWH").
   string code = 3 [(buf.validate.field).string = {

--- a/api/proto/meridian/reference_data/v1/instrument.proto
+++ b/api/proto/meridian/reference_data/v1/instrument.proto
@@ -107,4 +107,9 @@ message InstrumentDefinition {
 
   // deprecated_at is when this definition was deprecated (null if not deprecated).
   google.protobuf.Timestamp deprecated_at = 16;
+
+  // is_system indicates this instrument was seeded during tenant provisioning.
+  // System instruments are read-only (cannot be modified or deleted by tenants).
+  // Examples: USD, EUR, GBP - platform-wide instruments available to all tenants.
+  bool is_system = 17;
 }

--- a/api/proto/meridian/reference_data/v1/instrument.proto
+++ b/api/proto/meridian/reference_data/v1/instrument.proto
@@ -1,0 +1,109 @@
+syntax = "proto3";
+
+package meridian.reference_data.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1;referencedatav1";
+
+// InstrumentStatus defines the lifecycle state of an instrument definition.
+enum InstrumentStatus {
+  // INSTRUMENT_STATUS_UNSPECIFIED means the status is unknown.
+  INSTRUMENT_STATUS_UNSPECIFIED = 0;
+  // INSTRUMENT_STATUS_DRAFT means the instrument is being defined and cannot be used.
+  INSTRUMENT_STATUS_DRAFT = 1;
+  // INSTRUMENT_STATUS_ACTIVE means the instrument is available for use.
+  INSTRUMENT_STATUS_ACTIVE = 2;
+  // INSTRUMENT_STATUS_DEPRECATED means the instrument is no longer recommended for new use.
+  INSTRUMENT_STATUS_DEPRECATED = 3;
+}
+
+// Dimension defines the physical or conceptual dimension an instrument measures.
+enum Dimension {
+  // DIMENSION_UNSPECIFIED means the dimension is unknown.
+  DIMENSION_UNSPECIFIED = 0;
+  // DIMENSION_CURRENCY represents monetary values (USD, EUR, GBP).
+  DIMENSION_CURRENCY = 1;
+  // DIMENSION_ENERGY represents energy quantities (KWH, MWH, THERM).
+  DIMENSION_ENERGY = 2;
+  // DIMENSION_MASS represents mass quantities (KG, TON, LB).
+  DIMENSION_MASS = 3;
+  // DIMENSION_VOLUME represents volume quantities (LITRE, GALLON, BARREL).
+  DIMENSION_VOLUME = 4;
+  // DIMENSION_TIME represents time quantities (SECOND, HOUR, DAY).
+  DIMENSION_TIME = 5;
+  // DIMENSION_COMPUTE represents computational resources (GPU_HOUR, CPU_SECOND).
+  DIMENSION_COMPUTE = 6;
+  // DIMENSION_CARBON represents carbon credits or emissions (TONNE_CO2E).
+  DIMENSION_CARBON = 7;
+  // DIMENSION_DATA represents data quantities (GB, TB).
+  DIMENSION_DATA = 8;
+  // DIMENSION_COUNT represents countable items (units, tokens, vouchers).
+  DIMENSION_COUNT = 9;
+}
+
+// InstrumentDefinition defines a type of tradeable or measurable asset.
+// This is the reference data that describes how instrument amounts are validated and pooled.
+message InstrumentDefinition {
+  // id is the unique identifier for this definition (UUID).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // tenant_id identifies the tenant that owns this definition.
+  string tenant_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+  }];
+
+  // code is the unique instrument code within the tenant (e.g., "USD", "KWH").
+  string code = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // version is the schema version for this definition (monotonically increasing).
+  int32 version = 4 [(buf.validate.field).int32.gte = 1];
+
+  // dimension is the physical or conceptual dimension this instrument measures.
+  Dimension dimension = 5 [(buf.validate.field).enum.defined_only = true];
+
+  // precision is the number of decimal places for this instrument (0-18).
+  int32 precision = 6 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 18
+  }];
+
+  // status is the lifecycle state of this definition.
+  InstrumentStatus status = 7 [(buf.validate.field).enum.defined_only = true];
+
+  // validation_expression is a CEL expression to validate instrument amounts.
+  // Example: "amount > 0 && (attributes.batch_id != '' || instrument.dimension == 'CURRENCY')"
+  string validation_expression = 8 [(buf.validate.field).string.max_len = 2048];
+
+  // fungibility_key_expression is a CEL expression to generate the poolability key.
+  // Amounts with the same key can be pooled together.
+  // Example: "instrument_code + ':' + string(version)" for fully fungible instruments.
+  // Example: "instrument_code + ':' + attributes.batch_id" for batch-segregated inventory.
+  string fungibility_key_expression = 9 [(buf.validate.field).string.max_len = 2048];
+
+  // error_message_expression is a CEL expression to generate custom validation error messages.
+  // Example: "'Invalid amount: ' + string(amount) + ' for instrument ' + instrument_code"
+  string error_message_expression = 10 [(buf.validate.field).string.max_len = 2048];
+
+  // attribute_schema is a JSON Schema defining valid attributes for this instrument.
+  // Example: {"type":"object","properties":{"batch_id":{"type":"string"}}}
+  string attribute_schema = 11 [(buf.validate.field).string.max_len = 16384];
+
+  // display_name is the human-readable name for this instrument.
+  string display_name = 12 [(buf.validate.field).string.max_len = 128];
+
+  // description provides additional context about this instrument.
+  string description = 13 [(buf.validate.field).string.max_len = 1024];
+
+  // created_at is when this definition was created.
+  google.protobuf.Timestamp created_at = 14 [(buf.validate.field).required = true];
+
+  // activated_at is when this definition became active (null if never activated).
+  google.protobuf.Timestamp activated_at = 15;
+}

--- a/pkg/platform/quantity/interfaces.go
+++ b/pkg/platform/quantity/interfaces.go
@@ -1,0 +1,155 @@
+// Package quantity defines the core interfaces for the Universal Asset System.
+// These interfaces establish contracts for working with multi-dimensional quantities
+// that can represent currencies, energy, commodities, carbon credits, and other assets.
+package quantity
+
+import (
+	"context"
+	"time"
+)
+
+// Dimension represents a physical or conceptual dimension that an instrument measures.
+// Implementations must be comparable and suitable for use as map keys.
+type Dimension interface {
+	// String returns the canonical string representation of the dimension (e.g., "CURRENCY", "ENERGY").
+	String() string
+
+	// Validate returns an error if the dimension is not valid.
+	Validate() error
+}
+
+// Attribute represents a key-value pair attached to a quantity.
+type Attribute struct {
+	Key   string
+	Value string
+}
+
+// Quantity represents an amount of a specific instrument with optional attributes.
+// The type parameter D constrains the dimension type for compile-time safety.
+type Quantity[D Dimension] interface {
+	// Amount returns the decimal amount as a string for arbitrary precision.
+	Amount() string
+
+	// InstrumentCode returns the instrument identifier (e.g., "USD", "KWH").
+	InstrumentCode() string
+
+	// Version returns the instrument definition version.
+	Version() int32
+
+	// Attributes returns the key-value attributes attached to this quantity.
+	// Returns a copy to prevent mutation.
+	Attributes() []Attribute
+
+	// Dimension returns the dimension of this quantity.
+	Dimension() D
+
+	// ValidFrom returns the time from which this quantity is valid, or nil if unbounded.
+	ValidFrom() *time.Time
+
+	// ValidTo returns the time until which this quantity is valid, or nil if unbounded.
+	ValidTo() *time.Time
+
+	// Source returns the origin identifier for this quantity.
+	Source() string
+
+	// Add returns a new quantity that is the sum of this quantity and other.
+	// Returns an error if the quantities cannot be added (different instruments, incompatible attributes).
+	Add(other Quantity[D]) (Quantity[D], error)
+
+	// Subtract returns a new quantity that is this quantity minus other.
+	// Returns an error if the quantities cannot be subtracted.
+	Subtract(other Quantity[D]) (Quantity[D], error)
+
+	// Multiply returns a new quantity with the amount multiplied by the given factor.
+	// The factor is a string decimal for precision.
+	Multiply(factor string) (Quantity[D], error)
+
+	// IsNegative returns true if the amount is negative.
+	IsNegative() bool
+
+	// IsZero returns true if the amount is zero.
+	IsZero() bool
+
+	// FungibilityKey returns the poolability key for this quantity.
+	// Quantities with the same key can be pooled together.
+	FungibilityKey() string
+}
+
+// InstrumentDefinition represents the reference data for an instrument type.
+type InstrumentDefinition struct {
+	ID                       string
+	TenantID                 string
+	Code                     string
+	Version                  int32
+	Dimension                string
+	Precision                int32
+	Status                   string
+	ValidationExpression     string
+	FungibilityKeyExpression string
+	ErrorMessageExpression   string
+	AttributeSchema          string
+	DisplayName              string
+	Description              string
+	CreatedAt                time.Time
+	ActivatedAt              *time.Time
+}
+
+// InstrumentRegistry provides access to instrument definitions.
+type InstrumentRegistry interface {
+	// GetDefinition retrieves an instrument definition by tenant, code, and version.
+	// Returns an error if the instrument is not found.
+	GetDefinition(ctx context.Context, tenantID, code string, version int32) (*InstrumentDefinition, error)
+
+	// GetActiveDefinition retrieves the active version of an instrument.
+	// Returns an error if no active version exists.
+	GetActiveDefinition(ctx context.Context, tenantID, code string) (*InstrumentDefinition, error)
+
+	// ListActive returns all active instrument definitions for a tenant.
+	ListActive(ctx context.Context, tenantID string) ([]*InstrumentDefinition, error)
+
+	// CreateDraft creates a new instrument definition in DRAFT status.
+	// Returns the created definition with assigned ID.
+	CreateDraft(ctx context.Context, def *InstrumentDefinition) (*InstrumentDefinition, error)
+
+	// ActivateInstrument transitions an instrument from DRAFT to ACTIVE status.
+	// Returns an error if the instrument is not in DRAFT status.
+	ActivateInstrument(ctx context.Context, tenantID, code string, version int32) error
+
+	// DeprecateInstrument transitions an instrument to DEPRECATED status.
+	// Returns an error if the instrument is not in ACTIVE status.
+	DeprecateInstrument(ctx context.Context, tenantID, code string, version int32) error
+}
+
+// CachedInstrumentRegistry wraps an InstrumentRegistry with caching capabilities.
+type CachedInstrumentRegistry interface {
+	InstrumentRegistry
+
+	// InvalidateCache removes cached entries for the specified instrument.
+	// Pass empty code to invalidate all instruments for the tenant.
+	InvalidateCache(tenantID, code string)
+
+	// InvalidateAll removes all cached entries.
+	InvalidateAll()
+}
+
+// CELEvaluationResult contains the result of a CEL expression evaluation.
+type CELEvaluationResult struct {
+	Valid        bool
+	ErrorMessage string
+	ResultValue  any
+}
+
+// CELEvaluator evaluates Common Expression Language expressions for instrument validation.
+type CELEvaluator interface {
+	// Validate evaluates a validation expression against the given attributes.
+	// Returns the validation result including any error message.
+	Validate(ctx context.Context, expression string, amount string, instrumentCode string, attributes []Attribute) (*CELEvaluationResult, error)
+
+	// GenerateFungibilityKey evaluates a fungibility key expression.
+	// Returns the computed key as a string.
+	GenerateFungibilityKey(ctx context.Context, expression string, amount string, instrumentCode string, version int32, attributes []Attribute) (string, error)
+
+	// GenerateErrorMessage evaluates an error message expression.
+	// Returns the computed error message.
+	GenerateErrorMessage(ctx context.Context, expression string, amount string, instrumentCode string, attributes []Attribute) (string, error)
+}

--- a/pkg/platform/quantity/interfaces.go
+++ b/pkg/platform/quantity/interfaces.go
@@ -139,17 +139,30 @@ type CELEvaluationResult struct {
 	ResultValue  any
 }
 
+// InstrumentContext provides instrument metadata for CEL expression evaluation.
+// CEL expressions can access these values via the "instrument" variable.
+// Example: "instrument.precision == 2 && instrument.dimension == 'CURRENCY'"
+type InstrumentContext struct {
+	Code      string // Instrument code (e.g., "USD", "KWH")
+	Version   int32  // Instrument definition version
+	Dimension string // Physical/conceptual dimension (e.g., "CURRENCY", "ENERGY")
+	Precision int32  // Number of decimal places (0-18)
+}
+
 // CELEvaluator evaluates Common Expression Language expressions for instrument validation.
 type CELEvaluator interface {
 	// Validate evaluates a validation expression against the given attributes.
+	// The instrument context is available in CEL as "instrument" (e.g., "instrument.precision == 2").
 	// Returns the validation result including any error message.
-	Validate(ctx context.Context, expression string, amount string, instrumentCode string, attributes []Attribute) (*CELEvaluationResult, error)
+	Validate(ctx context.Context, expression string, amount string, instrument InstrumentContext, attributes []Attribute) (*CELEvaluationResult, error)
 
 	// GenerateFungibilityKey evaluates a fungibility key expression.
+	// The instrument context is available in CEL as "instrument".
 	// Returns the computed key as a string.
-	GenerateFungibilityKey(ctx context.Context, expression string, amount string, instrumentCode string, version int32, attributes []Attribute) (string, error)
+	GenerateFungibilityKey(ctx context.Context, expression string, amount string, instrument InstrumentContext, attributes []Attribute) (string, error)
 
 	// GenerateErrorMessage evaluates an error message expression.
+	// The instrument context is available in CEL as "instrument".
 	// Returns the computed error message.
-	GenerateErrorMessage(ctx context.Context, expression string, amount string, instrumentCode string, attributes []Attribute) (string, error)
+	GenerateErrorMessage(ctx context.Context, expression string, amount string, instrument InstrumentContext, attributes []Attribute) (string, error)
 }

--- a/pkg/platform/quantity/interfaces.go
+++ b/pkg/platform/quantity/interfaces.go
@@ -92,6 +92,7 @@ type InstrumentDefinition struct {
 	Description              string
 	CreatedAt                time.Time
 	ActivatedAt              *time.Time
+	DeprecatedAt             *time.Time
 }
 
 // InstrumentRegistry provides access to instrument definitions.

--- a/pkg/platform/quantity/interfaces.go
+++ b/pkg/platform/quantity/interfaces.go
@@ -76,9 +76,11 @@ type Quantity[D Dimension] interface {
 }
 
 // InstrumentDefinition represents the reference data for an instrument type.
+// Note: TenantID is NOT included here. Tenant isolation is handled at the database
+// schema level - each tenant has their own schema. The tenant context flows through
+// request headers and is extracted by interceptors for schema routing.
 type InstrumentDefinition struct {
 	ID                       string
-	TenantID                 string
 	Code                     string
 	Version                  int32
 	Dimension                string
@@ -96,17 +98,19 @@ type InstrumentDefinition struct {
 }
 
 // InstrumentRegistry provides access to instrument definitions.
+// Tenant context is extracted from ctx by the implementation (schema-per-tenant routing).
 type InstrumentRegistry interface {
-	// GetDefinition retrieves an instrument definition by tenant, code, and version.
+	// GetDefinition retrieves an instrument definition by code and version.
+	// Tenant is determined from ctx (extracted from request headers by interceptors).
 	// Returns an error if the instrument is not found.
-	GetDefinition(ctx context.Context, tenantID, code string, version int32) (*InstrumentDefinition, error)
+	GetDefinition(ctx context.Context, code string, version int32) (*InstrumentDefinition, error)
 
 	// GetActiveDefinition retrieves the active version of an instrument.
 	// Returns an error if no active version exists.
-	GetActiveDefinition(ctx context.Context, tenantID, code string) (*InstrumentDefinition, error)
+	GetActiveDefinition(ctx context.Context, code string) (*InstrumentDefinition, error)
 
-	// ListActive returns all active instrument definitions for a tenant.
-	ListActive(ctx context.Context, tenantID string) ([]*InstrumentDefinition, error)
+	// ListActive returns all active instrument definitions for the tenant (from ctx).
+	ListActive(ctx context.Context) ([]*InstrumentDefinition, error)
 
 	// CreateDraft creates a new instrument definition in DRAFT status.
 	// Returns the created definition with assigned ID.
@@ -114,22 +118,24 @@ type InstrumentRegistry interface {
 
 	// ActivateInstrument transitions an instrument from DRAFT to ACTIVE status.
 	// Returns an error if the instrument is not in DRAFT status.
-	ActivateInstrument(ctx context.Context, tenantID, code string, version int32) error
+	ActivateInstrument(ctx context.Context, code string, version int32) error
 
 	// DeprecateInstrument transitions an instrument to DEPRECATED status.
 	// Returns an error if the instrument is not in ACTIVE status.
-	DeprecateInstrument(ctx context.Context, tenantID, code string, version int32) error
+	DeprecateInstrument(ctx context.Context, code string, version int32) error
 }
 
 // CachedInstrumentRegistry wraps an InstrumentRegistry with caching capabilities.
+// Cache keys are internally scoped by tenant (determined from ctx during lookups).
 type CachedInstrumentRegistry interface {
 	InstrumentRegistry
 
-	// InvalidateCache removes cached entries for the specified instrument.
-	// Pass empty code to invalidate all instruments for the tenant.
-	InvalidateCache(tenantID, code string)
+	// InvalidateCache removes cached entries for the specified instrument within the
+	// current tenant context (from ctx). Pass empty code to invalidate all instruments.
+	InvalidateCache(ctx context.Context, code string)
 
-	// InvalidateAll removes all cached entries.
+	// InvalidateAll removes all cached entries across all tenants.
+	// Use with caution - typically only for system-wide cache refresh.
 	InvalidateAll()
 }
 

--- a/pkg/platform/quantity/interfaces.go
+++ b/pkg/platform/quantity/interfaces.go
@@ -95,6 +95,7 @@ type InstrumentDefinition struct {
 	CreatedAt                time.Time
 	ActivatedAt              *time.Time
 	DeprecatedAt             *time.Time
+	IsSystem                 bool // true = seeded during tenant provisioning, read-only
 }
 
 // InstrumentRegistry provides access to instrument definitions.


### PR DESCRIPTION
## Summary

- Create immutable API contracts for the Universal Asset System before parallel implementation streams begin
- Establish proto schemas for quantity types (InstrumentAmount, AttributeEntry) and instrument definitions
- Define Go interfaces for Dimension, Quantity, InstrumentRegistry, and CELEvaluator

## Task Master Reference

**Tag**: universal-asset-system
**Task**: 1 - Create Zero-State Contract Files (Proto + Interfaces)

## Changes Made

### Proto Contracts
- `api/proto/meridian/quantity/v1/quantity.proto`: InstrumentAmount and AttributeEntry messages for representing quantities of any instrument type
- `api/proto/meridian/reference_data/v1/instrument.proto`: InstrumentDefinition, Dimension, and InstrumentStatus for instrument reference data

### Go Interfaces
- `pkg/platform/quantity/interfaces.go`: Core interfaces including:
  - `Dimension` interface for type-safe dimension representation
  - `Quantity[D]` generic interface for compile-time dimension safety
  - `InstrumentRegistry` and `CachedInstrumentRegistry` interfaces
  - `CELEvaluator` interface for validation expressions

## Contract Verification

SHA256 checksums for contract verification:
```
e50b694b8781af25bc1b9788880fa7fcd0307644b07809cacd04e7e414cfd781  quantity.proto
55aa3a3dd15e7ab0ed3d8bafb8cf8b036f0a5036c3cfadc4fe64cd178c13a8bf  instrument.proto
88ed7ba608cf46cc56726e94da49557f8d27d15bd76ba9f812b73d3f817added  interfaces.go
```

## Test Plan

- [x] `buf lint` passes
- [x] `buf build` succeeds
- [x] `buf generate` produces valid Go stubs
- [x] `go build ./...` compiles without errors
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)