### PR TITLE
docs: update architecture documentation for balance delegation to Position Keeping

### DIFF
--- a/docs/adr/0023-balance-delegation-to-position-keeping.md
+++ b/docs/adr/0023-balance-delegation-to-position-keeping.md
@@ -1,0 +1,189 @@
+---
+name: adr-023-balance-delegation-to-position-keeping
+description: Delegate balance computation from Current Account to Position Keeping service per BIAN
+triggers:
+  - Designing balance query patterns
+  - Understanding why Current Account doesn't store balance
+  - Implementing balance-related features
+  - Querying account balances (7 BIAN types)
+  - Understanding Position Keeping as balance authority
+instructions: |
+  Balance is NOT stored in Current Account. All balance queries delegate to Position Keeping
+  service via gRPC. Use GetAccountBalance for single type, GetAccountBalances for all 7 types.
+
+  Balance types: OPENING, CLOSING, CURRENT, AVAILABLE, LEDGER, RESERVE, FREE.
+
+  Pattern: positionKeepingClient.GetAccountBalances(ctx, accountID)
+---
+
+# 23. Balance Delegation to Position Keeping
+
+Date: 2026-01-08
+
+## Status
+
+Accepted
+
+## Context
+
+Current Account originally stored balance locally in the database with fields `balance`,
+`available_balance`, and `balance_updated_at`. This created several problems:
+
+1. **Dual-write complexity**: Every transaction required updating both Position Keeping
+   (transaction log) and Current Account (balance). This introduced synchronization risks.
+
+2. **Consistency challenges**: If Position Keeping succeeded but Current Account failed,
+   the balance could become inconsistent with the transaction history.
+
+3. **Single source of truth violation**: Position Keeping already has all the data needed
+   to compute balance (the transaction log). Storing balance separately duplicates this
+   responsibility.
+
+4. **BIAN alignment**: Per BIAN service domain principles, Position Keeping owns the
+   transaction log and is the authoritative source for position data, which includes balance.
+
+## Decision Drivers
+
+* BIAN compliance: Position Keeping is the authoritative domain for position/balance data
+* Eliminate dual-write complexity and synchronization bugs
+* Single source of truth for balance computation
+* Support for 7 BIAN balance types (not just current/available)
+* Simpler Current Account schema (account metadata only)
+
+## Considered Options
+
+1. Keep balance in Current Account with synchronization
+2. Delegate balance computation to Position Keeping (chosen)
+3. Event-sourced balance with eventual consistency
+
+## Decision Outcome
+
+Chosen option: "Delegate balance computation to Position Keeping", because it eliminates
+dual-write complexity, aligns with BIAN service boundaries, and establishes a single
+source of truth for balance data.
+
+### Positive Consequences
+
+* Single source of truth: Position Keeping computes balance from transaction log
+* Simplified Current Account: Only stores account metadata, not derived data
+* BIAN compliance: Follows BIAN service domain boundaries
+* Richer balance types: 7 BIAN balance types (OPENING, CLOSING, CURRENT, AVAILABLE, etc.)
+* Eliminated synchronization bugs: No more dual-write consistency issues
+* Cleaner migration: Opening balance support via Position Keeping initialization
+
+### Negative Consequences
+
+* Additional network hop: Balance queries require gRPC call to Position Keeping
+* Current Account depends on Position Keeping availability (mitigated with circuit breaker)
+* Potential latency increase for balance-heavy operations
+
+## Pros and Cons of the Options
+
+### Option 1: Keep balance in Current Account with synchronization
+
+Store balance locally in Current Account and synchronize with Position Keeping.
+
+* Good, because no network hop for balance queries
+* Good, because Current Account is self-contained
+* Bad, because dual-write complexity introduces synchronization bugs
+* Bad, because violates single source of truth principle
+* Bad, because limited to 2 balance types (current, available)
+* Bad, because Current Account must understand balance computation logic
+
+### Option 2: Delegate balance computation to Position Keeping (chosen)
+
+Remove balance storage from Current Account. Position Keeping computes balance on-demand
+from the transaction log.
+
+* Good, because single source of truth (transaction log = balance)
+* Good, because eliminates dual-write synchronization issues
+* Good, because BIAN-compliant service boundaries
+* Good, because supports 7 balance types
+* Good, because Current Account schema is simpler
+* Bad, because requires network call for balance queries
+* Bad, because Current Account depends on Position Keeping availability
+
+### Option 3: Event-sourced balance with eventual consistency
+
+Publish balance change events from Position Keeping, consume in Current Account for caching.
+
+* Good, because Current Account has locally cached balance
+* Good, because eventually consistent without dual-write
+* Bad, because added complexity of event consumption and cache invalidation
+* Bad, because balance may be stale (eventual consistency window)
+* Bad, because still duplicates balance data
+
+## Implementation Notes
+
+### Database Migration
+
+Balance columns removed in `20260108000001_remove_balance_columns.sql`:
+
+```sql
+ALTER TABLE "account" DROP COLUMN IF EXISTS "balance";
+ALTER TABLE "account" DROP COLUMN IF EXISTS "available_balance";
+ALTER TABLE "account" DROP COLUMN IF EXISTS "balance_updated_at";
+```
+
+### Position Keeping Balance APIs
+
+New gRPC methods in Position Keeping:
+
+| Method | Purpose |
+|--------|---------|
+| `GetAccountBalance` | Query single balance type |
+| `GetAccountBalances` | Query all 7 balance types |
+
+### Balance Types
+
+| Type | Description |
+|------|-------------|
+| `BALANCE_TYPE_OPENING` | Balance at start of accounting period |
+| `BALANCE_TYPE_CLOSING` | Balance at end of accounting period |
+| `BALANCE_TYPE_CURRENT` | Real-time balance (sum of POSTED transactions) |
+| `BALANCE_TYPE_AVAILABLE` | Available for withdrawal (current - holds - reserves) |
+| `BALANCE_TYPE_LEDGER` | Book balance |
+| `BALANCE_TYPE_RESERVE` | Amount held in reserve |
+| `BALANCE_TYPE_FREE` | Unencumbered balance |
+
+### Usage Pattern
+
+```go
+// Current Account querying balance from Position Keeping
+balances, err := positionKeepingClient.GetAccountBalances(ctx, &pk.GetAccountBalancesRequest{
+    AccountId: accountID,
+})
+if err != nil {
+    return err // Circuit breaker handles transient failures
+}
+
+// Access specific balance type
+for _, b := range balances.Balances {
+    if b.BalanceType == pk.BALANCE_TYPE_AVAILABLE {
+        availableBalance = b.Amount
+    }
+}
+```
+
+### Resilience Patterns
+
+* Circuit breaker on Position Keeping client (3 retries, exponential backoff)
+* Graceful degradation when Position Keeping unavailable
+* Optional balance caching for read-heavy workloads (future optimization)
+
+## Links
+
+* [ADR-0002: Microservices Per BIAN Domain](0002-microservices-per-bian-domain.md)
+* [ADR-0019: Resilient Client Patterns](0019-resilient-client-patterns.md)
+* [BIAN Service Boundaries](../architecture/bian-service-boundaries.md)
+* [Position Keeping README](../../services/position-keeping/README.md)
+* [Current Account README](../../services/current-account/README.md)
+
+## Notes
+
+**Future Considerations:**
+
+* If balance query latency becomes a bottleneck, consider materialized balance snapshots
+  in Position Keeping (not in Current Account)
+* Balance change events from Position Keeping could enable downstream caching
+* Opening balance support enables account migration scenarios

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,6 +60,13 @@ Architectural Decision Records) format.
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0017](0017-temporal-quality-ladder.md) | Temporal Quality Ledger (Data Physics) | Proposed | 2025-12-14 |
 | [ADR-0018](0018-settlement-reconciliation.md) | Settlement & Reconciliation (Lifecycle) | Proposed | 2025-12-14 |
