### PR TITLE
feat(current-account): integrate Internal Bank Account for clearing account resolution

### DIFF
--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
 	"github.com/meridianhub/meridian/services/current-account/service"
 	finacctclient "github.com/meridianhub/meridian/services/financial-accounting/client"
+	internalbankaccountclient "github.com/meridianhub/meridian/services/internal-bank-account/client"
 	partyclient "github.com/meridianhub/meridian/services/party/client"
 	poskeepingclient "github.com/meridianhub/meridian/services/position-keeping/client"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
@@ -234,6 +235,8 @@ type serviceClients struct {
 	positionKeeping     service.PositionKeepingClient
 	financialAccounting service.FinancialAccountingClient
 	party               service.PartyClient
+	internalBankAccount service.InternalBankAccountClient
+	accountResolver     *service.AccountResolver
 	// Health clients bypass the circuit breaker for health checks
 	positionKeepingHealth     grpc_health_v1.HealthClient
 	financialAccountingHealth grpc_health_v1.HealthClient
@@ -343,6 +346,45 @@ func createServiceWithClients(
 	// Wrap the party client with CurrentAccount-specific methods (ValidateParty, GetParty)
 	partyClientWrapper := NewPartyClientWrapper(partyBaseClient)
 
+	// Create Internal Bank Account client for dynamic clearing account resolution.
+	// This is optional - if it fails, the service will fall back to static config.
+	var internalBankAccountClient *internalbankaccountclient.Client
+	var accountResolver *service.AccountResolver
+
+	ibaClient, ibaCleanup, err := internalbankaccountclient.New(internalbankaccountclient.Config{
+		ServiceName: internalbankaccountclient.ServiceName,
+		Namespace:   namespace,
+		Port:        ports.InternalBankAccount,
+		Timeout:     defaults.DefaultRPCTimeout,
+		Tracer:      tracer,
+		Resilience: &sharedclients.ResilientClientConfig{
+			Logger:             logger,
+			CircuitBreakerName: "internal-bank-account",
+			OnStateChange:      makeCircuitBreakerCallback(),
+		},
+	})
+	if err != nil {
+		logger.Warn("internal bank account client not available, clearing accounts will use static config",
+			"error", err)
+	} else {
+		internalBankAccountClient = ibaClient
+		cleanupFuncs = append(cleanupFuncs, ibaCleanup)
+
+		// Create AccountResolver with the client
+		accountResolver, err = service.NewAccountResolver(service.AccountResolverConfig{
+			Client:   internalBankAccountClient,
+			Logger:   logger,
+			CacheTTL: service.DefaultCacheTTL,
+		})
+		if err != nil {
+			logger.Warn("failed to create account resolver, clearing accounts will use static config",
+				"error", err)
+			accountResolver = nil
+		} else {
+			logger.Info("dynamic clearing account resolution enabled via Internal Bank Account service")
+		}
+	}
+
 	// Create service with the pre-created clients
 	// The new service-owned clients implement the same interfaces as defined in
 	// services/current-account/service/client_interfaces.go
@@ -357,6 +399,7 @@ func createServiceWithClients(
 		idempotencyService,
 		logger,
 		tracer,
+		accountResolver, // Optional: dynamic clearing account resolution
 	)
 	if err != nil {
 		// Cleanup all clients before returning
@@ -372,6 +415,8 @@ func createServiceWithClients(
 		positionKeeping:           posKeepingClient,
 		financialAccounting:       finAcctClient,
 		party:                     partyClientWrapper,
+		internalBankAccount:       internalBankAccountClient,
+		accountResolver:           accountResolver,
 		positionKeepingHealth:     grpc_health_v1.NewHealthClient(posKeepingClient.Conn()),
 		financialAccountingHealth: grpc_health_v1.NewHealthClient(finAcctClient.Conn()),
 		cleanupFuncs:              cleanupFuncs,

--- a/services/current-account/observability/metrics.go
+++ b/services/current-account/observability/metrics.go
@@ -115,6 +115,37 @@ var (
 		},
 		[]string{"service", "from_state", "to_state"},
 	)
+
+	// Clearing account resolver metrics
+	clearingAccountCacheHits = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "current_account_clearing_account_cache_hits_total",
+			Help: "Total number of clearing account cache hits",
+		},
+	)
+
+	clearingAccountCacheMisses = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "current_account_clearing_account_cache_misses_total",
+			Help: "Total number of clearing account cache misses",
+		},
+	)
+
+	clearingAccountLookupDuration = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "current_account_clearing_account_lookup_duration_seconds",
+			Help:    "Duration of clearing account lookups from Internal Bank Account service",
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+		},
+	)
+
+	clearingAccountLookupErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "current_account_clearing_account_lookup_errors_total",
+			Help: "Total number of clearing account lookup errors",
+		},
+		[]string{"clearing_type"},
+	)
 )
 
 // RecordOperationDuration records the duration of a current account operation
