### PR TITLE
feat(payment-order): integrate Internal Bank Account client for clearing operations

### DIFF
--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -32,6 +32,7 @@ import (
 	// Service-owned clients (standardized client packages from each service)
 	currentaccountclient "github.com/meridianhub/meridian/services/current-account/client"
 	financialaccountingclient "github.com/meridianhub/meridian/services/financial-accounting/client"
+	internalbankaccountclient "github.com/meridianhub/meridian/services/internal-bank-account/client"
 )
 
 // Build information set via ldflags during compilation.
@@ -110,6 +111,22 @@ func run(logger *slog.Logger) error {
 	}
 	defer faCleanup()
 
+	// Create internal bank account client (optional - for internal clearing operations)
+	// This client is only created if INTERNAL_CLEARING_ENABLED is true
+	internalClearingEnabled := env.GetEnvAsBool("INTERNAL_CLEARING_ENABLED", false)
+	var internalBankAccountClient service.InternalBankAccountClient
+	var ibaCleanup func()
+	if internalClearingEnabled {
+		internalBankAccountClient, ibaCleanup, err = createInternalBankAccountClient(namespace, logger, tracer)
+		if err != nil {
+			return fmt.Errorf("failed to create internal bank account client: %w", err)
+		}
+		defer ibaCleanup()
+		logger.Info("internal clearing enabled - internal bank account client configured")
+	} else {
+		logger.Info("internal clearing disabled - gateway-only mode")
+	}
+
 	// Create payment gateway
 	paymentGateway := createPaymentGateway(logger)
 
