### PR TITLE
feat: Add automatic default internal bank account provisioning

### DIFF
--- a/cmd/ibactl/cmd/provision_defaults.go
+++ b/cmd/ibactl/cmd/provision_defaults.go
@@ -1,0 +1,318 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/tenant/v1"
+	"github.com/meridianhub/meridian/cmd/tenantctl/client"
+	"github.com/meridianhub/meridian/services/internal-bank-account/provisioning"
+	"github.com/meridianhub/meridian/shared/platform/ports"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/spf13/cobra"
+)
+
+// Sentinel errors for provision-defaults command.
+var (
+	// ErrTenantIDOrFlagRequired is returned when no tenant ID and no --all or --list-templates flag is provided.
+	ErrTenantIDOrFlagRequired = errors.New("tenant ID required (or use --all or --list-templates)")
+	// ErrTenantIDWithAll is returned when tenant ID is specified along with --all.
+	ErrTenantIDWithAll = errors.New("cannot specify tenant ID with --all")
+	// ErrUnknownTemplateSet is returned when an unknown template set is specified.
+	ErrUnknownTemplateSet = errors.New("unknown template set")
+	// ErrAccountsFailedToProvision is returned when some accounts failed to provision.
+	ErrAccountsFailedToProvision = errors.New("accounts failed to provision")
+	// ErrTenantsFailedProvisioning is returned when some tenants failed provisioning.
+	ErrTenantsFailedProvisioning = errors.New("tenants failed provisioning")
+)
+
+var (
+	provisionAll        bool
+	tenantServiceURL    string
+	dryRun              bool
+	continueOnError     bool
+	maxConcurrent       int
+	provisioningTimeout time.Duration
+	templateSet         string
+	listTemplates       bool
+)
+
+var provisionDefaultsCmd = &cobra.Command{
+	Use:   "provision-defaults [tenant-id]",
+	Short: "Provision default internal bank accounts for a tenant",
+	Long: `Provision default internal bank accounts for a tenant.
+
+This command creates a set of internal bank accounts for a tenant based on
+the selected template set:
+
+  default  - Standard banking (clearing, revenue, expense, suspense)
+  energy   - Energy trading (includes KWH clearing and inventory)
+  compute  - Cloud/AI billing (includes GPU-hour, data transfer accounts)
+  minimal  - Only suspense account (for manual configuration)
+
+The operation is idempotent - accounts that already exist are skipped.
+
+Examples:
+  # Provision defaults for a specific tenant
+  ibactl provision-defaults acme_bank
+
+  # Use energy template set for an energy company
+  ibactl provision-defaults energy_co --template-set=energy
+
+  # Provision defaults for all active tenants
+  ibactl provision-defaults --all
+
+  # Dry run to see what would be created
+  ibactl provision-defaults acme_bank --dry-run
+
+  # List available template sets
+  ibactl provision-defaults --list-templates`,
+	Args: func(_ *cobra.Command, args []string) error {
+		if listTemplates {
+			return nil // No args needed for listing templates
+		}
+		if !provisionAll && len(args) == 0 {
+			return ErrTenantIDOrFlagRequired
+		}
+		if provisionAll && len(args) > 0 {
+			return ErrTenantIDWithAll
+		}
+		return nil
+	},
+	RunE: runProvisionDefaults,
+}
+
+func init() {
+	rootCmd.AddCommand(provisionDefaultsCmd)
+
+	provisionDefaultsCmd.Flags().BoolVar(&provisionAll, "all", false,
+		"Provision default accounts for all active tenants")
+	provisionDefaultsCmd.Flags().StringVar(&tenantServiceURL, "tenant-service-url",
+		getEnvOrDefault("TENANT_SERVICE_URL", fmt.Sprintf("localhost:%d", ports.Tenant)),
+		"Tenant service URL (for --all)")
+	provisionDefaultsCmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"Show what would be created without making changes")
+	provisionDefaultsCmd.Flags().BoolVar(&continueOnError, "continue-on-error", false,
+		"Continue provisioning other tenants if one fails (--all only)")
+	provisionDefaultsCmd.Flags().IntVar(&maxConcurrent, "max-concurrent", 5,
+		"Maximum number of concurrent tenant provisioning operations (--all only)")
+	provisionDefaultsCmd.Flags().DurationVar(&provisioningTimeout, "provisioning-timeout",
+		30*time.Second, "Timeout for each tenant's provisioning operation")
+	provisionDefaultsCmd.Flags().StringVar(&templateSet, "template-set", "default",
+		"Template set to use (default, energy, compute, minimal)")
+	provisionDefaultsCmd.Flags().BoolVar(&listTemplates, "list-templates", false,
+		"List available template sets")
+}
+
+func runProvisionDefaults(cmd *cobra.Command, args []string) error {
+	// Handle --list-templates
+	if listTemplates {
+		return listAvailableTemplates()
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+
+	// Validate template set
+	ts := provisioning.GetTemplateSet(templateSet)
+	if ts == nil {
+		return fmt.Errorf("%w: %s (use --list-templates to see available sets)", ErrUnknownTemplateSet, templateSet)
+	}
+
+	// Create IBA client
+	ibaClient, cleanup, err := newClient()
+	if err != nil {
+		return fmt.Errorf("failed to create internal bank account client: %w", err)
+	}
+	defer cleanup()
+
+	// Create provisioner
+	provisioner := provisioning.NewProvisioner(ibaClient, logger)
+
+	if provisionAll {
+		return provisionAllTenants(cmd.Context(), provisioner, ts, logger)
+	}
+
+	// Single tenant
+	tenantID, err := tenant.NewTenantID(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid tenant ID: %w", err)
+	}
+
+	return provisionSingleTenant(cmd.Context(), provisioner, tenantID, ts, logger)
+}
+
+func listAvailableTemplates() error {
+	fmt.Println("Available template sets:")
+	fmt.Println()
+	for _, name := range provisioning.ListTemplateSets() {
+		ts := provisioning.GetTemplateSet(name)
+		fmt.Printf("  %s\n", name)
+		fmt.Printf("    Description: %s\n", ts.Description)
+		fmt.Printf("    Accounts: %d\n", len(ts.Templates))
+		fmt.Println()
+	}
+	return nil
+}
+
+func provisionSingleTenant(ctx context.Context, provisioner *provisioning.Provisioner, tenantID tenant.TenantID, ts *provisioning.TemplateSet, _ *slog.Logger) error {
+	if dryRun {
+		fmt.Printf("Dry run: Would provision %d accounts from '%s' template set for tenant %s:\n",
+			len(ts.Templates), ts.Name, tenantID)
+		for _, template := range ts.Templates {
+			fmt.Printf("  - %s (%s): %s\n", template.Code, template.Type.String(), template.Name)
+		}
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, provisioningTimeout)
+	defer cancel()
+
+	fmt.Printf("Provisioning '%s' template accounts for tenant %s...\n", ts.Name, tenantID)
+
+	result, err := provisioner.ProvisionFromTemplates(ctx, tenantID, ts.Templates)
+	if err != nil {
+		return fmt.Errorf("provisioning failed: %w", err)
+	}
+
+	fmt.Printf("Completed: created=%d, skipped=%d, failed=%d\n",
+		result.Created, result.Skipped, result.Failed)
+
+	if len(result.Errors) > 0 {
+		fmt.Println("Errors:")
+		for _, e := range result.Errors {
+			fmt.Printf("  - %v\n", e)
+		}
+		return fmt.Errorf("%w: %d failed", ErrAccountsFailedToProvision, result.Failed)
+	}
+
+	return nil
+}
+
+// provisionStats tracks provisioning statistics across tenants.
+type provisionStats struct {
+	succeeded   int
+	failed      int
+	skipped     int
+	totalCreate int
+	totalSkip   int
+}
+
+func provisionAllTenants(ctx context.Context, provisioner *provisioning.Provisioner, ts *provisioning.TemplateSet, logger *slog.Logger) error {
+	tenants, err := fetchActiveTenants(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(tenants) == 0 {
+		fmt.Println("No active tenants found.")
+		return nil
+	}
+
+	fmt.Printf("Found %d active tenants\n", len(tenants))
+	fmt.Printf("Using template set: %s (%d accounts)\n", ts.Name, len(ts.Templates))
+
+	if dryRun {
+		printDryRunSummary(tenants, ts)
+		return nil
+	}
+
+	stats := &provisionStats{}
+	for i, t := range tenants {
+		if err := provisionOneTenant(ctx, provisioner, ts, t, i+1, len(tenants), logger, stats); err != nil {
+			return err
+		}
+	}
+
+	printFinalSummary(stats)
+	if stats.failed > 0 {
+		return fmt.Errorf("%w: %d failed", ErrTenantsFailedProvisioning, stats.failed)
+	}
+	return nil
+}
+
+func fetchActiveTenants(ctx context.Context) ([]*pb.Tenant, error) {
+	tenantClient, err := client.NewTenantClient(ctx, client.Config{
+		ServiceURL: tenantServiceURL,
+		Timeout:    timeout,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tenant client: %w", err)
+	}
+	defer func() { _ = tenantClient.Close() }()
+
+	fmt.Println("Fetching active tenants...")
+	resp, err := tenantClient.ListTenants(ctx, &pb.ListTenantsRequest{
+		StatusFilter: pb.TenantStatus_TENANT_STATUS_ACTIVE,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tenants: %w", err)
+	}
+	return resp.Tenants, nil
+}
+
+func printDryRunSummary(tenants []*pb.Tenant, ts *provisioning.TemplateSet) {
+	fmt.Println("\nDry run: Would provision accounts for:")
+	for _, t := range tenants {
+		fmt.Printf("  - %s (%s)\n", t.TenantId, t.DisplayName)
+	}
+	fmt.Printf("\nEach tenant would receive %d accounts from '%s' template set.\n", len(ts.Templates), ts.Name)
+}
+
+func printFinalSummary(stats *provisionStats) {
+	fmt.Printf("\n=== Summary ===\n")
+	fmt.Printf("Tenants: succeeded=%d, failed=%d, skipped=%d\n", stats.succeeded, stats.failed, stats.skipped)
+	fmt.Printf("Accounts: created=%d, skipped=%d\n", stats.totalCreate, stats.totalSkip)
+}
+
+func provisionOneTenant(
+	ctx context.Context,
+	provisioner *provisioning.Provisioner,
+	ts *provisioning.TemplateSet,
+	t *pb.Tenant,
+	index, total int,
+	logger *slog.Logger,
+	stats *provisionStats,
+) error {
+	tenantID, err := tenant.NewTenantID(t.TenantId)
+	if err != nil {
+		logger.Warn("invalid tenant ID, skipping", "tenant_id", t.TenantId, "error", err)
+		stats.skipped++
+		return nil
+	}
+
+	fmt.Printf("\n[%d/%d] Provisioning tenant %s (%s)...\n", index, total, tenantID, t.DisplayName)
+
+	opCtx, cancel := context.WithTimeout(ctx, provisioningTimeout)
+	result, err := provisioner.ProvisionFromTemplates(opCtx, tenantID, ts.Templates)
+	cancel()
+
+	if err != nil {
+		logger.Error("provisioning failed", "tenant_id", tenantID, "error", err)
+		stats.failed++
+		if !continueOnError {
+			return fmt.Errorf("provisioning failed for %s: %w", tenantID, err)
+		}
+		return nil
+	}
+
+	fmt.Printf("  Created: %d, Skipped: %d, Failed: %d\n", result.Created, result.Skipped, result.Failed)
+
+	if result.Failed > 0 {
+		stats.failed++
+		if !continueOnError {
+			return fmt.Errorf("%w for %s: %d accounts", ErrAccountsFailedToProvision, tenantID, result.Failed)
+		}
+	} else {
+		stats.succeeded++
+	}
+
+	stats.totalCreate += result.Created
+	stats.totalSkip += result.Skipped
+	return nil
+}

--- a/cmd/ibactl/cmd/root.go
+++ b/cmd/ibactl/cmd/root.go
@@ -1,0 +1,71 @@
+// Package cmd implements the ibactl CLI commands for Internal Bank Account management.
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/meridianhub/meridian/services/internal-bank-account/client"
+	"github.com/meridianhub/meridian/shared/platform/ports"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// serviceURL is the internal bank account service URL.
+	serviceURL string
+	// timeout is the gRPC call timeout.
+	timeout time.Duration
+)
+
+// rootCmd represents the base command when called without any subcommands.
+var rootCmd = &cobra.Command{
+	Use:   "ibactl",
+	Short: "Internal Bank Account management CLI",
+	Long: `ibactl is a command-line tool for managing internal bank accounts in Meridian.
+
+It provides commands to provision default accounts, list accounts, and manage
+internal bank account lifecycle. Internal bank accounts include clearing, nostro,
+vostro, holding, suspense, revenue, expense, and inventory accounts.
+
+Examples:
+  # Provision default accounts for a tenant
+  ibactl provision-defaults acme_bank
+
+  # Provision default accounts for all active tenants
+  ibactl provision-defaults --all
+
+  # List internal bank accounts for a tenant
+  ibactl list --tenant=acme_bank`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVar(&serviceURL, "service-url",
+		getEnvOrDefault("IBA_SERVICE_URL", fmt.Sprintf("localhost:%d", ports.InternalBankAccount)),
+		"Internal Bank Account service URL")
+	rootCmd.PersistentFlags().DurationVar(&timeout, "timeout", 30*time.Second, "gRPC call timeout")
+}
+
+// getEnvOrDefault returns the environment variable value or a default.
+func getEnvOrDefault(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+// newClient creates a new InternalBankAccount client using global flags.
+func newClient() (*client.Client, func(), error) {
+	cfg := client.Config{
+		Target:  serviceURL,
+		Timeout: timeout,
+	}
+	return client.New(cfg)
+}

--- a/cmd/ibactl/main.go
+++ b/cmd/ibactl/main.go
@@ -1,0 +1,15 @@
+// ibactl is a CLI tool for managing Internal Bank Accounts in Meridian.
+//
+// Usage:
+//
+//	ibactl provision-defaults <tenant-id>  # Provision default accounts for a tenant
+//	ibactl provision-defaults --all        # Provision for all active tenants
+//
+// See ibactl --help for full usage.
+package main
+
+import "github.com/meridianhub/meridian/cmd/ibactl/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/services/internal-bank-account/provisioning/default_accounts.go
+++ b/services/internal-bank-account/provisioning/default_accounts.go
@@ -1,0 +1,297 @@
+// Package provisioning handles the automated creation of default internal bank accounts
+// when new tenants are provisioned. This ensures each tenant has the essential accounts
+// needed for standard banking operations (clearing, revenue, expense, suspense).
+package provisioning
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// AccountTemplate defines a default account to be created during tenant provisioning.
+// Templates specify the account properties needed to call InitiateInternalBankAccount.
+type AccountTemplate struct {
+	// Code is the unique business identifier for the account (e.g., "CLR-GBP-DEPOSIT").
+	Code string
+
+	// Name is the human-readable display name (e.g., "GBP Deposit Clearing").
+	Name string
+
+	// Type is the account type (CLEARING, REVENUE, EXPENSE, SUSPENSE, etc.).
+	Type pb.InternalAccountType
+
+	// InstrumentCode references the instrument from Reference Data (e.g., "GBP", "USD").
+	InstrumentCode string
+
+	// Dimension describes the unit dimension (CURRENCY, ENERGY, COMPUTE, etc.).
+	Dimension string
+
+	// Description provides additional context about the account's purpose.
+	Description string
+}
+
+// Dimension constants matching the database constraint.
+const (
+	DimensionCurrency = "CURRENCY"
+	DimensionEnergy   = "ENERGY"
+	DimensionMass     = "MASS"
+	DimensionVolume   = "VOLUME"
+	DimensionTime     = "TIME"
+	DimensionCompute  = "COMPUTE"
+	DimensionCarbon   = "CARBON"
+	DimensionData     = "DATA"
+	DimensionCount    = "COUNT"
+)
+
+// DefaultAccounts defines the standard accounts created for every new tenant.
+// These accounts support core banking operations:
+// - Clearing accounts for deposit/withdrawal settlement across major currencies
+// - Revenue accounts for tracking fee income
+// - Expense accounts for operational costs
+// - Suspense account for unidentified transactions
+var DefaultAccounts = []AccountTemplate{
+	// GBP Clearing Accounts
+	{
+		Code:           "CLR-GBP-DEPOSIT",
+		Name:           "GBP Deposit Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Clearing account for GBP deposits pending settlement",
+	},
+	{
+		Code:           "CLR-GBP-WITHDRAW",
+		Name:           "GBP Withdrawal Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Clearing account for GBP withdrawals pending settlement",
+	},
+
+	// USD Clearing Accounts
+	{
+		Code:           "CLR-USD-DEPOSIT",
+		Name:           "USD Deposit Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+		Dimension:      DimensionCurrency,
+		Description:    "Clearing account for USD deposits pending settlement",
+	},
+	{
+		Code:           "CLR-USD-WITHDRAW",
+		Name:           "USD Withdrawal Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+		Dimension:      DimensionCurrency,
+		Description:    "Clearing account for USD withdrawals pending settlement",
+	},
+
+	// EUR Clearing Accounts
+	{
+		Code:           "CLR-EUR-DEPOSIT",
+		Name:           "EUR Deposit Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "EUR",
+		Dimension:      DimensionCurrency,
+		Description:    "Clearing account for EUR deposits pending settlement",
+	},
+	{
+		Code:           "CLR-EUR-WITHDRAW",
+		Name:           "EUR Withdrawal Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "EUR",
+		Dimension:      DimensionCurrency,
+		Description:    "Clearing account for EUR withdrawals pending settlement",
+	},
+
+	// Revenue Accounts
+	{
+		Code:           "REV-TRANSACTION-FEE",
+		Name:           "Transaction Fee Revenue",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Revenue account for transaction processing fees",
+	},
+	{
+		Code:           "REV-OVERDRAFT-INTEREST",
+		Name:           "Overdraft Interest Revenue",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Revenue account for overdraft interest charges",
+	},
+	{
+		Code:           "REV-ACCOUNT-FEE",
+		Name:           "Account Maintenance Fee Revenue",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Revenue account for account maintenance fees",
+	},
+
+	// Expense Accounts
+	{
+		Code:           "EXP-PAYMENT-PROCESSING",
+		Name:           "Payment Processing Expense",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_EXPENSE,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Expense account for payment processing costs",
+	},
+
+	// Suspense Account
+	{
+		Code:           "SUS-GENERAL",
+		Name:           "General Suspense Account",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_SUSPENSE,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Suspense account for unidentified or pending transactions",
+	},
+}
+
+// InternalBankAccountService defines the interface for creating internal bank accounts.
+// This abstraction allows the provisioner to work with both the gRPC service and test mocks.
+type InternalBankAccountService interface {
+	InitiateInternalBankAccount(ctx context.Context, req *pb.InitiateInternalBankAccountRequest) (*pb.InitiateInternalBankAccountResponse, error)
+}
+
+// Sentinel errors for provisioning operations.
+var (
+	// ErrServiceNotConfigured is returned when the internal bank account service is not set.
+	ErrServiceNotConfigured = errors.New("internal bank account service not configured")
+)
+
+// Result contains the outcome of provisioning default accounts.
+type Result struct {
+	// TenantID is the tenant that was provisioned.
+	TenantID tenant.TenantID
+
+	// Created is the number of accounts successfully created.
+	Created int
+
+	// Skipped is the number of accounts that already existed (idempotent).
+	Skipped int
+
+	// Failed is the number of accounts that failed to create.
+	Failed int
+
+	// Errors contains any errors encountered during provisioning.
+	Errors []error
+}
+
+// Provisioner creates default internal bank accounts for tenants.
+type Provisioner struct {
+	service InternalBankAccountService
+	logger  *slog.Logger
+}
+
+// NewProvisioner creates a new Provisioner with the given service.
+func NewProvisioner(service InternalBankAccountService, logger *slog.Logger) *Provisioner {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Provisioner{
+		service: service,
+		logger:  logger,
+	}
+}
+
+// ProvisionDefaultAccounts creates all default accounts for a tenant.
+// This operation is idempotent - existing accounts are skipped without error.
+//
+// The idempotency key format is: "default-account:{tenantID}:{accountCode}"
+// This ensures the same account cannot be created twice for the same tenant.
+func (p *Provisioner) ProvisionDefaultAccounts(ctx context.Context, tenantID tenant.TenantID) (*Result, error) {
+	return p.ProvisionFromTemplates(ctx, tenantID, DefaultAccounts)
+}
+
+// ProvisionFromTemplates creates accounts from a custom template list.
+// Use this for tenant-specific account configurations (e.g., energy companies).
+func (p *Provisioner) ProvisionFromTemplates(ctx context.Context, tenantID tenant.TenantID, templates []AccountTemplate) (*Result, error) {
+	if p.service == nil {
+		return nil, ErrServiceNotConfigured
+	}
+
+	result := &Result{
+		TenantID: tenantID,
+		Errors:   make([]error, 0),
+	}
+
+	p.logger.Info("starting default account provisioning",
+		"tenant_id", tenantID,
+		"template_count", len(templates))
+
+	for _, template := range templates {
+		// Build idempotency key scoped to tenant and account code
+		idempotencyKey := fmt.Sprintf("default-account:%s:%s", tenantID, template.Code)
+
+		req := &pb.InitiateInternalBankAccountRequest{
+			AccountCode:    template.Code,
+			Name:           template.Name,
+			AccountType:    template.Type,
+			InstrumentCode: template.InstrumentCode,
+			Description:    template.Description,
+			IdempotencyKey: &commonpb.IdempotencyKey{
+				Key: idempotencyKey,
+			},
+		}
+
+		_, err := p.service.InitiateInternalBankAccount(ctx, req)
+		if err != nil {
+			// Check if account already exists (idempotent case)
+			if isDuplicateError(err) {
+				p.logger.Debug("account already exists, skipping",
+					"tenant_id", tenantID,
+					"account_code", template.Code)
+				result.Skipped++
+				continue
+			}
+
+			// Record error but continue with other accounts
+			p.logger.Warn("failed to create default account",
+				"tenant_id", tenantID,
+				"account_code", template.Code,
+				"error", err)
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Errorf("failed to create %s: %w", template.Code, err))
+			continue
+		}
+
+		p.logger.Debug("created default account",
+			"tenant_id", tenantID,
+			"account_code", template.Code,
+			"account_type", template.Type.String())
+		result.Created++
+	}
+
+	p.logger.Info("completed default account provisioning",
+		"tenant_id", tenantID,
+		"created", result.Created,
+		"skipped", result.Skipped,
+		"failed", result.Failed)
+
+	return result, nil
+}
+
+// isDuplicateError checks if the error indicates the account already exists.
+// This handles the idempotent case where we can safely skip.
+func isDuplicateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		return false
+	}
+	return st.Code() == codes.AlreadyExists
+}

--- a/services/internal-bank-account/provisioning/default_accounts_test.go
+++ b/services/internal-bank-account/provisioning/default_accounts_test.go
@@ -1,0 +1,304 @@
+package provisioning
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Test sentinel errors for simulating failures.
+var (
+	errDatabaseUnavailable = errors.New("database unavailable")
+	errTimeout             = errors.New("timeout")
+	errSomeError           = errors.New("some error")
+)
+
+// mockService implements InternalBankAccountService for testing.
+type mockService struct {
+	// createdAccounts tracks all InitiateInternalBankAccount calls
+	createdAccounts []*pb.InitiateInternalBankAccountRequest
+
+	// existingCodes simulates accounts that already exist
+	existingCodes map[string]bool
+
+	// failOnCodes simulates failures for specific account codes
+	failOnCodes map[string]error
+}
+
+func newMockService() *mockService {
+	return &mockService{
+		createdAccounts: make([]*pb.InitiateInternalBankAccountRequest, 0),
+		existingCodes:   make(map[string]bool),
+		failOnCodes:     make(map[string]error),
+	}
+}
+
+func (m *mockService) InitiateInternalBankAccount(_ context.Context, req *pb.InitiateInternalBankAccountRequest) (*pb.InitiateInternalBankAccountResponse, error) {
+	// Check for simulated failure
+	if err, ok := m.failOnCodes[req.AccountCode]; ok {
+		return nil, err
+	}
+
+	// Check if account already exists
+	if m.existingCodes[req.AccountCode] {
+		return nil, status.Error(codes.AlreadyExists, "account code already exists")
+	}
+
+	// Record the creation
+	m.createdAccounts = append(m.createdAccounts, req)
+	m.existingCodes[req.AccountCode] = true
+
+	return &pb.InitiateInternalBankAccountResponse{
+		AccountId: "IBA-test-" + req.AccountCode,
+		Facility: &pb.InternalBankAccountFacility{
+			AccountId:      "IBA-test-" + req.AccountCode,
+			AccountCode:    req.AccountCode,
+			Name:           req.Name,
+			AccountType:    req.AccountType,
+			AccountStatus:  pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE,
+			InstrumentCode: req.InstrumentCode,
+		},
+	}, nil
+}
+
+func TestAccountTemplate_Validation(t *testing.T) {
+	// Verify all templates have required fields
+	for i, template := range DefaultAccounts {
+		assert.NotEmpty(t, template.Code, "template %d: Code required", i)
+		assert.NotEmpty(t, template.Name, "template %d: Name required", i)
+		assert.NotEqual(t, pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_UNSPECIFIED, template.Type,
+			"template %d: Type must be specified", i)
+		assert.NotEmpty(t, template.InstrumentCode, "template %d: InstrumentCode required", i)
+		assert.NotEmpty(t, template.Dimension, "template %d: Dimension required", i)
+	}
+}
+
+func TestDefaultAccounts_Count(t *testing.T) {
+	// Verify expected number of default accounts
+	// 6 clearing + 3 revenue + 1 expense + 1 suspense = 11
+	assert.Equal(t, 11, len(DefaultAccounts), "expected 11 default accounts")
+}
+
+func TestDefaultAccounts_Uniqueness(t *testing.T) {
+	// Verify all account codes are unique
+	codes := make(map[string]bool)
+	for _, template := range DefaultAccounts {
+		if codes[template.Code] {
+			t.Errorf("duplicate account code: %s", template.Code)
+		}
+		codes[template.Code] = true
+	}
+}
+
+func TestDefaultAccounts_CoveringRequiredTypes(t *testing.T) {
+	// Track which clearing accounts we have
+	clearingAccounts := make(map[string]bool)
+
+	// Required clearing accounts
+	requiredClearing := []string{
+		"CLR-GBP-DEPOSIT", "CLR-GBP-WITHDRAW",
+		"CLR-USD-DEPOSIT", "CLR-USD-WITHDRAW",
+		"CLR-EUR-DEPOSIT", "CLR-EUR-WITHDRAW",
+	}
+
+	for _, template := range DefaultAccounts {
+		clearingAccounts[template.Code] = true
+	}
+
+	for _, required := range requiredClearing {
+		assert.True(t, clearingAccounts[required], "missing required clearing account: %s", required)
+	}
+}
+
+func TestDefaultAccounts_HasRequiredAccountTypes(t *testing.T) {
+	typeCount := make(map[pb.InternalAccountType]int)
+	for _, template := range DefaultAccounts {
+		typeCount[template.Type]++
+	}
+
+	// Verify we have at least one of each required type
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING], 0, "missing CLEARING accounts")
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE], 0, "missing REVENUE accounts")
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_EXPENSE], 0, "missing EXPENSE accounts")
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_SUSPENSE], 0, "missing SUSPENSE accounts")
+}
+
+func TestProvisionDefaultAccounts_NewTenant(t *testing.T) {
+	mock := newMockService()
+	provisioner := NewProvisioner(mock, nil)
+	tenantID := tenant.TenantID("org_test_bank")
+
+	result, err := provisioner.ProvisionDefaultAccounts(context.Background(), tenantID)
+
+	require.NoError(t, err)
+	assert.Equal(t, tenantID, result.TenantID)
+	assert.Equal(t, 11, result.Created, "should create all 11 accounts")
+	assert.Equal(t, 0, result.Skipped)
+	assert.Equal(t, 0, result.Failed)
+	assert.Empty(t, result.Errors)
+
+	// Verify all accounts were created with correct tenant-scoped idempotency keys
+	for _, created := range mock.createdAccounts {
+		assert.NotNil(t, created.IdempotencyKey)
+		assert.Contains(t, created.IdempotencyKey.Key, string(tenantID))
+		assert.Contains(t, created.IdempotencyKey.Key, created.AccountCode)
+	}
+}
+
+func TestProvisionDefaultAccounts_Idempotent(t *testing.T) {
+	mock := newMockService()
+	// Pre-populate some existing accounts
+	mock.existingCodes["CLR-GBP-DEPOSIT"] = true
+	mock.existingCodes["REV-TRANSACTION-FEE"] = true
+	mock.existingCodes["SUS-GENERAL"] = true
+
+	provisioner := NewProvisioner(mock, nil)
+	tenantID := tenant.TenantID("org_test_bank")
+
+	result, err := provisioner.ProvisionDefaultAccounts(context.Background(), tenantID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 8, result.Created, "should create 8 new accounts")
+	assert.Equal(t, 3, result.Skipped, "should skip 3 existing accounts")
+	assert.Equal(t, 0, result.Failed)
+	assert.Empty(t, result.Errors)
+}
+
+func TestProvisionDefaultAccounts_PartialFailure(t *testing.T) {
+	mock := newMockService()
+	// Simulate failure for specific accounts
+	mock.failOnCodes["REV-TRANSACTION-FEE"] = errDatabaseUnavailable
+	mock.failOnCodes["EXP-PAYMENT-PROCESSING"] = errTimeout
+
+	provisioner := NewProvisioner(mock, nil)
+	tenantID := tenant.TenantID("org_test_bank")
+
+	result, err := provisioner.ProvisionDefaultAccounts(context.Background(), tenantID)
+
+	// Provisioning continues despite failures
+	require.NoError(t, err)
+	assert.Equal(t, 9, result.Created, "should create 9 accounts")
+	assert.Equal(t, 0, result.Skipped)
+	assert.Equal(t, 2, result.Failed, "2 accounts should fail")
+	assert.Len(t, result.Errors, 2)
+}
+
+func TestProvisionDefaultAccounts_NilService(t *testing.T) {
+	provisioner := NewProvisioner(nil, nil)
+	tenantID := tenant.TenantID("org_test_bank")
+
+	result, err := provisioner.ProvisionDefaultAccounts(context.Background(), tenantID)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestProvisionFromTemplates_CustomTemplates(t *testing.T) {
+	mock := newMockService()
+	provisioner := NewProvisioner(mock, nil)
+	tenantID := tenant.TenantID("org_energy_company")
+
+	// Custom templates for energy company
+	energyTemplates := []AccountTemplate{
+		{
+			Code:           "CLR-KWH-DELIVERY",
+			Name:           "KWH Delivery Clearing",
+			Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+			InstrumentCode: "KWH",
+			Dimension:      DimensionEnergy,
+			Description:    "Clearing account for energy delivery",
+		},
+		{
+			Code:           "REV-ENERGY-SALES",
+			Name:           "Energy Sales Revenue",
+			Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE,
+			InstrumentCode: "GBP",
+			Dimension:      DimensionCurrency,
+			Description:    "Revenue from energy sales",
+		},
+	}
+
+	result, err := provisioner.ProvisionFromTemplates(context.Background(), tenantID, energyTemplates)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.Created)
+	assert.Equal(t, 0, result.Skipped)
+
+	// Verify the energy account was created
+	var foundEnergy bool
+	for _, created := range mock.createdAccounts {
+		if created.AccountCode == "CLR-KWH-DELIVERY" {
+			foundEnergy = true
+			assert.Equal(t, "KWH", created.InstrumentCode)
+		}
+	}
+	assert.True(t, foundEnergy, "energy clearing account should be created")
+}
+
+func TestIsDuplicateError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "AlreadyExists status",
+			err:      status.Error(codes.AlreadyExists, "account exists"),
+			expected: true,
+		},
+		{
+			name:     "NotFound status",
+			err:      status.Error(codes.NotFound, "not found"),
+			expected: false,
+		},
+		{
+			name:     "Internal status",
+			err:      status.Error(codes.Internal, "internal error"),
+			expected: false,
+		},
+		{
+			name:     "plain error",
+			err:      errSomeError,
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isDuplicateError(tc.err))
+		})
+	}
+}
+
+func TestDefaultAccounts_ValidDimensions(t *testing.T) {
+	// Verify all dimensions are valid per database constraint
+	validDimensions := map[string]bool{
+		DimensionCurrency: true,
+		DimensionEnergy:   true,
+		DimensionMass:     true,
+		DimensionVolume:   true,
+		DimensionTime:     true,
+		DimensionCompute:  true,
+		DimensionCarbon:   true,
+		DimensionData:     true,
+		DimensionCount:    true,
+	}
+
+	for _, template := range DefaultAccounts {
+		assert.True(t, validDimensions[template.Dimension],
+			"template %s has invalid dimension: %s", template.Code, template.Dimension)
+	}
+}

