### PR TITLE
feat(internal-bank-account): add clearing_purpose column migration

### DIFF
--- a/services/internal-bank-account/migrations/20260116000001_add_clearing_purpose.sql
+++ b/services/internal-bank-account/migrations/20260116000001_add_clearing_purpose.sql
@@ -1,0 +1,41 @@
+-- Add clearing_purpose column to internal_bank_account table
+-- This column distinguishes the specific purpose of CLEARING accounts
+-- Matches the ClearingPurpose enum in the protobuf definition
+
+-- Add the clearing_purpose column (nullable initially to allow existing data)
+ALTER TABLE "internal_bank_account"
+ADD COLUMN "clearing_purpose" character varying(32) NULL;
+
+-- Add check constraint to enforce that CLEARING accounts must have a non-null clearing_purpose
+-- Non-CLEARING accounts should have NULL or CLEARING_PURPOSE_UNSPECIFIED
+ALTER TABLE "internal_bank_account"
+ADD CONSTRAINT "chk_clearing_purpose_for_clearing_type"
+CHECK (
+  account_type != 'CLEARING' OR clearing_purpose IS NOT NULL
+);
+
+-- Backfill existing CLEARING accounts based on account_code patterns
+-- This is a best-effort mapping based on common naming conventions:
+--   - Codes ending in '-DEPOSIT' -> CLEARING_PURPOSE_DEPOSIT
+--   - Codes ending in '-WITHDRAW' or '-WITHDRAWAL' -> CLEARING_PURPOSE_WITHDRAWAL
+--   - Codes ending in '-SETTLEMENT' -> CLEARING_PURPOSE_SETTLEMENT
+--   - All other CLEARING accounts -> CLEARING_PURPOSE_GENERAL
+UPDATE "internal_bank_account"
+SET "clearing_purpose" = CASE
+  WHEN account_code LIKE '%-DEPOSIT' OR account_code LIKE '%-deposit' THEN 'CLEARING_PURPOSE_DEPOSIT'
+  WHEN account_code LIKE '%-WITHDRAW' OR account_code LIKE '%-WITHDRAWAL'
+       OR account_code LIKE '%-withdraw' OR account_code LIKE '%-withdrawal' THEN 'CLEARING_PURPOSE_WITHDRAWAL'
+  WHEN account_code LIKE '%-SETTLEMENT' OR account_code LIKE '%-settlement' THEN 'CLEARING_PURPOSE_SETTLEMENT'
+  ELSE 'CLEARING_PURPOSE_GENERAL'
+END
+WHERE account_type = 'CLEARING' AND clearing_purpose IS NULL;
+
+-- Create partial index for efficient filtering of clearing accounts by purpose
+-- Only indexes rows where account_type = 'CLEARING', reducing index size
+CREATE INDEX "idx_internal_bank_account_clearing_purpose"
+ON "internal_bank_account" ("clearing_purpose")
+WHERE account_type = 'CLEARING';
+
+-- Add comment documenting the column
+COMMENT ON COLUMN "internal_bank_account"."clearing_purpose" IS
+  'Purpose classification for CLEARING accounts: CLEARING_PURPOSE_DEPOSIT (deposits), CLEARING_PURPOSE_WITHDRAWAL (withdrawals), CLEARING_PURPOSE_SETTLEMENT (settlements), CLEARING_PURPOSE_GENERAL (general). NULL or UNSPECIFIED for non-CLEARING account types.';

--- a/services/internal-bank-account/migrations/20260116000001_add_clearing_purpose.sql
+++ b/services/internal-bank-account/migrations/20260116000001_add_clearing_purpose.sql
@@ -6,20 +6,13 @@
 ALTER TABLE "internal_bank_account"
 ADD COLUMN "clearing_purpose" character varying(32) NULL;
 
--- Add check constraint to enforce that CLEARING accounts must have a non-null clearing_purpose
--- Non-CLEARING accounts should have NULL or CLEARING_PURPOSE_UNSPECIFIED
-ALTER TABLE "internal_bank_account"
-ADD CONSTRAINT "chk_clearing_purpose_for_clearing_type"
-CHECK (
-  account_type != 'CLEARING' OR clearing_purpose IS NOT NULL
-);
-
 -- Backfill existing CLEARING accounts based on account_code patterns
 -- This is a best-effort mapping based on common naming conventions:
 --   - Codes ending in '-DEPOSIT' -> CLEARING_PURPOSE_DEPOSIT
 --   - Codes ending in '-WITHDRAW' or '-WITHDRAWAL' -> CLEARING_PURPOSE_WITHDRAWAL
 --   - Codes ending in '-SETTLEMENT' -> CLEARING_PURPOSE_SETTLEMENT
 --   - All other CLEARING accounts -> CLEARING_PURPOSE_GENERAL
