### PR TITLE
docs: Add Canonical Ingestion Contract (PRD v1.3 + ADR-0026)

### DIFF
--- a/docs/adr/0026-canonical-ingestion-contract.md
+++ b/docs/adr/0026-canonical-ingestion-contract.md
@@ -1,16 +1,18 @@
 ---
 name: adr-026-canonical-ingestion-contract
-description: External systems structure data; Meridian validates and stores
+description: Keep ETL off critical path; Meridian validates and stores structured data at 100k TPS
 triggers:
   - Designing data ingestion from external sources
   - Building adapters for market data, IoT, or third-party feeds
   - Deciding where ETL logic should live
-  - Implementing validation at service boundaries
+  - Performance concerns about ingestion overhead
+  - Scaling decisions for high-throughput data pipelines
 instructions: |
-  Meridian services accept ONLY pre-structured data conforming to their Protobuf schemas.
-  All extraction, transformation, and normalization is the caller's responsibility.
-  CEL validation at the boundary enforces the contract - invalid data is rejected, not fixed.
-  External adapters are reference utilities, not core service features.
+  Meridian is a high-performance persistence layer (100k TPS target). Keep messy ETL OFF the
+  critical path. Services accept ONLY pre-structured Protobuf - all extraction, transformation,
+  and normalization is the caller's responsibility. This extends hexagonal architecture: Meridian
+  defines the Port (structured schema), external systems implement the Adapter (messy translation).
+  CEL validation at the boundary enforces the contract. Adapters scale independently from core.
 ---
 
 # 26. Canonical Ingestion Contract
@@ -23,36 +25,49 @@ Accepted
 
 ## Context
 
-Meridian needs to ingest data from diverse external sources: market data providers (ECB, Bloomberg),
-IoT devices (smart meters), weather APIs, and tenant-specific systems. Each source has different:
+**Meridian is a high-performance persistence layer for structured financial data.** The design
+target is **100,000 transactions per second** - writes to the database and reads from the database
+must be blazing fast.
 
-- **Protocols**: REST, WebSocket, TCP, file drops
-- **Formats**: XML, JSON, CSV, binary
-- **Schedules**: Real-time streaming, daily batches, on-demand
-- **Error modes**: Rate limits, connection drops, schema changes
+The critical path is simple: **Structured Data → Validation → Storage → Query**
 
-The question is: **Where should the "messy ETL" logic live?**
+External data sources (market data providers, IoT devices, weather APIs) introduce complexity
+that is fundamentally incompatible with this performance goal:
 
-BIAN's Service Domain encapsulation principle provides guidance:
+| External Source Characteristic | Impact on Critical Path |
+|-------------------------------|------------------------|
+| Variable protocols (REST, WebSocket, TCP) | Connection management overhead |
+| Diverse formats (XML, JSON, CSV, binary) | Parsing and transformation CPU cost |
+| Unpredictable latency (rate limits, timeouts) | Blocking or queueing delays |
+| Schema drift (API version changes) | Runtime adaptation logic |
+| Scaling requirements (burst handling) | Resource contention with core |
 
-> "Because the Service Domain handles all activities for the complete life cycle it internalizes
-> or encapsulates away much of the more complex processing logic."
+**The question is: Where should the "messy ETL" logic live?**
 
-However, this refers to **domain-specific** processing, not universal data integration middleware.
-Market Information Management's domain is storing and querying market observations with bi-temporal
-integrity - not parsing arbitrary external formats.
+The answer is driven by a fundamental architectural principle: **Keep slow, unpredictable work
+OFF the critical path.** Data ingestion from external sources is inherently slow and variable.
+Scaling up or scaling down to handle ingestion load is a separate concern from scaling the
+persistence layer.
+
+This extends the **Hexagonal Architecture** (Ports and Adapters) pattern:
+- **Meridian defines the Port** (the structured Protobuf schema)
+- **External systems implement the Adapter** (the messy translation logic)
+- **We are responsible for the structured database, not for adapting the messy external world**
 
 ## Decision Drivers
 
