### PR TITLE
feat: Add market-information service scaffolding

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -87,6 +87,7 @@ db_urls = {
   'payment_order': os.getenv('PAYMENT_ORDER_DATABASE_URL', 'postgres://meridian_payment_order_user@cockroachdb:26257/meridian_payment_order?sslmode=disable'),
   'party': os.getenv('PARTY_DATABASE_URL', 'postgres://meridian_party_user@cockroachdb:26257/meridian_party?sslmode=disable'),
   'internal_bank_account': os.getenv('INTERNAL_BANK_ACCOUNT_DATABASE_URL', 'postgres://meridian_internal_bank_account_user@cockroachdb:26257/meridian_internal_bank_account?sslmode=disable'),
+  'market_information': os.getenv('MARKET_INFORMATION_DATABASE_URL', 'postgres://meridian_market_information_user@cockroachdb:26257/meridian_market_information?sslmode=disable'),
 }
 
 # NOTE: Migrations now run as Kubernetes Jobs inside the cluster
@@ -472,6 +473,7 @@ k8s_resource(
 #   - Party:                50055
 #   - Tenant:               50056
 #   - InternalBankAccount:  50057
+#   - MarketInformation:    50058
 #   - Gateway (HTTP):       8080
 #   - HTTPHealth:           8081
 #   - HTTPMetrics:          9090
@@ -523,6 +525,13 @@ grpc_microservice(
     'internal-bank-account',
     grpc_port=50057,  # ports.InternalBankAccount
     resource_deps=['cockroachdb', 'migrate-internal-bank-account', 'position-keeping', 'current-account'],
+)
+
+# Market-Information Service - gRPC microservice for price benchmarks and market data
+grpc_microservice(
+    'market-information',
+    grpc_port=50058,  # ports.MarketInformation
+    resource_deps=['cockroachdb', 'migrate-market-information'],
 )
 
 # =============================================================================
@@ -736,6 +745,13 @@ migration_job(
   resource_deps=['init-database'],  # Independent database, only needs init to complete
 )
 
+migration_job(
+  'migrate-market-information',
+  'market-information',
+  'market_information',
+  resource_deps=['init-database'],  # Independent database, only needs init to complete
+)
+
 # Kafka cluster health check - runs automatically after kafka-cluster is ready
 local_resource(
   'kafka-health',
@@ -796,6 +812,7 @@ Microservices:
   • Party                  → localhost:50055 (gRPC)
   • Tenant                 → localhost:50056 (gRPC)
   • Internal-Bank-Account  → localhost:50057 (gRPC)
+  • Market-Information     → localhost:50058 (gRPC)
 
 Gateway:
   • HTTP Gateway           → localhost:8090 (subdomain routing)
@@ -833,12 +850,13 @@ Database Architecture (database-per-service):
     - meridian_payment_order
     - meridian_party
     - meridian_internal_bank_account
+    - meridian_market_information
   • Within each database: org schemas for multi-tenant isolation
   • Tables use singular, unqualified names (search_path routing)
   • See ADR-0003 for architecture details
 
 Database Migrations:
-  • Migrations run automatically on startup (7 resources):
+  • Migrations run automatically on startup (8 resources):
     1. current_account → meridian_current_account (account, lien, audit tables)
     2. financial_accounting → meridian_financial_accounting (ledger, booking)
     3. position_keeping → meridian_position_keeping (positions, transactions)
@@ -846,7 +864,8 @@ Database Migrations:
     5. party → meridian_party (party reference data)
     6. tenant → meridian_platform (tenant registry)
     7. internal_bank_account → meridian_internal_bank_account (internal accounts)
-  • Parallel execution: current_account + financial_accounting + party + tenant + internal_bank_account
+    8. market_information → meridian_market_information (price benchmarks, market data)
+  • Parallel execution: current_account + financial_accounting + party + tenant + internal_bank_account + market_information
   • Sequential dependencies:
     - position_keeping waits for current_account (Account FK)
     - payment_order waits for current_account (Account FK)
@@ -858,6 +877,7 @@ Database Migrations:
     - tilt trigger migrate-party
     - tilt trigger migrate-tenant
     - tilt trigger migrate-internal-bank-account
+    - tilt trigger migrate-market-information
 
 Testing Kafka Failover:
   kubectl delete pod kafka-1  # Kill broker

--- a/scripts/init-database.sh
+++ b/scripts/init-database.sh
@@ -25,6 +25,7 @@ DATABASES=(
   "meridian_payment_order:meridian_payment_order_user"
   "meridian_party:meridian_party_user"
   "meridian_internal_bank_account:meridian_internal_bank_account_user"
+  "meridian_market_information:meridian_market_information_user"
 )
 
 echo "Initializing CockroachDB databases..."

--- a/services/market-information/atlas/atlas.hcl
+++ b/services/market-information/atlas/atlas.hcl
@@ -1,0 +1,72 @@
+// Atlas configuration for Market Information Service
+// BIAN Service Domain: Market Information Management
+// Manages price benchmarks, market data feeds, and reference prices
+// Uses database-per-service architecture with unqualified table names
+
+data "external_schema" "gorm" {
+  program = [
+    "go",
+    "run",
+    "-mod=mod",
+    "./utilities/atlas-loader",
+    "--schema=market_information"
+  ]
+}
+
+env "local" {
+  // Service-specific migration directory
+  migration {
+    dir = "file://services/market-information/migrations"
+  }
+
+  // Dev database - uses default public schema
+  dev = "docker://postgres/16/dev"
+
+  // Source schema from GORM models via external loader
+  src = data.external_schema.gorm.url
+
+  // Lint configuration to catch dangerous changes
+  lint {
+    destructive {
+      error = true
+    }
+    data_depend {
+      error = true
+    }
+    incompatible {
+      error = true
+    }
+  }
+}
+
+env "ci" {
+  migration {
+    dir = "file://services/market-information/migrations"
+  }
+
+  dev = "docker://postgres/16/dev"
+
+  src = data.external_schema.gorm.url
+
+  lint {
+    destructive {
+      error = true
+    }
+    data_depend {
+      error = true
+    }
+    incompatible {
+      error = true
+    }
+  }
+}
+
+env "production" {
+  // Production environment - apply only, never diff
+  // URL points to service-specific database (meridian_market_information)
+  url = getenv("DATABASE_URL")
+
+  migration {
+    dir = "file://services/market-information/migrations"
+  }
+}

--- a/services/market-information/cmd/Dockerfile
+++ b/services/market-information/cmd/Dockerfile
@@ -1,0 +1,57 @@
+# Market-Information Service - Multi-Stage Dockerfile
+# BIAN Service Domain: Market Information Management
+# Optimized for security, size, and performance
+# Uses distroless base image (~2MB) enabled by pure-Go dependencies
+
+# Build stage
+FROM golang:1.25-bookworm AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum* ./
+RUN go mod download && go mod verify
+
+# Copy source code
+COPY . .
+
+# Build static binary (no CGO required)
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -o market-information \
+    ./services/market-information/cmd
+
+# Verify the binary exists and is executable
+RUN test -x market-information && echo "Binary built successfully"
+
+# Runtime stage - distroless for minimal attack surface (~2MB base)
+FROM gcr.io/distroless/static-debian12
+
+# Copy timezone data from builder for time-sensitive operations
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary from builder
+COPY --from=builder /build/market-information /market-information
+
+# Use non-root user (distroless provides nonroot user at uid 65532)
+USER nonroot:nonroot
+
+# Expose gRPC port
+EXPOSE 50058
+
+# Note: Health checks handled by gRPC health check service
+
+# Run the binary
+ENTRYPOINT ["/market-information"]

--- a/services/market-information/cmd/main.go
+++ b/services/market-information/cmd/main.go
@@ -1,0 +1,149 @@
+// Package main is the entry point for the Market Information service.
+// BIAN Service Domain: Market Information Management
+// Manages price benchmarks, market data feeds, and reference prices.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/meridianhub/meridian/services/market-information/service"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/meridianhub/meridian/shared/platform/defaults"
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/meridianhub/meridian/shared/platform/ports"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+// Build information set via ldflags during compilation
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+func main() {
+	// Initialize structured logging with configurable log level
+	logLevel := parseLogLevel(os.Getenv("LOG_LEVEL"))
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting market-information service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	// Run the service
+	if err := run(logger); err != nil {
+		logger.Error("service failed", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	ctx := context.Background()
+
+	// Initialize OpenTelemetry tracer
+	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
+		ServiceName:    "market-information-service",
+		ServiceVersion: Version,
+		Logger:         logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	defer bootstrap.ShutdownTracer(tracer, logger)
+
+	// Initialize database connection
+	dbConfig := bootstrap.DefaultDatabaseConfig()
+	dbConfig.Logger = logger
+	db, err := bootstrap.NewDatabase(ctx, dbConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize database: %w", err)
+	}
+
+	logger.Info("database connection established")
+
+	// Initialize auth interceptor (optional - based on AUTH_ENABLED)
+	authConfig := bootstrap.DefaultAuthConfig(logger)
+	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+
+	// Create gRPC server with interceptor chain
+	grpcServer := bootstrap.NewGrpcServerBuilder(tracer, logger).
+		WithAuthInterceptor(authInterceptor).
+		Build()
+
+	// TODO: Register Market Information service when proto definitions are available
+	// pb.RegisterMarketInformationServiceServer(grpcServer, marketInformationService)
+
+	// Register health check service
+	healthChecker := service.NewHealthChecker(service.HealthCheckerConfig{
+		Logger:       logger,
+		ServiceName:  "market-information",
+		CheckTimeout: defaults.DefaultHealthCheckTimeout,
+	})
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthChecker)
+
+	// Register reflection service for debugging
+	reflection.Register(grpcServer)
+
+	logger.Info("gRPC services registered")
+
+	// Get port from environment
+	port := env.GetEnvOrDefault("GRPC_PORT", strconv.Itoa(ports.MarketInformation))
+	address := fmt.Sprintf(":%s", port)
+
+	// Create listener
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", address)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", address, err)
+	}
+
+	// Start gRPC server in background
+	serverErrors := make(chan error, 1)
+	go func() {
+		logger.Info("starting gRPC server", "address", address)
+		if err := grpcServer.Serve(listener); err != nil {
+			serverErrors <- err
+		}
+	}()
+
+	// Wait for shutdown signal and orchestrate graceful shutdown
+	orchestrator := bootstrap.NewShutdownOrchestrator(grpcServer, logger)
+
+	// Register database cleanup
+	orchestrator.AddCleanup(func() error {
+		bootstrap.CloseDatabase(db, logger)
+		return nil
+	})
+
+	return orchestrator.Wait(serverErrors)
+}
+
+// parseLogLevel converts a string log level to slog.Level.
+// Supports: debug, info, warn, error (case-insensitive). Defaults to info.
+func parseLogLevel(levelStr string) slog.Level {
+	switch strings.ToLower(levelStr) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/services/market-information/config/config.go
+++ b/services/market-information/config/config.go
@@ -1,0 +1,10 @@
+// Package config provides configuration loading for the Market Information service.
+// BIAN Service Domain: Market Information Management
+package config
+
+// TODO: Add configuration when implementing Task 3 (External Dependencies)
+//
+// Expected configuration:
+// - ExternalDataFeedConfig: URLs and credentials for market data feeds
+// - CacheConfig: TTL and refresh settings for price caching
+// - RateLimitConfig: Throttling for external API calls

--- a/services/market-information/domain/models.go
+++ b/services/market-information/domain/models.go
@@ -1,0 +1,16 @@
+// Package domain contains the domain models for the Market Information service.
+// BIAN Service Domain: Market Information Management
+//
+// This package will contain domain entities for:
+// - Price Benchmark: Reference prices for commodities, currencies, and financial instruments
+// - Market Data Feed: Real-time and historical market data subscriptions
+// - Reference Price: Standard prices for valuation and settlement
+package domain
+
+// TODO: Add domain models when implementing Task 2 (Database Schema)
+//
+// Expected entities:
+// - PriceBenchmark: Represents a published benchmark price (e.g., LBMA Gold Price)
+// - MarketDataSource: Configuration for external data feeds
+// - ReferencePrice: Point-in-time price for an instrument/commodity
+// - PriceHistory: Historical price records with timestamps

--- a/services/market-information/domain/repository.go
+++ b/services/market-information/domain/repository.go
@@ -1,0 +1,9 @@
+// Package domain contains repository interfaces for the Market Information service.
+package domain
+
+// TODO: Add repository interfaces when implementing Task 5 (Repository Implementation)
+//
+// Expected interfaces:
+// - PriceBenchmarkRepository: CRUD for price benchmark configurations
+// - ReferencePriceRepository: Query and store reference prices
+// - PriceHistoryRepository: Historical price queries with time-series support

--- a/services/market-information/k8s/configmap.yaml
+++ b/services/market-information/k8s/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: market-information-config
+  labels:
+    app: market-information
+    component: microservice
+data:
+  # Logging configuration
+  LOG_LEVEL: "info"
+  LOG_FORMAT: "json"
+
+  # Database connection pool settings
+  DB_MAX_OPEN_CONNS: "25"
+  DB_MAX_IDLE_CONNS: "5"
+  DB_CONN_MAX_LIFETIME: "5m"
+  DB_CONN_MAX_IDLE_TIME: "10m"
+
+  # gRPC server configuration
+  GRPC_PORT: "50058"
+  GRPC_MAX_CONCURRENT_STREAMS: "100"
+
+  # OpenTelemetry configuration
+  OTEL_SERVICE_NAME: "market-information-service"
+  OTEL_SAMPLING_RATE: "0.1"
+
+  # Authentication configuration
+  # Set to "true" to require JWT validation on gRPC calls
+  AUTH_ENABLED: "false"
+  # AUTH_JWKS_URL: "http://keycloak:8080/realms/meridian/protocol/openid-connect/certs"

--- a/services/market-information/k8s/deployment.yaml
+++ b/services/market-information/k8s/deployment.yaml
@@ -1,0 +1,109 @@
+# Port Configuration: See shared/platform/ports/ports.go for canonical port assignments.
+# This service uses ports.MarketInformation (50058) for gRPC.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: market-information
+  labels:
+    app: market-information
+    component: microservice
+    tier: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: market-information
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: market-information
+        component: microservice
+        tier: backend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: market-information
+        image: market-information:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grpc
+          containerPort: 50058
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: market-information-config
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: market-information-db
+              key: DATABASE_URL
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        livenessProbe:
+          grpc:
+            port: 50058
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          grpc:
+            port: 50058
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        startupProbe:
+          grpc:
+            port: 50058
+          initialDelaySeconds: 0
+          periodSeconds: 2
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 30
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      terminationGracePeriodSeconds: 30

--- a/services/market-information/k8s/secret.yaml
+++ b/services/market-information/k8s/secret.yaml
@@ -1,0 +1,17 @@
+# SECURITY NOTE: This secret contains development credentials only.
+# For production deployments:
+# - Use external secret management (e.g., Sealed Secrets, External Secrets Operator)
+# - Rotate credentials regularly
+# - Use RBAC to restrict secret access
+# - Enable encryption at rest for secrets
+apiVersion: v1
+kind: Secret
+metadata:
+  name: market-information-db
+  labels:
+    app: market-information
+type: Opaque
+stringData:
+  # Local development connection string - CockroachDB in insecure mode
+  # Service connects to its own isolated database with dedicated user
+  DATABASE_URL: "postgres://meridian_market_information_user@cockroachdb:26257/meridian_market_information?sslmode=disable"

--- a/services/market-information/k8s/service.yaml
+++ b/services/market-information/k8s/service.yaml
@@ -1,0 +1,19 @@
+# Port Configuration: See shared/platform/ports/ports.go for canonical port assignments.
+# This service uses ports.MarketInformation (50058) for gRPC.
+apiVersion: v1
+kind: Service
+metadata:
+  name: market-information
+  labels:
+    app: market-information
+    component: microservice
+spec:
+  type: ClusterIP
+  clusterIP: None  # Headless service for gRPC client-side load balancing
+  ports:
+  - name: grpc
+    port: 50058
+    targetPort: grpc
+    protocol: TCP
+  selector:
+    app: market-information

--- a/services/market-information/observability/metrics.go
+++ b/services/market-information/observability/metrics.go
@@ -1,0 +1,83 @@
+// Package observability provides Prometheus metrics and monitoring for the Market Information service.
+// BIAN Service Domain: Market Information Management
+package observability
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// Operation duration metrics
+	operationDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "market_information_operation_duration_seconds",
+			Help:    "Duration of market information operations in seconds",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		},
+		[]string{"operation", "status"},
+	)
+
+	// Price benchmark metrics
+	priceBenchmarkUpdatesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "market_information_price_benchmark_updates_total",
+			Help: "Total number of price benchmark updates received",
+		},
+		[]string{"benchmark_type", "source"},
+	)
+
+	// Price query metrics
+	priceQueriesTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "market_information_price_queries_total",
+			Help: "Total number of price queries",
+		},
+		[]string{"query_type"},
+	)
+
+	// Data freshness gauge
+	dataFreshnessSeconds = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "market_information_data_freshness_seconds",
+			Help: "Age of the most recent data in seconds (lower is better)",
+		},
+		[]string{"data_type"},
+	)
+
+	// External service metrics for data feeds
+	externalFeedErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "market_information_external_feed_errors_total",
+			Help: "Total number of errors from external data feeds",
+		},
+		[]string{"feed_source", "error_type"},
+	)
+)
+
+// RecordOperationDuration records the duration of a market information operation
+func RecordOperationDuration(operation, status string, duration time.Duration) {
+	operationDuration.WithLabelValues(operation, status).Observe(duration.Seconds())
+}
+
+// RecordPriceBenchmarkUpdate records a price benchmark update
+func RecordPriceBenchmarkUpdate(benchmarkType, source string) {
+	priceBenchmarkUpdatesTotal.WithLabelValues(benchmarkType, source).Inc()
+}
+
+// RecordPriceQuery records a price query
+func RecordPriceQuery(queryType string) {
+	priceQueriesTotal.WithLabelValues(queryType).Inc()
+}
+
+// RecordDataFreshness records the age of the most recent data
+func RecordDataFreshness(dataType string, ageSeconds float64) {
+	dataFreshnessSeconds.WithLabelValues(dataType).Set(ageSeconds)
+}
+
+// RecordExternalFeedError records an error from an external data feed
+func RecordExternalFeedError(feedSource, errorType string) {
+	externalFeedErrors.WithLabelValues(feedSource, errorType).Inc()
+}

