### PR TITLE
feat(internal-bank-account): implement gRPC service layer

### DIFF
--- a/services/internal-bank-account/domain/internal_account.go
+++ b/services/internal-bank-account/domain/internal_account.go
@@ -112,6 +112,23 @@ func (a InternalBankAccount) Close(reason string) (InternalBankAccount, error) {
 	return a.withStatusChange(AccountStatusClosed, reason), nil
 }
 
+// Rename updates the account display name.
+// Returns a new instance with updated name.
+// Returns error if account is closed or name is empty.
+func (a InternalBankAccount) Rename(newName string) (InternalBankAccount, error) {
+	if a.status == AccountStatusClosed {
+		return a, ErrAccountClosed
+	}
+	if newName == "" {
+		return a, ErrNameRequired
+	}
+
+	newAccount := a.copyWithUpdatedTime()
+	newAccount.name = newName
+	newAccount.version++
+	return newAccount, nil
+}
+
 // UpdateCorrespondent sets or updates the correspondent bank details.
 // Returns a new instance with updated correspondent.
 //

--- a/services/internal-bank-account/domain/internal_account_test.go
+++ b/services/internal-bank-account/domain/internal_account_test.go
@@ -450,6 +450,67 @@ func TestUpdateCorrespondent_ClosedAccount(t *testing.T) {
 	assert.ErrorIs(t, err, ErrAccountClosed)
 }
 
+func TestRename_Success(t *testing.T) {
+	account, err := NewInternalBankAccount(
+		"IBA-001",
+		"CLR-001",
+		"Original Name",
+		AccountTypeClearing,
+		"USD",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "Original Name", account.Name())
+	assert.Equal(t, int64(1), account.Version())
+
+	// Rename the account
+	renamed, err := account.Rename("Updated Name")
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Name", renamed.Name())
+	assert.Equal(t, int64(2), renamed.Version())
+
+	// Original should be unchanged (immutability)
+	assert.Equal(t, "Original Name", account.Name())
+	assert.Equal(t, int64(1), account.Version())
+}
+
+func TestRename_EmptyName(t *testing.T) {
+	account, err := NewInternalBankAccount(
+		"IBA-001",
+		"CLR-001",
+		"Original Name",
+		AccountTypeClearing,
+		"USD",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+
+	_, err = account.Rename("")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNameRequired)
+}
+
+func TestRename_ClosedAccount(t *testing.T) {
+	account, err := NewInternalBankAccount(
+		"IBA-001",
+		"CLR-001",
+		"Original Name",
+		AccountTypeClearing,
+		"USD",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+
+	// Close the account
+	closed, err := account.Close("Decommissioned")
+	require.NoError(t, err)
+
+	// Try to rename closed account
+	_, err = closed.Rename("New Name")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAccountClosed)
+}
+
 func TestBuilder_Reconstruction(t *testing.T) {
 	// Simulate values from persistence
 	id := uuid.New()

--- a/services/internal-bank-account/observability/metrics.go
+++ b/services/internal-bank-account/observability/metrics.go
@@ -1,0 +1,53 @@
+// Package observability provides Prometheus metrics and monitoring for the InternalBankAccount service.
+package observability
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// Operation duration metrics
+	operationDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "internal_bank_account_operation_duration_seconds",
+			Help:    "Duration of internal bank account operations in seconds",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		},
+		[]string{"operation", "status"},
+	)
+
+	// Account lifecycle metrics
+	accountsCreated = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "internal_bank_account_accounts_created_total",
+			Help: "Total number of internal bank accounts created",
+		},
+		[]string{"account_type"},
+	)
+
+	accountStatusChanges = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "internal_bank_account_status_changes_total",
+			Help: "Total number of account status changes",
+		},
+		[]string{"from_status", "to_status"},
+	)
+)
+
+// RecordOperationDuration records the duration of an internal bank account operation.
+func RecordOperationDuration(operation, status string, duration time.Duration) {
+	operationDuration.WithLabelValues(operation, status).Observe(duration.Seconds())
+}
+
+// RecordAccountCreated records a newly created account.
+func RecordAccountCreated(accountType string) {
+	accountsCreated.WithLabelValues(accountType).Inc()
+}
+
+// RecordAccountStatusChange records an account status transition.
+func RecordAccountStatusChange(fromStatus, toStatus string) {
+	accountStatusChanges.WithLabelValues(fromStatus, toStatus).Inc()
+}

--- a/services/internal-bank-account/service/client_interfaces.go
+++ b/services/internal-bank-account/service/client_interfaces.go
@@ -1,0 +1,45 @@
+// Package service implements gRPC services for the internal bank account domain.
+package service
+
+import (
+	"context"
+
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+)
+
+// PositionKeepingClient defines the interface for communicating with the PositionKeeping service.
+//
+// This interface represents the subset of PositionKeeping operations used by InternalBankAccount.
+// The actual implementation is provided by services/position-keeping/client.Client.
+//
+// The PositionKeeping service maintains balances for all accounts in the system.
+// InternalBankAccount uses this service to query balances - it does NOT store balance locally.
+type PositionKeepingClient interface {
+	// GetAccountBalances retrieves all balance types for an account by instrument.
+	//
+	// Returns all balance types (opening, closing, current, available, ledger, reserve, free)
+	// for a specific instrument in a single call.
+	GetAccountBalances(ctx context.Context, req *positionkeepingv1.GetAccountBalancesRequest) (*positionkeepingv1.GetAccountBalancesResponse, error)
+
+	// Close terminates the client connection gracefully.
+	Close() error
+}
+
+// ReferenceDataClient defines the interface for communicating with the ReferenceData service.
+//
+// This interface represents the subset of ReferenceData operations used by InternalBankAccount.
+// The actual implementation is provided by services/reference-data/client.Client.
+//
+// The ReferenceData service manages instruments (currencies, commodities, etc.).
+// InternalBankAccount uses this service to validate that instrument_code exists before creating accounts.
+type ReferenceDataClient interface {
+	// RetrieveInstrument retrieves an instrument by its code.
+	//
+	// Returns the instrument if found, or an error if not found.
+	// Used to validate instrument_code during account initiation.
+	RetrieveInstrument(ctx context.Context, req *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error)
+
+	// Close terminates the client connection gracefully.
+	Close() error
+}

--- a/services/internal-bank-account/service/errors.go
+++ b/services/internal-bank-account/service/errors.go
@@ -1,0 +1,16 @@
+// Package service implements gRPC services for the internal bank account domain.
+package service
+
+import "errors"
+
+// Service-level sentinel errors for validation and state checks.
+var (
+	// ErrRepositoryNil is returned when attempting to create a service with a nil repository.
+	ErrRepositoryNil = errors.New("repository cannot be nil")
+)
+
+// Client interface errors.
+var (
+	// ErrPositionKeepingClientNil is returned when Position Keeping client is required but not configured.
+	ErrPositionKeepingClientNil = errors.New("position keeping client is required for balance queries")
+)

