### PR TITLE
feat: implement InstrumentRegistry with system instrument protection

### DIFF
--- a/services/reference-data/README.md
+++ b/services/reference-data/README.md
@@ -1,0 +1,208 @@
+# Reference Data Service
+
+The Reference Data service manages instrument definitions for the Meridian ledger system.
+It is aligned with the BIAN Reference Data Directory domain.
+
+## Overview
+
+Instrument definitions describe measurement units, currencies, and asset types that can be
+tracked in the ledger. Each instrument specifies:
+
+- **Dimension**: What type of value it measures (MONETARY, ENERGY, QUANTITY, etc.)
+- **Precision**: Decimal places for amounts (0-18)
+- **Validation Rules**: CEL expressions for validating quantities
+- **Fungibility Rules**: CEL expressions for bucket key generation
+
+## Architecture
+
+### System Instruments vs Tenant Instruments
+
+The service supports two types of instruments:
+
+**System Instruments** (`is_system=true`):
+
+- Pre-defined instruments like USD, EUR, GBP, KWH
+- **Seeded during tenant provisioning** by the tenant provisioner service
+- Read-only through the InstrumentRegistry API
+- Visible to all operations within a tenant's schema
+
+**Tenant Instruments** (`is_system=false`):
+
+- Created by tenants through the InstrumentRegistry API
+- Full lifecycle management (DRAFT → ACTIVE → DEPRECATED)
+- Tenant-specific and isolated
+
+### Multi-Tenant Isolation
+
+This service uses schema-per-tenant architecture:
+
+- Each tenant has an isolated PostgreSQL schema (`org_<tenant_id>`)
+- System instruments are COPIED into each tenant's schema during provisioning
+- No cross-schema queries or SystemTenantID constants needed
+- Tenant context extracted from ctx via `shared/platform/tenant`
+
+## Component Responsibilities
+
+### Reference-Data Service (This Service)
+
+- Enforces `is_system` read-only constraint
+- Manages tenant instrument lifecycle
+- Compiles and executes CEL validation rules
+- **Does NOT seed system instruments**
+
+### Tenant Provisioner Service (services/tenant)
+
+- Creates tenant schemas
+- Seeds system instruments with `is_system=true`
+- See: `services/tenant/provisioner/postgres_provisioner.go`
+
+## Instrument Lifecycle
+
+```text
+DRAFT ─────► ACTIVE ─────► DEPRECATED
+  │            │               │
+  │ Editable   │ Immutable     │ Read-only
+  │            │ validation    │ not for new
+  └────────────┴───────────────┴─────────────
+```
+
+### Status Transitions
+
+| From | To | Allowed | Notes |
+|------|----|---------|-------|
+| DRAFT | ACTIVE | ✓ | Sets `activated_at` |
+| ACTIVE | DEPRECATED | ✓ | Sets `deprecated_at` |
+| DRAFT | DEPRECATED | ✗ | Must activate first |
+| ACTIVE | DRAFT | ✗ | Cannot revert activation |
+| DEPRECATED | * | ✗ | Terminal state |
+
+### System Instrument Protection
+
+All modification operations reject system instruments:
+
+- `CreateDraft` - Cannot create with `is_system=true`
+- `UpdateDefinition` - Cannot update system instruments
+- `ActivateInstrument` - Cannot activate system instruments
+- `DeprecateInstrument` - Cannot deprecate system instruments
+
+Read operations work normally for system instruments:
+
+- `GetDefinition` - Returns system instruments
+- `GetActiveDefinition` - Returns active system instruments
+- `ListActive` - Includes both system and tenant instruments
+
+## CEL Validation
+
+Instrument definitions can include CEL expressions for validation.
+
+### Available Variables
+
+```cel
+attributes: map[string]string  // Key-value attributes from quantity
+amount: string                 // Decimal amount as string
+valid_from: timestamp          // Optional validity start
+valid_to: timestamp           // Optional validity end
+source: string                // Origin identifier
+```
+
+### Example Expressions
+
+```cel
+// Validate positive amounts
+parse_int(amount) > 0
+
+// Validate renewable energy source
+attributes["source_type"] == "renewable"
+
+// Validate time range
+valid_from < valid_to
+
+// Complex validation
+parse_int(amount) > 0 &&
+attributes.exists("batch_id") &&
+parse_iso_date(attributes["expiry"]) > now()
+```
+
+### CEL Compilation
+
+Expressions are compiled at creation time (fail-fast):
+
+- Invalid expressions reject the CreateDraft/UpdateDefinition call
+- Compiled programs are cached for performance
+- CEL cost limits prevent expensive expressions (max 10,000 cost units)
+
+## Database Schema
+
+### instrument_definition Table
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | UUID | Primary key |
+| code | VARCHAR(50) | Instrument code (e.g., "USD") |
+| version | INTEGER | Version number |
+| dimension | VARCHAR(20) | MONETARY, ENERGY, QUANTITY, etc. |
+| precision | INTEGER | Decimal places (0-18) |
+| status | VARCHAR(20) | DRAFT, ACTIVE, DEPRECATED |
+| is_system | BOOLEAN | True for system instruments |
+| validation_expression | TEXT | CEL validation rule |
+| fungibility_key_expression | TEXT | CEL bucket key rule |
+| error_message_expression | TEXT | CEL custom error message |
+| attribute_schema | JSONB | JSON schema for attributes |
+| display_name | VARCHAR(255) | Human-readable name |
+| description | TEXT | Additional context |
+| created_at | TIMESTAMPTZ | Creation timestamp |
+| updated_at | TIMESTAMPTZ | Last modification |
+| activated_at | TIMESTAMPTZ | When status became ACTIVE |
+| deprecated_at | TIMESTAMPTZ | When status became DEPRECATED |
+
+### Migrations
+
+Located in `migrations/`:
+
+- `20260104000001_initial.sql` - Initial schema and triggers
+- `20260105000001_add_is_system.sql` - Adds is_system column
+
+**Note**: System instruments are NOT seeded by migrations. They are seeded by the tenant provisioning service.
+
+## Usage Example
+
+```go
+// Create registry
+pool, _ := pgxpool.New(ctx, connStr)
+registry, _ := registry.NewPostgresRegistry(pool)
+
+// Create tenant instrument
+def := &registry.InstrumentDefinition{
+    Code:                 "CARBON_CREDIT",
+    Version:              1,
+    Dimension:            registry.DimensionQuantity,
+    Precision:            0,
+    ValidationExpression: `parse_int(amount) > 0 && attributes.exists("vintage_year")`,
+    DisplayName:          "Carbon Credit",
+}
+registry.CreateDraft(ctx, def)
+registry.ActivateInstrument(ctx, "CARBON_CREDIT", 1)
+
+// Validate a quantity
+result, _ := registry.ValidateAttributes(ctx, "CARBON_CREDIT", 1, registry.AttributeBag{
+    Amount:     "100",
+    Attributes: map[string]string{"vintage_year": "2024"},
+})
+// result.Valid == true
+```
+
+## Testing
+
+Integration tests use Testcontainers:
+
+```bash
+go test ./services/reference-data/... -v
+```
+
+Tests cover:
+
+- CRUD operations
+- Lifecycle transitions
+- System instrument protection
+- CEL validation
+- Tenant isolation

--- a/services/reference-data/migrations/20260105000001_add_is_system.sql
+++ b/services/reference-data/migrations/20260105000001_add_is_system.sql
@@ -1,0 +1,15 @@
+-- Add is_system column to instrument_definition table
+-- System instruments (USD, EUR, GBP, etc.) are seeded during tenant provisioning
+-- and should be read-only. Application layer enforces this constraint via InstrumentRegistry.
+-- NOTE: System instruments are seeded by tenant provisioning service, not by this migration.
+
+-- Add is_system column with default false (tenant-created instruments are not system instruments)
+ALTER TABLE "instrument_definition"
+  ADD COLUMN "is_system" boolean NOT NULL DEFAULT false;
+
+-- Create index for efficient filtering of system vs tenant instruments
+CREATE INDEX "idx_instrument_definition_is_system" ON "instrument_definition" ("is_system");
+
+-- Composite index for listing active system instruments efficiently
+CREATE INDEX "idx_instrument_definition_is_system_active" ON "instrument_definition" ("is_system", "code")
+  WHERE "status" = 'ACTIVE';

