### PR TITLE
feat(position-keeping): add balance computation with lien integration

### DIFF
--- a/services/current-account/client/client.go
+++ b/services/current-account/client/client.go
@@ -378,6 +378,31 @@ func (c *Client) RetrieveLien(ctx context.Context, req *currentaccountv1.Retriev
 	return resp, nil
 }
 
+// GetActiveAmountBlocks retrieves active fund reservations for balance calculations.
+// Used by Position Keeping to query blocked amounts without coupling to lien details.
+// This is an idempotent read operation, so it uses circuit breaker with retry.
+func (c *Client) GetActiveAmountBlocks(ctx context.Context, req *currentaccountv1.GetActiveAmountBlocksRequest) (*currentaccountv1.GetActiveAmountBlocksResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	// Use resilience patterns if configured (with retry for idempotent read)
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "GetActiveAmountBlocks", func() (*currentaccountv1.GetActiveAmountBlocksResponse, error) {
+			return c.currentAccount.GetActiveAmountBlocks(ctx, req)
+		})
+	}
+
+	resp, err := c.currentAccount.GetActiveAmountBlocks(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get active amount blocks: %w", err)
+	}
+
+	return resp, nil
+}
+
 // Close terminates the gRPC connection gracefully.
 func (c *Client) Close() error {
 	if c.conn != nil {

--- a/services/position-keeping/domain/balance_computer.go
+++ b/services/position-keeping/domain/balance_computer.go
@@ -21,9 +21,6 @@ var (
 
 	// ErrNilCurrentAccountClient is returned when the current account client is nil.
 	ErrNilCurrentAccountClient = errors.New("current account client cannot be nil")
-
-	// ErrNoOpeningBalance is returned when opening balance is required but not available.
-	ErrNoOpeningBalance = errors.New("opening balance is required for balance computation")
 )
 
 // BalanceComputer computes different balance types from transaction log entries.

--- a/services/position-keeping/domain/balance_computer.go
+++ b/services/position-keeping/domain/balance_computer.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -14,6 +15,15 @@ var (
 
 	// ErrNoInstrument is returned when unable to determine the instrument for a zero balance.
 	ErrNoInstrument = errors.New("unable to determine instrument for zero balance")
+
+	// ErrNilLog is returned when the financial position log is nil.
+	ErrNilLog = errors.New("financial position log cannot be nil")
+
+	// ErrNilCurrentAccountClient is returned when the current account client is nil.
+	ErrNilCurrentAccountClient = errors.New("current account client cannot be nil")
+
+	// ErrNoOpeningBalance is returned when opening balance is required but not available.
+	ErrNoOpeningBalance = errors.New("opening balance is required for balance computation")
 )
 
 // BalanceComputer computes different balance types from transaction log entries.
@@ -260,4 +270,203 @@ func (bc *BalanceComputer) sumEntries(entries []*TransactionLogEntry, expectedIn
 	}
 
 	return sum, nil
+}
+
+// =============================================================================
+// LogBalanceComputer - Stateful Balance Computer with Lien Integration
+// =============================================================================
+
+// LogBalanceComputer computes balances for a specific FinancialPositionLog with
+// integrated lien (reserve) query capability via CurrentAccountClient.
+//
+// Unlike the stateless BalanceComputer, this type holds references to the log
+// and client, providing a more convenient API for computing all balance types
+// for a specific position log.
+//
+// Example usage:
+//
+//	lbc, err := NewLogBalanceComputer(log, openingBalance, currentAccountClient)
+//	if err != nil {
+//	    return err
+//	}
+//	currentBal, err := lbc.CurrentBalance()
+//	reserveBal, err := lbc.ReserveBalance(ctx)
+//	availableBal, err := lbc.AvailableBalance(ctx, overdraftLimit, true)
+type LogBalanceComputer struct {
+	log                  *FinancialPositionLog
+	openingBalance       Money
+	currentAccountClient CurrentAccountClient
+	computer             *BalanceComputer
+}
+
+// NewLogBalanceComputer creates a new LogBalanceComputer for the given position log.
+//
+// Parameters:
+//   - log: The financial position log to compute balances for (required)
+//   - openingBalance: The opening balance for this position (required)
+//   - client: Client for querying liens/amount blocks from Current Account (optional,
+//     nil if reserve balance computation via client is not needed)
+//
+// Returns ErrNilLog if log is nil.
+func NewLogBalanceComputer(log *FinancialPositionLog, openingBalance Money, client CurrentAccountClient) (*LogBalanceComputer, error) {
+	if log == nil {
+		return nil, ErrNilLog
+	}
+
+	return &LogBalanceComputer{
+		log:                  log,
+		openingBalance:       openingBalance,
+		currentAccountClient: client,
+		computer:             NewBalanceComputer(),
+	}, nil
+}
+
+// CurrentBalance calculates the current balance from opening balance plus all transactions.
+// Includes ALL transactions in the log regardless of status.
+//
+// For DEBIT entries: amount is added (increases the balance)
+// For CREDIT entries: amount is subtracted (decreases the balance)
+func (lbc *LogBalanceComputer) CurrentBalance() (Balance, error) {
+	return lbc.computer.ComputeCurrent(
+		lbc.openingBalance,
+		lbc.log.TransactionLogEntries,
+		time.Now().UTC(),
+	)
+}
+
+// ReserveBalance queries and sums all active liens (amount blocks) from Current Account.
+// Returns the total amount of funds reserved/blocked for this account.
+//
+// Requires the CurrentAccountClient to be configured. Returns ErrNilCurrentAccountClient
+// if the client was not provided during construction.
+//
+// The reserve balance represents funds that are held but not yet debited:
+// - Payment Order liens awaiting settlement
+// - Authorization holds
+// - Regulatory reservations
+func (lbc *LogBalanceComputer) ReserveBalance(ctx context.Context) (Balance, error) {
+	if lbc.currentAccountClient == nil {
+		return Balance{}, ErrNilCurrentAccountClient
+	}
+
+	// Query active amount blocks from Current Account
+	blocks, err := lbc.currentAccountClient.GetActiveAmountBlocks(ctx, lbc.log.AccountID)
+	if err != nil {
+		return Balance{}, err
+	}
+
+	// Sum all block amounts
+	reserveAmount := NewQty[Monetary](decimal.Zero, lbc.openingBalance.Instrument)
+	for _, block := range blocks {
+		// Validate instrument matches
+		if !block.Amount.Instrument.Equal(lbc.openingBalance.Instrument) {
+			return Balance{}, ErrInstrumentMismatch
+		}
+
+		reserveAmount, err = reserveAmount.Add(block.Amount)
+		if err != nil {
+			return Balance{}, err
+		}
+	}
+
+	return Balance{
+		Type:   BalanceTypeReserve,
+		Amount: reserveAmount,
+		AsOf:   time.Now().UTC(),
+	}, nil
+}
+
+// AvailableBalance calculates the available balance for immediate use.
+// Available = Current - Reserve + Overdraft (if enabled)
+//
+// This method queries the Current Account for active liens to compute the reserve,
+// then subtracts it from the current balance and optionally adds the overdraft limit.
+//
+// Requires the CurrentAccountClient to be configured. Returns ErrNilCurrentAccountClient
+// if the client was not provided during construction.
+func (lbc *LogBalanceComputer) AvailableBalance(ctx context.Context, overdraftLimit Money, overdraftEnabled bool) (Balance, error) {
+	// Get current balance
+	currentBal, err := lbc.CurrentBalance()
+	if err != nil {
+		return Balance{}, err
+	}
+
+	// Get reserve balance
+	reserveBal, err := lbc.ReserveBalance(ctx)
+	if err != nil {
+		return Balance{}, err
+	}
+
+	// Apply overdraft if enabled, otherwise use zero
+	effectiveOverdraft := NewQty[Monetary](decimal.Zero, lbc.openingBalance.Instrument)
+	if overdraftEnabled {
+		effectiveOverdraft = overdraftLimit
+	}
+
+	return lbc.computer.ComputeAvailable(
+		currentBal.Amount,
+		reserveBal.Amount,
+		effectiveOverdraft,
+		time.Now().UTC(),
+	)
+}
+
+// FreeBalance calculates the free (unencumbered) balance.
+// Free = Current - Reserve
+//
+// Requires the CurrentAccountClient to be configured. Returns ErrNilCurrentAccountClient
+// if the client was not provided during construction.
+func (lbc *LogBalanceComputer) FreeBalance(ctx context.Context) (Balance, error) {
+	// Get current balance
+	currentBal, err := lbc.CurrentBalance()
+	if err != nil {
+		return Balance{}, err
+	}
+
+	// Get reserve balance
+	reserveBal, err := lbc.ReserveBalance(ctx)
+	if err != nil {
+		return Balance{}, err
+	}
+
+	return lbc.computer.ComputeFree(
+		currentBal.Amount,
+		reserveBal.Amount,
+		time.Now().UTC(),
+	)
+}
+
+// OpeningBalance returns the opening balance for this position.
+func (lbc *LogBalanceComputer) OpeningBalance() Balance {
+	return lbc.computer.ComputeOpening(lbc.openingBalance, lbc.log.CreatedAt)
+}
+
+// ClosingBalance calculates the closing balance at a specific period end.
+// Only includes transactions with Timestamp <= periodEnd.
+func (lbc *LogBalanceComputer) ClosingBalance(periodEnd time.Time) (Balance, error) {
+	return lbc.computer.ComputeClosing(
+		lbc.openingBalance,
+		lbc.log.TransactionLogEntries,
+		periodEnd,
+	)
+}
+
+// LedgerBalance calculates the ledger balance from all entries in the log.
+// This represents the sum of all recorded transactions.
+//
+// Note: This sums ALL entries. For status-filtered ledger balance,
+// use the stateless BalanceComputer.ComputeLedger with pre-filtered entries.
+func (lbc *LogBalanceComputer) LedgerBalance() (Balance, error) {
+	if len(lbc.log.TransactionLogEntries) == 0 {
+		// Return zero balance with opening balance's instrument
+		return Balance{
+			Type:   BalanceTypeLedger,
+			Amount: NewQty[Monetary](decimal.Zero, lbc.openingBalance.Instrument),
+			AsOf:   time.Now().UTC(),
+		}, nil
+	}
+	return lbc.computer.ComputeLedgerFromEntries(
+		lbc.log.TransactionLogEntries,
+		time.Now().UTC(),
+	)
 }

--- a/services/position-keeping/domain/balance_computer_test.go
+++ b/services/position-keeping/domain/balance_computer_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -902,4 +903,363 @@ func TestBalanceComputer_Errors(t *testing.T) {
 		assert.NotNil(t, ErrNoInstrument)
 		assert.Contains(t, ErrNoInstrument.Error(), "instrument")
 	})
