### PR TITLE
feat(cache): implement Redis L2 cache for cold start resilience

### DIFF
--- a/services/reference-data/cache/event_subscriber.go
+++ b/services/reference-data/cache/event_subscriber.go
@@ -23,16 +23,38 @@ type InstrumentUpdatedEvent struct {
 	Version int
 }
 
+// Invalidator defines the interface for cache invalidation operations.
+// Both InstrumentCache (L1 only) and TieredInstrumentCache (L1+L2) implement
+// this interface, allowing the EventSubscriber to work with either.
+type Invalidator interface {
+	// InvalidateCode removes all versions of an instrument code from the cache.
+	// For tiered caches, this propagates to all cache layers (L1 and L2).
+	InvalidateCode(ctx context.Context, code string)
+}
+
+// Verify that our cache implementations satisfy the Invalidator interface.
+var (
+	_ Invalidator = (*InstrumentCache)(nil)
+	_ Invalidator = (*TieredInstrumentCache)(nil)
+)
+
 // EventSubscriber handles Kafka events for distributed cache invalidation.
 // The actual Kafka subscription is wired up by the service layer - this
 // component provides the handler interface.
+//
+// When configured with a TieredInstrumentCache, invalidation events will
+// propagate to both L1 (in-memory) and L2 (Redis) cache layers.
 type EventSubscriber struct {
-	cache *InstrumentCache
+	cache Invalidator
 }
 
 // NewEventSubscriber creates a new EventSubscriber that will invalidate
 // cache entries when instrument update events are received.