--- a/services/internal-bank-account/provisioning/hooks.go
+++ b/services/internal-bank-account/provisioning/hooks.go
@@ -1,0 +1,60 @@
+// Package provisioning provides hooks for integrating with tenant provisioning workflows.
+package provisioning
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// DefaultAccountHookTimeout is the maximum time allowed for default account provisioning.
+const DefaultAccountHookTimeout = 30 * time.Second
+
+// CreateDefaultAccountHook creates a post-provisioning hook function that provisions
+// default internal bank accounts for newly created tenants.
+//
+// Usage with the provisioning worker:
+//
+//	provisioner := provisioning.NewProvisioner(ibaService, logger)
+//	worker.RegisterPostProvisioningHook("default-internal-accounts",
+//	    provisioning.CreateDefaultAccountHook(provisioner, logger))
+//
+// The returned hook is:
+// - Non-blocking: Errors are returned but the worker will continue
+// - Idempotent: Safe to call multiple times for the same tenant
+// - Timeout-protected: Uses DefaultAccountHookTimeout (30 seconds)
+func CreateDefaultAccountHook(provisioner *Provisioner, logger *slog.Logger) func(ctx context.Context, tenantID tenant.TenantID) error {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return func(ctx context.Context, tenantID tenant.TenantID) error {
+		// Apply timeout to prevent hanging
+		ctx, cancel := context.WithTimeout(ctx, DefaultAccountHookTimeout)
+		defer cancel()
+
+		logger.Info("provisioning default internal accounts",
+			"tenant_id", tenantID)
+
+		result, err := provisioner.ProvisionDefaultAccounts(ctx, tenantID)
+		if err != nil {
+			return err
+		}
+
+		// Log summary
+		logger.Info("default internal accounts provisioned",
+			"tenant_id", tenantID,
+			"created", result.Created,
+			"skipped", result.Skipped,
+			"failed", result.Failed)
+
+		// Return first error if any accounts failed (for logging by the worker)
+		if len(result.Errors) > 0 {
+			return result.Errors[0]
+		}
+
+		return nil
+	}
+}

