### PR TITLE
feat: Add Market Information Management proto API and gRPC stubs

### DIFF
--- a/api/proto/meridian/market_information/v1/market_information.proto
+++ b/api/proto/meridian/market_information/v1/market_information.proto
@@ -1,0 +1,1041 @@
+syntax = "proto3";
+
+package meridian.market_information.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "meridian/common/v1/types.proto";
+import "meridian/quantity/v1/quantity.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1;marketinformationv1";
+
+// OpenAPI specification metadata for Market Information Management Service
+option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+  info: {
+    title: "Meridian Market Information Management Service API"
+    version: "1.0"
+    description: "BIAN-compliant market information management operations for managing "
+                 "market data sets, price observations, and data sources with bi-temporal support."
+    contact: {
+      name: "Meridian API Team"
+      url: "https://github.com/meridianhub/meridian"
+    }
+    license: {
+      name: "Apache 2.0"
+      url: "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  }
+  schemes: HTTPS
+  consumes: "application/json"
+  produces: "application/json"
+  security_definitions: {
+    security: {
+      key: "Bearer"
+      value: {
+        type: TYPE_API_KEY
+        in: IN_HEADER
+        name: "Authorization"
+        description: "Bearer token authentication"
+      }
+    }
+  }
+  security: {
+    security_requirement: {
+      key: "Bearer"
+      value: {}
+    }
+  }
+};
+
+// ========================================
+// Enums
+// ========================================
+
+// DataCategory defines the type of market data being tracked.
+enum DataCategory {
+  // DATA_CATEGORY_UNSPECIFIED means the category is unknown.
+  DATA_CATEGORY_UNSPECIFIED = 0;
+  // DATA_CATEGORY_FX_RATE represents foreign exchange rates.
+  DATA_CATEGORY_FX_RATE = 1;
+  // DATA_CATEGORY_INTEREST_RATE represents interest rates (LIBOR, SOFR, etc.).
+  DATA_CATEGORY_INTEREST_RATE = 2;
+  // DATA_CATEGORY_COMMODITY_PRICE represents commodity prices (oil, gas, metals).
+  DATA_CATEGORY_COMMODITY_PRICE = 3;
+  // DATA_CATEGORY_EQUITY_PRICE represents equity/stock prices.
+  DATA_CATEGORY_EQUITY_PRICE = 4;
+  // DATA_CATEGORY_INDEX_VALUE represents index values (S&P 500, etc.).
+  DATA_CATEGORY_INDEX_VALUE = 5;
+  // DATA_CATEGORY_ENERGY_PRICE represents energy prices (electricity, gas).
+  DATA_CATEGORY_ENERGY_PRICE = 6;
+  // DATA_CATEGORY_CARBON_PRICE represents carbon credit prices.
+  DATA_CATEGORY_CARBON_PRICE = 7;
+  // DATA_CATEGORY_BENCHMARK_RATE represents benchmark rates (prime rate, fed funds).
+  DATA_CATEGORY_BENCHMARK_RATE = 8;
+  // DATA_CATEGORY_VOLATILITY represents volatility indices (VIX, etc.).
+  DATA_CATEGORY_VOLATILITY = 9;
+  // DATA_CATEGORY_CREDIT_SPREAD represents credit spreads.
+  DATA_CATEGORY_CREDIT_SPREAD = 10;
+}
+
+// DataSetStatus defines the lifecycle state of a data set definition.
+enum DataSetStatus {
+  // DATA_SET_STATUS_UNSPECIFIED means the status is unknown.
+  DATA_SET_STATUS_UNSPECIFIED = 0;
+  // DATA_SET_STATUS_DRAFT means the data set is being defined and cannot be used.
+  DATA_SET_STATUS_DRAFT = 1;
+  // DATA_SET_STATUS_ACTIVE means the data set is available for use.
+  DATA_SET_STATUS_ACTIVE = 2;
+  // DATA_SET_STATUS_DEPRECATED means the data set is no longer recommended for new use.
+  DATA_SET_STATUS_DEPRECATED = 3;
+}
+
+// QualityLevel defines the confidence level of an observation.
+enum QualityLevel {
+  // QUALITY_LEVEL_UNSPECIFIED means the quality is unknown.
+  QUALITY_LEVEL_UNSPECIFIED = 0;
+  // QUALITY_LEVEL_ESTIMATE indicates a preliminary estimate, subject to revision.
+  QUALITY_LEVEL_ESTIMATE = 1;
+  // QUALITY_LEVEL_PROVISIONAL indicates a provisional value, pending final verification.
+  QUALITY_LEVEL_PROVISIONAL = 2;
+  // QUALITY_LEVEL_ACTUAL indicates a verified, final value.
+  QUALITY_LEVEL_ACTUAL = 3;
+  // QUALITY_LEVEL_REVISED indicates a corrected value replacing a previous observation.
+  QUALITY_LEVEL_REVISED = 4;
+}
+
+// ========================================
+// Core Message Types
+// ========================================
+
+// DataSetDefinition defines a type of market data that can be tracked.
+// This is the reference data that describes how observations are validated and structured.
+message DataSetDefinition {
+  // id is the unique identifier for this definition (UUID).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // code is the unique data set code within the tenant (e.g., "USD_EUR_FX", "BRENT_CRUDE").
+  string code = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // version is the schema version for this definition (monotonically increasing).
+  int32 version = 3 [(buf.validate.field).int32.gte = 1];
+
+  // category is the type of market data this set represents.
+  DataCategory category = 4 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // unit describes the unit of measurement for observations (e.g., "USD", "USD/EUR", "USD/BBL").
+  string unit = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+  }];
+
+  // resolution_key_expression is a CEL expression to generate the resolution key for observations.
+  // Example: "tenor + ':' + settlement_type" for interest rate curves.
+  // Example: "'spot'" for simple spot prices.
+  string resolution_key_expression = 6 [(buf.validate.field).string.max_len = 2048];
+
+  // validation_expression is a CEL expression to validate observation values.
+  // Example: "value > 0 && value < 10000" for price bounds.
+  string validation_expression = 7 [(buf.validate.field).string.max_len = 2048];
+
+  // error_message_expression is a CEL expression to generate custom validation error messages.
+  // Example: "'Invalid price: ' + string(value) + ' for ' + dataset_code"
+  string error_message_expression = 8 [(buf.validate.field).string.max_len = 2048];
+
+  // attribute_schema is a JSON Schema defining valid attributes for observations.
+  // Example: {"type":"object","properties":{"tenor":{"type":"string"},"settlement":{"type":"string"}}}
+  google.protobuf.Struct attribute_schema = 9;
+
+  // status is the lifecycle state of this definition.
+  DataSetStatus status = 10 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // effective_from is when this data set definition becomes effective.
+  google.protobuf.Timestamp effective_from = 11 [(buf.validate.field).required = true];
+
+  // effective_to is when this data set definition expires (optional).
+  google.protobuf.Timestamp effective_to = 12;
+
+  // display_name is the human-readable name for this data set.
+  string display_name = 13 [(buf.validate.field).string.max_len = 128];
+
+  // description provides additional context about this data set.
+  string description = 14 [(buf.validate.field).string.max_len = 1024];
+
+  // created_at is when this definition was created.
+  google.protobuf.Timestamp created_at = 15 [(buf.validate.field).required = true];
+
+  // updated_at is when this definition was last updated.
+  google.protobuf.Timestamp updated_at = 16;
+}
+
+// MarketPriceObservation represents a single observation of market data.
+// Supports bi-temporal queries (knowledge time vs. valid time).
+message MarketPriceObservation {
+  // id is the unique identifier for this observation (UUID).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // dataset_code identifies the data set this observation belongs to.
+  string dataset_code = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // dataset_version is the version of the data set definition.
+  int32 dataset_version = 3 [(buf.validate.field).int32.gte = 1];
+
+  // resolution_key_value is the computed resolution key for this observation.
+  // Example: "1M:T+2" for a 1-month tenor with T+2 settlement.
+  string resolution_key_value = 4 [(buf.validate.field).string.max_len = 256];
+
+  // observed_at is when this observation was made (business time).
+  google.protobuf.Timestamp observed_at = 5 [(buf.validate.field).required = true];
+
+  // valid_from is when this observation value becomes valid (bi-temporal support).
+  google.protobuf.Timestamp valid_from = 6 [(buf.validate.field).required = true];
+
+  // valid_to is when this observation value expires (optional, for forward curves).
+  google.protobuf.Timestamp valid_to = 7;
+
+  // value is the observed value as a decimal string for precision.
+  string value = 8 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 40
+    pattern: "^-?[0-9]+(\\.[0-9]+)?$"
+  }];
+
+  // quality indicates the confidence level of this observation.
+  QualityLevel quality = 9 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // source_id identifies the data source that provided this observation.
+  string source_id = 10 [(buf.validate.field).string.uuid = true];
+
+  // created_at is the knowledge time - when this observation was recorded in the system.
+  google.protobuf.Timestamp created_at = 11 [(buf.validate.field).required = true];
+
+  // superseded_at is when this observation was superseded by a newer observation.
+  google.protobuf.Timestamp superseded_at = 12;
+
+  // superseded_by_id is the UUID of the observation that replaced this one.
+  string superseded_by_id = 13 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // attributes contains additional metadata for this observation.
+  repeated meridian.quantity.v1.AttributeEntry attributes = 14;
+}
+
+// DataSource represents a provider of market data.
+message DataSource {
+  // id is the unique identifier for this data source (UUID).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // code is the unique source code (e.g., "BLOOMBERG", "REUTERS", "ECB").
+  string code = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // name is the human-readable name for this source.
+  string name = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 128
+  }];
+
+  // description provides additional context about this source.
+  string description = 4 [(buf.validate.field).string.max_len = 1024];
+
+  // trust_level indicates the reliability of this source (0-100).
+  // Higher values indicate more trusted sources for conflict resolution.
+  int32 trust_level = 5 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 100
+  }];
+
+  // is_active indicates whether this source can provide new observations.
+  bool is_active = 6;
+
+  // created_at is when this source was registered.
+  google.protobuf.Timestamp created_at = 7 [(buf.validate.field).required = true];
+
+  // updated_at is when this source was last updated.
+  google.protobuf.Timestamp updated_at = 8;
+}
+
+// ========================================
+// Event Messages
+// ========================================
+
+// ObservationRecorded is an event emitted when a new observation is recorded.
+message ObservationRecorded {
+  // observation_id is the unique identifier of the recorded observation.
+  string observation_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // dataset_code identifies the data set this observation belongs to.
+  string dataset_code = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+  }];
+
+  // resolution_key_value is the computed resolution key for this observation.
+  string resolution_key_value = 3 [(buf.validate.field).string.max_len = 256];
+
+  // observed_at is when this observation was made.
+  google.protobuf.Timestamp observed_at = 4 [(buf.validate.field).required = true];
+
+  // quality indicates the confidence level of this observation.
+  QualityLevel quality = 5 [(buf.validate.field).enum.defined_only = true];
+
+  // value is the observed value as a decimal string.
+  string value = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 40
+  }];
+
+  // source_id identifies the data source that provided this observation.
+  string source_id = 7 [(buf.validate.field).string.uuid = true];
+
+  // recorded_at is when this event was emitted.
+  google.protobuf.Timestamp recorded_at = 8 [(buf.validate.field).required = true];
+
+  // supersedes_observation_id is set if this observation supersedes a previous one.
+  string supersedes_observation_id = 9 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string.uuid = true
+  ];
+}
+
+// ========================================
+// Service Definition
+// ========================================
+
+// MarketInformationService provides operations for managing market data sets,
+// observations, and data sources following BIAN v13.0 Market Information Management.
+service MarketInformationService {
+  // ----------------------------------------
+  // Data Set Operations
+  // ----------------------------------------
+
+  // RegisterDataSet creates a new data set definition in DRAFT status.
+  // Returns ALREADY_EXISTS if code+version exists.
+  // Returns INVALID_ARGUMENT if CEL expressions fail compilation.
+  rpc RegisterDataSet(RegisterDataSetRequest) returns (RegisterDataSetResponse) {
+    option (google.api.http) = {
+      post: "/v1/market-information/datasets"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "201"
+        value: {
+          description: "Data set definition created successfully"
+        }
+      }
+    };
+  }
+
+  // UpdateDataSet modifies a DRAFT data set definition.
+  // Returns NOT_FOUND if data set doesn't exist.
+  // Returns FAILED_PRECONDITION if not in DRAFT status.
+  rpc UpdateDataSet(UpdateDataSetRequest) returns (UpdateDataSetResponse) {
+    option (google.api.http) = {
+      patch: "/v1/market-information/datasets/{code}"
+      body: "*"
+    };
+  }
+
+  // ActivateDataSet transitions a data set from DRAFT to ACTIVE.
+  // Returns NOT_FOUND if data set doesn't exist.
+  // Returns FAILED_PRECONDITION if not in DRAFT status.
+  rpc ActivateDataSet(ActivateDataSetRequest) returns (ActivateDataSetResponse) {
+    option (google.api.http) = {
+      post: "/v1/market-information/datasets/{code}/activate"
+      body: "*"
+    };
+  }
+
+  // DeprecateDataSet transitions a data set from ACTIVE to DEPRECATED.
+  // Returns NOT_FOUND if data set doesn't exist.
+  // Returns FAILED_PRECONDITION if not in ACTIVE status.
+  rpc DeprecateDataSet(DeprecateDataSetRequest) returns (DeprecateDataSetResponse) {
+    option (google.api.http) = {
+      post: "/v1/market-information/datasets/{code}/deprecate"
+      body: "*"
+    };
+  }
+
+  // RetrieveDataSet fetches a specific data set by code and version.
+  // Returns NOT_FOUND if data set doesn't exist.
+  rpc RetrieveDataSet(RetrieveDataSetRequest) returns (RetrieveDataSetResponse) {
+    option (google.api.http) = {
+      get: "/v1/market-information/datasets/{code}"
+    };
+  }
+
+  // ListDataSets returns data sets matching the filter criteria.
+  // Supports filtering by status, category, and pagination.
+  rpc ListDataSets(ListDataSetsRequest) returns (ListDataSetsResponse) {
+    option (google.api.http) = {
+      get: "/v1/market-information/datasets"
+    };
+  }
+
+  // ----------------------------------------
+  // Data Source Operations
+  // ----------------------------------------
+
+  // RegisterDataSource creates a new data source.
+  // Returns ALREADY_EXISTS if code exists.
+  rpc RegisterDataSource(RegisterDataSourceRequest) returns (RegisterDataSourceResponse) {
+    option (google.api.http) = {
+      post: "/v1/market-information/sources"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "201"
+        value: {
+          description: "Data source created successfully"
+        }
+      }
+    };
+  }
+
+  // UpdateDataSource modifies an existing data source.
+  // Returns NOT_FOUND if data source doesn't exist.
+  rpc UpdateDataSource(UpdateDataSourceRequest) returns (UpdateDataSourceResponse) {
+    option (google.api.http) = {
+      patch: "/v1/market-information/sources/{code}"
+      body: "*"
+    };
+  }
+
+  // DeactivateDataSource marks a data source as inactive.
+  // Returns NOT_FOUND if data source doesn't exist.
+  rpc DeactivateDataSource(DeactivateDataSourceRequest) returns (DeactivateDataSourceResponse) {
+    option (google.api.http) = {
+      post: "/v1/market-information/sources/{code}/deactivate"
+      body: "*"
+    };
+  }
+
+  // ListDataSources returns data sources matching the filter criteria.
+  rpc ListDataSources(ListDataSourcesRequest) returns (ListDataSourcesResponse) {
+    option (google.api.http) = {
+      get: "/v1/market-information/sources"
+    };
+  }
+
+  // ----------------------------------------
+  // Observation Operations
+  // ----------------------------------------
+
+  // RecordObservation records a new market data observation.
+  // Returns INVALID_ARGUMENT if validation fails.
+  // Returns NOT_FOUND if data set or source doesn't exist.
+  rpc RecordObservation(RecordObservationRequest) returns (RecordObservationResponse) {
+    option (google.api.http) = {
+      post: "/v1/market-information/observations"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "201"
+        value: {
+          description: "Observation recorded successfully"
+        }
+      }
+    };
+  }
+
+  // RecordObservationBatch records multiple observations atomically.
+  // Returns partial success with details for each observation.
+  rpc RecordObservationBatch(RecordObservationBatchRequest) returns (RecordObservationBatchResponse) {
+    option (google.api.http) = {
+      post: "/v1/market-information/observations/batch"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "201"
+        value: {
+          description: "Observations recorded successfully"
+        }
+      }
+    };
+  }
+
+  // RetrieveObservation fetches a specific observation with bi-temporal query support.
+  // Returns NOT_FOUND if observation doesn't exist at the requested times.
+  rpc RetrieveObservation(RetrieveObservationRequest) returns (RetrieveObservationResponse) {
+    option (google.api.http) = {
+      get: "/v1/market-information/observations/{observation_id}"
+    };
+  }
+
+  // ListObservations returns observations matching the filter criteria.
+  // Supports filtering by data set, time ranges, quality level, and pagination.
+  rpc ListObservations(ListObservationsRequest) returns (ListObservationsResponse) {
+    option (google.api.http) = {
+      get: "/v1/market-information/datasets/{dataset_code}/observations"
+    };
+  }
+}
+
+// ========================================
+// Request/Response Messages - Data Sets
+// ========================================
+
+// RegisterDataSetRequest contains the data to create a new data set definition.
+message RegisterDataSetRequest {
+  // code is the unique data set code (e.g., "USD_EUR_FX").
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // category is the type of market data.
+  DataCategory category = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // unit describes the unit of measurement.
+  string unit = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+  }];
+
+  // resolution_key_expression is a CEL expression for resolution key generation.
+  string resolution_key_expression = 4 [(buf.validate.field).string.max_len = 2048];
+
+  // validation_expression is a CEL expression for value validation.
+  string validation_expression = 5 [(buf.validate.field).string.max_len = 2048];
+
+  // error_message_expression is a CEL expression for custom error messages.
+  string error_message_expression = 6 [(buf.validate.field).string.max_len = 2048];
+
+  // attribute_schema is a JSON Schema for observation attributes.
+  google.protobuf.Struct attribute_schema = 7;
+
+  // effective_from is when this data set becomes effective.
+  google.protobuf.Timestamp effective_from = 8 [(buf.validate.field).required = true];
+
+  // effective_to is when this data set expires (optional).
+  google.protobuf.Timestamp effective_to = 9;
+
+  // display_name is a human-readable name.
+  string display_name = 10 [(buf.validate.field).string.max_len = 128];
+
+  // description provides additional context.
+  string description = 11 [(buf.validate.field).string.max_len = 1024];
+
+  // idempotency_key ensures exactly-once processing.
+  meridian.common.v1.IdempotencyKey idempotency_key = 12;
+}
+
+// RegisterDataSetResponse returns the created data set definition.
+message RegisterDataSetResponse {
+  // dataset is the created data set in DRAFT status.
+  DataSetDefinition dataset = 1;
+}
+
+// UpdateDataSetRequest modifies an existing DRAFT data set definition.
+message UpdateDataSetRequest {
+  // code identifies which data set to update.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // version identifies which version to update.
+  int32 version = 2 [(buf.validate.field).int32.gte = 1];
+
+  // resolution_key_expression is a CEL expression for resolution key generation.
+  string resolution_key_expression = 3 [(buf.validate.field).string.max_len = 2048];
+
+  // validation_expression is a CEL expression for value validation.
+  string validation_expression = 4 [(buf.validate.field).string.max_len = 2048];
+
+  // error_message_expression is a CEL expression for custom error messages.
+  string error_message_expression = 5 [(buf.validate.field).string.max_len = 2048];
+
+  // attribute_schema is a JSON Schema for observation attributes.
+  google.protobuf.Struct attribute_schema = 6;
+
+  // effective_from is when this data set becomes effective.
+  google.protobuf.Timestamp effective_from = 7;
+
+  // effective_to is when this data set expires (optional).
+  google.protobuf.Timestamp effective_to = 8;
+
+  // display_name is a human-readable name.
+  string display_name = 9 [(buf.validate.field).string.max_len = 128];
+
+  // description provides additional context.
+  string description = 10 [(buf.validate.field).string.max_len = 1024];
+}
+
+// UpdateDataSetResponse returns the updated data set definition.
+message UpdateDataSetResponse {
+  // dataset is the updated data set definition.
+  DataSetDefinition dataset = 1;
+}
+
+// ActivateDataSetRequest transitions a data set from DRAFT to ACTIVE.
+message ActivateDataSetRequest {
+  // code identifies the data set to activate.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // version identifies which version to activate.
+  int32 version = 2 [(buf.validate.field).int32.gte = 1];
+}
+
+// ActivateDataSetResponse returns the activated data set definition.
+message ActivateDataSetResponse {
+  // dataset is the activated data set now in ACTIVE status.
+  DataSetDefinition dataset = 1;
+}
+
+// DeprecateDataSetRequest transitions a data set from ACTIVE to DEPRECATED.
+message DeprecateDataSetRequest {
+  // code identifies the data set to deprecate.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // version identifies which version to deprecate.
+  int32 version = 2 [(buf.validate.field).int32.gte = 1];
+
+  // successor_code optionally specifies the replacement data set.
+  string successor_code = 3 [(buf.validate.field).string.max_len = 64];
+
+  // successor_version optionally specifies the replacement version.
+  int32 successor_version = 4 [(buf.validate.field).int32.gte = 0];
+}
+
+// DeprecateDataSetResponse returns the deprecated data set definition.
+message DeprecateDataSetResponse {
+  // dataset is the deprecated data set now in DEPRECATED status.
+  DataSetDefinition dataset = 1;
+}
+
+// RetrieveDataSetRequest identifies which data set to retrieve.
+message RetrieveDataSetRequest {
+  // code identifies the data set.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // version specifies which version to retrieve.
+  // If 0, returns the latest ACTIVE version.
+  int32 version = 2 [(buf.validate.field).int32.gte = 0];
+
+  // as_of is the point-in-time for temporal queries (optional).
+  google.protobuf.Timestamp as_of = 3;
+}
+
+// RetrieveDataSetResponse returns the requested data set definition.
+message RetrieveDataSetResponse {
+  // dataset is the requested data set definition.
+  DataSetDefinition dataset = 1;
+}
+
+// ListDataSetsRequest specifies filtering and pagination for listing data sets.
+message ListDataSetsRequest {
+  // status_filter returns only data sets with this status.
+  // If UNSPECIFIED, returns all data sets.
+  DataSetStatus status_filter = 1;
+
+  // category_filter returns only data sets with this category.
+  // If UNSPECIFIED, returns all categories.
+  DataCategory category_filter = 2;
+
+  // page_size limits the number of results (max 100).
+  int32 page_size = 3 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 100
+  }];
+
+  // page_token for pagination (from previous response).
+  string page_token = 4;
+}
+
+// ListDataSetsResponse returns a page of data set definitions.
+message ListDataSetsResponse {
+  // datasets is the list of matching data sets.
+  repeated DataSetDefinition datasets = 1;
+
+  // next_page_token for pagination (empty if no more results).
+  string next_page_token = 2;
+}
+
+// ========================================
+// Request/Response Messages - Data Sources
+// ========================================
+
+// RegisterDataSourceRequest contains the data to create a new data source.
+message RegisterDataSourceRequest {
+  // code is the unique source code (e.g., "BLOOMBERG").
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // name is the human-readable name.
+  string name = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 128
+  }];
+
+  // description provides additional context.
+  string description = 3 [(buf.validate.field).string.max_len = 1024];
+
+  // trust_level indicates reliability (0-100).
+  int32 trust_level = 4 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 100
+  }];
+
+  // idempotency_key ensures exactly-once processing.
+  meridian.common.v1.IdempotencyKey idempotency_key = 5;
+}
+
+// RegisterDataSourceResponse returns the created data source.
+message RegisterDataSourceResponse {
+  // source is the created data source.
+  DataSource source = 1;
+}
+
+// UpdateDataSourceRequest modifies an existing data source.
+message UpdateDataSourceRequest {
+  // code identifies which data source to update.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // name is the human-readable name.
+  string name = 2 [(buf.validate.field).string.max_len = 128];
+
+  // description provides additional context.
+  string description = 3 [(buf.validate.field).string.max_len = 1024];
+
+  // trust_level indicates reliability (0-100).
+  int32 trust_level = 4 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 100
+  }];
+}
+
+// UpdateDataSourceResponse returns the updated data source.
+message UpdateDataSourceResponse {
+  // source is the updated data source.
+  DataSource source = 1;
+}
+
+// DeactivateDataSourceRequest marks a data source as inactive.
+message DeactivateDataSourceRequest {
+  // code identifies the data source to deactivate.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+}
+
+// DeactivateDataSourceResponse returns the deactivated data source.
+message DeactivateDataSourceResponse {
+  // source is the deactivated data source.
+  DataSource source = 1;
+}
+
+// ListDataSourcesRequest specifies filtering for listing data sources.
+message ListDataSourcesRequest {
+  // active_only returns only active data sources if true.
+  bool active_only = 1;
+
+  // page_size limits the number of results (max 100).
+  int32 page_size = 2 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 100
+  }];
+
+  // page_token for pagination (from previous response).
+  string page_token = 3;
+}
+
+// ListDataSourcesResponse returns a page of data sources.
+message ListDataSourcesResponse {
+  // sources is the list of matching data sources.
+  repeated DataSource sources = 1;
+
+  // next_page_token for pagination (empty if no more results).
+  string next_page_token = 2;
+}
+
+// ========================================
+// Request/Response Messages - Observations
+// ========================================
+
+// RecordObservationRequest contains the data to record a new observation.
+message RecordObservationRequest {
+  // dataset_code identifies the data set.
+  string dataset_code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // dataset_version is the version of the data set (optional, uses latest if 0).
+  int32 dataset_version = 2 [(buf.validate.field).int32.gte = 0];
+
+  // observed_at is when this observation was made.
+  google.protobuf.Timestamp observed_at = 3 [(buf.validate.field).required = true];
+
+  // valid_from is when this observation value becomes valid.
+  google.protobuf.Timestamp valid_from = 4 [(buf.validate.field).required = true];
+
+  // valid_to is when this observation value expires (optional).
+  google.protobuf.Timestamp valid_to = 5;
+
+  // value is the observed value as a decimal string.
+  string value = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 40
+    pattern: "^-?[0-9]+(\\.[0-9]+)?$"
+  }];
+
+  // quality indicates the confidence level.
+  QualityLevel quality = 7 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // source_code identifies the data source.
+  string source_code = 8 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // attributes contains additional metadata.
+  repeated meridian.quantity.v1.AttributeEntry attributes = 9;
+
+  // supersedes_observation_id optionally indicates this replaces a previous observation.
+  string supersedes_observation_id = 10 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // idempotency_key ensures exactly-once processing.
+  meridian.common.v1.IdempotencyKey idempotency_key = 11;
+}
+
+// RecordObservationResponse returns the recorded observation.
+message RecordObservationResponse {
+  // observation is the recorded observation.
+  MarketPriceObservation observation = 1;
+}
+
+// BatchObservationEntry is a single observation in a batch request.
+message BatchObservationEntry {
+  // dataset_code identifies the data set.
+  string dataset_code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // dataset_version is the version of the data set (optional, uses latest if 0).
+  int32 dataset_version = 2 [(buf.validate.field).int32.gte = 0];
+
+  // observed_at is when this observation was made.
+  google.protobuf.Timestamp observed_at = 3 [(buf.validate.field).required = true];
+
+  // valid_from is when this observation value becomes valid.
+  google.protobuf.Timestamp valid_from = 4 [(buf.validate.field).required = true];
+
+  // valid_to is when this observation value expires (optional).
+  google.protobuf.Timestamp valid_to = 5;
+
+  // value is the observed value as a decimal string.
+  string value = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 40
+    pattern: "^-?[0-9]+(\\.[0-9]+)?$"
+  }];
+
+  // quality indicates the confidence level.
+  QualityLevel quality = 7 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // source_code identifies the data source.
+  string source_code = 8 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // attributes contains additional metadata.
+  repeated meridian.quantity.v1.AttributeEntry attributes = 9;
+
+  // client_reference is an optional client-provided reference for correlation.
+  string client_reference = 10 [(buf.validate.field).string.max_len = 128];
+}
+
+// RecordObservationBatchRequest records multiple observations.
+message RecordObservationBatchRequest {
+  // observations is the list of observations to record (1-1000 items).
+  repeated BatchObservationEntry observations = 1 [(buf.validate.field).repeated = {
+    min_items: 1
+    max_items: 1000
+  }];
+
+  // idempotency_key ensures exactly-once processing for the entire batch.
+  meridian.common.v1.IdempotencyKey idempotency_key = 2;
+
+  // batch_id is an optional client-provided batch identifier for tracking.
+  string batch_id = 3 [(buf.validate.field).string.uuid = true];
+}
+
+// BatchObservationResult contains the result for a single observation in a batch.
+message BatchObservationResult {
+  // success indicates whether this observation was recorded successfully.
+  bool success = 1;
+
+  // observation is the recorded observation (present only if success is true).
+  MarketPriceObservation observation = 2;
+
+  // error_message provides details if success is false.
+  string error_message = 3;
+
+  // client_reference is the client-provided reference from the request.
+  string client_reference = 4;
+
+  // index is the position in the original request for correlation.
+  int32 index = 5;
+}
+
+// RecordObservationBatchResponse returns results for all observations.
+message RecordObservationBatchResponse {
+  // results contains the outcome for each observation (same order as input).
+  repeated BatchObservationResult results = 1;
+
+  // batch_id is the batch identifier (client-provided or server-generated).
+  string batch_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // total_count is the total number of observations in the batch.
+  int32 total_count = 3;
+
+  // success_count is the number of observations successfully recorded.
+  int32 success_count = 4;
+
+  // failure_count is the number of observations that failed.
+  int32 failure_count = 5;
+}
+
+// RetrieveObservationRequest fetches a specific observation with bi-temporal support.
+message RetrieveObservationRequest {
+  // observation_id is the UUID of the observation to retrieve.
+  string observation_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // knowledge_base_time is the "as-known-at" time for bi-temporal queries (optional).
+  // If not specified, returns the current knowledge.
+  google.protobuf.Timestamp knowledge_base_time = 2;
+}
+
+// RetrieveObservationResponse returns the requested observation.
+message RetrieveObservationResponse {
+  // observation is the requested observation.
+  MarketPriceObservation observation = 1;
+}
+
+// ListObservationsRequest specifies filtering for listing observations.
+message ListObservationsRequest {
+  // dataset_code identifies the data set (required).
+  string dataset_code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // dataset_version filters by data set version (optional, 0 for all versions).
+  int32 dataset_version = 2 [(buf.validate.field).int32.gte = 0];
+
+  // resolution_key_value filters by resolution key (optional).
+  string resolution_key_value = 3 [(buf.validate.field).string.max_len = 256];
+
+  // observed_from filters observations made on or after this time.
+  google.protobuf.Timestamp observed_from = 4;
+
+  // observed_to filters observations made before this time.
+  google.protobuf.Timestamp observed_to = 5;
+
+  // valid_at filters observations valid at this point in time.
+  google.protobuf.Timestamp valid_at = 6;
+
+  // knowledge_base_time is the "as-known-at" time for bi-temporal queries.
+  google.protobuf.Timestamp knowledge_base_time = 7;
+
+  // quality_filter returns only observations with this quality level.
+  QualityLevel quality_filter = 8;
+
+  // source_code filters by data source (optional).
+  string source_code = 9 [(buf.validate.field).string.max_len = 32];
+
+  // include_superseded includes superseded observations if true.
+  bool include_superseded = 10;
+
+  // page_size limits the number of results (max 1000).
+  int32 page_size = 11 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 1000
+  }];
+
+  // page_token for pagination (from previous response).
+  string page_token = 12;
+}
+
+// ListObservationsResponse returns a page of observations.
+message ListObservationsResponse {
+  // observations is the list of matching observations.
+  repeated MarketPriceObservation observations = 1;
+
+  // next_page_token for pagination (empty if no more results).
+  string next_page_token = 2;
+
+  // total_count is the total number of matching observations (if known).
+  int32 total_count = 3;
+}

