### PR TITLE
feat(financial-accounting): integrate AccountResolver into PostingService

### DIFF
--- a/services/financial-accounting/adapters/messaging/deposit_consumer_test.go
+++ b/services/financial-accounting/adapters/messaging/deposit_consumer_test.go
@@ -183,7 +183,10 @@ func setupTestServices(t *testing.T) (*service.PostingService, context.Context, 
 	ctx := tenant.WithTenant(context.Background(), tid)
 
 	repo := persistence.NewLedgerRepository(db)
-	return service.NewPostingService(repo, "BANK-CASH-001"), ctx, cleanup
+	return service.NewPostingServiceWithConfig(service.PostingServiceConfig{
+		Repo:              repo,
+		BankCashAccountID: "BANK-CASH-001",
+	}), ctx, cleanup
 }
 
 func TestNewDepositConsumer(t *testing.T) {

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	serviceobs "github.com/meridianhub/meridian/services/financial-accounting/observability"
 	"github.com/meridianhub/meridian/services/financial-accounting/service"
 	"github.com/meridianhub/meridian/services/financial-accounting/worker"
+	ibaclient "github.com/meridianhub/meridian/services/internal-bank-account/client"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/audit"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
@@ -175,10 +176,46 @@ func run(logger *slog.Logger) error {
 	// Create ledger repository
 	ledgerRepo := persistence.NewLedgerRepository(db)
 
-	// Create posting service (using validated bankCashAccountID from above)
-	postingService := service.NewPostingService(ledgerRepo, bankCashAccountID)
+	// Initialize Internal Bank Account client (optional - for dynamic clearing account lookup)
+	var accountResolver *service.AccountResolver
+	ibaServiceURL := env.GetEnvOrDefault("INTERNAL_BANK_ACCOUNT_SERVICE_URL", "")
+	if ibaServiceURL != "" {
+		ibaClient, ibaCleanup, err := ibaclient.New(ibaclient.Config{
+			Target:  ibaServiceURL,
+			Timeout: service.DefaultLookupTimeout,
+		})
+		if err != nil {
+			// Non-fatal: fall back to static config
+			logger.Warn("failed to create Internal Bank Account client, using static clearing account",
+				"error", err,
+				"service_url", ibaServiceURL)
+		} else {
+			defer ibaCleanup()
 
-	logger.Info("posting service initialized", "bank_cash_account_id", bankCashAccountID)
+			resolver, err := service.NewAccountResolver(service.AccountResolverConfig{
+				Client: ibaClient,
+				Logger: logger,
+			})
+			if err != nil {
+				logger.Warn("failed to create AccountResolver, using static clearing account",
+					"error", err)
+			} else {
+				accountResolver = resolver
+				logger.Info("dynamic clearing account resolution enabled",
+					"service_url", ibaServiceURL)
+			}
+		}
+	} else {
+		logger.Info("dynamic clearing account resolution disabled (INTERNAL_BANK_ACCOUNT_SERVICE_URL not set)")
+	}
+
+	// Create posting service with optional AccountResolver
+	postingService := service.NewPostingServiceWithConfig(service.PostingServiceConfig{
+		Repo:              ledgerRepo,
+		BankCashAccountID: bankCashAccountID,
+		AccountResolver:   accountResolver,
+		Logger:            logger,
+	})
 
 	// Create Redis client and idempotency service
 	var idempotencySvc idempotency.Service

--- a/services/financial-accounting/observability/metrics.go
+++ b/services/financial-accounting/observability/metrics.go
@@ -186,6 +186,14 @@ var (
 		},
 		[]string{"clearing_type"},
 	)
+
+	resolverFallbackTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "financial_accounting_resolver_fallback_total",
+			Help: "Total number of times the posting service fell back to static clearing account",
+		},
+		[]string{"instrument_code", "operation"},
+	)
 )
 
 // RecordOperationDuration records the duration of a financial accounting operation.
