### PR TITLE
fix: prevent untrusted code checkout in Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -60,12 +60,16 @@ jobs:
             console.log(`Found PR #${prNumber}`);
             core.setOutput('number', prNumber);
 
-      - name: Checkout repository
+      # SECURITY: Checkout the default branch, NOT the PR's head_sha
+      # This prevents malicious PRs from executing untrusted code in a privileged workflow_run context
+      # Claude Code can still review the PR diff via gh CLI commands
+      - name: Checkout repository (default branch)
         if: steps.pr.outputs.number
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Get current date
         if: steps.pr.outputs.number


### PR DESCRIPTION
## Summary

Fixes a HIGH severity security alert from GitHub code scanning (`actions/untrusted-checkout/high`).

The `workflow_run` trigger runs in a privileged context with access to repository secrets. The previous configuration checked out the PR's `head_sha`, which could allow malicious PRs to:
- Modify workflow files to exfiltrate secrets
- Execute arbitrary code in the privileged context

## Changes

- Checkout the default branch instead of the PR's head SHA
- Add `persist-credentials: false` for additional security hardening
- Claude Code can still review PRs via `gh pr diff` and `gh pr view` commands

## Remaining Alerts (88 container CVEs)

The other 88 alerts are OS-level CVEs in `debian:bookworm-slim` base images:

| CVE | Package | Severity | Impact |
|-----|---------|----------|--------|
| CVE-2022-0563 | util-linux | Low | Requires local access |
| CVE-2025-14104 | util-linux | Medium | Requires 256-byte usernames |
| CVE-2023-50495 | ncurses | Medium | Requires ncurses usage |
| CVE-2023-45853 | zlib | High | zipOpenNewFileInZip4_6 overflow |
| ... | ... | ... | Not exploitable in containerized Go services |

These are informational alerts about packages in the base OS image, not application vulnerabilities. Options to address:
1. **Accept risk** - These don't affect Go services running in containers
2. **Switch to distroless** - Eliminates most CVEs but requires librdkafka handling
3. **Wait for Debian patches** - Many have no upstream fix yet

Recommend addressing container CVEs in a separate PR if desired.

## Test Plan

- [ ] PR triggers Claude Code review workflow successfully
- [ ] Claude Code can still read CLAUDE.md from default branch
- [ ] Claude Code can review PR diff via `gh` commands