### PR TITLE
feat: Delegate balance management to Position Keeping service

### DIFF
--- a/services/current-account/domain/account.go
+++ b/services/current-account/domain/account.go
@@ -151,6 +151,93 @@ func (a CurrentAccount) Deposit(amount Money) (CurrentAccount, error) {
 	}, nil
 }
 
+// PrepareForCredit validates the account can receive a credit transaction and increments the
+// version for optimistic locking. This method does NOT mutate balance locally - balance is
+// managed externally by the Position Keeping service.
+//
+// Use this method when recording CREDIT transactions in Position Keeping while keeping
+// optimistic locking protection against concurrent modifications.
+func (a CurrentAccount) PrepareForCredit() (CurrentAccount, error) {
+	if a.status == AccountStatusFrozen {
+		return CurrentAccount{}, ErrAccountFrozen
+	}
+
+	if a.status == AccountStatusClosed {
+		return CurrentAccount{}, ErrAccountClosed
+	}
+
+	now := time.Now()
+	return CurrentAccount{
+		id:                    a.id,
+		accountID:             a.accountID,
+		accountIdentification: a.accountIdentification,
+		partyID:               a.partyID,
+		balance:               a.balance, // Balance NOT modified - Position Keeping is source of truth
+		availableBalance:      a.availableBalance,
+		status:                a.status,
+		freezeReason:          a.freezeReason,
+		statusHistory:         a.statusHistory,
+		overdraftLimit:        a.overdraftLimit,
+		overdraftEnabled:      a.overdraftEnabled,
+		overdraftRate:         a.overdraftRate,
+		balanceUpdatedAt:      a.balanceUpdatedAt,
+		version:               a.version + 1, // Version incremented for optimistic locking
+		createdAt:             a.createdAt,
+		updatedAt:             now,
+	}, nil
+}
+
+// PrepareForDebit validates the account can process a debit transaction (withdrawal) and
+// increments the version for optimistic locking. This method validates sufficient funds
+// but does NOT mutate balance locally - balance is managed externally by the Position
+// Keeping service.
+//
+// Use this method when recording DEBIT transactions in Position Keeping while keeping
+// optimistic locking protection against concurrent modifications.
+func (a CurrentAccount) PrepareForDebit(amount Money) (CurrentAccount, error) {
+	if !amount.IsPositive() {
+		return CurrentAccount{}, ErrInvalidAmount
+	}
+
+	if a.status == AccountStatusFrozen {
+		return CurrentAccount{}, ErrAccountFrozen
+	}
+
+	if a.status == AccountStatusClosed {
+		return CurrentAccount{}, ErrAccountClosed
+	}
+
+	if amount.Currency() != a.balance.Currency() {
+		return CurrentAccount{}, ErrCurrencyMismatch
+	}
+
+	// Check if sufficient funds (including overdraft via availableBalance)
+	cmp, _ := amount.Compare(a.availableBalance)
+	if cmp > 0 {
+		return CurrentAccount{}, ErrInsufficientFunds
+	}
+
+	now := time.Now()
+	return CurrentAccount{
+		id:                    a.id,
+		accountID:             a.accountID,
+		accountIdentification: a.accountIdentification,
+		partyID:               a.partyID,
+		balance:               a.balance, // Balance NOT modified - Position Keeping is source of truth
+		availableBalance:      a.availableBalance,
+		status:                a.status,
+		freezeReason:          a.freezeReason,
+		statusHistory:         a.statusHistory,
+		overdraftLimit:        a.overdraftLimit,
+		overdraftEnabled:      a.overdraftEnabled,
+		overdraftRate:         a.overdraftRate,
+		balanceUpdatedAt:      a.balanceUpdatedAt,
+		version:               a.version + 1, // Version incremented for optimistic locking
+		createdAt:             a.createdAt,
+		updatedAt:             now,
+	}, nil
+}
+
 // Withdraw removes funds from the account and returns a new account with the updated balance.
 // The original account is not modified.
 func (a CurrentAccount) Withdraw(amount Money) (CurrentAccount, error) {

--- a/services/current-account/domain/account_test.go
+++ b/services/current-account/domain/account_test.go
@@ -115,6 +115,138 @@ func TestDepositWhenClosed(t *testing.T) {
 	assert.ErrorIs(t, err, ErrAccountClosed)
 }
 
+func TestPrepareForCredit(t *testing.T) {
+	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
+	require.NoError(t, err)
+
+	// PrepareForCredit should succeed for active account
+	prepared, err := account.PrepareForCredit()
+	require.NoError(t, err)
+
+	// Balance should NOT change (Position Keeping is source of truth)
+	assert.Equal(t, account.Balance().AmountCents(), prepared.Balance().AmountCents())
+
+	// Version should be incremented for optimistic locking
+	assert.Equal(t, account.Version()+1, prepared.Version())
+
+	// UpdatedAt should be set
+	assert.True(t, prepared.UpdatedAt().After(account.UpdatedAt()) || prepared.UpdatedAt().Equal(account.UpdatedAt()))
+}
+
+func TestPrepareForCreditWhenFrozen(t *testing.T) {
+	account, err := NewCurrentAccount("ACC-001", "GB82WEST12345698765432", "PARTY-001", "GBP")
+	require.NoError(t, err)
+	account, _ = account.Freeze("Suspicious activity detected on account")
+
+	_, err = account.PrepareForCredit()
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrAccountFrozen)
+}
+
+func TestPrepareForCreditWhenClosed(t *testing.T) {
+	// Build a closed account using builder (simulating a reconstructed account)
+	zeroMoney, _ := NewMoney("GBP", 0)
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("PARTY-001").
+		WithBalance(zeroMoney).
+		WithAvailableBalance(zeroMoney).
+		WithStatus(AccountStatusClosed).
+		WithVersion(1).
+		Build()
+
+	_, err := account.PrepareForCredit()
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrAccountClosed)
+}
+
+func TestPrepareForDebit(t *testing.T) {
+	balance, _ := NewMoney("GBP", 10000) // £100.00
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("PARTY-001").
+		WithBalance(balance).
+		WithAvailableBalance(balance).
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		Build()
+
+	withdrawAmount, _ := NewMoney("GBP", 5000) // £50.00
+
+	// PrepareForDebit should succeed for active account with sufficient funds
+	prepared, err := account.PrepareForDebit(withdrawAmount)
+	require.NoError(t, err)
+
+	// Balance should NOT change (Position Keeping is source of truth)
+	assert.Equal(t, account.Balance().AmountCents(), prepared.Balance().AmountCents())
+
+	// Version should be incremented for optimistic locking
+	assert.Equal(t, account.Version()+1, prepared.Version())
+}
+
+func TestPrepareForDebitInsufficientFunds(t *testing.T) {
+	balance, _ := NewMoney("GBP", 5000) // £50.00
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("PARTY-001").
+		WithBalance(balance).
+		WithAvailableBalance(balance).
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		Build()
+
+	withdrawAmount, _ := NewMoney("GBP", 10000) // £100.00 - more than available
+
+	_, err := account.PrepareForDebit(withdrawAmount)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrInsufficientFunds)
+}
+
+func TestPrepareForDebitWhenFrozen(t *testing.T) {
+	balance, _ := NewMoney("GBP", 10000)
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("PARTY-001").
+		WithBalance(balance).
+		WithAvailableBalance(balance).
+		WithStatus(AccountStatusFrozen).
+		WithFreezeReason("Suspicious activity").
+		WithVersion(1).
+		Build()
+
+	withdrawAmount, _ := NewMoney("GBP", 5000)
+	_, err := account.PrepareForDebit(withdrawAmount)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrAccountFrozen)
+}
+
+func TestPrepareForDebitWhenClosed(t *testing.T) {
+	zeroMoney, _ := NewMoney("GBP", 0)
+	account := NewCurrentAccountBuilder().
+		WithAccountID("ACC-001").
+		WithAccountIdentification("GB82WEST12345698765432").
+		WithPartyID("PARTY-001").
+		WithBalance(zeroMoney).
+		WithAvailableBalance(zeroMoney).
+		WithStatus(AccountStatusClosed).
+		WithVersion(1).
+		Build()
+
+	withdrawAmount, _ := NewMoney("GBP", 5000)
+	_, err := account.PrepareForDebit(withdrawAmount)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrAccountClosed)
+}
+
 func TestWithdraw(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/services/current-account/service/deposit_orchestrator.go
+++ b/services/current-account/service/deposit_orchestrator.go
@@ -74,9 +74,9 @@ func NewDepositOrchestrator(cfg DepositOrchestratorConfig) (*DepositOrchestrator
 // Orchestrate executes the deposit saga with compensation on failure.
 //
 // Saga Steps (executed strictly sequentially - no concurrent execution):
-//  1. log_position: Create financial position log in PositionKeeping service
+//  1. log_position: Create CREDIT entry in PositionKeeping service (balance source of truth)
 //  2. post_ledger: Create booking log and dual ledger postings in FinancialAccounting service
-//  3. save_account: Persist updated account balance to database
+//  3. save_account: Persist account metadata (status, version) - balance NOT stored locally
 //
 // The saga uses the SagaOrchestrator which ensures steps run one at a time. Domain objects
 // (account, amount) are safely shared across steps since only one step executes at a time.
@@ -616,12 +616,14 @@ func (o *DepositOrchestrator) addSaveAccountStep(
 	transactionID string,
 ) {
 	saga.AddStep("save_account",
-		// Action: Persist the updated account balance
+		// Action: Persist account metadata (status, version for optimistic locking).
+		// Note: Balance is NOT persisted locally - Position Keeping is the source of truth.
+		// The repository's Save method excludes balance fields from persistence.
 		func(stepCtx context.Context) error {
 			o.logger.Info("executing save_account step",
 				"account_id", account.AccountID(),
 				"transaction_id", transactionID,
-				"new_balance", account.Balance().AmountCents())
+				"version", account.Version())
 
 			if err := o.repo.Save(stepCtx, account); err != nil {
 				return fmt.Errorf("failed to save account: %w", err)
@@ -629,7 +631,7 @@ func (o *DepositOrchestrator) addSaveAccountStep(
 
 			o.logger.Info("save_account step completed",
 				"account_id", account.AccountID(),
-				"new_balance", account.Balance().AmountCents())
+				"version", account.Version())
 
 			return nil
 		},

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -495,20 +495,25 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 			"deposit amount must be positive, got %d cents", amountCents)
 	}
 
-	// Execute deposit on domain model (returns new account, original unchanged)
-	account, err = account.Deposit(amount)
-	if err != nil {
-		operationStatus = "deposit_failed"
-		return nil, status.Errorf(codes.InvalidArgument, "deposit failed: %v", err)
-	}
-
 	// Generate transaction ID (full UUID required by position-keeping service)
 	transactionID := uuid.New().String()
 
 	var resp *pb.ExecuteDepositResponse
 
 	// If clients are not configured, fall back to simple save (backward compatibility)
+	// In this mode, we still mutate and save local balance since Position Keeping is unavailable.
 	if s.posKeepingClient == nil || s.finAcctClient == nil {
+		// Execute deposit on domain model for backward compatibility mode only.
+		// The domain Deposit method validates status (frozen/closed) and mutates balance.
+		account, err = account.Deposit(amount)
+		if err != nil {
+			operationStatus = "deposit_failed"
+			if errors.Is(err, domain.ErrAccountFrozen) || errors.Is(err, domain.ErrAccountClosed) {
+				return nil, status.Errorf(codes.FailedPrecondition, "deposit failed: %v", err)
+			}
+			return nil, status.Errorf(codes.InvalidArgument, "deposit failed: %v", err)
+		}
+
 		s.logger.Info("executing deposit without transaction orchestration (clients not configured)",
 			"account_id", account.AccountID(),
 			"transaction_id", transactionID)
@@ -530,12 +535,40 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 			Status:           pb.TransactionStatus_TRANSACTION_STATUS_COMPLETED,
 		}
 	} else {
+		// Position Keeping is configured - record CREDIT transaction there.
+		// Balance is NOT mutated locally; Position Keeping is the source of truth.
+
+		// Prepare account for credit transaction (validates status, increments version for optimistic locking)
+		account, err = account.PrepareForCredit()
+		if err != nil {
+			operationStatus = "deposit_failed"
+			if errors.Is(err, domain.ErrAccountFrozen) || errors.Is(err, domain.ErrAccountClosed) {
+				return nil, status.Errorf(codes.FailedPrecondition, "deposit failed: %v", err)
+			}
+			return nil, status.Errorf(codes.InvalidArgument, "deposit failed: %v", err)
+		}
+
 		// Orchestrate transaction with saga pattern using dedicated orchestrator
 		resp, err = s.depositOrchestrator.Orchestrate(ctx, account, amount, transactionID)
 		if err != nil {
 			operationStatus = opStatusSagaFailed
 			return nil, err
 		}
+
+		// After saga completes, query Position Keeping for the new balance
+		account, err = s.hydrateAccountWithBalance(ctx, account)
+		if err != nil {
+			s.logger.Error("failed to retrieve updated balance from Position Keeping after deposit",
+				"account_id", account.AccountID(),
+				"transaction_id", transactionID,
+				"error", err)
+			// Transaction succeeded but balance fetch failed - return response with stale balance
+			// The deposit was recorded in Position Keeping, client can retry balance query
+		}
+
+		// Update response with balance from Position Keeping
+		resp.NewBalance = toMoneyAmount(account.Balance())
+		resp.AvailableBalance = toMoneyAmount(account.AvailableBalance())
 
 		// Record business metrics on success
 		caobservability.RecordDeposit(string(account.Balance().Currency()))
@@ -565,7 +598,7 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 	return resp, nil
 }
 
-// RetrieveCurrentAccount gets current account details
+// RetrieveCurrentAccount gets current account details including balance from Position Keeping.
 func (s *Service) RetrieveCurrentAccount(ctx context.Context, req *pb.RetrieveCurrentAccountRequest) (*pb.RetrieveCurrentAccountResponse, error) {
 	start := time.Now()
 	operationStatus := operationStatusSuccess
@@ -582,6 +615,17 @@ func (s *Service) RetrieveCurrentAccount(ctx context.Context, req *pb.RetrieveCu
 		}
 		operationStatus = opStatusRetrieveFailed
 		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+
+	// Hydrate account with balance from Position Keeping service.
+	// Balance is no longer persisted locally - Position Keeping is the source of truth.
+	account, err = s.hydrateAccountWithBalance(ctx, account)
+	if err != nil {
+		operationStatus = opStatusRetrieveFailed
+		s.logger.Error("failed to retrieve balance from Position Keeping",
+			"account_id", req.AccountId,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to retrieve account balance: %v", err)
 	}
 
 	return &pb.RetrieveCurrentAccountResponse{
@@ -823,41 +867,34 @@ func (s *Service) ExecuteWithdrawal(ctx context.Context, req *pb.ExecuteWithdraw
 			"withdrawal amount must be positive, got %d cents", amountCents)
 	}
 
-	// Check sufficient available balance before attempting withdrawal
-	cmp, _ := amount.Compare(account.AvailableBalance())
-	if cmp > 0 {
-		operationStatus = opStatusInsufficientFunds
-		availCents, _ := account.AvailableBalance().ToMinorUnits()
-		return nil, status.Errorf(codes.FailedPrecondition,
-			"insufficient funds: requested %d cents, available %d cents", amountCents, availCents)
-	}
-
-	// Execute withdrawal on domain model (returns new account, original unchanged)
-	account, err = account.Withdraw(amount)
-	if err != nil {
-		if errors.Is(err, domain.ErrInsufficientFunds) {
-			operationStatus = opStatusInsufficientFunds
-			return nil, status.Errorf(codes.FailedPrecondition, "insufficient funds for withdrawal")
-		}
-		if errors.Is(err, domain.ErrAccountFrozen) {
-			operationStatus = opStatusAccountFrozen
-			return nil, status.Errorf(codes.FailedPrecondition, "account is frozen")
-		}
-		if errors.Is(err, domain.ErrAccountClosed) {
-			operationStatus = opStatusAccountClosed
-			return nil, status.Errorf(codes.FailedPrecondition, "account is closed")
-		}
-		operationStatus = opStatusWithdrawalFailed
-		return nil, status.Errorf(codes.InvalidArgument, "withdrawal failed: %v", err)
-	}
-
 	// Generate transaction ID (full UUID required by position-keeping service)
 	transactionID := uuid.New().String()
 
 	var resp *pb.ExecuteWithdrawalResponse
 
 	// If clients are not configured, fall back to simple save (backward compatibility)
+	// In this mode, we still mutate and save local balance since Position Keeping is unavailable.
 	if s.posKeepingClient == nil || s.finAcctClient == nil {
+		// Execute withdrawal on domain model for backward compatibility mode only.
+		// The domain Withdraw method validates status, sufficient funds, and mutates balance.
+		account, err = account.Withdraw(amount)
+		if err != nil {
+			if errors.Is(err, domain.ErrInsufficientFunds) {
+				operationStatus = opStatusInsufficientFunds
+				return nil, status.Errorf(codes.FailedPrecondition, "insufficient funds for withdrawal")
+			}
+			if errors.Is(err, domain.ErrAccountFrozen) {
+				operationStatus = opStatusAccountFrozen
+				return nil, status.Errorf(codes.FailedPrecondition, "account is frozen")
+			}
+			if errors.Is(err, domain.ErrAccountClosed) {
+				operationStatus = opStatusAccountClosed
+				return nil, status.Errorf(codes.FailedPrecondition, "account is closed")
+			}
+			operationStatus = opStatusWithdrawalFailed
+			return nil, status.Errorf(codes.InvalidArgument, "withdrawal failed: %v", err)
+		}
+
 		s.logger.Info("executing withdrawal without transaction orchestration (clients not configured)",
 			"account_id", account.AccountID(),
 			"transaction_id", transactionID)
@@ -880,12 +917,51 @@ func (s *Service) ExecuteWithdrawal(ctx context.Context, req *pb.ExecuteWithdraw
 			Timestamp:        timestamppb.Now(),
 		}
 	} else {
+		// Position Keeping is configured - record DEBIT transaction there.
+		// Balance is NOT mutated locally; Position Keeping is the source of truth.
+
+		// Prepare account for debit transaction (validates status, funds, increments version)
+		account, err = account.PrepareForDebit(amount)
+		if err != nil {
+			if errors.Is(err, domain.ErrInsufficientFunds) {
+				operationStatus = opStatusInsufficientFunds
+				availCents, _ := account.AvailableBalance().ToMinorUnits()
+				return nil, status.Errorf(codes.FailedPrecondition,
+					"insufficient funds: requested %d cents, available %d cents", amountCents, availCents)
+			}
+			if errors.Is(err, domain.ErrAccountFrozen) {
+				operationStatus = opStatusAccountFrozen
+				return nil, status.Errorf(codes.FailedPrecondition, "account is frozen")
+			}
+			if errors.Is(err, domain.ErrAccountClosed) {
+				operationStatus = opStatusAccountClosed
+				return nil, status.Errorf(codes.FailedPrecondition, "account is closed")
+			}
+			operationStatus = opStatusWithdrawalFailed
+			return nil, status.Errorf(codes.InvalidArgument, "withdrawal failed: %v", err)
+		}
+
 		// Orchestrate transaction with saga pattern using dedicated orchestrator
 		resp, err = s.withdrawalOrchestrator.Orchestrate(ctx, account, amount, transactionID)
 		if err != nil {
 			operationStatus = opStatusSagaFailed
 			return nil, err
 		}
+
+		// After saga completes, query Position Keeping for the new balance
+		account, err = s.hydrateAccountWithBalance(ctx, account)
+		if err != nil {
+			s.logger.Error("failed to retrieve updated balance from Position Keeping after withdrawal",
+				"account_id", account.AccountID(),
+				"transaction_id", transactionID,
+				"error", err)
+			// Transaction succeeded but balance fetch failed - return response with stale balance
+			// The withdrawal was recorded in Position Keeping, client can retry balance query
+		}
+
+		// Update response with balance from Position Keeping
+		resp.NewBalance = toMoneyAmount(account.Balance())
+		resp.AvailableBalance = toMoneyAmount(account.AvailableBalance())
 
 		// Record business metrics on success
 		caobservability.RecordWithdrawal(string(account.Balance().Currency()))

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -444,7 +444,12 @@ func TestExecuteDeposit_WithOrchestration_Success(t *testing.T) {
 	_ = createTestAccount(t, ctx, repo, "ACC-001")
 
 	// Create mock clients
-	mockPosKeeping := &mockPositionKeepingClient{}
+	// Configure Position Keeping mock to return the expected balance after deposit (£100.50 = 10050 cents)
+	mockPosKeeping := &mockPositionKeepingClient{
+		accountBalances: map[string]int64{
+			"ACC-001": 10050, // £100.50 in cents
+		},
+	}
 	mockFinAcct := &mockFinancialAccountingClient{}
 
 	// Create service with mocked clients

--- a/services/current-account/service/grpc_service_test.go
+++ b/services/current-account/service/grpc_service_test.go
@@ -411,7 +411,10 @@ func TestRetrieveCurrentAccount(t *testing.T) {
 	defer cleanup()
 
 	repo := persistence.NewRepository(db)
-	svc := mustNewService(t, repo, nil)
+	// Configure Position Keeping mock to return balance for ACC-001
+	svc := mustNewServiceWithPositionKeeping(t, repo, nil, map[string]int64{
+		"ACC-001": 150000, // 1500.00 GBP
+	})
 
 	// Create account first
 	account, err := domain.NewCurrentAccount("ACC-001", "ACC-001", uuid.New().String(), "GBP")
@@ -440,6 +443,16 @@ func TestRetrieveCurrentAccount(t *testing.T) {
 
 	if resp.Facility.AccountStatus != pb.AccountStatus_ACCOUNT_STATUS_ACTIVE {
 		t.Errorf("Expected ACTIVE status, got %v", resp.Facility.AccountStatus)
+	}
+
+	// Verify balance comes from Position Keeping (1500.00 GBP = 15.00 units)
+	if resp.Facility.CurrentBalance == nil {
+		t.Fatal("Expected current balance in response")
+	}
+	expectedUnits := int64(1500) // 150000 cents = 1500.00 GBP
+	if resp.Facility.CurrentBalance.CurrentBalance.Amount.Units != expectedUnits {
+		t.Errorf("Expected balance units %d, got %d",
+			expectedUnits, resp.Facility.CurrentBalance.CurrentBalance.Amount.Units)
 	}
 }
 

--- a/services/current-account/service/withdrawal_orchestrator.go
+++ b/services/current-account/service/withdrawal_orchestrator.go
@@ -74,10 +74,10 @@ func NewWithdrawalOrchestrator(cfg WithdrawalOrchestratorConfig) (*WithdrawalOrc
 // Orchestrate executes the withdrawal saga with compensation on failure.
 //
 // Saga Steps (executed strictly sequentially - no concurrent execution):
-//  1. log_position: Create financial position log in PositionKeeping service with DEBIT direction
+//  1. log_position: Create DEBIT entry in PositionKeeping service (balance source of truth)
 //  2. post_ledger: Create booking log and dual ledger postings in FinancialAccounting service
 //     (Customer account DEBIT, Bank cash account CREDIT - reversed from deposit)
-//  3. save_account: Persist updated account balance to database
+//  3. save_account: Persist account metadata (status, version) - balance NOT stored locally
 //
 // The saga uses the SagaOrchestrator which ensures steps run one at a time. Domain objects
 // (account, amount) are safely shared across steps since only one step executes at a time.
@@ -607,12 +607,14 @@ func (o *WithdrawalOrchestrator) addSaveAccountStep(
 	transactionID string,
 ) {
 	saga.AddStep("save_account",
-		// Action: Persist the updated account balance
+		// Action: Persist account metadata (status, version for optimistic locking).
+		// Note: Balance is NOT persisted locally - Position Keeping is the source of truth.
+		// The repository's Save method excludes balance fields from persistence.
 		func(stepCtx context.Context) error {
 			o.logger.Info("executing save_account step for withdrawal",
 				"account_id", account.AccountID(),
 				"transaction_id", transactionID,
-				"new_balance", account.Balance().AmountCents())
+				"version", account.Version())
 
 			if err := o.repo.Save(stepCtx, account); err != nil {
 				return fmt.Errorf("failed to save account: %w", err)
@@ -620,7 +622,7 @@ func (o *WithdrawalOrchestrator) addSaveAccountStep(
 
 			o.logger.Info("save_account step completed for withdrawal",
 				"account_id", account.AccountID(),
-				"new_balance", account.Balance().AmountCents())
+				"version", account.Version())
 
 			return nil
 		},

--- a/services/current-account/service/withdrawal_test.go
+++ b/services/current-account/service/withdrawal_test.go
@@ -79,10 +79,13 @@ func TestExecuteWithdrawal_Success(t *testing.T) {
 	// Create account with $1000 balance (100000 cents)
 	_ = createTestAccountWithBalance(t, ctx, repo, "ACC-WTH-001", 100000)
 
-	// Create mock clients with balance configured for Position Keeping
+	// Create mock clients with balance configured for Position Keeping.
+	// The mock returns the POST-withdrawal balance since Position Keeping is the source of truth
+	// and would have already recorded the DEBIT by the time we query the balance.
+	// Pre-withdrawal: $1000.00, Withdrawal: $100.50, Post-withdrawal: $899.50 (89950 cents)
 	mockPosKeeping := &mockPositionKeepingClient{
 		accountBalances: map[string]int64{
-			"ACC-WTH-001": 100000, // $1000
+			"ACC-WTH-001": 89950, // $899.50 post-withdrawal
 		},
 	}
 	mockFinAcct := &mockFinancialAccountingClient{}


### PR DESCRIPTION
## Summary

Updates the Current Account service layer to use Position Keeping as the source of truth for account balances, completing the balance delegation refactoring started in Task 9.

Key changes:
- Add `PrepareForCredit` and `PrepareForDebit` domain methods that validate account status and increment version for optimistic locking without mutating local balance
- Refactor `ExecuteDeposit` to use Position Keeping for balance (no local mutation)
- Refactor `ExecuteWithdrawal` to use Position Keeping for balance (no local mutation)
- Update `RetrieveCurrentAccount` to hydrate balance from Position Keeping
- Maintain backward compatibility when Position Keeping is not configured

## Technical Details

### Domain Model Changes
- `PrepareForCredit()` - Validates frozen/closed status, increments version
- `PrepareForDebit(amount)` - Validates frozen/closed/insufficient funds, increments version
- Both methods return new account with incremented version but same balance (balance comes from Position Keeping)

### Service Layer Changes
- When Position Keeping is configured: call `PrepareFor[Credit|Debit]`, run saga, then query Position Keeping for updated balance
- When Position Keeping is not configured (backward compat): use original `Deposit()`/`Withdraw()` methods that mutate local balance

### Orchestrator Updates
- Updated comments to reflect that balance is not stored locally
- Changed logs from `new_balance` to `version` since balance no longer changes locally

## Test plan

- [x] `TestPrepareForCredit` - validates new domain method
- [x] `TestPrepareForCreditWhenFrozen` - rejects frozen accounts
- [x] `TestPrepareForCreditWhenClosed` - rejects closed accounts
- [x] `TestPrepareForDebit` - validates new domain method
- [x] `TestPrepareForDebitInsufficientFunds` - rejects insufficient funds
- [x] `TestPrepareForDebitWhenFrozen` - rejects frozen accounts
- [x] `TestPrepareForDebitWhenClosed` - rejects closed accounts
- [x] `TestExecuteDeposit_WithOrchestration_Success` - full saga with Position Keeping mock
- [x] `TestExecuteWithdrawal_Success` - full saga with Position Keeping mock
- [x] `TestRetrieveCurrentAccount` - verifies balance comes from Position Keeping
- [x] Backward compatibility tests (no Position Keeping configured)

## Follow-up Tasks

| TM Task | Priority | Description |
|---------|----------|-------------|
| position-keeping-balance.10.5 | Medium | Add circuit breaker for Position Keeping unavailability |
| position-keeping-balance.10.6 | Low | Write integration and performance tests |

## Related

- Depends on: PR #556 (Task 9 - Refactor domain model to remove balance)
- Part of: Task 10 - Update Current Account Service Layer with Balance Delegation