### PR TITLE
fix(ci): remove pre-installation, let action handle Claude Code install

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,9 +11,6 @@ concurrency:
   group: claude-code-review-${{ github.repository }}
   cancel-in-progress: false
 
-env:
-  CLAUDE_CODE_VERSION: "2.0.74"
-
 jobs:
   claude-review:
     # Only run when ALL conditions are met:
@@ -75,74 +72,6 @@ jobs:
         id: date
         run: echo "current_date=$(date -u '+%Y-%m-%d')" >> $GITHUB_OUTPUT
 
-      - name: Cache Claude Code
-        if: steps.pr.outputs.number
-        id: cache-claude
-        uses: actions/cache@v4
-        with:
-          # Cache the entire directory - installer may create multiple files
-          path: ~/.local/bin
-          # v2: invalidate bad cache from previous version
-          key: claude-code-${{ env.CLAUDE_CODE_VERSION }}-linux-x64-v2
-
-      - name: Validate cached Claude Code
-        if: steps.pr.outputs.number && steps.cache-claude.outputs.cache-hit == 'true'
-        id: validate-cache
-        run: |
-          # Check if cached binary is valid (exists, executable, reasonable size)
-          if [ -f ~/.local/bin/claude ] && [ -x ~/.local/bin/claude ]; then
-            SIZE=$(stat -c%s ~/.local/bin/claude 2>/dev/null || stat -f%z ~/.local/bin/claude 2>/dev/null || echo "0")
-            # Claude Code binary should be at least 10MB
-            if [ "$SIZE" -gt 10000000 ]; then
-              echo "Cache valid: claude binary is ${SIZE} bytes"
-              echo "valid=true" >> $GITHUB_OUTPUT
-            else
-              echo "::warning::Cache invalid: claude binary too small (${SIZE} bytes), will reinstall"
-              rm -f ~/.local/bin/claude
-              echo "valid=false" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "::warning::Cache invalid: claude binary missing or not executable, will reinstall"
-            echo "valid=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Install Claude Code
-        if: steps.pr.outputs.number && (steps.cache-claude.outputs.cache-hit != 'true' || steps.validate-cache.outputs.valid != 'true')
-        run: |
-          echo "Installing Claude Code v${{ env.CLAUDE_CODE_VERSION }}..."
-          mkdir -p ~/.local/bin
-          for attempt in 1 2 3 4 5; do
-            echo "Installation attempt $attempt..."
-            if curl -fsSL https://claude.ai/install.sh | bash -s -- "${{ env.CLAUDE_CODE_VERSION }}"; then
-              # Verify installation succeeded
-              if [ -f ~/.local/bin/claude ] && [ -x ~/.local/bin/claude ]; then
-                SIZE=$(stat -c%s ~/.local/bin/claude 2>/dev/null || stat -f%z ~/.local/bin/claude 2>/dev/null || echo "0")
-                if [ "$SIZE" -gt 10000000 ]; then
-                  echo "Claude Code installed successfully (${SIZE} bytes)"
-                  break
-                else
-                  echo "::warning::Installation produced invalid binary (${SIZE} bytes)"
-                fi
-              fi
-            fi
-            if [ $attempt -eq 5 ]; then
-              echo "::error::Failed to install Claude Code after 5 attempts"
-              exit 1
-            fi
-            # Exponential backoff with jitter
-            sleep_time=$((attempt * 5 + RANDOM % 5))
-            echo "Installation failed, retrying in ${sleep_time}s..."
-            sleep $sleep_time
-          done
-
-      - name: Verify Claude Code installation
-        if: steps.pr.outputs.number
-        run: |
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          # Final verification - this will fail the job if claude isn't working
-          ~/.local/bin/claude --version
-          echo "Claude Code ready"
-
       - name: Run Claude Code Review
         if: steps.pr.outputs.number
         id: claude-review
@@ -150,7 +79,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          path_to_claude_code_executable: ~/.local/bin/claude
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ steps.pr.outputs.number }}
@@ -181,8 +109,6 @@ jobs:
           echo "## Claude Code Review Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **PR:** #${{ steps.pr.outputs.number }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Cache hit:** ${{ steps.cache-claude.outputs.cache-hit == 'true' && 'Yes' || 'No' }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Claude Code version:** ${{ env.CLAUDE_CODE_VERSION }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           if [ "${{ steps.claude-review.outcome }}" == "success" ]; then


### PR DESCRIPTION
## Summary

Fixes the broken Claude Code Review workflow by removing the pre-installation approach that doesn't work.

## Root Cause

The `install.sh` script creates a **48-byte wrapper script** at `~/.local/bin/claude`, not the actual binary. Pre-installing and caching this wrapper script breaks the action's internal installation mechanism.

From the failed run:
```
✔ Claude Code successfully installed!
##[warning]Installation produced invalid binary (48 bytes)
```

## Changes

**Removed:**
- Pre-installation steps
- Cache steps
- Validation steps
- `path_to_claude_code_executable` parameter

**Kept:**
- Concurrency group (prevents race conditions - this was the original fix we needed)
- Improved status reporting with GitHub Step Summary

## Why This Works

The original problem was race conditions during installation when multiple workflow runs started simultaneously. The **concurrency group alone** solves this by serializing runs. The action's internal installation mechanism works correctly when not interfered with.

## Testing

After merge, the next Claude Code Review should:
1. Queue if another review is running (concurrency group)
2. Install Claude Code via action's internal mechanism
3. Run review and post comment