+}
+
+// =============================================================================
+// LogBalanceComputer Tests
+// =============================================================================
+
+// mockCurrentAccountClient is a test double for CurrentAccountClient
+type mockCurrentAccountClient struct {
+	blocks []AmountBlock
+	err    error
+}
+
+func (m *mockCurrentAccountClient) GetActiveAmountBlocks(_ context.Context, _ string) ([]AmountBlock, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.blocks, nil
+}
+
+func createTestLog(t *testing.T, accountID string, entries []*TransactionLogEntry) *FinancialPositionLog {
+	t.Helper()
+	log, err := NewFinancialPositionLog(accountID, nil, nil)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		err := log.AddEntry(entry)
+		require.NoError(t, err)
+	}
+	return log
+}
+
+func TestNewLogBalanceComputer(t *testing.T) {
+	t.Run("creates with valid parameters", func(t *testing.T) {
+		log, _ := NewFinancialPositionLog("TEST-ACC-001", nil, nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		client := &mockCurrentAccountClient{}
+
+		lbc, err := NewLogBalanceComputer(log, opening, client)
+
+		require.NoError(t, err)
+		require.NotNil(t, lbc)
+	})
+
+	t.Run("creates without client (nil client allowed)", func(t *testing.T) {
+		log, _ := NewFinancialPositionLog("TEST-ACC-001", nil, nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+
+		lbc, err := NewLogBalanceComputer(log, opening, nil)
+
+		require.NoError(t, err)
+		require.NotNil(t, lbc)
+	})
+
+	t.Run("returns error for nil log", func(t *testing.T) {
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+
+		lbc, err := NewLogBalanceComputer(nil, opening, nil)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNilLog)
+		assert.Nil(t, lbc)
+	})
+}
+
+func TestLogBalanceComputer_CurrentBalance(t *testing.T) {
+	now := time.Now().UTC()
+
+	t.Run("returns opening balance when no entries", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		lbc, _ := NewLogBalanceComputer(log, opening, nil)
+
+		result, err := lbc.CurrentBalance()
+
+		require.NoError(t, err)
+		assert.Equal(t, BalanceTypeCurrent, result.Type)
+		assert.True(t, result.Amount.Amount.Equal(decimal.NewFromInt(1000)))
+	})
+
+	t.Run("adds DEBIT entries to opening balance", func(t *testing.T) {
+		entries := []*TransactionLogEntry{
+			newTestEntry(t, decimal.NewFromInt(100), CurrencyGBP, PostingDirectionDebit, now),
+			newTestEntry(t, decimal.NewFromInt(200), CurrencyGBP, PostingDirectionDebit, now),
+		}
+		log := createTestLog(t, "TEST-ACC-001", entries)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		lbc, _ := NewLogBalanceComputer(log, opening, nil)
+
+		result, err := lbc.CurrentBalance()
+
+		require.NoError(t, err)
+		assert.True(t, result.Amount.Amount.Equal(decimal.NewFromInt(1300))) // 1000 + 100 + 200
+	})
+
+	t.Run("subtracts CREDIT entries from opening balance", func(t *testing.T) {
+		entries := []*TransactionLogEntry{
+			newTestEntry(t, decimal.NewFromInt(100), CurrencyGBP, PostingDirectionCredit, now),
+		}
+		log := createTestLog(t, "TEST-ACC-001", entries)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		lbc, _ := NewLogBalanceComputer(log, opening, nil)
+
+		result, err := lbc.CurrentBalance()
+
+		require.NoError(t, err)
+		assert.True(t, result.Amount.Amount.Equal(decimal.NewFromInt(900))) // 1000 - 100
+	})
+}
+
+func TestLogBalanceComputer_ReserveBalance(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns error when client is nil", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		lbc, _ := NewLogBalanceComputer(log, opening, nil)
+
+		_, err := lbc.ReserveBalance(ctx)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNilCurrentAccountClient)
+	})
+
+	t.Run("returns zero when no blocks", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		client := &mockCurrentAccountClient{blocks: []AmountBlock{}}
+		lbc, _ := NewLogBalanceComputer(log, opening, client)
+
+		result, err := lbc.ReserveBalance(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, BalanceTypeReserve, result.Type)
+		assert.True(t, result.Amount.Amount.IsZero())
+	})
+
+	t.Run("sums all block amounts", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		client := &mockCurrentAccountClient{
+			blocks: []AmountBlock{
+				{BlockID: "B1", Amount: MustNewMoney(decimal.NewFromInt(100), CurrencyGBP), BlockType: AmountBlockTypePending},
+				{BlockID: "B2", Amount: MustNewMoney(decimal.NewFromInt(200), CurrencyGBP), BlockType: AmountBlockTypePending},
+				{BlockID: "B3", Amount: MustNewMoney(decimal.NewFromInt(50), CurrencyGBP), BlockType: AmountBlockTypeTemporary},
+			},
+		}
+		lbc, _ := NewLogBalanceComputer(log, opening, client)
+
+		result, err := lbc.ReserveBalance(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, BalanceTypeReserve, result.Type)
+		assert.True(t, result.Amount.Amount.Equal(decimal.NewFromInt(350))) // 100 + 200 + 50
+	})
+
+	t.Run("returns error for currency mismatch", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		client := &mockCurrentAccountClient{
+			blocks: []AmountBlock{
+				{BlockID: "B1", Amount: MustNewMoney(decimal.NewFromInt(100), CurrencyUSD), BlockType: AmountBlockTypePending},
+			},
+		}
+		lbc, _ := NewLogBalanceComputer(log, opening, client)
+
+		_, err := lbc.ReserveBalance(ctx)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInstrumentMismatch)
+	})
+
+	t.Run("propagates client errors", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		expectedErr := assert.AnError
+		client := &mockCurrentAccountClient{err: expectedErr}
+		lbc, _ := NewLogBalanceComputer(log, opening, client)
+
+		_, err := lbc.ReserveBalance(ctx)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, expectedErr)
+	})
+}
+
+func TestLogBalanceComputer_AvailableBalance(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	t.Run("computes Available = Current - Reserve + Overdraft", func(t *testing.T) {
+		entries := []*TransactionLogEntry{
+			newTestEntry(t, decimal.NewFromInt(500), CurrencyGBP, PostingDirectionDebit, now),
+		}
+		log := createTestLog(t, "TEST-ACC-001", entries)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		overdraft := MustNewMoney(decimal.NewFromInt(200), CurrencyGBP)
+		client := &mockCurrentAccountClient{
+			blocks: []AmountBlock{
+				{BlockID: "B1", Amount: MustNewMoney(decimal.NewFromInt(300), CurrencyGBP), BlockType: AmountBlockTypePending},
+			},
+		}
+		lbc, _ := NewLogBalanceComputer(log, opening, client)
+
+		result, err := lbc.AvailableBalance(ctx, overdraft, true)
+
+		require.NoError(t, err)
+		assert.Equal(t, BalanceTypeAvailable, result.Type)
+		// Current = 1000 + 500 = 1500
+		// Reserve = 300
+		// Available = 1500 - 300 + 200 = 1400
+		assert.True(t, result.Amount.Amount.Equal(decimal.NewFromInt(1400)))
+	})
+
+	t.Run("ignores overdraft when disabled", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		overdraft := MustNewMoney(decimal.NewFromInt(500), CurrencyGBP)
+		client := &mockCurrentAccountClient{
+			blocks: []AmountBlock{
+				{BlockID: "B1", Amount: MustNewMoney(decimal.NewFromInt(200), CurrencyGBP), BlockType: AmountBlockTypePending},
+			},
+		}
+		lbc, _ := NewLogBalanceComputer(log, opening, client)
+
+		result, err := lbc.AvailableBalance(ctx, overdraft, false)
+
+		require.NoError(t, err)
+		// Current = 1000, Reserve = 200, Overdraft = 0 (disabled)
+		// Available = 1000 - 200 + 0 = 800
+		assert.True(t, result.Amount.Amount.Equal(decimal.NewFromInt(800)))
+	})
+
+	t.Run("returns error when client is nil", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		overdraft := MustNewMoney(decimal.NewFromInt(500), CurrencyGBP)
+		lbc, _ := NewLogBalanceComputer(log, opening, nil)
+
+		_, err := lbc.AvailableBalance(ctx, overdraft, true)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNilCurrentAccountClient)
+	})
+}
+
+func TestLogBalanceComputer_FreeBalance(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("computes Free = Current - Reserve", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		client := &mockCurrentAccountClient{
+			blocks: []AmountBlock{
+				{BlockID: "B1", Amount: MustNewMoney(decimal.NewFromInt(300), CurrencyGBP), BlockType: AmountBlockTypePending},
+			},
+		}
+		lbc, _ := NewLogBalanceComputer(log, opening, client)
+
+		result, err := lbc.FreeBalance(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, BalanceTypeFree, result.Type)
+		// Free = 1000 - 300 = 700
+		assert.True(t, result.Amount.Amount.Equal(decimal.NewFromInt(700)))
+	})
+
+	t.Run("can go negative when reserve exceeds current", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(100), CurrencyGBP)
+		client := &mockCurrentAccountClient{
+			blocks: []AmountBlock{
+				{BlockID: "B1", Amount: MustNewMoney(decimal.NewFromInt(300), CurrencyGBP), BlockType: AmountBlockTypePending},
+			},
+		}
+		lbc, _ := NewLogBalanceComputer(log, opening, client)
+
+		result, err := lbc.FreeBalance(ctx)
+
+		require.NoError(t, err)
+		// Free = 100 - 300 = -200
+		assert.True(t, result.Amount.Amount.Equal(decimal.NewFromInt(-200)))
+	})
+}
+
+func TestLogBalanceComputer_OpeningBalance(t *testing.T) {
+	t.Run("returns opening balance", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		lbc, _ := NewLogBalanceComputer(log, opening, nil)
+
+		result := lbc.OpeningBalance()
+
+		assert.Equal(t, BalanceTypeOpening, result.Type)
+		assert.True(t, result.Amount.Amount.Equal(decimal.NewFromInt(1000)))
+		assert.Equal(t, log.CreatedAt, result.AsOf)
+	})
+}
+
+func TestLogBalanceComputer_ClosingBalance(t *testing.T) {
+	baseTime := time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2024, 1, 15, 18, 0, 0, 0, time.UTC)
+
+	t.Run("filters transactions by period end", func(t *testing.T) {
+		entries := []*TransactionLogEntry{
+			newTestEntry(t, decimal.NewFromInt(100), CurrencyGBP, PostingDirectionDebit, baseTime.Add(1*time.Hour)),     // included
+			newTestEntry(t, decimal.NewFromInt(200), CurrencyGBP, PostingDirectionDebit, periodEnd),                     // included
+			newTestEntry(t, decimal.NewFromInt(1000), CurrencyGBP, PostingDirectionDebit, periodEnd.Add(1*time.Second)), // excluded
+		}
+		log := createTestLog(t, "TEST-ACC-001", entries)
+		opening := MustNewMoney(decimal.NewFromInt(500), CurrencyGBP)
+		lbc, _ := NewLogBalanceComputer(log, opening, nil)
+
+		result, err := lbc.ClosingBalance(periodEnd)
+
+		require.NoError(t, err)
+		assert.Equal(t, BalanceTypeClosing, result.Type)
+		// 500 + 100 + 200 = 800 (1000 excluded)
+		assert.True(t, result.Amount.Amount.Equal(decimal.NewFromInt(800)))
+		assert.Equal(t, periodEnd, result.AsOf)
+	})
+}
+
+func TestLogBalanceComputer_LedgerBalance(t *testing.T) {
+	now := time.Now().UTC()
+
+	t.Run("returns zero for empty log", func(t *testing.T) {
+		log := createTestLog(t, "TEST-ACC-001", nil)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		lbc, _ := NewLogBalanceComputer(log, opening, nil)
+
+		result, err := lbc.LedgerBalance()
+
+		require.NoError(t, err)
+		assert.Equal(t, BalanceTypeLedger, result.Type)
+		assert.True(t, result.Amount.Amount.IsZero())
+	})
+
+	t.Run("sums all entries", func(t *testing.T) {
+		entries := []*TransactionLogEntry{
+			newTestEntry(t, decimal.NewFromInt(100), CurrencyGBP, PostingDirectionDebit, now),
+			newTestEntry(t, decimal.NewFromInt(200), CurrencyGBP, PostingDirectionDebit, now),
+			newTestEntry(t, decimal.NewFromInt(50), CurrencyGBP, PostingDirectionCredit, now),
+		}
+		log := createTestLog(t, "TEST-ACC-001", entries)
+		opening := MustNewMoney(decimal.NewFromInt(1000), CurrencyGBP)
+		lbc, _ := NewLogBalanceComputer(log, opening, nil)
+
+		result, err := lbc.LedgerBalance()
+
+		require.NoError(t, err)
+		assert.Equal(t, BalanceTypeLedger, result.Type)
+		// 100 + 200 - 50 = 250
+		assert.True(t, result.Amount.Amount.Equal(decimal.NewFromInt(250)))
+	})
+}
+
+func TestAmountBlockType_Constants(t *testing.T) {
+	assert.Equal(t, AmountBlockType("PENDING"), AmountBlockTypePending)
+	assert.Equal(t, AmountBlockType("FINAL"), AmountBlockTypeFinal)
+	assert.Equal(t, AmountBlockType("TEMPORARY"), AmountBlockTypeTemporary)
 }

