### PR TITLE
feat(payment-order): add internal clearing account support for ledger posting

### DIFF
--- a/services/payment-order/observability/metrics.go
+++ b/services/payment-order/observability/metrics.go
@@ -189,6 +189,37 @@ var (
 			Help: "Number of payment orders currently being processed",
 		},
 	)
+
+	// Clearing account resolver metrics
+	clearingAccountCacheHits = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "payment_order_clearing_account_cache_hits_total",
+			Help: "Total number of clearing account cache hits",
+		},
+	)
+
+	clearingAccountCacheMisses = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "payment_order_clearing_account_cache_misses_total",
+			Help: "Total number of clearing account cache misses",
+		},
+	)
+
+	clearingAccountLookupDuration = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "payment_order_clearing_account_lookup_duration_seconds",
+			Help:    "Duration of clearing account lookups from Internal Bank Account service",
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5},
+		},
+	)
+
+	clearingAccountLookupErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "payment_order_clearing_account_lookup_errors_total",
+			Help: "Total number of clearing account lookup errors",
+		},
+		[]string{"clearing_type"},
+	)
 )
 
 // RecordPaymentOrder records a payment order by status.
@@ -301,4 +332,24 @@ func IncPaymentOrdersInFlight() {
 // DecPaymentOrdersInFlight decrements the in-flight gauge.
 func DecPaymentOrdersInFlight() {
 	paymentOrdersInFlight.Dec()
+}
+
+// RecordClearingAccountCacheHit records a cache hit for clearing account resolution.
+func RecordClearingAccountCacheHit() {
+	clearingAccountCacheHits.Inc()
+}
+
+// RecordClearingAccountCacheMiss records a cache miss for clearing account resolution.
+func RecordClearingAccountCacheMiss() {
+	clearingAccountCacheMisses.Inc()
+}
+
+// RecordClearingAccountLookupDuration records the duration of a clearing account lookup.
+func RecordClearingAccountLookupDuration(duration time.Duration) {
+	clearingAccountLookupDuration.Observe(duration.Seconds())
+}
+
+// RecordClearingAccountLookupError records a clearing account lookup error.
+func RecordClearingAccountLookupError(clearingType string) {
+	clearingAccountLookupErrors.WithLabelValues(clearingType).Inc()
 }

--- a/services/payment-order/service/account_resolver.go
+++ b/services/payment-order/service/account_resolver.go
@@ -207,7 +207,12 @@ func (r *AccountResolver) resolveClearingAccount(ctx context.Context, clearingTy
 		// This should never happen as we control the singleflight function return type
 		return "", ErrAccountResolverInternalError
 	}
-	poobservability.RecordClearingAccountLookupDuration(time.Since(start))
+
+	// Only record lookup duration for the primary request, not for shared waiters.
+	// Shared requests just waited for the primary, so their "duration" is actually wait time.
+	if !shared {
+		poobservability.RecordClearingAccountLookupDuration(time.Since(start))
+	}
 
 	r.logger.Info("resolved clearing account",
 		"clearing_type", clearingType,

--- a/services/payment-order/service/account_resolver.go
+++ b/services/payment-order/service/account_resolver.go
@@ -1,0 +1,277 @@
+// Package service implements gRPC services for the payment order domain
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	poobservability "github.com/meridianhub/meridian/services/payment-order/observability"
+	"golang.org/x/sync/singleflight"
+)
+
+// AccountResolverErrors defines sentinel errors for the AccountResolver.
+var (
+	// ErrNoClearingAccountFound is returned when no active clearing account is found for the given criteria.
+	ErrNoClearingAccountFound = errors.New("no active clearing account found")
+
+	// ErrAccountResolverClientNil is returned when attempting to create an AccountResolver with a nil client.
+	ErrAccountResolverClientNil = errors.New("internal bank account client cannot be nil")
+
+	// ErrAccountResolverLoggerNil is returned when attempting to create an AccountResolver with a nil logger.
+	ErrAccountResolverLoggerNil = errors.New("logger cannot be nil")
+
+	// ErrAccountResolverInternalError is returned when an unexpected internal error occurs.
+	ErrAccountResolverInternalError = errors.New("internal error: unexpected result type from singleflight")
+)
+
+// ClearingAccountType defines the type of clearing account being resolved.
+type ClearingAccountType string
+
+const (
+	// ClearingAccountTypeSettlement identifies the clearing account for settlement operations.
+	// Payment Order uses settlement accounts for payment completion and reconciliation
+	// with external payment gateways.
+	ClearingAccountTypeSettlement ClearingAccountType = "SETTLEMENT"
+)
+
+// cacheEntry holds a cached account ID with its expiration time.
+type cacheEntry struct {
+	accountID string
+	expiresAt time.Time
+}
+
+// AccountResolver resolves clearing account IDs dynamically from the Internal Bank Account service.
+// It provides caching to reduce external service calls and supports settlement clearing account lookups.
+//
+// Thread-safe: All methods can be called concurrently from multiple goroutines.
+// Uses singleflight to prevent cache stampede (multiple concurrent requests for the same key).
+type AccountResolver struct {
+	client InternalBankAccountClient
+	logger *slog.Logger
+
+	// Cache configuration
+	cacheTTL      time.Duration
+	lookupTimeout time.Duration
+
+	// Thread-safe cache: key is "TYPE:INSTRUMENT" (e.g., "SETTLEMENT:GBP")
+	mu    sync.RWMutex
+	cache map[string]cacheEntry
+
+	// Singleflight to coalesce concurrent requests for the same cache key
+	sfGroup singleflight.Group
+}
+
+// AccountResolverConfig holds configuration for creating an AccountResolver.
+type AccountResolverConfig struct {
+	// Client is the Internal Bank Account gRPC client.
+	Client InternalBankAccountClient
+
+	// Logger is used for logging resolver operations.
+	Logger *slog.Logger
+
+	// CacheTTL is how long resolved account IDs are cached.
+	// Defaults to 5 minutes if not specified.
+	CacheTTL time.Duration
+
+	// LookupTimeout is the timeout for individual lookup requests to the Internal Bank Account service.
+	// Defaults to 2 seconds if not specified.
+	LookupTimeout time.Duration
+}
+
+const (
+	// DefaultCacheTTL is the default cache TTL for resolved account IDs.
+	DefaultCacheTTL = 5 * time.Minute
+
+	// DefaultLookupTimeout is the default timeout for clearing account lookups.
+	// This is shorter than the typical RPC timeout to allow graceful fallback to static config.
+	DefaultLookupTimeout = 2 * time.Second
+)
+
+// NewAccountResolver creates a new AccountResolver with the given configuration.
+// Returns an error if required configuration is missing.
+func NewAccountResolver(cfg AccountResolverConfig) (*AccountResolver, error) {
+	if cfg.Client == nil {
+		return nil, ErrAccountResolverClientNil
+	}
+	if cfg.Logger == nil {
+		return nil, ErrAccountResolverLoggerNil
+	}
+
+	ttl := cfg.CacheTTL
+	if ttl == 0 {
+		ttl = DefaultCacheTTL
+	}
+
+	lookupTimeout := cfg.LookupTimeout
+	if lookupTimeout == 0 {
+		lookupTimeout = DefaultLookupTimeout
+	}
+
+	return &AccountResolver{
+		client:        cfg.Client,
+		logger:        cfg.Logger,
+		cacheTTL:      ttl,
+		lookupTimeout: lookupTimeout,
+		cache:         make(map[string]cacheEntry),
+	}, nil
+}
+
+// GetSettlementClearingAccount resolves the clearing account ID for settlement operations
+// for the given instrument (currency/asset code like "GBP", "USD", "KWH").
+//
+// Settlement accounts are used by Payment Order for payment completion and reconciliation
+// with external payment gateways.
+//
+// It first checks the cache, and if not found or expired, queries the Internal Bank Account
+// service for an active CLEARING account matching the instrument.
+func (r *AccountResolver) GetSettlementClearingAccount(ctx context.Context, instrumentCode string) (string, error) {
+	return r.resolveClearingAccount(ctx, ClearingAccountTypeSettlement, instrumentCode)
+}
+
+// resolveClearingAccount is the internal implementation for resolving clearing accounts.
+// Uses singleflight to prevent cache stampede when multiple concurrent requests miss the cache.
+func (r *AccountResolver) resolveClearingAccount(ctx context.Context, clearingType ClearingAccountType, instrumentCode string) (string, error) {
+	cacheKey := r.cacheKey(clearingType, instrumentCode)
+
+	// Check cache first (read lock)
+	r.mu.RLock()
+	if entry, ok := r.cache[cacheKey]; ok && time.Now().Before(entry.expiresAt) {
+		r.mu.RUnlock()
+		r.logger.Debug("cache hit for clearing account",
+			"clearing_type", clearingType,
+			"instrument_code", instrumentCode,
+			"account_id", entry.accountID)
+		poobservability.RecordClearingAccountCacheHit()
+		return entry.accountID, nil
+	}
+	r.mu.RUnlock()
+
+	poobservability.RecordClearingAccountCacheMiss()
+
+	// Use singleflight to coalesce concurrent requests for the same cache key.
+	// This prevents cache stampede when multiple goroutines miss the cache simultaneously.
+	start := time.Now()
+	result, err, shared := r.sfGroup.Do(cacheKey, func() (interface{}, error) {
+		// Double-check cache after acquiring the singleflight "lock"
+		// Another goroutine might have already populated the cache
+		r.mu.RLock()
+		if entry, ok := r.cache[cacheKey]; ok && time.Now().Before(entry.expiresAt) {
+			r.mu.RUnlock()
+			return entry.accountID, nil
+		}
+		r.mu.RUnlock()
+
+		// Create a timeout context for the lookup to enable faster fallback
+		lookupCtx, cancel := context.WithTimeout(ctx, r.lookupTimeout)
+		defer cancel()
+
+		// Query the Internal Bank Account service
+		accountID, err := r.queryInternalBankAccount(lookupCtx, clearingType, instrumentCode)
+		if err != nil {
+			return "", err
+		}
+
+		// Cache the result (write lock)
+		r.mu.Lock()
+		r.cache[cacheKey] = cacheEntry{
+			accountID: accountID,
+			expiresAt: time.Now().Add(r.cacheTTL),
+		}
+		r.mu.Unlock()
+
+		return accountID, nil
+	})
+
+	if err != nil {
+		poobservability.RecordClearingAccountLookupError(string(clearingType))
+		return "", err
+	}
+
+	accountID, ok := result.(string)
+	if !ok {
+		// This should never happen as we control the singleflight function return type
+		return "", ErrAccountResolverInternalError
+	}
+	poobservability.RecordClearingAccountLookupDuration(time.Since(start))
+
+	r.logger.Info("resolved clearing account",
+		"clearing_type", clearingType,
+		"instrument_code", instrumentCode,
+		"account_id", accountID,
+		"duration_ms", time.Since(start).Milliseconds(),
+		"shared", shared)
+
+	return accountID, nil
+}
+
+// queryInternalBankAccount queries the Internal Bank Account service for a clearing account
+// with the specified clearing purpose.
+func (r *AccountResolver) queryInternalBankAccount(ctx context.Context, clearingType ClearingAccountType, instrumentCode string) (string, error) {
+	clearingPurpose := mapClearingTypeToPurpose(clearingType)
+
+	resp, err := r.client.ListInternalBankAccounts(ctx, &internalbankaccountv1.ListInternalBankAccountsRequest{
+		AccountTypeFilter:     internalbankaccountv1.InternalAccountType_INTERNAL_ACCOUNT_TYPE_CLEARING,
+		InstrumentCodeFilter:  instrumentCode,
+		StatusFilter:          internalbankaccountv1.InternalAccountStatus_INTERNAL_ACCOUNT_STATUS_ACTIVE,
+		ClearingPurposeFilter: clearingPurpose,
+	})
+	if err != nil {
+		r.logger.Error("failed to query internal bank accounts",
+			"clearing_type", clearingType,
+			"clearing_purpose", clearingPurpose.String(),
+			"instrument_code", instrumentCode,
+			"error", err)
+		return "", fmt.Errorf("failed to query clearing account: %w", err)
+	}
+
+	if len(resp.Facilities) == 0 {
+		r.logger.Warn("no active clearing account found",
+			"clearing_type", clearingType,
+			"clearing_purpose", clearingPurpose.String(),
+			"instrument_code", instrumentCode)
+		return "", fmt.Errorf("%w for %s %s", ErrNoClearingAccountFound, clearingType, instrumentCode)
+	}
+
+	// Use the first active clearing account matching the criteria.
+	account := resp.Facilities[0]
+	return account.AccountId, nil
+}
+
+// mapClearingTypeToPurpose converts the internal ClearingAccountType to the proto ClearingPurpose enum.
+func mapClearingTypeToPurpose(clearingType ClearingAccountType) internalbankaccountv1.ClearingPurpose {
+	switch clearingType {
+	case ClearingAccountTypeSettlement:
+		return internalbankaccountv1.ClearingPurpose_CLEARING_PURPOSE_SETTLEMENT
+	default:
+		// For unknown types, return UNSPECIFIED which means no filtering by clearing purpose.
+		return internalbankaccountv1.ClearingPurpose_CLEARING_PURPOSE_UNSPECIFIED
+	}
+}
+
+// cacheKey generates a cache key for the given clearing type and instrument.
+func (r *AccountResolver) cacheKey(clearingType ClearingAccountType, instrumentCode string) string {
+	return fmt.Sprintf("%s:%s", clearingType, instrumentCode)
+}
+
+// InvalidateCache clears all cached entries. Useful for testing or when accounts are modified.
+func (r *AccountResolver) InvalidateCache() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cache = make(map[string]cacheEntry)
+	r.logger.Debug("cache invalidated")
+}
+
+// InvalidateCacheEntry removes a specific entry from the cache.
+func (r *AccountResolver) InvalidateCacheEntry(clearingType ClearingAccountType, instrumentCode string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.cache, r.cacheKey(clearingType, instrumentCode))
+	r.logger.Debug("cache entry invalidated",
+		"clearing_type", clearingType,
+		"instrument_code", instrumentCode)
+}

