### PR TITLE
chore(ci): add dynamic date context to Claude Code actions and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "google.golang.org/*"
+          - "k8s.io/*"
+      google-cloud:
+        patterns:
+          - "google.golang.org/*"
+          - "cloud.google.com/*"
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(ci)"
+
+  # Docker images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(docker)"
+
+  # npm (for protobuf tooling)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -66,6 +66,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Get current date
+        id: date
+        run: echo "current_date=$(date -u '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
       - name: Run Claude Code Review
         id: claude-review
         continue-on-error: true  # Don't fail the workflow if Claude Code times out or has service issues
@@ -77,7 +81,7 @@ jobs:
             PR NUMBER: ${{ github.event.pull_request.number }}
 
             IMPORTANT CONTEXT:
-            - Current date: December 2025 or later
+            - Today's date is ${{ steps.date.outputs.current_date }}
             - Go version: This project uses Go 1.25+ which is the current stable release
             - Do not flag Go version references (like "Go 1.25") as errors or future versions
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Get current date
+        id: date
+        run: echo "current_date=$(date -u '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -44,8 +48,10 @@ jobs:
           system_prompt: |
             You are helping with the Meridian open banking ledger project.
 
+            IMPORTANT: Today's date is ${{ steps.date.outputs.current_date }}.
+
             Key project facts:
-            - This project uses Go 1.25.4 (latest stable release as of November 2025)
+            - This project uses Go 1.25.4 (latest stable release)
             - Go 1.25.4 is a valid version - do not question or flag it
             - Architecture: BIAN-compliant microservices
             - Stack: Go, Protocol Buffers, gRPC, Kubernetes


### PR DESCRIPTION
## Summary

- Add dynamic date injection to Claude Code GitHub Actions so Claude knows the current date
- Add Dependabot configuration for automated dependency updates

## Changes Made

### Claude Code Actions Date Fix
Both `claude.yml` and `claude-code-review.yml` now:
1. Run a "Get current date" step that outputs `date -u '+%Y-%m-%d'`
2. Pass this to Claude via the system_prompt/prompt with `${{ steps.date.outputs.current_date }}`

This replaces hardcoded date references like "December 2025 or later" with the actual runtime date.

### Dependabot Configuration
Added `.github/dependabot.yml` with:
- **Go modules**: Weekly updates, grouped by category (general, google-cloud, kubernetes)
- **GitHub Actions**: Weekly updates
- **Docker**: Weekly updates
- **npm**: Weekly updates (for protobuf tooling)

All updates scheduled for Monday with `chore(deps)` or `chore(ci)` commit prefixes.

## Test Plan
- [ ] Trigger Claude Code action via @claude mention and verify date appears in context
- [ ] Verify Dependabot PRs appear after merge