--- a/services/position-keeping/domain/current_account_client.go
+++ b/services/position-keeping/domain/current_account_client.go
@@ -1,0 +1,68 @@
+package domain
+
+import (
+	"context"
+	"time"
+)
+
+// CurrentAccountClient defines the interface for querying fund reservations
+// from the Current Account service. This abstraction allows Position Keeping
+// to compute Reserve balance without direct coupling to the Current Account
+// implementation details.
+//
+// The interface follows the Dependency Inversion Principle: high-level domain
+// logic depends on this interface, which is implemented by infrastructure-level
+// adapters (e.g., gRPC client wrapper).
+type CurrentAccountClient interface {
+	// GetActiveAmountBlocks retrieves all active fund reservations (liens) for
+	// an account. These blocks represent funds that are reserved but not yet
+	// debited, and should be subtracted from the current balance to compute
+	// the available/reserve balance.
+	//
+	// Returns an empty slice if no active blocks exist.
+	// Returns an error if the account is not found or the service is unavailable.
+	GetActiveAmountBlocks(ctx context.Context, accountID string) ([]AmountBlock, error)
+}
+
+// AmountBlockType categorizes the nature of a fund reservation.
+// Different block types may have different implications for balance calculations
+// and business rules.
+type AmountBlockType string
+
+const (
+	// AmountBlockTypePending indicates a temporary hold pending settlement.
+	// Example: Payment Order lien awaiting external payment confirmation.
+	AmountBlockTypePending AmountBlockType = "PENDING"
+
+	// AmountBlockTypeFinal indicates a permanent reservation.
+	// Example: Regulatory hold, court order freeze.
+	AmountBlockTypeFinal AmountBlockType = "FINAL"
+
+	// AmountBlockTypeTemporary indicates a short-term hold.
+	// Example: Authorization hold for card transactions.
+	AmountBlockTypeTemporary AmountBlockType = "TEMPORARY"
+)
+
+// AmountBlock represents a fund reservation from the perspective of Position Keeping.
+// This domain type abstracts the Current Account lien implementation, allowing
+// Position Keeping to query blocked amounts without coupling to lien-specific details.
+//
+// The Reserve balance = sum of all active AmountBlock.Amount values.
+type AmountBlock struct {
+	// BlockID is the unique identifier for this block (maps to lien_id in Current Account).
+	BlockID string
+
+	// Amount is the reserved amount. Must have the same currency as the account.
+	Amount Money
+
+	// BlockType indicates the nature of the reservation (PENDING, FINAL, TEMPORARY).
+	BlockType AmountBlockType
+
+	// Purpose describes why the funds are blocked.
+	// Example: "Payment Order: PO-12345", "Regulatory hold".
+	Purpose string
+
+	// ExpiresAt is when the block expires. Nil means no expiry.
+	// Expired blocks should not be included in reserve calculations.
+	ExpiresAt *time.Time
+}