@@ -202,4 +233,24 @@ func RecordCircuitBreakerState(service string, state CircuitBreakerState) {
 // RecordCircuitBreakerStateChange records a circuit breaker state transition
 func RecordCircuitBreakerStateChange(service, fromState, toState string) {
 	circuitBreakerStateChanges.WithLabelValues(service, fromState, toState).Inc()
+}
+
+// RecordClearingAccountCacheHit records a cache hit for clearing account resolution
+func RecordClearingAccountCacheHit() {
+	clearingAccountCacheHits.Inc()
+}
+
+// RecordClearingAccountCacheMiss records a cache miss for clearing account resolution
+func RecordClearingAccountCacheMiss() {
+	clearingAccountCacheMisses.Inc()
+}
+
+// RecordClearingAccountLookupDuration records the duration of a clearing account lookup
+func RecordClearingAccountLookupDuration(duration time.Duration) {
+	clearingAccountLookupDuration.Observe(duration.Seconds())
+}
+
+// RecordClearingAccountLookupError records a clearing account lookup error
+func RecordClearingAccountLookupError(clearingType string) {
+	clearingAccountLookupErrors.WithLabelValues(clearingType).Inc()
 }

--- a/services/current-account/service/account_resolver.go
+++ b/services/current-account/service/account_resolver.go
@@ -1,0 +1,214 @@
+// Package service implements gRPC services for the current account domain
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
+)
+
+// AccountResolverErrors defines sentinel errors for the AccountResolver.
+var (
+	// ErrNoClearingAccountFound is returned when no active clearing account is found for the given criteria.
+	ErrNoClearingAccountFound = errors.New("no active clearing account found")
+
+	// ErrAccountResolverClientNil is returned when attempting to create an AccountResolver with a nil client.
+	ErrAccountResolverClientNil = errors.New("internal bank account client cannot be nil")
+
+	// ErrAccountResolverLoggerNil is returned when attempting to create an AccountResolver with a nil logger.
+	ErrAccountResolverLoggerNil = errors.New("logger cannot be nil")
+)
+
+// ClearingAccountType defines the type of clearing account being resolved.
+type ClearingAccountType string
+
+const (
+	// ClearingAccountTypeDeposit identifies the clearing account for deposit operations.
+	ClearingAccountTypeDeposit ClearingAccountType = "DEPOSIT"
+
+	// ClearingAccountTypeWithdrawal identifies the clearing account for withdrawal operations.
+	ClearingAccountTypeWithdrawal ClearingAccountType = "WITHDRAWAL"
+)
+
+// cacheEntry holds a cached account ID with its expiration time.
+type cacheEntry struct {
+	accountID string
+	expiresAt time.Time
+}
+
+// AccountResolver resolves clearing account IDs dynamically from the Internal Bank Account service.
+// It provides caching to reduce external service calls and supports both deposit and withdrawal
+// clearing account lookups.
+//
+// Thread-safe: All methods can be called concurrently from multiple goroutines.
+type AccountResolver struct {
+	client InternalBankAccountClient
+	logger *slog.Logger
+
+	// Cache configuration
+	cacheTTL time.Duration
+
+	// Thread-safe cache: key is "TYPE:INSTRUMENT" (e.g., "DEPOSIT:GBP")
+	mu    sync.RWMutex
+	cache map[string]cacheEntry
+}
+
+// AccountResolverConfig holds configuration for creating an AccountResolver.
+type AccountResolverConfig struct {
+	// Client is the Internal Bank Account gRPC client.
+	Client InternalBankAccountClient
+
+	// Logger is used for logging resolver operations.
+	Logger *slog.Logger
+
+	// CacheTTL is how long resolved account IDs are cached.
+	// Defaults to 5 minutes if not specified.
+	CacheTTL time.Duration
+}
+
+// DefaultCacheTTL is the default cache TTL for resolved account IDs.
+const DefaultCacheTTL = 5 * time.Minute
+
+// NewAccountResolver creates a new AccountResolver with the given configuration.
+// Returns an error if required configuration is missing.
+func NewAccountResolver(cfg AccountResolverConfig) (*AccountResolver, error) {
+	if cfg.Client == nil {
+		return nil, ErrAccountResolverClientNil
+	}
+	if cfg.Logger == nil {
+		return nil, ErrAccountResolverLoggerNil
+	}
+
+	ttl := cfg.CacheTTL
+	if ttl == 0 {
+		ttl = DefaultCacheTTL
+	}
+
+	return &AccountResolver{
+		client:   cfg.Client,
+		logger:   cfg.Logger,
+		cacheTTL: ttl,
+		cache:    make(map[string]cacheEntry),
+	}, nil
+}
+
+// GetDepositClearingAccount resolves the clearing account ID for deposit operations
+// for the given instrument (currency/asset code like "GBP", "USD", "KWH").
+//
+// It first checks the cache, and if not found or expired, queries the Internal Bank Account
+// service for an active CLEARING account matching the instrument.
+func (r *AccountResolver) GetDepositClearingAccount(ctx context.Context, instrumentCode string) (string, error) {
+	return r.resolveClearingAccount(ctx, ClearingAccountTypeDeposit, instrumentCode)
+}
+
+// GetWithdrawalClearingAccount resolves the clearing account ID for withdrawal operations
+// for the given instrument (currency/asset code like "GBP", "USD", "KWH").
+//
+// It first checks the cache, and if not found or expired, queries the Internal Bank Account
+// service for an active CLEARING account matching the instrument.
+func (r *AccountResolver) GetWithdrawalClearingAccount(ctx context.Context, instrumentCode string) (string, error) {
+	return r.resolveClearingAccount(ctx, ClearingAccountTypeWithdrawal, instrumentCode)
+}
+
+// resolveClearingAccount is the internal implementation for resolving clearing accounts.
+func (r *AccountResolver) resolveClearingAccount(ctx context.Context, clearingType ClearingAccountType, instrumentCode string) (string, error) {
+	cacheKey := r.cacheKey(clearingType, instrumentCode)
+
+	// Check cache first (read lock)
+	r.mu.RLock()
+	if entry, ok := r.cache[cacheKey]; ok && time.Now().Before(entry.expiresAt) {
+		r.mu.RUnlock()
+		r.logger.Debug("cache hit for clearing account",
+			"clearing_type", clearingType,
+			"instrument_code", instrumentCode,
+			"account_id", entry.accountID)
+		caobservability.RecordClearingAccountCacheHit()
+		return entry.accountID, nil
+	}
+	r.mu.RUnlock()
+
+	caobservability.RecordClearingAccountCacheMiss()
+
+	// Query the Internal Bank Account service
+	start := time.Now()
+	accountID, err := r.queryInternalBankAccount(ctx, clearingType, instrumentCode)
+	if err != nil {
+		caobservability.RecordClearingAccountLookupError(string(clearingType))
+		return "", err
+	}
+	caobservability.RecordClearingAccountLookupDuration(time.Since(start))
+
+	// Cache the result (write lock)
+	r.mu.Lock()
+	r.cache[cacheKey] = cacheEntry{
+		accountID: accountID,
+		expiresAt: time.Now().Add(r.cacheTTL),
+	}
+	r.mu.Unlock()
+
+	r.logger.Info("resolved clearing account",
+		"clearing_type", clearingType,
+		"instrument_code", instrumentCode,
+		"account_id", accountID,
+		"duration_ms", time.Since(start).Milliseconds())
+
+	return accountID, nil
+}
+
+// queryInternalBankAccount queries the Internal Bank Account service for a clearing account.
+func (r *AccountResolver) queryInternalBankAccount(ctx context.Context, clearingType ClearingAccountType, instrumentCode string) (string, error) {
+	resp, err := r.client.ListInternalBankAccounts(ctx, &internalbankaccountv1.ListInternalBankAccountsRequest{
+		AccountTypeFilter:    internalbankaccountv1.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCodeFilter: instrumentCode,
+		StatusFilter:         internalbankaccountv1.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE,
+	})
+	if err != nil {
+		r.logger.Error("failed to query internal bank accounts",
+			"clearing_type", clearingType,
+			"instrument_code", instrumentCode,
+			"error", err)
+		return "", fmt.Errorf("failed to query clearing account: %w", err)
+	}
+
+	if len(resp.Facilities) == 0 {
+		r.logger.Warn("no active clearing account found",
+			"clearing_type", clearingType,
+			"instrument_code", instrumentCode)
+		return "", fmt.Errorf("%w for %s %s", ErrNoClearingAccountFound, clearingType, instrumentCode)
+	}
+
+	// Use the first active clearing account found.
+	// In the future, we could add logic to select based on additional criteria
+	// (e.g., account name pattern for deposit vs withdrawal).
+	account := resp.Facilities[0]
+	return account.AccountId, nil
+}
+
+// cacheKey generates a cache key for the given clearing type and instrument.
+func (r *AccountResolver) cacheKey(clearingType ClearingAccountType, instrumentCode string) string {
+	return fmt.Sprintf("%s:%s", clearingType, instrumentCode)
+}
+
+// InvalidateCache clears all cached entries. Useful for testing or when accounts are modified.
+func (r *AccountResolver) InvalidateCache() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cache = make(map[string]cacheEntry)
+	r.logger.Debug("cache invalidated")
+}
+
+// InvalidateCacheEntry removes a specific entry from the cache.
+func (r *AccountResolver) InvalidateCacheEntry(clearingType ClearingAccountType, instrumentCode string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.cache, r.cacheKey(clearingType, instrumentCode))
+	r.logger.Debug("cache entry invalidated",
+		"clearing_type", clearingType,
+		"instrument_code", instrumentCode)
+}