--- a/services/internal-bank-account/service/mappers.go
+++ b/services/internal-bank-account/service/mappers.go
@@ -1,0 +1,177 @@
+// Package service implements gRPC services for the internal bank account domain.
+package service
+
+import (
+	"errors"
+	"fmt"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ErrUnspecifiedEnum is returned when an enum value is UNSPECIFIED.
+var ErrUnspecifiedEnum = errors.New("unspecified enum value")
+
+// ErrUnknownAccountType is returned when an account type value is not recognized.
+var ErrUnknownAccountType = errors.New("unknown account type")
+
+// ErrUnknownAccountStatus is returned when an account status value is not recognized.
+var ErrUnknownAccountStatus = errors.New("unknown account status")
+
+// toProtoFacility converts a domain InternalBankAccount to a proto InternalBankAccountFacility.
+func toProtoFacility(account domain.InternalBankAccount) *pb.InternalBankAccountFacility {
+	facility := &pb.InternalBankAccountFacility{
+		AccountId:      account.AccountID(),
+		AccountCode:    account.AccountCode(),
+		Name:           account.Name(),
+		AccountType:    accountTypeToProto(account.AccountType()),
+		AccountStatus:  accountStatusToProto(account.Status()),
+		InstrumentCode: account.InstrumentCode(),
+		CreatedAt:      timestamppb.New(account.CreatedAt()),
+		UpdatedAt:      timestamppb.New(account.UpdatedAt()),
+		Version:        int32(account.Version()),
+	}
+
+	// Map correspondent details if present
+	if correspondent := account.Correspondent(); correspondent != nil {
+		facility.CorrespondentDetails = &pb.CorrespondentBankDetails{
+			BankId:             correspondent.BankID(),
+			BankName:           correspondent.BankName(),
+			ExternalAccountRef: correspondent.ExternalAccountRef(),
+			SwiftCode:          correspondent.SwiftCode(),
+			CorrespondentType:  correspondentTypeFromAccountType(account.AccountType()),
+		}
+	}
+
+	return facility
+}
+
+// protoToAccountType converts a proto InternalAccountType to a domain AccountType.
+func protoToAccountType(pt pb.InternalAccountType) (domain.AccountType, error) {
+	switch pt {
+	case pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING:
+		return domain.AccountTypeClearing, nil
+	case pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_NOSTRO:
+		return domain.AccountTypeNostro, nil
+	case pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_VOSTRO:
+		return domain.AccountTypeVostro, nil
+	case pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_HOLDING:
+		return domain.AccountTypeHolding, nil
+	case pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_SUSPENSE:
+		return domain.AccountTypeSuspense, nil
+	case pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE:
+		return domain.AccountTypeRevenue, nil
+	case pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_EXPENSE:
+		return domain.AccountTypeExpense, nil
+	case pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_INVENTORY:
+		// Map INVENTORY to HOLDING as closest equivalent
+		return domain.AccountTypeHolding, nil
+	case pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_UNSPECIFIED:
+		return "", fmt.Errorf("%w: account type", ErrUnspecifiedEnum)
+	default:
+		return "", fmt.Errorf("%w: %v", ErrUnknownAccountType, pt)
+	}
+}
+
+// accountTypeToProto converts a domain AccountType to a proto InternalAccountType.
+func accountTypeToProto(at domain.AccountType) pb.InternalAccountType {
+	switch at {
+	case domain.AccountTypeClearing:
+		return pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING
+	case domain.AccountTypeNostro:
+		return pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_NOSTRO
+	case domain.AccountTypeVostro:
+		return pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_VOSTRO
+	case domain.AccountTypeHolding:
+		return pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_HOLDING
+	case domain.AccountTypeSuspense:
+		return pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_SUSPENSE
+	case domain.AccountTypeRevenue:
+		return pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE
+	case domain.AccountTypeExpense:
+		return pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_EXPENSE
+	default:
+		return pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_UNSPECIFIED
+	}
+}
+
+// protoToAccountStatus converts a proto InternalAccountStatus to a domain AccountStatus.
+func protoToAccountStatus(ps pb.InternalAccountStatus) (domain.AccountStatus, error) {
+	switch ps {
+	case pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE:
+		return domain.AccountStatusActive, nil
+	case pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_SUSPENDED:
+		return domain.AccountStatusSuspended, nil
+	case pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_CLOSED:
+		return domain.AccountStatusClosed, nil
+	case pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_UNSPECIFIED:
+		return "", fmt.Errorf("%w: account status", ErrUnspecifiedEnum)
+	default:
+		return "", fmt.Errorf("%w: %v", ErrUnknownAccountStatus, ps)
+	}
+}
+
+// accountStatusToProto converts a domain AccountStatus to a proto InternalAccountStatus.
+func accountStatusToProto(as domain.AccountStatus) pb.InternalAccountStatus {
+	switch as {
+	case domain.AccountStatusActive:
+		return pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE
+	case domain.AccountStatusSuspended:
+		return pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_SUSPENDED
+	case domain.AccountStatusClosed:
+		return pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_CLOSED
+	default:
+		return pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_UNSPECIFIED
+	}
+}
+
+// correspondentTypeFromAccountType returns the correspondent type based on account type.
+func correspondentTypeFromAccountType(at domain.AccountType) pb.CorrespondentType {
+	switch at {
+	case domain.AccountTypeNostro:
+		return pb.CorrespondentType_CORRESPONDENT_TYPE_NOSTRO
+	case domain.AccountTypeVostro:
+		return pb.CorrespondentType_CORRESPONDENT_TYPE_VOSTRO
+	case domain.AccountTypeClearing,
+		domain.AccountTypeHolding,
+		domain.AccountTypeSuspense,
+		domain.AccountTypeRevenue,
+		domain.AccountTypeExpense:
+		return pb.CorrespondentType_CORRESPONDENT_TYPE_UNSPECIFIED
+	default:
+		return pb.CorrespondentType_CORRESPONDENT_TYPE_UNSPECIFIED
+	}
+}
+
+// mapDomainErrorToGRPC converts domain errors to appropriate gRPC status errors.
+func mapDomainErrorToGRPC(err error) error {
+	switch {
+	case errors.Is(err, domain.ErrAccountNotFound):
+		return status.Error(codes.NotFound, err.Error())
+	case errors.Is(err, domain.ErrAccountClosed):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, domain.ErrAccountSuspended):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, domain.ErrInvalidAccountType):
+		return status.Error(codes.InvalidArgument, err.Error())
+	case errors.Is(err, domain.ErrInvalidStatusTransition):
+		return status.Error(codes.FailedPrecondition, err.Error())
+	case errors.Is(err, domain.ErrCorrespondentRequired):
+		return status.Error(codes.InvalidArgument, err.Error())
+	case errors.Is(err, domain.ErrCorrespondentNotAllowed):
+		return status.Error(codes.InvalidArgument, err.Error())
+	case errors.Is(err, domain.ErrDuplicateAccountCode):
+		return status.Error(codes.AlreadyExists, err.Error())
+	case errors.Is(err, domain.ErrVersionMismatch):
+		return status.Error(codes.Aborted, err.Error())
+	case errors.Is(err, domain.ErrAccountIDRequired),
+		errors.Is(err, domain.ErrAccountCodeRequired),
+		errors.Is(err, domain.ErrNameRequired):
+		return status.Error(codes.InvalidArgument, err.Error())
+	default:
+		return status.Errorf(codes.Internal, "internal error: %v", err)
+	}
+}