--- a/services/internal-bank-account/provisioning/hooks_test.go
+++ b/services/internal-bank-account/provisioning/hooks_test.go
@@ -1,0 +1,101 @@
+package provisioning
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test sentinel error for simulated failures.
+var errSimulatedFailure = errors.New("simulated failure")
+
+func TestCreateDefaultAccountHook_Success(t *testing.T) {
+	mock := newMockService()
+	provisioner := NewProvisioner(mock, nil)
+	tenantID := tenant.TenantID("org_test_bank")
+
+	hook := CreateDefaultAccountHook(provisioner, nil)
+
+	err := hook(context.Background(), tenantID)
+
+	require.NoError(t, err)
+	assert.Equal(t, 11, len(mock.createdAccounts), "should create all default accounts")
+}
+
+func TestCreateDefaultAccountHook_Idempotent(t *testing.T) {
+	mock := newMockService()
+	provisioner := NewProvisioner(mock, nil)
+	tenantID := tenant.TenantID("org_test_bank")
+
+	hook := CreateDefaultAccountHook(provisioner, nil)
+
+	// First call creates accounts
+	err := hook(context.Background(), tenantID)
+	require.NoError(t, err)
+	assert.Equal(t, 11, len(mock.createdAccounts))
+
+	// Second call skips existing accounts
+	err = hook(context.Background(), tenantID)
+	require.NoError(t, err)
+	// Should still be 11 since duplicates are skipped
+	assert.Equal(t, 11, len(mock.createdAccounts))
+}
+
+func TestCreateDefaultAccountHook_PartialFailure(t *testing.T) {
+	mock := newMockService()
+	// Simulate failure for one account
+	mock.failOnCodes["REV-TRANSACTION-FEE"] = errSimulatedFailure
+
+	provisioner := NewProvisioner(mock, nil)
+	tenantID := tenant.TenantID("org_test_bank")
+
+	hook := CreateDefaultAccountHook(provisioner, nil)
+
+	err := hook(context.Background(), tenantID)
+
+	// Hook returns error on partial failure (logged by worker but non-blocking)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "REV-TRANSACTION-FEE")
+}
+
+func TestCreateDefaultAccountHook_ContextCancellation(t *testing.T) {
+	mock := &slowMockService{
+		delay: DefaultAccountHookTimeout * 2, // Longer than timeout
+	}
+	provisioner := NewProvisioner(mock, nil)
+	tenantID := tenant.TenantID("org_test_bank")
+
+	hook := CreateDefaultAccountHook(provisioner, nil)
+
+	// Hook has internal timeout of 30 seconds - use shorter test timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	err := hook(ctx, tenantID)
+
+	// Should return error due to timeout
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+}
+
+// slowMockService simulates a slow service for timeout testing.
+type slowMockService struct {
+	delay time.Duration
+}
+
+func (m *slowMockService) InitiateInternalBankAccount(ctx context.Context, req *pb.InitiateInternalBankAccountRequest) (*pb.InitiateInternalBankAccountResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-time.After(m.delay):
+		return &pb.InitiateInternalBankAccountResponse{
+			AccountId: "IBA-test-" + req.AccountCode,
+		}, nil
+	}
+}

