### PR TITLE
feat(internal-bank-account): implement domain model and entities

### DIFF
--- a/services/internal-bank-account/domain/account_status.go
+++ b/services/internal-bank-account/domain/account_status.go
@@ -1,0 +1,82 @@
+// Package domain contains the core business logic for internal bank accounts.
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrInvalidStatusTransition indicates an invalid account status transition was attempted.
+var ErrInvalidStatusTransition = errors.New("invalid status transition")
+
+// AccountStatus represents the lifecycle state of an internal bank account.
+type AccountStatus string
+
+// Account status constants.
+const (
+	AccountStatusActive    AccountStatus = "ACTIVE"
+	AccountStatusSuspended AccountStatus = "SUSPENDED"
+	AccountStatusClosed    AccountStatus = "CLOSED"
+)
+
+// Valid state transitions for internal bank accounts:
+//
+//	ACTIVE ↔ SUSPENDED (bidirectional)
+//	   │         │
+//	   └────┬────┘
+//	        ↓
+//	     CLOSED (terminal)
+//
+// - ACTIVE is the initial state for new accounts
+// - ACTIVE ↔ SUSPENDED transitions are bidirectional
+// - CLOSED is a terminal state - no transitions are allowed from CLOSED
+
+// validTransitions defines the allowed state transitions.
+// The map key is the source status, and the value is a set of valid target statuses.
+var validTransitions = map[AccountStatus]map[AccountStatus]bool{
+	AccountStatusActive: {
+		AccountStatusSuspended: true,
+		AccountStatusClosed:    true,
+	},
+	AccountStatusSuspended: {
+		AccountStatusActive: true,
+		AccountStatusClosed: true,
+	},
+	AccountStatusClosed: {
+		// No valid transitions from CLOSED - it's a terminal state
+	},
+}
+
+// CanTransitionTo checks if a transition from the current status to the target status is valid.
+func (s AccountStatus) CanTransitionTo(target AccountStatus) bool {
+	if s == target {
+		return false // Same status is not a transition
+	}
+	allowed, exists := validTransitions[s]
+	if !exists {
+		return false
+	}
+	return allowed[target]
+}
+
+// ValidateTransition checks if transitioning from one status to another is valid.
+// Returns an error if the transition is not allowed.
+func ValidateTransition(from, to AccountStatus) error {
+	if from == to {
+		return fmt.Errorf("%w: source and target status are the same", ErrInvalidStatusTransition)
+	}
+	if !from.CanTransitionTo(to) {
+		return fmt.Errorf("%w: cannot transition from %s to %s", ErrInvalidStatusTransition, from, to)
+	}
+	return nil
+}
+
+// StatusChange represents a recorded state transition for audit purposes.
+type StatusChange struct {
+	From      AccountStatus
+	To        AccountStatus
+	Reason    string
+	Timestamp time.Time
+	ChangedBy string
+}

--- a/services/internal-bank-account/domain/account_status_test.go
+++ b/services/internal-bank-account/domain/account_status_test.go
@@ -1,0 +1,236 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountStatus_ValidTransitions(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   AccountStatus
+		to     AccountStatus
+		reason string
+	}{
+		{
+			name:   "ACTIVE to SUSPENDED",
+			from:   AccountStatusActive,
+			to:     AccountStatusSuspended,
+			reason: "Suspending active account should be allowed",
+		},
+		{
+			name:   "SUSPENDED to ACTIVE",
+			from:   AccountStatusSuspended,
+			to:     AccountStatusActive,
+			reason: "Reactivating suspended account should be allowed",
+		},
+		{
+			name:   "ACTIVE to CLOSED",
+			from:   AccountStatusActive,
+			to:     AccountStatusClosed,
+			reason: "Closing active account should be allowed",
+		},
+		{
+			name:   "SUSPENDED to CLOSED",
+			from:   AccountStatusSuspended,
+			to:     AccountStatusClosed,
+			reason: "Closing suspended account should be allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test CanTransitionTo method
+			assert.True(t, tt.from.CanTransitionTo(tt.to), tt.reason)
+
+			// Test ValidateTransition function
+			err := ValidateTransition(tt.from, tt.to)
+			assert.NoError(t, err, tt.reason)
+		})
+	}
+}
+
+func TestAccountStatus_InvalidTransitions(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   AccountStatus
+		to     AccountStatus
+		reason string
+	}{
+		{
+			name:   "CLOSED to ACTIVE",
+			from:   AccountStatusClosed,
+			to:     AccountStatusActive,
+			reason: "Reactivating closed account should not be allowed",
+		},
+		{
+			name:   "CLOSED to SUSPENDED",
+			from:   AccountStatusClosed,
+			to:     AccountStatusSuspended,
+			reason: "Suspending closed account should not be allowed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test CanTransitionTo method
+			assert.False(t, tt.from.CanTransitionTo(tt.to), tt.reason)
+
+			// Test ValidateTransition function
+			err := ValidateTransition(tt.from, tt.to)
+			assert.Error(t, err, tt.reason)
+			assert.True(t, errors.Is(err, ErrInvalidStatusTransition))
+		})
+	}
+}
+
+func TestAccountStatus_TerminalState(t *testing.T) {
+	// CLOSED is a terminal state - no transitions should be allowed from it
+	closedStatus := AccountStatusClosed
+
+	t.Run("cannot transition to ACTIVE", func(t *testing.T) {
+		assert.False(t, closedStatus.CanTransitionTo(AccountStatusActive))
+		err := ValidateTransition(closedStatus, AccountStatusActive)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrInvalidStatusTransition))
+	})
+
+	t.Run("cannot transition to SUSPENDED", func(t *testing.T) {
+		assert.False(t, closedStatus.CanTransitionTo(AccountStatusSuspended))
+		err := ValidateTransition(closedStatus, AccountStatusSuspended)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrInvalidStatusTransition))
+	})
+
+	t.Run("cannot transition to CLOSED (same state)", func(t *testing.T) {
+		assert.False(t, closedStatus.CanTransitionTo(AccountStatusClosed))
+		err := ValidateTransition(closedStatus, AccountStatusClosed)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, ErrInvalidStatusTransition))
+		assert.Contains(t, err.Error(), "source and target status are the same")
+	})
+}
+
+func TestAccountStatus_SameStatusTransition(t *testing.T) {
+	// Transitioning to the same status should be rejected
+	tests := []struct {
+		name   string
+		status AccountStatus
+	}{
+		{"ACTIVE to ACTIVE", AccountStatusActive},
+		{"SUSPENDED to SUSPENDED", AccountStatusSuspended},
+		{"CLOSED to CLOSED", AccountStatusClosed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, tt.status.CanTransitionTo(tt.status))
+			err := ValidateTransition(tt.status, tt.status)
+			assert.Error(t, err)
+			assert.True(t, errors.Is(err, ErrInvalidStatusTransition))
+			assert.Contains(t, err.Error(), "source and target status are the same")
+		})
+	}
+}
+
+func TestStatusChange_AuditFields(t *testing.T) {
+	now := time.Now()
+
+	statusChange := StatusChange{
+		From:      AccountStatusActive,
+		To:        AccountStatusSuspended,
+		Reason:    "Suspicious activity detected",
+		Timestamp: now,
+		ChangedBy: "compliance-officer@example.com",
+	}
+
+	// Verify all fields are populated correctly
+	require.Equal(t, AccountStatusActive, statusChange.From, "From field should be set")
+	require.Equal(t, AccountStatusSuspended, statusChange.To, "To field should be set")
+	require.Equal(t, "Suspicious activity detected", statusChange.Reason, "Reason field should be set")
+	require.Equal(t, now, statusChange.Timestamp, "Timestamp field should be set")
+	require.Equal(t, "compliance-officer@example.com", statusChange.ChangedBy, "ChangedBy field should be set")
+
+	// Additional assertions to verify field values are not empty/zero
+	assert.NotEmpty(t, string(statusChange.From), "From should not be empty")
+	assert.NotEmpty(t, string(statusChange.To), "To should not be empty")
+	assert.NotEmpty(t, statusChange.Reason, "Reason should not be empty")
+	assert.False(t, statusChange.Timestamp.IsZero(), "Timestamp should not be zero")
+	assert.NotEmpty(t, statusChange.ChangedBy, "ChangedBy should not be empty")
+}
+
+func TestStatusChange_MultipleTranitionsAuditTrail(t *testing.T) {
+	// Simulate a series of status changes that would be recorded
+	baseTime := time.Now()
+
+	changes := []StatusChange{
+		{
+			From:      AccountStatusActive,
+			To:        AccountStatusSuspended,
+			Reason:    "Investigation required",
+			Timestamp: baseTime,
+			ChangedBy: "compliance@example.com",
+		},
+		{
+			From:      AccountStatusSuspended,
+			To:        AccountStatusActive,
+			Reason:    "Investigation cleared",
+			Timestamp: baseTime.Add(24 * time.Hour),
+			ChangedBy: "manager@example.com",
+		},
+		{
+			From:      AccountStatusActive,
+			To:        AccountStatusClosed,
+			Reason:    "Account closed by customer request",
+			Timestamp: baseTime.Add(48 * time.Hour),
+			ChangedBy: "customer-service@example.com",
+		},
+	}
+
+	// Verify the audit trail
+	require.Len(t, changes, 3, "Should have 3 status changes")
+
+	// First change: ACTIVE -> SUSPENDED
+	assert.Equal(t, AccountStatusActive, changes[0].From)
+	assert.Equal(t, AccountStatusSuspended, changes[0].To)
+
+	// Second change: SUSPENDED -> ACTIVE
+	assert.Equal(t, AccountStatusSuspended, changes[1].From)
+	assert.Equal(t, AccountStatusActive, changes[1].To)
+
+	// Third change: ACTIVE -> CLOSED (terminal)
+	assert.Equal(t, AccountStatusActive, changes[2].From)
+	assert.Equal(t, AccountStatusClosed, changes[2].To)
+
+	// Verify timestamps are in order
+	assert.True(t, changes[1].Timestamp.After(changes[0].Timestamp))
+	assert.True(t, changes[2].Timestamp.After(changes[1].Timestamp))
+}
+
+func TestAccountStatus_UnknownStatus(t *testing.T) {
+	// Test behavior with an unknown/invalid status
+	unknownStatus := AccountStatus("UNKNOWN")
+
+	t.Run("unknown status cannot transition to valid status", func(t *testing.T) {
+		assert.False(t, unknownStatus.CanTransitionTo(AccountStatusActive))
+		assert.False(t, unknownStatus.CanTransitionTo(AccountStatusSuspended))
+		assert.False(t, unknownStatus.CanTransitionTo(AccountStatusClosed))
+	})
+
+	t.Run("valid status cannot transition to unknown status", func(t *testing.T) {
+		// These should return false because the unknown status is not in the valid transitions
+		assert.False(t, AccountStatusActive.CanTransitionTo(unknownStatus))
+		assert.False(t, AccountStatusSuspended.CanTransitionTo(unknownStatus))
+	})
+}
+
+func TestAccountStatus_Constants(t *testing.T) {
+	// Verify the constant values are as expected
+	assert.Equal(t, AccountStatus("ACTIVE"), AccountStatusActive)
+	assert.Equal(t, AccountStatus("SUSPENDED"), AccountStatusSuspended)
+	assert.Equal(t, AccountStatus("CLOSED"), AccountStatusClosed)
+}