--- a/services/payment-order/service/account_resolver.go
+++ b/services/payment-order/service/account_resolver.go
@@ -19,6 +19,16 @@ var (
 	// ErrNoClearingAccountFound is returned when no active clearing account is found for the given criteria.
 	ErrNoClearingAccountFound = errors.New("no active clearing account found")
 
+	// ErrMultipleClearingAccounts is returned when multiple active clearing accounts are found for the same criteria.
+	// This indicates a data inconsistency - each instrument/purpose combination should have exactly one active account.
+	ErrMultipleClearingAccounts = errors.New("multiple active clearing accounts found")
+
+	// ErrEmptyClearingAccountID is returned when a clearing account has an empty account_id.
+	ErrEmptyClearingAccountID = errors.New("clearing account has empty account_id")
+
+	// ErrNilClearingAccountResponse is returned when the internal bank account service returns a nil response.
+	ErrNilClearingAccountResponse = errors.New("nil response from internal bank account service")
+
 	// ErrAccountResolverClientNil is returned when attempting to create an AccountResolver with a nil client.
 	ErrAccountResolverClientNil = errors.New("internal bank account client cannot be nil")
 
@@ -229,6 +239,15 @@ func (r *AccountResolver) queryInternalBankAccount(ctx context.Context, clearing
 		return "", fmt.Errorf("failed to query clearing account: %w", err)
 	}
 
+	// Defensive check for nil response
+	if resp == nil {
+		r.logger.Error("nil response from internal bank account service",
+			"clearing_type", clearingType,
+			"clearing_purpose", clearingPurpose.String(),
+			"instrument_code", instrumentCode)
+		return "", fmt.Errorf("%w for %s %s", ErrNilClearingAccountResponse, clearingType, instrumentCode)
+	}
+
 	if len(resp.Facilities) == 0 {
 		r.logger.Warn("no active clearing account found",
 			"clearing_type", clearingType,
@@ -237,8 +256,29 @@ func (r *AccountResolver) queryInternalBankAccount(ctx context.Context, clearing
 		return "", fmt.Errorf("%w for %s %s", ErrNoClearingAccountFound, clearingType, instrumentCode)
 	}
 
-	// Use the first active clearing account matching the criteria.
+	// Fail fast on multiple results to prevent nondeterministic routing.
+	// Each instrument/purpose combination should have exactly one active clearing account.
+	if len(resp.Facilities) > 1 {
+		r.logger.Error("multiple active clearing accounts found - data inconsistency",
+			"clearing_type", clearingType,
+			"clearing_purpose", clearingPurpose.String(),
+			"instrument_code", instrumentCode,
+			"count", len(resp.Facilities))
+		return "", fmt.Errorf("%w for %s %s (count: %d)", ErrMultipleClearingAccounts, clearingType, instrumentCode, len(resp.Facilities))
+	}
+
+	// Use the single active clearing account matching the criteria.
 	account := resp.Facilities[0]
+
+	// Defensive check for empty account_id
+	if account.AccountId == "" {
+		r.logger.Error("clearing account has empty account_id",
+			"clearing_type", clearingType,
+			"clearing_purpose", clearingPurpose.String(),
+			"instrument_code", instrumentCode)
+		return "", fmt.Errorf("%w for %s %s", ErrEmptyClearingAccountID, clearingType, instrumentCode)
+	}
+
 	return account.AccountId, nil
 }
 

--- a/services/payment-order/service/account_resolver_test.go
+++ b/services/payment-order/service/account_resolver_test.go
@@ -207,10 +207,11 @@ func TestAccountResolver_GetSettlementClearingAccount_CacheExpiry(t *testing.T) 
 	}
 
 	// Use very short TTL for testing
+	cacheTTL := 10 * time.Millisecond
 	resolver, err := NewAccountResolver(AccountResolverConfig{
 		Client:   mockClient,
 		Logger:   accountResolverTestLogger(),
-		CacheTTL: 10 * time.Millisecond,
+		CacheTTL: cacheTTL,
 	})
 	require.NoError(t, err)
 
@@ -219,8 +220,8 @@ func TestAccountResolver_GetSettlementClearingAccount_CacheExpiry(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, 1, mockClient.getCallCount())
 
-	// Wait for cache to expire
-	time.Sleep(20 * time.Millisecond)
+	// Wait for cache to expire (3x safety margin for CI scheduling variance)
+	time.Sleep(3 * cacheTTL)
 
 	// Second call - cache expired, should call client again
 	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
@@ -393,19 +394,23 @@ func TestAccountResolver_InvalidateCacheEntry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Populate cache for GBP and USD
-	_, _ = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
-	_, _ = resolver.GetSettlementClearingAccount(context.Background(), "USD")
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "USD")
+	require.NoError(t, err)
 	assert.Equal(t, 2, mockClient.getCallCount())
 
 	// Invalidate only GBP entry
 	resolver.InvalidateCacheEntry(ClearingAccountTypeSettlement, "GBP")
 
 	// GBP should trigger new lookup
