### PR TITLE
feat: implement rate limiting interceptor for RegisterInstrument

### DIFF
--- a/services/reference-data/middleware/rate_limit_interceptor.go
+++ b/services/reference-data/middleware/rate_limit_interceptor.go
@@ -284,7 +284,7 @@ func (r *RateLimitInterceptor) UnaryServerInterceptor() grpc.UnaryServerIntercep
 					"method", info.FullMethod)
 			}
 			return nil, status.Errorf(codes.ResourceExhausted,
-				"rate limit exceeded for tenant %s: max %d requests per minute",
+				"rate limit exceeded for tenant %s: burst capacity %d exhausted, try again later",
 				tenantStr, r.config.BurstSize)
 		}
 

--- a/services/reference-data/middleware/rate_limit_interceptor.go
+++ b/services/reference-data/middleware/rate_limit_interceptor.go
@@ -1,0 +1,305 @@
+// Package middleware provides gRPC interceptors for the reference-data service.
+package middleware
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	// RegisterInstrumentMethod is the full gRPC method name for rate limiting.
+	RegisterInstrumentMethod = "/meridian.reference_data.v1.ReferenceDataService/RegisterInstrument"
+
+	// DefaultBurstSize is the maximum number of tokens in the bucket (burst capacity).
+	DefaultBurstSize = 10
+
+	// DefaultRefillRate is how often a token is added (1 token per 6 seconds = 10 per minute).
+	DefaultRefillRate = 6 * time.Second
+
+	// DefaultCleanupInterval is how often to check for idle limiters.
+	DefaultCleanupInterval = 5 * time.Minute
+
+	// DefaultIdleTimeout is how long a limiter can be idle before eviction.
+	DefaultIdleTimeout = 1 * time.Hour
+)
+
+// tenantLimiter wraps a rate.Limiter with last-used timestamp for cleanup.
+type tenantLimiter struct {
+	limiter  *rate.Limiter
+	lastUsed time.Time
+	mu       sync.Mutex
+}
+
+// RateLimitInterceptorConfig configures the rate limiter behavior.
+type RateLimitInterceptorConfig struct {
+	// BurstSize is the maximum tokens in the bucket.
+	BurstSize int
+	// RefillRate is the duration between adding tokens.
+	RefillRate time.Duration
+	// CleanupInterval is how often to run cleanup.
+	CleanupInterval time.Duration
+	// IdleTimeout is how long before an idle limiter is evicted.
+	IdleTimeout time.Duration
+	// Logger for rate limit events.
+	Logger *slog.Logger
+}
+
+// DefaultConfig returns the default rate limiter configuration.
+func DefaultConfig() RateLimitInterceptorConfig {
+	return RateLimitInterceptorConfig{
+		BurstSize:       DefaultBurstSize,
+		RefillRate:      DefaultRefillRate,
+		CleanupInterval: DefaultCleanupInterval,
+		IdleTimeout:     DefaultIdleTimeout,
+	}
+}
+
+// RateLimitMetrics holds Prometheus metrics for rate limiting.
+type RateLimitMetrics struct {
+	allowed *prometheus.CounterVec
+	blocked *prometheus.CounterVec
+	active  prometheus.Gauge
+}
+
+// NewRateLimitMetrics creates metrics and registers them with the given registry.
+// If registry is nil, metrics are registered with the default registry.
+func NewRateLimitMetrics(registry prometheus.Registerer) *RateLimitMetrics {
+	if registry == nil {
+		registry = prometheus.DefaultRegisterer
+	}
+
+	m := &RateLimitMetrics{
+		allowed: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "reference_data",
+				Subsystem: "rate_limit",
+				Name:      "requests_allowed_total",
+				Help:      "Total number of requests allowed by the rate limiter",
+			},
+			[]string{"tenant"},
+		),
+		blocked: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "reference_data",
+				Subsystem: "rate_limit",
+				Name:      "requests_blocked_total",
+				Help:      "Total number of requests blocked by the rate limiter",
+			},
+			[]string{"tenant", "method"},
+		),
+		active: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "reference_data",
+				Subsystem: "rate_limit",
+				Name:      "active_limiters",
+				Help:      "Number of active per-tenant rate limiters in memory",
+			},
+		),
+	}
+
+	registry.MustRegister(m.allowed, m.blocked, m.active)
+	return m
+}
+
+// RateLimitInterceptor provides per-tenant rate limiting for gRPC endpoints.
+type RateLimitInterceptor struct {
+	limiters sync.Map // map[string]*tenantLimiter
+	config   RateLimitInterceptorConfig
+	metrics  *RateLimitMetrics
+	stopCh   chan struct{}
+	wg       sync.WaitGroup
+}
+
+// NewRateLimitInterceptor creates a new rate limit interceptor with the given config.
+func NewRateLimitInterceptor(config RateLimitInterceptorConfig, metrics *RateLimitMetrics) *RateLimitInterceptor {
+	if config.BurstSize == 0 {
+		config.BurstSize = DefaultBurstSize
+	}
+	if config.RefillRate == 0 {
+		config.RefillRate = DefaultRefillRate
+	}
+	if config.CleanupInterval == 0 {
+		config.CleanupInterval = DefaultCleanupInterval
+	}
+	if config.IdleTimeout == 0 {
+		config.IdleTimeout = DefaultIdleTimeout
+	}
+
+	r := &RateLimitInterceptor{
+		config:  config,
+		metrics: metrics,
+		stopCh:  make(chan struct{}),
+	}
+
+	// Start cleanup goroutine
+	r.wg.Add(1)
+	go r.cleanupLoop()
+
+	return r
+}
+
+// Stop gracefully stops the interceptor's background cleanup goroutine.
+func (r *RateLimitInterceptor) Stop() {
+	close(r.stopCh)
+	r.wg.Wait()
+}
+
+// cleanupLoop periodically removes idle limiters to prevent memory leaks.
+func (r *RateLimitInterceptor) cleanupLoop() {
+	defer r.wg.Done()
+
+	ticker := time.NewTicker(r.config.CleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-r.stopCh:
+			return
+		case <-ticker.C:
+			r.cleanupIdleLimiters()
+		}
+	}
+}
+
+// cleanupIdleLimiters removes limiters that haven't been used recently.
+func (r *RateLimitInterceptor) cleanupIdleLimiters() {
+	now := time.Now()
+	var activeCount int
+
+	r.limiters.Range(func(key, value any) bool {
+		tl, ok := value.(*tenantLimiter)
+		if !ok {
+			return true // Skip malformed entry
+		}
+		tl.mu.Lock()
+		idle := now.Sub(tl.lastUsed) > r.config.IdleTimeout
+		tl.mu.Unlock()
+
+		if idle {
+			r.limiters.Delete(key)
+			if r.config.Logger != nil {
+				r.config.Logger.Debug("evicted idle rate limiter",
+					"tenant", key,
+					"idle_duration", now.Sub(tl.lastUsed))
+			}
+		} else {
+			activeCount++
+		}
+		return true
+	})
+
+	if r.metrics != nil {
+		r.metrics.active.Set(float64(activeCount))
+	}
+}
+
+// getOrCreateLimiter returns the rate limiter for a tenant, creating one if needed.
+func (r *RateLimitInterceptor) getOrCreateLimiter(tenantID string) *tenantLimiter {
+	if existing, ok := r.limiters.Load(tenantID); ok {
+		tl, typeOK := existing.(*tenantLimiter)
+		if typeOK {
+			tl.mu.Lock()
+			tl.lastUsed = time.Now()
+			tl.mu.Unlock()
+			return tl
+		}
+		// Type assertion failed, fall through to create new limiter
+	}
+
+	// Create new limiter: rate.Every(6s) = ~0.167 tokens/sec, burst of 10
+	tl := &tenantLimiter{
+		limiter:  rate.NewLimiter(rate.Every(r.config.RefillRate), r.config.BurstSize),
+		lastUsed: time.Now(),
+	}
+
+	// LoadOrStore handles race conditions
+	actual, loaded := r.limiters.LoadOrStore(tenantID, tl)
+	if loaded {
+		// Another goroutine created the limiter first, use that one
+		if actualTL, typeOK := actual.(*tenantLimiter); typeOK {
+			return actualTL
+		}
+	}
+
+	// We created a new limiter, update the gauge
+	if r.metrics != nil {
+		// Count active limiters
+		var count int
+		r.limiters.Range(func(_, _ any) bool {
+			count++
+			return true
+		})
+		r.metrics.active.Set(float64(count))
+	}
+
+	return tl
+}
+
+// UnaryServerInterceptor returns a gRPC unary server interceptor that enforces
+// per-tenant rate limiting on the RegisterInstrument endpoint.
+func (r *RateLimitInterceptor) UnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		// Only rate limit RegisterInstrument, not read operations
+		if info.FullMethod != RegisterInstrumentMethod {
+			return handler(ctx, req)
+		}
+
+		// Extract tenant ID from context
+		tenantID, ok := tenant.FromContext(ctx)
+		if !ok {
+			// No tenant context - allow the request through
+			// The request will fail authorization elsewhere if required
+			return handler(ctx, req)
+		}
+
+		tenantStr := tenantID.String()
+		tl := r.getOrCreateLimiter(tenantStr)
+
+		if !tl.limiter.Allow() {
+			// Rate limit exceeded
+			if r.metrics != nil {
+				r.metrics.blocked.WithLabelValues(tenantStr, info.FullMethod).Inc()
+			}
+			if r.config.Logger != nil {
+				r.config.Logger.Warn("rate limit exceeded",
+					"tenant", tenantStr,
+					"method", info.FullMethod)
+			}
+			return nil, status.Errorf(codes.ResourceExhausted,
+				"rate limit exceeded for tenant %s: max %d requests per minute",
+				tenantStr, r.config.BurstSize)
+		}
+
+		// Request allowed
+		if r.metrics != nil {
+			r.metrics.allowed.WithLabelValues(tenantStr).Inc()
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// ActiveLimiters returns the number of active per-tenant rate limiters.
+// Useful for testing.
+func (r *RateLimitInterceptor) ActiveLimiters() int {
+	var count int
+	r.limiters.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	return count
+}

--- a/services/reference-data/middleware/rate_limit_interceptor.go
+++ b/services/reference-data/middleware/rate_limit_interceptor.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -112,11 +113,13 @@ func NewRateLimitMetrics(registry prometheus.Registerer) *RateLimitMetrics {
 
 // RateLimitInterceptor provides per-tenant rate limiting for gRPC endpoints.
 type RateLimitInterceptor struct {
-	limiters sync.Map // map[string]*tenantLimiter
-	config   RateLimitInterceptorConfig
-	metrics  *RateLimitMetrics
-	stopCh   chan struct{}
-	wg       sync.WaitGroup
+	limiters    sync.Map // map[string]*tenantLimiter
+	activeCount atomic.Int64
+	config      RateLimitInterceptorConfig
+	metrics     *RateLimitMetrics
+	stopCh      chan struct{}
+	stopOnce    sync.Once
+	wg          sync.WaitGroup
 }
 
 // NewRateLimitInterceptor creates a new rate limit interceptor with the given config.
@@ -148,8 +151,11 @@ func NewRateLimitInterceptor(config RateLimitInterceptorConfig, metrics *RateLim
 }
 
 // Stop gracefully stops the interceptor's background cleanup goroutine.
+// Safe to call multiple times.
 func (r *RateLimitInterceptor) Stop() {
-	close(r.stopCh)
+	r.stopOnce.Do(func() {
+		close(r.stopCh)
+	})
 	r.wg.Wait()
 }
 
@@ -173,7 +179,6 @@ func (r *RateLimitInterceptor) cleanupLoop() {
 // cleanupIdleLimiters removes limiters that haven't been used recently.
 func (r *RateLimitInterceptor) cleanupIdleLimiters() {
 	now := time.Now()
-	var activeCount int
 
 	r.limiters.Range(func(key, value any) bool {
 		tl, ok := value.(*tenantLimiter)
@@ -187,19 +192,18 @@ func (r *RateLimitInterceptor) cleanupIdleLimiters() {
 
 		if idle {
 			r.limiters.Delete(key)
+			r.activeCount.Add(-1)
 			if r.config.Logger != nil {
 				r.config.Logger.Debug("evicted idle rate limiter",
 					"tenant", key,
 					"idle_duration", idleDuration)
 			}
-		} else {
-			activeCount++
 		}
 		return true
 	})
 
 	if r.metrics != nil {
-		r.metrics.active.Set(float64(activeCount))
+		r.metrics.active.Set(float64(r.activeCount.Load()))
 	}
 }
 
@@ -235,14 +239,9 @@ func (r *RateLimitInterceptor) getOrCreateLimiter(tenantID string) *tenantLimite
 		}
 	}
 
-	// We created a new limiter, update the gauge
+	// We created a new limiter, update the counter and gauge
+	count := r.activeCount.Add(1)
 	if r.metrics != nil {
-		// Count active limiters
-		var count int
-		r.limiters.Range(func(_, _ any) bool {
-			count++
-			return true
-		})
 		r.metrics.active.Set(float64(count))
 	}
 
@@ -301,10 +300,5 @@ func (r *RateLimitInterceptor) UnaryServerInterceptor() grpc.UnaryServerIntercep
 // ActiveLimiters returns the number of active per-tenant rate limiters.
 // Useful for testing.
 func (r *RateLimitInterceptor) ActiveLimiters() int {
-	var count int
-	r.limiters.Range(func(_, _ any) bool {
-		count++
-		return true
-	})
-	return count
+	return int(r.activeCount.Load())
 }

--- a/services/reference-data/middleware/rate_limit_interceptor.go
+++ b/services/reference-data/middleware/rate_limit_interceptor.go
@@ -94,7 +94,7 @@ func NewRateLimitMetrics(registry prometheus.Registerer) *RateLimitMetrics {
 				Name:      "requests_blocked_total",
 				Help:      "Total number of requests blocked by the rate limiter",
 			},
-			[]string{"tenant", "method"},
+			[]string{"tenant"},
 		),
 		active: prometheus.NewGauge(
 			prometheus.GaugeOpts{
@@ -227,6 +227,10 @@ func (r *RateLimitInterceptor) getOrCreateLimiter(tenantID string) *tenantLimite
 	if loaded {
 		// Another goroutine created the limiter first, use that one
 		if actualTL, typeOK := actual.(*tenantLimiter); typeOK {
+			// Update lastUsed on the winner's limiter
+			actualTL.mu.Lock()
+			actualTL.lastUsed = time.Now()
+			actualTL.mu.Unlock()
 			return actualTL
 		}
 	}
@@ -273,7 +277,7 @@ func (r *RateLimitInterceptor) UnaryServerInterceptor() grpc.UnaryServerIntercep
 		if !tl.limiter.Allow() {
 			// Rate limit exceeded
 			if r.metrics != nil {
-				r.metrics.blocked.WithLabelValues(tenantStr, info.FullMethod).Inc()
+				r.metrics.blocked.WithLabelValues(tenantStr).Inc()
 			}
 			if r.config.Logger != nil {
 				r.config.Logger.Warn("rate limit exceeded",

--- a/services/reference-data/middleware/rate_limit_interceptor.go
+++ b/services/reference-data/middleware/rate_limit_interceptor.go
@@ -181,7 +181,8 @@ func (r *RateLimitInterceptor) cleanupIdleLimiters() {
 			return true // Skip malformed entry
 		}
 		tl.mu.Lock()
-		idle := now.Sub(tl.lastUsed) > r.config.IdleTimeout
+		idleDuration := now.Sub(tl.lastUsed)
+		idle := idleDuration > r.config.IdleTimeout
 		tl.mu.Unlock()
 
 		if idle {
@@ -189,7 +190,7 @@ func (r *RateLimitInterceptor) cleanupIdleLimiters() {
 			if r.config.Logger != nil {
 				r.config.Logger.Debug("evicted idle rate limiter",
 					"tenant", key,
-					"idle_duration", now.Sub(tl.lastUsed))
+					"idle_duration", idleDuration)
 			}
 		} else {
 			activeCount++

--- a/services/reference-data/middleware/rate_limit_interceptor_test.go
+++ b/services/reference-data/middleware/rate_limit_interceptor_test.go
@@ -1,0 +1,359 @@
+package middleware
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// testHandler is a simple gRPC handler for testing.
+func testHandler(_ context.Context, _ any) (any, error) {
+	return "ok", nil
+}
+
+// testRegistry creates an isolated Prometheus registry for testing.
+func testRegistry() *prometheus.Registry {
+	return prometheus.NewRegistry()
+}
+
+func TestRateLimitInterceptor_AllowsUpToBurstSize(t *testing.T) {
+	registry := testRegistry()
+	metrics := NewRateLimitMetrics(registry)
+
+	config := RateLimitInterceptorConfig{
+		BurstSize:       10,
+		RefillRate:      1 * time.Minute, // Very slow refill so we can test burst
+		CleanupInterval: 1 * time.Hour,   // Don't cleanup during test
+		IdleTimeout:     1 * time.Hour,
+	}
+	interceptor := NewRateLimitInterceptor(config, metrics)
+	defer interceptor.Stop()
+
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("test_tenant"))
+	info := &grpc.UnaryServerInfo{FullMethod: RegisterInstrumentMethod}
+	handler := interceptor.UnaryServerInterceptor()
+
+	// Should allow exactly 10 requests
+	for i := 0; i < 10; i++ {
+		resp, err := handler(ctx, nil, info, testHandler)
+		require.NoError(t, err, "request %d should succeed", i+1)
+		assert.Equal(t, "ok", resp)
+	}
+
+	// 11th request should be rate limited
+	_, err := handler(ctx, nil, info, testHandler)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.ResourceExhausted, st.Code())
+	assert.Contains(t, st.Message(), "rate limit exceeded")
+	assert.Contains(t, st.Message(), "test_tenant")
+}
+
+func TestRateLimitInterceptor_ReturnsResourceExhausted(t *testing.T) {
+	registry := testRegistry()
+	metrics := NewRateLimitMetrics(registry)
+
+	config := RateLimitInterceptorConfig{
+		BurstSize:  1, // Very small burst to trigger immediately
+		RefillRate: 1 * time.Hour,
+	}
+	interceptor := NewRateLimitInterceptor(config, metrics)
+	defer interceptor.Stop()
+
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("tenant_a"))
+	info := &grpc.UnaryServerInfo{FullMethod: RegisterInstrumentMethod}
+	handler := interceptor.UnaryServerInterceptor()
+
+	// First request succeeds
+	_, err := handler(ctx, nil, info, testHandler)
+	require.NoError(t, err)
+
+	// Second request should fail with ResourceExhausted
+	_, err = handler(ctx, nil, info, testHandler)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.ResourceExhausted, st.Code())
+}
+
+func TestRateLimitInterceptor_BypassesReadOperations(t *testing.T) {
+	registry := testRegistry()
+	metrics := NewRateLimitMetrics(registry)
+
+	config := RateLimitInterceptorConfig{
+		BurstSize:  1, // Would trigger immediately if rate limited
+		RefillRate: 1 * time.Hour,
+	}
+	interceptor := NewRateLimitInterceptor(config, metrics)
+	defer interceptor.Stop()
+
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("read_tenant"))
+	handler := interceptor.UnaryServerInterceptor()
+
+	// Read operations should never be rate limited
+	readMethods := []string{
+		"/meridian.reference_data.v1.ReferenceDataService/RetrieveInstrument",
+		"/meridian.reference_data.v1.ReferenceDataService/ListInstruments",
+		"/meridian.reference_data.v1.ReferenceDataService/GetAttributeSchema",
+	}
+
+	for _, method := range readMethods {
+		info := &grpc.UnaryServerInfo{FullMethod: method}
+		// Make many requests - none should be rate limited
+		for i := 0; i < 100; i++ {
+			resp, err := handler(ctx, nil, info, testHandler)
+			require.NoError(t, err, "request %d to %s should succeed", i+1, method)
+			assert.Equal(t, "ok", resp)
+		}
+	}
+}
+
+func TestRateLimitInterceptor_PerTenantIsolation(t *testing.T) {
+	registry := testRegistry()
+	metrics := NewRateLimitMetrics(registry)
+
+	config := RateLimitInterceptorConfig{
+		BurstSize:  2,
+		RefillRate: 1 * time.Hour,
+	}
+	interceptor := NewRateLimitInterceptor(config, metrics)
+	defer interceptor.Stop()
+
+	ctxA := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("tenant_a"))
+	ctxB := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("tenant_b"))
+	info := &grpc.UnaryServerInfo{FullMethod: RegisterInstrumentMethod}
+	handler := interceptor.UnaryServerInterceptor()
+
+	// Exhaust tenant A's quota
+	for i := 0; i < 2; i++ {
+		_, err := handler(ctxA, nil, info, testHandler)
+		require.NoError(t, err)
+	}
+	// Tenant A should be rate limited
+	_, err := handler(ctxA, nil, info, testHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+
+	// Tenant B should still have full quota
+	for i := 0; i < 2; i++ {
+		_, err := handler(ctxB, nil, info, testHandler)
+		require.NoError(t, err, "tenant B request %d should succeed", i+1)
+	}
+}
+
+func TestRateLimitInterceptor_NoTenantContext(t *testing.T) {
+	registry := testRegistry()
+	metrics := NewRateLimitMetrics(registry)
+
+	config := RateLimitInterceptorConfig{
+		BurstSize:  1,
+		RefillRate: 1 * time.Hour,
+	}
+	interceptor := NewRateLimitInterceptor(config, metrics)
+	defer interceptor.Stop()
+
+	// Context without tenant
+	ctx := context.Background()
+	info := &grpc.UnaryServerInfo{FullMethod: RegisterInstrumentMethod}
+	handler := interceptor.UnaryServerInterceptor()
+
+	// Requests without tenant context should pass through
+	// (will be rejected by auth layer if required)
+	for i := 0; i < 10; i++ {
+		resp, err := handler(ctx, nil, info, testHandler)
+		require.NoError(t, err)
+		assert.Equal(t, "ok", resp)
+	}
+}
+
+func TestRateLimitInterceptor_TokenReplenishment(t *testing.T) {
+	registry := testRegistry()
+	metrics := NewRateLimitMetrics(registry)
+
+	// Very fast refill for testing: 1 token every 50ms
+	config := RateLimitInterceptorConfig{
+		BurstSize:  2,
+		RefillRate: 50 * time.Millisecond,
+	}
+	interceptor := NewRateLimitInterceptor(config, metrics)
+	defer interceptor.Stop()
+
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("replenish_tenant"))
+	info := &grpc.UnaryServerInfo{FullMethod: RegisterInstrumentMethod}
+	handler := interceptor.UnaryServerInterceptor()
+
+	// Use up the burst
+	for i := 0; i < 2; i++ {
+		_, err := handler(ctx, nil, info, testHandler)
+		require.NoError(t, err)
+	}
+
+	// Should be rate limited now
+	_, err := handler(ctx, nil, info, testHandler)
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+
+	// Wait for token to replenish
+	time.Sleep(60 * time.Millisecond)
+
+	// Should succeed again
+	_, err = handler(ctx, nil, info, testHandler)
+	require.NoError(t, err)
+}
+
+func TestRateLimitInterceptor_ConcurrentAccess(t *testing.T) {
+	registry := testRegistry()
+	metrics := NewRateLimitMetrics(registry)
+
+	config := RateLimitInterceptorConfig{
+		BurstSize:  10,
+		RefillRate: 1 * time.Hour,
+	}
+	interceptor := NewRateLimitInterceptor(config, metrics)
+	defer interceptor.Stop()
+
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("concurrent_tenant"))
+	info := &grpc.UnaryServerInfo{FullMethod: RegisterInstrumentMethod}
+	handler := interceptor.UnaryServerInterceptor()
+
+	// Launch 20 concurrent requests
+	var wg sync.WaitGroup
+	var allowed, blocked atomic.Int32
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := handler(ctx, nil, info, testHandler)
+			if err == nil {
+				allowed.Add(1)
+			} else {
+				blocked.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Exactly 10 should be allowed, 10 blocked
+	assert.Equal(t, int32(10), allowed.Load(), "expected 10 allowed")
+	assert.Equal(t, int32(10), blocked.Load(), "expected 10 blocked")
+}
+
+func TestRateLimitInterceptor_CleanupIdleLimiters(t *testing.T) {
+	registry := testRegistry()
+	metrics := NewRateLimitMetrics(registry)
+
+	config := RateLimitInterceptorConfig{
+		BurstSize:       10,
+		RefillRate:      1 * time.Hour,
+		CleanupInterval: 50 * time.Millisecond,
+		IdleTimeout:     100 * time.Millisecond,
+	}
+	interceptor := NewRateLimitInterceptor(config, metrics)
+	defer interceptor.Stop()
+
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("cleanup_tenant"))
+	info := &grpc.UnaryServerInfo{FullMethod: RegisterInstrumentMethod}
+	handler := interceptor.UnaryServerInterceptor()
+
+	// Create a limiter
+	_, err := handler(ctx, nil, info, testHandler)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, interceptor.ActiveLimiters())
+
+	// Wait for cleanup to evict it
+	time.Sleep(200 * time.Millisecond)
+
+	assert.Equal(t, 0, interceptor.ActiveLimiters())
+}
+
+func TestRateLimitMetrics_Increment(t *testing.T) {
+	registry := testRegistry()
+	metrics := NewRateLimitMetrics(registry)
+
+	config := RateLimitInterceptorConfig{
+		BurstSize:  2,
+		RefillRate: 1 * time.Hour,
+	}
+	interceptor := NewRateLimitInterceptor(config, metrics)
+	defer interceptor.Stop()
+
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("metrics_tenant"))
+	info := &grpc.UnaryServerInfo{FullMethod: RegisterInstrumentMethod}
+	handler := interceptor.UnaryServerInterceptor()
+
+	// 2 allowed, 1 blocked
+	handler(ctx, nil, info, testHandler)
+	handler(ctx, nil, info, testHandler)
+	handler(ctx, nil, info, testHandler)
+
+	// Check allowed counter
+	allowedMetric := &dto.Metric{}
+	err := metrics.allowed.WithLabelValues("metrics_tenant").Write(allowedMetric)
+	require.NoError(t, err)
+	assert.Equal(t, float64(2), allowedMetric.Counter.GetValue())
+
+	// Check blocked counter
+	blockedMetric := &dto.Metric{}
+	err = metrics.blocked.WithLabelValues("metrics_tenant", RegisterInstrumentMethod).Write(blockedMetric)
+	require.NoError(t, err)
+	assert.Equal(t, float64(1), blockedMetric.Counter.GetValue())
+}
+
+func TestRateLimitMetrics_ActiveLimitersGauge(t *testing.T) {
+	registry := testRegistry()
+	metrics := NewRateLimitMetrics(registry)
+
+	config := RateLimitInterceptorConfig{
+		BurstSize:       10,
+		RefillRate:      1 * time.Hour,
+		CleanupInterval: 50 * time.Millisecond,
+		IdleTimeout:     100 * time.Millisecond,
+	}
+	interceptor := NewRateLimitInterceptor(config, metrics)
+	defer interceptor.Stop()
+
+	info := &grpc.UnaryServerInfo{FullMethod: RegisterInstrumentMethod}
+	handler := interceptor.UnaryServerInterceptor()
+
+	// Create limiters for 3 tenants
+	for i := 0; i < 3; i++ {
+		ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("tenant_"+string(rune('a'+i))))
+		handler(ctx, nil, info, testHandler)
+	}
+
+	// Check gauge
+	gaugeMetric := &dto.Metric{}
+	err := metrics.active.Write(gaugeMetric)
+	require.NoError(t, err)
+	assert.Equal(t, float64(3), gaugeMetric.Gauge.GetValue())
+
+	// Wait for cleanup
+	time.Sleep(200 * time.Millisecond)
+
+	err = metrics.active.Write(gaugeMetric)
+	require.NoError(t, err)
+	assert.Equal(t, float64(0), gaugeMetric.Gauge.GetValue())
+}
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+	assert.Equal(t, 10, config.BurstSize)
+	assert.Equal(t, 6*time.Second, config.RefillRate)
+	assert.Equal(t, 5*time.Minute, config.CleanupInterval)
+	assert.Equal(t, 1*time.Hour, config.IdleTimeout)
+}