--- a/services/internal-bank-account/domain/account_type.go
+++ b/services/internal-bank-account/domain/account_type.go
@@ -1,0 +1,60 @@
+// Package domain contains the core business logic for internal bank accounts.
+package domain
+
+// AccountType represents the type of internal bank account.
+// Internal accounts are used for the bank's own operations, not customer accounts.
+type AccountType string
+
+// Account type constants for internal bank accounts.
+// These represent different operational purposes within the bank's own accounting.
+const (
+	// AccountTypeClearing is used for settling transactions between accounts.
+	AccountTypeClearing AccountType = "CLEARING"
+
+	// AccountTypeNostro is an account held at another bank (our account at their bank).
+	// Requires a correspondent bank relationship.
+	AccountTypeNostro AccountType = "NOSTRO"
+
+	// AccountTypeVostro is an account held for another bank (their account at our bank).
+	// Requires a correspondent bank relationship.
+	AccountTypeVostro AccountType = "VOSTRO"
+
+	// AccountTypeHolding is used for temporarily holding funds during processing.
+	AccountTypeHolding AccountType = "HOLDING"
+
+	// AccountTypeSuspense is used for transactions that cannot be immediately categorized.
+	AccountTypeSuspense AccountType = "SUSPENSE"
+
+	// AccountTypeRevenue is used for tracking income and revenue streams.
+	AccountTypeRevenue AccountType = "REVENUE"
+
+	// AccountTypeExpense is used for tracking operational expenses.
+	AccountTypeExpense AccountType = "EXPENSE"
+)
+
+// validAccountTypes contains all valid account types for efficient lookup.
+var validAccountTypes = map[AccountType]bool{
+	AccountTypeClearing: true,
+	AccountTypeNostro:   true,
+	AccountTypeVostro:   true,
+	AccountTypeHolding:  true,
+	AccountTypeSuspense: true,
+	AccountTypeRevenue:  true,
+	AccountTypeExpense:  true,
+}
+
+// IsValid returns true if the account type is a recognized valid type.
+func (t AccountType) IsValid() bool {
+	return validAccountTypes[t]
+}
+
+// String returns the string representation of the account type.
+func (t AccountType) String() string {
+	return string(t)
+}
+
+// RequiresCorrespondent returns true if the account type requires a correspondent bank relationship.
+// This applies to NOSTRO and VOSTRO accounts which represent inter-bank relationships.
+func (t AccountType) RequiresCorrespondent() bool {
+	return t == AccountTypeNostro || t == AccountTypeVostro
+}

--- a/services/internal-bank-account/domain/account_type_test.go
+++ b/services/internal-bank-account/domain/account_type_test.go
@@ -1,0 +1,195 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccountType_IsValid(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountType AccountType
+		want        bool
+	}{
+		{
+			name:        "CLEARING is valid",
+			accountType: AccountTypeClearing,
+			want:        true,
+		},
+		{
+			name:        "NOSTRO is valid",
+			accountType: AccountTypeNostro,
+			want:        true,
+		},
+		{
+			name:        "VOSTRO is valid",
+			accountType: AccountTypeVostro,
+			want:        true,
+		},
+		{
+			name:        "HOLDING is valid",
+			accountType: AccountTypeHolding,
+			want:        true,
+		},
+		{
+			name:        "SUSPENSE is valid",
+			accountType: AccountTypeSuspense,
+			want:        true,
+		},
+		{
+			name:        "REVENUE is valid",
+			accountType: AccountTypeRevenue,
+			want:        true,
+		},
+		{
+			name:        "EXPENSE is valid",
+			accountType: AccountTypeExpense,
+			want:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.accountType.IsValid())
+		})
+	}
+}
+
+func TestAccountType_Invalid(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountType AccountType
+	}{
+		{
+			name:        "empty string is invalid",
+			accountType: AccountType(""),
+		},
+		{
+			name:        "unknown type is invalid",
+			accountType: AccountType("UNKNOWN"),
+		},
+		{
+			name:        "lowercase is invalid",
+			accountType: AccountType("clearing"),
+		},
+		{
+			name:        "mixed case is invalid",
+			accountType: AccountType("Nostro"),
+		},
+		{
+			name:        "typo is invalid",
+			accountType: AccountType("CLEERING"),
+		},
+		{
+			name:        "extra whitespace is invalid",
+			accountType: AccountType(" CLEARING"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, tt.accountType.IsValid())
+		})
+	}
+}
+
+func TestAccountType_String(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountType AccountType
+		want        string
+	}{
+		{
+			name:        "CLEARING string",
+			accountType: AccountTypeClearing,
+			want:        "CLEARING",
+		},
+		{
+			name:        "NOSTRO string",
+			accountType: AccountTypeNostro,
+			want:        "NOSTRO",
+		},
+		{
+			name:        "VOSTRO string",
+			accountType: AccountTypeVostro,
+			want:        "VOSTRO",
+		},
+		{
+			name:        "HOLDING string",
+			accountType: AccountTypeHolding,
+			want:        "HOLDING",
+		},
+		{
+			name:        "SUSPENSE string",
+			accountType: AccountTypeSuspense,
+			want:        "SUSPENSE",
+		},
+		{
+			name:        "REVENUE string",
+			accountType: AccountTypeRevenue,
+			want:        "REVENUE",
+		},
+		{
+			name:        "EXPENSE string",
+			accountType: AccountTypeExpense,
+			want:        "EXPENSE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.accountType.String())
+		})
+	}
+}
+
+func TestAccountType_RequiresCorrespondent(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountType AccountType
+		want        bool
+	}{
+		{
+			name:        "NOSTRO requires correspondent",
+			accountType: AccountTypeNostro,
+			want:        true,
+		},
+		{
+			name:        "VOSTRO requires correspondent",
+			accountType: AccountTypeVostro,
+			want:        true,
+		},
+		{
+			name:        "CLEARING does not require correspondent",
+			accountType: AccountTypeClearing,
+			want:        false,
+		},
+		{
+			name:        "HOLDING does not require correspondent",
+			accountType: AccountTypeHolding,
+			want:        false,
+		},
+		{
+			name:        "SUSPENSE does not require correspondent",
+			accountType: AccountTypeSuspense,
+			want:        false,
+		},
+		{
+			name:        "REVENUE does not require correspondent",
+			accountType: AccountTypeRevenue,
+			want:        false,
+		},
+		{
+			name:        "EXPENSE does not require correspondent",
+			accountType: AccountTypeExpense,
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.accountType.RequiresCorrespondent())
+		})
+	}
+}