--- a/services/current-account/service/account_resolver.go
+++ b/services/current-account/service/account_resolver.go
@@ -218,6 +218,12 @@ func (r *AccountResolver) resolveClearingAccount(ctx context.Context, clearingTy
 }
 
 // queryInternalBankAccount queries the Internal Bank Account service for a clearing account.
+//
+// Note: clearingType is currently used only for logging and cache key generation.
+// The Internal Bank Account API doesn't yet support filtering by clearing purpose
+// (deposit vs withdrawal), so the same account is returned for both operations.
+// Cache keys include clearingType intentionally to support future differentiation
+// without cache invalidation when the API is extended.
 func (r *AccountResolver) queryInternalBankAccount(ctx context.Context, clearingType ClearingAccountType, instrumentCode string) (string, error) {
 	resp, err := r.client.ListInternalBankAccounts(ctx, &internalbankaccountv1.ListInternalBankAccountsRequest{
 		AccountTypeFilter:    internalbankaccountv1.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
@@ -240,8 +246,10 @@ func (r *AccountResolver) queryInternalBankAccount(ctx context.Context, clearing
 	}
 
 	// Use the first active clearing account found.
-	// In the future, we could add logic to select based on additional criteria
-	// (e.g., account name pattern for deposit vs withdrawal).
+	// TODO(future): When the Internal Bank Account API supports clearing purpose filtering,
+	// use clearingType to select deposit-specific vs withdrawal-specific accounts.
+	// The current implementation returns the same account for both, which is acceptable
+	// for initial deployment where a single clearing account handles all operations.
 	account := resp.Facilities[0]
 	return account.AccountId, nil
 }

--- a/services/current-account/service/account_resolver.go
+++ b/services/current-account/service/account_resolver.go
@@ -11,6 +11,7 @@ import (
 
 	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
+	"golang.org/x/sync/singleflight"
 )
 
 // AccountResolverErrors defines sentinel errors for the AccountResolver.
@@ -23,6 +24,9 @@ var (
 
 	// ErrAccountResolverLoggerNil is returned when attempting to create an AccountResolver with a nil logger.
 	ErrAccountResolverLoggerNil = errors.New("logger cannot be nil")
+
+	// ErrAccountResolverInternalError is returned when an unexpected internal error occurs.
+	ErrAccountResolverInternalError = errors.New("internal error: unexpected result type from singleflight")
 )
 
 // ClearingAccountType defines the type of clearing account being resolved.
@@ -47,16 +51,21 @@ type cacheEntry struct {
 // clearing account lookups.
 //
 // Thread-safe: All methods can be called concurrently from multiple goroutines.
+// Uses singleflight to prevent cache stampede (multiple concurrent requests for the same key).
 type AccountResolver struct {
 	client InternalBankAccountClient
 	logger *slog.Logger
 
 	// Cache configuration
-	cacheTTL time.Duration
+	cacheTTL      time.Duration
+	lookupTimeout time.Duration
 
 	// Thread-safe cache: key is "TYPE:INSTRUMENT" (e.g., "DEPOSIT:GBP")
 	mu    sync.RWMutex
 	cache map[string]cacheEntry
+
+	// Singleflight to coalesce concurrent requests for the same cache key
+	sfGroup singleflight.Group
 }
 
 // AccountResolverConfig holds configuration for creating an AccountResolver.
@@ -70,10 +79,20 @@ type AccountResolverConfig struct {
 	// CacheTTL is how long resolved account IDs are cached.
 	// Defaults to 5 minutes if not specified.
 	CacheTTL time.Duration
+
+	// LookupTimeout is the timeout for individual lookup requests to the Internal Bank Account service.
+	// Defaults to 2 seconds if not specified.
+	LookupTimeout time.Duration
 }
 
-// DefaultCacheTTL is the default cache TTL for resolved account IDs.
-const DefaultCacheTTL = 5 * time.Minute
+const (
+	// DefaultCacheTTL is the default cache TTL for resolved account IDs.
+	DefaultCacheTTL = 5 * time.Minute
+
+	// DefaultLookupTimeout is the default timeout for clearing account lookups.
+	// This is shorter than the typical RPC timeout to allow graceful fallback to static config.
+	DefaultLookupTimeout = 2 * time.Second
+)
 
 // NewAccountResolver creates a new AccountResolver with the given configuration.
 // Returns an error if required configuration is missing.
@@ -90,11 +109,17 @@ func NewAccountResolver(cfg AccountResolverConfig) (*AccountResolver, error) {
 		ttl = DefaultCacheTTL
 	}
 
+	lookupTimeout := cfg.LookupTimeout
+	if lookupTimeout == 0 {
+		lookupTimeout = DefaultLookupTimeout
+	}
+
 	return &AccountResolver{
-		client:   cfg.Client,
-		logger:   cfg.Logger,
-		cacheTTL: ttl,
-		cache:    make(map[string]cacheEntry),
+		client:        cfg.Client,
+		logger:        cfg.Logger,
+		cacheTTL:      ttl,
+		lookupTimeout: lookupTimeout,
+		cache:         make(map[string]cacheEntry),
 	}, nil
 }
 
@@ -117,6 +142,7 @@ func (r *AccountResolver) GetWithdrawalClearingAccount(ctx context.Context, inst
 }
 
 // resolveClearingAccount is the internal implementation for resolving clearing accounts.
+// Uses singleflight to prevent cache stampede when multiple concurrent requests miss the cache.
 func (r *AccountResolver) resolveClearingAccount(ctx context.Context, clearingType ClearingAccountType, instrumentCode string) (string, error) {
 	cacheKey := r.cacheKey(clearingType, instrumentCode)
 
@@ -135,28 +161,58 @@ func (r *AccountResolver) resolveClearingAccount(ctx context.Context, clearingTy
 
 	caobservability.RecordClearingAccountCacheMiss()
 
-	// Query the Internal Bank Account service
+	// Use singleflight to coalesce concurrent requests for the same cache key.
+	// This prevents cache stampede when multiple goroutines miss the cache simultaneously.
 	start := time.Now()
-	accountID, err := r.queryInternalBankAccount(ctx, clearingType, instrumentCode)
+	result, err, shared := r.sfGroup.Do(cacheKey, func() (interface{}, error) {
+		// Double-check cache after acquiring the singleflight "lock"
+		// Another goroutine might have already populated the cache
+		r.mu.RLock()
+		if entry, ok := r.cache[cacheKey]; ok && time.Now().Before(entry.expiresAt) {
+			r.mu.RUnlock()
+			return entry.accountID, nil
+		}
+		r.mu.RUnlock()
+
+		// Create a timeout context for the lookup to enable faster fallback
+		lookupCtx, cancel := context.WithTimeout(ctx, r.lookupTimeout)
+		defer cancel()
+
+		// Query the Internal Bank Account service
+		accountID, err := r.queryInternalBankAccount(lookupCtx, clearingType, instrumentCode)
+		if err != nil {
+			return "", err
+		}
+
+		// Cache the result (write lock)
+		r.mu.Lock()
+		r.cache[cacheKey] = cacheEntry{
+			accountID: accountID,
+			expiresAt: time.Now().Add(r.cacheTTL),
+		}
+		r.mu.Unlock()
+
+		return accountID, nil
+	})
+
 	if err != nil {
 		caobservability.RecordClearingAccountLookupError(string(clearingType))
 		return "", err
 	}
-	caobservability.RecordClearingAccountLookupDuration(time.Since(start))
 
-	// Cache the result (write lock)
-	r.mu.Lock()
-	r.cache[cacheKey] = cacheEntry{
-		accountID: accountID,
-		expiresAt: time.Now().Add(r.cacheTTL),
+	accountID, ok := result.(string)
+	if !ok {
+		// This should never happen as we control the singleflight function return type
+		return "", ErrAccountResolverInternalError
 	}
-	r.mu.Unlock()
+	caobservability.RecordClearingAccountLookupDuration(time.Since(start))
 
 	r.logger.Info("resolved clearing account",
 		"clearing_type", clearingType,
 		"instrument_code", instrumentCode,
 		"account_id", accountID,
-		"duration_ms", time.Since(start).Milliseconds())
+		"duration_ms", time.Since(start).Milliseconds(),
+		"shared", shared)
 
 	return accountID, nil
 }

--- a/services/current-account/service/account_resolver_test.go
+++ b/services/current-account/service/account_resolver_test.go
@@ -86,7 +86,7 @@ func TestNewAccountResolver_CustomCacheTTL(t *testing.T) {
 
 	resolver, err := NewAccountResolver(AccountResolverConfig{
 		Client:   mockClient,
-		Logger:   testLogger(),
+		Logger:   accountResolverTestLogger(),
 		CacheTTL: customTTL,
 	})
 
@@ -131,7 +131,7 @@ func TestAccountResolver_GetDepositClearingAccount_CacheHit(t *testing.T) {
 
 	resolver, err := NewAccountResolver(AccountResolverConfig{
 		Client:   mockClient,
-		Logger:   testLogger(),
+		Logger:   accountResolverTestLogger(),
 		CacheTTL: 5 * time.Minute,
 	})
 	require.NoError(t, err)
@@ -162,7 +162,7 @@ func TestAccountResolver_GetDepositClearingAccount_CacheExpiry(t *testing.T) {
 	// Use very short TTL for testing
 	resolver, err := NewAccountResolver(AccountResolverConfig{
 		Client:   mockClient,
-		Logger:   testLogger(),
+		Logger:   accountResolverTestLogger(),
 		CacheTTL: 10 * time.Millisecond,
 	})
 	require.NoError(t, err)
@@ -250,7 +250,7 @@ func TestAccountResolver_InvalidateCache(t *testing.T) {
 
 	resolver, err := NewAccountResolver(AccountResolverConfig{
 		Client:   mockClient,
-		Logger:   testLogger(),
+		Logger:   accountResolverTestLogger(),
 		CacheTTL: 5 * time.Minute,
 	})
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func TestAccountResolver_InvalidateCacheEntry(t *testing.T) {
 
 	resolver, err := NewAccountResolver(AccountResolverConfig{
 		Client:   mockClient,
-		Logger:   testLogger(),
+		Logger:   accountResolverTestLogger(),
 		CacheTTL: 5 * time.Minute,
 	})
 	require.NoError(t, err)
@@ -344,7 +344,7 @@ func TestAccountResolver_ConcurrentAccess(t *testing.T) {
 
 	resolver, err := NewAccountResolver(AccountResolverConfig{
 		Client:   mockClient,
-		Logger:   testLogger(),
+		Logger:   accountResolverTestLogger(),
 		CacheTTL: 5 * time.Minute,
 	})
 	require.NoError(t, err)
@@ -388,7 +388,7 @@ func TestAccountResolver_DepositVsWithdrawal_SeparateCacheKeys(t *testing.T) {
 
 	resolver, err := NewAccountResolver(AccountResolverConfig{
 		Client:   mockClient,
-		Logger:   testLogger(),
+		Logger:   accountResolverTestLogger(),
 		CacheTTL: 5 * time.Minute,
 	})
 	require.NoError(t, err)

--- a/services/current-account/service/account_resolver_test.go
+++ b/services/current-account/service/account_resolver_test.go
@@ -1,0 +1,415 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockInternalBankAccountClient is a mock implementation for testing.
+type mockInternalBankAccountClient struct {
+	listResponse *internalbankaccountv1.ListInternalBankAccountsResponse
+	listErr      error
+	callCount    int
+	mu           sync.Mutex
+}
+
+func (m *mockInternalBankAccountClient) ListInternalBankAccounts(_ context.Context, _ *internalbankaccountv1.ListInternalBankAccountsRequest) (*internalbankaccountv1.ListInternalBankAccountsResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callCount++
+	return m.listResponse, m.listErr
+}
+
+func (m *mockInternalBankAccountClient) RetrieveInternalBankAccount(_ context.Context, _ *internalbankaccountv1.RetrieveInternalBankAccountRequest) (*internalbankaccountv1.RetrieveInternalBankAccountResponse, error) {
+	return nil, nil
+}
+
+func (m *mockInternalBankAccountClient) Close() error {
+	return nil
+}
+
+func (m *mockInternalBankAccountClient) getCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callCount
+}
+
+func accountResolverTestLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+func TestNewAccountResolver_NilClient(t *testing.T) {
+	_, err := NewAccountResolver(AccountResolverConfig{
+		Client: nil,
+		Logger: accountResolverTestLogger(),
+	})
+
+	assert.ErrorIs(t, err, ErrAccountResolverClientNil)
+}
+
+func TestNewAccountResolver_NilLogger(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{}
+
+	_, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: nil,
+	})
+
+	assert.ErrorIs(t, err, ErrAccountResolverLoggerNil)
+}
+
+func TestNewAccountResolver_DefaultCacheTTL(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+		// CacheTTL not specified - should default to DefaultCacheTTL
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, DefaultCacheTTL, resolver.cacheTTL)
+}
+
+func TestNewAccountResolver_CustomCacheTTL(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{}
+	customTTL := 10 * time.Minute
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   testLogger(),
+		CacheTTL: customTTL,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, customTTL, resolver.cacheTTL)
+}
+
+func TestAccountResolver_GetDepositClearingAccount_Success(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{
+					AccountId:   "clearing-account-123",
+					AccountCode: "CLR-GBP-001",
+					Name:        "GBP Clearing Account",
+				},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	accountID, err := resolver.GetDepositClearingAccount(context.Background(), "GBP")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "clearing-account-123", accountID)
+	assert.Equal(t, 1, mockClient.getCallCount())
+}
+
+func TestAccountResolver_GetDepositClearingAccount_CacheHit(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "clearing-account-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   testLogger(),
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// First call - cache miss
+	accountID1, err := resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, "clearing-account-123", accountID1)
+
+	// Second call - should be cache hit
+	accountID2, err := resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, "clearing-account-123", accountID2)
+
+	// Client should only be called once
+	assert.Equal(t, 1, mockClient.getCallCount())
+}
+
+func TestAccountResolver_GetDepositClearingAccount_CacheExpiry(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "clearing-account-123"},
+			},
+		},
+	}
+
+	// Use very short TTL for testing
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   testLogger(),
+		CacheTTL: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	// First call - cache miss
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 1, mockClient.getCallCount())
+
+	// Wait for cache to expire
+	time.Sleep(20 * time.Millisecond)
+
+	// Second call - cache expired, should call client again
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 2, mockClient.getCallCount())
+}
+
+func TestAccountResolver_GetDepositClearingAccount_NoClearingAccountFound(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{}, // Empty
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+
+	assert.ErrorIs(t, err, ErrNoClearingAccountFound)
+}
+
+var errAccountResolverTestConnectionRefused = errors.New("connection refused")
+
+func TestAccountResolver_GetDepositClearingAccount_ClientError(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listErr: errAccountResolverTestConnectionRefused,
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errAccountResolverTestConnectionRefused)
+}
+
+func TestAccountResolver_GetWithdrawalClearingAccount_Success(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "withdrawal-clearing-456"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	accountID, err := resolver.GetWithdrawalClearingAccount(context.Background(), "USD")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "withdrawal-clearing-456", accountID)
+}
+
+func TestAccountResolver_InvalidateCache(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "clearing-account-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   testLogger(),
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// First call - cache miss
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 1, mockClient.getCallCount())
+
+	// Second call - cache hit
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 1, mockClient.getCallCount())
+
+	// Invalidate cache
+	resolver.InvalidateCache()
+
+	// Third call - cache invalidated, should call client again
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 2, mockClient.getCallCount())
+}
+
+func TestAccountResolver_InvalidateCacheEntry(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "clearing-account-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   testLogger(),
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// Populate cache for GBP and USD
+	_, _ = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	_, _ = resolver.GetDepositClearingAccount(context.Background(), "USD")
+	assert.Equal(t, 2, mockClient.getCallCount())
+
+	// Invalidate only GBP entry
+	resolver.InvalidateCacheEntry(ClearingAccountTypeDeposit, "GBP")
+
+	// GBP should trigger new lookup
+	_, _ = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	assert.Equal(t, 3, mockClient.getCallCount())
+
+	// USD should still be cached
+	_, _ = resolver.GetDepositClearingAccount(context.Background(), "USD")
+	assert.Equal(t, 3, mockClient.getCallCount()) // No additional call
+}
+
+func TestAccountResolver_DifferentInstrumentCodes(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "clearing-account-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	// Query different instruments
+	currencies := []string{"GBP", "USD", "EUR", "KWH"}
+	for _, currency := range currencies {
+		_, err := resolver.GetDepositClearingAccount(context.Background(), currency)
+		require.NoError(t, err)
+	}
+
+	// Each unique instrument should trigger one client call
+	assert.Equal(t, 4, mockClient.getCallCount())
+}
+
+func TestAccountResolver_ConcurrentAccess(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "clearing-account-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   testLogger(),
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// Run concurrent requests
+	var wg sync.WaitGroup
+	errChan := make(chan error, 100)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := resolver.GetDepositClearingAccount(context.Background(), "GBP")
+			if err != nil {
+				errChan <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	// No errors should occur
+	for err := range errChan {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Due to caching, client should be called a small number of times
+	// (exact count depends on timing, but should be much less than 100)
+	assert.Less(t, mockClient.getCallCount(), 10, "Cache should reduce client calls significantly")
+}
+
+func TestAccountResolver_DepositVsWithdrawal_SeparateCacheKeys(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "clearing-account-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   testLogger(),
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// Query deposit clearing for GBP
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 1, mockClient.getCallCount())
+
+	// Query withdrawal clearing for GBP - should be separate cache entry
+	_, err = resolver.GetWithdrawalClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 2, mockClient.getCallCount())
+
+	// Query deposit again - should hit cache
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 2, mockClient.getCallCount())
+
+	// Query withdrawal again - should hit cache
+	_, err = resolver.GetWithdrawalClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 2, mockClient.getCallCount())
+}

