### PR TITLE
fix(ci): improve Claude Code Review reliability

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,6 +5,15 @@ on:
     workflows: ["Test", "Build", "Quality"]
     types: [completed]
 
+# Prevent concurrent Claude Code installations which cause lock conflicts
+# Only one Claude review can run at a time per repo
+concurrency:
+  group: claude-code-review-${{ github.repository }}
+  cancel-in-progress: false
+
+env:
+  CLAUDE_CODE_VERSION: "2.0.74"
+
 jobs:
   claude-review:
     # Only run when ALL conditions are met:
@@ -66,6 +75,41 @@ jobs:
         id: date
         run: echo "current_date=$(date -u '+%Y-%m-%d')" >> $GITHUB_OUTPUT
 
+      - name: Cache Claude Code
+        if: steps.pr.outputs.number
+        id: cache-claude
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/claude
+          key: claude-code-${{ env.CLAUDE_CODE_VERSION }}-linux-x64
+
+      - name: Install Claude Code
+        if: steps.pr.outputs.number && steps.cache-claude.outputs.cache-hit != 'true'
+        run: |
+          echo "Installing Claude Code v${{ env.CLAUDE_CODE_VERSION }}..."
+          mkdir -p ~/.local/bin
+          for attempt in 1 2 3 4 5; do
+            echo "Installation attempt $attempt..."
+            if curl -fsSL https://claude.ai/install.sh | bash -s -- "${{ env.CLAUDE_CODE_VERSION }}"; then
+              echo "Claude Code installed successfully"
+              break
+            fi
+            if [ $attempt -eq 5 ]; then
+              echo "::error::Failed to install Claude Code after 5 attempts"
+              exit 1
+            fi
+            # Exponential backoff with jitter
+            sleep_time=$((attempt * 5 + RANDOM % 5))
+            echo "Installation failed, retrying in ${sleep_time}s..."
+            sleep $sleep_time
+          done
+
+      - name: Verify Claude Code installation
+        if: steps.pr.outputs.number
+        run: |
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          ~/.local/bin/claude --version
+
       - name: Run Claude Code Review
         if: steps.pr.outputs.number
         id: claude-review
@@ -73,6 +117,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          path_to_claude_code_executable: ~/.local/bin/claude
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ steps.pr.outputs.number }}
@@ -100,9 +145,27 @@ jobs:
       - name: Report Final Status
         if: always() && steps.pr.outputs.number
         run: |
+          echo "## Claude Code Review Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **PR:** #${{ steps.pr.outputs.number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Cache hit:** ${{ steps.cache-claude.outputs.cache-hit == 'true' && 'Yes' || 'No' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Claude Code version:** ${{ env.CLAUDE_CODE_VERSION }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
           if [ "${{ steps.claude-review.outcome }}" == "success" ]; then
-            echo "✅ Claude Code review completed successfully for PR #${{ steps.pr.outputs.number }}"
-          elif [ "${{ steps.claude-review.outcome }}" == "failure" ] || [ "${{ steps.claude-review.outcome }}" == "cancelled" ]; then
-            echo "⚠️  Claude Code review failed or was cancelled - this is non-blocking"
+            echo "### Result: Success" >> $GITHUB_STEP_SUMMARY
+            echo "Claude Code review completed successfully." >> $GITHUB_STEP_SUMMARY
+            echo "::notice::Claude Code review completed successfully for PR #${{ steps.pr.outputs.number }}"
+          elif [ "${{ steps.claude-review.outcome }}" == "failure" ]; then
+            echo "### Result: Failed" >> $GITHUB_STEP_SUMMARY
+            echo "Claude Code review failed - this is non-blocking." >> $GITHUB_STEP_SUMMARY
+            echo "::warning::Claude Code review failed for PR #${{ steps.pr.outputs.number }} - this is non-blocking"
+          elif [ "${{ steps.claude-review.outcome }}" == "cancelled" ]; then
+            echo "### Result: Cancelled" >> $GITHUB_STEP_SUMMARY
+            echo "Claude Code review was cancelled." >> $GITHUB_STEP_SUMMARY
+            echo "::warning::Claude Code review was cancelled for PR #${{ steps.pr.outputs.number }}"
+          elif [ "${{ steps.claude-review.outcome }}" == "skipped" ]; then
+            echo "### Result: Skipped" >> $GITHUB_STEP_SUMMARY
+            echo "Claude Code review was skipped." >> $GITHUB_STEP_SUMMARY
           fi
           exit 0


### PR DESCRIPTION
## Summary

Fixes Claude Code Review workflow failures caused by installation lock conflicts when multiple workflow runs attempt to install Claude Code simultaneously.

## Changes Made

- **Concurrency group**: Prevents parallel Claude review runs using `concurrency` setting with `cancel-in-progress: false` (reviews queue instead of cancel)
- **Caching**: Cache Claude Code binary using `actions/cache@v4` to skip installation on subsequent runs
- **Pre-installation**: Install Claude Code before the action runs and pass path via `path_to_claude_code_executable`
- **Better retry logic**: 5 attempts with exponential backoff and jitter instead of 3 fixed attempts
- **Improved reporting**: GitHub Step Summary with cache hit status, version info, and workflow annotations

## Technical Details

The root cause was a race condition:
```
✘ Installation failed
Could not install - another process is currently installing Claude. Please try again in a moment.
```

This happened when multiple PRs triggered the workflow simultaneously, and they all tried to install Claude Code at the same time.

## Testing

- First run will install and cache Claude Code
- Subsequent runs will use cached binary (fast path)
- Concurrent workflow runs will queue instead of racing

## Risk Assessment

Low risk - changes only affect the Claude Code Review workflow which is already non-blocking.