### PR TITLE
feat(cache): implement local instrument cache with compiled CEL programs

### DIFF
--- a/services/reference-data/cache/event_subscriber.go
+++ b/services/reference-data/cache/event_subscriber.go
@@ -1,0 +1,56 @@
+// Package cache provides caching infrastructure for instrument definitions
+// with tenant isolation and TTL-based expiration.
+package cache
+
+import (
+	"context"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// InstrumentUpdatedEvent represents a Kafka event for instrument updates.
+// This event is published when an instrument is created, modified, or deleted
+// in the registry.
+type InstrumentUpdatedEvent struct {
+	// TenantID identifies which tenant's instrument was updated.
+	TenantID string
+
+	// Code is the instrument code that was updated.
+	Code string
+
+	// Version is the specific version of the instrument that changed.
+	// Used for logging/tracing; cache invalidates all versions of the code.
+	Version int
+}
+
+// EventSubscriber handles Kafka events for distributed cache invalidation.
+// The actual Kafka subscription is wired up by the service layer - this
+// component provides the handler interface.
+type EventSubscriber struct {
+	cache *InstrumentCache
+}
+
+// NewEventSubscriber creates a new EventSubscriber that will invalidate
+// cache entries when instrument update events are received.
+func NewEventSubscriber(cache *InstrumentCache) *EventSubscriber {
+	return &EventSubscriber{
+		cache: cache,
+	}
+}
+
+// HandleInstrumentUpdated processes an instrument.updated Kafka event
+// by invalidating all cached versions of the instrument for the tenant.
+//
+// This method uses MustNewTenantID since events should have valid tenant IDs.
+// If the tenant ID is invalid, it will panic - this is fail-fast behavior
+// to catch malformed events in development/testing rather than silently
+// ignoring them.
+func (s *EventSubscriber) HandleInstrumentUpdated(event InstrumentUpdatedEvent) {
+	// Construct context with tenant from event payload
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID(event.TenantID))
+
+	// Invalidate all versions of this instrument code
+	// The cache.InvalidateCode method already handles the case where
+	// the tenant cache doesn't exist (no-op)
+	s.cache.InvalidateCode(ctx, event.Code)
+}

--- a/services/reference-data/cache/event_subscriber_test.go
+++ b/services/reference-data/cache/event_subscriber_test.go
@@ -1,0 +1,147 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventSubscriber_HandleInstrumentUpdated_InvalidatesCorrectEntry(t *testing.T) {
+	cache := NewInstrumentCache()
+	subscriber := NewEventSubscriber(cache)
+
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate cache with multiple versions of USD and EUR
+	cache.Put(ctx, "USD", 1, newTestInstrument("USD", 1))
+	cache.Put(ctx, "USD", 2, newTestInstrument("USD", 2))
+	cache.Put(ctx, "EUR", 1, newTestInstrument("EUR", 1))
+
+	// Verify all are cached
+	require.NotNil(t, cache.Get(ctx, "USD", 1))
+	require.NotNil(t, cache.Get(ctx, "USD", 2))
+	require.NotNil(t, cache.Get(ctx, "EUR", 1))
+
+	// Handle update event for USD
+	event := InstrumentUpdatedEvent{
+		TenantID: "tenant1",
+		Code:     "USD",
+		Version:  1, // Version is for tracing, all versions are invalidated
+	}
+	subscriber.HandleInstrumentUpdated(event)
+
+	// All USD versions should be invalidated
+	assert.Nil(t, cache.Get(ctx, "USD", 1), "USD v1 should be invalidated")
+	assert.Nil(t, cache.Get(ctx, "USD", 2), "USD v2 should be invalidated")
+
+	// EUR should still be cached
+	assert.NotNil(t, cache.Get(ctx, "EUR", 1), "EUR should not be affected")
+}
+
+func TestEventSubscriber_HandleInstrumentUpdated_TenantIsolation(t *testing.T) {
+	cache := NewInstrumentCache()
+	subscriber := NewEventSubscriber(cache)
+
+	ctxA := newTestContext("tenantA")
+	ctxB := newTestContext("tenantB")
+
+	// Pre-populate cache for both tenants with same instrument code
+	cache.Put(ctxA, "USD", 1, newTestInstrument("USD", 1))
+	cache.Put(ctxA, "USD", 2, newTestInstrument("USD", 2))
+	cache.Put(ctxB, "USD", 1, newTestInstrument("USD", 1))
+	cache.Put(ctxB, "USD", 2, newTestInstrument("USD", 2))
+
+	// Verify all are cached
+	require.NotNil(t, cache.Get(ctxA, "USD", 1))
+	require.NotNil(t, cache.Get(ctxA, "USD", 2))
+	require.NotNil(t, cache.Get(ctxB, "USD", 1))
+	require.NotNil(t, cache.Get(ctxB, "USD", 2))
+
+	// Handle update event for tenantA only
+	event := InstrumentUpdatedEvent{
+		TenantID: "tenantA",
+		Code:     "USD",
+		Version:  1,
+	}
+	subscriber.HandleInstrumentUpdated(event)
+
+	// TenantA's USD should be invalidated
+	assert.Nil(t, cache.Get(ctxA, "USD", 1), "tenantA USD v1 should be invalidated")
+	assert.Nil(t, cache.Get(ctxA, "USD", 2), "tenantA USD v2 should be invalidated")
+
+	// TenantB's USD should still be cached
+	assert.NotNil(t, cache.Get(ctxB, "USD", 1), "tenantB USD v1 should not be affected")
+	assert.NotNil(t, cache.Get(ctxB, "USD", 2), "tenantB USD v2 should not be affected")
+}
+
+func TestEventSubscriber_HandleInstrumentUpdated_NonExistentCache(t *testing.T) {
+	cache := NewInstrumentCache()
+	subscriber := NewEventSubscriber(cache)
+
+	// Handle event for a tenant that has no cached data
+	// This should not panic or error
+	event := InstrumentUpdatedEvent{
+		TenantID: "nonexistent_tenant",
+		Code:     "USD",
+		Version:  1,
+	}
+
+	// Should not panic - if we reach this point without panic, the test passes
+	subscriber.HandleInstrumentUpdated(event)
+
+	// Verify the tenant cache was not created (should return 0,0)
+	ctx := newTestContext("nonexistent_tenant")
+	size, _ := cache.Stats(ctx)
+	assert.Equal(t, 0, size, "cache should be empty for nonexistent tenant")
+}
+
+func TestEventSubscriber_HandleInstrumentUpdated_MultipleCodes(t *testing.T) {
+	cache := NewInstrumentCache()
+	subscriber := NewEventSubscriber(cache)
+
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate cache with multiple instruments
+	cache.Put(ctx, "USD", 1, newTestInstrument("USD", 1))
+	cache.Put(ctx, "EUR", 1, newTestInstrument("EUR", 1))
+	cache.Put(ctx, "GBP", 1, newTestInstrument("GBP", 1))
+	cache.Put(ctx, "JPY", 1, newTestInstrument("JPY", 1))
+
+	// Invalidate EUR
+	subscriber.HandleInstrumentUpdated(InstrumentUpdatedEvent{
+		TenantID: "tenant1",
+		Code:     "EUR",
+		Version:  1,
+	})
+
+	// EUR should be invalidated
+	assert.Nil(t, cache.Get(ctx, "EUR", 1), "EUR should be invalidated")
+
+	// Others should still be cached
+	assert.NotNil(t, cache.Get(ctx, "USD", 1), "USD should not be affected")
+	assert.NotNil(t, cache.Get(ctx, "GBP", 1), "GBP should not be affected")
+	assert.NotNil(t, cache.Get(ctx, "JPY", 1), "JPY should not be affected")
+
+	// Now invalidate GBP
+	subscriber.HandleInstrumentUpdated(InstrumentUpdatedEvent{
+		TenantID: "tenant1",
+		Code:     "GBP",
+		Version:  1,
+	})
+
+	// GBP should now also be invalidated
+	assert.Nil(t, cache.Get(ctx, "GBP", 1), "GBP should be invalidated")
+
+	// USD and JPY should still be cached
+	assert.NotNil(t, cache.Get(ctx, "USD", 1), "USD should not be affected")
+	assert.NotNil(t, cache.Get(ctx, "JPY", 1), "JPY should not be affected")
+}
+
+func TestNewEventSubscriber(t *testing.T) {
+	cache := NewInstrumentCache()
+	subscriber := NewEventSubscriber(cache)
+
+	assert.NotNil(t, subscriber)
+	assert.NotNil(t, subscriber.cache)
+}

