### PR TITLE
feat(market-information): Implement PostgreSQL repository adapters

### DIFF
--- a/services/market-information/adapters/persistence/base_repository.go
+++ b/services/market-information/adapters/persistence/base_repository.go
@@ -1,0 +1,107 @@
+// Package persistence provides PostgreSQL persistence implementations for the Market Information service.
+package persistence
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// baseRepository provides common transaction and tenant scoping functionality.
+// All repository implementations embed this type to share tenant isolation logic.
+type baseRepository struct {
+	pool *pgxpool.Pool
+}
+
+// newBaseRepository creates a new base repository with the given connection pool.
+func newBaseRepository(pool *pgxpool.Pool) baseRepository {
+	return baseRepository{pool: pool}
+}
+
+// setSearchPath sets the PostgreSQL search_path for the transaction.
+// In multi-tenant mode, it sets the search_path to the tenant's schema.
+// In single-tenant mode (no tenant context), it does nothing.
+//
+// This must be called immediately after tx.Begin() to ensure all queries
+// in the transaction are scoped to the correct tenant schema.
+func (r *baseRepository) setSearchPath(ctx context.Context, tx pgx.Tx) error {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		// Single-tenant mode: no scoping needed
+		return nil
+	}
+
+	// Quote the schema name to prevent SQL injection
+	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
+
+	// SET LOCAL is transaction-scoped - automatically reverts on commit/rollback
+	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	_, err := tx.Exec(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to set tenant schema scope: %w", err)
+	}
+
+	return nil
+}
+
+// withReadTransaction executes a read-only function within a transaction with tenant scoping.
+// In multi-tenant mode, it wraps the function in a transaction with search_path set.
+// In single-tenant mode, it still uses a transaction for consistency but without search_path.
+// This is necessary because PostgreSQL's SET LOCAL requires a transaction context.
+func (r *baseRepository) withReadTransaction(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	// Set tenant scope if in multi-tenant mode
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+
+	// Commit the read-only transaction
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit read transaction: %w", err)
+	}
+
+	return nil
+}
+
+// withWriteTransaction executes a write function within a transaction with tenant scoping.
+// The function is responsible for committing the transaction on success.
+// On error, the transaction is automatically rolled back.
+func (r *baseRepository) withWriteTransaction(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	// Set tenant scope if in multi-tenant mode
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit write transaction: %w", err)
+	}
+
+	return nil
+}

--- a/services/market-information/adapters/persistence/dataset_repository.go
+++ b/services/market-information/adapters/persistence/dataset_repository.go
@@ -1,0 +1,347 @@
+// Package persistence provides PostgreSQL persistence implementations for the Market Information service.
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+)
+
+// DataSetRepository implements domain.DataSetRepository using PostgreSQL.
+type DataSetRepository struct {
+	baseRepository
+}
+
+// NewDataSetRepository creates a new PostgreSQL dataset repository.
+func NewDataSetRepository(pool *pgxpool.Pool) *DataSetRepository {
+	return &DataSetRepository{
+		baseRepository: newBaseRepository(pool),
+	}
+}
+
+// Save persists a new or updated dataset definition.
+// For new datasets, returns ErrDuplicateDataSetCode if the code already exists.
+// For updates, returns ErrVersionMismatch on optimistic lock failure.
+func (r *DataSetRepository) Save(ctx context.Context, dataset domain.DataSetDefinition) error {
+	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		userID := getUserFromContext(ctx)
+		entity := DataSetDefinitionToEntity(dataset)
+
+		// Check if this is an insert or update by looking for existing record
+		var existingVersion int
+		checkQuery := `SELECT version FROM dataset_definition WHERE id = $1 AND deleted_at IS NULL`
+		err := tx.QueryRow(ctx, checkQuery, entity.ID).Scan(&existingVersion)
+
+		if errors.Is(err, pgx.ErrNoRows) {
+			// New record - insert
+			return r.insertDataSet(ctx, tx, entity, userID)
+		} else if err != nil {
+			return fmt.Errorf("failed to check existing dataset: %w", err)
+		}
+
+		// Existing record - update with optimistic locking
+		return r.updateDataSet(ctx, tx, entity, userID, existingVersion)
+	})
+}
+
+func (r *DataSetRepository) insertDataSet(ctx context.Context, tx pgx.Tx, entity DataSetDefinitionEntity, userID string) error {
+	query := `
+		INSERT INTO dataset_definition (
+			id, code, version, name, description, data_category,
+			validation_expression, resolution_key_expression, error_message_expression,
+			status, created_at, created_by, updated_at, updated_by,
+			activated_at, deprecated_at
+		) VALUES (
+			$1, $2, $3, $4, $5, $6,
+			$7, $8, $9,
+			$10, $11, $12, $13, $14,
+			$15, $16
+		)`
+
+	_, err := tx.Exec(ctx, query,
+		entity.ID,
+		entity.Code,
+		entity.Version,
+		entity.Name,
+		nullStringPtr(entity.Description),
+		nullStringPtr(entity.DataCategory),
+		nullStringPtr(entity.ValidationExpression),
+		entity.ResolutionKeyExpression,
+		nullStringPtr(entity.ErrorMessageExpression),
+		entity.Status,
+		entity.CreatedAt,
+		userID,
+		entity.UpdatedAt,
+		userID,
+		nullTimePtr(entity.ActivatedAt),
+		nullTimePtr(entity.DeprecatedAt),
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return domain.ErrDuplicateDataSetCode
+		}
+		return fmt.Errorf("failed to insert dataset definition: %w", err)
+	}
+
+	return nil
+}
+
+func (r *DataSetRepository) updateDataSet(ctx context.Context, tx pgx.Tx, entity DataSetDefinitionEntity, userID string, expectedVersion int) error {
+	// Optimistic locking: only update if version matches
+	// Note: version is incremented by the domain layer before save
+	previousVersion := entity.Version - 1
+
+	if previousVersion != expectedVersion {
+		return domain.ErrVersionMismatch
+	}
+
+	query := `
+		UPDATE dataset_definition SET
+			name = $1,
+			description = $2,
+			data_category = $3,
+			validation_expression = $4,
+			resolution_key_expression = $5,
+			error_message_expression = $6,
+			status = $7,
+			version = $8,
+			updated_at = $9,
+			updated_by = $10,
+			activated_at = $11,
+			deprecated_at = $12
+		WHERE id = $13 AND version = $14 AND deleted_at IS NULL`
+
+	result, err := tx.Exec(ctx, query,
+		entity.Name,
+		nullStringPtr(entity.Description),
+		nullStringPtr(entity.DataCategory),
+		nullStringPtr(entity.ValidationExpression),
+		entity.ResolutionKeyExpression,
+		nullStringPtr(entity.ErrorMessageExpression),
+		entity.Status,
+		entity.Version,
+		entity.UpdatedAt,
+		userID,
+		nullTimePtr(entity.ActivatedAt),
+		nullTimePtr(entity.DeprecatedAt),
+		entity.ID,
+		previousVersion,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update dataset definition: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return domain.ErrVersionMismatch
+	}
+
+	return nil
+}
+
+// FindByCode retrieves the current version of a dataset by its unique code.
+// Returns the latest ACTIVE version, or the highest version if no ACTIVE version exists.
+// Returns ErrDataSetNotFound if the dataset does not exist.
+func (r *DataSetRepository) FindByCode(ctx context.Context, code string) (domain.DataSetDefinition, error) {
+	var result domain.DataSetDefinition
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		// Try to find ACTIVE version first, then fall back to highest version
+		query := `
+			SELECT id, code, version, name, description, data_category,
+				validation_expression, resolution_key_expression, error_message_expression,
+				status, created_at, updated_at, activated_at, deprecated_at
+			FROM dataset_definition
+			WHERE code = $1 AND deleted_at IS NULL
+			ORDER BY
+				CASE WHEN status = 'ACTIVE' THEN 0 ELSE 1 END,
+				version DESC
+			LIMIT 1`
+
+		entity, err := r.scanDataSetDefinition(ctx, tx, query, code)
+		if err != nil {
+			return err
+		}
+
+		result = EntityToDataSetDefinition(entity)
+		return nil
+	})
+
+	return result, err
+}
+
+// FindByCodeAndVersion retrieves a specific version of a dataset.
+// Returns ErrDataSetNotFound if the dataset or version does not exist.
+func (r *DataSetRepository) FindByCodeAndVersion(ctx context.Context, code string, version int) (domain.DataSetDefinition, error) {
+	var result domain.DataSetDefinition
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, code, version, name, description, data_category,
+				validation_expression, resolution_key_expression, error_message_expression,
+				status, created_at, updated_at, activated_at, deprecated_at
+			FROM dataset_definition
+			WHERE code = $1 AND version = $2 AND deleted_at IS NULL`
+
+		entity, err := r.scanDataSetDefinition(ctx, tx, query, code, version)
+		if err != nil {
+			return err
+		}
+
+		result = EntityToDataSetDefinition(entity)
+		return nil
+	})
+
+	return result, err
+}
+
+// List returns datasets matching the filter criteria.
+// Returns an empty slice if no datasets match the filter.
+func (r *DataSetRepository) List(ctx context.Context, filters domain.DataSetFilters) ([]domain.DataSetDefinition, error) {
+	var results []domain.DataSetDefinition
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, code, version, name, description, data_category,
+				validation_expression, resolution_key_expression, error_message_expression,
+				status, created_at, updated_at, activated_at, deprecated_at
+			FROM dataset_definition
+			WHERE deleted_at IS NULL`
+
+		args := []interface{}{}
+		argPos := 1
+
+		// Apply category filter
+		if filters.Category != nil {
+			query += fmt.Sprintf(" AND data_category = $%d", argPos)
+			args = append(args, filters.Category.String())
+			argPos++
+		}
+
+		// Apply status filter
+		if filters.Status != nil {
+			query += fmt.Sprintf(" AND status = $%d", argPos)
+			args = append(args, filters.Status.String())
+			argPos++
+		}
+
+		// Order by created_at descending
+		query += " ORDER BY created_at DESC"
+
+		// Apply pagination
+		limit := filters.Limit
+		if limit <= 0 {
+			limit = 100 // Default limit
+		}
+		query += fmt.Sprintf(" LIMIT $%d", argPos)
+		args = append(args, limit)
+		argPos++
+
+		if filters.Offset > 0 {
+			query += fmt.Sprintf(" OFFSET $%d", argPos)
+			args = append(args, filters.Offset)
+		}
+
+		rows, err := tx.Query(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("failed to list dataset definitions: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			entity, err := r.scanDataSetDefinitionFromRows(rows)
+			if err != nil {
+				return err
+			}
+			results = append(results, EntityToDataSetDefinition(entity))
+		}
+
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("error iterating dataset definitions: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// ExistsByCode checks if a dataset with the given code exists.
+func (r *DataSetRepository) ExistsByCode(ctx context.Context, code string) (bool, error) {
+	var exists bool
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `SELECT EXISTS(SELECT 1 FROM dataset_definition WHERE code = $1 AND deleted_at IS NULL)`
+		return tx.QueryRow(ctx, query, code).Scan(&exists)
+	})
+
+	return exists, err
+}
+
+// scanDataSetDefinition executes a query and scans a single DataSetDefinitionEntity.
+func (r *DataSetRepository) scanDataSetDefinition(ctx context.Context, tx pgx.Tx, query string, args ...interface{}) (DataSetDefinitionEntity, error) {
+	var entity DataSetDefinitionEntity
+
+	err := tx.QueryRow(ctx, query, args...).Scan(
+		&entity.ID,
+		&entity.Code,
+		&entity.Version,
+		&entity.Name,
+		&entity.Description,
+		&entity.DataCategory,
+		&entity.ValidationExpression,
+		&entity.ResolutionKeyExpression,
+		&entity.ErrorMessageExpression,
+		&entity.Status,
+		&entity.CreatedAt,
+		&entity.UpdatedAt,
+		&entity.ActivatedAt,
+		&entity.DeprecatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return entity, domain.ErrDataSetNotFound
+		}
+		return entity, fmt.Errorf("failed to scan dataset definition: %w", err)
+	}
+
+	return entity, nil
+}
+
+// scanDataSetDefinitionFromRows scans a DataSetDefinitionEntity from rows.
+func (r *DataSetRepository) scanDataSetDefinitionFromRows(rows pgx.Rows) (DataSetDefinitionEntity, error) {
+	var entity DataSetDefinitionEntity
+
+	err := rows.Scan(
+		&entity.ID,
+		&entity.Code,
+		&entity.Version,
+		&entity.Name,
+		&entity.Description,
+		&entity.DataCategory,
+		&entity.ValidationExpression,
+		&entity.ResolutionKeyExpression,
+		&entity.ErrorMessageExpression,
+		&entity.Status,
+		&entity.CreatedAt,
+		&entity.UpdatedAt,
+		&entity.ActivatedAt,
+		&entity.DeprecatedAt,
+	)
+	if err != nil {
+		return entity, fmt.Errorf("failed to scan dataset definition row: %w", err)
+	}
+
+	return entity, nil
+}
+
+// Ensure DataSetRepository implements domain.DataSetRepository.
+var _ domain.DataSetRepository = (*DataSetRepository)(nil)

