### PR TITLE
feat(position-keeping): add CEL validation and bucket key generation to RecordMeasurement

### DIFF
--- a/services/position-keeping/adapters/persistence/measurement_repository.go
+++ b/services/position-keeping/adapters/persistence/measurement_repository.go
@@ -96,16 +96,22 @@ func (r *MeasurementRepository) Create(ctx context.Context, measurement *domain.
 	query := `
 		INSERT INTO measurement (
 			id, created_at, created_by, updated_at, updated_by,
-			financial_position_log_id, measurement_type, value, unit, timestamp, metadata
+			financial_position_log_id, measurement_type, value, unit, timestamp, metadata, bucket_id
 		) VALUES (
 			$1, $2, $3, $4, $5,
-			$6, $7, $8, $9, $10, $11
+			$6, $7, $8, $9, $10, $11, $12
 		)`
+
+	// Convert empty bucket_id to NULL for database storage
+	var bucketID *string
+	if measurement.BucketID != "" {
+		bucketID = &measurement.BucketID
+	}
 
 	_, err = tx.Exec(ctx, query,
 		measurement.ID, measurement.CreatedAt, userID, measurement.UpdatedAt, userID,
 		dbPositionLogID, measurement.MeasurementType.String(), measurement.Value,
-		measurement.Unit, measurement.Timestamp, metadataJSON,
+		measurement.Unit, measurement.Timestamp, metadataJSON, bucketID,
 	)
 	if err != nil {
 		var pgErr *pgconn.PgError
@@ -144,7 +150,7 @@ func (r *MeasurementRepository) FindByID(ctx context.Context, id uuid.UUID) (*do
 
 	// Join with financial_position_log to get the log_id (domain ID) from the db ID
 	query := `
-		SELECT m.id, fpl.log_id, m.measurement_type, m.value, m.unit, m.timestamp, m.metadata,
+		SELECT m.id, fpl.log_id, m.measurement_type, m.value, m.unit, m.timestamp, m.metadata, m.bucket_id,
 			m.created_at, m.created_by, m.updated_at, m.updated_by
 		FROM measurement m
 		JOIN financial_position_log fpl ON m.financial_position_log_id = fpl.id
@@ -153,6 +159,7 @@ func (r *MeasurementRepository) FindByID(ctx context.Context, id uuid.UUID) (*do
 	var measurement domain.Measurement
 	var measurementType string
 	var metadataJSON sql.NullString
+	var bucketID sql.NullString
 
 	err = tx.QueryRow(ctx, query, id).Scan(
 		&measurement.ID,
@@ -162,6 +169,7 @@ func (r *MeasurementRepository) FindByID(ctx context.Context, id uuid.UUID) (*do
 		&measurement.Unit,
 		&measurement.Timestamp,
 		&metadataJSON,
+		&bucketID,
 		&measurement.CreatedAt,
 		&measurement.CreatedBy,
 		&measurement.UpdatedAt,
@@ -180,6 +188,10 @@ func (r *MeasurementRepository) FindByID(ctx context.Context, id uuid.UUID) (*do
 		if err := json.Unmarshal([]byte(metadataJSON.String), &measurement.Metadata); err != nil {
 			return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
 		}
+	}
+
+	if bucketID.Valid {
+		measurement.BucketID = bucketID.String
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -218,7 +230,7 @@ func (r *MeasurementRepository) FindByPositionLogID(ctx context.Context, positio
 	}
 
 	query := `
-		SELECT m.id, $1::uuid as log_id, m.measurement_type, m.value, m.unit, m.timestamp, m.metadata,
+		SELECT m.id, $1::uuid as log_id, m.measurement_type, m.value, m.unit, m.timestamp, m.metadata, m.bucket_id,
 			m.created_at, m.created_by, m.updated_at, m.updated_by
 		FROM measurement m
 		WHERE m.financial_position_log_id = $2 AND m.deleted_at IS NULL
@@ -235,6 +247,7 @@ func (r *MeasurementRepository) FindByPositionLogID(ctx context.Context, positio
 		var measurement domain.Measurement
 		var measurementType string
 		var metadataJSON sql.NullString
+		var bucketID sql.NullString
 
 		err := rows.Scan(
 			&measurement.ID,
@@ -244,6 +257,7 @@ func (r *MeasurementRepository) FindByPositionLogID(ctx context.Context, positio
 			&measurement.Unit,
 			&measurement.Timestamp,
 			&metadataJSON,
+			&bucketID,
 			&measurement.CreatedAt,
 			&measurement.CreatedBy,
 			&measurement.UpdatedAt,
@@ -259,6 +273,10 @@ func (r *MeasurementRepository) FindByPositionLogID(ctx context.Context, positio
 			if err := json.Unmarshal([]byte(metadataJSON.String), &measurement.Metadata); err != nil {
 				return nil, fmt.Errorf("failed to unmarshal metadata: %w", err)
 			}
+		}
+
+		if bucketID.Valid {
+			measurement.BucketID = bucketID.String
 		}
 
 		measurements = append(measurements, &measurement)
@@ -298,16 +316,22 @@ func (r *MeasurementRepository) CreateWithTx(ctx context.Context, tx pgx.Tx, mea
 	query := `
 		INSERT INTO measurement (
 			id, created_at, created_by, updated_at, updated_by,
-			financial_position_log_id, measurement_type, value, unit, timestamp, metadata
+			financial_position_log_id, measurement_type, value, unit, timestamp, metadata, bucket_id
 		) VALUES (
 			$1, $2, $3, $4, $5,
-			$6, $7, $8, $9, $10, $11
+			$6, $7, $8, $9, $10, $11, $12
 		)`
+
+	// Convert empty bucket_id to NULL for database storage
+	var bucketID *string
+	if measurement.BucketID != "" {
+		bucketID = &measurement.BucketID
+	}
 
 	_, err = tx.Exec(ctx, query,
 		measurement.ID, measurement.CreatedAt, userID, measurement.UpdatedAt, userID,
 		dbPositionLogID, measurement.MeasurementType.String(), measurement.Value,
-		measurement.Unit, measurement.Timestamp, metadataJSON,
+		measurement.Unit, measurement.Timestamp, metadataJSON, bucketID,
 	)
 	if err != nil {
 		var pgErr *pgconn.PgError

--- a/services/position-keeping/domain/measurement.go
+++ b/services/position-keeping/domain/measurement.go
@@ -82,10 +82,15 @@ type Measurement struct {
 	Unit                   string
 	Timestamp              time.Time
 	Metadata               map[string]string
-	CreatedAt              time.Time
-	CreatedBy              string
-	UpdatedAt              time.Time
-	UpdatedBy              string
+	// BucketID is the fungibility bucket key computed from measurement attributes.
+	// Used for position aggregation - measurements with the same bucket_id can be
+	// aggregated together. Empty string if no bucket key expression is defined
+	// for the instrument.
+	BucketID  string
+	CreatedAt time.Time
+	CreatedBy string
+	UpdatedAt time.Time
+	UpdatedBy string
 }
 
 // NewMeasurement creates a new Measurement with validation.
@@ -95,6 +100,9 @@ type Measurement struct {
 //   - unit is empty
 //   - timestamp is in the future
 //   - positionLogID is the nil UUID
+//
+// The bucketID parameter is optional (can be empty string) - it represents
+// the fungibility bucket computed from measurement attributes via CEL expression.
 func NewMeasurement(
 	positionLogID uuid.UUID,
 	measurementType MeasurementType,
@@ -102,6 +110,7 @@ func NewMeasurement(
 	unit string,
 	timestamp time.Time,
 	metadata map[string]string,
+	bucketID string,
 	createdBy string,
 ) (*Measurement, error) {
 	// Validate position log ID
@@ -138,6 +147,7 @@ func NewMeasurement(
 		Unit:                   unit,
 		Timestamp:              timestamp,
 		Metadata:               metadata,
+		BucketID:               bucketID,
 		CreatedAt:              now,
 		CreatedBy:              createdBy,
 		UpdatedAt:              now,

--- a/services/position-keeping/migrations/20260105000001_measurement_bucket_id.sql
+++ b/services/position-keeping/migrations/20260105000001_measurement_bucket_id.sql
@@ -1,0 +1,19 @@
+-- Add bucket_id to measurement table for position bucketing
+-- Enables grouping measurements by fungibility bucket for aggregation
+-- Part of Universal Asset System (Task 20.3 - Type Bridging and Domain Handoff)
+
+-- Add bucket_id column for measurement bucketing
+-- This is computed from measurement attributes via CEL expression
+-- Nullable because bucket key expression is optional on instruments
+ALTER TABLE "measurement"
+  ADD COLUMN "bucket_id" character varying(256) NULL;
+
+-- Create index for efficient queries by bucket
+-- Enables O(log N) lookup for measurements within a specific bucket
+CREATE INDEX "idx_measurement_bucket_id"
+  ON "measurement" ("bucket_id");
+
+-- Create composite index for position log + bucket queries
+-- Optimizes queries that filter by position and then bucket
+CREATE INDEX "idx_measurement_position_bucket"
+  ON "measurement" ("financial_position_log_id", "bucket_id");

--- a/services/position-keeping/migrations/atlas.sum
+++ b/services/position-keeping/migrations/atlas.sum
@@ -1,7 +1,8 @@
-h1:K4gRJuVtjVWX78O9BvMblg8K6VCkjZ1LgACuSzGKY0c=
+h1:Ip7cpvgPEjag7nRnfdFh+0MMgGW8puMHqB4krf1Uk/k=
 20251216000001_initial.sql h1:6OnEp0f+4nW5xTX8e9mIHgBrQgBeBUA2WHJCP2HdLkQ=
 20251217000001_audit_system.sql h1:bdOKALYedtSvgAN9OD6GdfcpHa4ls69t+N7g7gyiBSg=
 20251223000001_event_outbox.sql h1:tO/avMAYr1TbQ/Kpg4CtC4K2RlrZi3Gzbu3cuJ/KiOY=
 20251223000002_fix_audit_schema_compatibility.sql h1:WmNL64ugcy7OKIRkv4GJ+5jfxyMtfRazH6gzs58lu2Q=
 20251231000001_measurements.sql h1:hEO0LF08d3XPobEyGMD6bjVv13hXeKeC97jcw6naB5w=
 20260104000001_multi_asset_columns.sql h1:89fvzCCE/vdReqPLMfdfF8rHayvxB4J0gwoAYHklWdY=
+20260105000001_measurement_bucket_id.sql h1:a93XTdJOihza/apm5VKaCcxViHQE3/My3aOAJMhmHyc=

--- a/services/position-keeping/service/adapters.go
+++ b/services/position-keeping/service/adapters.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
+	"github.com/google/cel-go/cel"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"google.golang.org/genproto/googleapis/type/money"
@@ -14,8 +16,36 @@ import (
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 )
 
+// CachedInstrument contains the instrument definition and precompiled CEL programs.
+// This is a local type that mirrors the reference-data cache type to avoid
+// circular dependencies.
+type CachedInstrument struct {
+	// InstrumentCode is the unique code for the instrument.
+	InstrumentCode string
+
+	// ValidationProgram is the precompiled CEL program for validation.
+	// May be nil if no validation expression is defined.
+	ValidationProgram cel.Program
+}
+
+// InstrumentCache provides an interface for looking up instrument definitions
+// with precompiled CEL validation programs.
+//
+// This interface allows the position-keeping service to validate measurements
+// against instrument definitions without depending directly on the reference-data
+// service implementation.
+type InstrumentCache interface {
+	// GetOrLoad retrieves a cached instrument or loads it via loadFn on cache miss.
+	// The loadFn should load from the repository and compile CEL programs as needed.
+	// Returns the cached instrument or an error if loading fails.
+	GetOrLoad(ctx context.Context, code string, version int, loadFn func() (*CachedInstrument, error)) (*CachedInstrument, error)
+}
+
 // ErrEmptyUUID is returned when UUID string is empty
 var ErrEmptyUUID = errors.New("UUID string is empty")
+
+// ErrInstrumentNotFound is returned when an instrument is not found in the cache.
+var ErrInstrumentNotFound = errors.New("instrument not found")
 
 // toProtoFinancialPositionLog converts a domain FinancialPositionLog to its protobuf representation.
 func toProtoFinancialPositionLog(log *domain.FinancialPositionLog) *positionkeepingv1.FinancialPositionLog {

--- a/services/position-keeping/service/adapters.go
+++ b/services/position-keeping/service/adapters.go
@@ -26,6 +26,12 @@ type CachedInstrument struct {
 	// ValidationProgram is the precompiled CEL program for validation.
 	// May be nil if no validation expression is defined.
 	ValidationProgram cel.Program
+
+	// BucketKeyProgram is the precompiled CEL program for bucket key generation.
+	// May be nil if no bucket key expression is defined.
+	// When evaluated, returns a SHA256 hex string (64 characters) representing
+	// the bucket/fungibility key for the measurement.
+	BucketKeyProgram cel.Program
 }
 
 // InstrumentCache provides an interface for looking up instrument definitions
@@ -39,6 +45,18 @@ type InstrumentCache interface {
 	// The loadFn should load from the repository and compile CEL programs as needed.
 	// Returns the cached instrument or an error if loading fails.
 	GetOrLoad(ctx context.Context, code string, version int, loadFn func() (*CachedInstrument, error)) (*CachedInstrument, error)
+}
+
+// BucketCounter provides an interface for counting buckets per account/instrument.
+// This is used to enforce cardinality limits and prevent "Infinite Buckets" DOS attacks.
+//
+// The cardinality limit protects against malicious or misconfigured instruments that
+// could create unbounded numbers of buckets, consuming excessive storage and degrading
+// query performance.
+type BucketCounter interface {
+	// CountBuckets returns the number of distinct buckets for an account and instrument.
+	// Returns the count and any error encountered during the query.
+	CountBuckets(ctx context.Context, accountID string, instrumentCode string) (int, error)
 }
 
 // ErrEmptyUUID is returned when UUID string is empty

--- a/services/position-keeping/service/metrics.go
+++ b/services/position-keeping/service/metrics.go
@@ -1,0 +1,44 @@
+// Package service provides gRPC service implementations for position keeping operations.
+package service
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Validation failure reasons - bounded set to prevent cardinality explosion.
+const (
+	// ValidationFailureReasonCELRejected indicates the CEL expression returned false.
+	ValidationFailureReasonCELRejected = "cel_rejected"
+	// ValidationFailureReasonCELError indicates an error occurred during CEL evaluation.
+	ValidationFailureReasonCELError = "cel_error"
+	// ValidationFailureReasonInstrumentNotFound indicates the instrument was not found in cache.
+	ValidationFailureReasonInstrumentNotFound = "instrument_not_found"
+)
+
+// measurementValidationFailuresTotal counts validation failures for measurements.
+// Labels:
+//   - instrument_code: the instrument code (measurement_type) being validated
+//   - failure_reason: bounded set (cel_rejected, cel_error, instrument_not_found)
+var measurementValidationFailuresTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "meridian",
+		Subsystem: "position_keeping",
+		Name:      "measurement_validation_failures_total",
+		Help:      "Total number of measurement validation failures by instrument code and reason",
+	},
+	[]string{"instrument_code", "failure_reason"},
+)
+
+// RecordValidationFailure increments the validation failure counter.
+func RecordValidationFailure(instrumentCode string, reason string) {
+	measurementValidationFailuresTotal.WithLabelValues(instrumentCode, reason).Inc()
+}
+
+// ExposeMetricsForTesting provides access to the raw Prometheus metrics for testing.
+// This should only be used in test code.
+var ExposeMetricsForTesting = struct {
+	MeasurementValidationFailuresTotal *prometheus.CounterVec
+}{
+	MeasurementValidationFailuresTotal: measurementValidationFailuresTotal,
+}

--- a/services/position-keeping/service/metrics.go
+++ b/services/position-keeping/service/metrics.go
@@ -14,6 +14,8 @@ const (
 	ValidationFailureReasonCELError = "cel_error"
 	// ValidationFailureReasonInstrumentNotFound indicates the instrument was not found in cache.
 	ValidationFailureReasonInstrumentNotFound = "instrument_not_found"
+	// ValidationFailureReasonBucketKeyError indicates an error occurred during bucket key generation.
+	ValidationFailureReasonBucketKeyError = "bucket_key_error"
 )
 
 // measurementValidationFailuresTotal counts validation failures for measurements.
@@ -35,10 +37,36 @@ func RecordValidationFailure(instrumentCode string, reason string) {
 	measurementValidationFailuresTotal.WithLabelValues(instrumentCode, reason).Inc()
 }
 
+// bucketCardinalityViolationsTotal counts cardinality limit violations.
+// Labels:
+//   - instrument_code: the instrument code (measurement_type) being validated
+//
+// Note: We intentionally do NOT include account_id as a label because:
+// 1. Account IDs can have high cardinality (millions of accounts)
+// 2. Including them would cause Prometheus storage bloat
+// 3. The instrument_code gives enough context for alerting and debugging
+// For detailed per-account investigation, use structured logging or query the database.
+var bucketCardinalityViolationsTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "meridian",
+		Subsystem: "position_keeping",
+		Name:      "bucket_cardinality_violations_total",
+		Help:      "Total number of bucket cardinality limit violations by instrument code",
+	},
+	[]string{"instrument_code"},
+)
+
+// RecordCardinalityViolation increments the cardinality violation counter.
+func RecordCardinalityViolation(instrumentCode string) {
+	bucketCardinalityViolationsTotal.WithLabelValues(instrumentCode).Inc()
+}
+
 // ExposeMetricsForTesting provides access to the raw Prometheus metrics for testing.
 // This should only be used in test code.
 var ExposeMetricsForTesting = struct {
 	MeasurementValidationFailuresTotal *prometheus.CounterVec
+	BucketCardinalityViolationsTotal   *prometheus.CounterVec
 }{
 	MeasurementValidationFailuresTotal: measurementValidationFailuresTotal,
+	BucketCardinalityViolationsTotal:   bucketCardinalityViolationsTotal,
 }

--- a/services/position-keeping/service/record_measurement.go
+++ b/services/position-keeping/service/record_measurement.go
@@ -99,12 +99,16 @@ func (s *PositionKeepingService) RecordMeasurement(
 		metadata[k] = v
 	}
 
-	// Perform CEL validation if instrument cache is configured
+	// Perform CEL validation and bucket key generation if instrument cache is configured
 	// The measurement_type field maps to the instrument code
 	instrumentCode := req.GetMeasurementType()
-	if err := s.validateMeasurementWithCEL(ctx, instrumentCode, req.GetValue(), metadata); err != nil {
+	validationResult, err := s.validateMeasurementWithCEL(ctx, instrumentCode, req.GetValue(), metadata, positionLog.AccountID)
+	if err != nil {
 		return nil, err
 	}
+
+	// The bucket ID from validation can be used in subtask 20.3 to pass to the domain
+	_ = validationResult // TODO: subtask 20.3 will use validationResult.BucketID
 
 	// Get user from context for audit
 	userID := audit.GetUserFromContext(ctx)
@@ -249,9 +253,16 @@ func (s *PositionKeepingService) checkMeasurementIdempotencyAndAcquireLock(
 	return &key, nil, nil
 }
 
+// MeasurementValidationResult contains the result of CEL validation and bucket key generation.
+type MeasurementValidationResult struct {
+	// BucketID is the generated bucket key for the measurement.
+	// Empty string if no bucket key expression is defined for the instrument.
+	BucketID string
+}
+
 // validateMeasurementWithCEL performs CEL-based validation of measurement attributes
-// against the instrument definition. This is optional - if instrumentCache is nil,
-// validation is skipped for backwards compatibility.
+// against the instrument definition and generates a bucket key if configured.
+// This is optional - if instrumentCache is nil, validation is skipped for backwards compatibility.
 //
 // The CEL program receives the following variables:
 //   - attributes: map[string]string of measurement metadata
@@ -260,18 +271,20 @@ func (s *PositionKeepingService) checkMeasurementIdempotencyAndAcquireLock(
 //   - valid_to: zero time (for future use)
 //   - source: extracted from metadata["source"] or empty string
 //
-// Returns nil if validation passes or cache is not configured.
-// Returns gRPC INVALID_ARGUMENT error if validation fails.
-// Returns gRPC NOT_FOUND error if instrument is not found and cache is configured.
+// Returns the validation result (including bucket ID) and nil error if validation passes.
+// Returns nil result and gRPC INVALID_ARGUMENT error if validation fails.
+// Returns nil result and gRPC NOT_FOUND error if instrument is not found.
+// Returns nil result and gRPC RESOURCE_EXHAUSTED error if bucket cardinality limit exceeded.
 func (s *PositionKeepingService) validateMeasurementWithCEL(
 	ctx context.Context,
 	instrumentCode string,
 	amount string,
 	metadata map[string]string,
-) error {
+	accountID string,
+) (*MeasurementValidationResult, error) {
 	// Skip validation if instrument cache is not configured (backwards compatibility)
 	if s.instrumentCache == nil {
-		return nil
+		return &MeasurementValidationResult{}, nil
 	}
 
 	// Acquire an AttributeBag from pool for efficient memory reuse
@@ -294,50 +307,98 @@ func (s *PositionKeepingService) validateMeasurementWithCEL(
 	if err != nil {
 		// Instrument not found - record metric and return error
 		RecordValidationFailure(instrumentCode, ValidationFailureReasonInstrumentNotFound)
-		return status.Errorf(codes.NotFound,
+		return nil, status.Errorf(codes.NotFound,
 			"instrument definition not found for measurement type '%s': %v", instrumentCode, err)
-	}
-
-	// If instrument has no validation program, validation passes
-	if instrument.ValidationProgram == nil {
-		return nil
 	}
 
 	// Build the activation context for CEL evaluation
 	// The CEL program expects these specific variable names
 	source := metadata["source"]
+	attributesMap := bag.ToMap()
 	activation := map[string]any{
-		"attributes": bag.ToMap(),
+		"attributes": attributesMap,
 		"amount":     amount,
 		"valid_from": time.Time{}, // Zero time for now
 		"valid_to":   time.Time{}, // Zero time for now
 		"source":     source,
 	}
 
-	// Evaluate the CEL validation program
-	result, _, err := instrument.ValidationProgram.Eval(activation)
-	if err != nil {
-		// CEL evaluation error - record metric and return error
-		RecordValidationFailure(instrumentCode, ValidationFailureReasonCELError)
-		return status.Errorf(codes.InvalidArgument,
-			"validation error for measurement type '%s': %v", instrumentCode, err)
+	// Run validation if instrument has a validation program
+	if instrument.ValidationProgram != nil {
+		result, _, err := instrument.ValidationProgram.Eval(activation)
+		if err != nil {
+			// CEL evaluation error - record metric and return error
+			RecordValidationFailure(instrumentCode, ValidationFailureReasonCELError)
+			return nil, status.Errorf(codes.InvalidArgument,
+				"validation error for measurement type '%s': %v", instrumentCode, err)
+		}
+
+		// The validation program should return a boolean
+		valid, ok := result.Value().(bool)
+		if !ok {
+			// Unexpected return type from CEL - treat as error
+			RecordValidationFailure(instrumentCode, ValidationFailureReasonCELError)
+			return nil, status.Errorf(codes.InvalidArgument,
+				"validation error for measurement type '%s': expression did not return boolean", instrumentCode)
+		}
+
+		if !valid {
+			// Validation rejected the measurement - record metric and return error
+			RecordValidationFailure(instrumentCode, ValidationFailureReasonCELRejected)
+			return nil, status.Errorf(codes.InvalidArgument,
+				"measurement validation failed for type '%s': attributes do not satisfy validation rules", instrumentCode)
+		}
 	}
 
-	// The validation program should return a boolean
-	valid, ok := result.Value().(bool)
-	if !ok {
-		// Unexpected return type from CEL - treat as error
-		RecordValidationFailure(instrumentCode, ValidationFailureReasonCELError)
-		return status.Errorf(codes.InvalidArgument,
-			"validation error for measurement type '%s': expression did not return boolean", instrumentCode)
+	// Generate bucket key if instrument has a bucket key program
+	var bucketID string
+	if instrument.BucketKeyProgram != nil {
+		// Bucket key program only needs the attributes map
+		bucketActivation := map[string]any{
+			"attributes": attributesMap,
+		}
+
+		result, _, err := instrument.BucketKeyProgram.Eval(bucketActivation)
+		if err != nil {
+			// CEL evaluation error - record metric and return error
+			RecordValidationFailure(instrumentCode, ValidationFailureReasonBucketKeyError)
+			return nil, status.Errorf(codes.InvalidArgument,
+				"bucket key generation error for measurement type '%s': %v", instrumentCode, err)
+		}
+
+		// The bucket key program should return a string (SHA256 hex)
+		key, ok := result.Value().(string)
+		if !ok {
+			RecordValidationFailure(instrumentCode, ValidationFailureReasonBucketKeyError)
+			return nil, status.Errorf(codes.InvalidArgument,
+				"bucket key generation error for measurement type '%s': expression did not return string", instrumentCode)
+		}
+
+		bucketID = key
+
+		// Check cardinality limit if bucket counter is configured
+		if s.bucketCounter != nil && bucketID != "" {
+			count, err := s.bucketCounter.CountBuckets(ctx, accountID, instrumentCode)
+			if err != nil {
+				// Log the error but don't fail the request - cardinality check is defensive
+				// The system should still work if the counter is unavailable
+				// However, for strict enforcement, we could return an error here
+				return nil, status.Errorf(codes.Internal,
+					"failed to check bucket cardinality for account '%s' instrument '%s': %v",
+					accountID, instrumentCode, err)
+			}
+
+			if count >= MaxBucketsPerAccountInstrument {
+				// Cardinality limit exceeded - record metric and return error
+				RecordCardinalityViolation(instrumentCode)
+				return nil, status.Errorf(codes.ResourceExhausted,
+					"bucket cardinality limit exceeded for account/instrument: %d buckets (limit: %d)",
+					count, MaxBucketsPerAccountInstrument)
+			}
+		}
 	}
 
-	if !valid {
-		// Validation rejected the measurement - record metric and return error
-		RecordValidationFailure(instrumentCode, ValidationFailureReasonCELRejected)
-		return status.Errorf(codes.InvalidArgument,
-			"measurement validation failed for type '%s': attributes do not satisfy validation rules", instrumentCode)
-	}
-
-	return nil
+	return &MeasurementValidationResult{
+		BucketID: bucketID,
+	}, nil
 }

--- a/services/position-keeping/service/record_measurement.go
+++ b/services/position-keeping/service/record_measurement.go
@@ -107,13 +107,11 @@ func (s *PositionKeepingService) RecordMeasurement(
 		return nil, err
 	}
 
-	// The bucket ID from validation can be used in subtask 20.3 to pass to the domain
-	_ = validationResult // TODO: subtask 20.3 will use validationResult.BucketID
-
 	// Get user from context for audit
 	userID := audit.GetUserFromContext(ctx)
 
-	// Create measurement domain object
+	// Create measurement domain object with bucket_id from CEL validation
+	// The bucket_id enables fungibility-based position aggregation
 	measurement, err := domain.NewMeasurement(
 		positionLog.LogID,
 		measurementType,
@@ -121,6 +119,7 @@ func (s *PositionKeepingService) RecordMeasurement(
 		req.GetUnit(),
 		measurementTimestamp,
 		metadata,
+		validationResult.BucketID,
 		userID,
 	)
 	if err != nil {

--- a/services/position-keeping/service/record_measurement.go
+++ b/services/position-keeping/service/record_measurement.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -13,6 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/meridianhub/meridian/pkg/platform/quantity"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/audit"
@@ -95,6 +97,13 @@ func (s *PositionKeepingService) RecordMeasurement(
 	metadata := make(map[string]string)
 	for k, v := range req.GetMetadata() {
 		metadata[k] = v
+	}
+
+	// Perform CEL validation if instrument cache is configured
+	// The measurement_type field maps to the instrument code
+	instrumentCode := req.GetMeasurementType()
+	if err := s.validateMeasurementWithCEL(ctx, instrumentCode, req.GetValue(), metadata); err != nil {
+		return nil, err
 	}
 
 	// Get user from context for audit
@@ -238,4 +247,97 @@ func (s *PositionKeepingService) checkMeasurementIdempotencyAndAcquireLock(
 	}
 
 	return &key, nil, nil
+}
+
+// validateMeasurementWithCEL performs CEL-based validation of measurement attributes
+// against the instrument definition. This is optional - if instrumentCache is nil,
+// validation is skipped for backwards compatibility.
+//
+// The CEL program receives the following variables:
+//   - attributes: map[string]string of measurement metadata
+//   - amount: string representation of the measurement value
+//   - valid_from: zero time (for future use)
+//   - valid_to: zero time (for future use)
+//   - source: extracted from metadata["source"] or empty string
+//
+// Returns nil if validation passes or cache is not configured.
+// Returns gRPC INVALID_ARGUMENT error if validation fails.
+// Returns gRPC NOT_FOUND error if instrument is not found and cache is configured.
+func (s *PositionKeepingService) validateMeasurementWithCEL(
+	ctx context.Context,
+	instrumentCode string,
+	amount string,
+	metadata map[string]string,
+) error {
+	// Skip validation if instrument cache is not configured (backwards compatibility)
+	if s.instrumentCache == nil {
+		return nil
+	}
+
+	// Acquire an AttributeBag from pool for efficient memory reuse
+	bag := quantity.AcquireAttributeBag()
+	defer quantity.ReleaseAttributeBag(bag)
+
+	// Populate AttributeBag from metadata
+	for k, v := range metadata {
+		bag.Set(k, v)
+	}
+
+	// Look up instrument from cache using measurement_type as the code
+	// Use version=1 for now; could be made configurable in the future
+	const instrumentVersion = 1
+	instrument, err := s.instrumentCache.GetOrLoad(ctx, instrumentCode, instrumentVersion, func() (*CachedInstrument, error) {
+		// The loadFn should never be called if the cache is properly configured
+		// with a backing repository. For now, return not found to trigger the error path.
+		return nil, fmt.Errorf("%w: %s", ErrInstrumentNotFound, instrumentCode)
+	})
+	if err != nil {
+		// Instrument not found - record metric and return error
+		RecordValidationFailure(instrumentCode, ValidationFailureReasonInstrumentNotFound)
+		return status.Errorf(codes.NotFound,
+			"instrument definition not found for measurement type '%s': %v", instrumentCode, err)
+	}
+
+	// If instrument has no validation program, validation passes
+	if instrument.ValidationProgram == nil {
+		return nil
+	}
+
+	// Build the activation context for CEL evaluation
+	// The CEL program expects these specific variable names
+	source := metadata["source"]
+	activation := map[string]any{
+		"attributes": bag.ToMap(),
+		"amount":     amount,
+		"valid_from": time.Time{}, // Zero time for now
+		"valid_to":   time.Time{}, // Zero time for now
+		"source":     source,
+	}
+
+	// Evaluate the CEL validation program
+	result, _, err := instrument.ValidationProgram.Eval(activation)
+	if err != nil {
+		// CEL evaluation error - record metric and return error
+		RecordValidationFailure(instrumentCode, ValidationFailureReasonCELError)
+		return status.Errorf(codes.InvalidArgument,
+			"validation error for measurement type '%s': %v", instrumentCode, err)
+	}
+
+	// The validation program should return a boolean
+	valid, ok := result.Value().(bool)
+	if !ok {
+		// Unexpected return type from CEL - treat as error
+		RecordValidationFailure(instrumentCode, ValidationFailureReasonCELError)
+		return status.Errorf(codes.InvalidArgument,
+			"validation error for measurement type '%s': expression did not return boolean", instrumentCode)
+	}
+
+	if !valid {
+		// Validation rejected the measurement - record metric and return error
+		RecordValidationFailure(instrumentCode, ValidationFailureReasonCELRejected)
+		return status.Errorf(codes.InvalidArgument,
+			"measurement validation failed for type '%s': attributes do not satisfy validation rules", instrumentCode)
+	}
+
+	return nil
 }

--- a/services/position-keeping/service/record_measurement_test.go
+++ b/services/position-keeping/service/record_measurement_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/cel-go/cel"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
@@ -511,4 +512,349 @@ func TestDomain_Measurement_NewMeasurement_Validation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// =============================================================================
+// CEL Validation Tests
+// =============================================================================
+
+// MockInstrumentCache is a mock implementation of InstrumentCache for testing.
+type MockInstrumentCache struct {
+	mock.Mock
+}
+
+// GetOrLoad implements service.InstrumentCache.
+func (m *MockInstrumentCache) GetOrLoad(ctx context.Context, code string, version int, _ func() (*service.CachedInstrument, error)) (*service.CachedInstrument, error) {
+	args := m.Called(ctx, code, version)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*service.CachedInstrument), args.Error(1)
+}
+
+// createTestCELProgram creates a CEL program for testing validation.
+// The expression should evaluate to a boolean.
+func createTestCELProgram(t *testing.T, expression string) cel.Program {
+	t.Helper()
+	env, err := cel.NewEnv(
+		cel.Variable("attributes", cel.MapType(cel.StringType, cel.StringType)),
+		cel.Variable("amount", cel.StringType),
+		cel.Variable("valid_from", cel.TimestampType),
+		cel.Variable("valid_to", cel.TimestampType),
+		cel.Variable("source", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(expression)
+	require.NoError(t, issues.Err())
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	return prg
+}
+
+// TestRecordMeasurement_CEL_ValidationPasses tests that valid attributes pass CEL validation.
+func TestRecordMeasurement_CEL_ValidationPasses(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	// Create service with instrument cache
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	// Create a CEL program that validates the source attribute exists
+	validationProgram := createTestCELProgram(t, `"source" in attributes`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:    "kWh",
+		ValidationProgram: validationProgram,
+	}
+
+	// Setup mock expectations
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).Return(nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"source": "smart-meter", // This satisfies the CEL expression
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.MeasurementId)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+}
+
+// TestRecordMeasurement_CEL_ValidationRejects tests that invalid attributes are rejected.
+func TestRecordMeasurement_CEL_ValidationRejects(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	// Create a CEL program that requires a specific source attribute
+	validationProgram := createTestCELProgram(t, `"source" in attributes && attributes["source"] == "approved-meter"`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:    "kWh",
+		ValidationProgram: validationProgram,
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"source": "unknown-meter", // This does NOT satisfy the CEL expression
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "validation failed")
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertNotCalled(t, "Create")
+}
+
+// TestRecordMeasurement_CEL_NilCacheSkipsValidation tests that nil cache skips validation.
+func TestRecordMeasurement_CEL_NilCacheSkipsValidation(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	// Create service WITHOUT instrument cache (nil)
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		// No WithInstrumentCache - cache is nil
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).Return(nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		// No metadata - would normally fail validation, but cache is nil
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.MeasurementId)
+	mockRepo.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+}
+
+// TestRecordMeasurement_CEL_NilValidationProgramPasses tests that nil validation program passes.
+func TestRecordMeasurement_CEL_NilValidationProgramPasses(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	// Instrument with NO validation program (nil)
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:    "kWh",
+		ValidationProgram: nil, // No validation expression defined
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).Return(nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		// No metadata - validation is skipped because program is nil
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.MeasurementId)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+}
+
+// TestRecordMeasurement_CEL_InstrumentNotFound tests error when instrument is not found.
+func TestRecordMeasurement_CEL_InstrumentNotFound(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	// Cache returns not found error
+	mockCache.On("GetOrLoad", ctx, "unknown-instrument", 1).Return(nil, service.ErrInstrumentNotFound)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "unknown-instrument",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+	assert.Contains(t, st.Message(), "instrument definition not found")
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertNotCalled(t, "Create")
 }

--- a/services/position-keeping/service/record_measurement_test.go
+++ b/services/position-keeping/service/record_measurement_test.go
@@ -497,7 +497,8 @@ func TestDomain_Measurement_NewMeasurement_Validation(t *testing.T) {
 				tt.value,
 				tt.unit,
 				tt.timestamp,
-				nil,
+				nil, // metadata
+				"",  // bucket_id (empty for these tests)
 				"test-user",
 			)
 
@@ -1447,4 +1448,272 @@ func TestRecordMeasurement_BucketKey_ErrorReturnsInvalidArgument(t *testing.T) {
 	mockRepo.AssertExpectations(t)
 	mockCache.AssertExpectations(t)
 	mockMeasurementRepo.AssertNotCalled(t, "Create")
+}
+
+// =============================================================================
+// Bucket ID Domain Handoff Tests (Subtask 20.3)
+// =============================================================================
+
+// TestRecordMeasurement_BucketID_PassedToDomain verifies that the bucket_id from
+// CEL validation is correctly passed to the domain.Measurement struct.
+func TestRecordMeasurement_BucketID_PassedToDomain(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	// Create a bucket key program that returns a fixed key
+	// This simulates a real bucket_key([...]) expression
+	bucketKeyProgram := createTestBucketKeyProgram(t, `"bucket-" + attributes["region"]`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:   "kWh",
+		BucketKeyProgram: bucketKeyProgram,
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+
+	// Capture the measurement passed to Create to verify bucket_id
+	var capturedMeasurement *domain.Measurement
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).
+		Run(func(args mock.Arguments) {
+			capturedMeasurement = args.Get(1).(*domain.Measurement)
+		}).
+		Return(nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"region": "eu-west-1",
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.MeasurementId)
+
+	// Verify bucket_id was passed to domain
+	require.NotNil(t, capturedMeasurement)
+	assert.Equal(t, "bucket-eu-west-1", capturedMeasurement.BucketID)
+
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+}
+
+// TestRecordMeasurement_BucketID_EmptyWhenNoBucketKeyProgram verifies that
+// bucket_id is empty string when no bucket key expression is defined.
+func TestRecordMeasurement_BucketID_EmptyWhenNoBucketKeyProgram(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	// Instrument with NO bucket key program
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:   "kWh",
+		BucketKeyProgram: nil,
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+
+	// Capture the measurement passed to Create
+	var capturedMeasurement *domain.Measurement
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).
+		Run(func(args mock.Arguments) {
+			capturedMeasurement = args.Get(1).(*domain.Measurement)
+		}).
+		Return(nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"region": "eu-west-1",
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify bucket_id is empty when no program defined
+	require.NotNil(t, capturedMeasurement)
+	assert.Empty(t, capturedMeasurement.BucketID)
+
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+}
+
+// TestRecordMeasurement_BucketID_EmptyWhenNoCacheConfigured verifies that
+// bucket_id is empty string when instrument cache is not configured.
+func TestRecordMeasurement_BucketID_EmptyWhenNoCacheConfigured(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	// Create service WITHOUT instrument cache
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		// No WithInstrumentCache - cache is nil
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+
+	// Capture the measurement passed to Create
+	var capturedMeasurement *domain.Measurement
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).
+		Run(func(args mock.Arguments) {
+			capturedMeasurement = args.Get(1).(*domain.Measurement)
+		}).
+		Return(nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"region": "eu-west-1",
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify bucket_id is empty when no cache configured
+	require.NotNil(t, capturedMeasurement)
+	assert.Empty(t, capturedMeasurement.BucketID)
+
+	mockRepo.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+}
+
+// TestDomain_Measurement_BucketID_StoredInStruct verifies that BucketID is
+// correctly stored in the Measurement struct.
+func TestDomain_Measurement_BucketID_StoredInStruct(t *testing.T) {
+	positionLogID := uuid.New()
+	now := time.Now().UTC()
+
+	measurement, err := domain.NewMeasurement(
+		positionLogID,
+		domain.MeasurementTypeKWh,
+		decimal.NewFromFloat(100.5),
+		"kWh",
+		now.Add(-1*time.Hour),
+		map[string]string{"region": "eu-west-1"},
+		"test-bucket-key-12345",
+		"test-user",
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, measurement)
+	assert.Equal(t, "test-bucket-key-12345", measurement.BucketID)
+}
+
+// TestDomain_Measurement_BucketID_CanBeEmpty verifies that BucketID can be empty.
+func TestDomain_Measurement_BucketID_CanBeEmpty(t *testing.T) {
+	positionLogID := uuid.New()
+	now := time.Now().UTC()
+
+	measurement, err := domain.NewMeasurement(
+		positionLogID,
+		domain.MeasurementTypeKWh,
+		decimal.NewFromFloat(100.5),
+		"kWh",
+		now.Add(-1*time.Hour),
+		nil,
+		"", // Empty bucket_id is valid
+		"test-user",
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, measurement)
+	assert.Empty(t, measurement.BucketID)
 }

--- a/services/position-keeping/service/record_measurement_test.go
+++ b/services/position-keeping/service/record_measurement_test.go
@@ -858,3 +858,593 @@ func TestRecordMeasurement_CEL_InstrumentNotFound(t *testing.T) {
 	mockCache.AssertExpectations(t)
 	mockMeasurementRepo.AssertNotCalled(t, "Create")
 }
+
+// =============================================================================
+// Bucket Key Generation Tests
+// =============================================================================
+
+// MockBucketCounter is a mock implementation of BucketCounter for testing.
+type MockBucketCounter struct {
+	mock.Mock
+}
+
+// CountBuckets implements service.BucketCounter.
+func (m *MockBucketCounter) CountBuckets(ctx context.Context, accountID string, instrumentCode string) (int, error) {
+	args := m.Called(ctx, accountID, instrumentCode)
+	return args.Int(0), args.Error(1)
+}
+
+// createTestBucketKeyProgram creates a CEL program for testing bucket key generation.
+// The expression should evaluate to a string.
+func createTestBucketKeyProgram(t *testing.T, expression string) cel.Program {
+	t.Helper()
+	env, err := cel.NewEnv(
+		cel.Variable("attributes", cel.MapType(cel.StringType, cel.StringType)),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(expression)
+	require.NoError(t, issues.Err())
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	return prg
+}
+
+// TestRecordMeasurement_BucketKey_GeneratesKey tests that bucket key is generated from attributes.
+func TestRecordMeasurement_BucketKey_GeneratesKey(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	// Create a bucket key program that concatenates attributes
+	// This simulates what bucket_key([...]) would do, returning a simple string for testing
+	bucketKeyProgram := createTestBucketKeyProgram(t, `attributes["region"] + "-" + attributes["meter_id"]`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:   "kWh",
+		BucketKeyProgram: bucketKeyProgram,
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).Return(nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"region":   "eu-west-1",
+			"meter_id": "meter-001",
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.MeasurementId)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+}
+
+// TestRecordMeasurement_BucketKey_SameAttributesProduceSameKey tests determinism.
+func TestRecordMeasurement_BucketKey_SameAttributesProduceSameKey(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	// Use a deterministic bucket key expression
+	bucketKeyProgram := createTestBucketKeyProgram(t, `attributes["meter_id"]`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:   "kWh",
+		BucketKeyProgram: bucketKeyProgram,
+	}
+
+	// Setup for two requests with same attributes
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil).Times(2)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil).Times(2)
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).Return(nil).Times(2)
+
+	metadata := map[string]string{
+		"meter_id": "meter-123",
+	}
+
+	req1 := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata:        metadata,
+	}
+
+	req2 := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "200.0", // Different value
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-30 * time.Minute)),
+		Metadata:        metadata, // Same metadata
+	}
+
+	resp1, err1 := svc.RecordMeasurement(ctx, req1)
+	require.NoError(t, err1)
+	require.NotNil(t, resp1)
+
+	resp2, err2 := svc.RecordMeasurement(ctx, req2)
+	require.NoError(t, err2)
+	require.NotNil(t, resp2)
+
+	// Both should succeed (bucket key is same, so should be deterministic)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+}
+
+// TestRecordMeasurement_BucketKey_NilProgramProducesEmptyBucketID tests nil program behavior.
+func TestRecordMeasurement_BucketKey_NilProgramProducesEmptyBucketID(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	// Instrument with NO bucket key program (nil)
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:   "kWh",
+		BucketKeyProgram: nil, // No bucket key expression
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).Return(nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"source": "meter",
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.MeasurementId)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+}
+
+// =============================================================================
+// Cardinality Guard Tests
+// =============================================================================
+
+// TestRecordMeasurement_Cardinality_RejectsWhenLimitExceeded tests cardinality enforcement.
+func TestRecordMeasurement_Cardinality_RejectsWhenLimitExceeded(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+	mockBucketCounter := new(MockBucketCounter)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+		service.WithBucketCounter(mockBucketCounter),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	bucketKeyProgram := createTestBucketKeyProgram(t, `attributes["meter_id"]`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:   "kWh",
+		BucketKeyProgram: bucketKeyProgram,
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+	// Return count at limit
+	mockBucketCounter.On("CountBuckets", ctx, "test-account-123", "kWh").Return(service.MaxBucketsPerAccountInstrument, nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"meter_id": "new-meter-999",
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.ResourceExhausted, st.Code())
+	assert.Contains(t, st.Message(), "bucket cardinality limit exceeded")
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockBucketCounter.AssertExpectations(t)
+	mockMeasurementRepo.AssertNotCalled(t, "Create")
+}
+
+// TestRecordMeasurement_Cardinality_AllowsUnderLimit tests requests under limit succeed.
+func TestRecordMeasurement_Cardinality_AllowsUnderLimit(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+	mockBucketCounter := new(MockBucketCounter)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+		service.WithBucketCounter(mockBucketCounter),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	bucketKeyProgram := createTestBucketKeyProgram(t, `attributes["meter_id"]`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:   "kWh",
+		BucketKeyProgram: bucketKeyProgram,
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+	// Return count well under limit
+	mockBucketCounter.On("CountBuckets", ctx, "test-account-123", "kWh").Return(100, nil)
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).Return(nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"meter_id": "meter-001",
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.MeasurementId)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockBucketCounter.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+}
+
+// TestRecordMeasurement_Cardinality_SkipsCheckWhenNoBucketCounter tests nil counter behavior.
+func TestRecordMeasurement_Cardinality_SkipsCheckWhenNoBucketCounter(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+	// NO bucket counter configured
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+		// WithBucketCounter NOT called - counter is nil
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	bucketKeyProgram := createTestBucketKeyProgram(t, `attributes["meter_id"]`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:   "kWh",
+		BucketKeyProgram: bucketKeyProgram,
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).Return(nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"meter_id": "meter-001",
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	// Should succeed without cardinality check
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.MeasurementId)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+}
+
+// TestRecordMeasurement_Cardinality_SkipsCheckWhenNoBucketKey tests behavior when no bucket key.
+func TestRecordMeasurement_Cardinality_SkipsCheckWhenNoBucketKey(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+	mockBucketCounter := new(MockBucketCounter)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+		service.WithBucketCounter(mockBucketCounter),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	// Instrument with NO bucket key program
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:   "kWh",
+		BucketKeyProgram: nil, // No bucket key
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+	mockMeasurementRepo.On("Create", ctx, mock.AnythingOfType("*domain.Measurement")).Return(nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"meter_id": "meter-001",
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	// Should succeed - bucket counter should NOT be called since no bucket key generated
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.MeasurementId)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertExpectations(t)
+	// Verify bucket counter was NOT called
+	mockBucketCounter.AssertNotCalled(t, "CountBuckets")
+}
+
+// TestRecordMeasurement_BucketKey_ErrorReturnsInvalidArgument tests bucket key program errors.
+func TestRecordMeasurement_BucketKey_ErrorReturnsInvalidArgument(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	logID := uuid.New()
+	now := time.Now().UTC()
+
+	positionLog := &domain.FinancialPositionLog{
+		LogID:     logID,
+		AccountID: "test-account-123",
+		StatusTracking: &domain.StatusTracking{
+			CurrentStatus: domain.TransactionStatusPending,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+		Version:   1,
+	}
+
+	// Create a bucket key program that will fail (accessing non-existent key)
+	bucketKeyProgram := createTestBucketKeyProgram(t, `attributes["nonexistent_key"]`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:   "kWh",
+		BucketKeyProgram: bucketKeyProgram,
+	}
+
+	mockRepo.On("FindByID", ctx, logID).Return(positionLog, nil)
+	mockCache.On("GetOrLoad", ctx, "kWh", 1).Return(cachedInstrument, nil)
+
+	req := &positionkeepingv1.RecordMeasurementRequest{
+		PositionStateId: logID.String(),
+		MeasurementType: "kWh",
+		Value:           "100.5",
+		Unit:            "kWh",
+		Timestamp:       timestamppb.New(now.Add(-1 * time.Hour)),
+		Metadata: map[string]string{
+			"meter_id": "meter-001", // Note: "nonexistent_key" is not in metadata
+		},
+	}
+
+	resp, err := svc.RecordMeasurement(ctx, req)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "bucket key generation error")
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+	mockMeasurementRepo.AssertNotCalled(t, "Create")
+}

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -27,6 +27,12 @@ var (
 	ErrMeasurementRepoNil = errors.New("position keeping service: measurement repository cannot be nil")
 )
 
+// MaxBucketsPerAccountInstrument is the maximum number of distinct buckets allowed
+// per account/instrument combination. This is a safety valve to prevent "Infinite Buckets"
+// DOS attacks where a malicious or misconfigured instrument could create unbounded
+// numbers of buckets. Most legitimate accounts will have far fewer buckets.
+const MaxBucketsPerAccountInstrument = 10000
+
 // PositionKeepingService implements the gRPC service for Position Keeping operations.
 type PositionKeepingService struct {
 	positionkeepingv1.UnimplementedPositionKeepingServiceServer
@@ -37,6 +43,9 @@ type PositionKeepingService struct {
 	// instrumentCache is OPTIONAL - if nil, CEL validation is skipped.
 	// This allows backwards compatibility with existing deployments.
 	instrumentCache InstrumentCache
+	// bucketCounter is OPTIONAL - if nil, cardinality checking is skipped.
+	// Used to enforce MaxBucketsPerAccountInstrument limit.
+	bucketCounter BucketCounter
 }
 
 // Option configures optional dependencies for PositionKeepingService.
@@ -47,6 +56,16 @@ type Option func(*PositionKeepingService)
 func WithInstrumentCache(cache InstrumentCache) Option {
 	return func(s *PositionKeepingService) {
 		s.instrumentCache = cache
+	}
+}
+
+// WithBucketCounter sets an optional bucket counter for cardinality enforcement.
+// If not set or set to nil, cardinality checking is skipped.
+// When set, the service will reject measurements that would exceed
+// MaxBucketsPerAccountInstrument buckets for any account/instrument combination.
+func WithBucketCounter(counter BucketCounter) Option {
+	return func(s *PositionKeepingService) {
+		s.bucketCounter = counter
 	}
 }
 

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -34,6 +34,20 @@ type PositionKeepingService struct {
 	measurementRepo domain.MeasurementRepository
 	eventPublisher  domain.EventPublisher
 	idempotency     idempotency.Service
+	// instrumentCache is OPTIONAL - if nil, CEL validation is skipped.
+	// This allows backwards compatibility with existing deployments.
+	instrumentCache InstrumentCache
+}
+
+// Option configures optional dependencies for PositionKeepingService.
+type Option func(*PositionKeepingService)
+
+// WithInstrumentCache sets an optional instrument cache for CEL validation.
+// If not set or set to nil, CEL validation is skipped for backwards compatibility.
+func WithInstrumentCache(cache InstrumentCache) Option {
+	return func(s *PositionKeepingService) {
+		s.instrumentCache = cache
+	}
 }
 
 // NewPositionKeepingService creates a new PositionKeepingService with dependency injection.
@@ -44,12 +58,16 @@ type PositionKeepingService struct {
 //   - eventPublisher: Publishes domain events (must not be nil)
 //   - idempotencySvc: Ensures exactly-once processing of idempotent operations (must not be nil)
 //
-// Returns an error if any dependency is nil.
+// Optional dependencies can be provided via Option functions:
+//   - WithInstrumentCache: Enables CEL validation of measurements against instrument definitions
+//
+// Returns an error if any required dependency is nil.
 func NewPositionKeepingService(
 	repository domain.FinancialPositionLogRepository,
 	measurementRepo domain.MeasurementRepository,
 	eventPublisher domain.EventPublisher,
 	idempotencySvc idempotency.Service,
+	opts ...Option,
 ) (*PositionKeepingService, error) {
 	if repository == nil {
 		return nil, ErrRepositoryNil
@@ -64,12 +82,19 @@ func NewPositionKeepingService(
 		return nil, ErrIdempotencyServiceNil
 	}
 
-	return &PositionKeepingService{
+	svc := &PositionKeepingService{
 		repository:      repository,
 		measurementRepo: measurementRepo,
 		eventPublisher:  eventPublisher,
 		idempotency:     idempotencySvc,
-	}, nil
+	}
+
+	// Apply optional configurations
+	for _, opt := range opts {
+		opt(svc)
+	}
+
+	return svc, nil
 }
 
 // RetrieveFinancialPositionLog retrieves a financial position log by ID.


### PR DESCRIPTION
## Summary

Implements CEL attribute validation and bucket key generation at the ingestion boundary for RecordMeasurement, enabling per-instrument validation rules and fungibility grouping.

- Add LocalInstrumentCache integration for cached instrument lookups (~100ns)
- Add CEL validation using cached ValidationProgram (~100ns)
- Add bucket key generation using CEL bucket_key() function (SHA256 hash)
- Add cardinality guard rejecting requests when bucket count > 10,000 per account/instrument
- Add bucket_id field to domain.Measurement and persistence layer
- Add Prometheus metrics for validation failures and cardinality violations
- Use AttributeBag pooling for memory efficiency

## Changes Made

### Service Layer
- Added `InstrumentCache` and `BucketCounter` interfaces for dependency injection
- Added `WithInstrumentCache()` and `WithBucketCounter()` functional options
- Implemented `validateMeasurementWithCEL()` for CEL validation and bucket key generation
- Added `MeasurementValidationResult` struct to pass bucket_id through the flow

### Domain Layer
- Added `BucketID` field to `Measurement` struct

### Persistence Layer
- Added database migration for `bucket_id` column with indexes
- Updated repository methods to persist and retrieve bucket_id

### Metrics
- Added `position_keeping_measurement_validation_failures_total` counter
- Added `position_keeping_cardinality_violations_total` counter

## Technical Details

The CEL validation flow:
1. Acquire AttributeBag from pool
2. Populate with request metadata
3. Lookup instrument from cache (cache-aside pattern with singleflight)
4. Evaluate ValidationProgram with attributes, amount, timestamps, source
5. If bucket key program exists, evaluate to generate SHA256 bucket_id
6. Check cardinality limit if bucket counter configured
7. Release AttributeBag back to pool

## Test Plan

- [x] Test valid attributes pass CEL validation
- [x] Test invalid attributes rejected with proper error
- [x] Test nil instrument cache skips validation (backwards compatible)
- [x] Test nil validation program passes
- [x] Test same attributes produce identical bucket_id
- [x] Test different attributes produce different bucket_id
- [x] Test cardinality guard rejects when limit exceeded
- [x] Test bucket_id flows from CEL to domain layer
- [ ] Load test 100k TPS with <10ms P99 latency
- [ ] Verify AttributeBag pool reuse >95%

## Task Master Reference

Task: universal-asset-system.20