--- a/api/proto/meridian/market_information/v1/market_information_test.go
+++ b/api/proto/meridian/market_information/v1/market_information_test.go
@@ -1,0 +1,1084 @@
+package marketinformationv1_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"buf.build/go/protovalidate"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// testValidator is the shared validator instance for all validation tests.
+var testValidator protovalidate.Validator
+
+func TestMain(m *testing.M) {
+	var err error
+	testValidator, err = protovalidate.New()
+	if err != nil {
+		panic(fmt.Sprintf("failed to create validator: %v", err))
+	}
+	os.Exit(m.Run())
+}
+
+// TestDataCategoryEnum verifies all DataCategory enum values are defined.
+func TestDataCategoryEnum(t *testing.T) {
+	expected := []marketinformationv1.DataCategory{
+		marketinformationv1.DataCategory_DATA_CATEGORY_UNSPECIFIED,
+		marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+		marketinformationv1.DataCategory_DATA_CATEGORY_INTEREST_RATE,
+		marketinformationv1.DataCategory_DATA_CATEGORY_COMMODITY_PRICE,
+		marketinformationv1.DataCategory_DATA_CATEGORY_EQUITY_PRICE,
+		marketinformationv1.DataCategory_DATA_CATEGORY_INDEX_VALUE,
+		marketinformationv1.DataCategory_DATA_CATEGORY_ENERGY_PRICE,
+		marketinformationv1.DataCategory_DATA_CATEGORY_CARBON_PRICE,
+		marketinformationv1.DataCategory_DATA_CATEGORY_BENCHMARK_RATE,
+		marketinformationv1.DataCategory_DATA_CATEGORY_VOLATILITY,
+		marketinformationv1.DataCategory_DATA_CATEGORY_CREDIT_SPREAD,
+	}
+
+	for i, cat := range expected {
+		if int32(cat) != int32(i) {
+			t.Errorf("DataCategory %s has unexpected value %d, expected %d", cat, int32(cat), i)
+		}
+	}
+
+	// Verify total count matches
+	if len(marketinformationv1.DataCategory_name) != len(expected) {
+		t.Errorf("expected %d data categories, got %d", len(expected), len(marketinformationv1.DataCategory_name))
+	}
+}
+
+// TestDataSetStatusEnum verifies all DataSetStatus enum values.
+func TestDataSetStatusEnum(t *testing.T) {
+	expected := []marketinformationv1.DataSetStatus{
+		marketinformationv1.DataSetStatus_DATA_SET_STATUS_UNSPECIFIED,
+		marketinformationv1.DataSetStatus_DATA_SET_STATUS_DRAFT,
+		marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+		marketinformationv1.DataSetStatus_DATA_SET_STATUS_DEPRECATED,
+	}
+
+	for i, status := range expected {
+		if int32(status) != int32(i) {
+			t.Errorf("DataSetStatus %s has unexpected value %d, expected %d", status, int32(status), i)
+		}
+	}
+
+	// Verify total count
+	if len(marketinformationv1.DataSetStatus_name) != len(expected) {
+		t.Errorf("expected %d statuses, got %d", len(expected), len(marketinformationv1.DataSetStatus_name))
+	}
+}
+
+// TestQualityLevelEnum verifies all QualityLevel enum values.
+func TestQualityLevelEnum(t *testing.T) {
+	expected := []marketinformationv1.QualityLevel{
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_UNSPECIFIED,
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_PROVISIONAL,
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_REVISED,
+	}
+
+	for i, ql := range expected {
+		if int32(ql) != int32(i) {
+			t.Errorf("QualityLevel %s has unexpected value %d, expected %d", ql, int32(ql), i)
+		}
+	}
+
+	// Verify total count
+	if len(marketinformationv1.QualityLevel_name) != len(expected) {
+		t.Errorf("expected %d quality levels, got %d", len(expected), len(marketinformationv1.QualityLevel_name))
+	}
+}
+
+// TestDataSetDefinitionValidation verifies DataSetDefinition validation constraints.
+func TestDataSetDefinitionValidation(t *testing.T) {
+	now := timestamppb.Now()
+	validUUID := "123e4567-e89b-12d3-a456-426614174000"
+
+	tests := []struct {
+		name    string
+		def     *marketinformationv1.DataSetDefinition
+		wantErr bool
+	}{
+		{
+			name: "valid minimal definition",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:            validUUID,
+				Code:          "USD_EUR_FX",
+				Version:       1,
+				Category:      marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:          "USD/EUR",
+				Status:        marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				EffectiveFrom: now,
+				CreatedAt:     now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid full definition with CEL expressions",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:                      validUUID,
+				Code:                    "BRENT_CRUDE",
+				Version:                 1,
+				Category:                marketinformationv1.DataCategory_DATA_CATEGORY_COMMODITY_PRICE,
+				Unit:                    "USD/BBL",
+				ResolutionKeyExpression: "tenor + ':' + settlement",
+				ValidationExpression:    "value > 0 && value < 10000",
+				ErrorMessageExpression:  "'Invalid price: ' + string(value)",
+				Status:                  marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				EffectiveFrom:           now,
+				DisplayName:             "Brent Crude Oil",
+				Description:             "Brent crude oil spot price",
+				CreatedAt:               now,
+				UpdatedAt:               now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid DRAFT status",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:            validUUID,
+				Code:          "NEW_RATE",
+				Version:       1,
+				Category:      marketinformationv1.DataCategory_DATA_CATEGORY_INTEREST_RATE,
+				Unit:          "percent",
+				Status:        marketinformationv1.DataSetStatus_DATA_SET_STATUS_DRAFT,
+				EffectiveFrom: now,
+				CreatedAt:     now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: missing id",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:            "",
+				Code:          "USD_EUR_FX",
+				Version:       1,
+				Category:      marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:          "USD/EUR",
+				Status:        marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				EffectiveFrom: now,
+				CreatedAt:     now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: malformed UUID",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:            "not-a-uuid",
+				Code:          "USD_EUR_FX",
+				Version:       1,
+				Category:      marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:          "USD/EUR",
+				Status:        marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				EffectiveFrom: now,
+				CreatedAt:     now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: empty code",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:            validUUID,
+				Code:          "",
+				Version:       1,
+				Category:      marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:          "USD/EUR",
+				Status:        marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				EffectiveFrom: now,
+				CreatedAt:     now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: lowercase code",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:            validUUID,
+				Code:          "usd_eur_fx",
+				Version:       1,
+				Category:      marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:          "USD/EUR",
+				Status:        marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				EffectiveFrom: now,
+				CreatedAt:     now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: version is zero",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:            validUUID,
+				Code:          "USD_EUR_FX",
+				Version:       0,
+				Category:      marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:          "USD/EUR",
+				Status:        marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				EffectiveFrom: now,
+				CreatedAt:     now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: DATA_CATEGORY_UNSPECIFIED",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:            validUUID,
+				Code:          "USD_EUR_FX",
+				Version:       1,
+				Category:      marketinformationv1.DataCategory_DATA_CATEGORY_UNSPECIFIED,
+				Unit:          "USD/EUR",
+				Status:        marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				EffectiveFrom: now,
+				CreatedAt:     now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: DATA_SET_STATUS_UNSPECIFIED",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:            validUUID,
+				Code:          "USD_EUR_FX",
+				Version:       1,
+				Category:      marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:          "USD/EUR",
+				Status:        marketinformationv1.DataSetStatus_DATA_SET_STATUS_UNSPECIFIED,
+				EffectiveFrom: now,
+				CreatedAt:     now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: empty unit",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:            validUUID,
+				Code:          "USD_EUR_FX",
+				Version:       1,
+				Category:      marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:          "",
+				Status:        marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				EffectiveFrom: now,
+				CreatedAt:     now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: missing effective_from",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:        validUUID,
+				Code:      "USD_EUR_FX",
+				Version:   1,
+				Category:  marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:      "USD/EUR",
+				Status:    marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				CreatedAt: now,
+				// EffectiveFrom: nil - missing required field
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: missing created_at",
+			def: &marketinformationv1.DataSetDefinition{
+				Id:            validUUID,
+				Code:          "USD_EUR_FX",
+				Version:       1,
+				Category:      marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+				Unit:          "USD/EUR",
+				Status:        marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+				EffectiveFrom: now,
+				// CreatedAt: nil - missing required field
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testValidator.Validate(tt.def)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestMarketPriceObservationValidation verifies MarketPriceObservation validation constraints.
+func TestMarketPriceObservationValidation(t *testing.T) {
+	now := timestamppb.Now()
+	validUUID := "123e4567-e89b-12d3-a456-426614174000"
+	sourceUUID := "987fcdeb-51a2-3e4f-b6c7-890123456789"
+
+	tests := []struct {
+		name    string
+		obs     *marketinformationv1.MarketPriceObservation
+		wantErr bool
+	}{
+		{
+			name: "valid minimal observation",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "1.2345",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:       sourceUUID,
+				CreatedAt:      now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid full observation with attributes",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:                 validUUID,
+				DatasetCode:        "SOFR_3M",
+				DatasetVersion:     2,
+				ResolutionKeyValue: "3M:T+2",
+				ObservedAt:         now,
+				ValidFrom:          now,
+				ValidTo:            timestamppb.Now(),
+				Value:              "5.25",
+				Quality:            marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:           sourceUUID,
+				CreatedAt:          now,
+				Attributes: []*quantityv1.AttributeEntry{
+					{Key: "tenor", Value: "3M"},
+					{Key: "settlement", Value: "T+2"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid negative value",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "EUR_INTEREST",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "-0.50",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:       sourceUUID,
+				CreatedAt:      now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid ESTIMATE quality",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "1.2345",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+				SourceId:       sourceUUID,
+				CreatedAt:      now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid PROVISIONAL quality",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "1.2345",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_PROVISIONAL,
+				SourceId:       sourceUUID,
+				CreatedAt:      now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid REVISED quality with supersession",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "1.2346",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_REVISED,
+				SourceId:       sourceUUID,
+				CreatedAt:      now,
+				SupersededAt:   now,
+				SupersededById: "abcdef01-2345-6789-abcd-ef0123456789",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: missing id",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             "",
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "1.2345",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:       sourceUUID,
+				CreatedAt:      now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: empty dataset_code",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "1.2345",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:       sourceUUID,
+				CreatedAt:      now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: lowercase dataset_code",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "usd_eur_fx",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "1.2345",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:       sourceUUID,
+				CreatedAt:      now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: version is zero",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 0,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "1.2345",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:       sourceUUID,
+				CreatedAt:      now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: malformed value",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "not-a-number",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:       sourceUUID,
+				CreatedAt:      now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: QUALITY_LEVEL_UNSPECIFIED",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "1.2345",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_UNSPECIFIED,
+				SourceId:       sourceUUID,
+				CreatedAt:      now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: missing observed_at",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 1,
+				// ObservedAt: nil
+				ValidFrom: now,
+				Value:     "1.2345",
+				Quality:   marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:  sourceUUID,
+				CreatedAt: now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: missing valid_from",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				// ValidFrom: nil
+				Value:     "1.2345",
+				Quality:   marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:  sourceUUID,
+				CreatedAt: now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: missing source_id",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "1.2345",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:       "",
+				CreatedAt:      now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: malformed source_id",
+			obs: &marketinformationv1.MarketPriceObservation{
+				Id:             validUUID,
+				DatasetCode:    "USD_EUR_FX",
+				DatasetVersion: 1,
+				ObservedAt:     now,
+				ValidFrom:      now,
+				Value:          "1.2345",
+				Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceId:       "not-a-uuid",
+				CreatedAt:      now,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testValidator.Validate(tt.obs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestDataSourceValidation verifies DataSource validation constraints.
+func TestDataSourceValidation(t *testing.T) {
+	now := timestamppb.Now()
+	validUUID := "123e4567-e89b-12d3-a456-426614174000"
+
+	tests := []struct {
+		name    string
+		src     *marketinformationv1.DataSource
+		wantErr bool
+	}{
+		{
+			name: "valid minimal data source",
+			src: &marketinformationv1.DataSource{
+				Id:         validUUID,
+				Code:       "BLOOMBERG",
+				Name:       "Bloomberg LP",
+				TrustLevel: 90,
+				IsActive:   true,
+				CreatedAt:  now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid full data source",
+			src: &marketinformationv1.DataSource{
+				Id:          validUUID,
+				Code:        "ECB",
+				Name:        "European Central Bank",
+				Description: "Official ECB reference rates",
+				TrustLevel:  100,
+				IsActive:    true,
+				CreatedAt:   now,
+				UpdatedAt:   now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid: trust_level at minimum (0)",
+			src: &marketinformationv1.DataSource{
+				Id:         validUUID,
+				Code:       "MANUAL",
+				Name:       "Manual Entry",
+				TrustLevel: 0,
+				IsActive:   true,
+				CreatedAt:  now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid: trust_level at maximum (100)",
+			src: &marketinformationv1.DataSource{
+				Id:         validUUID,
+				Code:       "OFFICIAL",
+				Name:       "Official Source",
+				TrustLevel: 100,
+				IsActive:   true,
+				CreatedAt:  now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: missing id",
+			src: &marketinformationv1.DataSource{
+				Id:         "",
+				Code:       "BLOOMBERG",
+				Name:       "Bloomberg LP",
+				TrustLevel: 90,
+				IsActive:   true,
+				CreatedAt:  now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: empty code",
+			src: &marketinformationv1.DataSource{
+				Id:         validUUID,
+				Code:       "",
+				Name:       "Bloomberg LP",
+				TrustLevel: 90,
+				IsActive:   true,
+				CreatedAt:  now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: lowercase code",
+			src: &marketinformationv1.DataSource{
+				Id:         validUUID,
+				Code:       "bloomberg",
+				Name:       "Bloomberg LP",
+				TrustLevel: 90,
+				IsActive:   true,
+				CreatedAt:  now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: empty name",
+			src: &marketinformationv1.DataSource{
+				Id:         validUUID,
+				Code:       "BLOOMBERG",
+				Name:       "",
+				TrustLevel: 90,
+				IsActive:   true,
+				CreatedAt:  now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: trust_level negative",
+			src: &marketinformationv1.DataSource{
+				Id:         validUUID,
+				Code:       "BLOOMBERG",
+				Name:       "Bloomberg LP",
+				TrustLevel: -1,
+				IsActive:   true,
+				CreatedAt:  now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: trust_level exceeds 100",
+			src: &marketinformationv1.DataSource{
+				Id:         validUUID,
+				Code:       "BLOOMBERG",
+				Name:       "Bloomberg LP",
+				TrustLevel: 101,
+				IsActive:   true,
+				CreatedAt:  now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: missing created_at",
+			src: &marketinformationv1.DataSource{
+				Id:         validUUID,
+				Code:       "BLOOMBERG",
+				Name:       "Bloomberg LP",
+				TrustLevel: 90,
+				IsActive:   true,
+				// CreatedAt: nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testValidator.Validate(tt.src)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestObservationRecordedEvent verifies ObservationRecorded event validation.
+func TestObservationRecordedEvent(t *testing.T) {
+	now := timestamppb.Now()
+	validUUID := "123e4567-e89b-12d3-a456-426614174000"
+	sourceUUID := "987fcdeb-51a2-3e4f-b6c7-890123456789"
+
+	tests := []struct {
+		name    string
+		event   *marketinformationv1.ObservationRecorded
+		wantErr bool
+	}{
+		{
+			name: "valid event",
+			event: &marketinformationv1.ObservationRecorded{
+				ObservationId:      validUUID,
+				DatasetCode:        "USD_EUR_FX",
+				ResolutionKeyValue: "spot",
+				ObservedAt:         now,
+				Quality:            marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				Value:              "1.2345",
+				SourceId:           sourceUUID,
+				RecordedAt:         now,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid event with supersession",
+			event: &marketinformationv1.ObservationRecorded{
+				ObservationId:           validUUID,
+				DatasetCode:             "USD_EUR_FX",
+				ObservedAt:              now,
+				Quality:                 marketinformationv1.QualityLevel_QUALITY_LEVEL_REVISED,
+				Value:                   "1.2346",
+				SourceId:                sourceUUID,
+				RecordedAt:              now,
+				SupersedesObservationId: "abcdef01-2345-6789-abcd-ef0123456789",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: missing observation_id",
+			event: &marketinformationv1.ObservationRecorded{
+				ObservationId: "",
+				DatasetCode:   "USD_EUR_FX",
+				ObservedAt:    now,
+				Quality:       marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				Value:         "1.2345",
+				SourceId:      sourceUUID,
+				RecordedAt:    now,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: missing source_id",
+			event: &marketinformationv1.ObservationRecorded{
+				ObservationId: validUUID,
+				DatasetCode:   "USD_EUR_FX",
+				ObservedAt:    now,
+				Quality:       marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				Value:         "1.2345",
+				SourceId:      "",
+				RecordedAt:    now,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testValidator.Validate(tt.event)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestDataSetDefinitionSerialization verifies round-trip serialization.
+func TestDataSetDefinitionSerialization(t *testing.T) {
+	now := timestamppb.Now()
+	validUUID := "123e4567-e89b-12d3-a456-426614174000"
+
+	attrSchema, _ := structpb.NewStruct(map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"tenor": map[string]interface{}{"type": "string"},
+		},
+	})
+
+	original := &marketinformationv1.DataSetDefinition{
+		Id:                      validUUID,
+		Code:                    "SOFR_CURVE",
+		Version:                 2,
+		Category:                marketinformationv1.DataCategory_DATA_CATEGORY_INTEREST_RATE,
+		Unit:                    "percent",
+		ResolutionKeyExpression: "tenor",
+		ValidationExpression:    "value >= -10 && value <= 50",
+		ErrorMessageExpression:  "'Rate out of range'",
+		AttributeSchema:         attrSchema,
+		Status:                  marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+		EffectiveFrom:           now,
+		EffectiveTo:             now,
+		DisplayName:             "SOFR Interest Rate Curve",
+		Description:             "SOFR interest rate curve by tenor",
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+
+	data, err := proto.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	decoded := &marketinformationv1.DataSetDefinition{}
+	if err := proto.Unmarshal(data, decoded); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if !proto.Equal(original, decoded) {
+		t.Error("round-trip serialization produced different message")
+	}
+
+	// Verify specific fields
+	if decoded.Id != original.Id {
+		t.Errorf("id mismatch: got %v, want %v", decoded.Id, original.Id)
+	}
+	if decoded.Code != original.Code {
+		t.Errorf("code mismatch: got %v, want %v", decoded.Code, original.Code)
+	}
+	if decoded.Category != original.Category {
+		t.Errorf("category mismatch: got %v, want %v", decoded.Category, original.Category)
+	}
+	if decoded.Status != original.Status {
+		t.Errorf("status mismatch: got %v, want %v", decoded.Status, original.Status)
+	}
+}
+
+// TestMarketPriceObservationSerialization verifies round-trip serialization.
+func TestMarketPriceObservationSerialization(t *testing.T) {
+	now := timestamppb.Now()
+	validUUID := "123e4567-e89b-12d3-a456-426614174000"
+	sourceUUID := "987fcdeb-51a2-3e4f-b6c7-890123456789"
+
+	original := &marketinformationv1.MarketPriceObservation{
+		Id:                 validUUID,
+		DatasetCode:        "USD_EUR_FX",
+		DatasetVersion:     1,
+		ResolutionKeyValue: "spot",
+		ObservedAt:         now,
+		ValidFrom:          now,
+		Value:              "1.23456789",
+		Quality:            marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+		SourceId:           sourceUUID,
+		CreatedAt:          now,
+		Attributes: []*quantityv1.AttributeEntry{
+			{Key: "bid", Value: "1.23450"},
+			{Key: "ask", Value: "1.23462"},
+		},
+	}
+
+	data, err := proto.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	decoded := &marketinformationv1.MarketPriceObservation{}
+	if err := proto.Unmarshal(data, decoded); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if !proto.Equal(original, decoded) {
+		t.Error("round-trip serialization produced different message")
+	}
+
+	// Verify value precision is preserved
+	if decoded.Value != original.Value {
+		t.Errorf("value precision not preserved: got %v, want %v", decoded.Value, original.Value)
+	}
+
+	// Verify attributes are preserved
+	if len(decoded.Attributes) != len(original.Attributes) {
+		t.Errorf("attributes count mismatch: got %d, want %d", len(decoded.Attributes), len(original.Attributes))
+	}
+}
+
+// TestServiceClientInterface verifies service client interface exists with all methods.
+func TestServiceClientInterface(_ *testing.T) {
+	// This test verifies the gRPC client interface has all expected methods.
+	// We can't instantiate a client without a connection, but we can verify
+	// the interface exists by checking its type.
+
+	var client marketinformationv1.MarketInformationServiceClient
+	_ = client // Verifies the type exists
+
+	// The interface should have these methods (verified by compilation):
+	// - RegisterDataSet
+	// - UpdateDataSet
+	// - ActivateDataSet
+	// - DeprecateDataSet
+	// - RetrieveDataSet
+	// - ListDataSets
+	// - RegisterDataSource
+	// - UpdateDataSource
+	// - DeactivateDataSource
+	// - ListDataSources
+	// - RecordObservation
+	// - RecordObservationBatch
+	// - RetrieveObservation
+	// - ListObservations
+}
+
+// TestRequestResponseMessages verifies all request/response message types can be instantiated.
+func TestRequestResponseMessages(_ *testing.T) {
+	now := timestamppb.Now()
+
+	// Data Set requests
+	_ = &marketinformationv1.RegisterDataSetRequest{
+		Code:          "TEST",
+		Category:      marketinformationv1.DataCategory_DATA_CATEGORY_FX_RATE,
+		Unit:          "USD/EUR",
+		EffectiveFrom: now,
+	}
+	_ = &marketinformationv1.RegisterDataSetResponse{}
+	_ = &marketinformationv1.UpdateDataSetRequest{Code: "TEST", Version: 1}
+	_ = &marketinformationv1.UpdateDataSetResponse{}
+	_ = &marketinformationv1.ActivateDataSetRequest{Code: "TEST", Version: 1}
+	_ = &marketinformationv1.ActivateDataSetResponse{}
+	_ = &marketinformationv1.DeprecateDataSetRequest{Code: "TEST", Version: 1}
+	_ = &marketinformationv1.DeprecateDataSetResponse{}
+	_ = &marketinformationv1.RetrieveDataSetRequest{Code: "TEST"}
+	_ = &marketinformationv1.RetrieveDataSetResponse{}
+	_ = &marketinformationv1.ListDataSetsRequest{}
+	_ = &marketinformationv1.ListDataSetsResponse{}
+
+	// Data Source requests
+	_ = &marketinformationv1.RegisterDataSourceRequest{Code: "TEST", Name: "Test"}
+	_ = &marketinformationv1.RegisterDataSourceResponse{}
+	_ = &marketinformationv1.UpdateDataSourceRequest{Code: "TEST"}
+	_ = &marketinformationv1.UpdateDataSourceResponse{}
+	_ = &marketinformationv1.DeactivateDataSourceRequest{Code: "TEST"}
+	_ = &marketinformationv1.DeactivateDataSourceResponse{}
+	_ = &marketinformationv1.ListDataSourcesRequest{}
+	_ = &marketinformationv1.ListDataSourcesResponse{}
+
+	// Observation requests
+	_ = &marketinformationv1.RecordObservationRequest{
+		DatasetCode: "TEST",
+		Value:       "1.0",
+		ObservedAt:  now,
+		ValidFrom:   now,
+	}
+	_ = &marketinformationv1.RecordObservationResponse{}
+	_ = &marketinformationv1.RecordObservationBatchRequest{
+		Observations: []*marketinformationv1.BatchObservationEntry{
+			{DatasetCode: "TEST", Value: "1.0", ObservedAt: now, ValidFrom: now},
+		},
+	}
+	_ = &marketinformationv1.RecordObservationBatchResponse{}
+	_ = &marketinformationv1.RetrieveObservationRequest{ObservationId: "123e4567-e89b-12d3-a456-426614174000"}
+	_ = &marketinformationv1.RetrieveObservationResponse{}
+	_ = &marketinformationv1.ListObservationsRequest{DatasetCode: "TEST"}
+	_ = &marketinformationv1.ListObservationsResponse{}
+
+	// Batch types
+	_ = &marketinformationv1.BatchObservationEntry{}
+	_ = &marketinformationv1.BatchObservationResult{}
+}
+
+// TestRecordObservationRequestValidation verifies RecordObservationRequest validation.
+func TestRecordObservationRequestValidation(t *testing.T) {
+	now := timestamppb.Now()
+
+	tests := []struct {
+		name    string
+		req     *marketinformationv1.RecordObservationRequest
+		wantErr bool
+	}{
+		{
+			name: "valid request",
+			req: &marketinformationv1.RecordObservationRequest{
+				DatasetCode: "USD_EUR_FX",
+				ObservedAt:  now,
+				ValidFrom:   now,
+				Value:       "1.2345",
+				Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceCode:  "BLOOMBERG",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with supersession",
+			req: &marketinformationv1.RecordObservationRequest{
+				DatasetCode:             "USD_EUR_FX",
+				ObservedAt:              now,
+				ValidFrom:               now,
+				Value:                   "1.2345",
+				Quality:                 marketinformationv1.QualityLevel_QUALITY_LEVEL_REVISED,
+				SourceCode:              "BLOOMBERG",
+				SupersedesObservationId: "123e4567-e89b-12d3-a456-426614174000",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: empty dataset_code",
+			req: &marketinformationv1.RecordObservationRequest{
+				DatasetCode: "",
+				ObservedAt:  now,
+				ValidFrom:   now,
+				Value:       "1.2345",
+				Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceCode:  "BLOOMBERG",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: malformed value",
+			req: &marketinformationv1.RecordObservationRequest{
+				DatasetCode: "USD_EUR_FX",
+				ObservedAt:  now,
+				ValidFrom:   now,
+				Value:       "abc",
+				Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+				SourceCode:  "BLOOMBERG",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: QUALITY_LEVEL_UNSPECIFIED",
+			req: &marketinformationv1.RecordObservationRequest{
+				DatasetCode: "USD_EUR_FX",
+				ObservedAt:  now,
+				ValidFrom:   now,
+				Value:       "1.2345",
+				Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_UNSPECIFIED,
+				SourceCode:  "BLOOMBERG",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testValidator.Validate(tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Define complete protobuf definitions for Market Information Management service following BIAN v13.0 specification
- Implement 14 gRPC methods with bi-temporal query support for managing market data sets, observations, and data sources
- Add comprehensive validation constraints and smoke tests

## Changes Made

### Proto Definitions (`api/proto/meridian/market_information/v1/market_information.proto`)

**Enums:**
- `DataCategory`: FX_RATE, INTEREST_RATE, COMMODITY_PRICE, EQUITY_PRICE, INDEX_VALUE, ENERGY_PRICE, CARBON_PRICE, BENCHMARK_RATE, VOLATILITY, CREDIT_SPREAD
- `DataSetStatus`: DRAFT, ACTIVE, DEPRECATED
- `QualityLevel`: ESTIMATE, PROVISIONAL, ACTUAL, REVISED

**Core Messages:**
- `DataSetDefinition`: Market data set configuration with CEL expressions for resolution keys, validation, and error messages
- `MarketPriceObservation`: Individual observation with bi-temporal support (observed_at, valid_from/to, created_at, superseded_at)
- `DataSource`: Data provider with trust levels for conflict resolution
- `ObservationRecorded`: Event message for observation creation

**Service RPCs (14 methods):**
- Data Sets: RegisterDataSet, UpdateDataSet, ActivateDataSet, DeprecateDataSet, RetrieveDataSet, ListDataSets
- Data Sources: RegisterDataSource, UpdateDataSource, DeactivateDataSource, ListDataSources
- Observations: RecordObservation, RecordObservationBatch, RetrieveObservation, ListObservations

### Smoke Tests (`market_information_test.go`)

- Enum value verification
- Validation constraint tests for all message types
- Round-trip serialization tests
- Service client interface verification
- Request/response message instantiation tests

## Technical Details

- Package: `meridian.market_information.v1`
- Go package: `marketinformationv1`
- Follows existing proto patterns from `reference_data/v1` and `quantity/v1`
- Uses `buf.validate` constraints for field validation
- Includes `google.api.http` annotations for REST gateway support
- OpenAPI v2 annotations for Swagger documentation

## Testing

```bash
go test -v ./api/proto/meridian/market_information/v1/...
```

All tests pass (11 test functions, 60+ test cases).

## Task Master

- Tag: `market-information-management`
- Task: `market-information-management.1` - Define Proto API and Generate gRPC Stubs

## Checklist

- [x] Proto definitions compile without errors
- [x] `buf lint` passes
- [x] `buf breaking` passes (no breaking changes)
- [x] Generated Go code compiles
- [x] Smoke tests pass
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)