### PR TITLE
feat(market-information): Add observability infrastructure

### DIFF
--- a/services/market-information/cmd/main.go
+++ b/services/market-information/cmd/main.go
@@ -5,9 +5,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -17,6 +19,7 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	"github.com/meridianhub/meridian/shared/platform/env"
 	"github.com/meridianhub/meridian/shared/platform/ports"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 )
@@ -64,15 +67,16 @@ func run(logger *slog.Logger) error {
 	}
 	defer bootstrap.ShutdownTracer(tracer, logger)
 
-	// Initialize database connection
-	dbConfig := bootstrap.DefaultDatabaseConfig()
-	dbConfig.Logger = logger
-	db, err := bootstrap.NewDatabase(ctx, dbConfig)
-	if err != nil {
-		return fmt.Errorf("failed to initialize database: %w", err)
-	}
-
-	logger.Info("database connection established")
+	// TODO: Wire database into repository once persistence layer is implemented (Task 3)
+	// Currently scaffolding without database to avoid holding idle connections.
+	// Uncomment when ready:
+	// dbConfig := bootstrap.DefaultDatabaseConfig()
+	// dbConfig.Logger = logger
+	// db, err := bootstrap.NewDatabase(ctx, dbConfig)
+	// if err != nil {
+	// 	return fmt.Errorf("failed to initialize database: %w", err)
+	// }
+	// logger.Info("database connection established")
 
 	// Initialize auth interceptor (optional - based on AUTH_ENABLED)
 	authConfig := bootstrap.DefaultAuthConfig(logger)
@@ -102,9 +106,10 @@ func run(logger *slog.Logger) error {
 
 	logger.Info("gRPC services registered")
 
-	// Get port from environment
+	// Get ports from environment
 	port := env.GetEnvOrDefault("GRPC_PORT", strconv.Itoa(ports.MarketInformation))
 	address := fmt.Sprintf(":%s", port)
+	metricsPort := env.GetEnvOrDefault("METRICS_PORT", "8082")
 
 	// Create listener
 	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", address)
@@ -113,7 +118,9 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Start gRPC server in background
-	serverErrors := make(chan error, 1)
+	// Buffer size must match number of goroutines writing to this channel
+	// to prevent deadlock on simultaneous failures (gRPC + HTTP = 2)
+	serverErrors := make(chan error, 2)
 	go func() {
 		logger.Info("starting gRPC server", "address", address)
 		if err := grpcServer.Serve(listener); err != nil {
@@ -121,14 +128,87 @@ func run(logger *slog.Logger) error {
 		}
 	}()
 
+	// Start HTTP server for metrics and health endpoints
+	httpMux := http.NewServeMux()
+	httpMux.Handle("/metrics", promhttp.Handler())
+	httpMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		// Simple health endpoint for HTTP probes
+		resp, err := healthChecker.Check(r.Context(), &grpc_health_v1.HealthCheckRequest{})
+		if err != nil || resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			if _, err := w.Write([]byte("NOT_SERVING")); err != nil {
+				logger.Warn("failed to write health response",
+					"error", err,
+					"endpoint", r.URL.Path,
+					"remote_addr", r.RemoteAddr)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("SERVING")); err != nil {
+			logger.Warn("failed to write health response",
+				"error", err,
+				"endpoint", r.URL.Path,
+				"remote_addr", r.RemoteAddr)
+		}
+	})
+	httpMux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
+		// Readiness endpoint - checks all dependencies
+		resp, err := healthChecker.Check(r.Context(), &grpc_health_v1.HealthCheckRequest{})
+		if err != nil || resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			if _, err := w.Write([]byte("NOT_READY")); err != nil {
+				logger.Warn("failed to write readiness response",
+					"error", err,
+					"endpoint", r.URL.Path,
+					"remote_addr", r.RemoteAddr)
+			}
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("READY")); err != nil {
+			logger.Warn("failed to write readiness response",
+				"error", err,
+				"endpoint", r.URL.Path,
+				"remote_addr", r.RemoteAddr)
+		}
+	})
+
+	httpServer := &http.Server{
+		Addr:              fmt.Sprintf(":%s", metricsPort),
+		Handler:           httpMux,
+		ReadHeaderTimeout: defaults.DefaultHTTPReadHeaderTimeout,
+		WriteTimeout:      defaults.DefaultHTTPWriteTimeout,
+	}
+
+	go func() {
+		logger.Info("starting HTTP server for metrics", "address", httpServer.Addr)
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("HTTP server error", "error", err)
+			serverErrors <- fmt.Errorf("HTTP server error: %w", err)
+		}
+	}()
+
 	// Wait for shutdown signal and orchestrate graceful shutdown
 	orchestrator := bootstrap.NewShutdownOrchestrator(grpcServer, logger)
 