--- a/services/internal-bank-account/provisioning/templates.go
+++ b/services/internal-bank-account/provisioning/templates.go
@@ -1,0 +1,268 @@
+// Package provisioning provides tenant-specific account template customization.
+package provisioning
+
+import (
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+)
+
+// TemplateSet defines a named collection of account templates.
+// Different tenant types (banks, energy companies, etc.) can use different template sets.
+type TemplateSet struct {
+	// Name identifies the template set (e.g., "default", "energy", "compute").
+	Name string
+
+	// Description explains what the template set is for.
+	Description string
+
+	// Templates is the list of account templates in this set.
+	Templates []AccountTemplate
+}
+
+// BuiltInTemplateSets provides predefined template sets for common tenant types.
+var BuiltInTemplateSets = map[string]TemplateSet{
+	"default": {
+		Name:        "default",
+		Description: "Standard banking accounts (clearing, revenue, expense, suspense)",
+		Templates:   DefaultAccounts,
+	},
+	"energy": {
+		Name:        "energy",
+		Description: "Accounts for energy trading and settlement",
+		Templates:   EnergyAccounts,
+	},
+	"compute": {
+		Name:        "compute",
+		Description: "Accounts for compute resource billing",
+		Templates:   ComputeAccounts,
+	},
+	"minimal": {
+		Name:        "minimal",
+		Description: "Minimal set of accounts (suspense only)",
+		Templates:   MinimalAccounts,
+	},
+}
+
+// EnergyAccounts provides templates for energy trading companies.
+// Includes energy-specific clearing accounts in addition to standard financial accounts.
+var EnergyAccounts = []AccountTemplate{
+	// Standard currency clearing accounts
+	{
+		Code:           "CLR-GBP-DEPOSIT",
+		Name:           "GBP Deposit Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Clearing account for GBP deposits pending settlement",
+	},
+	{
+		Code:           "CLR-GBP-WITHDRAW",
+		Name:           "GBP Withdrawal Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Clearing account for GBP withdrawals pending settlement",
+	},
+
+	// Energy clearing accounts
+	{
+		Code:           "CLR-KWH-DELIVERY",
+		Name:           "KWH Delivery Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "KWH",
+		Dimension:      DimensionEnergy,
+		Description:    "Clearing account for energy delivery pending settlement",
+	},
+	{
+		Code:           "CLR-KWH-RECEIPT",
+		Name:           "KWH Receipt Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "KWH",
+		Dimension:      DimensionEnergy,
+		Description:    "Clearing account for energy receipt pending settlement",
+	},
+
+	// Energy inventory account
+	{
+		Code:           "INV-KWH-WHOLESALE",
+		Name:           "Wholesale Energy Inventory",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_INVENTORY,
+		InstrumentCode: "KWH",
+		Dimension:      DimensionEnergy,
+		Description:    "Inventory account for wholesale energy holdings",
+	},
+
+	// Revenue accounts
+	{
+		Code:           "REV-ENERGY-SALES",
+		Name:           "Energy Sales Revenue",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Revenue from energy sales",
+	},
+	{
+		Code:           "REV-GRID-FEE",
+		Name:           "Grid Access Fee Revenue",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Revenue from grid access fees",
+	},
+
+	// Expense accounts
+	{
+		Code:           "EXP-GRID-CONNECTION",
+		Name:           "Grid Connection Expense",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_EXPENSE,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Expense for grid connection costs",
+	},
+	{
+		Code:           "EXP-ENERGY-PROCUREMENT",
+		Name:           "Energy Procurement Expense",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_EXPENSE,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Expense for energy procurement",
+	},
+
+	// Suspense
+	{
+		Code:           "SUS-ENERGY-GENERAL",
+		Name:           "Energy General Suspense",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_SUSPENSE,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Suspense account for unidentified energy-related transactions",
+	},
+}
+
+// ComputeAccounts provides templates for compute resource billing (AI/cloud).
+// Includes compute-specific accounts for GPU hours, data transfer, etc.
+var ComputeAccounts = []AccountTemplate{
+	// Standard currency clearing
+	{
+		Code:           "CLR-USD-DEPOSIT",
+		Name:           "USD Deposit Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+		Dimension:      DimensionCurrency,
+		Description:    "Clearing account for USD deposits",
+	},
+	{
+		Code:           "CLR-USD-WITHDRAW",
+		Name:           "USD Withdrawal Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "USD",
+		Dimension:      DimensionCurrency,
+		Description:    "Clearing account for USD withdrawals",
+	},
+
+	// Compute clearing accounts
+	{
+		Code:           "CLR-GPU-HOUR-DELIVERY",
+		Name:           "GPU Hour Delivery Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "GPU-HOUR",
+		Dimension:      DimensionCompute,
+		Description:    "Clearing account for GPU hour delivery",
+	},
+	{
+		Code:           "CLR-CPU-HOUR-DELIVERY",
+		Name:           "CPU Hour Delivery Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "CPU-HOUR",
+		Dimension:      DimensionCompute,
+		Description:    "Clearing account for CPU hour delivery",
+	},
+
+	// Data transfer clearing
+	{
+		Code:           "CLR-DATA-EGRESS",
+		Name:           "Data Egress Clearing",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCode: "GB-DATA",
+		Dimension:      DimensionData,
+		Description:    "Clearing account for data egress",
+	},
+
+	// Inventory
+	{
+		Code:           "INV-GPU-CAPACITY",
+		Name:           "GPU Capacity Inventory",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_INVENTORY,
+		InstrumentCode: "GPU-HOUR",
+		Dimension:      DimensionCompute,
+		Description:    "Inventory of available GPU compute hours",
+	},
+
+	// Revenue accounts
+	{
+		Code:           "REV-COMPUTE-BILLING",
+		Name:           "Compute Billing Revenue",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE,
+		InstrumentCode: "USD",
+		Dimension:      DimensionCurrency,
+		Description:    "Revenue from compute resource billing",
+	},
+	{
+		Code:           "REV-DATA-TRANSFER",
+		Name:           "Data Transfer Revenue",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE,
+		InstrumentCode: "USD",
+		Dimension:      DimensionCurrency,
+		Description:    "Revenue from data transfer fees",
+	},
+
+	// Expense
+	{
+		Code:           "EXP-INFRASTRUCTURE",
+		Name:           "Infrastructure Expense",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_EXPENSE,
+		InstrumentCode: "USD",
+		Dimension:      DimensionCurrency,
+		Description:    "Expense for infrastructure costs",
+	},
+
+	// Suspense
+	{
+		Code:           "SUS-COMPUTE-GENERAL",
+		Name:           "Compute General Suspense",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_SUSPENSE,
+		InstrumentCode: "USD",
+		Dimension:      DimensionCurrency,
+		Description:    "Suspense account for unidentified compute transactions",
+	},
+}
+
+// MinimalAccounts provides the minimum viable set of accounts.
+// Useful for tenants that want to configure accounts manually.
+var MinimalAccounts = []AccountTemplate{
+	{
+		Code:           "SUS-GENERAL",
+		Name:           "General Suspense Account",
+		Type:           pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_SUSPENSE,
+		InstrumentCode: "GBP",
+		Dimension:      DimensionCurrency,
+		Description:    "Suspense account for unidentified transactions",
+	},
+}
+
+// GetTemplateSet returns a template set by name.
+// Returns nil if the template set is not found.
+func GetTemplateSet(name string) *TemplateSet {
+	if ts, ok := BuiltInTemplateSets[name]; ok {
+		return &ts
+	}
+	return nil
+}
+
+// ListTemplateSets returns the names of all available template sets.
+func ListTemplateSets() []string {
+	names := make([]string, 0, len(BuiltInTemplateSets))
+	for name := range BuiltInTemplateSets {
+		names = append(names, name)
+	}
+	return names
+}