--- a/services/reference-data/cache/instrument_cache.go
+++ b/services/reference-data/cache/instrument_cache.go
@@ -4,12 +4,15 @@ package cache
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"math/rand/v2"
 	"sync"
 	"time"
 
 	"github.com/google/cel-go/cel"
 	lru "github.com/hashicorp/golang-lru/v2"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/meridianhub/meridian/services/reference-data/registry"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -26,6 +29,14 @@ const (
 	// DefaultTTLJitter is the maximum random variation added to TTL.
 	// This prevents thundering herd when many entries expire simultaneously.
 	DefaultTTLJitter = 30 * time.Second
+)
+
+var (
+	// ErrTenantContextRequired is returned when a tenant context is required but not present.
+	ErrTenantContextRequired = errors.New("tenant context required")
+
+	// ErrUnexpectedResultType is returned when singleflight returns an unexpected type.
+	ErrUnexpectedResultType = errors.New("unexpected result type from singleflight")
 )
 
 // Key uniquely identifies an instrument within a tenant's cache.
@@ -76,6 +87,10 @@ type InstrumentCache struct {
 
 	// ttlJitter is the maximum random variation added to TTL
 	ttlJitter time.Duration
+
+	// sfGroup deduplicates concurrent cache misses for the same key.
+	// The singleflight key includes tenant ID to maintain isolation.
+	sfGroup singleflight.Group
 }
 
 // Option configures an InstrumentCache.
@@ -191,6 +206,96 @@ func (c *InstrumentCache) InvalidateAll(ctx context.Context) {
 	defer c.mu.Unlock()
 
 	delete(c.tenantCaches, tenantID)
+}
+
+// GetOrLoad retrieves a cached instrument or loads it via loadFn on cache miss.
+// Concurrent requests for the same key will share a single loadFn call via singleflight.
+// The loadFn should load from the repository and compile CEL programs as needed.
+// Returns nil and error if loading fails or tenant context is missing.
+func (c *InstrumentCache) GetOrLoad(
+	ctx context.Context,
+	code string,
+	version int,
+	loadFn func() (*CachedInstrument, error),
+) (*CachedInstrument, error) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil, ErrTenantContextRequired
+	}
+
+	// Fast path: check cache first
+	if cached := c.Get(ctx, code, version); cached != nil {
+		return cached, nil
+	}
+
+	// Slow path: use singleflight to deduplicate concurrent loads
+	sfKey := fmt.Sprintf("%s:%s:%d", tenantID, code, version)
+
+	result, err, _ := c.sfGroup.Do(sfKey, func() (interface{}, error) {
+		// Double-check cache after acquiring singleflight slot
+		// Another goroutine might have populated the cache
+		if cached := c.Get(ctx, code, version); cached != nil {
+			return cached, nil
+		}
+
+		// Load from source
+		instrument, err := loadFn()
+		if err != nil {
+			return nil, err
+		}
+
+		// Store in cache
+		c.Put(ctx, code, version, instrument)
+
+		return instrument, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	cached, ok := result.(*CachedInstrument)
+	if !ok {
+		return nil, ErrUnexpectedResultType
+	}
+
+	return cached, nil
+}
+
+// InvalidateCode removes all versions of an instrument code for the tenant in context.
+// This is useful when an instrument is updated and all cached versions should be invalidated.
+func (c *InstrumentCache) InvalidateCode(ctx context.Context, code string) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	cache := c.getTenantCache(tenantID)
+	if cache == nil {
+		return
+	}
+
+	// Iterate through all keys and remove those matching the code
+	keys := cache.Keys()
+	for _, key := range keys {
+		if key.Code == code {
+			cache.Remove(key)
+		}
+	}
+}
+
+// PurgeAll clears ALL cached entries for the tenant in context.
+// This is an admin method for emergency cache clearing.
+// Note: This is equivalent to InvalidateAll but named for admin clarity.
+func (c *InstrumentCache) PurgeAll(ctx context.Context) {
+	c.InvalidateAll(ctx)
+}
+
+// PurgeInstrument removes all versions of an instrument for the tenant in context.
+// This is an admin method for emergency instrument-specific cache clearing.
+// Note: This is equivalent to InvalidateCode but named for admin clarity.
+func (c *InstrumentCache) PurgeInstrument(ctx context.Context, code string) {
+	c.InvalidateCode(ctx, code)
 }
 
 // Stats returns cache statistics for the tenant in context.

