### PR TITLE
feat(position-keeping): add opening balance support

### DIFF
--- a/services/position-keeping/domain/financial_position_log.go
+++ b/services/position-keeping/domain/financial_position_log.go
@@ -127,12 +127,12 @@ func NewFinancialPositionLogWithOpeningBalance(
 		return nil, ErrEmptyAccountID
 	}
 
+	now := time.Now().UTC()
+
 	// Validate effective date is not in the future (allow 1 minute tolerance for clock skew)
-	if effectiveDate.After(time.Now().UTC().Add(time.Minute)) {
+	if effectiveDate.After(now.Add(time.Minute)) {
 		return nil, ErrInvalidEffectiveDate
 	}
-
-	now := time.Now().UTC()
 
 	// Determine posting direction based on balance sign
 	var direction PostingDirection

--- a/services/position-keeping/domain/financial_position_log.go
+++ b/services/position-keeping/domain/financial_position_log.go
@@ -24,6 +24,8 @@ var (
 	ErrTooManyAuditEntries = errors.New("maximum number of audit entries exceeded")
 	// ErrInvalidReconciliationStatus is returned when trying to mark as reconciled with unreconciled status
 	ErrInvalidReconciliationStatus = errors.New("reconciliation status must not be unreconciled when marking as reconciled")
+	// ErrInvalidEffectiveDate is returned when the effective date is invalid (e.g., in the future)
+	ErrInvalidEffectiveDate = errors.New("effective date cannot be in the future")
 )
 
 const (
@@ -43,16 +45,24 @@ const (
 // StatusTracking (MarkReconciled, MarkPosted, Reject, Amend, Fail, Cancel).
 // AddEntry does NOT increment Version as it represents accumulation within a draft
 // state rather than a lifecycle state transition.
+//
+// Opening Balance Support:
+// The OpeningBalance field stores the initial balance when the position log is created
+// during a migration scenario. This allows capturing existing balances from legacy systems
+// without requiring the full transaction history. The OpeningBalanceRecordedAt field tracks
+// when the opening balance was recorded. Both fields are immutable after initialization.
 type FinancialPositionLog struct {
-	LogID                 uuid.UUID
-	AccountID             string
-	TransactionLogEntries []*TransactionLogEntry
-	TransactionLineage    *TransactionLineage
-	AuditTrail            []*AuditTrailEntry
-	StatusTracking        *StatusTracking
-	CreatedAt             time.Time
-	UpdatedAt             time.Time
-	Version               int64 // Optimistic lock version, incremented on status transitions
+	LogID                    uuid.UUID
+	AccountID                string
+	TransactionLogEntries    []*TransactionLogEntry
+	TransactionLineage       *TransactionLineage
+	AuditTrail               []*AuditTrailEntry
+	StatusTracking           *StatusTracking
+	CreatedAt                time.Time
+	UpdatedAt                time.Time
+	Version                  int64 // Optimistic lock version, incremented on status transitions
+	OpeningBalance           Money // Initial balance for migration scenarios (immutable after init)
+	OpeningBalanceRecordedAt time.Time
 }
 
 // NewFinancialPositionLog creates a FinancialPositionLog for the given account, initializing identifiers, timestamps, version, empty entry and audit collections, and status tracking.
@@ -88,6 +98,101 @@ func NewFinancialPositionLog(
 	}
 
 	return log, nil
+}
+
+// NewFinancialPositionLogWithOpeningBalance creates a FinancialPositionLog with an opening balance
+// for migration scenarios. This constructor is used when bringing in existing account balances
+// from legacy systems where the full transaction history is not available.
+//
+// The opening balance is represented as a Money value which may be positive (CREDIT direction)
+// or negative (DEBIT direction). An opening balance transaction entry is automatically created
+// with TransactionSourceOpeningBalance source and TransactionStatusPosted status.
+//
+// Parameters:
+//   - accountID: The unique identifier for the account
+//   - openingBalance: The initial balance (positive for credit, negative for debit)
+//   - effectiveDate: The date when the opening balance becomes effective (cannot be in future)
+//   - migrationReference: A reference string identifying the migration source/batch
+//
+// Returns:
+//   - ErrEmptyAccountID when accountID is empty
+//   - ErrInvalidEffectiveDate when effectiveDate is in the future
+func NewFinancialPositionLogWithOpeningBalance(
+	accountID string,
+	openingBalance Money,
+	effectiveDate time.Time,
+	migrationReference string,
+) (*FinancialPositionLog, error) {
+	if accountID == "" {
+		return nil, ErrEmptyAccountID
+	}
+
+	// Validate effective date is not in the future (allow 1 minute tolerance for clock skew)
+	if effectiveDate.After(time.Now().UTC().Add(time.Minute)) {
+		return nil, ErrInvalidEffectiveDate
+	}
+
+	now := time.Now().UTC()
+
+	// Determine posting direction based on balance sign
+	var direction PostingDirection
+	var entryAmount Money
+	if openingBalance.IsNegative() {
+		direction = PostingDirectionDebit
+		entryAmount = openingBalance.Negate()
+	} else {
+		direction = PostingDirectionCredit
+		entryAmount = openingBalance
+	}
+
+	// Create the log with opening balance
+	log := &FinancialPositionLog{
+		LogID:                    uuid.New(),
+		AccountID:                accountID,
+		TransactionLogEntries:    make([]*TransactionLogEntry, 0),
+		TransactionLineage:       nil, // No lineage for opening balance
+		AuditTrail:               make([]*AuditTrailEntry, 0),
+		StatusTracking:           NewStatusTracking(),
+		CreatedAt:                now,
+		UpdatedAt:                now,
+		Version:                  1,
+		OpeningBalance:           openingBalance,
+		OpeningBalanceRecordedAt: now,
+	}
+
+	// Create opening balance transaction entry only if amount is non-zero
+	if !openingBalance.IsZero() {
+		entry, err := NewTransactionLogEntry(
+			uuid.New(), // New transaction ID for the opening balance
+			accountID,
+			entryAmount,
+			direction,
+			effectiveDate,
+			"Opening balance",
+			migrationReference,
+			TransactionSourceOpeningBalance,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := log.AddEntry(entry); err != nil {
+			return nil, err
+		}
+	}
+
+	// Mark the opening balance transaction as posted (it's already finalized)
+	if err := log.StatusTracking.UpdateStatus(TransactionStatusPosted, "Opening balance established"); err != nil {
+		return nil, err
+	}
+	log.Version++
+
+	return log, nil
+}
+
+// HasOpeningBalance returns true if the log was created with an opening balance.
+func (l *FinancialPositionLog) HasOpeningBalance() bool {
+	return !l.OpeningBalanceRecordedAt.IsZero()
 }
 
 // AddEntry adds a new transaction entry to the log.

--- a/services/position-keeping/domain/financial_position_log_test.go
+++ b/services/position-keeping/domain/financial_position_log_test.go
@@ -1556,3 +1556,485 @@ func TestFinancialPositionLog_ReconciliationStatus_MultipleMarkReconciled(t *tes
 		t.Errorf("Version should remain %d, got %d", initialVersion, log.Version)
 	}
 }
+
+// ==========================================
+// Opening Balance Tests
+// ==========================================
+
+func TestNewFinancialPositionLogWithOpeningBalance_PositiveBalance(t *testing.T) {
+	positiveBalance := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+	effectiveDate := time.Now().UTC().Add(-24 * time.Hour) // Yesterday
+
+	log, err := NewFinancialPositionLogWithOpeningBalance(
+		"ACC-001",
+		positiveBalance,
+		effectiveDate,
+		"MIGRATION-BATCH-001",
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify log is created
+	if log.LogID == uuid.Nil {
+		t.Error("Expected non-nil log ID")
+	}
+
+	if log.AccountID != "ACC-001" {
+		t.Errorf("Expected account ID ACC-001, got %v", log.AccountID)
+	}
+
+	// Verify opening balance is set
+	if !log.HasOpeningBalance() {
+		t.Error("Expected HasOpeningBalance to be true")
+	}
+
+	if !log.OpeningBalance.Equal(positiveBalance) {
+		t.Errorf("Expected opening balance %v, got %v", positiveBalance, log.OpeningBalance)
+	}
+
+	if log.OpeningBalanceRecordedAt.IsZero() {
+		t.Error("Expected OpeningBalanceRecordedAt to be set")
+	}
+
+	// Verify transaction entry was created
+	if log.EntryCount() != 1 {
+		t.Errorf("Expected 1 entry, got %d", log.EntryCount())
+	}
+
+	entry := log.TransactionLogEntries[0]
+
+	// Positive balance should create CREDIT direction
+	if entry.Direction != PostingDirectionCredit {
+		t.Errorf("Expected CREDIT direction for positive balance, got %v", entry.Direction)
+	}
+
+	// Entry amount should be the absolute value
+	if !entry.Amount.Equal(positiveBalance) {
+		t.Errorf("Expected entry amount %v, got %v", positiveBalance, entry.Amount)
+	}
+
+	// Verify source is OPENING_BALANCE
+	if entry.Source != TransactionSourceOpeningBalance {
+		t.Errorf("Expected source OPENING_BALANCE, got %v", entry.Source)
+	}
+
+	// Verify reference is migration reference
+	if entry.Reference != "MIGRATION-BATCH-001" {
+		t.Errorf("Expected reference MIGRATION-BATCH-001, got %v", entry.Reference)
+	}
+
+	// Verify timestamp is effective date
+	if !entry.Timestamp.Equal(effectiveDate) {
+		t.Errorf("Expected timestamp %v, got %v", effectiveDate, entry.Timestamp)
+	}
+
+	// Verify log is marked as POSTED
+	if log.StatusTracking.CurrentStatus != TransactionStatusPosted {
+		t.Errorf("Expected status POSTED, got %v", log.StatusTracking.CurrentStatus)
+	}
+
+	if !log.IsPosted() {
+		t.Error("Expected IsPosted to be true")
+	}
+
+	// Verify version incremented for posted status
+	if log.Version != 2 {
+		t.Errorf("Expected version 2, got %d", log.Version)
+	}
+}
+
+func TestNewFinancialPositionLogWithOpeningBalance_NegativeBalance(t *testing.T) {
+	negativeBalance := MustNewMoney(decimal.NewFromInt(-500), CurrencyGBP)
+	effectiveDate := time.Now().UTC().Add(-24 * time.Hour)
+
+	log, err := NewFinancialPositionLogWithOpeningBalance(
+		"ACC-001",
+		negativeBalance,
+		effectiveDate,
+		"MIGRATION-BATCH-001",
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify opening balance stores the original negative value
+	if !log.OpeningBalance.Equal(negativeBalance) {
+		t.Errorf("Expected opening balance %v, got %v", negativeBalance, log.OpeningBalance)
+	}
+
+	// Verify transaction entry was created
+	if log.EntryCount() != 1 {
+		t.Errorf("Expected 1 entry, got %d", log.EntryCount())
+	}
+
+	entry := log.TransactionLogEntries[0]
+
+	// Negative balance should create DEBIT direction
+	if entry.Direction != PostingDirectionDebit {
+		t.Errorf("Expected DEBIT direction for negative balance, got %v", entry.Direction)
+	}
+
+	// Entry amount should be the absolute value (positive)
+	expectedAmount := MustNewMoney(decimal.NewFromInt(500), CurrencyGBP)
+	if !entry.Amount.Equal(expectedAmount) {
+		t.Errorf("Expected entry amount %v, got %v", expectedAmount, entry.Amount)
+	}
+}
+
+func TestNewFinancialPositionLogWithOpeningBalance_ZeroBalance(t *testing.T) {
+	zeroBalance, _ := Zero(CurrencyGBP)
+	effectiveDate := time.Now().UTC().Add(-24 * time.Hour)
+
+	log, err := NewFinancialPositionLogWithOpeningBalance(
+		"ACC-001",
+		zeroBalance,
+		effectiveDate,
+		"MIGRATION-BATCH-001",
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify opening balance is set
+	if !log.HasOpeningBalance() {
+		t.Error("Expected HasOpeningBalance to be true for zero balance")
+	}
+
+	if !log.OpeningBalance.IsZero() {
+		t.Errorf("Expected zero opening balance, got %v", log.OpeningBalance)
+	}
+
+	// Zero balance should NOT create a transaction entry
+	if log.EntryCount() != 0 {
+		t.Errorf("Expected 0 entries for zero balance, got %d", log.EntryCount())
+	}
+
+	// Log should still be marked as POSTED
+	if log.StatusTracking.CurrentStatus != TransactionStatusPosted {
+		t.Errorf("Expected status POSTED, got %v", log.StatusTracking.CurrentStatus)
+	}
+}
+
+func TestNewFinancialPositionLogWithOpeningBalance_EmptyAccountID(t *testing.T) {
+	balance := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+	effectiveDate := time.Now().UTC().Add(-24 * time.Hour)
+
+	_, err := NewFinancialPositionLogWithOpeningBalance(
+		"", // Empty account ID
+		balance,
+		effectiveDate,
+		"MIGRATION-BATCH-001",
+	)
+
+	if err == nil {
+		t.Error("Expected error for empty account ID")
+	}
+
+	if !errors.Is(err, ErrEmptyAccountID) {
+		t.Errorf("Expected ErrEmptyAccountID, got %v", err)
+	}
+}
+
+func TestNewFinancialPositionLogWithOpeningBalance_FutureEffectiveDate(t *testing.T) {
+	balance := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+	futureDate := time.Now().UTC().Add(24 * time.Hour) // Tomorrow
+
+	_, err := NewFinancialPositionLogWithOpeningBalance(
+		"ACC-001",
+		balance,
+		futureDate,
+		"MIGRATION-BATCH-001",
+	)
+
+	if err == nil {
+		t.Error("Expected error for future effective date")
+	}
+
+	if !errors.Is(err, ErrInvalidEffectiveDate) {
+		t.Errorf("Expected ErrInvalidEffectiveDate, got %v", err)
+	}
+}
+
+func TestNewFinancialPositionLogWithOpeningBalance_EdgeDateWithinTolerance(t *testing.T) {
+	balance := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+	// Effective date within 1 minute tolerance should succeed
+	edgeDate := time.Now().UTC().Add(30 * time.Second)
+
+	log, err := NewFinancialPositionLogWithOpeningBalance(
+		"ACC-001",
+		balance,
+		edgeDate,
+		"MIGRATION-BATCH-001",
+	)
+	if err != nil {
+		t.Errorf("Expected success for date within tolerance, got error: %v", err)
+	}
+
+	if log == nil {
+		t.Error("Expected log to be created")
+	}
+}
+
+func TestNewFinancialPositionLogWithOpeningBalance_MigrationReferenceStored(t *testing.T) {
+	balance := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+	effectiveDate := time.Now().UTC().Add(-24 * time.Hour)
+	migrationRef := "LEGACY-SYSTEM-2024-Q4-BATCH-123"
+
+	log, err := NewFinancialPositionLogWithOpeningBalance(
+		"ACC-001",
+		balance,
+		effectiveDate,
+		migrationRef,
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if log.EntryCount() != 1 {
+		t.Fatalf("Expected 1 entry, got %d", log.EntryCount())
+	}
+
+	entry := log.TransactionLogEntries[0]
+	if entry.Reference != migrationRef {
+		t.Errorf("Expected reference %v, got %v", migrationRef, entry.Reference)
+	}
+}
+
+func TestNewFinancialPositionLogWithOpeningBalance_ImmutabilityAfterCreation(t *testing.T) {
+	balance := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+	effectiveDate := time.Now().UTC().Add(-24 * time.Hour)
+
+	log, err := NewFinancialPositionLogWithOpeningBalance(
+		"ACC-001",
+		balance,
+		effectiveDate,
+		"MIGRATION-BATCH-001",
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify the log is posted and entries cannot be added
+	newEntry, _ := NewTransactionLogEntry(
+		uuid.New(),
+		"ACC-001",
+		MustNewMoney(decimal.NewFromInt(100), CurrencyGBP),
+		PostingDirectionDebit,
+		time.Now(),
+		"New transaction",
+		"REF-002",
+		TransactionSourceManual,
+	)
+
+	err = log.AddEntry(newEntry)
+	if err == nil {
+		t.Error("Expected error when adding entry to posted log")
+	}
+
+	if !errors.Is(err, ErrAlreadyPosted) {
+		t.Errorf("Expected ErrAlreadyPosted, got %v", err)
+	}
+
+	// Entry count should remain at 1
+	if log.EntryCount() != 1 {
+		t.Errorf("Expected 1 entry, got %d", log.EntryCount())
+	}
+}
+
+func TestNewFinancialPositionLog_DefaultZeroOpeningBalance(t *testing.T) {
+	log, err := NewFinancialPositionLog("ACC-001", nil, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Default log should NOT have opening balance set
+	if log.HasOpeningBalance() {
+		t.Error("Expected HasOpeningBalance to be false for default constructor")
+	}
+
+	// OpeningBalanceRecordedAt should be zero time
+	if !log.OpeningBalanceRecordedAt.IsZero() {
+		t.Errorf("Expected zero OpeningBalanceRecordedAt, got %v", log.OpeningBalanceRecordedAt)
+	}
+
+	// OpeningBalance should be zero-valued Money
+	if !log.OpeningBalance.IsZero() {
+		t.Errorf("Expected zero OpeningBalance, got %v", log.OpeningBalance)
+	}
+}
+
+func TestHasOpeningBalance_DistinguishesBetweenConstructors(t *testing.T) {
+	// Log created with NewFinancialPositionLog
+	defaultLog, _ := NewFinancialPositionLog("ACC-001", nil, nil)
+
+	// Log created with NewFinancialPositionLogWithOpeningBalance
+	zeroBalance, _ := Zero(CurrencyGBP)
+	openingLog, _ := NewFinancialPositionLogWithOpeningBalance(
+		"ACC-002",
+		zeroBalance,
+		time.Now().UTC().Add(-time.Hour),
+		"MIGRATION",
+	)
+
+	if defaultLog.HasOpeningBalance() {
+		t.Error("Default log should NOT have opening balance")
+	}
+
+	if !openingLog.HasOpeningBalance() {
+		t.Error("Opening balance log SHOULD have opening balance (even if zero amount)")
+	}
+}
+
+func TestNewFinancialPositionLogWithOpeningBalance_DecimalPrecision(t *testing.T) {
+	// Test with high precision decimal
+	preciseAmount := decimal.RequireFromString("1234.56789")
+	balance := MustNewMoney(preciseAmount, CurrencyGBP)
+	effectiveDate := time.Now().UTC().Add(-24 * time.Hour)
+
+	log, err := NewFinancialPositionLogWithOpeningBalance(
+		"ACC-001",
+		balance,
+		effectiveDate,
+		"MIGRATION-BATCH-001",
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Verify the precision is preserved
+	if !log.OpeningBalance.Amount.Equal(preciseAmount) {
+		t.Errorf("Expected opening balance amount %v, got %v", preciseAmount, log.OpeningBalance.Amount)
+	}
+
+	entry := log.TransactionLogEntries[0]
+	if !entry.Amount.Amount.Equal(preciseAmount) {
+		t.Errorf("Expected entry amount %v, got %v", preciseAmount, entry.Amount.Amount)
+	}
+}
+
+func TestNewFinancialPositionLogWithOpeningBalance_DifferentCurrencies(t *testing.T) {
+	currencies := []Currency{CurrencyGBP, CurrencyUSD, CurrencyEUR, CurrencyJPY}
+
+	for _, currency := range currencies {
+		t.Run(string(currency), func(t *testing.T) {
+			amount := decimal.NewFromInt(1000)
+			if currency == CurrencyJPY {
+				// JPY has 0 decimal places
+				amount = decimal.NewFromInt(100000)
+			}
+
+			balance := MustNewMoney(amount, currency)
+			effectiveDate := time.Now().UTC().Add(-24 * time.Hour)
+
+			log, err := NewFinancialPositionLogWithOpeningBalance(
+				"ACC-001",
+				balance,
+				effectiveDate,
+				"MIGRATION-BATCH-001",
+			)
+			if err != nil {
+				t.Fatalf("Unexpected error for %v: %v", currency, err)
+			}
+
+			// Verify currency is preserved
+			if MoneyCurrency(log.OpeningBalance) != currency {
+				t.Errorf("Expected currency %v, got %v", currency, MoneyCurrency(log.OpeningBalance))
+			}
+
+			if log.EntryCount() > 0 {
+				entry := log.TransactionLogEntries[0]
+				if MoneyCurrency(entry.Amount) != currency {
+					t.Errorf("Expected entry currency %v, got %v", currency, MoneyCurrency(entry.Amount))
+				}
+			}
+		})
+	}
+}
+
+// ==========================================
+// Transaction Source Tests for New Sources
+// ==========================================
+
+func TestTransactionSource_OpeningBalance_IsValid(t *testing.T) {
+	if !TransactionSourceOpeningBalance.IsValid() {
+		t.Error("Expected OPENING_BALANCE to be valid")
+	}
+
+	if TransactionSourceOpeningBalance.String() != "OPENING_BALANCE" {
+		t.Errorf("Expected string OPENING_BALANCE, got %v", TransactionSourceOpeningBalance.String())
+	}
+}
+
+func TestTransactionSource_Migration_IsValid(t *testing.T) {
+	if !TransactionSourceMigration.IsValid() {
+		t.Error("Expected MIGRATION to be valid")
+	}
+
+	if TransactionSourceMigration.String() != "MIGRATION" {
+		t.Errorf("Expected string MIGRATION, got %v", TransactionSourceMigration.String())
+	}
+}
+
+func TestParseTransactionSource_NewSources(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected TransactionSource
+	}{
+		{"OPENING_BALANCE", TransactionSourceOpeningBalance},
+		{"MIGRATION", TransactionSourceMigration},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := ParseTransactionSource(tt.input)
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestNewTransactionLogEntry_WithOpeningBalanceSource(t *testing.T) {
+	amount := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+
+	entry, err := NewTransactionLogEntry(
+		uuid.New(),
+		"ACC-001",
+		amount,
+		PostingDirectionCredit,
+		time.Now(),
+		"Opening balance",
+		"MIGRATION-REF",
+		TransactionSourceOpeningBalance,
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if entry.Source != TransactionSourceOpeningBalance {
+		t.Errorf("Expected source OPENING_BALANCE, got %v", entry.Source)
+	}
+}
+
+func TestNewTransactionLogEntry_WithMigrationSource(t *testing.T) {
+	amount := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+
+	entry, err := NewTransactionLogEntry(
+		uuid.New(),
+		"ACC-001",
+		amount,
+		PostingDirectionDebit,
+		time.Now(),
+		"Migrated transaction",
+		"LEGACY-REF",
+		TransactionSourceMigration,
+	)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if entry.Source != TransactionSourceMigration {
+		t.Errorf("Expected source MIGRATION, got %v", entry.Source)
+	}
+}

--- a/services/position-keeping/domain/transaction_source.go
+++ b/services/position-keeping/domain/transaction_source.go
@@ -12,6 +12,8 @@ const (
 	TransactionSourceAdjustment          TransactionSource = "ADJUSTMENT"           // Adjustment or correction entry
 	TransactionSourceCurrentAccount      TransactionSource = "CURRENT_ACCOUNT"      // From Current Account service
 	TransactionSourceFinancialAccounting TransactionSource = "FINANCIAL_ACCOUNTING" // From Financial Accounting service
+	TransactionSourceOpeningBalance      TransactionSource = "OPENING_BALANCE"      // Opening balance entry for migration
+	TransactionSourceMigration           TransactionSource = "MIGRATION"            // General migration entry from legacy systems
 )
 
 // IsValid checks if the transaction source is valid.
@@ -19,7 +21,8 @@ func (t TransactionSource) IsValid() bool {
 	switch t {
 	case TransactionSourceManual, TransactionSourceAutomated, TransactionSourceImported,
 		TransactionSourceReconciliation, TransactionSourceAdjustment,
-		TransactionSourceCurrentAccount, TransactionSourceFinancialAccounting:
+		TransactionSourceCurrentAccount, TransactionSourceFinancialAccounting,
+		TransactionSourceOpeningBalance, TransactionSourceMigration:
 		return true
 	}
 	return false


### PR DESCRIPTION
## Summary

- Add opening balance support to `FinancialPositionLog` for migration scenarios where existing account balances need to be captured from legacy systems without full transaction history

## Changes Made

- Add `OpeningBalance` (Money) and `OpeningBalanceRecordedAt` (time.Time) fields to `FinancialPositionLog` struct
- Add `OPENING_BALANCE` and `MIGRATION` transaction source types
- Create `NewFinancialPositionLogWithOpeningBalance` constructor that:
  - Validates effective date is not in the future (with 1-minute tolerance)
  - Creates opening balance transaction entry with appropriate posting direction (CREDIT for positive, DEBIT for negative)
  - Marks the log as POSTED immediately
  - Handles zero balance correctly (no transaction entry created)
- Add `HasOpeningBalance()` helper method to distinguish between logs created with and without opening balance

## Test plan

- [x] Test positive opening balance creates CREDIT transaction
- [x] Test negative opening balance creates DEBIT transaction
- [x] Test zero opening balance (no transaction entry)
- [x] Test validation errors (empty account ID, future date)
- [x] Test edge date within tolerance
- [x] Test migration reference storage
- [x] Test immutability (cannot add entries after posted)
- [x] Test backward compatibility (default constructor still works)
- [x] Test `HasOpeningBalance()` distinguishes between constructors
- [x] Test decimal precision preservation
- [x] Test different currencies (GBP, USD, EUR, JPY)
- [x] Test new transaction sources are valid and parseable

## Task Master

Task: position-keeping-balance.3