@@ -321,4 +329,9 @@ func RecordClearingAccountLookupDuration(duration time.Duration) {
 // RecordClearingAccountLookupError records a clearing account lookup error.
 func RecordClearingAccountLookupError(clearingType string) {
 	clearingAccountLookupErrors.WithLabelValues(clearingType).Inc()
+}
+
+// RecordResolverFallback records when the posting service falls back to static clearing account.
+func RecordResolverFallback(instrumentCode, operation string) {
+	resolverFallbackTotal.WithLabelValues(instrumentCode, operation).Inc()
 }

--- a/services/financial-accounting/service/posting_service.go
+++ b/services/financial-accounting/service/posting_service.go
@@ -251,7 +251,7 @@ func (s *PostingService) ValidateDoubleEntry(ctx context.Context, bookingLogID u
 }
 
 // resolveClearingAccountForDeposit attempts dynamic clearing account lookup,
-// falling back to static config on any error.
+// falling back to static config on any error or empty result.
 func (s *PostingService) resolveClearingAccountForDeposit(ctx context.Context, instrumentCode string) string {
 	// If no resolver configured, use static fallback
 	if s.accountResolver == nil {
@@ -269,7 +269,16 @@ func (s *PostingService) resolveClearingAccountForDeposit(ctx context.Context, i
 			"instrument_code", instrumentCode,
 			"fallback_account_id", s.bankCashAccountID,
 			"error", err)
-		observability.RecordResolverFallback(instrumentCode, "deposit")
+		observability.RecordResolverFallback(instrumentCode, observability.OperationProcessDeposit)
+		return s.bankCashAccountID
+	}
+
+	// Guard against empty account ID - treat as lookup failure
+	if accountID == "" {
+		s.logger.Warn("dynamic clearing account lookup returned empty result, using static fallback",
+			"instrument_code", instrumentCode,
+			"fallback_account_id", s.bankCashAccountID)
+		observability.RecordResolverFallback(instrumentCode, observability.OperationProcessDeposit)
 		return s.bankCashAccountID
 	}
 

--- a/services/financial-accounting/service/posting_service.go
+++ b/services/financial-accounting/service/posting_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,13 +17,59 @@ import (
 type PostingService struct {
 	repo              *persistence.LedgerRepository
 	bankCashAccountID string
+	accountResolver   *AccountResolver
+	logger            *slog.Logger
 }
 
-// NewPostingService creates a new posting service
+// PostingServiceConfig holds configuration for creating a PostingService.
+type PostingServiceConfig struct {
+	// Repo is the ledger repository for database operations.
+	Repo *persistence.LedgerRepository
+
+	// BankCashAccountID is the static fallback account ID for clearing operations.
+	// Used when AccountResolver is nil or when dynamic lookup fails.
+	BankCashAccountID string
+
+	// AccountResolver is optional. When provided, enables dynamic clearing account
+	// lookup by instrument. Falls back to BankCashAccountID on lookup failure.
+	AccountResolver *AccountResolver
+
+	// Logger is optional. If nil, a default logger is used.
+	Logger *slog.Logger
+}
+
+// NewPostingService creates a new posting service.
+// Deprecated: Use NewPostingServiceWithConfig for full configuration options.
 func NewPostingService(repo *persistence.LedgerRepository, bankCashAccountID string) *PostingService {
 	return &PostingService{
 		repo:              repo,
 		bankCashAccountID: bankCashAccountID,
+		logger:            slog.Default(),
+	}
+}
+
+// NewPostingServiceWithConfig creates a new posting service with full configuration.
+// When AccountResolver is provided, the service will attempt dynamic clearing account
+// lookup before falling back to the static BankCashAccountID.
+func NewPostingServiceWithConfig(cfg PostingServiceConfig) *PostingService {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	mode := "static config"
+	if cfg.AccountResolver != nil {
+		mode = "dynamic clearing"
+	}
+	logger.Info("posting service initialized",
+		"mode", mode,
+		"static_account_id", cfg.BankCashAccountID)
+
+	return &PostingService{
+		repo:              cfg.Repo,
+		bankCashAccountID: cfg.BankCashAccountID,
+		accountResolver:   cfg.AccountResolver,
+		logger:            logger,
 	}
 }
 
@@ -83,12 +130,15 @@ func (s *PostingService) ProcessDeposit(ctx context.Context, event DepositEvent)
 		return fmt.Errorf("failed to create debit posting: %w", err)
 	}
 
-	// Create credit posting (bank cash account)
+	// Resolve clearing account for the credit posting
+	clearingAccountID := s.resolveClearingAccountForDeposit(ctx, instrument.Code)
+
+	// Create credit posting (clearing/bank cash account)
 	creditPosting, err := domain.NewLedgerPosting(
 		bookingLogID,
 		domain.PostingDirectionCredit,
 		money,
-		s.bankCashAccountID,
+		clearingAccountID,
 		event.ValueDate,
 		event.CorrelationID,
 	)
@@ -197,4 +247,33 @@ func (s *PostingService) ValidateDoubleEntry(ctx context.Context, bookingLogID u
 	}
 
 	return balanced, nil
+}
+
+// resolveClearingAccountForDeposit attempts dynamic clearing account lookup,
+// falling back to static config on any error.
+func (s *PostingService) resolveClearingAccountForDeposit(ctx context.Context, instrumentCode string) string {
+	// If no resolver configured, use static fallback
+	if s.accountResolver == nil {
+		s.logger.Debug("using static clearing account (no resolver configured)",
+			"instrument_code", instrumentCode,
+			"account_id", s.bankCashAccountID)
+		return s.bankCashAccountID
+	}
+
+	// Attempt dynamic lookup
+	accountID, err := s.accountResolver.GetDepositClearingAccount(ctx, instrumentCode)
+	if err != nil {
+		// Log fallback event for observability
+		s.logger.Warn("dynamic clearing account lookup failed, using static fallback",
+			"instrument_code", instrumentCode,
+			"fallback_account_id", s.bankCashAccountID,
+			"error", err)
+		observability.RecordResolverFallback(instrumentCode, "deposit")
+		return s.bankCashAccountID
+	}
+
+	s.logger.Debug("using dynamic clearing account",
+		"instrument_code", instrumentCode,
+		"account_id", accountID)
+	return accountID
 }

--- a/services/financial-accounting/service/posting_service.go
+++ b/services/financial-accounting/service/posting_service.go
@@ -39,6 +39,7 @@ type PostingServiceConfig struct {
 }
 
 // NewPostingService creates a new posting service.
+//
 // Deprecated: Use NewPostingServiceWithConfig for full configuration options.
 func NewPostingService(repo *persistence.LedgerRepository, bankCashAccountID string) *PostingService {
 	return &PostingService{

--- a/services/financial-accounting/service/posting_service_test.go
+++ b/services/financial-accounting/service/posting_service_test.go
@@ -2,11 +2,15 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
 	"github.com/meridianhub/meridian/services/financial-accounting/adapters/persistence"
 	"github.com/meridianhub/meridian/services/financial-accounting/domain"
 	"github.com/meridianhub/meridian/shared/platform/audit"
@@ -311,4 +315,233 @@ func TestValidateDoubleEntry_Unbalanced(t *testing.T) {
 	if balanced {
 		t.Error("Expected double entry to be unbalanced, but was balanced")
 	}
+}
+
+// =============================================================================
+// Tests for AccountResolver integration
+// =============================================================================
+
+func TestProcessDeposit_WithDynamicClearingAccount(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+	repo := persistence.NewLedgerRepository(db)
+
+	// Create mock that returns a dynamic clearing account
+	mockClient := &postingServiceMockClient{
+		accountID: "DYNAMIC-CLEARING-GBP",
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: postingTestLogger(),
+	})
+	require.NoError(t, err)
+
+	service := NewPostingServiceWithConfig(PostingServiceConfig{
+		Repo:              repo,
+		BankCashAccountID: "STATIC-FALLBACK",
+		AccountResolver:   resolver,
+		Logger:            postingTestLogger(),
+	})
+
+	event := DepositEvent{
+		AccountID:     "ACC-DYNAMIC-123",
+		AmountCents:   10000,
+		Currency:      "GBP",
+		CorrelationID: "deposit-dynamic-001",
+		ValueDate:     time.Now(),
+	}
+
+	err = service.ProcessDeposit(ctx, event)
+	require.NoError(t, err)
+
+	// Verify credit posting used dynamic clearing account
+	var creditEntity persistence.LedgerPostingEntity
+	err = db.Where("posting_direction = ?", "CREDIT").First(&creditEntity).Error
+	require.NoError(t, err)
+	require.Equal(t, "DYNAMIC-CLEARING-GBP", creditEntity.AccountID)
+}
+
+func TestProcessDeposit_FallbackOnResolverError(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+	repo := persistence.NewLedgerRepository(db)
+
+	// Create mock that returns an error
+	mockClient := &postingServiceMockClient{
+		err: errMockServiceUnavailable,
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: postingTestLogger(),
+	})
+	require.NoError(t, err)
+
+	service := NewPostingServiceWithConfig(PostingServiceConfig{
+		Repo:              repo,
+		BankCashAccountID: "STATIC-FALLBACK",
+		AccountResolver:   resolver,
+		Logger:            postingTestLogger(),
+	})
+
+	event := DepositEvent{
+		AccountID:     "ACC-FALLBACK-123",
+		AmountCents:   10000,
+		Currency:      "GBP",
+		CorrelationID: "deposit-fallback-001",
+		ValueDate:     time.Now(),
+	}
+
+	err = service.ProcessDeposit(ctx, event)
+	require.NoError(t, err)
+
+	// Verify credit posting used static fallback account
+	var creditEntity persistence.LedgerPostingEntity
+	err = db.Where("posting_direction = ?", "CREDIT").First(&creditEntity).Error
+	require.NoError(t, err)
+	require.Equal(t, "STATIC-FALLBACK", creditEntity.AccountID)
+}
+
+func TestProcessDeposit_WithoutResolver_UsesStaticAccount(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+	repo := persistence.NewLedgerRepository(db)
+
+	// Create service without AccountResolver
+	service := NewPostingServiceWithConfig(PostingServiceConfig{
+		Repo:              repo,
+		BankCashAccountID: "STATIC-ONLY",
+		AccountResolver:   nil, // Explicitly nil
+		Logger:            postingTestLogger(),
+	})
+
+	event := DepositEvent{
+		AccountID:     "ACC-STATIC-123",
+		AmountCents:   10000,
+		Currency:      "GBP",
+		CorrelationID: "deposit-static-001",
+		ValueDate:     time.Now(),
+	}
+
+	err := service.ProcessDeposit(ctx, event)
+	require.NoError(t, err)
+
+	// Verify credit posting used static account
+	var creditEntity persistence.LedgerPostingEntity
+	err = db.Where("posting_direction = ?", "CREDIT").First(&creditEntity).Error
+	require.NoError(t, err)
+	require.Equal(t, "STATIC-ONLY", creditEntity.AccountID)
+}
+
+func TestProcessDeposit_MultiAsset_DynamicLookup(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+	repo := persistence.NewLedgerRepository(db)
+
+	// Create mock that returns different accounts per instrument
+	mockClient := &postingServiceMockClient{
+		accountsByInstrument: map[string]string{
+			"GBP": "CLEARING-GBP-001",
+			"USD": "CLEARING-USD-001",
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: postingTestLogger(),
+	})
+	require.NoError(t, err)
+
+	service := NewPostingServiceWithConfig(PostingServiceConfig{
+		Repo:              repo,
+		BankCashAccountID: "FALLBACK",
+		AccountResolver:   resolver,
+		Logger:            postingTestLogger(),
+	})
+
+	// Process GBP deposit
+	gbpEvent := DepositEvent{
+		AccountID:     "ACC-GBP-123",
+		AmountCents:   10000,
+		Currency:      "GBP",
+		CorrelationID: "deposit-gbp-001",
+		ValueDate:     time.Now(),
+	}
+	err = service.ProcessDeposit(ctx, gbpEvent)
+	require.NoError(t, err)
+
+	// Process USD deposit
+	usdEvent := DepositEvent{
+		AccountID:     "ACC-USD-123",
+		AmountCents:   20000,
+		Currency:      "USD",
+		CorrelationID: "deposit-usd-001",
+		ValueDate:     time.Now(),
+	}
+	err = service.ProcessDeposit(ctx, usdEvent)
+	require.NoError(t, err)
+
+	// Verify GBP credit used GBP clearing account
+	var gbpCredit persistence.LedgerPostingEntity
+	err = db.Where("correlation_id = ? AND posting_direction = ?", "deposit-gbp-001", "CREDIT").First(&gbpCredit).Error
+	require.NoError(t, err)
+	require.Equal(t, "CLEARING-GBP-001", gbpCredit.AccountID)
+
+	// Verify USD credit used USD clearing account
+	var usdCredit persistence.LedgerPostingEntity
+	err = db.Where("correlation_id = ? AND posting_direction = ?", "deposit-usd-001", "CREDIT").First(&usdCredit).Error
+	require.NoError(t, err)
+	require.Equal(t, "CLEARING-USD-001", usdCredit.AccountID)
+}
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+// Sentinel error for testing fallback behavior
+var errMockServiceUnavailable = errors.New("mock: service unavailable")
+
+// postingServiceMockClient is a mock for testing PostingService integration
+type postingServiceMockClient struct {
+	accountID            string
+	accountsByInstrument map[string]string
+	err                  error
+}
+
+func (m *postingServiceMockClient) ListInternalBankAccounts(_ context.Context, req *internalbankaccountv1.ListInternalBankAccountsRequest) (*internalbankaccountv1.ListInternalBankAccountsResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	accountID := m.accountID
+	if m.accountsByInstrument != nil {
+		if id, ok := m.accountsByInstrument[req.InstrumentCodeFilter]; ok {
+			accountID = id
+		}
+	}
+
+	if accountID == "" {
+		return &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{},
+		}, nil
+	}
+
+	return &internalbankaccountv1.ListInternalBankAccountsResponse{
+		Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+			{AccountId: accountID},
+		},
+	}, nil
+}
+
+func (m *postingServiceMockClient) RetrieveInternalBankAccount(_ context.Context, _ *internalbankaccountv1.RetrieveInternalBankAccountRequest) (*internalbankaccountv1.RetrieveInternalBankAccountResponse, error) {
+	return nil, nil
+}
+
+func (m *postingServiceMockClient) Close() error {
+	return nil
+}
+
+func postingTestLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 }