--- a/services/market-information/adapters/persistence/dataset_repository_test.go
+++ b/services/market-information/adapters/persistence/dataset_repository_test.go
@@ -1,0 +1,337 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence/testhelpers"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDataSetRepository_Save_NewDataSet(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create a new dataset
+	dataset, err := domain.NewDataSetDefinition(
+		"TEST_DATASET",
+		"Test Dataset",
+		"A test dataset for unit tests",
+		domain.DataCategoryPricing,
+		"value > 0",
+		"observation_context.key",
+		"Invalid value",
+	)
+	require.NoError(t, err)
+
+	// Save it
+	err = tc.Repos.DataSet.Save(ctx, dataset)
+	require.NoError(t, err)
+
+	// Retrieve and verify
+	retrieved, err := tc.Repos.DataSet.FindByCode(ctx, "TEST_DATASET")
+	require.NoError(t, err)
+
+	assert.Equal(t, "TEST_DATASET", retrieved.Code())
+	assert.Equal(t, "Test Dataset", retrieved.Name())
+	assert.Equal(t, "A test dataset for unit tests", retrieved.Description())
+	assert.Equal(t, domain.DataCategoryPricing, retrieved.DataCategory())
+	assert.Equal(t, domain.DataSetStatusDraft, retrieved.Status())
+	assert.Equal(t, 1, retrieved.Version())
+}
+
+func TestDataSetRepository_Save_DuplicateCode(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create first dataset
+	dataset1, err := domain.NewDataSetDefinition(
+		"DUPLICATE_CODE",
+		"First Dataset",
+		"First description",
+		domain.DataCategoryPricing,
+		"value > 0",
+		"observation_context.key",
+		"",
+	)
+	require.NoError(t, err)
+
+	err = tc.Repos.DataSet.Save(ctx, dataset1)
+	require.NoError(t, err)
+
+	// Create second dataset with same code (should fail due to code+version unique constraint)
+	dataset2, err := domain.NewDataSetDefinition(
+		"DUPLICATE_CODE",
+		"Second Dataset",
+		"Second description",
+		domain.DataCategoryPricing,
+		"value > 0",
+		"observation_context.key",
+		"",
+	)
+	require.NoError(t, err)
+
+	err = tc.Repos.DataSet.Save(ctx, dataset2)
+	assert.ErrorIs(t, err, domain.ErrDuplicateDataSetCode)
+}
+
+func TestDataSetRepository_Save_UpdateWithOptimisticLocking(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create and save initial dataset
+	dataset, err := domain.NewDataSetDefinition(
+		"UPDATE_TEST",
+		"Original Name",
+		"Original description",
+		domain.DataCategoryPricing,
+		"value > 0",
+		"observation_context.key",
+		"",
+	)
+	require.NoError(t, err)
+
+	err = tc.Repos.DataSet.Save(ctx, dataset)
+	require.NoError(t, err)
+
+	// Retrieve it
+	retrieved, err := tc.Repos.DataSet.FindByCode(ctx, "UPDATE_TEST")
+	require.NoError(t, err)
+
+	// Update description (increments version)
+	updated, err := retrieved.UpdateDescription("Updated description")
+	require.NoError(t, err)
+
+	err = tc.Repos.DataSet.Save(ctx, updated)
+	require.NoError(t, err)
+
+	// Verify the update
+	final, err := tc.Repos.DataSet.FindByCode(ctx, "UPDATE_TEST")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Updated description", final.Description())
+	assert.Equal(t, 2, final.Version())
+}
+
+func TestDataSetRepository_FindByCode_NotFound(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	_, err := tc.Repos.DataSet.FindByCode(ctx, "NON_EXISTENT")
+	assert.ErrorIs(t, err, domain.ErrDataSetNotFound)
+}
+
+func TestDataSetRepository_FindByCodeAndVersion(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create dataset
+	dataset, err := domain.NewDataSetDefinition(
+		"VERSION_TEST",
+		"Version Test",
+		"Testing versioned retrieval",
+		domain.DataCategoryPricing,
+		"value > 0",
+		"observation_context.key",
+		"",
+	)
+	require.NoError(t, err)
+
+	err = tc.Repos.DataSet.Save(ctx, dataset)
+	require.NoError(t, err)
+
+	// Find by code and version
+	retrieved, err := tc.Repos.DataSet.FindByCodeAndVersion(ctx, "VERSION_TEST", 1)
+	require.NoError(t, err)
+
+	assert.Equal(t, "VERSION_TEST", retrieved.Code())
+	assert.Equal(t, 1, retrieved.Version())
+
+	// Wrong version should fail
+	_, err = tc.Repos.DataSet.FindByCodeAndVersion(ctx, "VERSION_TEST", 99)
+	assert.ErrorIs(t, err, domain.ErrDataSetNotFound)
+}
+
+func TestDataSetRepository_List_WithFilters(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create multiple datasets with different categories and statuses
+	datasets := []struct {
+		code     string
+		category domain.DataCategory
+	}{
+		{"PRICING_1", domain.DataCategoryPricing},
+		{"PRICING_2", domain.DataCategoryPricing},
+		{"CONTEXTUAL_1", domain.DataCategoryContextual},
+	}
+
+	for _, d := range datasets {
+		dataset, err := domain.NewDataSetDefinition(
+			d.code,
+			d.code,
+			"Description",
+			d.category,
+			"value > 0",
+			"observation_context.key",
+			"",
+		)
+		require.NoError(t, err)
+		err = tc.Repos.DataSet.Save(ctx, dataset)
+		require.NoError(t, err)
+	}
+
+	// List all
+	all, err := tc.Repos.DataSet.List(ctx, domain.DataSetFilters{})
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	// Filter by category
+	pricingCategory := domain.DataCategoryPricing
+	pricingOnly, err := tc.Repos.DataSet.List(ctx, domain.DataSetFilters{
+		Category: &pricingCategory,
+	})
+	require.NoError(t, err)
+	assert.Len(t, pricingOnly, 2)
+
+	// Filter by status
+	draftStatus := domain.DataSetStatusDraft
+	draftsOnly, err := tc.Repos.DataSet.List(ctx, domain.DataSetFilters{
+		Status: &draftStatus,
+	})
+	require.NoError(t, err)
+	assert.Len(t, draftsOnly, 3)
+}
+
+func TestDataSetRepository_List_Pagination(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create 5 datasets
+	for i := 0; i < 5; i++ {
+		dataset, err := domain.NewDataSetDefinition(
+			"PAGINATION_"+string(rune('A'+i)),
+			"Dataset "+string(rune('A'+i)),
+			"Description",
+			domain.DataCategoryPricing,
+			"value > 0",
+			"observation_context.key",
+			"",
+		)
+		require.NoError(t, err)
+		err = tc.Repos.DataSet.Save(ctx, dataset)
+		require.NoError(t, err)
+	}
+
+	// Get first page
+	page1, err := tc.Repos.DataSet.List(ctx, domain.DataSetFilters{
+		Limit:  2,
+		Offset: 0,
+	})
+	require.NoError(t, err)
+	assert.Len(t, page1, 2)
+
+	// Get second page
+	page2, err := tc.Repos.DataSet.List(ctx, domain.DataSetFilters{
+		Limit:  2,
+		Offset: 2,
+	})
+	require.NoError(t, err)
+	assert.Len(t, page2, 2)
+
+	// Get third page
+	page3, err := tc.Repos.DataSet.List(ctx, domain.DataSetFilters{
+		Limit:  2,
+		Offset: 4,
+	})
+	require.NoError(t, err)
+	assert.Len(t, page3, 1)
+}
+
+func TestDataSetRepository_ExistsByCode(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Should not exist initially
+	exists, err := tc.Repos.DataSet.ExistsByCode(ctx, "EXISTS_TEST")
+	require.NoError(t, err)
+	assert.False(t, exists)
+
+	// Create dataset
+	dataset, err := domain.NewDataSetDefinition(
+		"EXISTS_TEST",
+		"Exists Test",
+		"Testing existence check",
+		domain.DataCategoryPricing,
+		"value > 0",
+		"observation_context.key",
+		"",
+	)
+	require.NoError(t, err)
+	err = tc.Repos.DataSet.Save(ctx, dataset)
+	require.NoError(t, err)
+
+	// Should exist now
+	exists, err = tc.Repos.DataSet.ExistsByCode(ctx, "EXISTS_TEST")
+	require.NoError(t, err)
+	assert.True(t, exists)
+}
+
+func TestDataSetRepository_Lifecycle_DraftToActive(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create dataset in DRAFT status
+	dataset, err := domain.NewDataSetDefinition(
+		"LIFECYCLE_TEST",
+		"Lifecycle Test",
+		"Testing lifecycle transitions",
+		domain.DataCategoryPricing,
+		"value > 0",
+		"observation_context.key",
+		"",
+	)
+	require.NoError(t, err)
+
+	err = tc.Repos.DataSet.Save(ctx, dataset)
+	require.NoError(t, err)
+
+	// Retrieve and verify DRAFT status
+	retrieved, err := tc.Repos.DataSet.FindByCode(ctx, "LIFECYCLE_TEST")
+	require.NoError(t, err)
+	assert.Equal(t, domain.DataSetStatusDraft, retrieved.Status())
+	assert.Nil(t, retrieved.ActivatedAt())
+
+	// Activate
+	activated, err := retrieved.ActivateDataSet()
+	require.NoError(t, err)
+
+	err = tc.Repos.DataSet.Save(ctx, activated)
+	require.NoError(t, err)
+
+	// Verify ACTIVE status and activated_at timestamp
+	final, err := tc.Repos.DataSet.FindByCode(ctx, "LIFECYCLE_TEST")
+	require.NoError(t, err)
+	assert.Equal(t, domain.DataSetStatusActive, final.Status())
+	assert.NotNil(t, final.ActivatedAt())
+}