--- a/services/internal-bank-account/domain/correspondent.go
+++ b/services/internal-bank-account/domain/correspondent.go
@@ -1,0 +1,177 @@
+// Package domain contains the domain model for the Internal Bank Account service.
+package domain
+
+import (
+	"errors"
+)
+
+// Package-level validation errors for CorrespondentDetails.
+var (
+	errBankIDRequired             = errors.New("bank ID is required")
+	errBankNameTooShort           = errors.New("bank name must be at least 3 characters")
+	errExternalAccountRefRequired = errors.New("external account reference is required")
+)
+
+// CorrespondentDetails represents the correspondent bank relationship details for an internal bank account.
+// This is a value object (no identity) that captures the relationship between an internal account
+// and its corresponding account at an external correspondent bank.
+//
+// Value object semantics: immutable after construction, equality based on all fields.
+type CorrespondentDetails struct {
+	// bankID is the identifier for the correspondent bank (e.g., internal bank code, routing number).
+	bankID string
+
+	// bankName is the human-readable name of the correspondent bank.
+	bankName string
+
+	// externalAccountRef is the correspondent bank's reference for this account
+	// (e.g., their internal account number, nostro/vostro reference).
+	externalAccountRef string
+
+	// swiftCode is the optional BIC/SWIFT code for international routing.
+	swiftCode string
+
+	// attributes provides extensibility for additional correspondent-specific metadata.
+	attributes map[string]string
+}
+
+// NewCorrespondentDetails creates a new CorrespondentDetails with required fields.
+// Returns an error if validation fails.
+//
+// Validation rules:
+//   - bankID: required, minimum 1 character
+//   - bankName: required, minimum 3 characters
+//   - externalAccountRef: required, minimum 1 character
+func NewCorrespondentDetails(bankID, bankName, externalAccountRef string) (*CorrespondentDetails, error) {
+	return NewCorrespondentDetailsWithOptions(bankID, bankName, externalAccountRef, "", nil)
+}
+
+// NewCorrespondentDetailsWithOptions creates a new CorrespondentDetails with all fields including optional ones.
+// Returns an error if validation fails.
+//
+// Validation rules:
+//   - bankID: required, minimum 1 character
+//   - bankName: required, minimum 3 characters
+//   - externalAccountRef: required, minimum 1 character
+//   - swiftCode: optional (no validation)
+//   - attributes: optional (nil is valid)
+func NewCorrespondentDetailsWithOptions(
+	bankID, bankName, externalAccountRef, swiftCode string,
+	attributes map[string]string,
+) (*CorrespondentDetails, error) {
+	// Validate required fields
+	if bankID == "" {
+		return nil, errBankIDRequired
+	}
+	if len(bankName) < 3 {
+		return nil, errBankNameTooShort
+	}
+	if externalAccountRef == "" {
+		return nil, errExternalAccountRefRequired
+	}
+
+	// Deep copy attributes map to ensure immutability
+	var attrsCopy map[string]string
+	if attributes != nil {
+		attrsCopy = make(map[string]string, len(attributes))
+		for k, v := range attributes {
+			attrsCopy[k] = v
+		}
+	}
+
+	return &CorrespondentDetails{
+		bankID:             bankID,
+		bankName:           bankName,
+		externalAccountRef: externalAccountRef,
+		swiftCode:          swiftCode,
+		attributes:         attrsCopy,
+	}, nil
+}
+
+// BankID returns the correspondent bank identifier.
+func (c *CorrespondentDetails) BankID() string {
+	if c == nil {
+		return ""
+	}
+	return c.bankID
+}
+
+// BankName returns the human-readable correspondent bank name.
+func (c *CorrespondentDetails) BankName() string {
+	if c == nil {
+		return ""
+	}
+	return c.bankName
+}
+
+// ExternalAccountRef returns the correspondent bank's reference for this account.
+func (c *CorrespondentDetails) ExternalAccountRef() string {
+	if c == nil {
+		return ""
+	}
+	return c.externalAccountRef
+}
+
+// SwiftCode returns the optional BIC/SWIFT code.
+// Returns empty string if not set.
+func (c *CorrespondentDetails) SwiftCode() string {
+	if c == nil {
+		return ""
+	}
+	return c.swiftCode
+}
+
+// Attributes returns a copy of the extensibility attributes.
+// Returns nil if no attributes are set.
+// The returned map is a copy to preserve immutability.
+func (c *CorrespondentDetails) Attributes() map[string]string {
+	if c == nil || c.attributes == nil {
+		return nil
+	}
+	// Return a copy to preserve immutability
+	result := make(map[string]string, len(c.attributes))
+	for k, v := range c.attributes {
+		result[k] = v
+	}
+	return result
+}
+
+// Equals compares two CorrespondentDetails for value equality.
+// Two nil values are considered equal.
+// A nil compared to a non-nil is not equal.
+func (c *CorrespondentDetails) Equals(other *CorrespondentDetails) bool {
+	// Both nil are equal
+	if c == nil && other == nil {
+		return true
+	}
+	// One nil, one non-nil are not equal
+	if c == nil || other == nil {
+		return false
+	}
+
+	// Compare all fields
+	if c.bankID != other.bankID {
+		return false
+	}
+	if c.bankName != other.bankName {
+		return false
+	}
+	if c.externalAccountRef != other.externalAccountRef {
+		return false
+	}
+	if c.swiftCode != other.swiftCode {
+		return false
+	}
+
+	// Compare attributes maps
+	if len(c.attributes) != len(other.attributes) {
+		return false
+	}
+	for k, v := range c.attributes {
+		if otherV, ok := other.attributes[k]; !ok || v != otherV {
+			return false
+		}
+	}
+
+	return true
+}

--- a/services/internal-bank-account/domain/correspondent_test.go
+++ b/services/internal-bank-account/domain/correspondent_test.go
@@ -1,0 +1,393 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCorrespondentDetails_Success(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		bankID             string
+		bankName           string
+		externalAccountRef string
+	}{
+		{
+			name:               "minimum valid inputs",
+			bankID:             "B",
+			bankName:           "ABC",
+			externalAccountRef: "X",
+		},
+		{
+			name:               "typical values",
+			bankID:             "BARCLAYS_UK",
+			bankName:           "Barclays Bank UK PLC",
+			externalAccountRef: "GB82WEST12345698765432",
+		},
+		{
+			name:               "longer values",
+			bankID:             "CORRESPONDENT_BANK_12345",
+			bankName:           "First National Bank of Testing International",
+			externalAccountRef: "NOSTRO-ACC-2024-001-GBP",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			details, err := NewCorrespondentDetails(tt.bankID, tt.bankName, tt.externalAccountRef)
+
+			require.NoError(t, err)
+			require.NotNil(t, details)
+			assert.Equal(t, tt.bankID, details.BankID())
+			assert.Equal(t, tt.bankName, details.BankName())
+			assert.Equal(t, tt.externalAccountRef, details.ExternalAccountRef())
+			assert.Empty(t, details.SwiftCode(), "SwiftCode should be empty when not provided")
+			assert.Nil(t, details.Attributes(), "Attributes should be nil when not provided")
+		})
+	}
+}
+
+func TestNewCorrespondentDetailsWithOptions_Success(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		bankID             string
+		bankName           string
+		externalAccountRef string
+		swiftCode          string
+		attributes         map[string]string
+	}{
+		{
+			name:               "with swift code only",
+			bankID:             "BARCLAYS_UK",
+			bankName:           "Barclays Bank",
+			externalAccountRef: "ACC123",
+			swiftCode:          "BABORKLXXX",
+			attributes:         nil,
+		},
+		{
+			name:               "with attributes only",
+			bankID:             "HSBC_UK",
+			bankName:           "HSBC Holdings",
+			externalAccountRef: "ACC456",
+			swiftCode:          "",
+			attributes:         map[string]string{"region": "EMEA", "tier": "primary"},
+		},
+		{
+			name:               "with all optional fields",
+			bankID:             "LLOYDS_UK",
+			bankName:           "Lloyds Banking Group",
+			externalAccountRef: "ACC789",
+			swiftCode:          "LOYDGB2LXXX",
+			attributes:         map[string]string{"category": "clearing", "priority": "high"},
+		},
+		{
+			name:               "with empty attributes map",
+			bankID:             "NATWEST_UK",
+			bankName:           "NatWest Group",
+			externalAccountRef: "ACC000",
+			swiftCode:          "NWBKGB2L",
+			attributes:         map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			details, err := NewCorrespondentDetailsWithOptions(
+				tt.bankID, tt.bankName, tt.externalAccountRef,
+				tt.swiftCode, tt.attributes,
+			)
+
+			require.NoError(t, err)
+			require.NotNil(t, details)
+			assert.Equal(t, tt.bankID, details.BankID())
+			assert.Equal(t, tt.bankName, details.BankName())
+			assert.Equal(t, tt.externalAccountRef, details.ExternalAccountRef())
+			assert.Equal(t, tt.swiftCode, details.SwiftCode())
+
+			if tt.attributes == nil {
+				assert.Nil(t, details.Attributes())
+			} else {
+				// Verify attributes match (empty map returns empty map, not nil)
+				attrs := details.Attributes()
+				if len(tt.attributes) == 0 {
+					assert.Empty(t, attrs)
+				} else {
+					assert.Equal(t, tt.attributes, attrs)
+				}
+			}
+		})
+	}
+}
+
+func TestNewCorrespondentDetails_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		bankID             string
+		bankName           string
+		externalAccountRef string
+		expectedErr        error
+		errDescription     string
+	}{
+		{
+			name:               "empty bank ID",
+			bankID:             "",
+			bankName:           "Valid Bank Name",
+			externalAccountRef: "ACC123",
+			expectedErr:        errBankIDRequired,
+			errDescription:     "bank ID is required",
+		},
+		{
+			name:               "empty external account ref",
+			bankID:             "BANK123",
+			bankName:           "Valid Bank Name",
+			externalAccountRef: "",
+			expectedErr:        errExternalAccountRefRequired,
+			errDescription:     "external account reference is required",
+		},
+		{
+			name:               "bank name too short - empty",
+			bankID:             "BANK123",
+			bankName:           "",
+			externalAccountRef: "ACC123",
+			expectedErr:        errBankNameTooShort,
+			errDescription:     "bank name must be at least 3 characters",
+		},
+		{
+			name:               "bank name too short - one char",
+			bankID:             "BANK123",
+			bankName:           "A",
+			externalAccountRef: "ACC123",
+			expectedErr:        errBankNameTooShort,
+			errDescription:     "bank name must be at least 3 characters",
+		},
+		{
+			name:               "bank name too short - two chars",
+			bankID:             "BANK123",
+			bankName:           "AB",
+			externalAccountRef: "ACC123",
+			expectedErr:        errBankNameTooShort,
+			errDescription:     "bank name must be at least 3 characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			details, err := NewCorrespondentDetails(tt.bankID, tt.bankName, tt.externalAccountRef)
+
+			assert.Nil(t, details, "details should be nil on validation error")
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.expectedErr, "expected error: %s", tt.errDescription)
+		})
+	}
+}
+
+func TestCorrespondentDetails_Equality(t *testing.T) {
+	t.Parallel()
+
+	t.Run("identical values are equal", func(t *testing.T) {
+		t.Parallel()
+
+		details1, err := NewCorrespondentDetails("BANK1", "First Bank", "ACC001")
+		require.NoError(t, err)
+
+		details2, err := NewCorrespondentDetails("BANK1", "First Bank", "ACC001")
+		require.NoError(t, err)
+
+		assert.True(t, details1.Equals(details2), "identical details should be equal")
+		assert.True(t, details2.Equals(details1), "equality should be symmetric")
+	})
+
+	t.Run("different bank ID not equal", func(t *testing.T) {
+		t.Parallel()
+
+		details1, err := NewCorrespondentDetails("BANK1", "First Bank", "ACC001")
+		require.NoError(t, err)
+
+		details2, err := NewCorrespondentDetails("BANK2", "First Bank", "ACC001")
+		require.NoError(t, err)
+
+		assert.False(t, details1.Equals(details2), "different bank IDs should not be equal")
+	})
+
+	t.Run("different bank name not equal", func(t *testing.T) {
+		t.Parallel()
+
+		details1, err := NewCorrespondentDetails("BANK1", "First Bank", "ACC001")
+		require.NoError(t, err)
+
+		details2, err := NewCorrespondentDetails("BANK1", "Second Bank", "ACC001")
+		require.NoError(t, err)
+
+		assert.False(t, details1.Equals(details2), "different bank names should not be equal")
+	})
+
+	t.Run("different external account ref not equal", func(t *testing.T) {
+		t.Parallel()
+
+		details1, err := NewCorrespondentDetails("BANK1", "First Bank", "ACC001")
+		require.NoError(t, err)
+
+		details2, err := NewCorrespondentDetails("BANK1", "First Bank", "ACC002")
+		require.NoError(t, err)
+
+		assert.False(t, details1.Equals(details2), "different external refs should not be equal")
+	})
+
+	t.Run("different swift code not equal", func(t *testing.T) {
+		t.Parallel()
+
+		details1, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "SWIFT1", nil)
+		require.NoError(t, err)
+
+		details2, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "SWIFT2", nil)
+		require.NoError(t, err)
+
+		assert.False(t, details1.Equals(details2), "different swift codes should not be equal")
+	})
+
+	t.Run("different attributes not equal", func(t *testing.T) {
+		t.Parallel()
+
+		attrs1 := map[string]string{"key": "value1"}
+		attrs2 := map[string]string{"key": "value2"}
+
+		details1, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "", attrs1)
+		require.NoError(t, err)
+
+		details2, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "", attrs2)
+		require.NoError(t, err)
+
+		assert.False(t, details1.Equals(details2), "different attributes should not be equal")
+	})
+
+	t.Run("different attribute keys not equal", func(t *testing.T) {
+		t.Parallel()
+
+		attrs1 := map[string]string{"key1": "value"}
+		attrs2 := map[string]string{"key2": "value"}
+
+		details1, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "", attrs1)
+		require.NoError(t, err)
+
+		details2, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "", attrs2)
+		require.NoError(t, err)
+
+		assert.False(t, details1.Equals(details2), "different attribute keys should not be equal")
+	})
+
+	t.Run("nil attributes vs empty attributes", func(t *testing.T) {
+		t.Parallel()
+
+		details1, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "", nil)
+		require.NoError(t, err)
+
+		details2, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "", map[string]string{})
+		require.NoError(t, err)
+
+		// Both have len 0, so they should be equal
+		assert.True(t, details1.Equals(details2), "nil and empty attributes should be equal")
+	})
+
+	t.Run("identical with all optional fields", func(t *testing.T) {
+		t.Parallel()
+
+		attrs := map[string]string{"region": "EMEA", "tier": "primary"}
+
+		details1, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "SWIFT123", attrs)
+		require.NoError(t, err)
+
+		details2, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "SWIFT123", attrs)
+		require.NoError(t, err)
+
+		assert.True(t, details1.Equals(details2), "identical details with all fields should be equal")
+	})
+}
+
+func TestCorrespondentDetails_NilHandling(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil equals nil", func(t *testing.T) {
+		t.Parallel()
+
+		var details1 *CorrespondentDetails
+		var details2 *CorrespondentDetails
+
+		assert.True(t, details1.Equals(details2), "two nil CorrespondentDetails should be equal")
+	})
+
+	t.Run("nil not equal to non-nil", func(t *testing.T) {
+		t.Parallel()
+
+		var nilDetails *CorrespondentDetails
+		nonNilDetails, err := NewCorrespondentDetails("BANK1", "First Bank", "ACC001")
+		require.NoError(t, err)
+
+		assert.False(t, nilDetails.Equals(nonNilDetails), "nil should not equal non-nil")
+		assert.False(t, nonNilDetails.Equals(nilDetails), "non-nil should not equal nil")
+	})
+
+	t.Run("nil receiver returns empty values", func(t *testing.T) {
+		t.Parallel()
+
+		var details *CorrespondentDetails
+
+		assert.Empty(t, details.BankID(), "nil receiver BankID() should return empty string")
+		assert.Empty(t, details.BankName(), "nil receiver BankName() should return empty string")
+		assert.Empty(t, details.ExternalAccountRef(), "nil receiver ExternalAccountRef() should return empty string")
+		assert.Empty(t, details.SwiftCode(), "nil receiver SwiftCode() should return empty string")
+		assert.Nil(t, details.Attributes(), "nil receiver Attributes() should return nil")
+	})
+}
+
+func TestCorrespondentDetails_Immutability(t *testing.T) {
+	t.Parallel()
+
+	t.Run("attributes are copied on construction", func(t *testing.T) {
+		t.Parallel()
+
+		originalAttrs := map[string]string{"key": "original"}
+		details, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "", originalAttrs)
+		require.NoError(t, err)
+
+		// Modify the original map
+		originalAttrs["key"] = "modified"
+		originalAttrs["new_key"] = "new_value"
+
+		// The details should not be affected
+		attrs := details.Attributes()
+		assert.Equal(t, "original", attrs["key"], "internal attributes should not be modified")
+		assert.NotContains(t, attrs, "new_key", "internal attributes should not have new keys")
+	})
+
+	t.Run("returned attributes are a copy", func(t *testing.T) {
+		t.Parallel()
+
+		attrs := map[string]string{"key": "original"}
+		details, err := NewCorrespondentDetailsWithOptions("BANK1", "First Bank", "ACC001", "", attrs)
+		require.NoError(t, err)
+
+		// Get attributes and modify the returned map
+		returnedAttrs := details.Attributes()
+		returnedAttrs["key"] = "modified"
+		returnedAttrs["new_key"] = "new_value"
+
+		// Get attributes again - should be unchanged
+		freshAttrs := details.Attributes()
+		assert.Equal(t, "original", freshAttrs["key"], "original attributes should not be modified")
+		assert.NotContains(t, freshAttrs, "new_key", "original attributes should not have new keys")
+	})
+}