-func NewEventSubscriber(cache *InstrumentCache) *EventSubscriber {
+//
+// The cache parameter can be either:
+// - *InstrumentCache for L1-only invalidation
+// - *TieredInstrumentCache for dual-layer (L1+L2) invalidation
+func NewEventSubscriber(cache Invalidator) *EventSubscriber {
 	return &EventSubscriber{
 		cache: cache,
 	}

--- a/services/reference-data/cache/event_subscriber_test.go
+++ b/services/reference-data/cache/event_subscriber_test.go
@@ -3,6 +3,8 @@ package cache
 import (
 	"testing"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -144,4 +146,180 @@ func TestNewEventSubscriber(t *testing.T) {
 
 	assert.NotNil(t, subscriber)
 	assert.NotNil(t, subscriber.cache)
+}
+
+// TestEventSubscriber_WithTieredCache_InvalidatesBothL1AndL2 tests that when
+// the EventSubscriber is configured with a TieredInstrumentCache, invalidation
+// events propagate to both L1 (in-memory) and L2 (Redis) cache layers.
+func TestEventSubscriber_WithTieredCache_InvalidatesBothL1AndL2(t *testing.T) {
+	// Setup miniredis for L2
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	l1 := NewInstrumentCache()
+	l2, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	source := newMockSource()
+	tiered := NewTieredInstrumentCache(l1, l2, source, nil)
+
+	// Create subscriber with tiered cache
+	subscriber := NewEventSubscriber(tiered)
+
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate source with multiple versions
+	source.addDefinition("tenant1", newTieredTestDefinition("USD", 1))
+	source.addDefinition("tenant1", newTieredTestDefinition("USD", 2))
+	source.addDefinition("tenant1", newTieredTestDefinition("EUR", 1))
+
+	// Load into both caches via tiered.Get
+	for _, code := range []string{"USD", "EUR"} {
+		for v := 1; v <= 2; v++ {
+			if code == "EUR" && v == 2 {
+				continue // EUR only has v1
+			}
+			_, err := tiered.Get(ctx, code, v)
+			require.NoError(t, err)
+		}
+	}
+
+	// Verify L1 has all entries
+	require.NotNil(t, l1.Get(ctx, "USD", 1), "L1 should have USD v1")
+	require.NotNil(t, l1.Get(ctx, "USD", 2), "L1 should have USD v2")
+	require.NotNil(t, l1.Get(ctx, "EUR", 1), "L1 should have EUR v1")
+
+	// Verify L2 has all entries
+	require.NotNil(t, l2.Get(ctx, "USD", 1), "L2 should have USD v1")
+	require.NotNil(t, l2.Get(ctx, "USD", 2), "L2 should have USD v2")
+	require.NotNil(t, l2.Get(ctx, "EUR", 1), "L2 should have EUR v1")
+
+	// Handle update event for USD
+	event := InstrumentUpdatedEvent{
+		TenantID: "tenant1",
+		Code:     "USD",
+		Version:  1,
+	}
+	subscriber.HandleInstrumentUpdated(event)
+
+	// All USD versions should be invalidated from BOTH L1 and L2
+	assert.Nil(t, l1.Get(ctx, "USD", 1), "L1 should not have USD v1 after invalidation")
+	assert.Nil(t, l1.Get(ctx, "USD", 2), "L1 should not have USD v2 after invalidation")
+	assert.Nil(t, l2.Get(ctx, "USD", 1), "L2 should not have USD v1 after invalidation")
+	assert.Nil(t, l2.Get(ctx, "USD", 2), "L2 should not have USD v2 after invalidation")
+
+	// EUR should still be cached in both tiers
+	assert.NotNil(t, l1.Get(ctx, "EUR", 1), "L1 should still have EUR v1")
+	assert.NotNil(t, l2.Get(ctx, "EUR", 1), "L2 should still have EUR v1")
+}
+
+// TestEventSubscriber_WithTieredCache_TenantIsolation tests that invalidation
+// events for one tenant do not affect another tenant's cached data in either
+// L1 or L2 cache layers.
+func TestEventSubscriber_WithTieredCache_TenantIsolation(t *testing.T) {
+	// Setup miniredis for L2
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	l1 := NewInstrumentCache()
+	l2, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	source := newMockSource()
+	tiered := NewTieredInstrumentCache(l1, l2, source, nil)
+
+	subscriber := NewEventSubscriber(tiered)
+
+	ctxA := newTestContext("tenantA")
+	ctxB := newTestContext("tenantB")
+
+	// Pre-populate source for both tenants
+	source.addDefinition("tenantA", newTieredTestDefinition("USD", 1))
+	source.addDefinition("tenantB", newTieredTestDefinition("USD", 1))
+
+	// Load into caches for both tenants
+	_, err = tiered.Get(ctxA, "USD", 1)
+	require.NoError(t, err)
+	_, err = tiered.Get(ctxB, "USD", 1)
+	require.NoError(t, err)
+
+	// Verify both tenants have data in L1 and L2
+	require.NotNil(t, l1.Get(ctxA, "USD", 1))
+	require.NotNil(t, l1.Get(ctxB, "USD", 1))
+	require.NotNil(t, l2.Get(ctxA, "USD", 1))
+	require.NotNil(t, l2.Get(ctxB, "USD", 1))
+
+	// Handle update event for tenantA only
+	event := InstrumentUpdatedEvent{
+		TenantID: "tenantA",
+		Code:     "USD",
+		Version:  1,
+	}
+	subscriber.HandleInstrumentUpdated(event)
+
+	// TenantA's data should be invalidated from both L1 and L2
+	assert.Nil(t, l1.Get(ctxA, "USD", 1), "tenantA L1 should be invalidated")
+	assert.Nil(t, l2.Get(ctxA, "USD", 1), "tenantA L2 should be invalidated")
+
+	// TenantB's data should be unaffected in both L1 and L2
+	assert.NotNil(t, l1.Get(ctxB, "USD", 1), "tenantB L1 should not be affected")
+	assert.NotNil(t, l2.Get(ctxB, "USD", 1), "tenantB L2 should not be affected")
+}
+
+// TestEventSubscriber_AcceptsBothCacheTypes verifies that the EventSubscriber
+// can be constructed with either an InstrumentCache (L1 only) or a
+// TieredInstrumentCache (L1+L2).
+func TestEventSubscriber_AcceptsBothCacheTypes(t *testing.T) {
+	t.Run("with InstrumentCache (L1 only)", func(t *testing.T) {
+		l1 := NewInstrumentCache()
+		subscriber := NewEventSubscriber(l1)
+		require.NotNil(t, subscriber)
+
+		// Should work without panicking
+		ctx := newTestContext("tenant1")
+		l1.Put(ctx, "USD", 1, newTestInstrument("USD", 1))
+		require.NotNil(t, l1.Get(ctx, "USD", 1))
+
+		subscriber.HandleInstrumentUpdated(InstrumentUpdatedEvent{
+			TenantID: "tenant1",
+			Code:     "USD",
+			Version:  1,
+		})
+		assert.Nil(t, l1.Get(ctx, "USD", 1))
+	})
+
+	t.Run("with TieredInstrumentCache (L1+L2)", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		defer client.Close()
+
+		l1 := NewInstrumentCache()
+		l2, err := NewRedisL2Cache(client)
+		require.NoError(t, err)
+
+		source := newMockSource()
+		source.addDefinition("tenant1", newTieredTestDefinition("USD", 1))
+
+		tiered := NewTieredInstrumentCache(l1, l2, source, nil)
+		subscriber := NewEventSubscriber(tiered)
+		require.NotNil(t, subscriber)
+
+		// Load data into both caches
+		ctx := newTestContext("tenant1")
+		_, err = tiered.Get(ctx, "USD", 1)
+		require.NoError(t, err)
+		require.NotNil(t, l1.Get(ctx, "USD", 1))
+		require.NotNil(t, l2.Get(ctx, "USD", 1))
+
+		// Invalidate should clear both
+		subscriber.HandleInstrumentUpdated(InstrumentUpdatedEvent{
+			TenantID: "tenant1",
+			Code:     "USD",
+			Version:  1,
+		})
+		assert.Nil(t, l1.Get(ctx, "USD", 1))
+		assert.Nil(t, l2.Get(ctx, "USD", 1))
+	})
 }

--- a/services/reference-data/cache/redis_cache.go
+++ b/services/reference-data/cache/redis_cache.go
@@ -1,0 +1,416 @@
+// Package cache provides caching infrastructure for instrument definitions
+// with tenant isolation and TTL-based expiration.
+package cache
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Default Redis L2 cache configuration values.
+const (
+	// DefaultRedisL2TTL is the base TTL for L2 cache entries (1 hour).
+	DefaultRedisL2TTL = 1 * time.Hour
+
+	// DefaultRedisL2TTLJitter is the maximum random variation added to TTL.
+	// This prevents thundering herd when many entries expire simultaneously.
+	DefaultRedisL2TTLJitter = 5 * time.Minute
+
+	// DefaultRedisKeyPrefix is the default key prefix for instrument cache entries.
+	DefaultRedisKeyPrefix = "refdata"
+)
+
+// ErrRedisClientRequired is returned when Redis client is nil.
+var ErrRedisClientRequired = errors.New("redis client is required")
+
+// RedisL2CacheConfig holds configuration for the Redis L2 cache.
+type RedisL2CacheConfig struct {
+	// KeyPrefix is the prefix for all Redis keys (default: "refdata").
+	KeyPrefix string
+
+	// BaseTTL is the base TTL for cached entries (default: 1 hour).
+	BaseTTL time.Duration
+
+	// TTLJitter is the maximum random variation added to TTL (default: 5 min).
+	TTLJitter time.Duration
+}
+
+// RedisL2CacheOption configures a RedisL2Cache.
+type RedisL2CacheOption func(*RedisL2Cache)
+
+// WithRedisKeyPrefix sets the key prefix for Redis keys.
+func WithRedisKeyPrefix(prefix string) RedisL2CacheOption {
+	return func(c *RedisL2Cache) {
+		c.keyPrefix = prefix
+	}
+}
+
+// WithRedisL2TTL sets the base TTL and jitter for L2 cache entries.
+func WithRedisL2TTL(baseTTL, jitter time.Duration) RedisL2CacheOption {
+	return func(c *RedisL2Cache) {
+		c.baseTTL = baseTTL
+		c.ttlJitter = jitter
+	}
+}
+
+// RedisL2Cache provides Redis-based L2 caching for instrument definitions.
+// It stores proto-serialized InstrumentDefinition objects with tenant-scoped keys.
+//
+// Key format: {keyPrefix}:instrument:{tenantID}:{code}:{version}
+//
+// Thread-safety: All methods are safe for concurrent use.
+type RedisL2Cache struct {
+	// client is the Redis client for cache operations.
+	client redis.Cmdable
+
+	// keyPrefix is the prefix for all Redis keys.
+	keyPrefix string
+
+	// baseTTL is the base time-to-live for cache entries.
+	baseTTL time.Duration
+
+	// ttlJitter is the maximum random variation added to TTL.
+	ttlJitter time.Duration
+}
+
+// NewRedisL2Cache creates a new Redis L2 cache.
+// The client can be *redis.Client, *redis.ClusterClient, or any redis.Cmdable.
+func NewRedisL2Cache(client redis.Cmdable, opts ...RedisL2CacheOption) (*RedisL2Cache, error) {
+	if client == nil {
+		return nil, ErrRedisClientRequired
+	}
+
+	c := &RedisL2Cache{
+		client:    client,
+		keyPrefix: DefaultRedisKeyPrefix,
+		baseTTL:   DefaultRedisL2TTL,
+		ttlJitter: DefaultRedisL2TTLJitter,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c, nil
+}
+
+// Get retrieves an instrument definition from the L2 cache.
+// Returns nil if the entry is not found or tenant context is missing.
+// This method does NOT return errors on cache miss - only nil.
+func (c *RedisL2Cache) Get(ctx context.Context, code string, version int) *registry.InstrumentDefinition {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	key := c.instrumentKey(tenantID, code, version)
+	data, err := c.client.Get(ctx, key).Bytes()
+	if err != nil {
+		// Both redis.Nil (not found) and actual errors return nil
+		// L2 cache misses are expected and should not propagate errors
+		return nil
+	}
+
+	// Deserialize protobuf
+	var pbInstrument referencedatav1.InstrumentDefinition
+	if err := proto.Unmarshal(data, &pbInstrument); err != nil {
+		// Corrupted data - treat as cache miss
+		// Optionally, we could delete the corrupted entry here
+		return nil
+	}
+
+	// Convert protobuf to domain model
+	return fromProto(&pbInstrument)
+}
+
+// Put stores an instrument definition in the L2 cache.
+// Does nothing if tenant context is missing.
+func (c *RedisL2Cache) Put(ctx context.Context, code string, version int, def *registry.InstrumentDefinition) {
+	if def == nil {
+		return
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	// Convert to protobuf
+	pbInstrument := toProto(def)
+
+	// Serialize protobuf
+	data, err := proto.Marshal(pbInstrument)
+	if err != nil {
+		// Serialization failure - log and continue (cache miss is acceptable)
+		return
+	}
+
+	key := c.instrumentKey(tenantID, code, version)
+	ttl := c.jitteredTTL()
+
+	// Store with TTL - ignore errors (cache failures shouldn't break the application)
+	_ = c.client.Set(ctx, key, data, ttl).Err()
+}
+
+// Invalidate removes a specific entry from the L2 cache.
+func (c *RedisL2Cache) Invalidate(ctx context.Context, code string, version int) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	key := c.instrumentKey(tenantID, code, version)
+	_ = c.client.Del(ctx, key).Err()
+}
+
+// InvalidateCode removes all versions of an instrument code for the tenant.
+// Uses pattern matching with SCAN to find and delete all matching keys.
+func (c *RedisL2Cache) InvalidateCode(ctx context.Context, code string) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	// Pattern to match all versions: {prefix}:instrument:{tenantID}:{code}:*
+	pattern := c.instrumentKeyPattern(tenantID, code)
+
+	// Use SCAN to find matching keys (safer than KEYS for production)
+	var cursor uint64
+	for {
+		keys, nextCursor, err := c.client.Scan(ctx, cursor, pattern, 100).Result()
+		if err != nil {
+			return // Best effort invalidation
+		}
+
+		if len(keys) > 0 {
+			_ = c.client.Del(ctx, keys...).Err()
+		}
+
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+}
+
+// InvalidateAll removes all instrument cache entries for the tenant.
+// Uses pattern matching with SCAN to find and delete all matching keys.
+func (c *RedisL2Cache) InvalidateAll(ctx context.Context) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	// Pattern to match all tenant entries: {prefix}:instrument:{tenantID}:*
+	pattern := c.tenantKeyPattern(tenantID)
+
+	// Use SCAN to find matching keys
+	var cursor uint64
+	for {
+		keys, nextCursor, err := c.client.Scan(ctx, cursor, pattern, 100).Result()
+		if err != nil {
+			return // Best effort invalidation
+		}
+
+		if len(keys) > 0 {
+			_ = c.client.Del(ctx, keys...).Err()
+		}
+
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+}
+
+// instrumentKey generates the Redis key for a specific instrument.
+// Format: {keyPrefix}:instrument:{tenantID}:{code}:{version}
+func (c *RedisL2Cache) instrumentKey(tenantID tenant.TenantID, code string, version int) string {
+	return fmt.Sprintf("%s:instrument:%s:%s:%d", c.keyPrefix, tenantID, code, version)
+}
+
+// instrumentKeyPattern generates a pattern to match all versions of an instrument.
+// Format: {keyPrefix}:instrument:{tenantID}:{code}:*
+func (c *RedisL2Cache) instrumentKeyPattern(tenantID tenant.TenantID, code string) string {
+	return fmt.Sprintf("%s:instrument:%s:%s:*", c.keyPrefix, tenantID, code)
+}
+
+// tenantKeyPattern generates a pattern to match all instruments for a tenant.
+// Format: {keyPrefix}:instrument:{tenantID}:*
+func (c *RedisL2Cache) tenantKeyPattern(tenantID tenant.TenantID) string {
+	return fmt.Sprintf("%s:instrument:%s:*", c.keyPrefix, tenantID)
+}
+
+// jitteredTTL returns the base TTL plus a random jitter.
+// The jitter helps prevent thundering herd when many entries expire.
+func (c *RedisL2Cache) jitteredTTL() time.Duration {
+	if c.ttlJitter == 0 {
+		return c.baseTTL
+	}
+
+	// Generate random jitter in range [-ttlJitter, +ttlJitter]
+	jitterRange := int64(c.ttlJitter) * 2
+	jitter := rand.Int64N(jitterRange) - int64(c.ttlJitter)
+
+	return c.baseTTL + time.Duration(jitter)
+}
+
+// toProto converts InstrumentDefinition to protobuf.
+func toProto(def *registry.InstrumentDefinition) *referencedatav1.InstrumentDefinition {
+	pb := &referencedatav1.InstrumentDefinition{
+		Id:                       def.ID.String(),
+		Code:                     def.Code,
+		Version:                  int32(def.Version),
+		Dimension:                dimensionToProto(def.Dimension),
+		Precision:                int32(def.Precision),
+		Status:                   statusToProto(def.Status),
+		IsSystem:                 def.IsSystem,
+		ValidationExpression:     def.ValidationExpression,
+		FungibilityKeyExpression: def.FungibilityKeyExpression,
+		ErrorMessageExpression:   def.ErrorMessageExpression,
+		AttributeSchema:          string(def.AttributeSchema),
+		DisplayName:              def.DisplayName,
+		Description:              def.Description,
+		CreatedAt:                timestamppb.New(def.CreatedAt),
+	}
+
+	if def.ActivatedAt != nil {
+		pb.ActivatedAt = timestamppb.New(*def.ActivatedAt)
+	}
+
+	if def.DeprecatedAt != nil {
+		pb.DeprecatedAt = timestamppb.New(*def.DeprecatedAt)
+	}
+
+	return pb
+}
+
+// fromProto converts protobuf to InstrumentDefinition.
+func fromProto(pb *referencedatav1.InstrumentDefinition) *registry.InstrumentDefinition {
+	def := &registry.InstrumentDefinition{
+		Code:                     pb.Code,
+		Version:                  int(pb.Version),
+		Dimension:                dimensionFromProto(pb.Dimension),
+		Precision:                int(pb.Precision),
+		Status:                   statusFromProto(pb.Status),
+		IsSystem:                 pb.IsSystem,
+		ValidationExpression:     pb.ValidationExpression,
+		FungibilityKeyExpression: pb.FungibilityKeyExpression,
+		ErrorMessageExpression:   pb.ErrorMessageExpression,
+		AttributeSchema:          []byte(pb.AttributeSchema),
+		DisplayName:              pb.DisplayName,
+		Description:              pb.Description,
+	}
+
+	// Parse UUID
+	if id, err := uuid.Parse(pb.Id); err == nil {
+		def.ID = id
+	}
+
+	// Parse timestamps
+	if pb.CreatedAt != nil {
+		def.CreatedAt = pb.CreatedAt.AsTime()
+	}
+
+	if pb.ActivatedAt != nil {
+		t := pb.ActivatedAt.AsTime()
+		def.ActivatedAt = &t
+	}
+
+	if pb.DeprecatedAt != nil {
+		t := pb.DeprecatedAt.AsTime()
+		def.DeprecatedAt = &t
+	}
+
+	return def
+}
+
+// dimensionToProto converts domain Dimension to protobuf Dimension.
+func dimensionToProto(d registry.Dimension) referencedatav1.Dimension {
+	switch d {
+	case registry.DimensionMonetary:
+		return referencedatav1.Dimension_DIMENSION_CURRENCY
+	case registry.DimensionEnergy:
+		return referencedatav1.Dimension_DIMENSION_ENERGY
+	case registry.DimensionMass:
+		return referencedatav1.Dimension_DIMENSION_MASS
+	case registry.DimensionVolume:
+		return referencedatav1.Dimension_DIMENSION_VOLUME
+	case registry.DimensionTime:
+		return referencedatav1.Dimension_DIMENSION_TIME
+	case registry.DimensionCompute:
+		return referencedatav1.Dimension_DIMENSION_COMPUTE
+	case registry.DimensionQuantity:
+		return referencedatav1.Dimension_DIMENSION_COUNT
+	default:
+		return referencedatav1.Dimension_DIMENSION_UNSPECIFIED
+	}
+}
+
+// dimensionFromProto converts protobuf Dimension to domain Dimension.
+func dimensionFromProto(d referencedatav1.Dimension) registry.Dimension {
+	switch d {
+	case referencedatav1.Dimension_DIMENSION_CURRENCY:
+		return registry.DimensionMonetary
+	case referencedatav1.Dimension_DIMENSION_ENERGY:
+		return registry.DimensionEnergy
+	case referencedatav1.Dimension_DIMENSION_MASS:
+		return registry.DimensionMass
+	case referencedatav1.Dimension_DIMENSION_VOLUME:
+		return registry.DimensionVolume
+	case referencedatav1.Dimension_DIMENSION_TIME:
+		return registry.DimensionTime
+	case referencedatav1.Dimension_DIMENSION_COMPUTE:
+		return registry.DimensionCompute
+	case referencedatav1.Dimension_DIMENSION_COUNT:
+		return registry.DimensionQuantity
+	case referencedatav1.Dimension_DIMENSION_UNSPECIFIED,
+		referencedatav1.Dimension_DIMENSION_CARBON,
+		referencedatav1.Dimension_DIMENSION_DATA:
+		return ""
+	default:
+		return ""
+	}
+}
+
+// statusToProto converts domain Status to protobuf InstrumentStatus.
+func statusToProto(s registry.Status) referencedatav1.InstrumentStatus {
+	switch s {
+	case registry.StatusDraft:
+		return referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_DRAFT
+	case registry.StatusActive:
+		return referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE
+	case registry.StatusDeprecated:
+		return referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_DEPRECATED
+	default:
+		return referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_UNSPECIFIED
+	}
+}
+
+// statusFromProto converts protobuf InstrumentStatus to domain Status.
+func statusFromProto(s referencedatav1.InstrumentStatus) registry.Status {
+	switch s {
+	case referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_DRAFT:
+		return registry.StatusDraft
+	case referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE:
+		return registry.StatusActive
+	case referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_DEPRECATED:
+		return registry.StatusDeprecated
+	case referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_UNSPECIFIED:
+		return ""
+	default:
+		return ""
+	}
+}

--- a/services/reference-data/cache/redis_cache.go
+++ b/services/reference-data/cache/redis_cache.go
@@ -35,18 +35,6 @@ const (
 // ErrRedisClientRequired is returned when Redis client is nil.
 var ErrRedisClientRequired = errors.New("redis client is required")
 
-// RedisL2CacheConfig holds configuration for the Redis L2 cache.
-type RedisL2CacheConfig struct {
-	// KeyPrefix is the prefix for all Redis keys (default: "refdata").
-	KeyPrefix string
-
-	// BaseTTL is the base TTL for cached entries (default: 1 hour).
-	BaseTTL time.Duration
-
-	// TTLJitter is the maximum random variation added to TTL (default: 5 min).
-	TTLJitter time.Duration
-}
-
 // RedisL2CacheOption configures a RedisL2Cache.
 type RedisL2CacheOption func(*RedisL2Cache)
 
@@ -177,6 +165,7 @@ func (c *RedisL2Cache) Invalidate(ctx context.Context, code string, version int)
 
 // InvalidateCode removes all versions of an instrument code for the tenant.
 // Uses pattern matching with SCAN to find and delete all matching keys.
+// Uses UNLINK instead of DEL for non-blocking deletion.
 func (c *RedisL2Cache) InvalidateCode(ctx context.Context, code string) {
 	tenantID, ok := tenant.FromContext(ctx)
 	if !ok {
@@ -195,7 +184,8 @@ func (c *RedisL2Cache) InvalidateCode(ctx context.Context, code string) {
 		}
 
 		if len(keys) > 0 {
-			_ = c.client.Del(ctx, keys...).Err()
+			// Use UNLINK for non-blocking deletion (Redis 4.0+)
+			_ = c.client.Unlink(ctx, keys...).Err()
 		}
 
 		cursor = nextCursor
@@ -207,6 +197,7 @@ func (c *RedisL2Cache) InvalidateCode(ctx context.Context, code string) {
 
 // InvalidateAll removes all instrument cache entries for the tenant.
 // Uses pattern matching with SCAN to find and delete all matching keys.
+// Uses UNLINK instead of DEL for non-blocking deletion.
 func (c *RedisL2Cache) InvalidateAll(ctx context.Context) {
 	tenantID, ok := tenant.FromContext(ctx)
 	if !ok {
@@ -225,7 +216,8 @@ func (c *RedisL2Cache) InvalidateAll(ctx context.Context) {
 		}
 
 		if len(keys) > 0 {
-			_ = c.client.Del(ctx, keys...).Err()
+			// Use UNLINK for non-blocking deletion (Redis 4.0+)
+			_ = c.client.Unlink(ctx, keys...).Err()
 		}
 
 		cursor = nextCursor

--- a/services/reference-data/cache/redis_cache_test.go
+++ b/services/reference-data/cache/redis_cache_test.go
@@ -1,0 +1,630 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// setupMiniRedis creates a miniredis server and returns a connected client.
+func setupMiniRedis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	return mr, client
+}
+
+// newTestDefinitionWithDetails creates a test InstrumentDefinition with additional fields.
+func newTestDefinitionWithDetails(code string, version int) *registry.InstrumentDefinition {
+	return &registry.InstrumentDefinition{
+		ID:                       uuid.New(),
+		Code:                     code,
+		Version:                  version,
+		Dimension:                registry.DimensionMonetary,
+		Precision:                2,
+		Status:                   registry.StatusActive,
+		ValidationExpression:     "amount > 0",
+		FungibilityKeyExpression: "instrument_code",
+		DisplayName:              code + " Display",
+		Description:              "Test instrument " + code,
+		CreatedAt:                time.Now(),
+	}
+}
+
+func TestRedisL2Cache_NewRedisL2Cache(t *testing.T) {
+	t.Run("success with client", func(t *testing.T) {
+		_, client := setupMiniRedis(t)
+		defer client.Close()
+
+		cache, err := NewRedisL2Cache(client)
+		require.NoError(t, err)
+		assert.NotNil(t, cache)
+	})
+
+	t.Run("error when client is nil", func(t *testing.T) {
+		cache, err := NewRedisL2Cache(nil)
+		require.ErrorIs(t, err, ErrRedisClientRequired)
+		assert.Nil(t, cache)
+	})
+
+	t.Run("applies options", func(t *testing.T) {
+		_, client := setupMiniRedis(t)
+		defer client.Close()
+
+		cache, err := NewRedisL2Cache(client,
+			WithRedisKeyPrefix("custom"),
+			WithRedisL2TTL(2*time.Hour, 10*time.Minute),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "custom", cache.keyPrefix)
+		assert.Equal(t, 2*time.Hour, cache.baseTTL)
+		assert.Equal(t, 10*time.Minute, cache.ttlJitter)
+	})
+}
+
+func TestRedisL2Cache_Get_Hit(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := newTestContext("tenant1")
+	def := newTestDefinitionWithDetails("USD", 1)
+
+	// Put and Get
+	cache.Put(ctx, "USD", 1, def)
+	result := cache.Get(ctx, "USD", 1)
+
+	require.NotNil(t, result)
+	assert.Equal(t, def.Code, result.Code)
+	assert.Equal(t, def.Version, result.Version)
+	assert.Equal(t, def.Dimension, result.Dimension)
+	assert.Equal(t, def.Precision, result.Precision)
+	assert.Equal(t, def.Status, result.Status)
+	assert.Equal(t, def.ValidationExpression, result.ValidationExpression)
+	assert.Equal(t, def.FungibilityKeyExpression, result.FungibilityKeyExpression)
+	assert.Equal(t, def.DisplayName, result.DisplayName)
+	assert.Equal(t, def.Description, result.Description)
+	assert.Equal(t, def.ID, result.ID)
+}
+
+func TestRedisL2Cache_Get_Miss(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := newTestContext("tenant1")
+
+	// Get without Put should return nil
+	result := cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+}
+
+func TestRedisL2Cache_Get_MissingTenant(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := context.Background() // No tenant
+
+	// Should return nil when tenant context is missing
+	result := cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+}
+
+func TestRedisL2Cache_Put_MissingTenant(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := context.Background() // No tenant
+	def := newTestDefinition("USD", 1)
+
+	// Put should be a no-op when tenant context is missing
+	cache.Put(ctx, "USD", 1, def)
+
+	// Verify nothing was cached by trying with a valid tenant
+	validCtx := newTestContext("tenant1")
+	result := cache.Get(validCtx, "USD", 1)
+	assert.Nil(t, result)
+}
+
+func TestRedisL2Cache_Put_NilDefinition(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := newTestContext("tenant1")
+
+	// Put nil should be a no-op
+	cache.Put(ctx, "USD", 1, nil)
+
+	result := cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+}
+
+func TestRedisL2Cache_TenantIsolation(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	// Put entry for tenant1
+	def1 := newTestDefinition("USD", 1)
+	cache.Put(ctx1, "USD", 1, def1)
+
+	// Put different entry for tenant2
+	def2 := newTestDefinition("EUR", 1)
+	cache.Put(ctx2, "EUR", 1, def2)
+
+	// tenant1 should only see USD
+	result1USD := cache.Get(ctx1, "USD", 1)
+	require.NotNil(t, result1USD)
+	assert.Equal(t, "USD", result1USD.Code)
+
+	result1EUR := cache.Get(ctx1, "EUR", 1)
+	assert.Nil(t, result1EUR, "tenant1 should not see tenant2's EUR")
+
+	// tenant2 should only see EUR
+	result2EUR := cache.Get(ctx2, "EUR", 1)
+	require.NotNil(t, result2EUR)
+	assert.Equal(t, "EUR", result2EUR.Code)
+
+	result2USD := cache.Get(ctx2, "USD", 1)
+	assert.Nil(t, result2USD, "tenant2 should not see tenant1's USD")
+}
+
+func TestRedisL2Cache_TTL(t *testing.T) {
+	mr, client := setupMiniRedis(t)
+	defer client.Close()
+
+	// Use short TTL for testing
+	cache, err := NewRedisL2Cache(client,
+		WithRedisL2TTL(100*time.Millisecond, 0), // No jitter
+	)
+	require.NoError(t, err)
+
+	ctx := newTestContext("tenant1")
+	def := newTestDefinition("USD", 1)
+
+	// Put entry
+	cache.Put(ctx, "USD", 1, def)
+
+	// Should be retrievable immediately
+	result := cache.Get(ctx, "USD", 1)
+	require.NotNil(t, result)
+
+	// Fast-forward time in miniredis
+	mr.FastForward(200 * time.Millisecond)
+
+	// Should be expired now
+	result = cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result, "entry should be expired")
+}
+
+func TestRedisL2Cache_Invalidate(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := newTestContext("tenant1")
+	def := newTestDefinition("USD", 1)
+
+	// Put and verify
+	cache.Put(ctx, "USD", 1, def)
+	result := cache.Get(ctx, "USD", 1)
+	require.NotNil(t, result)
+
+	// Invalidate
+	cache.Invalidate(ctx, "USD", 1)
+
+	// Should be gone
+	result = cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+}
+
+func TestRedisL2Cache_Invalidate_MissingTenant(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := context.Background() // No tenant
+	validCtx := newTestContext("tenant1")
+
+	// Put something with valid tenant
+	def := newTestDefinition("USD", 1)
+	cache.Put(validCtx, "USD", 1, def)
+
+	// Invalidate without tenant should be no-op
+	cache.Invalidate(ctx, "USD", 1)
+
+	// Original entry should still exist
+	result := cache.Get(validCtx, "USD", 1)
+	require.NotNil(t, result)
+}
+
+func TestRedisL2Cache_InvalidateCode(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := newTestContext("tenant1")
+
+	// Put multiple versions of the same code
+	for i := 1; i <= 3; i++ {
+		cache.Put(ctx, "USD", i, newTestDefinition("USD", i))
+	}
+	// Put a different code
+	cache.Put(ctx, "EUR", 1, newTestDefinition("EUR", 1))
+
+	// Verify all are cached
+	for i := 1; i <= 3; i++ {
+		assert.NotNil(t, cache.Get(ctx, "USD", i))
+	}
+	assert.NotNil(t, cache.Get(ctx, "EUR", 1))
+
+	// Invalidate all USD versions
+	cache.InvalidateCode(ctx, "USD")
+
+	// All USD versions should be gone
+	for i := 1; i <= 3; i++ {
+		assert.Nil(t, cache.Get(ctx, "USD", i), "USD v%d should be invalidated", i)
+	}
+
+	// EUR should still be cached
+	assert.NotNil(t, cache.Get(ctx, "EUR", 1), "EUR should not be affected")
+}
+
+func TestRedisL2Cache_InvalidateCode_TenantIsolation(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	// Put USD for both tenants
+	cache.Put(ctx1, "USD", 1, newTestDefinition("USD", 1))
+	cache.Put(ctx1, "USD", 2, newTestDefinition("USD", 2))
+	cache.Put(ctx2, "USD", 1, newTestDefinition("USD", 1))
+	cache.Put(ctx2, "USD", 2, newTestDefinition("USD", 2))
+
+	// Invalidate USD for tenant1 only
+	cache.InvalidateCode(ctx1, "USD")
+
+	// tenant1's USD should be gone
+	assert.Nil(t, cache.Get(ctx1, "USD", 1))
+	assert.Nil(t, cache.Get(ctx1, "USD", 2))
+
+	// tenant2's USD should still be cached
+	assert.NotNil(t, cache.Get(ctx2, "USD", 1), "tenant2 USD v1 should not be affected")
+	assert.NotNil(t, cache.Get(ctx2, "USD", 2), "tenant2 USD v2 should not be affected")
+}
+
+func TestRedisL2Cache_InvalidateAll(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := newTestContext("tenant1")
+
+	// Put multiple entries
+	cache.Put(ctx, "USD", 1, newTestDefinition("USD", 1))
+	cache.Put(ctx, "EUR", 1, newTestDefinition("EUR", 1))
+	cache.Put(ctx, "GBP", 1, newTestDefinition("GBP", 1))
+
+	// Verify all are cached
+	assert.NotNil(t, cache.Get(ctx, "USD", 1))
+	assert.NotNil(t, cache.Get(ctx, "EUR", 1))
+	assert.NotNil(t, cache.Get(ctx, "GBP", 1))
+
+	// Invalidate all
+	cache.InvalidateAll(ctx)
+
+	// All should be gone
+	assert.Nil(t, cache.Get(ctx, "USD", 1))
+	assert.Nil(t, cache.Get(ctx, "EUR", 1))
+	assert.Nil(t, cache.Get(ctx, "GBP", 1))
+}
+
+func TestRedisL2Cache_InvalidateAll_TenantIsolation(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	// Put entries for both tenants
+	cache.Put(ctx1, "USD", 1, newTestDefinition("USD", 1))
+	cache.Put(ctx2, "EUR", 1, newTestDefinition("EUR", 1))
+
+	// Invalidate all for tenant1 only
+	cache.InvalidateAll(ctx1)
+
+	// tenant1's cache should be empty
+	assert.Nil(t, cache.Get(ctx1, "USD", 1))
+
+	// tenant2's cache should be unaffected
+	assert.NotNil(t, cache.Get(ctx2, "EUR", 1))
+}
+
+func TestRedisL2Cache_KeyFormat(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client,
+		WithRedisKeyPrefix("testprefix"),
+	)
+	require.NoError(t, err)
+
+	ctx := newTestContext("mytenant")
+	def := newTestDefinition("INSTRUMENT", 42)
+
+	cache.Put(ctx, "INSTRUMENT", 42, def)
+
+	// Verify key format by checking directly in Redis
+	expectedKey := "testprefix:instrument:mytenant:INSTRUMENT:42"
+	exists, err := client.Exists(ctx, expectedKey).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), exists, "expected key format: %s", expectedKey)
+}
+
+func TestRedisL2Cache_ProtoRoundtrip(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := newTestContext("tenant1")
+
+	// Create a fully populated definition
+	activatedAt := time.Now().Add(-24 * time.Hour)
+	def := &registry.InstrumentDefinition{
+		ID:                       uuid.New(),
+		Code:                     "CARBON_CREDIT",
+		Version:                  3,
+		Dimension:                registry.DimensionQuantity,
+		Precision:                4,
+		Status:                   registry.StatusActive,
+		IsSystem:                 true,
+		ValidationExpression:     "amount > 0 && has(attributes.vintage)",
+		FungibilityKeyExpression: "instrument_code + ':' + attributes.vintage",
+		ErrorMessageExpression:   "'Invalid carbon credit amount'",
+		AttributeSchema:          []byte(`{"type":"object","properties":{"vintage":{"type":"string"}}}`),
+		DisplayName:              "Verified Carbon Credit",
+		Description:              "Carbon credit from verified emission reduction projects",
+		CreatedAt:                time.Now(),
+		ActivatedAt:              &activatedAt,
+	}
+
+	// Put and Get
+	cache.Put(ctx, def.Code, def.Version, def)
+	result := cache.Get(ctx, def.Code, def.Version)
+
+	require.NotNil(t, result)
+	assert.Equal(t, def.ID, result.ID)
+	assert.Equal(t, def.Code, result.Code)
+	assert.Equal(t, def.Version, result.Version)
+	assert.Equal(t, def.Dimension, result.Dimension)
+	assert.Equal(t, def.Precision, result.Precision)
+	assert.Equal(t, def.Status, result.Status)
+	assert.Equal(t, def.IsSystem, result.IsSystem)
+	assert.Equal(t, def.ValidationExpression, result.ValidationExpression)
+	assert.Equal(t, def.FungibilityKeyExpression, result.FungibilityKeyExpression)
+	assert.Equal(t, def.ErrorMessageExpression, result.ErrorMessageExpression)
+	assert.Equal(t, def.AttributeSchema, result.AttributeSchema)
+	assert.Equal(t, def.DisplayName, result.DisplayName)
+	assert.Equal(t, def.Description, result.Description)
+
+	// Timestamps may have slight precision differences due to proto conversion
+	assert.WithinDuration(t, def.CreatedAt, result.CreatedAt, time.Millisecond)
+	require.NotNil(t, result.ActivatedAt)
+	assert.WithinDuration(t, *def.ActivatedAt, *result.ActivatedAt, time.Millisecond)
+}
+
+func TestRedisL2Cache_DimensionConversions(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := newTestContext("tenant1")
+
+	dimensions := []registry.Dimension{
+		registry.DimensionMonetary,
+		registry.DimensionEnergy,
+		registry.DimensionMass,
+		registry.DimensionVolume,
+		registry.DimensionTime,
+		registry.DimensionCompute,
+		registry.DimensionQuantity,
+	}
+
+	for i, dim := range dimensions {
+		def := &registry.InstrumentDefinition{
+			ID:        uuid.New(),
+			Code:      "TEST",
+			Version:   i + 1,
+			Dimension: dim,
+			Status:    registry.StatusActive,
+			CreatedAt: time.Now(),
+		}
+
+		cache.Put(ctx, def.Code, def.Version, def)
+		result := cache.Get(ctx, def.Code, def.Version)
+
+		require.NotNil(t, result, "dimension %s should be cached", dim)
+		assert.Equal(t, dim, result.Dimension, "dimension should roundtrip correctly")
+	}
+}
+
+func TestRedisL2Cache_StatusConversions(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := newTestContext("tenant1")
+
+	statuses := []registry.Status{
+		registry.StatusDraft,
+		registry.StatusActive,
+		registry.StatusDeprecated,
+	}
+
+	for i, status := range statuses {
+		def := &registry.InstrumentDefinition{
+			ID:        uuid.New(),
+			Code:      "TEST",
+			Version:   i + 1,
+			Dimension: registry.DimensionMonetary,
+			Status:    status,
+			CreatedAt: time.Now(),
+		}
+
+		cache.Put(ctx, def.Code, def.Version, def)
+		result := cache.Get(ctx, def.Code, def.Version)
+
+		require.NotNil(t, result, "status %s should be cached", status)
+		assert.Equal(t, status, result.Status, "status should roundtrip correctly")
+	}
+}
+
+func TestRedisL2Cache_CorruptedData(t *testing.T) {
+	mr, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	ctx := newTestContext("tenant1")
+
+	// Write corrupted data directly to Redis
+	key := "refdata:instrument:tenant1:USD:1"
+	mr.Set(key, "not a valid protobuf")
+
+	// Get should return nil (treat as cache miss)
+	result := cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result, "corrupted data should be treated as cache miss")
+}
+
+// Benchmark tests
+
+func BenchmarkRedisL2Cache_Get_Hit(b *testing.B) {
+	mr := miniredis.RunT(b)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	cache, _ := NewRedisL2Cache(client)
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("tenant1"))
+
+	def := newTestDefinition("USD", 1)
+	cache.Put(ctx, "USD", 1, def)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cache.Get(ctx, "USD", 1)
+	}
+}
+
+func BenchmarkRedisL2Cache_Get_Miss(b *testing.B) {
+	mr := miniredis.RunT(b)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	cache, _ := NewRedisL2Cache(client)
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("tenant1"))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cache.Get(ctx, "NONEXISTENT", 1)
+	}
+}
+
+func BenchmarkRedisL2Cache_Put(b *testing.B) {
+	mr := miniredis.RunT(b)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	cache, _ := NewRedisL2Cache(client)
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("tenant1"))
+	def := newTestDefinition("USD", 1)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Put(ctx, "USD", i%1000, def)
+	}
+}
+
+// Test NoOpL2Cache
+
+func TestNoOpL2Cache(t *testing.T) {
+	cache := &NoOpL2Cache{}
+	ctx := newTestContext("tenant1")
+
+	// All operations should be no-ops
+	result := cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+
+	// These should not panic
+	cache.Put(ctx, "USD", 1, newTestDefinition("USD", 1))
+	cache.Invalidate(ctx, "USD", 1)
+	cache.InvalidateCode(ctx, "USD")
+	cache.InvalidateAll(ctx)
+
+	// Still returns nil
+	result = cache.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+}
+
+// Test that RedisL2Cache implements L2Cache interface
+func TestRedisL2Cache_ImplementsL2Cache(t *testing.T) {
+	_, client := setupMiniRedis(t)
+	defer client.Close()
+
+	cache, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+
+	// This should compile - proves interface compliance
+	var _ L2Cache = cache
+}

