### PR TITLE
feat(current-account): add GetActiveAmountBlocks endpoint for Position Keeping

### DIFF
--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -719,6 +719,67 @@ message RetrieveLienResponse {
   Lien lien = 1 [(buf.validate.field).required = true];
 }
 
+// AmountBlockType defines the type of fund reservation
+// Used by Position Keeping to understand the nature of the block
+enum AmountBlockType {
+  // AMOUNT_BLOCK_TYPE_UNSPECIFIED is the default value and should not be used
+  AMOUNT_BLOCK_TYPE_UNSPECIFIED = 0;
+  // AMOUNT_BLOCK_TYPE_PENDING indicates a temporary hold pending settlement
+  // Example: Payment Order lien awaiting external payment confirmation
+  AMOUNT_BLOCK_TYPE_PENDING = 1;
+  // AMOUNT_BLOCK_TYPE_FINAL indicates a permanent reservation
+  // Example: Regulatory hold, court order freeze
+  AMOUNT_BLOCK_TYPE_FINAL = 2;
+  // AMOUNT_BLOCK_TYPE_TEMPORARY indicates a short-term hold
+  // Example: Authorization hold for card transactions
+  AMOUNT_BLOCK_TYPE_TEMPORARY = 3;
+}
+
+// AmountBlock represents a fund reservation from the perspective of Position Keeping.
+// This abstraction allows Position Keeping to query blocked amounts without coupling
+// to the specific Current Account lien implementation.
+message AmountBlock {
+  // block_id is the unique identifier for this block (maps to lien_id)
+  string block_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // amount is the reserved amount
+  meridian.common.v1.MoneyAmount amount = 2 [(buf.validate.field).required = true];
+
+  // block_type indicates the nature of the reservation
+  AmountBlockType block_type = 3 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // purpose describes why the funds are blocked
+  // Example: "Payment Order: PO-12345", "Lien hold for settlement"
+  string purpose = 4 [(buf.validate.field).string = {max_len: 500}];
+
+  // expires_at is when the block expires (optional, null means no expiry)
+  google.protobuf.Timestamp expires_at = 5;
+}
+
+// Request to retrieve active amount blocks for an account
+// Used by Position Keeping to query blocked funds for balance calculations
+message GetActiveAmountBlocksRequest {
+  // account_id is the account to query blocks for
+  string account_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+}
+
+// Response containing active amount blocks for an account
+message GetActiveAmountBlocksResponse {
+  // blocks is the list of active amount blocks (ACTIVE status liens only)
+  repeated AmountBlock blocks = 1;
+}
+
 // Request to update a current account facility settings
 // BIAN: Update Control Record (UpCR) - Modify account configuration
 message UpdateCurrentAccountRequest {
@@ -925,6 +986,19 @@ service CurrentAccountService {
   rpc RetrieveLien(RetrieveLienRequest) returns (RetrieveLienResponse) {
     option (google.api.http) = {
       get: "/v1/liens/{lien_id}"
+    };
+  }
+
+  // GetActiveAmountBlocks retrieves active fund reservations for Position Keeping.
+  // Returns all ACTIVE (non-expired) liens mapped to AmountBlock representation.
+  // Used by Position Keeping service to query blocked amounts without coupling to lien details.
+  rpc GetActiveAmountBlocks(GetActiveAmountBlocksRequest) returns (GetActiveAmountBlocksResponse) {
+    option (google.api.http) = {
+      get: "/v1/current-accounts/{account_id}/amount-blocks"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get active amount blocks for an account"
+      description: "Retrieves all active fund reservations (liens) for Position Keeping balance calculations"
     };
   }
 

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -781,3 +781,74 @@ func (s *Service) calculateAvailableBalance(ctx context.Context, accountID uuid.
 	}
 	return availableMoney
 }
+
+// GetActiveAmountBlocks retrieves active fund reservations for Position Keeping.
+// Returns all ACTIVE (non-expired) liens mapped to AmountBlock representation.
+// Used by Position Keeping service to query blocked amounts without coupling to lien details.
+func (s *Service) GetActiveAmountBlocks(ctx context.Context, req *pb.GetActiveAmountBlocksRequest) (*pb.GetActiveAmountBlocksResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		caobservability.RecordOperationDuration("get_active_amount_blocks", operationStatus, time.Since(start))
+	}()
+
+	// Validate lien repository is configured
+	if s.lienRepo == nil {
+		operationStatus = opStatusLienRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
+	}
+
+	// Retrieve account to validate it exists and get the internal UUID
+	account, err := s.repo.FindByID(ctx, req.AccountId)
+	if err != nil {
+		if errors.Is(err, persistence.ErrAccountNotFound) {
+			operationStatus = opStatusAccountNotFound
+			return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
+		}
+		operationStatus = opStatusRetrieveFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+
+	// Retrieve active liens for the account
+	liens, err := s.lienRepo.FindActiveByAccountID(ctx, account.ID())
+	if err != nil {
+		operationStatus = opStatusRetrieveFailed
+		s.logger.Error("failed to retrieve active liens",
+			"account_id", req.AccountId,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to retrieve active liens: %v", err)
+	}
+
+	// Convert liens to AmountBlock representation
+	blocks := make([]*pb.AmountBlock, 0, len(liens))
+	for _, lien := range liens {
+		block := toAmountBlockProto(lien)
+		blocks = append(blocks, block)
+	}
+
+	s.logger.Debug("retrieved active amount blocks",
+		"account_id", req.AccountId,
+		"block_count", len(blocks))
+
+	return &pb.GetActiveAmountBlocksResponse{
+		Blocks: blocks,
+	}, nil
+}
+
+// toAmountBlockProto converts a domain Lien to proto AmountBlock.
+// Liens are mapped to PENDING block type since they represent holds awaiting settlement.
+func toAmountBlockProto(lien *domain.Lien) *pb.AmountBlock {
+	block := &pb.AmountBlock{
+		BlockId:   lien.ID.String(),
+		Amount:    toMoneyAmount(lien.Amount),
+		BlockType: pb.AmountBlockType_AMOUNT_BLOCK_TYPE_PENDING, // All liens are pending holds
+		Purpose:   fmt.Sprintf("Payment Order: %s", lien.PaymentOrderReference),
+	}
+
+	// Only set expires_at if the lien has an expiry time
+	if lien.ExpiresAt != nil {
+		block.ExpiresAt = timestamppb.New(*lien.ExpiresAt)
+	}
+
+	return block
+}

--- a/services/current-account/service/lien_service_test.go
+++ b/services/current-account/service/lien_service_test.go
@@ -965,3 +965,227 @@ func TestInitiateLien_MultipleBuckets_IndependentLiens(t *testing.T) {
 	require.Equal(t, "", resp3.Lien.BucketId)
 	require.Equal(t, int64(100), resp3.AvailableBalance.Amount.Units) // £200 - £100 = £100
 }
+
+// ============================================================================
+// GetActiveAmountBlocks Tests
+// ============================================================================
+
+func TestGetActiveAmountBlocks_ReturnsAllActiveLiens(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := mustNewService(t, repo, lienRepo)
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-BLOCKS-001", 100000)
+
+	// Create 3 active liens
+	for i := 1; i <= 3; i++ {
+		lienAmount, err := domain.NewMoney("GBP", int64(i*10000)) // £100, £200, £300
+		require.NoError(t, err)
+		lien, err := domain.NewLien(account.ID(), lienAmount, "", fmt.Sprintf("PO-BLOCKS-%d", i), nil)
+		require.NoError(t, err)
+		require.NoError(t, lienRepo.Create(ctx, lien))
+	}
+
+	// Query active amount blocks
+	req := &pb.GetActiveAmountBlocksRequest{
+		AccountId: "ACC-BLOCKS-001",
+	}
+
+	resp, err := svc.GetActiveAmountBlocks(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, resp.Blocks, 3)
+
+	// Verify all blocks have correct type and purpose
+	for _, block := range resp.Blocks {
+		require.NotEmpty(t, block.BlockId)
+		require.Equal(t, pb.AmountBlockType_AMOUNT_BLOCK_TYPE_PENDING, block.BlockType)
+		require.Contains(t, block.Purpose, "Payment Order:")
+	}
+}
+
+func TestGetActiveAmountBlocks_FiltersOutExecutedLiens(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := mustNewService(t, repo, lienRepo)
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-BLOCKS-002", 100000)
+
+	// Create 3 liens
+	var lienIDs []uuid.UUID
+	for i := 1; i <= 3; i++ {
+		lienAmount, err := domain.NewMoney("GBP", int64(i*10000))
+		require.NoError(t, err)
+		lien, err := domain.NewLien(account.ID(), lienAmount, "", fmt.Sprintf("PO-BLOCKS-EXEC-%d", i), nil)
+		require.NoError(t, err)
+		require.NoError(t, lienRepo.Create(ctx, lien))
+		lienIDs = append(lienIDs, lien.ID)
+	}
+
+	// Execute one of the liens
+	executeReq := &pb.ExecuteLienRequest{LienId: lienIDs[0].String()}
+	_, err := svc.ExecuteLien(ctx, executeReq)
+	require.NoError(t, err)
+
+	// Query active amount blocks - should only return 2
+	req := &pb.GetActiveAmountBlocksRequest{
+		AccountId: "ACC-BLOCKS-002",
+	}
+
+	resp, err := svc.GetActiveAmountBlocks(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, resp.Blocks, 2, "should only return active (non-executed) liens")
+
+	// Verify the executed lien is not in the response
+	executedLienID := lienIDs[0].String()
+	for _, block := range resp.Blocks {
+		require.NotEqual(t, executedLienID, block.BlockId, "executed lien should not be returned")
+	}
+}
+
+func TestGetActiveAmountBlocks_FiltersOutTerminatedLiens(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := mustNewService(t, repo, lienRepo)
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-BLOCKS-003", 100000)
+
+	// Create 3 liens
+	var lienIDs []uuid.UUID
+	for i := 1; i <= 3; i++ {
+		lienAmount, err := domain.NewMoney("GBP", int64(i*10000))
+		require.NoError(t, err)
+		lien, err := domain.NewLien(account.ID(), lienAmount, "", fmt.Sprintf("PO-BLOCKS-TERM-%d", i), nil)
+		require.NoError(t, err)
+		require.NoError(t, lienRepo.Create(ctx, lien))
+		lienIDs = append(lienIDs, lien.ID)
+	}
+
+	// Terminate one of the liens
+	terminateReq := &pb.TerminateLienRequest{LienId: lienIDs[1].String(), Reason: "Test cancellation"}
+	_, err := svc.TerminateLien(ctx, terminateReq)
+	require.NoError(t, err)
+
+	// Query active amount blocks - should only return 2
+	req := &pb.GetActiveAmountBlocksRequest{
+		AccountId: "ACC-BLOCKS-003",
+	}
+
+	resp, err := svc.GetActiveAmountBlocks(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, resp.Blocks, 2, "should only return active (non-terminated) liens")
+
+	// Verify the terminated lien is not in the response
+	terminatedLienID := lienIDs[1].String()
+	for _, block := range resp.Blocks {
+		require.NotEqual(t, terminatedLienID, block.BlockId, "terminated lien should not be returned")
+	}
+}
+
+func TestGetActiveAmountBlocks_ReturnsEmptyForAccountWithNoLiens(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := mustNewService(t, repo, lienRepo)
+
+	// Create account with no liens
+	createTestAccountWithBalance(t, ctx, repo, "ACC-BLOCKS-EMPTY", 100000)
+
+	// Query active amount blocks
+	req := &pb.GetActiveAmountBlocksRequest{
+		AccountId: "ACC-BLOCKS-EMPTY",
+	}
+
+	resp, err := svc.GetActiveAmountBlocks(ctx, req)
+	require.NoError(t, err)
+	require.Empty(t, resp.Blocks)
+}
+
+func TestGetActiveAmountBlocks_AccountNotFound(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := mustNewService(t, repo, lienRepo)
+
+	req := &pb.GetActiveAmountBlocksRequest{
+		AccountId: "NON-EXISTENT-ACCOUNT",
+	}
+
+	_, err := svc.GetActiveAmountBlocks(ctx, req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestGetActiveAmountBlocks_LienRepoNotConfigured(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	svc := mustNewService(t, repo, nil) // No lien repo
+
+	// Create account first
+	createTestAccountWithBalance(t, ctx, repo, "ACC-BLOCKS-NO-REPO", 100000)
+
+	req := &pb.GetActiveAmountBlocksRequest{
+		AccountId: "ACC-BLOCKS-NO-REPO",
+	}
+
+	_, err := svc.GetActiveAmountBlocks(ctx, req)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+	require.Contains(t, st.Message(), "lien operations not configured")
+}
+
+func TestGetActiveAmountBlocks_MapsAmountCorrectly(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := mustNewService(t, repo, lienRepo)
+
+	// Create account
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-BLOCKS-AMOUNT", 100000)
+
+	// Create lien for £123.45 (12345 cents)
+	lienAmount, err := domain.NewMoney("GBP", 12345)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "", "PO-AMOUNT-TEST", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(ctx, lien))
+
+	// Query active amount blocks
+	req := &pb.GetActiveAmountBlocksRequest{
+		AccountId: "ACC-BLOCKS-AMOUNT",
+	}
+
+	resp, err := svc.GetActiveAmountBlocks(ctx, req)
+	require.NoError(t, err)
+	require.Len(t, resp.Blocks, 1)
+
+	block := resp.Blocks[0]
+	require.Equal(t, lien.ID.String(), block.BlockId)
+	require.Equal(t, "GBP", block.Amount.Amount.CurrencyCode)
+	require.Equal(t, int64(123), block.Amount.Amount.Units, "should map to £123")
+	require.Equal(t, int32(450000000), block.Amount.Amount.Nanos, "should map to .45")
+	require.Equal(t, "Payment Order: PO-AMOUNT-TEST", block.Purpose)
+}


### PR DESCRIPTION
## Summary

- Add new `GetActiveAmountBlocks` gRPC endpoint to current-account service
- Creates `AmountBlock` proto message abstraction over internal `Lien` model
- Returns all ACTIVE liens for an account in a format suitable for Position Keeping balance calculations

## Task Master Reference

`position-keeping-balance.6` - Add Current Account Lien Query Endpoint

## Changes Made

### Proto Definition (`api/proto/meridian/current_account/v1/current_account.proto`)
- Added `AmountBlockType` enum (PENDING, FINAL, TEMPORARY)
- Added `AmountBlock` message with block_id, amount, block_type, purpose, expires_at
- Added `GetActiveAmountBlocksRequest/Response` messages
- Added `GetActiveAmountBlocks` RPC to `CurrentAccountService`

### Service Implementation (`services/current-account/service/lien_service.go`)
- Implemented `GetActiveAmountBlocks` handler
- Validates lien repo is configured
- Uses existing `FindActiveByAccountID` repository method
- Maps domain `Lien` to proto `AmountBlock` with appropriate block type (PENDING)

### Unit Tests (`services/current-account/service/lien_service_test.go`)
- `TestGetActiveAmountBlocks_ReturnsAllActiveLiens` - Verifies all active liens returned
- `TestGetActiveAmountBlocks_FiltersOutExecutedLiens` - Executed liens excluded
- `TestGetActiveAmountBlocks_FiltersOutTerminatedLiens` - Terminated liens excluded
- `TestGetActiveAmountBlocks_ReturnsEmptyForAccountWithNoLiens` - Empty list when no liens
- `TestGetActiveAmountBlocks_AccountNotFound` - NotFound error for invalid account
- `TestGetActiveAmountBlocks_LienRepoNotConfigured` - FailedPrecondition when repo missing
- `TestGetActiveAmountBlocks_MapsAmountCorrectly` - Amount conversion verified

## Technical Details

The `AmountBlock` abstraction allows Position Keeping to query blocked funds without coupling to the specific `Lien` implementation:

```protobuf
message AmountBlock {
  string block_id = 1;                     // Lien ID
  MoneyAmount amount = 2;                  // Reserved amount
  AmountBlockType block_type = 3;          // PENDING for liens
  string purpose = 4;                      // "Payment Order: {reference}"
  google.protobuf.Timestamp expires_at = 5; // Optional expiry
}
```

## Test Plan

- [x] Unit tests for all happy and error paths
- [x] Tests use testcontainers with real Postgres DB
- [x] All existing tests pass (429s for service package)
- [ ] CI verification

## Risk Assessment

Low risk:
- Read-only endpoint, no state mutations
- Uses existing repository method (`FindActiveByAccountID`)
- Follows established patterns from other lien endpoints