### PR TITLE
feat(internal-bank-account): add persistence adapter layer

### DIFF
--- a/services/internal-bank-account/adapters/persistence/account_entity.go
+++ b/services/internal-bank-account/adapters/persistence/account_entity.go
@@ -1,0 +1,114 @@
+// Package persistence provides database persistence for the internal bank account domain.
+package persistence
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ErrInvalidAttributesScan is returned when scanning an incompatible type into AttributesJSON.
+var ErrInvalidAttributesScan = errors.New("cannot scan into AttributesJSON")
+
+// InternalBankAccountEntity represents the database persistence model for internal bank accounts.
+// This entity MUST match the schema defined in migrations/20260112000001_initial.sql.
+// The mapping between domain model and entity is handled by toEntity/toDomain functions.
+type InternalBankAccountEntity struct {
+	// Primary key
+	ID uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+
+	// Audit fields - must match BaseModel columns from migration
+	CreatedAt time.Time  `gorm:"column:created_at;not null;default:now()"`
+	CreatedBy string     `gorm:"column:created_by;type:varchar(100);not null"`
+	UpdatedAt time.Time  `gorm:"column:updated_at;not null;default:now()"`
+	UpdatedBy string     `gorm:"column:updated_by;type:varchar(100);not null"`
+	DeletedAt *time.Time `gorm:"column:deleted_at;index"`
+
+	// Account identifiers
+	AccountID   string `gorm:"column:account_id;type:varchar(100);uniqueIndex;not null"`
+	AccountCode string `gorm:"column:account_code;type:varchar(50);not null;index"`
+	Name        string `gorm:"column:name;type:varchar(255);not null"`
+
+	// Account classification
+	AccountType    string `gorm:"column:account_type;type:varchar(20);not null;index"`
+	InstrumentCode string `gorm:"column:instrument_code;type:varchar(32);not null;index"`
+	Dimension      string `gorm:"column:dimension;type:varchar(20);not null"`
+
+	// Account status
+	Status string `gorm:"column:status;type:varchar(20);not null;default:'ACTIVE';index"`
+
+	// Correspondent bank details (nullable for non-nostro/vostro accounts)
+	CorrespondentBankID      *string `gorm:"column:correspondent_bank_id;type:varchar(50)"`
+	CorrespondentBankName    *string `gorm:"column:correspondent_bank_name;type:varchar(255)"`
+	CorrespondentExternalRef *string `gorm:"column:correspondent_external_ref;type:varchar(100)"`
+
+	// Extensible attributes
+	Attributes AttributesJSON `gorm:"column:attributes;type:jsonb;not null;default:'{}'"`
+
+	// Optimistic locking
+	Version int64 `gorm:"column:version;not null;default:1"`
+}
+
+// TableName overrides the default table name.
+// Uses singular, unqualified name per database-per-service architecture.
+func (InternalBankAccountEntity) TableName() string {
+	return "internal_bank_account"
+}
+
+// AttributesJSON is a custom type for handling JSONB attributes column.
+type AttributesJSON map[string]string
+
+// Value implements driver.Valuer for database writes.
+func (a AttributesJSON) Value() (driver.Value, error) {
+	if a == nil {
+		return "{}", nil
+	}
+	return json.Marshal(a)
+}
+
+// Scan implements sql.Scanner for database reads.
+func (a *AttributesJSON) Scan(value interface{}) error {
+	if value == nil {
+		*a = make(AttributesJSON)
+		return nil
+	}
+
+	var bytes []byte
+	switch v := value.(type) {
+	case []byte:
+		bytes = v
+	case string:
+		bytes = []byte(v)
+	default:
+		return fmt.Errorf("%w: unsupported type %T", ErrInvalidAttributesScan, value)
+	}
+
+	return json.Unmarshal(bytes, a)
+}
+
+// StatusHistoryEntity represents the database persistence model for status change audit trail.
+// This entity MUST match the schema defined in migrations/20260112000001_initial.sql.
+type StatusHistoryEntity struct {
+	// Primary key
+	ID uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+
+	// Foreign key reference (via account_id, not UUID)
+	AccountID string `gorm:"column:account_id;type:varchar(100);not null;index"`
+
+	// Status change details
+	FromStatus string    `gorm:"column:from_status;type:varchar(20);not null"`
+	ToStatus   string    `gorm:"column:to_status;type:varchar(20);not null"`
+	Reason     string    `gorm:"column:reason;type:text"`
+	ChangedBy  string    `gorm:"column:changed_by;type:varchar(100);not null"`
+	ChangedAt  time.Time `gorm:"column:changed_at;not null;default:now();index"`
+}
+
+// TableName overrides the default table name.
+// Uses singular, unqualified name per database-per-service architecture.
+func (StatusHistoryEntity) TableName() string {
+	return "internal_bank_account_status_history"
+}

