### PR TITLE
feat(position-keeping): add account validation before creating position logs

### DIFF
--- a/services/position-keeping/app/config.go
+++ b/services/position-keeping/app/config.go
@@ -12,13 +12,14 @@ import (
 
 // Config holds all configuration for the position-keeping service
 type Config struct {
-	Server        ServerConfig
-	Database      DatabaseConfig
-	Kafka         KafkaConfig
-	Redis         RedisConfig
-	Auth          AuthConfig
-	Observability ObservabilityConfig
-	Compaction    CompactionConfig
+	Server            ServerConfig
+	Database          DatabaseConfig
+	Kafka             KafkaConfig
+	Redis             RedisConfig
+	Auth              AuthConfig
+	Observability     ObservabilityConfig
+	Compaction        CompactionConfig
+	AccountValidation AccountValidationConfig
 }
 
 // ServerConfig holds gRPC server configuration
@@ -117,16 +118,34 @@ type CompactionConfig struct {
 	BatchSize int
 }
 
+// AccountValidationConfig holds account validation configuration
+type AccountValidationConfig struct {
+	// Enabled indicates if account validation is enabled
+	// When enabled, the service validates that accounts exist in Current Account
+	// before creating position logs. Defaults to false for backwards compatibility.
+	Enabled bool
+	// CurrentAccountServiceURL is the gRPC address of the Current Account service
+	// Required when validation is enabled
+	CurrentAccountServiceURL string
+	// CacheTTL is how long to cache validation results
+	// Defaults to 1 minute if not specified
+	CacheTTL time.Duration
+	// ConnectionTimeout is the timeout for connecting to Current Account service
+	// Defaults to 5 seconds if not specified
+	ConnectionTimeout time.Duration
+}
+
 // LoadConfig loads configuration from environment variables with defaults
 func LoadConfig() (*Config, error) {
 	config := &Config{
-		Server:        loadServerConfig(),
-		Database:      loadDatabaseConfig(),
-		Kafka:         loadKafkaConfig(),
-		Redis:         loadRedisConfig(),
-		Auth:          loadAuthConfig(),
-		Observability: loadObservabilityConfig(),
-		Compaction:    loadCompactionConfig(),
+		Server:            loadServerConfig(),
+		Database:          loadDatabaseConfig(),
+		Kafka:             loadKafkaConfig(),
+		Redis:             loadRedisConfig(),
+		Auth:              loadAuthConfig(),
+		Observability:     loadObservabilityConfig(),
+		Compaction:        loadCompactionConfig(),
+		AccountValidation: loadAccountValidationConfig(),
 	}
 
 	if err := config.Validate(); err != nil {
@@ -219,6 +238,16 @@ func loadCompactionConfig() CompactionConfig {
 	}
 }
 
+// loadAccountValidationConfig loads account validation configuration from environment variables
+func loadAccountValidationConfig() AccountValidationConfig {
+	return AccountValidationConfig{
+		Enabled:                  env.GetEnvAsBool("ACCOUNT_VALIDATION_ENABLED", false),
+		CurrentAccountServiceURL: env.GetEnvOrDefault("CURRENT_ACCOUNT_SERVICE_URL", ""),
+		CacheTTL:                 env.GetEnvAsDuration("ACCOUNT_VALIDATION_CACHE_TTL", 1*time.Minute),
+		ConnectionTimeout:        env.GetEnvAsDuration("ACCOUNT_VALIDATION_CONNECTION_TIMEOUT", 5*time.Second),
+	}
+}
+
 // Validation errors
 var (
 	ErrEmptyPort                  = fmt.Errorf("server port must not be empty")
@@ -233,6 +262,8 @@ var (
 	ErrInvalidCompactionInterval  = fmt.Errorf("compaction run interval must be greater than zero")
 	ErrInvalidFragmentThreshold   = fmt.Errorf("compaction fragment threshold must be at least 2")
 	ErrInvalidCompactionBatchSize = fmt.Errorf("compaction batch size must be at least 1")
+	// ErrAccountValidationURLRequired is returned when account validation is enabled but URL is not provided
+	ErrAccountValidationURLRequired = fmt.Errorf("current account service URL is required when account validation is enabled")
 )
 
 // Validate validates the configuration
@@ -270,18 +301,34 @@ func (c *Config) Validate() error {
 		return ErrInvalidSamplingRate
 	}
 
-	// Compaction validation (only when enabled)
-	if c.Compaction.Enabled {
-		if c.Compaction.RunInterval <= 0 {
-			return ErrInvalidCompactionInterval
-		}
-		if c.Compaction.FragmentThreshold < 2 {
-			return ErrInvalidFragmentThreshold
-		}
-		if c.Compaction.BatchSize < 1 {
-			return ErrInvalidCompactionBatchSize
-		}
+	if err := c.Compaction.Validate(); err != nil {
+		return err
 	}
 
+	return c.AccountValidation.Validate()
+}
+
+// Validate validates the compaction configuration
+func (c *CompactionConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.RunInterval <= 0 {
+		return ErrInvalidCompactionInterval
+	}
+	if c.FragmentThreshold < 2 {
+		return ErrInvalidFragmentThreshold
+	}
+	if c.BatchSize < 1 {
+		return ErrInvalidCompactionBatchSize
+	}
+	return nil
+}
+
+// Validate validates the account validation configuration
+func (c *AccountValidationConfig) Validate() error {
+	if c.Enabled && c.CurrentAccountServiceURL == "" {
+		return ErrAccountValidationURLRequired
+	}
 	return nil
 }

--- a/services/position-keeping/app/config.go
+++ b/services/position-keeping/app/config.go
@@ -122,15 +122,19 @@ type CompactionConfig struct {
 type AccountValidationConfig struct {
 	// Enabled indicates if account validation is enabled
 	// When enabled, the service validates that accounts exist in Current Account
-	// before creating position logs. Defaults to false for backwards compatibility.
+	// or Internal Bank Account before creating position logs.
+	// Defaults to true to prevent orphan position logs.
 	Enabled bool
 	// CurrentAccountServiceURL is the gRPC address of the Current Account service
-	// Required when validation is enabled
+	// Optional - if not specified, Current Account validation is skipped
 	CurrentAccountServiceURL string
+	// InternalBankAccountServiceURL is the gRPC address of the Internal Bank Account service
+	// Optional - if not specified, Internal Bank Account validation is skipped
+	InternalBankAccountServiceURL string
 	// CacheTTL is how long to cache validation results
 	// Defaults to 1 minute if not specified
 	CacheTTL time.Duration
-	// ConnectionTimeout is the timeout for connecting to Current Account service
+	// ConnectionTimeout is the timeout for connecting to account services
 	// Defaults to 5 seconds if not specified
 	ConnectionTimeout time.Duration
 }
@@ -241,10 +245,11 @@ func loadCompactionConfig() CompactionConfig {
 // loadAccountValidationConfig loads account validation configuration from environment variables
 func loadAccountValidationConfig() AccountValidationConfig {
 	return AccountValidationConfig{
-		Enabled:                  env.GetEnvAsBool("ACCOUNT_VALIDATION_ENABLED", false),
-		CurrentAccountServiceURL: env.GetEnvOrDefault("CURRENT_ACCOUNT_SERVICE_URL", ""),
-		CacheTTL:                 env.GetEnvAsDuration("ACCOUNT_VALIDATION_CACHE_TTL", 1*time.Minute),
-		ConnectionTimeout:        env.GetEnvAsDuration("ACCOUNT_VALIDATION_CONNECTION_TIMEOUT", 5*time.Second),
+		Enabled:                       env.GetEnvAsBool("ACCOUNT_VALIDATION_ENABLED", true),
+		CurrentAccountServiceURL:      env.GetEnvOrDefault("CURRENT_ACCOUNT_SERVICE_URL", ""),
+		InternalBankAccountServiceURL: env.GetEnvOrDefault("INTERNAL_BANK_ACCOUNT_SERVICE_URL", ""),
+		CacheTTL:                      env.GetEnvAsDuration("ACCOUNT_VALIDATION_CACHE_TTL", 1*time.Minute),
+		ConnectionTimeout:             env.GetEnvAsDuration("ACCOUNT_VALIDATION_CONNECTION_TIMEOUT", 5*time.Second),
 	}
 }
 
@@ -262,8 +267,8 @@ var (
 	ErrInvalidCompactionInterval  = fmt.Errorf("compaction run interval must be greater than zero")
 	ErrInvalidFragmentThreshold   = fmt.Errorf("compaction fragment threshold must be at least 2")
 	ErrInvalidCompactionBatchSize = fmt.Errorf("compaction batch size must be at least 1")
-	// ErrAccountValidationURLRequired is returned when account validation is enabled but URL is not provided
-	ErrAccountValidationURLRequired = fmt.Errorf("current account service URL is required when account validation is enabled")
+	// ErrAccountValidationURLRequired is returned when account validation is enabled but no service URL is provided
+	ErrAccountValidationURLRequired = fmt.Errorf("at least one account service URL is required when account validation is enabled")
 )
 
 // Validate validates the configuration
@@ -327,7 +332,7 @@ func (c *CompactionConfig) Validate() error {
 
 // Validate validates the account validation configuration
 func (c *AccountValidationConfig) Validate() error {
-	if c.Enabled && c.CurrentAccountServiceURL == "" {
+	if c.Enabled && c.CurrentAccountServiceURL == "" && c.InternalBankAccountServiceURL == "" {
 		return ErrAccountValidationURLRequired
 	}
 	return nil

--- a/services/position-keeping/app/config_test.go
+++ b/services/position-keeping/app/config_test.go
@@ -14,6 +14,8 @@ func TestLoadConfig_Defaults(t *testing.T) {
 	clearEnv(t)
 	// DATABASE_URL is required (no default to avoid hardcoded credentials)
 	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
+	// Disable account validation for default config tests (it's enabled by default)
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
 
 	config, err := LoadConfig()
 	if err != nil {
@@ -87,6 +89,8 @@ func TestLoadConfig_CustomValues(t *testing.T) {
 	t.Setenv("LOG_LEVEL", "debug")
 	t.Setenv("METRICS_ENABLED", "false")
 	t.Setenv("METRICS_PORT", "9091")
+	// Disable account validation for this test (enabled by default)
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
 
 	config, err := LoadConfig()
 	if err != nil {
@@ -691,6 +695,8 @@ func TestValidate_CompactionInvalidBatchSize(t *testing.T) {
 func TestLoadConfig_CompactionDefaults(t *testing.T) {
 	clearEnv(t)
 	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
+	// Disable account validation for this test (enabled by default)
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
 
 	config, err := LoadConfig()
 	if err != nil {
@@ -719,6 +725,8 @@ func TestLoadConfig_CompactionCustomValues(t *testing.T) {
 	t.Setenv("COMPACTION_RUN_INTERVAL", "10m")
 	t.Setenv("COMPACTION_FRAGMENT_THRESHOLD", "200")
 	t.Setenv("COMPACTION_BATCH_SIZE", "100")
+	// Disable account validation for this test (enabled by default)
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
 
 	config, err := LoadConfig()
 	if err != nil {
@@ -740,6 +748,118 @@ func TestLoadConfig_CompactionCustomValues(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_AccountValidation_Defaults(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
+	// Provide at least one URL since validation is enabled by default
+	t.Setenv("CURRENT_ACCOUNT_SERVICE_URL", "localhost:50051")
+
+	config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+
+	// Verify account validation defaults
+	if !config.AccountValidation.Enabled {
+		t.Error("AccountValidation.Enabled = false, want true (default)")
+	}
+	if config.AccountValidation.CurrentAccountServiceURL != "localhost:50051" {
+		t.Errorf("AccountValidation.CurrentAccountServiceURL = %s, want localhost:50051",
+			config.AccountValidation.CurrentAccountServiceURL)
+	}
+	if config.AccountValidation.CacheTTL != 1*time.Minute {
+		t.Errorf("AccountValidation.CacheTTL = %v, want 1m", config.AccountValidation.CacheTTL)
+	}
+	if config.AccountValidation.ConnectionTimeout != 5*time.Second {
+		t.Errorf("AccountValidation.ConnectionTimeout = %v, want 5s", config.AccountValidation.ConnectionTimeout)
+	}
+}
+
+func TestLoadConfig_AccountValidation_CustomValues(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "true")
+	t.Setenv("CURRENT_ACCOUNT_SERVICE_URL", "current-account:50051")
+	t.Setenv("INTERNAL_BANK_ACCOUNT_SERVICE_URL", "internal-bank-account:50052")
+	t.Setenv("ACCOUNT_VALIDATION_CACHE_TTL", "5m")
+	t.Setenv("ACCOUNT_VALIDATION_CONNECTION_TIMEOUT", "10s")
+
+	config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+
+	if !config.AccountValidation.Enabled {
+		t.Error("AccountValidation.Enabled = false, want true")
+	}
+	if config.AccountValidation.CurrentAccountServiceURL != "current-account:50051" {
+		t.Errorf("AccountValidation.CurrentAccountServiceURL = %s, want current-account:50051",
+			config.AccountValidation.CurrentAccountServiceURL)
+	}
+	if config.AccountValidation.InternalBankAccountServiceURL != "internal-bank-account:50052" {
+		t.Errorf("AccountValidation.InternalBankAccountServiceURL = %s, want internal-bank-account:50052",
+			config.AccountValidation.InternalBankAccountServiceURL)
+	}
+	if config.AccountValidation.CacheTTL != 5*time.Minute {
+		t.Errorf("AccountValidation.CacheTTL = %v, want 5m", config.AccountValidation.CacheTTL)
+	}
+	if config.AccountValidation.ConnectionTimeout != 10*time.Second {
+		t.Errorf("AccountValidation.ConnectionTimeout = %v, want 10s", config.AccountValidation.ConnectionTimeout)
+	}
+}
+
+func TestLoadConfig_AccountValidation_Disabled(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
+	// No URLs needed when validation is disabled
+
+	config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+
+	if config.AccountValidation.Enabled {
+		t.Error("AccountValidation.Enabled = true, want false")
+	}
+}
+
+func TestLoadConfig_AccountValidation_OnlyInternalBankAccount(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "true")
+	// Only Internal Bank Account URL - should be valid
+	t.Setenv("INTERNAL_BANK_ACCOUNT_SERVICE_URL", "internal-bank-account:50052")
+
+	config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v, want nil", err)
+	}
+
+	if !config.AccountValidation.Enabled {
+		t.Error("AccountValidation.Enabled = false, want true")
+	}
+	if config.AccountValidation.InternalBankAccountServiceURL != "internal-bank-account:50052" {
+		t.Errorf("AccountValidation.InternalBankAccountServiceURL = %s, want internal-bank-account:50052",
+			config.AccountValidation.InternalBankAccountServiceURL)
+	}
+}
+
+func TestLoadConfig_AccountValidation_EnabledNoURL_ReturnsError(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "true")
+	// No URLs provided - should fail validation
+
+	_, err := LoadConfig()
+	if err == nil {
+		t.Fatal("LoadConfig() error = nil, want error for missing account service URLs")
+	}
+	if !errors.Is(err, ErrAccountValidationURLRequired) {
+		t.Errorf("LoadConfig() error = %v, want ErrAccountValidationURLRequired", err)
+	}
+}
+
 // clearEnv clears environment variables used in tests
 func clearEnv(t *testing.T) {
 	t.Helper()
@@ -754,6 +874,9 @@ func clearEnv(t *testing.T) {
 		"SAMPLING_RATE", "LOG_LEVEL", "METRICS_ENABLED", "METRICS_PORT",
 		"COMPACTION_ENABLED", "COMPACTION_RUN_INTERVAL",
 		"COMPACTION_FRAGMENT_THRESHOLD", "COMPACTION_BATCH_SIZE",
+		"ACCOUNT_VALIDATION_ENABLED", "CURRENT_ACCOUNT_SERVICE_URL",
+		"INTERNAL_BANK_ACCOUNT_SERVICE_URL", "ACCOUNT_VALIDATION_CACHE_TTL",
+		"ACCOUNT_VALIDATION_CONNECTION_TIMEOUT",
 	}
 	for _, key := range envVars {
 		_ = os.Unsetenv(key)

--- a/services/position-keeping/app/container_test.go
+++ b/services/position-keeping/app/container_test.go
@@ -19,8 +19,9 @@ func TestNewContainer_Success(t *testing.T) {
 	// Set up test environment with minimal config
 	clearEnv(t)
 	t.Setenv("DATABASE_URL", "postgres://test:test@localhost:5432/testdb")
-	t.Setenv("KAFKA_ENABLED", "false") // Disable Kafka for unit test
-	t.Setenv("OTLP_ENDPOINT", "")      // Disable tracing for unit test
+	t.Setenv("KAFKA_ENABLED", "false")              // Disable Kafka for unit test
+	t.Setenv("OTLP_ENDPOINT", "")                   // Disable tracing for unit test
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "false") // Disable account validation for unit test
 
 	config, err := LoadConfig()
 	if err != nil {
@@ -112,6 +113,7 @@ func TestKafkaDisabled(t *testing.T) {
 	clearEnv(t)
 	t.Setenv("DATABASE_URL", "postgres://localhost:5432/testdb")
 	t.Setenv("KAFKA_ENABLED", "false")
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
 
 	config, err := LoadConfig()
 	if err != nil {
@@ -135,6 +137,7 @@ func TestDatabasePoolConfiguration(t *testing.T) {
 	t.Setenv("DB_MAX_IDLE_CONNS", "10")
 	t.Setenv("DB_CONN_MAX_LIFETIME", "15m")
 	t.Setenv("DB_CONN_MAX_IDLE_TIME", "20m")
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
 
 	config, err := LoadConfig()
 	if err != nil {
@@ -163,6 +166,7 @@ func TestObservabilityConfiguration(t *testing.T) {
 	t.Setenv("SERVICE_VERSION", "1.2.3")
 	t.Setenv("ENVIRONMENT", "test")
 	t.Setenv("SAMPLING_RATE", "0.25")
+	t.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
 
 	config, err := LoadConfig()
 	if err != nil {

--- a/services/position-keeping/cmd/main.go
+++ b/services/position-keeping/cmd/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/app"
 	"github.com/meridianhub/meridian/services/position-keeping/observability"
@@ -192,54 +193,113 @@ func run(logger *slog.Logger) error {
 	// Create account validator if validation is enabled
 	var serviceOpts []service.Option
 	var currentAccountConn *grpc.ClientConn
+	var internalBankAccountConn *grpc.ClientConn
 
 	if config.AccountValidation.Enabled {
-		// Create gRPC connection to Current Account service
-		// Note: We use NewClient (non-blocking) with insecure credentials.
-		// Connection is established lazily on first RPC call.
-		var connErr error
-		currentAccountConn, connErr = grpc.NewClient(
-			config.AccountValidation.CurrentAccountServiceURL,
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		)
+		var currentAccountValidator *service.CurrentAccountValidator
+		var internalBankAccountValidator *service.InternalBankAccountValidator
 
-		if connErr != nil {
-			return fmt.Errorf("failed to create current account client at %s: %w",
-				config.AccountValidation.CurrentAccountServiceURL, connErr)
+		// Create Current Account validator if URL is configured
+		if config.AccountValidation.CurrentAccountServiceURL != "" {
+			var connErr error
+			currentAccountConn, connErr = grpc.NewClient(
+				config.AccountValidation.CurrentAccountServiceURL,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			if connErr != nil {
+				return fmt.Errorf("failed to create current account client at %s: %w",
+					config.AccountValidation.CurrentAccountServiceURL, connErr)
+			}
+
+			currentAccountClient := currentaccountv1.NewCurrentAccountServiceClient(currentAccountConn)
+			var validatorErr error
+			currentAccountValidator, validatorErr = service.NewCurrentAccountValidator(service.CurrentAccountValidatorConfig{
+				Client:        &currentAccountClientAdapter{client: currentAccountClient},
+				Logger:        logger,
+				CacheTTL:      config.AccountValidation.CacheTTL,
+				LookupTimeout: config.AccountValidation.ConnectionTimeout,
+			})
+			if validatorErr != nil {
+				currentAccountConn.Close()
+				return fmt.Errorf("failed to create current account validator: %w", validatorErr)
+			}
+			logger.Info("current account validator configured",
+				"url", config.AccountValidation.CurrentAccountServiceURL)
 		}
 
-		// Create Current Account client
-		currentAccountClient := currentaccountv1.NewCurrentAccountServiceClient(currentAccountConn)
+		// Create Internal Bank Account validator if URL is configured
+		if config.AccountValidation.InternalBankAccountServiceURL != "" {
+			var connErr error
+			internalBankAccountConn, connErr = grpc.NewClient(
+				config.AccountValidation.InternalBankAccountServiceURL,
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			if connErr != nil {
+				if currentAccountConn != nil {
+					currentAccountConn.Close()
+				}
+				return fmt.Errorf("failed to create internal bank account client at %s: %w",
+					config.AccountValidation.InternalBankAccountServiceURL, connErr)
+			}
 
-		// Create account validator
-		validator, validatorErr := service.NewCurrentAccountValidator(service.CurrentAccountValidatorConfig{
-			Client:        &currentAccountClientAdapter{client: currentAccountClient},
-			Logger:        logger,
-			CacheTTL:      config.AccountValidation.CacheTTL,
-			LookupTimeout: config.AccountValidation.ConnectionTimeout,
+			internalBankAccountClient := internalbankaccountv1.NewInternalBankAccountServiceClient(internalBankAccountConn)
+			var validatorErr error
+			internalBankAccountValidator, validatorErr = service.NewInternalBankAccountValidator(service.InternalBankAccountValidatorConfig{
+				Client:        &internalBankAccountClientAdapter{client: internalBankAccountClient},
+				Logger:        logger,
+				CacheTTL:      config.AccountValidation.CacheTTL,
+				LookupTimeout: config.AccountValidation.ConnectionTimeout,
+			})
+			if validatorErr != nil {
+				if currentAccountConn != nil {
+					currentAccountConn.Close()
+				}
+				internalBankAccountConn.Close()
+				return fmt.Errorf("failed to create internal bank account validator: %w", validatorErr)
+			}
+			logger.Info("internal bank account validator configured",
+				"url", config.AccountValidation.InternalBankAccountServiceURL)
+		}
+
+		// Create composite validator that checks both services
+		compositeValidator, compositeErr := service.NewCompositeAccountValidator(service.CompositeAccountValidatorConfig{
+			CurrentAccountValidator:      currentAccountValidator,
+			InternalBankAccountValidator: internalBankAccountValidator,
+			Logger:                       logger,
 		})
-		if validatorErr != nil {
-			currentAccountConn.Close()
-			return fmt.Errorf("failed to create account validator: %w", validatorErr)
+		if compositeErr != nil {
+			if currentAccountConn != nil {
+				currentAccountConn.Close()
+			}
+			if internalBankAccountConn != nil {
+				internalBankAccountConn.Close()
+			}
+			return fmt.Errorf("failed to create composite account validator: %w", compositeErr)
 		}
 
 		serviceOpts = append(serviceOpts,
-			service.WithAccountValidator(validator),
+			service.WithAccountValidator(compositeValidator),
 			service.WithAccountValidationEnabled(true),
 		)
 
 		logger.Info("account validation enabled",
-			"current_account_service_url", config.AccountValidation.CurrentAccountServiceURL,
+			"current_account_url", config.AccountValidation.CurrentAccountServiceURL,
+			"internal_bank_account_url", config.AccountValidation.InternalBankAccountServiceURL,
 			"cache_ttl", config.AccountValidation.CacheTTL)
 	} else {
 		logger.Info("account validation disabled")
 	}
 
-	// Ensure Current Account connection is closed on shutdown
+	// Ensure account service connections are closed on shutdown
 	defer func() {
 		if currentAccountConn != nil {
 			if err := currentAccountConn.Close(); err != nil {
 				logger.Error("failed to close current account connection", "error", err)
+			}
+		}
+		if internalBankAccountConn != nil {
+			if err := internalBankAccountConn.Close(); err != nil {
+				logger.Error("failed to close internal bank account connection", "error", err)
 			}
 		}
 	}()
@@ -529,4 +589,16 @@ type currentAccountClientAdapter struct {
 // RetrieveCurrentAccount implements service.CurrentAccountClient by delegating to the generated client.
 func (a *currentAccountClientAdapter) RetrieveCurrentAccount(ctx context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
 	return a.client.RetrieveCurrentAccount(ctx, req)
+}
+
+// internalBankAccountClientAdapter adapts the generated gRPC client to the service.InternalBankAccountClient interface.
+// This adapter is needed because the service package defines its own interface for testability,
+// while the generated client has a different method signature.
+type internalBankAccountClientAdapter struct {
+	client internalbankaccountv1.InternalBankAccountServiceClient
+}
+
+// RetrieveInternalBankAccount implements service.InternalBankAccountClient by delegating to the generated client.
+func (a *internalBankAccountClientAdapter) RetrieveInternalBankAccount(ctx context.Context, req *internalbankaccountv1.RetrieveInternalBankAccountRequest) (*internalbankaccountv1.RetrieveInternalBankAccountResponse, error) {
+	return a.client.RetrieveInternalBankAccount(ctx, req)
 }

--- a/services/position-keeping/cmd/main.go
+++ b/services/position-keeping/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"time"
 
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/app"
 	"github.com/meridianhub/meridian/services/position-keeping/observability"
@@ -26,6 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 )
@@ -187,12 +189,68 @@ func run(logger *slog.Logger) error {
 		logger.Info("idempotency service disabled (Redis not configured)")
 	}
 
+	// Create account validator if validation is enabled
+	var serviceOpts []service.Option
+	var currentAccountConn *grpc.ClientConn
+
+	if config.AccountValidation.Enabled {
+		// Create gRPC connection to Current Account service
+		// Note: We use NewClient (non-blocking) with insecure credentials.
+		// Connection is established lazily on first RPC call.
+		var connErr error
+		currentAccountConn, connErr = grpc.NewClient(
+			config.AccountValidation.CurrentAccountServiceURL,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+
+		if connErr != nil {
+			return fmt.Errorf("failed to create current account client at %s: %w",
+				config.AccountValidation.CurrentAccountServiceURL, connErr)
+		}
+
+		// Create Current Account client
+		currentAccountClient := currentaccountv1.NewCurrentAccountServiceClient(currentAccountConn)
+
+		// Create account validator
+		validator, validatorErr := service.NewCurrentAccountValidator(service.CurrentAccountValidatorConfig{
+			Client:        &currentAccountClientAdapter{client: currentAccountClient},
+			Logger:        logger,
+			CacheTTL:      config.AccountValidation.CacheTTL,
+			LookupTimeout: config.AccountValidation.ConnectionTimeout,
+		})
+		if validatorErr != nil {
+			currentAccountConn.Close()
+			return fmt.Errorf("failed to create account validator: %w", validatorErr)
+		}
+
+		serviceOpts = append(serviceOpts,
+			service.WithAccountValidator(validator),
+			service.WithAccountValidationEnabled(true),
+		)
+
+		logger.Info("account validation enabled",
+			"current_account_service_url", config.AccountValidation.CurrentAccountServiceURL,
+			"cache_ttl", config.AccountValidation.CacheTTL)
+	} else {
+		logger.Info("account validation disabled")
+	}
+
+	// Ensure Current Account connection is closed on shutdown
+	defer func() {
+		if currentAccountConn != nil {
+			if err := currentAccountConn.Close(); err != nil {
+				logger.Error("failed to close current account connection", "error", err)
+			}
+		}
+	}()
+
 	// Create gRPC service
 	positionKeepingService, err := service.NewPositionKeepingService(
 		container.PositionLogRepository,
 		container.MeasurementRepository,
 		container.EventPublisher,
 		idempotencySvc,
+		serviceOpts...,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create position keeping service: %w", err)
@@ -459,4 +517,16 @@ func (h *healthServer) Watch(_ *grpc_health_v1.HealthCheckRequest, stream grpc_h
 			}
 		}
 	}
+}
+
+// currentAccountClientAdapter adapts the generated gRPC client to the service.CurrentAccountClient interface.
+// This adapter is needed because the service package defines its own interface for testability,
+// while the generated client has a different method signature.
+type currentAccountClientAdapter struct {
+	client currentaccountv1.CurrentAccountServiceClient
+}
+
+// RetrieveCurrentAccount implements service.CurrentAccountClient by delegating to the generated client.
+func (a *currentAccountClientAdapter) RetrieveCurrentAccount(ctx context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+	return a.client.RetrieveCurrentAccount(ctx, req)
 }

--- a/services/position-keeping/cmd/main_test.go
+++ b/services/position-keeping/cmd/main_test.go
@@ -42,7 +42,11 @@ func TestHealthServer_Check_WithHealthyDatabase(t *testing.T) {
 	// This test requires a real database connection
 	// Set up minimal environment
 	_ = os.Setenv("DATABASE_URL", "postgres://test:test@localhost:5432/testdb")
-	defer func() { _ = os.Unsetenv("DATABASE_URL") }()
+	_ = os.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
+	defer func() {
+		_ = os.Unsetenv("DATABASE_URL")
+		_ = os.Unsetenv("ACCOUNT_VALIDATION_ENABLED")
+	}()
 
 	config, err := app.LoadConfig()
 	if err != nil {
@@ -99,7 +103,11 @@ func TestHealthServer_Check_WithHealthyDatabase(t *testing.T) {
 func TestHealthServer_Check_ReturnsResponse(t *testing.T) {
 	// This test doesn't require a real database - just validates structure
 	_ = os.Setenv("DATABASE_URL", "postgres://test:test@localhost:5432/testdb")
-	defer func() { _ = os.Unsetenv("DATABASE_URL") }()
+	_ = os.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
+	defer func() {
+		_ = os.Unsetenv("DATABASE_URL")
+		_ = os.Unsetenv("ACCOUNT_VALIDATION_ENABLED")
+	}()
 
 	config, err := app.LoadConfig()
 	if err != nil {
@@ -153,7 +161,11 @@ func TestHealthServer_Check_ReturnsResponse(t *testing.T) {
 
 func TestHealthServer_Watch_SendsInitialStatus(t *testing.T) {
 	_ = os.Setenv("DATABASE_URL", "postgres://test:test@localhost:5432/testdb")
-	defer func() { _ = os.Unsetenv("DATABASE_URL") }()
+	_ = os.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
+	defer func() {
+		_ = os.Unsetenv("DATABASE_URL")
+		_ = os.Unsetenv("ACCOUNT_VALIDATION_ENABLED")
+	}()
 
 	config, err := app.LoadConfig()
 	if err != nil {
@@ -225,7 +237,11 @@ func TestHealthServer_Watch_SendsInitialStatus(t *testing.T) {
 
 func TestHealthServer_Watch_RespectsContext(t *testing.T) {
 	_ = os.Setenv("DATABASE_URL", "postgres://test:test@localhost:5432/testdb")
-	defer func() { _ = os.Unsetenv("DATABASE_URL") }()
+	_ = os.Setenv("ACCOUNT_VALIDATION_ENABLED", "false")
+	defer func() {
+		_ = os.Unsetenv("DATABASE_URL")
+		_ = os.Unsetenv("ACCOUNT_VALIDATION_ENABLED")
+	}()
 
 	config, err := app.LoadConfig()
 	if err != nil {

--- a/services/position-keeping/service/account_validator.go
+++ b/services/position-keeping/service/account_validator.go
@@ -9,6 +9,7 @@ import (
 
 	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -154,7 +155,7 @@ func (v *CurrentAccountValidator) ValidateExists(ctx context.Context, accountID 
 		v.mu.RUnlock()
 
 		// Create a timeout context for the lookup to enable faster fallback
-		lookupCtx, cancel := context.WithTimeout(ctx, v.lookupTimeout)
+		lookupCtx, cancel := clients.WithTimeout(ctx, v.lookupTimeout)
 		defer cancel()
 
 		// Query the Current Account service
@@ -349,7 +350,7 @@ func (v *InternalBankAccountValidator) ValidateExists(ctx context.Context, accou
 		v.mu.RUnlock()
 
 		// Create a timeout context for the lookup to enable faster fallback
-		lookupCtx, cancel := context.WithTimeout(ctx, v.lookupTimeout)
+		lookupCtx, cancel := clients.WithTimeout(ctx, v.lookupTimeout)
 		defer cancel()
 
 		// Query the Internal Bank Account service

--- a/services/position-keeping/service/account_validator.go
+++ b/services/position-keeping/service/account_validator.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -243,4 +244,280 @@ func (v *CurrentAccountValidator) InvalidateCacheEntry(accountID string) {
 	delete(v.cache, accountID)
 	v.logger.Debug("validation cache entry invalidated",
 		"account_id", accountID)
+}
+
+// InternalBankAccountClient defines the interface for the Internal Bank Account gRPC client.
+// This abstraction allows for easy testing and decoupling from the generated client.
+type InternalBankAccountClient interface {
+	RetrieveInternalBankAccount(ctx context.Context, req *internalbankaccountv1.RetrieveInternalBankAccountRequest) (*internalbankaccountv1.RetrieveInternalBankAccountResponse, error)
+}
+
+// InternalBankAccountValidator validates accounts using the Internal Bank Account service.
+// It implements the AccountValidator interface with caching and graceful degradation.
+//
+// Thread-safe: All methods can be called concurrently from multiple goroutines.
+// Uses singleflight to prevent cache stampede (multiple concurrent requests for the same key).
+type InternalBankAccountValidator struct {
+	client InternalBankAccountClient
+	logger *slog.Logger
+
+	// Cache configuration
+	cacheTTL      time.Duration
+	lookupTimeout time.Duration
+
+	// Thread-safe cache: key is accountID
+	mu    sync.RWMutex
+	cache map[string]validationCacheEntry
+
+	// Singleflight to coalesce concurrent requests for the same account
+	sfGroup singleflight.Group
+}
+
+// InternalBankAccountValidatorConfig holds configuration for creating an InternalBankAccountValidator.
+type InternalBankAccountValidatorConfig struct {
+	// Client is the Internal Bank Account gRPC client.
+	Client InternalBankAccountClient
+
+	// Logger is used for logging validator operations.
+	Logger *slog.Logger
+
+	// CacheTTL is how long validation results are cached.
+	// Defaults to 1 minute if not specified.
+	CacheTTL time.Duration
+
+	// LookupTimeout is the timeout for individual lookup requests to the Internal Bank Account service.
+	// Defaults to 2 seconds if not specified.
+	LookupTimeout time.Duration
+}
+
+// NewInternalBankAccountValidator creates a new InternalBankAccountValidator with the given configuration.
+// Returns an error if required configuration is missing.
+func NewInternalBankAccountValidator(cfg InternalBankAccountValidatorConfig) (*InternalBankAccountValidator, error) {
+	if cfg.Client == nil {
+		return nil, status.Error(codes.Internal, "internal bank account client cannot be nil")
+	}
+	if cfg.Logger == nil {
+		return nil, ErrAccountValidatorLoggerNil
+	}
+
+	ttl := cfg.CacheTTL
+	if ttl == 0 {
+		ttl = DefaultValidationCacheTTL
+	}
+
+	lookupTimeout := cfg.LookupTimeout
+	if lookupTimeout == 0 {
+		lookupTimeout = DefaultValidationLookupTimeout
+	}
+
+	return &InternalBankAccountValidator{
+		client:        cfg.Client,
+		logger:        cfg.Logger,
+		cacheTTL:      ttl,
+		lookupTimeout: lookupTimeout,
+		cache:         make(map[string]validationCacheEntry),
+	}, nil
+}
+
+// ValidateExists checks if an account exists using the Internal Bank Account service.
+// Returns nil if the account exists or if the service is unavailable (graceful degradation).
+// Returns codes.InvalidArgument if the account does not exist.
+func (v *InternalBankAccountValidator) ValidateExists(ctx context.Context, accountID string) error {
+	// Check cache first (read lock)
+	v.mu.RLock()
+	if entry, ok := v.cache[accountID]; ok && time.Now().Before(entry.expiresAt) {
+		v.mu.RUnlock()
+		v.logger.Debug("cache hit for internal account validation",
+			"account_id", accountID,
+			"exists", entry.exists)
+		if !entry.exists {
+			return status.Errorf(codes.InvalidArgument, "internal bank account not found: %s", accountID)
+		}
+		return nil
+	}
+	v.mu.RUnlock()
+
+	// Use singleflight to coalesce concurrent requests for the same account.
+	start := time.Now()
+	result, err, shared := v.sfGroup.Do(accountID, func() (interface{}, error) {
+		// Double-check cache after acquiring the singleflight "lock"
+		v.mu.RLock()
+		if entry, ok := v.cache[accountID]; ok && time.Now().Before(entry.expiresAt) {
+			v.mu.RUnlock()
+			return entry.exists, nil
+		}
+		v.mu.RUnlock()
+
+		// Create a timeout context for the lookup to enable faster fallback
+		lookupCtx, cancel := context.WithTimeout(ctx, v.lookupTimeout)
+		defer cancel()
+
+		// Query the Internal Bank Account service
+		exists, lookupErr := v.queryInternalBankAccount(lookupCtx, accountID)
+		if lookupErr != nil {
+			// Graceful degradation: if service is unavailable, allow the operation
+			v.logger.Warn("internal bank account service unavailable, skipping validation",
+				"account_id", accountID,
+				"error", lookupErr)
+			return true, nil // Return true to allow operation
+		}
+
+		// Cache the result (write lock)
+		v.mu.Lock()
+		v.cache[accountID] = validationCacheEntry{
+			exists:    exists,
+			expiresAt: time.Now().Add(v.cacheTTL),
+		}
+		v.mu.Unlock()
+
+		return exists, nil
+	})
+
+	if err != nil {
+		v.logger.Error("unexpected error during internal account validation",
+			"account_id", accountID,
+			"error", err)
+		return nil // Graceful degradation
+	}
+
+	exists, ok := result.(bool)
+	if !ok {
+		v.logger.Error("internal error: unexpected result type from singleflight",
+			"account_id", accountID)
+		return nil // Graceful degradation
+	}
+
+	v.logger.Debug("internal account validation completed",
+		"account_id", accountID,
+		"exists", exists,
+		"duration_ms", time.Since(start).Milliseconds(),
+		"shared", shared)
+
+	if !exists {
+		return status.Errorf(codes.InvalidArgument, "internal bank account not found: %s", accountID)
+	}
+
+	return nil
+}
+
+// queryInternalBankAccount queries the Internal Bank Account service to check if an account exists.
+// Returns (true, nil) if account exists, (false, nil) if not found, or (false, error) on service error.
+func (v *InternalBankAccountValidator) queryInternalBankAccount(ctx context.Context, accountID string) (bool, error) {
+	resp, err := v.client.RetrieveInternalBankAccount(ctx, &internalbankaccountv1.RetrieveInternalBankAccountRequest{
+		AccountId: accountID,
+	})
+	if err != nil {
+		// Check if it's a NotFound error - that means the account doesn't exist
+		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+			v.logger.Debug("account not found in internal bank account service",
+				"account_id", accountID)
+			return false, nil
+		}
+		// Any other error is a service availability issue
+		return false, err
+	}
+
+	// Account exists if we got a valid response with a facility
+	exists := resp != nil && resp.Facility != nil
+	return exists, nil
+}
+
+// CompositeAccountValidator validates accounts by checking multiple services.
+// It tries each validator in order and returns success if any validator finds the account.
+// This allows Position Keeping to validate accounts from both Current Account and Internal Bank Account.
+//
+// Validation order: Current Account -> Internal Bank Account
+// - If found in Current Account: success
+// - If NotFound in Current Account, check Internal Bank Account
+// - If found in Internal Bank Account: success
+// - If NotFound in both: return InvalidArgument error
+// - If any service is unavailable: graceful degradation (allow operation)
+type CompositeAccountValidator struct {
+	currentAccountValidator      *CurrentAccountValidator
+	internalBankAccountValidator *InternalBankAccountValidator
+	logger                       *slog.Logger
+}
+
+// CompositeAccountValidatorConfig holds configuration for creating a CompositeAccountValidator.
+type CompositeAccountValidatorConfig struct {
+	// CurrentAccountValidator validates customer-facing accounts.
+	// Optional - if nil, current account validation is skipped.
+	CurrentAccountValidator *CurrentAccountValidator
+
+	// InternalBankAccountValidator validates internal bank accounts.
+	// Optional - if nil, internal bank account validation is skipped.
+	InternalBankAccountValidator *InternalBankAccountValidator
+
+	// Logger is used for logging validator operations.
+	Logger *slog.Logger
+}
+
+// NewCompositeAccountValidator creates a new CompositeAccountValidator with the given configuration.
+// At least one validator must be provided.
+func NewCompositeAccountValidator(cfg CompositeAccountValidatorConfig) (*CompositeAccountValidator, error) {
+	if cfg.CurrentAccountValidator == nil && cfg.InternalBankAccountValidator == nil {
+		return nil, status.Error(codes.Internal, "at least one account validator must be provided")
+	}
+	if cfg.Logger == nil {
+		return nil, ErrAccountValidatorLoggerNil
+	}
+
+	return &CompositeAccountValidator{
+		currentAccountValidator:      cfg.CurrentAccountValidator,
+		internalBankAccountValidator: cfg.InternalBankAccountValidator,
+		logger:                       cfg.Logger,
+	}, nil
+}
+
+// ValidateExists checks if an account exists by trying multiple services.
+// Returns nil if the account exists in either Current Account or Internal Bank Account.
+// Returns codes.InvalidArgument if the account is not found in any service.
+// Returns nil on service unavailability (graceful degradation).
+func (v *CompositeAccountValidator) ValidateExists(ctx context.Context, accountID string) error {
+	// Try Current Account first (most common case - customer accounts)
+	if v.currentAccountValidator != nil {
+		err := v.currentAccountValidator.ValidateExists(ctx, accountID)
+		if err == nil {
+			// Found in Current Account
+			v.logger.Debug("account found in current account service",
+				"account_id", accountID)
+			return nil
+		}
+
+		// Check if it's an InvalidArgument (not found) vs other errors
+		if st, ok := status.FromError(err); ok && st.Code() == codes.InvalidArgument {
+			// Not found in Current Account - try Internal Bank Account
+			v.logger.Debug("account not found in current account, trying internal bank account",
+				"account_id", accountID)
+		} else {
+			// Other error (service unavailable) - graceful degradation already handled
+			return nil
+		}
+	}
+
+	// Try Internal Bank Account
+	if v.internalBankAccountValidator != nil {
+		err := v.internalBankAccountValidator.ValidateExists(ctx, accountID)
+		if err == nil {
+			// Found in Internal Bank Account
+			v.logger.Debug("account found in internal bank account service",
+				"account_id", accountID)
+			return nil
+		}
+
+		// Check if it's an InvalidArgument (not found)
+		if st, ok := status.FromError(err); ok && st.Code() == codes.InvalidArgument {
+			// Not found in Internal Bank Account either
+			v.logger.Debug("account not found in internal bank account service",
+				"account_id", accountID)
+		} else {
+			// Other error (service unavailable) - graceful degradation already handled
+			return nil
+		}
+	}
+
+	// Account not found in any service
+	v.logger.Warn("account not found in any account service",
+		"account_id", accountID)
+	return status.Errorf(codes.InvalidArgument, "account not found: %s", accountID)
 }

--- a/services/position-keeping/service/account_validator.go
+++ b/services/position-keeping/service/account_validator.go
@@ -1,0 +1,246 @@
+// Package service implements gRPC services for the position keeping domain.
+package service
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"golang.org/x/sync/singleflight"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// AccountValidator validates that accounts exist before creating position logs.
+// This interface allows Position Keeping to validate account existence without
+// direct coupling to the Current Account implementation details.
+type AccountValidator interface {
+	// ValidateExists checks if an account exists and is valid for position tracking.
+	// Returns nil if the account exists and is valid.
+	// Returns codes.InvalidArgument error if the account does not exist.
+	// Returns nil on service unavailability (graceful degradation).
+	ValidateExists(ctx context.Context, accountID string) error
+}
+
+// AccountValidatorErrors defines sentinel errors for the AccountValidator.
+var (
+	// ErrAccountValidatorClientNil is returned when attempting to create an AccountValidator with a nil client.
+	ErrAccountValidatorClientNil = status.Error(codes.Internal, "current account client cannot be nil")
+
+	// ErrAccountValidatorLoggerNil is returned when attempting to create an AccountValidator with a nil logger.
+	ErrAccountValidatorLoggerNil = status.Error(codes.Internal, "logger cannot be nil")
+)
+
+// CurrentAccountClient defines the interface for the Current Account gRPC client.
+// This abstraction allows for easy testing and decoupling from the generated client.
+type CurrentAccountClient interface {
+	RetrieveCurrentAccount(ctx context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error)
+}
+
+// validationCacheEntry holds a cached validation result with its expiration time.
+type validationCacheEntry struct {
+	exists    bool
+	expiresAt time.Time
+}
+
+// CurrentAccountValidator validates accounts using the Current Account service.
+// It implements the AccountValidator interface with caching and graceful degradation.
+//
+// Thread-safe: All methods can be called concurrently from multiple goroutines.
+// Uses singleflight to prevent cache stampede (multiple concurrent requests for the same key).
+type CurrentAccountValidator struct {
+	client CurrentAccountClient
+	logger *slog.Logger
+
+	// Cache configuration
+	cacheTTL      time.Duration
+	lookupTimeout time.Duration
+
+	// Thread-safe cache: key is accountID
+	mu    sync.RWMutex
+	cache map[string]validationCacheEntry
+
+	// Singleflight to coalesce concurrent requests for the same account
+	sfGroup singleflight.Group
+}
+
+// CurrentAccountValidatorConfig holds configuration for creating a CurrentAccountValidator.
+type CurrentAccountValidatorConfig struct {
+	// Client is the Current Account gRPC client.
+	Client CurrentAccountClient
+
+	// Logger is used for logging validator operations.
+	Logger *slog.Logger
+
+	// CacheTTL is how long validation results are cached.
+	// Defaults to 1 minute if not specified.
+	CacheTTL time.Duration
+
+	// LookupTimeout is the timeout for individual lookup requests to the Current Account service.
+	// Defaults to 2 seconds if not specified.
+	LookupTimeout time.Duration
+}
+
+const (
+	// DefaultValidationCacheTTL is the default cache TTL for validation results.
+	DefaultValidationCacheTTL = 1 * time.Minute
+
+	// DefaultValidationLookupTimeout is the default timeout for account validation lookups.
+	// This is shorter than the typical RPC timeout to allow graceful fallback.
+	DefaultValidationLookupTimeout = 2 * time.Second
+)
+
+// NewCurrentAccountValidator creates a new CurrentAccountValidator with the given configuration.
+// Returns an error if required configuration is missing.
+func NewCurrentAccountValidator(cfg CurrentAccountValidatorConfig) (*CurrentAccountValidator, error) {
+	if cfg.Client == nil {
+		return nil, ErrAccountValidatorClientNil
+	}
+	if cfg.Logger == nil {
+		return nil, ErrAccountValidatorLoggerNil
+	}
+
+	ttl := cfg.CacheTTL
+	if ttl == 0 {
+		ttl = DefaultValidationCacheTTL
+	}
+
+	lookupTimeout := cfg.LookupTimeout
+	if lookupTimeout == 0 {
+		lookupTimeout = DefaultValidationLookupTimeout
+	}
+
+	return &CurrentAccountValidator{
+		client:        cfg.Client,
+		logger:        cfg.Logger,
+		cacheTTL:      ttl,
+		lookupTimeout: lookupTimeout,
+		cache:         make(map[string]validationCacheEntry),
+	}, nil
+}
+
+// ValidateExists checks if an account exists using the Current Account service.
+// Returns nil if the account exists or if the service is unavailable (graceful degradation).
+// Returns codes.InvalidArgument if the account does not exist.
+func (v *CurrentAccountValidator) ValidateExists(ctx context.Context, accountID string) error {
+	// Check cache first (read lock)
+	v.mu.RLock()
+	if entry, ok := v.cache[accountID]; ok && time.Now().Before(entry.expiresAt) {
+		v.mu.RUnlock()
+		v.logger.Debug("cache hit for account validation",
+			"account_id", accountID,
+			"exists", entry.exists)
+		if !entry.exists {
+			return status.Errorf(codes.InvalidArgument, "account not found: %s", accountID)
+		}
+		return nil
+	}
+	v.mu.RUnlock()
+
+	// Use singleflight to coalesce concurrent requests for the same account.
+	// This prevents cache stampede when multiple goroutines validate the same account simultaneously.
+	start := time.Now()
+	result, err, shared := v.sfGroup.Do(accountID, func() (interface{}, error) {
+		// Double-check cache after acquiring the singleflight "lock"
+		// Another goroutine might have already populated the cache
+		v.mu.RLock()
+		if entry, ok := v.cache[accountID]; ok && time.Now().Before(entry.expiresAt) {
+			v.mu.RUnlock()
+			return entry.exists, nil
+		}
+		v.mu.RUnlock()
+
+		// Create a timeout context for the lookup to enable faster fallback
+		lookupCtx, cancel := context.WithTimeout(ctx, v.lookupTimeout)
+		defer cancel()
+
+		// Query the Current Account service
+		exists, lookupErr := v.queryCurrentAccount(lookupCtx, accountID)
+		if lookupErr != nil {
+			// Graceful degradation: if service is unavailable, allow the operation
+			v.logger.Warn("current account service unavailable, skipping validation",
+				"account_id", accountID,
+				"error", lookupErr)
+			return true, nil // Return true to allow operation
+		}
+
+		// Cache the result (write lock)
+		v.mu.Lock()
+		v.cache[accountID] = validationCacheEntry{
+			exists:    exists,
+			expiresAt: time.Now().Add(v.cacheTTL),
+		}
+		v.mu.Unlock()
+
+		return exists, nil
+	})
+
+	if err != nil {
+		// This shouldn't happen with our implementation, but handle it gracefully
+		v.logger.Error("unexpected error during account validation",
+			"account_id", accountID,
+			"error", err)
+		return nil // Graceful degradation
+	}
+
+	exists, ok := result.(bool)
+	if !ok {
+		// This should never happen as we control the singleflight function return type
+		v.logger.Error("internal error: unexpected result type from singleflight",
+			"account_id", accountID)
+		return nil // Graceful degradation
+	}
+
+	v.logger.Debug("account validation completed",
+		"account_id", accountID,
+		"exists", exists,
+		"duration_ms", time.Since(start).Milliseconds(),
+		"shared", shared)
+
+	if !exists {
+		return status.Errorf(codes.InvalidArgument, "account not found: %s", accountID)
+	}
+
+	return nil
+}
+
+// queryCurrentAccount queries the Current Account service to check if an account exists.
+// Returns (true, nil) if account exists, (false, nil) if not found, or (false, error) on service error.
+func (v *CurrentAccountValidator) queryCurrentAccount(ctx context.Context, accountID string) (bool, error) {
+	resp, err := v.client.RetrieveCurrentAccount(ctx, &currentaccountv1.RetrieveCurrentAccountRequest{
+		AccountId: accountID,
+	})
+	if err != nil {
+		// Check if it's a NotFound error - that means the account doesn't exist
+		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+			v.logger.Debug("account not found in current account service",
+				"account_id", accountID)
+			return false, nil
+		}
+		// Any other error is a service availability issue
+		return false, err
+	}
+
+	// Account exists if we got a valid response with a facility
+	exists := resp != nil && resp.Facility != nil
+	return exists, nil
+}
+
+// InvalidateCache clears all cached entries. Useful for testing or when accounts are modified.
+func (v *CurrentAccountValidator) InvalidateCache() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.cache = make(map[string]validationCacheEntry)
+	v.logger.Debug("validation cache invalidated")
+}
+
+// InvalidateCacheEntry removes a specific entry from the cache.
+func (v *CurrentAccountValidator) InvalidateCacheEntry(accountID string) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	delete(v.cache, accountID)
+	v.logger.Debug("validation cache entry invalidated",
+		"account_id", accountID)
+}

--- a/services/position-keeping/service/account_validator_test.go
+++ b/services/position-keeping/service/account_validator_test.go
@@ -1,0 +1,487 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mockCurrentAccountClient is a test double for the Current Account client
+type mockCurrentAccountClient struct {
+	retrieveFunc  func(ctx context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error)
+	callCount     atomic.Int32
+	callCountLock sync.Mutex
+	calls         []string // Track account IDs that were queried
+}
+
+func (m *mockCurrentAccountClient) RetrieveCurrentAccount(ctx context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+	m.callCount.Add(1)
+	m.callCountLock.Lock()
+	m.calls = append(m.calls, req.GetAccountId())
+	m.callCountLock.Unlock()
+	if m.retrieveFunc != nil {
+		return m.retrieveFunc(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockCurrentAccountClient) GetCallCount() int {
+	return int(m.callCount.Load())
+}
+
+func (m *mockCurrentAccountClient) GetCalls() []string {
+	m.callCountLock.Lock()
+	defer m.callCountLock.Unlock()
+	result := make([]string, len(m.calls))
+	copy(result, m.calls)
+	return result
+}
+
+func TestNewCurrentAccountValidator(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{}
+
+	t.Run("creates validator with valid config", func(t *testing.T) {
+		validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+			Client: client,
+			Logger: logger,
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, validator)
+	})
+
+	t.Run("returns error when client is nil", func(t *testing.T) {
+		validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+			Client: nil,
+			Logger: logger,
+		})
+
+		require.Error(t, err)
+		assert.Nil(t, validator)
+		assert.Equal(t, codes.Internal, status.Code(err))
+		assert.Contains(t, err.Error(), "client cannot be nil")
+	})
+
+	t.Run("returns error when logger is nil", func(t *testing.T) {
+		validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+			Client: client,
+			Logger: nil,
+		})
+
+		require.Error(t, err)
+		assert.Nil(t, validator)
+		assert.Equal(t, codes.Internal, status.Code(err))
+		assert.Contains(t, err.Error(), "logger cannot be nil")
+	})
+
+	t.Run("uses default TTL when not specified", func(t *testing.T) {
+		validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+			Client: client,
+			Logger: logger,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, DefaultValidationCacheTTL, validator.cacheTTL)
+	})
+
+	t.Run("uses custom TTL when specified", func(t *testing.T) {
+		customTTL := 5 * time.Minute
+		validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+			Client:   client,
+			Logger:   logger,
+			CacheTTL: customTTL,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, customTTL, validator.cacheTTL)
+	})
+
+	t.Run("uses default lookup timeout when not specified", func(t *testing.T) {
+		validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+			Client: client,
+			Logger: logger,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, DefaultValidationLookupTimeout, validator.lookupTimeout)
+	})
+}
+
+func TestValidateExists_ValidAccount(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					AccountId: req.GetAccountId(),
+				},
+			}, nil
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client: client,
+		Logger: logger,
+	})
+	require.NoError(t, err)
+
+	err = validator.ValidateExists(context.Background(), "valid-account-123")
+
+	assert.NoError(t, err)
+	assert.Equal(t, 1, client.GetCallCount())
+}
+
+func TestValidateExists_InvalidAccount(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return nil, status.Error(codes.NotFound, "account not found")
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client: client,
+		Logger: logger,
+	})
+	require.NoError(t, err)
+
+	err = validator.ValidateExists(context.Background(), "invalid-account-123")
+
+	require.Error(t, err)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "account not found")
+	assert.Contains(t, err.Error(), "invalid-account-123")
+}
+
+func TestValidateExists_CacheHit(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					AccountId: req.GetAccountId(),
+				},
+			}, nil
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client:   client,
+		Logger:   logger,
+		CacheTTL: 5 * time.Minute, // Long TTL to ensure cache hit
+	})
+	require.NoError(t, err)
+
+	// First call - should hit the service
+	err = validator.ValidateExists(context.Background(), "cached-account-123")
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.GetCallCount())
+
+	// Second call - should hit cache
+	err = validator.ValidateExists(context.Background(), "cached-account-123")
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.GetCallCount()) // Count should NOT increase
+}
+
+func TestValidateExists_CacheMiss(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					AccountId: req.GetAccountId(),
+				},
+			}, nil
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client:   client,
+		Logger:   logger,
+		CacheTTL: 1 * time.Millisecond, // Very short TTL to ensure cache miss
+	})
+	require.NoError(t, err)
+
+	// First call
+	err = validator.ValidateExists(context.Background(), "cache-miss-account")
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.GetCallCount())
+
+	// Wait for cache to expire
+	time.Sleep(5 * time.Millisecond)
+
+	// Second call - cache should have expired
+	err = validator.ValidateExists(context.Background(), "cache-miss-account")
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.GetCallCount()) // Count should increase
+}
+
+func TestValidateExists_ServiceUnavailable_GracefulDegradation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return nil, status.Error(codes.Unavailable, "service unavailable")
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client: client,
+		Logger: logger,
+	})
+	require.NoError(t, err)
+
+	// Service is unavailable - validation should pass (graceful degradation)
+	err = validator.ValidateExists(context.Background(), "any-account-123")
+
+	assert.NoError(t, err) // Should NOT return error - graceful degradation
+}
+
+func TestValidateExists_InternalError_GracefulDegradation(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return nil, status.Error(codes.Internal, "internal server error")
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client: client,
+		Logger: logger,
+	})
+	require.NoError(t, err)
+
+	// Internal error - validation should pass (graceful degradation)
+	err = validator.ValidateExists(context.Background(), "any-account-123")
+
+	assert.NoError(t, err) // Should NOT return error - graceful degradation
+}
+
+func TestValidateExists_CachesInvalidAccountResult(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, _ *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return nil, status.Error(codes.NotFound, "account not found")
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client:   client,
+		Logger:   logger,
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// First call - should hit the service and cache the "not found" result
+	err1 := validator.ValidateExists(context.Background(), "invalid-cached-account")
+	require.Error(t, err1)
+	assert.Equal(t, 1, client.GetCallCount())
+
+	// Second call - should hit cache (returning "not found" from cache)
+	err2 := validator.ValidateExists(context.Background(), "invalid-cached-account")
+	require.Error(t, err2)
+	assert.Equal(t, 1, client.GetCallCount()) // Count should NOT increase
+}
+
+func TestValidateExists_ConcurrentRequests_NoStampede(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	callCount := atomic.Int32{}
+
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			callCount.Add(1)
+			// Simulate slow service response
+			time.Sleep(50 * time.Millisecond)
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					AccountId: req.GetAccountId(),
+				},
+			}, nil
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client:        client,
+		Logger:        logger,
+		LookupTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Start multiple concurrent validations for the same account
+	var wg sync.WaitGroup
+	const numGoroutines = 10
+	errors := make([]error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errors[idx] = validator.ValidateExists(context.Background(), "stampede-test-account")
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All validations should succeed
+	for i, err := range errors {
+		assert.NoError(t, err, "goroutine %d failed", i)
+	}
+
+	// Service should only be called once due to singleflight
+	assert.Equal(t, int32(1), callCount.Load(), "singleflight should coalesce requests")
+}
+
+func TestValidateExists_DifferentAccounts_SeparateCalls(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					AccountId: req.GetAccountId(),
+				},
+			}, nil
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client: client,
+		Logger: logger,
+	})
+	require.NoError(t, err)
+
+	// Validate different accounts
+	err = validator.ValidateExists(context.Background(), "account-1")
+	require.NoError(t, err)
+
+	err = validator.ValidateExists(context.Background(), "account-2")
+	require.NoError(t, err)
+
+	err = validator.ValidateExists(context.Background(), "account-3")
+	require.NoError(t, err)
+
+	// Each account should trigger a separate service call
+	assert.Equal(t, 3, client.GetCallCount())
+	calls := client.GetCalls()
+	assert.Contains(t, calls, "account-1")
+	assert.Contains(t, calls, "account-2")
+	assert.Contains(t, calls, "account-3")
+}
+
+func TestInvalidateCache(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					AccountId: req.GetAccountId(),
+				},
+			}, nil
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client:   client,
+		Logger:   logger,
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// Populate cache
+	err = validator.ValidateExists(context.Background(), "cache-invalidate-test")
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.GetCallCount())
+
+	// Verify cache is hit
+	err = validator.ValidateExists(context.Background(), "cache-invalidate-test")
+	require.NoError(t, err)
+	assert.Equal(t, 1, client.GetCallCount())
+
+	// Invalidate entire cache
+	validator.InvalidateCache()
+
+	// Next call should hit service again
+	err = validator.ValidateExists(context.Background(), "cache-invalidate-test")
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.GetCallCount())
+}
+
+func TestInvalidateCacheEntry(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(_ context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			return &currentaccountv1.RetrieveCurrentAccountResponse{
+				Facility: &currentaccountv1.CurrentAccountFacility{
+					AccountId: req.GetAccountId(),
+				},
+			}, nil
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client:   client,
+		Logger:   logger,
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// Populate cache with two accounts
+	err = validator.ValidateExists(context.Background(), "account-keep")
+	require.NoError(t, err)
+	err = validator.ValidateExists(context.Background(), "account-remove")
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.GetCallCount())
+
+	// Invalidate only one entry
+	validator.InvalidateCacheEntry("account-remove")
+
+	// account-keep should still be cached
+	err = validator.ValidateExists(context.Background(), "account-keep")
+	require.NoError(t, err)
+	assert.Equal(t, 2, client.GetCallCount()) // No new call
+
+	// account-remove should trigger new call
+	err = validator.ValidateExists(context.Background(), "account-remove")
+	require.NoError(t, err)
+	assert.Equal(t, 3, client.GetCallCount()) // New call made
+}
+
+func TestValidateExists_ContextTimeout(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	client := &mockCurrentAccountClient{
+		retrieveFunc: func(ctx context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+			// Simulate slow response that exceeds timeout
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(5 * time.Second):
+				return &currentaccountv1.RetrieveCurrentAccountResponse{
+					Facility: &currentaccountv1.CurrentAccountFacility{
+						AccountId: req.GetAccountId(),
+					},
+				}, nil
+			}
+		},
+	}
+
+	validator, err := NewCurrentAccountValidator(CurrentAccountValidatorConfig{
+		Client:        client,
+		Logger:        logger,
+		LookupTimeout: 50 * time.Millisecond, // Very short timeout
+	})
+	require.NoError(t, err)
+
+	// Validation should gracefully degrade (return nil) when timeout occurs
+	err = validator.ValidateExists(context.Background(), "timeout-test-account")
+
+	assert.NoError(t, err) // Graceful degradation - allow operation
+}

