### PR TITLE
feat(internal-bank-account): implement Reference Data validation

### DIFF
--- a/services/internal-bank-account/observability/metrics.go
+++ b/services/internal-bank-account/observability/metrics.go
@@ -49,7 +49,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "internal_bank_account_instrument_validation_duration_seconds",
 			Help:    "Duration of instrument validation calls to Reference Data service",
-			Buckets: []float64{.001, .005, .01, .05, .1, .5, 1.0},
+			Buckets: []float64{.001, .005, .01, .05, .1, .5, 1.0, 2.5, 5.0},
 		},
 		[]string{"result"},
 	)
@@ -71,7 +71,7 @@ func RecordAccountStatusChange(fromStatus, toStatus string) {
 }
 
 // RecordInstrumentValidation records an instrument validation attempt with its result.
-// Result should be one of: "success", "not_found", "not_active", "error".
+// Result should be one of: "success", "not_found", "not_active", "timeout", "error".
 func RecordInstrumentValidation(result string, duration time.Duration) {
 	instrumentValidation.WithLabelValues(result).Inc()
 	instrumentValidationDuration.WithLabelValues(result).Observe(duration.Seconds())

--- a/services/internal-bank-account/observability/metrics.go
+++ b/services/internal-bank-account/observability/metrics.go
@@ -35,6 +35,24 @@ var (
 		},
 		[]string{"from_status", "to_status"},
 	)
+
+	// Instrument validation metrics
+	instrumentValidation = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "internal_bank_account_instrument_validation_total",
+			Help: "Total number of instrument validation attempts",
+		},
+		[]string{"result"},
+	)
+
+	instrumentValidationDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "internal_bank_account_instrument_validation_duration_seconds",
+			Help:    "Duration of instrument validation calls to Reference Data service",
+			Buckets: []float64{.001, .005, .01, .05, .1, .5, 1.0},
+		},
+		[]string{"result"},
+	)
 )
 
 // RecordOperationDuration records the duration of an internal bank account operation.
@@ -50,4 +68,11 @@ func RecordAccountCreated(accountType string) {
 // RecordAccountStatusChange records an account status transition.
 func RecordAccountStatusChange(fromStatus, toStatus string) {
 	accountStatusChanges.WithLabelValues(fromStatus, toStatus).Inc()
+}
+
+// RecordInstrumentValidation records an instrument validation attempt with its result.
+// Result should be one of: "success", "not_found", "not_active", "error".
+func RecordInstrumentValidation(result string, duration time.Duration) {
+	instrumentValidation.WithLabelValues(result).Inc()
+	instrumentValidationDuration.WithLabelValues(result).Observe(duration.Seconds())
 }

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -35,6 +36,7 @@ const (
 	opStatusDuplicateCode           = "duplicate_code"
 	opStatusInstrumentNotFound      = "instrument_not_found"
 	opStatusInstrumentNotActive     = "instrument_not_active"
+	opStatusInstrumentValidationErr = "instrument_validation_error"
 	opStatusPositionKeepingError    = "position_keeping_error"
 )
 
@@ -115,14 +117,22 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 		})
 		if err != nil {
 			validationDuration := time.Since(validationStart)
-			operationStatus = opStatusInstrumentNotFound
+			errCode := status.Code(err)
 			s.logger.Warn("instrument validation failed",
 				"instrument_code", req.InstrumentCode,
 				"error", err)
-			if status.Code(err) == codes.NotFound {
+
+			if errCode == codes.NotFound {
+				operationStatus = opStatusInstrumentNotFound
 				ibaobservability.RecordInstrumentValidation("not_found", validationDuration)
 				return nil, status.Errorf(codes.InvalidArgument, "instrument not found: %s", req.InstrumentCode)
 			}
+			if errCode == codes.DeadlineExceeded || errCode == codes.Canceled {
+				operationStatus = opStatusInstrumentValidationErr
+				ibaobservability.RecordInstrumentValidation("timeout", validationDuration)
+				return nil, status.Errorf(codes.DeadlineExceeded, "instrument validation timed out for: %s", req.InstrumentCode)
+			}
+			operationStatus = opStatusInstrumentValidationErr
 			ibaobservability.RecordInstrumentValidation("error", validationDuration)
 			return nil, status.Errorf(codes.Internal, "failed to validate instrument: %v", err)
 		}
@@ -139,8 +149,8 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 				req.InstrumentCode, refDataResp.Instrument.Status.String())
 		}
 
