### PR TITLE
feat: migrate Utilization Metering to Quantity[Commodity]

### DIFF
--- a/services/utilization-metering-consumer/adapters/grpc/position_keeping_client.go
+++ b/services/utilization-metering-consumer/adapters/grpc/position_keeping_client.go
@@ -177,6 +177,16 @@ func (c *PositionKeepingGRPCClient) RecordMeasurement(ctx context.Context, measu
 }
 
 // buildRecordMeasurementRequest converts a domain Measurement to a proto request.
+//
+// This method maps the auditdomain.Measurement to the RecordMeasurementRequest proto,
+// leveraging the Universal Asset System's typed instrument definitions to provide
+// richer metadata for Position Keeping.
+//
+// The mapping uses:
+//   - AssetCode as measurement_type (e.g., "MERIDIAN-CURRENT-ACCOUNT-OPS")
+//   - Quantity.String() as value (decimal precision preserved)
+//   - Instrument-derived unit from the measurement type attribute
+//   - Instrument metadata for typed quantity reconstruction on Position Keeping side
 func (c *PositionKeepingGRPCClient) buildRecordMeasurementRequest(measurement *auditdomain.Measurement) *positionkeepingv1.RecordMeasurementRequest {
 	// Map measurement fields to proto request
 	// measurement_type is derived from AssetCode (e.g., "MERIDIAN-CURRENT-ACCOUNT-OPS")
@@ -186,11 +196,18 @@ func (c *PositionKeepingGRPCClient) buildRecordMeasurementRequest(measurement *a
 	// Value is the quantity as a decimal string
 	value := measurement.Quantity.String()
 
-	// Unit is derived from the attributes or defaults to "operations"
-	unit := "operations"
-	if unitAttr, ok := measurement.Attributes["unit"]; ok {
-		unit = unitAttr
+	// Get the typed instrument based on the unit attribute.
+	// This provides proper instrument metadata for Position Keeping to reconstruct
+	// typed quantities using the Universal Asset System.
+	unitAttr := "operation" // default unit type
+	if attr, ok := measurement.Attributes["unit"]; ok {
+		unitAttr = attr
 	}
+	instrument := domain.InstrumentForMeasurementType(unitAttr)
+
+	// Use the instrument's dimension as the unit (e.g., "COUNT", "DATA", "COMPUTE")
+	// This is more semantically accurate than the raw unit attribute
+	unit := instrument.Dimension
 
 	// Timestamp from the period start (audit events are point-in-time)
 	timestamp := timestamppb.New(measurement.Period.Start)
@@ -203,6 +220,14 @@ func (c *PositionKeepingGRPCClient) buildRecordMeasurementRequest(measurement *a
 	// Add source info to metadata
 	metadata["source"] = measurement.Source
 	metadata["quality_score"] = fmt.Sprintf("%d", measurement.QualityScore)
+
+	// Add instrument metadata for typed quantity reconstruction.
+	// Position Keeping can use these fields to create properly typed quantities
+	// using the Universal Asset System's InstrumentAmount proto or domain types.
+	metadata["instrument_code"] = instrument.Code
+	metadata["instrument_version"] = fmt.Sprintf("%d", instrument.Version)
+	metadata["instrument_dimension"] = instrument.Dimension
+	metadata["instrument_precision"] = fmt.Sprintf("%d", instrument.Precision)
 
 	// Position state ID is the AccountID (the billing account for this tenant)
 	positionStateID := measurement.AccountID.String()

--- a/services/utilization-metering-consumer/adapters/grpc/position_keeping_client_test.go
+++ b/services/utilization-metering-consumer/adapters/grpc/position_keeping_client_test.go
@@ -296,25 +296,82 @@ func TestPositionKeepingGRPCClient_buildRecordMeasurementRequest(t *testing.T) {
 
 	assert.Equal(t, "MERIDIAN-CURRENT-ACCOUNT-OPS", req.MeasurementType)
 	assert.Equal(t, "1", req.Value)
-	assert.Equal(t, "operations", req.Unit)
+	// Unit now uses instrument dimension (COUNT for operation type)
+	assert.Equal(t, "COUNT", req.Unit)
 	assert.Equal(t, measurement.AccountID.String(), req.PositionStateId)
 	assert.NotNil(t, req.Timestamp)
 
-	// Check metadata
+	// Check metadata from measurement attributes
 	assert.Equal(t, "current_account", req.Metadata["service"])
 	assert.Equal(t, "INSERT", req.Metadata["operation"])
 	assert.Equal(t, "AUDIT_STREAM", req.Metadata["source"])
 	assert.Equal(t, "100", req.Metadata["quality_score"])
+
+	// Check instrument metadata for typed quantity reconstruction
+	assert.Equal(t, "OPERATION", req.Metadata["instrument_code"])
+	assert.Equal(t, "1", req.Metadata["instrument_version"])
+	assert.Equal(t, "COUNT", req.Metadata["instrument_dimension"])
+	assert.Equal(t, "0", req.Metadata["instrument_precision"])
 }
 
-func TestPositionKeepingGRPCClient_buildRecordMeasurementRequest_CustomUnit(t *testing.T) {
+func TestPositionKeepingGRPCClient_buildRecordMeasurementRequest_TransactionUnit(t *testing.T) {
 	client := &PositionKeepingGRPCClient{}
 	measurement := createTestMeasurement()
-	measurement.Attributes["unit"] = "kWh"
+	measurement.Attributes["unit"] = "transaction"
 
 	req := client.buildRecordMeasurementRequest(measurement)
 
-	assert.Equal(t, "kWh", req.Unit)
+	// Unit uses instrument dimension
+	assert.Equal(t, "COUNT", req.Unit)
+	// Instrument metadata reflects TRANSACTION instrument
+	assert.Equal(t, "TRANSACTION", req.Metadata["instrument_code"])
+	assert.Equal(t, "1", req.Metadata["instrument_version"])
+	assert.Equal(t, "COUNT", req.Metadata["instrument_dimension"])
+	assert.Equal(t, "0", req.Metadata["instrument_precision"])
+}
+
+func TestPositionKeepingGRPCClient_buildRecordMeasurementRequest_StorageUnit(t *testing.T) {
+	client := &PositionKeepingGRPCClient{}
+	measurement := createTestMeasurement()
+	measurement.Attributes["unit"] = "storage_gb_hour"
+
+	req := client.buildRecordMeasurementRequest(measurement)
+
+	// Unit uses instrument dimension
+	assert.Equal(t, "DATA", req.Unit)
+	// Instrument metadata reflects STORAGE_GB_HOUR instrument
+	assert.Equal(t, "STORAGE_GB_HOUR", req.Metadata["instrument_code"])
+	assert.Equal(t, "1", req.Metadata["instrument_version"])
+	assert.Equal(t, "DATA", req.Metadata["instrument_dimension"])
+	assert.Equal(t, "6", req.Metadata["instrument_precision"])
+}
+
+func TestPositionKeepingGRPCClient_buildRecordMeasurementRequest_ComputeUnit(t *testing.T) {
+	client := &PositionKeepingGRPCClient{}
+	measurement := createTestMeasurement()
+	measurement.Attributes["unit"] = "compute_hour"
+
+	req := client.buildRecordMeasurementRequest(measurement)
+
+	// Unit uses instrument dimension
+	assert.Equal(t, "COMPUTE", req.Unit)
+	// Instrument metadata reflects COMPUTE_HOUR instrument
+	assert.Equal(t, "COMPUTE_HOUR", req.Metadata["instrument_code"])
+	assert.Equal(t, "1", req.Metadata["instrument_version"])
+	assert.Equal(t, "COMPUTE", req.Metadata["instrument_dimension"])
+	assert.Equal(t, "6", req.Metadata["instrument_precision"])
+}
+
+func TestPositionKeepingGRPCClient_buildRecordMeasurementRequest_UnknownUnit(t *testing.T) {
+	client := &PositionKeepingGRPCClient{}
+	measurement := createTestMeasurement()
+	measurement.Attributes["unit"] = "unknown_type"
+
+	req := client.buildRecordMeasurementRequest(measurement)
+
+	// Unknown unit types default to OPERATION instrument
+	assert.Equal(t, "COUNT", req.Unit)
+	assert.Equal(t, "OPERATION", req.Metadata["instrument_code"])
 }
 
 func TestNewPositionKeepingClient_ValidationErrors(t *testing.T) {

--- a/services/utilization-metering-consumer/domain/instruments.go
+++ b/services/utilization-metering-consumer/domain/instruments.go
@@ -12,7 +12,7 @@
 package domain
 
 import (
-	"sort"
+	"strings"
 
 	"github.com/meridianhub/meridian/pkg/platform/quantity"
 )
@@ -75,7 +75,7 @@ func mustInstrument(code string, version uint32, dimension string, precision int
 // InstrumentForMeasurementType returns the appropriate instrument for a given unit of measure.
 // This maps legacy string-based unit types to typed instruments.
 //
-// Supported measurement types (case-sensitive, lowercase expected):
+// Supported measurement types (case-insensitive):
 //   - "transaction" -> InstrumentTransaction
 //   - "api_call" -> InstrumentAPICall
 //   - "operation" -> InstrumentOperation
@@ -83,9 +83,8 @@ func mustInstrument(code string, version uint32, dimension string, precision int
 //   - "compute_hour" -> InstrumentComputeHour
 //
 // If the measurement type is not recognized, InstrumentOperation is returned as a fallback.
-// Note: The mapping is case-sensitive - use lowercase measurement type strings.
 func InstrumentForMeasurementType(unitOfMeasure string) quantity.Instrument {
-	if inst, ok := instrumentsByMeasurementType[unitOfMeasure]; ok {
+	if inst, ok := instrumentsByMeasurementType[strings.ToLower(unitOfMeasure)]; ok {
 		return inst
 	}
 	// Default to generic operation for unknown types
@@ -104,14 +103,21 @@ func AllInstruments() []quantity.Instrument {
 	}
 }
 
+// supportedMeasurementTypes is a cached, sorted list of measurement type strings.
+// Initialized once at package load to avoid repeated allocation and sorting.
+var supportedMeasurementTypes = []string{
+	"api_call",
+	"compute_hour",
+	"operation",
+	"storage_gb_hour",
+	"transaction",
+}
+
 // SupportedMeasurementTypes returns all supported measurement type strings in sorted order.
 // These are the valid values for the unitOfMeasure parameter in InstrumentForMeasurementType.
-// The slice is sorted alphabetically for deterministic output in documentation and logging.
+// Returns a copy to prevent caller modification of the cached slice.
 func SupportedMeasurementTypes() []string {
-	types := make([]string, 0, len(instrumentsByMeasurementType))
-	for t := range instrumentsByMeasurementType {
-		types = append(types, t)
-	}
-	sort.Strings(types)
-	return types
+	result := make([]string, len(supportedMeasurementTypes))
+	copy(result, supportedMeasurementTypes)
+	return result
 }

--- a/services/utilization-metering-consumer/domain/instruments.go
+++ b/services/utilization-metering-consumer/domain/instruments.go
@@ -1,0 +1,112 @@
+// Package domain contains the core domain models for utilization metering.
+//
+// # System Tenant Instruments
+//
+// This file defines the standard instruments used for utilization metering across
+// the Meridian platform. These instruments represent the "Commodity dimension" of
+// the Universal Asset System - they track non-monetary quantities like transaction
+// counts, API calls, storage usage, and compute time.
+//
+// All utilization instruments use version 1 and are designed for billing purposes
+// in the system tenant (tenant-zero).
+package domain
+
+import (
+	"github.com/meridianhub/meridian/pkg/platform/quantity"
+)
+
+// System tenant instrument definitions for utilization metering.
+// These instruments are used to track usage quantities for billing.
+//
+// Instrument naming conventions:
+//   - COUNT dimension: whole units, precision 0 (TRANSACTION, API_CALL, OPERATION)
+//   - DATA dimension: fractional units for storage, precision 6 (STORAGE_GB_HOUR)
+//   - COMPUTE dimension: fractional units for compute time, precision 6 (COMPUTE_HOUR)
+var (
+	// InstrumentTransaction is used for counting billable transactions.
+	// Examples: account creation, payment processing, balance updates.
+	// Dimension: COUNT, Precision: 0 (whole transactions only)
+	InstrumentTransaction = mustInstrument("TRANSACTION", 1, "COUNT", 0)
+
+	// InstrumentAPICall is used for counting API calls.
+	// Examples: REST/gRPC requests to Meridian services.
+	// Dimension: COUNT, Precision: 0 (whole API calls only)
+	InstrumentAPICall = mustInstrument("API_CALL", 1, "COUNT", 0)
+
+	// InstrumentOperation is used for counting generic operations.
+	// This is the fallback instrument for operations that don't have a specific type.
+	// Dimension: COUNT, Precision: 0 (whole operations only)
+	InstrumentOperation = mustInstrument("OPERATION", 1, "COUNT", 0)
+
+	// InstrumentStorageGBHour is used for storage usage billing.
+	// Represents gigabyte-hours of storage consumption.
+	// Dimension: DATA, Precision: 6 (supports fractional GB-hours)
+	InstrumentStorageGBHour = mustInstrument("STORAGE_GB_HOUR", 1, "DATA", 6)
+
+	// InstrumentComputeHour is used for compute resource billing.
+	// Represents hours of compute resource usage (CPU, GPU, etc.).
+	// Dimension: COMPUTE, Precision: 6 (supports fractional hours)
+	InstrumentComputeHour = mustInstrument("COMPUTE_HOUR", 1, "COMPUTE", 6)
+)
+
+// instrumentsByMeasurementType maps string-based unit types to their corresponding instruments.
+// This supports backward compatibility with legacy string-based unit specifications.
+var instrumentsByMeasurementType = map[string]quantity.Instrument{
+	"transaction":     InstrumentTransaction,
+	"api_call":        InstrumentAPICall,
+	"operation":       InstrumentOperation,
+	"storage_gb_hour": InstrumentStorageGBHour,
+	"compute_hour":    InstrumentComputeHour,
+}
+
+// mustInstrument creates an instrument, panicking on error.
+// This is safe because all instrument definitions are compile-time constants
+// and errors would indicate programming bugs that should be caught immediately.
+func mustInstrument(code string, version uint32, dimension string, precision int) quantity.Instrument {
+	inst, err := quantity.NewInstrument(code, version, dimension, precision)
+	if err != nil {
+		panic("invalid instrument definition: " + err.Error())
+	}
+	return inst
+}
+
+// InstrumentForMeasurementType returns the appropriate instrument for a given unit of measure.
+// This maps legacy string-based unit types to typed instruments.
+//
+// Supported measurement types:
+//   - "transaction" -> InstrumentTransaction
+//   - "api_call" -> InstrumentAPICall
+//   - "operation" -> InstrumentOperation
+//   - "storage_gb_hour" -> InstrumentStorageGBHour
+//   - "compute_hour" -> InstrumentComputeHour
+//
+// If the measurement type is not recognized, InstrumentOperation is returned as a fallback.
+func InstrumentForMeasurementType(unitOfMeasure string) quantity.Instrument {
+	if inst, ok := instrumentsByMeasurementType[unitOfMeasure]; ok {
+		return inst
+	}
+	// Default to generic operation for unknown types
+	return InstrumentOperation
+}
+
+// AllInstruments returns all defined utilization instruments.
+// Useful for initialization, validation, or reporting purposes.
+func AllInstruments() []quantity.Instrument {
+	return []quantity.Instrument{
+		InstrumentTransaction,
+		InstrumentAPICall,
+		InstrumentOperation,
+		InstrumentStorageGBHour,
+		InstrumentComputeHour,
+	}
+}
+
+// SupportedMeasurementTypes returns all supported measurement type strings.
+// These are the valid values for the unitOfMeasure parameter in InstrumentForMeasurementType.
+func SupportedMeasurementTypes() []string {
+	types := make([]string, 0, len(instrumentsByMeasurementType))
+	for t := range instrumentsByMeasurementType {
+		types = append(types, t)
+	}
+	return types
+}

--- a/services/utilization-metering-consumer/domain/instruments.go
+++ b/services/utilization-metering-consumer/domain/instruments.go
@@ -12,6 +12,8 @@
 package domain
 
 import (
+	"sort"
+
 	"github.com/meridianhub/meridian/pkg/platform/quantity"
 )
 
@@ -73,7 +75,7 @@ func mustInstrument(code string, version uint32, dimension string, precision int
 // InstrumentForMeasurementType returns the appropriate instrument for a given unit of measure.
 // This maps legacy string-based unit types to typed instruments.
 //
-// Supported measurement types:
+// Supported measurement types (case-sensitive, lowercase expected):
 //   - "transaction" -> InstrumentTransaction
 //   - "api_call" -> InstrumentAPICall
 //   - "operation" -> InstrumentOperation
@@ -81,6 +83,7 @@ func mustInstrument(code string, version uint32, dimension string, precision int
 //   - "compute_hour" -> InstrumentComputeHour
 //
 // If the measurement type is not recognized, InstrumentOperation is returned as a fallback.
+// Note: The mapping is case-sensitive - use lowercase measurement type strings.
 func InstrumentForMeasurementType(unitOfMeasure string) quantity.Instrument {
 	if inst, ok := instrumentsByMeasurementType[unitOfMeasure]; ok {
 		return inst
@@ -101,12 +104,14 @@ func AllInstruments() []quantity.Instrument {
 	}
 }
 
-// SupportedMeasurementTypes returns all supported measurement type strings.
+// SupportedMeasurementTypes returns all supported measurement type strings in sorted order.
 // These are the valid values for the unitOfMeasure parameter in InstrumentForMeasurementType.
+// The slice is sorted alphabetically for deterministic output in documentation and logging.
 func SupportedMeasurementTypes() []string {
 	types := make([]string, 0, len(instrumentsByMeasurementType))
 	for t := range instrumentsByMeasurementType {
 		types = append(types, t)
 	}
+	sort.Strings(types)
 	return types
 }

--- a/services/utilization-metering-consumer/domain/instruments_test.go
+++ b/services/utilization-metering-consumer/domain/instruments_test.go
@@ -139,8 +139,6 @@ func TestInstrumentForMeasurementType_UnknownTypes_FallbackToOperation(t *testin
 		"unknown",
 		"custom_metric",
 		"",
-		"TRANSACTION", // uppercase should not match (case-sensitive)
-		"Transaction",
 		"api-call", // wrong separator
 	}
 
@@ -150,6 +148,29 @@ func TestInstrumentForMeasurementType_UnknownTypes_FallbackToOperation(t *testin
 			// Should fallback to InstrumentOperation
 			assert.Equal(t, "OPERATION", inst.Code)
 			assert.Equal(t, InstrumentOperation, inst)
+		})
+	}
+}
+
+func TestInstrumentForMeasurementType_CaseInsensitive(t *testing.T) {
+	// Mapping should be case-insensitive for convenience
+	tests := []struct {
+		input    string
+		expected quantity.Instrument
+	}{
+		{"transaction", InstrumentTransaction},
+		{"TRANSACTION", InstrumentTransaction},
+		{"Transaction", InstrumentTransaction},
+		{"API_CALL", InstrumentAPICall},
+		{"Api_Call", InstrumentAPICall},
+		{"STORAGE_GB_HOUR", InstrumentStorageGBHour},
+		{"Compute_Hour", InstrumentComputeHour},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			inst := InstrumentForMeasurementType(tt.input)
+			assert.Equal(t, tt.expected, inst)
 		})
 	}
 }

--- a/services/utilization-metering-consumer/domain/instruments_test.go
+++ b/services/utilization-metering-consumer/domain/instruments_test.go
@@ -1,0 +1,253 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/pkg/platform/quantity"
+)
+
+func TestInstrumentTransaction_Valid(t *testing.T) {
+	inst := InstrumentTransaction
+
+	assert.Equal(t, "TRANSACTION", inst.Code)
+	assert.Equal(t, uint32(1), inst.Version)
+	assert.Equal(t, "COUNT", inst.Dimension)
+	assert.Equal(t, 0, inst.Precision)
+
+	// Validate the instrument
+	err := inst.Validate()
+	require.NoError(t, err)
+
+	// Should be a commodity, not monetary
+	assert.True(t, inst.IsCommodity())
+	assert.False(t, inst.IsMonetary())
+}
+
+func TestInstrumentAPICall_Valid(t *testing.T) {
+	inst := InstrumentAPICall
+
+	assert.Equal(t, "API_CALL", inst.Code)
+	assert.Equal(t, uint32(1), inst.Version)
+	assert.Equal(t, "COUNT", inst.Dimension)
+	assert.Equal(t, 0, inst.Precision)
+
+	err := inst.Validate()
+	require.NoError(t, err)
+
+	assert.True(t, inst.IsCommodity())
+	assert.False(t, inst.IsMonetary())
+}
+
+func TestInstrumentOperation_Valid(t *testing.T) {
+	inst := InstrumentOperation
+
+	assert.Equal(t, "OPERATION", inst.Code)
+	assert.Equal(t, uint32(1), inst.Version)
+	assert.Equal(t, "COUNT", inst.Dimension)
+	assert.Equal(t, 0, inst.Precision)
+
+	err := inst.Validate()
+	require.NoError(t, err)
+
+	assert.True(t, inst.IsCommodity())
+	assert.False(t, inst.IsMonetary())
+}
+
+func TestInstrumentStorageGBHour_Valid(t *testing.T) {
+	inst := InstrumentStorageGBHour
+
+	assert.Equal(t, "STORAGE_GB_HOUR", inst.Code)
+	assert.Equal(t, uint32(1), inst.Version)
+	assert.Equal(t, "DATA", inst.Dimension)
+	assert.Equal(t, 6, inst.Precision)
+
+	err := inst.Validate()
+	require.NoError(t, err)
+
+	assert.True(t, inst.IsCommodity())
+	assert.False(t, inst.IsMonetary())
+}
+
+func TestInstrumentComputeHour_Valid(t *testing.T) {
+	inst := InstrumentComputeHour
+
+	assert.Equal(t, "COMPUTE_HOUR", inst.Code)
+	assert.Equal(t, uint32(1), inst.Version)
+	assert.Equal(t, "COMPUTE", inst.Dimension)
+	assert.Equal(t, 6, inst.Precision)
+
+	err := inst.Validate()
+	require.NoError(t, err)
+
+	assert.True(t, inst.IsCommodity())
+	assert.False(t, inst.IsMonetary())
+}
+
+func TestAllInstruments_Valid(t *testing.T) {
+	instruments := AllInstruments()
+
+	// Should return all 5 defined instruments
+	assert.Len(t, instruments, 5)
+
+	// Each instrument should be valid
+	for _, inst := range instruments {
+		err := inst.Validate()
+		require.NoError(t, err, "instrument %s should be valid", inst.Code)
+
+		// All utilization instruments are commodities
+		assert.True(t, inst.IsCommodity(), "instrument %s should be a commodity", inst.Code)
+		assert.False(t, inst.IsMonetary(), "instrument %s should not be monetary", inst.Code)
+	}
+
+	// Verify all expected instruments are present
+	codes := make(map[string]bool)
+	for _, inst := range instruments {
+		codes[inst.Code] = true
+	}
+	assert.True(t, codes["TRANSACTION"])
+	assert.True(t, codes["API_CALL"])
+	assert.True(t, codes["OPERATION"])
+	assert.True(t, codes["STORAGE_GB_HOUR"])
+	assert.True(t, codes["COMPUTE_HOUR"])
+}
+
+func TestInstrumentForMeasurementType_KnownTypes(t *testing.T) {
+	tests := []struct {
+		measurementType string
+		expectedCode    string
+	}{
+		{"transaction", "TRANSACTION"},
+		{"api_call", "API_CALL"},
+		{"operation", "OPERATION"},
+		{"storage_gb_hour", "STORAGE_GB_HOUR"},
+		{"compute_hour", "COMPUTE_HOUR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.measurementType, func(t *testing.T) {
+			inst := InstrumentForMeasurementType(tt.measurementType)
+			assert.Equal(t, tt.expectedCode, inst.Code)
+		})
+	}
+}
+
+func TestInstrumentForMeasurementType_UnknownTypes_FallbackToOperation(t *testing.T) {
+	unknownTypes := []string{
+		"unknown",
+		"custom_metric",
+		"",
+		"TRANSACTION", // uppercase should not match (case-sensitive)
+		"Transaction",
+		"api-call", // wrong separator
+	}
+
+	for _, unknownType := range unknownTypes {
+		t.Run(unknownType, func(t *testing.T) {
+			inst := InstrumentForMeasurementType(unknownType)
+			// Should fallback to InstrumentOperation
+			assert.Equal(t, "OPERATION", inst.Code)
+			assert.Equal(t, InstrumentOperation, inst)
+		})
+	}
+}
+
+func TestSupportedMeasurementTypes(t *testing.T) {
+	types := SupportedMeasurementTypes()
+
+	// Should return all 5 supported types
+	assert.Len(t, types, 5)
+
+	// Convert to map for easy checking
+	typeMap := make(map[string]bool)
+	for _, typ := range types {
+		typeMap[typ] = true
+	}
+
+	assert.True(t, typeMap["transaction"])
+	assert.True(t, typeMap["api_call"])
+	assert.True(t, typeMap["operation"])
+	assert.True(t, typeMap["storage_gb_hour"])
+	assert.True(t, typeMap["compute_hour"])
+}
+
+func TestInstrumentForMeasurementType_ReturnsEqualInstrument(t *testing.T) {
+	// Verify that the returned instruments are equal to the defined constants
+	assert.Equal(t, InstrumentTransaction, InstrumentForMeasurementType("transaction"))
+	assert.Equal(t, InstrumentAPICall, InstrumentForMeasurementType("api_call"))
+	assert.Equal(t, InstrumentOperation, InstrumentForMeasurementType("operation"))
+	assert.Equal(t, InstrumentStorageGBHour, InstrumentForMeasurementType("storage_gb_hour"))
+	assert.Equal(t, InstrumentComputeHour, InstrumentForMeasurementType("compute_hour"))
+}
+
+func TestInstruments_UsableInQuantityOperations(t *testing.T) {
+	// Verify that instruments can be used to create quantities
+	txnQty := quantity.NewAssetFromInt(100, InstrumentTransaction)
+	assert.Equal(t, "100 TRANSACTION", txnQty.String())
+
+	apiQty := quantity.NewAssetFromInt(500, InstrumentAPICall)
+	assert.Equal(t, "500 API_CALL", apiQty.String())
+
+	// Storage with precision 6
+	storageQty := quantity.NewAssetFromInt(25, InstrumentStorageGBHour)
+	assert.Equal(t, "25.000000 STORAGE_GB_HOUR", storageQty.String())
+
+	// Compute with precision 6
+	computeQty := quantity.NewAssetFromInt(8, InstrumentComputeHour)
+	assert.Equal(t, "8.000000 COMPUTE_HOUR", computeQty.String())
+}
+
+func TestInstruments_SameInstrumentAddition(t *testing.T) {
+	// Quantities with same instrument can be added
+	qty1 := quantity.NewAssetFromInt(100, InstrumentTransaction)
+	qty2 := quantity.NewAssetFromInt(50, InstrumentTransaction)
+
+	result, err := qty1.Add(qty2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(150), result.Amount.IntPart())
+}
+
+func TestInstruments_DifferentInstrumentsCannotBeAdded(t *testing.T) {
+	// Quantities with different instruments cannot be added
+	txnQty := quantity.NewAssetFromInt(100, InstrumentTransaction)
+	apiQty := quantity.NewAssetFromInt(50, InstrumentAPICall)
+
+	_, err := txnQty.Add(apiQty)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, quantity.ErrInstrumentMismatch)
+}
+
+func TestInstruments_CountDimensionHasZeroPrecision(t *testing.T) {
+	// COUNT dimension instruments should have precision 0 (whole units only)
+	countInstruments := []quantity.Instrument{
+		InstrumentTransaction,
+		InstrumentAPICall,
+		InstrumentOperation,
+	}
+
+	for _, inst := range countInstruments {
+		assert.Equal(t, 0, inst.Precision, "COUNT dimension instrument %s should have precision 0", inst.Code)
+		assert.Equal(t, "COUNT", inst.Dimension)
+	}
+}
+
+func TestInstruments_FractionalDimensionsHaveHigherPrecision(t *testing.T) {
+	// DATA and COMPUTE dimensions should have precision 6 for fractional values
+	fractionalInstruments := []quantity.Instrument{
+		InstrumentStorageGBHour,
+		InstrumentComputeHour,
+	}
+
+	for _, inst := range fractionalInstruments {
+		assert.Equal(t, 6, inst.Precision, "fractional instrument %s should have precision 6", inst.Code)
+	}
+}
+
+func TestInstruments_Version(t *testing.T) {
+	// All instruments should use version 1
+	for _, inst := range AllInstruments() {
+		assert.Equal(t, uint32(1), inst.Version, "instrument %s should have version 1", inst.Code)
+	}
+}

--- a/services/utilization-metering-consumer/domain/measurement.go
+++ b/services/utilization-metering-consumer/domain/measurement.go
@@ -1,7 +1,11 @@
 // Package domain contains the core domain models for utilization metering.
 package domain
 
-import "time"
+import (
+	"time"
+
+	"github.com/meridianhub/meridian/pkg/platform/quantity"
+)
 
 // UtilizationMeasurement represents a single utilization measurement derived from an audit event.
 // This will be sent to Position Keeping service as a position change for tenant-zero billing.
@@ -16,13 +20,10 @@ type UtilizationMeasurement struct {
 	// OperationType is the operation that was performed (e.g., "CreateAccount", "ProcessPayment")
 	OperationType string
 
-	// Quantity is the measured quantity for billing purposes
-	// Examples: 1 (for transaction count), bytes processed, API calls made
-	Quantity int64
-
-	// UnitOfMeasure describes what is being measured
-	// Examples: "transaction", "api_call", "storage_gb"
-	UnitOfMeasure string
+	// Amount is the measured quantity for billing purposes using the Universal Asset System.
+	// The instrument identifies what is being measured (TRANSACTION, API_CALL, STORAGE_GB, etc.)
+	// Examples: 1 TRANSACTION, 5 API_CALL, 100 STORAGE_GB
+	Amount quantity.Asset
 
 	// Timestamp is when the utilization occurred
 	Timestamp time.Time

--- a/services/utilization-metering-consumer/domain/measurement_test.go
+++ b/services/utilization-metering-consumer/domain/measurement_test.go
@@ -10,16 +10,14 @@ import (
 	"github.com/meridianhub/meridian/pkg/platform/quantity"
 )
 
-// Test instruments mirror the production instruments from instruments.go.
-// These are defined separately to avoid import cycles and to test instrument creation.
-// See instruments.go for production instrument definitions.
+// Tests use production instruments from instruments.go directly to ensure they stay in sync.
+// Aliases for readability in tests.
 var (
-	transactionInstrument, _ = quantity.NewInstrument("TRANSACTION", 1, "COUNT", 0)
-	apiCallInstrument, _     = quantity.NewInstrument("API_CALL", 1, "COUNT", 0)
-	operationInstrument, _   = quantity.NewInstrument("OPERATION", 1, "COUNT", 0)
-	// Note: precision matches production instruments (6 for fractional units)
-	storageGBInstrument, _   = quantity.NewInstrument("STORAGE_GB_HOUR", 1, "DATA", 6)
-	computeHourInstrument, _ = quantity.NewInstrument("COMPUTE_HOUR", 1, "COMPUTE", 6)
+	transactionInstrument = InstrumentTransaction
+	apiCallInstrument     = InstrumentAPICall
+	operationInstrument   = InstrumentOperation
+	storageGBInstrument   = InstrumentStorageGBHour
+	computeHourInstrument = InstrumentComputeHour
 )
 
 func TestUtilizationMeasurement_Creation(t *testing.T) {

--- a/services/utilization-metering-consumer/domain/measurement_test.go
+++ b/services/utilization-metering-consumer/domain/measurement_test.go
@@ -5,6 +5,18 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/pkg/platform/quantity"
+)
+
+// Test instruments for utilization metering - all use COUNT dimension with precision 0.
+var (
+	transactionInstrument, _ = quantity.NewInstrument("TRANSACTION", 1, "COUNT", 0)
+	apiCallInstrument, _     = quantity.NewInstrument("API_CALL", 1, "COUNT", 0)
+	operationInstrument, _   = quantity.NewInstrument("OPERATION", 1, "COUNT", 0)
+	storageGBInstrument, _   = quantity.NewInstrument("STORAGE_GB", 1, "DATA", 2)
+	computeHourInstrument, _ = quantity.NewInstrument("COMPUTE_HOUR", 1, "COMPUTE", 4)
 )
 
 func TestUtilizationMeasurement_Creation(t *testing.T) {
@@ -14,8 +26,7 @@ func TestUtilizationMeasurement_Creation(t *testing.T) {
 		TenantID:      "tenant-123",
 		ServiceName:   "current-account",
 		OperationType: "CreateAccount",
-		Quantity:      1,
-		UnitOfMeasure: "transaction",
+		Amount:        quantity.NewAssetFromInt(1, transactionInstrument),
 		Timestamp:     now,
 		CorrelationID: "corr-456",
 	}
@@ -23,32 +34,32 @@ func TestUtilizationMeasurement_Creation(t *testing.T) {
 	assert.Equal(t, "tenant-123", measurement.TenantID)
 	assert.Equal(t, "current-account", measurement.ServiceName)
 	assert.Equal(t, "CreateAccount", measurement.OperationType)
-	assert.Equal(t, int64(1), measurement.Quantity)
-	assert.Equal(t, "transaction", measurement.UnitOfMeasure)
+	assert.Equal(t, int64(1), measurement.Amount.Amount.IntPart())
+	assert.Equal(t, "TRANSACTION", measurement.Amount.Instrument.Code)
 	assert.Equal(t, now, measurement.Timestamp)
 	assert.Equal(t, "corr-456", measurement.CorrelationID)
 }
 
 func TestUtilizationMeasurement_DifferentQuantities(t *testing.T) {
 	tests := []struct {
-		name     string
-		quantity int64
+		name   string
+		amount int64
 	}{
 		{
-			name:     "single transaction",
-			quantity: 1,
+			name:   "single transaction",
+			amount: 1,
 		},
 		{
-			name:     "batch of 10 operations",
-			quantity: 10,
+			name:   "batch of 10 operations",
+			amount: 10,
 		},
 		{
-			name:     "large batch",
-			quantity: 1000,
+			name:   "large batch",
+			amount: 1000,
 		},
 		{
-			name:     "zero quantity (edge case)",
-			quantity: 0,
+			name:   "zero quantity (edge case)",
+			amount: 0,
 		},
 	}
 
@@ -58,53 +69,52 @@ func TestUtilizationMeasurement_DifferentQuantities(t *testing.T) {
 				TenantID:      "tenant-test",
 				ServiceName:   "test-service",
 				OperationType: "TestOperation",
-				Quantity:      tt.quantity,
-				UnitOfMeasure: "operation",
+				Amount:        quantity.NewAssetFromInt(tt.amount, operationInstrument),
 				Timestamp:     time.Now(),
 				CorrelationID: "test-corr",
 			}
 
-			assert.Equal(t, tt.quantity, measurement.Quantity)
+			assert.Equal(t, tt.amount, measurement.Amount.Amount.IntPart())
 		})
 	}
 }
 
-func TestUtilizationMeasurement_DifferentUnitsOfMeasure(t *testing.T) {
+func TestUtilizationMeasurement_DifferentInstrumentTypes(t *testing.T) {
 	tests := []struct {
-		name          string
-		unitOfMeasure string
-		quantity      int64
-		description   string
+		name        string
+		instrument  quantity.Instrument
+		amount      int64
+		description string
 	}{
 		{
-			name:          "transaction count",
-			unitOfMeasure: "transaction",
-			quantity:      1,
-			description:   "Single transaction",
+			name:        "transaction count",
+			instrument:  transactionInstrument,
+			amount:      1,
+			description: "Single transaction",
 		},
 		{
-			name:          "API call count",
-			unitOfMeasure: "api_call",
-			quantity:      5,
-			description:   "Multiple API calls",
+			name:        "API call count",
+			instrument:  apiCallInstrument,
+			amount:      5,
+			description: "Multiple API calls",
 		},
 		{
-			name:          "storage in gigabytes",
-			unitOfMeasure: "storage_gb",
-			quantity:      100,
-			description:   "Storage usage",
+			name:        "storage in gigabytes",
+			instrument:  storageGBInstrument,
+			amount:      100,
+			description: "Storage usage",
 		},
 		{
-			name:          "compute hours",
-			unitOfMeasure: "compute_hours",
-			quantity:      24,
-			description:   "Compute resource usage",
+			name:        "compute hours",
+			instrument:  computeHourInstrument,
+			amount:      24,
+			description: "Compute resource usage",
 		},
 		{
-			name:          "operation count",
-			unitOfMeasure: "operation",
-			quantity:      1,
-			description:   "Generic operation",
+			name:        "operation count",
+			instrument:  operationInstrument,
+			amount:      1,
+			description: "Generic operation",
 		},
 	}
 
@@ -114,14 +124,13 @@ func TestUtilizationMeasurement_DifferentUnitsOfMeasure(t *testing.T) {
 				TenantID:      "tenant-test",
 				ServiceName:   "test-service",
 				OperationType: "TestOperation",
-				Quantity:      tt.quantity,
-				UnitOfMeasure: tt.unitOfMeasure,
+				Amount:        quantity.NewAssetFromInt(tt.amount, tt.instrument),
 				Timestamp:     time.Now(),
 				CorrelationID: "test-corr",
 			}
 
-			assert.Equal(t, tt.unitOfMeasure, measurement.UnitOfMeasure)
-			assert.Equal(t, tt.quantity, measurement.Quantity)
+			assert.Equal(t, tt.instrument.Code, measurement.Amount.Instrument.Code)
+			assert.Equal(t, tt.amount, measurement.Amount.Amount.IntPart())
 		})
 	}
 }
@@ -142,8 +151,7 @@ func TestUtilizationMeasurement_AllServiceTypes(t *testing.T) {
 				TenantID:      "tenant-test",
 				ServiceName:   service,
 				OperationType: "TestOperation",
-				Quantity:      1,
-				UnitOfMeasure: "operation",
+				Amount:        quantity.NewAssetFromInt(1, operationInstrument),
 				Timestamp:     time.Now(),
 				CorrelationID: "test-corr",
 			}
@@ -186,8 +194,7 @@ func TestUtilizationMeasurement_OperationTypes(t *testing.T) {
 				TenantID:      "tenant-test",
 				ServiceName:   "test-service",
 				OperationType: tt.operationType,
-				Quantity:      1,
-				UnitOfMeasure: "operation",
+				Amount:        quantity.NewAssetFromInt(1, operationInstrument),
 				Timestamp:     time.Now(),
 				CorrelationID: "test-corr",
 			}
@@ -230,8 +237,7 @@ func TestUtilizationMeasurement_TenantIDs(t *testing.T) {
 				TenantID:      tt.tenantID,
 				ServiceName:   "test-service",
 				OperationType: "TestOperation",
-				Quantity:      1,
-				UnitOfMeasure: "operation",
+				Amount:        quantity.NewAssetFromInt(1, operationInstrument),
 				Timestamp:     time.Now(),
 				CorrelationID: "test-corr",
 			}
@@ -248,8 +254,7 @@ func TestUtilizationMeasurement_TimestampPrecision(t *testing.T) {
 		TenantID:      "tenant-test",
 		ServiceName:   "test-service",
 		OperationType: "TestOperation",
-		Quantity:      1,
-		UnitOfMeasure: "operation",
+		Amount:        quantity.NewAssetFromInt(1, operationInstrument),
 		Timestamp:     now,
 		CorrelationID: "test-corr",
 	}
@@ -259,6 +264,22 @@ func TestUtilizationMeasurement_TimestampPrecision(t *testing.T) {
 	assert.Equal(t, now.UnixNano(), measurement.Timestamp.UnixNano())
 }
 
+func TestUtilizationMeasurement_ZeroValueAmount(t *testing.T) {
+	// Test that measurements can be created with zero-valued quantity
+	// This might happen during testing or edge cases
+	measurement := &UtilizationMeasurement{
+		TenantID:      "tenant-test",
+		ServiceName:   "test-service",
+		OperationType: "TestOperation",
+		Amount:        quantity.ZeroAsset(operationInstrument),
+		Timestamp:     time.Now(),
+		CorrelationID: "test-corr",
+	}
+
+	assert.True(t, measurement.Amount.IsZero())
+	assert.Equal(t, "OPERATION", measurement.Amount.Instrument.Code)
+}
+
 func TestUtilizationMeasurement_EmptyFields(t *testing.T) {
 	// Test that measurements can be created with empty/zero values
 	// This might happen during testing or error scenarios
@@ -266,8 +287,7 @@ func TestUtilizationMeasurement_EmptyFields(t *testing.T) {
 		TenantID:      "",
 		ServiceName:   "",
 		OperationType: "",
-		Quantity:      0,
-		UnitOfMeasure: "",
+		Amount:        quantity.Asset{}, // zero-value Asset
 		Timestamp:     time.Time{},
 		CorrelationID: "",
 	}
@@ -275,8 +295,7 @@ func TestUtilizationMeasurement_EmptyFields(t *testing.T) {
 	assert.Equal(t, "", measurement.TenantID)
 	assert.Equal(t, "", measurement.ServiceName)
 	assert.Equal(t, "", measurement.OperationType)
-	assert.Equal(t, int64(0), measurement.Quantity)
-	assert.Equal(t, "", measurement.UnitOfMeasure)
+	assert.True(t, measurement.Amount.IsZero())
 	assert.True(t, measurement.Timestamp.IsZero())
 	assert.Equal(t, "", measurement.CorrelationID)
 }
@@ -310,8 +329,7 @@ func TestUtilizationMeasurement_CorrelationIDFormats(t *testing.T) {
 				TenantID:      "tenant-test",
 				ServiceName:   "test-service",
 				OperationType: "TestOperation",
-				Quantity:      1,
-				UnitOfMeasure: "operation",
+				Amount:        quantity.NewAssetFromInt(1, operationInstrument),
 				Timestamp:     time.Now(),
 				CorrelationID: tt.correlationID,
 			}
@@ -319,4 +337,75 @@ func TestUtilizationMeasurement_CorrelationIDFormats(t *testing.T) {
 			assert.Equal(t, tt.correlationID, measurement.CorrelationID)
 		})
 	}