--- a/services/reference-data/cache/instrument_cache.go
+++ b/services/reference-data/cache/instrument_cache.go
@@ -1,0 +1,272 @@
+// Package cache provides caching infrastructure for instrument definitions
+// with tenant isolation and TTL-based expiration.
+package cache
+
+import (
+	"context"
+	"math/rand/v2"
+	"sync"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Default cache configuration values.
+const (
+	// DefaultCacheSize is the maximum number of entries per tenant cache.
+	DefaultCacheSize = 10000
+
+	// DefaultTTL is the base TTL for cached entries.
+	DefaultTTL = 5 * time.Minute
+
+	// DefaultTTLJitter is the maximum random variation added to TTL.
+	// This prevents thundering herd when many entries expire simultaneously.
+	DefaultTTLJitter = 30 * time.Second
+)
+
+// Key uniquely identifies an instrument within a tenant's cache.
+// Tenant isolation is handled externally via context - each tenant has
+// its own LRU cache instance.
+type Key struct {
+	Code    string
+	Version int
+}
+
+// CachedInstrument contains the instrument definition and precompiled CEL programs.
+type CachedInstrument struct {
+	// Definition is the cached instrument definition.
+	Definition *registry.InstrumentDefinition
+
+	// ValidationProgram is the precompiled CEL program for validation.
+	// May be nil if no validation expression is defined.
+	ValidationProgram cel.Program
+
+	// BucketKeyProgram is the precompiled CEL program for bucket key generation.
+	// May be nil if no bucket key expression is defined.
+	BucketKeyProgram cel.Program
+
+	// cachedAt records when this entry was added to the cache.
+	cachedAt time.Time
+
+	// expiresAt is the precomputed expiration time (cachedAt + jitteredTTL).
+	// Computed once at cache time to ensure consistent expiration checks.
+	expiresAt time.Time
+}
+
+// InstrumentCache provides tenant-isolated caching for instrument definitions.
+// Each tenant has its own LRU cache to ensure complete isolation.
+//
+// Thread-safety: All methods are safe for concurrent use.
+type InstrumentCache struct {
+	// mu protects the tenantCaches map
+	mu sync.RWMutex
+
+	// tenantCaches maps tenant IDs to their individual LRU caches
+	tenantCaches map[tenant.TenantID]*lru.Cache[Key, *CachedInstrument]
+
+	// cacheSize is the maximum entries per tenant cache
+	cacheSize int
+
+	// baseTTL is the base time-to-live for cache entries
+	baseTTL time.Duration
+
+	// ttlJitter is the maximum random variation added to TTL
+	ttlJitter time.Duration
+}
+
+// Option configures an InstrumentCache.
+type Option func(*InstrumentCache)
+
+// WithCacheSize sets the maximum number of entries per tenant cache.
+func WithCacheSize(size int) Option {
+	return func(c *InstrumentCache) {
+		c.cacheSize = size
+	}
+}
+
+// WithTTL sets the base TTL and jitter for cache entries.
+func WithTTL(baseTTL, jitter time.Duration) Option {
+	return func(c *InstrumentCache) {
+		c.baseTTL = baseTTL
+		c.ttlJitter = jitter
+	}
+}
+
+// NewInstrumentCache creates a new tenant-isolated instrument cache.
+func NewInstrumentCache(opts ...Option) *InstrumentCache {
+	c := &InstrumentCache{
+		tenantCaches: make(map[tenant.TenantID]*lru.Cache[Key, *CachedInstrument]),
+		cacheSize:    DefaultCacheSize,
+		baseTTL:      DefaultTTL,
+		ttlJitter:    DefaultTTLJitter,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+// Get retrieves a cached instrument for the tenant in context.
+// Returns nil if the entry is not found, expired, or tenant context is missing.
+func (c *InstrumentCache) Get(ctx context.Context, code string, version int) *CachedInstrument {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	cache := c.getTenantCache(tenantID)
+	if cache == nil {
+		return nil
+	}
+
+	key := Key{Code: code, Version: version}
+	entry, ok := cache.Get(key)
+	if !ok {
+		return nil
+	}
+
+	// Check if entry has expired
+	if time.Now().After(entry.expiresAt) {
+		// Remove expired entry
+		cache.Remove(key)
+		return nil
+	}
+
+	return entry
+}
+
+// Put stores an instrument in the cache for the tenant in context.
+// Does nothing if tenant context is missing.
+func (c *InstrumentCache) Put(ctx context.Context, code string, version int, instrument *CachedInstrument) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	cache := c.getOrCreateTenantCache(tenantID)
+	if cache == nil {
+		return
+	}
+
+	key := Key{Code: code, Version: version}
+
+	// Set cache timestamps
+	now := time.Now()
+	instrument.cachedAt = now
+	instrument.expiresAt = now.Add(c.jitteredTTL())
+
+	cache.Add(key, instrument)
+}
+
+// Invalidate removes a specific entry from the cache for the tenant in context.
+func (c *InstrumentCache) Invalidate(ctx context.Context, code string, version int) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	cache := c.getTenantCache(tenantID)
+	if cache == nil {
+		return
+	}
+
+	key := Key{Code: code, Version: version}
+	cache.Remove(key)
+}
+
+// InvalidateAll removes all entries for the tenant in context.
+func (c *InstrumentCache) InvalidateAll(ctx context.Context) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	delete(c.tenantCaches, tenantID)
+}
+
+// Stats returns cache statistics for the tenant in context.
+// Returns (0, 0) if tenant context is missing or cache doesn't exist.
+func (c *InstrumentCache) Stats(ctx context.Context) (size int, capacity int) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return 0, 0
+	}
+
+	cache := c.getTenantCache(tenantID)
+	if cache == nil {
+		return 0, 0
+	}
+
+	return cache.Len(), c.cacheSize
+}
+
+// getTenantCache returns the cache for a tenant, or nil if not found.
+func (c *InstrumentCache) getTenantCache(tenantID tenant.TenantID) *lru.Cache[Key, *CachedInstrument] {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.tenantCaches[tenantID]
+}
+
+// getOrCreateTenantCache returns the cache for a tenant, creating it if needed.
+func (c *InstrumentCache) getOrCreateTenantCache(tenantID tenant.TenantID) *lru.Cache[Key, *CachedInstrument] {
+	// Fast path: check if already exists
+	c.mu.RLock()
+	cache, ok := c.tenantCaches[tenantID]
+	c.mu.RUnlock()
+
+	if ok {
+		return cache
+	}
+
+	// Slow path: create new cache
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if cache, ok = c.tenantCaches[tenantID]; ok {
+		return cache
+	}
+
+	// Create new LRU cache for this tenant
+	newCache, err := lru.New[Key, *CachedInstrument](c.cacheSize)
+	if err != nil {
+		// This should never happen with valid cache size
+		return nil
+	}
+
+	c.tenantCaches[tenantID] = newCache
+	return newCache
+}
+
+// jitteredTTL returns the base TTL plus a random jitter.
+// The jitter helps prevent thundering herd when many entries expire.
+func (c *InstrumentCache) jitteredTTL() time.Duration {
+	if c.ttlJitter == 0 {
+		return c.baseTTL
+	}
+
+	// Generate random jitter in range [-ttlJitter, +ttlJitter]
+	jitterRange := int64(c.ttlJitter) * 2
+	jitter := rand.Int64N(jitterRange) - int64(c.ttlJitter)
+
+	return c.baseTTL + time.Duration(jitter)
+}
+
+// CachedAt returns when this entry was cached.
+func (ci *CachedInstrument) CachedAt() time.Time {
+	return ci.cachedAt
+}
+
+// ExpiresAt returns when this entry will expire.
+func (ci *CachedInstrument) ExpiresAt() time.Time {
+	return ci.expiresAt
+}

--- a/services/reference-data/cache/instrument_cache_test.go
+++ b/services/reference-data/cache/instrument_cache_test.go
@@ -2,7 +2,9 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -472,4 +474,316 @@ func BenchmarkInstrumentCache_Get_Parallel(b *testing.B) {
 			i++
 		}
 	})
