### PR TITLE
feat(internal-bank-account): add production-ready Kubernetes manifests

### DIFF
--- a/services/internal-bank-account/k8s/configmap.yaml
+++ b/services/internal-bank-account/k8s/configmap.yaml
@@ -20,6 +20,9 @@ data:
   GRPC_PORT: "50057"
   GRPC_MAX_CONCURRENT_STREAMS: "100"
 
+  # HTTP metrics server configuration
+  METRICS_PORT: "8082"
+
   # OpenTelemetry configuration
   OTEL_SERVICE_NAME: "internal-bank-account-service"
   OTEL_SAMPLING_RATE: "0.1"

--- a/services/internal-bank-account/k8s/deployment.yaml
+++ b/services/internal-bank-account/k8s/deployment.yaml
@@ -40,6 +40,9 @@ spec:
         - name: grpc
           containerPort: 50057
           protocol: TCP
+        - name: http-metrics
+          containerPort: 8082
+          protocol: TCP
         envFrom:
         - configMapRef:
             name: internal-bank-account-config

--- a/services/internal-bank-account/k8s/hpa.yaml
+++ b/services/internal-bank-account/k8s/hpa.yaml
@@ -1,0 +1,46 @@
+# HorizontalPodAutoscaler for internal-bank-account service
+# Scales based on CPU and memory utilization
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: internal-bank-account
+  labels:
+    app: internal-bank-account
+    component: microservice
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: internal-bank-account
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: Utilization
+        averageUtilization: 80
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 300
+      policies:
+      - type: Percent
+        value: 50
+        periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 30
+      - type: Pods
+        value: 2
+        periodSeconds: 30
+      selectPolicy: Max

--- a/services/internal-bank-account/k8s/poddisruptionbudget.yaml
+++ b/services/internal-bank-account/k8s/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+# PodDisruptionBudget for internal-bank-account service
+# Ensures at least 2 replicas remain available during disruptions
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: internal-bank-account-pdb
+  labels:
+    app: internal-bank-account
+    component: microservice
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: internal-bank-account

--- a/services/internal-bank-account/k8s/service.yaml
+++ b/services/internal-bank-account/k8s/service.yaml
@@ -15,5 +15,9 @@ spec:
     port: 50057
     targetPort: grpc
     protocol: TCP
+  - name: http-metrics
+    port: 8082
+    targetPort: http-metrics
+    protocol: TCP
   selector:
     app: internal-bank-account

--- a/services/internal-bank-account/k8s/servicemonitor.yaml
+++ b/services/internal-bank-account/k8s/servicemonitor.yaml
@@ -1,0 +1,23 @@
+# ServiceMonitor for internal-bank-account service
+# Enables Prometheus Operator to scrape metrics from the service
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: internal-bank-account
+  labels:
+    app: internal-bank-account
+    component: microservice
+    prometheus: kube-prometheus
+spec:
+  selector:
+    matchLabels:
+      app: internal-bank-account
+  endpoints:
+  - port: http-metrics
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 10s
+    scheme: http
+  namespaceSelector:
+    matchNames:
+    - meridian


### PR DESCRIPTION
## Summary
- Add HorizontalPodAutoscaler for auto-scaling (3-10 replicas based on CPU/memory)
- Add PodDisruptionBudget to maintain at least 2 replicas during disruptions  
- Add ServiceMonitor for Prometheus metrics scraping
- Expose HTTP metrics port (8082) in deployment and service
- Add METRICS_PORT configuration to configmap

## Task Master
- **Tag**: internal-bank-account
- **Task**: 13 - Create Kubernetes deployment manifests

## Changes Made

### New files:
- `services/internal-bank-account/k8s/hpa.yaml` - Auto-scaling with CPU (70%) and memory (80%) targets
- `services/internal-bank-account/k8s/poddisruptionbudget.yaml` - Ensures minAvailable: 2 during disruptions
- `services/internal-bank-account/k8s/servicemonitor.yaml` - Prometheus Operator integration for /metrics scraping

### Modified files:
- `deployment.yaml` - Added http-metrics port (8082)
- `service.yaml` - Added http-metrics port (8082)
- `configmap.yaml` - Added METRICS_PORT configuration

## Test plan
- [ ] Validate manifests with `kubectl apply --dry-run=client`
- [ ] Deploy to local cluster and verify:
  - [ ] HPA shows correct metrics targets
  - [ ] PDB is active and blocking evictions beyond minAvailable
  - [ ] ServiceMonitor appears in Prometheus targets
  - [ ] Metrics endpoint responds at :8082/metrics