--- a/services/reference-data/registry/postgres_registry.go
+++ b/services/reference-data/registry/postgres_registry.go
@@ -449,8 +449,14 @@ func (r *PostgresRegistry) ValidateAttributes(ctx context.Context, code string, 
 
 // buildCELInput constructs the input map for CEL evaluation.
 func (r *PostgresRegistry) buildCELInput(attrs AttributeBag) map[string]any {
+	// Ensure attributes is never nil to prevent CEL evaluation issues
+	attributes := attrs.Attributes
+	if attributes == nil {
+		attributes = make(map[string]string)
+	}
+
 	input := map[string]any{
-		"attributes": attrs.Attributes,
+		"attributes": attributes,
 		"amount":     attrs.Amount,
 		"source":     attrs.Source,
 		"valid_from": time.Time{},

--- a/services/reference-data/registry/postgres_registry.go
+++ b/services/reference-data/registry/postgres_registry.go
@@ -1,0 +1,684 @@
+// Package registry provides the InstrumentRegistry implementation backed by PostgreSQL.
+package registry
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+	refcel "github.com/meridianhub/meridian/services/reference-data/cel"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// PostgresRegistry implements InstrumentRegistry using PostgreSQL.
+type PostgresRegistry struct {
+	pool     *pgxpool.Pool
+	compiler *refcel.Compiler
+
+	// programCache stores compiled CEL programs keyed by "code:version:expression_type".
+	// This avoids recompiling CEL expressions on every ValidateAttributes call.
+	programCache   map[string]cel.Program
+	programCacheMu sync.RWMutex
+}
+
+// NewPostgresRegistry creates a new PostgreSQL-backed instrument registry.
+func NewPostgresRegistry(pool *pgxpool.Pool) (*PostgresRegistry, error) {
+	compiler, err := refcel.NewCompiler()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL compiler: %w", err)
+	}
+
+	return &PostgresRegistry{
+		pool:         pool,
+		compiler:     compiler,
+		programCache: make(map[string]cel.Program),
+	}, nil
+}
+
+// setSearchPath sets the PostgreSQL search_path for the transaction.
+// In multi-tenant mode, it sets the search_path to the tenant's schema.
+func (r *PostgresRegistry) setSearchPath(ctx context.Context, tx pgx.Tx) error {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return tenant.ErrMissingTenantContext
+	}
+
+	// Quote the schema name to prevent SQL injection
+	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
+
+	// SET LOCAL is transaction-scoped - automatically reverts on commit/rollback
+	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	_, err := tx.Exec(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to set tenant schema scope: %w", err)
+	}
+
+	return nil
+}
+
+// withReadTransaction executes a read-only function within a transaction with tenant scoping.
+func (r *PostgresRegistry) withReadTransaction(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit read transaction: %w", err)
+	}
+
+	return nil
+}
+
+// withWriteTransaction executes a write function within a transaction with tenant scoping.
+func (r *PostgresRegistry) withWriteTransaction(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// GetDefinition retrieves a specific instrument by code and version.
+func (r *PostgresRegistry) GetDefinition(ctx context.Context, code string, version int) (*InstrumentDefinition, error) {
+	var result *InstrumentDefinition
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, code, version, dimension, precision, status, is_system,
+				validation_expression, fungibility_key_expression, error_message_expression,
+				attribute_schema, display_name, description,
+				created_at, updated_at, activated_at, deprecated_at
+			FROM instrument_definition
+			WHERE code = $1 AND version = $2`
+
+		row := tx.QueryRow(ctx, query, code, version)
+		def, err := r.scanInstrumentDefinition(row)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to query instrument definition: %w", err)
+		}
+
+		result = def
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetActiveDefinition retrieves the latest ACTIVE version of an instrument.
+func (r *PostgresRegistry) GetActiveDefinition(ctx context.Context, code string) (*InstrumentDefinition, error) {
+	var result *InstrumentDefinition
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, code, version, dimension, precision, status, is_system,
+				validation_expression, fungibility_key_expression, error_message_expression,
+				attribute_schema, display_name, description,
+				created_at, updated_at, activated_at, deprecated_at
+			FROM instrument_definition
+			WHERE code = $1 AND status = 'ACTIVE'
+			ORDER BY version DESC
+			LIMIT 1`
+
+		row := tx.QueryRow(ctx, query, code)
+		def, err := r.scanInstrumentDefinition(row)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to query active instrument definition: %w", err)
+		}
+
+		result = def
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// ListActive retrieves all instruments with ACTIVE status.
+func (r *PostgresRegistry) ListActive(ctx context.Context) ([]*InstrumentDefinition, error) {
+	var result []*InstrumentDefinition
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, code, version, dimension, precision, status, is_system,
+				validation_expression, fungibility_key_expression, error_message_expression,
+				attribute_schema, display_name, description,
+				created_at, updated_at, activated_at, deprecated_at
+			FROM instrument_definition
+			WHERE status = 'ACTIVE'
+			ORDER BY code, version DESC`
+
+		rows, err := tx.Query(ctx, query)
+		if err != nil {
+			return fmt.Errorf("failed to query active instruments: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			def, err := r.scanInstrumentDefinitionFromRows(rows)
+			if err != nil {
+				return err
+			}
+			result = append(result, def)
+		}
+
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// CreateDraft creates a new instrument definition in DRAFT status.
+func (r *PostgresRegistry) CreateDraft(ctx context.Context, def *InstrumentDefinition) error {
+	// Reject system instrument creation
+	if def.IsSystem {
+		return ErrSystemInstrumentReadOnly
+	}
+
+	// Compile CEL expressions at creation time (fail-fast)
+	if err := r.compileCELExpressions(def); err != nil {
+		return err
+	}
+
+	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			INSERT INTO instrument_definition (
+				id, code, version, dimension, precision, status, is_system,
+				validation_expression, fungibility_key_expression, error_message_expression,
+				attribute_schema, display_name, description,
+				created_at, updated_at
+			) VALUES (
+				$1, $2, $3, $4, $5, $6, $7,
+				$8, $9, $10,
+				$11, $12, $13,
+				$14, $15
+			)`
+
+		// Generate ID if not set
+		if def.ID == uuid.Nil {
+			def.ID = uuid.New()
+		}
+
+		now := time.Now()
+		def.CreatedAt = now
+		def.UpdatedAt = now
+		def.Status = StatusDraft
+
+		_, err := tx.Exec(ctx, query,
+			def.ID, def.Code, def.Version, string(def.Dimension), def.Precision, string(def.Status), def.IsSystem,
+			nullString(def.ValidationExpression), def.FungibilityKeyExpression, nullString(def.ErrorMessageExpression),
+			def.AttributeSchema, nullString(def.DisplayName), nullString(def.Description),
+			def.CreatedAt, def.UpdatedAt,
+		)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
+				return ErrAlreadyExists
+			}
+			return fmt.Errorf("failed to insert instrument definition: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// UpdateDefinition updates a DRAFT instrument definition.
+func (r *PostgresRegistry) UpdateDefinition(ctx context.Context, code string, version int, updates *InstrumentDefinition) error {
+	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		// First, check if the instrument exists and is not a system instrument
+		var isSystem bool
+		var currentStatus string
+		var currentUpdatedAt time.Time
+
+		checkQuery := `SELECT is_system, status, updated_at FROM instrument_definition WHERE code = $1 AND version = $2`
+		err := tx.QueryRow(ctx, checkQuery, code, version).Scan(&isSystem, &currentStatus, &currentUpdatedAt)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to check instrument: %w", err)
+		}
+
+		if isSystem {
+			return ErrSystemInstrumentReadOnly
+		}
+
+		if currentStatus != string(StatusDraft) {
+			return ErrNotDraft
+		}
+
+		// Compile CEL expressions if provided
+		if err := r.compileCELExpressions(updates); err != nil {
+			return err
+		}
+
+		// Update the instrument
+		updateQuery := `
+			UPDATE instrument_definition SET
+				dimension = COALESCE(NULLIF($1, ''), dimension),
+				precision = CASE WHEN $2 >= 0 THEN $2 ELSE precision END,
+				validation_expression = $3,
+				fungibility_key_expression = $4,
+				error_message_expression = $5,
+				attribute_schema = COALESCE($6, attribute_schema),
+				display_name = $7,
+				description = $8,
+				updated_at = $9
+			WHERE code = $10 AND version = $11 AND updated_at = $12`
+
+		now := time.Now()
+		result, err := tx.Exec(ctx, updateQuery,
+			string(updates.Dimension), updates.Precision,
+			nullString(updates.ValidationExpression),
+			updates.FungibilityKeyExpression,
+			nullString(updates.ErrorMessageExpression),
+			updates.AttributeSchema,
+			nullString(updates.DisplayName),
+			nullString(updates.Description),
+			now,
+			code, version, currentUpdatedAt,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to update instrument definition: %w", err)
+		}
+
+		if result.RowsAffected() == 0 {
+			return ErrOptimisticLock
+		}
+
+		// Invalidate cache for this instrument
+		r.invalidateCache(code, version)
+
+		return nil
+	})
+}
+
+// ActivateInstrument transitions an instrument from DRAFT to ACTIVE.
+func (r *PostgresRegistry) ActivateInstrument(ctx context.Context, code string, version int) error {
+	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		// Check current state
+		var isSystem bool
+		var currentStatus string
+
+		checkQuery := `SELECT is_system, status FROM instrument_definition WHERE code = $1 AND version = $2`
+		err := tx.QueryRow(ctx, checkQuery, code, version).Scan(&isSystem, &currentStatus)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to check instrument: %w", err)
+		}
+
+		if isSystem {
+			return ErrSystemInstrumentReadOnly
+		}
+
+		if currentStatus != string(StatusDraft) {
+			return ErrNotDraft
+		}
+
+		// Transition to ACTIVE
+		now := time.Now()
+		updateQuery := `
+			UPDATE instrument_definition SET
+				status = 'ACTIVE',
+				activated_at = $1,
+				updated_at = $1
+			WHERE code = $2 AND version = $3`
+
+		_, err = tx.Exec(ctx, updateQuery, now, code, version)
+		if err != nil {
+			return fmt.Errorf("failed to activate instrument: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// DeprecateInstrument transitions an instrument from ACTIVE to DEPRECATED.
+func (r *PostgresRegistry) DeprecateInstrument(ctx context.Context, code string, version int) error {
+	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		// Check current state
+		var isSystem bool
+		var currentStatus string
+
+		checkQuery := `SELECT is_system, status FROM instrument_definition WHERE code = $1 AND version = $2`
+		err := tx.QueryRow(ctx, checkQuery, code, version).Scan(&isSystem, &currentStatus)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to check instrument: %w", err)
+		}
+
+		if isSystem {
+			return ErrSystemInstrumentReadOnly
+		}
+
+		if currentStatus != string(StatusActive) {
+			return ErrNotActive
+		}
+
+		// Transition to DEPRECATED
+		now := time.Now()
+		updateQuery := `
+			UPDATE instrument_definition SET
+				status = 'DEPRECATED',
+				deprecated_at = $1,
+				updated_at = $1
+			WHERE code = $2 AND version = $3`
+
+		_, err = tx.Exec(ctx, updateQuery, now, code, version)
+		if err != nil {
+			return fmt.Errorf("failed to deprecate instrument: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// ValidateAttributes executes the CEL validation expression against the provided attributes.
+func (r *PostgresRegistry) ValidateAttributes(ctx context.Context, code string, version int, attrs AttributeBag) (ValidationResult, error) {
+	def, err := r.GetDefinition(ctx, code, version)
+	if err != nil {
+		return ValidationResult{}, err
+	}
+
+	if def.ValidationExpression == "" {
+		return ValidationResult{Valid: true}, nil
+	}
+
+	prg, err := r.getOrCompileValidation(code, version, def.ValidationExpression)
+	if err != nil {
+		return ValidationResult{}, fmt.Errorf("failed to get validation program: %w", err)
+	}
+
+	input := r.buildCELInput(attrs)
+	return r.executeValidation(prg, input, def, code, version)
+}
+
+// buildCELInput constructs the input map for CEL evaluation.
+func (r *PostgresRegistry) buildCELInput(attrs AttributeBag) map[string]any {
+	input := map[string]any{
+		"attributes": attrs.Attributes,
+		"amount":     attrs.Amount,
+		"source":     attrs.Source,
+		"valid_from": time.Time{},
+		"valid_to":   time.Time{},
+	}
+
+	if attrs.ValidFrom != nil {
+		input["valid_from"] = *attrs.ValidFrom
+	}
+	if attrs.ValidTo != nil {
+		input["valid_to"] = *attrs.ValidTo
+	}
+
+	return input
+}
+
+// executeValidation runs the CEL program and handles the result.
+func (r *PostgresRegistry) executeValidation(prg cel.Program, input map[string]any, def *InstrumentDefinition, code string, version int) (ValidationResult, error) {
+	result, _, err := prg.Eval(input)
+	if err != nil {
+		return ValidationResult{
+			Valid:        false,
+			ErrorMessage: fmt.Sprintf("validation expression error: %v", err),
+		}, nil
+	}
+
+	valid, ok := result.Value().(bool)
+	if !ok {
+		return ValidationResult{
+			Valid:        false,
+			ErrorMessage: "validation expression did not return boolean",
+		}, nil
+	}
+
+	if valid {
+		return ValidationResult{Valid: true}, nil
+	}
+
+	errorMsg := r.getCustomErrorMessage(def, code, version, input)
+	return ValidationResult{Valid: false, ErrorMessage: errorMsg}, nil
+}
+
+const defaultValidationErrorMsg = "validation failed"
+
+// getCustomErrorMessage evaluates the error message expression if defined.
+func (r *PostgresRegistry) getCustomErrorMessage(def *InstrumentDefinition, code string, version int, input map[string]any) string {
+	if def.ErrorMessageExpression == "" {
+		return defaultValidationErrorMsg
+	}
+
+	errorPrg, err := r.getOrCompileErrorMessage(code, version, def.ErrorMessageExpression)
+	if err != nil {
+		return defaultValidationErrorMsg
+	}
+
+	errorResult, _, evalErr := errorPrg.Eval(input)
+	if evalErr != nil {
+		return defaultValidationErrorMsg
+	}
+
+	if msg, ok := errorResult.Value().(string); ok {
+		return msg
+	}
+
+	return defaultValidationErrorMsg
+}
+
+// compileCELExpressions validates and compiles all CEL expressions in a definition.
+func (r *PostgresRegistry) compileCELExpressions(def *InstrumentDefinition) error {
+	if def.ValidationExpression != "" {
+		_, err := r.compiler.CompileValidation(def.ValidationExpression)
+		if err != nil {
+			return errors.Join(ErrInvalidCEL, fmt.Errorf("validation expression: %w", err))
+		}
+	}
+
+	if def.FungibilityKeyExpression != "" {
+		_, err := r.compiler.CompileBucketKey(def.FungibilityKeyExpression)
+		if err != nil {
+			return errors.Join(ErrInvalidCEL, fmt.Errorf("fungibility key expression: %w", err))
+		}
+	}
+
+	// ErrorMessageExpression uses the same environment as validation
+	if def.ErrorMessageExpression != "" {
+		_, err := r.compiler.CompileValidation(def.ErrorMessageExpression)
+		if err != nil {
+			return errors.Join(ErrInvalidCEL, fmt.Errorf("error message expression: %w", err))
+		}
+	}
+
+	return nil
+}
+
+// getOrCompileValidation gets a cached validation program or compiles one.
+func (r *PostgresRegistry) getOrCompileValidation(code string, version int, expr string) (cel.Program, error) {
+	cacheKey := fmt.Sprintf("%s:%d:validation", code, version)
+
+	r.programCacheMu.RLock()
+	prg, ok := r.programCache[cacheKey]
+	r.programCacheMu.RUnlock()
+
+	if ok {
+		return prg, nil
+	}
+
+	// Compile and cache
+	prg, err := r.compiler.CompileValidation(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	r.programCacheMu.Lock()
+	r.programCache[cacheKey] = prg
+	r.programCacheMu.Unlock()
+
+	return prg, nil
+}
+
+// getOrCompileErrorMessage gets a cached error message program or compiles one.
+func (r *PostgresRegistry) getOrCompileErrorMessage(code string, version int, expr string) (cel.Program, error) {
+	cacheKey := fmt.Sprintf("%s:%d:error", code, version)
+
+	r.programCacheMu.RLock()
+	prg, ok := r.programCache[cacheKey]
+	r.programCacheMu.RUnlock()
+
+	if ok {
+		return prg, nil
+	}
+
+	// Compile and cache
+	prg, err := r.compiler.CompileValidation(expr)
+	if err != nil {
+		return nil, err
+	}
+
+	r.programCacheMu.Lock()
+	r.programCache[cacheKey] = prg
+	r.programCacheMu.Unlock()
+
+	return prg, nil
+}
+
+// invalidateCache removes cached programs for an instrument.
+func (r *PostgresRegistry) invalidateCache(code string, version int) {
+	r.programCacheMu.Lock()
+	defer r.programCacheMu.Unlock()
+
+	delete(r.programCache, fmt.Sprintf("%s:%d:validation", code, version))
+	delete(r.programCache, fmt.Sprintf("%s:%d:error", code, version))
+	delete(r.programCache, fmt.Sprintf("%s:%d:bucket", code, version))
+}
+
+// scanInstrumentDefinition scans a single row into an InstrumentDefinition.
+func (r *PostgresRegistry) scanInstrumentDefinition(row pgx.Row) (*InstrumentDefinition, error) {
+	var def InstrumentDefinition
+	var dimension, status string
+	var validationExpr, errorMsgExpr, displayName, description sql.NullString
+
+	err := row.Scan(
+		&def.ID, &def.Code, &def.Version, &dimension, &def.Precision, &status, &def.IsSystem,
+		&validationExpr, &def.FungibilityKeyExpression, &errorMsgExpr,
+		&def.AttributeSchema, &displayName, &description,
+		&def.CreatedAt, &def.UpdatedAt, &def.ActivatedAt, &def.DeprecatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	def.Dimension = Dimension(dimension)
+	def.Status = Status(status)
+
+	if validationExpr.Valid {
+		def.ValidationExpression = validationExpr.String
+	}
+	if errorMsgExpr.Valid {
+		def.ErrorMessageExpression = errorMsgExpr.String
+	}
+	if displayName.Valid {
+		def.DisplayName = displayName.String
+	}
+	if description.Valid {
+		def.Description = description.String
+	}
+
+	return &def, nil
+}
+
+// scanInstrumentDefinitionFromRows scans from pgx.Rows.
+func (r *PostgresRegistry) scanInstrumentDefinitionFromRows(rows pgx.Rows) (*InstrumentDefinition, error) {
+	var def InstrumentDefinition
+	var dimension, status string
+	var validationExpr, errorMsgExpr, displayName, description sql.NullString
+
+	err := rows.Scan(
+		&def.ID, &def.Code, &def.Version, &dimension, &def.Precision, &status, &def.IsSystem,
+		&validationExpr, &def.FungibilityKeyExpression, &errorMsgExpr,
+		&def.AttributeSchema, &displayName, &description,
+		&def.CreatedAt, &def.UpdatedAt, &def.ActivatedAt, &def.DeprecatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	def.Dimension = Dimension(dimension)
+	def.Status = Status(status)
+
+	if validationExpr.Valid {
+		def.ValidationExpression = validationExpr.String
+	}
+	if errorMsgExpr.Valid {
+		def.ErrorMessageExpression = errorMsgExpr.String
+	}
+	if displayName.Valid {
+		def.DisplayName = displayName.String
+	}
+	if description.Valid {
+		def.Description = description.String
+	}
+
+	return &def, nil
+}
+
+// nullString converts a string to sql.NullString, treating empty strings as NULL.
+func nullString(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{Valid: false}
+	}
+	return sql.NullString{String: s, Valid: true}
+}

--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/services/reference-data/registry"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
@@ -53,7 +54,7 @@ func seedSystemInstrument(t *testing.T, pool *pgxpool.Pool, ctx context.Context,
 	tx, err := pool.Begin(ctx)
 	require.NoError(t, err)
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %q, public", schemaName))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
 	require.NoError(t, err)
 
 	_, err = tx.Exec(ctx, query, code)

--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -28,7 +28,8 @@ func setupTestRegistry(t *testing.T) (*registry.PostgresRegistry, *pgxpool.Pool)
 
 func setupTenantContext(t *testing.T, pool *pgxpool.Pool, tenantID string) context.Context {
 	t.Helper()
-	ctx, _ := testdb.SetupTenantSchemaForPgx(t, pool, tenantID, "reference-data")
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, tenantID, "reference-data")
+	t.Cleanup(cleanup)
 	return ctx
 }
 

--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -1,0 +1,643 @@
+package registry_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestRegistry(t *testing.T) (*registry.PostgresRegistry, *pgxpool.Pool) {
+	t.Helper()
+
+	pool := testdb.NewTestPool(t)
+
+	reg, err := registry.NewPostgresRegistry(pool)
+	require.NoError(t, err)
+
+	return reg, pool
+}
+
+func setupTenantContext(t *testing.T, pool *pgxpool.Pool, tenantID string) context.Context {
+	t.Helper()
+	ctx, _ := testdb.SetupTenantSchemaForPgx(t, pool, tenantID, "reference-data")
+	return ctx
+}
+
+func seedSystemInstrument(t *testing.T, pool *pgxpool.Pool, ctx context.Context, code string) {
+	t.Helper()
+
+	tenantID, _ := tenant.FromContext(ctx)
+	schemaName := tenantID.SchemaName()
+
+	// Seed a system instrument directly via SQL (simulating provisioning)
+	query := `
+		INSERT INTO instrument_definition (
+			id, code, version, dimension, precision, status, is_system,
+			fungibility_key_expression, created_at, updated_at, activated_at
+		) VALUES (
+			gen_random_uuid(), $1, 1, 'MONETARY', 2, 'ACTIVE', true,
+			'', NOW(), NOW(), NOW()
+		)`
+
+	// Set search_path and insert
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %q, public", schemaName))
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, query, code)
+	require.NoError(t, err)
+
+	require.NoError(t, tx.Commit(ctx))
+}
+
+func TestPostgresRegistry_CreateDraft(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-1")
+
+	t.Run("creates draft instrument successfully", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:                 "TESTUSD",
+			Version:              1,
+			Dimension:            registry.DimensionMonetary,
+			Precision:            2,
+			ValidationExpression: "parse_int(amount) > 0",
+			DisplayName:          "Test US Dollar",
+			Description:          "Test currency for unit tests",
+		}
+
+		err := reg.CreateDraft(ctx, def)
+		require.NoError(t, err)
+		assert.NotEqual(t, uuid.Nil, def.ID)
+		assert.Equal(t, registry.StatusDraft, def.Status)
+		assert.False(t, def.IsSystem)
+	})
+
+	t.Run("rejects system instrument creation", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "SYSEUR",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+			IsSystem:  true,
+		}
+
+		err := reg.CreateDraft(ctx, def)
+		require.ErrorIs(t, err, registry.ErrSystemInstrumentReadOnly)
+	})
+
+	t.Run("rejects invalid CEL expression", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:                 "BADCEL",
+			Version:              1,
+			Dimension:            registry.DimensionMonetary,
+			Precision:            2,
+			ValidationExpression: "this is not valid CEL {{{",
+		}
+
+		err := reg.CreateDraft(ctx, def)
+		require.ErrorIs(t, err, registry.ErrInvalidCEL)
+	})
+
+	t.Run("rejects duplicate code+version", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "DUPE",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+
+		err := reg.CreateDraft(ctx, def)
+		require.NoError(t, err)
+
+		// Try to create again
+		def2 := &registry.InstrumentDefinition{
+			Code:      "DUPE",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+
+		err = reg.CreateDraft(ctx, def2)
+		require.ErrorIs(t, err, registry.ErrAlreadyExists)
+	})
+}
+
+func TestPostgresRegistry_GetDefinition(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-2")
+
+	// Create a test instrument
+	def := &registry.InstrumentDefinition{
+		Code:        "GETTEST",
+		Version:     1,
+		Dimension:   registry.DimensionEnergy,
+		Precision:   3,
+		DisplayName: "Get Test Instrument",
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+
+	t.Run("retrieves existing instrument", func(t *testing.T) {
+		result, err := reg.GetDefinition(ctx, "GETTEST", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "GETTEST", result.Code)
+		assert.Equal(t, 1, result.Version)
+		assert.Equal(t, registry.DimensionEnergy, result.Dimension)
+		assert.Equal(t, 3, result.Precision)
+		assert.Equal(t, registry.StatusDraft, result.Status)
+	})
+
+	t.Run("returns ErrNotFound for missing instrument", func(t *testing.T) {
+		_, err := reg.GetDefinition(ctx, "NOTEXIST", 1)
+		require.ErrorIs(t, err, registry.ErrNotFound)
+	})
+}
+
+func TestPostgresRegistry_GetActiveDefinition(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-3")
+
+	// Create and activate an instrument
+	def := &registry.InstrumentDefinition{
+		Code:      "ACTIVETEST",
+		Version:   1,
+		Dimension: registry.DimensionMonetary,
+		Precision: 2,
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+	require.NoError(t, reg.ActivateInstrument(ctx, "ACTIVETEST", 1))
+
+	t.Run("retrieves active instrument", func(t *testing.T) {
+		result, err := reg.GetActiveDefinition(ctx, "ACTIVETEST")
+		require.NoError(t, err)
+		assert.Equal(t, "ACTIVETEST", result.Code)
+		assert.Equal(t, registry.StatusActive, result.Status)
+	})
+
+	t.Run("returns highest active version", func(t *testing.T) {
+		// Create version 2 and activate it
+		def2 := &registry.InstrumentDefinition{
+			Code:      "ACTIVETEST",
+			Version:   2,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def2))
+		require.NoError(t, reg.ActivateInstrument(ctx, "ACTIVETEST", 2))
+
+		result, err := reg.GetActiveDefinition(ctx, "ACTIVETEST")
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.Version)
+	})
+
+	t.Run("returns ErrNotFound for non-active instrument", func(t *testing.T) {
+		// Create a draft instrument
+		draft := &registry.InstrumentDefinition{
+			Code:      "DRAFTONLY",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, draft))
+
+		_, err := reg.GetActiveDefinition(ctx, "DRAFTONLY")
+		require.ErrorIs(t, err, registry.ErrNotFound)
+	})
+}
+
+func TestPostgresRegistry_ListActive(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-4")
+
+	// Seed a system instrument
+	seedSystemInstrument(t, pool, ctx, "USD")
+
+	// Create and activate a tenant instrument
+	def := &registry.InstrumentDefinition{
+		Code:      "TENANTCOIN",
+		Version:   1,
+		Dimension: registry.DimensionQuantity,
+		Precision: 0,
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+	require.NoError(t, reg.ActivateInstrument(ctx, "TENANTCOIN", 1))
+
+	t.Run("returns both system and tenant instruments", func(t *testing.T) {
+		results, err := reg.ListActive(ctx)
+		require.NoError(t, err)
+
+		// Should have at least the system USD and tenant TENANTCOIN
+		codes := make(map[string]bool)
+		for _, r := range results {
+			codes[r.Code] = true
+		}
+
+		assert.True(t, codes["USD"], "expected system instrument USD")
+		assert.True(t, codes["TENANTCOIN"], "expected tenant instrument TENANTCOIN")
+	})
+}
+
+func TestPostgresRegistry_SystemInstrumentProtection(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-5")
+
+	// Seed system instruments
+	seedSystemInstrument(t, pool, ctx, "USD")
+	seedSystemInstrument(t, pool, ctx, "EUR")
+	seedSystemInstrument(t, pool, ctx, "GBP")
+
+	t.Run("CreateDraft rejects is_system=true", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "FAKESYS",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+			IsSystem:  true,
+		}
+		err := reg.CreateDraft(ctx, def)
+		require.ErrorIs(t, err, registry.ErrSystemInstrumentReadOnly)
+	})
+
+	t.Run("UpdateDefinition rejects system instrument", func(t *testing.T) {
+		updates := &registry.InstrumentDefinition{
+			DisplayName: "Modified USD",
+		}
+		err := reg.UpdateDefinition(ctx, "USD", 1, updates)
+		require.ErrorIs(t, err, registry.ErrSystemInstrumentReadOnly)
+	})
+
+	t.Run("ActivateInstrument rejects system instrument", func(t *testing.T) {
+		err := reg.ActivateInstrument(ctx, "EUR", 1)
+		require.ErrorIs(t, err, registry.ErrSystemInstrumentReadOnly)
+	})
+
+	t.Run("DeprecateInstrument rejects system instrument", func(t *testing.T) {
+		err := reg.DeprecateInstrument(ctx, "GBP", 1)
+		require.ErrorIs(t, err, registry.ErrSystemInstrumentReadOnly)
+	})
+
+	t.Run("GetDefinition still works for system instruments", func(t *testing.T) {
+		def, err := reg.GetDefinition(ctx, "USD", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "USD", def.Code)
+		assert.True(t, def.IsSystem)
+		assert.Equal(t, registry.StatusActive, def.Status)
+	})
+}
+
+func TestPostgresRegistry_LifecycleTransitions(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-6")
+
+	t.Run("DRAFT to ACTIVE succeeds", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "LIFECYCLE1",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		err := reg.ActivateInstrument(ctx, "LIFECYCLE1", 1)
+		require.NoError(t, err)
+
+		// Verify status changed
+		result, err := reg.GetDefinition(ctx, "LIFECYCLE1", 1)
+		require.NoError(t, err)
+		assert.Equal(t, registry.StatusActive, result.Status)
+		assert.NotNil(t, result.ActivatedAt)
+	})
+
+	t.Run("ACTIVE to DEPRECATED succeeds", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "LIFECYCLE2",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateInstrument(ctx, "LIFECYCLE2", 1))
+
+		err := reg.DeprecateInstrument(ctx, "LIFECYCLE2", 1)
+		require.NoError(t, err)
+
+		// Verify status changed
+		result, err := reg.GetDefinition(ctx, "LIFECYCLE2", 1)
+		require.NoError(t, err)
+		assert.Equal(t, registry.StatusDeprecated, result.Status)
+		assert.NotNil(t, result.DeprecatedAt)
+	})
+
+	t.Run("ACTIVE to ACTIVE fails", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "LIFECYCLE3",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateInstrument(ctx, "LIFECYCLE3", 1))
+
+		err := reg.ActivateInstrument(ctx, "LIFECYCLE3", 1)
+		require.ErrorIs(t, err, registry.ErrNotDraft)
+	})
+
+	t.Run("DRAFT to DEPRECATED fails", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "LIFECYCLE4",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		err := reg.DeprecateInstrument(ctx, "LIFECYCLE4", 1)
+		require.ErrorIs(t, err, registry.ErrNotActive)
+	})
+}
+
+func TestPostgresRegistry_UpdateDefinition(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-7")
+
+	t.Run("updates draft instrument successfully", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "UPDATE1",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		updates := &registry.InstrumentDefinition{
+			DisplayName:          "Updated Display Name",
+			Description:          "Updated Description",
+			ValidationExpression: "true",
+		}
+		err := reg.UpdateDefinition(ctx, "UPDATE1", 1, updates)
+		require.NoError(t, err)
+
+		// Verify updates
+		result, err := reg.GetDefinition(ctx, "UPDATE1", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated Display Name", result.DisplayName)
+		assert.Equal(t, "Updated Description", result.Description)
+		assert.Equal(t, "true", result.ValidationExpression)
+	})
+
+	t.Run("rejects update on active instrument", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "UPDATE2",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateInstrument(ctx, "UPDATE2", 1))
+
+		updates := &registry.InstrumentDefinition{
+			DisplayName: "Should Fail",
+		}
+		err := reg.UpdateDefinition(ctx, "UPDATE2", 1, updates)
+		require.ErrorIs(t, err, registry.ErrNotDraft)
+	})
+
+	t.Run("returns ErrNotFound for missing instrument", func(t *testing.T) {
+		updates := &registry.InstrumentDefinition{
+			DisplayName: "Does not exist",
+		}
+		err := reg.UpdateDefinition(ctx, "NOTEXIST", 1, updates)
+		require.ErrorIs(t, err, registry.ErrNotFound)
+	})
+}
+
+func TestPostgresRegistry_ValidateAttributes(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-8")
+
+	t.Run("validates with CEL expression", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:                   "VALIDATE1",
+			Version:                1,
+			Dimension:              registry.DimensionMonetary,
+			Precision:              2,
+			ValidationExpression:   `parse_int(amount) > 0`,
+			ErrorMessageExpression: `"Amount must be positive, got: " + amount`,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateInstrument(ctx, "VALIDATE1", 1))
+
+		// Valid case
+		result, err := reg.ValidateAttributes(ctx, "VALIDATE1", 1, registry.AttributeBag{
+			Amount: "100",
+		})
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+
+		// Invalid case
+		result, err = reg.ValidateAttributes(ctx, "VALIDATE1", 1, registry.AttributeBag{
+			Amount: "-50",
+		})
+		require.NoError(t, err)
+		assert.False(t, result.Valid)
+		assert.Contains(t, result.ErrorMessage, "Amount must be positive")
+	})
+
+	t.Run("validates with attributes", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:                 "VALIDATE2",
+			Version:              1,
+			Dimension:            registry.DimensionEnergy,
+			Precision:            3,
+			ValidationExpression: `attributes["source_type"] == "renewable"`,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateInstrument(ctx, "VALIDATE2", 1))
+
+		// Valid case
+		result, err := reg.ValidateAttributes(ctx, "VALIDATE2", 1, registry.AttributeBag{
+			Attributes: map[string]string{"source_type": "renewable"},
+		})
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+
+		// Invalid case
+		result, err = reg.ValidateAttributes(ctx, "VALIDATE2", 1, registry.AttributeBag{
+			Attributes: map[string]string{"source_type": "fossil"},
+		})
+		require.NoError(t, err)
+		assert.False(t, result.Valid)
+	})
+
+	t.Run("returns valid when no validation expression", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "VALIDATE3",
+			Version:   1,
+			Dimension: registry.DimensionQuantity,
+			Precision: 0,
+			// No validation expression
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateInstrument(ctx, "VALIDATE3", 1))
+
+		result, err := reg.ValidateAttributes(ctx, "VALIDATE3", 1, registry.AttributeBag{
+			Amount: "anything",
+		})
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+	})
+}
+
+func TestPostgresRegistry_CELCompilationAtCreation(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-9")
+
+	testCases := []struct {
+		name       string
+		expression string
+		valid      bool
+	}{
+		{
+			name:       "valid boolean expression",
+			expression: "parse_int(amount) > 0",
+			valid:      true,
+		},
+		{
+			name:       "valid attribute check",
+			expression: `attributes["key"] == "value"`,
+			valid:      true,
+		},
+		{
+			name:       "valid timestamp check",
+			expression: `valid_from < valid_to`,
+			valid:      true,
+		},
+		{
+			name:       "invalid syntax",
+			expression: "{{{{invalid syntax",
+			valid:      false,
+		},
+		{
+			name:       "undefined variable",
+			expression: "undefined_var > 0",
+			valid:      false,
+		},
+		{
+			name:       "type mismatch",
+			expression: `amount + attributes`, // can't add string and map
+			valid:      false,
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			def := &registry.InstrumentDefinition{
+				Code:                 fmt.Sprintf("CEL%d", i),
+				Version:              1,
+				Dimension:            registry.DimensionMonetary,
+				Precision:            2,
+				ValidationExpression: tc.expression,
+			}
+
+			err := reg.CreateDraft(ctx, def)
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, registry.ErrInvalidCEL)
+			}
+		})
+	}
+}
+
+func TestPostgresRegistry_TenantIsolation(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx1 := setupTenantContext(t, pool, "tenant-iso-1")
+	ctx2 := setupTenantContext(t, pool, "tenant-iso-2")
+
+	// Create instrument in tenant 1
+	def1 := &registry.InstrumentDefinition{
+		Code:      "ISOLATED",
+		Version:   1,
+		Dimension: registry.DimensionMonetary,
+		Precision: 2,
+	}
+	require.NoError(t, reg.CreateDraft(ctx1, def1))
+
+	t.Run("tenant 1 can see its instrument", func(t *testing.T) {
+		result, err := reg.GetDefinition(ctx1, "ISOLATED", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "ISOLATED", result.Code)
+	})
+
+	t.Run("tenant 2 cannot see tenant 1's instrument", func(t *testing.T) {
+		_, err := reg.GetDefinition(ctx2, "ISOLATED", 1)
+		require.ErrorIs(t, err, registry.ErrNotFound)
+	})
+
+	t.Run("tenants can have same code independently", func(t *testing.T) {
+		def2 := &registry.InstrumentDefinition{
+			Code:        "ISOLATED",
+			Version:     1,
+			Dimension:   registry.DimensionEnergy, // Different dimension
+			Precision:   3,
+			DisplayName: "Tenant 2 version",
+		}
+		require.NoError(t, reg.CreateDraft(ctx2, def2))
+
+		// Verify both exist independently
+		result1, err := reg.GetDefinition(ctx1, "ISOLATED", 1)
+		require.NoError(t, err)
+		assert.Equal(t, registry.DimensionMonetary, result1.Dimension)
+
+		result2, err := reg.GetDefinition(ctx2, "ISOLATED", 1)
+		require.NoError(t, err)
+		assert.Equal(t, registry.DimensionEnergy, result2.Dimension)
+		assert.Equal(t, "Tenant 2 version", result2.DisplayName)
+	})
+}
+
+func TestPostgresRegistry_ValidateAttributesWithTimestamps(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-10")
+
+	def := &registry.InstrumentDefinition{
+		Code:                 "TIMETEST",
+		Version:              1,
+		Dimension:            registry.DimensionEnergy,
+		Precision:            3,
+		ValidationExpression: `valid_from < valid_to`,
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+	require.NoError(t, reg.ActivateInstrument(ctx, "TIMETEST", 1))
+
+	now := time.Now()
+	later := now.Add(time.Hour)
+
+	t.Run("valid time range passes", func(t *testing.T) {
+		result, err := reg.ValidateAttributes(ctx, "TIMETEST", 1, registry.AttributeBag{
+			ValidFrom: &now,
+			ValidTo:   &later,
+		})
+		require.NoError(t, err)
+		assert.True(t, result.Valid)
+	})
+
+	t.Run("invalid time range fails", func(t *testing.T) {
+		result, err := reg.ValidateAttributes(ctx, "TIMETEST", 1, registry.AttributeBag{
+			ValidFrom: &later,
+			ValidTo:   &now, // Before ValidFrom
+		})
+		require.NoError(t, err)
+		assert.False(t, result.Valid)
+	})
+}

--- a/services/reference-data/registry/registry.go
+++ b/services/reference-data/registry/registry.go
@@ -83,7 +83,7 @@ type InstrumentDefinition struct {
 	Code string
 
 	// Version allows multiple versions of the same instrument code.
-	// Use 0 as a special value meaning "latest active version" in queries.
+	// Versions start at 1. Use GetActiveDefinition to retrieve the latest active version.
 	Version int
 
 	// Dimension categorizes what this instrument measures.

--- a/services/reference-data/registry/registry.go
+++ b/services/reference-data/registry/registry.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/google/cel-go/cel"
 	"github.com/google/uuid"
 )
 
@@ -210,12 +209,4 @@ type InstrumentRegistry interface {
 	// If no validation expression is defined, always returns valid.
 	// Uses pre-compiled CEL programs for performance.
 	ValidateAttributes(ctx context.Context, code string, version int, attrs AttributeBag) (ValidationResult, error)
-}
-
-// CompiledPrograms holds pre-compiled CEL programs for an instrument.
-// This avoids recompiling expressions on every validation call.
-type CompiledPrograms struct {
-	Validation     cel.Program
-	FungibilityKey cel.Program
-	ErrorMessage   cel.Program
 }

--- a/services/reference-data/registry/registry.go
+++ b/services/reference-data/registry/registry.go
@@ -1,0 +1,221 @@
+// Package registry provides the InstrumentRegistry interface and implementation
+// for managing instrument definitions with lifecycle management and CEL validation.
+package registry
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/uuid"
+)
+
+// Status represents the lifecycle status of an instrument definition.
+type Status string
+
+const (
+	// StatusDraft indicates an instrument that is not yet active and can be modified.
+	StatusDraft Status = "DRAFT"
+
+	// StatusActive indicates an instrument that is in use and immutable (validation rules frozen).
+	StatusActive Status = "ACTIVE"
+
+	// StatusDeprecated indicates an instrument that should no longer be used for new positions
+	// but existing positions with this instrument remain valid.
+	StatusDeprecated Status = "DEPRECATED"
+)
+
+// Dimension represents the type of value an instrument measures.
+type Dimension string
+
+// Dimension constants define the types of values an instrument can measure.
+const (
+	DimensionMonetary Dimension = "MONETARY"
+	DimensionEnergy   Dimension = "ENERGY"
+	DimensionQuantity Dimension = "QUANTITY"
+	DimensionCompute  Dimension = "COMPUTE"
+	DimensionTime     Dimension = "TIME"
+	DimensionMass     Dimension = "MASS"
+	DimensionVolume   Dimension = "VOLUME"
+)
+
+// Error types for the registry.
+var (
+	// ErrNotFound is returned when an instrument definition cannot be found.
+	ErrNotFound = errors.New("instrument definition not found")
+
+	// ErrSystemInstrumentReadOnly is returned when attempting to modify a system instrument.
+	// System instruments (USD, EUR, GBP, etc.) are seeded during tenant provisioning with
+	// is_system=true and cannot be modified through the registry API.
+	ErrSystemInstrumentReadOnly = errors.New("system instruments are read-only")
+
+	// ErrInvalidStatus is returned when an instrument is not in the required status.
+	ErrInvalidStatus = errors.New("invalid instrument status")
+
+	// ErrInvalidStateTransition is returned for illegal status transitions.
+	// Valid transitions: DRAFT→ACTIVE, ACTIVE→DEPRECATED.
+	ErrInvalidStateTransition = errors.New("invalid state transition")
+
+	// ErrNotDraft is returned when attempting to modify an instrument that is not in DRAFT status.
+	ErrNotDraft = errors.New("instrument must be in DRAFT status")
+
+	// ErrNotActive is returned when attempting operations that require ACTIVE status.
+	ErrNotActive = errors.New("instrument must be in ACTIVE status")
+
+	// ErrInvalidCEL is returned when a CEL expression fails compilation.
+	// CEL expressions are compiled at creation time (fail-fast) to catch errors early.
+	ErrInvalidCEL = errors.New("invalid CEL expression")
+
+	// ErrOptimisticLock is returned when concurrent modification is detected.
+	ErrOptimisticLock = errors.New("optimistic lock failure: instrument was modified")
+
+	// ErrAlreadyExists is returned when creating an instrument with existing code+version.
+	ErrAlreadyExists = errors.New("instrument with this code and version already exists")
+)
+
+// InstrumentDefinition represents a measurement unit, currency, or asset type
+// that can be tracked in the ledger.
+type InstrumentDefinition struct {
+	// ID is the unique identifier for this definition.
+	ID uuid.UUID
+
+	// Code is the human-readable instrument code (e.g., "USD", "EUR", "KWH").
+	Code string
+
+	// Version allows multiple versions of the same instrument code.
+	// Use 0 as a special value meaning "latest active version" in queries.
+	Version int
+
+	// Dimension categorizes what this instrument measures.
+	Dimension Dimension
+
+	// Precision is the number of decimal places for amounts (0-18).
+	Precision int
+
+	// Status is the current lifecycle status.
+	Status Status
+
+	// IsSystem indicates this is a system instrument seeded during tenant provisioning.
+	// System instruments are read-only - CreateDraft, UpdateDefinition, ActivateInstrument,
+	// and DeprecateInstrument all reject operations on is_system=true instruments.
+	IsSystem bool
+
+	// ValidationExpression is an optional CEL expression for validating quantities.
+	// Compiled at creation time (fail-fast). Available variables:
+	//   - attributes: map[string]string
+	//   - amount: string (decimal)
+	//   - valid_from: timestamp
+	//   - valid_to: timestamp
+	//   - source: string
+	ValidationExpression string
+
+	// FungibilityKeyExpression is a CEL expression for generating bucket keys.
+	// Empty string means default fungibility (all quantities are fungible).
+	FungibilityKeyExpression string
+
+	// ErrorMessageExpression is a CEL expression for custom validation error messages.
+	ErrorMessageExpression string
+
+	// AttributeSchema defines the JSON schema for allowed attributes (optional).
+	AttributeSchema []byte
+
+	// DisplayName is a human-readable name.
+	DisplayName string
+
+	// Description provides additional context about this instrument.
+	Description string
+
+	// CreatedAt is when this definition was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is when this definition was last modified.
+	UpdatedAt time.Time
+
+	// ActivatedAt is when this definition transitioned to ACTIVE (nil if never activated).
+	ActivatedAt *time.Time
+
+	// DeprecatedAt is when this definition transitioned to DEPRECATED (nil if not deprecated).
+	DeprecatedAt *time.Time
+}
+
+// AttributeBag represents the input data for CEL validation.
+type AttributeBag struct {
+	Attributes map[string]string
+	Amount     string
+	ValidFrom  *time.Time
+	ValidTo    *time.Time
+	Source     string
+}
+
+// ValidationResult contains the outcome of CEL validation.
+type ValidationResult struct {
+	Valid        bool
+	ErrorMessage string
+}
+
+// InstrumentRegistry defines the interface for managing instrument definitions.
+// All methods extract tenant context from ctx using shared/platform/tenant.
+// Schema routing is handled by GORM tenant scope.
+//
+// System Instrument Semantics:
+// System instruments (USD, EUR, GBP, etc.) are COPIED into each tenant's schema
+// during tenant provisioning with is_system=true. This registry does NOT seed
+// system instruments - it only enforces the read-only constraint.
+type InstrumentRegistry interface {
+	// GetDefinition retrieves a specific instrument by code and version.
+	// Returns ErrNotFound if the instrument doesn't exist.
+	// The tenant schema is determined from ctx via tenant.FromContext.
+	GetDefinition(ctx context.Context, code string, version int) (*InstrumentDefinition, error)
+
+	// GetActiveDefinition retrieves the latest ACTIVE version of an instrument.
+	// Returns ErrNotFound if no active version exists.
+	// When multiple active versions exist, returns the highest version number.
+	GetActiveDefinition(ctx context.Context, code string) (*InstrumentDefinition, error)
+
+	// ListActive retrieves all instruments with ACTIVE status.
+	// Returns both system instruments (is_system=true) and tenant-specific instruments.
+	// All instruments are queried from the tenant's schema - system instruments were
+	// copied there during tenant provisioning.
+	ListActive(ctx context.Context) ([]*InstrumentDefinition, error)
+
+	// CreateDraft creates a new instrument definition in DRAFT status.
+	// Returns ErrSystemInstrumentReadOnly if is_system=true is attempted.
+	// Returns ErrInvalidCEL if any CEL expression fails compilation.
+	// Returns ErrAlreadyExists if an instrument with the same code+version exists.
+	// CEL expressions are compiled at creation time (fail-fast validation).
+	CreateDraft(ctx context.Context, def *InstrumentDefinition) error
+
+	// UpdateDefinition updates a DRAFT instrument definition.
+	// Returns ErrSystemInstrumentReadOnly if the instrument has is_system=true.
+	// Returns ErrNotDraft if the instrument is not in DRAFT status.
+	// Returns ErrInvalidCEL if any CEL expression fails compilation.
+	// Uses optimistic locking via UpdatedAt.
+	UpdateDefinition(ctx context.Context, code string, version int, updates *InstrumentDefinition) error
+
+	// ActivateInstrument transitions an instrument from DRAFT to ACTIVE.
+	// Returns ErrSystemInstrumentReadOnly if the instrument has is_system=true.
+	// Returns ErrNotDraft if not currently in DRAFT status.
+	// Once activated, validation rules become immutable.
+	ActivateInstrument(ctx context.Context, code string, version int) error
+
+	// DeprecateInstrument transitions an instrument from ACTIVE to DEPRECATED.
+	// Returns ErrSystemInstrumentReadOnly if the instrument has is_system=true.
+	// Returns ErrNotActive if not currently in ACTIVE status.
+	// Instruments in DEPRECATED status remain valid for existing positions but are not used for new ones.
+	DeprecateInstrument(ctx context.Context, code string, version int) error
+
+	// ValidateAttributes executes the CEL validation expression against the provided attributes.
+	// Returns ValidationResult indicating whether the attributes are valid.
+	// If no validation expression is defined, always returns valid.
+	// Uses pre-compiled CEL programs for performance.
+	ValidateAttributes(ctx context.Context, code string, version int, attrs AttributeBag) (ValidationResult, error)
+}
+
+// CompiledPrograms holds pre-compiled CEL programs for an instrument.
+// This avoids recompiling expressions on every validation call.
+type CompiledPrograms struct {
+	Validation     cel.Program
+	FungibilityKey cel.Program
+	ErrorMessage   cel.Program
+}