--- a/services/reference-data/cache/tiered_cache.go
+++ b/services/reference-data/cache/tiered_cache.go
@@ -95,6 +95,10 @@ type TieredCache interface {
 }
 
 // TieredCacheStats contains statistics for monitoring cache performance.
+//
+// Note: Stats are read with atomic loads but not as an atomic snapshot.
+// Under high concurrency, individual counters may reflect slightly
+// different points in time. This is acceptable for monitoring purposes.
 type TieredCacheStats struct {
 	// L1Size is the current number of entries in the L1 cache for this tenant.
 	L1Size int

--- a/services/reference-data/cache/tiered_cache.go
+++ b/services/reference-data/cache/tiered_cache.go
@@ -1,0 +1,136 @@
+// Package cache provides caching infrastructure for instrument definitions
+// with tenant isolation and TTL-based expiration.
+package cache
+
+import (
+	"context"
+
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+)
+
+// L2Cache defines the interface for L2 (Redis) caching of instrument definitions.
+// L2 cache stores serialized InstrumentDefinition protos without CEL programs.
+// CEL programs cannot be serialized and must be compiled after retrieval from L2.
+//
+// All methods extract tenant context from ctx using shared/platform/tenant.
+// Methods are designed to be non-blocking and fail-safe:
+// - Get returns nil on cache miss or error (no error propagation)
+// - Put/Invalidate are best-effort operations
+type L2Cache interface {
+	// Get retrieves an instrument definition from the L2 cache.
+	// Returns nil if the entry is not found, expired, or tenant context is missing.
+	// Does NOT return errors - cache misses are expected and should not propagate errors.
+	Get(ctx context.Context, code string, version int) *registry.InstrumentDefinition
+
+	// Put stores an instrument definition in the L2 cache.
+	// Does nothing if tenant context is missing or definition is nil.
+	// This is a best-effort operation - failures are silently ignored.
+	Put(ctx context.Context, code string, version int, def *registry.InstrumentDefinition)
+
+	// Invalidate removes a specific entry from the L2 cache.
+	// Does nothing if tenant context is missing.
+	Invalidate(ctx context.Context, code string, version int)
+
+	// InvalidateCode removes all versions of an instrument code from the L2 cache.
+	// Does nothing if tenant context is missing.
+	InvalidateCode(ctx context.Context, code string)
+
+	// InvalidateAll removes all instrument cache entries for the tenant.
+	// Does nothing if tenant context is missing.
+	InvalidateAll(ctx context.Context)
+}
+
+// Source defines the interface for loading instrument definitions from the source of truth.
+// This is typically the database via the InstrumentRegistry.
+type Source interface {
+	// GetDefinition retrieves a specific instrument by code and version.
+	// Returns registry.ErrNotFound if the instrument doesn't exist.
+	GetDefinition(ctx context.Context, code string, version int) (*registry.InstrumentDefinition, error)
+}
+
+// TieredCache provides a multi-level cache for instrument definitions with:
+// - L1: In-memory LRU cache with compiled CEL programs (fast, short TTL)
+// - L2: Redis cache with serialized protos (warm, longer TTL)
+// - Source: Database via InstrumentRegistry (persistent, source of truth)
+//
+// Cache flow:
+// 1. Check L1 (memory) - returns CachedInstrument with compiled CEL programs
+// 2. If L1 miss, check L2 (Redis) - returns InstrumentDefinition (no CEL)
+// 3. If L2 hit, compile CEL programs, store in L1, return
+// 4. If L2 miss, fetch from Source, store in L2 and L1, return
+//
+// CEL program compilation happens only on L1 cache population.
+// This ensures CEL programs are compiled once per L1 entry.
+//
+// Write-through invalidation:
+// - On instrument update: Invalidate L1 and L2
+// - On instrument activation: Invalidate L1 and L2 for the code
+// - On instrument deprecation: Invalidate L1 and L2 for the code
+type TieredCache interface {
+	// Get retrieves a cached instrument with compiled CEL programs.
+	// Implements the tiered lookup: L1 -> L2 -> Source.
+	// Returns nil and error if the instrument cannot be found or loading fails.
+	Get(ctx context.Context, code string, version int) (*CachedInstrument, error)
+
+	// Invalidate removes a specific entry from all cache tiers.
+	// This is called after instrument updates to ensure consistency.
+	Invalidate(ctx context.Context, code string, version int)
+
+	// InvalidateCode removes all versions of an instrument code from all cache tiers.
+	// This is called after instrument activation/deprecation.
+	InvalidateCode(ctx context.Context, code string)
+
+	// InvalidateAll removes all entries for the tenant from all cache tiers.
+	// This is an admin operation for emergency cache clearing.
+	InvalidateAll(ctx context.Context)
+
+	// Stats returns cache statistics for monitoring.
+	Stats(ctx context.Context) TieredCacheStats
+}
+
+// TieredCacheStats contains statistics for monitoring cache performance.
+type TieredCacheStats struct {
+	// L1Size is the current number of entries in the L1 cache for this tenant.
+	L1Size int
+
+	// L1Capacity is the maximum capacity of the L1 cache.
+	L1Capacity int
+
+	// L1Hits is the number of L1 cache hits (since service start).
+	L1Hits int64
+
+	// L1Misses is the number of L1 cache misses (since service start).
+	L1Misses int64
+
+	// L2Hits is the number of L2 cache hits (since service start).
+	L2Hits int64
+
+	// L2Misses is the number of L2 cache misses (since service start).
+	L2Misses int64
+
+	// SourceLoads is the number of loads from source (since service start).
+	SourceLoads int64
+}
+
+// NoOpL2Cache is an L2Cache implementation that does nothing.
+// Useful when Redis is not available or for testing.
+type NoOpL2Cache struct{}
+
+var _ L2Cache = (*NoOpL2Cache)(nil)
+
+// Get always returns nil (cache miss).
+func (n *NoOpL2Cache) Get(_ context.Context, _ string, _ int) *registry.InstrumentDefinition {
+	return nil
+}
+
+// Put does nothing.
+func (n *NoOpL2Cache) Put(_ context.Context, _ string, _ int, _ *registry.InstrumentDefinition) {}
+
+// Invalidate does nothing.
+func (n *NoOpL2Cache) Invalidate(_ context.Context, _ string, _ int) {}
+
+// InvalidateCode does nothing.
+func (n *NoOpL2Cache) InvalidateCode(_ context.Context, _ string) {}
+
+// InvalidateAll does nothing.
+func (n *NoOpL2Cache) InvalidateAll(_ context.Context) {}

--- a/services/reference-data/cache/tiered_cache.go
+++ b/services/reference-data/cache/tiered_cache.go
@@ -4,8 +4,14 @@ package cache
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
+
+	"github.com/google/cel-go/cel"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
 // L2Cache defines the interface for L2 (Redis) caching of instrument definitions.
@@ -134,3 +140,200 @@ func (n *NoOpL2Cache) InvalidateCode(_ context.Context, _ string) {}
 
 // InvalidateAll does nothing.
 func (n *NoOpL2Cache) InvalidateAll(_ context.Context) {}
+
+// CELCompiler defines the interface for compiling CEL expressions.
+// This is typically implemented by cel.Compiler.
+type CELCompiler interface {
+	// CompileValidation compiles a validation expression.
+	// Returns nil if the expression is empty.
+	CompileValidation(expression string) (cel.Program, error)
+
+	// CompileBucketKey compiles a bucket key expression.
+	// Returns nil if the expression is empty.
+	CompileBucketKey(expression string) (cel.Program, error)
+}
+
+// TieredInstrumentCache provides a multi-level cache with L1 (memory) -> L2 (Redis) -> Source (gRPC/database).
+// It implements the TieredCache interface and provides cold start resilience via the L2 cache.
+//
+// Cache flow:
+// 1. Check L1 (memory) - returns CachedInstrument with compiled CEL programs
+// 2. If L1 miss, check L2 (Redis) - returns InstrumentDefinition (no CEL)
+// 3. If L2 hit, compile CEL programs, store in L1, return
+// 4. If L2 miss, fetch from Source, store in L2 and L1, return
+//
+// Thread-safety: All methods are safe for concurrent use.
+// Singleflight is used to deduplicate concurrent requests for the same key.
+type TieredInstrumentCache struct {
+	l1       *InstrumentCache
+	l2       L2Cache
+	source   Source
+	compiler CELCompiler
+
+	// sfGroup deduplicates concurrent cache misses for the same key.
+	// The singleflight key includes tenant ID to maintain isolation.
+	sfGroup singleflight.Group
+
+	// Stats counters (atomic)
+	l1Hits      int64
+	l1Misses    int64
+	l2Hits      int64
+	l2Misses    int64
+	sourceLoads int64
+}
+
+// Verify TieredInstrumentCache implements TieredCache.
+var _ TieredCache = (*TieredInstrumentCache)(nil)
+
+// NewTieredInstrumentCache creates a new tiered cache with the given components.
+// If l2 is nil, a NoOpL2Cache is used (disabling L2 caching).
+// If compiler is nil, CEL compilation will be skipped.
+func NewTieredInstrumentCache(l1 *InstrumentCache, l2 L2Cache, source Source, compiler CELCompiler) *TieredInstrumentCache {
+	if l2 == nil {
+		l2 = &NoOpL2Cache{}
+	}
+
+	return &TieredInstrumentCache{
+		l1:       l1,
+		l2:       l2,
+		source:   source,
+		compiler: compiler,
+	}
+}
+
+// Get retrieves a cached instrument with compiled CEL programs.
+// Implements the tiered lookup: L1 -> L2 -> Source.
+// Uses singleflight to deduplicate concurrent requests for the same key.
+func (t *TieredInstrumentCache) Get(ctx context.Context, code string, version int) (*CachedInstrument, error) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil, ErrTenantContextRequired
+	}
+
+	// Fast path: check L1 cache
+	if cached := t.l1.Get(ctx, code, version); cached != nil {
+		atomic.AddInt64(&t.l1Hits, 1)
+		return cached, nil
+	}
+	atomic.AddInt64(&t.l1Misses, 1)
+
+	// Slow path: use singleflight to deduplicate concurrent fetches
+	sfKey := fmt.Sprintf("%s:%s:%d", tenantID, code, version)
+
+	result, err, _ := t.sfGroup.Do(sfKey, func() (interface{}, error) {
+		// Double-check L1 after acquiring singleflight slot
+		// Another goroutine might have populated the cache
+		if cached := t.l1.Get(ctx, code, version); cached != nil {
+			return cached, nil
+		}
+
+		// Check L2 cache
+		if def := t.l2.Get(ctx, code, version); def != nil {
+			atomic.AddInt64(&t.l2Hits, 1)
+
+			// Compile CEL programs and populate L1
+			cached, err := t.compileCEL(def)
+			if err != nil {
+				return nil, err
+			}
+			t.l1.Put(ctx, code, version, cached)
+			return cached, nil
+		}
+		atomic.AddInt64(&t.l2Misses, 1)
+
+		// Fetch from source
+		def, err := t.source.GetDefinition(ctx, code, version)
+		if err != nil {
+			return nil, err
+		}
+		atomic.AddInt64(&t.sourceLoads, 1)
+
+		// Populate L2 (non-blocking, best-effort)
+		t.l2.Put(ctx, code, version, def)
+
+		// Compile CEL programs and populate L1
+		cached, err := t.compileCEL(def)
+		if err != nil {
+			return nil, err
+		}
+		t.l1.Put(ctx, code, version, cached)
+
+		return cached, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	cached, ok := result.(*CachedInstrument)
+	if !ok {
+		return nil, ErrUnexpectedResultType
+	}
+
+	return cached, nil
+}
+
+// compileCEL compiles CEL programs for the given definition.
+// Returns a CachedInstrument with the definition and compiled programs.
+func (t *TieredInstrumentCache) compileCEL(def *registry.InstrumentDefinition) (*CachedInstrument, error) {
+	cached := &CachedInstrument{
+		Definition: def,
+	}
+
+	if t.compiler == nil {
+		return cached, nil
+	}
+
+	// Compile validation expression if present
+	if def.ValidationExpression != "" {
+		prg, err := t.compiler.CompileValidation(def.ValidationExpression)
+		if err != nil {
+			return nil, fmt.Errorf("compile validation expression: %w", err)
+		}
+		cached.ValidationProgram = prg
+	}
+
+	// Compile bucket key expression if present
+	if def.FungibilityKeyExpression != "" {
+		prg, err := t.compiler.CompileBucketKey(def.FungibilityKeyExpression)
+		if err != nil {
+			return nil, fmt.Errorf("compile bucket key expression: %w", err)
+		}
+		cached.BucketKeyProgram = prg
+	}
+
+	return cached, nil
+}
+
+// Invalidate removes a specific entry from all cache tiers.
+func (t *TieredInstrumentCache) Invalidate(ctx context.Context, code string, version int) {
+	t.l1.Invalidate(ctx, code, version)
+	t.l2.Invalidate(ctx, code, version)
+}
+
+// InvalidateCode removes all versions of an instrument code from all cache tiers.
+func (t *TieredInstrumentCache) InvalidateCode(ctx context.Context, code string) {
+	t.l1.InvalidateCode(ctx, code)
+	t.l2.InvalidateCode(ctx, code)
+}
+
+// InvalidateAll removes all entries for the tenant from all cache tiers.
+func (t *TieredInstrumentCache) InvalidateAll(ctx context.Context) {
+	t.l1.InvalidateAll(ctx)
+	t.l2.InvalidateAll(ctx)
+}
+
+// Stats returns cache statistics for monitoring.
+func (t *TieredInstrumentCache) Stats(ctx context.Context) TieredCacheStats {
+	l1Size, l1Capacity := t.l1.Stats(ctx)
+
+	return TieredCacheStats{
+		L1Size:      l1Size,
+		L1Capacity:  l1Capacity,
+		L1Hits:      atomic.LoadInt64(&t.l1Hits),
+		L1Misses:    atomic.LoadInt64(&t.l1Misses),
+		L2Hits:      atomic.LoadInt64(&t.l2Hits),
+		L2Misses:    atomic.LoadInt64(&t.l2Misses),
+		SourceLoads: atomic.LoadInt64(&t.sourceLoads),
+	}
+}

--- a/services/reference-data/cache/tiered_cache_test.go
+++ b/services/reference-data/cache/tiered_cache_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"errors"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -64,7 +65,7 @@ func (m *mockSource) addDefinition(tenantID string, def *registry.InstrumentDefi
 }
 
 func sourceKey(tenantID, code string, version int) string {
-	return tenantID + ":" + code + ":" + string(rune(version+'0'))
+	return tenantID + ":" + code + ":" + strconv.Itoa(version)
 }
 
 // mockCELCompiler is a test implementation of CELCompiler.

--- a/services/reference-data/cache/tiered_cache_test.go
+++ b/services/reference-data/cache/tiered_cache_test.go
@@ -1,0 +1,927 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/cel-go/cel"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// mockSource is a test implementation of the Source interface.
+type mockSource struct {
+	definitions map[string]*registry.InstrumentDefinition // keyed by "tenantID:code:version"
+	loadCount   int32
+	loadDelay   time.Duration
+	loadErr     error
+}
+
+func newMockSource() *mockSource {
+	return &mockSource{
+		definitions: make(map[string]*registry.InstrumentDefinition),
+	}
+}
+
+func (m *mockSource) GetDefinition(ctx context.Context, code string, version int) (*registry.InstrumentDefinition, error) {
+	atomic.AddInt32(&m.loadCount, 1)
+
+	if m.loadDelay > 0 {
+		time.Sleep(m.loadDelay)
+	}
+
+	if m.loadErr != nil {
+		return nil, m.loadErr
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil, ErrTenantContextRequired
+	}
+
+	key := sourceKey(string(tenantID), code, version)
+	def, ok := m.definitions[key]
+	if !ok {
+		return nil, registry.ErrNotFound
+	}
+
+	return def, nil
+}
+
+func (m *mockSource) addDefinition(tenantID string, def *registry.InstrumentDefinition) {
+	key := sourceKey(tenantID, def.Code, def.Version)
+	m.definitions[key] = def
+}
+
+func sourceKey(tenantID, code string, version int) string {
+	return tenantID + ":" + code + ":" + string(rune(version+'0'))
+}
+
+// mockCELCompiler is a test implementation of CELCompiler.
+type mockCELCompiler struct {
+	compileValidationFn func(expression string) (cel.Program, error)
+	compileBucketKeyFn  func(expression string) (cel.Program, error)
+	compileCount        int32
+}
+
+func newMockCELCompiler() *mockCELCompiler {
+	return &mockCELCompiler{
+		compileValidationFn: func(_ string) (cel.Program, error) {
+			return nil, nil // Return nil program, which is valid
+		},
+		compileBucketKeyFn: func(_ string) (cel.Program, error) {
+			return nil, nil
+		},
+	}
+}
+
+func (m *mockCELCompiler) CompileValidation(expression string) (cel.Program, error) {
+	atomic.AddInt32(&m.compileCount, 1)
+	return m.compileValidationFn(expression)
+}
+
+func (m *mockCELCompiler) CompileBucketKey(expression string) (cel.Program, error) {
+	atomic.AddInt32(&m.compileCount, 1)
+	return m.compileBucketKeyFn(expression)
+}
+
+// mockL2Cache tracks calls for testing.
+type mockL2Cache struct {
+	NoOpL2Cache
+	getCount  int32
+	putCount  int32
+	getCalled map[string]bool
+	putCalled map[string]bool
+	data      map[string]*registry.InstrumentDefinition
+	mu        sync.Mutex
+}
+
+func newMockL2Cache() *mockL2Cache {
+	return &mockL2Cache{
+		getCalled: make(map[string]bool),
+		putCalled: make(map[string]bool),
+		data:      make(map[string]*registry.InstrumentDefinition),
+	}
+}
+
+func (m *mockL2Cache) Get(ctx context.Context, code string, version int) *registry.InstrumentDefinition {
+	atomic.AddInt32(&m.getCount, 1)
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := sourceKey(string(tenantID), code, version)
+	m.getCalled[key] = true
+	return m.data[key]
+}
+
+func (m *mockL2Cache) Put(ctx context.Context, code string, version int, def *registry.InstrumentDefinition) {
+	atomic.AddInt32(&m.putCount, 1)
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := sourceKey(string(tenantID), code, version)
+	m.putCalled[key] = true
+	if def != nil {
+		m.data[key] = def
+	}
+}
+
+func (m *mockL2Cache) addDefinition(tenantID string, def *registry.InstrumentDefinition) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := sourceKey(tenantID, def.Code, def.Version)
+	m.data[key] = def
+}
+
+// Test helpers
+
+func newTieredTestDefinition(code string, version int) *registry.InstrumentDefinition {
+	return &registry.InstrumentDefinition{
+		ID:        uuid.New(),
+		Code:      code,
+		Version:   version,
+		Dimension: registry.DimensionMonetary,
+		Precision: 2,
+		Status:    registry.StatusActive,
+		CreatedAt: time.Now(),
+	}
+}
+
+func newTieredTestDefinitionWithCEL(code string, version int) *registry.InstrumentDefinition {
+	def := newTieredTestDefinition(code, version)
+	def.ValidationExpression = "amount > 0"
+	def.FungibilityKeyExpression = "instrument_code"
+	return def
+}
+
+// Tests for L1 hit path
+
+func TestTieredInstrumentCache_L1Hit(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate L1 cache
+	def := newTieredTestDefinition("USD", 1)
+	cached := &CachedInstrument{Definition: def}
+	l1.Put(ctx, "USD", 1, cached)
+
+	// Get should hit L1 without checking L2 or source
+	result, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "USD", result.Definition.Code)
+
+	// Verify L2 and source were not called
+	assert.Equal(t, int32(0), atomic.LoadInt32(&l2.getCount), "L2 should not be called on L1 hit")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&source.loadCount), "source should not be called on L1 hit")
+
+	// Verify stats
+	stats := tiered.Stats(ctx)
+	assert.Equal(t, int64(1), stats.L1Hits)
+	assert.Equal(t, int64(0), stats.L1Misses)
+	assert.Equal(t, int64(0), stats.L2Hits)
+}
+
+// Tests for L2 hit path
+
+func TestTieredInstrumentCache_L1Miss_L2Hit(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate L2 cache (not L1)
+	def := newTieredTestDefinitionWithCEL("USD", 1)
+	l2.addDefinition("tenant1", def)
+
+	// Get should miss L1, hit L2, compile CEL, and populate L1
+	result, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "USD", result.Definition.Code)
+
+	// Verify source was not called
+	assert.Equal(t, int32(0), atomic.LoadInt32(&source.loadCount), "source should not be called on L2 hit")
+
+	// Verify L1 was populated
+	l1Cached := l1.Get(ctx, "USD", 1)
+	require.NotNil(t, l1Cached, "L1 should be populated after L2 hit")
+	assert.Equal(t, "USD", l1Cached.Definition.Code)
+
+	// Verify stats
+	stats := tiered.Stats(ctx)
+	assert.Equal(t, int64(0), stats.L1Hits)
+	assert.Equal(t, int64(1), stats.L1Misses)
+	assert.Equal(t, int64(1), stats.L2Hits)
+	assert.Equal(t, int64(0), stats.L2Misses)
+	assert.Equal(t, int64(0), stats.SourceLoads)
+}
+
+func TestTieredInstrumentCache_L2Hit_CompilesCEL(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate L2 with definition that has CEL expressions
+	def := newTieredTestDefinitionWithCEL("USD", 1)
+	l2.addDefinition("tenant1", def)
+
+	// Get should trigger CEL compilation
+	result, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// CEL compiler should have been called twice (validation + bucket key)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&compiler.compileCount),
+		"compiler should be called for both validation and bucket key expressions")
+}
+
+// Tests for source fetch path
+
+func TestTieredInstrumentCache_L1Miss_L2Miss_SourceFetch(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate source (not L1 or L2)
+	def := newTieredTestDefinition("USD", 1)
+	source.addDefinition("tenant1", def)
+
+	// Get should miss L1, miss L2, fetch from source, and populate both
+	result, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "USD", result.Definition.Code)
+
+	// Verify source was called
+	assert.Equal(t, int32(1), atomic.LoadInt32(&source.loadCount), "source should be called once")
+
+	// Verify L2 was populated
+	assert.True(t, l2.putCalled[sourceKey("tenant1", "USD", 1)], "L2 should be populated")
+
+	// Verify L1 was populated
+	l1Cached := l1.Get(ctx, "USD", 1)
+	require.NotNil(t, l1Cached, "L1 should be populated after source fetch")
+
+	// Verify stats
+	stats := tiered.Stats(ctx)
+	assert.Equal(t, int64(0), stats.L1Hits)
+	assert.Equal(t, int64(1), stats.L1Misses)
+	assert.Equal(t, int64(0), stats.L2Hits)
+	assert.Equal(t, int64(1), stats.L2Misses)
+	assert.Equal(t, int64(1), stats.SourceLoads)
+}
+
+// Tests for cold start resilience
+
+func TestTieredInstrumentCache_ColdStartResilience_SourceUnavailable_L2Hit(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	// Simulate source unavailable
+	source.loadErr = errors.New("source unavailable") //nolint:err113 // test error
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate L2 (simulating warm L2 from before pod restart)
+	def := newTieredTestDefinition("USD", 1)
+	l2.addDefinition("tenant1", def)
+
+	// Get should miss L1, hit L2, and return successfully despite source being unavailable
+	result, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err, "should succeed from L2 even when source is unavailable")
+	require.NotNil(t, result)
+	assert.Equal(t, "USD", result.Definition.Code)
+
+	// Source should not have been called (L2 hit)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&source.loadCount))
+
+	// L1 should now be populated
+	l1Cached := l1.Get(ctx, "USD", 1)
+	require.NotNil(t, l1Cached, "L1 should be populated from L2")
+}
+
+func TestTieredInstrumentCache_SourceUnavailable_L2Miss_ReturnsError(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	// Simulate source unavailable
+	sourceErr := errors.New("source unavailable") //nolint:err113 // test error
+	source.loadErr = sourceErr
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// No data in L1 or L2
+
+	// Get should fail when both L1 and L2 miss and source is unavailable
+	result, err := tiered.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, sourceErr)
+}
+
+// Tests for singleflight deduplication
+
+func TestTieredInstrumentCache_SingleflightDeduplication(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	// Add delay to source to increase overlap window
+	source.loadDelay = 50 * time.Millisecond
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate source
+	def := newTieredTestDefinition("USD", 1)
+	source.addDefinition("tenant1", def)
+
+	const concurrency = 50
+	var wg sync.WaitGroup
+	startCh := make(chan struct{})
+
+	results := make([]*CachedInstrument, concurrency)
+	errs := make([]error, concurrency)
+
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			<-startCh // Wait for start signal
+			results[idx], errs[idx] = tiered.Get(ctx, "USD", 1)
+		}(i)
+	}
+
+	// Release all goroutines simultaneously
+	close(startCh)
+	wg.Wait()
+
+	// All requests should succeed
+	for i := 0; i < concurrency; i++ {
+		require.NoError(t, errs[i], "request %d failed", i)
+		require.NotNil(t, results[i], "request %d returned nil", i)
+		assert.Equal(t, "USD", results[i].Definition.Code)
+	}
+
+	// Singleflight should have deduplicated to exactly 1 source call
+	assert.Equal(t, int32(1), atomic.LoadInt32(&source.loadCount),
+		"singleflight should deduplicate %d concurrent requests to 1 source call", concurrency)
+}
+
+func TestTieredInstrumentCache_SingleflightTenantIsolation(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	source.loadDelay = 20 * time.Millisecond
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	// Pre-populate source for both tenants
+	def1 := newTieredTestDefinition("USD", 1)
+	def2 := newTieredTestDefinition("USD", 1)
+	source.addDefinition("tenant1", def1)
+	source.addDefinition("tenant2", def2)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Both tenants request the same code+version concurrently
+	go func() {
+		defer wg.Done()
+		_, _ = tiered.Get(ctx1, "USD", 1)
+	}()
+
+	go func() {
+		defer wg.Done()
+		_, _ = tiered.Get(ctx2, "USD", 1)
+	}()
+
+	wg.Wait()
+
+	// Each tenant should have its own source call (singleflight key includes tenant)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&source.loadCount),
+		"each tenant should have separate singleflight groups")
+}
+
+// Tests for tenant isolation
+
+func TestTieredInstrumentCache_TenantIsolation(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	// Pre-populate source with different data for each tenant
+	def1 := newTieredTestDefinition("USD", 1)
+	def1.DisplayName = "Tenant1 USD"
+	source.addDefinition("tenant1", def1)
+
+	def2 := newTieredTestDefinition("USD", 1)
+	def2.DisplayName = "Tenant2 USD"
+	source.addDefinition("tenant2", def2)
+
+	// Get for tenant1
+	result1, err := tiered.Get(ctx1, "USD", 1)
+	require.NoError(t, err)
+	require.NotNil(t, result1)
+	assert.Equal(t, "Tenant1 USD", result1.Definition.DisplayName)
+
+	// Get for tenant2
+	result2, err := tiered.Get(ctx2, "USD", 1)
+	require.NoError(t, err)
+	require.NotNil(t, result2)
+	assert.Equal(t, "Tenant2 USD", result2.Definition.DisplayName)
+
+	// Verify tenant1 still gets their data (cached in L1 now)
+	result1Again, err := tiered.Get(ctx1, "USD", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "Tenant1 USD", result1Again.Definition.DisplayName)
+}
+
+// Tests for missing tenant context
+
+func TestTieredInstrumentCache_MissingTenantContext(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := context.Background() // No tenant
+
+	result, err := tiered.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrTenantContextRequired)
+}
+
+// Tests for invalidation
+
+func TestTieredInstrumentCache_Invalidate(t *testing.T) {
+	mr, client := setupMiniRedis(t)
+	defer client.Close()
+	_ = mr
+
+	l1 := NewInstrumentCache()
+	l2, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate source
+	def := newTieredTestDefinition("USD", 1)
+	source.addDefinition("tenant1", def)
+
+	// Get to populate caches
+	_, err = tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+
+	// Verify L1 has the entry
+	require.NotNil(t, l1.Get(ctx, "USD", 1))
+	// Verify L2 has the entry
+	require.NotNil(t, l2.Get(ctx, "USD", 1))
+
+	// Invalidate
+	tiered.Invalidate(ctx, "USD", 1)
+
+	// Both caches should be empty
+	assert.Nil(t, l1.Get(ctx, "USD", 1), "L1 should be invalidated")
+	assert.Nil(t, l2.Get(ctx, "USD", 1), "L2 should be invalidated")
+}
+
+func TestTieredInstrumentCache_InvalidateCode(t *testing.T) {
+	mr, client := setupMiniRedis(t)
+	defer client.Close()
+	_ = mr
+
+	l1 := NewInstrumentCache()
+	l2, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate source with multiple versions
+	for i := 1; i <= 3; i++ {
+		def := newTieredTestDefinition("USD", i)
+		source.addDefinition("tenant1", def)
+	}
+	// Add different code
+	eurDef := newTieredTestDefinition("EUR", 1)
+	source.addDefinition("tenant1", eurDef)
+
+	// Get to populate caches
+	for i := 1; i <= 3; i++ {
+		_, err := tiered.Get(ctx, "USD", i)
+		require.NoError(t, err)
+	}
+	_, err = tiered.Get(ctx, "EUR", 1)
+	require.NoError(t, err)
+
+	// InvalidateCode for USD
+	tiered.InvalidateCode(ctx, "USD")
+
+	// All USD versions should be invalidated from L1
+	for i := 1; i <= 3; i++ {
+		assert.Nil(t, l1.Get(ctx, "USD", i), "USD v%d should be invalidated from L1", i)
+	}
+
+	// EUR should still be cached in L1
+	assert.NotNil(t, l1.Get(ctx, "EUR", 1), "EUR should not be affected in L1")
+}
+
+func TestTieredInstrumentCache_InvalidateAll(t *testing.T) {
+	mr, client := setupMiniRedis(t)
+	defer client.Close()
+	_ = mr
+
+	l1 := NewInstrumentCache()
+	l2, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate source
+	for _, code := range []string{"USD", "EUR", "GBP"} {
+		def := newTieredTestDefinition(code, 1)
+		source.addDefinition("tenant1", def)
+	}
+
+	// Get to populate caches
+	for _, code := range []string{"USD", "EUR", "GBP"} {
+		_, err := tiered.Get(ctx, code, 1)
+		require.NoError(t, err)
+	}
+
+	// InvalidateAll
+	tiered.InvalidateAll(ctx)
+
+	// All should be invalidated from L1
+	for _, code := range []string{"USD", "EUR", "GBP"} {
+		assert.Nil(t, l1.Get(ctx, code, 1), "%s should be invalidated from L1", code)
+	}
+}
+
+func TestTieredInstrumentCache_InvalidateAll_TenantIsolation(t *testing.T) {
+	mr, client := setupMiniRedis(t)
+	defer client.Close()
+	_ = mr
+
+	l1 := NewInstrumentCache()
+	l2, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx1 := newTestContext("tenant1")
+	ctx2 := newTestContext("tenant2")
+
+	// Pre-populate source for both tenants
+	source.addDefinition("tenant1", newTieredTestDefinition("USD", 1))
+	source.addDefinition("tenant2", newTieredTestDefinition("EUR", 1))
+
+	// Get to populate caches
+	_, err = tiered.Get(ctx1, "USD", 1)
+	require.NoError(t, err)
+	_, err = tiered.Get(ctx2, "EUR", 1)
+	require.NoError(t, err)
+
+	// InvalidateAll for tenant1 only
+	tiered.InvalidateAll(ctx1)
+
+	// Tenant1's cache should be empty
+	assert.Nil(t, l1.Get(ctx1, "USD", 1), "tenant1's USD should be invalidated")
+
+	// Tenant2's cache should be unaffected
+	assert.NotNil(t, l1.Get(ctx2, "EUR", 1), "tenant2's EUR should not be affected")
+}
+
+// Tests for nil L2 cache
+
+func TestTieredInstrumentCache_NilL2UsesNoOp(t *testing.T) {
+	l1 := NewInstrumentCache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	// Create with nil L2
+	tiered := NewTieredInstrumentCache(l1, nil, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate source
+	def := newTieredTestDefinition("USD", 1)
+	source.addDefinition("tenant1", def)
+
+	// Should work without L2
+	result, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "USD", result.Definition.Code)
+
+	// Second get should hit L1
+	result2, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+	assert.NotNil(t, result2)
+
+	// Only one source load
+	assert.Equal(t, int32(1), atomic.LoadInt32(&source.loadCount))
+}
+
+// Tests for nil compiler
+
+func TestTieredInstrumentCache_NilCompilerSkipsCEL(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+
+	// Create with nil compiler
+	tiered := NewTieredInstrumentCache(l1, l2, source, nil)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate source with CEL expressions
+	def := newTieredTestDefinitionWithCEL("USD", 1)
+	source.addDefinition("tenant1", def)
+
+	// Should work without compiler
+	result, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "USD", result.Definition.Code)
+
+	// CEL programs should be nil
+	assert.Nil(t, result.ValidationProgram)
+	assert.Nil(t, result.BucketKeyProgram)
+}
+
+// Tests for CEL compilation errors
+
+func TestTieredInstrumentCache_CELCompilationError(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+
+	// Compiler that returns error
+	compiler := newMockCELCompiler()
+	compileErr := errors.New("CEL compilation failed") //nolint:err113 // test error
+	compiler.compileValidationFn = func(_ string) (cel.Program, error) {
+		return nil, compileErr
+	}
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate source with CEL expressions
+	def := newTieredTestDefinitionWithCEL("USD", 1)
+	source.addDefinition("tenant1", def)
+
+	// Get should fail with CEL compilation error
+	result, err := tiered.Get(ctx, "USD", 1)
+	assert.Nil(t, result)
+	assert.ErrorContains(t, err, "compile validation expression")
+}
+
+// Tests for Stats
+
+func TestTieredInstrumentCache_Stats(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate source
+	def := newTieredTestDefinition("USD", 1)
+	source.addDefinition("tenant1", def)
+
+	// Initial stats
+	stats := tiered.Stats(ctx)
+	assert.Equal(t, int64(0), stats.L1Hits)
+	assert.Equal(t, int64(0), stats.L1Misses)
+	assert.Equal(t, int64(0), stats.L2Hits)
+	assert.Equal(t, int64(0), stats.L2Misses)
+	assert.Equal(t, int64(0), stats.SourceLoads)
+
+	// First get: L1 miss, L2 miss, source load
+	_, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+
+	stats = tiered.Stats(ctx)
+	assert.Equal(t, int64(0), stats.L1Hits)
+	assert.Equal(t, int64(1), stats.L1Misses)
+	assert.Equal(t, int64(0), stats.L2Hits)
+	assert.Equal(t, int64(1), stats.L2Misses)
+	assert.Equal(t, int64(1), stats.SourceLoads)
+
+	// Second get: L1 hit
+	_, err = tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+
+	stats = tiered.Stats(ctx)
+	assert.Equal(t, int64(1), stats.L1Hits)
+	assert.Equal(t, int64(1), stats.L1Misses)
+	assert.Equal(t, int64(0), stats.L2Hits)
+	assert.Equal(t, int64(1), stats.L2Misses)
+	assert.Equal(t, int64(1), stats.SourceLoads)
+
+	// L1 size and capacity
+	assert.Equal(t, 1, stats.L1Size)
+	assert.Equal(t, DefaultCacheSize, stats.L1Capacity)
+}
+
+func TestTieredInstrumentCache_Stats_L2Hit(t *testing.T) {
+	l1 := NewInstrumentCache()
+	l2 := newMockL2Cache()
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate L2 only
+	def := newTieredTestDefinition("USD", 1)
+	l2.addDefinition("tenant1", def)
+
+	// Get: L1 miss, L2 hit
+	_, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+
+	stats := tiered.Stats(ctx)
+	assert.Equal(t, int64(0), stats.L1Hits)
+	assert.Equal(t, int64(1), stats.L1Misses)
+	assert.Equal(t, int64(1), stats.L2Hits)
+	assert.Equal(t, int64(0), stats.L2Misses)
+	assert.Equal(t, int64(0), stats.SourceLoads)
+}
+
+// Integration test with real Redis
+
+func TestTieredInstrumentCache_Integration_WithRedis(t *testing.T) {
+	mr, client := setupMiniRedis(t)
+	defer client.Close()
+	_ = mr
+
+	l1 := NewInstrumentCache()
+	l2, err := NewRedisL2Cache(client)
+	require.NoError(t, err)
+	source := newMockSource()
+	compiler := newMockCELCompiler()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, compiler)
+	ctx := newTestContext("tenant1")
+
+	// Pre-populate source
+	def := newTieredTestDefinition("USD", 1)
+	def.DisplayName = "US Dollar"
+	source.addDefinition("tenant1", def)
+
+	// First get: populates L1 and L2
+	result, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "US Dollar", result.Definition.DisplayName)
+
+	// Verify L2 has the entry
+	l2Entry := l2.Get(ctx, "USD", 1)
+	require.NotNil(t, l2Entry)
+	assert.Equal(t, "US Dollar", l2Entry.DisplayName)
+
+	// Clear L1 to simulate pod restart
+	l1.InvalidateAll(ctx)
+
+	// Second get should hit L2 (not source)
+	result2, err := tiered.Get(ctx, "USD", 1)
+	require.NoError(t, err)
+	assert.Equal(t, "US Dollar", result2.Definition.DisplayName)
+
+	// Source should only have been called once
+	assert.Equal(t, int32(1), atomic.LoadInt32(&source.loadCount))
+}
+
+// Benchmark tests
+
+func BenchmarkTieredInstrumentCache_L1Hit(b *testing.B) {
+	l1 := NewInstrumentCache()
+	l2 := &NoOpL2Cache{}
+	source := newMockSource()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, nil)
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("tenant1"))
+
+	// Pre-populate L1
+	def := newTieredTestDefinition("USD", 1)
+	l1.Put(ctx, "USD", 1, &CachedInstrument{Definition: def})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = tiered.Get(ctx, "USD", 1)
+	}
+}
+
+func BenchmarkTieredInstrumentCache_L2Hit(b *testing.B) {
+	mr := miniredis.RunT(b)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer client.Close()
+
+	l1 := NewInstrumentCache()
+	l2, _ := NewRedisL2Cache(client)
+	source := newMockSource()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, nil)
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("tenant1"))
+
+	// Pre-populate L2 only
+	def := newTieredTestDefinition("USD", 1)
+	l2.Put(ctx, "USD", 1, def)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Clear L1 for each iteration to measure L2 hit path
+		l1.InvalidateAll(ctx)
+		_, _ = tiered.Get(ctx, "USD", 1)
+	}
+}
+
+func BenchmarkTieredInstrumentCache_Parallel(b *testing.B) {
+	l1 := NewInstrumentCache()
+	l2 := &NoOpL2Cache{}
+	source := newMockSource()
+
+	tiered := NewTieredInstrumentCache(l1, l2, source, nil)
+	ctx := tenant.WithTenant(context.Background(), tenant.MustNewTenantID("tenant1"))
+
+	// Pre-populate L1 with multiple entries
+	for i := 0; i < 100; i++ {
+		def := newTieredTestDefinition("INS", i)
+		l1.Put(ctx, "INS", i, &CachedInstrument{Definition: def})
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			_, _ = tiered.Get(ctx, "INS", i%100)
+			i++
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Add Redis L2 cache layer to survive Reference Data service outages during pod restarts
- Implement tiered cache architecture: L1 (memory LRU, 5min TTL) → L2 (Redis, 1hr TTL) → Source (gRPC/database)
- Wire up dual-layer cache invalidation on instrument.updated events

## Changes Made

### Subtask universal-asset-system.16.1: Redis L2 Cache Infrastructure
- `redis_cache.go`: RedisL2Cache storing proto-serialized InstrumentDefinition
- Key format: `{prefix}:instrument:{tenantID}:{code}:{version}`
- Tenant isolation via key namespacing
- Jittered TTL to prevent thundering herd

### Subtask universal-asset-system.16.2: Tiered Lookup Logic
- `tiered_cache.go`: TieredInstrumentCache implementation
- L1 hit → return immediately
- L1 miss + L2 hit → compile CEL programs, populate L1, return
- L1 miss + L2 miss → fetch from source, populate both layers
- Singleflight deduplication for concurrent requests
- Atomic stats counters for observability

### Subtask universal-asset-system.16.3: Event-Driven Invalidation
- Updated `event_subscriber.go` with `Invalidator` interface
- Both InstrumentCache and TieredInstrumentCache satisfy the interface
- instrument.updated events now invalidate both L1 and L2

## Test Plan

- [x] Unit tests for RedisL2Cache (Get/Put, tenant isolation, TTL, proto roundtrip)
- [x] Unit tests for TieredInstrumentCache (L1 hit, L2 hit, source fetch, cold start resilience)
- [x] Unit tests for singleflight deduplication (50 concurrent requests → 1 source call)
- [x] Unit tests for dual-layer invalidation via events
- [x] All tests use miniredis for Redis mocking