--- a/services/internal-bank-account/adapters/persistence/mappers.go
+++ b/services/internal-bank-account/adapters/persistence/mappers.go
@@ -1,0 +1,109 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
+	"github.com/meridianhub/meridian/shared/platform/audit"
+)
+
+// toEntity converts a domain InternalBankAccount to a persistence entity.
+func toEntity(ctx context.Context, account domain.InternalBankAccount) *InternalBankAccountEntity {
+	auditUser := audit.GetUserFromContext(ctx)
+
+	// Handle nullable correspondent fields
+	var correspondentBankID, correspondentBankName, correspondentExternalRef *string
+	if correspondent := account.Correspondent(); correspondent != nil {
+		bankID := correspondent.BankID()
+		bankName := correspondent.BankName()
+		externalRef := correspondent.ExternalAccountRef()
+		correspondentBankID = &bankID
+		correspondentBankName = &bankName
+		correspondentExternalRef = &externalRef
+	}
+
+	// Convert attributes map
+	var attributes AttributesJSON
+	if attrs := account.Attributes(); attrs != nil {
+		attributes = make(AttributesJSON, len(attrs))
+		for k, v := range attrs {
+			attributes[k] = v
+		}
+	} else {
+		attributes = make(AttributesJSON)
+	}
+
+	return &InternalBankAccountEntity{
+		ID:                       account.ID(),
+		AccountID:                account.AccountID(),
+		AccountCode:              account.AccountCode(),
+		Name:                     account.Name(),
+		AccountType:              string(account.AccountType()),
+		InstrumentCode:           account.InstrumentCode(),
+		Dimension:                account.Dimension(),
+		Status:                   string(account.Status()),
+		CorrespondentBankID:      correspondentBankID,
+		CorrespondentBankName:    correspondentBankName,
+		CorrespondentExternalRef: correspondentExternalRef,
+		Attributes:               attributes,
+		Version:                  account.Version(),
+		CreatedAt:                account.CreatedAt(),
+		UpdatedAt:                account.UpdatedAt(),
+		CreatedBy:                auditUser,
+		UpdatedBy:                auditUser,
+	}
+}
+
+// toDomain converts a persistence entity to a domain InternalBankAccount.
+func toDomain(entity *InternalBankAccountEntity) domain.InternalBankAccount {
+	// Handle correspondent details reconstruction
+	var correspondent *domain.CorrespondentDetails
+	if entity.CorrespondentBankID != nil && entity.CorrespondentBankName != nil && entity.CorrespondentExternalRef != nil {
+		// Reconstruct correspondent details from persistence
+		// Use empty swift code and nil attributes since we don't persist those in the main table
+		correspondent = reconstructCorrespondent(
+			*entity.CorrespondentBankID,
+			*entity.CorrespondentBankName,
+			*entity.CorrespondentExternalRef,
+		)
+	}
+
+	// Convert JSONB attributes to map
+	var attributes map[string]string
+	if len(entity.Attributes) > 0 {
+		attributes = make(map[string]string, len(entity.Attributes))
+		for k, v := range entity.Attributes {
+			attributes[k] = v
+		}
+	}
+
+	// Use builder pattern to reconstruct domain model
+	return domain.NewInternalBankAccountBuilder().
+		WithID(entity.ID).
+		WithAccountID(entity.AccountID).
+		WithAccountCode(entity.AccountCode).
+		WithName(entity.Name).
+		WithAccountType(domain.AccountType(entity.AccountType)).
+		WithInstrumentCode(entity.InstrumentCode).
+		WithDimension(entity.Dimension).
+		WithStatus(domain.AccountStatus(entity.Status)).
+		WithCorrespondent(correspondent).
+		WithAttributes(attributes).
+		WithVersion(entity.Version).
+		WithCreatedAt(entity.CreatedAt).
+		WithUpdatedAt(entity.UpdatedAt).
+		Build()
+}
+
+// reconstructCorrespondent creates a CorrespondentDetails from persisted values.
+// This bypasses normal validation since we trust persisted data.
+func reconstructCorrespondent(bankID, bankName, externalRef string) *domain.CorrespondentDetails {
+	// Use the domain constructor - persisted data should always be valid
+	details, err := domain.NewCorrespondentDetails(bankID, bankName, externalRef)
+	if err != nil {
+		// This should never happen for valid persisted data
+		// Return nil to gracefully handle corrupt data
+		return nil
+	}
+	return details
+}

--- a/services/internal-bank-account/adapters/persistence/mappers.go
+++ b/services/internal-bank-account/adapters/persistence/mappers.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
 	"github.com/meridianhub/meridian/shared/platform/audit"
@@ -101,8 +102,14 @@ func reconstructCorrespondent(bankID, bankName, externalRef string) *domain.Corr
 	// Use the domain constructor - persisted data should always be valid
 	details, err := domain.NewCorrespondentDetails(bankID, bankName, externalRef)
 	if err != nil {
-		// This should never happen for valid persisted data
-		// Return nil to gracefully handle corrupt data
+		// Log at warn level - this indicates data corruption that needs investigation.
+		// Return nil to gracefully handle corrupt data without failing the request.
+		slog.Warn("corrupt correspondent data in database",
+			"bankID", bankID,
+			"bankName", bankName,
+			"externalRef", externalRef,
+			"error", err,
+		)
 		return nil
 	}
 	return details

