### PR TITLE
feat(reference-data): add instrument successor lineage support

### DIFF
--- a/api/proto/meridian/reference_data/v1/instrument.proto
+++ b/api/proto/meridian/reference_data/v1/instrument.proto
@@ -120,6 +120,15 @@ message InstrumentDefinition {
   // System instruments are read-only (cannot be modified or deleted by tenants).
   // Examples: USD, EUR, GBP - platform-wide instruments available to all tenants.
   bool is_system = 17;
+
+  // successor_id is the UUID of the instrument that replaces this one when deprecated.
+  // This creates a forward lineage chain: when querying a deprecated instrument,
+  // clients can follow successor_id to find the current replacement.
+  // Only set when status is DEPRECATED. Empty string if no successor designated.
+  string successor_id = 18 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string.uuid = true
+  ];
 }
 
 // ========================================
@@ -331,6 +340,15 @@ message DeprecateInstrumentRequest {
 
   // version identifies which version to deprecate.
   int32 version = 2 [(buf.validate.field).int32.gte = 1];
+
+  // successor_id optionally specifies the UUID of the replacement instrument.
+  // When provided, the deprecated instrument will point to this successor,
+  // creating a lineage chain for clients to follow to the current version.
+  // The successor must exist and be in ACTIVE status.
+  string successor_id = 3 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string.uuid = true
+  ];
 }
 
 // DeprecateInstrumentResponse returns the deprecated instrument definition.