+}
+
+// Tests for GetOrLoad and singleflight deduplication
+
+func TestInstrumentCache_GetOrLoad_CacheHit(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate cache
+	instrument := newTestInstrument("USD", 1)
+	cache.Put(ctx, "USD", 1, instrument)
+
+	var loadCalled int32
+
+	// GetOrLoad should return cached value without calling loadFn
+	result, err := cache.GetOrLoad(ctx, "USD", 1, func() (*CachedInstrument, error) {
+		atomic.AddInt32(&loadCalled, 1)
+		return newTestInstrument("USD", 1), nil
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "USD", result.Definition.Code)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&loadCalled), "loadFn should not be called on cache hit")
+}
+
+func TestInstrumentCache_GetOrLoad_CacheMiss(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	var loadCalled int32
+
+	// GetOrLoad should call loadFn on cache miss
+	result, err := cache.GetOrLoad(ctx, "USD", 1, func() (*CachedInstrument, error) {
+		atomic.AddInt32(&loadCalled, 1)
+		return newTestInstrument("USD", 1), nil
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "USD", result.Definition.Code)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&loadCalled), "loadFn should be called once on cache miss")
+
+	// Verify it was cached
+	cached := cache.Get(ctx, "USD", 1)
+	require.NotNil(t, cached)
+	assert.Equal(t, "USD", cached.Definition.Code)
+}
+
+func TestInstrumentCache_GetOrLoad_LoadError(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	expectedErr := errors.New("database error") //nolint:err113 // test sentinel error
+
+	result, err := cache.GetOrLoad(ctx, "USD", 1, func() (*CachedInstrument, error) {
+		return nil, expectedErr
+	})
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, expectedErr)
+
+	// Verify nothing was cached
+	cached := cache.Get(ctx, "USD", 1)
+	assert.Nil(t, cached)
+}
+
+func TestInstrumentCache_GetOrLoad_MissingTenant(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := context.Background() // No tenant
+
+	result, err := cache.GetOrLoad(ctx, "USD", 1, func() (*CachedInstrument, error) {
+		return newTestInstrument("USD", 1), nil
+	})
+
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrTenantContextRequired)
+}
+
+func TestInstrumentCache_GetOrLoad_SingleflightDeduplication(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	var loadCalled int32
+	const concurrency = 100
+
+	// Barrier to ensure all goroutines start at the same time
+	var wg sync.WaitGroup
+	startCh := make(chan struct{})
+
+	wg.Add(concurrency)
+	results := make([]*CachedInstrument, concurrency)
+	errs := make([]error, concurrency)
+
+	for i := 0; i < concurrency; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			<-startCh // Wait for start signal
+
+			results[idx], errs[idx] = cache.GetOrLoad(ctx, "USD", 1, func() (*CachedInstrument, error) {
+				atomic.AddInt32(&loadCalled, 1)
+				// Simulate some load time to increase overlap window
+				time.Sleep(10 * time.Millisecond)
+				return newTestInstrument("USD", 1), nil
+			})
+		}(i)
+	}
+
+	// Release all goroutines simultaneously
+	close(startCh)
+	wg.Wait()
+
+	// All requests should succeed
+	for i := 0; i < concurrency; i++ {
+		require.NoError(t, errs[i], "request %d failed", i)
+		require.NotNil(t, results[i], "request %d returned nil", i)
+		assert.Equal(t, "USD", results[i].Definition.Code)
+	}
+
+	// Singleflight should have deduplicated to exactly 1 call
+	assert.Equal(t, int32(1), atomic.LoadInt32(&loadCalled),
+		"singleflight should deduplicate %d concurrent requests to 1 loadFn call", concurrency)
+}
+
+func TestInstrumentCache_GetOrLoad_SingleflightTenantIsolation(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	var loadCalled1, loadCalled2 int32
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Both tenants request the same code+version concurrently
+	go func() {
+		defer wg.Done()
+		_, _ = cache.GetOrLoad(ctx1, "USD", 1, func() (*CachedInstrument, error) {
+			atomic.AddInt32(&loadCalled1, 1)
+			time.Sleep(10 * time.Millisecond)
+			return newTestInstrument("USD", 1), nil
+		})
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, _ = cache.GetOrLoad(ctx2, "USD", 1, func() (*CachedInstrument, error) {
+			atomic.AddInt32(&loadCalled2, 1)
+			time.Sleep(10 * time.Millisecond)
+			return newTestInstrument("USD", 1), nil
+		})
+	}()
+
+	wg.Wait()
+
+	// Each tenant should have its own load call (singleflight key includes tenant)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&loadCalled1), "tenant1 should have called loadFn once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&loadCalled2), "tenant2 should have called loadFn once")
+}
+
+// Tests for InvalidateCode
+
+func TestInstrumentCache_InvalidateCode_AllVersions(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Put multiple versions of the same code
+	cache.Put(ctx, "USD", 1, newTestInstrument("USD", 1))
+	cache.Put(ctx, "USD", 2, newTestInstrument("USD", 2))
+	cache.Put(ctx, "USD", 3, newTestInstrument("USD", 3))
+	cache.Put(ctx, "EUR", 1, newTestInstrument("EUR", 1)) // Different code
+
+	// Verify all are cached
+	assert.NotNil(t, cache.Get(ctx, "USD", 1))
+	assert.NotNil(t, cache.Get(ctx, "USD", 2))
+	assert.NotNil(t, cache.Get(ctx, "USD", 3))
+	assert.NotNil(t, cache.Get(ctx, "EUR", 1))
+
+	// Invalidate all USD versions
+	cache.InvalidateCode(ctx, "USD")
+
+	// All USD versions should be gone
+	assert.Nil(t, cache.Get(ctx, "USD", 1), "USD v1 should be invalidated")
+	assert.Nil(t, cache.Get(ctx, "USD", 2), "USD v2 should be invalidated")
+	assert.Nil(t, cache.Get(ctx, "USD", 3), "USD v3 should be invalidated")
+
+	// EUR should still be cached
+	assert.NotNil(t, cache.Get(ctx, "EUR", 1), "EUR should not be affected")
+}
+
+func TestInstrumentCache_InvalidateCode_TenantIsolation(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	// Put USD for both tenants
+	cache.Put(ctx1, "USD", 1, newTestInstrument("USD", 1))
+	cache.Put(ctx1, "USD", 2, newTestInstrument("USD", 2))
+	cache.Put(ctx2, "USD", 1, newTestInstrument("USD", 1))
+	cache.Put(ctx2, "USD", 2, newTestInstrument("USD", 2))
+
+	// Invalidate USD for tenant1 only
+	cache.InvalidateCode(ctx1, "USD")
+
+	// tenant1's USD should be gone
+	assert.Nil(t, cache.Get(ctx1, "USD", 1))
+	assert.Nil(t, cache.Get(ctx1, "USD", 2))
+
+	// tenant2's USD should still be cached
+	assert.NotNil(t, cache.Get(ctx2, "USD", 1), "tenant2 USD v1 should not be affected")
+	assert.NotNil(t, cache.Get(ctx2, "USD", 2), "tenant2 USD v2 should not be affected")
+}
+
+func TestInstrumentCache_InvalidateCode_MissingTenant(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := context.Background() // No tenant
+	validCtx := newTestContext("tenant1")
+
+	// Put something to verify operation is a no-op
+	cache.Put(validCtx, "USD", 1, newTestInstrument("USD", 1))
+
+	// Should be a no-op without panic
+	cache.InvalidateCode(ctx, "USD")
+
+	// Original entry should still exist
+	assert.NotNil(t, cache.Get(validCtx, "USD", 1))
+}
+
+func TestInstrumentCache_InvalidateCode_EmptyCache(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Should be a no-op without panic (tenant cache doesn't exist yet)
+	cache.InvalidateCode(ctx, "USD")
+
+	// Verify no side effects by checking stats
+	size, _ := cache.Stats(ctx)
+	assert.Equal(t, 0, size)
+}
+
+// Tests for PurgeInstrument
+
+func TestInstrumentCache_PurgeInstrument_AllVersions(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Put multiple versions
+	cache.Put(ctx, "GBP", 1, newTestInstrument("GBP", 1))
+	cache.Put(ctx, "GBP", 2, newTestInstrument("GBP", 2))
+	cache.Put(ctx, "JPY", 1, newTestInstrument("JPY", 1))
+
+	// PurgeInstrument should behave like InvalidateCode
+	cache.PurgeInstrument(ctx, "GBP")
+
+	// All GBP versions should be gone
+	assert.Nil(t, cache.Get(ctx, "GBP", 1))
+	assert.Nil(t, cache.Get(ctx, "GBP", 2))
+
+	// JPY should still be cached
+	assert.NotNil(t, cache.Get(ctx, "JPY", 1))
+}
+
+// Tests for PurgeAll
+
+func TestInstrumentCache_PurgeAll_TenantScoped(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	// Put entries for both tenants
+	cache.Put(ctx1, "USD", 1, newTestInstrument("USD", 1))
+	cache.Put(ctx1, "EUR", 1, newTestInstrument("EUR", 1))
+	cache.Put(ctx1, "GBP", 1, newTestInstrument("GBP", 1))
+	cache.Put(ctx2, "JPY", 1, newTestInstrument("JPY", 1))
+	cache.Put(ctx2, "CHF", 1, newTestInstrument("CHF", 1))
+
+	// Verify initial state
+	size1, _ := cache.Stats(ctx1)
+	size2, _ := cache.Stats(ctx2)
+	assert.Equal(t, 3, size1)
+	assert.Equal(t, 2, size2)
+
+	// PurgeAll for tenant1 only
+	cache.PurgeAll(ctx1)
+
+	// tenant1 should be empty
+	assert.Nil(t, cache.Get(ctx1, "USD", 1))
+	assert.Nil(t, cache.Get(ctx1, "EUR", 1))
+	assert.Nil(t, cache.Get(ctx1, "GBP", 1))
+	size1After, _ := cache.Stats(ctx1)
+	assert.Equal(t, 0, size1After)
+
+	// tenant2 should be unaffected
+	assert.NotNil(t, cache.Get(ctx2, "JPY", 1), "tenant2 JPY should not be affected")
+	assert.NotNil(t, cache.Get(ctx2, "CHF", 1), "tenant2 CHF should not be affected")
+	size2After, _ := cache.Stats(ctx2)
+	assert.Equal(t, 2, size2After)
+}
+
+func TestInstrumentCache_PurgeAll_MissingTenant(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := context.Background() // No tenant
+	validCtx := newTestContext("tenant1")
+
+	// Put something to verify operation is a no-op
+	cache.Put(validCtx, "USD", 1, newTestInstrument("USD", 1))
+
+	// Should be a no-op without panic
+	cache.PurgeAll(ctx)
+
+	// Original entry should still exist
+	assert.NotNil(t, cache.Get(validCtx, "USD", 1))
 }

--- a/services/reference-data/cache/instrument_cache_test.go
+++ b/services/reference-data/cache/instrument_cache_test.go
@@ -1,0 +1,475 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// newTestContext creates a context with a test tenant.
+func newTestContext(tenantID string) context.Context {
+	return tenant.WithTenant(context.Background(), tenant.MustNewTenantID(tenantID))
+}
+
+// newTestInstrument creates a test CachedInstrument with the given code and version.
+func newTestInstrument(code string, version int) *CachedInstrument {
+	return &CachedInstrument{
+		Definition: &registry.InstrumentDefinition{
+			ID:        uuid.New(),
+			Code:      code,
+			Version:   version,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+			Status:    registry.StatusActive,
+		},
+		// ValidationProgram and BucketKeyProgram left nil for basic tests
+	}
+}
+
+func TestInstrumentCache_Get_Hit(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Put an entry
+	instrument := newTestInstrument("USD", 1)
+	cache.Put(ctx, "USD", 1, instrument)
+
+	// Get should return the entry
+	result := cache.Get(ctx, "USD", 1)
+	require.NotNil(t, result)
+	assert.Equal(t, "USD", result.Definition.Code)
+	assert.Equal(t, 1, result.Definition.Version)
+	assert.Equal(t, registry.DimensionMonetary, result.Definition.Dimension)
+	assert.Equal(t, 2, result.Definition.Precision)
+}
+
+func TestInstrumentCache_Get_Miss(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Get without Put should return nil
+	result := cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+}
+
+func TestInstrumentCache_Get_MissingTenant(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := context.Background() // No tenant
+
+	// Should return nil when tenant context is missing
+	result := cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+}
+
+func TestInstrumentCache_Put_MissingTenant(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := context.Background() // No tenant
+
+	// Put should be a no-op when tenant context is missing
+	instrument := newTestInstrument("USD", 1)
+	cache.Put(ctx, "USD", 1, instrument)
+
+	// Verify nothing was cached by trying with a valid tenant
+	validCtx := newTestContext("tenant1")
+	result := cache.Get(validCtx, "USD", 1)
+	assert.Nil(t, result)
+}
+
+func TestInstrumentCache_TenantIsolation(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	// Put entry for tenant1
+	instrument1 := newTestInstrument("USD", 1)
+	cache.Put(ctx1, "USD", 1, instrument1)
+
+	// Put different entry for tenant2
+	instrument2 := newTestInstrument("EUR", 1)
+	cache.Put(ctx2, "EUR", 1, instrument2)
+
+	// tenant1 should only see USD
+	result1USD := cache.Get(ctx1, "USD", 1)
+	require.NotNil(t, result1USD)
+	assert.Equal(t, "USD", result1USD.Definition.Code)
+
+	result1EUR := cache.Get(ctx1, "EUR", 1)
+	assert.Nil(t, result1EUR, "tenant1 should not see tenant2's EUR")
+
+	// tenant2 should only see EUR
+	result2EUR := cache.Get(ctx2, "EUR", 1)
+	require.NotNil(t, result2EUR)
+	assert.Equal(t, "EUR", result2EUR.Definition.Code)
+
+	result2USD := cache.Get(ctx2, "USD", 1)
+	assert.Nil(t, result2USD, "tenant2 should not see tenant1's USD")
+}
+
+func TestInstrumentCache_TTLExpiration(t *testing.T) {
+	// Use very short TTL for testing
+	cache := NewInstrumentCache(
+		WithTTL(50*time.Millisecond, 0), // No jitter for predictable tests
+	)
+	ctx := newTestContext("tenant1")
+
+	// Put an entry
+	instrument := newTestInstrument("USD", 1)
+	cache.Put(ctx, "USD", 1, instrument)
+
+	// Should be retrievable immediately
+	result := cache.Get(ctx, "USD", 1)
+	require.NotNil(t, result)
+
+	// Wait for expiration
+	time.Sleep(60 * time.Millisecond)
+
+	// Should be expired now
+	result = cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result, "entry should be expired")
+}
+
+func TestInstrumentCache_JitterVariance(t *testing.T) {
+	// Use TTL with jitter
+	cache := NewInstrumentCache(
+		WithTTL(100*time.Millisecond, 50*time.Millisecond), // 100ms ± 50ms
+	)
+	ctx := newTestContext("tenant1")
+
+	// Put multiple entries and collect their expiration times
+	var expirations []time.Duration
+	for i := 0; i < 20; i++ {
+		instrument := newTestInstrument("INS", i)
+		cache.Put(ctx, "INS", i, instrument)
+
+		result := cache.Get(ctx, "INS", i)
+		require.NotNil(t, result)
+		expirations = append(expirations, result.ExpiresAt().Sub(result.CachedAt()))
+	}
+
+	// Verify we have variance in expiration times
+	// With jitter of ±50ms, we expect some variation
+	minExp := expirations[0]
+	maxExp := expirations[0]
+	for _, exp := range expirations[1:] {
+		if exp < minExp {
+			minExp = exp
+		}
+		if exp > maxExp {
+			maxExp = exp
+		}
+	}
+
+	// The difference between min and max should be non-zero if jitter is working
+	// Note: There's a small chance this could fail due to random chance,
+	// but with 20 samples it's very unlikely
+	diff := maxExp - minExp
+	assert.Greater(t, diff.Milliseconds(), int64(0), "jitter should produce variance in TTL")
+}
+
+func TestInstrumentCache_Invalidate(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Put an entry
+	instrument := newTestInstrument("USD", 1)
+	cache.Put(ctx, "USD", 1, instrument)
+
+	// Verify it's cached
+	result := cache.Get(ctx, "USD", 1)
+	require.NotNil(t, result)
+
+	// Invalidate it
+	cache.Invalidate(ctx, "USD", 1)
+
+	// Should be gone
+	result = cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+}
+
+func TestInstrumentCache_InvalidateAll(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Put multiple entries
+	cache.Put(ctx, "USD", 1, newTestInstrument("USD", 1))
+	cache.Put(ctx, "EUR", 1, newTestInstrument("EUR", 1))
+	cache.Put(ctx, "GBP", 1, newTestInstrument("GBP", 1))
+
+	// Verify they're cached
+	assert.NotNil(t, cache.Get(ctx, "USD", 1))
+	assert.NotNil(t, cache.Get(ctx, "EUR", 1))
+	assert.NotNil(t, cache.Get(ctx, "GBP", 1))
+
+	// Invalidate all
+	cache.InvalidateAll(ctx)
+
+	// All should be gone
+	assert.Nil(t, cache.Get(ctx, "USD", 1))
+	assert.Nil(t, cache.Get(ctx, "EUR", 1))
+	assert.Nil(t, cache.Get(ctx, "GBP", 1))
+}
+
+func TestInstrumentCache_InvalidateAll_TenantIsolation(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	// Put entries for both tenants
+	cache.Put(ctx1, "USD", 1, newTestInstrument("USD", 1))
+	cache.Put(ctx2, "EUR", 1, newTestInstrument("EUR", 1))
+
+	// Invalidate all for tenant1 only
+	cache.InvalidateAll(ctx1)
+
+	// tenant1's cache should be empty
+	assert.Nil(t, cache.Get(ctx1, "USD", 1))
+
+	// tenant2's cache should be unaffected
+	assert.NotNil(t, cache.Get(ctx2, "EUR", 1))
+}
+
+func TestInstrumentCache_EvictionUnderPressure(t *testing.T) {
+	// Create cache with very small size
+	cache := NewInstrumentCache(
+		WithCacheSize(5),
+		WithTTL(1*time.Hour, 0), // Long TTL to avoid expiration
+	)
+	ctx := newTestContext("tenant1")
+
+	// Add more entries than cache size
+	for i := 0; i < 10; i++ {
+		cache.Put(ctx, "INS", i, newTestInstrument("INS", i))
+	}
+
+	// Check stats - should not exceed capacity
+	size, capacity := cache.Stats(ctx)
+	assert.Equal(t, 5, capacity)
+	assert.LessOrEqual(t, size, capacity)
+
+	// Recent entries (higher versions) should still be in cache
+	// Older entries may have been evicted by LRU
+	foundCount := 0
+	for i := 0; i < 10; i++ {
+		if cache.Get(ctx, "INS", i) != nil {
+			foundCount++
+		}
+	}
+	assert.Equal(t, 5, foundCount, "should have exactly capacity entries")
+}
+
+func TestInstrumentCache_Stats(t *testing.T) {
+	cache := NewInstrumentCache(WithCacheSize(100))
+	ctx := newTestContext("tenant1")
+
+	// Initially empty - no tenant cache exists yet, so returns 0,0
+	size, capacity := cache.Stats(ctx)
+	assert.Equal(t, 0, size)
+	assert.Equal(t, 0, capacity, "capacity is 0 until tenant cache is created")
+
+	// Add some entries - this creates the tenant cache
+	cache.Put(ctx, "USD", 1, newTestInstrument("USD", 1))
+	cache.Put(ctx, "EUR", 1, newTestInstrument("EUR", 1))
+
+	// Now we have a tenant cache with configured capacity
+	size, capacity = cache.Stats(ctx)
+	assert.Equal(t, 2, size)
+	assert.Equal(t, 100, capacity)
+}
+
+func TestInstrumentCache_Stats_MissingTenant(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := context.Background() // No tenant
+
+	size, capacity := cache.Stats(ctx)
+	assert.Equal(t, 0, size)
+	assert.Equal(t, 0, capacity)
+}
+
+func TestInstrumentCache_ConcurrentAccess(t *testing.T) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate with some entries
+	for i := 0; i < 100; i++ {
+		cache.Put(ctx, "INS", i, newTestInstrument("INS", i))
+	}
+
+	// Run concurrent reads and writes
+	var wg sync.WaitGroup
+	errors := make(chan error, 100)
+
+	// Readers
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100; j++ {
+				_ = cache.Get(ctx, "INS", j%100)
+			}
+		}()
+	}
+
+	// Writers
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				version := workerID*100 + j
+				cache.Put(ctx, "NEW", version, newTestInstrument("NEW", version))
+			}
+		}(i)
+	}
+
+	// Invalidators
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				cache.Invalidate(ctx, "INS", j)
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errors)
+
+	// No errors should have occurred (race conditions, panics, etc.)
+	for err := range errors {
+		t.Errorf("concurrent access error: %v", err)
+	}
+}
+
+func TestInstrumentCache_ConcurrentTenants(t *testing.T) {
+	cache := NewInstrumentCache()
+
+	var wg sync.WaitGroup
+
+	// Multiple tenants operating concurrently
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(tenantNum int) {
+			defer wg.Done()
+			ctx := newTestContext("tenant" + string(rune('A'+tenantNum)))
+
+			// Each tenant does its own operations
+			for j := 0; j < 100; j++ {
+				cache.Put(ctx, "INS", j, newTestInstrument("INS", j))
+				_ = cache.Get(ctx, "INS", j)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify each tenant has their own cached entries
+	for i := 0; i < 10; i++ {
+		ctx := newTestContext("tenant" + string(rune('A'+i)))
+		size, _ := cache.Stats(ctx)
+		assert.Equal(t, 100, size, "tenant %d should have 100 cached entries", i)
+	}
+}
+
+func TestCachedInstrument_Timestamps(t *testing.T) {
+	cache := NewInstrumentCache(
+		WithTTL(5*time.Minute, 30*time.Second),
+	)
+	ctx := newTestContext("tenant1")
+
+	before := time.Now()
+	cache.Put(ctx, "USD", 1, newTestInstrument("USD", 1))
+	after := time.Now()
+
+	result := cache.Get(ctx, "USD", 1)
+	require.NotNil(t, result)
+
+	// CachedAt should be between before and after
+	assert.True(t, result.CachedAt().After(before) || result.CachedAt().Equal(before))
+	assert.True(t, result.CachedAt().Before(after) || result.CachedAt().Equal(after))
+
+	// ExpiresAt should be cachedAt + TTL (within jitter range)
+	expectedMinExpiry := result.CachedAt().Add(5*time.Minute - 30*time.Second)
+	expectedMaxExpiry := result.CachedAt().Add(5*time.Minute + 30*time.Second)
+
+	assert.True(t, result.ExpiresAt().After(expectedMinExpiry) || result.ExpiresAt().Equal(expectedMinExpiry))
+	assert.True(t, result.ExpiresAt().Before(expectedMaxExpiry) || result.ExpiresAt().Equal(expectedMaxExpiry))
+}
+
+func TestKey_Equality(t *testing.T) {
+	// Key should work correctly as a map key
+	key1 := Key{Code: "USD", Version: 1}
+	key2 := Key{Code: "USD", Version: 1}
+	key3 := Key{Code: "USD", Version: 2}
+	key4 := Key{Code: "EUR", Version: 1}
+
+	assert.Equal(t, key1, key2, "same code and version should be equal")
+	assert.NotEqual(t, key1, key3, "different version should not be equal")
+	assert.NotEqual(t, key1, key4, "different code should not be equal")
+}
+
+// Benchmark tests
+
+func BenchmarkInstrumentCache_Get_Hit(b *testing.B) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate
+	cache.Put(ctx, "USD", 1, newTestInstrument("USD", 1))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cache.Get(ctx, "USD", 1)
+	}
+}
+
+func BenchmarkInstrumentCache_Get_Miss(b *testing.B) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Ensure tenant cache exists but entry doesn't
+	cache.Put(ctx, "EUR", 1, newTestInstrument("EUR", 1))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cache.Get(ctx, "USD", 1) // Misses
+	}
+}
+
+func BenchmarkInstrumentCache_Put(b *testing.B) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+	instrument := newTestInstrument("USD", 1)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Put(ctx, "USD", i%1000, instrument)
+	}
+}
+
+func BenchmarkInstrumentCache_Get_Parallel(b *testing.B) {
+	cache := NewInstrumentCache()
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate
+	for i := 0; i < 1000; i++ {
+		cache.Put(ctx, "INS", i, newTestInstrument("INS", i))
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			_ = cache.Get(ctx, "INS", i%1000)
+			i++
+		}
+	})
+}