--- a/services/financial-accounting/service/posting_service_test.go
+++ b/services/financial-accounting/service/posting_service_test.go
@@ -434,6 +434,47 @@ func TestProcessDeposit_WithoutResolver_UsesStaticAccount(t *testing.T) {
 	require.Equal(t, "STATIC-ONLY", creditEntity.AccountID)
 }
 
+func TestProcessDeposit_FallbackOnNoClearingAccountFound(t *testing.T) {
+	db, ctx, cleanup := setupTestDB(t)
+	defer cleanup()
+	repo := persistence.NewLedgerRepository(db)
+
+	// Create mock that returns no accounts (ErrNoClearingAccountFound path)
+	mockClient := &postingServiceMockClient{
+		accountID: "", // Empty means no accounts returned
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: postingTestLogger(),
+	})
+	require.NoError(t, err)
+
+	service := NewPostingServiceWithConfig(PostingServiceConfig{
+		Repo:              repo,
+		BankCashAccountID: "STATIC-FALLBACK-EMPTY",
+		AccountResolver:   resolver,
+		Logger:            postingTestLogger(),
+	})
+
+	event := DepositEvent{
+		AccountID:     "ACC-EMPTY-123",
+		AmountCents:   10000,
+		Currency:      "GBP",
+		CorrelationID: "deposit-empty-001",
+		ValueDate:     time.Now(),
+	}
+
+	err = service.ProcessDeposit(ctx, event)
+	require.NoError(t, err)
+
+	// Verify credit posting used static fallback account
+	var creditEntity persistence.LedgerPostingEntity
+	err = db.Where("posting_direction = ?", "CREDIT").First(&creditEntity).Error
+	require.NoError(t, err)
+	require.Equal(t, "STATIC-FALLBACK-EMPTY", creditEntity.AccountID)
+}
+
 func TestProcessDeposit_MultiAsset_DynamicLookup(t *testing.T) {
 	db, ctx, cleanup := setupTestDB(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
- Integrates `AccountResolver` into `PostingService` for dynamic clearing account resolution
- Enables instrument-specific clearing accounts (GBP, USD, KWH, etc.) from Internal Bank Account service
- Provides graceful fallback to static `BANK_CASH_ACCOUNT_ID` when resolver unavailable or fails

## Changes Made
- **PostingService** (`posting_service.go`):
  - Added `PostingServiceConfig` struct with optional `AccountResolver`
  - Added `NewPostingServiceWithConfig()` constructor
  - Added `resolveClearingAccountForDeposit()` helper with fallback logic
  - Updated `ProcessDeposit()` to use dynamic clearing account lookup
  
- **Metrics** (`observability/metrics.go`):
  - Added `resolver_fallback_total` counter for fallback observability
  
- **Main** (`cmd/main.go`):
  - Added `INTERNAL_BANK_ACCOUNT_SERVICE_URL` env var support
  - Wire up Internal Bank Account client and AccountResolver
  - Log mode (dynamic vs static) on startup

## Technical Details
The integration follows the graceful degradation pattern:
1. If `INTERNAL_BANK_ACCOUNT_SERVICE_URL` not set → static mode only
2. If client creation fails → log warning, static mode
3. If resolver lookup fails → log warning, use static fallback
4. On success → use instrument-specific clearing account

## Test Plan
- [x] Unit test: Dynamic clearing account resolution success path
- [x] Unit test: Fallback to static config on resolver error
- [x] Unit test: Static-only mode when resolver not configured
- [x] Unit test: Multi-asset (GBP, USD) dynamic lookup verification
- [x] All existing `posting_service_test.go` tests pass
- [x] Full `financial-accounting` test suite passes

## Task Master
- Tag: `internal-bank-account`
- Task: `internal-bank-account.26` - Integrate AccountResolver into Financial Accounting PostingService