### PR TITLE
feat(internal-bank-account): add Protocol Buffer API specification

### DIFF
--- a/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
+++ b/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
@@ -133,8 +133,10 @@ message CorrespondentBankDetails {
     max_len: 255
   }];
 
-  // swift_code is the SWIFT/BIC code of the correspondent bank.
+  // swift_code is the SWIFT/BIC code of the correspondent bank (optional).
   // Pattern validates BIC8 (8 chars) or BIC11 (11 chars) format.
+  // Empty string is allowed for correspondent banks without SWIFT codes
+  // (e.g., domestic correspondents, emerging market banks).
   string swift_code = 4 [(buf.validate.field).string = {
     max_len: 11
     pattern: "^([A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?)?$"
@@ -191,7 +193,8 @@ message InternalBankAccountFacility {
   }];
 
   // correspondent_details contains correspondent bank information for NOSTRO/VOSTRO accounts.
-  // This field is required when account_type is NOSTRO or VOSTRO.
+  // Required when account_type is NOSTRO or VOSTRO (enforced at service layer since
+  // proto validation cannot express cross-field conditional constraints).
   CorrespondentBankDetails correspondent_details = 7;
 
   // description provides additional context about this account's purpose.
@@ -241,6 +244,7 @@ message InitiateInternalBankAccountRequest {
   }];
 
   // correspondent_details is required for NOSTRO/VOSTRO account types.
+  // Cross-field validation enforced at service layer.
   CorrespondentBankDetails correspondent_details = 5;
 
   // description provides additional context about this account's purpose.

--- a/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
+++ b/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
@@ -245,6 +245,9 @@ message InitiateInternalBankAccountRequest {
 
   // description provides additional context about this account's purpose.
   string description = 6 [(buf.validate.field).string.max_len = 1000];
+
+  // idempotency_key ensures exactly-once processing for retry scenarios.
+  meridian.common.v1.IdempotencyKey idempotency_key = 7;
 }
 
 // InitiateInternalBankAccountResponse returns the newly created account.
@@ -274,6 +277,9 @@ message UpdateInternalBankAccountRequest {
 
   // correspondent_details updates correspondent information (for NOSTRO/VOSTRO accounts).
   CorrespondentBankDetails correspondent_details = 4;
+
+  // expected_version for optimistic locking. If provided, update fails if current version differs.
+  int32 expected_version = 5 [(buf.validate.field).int32 = {gte: 0}];
 }
 
 // UpdateInternalBankAccountResponse returns the updated account.
@@ -299,7 +305,8 @@ message ControlInternalBankAccountRequest {
   }];
 
   // reason explains why this control action is being performed.