-	_, _ = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
 	assert.Equal(t, 3, mockClient.getCallCount())
 
 	// USD should still be cached
-	_, _ = resolver.GetSettlementClearingAccount(context.Background(), "USD")
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "USD")
+	require.NoError(t, err)
 	assert.Equal(t, 3, mockClient.getCallCount()) // No additional call
 }
 

--- a/services/payment-order/service/account_resolver_test.go
+++ b/services/payment-order/service/account_resolver_test.go
@@ -1,0 +1,566 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockInternalBankAccountClient is a mock implementation of InternalBankAccountClient for testing.
+type mockInternalBankAccountClient struct {
+	listResponse *internalbankaccountv1.ListInternalBankAccountsResponse
+	listErr      error
+	callCount    int
+	mu           sync.Mutex
+}
+
+func (m *mockInternalBankAccountClient) ListInternalBankAccounts(_ context.Context, _ *internalbankaccountv1.ListInternalBankAccountsRequest) (*internalbankaccountv1.ListInternalBankAccountsResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callCount++
+	return m.listResponse, m.listErr
+}
+
+func (m *mockInternalBankAccountClient) GetBalance(_ context.Context, _ *internalbankaccountv1.GetBalanceRequest) (*internalbankaccountv1.GetBalanceResponse, error) {
+	return nil, nil
+}
+
+func (m *mockInternalBankAccountClient) RetrieveInternalBankAccount(_ context.Context, _ *internalbankaccountv1.RetrieveInternalBankAccountRequest) (*internalbankaccountv1.RetrieveInternalBankAccountResponse, error) {
+	return nil, nil
+}
+
+func (m *mockInternalBankAccountClient) Close() error {
+	return nil
+}
+
+func (m *mockInternalBankAccountClient) getCallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.callCount
+}
+
+func accountResolverTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// Test errors for mock responses
+var errAccountResolverTestConnectionRefused = errors.New("connection refused")
+
+// =============================================================================
+// Constructor Tests
+// =============================================================================
+
+func TestNewAccountResolver_NilClient(t *testing.T) {
+	_, err := NewAccountResolver(AccountResolverConfig{
+		Client: nil,
+		Logger: accountResolverTestLogger(),
+	})
+
+	assert.ErrorIs(t, err, ErrAccountResolverClientNil)
+}
+
+func TestNewAccountResolver_NilLogger(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{}
+
+	_, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: nil,
+	})
+
+	assert.ErrorIs(t, err, ErrAccountResolverLoggerNil)
+}
+
+func TestNewAccountResolver_DefaultCacheTTL(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+		// CacheTTL not specified - should default to DefaultCacheTTL
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, DefaultCacheTTL, resolver.cacheTTL)
+}
+
+func TestNewAccountResolver_CustomCacheTTL(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{}
+	customTTL := 10 * time.Minute
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   accountResolverTestLogger(),
+		CacheTTL: customTTL,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, customTTL, resolver.cacheTTL)
+}
+
+func TestNewAccountResolver_DefaultLookupTimeout(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+		// LookupTimeout not specified - should default to DefaultLookupTimeout
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, DefaultLookupTimeout, resolver.lookupTimeout)
+}
+
+func TestNewAccountResolver_CustomLookupTimeout(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{}
+	customTimeout := 5 * time.Second
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:        mockClient,
+		Logger:        accountResolverTestLogger(),
+		LookupTimeout: customTimeout,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, customTimeout, resolver.lookupTimeout)
+}
+
+// =============================================================================
+// GetSettlementClearingAccount - Success Cases
+// =============================================================================
+
+func TestAccountResolver_GetSettlementClearingAccount_Success(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{
+					AccountId:       "settlement-clearing-123",
+					AccountCode:     "CLR-GBP-SETTLEMENT",
+					Name:            "GBP Settlement Clearing Account",
+					ClearingPurpose: internalbankaccountv1.ClearingPurpose_CLEARING_PURPOSE_SETTLEMENT,
+				},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	accountID, err := resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "settlement-clearing-123", accountID)
+	assert.Equal(t, 1, mockClient.getCallCount())
+}
+
+// =============================================================================
+// Cache Behavior Tests
+// =============================================================================
+
+func TestAccountResolver_GetSettlementClearingAccount_CacheHit(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "settlement-clearing-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   accountResolverTestLogger(),
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// First call - cache miss
+	accountID1, err := resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, "settlement-clearing-123", accountID1)
+
+	// Second call - should be cache hit
+	accountID2, err := resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, "settlement-clearing-123", accountID2)
+
+	// Client should only be called once
+	assert.Equal(t, 1, mockClient.getCallCount())
+}
+
+func TestAccountResolver_GetSettlementClearingAccount_CacheExpiry(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "settlement-clearing-123"},
+			},
+		},
+	}
+
+	// Use very short TTL for testing
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   accountResolverTestLogger(),
+		CacheTTL: 10 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	// First call - cache miss
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 1, mockClient.getCallCount())
+
+	// Wait for cache to expire
+	time.Sleep(20 * time.Millisecond)
+
+	// Second call - cache expired, should call client again
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 2, mockClient.getCallCount())
+}
+
+// =============================================================================
+// Error Cases
+// =============================================================================
+
+func TestAccountResolver_GetSettlementClearingAccount_NoClearingAccountFound(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{}, // Empty
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+
+	assert.ErrorIs(t, err, ErrNoClearingAccountFound)
+	assert.Contains(t, err.Error(), "SETTLEMENT")
+	assert.Contains(t, err.Error(), "GBP")
+}
+
+func TestAccountResolver_GetSettlementClearingAccount_MultipleClearingAccountsFound(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "settlement-clearing-123", AccountCode: "CLR-GBP-SETTLEMENT-1"},
+				{AccountId: "settlement-clearing-456", AccountCode: "CLR-GBP-SETTLEMENT-2"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+
+	assert.ErrorIs(t, err, ErrMultipleClearingAccounts)
+	assert.Contains(t, err.Error(), "SETTLEMENT")
+	assert.Contains(t, err.Error(), "GBP")
+	assert.Contains(t, err.Error(), "count: 2")
+}
+
+func TestAccountResolver_GetSettlementClearingAccount_EmptyAccountID(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{
+					AccountId:   "", // Empty account_id
+					AccountCode: "CLR-GBP-SETTLEMENT",
+				},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+
+	assert.ErrorIs(t, err, ErrEmptyClearingAccountID)
+	assert.Contains(t, err.Error(), "SETTLEMENT")
+	assert.Contains(t, err.Error(), "GBP")
+}
+
+func TestAccountResolver_GetSettlementClearingAccount_NilResponse(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: nil, // Nil response
+		listErr:      nil, // No error - but response is nil
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+
+	assert.ErrorIs(t, err, ErrNilClearingAccountResponse)
+	assert.Contains(t, err.Error(), "SETTLEMENT")
+	assert.Contains(t, err.Error(), "GBP")
+}
+
+func TestAccountResolver_GetSettlementClearingAccount_ClientError(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listErr: errAccountResolverTestConnectionRefused,
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, errAccountResolverTestConnectionRefused)
+}
+
+// =============================================================================
+// Cache Management Tests
+// =============================================================================
+
+func TestAccountResolver_InvalidateCache(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "settlement-clearing-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   accountResolverTestLogger(),
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// First call - cache miss
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 1, mockClient.getCallCount())
+
+	// Second call - cache hit
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 1, mockClient.getCallCount())
+
+	// Invalidate cache
+	resolver.InvalidateCache()
+
+	// Third call - cache invalidated, should call client again
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, 2, mockClient.getCallCount())
+}
+
+func TestAccountResolver_InvalidateCacheEntry(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "settlement-clearing-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   accountResolverTestLogger(),
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// Populate cache for GBP and USD
+	_, _ = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	_, _ = resolver.GetSettlementClearingAccount(context.Background(), "USD")
+	assert.Equal(t, 2, mockClient.getCallCount())
+
+	// Invalidate only GBP entry
+	resolver.InvalidateCacheEntry(ClearingAccountTypeSettlement, "GBP")
+
+	// GBP should trigger new lookup
+	_, _ = resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+	assert.Equal(t, 3, mockClient.getCallCount())
+
+	// USD should still be cached
+	_, _ = resolver.GetSettlementClearingAccount(context.Background(), "USD")
+	assert.Equal(t, 3, mockClient.getCallCount()) // No additional call
+}
+
+// =============================================================================
+// Multiple Instrument Tests
+// =============================================================================
+
+func TestAccountResolver_DifferentInstrumentCodes(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "settlement-clearing-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	// Query different instruments
+	instruments := []string{"GBP", "USD", "EUR", "KWH"}
+	for _, instrument := range instruments {
+		_, err := resolver.GetSettlementClearingAccount(context.Background(), instrument)
+		require.NoError(t, err)
+	}
+
+	// Each unique instrument should trigger one client call
+	assert.Equal(t, 4, mockClient.getCallCount())
+}
+
+// =============================================================================
+// Concurrency Tests
+// =============================================================================
+
+func TestAccountResolver_ConcurrentAccess(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "settlement-clearing-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   accountResolverTestLogger(),
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// Run concurrent requests for the same instrument
+	var wg sync.WaitGroup
+	errChan := make(chan error, 100)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := resolver.GetSettlementClearingAccount(context.Background(), "GBP")
+			if err != nil {
+				errChan <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	// No errors should occur
+	for err := range errChan {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Due to singleflight + caching, client should be called a small number of times
+	// (exact count depends on timing, but should be much less than 100)
+	assert.Less(t, mockClient.getCallCount(), 10, "Singleflight + cache should reduce client calls significantly")
+}
+
+func TestAccountResolver_ConcurrentAccessDifferentInstruments(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "settlement-clearing-123"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   accountResolverTestLogger(),
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	instruments := []string{"GBP", "USD", "EUR", "JPY"}
+	var wg sync.WaitGroup
+	errChan := make(chan error, 400)
+
+	// 25 concurrent requests per instrument
+	for _, instrument := range instruments {
+		for i := 0; i < 25; i++ {
+			wg.Add(1)
+			go func(inst string) {
+				defer wg.Done()
+				_, err := resolver.GetSettlementClearingAccount(context.Background(), inst)
+				if err != nil {
+					errChan <- err
+				}
+			}(instrument)
+		}
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	// No errors should occur
+	for err := range errChan {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Should have approximately 4 calls (one per instrument) due to singleflight
+	// Allow some slack for timing variations
+	assert.LessOrEqual(t, mockClient.getCallCount(), 16, "Singleflight should coalesce concurrent requests per instrument")
+}
+
+// =============================================================================
+// ClearingAccountType Mapping Tests
+// =============================================================================
+
+func TestMapClearingTypeToPurpose_Settlement(t *testing.T) {
+	purpose := mapClearingTypeToPurpose(ClearingAccountTypeSettlement)
+	assert.Equal(t, internalbankaccountv1.ClearingPurpose_CLEARING_PURPOSE_SETTLEMENT, purpose)
+}
+
+func TestMapClearingTypeToPurpose_Unknown(t *testing.T) {
+	// For unknown types, should return UNSPECIFIED
+	purpose := mapClearingTypeToPurpose(ClearingAccountType("UNKNOWN"))
+	assert.Equal(t, internalbankaccountv1.ClearingPurpose_CLEARING_PURPOSE_UNSPECIFIED, purpose)
+}
+
+// =============================================================================
+// Cache Key Tests
+// =============================================================================
+
+func TestAccountResolver_CacheKey(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{}
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	key := resolver.cacheKey(ClearingAccountTypeSettlement, "GBP")
+	assert.Equal(t, "SETTLEMENT:GBP", key)
+}

--- a/services/payment-order/service/payment_orchestrator.go
+++ b/services/payment-order/service/payment_orchestrator.go
@@ -56,6 +56,7 @@ type PaymentOrchestrator struct {
 	paymentGateway            gateway.PaymentGateway
 	financialAccountingClient FinancialAccountingClient
 	internalBankAccountClient InternalBankAccountClient // Optional - for internal clearing
+	accountResolver           *AccountResolver          // Optional - resolves clearing accounts dynamically
 	gatewayAccountConfig      *config.GatewayAccountConfig
 	kafkaPublisher            KafkaPublisher
 	lienExecutionRetryConfig  *sharedclients.RetryConfig
@@ -70,6 +71,7 @@ type PaymentOrchestratorConfig struct {
 	PaymentGateway            gateway.PaymentGateway
 	FinancialAccountingClient FinancialAccountingClient
 	InternalBankAccountClient InternalBankAccountClient // Optional - for internal clearing
+	AccountResolver           *AccountResolver          // Optional - auto-created if InternalBankAccountClient is provided
 	GatewayAccountConfig      *config.GatewayAccountConfig
 	KafkaPublisher            KafkaPublisher
 	LienExecutionRetryConfig  *sharedclients.RetryConfig
@@ -79,6 +81,9 @@ type PaymentOrchestratorConfig struct {
 // NewPaymentOrchestrator creates a new payment orchestrator with the given dependencies.
 // Returns an error if required dependencies (Logger, Repo) are nil. CurrentAccountClient and
 // PaymentGateway are validated at runtime in Orchestrate() with graceful error handling.
+//
+// If InternalBankAccountClient is provided but AccountResolver is nil, an AccountResolver
+// is automatically created using the client and logger.
 func NewPaymentOrchestrator(cfg PaymentOrchestratorConfig) (*PaymentOrchestrator, error) {
 	if cfg.Logger == nil {
 		return nil, ErrOrchestratorLoggerNil
@@ -86,6 +91,20 @@ func NewPaymentOrchestrator(cfg PaymentOrchestratorConfig) (*PaymentOrchestrator
 	if cfg.Repo == nil {
 		return nil, ErrOrchestratorRepoNil
 	}
+
+	// Auto-create AccountResolver if InternalBankAccountClient is provided but AccountResolver is nil
+	accountResolver := cfg.AccountResolver
+	if cfg.InternalBankAccountClient != nil && accountResolver == nil {
+		var err error
+		accountResolver, err = NewAccountResolver(AccountResolverConfig{
+			Client: cfg.InternalBankAccountClient,
+			Logger: cfg.Logger,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create account resolver: %w", err)
+		}
+	}
+
 	return &PaymentOrchestrator{
 		logger:                    cfg.Logger,
 		repo:                      cfg.Repo,
@@ -93,6 +112,7 @@ func NewPaymentOrchestrator(cfg PaymentOrchestratorConfig) (*PaymentOrchestrator
 		paymentGateway:            cfg.PaymentGateway,
 		financialAccountingClient: cfg.FinancialAccountingClient,
 		internalBankAccountClient: cfg.InternalBankAccountClient,
+		accountResolver:           accountResolver,
 		gatewayAccountConfig:      cfg.GatewayAccountConfig,
 		kafkaPublisher:            cfg.KafkaPublisher,
 		lienExecutionRetryConfig:  cfg.LienExecutionRetryConfig,

--- a/services/payment-order/service/payment_orchestrator.go
+++ b/services/payment-order/service/payment_orchestrator.go
@@ -426,22 +426,34 @@ func (o *PaymentOrchestrator) failPaymentOrder(ctx context.Context, po *domain.P
 // It creates a BookingLog in PENDING status, captures debit and credit postings, then
 // updates the BookingLog to POSTED status. Returns the booking log ID on success.
 //
-// Double-entry accounting for outbound payments:
+// Double-entry accounting supports two flows:
+//
+// Standard Flow (2 postings):
 //   - DEBIT: Customer's account (funds leaving their account)
 //   - CREDIT: Gateway's contra-account (liability to payment processor)
 //
+// Internal Clearing Flow (4 postings) - when internalClearingEnabled and clearing account resolved:
+//   - DEBIT: Customer's account (funds leaving their account)
+//   - CREDIT: Clearing account (funds enter internal clearing)
+//   - DEBIT: Clearing account (funds leave internal clearing)
+//   - CREDIT: Gateway's contra-account (liability to payment processor)
+//
+// The 4-posting flow maintains double-entry balance while routing through the internal
+// clearing account, enabling enhanced reconciliation and settlement tracking.
+//
 // Atomicity considerations:
-// This function makes 4 sequential gRPC calls to the FinancialAccounting service:
+// Standard flow makes 4 sequential gRPC calls, clearing flow makes 6:
 //  1. InitiateFinancialBookingLog (creates BookingLog in PENDING)
-//  2. CaptureLedgerPosting (DEBIT entry)
-//  3. CaptureLedgerPosting (CREDIT entry)
-//  4. UpdateFinancialBookingLog (marks as POSTED)
+//  2. CaptureLedgerPosting (DEBIT customer)
+//  3. CaptureLedgerPosting (CREDIT clearing) - only in clearing flow
+//  4. CaptureLedgerPosting (DEBIT clearing) - only in clearing flow
+//  5. CaptureLedgerPosting (CREDIT gateway)
+//  6. UpdateFinancialBookingLog (marks as POSTED)
 //
 // Partial failure scenarios (documented for operational runbooks):
 //   - Step 1 fails: No orphaned state - safe to retry
-//   - Step 2 fails: BookingLog in PENDING, no postings - needs cleanup
-//   - Step 3 fails: BookingLog in PENDING, unbalanced (debit only) - needs reversal
-//   - Step 4 fails: BookingLog in PENDING, balanced entries exist - just needs status update
+//   - Posting step fails: BookingLog in PENDING, unbalanced - needs reversal/cleanup
+//   - Final status update fails: BookingLog in PENDING, balanced entries exist - just needs status update
 //
 // All partial failures are logged with RECONCILIATION_REQUIRED prefix and include
 // the booking_log_id for manual resolution. See runbook: docs/runbooks/saga-failure-recovery.md
@@ -449,6 +461,9 @@ func (o *PaymentOrchestrator) failPaymentOrder(ctx context.Context, po *domain.P
 // Error handling: If any step fails, the error is returned and the calling code
 // should mark the payment as FAILED. The BookingLog will remain in PENDING status
 // for reconciliation purposes.
+//
+// Clearing account fallback: If internal clearing is enabled but the clearing account
+// lookup fails, the method falls back to the standard 2-posting flow gracefully.
 func (o *PaymentOrchestrator) PostLedgerEntries(ctx context.Context, po *domain.PaymentOrder) (string, error) {
 	// Check required dependencies - these may be nil in minimal test configuration
 	if o.gatewayAccountConfig == nil {
@@ -513,9 +528,57 @@ func (o *PaymentOrchestrator) PostLedgerEntries(ctx context.Context, po *domain.
 	}
 	valueDate := timestamppb.Now()
 
+	// Determine if we should use the 4-posting flow with internal clearing
+	var clearingAccountID string
+	useClearingFlow := false
+
+	if o.internalClearingEnabled && o.accountResolver != nil {
+		var resolveErr error
+		clearingAccountID, resolveErr = o.accountResolver.GetSettlementClearingAccount(ctx, currencyCode)
+		if resolveErr != nil {
+			// Log the fallback but continue with standard 2-posting flow
+			o.logger.Info("clearing account lookup failed, falling back to standard posting flow",
+				"payment_order_id", po.ID.String(),
+				"currency", currencyCode,
+				"reason", resolveErr.Error())
+		} else {
+			useClearingFlow = true
+			o.logger.Info("using internal clearing flow with 4 postings",
+				"payment_order_id", po.ID.String(),
+				"clearing_account_id", clearingAccountID,
+				"currency", currencyCode)
+		}
+	} else if o.internalClearingEnabled {
+		o.logger.Debug("internal clearing enabled but account resolver not configured, using standard flow",
+			"payment_order_id", po.ID.String())
+	}
+
+	if useClearingFlow {
+		// 4-posting flow: Customer DEBIT -> Clearing CREDIT -> Clearing DEBIT -> Gateway CREDIT
+		return o.postLedgerEntriesWithClearing(ctx, po, bookingLogID, postingAmount, valueDate,
+			clearingAccountID, contraAccountID, amountCents, currencyCode)
+	}
+
+	// Standard 2-posting flow: Customer DEBIT -> Gateway CREDIT
+	return o.postLedgerEntriesStandard(ctx, po, bookingLogID, postingAmount, valueDate,
+		contraAccountID, amountCents, currencyCode)
+}
+
+// postLedgerEntriesStandard creates the standard 2-posting flow for ledger entries.
+// Posts: Customer DEBIT -> Gateway CREDIT
+func (o *PaymentOrchestrator) postLedgerEntriesStandard(
+	ctx context.Context,
+	po *domain.PaymentOrder,
+	bookingLogID string,
+	postingAmount *money.Money,
+	valueDate *timestamppb.Timestamp,
+	contraAccountID string,
+	amountCents int64,
+	currencyCode string,
+) (string, error) {
 	// Step 2: Create DEBIT posting (customer account - funds leaving)
-	debitIdempKey := fmt.Sprintf("debit-%s", po.IdempotencyKey)
-	_, err = o.financialAccountingClient.CaptureLedgerPosting(ctx, &financialaccountingv1.CaptureLedgerPostingRequest{
+	debitIdempKey := fmt.Sprintf("debit-customer-%s", po.IdempotencyKey)
+	_, err := o.financialAccountingClient.CaptureLedgerPosting(ctx, &financialaccountingv1.CaptureLedgerPostingRequest{
 		FinancialBookingLogId: bookingLogID,
 		PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_DEBIT,
 		PostingAmount:         postingAmount,
@@ -531,20 +594,21 @@ func (o *PaymentOrchestrator) PostLedgerEntries(ctx context.Context, po *domain.
 			"booking_log_id", bookingLogID,
 			"booking_log_status", "PENDING",
 			"payment_order_id", po.ID.String(),
-			"failed_step", "debit_posting",
+			"failed_step", "debit_customer_posting",
+			"posting_flow", "standard",
 			"debtor_account", po.DebtorAccountID,
 			"error", err.Error())
 		return "", fmt.Errorf("failed to create debit posting for account %s: %w", po.DebtorAccountID, err)
 	}
 
-	o.logger.Debug("created debit posting",
+	o.logger.Debug("created debit posting (customer)",
 		"booking_log_id", bookingLogID,
 		"account_id", po.DebtorAccountID,
 		"amount_cents", amountCents,
 		"payment_order_id", po.ID.String())
 
 	// Step 3: Create CREDIT posting (gateway contra-account - liability to processor)
-	creditIdempKey := fmt.Sprintf("credit-%s", po.IdempotencyKey)
+	creditIdempKey := fmt.Sprintf("credit-gateway-%s", po.IdempotencyKey)
 	_, err = o.financialAccountingClient.CaptureLedgerPosting(ctx, &financialaccountingv1.CaptureLedgerPostingRequest{
 		FinancialBookingLogId: bookingLogID,
 		PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_CREDIT,
@@ -561,15 +625,16 @@ func (o *PaymentOrchestrator) PostLedgerEntries(ctx context.Context, po *domain.
 			"booking_log_id", bookingLogID,
 			"booking_log_status", "PENDING",
 			"payment_order_id", po.ID.String(),
-			"failed_step", "credit_posting",
+			"failed_step", "credit_gateway_posting",
+			"posting_flow", "standard",
 			"debtor_account", po.DebtorAccountID,
 			"contra_account", contraAccountID,
-			"has_debit_posting", true,
+			"has_debit_customer_posting", true,
 			"error", err.Error())
 		return "", fmt.Errorf("failed to create credit posting for account %s: %w", contraAccountID, err)
 	}
 
-	o.logger.Debug("created credit posting",
+	o.logger.Debug("created credit posting (gateway)",
 		"booking_log_id", bookingLogID,
 		"account_id", contraAccountID,
 		"amount_cents", amountCents,
@@ -589,18 +654,200 @@ func (o *PaymentOrchestrator) PostLedgerEntries(ctx context.Context, po *domain.
 			"target_status", "POSTED",
 			"payment_order_id", po.ID.String(),
 			"failed_step", "status_update",
-			"has_debit_posting", true,
-			"has_credit_posting", true,
+			"posting_flow", "standard",
+			"has_debit_customer_posting", true,
+			"has_credit_gateway_posting", true,
 			"resolution", "manually update booking log status to POSTED",
 			"error", err.Error())
 		return "", fmt.Errorf("failed to update booking log to POSTED: %w", err)
 	}
 
-	o.logger.Info("ledger posting completed successfully",
+	o.logger.Info("ledger posting completed successfully (standard flow)",
 		"booking_log_id", bookingLogID,
 		"payment_order_id", po.ID.String(),
 		"debtor_account", po.DebtorAccountID,
 		"contra_account", contraAccountID,
+		"posting_count", 2,
+		"amount_cents", amountCents,
+		"currency", currencyCode)
+
+	return bookingLogID, nil
+}
+
+// postLedgerEntriesWithClearing creates the 4-posting flow for ledger entries with internal clearing.
+// Posts: Customer DEBIT -> Clearing CREDIT -> Clearing DEBIT -> Gateway CREDIT
+// This maintains double-entry balance while routing through the internal clearing account.
+func (o *PaymentOrchestrator) postLedgerEntriesWithClearing(
+	ctx context.Context,
+	po *domain.PaymentOrder,
+	bookingLogID string,
+	postingAmount *money.Money,
+	valueDate *timestamppb.Timestamp,
+	clearingAccountID string,
+	contraAccountID string,
+	amountCents int64,
+	currencyCode string,
+) (string, error) {
+	// Step 2: Create DEBIT posting (customer account - funds leaving)
+	debitCustomerIdempKey := fmt.Sprintf("debit-customer-%s", po.IdempotencyKey)
+	_, err := o.financialAccountingClient.CaptureLedgerPosting(ctx, &financialaccountingv1.CaptureLedgerPostingRequest{
+		FinancialBookingLogId: bookingLogID,
+		PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_DEBIT,
+		PostingAmount:         postingAmount,
+		AccountId:             po.DebtorAccountID,
+		ValueDate:             valueDate,
+		IdempotencyKey: &commonpb.IdempotencyKey{
+			Key: debitCustomerIdempKey,
+		},
+	})
+	if err != nil {
+		o.logger.Error("RECONCILIATION_REQUIRED: booking log orphaned after debit posting failure",
+			"booking_log_id", bookingLogID,
+			"booking_log_status", "PENDING",
+			"payment_order_id", po.ID.String(),
+			"failed_step", "debit_customer_posting",
+			"posting_flow", "clearing",
+			"debtor_account", po.DebtorAccountID,
+			"clearing_account", clearingAccountID,
+			"error", err.Error())
+		return "", fmt.Errorf("failed to create debit posting for customer account %s: %w", po.DebtorAccountID, err)
+	}
+
+	o.logger.Debug("created debit posting (customer) in clearing flow",
+		"booking_log_id", bookingLogID,
+		"account_id", po.DebtorAccountID,
+		"amount_cents", amountCents,
+		"payment_order_id", po.ID.String())
+
+	// Step 3: Create CREDIT posting (clearing account - funds enter clearing)
+	creditClearingIdempKey := fmt.Sprintf("credit-clearing-%s", po.IdempotencyKey)
+	_, err = o.financialAccountingClient.CaptureLedgerPosting(ctx, &financialaccountingv1.CaptureLedgerPostingRequest{
+		FinancialBookingLogId: bookingLogID,
+		PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_CREDIT,
+		PostingAmount:         postingAmount,
+		AccountId:             clearingAccountID,
+		ValueDate:             valueDate,
+		IdempotencyKey: &commonpb.IdempotencyKey{
+			Key: creditClearingIdempKey,
+		},
+	})
+	if err != nil {
+		o.logger.Error("RECONCILIATION_REQUIRED: booking log orphaned after credit clearing posting failure",
+			"booking_log_id", bookingLogID,
+			"booking_log_status", "PENDING",
+			"payment_order_id", po.ID.String(),
+			"failed_step", "credit_clearing_posting",
+			"posting_flow", "clearing",
+			"debtor_account", po.DebtorAccountID,
+			"clearing_account", clearingAccountID,
+			"has_debit_customer_posting", true,
+			"error", err.Error())
+		return "", fmt.Errorf("failed to create credit posting for clearing account %s: %w", clearingAccountID, err)
+	}
+
+	o.logger.Debug("created credit posting (clearing) in clearing flow",
+		"booking_log_id", bookingLogID,
+		"account_id", clearingAccountID,
+		"amount_cents", amountCents,
+		"payment_order_id", po.ID.String())
+
+	// Step 4: Create DEBIT posting (clearing account - funds leave clearing)
+	debitClearingIdempKey := fmt.Sprintf("debit-clearing-%s", po.IdempotencyKey)
+	_, err = o.financialAccountingClient.CaptureLedgerPosting(ctx, &financialaccountingv1.CaptureLedgerPostingRequest{
+		FinancialBookingLogId: bookingLogID,
+		PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_DEBIT,
+		PostingAmount:         postingAmount,
+		AccountId:             clearingAccountID,
+		ValueDate:             valueDate,
+		IdempotencyKey: &commonpb.IdempotencyKey{
+			Key: debitClearingIdempKey,
+		},
+	})
+	if err != nil {
+		o.logger.Error("RECONCILIATION_REQUIRED: booking log orphaned after debit clearing posting failure",
+			"booking_log_id", bookingLogID,
+			"booking_log_status", "PENDING",
+			"payment_order_id", po.ID.String(),
+			"failed_step", "debit_clearing_posting",
+			"posting_flow", "clearing",
+			"debtor_account", po.DebtorAccountID,
+			"clearing_account", clearingAccountID,
+			"has_debit_customer_posting", true,
+			"has_credit_clearing_posting", true,
+			"error", err.Error())
+		return "", fmt.Errorf("failed to create debit posting for clearing account %s: %w", clearingAccountID, err)
+	}
+
+	o.logger.Debug("created debit posting (clearing) in clearing flow",
+		"booking_log_id", bookingLogID,
+		"account_id", clearingAccountID,
+		"amount_cents", amountCents,
+		"payment_order_id", po.ID.String())
+
+	// Step 5: Create CREDIT posting (gateway contra-account - liability to processor)
+	creditGatewayIdempKey := fmt.Sprintf("credit-gateway-%s", po.IdempotencyKey)
+	_, err = o.financialAccountingClient.CaptureLedgerPosting(ctx, &financialaccountingv1.CaptureLedgerPostingRequest{
+		FinancialBookingLogId: bookingLogID,
+		PostingDirection:      commonpb.PostingDirection_POSTING_DIRECTION_CREDIT,
+		PostingAmount:         postingAmount,
+		AccountId:             contraAccountID,
+		ValueDate:             valueDate,
+		IdempotencyKey: &commonpb.IdempotencyKey{
+			Key: creditGatewayIdempKey,
+		},
+	})
+	if err != nil {
+		o.logger.Error("RECONCILIATION_REQUIRED: booking log orphaned after credit gateway posting failure",
+			"booking_log_id", bookingLogID,
+			"booking_log_status", "PENDING",
+			"payment_order_id", po.ID.String(),
+			"failed_step", "credit_gateway_posting",
+			"posting_flow", "clearing",
+			"debtor_account", po.DebtorAccountID,
+			"clearing_account", clearingAccountID,
+			"contra_account", contraAccountID,
+			"has_debit_customer_posting", true,
+			"has_credit_clearing_posting", true,
+			"has_debit_clearing_posting", true,
+			"error", err.Error())
+		return "", fmt.Errorf("failed to create credit posting for gateway account %s: %w", contraAccountID, err)
+	}
+
+	o.logger.Debug("created credit posting (gateway) in clearing flow",
+		"booking_log_id", bookingLogID,
+		"account_id", contraAccountID,
+		"amount_cents", amountCents,
+		"payment_order_id", po.ID.String())
+
+	// Step 6: Update BookingLog status to POSTED (all 4 balanced entries are complete)
+	_, err = o.financialAccountingClient.UpdateFinancialBookingLog(ctx, &financialaccountingv1.UpdateFinancialBookingLogRequest{
+		Id:     bookingLogID,
+		Status: commonpb.TransactionStatus_TRANSACTION_STATUS_POSTED,
+	})
+	if err != nil {
+		o.logger.Error("RECONCILIATION_REQUIRED: booking log status update failed after successful postings",
+			"booking_log_id", bookingLogID,
+			"booking_log_status", "PENDING",
+			"target_status", "POSTED",
+			"payment_order_id", po.ID.String(),
+			"failed_step", "status_update",
+			"posting_flow", "clearing",
+			"has_debit_customer_posting", true,
+			"has_credit_clearing_posting", true,
+			"has_debit_clearing_posting", true,
+			"has_credit_gateway_posting", true,
+			"resolution", "manually update booking log status to POSTED",
+			"error", err.Error())
+		return "", fmt.Errorf("failed to update booking log to POSTED: %w", err)
+	}
+
+	o.logger.Info("ledger posting completed successfully (clearing flow)",
+		"booking_log_id", bookingLogID,
+		"payment_order_id", po.ID.String(),
+		"debtor_account", po.DebtorAccountID,
+		"clearing_account", clearingAccountID,
+		"contra_account", contraAccountID,
+		"posting_count", 4,
 		"amount_cents", amountCents,
 		"currency", currencyCode)
 


### PR DESCRIPTION
## Summary

Enhances the Payment Order service to use internal clearing accounts when feature flag is enabled, providing improved reconciliation and settlement tracking capabilities.

**Task Master**: internal-bank-account.28

## Changes Made

### 1. AccountResolver Pattern (subtask 28.1)
- Created `services/payment-order/service/account_resolver.go` following the pattern from Financial Accounting service
- Thread-safe caching with singleflight to prevent cache stampede
- `GetSettlementClearingAccount(ctx, instrumentCode)` method for resolving settlement clearing accounts
- Added observability metrics: cache hits/misses, lookup duration, lookup errors

### 2. PaymentOrchestrator Integration (subtask 28.2)
- Added `accountResolver *AccountResolver` field to PaymentOrchestrator
- Auto-creation of AccountResolver when InternalBankAccountClient is provided
- Backward compatible - works without clearing when client not configured

### 3. Two-Leg Posting Flow (subtask 28.3)
- When `internalClearingEnabled=true` AND clearing account resolved:
  - Customer DEBIT → Clearing CREDIT (funds enter clearing)
  - Clearing DEBIT → Gateway CREDIT (funds leave clearing)
- Graceful fallback to standard 2-posting flow when:
  - Feature flag disabled
  - Clearing account lookup fails
- Updated idempotency keys to distinguish between posting types
- Enhanced RECONCILIATION_REQUIRED logging with posting flow context

### 4. No Client Changes Needed (subtask 28.4)
- Existing CaptureLedgerPosting API already supports multiple postings per BookingLog
- All 4 postings use the same BookingLog for atomicity

## Technical Details

**Standard Flow (2 postings)**:
```
Customer DEBIT → Gateway CREDIT
```

**Clearing Flow (4 postings)**:
```
Customer DEBIT → Clearing CREDIT → Clearing DEBIT → Gateway CREDIT
```

This maintains double-entry balance while routing through the internal clearing account, enabling enhanced settlement reconciliation.

## Test Plan

- [x] Unit tests pass for AccountResolver
- [x] Integration tests verify standard flow (existing tests)
- [x] Fallback behavior tested (clearing lookup failure → standard flow)
- [ ] Manual test: Enable feature flag and provision clearing account
- [ ] Verify 4-posting flow in Financial Accounting ledger