### PR TITLE
docs: add PRD skills structure with metadata frontmatter

### DIFF
--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -1,0 +1,74 @@
+# Product Requirements Documents (PRDs)
+
+This directory contains Product Requirements Documents for Meridian features. Like ADRs, these
+documents are configured as Claude Code skills that automatically load when relevant triggers match.
+
+## What are PRDs?
+
+PRDs define the requirements, design, and implementation approach for significant features. They:
+
+- Document the "what" and "why" of features before implementation
+- Provide context for AI assistants during development
+- Define Task Master tags for tracking work
+- Link to related ADRs for architectural decisions
+
+## PRD Index
+
+| PRD | Title | Status | Task Master Tag |
+|-----|-------|--------|-----------------|
+| [Universal Asset System](universal-asset-system.md) | Multi-asset ledger support | Draft | `universal-asset-system` |
+
+## Categories
+
+### Core Platform
+
+- [Universal Asset System](universal-asset-system.md) - Multi-asset support with dimensional safety
+
+## How PRD Skills Work
+
+Each PRD has YAML frontmatter that enables Claude Code to automatically load it when relevant:
+
+```yaml
+---
+name: prd-universal-asset-system
+description: Extend Meridian's ledger from fiat-only to multi-asset support
+triggers:
+  - Implementing multi-asset or universal asset support
+  - Working on InstrumentType, Quantity, or asset definitions
+instructions: |
+  Key patterns and guidance for implementing this PRD...
+---
+```
+
+Claude Code loads PRDs when:
+
+- Discussion topics match the triggers
+- Keywords align with the PRD's domain
+- The instructions would be helpful for the current task
+
+## Creating New PRDs
+
+1. Create a new markdown file with descriptive name (e.g., `feature-name.md`)
+2. Add YAML frontmatter with:
+   - `name`: Unique identifier (e.g., `prd-feature-name`)
+   - `description`: One-line summary
+   - `triggers`: List of scenarios when this PRD should load
+   - `instructions`: Key guidance for Claude Code
+3. Write the PRD content following the existing structure
+4. Update this README with the new entry
+5. If applicable, create related ADRs for architectural decisions
+
+## PRD Structure
+
+PRDs typically include:
+
+- **Overview**: Goals and non-goals
+- **Requirements**: Functional and non-functional requirements
+- **Design**: Technical approach and contracts
+- **Work Streams**: Implementation phases with Task Master tags
+- **Success Metrics**: How to measure completion
+
+## Related Documentation
+
+- [Architecture Decision Records](../adr/README.md) - Architectural decisions
+- [Claude Code Skills](../claude-code-skills.md) - How skills work in Meridian

--- a/docs/prd/universal-asset-system.md
+++ b/docs/prd/universal-asset-system.md
@@ -1,3 +1,21 @@
+---
+name: prd-universal-asset-system
+description: Extend Meridian's ledger from fiat-only to multi-asset support with dimensional safety
+triggers:
+  - Implementing multi-asset or universal asset support
+  - Working on InstrumentType, Quantity, or asset definitions
+  - Adding new asset types (commodities, energy, vouchers)
+  - Designing tenant-specific asset catalogs
+  - Implementing dimensional safety or asset quantity types
+  - Working on reference data service
+instructions: |
+  This PRD defines the Universal Asset System for multi-asset ledger support.
+  Key patterns: Use Go generics for dimensional safety (Monetary vs Commodity).
+  Assets are configured via database, not code. Each tenant has isolated catalog.
+  Refer to ADR-0013 (Quantity Types) and ADR-0014 (Reference Data) for implementation.
+  Immutable proto contracts are defined in Zero-State Contract section - never modify.
+---
+
 # PRD: Universal Asset System
 
 **Status:** Draft


### PR DESCRIPTION
## Summary

- Add YAML frontmatter metadata to PRD files for Claude Code skill auto-loading
- Create README.md index for the `docs/prd/` folder following the ADR pattern
- Establish structure for future PRDs as contextual skills

## Changes Made

1. **`docs/prd/universal-asset-system.md`**: Added YAML frontmatter with:
   - `name`: Unique skill identifier
   - `description`: One-line summary
   - `triggers`: Scenarios when skill should load
   - `instructions`: Key guidance for Claude Code

2. **`docs/prd/README.md`**: New index file with:
   - PRD table with status and Task Master tags
   - Category organization
   - Guide for creating new PRDs
   - Explanation of how PRD skills work

## Follow-up

The parent `CLAUDE.md` (outside the repo) can be manually updated to reference PRDs similar to how ADRs are referenced:

```markdown
## Available Product Requirements Documents (PRDs)

All PRDs are located in `meridian-main/docs/prd/` and should be loaded when their triggers match:

- `meridian-main/docs/prd/universal-asset-system.md` - Multi-asset ledger support with dimensional safety
```

## Test Plan

- [x] Verify YAML frontmatter parses correctly (no syntax errors)
- [x] Verify markdownlint passes
- [ ] Verify Claude Code recognizes PRD skills when relevant triggers match