--- a/services/current-account/service/client_interfaces.go
+++ b/services/current-account/service/client_interfaces.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
+	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 )
@@ -152,6 +153,31 @@ type PartyClient interface {
 	//
 	// Returns the party data if found, or an error if not found.
 	GetParty(ctx context.Context, partyID string) (*partyv1.Party, error)
+
+	// Close terminates the client connection gracefully.
+	Close() error
+}
+
+// InternalBankAccountClient defines the interface for communicating with the Internal Bank Account service.
+//
+// This interface represents the subset of InternalBankAccount operations used by CurrentAccount
+// for resolving clearing account IDs dynamically. The actual implementation is provided by
+// services/internal-bank-account/client.Client which implements this interface directly.
+//
+// The InternalBankAccount service manages non-customer-facing accounts including clearing,
+// nostro, vostro, holding, suspense, revenue, expense, and inventory accounts. CurrentAccount
+// uses this service to resolve clearing accounts for deposit and withdrawal operations.
+type InternalBankAccountClient interface {
+	// ListInternalBankAccounts queries accounts with filtering and pagination.
+	//
+	// Used by AccountResolver to find active clearing accounts for a specific instrument.
+	// Supports filtering by account type, instrument code, and status.
+	ListInternalBankAccounts(ctx context.Context, req *internalbankaccountv1.ListInternalBankAccountsRequest) (*internalbankaccountv1.ListInternalBankAccountsResponse, error)
+
+	// RetrieveInternalBankAccount fetches a single account by ID.
+	//
+	// Used to verify account existence and status.
+	RetrieveInternalBankAccount(ctx context.Context, req *internalbankaccountv1.RetrieveInternalBankAccountRequest) (*internalbankaccountv1.RetrieveInternalBankAccountResponse, error)
 
 	// Close terminates the client connection gracefully.
 	Close() error

--- a/services/current-account/service/deposit_orchestrator.go
+++ b/services/current-account/service/deposit_orchestrator.go
@@ -36,6 +36,7 @@ type DepositOrchestrator struct {
 	posKeepingClient PositionKeepingClient
 	finAcctClient    FinancialAccountingClient
 	accountConfig    *config.AccountConfig
+	accountResolver  *AccountResolver
 }
 
 // DepositOrchestratorConfig contains dependencies for creating a DepositOrchestrator
@@ -45,6 +46,10 @@ type DepositOrchestratorConfig struct {
 	PosKeepingClient PositionKeepingClient
 	FinAcctClient    FinancialAccountingClient
 	AccountConfig    *config.AccountConfig
+	// AccountResolver enables dynamic clearing account resolution from Internal Bank Account service.
+	// If provided, takes precedence over AccountConfig for clearing account lookup.
+	// If nil, falls back to static AccountConfig environment variables.
+	AccountResolver *AccountResolver
 }
 
 // NewDepositOrchestrator creates a new deposit orchestrator with the given dependencies.
@@ -68,6 +73,7 @@ func NewDepositOrchestrator(cfg DepositOrchestratorConfig) (*DepositOrchestrator
 		posKeepingClient: cfg.PosKeepingClient,
 		finAcctClient:    cfg.FinAcctClient,
 		accountConfig:    cfg.AccountConfig,
+		accountResolver:  cfg.AccountResolver,
 	}, nil
 }
 
