### PR TITLE
feat(position-keeping): implement background compaction worker

### DIFF
--- a/services/position-keeping/app/config.go
+++ b/services/position-keeping/app/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	Redis         RedisConfig
 	Auth          AuthConfig
 	Observability ObservabilityConfig
+	Compaction    CompactionConfig
 }
 
 // ServerConfig holds gRPC server configuration
@@ -104,6 +105,18 @@ type ObservabilityConfig struct {
 	MetricsPort string
 }
 
+// CompactionConfig holds background compaction worker configuration
+type CompactionConfig struct {
+	// Enabled indicates if the compaction worker is enabled
+	Enabled bool
+	// RunInterval is how often the compaction worker runs (e.g., 5 minutes)
+	RunInterval time.Duration
+	// FragmentThreshold is the minimum number of rows in a bucket to trigger compaction
+	FragmentThreshold int
+	// BatchSize is the maximum number of buckets to compact per run
+	BatchSize int
+}
+
 // LoadConfig loads configuration from environment variables with defaults
 func LoadConfig() (*Config, error) {
 	config := &Config{
@@ -113,6 +126,7 @@ func LoadConfig() (*Config, error) {
 		Redis:         loadRedisConfig(),
 		Auth:          loadAuthConfig(),
 		Observability: loadObservabilityConfig(),
+		Compaction:    loadCompactionConfig(),
 	}
 
 	if err := config.Validate(); err != nil {
@@ -195,17 +209,30 @@ func loadObservabilityConfig() ObservabilityConfig {
 	}
 }
 
+// loadCompactionConfig loads background compaction worker configuration from environment variables
+func loadCompactionConfig() CompactionConfig {
+	return CompactionConfig{
+		Enabled:           env.GetEnvAsBool("COMPACTION_ENABLED", true),
+		RunInterval:       env.GetEnvAsDuration("COMPACTION_RUN_INTERVAL", 5*time.Minute),
+		FragmentThreshold: env.GetEnvAsInt("COMPACTION_FRAGMENT_THRESHOLD", 100),
+		BatchSize:         env.GetEnvAsInt("COMPACTION_BATCH_SIZE", 50),
+	}
+}
+
 // Validation errors
 var (
-	ErrEmptyPort              = fmt.Errorf("server port must not be empty")
-	ErrEmptyDatabaseURL       = fmt.Errorf("database URL must not be empty")
-	ErrInvalidMaxOpenConns    = fmt.Errorf("database max open connections must be at least 1")
-	ErrInvalidMaxIdleConns    = fmt.Errorf("database max idle connections must be non-negative")
-	ErrKafkaBrokersEmpty      = fmt.Errorf("kafka brokers must not be empty when kafka is enabled")
-	ErrInvalidSamplingRate    = fmt.Errorf("sampling rate must be between 0.0 and 1.0")
-	ErrContainerCloseFailures = fmt.Errorf("errors during container close")
-	ErrMaxOpenConnsOverflow   = fmt.Errorf("max open connections exceeds int32 limit")
-	ErrMaxIdleConnsOverflow   = fmt.Errorf("max idle connections exceeds int32 limit")
+	ErrEmptyPort                  = fmt.Errorf("server port must not be empty")
+	ErrEmptyDatabaseURL           = fmt.Errorf("database URL must not be empty")
+	ErrInvalidMaxOpenConns        = fmt.Errorf("database max open connections must be at least 1")
+	ErrInvalidMaxIdleConns        = fmt.Errorf("database max idle connections must be non-negative")
+	ErrKafkaBrokersEmpty          = fmt.Errorf("kafka brokers must not be empty when kafka is enabled")
+	ErrInvalidSamplingRate        = fmt.Errorf("sampling rate must be between 0.0 and 1.0")
+	ErrContainerCloseFailures     = fmt.Errorf("errors during container close")
+	ErrMaxOpenConnsOverflow       = fmt.Errorf("max open connections exceeds int32 limit")
+	ErrMaxIdleConnsOverflow       = fmt.Errorf("max idle connections exceeds int32 limit")
+	ErrInvalidCompactionInterval  = fmt.Errorf("compaction run interval must be greater than zero")
+	ErrInvalidFragmentThreshold   = fmt.Errorf("compaction fragment threshold must be at least 2")
+	ErrInvalidCompactionBatchSize = fmt.Errorf("compaction batch size must be at least 1")
 )
 
 // Validate validates the configuration
@@ -241,6 +268,19 @@ func (c *Config) Validate() error {
 
 	if c.Observability.SamplingRate < 0.0 || c.Observability.SamplingRate > 1.0 {
 		return ErrInvalidSamplingRate
+	}
+
+	// Compaction validation (only when enabled)
+	if c.Compaction.Enabled {
+		if c.Compaction.RunInterval <= 0 {
+			return ErrInvalidCompactionInterval
+		}
+		if c.Compaction.FragmentThreshold < 2 {
+			return ErrInvalidFragmentThreshold
+		}
+		if c.Compaction.BatchSize < 1 {
+			return ErrInvalidCompactionBatchSize
+		}
 	}
 
 	return nil

--- a/services/position-keeping/app/config_test.go
+++ b/services/position-keeping/app/config_test.go
@@ -528,6 +528,217 @@ func TestGetEnvAsSlice_WithWhitespace(t *testing.T) {
 	}
 }
 
+func TestValidate_CompactionConfigDefaults(t *testing.T) {
+	config := &Config{
+		Server: ServerConfig{
+			Port:                    "50053",
+			GracefulShutdownTimeout: 30 * time.Second,
+		},
+		Database: DatabaseConfig{
+			URL:          "postgres://localhost:5432/db",
+			MaxOpenConns: 10,
+			MaxIdleConns: 5,
+		},
+		Observability: ObservabilityConfig{
+			SamplingRate: 0.5,
+		},
+		Compaction: CompactionConfig{
+			Enabled:           true,
+			RunInterval:       5 * time.Minute,
+			FragmentThreshold: 100,
+			BatchSize:         50,
+		},
+	}
+
+	if err := config.Validate(); err != nil {
+		t.Errorf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestValidate_CompactionDisabledSkipsValidation(t *testing.T) {
+	config := &Config{
+		Server: ServerConfig{
+			Port:                    "50053",
+			GracefulShutdownTimeout: 30 * time.Second,
+		},
+		Database: DatabaseConfig{
+			URL:          "postgres://localhost:5432/db",
+			MaxOpenConns: 10,
+			MaxIdleConns: 5,
+		},
+		Observability: ObservabilityConfig{
+			SamplingRate: 0.5,
+		},
+		Compaction: CompactionConfig{
+			Enabled:           false,
+			RunInterval:       0, // Invalid but should be skipped
+			FragmentThreshold: 0, // Invalid but should be skipped
+			BatchSize:         0, // Invalid but should be skipped
+		},
+	}
+
+	if err := config.Validate(); err != nil {
+		t.Errorf("Validate() error = %v, want nil when compaction disabled", err)
+	}
+}
+
+func TestValidate_CompactionInvalidRunInterval(t *testing.T) {
+	config := &Config{
+		Server: ServerConfig{
+			Port:                    "50053",
+			GracefulShutdownTimeout: 30 * time.Second,
+		},
+		Database: DatabaseConfig{
+			URL:          "postgres://localhost:5432/db",
+			MaxOpenConns: 10,
+			MaxIdleConns: 5,
+		},
+		Observability: ObservabilityConfig{
+			SamplingRate: 0.5,
+		},
+		Compaction: CompactionConfig{
+			Enabled:           true,
+			RunInterval:       0, // Invalid
+			FragmentThreshold: 100,
+			BatchSize:         50,
+		},
+	}
+
+	err := config.Validate()
+	if err == nil {
+		t.Error("Validate() error = nil, want error for zero run interval")
+	}
+	if err != ErrInvalidCompactionInterval {
+		t.Errorf("Validate() error = %v, want ErrInvalidCompactionInterval", err)
+	}
+}
+
+func TestValidate_CompactionInvalidFragmentThreshold(t *testing.T) {
+	tests := []struct {
+		name      string
+		threshold int
+	}{
+		{"zero", 0},
+		{"one", 1}, // Must be at least 2 (need 2+ rows to compact)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{
+				Server: ServerConfig{
+					Port:                    "50053",
+					GracefulShutdownTimeout: 30 * time.Second,
+				},
+				Database: DatabaseConfig{
+					URL:          "postgres://localhost:5432/db",
+					MaxOpenConns: 10,
+					MaxIdleConns: 5,
+				},
+				Observability: ObservabilityConfig{
+					SamplingRate: 0.5,
+				},
+				Compaction: CompactionConfig{
+					Enabled:           true,
+					RunInterval:       5 * time.Minute,
+					FragmentThreshold: tt.threshold,
+					BatchSize:         50,
+				},
+			}
+
+			err := config.Validate()
+			if err == nil {
+				t.Errorf("Validate() error = nil, want error for threshold %d", tt.threshold)
+			}
+			if err != ErrInvalidFragmentThreshold {
+				t.Errorf("Validate() error = %v, want ErrInvalidFragmentThreshold", err)
+			}
+		})
+	}
+}
+
+func TestValidate_CompactionInvalidBatchSize(t *testing.T) {
+	config := &Config{
+		Server: ServerConfig{
+			Port:                    "50053",
+			GracefulShutdownTimeout: 30 * time.Second,
+		},
+		Database: DatabaseConfig{
+			URL:          "postgres://localhost:5432/db",
+			MaxOpenConns: 10,
+			MaxIdleConns: 5,
+		},
+		Observability: ObservabilityConfig{
+			SamplingRate: 0.5,
+		},
+		Compaction: CompactionConfig{
+			Enabled:           true,
+			RunInterval:       5 * time.Minute,
+			FragmentThreshold: 100,
+			BatchSize:         0, // Invalid
+		},
+	}
+
+	err := config.Validate()
+	if err == nil {
+		t.Error("Validate() error = nil, want error for zero batch size")
+	}
+	if err != ErrInvalidCompactionBatchSize {
+		t.Errorf("Validate() error = %v, want ErrInvalidCompactionBatchSize", err)
+	}
+}
+
+func TestLoadConfig_CompactionDefaults(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
+
+	config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+
+	// Verify compaction defaults
+	if !config.Compaction.Enabled {
+		t.Error("Compaction.Enabled = false, want true")
+	}
+	if config.Compaction.RunInterval != 5*time.Minute {
+		t.Errorf("Compaction.RunInterval = %v, want 5m", config.Compaction.RunInterval)
+	}
+	if config.Compaction.FragmentThreshold != 100 {
+		t.Errorf("Compaction.FragmentThreshold = %d, want 100", config.Compaction.FragmentThreshold)
+	}
+	if config.Compaction.BatchSize != 50 {
+		t.Errorf("Compaction.BatchSize = %d, want 50", config.Compaction.BatchSize)
+	}
+}
+
+func TestLoadConfig_CompactionCustomValues(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
+	t.Setenv("COMPACTION_ENABLED", "false")
+	t.Setenv("COMPACTION_RUN_INTERVAL", "10m")
+	t.Setenv("COMPACTION_FRAGMENT_THRESHOLD", "200")
+	t.Setenv("COMPACTION_BATCH_SIZE", "100")
+
+	config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+
+	// Verify custom values
+	if config.Compaction.Enabled {
+		t.Error("Compaction.Enabled = true, want false")
+	}
+	if config.Compaction.RunInterval != 10*time.Minute {
+		t.Errorf("Compaction.RunInterval = %v, want 10m", config.Compaction.RunInterval)
+	}
+	if config.Compaction.FragmentThreshold != 200 {
+		t.Errorf("Compaction.FragmentThreshold = %d, want 200", config.Compaction.FragmentThreshold)
+	}
+	if config.Compaction.BatchSize != 100 {
+		t.Errorf("Compaction.BatchSize = %d, want 100", config.Compaction.BatchSize)
+	}
+}
+
 // clearEnv clears environment variables used in tests
 func clearEnv(t *testing.T) {
 	t.Helper()
@@ -540,6 +751,8 @@ func clearEnv(t *testing.T) {
 		"REDIS_POOL_SIZE", "REDIS_CONN_MAX_IDLE_TIME",
 		"SERVICE_NAME", "SERVICE_VERSION", "ENVIRONMENT", "OTLP_ENDPOINT",
 		"SAMPLING_RATE", "LOG_LEVEL", "METRICS_ENABLED", "METRICS_PORT",
+		"COMPACTION_ENABLED", "COMPACTION_RUN_INTERVAL",
+		"COMPACTION_FRAGMENT_THRESHOLD", "COMPACTION_BATCH_SIZE",
 	}
 	for _, key := range envVars {
 		_ = os.Unsetenv(key)

--- a/services/position-keeping/app/config_test.go
+++ b/services/position-keeping/app/config_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"os"
 	"testing"
 	"time"

--- a/services/position-keeping/app/config_test.go
+++ b/services/position-keeping/app/config_test.go
@@ -608,7 +608,7 @@ func TestValidate_CompactionInvalidRunInterval(t *testing.T) {
 	if err == nil {
 		t.Error("Validate() error = nil, want error for zero run interval")
 	}
-	if err != ErrInvalidCompactionInterval {
+	if !errors.Is(err, ErrInvalidCompactionInterval) {
 		t.Errorf("Validate() error = %v, want ErrInvalidCompactionInterval", err)
 	}
 }
@@ -649,7 +649,7 @@ func TestValidate_CompactionInvalidFragmentThreshold(t *testing.T) {
 			if err == nil {
 				t.Errorf("Validate() error = nil, want error for threshold %d", tt.threshold)
 			}
-			if err != ErrInvalidFragmentThreshold {
+			if !errors.Is(err, ErrInvalidFragmentThreshold) {
 				t.Errorf("Validate() error = %v, want ErrInvalidFragmentThreshold", err)
 			}
 		})
@@ -682,7 +682,7 @@ func TestValidate_CompactionInvalidBatchSize(t *testing.T) {
 	if err == nil {
 		t.Error("Validate() error = nil, want error for zero batch size")
 	}
-	if err != ErrInvalidCompactionBatchSize {
+	if !errors.Is(err, ErrInvalidCompactionBatchSize) {
 		t.Errorf("Validate() error = %v, want ErrInvalidCompactionBatchSize", err)
 	}
 }

--- a/services/position-keeping/cmd/main.go
+++ b/services/position-keeping/cmd/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/meridianhub/meridian/services/position-keeping/app"
 	"github.com/meridianhub/meridian/services/position-keeping/observability"
 	"github.com/meridianhub/meridian/services/position-keeping/service"
+	"github.com/meridianhub/meridian/services/position-keeping/worker"
 	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/pkg/interceptors"
@@ -143,6 +144,38 @@ func run(logger *slog.Logger) error {
 		outboxWorker.Start(workerCtx)
 	} else {
 		logger.Info("event outbox worker disabled (kafka not configured)")
+	}
+
+	// Initialize and start compaction worker (if enabled)
+	var compactionWorker *worker.CompactionWorker
+	var compactionWorkerCancel context.CancelFunc
+	if config.Compaction.Enabled {
+		compactionConfig := worker.CompactionConfig{
+			RunInterval:       config.Compaction.RunInterval,
+			FragmentThreshold: config.Compaction.FragmentThreshold,
+			BatchSize:         config.Compaction.BatchSize,
+		}
+		var workerErr error
+		compactionWorker, workerErr = worker.NewCompactionWorker(container.DBPool, compactionConfig, logger)
+		if workerErr != nil {
+			return fmt.Errorf("failed to create compaction worker: %w", workerErr)
+		}
+
+		// Start compaction worker in background
+		var compactionWorkerCtx context.Context
+		compactionWorkerCtx, compactionWorkerCancel = context.WithCancel(context.Background())
+		defer compactionWorkerCancel() // Safety net; primary shutdown goes through explicit cancellation
+		go func() {
+			if err := compactionWorker.Start(compactionWorkerCtx); err != nil {
+				logger.Error("compaction worker error", "error", err)
+			}
+		}()
+		logger.Info("compaction worker started",
+			"run_interval", config.Compaction.RunInterval,
+			"fragment_threshold", config.Compaction.FragmentThreshold,
+			"batch_size", config.Compaction.BatchSize)
+	} else {
+		logger.Info("compaction worker disabled")
 	}
 
 	// Create idempotency service
@@ -309,6 +342,16 @@ func run(logger *slog.Logger) error {
 		}
 		outboxWorker.Stop() // Blocks until current batch completes and Kafka flush finishes
 		logger.Info("event outbox worker stopped")
+	}
+
+	// Shutdown compaction worker
+	if compactionWorker != nil {
+		logger.Info("stopping compaction worker...")
+		if compactionWorkerCancel != nil {
+			compactionWorkerCancel() // Cancel context first to signal worker to stop
+		}
+		compactionWorker.Stop() // Blocks until current compaction iteration completes
+		logger.Info("compaction worker stopped")
 	}
 
 	// Create shutdown context with timeout

--- a/services/position-keeping/cmd/main.go
+++ b/services/position-keeping/cmd/main.go
@@ -170,7 +170,7 @@ func run(logger *slog.Logger) error {
 				logger.Error("compaction worker error", "error", err)
 			}
 		}()
-		logger.Info("compaction worker started",
+		logger.Info("compaction worker enabled",
 			"run_interval", config.Compaction.RunInterval,
 			"fragment_threshold", config.Compaction.FragmentThreshold,
 			"batch_size", config.Compaction.BatchSize)

--- a/services/position-keeping/worker/compaction_worker.go
+++ b/services/position-keeping/worker/compaction_worker.go
@@ -138,10 +138,11 @@ func (w *CompactionWorker) Start(ctx context.Context) error {
 	defer ticker.Stop()
 
 	// Run initial compaction immediately
-	// Add to WaitGroup before calling to prevent race with Stop()
-	w.wg.Add(1)
-	w.runCompactionIteration(ctx)
-	w.wg.Done()
+	// Use tryStartIteration to safely add to WaitGroup only if not stopped
+	if w.tryStartIteration() {
+		w.runCompactionIteration(ctx)
+		w.wg.Done()
+	}
 
 	for {
 		select {
@@ -388,7 +389,10 @@ func consolidatePositions(positions []PositionRow) consolidatedPosition {
 // compactBucket consolidates all position rows for a specific bucket into a single row.
 // Returns the number of original rows consolidated.
 func (w *CompactionWorker) compactBucket(ctx context.Context, accountID, instrumentCode, bucketKey string) (int, error) {
-	tx, err := w.pool.Begin(ctx)
+	// Use RepeatableRead isolation for correctness with FOR UPDATE locks
+	tx, err := w.pool.BeginTx(ctx, pgx.TxOptions{
+		IsoLevel: pgx.RepeatableRead,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to begin transaction: %w", err)
 	}

--- a/services/position-keeping/worker/compaction_worker.go
+++ b/services/position-keeping/worker/compaction_worker.go
@@ -1,0 +1,653 @@
+// Package worker provides background workers for the position-keeping service.
+package worker
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/shopspring/decimal"
+)
+
+// CompactionConfig holds configuration for the compaction worker.
+type CompactionConfig struct {
+	// RunInterval specifies how often to run compaction (e.g., 5 minutes)
+	RunInterval time.Duration
+
+	// FragmentThreshold is the minimum number of rows to trigger compaction
+	// for a given (account_id, instrument_code, bucket_key) combination
+	FragmentThreshold int
+
+	// BatchSize is how many buckets to compact per run
+	BatchSize int
+}
+
+// CompactionWorker is a background worker that consolidates fragmented position
+// rows in the append-only positions table.
+//
+// The position-keeping service uses append-only writes for O(1) constant-time
+// inserts. Over time, this creates fragmentation - multiple rows for the same
+// (account_id, instrument_code, bucket_key) combination. The compaction worker
+// runs periodically to consolidate these rows while preserving the audit trail.
+type CompactionWorker struct {
+	pool    *pgxpool.Pool
+	config  CompactionConfig
+	logger  *slog.Logger
+	done    chan struct{}
+	wg      sync.WaitGroup
+	mu      sync.Mutex
+	running bool
+	stopped bool // guards wg.Add/Wait race
+}
+
+// Errors returned by the compaction worker.
+var (
+	ErrNilPool                  = errors.New("pool cannot be nil")
+	ErrNilLogger                = errors.New("logger cannot be nil")
+	ErrInvalidRunInterval       = errors.New("run interval must be greater than zero")
+	ErrInvalidFragmentThreshold = errors.New("fragment threshold must be greater than zero")
+	ErrInvalidBatchSize         = errors.New("batch size must be greater than zero")
+	ErrWorkerAlreadyRunning     = errors.New("worker is already running")
+)
+
+// FragmentedBucket represents a bucket that has fragmentation above the threshold.
+type FragmentedBucket struct {
+	AccountID      string
+	InstrumentCode string
+	BucketKey      string
+	RowCount       int64
+}
+
+// PositionRow represents a single position row for compaction.
+type PositionRow struct {
+	ID          uuid.UUID
+	Amount      decimal.Decimal
+	Dimension   string
+	Attributes  map[string]string
+	ReferenceID uuid.UUID
+	CreatedAt   time.Time
+}
+
+// NewCompactionWorker creates a new compaction worker.
+//
+// Parameters:
+//   - pool: PostgreSQL connection pool
+//   - config: Worker configuration
+//   - logger: Structured logger
+//
+// Returns an error if any required parameter is invalid.
+func NewCompactionWorker(
+	pool *pgxpool.Pool,
+	config CompactionConfig,
+	logger *slog.Logger,
+) (*CompactionWorker, error) {
+	if pool == nil {
+		return nil, ErrNilPool
+	}
+	if logger == nil {
+		return nil, ErrNilLogger
+	}
+	if config.RunInterval <= 0 {
+		return nil, ErrInvalidRunInterval
+	}
+	if config.FragmentThreshold <= 0 {
+		return nil, ErrInvalidFragmentThreshold
+	}
+	if config.BatchSize <= 0 {
+		return nil, ErrInvalidBatchSize
+	}
+
+	return &CompactionWorker{
+		pool:   pool,
+		config: config,
+		logger: logger.With("component", "compaction_worker"),
+		done:   make(chan struct{}),
+	}, nil
+}
+
+// Start begins the background compaction loop.
+// It runs until ctx is cancelled or Stop() is called.
+// The method blocks and should be run in a separate goroutine.
+//
+// Returns ErrWorkerAlreadyRunning if Start is called while already running.
+func (w *CompactionWorker) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return ErrWorkerAlreadyRunning
+	}
+	w.running = true
+	w.mu.Unlock()
+
+	w.logger.Info("compaction worker started",
+		"run_interval", w.config.RunInterval,
+		"fragment_threshold", w.config.FragmentThreshold,
+		"batch_size", w.config.BatchSize)
+
+	ticker := time.NewTicker(w.config.RunInterval)
+	defer ticker.Stop()
+
+	// Run initial compaction immediately
+	// Add to WaitGroup before calling to prevent race with Stop()
+	w.wg.Add(1)
+	w.runCompactionIteration(ctx)
+	w.wg.Done()
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("compaction worker stopped: context cancelled")
+			w.markStopped()
+			return nil
+		case <-w.done:
+			w.logger.Info("compaction worker stopped: explicit shutdown")
+			w.markStopped()
+			return nil
+		case <-ticker.C:
+			// Use tryStartIteration to safely add to WaitGroup only if not stopped
+			if w.tryStartIteration() {
+				w.runCompactionIteration(ctx)
+				w.wg.Done()
+			} else {
+				// Worker is stopping, exit the loop
+				w.logger.Info("compaction worker stopped: explicit shutdown")
+				w.markStopped()
+				return nil
+			}
+		}
+	}
+}
+
+// markStopped safely marks the worker as not running.
+func (w *CompactionWorker) markStopped() {
+	w.mu.Lock()
+	w.running = false
+	w.mu.Unlock()
+}
+
+// tryStartIteration attempts to start a new compaction iteration.
+// Returns true if the iteration can proceed (wg.Add(1) was called).
+// Returns false if the worker is stopping (do not proceed with iteration).
+// This method prevents the race between wg.Add and wg.Wait.
+func (w *CompactionWorker) tryStartIteration() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.stopped {
+		return false
+	}
+	w.wg.Add(1)
+	return true
+}
+
+// Stop signals the worker to shut down gracefully.
+// It waits for the current compaction iteration to complete.
+// It is safe to call Stop multiple times.
+func (w *CompactionWorker) Stop() {
+	// Mark as stopped under lock to prevent new iterations from starting
+	w.mu.Lock()
+	alreadyStopped := w.stopped
+	w.stopped = true
+	w.mu.Unlock()
+
+	if !alreadyStopped {
+		select {
+		case <-w.done:
+			// Already closed
+		default:
+			close(w.done)
+		}
+	}
+
+	// Wait for in-flight compaction operations to complete
+	// This is safe because tryStartIteration won't call wg.Add after stopped=true
+	w.wg.Wait()
+	w.logger.Info("compaction worker shutdown complete")
+}
+
+// runCompactionIteration performs one compaction pass.
+// It finds fragmented buckets and consolidates them.
+// The caller must manage WaitGroup to prevent races with Stop().
+func (w *CompactionWorker) runCompactionIteration(ctx context.Context) {
+	// Check for context cancellation before starting
+	select {
+	case <-ctx.Done():
+		return
+	default:
+	}
+
+	w.logger.Debug("starting compaction iteration")
+	start := time.Now()
+	RecordCompactionRun()
+
+	var totalProcessed, totalRowsConsolidated int
+	var iterationErrors []error
+
+	// Find fragmented buckets
+	fragmentedBuckets, err := w.findFragmentedBuckets(ctx)
+	if err != nil {
+		w.logger.Error("failed to find fragmented buckets", "error", err)
+		RecordCompactionError(ErrorTypeScan)
+		iterationErrors = append(iterationErrors, err)
+		w.logIterationComplete(start, totalProcessed, totalRowsConsolidated, iterationErrors)
+		return
+	}
+
+	// Update fragmented buckets gauge
+	SetFragmentedBucketsCount(len(fragmentedBuckets))
+
+	if len(fragmentedBuckets) == 0 {
+		w.logger.Debug("compaction iteration complete: no fragmented buckets found",
+			"duration", time.Since(start))
+		ObserveCompactionDuration(time.Since(start).Seconds())
+		return
+	}
+
+	w.logger.Info("found fragmented buckets",
+		"count", len(fragmentedBuckets),
+		"threshold", w.config.FragmentThreshold)
+
+	// Process each fragmented bucket
+	for _, bucket := range fragmentedBuckets {
+		// Check for shutdown signal between buckets
+		select {
+		case <-ctx.Done():
+			w.logIterationComplete(start, totalProcessed, totalRowsConsolidated, iterationErrors)
+			return
+		case <-w.done:
+			w.logIterationComplete(start, totalProcessed, totalRowsConsolidated, iterationErrors)
+			return
+		default:
+		}
+
+		rowsConsolidated, err := w.compactBucket(ctx, bucket.AccountID, bucket.InstrumentCode, bucket.BucketKey)
+		if err != nil {
+			w.logger.Error("failed to compact bucket",
+				"account_id", bucket.AccountID,
+				"instrument_code", bucket.InstrumentCode,
+				"bucket_key", bucket.BucketKey,
+				"error", err)
+			// Determine error type for metrics
+			RecordCompactionError(ErrorTypeTx)
+			iterationErrors = append(iterationErrors, err)
+			continue
+		}
+
+		totalProcessed++
+		totalRowsConsolidated += rowsConsolidated
+		RecordBucketCompacted()
+		RecordRowsConsolidated(rowsConsolidated)
+
+		w.logger.Debug("compacted bucket",
+			"account_id", bucket.AccountID,
+			"instrument_code", bucket.InstrumentCode,
+			"bucket_key", bucket.BucketKey,
+			"rows_consolidated", rowsConsolidated)
+	}
+
+	w.logIterationComplete(start, totalProcessed, totalRowsConsolidated, iterationErrors)
+}
+
+// findFragmentedBuckets finds buckets with more rows than the fragment threshold.
+func (w *CompactionWorker) findFragmentedBuckets(ctx context.Context) ([]FragmentedBucket, error) {
+	tx, err := w.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	// Set tenant scope if in multi-tenant mode
+	if err := w.setSearchPath(ctx, tx); err != nil {
+		return nil, err
+	}
+
+	query := `
+		SELECT account_id, instrument_code, bucket_key, COUNT(*) as row_count
+		FROM position
+		WHERE deleted_at IS NULL
+		GROUP BY account_id, instrument_code, bucket_key
+		HAVING COUNT(*) > $1
+		ORDER BY row_count DESC
+		LIMIT $2`
+
+	rows, err := tx.Query(ctx, query, w.config.FragmentThreshold, w.config.BatchSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query fragmented buckets: %w", err)
+	}
+	defer rows.Close()
+
+	var buckets []FragmentedBucket
+	for rows.Next() {
+		var bucket FragmentedBucket
+		if err := rows.Scan(&bucket.AccountID, &bucket.InstrumentCode, &bucket.BucketKey, &bucket.RowCount); err != nil {
+			return nil, fmt.Errorf("failed to scan fragmented bucket: %w", err)
+		}
+		buckets = append(buckets, bucket)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating fragmented buckets: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return buckets, nil
+}
+
+// consolidatedPosition holds the result of consolidating multiple position rows.
+type consolidatedPosition struct {
+	Amount      decimal.Decimal
+	Dimension   string
+	Attributes  map[string]string
+	OriginalIDs []uuid.UUID
+}
+
+// consolidatePositions calculates the consolidated values from multiple position rows.
+func consolidatePositions(positions []PositionRow) consolidatedPosition {
+	result := consolidatedPosition{
+		Amount:      decimal.Zero,
+		OriginalIDs: make([]uuid.UUID, len(positions)),
+	}
+	var latestCreatedAt time.Time
+
+	for i, pos := range positions {
+		result.Amount = result.Amount.Add(pos.Amount)
+		result.OriginalIDs[i] = pos.ID
+
+		// Use dimension and attributes from most recent position
+		if pos.CreatedAt.After(latestCreatedAt) {
+			latestCreatedAt = pos.CreatedAt
+			result.Dimension = pos.Dimension
+			// Copy attributes to avoid mutation
+			if pos.Attributes != nil {
+				result.Attributes = make(map[string]string, len(pos.Attributes))
+				for k, v := range pos.Attributes {
+					result.Attributes[k] = v
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+// compactBucket consolidates all position rows for a specific bucket into a single row.
+// Returns the number of original rows consolidated.
+func (w *CompactionWorker) compactBucket(ctx context.Context, accountID, instrumentCode, bucketKey string) (int, error) {
+	tx, err := w.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	// Set tenant scope if in multi-tenant mode
+	if err := w.setSearchPath(ctx, tx); err != nil {
+		return 0, err
+	}
+
+	// Lock and get all positions for this bucket
+	positions, err := w.lockAndGetPositions(ctx, tx, accountID, instrumentCode, bucketKey)
+	if err != nil {
+		RecordCompactionError(ErrorTypeLock)
+		return 0, err
+	}
+
+	// Need at least 2 rows to compact (otherwise nothing to consolidate)
+	if len(positions) < 2 {
+		if err := tx.Commit(ctx); err != nil {
+			return 0, fmt.Errorf("failed to commit transaction: %w", err)
+		}
+		return 0, nil
+	}
+
+	// Calculate consolidated values
+	consolidated := consolidatePositions(positions)
+
+	// Execute the compaction within the transaction
+	if err := w.executeCompaction(ctx, tx, accountID, instrumentCode, bucketKey, consolidated); err != nil {
+		return 0, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		RecordCompactionError(ErrorTypeTx)
+		return 0, fmt.Errorf("failed to commit compaction transaction: %w", err)
+	}
+
+	return len(positions), nil
+}
+
+// executeCompaction performs the actual compaction operations within a transaction.
+func (w *CompactionWorker) executeCompaction(
+	ctx context.Context,
+	tx pgx.Tx,
+	accountID, instrumentCode, bucketKey string,
+	consolidated consolidatedPosition,
+) error {
+	consolidatedID := uuid.New()
+	compactionRef := uuid.New()
+	now := time.Now().UTC()
+
+	// Prepare attributes with compaction metadata
+	attrs := consolidated.Attributes
+	if attrs == nil {
+		attrs = make(map[string]string)
+	}
+	attrs["_compacted_from_count"] = fmt.Sprintf("%d", len(consolidated.OriginalIDs))
+	attrs["_compaction_ref"] = compactionRef.String()
+
+	attributesJSON, err := json.Marshal(attrs)
+	if err != nil {
+		return fmt.Errorf("failed to marshal attributes: %w", err)
+	}
+
+	// Insert consolidated row
+	if err := w.insertConsolidatedPosition(ctx, tx, consolidatedID, now, accountID, instrumentCode,
+		bucketKey, consolidated.Amount, consolidated.Dimension, attributesJSON, compactionRef); err != nil {
+		return err
+	}
+
+	// Soft delete original positions
+	if err := w.softDeletePositions(ctx, tx, consolidated.OriginalIDs); err != nil {
+		return err
+	}
+
+	// Try to insert audit record (optional - may not exist)
+	w.tryInsertAuditRecord(ctx, tx, now, compactionRef, consolidatedID,
+		consolidated.OriginalIDs, accountID, instrumentCode, bucketKey)
+
+	return nil
+}
+
+// insertConsolidatedPosition inserts the new consolidated position row.
+func (w *CompactionWorker) insertConsolidatedPosition(
+	ctx context.Context,
+	tx pgx.Tx,
+	id uuid.UUID,
+	createdAt time.Time,
+	accountID, instrumentCode, bucketKey string,
+	amount decimal.Decimal,
+	dimension string,
+	attributesJSON []byte,
+	referenceID uuid.UUID,
+) error {
+	query := `
+		INSERT INTO position (
+			id, created_at, created_by,
+			account_id, instrument_code, bucket_key, amount, dimension, attributes, reference_id
+		) VALUES (
+			$1, $2, 'compaction_worker',
+			$3, $4, $5, $6, $7, $8, $9
+		)`
+
+	_, err := tx.Exec(ctx, query, id, createdAt, accountID, instrumentCode, bucketKey,
+		amount, dimension, attributesJSON, referenceID)
+	if err != nil {
+		RecordCompactionError(ErrorTypeInsert)
+		return fmt.Errorf("failed to insert consolidated position: %w", err)
+	}
+	return nil
+}
+
+// softDeletePositions marks the original positions as deleted.
+func (w *CompactionWorker) softDeletePositions(ctx context.Context, tx pgx.Tx, ids []uuid.UUID) error {
+	query := `
+		UPDATE position
+		SET deleted_at = NOW()
+		WHERE id = ANY($1)`
+
+	_, err := tx.Exec(ctx, query, ids)
+	if err != nil {
+		RecordCompactionError(ErrorTypeDelete)
+		return fmt.Errorf("failed to soft delete original positions: %w", err)
+	}
+	return nil
+}
+
+// tryInsertAuditRecord attempts to insert a compaction audit record.
+// Failures are logged but do not cause the compaction to fail.
+func (w *CompactionWorker) tryInsertAuditRecord(
+	ctx context.Context,
+	tx pgx.Tx,
+	createdAt time.Time,
+	compactionRef, consolidatedID uuid.UUID,
+	originalIDs []uuid.UUID,
+	accountID, instrumentCode, bucketKey string,
+) {
+	query := `
+		INSERT INTO position_compaction_audit (
+			id, created_at, compaction_ref, consolidated_position_id,
+			original_position_ids, original_count, account_id, instrument_code, bucket_key
+		) VALUES (
+			$1, $2, $3, $4, $5, $6, $7, $8, $9
+		)`
+
+	originalIDsJSON, err := json.Marshal(originalIDs)
+	if err != nil {
+		w.logger.Warn("failed to marshal original IDs for audit",
+			"error", err,
+			"compaction_ref", compactionRef)
+		return
+	}
+
+	_, err = tx.Exec(ctx, query,
+		uuid.New(), createdAt, compactionRef, consolidatedID,
+		originalIDsJSON, len(originalIDs), accountID, instrumentCode, bucketKey,
+	)
+	if err != nil {
+		w.logger.Warn("failed to insert compaction audit record (audit table may not exist)",
+			"error", err,
+			"compaction_ref", compactionRef,
+			"consolidated_position_id", consolidatedID)
+	}
+}
+
+// lockAndGetPositions acquires row-level locks and returns all positions for a bucket.
+func (w *CompactionWorker) lockAndGetPositions(ctx context.Context, tx pgx.Tx, accountID, instrumentCode, bucketKey string) ([]PositionRow, error) {
+	query := `
+		SELECT id, amount, dimension, attributes, reference_id, created_at
+		FROM position
+		WHERE account_id = $1 AND instrument_code = $2 AND bucket_key = $3 AND deleted_at IS NULL
+		FOR UPDATE`
+
+	rows, err := tx.Query(ctx, query, accountID, instrumentCode, bucketKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to lock and query positions: %w", err)
+	}
+	defer rows.Close()
+
+	var positions []PositionRow
+	for rows.Next() {
+		var pos PositionRow
+		var attributesJSON sql.NullString
+		var refID sql.NullString
+
+		if err := rows.Scan(&pos.ID, &pos.Amount, &pos.Dimension, &attributesJSON, &refID, &pos.CreatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan position row: %w", err)
+		}
+
+		if attributesJSON.Valid && attributesJSON.String != "" {
+			if err := json.Unmarshal([]byte(attributesJSON.String), &pos.Attributes); err != nil {
+				return nil, fmt.Errorf("failed to unmarshal attributes: %w", err)
+			}
+		}
+
+		if refID.Valid {
+			pos.ReferenceID, err = uuid.Parse(refID.String)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse reference_id: %w", err)
+			}
+		}
+
+		positions = append(positions, pos)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating positions: %w", err)
+	}
+
+	return positions, nil
+}
+
+// setSearchPath sets the PostgreSQL search_path for the transaction.
+// In multi-tenant mode, it sets the search_path to the tenant's schema.
+// In single-tenant mode (no tenant context), it does nothing.
+func (w *CompactionWorker) setSearchPath(ctx context.Context, tx pgx.Tx) error {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
+	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	_, err := tx.Exec(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to set tenant schema scope: %w", err)
+	}
+
+	return nil
+}
+
+// logIterationComplete logs the summary of a compaction iteration.
+func (w *CompactionWorker) logIterationComplete(
+	start time.Time,
+	bucketsProcessed, rowsConsolidated int,
+	errs []error,
+) {
+	duration := time.Since(start)
+	ObserveCompactionDuration(duration.Seconds())
+
+	if bucketsProcessed == 0 && len(errs) == 0 {
+		w.logger.Debug("compaction iteration complete: no buckets processed",
+			"duration", duration)
+		return
+	}
+
+	if len(errs) > 0 {
+		w.logger.Warn("compaction iteration complete with errors",
+			"buckets_processed", bucketsProcessed,
+			"rows_consolidated", rowsConsolidated,
+			"error_count", len(errs),
+			"duration", duration)
+	} else {
+		w.logger.Info("compaction iteration complete",
+			"buckets_processed", bucketsProcessed,
+			"rows_consolidated", rowsConsolidated,
+			"duration", duration)
+	}
+}

--- a/services/position-keeping/worker/compaction_worker_test.go
+++ b/services/position-keeping/worker/compaction_worker_test.go
@@ -1,0 +1,455 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// mockPool creates a minimal pool configuration for testing
+// Note: This does not actually connect to a database
+func mockPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	// Create a pool config with a test URL - parsing only, no actual connection
+	config, err := pgxpool.ParseConfig("postgres://test:test@localhost:5432/testdb")
+	if err != nil {
+		t.Fatalf("failed to parse pool config: %v", err)
+	}
+	// Create pool without connecting (for constructor tests only)
+	// The pool will fail on actual use, but that's fine for unit tests
+	pool, err := pgxpool.NewWithConfig(context.Background(), config)
+	if err != nil {
+		// Skip test if we can't create a pool (e.g., no PostgreSQL available)
+		t.Skipf("skipping test: cannot create pool: %v", err)
+	}
+	return pool
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+}
+
+func validConfig() CompactionConfig {
+	return CompactionConfig{
+		RunInterval:       5 * time.Minute,
+		FragmentThreshold: 100,
+		BatchSize:         50,
+	}
+}
+
+func TestNewCompactionWorker_Success(t *testing.T) {
+	pool := mockPool(t)
+	defer pool.Close()
+	logger := testLogger()
+	config := validConfig()
+
+	worker, err := NewCompactionWorker(pool, config, logger)
+	if err != nil {
+		t.Fatalf("NewCompactionWorker() error = %v, want nil", err)
+	}
+	if worker == nil {
+		t.Fatal("NewCompactionWorker() returned nil worker")
+	}
+
+	if worker.pool != pool {
+		t.Error("worker.pool does not match provided pool")
+	}
+
+	if worker.config.RunInterval != config.RunInterval {
+		t.Errorf("worker.config.RunInterval = %v, want %v", worker.config.RunInterval, config.RunInterval)
+	}
+
+	if worker.config.FragmentThreshold != config.FragmentThreshold {
+		t.Errorf("worker.config.FragmentThreshold = %d, want %d", worker.config.FragmentThreshold, config.FragmentThreshold)
+	}
+
+	if worker.config.BatchSize != config.BatchSize {
+		t.Errorf("worker.config.BatchSize = %d, want %d", worker.config.BatchSize, config.BatchSize)
+	}
+}
+
+func TestNewCompactionWorker_NilPool(t *testing.T) {
+	logger := testLogger()
+	config := validConfig()
+
+	worker, err := NewCompactionWorker(nil, config, logger)
+	if err == nil {
+		t.Error("NewCompactionWorker() error = nil, want error for nil pool")
+	}
+	if !errors.Is(err, ErrNilPool) {
+		t.Errorf("NewCompactionWorker() error = %v, want ErrNilPool", err)
+	}
+	if worker != nil {
+		t.Error("NewCompactionWorker() returned non-nil worker for nil pool")
+	}
+}
+
+func TestNewCompactionWorker_NilLogger(t *testing.T) {
+	pool := mockPool(t)
+	defer pool.Close()
+	config := validConfig()
+
+	worker, err := NewCompactionWorker(pool, config, nil)
+	if err == nil {
+		t.Error("NewCompactionWorker() error = nil, want error for nil logger")
+	}
+	if !errors.Is(err, ErrNilLogger) {
+		t.Errorf("NewCompactionWorker() error = %v, want ErrNilLogger", err)
+	}
+	if worker != nil {
+		t.Error("NewCompactionWorker() returned non-nil worker for nil logger")
+	}
+}
+
+func TestNewCompactionWorker_InvalidRunInterval(t *testing.T) {
+	pool := mockPool(t)
+	defer pool.Close()
+	logger := testLogger()
+
+	tests := []struct {
+		name     string
+		interval time.Duration
+	}{
+		{"zero", 0},
+		{"negative", -1 * time.Second},
+		{"negative minutes", -5 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := CompactionConfig{
+				RunInterval:       tt.interval,
+				FragmentThreshold: 100,
+				BatchSize:         50,
+			}
+
+			worker, err := NewCompactionWorker(pool, config, logger)
+			if err == nil {
+				t.Error("NewCompactionWorker() error = nil, want error for invalid run interval")
+			}
+			if !errors.Is(err, ErrInvalidRunInterval) {
+				t.Errorf("NewCompactionWorker() error = %v, want ErrInvalidRunInterval", err)
+			}
+			if worker != nil {
+				t.Error("NewCompactionWorker() returned non-nil worker for invalid run interval")
+			}
+		})
+	}
+}
+
+func TestNewCompactionWorker_InvalidFragmentThreshold(t *testing.T) {
+	pool := mockPool(t)
+	defer pool.Close()
+	logger := testLogger()
+
+	tests := []struct {
+		name      string
+		threshold int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+		{"negative large", -100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := CompactionConfig{
+				RunInterval:       5 * time.Minute,
+				FragmentThreshold: tt.threshold,
+				BatchSize:         50,
+			}
+
+			worker, err := NewCompactionWorker(pool, config, logger)
+			if err == nil {
+				t.Error("NewCompactionWorker() error = nil, want error for invalid fragment threshold")
+			}
+			if !errors.Is(err, ErrInvalidFragmentThreshold) {
+				t.Errorf("NewCompactionWorker() error = %v, want ErrInvalidFragmentThreshold", err)
+			}
+			if worker != nil {
+				t.Error("NewCompactionWorker() returned non-nil worker for invalid fragment threshold")
+			}
+		})
+	}
+}
+
+func TestNewCompactionWorker_InvalidBatchSize(t *testing.T) {
+	pool := mockPool(t)
+	defer pool.Close()
+	logger := testLogger()
+
+	tests := []struct {
+		name      string
+		batchSize int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+		{"negative large", -50},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := CompactionConfig{
+				RunInterval:       5 * time.Minute,
+				FragmentThreshold: 100,
+				BatchSize:         tt.batchSize,
+			}
+
+			worker, err := NewCompactionWorker(pool, config, logger)
+			if err == nil {
+				t.Error("NewCompactionWorker() error = nil, want error for invalid batch size")
+			}
+			if !errors.Is(err, ErrInvalidBatchSize) {
+				t.Errorf("NewCompactionWorker() error = %v, want ErrInvalidBatchSize", err)
+			}
+			if worker != nil {
+				t.Error("NewCompactionWorker() returned non-nil worker for invalid batch size")
+			}
+		})
+	}
+}
+
+func TestCompactionWorker_StartAlreadyRunning(t *testing.T) {
+	pool := mockPool(t)
+	defer pool.Close()
+	logger := testLogger()
+	config := validConfig()
+
+	worker, err := NewCompactionWorker(pool, config, logger)
+	if err != nil {
+		t.Fatalf("NewCompactionWorker() error = %v", err)
+	}
+
+	// Set running state manually
+	worker.mu.Lock()
+	worker.running = true
+	worker.mu.Unlock()
+
+	// Try to start again
+	err = worker.Start(context.Background())
+	if err == nil {
+		t.Error("Start() error = nil, want error for already running worker")
+	}
+	if !errors.Is(err, ErrWorkerAlreadyRunning) {
+		t.Errorf("Start() error = %v, want ErrWorkerAlreadyRunning", err)
+	}
+}
+
+func TestCompactionWorker_StopIdempotent(t *testing.T) {
+	pool := mockPool(t)
+	defer pool.Close()
+	logger := testLogger()
+	config := validConfig()
+
+	worker, err := NewCompactionWorker(pool, config, logger)
+	if err != nil {
+		t.Fatalf("NewCompactionWorker() error = %v", err)
+	}
+
+	// Stop should be idempotent (safe to call multiple times)
+	// This should not panic
+	worker.Stop()
+	worker.Stop()
+	worker.Stop()
+}
+
+func TestCompactionWorker_ContextCancellation(t *testing.T) {
+	pool := mockPool(t)
+	defer pool.Close()
+	logger := testLogger()
+	config := CompactionConfig{
+		RunInterval:       100 * time.Millisecond, // Fast interval for testing
+		FragmentThreshold: 100,
+		BatchSize:         50,
+	}
+
+	worker, err := NewCompactionWorker(pool, config, logger)
+	if err != nil {
+		t.Fatalf("NewCompactionWorker() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start worker in goroutine (it will fail immediately on DB operations, but that's expected)
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- worker.Start(ctx)
+	}()
+
+	// Give worker time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Cancel context
+	cancel()
+
+	// Worker should stop within a reasonable time
+	select {
+	case <-startErr:
+		// Worker stopped as expected
+	case <-time.After(2 * time.Second):
+		t.Error("Worker did not stop after context cancellation")
+	}
+}
+
+func TestCompactionWorker_StopSignal(t *testing.T) {
+	pool := mockPool(t)
+	defer pool.Close()
+	logger := testLogger()
+	config := CompactionConfig{
+		RunInterval:       100 * time.Millisecond,
+		FragmentThreshold: 100,
+		BatchSize:         50,
+	}
+
+	worker, err := NewCompactionWorker(pool, config, logger)
+	if err != nil {
+		t.Fatalf("NewCompactionWorker() error = %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Start worker in goroutine
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- worker.Start(ctx)
+	}()
+
+	// Give worker time to start
+	time.Sleep(50 * time.Millisecond)
+
+	// Call Stop
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		worker.Stop()
+	}()
+
+	// Worker should stop within a reasonable time
+	select {
+	case <-startErr:
+		// Worker stopped as expected
+	case <-time.After(2 * time.Second):
+		t.Error("Worker did not stop after Stop() was called")
+	}
+
+	wg.Wait()
+}
+
+func TestCompactionWorker_TryStartIteration(t *testing.T) {
+	pool := mockPool(t)
+	defer pool.Close()
+	logger := testLogger()
+	config := validConfig()
+
+	worker, err := NewCompactionWorker(pool, config, logger)
+	if err != nil {
+		t.Fatalf("NewCompactionWorker() error = %v", err)
+	}
+
+	// Before stopped, tryStartIteration should return true
+	if !worker.tryStartIteration() {
+		t.Error("tryStartIteration() = false, want true when not stopped")
+	}
+	worker.wg.Done() // Clean up the added wait group
+
+	// After marking stopped, tryStartIteration should return false
+	worker.mu.Lock()
+	worker.stopped = true
+	worker.mu.Unlock()
+
+	if worker.tryStartIteration() {
+		t.Error("tryStartIteration() = true, want false when stopped")
+	}
+}
+
+func TestFragmentedBucket_Struct(t *testing.T) {
+	bucket := FragmentedBucket{
+		AccountID:      "ACC001",
+		InstrumentCode: "USD",
+		BucketKey:      "default",
+		RowCount:       150,
+	}
+
+	if bucket.AccountID != "ACC001" {
+		t.Errorf("bucket.AccountID = %s, want ACC001", bucket.AccountID)
+	}
+	if bucket.InstrumentCode != "USD" {
+		t.Errorf("bucket.InstrumentCode = %s, want USD", bucket.InstrumentCode)
+	}
+	if bucket.BucketKey != "default" {
+		t.Errorf("bucket.BucketKey = %s, want default", bucket.BucketKey)
+	}
+	if bucket.RowCount != 150 {
+		t.Errorf("bucket.RowCount = %d, want 150", bucket.RowCount)
+	}
+}
+
+func TestPositionRow_Struct(t *testing.T) {
+	now := time.Now()
+	row := PositionRow{
+		Dimension:  "Monetary",
+		Attributes: map[string]string{"key": "value"},
+		CreatedAt:  now,
+	}
+
+	if row.Dimension != "Monetary" {
+		t.Errorf("row.Dimension = %s, want Monetary", row.Dimension)
+	}
+	if row.Attributes["key"] != "value" {
+		t.Errorf("row.Attributes[key] = %s, want value", row.Attributes["key"])
+	}
+	if !row.CreatedAt.Equal(now) {
+		t.Errorf("row.CreatedAt = %v, want %v", row.CreatedAt, now)
+	}
+}
+
+func TestCompactionConfig_Struct(t *testing.T) {
+	config := CompactionConfig{
+		RunInterval:       10 * time.Minute,
+		FragmentThreshold: 200,
+		BatchSize:         100,
+	}
+
+	if config.RunInterval != 10*time.Minute {
+		t.Errorf("config.RunInterval = %v, want 10m", config.RunInterval)
+	}
+	if config.FragmentThreshold != 200 {
+		t.Errorf("config.FragmentThreshold = %d, want 200", config.FragmentThreshold)
+	}
+	if config.BatchSize != 100 {
+		t.Errorf("config.BatchSize = %d, want 100", config.BatchSize)
+	}
+}
+
+func TestCompactionWorker_Errors(t *testing.T) {
+	// Verify error variable definitions
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"ErrNilPool", ErrNilPool, "pool cannot be nil"},
+		{"ErrNilLogger", ErrNilLogger, "logger cannot be nil"},
+		{"ErrInvalidRunInterval", ErrInvalidRunInterval, "run interval must be greater than zero"},
+		{"ErrInvalidFragmentThreshold", ErrInvalidFragmentThreshold, "fragment threshold must be greater than zero"},
+		{"ErrInvalidBatchSize", ErrInvalidBatchSize, "batch size must be greater than zero"},
+		{"ErrWorkerAlreadyRunning", ErrWorkerAlreadyRunning, "worker is already running"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err.Error() != tt.want {
+				t.Errorf("%s.Error() = %s, want %s", tt.name, tt.err.Error(), tt.want)
+			}
+		})
+	}
+}

--- a/services/position-keeping/worker/metrics.go
+++ b/services/position-keeping/worker/metrics.go
@@ -1,0 +1,135 @@
+// Package worker provides background workers for the position-keeping service.
+package worker
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Compaction error type constants for bounded label cardinality.
+// Using constants prevents metric cardinality explosion from arbitrary error messages.
+const (
+	// ErrorTypeScan indicates an error scanning for fragmented buckets.
+	ErrorTypeScan = "scan_error"
+	// ErrorTypeLock indicates an error acquiring row locks.
+	ErrorTypeLock = "lock_error"
+	// ErrorTypeInsert indicates an error inserting consolidated row.
+	ErrorTypeInsert = "insert_error"
+	// ErrorTypeDelete indicates an error soft-deleting original rows.
+	ErrorTypeDelete = "delete_error"
+	// ErrorTypeTx indicates a transaction error.
+	ErrorTypeTx = "tx_error"
+)
+
+var (
+	// compactionRunsTotal counts total compaction runs.
+	compactionRunsTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "position_keeping",
+			Name:      "compaction_runs_total",
+			Help:      "Total number of compaction runs",
+		},
+	)
+
+	// compactionBucketsCompactedTotal counts buckets compacted.
+	compactionBucketsCompactedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "position_keeping",
+			Name:      "compaction_buckets_compacted_total",
+			Help:      "Total number of buckets compacted",
+		},
+	)
+
+	// compactionRowsConsolidatedTotal counts rows consolidated.
+	compactionRowsConsolidatedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "position_keeping",
+			Name:      "compaction_rows_consolidated_total",
+			Help:      "Total number of position rows consolidated",
+		},
+	)
+
+	// compactionErrorsTotal counts compaction errors by error type.
+	compactionErrorsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "position_keeping",
+			Name:      "compaction_errors_total",
+			Help:      "Total number of compaction errors by error type",
+		},
+		[]string{"error_type"},
+	)
+
+	// compactionDurationSeconds tracks compaction duration.
+	compactionDurationSeconds = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "meridian",
+			Subsystem: "position_keeping",
+			Name:      "compaction_duration_seconds",
+			Help:      "Duration of compaction runs in seconds",
+			Buckets:   []float64{0.1, 0.5, 1, 2.5, 5, 10, 30, 60},
+		},
+	)
+
+	// fragmentedBucketsGauge shows current fragmented bucket count.
+	fragmentedBucketsGauge = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "meridian",
+			Subsystem: "position_keeping",
+			Name:      "fragmented_buckets",
+			Help:      "Current number of fragmented buckets above threshold",
+		},
+	)
+)
+
+// RecordCompactionRun increments the counter for total compaction runs.
+func RecordCompactionRun() {
+	compactionRunsTotal.Inc()
+}
+
+// RecordBucketCompacted increments the counter for buckets compacted.
+func RecordBucketCompacted() {
+	compactionBucketsCompactedTotal.Inc()
+}
+
+// RecordRowsConsolidated adds the count of rows consolidated to the counter.
+func RecordRowsConsolidated(count int) {
+	compactionRowsConsolidatedTotal.Add(float64(count))
+}
+
+// RecordCompactionError increments the error counter for the given error type.
+// errorType should be one of the ErrorType* constants defined in this package.
+func RecordCompactionError(errorType string) {
+	compactionErrorsTotal.WithLabelValues(errorType).Inc()
+}
+
+// ObserveCompactionDuration records the duration of a compaction run.
+func ObserveCompactionDuration(seconds float64) {
+	compactionDurationSeconds.Observe(seconds)
+}
+
+// SetFragmentedBucketsCount sets the current number of fragmented buckets.
+func SetFragmentedBucketsCount(count int) {
+	fragmentedBucketsGauge.Set(float64(count))
+}
+
+// ExposeMetricsForTesting provides access to the raw Prometheus metrics for testing.
+// This should only be used in test code.
+var ExposeMetricsForTesting = struct {
+	CompactionRunsTotal             prometheus.Counter
+	CompactionBucketsCompactedTotal prometheus.Counter
+	CompactionRowsConsolidatedTotal prometheus.Counter
+	CompactionErrorsTotal           *prometheus.CounterVec
+	CompactionDurationSeconds       prometheus.Histogram
+	FragmentedBucketsGauge          prometheus.Gauge
+}{
+	CompactionRunsTotal:             compactionRunsTotal,
+	CompactionBucketsCompactedTotal: compactionBucketsCompactedTotal,
+	CompactionRowsConsolidatedTotal: compactionRowsConsolidatedTotal,
+	CompactionErrorsTotal:           compactionErrorsTotal,
+	CompactionDurationSeconds:       compactionDurationSeconds,
+	FragmentedBucketsGauge:          fragmentedBucketsGauge,
+}