--- a/services/market-information/adapters/persistence/entities.go
+++ b/services/market-information/adapters/persistence/entities.go
@@ -1,0 +1,58 @@
+// Package persistence provides PostgreSQL persistence implementations for the Market Information service.
+package persistence
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// DataSetDefinitionEntity represents a dataset definition row in the database.
+type DataSetDefinitionEntity struct {
+	ID                      uuid.UUID
+	Code                    string
+	Version                 int
+	Name                    string
+	Description             sql.NullString
+	DataCategory            sql.NullString
+	ValidationExpression    sql.NullString
+	ResolutionKeyExpression string
+	ErrorMessageExpression  sql.NullString
+	Status                  string
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
+	ActivatedAt             sql.NullTime
+	DeprecatedAt            sql.NullTime
+}
+
+// MarketPriceObservationEntity represents a market price observation row in the database.
+type MarketPriceObservationEntity struct {
+	ID                  uuid.UUID
+	DataSetDefinitionID uuid.UUID
+	DataSourceID        uuid.UUID
+	ResolutionKey       string
+	ObservedAt          time.Time
+	ValidFrom           sql.NullTime
+	ValidTo             sql.NullTime
+	CreatedAt           time.Time
+	Quality             int
+	ObservationContext  []byte // JSONB stored as bytes
+	NumericValue        decimal.NullDecimal
+	TextValue           sql.NullString
+	SupersededBy        uuid.NullUUID
+	CausationID         uuid.NullUUID
+}
+
+// DataSourceEntity represents a data source row in the database.
+type DataSourceEntity struct {
+	ID          uuid.UUID
+	Code        string
+	Name        string
+	Description sql.NullString
+	TrustLevel  int
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+	Version     int64
+}

--- a/services/market-information/adapters/persistence/helpers.go
+++ b/services/market-information/adapters/persistence/helpers.go
@@ -1,0 +1,71 @@
+// Package persistence provides PostgreSQL persistence implementations for the Market Information service.
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+)
+
+const defaultUser = "system"
+
+// getUserFromContext extracts the user identifier from the request context.
+// Returns the user ID if available, otherwise returns "system".
+func getUserFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return defaultUser
+	}
+	userID, ok := auth.GetUserIDFromContext(ctx)
+	if !ok || userID == "" {
+		return defaultUser
+	}
+	return userID
+}
+
+// nullStringPtr converts a sql.NullString to a *string for use in queries.
+// Returns nil if not valid.
+func nullStringPtr(ns sql.NullString) interface{} {
+	if !ns.Valid {
+		return nil
+	}
+	return ns.String
+}
+
+// nullTimePtr converts a sql.NullTime to a *time.Time for use in queries.
+// Returns nil if not valid.
+func nullTimePtr(nt sql.NullTime) interface{} {
+	if !nt.Valid {
+		return nil
+	}
+	return nt.Time
+}
+
+// nullTimeValue converts a time.Time to a sql.NullTime.
+// Returns a non-valid NullTime if the time is zero.
+func nullTimeValue(t time.Time) sql.NullTime {
+	if t.IsZero() {
+		return sql.NullTime{Valid: false}
+	}
+	return sql.NullTime{Time: t, Valid: true}
+}
+
+// nullUUIDValue converts a *uuid.UUID to a uuid.NullUUID.
+// Returns a non-valid NullUUID if the pointer is nil.
+func nullUUIDValue(id *uuid.UUID) uuid.NullUUID {
+	if id == nil {
+		return uuid.NullUUID{Valid: false}
+	}
+	return uuid.NullUUID{UUID: *id, Valid: true}
+}
+
+// nullUUIDNonNil converts a uuid.UUID to a uuid.NullUUID.
+// Returns a non-valid NullUUID if the UUID is nil (zero value).
+func nullUUIDNonNil(id uuid.UUID) uuid.NullUUID {
+	if id == uuid.Nil {
+		return uuid.NullUUID{Valid: false}
+	}
+	return uuid.NullUUID{UUID: id, Valid: true}
+}

--- a/services/market-information/adapters/persistence/mappers.go
+++ b/services/market-information/adapters/persistence/mappers.go
@@ -1,0 +1,212 @@
+// Package persistence provides PostgreSQL persistence implementations for the Market Information service.
+package persistence
+
+import (
+	"database/sql"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+	"github.com/shopspring/decimal"
+)
+
+// DataSetDefinitionToEntity converts a domain DataSetDefinition to a database entity.
+func DataSetDefinitionToEntity(d domain.DataSetDefinition) DataSetDefinitionEntity {
+	entity := DataSetDefinitionEntity{
+		ID:                      d.ID(),
+		Code:                    d.Code(),
+		Version:                 d.Version(),
+		Name:                    d.Name(),
+		ResolutionKeyExpression: d.ResolutionKeyExpression(),
+		Status:                  d.Status().String(),
+		CreatedAt:               d.CreatedAt(),
+		UpdatedAt:               d.UpdatedAt(),
+	}
+
+	if d.Description() != "" {
+		entity.Description = sql.NullString{String: d.Description(), Valid: true}
+	}
+	if d.DataCategory().String() != "" {
+		entity.DataCategory = sql.NullString{String: d.DataCategory().String(), Valid: true}
+	}
+	if d.ValidationExpression() != "" {
+		entity.ValidationExpression = sql.NullString{String: d.ValidationExpression(), Valid: true}
+	}
+	if d.ErrorMessageExpression() != "" {
+		entity.ErrorMessageExpression = sql.NullString{String: d.ErrorMessageExpression(), Valid: true}
+	}
+	if d.ActivatedAt() != nil {
+		entity.ActivatedAt = sql.NullTime{Time: *d.ActivatedAt(), Valid: true}
+	}
+	if d.DeprecatedAt() != nil {
+		entity.DeprecatedAt = sql.NullTime{Time: *d.DeprecatedAt(), Valid: true}
+	}
+
+	return entity
+}
+
+// EntityToDataSetDefinition converts a database entity to a domain DataSetDefinition.
+func EntityToDataSetDefinition(e DataSetDefinitionEntity) domain.DataSetDefinition {
+	builder := domain.NewDataSetDefinitionBuilder().
+		WithID(e.ID).
+		WithCode(e.Code).
+		WithVersion(e.Version).
+		WithName(e.Name).
+		WithResolutionKeyExpression(e.ResolutionKeyExpression).
+		WithStatus(parseDataSetStatus(e.Status)).
+		WithCreatedAt(e.CreatedAt).
+		WithUpdatedAt(e.UpdatedAt)
+
+	if e.Description.Valid {
+		builder.WithDescription(e.Description.String)
+	}
+	if e.DataCategory.Valid {
+		builder.WithDataCategory(domain.DataCategory(e.DataCategory.String))
+	}
+	if e.ValidationExpression.Valid {
+		builder.WithValidationExpression(e.ValidationExpression.String)
+	}
+	if e.ErrorMessageExpression.Valid {
+		builder.WithErrorMessageExpression(e.ErrorMessageExpression.String)
+	}
+	if e.ActivatedAt.Valid {
+		activatedAt := e.ActivatedAt.Time
+		builder.WithActivatedAt(&activatedAt)
+	}
+	if e.DeprecatedAt.Valid {
+		deprecatedAt := e.DeprecatedAt.Time
+		builder.WithDeprecatedAt(&deprecatedAt)
+	}
+
+	return builder.Build()
+}
+
+// parseDataSetStatus converts a string status to domain.DataSetStatus.
+func parseDataSetStatus(s string) domain.DataSetStatus {
+	switch s {
+	case "DRAFT":
+		return domain.DataSetStatusDraft
+	case "ACTIVE":
+		return domain.DataSetStatusActive
+	case "DEPRECATED":
+		return domain.DataSetStatusDeprecated
+	default:
+		return domain.DataSetStatusDraft
+	}
+}
+
+// DataSourceToEntity converts a domain DataSource to a database entity.
+func DataSourceToEntity(s domain.DataSource) DataSourceEntity {
+	entity := DataSourceEntity{
+		ID:         s.ID(),
+		Code:       s.Code(),
+		Name:       s.Name(),
+		TrustLevel: s.TrustLevel(),
+		CreatedAt:  s.CreatedAt(),
+		UpdatedAt:  s.UpdatedAt(),
+		Version:    1, // Default version for new entities
+	}
+
+	if s.Description() != "" {
+		entity.Description = sql.NullString{String: s.Description(), Valid: true}
+	}
+
+	return entity
+}
+
+// EntityToDataSource converts a database entity to a domain DataSource.
+func EntityToDataSource(e DataSourceEntity) domain.DataSource {
+	builder := domain.NewDataSourceBuilder().
+		WithID(e.ID).
+		WithCode(e.Code).
+		WithName(e.Name).
+		WithTrustLevel(e.TrustLevel).
+		WithCreatedAt(e.CreatedAt).
+		WithUpdatedAt(e.UpdatedAt)
+
+	if e.Description.Valid {
+		builder.WithDescription(e.Description.String)
+	}
+
+	return builder.Build()
+}
+
+// ObservationToEntity converts a domain MarketPriceObservation to a database entity.
+// The dataSetDefinitionID parameter is required because the domain model uses code, not ID.
+func ObservationToEntity(o domain.MarketPriceObservation, dataSetDefinitionID uuid.UUID) MarketPriceObservationEntity {
+	entity := MarketPriceObservationEntity{
+		ID:                  o.ID(),
+		DataSetDefinitionID: dataSetDefinitionID,
+		DataSourceID:        o.SourceID(),
+		ResolutionKey:       o.ResolutionKey(),
+		ObservedAt:          o.ObservedAt(),
+		CreatedAt:           o.CreatedAt(),
+		Quality:             o.QualityLevel().Int(),
+		ObservationContext:  []byte("{}"), // Placeholder - actual context handling TBD
+	}
+
+	// Set numeric value from decimal
+	entity.NumericValue = decimal.NullDecimal{
+		Decimal: o.Value(),
+		Valid:   true,
+	}
+
+	// Set valid time bounds
+	if !o.ValidFrom().IsZero() {
+		entity.ValidFrom = sql.NullTime{Time: o.ValidFrom(), Valid: true}
+	}
+	if !o.ValidTo().IsZero() {
+		entity.ValidTo = sql.NullTime{Time: o.ValidTo(), Valid: true}
+	}
+
+	// Set supersession info
+	if o.SupersededBy() != nil {
+		entity.SupersededBy = uuid.NullUUID{UUID: *o.SupersededBy(), Valid: true}
+	}
+
+	// Set causation ID
+	if o.CausationID() != uuid.Nil {
+		entity.CausationID = uuid.NullUUID{UUID: o.CausationID(), Valid: true}
+	}
+
+	return entity
+}
+
+// EntityToObservation converts a database entity to a domain MarketPriceObservation.
+// The dataSetCode and trustLevel parameters are required because they're not stored in the observation table.
+func EntityToObservation(e MarketPriceObservationEntity, dataSetCode string, trustLevel int) domain.MarketPriceObservation {
+	builder := domain.NewMarketPriceObservationBuilder().
+		WithID(e.ID).
+		WithDataSetCode(dataSetCode).
+		WithSourceID(e.DataSourceID).
+		WithResolutionKey(e.ResolutionKey).
+		WithObservedAt(e.ObservedAt).
+		WithCreatedAt(e.CreatedAt).
+		WithQualityLevel(domain.QualityLevel(e.Quality)).
+		WithTrustLevel(trustLevel)
+
+	// Set value
+	if e.NumericValue.Valid {
+		builder.WithValue(e.NumericValue.Decimal)
+	}
+
+	// Set valid time bounds
+	if e.ValidFrom.Valid {
+		builder.WithValidFrom(e.ValidFrom.Time)
+	}
+	if e.ValidTo.Valid {
+		builder.WithValidTo(e.ValidTo.Time)
+	}
+
+	// Set supersession info
+	if e.SupersededBy.Valid {
+		supersededBy := e.SupersededBy.UUID
+		builder.WithSupersededBy(&supersededBy)
+	}
+
+	// Set causation ID
+	if e.CausationID.Valid {
+		builder.WithCausationID(e.CausationID.UUID)
+	}
+
+	return builder.Build()
+}

