### PR TITLE
fix: Improve Claude review prompts for actionable feedback

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -93,14 +93,26 @@ jobs:
             - Do not flag Go version references (like "Go 1.25") as errors or future versions
             - CI has already passed (tests, build, linting) - focus on code quality
 
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage
+            Review this pull request. Structure your feedback as:
 
-            Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            ## Must Fix
+            Issues that should be addressed before merge (bugs, security issues, correctness problems).
+
+            ## Should Fix
+            Improvements worth making in this PR (race conditions, error handling, edge cases, performance).
+            If you mention it here, it's worth implementing - not a footnote.
+
+            ## Future Work
+            Larger refactors or enhancements that belong in a separate PR.
+
+            REVIEW STANDARDS:
+            - Be direct. "Consider using X" → "Use X because Y"
+            - No "low priority" labels. Either it's worth fixing or don't mention it.
+            - Race conditions, concurrency issues, edge cases = Should Fix, not optional
+            - If a section is empty, omit it. Don't pad with low-value suggestions.
+            - Assume the author will implement your suggestions. Be worth implementing.
+
+            Use the repository's CLAUDE.md for guidance on style and conventions.
 
             Use `gh pr comment ${{ steps.pr.outputs.number }}` with your Bash tool to leave your review as a comment on the PR.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -112,7 +112,12 @@ jobs:
             - If a section is empty, omit it. Don't pad with low-value suggestions.
             - Assume the author will implement your suggestions. Be worth implementing.
 
-            Use the repository's CLAUDE.md for guidance on style and conventions.
+            PROJECT CONTEXT (read what's helpful):
+            - CONTRIBUTING.md - development guidelines and conventions
+            - docs/adr/ - Architecture Decision Records for design context
+            - docs/prd/ - Product Requirements for feature context
+            - docs/skills/ - available automation skills
+            - Service-specific README.md files for local conventions
 
             Use `gh pr comment ${{ steps.pr.outputs.number }}` with your Bash tool to leave your review as a comment on the PR.
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,6 +65,12 @@ jobs:
             - Ensure golangci-lint compliance
             - Do NOT question tool versions unless genuinely outdated
 
+            Review standards:
+            - Be direct. "Consider using X" → "Use X because Y"
+            - No "low priority" labels. Either it's worth fixing or don't mention it.
+            - Race conditions, concurrency issues, edge cases = worth fixing, not optional
+            - Assume the author will implement your suggestions. Be worth implementing.
+
             Read CONTRIBUTING.md in the repository root for full development guidelines.
 
           # Customize Claude's behavior

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -71,7 +71,12 @@ jobs:
             - Race conditions, concurrency issues, edge cases = worth fixing, not optional
             - Assume the author will implement your suggestions. Be worth implementing.
 
-            Read CONTRIBUTING.md in the repository root for full development guidelines.
+            Project context (read what's helpful):
+            - CONTRIBUTING.md - development guidelines and conventions
+            - docs/adr/ - Architecture Decision Records for design context
+            - docs/prd/ - Product Requirements for feature context
+            - docs/skills/ - available automation skills
+            - Service-specific README.md files for local conventions
 
           # Customize Claude's behavior
           # Using Opus 4.5 for higher quality responses


### PR DESCRIPTION
## Summary

Updates Claude review workflow prompts to produce more actionable feedback that will actually be implemented.

## Problem

PR #611 included a valid suggestion about a TOCTOU race condition that was labeled "Low Priority" and dismissed, when it was actually worth implementing. The current prompts allow hedging language that makes it unclear whether feedback should be acted on.

## Changes

**claude-code-review.yml** (automated reviews):
- Structure reviews as: Must Fix / Should Fix / Future Work
- Clear guidance that "Should Fix" items are worth implementing, not footnotes
- Explicit instruction that race conditions, concurrency issues = Should Fix

**claude.yml** (on-demand @claude):
- Added review standards section with same principles
- Direct language: "Consider using X" → "Use X because Y"

## Review Standards Added

```
- Be direct. "Consider using X" → "Use X because Y"
- No "low priority" labels. Either it's worth fixing or don't mention it.
- Race conditions, concurrency issues, edge cases = worth fixing, not optional
- Assume the author will implement your suggestions. Be worth implementing.
```

## Test Plan

- [ ] Merge and observe next few PR reviews
- [ ] Verify reviews use Must Fix / Should Fix / Future Work structure
- [ ] Check that valid improvements aren't dismissed as "low priority"