--- a/shared/platform/testdb/pgx.go
+++ b/shared/platform/testdb/pgx.go
@@ -1,0 +1,267 @@
+// Package testdb provides utilities for setting up test databases.
+package testdb
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// PoolOption configures the pgx pool test setup.
+type PoolOption func(*poolConfig)
+
+type poolConfig struct {
+	migrations string // service name for migrations directory
+}
+
+// WithMigrations specifies which service's migrations to apply.
+// The migrations directory is expected at services/<service>/migrations/.
+func WithMigrations(service string) PoolOption {
+	return func(cfg *poolConfig) {
+		cfg.migrations = service
+	}
+}
+
+// NewTestPool creates a pgxpool.Pool connected to a PostgreSQL testcontainer.
+// It returns a configured pool that tests should defer Close() on.
+//
+// Usage:
+//
+//	func TestMyRepository(t *testing.T) {
+//	    pool := testdb.NewTestPool(t, testdb.WithMigrations("reference-data"))
+//	    defer pool.Close()
+//
+//	    // Your test code here
+//	}
+//
+// The pool can be used directly with pgx-based repositories.
+func NewTestPool(t *testing.T, opts ...PoolOption) *pgxpool.Pool {
+	t.Helper()
+
+	// Apply configuration options
+	cfg := &poolConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	// Create context with timeout for container operations
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	// Create PostgreSQL container
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:15-alpine",
+		postgres.WithDatabase("test_db"),
+		postgres.WithUsername("test_user"),
+		postgres.WithPassword("test_password"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("Failed to start PostgreSQL container: %v", err)
+	}
+
+	// Register cleanup
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_ = pgContainer.Terminate(cleanupCtx)
+	})
+
+	// Get connection string
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("Failed to get connection string: %v", err)
+	}
+
+	// Create pgxpool
+	pool, err := pgxpool.New(ctx, connStr)
+	if err != nil {
+		t.Fatalf("Failed to create connection pool: %v", err)
+	}
+
+	// Register pool cleanup
+	t.Cleanup(func() {
+		pool.Close()
+	})
+
+	// Apply migrations if specified
+	if cfg.migrations != "" {
+		applyMigrationsWithPgx(t, pool, cfg.migrations)
+	}
+
+	return pool
+}
+
+// applyMigrationsWithPgx reads and applies SQL migrations from services/<service>/migrations/.
+func applyMigrationsWithPgx(t *testing.T, pool *pgxpool.Pool, service string) {
+	t.Helper()
+
+	// Find migrations directory - try multiple paths for test execution contexts
+	var migrationsDir string
+	possiblePaths := []string{
+		filepath.Join("services", service, "migrations"),
+		filepath.Join("..", "..", "services", service, "migrations"),
+		filepath.Join("..", "..", "..", "services", service, "migrations"),
+		filepath.Join("..", "..", "..", "..", "services", service, "migrations"),
+	}
+
+	for _, path := range possiblePaths {
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			migrationsDir = path
+			break
+		}
+	}
+
+	if migrationsDir == "" {
+		t.Fatalf("Could not find migrations directory for service %s", service)
+	}
+
+	// Read migration files in order
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		t.Fatalf("Failed to read migrations directory: %v", err)
+	}
+
+	ctx := context.Background()
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".sql" {
+			continue
+		}
+
+		path := filepath.Join(migrationsDir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("Failed to read migration %s: %v", entry.Name(), err)
+		}
+
+		_, err = pool.Exec(ctx, string(content))
+		if err != nil {
+			t.Fatalf("Failed to apply migration %s: %v", entry.Name(), err)
+		}
+	}
+}
+
+// SetupTenantSchemaForPgx creates a tenant schema and applies migrations.
+// Returns a context with tenant ID and a cleanup function.
+//
+// Usage:
+//
+//	pool := testdb.NewTestPool(t)
+//	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, "test-tenant", "reference-data")
+//	defer cleanup()
+func SetupTenantSchemaForPgx(t *testing.T, pool *pgxpool.Pool, tenantID string, service string) (context.Context, func()) {
+	t.Helper()
+
+	tid := tenant.TenantID(tenantID)
+	schemaName := tid.SchemaName()
+
+	ctx := context.Background()
+
+	// Create the tenant schema
+	_, err := pool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName))
+	if err != nil {
+		t.Fatalf("Failed to create tenant schema %s: %v", schemaName, err)
+	}
+
+	// Apply migrations to tenant schema
+	if service != "" {
+		applyMigrationsToSchema(t, pool, service, schemaName)
+	}
+
+	// Create context with tenant
+	tenantCtx := tenant.WithTenant(context.Background(), tid)
+
+	cleanup := func() {
+		cleanupCtx := context.Background()
+		_, _ = pool.Exec(cleanupCtx, fmt.Sprintf("DROP SCHEMA IF EXISTS %q CASCADE", schemaName))
+	}
+
+	return tenantCtx, cleanup
+}
+
+// applyMigrationsToSchema applies migrations to a specific schema.
+func applyMigrationsToSchema(t *testing.T, pool *pgxpool.Pool, service string, schemaName string) {
+	t.Helper()
+
+	// Find migrations directory
+	var migrationsDir string
+	possiblePaths := []string{
+		filepath.Join("services", service, "migrations"),
+		filepath.Join("..", "..", "services", service, "migrations"),
+		filepath.Join("..", "..", "..", "services", service, "migrations"),
+		filepath.Join("..", "..", "..", "..", "services", service, "migrations"),
+	}
+
+	for _, path := range possiblePaths {
+		if info, err := os.Stat(path); err == nil && info.IsDir() {
+			migrationsDir = path
+			break
+		}
+	}
+
+	if migrationsDir == "" {
+		t.Fatalf("Could not find migrations directory for service %s", service)
+	}
+
+	// Read migration files in order
+	entries, err := os.ReadDir(migrationsDir)
+	if err != nil {
+		t.Fatalf("Failed to read migrations directory: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Start a transaction and set search_path
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Failed to begin transaction: %v", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %q, public", schemaName))
+	if err != nil {
+		t.Fatalf("Failed to set search_path: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".sql" {
+			continue
+		}
+
+		path := filepath.Join(migrationsDir, entry.Name())
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("Failed to read migration %s: %v", entry.Name(), err)
+		}
+
+		_, err = tx.Exec(ctx, string(content))
+		if err != nil {
+			t.Fatalf("Failed to apply migration %s to schema %s: %v", entry.Name(), schemaName, err)
+		}
+	}
+
+	err = tx.Commit(ctx)
+	if err != nil {
+		t.Fatalf("Failed to commit migrations: %v", err)
+	}
+}

