### PR TITLE
feat: add client-side account ID format pre-validation

### DIFF
--- a/services/current-account/client/client.go
+++ b/services/current-account/client/client.go
@@ -35,9 +35,12 @@ import (
 	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
+	"github.com/meridianhub/meridian/shared/pkg/validation"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -234,6 +237,10 @@ func (c *Client) InitiateCurrentAccount(ctx context.Context, req *currentaccount
 // ExecuteDeposit processes a deposit transaction (Behavior Qualifier).
 // This is a non-idempotent operation, so it uses circuit breaker without retry.
 func (c *Client) ExecuteDeposit(ctx context.Context, req *currentaccountv1.ExecuteDepositRequest) (*currentaccountv1.ExecuteDepositResponse, error) {
+	if err := validation.ValidateAccountID(req.GetAccountId()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account_id format: %v", err)
+	}
+
 	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
@@ -258,6 +265,10 @@ func (c *Client) ExecuteDeposit(ctx context.Context, req *currentaccountv1.Execu
 // RetrieveCurrentAccount gets current account details.
 // This is an idempotent read operation, so it uses circuit breaker with retry.
 func (c *Client) RetrieveCurrentAccount(ctx context.Context, req *currentaccountv1.RetrieveCurrentAccountRequest) (*currentaccountv1.RetrieveCurrentAccountResponse, error) {
+	if err := validation.ValidateAccountID(req.GetAccountId()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account_id format: %v", err)
+	}
+
 	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
@@ -283,6 +294,10 @@ func (c *Client) RetrieveCurrentAccount(ctx context.Context, req *currentaccount
 // Used by Payment Order to reserve funds before external payment execution.
 // This is a non-idempotent operation, so it uses circuit breaker without retry.
 func (c *Client) InitiateLien(ctx context.Context, req *currentaccountv1.InitiateLienRequest) (*currentaccountv1.InitiateLienResponse, error) {
+	if err := validation.ValidateAccountID(req.GetAccountId()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account_id format: %v", err)
+	}
+
 	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
 	defer cancel()
 

--- a/services/current-account/client/client_test.go
+++ b/services/current-account/client/client_test.go
@@ -1,12 +1,17 @@
 package client
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
+	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestNew_WithTarget(t *testing.T) {
@@ -134,4 +139,95 @@ func TestNew_WithoutResilience(t *testing.T) {
 
 	// Verify resilient client was not created
 	assert.Nil(t, client.resilient)
+}
+
+// Account ID validation tests
+
+func TestRetrieveCurrentAccount_InvalidAccountID(t *testing.T) {
+	client, cleanup, err := New(Config{
+		Target: "localhost:50051",
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	tests := []struct {
+		name      string
+		accountID string
+	}{
+		{"empty string", ""},
+		{"contains space", "ACC 123"},
+		{"contains at symbol", "ACC@123"},
+		{"contains slash", "ACC/123"},
+		{"exceeds max length", strings.Repeat("a", 101)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.RetrieveCurrentAccount(context.Background(), &currentaccountv1.RetrieveCurrentAccountRequest{
+				AccountId: tt.accountID,
+			})
+
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+			assert.Contains(t, err.Error(), "invalid account_id format")
+		})
+	}
+}
+
+func TestExecuteDeposit_InvalidAccountID(t *testing.T) {
+	client, cleanup, err := New(Config{
+		Target: "localhost:50051",
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	tests := []struct {
+		name      string
+		accountID string
+	}{
+		{"empty string", ""},
+		{"contains special char", "ACC#123"},
+		{"exceeds max length", strings.Repeat("a", 101)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.ExecuteDeposit(context.Background(), &currentaccountv1.ExecuteDepositRequest{
+				AccountId: tt.accountID,
+			})
+
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+			assert.Contains(t, err.Error(), "invalid account_id format")
+		})
+	}
+}
+
+func TestInitiateLien_InvalidAccountID(t *testing.T) {
+	client, cleanup, err := New(Config{
+		Target: "localhost:50051",
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	tests := []struct {
+		name      string
+		accountID string
+	}{
+		{"empty string", ""},
+		{"contains dot", "ACC.123"},
+		{"exceeds max length", strings.Repeat("a", 101)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.InitiateLien(context.Background(), &currentaccountv1.InitiateLienRequest{
+				AccountId: tt.accountID,
+			})
+
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+			assert.Contains(t, err.Error(), "invalid account_id format")
+		})
+	}
 }

--- a/services/internal-bank-account/client/client.go
+++ b/services/internal-bank-account/client/client.go
@@ -36,9 +36,12 @@ import (
 	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
+	"github.com/meridianhub/meridian/shared/pkg/validation"
 	"github.com/meridianhub/meridian/shared/platform/observability"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -255,6 +258,10 @@ func (c *Client) InitiateInternalBankAccount(ctx context.Context, req *internalb
 // ControlInternalBankAccount performs lifecycle state transitions (suspend, activate, close).
 // This is a non-idempotent operation, so it uses circuit breaker without retry.
 func (c *Client) ControlInternalBankAccount(ctx context.Context, req *internalbankaccountv1.ControlInternalBankAccountRequest) (*internalbankaccountv1.ControlInternalBankAccountResponse, error) {
+	if err := validation.ValidateAccountID(req.GetAccountId()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account_id format: %v", err)
+	}
+
 	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
@@ -284,6 +291,10 @@ func (c *Client) ControlInternalBankAccount(ctx context.Context, req *internalba
 // Updates are idempotent when using version-based concurrency (expected_version),
 // so retry is enabled.
 func (c *Client) UpdateInternalBankAccount(ctx context.Context, req *internalbankaccountv1.UpdateInternalBankAccountRequest) (*internalbankaccountv1.UpdateInternalBankAccountResponse, error) {
+	if err := validation.ValidateAccountID(req.GetAccountId()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account_id format: %v", err)
+	}
+
 	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
@@ -308,6 +319,10 @@ func (c *Client) UpdateInternalBankAccount(ctx context.Context, req *internalban
 // RetrieveInternalBankAccount fetches a single account by ID.
 // This is an idempotent read operation, so it uses circuit breaker with retry.
 func (c *Client) RetrieveInternalBankAccount(ctx context.Context, req *internalbankaccountv1.RetrieveInternalBankAccountRequest) (*internalbankaccountv1.RetrieveInternalBankAccountResponse, error) {
+	if err := validation.ValidateAccountID(req.GetAccountId()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account_id format: %v", err)
+	}
+
 	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
@@ -356,6 +371,10 @@ func (c *Client) ListInternalBankAccounts(ctx context.Context, req *internalbank
 // GetBalance queries the current balance for an internal account.
 // This is an idempotent read operation, so it uses circuit breaker with retry.
 func (c *Client) GetBalance(ctx context.Context, req *internalbankaccountv1.GetBalanceRequest) (*internalbankaccountv1.GetBalanceResponse, error) {
+	if err := validation.ValidateAccountID(req.GetAccountId()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account_id format: %v", err)
+	}
+
 	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
 	defer cancel()
 

--- a/services/internal-bank-account/client/client_test.go
+++ b/services/internal-bank-account/client/client_test.go
@@ -1,12 +1,17 @@
 package client
 
 import (
+	"context"
+	"strings"
 	"testing"
 	"time"
 
+	internalbankaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestNew_WithTarget(t *testing.T) {
@@ -145,4 +150,124 @@ func TestConn(t *testing.T) {
 	conn := client.Conn()
 	assert.NotNil(t, conn)
 	assert.Equal(t, client.conn, conn)
+}
+
+// Account ID validation tests
+
+func TestRetrieveInternalBankAccount_InvalidAccountID(t *testing.T) {
+	client, cleanup, err := New(Config{
+		Target: "localhost:50057",
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	tests := []struct {
+		name      string
+		accountID string
+	}{
+		{"empty string", ""},
+		{"contains space", "ACC 123"},
+		{"contains at symbol", "ACC@123"},
+		{"contains slash", "ACC/123"},
+		{"exceeds max length", strings.Repeat("a", 101)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.RetrieveInternalBankAccount(context.Background(), &internalbankaccountv1.RetrieveInternalBankAccountRequest{
+				AccountId: tt.accountID,
+			})
+
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+			assert.Contains(t, err.Error(), "invalid account_id format")
+		})
+	}
+}
+
+func TestUpdateInternalBankAccount_InvalidAccountID(t *testing.T) {
+	client, cleanup, err := New(Config{
+		Target: "localhost:50057",
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	tests := []struct {
+		name      string
+		accountID string
+	}{
+		{"empty string", ""},
+		{"contains special char", "ACC#123"},
+		{"exceeds max length", strings.Repeat("a", 101)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.UpdateInternalBankAccount(context.Background(), &internalbankaccountv1.UpdateInternalBankAccountRequest{
+				AccountId: tt.accountID,
+			})
+
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+			assert.Contains(t, err.Error(), "invalid account_id format")
+		})
+	}
+}
+
+func TestControlInternalBankAccount_InvalidAccountID(t *testing.T) {
+	client, cleanup, err := New(Config{
+		Target: "localhost:50057",
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	tests := []struct {
+		name      string
+		accountID string
+	}{
+		{"empty string", ""},
+		{"contains dot", "ACC.123"},
+		{"exceeds max length", strings.Repeat("a", 101)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.ControlInternalBankAccount(context.Background(), &internalbankaccountv1.ControlInternalBankAccountRequest{
+				AccountId: tt.accountID,
+			})
+
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+			assert.Contains(t, err.Error(), "invalid account_id format")
+		})
+	}
+}
+
+func TestGetBalance_InvalidAccountID(t *testing.T) {
+	client, cleanup, err := New(Config{
+		Target: "localhost:50057",
+	})
+	require.NoError(t, err)
+	defer cleanup()
+
+	tests := []struct {
+		name      string
+		accountID string
+	}{
+		{"empty string", ""},
+		{"contains newline", "ACC\n123"},
+		{"exceeds max length", strings.Repeat("a", 101)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.GetBalance(context.Background(), &internalbankaccountv1.GetBalanceRequest{
+				AccountId: tt.accountID,
+			})
+
+			require.Error(t, err)
+			assert.Equal(t, codes.InvalidArgument, status.Code(err))
+			assert.Contains(t, err.Error(), "invalid account_id format")
+		})
+	}
 }

--- a/shared/pkg/validation/account_id.go
+++ b/shared/pkg/validation/account_id.go
@@ -1,0 +1,37 @@
+// Package validation provides input validation utilities for client-side
+// pre-validation before making RPC calls.
+package validation
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// accountIDPattern matches proto validation: ^[a-zA-Z0-9_-]+$
+// Length: 1-100 characters
+var accountIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,100}$`)
+
+// ErrAccountIDRequired is returned when account ID is empty.
+var ErrAccountIDRequired = errors.New("account_id is required")
+
+// ErrAccountIDTooLong is returned when account ID exceeds maximum length.
+var ErrAccountIDTooLong = errors.New("account_id exceeds maximum length of 100 characters")
+
+// ErrAccountIDInvalidCharacters is returned when account ID contains invalid characters.
+var ErrAccountIDInvalidCharacters = errors.New("account_id contains invalid characters: must match ^[a-zA-Z0-9_-]+$")
+
+// ValidateAccountID checks if an account ID matches the required format.
+// Returns nil if valid, error with descriptive message if invalid.
+func ValidateAccountID(accountID string) error {
+	if accountID == "" {
+		return ErrAccountIDRequired
+	}
+	if len(accountID) > 100 {
+		return fmt.Errorf("%w: got %d", ErrAccountIDTooLong, len(accountID))
+	}
+	if !accountIDPattern.MatchString(accountID) {
+		return fmt.Errorf("%w (got: %q)", ErrAccountIDInvalidCharacters, accountID)
+	}
+	return nil
+}

--- a/shared/pkg/validation/account_id.go
+++ b/shared/pkg/validation/account_id.go
@@ -8,8 +8,10 @@ import (
 	"regexp"
 )
 
-// accountIDPattern matches proto validation: ^[a-zA-Z0-9_-]+$
-// Length: 1-100 characters
+// accountIDPattern is compiled once at package init (regexp.MustCompile panics on invalid patterns).
+// Matches proto validation: ^[a-zA-Z0-9_-]+$ with length 1-100 characters.
+// Note: This is for API/RPC layer validation matching proto rules. Domain primitives
+// in shared/domain/primitives may enforce stricter formats (e.g., UUID v4).
 var accountIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_-]{1,100}$`)
 
 // ErrAccountIDRequired is returned when account ID is empty.

--- a/shared/pkg/validation/account_id_test.go
+++ b/shared/pkg/validation/account_id_test.go
@@ -1,0 +1,59 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateAccountID(t *testing.T) {
+	tests := []struct {
+		name      string
+		accountID string
+		wantErr   error
+	}{
+		// Valid cases
+		{"valid UUID style", "550e8400-e29b-41d4-a716-446655440000", nil},
+		{"valid alphanumeric", "ACC123", nil},
+		{"valid with underscore", "CLR_GBP_001", nil},
+		{"valid with hyphen", "CLR-GBP-001", nil},
+		{"valid mixed", "Account-123_v2", nil},
+		{"single character", "A", nil},
+		{"100 characters", strings.Repeat("a", 100), nil},
+		{"pure numbers", "12345", nil},
+		{"lowercase only", "account", nil},
+		{"uppercase only", "ACCOUNT", nil},
+
+		// Invalid cases
+		{"empty string", "", ErrAccountIDRequired},
+		{"exceeds max length", strings.Repeat("a", 101), ErrAccountIDTooLong},
+		{"contains space", "ACC 123", ErrAccountIDInvalidCharacters},
+		{"contains at symbol", "ACC@123", ErrAccountIDInvalidCharacters},
+		{"contains slash", "ACC/123", ErrAccountIDInvalidCharacters},
+		{"contains hash", "ACC#123", ErrAccountIDInvalidCharacters},
+		{"contains dollar", "ACC$123", ErrAccountIDInvalidCharacters},
+		{"only special chars", "!@#$", ErrAccountIDInvalidCharacters},
+		{"contains dot", "ACC.123", ErrAccountIDInvalidCharacters},
+		{"contains newline", "ACC\n123", ErrAccountIDInvalidCharacters},
+		{"contains tab", "ACC\t123", ErrAccountIDInvalidCharacters},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateAccountID(tt.accountID)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func BenchmarkValidateAccountID(b *testing.B) {
+	validID := "CLR-GBP-001"
+	for i := 0; i < b.N; i++ {
+		_ = ValidateAccountID(validID)
+	}
+}


### PR DESCRIPTION
## Summary

Add pre-validation to client packages to reject malformed account IDs before making RPC calls, reducing network overhead and improving error handling performance.

- Create shared validation package with regex-based validation matching proto rules (`^[a-zA-Z0-9_-]{1,100}$`)
- Add pre-validation to Internal Bank Account client methods: `RetrieveInternalBankAccount`, `UpdateInternalBankAccount`, `ControlInternalBankAccount`, `GetBalance`
- Add pre-validation to Current Account client methods: `RetrieveCurrentAccount`, `ExecuteDeposit`, `InitiateLien`
- Return `codes.InvalidArgument` on validation failure to match server-side error codes

## Task Master

Task: 33 - Add Client-Side Account ID Format Pre-Validation

## Test Plan

- [x] Unit tests for validation package covering valid formats (UUID-style, alphanumeric, underscore, hyphen)
- [x] Unit tests for boundary conditions (1 char min, 100 char max, 101 char exceeds)
- [x] Unit tests for invalid formats (empty, spaces, special chars)
- [x] Unit tests for Internal Bank Account client validation rejection
- [x] Unit tests for Current Account client validation rejection
- [x] Build verification - all packages compile successfully