+| [ADR-0019](0019-resilient-client-patterns.md) | Resilient Client Patterns | Accepted | 2025-12-18 |
+| [ADR-0020](0020-per-service-audit-workers.md) | Per-Service Audit Workers | Accepted | 2025-12-20 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0021](0021-kyc-aml-verification-provider-architecture.md) | KYC/AML Verification Provider Architecture | Proposed | 2025-12-22 |
+| [ADR-0022](0022-instrument-successor-lineage.md) | Instrument Successor Lineage | Proposed | 2025-12-28 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0023](0023-balance-delegation-to-position-keeping.md) | Balance Delegation to Position Keeping | Accepted | 2026-01-08 |
 
 ## Categories
 
@@ -80,6 +87,7 @@ Architectural Decision Records) format.
 - [ADR-0014](0014-financial-instrument-reference-data.md) - Financial Instrument Reference Data (BIAN)
 - [ADR-0017](0017-temporal-quality-ladder.md) - Temporal Quality Ledger (Data Physics)
 - [ADR-0018](0018-settlement-reconciliation.md) - Settlement & Reconciliation (Lifecycle)
+- [ADR-0023](0023-balance-delegation-to-position-keeping.md) - Balance Delegation to Position Keeping
 
 ### Development Environment & Infrastructure
 

--- a/docs/architecture/api-contracts/current-account-contract.md
+++ b/docs/architecture/api-contracts/current-account-contract.md
@@ -644,6 +644,8 @@ These invariants MUST hold at all times across all operations:
 
 1. **Balance Constraint**: `current_balance >= -overdraft_limit` (if overdraft enabled) OR `current_balance >= 0` (if overdraft disabled)
 2. **Available Balance**: `available_balance = current_balance + (overdraft_enabled ? overdraft_limit : 0) - active_liens`