--- a/services/position-keeping/service/initiate.go
+++ b/services/position-keeping/service/initiate.go
@@ -52,6 +52,16 @@ func (s *PositionKeepingService) InitiateFinancialPositionLog(
 		return nil, status.Errorf(codes.Canceled, "request cancelled: %v", err)
 	}
 
+	// Validate account exists if validation is enabled
+	// This check ensures we don't create position logs for non-existent accounts.
+	// The validator uses graceful degradation: if Current Account service is unavailable,
+	// validation is skipped to avoid blocking operations during service outages.
+	if s.accountValidationEnabled && s.accountValidator != nil {
+		if err := s.accountValidator.ValidateExists(ctx, req.AccountId); err != nil {
+			return nil, err // Returns codes.InvalidArgument if account not found
+		}
+	}
+
 	// Convert initial entry from proto to domain if provided
 	var initialEntry *domain.TransactionLogEntry
 	if req.InitialEntry != nil {

--- a/services/position-keeping/service/initiate_validation_test.go
+++ b/services/position-keeping/service/initiate_validation_test.go
@@ -1,0 +1,413 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/money"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/services/position-keeping/service"
+	"github.com/meridianhub/meridian/shared/pkg/idempotency"
+)
+
+// MockAccountValidator is a mock implementation of AccountValidator
+type MockAccountValidator struct {
+	mock.Mock
+}
+
+func (m *MockAccountValidator) ValidateExists(ctx context.Context, accountID string) error {
+	args := m.Called(ctx, accountID)
+	return args.Error(0)
+}
+
+func TestInitiateFinancialPositionLog_AccountValidation_Enabled_ValidAccount(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockValidator := new(MockAccountValidator)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithAccountValidator(mockValidator),
+		service.WithAccountValidationEnabled(true),
+	)
+	require.NoError(t, err)
+
+	req := &positionkeepingv1.InitiateFinancialPositionLogRequest{
+		AccountId: "valid-account-123",
+		InitialEntry: &positionkeepingv1.TransactionLogEntry{
+			EntryId:       uuid.NewString(),
+			TransactionId: uuid.NewString(),
+			AccountId:     "valid-account-123",
+			Amount: &commonv1.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: "GBP",
+					Units:        100,
+					Nanos:        0,
+				},
+			},
+			Direction:   commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+			Description: "Test transaction",
+		},
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.NewString(),
+		},
+	}
+
+	// Mock idempotency check - no previous operation
+	mockIdempotency.On("Check", ctx, mock.AnythingOfType("idempotency.Key")).
+		Return(nil, idempotency.ErrResultNotFound)
+	mockIdempotency.On("MarkPending", ctx, mock.AnythingOfType("idempotency.Key"), mock.AnythingOfType("time.Duration")).
+		Return(nil)
+
+	// Mock account validation - account exists
+	mockValidator.On("ValidateExists", ctx, "valid-account-123").Return(nil)
+
+	// Mock repository create
+	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	// Mock idempotency store result
+	mockIdempotency.On("StoreResult", ctx, mock.AnythingOfType("idempotency.Result")).Return(nil)
+
+	// Act
+	resp, err := svc.InitiateFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "valid-account-123", resp.Log.AccountId)
+
+	// Verify validator was called
+	mockValidator.AssertCalled(t, "ValidateExists", ctx, "valid-account-123")
+	mockRepo.AssertExpectations(t)
+}
+
+func TestInitiateFinancialPositionLog_AccountValidation_Enabled_InvalidAccount(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockValidator := new(MockAccountValidator)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithAccountValidator(mockValidator),
+		service.WithAccountValidationEnabled(true),
+	)
+	require.NoError(t, err)
+
+	req := &positionkeepingv1.InitiateFinancialPositionLogRequest{
+		AccountId: "invalid-account-456",
+		InitialEntry: &positionkeepingv1.TransactionLogEntry{
+			EntryId:       uuid.NewString(),
+			TransactionId: uuid.NewString(),
+			AccountId:     "invalid-account-456",
+			Amount: &commonv1.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: "GBP",
+					Units:        100,
+					Nanos:        0,
+				},
+			},
+			Direction:   commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+			Description: "Test transaction",
+		},
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.NewString(),
+		},
+	}
+
+	// Mock idempotency check - no previous operation
+	mockIdempotency.On("Check", ctx, mock.AnythingOfType("idempotency.Key")).
+		Return(nil, idempotency.ErrResultNotFound)
+	mockIdempotency.On("MarkPending", ctx, mock.AnythingOfType("idempotency.Key"), mock.AnythingOfType("time.Duration")).
+		Return(nil)
+	// When validation fails, the idempotency key is deleted to allow retry
+	mockIdempotency.On("Delete", ctx, mock.AnythingOfType("idempotency.Key")).Return(nil)
+
+	// Mock account validation - account NOT found
+	mockValidator.On("ValidateExists", ctx, "invalid-account-456").
+		Return(status.Error(codes.InvalidArgument, "account not found: invalid-account-456"))
+
+	// Act
+	resp, err := svc.InitiateFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	assert.Contains(t, err.Error(), "account not found")
+	assert.Contains(t, err.Error(), "invalid-account-456")
+
+	// Verify validator was called but repository was NOT called
+	mockValidator.AssertCalled(t, "ValidateExists", ctx, "invalid-account-456")
+	mockRepo.AssertNotCalled(t, "Create")
+}
+
+func TestInitiateFinancialPositionLog_AccountValidation_Disabled_SkipsValidation(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockValidator := new(MockAccountValidator)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+
+	// Validation disabled (default) - even with validator set
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithAccountValidator(mockValidator),
+		// WithAccountValidationEnabled not called - defaults to false
+	)
+	require.NoError(t, err)
+
+	req := &positionkeepingv1.InitiateFinancialPositionLogRequest{
+		AccountId: "any-account-789",
+		InitialEntry: &positionkeepingv1.TransactionLogEntry{
+			EntryId:       uuid.NewString(),
+			TransactionId: uuid.NewString(),
+			AccountId:     "any-account-789",
+			Amount: &commonv1.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: "GBP",
+					Units:        100,
+					Nanos:        0,
+				},
+			},
+			Direction:   commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+			Description: "Test transaction",
+		},
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.NewString(),
+		},
+	}
+
+	// Mock idempotency check - no previous operation
+	mockIdempotency.On("Check", ctx, mock.AnythingOfType("idempotency.Key")).
+		Return(nil, idempotency.ErrResultNotFound)
+	mockIdempotency.On("MarkPending", ctx, mock.AnythingOfType("idempotency.Key"), mock.AnythingOfType("time.Duration")).
+		Return(nil)
+
+	// Mock repository create - should be called since validation is disabled
+	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockIdempotency.On("StoreResult", ctx, mock.AnythingOfType("idempotency.Result")).Return(nil)
+
+	// Act
+	resp, err := svc.InitiateFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify validator was NOT called (validation disabled)
+	mockValidator.AssertNotCalled(t, "ValidateExists")
+	// Verify repository WAS called (position log created)
+	mockRepo.AssertCalled(t, "Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog"))
+}
+
+func TestInitiateFinancialPositionLog_AccountValidation_ValidatorNil_SkipsValidation(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+
+	// Validation enabled but no validator provided
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithAccountValidationEnabled(true), // Enabled but...
+		// WithAccountValidator not called - validator is nil
+	)
+	require.NoError(t, err)
+
+	req := &positionkeepingv1.InitiateFinancialPositionLogRequest{
+		AccountId: "any-account-000",
+		InitialEntry: &positionkeepingv1.TransactionLogEntry{
+			EntryId:       uuid.NewString(),
+			TransactionId: uuid.NewString(),
+			AccountId:     "any-account-000",
+			Amount: &commonv1.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: "GBP",
+					Units:        100,
+					Nanos:        0,
+				},
+			},
+			Direction:   commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+			Description: "Test transaction",
+		},
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.NewString(),
+		},
+	}
+
+	// Mock idempotency check - no previous operation
+	mockIdempotency.On("Check", ctx, mock.AnythingOfType("idempotency.Key")).
+		Return(nil, idempotency.ErrResultNotFound)
+	mockIdempotency.On("MarkPending", ctx, mock.AnythingOfType("idempotency.Key"), mock.AnythingOfType("time.Duration")).
+		Return(nil)
+
+	// Mock repository create - should be called since validator is nil
+	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockIdempotency.On("StoreResult", ctx, mock.AnythingOfType("idempotency.Result")).Return(nil)
+
+	// Act
+	resp, err := svc.InitiateFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify repository WAS called (position log created despite enabled flag)
+	mockRepo.AssertCalled(t, "Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog"))
+}
+
+func TestInitiateFinancialPositionLog_AccountValidation_GracefulDegradation(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockValidator := new(MockAccountValidator)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithAccountValidator(mockValidator),
+		service.WithAccountValidationEnabled(true),
+	)
+	require.NoError(t, err)
+
+	req := &positionkeepingv1.InitiateFinancialPositionLogRequest{
+		AccountId: "graceful-account-123",
+		InitialEntry: &positionkeepingv1.TransactionLogEntry{
+			EntryId:       uuid.NewString(),
+			TransactionId: uuid.NewString(),
+			AccountId:     "graceful-account-123",
+			Amount: &commonv1.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: "GBP",
+					Units:        100,
+					Nanos:        0,
+				},
+			},
+			Direction:   commonv1.PostingDirection_POSTING_DIRECTION_DEBIT,
+			Description: "Test transaction",
+		},
+		IdempotencyKey: &commonv1.IdempotencyKey{
+			Key: uuid.NewString(),
+		},
+	}
+
+	// Mock idempotency check - no previous operation
+	mockIdempotency.On("Check", ctx, mock.AnythingOfType("idempotency.Key")).
+		Return(nil, idempotency.ErrResultNotFound)
+	mockIdempotency.On("MarkPending", ctx, mock.AnythingOfType("idempotency.Key"), mock.AnythingOfType("time.Duration")).
+		Return(nil)
+
+	// Mock account validation - service unavailable (graceful degradation returns nil)
+	// Note: The CurrentAccountValidator returns nil on service unavailability
+	mockValidator.On("ValidateExists", ctx, "graceful-account-123").Return(nil)
+
+	// Mock repository create - should be called due to graceful degradation
+	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+	mockIdempotency.On("StoreResult", ctx, mock.AnythingOfType("idempotency.Result")).Return(nil)
+
+	// Act
+	resp, err := svc.InitiateFinancialPositionLog(ctx, req)
+
+	// Assert
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Verify position log was created despite potential service unavailability
+	mockRepo.AssertCalled(t, "Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog"))
+}
+
+func TestWithAccountValidator_Option(t *testing.T) {
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockValidator := new(MockAccountValidator)
+
+	t.Run("sets account validator", func(t *testing.T) {
+		svc, err := service.NewPositionKeepingService(
+			mockRepo,
+			mockMeasurementRepo,
+			mockEventPublisher,
+			mockIdempotency,
+			service.WithAccountValidator(mockValidator),
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, svc)
+	})
+
+	t.Run("allows nil validator", func(t *testing.T) {
+		svc, err := service.NewPositionKeepingService(
+			mockRepo,
+			mockMeasurementRepo,
+			mockEventPublisher,
+			mockIdempotency,
+			service.WithAccountValidator(nil),
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, svc)
+	})
+}
+
+func TestWithAccountValidationEnabled_Option(t *testing.T) {
+	mockRepo := new(MockRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+
+	t.Run("enables validation", func(t *testing.T) {
+		svc, err := service.NewPositionKeepingService(
+			mockRepo,
+			mockMeasurementRepo,
+			mockEventPublisher,
+			mockIdempotency,
+			service.WithAccountValidationEnabled(true),
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, svc)
+	})
+
+	t.Run("disables validation", func(t *testing.T) {
+		svc, err := service.NewPositionKeepingService(
+			mockRepo,
+			mockMeasurementRepo,
+			mockEventPublisher,
+			mockIdempotency,
+			service.WithAccountValidationEnabled(false),
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, svc)
+	})
+}

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -50,6 +50,14 @@ type PositionKeepingService struct {
 	// computations will fail with a FailedPrecondition error.
 	// Used to query active liens (amount blocks) from Current Account service.
 	currentAccountClient domain.CurrentAccountClient
+	// accountValidator is OPTIONAL - if nil, account validation is skipped.
+	// When set along with accountValidationEnabled, validates that accounts exist
+	// in Current Account service before creating position logs.
+	accountValidator AccountValidator
+	// accountValidationEnabled controls whether account validation is performed.
+	// Both this flag and accountValidator must be set for validation to occur.
+	// Defaults to false for backwards compatibility.
+	accountValidationEnabled bool
 }
 
 // Option configures optional dependencies for PositionKeepingService.
@@ -79,6 +87,26 @@ func WithBucketCounter(counter BucketCounter) Option {
 func WithCurrentAccountClient(client domain.CurrentAccountClient) Option {
 	return func(s *PositionKeepingService) {
 		s.currentAccountClient = client
+	}
+}
+
+// WithAccountValidator sets an optional account validator for validating account existence.
+// When enabled via WithAccountValidationEnabled, the service will validate that accounts
+// exist in the Current Account service before creating position logs.
+// If not set or set to nil, account validation is skipped for backwards compatibility.
+func WithAccountValidator(validator AccountValidator) Option {
+	return func(s *PositionKeepingService) {
+		s.accountValidator = validator
+	}
+}
+
+// WithAccountValidationEnabled enables or disables account validation.
+// When set to true and an AccountValidator is configured, the service will validate
+// that accounts exist before creating position logs.
+// Defaults to false for backwards compatibility.
+func WithAccountValidationEnabled(enabled bool) Option {
+	return func(s *PositionKeepingService) {
+		s.accountValidationEnabled = enabled
 	}
 }
 


### PR DESCRIPTION
## Summary

Add account existence validation that checks with Current Account service before creating new financial position logs. This prevents orphan position logs for non-existent accounts.

**Key features:**
- AccountValidator interface with CurrentAccountValidator implementation
- Caching with configurable TTL to reduce service calls (uses singleflight to prevent cache stampede)
- Feature flag to enable/disable validation (defaults to disabled for backwards compatibility)
- Graceful degradation: allows operation if Current Account service is unavailable

## Changes Made

### New Files
- `services/position-keeping/service/account_validator.go` - AccountValidator interface and CurrentAccountValidator implementation
- `services/position-keeping/service/account_validator_test.go` - Unit tests for the validator
- `services/position-keeping/service/initiate_validation_test.go` - Integration tests for validation in InitiateFinancialPositionLog

### Modified Files
- `services/position-keeping/app/config.go` - Add AccountValidationConfig and loader
- `services/position-keeping/cmd/main.go` - Wire up the validator and gRPC client
- `services/position-keeping/service/service.go` - Add WithAccountValidator and WithAccountValidationEnabled options
- `services/position-keeping/service/initiate.go` - Add validation call in InitiateFinancialPositionLog

## Environment Variables

| Variable | Description | Default |
|----------|-------------|---------|
| `ACCOUNT_VALIDATION_ENABLED` | Enable/disable account validation | `false` |
| `CURRENT_ACCOUNT_SERVICE_URL` | gRPC address of Current Account service | (required when enabled) |
| `ACCOUNT_VALIDATION_CACHE_TTL` | Cache duration for validation results | `1m` |
| `ACCOUNT_VALIDATION_CONNECTION_TIMEOUT` | Connection timeout for Current Account service | `5s` |

## Test Plan

- [x] Unit tests for AccountValidator (caching, singleflight, graceful degradation)
- [x] Integration tests for InitiateFinancialPositionLog with validation
- [x] All existing tests pass
- [ ] Manual testing in Tilt environment (optional - validation disabled by default)

## Task Reference

Task: internal-bank-account.29