### PR TITLE
fix: add protobuf generation to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,14 +67,15 @@ jobs:
         go-version: '1.25.5'
         cache: true
 
-    # Set up buf for protobuf generation
+    # Set up buf for protobuf generation (pinned version for reproducibility)
     - name: Set up buf
       if: matrix.language == 'go'
-      uses: bufbuild/buf-setup-action@v1
+      uses: bufbuild/buf-setup-action@v1.50.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
 
     # Generate protobuf files before CodeQL analysis
+    # Failure here should fail the workflow - proto packages are required for complete analysis
     - name: Generate protobuf files
       if: matrix.language == 'go'
       run: buf generate

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,6 +67,18 @@ jobs:
         go-version: '1.25.5'
         cache: true
 
+    # Set up buf for protobuf generation
+    - name: Set up buf
+      if: matrix.language == 'go'
+      uses: bufbuild/buf-setup-action@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+
+    # Generate protobuf files before CodeQL analysis
+    - name: Generate protobuf files
+      if: matrix.language == 'go'
+      run: buf generate
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4


### PR DESCRIPTION
## Summary

- Add buf setup and `buf generate` steps to CodeQL workflow before analysis

## Problem

CodeQL was reporting warnings about missing packages:
- `github.com/meridianhub/meridian/api/proto/meridian/audit/v1`
- `github.com/meridianhub/meridian/api/proto/meridian/tenant/v1`
- `github.com/meridianhub/meridian/api/proto/meridian/platform/v1`
- `github.com/meridianhub/meridian/api/proto/meridian/party/v1`
- `github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1`

These are protobuf-generated packages that aren't committed to the repo (gitignored). CodeQL's autobuild doesn't generate them, causing incomplete analysis.

## Solution

Added steps to generate protobuf files before CodeQL initialization:
1. Set up buf CLI
2. Run `buf generate` to create Go files from proto definitions

## Test plan

- [ ] CodeQL workflow runs without "packages not found" warnings
- [ ] Security scanning shows 100% Go files scanned (currently 51%)