--- a/services/market-information/adapters/persistence/observation_repository.go
+++ b/services/market-information/adapters/persistence/observation_repository.go
@@ -1,0 +1,510 @@
+// Package persistence provides PostgreSQL persistence implementations for the Market Information service.
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+	"github.com/shopspring/decimal"
+)
+
+// ObservationRepository implements domain.ObservationRepository using PostgreSQL.
+// Supports bi-temporal queries with quality ladder resolution.
+type ObservationRepository struct {
+	baseRepository
+}
+
+// NewObservationRepository creates a new PostgreSQL observation repository.
+func NewObservationRepository(pool *pgxpool.Pool) *ObservationRepository {
+	return &ObservationRepository{
+		baseRepository: newBaseRepository(pool),
+	}
+}
+
+// Record persists a new market price observation.
+// This is an append-only operation - observations are never updated in place.
+// When a higher quality observation is recorded, it automatically marks lower quality
+// observations for the same resolution key as superseded.
+func (r *ObservationRepository) Record(ctx context.Context, obs domain.MarketPriceObservation) error {
+	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		userID := getUserFromContext(ctx)
+
+		// First, resolve dataset definition ID from code
+		dataSetDefID, err := r.resolveDataSetDefinitionID(ctx, tx, obs.DataSetCode())
+		if err != nil {
+			return err
+		}
+
+		// Insert the new observation
+		insertQuery := `
+			INSERT INTO market_price_observation (
+				id, dataset_definition_id, data_source_id, resolution_key,
+				observed_at, valid_from, valid_to, created_at, created_by,
+				quality, observation_context, numeric_value, text_value,
+				superseded_by, causation_id
+			) VALUES (
+				$1, $2, $3, $4,
+				$5, $6, $7, $8, $9,
+				$10, $11, $12, $13,
+				$14, $15
+			)`
+
+		validFrom := nullTimeValue(obs.ValidFrom())
+		validTo := nullTimeValue(obs.ValidTo())
+		supersededBy := nullUUIDValue(obs.SupersededBy())
+		causationID := nullUUIDNonNil(obs.CausationID())
+
+		_, err = tx.Exec(ctx, insertQuery,
+			obs.ID(),
+			dataSetDefID,
+			obs.SourceID(),
+			obs.ResolutionKey(),
+			obs.ObservedAt(),
+			validFrom,
+			validTo,
+			obs.CreatedAt(),
+			userID,
+			obs.QualityLevel().Int(),
+			[]byte("{}"), // observation_context - placeholder
+			obs.Value(),
+			nil, // text_value - numeric observations use numeric_value
+			supersededBy,
+			causationID,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to insert observation: %w", err)
+		}
+
+		// Mark lower quality observations as superseded
+		// Only supersede observations with lower quality for the same resolution key
+		supersedQuery := `
+			UPDATE market_price_observation
+			SET superseded_by = $1
+			WHERE dataset_definition_id = $2
+				AND resolution_key = $3
+				AND superseded_by IS NULL
+				AND id != $1
+				AND quality < $4`
+
+		_, err = tx.Exec(ctx, supersedQuery,
+			obs.ID(),
+			dataSetDefID,
+			obs.ResolutionKey(),
+			obs.QualityLevel().Int(),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to supersede lower quality observations: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// FindByID retrieves an observation by its unique identifier.
+// Returns ErrObservationNotFound if the observation does not exist.
+func (r *ObservationRepository) FindByID(ctx context.Context, id uuid.UUID) (domain.MarketPriceObservation, error) {
+	var result domain.MarketPriceObservation
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT o.id, o.dataset_definition_id, o.data_source_id, o.resolution_key,
+				o.observed_at, o.valid_from, o.valid_to, o.created_at,
+				o.quality, o.numeric_value, o.text_value,
+				o.superseded_by, o.causation_id,
+				d.code as dataset_code,
+				s.trust_level
+			FROM market_price_observation o
+			JOIN dataset_definition d ON o.dataset_definition_id = d.id
+			JOIN data_source s ON o.data_source_id = s.id
+			WHERE o.id = $1`
+
+		obs, err := r.scanObservation(ctx, tx, query, id)
+		if err != nil {
+			return err
+		}
+
+		result = obs
+		return nil
+	})
+
+	return result, err
+}
+
+// Query retrieves observations matching the query criteria.
+// Returns an empty slice if no observations match.
+// Results are ordered by ObservedAt descending (most recent first).
+func (r *ObservationRepository) Query(ctx context.Context, query domain.ObservationQuery) ([]domain.MarketPriceObservation, error) {
+	var results []domain.MarketPriceObservation
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		// First, resolve dataset definition ID from code
+		dataSetDefID, err := r.resolveDataSetDefinitionID(ctx, tx, query.DataSetCode)
+		if err != nil {
+			return err
+		}
+
+		sqlQuery := `
+			SELECT o.id, o.dataset_definition_id, o.data_source_id, o.resolution_key,
+				o.observed_at, o.valid_from, o.valid_to, o.created_at,
+				o.quality, o.numeric_value, o.text_value,
+				o.superseded_by, o.causation_id,
+				d.code as dataset_code,
+				s.trust_level
+			FROM market_price_observation o
+			JOIN dataset_definition d ON o.dataset_definition_id = d.id
+			JOIN data_source s ON o.data_source_id = s.id
+			WHERE o.dataset_definition_id = $1`
+
+		args := []interface{}{dataSetDefID}
+		argPos := 2
+
+		// Filter by resolution key
+		if query.ResolutionKey != nil {
+			sqlQuery += fmt.Sprintf(" AND o.resolution_key = $%d", argPos)
+			args = append(args, *query.ResolutionKey)
+			argPos++
+		}
+
+		// Filter by observed time range
+		if query.ObservedAfter != nil {
+			sqlQuery += fmt.Sprintf(" AND o.observed_at > $%d", argPos)
+			args = append(args, *query.ObservedAfter)
+			argPos++
+		}
+		if query.ObservedBefore != nil {
+			sqlQuery += fmt.Sprintf(" AND o.observed_at < $%d", argPos)
+			args = append(args, *query.ObservedBefore)
+			argPos++
+		}
+
+		// Filter by quality level
+		if query.QualityLevel != nil {
+			sqlQuery += fmt.Sprintf(" AND o.quality = $%d", argPos)
+			args = append(args, query.QualityLevel.Int())
+			argPos++
+		}
+
+		// Filter superseded observations
+		if !query.IncludeSuperseded {
+			sqlQuery += " AND o.superseded_by IS NULL"
+		}
+
+		// Order by observed_at descending
+		sqlQuery += " ORDER BY o.observed_at DESC"
+
+		// Apply limit
+		limit := query.Limit
+		if limit <= 0 {
+			limit = 100 // Default limit
+		}
+		sqlQuery += fmt.Sprintf(" LIMIT $%d", argPos)
+		args = append(args, limit)
+
+		rows, err := tx.Query(ctx, sqlQuery, args...)
+		if err != nil {
+			return fmt.Errorf("failed to query observations: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			obs, err := r.scanObservationFromRows(rows)
+			if err != nil {
+				return err
+			}
+			results = append(results, obs)
+		}
+
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("error iterating observations: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetLatest retrieves the most recent non-superseded observation
+// for a specific dataset and resolution key combination.
+// Uses the quality ladder for precedence: VERIFIED > ACTUAL > ESTIMATE.
+// Returns ErrObservationNotFound if no matching observation exists.
+func (r *ObservationRepository) GetLatest(ctx context.Context, dataSetCode string, resolutionKey string) (domain.MarketPriceObservation, error) {
+	var result domain.MarketPriceObservation
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		// First, resolve dataset definition ID from code
+		dataSetDefID, err := r.resolveDataSetDefinitionID(ctx, tx, dataSetCode)
+		if err != nil {
+			return err
+		}
+
+		// Use the bi-temporal index for efficient query
+		// Order by quality DESC (VERIFIED > ACTUAL > ESTIMATE), then observed_at DESC, then trust_level DESC
+		query := `
+			SELECT o.id, o.dataset_definition_id, o.data_source_id, o.resolution_key,
+				o.observed_at, o.valid_from, o.valid_to, o.created_at,
+				o.quality, o.numeric_value, o.text_value,
+				o.superseded_by, o.causation_id,
+				d.code as dataset_code,
+				s.trust_level
+			FROM market_price_observation o
+			JOIN dataset_definition d ON o.dataset_definition_id = d.id
+			JOIN data_source s ON o.data_source_id = s.id
+			WHERE o.dataset_definition_id = $1
+				AND o.resolution_key = $2
+				AND o.superseded_by IS NULL
+			ORDER BY o.quality DESC, o.observed_at DESC, s.trust_level DESC, o.created_at DESC
+			LIMIT 1`
+
+		obs, err := r.scanObservation(ctx, tx, query, dataSetDefID, resolutionKey)
+		if err != nil {
+			return err
+		}
+
+		result = obs
+		return nil
+	})
+
+	return result, err
+}
+
+// RetrieveObservation retrieves the best observation for a resolution key at a specific knowledge time.
+// This enables bi-temporal "time travel" queries - what did we know at a given point in time?
+// Uses the quality ladder with trust level tiebreaker:
+// ORDER BY quality DESC, observed_at DESC, trust_level DESC, created_at DESC
+//
+// Parameters:
+//   - dataSetCode: The dataset code to query
+//   - resolutionKey: The unique resolution key (e.g., "EUR/USD")
+//   - knowledgeBaseTime: The point in time to query "what was known". Use time.Time{} for current knowledge.
+func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSetCode string, resolutionKey string, knowledgeBaseTime time.Time) (domain.MarketPriceObservation, error) {
+	var result domain.MarketPriceObservation
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		// First, resolve dataset definition ID from code
+		dataSetDefID, err := r.resolveDataSetDefinitionID(ctx, tx, dataSetCode)
+		if err != nil {
+			return err
+		}
+
+		// Bi-temporal query: find the best observation that was known at knowledgeBaseTime
+		// JOIN data_source for trust_level in ordering
+		query := `
+			SELECT o.id, o.dataset_definition_id, o.data_source_id, o.resolution_key,
+				o.observed_at, o.valid_from, o.valid_to, o.created_at,
+				o.quality, o.numeric_value, o.text_value,
+				o.superseded_by, o.causation_id,
+				d.code as dataset_code,
+				s.trust_level
+			FROM market_price_observation o
+			JOIN dataset_definition d ON o.dataset_definition_id = d.id
+			JOIN data_source s ON o.data_source_id = s.id
+			WHERE o.dataset_definition_id = $1
+				AND o.resolution_key = $2
+				AND o.superseded_by IS NULL
+				AND o.created_at <= $3
+			ORDER BY o.quality DESC, o.observed_at DESC, s.trust_level DESC, o.created_at DESC
+			LIMIT 1`
+
+		// If knowledgeBaseTime is zero, use current time
+		kbt := knowledgeBaseTime
+		if kbt.IsZero() {
+			kbt = time.Now()
+		}
+
+		obs, err := r.scanObservation(ctx, tx, query, dataSetDefID, resolutionKey, kbt)
+		if err != nil {
+			return err
+		}
+
+		result = obs
+		return nil
+	})
+
+	return result, err
+}
+
+// resolveDataSetDefinitionID looks up the dataset definition ID from code.
+func (r *ObservationRepository) resolveDataSetDefinitionID(ctx context.Context, tx pgx.Tx, code string) (uuid.UUID, error) {
+	var id uuid.UUID
+	query := `
+		SELECT id FROM dataset_definition
+		WHERE code = $1 AND status = 'ACTIVE' AND deleted_at IS NULL
+		ORDER BY version DESC
+		LIMIT 1`
+
+	err := tx.QueryRow(ctx, query, code).Scan(&id)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return uuid.Nil, domain.ErrDataSetNotFound
+		}
+		return uuid.Nil, fmt.Errorf("failed to resolve dataset definition ID: %w", err)
+	}
+
+	return id, nil
+}
+
+// scanObservation executes a query and scans a single observation.
+func (r *ObservationRepository) scanObservation(ctx context.Context, tx pgx.Tx, query string, args ...interface{}) (domain.MarketPriceObservation, error) {
+	var (
+		id                  uuid.UUID
+		dataSetDefinitionID uuid.UUID
+		dataSourceID        uuid.UUID
+		resolutionKey       string
+		observedAt          time.Time
+		validFrom           sql.NullTime
+		validTo             sql.NullTime
+		createdAt           time.Time
+		quality             int
+		numericValue        decimal.NullDecimal
+		textValue           sql.NullString
+		supersededBy        uuid.NullUUID
+		causationID         uuid.NullUUID
+		dataSetCode         string
+		trustLevel          int
+	)
+
+	err := tx.QueryRow(ctx, query, args...).Scan(
+		&id,
+		&dataSetDefinitionID,
+		&dataSourceID,
+		&resolutionKey,
+		&observedAt,
+		&validFrom,
+		&validTo,
+		&createdAt,
+		&quality,
+		&numericValue,
+		&textValue,
+		&supersededBy,
+		&causationID,
+		&dataSetCode,
+		&trustLevel,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return domain.MarketPriceObservation{}, domain.ErrObservationNotFound
+		}
+		return domain.MarketPriceObservation{}, fmt.Errorf("failed to scan observation: %w", err)
+	}
+
+	return r.buildObservation(
+		id, dataSourceID, resolutionKey, observedAt, validFrom, validTo,
+		createdAt, quality, numericValue, supersededBy, causationID,
+		dataSetCode, trustLevel,
+	), nil
+}
+
+// scanObservationFromRows scans an observation from rows.
+func (r *ObservationRepository) scanObservationFromRows(rows pgx.Rows) (domain.MarketPriceObservation, error) {
+	var (
+		id                  uuid.UUID
+		dataSetDefinitionID uuid.UUID
+		dataSourceID        uuid.UUID
+		resolutionKey       string
+		observedAt          time.Time
+		validFrom           sql.NullTime
+		validTo             sql.NullTime
+		createdAt           time.Time
+		quality             int
+		numericValue        decimal.NullDecimal
+		textValue           sql.NullString
+		supersededBy        uuid.NullUUID
+		causationID         uuid.NullUUID
+		dataSetCode         string
+		trustLevel          int
+	)
+
+	err := rows.Scan(
+		&id,
+		&dataSetDefinitionID,
+		&dataSourceID,
+		&resolutionKey,
+		&observedAt,
+		&validFrom,
+		&validTo,
+		&createdAt,
+		&quality,
+		&numericValue,
+		&textValue,
+		&supersededBy,
+		&causationID,
+		&dataSetCode,
+		&trustLevel,
+	)
+	if err != nil {
+		return domain.MarketPriceObservation{}, fmt.Errorf("failed to scan observation row: %w", err)
+	}
+
+	return r.buildObservation(
+		id, dataSourceID, resolutionKey, observedAt, validFrom, validTo,
+		createdAt, quality, numericValue, supersededBy, causationID,
+		dataSetCode, trustLevel,
+	), nil
+}
+
+// buildObservation constructs a domain observation from scanned values.
+func (r *ObservationRepository) buildObservation(
+	id uuid.UUID,
+	dataSourceID uuid.UUID,
+	resolutionKey string,
+	observedAt time.Time,
+	validFrom sql.NullTime,
+	validTo sql.NullTime,
+	createdAt time.Time,
+	quality int,
+	numericValue decimal.NullDecimal,
+	supersededBy uuid.NullUUID,
+	causationID uuid.NullUUID,
+	dataSetCode string,
+	trustLevel int,
+) domain.MarketPriceObservation {
+	builder := domain.NewMarketPriceObservationBuilder().
+		WithID(id).
+		WithDataSetCode(dataSetCode).
+		WithSourceID(dataSourceID).
+		WithResolutionKey(resolutionKey).
+		WithObservedAt(observedAt).
+		WithCreatedAt(createdAt).
+		WithQualityLevel(domain.QualityLevel(quality)).
+		WithTrustLevel(trustLevel)
+
+	// Set value
+	if numericValue.Valid {
+		builder.WithValue(numericValue.Decimal)
+	}
+
+	// Set valid time bounds
+	if validFrom.Valid {
+		builder.WithValidFrom(validFrom.Time)
+	}
+	if validTo.Valid {
+		builder.WithValidTo(validTo.Time)
+	}
+
+	// Set supersession info
+	if supersededBy.Valid {
+		supersededByPtr := supersededBy.UUID
+		builder.WithSupersededBy(&supersededByPtr)
+	}
+
+	// Set causation ID
+	if causationID.Valid {
+		builder.WithCausationID(causationID.UUID)
+	}
+
+	return builder.Build()
+}
+
+// Ensure ObservationRepository implements domain.ObservationRepository.
+var _ domain.ObservationRepository = (*ObservationRepository)(nil)

--- a/services/market-information/adapters/persistence/observation_repository_test.go
+++ b/services/market-information/adapters/persistence/observation_repository_test.go
@@ -1,0 +1,523 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence/testhelpers"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestDataSetAndSource creates a test dataset and data source for observation tests.
+func setupTestDataSetAndSource(t *testing.T, tc *testhelpers.TestContainer) (domain.DataSetDefinition, domain.DataSource) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Create and activate a dataset
+	dataset, err := domain.NewDataSetDefinition(
+		"FX_RATE_TEST",
+		"FX Rate Test",
+		"Test dataset for observations",
+		domain.DataCategoryPricing,
+		"value > 0",
+		"observation_context.key",
+		"",
+	)
+	require.NoError(t, err)
+
+	err = tc.Repos.DataSet.Save(ctx, dataset)
+	require.NoError(t, err)
+
+	// Retrieve to get the generated ID
+	dataset, err = tc.Repos.DataSet.FindByCode(ctx, "FX_RATE_TEST")
+	require.NoError(t, err)
+
+	// Activate the dataset
+	activatedDataset, err := dataset.ActivateDataSet()
+	require.NoError(t, err)
+	err = tc.Repos.DataSet.Save(ctx, activatedDataset)
+	require.NoError(t, err)
+
+	// Create a data source
+	source, err := domain.NewDataSource(
+		"ECB_TEST",
+		"ECB Test",
+		"European Central Bank test feed",
+		domain.SourceTypeAPI,
+		90,
+	)
+	require.NoError(t, err)
+
+	err = tc.Repos.Source.Save(ctx, source)
+	require.NoError(t, err)
+
+	source, err = tc.Repos.Source.FindByCode(ctx, "ECB_TEST")
+	require.NoError(t, err)
+
+	return activatedDataset, source
+}
+
+func TestObservationRepository_Record_NewObservation(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupTestDataSetAndSource(t, tc)
+
+	// Create an observation
+	now := time.Now()
+	obs, err := domain.NewMarketPriceObservation(
+		"FX_RATE_TEST",
+		source.ID(),
+		"EUR/USD",
+		decimal.NewFromFloat(1.0850),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+
+	// Record it
+	err = tc.Repos.Observation.Record(ctx, obs)
+	require.NoError(t, err)
+
+	// Retrieve and verify
+	retrieved, err := tc.Repos.Observation.FindByID(ctx, obs.ID())
+	require.NoError(t, err)
+
+	assert.Equal(t, "FX_RATE_TEST", retrieved.DataSetCode())
+	assert.Equal(t, "EUR/USD", retrieved.ResolutionKey())
+	assert.Equal(t, domain.QualityLevelActual, retrieved.QualityLevel())
+	assert.True(t, decimal.NewFromFloat(1.0850).Equal(retrieved.Value()))
+}
+
+func TestObservationRepository_Record_SupersessionByQuality(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupTestDataSetAndSource(t, tc)
+
+	now := time.Now()
+
+	// First, record an ESTIMATE
+	estimate, err := domain.NewMarketPriceObservation(
+		"FX_RATE_TEST",
+		source.ID(),
+		"EUR/USD",
+		decimal.NewFromFloat(1.0800),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelEstimate,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, estimate)
+	require.NoError(t, err)
+
+	// Verify estimate is retrievable via GetLatest
+	latest, err := tc.Repos.Observation.GetLatest(ctx, "FX_RATE_TEST", "EUR/USD")
+	require.NoError(t, err)
+	assert.Equal(t, domain.QualityLevelEstimate, latest.QualityLevel())
+
+	// Record an ACTUAL for the same resolution key
+	actual, err := domain.NewMarketPriceObservation(
+		"FX_RATE_TEST",
+		source.ID(),
+		"EUR/USD",
+		decimal.NewFromFloat(1.0850),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, actual)
+	require.NoError(t, err)
+
+	// Now GetLatest should return the ACTUAL (higher quality supersedes)
+	latest, err = tc.Repos.Observation.GetLatest(ctx, "FX_RATE_TEST", "EUR/USD")
+	require.NoError(t, err)
+	assert.Equal(t, domain.QualityLevelActual, latest.QualityLevel())
+	assert.True(t, decimal.NewFromFloat(1.0850).Equal(latest.Value()))
+
+	// The estimate should now be superseded
+	oldEstimate, err := tc.Repos.Observation.FindByID(ctx, estimate.ID())
+	require.NoError(t, err)
+	assert.NotNil(t, oldEstimate.SupersededBy())
+	assert.Equal(t, actual.ID(), *oldEstimate.SupersededBy())
+}
+
+func TestObservationRepository_FindByID_NotFound(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	_, err := tc.Repos.Observation.FindByID(ctx, uuid.New())
+	assert.ErrorIs(t, err, domain.ErrObservationNotFound)
+}
+
+func TestObservationRepository_Query_ByDataSetCode(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupTestDataSetAndSource(t, tc)
+
+	now := time.Now()
+
+	// Create multiple observations
+	for i := 0; i < 3; i++ {
+		obs, err := domain.NewMarketPriceObservation(
+			"FX_RATE_TEST",
+			source.ID(),
+			"EUR/USD/"+string(rune('0'+i)),
+			decimal.NewFromFloat(1.08+float64(i)*0.001),
+			"USD",
+			now.Add(time.Duration(i)*time.Hour),
+			now,
+			now.Add(24*time.Hour),
+			uuid.New(),
+			domain.QualityLevelActual,
+			source.TrustLevel(),
+		)
+		require.NoError(t, err)
+		err = tc.Repos.Observation.Record(ctx, obs)
+		require.NoError(t, err)
+	}
+
+	// Query all observations for the dataset
+	results, err := tc.Repos.Observation.Query(ctx, domain.ObservationQuery{
+		DataSetCode: "FX_RATE_TEST",
+	})
+	require.NoError(t, err)
+	assert.Len(t, results, 3)
+
+	// Results should be ordered by observed_at descending
+	assert.True(t, results[0].ObservedAt().After(results[1].ObservedAt()))
+	assert.True(t, results[1].ObservedAt().After(results[2].ObservedAt()))
+}
+
+func TestObservationRepository_Query_ByResolutionKey(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupTestDataSetAndSource(t, tc)
+
+	now := time.Now()
+
+	// Create observations for different resolution keys
+	keys := []string{"EUR/USD", "GBP/USD", "EUR/USD"}
+	for i, key := range keys {
+		obs, err := domain.NewMarketPriceObservation(
+			"FX_RATE_TEST",
+			source.ID(),
+			key,
+			decimal.NewFromFloat(1.08+float64(i)*0.001),
+			"USD",
+			now.Add(time.Duration(i)*time.Minute),
+			now,
+			now.Add(24*time.Hour),
+			uuid.New(),
+			domain.QualityLevelActual,
+			source.TrustLevel(),
+		)
+		require.NoError(t, err)
+		err = tc.Repos.Observation.Record(ctx, obs)
+		require.NoError(t, err)
+	}
+
+	// Query by specific resolution key
+	resKey := "EUR/USD"
+	results, err := tc.Repos.Observation.Query(ctx, domain.ObservationQuery{
+		DataSetCode:   "FX_RATE_TEST",
+		ResolutionKey: &resKey,
+	})
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	for _, r := range results {
+		assert.Equal(t, "EUR/USD", r.ResolutionKey())
+	}
+}
+
+func TestObservationRepository_Query_ByQualityLevel(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupTestDataSetAndSource(t, tc)
+
+	now := time.Now()
+
+	// Create observations with different quality levels
+	qualities := []domain.QualityLevel{
+		domain.QualityLevelEstimate,
+		domain.QualityLevelActual,
+		domain.QualityLevelVerified,
+	}
+
+	for i, q := range qualities {
+		obs, err := domain.NewMarketPriceObservation(
+			"FX_RATE_TEST",
+			source.ID(),
+			"KEY_"+string(rune('0'+i)),
+			decimal.NewFromFloat(1.08+float64(i)*0.001),
+			"USD",
+			now,
+			now,
+			now.Add(24*time.Hour),
+			uuid.New(),
+			q,
+			source.TrustLevel(),
+		)
+		require.NoError(t, err)
+		err = tc.Repos.Observation.Record(ctx, obs)
+		require.NoError(t, err)
+	}
+
+	// Query by VERIFIED quality only
+	verifiedQuality := domain.QualityLevelVerified
+	results, err := tc.Repos.Observation.Query(ctx, domain.ObservationQuery{
+		DataSetCode:  "FX_RATE_TEST",
+		QualityLevel: &verifiedQuality,
+	})
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, domain.QualityLevelVerified, results[0].QualityLevel())
+}
+
+func TestObservationRepository_Query_IncludeSuperseded(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupTestDataSetAndSource(t, tc)
+
+	now := time.Now()
+
+	// Create an ESTIMATE
+	estimate, err := domain.NewMarketPriceObservation(
+		"FX_RATE_TEST",
+		source.ID(),
+		"EUR/GBP",
+		decimal.NewFromFloat(0.8500),
+		"GBP",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelEstimate,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, estimate)
+	require.NoError(t, err)
+
+	// Supersede with ACTUAL
+	actual, err := domain.NewMarketPriceObservation(
+		"FX_RATE_TEST",
+		source.ID(),
+		"EUR/GBP",
+		decimal.NewFromFloat(0.8550),
+		"GBP",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, actual)
+	require.NoError(t, err)
+
+	// Query without superseded (default) - should only get ACTUAL
+	resKey := "EUR/GBP"
+	nonSuperseded, err := tc.Repos.Observation.Query(ctx, domain.ObservationQuery{
+		DataSetCode:       "FX_RATE_TEST",
+		ResolutionKey:     &resKey,
+		IncludeSuperseded: false,
+	})
+	require.NoError(t, err)
+	assert.Len(t, nonSuperseded, 1)
+	assert.Equal(t, domain.QualityLevelActual, nonSuperseded[0].QualityLevel())
+
+	// Query with superseded - should get both
+	withSuperseded, err := tc.Repos.Observation.Query(ctx, domain.ObservationQuery{
+		DataSetCode:       "FX_RATE_TEST",
+		ResolutionKey:     &resKey,
+		IncludeSuperseded: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, withSuperseded, 2)
+}
+
+func TestObservationRepository_GetLatest_QualityLadder(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupTestDataSetAndSource(t, tc)
+
+	now := time.Now()
+
+	// Create VERIFIED observation first (oldest)
+	verified, err := domain.NewMarketPriceObservation(
+		"FX_RATE_TEST",
+		source.ID(),
+		"QUALITY_TEST",
+		decimal.NewFromFloat(1.0900),
+		"USD",
+		now.Add(-2*time.Hour),
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelVerified,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, verified)
+	require.NoError(t, err)
+
+	// Create ACTUAL observation (newer)
+	actual, err := domain.NewMarketPriceObservation(
+		"FX_RATE_TEST",
+		source.ID(),
+		"QUALITY_TEST",
+		decimal.NewFromFloat(1.0850),
+		"USD",
+		now.Add(-1*time.Hour),
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, actual)
+	require.NoError(t, err)
+
+	// Create ESTIMATE observation (newest)
+	estimate, err := domain.NewMarketPriceObservation(
+		"FX_RATE_TEST",
+		source.ID(),
+		"QUALITY_TEST",
+		decimal.NewFromFloat(1.0800),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelEstimate,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, estimate)
+	require.NoError(t, err)
+
+	// GetLatest should return VERIFIED (highest quality) despite being oldest
+	latest, err := tc.Repos.Observation.GetLatest(ctx, "FX_RATE_TEST", "QUALITY_TEST")
+	require.NoError(t, err)
+	assert.Equal(t, domain.QualityLevelVerified, latest.QualityLevel())
+	assert.True(t, decimal.NewFromFloat(1.0900).Equal(latest.Value()))
+}
+
+func TestObservationRepository_RetrieveObservation_KnowledgeBaseTime(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupTestDataSetAndSource(t, tc)
+
+	// We need to control created_at times, so we'll insert directly
+	// For this test, let's use the repository and check time-based queries
+
+	now := time.Now()
+
+	// Create an observation
+	obs, err := domain.NewMarketPriceObservation(
+		"FX_RATE_TEST",
+		source.ID(),
+		"BITEMPORAL_TEST",
+		decimal.NewFromFloat(1.0850),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, obs)
+	require.NoError(t, err)
+
+	// Query with knowledge base time in the future - should find the observation
+	futureTime := now.Add(1 * time.Hour)
+	result, err := tc.Repos.Observation.RetrieveObservation(ctx, "FX_RATE_TEST", "BITEMPORAL_TEST", futureTime)
+	require.NoError(t, err)
+	assert.Equal(t, "BITEMPORAL_TEST", result.ResolutionKey())
+
+	// Query with knowledge base time before the observation was created - should not find it
+	pastTime := now.Add(-1 * time.Hour)
+	_, err = tc.Repos.Observation.RetrieveObservation(ctx, "FX_RATE_TEST", "BITEMPORAL_TEST", pastTime)
+	assert.ErrorIs(t, err, domain.ErrObservationNotFound)
+}
+
+func TestObservationRepository_GetLatest_NotFound(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	setupTestDataSetAndSource(t, tc)
+
+	_, err := tc.Repos.Observation.GetLatest(ctx, "FX_RATE_TEST", "NON_EXISTENT_KEY")
+	assert.ErrorIs(t, err, domain.ErrObservationNotFound)
+}
+
+func TestObservationRepository_Record_InvalidDataSetCode(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupTestDataSetAndSource(t, tc)
+
+	now := time.Now()
+
+	// Try to record observation with non-existent dataset code
+	obs, err := domain.NewMarketPriceObservation(
+		"NON_EXISTENT_DATASET",
+		source.ID(),
+		"EUR/USD",
+		decimal.NewFromFloat(1.0850),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+
+	err = tc.Repos.Observation.Record(ctx, obs)
+	assert.ErrorIs(t, err, domain.ErrDataSetNotFound)
+}

--- a/services/market-information/adapters/persistence/repositories.go
+++ b/services/market-information/adapters/persistence/repositories.go
@@ -1,0 +1,25 @@
+// Package persistence provides PostgreSQL persistence implementations for the Market Information service.
+package persistence
+
+import (
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+)
+
+// Repositories holds all repository implementations for the Market Information service.
+// All repositories share the same connection pool for efficiency.
+type Repositories struct {
+	DataSet     domain.DataSetRepository
+	Observation domain.ObservationRepository
+	Source      domain.SourceRepository
+}
+
+// NewRepositories creates all repository implementations with a shared connection pool.
+// This is the recommended way to create repositories for production use.
+func NewRepositories(pool *pgxpool.Pool) *Repositories {
+	return &Repositories{
+		DataSet:     NewDataSetRepository(pool),
+		Observation: NewObservationRepository(pool),
+		Source:      NewSourceRepository(pool),
+	}
+}

--- a/services/market-information/adapters/persistence/source_repository.go
+++ b/services/market-information/adapters/persistence/source_repository.go
@@ -1,0 +1,219 @@
+// Package persistence provides PostgreSQL persistence implementations for the Market Information service.
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+)
+
+// SourceRepository implements domain.SourceRepository using PostgreSQL.
+type SourceRepository struct {
+	baseRepository
+}
+
+// NewSourceRepository creates a new PostgreSQL source repository.
+func NewSourceRepository(pool *pgxpool.Pool) *SourceRepository {
+	return &SourceRepository{
+		baseRepository: newBaseRepository(pool),
+	}
+}
+
+// Save persists a new or updated data source.
+// For new sources, returns ErrDuplicateDataSourceCode if the code already exists.
+func (r *SourceRepository) Save(ctx context.Context, source domain.DataSource) error {
+	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		userID := getUserFromContext(ctx)
+
+		// Try to insert, on conflict update
+		query := `
+			INSERT INTO data_source (
+				id, code, name, description, trust_level,
+				created_at, created_by, updated_at, updated_by, version
+			) VALUES (
+				$1, $2, $3, $4, $5,
+				$6, $7, $8, $9, 1
+			)
+			ON CONFLICT (code) DO UPDATE SET
+				name = EXCLUDED.name,
+				description = EXCLUDED.description,
+				trust_level = EXCLUDED.trust_level,
+				updated_at = EXCLUDED.updated_at,
+				updated_by = EXCLUDED.updated_by,
+				version = data_source.version + 1
+			WHERE data_source.deleted_at IS NULL`
+
+		entity := DataSourceToEntity(source)
+		_, err := tx.Exec(ctx, query,
+			entity.ID,
+			entity.Code,
+			entity.Name,
+			entity.Description,
+			entity.TrustLevel,
+			entity.CreatedAt,
+			userID,
+			entity.UpdatedAt,
+			userID,
+		)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+				return domain.ErrDuplicateDataSourceCode
+			}
+			return fmt.Errorf("failed to save data source: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// FindByID retrieves a data source by its unique identifier.
+// Returns ErrDataSourceNotFound if the source does not exist.
+func (r *SourceRepository) FindByID(ctx context.Context, id uuid.UUID) (domain.DataSource, error) {
+	var result domain.DataSource
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, code, name, description, trust_level, created_at, updated_at, version
+			FROM data_source
+			WHERE id = $1 AND deleted_at IS NULL`
+
+		var entity DataSourceEntity
+		err := tx.QueryRow(ctx, query, id).Scan(
+			&entity.ID,
+			&entity.Code,
+			&entity.Name,
+			&entity.Description,
+			&entity.TrustLevel,
+			&entity.CreatedAt,
+			&entity.UpdatedAt,
+			&entity.Version,
+		)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return domain.ErrDataSourceNotFound
+			}
+			return fmt.Errorf("failed to find data source by ID: %w", err)
+		}
+
+		result = EntityToDataSource(entity)
+		return nil
+	})
+
+	return result, err
+}
+
+// FindByCode retrieves a data source by its unique business code.
+// Returns ErrDataSourceNotFound if the source does not exist.
+func (r *SourceRepository) FindByCode(ctx context.Context, code string) (domain.DataSource, error) {
+	var result domain.DataSource
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, code, name, description, trust_level, created_at, updated_at, version
+			FROM data_source
+			WHERE code = $1 AND deleted_at IS NULL`
+
+		var entity DataSourceEntity
+		err := tx.QueryRow(ctx, query, code).Scan(
+			&entity.ID,
+			&entity.Code,
+			&entity.Name,
+			&entity.Description,
+			&entity.TrustLevel,
+			&entity.CreatedAt,
+			&entity.UpdatedAt,
+			&entity.Version,
+		)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return domain.ErrDataSourceNotFound
+			}
+			return fmt.Errorf("failed to find data source by code: %w", err)
+		}
+
+		result = EntityToDataSource(entity)
+		return nil
+	})
+
+	return result, err
+}
+
+// List returns all data sources, optionally filtering to only active sources.
+// Returns an empty slice if no sources exist.
+func (r *SourceRepository) List(ctx context.Context, _ bool) ([]domain.DataSource, error) {
+	var results []domain.DataSource
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, code, name, description, trust_level, created_at, updated_at, version
+			FROM data_source
+			WHERE deleted_at IS NULL
+			ORDER BY trust_level DESC, name ASC`
+
+		rows, err := tx.Query(ctx, query)
+		if err != nil {
+			return fmt.Errorf("failed to list data sources: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var entity DataSourceEntity
+			err := rows.Scan(
+				&entity.ID,
+				&entity.Code,
+				&entity.Name,
+				&entity.Description,
+				&entity.TrustLevel,
+				&entity.CreatedAt,
+				&entity.UpdatedAt,
+				&entity.Version,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to scan data source: %w", err)
+			}
+
+			results = append(results, EntityToDataSource(entity))
+		}
+
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("error iterating data sources: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// GetTrustLevel retrieves the trust level for a data source by ID.
+// This is a helper method used by observation queries to get trust level for quality ordering.
+func (r *SourceRepository) GetTrustLevel(ctx context.Context, sourceID uuid.UUID) (int, error) {
+	var trustLevel int
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `SELECT trust_level FROM data_source WHERE id = $1 AND deleted_at IS NULL`
+		err := tx.QueryRow(ctx, query, sourceID).Scan(&trustLevel)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return domain.ErrDataSourceNotFound
+			}
+			return fmt.Errorf("failed to get trust level: %w", err)
+		}
+		return nil
+	})
+
+	return trustLevel, err
+}
+
+// Ensure SourceRepository implements domain.SourceRepository.
+var _ domain.SourceRepository = (*SourceRepository)(nil)