-  // Required for SUSPEND and CLOSE actions (minimum 10 characters for audit trail).
+  // Required for all control actions with minimum 10 characters for audit trail completeness.
+  // This ensures meaningful audit records for compliance and traceability.
   string reason = 3 [(buf.validate.field).string = {
     min_len: 10
     max_len: 1000
@@ -417,11 +424,11 @@ service InternalBankAccountService {
     };
   }
 
-  // UpdateInternalBankAccount modifies account settings.
+  // UpdateInternalBankAccount modifies account settings (partial update).
   // Cannot change account_type or instrument_code after creation.
   rpc UpdateInternalBankAccount(UpdateInternalBankAccountRequest) returns (UpdateInternalBankAccountResponse) {
     option (google.api.http) = {
-      put: "/v1/internal-bank-accounts/{account_id}"
+      patch: "/v1/internal-bank-accounts/{account_id}"
       body: "*"
     };
   }

--- a/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
+++ b/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
@@ -1,0 +1,467 @@
+syntax = "proto3";
+
+package meridian.internal_bank_account.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
+import "meridian/common/v1/types.proto";
+import "meridian/quantity/v1/quantity.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1;internalbankaccountv1";
+
+// OpenAPI specification metadata for Internal Bank Account Service
+option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+  info: {
+    title: "Meridian Internal Bank Account Service API"
+    version: "1.0"
+    description: "BIAN-compliant internal bank account operations for managing non-customer-facing accounts "
+                 "including clearing, nostro, vostro, holding, suspense, revenue, expense, and inventory accounts. "
+                 "Supports multi-asset instruments (fiat, energy, compute, carbon credits)."
+    contact: {
+      name: "Meridian API Team"
+      url: "https://github.com/meridianhub/meridian"
+    }
+    license: {
+      name: "Apache 2.0"
+      url: "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  }
+  schemes: HTTPS
+  consumes: "application/json"
+  produces: "application/json"
+  security_definitions: {
+    security: {
+      key: "Bearer"
+      value: {
+        type: TYPE_API_KEY
+        in: IN_HEADER
+        name: "Authorization"
+        description: "Bearer token authentication"
+      }
+    }
+  }
+  security: {
+    security_requirement: {
+      key: "Bearer"
+      value: {}
+    }
+  }
+};
+
+// InternalAccountType defines the type of internal bank account per BIAN v13.0.
+// Internal accounts are non-customer-facing accounts used for operational purposes.
+enum InternalAccountType {
+  // INTERNAL_ACCOUNT_TYPE_UNSPECIFIED means the account type is unknown.
+  INTERNAL_ACCOUNT_TYPE_UNSPECIFIED = 0;
+  // INTERNAL_ACCOUNT_TYPE_CLEARING is for settlement and clearing operations.
+  INTERNAL_ACCOUNT_TYPE_CLEARING = 1;
+  // INTERNAL_ACCOUNT_TYPE_NOSTRO is our account held at another bank (their books, our money).
+  INTERNAL_ACCOUNT_TYPE_NOSTRO = 2;
+  // INTERNAL_ACCOUNT_TYPE_VOSTRO is another bank's account held at us (our books, their money).
+  INTERNAL_ACCOUNT_TYPE_VOSTRO = 3;
+  // INTERNAL_ACCOUNT_TYPE_HOLDING is for temporary holding of funds.
+  INTERNAL_ACCOUNT_TYPE_HOLDING = 4;
+  // INTERNAL_ACCOUNT_TYPE_SUSPENSE is for unidentified or pending transactions.
+  INTERNAL_ACCOUNT_TYPE_SUSPENSE = 5;
+  // INTERNAL_ACCOUNT_TYPE_REVENUE is for tracking revenue/income.
+  INTERNAL_ACCOUNT_TYPE_REVENUE = 6;
+  // INTERNAL_ACCOUNT_TYPE_EXPENSE is for tracking expenses/costs.
+  INTERNAL_ACCOUNT_TYPE_EXPENSE = 7;
+  // INTERNAL_ACCOUNT_TYPE_INVENTORY is for tracking non-cash assets (energy, commodities, etc.).
+  INTERNAL_ACCOUNT_TYPE_INVENTORY = 8;
+}
+
+// InternalAccountStatus defines the lifecycle state of an internal bank account.
+enum InternalAccountStatus {
+  // INTERNAL_ACCOUNT_STATUS_UNSPECIFIED means the status is unknown.
+  INTERNAL_ACCOUNT_STATUS_UNSPECIFIED = 0;
+  // INTERNAL_ACCOUNT_STATUS_ACTIVE means the account is operational and can process transactions.
+  INTERNAL_ACCOUNT_STATUS_ACTIVE = 1;
+  // INTERNAL_ACCOUNT_STATUS_SUSPENDED means the account is temporarily suspended.
+  INTERNAL_ACCOUNT_STATUS_SUSPENDED = 2;
+  // INTERNAL_ACCOUNT_STATUS_CLOSED means the account is permanently closed.
+  INTERNAL_ACCOUNT_STATUS_CLOSED = 3;
+}
+
+// ControlAction defines the control operations for account lifecycle management.
+// These are BIAN Control Record (CoCR) operations.
+enum ControlAction {
+  // CONTROL_ACTION_UNSPECIFIED is the default value and should not be used.
+  CONTROL_ACTION_UNSPECIFIED = 0;
+  // CONTROL_ACTION_SUSPEND temporarily suspends account operations (reversible).
+  // Transitions: ACTIVE -> SUSPENDED
+  CONTROL_ACTION_SUSPEND = 1;
+  // CONTROL_ACTION_ACTIVATE restores a suspended account to active status.
+  // Transitions: SUSPENDED -> ACTIVE
+  CONTROL_ACTION_ACTIVATE = 2;
+  // CONTROL_ACTION_CLOSE permanently closes the account (irreversible).
+  // Transitions: ACTIVE or SUSPENDED -> CLOSED
+  CONTROL_ACTION_CLOSE = 3;
+}
+
+// CorrespondentType distinguishes between nostro and vostro relationships.
+enum CorrespondentType {
+  // CORRESPONDENT_TYPE_UNSPECIFIED is the default value and should not be used.
+  CORRESPONDENT_TYPE_UNSPECIFIED = 0;
+  // CORRESPONDENT_TYPE_NOSTRO means our account at the correspondent bank.
+  CORRESPONDENT_TYPE_NOSTRO = 1;
+  // CORRESPONDENT_TYPE_VOSTRO means their account at our bank.
+  CORRESPONDENT_TYPE_VOSTRO = 2;
+}
+
+// CorrespondentBankDetails contains information about the correspondent bank
+// for NOSTRO and VOSTRO account types.
+message CorrespondentBankDetails {
+  // bank_id is the unique identifier for the correspondent bank.
+  string bank_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // bank_name is the display name of the correspondent bank.
+  string bank_name = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // external_account_ref is the account reference at the correspondent bank.
+  string external_account_ref = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // swift_code is the SWIFT/BIC code of the correspondent bank.
+  // Pattern validates BIC8 (8 chars) or BIC11 (11 chars) format.
+  string swift_code = 4 [(buf.validate.field).string = {
+    max_len: 11
+    pattern: "^([A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?)?$"
+  }];
+
+  // correspondent_type indicates whether this is a NOSTRO or VOSTRO relationship.
+  CorrespondentType correspondent_type = 5 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+}
+
+// InternalBankAccountFacility represents a BIAN-compliant internal bank account.
+// This is the Control Record (CR) for the Internal Bank Account service domain.
+message InternalBankAccountFacility {
+  // account_id is the unique identifier for this account (UUID format).
+  string account_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // account_code is the business-friendly account code (e.g., "CLR-001", "NOSTRO-USD-HSBC").
+  string account_code = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^[A-Z0-9_-]+$"
+  }];
+
+  // name is the human-readable account name.
+  string name = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // account_type defines the type of internal account.
+  InternalAccountType account_type = 4 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // account_status is the current lifecycle state of the account.
+  InternalAccountStatus account_status = 5 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // instrument_code references the instrument from Reference Data service.
+  // This defines what asset type this account holds (e.g., "USD", "KWH", "CARBON_CREDIT").
+  string instrument_code = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // correspondent_details contains correspondent bank information for NOSTRO/VOSTRO accounts.
+  // This field is required when account_type is NOSTRO or VOSTRO.
+  CorrespondentBankDetails correspondent_details = 7;
+
+  // description provides additional context about this account's purpose.
+  string description = 8 [(buf.validate.field).string.max_len = 1000];
+
+  // created_at is when the account was created.
+  google.protobuf.Timestamp created_at = 9;
+
+  // updated_at is when the account was last modified.
+  google.protobuf.Timestamp updated_at = 10;
+
+  // version is for optimistic locking.
+  int32 version = 11 [(buf.validate.field).int32 = {gte: 0}];
+}
+
+// ========================================
+// Request/Response Messages
+// ========================================
+
+// InitiateInternalBankAccountRequest creates a new internal bank account.
+// BIAN: Initiate Control Record (InCR)
+message InitiateInternalBankAccountRequest {
+  // account_code is the business-friendly account code.
+  string account_code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^[A-Z0-9_-]+$"
+  }];
+
+  // name is the human-readable account name.
+  string name = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // account_type defines the type of internal account.
+  InternalAccountType account_type = 3 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // instrument_code references the instrument from Reference Data service.
+  string instrument_code = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // correspondent_details is required for NOSTRO/VOSTRO account types.
+  CorrespondentBankDetails correspondent_details = 5;
+
+  // description provides additional context about this account's purpose.
+  string description = 6 [(buf.validate.field).string.max_len = 1000];
+}
+
+// InitiateInternalBankAccountResponse returns the newly created account.
+message InitiateInternalBankAccountResponse {
+  // account_id is the generated unique identifier.
+  string account_id = 1;
+
+  // facility is the complete account facility details.
+  InternalBankAccountFacility facility = 2;
+}
+
+// UpdateInternalBankAccountRequest modifies account settings.
+// BIAN: Update Control Record (UpCR)
+message UpdateInternalBankAccountRequest {
+  // account_id identifies the account to update.
+  string account_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // name is the updated account name (optional).
+  string name = 2 [(buf.validate.field).string.max_len = 255];
+
+  // description is the updated description (optional).
+  string description = 3 [(buf.validate.field).string.max_len = 1000];
+
+  // correspondent_details updates correspondent information (for NOSTRO/VOSTRO accounts).
+  CorrespondentBankDetails correspondent_details = 4;
+}
+
+// UpdateInternalBankAccountResponse returns the updated account.
+message UpdateInternalBankAccountResponse {
+  // facility is the updated account facility.
+  InternalBankAccountFacility facility = 1;
+}
+
+// ControlInternalBankAccountRequest performs lifecycle state transitions.
+// BIAN: Control Control Record (CoCR)
+message ControlInternalBankAccountRequest {
+  // account_id identifies the account to control.
+  string account_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // control_action is the action to perform.
+  ControlAction control_action = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // reason explains why this control action is being performed.
+  // Required for SUSPEND and CLOSE actions (minimum 10 characters for audit trail).
+  string reason = 3 [(buf.validate.field).string = {
+    min_len: 10
+    max_len: 1000
+  }];
+}
+
+// ControlInternalBankAccountResponse returns the updated account after control action.
+message ControlInternalBankAccountResponse {
+  // facility is the account with updated status.
+  InternalBankAccountFacility facility = 1;
+
+  // action_timestamp is when the control action was executed.
+  google.protobuf.Timestamp action_timestamp = 2;
+}
+
+// RetrieveInternalBankAccountRequest fetches a single account by ID.
+// BIAN: Retrieve Control Record (ReCR)
+message RetrieveInternalBankAccountRequest {
+  // account_id identifies the account to retrieve.
+  string account_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+}
+
+// RetrieveInternalBankAccountResponse returns the requested account.
+message RetrieveInternalBankAccountResponse {
+  // facility is the requested account facility.
+  InternalBankAccountFacility facility = 1;
+}
+
+// ListInternalBankAccountsRequest queries accounts with filtering and pagination.
+message ListInternalBankAccountsRequest {
+  // account_type_filter returns only accounts of this type (optional).
+  InternalAccountType account_type_filter = 1;
+
+  // instrument_code_filter returns only accounts for this instrument (optional).
+  string instrument_code_filter = 2 [(buf.validate.field).string = {
+    max_len: 32
+    pattern: "^([A-Z][A-Z0-9_]*)?$"
+  }];
+
+  // status_filter returns only accounts with this status (optional).
+  InternalAccountStatus status_filter = 3;
+
+  // pagination controls result pagination.
+  meridian.common.v1.Pagination pagination = 4;
+}
+
+// ListInternalBankAccountsResponse returns a paginated list of accounts.
+message ListInternalBankAccountsResponse {
+  // facilities is the list of matching accounts.
+  repeated InternalBankAccountFacility facilities = 1;
+
+  // pagination contains pagination metadata.
+  meridian.common.v1.PaginationResponse pagination = 2;
+}
+
+// GetBalanceRequest queries the balance for an internal account.
+// Balance is retrieved from Position Keeping service via internal query.
+message GetBalanceRequest {
+  // account_id identifies the account to query balance for.
+  string account_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+}
+
+// GetBalanceResponse returns the account balance.
+// Uses InstrumentAmount for multi-asset support per ADR-0013.
+message GetBalanceResponse {
+  // account_id is the queried account.
+  string account_id = 1;
+
+  // balance is the current account balance in instrument units.
+  // Uses InstrumentAmount instead of MoneyAmount for multi-asset support
+  // (energy, compute, carbon credits, etc.).
+  meridian.quantity.v1.InstrumentAmount balance = 2;
+
+  // last_updated is when the balance was last calculated.
+  google.protobuf.Timestamp last_updated = 3;
+}
+
+// ========================================
+// Service Definition
+// ========================================
+
+// InternalBankAccountService provides BIAN-compliant internal bank account operations.
+// Internal bank accounts are non-customer-facing accounts used for operational purposes
+// such as clearing, correspondent banking (nostro/vostro), holding, suspense, and GL entries.
+//
+// Design Notes:
+// - DELETE operations are intentionally not provided. Accounts are managed through
+//   status transitions (Active -> Suspended -> Closed) for audit compliance.
+// - Balance queries route to Position Keeping service - internal accounts participate
+//   in the universal position tracking system.
+// - No RecordPosting RPC - postings flow through Financial Accounting -> Position Keeping.
+service InternalBankAccountService {
+  // InitiateInternalBankAccount creates a new internal bank account.
+  // The account is created in ACTIVE status.
+  rpc InitiateInternalBankAccount(InitiateInternalBankAccountRequest) returns (InitiateInternalBankAccountResponse) {
+    option (google.api.http) = {
+      post: "/v1/internal-bank-accounts"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "201"
+        value: {
+          description: "Internal bank account created successfully"
+        }
+      }
+    };
+  }
+
+  // UpdateInternalBankAccount modifies account settings.
+  // Cannot change account_type or instrument_code after creation.
+  rpc UpdateInternalBankAccount(UpdateInternalBankAccountRequest) returns (UpdateInternalBankAccountResponse) {
+    option (google.api.http) = {
+      put: "/v1/internal-bank-accounts/{account_id}"
+      body: "*"
+    };
+  }
+
+  // ControlInternalBankAccount performs lifecycle state transitions.
+  // Supports SUSPEND, ACTIVATE, and CLOSE actions with audit trail.
+  rpc ControlInternalBankAccount(ControlInternalBankAccountRequest) returns (ControlInternalBankAccountResponse) {
+    option (google.api.http) = {
+      post: "/v1/internal-bank-accounts/{account_id}/control"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "200"
+        value: {
+          description: "Control action executed successfully"
+        }
+      }
+    };
+  }
+
+  // RetrieveInternalBankAccount fetches a single account by ID.
+  rpc RetrieveInternalBankAccount(RetrieveInternalBankAccountRequest) returns (RetrieveInternalBankAccountResponse) {
+    option (google.api.http) = {
+      get: "/v1/internal-bank-accounts/{account_id}"
+    };
+  }
+
+  // ListInternalBankAccounts queries accounts with filtering and pagination.
+  rpc ListInternalBankAccounts(ListInternalBankAccountsRequest) returns (ListInternalBankAccountsResponse) {
+    option (google.api.http) = {
+      get: "/v1/internal-bank-accounts"
+    };
+  }
+
+  // GetBalance queries the current balance for an internal account.
+  // The balance is retrieved from Position Keeping service.
+  rpc GetBalance(GetBalanceRequest) returns (GetBalanceResponse) {
+    option (google.api.http) = {
+      get: "/v1/internal-bank-accounts/{account_id}/balance"
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- Define gRPC API for Internal Bank Account service per BIAN v13.0 specification
- Add InternalBankAccountFacility Control Record with all required fields
- Implement 6 RPCs: Initiate, Update, Control, Retrieve, List, GetBalance

## Changes Made

- Created `api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto`
- Defined enums: InternalAccountType (8 values), InternalAccountStatus, ControlAction, CorrespondentType
- Added CorrespondentBankDetails nested message for NOSTRO/VOSTRO accounts
- Defined InternalBankAccountFacility message (Control Record)
- Created Request/Response pairs for all 6 BIAN operations
- Added OpenAPI metadata with security definitions

## Technical Details

**Enums:**
- `InternalAccountType`: CLEARING, NOSTRO, VOSTRO, HOLDING, SUSPENSE, REVENUE, EXPENSE, INVENTORY
- `InternalAccountStatus`: ACTIVE, SUSPENDED, CLOSED
- `ControlAction`: SUSPEND, ACTIVATE, CLOSE

**Multi-Asset Support:**
- Uses `InstrumentAmount` from quantity/v1 for balance responses (per ADR-0013)
- References instrument_code from Reference Data service
- Supports fiat, energy, compute, carbon credits, etc.

**Design Decisions:**
- No RecordPosting RPC - postings flow through Financial Accounting -> Position Keeping
- No DELETE operation - accounts managed through status transitions for audit compliance
- SWIFT code validation pattern supports both BIC8 and BIC11 formats

## Testing

- `buf lint` passes
- `buf breaking --against develop` passes (new file, no breaking changes)
- `buf generate` succeeds
- Generated Go code compiles without errors

## Task Master

| TM Task | Description |
|---------|-------------|
| internal-bank-account.1 | Define Protocol Buffer API specification |
| internal-bank-account.1.1 | Define enums and core message types |
| internal-bank-account.1.2 | Define correspondent bank nested message |
| internal-bank-account.1.3 | Define Request/Response message pairs |
| internal-bank-account.1.4 | Define InternalBankAccountService with RPCs |
| internal-bank-account.1.5 | Add OpenAPI metadata and run buf validation |