@@ -119,10 +125,14 @@ func (o *DepositOrchestrator) Orchestrate(ctx context.Context, account domain.Cu
 	var debitPosted bool
 	var creditPosted bool
 
-	// Get clearing account ID from config
-	var clearingAccountID string
-	if o.accountConfig != nil {
-		clearingAccountID = o.accountConfig.DepositClearingAccountID
+	// Resolve clearing account ID (dynamic resolver preferred, fallback to static config)
+	clearingAccountID, err := o.resolveClearingAccountID(ctx, string(amount.Currency()))
+	if err != nil {
+		o.logger.Warn("failed to resolve clearing account, deposit will proceed without double-entry clearing",
+			"account_id", account.AccountID(),
+			"transaction_id", transactionID,
+			"error", err)
+		clearingAccountID = ""
 	}
 
 	// Step 1: Log position in PositionKeeping service
@@ -650,4 +660,39 @@ func (o *DepositOrchestrator) addSaveAccountStep(
 			return nil
 		},
 	)
+}
+
+// resolveClearingAccountID resolves the clearing account ID for deposit operations.
+// Priority:
+//  1. AccountResolver (dynamic lookup from Internal Bank Account service)
+//  2. AccountConfig (static environment variable fallback)
+//
+// Returns empty string and nil error if neither is configured (single-entry mode).
+func (o *DepositOrchestrator) resolveClearingAccountID(ctx context.Context, currency string) (string, error) {
+	// Try dynamic resolver first (preferred)
+	if o.accountResolver != nil {
+		accountID, err := o.accountResolver.GetDepositClearingAccount(ctx, currency)
+		if err != nil {
+			// Log but don't fail - allow fallback to static config
+			o.logger.Warn("dynamic clearing account resolution failed, trying static config",
+				"currency", currency,
+				"error", err)
+		} else {
+			o.logger.Debug("resolved clearing account dynamically",
+				"currency", currency,
+				"account_id", accountID)
+			return accountID, nil
+		}
+	}
+
+	// Fallback to static config
+	if o.accountConfig != nil && o.accountConfig.DepositClearingAccountID != "" {
+		o.logger.Debug("using static clearing account from config",
+			"account_id", o.accountConfig.DepositClearingAccountID)
+		return o.accountConfig.DepositClearingAccountID, nil
+	}
+
+	// Neither configured - single-entry mode
+	o.logger.Debug("no clearing account configured, operating in single-entry mode")
+	return "", nil
 }