--- a/services/internal-bank-account/provisioning/templates_test.go
+++ b/services/internal-bank-account/provisioning/templates_test.go
@@ -1,0 +1,154 @@
+package provisioning
+
+import (
+	"testing"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuiltInTemplateSets_Exist(t *testing.T) {
+	// Verify expected template sets exist
+	expectedSets := []string{"default", "energy", "compute", "minimal"}
+
+	for _, name := range expectedSets {
+		ts := GetTemplateSet(name)
+		require.NotNil(t, ts, "template set %s should exist", name)
+		assert.Equal(t, name, ts.Name)
+		assert.NotEmpty(t, ts.Description)
+		assert.NotEmpty(t, ts.Templates)
+	}
+}
+
+func TestGetTemplateSet_Unknown(t *testing.T) {
+	ts := GetTemplateSet("nonexistent")
+	assert.Nil(t, ts)
+}
+
+func TestListTemplateSets(t *testing.T) {
+	names := ListTemplateSets()
+	assert.GreaterOrEqual(t, len(names), 4)
+	assert.Contains(t, names, "default")
+	assert.Contains(t, names, "energy")
+	assert.Contains(t, names, "compute")
+	assert.Contains(t, names, "minimal")
+}
+
+func TestEnergyAccounts_HasRequiredTypes(t *testing.T) {
+	typeCount := make(map[pb.InternalAccountType]int)
+	for _, template := range EnergyAccounts {
+		typeCount[template.Type]++
+	}
+
+	// Energy should have:
+	// - Clearing accounts (currency + energy)
+	// - At least one inventory account
+	// - Revenue accounts
+	// - Expense accounts
+	// - Suspense account
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING], 0, "should have CLEARING accounts")
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_INVENTORY], 0, "should have INVENTORY accounts")
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE], 0, "should have REVENUE accounts")
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_EXPENSE], 0, "should have EXPENSE accounts")
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_SUSPENSE], 0, "should have SUSPENSE accounts")
+}
+
+func TestEnergyAccounts_HasEnergyInstruments(t *testing.T) {
+	var hasKWH bool
+	for _, template := range EnergyAccounts {
+		if template.InstrumentCode == "KWH" {
+			hasKWH = true
+			assert.Equal(t, DimensionEnergy, template.Dimension, "KWH should have ENERGY dimension")
+		}
+	}
+	assert.True(t, hasKWH, "energy accounts should include KWH instruments")
+}
+
+func TestComputeAccounts_HasRequiredTypes(t *testing.T) {
+	typeCount := make(map[pb.InternalAccountType]int)
+	for _, template := range ComputeAccounts {
+		typeCount[template.Type]++
+	}
+
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING], 0, "should have CLEARING accounts")
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_INVENTORY], 0, "should have INVENTORY accounts")
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_REVENUE], 0, "should have REVENUE accounts")
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_EXPENSE], 0, "should have EXPENSE accounts")
+	assert.Greater(t, typeCount[pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_SUSPENSE], 0, "should have SUSPENSE accounts")
+}
+
+func TestComputeAccounts_HasComputeInstruments(t *testing.T) {
+	var hasGPU, hasCPU, hasData bool
+	for _, template := range ComputeAccounts {
+		switch template.InstrumentCode {
+		case "GPU-HOUR":
+			hasGPU = true
+			assert.Equal(t, DimensionCompute, template.Dimension, "GPU-HOUR should have COMPUTE dimension")
+		case "CPU-HOUR":
+			hasCPU = true
+			assert.Equal(t, DimensionCompute, template.Dimension, "CPU-HOUR should have COMPUTE dimension")
+		case "GB-DATA":
+			hasData = true
+			assert.Equal(t, DimensionData, template.Dimension, "GB-DATA should have DATA dimension")
+		}
+	}
+	assert.True(t, hasGPU, "compute accounts should include GPU-HOUR instruments")
+	assert.True(t, hasCPU, "compute accounts should include CPU-HOUR instruments")
+	assert.True(t, hasData, "compute accounts should include GB-DATA instruments")
+}
+
+func TestMinimalAccounts_HasOnlySuspense(t *testing.T) {
+	assert.Equal(t, 1, len(MinimalAccounts), "minimal should have only 1 account")
+	assert.Equal(t, pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_SUSPENSE, MinimalAccounts[0].Type)
+}
+
+func TestTemplateSet_UniqueCodes(t *testing.T) {
+	for name, ts := range BuiltInTemplateSets {
+		t.Run(name, func(t *testing.T) {
+			codes := make(map[string]bool)
+			for _, template := range ts.Templates {
+				if codes[template.Code] {
+					t.Errorf("duplicate account code in %s: %s", name, template.Code)
+				}
+				codes[template.Code] = true
+			}
+		})
+	}
+}
+
+func TestTemplateSet_ValidDimensions(t *testing.T) {
+	validDimensions := map[string]bool{
+		DimensionCurrency: true,
+		DimensionEnergy:   true,
+		DimensionMass:     true,
+		DimensionVolume:   true,
+		DimensionTime:     true,
+		DimensionCompute:  true,
+		DimensionCarbon:   true,
+		DimensionData:     true,
+		DimensionCount:    true,
+	}
+
+	for name, ts := range BuiltInTemplateSets {
+		t.Run(name, func(t *testing.T) {
+			for _, template := range ts.Templates {
+				assert.True(t, validDimensions[template.Dimension],
+					"template %s in set %s has invalid dimension: %s",
+					template.Code, name, template.Dimension)
+			}
+		})
+	}
+}
+
+func TestTemplateSet_ValidAccountTypes(t *testing.T) {
+	for name, ts := range BuiltInTemplateSets {
+		t.Run(name, func(t *testing.T) {
+			for _, template := range ts.Templates {
+				assert.NotEqual(t, pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_UNSPECIFIED, template.Type,
+					"template %s in set %s has unspecified account type",
+					template.Code, name)
+			}
+		})
+	}
+}