-	// Register database cleanup
+	// Register cleanup functions (LIFO order - HTTP server first, then database)
 	orchestrator.AddCleanup(func() error {
-		bootstrap.CloseDatabase(db, logger)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), defaults.DefaultGracefulShutdown)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			logger.Error("HTTP server shutdown error", "error", err)
+			return err
+		}
+		logger.Info("HTTP server stopped")
 		return nil
 	})
+
+	// TODO: Re-enable database cleanup when persistence layer is implemented
+	// orchestrator.AddCleanup(func() error {
+	// 	bootstrap.CloseDatabase(db, logger)
+	// 	return nil
+	// })
 
 	return orchestrator.Wait(serverErrors)
 }

--- a/services/market-information/observability/metrics.go
+++ b/services/market-information/observability/metrics.go
@@ -9,6 +9,29 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// Error category constants for bounded label cardinality.
+const (
+	ErrorCategoryValidation = "validation"
+	ErrorCategoryNotFound   = "not_found"
+	ErrorCategoryInternal   = "internal"
+	ErrorCategoryDatabase   = "database"
+	ErrorCategoryExternal   = "external"
+)
+
+// Operation name constants for consistent metric labeling.
+const (
+	OperationDefineDataset     = "define_dataset"
+	OperationRecordObservation = "record_observation"
+	OperationQueryPrices       = "query_prices"
+	OperationRetrieveDataset   = "retrieve_dataset"
+)
+
+// Status constants for operation outcomes.
+const (
+	StatusSuccess = "success"
+	StatusError   = "error"
+)
+
 var (
 	// Operation duration metrics
 	operationDuration = promauto.NewHistogramVec(
@@ -55,6 +78,33 @@ var (
 		},
 		[]string{"feed_source", "error_type"},
 	)
+
+	// Health check metrics
+	healthCheckTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "market_information_health_check_total",
+			Help: "Total number of health checks by component and status",
+		},
+		[]string{"component", "status"},
+	)
+
+	// Error metrics
+	errorsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "market_information_errors_total",
+			Help: "Total number of errors by category and operation",
+		},
+		[]string{"category", "operation"},
+	)
+
+	// In-flight operations gauge
+	operationsInFlight = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "market_information_operations_in_flight",
+			Help: "Number of operations currently being processed",
+		},
+		[]string{"operation"},
+	)
 )
 
 // RecordOperationDuration records the duration of a market information operation