--- a/services/internal-bank-account/domain/errors.go
+++ b/services/internal-bank-account/domain/errors.go
@@ -1,0 +1,49 @@
+// Package domain contains the core business logic for internal bank accounts.
+package domain
+
+import "errors"
+
+// Domain errors for internal bank account operations.
+// These follow the sentinel error pattern for consistent error handling.
+var (
+	// ErrAccountNotFound indicates the requested account does not exist.
+	ErrAccountNotFound = errors.New("account not found")
+
+	// ErrAccountClosed indicates an operation was attempted on a closed account.
+	ErrAccountClosed = errors.New("account is closed")
+
+	// ErrAccountSuspended indicates an operation was attempted on a suspended account.
+	ErrAccountSuspended = errors.New("account is suspended")
+
+	// ErrInvalidAccountType indicates an unrecognized account type was provided.
+	ErrInvalidAccountType = errors.New("invalid account type")
+
+	// ErrCorrespondentRequired indicates that correspondent details are required
+	// for NOSTRO/VOSTRO accounts but were not provided.
+	ErrCorrespondentRequired = errors.New("correspondent details required for NOSTRO/VOSTRO accounts")
+
+	// ErrCorrespondentNotAllowed indicates that correspondent details were provided
+	// for an account type that does not support correspondent relationships.
+	ErrCorrespondentNotAllowed = errors.New("correspondent details not allowed for this account type")
+
+	// ErrDuplicateAccountCode indicates an account with the given code already exists.
+	ErrDuplicateAccountCode = errors.New("account code already exists")
+
+	// ErrInvalidInstrumentCode indicates the provided instrument code is not valid.
+	ErrInvalidInstrumentCode = errors.New("invalid instrument code")
+
+	// ErrVersionMismatch indicates an optimistic locking conflict occurred.
+	// The account was modified by another process since it was read.
+	ErrVersionMismatch = errors.New("version mismatch: account was modified")
+
+	// Validation errors for required fields.
+
+	// ErrAccountIDRequired indicates the account ID was not provided.
+	ErrAccountIDRequired = errors.New("account ID is required")
+
+	// ErrAccountCodeRequired indicates the account code was not provided.
+	ErrAccountCodeRequired = errors.New("account code is required")
+
+	// ErrNameRequired indicates the account name was not provided.
+	ErrNameRequired = errors.New("name is required")
+)

--- a/services/internal-bank-account/domain/internal_account.go
+++ b/services/internal-bank-account/domain/internal_account.go
@@ -2,21 +2,9 @@
 package domain
 
 import (
-	"errors"
 	"time"
 
 	"github.com/google/uuid"
-)
-
-// Validation errors for InternalBankAccount.
-var (
-	errAccountIDRequired       = errors.New("account ID is required")
-	errAccountCodeRequired     = errors.New("account code is required")
-	errAccountNameRequired     = errors.New("account name is required")
-	errInvalidAccountType      = errors.New("invalid account type")
-	errCorrespondentRequired   = errors.New("correspondent details required for NOSTRO/VOSTRO accounts")
-	errCorrespondentNotAllowed = errors.New("correspondent details not allowed for this account type")
-	errAccountClosed           = errors.New("cannot modify closed account")
 )
 
 // InternalBankAccount represents an internal bank account aggregate root.