--- a/services/internal-bank-account/service/mappers_test.go
+++ b/services/internal-bank-account/service/mappers_test.go
@@ -1,0 +1,217 @@
+package service
+
+import (
+	"testing"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestProtoToAccountType_Valid(t *testing.T) {
+	tests := []struct {
+		name     string
+		proto    pb.InternalAccountType
+		expected domain.AccountType
+	}{
+		{"CLEARING", pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING, domain.AccountTypeClearing},
+		{"NOSTRO", pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_NOSTRO, domain.AccountTypeNostro},
+		{"VOSTRO", pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_VOSTRO, domain.AccountTypeVostro},
+		{"HOLDING", pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_HOLDING, domain.AccountTypeHolding},
+		{"SUSPENSE", pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_SUSPENSE, domain.AccountTypeSuspense},
+		{"REVENUE", pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE, domain.AccountTypeRevenue},
+		{"EXPENSE", pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_EXPENSE, domain.AccountTypeExpense},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := protoToAccountType(tt.proto)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProtoToAccountType_Unspecified(t *testing.T) {
+	_, err := protoToAccountType(pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_UNSPECIFIED)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnspecifiedEnum)
+}
+
+func TestAccountTypeToProto_RoundTrip(t *testing.T) {
+	tests := []domain.AccountType{
+		domain.AccountTypeClearing,
+		domain.AccountTypeNostro,
+		domain.AccountTypeVostro,
+		domain.AccountTypeHolding,
+		domain.AccountTypeSuspense,
+		domain.AccountTypeRevenue,
+		domain.AccountTypeExpense,
+	}
+
+	for _, at := range tests {
+		t.Run(string(at), func(t *testing.T) {
+			proto := accountTypeToProto(at)
+			result, err := protoToAccountType(proto)
+			require.NoError(t, err)
+			assert.Equal(t, at, result)
+		})
+	}
+}
+
+func TestProtoToAccountStatus_Valid(t *testing.T) {
+	tests := []struct {
+		name     string
+		proto    pb.InternalAccountStatus
+		expected domain.AccountStatus
+	}{
+		{"ACTIVE", pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE, domain.AccountStatusActive},
+		{"SUSPENDED", pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_SUSPENDED, domain.AccountStatusSuspended},
+		{"CLOSED", pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_CLOSED, domain.AccountStatusClosed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := protoToAccountStatus(tt.proto)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProtoToAccountStatus_Unspecified(t *testing.T) {
+	_, err := protoToAccountStatus(pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_UNSPECIFIED)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnspecifiedEnum)
+}
+
+func TestAccountStatusToProto_RoundTrip(t *testing.T) {
+	tests := []domain.AccountStatus{
+		domain.AccountStatusActive,
+		domain.AccountStatusSuspended,
+		domain.AccountStatusClosed,
+	}
+
+	for _, as := range tests {
+		t.Run(string(as), func(t *testing.T) {
+			proto := accountStatusToProto(as)
+			result, err := protoToAccountStatus(proto)
+			require.NoError(t, err)
+			assert.Equal(t, as, result)
+		})
+	}
+}
+
+func TestCorrespondentTypeFromAccountType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    domain.AccountType
+		expected pb.CorrespondentType
+	}{
+		{"NOSTRO", domain.AccountTypeNostro, pb.CorrespondentType_CORRESPONDENT_TYPE_NOSTRO},
+		{"VOSTRO", domain.AccountTypeVostro, pb.CorrespondentType_CORRESPONDENT_TYPE_VOSTRO},
+		{"CLEARING", domain.AccountTypeClearing, pb.CorrespondentType_CORRESPONDENT_TYPE_UNSPECIFIED},
+		{"HOLDING", domain.AccountTypeHolding, pb.CorrespondentType_CORRESPONDENT_TYPE_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := correspondentTypeFromAccountType(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMapDomainErrorToGRPC(t *testing.T) {
+	tests := []struct {
+		name         string
+		err          error
+		expectedCode codes.Code
+	}{
+		{"AccountNotFound", domain.ErrAccountNotFound, codes.NotFound},
+		{"AccountClosed", domain.ErrAccountClosed, codes.FailedPrecondition},
+		{"AccountSuspended", domain.ErrAccountSuspended, codes.FailedPrecondition},
+		{"InvalidAccountType", domain.ErrInvalidAccountType, codes.InvalidArgument},
+		{"InvalidStatusTransition", domain.ErrInvalidStatusTransition, codes.FailedPrecondition},
+		{"CorrespondentRequired", domain.ErrCorrespondentRequired, codes.InvalidArgument},
+		{"CorrespondentNotAllowed", domain.ErrCorrespondentNotAllowed, codes.InvalidArgument},
+		{"DuplicateAccountCode", domain.ErrDuplicateAccountCode, codes.AlreadyExists},
+		{"VersionMismatch", domain.ErrVersionMismatch, codes.Aborted},
+		{"AccountIDRequired", domain.ErrAccountIDRequired, codes.InvalidArgument},
+		{"AccountCodeRequired", domain.ErrAccountCodeRequired, codes.InvalidArgument},
+		{"NameRequired", domain.ErrNameRequired, codes.InvalidArgument},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapDomainErrorToGRPC(tt.err)
+			st, ok := status.FromError(result)
+			require.True(t, ok)
+			assert.Equal(t, tt.expectedCode, st.Code())
+		})
+	}
+}
+
+func TestToProtoFacility(t *testing.T) {
+	// Create a domain account
+	account, err := domain.NewInternalBankAccount(
+		"IBA-001",
+		"CLR-001",
+		"Test Clearing Account",
+		domain.AccountTypeClearing,
+		"USD",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+
+	facility := toProtoFacility(account)
+
+	assert.Equal(t, "IBA-001", facility.AccountId)
+	assert.Equal(t, "CLR-001", facility.AccountCode)
+	assert.Equal(t, "Test Clearing Account", facility.Name)
+	assert.Equal(t, pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING, facility.AccountType)
+	assert.Equal(t, pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE, facility.AccountStatus)
+	assert.Equal(t, "USD", facility.InstrumentCode)
+	assert.Nil(t, facility.CorrespondentDetails)
+	assert.NotNil(t, facility.CreatedAt)
+	assert.NotNil(t, facility.UpdatedAt)
+	assert.Equal(t, int32(1), facility.Version)
+}
+
+func TestToProtoFacility_WithCorrespondent(t *testing.T) {
+	// Create a NOSTRO account with correspondent
+	account, err := domain.NewInternalBankAccount(
+		"IBA-002",
+		"NOSTRO-USD-HSBC",
+		"HSBC USD Nostro",
+		domain.AccountTypeNostro,
+		"USD",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+
+	// Add correspondent details
+	correspondent, err := domain.NewCorrespondentDetailsWithOptions(
+		"HSBC001",
+		"HSBC Bank",
+		"12345678",
+		"HSBCGB2L",
+		nil,
+	)
+	require.NoError(t, err)
+
+	account, err = account.UpdateCorrespondent(correspondent)
+	require.NoError(t, err)
+
+	facility := toProtoFacility(account)
+
+	assert.NotNil(t, facility.CorrespondentDetails)
+	assert.Equal(t, "HSBC001", facility.CorrespondentDetails.BankId)
+	assert.Equal(t, "HSBC Bank", facility.CorrespondentDetails.BankName)
+	assert.Equal(t, "12345678", facility.CorrespondentDetails.ExternalAccountRef)
+	assert.Equal(t, "HSBCGB2L", facility.CorrespondentDetails.SwiftCode)
+	assert.Equal(t, pb.CorrespondentType_CORRESPONDENT_TYPE_NOSTRO, facility.CorrespondentDetails.CorrespondentType)
+}

--- a/services/internal-bank-account/service/mappers_test.go
+++ b/services/internal-bank-account/service/mappers_test.go
@@ -41,6 +41,27 @@ func TestProtoToAccountType_Unspecified(t *testing.T) {
 	assert.ErrorIs(t, err, ErrUnspecifiedEnum)
 }
 
+func TestProtoToAccountType_Inventory(t *testing.T) {
+	// INVENTORY should map to HOLDING as the closest equivalent
+	result, err := protoToAccountType(pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_INVENTORY)
+	require.NoError(t, err)
+	assert.Equal(t, domain.AccountTypeHolding, result)
+}
+
+func TestProtoToAccountType_Unknown(t *testing.T) {
+	// Unknown enum values should return an error
+	_, err := protoToAccountType(pb.InternalAccountType(9999))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownAccountType)
+}
+
+func TestProtoToAccountStatus_Unknown(t *testing.T) {
+	// Unknown enum values should return an error
+	_, err := protoToAccountStatus(pb.InternalAccountStatus(9999))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnknownAccountStatus)
+}
+
 func TestAccountTypeToProto_RoundTrip(t *testing.T) {
 	tests := []domain.AccountType{
 		domain.AccountTypeClearing,

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -458,14 +458,17 @@ func (s *Service) GetBalance(ctx context.Context, req *pb.GetBalanceRequest) (*p
 		return nil, status.Errorf(codes.Internal, "failed to retrieve balance: %v", err)
 	}
 
-	// Find the current balance from the response
+	// Find the current balance from the response.
+	// Note: LastUpdated reflects when this service queried Position Keeping,
+	// not when the balance was last modified. Position Keeping is the source
+	// of truth for balance timestamps if needed.
 	var currentBalance *pb.GetBalanceResponse
 	for _, entry := range balanceResp.GetBalances() {
 		if entry.GetBalanceType() == positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT {
 			currentBalance = &pb.GetBalanceResponse{
 				AccountId:   req.AccountId,
 				Balance:     entry.GetAmount(),
-				LastUpdated: timestamppb.Now(),
+				LastUpdated: timestamppb.Now(), // Query time, not balance update time
 			}
 			break
 		}
@@ -476,7 +479,7 @@ func (s *Service) GetBalance(ctx context.Context, req *pb.GetBalanceRequest) (*p
 		return &pb.GetBalanceResponse{
 			AccountId:   req.AccountId,
 			Balance:     nil,
-			LastUpdated: timestamppb.Now(),
+			LastUpdated: timestamppb.Now(), // Query time
 		}, nil
 	}
 

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -104,7 +104,10 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 
 	// Validate instrument exists via Reference Data service (if client is configured)
 	if s.referenceDataClient != nil {
-		_, err := s.referenceDataClient.RetrieveInstrument(ctx, &referencedatav1.RetrieveInstrumentRequest{
+		refDataCtx, refDataCancel := context.WithTimeout(ctx, 5*time.Second)
+		defer refDataCancel()
+
+		_, err := s.referenceDataClient.RetrieveInstrument(refDataCtx, &referencedatav1.RetrieveInstrumentRequest{
 			Code: req.InstrumentCode,
 		})
 		if err != nil {
@@ -119,8 +122,8 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 		}
 	}
 
-	// Generate account ID
-	accountID := fmt.Sprintf("IBA-%s", uuid.New().String()[:8])
+	// Generate account ID using full UUID for uniqueness
+	accountID := fmt.Sprintf("IBA-%s", uuid.New().String())
 
 	// Create domain entity
 	account, err := domain.NewInternalBankAccount(
@@ -169,6 +172,9 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 		s.logger.Error("failed to save account", "error", err)
 		return nil, status.Errorf(codes.Internal, "failed to create account: %v", err)
 	}
+
+	// Record metric for account creation
+	ibaobservability.RecordAccountCreated(accountType.String())
 
 	s.logger.Info("created internal bank account",
 		"account_id", accountID,
@@ -227,6 +233,17 @@ func (s *Service) updateAccount(ctx context.Context, account domain.InternalBank
 		return nil, status.Error(codes.FailedPrecondition, "cannot update closed account")
 	}
 
+	var err error
+
+	// Update name if provided
+	if req.Name != "" {
+		account, err = account.Rename(req.Name)
+		if err != nil {
+			*operationStatus = operationStatusFailed
+			return nil, mapDomainErrorToGRPC(err)
+		}
+	}
+
 	// Update correspondent details if provided
 	if req.CorrespondentDetails != nil {
 		correspondent, err := domain.NewCorrespondentDetailsWithOptions(
@@ -277,6 +294,9 @@ func (s *Service) ControlInternalBankAccount(ctx context.Context, req *pb.Contro
 		return nil, err
 	}
 
+	// Capture previous status for metrics
+	previousStatus := account.Status()
+
 	// Execute state transition based on control action
 	switch req.ControlAction {
 	case pb.ControlAction_CONTROL_ACTION_SUSPEND:
@@ -311,6 +331,9 @@ func (s *Service) ControlInternalBankAccount(ctx context.Context, req *pb.Contro
 		operationStatus = operationStatusFailed
 		return nil, status.Errorf(codes.Internal, "failed to save account: %v", err)
 	}
+
+	// Record status change metric
+	ibaobservability.RecordAccountStatusChange(string(previousStatus), string(account.Status()))
 
 	s.logger.Info("executed control action on internal bank account",
 		"account_id", req.AccountId,
@@ -445,8 +468,11 @@ func (s *Service) GetBalance(ctx context.Context, req *pb.GetBalanceRequest) (*p
 		return nil, status.Error(codes.Unimplemented, "position keeping service not configured")
 	}
 
-	// Query Position Keeping service (source of truth for balance)
-	balanceResp, err := s.positionKeepingClient.GetAccountBalances(ctx, &positionkeepingv1.GetAccountBalancesRequest{
+	// Query Position Keeping service (source of truth for balance) with timeout
+	pkCtx, pkCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer pkCancel()
+
+	balanceResp, err := s.positionKeepingClient.GetAccountBalances(pkCtx, &positionkeepingv1.GetAccountBalancesRequest{
 		AccountId:      account.AccountID(),
 		InstrumentCode: account.InstrumentCode(),
 	})

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -1,0 +1,509 @@
+// Package service implements gRPC services for the internal bank account domain.
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/internal-bank-account/adapters/persistence"
+	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
+	ibaobservability "github.com/meridianhub/meridian/services/internal-bank-account/observability"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Operation status constants for metrics and logging.
+const (
+	operationStatusSuccess = "success"
+	operationStatusFailed  = "failed"
+
+	opStatusAccountNotFound         = "account_not_found"
+	opStatusInvalidAccountType      = "invalid_account_type"
+	opStatusInvalidStatusTransition = "invalid_status_transition"
+	opStatusVersionConflict         = "version_conflict"
+	opStatusDuplicateCode           = "duplicate_code"
+	opStatusInstrumentNotFound      = "instrument_not_found"
+	opStatusPositionKeepingError    = "position_keeping_error"
+)
+
+// Service implements the InternalBankAccountService gRPC service.
+type Service struct {
+	pb.UnimplementedInternalBankAccountServiceServer
+	repo                  domain.Repository
+	positionKeepingClient PositionKeepingClient
+	referenceDataClient   ReferenceDataClient
+	logger                *slog.Logger
+	tracer                *observability.Tracer
+}
+
+// NewService creates a new internal bank account service with minimal dependencies.
+// This is primarily used for testing. For production use, prefer NewServiceWithClients.
+// Returns an error if repository is nil.
+func NewService(repo domain.Repository) (*Service, error) {
+	if repo == nil {
+		return nil, ErrRepositoryNil
+	}
+	return &Service{
+		repo:   repo,
+		logger: slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}, nil
+}
+
+// NewServiceWithClients creates a new service with external client dependencies.
+// Use this constructor for production deployments where Position Keeping and Reference Data
+// service integrations are required.
+func NewServiceWithClients(
+	repo domain.Repository,
+	posKeepingClient PositionKeepingClient,
+	refDataClient ReferenceDataClient,
+	logger *slog.Logger,
+	tracer *observability.Tracer,
+) (*Service, error) {
+	if repo == nil {
+		return nil, ErrRepositoryNil
+	}
+
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+
+	return &Service{
+		repo:                  repo,
+		positionKeepingClient: posKeepingClient,
+		referenceDataClient:   refDataClient,
+		logger:                logger,
+		tracer:                tracer,
+	}, nil
+}
+
+// InitiateInternalBankAccount creates a new internal bank account.
+func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.InitiateInternalBankAccountRequest) (*pb.InitiateInternalBankAccountResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		ibaobservability.RecordOperationDuration("initiate_internal_bank_account", operationStatus, time.Since(start))
+	}()
+
+	// Map proto account type to domain
+	accountType, err := protoToAccountType(req.AccountType)
+	if err != nil {
+		operationStatus = opStatusInvalidAccountType
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account type: %v", err)
+	}
+
+	// Validate instrument exists via Reference Data service (if client is configured)
+	if s.referenceDataClient != nil {
+		_, err := s.referenceDataClient.RetrieveInstrument(ctx, &referencedatav1.RetrieveInstrumentRequest{
+			Code: req.InstrumentCode,
+		})
+		if err != nil {
+			operationStatus = opStatusInstrumentNotFound
+			s.logger.Warn("instrument validation failed",
+				"instrument_code", req.InstrumentCode,
+				"error", err)
+			if status.Code(err) == codes.NotFound {
+				return nil, status.Errorf(codes.InvalidArgument, "instrument not found: %s", req.InstrumentCode)
+			}
+			return nil, status.Errorf(codes.Internal, "failed to validate instrument: %v", err)
+		}
+	}
+
+	// Generate account ID
+	accountID := fmt.Sprintf("IBA-%s", uuid.New().String()[:8])
+
+	// Create domain entity
+	account, err := domain.NewInternalBankAccount(
+		accountID,
+		req.AccountCode,
+		req.Name,
+		accountType,
+		req.InstrumentCode,
+		"", // dimension - could be populated from Reference Data response
+	)
+	if err != nil {
+		operationStatus = operationStatusFailed
+		return nil, mapDomainErrorToGRPC(err)
+	}
+
+	// Handle correspondent details for NOSTRO/VOSTRO accounts
+	if req.CorrespondentDetails != nil {
+		correspondent, err := domain.NewCorrespondentDetailsWithOptions(
+			req.CorrespondentDetails.BankId,
+			req.CorrespondentDetails.BankName,
+			req.CorrespondentDetails.ExternalAccountRef,
+			req.CorrespondentDetails.SwiftCode,
+			nil,
+		)
+		if err != nil {
+			operationStatus = operationStatusFailed
+			return nil, status.Errorf(codes.InvalidArgument, "invalid correspondent details: %v", err)
+		}
+		account, err = account.UpdateCorrespondent(correspondent)
+		if err != nil {
+			operationStatus = operationStatusFailed
+			return nil, mapDomainErrorToGRPC(err)
+		}
+	} else if accountType.RequiresCorrespondent() {
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.InvalidArgument, "correspondent details required for %s accounts", accountType)
+	}
+
+	// Persist via repository
+	if err := s.repo.Save(ctx, account); err != nil {
+		if errors.Is(err, persistence.ErrDuplicateCode) {
+			operationStatus = opStatusDuplicateCode
+			return nil, status.Errorf(codes.AlreadyExists, "account code already exists: %s", req.AccountCode)
+		}
+		operationStatus = operationStatusFailed
+		s.logger.Error("failed to save account", "error", err)
+		return nil, status.Errorf(codes.Internal, "failed to create account: %v", err)
+	}
+
+	s.logger.Info("created internal bank account",
+		"account_id", accountID,
+		"account_code", req.AccountCode,
+		"account_type", accountType.String())
+
+	return &pb.InitiateInternalBankAccountResponse{
+		AccountId: accountID,
+		Facility:  toProtoFacility(account),
+	}, nil
+}
+
+// UpdateInternalBankAccount modifies account settings.
+func (s *Service) UpdateInternalBankAccount(ctx context.Context, req *pb.UpdateInternalBankAccountRequest) (*pb.UpdateInternalBankAccountResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		ibaobservability.RecordOperationDuration("update_internal_bank_account", operationStatus, time.Since(start))
+	}()
+
+	// Load existing account
+	accountUUID, err := uuid.Parse(req.AccountId)
+	if err != nil {
+		// Try finding by account_id string if not a UUID
+		account, err := s.findAccountByID(ctx, req.AccountId)
+		if err != nil {
+			operationStatus = opStatusAccountNotFound
+			return nil, err
+		}
+		return s.updateAccount(ctx, account, req, &operationStatus)
+	}
+
+	account, err := s.repo.FindByID(ctx, accountUUID)
+	if err != nil {
+		if errors.Is(err, domain.ErrAccountNotFound) {
+			operationStatus = opStatusAccountNotFound
+			return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
+		}
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+
+	return s.updateAccount(ctx, account, req, &operationStatus)
+}
+
+func (s *Service) updateAccount(ctx context.Context, account domain.InternalBankAccount, req *pb.UpdateInternalBankAccountRequest, operationStatus *string) (*pb.UpdateInternalBankAccountResponse, error) {
+	// Check version for optimistic locking if provided
+	if req.ExpectedVersion > 0 && int64(req.ExpectedVersion) != account.Version() {
+		*operationStatus = opStatusVersionConflict
+		return nil, status.Errorf(codes.Aborted, "version mismatch: expected %d, got %d", req.ExpectedVersion, account.Version())
+	}
+
+	// Cannot update closed accounts
+	if account.Status() == domain.AccountStatusClosed {
+		*operationStatus = operationStatusFailed
+		return nil, status.Error(codes.FailedPrecondition, "cannot update closed account")
+	}
+
+	// Update correspondent details if provided
+	if req.CorrespondentDetails != nil {
+		correspondent, err := domain.NewCorrespondentDetailsWithOptions(
+			req.CorrespondentDetails.BankId,
+			req.CorrespondentDetails.BankName,
+			req.CorrespondentDetails.ExternalAccountRef,
+			req.CorrespondentDetails.SwiftCode,
+			nil,
+		)
+		if err != nil {
+			*operationStatus = operationStatusFailed
+			return nil, status.Errorf(codes.InvalidArgument, "invalid correspondent details: %v", err)
+		}
+		account, err = account.UpdateCorrespondent(correspondent)
+		if err != nil {
+			*operationStatus = operationStatusFailed
+			return nil, mapDomainErrorToGRPC(err)
+		}
+	}
+
+	// Persist changes
+	if err := s.repo.Save(ctx, account); err != nil {
+		if errors.Is(err, persistence.ErrVersionConflict) {
+			*operationStatus = opStatusVersionConflict
+			return nil, status.Error(codes.Aborted, "account was modified by another transaction")
+		}
+		*operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to save account: %v", err)
+	}
+
+	return &pb.UpdateInternalBankAccountResponse{
+		Facility: toProtoFacility(account),
+	}, nil
+}
+
+// ControlInternalBankAccount performs lifecycle state transitions.
+func (s *Service) ControlInternalBankAccount(ctx context.Context, req *pb.ControlInternalBankAccountRequest) (*pb.ControlInternalBankAccountResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		ibaobservability.RecordOperationDuration("control_internal_bank_account", operationStatus, time.Since(start))
+	}()
+
+	// Load existing account
+	account, err := s.findAccountByID(ctx, req.AccountId)
+	if err != nil {
+		operationStatus = opStatusAccountNotFound
+		return nil, err
+	}
+
+	// Execute state transition based on control action
+	switch req.ControlAction {
+	case pb.ControlAction_CONTROL_ACTION_SUSPEND:
+		account, err = account.Suspend(req.Reason)
+	case pb.ControlAction_CONTROL_ACTION_ACTIVATE:
+		account, err = account.Activate()
+	case pb.ControlAction_CONTROL_ACTION_CLOSE:
+		account, err = account.Close(req.Reason)
+	case pb.ControlAction_CONTROL_ACTION_UNSPECIFIED:
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.InvalidArgument, "control action must be specified")
+	default:
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.InvalidArgument, "invalid control action: %v", req.ControlAction)
+	}
+
+	if err != nil {
+		if errors.Is(err, domain.ErrInvalidStatusTransition) {
+			operationStatus = opStatusInvalidStatusTransition
+			return nil, status.Errorf(codes.FailedPrecondition, "invalid status transition: %v", err)
+		}
+		operationStatus = operationStatusFailed
+		return nil, mapDomainErrorToGRPC(err)
+	}
+
+	// Persist changes
+	if err := s.repo.Save(ctx, account); err != nil {
+		if errors.Is(err, persistence.ErrVersionConflict) {
+			operationStatus = opStatusVersionConflict
+			return nil, status.Error(codes.Aborted, "account was modified by another transaction")
+		}
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to save account: %v", err)
+	}
+
+	s.logger.Info("executed control action on internal bank account",
+		"account_id", req.AccountId,
+		"action", req.ControlAction.String(),
+		"new_status", string(account.Status()))
+
+	return &pb.ControlInternalBankAccountResponse{
+		Facility:        toProtoFacility(account),
+		ActionTimestamp: timestamppb.Now(),
+	}, nil
+}
+
+// RetrieveInternalBankAccount fetches a single account by ID.
+func (s *Service) RetrieveInternalBankAccount(ctx context.Context, req *pb.RetrieveInternalBankAccountRequest) (*pb.RetrieveInternalBankAccountResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		ibaobservability.RecordOperationDuration("retrieve_internal_bank_account", operationStatus, time.Since(start))
+	}()
+
+	account, err := s.findAccountByID(ctx, req.AccountId)
+	if err != nil {
+		operationStatus = opStatusAccountNotFound
+		return nil, err
+	}
+
+	return &pb.RetrieveInternalBankAccountResponse{
+		Facility: toProtoFacility(account),
+	}, nil
+}
+
+// ListInternalBankAccounts queries accounts with filtering and pagination.
+func (s *Service) ListInternalBankAccounts(ctx context.Context, req *pb.ListInternalBankAccountsRequest) (*pb.ListInternalBankAccountsResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		ibaobservability.RecordOperationDuration("list_internal_bank_accounts", operationStatus, time.Since(start))
+	}()
+
+	// Build filter
+	filter := domain.ListFilter{
+		Limit:  50, // Default
+		Offset: 0,
+	}
+
+	// Apply account type filter
+	if req.AccountTypeFilter != pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_UNSPECIFIED {
+		accountType, err := protoToAccountType(req.AccountTypeFilter)
+		if err == nil {
+			filter.AccountType = &accountType
+		}
+	}
+
+	// Apply instrument code filter
+	if req.InstrumentCodeFilter != "" {
+		filter.InstrumentCode = &req.InstrumentCodeFilter
+	}
+
+	// Apply status filter
+	if req.StatusFilter != pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_UNSPECIFIED {
+		accountStatus, err := protoToAccountStatus(req.StatusFilter)
+		if err == nil {
+			filter.Status = &accountStatus
+		}
+	}
+
+	// Apply pagination
+	if req.Pagination != nil {
+		if req.Pagination.PageSize > 0 {
+			filter.Limit = int(req.Pagination.PageSize)
+		}
+		// Parse page_token as offset (simple offset-based pagination)
+		if req.Pagination.PageToken != "" {
+			var offset int
+			if _, err := fmt.Sscanf(req.Pagination.PageToken, "%d", &offset); err == nil {
+				filter.Offset = offset
+			}
+		}
+	}
+
+	// Query repository
+	accounts, err := s.repo.List(ctx, filter)
+	if err != nil {
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to list accounts: %v", err)
+	}
+
+	// Convert to proto
+	facilities := make([]*pb.InternalBankAccountFacility, len(accounts))
+	for i, account := range accounts {
+		facilities[i] = toProtoFacility(account)
+	}
+
+	// Build pagination response
+	var nextPageToken string
+	if len(accounts) == filter.Limit {
+		nextPageToken = fmt.Sprintf("%d", filter.Offset+filter.Limit)
+	}
+
+	return &pb.ListInternalBankAccountsResponse{
+		Facilities: facilities,
+		Pagination: &commonpb.PaginationResponse{
+			NextPageToken: nextPageToken,
+		},
+	}, nil
+}
+
+// GetBalance queries the balance for an internal account from Position Keeping service.
+func (s *Service) GetBalance(ctx context.Context, req *pb.GetBalanceRequest) (*pb.GetBalanceResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		ibaobservability.RecordOperationDuration("get_balance", operationStatus, time.Since(start))
+	}()
+
+	// Validate account exists and is active
+	account, err := s.findAccountByID(ctx, req.AccountId)
+	if err != nil {
+		operationStatus = opStatusAccountNotFound
+		return nil, err
+	}
+
+	// Only active accounts have queryable balances
+	if account.Status() != domain.AccountStatusActive {
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.FailedPrecondition, "account not active: %s", string(account.Status()))
+	}
+
+	// Position Keeping client must be configured for balance queries
+	if s.positionKeepingClient == nil {
+		operationStatus = operationStatusFailed
+		return nil, status.Error(codes.Unimplemented, "position keeping service not configured")
+	}
+
+	// Query Position Keeping service (source of truth for balance)
+	balanceResp, err := s.positionKeepingClient.GetAccountBalances(ctx, &positionkeepingv1.GetAccountBalancesRequest{
+		AccountId:      account.AccountID(),
+		InstrumentCode: account.InstrumentCode(),
+	})
+	if err != nil {
+		operationStatus = opStatusPositionKeepingError
+		s.logger.Error("failed to query balance from Position Keeping",
+			"account_id", req.AccountId,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to retrieve balance: %v", err)
+	}
+
+	// Find the current balance from the response
+	var currentBalance *pb.GetBalanceResponse
+	for _, entry := range balanceResp.GetBalances() {
+		if entry.GetBalanceType() == positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT {
+			currentBalance = &pb.GetBalanceResponse{
+				AccountId:   req.AccountId,
+				Balance:     entry.GetAmount(),
+				LastUpdated: timestamppb.Now(),
+			}
+			break
+		}
+	}
+
+	if currentBalance == nil {
+		// No current balance found - return zero balance
+		return &pb.GetBalanceResponse{
+			AccountId:   req.AccountId,
+			Balance:     nil,
+			LastUpdated: timestamppb.Now(),
+		}, nil
+	}
+
+	return currentBalance, nil
+}
+
+// findAccountByID finds an account by its ID (UUID or business ID).
+func (s *Service) findAccountByID(ctx context.Context, accountID string) (domain.InternalBankAccount, error) {
+	// First try to parse as UUID
+	if id, err := uuid.Parse(accountID); err == nil {
+		account, err := s.repo.FindByID(ctx, id)
+		if err != nil {
+			if errors.Is(err, domain.ErrAccountNotFound) {
+				return domain.InternalBankAccount{}, status.Errorf(codes.NotFound, "account not found: %s", accountID)
+			}
+			return domain.InternalBankAccount{}, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+		}
+		return account, nil
+	}
+
+	// Try to find by account code
+	account, err := s.repo.FindByCode(ctx, accountID)
+	if err != nil {
+		if errors.Is(err, domain.ErrAccountNotFound) {
+			return domain.InternalBankAccount{}, status.Errorf(codes.NotFound, "account not found: %s", accountID)
+		}
+		return domain.InternalBankAccount{}, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+	return account, nil
+}

--- a/services/internal-bank-account/service/server_test.go
+++ b/services/internal-bank-account/service/server_test.go
@@ -547,6 +547,45 @@ func TestUpdateInternalBankAccount_Success(t *testing.T) {
 	assert.NotNil(t, updateResp.Facility)
 }
 
+func TestUpdateInternalBankAccount_VersionConflict(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create account (version 1)
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	})
+	require.NoError(t, err)
+	originalVersion := createResp.Facility.Version
+	assert.Equal(t, int32(1), originalVersion)
+
+	// Suspend the account - this bumps version to 2
+	controlResp, err := svc.ControlInternalBankAccount(ctx, &pb.ControlInternalBankAccountRequest{
+		AccountId:     createResp.Facility.AccountCode,
+		ControlAction: pb.ControlAction_CONTROL_ACTION_SUSPEND,
+		Reason:        "Testing version conflict",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), controlResp.Facility.Version)
+
+	// Try to update with stale version - should fail with Aborted
+	_, err = svc.UpdateInternalBankAccount(ctx, &pb.UpdateInternalBankAccountRequest{
+		AccountId:       createResp.Facility.AccountCode,
+		Name:            "Update with stale version",
+		ExpectedVersion: originalVersion, // Version 1 is now stale, current is 2
+	})
+	assert.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Aborted, st.Code())
+}
+
 func TestUpdateInternalBankAccount_ClosedAccount(t *testing.T) {
 	repo := newMockRepository()
 	svc, err := NewService(repo)

--- a/services/internal-bank-account/service/server_test.go
+++ b/services/internal-bank-account/service/server_test.go
@@ -537,14 +537,17 @@ func TestUpdateInternalBankAccount_Success(t *testing.T) {
 		InstrumentCode: "USD",
 	})
 	require.NoError(t, err)
+	assert.Equal(t, "USD Clearing Account", createResp.Facility.Name)
 
-	// Update account
+	// Update account name
 	updateResp, err := svc.UpdateInternalBankAccount(ctx, &pb.UpdateInternalBankAccountRequest{
 		AccountId: createResp.Facility.AccountCode,
 		Name:      "Updated USD Clearing Account",
 	})
 	require.NoError(t, err)
 	assert.NotNil(t, updateResp.Facility)
+	assert.Equal(t, "Updated USD Clearing Account", updateResp.Facility.Name)
+	assert.Equal(t, int32(2), updateResp.Facility.Version) // Version should be bumped
 }
 
 func TestUpdateInternalBankAccount_VersionConflict(t *testing.T) {

--- a/services/internal-bank-account/service/server_test.go
+++ b/services/internal-bank-account/service/server_test.go
@@ -1,0 +1,582 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mockRepository implements domain.Repository for testing.
+type mockRepository struct {
+	accounts        map[uuid.UUID]domain.InternalBankAccount
+	accountsByCode  map[string]domain.InternalBankAccount
+	saveErr         error
+	findByIDErr     error
+	findByCodeErr   error
+	listErr         error
+	existsByCodeErr error
+}
+
+func newMockRepository() *mockRepository {
+	return &mockRepository{
+		accounts:       make(map[uuid.UUID]domain.InternalBankAccount),
+		accountsByCode: make(map[string]domain.InternalBankAccount),
+	}
+}
+
+func (m *mockRepository) Save(_ context.Context, account domain.InternalBankAccount) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.accounts[account.ID()] = account
+	m.accountsByCode[account.AccountCode()] = account
+	return nil
+}
+
+func (m *mockRepository) FindByID(_ context.Context, id uuid.UUID) (domain.InternalBankAccount, error) {
+	if m.findByIDErr != nil {
+		return domain.InternalBankAccount{}, m.findByIDErr
+	}
+	account, ok := m.accounts[id]
+	if !ok {
+		return domain.InternalBankAccount{}, domain.ErrAccountNotFound
+	}
+	return account, nil
+}
+
+func (m *mockRepository) FindByCode(_ context.Context, accountCode string) (domain.InternalBankAccount, error) {
+	if m.findByCodeErr != nil {
+		return domain.InternalBankAccount{}, m.findByCodeErr
+	}
+	account, ok := m.accountsByCode[accountCode]
+	if !ok {
+		return domain.InternalBankAccount{}, domain.ErrAccountNotFound
+	}
+	return account, nil
+}
+
+func (m *mockRepository) List(_ context.Context, _ domain.ListFilter) ([]domain.InternalBankAccount, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	accounts := make([]domain.InternalBankAccount, 0, len(m.accounts))
+	for _, account := range m.accounts {
+		accounts = append(accounts, account)
+	}
+	return accounts, nil
+}
+
+func (m *mockRepository) ExistsByCode(_ context.Context, accountCode string) (bool, error) {
+	if m.existsByCodeErr != nil {
+		return false, m.existsByCodeErr
+	}
+	_, ok := m.accountsByCode[accountCode]
+	return ok, nil
+}
+
+// mockPositionKeepingClient implements PositionKeepingClient for testing.
+type mockPositionKeepingClient struct {
+	balances []*positionkeepingv1.BalanceEntry
+	err      error
+}
+
+func (m *mockPositionKeepingClient) GetAccountBalances(_ context.Context, req *positionkeepingv1.GetAccountBalancesRequest) (*positionkeepingv1.GetAccountBalancesResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &positionkeepingv1.GetAccountBalancesResponse{
+		AccountId: req.AccountId,
+		Balances:  m.balances,
+	}, nil
+}
+
+func (m *mockPositionKeepingClient) Close() error {
+	return nil
+}
+
+// mockReferenceDataClient implements ReferenceDataClient for testing.
+type mockReferenceDataClient struct {
+	instrument *referencedatav1.InstrumentDefinition
+	err        error
+}
+
+func (m *mockReferenceDataClient) RetrieveInstrument(_ context.Context, _ *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &referencedatav1.RetrieveInstrumentResponse{
+		Instrument: m.instrument,
+	}, nil
+}
+
+func (m *mockReferenceDataClient) Close() error {
+	return nil
+}
+
+func TestNewService_Success(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}
+
+func TestNewService_NilRepository(t *testing.T) {
+	svc, err := NewService(nil)
+	assert.Error(t, err)
+	assert.Equal(t, ErrRepositoryNil, err)
+	assert.Nil(t, svc)
+}
+
+func TestNewServiceWithClients_Success(t *testing.T) {
+	repo := newMockRepository()
+	posClient := &mockPositionKeepingClient{}
+	refClient := &mockReferenceDataClient{}
+
+	svc, err := NewServiceWithClients(repo, posClient, refClient, nil, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, svc)
+}
+
+func TestInitiateInternalBankAccount_Success(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.AccountId)
+	assert.NotNil(t, resp.Facility)
+	assert.Equal(t, "CLR-001", resp.Facility.AccountCode)
+	assert.Equal(t, "USD Clearing Account", resp.Facility.Name)
+	assert.Equal(t, pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING, resp.Facility.AccountType)
+	assert.Equal(t, pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE, resp.Facility.AccountStatus)
+}
+
+func TestInitiateInternalBankAccount_WithCorrespondent(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "NOSTRO-USD-HSBC",
+		Name:           "HSBC USD Nostro",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_NOSTRO,
+		InstrumentCode: "USD",
+		CorrespondentDetails: &pb.CorrespondentBankDetails{
+			BankId:             "HSBC001",
+			BankName:           "HSBC Bank",
+			ExternalAccountRef: "12345678",
+			SwiftCode:          "HSBCGB2L",
+			CorrespondentType:  pb.CorrespondentType_CORRESPONDENT_TYPE_NOSTRO,
+		},
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	require.NoError(t, err)
+	assert.NotNil(t, resp.Facility.CorrespondentDetails)
+	assert.Equal(t, "HSBC001", resp.Facility.CorrespondentDetails.BankId)
+	assert.Equal(t, "HSBC Bank", resp.Facility.CorrespondentDetails.BankName)
+}
+
+func TestInitiateInternalBankAccount_NostroWithoutCorrespondent(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "NOSTRO-USD-HSBC",
+		Name:           "HSBC USD Nostro",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_NOSTRO,
+		InstrumentCode: "USD",
+		// Missing CorrespondentDetails
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestInitiateInternalBankAccount_InvalidAccountType(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "Test Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_UNSPECIFIED,
+		InstrumentCode: "USD",
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestRetrieveInternalBankAccount_Success(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// First create an account
+	createReq := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	}
+	createResp, err := svc.InitiateInternalBankAccount(ctx, createReq)
+	require.NoError(t, err)
+
+	// Then retrieve it by code
+	retrieveResp, err := svc.RetrieveInternalBankAccount(ctx, &pb.RetrieveInternalBankAccountRequest{
+		AccountId: "CLR-001",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, createResp.Facility.AccountCode, retrieveResp.Facility.AccountCode)
+}
+
+func TestRetrieveInternalBankAccount_NotFound(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	resp, err := svc.RetrieveInternalBankAccount(ctx, &pb.RetrieveInternalBankAccountRequest{
+		AccountId: "nonexistent",
+	})
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestControlInternalBankAccount_Suspend(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create account
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	})
+	require.NoError(t, err)
+
+	// Suspend the account
+	controlResp, err := svc.ControlInternalBankAccount(ctx, &pb.ControlInternalBankAccountRequest{
+		AccountId:     createResp.Facility.AccountCode,
+		ControlAction: pb.ControlAction_CONTROL_ACTION_SUSPEND,
+		Reason:        "Testing suspension for compliance review",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_SUSPENDED, controlResp.Facility.AccountStatus)
+}
+
+func TestControlInternalBankAccount_Close(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create account
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	})
+	require.NoError(t, err)
+
+	// Close the account
+	controlResp, err := svc.ControlInternalBankAccount(ctx, &pb.ControlInternalBankAccountRequest{
+		AccountId:     createResp.Facility.AccountCode,
+		ControlAction: pb.ControlAction_CONTROL_ACTION_CLOSE,
+		Reason:        "Account no longer needed after migration",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_CLOSED, controlResp.Facility.AccountStatus)
+}
+
+func TestControlInternalBankAccount_InvalidTransition(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create and close account
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	})
+	require.NoError(t, err)
+
+	_, err = svc.ControlInternalBankAccount(ctx, &pb.ControlInternalBankAccountRequest{
+		AccountId:     createResp.Facility.AccountCode,
+		ControlAction: pb.ControlAction_CONTROL_ACTION_CLOSE,
+		Reason:        "Closing the account for testing",
+	})
+	require.NoError(t, err)
+
+	// Try to activate a closed account - should fail
+	_, err = svc.ControlInternalBankAccount(ctx, &pb.ControlInternalBankAccountRequest{
+		AccountId:     createResp.Facility.AccountCode,
+		ControlAction: pb.ControlAction_CONTROL_ACTION_ACTIVATE,
+		Reason:        "Trying to reactivate closed account",
+	})
+	assert.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestListInternalBankAccounts_Success(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create multiple accounts
+	for i := 0; i < 3; i++ {
+		_, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+			AccountCode:    "CLR-00" + string(rune('1'+i)),
+			Name:           "Clearing Account " + string(rune('1'+i)),
+			AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+			InstrumentCode: "USD",
+		})
+		require.NoError(t, err)
+	}
+
+	// List all accounts
+	resp, err := svc.ListInternalBankAccounts(ctx, &pb.ListInternalBankAccountsRequest{})
+	require.NoError(t, err)
+	assert.Len(t, resp.Facilities, 3)
+}
+
+func TestGetBalance_Success(t *testing.T) {
+	repo := newMockRepository()
+	posClient := &mockPositionKeepingClient{
+		balances: []*positionkeepingv1.BalanceEntry{
+			{
+				BalanceType: positionkeepingv1.BalanceType_BALANCE_TYPE_CURRENT,
+				Amount: &quantityv1.InstrumentAmount{
+					InstrumentCode: "USD",
+					Amount:         "1000.00",
+				},
+			},
+		},
+	}
+	svc, err := NewServiceWithClients(repo, posClient, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create account
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	})
+	require.NoError(t, err)
+
+	// Get balance
+	balanceResp, err := svc.GetBalance(ctx, &pb.GetBalanceRequest{
+		AccountId: createResp.Facility.AccountCode,
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, balanceResp.Balance)
+	assert.Equal(t, "USD", balanceResp.Balance.InstrumentCode)
+	assert.Equal(t, "1000.00", balanceResp.Balance.Amount)
+}
+
+func TestGetBalance_AccountNotActive(t *testing.T) {
+	repo := newMockRepository()
+	posClient := &mockPositionKeepingClient{}
+	svc, err := NewServiceWithClients(repo, posClient, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create and suspend account
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	})
+	require.NoError(t, err)
+
+	_, err = svc.ControlInternalBankAccount(ctx, &pb.ControlInternalBankAccountRequest{
+		AccountId:     createResp.Facility.AccountCode,
+		ControlAction: pb.ControlAction_CONTROL_ACTION_SUSPEND,
+		Reason:        "Suspending for balance test",
+	})
+	require.NoError(t, err)
+
+	// Try to get balance - should fail
+	_, err = svc.GetBalance(ctx, &pb.GetBalanceRequest{
+		AccountId: createResp.Facility.AccountCode,
+	})
+	assert.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestGetBalance_NoPositionKeepingClient(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create account
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	})
+	require.NoError(t, err)
+
+	// Try to get balance without position keeping client
+	_, err = svc.GetBalance(ctx, &pb.GetBalanceRequest{
+		AccountId: createResp.Facility.AccountCode,
+	})
+	assert.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+}
+
+// ErrPositionKeepingUnavailable is used in tests.
+var errPositionKeepingUnavailable = errors.New("position keeping service unavailable")
+
+func TestGetBalance_PositionKeepingError(t *testing.T) {
+	repo := newMockRepository()
+	posClient := &mockPositionKeepingClient{
+		err: errPositionKeepingUnavailable,
+	}
+	svc, err := NewServiceWithClients(repo, posClient, nil, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create account
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	})
+	require.NoError(t, err)
+
+	// Try to get balance - position keeping error
+	_, err = svc.GetBalance(ctx, &pb.GetBalanceRequest{
+		AccountId: createResp.Facility.AccountCode,
+	})
+	assert.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+func TestUpdateInternalBankAccount_Success(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create account
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	})
+	require.NoError(t, err)
+
+	// Update account
+	updateResp, err := svc.UpdateInternalBankAccount(ctx, &pb.UpdateInternalBankAccountRequest{
+		AccountId: createResp.Facility.AccountCode,
+		Name:      "Updated USD Clearing Account",
+	})
+	require.NoError(t, err)
+	assert.NotNil(t, updateResp.Facility)
+}
+
+func TestUpdateInternalBankAccount_ClosedAccount(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create and close account
+	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	})
+	require.NoError(t, err)
+
+	_, err = svc.ControlInternalBankAccount(ctx, &pb.ControlInternalBankAccountRequest{
+		AccountId:     createResp.Facility.AccountCode,
+		ControlAction: pb.ControlAction_CONTROL_ACTION_CLOSE,
+		Reason:        "Closing for update test",
+	})
+	require.NoError(t, err)
+
+	// Try to update closed account - should fail
+	_, err = svc.UpdateInternalBankAccount(ctx, &pb.UpdateInternalBankAccountRequest{
+		AccountId: createResp.Facility.AccountCode,
+		Name:      "Updated Name",
+	})
+	assert.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}