--- a/services/tenant/worker/provisioning_worker.go
+++ b/services/tenant/worker/provisioning_worker.go
@@ -20,22 +20,35 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
+// PostProvisioningHook is called after schema provisioning succeeds but before
+// marking the tenant as active. Hooks are non-blocking - errors are logged but
+// do not prevent tenant activation. This allows for best-effort initialization
+// of tenant-specific resources (e.g., default internal bank accounts).
+type PostProvisioningHook func(ctx context.Context, tenantID tenant.TenantID) error
+
 // ProvisioningWorker polls for tenants in PROVISIONING_PENDING status
 // and triggers schema provisioning for them.
 type ProvisioningWorker struct {
-	repo           *persistence.Repository
-	provisioner    provisioner.SchemaProvisioner
-	alertManager   *AlertManager
-	pollInterval   time.Duration
-	alertInterval  time.Duration
-	alertThreshold time.Duration
-	maxRetries     int
-	retryBaseDelay time.Duration
-	retryMaxDelay  time.Duration
-	maxConcurrent  int
-	logger         *slog.Logger
-	done           chan struct{}
-	wg             sync.WaitGroup // Tracks in-flight provisioning goroutines
+	repo                  *persistence.Repository
+	provisioner           provisioner.SchemaProvisioner
+	alertManager          *AlertManager
+	postProvisioningHooks []namedHook
+	pollInterval          time.Duration
+	alertInterval         time.Duration
+	alertThreshold        time.Duration
+	maxRetries            int
+	retryBaseDelay        time.Duration
+	retryMaxDelay         time.Duration
+	maxConcurrent         int
+	logger                *slog.Logger
+	done                  chan struct{}
+	wg                    sync.WaitGroup // Tracks in-flight provisioning goroutines
+}
+
+// namedHook wraps a hook with its name for logging.
+type namedHook struct {
+	name string
+	hook PostProvisioningHook
 }
 
 // Errors returned by NewProvisioningWorker and provisioning operations.
