### PR TITLE
feat(position-keeping): extend balance API for multi-asset support

### DIFF
--- a/api/proto/meridian/position_keeping/v1/position_keeping.proto
+++ b/api/proto/meridian/position_keeping/v1/position_keeping.proto
@@ -6,6 +6,7 @@ import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
 import "google/protobuf/timestamp.proto";
 import "meridian/common/v1/types.proto";
+import "meridian/quantity/v1/quantity.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1;positionkeepingv1";
@@ -529,10 +530,11 @@ message GetAccountBalanceRequest {
     not_in: [0] /* Disallow UNSPECIFIED */
   }];
 
-  // currency filters the balance by currency (optional, ISO 4217 format).
-  string currency = 3 [(buf.validate.field).string = {
-    max_len: 3
-    pattern: "^[A-Z]{0,3}$"
+  // instrument_code filters the balance by instrument (optional).
+  // Supports ISO 4217 currency codes (USD, GBP) and extended asset codes (KWH, GPU_HOUR, CARBON_TONNE).
+  string instrument_code = 3 [(buf.validate.field).string = {
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
   }];
 }
 
@@ -547,8 +549,9 @@ message GetAccountBalanceResponse {
   // balance_type is the type of balance returned.
   BalanceType balance_type = 2 [(buf.validate.field).enum.defined_only = true];
 
-  // amount is the balance amount.
-  meridian.common.v1.MoneyAmount amount = 3 [(buf.validate.field).required = true];
+  // amount is the balance amount expressed as an InstrumentAmount.
+  // Supports both currency amounts (USD, GBP) and multi-asset amounts (KWH, GPU_HOUR).
+  meridian.quantity.v1.InstrumentAmount amount = 3 [(buf.validate.field).required = true];
 
   // as_of is the timestamp representing when this balance was calculated.
   google.protobuf.Timestamp as_of = 4 [(buf.validate.field).required = true];
@@ -566,10 +569,11 @@ message GetAccountBalancesRequest {
     }
   ];
 
-  // currency filters balances by currency (optional, ISO 4217 format).
-  string currency = 2 [(buf.validate.field).string = {
-    max_len: 3
-    pattern: "^[A-Z]{0,3}$"
+  // instrument_code filters balances by instrument (optional).
+  // Supports ISO 4217 currency codes (USD, GBP) and extended asset codes (KWH, GPU_HOUR, CARBON_TONNE).
+  string instrument_code = 2 [(buf.validate.field).string = {
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
   }];
 }
 
@@ -578,8 +582,9 @@ message BalanceEntry {
   // balance_type is the type of this balance.
   BalanceType balance_type = 1 [(buf.validate.field).enum.defined_only = true];
 
-  // amount is the balance amount.
-  meridian.common.v1.MoneyAmount amount = 2 [(buf.validate.field).required = true];
+  // amount is the balance amount expressed as an InstrumentAmount.
+  // Supports both currency amounts (USD, GBP) and multi-asset amounts (KWH, GPU_HOUR).
+  meridian.quantity.v1.InstrumentAmount amount = 2 [(buf.validate.field).required = true];
 }
 
 // GetAccountBalancesResponse returns all balances for an account.

--- a/buf.yaml
+++ b/buf.yaml
@@ -30,4 +30,9 @@ breaking:
     - WIRE           # Wire-level compatibility only
   except:
     - EXTENSION_MESSAGE_NO_DELETE  # Allow during initial development
+  ignore:
+    # Intentional breaking change: Multi-asset support (internal-bank-account task 19)
+    # Changes: currency → instrument_code, MoneyAmount → InstrumentAmount
+    # All consumers updated in this PR - see services/current-account/service/lien_service.go
+    - api/proto/meridian/position_keeping/v1/position_keeping.proto
   ignore_unstable_packages: true

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/shopspring/decimal"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
@@ -21,8 +20,10 @@ import (
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -10,10 +10,12 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/config"
 	"github.com/meridianhub/meridian/services/current-account/domain"
@@ -21,7 +23,6 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -176,18 +177,15 @@ func (m *mockPositionKeepingClient) GetAccountBalance(_ context.Context, req *po
 		balanceCents = m.accountBalances[req.AccountId]
 	}
 	m.mu.Unlock()
-	// Convert cents to units.nanos format (e.g., 10050 cents = 100 units + 500000000 nanos)
-	units := balanceCents / 100
-	nanos := (balanceCents % 100) * 10000000
+	// Convert cents to decimal amount string (e.g., 10050 cents = "100.50")
+	amount := decimal.NewFromInt(balanceCents).Div(decimal.NewFromInt(100))
 	return &positionkeepingv1.GetAccountBalanceResponse{
 		AccountId:   req.AccountId,
 		BalanceType: req.BalanceType,
-		Amount: &commonpb.MoneyAmount{
-			Amount: &money.Money{
-				CurrencyCode: "GBP",
-				Units:        units,
-				Nanos:        int32(nanos),
-			},
+		Amount: &quantityv1.InstrumentAmount{
+			Amount:         amount.StringFixed(2),
+			InstrumentCode: "GBP",
+			Version:        1,
 		},
 		AsOf: timestamppb.Now(),
 	}, nil
@@ -1329,17 +1327,15 @@ func (m *mockPositionKeepingClientWithGetBalanceFailure) GetAccountBalance(_ con
 	if m.accountBalances != nil {
 		balanceCents = m.accountBalances[req.AccountId]
 	}
-	units := balanceCents / 100
-	nanos := (balanceCents % 100) * 10000000
+	// Convert cents to decimal amount string
+	amount := decimal.NewFromInt(balanceCents).Div(decimal.NewFromInt(100))
 	return &positionkeepingv1.GetAccountBalanceResponse{
 		AccountId:   req.AccountId,
 		BalanceType: req.BalanceType,
-		Amount: &commonpb.MoneyAmount{
-			Amount: &money.Money{
-				CurrencyCode: "GBP",
-				Units:        units,
-				Nanos:        int32(nanos),
-			},
+		Amount: &quantityv1.InstrumentAmount{
+			Amount:         amount.StringFixed(2),
+			InstrumentCode: "GBP",
+			Version:        1,
 		},
 		AsOf: timestamppb.Now(),
 	}, nil

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -954,8 +954,9 @@ func (s *Service) getAccountBalanceCents(ctx context.Context, accountID string) 
 		return 0, fmt.Errorf("failed to parse balance amount: %w", err)
 	}
 
-	// Convert to minor units (cents/pence) - multiply by 100 for 2 decimal currencies
-	// Using RoundBank (banker's rounding) for consistent handling of half-cents
+	// Convert to minor units (cents/pence) - multiply by 100 for 2 decimal currencies.
+	// Uses banker's rounding (round-to-even) which differs from half-up at .5 boundaries:
+	// e.g., 0.015 -> 2 (rounds to even), 0.025 -> 2 (rounds to even), 0.035 -> 4 (rounds to even)
 	cents := amount.Mul(decimal.NewFromInt(100)).RoundBank(0)
 
 	// Check for overflow using int64 bounds

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
@@ -941,32 +942,30 @@ func (s *Service) getAccountBalanceCents(ctx context.Context, accountID string) 
 		return 0, fmt.Errorf("failed to get balance from Position Keeping: %w", err)
 	}
 
-	if resp.Amount == nil || resp.Amount.Amount == nil {
+	if resp.Amount == nil || resp.Amount.Amount == "" {
 		return 0, nil
 	}
 
-	units := resp.Amount.Amount.Units
-	nanos := resp.Amount.Amount.Nanos
+	// Parse InstrumentAmount as decimal
+	amount, err := decimal.NewFromString(resp.Amount.Amount)
+	if err != nil {
+		s.logger.Error("failed to parse balance amount",
+			"account_id", accountID, "amount", resp.Amount.Amount, "error", err)
+		return 0, fmt.Errorf("failed to parse balance amount: %w", err)
+	}
 
-	// Calculate nanosCents first to include in overflow check
-	// Round nanos instead of truncating (add 5000000 before division for banker's rounding)
-	// Consistent with protoToMoney conversion logic
-	// nanosCents is at most 100 (nanos range 0-999999999, (999999999+5000000)/10000000 = 100)
-	nanosCents := (nanos + 5000000) / 10000000
+	// Convert to minor units (cents/pence) - multiply by 100 for 2 decimal currencies
+	// Using RoundBank (banker's rounding) for consistent handling of half-cents
+	cents := amount.Mul(decimal.NewFromInt(100)).RoundBank(0)
 
-	// Validate units won't overflow when multiplied by 100 and added to nanosCents
-	// Reserve space for nanosCents (max 100) to prevent overflow in final addition
-	if units > (math.MaxInt64-100)/100 || units < (math.MinInt64+100)/100 {
+	// Check for overflow using int64 bounds
+	maxInt64 := decimal.NewFromInt(math.MaxInt64)
+	minInt64 := decimal.NewFromInt(math.MinInt64)
+	if cents.GreaterThan(maxInt64) || cents.LessThan(minInt64) {
 		return 0, ErrAmountOverflow
 	}
 
-	// Convert units.nanos to minor units (cents)
-	// Units are whole currency units, nanos are fractional parts (1 billionth)
-	// For GBP: 1.50 = 150 cents = (1 * 100) + rounded(500000000 / 10000000)
-	unitsCents := units * 100
-	cents := unitsCents + int64(nanosCents)
-
-	return cents, nil
+	return cents.IntPart(), nil
 }
 
 // calculateAvailableBalance calculates available balance with active liens.

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/shopspring/decimal"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
@@ -19,6 +18,7 @@ import (
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/db"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/shopspring/decimal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"

--- a/services/position-keeping/adapters/balance_mapper.go
+++ b/services/position-keeping/adapters/balance_mapper.go
@@ -150,6 +150,9 @@ var ErrInvalidAmount = errors.New("invalid amount string")
 // ErrInvalidInstrumentCode is returned when the instrument code is empty or invalid.
 var ErrInvalidInstrumentCode = errors.New("invalid or empty instrument code")
 
+// ErrInvalidVersion is returned when the instrument version is negative.
+var ErrInvalidVersion = errors.New("invalid instrument version")
+
 // ToProtoInstrumentAmount converts a domain Money to its protobuf InstrumentAmount representation.
 // This supports the Universal Asset System for multi-asset position tracking by representing
 // monetary quantities as InstrumentAmount with the currency code as instrument_code.
@@ -189,6 +192,11 @@ func ToDomainMoneyFromInstrumentAmount(protoAmount *quantityv1.InstrumentAmount)
 		return domain.Money{}, ErrInvalidInstrumentCode
 	}
 
+	// Reject negative version values
+	if protoAmount.Version < 0 {
+		return domain.Money{}, fmt.Errorf("%w: negative version %d", ErrInvalidVersion, protoAmount.Version)
+	}
+
 	amount, err := decimal.NewFromString(protoAmount.Amount)
 	if err != nil {
 		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidAmount, protoAmount.Amount)
@@ -222,6 +230,11 @@ func ToDomainAssetFromInstrumentAmount(protoAmount *quantityv1.InstrumentAmount)
 
 	// Infer dimension and precision from instrument code
 	dimension, precision := inferInstrumentProperties(protoAmount.InstrumentCode)
+
+	// Reject negative version values (would wrap to large uint32)
+	if protoAmount.Version < 0 {
+		return domain.Asset{}, fmt.Errorf("%w: negative version %d", ErrInvalidVersion, protoAmount.Version)
+	}
 
 	version := uint32(protoAmount.Version)
 	if version == 0 {

--- a/services/position-keeping/adapters/balance_mapper.go
+++ b/services/position-keeping/adapters/balance_mapper.go
@@ -10,6 +10,7 @@ import (
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 )
 
@@ -138,4 +139,122 @@ func ToDomainMoney(protoMoney *commonv1.MoneyAmount) (domain.Money, error) {
 	amount := unitsDecimal.Add(nanosDecimal)
 
 	return domain.MustNewMoney(amount, currency), nil
+}
+
+// ErrNilInstrumentAmount is returned when attempting to convert a nil InstrumentAmount.
+var ErrNilInstrumentAmount = errors.New("InstrumentAmount is nil")
+
+// ErrInvalidAmount is returned when the amount string cannot be parsed as a decimal.
+var ErrInvalidAmount = errors.New("invalid amount string")
+
+// ErrInvalidInstrumentCode is returned when the instrument code is empty or invalid.
+var ErrInvalidInstrumentCode = errors.New("invalid or empty instrument code")
+
+// ToProtoInstrumentAmount converts a domain Money to its protobuf InstrumentAmount representation.
+// This supports the Universal Asset System for multi-asset position tracking by representing
+// monetary quantities as InstrumentAmount with the currency code as instrument_code.
+func ToProtoInstrumentAmount(domainMoney domain.Money) *quantityv1.InstrumentAmount {
+	// Use the instrument precision for fixed-point string representation
+	precision := int32(domainMoney.Instrument.Precision)
+
+	return &quantityv1.InstrumentAmount{
+		Amount:         domainMoney.Amount.StringFixed(precision),
+		InstrumentCode: domainMoney.Instrument.Code,
+		Version:        int32(domainMoney.Instrument.Version),
+	}
+}
+
+// ToProtoInstrumentAmountFromAsset converts a domain Asset to its protobuf InstrumentAmount representation.
+// This supports non-monetary quantities like energy (KWH), compute (GPU_HOUR), and carbon credits.
+func ToProtoInstrumentAmountFromAsset(domainAsset domain.Asset) *quantityv1.InstrumentAmount {
+	// Use the instrument precision for fixed-point string representation
+	precision := int32(domainAsset.Instrument.Precision)
+
+	return &quantityv1.InstrumentAmount{
+		Amount:         domainAsset.Amount.StringFixed(precision),
+		InstrumentCode: domainAsset.Instrument.Code,
+		Version:        int32(domainAsset.Instrument.Version),
+	}
+}
+
+// ToDomainMoneyFromInstrumentAmount converts a protobuf InstrumentAmount to its domain Money representation.
+// This function expects the InstrumentAmount to represent a currency (e.g., USD, GBP, EUR).
+// Returns an error if the amount is invalid or the instrument code is not a valid currency.
+func ToDomainMoneyFromInstrumentAmount(protoAmount *quantityv1.InstrumentAmount) (domain.Money, error) {
+	if protoAmount == nil {
+		return domain.Money{}, ErrNilInstrumentAmount
+	}
+
+	if protoAmount.InstrumentCode == "" {
+		return domain.Money{}, ErrInvalidInstrumentCode
+	}
+
+	amount, err := decimal.NewFromString(protoAmount.Amount)
+	if err != nil {
+		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidAmount, protoAmount.Amount)
+	}
+
+	// Parse as currency - this validates it's a valid ISO 4217 code
+	currency, err := domain.ParseCurrency(protoAmount.InstrumentCode)
+	if err != nil {
+		return domain.Money{}, fmt.Errorf("%w: %s", ErrInvalidCurrency, protoAmount.InstrumentCode)
+	}
+
+	return domain.MustNewMoney(amount, currency), nil
+}
+
+// ToDomainAssetFromInstrumentAmount converts a protobuf InstrumentAmount to its domain Asset representation.
+// This function is for non-monetary quantities like energy (KWH), compute (GPU_HOUR), and carbon credits.
+// Returns an error if the amount is invalid or the instrument code is empty.
+func ToDomainAssetFromInstrumentAmount(protoAmount *quantityv1.InstrumentAmount) (domain.Asset, error) {
+	if protoAmount == nil {
+		return domain.Asset{}, ErrNilInstrumentAmount
+	}
+
+	if protoAmount.InstrumentCode == "" {
+		return domain.Asset{}, ErrInvalidInstrumentCode
+	}
+
+	amount, err := decimal.NewFromString(protoAmount.Amount)
+	if err != nil {
+		return domain.Asset{}, fmt.Errorf("%w: %s", ErrInvalidAmount, protoAmount.Amount)
+	}
+
+	// Infer dimension and precision from instrument code
+	dimension, precision := inferInstrumentProperties(protoAmount.InstrumentCode)
+
+	version := uint32(protoAmount.Version)
+	if version == 0 {
+		version = 1 // Default version
+	}
+
+	instrument, err := domain.NewInstrument(protoAmount.InstrumentCode, version, dimension, precision)
+	if err != nil {
+		return domain.Asset{}, fmt.Errorf("%w: %v", ErrInvalidInstrumentCode, err)
+	}
+
+	return domain.NewAsset(amount, instrument), nil
+}
+
+// inferInstrumentProperties returns the dimension and precision for a given instrument code.
+// Known instrument codes get specific precision, others default to 6 decimal places.
+func inferInstrumentProperties(code string) (dimension string, precision int) {
+	// Currency codes (3-char uppercase letters)
+	switch code {
+	case "USD", "EUR", "GBP", "CHF", "CAD", "AUD":
+		return domain.DimensionCurrency, 2
+	case "JPY":
+		return domain.DimensionCurrency, 0
+	case "KWH":
+		return "ENERGY", 6 // Kilowatt-hours
+	case "GPU_HOUR":
+		return "COMPUTE", 6 // GPU compute hours
+	case "CARBON_TONNE":
+		return "CARBON", 3 // Carbon credits
+	case "CARBON_CREDIT":
+		return "CARBON", 3 // Carbon credits
+	default:
+		// Default to commodity dimension with 6 decimal places
+		return "COMMODITY", 6
+	}
 }

--- a/services/position-keeping/adapters/balance_mapper.go
+++ b/services/position-keeping/adapters/balance_mapper.go
@@ -230,7 +230,7 @@ func ToDomainAssetFromInstrumentAmount(protoAmount *quantityv1.InstrumentAmount)
 
 	instrument, err := domain.NewInstrument(protoAmount.InstrumentCode, version, dimension, precision)
 	if err != nil {
-		return domain.Asset{}, fmt.Errorf("%w: %v", ErrInvalidInstrumentCode, err)
+		return domain.Asset{}, fmt.Errorf("%w: %w", ErrInvalidInstrumentCode, err)
 	}
 
 	return domain.NewAsset(amount, instrument), nil

--- a/services/position-keeping/adapters/balance_mapper_test.go
+++ b/services/position-keeping/adapters/balance_mapper_test.go
@@ -744,6 +744,16 @@ func TestToDomainMoneyFromInstrumentAmount(t *testing.T) {
 			expectError: true,
 			errContains: "currency",
 		},
+		{
+			name: "negative version returns error",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "100",
+				InstrumentCode: "GBP",
+				Version:        -1,
+			},
+			expectError: true,
+			errContains: "version",
+		},
 	}
 
 	for _, tt := range tests {
@@ -844,6 +854,16 @@ func TestToDomainAssetFromInstrumentAmount(t *testing.T) {
 			},
 			expectError: true,
 			errContains: "invalid amount",
+		},
+		{
+			name: "negative version returns error",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "100",
+				InstrumentCode: "KWH",
+				Version:        -1,
+			},
+			expectError: true,
+			errContains: "version",
 		},
 	}
 

--- a/services/position-keeping/adapters/balance_mapper_test.go
+++ b/services/position-keeping/adapters/balance_mapper_test.go
@@ -10,6 +10,7 @@ import (
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/adapters"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 )
@@ -550,4 +551,364 @@ func mustNewMoney(amount string, currency domain.Currency) domain.Money {
 		panic(err)
 	}
 	return m
+}
+
+// =============================================================================
+// InstrumentAmount Adapter Tests
+// =============================================================================
+
+// TestToProtoInstrumentAmount tests conversion of domain Money to proto InstrumentAmount.
+func TestToProtoInstrumentAmount(t *testing.T) {
+	tests := []struct {
+		name           string
+		domainMoney    domain.Money
+		expectedAmount string
+		expectedCode   string
+		expectedVer    int32
+	}{
+		{
+			name:           "GBP with 2 decimal places",
+			domainMoney:    mustNewMoney("123.45", domain.CurrencyGBP),
+			expectedAmount: "123.45",
+			expectedCode:   "GBP",
+			expectedVer:    1,
+		},
+		{
+			name:           "USD with fractional cents",
+			domainMoney:    mustNewMoney("100.999", domain.CurrencyUSD),
+			expectedAmount: "101.00", // Rounded to precision
+			expectedCode:   "USD",
+			expectedVer:    1,
+		},
+		{
+			name:           "JPY with 0 decimal places",
+			domainMoney:    mustNewMoney("1000", domain.CurrencyJPY),
+			expectedAmount: "1000",
+			expectedCode:   "JPY",
+			expectedVer:    1,
+		},
+		{
+			name:           "EUR zero amount",
+			domainMoney:    mustNewMoney("0", domain.CurrencyEUR),
+			expectedAmount: "0.00",
+			expectedCode:   "EUR",
+			expectedVer:    1,
+		},
+		{
+			name:           "negative amount",
+			domainMoney:    mustNewMoney("-50.25", domain.CurrencyGBP),
+			expectedAmount: "-50.25",
+			expectedCode:   "GBP",
+			expectedVer:    1,
+		},
+		{
+			name:           "large amount",
+			domainMoney:    mustNewMoney("9999999.99", domain.CurrencyGBP),
+			expectedAmount: "9999999.99",
+			expectedCode:   "GBP",
+			expectedVer:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := adapters.ToProtoInstrumentAmount(tt.domainMoney)
+
+			assert.Equal(t, tt.expectedAmount, result.Amount)
+			assert.Equal(t, tt.expectedCode, result.InstrumentCode)
+			assert.Equal(t, tt.expectedVer, result.Version)
+		})
+	}
+}
+
+// TestToProtoInstrumentAmountFromAsset tests conversion of domain Asset to proto InstrumentAmount.
+func TestToProtoInstrumentAmountFromAsset(t *testing.T) {
+	tests := []struct {
+		name           string
+		instrument     domain.Instrument
+		amount         decimal.Decimal
+		expectedAmount string
+		expectedCode   string
+	}{
+		{
+			name:           "KWH energy asset",
+			instrument:     domain.MustNewInstrument("KWH", 1, "ENERGY", 6),
+			amount:         decimal.NewFromFloat(1234.567890),
+			expectedAmount: "1234.567890",
+			expectedCode:   "KWH",
+		},
+		{
+			name:           "GPU_HOUR compute asset",
+			instrument:     domain.MustNewInstrument("GPU_HOUR", 1, "COMPUTE", 6),
+			amount:         decimal.NewFromFloat(100.5),
+			expectedAmount: "100.500000",
+			expectedCode:   "GPU_HOUR",
+		},
+		{
+			name:           "CARBON_TONNE asset",
+			instrument:     domain.MustNewInstrument("CARBON_TONNE", 1, "CARBON", 3),
+			amount:         decimal.NewFromFloat(500.123),
+			expectedAmount: "500.123",
+			expectedCode:   "CARBON_TONNE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asset := domain.NewAsset(tt.amount, tt.instrument)
+			result := adapters.ToProtoInstrumentAmountFromAsset(asset)
+
+			assert.Equal(t, tt.expectedAmount, result.Amount)
+			assert.Equal(t, tt.expectedCode, result.InstrumentCode)
+			assert.Equal(t, int32(1), result.Version)
+		})
+	}
+}
+
+// TestToDomainMoneyFromInstrumentAmount tests conversion of proto InstrumentAmount to domain Money.
+func TestToDomainMoneyFromInstrumentAmount(t *testing.T) {
+	tests := []struct {
+		name         string
+		proto        *quantityv1.InstrumentAmount
+		expectError  bool
+		errContains  string
+		expectAmount string
+		expectCode   string
+	}{
+		{
+			name: "valid GBP amount",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "123.45",
+				InstrumentCode: "GBP",
+				Version:        1,
+			},
+			expectError:  false,
+			expectAmount: "123.45",
+			expectCode:   "GBP",
+		},
+		{
+			name: "valid USD zero amount",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "0",
+				InstrumentCode: "USD",
+				Version:        1,
+			},
+			expectError:  false,
+			expectAmount: "0",
+			expectCode:   "USD",
+		},
+		{
+			name: "valid negative amount",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "-50.25",
+				InstrumentCode: "EUR",
+				Version:        1,
+			},
+			expectError:  false,
+			expectAmount: "-50.25",
+			expectCode:   "EUR",
+		},
+		{
+			name:        "nil InstrumentAmount returns error",
+			proto:       nil,
+			expectError: true,
+			errContains: "nil",
+		},
+		{
+			name: "empty instrument code returns error",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "100",
+				InstrumentCode: "",
+				Version:        1,
+			},
+			expectError: true,
+			errContains: "instrument code",
+		},
+		{
+			name: "invalid amount string returns error",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "not-a-number",
+				InstrumentCode: "GBP",
+				Version:        1,
+			},
+			expectError: true,
+			errContains: "invalid amount",
+		},
+		{
+			name: "non-currency code returns error",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "100",
+				InstrumentCode: "KWH", // Not a currency
+				Version:        1,
+			},
+			expectError: true,
+			errContains: "currency",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := adapters.ToDomainMoneyFromInstrumentAmount(tt.proto)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectAmount, result.Amount.String())
+			assert.Equal(t, tt.expectCode, result.Instrument.Code)
+		})
+	}
+}
+
+// TestToDomainAssetFromInstrumentAmount tests conversion of proto InstrumentAmount to domain Asset.
+func TestToDomainAssetFromInstrumentAmount(t *testing.T) {
+	tests := []struct {
+		name         string
+		proto        *quantityv1.InstrumentAmount
+		expectError  bool
+		errContains  string
+		expectAmount string
+		expectCode   string
+	}{
+		{
+			name: "valid KWH asset",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "1234.567890",
+				InstrumentCode: "KWH",
+				Version:        1,
+			},
+			expectError:  false,
+			expectAmount: "1234.56789",
+			expectCode:   "KWH",
+		},
+		{
+			name: "valid GPU_HOUR asset",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "100.5",
+				InstrumentCode: "GPU_HOUR",
+				Version:        1,
+			},
+			expectError:  false,
+			expectAmount: "100.5",
+			expectCode:   "GPU_HOUR",
+		},
+		{
+			name: "valid CARBON_TONNE asset",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "500.123",
+				InstrumentCode: "CARBON_TONNE",
+				Version:        1,
+			},
+			expectError:  false,
+			expectAmount: "500.123",
+			expectCode:   "CARBON_TONNE",
+		},
+		{
+			name: "zero version defaults to 1",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "100",
+				InstrumentCode: "KWH",
+				Version:        0, // Should default to 1
+			},
+			expectError:  false,
+			expectAmount: "100",
+			expectCode:   "KWH",
+		},
+		{
+			name:        "nil InstrumentAmount returns error",
+			proto:       nil,
+			expectError: true,
+			errContains: "nil",
+		},
+		{
+			name: "empty instrument code returns error",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "100",
+				InstrumentCode: "",
+				Version:        1,
+			},
+			expectError: true,
+			errContains: "instrument code",
+		},
+		{
+			name: "invalid amount string returns error",
+			proto: &quantityv1.InstrumentAmount{
+				Amount:         "not-a-number",
+				InstrumentCode: "KWH",
+				Version:        1,
+			},
+			expectError: true,
+			errContains: "invalid amount",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := adapters.ToDomainAssetFromInstrumentAmount(tt.proto)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectAmount, result.Amount.String())
+			assert.Equal(t, tt.expectCode, result.Instrument.Code)
+		})
+	}
+}
+
+// TestRoundTripMoneyToInstrumentAmount tests round-trip conversion preserves precision.
+func TestRoundTripMoneyToInstrumentAmount(t *testing.T) {
+	tests := []struct {
+		name     string
+		amount   string
+		currency domain.Currency
+	}{
+		{
+			name:     "GBP round trip",
+			amount:   "123.45",
+			currency: domain.CurrencyGBP,
+		},
+		{
+			name:     "USD round trip",
+			amount:   "1000.00",
+			currency: domain.CurrencyUSD,
+		},
+		{
+			name:     "EUR round trip with zero fraction",
+			amount:   "500.00",
+			currency: domain.CurrencyEUR,
+		},
+		{
+			name:     "JPY round trip (no decimals)",
+			amount:   "1000",
+			currency: domain.CurrencyJPY,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Domain -> Proto
+			original := mustNewMoney(tt.amount, tt.currency)
+			proto := adapters.ToProtoInstrumentAmount(original)
+
+			// Proto -> Domain
+			result, err := adapters.ToDomainMoneyFromInstrumentAmount(proto)
+			require.NoError(t, err)
+
+			// Compare
+			assert.True(t, original.Amount.Equal(result.Amount),
+				"Expected %s, got %s", original.Amount.String(), result.Amount.String())
+			assert.Equal(t, original.Instrument.Code, result.Instrument.Code)
+		})
+	}
 }