+   > `active_liens` are fund holds created via `InitiateLien` operations (see [Lien Lifecycle](../../services/current-account/README.md#lien-lifecycle)).
+   > Only liens with status `ACTIVE` reduce available balance; `EXECUTED` and `TERMINATED` liens do not.
 3. **Balance Source**: Balance is queried from PositionKeeping via `GetAccountBalances` RPC (7 BIAN types)
 4. **Zero Balance Closure**: Account can only transition to CLOSED if `current_balance == 0`
 

--- a/docs/architecture/api-contracts/current-account-contract.md
+++ b/docs/architecture/api-contracts/current-account-contract.md
@@ -1,7 +1,7 @@
 # CurrentAccount Service Behavioral API Contract
 
-**Document Version:** 1.0
-**Last Updated:** 2025-11-19
+**Document Version:** 1.1
+**Last Updated:** 2026-01-08
 **Status:** Active
 **BIAN Domain:** Current Account (Service Domain)
 **Proto Definition:** `api/proto/meridian/current_account/v1/current_account.proto`
@@ -9,6 +9,7 @@
 
 - [BIAN Service Boundaries](../bian-service-boundaries.md)
 - [Service Coupling Analysis](../service-coupling-analysis.md)
+- [ADR-0023: Balance Delegation to Position Keeping](../adr/0023-balance-delegation-to-position-keeping.md)
 
 ## Overview
 
@@ -24,9 +25,13 @@ The CurrentAccount service implements the BIAN Current Account service domain, m
 
 **Architectural Pattern:** Orchestration Layer (Instability I=1.00)
 
-- Depends on: PositionKeeping (balance queries), FinancialAccounting (ledger postings)
+- Depends on: PositionKeeping (balance queries via `GetAccountBalances`), FinancialAccounting (ledger postings)
 - No dependents: Client-facing service with no upstream consumers
 - High instability is expected and appropriate for this orchestration role
+
+**Balance Delegation (ADR-0023):** Balance is NOT stored in Current Account. All balance queries
+delegate to Position Keeping service which computes 7 BIAN balance types (OPENING, CLOSING,
+CURRENT, AVAILABLE, LEDGER, RESERVE, FREE) from the transaction log.
 
 ## State Machine
 
@@ -634,9 +639,12 @@ These invariants MUST hold at all times across all operations:
 
 ### Balance Invariants
 
+> **Note:** Balance is computed by Position Keeping service (ADR-0023). Current Account does NOT
+> store balance locally. These invariants are enforced by Position Keeping's balance computation.
+
 1. **Balance Constraint**: `current_balance >= -overdraft_limit` (if overdraft enabled) OR `current_balance >= 0` (if overdraft disabled)
-2. **Available Balance**: `available_balance = current_balance + (overdraft_enabled ? overdraft_limit : 0)`
-3. **Balance Consistency**: current_balance equals sum of all POSTED transactions from PositionKeeping
+2. **Available Balance**: `available_balance = current_balance + (overdraft_enabled ? overdraft_limit : 0) - active_liens`
+3. **Balance Source**: Balance is queried from PositionKeeping via `GetAccountBalances` RPC (7 BIAN types)
 4. **Zero Balance Closure**: Account can only transition to CLOSED if `current_balance == 0`
 
 ### Transaction Invariants
@@ -781,6 +789,65 @@ Compensation operations are idempotent:
    - Payment status tracking
    - Payment cancellation support
 
+## Balance Query Delegation
+
+Per ADR-0023, Current Account delegates all balance queries to Position Keeping service.
+
+### Balance Query Pattern
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant CA as CurrentAccount
+    participant PK as PositionKeeping
+
+    Client->>CA: RetrieveCurrentAccount(accountID)
+    CA->>PK: GetAccountBalances(accountID)
+    PK->>PK: Compute from transaction log
+    PK-->>CA: BalanceEntry[] (7 types)
+    CA-->>Client: CurrentAccountFacility with balances
+```
+
+### BIAN Balance Types
+
+Position Keeping computes 7 BIAN-compliant balance types:
+
+| Balance Type | Description | Use Case |
+|--------------|-------------|----------|
+| `OPENING` | Balance at period start | Reconciliation, statements |
+| `CLOSING` | Balance at period end | Reconciliation, statements |
+| `CURRENT` | Real-time posted balance | Account display |
+| `AVAILABLE` | Available for withdrawal | Transaction validation |
+| `LEDGER` | Book balance | Accounting |
+| `RESERVE` | Held in reserve | Regulatory holds |
+| `FREE` | Unencumbered balance | Withdrawal limit |
+
+### Balance Query Implementation
+
+Current Account queries Position Keeping on every `RetrieveCurrentAccount` call:
+
+```go
+// Inside RetrieveCurrentAccount handler
+balances, err := s.positionKeepingClient.GetAccountBalances(ctx, &pk.GetAccountBalancesRequest{
+    AccountId: req.AccountId,
+})
+if err != nil {
+    // Circuit breaker handles transient failures
+    return nil, status.Error(codes.Unavailable, "Position Keeping unavailable")
+}
+
+// Map balances to response
+facility.CurrentBalance = mapBalancesToResponse(balances)
+```
+
+### Error Handling for Balance Queries
+
+| Error | Handling | Client Behavior |
+|-------|----------|-----------------|
+| Position Keeping unavailable | Circuit breaker, return UNAVAILABLE | Retry with backoff |
+| Timeout | Return DEADLINE_EXCEEDED | Retry with longer timeout |
+| Account not found in PK | Return balance as zero | Normal (new account) |
+
 ## Related Documentation
 
 - **Proto Schema**: `api/proto/meridian/current_account/v1/current_account.proto`
@@ -790,4 +857,5 @@ Compensation operations are idempotent:
 - **Financial Accounting Contract**: `docs/architecture/api-contracts/financial-accounting-contract.md`
 - **ADR-0002**: Microservices Per BIAN Domain
 - **ADR-0005**: Adapter Pattern Layer Translation
+- **ADR-0023**: Balance Delegation to Position Keeping
 - **BIAN Reference**: Current Account Service Domain (Release 13.0)

--- a/docs/architecture/api-contracts/position-keeping-contract.md
+++ b/docs/architecture/api-contracts/position-keeping-contract.md
@@ -1,7 +1,7 @@
 # PositionKeeping Service Behavioral API Contract
 
-**Document Version:** 1.0
-**Last Updated:** 2025-11-19
+**Document Version:** 1.1
+**Last Updated:** 2026-01-08
 **Status:** Active
 **BIAN Domain:** Position Keeping (Service Domain)
 **Proto Definition:** `api/proto/meridian/position_keeping/v1/position_keeping.proto`
@@ -10,6 +10,7 @@
 
 - [BIAN Service Boundaries](../bian-service-boundaries.md)
 - [Service Coupling Analysis](../service-coupling-analysis.md)
+- [ADR-0023: Balance Delegation to Position Keeping](../adr/0023-balance-delegation-to-position-keeping.md)
 
 ## Overview
 
@@ -24,6 +25,7 @@ The PositionKeeping service implements the BIAN Position Keeping service domain,
 - Position snapshot generation and reporting
 - Bulk transaction import (up to 1,000 entries per batch)
 - Event publishing for downstream consumers
+- **Balance computation** (authoritative source for all 7 BIAN balance types - see ADR-0023)
 
 **Architectural Pattern:** Stable Provider Service (Instability I=0.00)
 
@@ -1294,6 +1296,245 @@ The PositionKeeping service publishes events to Kafka for downstream consumers (
 
 Defined in `api/proto/meridian/events/v1/position_keeping_events.proto`.
 
+## Balance Query APIs
+
+Position Keeping is the authoritative source for balance computation (ADR-0023). Balance is
+computed on-demand from POSTED transaction entries.
+
+### GetAccountBalance
+
+Retrieves a single balance type for an account.
+
+**Proto Definition:**
+
+```protobuf
+rpc GetAccountBalance(GetAccountBalanceRequest) returns (GetAccountBalanceResponse);
+
+message GetAccountBalanceRequest {
+  string account_id = 1;                          // Account to query (required)
+  BalanceType balance_type = 2;                   // Balance type to retrieve (required)
+  string currency = 3;                            // Currency filter (optional)
+}
+
+message GetAccountBalanceResponse {
+  string account_id = 1;                          // Account queried
+  BalanceType balance_type = 2;                   // Balance type returned
+  meridian.common.v1.MoneyAmount amount = 3;      // Balance amount
+  google.protobuf.Timestamp as_of = 4;            // Timestamp of computation
+}
+```
+
+**Behavioral Semantics:**
+
+This operation computes the requested balance type from POSTED transaction entries.
+
+**Preconditions:**
+
+- `account_id` must be non-empty (1-255 chars)
+- `balance_type` must be defined enum value (not UNSPECIFIED)
+- If `currency` provided, must be valid currency code
+
+**Postconditions:**
+
+- Returns computed balance for requested type
+- `as_of` reflects timestamp of computation
+- No state changes (read-only)
+
+**Balance Types:**
+
+| Balance Type | Proto Enum | Computation |
+|--------------|------------|-------------|
+| Opening | `BALANCE_TYPE_OPENING` | Balance at start of accounting period |
+| Closing | `BALANCE_TYPE_CLOSING` | Balance at end of accounting period |
+| Current | `BALANCE_TYPE_CURRENT` | Sum of all POSTED transactions |
+| Available | `BALANCE_TYPE_AVAILABLE` | Current minus holds, liens, reserves |
+| Ledger | `BALANCE_TYPE_LEDGER` | Book balance |
+| Reserve | `BALANCE_TYPE_RESERVE` | Amount held in reserve |
+| Free | `BALANCE_TYPE_FREE` | Unencumbered balance |
+
+**Error Handling:**
+
+| Error Code | Condition | Response | Retry Strategy |
+|------------|-----------|----------|----------------|
+| `INVALID_ARGUMENT` | Missing account_id | Details indicate field | Do not retry |
+| `INVALID_ARGUMENT` | Invalid balance_type | Details show valid types | Do not retry |
+| `NOT_FOUND` | Account has no transactions | Returns zero balance | Normal (new account) |
+| `DEADLINE_EXCEEDED` | Computation timeout | Timeout duration | Retry with backoff |
+| `INTERNAL` | Database failure | Stack trace in logs | Retry with backoff |
+
+**Idempotency:**
+
+Fully idempotent. Read-only operation with no side effects.
+
+**Examples:**
+
+```json
+// Query available balance
+Request: {
+  "account_id": "acc-550e8400-e29b-41d4-a716-446655440000",
+  "balance_type": "BALANCE_TYPE_AVAILABLE",
+  "currency": "GBP"
+}
+
+Response: {
+  "account_id": "acc-550e8400-e29b-41d4-a716-446655440000",
+  "balance_type": "BALANCE_TYPE_AVAILABLE",
+  "amount": {
+    "currency_code": "GBP",
+    "units": 1500,
+    "nanos": 500000000
+  },
+  "as_of": "2026-01-08T14:30:00Z"
+}
+```
+
+---
+
+### GetAccountBalances
+
+Retrieves all balance types for an account in a single call.
+
+**Proto Definition:**
+
+```protobuf
+rpc GetAccountBalances(GetAccountBalancesRequest) returns (GetAccountBalancesResponse);
+
+message GetAccountBalancesRequest {
+  string account_id = 1;                          // Account to query (required)
+  string currency = 2;                            // Currency filter (optional)
+}
+
+message GetAccountBalancesResponse {
+  string account_id = 1;                          // Account queried
+  repeated BalanceEntry balances = 2;             // All balance types
+  google.protobuf.Timestamp as_of = 3;            // Timestamp of computation
+}
+
+message BalanceEntry {
+  BalanceType balance_type = 1;
+  meridian.common.v1.MoneyAmount amount = 2;
+}
+```
+
+**Behavioral Semantics:**
+
+This operation computes all 7 balance types in a single pass over POSTED transactions.
+More efficient than calling `GetAccountBalance` 7 times.
+
+**Preconditions:**
+
+- `account_id` must be non-empty (1-255 chars)
+- If `currency` provided, must be valid currency code
+
+**Postconditions:**
+
+- Returns 7 balance entries (one per balance type)
+- All balances computed from same transaction snapshot
+- `as_of` reflects timestamp of computation
+- No state changes (read-only)
+
+**Performance:**
+
+- Single query: O(n) where n = number of POSTED transactions
+- All 7 balance types computed in single pass
+- More efficient than 7 individual `GetAccountBalance` calls
+
+**Error Handling:**
+
+| Error Code | Condition | Response | Retry Strategy |
+|------------|-----------|----------|----------------|
+| `INVALID_ARGUMENT` | Missing account_id | Details indicate field | Do not retry |
+| `NOT_FOUND` | Account has no transactions | Returns zero for all types | Normal (new account) |
+| `DEADLINE_EXCEEDED` | Computation timeout | Timeout duration | Retry with backoff |
+| `INTERNAL` | Database failure | Stack trace in logs | Retry with backoff |
+
+**Idempotency:**
+
+Fully idempotent. Read-only operation with no side effects.
+
+**Examples:**
+
+```json
+// Query all balances
+Request: {
+  "account_id": "acc-550e8400-e29b-41d4-a716-446655440000",
+  "currency": "GBP"
+}
+
+Response: {
+  "account_id": "acc-550e8400-e29b-41d4-a716-446655440000",
+  "balances": [
+    {
+      "balance_type": "BALANCE_TYPE_OPENING",
+      "amount": { "currency_code": "GBP", "units": 10000, "nanos": 0 }
+    },
+    {
+      "balance_type": "BALANCE_TYPE_CLOSING",
+      "amount": { "currency_code": "GBP", "units": 15000, "nanos": 0 }
+    },
+    {
+      "balance_type": "BALANCE_TYPE_CURRENT",
+      "amount": { "currency_code": "GBP", "units": 15500, "nanos": 500000000 }
+    },
+    {
+      "balance_type": "BALANCE_TYPE_AVAILABLE",
+      "amount": { "currency_code": "GBP", "units": 14000, "nanos": 0 }
+    },
+    {
+      "balance_type": "BALANCE_TYPE_LEDGER",
+      "amount": { "currency_code": "GBP", "units": 15500, "nanos": 500000000 }
+    },
+    {
+      "balance_type": "BALANCE_TYPE_RESERVE",
+      "amount": { "currency_code": "GBP", "units": 500, "nanos": 0 }
+    },
+    {
+      "balance_type": "BALANCE_TYPE_FREE",
+      "amount": { "currency_code": "GBP", "units": 14000, "nanos": 0 }
+    }
+  ],
+  "as_of": "2026-01-08T14:30:00Z"
+}
+```
+
+---
+
+### Balance Computation Semantics
+
+Balance is computed on-demand from POSTED transactions:
+
+```text
+CURRENT   = Σ(POSTED transactions: credits - debits)
+AVAILABLE = CURRENT - RESERVE - ACTIVE_LIENS
+LEDGER    = CURRENT (excluding pending transactions)
+FREE      = CURRENT - RESERVE - HOLDS
+OPENING   = Balance at accounting period start
+CLOSING   = Balance at accounting period end
+```
+
+### Balance Query Architecture
+
+```mermaid
+sequenceDiagram
+    participant CA as CurrentAccount
+    participant PK as PositionKeeping
+    participant DB as PositionKeeping DB
+
+    CA->>PK: GetAccountBalances(accountID)
+    PK->>DB: SELECT entries WHERE status=POSTED
+    DB-->>PK: Transaction entries
+    PK->>PK: Compute all balance types
+    PK-->>CA: BalanceEntry[] (7 types)
+```
+
+### Performance Optimization
+
+For high-traffic accounts, consider:
+
+- **Balance snapshots**: Periodic materialized balance at EOD
+- **Caching**: Short-lived cache (TTL 1-5 seconds) for read-heavy workloads
+- **Async computation**: Background balance computation for non-critical queries
+
 ## Future Enhancements
 
 ### Planned Features
@@ -1305,6 +1546,7 @@ Defined in `api/proto/meridian/events/v1/position_keeping_events.proto`.
 5. **Archival**: Automatic archival of old logs (> 1 year)
 6. **Lineage API**: Dedicated RPC for lineage traversal queries
 7. **Aggregate Queries**: Sum/count operations across logs
+8. **Balance Snapshots**: Materialized balance views for high-traffic accounts
 
 ## Related Documentation
 
@@ -1316,4 +1558,5 @@ Defined in `api/proto/meridian/events/v1/position_keeping_events.proto`.
 - **Financial Accounting Contract**: `docs/architecture/api-contracts/financial-accounting-contract.md`
 - **ADR-0002**: Microservices Per BIAN Domain
 - **ADR-0004**: Event Schema Evolution
+- **ADR-0023**: Balance Delegation to Position Keeping
 - **BIAN Reference**: Position Keeping Service Domain (Release 13.0)

--- a/docs/architecture/bian-service-boundaries.md
+++ b/docs/architecture/bian-service-boundaries.md
@@ -135,7 +135,10 @@ The CurrentAccount service owns:
 
 **Position-Keeping Service (gRPC Client):**
 
-- Balance queries for account operations
+- **Balance queries** via `GetAccountBalance` and `GetAccountBalances` RPCs
+  - Returns 7 BIAN balance types: OPENING, CLOSING, CURRENT, AVAILABLE, LEDGER, RESERVE, FREE
+  - Balance is computed by Position Keeping, not stored in Current Account
+  - See [ADR-0023](../adr/0023-balance-delegation-to-position-keeping.md)
 - Transaction log retrieval for account history
 - Position snapshot data for reconciliation
 - **Implementation:** `services/current-account/client/positionkeeping_client.go`
@@ -165,9 +168,10 @@ The CurrentAccount service owns:
 
 **Forbidden Operations:**
 
-1. **Direct balance manipulation** - Balances are owned by position-keeping service
-   - MUST call `PositionKeepingService.UpdateFinancialPositionLog` instead
-   - MUST NOT store balance state except in read-only cache
+1. **Direct balance storage or computation** - Balances are owned by Position Keeping service
+   - MUST call `PositionKeepingService.GetAccountBalance` or `GetAccountBalances` for balance queries
+   - MUST NOT store balance in database (balance columns removed per ADR-0023)
+   - MUST NOT compute balance from local transaction data
 
 2. **Direct ledger posting** - Double-entry bookkeeping is owned by financial-accounting service
    - MUST call `FinancialAccountingService.CaptureLedgerPosting` instead
@@ -309,6 +313,22 @@ The PositionKeeping service owns:
   - Point-in-time account positions
   - Reconciliation support
   - Audit trail queries
+
+#### Balance Computation (Authoritative Source)
+
+- **Balance calculation** - Position Keeping is the authoritative source for all balance types
+  - Computes 7 BIAN balance types: OPENING, CLOSING, CURRENT, AVAILABLE, LEDGER, RESERVE, FREE
+  - Balance derived from POSTED transaction log entries
+  - See [ADR-0023](../adr/0023-balance-delegation-to-position-keeping.md)
+
+- **Balance query APIs** (`GetAccountBalance`, `GetAccountBalances` RPCs)
+  - `GetAccountBalance` - Query single balance type for an account
+  - `GetAccountBalances` - Query all 7 balance types for an account
+  - Returns `as_of` timestamp indicating when balance was calculated
+
+- **Opening balance support** for account migration
+  - Initialize accounts with opening balance via synthetic transaction entry
+  - Supports migration from legacy systems
 
 ### Boundaries
 

--- a/services/current-account/README.md
+++ b/services/current-account/README.md
@@ -9,18 +9,25 @@ triggers:
   - Integration with payment order saga patterns
   - Transaction logging and position keeping
   - Financial accounting and ledger posting
-  - Account balance validation and reconciliation
+  - Account balance queries (delegated to Position Keeping)
 instructions: |
   CurrentAccount orchestrates customer-facing banking operations with three upstream dependencies:
   - Party (validate customer exists and is active)
-  - PositionKeeping (transaction audit trail)
+  - PositionKeeping (balance queries and transaction audit trail)
   - FinancialAccounting (double-entry ledger posting)
 
   Key patterns:
+  - Balance delegation: All balance queries use Position Keeping service (not stored locally)
   - Lien-based fund reservation for payment processing (ACTIVE → EXECUTED or TERMINATED)
-  - Overdraft facility: AvailableBalance = Balance + (OverdraftEnabled ? OverdraftLimit : 0)
   - Account lifecycle: ACTIVE → FROZEN → CLOSED (state machine)
   - Optimistic locking via version field for concurrent updates
+
+  Balance Query Pattern:
+  ```go
+  // Query all balance types from Position Keeping
+  balances, err := positionKeepingClient.GetAccountBalances(ctx, accountID)
+  // Returns: OPENING, CLOSING, CURRENT, AVAILABLE, LEDGER, RESERVE, FREE
+  ```
 
   Port: 50057 (gRPC)
 ---
@@ -67,8 +74,6 @@ classDiagram
         +string AccountID
         +string AccountIdentification
         +UUID PartyID
-        +Money Balance
-        +Money AvailableBalance
         +AccountStatus Status
         +Money OverdraftLimit
         +bool OverdraftEnabled
@@ -109,6 +114,8 @@ classDiagram
 - `AccountID`: Business ID format `ACC-{uuid[:8]}`
 - `AccountIdentification`: IBAN format
 - `PaymentOrderReference`: Idempotency key for payment orders
+- **Balance fields removed**: Balance is computed by Position Keeping service (see
+  [Balance Query Delegation](#balance-query-delegation))
 
 ## Lien Lifecycle
 
@@ -145,8 +152,6 @@ erDiagram
         varchar(100) account_id UK "ACC-xxxxxxxx"
         varchar(34) account_identification UK "IBAN"
         uuid party_id FK
-        bigint balance "cents"
-        bigint available_balance "cents"
         varchar(20) status "ACTIVE, FROZEN, CLOSED"
         bigint overdraft_limit "cents"
         bigint version "optimistic lock"
@@ -163,6 +168,10 @@ erDiagram
 
     accounts ||--o{ liens : "has"
 ```
+
+> **Note:** Balance columns (`balance`, `available_balance`, `balance_updated_at`) were removed
+> in migration `20260108000001_remove_balance_columns.sql`. Balance is now computed by Position
+> Keeping service.
 
 ## Configuration
 
@@ -197,10 +206,64 @@ erDiagram
 
 - `InitiateCurrentAccount`: Creating duplicate accounts requires unique party/IBAN
 
+### Balance Query Delegation
+
+Balance is computed by Position Keeping service, not stored locally. Current Account queries
+Position Keeping for all balance operations.
+
+**Balance Types (BIAN-compliant):**
+
+| Type | Description |
+|------|-------------|
+| `OPENING` | Balance at start of accounting period |
+| `CLOSING` | Balance at end of accounting period |
+| `CURRENT` | Real-time balance including all posted transactions |
+| `AVAILABLE` | Balance available for withdrawal (considers holds/liens) |
+| `LEDGER` | Balance on the books (may differ from current due to holds) |
+| `RESERVE` | Amount held in reserve (not available for use) |
+| `FREE` | Unencumbered balance (current minus holds and reserves) |
+
+**Query Pattern:**
+
+```go
+import pk "meridian/position_keeping/v1"
+
+// Query single balance type
+resp, err := pkClient.GetAccountBalance(ctx, &pk.GetAccountBalanceRequest{
+    AccountId:   accountID,
+    BalanceType: pk.BALANCE_TYPE_AVAILABLE,
+})
+
+// Query all balance types
+resp, err := pkClient.GetAccountBalances(ctx, &pk.GetAccountBalancesRequest{
+    AccountId: accountID,
+})
+for _, balance := range resp.Balances {
+    log.Printf("%s: %v", balance.BalanceType, balance.Amount)
+}
+```
+
+**Sequence Diagram:**
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant CA as CurrentAccount
+    participant PK as PositionKeeping
+
+    Client->>CA: RetrieveCurrentAccount(accountID)
+    CA->>PK: GetAccountBalances(accountID)
+    PK-->>CA: BalanceEntry[] (7 types)
+    CA-->>Client: CurrentAccountFacility with balances
+```
+
 ### Overdraft Facility
 
+Overdraft configuration is stored in Current Account. When calculating available balance,
+Position Keeping considers the overdraft limit.
+
 ```text
-AvailableBalance = Balance + (OverdraftEnabled ? OverdraftLimit : 0)
+AvailableBalance = CurrentBalance + (OverdraftEnabled ? OverdraftLimit : 0) - ActiveLiens
 ```
 
 Allows withdrawals beyond zero balance up to the configured limit.

--- a/services/position-keeping/README.md
+++ b/services/position-keeping/README.md
@@ -1,6 +1,6 @@
 ---
 name: position-keeping-service
-description: BIAN transaction log for immutable financial transaction history and position tracking
+description: BIAN transaction log for immutable financial transaction history, position tracking, and balance computation
 triggers:
   - Designing transaction capture and position keeping systems
   - Implementing financial audit trails and reconciliation workflows
@@ -8,14 +8,24 @@ triggers:
   - Building event-driven transaction systems
   - Understanding capacity limits and state machines for financial data
   - Handling optimistic concurrency control in transactional systems
+  - Querying account balances (7 BIAN balance types)
+  - Understanding balance computation responsibility
 instructions: |
-  PositionKeeping maintains immutable transaction history with comprehensive audit trails.
+  PositionKeeping maintains immutable transaction history with comprehensive audit trails
+  and serves as the authoritative source for balance computation.
 
   Key concepts:
   - FinancialPositionLog: Aggregate root with 10,000 entry limit
   - Transaction state machine: PENDING → RECONCILED → POSTED → REVERSED
   - Parent-child lineage for reversals and amendments
   - Kafka event publishing (fire-and-forget) for downstream consumers
+  - Balance ownership: Computes all 7 BIAN balance types (see Balance Calculation section)
+
+  Balance Query APIs:
+  - GetAccountBalance: Query single balance type
+  - GetAccountBalances: Query all 7 balance types for an account
+
+  Balance Types: OPENING, CLOSING, CURRENT, AVAILABLE, LEDGER, RESERVE, FREE
 
   Capacity limits:
   - MaxTransactionEntries: 10,000 per log
@@ -42,6 +52,8 @@ BIAN-compliant position keeping service for immutable financial transaction hist
 
 ## gRPC Methods
 
+### Position Log Operations
+
 | Method | HTTP | Purpose |
 |--------|------|---------|
 | `InitiateFinancialPositionLog` | `POST /v1/position-logs` | Create log with initial transaction |
@@ -49,6 +61,13 @@ BIAN-compliant position keeping service for immutable financial transaction hist
 | `ListFinancialPositionLogs` | `GET /v1/position-logs` | List with filters |
 | `UpdateFinancialPositionLog` | `PATCH /v1/position-logs/{id}` | State transitions |
 | `BulkImportTransactions` | `POST /v1/position-logs/bulk` | Batch import |
+
+### Balance Query Operations
+
+| Method | HTTP | Purpose |
+|--------|------|---------|
+| `GetAccountBalance` | `GET /v1/accounts/{account_id}/balance/{balance_type}` | Query single balance type |
+| `GetAccountBalances` | `GET /v1/accounts/{account_id}/balances` | Query all balance types |
 
 ## Domain Model
 
@@ -298,8 +317,127 @@ Version field required for all updates. Returns conflict error on mismatch.
 
 POSTED logs cannot be modified. Returns `ErrAlreadyPosted`.
 
+## Balance Calculation Responsibility
+
+Position Keeping is the authoritative source for account balance computation. This design
+follows BIAN service domain principles where Position Keeping owns the transaction log and
+therefore has the data required to compute accurate balances.
+
+### Balance Types (BIAN-Compliant)
+
+Position Keeping computes 7 balance types per account:
+
+| Balance Type | Proto Enum | Computation |
+|--------------|------------|-------------|
+| **Opening** | `BALANCE_TYPE_OPENING` | Balance at start of accounting period |
+| **Closing** | `BALANCE_TYPE_CLOSING` | Balance at end of accounting period |
+| **Current** | `BALANCE_TYPE_CURRENT` | Sum of all POSTED transactions (real-time) |
+| **Available** | `BALANCE_TYPE_AVAILABLE` | Current minus holds, liens, and reserves |
+| **Ledger** | `BALANCE_TYPE_LEDGER` | Book balance (may differ from current due to holds) |
+| **Reserve** | `BALANCE_TYPE_RESERVE` | Amount held in reserve (not available for use) |
+| **Free** | `BALANCE_TYPE_FREE` | Unencumbered balance (current minus all encumbrances) |
+
+### Balance Calculation Formulas
+
+```text
+CURRENT   = Σ(POSTED transactions: credits - debits)
+AVAILABLE = CURRENT - RESERVE - ACTIVE_LIENS
+LEDGER    = CURRENT (excluding pending transactions)
+FREE      = CURRENT - RESERVE - HOLDS
+```
+
+### Balance Query APIs
+
+**GetAccountBalance** - Query a single balance type:
+
+```go
+// Request
+req := &pk.GetAccountBalanceRequest{
+    AccountId:   "ACC-12345678",
+    BalanceType: pk.BALANCE_TYPE_AVAILABLE,
+    Currency:    "GBP",  // Optional: filter by currency
+}
+
+// Response
+resp := &pk.GetAccountBalanceResponse{
+    AccountId:   "ACC-12345678",
+    BalanceType: pk.BALANCE_TYPE_AVAILABLE,
+    Amount:      &common.MoneyAmount{Units: 1500, Nanos: 0, CurrencyCode: "GBP"},
+    AsOf:        timestamppb.Now(),
+}
+```
+
+**GetAccountBalances** - Query all balance types:
+
+```go
+// Request
+req := &pk.GetAccountBalancesRequest{
+    AccountId: "ACC-12345678",
+    Currency:  "GBP",  // Optional
+}
+
+// Response contains all 7 balance types
+resp := &pk.GetAccountBalancesResponse{
+    AccountId: "ACC-12345678",
+    Balances: []*pk.BalanceEntry{
+        {BalanceType: pk.BALANCE_TYPE_OPENING, Amount: ...},
+        {BalanceType: pk.BALANCE_TYPE_CLOSING, Amount: ...},
+        {BalanceType: pk.BALANCE_TYPE_CURRENT, Amount: ...},
+        {BalanceType: pk.BALANCE_TYPE_AVAILABLE, Amount: ...},
+        {BalanceType: pk.BALANCE_TYPE_LEDGER, Amount: ...},
+        {BalanceType: pk.BALANCE_TYPE_RESERVE, Amount: ...},
+        {BalanceType: pk.BALANCE_TYPE_FREE, Amount: ...},
+    },
+    AsOf: timestamppb.Now(),
+}
+```
+
+### Balance Query Sequence
+
+```mermaid
+sequenceDiagram
+    participant CA as CurrentAccount
+    participant PK as PositionKeeping
+    participant DB as PositionKeeping DB
+
+    CA->>PK: GetAccountBalances(accountID)
+    PK->>DB: Query POSTED transactions
+    DB-->>PK: Transaction entries
+    PK->>PK: Compute balance types
+    PK-->>CA: BalanceEntry[] (7 types)
+```
+
+### Performance Characteristics
+
+| Operation | Complexity | Notes |
+|-----------|------------|-------|
+| `GetAccountBalance` | O(n) | Aggregates over POSTED transactions |
+| `GetAccountBalances` | O(n) | Single pass computes all types |
+
+**Optimization:** Balance snapshots may be cached or materialized for high-traffic accounts.
+
+### Opening Balance Support
+
+For account migration scenarios, Position Keeping supports initializing accounts with an
+opening balance:
+
+```go
+// InitiateWithOpeningBalance creates a position log with a synthetic
+// opening balance transaction for migration purposes
+req := &pk.InitiateFinancialPositionLogRequest{
+    AccountId: "ACC-12345678",
+    OpeningBalance: &common.MoneyAmount{
+        Units:        10000,
+        CurrencyCode: "GBP",
+    },
+}
+```
+
+This creates an initial transaction entry that establishes the account's starting position.
+
 ## References
 
 - [BIAN Position Keeping Specification](https://github.com/bian-official/public/blob/main/release13.0.0/semantic-apis/oas3/yamls/PositionKeeping.yaml)
 - [Service Architecture](../README.md)
 - [Proto Definitions](../../api/proto/meridian/position_keeping/v1/)
+- [ADR-0023: Balance Delegation to Position Keeping](../../docs/adr/0023-balance-delegation-to-position-keeping.md)


### PR DESCRIPTION
## Summary

- Update documentation to reflect balance delegation from Current Account to Position Keeping per BIAN service domain boundaries
- Create ADR-0023 documenting the architectural decision
- Document 7 BIAN balance types (OPENING, CLOSING, CURRENT, AVAILABLE, LEDGER, RESERVE, FREE)

## Changes Made

| File | Changes |
|------|---------|
| `docs/adr/0023-balance-delegation-to-position-keeping.md` | New ADR documenting balance delegation decision |
| `docs/adr/README.md` | Add ADR-0023 to index and categories |
| `services/current-account/README.md` | Remove balance fields from domain model, add Balance Query Delegation section |
| `services/position-keeping/README.md` | Add Balance Calculation section with formulas, APIs, and sequence diagrams |
| `docs/architecture/bian-service-boundaries.md` | Update Position Keeping ownership and Current Account forbidden operations |
| `docs/architecture/api-contracts/current-account-contract.md` | Add balance delegation section, update invariants |
| `docs/architecture/api-contracts/position-keeping-contract.md` | Add GetAccountBalance/GetAccountBalances API documentation |

## Task Master Reference

| Task | Description |
|------|-------------|
| position-keeping-balance.15 | Update balance architecture documentation |

## Test Plan

- [x] Markdown linting passes (`npm run lint:md`)
- [x] All links to ADR-0023 are consistent
- [x] Domain model diagrams updated to remove balance fields
- [x] API documentation includes request/response examples