### PR TITLE
feat(internal-bank-account): add ClearingPurpose to domain model and repository

### DIFF
--- a/services/internal-bank-account/adapters/persistence/account_entity.go
+++ b/services/internal-bank-account/adapters/persistence/account_entity.go
@@ -41,6 +41,9 @@ type InternalBankAccountEntity struct {
 	// Account status
 	Status string `gorm:"column:status;type:varchar(20);not null;default:'ACTIVE';index"`
 
+	// Clearing purpose (only meaningful for CLEARING account type)
+	ClearingPurpose *string `gorm:"column:clearing_purpose;type:varchar(32)"`
+
 	// Correspondent bank details (nullable for non-nostro/vostro accounts)
 	CorrespondentBankID      *string `gorm:"column:correspondent_bank_id;type:varchar(50)"`
 	CorrespondentBankName    *string `gorm:"column:correspondent_bank_name;type:varchar(255)"`

--- a/services/internal-bank-account/adapters/persistence/mappers.go
+++ b/services/internal-bank-account/adapters/persistence/mappers.go
@@ -34,12 +34,20 @@ func toEntity(ctx context.Context, account domain.InternalBankAccount) *Internal
 		attributes = make(AttributesJSON)
 	}
 
+	// Handle nullable clearing_purpose field
+	var clearingPurpose *string
+	if cp := account.ClearingPurpose(); cp != "" && cp != domain.ClearingPurposeUnspecified {
+		cpStr := string(cp)
+		clearingPurpose = &cpStr
+	}
+
 	return &InternalBankAccountEntity{
 		ID:                       account.ID(),
 		AccountID:                account.AccountID(),
 		AccountCode:              account.AccountCode(),
 		Name:                     account.Name(),
 		AccountType:              string(account.AccountType()),
+		ClearingPurpose:          clearingPurpose,
 		InstrumentCode:           account.InstrumentCode(),
 		Dimension:                account.Dimension(),
 		Status:                   string(account.Status()),
@@ -78,6 +86,12 @@ func toDomain(entity *InternalBankAccountEntity) domain.InternalBankAccount {
 		}
 	}
 
+	// Handle nullable clearing_purpose - default to UNSPECIFIED if nil
+	clearingPurpose := domain.ClearingPurposeUnspecified
+	if entity.ClearingPurpose != nil {
+		clearingPurpose = domain.ClearingPurpose(*entity.ClearingPurpose)
+	}
+
 	// Use builder pattern to reconstruct domain model
 	return domain.NewInternalBankAccountBuilder().
 		WithID(entity.ID).