--- a/shared/platform/testdb/pgx.go
+++ b/shared/platform/testdb/pgx.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -177,8 +178,8 @@ func SetupTenantSchemaForPgx(t *testing.T, pool *pgxpool.Pool, tenantID string, 
 
 	ctx := context.Background()
 
-	// Create the tenant schema
-	_, err := pool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName))
+	// Create the tenant schema using proper SQL identifier quoting
+	_, err := pool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName)))
 	if err != nil {
 		t.Fatalf("Failed to create tenant schema %s: %v", schemaName, err)
 	}
@@ -193,7 +194,7 @@ func SetupTenantSchemaForPgx(t *testing.T, pool *pgxpool.Pool, tenantID string, 
 
 	cleanup := func() {
 		cleanupCtx := context.Background()
-		_, _ = pool.Exec(cleanupCtx, fmt.Sprintf("DROP SCHEMA IF EXISTS %q CASCADE", schemaName))
+		_, _ = pool.Exec(cleanupCtx, fmt.Sprintf("DROP SCHEMA IF EXISTS %s CASCADE", pq.QuoteIdentifier(schemaName)))
 	}
 
 	return tenantCtx, cleanup
@@ -240,7 +241,7 @@ func applyMigrationsToSchema(t *testing.T, pool *pgxpool.Pool, service string, s
 		_ = tx.Rollback(ctx)
 	}()
 
-	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %q, public", schemaName))
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
 	if err != nil {
 		t.Fatalf("Failed to set search_path: %v", err)
 	}

--- a/shared/platform/testdb/pgx.go
+++ b/shared/platform/testdb/pgx.go
@@ -55,7 +55,6 @@ func NewTestPool(t *testing.T, opts ...PoolOption) *pgxpool.Pool {
 
 	// Create context with timeout for container operations
 	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-	defer cancel()
 
 	// Create PostgreSQL container
 	pgContainer, err := postgres.Run(ctx,
@@ -69,6 +68,7 @@ func NewTestPool(t *testing.T, opts ...PoolOption) *pgxpool.Pool {
 				WithStartupTimeout(60*time.Second)),
 	)
 	if err != nil {
+		cancel()
 		t.Fatalf("Failed to start PostgreSQL container: %v", err)
 	}
 
@@ -82,14 +82,19 @@ func NewTestPool(t *testing.T, opts ...PoolOption) *pgxpool.Pool {
 	// Get connection string
 	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {
+		cancel()
 		t.Fatalf("Failed to get connection string: %v", err)
 	}
 
 	// Create pgxpool
 	pool, err := pgxpool.New(ctx, connStr)
 	if err != nil {
+		cancel()
 		t.Fatalf("Failed to create connection pool: %v", err)
 	}
+
+	// Cancel setup context now that pool is created
+	cancel()
 
 	// Register pool cleanup
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary

- Implement `InstrumentRegistry` interface for managing instrument definitions with lifecycle management
- Add `is_system` column to protect system instruments (USD, EUR, GBP) from modification
- CEL expression compilation at creation time (fail-fast validation)
- PostgreSQL implementation with tenant isolation via schema-per-tenant architecture

## Task Master Reference

universal-asset-system.12 - Implement InstrumentRegistry with System Instrument Protection

## Changes Made

### New Files
- `services/reference-data/registry/registry.go` - Interface and domain types
- `services/reference-data/registry/postgres_registry.go` - PostgreSQL implementation
- `services/reference-data/registry/postgres_registry_test.go` - Integration tests
- `services/reference-data/migrations/20260105000001_add_is_system.sql` - Schema migration
- `services/reference-data/README.md` - Service documentation
- `shared/platform/testdb/pgx.go` - pgxpool test helper for integration tests

### Key Features

1. **System Instrument Protection**: All modification operations reject instruments with `is_system=true`
   - `CreateDraft`, `UpdateDefinition`, `ActivateInstrument`, `DeprecateInstrument` all check this constraint

2. **Lifecycle State Machine**: DRAFT → ACTIVE → DEPRECATED transitions enforced
   - Database trigger provides additional protection for immutable fields

3. **CEL Validation**: Expressions compiled at creation (fail-fast)
   - Validation programs cached for performance
   - Custom error messages supported

4. **Tenant Isolation**: Full schema-per-tenant support
   - System instruments seeded into each tenant schema during provisioning
   - No cross-schema queries or SystemTenantID constants

## Test Plan

- [ ] Integration tests pass with Testcontainers PostgreSQL
- [ ] System instrument protection tests verify read-only behavior
- [ ] Lifecycle transition tests verify state machine
- [ ] CEL compilation tests verify fail-fast validation
- [ ] Tenant isolation tests verify schema separation