+}
+
+// =============================================================================
+// Quantity operations tests - verifying the Universal Asset System integration
+// =============================================================================
+
+func TestUtilizationMeasurement_QuantityOperations_Addition(t *testing.T) {
+	// Test that quantities from the same instrument can be added
+	amount1 := quantity.NewAssetFromInt(5, transactionInstrument)
+	amount2 := quantity.NewAssetFromInt(3, transactionInstrument)
+
+	result, err := amount1.Add(amount2)
+	require.NoError(t, err)
+	assert.Equal(t, int64(8), result.Amount.IntPart())
+	assert.Equal(t, "TRANSACTION", result.Instrument.Code)
+}
+
+func TestUtilizationMeasurement_QuantityOperations_Comparison(t *testing.T) {
+	// Test that quantities from the same instrument can be compared
+	amount1 := quantity.NewAssetFromInt(5, transactionInstrument)
+	amount2 := quantity.NewAssetFromInt(10, transactionInstrument)
+
+	cmp, err := amount1.Compare(amount2)
+	require.NoError(t, err)
+	assert.Equal(t, -1, cmp) // amount1 < amount2
+
+	lt, err := amount1.LessThan(amount2)
+	require.NoError(t, err)
+	assert.True(t, lt)
+}
+
+func TestUtilizationMeasurement_QuantityOperations_DifferentInstrumentsFail(t *testing.T) {
+	// Test that quantities from different instruments cannot be combined
+	transactionAmount := quantity.NewAssetFromInt(5, transactionInstrument)
+	apiCallAmount := quantity.NewAssetFromInt(3, apiCallInstrument)
+
+	_, err := transactionAmount.Add(apiCallAmount)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, quantity.ErrInstrumentMismatch)
+}
+
+func TestUtilizationMeasurement_QuantityString(t *testing.T) {
+	// Test the string representation of utilization quantities
+	amount := quantity.NewAssetFromInt(42, transactionInstrument)
+	assert.Equal(t, "42 TRANSACTION", amount.String())
+
+	storageAmount := quantity.NewAssetFromInt(100, storageGBInstrument)
+	assert.Equal(t, "100.00 STORAGE_GB", storageAmount.String())
+}
+
+func TestUtilizationMeasurement_InstrumentDimension(t *testing.T) {
+	// Verify the instrument dimension is correctly set for utilization types
+	assert.Equal(t, "COUNT", transactionInstrument.Dimension)
+	assert.Equal(t, "COUNT", apiCallInstrument.Dimension)
+	assert.Equal(t, "COUNT", operationInstrument.Dimension)
+	assert.Equal(t, "DATA", storageGBInstrument.Dimension)
+	assert.Equal(t, "COMPUTE", computeHourInstrument.Dimension)
+
+	// All should be commodities, not currencies
+	assert.True(t, transactionInstrument.IsCommodity())
+	assert.True(t, apiCallInstrument.IsCommodity())
+	assert.True(t, storageGBInstrument.IsCommodity())
+	assert.False(t, transactionInstrument.IsMonetary())
+}
+
+func TestUtilizationMeasurement_InstrumentPrecision(t *testing.T) {
+	// Verify precision for different utilization types
+	assert.Equal(t, 0, transactionInstrument.Precision) // Whole transactions
+	assert.Equal(t, 0, apiCallInstrument.Precision)     // Whole API calls
+	assert.Equal(t, 2, storageGBInstrument.Precision)   // Two decimal places for storage
+	assert.Equal(t, 4, computeHourInstrument.Precision) // Four decimal places for compute time
 }

