### PR TITLE
fix(financial-accounting): fail-fast on multiple clearing accounts

### DIFF
--- a/services/financial-accounting/service/account_resolver.go
+++ b/services/financial-accounting/service/account_resolver.go
@@ -19,6 +19,10 @@ var (
 	// ErrNoClearingAccountFound is returned when no active clearing account is found for the given criteria.
 	ErrNoClearingAccountFound = errors.New("no active clearing account found")
 
+	// ErrMultipleClearingAccounts is returned when multiple active clearing accounts are found for the same criteria.
+	// This indicates a data inconsistency - each instrument/purpose combination should have exactly one active account.
+	ErrMultipleClearingAccounts = errors.New("multiple active clearing accounts found")
+
 	// ErrAccountResolverClientNil is returned when attempting to create an AccountResolver with a nil client.
 	ErrAccountResolverClientNil = errors.New("internal bank account client cannot be nil")
 
@@ -262,7 +266,18 @@ func (r *AccountResolver) queryInternalBankAccount(ctx context.Context, clearing
 		return "", fmt.Errorf("%w for %s %s", ErrNoClearingAccountFound, clearingType, instrumentCode)
 	}
 
-	// Use the first active clearing account matching the criteria.
+	// Fail fast on multiple results to prevent nondeterministic routing.
+	// Each instrument/purpose combination should have exactly one active clearing account.
+	if len(resp.Facilities) > 1 {
+		r.logger.Error("multiple active clearing accounts found - data inconsistency",
+			"clearing_type", clearingType,
+			"clearing_purpose", clearingPurpose.String(),
+			"instrument_code", instrumentCode,
+			"count", len(resp.Facilities))
+		return "", fmt.Errorf("%w for %s %s (count: %d)", ErrMultipleClearingAccounts, clearingType, instrumentCode, len(resp.Facilities))
+	}
+
+	// Use the single active clearing account matching the criteria.
 	account := resp.Facilities[0]
 	return account.AccountId, nil
 }

--- a/services/financial-accounting/service/account_resolver_test.go
+++ b/services/financial-accounting/service/account_resolver_test.go
@@ -445,6 +445,142 @@ func TestBackendError_PropagatesError(t *testing.T) {
 }
 
 // =============================================================================
+// Multiple accounts error tests (fail-fast behavior)
+// =============================================================================
+
+func TestMultipleAccounts_GetDepositClearingAccount_ReturnsError(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "clearing-account-1"},
+				{AccountId: "clearing-account-2"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+
+	assert.ErrorIs(t, err, ErrMultipleClearingAccounts)
+	assert.Contains(t, err.Error(), "DEPOSIT")
+	assert.Contains(t, err.Error(), "GBP")
+	assert.Contains(t, err.Error(), "count: 2")
+}
+
+func TestMultipleAccounts_GetWithdrawalClearingAccount_ReturnsError(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "clearing-account-1"},
+				{AccountId: "clearing-account-2"},
+				{AccountId: "clearing-account-3"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.GetWithdrawalClearingAccount(context.Background(), "USD")
+
+	assert.ErrorIs(t, err, ErrMultipleClearingAccounts)
+	assert.Contains(t, err.Error(), "WITHDRAWAL")
+	assert.Contains(t, err.Error(), "USD")
+	assert.Contains(t, err.Error(), "count: 3")
+}
+
+func TestMultipleAccounts_GetSettlementClearingAccount_ReturnsError(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "clearing-account-1"},
+				{AccountId: "clearing-account-2"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	_, err = resolver.GetSettlementClearingAccount(context.Background(), "EUR")
+
+	assert.ErrorIs(t, err, ErrMultipleClearingAccounts)
+	assert.Contains(t, err.Error(), "SETTLEMENT")
+	assert.Contains(t, err.Error(), "EUR")
+	assert.Contains(t, err.Error(), "count: 2")
+}
+
+func TestMultipleAccounts_DoesNotCache(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "clearing-account-1"},
+				{AccountId: "clearing-account-2"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client:   mockClient,
+		Logger:   accountResolverTestLogger(),
+		CacheTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+
+	// First call - should fail
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	assert.ErrorIs(t, err, ErrMultipleClearingAccounts)
+	assert.Equal(t, 1, mockClient.getCallCount())
+
+	// Second call - should also fail, and should NOT be cached (client called again)
+	_, err = resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	assert.ErrorIs(t, err, ErrMultipleClearingAccounts)
+	assert.Equal(t, 2, mockClient.getCallCount(), "Error responses should not be cached")
+}
+
+func TestSingleAccount_StillWorks(t *testing.T) {
+	mockClient := &mockInternalBankAccountClient{
+		listResponse: &internalbankaccountv1.ListInternalBankAccountsResponse{
+			Facilities: []*internalbankaccountv1.InternalBankAccountFacility{
+				{AccountId: "single-clearing-account"},
+			},
+		},
+	}
+
+	resolver, err := NewAccountResolver(AccountResolverConfig{
+		Client: mockClient,
+		Logger: accountResolverTestLogger(),
+	})
+	require.NoError(t, err)
+
+	// Test deposit
+	accountID, err := resolver.GetDepositClearingAccount(context.Background(), "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, "single-clearing-account", accountID)
+
+	// Test withdrawal
+	accountID, err = resolver.GetWithdrawalClearingAccount(context.Background(), "USD")
+	require.NoError(t, err)
+	assert.Equal(t, "single-clearing-account", accountID)
+
+	// Test settlement
+	accountID, err = resolver.GetSettlementClearingAccount(context.Background(), "EUR")
+	require.NoError(t, err)
+	assert.Equal(t, "single-clearing-account", accountID)
+}
+
+// =============================================================================
 // Additional tests (from current-account patterns)
 // =============================================================================
 


### PR DESCRIPTION
## Summary

- Add `ErrMultipleClearingAccounts` sentinel error for when multiple active clearing accounts match the same criteria
- Update `AccountResolver.queryInternalBankAccount` to fail-fast instead of silently returning the first account
- Log at ERROR level for visibility into data inconsistencies
- Add comprehensive unit tests for the new error path

## Context

Task Master: internal-bank-account.32

Previously, when multiple active clearing accounts were found for the same instrument/purpose combination (e.g., two active GBP deposit clearing accounts), the code would silently return the first one. This creates:

1. **Non-deterministic behavior** - different ordering could return different accounts
2. **Hidden data inconsistencies** - the duplicate accounts indicate a configuration problem that should be fixed

This change aligns Financial Accounting with fail-fast principles: each instrument/purpose combination should have exactly one active clearing account.

## Test plan

- [x] Added unit tests for all three clearing account types (deposit, withdrawal, settlement)
- [x] Added test verifying errors are not cached
- [x] Added regression test confirming single account still works
- [x] All existing tests pass
- [x] Lint passes