@@ -177,6 +190,56 @@ func (w *ProvisioningWorker) Stop() {
 	w.logger.Info("waiting for in-flight provisioning to complete")
 	w.wg.Wait()
 	w.logger.Info("all provisioning goroutines completed")
+}
+
+// RegisterPostProvisioningHook adds a hook to be called after schema provisioning succeeds.
+// Hooks are executed in registration order and are non-blocking - errors are logged
+// but do not prevent tenant activation. Use this for best-effort initialization like
+// creating default internal bank accounts.
+//
+// The name parameter is used for logging to identify which hook succeeded or failed.
+func (w *ProvisioningWorker) RegisterPostProvisioningHook(name string, hook PostProvisioningHook) {
+	w.postProvisioningHooks = append(w.postProvisioningHooks, namedHook{
+		name: name,
+		hook: hook,
+	})
+	w.logger.Info("registered post-provisioning hook", "name", name)
+}
+
+// executePostProvisioningHooks runs all registered hooks sequentially.
+// Errors are logged but do not stop execution of subsequent hooks.
+// Returns the count of hooks that succeeded.
+func (w *ProvisioningWorker) executePostProvisioningHooks(ctx context.Context, tenantID tenant.TenantID) int {
+	if len(w.postProvisioningHooks) == 0 {
+		return 0
+	}
+
+	w.logger.Debug("executing post-provisioning hooks",
+		"tenant_id", tenantID,
+		"hook_count", len(w.postProvisioningHooks))
+
+	succeeded := 0
+	for _, nh := range w.postProvisioningHooks {
+		if err := nh.hook(ctx, tenantID); err != nil {
+			// Log error but continue - hooks are non-blocking
+			w.logger.Warn("post-provisioning hook failed",
+				"tenant_id", tenantID,
+				"hook_name", nh.name,
+				"error", err)
+		} else {
+			w.logger.Debug("post-provisioning hook succeeded",
+				"tenant_id", tenantID,
+				"hook_name", nh.name)
+			succeeded++
+		}
+	}
+
+	w.logger.Info("post-provisioning hooks completed",
+		"tenant_id", tenantID,
+		"succeeded", succeeded,
+		"total", len(w.postProvisioningHooks))
+
+	return succeeded
 }
 
 // checkFailedProvisioningAlerts checks for persistent provisioning failures