--- a/services/utilization-metering-consumer/domain/measurement_test.go
+++ b/services/utilization-metering-consumer/domain/measurement_test.go
@@ -10,13 +10,16 @@ import (
 	"github.com/meridianhub/meridian/pkg/platform/quantity"
 )
 
-// Test instruments for utilization metering - all use COUNT dimension with precision 0.
+// Test instruments mirror the production instruments from instruments.go.
+// These are defined separately to avoid import cycles and to test instrument creation.
+// See instruments.go for production instrument definitions.
 var (
 	transactionInstrument, _ = quantity.NewInstrument("TRANSACTION", 1, "COUNT", 0)
 	apiCallInstrument, _     = quantity.NewInstrument("API_CALL", 1, "COUNT", 0)
 	operationInstrument, _   = quantity.NewInstrument("OPERATION", 1, "COUNT", 0)
-	storageGBInstrument, _   = quantity.NewInstrument("STORAGE_GB", 1, "DATA", 2)
-	computeHourInstrument, _ = quantity.NewInstrument("COMPUTE_HOUR", 1, "COMPUTE", 4)
+	// Note: precision matches production instruments (6 for fractional units)
+	storageGBInstrument, _   = quantity.NewInstrument("STORAGE_GB_HOUR", 1, "DATA", 6)
+	computeHourInstrument, _ = quantity.NewInstrument("COMPUTE_HOUR", 1, "COMPUTE", 6)
 )
 
 func TestUtilizationMeasurement_Creation(t *testing.T) {
@@ -383,8 +386,9 @@ func TestUtilizationMeasurement_QuantityString(t *testing.T) {
 	amount := quantity.NewAssetFromInt(42, transactionInstrument)
 	assert.Equal(t, "42 TRANSACTION", amount.String())
 
+	// Storage instrument uses 6 decimal places and full code name
 	storageAmount := quantity.NewAssetFromInt(100, storageGBInstrument)
-	assert.Equal(t, "100.00 STORAGE_GB", storageAmount.String())
+	assert.Equal(t, "100.000000 STORAGE_GB_HOUR", storageAmount.String())
 }
 
 func TestUtilizationMeasurement_InstrumentDimension(t *testing.T) {
@@ -403,9 +407,9 @@ func TestUtilizationMeasurement_InstrumentDimension(t *testing.T) {
 }
 
 func TestUtilizationMeasurement_InstrumentPrecision(t *testing.T) {
-	// Verify precision for different utilization types
-	assert.Equal(t, 0, transactionInstrument.Precision) // Whole transactions
-	assert.Equal(t, 0, apiCallInstrument.Precision)     // Whole API calls
-	assert.Equal(t, 2, storageGBInstrument.Precision)   // Two decimal places for storage
-	assert.Equal(t, 4, computeHourInstrument.Precision) // Four decimal places for compute time
+	// Verify precision for different utilization types matches production instruments
+	assert.Equal(t, 0, transactionInstrument.Precision) // Whole transactions (COUNT)
+	assert.Equal(t, 0, apiCallInstrument.Precision)     // Whole API calls (COUNT)
+	assert.Equal(t, 6, storageGBInstrument.Precision)   // Six decimal places for storage (DATA)
+	assert.Equal(t, 6, computeHourInstrument.Precision) // Six decimal places for compute time (COMPUTE)
 }


### PR DESCRIPTION
## Summary

Migrates the utilization-metering-consumer service from untyped integer quantities to the Universal Asset System's typed `Quantity[Commodity]` pattern.

**Task Master**: universal-asset-system.28

## Changes Made

### Domain Model (28.1)
- Replace `{Quantity int64; UnitOfMeasure string}` with `{Amount quantity.Asset}` in `UtilizationMeasurement`
- `quantity.Asset` is `Qty[Commodity]` providing compile-time dimension safety

### System Instruments (28.2)
- Add `instruments.go` with predefined utilization instruments:
  | Code | Dimension | Precision | Purpose |
  |------|-----------|-----------|---------|
  | TRANSACTION | COUNT | 0 | Transaction counting |
  | API_CALL | COUNT | 0 | API call counting |
  | OPERATION | COUNT | 0 | Generic operations |
  | STORAGE_GB_HOUR | DATA | 6 | Storage billing |
  | COMPUTE_HOUR | COMPUTE | 6 | Compute billing |
- Add `InstrumentForMeasurementType()` for backward-compatible mapping from legacy unit strings

### Position Keeping Adapter (28.3)
- Update `buildRecordMeasurementRequest()` to include instrument metadata:
  - `instrument_code`, `instrument_version`, `instrument_dimension`, `instrument_precision`
- Use typed instruments to determine measurement unit from dimension

## Technical Details

This migration aligns utilization metering with the Universal Asset System design:
- **Type Safety**: `Qty[Commodity]` prevents accidental mixing with monetary values at compile time
- **Instrument Identity**: Each measurement now carries full instrument metadata (code, version, dimension, precision)
- **Backward Compatibility**: `InstrumentForMeasurementType()` maps legacy string units to typed instruments

## Test Plan

- [x] All domain tests pass with new `quantity.Asset` type
- [x] Instrument validation tests for each predefined instrument
- [x] InstrumentForMeasurementType mapping tests including fallback behavior
- [x] Position Keeping client tests verify instrument metadata in requests
- [x] Integration tests pass (`go test ./services/utilization-metering-consumer/...`)