--- a/services/reference-data/middleware/rate_limit_interceptor_test.go
+++ b/services/reference-data/middleware/rate_limit_interceptor_test.go
@@ -309,7 +309,7 @@ func TestRateLimitMetrics_Increment(t *testing.T) {
 
 	// Check blocked counter
 	blockedMetric := &dto.Metric{}
-	err = metrics.blocked.WithLabelValues("metrics_tenant", RegisterInstrumentMethod).Write(blockedMetric)
+	err = metrics.blocked.WithLabelValues("metrics_tenant").Write(blockedMetric)
 	require.NoError(t, err)
 	assert.Equal(t, float64(1), blockedMetric.Counter.GetValue())
 }

--- a/services/reference-data/middleware/rate_limit_interceptor_test.go
+++ b/services/reference-data/middleware/rate_limit_interceptor_test.go
@@ -357,3 +357,22 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 5*time.Minute, config.CleanupInterval)
 	assert.Equal(t, 1*time.Hour, config.IdleTimeout)
 }
+
+func TestRateLimitInterceptor_StopIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	registry := testRegistry()
+	metrics := NewRateLimitMetrics(registry)
+
+	config := RateLimitInterceptorConfig{
+		BurstSize:       10,
+		RefillRate:      1 * time.Hour,
+		CleanupInterval: 1 * time.Hour,
+	}
+	interceptor := NewRateLimitInterceptor(config, metrics)
+
+	// Stop should be safe to call multiple times without panicking
+	interceptor.Stop()
+	interceptor.Stop()
+	interceptor.Stop()
+}