-* **Separation of Concerns**: Domain services should focus on their core capability, not protocol
-  translation
-* **Maintainability**: Source-specific adapters change frequently (API versions, format changes);
-  core services should remain stable
-* **Testability**: CEL validation at the boundary provides a clear contract that's easy to test
-* **Flexibility**: Tenants should be able to build their own adapters without modifying Meridian
-* **Security**: Rejecting malformed data at the boundary prevents garbage-in scenarios
-* **BIAN Alignment**: Follows the atomic service design principle where each domain handles one
-  type of asset/pattern
+* **Performance (PRIMARY)**: The critical path (validate → store → query) must achieve 100k TPS.
+  ETL logic in the critical path would destroy this target.
+* **Predictable Latency**: Database writes should have consistent, low latency. External source
+  variability (rate limits, connection drops, slow APIs) must not affect core service SLAs.
+* **Independent Scaling**: Adapters may need to scale differently than the core. A burst of
+  weather data shouldn't compete for resources with payment processing.
+* **Hexagonal Architecture**: Meridian defines structured ports; adapters are external. This is
+  the classic ports-and-adapters pattern applied to data ingestion.
+* **Operational Isolation**: Adapter failures (Bloomberg API down) should not crash or degrade
+  core services. Blast radius containment.
+* **Tenant Flexibility**: Tenants can build, scale, and operate their own adapters without
+  touching Meridian core.
 
 ## Considered Options
 
@@ -65,8 +80,9 @@ integrity - not parsing arbitrary external formats.
 
 ## Decision Outcome
 
-Chosen option: **"Canonical Ingestion Contract"**, because it provides the cleanest separation of
-concerns while maintaining data integrity through CEL validation at the boundary.
+Chosen option: **"Canonical Ingestion Contract"**, because it keeps the messy, slow, unpredictable
+ETL work OFF the critical path, enabling Meridian to achieve its 100k TPS target while maintaining
+data integrity through CEL validation at the boundary.
 
 ### The Contract
 
@@ -118,16 +134,20 @@ concerns while maintaining data integrity through CEL validation at the boundary
 
 ### Positive Consequences
 
+* **100k TPS Achievable**: Critical path contains only validation and storage - no ETL overhead
+* **Predictable Latency**: Database operations have consistent performance; external variability
+  is isolated in adapters
+* **Independent Scaling**: Adapters scale separately from core; burst ingestion doesn't starve
+  transaction processing
+* **Operational Isolation**: Adapter failures don't crash core services; blast radius contained
 * **Clean Domain Services**: Core services remain focused on their BIAN responsibility
-* **Stable APIs**: Service contracts don't change when external sources change their formats
 * **Testable Boundaries**: CEL validation provides deterministic, testable contract enforcement
 * **Tenant Flexibility**: Tenants can build custom adapters without modifying Meridian
-* **Security**: Malformed data is rejected at the boundary, preventing data quality issues
-* **Reusability**: Reference adapters can be shared across deployments
 
 ### Negative Consequences
 
 * **More Components**: Requires separate adapter deployment/maintenance for each external source
+* **Adapter Scaling Responsibility**: Tenants must scale their own adapters for burst handling
 * **Duplication Risk**: Without good reference implementations, teams might reinvent adapters
 * **Operational Complexity**: Adapters need their own monitoring, logging, and error handling
 