+-- NOTE: Backfill MUST run before adding the constraint to avoid migration failure
 UPDATE "internal_bank_account"
 SET "clearing_purpose" = CASE
   WHEN account_code LIKE '%-DEPOSIT' OR account_code LIKE '%-deposit' THEN 'CLEARING_PURPOSE_DEPOSIT'
@@ -29,6 +22,15 @@ SET "clearing_purpose" = CASE
   ELSE 'CLEARING_PURPOSE_GENERAL'
 END
 WHERE account_type = 'CLEARING' AND clearing_purpose IS NULL;
+
+-- Add check constraint to enforce that CLEARING accounts must have a non-null clearing_purpose
+-- Non-CLEARING accounts should have NULL or CLEARING_PURPOSE_UNSPECIFIED
+-- NOTE: Constraint added AFTER backfill to ensure existing data satisfies it
+ALTER TABLE "internal_bank_account"
+ADD CONSTRAINT "chk_clearing_purpose_for_clearing_type"
+CHECK (
+  account_type != 'CLEARING' OR clearing_purpose IS NOT NULL
+);
 
 -- Create partial index for efficient filtering of clearing accounts by purpose
 -- Only indexes rows where account_type = 'CLEARING', reducing index size

--- a/services/internal-bank-account/migrations/atlas.sum
+++ b/services/internal-bank-account/migrations/atlas.sum
@@ -1,2 +1,3 @@
-h1:IuH1urcVsXhG91SwkOWPCt3fCxdaAnXvu836XHi4kVY=
+h1:MPYfwDtjjxcLJk39zldJ/eeFGxEGKew3SW9ckGnFyUo=
 20260112000001_initial.sql h1:DGFY67QMovT7UV5WkUEOrSZE7dLYIppV90Ix2x+qMls=
+20260116000001_add_clearing_purpose.sql h1:azt0fbSYM9yMwtZy/KDwvBlGhUHqDx+SSUBuUFziNNE=

--- a/services/internal-bank-account/migrations/atlas.sum
+++ b/services/internal-bank-account/migrations/atlas.sum
@@ -1,3 +1,3 @@
-h1:MPYfwDtjjxcLJk39zldJ/eeFGxEGKew3SW9ckGnFyUo=
+h1:hlYD/3kPm44q9HT7Ws0ibA/hG+udyK1HHWxf4jPG/dY=
 20260112000001_initial.sql h1:DGFY67QMovT7UV5WkUEOrSZE7dLYIppV90Ix2x+qMls=
-20260116000001_add_clearing_purpose.sql h1:azt0fbSYM9yMwtZy/KDwvBlGhUHqDx+SSUBuUFziNNE=
+20260116000001_add_clearing_purpose.sql h1:6O2TqPfMEf0BUXUi/zfq4ot8ZPW1s/zeNjvgIinrISI=


### PR DESCRIPTION
## Summary

- Add database migration for `clearing_purpose` column to support ClearingPurpose enum
- Add check constraint ensuring CLEARING accounts have a purpose set
- Backfill existing CLEARING accounts based on account_code naming patterns
- Create partial index for efficient filtering by clearing_purpose

## Changes Made

**New Migration: `20260116000001_add_clearing_purpose.sql`**

1. **Column Addition**: Adds `clearing_purpose VARCHAR(32)` column (nullable initially for existing data)
2. **Constraint**: Enforces that CLEARING account types must have a non-null clearing_purpose
3. **Backfill Logic**: 
   - Account codes ending in `-DEPOSIT` → `CLEARING_PURPOSE_DEPOSIT`
   - Account codes ending in `-WITHDRAW`/`-WITHDRAWAL` → `CLEARING_PURPOSE_WITHDRAWAL`
   - Account codes ending in `-SETTLEMENT` → `CLEARING_PURPOSE_SETTLEMENT`
   - All other CLEARING accounts → `CLEARING_PURPOSE_GENERAL`
4. **Partial Index**: `idx_internal_bank_account_clearing_purpose` indexes only CLEARING accounts for efficient queries

## Test Plan

- [ ] Migration applies successfully to test database
- [ ] Constraint correctly rejects CLEARING accounts without clearing_purpose
- [ ] Backfill correctly assigns purposes based on account_code patterns
- [ ] Partial index is used for clearing_purpose filter queries (verify via EXPLAIN)

## Task Master Reference

Task: `internal-bank-account.23`