### PR DESCRIPTION
## Summary

- Add `CurrentAccountClient` interface and `AmountBlock` type for Position Keeping to query fund reservations from Current Account without direct coupling to lien implementation
- Add `LogBalanceComputer` that holds references to `FinancialPositionLog` and `CurrentAccountClient` for stateful balance computation
- Implement all BIAN-compliant balance types: Current, Reserve, Available, Free, Opening, Closing, Ledger
- Add `GetActiveAmountBlocks` method to Current Account client for querying active liens

## Changes Made

### Position Keeping Domain (`services/position-keeping/domain/`)
- **`current_account_client.go`**: New file with `CurrentAccountClient` interface and `AmountBlock` type
- **`balance_computer.go`**: Added `LogBalanceComputer` struct with methods:
  - `CurrentBalance()` - opening + sum of all transactions
  - `ReserveBalance(ctx)` - queries liens from Current Account via client
  - `AvailableBalance(ctx, overdraftLimit, overdraftEnabled)` - Current - Reserve + Overdraft
  - `FreeBalance(ctx)` - Current - Reserve
  - `OpeningBalance()`, `ClosingBalance(periodEnd)`, `LedgerBalance()`
- **`balance_computer_test.go`**: Comprehensive unit tests with mock client

### Current Account Client (`services/current-account/client/`)
- **`client.go`**: Added `GetActiveAmountBlocks()` method with resilience patterns

## Technical Details

The `LogBalanceComputer` follows Dependency Inversion Principle - domain logic depends on the `CurrentAccountClient` interface rather than concrete gRPC client. This allows:
- Easy unit testing with mock clients
- Flexibility to swap client implementations
- Clean separation between Position Keeping and Current Account services

Balance computations:
- `Current = Opening + Σ(DEBIT entries) - Σ(CREDIT entries)`
- `Reserve = Σ(active AmountBlock.Amount)` from Current Account
- `Available = Current - Reserve + Overdraft`
- `Free = Current - Reserve`

## Test Plan

- [x] Unit tests for `LogBalanceComputer` with mock `CurrentAccountClient`
- [x] Tests for all balance types: Current, Reserve, Available, Free, Opening, Closing, Ledger
- [x] Error handling tests: nil client, currency mismatch, client errors
- [x] Edge cases: empty log, negative balances, overdraft enabled/disabled
- [x] All existing `BalanceComputer` tests still pass

## Task Master Reference

Task: position-keeping-balance.2