### PR TITLE
feat: add currency package with ISO 4217 fiat currency instruments

### DIFF
--- a/pkg/platform/quantity/currency/currency.go
+++ b/pkg/platform/quantity/currency/currency.go
@@ -1,0 +1,145 @@
+// Package currency provides predefined Instrument instances for major fiat currencies.
+//
+// # ISO 4217 Standard
+//
+// Currency codes and precisions follow the ISO 4217 standard:
+//   - Most currencies use 2 decimal places (cents, pence, etc.)
+//   - JPY uses 0 decimal places (no minor units)
+//
+// # Usage
+//
+// Use predefined instruments for compile-time safety:
+//
+//	usdAmount := currency.USD(decimal.NewFromInt(100))    // $100.00
+//	jpyAmount := currency.JPY(decimal.NewFromInt(10000))  // ¥10000
+//
+// Look up currencies by code:
+//
+//	instrument, ok := currency.ByCode("EUR")
+//	if ok {
+//	    euroAmount := quantity.NewMoney(decimal.NewFromInt(50), instrument)
+//	}
+package currency
+
+import (
+	"github.com/shopspring/decimal"
+
+	"github.com/meridianhub/meridian/pkg/platform/quantity"
+)
+
+// Currency instruments for major fiat currencies.
+// All instruments use version 0 (initial/unversioned) and CURRENCY dimension.
+var (
+	// InstrumentUSD is the US Dollar instrument (2 decimal places).
+	InstrumentUSD = mustNewCurrency("USD", 2)
+
+	// InstrumentEUR is the Euro instrument (2 decimal places).
+	InstrumentEUR = mustNewCurrency("EUR", 2)
+
+	// InstrumentGBP is the British Pound Sterling instrument (2 decimal places).
+	InstrumentGBP = mustNewCurrency("GBP", 2)
+
+	// InstrumentJPY is the Japanese Yen instrument (0 decimal places).
+	InstrumentJPY = mustNewCurrency("JPY", 0)
+
+	// InstrumentCHF is the Swiss Franc instrument (2 decimal places).
+	InstrumentCHF = mustNewCurrency("CHF", 2)
+
+	// InstrumentAUD is the Australian Dollar instrument (2 decimal places).
+	InstrumentAUD = mustNewCurrency("AUD", 2)
+
+	// InstrumentCAD is the Canadian Dollar instrument (2 decimal places).
+	InstrumentCAD = mustNewCurrency("CAD", 2)
+
+	// InstrumentNZD is the New Zealand Dollar instrument (2 decimal places).
+	InstrumentNZD = mustNewCurrency("NZD", 2)
+)
+
+// currencies is the lookup map for currency instruments by code.
+var currencies = map[string]quantity.Instrument{
+	"USD": InstrumentUSD,
+	"EUR": InstrumentEUR,
+	"GBP": InstrumentGBP,
+	"JPY": InstrumentJPY,
+	"CHF": InstrumentCHF,
+	"AUD": InstrumentAUD,
+	"CAD": InstrumentCAD,
+	"NZD": InstrumentNZD,
+}
+
+// mustNewCurrency creates a currency instrument, panicking on error.
+// This is safe because currency codes are compile-time constants.
+func mustNewCurrency(code string, precision int) quantity.Instrument {
+	inst, err := quantity.NewInstrument(code, 0, quantity.DimensionCurrency, precision)
+	if err != nil {
+		panic("invalid currency instrument: " + err.Error())
+	}
+	return inst
+}
+
+// ByCode returns the currency Instrument for the given ISO 4217 code.
+// Returns the instrument and true if found, or a zero Instrument and false if not found.
+//
+// Supported codes: USD, EUR, GBP, JPY, CHF, AUD, CAD, NZD.
+func ByCode(code string) (quantity.Instrument, bool) {
+	inst, ok := currencies[code]
+	return inst, ok
+}
+
+// All returns a copy of all supported currency instruments.
+func All() []quantity.Instrument {
+	result := make([]quantity.Instrument, 0, len(currencies))
+	for _, inst := range currencies {
+		result = append(result, inst)
+	}
+	return result
+}
+
+// Codes returns all supported currency codes.
+func Codes() []string {
+	codes := make([]string, 0, len(currencies))
+	for code := range currencies {
+		codes = append(codes, code)
+	}
+	return codes
+}
+
+// USD creates a Money quantity in US Dollars.
+func USD(amount decimal.Decimal) quantity.Money {
+	return quantity.NewMoney(amount, InstrumentUSD)
+}
+
+// EUR creates a Money quantity in Euros.
+func EUR(amount decimal.Decimal) quantity.Money {
+	return quantity.NewMoney(amount, InstrumentEUR)
+}
+
+// GBP creates a Money quantity in British Pounds.
+func GBP(amount decimal.Decimal) quantity.Money {
+	return quantity.NewMoney(amount, InstrumentGBP)
+}
+
+// JPY creates a Money quantity in Japanese Yen.
+func JPY(amount decimal.Decimal) quantity.Money {
+	return quantity.NewMoney(amount, InstrumentJPY)
+}
+
+// CHF creates a Money quantity in Swiss Francs.
+func CHF(amount decimal.Decimal) quantity.Money {
+	return quantity.NewMoney(amount, InstrumentCHF)
+}
+
+// AUD creates a Money quantity in Australian Dollars.
+func AUD(amount decimal.Decimal) quantity.Money {
+	return quantity.NewMoney(amount, InstrumentAUD)
+}
+
+// CAD creates a Money quantity in Canadian Dollars.
+func CAD(amount decimal.Decimal) quantity.Money {
+	return quantity.NewMoney(amount, InstrumentCAD)
+}
+
+// NZD creates a Money quantity in New Zealand Dollars.
+func NZD(amount decimal.Decimal) quantity.Money {
+	return quantity.NewMoney(amount, InstrumentNZD)
+}