@@ -143,12 +160,14 @@ func run(logger *slog.Logger) error {
 		Repository:                repo,
 		CurrentAccountClient:      currentAccountClient,
 		FinancialAccountingClient: financialAccountingClient,
+		InternalBankAccountClient: internalBankAccountClient, // May be nil if internal clearing disabled
 		PaymentGateway:            paymentGateway,
 		GatewayAccountConfig:      gatewayAccountConfig,
 		KafkaPublisher:            kafkaProducer,
 		IdempotencyService:        idempotencyService,
 		Logger:                    logger,
 		Tracer:                    tracer,
+		InternalClearingEnabled:   internalClearingEnabled,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create payment order service: %w", err)
@@ -403,6 +422,57 @@ func createFinancialAccountingClient(namespace string, logger *slog.Logger, trac
 	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create financial-accounting client: %w", err)
+	}
+
+	return client, cleanup, nil
+}
+
+// createInternalBankAccountClient creates the InternalBankAccount gRPC client with resilience patterns.
+// Uses the service-owned client package from services/internal-bank-account/client for standardized
+// client creation with built-in tracing and resilience patterns.
+// This client is optional and only created when INTERNAL_CLEARING_ENABLED is true.
+func createInternalBankAccountClient(namespace string, logger *slog.Logger, tracer *observability.Tracer) (service.InternalBankAccountClient, func(), error) {
+	logger.Info("connecting to internal-bank-account service",
+		"service", internalbankaccountclient.ServiceName,
+		"namespace", namespace,
+		"port", ports.InternalBankAccount)
+
+	// Configure resilience settings from environment
+	resilientConfig := &sharedclients.ResilientClientConfig{
+		// Circuit breaker settings
+		CircuitBreakerName:     "internal-bank-account",
+		CircuitBreakerTimeout:  env.GetEnvAsDuration("INTERNAL_BANK_ACCOUNT_CIRCUIT_BREAKER_TIMEOUT", defaults.DefaultCircuitBreakerOpenTimeout),
+		CircuitBreakerInterval: env.GetEnvAsDuration("INTERNAL_BANK_ACCOUNT_CIRCUIT_BREAKER_INTERVAL", defaults.DefaultCircuitBreakerInterval),
+		MaxRequests:            env.GetEnvAsUint32("INTERNAL_BANK_ACCOUNT_CIRCUIT_BREAKER_MAX_REQUESTS", 1),
+		FailureThreshold:       env.GetEnvAsUint32("INTERNAL_BANK_ACCOUNT_CIRCUIT_BREAKER_FAILURE_THRESHOLD", 5),
+
+		// Retry settings
+		MaxRetries:          env.GetEnvAsInt("INTERNAL_BANK_ACCOUNT_MAX_RETRIES", 3),
+		InitialInterval:     env.GetEnvAsDuration("INTERNAL_BANK_ACCOUNT_RETRY_INITIAL_INTERVAL", defaults.DefaultRetryDelay),
+		MaxInterval:         env.GetEnvAsDuration("INTERNAL_BANK_ACCOUNT_RETRY_MAX_INTERVAL", defaults.DefaultMaxRetryInterval),
+		Multiplier:          env.GetEnvAsFloat("INTERNAL_BANK_ACCOUNT_RETRY_MULTIPLIER", 2.0),
+		RandomizationFactor: env.GetEnvAsFloat("INTERNAL_BANK_ACCOUNT_RETRY_RANDOMIZATION", 0.5),
+
+		Logger: logger,
+	}
+
+	logger.Info("internal-bank-account client configured with resilience patterns",
+		"circuit_breaker_timeout", resilientConfig.CircuitBreakerTimeout,
+		"circuit_breaker_failure_threshold", resilientConfig.FailureThreshold,
+		"max_retries", resilientConfig.MaxRetries,
+	)
+
+	// Use the service-owned client package with DNS-based load balancing
+	client, cleanup, err := internalbankaccountclient.New(internalbankaccountclient.Config{
+		ServiceName: internalbankaccountclient.ServiceName,
+		Namespace:   namespace,
+		Port:        ports.InternalBankAccount,
+		Timeout:     env.GetEnvAsDuration("INTERNAL_BANK_ACCOUNT_TIMEOUT", internalbankaccountclient.DefaultTimeout),
+		Tracer:      tracer,
+		Resilience:  resilientConfig,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create internal-bank-account client: %w", err)
 	}
 
 	return client, cleanup, nil

--- a/services/payment-order/service/grpc_service.go
+++ b/services/payment-order/service/grpc_service.go
@@ -41,6 +41,7 @@ var (
 	ErrRepositoryNil                = errors.New("repository cannot be nil")
 	ErrCurrentAccountClientNil      = errors.New("current account client cannot be nil")
 	ErrFinancialAccountingClientNil = errors.New("financial accounting client cannot be nil")
+	ErrInternalBankAccountClientNil = errors.New("internal bank account client cannot be nil when internal clearing is enabled")
 	ErrPaymentGatewayNil            = errors.New("payment gateway cannot be nil")
 	ErrGatewayAccountConfigNil      = errors.New("gateway account config cannot be nil")
 	ErrIdempotencyServiceNil        = errors.New("idempotency service cannot be nil")
@@ -280,6 +281,10 @@ func NewServiceWithConfig(cfg Config) (*Service, error) {
 		return nil, ErrIdempotencyServiceNil
 	}
 	// KafkaPublisher is optional - nil is handled gracefully by publishEvent
+	// InternalBankAccountClient is optional but required if internal clearing is enabled
+	if cfg.InternalClearingEnabled && cfg.InternalBankAccountClient == nil {
+		return nil, ErrInternalBankAccountClientNil
+	}
 
 	// Apply default logger if not provided
 	logger := cfg.Logger

--- a/services/payment-order/service/grpc_service.go
+++ b/services/payment-order/service/grpc_service.go
@@ -15,6 +15,7 @@ import (
 	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
 	financialaccountingv1 "github.com/meridianhub/meridian/api/proto/meridian/financial_accounting/v1"
+	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
@@ -97,6 +98,22 @@ type FinancialAccountingClient interface {
 	Close() error
 }
 
+// InternalBankAccountClient defines the interface for communicating with the Internal Bank Account service
+// for clearing account resolution. This is an optional dependency for internal clearing operations.
+type InternalBankAccountClient interface {
+	// GetBalance retrieves the current balance for an internal bank account.
+	// Used to query clearing account balances for reconciliation.
+	GetBalance(ctx context.Context, req *internalbankaccountv1.GetBalanceRequest) (*internalbankaccountv1.GetBalanceResponse, error)
+	// RetrieveInternalBankAccount fetches account details by ID.
+	// Used to verify clearing account configuration.
+	RetrieveInternalBankAccount(ctx context.Context, req *internalbankaccountv1.RetrieveInternalBankAccountRequest) (*internalbankaccountv1.RetrieveInternalBankAccountResponse, error)
+	// ListInternalBankAccounts queries accounts with filtering.
+	// Used to discover clearing accounts by type and instrument.
+	ListInternalBankAccounts(ctx context.Context, req *internalbankaccountv1.ListInternalBankAccountsRequest) (*internalbankaccountv1.ListInternalBankAccountsResponse, error)
+	// Close terminates the client connection
+	Close() error
+}
+
 // KafkaPublisher defines the interface for publishing protobuf messages to Kafka.
 // This abstraction allows for mocking in tests and alternative implementations.
 type KafkaPublisher interface {
@@ -159,6 +176,7 @@ type Service struct {
 	repo                      persistence.Repository
 	currentAccountClient      CurrentAccountClient
 	financialAccountingClient FinancialAccountingClient
+	internalBankAccountClient InternalBankAccountClient // Optional - for internal clearing operations
 	paymentGateway            gateway.PaymentGateway
 	gatewayAccountConfig      *config.GatewayAccountConfig
 	kafkaPublisher            KafkaPublisher
@@ -171,6 +189,7 @@ type Service struct {
 	maxIdempotencyKeyLength   int
 	lienExecutionRetryConfig  *sharedclients.RetryConfig // nil means use default
 	orchestrator              *PaymentOrchestrator       // Handles payment saga orchestration
+	internalClearingEnabled   bool                       // Feature flag for internal clearing operations
 }
 
 // Config contains configuration for creating a new Service
@@ -178,6 +197,7 @@ type Config struct {
 	Repository                persistence.Repository
 	CurrentAccountClient      CurrentAccountClient
 	FinancialAccountingClient FinancialAccountingClient
+	InternalBankAccountClient InternalBankAccountClient // Optional - for internal clearing operations
 	PaymentGateway            gateway.PaymentGateway
 	GatewayAccountConfig      *config.GatewayAccountConfig
 	KafkaPublisher            KafkaPublisher
@@ -197,6 +217,9 @@ type Config struct {
 	// LienExecutionRetryConfig configures retry behavior for async lien execution.
 	// If nil, default retry config is used. Primarily useful for testing.
 	LienExecutionRetryConfig *sharedclients.RetryConfig
+	// InternalClearingEnabled enables internal clearing operations (default: false).
+	// When enabled, the service uses InternalBankAccountClient for clearing account resolution.
+	InternalClearingEnabled bool
 }
 
 // NewService creates a new payment order service with minimal dependencies.
@@ -292,9 +315,11 @@ func NewServiceWithConfig(cfg Config) (*Service, error) {
 		CurrentAccountClient:      cfg.CurrentAccountClient,
 		PaymentGateway:            cfg.PaymentGateway,
 		FinancialAccountingClient: cfg.FinancialAccountingClient,
+		InternalBankAccountClient: cfg.InternalBankAccountClient,
 		GatewayAccountConfig:      cfg.GatewayAccountConfig,
 		KafkaPublisher:            cfg.KafkaPublisher,
 		LienExecutionRetryConfig:  cfg.LienExecutionRetryConfig,
+		InternalClearingEnabled:   cfg.InternalClearingEnabled,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create payment orchestrator: %w", err)
@@ -304,6 +329,7 @@ func NewServiceWithConfig(cfg Config) (*Service, error) {
 		repo:                      cfg.Repository,
 		currentAccountClient:      cfg.CurrentAccountClient,
 		financialAccountingClient: cfg.FinancialAccountingClient,
+		internalBankAccountClient: cfg.InternalBankAccountClient, // Optional - may be nil
 		paymentGateway:            cfg.PaymentGateway,
 		gatewayAccountConfig:      cfg.GatewayAccountConfig,
 		kafkaPublisher:            cfg.KafkaPublisher,
@@ -316,6 +342,7 @@ func NewServiceWithConfig(cfg Config) (*Service, error) {
 		maxIdempotencyKeyLength:   maxIdempotencyKeyLength,
 		lienExecutionRetryConfig:  cfg.LienExecutionRetryConfig, // nil means use default
 		orchestrator:              orchestrator,
+		internalClearingEnabled:   cfg.InternalClearingEnabled,
 	}, nil
 }
 

--- a/services/payment-order/service/payment_orchestrator.go
+++ b/services/payment-order/service/payment_orchestrator.go
@@ -55,9 +55,11 @@ type PaymentOrchestrator struct {
 	currentAccountClient      CurrentAccountClient
 	paymentGateway            gateway.PaymentGateway
 	financialAccountingClient FinancialAccountingClient
+	internalBankAccountClient InternalBankAccountClient // Optional - for internal clearing
 	gatewayAccountConfig      *config.GatewayAccountConfig
 	kafkaPublisher            KafkaPublisher
 	lienExecutionRetryConfig  *sharedclients.RetryConfig
+	internalClearingEnabled   bool
 }
 
 // PaymentOrchestratorConfig contains dependencies for creating a PaymentOrchestrator
@@ -67,9 +69,11 @@ type PaymentOrchestratorConfig struct {
 	CurrentAccountClient      CurrentAccountClient
 	PaymentGateway            gateway.PaymentGateway
 	FinancialAccountingClient FinancialAccountingClient
+	InternalBankAccountClient InternalBankAccountClient // Optional - for internal clearing
 	GatewayAccountConfig      *config.GatewayAccountConfig
 	KafkaPublisher            KafkaPublisher
 	LienExecutionRetryConfig  *sharedclients.RetryConfig
+	InternalClearingEnabled   bool
 }
 
 // NewPaymentOrchestrator creates a new payment orchestrator with the given dependencies.
@@ -88,9 +92,11 @@ func NewPaymentOrchestrator(cfg PaymentOrchestratorConfig) (*PaymentOrchestrator
 		currentAccountClient:      cfg.CurrentAccountClient,
 		paymentGateway:            cfg.PaymentGateway,
 		financialAccountingClient: cfg.FinancialAccountingClient,
+		internalBankAccountClient: cfg.InternalBankAccountClient,
 		gatewayAccountConfig:      cfg.GatewayAccountConfig,
 		kafkaPublisher:            cfg.KafkaPublisher,
 		lienExecutionRetryConfig:  cfg.LienExecutionRetryConfig,
+		internalClearingEnabled:   cfg.InternalClearingEnabled,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

Integrates the Internal Bank Account service client into the payment-order service to enable future internal clearing operations with clearing accounts.

- Adds `InternalBankAccountClient` interface with `GetBalance`, `RetrieveInternalBankAccount`, and `ListInternalBankAccounts` methods
- Wires up the existing `services/internal-bank-account/client` package into the payment-order service
- Adds `INTERNAL_CLEARING_ENABLED` feature flag (default: `false`) for opt-in activation
- Configures circuit breaker and retry patterns via `INTERNAL_BANK_ACCOUNT_*` environment variables

The client is optional and only instantiated when `INTERNAL_CLEARING_ENABLED=true`, maintaining backward compatibility.

## Task Master

**Tag**: internal-bank-account
**Task**: 27 - Integrate Internal Bank Account Client into Payment Order Service

## Test Plan

- [x] All existing payment-order tests pass (`go test ./services/payment-order/...`)
- [x] Internal-bank-account client tests pass (`go test ./services/internal-bank-account/client/...`)
- [x] `go vet` passes with no errors
- [x] Pre-commit hooks (gofumpt, golangci-lint) pass
- [ ] CI pipeline passes