--- a/services/market-information/service/health.go
+++ b/services/market-information/service/health.go
@@ -1,0 +1,65 @@
+// Package service provides gRPC service implementations for the Market Information service.
+// BIAN Service Domain: Market Information Management
+package service
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+// HealthCheckerConfig holds configuration for the health checker.
+type HealthCheckerConfig struct {
+	// Logger for health check operations
+	Logger *slog.Logger
+	// ServiceName used in health check responses
+	ServiceName string
+	// CheckTimeout is the maximum duration for health checks
+	CheckTimeout time.Duration
+}
+
+// HealthChecker implements the gRPC health check protocol.
+type HealthChecker struct {
+	grpc_health_v1.UnimplementedHealthServer
+	logger      *slog.Logger
+	serviceName string
+	timeout     time.Duration
+}
+
+// NewHealthChecker creates a new HealthChecker.
+func NewHealthChecker(cfg HealthCheckerConfig) *HealthChecker {
+	return &HealthChecker{
+		logger:      cfg.Logger,
+		serviceName: cfg.ServiceName,
+		timeout:     cfg.CheckTimeout,
+	}
+}
+
+// Check implements the gRPC health check protocol.
+func (h *HealthChecker) Check(_ context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	// For now, always report healthy since we don't have dependencies to check
+	// TODO: Add database connectivity check when repository is implemented
+	h.logger.Debug("health check", "service", req.Service)
+
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+// Watch implements the gRPC health watch protocol.
+func (h *HealthChecker) Watch(_ *grpc_health_v1.HealthCheckRequest, stream grpc_health_v1.Health_WatchServer) error {
+	// Send initial status
+	if err := stream.Send(&grpc_health_v1.HealthCheckResponse{
+		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+	}); err != nil {
+		return status.Errorf(codes.Internal, "failed to send health response: %v", err)
+	}
+
+	// Keep the stream open until client disconnects
+	<-stream.Context().Done()
+	return nil
+}

--- a/shared/platform/ports/ports.go
+++ b/shared/platform/ports/ports.go
@@ -91,6 +91,13 @@ const (
 	// Protocol: gRPC (internal)
 	// Visibility: Cluster-internal only
 	InternalBankAccount = 50057
+
+	// MarketInformation is the gRPC port for the Market Information service.
+	// BIAN Service Domain: Market Information Management
+	// Manages price benchmarks, market data feeds, and reference prices.
+	// Protocol: gRPC (internal)
+	// Visibility: Cluster-internal only
+	MarketInformation = 50058
 )
 
 // HTTP service ports (various protocols).


### PR DESCRIPTION
## Summary

- Add complete service directory structure for the Market Information service following ADR-0015 Standard Service Directory Structure
- Create gRPC server bootstrap with health check, tracing, and auth interceptors
- Configure Kubernetes manifests for deployment (port 50058)
- Integrate into Tiltfile and init-database.sh for local development

## Changes Made

**New Service Components:**
- `services/market-information/cmd/main.go` - Service entry point with gRPC server bootstrap
- `services/market-information/cmd/Dockerfile` - Multi-stage build with distroless runtime
- `services/market-information/service/health.go` - Basic health checker implementation
- `services/market-information/observability/metrics.go` - Prometheus metrics definitions
- `services/market-information/atlas/atlas.hcl` - Database migration configuration
- `services/market-information/k8s/*.yaml` - Kubernetes manifests (deployment, service, configmap, secret)
- `services/market-information/domain/` - Placeholder for domain models and repository interfaces
- `services/market-information/config/` - Placeholder for service configuration

**Infrastructure Updates:**
- `shared/platform/ports/ports.go` - Add MarketInformation port constant (50058)
- `Tiltfile` - Add market-information service and migration job definitions
- `scripts/init-database.sh` - Add meridian_market_information database setup

## Technical Details

- Port: 50058 (next available after InternalBankAccount 50057)
- Database: `meridian_market_information` with user `meridian_market_information_user`
- BIAN Service Domain: Market Information Management
- Uses distroless base image for minimal attack surface

## Test plan

- [x] Go code compiles: `go build -o /dev/null ./services/market-information/cmd`
- [x] Go list includes new paths: `go list ./services/market-information/...`
- [x] K8s manifests validate: `kubectl apply --dry-run=client -f services/market-information/k8s/*.yaml`
- [x] Port 50058 consistently configured across all files
- [ ] CI passes (automated checks)

## Notes

This scaffolding is a prerequisite for:
- Task 1: Proto definitions (market_information/v1)
- Task 2: Database schema (price benchmarks, market data feeds)

Service will fail to start until Task 1 (Proto definitions) is complete, which is expected behavior.