--- a/docs/adr/0026-canonical-ingestion-contract.md
+++ b/docs/adr/0026-canonical-ingestion-contract.md
@@ -1,0 +1,254 @@
+---
+name: adr-026-canonical-ingestion-contract
+description: External systems structure data; Meridian validates and stores
+triggers:
+  - Designing data ingestion from external sources
+  - Building adapters for market data, IoT, or third-party feeds
+  - Deciding where ETL logic should live
+  - Implementing validation at service boundaries
+instructions: |
+  Meridian services accept ONLY pre-structured data conforming to their Protobuf schemas.
+  All extraction, transformation, and normalization is the caller's responsibility.
+  CEL validation at the boundary enforces the contract - invalid data is rejected, not fixed.
+  External adapters are reference utilities, not core service features.
+---
+
+# 26. Canonical Ingestion Contract
+
+Date: 2026-01-17
+
+## Status
+
+Accepted
+
+## Context
+
+Meridian needs to ingest data from diverse external sources: market data providers (ECB, Bloomberg),
+IoT devices (smart meters), weather APIs, and tenant-specific systems. Each source has different:
+
+- **Protocols**: REST, WebSocket, TCP, file drops
+- **Formats**: XML, JSON, CSV, binary
+- **Schedules**: Real-time streaming, daily batches, on-demand
+- **Error modes**: Rate limits, connection drops, schema changes
+
+The question is: **Where should the "messy ETL" logic live?**
+
+BIAN's Service Domain encapsulation principle provides guidance:
+
+> "Because the Service Domain handles all activities for the complete life cycle it internalizes
+> or encapsulates away much of the more complex processing logic."
+
+However, this refers to **domain-specific** processing, not universal data integration middleware.
+Market Information Management's domain is storing and querying market observations with bi-temporal
+integrity - not parsing arbitrary external formats.
+
+## Decision Drivers
+
+* **Separation of Concerns**: Domain services should focus on their core capability, not protocol
+  translation
+* **Maintainability**: Source-specific adapters change frequently (API versions, format changes);
+  core services should remain stable
+* **Testability**: CEL validation at the boundary provides a clear contract that's easy to test
+* **Flexibility**: Tenants should be able to build their own adapters without modifying Meridian
+* **Security**: Rejecting malformed data at the boundary prevents garbage-in scenarios
+* **BIAN Alignment**: Follows the atomic service design principle where each domain handles one
+  type of asset/pattern
+
+## Considered Options
+
+1. **Universal Ingestion Middleware**: Build a separate ETL service that handles all source
+   connectivity, extraction, and transformation
+2. **Source-Specific Adapters in Core Services**: Embed Bloomberg, ECB, smart meter adapters
+   directly in each consuming service
+3. **Canonical Ingestion Contract**: Define a strict boundary - services accept only pre-structured
+   Protobuf; adapters are external utilities
+
+## Decision Outcome
+
+Chosen option: **"Canonical Ingestion Contract"**, because it provides the cleanest separation of
+concerns while maintaining data integrity through CEL validation at the boundary.
+
+### The Contract
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         CANONICAL INGESTION CONTRACT                        │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  External World                    │  Meridian Core                         │
+│  ─────────────                     │  ────────────                          │
+│                                    │                                        │
+│  ┌─────────────────┐               │   ┌───────────────────────┐            │
+│  │ External Source │               │   │ DataSetDefinition     │            │
+│  │ (Bloomberg/ECB/ │               │   │ ─────────────────     │            │
+│  │  Smart Meter)   │               │   │ validation_expr (CEL) │            │
+│  └────────┬────────┘               │   └───────────┬───────────┘            │
+│           │ Raw Data               │               │                        │
+│           ▼                        │               ▼                        │
+│  ┌─────────────────┐               │   ┌───────────────────────┐            │
+│  │ External        │  Structured   │   │ CEL Validator         │            │
+│  │ Adapter         │  Protobuf     │   │ ─────────────         │            │
+│  │ ─────────────── ├───────────────┼──►│ PASS → Store          │            │
+│  │ YOUR CODE       │  (gRPC call)  │   │ FAIL → INVALID_ARG    │            │
+│  └─────────────────┘               │   └───────────────────────┘            │
+│                                    │                                        │
+│  Responsibility:                   │   Responsibility:                      │
+│  • Connectivity                    │   • Schema Definition                  │
+│  • Extraction                      │   • Contract Enforcement               │
+│  • Normalization                   │   • Bi-Temporal Storage                │
+│  • Scheduling                      │   • Quality Resolution                 │
+│  • Error Recovery                  │   • Knowledge Lineage                  │
+│                                    │                                        │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Boundary Rules
+
+1. **No Protocol Adapters in Core**: Services SHALL NOT contain source-specific logic (no code
+   for Bloomberg WebSocket, smart meter protocols, or weather APIs inside domain services)
+
+2. **Validation-on-Arrival**: Every observation MUST be validated against the `DataSetDefinition`
+   CEL expressions. Invalid data is rejected with `INVALID_ARGUMENT`, not silently fixed
+
+3. **Caller Responsibility**: It is the responsibility of the *caller* (external adapter) to
+   structure data into the canonical Protobuf format before calling
+
+4. **No Implicit Transformation**: If data doesn't match the schema, the service does not attempt
+   to fix it. The "messy ETL" stays on the external side of the boundary
+
+### Positive Consequences
+
+* **Clean Domain Services**: Core services remain focused on their BIAN responsibility
+* **Stable APIs**: Service contracts don't change when external sources change their formats
+* **Testable Boundaries**: CEL validation provides deterministic, testable contract enforcement
+* **Tenant Flexibility**: Tenants can build custom adapters without modifying Meridian
+* **Security**: Malformed data is rejected at the boundary, preventing data quality issues
+* **Reusability**: Reference adapters can be shared across deployments
+
+### Negative Consequences
+
+* **More Components**: Requires separate adapter deployment/maintenance for each external source
+* **Duplication Risk**: Without good reference implementations, teams might reinvent adapters
+* **Operational Complexity**: Adapters need their own monitoring, logging, and error handling
+
+## Pros and Cons of the Options
+
+### Option 1: Universal Ingestion Middleware
+
+Build a centralized ETL service that handles all external connectivity and transformation.
+
+* Good, because it centralizes integration logic
+* Good, because it provides a single point for monitoring
+* Bad, because it becomes a bottleneck and single point of failure
+* Bad, because it requires deep knowledge of every possible source format
+* Bad, because it creates tight coupling between unrelated data sources
+* Bad, because schema changes in one source could affect others
+
+### Option 2: Source-Specific Adapters in Core Services
+
+Embed adapters (Bloomberg, ECB, etc.) directly in consuming services.
+
+* Good, because it's simple for small numbers of sources
+* Bad, because it pollutes domain services with integration concerns
+* Bad, because adapter bugs could crash core services
+* Bad, because it requires service redeployment when source formats change
+* Bad, because it creates dependency on external libraries (Bloomberg SDK, etc.) in core services
+* Bad, because it violates BIAN's atomic service design principle
+
+### Option 3: Canonical Ingestion Contract (Chosen)
+
+Define a strict boundary with CEL validation; adapters are external utilities.
+
+* Good, because it cleanly separates domain logic from integration logic
+* Good, because adapters can be updated independently of core services
+* Good, because CEL validation provides auditable contract enforcement
+* Good, because tenants can build custom adapters for proprietary sources
+* Good, because it aligns with ADR-0005 (Adapter Pattern)
+* Neutral, because it requires more initial setup for reference adapters
+
+## Implementation Guidelines
+
+### Reference Adapter Location
+
+External adapters are placed in `cmd/` as standalone utilities, not in `services/`:
+
+```text
+cmd/
+├── market-data-tool/           # CLI for bulk imports
+│   ├── cmd/
+│   │   ├── import.go
+│   │   ├── validate.go
+│   │   └── schema.go
+│   └── adapters/
+│       ├── ecb/                # ECB daily rates adapter
+│       └── generic/            # CSV/JSON generic adapter
+└── ...
+```
+
+### CEL Validation as Gatekeeper
+
+The CEL validator in each service is the **Compliance Auditor**:
+
+```go
+// In the gRPC handler
+func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservationRequest) (*pb.RecordObservationResponse, error) {
+    // Load dataset definition
+    dataset, err := s.repo.GetDataSet(ctx, req.DatasetCode)
+    if err != nil {
+        return nil, status.Error(codes.NotFound, "dataset not found")
+    }
+
+    // Validate against CEL expression - THIS IS THE BOUNDARY
+    if err := s.validator.Validate(dataset.ValidationExpression, req); err != nil {
+        return nil, status.Errorf(codes.InvalidArgument,
+            "validation failed: %s (expression: %s)",
+            err.Error(), dataset.ValidationExpression)
+    }
+
+    // Only after validation passes do we store
+    // ...
+}
+```
+
+### Error Messages Must Be Helpful
+
+When validation fails, the error should help the adapter developer fix their code:
+
+```text
+INVALID_ARGUMENT: validation failed: attribute 'tou_period' is required
+  Expression: has(tou_period) && tou_period in ['PEAK', 'OFF_PEAK', 'SHOULDER']
+  Provided context: {base_code: "USD", quote_code: "EUR"}
+  Missing: tou_period
+```
+
+## Links
+
+* [ADR-0005 Adapter Pattern Layer Translation](0005-adapter-pattern-layer-translation.md) -
+  Establishes the Port/Adapter pattern this decision extends
+* [PRD: Market Information Management](../prd/market-information-management.md) -
+  Service Boundaries section defines the specific application
+* [BIAN Semantic API Practitioner Guide V8.1](https://bian.org/wp-content/uploads/2024/12/BIAN-Semantic-API-Pactitioner-Guide-V8.1-FINAL.pdf) -
+  Service Domain encapsulation principle
+
+## Notes
+
+### When to Reconsider
+
+This decision should be reconsidered if:
+
+* Meridian becomes a general-purpose data integration platform (scope change)
+* A specific source requires sub-millisecond latency that adapter overhead can't meet
+* Regulatory requirements mandate specific connectivity patterns within the core service
+
+### Applicability Beyond Market Information
+
+This pattern applies to **all** Meridian services accepting external data:
+
+| Service | Canonical Input | External Adapters |
+|---------|-----------------|-------------------|
+| Market Information | `MarketPriceObservation` | ECB, Bloomberg, weather APIs |
+| Position Keeping | `PositionMeasurement` | Smart meters, IoT devices |
+| Reference Data | `InstrumentDefinition` | Regulatory feeds, tenant uploads |
+
+The principle remains constant: **Meridian provides the Universal Schema; the external world
+provides the Translation.**

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -70,6 +70,8 @@ Architectural Decision Records) format.
 | [ADR-0024](0024-internal-bank-account-service.md) | Internal Bank Account Service Domain | Accepted | 2026-01-15 |
 <!-- markdownlint-disable-next-line MD013 -->
 | [ADR-0025](0025-clearing-purpose-specialization.md) | Clearing Purpose Specialization | Accepted | 2026-01-16 |