### PR DESCRIPTION
## Summary

- Implement a background compaction worker that consolidates fragmented position rows in the append-only positions table
- Add Prometheus metrics for observability (runs, buckets, rows, errors, duration)
- Add environment variable configuration for compaction settings
- Wire up the worker in main.go with graceful shutdown support

## Changes Made

### New Files
- `services/position-keeping/worker/compaction_worker.go` - Main worker implementation
- `services/position-keeping/worker/compaction_worker_test.go` - Unit tests
- `services/position-keeping/worker/metrics.go` - Prometheus metrics

### Modified Files
- `services/position-keeping/app/config.go` - Added CompactionConfig struct and loading
- `services/position-keeping/app/config_test.go` - Added tests for compaction config
- `services/position-keeping/cmd/main.go` - Wired up worker initialization and shutdown

## Technical Details

The position-keeping service uses append-only writes for O(1) constant-time inserts without locks. Over time, this creates fragmentation - multiple rows for the same (account_id, instrument_code, bucket_key) combination. The compaction worker consolidates these rows periodically.

**Key features:**
- `time.Ticker`-based scheduling with configurable run interval
- Finds fragmented buckets (rows > threshold per account/instrument/bucket_key)
- Consolidates rows atomically using FOR UPDATE row-level locking
- Preserves audit trail via soft-delete and compaction metadata in attributes
- Graceful shutdown with WaitGroup synchronization
- Multi-tenant support via SET LOCAL search_path

**Configuration via environment variables:**
| Variable | Default | Description |
|----------|---------|-------------|
| `COMPACTION_ENABLED` | `true` | Enable/disable the worker |
| `COMPACTION_RUN_INTERVAL` | `5m` | How often to run compaction |
| `COMPACTION_FRAGMENT_THRESHOLD` | `100` | Min rows to trigger compaction |
| `COMPACTION_BATCH_SIZE` | `50` | Max buckets to compact per run |

## Test plan

- [x] Unit tests for NewCompactionWorker validation
- [x] Unit tests for Start/Stop lifecycle
- [x] Unit tests for context cancellation
- [x] Unit tests for config validation
- [ ] Integration tests with actual database (requires testcontainers)

## Task

Task Master: universal-asset-system.23