--- a/services/reference-data/cache/prefetch.go
+++ b/services/reference-data/cache/prefetch.go
@@ -1,0 +1,131 @@
+// Package cache provides caching infrastructure for instrument definitions
+// with tenant isolation and TTL-based expiration.
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/google/cel-go/cel"
+
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// RegistryLoader provides access to the instrument registry for prefetching.
+// This interface is implemented by the service layer to decouple the cache
+// from specific registry implementations.
+type RegistryLoader interface {
+	// ListActive retrieves all instruments with ACTIVE status for the tenant in context.
+	ListActive(ctx context.Context) ([]*registry.InstrumentDefinition, error)
+
+	// CompilePrograms compiles CEL programs for an instrument definition.
+	// Returns the validation program, bucket key program, and any compilation error.
+	// Either program may be nil if no expression is defined.
+	CompilePrograms(def *registry.InstrumentDefinition) (validationPrg, bucketKeyPrg cel.Program, err error)
+}
+
+// Prefetcher loads all active instruments into the cache at startup.
+// This ensures the cache is warm before the service starts accepting traffic,
+// reducing cold-start latency for the first requests.
+type Prefetcher struct {
+	cache  *InstrumentCache
+	loader RegistryLoader
+
+	// prefetchComplete tracks whether prefetch has finished successfully.
+	// Use atomic operations for thread-safe access.
+	prefetchComplete atomic.Bool
+}
+
+// NewPrefetcher creates a new Prefetcher for warming the instrument cache.
+func NewPrefetcher(cache *InstrumentCache, loader RegistryLoader) *Prefetcher {
+	return &Prefetcher{
+		cache:  cache,
+		loader: loader,
+	}
+}
+
+// Prefetch loads all active instruments for the tenant in context into the cache.
+// The tenant context must be present in ctx.
+//
+// Returns an error if the tenant context is missing, the registry query fails,
+// or any CEL compilation fails. On error, partial results may have been cached.
+func (p *Prefetcher) Prefetch(ctx context.Context) error {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return ErrTenantContextRequired
+	}
+
+	// Load all active instruments from registry
+	instruments, err := p.loader.ListActive(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list active instruments for tenant %s: %w", tenantID, err)
+	}
+
+	// Compile CEL programs and cache each instrument
+	for _, def := range instruments {
+		validationPrg, bucketKeyPrg, err := p.loader.CompilePrograms(def)
+		if err != nil {
+			return fmt.Errorf("failed to compile CEL programs for instrument %s v%d: %w",
+				def.Code, def.Version, err)
+		}
+
+		cached := &CachedInstrument{
+			Definition:        def,
+			ValidationProgram: validationPrg,
+			BucketKeyProgram:  bucketKeyPrg,
+		}
+
+		p.cache.Put(ctx, def.Code, def.Version, cached)
+	}
+
+	return nil
+}
+
+// PrefetchMultipleTenants loads all active instruments for multiple tenants.
+// This is the primary method for startup prefetching when the service serves
+// multiple tenants.
+//
+// The base context should not have a tenant set - tenant context will be added
+// for each tenant ID. If any tenant prefetch fails, an error is returned and
+// prefetch completion is not marked (partial results may be cached).
+//
+// On successful completion of all tenants, marks prefetch as complete.
+func (p *Prefetcher) PrefetchMultipleTenants(ctx context.Context, tenantIDs []tenant.TenantID) error {
+	for _, tenantID := range tenantIDs {
+		// Check for context cancellation between tenants
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("prefetch cancelled: %w", err)
+		}
+
+		tenantCtx := tenant.WithTenant(ctx, tenantID)
+		if err := p.Prefetch(tenantCtx); err != nil {
+			return fmt.Errorf("prefetch failed for tenant %s: %w", tenantID, err)
+		}
+	}
+
+	// Mark prefetch as complete only after all tenants succeed
+	p.prefetchComplete.Store(true)
+
+	return nil
+}
+
+// IsPrefetchComplete returns true if prefetch has completed successfully.
+// This can be used by health checks to determine if the service is ready
+// to accept traffic.
+func (p *Prefetcher) IsPrefetchComplete() bool {
+	return p.prefetchComplete.Load()
+}
+
+// MarkPrefetchComplete manually marks prefetch as complete.
+// This is useful when prefetch is performed externally or skipped.
+func (p *Prefetcher) MarkPrefetchComplete() {
+	p.prefetchComplete.Store(true)
+}
+
+// ResetPrefetchStatus resets the prefetch completion status.
+// This is primarily useful for testing.
+func (p *Prefetcher) ResetPrefetchStatus() {
+	p.prefetchComplete.Store(false)
+}