@@ -365,10 +428,18 @@ func (w *ProvisioningWorker) checkContextCancellation(ctx context.Context, tenan
 }
 
 // markTenantAsActive updates tenant status to active after successful provisioning.
+// Before marking as active, it executes any registered post-provisioning hooks
+// (e.g., creating default internal bank accounts). Hook failures are logged but
+// do not prevent tenant activation.
 func (w *ProvisioningWorker) markTenantAsActive(ctx context.Context, tenantID tenant.TenantID, attempt int) {
 	w.logger.Info("provisioning succeeded",
 		"tenant_id", tenantID,
 		"attempt", attempt)
+
+	// Execute post-provisioning hooks (non-blocking)
+	// These hooks can initialize tenant-specific resources like default internal bank accounts.
+	// Failures are logged but do not prevent tenant activation.
+	w.executePostProvisioningHooks(ctx, tenantID)
 
 	tenant, getErr := w.repo.GetByID(ctx, tenantID)
 	if getErr != nil {


### PR DESCRIPTION
## Summary

- Implement automatic provisioning of default internal bank accounts when new tenants are created
- Add `ibactl` CLI tool for provisioning existing tenants and managing account templates
- Support multiple template sets for different tenant types (banking, energy, compute)

## Changes Made

### New Provisioning Package (`services/internal-bank-account/provisioning/`)
- **`default_accounts.go`**: Core types (`AccountTemplate`, `Provisioner`, `Result`) and 11 default accounts (GBP/USD/EUR clearing, revenue, expense, suspense)
- **`templates.go`**: Multiple template sets:
  - `default`: Standard banking accounts
  - `energy`: Energy trading (includes KWH clearing, inventory)
  - `compute`: Cloud/AI billing (GPU-hour, CPU-hour, data transfer)
  - `minimal`: Only suspense account for manual configuration
- **`hooks.go`**: Factory function for post-provisioning hook integration

### Tenant Worker Integration (`services/tenant/worker/provisioning_worker.go`)
- Added `PostProvisioningHook` type for non-blocking, idempotent hooks
- Hooks execute after schema provisioning, before marking tenant active
- Hook failures are logged but don't block tenant activation

### CLI Tool (`cmd/ibactl/`)
- `ibactl provision-defaults <tenant-id>`: Provision accounts for a single tenant
- `ibactl provision-defaults --all`: Backfill all active tenants
- `--template-set`: Choose template set (default, energy, compute, minimal)
- `--dry-run`: Preview what would be created
- `--list-templates`: Show available template sets

## Technical Details

- **Idempotency**: Uses tenant-scoped idempotency keys (`default-account:{tenantID}:{accountCode}`)
- **Graceful failures**: AlreadyExists errors are treated as skipped (not failures)
- **Partial failure handling**: Continues provisioning remaining accounts if some fail

## Test Plan

- [x] Unit tests for Provisioner and all template sets
- [x] Unit tests for hook factory and timeout behavior
- [x] Tests for template uniqueness and valid dimensions
- [x] Verify dry-run mode works correctly
- [ ] Integration test with real IBA service
- [ ] Test CLI with `--all` against staging environment

## Task Master

internal-bank-account.12 - Automatic Creation of Default Internal Bank Accounts