### PR TITLE
chore: add .clabot to exempt bots from CLA signing

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -1,0 +1,10 @@
+{
+  "allowlist": [
+    "dependabot[bot]",
+    "dependabot-preview[bot]",
+    "renovate[bot]",
+    "github-actions[bot]",
+    "mergify[bot]",
+    "allcontributors[bot]"
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `.clabot` configuration file to exempt common bots from CLA signing requirement

## Bots Allowlisted

| Bot | Purpose |
|-----|---------|
| `dependabot[bot]` | Automated dependency updates |
| `dependabot-preview[bot]` | Dependabot preview version |
| `renovate[bot]` | Alternative dependency updater |
| `github-actions[bot]` | GitHub Actions automation |
| `mergify[bot]` | Auto-merge bot |
| `allcontributors[bot]` | Contributors management |

## Why

Bots cannot sign CLAs, which blocks their PRs from merging. This is especially relevant now that we've added Dependabot (#507).

## Test Plan

- [ ] Verify next Dependabot PR doesn't require CLA signature