--- a/services/reference-data/cache/prefetch_test.go
+++ b/services/reference-data/cache/prefetch_test.go
@@ -1,0 +1,327 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// mockRegistryLoader is a test implementation of RegistryLoader.
+type mockRegistryLoader struct {
+	instruments       map[string][]*registry.InstrumentDefinition // keyed by tenant ID
+	compileProgramsFn func(def *registry.InstrumentDefinition) (cel.Program, cel.Program, error)
+	listActiveErr     error
+}
+
+func newMockRegistryLoader() *mockRegistryLoader {
+	return &mockRegistryLoader{
+		instruments: make(map[string][]*registry.InstrumentDefinition),
+		compileProgramsFn: func(_ *registry.InstrumentDefinition) (cel.Program, cel.Program, error) {
+			return nil, nil, nil // Default: no CEL programs
+		},
+	}
+}
+
+func (m *mockRegistryLoader) ListActive(ctx context.Context) ([]*registry.InstrumentDefinition, error) {
+	if m.listActiveErr != nil {
+		return nil, m.listActiveErr
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil, ErrTenantContextRequired
+	}
+
+	return m.instruments[string(tenantID)], nil
+}
+
+func (m *mockRegistryLoader) CompilePrograms(def *registry.InstrumentDefinition) (cel.Program, cel.Program, error) {
+	return m.compileProgramsFn(def)
+}
+
+func (m *mockRegistryLoader) addInstrument(tenantID string, def *registry.InstrumentDefinition) {
+	m.instruments[tenantID] = append(m.instruments[tenantID], def)
+}
+
+func newTestDefinition(code string, version int) *registry.InstrumentDefinition {
+	return &registry.InstrumentDefinition{
+		ID:        uuid.New(),
+		Code:      code,
+		Version:   version,
+		Dimension: registry.DimensionMonetary,
+		Precision: 2,
+		Status:    registry.StatusActive,
+	}
+}
+
+func TestPrefetcher_Prefetch_LoadsAllActiveInstruments(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+
+	// Add test instruments for tenant1
+	loader.addInstrument("tenant1", newTestDefinition("USD", 1))
+	loader.addInstrument("tenant1", newTestDefinition("EUR", 1))
+	loader.addInstrument("tenant1", newTestDefinition("GBP", 1))
+
+	prefetcher := NewPrefetcher(cache, loader)
+	ctx := newTestContext("tenant1")
+
+	// Prefetch should load all instruments
+	err := prefetcher.Prefetch(ctx)
+	require.NoError(t, err)
+
+	// Verify all instruments are cached
+	assert.NotNil(t, cache.Get(ctx, "USD", 1), "USD should be cached")
+	assert.NotNil(t, cache.Get(ctx, "EUR", 1), "EUR should be cached")
+	assert.NotNil(t, cache.Get(ctx, "GBP", 1), "GBP should be cached")
+
+	// Verify cache stats
+	size, _ := cache.Stats(ctx)
+	assert.Equal(t, 3, size)
+}
+
+func TestPrefetcher_Prefetch_MissingTenantContext(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+	prefetcher := NewPrefetcher(cache, loader)
+
+	ctx := context.Background() // No tenant
+
+	err := prefetcher.Prefetch(ctx)
+	assert.ErrorIs(t, err, ErrTenantContextRequired)
+}
+
+func TestPrefetcher_Prefetch_RegistryError(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+	loader.listActiveErr = errors.New("database connection failed") //nolint:err113 // test sentinel
+
+	prefetcher := NewPrefetcher(cache, loader)
+	ctx := newTestContext("tenant1")
+
+	err := prefetcher.Prefetch(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list active instruments")
+	assert.Contains(t, err.Error(), "database connection failed")
+}
+
+func TestPrefetcher_Prefetch_CELCompilationError(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+
+	// Add instrument
+	loader.addInstrument("tenant1", newTestDefinition("USD", 1))
+
+	// Make CEL compilation fail
+	loader.compileProgramsFn = func(_ *registry.InstrumentDefinition) (cel.Program, cel.Program, error) {
+		return nil, nil, errors.New("invalid CEL expression") //nolint:err113 // test sentinel
+	}
+
+	prefetcher := NewPrefetcher(cache, loader)
+	ctx := newTestContext("tenant1")
+
+	err := prefetcher.Prefetch(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to compile CEL programs")
+	assert.Contains(t, err.Error(), "USD")
+}
+
+func TestPrefetcher_Prefetch_EmptyRegistry(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+	// No instruments added
+
+	prefetcher := NewPrefetcher(cache, loader)
+	ctx := newTestContext("tenant1")
+
+	// Should succeed with empty result
+	err := prefetcher.Prefetch(ctx)
+	require.NoError(t, err)
+
+	// Cache should be empty
+	size, _ := cache.Stats(ctx)
+	assert.Equal(t, 0, size)
+}
+
+func TestPrefetcher_PrefetchCompletionTracking(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+	prefetcher := NewPrefetcher(cache, loader)
+
+	// Initially not complete
+	assert.False(t, prefetcher.IsPrefetchComplete())
+
+	// Manual completion
+	prefetcher.MarkPrefetchComplete()
+	assert.True(t, prefetcher.IsPrefetchComplete())
+
+	// Reset
+	prefetcher.ResetPrefetchStatus()
+	assert.False(t, prefetcher.IsPrefetchComplete())
+}
+
+func TestPrefetcher_PrefetchMultipleTenants_Success(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+
+	// Add instruments for multiple tenants
+	loader.addInstrument("tenant1", newTestDefinition("USD", 1))
+	loader.addInstrument("tenant1", newTestDefinition("EUR", 1))
+	loader.addInstrument("tenant2", newTestDefinition("JPY", 1))
+	loader.addInstrument("tenant2", newTestDefinition("CNY", 1))
+	loader.addInstrument("tenant3", newTestDefinition("GBP", 1))
+
+	prefetcher := NewPrefetcher(cache, loader)
+
+	tenantIDs := []tenant.TenantID{
+		tenant.MustNewTenantID("tenant1"),
+		tenant.MustNewTenantID("tenant2"),
+		tenant.MustNewTenantID("tenant3"),
+	}
+
+	err := prefetcher.PrefetchMultipleTenants(context.Background(), tenantIDs)
+	require.NoError(t, err)
+
+	// Verify completion status
+	assert.True(t, prefetcher.IsPrefetchComplete())
+
+	// Verify each tenant's instruments are cached
+	ctx1 := newTestContext("tenant1")
+	assert.NotNil(t, cache.Get(ctx1, "USD", 1))
+	assert.NotNil(t, cache.Get(ctx1, "EUR", 1))
+
+	ctx2 := newTestContext("tenant2")
+	assert.NotNil(t, cache.Get(ctx2, "JPY", 1))
+	assert.NotNil(t, cache.Get(ctx2, "CNY", 1))
+
+	ctx3 := newTestContext("tenant3")
+	assert.NotNil(t, cache.Get(ctx3, "GBP", 1))
+}
+
+func TestPrefetcher_PrefetchMultipleTenants_PartialFailure(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+
+	// Add instruments for tenant1 only
+	loader.addInstrument("tenant1", newTestDefinition("USD", 1))
+	// tenant2 will fail with CEL compilation error
+
+	loader.addInstrument("tenant2", newTestDefinition("FAIL", 1))
+
+	callCount := 0
+	loader.compileProgramsFn = func(def *registry.InstrumentDefinition) (cel.Program, cel.Program, error) {
+		callCount++
+		if def.Code == "FAIL" {
+			return nil, nil, errors.New("compilation error") //nolint:err113 // test sentinel
+		}
+		return nil, nil, nil
+	}
+
+	prefetcher := NewPrefetcher(cache, loader)
+
+	tenantIDs := []tenant.TenantID{
+		tenant.MustNewTenantID("tenant1"),
+		tenant.MustNewTenantID("tenant2"),
+		tenant.MustNewTenantID("tenant3"),
+	}
+
+	err := prefetcher.PrefetchMultipleTenants(context.Background(), tenantIDs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prefetch failed for tenant tenant2")
+
+	// Prefetch should NOT be marked complete on failure
+	assert.False(t, prefetcher.IsPrefetchComplete())
+
+	// tenant1's instruments should be cached (completed before failure)
+	ctx1 := newTestContext("tenant1")
+	assert.NotNil(t, cache.Get(ctx1, "USD", 1))
+}
+
+func TestPrefetcher_PrefetchMultipleTenants_ContextCancellation(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+
+	loader.addInstrument("tenant1", newTestDefinition("USD", 1))
+	loader.addInstrument("tenant2", newTestDefinition("EUR", 1))
+
+	prefetcher := NewPrefetcher(cache, loader)
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	tenantIDs := []tenant.TenantID{
+		tenant.MustNewTenantID("tenant1"),
+		tenant.MustNewTenantID("tenant2"),
+	}
+
+	err := prefetcher.PrefetchMultipleTenants(ctx, tenantIDs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prefetch cancelled")
+
+	// Should not be marked complete
+	assert.False(t, prefetcher.IsPrefetchComplete())
+}
+
+func TestPrefetcher_PrefetchMultipleTenants_EmptyTenantList(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+	prefetcher := NewPrefetcher(cache, loader)
+
+	err := prefetcher.PrefetchMultipleTenants(context.Background(), []tenant.TenantID{})
+	require.NoError(t, err)
+
+	// Should be marked complete even with empty list
+	assert.True(t, prefetcher.IsPrefetchComplete())
+}
+
+func TestPrefetcher_PrefetchMultipleTenants_TenantIsolation(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+
+	// Same code "USD" in both tenants
+	loader.addInstrument("tenant1", newTestDefinition("USD", 1))
+	loader.addInstrument("tenant2", newTestDefinition("USD", 1))
+
+	prefetcher := NewPrefetcher(cache, loader)
+
+	tenantIDs := []tenant.TenantID{
+		tenant.MustNewTenantID("tenant1"),
+		tenant.MustNewTenantID("tenant2"),
+	}
+
+	err := prefetcher.PrefetchMultipleTenants(context.Background(), tenantIDs)
+	require.NoError(t, err)
+
+	// Verify each tenant has their own cached USD
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	usd1 := cache.Get(ctx1, "USD", 1)
+	usd2 := cache.Get(ctx2, "USD", 1)
+
+	require.NotNil(t, usd1)
+	require.NotNil(t, usd2)
+
+	// They should be different cache entries (different UUIDs)
+	assert.NotEqual(t, usd1.Definition.ID, usd2.Definition.ID)
+}
+
+func TestNewPrefetcher(t *testing.T) {
+	cache := NewInstrumentCache()
+	loader := newMockRegistryLoader()
+	prefetcher := NewPrefetcher(cache, loader)
+
+	assert.NotNil(t, prefetcher)
+	assert.NotNil(t, prefetcher.cache)
+	assert.NotNil(t, prefetcher.loader)
+	assert.False(t, prefetcher.IsPrefetchComplete())
+}


### PR DESCRIPTION
## Summary

Implements a high-performance local instrument cache for the reference-data service with compiled CEL programs, providing:

- **LRU Cache with TTL**: Per-tenant LRU caches using hashicorp/golang-lru/v2 with jittered TTL (5min ± 30sec) to prevent thundering herd
- **Singleflight Deduplication**: Concurrent cache misses for the same key trigger exactly one repository fetch
- **Event-driven Invalidation**: Handler interface for Kafka `instrument.updated` events to invalidate stale entries
- **Startup Prefetch**: Load all active instruments before accepting traffic with completion tracking for health checks

## Changes Made

### New Files in `services/reference-data/cache/`

- `instrument_cache.go` - Core cache implementation with per-tenant LRU caches, TTL with jitter, singleflight deduplication
- `instrument_cache_test.go` - Comprehensive tests including benchmarks (~100ns cache hit, 0 allocs)
- `event_subscriber.go` - Handler for instrument.updated events with tenant-scoped invalidation
- `event_subscriber_test.go` - Tests for event handling and tenant isolation
- `prefetch.go` - Startup prefetch with completion tracking and multi-tenant support
- `prefetch_test.go` - Tests for prefetch behavior and error handling

## Technical Details

### Cache Design

- **Key**: `{Code, Version}` - tenant is NOT in the key
- **Tenant Isolation**: Separate LRU cache per tenant (`map[TenantID]*lru.Cache`)
- **Value**: `CachedInstrument{Definition, ValidationProgram, BucketKeyProgram, cachedAt, expiresAt}`
- **Jittered TTL**: Pre-computed at cache time to ensure consistent expiration

### Singleflight

- Key format: `tenantID:code:version` for proper tenant isolation
- Double-check pattern after acquiring singleflight slot to handle races

### Thread Safety

- `sync.RWMutex` for tenant cache map
- hashicorp/golang-lru's built-in thread safety for individual caches
- Atomic bool for prefetch completion status

## Test Plan

- [x] Cache hit returns CachedInstrument with all fields
- [x] TTL expiration evicts entry after jittered duration
- [x] Multiple gets show jitter variance
- [x] Cache miss returns nil
- [x] LRU eviction under size pressure
- [x] Benchmark cache hit <100ns with 0 allocations
- [x] Tenant isolation in cache operations
- [x] 100 concurrent cache misses trigger exactly 1 loadFn call (singleflight)
- [x] InvalidateCode removes all versions for tenant
- [x] PurgeAll clears only requesting tenant's cache
- [x] Event handler invalidates correct cache entries
- [x] Prefetch loads all active instruments into cache
- [x] Prefetch completion tracking works correctly
- [x] Race detector passes on all tests

## Task Master Reference

Task: universal-asset-system.15 - Implement Local Instrument Cache with Compiled CEL Programs