-		// Extract dimension from validated instrument
-		dimension = refDataResp.Instrument.Dimension.String()
+		// Extract dimension from validated instrument (strip DIMENSION_ prefix for domain consistency)
+		dimension = strings.TrimPrefix(refDataResp.Instrument.Dimension.String(), "DIMENSION_")
 		ibaobservability.RecordInstrumentValidation("success", time.Since(validationStart))
 	}
 

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -34,6 +34,7 @@ const (
 	opStatusVersionConflict         = "version_conflict"
 	opStatusDuplicateCode           = "duplicate_code"
 	opStatusInstrumentNotFound      = "instrument_not_found"
+	opStatusInstrumentNotActive     = "instrument_not_active"
 	opStatusPositionKeepingError    = "position_keeping_error"
 )
 
@@ -129,7 +130,7 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 		// Validate instrument status is ACTIVE
 		if refDataResp.Instrument.Status != referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE {
 			validationDuration := time.Since(validationStart)
-			operationStatus = opStatusInstrumentNotFound
+			operationStatus = opStatusInstrumentNotActive
 			s.logger.Warn("instrument not active",
 				"instrument_code", req.InstrumentCode,
 				"status", refDataResp.Instrument.Status.String())

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -137,6 +137,16 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 			return nil, status.Errorf(codes.Internal, "failed to validate instrument: %v", err)
 		}
 
+		// Guard against nil instrument in response (defensive programming)
+		if refDataResp.Instrument == nil {
+			validationDuration := time.Since(validationStart)
+			operationStatus = opStatusInstrumentValidationErr
+			s.logger.Error("reference data service returned nil instrument",
+				"instrument_code", req.InstrumentCode)
+			ibaobservability.RecordInstrumentValidation("error", validationDuration)
+			return nil, status.Errorf(codes.Internal, "reference data service returned invalid response for instrument: %s", req.InstrumentCode)
+		}
+
 		// Validate instrument status is ACTIVE
 		if refDataResp.Instrument.Status != referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE {
 			validationDuration := time.Since(validationStart)

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -102,37 +102,58 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 		return nil, status.Errorf(codes.InvalidArgument, "invalid account type: %v", err)
 	}
 