@@ -85,6 +99,7 @@ func toDomain(entity *InternalBankAccountEntity) domain.InternalBankAccount {
 		WithAccountCode(entity.AccountCode).
 		WithName(entity.Name).
 		WithAccountType(domain.AccountType(entity.AccountType)).
+		WithClearingPurpose(clearingPurpose).
 		WithInstrumentCode(entity.InstrumentCode).
 		WithDimension(entity.Dimension).
 		WithStatus(domain.AccountStatus(entity.Status)).

--- a/services/internal-bank-account/adapters/persistence/mappers_test.go
+++ b/services/internal-bank-account/adapters/persistence/mappers_test.go
@@ -141,7 +141,7 @@ func TestToEntity_NilAttributes(t *testing.T) {
 		"GBP_BASIC",
 		"GBP Basic Account",
 		domain.AccountTypeClearing,
-		domain.ClearingPurposeUnspecified,
+		domain.ClearingPurposeGeneral, // CLEARING accounts require a specific purpose
 		"GBP",
 		"CURRENCY",
 	)
@@ -423,16 +423,15 @@ func TestToDomain_AllClearingPurposes(t *testing.T) {
 func TestToEntity_ClearingPurpose(t *testing.T) {
 	ctx := createTestContextForMappers()
 
+	// Test specific clearing purposes for CLEARING accounts
 	testCases := []struct {
 		name            string
 		clearingPurpose domain.ClearingPurpose
-		expectNil       bool // true if entity.ClearingPurpose should be nil
 	}{
-		{"Deposit", domain.ClearingPurposeDeposit, false},
-		{"Withdrawal", domain.ClearingPurposeWithdrawal, false},
-		{"Settlement", domain.ClearingPurposeSettlement, false},
-		{"General", domain.ClearingPurposeGeneral, false},
-		{"Unspecified", domain.ClearingPurposeUnspecified, true},
+		{"Deposit", domain.ClearingPurposeDeposit},
+		{"Withdrawal", domain.ClearingPurposeWithdrawal},
+		{"Settlement", domain.ClearingPurposeSettlement},
+		{"General", domain.ClearingPurposeGeneral},
 	}
 
 	for _, tc := range testCases {
@@ -450,14 +449,28 @@ func TestToEntity_ClearingPurpose(t *testing.T) {
 
 			entity := toEntity(ctx, account)
 
-			if tc.expectNil {
-				assert.Nil(t, entity.ClearingPurpose)
-			} else {
-				require.NotNil(t, entity.ClearingPurpose)
-				assert.Equal(t, string(tc.clearingPurpose), *entity.ClearingPurpose)
-			}
+			require.NotNil(t, entity.ClearingPurpose)
+			assert.Equal(t, string(tc.clearingPurpose), *entity.ClearingPurpose)
 		})
 	}
+
+	// Test that non-CLEARING accounts with UNSPECIFIED purpose have nil ClearingPurpose
+	t.Run("Unspecified_NonClearing", func(t *testing.T) {
+		account, err := domain.NewInternalBankAccount(
+			"IBA-CP-Unspecified",
+			"CODE_Unspecified",
+			"Holding Account with Unspecified Purpose",
+			domain.AccountTypeHolding, // Non-CLEARING account type
+			domain.ClearingPurposeUnspecified,
+			"GBP",
+			"CURRENCY",
+		)
+		require.NoError(t, err)
+
+		entity := toEntity(ctx, account)
+
+		assert.Nil(t, entity.ClearingPurpose)
+	})
 }
 
 // TestRoundTrip_BasicAccount tests domain -> entity -> domain preserves equality.
@@ -615,7 +628,7 @@ func TestRoundTrip_SuspendedStatus(t *testing.T) {
 		"GBP_SUSPENDED",
 		"GBP Suspended Account",
 		domain.AccountTypeClearing,
-		domain.ClearingPurposeUnspecified,
+		domain.ClearingPurposeGeneral, // CLEARING accounts require a specific purpose
 		"GBP",
 		"CURRENCY",
 	)

--- a/services/internal-bank-account/adapters/persistence/mappers_test.go
+++ b/services/internal-bank-account/adapters/persistence/mappers_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// ptr returns a pointer to the given string value.
+func ptr(s string) *string {
+	return &s
+}
+
 // createTestContextForMappers creates a context with audit information for mapper tests.
 func createTestContextForMappers() context.Context {
 	ctx := context.Background()
@@ -28,6 +33,7 @@ func TestToEntity_BasicFields(t *testing.T) {
 		"GBP_CLEARING",
 		"GBP Clearing Account",
 		domain.AccountTypeClearing,
+		domain.ClearingPurposeDeposit,
 		"GBP",
 		"CURRENCY",
 	)
@@ -42,6 +48,8 @@ func TestToEntity_BasicFields(t *testing.T) {
 	assert.Equal(t, account.AccountCode(), entity.AccountCode)
 	assert.Equal(t, account.Name(), entity.Name)
 	assert.Equal(t, string(account.AccountType()), entity.AccountType)
+	require.NotNil(t, entity.ClearingPurpose)
+	assert.Equal(t, string(account.ClearingPurpose()), *entity.ClearingPurpose)
 	assert.Equal(t, account.InstrumentCode(), entity.InstrumentCode)
 	assert.Equal(t, account.Dimension(), entity.Dimension)
 	assert.Equal(t, string(account.Status()), entity.Status)
@@ -69,6 +77,7 @@ func TestToEntity_WithCorrespondent(t *testing.T) {
 		"USD_NOSTRO_CITI",
 		"USD NOSTRO at Citibank",
 		domain.AccountTypeNostro,
+		domain.ClearingPurposeUnspecified,
 		"USD",
 		"CURRENCY",
 	)
@@ -132,6 +141,7 @@ func TestToEntity_NilAttributes(t *testing.T) {
 		"GBP_BASIC",
 		"GBP Basic Account",
 		domain.AccountTypeClearing,
+		domain.ClearingPurposeUnspecified,
 		"GBP",
 		"CURRENCY",
 	)
@@ -150,20 +160,21 @@ func TestToDomain_BasicFields(t *testing.T) {
 	entityID := uuid.New()
 
 	entity := &InternalBankAccountEntity{
-		ID:             entityID,
-		AccountID:      "IBA-MAP-010",
-		AccountCode:    "EUR_CLEARING",
-		Name:           "EUR Clearing Account",
-		AccountType:    "CLEARING",
-		InstrumentCode: "EUR",
-		Dimension:      "CURRENCY",
-		Status:         "ACTIVE",
-		Version:        1,
-		CreatedAt:      now,
-		UpdatedAt:      now,
-		CreatedBy:      "system",
-		UpdatedBy:      "system",
-		Attributes:     make(AttributesJSON),
+		ID:              entityID,
+		AccountID:       "IBA-MAP-010",
+		AccountCode:     "EUR_CLEARING",
+		Name:            "EUR Clearing Account",
+		AccountType:     "CLEARING",
+		ClearingPurpose: ptr("CLEARING_PURPOSE_SETTLEMENT"),
+		InstrumentCode:  "EUR",
+		Dimension:       "CURRENCY",
+		Status:          "ACTIVE",
+		Version:         1,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		CreatedBy:       "system",
+		UpdatedBy:       "system",
+		Attributes:      make(AttributesJSON),
 	}
 
 	// Convert to domain
@@ -175,6 +186,7 @@ func TestToDomain_BasicFields(t *testing.T) {
 	assert.Equal(t, "EUR_CLEARING", account.AccountCode())
 	assert.Equal(t, "EUR Clearing Account", account.Name())
 	assert.Equal(t, domain.AccountTypeClearing, account.AccountType())
+	assert.Equal(t, domain.ClearingPurposeSettlement, account.ClearingPurpose())
 	assert.Equal(t, "EUR", account.InstrumentCode())
 	assert.Equal(t, "CURRENCY", account.Dimension())
 	assert.Equal(t, domain.AccountStatusActive, account.Status())
@@ -197,6 +209,7 @@ func TestToDomain_WithCorrespondent(t *testing.T) {
 		AccountCode:              "USD_NOSTRO_CITI",
 		Name:                     "USD NOSTRO at Citibank",
 		AccountType:              "NOSTRO",
+		ClearingPurpose:          nil, // NOSTRO accounts don't have clearing purpose
 		InstrumentCode:           "USD",
 		Dimension:                "CURRENCY",
 		Status:                   "ACTIVE",
@@ -226,14 +239,15 @@ func TestToDomain_WithAttributes(t *testing.T) {
 	now := time.Now()
 
 	entity := &InternalBankAccountEntity{
-		ID:             uuid.New(),
-		AccountID:      "IBA-MAP-012",
-		AccountCode:    "GBP_SPECIAL",
-		Name:           "GBP Special Account",
-		AccountType:    "CLEARING",
-		InstrumentCode: "GBP",
-		Dimension:      "CURRENCY",
-		Status:         "ACTIVE",
+		ID:              uuid.New(),
+		AccountID:       "IBA-MAP-012",
+		AccountCode:     "GBP_SPECIAL",
+		Name:            "GBP Special Account",
+		AccountType:     "CLEARING",
+		ClearingPurpose: ptr("CLEARING_PURPOSE_GENERAL"),
+		InstrumentCode:  "GBP",
+		Dimension:       "CURRENCY",
+		Status:          "ACTIVE",
 		Attributes: AttributesJSON{
 			"cost_center": "CC001",
 			"department":  "Treasury",
@@ -263,20 +277,21 @@ func TestToDomain_EmptyAttributes(t *testing.T) {
 	now := time.Now()
 
 	entity := &InternalBankAccountEntity{
-		ID:             uuid.New(),
-		AccountID:      "IBA-MAP-013",
-		AccountCode:    "GBP_BASIC",
-		Name:           "GBP Basic Account",
-		AccountType:    "CLEARING",
-		InstrumentCode: "GBP",
-		Dimension:      "CURRENCY",
-		Status:         "ACTIVE",
-		Attributes:     make(AttributesJSON),
-		Version:        1,
-		CreatedAt:      now,
-		UpdatedAt:      now,
-		CreatedBy:      "system",
-		UpdatedBy:      "system",
+		ID:              uuid.New(),
+		AccountID:       "IBA-MAP-013",
+		AccountCode:     "GBP_BASIC",
+		Name:            "GBP Basic Account",
+		AccountType:     "CLEARING",
+		ClearingPurpose: nil, // nil means unspecified
+		InstrumentCode:  "GBP",
+		Dimension:       "CURRENCY",
+		Status:          "ACTIVE",
+		Attributes:      make(AttributesJSON),
+		Version:         1,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+		CreatedBy:       "system",
+		UpdatedBy:       "system",
 	}
 
 	// Convert to domain
@@ -304,20 +319,21 @@ func TestToDomain_AllAccountTypes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.entityType, func(t *testing.T) {
 			entity := &InternalBankAccountEntity{
-				ID:             uuid.New(),
-				AccountID:      "IBA-TYPE-" + tc.entityType,
-				AccountCode:    "CODE_" + tc.entityType,
-				Name:           tc.entityType + " Account",
-				AccountType:    tc.entityType,
-				InstrumentCode: "GBP",
-				Dimension:      "CURRENCY",
-				Status:         "ACTIVE",
-				Attributes:     make(AttributesJSON),
-				Version:        1,
-				CreatedAt:      time.Now(),
-				UpdatedAt:      time.Now(),
-				CreatedBy:      "system",
-				UpdatedBy:      "system",
+				ID:              uuid.New(),
+				AccountID:       "IBA-TYPE-" + tc.entityType,
+				AccountCode:     "CODE_" + tc.entityType,
+				Name:            tc.entityType + " Account",
+				AccountType:     tc.entityType,
+				ClearingPurpose: nil, // nil means unspecified
+				InstrumentCode:  "GBP",
+				Dimension:       "CURRENCY",
+				Status:          "ACTIVE",
+				Attributes:      make(AttributesJSON),
+				Version:         1,
+				CreatedAt:       time.Now(),
+				UpdatedAt:       time.Now(),
+				CreatedBy:       "system",
+				UpdatedBy:       "system",
 			}
 
 			account := toDomain(entity)
@@ -340,24 +356,106 @@ func TestToDomain_AllStatuses(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.entityStatus, func(t *testing.T) {
 			entity := &InternalBankAccountEntity{
-				ID:             uuid.New(),
-				AccountID:      "IBA-STATUS-" + tc.entityStatus,
-				AccountCode:    "CODE_" + tc.entityStatus,
-				Name:           tc.entityStatus + " Account",
-				AccountType:    "CLEARING",
-				InstrumentCode: "GBP",
-				Dimension:      "CURRENCY",
-				Status:         tc.entityStatus,
-				Attributes:     make(AttributesJSON),
-				Version:        1,
-				CreatedAt:      time.Now(),
-				UpdatedAt:      time.Now(),
-				CreatedBy:      "system",
-				UpdatedBy:      "system",
+				ID:              uuid.New(),
+				AccountID:       "IBA-STATUS-" + tc.entityStatus,
+				AccountCode:     "CODE_" + tc.entityStatus,
+				Name:            tc.entityStatus + " Account",
+				AccountType:     "CLEARING",
+				ClearingPurpose: nil, // nil means unspecified
+				InstrumentCode:  "GBP",
+				Dimension:       "CURRENCY",
+				Status:          tc.entityStatus,
+				Attributes:      make(AttributesJSON),
+				Version:         1,
+				CreatedAt:       time.Now(),
+				UpdatedAt:       time.Now(),
+				CreatedBy:       "system",
+				UpdatedBy:       "system",
 			}
 
 			account := toDomain(entity)
 			assert.Equal(t, tc.domainStatus, account.Status())
+		})
+	}
+}
+
+// TestToDomain_AllClearingPurposes tests mapping for all clearing purpose values.
+func TestToDomain_AllClearingPurposes(t *testing.T) {
+	testCases := []struct {
+		name          string
+		entityPurpose *string
+		domainPurpose domain.ClearingPurpose
+	}{
+		{"nil (unspecified)", nil, domain.ClearingPurposeUnspecified},
+		{"DEPOSIT", ptr("CLEARING_PURPOSE_DEPOSIT"), domain.ClearingPurposeDeposit},
+		{"WITHDRAWAL", ptr("CLEARING_PURPOSE_WITHDRAWAL"), domain.ClearingPurposeWithdrawal},
+		{"SETTLEMENT", ptr("CLEARING_PURPOSE_SETTLEMENT"), domain.ClearingPurposeSettlement},
+		{"GENERAL", ptr("CLEARING_PURPOSE_GENERAL"), domain.ClearingPurposeGeneral},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			entity := &InternalBankAccountEntity{
+				ID:              uuid.New(),
+				AccountID:       "IBA-PURPOSE-" + tc.name,
+				AccountCode:     "CODE_" + tc.name,
+				Name:            tc.name + " Purpose Account",
+				AccountType:     "CLEARING",
+				ClearingPurpose: tc.entityPurpose,
+				InstrumentCode:  "GBP",
+				Dimension:       "CURRENCY",
+				Status:          "ACTIVE",
+				Attributes:      make(AttributesJSON),
+				Version:         1,
+				CreatedAt:       time.Now(),
+				UpdatedAt:       time.Now(),
+				CreatedBy:       "system",
+				UpdatedBy:       "system",
+			}
+
+			account := toDomain(entity)
+			assert.Equal(t, tc.domainPurpose, account.ClearingPurpose())
+		})
+	}
+}
+
+// TestToEntity_ClearingPurpose tests that toEntity correctly maps clearing purpose field.
+func TestToEntity_ClearingPurpose(t *testing.T) {
+	ctx := createTestContextForMappers()
+
+	testCases := []struct {
+		name            string
+		clearingPurpose domain.ClearingPurpose
+		expectNil       bool // true if entity.ClearingPurpose should be nil
+	}{
+		{"Deposit", domain.ClearingPurposeDeposit, false},
+		{"Withdrawal", domain.ClearingPurposeWithdrawal, false},
+		{"Settlement", domain.ClearingPurposeSettlement, false},
+		{"General", domain.ClearingPurposeGeneral, false},
+		{"Unspecified", domain.ClearingPurposeUnspecified, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			account, err := domain.NewInternalBankAccount(
+				"IBA-CP-"+tc.name,
+				"CODE_"+tc.name,
+				tc.name+" Clearing Account",
+				domain.AccountTypeClearing,
+				tc.clearingPurpose,
+				"GBP",
+				"CURRENCY",
+			)
+			require.NoError(t, err)
+
+			entity := toEntity(ctx, account)
+
+			if tc.expectNil {
+				assert.Nil(t, entity.ClearingPurpose)
+			} else {
+				require.NotNil(t, entity.ClearingPurpose)
+				assert.Equal(t, string(tc.clearingPurpose), *entity.ClearingPurpose)
+			}
 		})
 	}
 }
@@ -372,6 +470,7 @@ func TestRoundTrip_BasicAccount(t *testing.T) {
 		"GBP_CLEARING",
 		"GBP Clearing Account",
 		domain.AccountTypeClearing,
+		domain.ClearingPurposeGeneral,
 		"GBP",
 		"CURRENCY",
 	)
@@ -387,6 +486,7 @@ func TestRoundTrip_BasicAccount(t *testing.T) {
 	assert.Equal(t, original.AccountCode(), reconstructed.AccountCode())
 	assert.Equal(t, original.Name(), reconstructed.Name())
 	assert.Equal(t, original.AccountType(), reconstructed.AccountType())
+	assert.Equal(t, original.ClearingPurpose(), reconstructed.ClearingPurpose())
 	assert.Equal(t, original.InstrumentCode(), reconstructed.InstrumentCode())
 	assert.Equal(t, original.Dimension(), reconstructed.Dimension())
 	assert.Equal(t, original.Status(), reconstructed.Status())
@@ -403,6 +503,7 @@ func TestRoundTrip_WithCorrespondent(t *testing.T) {
 		"USD_NOSTRO_CITI",
 		"USD NOSTRO at Citibank",
 		domain.AccountTypeNostro,
+		domain.ClearingPurposeUnspecified,
 		"USD",
 		"CURRENCY",
 	)
@@ -472,6 +573,7 @@ func TestRoundTrip_VostroAccount(t *testing.T) {
 		"EUR_VOSTRO_DB",
 		"EUR VOSTRO from Deutsche Bank",
 		domain.AccountTypeVostro,
+		domain.ClearingPurposeUnspecified,
 		"EUR",
 		"CURRENCY",
 	)
@@ -513,6 +615,7 @@ func TestRoundTrip_SuspendedStatus(t *testing.T) {
 		"GBP_SUSPENDED",
 		"GBP Suspended Account",
 		domain.AccountTypeClearing,
+		domain.ClearingPurposeUnspecified,
 		"GBP",
 		"CURRENCY",
 	)
@@ -645,6 +748,7 @@ func TestToDomain_PartialCorrespondent(t *testing.T) {
 			AccountCode:         "TEST",
 			Name:                "Test Account",
 			AccountType:         "CLEARING",
+			ClearingPurpose:     nil, // nil means unspecified
 			InstrumentCode:      "GBP",
 			Dimension:           "CURRENCY",
 			Status:              "ACTIVE",
@@ -673,6 +777,7 @@ func TestToDomain_PartialCorrespondent(t *testing.T) {
 			AccountCode:           "TEST",
 			Name:                  "Test Account",
 			AccountType:           "CLEARING",
+			ClearingPurpose:       nil, // nil means unspecified
 			InstrumentCode:        "GBP",
 			Dimension:             "CURRENCY",
 			Status:                "ACTIVE",

--- a/services/internal-bank-account/adapters/persistence/repository.go
+++ b/services/internal-bank-account/adapters/persistence/repository.go
@@ -121,6 +121,7 @@ func (r *Repository) Save(ctx context.Context, account domain.InternalBankAccoun
 					"account_code":               entity.AccountCode,
 					"name":                       entity.Name,
 					"status":                     entity.Status,
+					"clearing_purpose":           entity.ClearingPurpose,
 					"correspondent_bank_id":      entity.CorrespondentBankID,
 					"correspondent_bank_name":    entity.CorrespondentBankName,
 					"correspondent_external_ref": entity.CorrespondentExternalRef,
@@ -250,6 +251,9 @@ func (r *Repository) List(ctx context.Context, filter domain.ListFilter) ([]doma
 		}
 		if filter.Status != nil {
 			query = query.Where("status = ?", string(*filter.Status))
+		}
+		if filter.ClearingPurpose != nil {
+			query = query.Where("clearing_purpose = ?", string(*filter.ClearingPurpose))
 		}
 
 		// Apply pagination

--- a/services/internal-bank-account/adapters/persistence/repository_integration_test.go
+++ b/services/internal-bank-account/adapters/persistence/repository_integration_test.go
@@ -223,6 +223,7 @@ func createTestAccountIntegration(t *testing.T, accountID, accountCode, name str
 		accountCode,
 		name,
 		accountType,
+		domain.ClearingPurposeUnspecified,
 		"GBP",
 		"CURRENCY",
 	)
@@ -519,6 +520,7 @@ func TestIntegration_CorrespondentDetails(t *testing.T) {
 		"USD_NOSTRO_CITI",
 		"USD NOSTRO at Citibank",
 		domain.AccountTypeNostro,
+		domain.ClearingPurposeUnspecified,
 		"USD",
 		"CURRENCY",
 	)
@@ -1287,6 +1289,7 @@ func createBenchAccount(accountID, accountCode, name string, accountType domain.
 		accountCode,
 		name,
 		accountType,
+		domain.ClearingPurposeUnspecified,
 		"GBP",
 		"CURRENCY",
 	)

--- a/services/internal-bank-account/adapters/persistence/repository_test.go
+++ b/services/internal-bank-account/adapters/persistence/repository_test.go
@@ -41,6 +41,7 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		account_code VARCHAR(50) NOT NULL,
 		name VARCHAR(255) NOT NULL,
 		account_type VARCHAR(20) NOT NULL,
+		clearing_purpose VARCHAR(32) NULL,
 		instrument_code VARCHAR(32) NOT NULL,
 		dimension VARCHAR(20) NOT NULL,
 		status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
@@ -85,6 +86,22 @@ func createTestAccount(t *testing.T, accountID, accountCode, name string, accoun
 		accountCode,
 		name,
 		accountType,
+		domain.ClearingPurposeUnspecified,
+		"GBP",
+		"CURRENCY",
+	)
+	require.NoError(t, err)
+	return account
+}
+
+func createTestAccountWithClearingPurpose(t *testing.T, accountID, accountCode, name string, accountType domain.AccountType, clearingPurpose domain.ClearingPurpose) domain.InternalBankAccount {
+	t.Helper()
+	account, err := domain.NewInternalBankAccount(
+		accountID,
+		accountCode,
+		name,
+		accountType,
+		clearingPurpose,
 		"GBP",
 		"CURRENCY",
 	)
@@ -212,6 +229,58 @@ func TestListWithFilters(t *testing.T) {
 	assert.Len(t, results, 3)
 }
 
+func TestListWithClearingPurposeFilter(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewRepository(db)
+
+	// Create clearing accounts with different purposes
+	depositAcc := createTestAccountWithClearingPurpose(t, "IBA-CP-001", "CLR_DEPOSIT", "Deposit Clearing", domain.AccountTypeClearing, domain.ClearingPurposeDeposit)
+	withdrawalAcc := createTestAccountWithClearingPurpose(t, "IBA-CP-002", "CLR_WITHDRAWAL", "Withdrawal Clearing", domain.AccountTypeClearing, domain.ClearingPurposeWithdrawal)
+	settlementAcc := createTestAccountWithClearingPurpose(t, "IBA-CP-003", "CLR_SETTLEMENT", "Settlement Clearing", domain.AccountTypeClearing, domain.ClearingPurposeSettlement)
+	generalAcc := createTestAccountWithClearingPurpose(t, "IBA-CP-004", "CLR_GENERAL", "General Clearing", domain.AccountTypeClearing, domain.ClearingPurposeGeneral)
+
+	require.NoError(t, repo.Save(ctx, depositAcc))
+	require.NoError(t, repo.Save(ctx, withdrawalAcc))
+	require.NoError(t, repo.Save(ctx, settlementAcc))
+	require.NoError(t, repo.Save(ctx, generalAcc))
+
+	// Filter by clearing purpose - DEPOSIT
+	depositPurpose := domain.ClearingPurposeDeposit
+	filter := domain.ListFilter{ClearingPurpose: &depositPurpose}
+	results, err := repo.List(ctx, filter)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "CLR_DEPOSIT", results[0].AccountCode())
+	assert.Equal(t, domain.ClearingPurposeDeposit, results[0].ClearingPurpose())
+
+	// Filter by clearing purpose - SETTLEMENT
+	settlementPurpose := domain.ClearingPurposeSettlement
+	filter = domain.ListFilter{ClearingPurpose: &settlementPurpose}
+	results, err = repo.List(ctx, filter)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "CLR_SETTLEMENT", results[0].AccountCode())
+
+	// Combine filters: account type + clearing purpose
+	clearingType := domain.AccountTypeClearing
+	filter = domain.ListFilter{
+		AccountType:     &clearingType,
+		ClearingPurpose: &depositPurpose,
+	}
+	results, err = repo.List(ctx, filter)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "CLR_DEPOSIT", results[0].AccountCode())
+
+	// No filter returns all accounts
+	filter = domain.ListFilter{}
+	results, err = repo.List(ctx, filter)
+	require.NoError(t, err)
+	assert.Len(t, results, 4)
+}
+
 func TestOptimisticLocking(t *testing.T) {
 	db, ctx, cleanup := setupTestDB(t)
 	defer cleanup()
@@ -271,6 +340,7 @@ func TestTenantIsolation(t *testing.T) {
 			account_code VARCHAR(50) NOT NULL,
 			name VARCHAR(255) NOT NULL,
 			account_type VARCHAR(20) NOT NULL,
+			clearing_purpose VARCHAR(32) NULL,
 			instrument_code VARCHAR(32) NOT NULL,
 			dimension VARCHAR(20) NOT NULL,
 			status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
@@ -337,6 +407,7 @@ func TestCorrespondentDetails(t *testing.T) {
 		"USD_NOSTRO_CITI",
 		"USD NOSTRO at Citibank",
 		domain.AccountTypeNostro,
+		domain.ClearingPurposeUnspecified,
 		"USD",
 		"CURRENCY",
 	)
@@ -412,6 +483,7 @@ func TestRoundTripMapping(t *testing.T) {
 		"EUR_VOSTRO_DB",
 		"EUR VOSTRO from Deutsche Bank",
 		domain.AccountTypeVostro,
+		domain.ClearingPurposeUnspecified,
 		"EUR",
 		"CURRENCY",
 	)

--- a/services/internal-bank-account/adapters/persistence/repository_test.go
+++ b/services/internal-bank-account/adapters/persistence/repository_test.go
@@ -81,12 +81,17 @@ func setupTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 
 func createTestAccount(t *testing.T, accountID, accountCode, name string, accountType domain.AccountType) domain.InternalBankAccount {
 	t.Helper()
+	// CLEARING accounts require a specific purpose; use GENERAL for tests
+	clearingPurpose := domain.ClearingPurposeUnspecified
+	if accountType == domain.AccountTypeClearing {
+		clearingPurpose = domain.ClearingPurposeGeneral
+	}
 	account, err := domain.NewInternalBankAccount(
 		accountID,
 		accountCode,
 		name,
 		accountType,
-		domain.ClearingPurposeUnspecified,
+		clearingPurpose,
 		"GBP",
 		"CURRENCY",
 	)

--- a/services/internal-bank-account/benchmarks/helpers_test.go
+++ b/services/internal-bank-account/benchmarks/helpers_test.go
@@ -232,13 +232,19 @@ func setupTestContainer(t *testing.T) *testContainer {
 func createBenchAccount(tb testing.TB, tc *testContainer, accountCode string, accountType domain.AccountType) domain.InternalBankAccount {
 	tb.Helper()
 
+	// CLEARING accounts require a specific purpose; use GENERAL for benchmarks
+	clearingPurpose := domain.ClearingPurposeUnspecified
+	if accountType == domain.AccountTypeClearing {
+		clearingPurpose = domain.ClearingPurposeGeneral
+	}
+
 	accountID := fmt.Sprintf("IBA-%s", uuid.New().String())
 	account, err := domain.NewInternalBankAccount(
 		accountID,
 		accountCode,
 		fmt.Sprintf("Benchmark %s Account", accountType),
 		accountType,
-		domain.ClearingPurposeUnspecified,
+		clearingPurpose,
 		"GBP",
 		"CURRENCY",
 	)
@@ -274,6 +280,12 @@ func createBenchAccounts(tb testing.TB, tc *testContainer, count int) []domain.I
 		accountType := accountTypes[i%len(accountTypes)]
 		instrumentCode := instrumentCodes[i%len(instrumentCodes)]
 
+		// CLEARING accounts require a specific purpose; use GENERAL for benchmarks
+		clearingPurpose := domain.ClearingPurposeUnspecified
+		if accountType == domain.AccountTypeClearing {
+			clearingPurpose = domain.ClearingPurposeGeneral
+		}
+
 		accountID := fmt.Sprintf("IBA-%s", uuid.New().String())
 		accountCode := fmt.Sprintf("BENCH_%s_%04d", accountType, i)
 
@@ -282,7 +294,7 @@ func createBenchAccounts(tb testing.TB, tc *testContainer, count int) []domain.I
 			accountCode,
 			fmt.Sprintf("Benchmark %s Account %d", accountType, i),
 			accountType,
-			domain.ClearingPurposeUnspecified,
+			clearingPurpose,
 			instrumentCode,
 			"CURRENCY",
 		)

--- a/services/internal-bank-account/benchmarks/helpers_test.go
+++ b/services/internal-bank-account/benchmarks/helpers_test.go
@@ -155,7 +155,8 @@ func setupTestContainer(t *testing.T) *testContainer {
 		correspondent_bank_name VARCHAR(255),
 		correspondent_external_ref VARCHAR(100),
 		attributes JSONB NOT NULL DEFAULT '{}',
-		version BIGINT NOT NULL DEFAULT 1
+		version BIGINT NOT NULL DEFAULT 1,
+		clearing_purpose VARCHAR(32) NULL
 	)`, schemaName)).Error
 	if err != nil {
 		t.Fatalf("Failed to create internal_bank_account table: %v", err)
@@ -237,6 +238,7 @@ func createBenchAccount(tb testing.TB, tc *testContainer, accountCode string, ac
 		accountCode,
 		fmt.Sprintf("Benchmark %s Account", accountType),
 		accountType,
+		domain.ClearingPurposeUnspecified,
 		"GBP",
 		"CURRENCY",
 	)
@@ -280,6 +282,7 @@ func createBenchAccounts(tb testing.TB, tc *testContainer, count int) []domain.I
 			accountCode,
 			fmt.Sprintf("Benchmark %s Account %d", accountType, i),
 			accountType,
+			domain.ClearingPurposeUnspecified,
 			instrumentCode,
 			"CURRENCY",
 		)

--- a/services/internal-bank-account/benchmarks/load_test.go
+++ b/services/internal-bank-account/benchmarks/load_test.go
@@ -61,10 +61,11 @@ func BenchmarkConcurrentWrites(b *testing.B) {
 		for pbt.Next() {
 			id := atomic.AddInt64(&counter, 1)
 			req := &pb.InitiateInternalBankAccountRequest{
-				AccountCode:    fmt.Sprintf("CONC-%08d", id),
-				Name:           fmt.Sprintf("Concurrent Test Account %d", id),
-				AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-				InstrumentCode: "USD",
+				AccountCode:     fmt.Sprintf("CONC-%08d", id),
+				Name:            fmt.Sprintf("Concurrent Test Account %d", id),
+				AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+				ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+				InstrumentCode:  "USD",
 			}
 
 			_, err := tc.service.InitiateInternalBankAccount(ctx, req)
@@ -139,10 +140,11 @@ func BenchmarkMixedWorkloadWithBalance(b *testing.B) {
 		default: // 10% creates
 			id := atomic.AddInt64(&createCounter, 1)
 			req := &pb.InitiateInternalBankAccountRequest{
-				AccountCode:    fmt.Sprintf("MIXED-%08d", id+1000),
-				Name:           fmt.Sprintf("Mixed Workload Account %d", id),
-				AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-				InstrumentCode: "USD",
+				AccountCode:     fmt.Sprintf("MIXED-%08d", id+1000),
+				Name:            fmt.Sprintf("Mixed Workload Account %d", id),
+				AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+				ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+				InstrumentCode:  "USD",
 			}
 			_, err := tc.service.InitiateInternalBankAccount(ctx, req)
 			if err != nil {
@@ -194,10 +196,11 @@ func BenchmarkMixedWorkloadParallel(b *testing.B) {
 			default: // 10% creates
 				id := atomic.AddInt64(&createCounter, 1)
 				req := &pb.InitiateInternalBankAccountRequest{
-					AccountCode:    fmt.Sprintf("MIXPAR-%08d", id+10000),
-					Name:           fmt.Sprintf("Mixed Parallel Account %d", id),
-					AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-					InstrumentCode: "USD",
+					AccountCode:     fmt.Sprintf("MIXPAR-%08d", id+10000),
+					Name:            fmt.Sprintf("Mixed Parallel Account %d", id),
+					AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+					ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+					InstrumentCode:  "USD",
 				}
 				_, err := tc.service.InitiateInternalBankAccount(ctx, req)
 				if err != nil {
@@ -335,10 +338,11 @@ func TestThroughputMixedWorkload(t *testing.T) {
 				default: // 10% creates
 					id := atomic.AddInt64(&createCounter, 1)
 					req := &pb.InitiateInternalBankAccountRequest{
-						AccountCode:    fmt.Sprintf("THRU-%d-%08d", workerID, id),
-						Name:           fmt.Sprintf("Throughput Account %d", id),
-						AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-						InstrumentCode: "USD",
+						AccountCode:     fmt.Sprintf("THRU-%d-%08d", workerID, id),
+						Name:            fmt.Sprintf("Throughput Account %d", id),
+						AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+						ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+						InstrumentCode:  "USD",
 					}
 					_, err := tc.service.InitiateInternalBankAccount(ctx, req)
 					if err != nil {
@@ -467,10 +471,11 @@ func TestConcurrentMixedOperations(t *testing.T) {
 			default: // 10% creates
 				id := atomic.AddInt64(&createCounter, 1)
 				req := &pb.InitiateInternalBankAccountRequest{
-					AccountCode:    fmt.Sprintf("CMIX-%08d", id),
-					Name:           fmt.Sprintf("Concurrent Mixed Account %d", id),
-					AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-					InstrumentCode: "USD",
+					AccountCode:     fmt.Sprintf("CMIX-%08d", id),
+					Name:            fmt.Sprintf("Concurrent Mixed Account %d", id),
+					AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+					ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+					InstrumentCode:  "USD",
 				}
 				_, err := tc.service.InitiateInternalBankAccount(ctx, req)
 				if err != nil {
@@ -518,10 +523,11 @@ func TestConcurrentWriteContention(t *testing.T) {
 			defer wg.Done()
 
 			req := &pb.InitiateInternalBankAccountRequest{
-				AccountCode:    fmt.Sprintf("CONT-%08d", idx),
-				Name:           fmt.Sprintf("Contention Test Account %d", idx),
-				AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-				InstrumentCode: "USD",
+				AccountCode:     fmt.Sprintf("CONT-%08d", idx),
+				Name:            fmt.Sprintf("Contention Test Account %d", idx),
+				AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+				ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+				InstrumentCode:  "USD",
 			}
 
 			_, err := tc.service.InitiateInternalBankAccount(ctx, req)

--- a/services/internal-bank-account/benchmarks/nfr_validation_test.go
+++ b/services/internal-bank-account/benchmarks/nfr_validation_test.go
@@ -65,10 +65,11 @@ func createNFRBenchAccount(t *testing.T, tc *testContainer, codePrefix string) d
 // createNFRAccountRequest creates a proto request for NFR account creation tests.
 func createNFRAccountRequest(codePrefix string) *pb.InitiateInternalBankAccountRequest {
 	return &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    fmt.Sprintf("%s-%d", codePrefix, time.Now().UnixNano()%100000),
-		Name:           fmt.Sprintf("%s NFR Benchmark Account", codePrefix),
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     fmt.Sprintf("%s-%d", codePrefix, time.Now().UnixNano()%100000),
+		Name:            fmt.Sprintf("%s NFR Benchmark Account", codePrefix),
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	}
 }
 

--- a/services/internal-bank-account/domain/clearing_purpose.go
+++ b/services/internal-bank-account/domain/clearing_purpose.go
@@ -1,0 +1,45 @@
+// Package domain contains the core business logic for internal bank accounts.
+package domain
+
+// ClearingPurpose represents the specific purpose of a clearing account.
+// Only applicable to accounts of type CLEARING.
+type ClearingPurpose string
+
+// Clearing purpose constants for internal bank accounts.
+// These represent different operational purposes for clearing accounts.
+const (
+	// ClearingPurposeUnspecified indicates no specific clearing purpose.
+	// This is the default value for non-CLEARING accounts.
+	ClearingPurposeUnspecified ClearingPurpose = "CLEARING_PURPOSE_UNSPECIFIED"
+
+	// ClearingPurposeDeposit is used for clearing incoming deposits.
+	ClearingPurposeDeposit ClearingPurpose = "CLEARING_PURPOSE_DEPOSIT"
+
+	// ClearingPurposeWithdrawal is used for clearing outgoing withdrawals.
+	ClearingPurposeWithdrawal ClearingPurpose = "CLEARING_PURPOSE_WITHDRAWAL"
+
+	// ClearingPurposeSettlement is used for settling transactions between parties.
+	ClearingPurposeSettlement ClearingPurpose = "CLEARING_PURPOSE_SETTLEMENT"
+
+	// ClearingPurposeGeneral is used for general clearing operations.
+	ClearingPurposeGeneral ClearingPurpose = "CLEARING_PURPOSE_GENERAL"
+)
+
+// validClearingPurposes contains all valid clearing purposes for efficient lookup.
+var validClearingPurposes = map[ClearingPurpose]bool{
+	ClearingPurposeUnspecified: true,
+	ClearingPurposeDeposit:     true,
+	ClearingPurposeWithdrawal:  true,
+	ClearingPurposeSettlement:  true,
+	ClearingPurposeGeneral:     true,
+}
+
+// IsValid returns true if the clearing purpose is a recognized valid value.
+func (p ClearingPurpose) IsValid() bool {
+	return validClearingPurposes[p]
+}
+
+// String returns the string representation of the clearing purpose.
+func (p ClearingPurpose) String() string {
+	return string(p)
+}

--- a/services/internal-bank-account/domain/clearing_purpose_test.go
+++ b/services/internal-bank-account/domain/clearing_purpose_test.go
@@ -1,0 +1,160 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClearingPurpose_IsValid(t *testing.T) {
+	tests := []struct {
+		name            string
+		clearingPurpose ClearingPurpose
+		want            bool
+	}{
+		{
+			name:            "UNSPECIFIED is valid",
+			clearingPurpose: ClearingPurposeUnspecified,
+			want:            true,
+		},
+		{
+			name:            "DEPOSIT is valid",
+			clearingPurpose: ClearingPurposeDeposit,
+			want:            true,
+		},
+		{
+			name:            "WITHDRAWAL is valid",
+			clearingPurpose: ClearingPurposeWithdrawal,
+			want:            true,
+		},
+		{
+			name:            "SETTLEMENT is valid",
+			clearingPurpose: ClearingPurposeSettlement,
+			want:            true,
+		},
+		{
+			name:            "GENERAL is valid",
+			clearingPurpose: ClearingPurposeGeneral,
+			want:            true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.clearingPurpose.IsValid())
+		})
+	}
+}
+
+func TestClearingPurpose_Invalid(t *testing.T) {
+	tests := []struct {
+		name            string
+		clearingPurpose ClearingPurpose
+	}{
+		{
+			name:            "empty string is invalid",
+			clearingPurpose: ClearingPurpose(""),
+		},
+		{
+			name:            "unknown type is invalid",
+			clearingPurpose: ClearingPurpose("UNKNOWN"),
+		},
+		{
+			name:            "lowercase is invalid",
+			clearingPurpose: ClearingPurpose("deposit"),
+		},
+		{
+			name:            "mixed case is invalid",
+			clearingPurpose: ClearingPurpose("Deposit"),
+		},
+		{
+			name:            "typo is invalid",
+			clearingPurpose: ClearingPurpose("DEPOSITT"),
+		},
+		{
+			name:            "extra whitespace is invalid",
+			clearingPurpose: ClearingPurpose(" DEPOSIT"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.False(t, tt.clearingPurpose.IsValid())
+		})
+	}
+}
+
+func TestClearingPurpose_String(t *testing.T) {
+	tests := []struct {
+		name            string
+		clearingPurpose ClearingPurpose
+		want            string
+	}{
+		{
+			name:            "UNSPECIFIED string",
+			clearingPurpose: ClearingPurposeUnspecified,
+			want:            "CLEARING_PURPOSE_UNSPECIFIED",
+		},
+		{
+			name:            "DEPOSIT string",
+			clearingPurpose: ClearingPurposeDeposit,
+			want:            "CLEARING_PURPOSE_DEPOSIT",
+		},
+		{
+			name:            "WITHDRAWAL string",
+			clearingPurpose: ClearingPurposeWithdrawal,
+			want:            "CLEARING_PURPOSE_WITHDRAWAL",
+		},
+		{
+			name:            "SETTLEMENT string",
+			clearingPurpose: ClearingPurposeSettlement,
+			want:            "CLEARING_PURPOSE_SETTLEMENT",
+		},
+		{
+			name:            "GENERAL string",
+			clearingPurpose: ClearingPurposeGeneral,
+			want:            "CLEARING_PURPOSE_GENERAL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.clearingPurpose.String())
+		})
+	}
+}
+
+func TestClearingPurpose_Constants(t *testing.T) {
+	// Verify the constant values are as expected
+	assert.Equal(t, ClearingPurpose("CLEARING_PURPOSE_UNSPECIFIED"), ClearingPurposeUnspecified)
+	assert.Equal(t, ClearingPurpose("CLEARING_PURPOSE_DEPOSIT"), ClearingPurposeDeposit)
+	assert.Equal(t, ClearingPurpose("CLEARING_PURPOSE_WITHDRAWAL"), ClearingPurposeWithdrawal)
+	assert.Equal(t, ClearingPurpose("CLEARING_PURPOSE_SETTLEMENT"), ClearingPurposeSettlement)
+	assert.Equal(t, ClearingPurpose("CLEARING_PURPOSE_GENERAL"), ClearingPurposeGeneral)
+}
+
+func TestClearingPurpose_AllValidPurposesCount(t *testing.T) {
+	// Test that we have exactly 5 valid clearing purposes
+	validPurposes := []ClearingPurpose{
+		ClearingPurposeUnspecified,
+		ClearingPurposeDeposit,
+		ClearingPurposeWithdrawal,
+		ClearingPurposeSettlement,
+		ClearingPurposeGeneral,
+	}
+
+	for _, cp := range validPurposes {
+		assert.True(t, cp.IsValid(), "expected %s to be valid", cp)
+	}
+
+	assert.Len(t, validPurposes, 5, "expected exactly 5 valid clearing purposes")
+}
+
+func TestClearingPurpose_StringOnInvalid(t *testing.T) {
+	// Test String() on invalid types returns the underlying string
+	invalid := ClearingPurpose("INVALID")
+	assert.Equal(t, "INVALID", invalid.String())
+
+	empty := ClearingPurpose("")
+	assert.Equal(t, "", empty.String())
+}

--- a/services/internal-bank-account/domain/errors.go
+++ b/services/internal-bank-account/domain/errors.go
@@ -53,4 +53,8 @@ var (
 	// ErrClearingPurposeNotAllowed indicates that a clearing purpose was specified
 	// for an account type that is not CLEARING.
 	ErrClearingPurposeNotAllowed = errors.New("clearing purpose only allowed for CLEARING account type")
+
+	// ErrClearingPurposeRequired indicates that a CLEARING account was created
+	// without specifying a clearing purpose (cannot be UNSPECIFIED).
+	ErrClearingPurposeRequired = errors.New("clearing purpose required for CLEARING account type")
 )

--- a/services/internal-bank-account/domain/errors.go
+++ b/services/internal-bank-account/domain/errors.go
@@ -46,4 +46,11 @@ var (
 
 	// ErrNameRequired indicates the account name was not provided.
 	ErrNameRequired = errors.New("name is required")
+
+	// ErrInvalidClearingPurpose indicates an unrecognized clearing purpose was provided.
+	ErrInvalidClearingPurpose = errors.New("invalid clearing purpose")
+
+	// ErrClearingPurposeNotAllowed indicates that a clearing purpose was specified
+	// for an account type that is not CLEARING.
+	ErrClearingPurposeNotAllowed = errors.New("clearing purpose only allowed for CLEARING account type")
 )

--- a/services/internal-bank-account/domain/internal_account.go
+++ b/services/internal-bank-account/domain/internal_account.go
@@ -19,19 +19,20 @@ import (
 // - REVENUE: Tracking income and revenue streams
 // - EXPENSE: Tracking operational expenses
 type InternalBankAccount struct {
-	id             uuid.UUID
-	accountID      string // Business identifier like 'IBA-001'
-	accountCode    string // Unique code like 'GBP_CLEARING'
-	name           string // Display name
-	accountType    AccountType
-	instrumentCode string // References Reference Data (e.g., "USD", "GBP")
-	dimension      string // From reference_data (e.g., "CURRENCY", "ENERGY")
-	status         AccountStatus
-	correspondent  *CorrespondentDetails // Required for NOSTRO/VOSTRO
-	attributes     map[string]string     // Metadata
-	version        int64
-	createdAt      time.Time
-	updatedAt      time.Time
+	id              uuid.UUID
+	accountID       string // Business identifier like 'IBA-001'
+	accountCode     string // Unique code like 'GBP_CLEARING'
+	name            string // Display name
+	accountType     AccountType
+	clearingPurpose ClearingPurpose // Only meaningful for CLEARING accounts
+	instrumentCode  string          // References Reference Data (e.g., "USD", "GBP")
+	dimension       string          // From reference_data (e.g., "CURRENCY", "ENERGY")
+	status          AccountStatus
+	correspondent   *CorrespondentDetails // Required for NOSTRO/VOSTRO
+	attributes      map[string]string     // Metadata
+	version         int64
+	createdAt       time.Time
+	updatedAt       time.Time
 }
 
 // NewInternalBankAccount creates a new InternalBankAccount with validated fields.
@@ -45,9 +46,12 @@ type InternalBankAccount struct {
 // Validation:
 //   - accountID, accountCode, name cannot be empty
 //   - accountType must be valid
+//   - clearingPurpose must be valid if provided
+//   - clearingPurpose can only be non-UNSPECIFIED for CLEARING accounts
 func NewInternalBankAccount(
 	accountID, accountCode, name string,
 	accountType AccountType,
+	clearingPurpose ClearingPurpose,
 	instrumentCode, dimension string,
 ) (InternalBankAccount, error) {
 	if accountID == "" {
@@ -62,22 +66,30 @@ func NewInternalBankAccount(
 	if !accountType.IsValid() {
 		return InternalBankAccount{}, ErrInvalidAccountType
 	}
+	if !clearingPurpose.IsValid() {
+		return InternalBankAccount{}, ErrInvalidClearingPurpose
+	}
+	// Non-CLEARING accounts must not have a specific clearing purpose
+	if accountType != AccountTypeClearing && clearingPurpose != ClearingPurposeUnspecified {
+		return InternalBankAccount{}, ErrClearingPurposeNotAllowed
+	}
 
 	now := time.Now()
 	return InternalBankAccount{
-		id:             uuid.New(),
-		accountID:      accountID,
-		accountCode:    accountCode,
-		name:           name,
-		accountType:    accountType,
-		instrumentCode: instrumentCode,
-		dimension:      dimension,
-		status:         AccountStatusActive,
-		correspondent:  nil,
-		attributes:     nil,
-		version:        1,
-		createdAt:      now,
-		updatedAt:      now,
+		id:              uuid.New(),
+		accountID:       accountID,
+		accountCode:     accountCode,
+		name:            name,
+		accountType:     accountType,
+		clearingPurpose: clearingPurpose,
+		instrumentCode:  instrumentCode,
+		dimension:       dimension,
+		status:          AccountStatusActive,
+		correspondent:   nil,
+		attributes:      nil,
+		version:         1,
+		createdAt:       now,
+		updatedAt:       now,
 	}, nil
 }
 
@@ -209,6 +221,12 @@ func (a InternalBankAccount) AccountType() AccountType {
 	return a.accountType
 }
 
+// ClearingPurpose returns the clearing purpose.
+// Only meaningful for CLEARING account type; returns UNSPECIFIED for other types.
+func (a InternalBankAccount) ClearingPurpose() ClearingPurpose {
+	return a.clearingPurpose
+}
+
 // InstrumentCode returns the instrument code reference (e.g., "USD", "GBP").
 func (a InternalBankAccount) InstrumentCode() string {
 	return a.instrumentCode
@@ -299,6 +317,12 @@ func (b *InternalBankAccountBuilder) WithName(name string) *InternalBankAccountB
 // WithAccountType sets the account type.
 func (b *InternalBankAccountBuilder) WithAccountType(accountType AccountType) *InternalBankAccountBuilder {
 	b.account.accountType = accountType
+	return b
+}
+
+// WithClearingPurpose sets the clearing purpose.
+func (b *InternalBankAccountBuilder) WithClearingPurpose(clearingPurpose ClearingPurpose) *InternalBankAccountBuilder {
+	b.account.clearingPurpose = clearingPurpose
 	return b
 }
 

--- a/services/internal-bank-account/domain/internal_account.go
+++ b/services/internal-bank-account/domain/internal_account.go
@@ -73,6 +73,10 @@ func NewInternalBankAccount(
 	if accountType != AccountTypeClearing && clearingPurpose != ClearingPurposeUnspecified {
 		return InternalBankAccount{}, ErrClearingPurposeNotAllowed
 	}
+	// CLEARING accounts must have a specific clearing purpose (not UNSPECIFIED)
+	if accountType == AccountTypeClearing && clearingPurpose == ClearingPurposeUnspecified {
+		return InternalBankAccount{}, ErrClearingPurposeRequired
+	}
 
 	now := time.Now()
 	return InternalBankAccount{

--- a/services/internal-bank-account/domain/internal_account_test.go
+++ b/services/internal-bank-account/domain/internal_account_test.go
@@ -11,58 +11,64 @@ import (
 
 func TestNewInternalBankAccount_Success(t *testing.T) {
 	tests := []struct {
-		name           string
-		accountID      string
-		accountCode    string
-		accountName    string
-		accountType    AccountType
-		instrumentCode string
-		dimension      string
+		name            string
+		accountID       string
+		accountCode     string
+		accountName     string
+		accountType     AccountType
+		clearingPurpose ClearingPurpose
+		instrumentCode  string
+		dimension       string
 	}{
 		{
-			name:           "clearing account",
-			accountID:      "IBA-001",
-			accountCode:    "GBP_CLEARING",
-			accountName:    "GBP Clearing Account",
-			accountType:    AccountTypeClearing,
-			instrumentCode: "GBP",
-			dimension:      "CURRENCY",
+			name:            "clearing account with unspecified purpose",
+			accountID:       "IBA-001",
+			accountCode:     "GBP_CLEARING",
+			accountName:     "GBP Clearing Account",
+			accountType:     AccountTypeClearing,
+			clearingPurpose: ClearingPurposeUnspecified,
+			instrumentCode:  "GBP",
+			dimension:       "CURRENCY",
 		},
 		{
-			name:           "nostro account",
-			accountID:      "IBA-002",
-			accountCode:    "USD_NOSTRO_CHASE",
-			accountName:    "USD Nostro at Chase",
-			accountType:    AccountTypeNostro,
-			instrumentCode: "USD",
-			dimension:      "CURRENCY",
+			name:            "nostro account",
+			accountID:       "IBA-002",
+			accountCode:     "USD_NOSTRO_CHASE",
+			accountName:     "USD Nostro at Chase",
+			accountType:     AccountTypeNostro,
+			clearingPurpose: ClearingPurposeUnspecified,
+			instrumentCode:  "USD",
+			dimension:       "CURRENCY",
 		},
 		{
-			name:           "vostro account",
-			accountID:      "IBA-003",
-			accountCode:    "EUR_VOSTRO_DB",
-			accountName:    "EUR Vostro for Deutsche Bank",
-			accountType:    AccountTypeVostro,
-			instrumentCode: "EUR",
-			dimension:      "CURRENCY",
+			name:            "vostro account",
+			accountID:       "IBA-003",
+			accountCode:     "EUR_VOSTRO_DB",
+			accountName:     "EUR Vostro for Deutsche Bank",
+			accountType:     AccountTypeVostro,
+			clearingPurpose: ClearingPurposeUnspecified,
+			instrumentCode:  "EUR",
+			dimension:       "CURRENCY",
 		},
 		{
-			name:           "suspense account",
-			accountID:      "IBA-004",
-			accountCode:    "SUSPENSE_001",
-			accountName:    "General Suspense",
-			accountType:    AccountTypeSuspense,
-			instrumentCode: "USD",
-			dimension:      "CURRENCY",
+			name:            "suspense account",
+			accountID:       "IBA-004",
+			accountCode:     "SUSPENSE_001",
+			accountName:     "General Suspense",
+			accountType:     AccountTypeSuspense,
+			clearingPurpose: ClearingPurposeUnspecified,
+			instrumentCode:  "USD",
+			dimension:       "CURRENCY",
 		},
 		{
-			name:           "energy holding account",
-			accountID:      "IBA-005",
-			accountCode:    "KWH_HOLDING",
-			accountName:    "Energy Holding Account",
-			accountType:    AccountTypeHolding,
-			instrumentCode: "KWH",
-			dimension:      "ENERGY",
+			name:            "energy holding account",
+			accountID:       "IBA-005",
+			accountCode:     "KWH_HOLDING",
+			accountName:     "Energy Holding Account",
+			accountType:     AccountTypeHolding,
+			clearingPurpose: ClearingPurposeUnspecified,
+			instrumentCode:  "KWH",
+			dimension:       "ENERGY",
 		},
 	}
 
@@ -75,6 +81,7 @@ func TestNewInternalBankAccount_Success(t *testing.T) {
 				tt.accountCode,
 				tt.accountName,
 				tt.accountType,
+				tt.clearingPurpose,
 				tt.instrumentCode,
 				tt.dimension,
 			)
@@ -87,6 +94,7 @@ func TestNewInternalBankAccount_Success(t *testing.T) {
 			assert.Equal(t, tt.accountCode, account.AccountCode())
 			assert.Equal(t, tt.accountName, account.Name())
 			assert.Equal(t, tt.accountType, account.AccountType())
+			assert.Equal(t, tt.clearingPurpose, account.ClearingPurpose())
 			assert.Equal(t, tt.instrumentCode, account.InstrumentCode())
 			assert.Equal(t, tt.dimension, account.Dimension())
 
@@ -106,64 +114,81 @@ func TestNewInternalBankAccount_Success(t *testing.T) {
 
 func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 	tests := []struct {
-		name           string
-		accountID      string
-		accountCode    string
-		accountName    string
-		accountType    AccountType
-		instrumentCode string
-		dimension      string
-		expectedErr    error
+		name            string
+		accountID       string
+		accountCode     string
+		accountName     string
+		accountType     AccountType
+		clearingPurpose ClearingPurpose
+		instrumentCode  string
+		dimension       string
+		expectedErr     error
 	}{
 		{
-			name:           "empty account ID",
-			accountID:      "",
-			accountCode:    "GBP_CLEARING",
-			accountName:    "GBP Clearing Account",
-			accountType:    AccountTypeClearing,
-			instrumentCode: "GBP",
-			dimension:      "CURRENCY",
-			expectedErr:    ErrAccountIDRequired,
+			name:            "empty account ID",
+			accountID:       "",
+			accountCode:     "GBP_CLEARING",
+			accountName:     "GBP Clearing Account",
+			accountType:     AccountTypeClearing,
+			clearingPurpose: ClearingPurposeUnspecified,
+			instrumentCode:  "GBP",
+			dimension:       "CURRENCY",
+			expectedErr:     ErrAccountIDRequired,
 		},
 		{
-			name:           "empty account code",
-			accountID:      "IBA-001",
-			accountCode:    "",
-			accountName:    "GBP Clearing Account",
-			accountType:    AccountTypeClearing,
-			instrumentCode: "GBP",
-			dimension:      "CURRENCY",
-			expectedErr:    ErrAccountCodeRequired,
+			name:            "empty account code",
+			accountID:       "IBA-001",
+			accountCode:     "",
+			accountName:     "GBP Clearing Account",
+			accountType:     AccountTypeClearing,
+			clearingPurpose: ClearingPurposeUnspecified,
+			instrumentCode:  "GBP",
+			dimension:       "CURRENCY",
+			expectedErr:     ErrAccountCodeRequired,
 		},
 		{
-			name:           "empty name",
-			accountID:      "IBA-001",
-			accountCode:    "GBP_CLEARING",
-			accountName:    "",
-			accountType:    AccountTypeClearing,
-			instrumentCode: "GBP",
-			dimension:      "CURRENCY",
-			expectedErr:    ErrNameRequired,
+			name:            "empty name",
+			accountID:       "IBA-001",
+			accountCode:     "GBP_CLEARING",
+			accountName:     "",
+			accountType:     AccountTypeClearing,
+			clearingPurpose: ClearingPurposeUnspecified,
+			instrumentCode:  "GBP",
+			dimension:       "CURRENCY",
+			expectedErr:     ErrNameRequired,
 		},
 		{
-			name:           "invalid account type",
-			accountID:      "IBA-001",
-			accountCode:    "GBP_CLEARING",
-			accountName:    "GBP Clearing Account",
-			accountType:    AccountType("INVALID"),
-			instrumentCode: "GBP",
-			dimension:      "CURRENCY",
-			expectedErr:    ErrInvalidAccountType,
+			name:            "invalid account type",
+			accountID:       "IBA-001",
+			accountCode:     "GBP_CLEARING",
+			accountName:     "GBP Clearing Account",
+			accountType:     AccountType("INVALID"),
+			clearingPurpose: ClearingPurposeUnspecified,
+			instrumentCode:  "GBP",
+			dimension:       "CURRENCY",
+			expectedErr:     ErrInvalidAccountType,
 		},
 		{
-			name:           "empty account type",
-			accountID:      "IBA-001",
-			accountCode:    "GBP_CLEARING",
-			accountName:    "GBP Clearing Account",
-			accountType:    AccountType(""),
-			instrumentCode: "GBP",
-			dimension:      "CURRENCY",
-			expectedErr:    ErrInvalidAccountType,
+			name:            "empty account type",
+			accountID:       "IBA-001",
+			accountCode:     "GBP_CLEARING",
+			accountName:     "GBP Clearing Account",
+			accountType:     AccountType(""),
+			clearingPurpose: ClearingPurposeUnspecified,
+			instrumentCode:  "GBP",
+			dimension:       "CURRENCY",
+			expectedErr:     ErrInvalidAccountType,
+		},
+		{
+			name:            "invalid clearing purpose",
+			accountID:       "IBA-001",
+			accountCode:     "GBP_CLEARING",
+			accountName:     "GBP Clearing Account",
+			accountType:     AccountTypeClearing,
+			clearingPurpose: ClearingPurpose("INVALID"),
+			instrumentCode:  "GBP",
+			dimension:       "CURRENCY",
+			expectedErr:     ErrInvalidClearingPurpose,
 		},
 	}
 
@@ -174,6 +199,7 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 				tt.accountCode,
 				tt.accountName,
 				tt.accountType,
+				tt.clearingPurpose,
 				tt.instrumentCode,
 				tt.dimension,
 			)
@@ -456,6 +482,7 @@ func TestRename_Success(t *testing.T) {
 		"CLR-001",
 		"Original Name",
 		AccountTypeClearing,
+		ClearingPurposeUnspecified,
 		"USD",
 		"CURRENCY",
 	)
@@ -480,6 +507,7 @@ func TestRename_EmptyName(t *testing.T) {
 		"CLR-001",
 		"Original Name",
 		AccountTypeClearing,
+		ClearingPurposeUnspecified,
 		"USD",
 		"CURRENCY",
 	)
@@ -496,6 +524,7 @@ func TestRename_ClosedAccount(t *testing.T) {
 		"CLR-001",
 		"Original Name",
 		AccountTypeClearing,
+		ClearingPurposeUnspecified,
 		"USD",
 		"CURRENCY",
 	)
@@ -855,6 +884,7 @@ func TestNewInternalBankAccount_AllAccountTypes(t *testing.T) {
 				"CODE_"+tt.name,
 				"Test "+tt.name+" Account",
 				tt.accountType,
+				ClearingPurposeUnspecified,
 				"USD",
 				"CURRENCY",
 			)
@@ -981,10 +1011,137 @@ func createTestAccount(t *testing.T, accountType AccountType) InternalBankAccoun
 		accountCode,
 		name,
 		accountType,
+		ClearingPurposeUnspecified,
 		"USD",
 		"CURRENCY",
 	)
 	require.NoError(t, err)
 
 	return account
+}
+
+func TestNewInternalBankAccount_ClearingTypeWithPurpose(t *testing.T) {
+	// CLEARING accounts can have any valid clearing purpose
+	tests := []struct {
+		name            string
+		clearingPurpose ClearingPurpose
+	}{
+		{"UNSPECIFIED purpose", ClearingPurposeUnspecified},
+		{"DEPOSIT purpose", ClearingPurposeDeposit},
+		{"WITHDRAWAL purpose", ClearingPurposeWithdrawal},
+		{"SETTLEMENT purpose", ClearingPurposeSettlement},
+		{"GENERAL purpose", ClearingPurposeGeneral},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account, err := NewInternalBankAccount(
+				"IBA-001",
+				"GBP_CLEARING",
+				"GBP Clearing Account",
+				AccountTypeClearing,
+				tt.clearingPurpose,
+				"GBP",
+				"CURRENCY",
+			)
+
+			require.NoError(t, err)
+			assert.Equal(t, AccountTypeClearing, account.AccountType())
+			assert.Equal(t, tt.clearingPurpose, account.ClearingPurpose())
+		})
+	}
+}
+
+func TestNewInternalBankAccount_NonClearingTypeWithPurpose(t *testing.T) {
+	// Non-CLEARING accounts must not have a specific clearing purpose (only UNSPECIFIED is allowed)
+	nonClearingTypes := []AccountType{
+		AccountTypeNostro,
+		AccountTypeVostro,
+		AccountTypeHolding,
+		AccountTypeSuspense,
+		AccountTypeRevenue,
+		AccountTypeExpense,
+	}
+
+	specificPurposes := []ClearingPurpose{
+		ClearingPurposeDeposit,
+		ClearingPurposeWithdrawal,
+		ClearingPurposeSettlement,
+		ClearingPurposeGeneral,
+	}
+
+	for _, accountType := range nonClearingTypes {
+		for _, purpose := range specificPurposes {
+			testName := string(accountType) + " with " + string(purpose)
+			t.Run(testName, func(t *testing.T) {
+				account, err := NewInternalBankAccount(
+					"IBA-001",
+					"TEST_ACCOUNT",
+					"Test Account",
+					accountType,
+					purpose,
+					"USD",
+					"CURRENCY",
+				)
+
+				require.Error(t, err)
+				assert.ErrorIs(t, err, ErrClearingPurposeNotAllowed)
+				assert.Equal(t, InternalBankAccount{}, account, "should return zero value on error")
+			})
+		}
+	}
+}
+
+func TestNewInternalBankAccount_ClearingTypeWithUnspecified(t *testing.T) {
+	// CLEARING accounts with UNSPECIFIED purpose should be valid
+	account, err := NewInternalBankAccount(
+		"IBA-001",
+		"GBP_CLEARING",
+		"GBP Clearing Account",
+		AccountTypeClearing,
+		ClearingPurposeUnspecified,
+		"GBP",
+		"CURRENCY",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, AccountTypeClearing, account.AccountType())
+	assert.Equal(t, ClearingPurposeUnspecified, account.ClearingPurpose())
+}
+
+func TestBuilder_WithClearingPurpose(t *testing.T) {
+	// Test builder method for setting clearing purpose
+	id := uuid.New()
+	account := NewInternalBankAccountBuilder().
+		WithID(id).
+		WithAccountID("IBA-001").
+		WithAccountCode("GBP_CLEARING_DEPOSIT").
+		WithName("GBP Deposit Clearing").
+		WithAccountType(AccountTypeClearing).
+		WithClearingPurpose(ClearingPurposeDeposit).
+		WithInstrumentCode("GBP").
+		WithDimension("CURRENCY").
+		WithStatus(AccountStatusActive).
+		WithVersion(1).
+		WithCreatedAt(time.Now()).
+		WithUpdatedAt(time.Now()).
+		Build()
+
+	assert.Equal(t, id, account.ID())
+	assert.Equal(t, AccountTypeClearing, account.AccountType())
+	assert.Equal(t, ClearingPurposeDeposit, account.ClearingPurpose())
+}
+
+func TestBuilder_WithClearingPurpose_DefaultValue(t *testing.T) {
+	// Test that builder without WithClearingPurpose returns zero value (empty string)
+	account := NewInternalBankAccountBuilder().
+		WithID(uuid.New()).
+		WithAccountID("IBA-001").
+		WithAccountCode("TEST").
+		WithName("Test").
+		WithAccountType(AccountTypeClearing).
+		Build()
+
+	// Without calling WithClearingPurpose, the value should be the zero value
+	assert.Equal(t, ClearingPurpose(""), account.ClearingPurpose())
 }

--- a/services/internal-bank-account/domain/internal_account_test.go
+++ b/services/internal-bank-account/domain/internal_account_test.go
@@ -21,12 +21,12 @@ func TestNewInternalBankAccount_Success(t *testing.T) {
 		dimension       string
 	}{
 		{
-			name:            "clearing account with unspecified purpose",
+			name:            "clearing account with general purpose",
 			accountID:       "IBA-001",
 			accountCode:     "GBP_CLEARING",
 			accountName:     "GBP Clearing Account",
 			accountType:     AccountTypeClearing,
-			clearingPurpose: ClearingPurposeUnspecified,
+			clearingPurpose: ClearingPurposeGeneral,
 			instrumentCode:  "GBP",
 			dimension:       "CURRENCY",
 		},
@@ -130,7 +130,7 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 			accountCode:     "GBP_CLEARING",
 			accountName:     "GBP Clearing Account",
 			accountType:     AccountTypeClearing,
-			clearingPurpose: ClearingPurposeUnspecified,
+			clearingPurpose: ClearingPurposeGeneral,
 			instrumentCode:  "GBP",
 			dimension:       "CURRENCY",
 			expectedErr:     ErrAccountIDRequired,
@@ -141,7 +141,7 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 			accountCode:     "",
 			accountName:     "GBP Clearing Account",
 			accountType:     AccountTypeClearing,
-			clearingPurpose: ClearingPurposeUnspecified,
+			clearingPurpose: ClearingPurposeGeneral,
 			instrumentCode:  "GBP",
 			dimension:       "CURRENCY",
 			expectedErr:     ErrAccountCodeRequired,
@@ -152,7 +152,7 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 			accountCode:     "GBP_CLEARING",
 			accountName:     "",
 			accountType:     AccountTypeClearing,
-			clearingPurpose: ClearingPurposeUnspecified,
+			clearingPurpose: ClearingPurposeGeneral,
 			instrumentCode:  "GBP",
 			dimension:       "CURRENCY",
 			expectedErr:     ErrNameRequired,
@@ -163,7 +163,7 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 			accountCode:     "GBP_CLEARING",
 			accountName:     "GBP Clearing Account",
 			accountType:     AccountType("INVALID"),
-			clearingPurpose: ClearingPurposeUnspecified,
+			clearingPurpose: ClearingPurposeGeneral,
 			instrumentCode:  "GBP",
 			dimension:       "CURRENCY",
 			expectedErr:     ErrInvalidAccountType,
@@ -174,7 +174,7 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 			accountCode:     "GBP_CLEARING",
 			accountName:     "GBP Clearing Account",
 			accountType:     AccountType(""),
-			clearingPurpose: ClearingPurposeUnspecified,
+			clearingPurpose: ClearingPurposeGeneral,
 			instrumentCode:  "GBP",
 			dimension:       "CURRENCY",
 			expectedErr:     ErrInvalidAccountType,
@@ -189,6 +189,17 @@ func TestNewInternalBankAccount_ValidationErrors(t *testing.T) {
 			instrumentCode:  "GBP",
 			dimension:       "CURRENCY",
 			expectedErr:     ErrInvalidClearingPurpose,
+		},
+		{
+			name:            "clearing account with unspecified purpose",
+			accountID:       "IBA-001",
+			accountCode:     "GBP_CLEARING",
+			accountName:     "GBP Clearing Account",
+			accountType:     AccountTypeClearing,
+			clearingPurpose: ClearingPurposeUnspecified,
+			instrumentCode:  "GBP",
+			dimension:       "CURRENCY",
+			expectedErr:     ErrClearingPurposeRequired,
 		},
 	}
 
@@ -482,7 +493,7 @@ func TestRename_Success(t *testing.T) {
 		"CLR-001",
 		"Original Name",
 		AccountTypeClearing,
-		ClearingPurposeUnspecified,
+		ClearingPurposeGeneral,
 		"USD",
 		"CURRENCY",
 	)
@@ -507,7 +518,7 @@ func TestRename_EmptyName(t *testing.T) {
 		"CLR-001",
 		"Original Name",
 		AccountTypeClearing,
-		ClearingPurposeUnspecified,
+		ClearingPurposeGeneral,
 		"USD",
 		"CURRENCY",
 	)
@@ -524,7 +535,7 @@ func TestRename_ClosedAccount(t *testing.T) {
 		"CLR-001",
 		"Original Name",
 		AccountTypeClearing,
-		ClearingPurposeUnspecified,
+		ClearingPurposeGeneral,
 		"USD",
 		"CURRENCY",
 	)
@@ -865,16 +876,17 @@ func TestBuilder_MinimalFields(t *testing.T) {
 func TestNewInternalBankAccount_AllAccountTypes(t *testing.T) {
 	// Test creating accounts with all valid account types
 	tests := []struct {
-		name        string
-		accountType AccountType
+		name            string
+		accountType     AccountType
+		clearingPurpose ClearingPurpose
 	}{
-		{"CLEARING", AccountTypeClearing},
-		{"NOSTRO", AccountTypeNostro},
-		{"VOSTRO", AccountTypeVostro},
-		{"HOLDING", AccountTypeHolding},
-		{"SUSPENSE", AccountTypeSuspense},
-		{"REVENUE", AccountTypeRevenue},
-		{"EXPENSE", AccountTypeExpense},
+		{"CLEARING", AccountTypeClearing, ClearingPurposeGeneral},
+		{"NOSTRO", AccountTypeNostro, ClearingPurposeUnspecified},
+		{"VOSTRO", AccountTypeVostro, ClearingPurposeUnspecified},
+		{"HOLDING", AccountTypeHolding, ClearingPurposeUnspecified},
+		{"SUSPENSE", AccountTypeSuspense, ClearingPurposeUnspecified},
+		{"REVENUE", AccountTypeRevenue, ClearingPurposeUnspecified},
+		{"EXPENSE", AccountTypeExpense, ClearingPurposeUnspecified},
 	}
 
 	for _, tt := range tests {
@@ -884,7 +896,7 @@ func TestNewInternalBankAccount_AllAccountTypes(t *testing.T) {
 				"CODE_"+tt.name,
 				"Test "+tt.name+" Account",
 				tt.accountType,
-				ClearingPurposeUnspecified,
+				tt.clearingPurpose,
 				"USD",
 				"CURRENCY",
 			)
@@ -1006,12 +1018,18 @@ func createTestAccount(t *testing.T, accountType AccountType) InternalBankAccoun
 	accountCode := "TEST_" + string(accountType)
 	name := "Test " + string(accountType) + " Account"
 
+	// CLEARING accounts require a specific purpose, other types must use UNSPECIFIED
+	clearingPurpose := ClearingPurposeUnspecified
+	if accountType == AccountTypeClearing {
+		clearingPurpose = ClearingPurposeGeneral
+	}
+
 	account, err := NewInternalBankAccount(
 		accountID,
 		accountCode,
 		name,
 		accountType,
-		ClearingPurposeUnspecified,
+		clearingPurpose,
 		"USD",
 		"CURRENCY",
 	)
@@ -1021,12 +1039,11 @@ func createTestAccount(t *testing.T, accountType AccountType) InternalBankAccoun
 }
 
 func TestNewInternalBankAccount_ClearingTypeWithPurpose(t *testing.T) {
-	// CLEARING accounts can have any valid clearing purpose
+	// CLEARING accounts must have a specific clearing purpose (not UNSPECIFIED)
 	tests := []struct {
 		name            string
 		clearingPurpose ClearingPurpose
 	}{
-		{"UNSPECIFIED purpose", ClearingPurposeUnspecified},
 		{"DEPOSIT purpose", ClearingPurposeDeposit},
 		{"WITHDRAWAL purpose", ClearingPurposeWithdrawal},
 		{"SETTLEMENT purpose", ClearingPurposeSettlement},
@@ -1093,7 +1110,7 @@ func TestNewInternalBankAccount_NonClearingTypeWithPurpose(t *testing.T) {
 }
 
 func TestNewInternalBankAccount_ClearingTypeWithUnspecified(t *testing.T) {
-	// CLEARING accounts with UNSPECIFIED purpose should be valid
+	// CLEARING accounts with UNSPECIFIED purpose should be rejected
 	account, err := NewInternalBankAccount(
 		"IBA-001",
 		"GBP_CLEARING",
@@ -1104,9 +1121,9 @@ func TestNewInternalBankAccount_ClearingTypeWithUnspecified(t *testing.T) {
 		"CURRENCY",
 	)
 
-	require.NoError(t, err)
-	assert.Equal(t, AccountTypeClearing, account.AccountType())
-	assert.Equal(t, ClearingPurposeUnspecified, account.ClearingPurpose())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrClearingPurposeRequired)
+	assert.Equal(t, InternalBankAccount{}, account, "should return zero value on error")
 }
 
 func TestBuilder_WithClearingPurpose(t *testing.T) {

--- a/services/internal-bank-account/domain/repository.go
+++ b/services/internal-bank-account/domain/repository.go
@@ -46,6 +46,10 @@ type ListFilter struct {
 	// Status filters by account status. Nil matches all statuses.
 	Status *AccountStatus
 
+	// ClearingPurpose filters by clearing purpose. Nil matches all purposes.
+	// Only meaningful when filtering for CLEARING account types.
+	ClearingPurpose *ClearingPurpose
+
 	// Limit specifies the maximum number of results to return.
 	// Zero or negative values use the implementation's default limit.
 	Limit int

--- a/services/internal-bank-account/migrations/20260116000001_add_clearing_purpose.sql
+++ b/services/internal-bank-account/migrations/20260116000001_add_clearing_purpose.sql
@@ -1,18 +1,43 @@
 -- Add clearing_purpose column to internal_bank_account table
--- This column specifies the operational purpose for CLEARING account types.
--- Non-CLEARING accounts will have 'UNSPECIFIED' as the default value.
+-- This column distinguishes the specific purpose of CLEARING accounts
+-- Matches the ClearingPurpose enum in the protobuf definition
 
--- Add the clearing_purpose column
-ALTER TABLE "internal_bank_account" ADD COLUMN "clearing_purpose" character varying(20) NOT NULL DEFAULT 'UNSPECIFIED';
+-- Add the clearing_purpose column (nullable initially to allow existing data)
+ALTER TABLE "internal_bank_account"
+ADD COLUMN "clearing_purpose" character varying(32) NULL;
 
--- Add CHECK constraint for valid clearing purpose values
-ALTER TABLE "internal_bank_account" ADD CONSTRAINT "chk_clearing_purpose" CHECK (clearing_purpose IN (
-  'UNSPECIFIED', 'DEPOSIT', 'WITHDRAWAL', 'SETTLEMENT', 'GENERAL'
-));
+-- Backfill existing CLEARING accounts based on account_code patterns
+-- This is a best-effort mapping based on common naming conventions:
+--   - Codes ending in '-DEPOSIT' -> CLEARING_PURPOSE_DEPOSIT
+--   - Codes ending in '-WITHDRAW' or '-WITHDRAWAL' -> CLEARING_PURPOSE_WITHDRAWAL
+--   - Codes ending in '-SETTLEMENT' -> CLEARING_PURPOSE_SETTLEMENT
+--   - All other CLEARING accounts -> CLEARING_PURPOSE_GENERAL
+-- NOTE: Backfill MUST run before adding the constraint to avoid migration failure
+UPDATE "internal_bank_account"
+SET "clearing_purpose" = CASE
+  WHEN account_code LIKE '%-DEPOSIT' OR account_code LIKE '%-deposit' THEN 'CLEARING_PURPOSE_DEPOSIT'
+  WHEN account_code LIKE '%-WITHDRAW' OR account_code LIKE '%-WITHDRAWAL'
+       OR account_code LIKE '%-withdraw' OR account_code LIKE '%-withdrawal' THEN 'CLEARING_PURPOSE_WITHDRAWAL'
+  WHEN account_code LIKE '%-SETTLEMENT' OR account_code LIKE '%-settlement' THEN 'CLEARING_PURPOSE_SETTLEMENT'
+  ELSE 'CLEARING_PURPOSE_GENERAL'
+END
+WHERE account_type = 'CLEARING' AND clearing_purpose IS NULL;
 
--- Add index for filtered queries by clearing purpose
-CREATE INDEX "idx_internal_bank_account_clearing_purpose" ON "internal_bank_account" ("clearing_purpose");
+-- Add check constraint to enforce that CLEARING accounts must have a non-null clearing_purpose
+-- Non-CLEARING accounts should have NULL or CLEARING_PURPOSE_UNSPECIFIED
+-- NOTE: Constraint added AFTER backfill to ensure existing data satisfies it
+ALTER TABLE "internal_bank_account"
+ADD CONSTRAINT "chk_clearing_purpose_for_clearing_type"
+CHECK (
+  account_type != 'CLEARING' OR clearing_purpose IS NOT NULL
+);
 
--- Add comment for documentation
+-- Create partial index for efficient filtering of clearing accounts by purpose
+-- Only indexes rows where account_type = 'CLEARING', reducing index size
+CREATE INDEX "idx_internal_bank_account_clearing_purpose"
+ON "internal_bank_account" ("clearing_purpose")
+WHERE account_type = 'CLEARING';
+
+-- Add comment documenting the column
 COMMENT ON COLUMN "internal_bank_account"."clearing_purpose" IS
-  'Operational purpose for CLEARING accounts: DEPOSIT (incoming), WITHDRAWAL (outgoing), SETTLEMENT (inter-party), GENERAL (multi-purpose). UNSPECIFIED for non-CLEARING account types.';
+  'Purpose classification for CLEARING accounts: CLEARING_PURPOSE_DEPOSIT (deposits), CLEARING_PURPOSE_WITHDRAWAL (withdrawals), CLEARING_PURPOSE_SETTLEMENT (settlements), CLEARING_PURPOSE_GENERAL (general). NULL or UNSPECIFIED for non-CLEARING account types.';

--- a/services/internal-bank-account/migrations/20260116000001_add_clearing_purpose.sql
+++ b/services/internal-bank-account/migrations/20260116000001_add_clearing_purpose.sql
@@ -1,43 +1,18 @@
 -- Add clearing_purpose column to internal_bank_account table
--- This column distinguishes the specific purpose of CLEARING accounts
--- Matches the ClearingPurpose enum in the protobuf definition
+-- This column specifies the operational purpose for CLEARING account types.
+-- Non-CLEARING accounts will have 'UNSPECIFIED' as the default value.
 
--- Add the clearing_purpose column (nullable initially to allow existing data)
-ALTER TABLE "internal_bank_account"
-ADD COLUMN "clearing_purpose" character varying(32) NULL;
+-- Add the clearing_purpose column
+ALTER TABLE "internal_bank_account" ADD COLUMN "clearing_purpose" character varying(20) NOT NULL DEFAULT 'UNSPECIFIED';
 
--- Backfill existing CLEARING accounts based on account_code patterns
--- This is a best-effort mapping based on common naming conventions:
---   - Codes ending in '-DEPOSIT' -> CLEARING_PURPOSE_DEPOSIT
---   - Codes ending in '-WITHDRAW' or '-WITHDRAWAL' -> CLEARING_PURPOSE_WITHDRAWAL
---   - Codes ending in '-SETTLEMENT' -> CLEARING_PURPOSE_SETTLEMENT
---   - All other CLEARING accounts -> CLEARING_PURPOSE_GENERAL
--- NOTE: Backfill MUST run before adding the constraint to avoid migration failure
-UPDATE "internal_bank_account"
-SET "clearing_purpose" = CASE
-  WHEN account_code LIKE '%-DEPOSIT' OR account_code LIKE '%-deposit' THEN 'CLEARING_PURPOSE_DEPOSIT'
-  WHEN account_code LIKE '%-WITHDRAW' OR account_code LIKE '%-WITHDRAWAL'
-       OR account_code LIKE '%-withdraw' OR account_code LIKE '%-withdrawal' THEN 'CLEARING_PURPOSE_WITHDRAWAL'
-  WHEN account_code LIKE '%-SETTLEMENT' OR account_code LIKE '%-settlement' THEN 'CLEARING_PURPOSE_SETTLEMENT'
-  ELSE 'CLEARING_PURPOSE_GENERAL'
-END
-WHERE account_type = 'CLEARING' AND clearing_purpose IS NULL;
+-- Add CHECK constraint for valid clearing purpose values
+ALTER TABLE "internal_bank_account" ADD CONSTRAINT "chk_clearing_purpose" CHECK (clearing_purpose IN (
+  'UNSPECIFIED', 'DEPOSIT', 'WITHDRAWAL', 'SETTLEMENT', 'GENERAL'
+));
 
--- Add check constraint to enforce that CLEARING accounts must have a non-null clearing_purpose
--- Non-CLEARING accounts should have NULL or CLEARING_PURPOSE_UNSPECIFIED
--- NOTE: Constraint added AFTER backfill to ensure existing data satisfies it
-ALTER TABLE "internal_bank_account"
-ADD CONSTRAINT "chk_clearing_purpose_for_clearing_type"
-CHECK (
-  account_type != 'CLEARING' OR clearing_purpose IS NOT NULL
-);
+-- Add index for filtered queries by clearing purpose
+CREATE INDEX "idx_internal_bank_account_clearing_purpose" ON "internal_bank_account" ("clearing_purpose");
 
--- Create partial index for efficient filtering of clearing accounts by purpose
--- Only indexes rows where account_type = 'CLEARING', reducing index size
-CREATE INDEX "idx_internal_bank_account_clearing_purpose"
-ON "internal_bank_account" ("clearing_purpose")
-WHERE account_type = 'CLEARING';
-
--- Add comment documenting the column
+-- Add comment for documentation
 COMMENT ON COLUMN "internal_bank_account"."clearing_purpose" IS
-  'Purpose classification for CLEARING accounts: CLEARING_PURPOSE_DEPOSIT (deposits), CLEARING_PURPOSE_WITHDRAWAL (withdrawals), CLEARING_PURPOSE_SETTLEMENT (settlements), CLEARING_PURPOSE_GENERAL (general). NULL or UNSPECIFIED for non-CLEARING account types.';
+  'Operational purpose for CLEARING accounts: DEPOSIT (incoming), WITHDRAWAL (outgoing), SETTLEMENT (inter-party), GENERAL (multi-purpose). UNSPECIFIED for non-CLEARING account types.';

--- a/services/internal-bank-account/migrations/atlas.sum
+++ b/services/internal-bank-account/migrations/atlas.sum
@@ -1,3 +1,3 @@
-h1:hlYD/3kPm44q9HT7Ws0ibA/hG+udyK1HHWxf4jPG/dY=
+h1:ZLJmjBBDgjRhB9dUbGtPsUKu5MiSvPgJ2xGX+RUcYlI=
 20260112000001_initial.sql h1:DGFY67QMovT7UV5WkUEOrSZE7dLYIppV90Ix2x+qMls=
-20260116000001_add_clearing_purpose.sql h1:6O2TqPfMEf0BUXUi/zfq4ot8ZPW1s/zeNjvgIinrISI=
+20260116000001_add_clearing_purpose.sql h1:fZ83eW+T6liAQqcleV9kwMLVClrsbT25vlNGBZoqf6Y=

--- a/services/internal-bank-account/migrations/atlas.sum
+++ b/services/internal-bank-account/migrations/atlas.sum
@@ -1,3 +1,3 @@
-h1:ZLJmjBBDgjRhB9dUbGtPsUKu5MiSvPgJ2xGX+RUcYlI=
+h1:hlYD/3kPm44q9HT7Ws0ibA/hG+udyK1HHWxf4jPG/dY=
 20260112000001_initial.sql h1:DGFY67QMovT7UV5WkUEOrSZE7dLYIppV90Ix2x+qMls=
-20260116000001_add_clearing_purpose.sql h1:fZ83eW+T6liAQqcleV9kwMLVClrsbT25vlNGBZoqf6Y=
+20260116000001_add_clearing_purpose.sql h1:6O2TqPfMEf0BUXUi/zfq4ot8ZPW1s/zeNjvgIinrISI=

--- a/services/internal-bank-account/service/balance_service_test.go
+++ b/services/internal-bank-account/service/balance_service_test.go
@@ -43,10 +43,11 @@ func TestBalanceService_GetBalance_ReturnsCurrentBalance(t *testing.T) {
 
 	// Create an active account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-USD-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-USD-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -84,10 +85,11 @@ func TestBalanceService_GetBalance_MultiCurrency(t *testing.T) {
 
 	// Create EUR account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-EUR-001",
-		Name:           "EUR Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "EUR",
+		AccountCode:     "CLR-EUR-001",
+		Name:            "EUR Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "EUR",
 	})
 	require.NoError(t, err)
 
@@ -151,10 +153,11 @@ func TestBalanceService_GetBalance_RequiresActiveAccount(t *testing.T) {
 
 	// Create and suspend account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -196,10 +199,11 @@ func TestBalanceService_GetBalance_ReactivatedAccountQueryable(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -237,10 +241,11 @@ func TestBalanceService_GetBalance_ClosedAccountNotQueryable(t *testing.T) {
 
 	// Create and close account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -273,10 +278,11 @@ func TestBalanceService_GetBalance_HandlesPositionKeepingTimeout(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -302,10 +308,11 @@ func TestBalanceService_GetBalance_HandlesPositionKeepingRateLimiting(t *testing
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -329,10 +336,11 @@ func TestBalanceService_RequiresPositionKeepingClient(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -433,10 +441,11 @@ func TestBalanceService_MultipleBalanceTypes(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -485,10 +494,11 @@ func BenchmarkGetBalance(b *testing.B) {
 
 	ctx := context.Background()
 	resp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "BENCH-BAL-001",
-		Name:           "Benchmark Balance Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "BENCH-BAL-001",
+		Name:            "Benchmark Balance Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	if err != nil {
 		b.Fatalf("failed to create account: %v", err)
@@ -539,10 +549,11 @@ func BenchmarkGetBalance_MultipleBalanceTypes(b *testing.B) {
 
 	ctx := context.Background()
 	resp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "BENCH-MULTI-001",
-		Name:           "Benchmark Multi Balance Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "BENCH-MULTI-001",
+		Name:            "Benchmark Multi Balance Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	if err != nil {
 		b.Fatalf("failed to create account: %v", err)

--- a/services/internal-bank-account/service/mappers.go
+++ b/services/internal-bank-account/service/mappers.go
@@ -21,18 +21,22 @@ var ErrUnknownAccountType = errors.New("unknown account type")
 // ErrUnknownAccountStatus is returned when an account status value is not recognized.
 var ErrUnknownAccountStatus = errors.New("unknown account status")
 
+// ErrUnknownClearingPurpose is returned when a clearing purpose value is not recognized.
+var ErrUnknownClearingPurpose = errors.New("unknown clearing purpose")
+
 // toProtoFacility converts a domain InternalBankAccount to a proto InternalBankAccountFacility.
 func toProtoFacility(account domain.InternalBankAccount) *pb.InternalBankAccountFacility {
 	facility := &pb.InternalBankAccountFacility{
-		AccountId:      account.AccountID(),
-		AccountCode:    account.AccountCode(),
-		Name:           account.Name(),
-		AccountType:    accountTypeToProto(account.AccountType()),
-		AccountStatus:  accountStatusToProto(account.Status()),
-		InstrumentCode: account.InstrumentCode(),
-		CreatedAt:      timestamppb.New(account.CreatedAt()),
-		UpdatedAt:      timestamppb.New(account.UpdatedAt()),
-		Version:        int32(account.Version()),
+		AccountId:       account.AccountID(),
+		AccountCode:     account.AccountCode(),
+		Name:            account.Name(),
+		AccountType:     accountTypeToProto(account.AccountType()),
+		ClearingPurpose: clearingPurposeToProto(account.ClearingPurpose()),
+		AccountStatus:   accountStatusToProto(account.Status()),
+		InstrumentCode:  account.InstrumentCode(),
+		CreatedAt:       timestamppb.New(account.CreatedAt()),
+		UpdatedAt:       timestamppb.New(account.UpdatedAt()),
+		Version:         int32(account.Version()),
 	}
 
 	// Map correspondent details if present
@@ -128,6 +132,42 @@ func accountStatusToProto(as domain.AccountStatus) pb.InternalAccountStatus {
 	}
 }
 
+// protoToClearingPurpose converts a proto ClearingPurpose to a domain ClearingPurpose.
+func protoToClearingPurpose(pc pb.ClearingPurpose) (domain.ClearingPurpose, error) {
+	switch pc {
+	case pb.ClearingPurpose_CLEARING_PURPOSE_UNSPECIFIED:
+		return domain.ClearingPurposeUnspecified, nil
+	case pb.ClearingPurpose_CLEARING_PURPOSE_DEPOSIT:
+		return domain.ClearingPurposeDeposit, nil
+	case pb.ClearingPurpose_CLEARING_PURPOSE_WITHDRAWAL:
+		return domain.ClearingPurposeWithdrawal, nil
+	case pb.ClearingPurpose_CLEARING_PURPOSE_SETTLEMENT:
+		return domain.ClearingPurposeSettlement, nil
+	case pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL:
+		return domain.ClearingPurposeGeneral, nil
+	default:
+		return "", fmt.Errorf("%w: %v", ErrUnknownClearingPurpose, pc)
+	}
+}
+
+// clearingPurposeToProto converts a domain ClearingPurpose to a proto ClearingPurpose.
+func clearingPurposeToProto(cp domain.ClearingPurpose) pb.ClearingPurpose {
+	switch cp {
+	case domain.ClearingPurposeDeposit:
+		return pb.ClearingPurpose_CLEARING_PURPOSE_DEPOSIT
+	case domain.ClearingPurposeWithdrawal:
+		return pb.ClearingPurpose_CLEARING_PURPOSE_WITHDRAWAL
+	case domain.ClearingPurposeSettlement:
+		return pb.ClearingPurpose_CLEARING_PURPOSE_SETTLEMENT
+	case domain.ClearingPurposeGeneral:
+		return pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL
+	case domain.ClearingPurposeUnspecified:
+		return pb.ClearingPurpose_CLEARING_PURPOSE_UNSPECIFIED
+	default:
+		return pb.ClearingPurpose_CLEARING_PURPOSE_UNSPECIFIED
+	}
+}
+
 // correspondentTypeFromAccountType returns the correspondent type based on account type.
 func correspondentTypeFromAccountType(at domain.AccountType) pb.CorrespondentType {
 	switch at {
@@ -169,7 +209,9 @@ func mapDomainErrorToGRPC(err error) error {
 		return status.Error(codes.Aborted, err.Error())
 	case errors.Is(err, domain.ErrAccountIDRequired),
 		errors.Is(err, domain.ErrAccountCodeRequired),
-		errors.Is(err, domain.ErrNameRequired):
+		errors.Is(err, domain.ErrNameRequired),
+		errors.Is(err, domain.ErrInvalidClearingPurpose),
+		errors.Is(err, domain.ErrClearingPurposeNotAllowed):
 		return status.Error(codes.InvalidArgument, err.Error())
 	default:
 		return status.Errorf(codes.Internal, "internal error: %v", err)

--- a/services/internal-bank-account/service/mappers.go
+++ b/services/internal-bank-account/service/mappers.go
@@ -211,7 +211,8 @@ func mapDomainErrorToGRPC(err error) error {
 		errors.Is(err, domain.ErrAccountCodeRequired),
 		errors.Is(err, domain.ErrNameRequired),
 		errors.Is(err, domain.ErrInvalidClearingPurpose),
-		errors.Is(err, domain.ErrClearingPurposeNotAllowed):
+		errors.Is(err, domain.ErrClearingPurposeNotAllowed),
+		errors.Is(err, domain.ErrClearingPurposeRequired):
 		return status.Error(codes.InvalidArgument, err.Error())
 	default:
 		return status.Errorf(codes.Internal, "internal error: %v", err)

--- a/services/internal-bank-account/service/mappers_test.go
+++ b/services/internal-bank-account/service/mappers_test.go
@@ -183,6 +183,7 @@ func TestToProtoFacility(t *testing.T) {
 		"CLR-001",
 		"Test Clearing Account",
 		domain.AccountTypeClearing,
+		domain.ClearingPurposeDeposit,
 		"USD",
 		"CURRENCY",
 	)
@@ -194,6 +195,7 @@ func TestToProtoFacility(t *testing.T) {
 	assert.Equal(t, "CLR-001", facility.AccountCode)
 	assert.Equal(t, "Test Clearing Account", facility.Name)
 	assert.Equal(t, pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING, facility.AccountType)
+	assert.Equal(t, pb.ClearingPurpose_CLEARING_PURPOSE_DEPOSIT, facility.ClearingPurpose)
 	assert.Equal(t, pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE, facility.AccountStatus)
 	assert.Equal(t, "USD", facility.InstrumentCode)
 	assert.Nil(t, facility.CorrespondentDetails)
@@ -209,6 +211,7 @@ func TestToProtoFacility_WithCorrespondent(t *testing.T) {
 		"NOSTRO-USD-HSBC",
 		"HSBC USD Nostro",
 		domain.AccountTypeNostro,
+		domain.ClearingPurposeUnspecified,
 		"USD",
 		"CURRENCY",
 	)
@@ -235,4 +238,55 @@ func TestToProtoFacility_WithCorrespondent(t *testing.T) {
 	assert.Equal(t, "12345678", facility.CorrespondentDetails.ExternalAccountRef)
 	assert.Equal(t, "HSBCGB2L", facility.CorrespondentDetails.SwiftCode)
 	assert.Equal(t, pb.CorrespondentType_CORRESPONDENT_TYPE_NOSTRO, facility.CorrespondentDetails.CorrespondentType)
+}
+
+func TestProtoToClearingPurpose(t *testing.T) {
+	testCases := []struct {
+		name     string
+		proto    pb.ClearingPurpose
+		expected domain.ClearingPurpose
+		wantErr  bool
+	}{
+		{"Unspecified", pb.ClearingPurpose_CLEARING_PURPOSE_UNSPECIFIED, domain.ClearingPurposeUnspecified, false},
+		{"Deposit", pb.ClearingPurpose_CLEARING_PURPOSE_DEPOSIT, domain.ClearingPurposeDeposit, false},
+		{"Withdrawal", pb.ClearingPurpose_CLEARING_PURPOSE_WITHDRAWAL, domain.ClearingPurposeWithdrawal, false},
+		{"Settlement", pb.ClearingPurpose_CLEARING_PURPOSE_SETTLEMENT, domain.ClearingPurposeSettlement, false},
+		{"General", pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL, domain.ClearingPurposeGeneral, false},
+		{"Unknown", pb.ClearingPurpose(999), "", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := protoToClearingPurpose(tc.proto)
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, ErrUnknownClearingPurpose)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestClearingPurposeToProto(t *testing.T) {
+	testCases := []struct {
+		name     string
+		domain   domain.ClearingPurpose
+		expected pb.ClearingPurpose
+	}{
+		{"Unspecified", domain.ClearingPurposeUnspecified, pb.ClearingPurpose_CLEARING_PURPOSE_UNSPECIFIED},
+		{"Deposit", domain.ClearingPurposeDeposit, pb.ClearingPurpose_CLEARING_PURPOSE_DEPOSIT},
+		{"Withdrawal", domain.ClearingPurposeWithdrawal, pb.ClearingPurpose_CLEARING_PURPOSE_WITHDRAWAL},
+		{"Settlement", domain.ClearingPurposeSettlement, pb.ClearingPurpose_CLEARING_PURPOSE_SETTLEMENT},
+		{"General", domain.ClearingPurposeGeneral, pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL},
+		{"Unknown", domain.ClearingPurpose("UNKNOWN"), pb.ClearingPurpose_CLEARING_PURPOSE_UNSPECIFIED},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := clearingPurposeToProto(tc.domain)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -167,12 +167,20 @@ func (s *Service) InitiateInternalBankAccount(ctx context.Context, req *pb.Initi
 	// Generate account ID using full UUID for uniqueness
 	accountID := fmt.Sprintf("IBA-%s", uuid.New().String())
 
+	// Convert clearing purpose from proto to domain
+	clearingPurpose, err := protoToClearingPurpose(req.ClearingPurpose)
+	if err != nil {
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.InvalidArgument, "invalid clearing purpose: %v", err)
+	}
+
 	// Create domain entity with dimension from Reference Data
 	account, err := domain.NewInternalBankAccount(
 		accountID,
 		req.AccountCode,
 		req.Name,
 		accountType,
+		clearingPurpose,
 		req.InstrumentCode,
 		dimension,
 	)
@@ -439,6 +447,14 @@ func (s *Service) ListInternalBankAccounts(ctx context.Context, req *pb.ListInte
 		accountStatus, err := protoToAccountStatus(req.StatusFilter)
 		if err == nil {
 			filter.Status = &accountStatus
+		}
+	}
+
+	// Apply clearing purpose filter
+	if req.ClearingPurposeFilter != pb.ClearingPurpose_CLEARING_PURPOSE_UNSPECIFIED {
+		clearingPurpose, err := protoToClearingPurpose(req.ClearingPurposeFilter)
+		if err == nil {
+			filter.ClearingPurpose = &clearingPurpose
 		}
 	}
 

--- a/services/internal-bank-account/service/server_test.go
+++ b/services/internal-bank-account/service/server_test.go
@@ -158,10 +158,11 @@ func TestInitiateInternalBankAccount_Success(t *testing.T) {
 
 	ctx := context.Background()
 	req := &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	}
 
 	resp, err := svc.InitiateInternalBankAccount(ctx, req)
@@ -253,10 +254,11 @@ func TestRetrieveInternalBankAccount_Success(t *testing.T) {
 
 	// First create an account
 	createReq := &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	}
 	createResp, err := svc.InitiateInternalBankAccount(ctx, createReq)
 	require.NoError(t, err)
@@ -294,10 +296,11 @@ func TestControlInternalBankAccount_Suspend(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -320,10 +323,11 @@ func TestControlInternalBankAccount_Close(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -346,10 +350,11 @@ func TestControlInternalBankAccount_InvalidTransition(t *testing.T) {
 
 	// Create and close account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -382,10 +387,11 @@ func TestListInternalBankAccounts_Success(t *testing.T) {
 	// Create multiple accounts
 	for i := 0; i < 3; i++ {
 		_, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-			AccountCode:    "CLR-00" + string(rune('1'+i)),
-			Name:           "Clearing Account " + string(rune('1'+i)),
-			AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-			InstrumentCode: "USD",
+			AccountCode:     "CLR-00" + string(rune('1'+i)),
+			Name:            "Clearing Account " + string(rune('1'+i)),
+			AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+			ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+			InstrumentCode:  "USD",
 		})
 		require.NoError(t, err)
 	}
@@ -416,10 +422,11 @@ func TestGetBalance_Success(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -444,10 +451,11 @@ func TestGetBalance_AccountSuspended(t *testing.T) {
 
 	// Create and suspend account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -478,10 +486,11 @@ func TestGetBalance_NoPositionKeepingClient(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -526,10 +535,11 @@ func TestGetBalance_AccountClosed(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -564,10 +574,11 @@ func TestGetBalance_PositionKeepingError(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -593,10 +604,11 @@ func TestGetBalance_PositionKeepingUnavailable(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -619,10 +631,11 @@ func TestUpdateInternalBankAccount_Success(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "USD Clearing Account", createResp.Facility.Name)
@@ -647,10 +660,11 @@ func TestUpdateInternalBankAccount_VersionConflict(t *testing.T) {
 
 	// Create account (version 1)
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 	originalVersion := createResp.Facility.Version
@@ -686,10 +700,11 @@ func TestUpdateInternalBankAccount_ClosedAccount(t *testing.T) {
 
 	// Create and close account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -730,10 +745,11 @@ func TestInitiateInternalBankAccount_WithReferenceDataValidation_Success(t *test
 
 	ctx := context.Background()
 	req := &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	}
 
 	resp, err := svc.InitiateInternalBankAccount(ctx, req)
@@ -758,10 +774,11 @@ func TestInitiateInternalBankAccount_InstrumentNotFound(t *testing.T) {
 
 	ctx := context.Background()
 	req := &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "Test Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "INVALID",
+		AccountCode:     "CLR-001",
+		Name:            "Test Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "INVALID",
 	}
 
 	resp, err := svc.InitiateInternalBankAccount(ctx, req)
@@ -788,10 +805,11 @@ func TestInitiateInternalBankAccount_InstrumentNotActive(t *testing.T) {
 
 	ctx := context.Background()
 	req := &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "Test Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "DRAFT_COIN",
+		AccountCode:     "CLR-001",
+		Name:            "Test Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "DRAFT_COIN",
 	}
 
 	resp, err := svc.InitiateInternalBankAccount(ctx, req)
@@ -818,10 +836,11 @@ func TestInitiateInternalBankAccount_InstrumentDeprecated(t *testing.T) {
 
 	ctx := context.Background()
 	req := &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "Test Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "OLD_COIN",
+		AccountCode:     "CLR-001",
+		Name:            "Test Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "OLD_COIN",
 	}
 
 	resp, err := svc.InitiateInternalBankAccount(ctx, req)
@@ -844,10 +863,11 @@ func TestInitiateInternalBankAccount_ReferenceDataServiceUnavailable(t *testing.
 
 	ctx := context.Background()
 	req := &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "Test Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "Test Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	}
 
 	resp, err := svc.InitiateInternalBankAccount(ctx, req)
@@ -870,10 +890,11 @@ func TestInitiateInternalBankAccount_ReferenceDataTimeout(t *testing.T) {
 
 	ctx := context.Background()
 	req := &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "Test Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "Test Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	}
 
 	resp, err := svc.InitiateInternalBankAccount(ctx, req)
@@ -896,10 +917,11 @@ func TestInitiateInternalBankAccount_NilInstrumentInResponse(t *testing.T) {
 
 	ctx := context.Background()
 	req := &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "Test Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "Test Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	}
 
 	resp, err := svc.InitiateInternalBankAccount(ctx, req)
@@ -984,10 +1006,11 @@ func TestInitiateInternalBankAccount_DuplicateCode(t *testing.T) {
 
 	// Create first account
 	_, err = svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -996,10 +1019,11 @@ func TestInitiateInternalBankAccount_DuplicateCode(t *testing.T) {
 
 	// Try to create account with same code - should fail
 	resp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "Another USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "Another USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
@@ -1019,10 +1043,11 @@ func TestInitiateInternalBankAccount_RepositoryError(t *testing.T) {
 
 	// Try to create account when repository has error
 	resp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	assert.Error(t, err)
 	assert.Nil(t, resp)
@@ -1060,10 +1085,11 @@ func TestUpdateInternalBankAccount_RepositorySaveError(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -1091,10 +1117,11 @@ func TestControlInternalBankAccount_Reactivate(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 	assert.Equal(t, pb.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE, createResp.Facility.AccountStatus)
@@ -1148,10 +1175,11 @@ func TestControlInternalBankAccount_UnspecifiedAction(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -1177,10 +1205,11 @@ func TestControlInternalBankAccount_RepositorySaveError(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -1209,10 +1238,11 @@ func TestListInternalBankAccounts_WithFilters(t *testing.T) {
 
 	// Create accounts with different types
 	_, err = svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -1264,10 +1294,11 @@ func TestGetBalance_ZeroBalance(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -1292,10 +1323,11 @@ func TestGetBalance_PositionKeepingNotFound(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -1321,10 +1353,11 @@ func TestGetBalance_PositionKeepingDeadlineExceeded(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 
@@ -1350,10 +1383,11 @@ func TestGetBalance_PositionKeepingResourceExhausted(t *testing.T) {
 
 	// Create account
 	createResp, err := svc.InitiateInternalBankAccount(ctx, &pb.InitiateInternalBankAccountRequest{
-		AccountCode:    "CLR-001",
-		Name:           "USD Clearing Account",
-		AccountType:    pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
-		InstrumentCode: "USD",
+		AccountCode:     "CLR-001",
+		Name:            "USD Clearing Account",
+		AccountType:     pb.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		ClearingPurpose: pb.ClearingPurpose_CLEARING_PURPOSE_GENERAL,
+		InstrumentCode:  "USD",
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
## Summary

Extend the Internal Bank Account domain aggregate and repository to support the `clearing_purpose` field with cross-field validation. This enables differentiation of clearing accounts by purpose (deposit, withdrawal, settlement, general).

- Add `ClearingPurpose` type with validation in domain layer
- Add `clearingPurpose` field to `InternalBankAccount` aggregate with cross-field validation (non-CLEARING accounts must use UNSPECIFIED)
- Add `clearing_purpose` column to repository layer with filtering support
- Add database migration for `clearing_purpose` column with CHECK constraint
- Update proto<->domain mappers for bidirectional conversion
- Update service layer to pass clearing_purpose through InitiateAccount and List operations

## Changes Made

### Domain Layer (`services/internal-bank-account/domain/`)
- **`clearing_purpose.go`**: New type with constants (Unspecified, Deposit, Withdrawal, Settlement, General) and validation
- **`internal_account.go`**: Added `clearingPurpose` field, updated constructor with validation, added getter and builder method
- **`errors.go`**: Added `ErrInvalidClearingPurpose` and `ErrClearingPurposeNotAllowed` errors
- **`repository.go`**: Added `ClearingPurpose` filter to `ListFilter`

### Repository Layer (`services/internal-bank-account/adapters/persistence/`)
- **`account_entity.go`**: Added `ClearingPurpose` field with GORM tags
- **`mappers.go`**: Updated toEntity/toDomain mappers for clearing_purpose
- **`repository.go`**: Added clearing_purpose to Save updates and List filtering

### Service Layer (`services/internal-bank-account/service/`)
- **`mappers.go`**: Added `protoToClearingPurpose` and `clearingPurposeToProto` conversion functions, updated error handling
- **`server.go`**: Updated InitiateAccount to convert and pass clearing_purpose, added filtering in ListAccounts

### Migration
- **`migrations/20260116000001_add_clearing_purpose.sql`**: Adds `clearing_purpose` column with CHECK constraint and index

## Test plan

- [x] Unit tests for ClearingPurpose type validation (IsValid, String)
- [x] Unit tests for domain validation (CLEARING accounts with purpose, non-CLEARING accounts reject purpose)
- [x] Unit tests for builder with ClearingPurpose
- [x] Repository tests for clearing_purpose mapping and filtering
- [x] Service layer tests for proto<->domain conversion
- [x] Integration tests pass with testcontainers
- [x] Benchmark tests updated with new schema column
- [x] All pre-commit checks pass (gofumpt, golangci-lint)

## Task Reference

Task: internal-bank-account.22