@@ -63,16 +51,16 @@ func NewInternalBankAccount(
 	instrumentCode, dimension string,
 ) (InternalBankAccount, error) {
 	if accountID == "" {
-		return InternalBankAccount{}, errAccountIDRequired
+		return InternalBankAccount{}, ErrAccountIDRequired
 	}
 	if accountCode == "" {
-		return InternalBankAccount{}, errAccountCodeRequired
+		return InternalBankAccount{}, ErrAccountCodeRequired
 	}
 	if name == "" {
-		return InternalBankAccount{}, errAccountNameRequired
+		return InternalBankAccount{}, ErrNameRequired
 	}
 	if !accountType.IsValid() {
-		return InternalBankAccount{}, errInvalidAccountType
+		return InternalBankAccount{}, ErrInvalidAccountType
 	}
 
 	now := time.Now()
@@ -132,16 +120,16 @@ func (a InternalBankAccount) Close(reason string) (InternalBankAccount, error) {
 //   - Other account types REJECT correspondent details (cannot pass non-nil)
 func (a InternalBankAccount) UpdateCorrespondent(details *CorrespondentDetails) (InternalBankAccount, error) {
 	if a.status == AccountStatusClosed {
-		return a, errAccountClosed
+		return a, ErrAccountClosed
 	}
 
 	requiresCorrespondent := a.accountType.RequiresCorrespondent()
 
 	if requiresCorrespondent && details == nil {
-		return a, errCorrespondentRequired
+		return a, ErrCorrespondentRequired
 	}
 	if !requiresCorrespondent && details != nil {
-		return a, errCorrespondentNotAllowed
+		return a, ErrCorrespondentNotAllowed
 	}
 
 	// Create new instance with updated correspondent

--- a/services/internal-bank-account/domain/internal_account.go
+++ b/services/internal-bank-account/domain/internal_account.go
@@ -1,0 +1,357 @@
+// Package domain contains the core business logic for internal bank accounts.
+package domain
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Validation errors for InternalBankAccount.
+var (
+	errAccountIDRequired       = errors.New("account ID is required")
+	errAccountCodeRequired     = errors.New("account code is required")
+	errAccountNameRequired     = errors.New("account name is required")
+	errInvalidAccountType      = errors.New("invalid account type")
+	errCorrespondentRequired   = errors.New("correspondent details required for NOSTRO/VOSTRO accounts")
+	errCorrespondentNotAllowed = errors.New("correspondent details not allowed for this account type")
+	errAccountClosed           = errors.New("cannot modify closed account")
+)
+
+// InternalBankAccount represents an internal bank account aggregate root.
+// This is an immutable value type - all modification methods return a new instance.
+//
+// Internal bank accounts are used for the bank's own operations:
+// - CLEARING: For settling transactions between accounts
+// - NOSTRO: Our account at another bank (requires correspondent)
+// - VOSTRO: Another bank's account at our bank (requires correspondent)
+// - HOLDING: Temporarily holding funds during processing
+// - SUSPENSE: Transactions that cannot be immediately categorized
+// - REVENUE: Tracking income and revenue streams
+// - EXPENSE: Tracking operational expenses
+type InternalBankAccount struct {
+	id             uuid.UUID
+	accountID      string // Business identifier like 'IBA-001'
+	accountCode    string // Unique code like 'GBP_CLEARING'
+	name           string // Display name
+	accountType    AccountType
+	instrumentCode string // References Reference Data (e.g., "USD", "GBP")
+	dimension      string // From reference_data (e.g., "CURRENCY", "ENERGY")
+	status         AccountStatus
+	correspondent  *CorrespondentDetails // Required for NOSTRO/VOSTRO
+	attributes     map[string]string     // Metadata
+	version        int64
+	createdAt      time.Time
+	updatedAt      time.Time
+}
+
+// NewInternalBankAccount creates a new InternalBankAccount with validated fields.
+// Returns a value type (not pointer) following the immutability pattern.
+//
+// Initial state:
+//   - Status: ACTIVE
+//   - Version: 1
+//   - Correspondent: nil (must be set via UpdateCorrespondent for NOSTRO/VOSTRO before use)
+//
+// Validation:
+//   - accountID, accountCode, name cannot be empty
+//   - accountType must be valid
+func NewInternalBankAccount(
+	accountID, accountCode, name string,
+	accountType AccountType,
+	instrumentCode, dimension string,
+) (InternalBankAccount, error) {
+	if accountID == "" {
+		return InternalBankAccount{}, errAccountIDRequired
+	}
+	if accountCode == "" {
+		return InternalBankAccount{}, errAccountCodeRequired
+	}
+	if name == "" {
+		return InternalBankAccount{}, errAccountNameRequired
+	}
+	if !accountType.IsValid() {
+		return InternalBankAccount{}, errInvalidAccountType
+	}
+
+	now := time.Now()
+	return InternalBankAccount{
+		id:             uuid.New(),
+		accountID:      accountID,
+		accountCode:    accountCode,
+		name:           name,
+		accountType:    accountType,
+		instrumentCode: instrumentCode,
+		dimension:      dimension,
+		status:         AccountStatusActive,
+		correspondent:  nil,
+		attributes:     nil,
+		version:        1,
+		createdAt:      now,
+		updatedAt:      now,
+	}, nil
+}
+
+// Suspend transitions the account to SUSPENDED status.
+// Returns a new instance with updated status.
+// Returns error if the transition is not valid.
+func (a InternalBankAccount) Suspend(reason string) (InternalBankAccount, error) {
+	if err := ValidateTransition(a.status, AccountStatusSuspended); err != nil {
+		return a, err
+	}
+	return a.withStatusChange(AccountStatusSuspended, reason), nil
+}
+
+// Activate transitions the account to ACTIVE status.
+// Returns a new instance with updated status.
+// Returns error if the transition is not valid.
+func (a InternalBankAccount) Activate() (InternalBankAccount, error) {
+	if err := ValidateTransition(a.status, AccountStatusActive); err != nil {
+		return a, err
+	}
+	return a.withStatusChange(AccountStatusActive, ""), nil
+}
+
+// Close transitions the account to CLOSED status.
+// This is a terminal state - no further transitions are allowed.
+// Returns a new instance with updated status.
+// Returns error if the transition is not valid.
+func (a InternalBankAccount) Close(reason string) (InternalBankAccount, error) {
+	if err := ValidateTransition(a.status, AccountStatusClosed); err != nil {
+		return a, err
+	}
+	return a.withStatusChange(AccountStatusClosed, reason), nil
+}
+
+// UpdateCorrespondent sets or updates the correspondent bank details.
+// Returns a new instance with updated correspondent.
+//
+// Validation:
+//   - NOSTRO/VOSTRO accounts REQUIRE correspondent details (cannot pass nil)
+//   - Other account types REJECT correspondent details (cannot pass non-nil)
+func (a InternalBankAccount) UpdateCorrespondent(details *CorrespondentDetails) (InternalBankAccount, error) {
+	if a.status == AccountStatusClosed {
+		return a, errAccountClosed
+	}
+
+	requiresCorrespondent := a.accountType.RequiresCorrespondent()
+
+	if requiresCorrespondent && details == nil {
+		return a, errCorrespondentRequired
+	}
+	if !requiresCorrespondent && details != nil {
+		return a, errCorrespondentNotAllowed
+	}
+
+	// Create new instance with updated correspondent
+	newAccount := a.copyWithUpdatedTime()
+	newAccount.correspondent = details
+	newAccount.version++
+	return newAccount, nil
+}
+
+// withStatusChange creates a new instance with updated status.
+// This is a private helper that handles the immutable update pattern.
+func (a InternalBankAccount) withStatusChange(newStatus AccountStatus, _ string) InternalBankAccount {
+	newAccount := a.copyWithUpdatedTime()
+	newAccount.status = newStatus
+	newAccount.version++
+	return newAccount
+}
+
+// copyWithUpdatedTime creates a copy of the account with updated timestamp.
+// Deep copies maps to ensure immutability.
+func (a InternalBankAccount) copyWithUpdatedTime() InternalBankAccount {
+	newAccount := a
+	newAccount.updatedAt = time.Now()
+
+	// Deep copy attributes map
+	if a.attributes != nil {
+		newAccount.attributes = make(map[string]string, len(a.attributes))
+		for k, v := range a.attributes {
+			newAccount.attributes[k] = v
+		}
+	}
+
+	return newAccount
+}
+
+// Getters for all unexported fields.
+
+// ID returns the internal unique identifier.
+func (a InternalBankAccount) ID() uuid.UUID {
+	return a.id
+}
+
+// AccountID returns the business identifier (e.g., 'IBA-001').
+func (a InternalBankAccount) AccountID() string {
+	return a.accountID
+}
+
+// AccountCode returns the unique code (e.g., 'GBP_CLEARING').
+func (a InternalBankAccount) AccountCode() string {
+	return a.accountCode
+}
+
+// Name returns the display name.
+func (a InternalBankAccount) Name() string {
+	return a.name
+}
+
+// AccountType returns the account type.
+func (a InternalBankAccount) AccountType() AccountType {
+	return a.accountType
+}
+
+// InstrumentCode returns the instrument code reference (e.g., "USD", "GBP").
+func (a InternalBankAccount) InstrumentCode() string {
+	return a.instrumentCode
+}
+
+// Dimension returns the dimension from reference data (e.g., "CURRENCY", "ENERGY").
+func (a InternalBankAccount) Dimension() string {
+	return a.dimension
+}
+
+// Status returns the current account status.
+func (a InternalBankAccount) Status() AccountStatus {
+	return a.status
+}
+
+// Correspondent returns the correspondent bank details.
+// Returns nil for non-NOSTRO/VOSTRO accounts.
+func (a InternalBankAccount) Correspondent() *CorrespondentDetails {
+	return a.correspondent
+}
+
+// Attributes returns a copy of the metadata attributes.
+// Returns nil if no attributes are set.
+func (a InternalBankAccount) Attributes() map[string]string {
+	if a.attributes == nil {
+		return nil
+	}
+	result := make(map[string]string, len(a.attributes))
+	for k, v := range a.attributes {
+		result[k] = v
+	}
+	return result
+}
+
+// Version returns the version number for optimistic locking.
+func (a InternalBankAccount) Version() int64 {
+	return a.version
+}
+
+// CreatedAt returns the creation timestamp.
+func (a InternalBankAccount) CreatedAt() time.Time {
+	return a.createdAt
+}
+
+// UpdatedAt returns the last update timestamp.
+func (a InternalBankAccount) UpdatedAt() time.Time {
+	return a.updatedAt
+}
+
+// InternalBankAccountBuilder provides a builder pattern for reconstructing
+// InternalBankAccount from persistence layer. This bypasses normal validation
+// since we assume persisted data was already validated.
+type InternalBankAccountBuilder struct {
+	account InternalBankAccount
+}
+
+// NewInternalBankAccountBuilder creates a new builder for InternalBankAccount reconstruction.
+func NewInternalBankAccountBuilder() *InternalBankAccountBuilder {
+	return &InternalBankAccountBuilder{
+		account: InternalBankAccount{},
+	}
+}
+
+// WithID sets the internal unique identifier.
+func (b *InternalBankAccountBuilder) WithID(id uuid.UUID) *InternalBankAccountBuilder {
+	b.account.id = id
+	return b
+}
+
+// WithAccountID sets the business identifier.
+func (b *InternalBankAccountBuilder) WithAccountID(accountID string) *InternalBankAccountBuilder {
+	b.account.accountID = accountID
+	return b
+}
+
+// WithAccountCode sets the unique code.
+func (b *InternalBankAccountBuilder) WithAccountCode(accountCode string) *InternalBankAccountBuilder {
+	b.account.accountCode = accountCode
+	return b
+}
+
+// WithName sets the display name.
+func (b *InternalBankAccountBuilder) WithName(name string) *InternalBankAccountBuilder {
+	b.account.name = name
+	return b
+}
+
+// WithAccountType sets the account type.
+func (b *InternalBankAccountBuilder) WithAccountType(accountType AccountType) *InternalBankAccountBuilder {
+	b.account.accountType = accountType
+	return b
+}
+
+// WithInstrumentCode sets the instrument code reference.
+func (b *InternalBankAccountBuilder) WithInstrumentCode(instrumentCode string) *InternalBankAccountBuilder {
+	b.account.instrumentCode = instrumentCode
+	return b
+}
+
+// WithDimension sets the dimension.
+func (b *InternalBankAccountBuilder) WithDimension(dimension string) *InternalBankAccountBuilder {
+	b.account.dimension = dimension
+	return b
+}
+
+// WithStatus sets the account status.
+func (b *InternalBankAccountBuilder) WithStatus(status AccountStatus) *InternalBankAccountBuilder {
+	b.account.status = status
+	return b
+}
+
+// WithCorrespondent sets the correspondent bank details.
+func (b *InternalBankAccountBuilder) WithCorrespondent(correspondent *CorrespondentDetails) *InternalBankAccountBuilder {
+	b.account.correspondent = correspondent
+	return b
+}
+
+// WithAttributes sets the metadata attributes.
+func (b *InternalBankAccountBuilder) WithAttributes(attributes map[string]string) *InternalBankAccountBuilder {
+	if attributes != nil {
+		b.account.attributes = make(map[string]string, len(attributes))
+		for k, v := range attributes {
+			b.account.attributes[k] = v
+		}
+	}
+	return b
+}
+
+// WithVersion sets the version number.
+func (b *InternalBankAccountBuilder) WithVersion(version int64) *InternalBankAccountBuilder {
+	b.account.version = version
+	return b
+}
+
+// WithCreatedAt sets the creation timestamp.
+func (b *InternalBankAccountBuilder) WithCreatedAt(createdAt time.Time) *InternalBankAccountBuilder {
+	b.account.createdAt = createdAt
+	return b
+}
+
+// WithUpdatedAt sets the last update timestamp.
+func (b *InternalBankAccountBuilder) WithUpdatedAt(updatedAt time.Time) *InternalBankAccountBuilder {
+	b.account.updatedAt = updatedAt
+	return b
+}
+
+// Build returns the constructed InternalBankAccount.
+// This is used for persistence reconstruction and does not validate.
+func (b *InternalBankAccountBuilder) Build() InternalBankAccount {
+	return b.account
+}

--- a/services/internal-bank-account/domain/internal_account_test.go
+++ b/services/internal-bank-account/domain/internal_account_test.go
@@ -1,0 +1,592 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewInternalBankAccount_Success(t *testing.T) {
+	tests := []struct {
+		name           string
+		accountID      string
+		accountCode    string
+		accountName    string
+		accountType    AccountType
+		instrumentCode string
+		dimension      string
+	}{
+		{
+			name:           "clearing account",
+			accountID:      "IBA-001",
+			accountCode:    "GBP_CLEARING",
+			accountName:    "GBP Clearing Account",
+			accountType:    AccountTypeClearing,
+			instrumentCode: "GBP",
+			dimension:      "CURRENCY",
+		},
+		{
+			name:           "nostro account",
+			accountID:      "IBA-002",
+			accountCode:    "USD_NOSTRO_CHASE",
+			accountName:    "USD Nostro at Chase",
+			accountType:    AccountTypeNostro,
+			instrumentCode: "USD",
+			dimension:      "CURRENCY",
+		},
+		{
+			name:           "vostro account",
+			accountID:      "IBA-003",
+			accountCode:    "EUR_VOSTRO_DB",
+			accountName:    "EUR Vostro for Deutsche Bank",
+			accountType:    AccountTypeVostro,
+			instrumentCode: "EUR",
+			dimension:      "CURRENCY",
+		},
+		{
+			name:           "suspense account",
+			accountID:      "IBA-004",
+			accountCode:    "SUSPENSE_001",
+			accountName:    "General Suspense",
+			accountType:    AccountTypeSuspense,
+			instrumentCode: "USD",
+			dimension:      "CURRENCY",
+		},
+		{
+			name:           "energy holding account",
+			accountID:      "IBA-005",
+			accountCode:    "KWH_HOLDING",
+			accountName:    "Energy Holding Account",
+			accountType:    AccountTypeHolding,
+			instrumentCode: "KWH",
+			dimension:      "ENERGY",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			beforeCreate := time.Now()
+
+			account, err := NewInternalBankAccount(
+				tt.accountID,
+				tt.accountCode,
+				tt.accountName,
+				tt.accountType,
+				tt.instrumentCode,
+				tt.dimension,
+			)
+
+			require.NoError(t, err)
+
+			// Verify all fields are set correctly
+			assert.NotEqual(t, uuid.Nil, account.ID(), "ID should be generated")
+			assert.Equal(t, tt.accountID, account.AccountID())
+			assert.Equal(t, tt.accountCode, account.AccountCode())
+			assert.Equal(t, tt.accountName, account.Name())
+			assert.Equal(t, tt.accountType, account.AccountType())
+			assert.Equal(t, tt.instrumentCode, account.InstrumentCode())
+			assert.Equal(t, tt.dimension, account.Dimension())
+
+			// Verify initial state
+			assert.Equal(t, AccountStatusActive, account.Status(), "initial status should be ACTIVE")
+			assert.Equal(t, int64(1), account.Version(), "initial version should be 1")
+			assert.Nil(t, account.Correspondent(), "correspondent should be nil initially")
+			assert.Nil(t, account.Attributes(), "attributes should be nil initially")
+
+			// Verify timestamps
+			assert.False(t, account.CreatedAt().Before(beforeCreate), "createdAt should be >= beforeCreate")
+			assert.False(t, account.UpdatedAt().Before(beforeCreate), "updatedAt should be >= beforeCreate")
+			assert.Equal(t, account.CreatedAt(), account.UpdatedAt(), "createdAt and updatedAt should match initially")
+		})
+	}
+}
+
+func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
+	tests := []struct {
+		name           string
+		accountID      string
+		accountCode    string
+		accountName    string
+		accountType    AccountType
+		instrumentCode string
+		dimension      string
+		expectedErr    error
+	}{
+		{
+			name:           "empty account ID",
+			accountID:      "",
+			accountCode:    "GBP_CLEARING",
+			accountName:    "GBP Clearing Account",
+			accountType:    AccountTypeClearing,
+			instrumentCode: "GBP",
+			dimension:      "CURRENCY",
+			expectedErr:    errAccountIDRequired,
+		},
+		{
+			name:           "empty account code",
+			accountID:      "IBA-001",
+			accountCode:    "",
+			accountName:    "GBP Clearing Account",
+			accountType:    AccountTypeClearing,
+			instrumentCode: "GBP",
+			dimension:      "CURRENCY",
+			expectedErr:    errAccountCodeRequired,
+		},
+		{
+			name:           "empty name",
+			accountID:      "IBA-001",
+			accountCode:    "GBP_CLEARING",
+			accountName:    "",
+			accountType:    AccountTypeClearing,
+			instrumentCode: "GBP",
+			dimension:      "CURRENCY",
+			expectedErr:    errAccountNameRequired,
+		},
+		{
+			name:           "invalid account type",
+			accountID:      "IBA-001",
+			accountCode:    "GBP_CLEARING",
+			accountName:    "GBP Clearing Account",
+			accountType:    AccountType("INVALID"),
+			instrumentCode: "GBP",
+			dimension:      "CURRENCY",
+			expectedErr:    errInvalidAccountType,
+		},
+		{
+			name:           "empty account type",
+			accountID:      "IBA-001",
+			accountCode:    "GBP_CLEARING",
+			accountName:    "GBP Clearing Account",
+			accountType:    AccountType(""),
+			instrumentCode: "GBP",
+			dimension:      "CURRENCY",
+			expectedErr:    errInvalidAccountType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account, err := NewInternalBankAccount(
+				tt.accountID,
+				tt.accountCode,
+				tt.accountName,
+				tt.accountType,
+				tt.instrumentCode,
+				tt.dimension,
+			)
+
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.expectedErr)
+			assert.Equal(t, InternalBankAccount{}, account, "should return zero value on error")
+		})
+	}
+}
+
+func TestLifecycleTransitions_Valid(t *testing.T) {
+	account := createTestAccount(t, AccountTypeClearing)
+
+	// ACTIVE -> SUSPENDED
+	suspended, err := account.Suspend("Maintenance period")
+	require.NoError(t, err)
+	assert.Equal(t, AccountStatusSuspended, suspended.Status())
+	assert.Equal(t, int64(2), suspended.Version())
+
+	// SUSPENDED -> ACTIVE
+	reactivated, err := suspended.Activate()
+	require.NoError(t, err)
+	assert.Equal(t, AccountStatusActive, reactivated.Status())
+	assert.Equal(t, int64(3), reactivated.Version())
+
+	// ACTIVE -> CLOSED
+	closed, err := reactivated.Close("Account decommissioned")
+	require.NoError(t, err)
+	assert.Equal(t, AccountStatusClosed, closed.Status())
+	assert.Equal(t, int64(4), closed.Version())
+}
+
+func TestLifecycleTransitions_DirectToClose(t *testing.T) {
+	// Test ACTIVE -> CLOSED directly
+	account := createTestAccount(t, AccountTypeClearing)
+	closed, err := account.Close("No longer needed")
+	require.NoError(t, err)
+	assert.Equal(t, AccountStatusClosed, closed.Status())
+
+	// Test SUSPENDED -> CLOSED
+	suspended, err := createTestAccount(t, AccountTypeClearing).Suspend("Temporary")
+	require.NoError(t, err)
+	closedFromSuspended, err := suspended.Close("Permanently closed")
+	require.NoError(t, err)
+	assert.Equal(t, AccountStatusClosed, closedFromSuspended.Status())
+}
+
+func TestLifecycleTransitions_Invalid(t *testing.T) {
+	account := createTestAccount(t, AccountTypeClearing)
+
+	// Close the account first
+	closed, err := account.Close("Decommissioned")
+	require.NoError(t, err)
+
+	// Try to suspend a closed account
+	_, err = closed.Suspend("Try to suspend")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidStatusTransition)
+
+	// Try to activate a closed account
+	_, err = closed.Activate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidStatusTransition)
+
+	// Try to close again
+	_, err = closed.Close("Close again")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidStatusTransition)
+}
+
+func TestLifecycleTransitions_SameStatus(t *testing.T) {
+	account := createTestAccount(t, AccountTypeClearing)
+
+	// Try to activate an already active account
+	_, err := account.Activate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidStatusTransition)
+
+	// Try to suspend an already suspended account
+	suspended, err := account.Suspend("Maintenance")
+	require.NoError(t, err)
+	_, err = suspended.Suspend("Suspend again")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidStatusTransition)
+}
+
+func TestImmutability(t *testing.T) {
+	original := createTestAccount(t, AccountTypeClearing)
+	originalID := original.ID()
+	originalVersion := original.Version()
+	originalStatus := original.Status()
+	originalUpdatedAt := original.UpdatedAt()
+
+	// Give some time for timestamp difference
+	time.Sleep(1 * time.Millisecond)
+
+	// Perform a status change
+	suspended, err := original.Suspend("Testing immutability")
+	require.NoError(t, err)
+
+	// Verify original is unchanged
+	assert.Equal(t, originalID, original.ID(), "original ID should be unchanged")
+	assert.Equal(t, originalVersion, original.Version(), "original version should be unchanged")
+	assert.Equal(t, originalStatus, original.Status(), "original status should be unchanged")
+	assert.Equal(t, originalUpdatedAt, original.UpdatedAt(), "original updatedAt should be unchanged")
+
+	// Verify new instance has changes
+	assert.Equal(t, originalID, suspended.ID(), "ID should be preserved")
+	assert.Equal(t, originalVersion+1, suspended.Version(), "version should be incremented")
+	assert.Equal(t, AccountStatusSuspended, suspended.Status(), "status should be updated")
+	assert.True(t, suspended.UpdatedAt().After(originalUpdatedAt), "updatedAt should be newer")
+}
+
+func TestImmutability_AttributesNotShared(t *testing.T) {
+	// Use builder to create account with attributes
+	attrs := map[string]string{"key": "value"}
+	account := NewInternalBankAccountBuilder().
+		WithID(uuid.New()).
+		WithAccountID("IBA-001").
+		WithAccountCode("TEST_CLEARING").
+		WithName("Test Account").
+		WithAccountType(AccountTypeClearing).
+		WithInstrumentCode("USD").
+		WithDimension("CURRENCY").
+		WithStatus(AccountStatusActive).
+		WithAttributes(attrs).
+		WithVersion(1).
+		WithCreatedAt(time.Now()).
+		WithUpdatedAt(time.Now()).
+		Build()
+
+	// Get attributes from account
+	retrievedAttrs := account.Attributes()
+	require.NotNil(t, retrievedAttrs)
+
+	// Modify the retrieved attributes
+	retrievedAttrs["new_key"] = "new_value"
+
+	// Verify original attributes are unchanged
+	originalAttrs := account.Attributes()
+	assert.NotContains(t, originalAttrs, "new_key", "modifying returned attributes should not affect internal state")
+}
+
+func TestUpdateCorrespondent_Success(t *testing.T) {
+	// Create a NOSTRO account
+	nostroAccount := createTestAccount(t, AccountTypeNostro)
+
+	// Create correspondent details
+	correspondent, err := NewCorrespondentDetails(
+		"CHASE001",
+		"JPMorgan Chase Bank",
+		"ACC-12345",
+	)
+	require.NoError(t, err)
+
+	// Update correspondent
+	updated, err := nostroAccount.UpdateCorrespondent(correspondent)
+	require.NoError(t, err)
+
+	assert.NotNil(t, updated.Correspondent())
+	assert.Equal(t, "CHASE001", updated.Correspondent().BankID())
+	assert.Equal(t, int64(2), updated.Version())
+
+	// Verify original is unchanged
+	assert.Nil(t, nostroAccount.Correspondent())
+	assert.Equal(t, int64(1), nostroAccount.Version())
+}
+
+func TestUpdateCorrespondent_VostroAccount(t *testing.T) {
+	// Create a VOSTRO account
+	vostroAccount := createTestAccount(t, AccountTypeVostro)
+
+	// Create correspondent details
+	correspondent, err := NewCorrespondentDetails(
+		"DB001",
+		"Deutsche Bank",
+		"VOSTRO-REF-001",
+	)
+	require.NoError(t, err)
+
+	// Update correspondent
+	updated, err := vostroAccount.UpdateCorrespondent(correspondent)
+	require.NoError(t, err)
+
+	assert.NotNil(t, updated.Correspondent())
+	assert.Equal(t, "DB001", updated.Correspondent().BankID())
+}
+
+func TestUpdateCorrespondent_ValidationForType(t *testing.T) {
+	t.Run("NOSTRO requires correspondent", func(t *testing.T) {
+		nostro := createTestAccount(t, AccountTypeNostro)
+
+		// Try to set nil correspondent on NOSTRO
+		_, err := nostro.UpdateCorrespondent(nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errCorrespondentRequired)
+	})
+
+	t.Run("VOSTRO requires correspondent", func(t *testing.T) {
+		vostro := createTestAccount(t, AccountTypeVostro)
+
+		// Try to set nil correspondent on VOSTRO
+		_, err := vostro.UpdateCorrespondent(nil)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errCorrespondentRequired)
+	})
+
+	t.Run("CLEARING rejects correspondent", func(t *testing.T) {
+		clearing := createTestAccount(t, AccountTypeClearing)
+
+		correspondent, err := NewCorrespondentDetails(
+			"BANK001",
+			"Some Bank",
+			"REF-001",
+		)
+		require.NoError(t, err)
+
+		// Try to set correspondent on CLEARING account
+		_, err = clearing.UpdateCorrespondent(correspondent)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errCorrespondentNotAllowed)
+	})
+
+	t.Run("HOLDING rejects correspondent", func(t *testing.T) {
+		holding := createTestAccount(t, AccountTypeHolding)
+
+		correspondent, err := NewCorrespondentDetails(
+			"BANK001",
+			"Some Bank",
+			"REF-001",
+		)
+		require.NoError(t, err)
+
+		// Try to set correspondent on HOLDING account
+		_, err = holding.UpdateCorrespondent(correspondent)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errCorrespondentNotAllowed)
+	})
+
+	t.Run("SUSPENSE rejects correspondent", func(t *testing.T) {
+		suspense := createTestAccount(t, AccountTypeSuspense)
+
+		correspondent, err := NewCorrespondentDetails(
+			"BANK001",
+			"Some Bank",
+			"REF-001",
+		)
+		require.NoError(t, err)
+
+		_, err = suspense.UpdateCorrespondent(correspondent)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errCorrespondentNotAllowed)
+	})
+}
+
+func TestUpdateCorrespondent_ClosedAccount(t *testing.T) {
+	nostro := createTestAccount(t, AccountTypeNostro)
+
+	// Close the account
+	closed, err := nostro.Close("Decommissioned")
+	require.NoError(t, err)
+
+	// Try to update correspondent on closed account
+	correspondent, err := NewCorrespondentDetails(
+		"BANK001",
+		"Some Bank",
+		"REF-001",
+	)
+	require.NoError(t, err)
+
+	_, err = closed.UpdateCorrespondent(correspondent)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errAccountClosed)
+}
+
+func TestBuilder_Reconstruction(t *testing.T) {
+	// Simulate values from persistence
+	id := uuid.New()
+	createdAt := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2024, 1, 15, 14, 30, 0, 0, time.UTC)
+	correspondent, err := NewCorrespondentDetails(
+		"CHASE001",
+		"JPMorgan Chase Bank",
+		"ACC-12345",
+	)
+	require.NoError(t, err)
+
+	attributes := map[string]string{
+		"category":   "trading",
+		"department": "treasury",
+	}
+
+	// Reconstruct using builder
+	account := NewInternalBankAccountBuilder().
+		WithID(id).
+		WithAccountID("IBA-001").
+		WithAccountCode("USD_NOSTRO_CHASE").
+		WithName("USD Nostro at Chase").
+		WithAccountType(AccountTypeNostro).
+		WithInstrumentCode("USD").
+		WithDimension("CURRENCY").
+		WithStatus(AccountStatusSuspended).
+		WithCorrespondent(correspondent).
+		WithAttributes(attributes).
+		WithVersion(5).
+		WithCreatedAt(createdAt).
+		WithUpdatedAt(updatedAt).
+		Build()
+
+	// Verify all fields were set correctly
+	assert.Equal(t, id, account.ID())
+	assert.Equal(t, "IBA-001", account.AccountID())
+	assert.Equal(t, "USD_NOSTRO_CHASE", account.AccountCode())
+	assert.Equal(t, "USD Nostro at Chase", account.Name())
+	assert.Equal(t, AccountTypeNostro, account.AccountType())
+	assert.Equal(t, "USD", account.InstrumentCode())
+	assert.Equal(t, "CURRENCY", account.Dimension())
+	assert.Equal(t, AccountStatusSuspended, account.Status())
+	assert.NotNil(t, account.Correspondent())
+	assert.Equal(t, "CHASE001", account.Correspondent().BankID())
+	assert.Equal(t, int64(5), account.Version())
+	assert.Equal(t, createdAt, account.CreatedAt())
+	assert.Equal(t, updatedAt, account.UpdatedAt())
+
+	// Verify attributes
+	attrs := account.Attributes()
+	assert.Equal(t, "trading", attrs["category"])
+	assert.Equal(t, "treasury", attrs["department"])
+}
+
+func TestBuilder_AttributesDeepCopy(t *testing.T) {
+	originalAttrs := map[string]string{"key": "value"}
+
+	account := NewInternalBankAccountBuilder().
+		WithID(uuid.New()).
+		WithAccountID("IBA-001").
+		WithAccountCode("TEST").
+		WithName("Test").
+		WithAccountType(AccountTypeClearing).
+		WithAttributes(originalAttrs).
+		Build()
+
+	// Modify original map
+	originalAttrs["key"] = "modified"
+	originalAttrs["new_key"] = "new_value"
+
+	// Verify account attributes are unchanged
+	attrs := account.Attributes()
+	assert.Equal(t, "value", attrs["key"], "builder should deep copy attributes")
+	assert.NotContains(t, attrs, "new_key", "builder should deep copy attributes")
+}
+
+func TestVersionIncrement(t *testing.T) {
+	account := createTestAccount(t, AccountTypeClearing)
+	assert.Equal(t, int64(1), account.Version())
+
+	// First transition
+	suspended, err := account.Suspend("Test")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), suspended.Version())
+
+	// Second transition
+	reactivated, err := suspended.Activate()
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), reactivated.Version())
+
+	// Third transition
+	closed, err := reactivated.Close("Done")
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), closed.Version())
+
+	// Verify original still has version 1
+	assert.Equal(t, int64(1), account.Version())
+}
+
+func TestVersionIncrement_UpdateCorrespondent(t *testing.T) {
+	nostro := createTestAccount(t, AccountTypeNostro)
+	assert.Equal(t, int64(1), nostro.Version())
+
+	correspondent, err := NewCorrespondentDetails(
+		"BANK001",
+		"Test Bank",
+		"REF-001",
+	)
+	require.NoError(t, err)
+
+	// Update correspondent should increment version
+	updated, err := nostro.UpdateCorrespondent(correspondent)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), updated.Version())
+
+	// Original should still be version 1
+	assert.Equal(t, int64(1), nostro.Version())
+}
+
+// createTestAccount is a helper function to create a test account with the given type.
+func createTestAccount(t *testing.T, accountType AccountType) InternalBankAccount {
+	t.Helper()
+
+	accountID := "IBA-TEST"
+	accountCode := "TEST_" + string(accountType)
+	name := "Test " + string(accountType) + " Account"
+
+	account, err := NewInternalBankAccount(
+		accountID,
+		accountCode,
+		name,
+		accountType,
+		"USD",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+
+	return account
+}

--- a/services/internal-bank-account/domain/internal_account_test.go
+++ b/services/internal-bank-account/domain/internal_account_test.go
@@ -123,7 +123,7 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 			accountType:    AccountTypeClearing,
 			instrumentCode: "GBP",
 			dimension:      "CURRENCY",
-			expectedErr:    errAccountIDRequired,
+			expectedErr:    ErrAccountIDRequired,
 		},
 		{
 			name:           "empty account code",
@@ -133,7 +133,7 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 			accountType:    AccountTypeClearing,
 			instrumentCode: "GBP",
 			dimension:      "CURRENCY",
-			expectedErr:    errAccountCodeRequired,
+			expectedErr:    ErrAccountCodeRequired,
 		},
 		{
 			name:           "empty name",
@@ -143,7 +143,7 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 			accountType:    AccountTypeClearing,
 			instrumentCode: "GBP",
 			dimension:      "CURRENCY",
-			expectedErr:    errAccountNameRequired,
+			expectedErr:    ErrNameRequired,
 		},
 		{
 			name:           "invalid account type",
@@ -153,7 +153,7 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 			accountType:    AccountType("INVALID"),
 			instrumentCode: "GBP",
 			dimension:      "CURRENCY",
-			expectedErr:    errInvalidAccountType,
+			expectedErr:    ErrInvalidAccountType,
 		},
 		{
 			name:           "empty account type",
@@ -163,7 +163,7 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 			accountType:    AccountType(""),
 			instrumentCode: "GBP",
 			dimension:      "CURRENCY",
-			expectedErr:    errInvalidAccountType,
+			expectedErr:    ErrInvalidAccountType,
 		},
 	}
 