@@ -80,4 +130,65 @@ func RecordDataFreshness(dataType string, ageSeconds float64) {
 // RecordExternalFeedError records an error from an external data feed
 func RecordExternalFeedError(feedSource, errorType string) {
 	externalFeedErrors.WithLabelValues(feedSource, errorType).Inc()
+}
+
+// RecordHealthCheck records a health check result.
+func RecordHealthCheck(component, status string) {
+	healthCheckTotal.WithLabelValues(component, status).Inc()
+}
+
+// RecordError records an error with category and operation context.
+func RecordError(category, operation string) {
+	errorsTotal.WithLabelValues(category, operation).Inc()
+}
+
+// IncOperationsInFlight increments the in-flight gauge for an operation.
+func IncOperationsInFlight(operation string) {
+	operationsInFlight.WithLabelValues(operation).Inc()
+}
+
+// DecOperationsInFlight decrements the in-flight gauge for an operation.
+func DecOperationsInFlight(operation string) {
+	operationsInFlight.WithLabelValues(operation).Dec()
+}
+
+// OperationTimer provides a convenient way to time operations and record metrics.
+// It protects against double-observation which would cause incorrect gauge values.
+type OperationTimer struct {
+	operation string
+	start     time.Time
+	observed  bool
+}
+
+// NewOperationTimer creates a new timer and increments the in-flight gauge.
+func NewOperationTimer(operation string) *OperationTimer {
+	IncOperationsInFlight(operation)
+	return &OperationTimer{
+		operation: operation,
+		start:     time.Now(),
+		observed:  false,
+	}
+}
+
+// ObserveSuccess records a successful operation and decrements in-flight gauge.
+// Safe to call multiple times; only the first call has effect.
+func (t *OperationTimer) ObserveSuccess() {
+	if t.observed {
+		return
+	}
+	t.observed = true
+	DecOperationsInFlight(t.operation)
+	RecordOperationDuration(t.operation, StatusSuccess, time.Since(t.start))
+}
+
+// ObserveError records a failed operation with error category and decrements in-flight gauge.
+// Safe to call multiple times; only the first call has effect.
+func (t *OperationTimer) ObserveError(errorCategory string) {
+	if t.observed {
+		return
+	}
+	t.observed = true
+	DecOperationsInFlight(t.operation)
+	RecordOperationDuration(t.operation, StatusError, time.Since(t.start))
+	RecordError(errorCategory, t.operation)
 }

--- a/services/market-information/observability/metrics_test.go
+++ b/services/market-information/observability/metrics_test.go
@@ -1,0 +1,98 @@
+package observability
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOperationTimer_ObserveSuccess(t *testing.T) {
+	t.Run("records success metrics", func(t *testing.T) {
+		timer := NewOperationTimer(OperationDefineDataset)
+
+		// Simulate some work
+		time.Sleep(10 * time.Millisecond)
+
+		timer.ObserveSuccess()
+
+		// Verify it was observed
+		assert.True(t, timer.observed)
+	})
+
+	t.Run("is idempotent - multiple calls only record once", func(t *testing.T) {
+		timer := NewOperationTimer(OperationQueryPrices)
+
+		timer.ObserveSuccess()
+		assert.True(t, timer.observed)
+
+		// Second call should be a no-op
+		timer.ObserveSuccess()
+		assert.True(t, timer.observed)
+	})
+}
+
+func TestOperationTimer_ObserveError(t *testing.T) {
+	t.Run("records error metrics with category", func(t *testing.T) {
+		timer := NewOperationTimer(OperationRecordObservation)
+
+		timer.ObserveError(ErrorCategoryValidation)
+
+		assert.True(t, timer.observed)
+	})
+
+	t.Run("is idempotent - multiple calls only record once", func(t *testing.T) {
+		timer := NewOperationTimer(OperationRetrieveDataset)
+
+		timer.ObserveError(ErrorCategoryDatabase)
+		assert.True(t, timer.observed)
+
+		// Second call should be a no-op
+		timer.ObserveError(ErrorCategoryInternal)
+		assert.True(t, timer.observed)
+	})
+
+	t.Run("success after error is no-op", func(t *testing.T) {
+		timer := NewOperationTimer(OperationDefineDataset)
+
+		timer.ObserveError(ErrorCategoryExternal)
+		assert.True(t, timer.observed)
+
+		// Success after error should be no-op
+		timer.ObserveSuccess()
+		assert.True(t, timer.observed)
+	})
+
+	t.Run("error after success is no-op", func(t *testing.T) {
+		timer := NewOperationTimer(OperationQueryPrices)
+
+		timer.ObserveSuccess()
+		assert.True(t, timer.observed)
+
+		// Error after success should be no-op
+		timer.ObserveError(ErrorCategoryNotFound)
+		assert.True(t, timer.observed)
+	})
+}
+
+func TestOperationConstants(t *testing.T) {
+	t.Run("error category constants are defined", func(t *testing.T) {
+		assert.Equal(t, "validation", ErrorCategoryValidation)
+		assert.Equal(t, "not_found", ErrorCategoryNotFound)
+		assert.Equal(t, "internal", ErrorCategoryInternal)
+		assert.Equal(t, "database", ErrorCategoryDatabase)
+		assert.Equal(t, "external", ErrorCategoryExternal)
+	})
+
+	t.Run("operation constants are defined", func(t *testing.T) {
+		assert.Equal(t, "define_dataset", OperationDefineDataset)
+		assert.Equal(t, "record_observation", OperationRecordObservation)
+		assert.Equal(t, "query_prices", OperationQueryPrices)
+		assert.Equal(t, "retrieve_dataset", OperationRetrieveDataset)
+	})
+
+	t.Run("status constants are defined", func(t *testing.T) {
+		assert.Equal(t, "success", StatusSuccess)
+		assert.Equal(t, "error", StatusError)
+	})
+}

--- a/services/market-information/service/health.go
+++ b/services/market-information/service/health.go
@@ -4,16 +4,20 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
-	"google.golang.org/grpc/codes"
+	"github.com/meridianhub/meridian/services/market-information/observability"
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/meridianhub/meridian/shared/platform/db"
 	"google.golang.org/grpc/health/grpc_health_v1"
-	"google.golang.org/grpc/status"
 )
 
 // HealthCheckerConfig holds configuration for the health checker.
 type HealthCheckerConfig struct {
+	// Database connection pool (optional during scaffolding)
+	Database *db.PostgresPool
 	// Logger for health check operations
 	Logger *slog.Logger
 	// ServiceName used in health check responses
@@ -22,44 +26,144 @@ type HealthCheckerConfig struct {
 	CheckTimeout time.Duration
 }
 
-// HealthChecker implements the gRPC health check protocol.
+// HealthChecker implements the gRPC health check protocol with dependency aggregation.
 type HealthChecker struct {
 	grpc_health_v1.UnimplementedHealthServer
 	logger      *slog.Logger
+	aggregator  *health.Aggregator
 	serviceName string
 	timeout     time.Duration
 }
 
-// NewHealthChecker creates a new HealthChecker.
+// NewHealthChecker creates a new HealthChecker with health check aggregation.
 func NewHealthChecker(cfg HealthCheckerConfig) *HealthChecker {
+	// Build list of health checkers
+	var checkers []health.Checker
+
+	// Add database checker if database is configured
+	if cfg.Database != nil {
+		checkers = append(checkers, health.NewDatabaseChecker(cfg.Database))
+	}
+	// TODO: Add external service checkers when dependencies are added
+	// Example: checkers = append(checkers, NewExternalServiceChecker(...))
+
+	aggregator := health.NewAggregator(checkers)
+
 	return &HealthChecker{
 		logger:      cfg.Logger,
+		aggregator:  aggregator,
 		serviceName: cfg.ServiceName,
 		timeout:     cfg.CheckTimeout,
 	}
 }
 
 // Check implements the gRPC health check protocol.
-func (h *HealthChecker) Check(_ context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	// For now, always report healthy since we don't have dependencies to check
-	// TODO: Add database connectivity check when repository is implemented
-	h.logger.Debug("health check", "service", req.Service)
+func (h *HealthChecker) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	// Apply timeout to health check context
+	checkCtx, cancel := context.WithTimeout(ctx, h.timeout)
+	defer cancel()
 
+	// Empty service name or matching service name: check all components
+	if req.Service == "" || req.Service == h.serviceName {
+		report := h.aggregator.CheckAll(checkCtx)
+		overallStatus := report.OverallStatus()
+		grpcStatus := h.mapStatusToGRPC(overallStatus)
+
+		// Record metrics
+		h.recordHealthCheckMetrics(report)
+
+		h.logger.Debug("health check completed",
+			"overall_status", overallStatus.String(),
+			"grpc_status", grpcStatus.String(),
+			"component_count", len(report.Components))
+
+		return &grpc_health_v1.HealthCheckResponse{
+			Status: grpcStatus,
+		}, nil
+	}
+
+	// Check if request is for a specific component
+	componentResult, found := h.aggregator.CheckByName(checkCtx, req.Service)
+	if found {
+		grpcStatus := h.mapStatusToGRPC(componentResult.Status)
+
+		h.logger.Debug("component health check completed",
+			"component", componentResult.Name,
+			"status", componentResult.Status.String(),
+			"grpc_status", grpcStatus.String())
+
+		return &grpc_health_v1.HealthCheckResponse{
+			Status: grpcStatus,
+		}, nil
+	}
+
+	// Service name doesn't match and component not found
 	return &grpc_health_v1.HealthCheckResponse{
-		Status: grpc_health_v1.HealthCheckResponse_SERVING,
+		Status: grpc_health_v1.HealthCheckResponse_UNKNOWN,
 	}, nil
 }
 
 // Watch implements the gRPC health watch protocol.
-func (h *HealthChecker) Watch(_ *grpc_health_v1.HealthCheckRequest, stream grpc_health_v1.Health_WatchServer) error {
-	// Send initial status
-	if err := stream.Send(&grpc_health_v1.HealthCheckResponse{
-		Status: grpc_health_v1.HealthCheckResponse_SERVING,
-	}); err != nil {
-		return status.Errorf(codes.Internal, "failed to send health response: %v", err)
+func (h *HealthChecker) Watch(req *grpc_health_v1.HealthCheckRequest, stream grpc_health_v1.Health_WatchServer) error {
+	ctx := stream.Context()
+
+	// Send immediate health check
+	resp, err := h.Check(ctx, req)
+	if err != nil {
+		return err
 	}
 
-	// Keep the stream open until client disconnects
-	<-stream.Context().Done()
-	return nil
+	if err := stream.Send(resp); err != nil {
+		h.logger.Error("failed to send initial health check", "error", err)
+		return fmt.Errorf("failed to send initial health status: %w", err)
+	}
+
+	// Stream periodic updates
+	ticker := time.NewTicker(h.timeout)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			h.logger.Debug("health watch stream closed", "reason", ctx.Err())
+			return fmt.Errorf("health watch context cancelled: %w", ctx.Err())
+
+		case <-ticker.C:
+			resp, err := h.Check(ctx, req)
+			if err != nil {
+				h.logger.Error("health check failed during watch", "error", err)
+				return err
+			}
+
+			if err := stream.Send(resp); err != nil {
+				h.logger.Error("failed to send health check update", "error", err)
+				return fmt.Errorf("failed to send health status update: %w", err)
+			}
+		}
+	}
+}
+
+// mapStatusToGRPC converts internal health status to gRPC health check status.
+func (h *HealthChecker) mapStatusToGRPC(status health.Status) grpc_health_v1.HealthCheckResponse_ServingStatus {
+	switch status {
+	case health.StatusHealthy, health.StatusDegraded:
+		return grpc_health_v1.HealthCheckResponse_SERVING
+	case health.StatusUnhealthy:
+		return grpc_health_v1.HealthCheckResponse_NOT_SERVING
+	case health.StatusUnknown:
+		return grpc_health_v1.HealthCheckResponse_UNKNOWN
+	default:
+		return grpc_health_v1.HealthCheckResponse_UNKNOWN
+	}
+}
+
+// recordHealthCheckMetrics records health check results to Prometheus.
+func (h *HealthChecker) recordHealthCheckMetrics(report *health.Report) {
+	for _, comp := range report.Components {
+		status := "healthy"
+		if comp.Status != health.StatusHealthy {
+			status = comp.Status.String()
+		}
+		observability.RecordHealthCheck(comp.Name, status)
+	}
 }

--- a/services/market-information/service/health_test.go
+++ b/services/market-information/service/health_test.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+func TestNewHealthChecker(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	t.Run("creates health checker without database", func(t *testing.T) {
+		checker := NewHealthChecker(HealthCheckerConfig{
+			Logger:       logger,
+			ServiceName:  "test-service",
+			CheckTimeout: 5 * time.Second,
+		})
+
+		require.NotNil(t, checker)
+		assert.Equal(t, "test-service", checker.serviceName)
+		assert.Equal(t, 5*time.Second, checker.timeout)
+	})
+}
+
+func TestHealthChecker_Check(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	t.Run("returns SERVING for empty service name", func(t *testing.T) {
+		checker := NewHealthChecker(HealthCheckerConfig{
+			Logger:       logger,
+			ServiceName:  "test-service",
+			CheckTimeout: 5 * time.Second,
+		})
+
+		resp, err := checker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+	})
+
+	t.Run("returns SERVING for matching service name", func(t *testing.T) {
+		checker := NewHealthChecker(HealthCheckerConfig{
+			Logger:       logger,
+			ServiceName:  "test-service",
+			CheckTimeout: 5 * time.Second,
+		})
+
+		resp, err := checker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+			Service: "test-service",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+	})
+
+	t.Run("returns UNKNOWN for unknown component", func(t *testing.T) {
+		checker := NewHealthChecker(HealthCheckerConfig{
+			Logger:       logger,
+			ServiceName:  "test-service",
+			CheckTimeout: 5 * time.Second,
+		})
+
+		resp, err := checker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+			Service: "unknown-component",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, grpc_health_v1.HealthCheckResponse_UNKNOWN, resp.Status)
+	})
+}
+
+func TestHealthChecker_mapStatusToGRPC(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	checker := NewHealthChecker(HealthCheckerConfig{
+		Logger:       logger,
+		ServiceName:  "test-service",
+		CheckTimeout: 5 * time.Second,
+	})
+
+	tests := []struct {
+		name     string
+		status   health.Status
+		expected grpc_health_v1.HealthCheckResponse_ServingStatus
+	}{
+		{
+			name:     "healthy maps to SERVING",
+			status:   health.StatusHealthy,
+			expected: grpc_health_v1.HealthCheckResponse_SERVING,
+		},
+		{
+			name:     "degraded maps to SERVING",
+			status:   health.StatusDegraded,
+			expected: grpc_health_v1.HealthCheckResponse_SERVING,
+		},
+		{
+			name:     "unhealthy maps to NOT_SERVING",
+			status:   health.StatusUnhealthy,
+			expected: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+		},
+		{
+			name:     "unknown maps to UNKNOWN",
+			status:   health.StatusUnknown,
+			expected: grpc_health_v1.HealthCheckResponse_UNKNOWN,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := checker.mapStatusToGRPC(tt.status)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Addresses observability gaps identified in PR #604 review by adding production-ready observability patterns to the market-information service scaffolding.

## Changes Made

- **HTTP Metrics Server (port 8082)**: Added dedicated HTTP server for `/metrics`, `/health`, and `/ready` endpoints following the internal-bank-account service pattern
- **Enhanced Health Checker**: Replaced simple always-SERVING health check with aggregator pattern from `shared/pkg/health` for extensible dependency checking
- **OperationTimer Helper**: Added helper for measuring operation durations with in-flight tracking and idempotent observation to prevent double-counting
- **Bounded Label Constants**: Added error category and operation constants to prevent metric cardinality explosion
- **Database Initialization Cleanup**: Commented out database initialization until persistence layer is implemented (Task 3) to avoid holding idle connections

## Technical Details

The changes follow established patterns from the internal-bank-account service:
- HTTP server runs on configurable `METRICS_PORT` (default 8082)
- Health/ready endpoints delegate to gRPC health checker
- Graceful shutdown orchestration handles HTTP server cleanup
- Server error channel buffered for both gRPC and HTTP servers

## Test Plan

- [x] Unit tests for OperationTimer (idempotency, success/error paths)
- [x] Unit tests for HealthChecker (status mapping, aggregation)
- [x] All tests pass: `go test ./services/market-information/...`
- [x] Pre-commit checks pass (gofumpt, golangci-lint)

## Task Master

`market-information-management.15`