--- a/services/current-account/service/deposit_orchestrator.go
+++ b/services/current-account/service/deposit_orchestrator.go
@@ -126,14 +126,7 @@ func (o *DepositOrchestrator) Orchestrate(ctx context.Context, account domain.Cu
 	var creditPosted bool
 
 	// Resolve clearing account ID (dynamic resolver preferred, fallback to static config)
-	clearingAccountID, err := o.resolveClearingAccountID(ctx, string(amount.Currency()))
-	if err != nil {
-		o.logger.Warn("failed to resolve clearing account, deposit will proceed without double-entry clearing",
-			"account_id", account.AccountID(),
-			"transaction_id", transactionID,
-			"error", err)
-		clearingAccountID = ""
-	}
+	clearingAccountID := o.resolveClearingAccountID(ctx, string(amount.Currency()))
 
 	// Step 1: Log position in PositionKeeping service
 	o.addLogPositionStep(saga, account, amount, transactionID, &positionLogID, &positionLogVersion)
@@ -667,8 +660,9 @@ func (o *DepositOrchestrator) addSaveAccountStep(
 //  1. AccountResolver (dynamic lookup from Internal Bank Account service)
 //  2. AccountConfig (static environment variable fallback)
 //
-// Returns empty string and nil error if neither is configured (single-entry mode).
-func (o *DepositOrchestrator) resolveClearingAccountID(ctx context.Context, currency string) (string, error) {
+// Returns empty string if neither is configured (single-entry mode).
+// All error cases are handled internally with fallback behavior.
+func (o *DepositOrchestrator) resolveClearingAccountID(ctx context.Context, currency string) string {
 	// Try dynamic resolver first (preferred)
 	if o.accountResolver != nil {
 		accountID, err := o.accountResolver.GetDepositClearingAccount(ctx, currency)
@@ -681,7 +675,7 @@ func (o *DepositOrchestrator) resolveClearingAccountID(ctx context.Context, curr
 			o.logger.Debug("resolved clearing account dynamically",
 				"currency", currency,
 				"account_id", accountID)
-			return accountID, nil
+			return accountID
 		}
 	}
 
@@ -689,10 +683,10 @@ func (o *DepositOrchestrator) resolveClearingAccountID(ctx context.Context, curr
 	if o.accountConfig != nil && o.accountConfig.DepositClearingAccountID != "" {
 		o.logger.Debug("using static clearing account from config",
 			"account_id", o.accountConfig.DepositClearingAccountID)
-		return o.accountConfig.DepositClearingAccountID, nil
+		return o.accountConfig.DepositClearingAccountID
 	}
 
 	// Neither configured - single-entry mode
 	o.logger.Debug("no clearing account configured, operating in single-entry mode")
-	return "", nil
+	return ""
 }

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -203,6 +203,13 @@ func NewServiceWithIdempotency(repo *persistence.Repository, lienRepo *persisten
 // NewServiceWithExistingClients creates a new service with pre-created client instances.
 // This constructor is useful when clients need to be shared with other components
 // (e.g., health checkers) to avoid creating duplicate connections.
+//
+// Optional parameters:
+//   - accountConfig: Static clearing account configuration (environment variables)
+//   - accountResolver: Dynamic clearing account resolution from Internal Bank Account service
+//
+// If both accountConfig and accountResolver are provided, the resolver takes precedence
+// with fallback to static config.
 func NewServiceWithExistingClients(
 	repo *persistence.Repository,
 	lienRepo *persistence.LienRepository,
@@ -214,6 +221,7 @@ func NewServiceWithExistingClients(
 	idempotencyService idempotency.Service,
 	logger *slog.Logger,
 	tracer *observability.Tracer,
+	accountResolver *AccountResolver, // Optional: dynamic clearing account resolution
 ) (*Service, error) {
 	if repo == nil {
 		return nil, ErrRepositoryNil
@@ -231,6 +239,7 @@ func NewServiceWithExistingClients(
 		PosKeepingClient: posKeepingClient,
 		FinAcctClient:    finAcctClient,
 		AccountConfig:    accountConfig,
+		AccountResolver:  accountResolver,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create deposit orchestrator: %w", err)
@@ -243,6 +252,7 @@ func NewServiceWithExistingClients(
 		PosKeepingClient: posKeepingClient,
 		FinAcctClient:    finAcctClient,
 		AccountConfig:    accountConfig,
+		AccountResolver:  accountResolver,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create withdrawal orchestrator: %w", err)

--- a/services/current-account/service/withdrawal_orchestrator.go
+++ b/services/current-account/service/withdrawal_orchestrator.go
@@ -36,6 +36,7 @@ type WithdrawalOrchestrator struct {
 	posKeepingClient PositionKeepingClient
 	finAcctClient    FinancialAccountingClient
 	accountConfig    *config.AccountConfig
+	accountResolver  *AccountResolver
 }
 
 // WithdrawalOrchestratorConfig contains dependencies for creating a WithdrawalOrchestrator
@@ -45,6 +46,10 @@ type WithdrawalOrchestratorConfig struct {
 	PosKeepingClient PositionKeepingClient
 	FinAcctClient    FinancialAccountingClient
 	AccountConfig    *config.AccountConfig
+	// AccountResolver enables dynamic clearing account resolution from Internal Bank Account service.
+	// If provided, takes precedence over AccountConfig for clearing account lookup.
+	// If nil, falls back to static AccountConfig environment variables.
+	AccountResolver *AccountResolver
 }
 
 // NewWithdrawalOrchestrator creates a new withdrawal orchestrator with the given dependencies.
@@ -68,6 +73,7 @@ func NewWithdrawalOrchestrator(cfg WithdrawalOrchestratorConfig) (*WithdrawalOrc
 		posKeepingClient: cfg.PosKeepingClient,
 		finAcctClient:    cfg.FinAcctClient,
 		accountConfig:    cfg.AccountConfig,
+		accountResolver:  cfg.AccountResolver,
 	}, nil
 }
 
@@ -120,10 +126,14 @@ func (o *WithdrawalOrchestrator) Orchestrate(ctx context.Context, account domain
 	var debitPosted bool
 	var creditPosted bool
 
-	// Get clearing account ID from config (for withdrawals, this is the bank cash account)
-	var withdrawalClearingAccountID string
-	if o.accountConfig != nil {
-		withdrawalClearingAccountID = o.accountConfig.WithdrawalClearingAccountID
+	// Resolve clearing account ID (dynamic resolver preferred, fallback to static config)
+	withdrawalClearingAccountID, err := o.resolveClearingAccountID(ctx, string(amount.Currency()))
+	if err != nil {
+		o.logger.Warn("failed to resolve clearing account, withdrawal will proceed without double-entry clearing",
+			"account_id", account.AccountID(),
+			"transaction_id", transactionID,
+			"error", err)
+		withdrawalClearingAccountID = ""
 	}
 
 	// Step 1: Log position in PositionKeeping service with DEBIT direction (opposite of deposit)
@@ -638,4 +648,39 @@ func (o *WithdrawalOrchestrator) addSaveAccountStep(
 			return nil
 		},
 	)
+}
+
+// resolveClearingAccountID resolves the clearing account ID for withdrawal operations.
+// Priority:
+//  1. AccountResolver (dynamic lookup from Internal Bank Account service)
+//  2. AccountConfig (static environment variable fallback)
+//
+// Returns empty string and nil error if neither is configured (single-entry mode).
+func (o *WithdrawalOrchestrator) resolveClearingAccountID(ctx context.Context, currency string) (string, error) {
+	// Try dynamic resolver first (preferred)
+	if o.accountResolver != nil {
+		accountID, err := o.accountResolver.GetWithdrawalClearingAccount(ctx, currency)
+		if err != nil {
+			// Log but don't fail - allow fallback to static config
+			o.logger.Warn("dynamic clearing account resolution failed, trying static config",
+				"currency", currency,
+				"error", err)
+		} else {
+			o.logger.Debug("resolved clearing account dynamically",
+				"currency", currency,
+				"account_id", accountID)
+			return accountID, nil
+		}
+	}
+
+	// Fallback to static config
+	if o.accountConfig != nil && o.accountConfig.WithdrawalClearingAccountID != "" {
+		o.logger.Debug("using static clearing account from config",
+			"account_id", o.accountConfig.WithdrawalClearingAccountID)
+		return o.accountConfig.WithdrawalClearingAccountID, nil
+	}
+
+	// Neither configured - single-entry mode
+	o.logger.Debug("no clearing account configured, operating in single-entry mode")
+	return "", nil
 }

--- a/services/current-account/service/withdrawal_orchestrator.go
+++ b/services/current-account/service/withdrawal_orchestrator.go
@@ -127,14 +127,7 @@ func (o *WithdrawalOrchestrator) Orchestrate(ctx context.Context, account domain
 	var creditPosted bool
 
 	// Resolve clearing account ID (dynamic resolver preferred, fallback to static config)
-	withdrawalClearingAccountID, err := o.resolveClearingAccountID(ctx, string(amount.Currency()))
-	if err != nil {
-		o.logger.Warn("failed to resolve clearing account, withdrawal will proceed without double-entry clearing",
-			"account_id", account.AccountID(),
-			"transaction_id", transactionID,
-			"error", err)
-		withdrawalClearingAccountID = ""
-	}
+	withdrawalClearingAccountID := o.resolveClearingAccountID(ctx, string(amount.Currency()))
 
 	// Step 1: Log position in PositionKeeping service with DEBIT direction (opposite of deposit)
 	o.addLogPositionStep(saga, account, amount, transactionID, &positionLogID, &positionLogVersion)
@@ -655,8 +648,9 @@ func (o *WithdrawalOrchestrator) addSaveAccountStep(
 //  1. AccountResolver (dynamic lookup from Internal Bank Account service)
 //  2. AccountConfig (static environment variable fallback)
 //
-// Returns empty string and nil error if neither is configured (single-entry mode).
-func (o *WithdrawalOrchestrator) resolveClearingAccountID(ctx context.Context, currency string) (string, error) {
+// Returns empty string if neither is configured (single-entry mode).
+// All error cases are handled internally with fallback behavior.
+func (o *WithdrawalOrchestrator) resolveClearingAccountID(ctx context.Context, currency string) string {
 	// Try dynamic resolver first (preferred)
 	if o.accountResolver != nil {
 		accountID, err := o.accountResolver.GetWithdrawalClearingAccount(ctx, currency)
@@ -669,7 +663,7 @@ func (o *WithdrawalOrchestrator) resolveClearingAccountID(ctx context.Context, c
 			o.logger.Debug("resolved clearing account dynamically",
 				"currency", currency,
 				"account_id", accountID)
-			return accountID, nil
+			return accountID
 		}
 	}
 
@@ -677,10 +671,10 @@ func (o *WithdrawalOrchestrator) resolveClearingAccountID(ctx context.Context, c
 	if o.accountConfig != nil && o.accountConfig.WithdrawalClearingAccountID != "" {
 		o.logger.Debug("using static clearing account from config",
 			"account_id", o.accountConfig.WithdrawalClearingAccountID)
-		return o.accountConfig.WithdrawalClearingAccountID, nil
+		return o.accountConfig.WithdrawalClearingAccountID
 	}
 
 	// Neither configured - single-entry mode
 	o.logger.Debug("no clearing account configured, operating in single-entry mode")
-	return "", nil
+	return ""
 }


### PR DESCRIPTION
## Summary

- Add dynamic clearing account resolution via Internal Bank Account service
- Replace static environment variable configuration with gRPC-based lookups
- Provide graceful degradation to static config when service unavailable

## Changes Made

- **AccountResolver** (`services/current-account/service/account_resolver.go`):
  - New component with TTL-based caching (5 minute default)
  - Thread-safe cache for concurrent access
  - Support for deposit and withdrawal clearing account types
  
- **Client Interface** (`services/current-account/service/client_interfaces.go`):
  - Added `InternalBankAccountClient` interface for ListInternalBankAccounts

- **Orchestrator Updates**:
  - `DepositOrchestrator`: Uses AccountResolver with static config fallback
  - `WithdrawalOrchestrator`: Uses AccountResolver with static config fallback

- **Wiring** (`services/current-account/cmd/main.go`):
  - Create Internal Bank Account client with circuit breaker
  - Initialize AccountResolver and pass to service constructor

- **Observability** (`services/current-account/observability/metrics.go`):
  - Cache hit/miss counters
  - Lookup duration histogram
  - Lookup error counters by clearing type

## Technical Details

The resolver follows a priority hierarchy:
1. Dynamic lookup from Internal Bank Account service (preferred)
2. Static config from environment variables (fallback)
3. Single-entry mode if neither configured

This design enables:
- **Multi-currency support**: Clearing accounts resolved per instrument code (GBP, USD, etc.)
- **Operational flexibility**: Accounts managed centrally without redeployment
- **Zero-downtime migration**: Existing static config continues to work

## Testing

- All existing current-account tests pass
- Build successful with new integration

## Task Reference

Task: internal-bank-account.11 - Migrate Current Account to use Internal Bank Account clearing