--- a/pkg/platform/quantity/currency/currency_test.go
+++ b/pkg/platform/quantity/currency/currency_test.go
@@ -1,0 +1,192 @@
+package currency_test
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/pkg/platform/quantity"
+	"github.com/meridianhub/meridian/pkg/platform/quantity/currency"
+)
+
+func TestInstrumentConstants(t *testing.T) {
+	tests := []struct {
+		name       string
+		instrument quantity.Instrument
+		code       string
+		precision  int
+	}{
+		{"USD", currency.InstrumentUSD, "USD", 2},
+		{"EUR", currency.InstrumentEUR, "EUR", 2},
+		{"GBP", currency.InstrumentGBP, "GBP", 2},
+		{"JPY", currency.InstrumentJPY, "JPY", 0},
+		{"CHF", currency.InstrumentCHF, "CHF", 2},
+		{"AUD", currency.InstrumentAUD, "AUD", 2},
+		{"CAD", currency.InstrumentCAD, "CAD", 2},
+		{"NZD", currency.InstrumentNZD, "NZD", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.code, tt.instrument.Code)
+			assert.Equal(t, tt.precision, tt.instrument.Precision)
+			assert.Equal(t, quantity.DimensionCurrency, tt.instrument.Dimension)
+			assert.Equal(t, uint32(0), tt.instrument.Version)
+			assert.True(t, tt.instrument.IsMonetary())
+			assert.NoError(t, tt.instrument.Validate())
+		})
+	}
+}
+
+func TestByCode(t *testing.T) {
+	tests := []struct {
+		code     string
+		wantOk   bool
+		wantCode string
+		wantPrec int
+	}{
+		{"USD", true, "USD", 2},
+		{"EUR", true, "EUR", 2},
+		{"GBP", true, "GBP", 2},
+		{"JPY", true, "JPY", 0},
+		{"CHF", true, "CHF", 2},
+		{"AUD", true, "AUD", 2},
+		{"CAD", true, "CAD", 2},
+		{"NZD", true, "NZD", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.code, func(t *testing.T) {
+			inst, ok := currency.ByCode(tt.code)
+			assert.Equal(t, tt.wantOk, ok)
+			if tt.wantOk {
+				assert.Equal(t, tt.wantCode, inst.Code)
+				assert.Equal(t, tt.wantPrec, inst.Precision)
+			}
+		})
+	}
+}
+
+func TestByCode_UnknownCurrency(t *testing.T) {
+	unknownCodes := []string{
+		"XYZ",   // completely invalid
+		"usd",   // lowercase
+		"Usd",   // mixed case
+		"",      // empty
+		"USDZZ", // too long
+		"US",    // too short
+		"CNY",   // not in our list
+		"INR",   // not in our list
+	}
+
+	for _, code := range unknownCodes {
+		t.Run(code, func(t *testing.T) {
+			inst, ok := currency.ByCode(code)
+			assert.False(t, ok)
+			assert.Equal(t, quantity.Instrument{}, inst)
+		})
+	}
+}
+
+func TestConstructorHelpers(t *testing.T) {
+	amount := decimal.NewFromInt(100)
+
+	tests := []struct {
+		name     string
+		money    quantity.Money
+		wantCode string
+		wantPrec int
+	}{
+		{"USD", currency.USD(amount), "USD", 2},
+		{"EUR", currency.EUR(amount), "EUR", 2},
+		{"GBP", currency.GBP(amount), "GBP", 2},
+		{"JPY", currency.JPY(amount), "JPY", 0},
+		{"CHF", currency.CHF(amount), "CHF", 2},
+		{"AUD", currency.AUD(amount), "AUD", 2},
+		{"CAD", currency.CAD(amount), "CAD", 2},
+		{"NZD", currency.NZD(amount), "NZD", 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.True(t, tt.money.Amount.Equal(amount))
+			assert.Equal(t, tt.wantCode, tt.money.Instrument.Code)
+			assert.Equal(t, tt.wantPrec, tt.money.Instrument.Precision)
+		})
+	}
+}
+
+func TestConstructorHelpers_WithDecimalValues(t *testing.T) {
+	t.Run("USD with cents", func(t *testing.T) {
+		amount := decimal.NewFromFloat(99.99)
+		money := currency.USD(amount)
+		assert.True(t, money.Amount.Equal(amount))
+		assert.Equal(t, "99.99 USD", money.String())
+	})
+
+	t.Run("JPY rounds to whole number", func(t *testing.T) {
+		amount := decimal.NewFromInt(10000)
+		money := currency.JPY(amount)
+		assert.True(t, money.Amount.Equal(amount))
+		assert.Equal(t, "10000 JPY", money.String())
+	})
+}
+
+func TestMoneyArithmetic(t *testing.T) {
+	usd100 := currency.USD(decimal.NewFromInt(100))
+	usd50 := currency.USD(decimal.NewFromInt(50))
+
+	t.Run("add same currency", func(t *testing.T) {
+		result, err := usd100.Add(usd50)
+		require.NoError(t, err)
+		assert.True(t, result.Amount.Equal(decimal.NewFromInt(150)))
+		assert.Equal(t, "USD", result.Instrument.Code)
+	})
+
+	t.Run("subtract same currency", func(t *testing.T) {
+		result, err := usd100.Subtract(usd50)
+		require.NoError(t, err)
+		assert.True(t, result.Amount.Equal(decimal.NewFromInt(50)))
+	})
+
+	t.Run("cannot add different currencies", func(t *testing.T) {
+		eur100 := currency.EUR(decimal.NewFromInt(100))
+		_, err := usd100.Add(eur100)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, quantity.ErrInstrumentMismatch)
+	})
+}
+
+func TestJPYPrecision(t *testing.T) {
+	// JPY has 0 decimal places
+	jpy := currency.JPY(decimal.NewFromFloat(12345.67))
+
+	// Multiply and check rounding
+	result := jpy.Multiply(decimal.NewFromFloat(1.5))
+	// 12345.67 * 1.5 = 18518.505, rounded to 18519 (banker's rounding)
+	assert.True(t, result.Amount.Equal(decimal.NewFromInt(18519)))
+}
+
+func TestAll(t *testing.T) {
+	all := currency.All()
+	assert.Len(t, all, 8) // USD, EUR, GBP, JPY, CHF, AUD, CAD, NZD
+
+	// Verify all are valid
+	for _, inst := range all {
+		assert.NoError(t, inst.Validate())
+		assert.Equal(t, quantity.DimensionCurrency, inst.Dimension)
+	}
+}
+
+func TestCodes(t *testing.T) {
+	codes := currency.Codes()
+	assert.Len(t, codes, 8)
+
+	// All codes should be valid lookups
+	for _, code := range codes {
+		_, ok := currency.ByCode(code)
+		assert.True(t, ok, "code %s should be valid", code)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements predefined `Instrument` instances for major fiat currencies (USD, EUR, GBP, JPY, CHF, AUD, CAD, NZD) with correct ISO 4217 precisions
- Provides `ByCode(code string) (Instrument, bool)` lookup function for currency retrieval
- Adds ergonomic constructor helpers like `USD(amount decimal.Decimal) Money` for clean Money creation

## Task Master Reference

Task: `universal-asset-system.7` - Implement Currency Definitions Package

## Changes Made

- **New package**: `pkg/platform/quantity/currency/`
  - `currency.go`: Currency instrument definitions and helpers
  - `currency_test.go`: Comprehensive test coverage

## Technical Details

- All currencies use version 0 (initial/unversioned) and CURRENCY dimension
- JPY uses precision 0 (no minor units), all others use precision 2
- Currency constants are validated at package init (panics on invalid)
- Helper functions (`All()`, `Codes()`) for iteration over supported currencies

## Testing

```bash
go test ./pkg/platform/quantity/currency/... -v
```

All tests pass covering:
- Instrument constant validation (code, precision, dimension)
- ByCode lookup for known and unknown currencies
- Constructor helpers with various amount types
- Money arithmetic with currency instruments
- JPY precision handling

## Risk Assessment

Low risk - additive change only, no modifications to existing code.

## Performance Considerations

None - simple map lookup for `ByCode`, no allocations in hot paths.