+<!-- markdownlint-disable-next-line MD013 -->
+| [ADR-0026](0026-canonical-ingestion-contract.md) | Canonical Ingestion Contract | Accepted | 2026-01-17 |
 
 ## Categories
 
@@ -93,6 +95,7 @@ Architectural Decision Records) format.
 - [ADR-0023](0023-balance-delegation-to-position-keeping.md) - Balance Delegation to Position Keeping
 - [ADR-0024](0024-internal-bank-account-service.md) - Internal Bank Account Service Domain
 - [ADR-0025](0025-clearing-purpose-specialization.md) - Clearing Purpose Specialization
+- [ADR-0026](0026-canonical-ingestion-contract.md) - Canonical Ingestion Contract
 
 ### Development Environment & Infrastructure
 

--- a/docs/prd/market-information-management.md
+++ b/docs/prd/market-information-management.md
@@ -19,12 +19,15 @@ instructions: |
 # PRD: Market Information Management Service
 
 **Status:** Draft
-**Version:** 1.2
-**Date:** 2026-01-16
+**Version:** 1.3
+**Date:** 2026-01-17
 **Author:** Architecture Team
 
 **Version History:**
 
+- v1.3 (2026-01-17): Added Service Boundaries section defining Canonical Ingestion Contract,
+  clarified in-scope vs out-of-scope responsibilities, positioned external adapters as
+  reference utilities per BIAN Service Domain encapsulation principle
 - v1.2 (2026-01-16): PR review feedback - causation_id in request, UpdateDataSource/
   DeactivateDataSource RPCs, structured batch errors, CEL map conversion docs, bi-temporal index
 - v1.1 (2026-01-16): Added bi-temporal integrity (knowledge_base_time), knowledge lineage