### PR DESCRIPTION
## Summary

- Implements complete gRPC service layer for InternalBankAccount service
- Follows established patterns from current-account service
- Task Master: internal-bank-account.6

## Changes Made

### Service Implementation (`services/internal-bank-account/service/`)

**server.go**:
- Service struct with configurable dependencies (repository, Position Keeping client, Reference Data client)
- `InitiateInternalBankAccount` RPC - creates new internal accounts with optional correspondent details
- `UpdateInternalBankAccount` RPC - updates account settings with optimistic locking
- `ControlInternalBankAccount` RPC - lifecycle management (suspend, activate, close)
- `RetrieveInternalBankAccount` RPC - fetches single account by ID
- `ListInternalBankAccounts` RPC - queries with filtering and pagination
- `GetBalance` RPC - delegates to Position Keeping service (source of truth for balances)

**mappers.go**:
- Proto-to-domain type conversions for account types and statuses
- Domain-to-proto facility mapping with correspondent details
- Comprehensive error mapping to gRPC status codes

**client_interfaces.go**:
- `PositionKeepingClient` interface for balance queries
- `ReferenceDataClient` interface for instrument validation

**errors.go**:
- Sentinel errors for validation failures

### Observability (`services/internal-bank-account/observability/`)

- Prometheus metrics for operation duration, account creation, and status changes

### Tests

- Unit tests with mock repository and client implementations
- Coverage for success paths and error conditions
- Tests for all RPC methods and mapper functions

## Technical Details

- Uses constructor injection for testability
- Implements Position Keeping integration for balance queries (no local balance storage)
- Supports correspondent bank details for NOSTRO/VOSTRO accounts
- Follows BIAN domain patterns

## Test Plan

- [x] Unit tests pass (`go test ./services/internal-bank-account/...`)
- [x] Linting passes (`golangci-lint run`)
- [x] Build succeeds (`go build ./services/internal-bank-account/...`)
- [ ] CI pipeline passes

## Dependencies

- Depends on Task 5 (persistence layer) - ✅ merged