@@ -370,7 +370,7 @@ func TestUpdateCorrespondent_ValidationForType(t *testing.T) {
 		// Try to set nil correspondent on NOSTRO
 		_, err := nostro.UpdateCorrespondent(nil)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, errCorrespondentRequired)
+		assert.ErrorIs(t, err, ErrCorrespondentRequired)
 	})
 
 	t.Run("VOSTRO requires correspondent", func(t *testing.T) {
@@ -379,7 +379,7 @@ func TestUpdateCorrespondent_ValidationForType(t *testing.T) {
 		// Try to set nil correspondent on VOSTRO
 		_, err := vostro.UpdateCorrespondent(nil)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, errCorrespondentRequired)
+		assert.ErrorIs(t, err, ErrCorrespondentRequired)
 	})
 
 	t.Run("CLEARING rejects correspondent", func(t *testing.T) {
@@ -395,7 +395,7 @@ func TestUpdateCorrespondent_ValidationForType(t *testing.T) {
 		// Try to set correspondent on CLEARING account
 		_, err = clearing.UpdateCorrespondent(correspondent)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, errCorrespondentNotAllowed)
+		assert.ErrorIs(t, err, ErrCorrespondentNotAllowed)
 	})
 
 	t.Run("HOLDING rejects correspondent", func(t *testing.T) {
@@ -411,7 +411,7 @@ func TestUpdateCorrespondent_ValidationForType(t *testing.T) {
 		// Try to set correspondent on HOLDING account
 		_, err = holding.UpdateCorrespondent(correspondent)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, errCorrespondentNotAllowed)
+		assert.ErrorIs(t, err, ErrCorrespondentNotAllowed)
 	})
 
 	t.Run("SUSPENSE rejects correspondent", func(t *testing.T) {
@@ -426,7 +426,7 @@ func TestUpdateCorrespondent_ValidationForType(t *testing.T) {
 
 		_, err = suspense.UpdateCorrespondent(correspondent)
 		require.Error(t, err)
-		assert.ErrorIs(t, err, errCorrespondentNotAllowed)
+		assert.ErrorIs(t, err, ErrCorrespondentNotAllowed)
 	})
 }
 