--- a/services/market-information/adapters/persistence/source_repository_test.go
+++ b/services/market-information/adapters/persistence/source_repository_test.go
@@ -1,0 +1,215 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence/testhelpers"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceRepository_Save_NewSource(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create a new data source
+	source, err := domain.NewDataSource(
+		"TEST_SOURCE",
+		"Test Source",
+		"A test data source",
+		domain.SourceTypeAPI,
+		85,
+	)
+	require.NoError(t, err)
+
+	// Save it
+	err = tc.Repos.Source.Save(ctx, source)
+	require.NoError(t, err)
+
+	// Retrieve by code and verify
+	retrieved, err := tc.Repos.Source.FindByCode(ctx, "TEST_SOURCE")
+	require.NoError(t, err)
+
+	assert.Equal(t, "TEST_SOURCE", retrieved.Code())
+	assert.Equal(t, "Test Source", retrieved.Name())
+	assert.Equal(t, "A test data source", retrieved.Description())
+	assert.Equal(t, 85, retrieved.TrustLevel())
+}
+
+func TestSourceRepository_Save_UpdateExisting(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create and save initial source
+	source, err := domain.NewDataSource(
+		"UPDATE_SOURCE",
+		"Original Name",
+		"Original description",
+		domain.SourceTypeManual,
+		50,
+	)
+	require.NoError(t, err)
+
+	err = tc.Repos.Source.Save(ctx, source)
+	require.NoError(t, err)
+
+	// Create updated source with same code but different attributes
+	updatedSource, err := domain.NewDataSource(
+		"UPDATE_SOURCE",
+		"Updated Name",
+		"Updated description",
+		domain.SourceTypeManual,
+		75,
+	)
+	require.NoError(t, err)
+
+	// Save should update (upsert behavior)
+	err = tc.Repos.Source.Save(ctx, updatedSource)
+	require.NoError(t, err)
+
+	// Verify the update
+	retrieved, err := tc.Repos.Source.FindByCode(ctx, "UPDATE_SOURCE")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Updated Name", retrieved.Name())
+	assert.Equal(t, "Updated description", retrieved.Description())
+	assert.Equal(t, 75, retrieved.TrustLevel())
+}
+
+func TestSourceRepository_FindByID(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create and save a source
+	source, err := domain.NewDataSource(
+		"FIND_BY_ID_SOURCE",
+		"Find By ID Source",
+		"Testing FindByID",
+		domain.SourceTypeScheduled,
+		60,
+	)
+	require.NoError(t, err)
+
+	err = tc.Repos.Source.Save(ctx, source)
+	require.NoError(t, err)
+
+	// Get the ID by finding by code first
+	byCode, err := tc.Repos.Source.FindByCode(ctx, "FIND_BY_ID_SOURCE")
+	require.NoError(t, err)
+
+	// Now find by ID
+	byID, err := tc.Repos.Source.FindByID(ctx, byCode.ID())
+	require.NoError(t, err)
+
+	assert.Equal(t, byCode.Code(), byID.Code())
+	assert.Equal(t, byCode.Name(), byID.Name())
+}
+
+func TestSourceRepository_FindByID_NotFound(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	_, err := tc.Repos.Source.FindByID(ctx, uuid.New())
+	assert.ErrorIs(t, err, domain.ErrDataSourceNotFound)
+}
+
+func TestSourceRepository_FindByCode_NotFound(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	_, err := tc.Repos.Source.FindByCode(ctx, "NON_EXISTENT_SOURCE")
+	assert.ErrorIs(t, err, domain.ErrDataSourceNotFound)
+}
+
+func TestSourceRepository_List(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create multiple sources with different trust levels
+	sources := []struct {
+		code       string
+		trustLevel int
+	}{
+		{"HIGH_TRUST", 90},
+		{"MEDIUM_TRUST", 60},
+		{"LOW_TRUST", 30},
+	}
+
+	for _, s := range sources {
+		source, err := domain.NewDataSource(
+			s.code,
+			s.code,
+			"Description",
+			domain.SourceTypeAPI,
+			s.trustLevel,
+		)
+		require.NoError(t, err)
+		err = tc.Repos.Source.Save(ctx, source)
+		require.NoError(t, err)
+	}
+
+	// List all sources
+	all, err := tc.Repos.Source.List(ctx, false)
+	require.NoError(t, err)
+	assert.Len(t, all, 3)
+
+	// Verify ordering by trust level (descending)
+	assert.Equal(t, 90, all[0].TrustLevel())
+	assert.Equal(t, 60, all[1].TrustLevel())
+	assert.Equal(t, 30, all[2].TrustLevel())
+}
+
+func TestSourceRepository_TrustLevel_Validation(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Trust level 0 should be valid
+	source0, err := domain.NewDataSource(
+		"TRUST_ZERO",
+		"Zero Trust",
+		"Minimal trust",
+		domain.SourceTypeAPI,
+		0,
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Source.Save(ctx, source0)
+	require.NoError(t, err)
+
+	// Trust level 100 should be valid
+	source100, err := domain.NewDataSource(
+		"TRUST_MAX",
+		"Max Trust",
+		"Maximum trust",
+		domain.SourceTypeAPI,
+		100,
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Source.Save(ctx, source100)
+	require.NoError(t, err)
+
+	// Verify they were saved correctly
+	retrieved0, err := tc.Repos.Source.FindByCode(ctx, "TRUST_ZERO")
+	require.NoError(t, err)
+	assert.Equal(t, 0, retrieved0.TrustLevel())
+
+	retrieved100, err := tc.Repos.Source.FindByCode(ctx, "TRUST_MAX")
+	require.NoError(t, err)
+	assert.Equal(t, 100, retrieved100.TrustLevel())
+}

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -1,0 +1,203 @@
+// Package testhelpers provides shared utilities for repository integration tests.
+package testhelpers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// TestContainer holds the test database container, connection pool, and repository instances.
+type TestContainer struct {
+	container *postgres.PostgresContainer
+	Pool      *pgxpool.Pool
+	Repos     *persistence.Repositories
+}
+
+// SetupTestContainer creates a PostgreSQL testcontainer with the market_information schema loaded.
+func SetupTestContainer(t *testing.T) *TestContainer {
+	t.Helper()
+
+	ctx := context.Background()
+
+	// Create PostgreSQL container with explicit wait strategy
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("test_market_information"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForAll(
+				wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+				wait.ForListeningPort("5432/tcp"),
+			).WithDeadline(30*time.Second)),
+	)
+	require.NoError(t, err, "Failed to start PostgreSQL container")
+
+	// Get connection string
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err, "Failed to get connection string")
+
+	// Create connection pool
+	poolConfig, err := pgxpool.ParseConfig(connStr)
+	require.NoError(t, err, "Failed to parse pool config")
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	require.NoError(t, err, "Failed to create connection pool")
+
+	// Load schema
+	loadSchema(t, pool)
+
+	// Create repositories
+	repos := persistence.NewRepositories(pool)
+
+	return &TestContainer{
+		container: pgContainer,
+		Pool:      pool,
+		Repos:     repos,
+	}
+}
+
+// Cleanup closes the connection pool and terminates the container.
+func (tc *TestContainer) Cleanup(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	if tc.Pool != nil {
+		tc.Pool.Close()
+	}
+
+	if tc.container != nil {
+		require.NoError(t, tc.container.Terminate(ctx), "Failed to terminate container")
+	}
+}
+
+// loadSchema loads the complete market_information schema into the test database.
+func loadSchema(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Create data_source table
+	_, err := pool.Exec(ctx, `
+		CREATE TABLE data_source (
+			id uuid NOT NULL DEFAULT gen_random_uuid(),
+			code character varying(50) NOT NULL,
+			name character varying(255) NOT NULL,
+			description text NULL,
+			trust_level integer NOT NULL DEFAULT 50,
+			created_at timestamptz NOT NULL DEFAULT now(),
+			created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+			updated_at timestamptz NOT NULL DEFAULT now(),
+			updated_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+			deleted_at timestamptz NULL,
+			version bigint NOT NULL DEFAULT 1,
+			PRIMARY KEY (id),
+			CONSTRAINT uq_data_source_code UNIQUE (code),
+			CONSTRAINT chk_data_source_trust_level CHECK (trust_level >= 0 AND trust_level <= 100)
+		)
+	`)
+	require.NoError(t, err, "Failed to create data_source table")
+
+	// Create dataset_definition table
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE dataset_definition (
+			id uuid NOT NULL DEFAULT gen_random_uuid(),
+			code character varying(50) NOT NULL,
+			version integer NOT NULL DEFAULT 1,
+			name character varying(255) NOT NULL,
+			description text NULL,
+			data_category character varying(50) NULL,
+			validation_expression text NULL,
+			resolution_key_expression text NOT NULL,
+			error_message_expression text NULL,
+			attribute_schema jsonb NULL,
+			status character varying(20) NOT NULL DEFAULT 'DRAFT',
+			created_at timestamptz NOT NULL DEFAULT now(),
+			created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+			updated_at timestamptz NOT NULL DEFAULT now(),
+			updated_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+			deleted_at timestamptz NULL,
+			activated_at timestamptz NULL,
+			deprecated_at timestamptz NULL,
+			PRIMARY KEY (id),
+			CONSTRAINT uq_dataset_definition_code_version UNIQUE (code, version),
+			CONSTRAINT chk_dataset_definition_status CHECK (status IN ('DRAFT', 'ACTIVE', 'DEPRECATED'))
+		)
+	`)
+	require.NoError(t, err, "Failed to create dataset_definition table")
+
+	// Create indexes for dataset_definition
+	_, err = pool.Exec(ctx, `
+		CREATE INDEX idx_dataset_definition_code_active ON dataset_definition (code) WHERE status = 'ACTIVE';
+		CREATE INDEX idx_dataset_definition_status ON dataset_definition (status);
+		CREATE INDEX idx_dataset_definition_created_at ON dataset_definition (created_at);
+		CREATE INDEX idx_dataset_definition_deleted_at ON dataset_definition (deleted_at);
+	`)
+	require.NoError(t, err, "Failed to create dataset_definition indexes")
+
+	// Create market_price_observation table
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE market_price_observation (
+			id uuid NOT NULL DEFAULT gen_random_uuid(),
+			dataset_definition_id uuid NOT NULL,
+			data_source_id uuid NOT NULL,
+			resolution_key character varying(255) NOT NULL,
+			observed_at timestamptz NOT NULL,
+			valid_from timestamptz NULL,
+			valid_to timestamptz NULL,
+			created_at timestamptz NOT NULL DEFAULT now(),
+			created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+			quality integer NOT NULL,
+			observation_context jsonb NOT NULL DEFAULT '{}'::jsonb,
+			numeric_value numeric NULL,
+			text_value text NULL,
+			superseded_by uuid NULL,
+			causation_id uuid NULL,
+			PRIMARY KEY (id),
+			CONSTRAINT fk_observation_dataset_definition
+				FOREIGN KEY (dataset_definition_id) REFERENCES dataset_definition(id) ON DELETE RESTRICT,
+			CONSTRAINT fk_observation_data_source
+				FOREIGN KEY (data_source_id) REFERENCES data_source(id) ON DELETE RESTRICT,
+			CONSTRAINT fk_observation_superseded_by
+				FOREIGN KEY (superseded_by) REFERENCES market_price_observation(id) ON DELETE SET NULL,
+			CONSTRAINT chk_observation_quality CHECK (quality IN (1, 2, 3)),
+			CONSTRAINT chk_observation_value_present CHECK (numeric_value IS NOT NULL OR text_value IS NOT NULL)
+		)
+	`)
+	require.NoError(t, err, "Failed to create market_price_observation table")
+
+	// Create indexes for market_price_observation
+	_, err = pool.Exec(ctx, `
+		CREATE INDEX idx_observation_resolution_bitemporal
+			ON market_price_observation (resolution_key, quality DESC, observed_at DESC, created_at DESC)
+			WHERE superseded_by IS NULL;
+		CREATE INDEX idx_observation_dataset
+			ON market_price_observation (dataset_definition_id, observed_at DESC);
+		CREATE INDEX idx_observation_source
+			ON market_price_observation (data_source_id, created_at DESC);
+		CREATE INDEX idx_observation_created_at
+			ON market_price_observation (created_at DESC)
+			WHERE superseded_by IS NULL;
+		CREATE INDEX idx_observation_superseded_by
+			ON market_price_observation (superseded_by)
+			WHERE superseded_by IS NOT NULL;
+		CREATE INDEX idx_observation_causation
+			ON market_price_observation (causation_id)
+			WHERE causation_id IS NOT NULL;
+	`)
+	require.NoError(t, err, "Failed to create market_price_observation indexes")
+
+	// Create data source index
+	_, err = pool.Exec(ctx, `
+		CREATE INDEX idx_data_source_trust_level ON data_source (trust_level DESC);
+		CREATE INDEX idx_data_source_deleted_at ON data_source (deleted_at);
+	`)
+	require.NoError(t, err, "Failed to create data_source indexes")
+}