@@ -150,6 +153,101 @@ different purpose:
 
 **Loose coupling benefit**: Market Information can ingest data for instruments not yet defined
 in Reference Data (onboarding, external feeds, non-instrument data like weather).
+
+---
+
+## Service Boundaries (Canonical Ingestion Contract)
+
+This section defines the strict boundary between Meridian's responsibility and external systems.
+Following BIAN's Service Domain encapsulation principle, Market Information Management provides
+the **Vault** (storage) and **Rules** (validation), while external systems provide the
+**Translation** (data structuring).
+
+### In-Scope (Meridian's Responsibility)
+
+| Capability | Description |
+|------------|-------------|
+| **Schema Definition** | Maintaining `DataSetDefinition` with `attribute_schema` and validation rules |
+| **Contract Enforcement** | Validating incoming data against CEL expressions (`validation_expression`) |
+| **Bi-Temporal Storage** | Storing observations with Event Time (observed_at) and Knowledge Time (created_at) |
+| **Quality Resolution** | Resolving conflicts via Quality Ladder (ESTIMATE < ACTUAL < VERIFIED) |
+| **Knowledge Lineage** | Tracking supersession chains and causation_id for audit |
+| **Temporal Queries** | Answering "What was the value at time X with knowledge at time Y?" |
+| **Event Publishing** | Market Data Switch events on ACTUAL/VERIFIED ingestion |
+
+### Out-of-Scope (External Adapter Responsibility)
+
+| Capability | Description | Example |
+|------------|-------------|---------|
+| **Connectivity** | Maintaining connections to external sources | WebSocket to Bloomberg, TCP to Smart Meters |
+| **Extraction** | Polling APIs, scraping, reading raw feeds | Calling ECB SDMX API, reading meter registers |
+| **Normalization** | Converting source-specific formats to Meridian Protobuf | XML → `MarketPriceObservation`, CSV → gRPC request |
+| **Scheduling** | Managing ingestion timing and frequency | Cron jobs, event-driven triggers |
+| **Error Recovery** | Handling source-specific failure modes | API rate limits, connection timeouts |
+
+### The Formatted Data Contract
+
+Meridian's `RecordObservation` and `RecordObservationBatch` endpoints are **Strict Gatekeepers**.
+The service accepts ONLY pre-structured data conforming to the `MarketPriceObservation` schema.
+
+**Key Principles:**
+
+1. **No Protocol Adapters in Core**: The service SHALL NOT contain source-specific logic
+   (e.g., no code for weather APIs or smart meter protocols inside the service).
+
+2. **Validation-on-Arrival**: The system MUST validate every observation against the
+   `DataSetDefinition` CEL expressions. Invalid data is rejected with `INVALID_ARGUMENT`.
+
+3. **Caller Responsibility**: It is the responsibility of the *caller* (external adapter)
+   to structure data into the Meridian `MarketPriceObservation` format before calling.
+
+4. **No Implicit Transformation**: If an observation doesn't match the schema, the service
+   does not attempt to fix it. The "messy ETL" stays on the external side.
+
+### CEL as Contract Enforcer
+
+The CEL validator (FR-2.2, FR-2.6) becomes the **Compliance Auditor** at the boundary:
+
+```text
+External World                    │  Meridian Core
+                                  │
+┌─────────────────┐               │   ┌───────────────────────┐
+│ Smart Meter     │               │   │                       │
+│ ─────────────── │               │   │  DataSetDefinition    │
+│ Raw Binary Data │               │   │  ─────────────────    │
+└────────┬────────┘               │   │  validation_expr:     │
+         │                        │   │  "decimal(value) > 0  │
+         ▼                        │   │   && tou_period in    │
+┌─────────────────┐               │   │   ['PEAK','OFF_PEAK']"│
+│ External        │               │   └───────────┬───────────┘
+│ Adapter         │  Formatted    │               │
+│ ─────────────── │  Protobuf     │               ▼
+│ Normalize to    ├───────────────┼──►┌───────────────────────┐
+│ MarketPrice     │               │   │ CEL Validator         │
+│ Observation     │               │   │ ─────────────────     │
+└─────────────────┘               │   │ PASS → Store          │
+                                  │   │ FAIL → INVALID_ARG    │
+                                  │   └───────────────────────┘
+```
+
+### External Adapters as Reference Utilities
+
+Adapters (like the ECB Daily Rates example) are **demonstration utilities**, not core service
+features. They show how external systems should structure data for Meridian:
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| `market-data-tool` | `cmd/market-data-tool/` | Reference CLI for tenant bulk imports |
+| ECB Adapter | `cmd/market-data-tool/adapters/ecb/` | Example of external API → Meridian format |
+
+These utilities are **operationally independent** from the core service. Tenants may:
+
+- Use the reference utilities as-is
+- Build their own adapters following the same pattern
+- Integrate via any system that can call gRPC with properly structured payloads
+
+**This approach mirrors ADR-0005 (Adapter Pattern): Meridian owns the Domain and the Port;
+the external world owns the Adapter.**
 
 ---
 