### PR DESCRIPTION
## Summary

Add per-tenant rate limiting interceptor to prevent DOS attacks on the RegisterInstrument gRPC endpoint.

- Implements token bucket algorithm (10 tokens, 1 token per 6 seconds = max 10 requests/minute)
- Uses `sync.Map` for per-tenant isolation with automatic cleanup of idle limiters
- Only rate-limits RegisterInstrument endpoint, not read operations (RetrieveInstrument, ListInstruments, etc.)
- Returns gRPC `ResourceExhausted` (code 8) with clear error message when limit exceeded
- Includes Prometheus metrics for monitoring rate limit hits and active limiters

## Test plan

- [x] Unit test: allows 10 requests then blocks 11th
- [x] Unit test: token replenishment after time
- [x] Unit test: read endpoints bypass rate limiting
- [x] Unit test: per-tenant isolation (tenant A rate limited doesn't affect tenant B)
- [x] Unit test: gRPC error returns ResourceExhausted code
- [x] Unit test: concurrent access (20 concurrent requests, verify 10 allowed/10 blocked)
- [x] Unit test: cleanup evicts idle limiters after timeout
- [x] Unit test: Prometheus metrics increment correctly
- [ ] Manual test: verify metrics on `/metrics` endpoint

## Related

Task Master: universal-asset-system.14 - Implement Rate Limiting Interceptor

## Notes

This is a fallback rate limiter. API Gateway-level rate limiting (Envoy ratelimit service) is preferred for production deployments.