--- a/services/position-keeping/client/client_test.go
+++ b/services/position-keeping/client/client_test.go
@@ -9,15 +9,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/client"
 )
 
@@ -94,12 +93,10 @@ func TestGetAccountBalance_Success(t *testing.T) {
 		getAccountBalanceResp: &positionkeepingv1.GetAccountBalanceResponse{
 			AccountId:   "acc-123",
 			BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-			Amount: &commonv1.MoneyAmount{
-				Amount: &money.Money{
-					CurrencyCode: "GBP",
-					Units:        100,
-					Nanos:        500000000, // 0.50
-				},
+			Amount: &quantityv1.InstrumentAmount{
+				Amount:         "100.50",
+				InstrumentCode: "GBP",
+				Version:        1,
 			},
 			AsOf: timestamppb.New(now),
 		},
@@ -122,9 +119,9 @@ func TestGetAccountBalance_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "acc-123", resp.AccountId)
 	assert.Equal(t, positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT, resp.BalanceType)
-	assert.Equal(t, "GBP", resp.Amount.Amount.CurrencyCode)
-	assert.Equal(t, int64(100), resp.Amount.Amount.Units)
-	assert.Equal(t, int32(500000000), resp.Amount.Amount.Nanos)
+	assert.Equal(t, "GBP", resp.Amount.InstrumentCode)
+	assert.Equal(t, "100.50", resp.Amount.Amount)
+	assert.Equal(t, int32(1), resp.Amount.Version)
 }
 
 func TestGetAccountBalance_NotFound(t *testing.T) {
@@ -191,22 +188,18 @@ func TestGetAccountBalances_Success(t *testing.T) {
 			Balances: []*positionkeepingv1.BalanceEntry{
 				{
 					BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-					Amount: &commonv1.MoneyAmount{
-						Amount: &money.Money{
-							CurrencyCode: "GBP",
-							Units:        1000,
-							Nanos:        0,
-						},
+					Amount: &quantityv1.InstrumentAmount{
+						Amount:         "1000.00",
+						InstrumentCode: "GBP",
+						Version:        1,
 					},
 				},
 				{
 					BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_AVAILABLE,
-					Amount: &commonv1.MoneyAmount{
-						Amount: &money.Money{
-							CurrencyCode: "GBP",
-							Units:        800,
-							Nanos:        0,
-						},
+					Amount: &quantityv1.InstrumentAmount{
+						Amount:         "800.00",
+						InstrumentCode: "GBP",
+						Version:        1,
 					},
 				},
 			},
@@ -233,11 +226,11 @@ func TestGetAccountBalances_Success(t *testing.T) {
 
 	// Check current balance
 	assert.Equal(t, positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT, resp.Balances[0].BalanceType)
-	assert.Equal(t, int64(1000), resp.Balances[0].Amount.Amount.Units)
+	assert.Equal(t, "1000.00", resp.Balances[0].Amount.Amount)
 
 	// Check available balance
 	assert.Equal(t, positionkeepingv1.BalanceType_BALANCE_TYPE_AVAILABLE, resp.Balances[1].BalanceType)
-	assert.Equal(t, int64(800), resp.Balances[1].Amount.Amount.Units)
+	assert.Equal(t, "800.00", resp.Balances[1].Amount.Amount)
 }
 
 func TestGetAccountBalances_NotFound(t *testing.T) {
@@ -323,7 +316,7 @@ func TestGetAccountBalance_ContextCanceled(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
-func TestGetAccountBalances_WithCurrencyFilter(t *testing.T) {
+func TestGetAccountBalances_WithInstrumentFilter(t *testing.T) {
 	// Arrange
 	now := time.Now()
 	mock := &mockPositionKeepingServer{
@@ -332,12 +325,10 @@ func TestGetAccountBalances_WithCurrencyFilter(t *testing.T) {
 			Balances: []*positionkeepingv1.BalanceEntry{
 				{
 					BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-					Amount: &commonv1.MoneyAmount{
-						Amount: &money.Money{
-							CurrencyCode: "USD",
-							Units:        500,
-							Nanos:        0,
-						},
+					Amount: &quantityv1.InstrumentAmount{
+						Amount:         "500.00",
+						InstrumentCode: "USD",
+						Version:        1,
 					},
 				},
 			},
@@ -352,15 +343,15 @@ func TestGetAccountBalances_WithCurrencyFilter(t *testing.T) {
 	require.NoError(t, err)
 	defer clientCleanup()
 
-	// Act - request with currency filter
+	// Act - request with instrument code filter
 	resp, err := c.GetAccountBalances(context.Background(), &positionkeepingv1.GetAccountBalancesRequest{
-		AccountId: "acc-123",
-		Currency:  "USD",
+		AccountId:      "acc-123",
+		InstrumentCode: "USD",
 	})
 
 	// Assert
 	require.NoError(t, err)
 	assert.Equal(t, "acc-123", resp.AccountId)
 	require.Len(t, resp.Balances, 1)
-	assert.Equal(t, "USD", resp.Balances[0].Amount.Amount.CurrencyCode)
+	assert.Equal(t, "USD", resp.Balances[0].Amount.InstrumentCode)
 }

--- a/services/position-keeping/service/balance.go
+++ b/services/position-keeping/service/balance.go
@@ -84,10 +84,10 @@ func (s *PositionKeepingService) GetAccountBalance(
 		currency = openingBalance.Instrument
 	}
 
-	// Apply currency filter if specified
-	if req.GetCurrency() != "" {
-		if currency.Code != req.GetCurrency() {
-			return nil, status.Errorf(codes.NotFound, "no balance found for currency: %s", req.GetCurrency())
+	// Apply instrument filter if specified (supports both currency codes and extended asset codes)
+	if req.GetInstrumentCode() != "" {
+		if currency.Code != req.GetInstrumentCode() {
+			return nil, status.Errorf(codes.NotFound, "no balance found for instrument: %s", req.GetInstrumentCode())
 		}
 	}
 
@@ -111,7 +111,7 @@ func (s *PositionKeepingService) GetAccountBalance(
 	return &positionkeepingv1.GetAccountBalanceResponse{
 		AccountId:   req.GetAccountId(),
 		BalanceType: adapters.ToProtoBalanceType(balance.Type),
-		Amount:      adapters.ToProtoMoneyAmount(balance.Amount),
+		Amount:      adapters.ToProtoInstrumentAmount(balance.Amount),
 		AsOf:        timestamppb.New(balance.AsOf),
 	}, nil
 }
@@ -163,10 +163,10 @@ func (s *PositionKeepingService) GetAccountBalances(
 		currency = openingBalance.Instrument
 	}
 
-	// Apply currency filter if specified
-	if req.GetCurrency() != "" {
-		if currency.Code != req.GetCurrency() {
-			return nil, status.Errorf(codes.NotFound, "no balances found for currency: %s", req.GetCurrency())
+	// Apply instrument filter if specified (supports both currency codes and extended asset codes)
+	if req.GetInstrumentCode() != "" {
+		if currency.Code != req.GetInstrumentCode() {
+			return nil, status.Errorf(codes.NotFound, "no balances found for instrument: %s", req.GetInstrumentCode())
 		}
 	}
 
@@ -194,7 +194,7 @@ func (s *PositionKeepingService) GetAccountBalances(
 
 		balanceEntries = append(balanceEntries, &positionkeepingv1.BalanceEntry{
 			BalanceType: adapters.ToProtoBalanceType(balance.Type),
-			Amount:      adapters.ToProtoMoneyAmount(balance.Amount),
+			Amount:      adapters.ToProtoInstrumentAmount(balance.Amount),
 		})
 	}
 

--- a/services/position-keeping/service/balance_integration_test.go
+++ b/services/position-keeping/service/balance_integration_test.go
@@ -486,7 +486,7 @@ func TestIntegration_GetAccountBalance_AllBalanceTypes(t *testing.T) {
 			assert.Equal(t, tt.balanceType, resp.BalanceType)
 			assert.NotNil(t, resp.Amount)
 			assert.NotNil(t, resp.AsOf)
-			assert.Equal(t, "GBP", resp.Amount.Amount.CurrencyCode)
+			assert.Equal(t, "GBP", resp.Amount.InstrumentCode)
 		})
 	}
 }
@@ -550,7 +550,7 @@ func TestIntegration_GetAccountBalance_WithLiens(t *testing.T) {
 
 		resp, err := tc.Service.GetAccountBalance(ctx, req)
 		require.NoError(t, err)
-		assert.Equal(t, int64(300), resp.Amount.Amount.Units)
+		assert.Equal(t, "300.00", resp.Amount.Amount)
 	})
 
 	// Test Available balance (Current - Reserve = 1000 - 300 = 700)
@@ -562,7 +562,7 @@ func TestIntegration_GetAccountBalance_WithLiens(t *testing.T) {
 
 		resp, err := tc.Service.GetAccountBalance(ctx, req)
 		require.NoError(t, err)
-		assert.Equal(t, int64(700), resp.Amount.Amount.Units)
+		assert.Equal(t, "700.00", resp.Amount.Amount)
 	})
 
 	// Test Free balance (Current - Reserve = 1000 - 300 = 700)
@@ -574,7 +574,7 @@ func TestIntegration_GetAccountBalance_WithLiens(t *testing.T) {
 
 		resp, err := tc.Service.GetAccountBalance(ctx, req)
 		require.NoError(t, err)
-		assert.Equal(t, int64(700), resp.Amount.Amount.Units)
+		assert.Equal(t, "700.00", resp.Amount.Amount)
 	})
 }
 
@@ -697,7 +697,7 @@ func TestIntegration_GetAccountBalance_CurrencyFiltering(t *testing.T) {
 
 		resp, err := tc.Service.GetAccountBalance(ctx, req)
 		require.NoError(t, err)
-		assert.Equal(t, "GBP", resp.Amount.Amount.CurrencyCode)
+		assert.Equal(t, "GBP", resp.Amount.InstrumentCode)
 	})
 
 	t.Run("returns NotFound when currency does not match", func(t *testing.T) {
@@ -722,7 +722,7 @@ func TestIntegration_GetAccountBalance_CurrencyFiltering(t *testing.T) {
 
 		resp, err := tc.Service.GetAccountBalance(ctx, req)
 		require.NoError(t, err)
-		assert.Equal(t, "USD", resp.Amount.Amount.CurrencyCode)
+		assert.Equal(t, "USD", resp.Amount.InstrumentCode)
 	})
 }
 
@@ -811,7 +811,7 @@ func TestIntegration_ConcurrentBalanceQueries(t *testing.T) {
 		resultCount++
 		assert.Equal(t, accountID, resp.AccountId)
 		assert.NotNil(t, resp.Amount)
-		assert.Equal(t, "GBP", resp.Amount.Amount.CurrencyCode)
+		assert.Equal(t, "GBP", resp.Amount.InstrumentCode)
 	}
 
 	assert.Equal(t, numGoroutines*queriesPerGoroutine, resultCount,

--- a/services/position-keeping/service/balance_test.go
+++ b/services/position-keeping/service/balance_test.go
@@ -180,7 +180,9 @@ func TestGetAccountBalance_Success(t *testing.T) {
 			assert.Equal(t, tt.balanceType, resp.BalanceType)
 			assert.NotNil(t, resp.Amount)
 			assert.NotNil(t, resp.AsOf)
-			assert.Equal(t, tt.expectAmount, resp.Amount.Amount.Units)
+			// InstrumentAmount uses string representation, convert expected units for comparison
+			expectedAmount := decimal.NewFromInt(tt.expectAmount).StringFixed(2)
+			assert.Equal(t, expectedAmount, resp.Amount.Amount)
 			mockRepo.AssertExpectations(t)
 			mockCurrentAccount.AssertExpectations(t)
 		})
@@ -323,9 +325,9 @@ func TestGetAccountBalance_CurrencyFilter(t *testing.T) {
 		require.NoError(t, err)
 
 		req := &positionkeepingv1.GetAccountBalanceRequest{
-			AccountId:   "test-account",
-			BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_OPENING,
-			Currency:    "GBP",
+			AccountId:      "test-account",
+			BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_OPENING,
+			InstrumentCode: "GBP",
 		}
 
 		// Act
@@ -334,10 +336,10 @@ func TestGetAccountBalance_CurrencyFilter(t *testing.T) {
 		// Assert
 		require.NoError(t, err)
 		assert.NotNil(t, resp)
-		assert.Equal(t, "GBP", resp.Amount.Amount.CurrencyCode)
+		assert.Equal(t, "GBP", resp.Amount.InstrumentCode)
 	})
 
-	t.Run("returns NotFound when currency does not match", func(t *testing.T) {
+	t.Run("returns NotFound when instrument code does not match", func(t *testing.T) {
 		// Arrange
 		mockRepo := new(MockRepository)
 		mockMeasurementRepo := new(MockMeasurementRepository)
@@ -356,9 +358,9 @@ func TestGetAccountBalance_CurrencyFilter(t *testing.T) {
 		require.NoError(t, err)
 
 		req := &positionkeepingv1.GetAccountBalanceRequest{
-			AccountId:   "test-account",
-			BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_OPENING,
-			Currency:    "USD", // Different currency
+			AccountId:      "test-account",
+			BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_OPENING,
+			InstrumentCode: "USD", // Different instrument
 		}
 
 		// Act
@@ -604,8 +606,8 @@ func TestGetAccountBalances_CurrencyFilter(t *testing.T) {
 		require.NoError(t, err)
 
 		req := &positionkeepingv1.GetAccountBalancesRequest{
-			AccountId: "test-account",
-			Currency:  "GBP",
+			AccountId:      "test-account",
+			InstrumentCode: "GBP",
 		}
 
 		// Act
@@ -617,7 +619,7 @@ func TestGetAccountBalances_CurrencyFilter(t *testing.T) {
 		assert.NotEmpty(t, resp.Balances)
 	})
 
-	t.Run("returns NotFound when currency does not match", func(t *testing.T) {
+	t.Run("returns NotFound when instrument code does not match", func(t *testing.T) {
 		// Arrange
 		mockRepo := new(MockRepository)
 		mockMeasurementRepo := new(MockMeasurementRepository)
@@ -636,8 +638,8 @@ func TestGetAccountBalances_CurrencyFilter(t *testing.T) {
 		require.NoError(t, err)
 
 		req := &positionkeepingv1.GetAccountBalancesRequest{
-			AccountId: "test-account",
-			Currency:  "EUR", // Different currency
+			AccountId:      "test-account",
+			InstrumentCode: "EUR", // Different instrument
 		}
 
 		// Act
@@ -732,5 +734,5 @@ func TestGetAccountBalance_WithLiens(t *testing.T) {
 	// Assert
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
-	assert.Equal(t, int64(200), resp.Amount.Amount.Units) // Total liens = 200
+	assert.Equal(t, "200.00", resp.Amount.Amount) // Total liens = 200
 }

--- a/services/position-keeping/service/initiate_migration_integration_test.go
+++ b/services/position-keeping/service/initiate_migration_integration_test.go
@@ -66,19 +66,18 @@ func TestIntegration_InitiateWithOpeningBalance_PositiveBalance(t *testing.T) {
 
 	// Verify balance query returns correct value
 	balanceReq := &positionkeepingv1.GetAccountBalanceRequest{
-		AccountId:   accountID,
-		BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-		Currency:    "GBP",
+		AccountId:      accountID,
+		BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+		InstrumentCode: "GBP",
 	}
 
 	balanceResp, err := tc.Service.GetAccountBalance(ctx, balanceReq)
 	require.NoError(t, err, "Expected successful balance query")
 	require.NotNil(t, balanceResp, "Expected balance response")
 
-	// Verify the balance amount
-	assert.Equal(t, int64(1500), balanceResp.Amount.Amount.Units)
-	assert.Equal(t, int32(500000000), balanceResp.Amount.Amount.Nanos)
-	assert.Equal(t, "GBP", balanceResp.Amount.Amount.CurrencyCode)
+	// Verify the balance amount (1500.50 GBP)
+	assert.Equal(t, "1500.50", balanceResp.Amount.Amount)
+	assert.Equal(t, "GBP", balanceResp.Amount.InstrumentCode)
 }
 
 // TestIntegration_InitiateWithOpeningBalance_NegativeBalance tests migrating an overdrawn account.
@@ -122,17 +121,17 @@ func TestIntegration_InitiateWithOpeningBalance_NegativeBalance(t *testing.T) {
 
 	// Verify balance query returns correct negative value
 	balanceReq := &positionkeepingv1.GetAccountBalanceRequest{
-		AccountId:   accountID,
-		BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-		Currency:    "GBP",
+		AccountId:      accountID,
+		BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+		InstrumentCode: "GBP",
 	}
 
 	balanceResp, err := tc.Service.GetAccountBalance(ctx, balanceReq)
 	require.NoError(t, err, "Expected successful balance query")
 
-	// Balance should be negative (overdrawn)
-	assert.Equal(t, int64(-500), balanceResp.Amount.Amount.Units)
-	assert.Equal(t, int32(-250000000), balanceResp.Amount.Amount.Nanos)
+	// Balance should be negative (overdrawn) - -500.25 GBP
+	assert.Equal(t, "-500.25", balanceResp.Amount.Amount)
+	assert.Equal(t, "GBP", balanceResp.Amount.InstrumentCode)
 }
 
 // TestIntegration_InitiateWithOpeningBalance_MultipleAccounts tests migrating multiple
@@ -150,13 +149,14 @@ func TestIntegration_InitiateWithOpeningBalance_MultipleAccounts(t *testing.T) {
 
 	// Migrate multiple accounts with different balances
 	accounts := []struct {
-		accountID string
-		units     int64
-		nanos     int32
+		accountID      string
+		units          int64
+		nanos          int32
+		expectedAmount string // Expected balance in InstrumentAmount format
 	}{
-		{"ACC-MULTI-001", 1000, 0},
-		{"ACC-MULTI-002", 2500, 500000000}, // £2500.50
-		{"ACC-MULTI-003", -100, 0},         // Overdrawn
+		{"ACC-MULTI-001", 1000, 0, "1000.00"},
+		{"ACC-MULTI-002", 2500, 500000000, "2500.50"}, // £2500.50
+		{"ACC-MULTI-003", -100, 0, "-100.00"},         // Overdrawn
 	}
 
 	createdLogIDs := make(map[string]string)
@@ -186,18 +186,18 @@ func TestIntegration_InitiateWithOpeningBalance_MultipleAccounts(t *testing.T) {
 	// Verify each account has its correct balance
 	for _, acc := range accounts {
 		balanceReq := &positionkeepingv1.GetAccountBalanceRequest{
-			AccountId:   acc.accountID,
-			BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-			Currency:    "GBP",
+			AccountId:      acc.accountID,
+			BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+			InstrumentCode: "GBP",
 		}
 
 		balanceResp, err := tc.Service.GetAccountBalance(ctx, balanceReq)
 		require.NoError(t, err, "Balance query should succeed for %s", acc.accountID)
 
-		assert.Equal(t, acc.units, balanceResp.Amount.Amount.Units,
-			"Balance units should match for %s", acc.accountID)
-		assert.Equal(t, acc.nanos, balanceResp.Amount.Amount.Nanos,
-			"Balance nanos should match for %s", acc.accountID)
+		assert.Equal(t, acc.expectedAmount, balanceResp.Amount.Amount,
+			"Balance amount should match for %s", acc.accountID)
+		assert.Equal(t, "GBP", balanceResp.Amount.InstrumentCode,
+			"Instrument code should be GBP for %s", acc.accountID)
 	}
 
 	// Verify all log IDs are unique
@@ -288,15 +288,15 @@ func TestIntegration_InitiateWithOpeningBalance_ZeroBalance(t *testing.T) {
 
 	// Balance should be zero
 	balanceReq := &positionkeepingv1.GetAccountBalanceRequest{
-		AccountId:   accountID,
-		BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-		Currency:    "GBP",
+		AccountId:      accountID,
+		BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+		InstrumentCode: "GBP",
 	}
 
 	balanceResp, err := tc.Service.GetAccountBalance(ctx, balanceReq)
 	require.NoError(t, err, "Expected successful balance query")
-	assert.Equal(t, int64(0), balanceResp.Amount.Amount.Units)
-	assert.Equal(t, int32(0), balanceResp.Amount.Amount.Nanos)
+	assert.Equal(t, "0.00", balanceResp.Amount.Amount)
+	assert.Equal(t, "GBP", balanceResp.Amount.InstrumentCode)
 }
 
 // TestIntegration_InitiateWithOpeningBalance_FutureEffectiveDate tests validation rejects future dates.
@@ -393,16 +393,17 @@ func TestIntegration_InitiateWithOpeningBalance_ThenAddTransactions(t *testing.T
 
 	// Step 3: Verify total balance is £1500
 	balanceReq := &positionkeepingv1.GetAccountBalanceRequest{
-		AccountId:   accountID,
-		BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-		Currency:    "GBP",
+		AccountId:      accountID,
+		BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+		InstrumentCode: "GBP",
 	}
 
 	balanceResp, err := tc.Service.GetAccountBalance(ctx, balanceReq)
 	require.NoError(t, err, "Expected successful balance query")
 
 	// Opening balance (£1000) + additional credit (£500) = £1500
-	assert.Equal(t, int64(1500), balanceResp.Amount.Amount.Units)
+	assert.Equal(t, "1500.00", balanceResp.Amount.Amount)
+	assert.Equal(t, "GBP", balanceResp.Amount.InstrumentCode)
 
 	_ = migrateResp // Use the response to avoid unused variable warning
 }
@@ -455,16 +456,17 @@ func TestIntegration_MigrationIdempotency(t *testing.T) {
 
 	// Verify balance is still correct and not doubled
 	balanceReq := &positionkeepingv1.GetAccountBalanceRequest{
-		AccountId:   accountID,
-		BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-		Currency:    "GBP",
+		AccountId:      accountID,
+		BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+		InstrumentCode: "GBP",
 	}
 
 	balanceResp, err := tc.Service.GetAccountBalance(ctx, balanceReq)
 	require.NoError(t, err, "Balance query should succeed")
 
-	assert.Equal(t, int64(3000), balanceResp.Amount.Amount.Units,
+	assert.Equal(t, "3000.00", balanceResp.Amount.Amount,
 		"Balance should still be 3000, not doubled")
+	assert.Equal(t, "GBP", balanceResp.Amount.InstrumentCode)
 }
 
 // TestIntegration_MigrationInvalidBalances tests that invalid balance amounts
@@ -573,20 +575,34 @@ func TestIntegration_BatchMigration(t *testing.T) {
 	// Create 20 accounts with various balances (reduced from 100 for faster test execution)
 	const accountCount = 20
 	accounts := make([]struct {
-		accountID string
-		units     int64
-		nanos     int32
+		accountID      string
+		units          int64
+		nanos          int32
+		expectedAmount string // Expected balance in InstrumentAmount format
 	}, accountCount)
 
 	for i := 0; i < accountCount; i++ {
+		units := int64((i + 1) * 100)
+		nanosPart := int32((i % 10) * 100000000)
+		// Format expected amount: units + nanos/1e9
+		var expectedAmount string
+		if nanosPart == 0 {
+			expectedAmount = decimal.NewFromInt(units).StringFixed(2)
+		} else {
+			expectedAmount = decimal.NewFromInt(units).Add(
+				decimal.NewFromInt(int64(nanosPart)).Div(decimal.NewFromInt(1_000_000_000)),
+			).StringFixed(2)
+		}
 		accounts[i] = struct {
-			accountID string
-			units     int64
-			nanos     int32
+			accountID      string
+			units          int64
+			nanos          int32
+			expectedAmount string
 		}{
-			accountID: "BATCH-" + uuid.New().String()[:8],
-			units:     int64((i + 1) * 100),        // £100, £200, £300, etc.
-			nanos:     int32((i % 10) * 100000000), // Various nanos
+			accountID:      "BATCH-" + uuid.New().String()[:8],
+			units:          units,
+			nanos:          nanosPart,
+			expectedAmount: expectedAmount,
 		}
 	}
 
@@ -614,18 +630,18 @@ func TestIntegration_BatchMigration(t *testing.T) {
 	// Verify all accounts have correct balances
 	for _, acc := range accounts {
 		balanceReq := &positionkeepingv1.GetAccountBalanceRequest{
-			AccountId:   acc.accountID,
-			BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-			Currency:    "GBP",
+			AccountId:      acc.accountID,
+			BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+			InstrumentCode: "GBP",
 		}
 
 		balanceResp, err := tc.Service.GetAccountBalance(ctx, balanceReq)
 		require.NoError(t, err, "Balance query should succeed for %s", acc.accountID)
 
-		assert.Equal(t, acc.units, balanceResp.Amount.Amount.Units,
-			"Balance units should match for %s", acc.accountID)
-		assert.Equal(t, acc.nanos, balanceResp.Amount.Amount.Nanos,
-			"Balance nanos should match for %s", acc.accountID)
+		assert.Equal(t, acc.expectedAmount, balanceResp.Amount.Amount,
+			"Balance amount should match for %s", acc.accountID)
+		assert.Equal(t, "GBP", balanceResp.Amount.InstrumentCode,
+			"Instrument code should be GBP for %s", acc.accountID)
 	}
 
 	// Add a transaction to one of the migrated accounts to verify post-migration consistency
@@ -649,18 +665,20 @@ func TestIntegration_BatchMigration(t *testing.T) {
 
 	// Verify balance updated correctly
 	balanceReq := &positionkeepingv1.GetAccountBalanceRequest{
-		AccountId:   testAccount.accountID,
-		BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-		Currency:    "GBP",
+		AccountId:      testAccount.accountID,
+		BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+		InstrumentCode: "GBP",
 	}
 
 	balanceResp, err := tc.Service.GetAccountBalance(ctx, balanceReq)
 	require.NoError(t, err, "Balance query should succeed")
 
 	// Expected: original balance + 250
-	expectedUnits := testAccount.units + 250
-	assert.Equal(t, expectedUnits, balanceResp.Amount.Amount.Units,
+	// testAccount is accounts[0] which has units=100, nanos=0, so expectedAmount="100.00"
+	// After adding 250, expected balance is 350.00
+	assert.Equal(t, "350.00", balanceResp.Amount.Amount,
 		"Balance should be opening balance + deposit")
+	assert.Equal(t, "GBP", balanceResp.Amount.InstrumentCode)
 }
 
 // TestIntegration_MigrationBalanceConsistencyMultipleTransactions tests that after
@@ -741,21 +759,22 @@ func TestIntegration_MigrationBalanceConsistencyMultipleTransactions(t *testing.
 
 		// Verify balance after this transaction
 		balanceReq := &positionkeepingv1.GetAccountBalanceRequest{
-			AccountId:   accountID,
-			BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
-			Currency:    "GBP",
+			AccountId:      accountID,
+			BalanceType:    positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+			InstrumentCode: "GBP",
 		}
 
 		balanceResp, err := tc.Service.GetAccountBalance(ctx, balanceReq)
 		require.NoError(t, err, "Balance query should succeed after transaction %d", i+1)
 
-		// Convert response to decimal for comparison
-		actualBalance := decimal.NewFromInt(balanceResp.Amount.Amount.Units).Add(
-			decimal.NewFromInt(int64(balanceResp.Amount.Amount.Nanos)).Div(decimal.NewFromInt(1_000_000_000)),
-		)
+		// Parse response amount string to decimal for comparison
+		actualBalance, err := decimal.NewFromString(balanceResp.Amount.Amount)
+		require.NoError(t, err, "Balance amount should be valid decimal")
 
 		assert.True(t, runningBalance.Equal(actualBalance),
 			"After transaction %d (%s): Expected balance %s, got %s",
 			i+1, tx.desc, runningBalance.String(), actualBalance.String())
+		assert.Equal(t, "GBP", balanceResp.Amount.InstrumentCode,
+			"Instrument code should be GBP after transaction %d", i+1)
 	}
 }


### PR DESCRIPTION
## Summary

- Extends Position Keeping balance API to support multi-asset instruments (KWH, GPU_HOUR, CARBON_TONNE, etc.)
- Replaces currency-specific `MoneyAmount` with instrument-agnostic `InstrumentAmount` type
- Renames `currency` field to `instrument_code` for semantic clarity

## Changes Made

### Protocol Buffers
- `api/proto/meridian/position_keeping/v1/position_keeping.proto`:
  - Changed `GetAccountBalanceRequest.currency` → `instrument_code` with extended validation
  - Changed `GetAccountBalancesRequest.currency` → `instrument_code`
  - Changed response amount type from `MoneyAmount` → `InstrumentAmount`

### Adapters
- `services/position-keeping/adapters/balance_mapper.go`:
  - Added `ToProtoInstrumentAmount()` for domain Money → proto conversion
  - Added `ToProtoInstrumentAmountFromAsset()` for domain Asset → proto conversion
  - Added `ToDomainMoneyFromInstrumentAmount()` for proto → domain Money
  - Added `ToDomainAssetFromInstrumentAmount()` for proto → domain Asset
  - Added `inferInstrumentProperties()` helper for instrument code metadata

### Service Layer
- `services/position-keeping/service/balance.go`: Updated to use new adapters

### Consumer Updates
- `services/current-account/service/lien_service.go`: Updated to parse `InstrumentAmount` responses

### Tests
- Added comprehensive unit tests for all new adapter functions
- Updated existing tests in position-keeping and current-account services

## Technical Details

The `InstrumentAmount` type provides:
- String-based decimal `amount` for precision preservation
- `instrument_code` for asset identification (GBP, USD, KWH, GPU_HOUR, etc.)
- `version` for instrument versioning

## Breaking Changes

| Change | Before | After |
|--------|--------|-------|
| Request field | `currency` | `instrument_code` |
| Response type | `MoneyAmount` (units/nanos) | `InstrumentAmount` (string amount) |

## Test Plan

- [x] Unit tests for new adapter functions pass
- [x] Existing position-keeping service tests updated and pass
- [x] Current-account integration tests updated and pass
- [x] `go build ./...` succeeds
- [ ] CI pipeline passes

## Task Master

- Tag: `internal-bank-account`
- Task: `19` - Extend Position Keeping balance API for multi-asset support