### PR TITLE
feat(position-keeping): add Kafka topic mapping for OpeningBalanceRecordedEvent

### DIFF
--- a/services/position-keeping/adapters/messaging/kafka_event_publisher.go
+++ b/services/position-keeping/adapters/messaging/kafka_event_publisher.go
@@ -53,6 +53,8 @@ type TopicConfig struct {
 	TransactionCancelledTopic string
 	// BulkTransactionCapturedTopic is the topic for bulk transaction captured events
 	BulkTransactionCapturedTopic string
+	// OpeningBalanceRecordedTopic is the topic for opening balance recorded events
+	OpeningBalanceRecordedTopic string
 }
 
 // DefaultTopicConfig returns the default topic configuration for position keeping events.
@@ -66,6 +68,7 @@ func DefaultTopicConfig() TopicConfig {
 		TransactionFailedTopic:       "position-keeping.transaction-failed.v1",
 		TransactionCancelledTopic:    "position-keeping.transaction-cancelled.v1",
 		BulkTransactionCapturedTopic: "position-keeping.bulk-transaction-captured.v1",
+		OpeningBalanceRecordedTopic:  "position-keeping.opening-balance-recorded.v1",
 	}
 }
 
@@ -96,6 +99,7 @@ func NewKafkaEventPublisher(producer protoPublisher, topicConfig TopicConfig) (*
 		"position_keeping.transaction_failed.v1":        topicConfig.TransactionFailedTopic,
 		"position_keeping.transaction_cancelled.v1":     topicConfig.TransactionCancelledTopic,
 		"position_keeping.bulk_transaction_captured.v1": topicConfig.BulkTransactionCapturedTopic,
+		"position_keeping.opening_balance_recorded.v1":  topicConfig.OpeningBalanceRecordedTopic,
 	}
 
 	return &KafkaEventPublisher{

--- a/services/position-keeping/adapters/messaging/kafka_event_publisher_test.go
+++ b/services/position-keeping/adapters/messaging/kafka_event_publisher_test.go
@@ -64,6 +64,7 @@ func TestDefaultTopicConfig(t *testing.T) {
 	assert.Equal(t, "position-keeping.transaction-failed.v1", config.TransactionFailedTopic)
 	assert.Equal(t, "position-keeping.transaction-cancelled.v1", config.TransactionCancelledTopic)
 	assert.Equal(t, "position-keeping.bulk-transaction-captured.v1", config.BulkTransactionCapturedTopic)
+	assert.Equal(t, "position-keeping.opening-balance-recorded.v1", config.OpeningBalanceRecordedTopic)
 }
 
 func TestNewKafkaEventPublisher_NilProducer(t *testing.T) {
@@ -320,6 +321,20 @@ func TestKafkaEventPublisher_TopicMapping(t *testing.T) {
 				Timestamp: timestamp,
 			},
 			expectedTopic: "position-keeping.bulk-transaction-captured.v1",
+		},
+		{
+			name: "OpeningBalanceRecorded",
+			event: &domain.OpeningBalanceRecorded{
+				LogID:              logID,
+				AccountID:          "ACC-123",
+				OpeningBalance:     money,
+				EffectiveDate:      timestamp,
+				MigrationReference: "MIGRATION-001",
+				CorrelationID:      "CORR-123",
+				Timestamp:          timestamp,
+				Version:            1,
+			},
+			expectedTopic: "position-keeping.opening-balance-recorded.v1",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Adds missing Kafka topic mapping for `OpeningBalanceRecordedEvent` in `KafkaEventPublisher`
- The `OpeningBalanceRecorded` domain event was already being published in `InitiateWithOpeningBalance`, but publishes were silently failing because the topic routing was missing

## Changes Made

- Added `OpeningBalanceRecordedTopic` field to `TopicConfig` struct
- Added default topic name `position-keeping.opening-balance-recorded.v1` to `DefaultTopicConfig()`
- Added topic routing map entry for `position_keeping.opening_balance_recorded.v1` event type
- Added test coverage for the new topic mapping in `TestDefaultTopicConfig` and `TestKafkaEventPublisher_TopicMapping`

## Technical Details

The proto message `OpeningBalanceRecordedEvent` and domain event `OpeningBalanceRecorded` already existed (added in PR #553). The service layer was publishing the event correctly, but the Kafka event publisher's `getTopicForEvent()` method would return an empty string for this event type, resulting in `ErrUnknownEventType`. Since the publish call in `initiate_migration.go` ignores errors (`_ = s.eventPublisher.Publish(ctx, event)`), this was failing silently.

## Test Plan

- [x] Unit tests pass for `TestDefaultTopicConfig` (verifies new topic config field)
- [x] Unit tests pass for `TestKafkaEventPublisher_TopicMapping` (verifies event routes to correct topic)
- [x] Full position-keeping test suite passes
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)

## Task Master Reference

Task: `position-keeping-balance.12` - Publish Balance Change Events from Position Keeping