--- a/services/market-information/domain/repository.go
+++ b/services/market-information/domain/repository.go
@@ -80,6 +80,19 @@ type ObservationRepository interface {
 	// for a specific dataset and resolution key combination.
 	// Returns ErrObservationNotFound if no matching observation exists.
 	GetLatest(ctx context.Context, dataSetCode string, resolutionKey string) (MarketPriceObservation, error)
+
+	// RetrieveObservation retrieves the best observation for a resolution key at a specific knowledge time.
+	// This enables bi-temporal "time travel" queries - what did we know at a given point in time?
+	// Uses the quality ladder with trust level tiebreaker:
+	// ORDER BY quality DESC, observed_at DESC, trust_level DESC, created_at DESC
+	//
+	// Parameters:
+	//   - dataSetCode: The dataset code to query
+	//   - resolutionKey: The unique resolution key (e.g., "EUR/USD")
+	//   - knowledgeBaseTime: The point in time to query "what was known". Use zero time for current knowledge.
+	//
+	// Returns ErrObservationNotFound if no matching observation exists.
+	RetrieveObservation(ctx context.Context, dataSetCode string, resolutionKey string, knowledgeBaseTime time.Time) (MarketPriceObservation, error)
 }
 
 // ObservationQuery specifies criteria for querying market price observations.