@@ -447,7 +447,7 @@ func TestUpdateCorrespondent_ClosedAccount(t *testing.T) {
 
 	_, err = closed.UpdateCorrespondent(correspondent)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, errAccountClosed)
+	assert.ErrorIs(t, err, ErrAccountClosed)
 }
 
 func TestBuilder_Reconstruction(t *testing.T) {

--- a/services/internal-bank-account/domain/repository.go
+++ b/services/internal-bank-account/domain/repository.go
@@ -1,0 +1,55 @@
+// Package domain contains the core business logic for internal bank accounts.
+package domain
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// Repository defines the persistence port for InternalBankAccount aggregates.
+// This interface follows the hexagonal architecture pattern, allowing the domain
+// to remain independent of specific persistence implementations.
+//
+// Implementations must be thread-safe and handle tenant context from ctx.
+type Repository interface {
+	// Save persists a new or updated account.
+	// For new accounts, returns ErrDuplicateAccountCode if the code already exists.
+	// For updates, returns ErrVersionMismatch on optimistic lock failure.
+	Save(ctx context.Context, account InternalBankAccount) error
+
+	// FindByID retrieves an account by its UUID.
+	// Returns ErrAccountNotFound if the account does not exist.
+	FindByID(ctx context.Context, id uuid.UUID) (InternalBankAccount, error)
+
+	// FindByCode retrieves an account by its unique code.
+	// Returns ErrAccountNotFound if the account does not exist.
+	FindByCode(ctx context.Context, accountCode string) (InternalBankAccount, error)
+
+	// List returns accounts matching the filter criteria.
+	// Returns an empty slice if no accounts match the filter.
+	List(ctx context.Context, filter ListFilter) ([]InternalBankAccount, error)
+
+	// ExistsByCode checks if an account with the given code exists.
+	ExistsByCode(ctx context.Context, accountCode string) (bool, error)
+}
+
+// ListFilter specifies criteria for listing accounts.
+// Nil pointer fields are treated as "match all" for that criterion.
+type ListFilter struct {
+	// AccountType filters by account type. Nil matches all types.
+	AccountType *AccountType
+
+	// InstrumentCode filters by instrument code. Nil matches all instruments.
+	InstrumentCode *string
+
+	// Status filters by account status. Nil matches all statuses.
+	Status *AccountStatus
+
+	// Limit specifies the maximum number of results to return.
+	// Zero or negative values use the implementation's default limit.
+	Limit int
+
+	// Offset specifies the number of results to skip for pagination.
+	Offset int
+}


### PR DESCRIPTION
## Summary

Implements the domain layer for the Internal Bank Account service with immutable design patterns following the established CurrentAccount architecture.

### Changes Made

**New Domain Types:**
- `AccountType` enum - CLEARING, NOSTRO, VOSTRO, HOLDING, SUSPENSE, REVENUE, EXPENSE with validation
- `AccountStatus` enum - ACTIVE/SUSPENDED/CLOSED lifecycle state machine
- `CorrespondentDetails` value object - Bank relationship details for NOSTRO/VOSTRO accounts
- `InternalBankAccount` aggregate root - Main domain entity with immutable design
- `Repository` interface - Hexagonal architecture port for persistence
- Domain-specific sentinel errors

**Key Design Patterns:**
- Immutable design: unexported fields, all mutations return new instances
- Value objects: CorrespondentDetails compared by value, not reference
- State machine: Strict lifecycle transitions (ACTIVE ↔ SUSPENDED → CLOSED)
- Builder pattern: For persistence layer reconstruction
- Optimistic locking: Version field incremented on each mutation

## Test Plan

- [x] Unit tests for AccountType validation (25 tests)
- [x] Unit tests for AccountStatus state machine (15+ tests)
- [x] Unit tests for CorrespondentDetails validation and equality (35 tests)
- [x] Unit tests for InternalBankAccount lifecycle and immutability (25+ tests)
- [x] All tests passing locally
- [x] golangci-lint passing

## Task Master

Tag: `internal-bank-account`
Task: `3` - Implement domain model and entities