-	// Validate instrument exists via Reference Data service (if client is configured)
+	// Validate instrument exists and is ACTIVE via Reference Data service (if client is configured)
+	var dimension string
 	if s.referenceDataClient != nil {
+		validationStart := time.Now()
 		refDataCtx, refDataCancel := context.WithTimeout(ctx, 5*time.Second)
 		defer refDataCancel()
 
-		_, err := s.referenceDataClient.RetrieveInstrument(refDataCtx, &referencedatav1.RetrieveInstrumentRequest{
+		refDataResp, err := s.referenceDataClient.RetrieveInstrument(refDataCtx, &referencedatav1.RetrieveInstrumentRequest{
 			Code: req.InstrumentCode,
 		})
 		if err != nil {
+			validationDuration := time.Since(validationStart)
 			operationStatus = opStatusInstrumentNotFound
 			s.logger.Warn("instrument validation failed",
 				"instrument_code", req.InstrumentCode,
 				"error", err)
 			if status.Code(err) == codes.NotFound {
+				ibaobservability.RecordInstrumentValidation("not_found", validationDuration)
 				return nil, status.Errorf(codes.InvalidArgument, "instrument not found: %s", req.InstrumentCode)
 			}
+			ibaobservability.RecordInstrumentValidation("error", validationDuration)
 			return nil, status.Errorf(codes.Internal, "failed to validate instrument: %v", err)
 		}
+
+		// Validate instrument status is ACTIVE
+		if refDataResp.Instrument.Status != referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE {
+			validationDuration := time.Since(validationStart)
+			operationStatus = opStatusInstrumentNotFound
+			s.logger.Warn("instrument not active",
+				"instrument_code", req.InstrumentCode,
+				"status", refDataResp.Instrument.Status.String())
+			ibaobservability.RecordInstrumentValidation("not_active", validationDuration)
+			return nil, status.Errorf(codes.InvalidArgument, "instrument %s is not active (status: %s)",
+				req.InstrumentCode, refDataResp.Instrument.Status.String())
+		}
+
+		// Extract dimension from validated instrument
+		dimension = refDataResp.Instrument.Dimension.String()
+		ibaobservability.RecordInstrumentValidation("success", time.Since(validationStart))
 	}
 
 	// Generate account ID using full UUID for uniqueness
 	accountID := fmt.Sprintf("IBA-%s", uuid.New().String())
 
-	// Create domain entity
+	// Create domain entity with dimension from Reference Data
 	account, err := domain.NewInternalBankAccount(
 		accountID,
 		req.AccountCode,
 		req.Name,
 		accountType,
 		req.InstrumentCode,
-		"", // dimension - could be populated from Reference Data response
+		dimension,
 	)
 	if err != nil {
 		operationStatus = operationStatusFailed

--- a/services/internal-bank-account/service/server_test.go
+++ b/services/internal-bank-account/service/server_test.go
@@ -652,6 +652,11 @@ func TestInitiateInternalBankAccount_WithReferenceDataValidation_Success(t *test
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp.AccountId)
 	assert.Equal(t, "CLR-001", resp.Facility.AccountCode)
+
+	// Verify dimension was correctly extracted and stored (DIMENSION_ prefix stripped)
+	savedAccount, err := repo.FindByCode(ctx, "CLR-001")
+	require.NoError(t, err)
+	assert.Equal(t, "CURRENCY", savedAccount.Dimension(), "dimension should be stripped of DIMENSION_ prefix")
 }
 
 func TestInitiateInternalBankAccount_InstrumentNotFound(t *testing.T) {
@@ -764,6 +769,32 @@ func TestInitiateInternalBankAccount_ReferenceDataServiceUnavailable(t *testing.
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
 	assert.Contains(t, st.Message(), "failed to validate instrument")
+}
+
+func TestInitiateInternalBankAccount_ReferenceDataTimeout(t *testing.T) {
+	repo := newMockRepository()
+	refClient := &mockReferenceDataClient{
+		err: status.Error(codes.DeadlineExceeded, "context deadline exceeded"),
+	}
+
+	svc, err := NewServiceWithClients(repo, nil, refClient, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "Test Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.DeadlineExceeded, st.Code())
+	assert.Contains(t, st.Message(), "timed out")
 }
 
 func TestInitiateInternalBankAccount_EnergyInstrument(t *testing.T) {

--- a/services/internal-bank-account/service/server_test.go
+++ b/services/internal-bank-account/service/server_test.go
@@ -797,6 +797,32 @@ func TestInitiateInternalBankAccount_ReferenceDataTimeout(t *testing.T) {
 	assert.Contains(t, st.Message(), "timed out")
 }
 
+func TestInitiateInternalBankAccount_NilInstrumentInResponse(t *testing.T) {
+	repo := newMockRepository()
+	refClient := &mockReferenceDataClient{
+		instrument: nil, // Simulate malformed response
+	}
+
+	svc, err := NewServiceWithClients(repo, nil, refClient, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "Test Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "invalid response")
+}
+
 func TestInitiateInternalBankAccount_EnergyInstrument(t *testing.T) {
 	repo := newMockRepository()
 	refClient := &mockReferenceDataClient{

--- a/services/internal-bank-account/service/server_test.go
+++ b/services/internal-bank-account/service/server_test.go
@@ -622,3 +622,200 @@ func TestUpdateInternalBankAccount_ClosedAccount(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.FailedPrecondition, st.Code())
 }
+
+// =============================================================================
+// Reference Data Validation Tests
+// =============================================================================
+
+func TestInitiateInternalBankAccount_WithReferenceDataValidation_Success(t *testing.T) {
+	repo := newMockRepository()
+	refClient := &mockReferenceDataClient{
+		instrument: &referencedatav1.InstrumentDefinition{
+			Code:      "USD",
+			Status:    referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+			Dimension: referencedatav1.Dimension_DIMENSION_CURRENCY,
+		},
+	}
+
+	svc, err := NewServiceWithClients(repo, nil, refClient, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "USD Clearing Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.AccountId)
+	assert.Equal(t, "CLR-001", resp.Facility.AccountCode)
+}
+
+func TestInitiateInternalBankAccount_InstrumentNotFound(t *testing.T) {
+	repo := newMockRepository()
+	refClient := &mockReferenceDataClient{
+		err: status.Error(codes.NotFound, "instrument not found"),
+	}
+
+	svc, err := NewServiceWithClients(repo, nil, refClient, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "Test Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "INVALID",
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "instrument not found")
+}
+
+func TestInitiateInternalBankAccount_InstrumentNotActive(t *testing.T) {
+	repo := newMockRepository()
+	refClient := &mockReferenceDataClient{
+		instrument: &referencedatav1.InstrumentDefinition{
+			Code:      "DRAFT_COIN",
+			Status:    referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_DRAFT,
+			Dimension: referencedatav1.Dimension_DIMENSION_CURRENCY,
+		},
+	}
+
+	svc, err := NewServiceWithClients(repo, nil, refClient, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "Test Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "DRAFT_COIN",
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "is not active")
+}
+
+func TestInitiateInternalBankAccount_InstrumentDeprecated(t *testing.T) {
+	repo := newMockRepository()
+	refClient := &mockReferenceDataClient{
+		instrument: &referencedatav1.InstrumentDefinition{
+			Code:      "OLD_COIN",
+			Status:    referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_DEPRECATED,
+			Dimension: referencedatav1.Dimension_DIMENSION_CURRENCY,
+		},
+	}
+
+	svc, err := NewServiceWithClients(repo, nil, refClient, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "Test Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "OLD_COIN",
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "is not active")
+}
+
+func TestInitiateInternalBankAccount_ReferenceDataServiceUnavailable(t *testing.T) {
+	repo := newMockRepository()
+	refClient := &mockReferenceDataClient{
+		err: status.Error(codes.Unavailable, "service unavailable"),
+	}
+
+	svc, err := NewServiceWithClients(repo, nil, refClient, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "CLR-001",
+		Name:           "Test Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "failed to validate instrument")
+}
+
+func TestInitiateInternalBankAccount_EnergyInstrument(t *testing.T) {
+	repo := newMockRepository()
+	refClient := &mockReferenceDataClient{
+		instrument: &referencedatav1.InstrumentDefinition{
+			Code:      "KWH",
+			Status:    referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+			Dimension: referencedatav1.Dimension_DIMENSION_ENERGY,
+		},
+	}
+
+	svc, err := NewServiceWithClients(repo, nil, refClient, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "INV-ENERGY-001",
+		Name:           "Energy Inventory Account",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_INVENTORY,
+		InstrumentCode: "KWH",
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.AccountId)
+	assert.Equal(t, "INV-ENERGY-001", resp.Facility.AccountCode)
+}
+
+func TestInitiateInternalBankAccount_ComputeInstrument(t *testing.T) {
+	repo := newMockRepository()
+	refClient := &mockReferenceDataClient{
+		instrument: &referencedatav1.InstrumentDefinition{
+			Code:      "GPU_HOUR",
+			Status:    referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+			Dimension: referencedatav1.Dimension_DIMENSION_COMPUTE,
+		},
+	}
+
+	svc, err := NewServiceWithClients(repo, nil, refClient, nil, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := &pb.InitiateInternalBankAccountRequest{
+		AccountCode:    "INV-COMPUTE-001",
+		Name:           "GPU Compute Inventory",
+		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_INVENTORY,
+		InstrumentCode: "GPU_HOUR",
+	}
+
+	resp, err := svc.InitiateInternalBankAccount(ctx, req)
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.AccountId)
+	assert.Equal(t, "INV-COMPUTE-001", resp.Facility.AccountCode)
+}


### PR DESCRIPTION
## Summary

Enhances the `InitiateInternalBankAccount` RPC with comprehensive instrument validation via the Reference Data service:

- **Status validation**: Rejects instruments that are not ACTIVE (DRAFT, DEPRECATED)
- **Dimension extraction**: Stores the instrument's dimension in the domain model
- **Observability**: Adds Prometheus metrics for validation count and duration

## Task Master

- Tag: `internal-bank-account`
- Task: `10 - Implement Reference Data validation`

## Changes Made

### `services/internal-bank-account/service/server.go`
- Enhanced `InitiateInternalBankAccount` to validate instrument status is ACTIVE
- Extract dimension from Reference Data response and pass to domain entity
- Added timing metrics for validation operations

### `services/internal-bank-account/observability/metrics.go`
- Added `instrument_validation_total` counter with result labels
- Added `instrument_validation_duration_seconds` histogram

### `services/internal-bank-account/service/server_test.go`
- Added 7 new test cases covering validation scenarios:
  - Valid active instrument
  - Instrument not found
  - Instrument not active (DRAFT status)
  - Instrument deprecated
  - Reference Data service unavailable
  - Energy instrument (DIMENSION_ENERGY)
  - Compute instrument (DIMENSION_COMPUTE)

## Testing

```bash
go test ./services/internal-bank-account/... -v
# All tests pass
```

## Risk Assessment

**Low risk** - This change adds validation that was already partially implemented. The validation is only applied when the Reference Data client is configured, maintaining backward compatibility.