--- a/services/market-information/domain/repository_test.go
+++ b/services/market-information/domain/repository_test.go
@@ -78,6 +78,10 @@ func (m *mockObservationRepository) GetLatest(_ context.Context, _ string, _ str
 	return MarketPriceObservation{}, ErrObservationNotFound
 }
 
+func (m *mockObservationRepository) RetrieveObservation(_ context.Context, _ string, _ string, _ time.Time) (MarketPriceObservation, error) {
+	return MarketPriceObservation{}, ErrObservationNotFound
+}
+
 // Verify mockObservationRepository implements ObservationRepository
 var _ ObservationRepository = (*mockObservationRepository)(nil)
 


### PR DESCRIPTION
## Summary

Implements PostgreSQL persistence layer for the Market Information service, completing task `market-information-management.5` from Task Master.

### Changes Made

- **DataSetRepository**: CRUD operations with optimistic locking, lifecycle management (DRAFT → ACTIVE → DEPRECATED)
- **ObservationRepository**: Bi-temporal storage with quality ladder supersession, `RetrieveObservation` for knowledge-time queries
- **SourceRepository**: Data source management with trust level ordering
- **Schema-per-tenant routing**: Uses `SET LOCAL search_path` for multi-tenant isolation
- **Integration tests**: Full testcontainers-based test suite for all repositories

### Technical Details

The observation repository implements the Time-Bound Quality Ladder pattern (ADR-0017):
- Quality levels: VERIFIED (3) > ACTUAL (2) > ESTIMATE (1)
- Higher quality observations automatically supersede lower quality ones for the same resolution key
- Bi-temporal queries support "what did we know at time T?" via `RetrieveObservation`

### Test Plan

- [x] All integration tests pass (27 tests across 3 repositories)
- [x] Tests verify supersession logic, bi-temporal queries, lifecycle transitions
- [x] Tests use testcontainers for isolated PostgreSQL instances

### Risk Assessment

Low risk - new adapter layer, no changes to existing production code paths.