--- a/docs/adr/0022-instrument-successor-lineage.md
+++ b/docs/adr/0022-instrument-successor-lineage.md
@@ -1,0 +1,415 @@
+---
+name: adr-022-instrument-successor-lineage
+description: Forward lineage tracking for deprecated instruments via successor_id enabling upgrade path discovery
+triggers:
+  - Deprecating an instrument and pointing clients to its replacement
+  - Querying what replaced a deprecated instrument
+  - Managing instrument version evolution with breaking changes
+  - Migrating positions from old to new instrument versions
+instructions: |
+  When deprecating an instrument, optionally set successor_id to point to the replacement
+  instrument. This creates a 1-to-1 forward lineage chain (A -> B -> C). Use recursive
+  CTE queries to traverse the chain to find the current active instrument. Successor must
+  be ACTIVE and have the same dimension. Write-once semantics: once successor_id is set,
+  it cannot be changed.
+---
+
+# 22. Instrument Successor Lineage
+
+Date: 2026-01-05
+
+## Status
+
+Proposed
+
+## Context
+
+Meridian's multi-asset platform tracks diverse financial instruments (currencies, energy,
+compute credits, carbon offsets) that evolve over time. The Financial Instrument Reference
+Data Management service (ADR-0014) provides tenant-defined instrument definitions with
+immutable versions and a lifecycle (DRAFT -> ACTIVE -> DEPRECATED).
+
+### The Evolution Problem
+
+Instruments evolve for various reasons:
+
+| Reason | Example | Impact |
+|--------|---------|--------|
+| Regulatory changes | New ISO 4217 currency code | Old positions need migration path |
+| Precision updates | BTC moving from 8 to 18 decimals | Incompatible with existing entries |
+| Schema changes | New required attributes | Old positions cannot be upgraded in-place |
+| Rebranding | Corporate merger renames instrument | Business continuity requirement |
+| Error correction | Fixing misconfigured validation rules | Cannot edit ACTIVE instruments |
+
+When an instrument transitions to DEPRECATED, existing ledger entries remain immutable -
+they reference the old instrument ID forever. However, clients need to know:
+
+1. **What replaces this instrument?** - UI/API consumers need to suggest alternatives
+2. **Is this still a valid instrument?** - Prevent new entries using deprecated instruments
+3. **How do I migrate positions?** - Operational guidance for moving to the successor
+
+### Why Not Just Version Numbers?
+
+ADR-0014 already provides version numbers (v1, v2, v3...) for schema evolution within
+the same instrument code. However, version numbers solve a different problem:
+
+| Scenario | Solution |
+|----------|----------|
+| Same instrument, backward-compatible changes | Version increment (USD v1 -> v2) |
+| Same instrument, breaking changes | New instrument + successor link |
+| Different instrument replaces old | New instrument + successor link |
+| Instrument split into multiple | Manual intervention (no single successor) |
+
+**Version numbers** handle gradual evolution where old and new can coexist.
+**Successor links** handle deprecation where the old instrument should no longer be used.
+
+### Relationship to Other ADRs
+
+This ADR builds on:
+
+- **ADR-0014 (Financial Instrument Reference Data):** Defines the `instrument_definition`
+  table, lifecycle states, and CEL validation expressions
+- **ADR-0016 (Tenant Isolation):** Ensures successor links respect tenant boundaries
+- **ADR-0017 (Temporal Quality Ladder):** Position entries reference instruments by ID;
+  those references must remain valid even when instruments are deprecated
+
+## Decision Drivers
+
+* **Forward discovery**: Clients need to find current replacement without scanning all instruments
+* **Immutable ledger integrity**: Existing entries cannot be modified to point to new instruments
+* **Simple model**: 1-to-1 succession covers 90% of cases; complex scenarios need manual handling
+* **Dimension safety**: Prevent invalid successors that would break quantity type safety
+* **Write-once semantics**: Once succession is established, it cannot be changed
+
+## Considered Options
+
+### Option 1: Successor ID Column (Self-Referential FK)
+
+Add a `successor_id` column to `instrument_definition` that points to the replacement
+instrument. Simple forward pointer, enforced at database level.
+
+### Option 2: Separate Lineage Table
+
+Create a `instrument_lineage` table with `deprecated_id`, `successor_id`, and `reason`.
+More flexible but adds join complexity and potential consistency issues.
+
+### Option 3: Bidirectional Links (predecessor + successor)
+
+Track both `predecessor_id` and `successor_id` for full lineage traversal in both
+directions.
+
+### Option 4: Version Graph with Edges
+
+Full graph model supporting 1-to-many (splits) and many-to-1 (merges) relationships.
+
+## Decision Outcome
+
+Chosen option: **Option 1 - Successor ID Column**, because:
+
+- Simplest implementation with minimal schema changes
+- Database-enforced referential integrity via FK constraint
+- Forward traversal (old -> new) is the primary use case
+- Complex scenarios (splits, merges) are rare and require manual intervention anyway
+
+### Schema Changes
+
+```sql
+-- Add successor_id column (nullable - not all deprecated instruments have successors)
+ALTER TABLE "instrument_definition"
+  ADD COLUMN "successor_id" uuid NULL;
+
+-- Self-referential foreign key ensures successor exists
+ALTER TABLE "instrument_definition"
+  ADD CONSTRAINT "fk_instrument_definition_successor"
+  FOREIGN KEY ("successor_id") REFERENCES "instrument_definition" ("id");
+
+-- Index for efficient reverse lookups (finding all predecessors of an instrument)
+CREATE INDEX "idx_instrument_definition_successor_id" ON "instrument_definition" ("successor_id")
+  WHERE "successor_id" IS NOT NULL;
+```
+
+### Validation Rules (Trigger-Enforced)
+
+The `enforce_instrument_lifecycle` trigger validates successor relationships:
+
+```sql
+-- On transition to DEPRECATED with successor_id:
+-- 1. Successor must exist
+-- 2. Successor must be ACTIVE (not DRAFT or DEPRECATED)
+-- 3. Successor must have same dimension (prevents type mismatch)
+
+IF NEW."successor_id" IS NOT NULL THEN
+  SELECT "id", "status", "dimension"
+  INTO successor_record
+  FROM "instrument_definition"
+  WHERE "id" = NEW."successor_id";
+
+  IF successor_record.id IS NULL THEN
+    RAISE EXCEPTION 'Successor instrument does not exist: %', NEW."successor_id";
+  END IF;
+
+  IF successor_record.status != 'ACTIVE' THEN
+    RAISE EXCEPTION 'Successor instrument must be ACTIVE, but is %', successor_record.status;
+  END IF;
+
+  IF successor_record.dimension != NEW."dimension" THEN
+    RAISE EXCEPTION 'Successor instrument dimension (%) must match current instrument dimension (%)',
+      successor_record.dimension, NEW."dimension";
+  END IF;
+END IF;
+```
+
+### Write-Once Semantics
+
+Once `successor_id` is set, it cannot be changed:
+
+```sql
+-- Enforce write-once semantics regardless of status
+IF OLD."successor_id" IS NOT NULL AND OLD."successor_id" IS DISTINCT FROM NEW."successor_id" THEN
+  RAISE EXCEPTION 'Cannot modify successor_id once set (write-once semantics)';
+END IF;
+```
+
+**Rationale**: Allowing successor changes would break client caching and could create
+confusion in audit trails. If the wrong successor was set, create a new version instead.
+
+### Lineage Traversal Query
+
+To find the current active instrument from any point in the lineage chain:
+
+```sql
+-- Recursive CTE to traverse lineage chain
+WITH RECURSIVE lineage AS (
+  -- Start from the deprecated instrument
+  SELECT id, code, version, status, successor_id, dimension, 1 as depth
+  FROM instrument_definition
+  WHERE id = $1  -- Starting instrument ID
+
+  UNION ALL
+
+  -- Follow successor chain
+  SELECT i.id, i.code, i.version, i.status, i.successor_id, i.dimension, l.depth + 1
+  FROM instrument_definition i
+  JOIN lineage l ON i.id = l.successor_id
+  WHERE l.depth < 10  -- Prevent infinite loops (defensive)
+)
+SELECT * FROM lineage
+WHERE status = 'ACTIVE'
+ORDER BY depth
+LIMIT 1;
+```
+
+### API Integration
+
+The `DeprecateInstrument` RPC accepts an optional `successor_id`:
+
+```protobuf
+message DeprecateInstrumentRequest {
+  string code = 1;
+  int32 version = 2;
+
+  // Optional: UUID of the replacement instrument (must be ACTIVE, same dimension)
+  string successor_id = 3;
+}
+```
+
+### Domain Model
+
+```go
+// InstrumentDefinition includes successor reference for lineage tracking.
+type InstrumentDefinition struct {
+    ID          uuid.UUID
+    Code        string
+    Version     int32
+    Dimension   Dimension
+    Status      InstrumentStatus
+    // ... other fields ...
+
+    // SuccessorID points to the replacement instrument when deprecated.
+    // Nil if no successor designated or instrument is not deprecated.
+    SuccessorID *uuid.UUID
+}
+
+// GetCurrentSuccessor traverses the lineage chain to find the active replacement.
+// Returns nil if the instrument is active or has no successor chain leading to active.
+func (s *InstrumentService) GetCurrentSuccessor(
+    ctx context.Context,
+    instrumentID uuid.UUID,
+) (*InstrumentDefinition, error) {
+    // Implementation uses recursive CTE query
+}
+```
+
+## Consequences
+
+### Positive
+
+* **Simple forward discovery**: Single column lookup to find replacement
+* **Database integrity**: FK constraint ensures successor exists
+* **Dimension safety**: Trigger prevents cross-dimension successors
+* **Audit-friendly**: Write-once semantics create immutable lineage records
+* **Query efficient**: Index on successor_id enables fast reverse lookups
+* **Minimal schema change**: One nullable column, one FK, one index
+
+### Negative
+
+* **No split handling**: 1-to-many splits require manual intervention
+* **No merge handling**: Many-to-1 merges require custom logic
+* **Chain traversal cost**: Long chains require recursive queries (mitigated by depth limit)
+* **No reason tracking**: Why an instrument was deprecated is not captured in the schema
+
+## Architectural Considerations
+
+### Tenant Isolation
+
+The FK constraint is within the tenant schema (per ADR-0016), so successors must be
+instruments within the same tenant. Cross-tenant succession is not possible, which
+is the correct behavior for tenant isolation.
+
+### Cache Invalidation
+
+When an instrument is deprecated:
+
+1. Cache entry for the deprecated instrument should be updated (not invalidated)
+2. Position Keeping services should handle deprecated instruments gracefully
+3. UI clients should show "deprecated, use X instead" based on successor_id
+
+```go
+// Example cache invalidation handler
+func (c *InstrumentCache) OnInstrumentDeprecated(evt InstrumentDeprecatedEvent) {
+    // Update cached entry with deprecated status and successor
+    if entry, ok := c.Get(evt.InstrumentID); ok {
+        entry.Status = StatusDeprecated
+        entry.SuccessorID = evt.SuccessorID
+        c.Set(evt.InstrumentID, entry)
+    }
+
+    // Optionally pre-warm successor if not cached
+    if evt.SuccessorID != nil {
+        c.EnsureLoaded(*evt.SuccessorID)
+    }
+}
+```
+
+### Position Keeping Integration
+
+Position entries reference instruments by ID. When querying positions:
+
+```go
+// PositionWithLineage includes the current active instrument for deprecated instruments.
+type PositionWithLineage struct {
+    Position          Position
+    Instrument        InstrumentDefinition
+    CurrentSuccessor  *InstrumentDefinition  // Non-nil if instrument is deprecated
+}
+
+// GetPositionsWithLineage enriches positions with successor information.
+func (s *PositionService) GetPositionsWithLineage(
+    ctx context.Context,
+    accountID uuid.UUID,
+) ([]PositionWithLineage, error) {
+    // For each position with deprecated instrument, resolve current successor
+}
+```
+
+### Historical Ledger Entries
+
+Existing ledger entries remain unchanged - they reference the original instrument ID.
+This is correct behavior because:
+
+1. **Immutability**: Ledger entries are append-only (ADR-0017)
+2. **Audit trail**: Historical entries should reflect what was recorded at the time
+3. **Position calculation**: Sum of entries gives position in the original instrument
+
+Migration to the successor instrument requires explicit action (transfer, conversion)
+that creates new ledger entries in the successor instrument.
+
+## Scenarios Not Handled
+
+The following scenarios require manual intervention and cannot be expressed via
+simple successor links:
+
+### 1-to-Many Splits
+
+Example: Company stock split (1 share -> 10 shares)
+
+```
+OLD_STOCK (DEPRECATED)
+    └─> NEW_STOCK_A (ACTIVE)  -- Cannot express with single successor
+    └─> NEW_STOCK_B (ACTIVE)
+```
+
+**Manual process**: Create transfer entries to move positions proportionally.
+
+### Many-to-1 Merges
+
+Example: Currency union (DEM, FRF, ITL -> EUR)
+
+```
+DEM (DEPRECATED) ─┐
+FRF (DEPRECATED) ─┼─> EUR (ACTIVE)  -- Each can point to EUR individually
+ITL (DEPRECATED) ─┘
+```
+
+**This works**: Each old currency can have EUR as its successor.
+
+### Chain Deprecation
+
+Example: Rapid iteration (A -> B -> C in quick succession)
+
+```
+A (DEPRECATED) -> B (DEPRECATED) -> C (ACTIVE)
+```
+
+**This works**: Recursive CTE traverses to find C as the current active instrument.
+However, if B is deprecated before clients update from A, they may briefly see B.
+
+## Future Considerations
+
+### Deprecation Reason
+
+Consider adding a `deprecation_reason` column for audit purposes:
+
+```sql
+ALTER TABLE "instrument_definition"
+  ADD COLUMN "deprecation_reason" TEXT;
+```
+
+### Bulk Migration API
+
+For large-scale migrations, a bulk transfer API could automate position migration:
+
+```protobuf
+rpc MigratePositions(MigratePositionsRequest) returns (MigratePositionsResponse);
+
+message MigratePositionsRequest {
+  string from_instrument_id = 1;  // Must be DEPRECATED
+  string to_instrument_id = 2;    // Must be ACTIVE, same dimension
+  string conversion_factor = 3;   // e.g., "1.0" or "10.0" for stock splits
+}
+```
+
+### Event Emission
+
+Consider emitting domain events for lineage changes:
+
+```go
+type InstrumentDeprecatedEvent struct {
+    InstrumentID uuid.UUID
+    SuccessorID  *uuid.UUID
+    DeprecatedAt time.Time
+}
+```
+
+## Links
+
+### Internal ADRs
+
+* [ADR-0014: Financial Instrument Reference Data](0014-financial-instrument-reference-data.md) - Instrument definitions and lifecycle
+* [ADR-0016: Tenant Isolation](0016-tenant-id-naming-strategy.md) - Schema-per-tenant isolation
+* [ADR-0017: Temporal Quality Ladder](0017-temporal-quality-ladder.md) - Position entries and immutability
+
+### External References
+
+* [ISO 20022 Financial Instrument Identification](https://www.iso20022.org) - Standard instrument identifiers
+* [BIAN Financial Instrument Reference Data Management](https://bian.org) - Service domain specification

--- a/docs/adr/0022-instrument-successor-lineage.md
+++ b/docs/adr/0022-instrument-successor-lineage.md
@@ -436,6 +436,38 @@ A (DEPRECATED) -> B (DEPRECATED) -> C (ACTIVE)
 **This works**: Recursive CTE traverses to find C as the current active instrument.
 However, if B is deprecated before clients update from A, they may briefly see B.
 
+### Circular Lineage Prevention
+
+The trigger validation naturally prevents circular references:
+
+```
+Scenario: A → B, then attempt B → A
+
+1. A is ACTIVE
+2. Deprecate A with successor B (B must be ACTIVE) ✅
+3. A is now DEPRECATED, B is ACTIVE
+4. Attempt to deprecate B with successor A
+   └─> FAILS: A is DEPRECATED, not ACTIVE ❌
+```
+
+The "successor must be ACTIVE" constraint prevents circular chains because an instrument
+that is already in the lineage chain (A) would have to be DEPRECATED to be there. The
+trigger also explicitly rejects self-referential successors (A → A).
+
+### Chain Depth Limits
+
+The recursive CTE query includes a depth limit of 10 to prevent runaway queries:
+
+```sql
+WHERE l.depth < 10  -- Defensive limit
+```
+
+**Note**: This limit is enforced on the read side only. There is no write-time
+enforcement preventing chains longer than 10. In practice, chains this long indicate
+a process problem (too many rapid deprecations) rather than a technical one. If
+enforcement is needed, a trigger could be added to validate chain depth before
+allowing a new successor to be set.
+
 ## Future Considerations
 
 ### Deprecation Reason

--- a/docs/adr/0022-instrument-successor-lineage.md
+++ b/docs/adr/0022-instrument-successor-lineage.md
@@ -6,12 +6,18 @@ triggers:
   - Querying what replaced a deprecated instrument
   - Managing instrument version evolution with breaking changes
   - Migrating positions from old to new instrument versions
+  - Trading deprecated instruments for successor instruments
+  - Validating ledger entries against instrument status
 instructions: |
   When deprecating an instrument, optionally set successor_id to point to the replacement
   instrument. This creates a 1-to-1 forward lineage chain (A -> B -> C). Use recursive
   CTE queries to traverse the chain to find the current active instrument. Successor must
   be ACTIVE and have the same dimension. Write-once semantics: once successor_id is set,
   it cannot be changed.
+
+  MIGRATION RULE: Position migration is modeled as a trade (sell deprecated, buy successor).
+  Deprecated instruments allow DEBITS (selling out) but REJECT CREDITS (buying in). This
+  enforcement happens in Financial Accounting/Position Keeping, not Reference Data.
 ---
 
 # 22. Instrument Successor Lineage
@@ -321,8 +327,74 @@ This is correct behavior because:
 2. **Audit trail**: Historical entries should reflect what was recorded at the time
 3. **Position calculation**: Sum of entries gives position in the original instrument
 
-Migration to the successor instrument requires explicit action (transfer, conversion)
-that creates new ledger entries in the successor instrument.
+### Position Migration via Trades
+
+Migration from a deprecated instrument to its successor is modeled as a **trade** -
+this keeps the ledger model consistent and leverages the existing Financial Accounting
+infrastructure:
+
+```
+Deprecated Position          Trade                    New Position
+─────────────────────────────────────────────────────────────────────────────
+USD_V1: 1,000.00    →    Sell USD_V1 / Buy USD_V2    →    USD_V2: 1,000.00
+                              ↑
+                    Valuation Engine determines rate
+                    (1:1 for same currency, or
+                     10:1 for stock split, etc.)
+```
+
+**The key rule for deprecated instruments:**
+
+| Operation | Allowed | Rationale |
+|-----------|---------|-----------|
+| Debit (sell out of) | ✅ Yes | This is how you exit positions in deprecated instruments |
+| Credit (buy into) | ❌ No | Prevent new positions in deprecated instruments |
+
+This asymmetric rule means:
+
+1. **No new exposure**: Clients cannot acquire positions in deprecated instruments
+2. **Clean exit path**: Existing positions can be sold/converted to the successor
+3. **Valuation Engine decides rate**: The conversion factor (1:1, 10:1, etc.) is
+   determined by the yet-to-be-defined Valuation Engine, not Reference Data
+
+**Where this is enforced:**
+
+- **Reference Data**: Only manages the `successor_id` pointer - does NOT enforce
+  trading rules (it has no knowledge of ledger operations)
+- **Financial Accounting / Position Keeping**: Validates instrument status on ledger
+  entry creation - rejects credits to DEPRECATED instruments with clear error message
+  pointing to the successor
+
+```go
+// In Financial Accounting ledger entry validation
+func (s *LedgerService) ValidateEntry(ctx context.Context, entry *LedgerEntry) error {
+    instrument, err := s.refData.GetDefinition(ctx, entry.InstrumentCode, entry.InstrumentVersion)
+    if err != nil {
+        return err
+    }
+
+    // Allow debits from deprecated instruments (this is the migration path)
+    // Reject credits to deprecated instruments (no new positions)
+    if instrument.Status == StatusDeprecated && entry.Amount.IsPositive() {
+        return &DeprecatedInstrumentError{
+            InstrumentID: instrument.ID,
+            SuccessorID:  instrument.SuccessorID,
+            Message:      "Cannot credit deprecated instrument; use successor instead",
+        }
+    }
+
+    return nil
+}
+```
+
+**Future: Valuation Engine ADR**
+
+The Valuation Engine (future ADR/PRD) will provide:
+
+- Conversion rates between deprecated and successor instruments
+- Historical rate lookups for audit/reconciliation
+- Rate validation rules (e.g., same-dimension instruments must have rate)
+- Bulk migration rate schedules for planned deprecations
 
 ## Scenarios Not Handled
 

--- a/services/reference-data/handler/grpc_handler.go
+++ b/services/reference-data/handler/grpc_handler.go
@@ -214,7 +214,17 @@ func (s *Service) ActivateInstrument(ctx context.Context, req *pb.ActivateInstru
 
 // DeprecateInstrument transitions an instrument from ACTIVE to DEPRECATED.
 func (s *Service) DeprecateInstrument(ctx context.Context, req *pb.DeprecateInstrumentRequest) (*pb.DeprecateInstrumentResponse, error) {
-	if err := s.registry.DeprecateInstrument(ctx, req.Code, int(req.Version)); err != nil {
+	// Parse optional successor_id from request
+	var successorID *uuid.UUID
+	if req.SuccessorId != "" {
+		parsed, err := uuid.Parse(req.SuccessorId)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid successor_id: %v", err)
+		}
+		successorID = &parsed
+	}
+
+	if err := s.registry.DeprecateInstrument(ctx, req.Code, int(req.Version), successorID); err != nil {
 		return nil, s.mapDomainError(err, "DeprecateInstrument", req.Code)
 	}
 
@@ -226,7 +236,8 @@ func (s *Service) DeprecateInstrument(ctx context.Context, req *pb.DeprecateInst
 
 	s.logger.Info("instrument deprecated",
 		"code", req.Code,
-		"version", req.Version)
+		"version", req.Version,
+		"successorId", req.SuccessorId)
 
 	return &pb.DeprecateInstrumentResponse{
 		Instrument: domainToProto(def),
@@ -446,6 +457,12 @@ func (s *Service) mapDomainError(err error, operation, code string) error {
 			"code", code)
 		return status.Errorf(codes.FailedPrecondition, "invalid state transition: %v", err)
 
+	case errors.Is(err, registry.ErrSuccessorInvalid):
+		s.logger.Warn("invalid successor instrument",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.FailedPrecondition, "successor instrument is invalid: must exist, be ACTIVE, and have same dimension")
+
 	default:
 		s.logger.Error("internal error",
 			"operation", operation,
@@ -483,6 +500,9 @@ func domainToProto(def *registry.InstrumentDefinition) *pb.InstrumentDefinition 
 	}
 	if def.DeprecatedAt != nil {
 		proto.DeprecatedAt = timestamppb.New(*def.DeprecatedAt)
+	}
+	if def.SuccessorID != nil {
+		proto.SuccessorId = def.SuccessorID.String()
 	}
 
 	return proto

--- a/services/reference-data/handler/grpc_handler_test.go
+++ b/services/reference-data/handler/grpc_handler_test.go
@@ -154,7 +154,7 @@ func (m *mockRegistry) ActivateInstrument(_ context.Context, code string, versio
 	return nil
 }
 
-func (m *mockRegistry) DeprecateInstrument(_ context.Context, code string, version int) error {
+func (m *mockRegistry) DeprecateInstrument(_ context.Context, code string, version int, successorID *uuid.UUID) error {
 	if m.deprecateErr != nil {
 		return m.deprecateErr
 	}
@@ -172,6 +172,7 @@ func (m *mockRegistry) DeprecateInstrument(_ context.Context, code string, versi
 	now := time.Now()
 	def.DeprecatedAt = &now
 	def.UpdatedAt = now
+	def.SuccessorID = successorID
 	return nil
 }
 
@@ -687,6 +688,7 @@ func TestErrorMapping(t *testing.T) {
 		{"AlreadyExists", registry.ErrAlreadyExists, codes.AlreadyExists},
 		{"OptimisticLock", registry.ErrOptimisticLock, codes.Aborted},
 		{"InvalidStateTransition", registry.ErrInvalidStateTransition, codes.FailedPrecondition},
+		{"SuccessorInvalid", registry.ErrSuccessorInvalid, codes.FailedPrecondition},
 		{"Unknown", errMockUnknown, codes.Internal},
 	}
 

--- a/services/reference-data/migrations/20260106000001_add_successor_id.sql
+++ b/services/reference-data/migrations/20260106000001_add_successor_id.sql
@@ -67,6 +67,11 @@ BEGIN
 
       -- If successor_id is provided, validate it
       IF NEW."successor_id" IS NOT NULL THEN
+        -- Cannot designate self as successor
+        IF NEW."successor_id" = NEW."id" THEN
+          RAISE EXCEPTION 'Instrument cannot designate itself as its own successor';
+        END IF;
+
         -- Look up the successor instrument
         SELECT "id", "status", "dimension"
         INTO successor_record

--- a/services/reference-data/migrations/20260106000001_add_successor_id.sql
+++ b/services/reference-data/migrations/20260106000001_add_successor_id.sql
@@ -1,0 +1,103 @@
+-- Add successor_id column for instrument lineage tracking
+-- When an instrument is DEPRECATED, it can optionally point to its successor (replacement) instrument.
+-- This enables clients to follow the lineage chain to find the current active instrument.
+
+-- Add successor_id column (nullable - not all deprecated instruments have successors)
+ALTER TABLE "instrument_definition"
+  ADD COLUMN "successor_id" uuid NULL;
+
+-- Add self-referential foreign key constraint
+ALTER TABLE "instrument_definition"
+  ADD CONSTRAINT "fk_instrument_definition_successor"
+  FOREIGN KEY ("successor_id") REFERENCES "instrument_definition" ("id");
+
+-- Index for efficient lineage traversal (finding all instruments that point to a given successor)
+CREATE INDEX "idx_instrument_definition_successor_id" ON "instrument_definition" ("successor_id")
+  WHERE "successor_id" IS NOT NULL;
+
+-- Update the lifecycle trigger to enforce successor_id validation rules
+CREATE OR REPLACE FUNCTION "enforce_instrument_lifecycle"()
+RETURNS TRIGGER AS $$
+DECLARE
+  successor_record RECORD;
+BEGIN
+  -- Always update updated_at on any change
+  NEW."updated_at" = NOW();
+
+  -- Enforce write-once semantics for successor_id
+  -- Once set, successor_id cannot be changed (regardless of status)
+  IF OLD."successor_id" IS NOT NULL AND OLD."successor_id" IS DISTINCT FROM NEW."successor_id" THEN
+    RAISE EXCEPTION 'Cannot modify successor_id once set (write-once semantics)';
+  END IF;
+
+  -- Allow all edits when status is DRAFT
+  IF OLD."status" = 'DRAFT' THEN
+    -- If transitioning from DRAFT to ACTIVE, set activated_at
+    IF NEW."status" = 'ACTIVE' THEN
+      NEW."activated_at" = NOW();
+    -- If transitioning from DRAFT to DEPRECATED, set deprecated_at
+    ELSIF NEW."status" = 'DEPRECATED' THEN
+      NEW."deprecated_at" = NOW();
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  -- For ACTIVE or DEPRECATED instruments, certain fields become immutable
+  IF OLD."status" IN ('ACTIVE', 'DEPRECATED') THEN
+    -- Prevent changes to immutable fields (validation rules that affect ledger integrity)
+    IF OLD."validation_expression" IS DISTINCT FROM NEW."validation_expression" THEN
+      RAISE EXCEPTION 'Cannot modify validation_expression for % instrument', OLD."status";
+    END IF;
+    IF OLD."fungibility_key_expression" IS DISTINCT FROM NEW."fungibility_key_expression" THEN
+      RAISE EXCEPTION 'Cannot modify fungibility_key_expression for % instrument', OLD."status";
+    END IF;
+    IF OLD."error_message_expression" IS DISTINCT FROM NEW."error_message_expression" THEN
+      RAISE EXCEPTION 'Cannot modify error_message_expression for % instrument', OLD."status";
+    END IF;
+  END IF;
+
+  -- Prevent invalid status transitions
+  IF OLD."status" = 'ACTIVE' THEN
+    IF NEW."status" = 'DRAFT' THEN
+      RAISE EXCEPTION 'Cannot transition from ACTIVE back to DRAFT';
+    END IF;
+    -- Allow ACTIVE to DEPRECATED, set deprecated_at and validate successor
+    IF NEW."status" = 'DEPRECATED' THEN
+      NEW."deprecated_at" = NOW();
+
+      -- If successor_id is provided, validate it
+      IF NEW."successor_id" IS NOT NULL THEN
+        -- Look up the successor instrument
+        SELECT "id", "status", "dimension"
+        INTO successor_record
+        FROM "instrument_definition"
+        WHERE "id" = NEW."successor_id";
+
+        -- Successor must exist
+        IF successor_record.id IS NULL THEN
+          RAISE EXCEPTION 'Successor instrument does not exist: %', NEW."successor_id";
+        END IF;
+
+        -- Successor must be ACTIVE
+        IF successor_record.status != 'ACTIVE' THEN
+          RAISE EXCEPTION 'Successor instrument must be ACTIVE, but is %', successor_record.status;
+        END IF;
+
+        -- Successor must have same dimension
+        IF successor_record.dimension != NEW."dimension" THEN
+          RAISE EXCEPTION 'Successor instrument dimension (%) must match current instrument dimension (%)',
+            successor_record.dimension, NEW."dimension";
+        END IF;
+      END IF;
+    END IF;
+  END IF;
+
+  IF OLD."status" = 'DEPRECATED' THEN
+    IF NEW."status" IN ('DRAFT', 'ACTIVE') THEN
+      RAISE EXCEPTION 'Cannot transition from DEPRECATED to %', NEW."status";
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/services/reference-data/registry/postgres_registry.go
+++ b/services/reference-data/registry/postgres_registry.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -426,8 +427,18 @@ func (r *PostgresRegistry) DeprecateInstrument(ctx context.Context, code string,
 			// Check if the error is from the successor validation trigger
 			var pgErr *pgconn.PgError
 			if errors.As(err, &pgErr) && pgErr.Code == "P0001" { // raise_exception
-				// The trigger raises exceptions for invalid successor
-				return ErrSuccessorInvalid
+				// Map specific trigger errors based on error message
+				msg := pgErr.Message
+				switch {
+				case strings.Contains(msg, "successor"):
+					return ErrSuccessorInvalid
+				case strings.Contains(msg, "Cannot transition"):
+					return ErrInvalidStateTransition
+				case strings.Contains(msg, "Cannot modify"):
+					return ErrInvalidStatus
+				default:
+					return fmt.Errorf("%w: %s", ErrInvalidStatus, msg)
+				}
 			}
 			return fmt.Errorf("failed to deprecate instrument: %w", err)
 		}

--- a/services/reference-data/registry/postgres_registry.go
+++ b/services/reference-data/registry/postgres_registry.go
@@ -429,12 +429,13 @@ func (r *PostgresRegistry) DeprecateInstrument(ctx context.Context, code string,
 			if errors.As(err, &pgErr) && pgErr.Code == "P0001" { // raise_exception
 				// Map specific trigger errors based on error message
 				msg := pgErr.Message
+				msgLower := strings.ToLower(msg)
 				switch {
-				case strings.Contains(msg, "successor"):
+				case strings.Contains(msgLower, "successor"):
 					return ErrSuccessorInvalid
-				case strings.Contains(msg, "Cannot transition"):
+				case strings.Contains(msgLower, "cannot transition"):
 					return ErrInvalidStateTransition
-				case strings.Contains(msg, "Cannot modify"):
+				case strings.Contains(msgLower, "cannot modify"):
 					return ErrInvalidStatus
 				default:
 					return fmt.Errorf("%w: %s", ErrInvalidStatus, msg)

--- a/services/reference-data/registry/postgres_registry.go
+++ b/services/reference-data/registry/postgres_registry.go
@@ -124,7 +124,7 @@ func (r *PostgresRegistry) GetDefinition(ctx context.Context, code string, versi
 			SELECT id, code, version, dimension, precision, status, is_system,
 				validation_expression, fungibility_key_expression, error_message_expression,
 				attribute_schema, display_name, description,
-				created_at, updated_at, activated_at, deprecated_at
+				created_at, updated_at, activated_at, deprecated_at, successor_id
 			FROM instrument_definition
 			WHERE code = $1 AND version = $2`
 
@@ -156,7 +156,7 @@ func (r *PostgresRegistry) GetActiveDefinition(ctx context.Context, code string)
 			SELECT id, code, version, dimension, precision, status, is_system,
 				validation_expression, fungibility_key_expression, error_message_expression,
 				attribute_schema, display_name, description,
-				created_at, updated_at, activated_at, deprecated_at
+				created_at, updated_at, activated_at, deprecated_at, successor_id
 			FROM instrument_definition
 			WHERE code = $1 AND status = 'ACTIVE'
 			ORDER BY version DESC
@@ -190,7 +190,7 @@ func (r *PostgresRegistry) ListActive(ctx context.Context) ([]*InstrumentDefinit
 			SELECT id, code, version, dimension, precision, status, is_system,
 				validation_expression, fungibility_key_expression, error_message_expression,
 				attribute_schema, display_name, description,
-				created_at, updated_at, activated_at, deprecated_at
+				created_at, updated_at, activated_at, deprecated_at, successor_id
 			FROM instrument_definition
 			WHERE status = 'ACTIVE'
 			ORDER BY code, version DESC`
@@ -386,7 +386,9 @@ func (r *PostgresRegistry) ActivateInstrument(ctx context.Context, code string, 
 }
 
 // DeprecateInstrument transitions an instrument from ACTIVE to DEPRECATED.
-func (r *PostgresRegistry) DeprecateInstrument(ctx context.Context, code string, version int) error {
+// If successorID is provided, the database trigger validates that the successor exists,
+// is ACTIVE, and has the same dimension as the deprecated instrument.
+func (r *PostgresRegistry) DeprecateInstrument(ctx context.Context, code string, version int, successorID *uuid.UUID) error {
 	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
 		// Check current state
 		var isSystem bool
@@ -409,17 +411,24 @@ func (r *PostgresRegistry) DeprecateInstrument(ctx context.Context, code string,
 			return ErrNotActive
 		}
 
-		// Transition to DEPRECATED
+		// Transition to DEPRECATED with optional successor
 		now := time.Now()
 		updateQuery := `
 			UPDATE instrument_definition SET
 				status = 'DEPRECATED',
 				deprecated_at = $1,
-				updated_at = $1
+				updated_at = $1,
+				successor_id = $4
 			WHERE code = $2 AND version = $3`
 
-		_, err = tx.Exec(ctx, updateQuery, now, code, version)
+		_, err = tx.Exec(ctx, updateQuery, now, code, version, successorID)
 		if err != nil {
+			// Check if the error is from the successor validation trigger
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "P0001" { // raise_exception
+				// The trigger raises exceptions for invalid successor
+				return ErrSuccessorInvalid
+			}
 			return fmt.Errorf("failed to deprecate instrument: %w", err)
 		}
 
@@ -616,12 +625,13 @@ func (r *PostgresRegistry) scanInstrumentDefinition(row pgx.Row) (*InstrumentDef
 	var def InstrumentDefinition
 	var dimension, status string
 	var validationExpr, errorMsgExpr, displayName, description sql.NullString
+	var successorID *uuid.UUID
 
 	err := row.Scan(
 		&def.ID, &def.Code, &def.Version, &dimension, &def.Precision, &status, &def.IsSystem,
 		&validationExpr, &def.FungibilityKeyExpression, &errorMsgExpr,
 		&def.AttributeSchema, &displayName, &description,
-		&def.CreatedAt, &def.UpdatedAt, &def.ActivatedAt, &def.DeprecatedAt,
+		&def.CreatedAt, &def.UpdatedAt, &def.ActivatedAt, &def.DeprecatedAt, &successorID,
 	)
 	if err != nil {
 		return nil, err
@@ -629,6 +639,7 @@ func (r *PostgresRegistry) scanInstrumentDefinition(row pgx.Row) (*InstrumentDef
 
 	def.Dimension = Dimension(dimension)
 	def.Status = Status(status)
+	def.SuccessorID = successorID
 
 	if validationExpr.Valid {
 		def.ValidationExpression = validationExpr.String
@@ -651,12 +662,13 @@ func (r *PostgresRegistry) scanInstrumentDefinitionFromRows(rows pgx.Rows) (*Ins
 	var def InstrumentDefinition
 	var dimension, status string
 	var validationExpr, errorMsgExpr, displayName, description sql.NullString
+	var successorID *uuid.UUID
 
 	err := rows.Scan(
 		&def.ID, &def.Code, &def.Version, &dimension, &def.Precision, &status, &def.IsSystem,
 		&validationExpr, &def.FungibilityKeyExpression, &errorMsgExpr,
 		&def.AttributeSchema, &displayName, &description,
-		&def.CreatedAt, &def.UpdatedAt, &def.ActivatedAt, &def.DeprecatedAt,
+		&def.CreatedAt, &def.UpdatedAt, &def.ActivatedAt, &def.DeprecatedAt, &successorID,
 	)
 	if err != nil {
 		return nil, err
@@ -664,6 +676,7 @@ func (r *PostgresRegistry) scanInstrumentDefinitionFromRows(rows pgx.Rows) (*Ins
 
 	def.Dimension = Dimension(dimension)
 	def.Status = Status(status)
+	def.SuccessorID = successorID
 
 	if validationExpr.Valid {
 		def.ValidationExpression = validationExpr.String

--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -643,3 +643,183 @@ func TestPostgresRegistry_ValidateAttributesWithTimestamps(t *testing.T) {
 		assert.False(t, result.Valid)
 	})
 }
+
+func TestPostgresRegistry_DeprecateWithSuccessor(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-successor")
+
+	t.Run("deprecate with valid successor succeeds", func(t *testing.T) {
+		// Create and activate the old instrument
+		oldDef := &registry.InstrumentDefinition{
+			Code:      "OLD_V1",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, oldDef))
+		require.NoError(t, reg.ActivateInstrument(ctx, "OLD_V1", 1))
+
+		// Create and activate the successor instrument
+		newDef := &registry.InstrumentDefinition{
+			Code:      "NEW_V2",
+			Version:   1,
+			Dimension: registry.DimensionMonetary, // Same dimension
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, newDef))
+		require.NoError(t, reg.ActivateInstrument(ctx, "NEW_V2", 1))
+
+		// Deprecate old with successor
+		err := reg.DeprecateInstrument(ctx, "OLD_V1", 1, &newDef.ID)
+		require.NoError(t, err)
+
+		// Verify successor was set
+		result, err := reg.GetDefinition(ctx, "OLD_V1", 1)
+		require.NoError(t, err)
+		assert.Equal(t, registry.StatusDeprecated, result.Status)
+		assert.NotNil(t, result.SuccessorID)
+		assert.Equal(t, newDef.ID, *result.SuccessorID)
+	})
+
+	t.Run("deprecate with non-existent successor fails", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "NOSUCC",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateInstrument(ctx, "NOSUCC", 1))
+
+		// Try to deprecate with non-existent successor
+		fakeID := uuid.New()
+		err := reg.DeprecateInstrument(ctx, "NOSUCC", 1, &fakeID)
+		require.ErrorIs(t, err, registry.ErrSuccessorInvalid)
+	})
+
+	t.Run("deprecate with DRAFT successor fails", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "DRAFTSUCC1",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateInstrument(ctx, "DRAFTSUCC1", 1))
+
+		// Create successor but keep in DRAFT
+		successor := &registry.InstrumentDefinition{
+			Code:      "DRAFTSUCC2",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, successor))
+		// NOT activated - still DRAFT
+
+		err := reg.DeprecateInstrument(ctx, "DRAFTSUCC1", 1, &successor.ID)
+		require.ErrorIs(t, err, registry.ErrSuccessorInvalid)
+	})
+
+	t.Run("deprecate with different dimension successor fails", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "DIMTEST1",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateInstrument(ctx, "DIMTEST1", 1))
+
+		// Create successor with different dimension
+		successor := &registry.InstrumentDefinition{
+			Code:      "DIMTEST2",
+			Version:   1,
+			Dimension: registry.DimensionEnergy, // Different dimension!
+			Precision: 3,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, successor))
+		require.NoError(t, reg.ActivateInstrument(ctx, "DIMTEST2", 1))
+
+		err := reg.DeprecateInstrument(ctx, "DIMTEST1", 1, &successor.ID)
+		require.ErrorIs(t, err, registry.ErrSuccessorInvalid)
+	})
+
+	t.Run("deprecate with self as successor fails", func(t *testing.T) {
+		def := &registry.InstrumentDefinition{
+			Code:      "SELFREF",
+			Version:   1,
+			Dimension: registry.DimensionMonetary,
+			Precision: 2,
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateInstrument(ctx, "SELFREF", 1))
+
+		// Try to set self as successor
+		err := reg.DeprecateInstrument(ctx, "SELFREF", 1, &def.ID)
+		require.ErrorIs(t, err, registry.ErrSuccessorInvalid)
+	})
+}
+
+func TestPostgresRegistry_SuccessorWriteOnce(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-writeonce")
+
+	// Create old instrument and two potential successors
+	oldDef := &registry.InstrumentDefinition{
+		Code:      "WRITEONCE_OLD",
+		Version:   1,
+		Dimension: registry.DimensionMonetary,
+		Precision: 2,
+	}
+	require.NoError(t, reg.CreateDraft(ctx, oldDef))
+	require.NoError(t, reg.ActivateInstrument(ctx, "WRITEONCE_OLD", 1))
+
+	successor1 := &registry.InstrumentDefinition{
+		Code:      "WRITEONCE_NEW1",
+		Version:   1,
+		Dimension: registry.DimensionMonetary,
+		Precision: 2,
+	}
+	require.NoError(t, reg.CreateDraft(ctx, successor1))
+	require.NoError(t, reg.ActivateInstrument(ctx, "WRITEONCE_NEW1", 1))
+
+	successor2 := &registry.InstrumentDefinition{
+		Code:      "WRITEONCE_NEW2",
+		Version:   1,
+		Dimension: registry.DimensionMonetary,
+		Precision: 2,
+	}
+	require.NoError(t, reg.CreateDraft(ctx, successor2))
+	require.NoError(t, reg.ActivateInstrument(ctx, "WRITEONCE_NEW2", 1))
+
+	t.Run("cannot change successor_id once set", func(t *testing.T) {
+		// Deprecate with first successor
+		err := reg.DeprecateInstrument(ctx, "WRITEONCE_OLD", 1, &successor1.ID)
+		require.NoError(t, err)
+
+		// Verify successor was set
+		result, err := reg.GetDefinition(ctx, "WRITEONCE_OLD", 1)
+		require.NoError(t, err)
+		assert.Equal(t, successor1.ID, *result.SuccessorID)
+
+		// Try to change successor - this should fail via trigger
+		// We need to attempt an UPDATE directly since the API doesn't expose this
+		// The trigger should reject this attempt
+		tenantID, _ := tenant.FromContext(ctx)
+		schemaName := tenantID.SchemaName()
+
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx, `UPDATE instrument_definition SET successor_id = $1 WHERE code = 'WRITEONCE_OLD' AND version = 1`, successor2.ID)
+		// Should fail due to write-once trigger
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "write-once")
+
+		_ = tx.Rollback(ctx)
+	})
+}

--- a/services/reference-data/registry/postgres_registry_test.go
+++ b/services/reference-data/registry/postgres_registry_test.go
@@ -284,7 +284,7 @@ func TestPostgresRegistry_SystemInstrumentProtection(t *testing.T) {
 	})
 
 	t.Run("DeprecateInstrument rejects system instrument", func(t *testing.T) {
-		err := reg.DeprecateInstrument(ctx, "GBP", 1)
+		err := reg.DeprecateInstrument(ctx, "GBP", 1, nil)
 		require.ErrorIs(t, err, registry.ErrSystemInstrumentReadOnly)
 	})
 
@@ -330,7 +330,7 @@ func TestPostgresRegistry_LifecycleTransitions(t *testing.T) {
 		require.NoError(t, reg.CreateDraft(ctx, def))
 		require.NoError(t, reg.ActivateInstrument(ctx, "LIFECYCLE2", 1))
 
-		err := reg.DeprecateInstrument(ctx, "LIFECYCLE2", 1)
+		err := reg.DeprecateInstrument(ctx, "LIFECYCLE2", 1, nil)
 		require.NoError(t, err)
 
 		// Verify status changed
@@ -363,7 +363,7 @@ func TestPostgresRegistry_LifecycleTransitions(t *testing.T) {
 		}
 		require.NoError(t, reg.CreateDraft(ctx, def))
 
-		err := reg.DeprecateInstrument(ctx, "LIFECYCLE4", 1)
+		err := reg.DeprecateInstrument(ctx, "LIFECYCLE4", 1, nil)
 		require.ErrorIs(t, err, registry.ErrNotActive)
 	})
 }

--- a/services/reference-data/registry/registry.go
+++ b/services/reference-data/registry/registry.go
@@ -73,8 +73,8 @@ var (
 	ErrAlreadyExists = errors.New("instrument with this code and version already exists")
 
 	// ErrSuccessorInvalid is returned when the specified successor instrument is invalid.
-	// A valid successor must exist and be in ACTIVE status.
-	ErrSuccessorInvalid = errors.New("successor instrument is invalid: must exist and be ACTIVE")
+	// A valid successor must exist, be in ACTIVE status, have the same dimension, and not be self-referential.
+	ErrSuccessorInvalid = errors.New("successor instrument is invalid: must exist, be ACTIVE, have same dimension, and not be self-referential")
 )
 
 // InstrumentDefinition represents a measurement unit, currency, or asset type

--- a/services/reference-data/registry/registry.go
+++ b/services/reference-data/registry/registry.go
@@ -71,6 +71,10 @@ var (
 
 	// ErrAlreadyExists is returned when creating an instrument with existing code+version.
 	ErrAlreadyExists = errors.New("instrument with this code and version already exists")
+
+	// ErrSuccessorInvalid is returned when the specified successor instrument is invalid.
+	// A valid successor must exist and be in ACTIVE status.
+	ErrSuccessorInvalid = errors.New("successor instrument is invalid: must exist and be ACTIVE")
 )
 
 // InstrumentDefinition represents a measurement unit, currency, or asset type
@@ -136,6 +140,12 @@ type InstrumentDefinition struct {
 
 	// DeprecatedAt is when this definition transitioned to DEPRECATED (nil if not deprecated).
 	DeprecatedAt *time.Time
+
+	// SuccessorID is the UUID of the instrument that replaces this one when deprecated.
+	// This creates a forward lineage chain: when querying a deprecated instrument,
+	// clients can follow SuccessorID to find the current replacement.
+	// Only set when Status is DEPRECATED. Nil if no successor designated.
+	SuccessorID *uuid.UUID
 }
 
 // AttributeBag represents the input data for CEL validation.
@@ -201,8 +211,10 @@ type InstrumentRegistry interface {
 	// DeprecateInstrument transitions an instrument from ACTIVE to DEPRECATED.
 	// Returns ErrSystemInstrumentReadOnly if the instrument has is_system=true.
 	// Returns ErrNotActive if not currently in ACTIVE status.
+	// Returns ErrSuccessorInvalid if successorID is provided but refers to an invalid instrument.
 	// Instruments in DEPRECATED status remain valid for existing positions but are not used for new ones.
-	DeprecateInstrument(ctx context.Context, code string, version int) error
+	// The successorID optionally points to the replacement instrument (must be ACTIVE with same dimension).
+	DeprecateInstrument(ctx context.Context, code string, version int, successorID *uuid.UUID) error
 
 	// ValidateAttributes executes the CEL validation expression against the provided attributes.
 	// Returns ValidationResult indicating whether the attributes are valid.


### PR DESCRIPTION
## Summary

Add successor_id field to instrument_definition table enabling explicit 1-to-1 asset lineage chains when deprecating instruments. When an instrument is deprecated, it can optionally point to its successor (replacement) instrument, creating a traversable forward lineage chain.

## Changes Made

- **Database migration**: Add `successor_id` column with self-referential FK constraint
- **Lifecycle trigger**: Update to validate successor on deprecation (must exist, be ACTIVE, same dimension)
- **Write-once semantics**: Prevent modification of successor_id after initial setting
- **Proto schema**: Add `successor_id` field to `InstrumentDefinition` and `DeprecateInstrumentRequest`
- **gRPC handler**: Support optional successor_id parameter on DeprecateInstrument RPC
- **ADR-0022**: Document the lineage architecture and design decisions

## Technical Details

### Lineage Chain Example
```
USD_V1 (DEPRECATED) → successor_id → USD_V2 (ACTIVE)
```

### Validation Rules (Enforced by DB Trigger)
- Successor must exist in the same tenant schema
- Successor must be in ACTIVE status
- Successor must have the same dimension as the deprecated instrument
- Once set, successor_id cannot be changed (write-once)

## Testing

- All existing migration tests pass
- Handler tests updated for new DeprecateInstrument signature
- Repository tests updated to include successor_id in queries

## Task Master

- Tag: `universal-asset-system`
- Task: `33` - Add Successor ID Field and Asset Lineage Support