### PR TITLE
feat: add instrument-cli simulation tool

### DIFF
--- a/cmd/instrument-cli/cmd/root.go
+++ b/cmd/instrument-cli/cmd/root.go
@@ -1,0 +1,58 @@
+// Package cmd implements the instrument-cli CLI commands.
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// serviceURL is the reference data service URL.
+var serviceURL string
+
+// rootCmd represents the base command when called without any subcommands.
+var rootCmd = &cobra.Command{
+	Use:   "instrument-cli",
+	Short: "Instrument simulation CLI for Meridian platform",
+	Long: `instrument-cli is a command-line tool for simulating instrument transactions
+in the Meridian platform.
+
+It provides dry-run capabilities to test validation rules, bucket key generation,
+and position previews without persisting data. This is useful for:
+
+  - Testing CEL expressions before activating instruments
+  - Debugging validation failures in production
+  - Understanding how attributes map to bucket IDs
+  - Previewing position records before creation
+
+Examples:
+  # Simulate a USD transaction
+  instrument-cli simulate --tenant=acme_bank --instrument=USD --amount=100.00
+
+  # Simulate with attributes for bucket key generation
+  instrument-cli simulate --tenant=acme_bank --instrument=CARBON_CREDIT \
+    --amount=50.00 --attr=vintage_year=2024 --attr=registry=VERRA
+
+  # Simulate with validity period
+  instrument-cli simulate --tenant=acme_bank --instrument=VOUCHER \
+    --amount=10 --valid-from=2024-01-01T00:00:00Z --valid-to=2024-12-31T23:59:59Z`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&serviceURL, "service-url", getEnvOrDefault("REFERENCE_DATA_SERVICE_URL", "localhost:8080"), "Reference data service URL")
+}
+
+// getEnvOrDefault returns the environment variable value or a default.
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/cmd/instrument-cli/cmd/root.go
+++ b/cmd/instrument-cli/cmd/root.go
@@ -2,18 +2,34 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"strings"
+	"time"
 
+	"github.com/meridianhub/meridian/shared/platform/ports"
 	"github.com/spf13/cobra"
 )
 
