### PR TITLE
docs: add generate-llm-blueprint skill

### DIFF
--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -28,6 +28,10 @@ Each skill document includes:
 
 - **[testing.md](testing.md)** - Testing standards: await package, testcontainers, defensive testing
 
+### Tooling
+
+- **[generate-llm-blueprint.md](generate-llm-blueprint.md)** - Generate codebase blueprint for LLMs
+
 ## Skill Metadata Format
 
 Skills use YAML frontmatter at the start of each document:

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -32,6 +32,36 @@ Each skill document includes:
 
 - **[generate-llm-blueprint.md](generate-llm-blueprint.md)** - Generate codebase blueprint for LLMs
 
+## Additional Skill Locations
+
+Skills are also found in these directories - each document has YAML frontmatter with triggers:
+
+### Architecture Decision Records (ADRs)
+
+**Location:** [`../adr/`](../adr/README.md)
+
+ADRs capture architectural decisions with context and rationale. Load when discussing:
+- Service design and boundaries
+- Technology choices and trade-offs
+- Implementation patterns
+
+### Runbooks
+
+**Location:** [`../runbooks/`](../runbooks/)
+
+Operational procedures for incidents and recovery. Load when handling:
+- Security incidents or outages
+- Disaster recovery scenarios
+- Service degradation
+
+### Product Requirements (PRDs)
+
+**Location:** [`../prd/`](../prd/)
+
+Product specifications and feature designs. Load when understanding:
+- Feature scope and requirements
+- Business context and goals
+
 ## Skill Metadata Format
 
 Skills use YAML frontmatter at the start of each document:
@@ -149,7 +179,4 @@ Content starts here...
 
 ## Related Documentation
 
-- Architecture decisions: `../adr/` - Architectural choices and rationale
-- Runbooks: `../runbooks/` - Operational procedures
-- Main project docs: `../` - General documentation
-- Claude Code config: `../claude-code-skills.md` - Skills system overview
+- Claude Code skills system: `../claude-code-skills.md` - How the skills system works

--- a/docs/skills/generate-llm-blueprint.md
+++ b/docs/skills/generate-llm-blueprint.md
@@ -1,0 +1,46 @@
+# Generate LLM Blueprint
+
+Generate a comprehensive codebase blueprint for uploading to Claude Projects or other LLMs.
+
+## Command
+
+Run from the `meridian-main` directory:
+
+```bash
+repomix --style markdown \
+  --include "**/*.md,api/proto/**/*.proto,**/*.sql,**/atlas.hcl,**/openapi.json,go.mod" \
+  --ignore "node_modules/**,**/CHANGELOG.md" \
+  --remove-empty-lines \
+  -o ../meridian-blueprint.md
+```
+
+## What's Included (~495k tokens)
+
+| Content | Purpose |
+|---------|---------|
+| Markdown docs | PRDs, ADRs, architecture, runbooks, READMEs |
+| Proto files | gRPC API contracts and data models |
+| SQL migrations | Database schemas |
+| Atlas HCL | Migration configurations |
+| OpenAPI specs | REST API definitions |
+| go.mod | Dependency graph |
+
+## What's Excluded
+
+- Go implementation code (too verbose for context windows)
+- Test files
+- Generated protobuf code (`*.pb.go`, `*_grpc.pb.go`)
+- node_modules
+- CHANGELOG files
+
+## Why This Works
+
+The markdown documentation serves as a compressed blueprint of system behavior. ADRs capture
+architectural decisions and rationale, PRDs define what's being built, and proto files define the
+contracts. An LLM with this context can understand *how Meridian works* without reading 861k+ tokens
+of implementation code.
+
+## Output Location
+
+The file is written to `../meridian-blueprint.md` (repo root, outside `meridian-main`) to keep it
+separate from the codebase and easily accessible for upload.

--- a/docs/skills/generate-llm-blueprint.md
+++ b/docs/skills/generate-llm-blueprint.md
@@ -1,3 +1,15 @@
+---
+name: generate-llm-blueprint
+description: Generate codebase blueprint for Claude Projects or other LLMs
+triggers:
+  - Uploading codebase to Claude Projects
+  - Creating context for LLMs
+  - Repomix blueprint generation
+instructions: |
+  Run repomix from meridian-main to generate meridian-blueprint.md.
+  Includes docs, protos, SQL, atlas configs. Excludes Go implementation code.
+---
+
 # Generate LLM Blueprint
 
 Generate a comprehensive codebase blueprint for uploading to Claude Projects or other LLMs.
@@ -14,7 +26,7 @@ repomix --style markdown \
   -o ../meridian-blueprint.md
 ```
 
-## What's Included (~495k tokens)
+## What's Included
 
 | Content | Purpose |
 |---------|---------|


### PR DESCRIPTION
## Summary

- Add skill document for generating codebase blueprints using repomix
- Document captures markdown docs, proto files, SQL migrations, Atlas configs, and OpenAPI specs
- Useful for uploading to Claude Projects or other LLMs

## Changes

- `docs/skills/generate-llm-blueprint.md` - New skill document with repomix command and explanation
- `docs/skills/README.md` - Added link to new skill under Tooling section

## Test Plan

- [x] Verified repomix command works and produces expected output
- [x] Markdown linting passes