--- a/services/internal-bank-account/adapters/persistence/repository.go
+++ b/services/internal-bank-account/adapters/persistence/repository.go
@@ -84,15 +84,11 @@ func (r *Repository) withForUpdateScope(ctx context.Context, fn func(tx *gorm.DB
 }
 
 // Save creates or updates an account with optimistic locking.
+// Uses withTenantTransaction to respect existing transactions from WithTx.
 func (r *Repository) Save(ctx context.Context, account domain.InternalBankAccount) error {
 	entity := toEntity(ctx, account)
 
-	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		tx, err := r.withTenantScope(ctx, tx)
-		if err != nil {
-			return err
-		}
-
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		// Check if exists by account_id (business identifier)
 		// Explicit deleted_at check for code clarity
 		var existing InternalBankAccountEntity

--- a/services/internal-bank-account/adapters/persistence/repository.go
+++ b/services/internal-bank-account/adapters/persistence/repository.go
@@ -94,7 +94,11 @@ func (r *Repository) Save(ctx context.Context, account domain.InternalBankAccoun
 			entity.CreatedAt = existing.CreatedAt
 			entity.CreatedBy = existing.CreatedBy
 
-			// Optimistic locking: domain already incremented version during mutation.
+			// Optimistic locking contract: The domain model increments version on all
+			// mutations (Suspend, Activate, Close, UpdateCorrespondent) before passing
+			// to Save. We check the original version (current - 1) to detect concurrent
+			// modifications. If another transaction has modified the record, the version
+			// won't match and we return ErrVersionConflict.
 			originalVersion := entity.Version - 1
 			updateResult := tx.Model(&InternalBankAccountEntity{}).
 				Where("account_id = ? AND version = ?", entity.AccountID, originalVersion).
@@ -214,7 +218,8 @@ func (r *Repository) FindByCode(ctx context.Context, accountCode string) (domain
 func (r *Repository) List(ctx context.Context, filter domain.ListFilter) ([]domain.InternalBankAccount, error) {
 	var accounts []domain.InternalBankAccount
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
-		query := tx.Where("deleted_at IS NULL")
+		// Deterministic ordering is required for stable pagination
+		query := tx.Where("deleted_at IS NULL").Order("created_at ASC, id ASC")
 
 		if filter.AccountType != nil {
 			query = query.Where("account_type = ?", string(*filter.AccountType))

--- a/services/internal-bank-account/adapters/persistence/repository.go
+++ b/services/internal-bank-account/adapters/persistence/repository.go
@@ -72,6 +72,9 @@ func (r *Repository) isInTransaction() bool {
 }
 
 // withForUpdateScope executes the given function with FOR UPDATE locking support.
+// Implementation is identical to withTenantTransaction but kept separate for semantic
+// clarity: this method is specifically for operations that will use SELECT FOR UPDATE
+// (pessimistic locking), making the intent explicit at call sites.
 func (r *Repository) withForUpdateScope(ctx context.Context, fn func(tx *gorm.DB) error) error {
 	if r.isInTransaction() {
 		tx, err := r.withTenantScope(ctx, r.db.WithContext(ctx))
@@ -230,6 +233,9 @@ func (r *Repository) FindByCode(ctx context.Context, accountCode string) (domain
 }
 
 // List returns accounts matching the filter criteria.
+// Query performance supported by: idx_account_type, idx_instrument_code, idx_status, idx_deleted_at.
+// For high-volume filtered queries, consider composite index on (account_type, instrument_code).
+// Uses offset-based pagination; for large datasets cursor-based pagination would be more performant.
 func (r *Repository) List(ctx context.Context, filter domain.ListFilter) ([]domain.InternalBankAccount, error) {
 	var accounts []domain.InternalBankAccount
 	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
@@ -292,6 +298,9 @@ func (r *Repository) ExistsByCode(ctx context.Context, accountCode string) (bool
 }
 
 // RecordStatusChange persists a status change to the audit trail.
+// Note: Does not validate account existence at app level; relies on FK constraint
+// (fk_status_history_account) to enforce referential integrity. This allows the
+// database to be the single source of truth for constraint enforcement.
 func (r *Repository) RecordStatusChange(ctx context.Context, accountID, fromStatus, toStatus, reason string) error {
 	auditUser := audit.GetUserFromContext(ctx)
 
@@ -309,11 +318,18 @@ func (r *Repository) RecordStatusChange(ctx context.Context, accountID, fromStat
 }
 
 // Delete soft deletes an account by its UUID.
+// Records both deleted_at and updated_by for complete audit trail.
 func (r *Repository) Delete(ctx context.Context, id uuid.UUID) error {
+	auditUser := audit.GetUserFromContext(ctx)
+
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		result := tx.Model(&InternalBankAccountEntity{}).
 			Where("id = ? AND deleted_at IS NULL", id).
-			Update("deleted_at", gorm.Expr("now()"))
+			Updates(map[string]interface{}{
+				"deleted_at": gorm.Expr("now()"),
+				"updated_at": gorm.Expr("now()"),
+				"updated_by": auditUser,
+			})
 
 		if result.Error != nil {
 			return result.Error

--- a/services/internal-bank-account/adapters/persistence/repository.go
+++ b/services/internal-bank-account/adapters/persistence/repository.go
@@ -3,9 +3,9 @@ package persistence
 import (
 	"context"
 	"errors"
-	"strings"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
 	"github.com/meridianhub/meridian/shared/platform/audit"
 	"github.com/meridianhub/meridian/shared/platform/db"
@@ -49,7 +49,16 @@ func (r *Repository) withTenantScope(ctx context.Context, tx *gorm.DB) (*gorm.DB
 }
 
 // withTenantTransaction executes the given function with tenant scoping in a transaction.
+// If already in a transaction (via WithTx), it uses the existing transaction directly
+// with tenant scope set, avoiding nested transactions.
 func (r *Repository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if r.isInTransaction() {
+		tx, err := r.withTenantScope(ctx, r.db.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+		return fn(tx)
+	}
 	return db.WithGormTenantTransaction(ctx, r.db, fn)
 }
 
@@ -85,14 +94,21 @@ func (r *Repository) Save(ctx context.Context, account domain.InternalBankAccoun
 		}
 
 		// Check if exists by account_id (business identifier)
+		// Explicit deleted_at check for code clarity
 		var existing InternalBankAccountEntity
-		result := tx.Where("account_id = ?", entity.AccountID).First(&existing)
+		result := tx.Where("account_id = ? AND deleted_at IS NULL", entity.AccountID).First(&existing)
 
 		if result.Error == nil {
 			// Update existing with optimistic locking
 			entity.ID = existing.ID
 			entity.CreatedAt = existing.CreatedAt
 			entity.CreatedBy = existing.CreatedBy
+
+			// Version guard: domain contract says version is incremented before Save
+			// on updates. Version 0 indicates an invalid state for updates.
+			if entity.Version == 0 {
+				return ErrVersionConflict
+			}
 
 			// Optimistic locking contract: The domain model increments version on all
 			// mutations (Suspend, Activate, Close, UpdateCorrespondent) before passing
@@ -101,7 +117,7 @@ func (r *Repository) Save(ctx context.Context, account domain.InternalBankAccoun
 			// won't match and we return ErrVersionConflict.
 			originalVersion := entity.Version - 1
 			updateResult := tx.Model(&InternalBankAccountEntity{}).
-				Where("account_id = ? AND version = ?", entity.AccountID, originalVersion).
+				Where("account_id = ? AND version = ? AND deleted_at IS NULL", entity.AccountID, originalVersion).
 				Updates(map[string]interface{}{
 					"account_code":               entity.AccountCode,
 					"name":                       entity.Name,
@@ -116,6 +132,9 @@ func (r *Repository) Save(ctx context.Context, account domain.InternalBankAccoun
 				})
 
 			if updateResult.Error != nil {
+				if isDuplicateKeyError(updateResult.Error) {
+					return ErrDuplicateCode
+				}
 				return updateResult.Error
 			}
 
@@ -317,13 +336,18 @@ func (r *Repository) Ping() error {
 }
 
 // isDuplicateKeyError checks if the error is a PostgreSQL unique constraint violation.
+// Uses structured pgconn.PgError detection, consistent with other services in the codebase.
 func isDuplicateKeyError(err error) bool {
 	if err == nil {
 		return false
 	}
-	errStr := err.Error()
-	return errors.Is(err, gorm.ErrDuplicatedKey) ||
-		strings.Contains(errStr, "23505") ||
-		strings.Contains(errStr, "duplicate key") ||
-		strings.Contains(errStr, "unique constraint")
+
+	// Check for pgconn.PgError with unique violation code (23505)
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		return true
+	}
+
+	// Fallback for GORM-wrapped duplicate key errors
+	return errors.Is(err, gorm.ErrDuplicatedKey)
 }

--- a/services/internal-bank-account/adapters/persistence/repository.go
+++ b/services/internal-bank-account/adapters/persistence/repository.go
@@ -1,0 +1,324 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
+	"github.com/meridianhub/meridian/shared/platform/audit"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Repository errors
+var (
+	ErrAccountNotFound = errors.New("account not found")
+	ErrDuplicateCode   = errors.New("account code already exists")
+	ErrVersionConflict = errors.New("version conflict: account was modified by another transaction")
+)
+
+// Compile-time interface compliance check
+var _ domain.Repository = (*Repository)(nil)
+
+// Repository provides persistence operations for internal bank accounts.
+type Repository struct {
+	db *gorm.DB
+}
+
+// NewRepository creates a new account repository.
+func NewRepository(db *gorm.DB) *Repository {
+	return &Repository{db: db}
+}
+
+// DB returns the underlying database connection for transaction support.
+func (r *Repository) DB() *gorm.DB {
+	return r.db
+}
+
+// WithTx returns a new Repository that uses the provided transaction.
+func (r *Repository) WithTx(tx *gorm.DB) *Repository {
+	return &Repository{db: tx}
+}
+
+// withTenantScope returns a GORM DB instance scoped to the tenant from context.
+func (r *Repository) withTenantScope(ctx context.Context, tx *gorm.DB) (*gorm.DB, error) {
+	return db.WithGormTenantScope(ctx, tx)
+}
+
+// withTenantTransaction executes the given function with tenant scoping in a transaction.
+func (r *Repository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// isInTransaction checks if the repository's db connection is already within a transaction.
+func (r *Repository) isInTransaction() bool {
+	if r.db.Statement == nil || r.db.Statement.ConnPool == nil {
+		return false
+	}
+	committer, ok := r.db.Statement.ConnPool.(gorm.TxCommitter)
+	return ok && committer != nil
+}
+
+// withForUpdateScope executes the given function with FOR UPDATE locking support.
+func (r *Repository) withForUpdateScope(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if r.isInTransaction() {
+		tx, err := r.withTenantScope(ctx, r.db.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+		return fn(tx)
+	}
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// Save creates or updates an account with optimistic locking.
+func (r *Repository) Save(ctx context.Context, account domain.InternalBankAccount) error {
+	entity := toEntity(ctx, account)
+
+	return r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		tx, err := r.withTenantScope(ctx, tx)
+		if err != nil {
+			return err
+		}
+
+		// Check if exists by account_id (business identifier)
+		var existing InternalBankAccountEntity
+		result := tx.Where("account_id = ?", entity.AccountID).First(&existing)
+
+		if result.Error == nil {
+			// Update existing with optimistic locking
+			entity.ID = existing.ID
+			entity.CreatedAt = existing.CreatedAt
+			entity.CreatedBy = existing.CreatedBy
+
+			// Optimistic locking: domain already incremented version during mutation.
+			originalVersion := entity.Version - 1
+			updateResult := tx.Model(&InternalBankAccountEntity{}).
+				Where("account_id = ? AND version = ?", entity.AccountID, originalVersion).
+				Updates(map[string]interface{}{
+					"account_code":               entity.AccountCode,
+					"name":                       entity.Name,
+					"status":                     entity.Status,
+					"correspondent_bank_id":      entity.CorrespondentBankID,
+					"correspondent_bank_name":    entity.CorrespondentBankName,
+					"correspondent_external_ref": entity.CorrespondentExternalRef,
+					"attributes":                 entity.Attributes,
+					"version":                    entity.Version,
+					"updated_at":                 entity.UpdatedAt,
+					"updated_by":                 entity.UpdatedBy,
+				})
+
+			if updateResult.Error != nil {
+				return updateResult.Error
+			}
+
+			if updateResult.RowsAffected == 0 {
+				return ErrVersionConflict
+			}
+
+			return nil
+		}
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			// Create new
+			if err := tx.Create(&entity).Error; err != nil {
+				if isDuplicateKeyError(err) {
+					return ErrDuplicateCode
+				}
+				return err
+			}
+			return nil
+		}
+
+		return result.Error
+	})
+}
+
+// FindByID retrieves an account by its UUID.
+func (r *Repository) FindByID(ctx context.Context, id uuid.UUID) (domain.InternalBankAccount, error) {
+	var account domain.InternalBankAccount
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entity InternalBankAccountEntity
+		result := tx.Where("id = ? AND deleted_at IS NULL", id).First(&entity)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrAccountNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+
+		account = toDomain(&entity)
+		return nil
+	})
+	if err != nil {
+		return domain.InternalBankAccount{}, err
+	}
+	return account, nil
+}
+
+// FindByIDForUpdate retrieves an account by its UUID with a pessimistic lock.
+func (r *Repository) FindByIDForUpdate(ctx context.Context, id uuid.UUID) (domain.InternalBankAccount, error) {
+	var account domain.InternalBankAccount
+
+	err := r.withForUpdateScope(ctx, func(tx *gorm.DB) error {
+		var entity InternalBankAccountEntity
+		result := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ? AND deleted_at IS NULL", id).
+			First(&entity)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrAccountNotFound
+		}
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		account = toDomain(&entity)
+		return nil
+	})
+	if err != nil {
+		return domain.InternalBankAccount{}, err
+	}
+	return account, nil
+}
+
+// FindByCode retrieves an account by its unique code.
+func (r *Repository) FindByCode(ctx context.Context, accountCode string) (domain.InternalBankAccount, error) {
+	var account domain.InternalBankAccount
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entity InternalBankAccountEntity
+		result := tx.Where("account_code = ? AND deleted_at IS NULL", accountCode).First(&entity)
+
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrAccountNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+
+		account = toDomain(&entity)
+		return nil
+	})
+	if err != nil {
+		return domain.InternalBankAccount{}, err
+	}
+	return account, nil
+}
+
+// List returns accounts matching the filter criteria.
+func (r *Repository) List(ctx context.Context, filter domain.ListFilter) ([]domain.InternalBankAccount, error) {
+	var accounts []domain.InternalBankAccount
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		query := tx.Where("deleted_at IS NULL")
+
+		if filter.AccountType != nil {
+			query = query.Where("account_type = ?", string(*filter.AccountType))
+		}
+		if filter.InstrumentCode != nil {
+			query = query.Where("instrument_code = ?", *filter.InstrumentCode)
+		}
+		if filter.Status != nil {
+			query = query.Where("status = ?", string(*filter.Status))
+		}
+
+		// Apply pagination
+		if filter.Limit > 0 {
+			query = query.Limit(filter.Limit)
+		} else {
+			query = query.Limit(100) // Default limit
+		}
+		if filter.Offset > 0 {
+			query = query.Offset(filter.Offset)
+		}
+
+		var entities []InternalBankAccountEntity
+		if err := query.Find(&entities).Error; err != nil {
+			return err
+		}
+
+		accounts = make([]domain.InternalBankAccount, 0, len(entities))
+		for i := range entities {
+			accounts = append(accounts, toDomain(&entities[i]))
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return accounts, nil
+}
+
+// ExistsByCode checks if an account with the given code exists.
+func (r *Repository) ExistsByCode(ctx context.Context, accountCode string) (bool, error) {
+	var exists bool
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var count int64
+		result := tx.Model(&InternalBankAccountEntity{}).
+			Where("account_code = ? AND deleted_at IS NULL", accountCode).
+			Count(&count)
+
+		if result.Error != nil {
+			return result.Error
+		}
+		exists = count > 0
+		return nil
+	})
+	return exists, err
+}
+
+// RecordStatusChange persists a status change to the audit trail.
+func (r *Repository) RecordStatusChange(ctx context.Context, accountID, fromStatus, toStatus, reason string) error {
+	auditUser := audit.GetUserFromContext(ctx)
+
+	entity := StatusHistoryEntity{
+		AccountID:  accountID,
+		FromStatus: fromStatus,
+		ToStatus:   toStatus,
+		Reason:     reason,
+		ChangedBy:  auditUser,
+	}
+
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Create(&entity).Error
+	})
+}
+
+// Delete soft deletes an account by its UUID.
+func (r *Repository) Delete(ctx context.Context, id uuid.UUID) error {
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Model(&InternalBankAccountEntity{}).
+			Where("id = ? AND deleted_at IS NULL", id).
+			Update("deleted_at", gorm.Expr("now()"))
+
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return ErrAccountNotFound
+		}
+		return nil
+	})
+}
+
+// Ping checks database connectivity.
+func (r *Repository) Ping() error {
+	var result int
+	return r.db.Raw("SELECT 1").Scan(&result).Error
+}
+
+// isDuplicateKeyError checks if the error is a PostgreSQL unique constraint violation.
+func isDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return errors.Is(err, gorm.ErrDuplicatedKey) ||
+		strings.Contains(errStr, "23505") ||
+		strings.Contains(errStr, "duplicate key") ||
+		strings.Contains(errStr, "unique constraint")
+}

--- a/services/internal-bank-account/adapters/persistence/repository_test.go
+++ b/services/internal-bank-account/adapters/persistence/repository_test.go
@@ -1,0 +1,509 @@
+package persistence
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+const testTenantID = "test_tenant"
+
+func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{
+		&InternalBankAccountEntity{},
+		&StatusHistoryEntity{},
+	})
+
+	// Create the tenant schema for tests
+	tid := tenant.TenantID(testTenantID)
+	schemaName := tid.SchemaName()
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
+	require.NoError(t, err)
+
+	// Create the internal_bank_account table in the tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.internal_bank_account (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+		created_by VARCHAR(100) NOT NULL,
+		updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+		updated_by VARCHAR(100) NOT NULL,
+		deleted_at TIMESTAMPTZ,
+		account_id VARCHAR(100) NOT NULL UNIQUE,
+		account_code VARCHAR(50) NOT NULL,
+		name VARCHAR(255) NOT NULL,
+		account_type VARCHAR(20) NOT NULL,
+		instrument_code VARCHAR(32) NOT NULL,
+		dimension VARCHAR(20) NOT NULL,
+		status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+		correspondent_bank_id VARCHAR(50),
+		correspondent_bank_name VARCHAR(255),
+		correspondent_external_ref VARCHAR(100),
+		attributes JSONB NOT NULL DEFAULT '{}',
+		version BIGINT NOT NULL DEFAULT 1
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create the status history table
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.internal_bank_account_status_history (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		account_id VARCHAR(100) NOT NULL,
+		from_status VARCHAR(20) NOT NULL,
+		to_status VARCHAR(20) NOT NULL,
+		reason TEXT,
+		changed_by VARCHAR(100) NOT NULL,
+		changed_at TIMESTAMPTZ NOT NULL DEFAULT now()
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create index on account_code
+	err = db.Exec(fmt.Sprintf(`CREATE INDEX IF NOT EXISTS idx_account_code ON %q.internal_bank_account (account_code)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Set default search_path to include tenant schema
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	require.NoError(t, err)
+
+	// Create context with tenant
+	ctx := tenant.WithTenant(context.Background(), tid)
+
+	return db, ctx, cleanup
+}
+
+func createTestAccount(t *testing.T, accountID, accountCode, name string, accountType domain.AccountType) domain.InternalBankAccount {
+	t.Helper()
+	account, err := domain.NewInternalBankAccount(
+		accountID,
+		accountCode,
+		name,
+		accountType,
+		"GBP",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+	return account
+}
+
+func TestSaveNewAccount(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	account := createTestAccount(t, "IBA-001", "GBP_CLEARING", "GBP Clearing Account", domain.AccountTypeClearing)
+
+	err := repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Verify account was saved
+	retrieved, err := repo.FindByID(ctx, account.ID())
+	require.NoError(t, err)
+
+	assert.Equal(t, account.AccountID(), retrieved.AccountID())
+	assert.Equal(t, account.AccountCode(), retrieved.AccountCode())
+	assert.Equal(t, account.Name(), retrieved.Name())
+	assert.Equal(t, domain.AccountStatusActive, retrieved.Status())
+	assert.Equal(t, int64(1), retrieved.Version())
+}
+
+func TestSaveNewAccount_InitialVersion(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	account := createTestAccount(t, "IBA-002", "USD_CLEARING", "USD Clearing Account", domain.AccountTypeClearing)
+
+	err := repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	retrieved, err := repo.FindByID(ctx, account.ID())
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), retrieved.Version(), "New account should have version 1")
+}
+
+func TestFindByID(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	account := createTestAccount(t, "IBA-003", "EUR_CLEARING", "EUR Clearing Account", domain.AccountTypeClearing)
+
+	err := repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Find by UUID
+	found, err := repo.FindByID(ctx, account.ID())
+	require.NoError(t, err)
+	assert.Equal(t, account.AccountID(), found.AccountID())
+}
+
+func TestFindByID_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	_, err := repo.FindByID(ctx, uuid.New())
+	assert.ErrorIs(t, err, ErrAccountNotFound)
+}
+
+func TestFindByCode(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	account := createTestAccount(t, "IBA-004", "CHF_CLEARING", "CHF Clearing Account", domain.AccountTypeClearing)
+
+	err := repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Find by code
+	found, err := repo.FindByCode(ctx, "CHF_CLEARING")
+	require.NoError(t, err)
+	assert.Equal(t, account.AccountID(), found.AccountID())
+}
+
+func TestFindByCode_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	_, err := repo.FindByCode(ctx, "NONEXISTENT")
+	assert.ErrorIs(t, err, ErrAccountNotFound)
+}
+
+func TestListWithFilters(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	// Create accounts of different types
+	clearing := createTestAccount(t, "IBA-010", "GBP_CLR", "GBP Clearing", domain.AccountTypeClearing)
+	holding := createTestAccount(t, "IBA-011", "GBP_HOLD", "GBP Holding", domain.AccountTypeHolding)
+	suspense := createTestAccount(t, "IBA-012", "GBP_SUSP", "GBP Suspense", domain.AccountTypeSuspense)
+
+	require.NoError(t, repo.Save(ctx, clearing))
+	require.NoError(t, repo.Save(ctx, holding))
+	require.NoError(t, repo.Save(ctx, suspense))
+
+	// Filter by account type
+	clearingType := domain.AccountTypeClearing
+	filter := domain.ListFilter{AccountType: &clearingType}
+	results, err := repo.List(ctx, filter)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "GBP_CLR", results[0].AccountCode())
+
+	// Filter by instrument code
+	instrumentCode := "GBP"
+	filter = domain.ListFilter{InstrumentCode: &instrumentCode}
+	results, err = repo.List(ctx, filter)
+	require.NoError(t, err)
+	assert.Len(t, results, 3)
+}
+
+func TestOptimisticLocking(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	account := createTestAccount(t, "IBA-020", "LOCK_TEST", "Lock Test Account", domain.AccountTypeClearing)
+
+	// Save initial
+	err := repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Retrieve account
+	retrieved1, err := repo.FindByID(ctx, account.ID())
+	require.NoError(t, err)
+
+	retrieved2, err := repo.FindByID(ctx, account.ID())
+	require.NoError(t, err)
+
+	// Suspend first copy (increments version to 2)
+	suspended, err := retrieved1.Suspend("Testing")
+	require.NoError(t, err)
+	err = repo.Save(ctx, suspended)
+	require.NoError(t, err)
+
+	// Try to update second copy (still has version 1)
+	// This should fail due to version mismatch
+	suspended2, err := retrieved2.Suspend("Concurrent update")
+	require.NoError(t, err)
+	err = repo.Save(ctx, suspended2)
+	assert.ErrorIs(t, err, ErrVersionConflict)
+}
+
+func TestTenantIsolation(t *testing.T) {
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{
+		&InternalBankAccountEntity{},
+		&StatusHistoryEntity{},
+	})
+	defer cleanup()
+
+	// Create two tenant schemas
+	tenant1 := tenant.TenantID("tenant_1")
+	tenant2 := tenant.TenantID("tenant_2")
+
+	for _, tid := range []tenant.TenantID{tenant1, tenant2} {
+		schemaName := tid.SchemaName()
+		err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
+		require.NoError(t, err)
+
+		err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.internal_bank_account (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			created_by VARCHAR(100) NOT NULL,
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			updated_by VARCHAR(100) NOT NULL,
+			deleted_at TIMESTAMPTZ,
+			account_id VARCHAR(100) NOT NULL UNIQUE,
+			account_code VARCHAR(50) NOT NULL,
+			name VARCHAR(255) NOT NULL,
+			account_type VARCHAR(20) NOT NULL,
+			instrument_code VARCHAR(32) NOT NULL,
+			dimension VARCHAR(20) NOT NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+			correspondent_bank_id VARCHAR(50),
+			correspondent_bank_name VARCHAR(255),
+			correspondent_external_ref VARCHAR(100),
+			attributes JSONB NOT NULL DEFAULT '{}',
+			version BIGINT NOT NULL DEFAULT 1
+		)`, schemaName)).Error
+		require.NoError(t, err)
+	}
+
+	repo := NewRepository(db)
+
+	// Create account in tenant 1
+	ctx1 := tenant.WithTenant(context.Background(), tenant1)
+	account1 := createTestAccount(t, "IBA-T1", "TENANT1_ACC", "Tenant 1 Account", domain.AccountTypeClearing)
+	require.NoError(t, repo.Save(ctx1, account1))
+
+	// Create account in tenant 2
+	ctx2 := tenant.WithTenant(context.Background(), tenant2)
+	account2 := createTestAccount(t, "IBA-T2", "TENANT2_ACC", "Tenant 2 Account", domain.AccountTypeClearing)
+	require.NoError(t, repo.Save(ctx2, account2))
+
+	// Verify tenant 1 can only see their account
+	results1, err := repo.List(ctx1, domain.ListFilter{})
+	require.NoError(t, err)
+	require.Len(t, results1, 1)
+	assert.Equal(t, "TENANT1_ACC", results1[0].AccountCode())
+
+	// Verify tenant 2 can only see their account
+	results2, err := repo.List(ctx2, domain.ListFilter{})
+	require.NoError(t, err)
+	require.Len(t, results2, 1)
+	assert.Equal(t, "TENANT2_ACC", results2[0].AccountCode())
+}
+
+func TestStatusHistoryRecording(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	// Record a status change
+	err := repo.RecordStatusChange(ctx, "IBA-030", "ACTIVE", "SUSPENDED", "Test suspension")
+	require.NoError(t, err)
+
+	// Verify the status history was recorded (query directly to check)
+	var count int64
+	err = db.Model(&StatusHistoryEntity{}).Where("account_id = ?", "IBA-030").Count(&count).Error
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestCorrespondentDetails(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	// Create a NOSTRO account
+	nostro, err := domain.NewInternalBankAccount(
+		"IBA-040",
+		"USD_NOSTRO_CITI",
+		"USD NOSTRO at Citibank",
+		domain.AccountTypeNostro,
+		"USD",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+
+	// Add correspondent details
+	correspondent, err := domain.NewCorrespondentDetails("CITI001", "Citibank NA", "12345678")
+	require.NoError(t, err)
+	nostro, err = nostro.UpdateCorrespondent(correspondent)
+	require.NoError(t, err)
+
+	// Save
+	err = repo.Save(ctx, nostro)
+	require.NoError(t, err)
+
+	// Retrieve and verify correspondent details
+	retrieved, err := repo.FindByID(ctx, nostro.ID())
+	require.NoError(t, err)
+
+	require.NotNil(t, retrieved.Correspondent())
+	assert.Equal(t, "CITI001", retrieved.Correspondent().BankID())
+	assert.Equal(t, "Citibank NA", retrieved.Correspondent().BankName())
+	assert.Equal(t, "12345678", retrieved.Correspondent().ExternalAccountRef())
+}
+
+func TestJSONBAttributes(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	// Create account with custom attributes using the builder
+	account := domain.NewInternalBankAccountBuilder().
+		WithID(uuid.New()).
+		WithAccountID("IBA-050").
+		WithAccountCode("GBP_SPECIAL").
+		WithName("GBP Special Account").
+		WithAccountType(domain.AccountTypeClearing).
+		WithInstrumentCode("GBP").
+		WithDimension("CURRENCY").
+		WithStatus(domain.AccountStatusActive).
+		WithAttributes(map[string]string{
+			"cost_center": "CC001",
+			"department":  "Treasury",
+			"region":      "EMEA",
+		}).
+		WithVersion(1).
+		Build()
+
+	err := repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Retrieve and verify attributes
+	retrieved, err := repo.FindByID(ctx, account.ID())
+	require.NoError(t, err)
+
+	attrs := retrieved.Attributes()
+	require.NotNil(t, attrs)
+	assert.Equal(t, "CC001", attrs["cost_center"])
+	assert.Equal(t, "Treasury", attrs["department"])
+	assert.Equal(t, "EMEA", attrs["region"])
+}
+
+func TestRoundTripMapping(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	// Create a fully populated VOSTRO account
+	original, err := domain.NewInternalBankAccount(
+		"IBA-060",
+		"EUR_VOSTRO_DB",
+		"EUR VOSTRO from Deutsche Bank",
+		domain.AccountTypeVostro,
+		"EUR",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+
+	correspondent, err := domain.NewCorrespondentDetails("DB001", "Deutsche Bank AG", "DE89370400440532013000")
+	require.NoError(t, err)
+	original, err = original.UpdateCorrespondent(correspondent)
+	require.NoError(t, err)
+
+	// Save
+	err = repo.Save(ctx, original)
+	require.NoError(t, err)
+
+	// Retrieve
+	retrieved, err := repo.FindByID(ctx, original.ID())
+	require.NoError(t, err)
+
+	// Verify all fields round-trip correctly
+	assert.Equal(t, original.ID(), retrieved.ID())
+	assert.Equal(t, original.AccountID(), retrieved.AccountID())
+	assert.Equal(t, original.AccountCode(), retrieved.AccountCode())
+	assert.Equal(t, original.Name(), retrieved.Name())
+	assert.Equal(t, original.AccountType(), retrieved.AccountType())
+	assert.Equal(t, original.InstrumentCode(), retrieved.InstrumentCode())
+	assert.Equal(t, original.Dimension(), retrieved.Dimension())
+	assert.Equal(t, original.Status(), retrieved.Status())
+	assert.Equal(t, original.Version(), retrieved.Version())
+
+	// Verify correspondent details
+	require.NotNil(t, retrieved.Correspondent())
+	assert.Equal(t, original.Correspondent().BankID(), retrieved.Correspondent().BankID())
+	assert.Equal(t, original.Correspondent().BankName(), retrieved.Correspondent().BankName())
+	assert.Equal(t, original.Correspondent().ExternalAccountRef(), retrieved.Correspondent().ExternalAccountRef())
+}
+
+func TestExistsByCode(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	account := createTestAccount(t, "IBA-070", "EXISTS_TEST", "Exists Test Account", domain.AccountTypeClearing)
+
+	// Should not exist before save
+	exists, err := repo.ExistsByCode(ctx, "EXISTS_TEST")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// Save
+	err = repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Should exist after save
+	exists, err = repo.ExistsByCode(ctx, "EXISTS_TEST")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestDelete(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	account := createTestAccount(t, "IBA-080", "DELETE_TEST", "Delete Test Account", domain.AccountTypeClearing)
+
+	err := repo.Save(ctx, account)
+	require.NoError(t, err)
+
+	// Delete
+	err = repo.Delete(ctx, account.ID())
+	require.NoError(t, err)
+
+	// Should not be found after delete
+	_, err = repo.FindByID(ctx, account.ID())
+	assert.ErrorIs(t, err, ErrAccountNotFound)
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	err := repo.Delete(ctx, uuid.New())
+	assert.ErrorIs(t, err, ErrAccountNotFound)
+}
+
+func TestPing(t *testing.T) {
+	db, _, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+	err := repo.Ping()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

- Implement GORM entity definitions matching the database migration schema
- Add repository with tenant scoping, optimistic locking, and transaction support
- Create bidirectional domain↔entity mappers with JSONB and nullable field handling
- Comprehensive integration tests using testcontainers (16 tests)

## Changes Made

**New Files:**
- `services/internal-bank-account/adapters/persistence/account_entity.go` - GORM entities for InternalBankAccount and StatusHistory
- `services/internal-bank-account/adapters/persistence/repository.go` - Repository implementation with full domain.Repository interface compliance
- `services/internal-bank-account/adapters/persistence/mappers.go` - Bidirectional domain↔entity conversion functions
- `services/internal-bank-account/adapters/persistence/repository_test.go` - Integration tests

## Test Plan

- [x] TestSaveNewAccount - Create and verify persistence
- [x] TestSaveNewAccount_InitialVersion - Verify version starts at 1
- [x] TestFindByID - Retrieve by UUID
- [x] TestFindByID_NotFound - Error handling for missing account
- [x] TestFindByCode - Retrieve by account_code
- [x] TestFindByCode_NotFound - Error handling for missing code
- [x] TestListWithFilters - Query with type/instrument/status filters
- [x] TestOptimisticLocking - Concurrent updates trigger version conflict
- [x] TestTenantIsolation - Accounts in different schemas are isolated
- [x] TestStatusHistoryRecording - Audit trail persists correctly
- [x] TestCorrespondentDetails - NOSTRO/VOSTRO with correspondent data
- [x] TestJSONBAttributes - Custom attributes store/retrieve
- [x] TestRoundTripMapping - Domain→entity→domain preserves all data
- [x] TestExistsByCode - Check for code existence
- [x] TestDelete - Soft delete functionality
- [x] TestDelete_NotFound - Error handling for delete of missing account
- [x] TestPing - Health check connectivity

## Task Master

Tag: `internal-bank-account`
Task: 5 - Implement persistence adapter layer