-// serviceURL is the reference data service URL.
-var serviceURL string
+// Version information set at build time.
+var (
+	Version   = "dev"
+	GitCommit = "unknown"
+	BuildDate = "unknown"
+)
+
+// Global flags.
+var (
+	serviceURL   string
+	timeout      time.Duration
+	insecureMode bool
+)
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Use:   "instrument-cli",
-	Short: "Instrument simulation CLI for Meridian platform",
+	Use:     "instrument-cli",
+	Short:   "Instrument simulation CLI for Meridian platform",
+	Version: fmt.Sprintf("%s (commit: %s, built: %s)", Version, GitCommit, BuildDate),
 	Long: `instrument-cli is a command-line tool for simulating instrument transactions
 in the Meridian platform.
 
@@ -24,6 +40,10 @@ and position previews without persisting data. This is useful for:
   - Debugging validation failures in production
   - Understanding how attributes map to bucket IDs
   - Previewing position records before creation
+
+Exit Codes:
+  0 - Success (validation passed)
+  1 - Failure (validation failed or error occurred)
 
 Examples:
   # Simulate a USD transaction
@@ -46,7 +66,13 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&serviceURL, "service-url", getEnvOrDefault("REFERENCE_DATA_SERVICE_URL", "localhost:8080"), "Reference data service URL")
+	rootCmd.PersistentFlags().StringVar(&serviceURL, "service-url",
+		getEnvOrDefault("REFERENCE_DATA_SERVICE_URL", fmt.Sprintf("localhost:%d", ports.Gateway)),
+		"Reference data service URL")
+	rootCmd.PersistentFlags().DurationVar(&timeout, "timeout", 30*time.Second,
+		"gRPC call timeout")
+	rootCmd.PersistentFlags().BoolVar(&insecureMode, "insecure", false,
+		"Use insecure connection (no TLS). Required for local development.")
 }
 
 // getEnvOrDefault returns the environment variable value or a default.
@@ -55,4 +81,38 @@ func getEnvOrDefault(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
+}
+
+// handleGRPCError handles gRPC errors and prints user-friendly messages.
+// Returns exit code: 0 for success, 1 for errors.
+func handleGRPCError(err error, operation string) int {
+	if err == nil {
+		return 0
+	}
+
+	errStr := err.Error()
+
+	switch {
+	case strings.Contains(errStr, "NotFound"):
+		fmt.Fprintf(os.Stderr, "Error: %s not found\n", operation)
+		return 1
+	case strings.Contains(errStr, "InvalidArgument"):
+		fmt.Fprintf(os.Stderr, "Error: Invalid input for %s: %v\n", operation, err)
+		return 1
+	case strings.Contains(errStr, "FailedPrecondition"):
+		fmt.Fprintf(os.Stderr, "Error: Operation not allowed for %s: %v\n", operation, err)
+		return 1
+	case strings.Contains(errStr, "Unavailable"):
+		fmt.Fprintf(os.Stderr, "Error: Reference Data service unavailable: %v\n", err)
+		return 1
+	case strings.Contains(errStr, "DeadlineExceeded"):
+		fmt.Fprintf(os.Stderr, "Error: Request timeout for %s\n", operation)
+		return 1
+	case strings.Contains(errStr, "connection refused"):
+		fmt.Fprintf(os.Stderr, "Error: Cannot connect to %s. Is the service running?\n", serviceURL)
+		return 1
+	default:
+		fmt.Fprintf(os.Stderr, "Error: %s failed: %v\n", operation, err)
+		return 1
+	}
 }

--- a/cmd/instrument-cli/cmd/simulate.go
+++ b/cmd/instrument-cli/cmd/simulate.go
@@ -1,0 +1,572 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	refcel "github.com/meridianhub/meridian/services/reference-data/cel"
+)
+
+// Sentinel errors for CEL expression evaluation.
+var (
+	ErrAttributeFormat      = errors.New("attribute must be in key=value format")
+	ErrValidationReturnType = errors.New("validation expression must return boolean")
+	ErrBucketKeyReturnType  = errors.New("bucket key expression must return string")
+	ErrErrorMsgReturnType   = errors.New("error message expression must return string")
+)
+
+// SimulateResult contains the outcome of a simulation run.
+type SimulateResult struct {
+	// Input parameters
+	TenantID   string
+	Instrument string
+	Version    int
+	Amount     string
+	Attributes map[string]string
+	ValidFrom  *time.Time
+	ValidTo    *time.Time
+	Source     string
+
+	// Instrument definition
+	InstrumentDef *pb.InstrumentDefinition
+
+	// Validation results
+	ValidationPassed bool
+	ValidationErrors []string
+
+	// Bucket key results
+	BucketID       string
+	BucketIDErrors []string
+
+	// Position preview
+	PositionPreview *PositionPreview
+
+	// Error message (if validation failed)
+	CustomErrorMessage string
+}
+
+// PositionPreview represents a preview of the position record structure.
+type PositionPreview struct {
+	InstrumentCode string
+	Version        int
+	BucketID       string
+	Amount         string
+	Dimension      string
+	Attributes     map[string]string
+	ValidFrom      *time.Time
+	ValidTo        *time.Time
+	Source         string
+}
+
+var (
+	tenantID   string
+	instrument string
+	version    int
+	amount     string
+	attrs      []string
+	validFrom  string
+	validTo    string
+	source     string
+	outputJSON bool
+)
+
+// simulateCmd represents the simulate command.
+var simulateCmd = &cobra.Command{
+	Use:   "simulate",
+	Short: "Simulate a transaction for an instrument",
+	Long: `Simulate runs a full transaction dry run showing validation,
+bucket ID generation, and position preview.
+
+This command fetches the instrument definition from the Reference Data Service,
+evaluates CEL expressions for validation and bucket key generation, and
+outputs a formatted report of the results.
+
+Examples:
+  # Basic simulation
+  instrument-cli simulate --tenant=acme_bank --instrument=USD --amount=100.00
+
+  # With attributes for non-fungible instruments
+  instrument-cli simulate --tenant=acme_bank --instrument=CARBON_CREDIT \
+    --amount=50.00 --attr=vintage_year=2024 --attr=registry=VERRA
+
+  # With validity period
+  instrument-cli simulate --tenant=acme_bank --instrument=VOUCHER \
+    --amount=10 --valid-from=2024-01-01T00:00:00Z --valid-to=2024-12-31T23:59:59Z
+
+  # JSON output for scripting
+  instrument-cli simulate --tenant=acme_bank --instrument=USD --amount=100 --json`,
+	RunE: runSimulate,
+}
+
+func init() {
+	rootCmd.AddCommand(simulateCmd)
+
+	simulateCmd.Flags().StringVar(&tenantID, "tenant", "", "Tenant ID (required)")
+	simulateCmd.Flags().StringVar(&instrument, "instrument", "", "Instrument code (required)")
+	simulateCmd.Flags().IntVar(&version, "version", 0, "Instrument version (0 = latest active)")
+	simulateCmd.Flags().StringVar(&amount, "amount", "", "Transaction amount (required)")
+	simulateCmd.Flags().StringSliceVar(&attrs, "attr", nil, "Attributes as key=value (repeatable)")
+	simulateCmd.Flags().StringVar(&validFrom, "valid-from", "", "Validity start time (RFC3339)")
+	simulateCmd.Flags().StringVar(&validTo, "valid-to", "", "Validity end time (RFC3339)")
+	simulateCmd.Flags().StringVar(&source, "source", "", "Source identifier")
+	simulateCmd.Flags().BoolVar(&outputJSON, "json", false, "Output as JSON")
+
+	_ = simulateCmd.MarkFlagRequired("tenant")
+	_ = simulateCmd.MarkFlagRequired("instrument")
+	_ = simulateCmd.MarkFlagRequired("amount")
+}
+
+func runSimulate(cmd *cobra.Command, _ []string) error {
+	ctx := cmd.Context()
+
+	// Parse attributes
+	attributes, err := parseAttributes(attrs)
+	if err != nil {
+		return fmt.Errorf("invalid attributes: %w", err)
+	}
+
+	// Parse validity times
+	var validFromTime, validToTime *time.Time
+	if validFrom != "" {
+		t, err := time.Parse(time.RFC3339, validFrom)
+		if err != nil {
+			return fmt.Errorf("invalid valid-from time: %w", err)
+		}
+		validFromTime = &t
+	}
+	if validTo != "" {
+		t, err := time.Parse(time.RFC3339, validTo)
+		if err != nil {
+			return fmt.Errorf("invalid valid-to time: %w", err)
+		}
+		validToTime = &t
+	}
+
+	// Fetch instrument definition
+	instrDef, err := fetchInstrument(ctx, tenantID, instrument, version)
+	if err != nil {
+		return fmt.Errorf("failed to fetch instrument: %w", err)
+	}
+
+	// Run simulation
+	result := simulate(instrDef, attributes, amount, validFromTime, validToTime, source)
+	result.TenantID = tenantID
+	result.Instrument = instrument
+	result.Version = version
+	result.Amount = amount
+	result.Attributes = attributes
+	result.ValidFrom = validFromTime
+	result.ValidTo = validToTime
+	result.Source = source
+	result.InstrumentDef = instrDef
+
+	// Output results
+	if outputJSON {
+		printJSONResult(result)
+	} else {
+		printFormattedResult(result)
+	}
+
+	// Exit with non-zero code if validation failed
+	if !result.ValidationPassed {
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+func parseAttributes(attrs []string) (map[string]string, error) {
+	result := make(map[string]string)
+	for _, attr := range attrs {
+		parts := strings.SplitN(attr, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("%w: %q", ErrAttributeFormat, attr)
+		}
+		result[parts[0]] = parts[1]
+	}
+	return result, nil
+}
+
+func fetchInstrument(ctx context.Context, tenantID, code string, version int) (*pb.InstrumentDefinition, error) {
+	// Create gRPC connection
+	conn, err := grpc.NewClient(serviceURL, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect: %w", err)
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil {
+			slog.Debug("failed to close gRPC connection", "error", closeErr)
+		}
+	}()
+
+	client := pb.NewReferenceDataServiceClient(conn)
+
+	// Add tenant header
+	ctx = metadata.AppendToOutgoingContext(ctx, "x-tenant-id", tenantID)
+
+	// Fetch instrument
+	resp, err := client.RetrieveInstrument(ctx, &pb.RetrieveInstrumentRequest{
+		Code:    code,
+		Version: int32(version),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Instrument, nil
+}
+
+func simulate(
+	instrDef *pb.InstrumentDefinition,
+	attributes map[string]string,
+	amount string,
+	validFrom, validTo *time.Time,
+	source string,
+) *SimulateResult {
+	result := &SimulateResult{
+		ValidationPassed: true,
+	}
+
+	// Create CEL compiler
+	compiler, err := refcel.NewCompiler()
+	if err != nil {
+		result.ValidationPassed = false
+		result.ValidationErrors = append(result.ValidationErrors, fmt.Sprintf("failed to create CEL compiler: %v", err))
+		return result
+	}
+
+	// Build CEL input
+	input := buildCELInput(attributes, amount, validFrom, validTo, source)
+	bucketInput := map[string]any{"attributes": attributes}
+
+	// Run validation expression
+	if instrDef.ValidationExpression != "" {
+		validationPassed, validationErr := evalValidation(compiler, instrDef.ValidationExpression, input)
+		if validationErr != nil {
+			result.ValidationPassed = false
+			result.ValidationErrors = append(result.ValidationErrors, validationErr.Error())
+		} else if !validationPassed {
+			result.ValidationPassed = false
+			result.ValidationErrors = append(result.ValidationErrors, "validation expression returned false")
+		}
+	}
+
+	// Generate bucket key
+	if instrDef.FungibilityKeyExpression != "" {
+		bucketKey, bucketErr := evalBucketKey(compiler, instrDef.FungibilityKeyExpression, bucketInput)
+		if bucketErr != nil {
+			result.BucketIDErrors = append(result.BucketIDErrors, bucketErr.Error())
+		} else {
+			result.BucketID = bucketKey
+		}
+	} else {
+		// Default bucket key: instrument code only (fully fungible)
+		result.BucketID = generateDefaultBucketKey(instrDef.Code, int(instrDef.Version))
+	}
+
+	// Generate custom error message if validation failed
+	if !result.ValidationPassed && instrDef.ErrorMessageExpression != "" {
+		errorMsg, _ := evalErrorMessage(compiler, instrDef.ErrorMessageExpression, input)
+		result.CustomErrorMessage = errorMsg
+	}
+
+	// Build position preview
+	result.PositionPreview = &PositionPreview{
+		InstrumentCode: instrDef.Code,
+		Version:        int(instrDef.Version),
+		BucketID:       result.BucketID,
+		Amount:         amount,
+		Dimension:      dimensionToString(instrDef.Dimension),
+		Attributes:     attributes,
+		ValidFrom:      validFrom,
+		ValidTo:        validTo,
+		Source:         source,
+	}
+
+	return result
+}
+
+func buildCELInput(attributes map[string]string, amount string, validFrom, validTo *time.Time, source string) map[string]any {
+	input := map[string]any{
+		"attributes": attributes,
+		"amount":     amount,
+		"source":     source,
+	}
+	if validFrom != nil {
+		input["valid_from"] = *validFrom
+	} else {
+		input["valid_from"] = time.Time{}
+	}
+	if validTo != nil {
+		input["valid_to"] = *validTo
+	} else {
+		input["valid_to"] = time.Time{}
+	}
+	return input
+}
+
+func evalValidation(compiler *refcel.Compiler, expr string, input map[string]any) (bool, error) {
+	prg, err := compiler.CompileValidation(expr)
+	if err != nil {
+		return false, fmt.Errorf("compilation failed: %w", err)
+	}
+
+	out, _, evalErr := prg.Eval(input)
+	if evalErr != nil {
+		return false, fmt.Errorf("evaluation failed: %w", evalErr)
+	}
+
+	b, ok := out.Value().(bool)
+	if !ok {
+		return false, ErrValidationReturnType
+	}
+
+	return b, nil
+}
+
+func evalBucketKey(compiler *refcel.Compiler, expr string, input map[string]any) (string, error) {
+	prg, err := compiler.CompileBucketKey(expr)
+	if err != nil {
+		return "", fmt.Errorf("compilation failed: %w", err)
+	}
+
+	out, _, evalErr := prg.Eval(input)
+	if evalErr != nil {
+		return "", fmt.Errorf("evaluation failed: %w", evalErr)
+	}
+
+	s, ok := out.Value().(string)
+	if !ok {
+		return "", ErrBucketKeyReturnType
+	}
+
+	return s, nil
+}
+
+func evalErrorMessage(compiler *refcel.Compiler, expr string, input map[string]any) (string, error) {
+	// Error message uses validation environment (has access to all variables)
+	prg, err := compiler.CompileValidation(expr)
+	if err != nil {
+		return "", fmt.Errorf("compilation failed: %w", err)
+	}
+
+	out, _, evalErr := prg.Eval(input)
+	if evalErr != nil {
+		return "", fmt.Errorf("evaluation failed: %w", evalErr)
+	}
+
+	s, ok := out.Value().(string)
+	if !ok {
+		return "", ErrErrorMsgReturnType
+	}
+
+	return s, nil
+}
+
+// generateDefaultBucketKey generates a bucket key using the same algorithm as the CEL bucket_key function.
+func generateDefaultBucketKey(code string, version int) string {
+	hasher := sha256.New()
+
+	// Write code length prefix and value
+	lenBytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(lenBytes, uint32(len(code)))
+	hasher.Write(lenBytes)
+	hasher.Write([]byte(code))
+
+	// Write version as string
+	versionStr := fmt.Sprintf("%d", version)
+	binary.BigEndian.PutUint32(lenBytes, uint32(len(versionStr)))
+	hasher.Write(lenBytes)
+	hasher.Write([]byte(versionStr))
+
+	return hex.EncodeToString(hasher.Sum(nil))
+}
+
+func dimensionToString(d pb.Dimension) string {
+	switch d {
+	case pb.Dimension_DIMENSION_UNSPECIFIED:
+		return "UNKNOWN"
+	case pb.Dimension_DIMENSION_CURRENCY:
+		return "MONETARY"
+	case pb.Dimension_DIMENSION_ENERGY:
+		return "ENERGY"
+	case pb.Dimension_DIMENSION_MASS:
+		return "MASS"
+	case pb.Dimension_DIMENSION_VOLUME:
+		return "VOLUME"
+	case pb.Dimension_DIMENSION_TIME:
+		return "TIME"
+	case pb.Dimension_DIMENSION_COMPUTE:
+		return "COMPUTE"
+	case pb.Dimension_DIMENSION_CARBON:
+		return "CARBON"
+	case pb.Dimension_DIMENSION_DATA:
+		return "DATA"
+	case pb.Dimension_DIMENSION_COUNT:
+		return "COUNT"
+	}
+	return "UNKNOWN"
+}
+
+func printFormattedResult(result *SimulateResult) {
+	fmt.Println()
+	fmt.Println("╭─────────────────────────────────────────────────────────────────────────╮")
+	fmt.Println("│                    INSTRUMENT SIMULATION REPORT                         │")
+	fmt.Println("╰─────────────────────────────────────────────────────────────────────────╯")
+	fmt.Println()
+
+	printInputSection(result)
+	printValidationSection(result)
+	printBucketIDSection(result)
+	printPositionPreviewSection(result)
+	fmt.Println()
+}
+
+func printInputSection(result *SimulateResult) {
+	fmt.Println("┌─ INPUT ────────────────────────────────────────────────────────────────┐")
+	fmt.Printf("│ Tenant:     %-60s│\n", result.TenantID)
+	fmt.Printf("│ Instrument: %-60s│\n", result.Instrument)
+	if result.InstrumentDef != nil {
+		fmt.Printf("│ Version:    %-60s│\n", fmt.Sprintf("%d (%s)", result.InstrumentDef.Version, result.InstrumentDef.DisplayName))
+	}
+	fmt.Printf("│ Amount:     %-60s│\n", result.Amount)
+	printAttributesInSection(result.Attributes)
+	if result.ValidFrom != nil {
+		fmt.Printf("│ Valid From: %-60s│\n", result.ValidFrom.Format(time.RFC3339))
+	}
+	if result.ValidTo != nil {
+		fmt.Printf("│ Valid To:   %-60s│\n", result.ValidTo.Format(time.RFC3339))
+	}
+	if result.Source != "" {
+		fmt.Printf("│ Source:     %-60s│\n", result.Source)
+	}
+	fmt.Println("└────────────────────────────────────────────────────────────────────────┘")
+	fmt.Println()
+}
+
+func printAttributesInSection(attributes map[string]string) {
+	if len(attributes) == 0 {
+		return
+	}
+	fmt.Println("│ Attributes:                                                            │")
+	keys := sortedKeys(attributes)
+	for _, k := range keys {
+		fmt.Printf("│   %s = %-57s│\n", k, attributes[k])
+	}
+}
+
+func printValidationSection(result *SimulateResult) {
+	fmt.Println("┌─ VALIDATION ───────────────────────────────────────────────────────────┐")
+	if result.ValidationPassed {
+		fmt.Println("│ Status: ✓ PASSED                                                       │")
+	} else {
+		fmt.Println("│ Status: ✗ FAILED                                                       │")
+		for _, err := range result.ValidationErrors {
+			fmt.Printf("│ Error:  %-64s│\n", truncate(err, 64))
+		}
+		if result.CustomErrorMessage != "" {
+			fmt.Printf("│ Message: %-63s│\n", truncate(result.CustomErrorMessage, 63))
+		}
+	}
+	fmt.Println("└────────────────────────────────────────────────────────────────────────┘")
+	fmt.Println()
+}
+
+func printBucketIDSection(result *SimulateResult) {
+	fmt.Println("┌─ BUCKET ID ────────────────────────────────────────────────────────────┐")
+	if len(result.BucketIDErrors) > 0 {
+		fmt.Println("│ Status: ✗ GENERATION FAILED                                           │")
+		for _, err := range result.BucketIDErrors {
+			fmt.Printf("│ Error:  %-64s│\n", truncate(err, 64))
+		}
+	} else {
+		fmt.Println("│ Status: ✓ GENERATED                                                    │")
+		fmt.Printf("│ ID:     %-64s│\n", result.BucketID)
+	}
+	fmt.Println("└────────────────────────────────────────────────────────────────────────┘")
+	fmt.Println()
+}
+
+func printPositionPreviewSection(result *SimulateResult) {
+	if result.PositionPreview == nil {
+		return
+	}
+	fmt.Println("┌─ POSITION PREVIEW ─────────────────────────────────────────────────────┐")
+	fmt.Printf("│ instrument_code: %-55s│\n", result.PositionPreview.InstrumentCode)
+	fmt.Printf("│ version:         %-55s│\n", fmt.Sprintf("%d", result.PositionPreview.Version))
+	fmt.Printf("│ bucket_id:       %-55s│\n", truncate(result.PositionPreview.BucketID, 55))
+	fmt.Printf("│ amount:          %-55s│\n", result.PositionPreview.Amount)
+	fmt.Printf("│ dimension:       %-55s│\n", result.PositionPreview.Dimension)
+	if len(result.PositionPreview.Attributes) > 0 {
+		fmt.Println("│ attributes:                                                            │")
+		keys := sortedKeys(result.PositionPreview.Attributes)
+		for _, k := range keys {
+			fmt.Printf("│   %s: %-60s│\n", k, result.PositionPreview.Attributes[k])
+		}
+	}
+	fmt.Println("└────────────────────────────────────────────────────────────────────────┘")
+}
+
+func printJSONResult(result *SimulateResult) {
+	// Simple JSON output for scripting
+	fmt.Println("{")
+	fmt.Printf("  \"tenant_id\": %q,\n", result.TenantID)
+	fmt.Printf("  \"instrument\": %q,\n", result.Instrument)
+	if result.InstrumentDef != nil {
+		fmt.Printf("  \"version\": %d,\n", result.InstrumentDef.Version)
+	}
+	fmt.Printf("  \"amount\": %q,\n", result.Amount)
+	fmt.Printf("  \"validation_passed\": %t,\n", result.ValidationPassed)
+	if len(result.ValidationErrors) > 0 {
+		fmt.Printf("  \"validation_errors\": %q,\n", strings.Join(result.ValidationErrors, "; "))
+	}
+	fmt.Printf("  \"bucket_id\": %q,\n", result.BucketID)
+	if result.CustomErrorMessage != "" {
+		fmt.Printf("  \"error_message\": %q,\n", result.CustomErrorMessage)
+	}
+	if result.PositionPreview != nil {
+		fmt.Printf("  \"position_preview\": {\n")
+		fmt.Printf("    \"instrument_code\": %q,\n", result.PositionPreview.InstrumentCode)
+		fmt.Printf("    \"version\": %d,\n", result.PositionPreview.Version)
+		fmt.Printf("    \"bucket_id\": %q,\n", result.PositionPreview.BucketID)
+		fmt.Printf("    \"amount\": %q,\n", result.PositionPreview.Amount)
+		fmt.Printf("    \"dimension\": %q\n", result.PositionPreview.Dimension)
+		fmt.Printf("  }\n")
+	}
+	fmt.Println("}")
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-3] + "..."
+}
+
+// Ensure cel.Program is used (imported for type checking)
+var _ cel.Program

--- a/cmd/instrument-cli/cmd/simulate.go
+++ b/cmd/instrument-cli/cmd/simulate.go
@@ -3,8 +3,10 @@ package cmd
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/tls"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -13,9 +15,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/cel-go/cel"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 
@@ -29,49 +31,50 @@ var (
 	ErrValidationReturnType = errors.New("validation expression must return boolean")
 	ErrBucketKeyReturnType  = errors.New("bucket key expression must return string")
 	ErrErrorMsgReturnType   = errors.New("error message expression must return string")
+	ErrValidationFailed     = errors.New("validation failed")
 )
 
 // SimulateResult contains the outcome of a simulation run.
 type SimulateResult struct {
 	// Input parameters
-	TenantID   string
-	Instrument string
-	Version    int
-	Amount     string
-	Attributes map[string]string
-	ValidFrom  *time.Time
-	ValidTo    *time.Time
-	Source     string
+	TenantID   string            `json:"tenant_id"`
+	Instrument string            `json:"instrument"`
+	Version    int               `json:"version,omitempty"`
+	Amount     string            `json:"amount"`
+	Attributes map[string]string `json:"attributes,omitempty"`
+	ValidFrom  *time.Time        `json:"valid_from,omitempty"`
+	ValidTo    *time.Time        `json:"valid_to,omitempty"`
+	Source     string            `json:"source,omitempty"`
 
-	// Instrument definition
-	InstrumentDef *pb.InstrumentDefinition
+	// Instrument definition (excluded from JSON)
+	InstrumentDef *pb.InstrumentDefinition `json:"-"`
 
 	// Validation results
-	ValidationPassed bool
-	ValidationErrors []string
+	ValidationPassed bool     `json:"validation_passed"`
+	ValidationErrors []string `json:"validation_errors,omitempty"`
 
 	// Bucket key results
-	BucketID       string
-	BucketIDErrors []string
+	BucketID       string   `json:"bucket_id"`
+	BucketIDErrors []string `json:"bucket_id_errors,omitempty"`
 
 	// Position preview
-	PositionPreview *PositionPreview
+	PositionPreview *PositionPreview `json:"position_preview,omitempty"`
 
 	// Error message (if validation failed)
-	CustomErrorMessage string
+	CustomErrorMessage string `json:"error_message,omitempty"`
 }
 
 // PositionPreview represents a preview of the position record structure.
 type PositionPreview struct {
-	InstrumentCode string
-	Version        int
-	BucketID       string
-	Amount         string
-	Dimension      string
-	Attributes     map[string]string
-	ValidFrom      *time.Time
-	ValidTo        *time.Time
-	Source         string
+	InstrumentCode string            `json:"instrument_code"`
+	Version        int               `json:"version"`
+	BucketID       string            `json:"bucket_id"`
+	Amount         string            `json:"amount"`
+	Dimension      string            `json:"dimension"`
+	Attributes     map[string]string `json:"attributes,omitempty"`
+	ValidFrom      *time.Time        `json:"valid_from,omitempty"`
+	ValidTo        *time.Time        `json:"valid_to,omitempty"`
+	Source         string            `json:"source,omitempty"`
 }
 
 var (
@@ -110,8 +113,12 @@ Examples:
     --amount=10 --valid-from=2024-01-01T00:00:00Z --valid-to=2024-12-31T23:59:59Z
 
   # JSON output for scripting
-  instrument-cli simulate --tenant=acme_bank --instrument=USD --amount=100 --json`,
-	RunE: runSimulate,
+  instrument-cli simulate --tenant=acme_bank --instrument=USD --amount=100 --json
+
+  # Local development (insecure connection)
+  instrument-cli simulate --insecure --tenant=acme_bank --instrument=USD --amount=100`,
+	RunE:          runSimulateWrapper,
+	SilenceErrors: true, // We handle errors ourselves for proper exit codes
 }
 
 func init() {
@@ -132,8 +139,30 @@ func init() {
 	_ = simulateCmd.MarkFlagRequired("amount")
 }
 
+// runSimulateWrapper handles exit codes for the simulate command.
+// This wrapper exists to avoid exitAfterDefer linter warnings by keeping
+// os.Exit calls separate from functions with deferred cleanup.
+func runSimulateWrapper(cmd *cobra.Command, args []string) error {
+	err := runSimulate(cmd, args)
+	if err == nil {
+		return nil
+	}
+
+	// Handle validation failure - exit 1 (output already printed)
+	if errors.Is(err, ErrValidationFailed) {
+		os.Exit(1)
+	}
+
+	// For other errors, print and exit
+	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	os.Exit(1)
+	return nil // unreachable but satisfies compiler
+}
+
 func runSimulate(cmd *cobra.Command, _ []string) error {
-	ctx := cmd.Context()
+	// Create context with timeout
+	ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+	defer cancel()
 
 	// Parse attributes
 	attributes, err := parseAttributes(attrs)
@@ -161,7 +190,8 @@ func runSimulate(cmd *cobra.Command, _ []string) error {
 	// Fetch instrument definition
 	instrDef, err := fetchInstrument(ctx, tenantID, instrument, version)
 	if err != nil {
-		return fmt.Errorf("failed to fetch instrument: %w", err)
+		handleGRPCError(err, fmt.Sprintf("Instrument %s", instrument))
+		return fmt.Errorf("fetch instrument: %w", err)
 	}
 
 	// Run simulation
@@ -178,14 +208,16 @@ func runSimulate(cmd *cobra.Command, _ []string) error {
 
 	// Output results
 	if outputJSON {
-		printJSONResult(result)
+		if err := printJSONResult(result); err != nil {
+			return fmt.Errorf("failed to encode JSON: %w", err)
+		}
 	} else {
 		printFormattedResult(result)
 	}
 
-	// Exit with non-zero code if validation failed
+	// Return error if validation failed (wrapper handles exit code)
 	if !result.ValidationPassed {
-		os.Exit(1)
+		return ErrValidationFailed
 	}
 
 	return nil
@@ -204,8 +236,16 @@ func parseAttributes(attrs []string) (map[string]string, error) {
 }
 
 func fetchInstrument(ctx context.Context, tenantID, code string, version int) (*pb.InstrumentDefinition, error) {
+	// Configure transport credentials
+	var creds credentials.TransportCredentials
+	if insecureMode {
+		creds = insecure.NewCredentials()
+	} else {
+		creds = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
+	}
+
 	// Create gRPC connection
-	conn, err := grpc.NewClient(serviceURL, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(serviceURL, grpc.WithTransportCredentials(creds))
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect: %w", err)
 	}
@@ -523,33 +563,10 @@ func printPositionPreviewSection(result *SimulateResult) {
 	fmt.Println("└────────────────────────────────────────────────────────────────────────┘")
 }
 
-func printJSONResult(result *SimulateResult) {
-	// Simple JSON output for scripting
-	fmt.Println("{")
-	fmt.Printf("  \"tenant_id\": %q,\n", result.TenantID)
-	fmt.Printf("  \"instrument\": %q,\n", result.Instrument)
-	if result.InstrumentDef != nil {
-		fmt.Printf("  \"version\": %d,\n", result.InstrumentDef.Version)
-	}
-	fmt.Printf("  \"amount\": %q,\n", result.Amount)
-	fmt.Printf("  \"validation_passed\": %t,\n", result.ValidationPassed)
-	if len(result.ValidationErrors) > 0 {
-		fmt.Printf("  \"validation_errors\": %q,\n", strings.Join(result.ValidationErrors, "; "))
-	}
-	fmt.Printf("  \"bucket_id\": %q,\n", result.BucketID)
-	if result.CustomErrorMessage != "" {
-		fmt.Printf("  \"error_message\": %q,\n", result.CustomErrorMessage)
-	}
-	if result.PositionPreview != nil {
-		fmt.Printf("  \"position_preview\": {\n")
-		fmt.Printf("    \"instrument_code\": %q,\n", result.PositionPreview.InstrumentCode)
-		fmt.Printf("    \"version\": %d,\n", result.PositionPreview.Version)
-		fmt.Printf("    \"bucket_id\": %q,\n", result.PositionPreview.BucketID)
-		fmt.Printf("    \"amount\": %q,\n", result.PositionPreview.Amount)
-		fmt.Printf("    \"dimension\": %q\n", result.PositionPreview.Dimension)
-		fmt.Printf("  }\n")
-	}
-	fmt.Println("}")
+func printJSONResult(result *SimulateResult) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(result)
 }
 
 func sortedKeys(m map[string]string) []string {
@@ -562,11 +579,11 @@ func sortedKeys(m map[string]string) []string {
 }
 
 func truncate(s string, maxLen int) string {
+	if maxLen < 4 {
+		maxLen = 4 // Minimum length to show "..."
+	}
 	if len(s) <= maxLen {
 		return s
 	}
 	return s[:maxLen-3] + "..."
 }
-
-// Ensure cel.Program is used (imported for type checking)
-var _ cel.Program

--- a/cmd/instrument-cli/cmd/simulate_test.go
+++ b/cmd/instrument-cli/cmd/simulate_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -49,6 +50,7 @@ func TestParseAttributes(t *testing.T) {
 			got, err := parseAttributes(tt.attrs)
 			if tt.wantErr {
 				assert.Error(t, err)
+				assert.True(t, errors.Is(err, ErrAttributeFormat))
 				return
 			}
 			require.NoError(t, err)
@@ -84,19 +86,57 @@ func TestDimensionToString(t *testing.T) {
 
 func TestTruncate(t *testing.T) {
 	tests := []struct {
+		name   string
 		input  string
 		maxLen int
 		want   string
 	}{
-		{"short", 10, "short"},
-		{"exactly_10", 10, "exactly_10"},
-		{"this is too long", 10, "this is..."},
-		{"", 10, ""},
-		{"hello", 3, "..."},
+		{
+			name:   "short string within limit",
+			input:  "short",
+			maxLen: 10,
+			want:   "short",
+		},
+		{
+			name:   "string at exact limit",
+			input:  "exactly_10",
+			maxLen: 10,
+			want:   "exactly_10",
+		},
+		{
+			name:   "string exceeds limit",
+			input:  "this is too long",
+			maxLen: 10,
+			want:   "this is...",
+		},
+		{
+			name:   "empty string",
+			input:  "",
+			maxLen: 10,
+			want:   "",
+		},
+		{
+			name:   "maxLen below minimum enforces minimum",
+			input:  "hello",
+			maxLen: 3,
+			want:   "h...", // minLen enforced to 4, then truncates
+		},
+		{
+			name:   "maxLen of zero enforces minimum",
+			input:  "testing",
+			maxLen: 0,
+			want:   "t...", // minLen enforced to 4
+		},
+		{
+			name:   "short string with small maxLen",
+			input:  "hi",
+			maxLen: 2,
+			want:   "hi", // len(s) <= enforced minLen of 4
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			got := truncate(tt.input, tt.maxLen)
 			assert.Equal(t, tt.want, got)
 		})
@@ -223,6 +263,25 @@ func TestSimulate_CustomErrorMessage(t *testing.T) {
 	assert.Equal(t, "Transaction of 100.00 failed validation", result.CustomErrorMessage)
 }
 
+func TestSimulate_ErrorMessageExpressionTypeError(t *testing.T) {
+	// Error message expression returns boolean instead of string
+	instrDef := &pb.InstrumentDefinition{
+		Code:                   "USD",
+		Version:                1,
+		Dimension:              pb.Dimension_DIMENSION_CURRENCY,
+		Precision:              2,
+		Status:                 pb.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+		ValidationExpression:   "false",
+		ErrorMessageExpression: "true", // Returns bool, not string
+		CreatedAt:              timestamppb.Now(),
+	}
+
+	result := simulate(instrDef, map[string]string{}, "100.00", nil, nil, "")
+	assert.False(t, result.ValidationPassed)
+	// Error message should be empty because expression returned wrong type
+	assert.Empty(t, result.CustomErrorMessage)
+}
+
 func TestGenerateDefaultBucketKey(t *testing.T) {
 	// Same code+version should generate same key
 	key1 := generateDefaultBucketKey("USD", 1)
@@ -236,4 +295,20 @@ func TestGenerateDefaultBucketKey(t *testing.T) {
 	// Different version should generate different key
 	key4 := generateDefaultBucketKey("USD", 2)
 	assert.NotEqual(t, key1, key4)
+}
+
+func TestSentinelErrors(t *testing.T) {
+	// Verify sentinel errors are properly defined
+	assert.NotNil(t, ErrAttributeFormat)
+	assert.NotNil(t, ErrValidationReturnType)
+	assert.NotNil(t, ErrBucketKeyReturnType)
+	assert.NotNil(t, ErrErrorMsgReturnType)
+	assert.NotNil(t, ErrValidationFailed)
+
+	// Verify error messages are descriptive
+	assert.Contains(t, ErrAttributeFormat.Error(), "key=value")
+	assert.Contains(t, ErrValidationReturnType.Error(), "boolean")
+	assert.Contains(t, ErrBucketKeyReturnType.Error(), "string")
+	assert.Contains(t, ErrErrorMsgReturnType.Error(), "string")
+	assert.Contains(t, ErrValidationFailed.Error(), "validation")
 }

--- a/cmd/instrument-cli/cmd/simulate_test.go
+++ b/cmd/instrument-cli/cmd/simulate_test.go
@@ -1,0 +1,239 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestParseAttributes(t *testing.T) {
+	tests := []struct {
+		name    string
+		attrs   []string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:  "empty attributes",
+			attrs: nil,
+			want:  map[string]string{},
+		},
+		{
+			name:  "single attribute",
+			attrs: []string{"key=value"},
+			want:  map[string]string{"key": "value"},
+		},
+		{
+			name:  "multiple attributes",
+			attrs: []string{"key1=value1", "key2=value2"},
+			want:  map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		{
+			name:  "attribute with equals in value",
+			attrs: []string{"equation=a=b"},
+			want:  map[string]string{"equation": "a=b"},
+		},
+		{
+			name:    "invalid attribute format",
+			attrs:   []string{"no_equals_sign"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAttributes(tt.attrs)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDimensionToString(t *testing.T) {
+	tests := []struct {
+		dimension pb.Dimension
+		want      string
+	}{
+		{pb.Dimension_DIMENSION_CURRENCY, "MONETARY"},
+		{pb.Dimension_DIMENSION_ENERGY, "ENERGY"},
+		{pb.Dimension_DIMENSION_MASS, "MASS"},
+		{pb.Dimension_DIMENSION_VOLUME, "VOLUME"},
+		{pb.Dimension_DIMENSION_TIME, "TIME"},
+		{pb.Dimension_DIMENSION_COMPUTE, "COMPUTE"},
+		{pb.Dimension_DIMENSION_CARBON, "CARBON"},
+		{pb.Dimension_DIMENSION_DATA, "DATA"},
+		{pb.Dimension_DIMENSION_COUNT, "COUNT"},
+		{pb.Dimension_DIMENSION_UNSPECIFIED, "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := dimensionToString(tt.dimension)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"short", 10, "short"},
+		{"exactly_10", 10, "exactly_10"},
+		{"this is too long", 10, "this is..."},
+		{"", 10, ""},
+		{"hello", 3, "..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := truncate(tt.input, tt.maxLen)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSortedKeys(t *testing.T) {
+	m := map[string]string{
+		"zebra": "z",
+		"apple": "a",
+		"mango": "m",
+	}
+	got := sortedKeys(m)
+	assert.Equal(t, []string{"apple", "mango", "zebra"}, got)
+}
+
+func TestSimulate_BasicValidation(t *testing.T) {
+	instrDef := &pb.InstrumentDefinition{
+		Code:                 "USD",
+		Version:              1,
+		Dimension:            pb.Dimension_DIMENSION_CURRENCY,
+		Precision:            2,
+		Status:               pb.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+		ValidationExpression: "true",
+		CreatedAt:            timestamppb.Now(),
+	}
+
+	result := simulate(instrDef, map[string]string{}, "100.00", nil, nil, "")
+	assert.True(t, result.ValidationPassed)
+	assert.Empty(t, result.ValidationErrors)
+	assert.NotEmpty(t, result.BucketID)
+}
+
+func TestSimulate_ValidationFailure(t *testing.T) {
+	instrDef := &pb.InstrumentDefinition{
+		Code:                 "USD",
+		Version:              1,
+		Dimension:            pb.Dimension_DIMENSION_CURRENCY,
+		Precision:            2,
+		Status:               pb.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+		ValidationExpression: "false",
+		CreatedAt:            timestamppb.Now(),
+	}
+
+	result := simulate(instrDef, map[string]string{}, "100.00", nil, nil, "")
+	assert.False(t, result.ValidationPassed)
+	assert.NotEmpty(t, result.ValidationErrors)
+}
+
+func TestSimulate_BucketKeyGeneration(t *testing.T) {
+	instrDef := &pb.InstrumentDefinition{
+		Code:                     "CARBON_CREDIT",
+		Version:                  1,
+		Dimension:                pb.Dimension_DIMENSION_CARBON,
+		Precision:                4,
+		Status:                   pb.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+		FungibilityKeyExpression: `"CARBON_CREDIT:" + attributes.vintage_year + ":" + attributes.registry`,
+		CreatedAt:                timestamppb.Now(),
+	}
+
+	attrs := map[string]string{
+		"vintage_year": "2024",
+		"registry":     "VERRA",
+	}
+
+	result := simulate(instrDef, attrs, "50.00", nil, nil, "")
+	assert.True(t, result.ValidationPassed)
+	assert.Equal(t, "CARBON_CREDIT:2024:VERRA", result.BucketID)
+}
+
+func TestSimulate_DefaultBucketKey(t *testing.T) {
+	instrDef := &pb.InstrumentDefinition{
+		Code:      "USD",
+		Version:   1,
+		Dimension: pb.Dimension_DIMENSION_CURRENCY,
+		Precision: 2,
+		Status:    pb.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+		CreatedAt: timestamppb.Now(),
+	}
+
+	result := simulate(instrDef, map[string]string{}, "100.00", nil, nil, "")
+	assert.NotEmpty(t, result.BucketID)
+	// Default bucket key should be deterministic for same code+version
+	result2 := simulate(instrDef, map[string]string{}, "200.00", nil, nil, "")
+	assert.Equal(t, result.BucketID, result2.BucketID)
+}
+
+func TestSimulate_PositionPreview(t *testing.T) {
+	instrDef := &pb.InstrumentDefinition{
+		Code:      "KWH",
+		Version:   1,
+		Dimension: pb.Dimension_DIMENSION_ENERGY,
+		Precision: 6,
+		Status:    pb.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+		CreatedAt: timestamppb.Now(),
+	}
+
+	attrs := map[string]string{"meter_id": "M001"}
+	result := simulate(instrDef, attrs, "123.456789", nil, nil, "grid_feed")
+
+	require.NotNil(t, result.PositionPreview)
+	assert.Equal(t, "KWH", result.PositionPreview.InstrumentCode)
+	assert.Equal(t, 1, result.PositionPreview.Version)
+	assert.Equal(t, "123.456789", result.PositionPreview.Amount)
+	assert.Equal(t, "ENERGY", result.PositionPreview.Dimension)
+	assert.Equal(t, "M001", result.PositionPreview.Attributes["meter_id"])
+	assert.Equal(t, "grid_feed", result.PositionPreview.Source)
+}
+
+func TestSimulate_CustomErrorMessage(t *testing.T) {
+	instrDef := &pb.InstrumentDefinition{
+		Code:                   "USD",
+		Version:                1,
+		Dimension:              pb.Dimension_DIMENSION_CURRENCY,
+		Precision:              2,
+		Status:                 pb.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+		ValidationExpression:   "false",
+		ErrorMessageExpression: `"Transaction of " + amount + " failed validation"`,
+		CreatedAt:              timestamppb.Now(),
+	}
+
+	result := simulate(instrDef, map[string]string{}, "100.00", nil, nil, "")
+	assert.False(t, result.ValidationPassed)
+	assert.Equal(t, "Transaction of 100.00 failed validation", result.CustomErrorMessage)
+}
+
+func TestGenerateDefaultBucketKey(t *testing.T) {
+	// Same code+version should generate same key
+	key1 := generateDefaultBucketKey("USD", 1)
+	key2 := generateDefaultBucketKey("USD", 1)
+	assert.Equal(t, key1, key2)
+
+	// Different code should generate different key
+	key3 := generateDefaultBucketKey("EUR", 1)
+	assert.NotEqual(t, key1, key3)
+
+	// Different version should generate different key
+	key4 := generateDefaultBucketKey("USD", 2)
+	assert.NotEqual(t, key1, key4)
+}

--- a/cmd/instrument-cli/main.go
+++ b/cmd/instrument-cli/main.go
@@ -1,0 +1,12 @@
+// Package main is the entry point for the instrument-cli CLI.
+//
+// instrument-cli is a command-line tool for simulating instrument transactions.
+// It provides dry-run capabilities to test validation rules, bucket key generation,
+// and position previews without persisting data.
+package main
+
+import "github.com/meridianhub/meridian/cmd/instrument-cli/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary

- Add `instrument-cli` CLI tool for simulating instrument transactions without persisting data
- Enable developers to test CEL validation expressions and bucket key generation
- Preview position record structure before deployment

## Changes Made

- **cmd/instrument-cli/main.go**: Entry point for the CLI
- **cmd/instrument-cli/cmd/root.go**: Root command with service URL configuration
- **cmd/instrument-cli/cmd/simulate.go**: Main simulation logic including:
  - gRPC client for Reference Data Service
  - CEL expression compilation and evaluation
  - Formatted human-readable output with Unicode box-drawing
  - JSON output mode for scripting
  - Position preview generation
- **cmd/instrument-cli/cmd/simulate_test.go**: Unit tests covering:
  - Attribute parsing
  - Dimension string conversion
  - Validation, bucket key, and error message evaluation
  - Position preview generation

## Technical Details

The CLI fetches instrument definitions from the Reference Data Service via gRPC, compiles and evaluates CEL expressions for validation and bucket key generation, then outputs either a formatted report or JSON.

### Usage Examples

```bash
# Basic simulation
instrument-cli simulate --tenant=acme_bank --instrument=USD --amount=100.00

# With attributes for non-fungible instruments
instrument-cli simulate --tenant=acme_bank --instrument=CARBON_CREDIT \
  --amount=50.00 --attr=vintage_year=2024 --attr=registry=VERRA

# JSON output for scripting
instrument-cli simulate --tenant=acme_bank --instrument=USD --amount=100 --json
```

## Testing

- All 12 unit tests pass
- Integration tested with Reference Data Service (manual)

## Task Reference

Task: universal-asset-system.17