--- a/docs/prd/market-information-management.md
+++ b/docs/prd/market-information-management.md
@@ -38,11 +38,13 @@ instructions: |
 **ADRs:**
 
 - [0002 - Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
+- [0005 - Adapter Pattern for Layer Translation](../adr/0005-adapter-pattern-layer-translation.md)
 - [0013 - Universal Quantity Type System](../adr/0013-generic-asset-quantity-types.md)
 - [0014 - Financial Instrument Reference Data](../adr/0014-financial-instrument-reference-data.md)
 - [0015 - Standard Service Directory Structure](../adr/0015-standard-service-directory-structure.md)
 - [0016 - Tenant ID Naming Strategy](../adr/0016-tenant-id-naming-strategy.md)
 - [0017 - Temporal Quality Ladder](../adr/0017-temporal-quality-ladder.md)
+- [0026 - Canonical Ingestion Contract](../adr/0026-canonical-ingestion-contract.md)
 
 **Related PRDs:**
 


### PR DESCRIPTION
## Summary

Defines the **Canonical Ingestion Contract** - the strict boundary between Meridian's responsibility and external systems. This is a core design philosophy that applies across all Meridian services.

**Key Principle:** *"Meridian provides the Universal Schema; the external world provides the Translation."*

## Changes Made

### PRD: Market Information Management v1.3

Added **Service Boundaries (Canonical Ingestion Contract)** section defining:

| Meridian Core (In-Scope) | External Adapters (Out-of-Scope) |
|--------------------------|----------------------------------|
| Schema Definition (`DataSetDefinition`) | Connectivity (WebSockets, TCP) |
| Contract Enforcement (CEL validation) | Extraction (API polling, scraping) |
| Bi-Temporal Storage | Normalization (XML → Protobuf) |
| Quality Resolution | Scheduling (cron, triggers) |
| Knowledge Lineage | Error Recovery (rate limits, timeouts) |

### ADR-0026: Canonical Ingestion Contract

New ADR establishing this as a cross-cutting architectural principle:

- Extends ADR-0005 (Adapter Pattern) to data ingestion boundaries
- External adapters are **reference utilities**, not core service features
- CEL validation acts as the **Compliance Auditor** at the boundary
- Applies to all services accepting external data (Market Information, Position Keeping, Reference Data)

### Architecture Diagram

```text
External World                    │  Meridian Core
                                  │
┌─────────────────┐               │   ┌───────────────────────┐
│ External Source │  Structured   │   │ CEL Validator         │
│ (Bloomberg/ECB/ │  Protobuf     │   │ ─────────────         │
│  Smart Meter)   ├───────────────┼──►│ PASS → Store          │
│ + Your Adapter  │  (gRPC call)  │   │ FAIL → INVALID_ARG    │
└─────────────────┘               │   └───────────────────────┘
```

## Related

- Task Master tag: `market-information-management`
- Tasks 4 (CEL Validator), 12 (ECB Adapter), 14 (market-data-tool) updated to reflect this boundary
- Links to ADR-0005 (Adapter Pattern)

## Test Plan

- [ ] Verify PRD markdown renders correctly
- [ ] Verify ADR markdown renders correctly
- [ ] Confirm ADR appears in README index