### PR TITLE
feat(market-information): Implement gRPC service handlers and business logic

### DIFF
--- a/services/market-information/service/dataset_service.go
+++ b/services/market-information/service/dataset_service.go
@@ -1,0 +1,582 @@
+// Package service provides gRPC service implementations for the Market Information service.
+// BIAN Service Domain: Market Information Management
+//
+// This file implements the DataSet-related gRPC methods for the MarketInformationService.
+package service
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+)
+
+// RegisterDataSet creates a new data set definition in DRAFT status.
+// Returns ALREADY_EXISTS if code already exists.
+// Returns INVALID_ARGUMENT if CEL expressions fail compilation.
+func (s *Server) RegisterDataSet(ctx context.Context, req *pb.RegisterDataSetRequest) (*pb.RegisterDataSetResponse, error) {
+	// Check if dataset with this code already exists
+	exists, err := s.dataSetRepo.ExistsByCode(ctx, req.Code)
+	if err != nil {
+		s.logger.Error("failed to check dataset existence",
+			"code", req.Code,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to check dataset existence: %v", err)
+	}
+	if exists {
+		s.logger.Warn("dataset code already exists",
+			"code", req.Code)
+		return nil, status.Errorf(codes.AlreadyExists, "dataset already exists: %s", req.Code)
+	}
+
+	// Validate CEL expressions if validator is configured
+	if s.celValidator != nil {
+		if err := s.validateCelExpressions(
+			req.ValidationExpression,
+			req.ResolutionKeyExpression,
+			req.ErrorMessageExpression,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	// Map proto category to domain category
+	domainCategory, err := protoCategoryToDomain(req.Category)
+	if err != nil {
+		s.logger.Warn("invalid data category",
+			"code", req.Code,
+			"category", req.Category)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid data category: %v", err)
+	}
+
+	// Create domain entity using NewDataSetDefinition constructor
+	// The constructor creates the entity in DRAFT status with version 1
+	dataset, err := domain.NewDataSetDefinition(
+		req.Code,
+		req.DisplayName,
+		req.Description,
+		domainCategory,
+		req.ValidationExpression,
+		req.ResolutionKeyExpression,
+		req.ErrorMessageExpression,
+	)
+	if err != nil {
+		s.logger.Warn("failed to create dataset entity",
+			"code", req.Code,
+			"error", err)
+		return nil, s.mapDataSetDomainError(err, "RegisterDataSet", req.Code)
+	}
+
+	// Persist the dataset
+	if err := s.dataSetRepo.Save(ctx, dataset); err != nil {
+		return nil, s.mapDataSetDomainError(err, "RegisterDataSet", req.Code)
+	}
+
+	s.logger.Info("dataset registered",
+		"code", dataset.Code(),
+		"id", dataset.ID().String(),
+		"status", dataset.Status())
+
+	return &pb.RegisterDataSetResponse{
+		Dataset: domainDataSetToProto(dataset),
+	}, nil
+}
+
+// UpdateDataSet modifies a DRAFT data set definition.
+// Returns NOT_FOUND if data set doesn't exist.
+// Returns FAILED_PRECONDITION if not in DRAFT status.
+// Returns INVALID_ARGUMENT if CEL expressions fail compilation.
+func (s *Server) UpdateDataSet(ctx context.Context, req *pb.UpdateDataSetRequest) (*pb.UpdateDataSetResponse, error) {
+	// Retrieve existing dataset by code and version
+	existing, err := s.dataSetRepo.FindByCodeAndVersion(ctx, req.Code, int(req.Version))
+	if err != nil {
+		return nil, s.mapDataSetDomainError(err, "UpdateDataSet", req.Code)
+	}
+
+	// Enforce DRAFT-only updates
+	if existing.Status() != domain.DataSetStatusDraft {
+		s.logger.Warn("cannot update non-draft dataset",
+			"code", req.Code,
+			"version", req.Version,
+			"status", existing.Status())
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"dataset must be in DRAFT status to update, current status: %s", existing.Status())
+	}
+
+	// Track if any CEL expressions changed
+	validationChanged := req.ValidationExpression != "" && req.ValidationExpression != existing.ValidationExpression()
+	resolutionKeyChanged := req.ResolutionKeyExpression != "" && req.ResolutionKeyExpression != existing.ResolutionKeyExpression()
+	errorMessageChanged := req.ErrorMessageExpression != "" && req.ErrorMessageExpression != existing.ErrorMessageExpression()
+
+	// Validate CEL expressions if any changed and validator is configured
+	if s.celValidator != nil && (validationChanged || resolutionKeyChanged || errorMessageChanged) {
+		// Use new values if provided, otherwise use existing
+		validationExpr := existing.ValidationExpression()
+		if req.ValidationExpression != "" {
+			validationExpr = req.ValidationExpression
+		}
+		resolutionKeyExpr := existing.ResolutionKeyExpression()
+		if req.ResolutionKeyExpression != "" {
+			resolutionKeyExpr = req.ResolutionKeyExpression
+		}
+		errorMessageExpr := existing.ErrorMessageExpression()
+		if req.ErrorMessageExpression != "" {
+			errorMessageExpr = req.ErrorMessageExpression
+		}
+
+		if err := s.validateCelExpressions(validationExpr, resolutionKeyExpr, errorMessageExpr); err != nil {
+			return nil, err
+		}
+	}
+
+	// Apply updates using domain methods
+	updated := existing
+
+	// Update description if provided (allow clearing with empty string check)
+	if req.Description != existing.Description() {
+		updated, err = updated.UpdateDescription(req.Description)
+		if err != nil {
+			return nil, s.mapDataSetDomainError(err, "UpdateDataSet", req.Code)
+		}
+	}
+
+	// Update CEL expressions if provided
+	if validationChanged {
+		updated, err = updated.UpdateValidationExpression(req.ValidationExpression)
+		if err != nil {
+			return nil, s.mapDataSetDomainError(err, "UpdateDataSet", req.Code)
+		}
+	}
+
+	if resolutionKeyChanged {
+		updated, err = updated.UpdateResolutionKeyExpression(req.ResolutionKeyExpression)
+		if err != nil {
+			return nil, s.mapDataSetDomainError(err, "UpdateDataSet", req.Code)
+		}
+	}
+
+	if errorMessageChanged {
+		updated, err = updated.UpdateErrorMessageExpression(req.ErrorMessageExpression)
+		if err != nil {
+			return nil, s.mapDataSetDomainError(err, "UpdateDataSet", req.Code)
+		}
+	}
+
+	// Persist the updated dataset
+	if err := s.dataSetRepo.Save(ctx, updated); err != nil {
+		return nil, s.mapDataSetDomainError(err, "UpdateDataSet", req.Code)
+	}
+
+	s.logger.Info("dataset updated",
+		"code", updated.Code(),
+		"version", updated.Version())
+
+	return &pb.UpdateDataSetResponse{
+		Dataset: domainDataSetToProto(updated),
+	}, nil
+}
+
+// ActivateDataSet transitions a data set from DRAFT to ACTIVE.
+// Returns NOT_FOUND if data set doesn't exist.
+// Returns FAILED_PRECONDITION if not in DRAFT status.
+// Returns INVALID_ARGUMENT if CEL expressions fail validation.
+func (s *Server) ActivateDataSet(ctx context.Context, req *pb.ActivateDataSetRequest) (*pb.ActivateDataSetResponse, error) {
+	// Retrieve existing dataset
+	existing, err := s.dataSetRepo.FindByCodeAndVersion(ctx, req.Code, int(req.Version))
+	if err != nil {
+		return nil, s.mapDataSetDomainError(err, "ActivateDataSet", req.Code)
+	}
+
+	// Perform full CEL validation before activation (compile all expressions)
+	if s.celValidator != nil {
+		if err := s.validateCelExpressions(
+			existing.ValidationExpression(),
+			existing.ResolutionKeyExpression(),
+			existing.ErrorMessageExpression(),
+		); err != nil {
+			s.logger.Warn("CEL validation failed during activation",
+				"code", req.Code,
+				"version", req.Version,
+				"error", err)
+			return nil, err
+		}
+	}
+
+	// Transition DRAFT -> ACTIVE using domain method
+	activated, err := existing.ActivateDataSet()
+	if err != nil {
+		s.logger.Warn("failed to activate dataset",
+			"code", req.Code,
+			"version", req.Version,
+			"current_status", existing.Status(),
+			"error", err)
+		return nil, s.mapDataSetDomainError(err, "ActivateDataSet", req.Code)
+	}
+
+	// Persist the activated dataset
+	if err := s.dataSetRepo.Save(ctx, activated); err != nil {
+		return nil, s.mapDataSetDomainError(err, "ActivateDataSet", req.Code)
+	}
+
+	s.logger.Info("dataset activated",
+		"code", activated.Code(),
+		"version", activated.Version(),
+		"status", activated.Status())
+
+	return &pb.ActivateDataSetResponse{
+		Dataset: domainDataSetToProto(activated),
+	}, nil
+}
+
+// DeprecateDataSet transitions a data set from ACTIVE to DEPRECATED.
+// Returns NOT_FOUND if data set doesn't exist.
+// Returns FAILED_PRECONDITION if not in ACTIVE status.
+func (s *Server) DeprecateDataSet(ctx context.Context, req *pb.DeprecateDataSetRequest) (*pb.DeprecateDataSetResponse, error) {
+	// Retrieve existing dataset
+	existing, err := s.dataSetRepo.FindByCodeAndVersion(ctx, req.Code, int(req.Version))
+	if err != nil {
+		return nil, s.mapDataSetDomainError(err, "DeprecateDataSet", req.Code)
+	}
+
+	// Transition to DEPRECATED using domain method
+	// Domain validates the transition (DRAFT->DEPRECATED and ACTIVE->DEPRECATED are both valid)
+	deprecated, err := existing.DeprecateDataSet()
+	if err != nil {
+		s.logger.Warn("failed to deprecate dataset",
+			"code", req.Code,
+			"version", req.Version,
+			"current_status", existing.Status(),
+			"error", err)
+		return nil, s.mapDataSetDomainError(err, "DeprecateDataSet", req.Code)
+	}
+
+	// Persist the deprecated dataset
+	if err := s.dataSetRepo.Save(ctx, deprecated); err != nil {
+		return nil, s.mapDataSetDomainError(err, "DeprecateDataSet", req.Code)
+	}
+
+	s.logger.Info("dataset deprecated",
+		"code", deprecated.Code(),
+		"version", deprecated.Version(),
+		"status", deprecated.Status())
+
+	return &pb.DeprecateDataSetResponse{
+		Dataset: domainDataSetToProto(deprecated),
+	}, nil
+}
+
+// RetrieveDataSet fetches a specific data set by code and version.
+// If version is 0, returns the latest (current) version.
+// Returns NOT_FOUND if data set doesn't exist.
+func (s *Server) RetrieveDataSet(ctx context.Context, req *pb.RetrieveDataSetRequest) (*pb.RetrieveDataSetResponse, error) {
+	var dataset domain.DataSetDefinition
+	var err error
+
+	if req.Version == 0 {
+		// Version 0 means get the latest (current) version
+		dataset, err = s.dataSetRepo.FindByCode(ctx, req.Code)
+	} else {
+		// Get specific version
+		dataset, err = s.dataSetRepo.FindByCodeAndVersion(ctx, req.Code, int(req.Version))
+	}
+
+	if err != nil {
+		return nil, s.mapDataSetDomainError(err, "RetrieveDataSet", req.Code)
+	}
+
+	s.logger.Debug("dataset retrieved",
+		"code", dataset.Code(),
+		"version", dataset.Version())
+
+	return &pb.RetrieveDataSetResponse{
+		Dataset: domainDataSetToProto(dataset),
+	}, nil
+}
+
+// ListDataSets returns data sets matching the filter criteria.
+// Supports filtering by status, category, and pagination.
+func (s *Server) ListDataSets(ctx context.Context, req *pb.ListDataSetsRequest) (*pb.ListDataSetsResponse, error) {
+	// Build domain filters from proto request
+	filters := domain.DataSetFilters{}
+
+	// Apply status filter if specified (not UNSPECIFIED)
+	if req.StatusFilter != pb.DataSetStatus_DATA_SET_STATUS_UNSPECIFIED {
+		domainStatus, err := protoStatusToDomain(req.StatusFilter)
+		if err != nil {
+			s.logger.Warn("invalid status filter",
+				"status_filter", req.StatusFilter)
+			return nil, status.Errorf(codes.InvalidArgument, "invalid status filter: %v", err)
+		}
+		filters.Status = &domainStatus
+	}
+
+	// Apply category filter if specified (not UNSPECIFIED)
+	if req.CategoryFilter != pb.DataCategory_DATA_CATEGORY_UNSPECIFIED {
+		domainCategory, err := protoCategoryToDomain(req.CategoryFilter)
+		if err != nil {
+			s.logger.Warn("invalid category filter",
+				"category_filter", req.CategoryFilter)
+			return nil, status.Errorf(codes.InvalidArgument, "invalid category filter: %v", err)
+		}
+		filters.Category = &domainCategory
+	}
+
+	// Apply pagination
+	pageSize := int(req.PageSize)
+	if pageSize == 0 {
+		pageSize = 50 // Default page size
+	}
+	if pageSize > 100 {
+		pageSize = 100 // Max page size from proto validation
+	}
+	filters.Limit = pageSize
+
+	// TODO: Implement proper cursor-based pagination using page_token
+	// For now, we only support the first page
+	filters.Offset = 0
+
+	// Delegate to repository
+	datasets, err := s.dataSetRepo.List(ctx, filters)
+	if err != nil {
+		s.logger.Error("failed to list datasets",
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to list datasets: %v", err)
+	}
+
+	// Convert to proto messages
+	pbDatasets := make([]*pb.DataSetDefinition, len(datasets))
+	for i, ds := range datasets {
+		pbDatasets[i] = domainDataSetToProto(ds)
+	}
+
+	s.logger.Debug("listed datasets",
+		"count", len(pbDatasets),
+		"status_filter", req.StatusFilter,
+		"category_filter", req.CategoryFilter)
+
+	return &pb.ListDataSetsResponse{
+		Datasets:      pbDatasets,
+		NextPageToken: "", // TODO: Implement pagination token
+	}, nil
+}
+
+// validateCelExpressions validates all three CEL expressions using the CEL validator.
+// Returns a gRPC InvalidArgument error if any expression fails to compile.
+func (s *Server) validateCelExpressions(validation, resolutionKey, errorMessage string) error {
+	// Compile validation expression
+	if validation != "" {
+		_, err := s.celValidator.CompileValidation(validation)
+		if err != nil {
+			s.logger.Warn("validation expression compilation failed",
+				"expression", validation,
+				"error", err)
+			return status.Errorf(codes.InvalidArgument,
+				"validation_expression compilation failed: %v", err)
+		}
+	}
+
+	// Compile resolution key expression
+	if resolutionKey != "" {
+		_, err := s.celValidator.CompileResolutionKey(resolutionKey)
+		if err != nil {
+			s.logger.Warn("resolution key expression compilation failed",
+				"expression", resolutionKey,
+				"error", err)
+			return status.Errorf(codes.InvalidArgument,
+				"resolution_key_expression compilation failed: %v", err)
+		}
+	}
+
+	// Compile error message expression (optional, can be empty)
+	if errorMessage != "" {
+		_, err := s.celValidator.CompileErrorMessage(errorMessage)
+		if err != nil {
+			s.logger.Warn("error message expression compilation failed",
+				"expression", errorMessage,
+				"error", err)
+			return status.Errorf(codes.InvalidArgument,
+				"error_message_expression compilation failed: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// mapDataSetDomainError converts domain errors to appropriate gRPC status codes.
+func (s *Server) mapDataSetDomainError(err error, operation, code string) error {
+	switch {
+	case errors.Is(err, domain.ErrDataSetNotFound):
+		s.logger.Warn("dataset not found",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.NotFound, "dataset not found: %s", code)
+
+	case errors.Is(err, domain.ErrDuplicateDataSetCode):
+		s.logger.Warn("dataset code already exists",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.AlreadyExists, "dataset already exists: %s", code)
+
+	case errors.Is(err, domain.ErrInvalidStatusTransition):
+		s.logger.Warn("invalid status transition",
+			"operation", operation,
+			"code", code,
+			"error", err)
+		return status.Errorf(codes.FailedPrecondition, "invalid status transition: %v", err)
+
+	case errors.Is(err, domain.ErrDataSetDeprecated):
+		s.logger.Warn("dataset is deprecated",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.FailedPrecondition, "dataset is deprecated: %s", code)
+
+	case errors.Is(err, domain.ErrVersionMismatch):
+		s.logger.Warn("version mismatch",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.Aborted, "version mismatch: dataset was modified concurrently")
+
+	case errors.Is(err, domain.ErrCodeRequired):
+		s.logger.Warn("dataset code required",
+			"operation", operation)
+		return status.Errorf(codes.InvalidArgument, "dataset code is required")
+
+	case errors.Is(err, domain.ErrNameRequired):
+		s.logger.Warn("dataset name required",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.InvalidArgument, "dataset name (display_name) is required")
+
+	case errors.Is(err, domain.ErrValidationExpressionRequired):
+		s.logger.Warn("validation expression required",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.InvalidArgument, "validation_expression is required")
+
+	case errors.Is(err, domain.ErrResolutionKeyExpressionRequired):
+		s.logger.Warn("resolution key expression required",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.InvalidArgument, "resolution_key_expression is required")
+
+	case errors.Is(err, domain.ErrInvalidDataCategory):
+		s.logger.Warn("invalid data category",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.InvalidArgument, "invalid data category")
+
+	default:
+		s.logger.Error("internal error",
+			"operation", operation,
+			"code", code,
+			"error", err)
+		return status.Errorf(codes.Internal, "internal error: %v", err)
+	}
+}
+
+// domainDataSetToProto converts a domain DataSetDefinition to proto DataSetDefinition.
+func domainDataSetToProto(ds domain.DataSetDefinition) *pb.DataSetDefinition {
+	pbDataSet := &pb.DataSetDefinition{
+		Id:                      ds.ID().String(),
+		Code:                    ds.Code(),
+		Version:                 int32(ds.Version()),
+		Category:                domainCategoryToProto(ds.DataCategory()),
+		Unit:                    "", // Unit is not stored in domain; could be derived from category
+		ResolutionKeyExpression: ds.ResolutionKeyExpression(),
+		ValidationExpression:    ds.ValidationExpression(),
+		ErrorMessageExpression:  ds.ErrorMessageExpression(),
+		Status:                  domainStatusToProto(ds.Status()),
+		DisplayName:             ds.Name(),
+		Description:             ds.Description(),
+		CreatedAt:               timestamppb.New(ds.CreatedAt()),
+	}
+
+	// Set UpdatedAt if different from CreatedAt
+	if !ds.UpdatedAt().Equal(ds.CreatedAt()) {
+		pbDataSet.UpdatedAt = timestamppb.New(ds.UpdatedAt())
+	}
+
+	// Set EffectiveFrom to CreatedAt as default (domain doesn't have separate effective dates)
+	pbDataSet.EffectiveFrom = timestamppb.New(ds.CreatedAt())
+
+	return pbDataSet
+}
+
+// domainStatusToProto converts domain DataSetStatus to proto DataSetStatus.
+func domainStatusToProto(status domain.DataSetStatus) pb.DataSetStatus {
+	switch status {
+	case domain.DataSetStatusDraft:
+		return pb.DataSetStatus_DATA_SET_STATUS_DRAFT
+	case domain.DataSetStatusActive:
+		return pb.DataSetStatus_DATA_SET_STATUS_ACTIVE
+	case domain.DataSetStatusDeprecated:
+		return pb.DataSetStatus_DATA_SET_STATUS_DEPRECATED
+	default:
+		return pb.DataSetStatus_DATA_SET_STATUS_UNSPECIFIED
+	}
+}
+
+// protoStatusToDomain converts proto DataSetStatus to domain DataSetStatus.
+func protoStatusToDomain(status pb.DataSetStatus) (domain.DataSetStatus, error) {
+	switch status {
+	case pb.DataSetStatus_DATA_SET_STATUS_UNSPECIFIED:
+		return "", domain.ErrInvalidDataSetStatus
+	case pb.DataSetStatus_DATA_SET_STATUS_DRAFT:
+		return domain.DataSetStatusDraft, nil
+	case pb.DataSetStatus_DATA_SET_STATUS_ACTIVE:
+		return domain.DataSetStatusActive, nil
+	case pb.DataSetStatus_DATA_SET_STATUS_DEPRECATED:
+		return domain.DataSetStatusDeprecated, nil
+	default:
+		return "", domain.ErrInvalidDataSetStatus
+	}
+}
+
+// domainCategoryToProto converts domain DataCategory to proto DataCategory.
+// Note: The domain uses a simplified two-value category system (PRICING/CONTEXTUAL)
+// while proto has more granular categories. We map PRICING to FX_RATE as default.
+func domainCategoryToProto(category domain.DataCategory) pb.DataCategory {
+	switch category {
+	case domain.DataCategoryPricing:
+		// Default PRICING to FX_RATE in proto as the domain doesn't have granular categories
+		return pb.DataCategory_DATA_CATEGORY_FX_RATE
+	case domain.DataCategoryContextual:
+		// CONTEXTUAL maps to INDEX_VALUE as a reasonable default for reference data
+		return pb.DataCategory_DATA_CATEGORY_INDEX_VALUE
+	default:
+		return pb.DataCategory_DATA_CATEGORY_UNSPECIFIED
+	}
+}
+
+// protoCategoryToDomain converts proto DataCategory to domain DataCategory.
+// Groups proto categories into domain's simpler PRICING/CONTEXTUAL model.
+func protoCategoryToDomain(category pb.DataCategory) (domain.DataCategory, error) {
+	switch category {
+	// Price-based categories -> PRICING
+	case pb.DataCategory_DATA_CATEGORY_FX_RATE,
+		pb.DataCategory_DATA_CATEGORY_INTEREST_RATE,
+		pb.DataCategory_DATA_CATEGORY_COMMODITY_PRICE,
+		pb.DataCategory_DATA_CATEGORY_EQUITY_PRICE,
+		pb.DataCategory_DATA_CATEGORY_ENERGY_PRICE,
+		pb.DataCategory_DATA_CATEGORY_CARBON_PRICE,
+		pb.DataCategory_DATA_CATEGORY_BENCHMARK_RATE,
+		pb.DataCategory_DATA_CATEGORY_CREDIT_SPREAD:
+		return domain.DataCategoryPricing, nil
+
+	// Index/reference categories -> CONTEXTUAL
+	case pb.DataCategory_DATA_CATEGORY_INDEX_VALUE,
+		pb.DataCategory_DATA_CATEGORY_VOLATILITY:
+		return domain.DataCategoryContextual, nil
+
+	case pb.DataCategory_DATA_CATEGORY_UNSPECIFIED:
+		return "", domain.ErrInvalidDataCategory
+
+	default:
+		return "", domain.ErrInvalidDataCategory
+	}
+}

--- a/services/market-information/service/event_publisher.go
+++ b/services/market-information/service/event_publisher.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	"github.com/meridianhub/meridian/services/market-information/domain"
@@ -23,6 +22,8 @@ var (
 	ErrNilProducer = errors.New("kafka producer cannot be nil")
 	// ErrNilObservation is returned when the observation is nil.
 	ErrNilObservation = errors.New("observation cannot be nil")
+	// ErrUnsupportedEventType is returned when Publish receives an unsupported event type.
+	ErrUnsupportedEventType = errors.New("unsupported event type")
 )
 
 // ObservationEventPublisher defines the interface for publishing observation-related events.
@@ -83,8 +84,8 @@ func NewKafkaObservationPublisher(producer protoPublisher) (*KafkaObservationPub
 // PublishObservationRecorded publishes an ObservationRecorded event when a new
 // observation is recorded in the system.
 //
-// The event is published to the ObservationRecordedTopic with the tenant ID as
-// the partition key to ensure ordering of events for the same tenant.
+// The event is published to the ObservationRecordedTopic with the dataset code as
+// the partition key to ensure ordering of events for the same dataset.
 //
 // The method maps the domain MarketPriceObservation to the proto ObservationRecorded
 // event message before publishing.
@@ -121,6 +122,24 @@ func (p *KafkaObservationPublisher) FlushWithTimeout(timeoutMs int) int {
 	return p.producer.FlushWithTimeout(timeoutMs)
 }
 
+// Publish implements the EventPublisher interface by type-switching on the event
+// and delegating to the appropriate publish method.
+// Currently supports *marketinformationv1.ObservationRecorded events.
+// Returns ErrUnsupportedEventType for unsupported event types.
+func (p *KafkaObservationPublisher) Publish(ctx context.Context, event any) error {
+	switch e := event.(type) {
+	case *marketinformationv1.ObservationRecorded:
+		// Use dataset_code as partition key for ordering within the same dataset
+		partitionKey := e.DatasetCode
+		if err := p.producer.PublishWithTenant(ctx, p.topic, partitionKey, e); err != nil {
+			return fmt.Errorf("failed to publish ObservationRecorded event: %w", err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: %T", ErrUnsupportedEventType, event)
+	}
+}
+
 // mapObservationToProtoEvent converts a domain MarketPriceObservation to a proto
 // ObservationRecorded event message.
 func mapObservationToProtoEvent(obs domain.MarketPriceObservation) *marketinformationv1.ObservationRecorded {
@@ -132,7 +151,7 @@ func mapObservationToProtoEvent(obs domain.MarketPriceObservation) *marketinform
 		Quality:            mapQualityLevelToProto(obs.QualityLevel()),
 		Value:              obs.Value().String(),
 		SourceId:           obs.SourceID().String(),
-		RecordedAt:         timestamppb.New(time.Now()),
+		RecordedAt:         timestamppb.New(obs.CreatedAt()),
 	}
 
 	// Note: The proto event has supersedes_observation_id to track what this observation

--- a/services/market-information/service/event_publisher.go
+++ b/services/market-information/service/event_publisher.go
@@ -1,0 +1,160 @@
+// Package service provides application services for the Market Information service.
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	// ObservationRecordedTopic is the Kafka topic for observation recorded events.
+	ObservationRecordedTopic = "meridian.market_information.v1.ObservationRecorded"
+)
+
+var (
+	// ErrNilProducer is returned when the Kafka producer is nil.
+	ErrNilProducer = errors.New("kafka producer cannot be nil")
+	// ErrNilObservation is returned when the observation is nil.
+	ErrNilObservation = errors.New("observation cannot be nil")
+)
+
+// ObservationEventPublisher defines the interface for publishing observation-related events.
+// This interface allows the service layer to remain decoupled from the Kafka implementation.
+type ObservationEventPublisher interface {
+	// PublishObservationRecorded publishes an event when a new observation is recorded.
+	// The tenant context must be set in ctx for multi-tenant event isolation.
+	// Returns an error if the event cannot be published.
+	PublishObservationRecorded(ctx context.Context, observation domain.MarketPriceObservation) error
+
+	// Close releases resources held by the publisher.
+	// Should be called during application shutdown.
+	Close()
+
+	// FlushWithTimeout waits for all outstanding messages to be delivered.
+	// Returns the number of messages still in flight after the timeout.
+	FlushWithTimeout(timeoutMs int) int
+}
+
+// protoPublisher is an interface for publishing protobuf messages to Kafka.
+// This interface allows the KafkaObservationPublisher to be unit-tested without
+// requiring a real Kafka connection.
+type protoPublisher interface {
+	// PublishWithTenant publishes a protobuf message with tenant context
+	// extracted from ctx and injected as a Kafka header (x-tenant-id).
+	PublishWithTenant(ctx context.Context, topic, key string, msg proto.Message) error
+	// FlushWithTimeout waits for outstanding messages to be delivered with timeout.
+	// Returns number of messages still in flight (0 = all delivered).
+	FlushWithTimeout(timeoutMs int) int
+	// Close closes the producer
+	Close()
+}
+
+// KafkaObservationPublisher publishes observation domain events to Kafka topics.
+// It uses the protoPublisher interface for reliable message delivery with tenant isolation.
+type KafkaObservationPublisher struct {
+	producer protoPublisher
+	topic    string
+}
+
+// NewKafkaObservationPublisher creates a new Kafka-based observation event publisher.
+// The producer must be configured with appropriate retry and acknowledgment settings
+// for production use.
+//
+// The producer parameter can be any implementation of protoPublisher
+// (typically *kafka.ProtoProducer).
+func NewKafkaObservationPublisher(producer protoPublisher) (*KafkaObservationPublisher, error) {
+	if producer == nil {
+		return nil, ErrNilProducer
+	}
+
+	return &KafkaObservationPublisher{
+		producer: producer,
+		topic:    ObservationRecordedTopic,
+	}, nil
+}
+
+// PublishObservationRecorded publishes an ObservationRecorded event when a new
+// observation is recorded in the system.
+//
+// The event is published to the ObservationRecordedTopic with the tenant ID as
+// the partition key to ensure ordering of events for the same tenant.
+//
+// The method maps the domain MarketPriceObservation to the proto ObservationRecorded
+// event message before publishing.
+func (p *KafkaObservationPublisher) PublishObservationRecorded(
+	ctx context.Context,
+	observation domain.MarketPriceObservation,
+) error {
+	// Map domain observation to proto event
+	event := mapObservationToProtoEvent(observation)
+
+	// Use dataset_code as partition key for ordering within the same dataset
+	// This ensures observations for the same dataset are processed in order
+	partitionKey := observation.DataSetCode()
+
+	// Publish with tenant headers (extracted from context)
+	if err := p.producer.PublishWithTenant(ctx, p.topic, partitionKey, event); err != nil {
+		return fmt.Errorf("failed to publish ObservationRecorded event for observation %s: %w",
+			observation.ID().String(), err)
+	}
+
+	return nil
+}
+
+// Close closes the underlying Kafka producer and releases resources.
+// Should be called during application shutdown. This does not wait for
+// outstanding messages - call FlushWithTimeout first if needed.
+func (p *KafkaObservationPublisher) Close() {
+	p.producer.Close()
+}
+
+// FlushWithTimeout waits for all outstanding messages to be delivered.
+// Returns the number of messages still in flight after the timeout.
+func (p *KafkaObservationPublisher) FlushWithTimeout(timeoutMs int) int {
+	return p.producer.FlushWithTimeout(timeoutMs)
+}
+
+// mapObservationToProtoEvent converts a domain MarketPriceObservation to a proto
+// ObservationRecorded event message.
+func mapObservationToProtoEvent(obs domain.MarketPriceObservation) *marketinformationv1.ObservationRecorded {
+	event := &marketinformationv1.ObservationRecorded{
+		ObservationId:      obs.ID().String(),
+		DatasetCode:        obs.DataSetCode(),
+		ResolutionKeyValue: obs.ResolutionKey(),
+		ObservedAt:         timestamppb.New(obs.ObservedAt()),
+		Quality:            mapQualityLevelToProto(obs.QualityLevel()),
+		Value:              obs.Value().String(),
+		SourceId:           obs.SourceID().String(),
+		RecordedAt:         timestamppb.New(time.Now()),
+	}
+
+	// Note: The proto event has supersedes_observation_id to track what this observation
+	// supersedes. However, the domain model tracks the inverse (SupersededBy - what replaced
+	// this observation). If the caller needs to set supersedes_observation_id, they should
+	// handle it at the application layer where this relationship is known from the request.
+
+	return event
+}
+
+// mapQualityLevelToProto converts a domain QualityLevel to a proto QualityLevel.
+func mapQualityLevelToProto(level domain.QualityLevel) marketinformationv1.QualityLevel {
+	switch level {
+	case domain.QualityLevelEstimate:
+		return marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE
+	case domain.QualityLevelActual:
+		return marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL
+	case domain.QualityLevelVerified:
+		// Map Verified to ACTUAL since proto has ESTIMATE, PROVISIONAL, ACTUAL, REVISED
+		// The domain QualityLevelVerified is semantically closest to ACTUAL
+		return marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL
+	default:
+		return marketinformationv1.QualityLevel_QUALITY_LEVEL_UNSPECIFIED
+	}
+}

--- a/services/market-information/service/observation_service.go
+++ b/services/market-information/service/observation_service.go
@@ -1,0 +1,810 @@
+// Package service provides gRPC service implementations for the Market Information service.
+// BIAN Service Domain: Market Information Management
+//
+// This file implements the Observation-related gRPC methods for the MarketInformationService.
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+)
+
+// RecordObservation records a new market data observation.
+// Returns INVALID_ARGUMENT if validation fails.
+// Returns NOT_FOUND if data set or source doesn't exist.
+func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservationRequest) (*pb.RecordObservationResponse, error) {
+	// 1. Load active dataset definition by code
+	dataset, err := s.dataSetRepo.FindByCode(ctx, req.DatasetCode)
+	if err != nil {
+		return nil, s.mapObservationDomainError(err, "RecordObservation", req.DatasetCode)
+	}
+
+	// Verify dataset is active
+	if dataset.Status() != domain.DataSetStatusActive {
+		s.logger.Warn("dataset is not active",
+			"dataset_code", req.DatasetCode,
+			"status", dataset.Status().String())
+		return nil, status.Errorf(codes.FailedPrecondition, "dataset %s is not active (status: %s)", req.DatasetCode, dataset.Status().String())
+	}
+
+	// 2. Load the data source
+	source, err := s.sourceRepo.FindByCode(ctx, req.SourceCode)
+	if err != nil {
+		return nil, s.mapObservationDomainError(err, "RecordObservation", req.SourceCode)
+	}
+
+	// Verify source is active
+	if !source.IsActive() {
+		s.logger.Warn("data source is not active",
+			"source_code", req.SourceCode)
+		return nil, status.Errorf(codes.FailedPrecondition, "data source %s is not active", req.SourceCode)
+	}
+
+	// 3. Convert observation context to CEL map
+	observationContext := ToContextMap(req.Attributes)
+
+	// 4. Compute resolution key via CEL evaluation (if celValidator is available)
+	resolutionKey, err := s.computeResolutionKey(dataset, observationContext)
+	if err != nil {
+		s.logger.Warn("resolution key computation failed",
+			"dataset_code", req.DatasetCode,
+			"error", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to compute resolution key: %v", err)
+	}
+
+	// 5. Evaluate validation expression (reject if false)
+	if err := s.validateObservation(dataset, req, observationContext); err != nil {
+		s.logger.Warn("observation validation failed",
+			"dataset_code", req.DatasetCode,
+			"value", req.Value,
+			"error", err)
+		return nil, err // Already formatted as gRPC status error
+	}
+
+	// 6. Parse the decimal value
+	value, err := decimal.NewFromString(req.Value)
+	if err != nil {
+		s.logger.Warn("invalid decimal value",
+			"value", req.Value,
+			"error", err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid decimal value: %s", req.Value)
+	}
+
+	// 7. Convert proto QualityLevel to domain QualityLevel
+	qualityLevel := protoQualityLevelToDomain(req.Quality)
+
+	// 8. Determine valid_to (use provided or default to 100 years in future)
+	validTo := time.Now().Add(100 * 365 * 24 * time.Hour) // Default: far future
+	if req.ValidTo != nil {
+		validTo = req.ValidTo.AsTime()
+	}
+
+	// 9. Create the domain observation
+	observation, err := domain.NewMarketPriceObservation(
+		req.DatasetCode,
+		source.ID(),
+		resolutionKey,
+		value,
+		dataset.Name(), // Use dataset name as unit
+		req.ObservedAt.AsTime(),
+		req.ValidFrom.AsTime(),
+		validTo,
+		uuid.New(), // CausationID - generate new for this request
+		qualityLevel,
+		source.TrustLevel(),
+	)
+	if err != nil {
+		s.logger.Warn("failed to create observation",
+			"dataset_code", req.DatasetCode,
+			"error", err)
+		return nil, s.mapObservationDomainError(err, "RecordObservation", req.DatasetCode)
+	}
+
+	// 10. Persist the observation
+	if err := s.observationRepo.Record(ctx, observation); err != nil {
+		s.logger.Error("failed to record observation",
+			"dataset_code", req.DatasetCode,
+			"error", err)
+		return nil, s.mapObservationDomainError(err, "RecordObservation", req.DatasetCode)
+	}
+
+	s.logger.Info("observation recorded",
+		"observation_id", observation.ID().String(),
+		"dataset_code", req.DatasetCode,
+		"resolution_key", resolutionKey,
+		"quality", qualityLevel.String())
+
+	// 11. Publish ObservationRecorded event to Kafka ONLY if quality is ACTUAL or VERIFIED (not ESTIMATE)
+	if s.eventPublisher != nil && shouldPublishObservationEvent(qualityLevel) {
+		// Use the specialized publisher if available, otherwise use generic publisher
+		if obsPublisher, ok := s.eventPublisher.(ObservationEventPublisher); ok {
+			if err := obsPublisher.PublishObservationRecorded(ctx, observation); err != nil {
+				// Log but don't fail the request - observation is already persisted
+				s.logger.Error("failed to publish observation event",
+					"observation_id", observation.ID().String(),
+					"error", err)
+			}
+		} else {
+			// Fallback to generic publisher
+			event := mapObservationToProtoEvent(observation)
+			if err := s.eventPublisher.Publish(ctx, event); err != nil {
+				s.logger.Error("failed to publish observation event",
+					"observation_id", observation.ID().String(),
+					"error", err)
+			}
+		}
+	}
+
+	// 12. Return proto response
+	return &pb.RecordObservationResponse{
+		Observation: domainObservationToProto(observation, req.Attributes),
+	}, nil
+}
+
+// RecordObservationBatch records multiple observations with parallel validation.
+// Returns partial success with details for each observation.
+func (s *Server) RecordObservationBatch(ctx context.Context, req *pb.RecordObservationBatchRequest) (*pb.RecordObservationBatchResponse, error) {
+	if len(req.Observations) == 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "at least one observation is required")
+	}
+
+	// Generate batch ID if not provided
+	batchID := req.BatchId
+	if batchID == "" {
+		batchID = uuid.New().String()
+	}
+
+	// Pre-fetch datasets and sources to avoid repeated lookups
+	datasets := make(map[string]domain.DataSetDefinition)
+	sources := make(map[string]domain.DataSource)
+	var fetchMu sync.Mutex
+
+	// Use sync.Map for concurrent error collection
+	validationErrors := &sync.Map{}
+
+	// Parallel CEL validation using errgroup
+	g, gCtx := errgroup.WithContext(ctx)
+
+	// Limit concurrency to avoid overwhelming the system
+	g.SetLimit(50)
+
+	for i, entry := range req.Observations {
+		i, entry := i, entry // Capture loop variables
+
+		g.Go(func() error {
+			// Check context cancellation
+			if gCtx.Err() != nil {
+				return gCtx.Err()
+			}
+
+			// validateEntry handles validation and stores errors in validationErrors.
+			// We always return nil from the goroutine to allow other entries to continue processing.
+			// The actual errors are collected in validationErrors sync.Map.
+			validateEntry := func() {
+				// Fetch or get cached dataset
+				fetchMu.Lock()
+				dataset, exists := datasets[entry.DatasetCode]
+				fetchMu.Unlock()
+
+				if !exists {
+					ds, err := s.dataSetRepo.FindByCode(gCtx, entry.DatasetCode)
+					if err != nil {
+						validationErrors.Store(i, fmt.Sprintf("dataset not found: %s", entry.DatasetCode))
+						return
+					}
+					fetchMu.Lock()
+					datasets[entry.DatasetCode] = ds
+					dataset = ds
+					fetchMu.Unlock()
+				}
+
+				// Verify dataset is active
+				if dataset.Status() != domain.DataSetStatusActive {
+					validationErrors.Store(i, fmt.Sprintf("dataset %s is not active", entry.DatasetCode))
+					return
+				}
+
+				// Fetch or get cached source
+				fetchMu.Lock()
+				source, exists := sources[entry.SourceCode]
+				fetchMu.Unlock()
+
+				if !exists {
+					src, err := s.sourceRepo.FindByCode(gCtx, entry.SourceCode)
+					if err != nil {
+						validationErrors.Store(i, fmt.Sprintf("source not found: %s", entry.SourceCode))
+						return
+					}
+					fetchMu.Lock()
+					sources[entry.SourceCode] = src
+					source = src
+					fetchMu.Unlock()
+				}
+
+				// Verify source is active
+				if !source.IsActive() {
+					validationErrors.Store(i, fmt.Sprintf("source %s is not active", entry.SourceCode))
+					return
+				}
+
+				// Convert observation context
+				observationContext := ToContextMap(entry.Attributes)
+
+				// Validate using CEL expression
+				if s.celValidator != nil && dataset.ValidationExpression() != "" {
+					validTo := time.Now().Add(100 * 365 * 24 * time.Hour)
+					if entry.ValidTo != nil {
+						validTo = entry.ValidTo.AsTime()
+					}
+
+					validationInput := ValidationInput{
+						Value:              entry.Value,
+						ObservationContext: observationContext,
+						ObservedAt:         entry.ObservedAt.AsTime(),
+						ValidFrom:          entry.ValidFrom.AsTime(),
+						ValidTo:            validTo,
+						SourceID:           source.ID().String(),
+						Quality:            int(entry.Quality),
+					}
+
+					prg, err := s.celValidator.CompileValidation(dataset.ValidationExpression())
+					if err != nil {
+						validationErrors.Store(i, fmt.Sprintf("validation expression error: %v", err))
+						return
+					}
+
+					valid, err := s.celValidator.EvaluateValidation(prg, validationInput)
+					if err != nil {
+						validationErrors.Store(i, fmt.Sprintf("validation evaluation error: %v", err))
+						return
+					}
+
+					if !valid {
+						errMsg := s.generateValidationErrorMessage(dataset, entry.Value, observationContext)
+						validationErrors.Store(i, errMsg)
+						return
+					}
+				}
+
+				// Validate decimal value
+				if _, err := decimal.NewFromString(entry.Value); err != nil {
+					validationErrors.Store(i, fmt.Sprintf("invalid decimal value: %s", entry.Value))
+					return
+				}
+			}
+
+			validateEntry()
+			return nil
+		})
+	}
+
+	// Wait for all validations to complete
+	if err := g.Wait(); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, status.Errorf(codes.DeadlineExceeded, "batch validation timed out")
+		}
+		return nil, status.Errorf(codes.Internal, "batch validation failed: %v", err)
+	}
+
+	// Process valid observations and build results
+	results := make([]*pb.BatchObservationResult, len(req.Observations))
+	var successCount, failureCount int32
+
+	for i, entry := range req.Observations {
+		// Check if this entry had a validation error
+		if errMsgVal, hasError := validationErrors.Load(i); hasError {
+			errMsg, ok := errMsgVal.(string)
+			if !ok {
+				errMsg = "unknown validation error"
+			}
+			results[i] = &pb.BatchObservationResult{
+				Success:         false,
+				ErrorMessage:    errMsg,
+				ClientReference: entry.ClientReference,
+				Index:           int32(i),
+			}
+			failureCount++
+			continue
+		}
+
+		// Get cached dataset and source
+		fetchMu.Lock()
+		dataset := datasets[entry.DatasetCode]
+		source := sources[entry.SourceCode]
+		fetchMu.Unlock()
+
+		// Compute resolution key
+		observationContext := ToContextMap(entry.Attributes)
+		resolutionKey, err := s.computeResolutionKey(dataset, observationContext)
+		if err != nil {
+			results[i] = &pb.BatchObservationResult{
+				Success:         false,
+				ErrorMessage:    fmt.Sprintf("resolution key error: %v", err),
+				ClientReference: entry.ClientReference,
+				Index:           int32(i),
+			}
+			failureCount++
+			continue
+		}
+
+		// Parse value
+		value, _ := decimal.NewFromString(entry.Value) // Already validated
+
+		// Convert quality level
+		qualityLevel := protoQualityLevelToDomain(entry.Quality)
+
+		// Determine valid_to
+		validTo := time.Now().Add(100 * 365 * 24 * time.Hour)
+		if entry.ValidTo != nil {
+			validTo = entry.ValidTo.AsTime()
+		}
+
+		// Create domain observation
+		observation, err := domain.NewMarketPriceObservation(
+			entry.DatasetCode,
+			source.ID(),
+			resolutionKey,
+			value,
+			dataset.Name(),
+			entry.ObservedAt.AsTime(),
+			entry.ValidFrom.AsTime(),
+			validTo,
+			uuid.New(),
+			qualityLevel,
+			source.TrustLevel(),
+		)
+		if err != nil {
+			results[i] = &pb.BatchObservationResult{
+				Success:         false,
+				ErrorMessage:    fmt.Sprintf("observation creation error: %v", err),
+				ClientReference: entry.ClientReference,
+				Index:           int32(i),
+			}
+			failureCount++
+			continue
+		}
+
+		// Record the observation
+		if err := s.observationRepo.Record(ctx, observation); err != nil {
+			results[i] = &pb.BatchObservationResult{
+				Success:         false,
+				ErrorMessage:    fmt.Sprintf("persistence error: %v", err),
+				ClientReference: entry.ClientReference,
+				Index:           int32(i),
+			}
+			failureCount++
+			continue
+		}
+
+		// Publish event for ACTUAL and VERIFIED quality levels
+		if s.eventPublisher != nil && shouldPublishObservationEvent(qualityLevel) {
+			if obsPublisher, ok := s.eventPublisher.(ObservationEventPublisher); ok {
+				if err := obsPublisher.PublishObservationRecorded(ctx, observation); err != nil {
+					s.logger.Error("failed to publish batch observation event",
+						"observation_id", observation.ID().String(),
+						"error", err)
+				}
+			} else {
+				event := mapObservationToProtoEvent(observation)
+				if err := s.eventPublisher.Publish(ctx, event); err != nil {
+					s.logger.Error("failed to publish batch observation event",
+						"observation_id", observation.ID().String(),
+						"error", err)
+				}
+			}
+		}
+
+		results[i] = &pb.BatchObservationResult{
+			Success:         true,
+			Observation:     domainObservationToProto(observation, entry.Attributes),
+			ClientReference: entry.ClientReference,
+			Index:           int32(i),
+		}
+		successCount++
+	}
+
+	s.logger.Info("batch observation recorded",
+		"batch_id", batchID,
+		"total", len(req.Observations),
+		"success", successCount,
+		"failure", failureCount)
+
+	return &pb.RecordObservationBatchResponse{
+		Results:      results,
+		BatchId:      batchID,
+		TotalCount:   int32(len(req.Observations)),
+		SuccessCount: successCount,
+		FailureCount: failureCount,
+	}, nil
+}
+
+// RetrieveObservation fetches a specific observation with bi-temporal query support.
+// Returns NOT_FOUND if observation doesn't exist at the requested times.
+func (s *Server) RetrieveObservation(ctx context.Context, req *pb.RetrieveObservationRequest) (*pb.RetrieveObservationResponse, error) {
+	// Parse observation ID
+	obsID, err := uuid.Parse(req.ObservationId)
+	if err != nil {
+		s.logger.Warn("invalid observation ID",
+			"observation_id", req.ObservationId,
+			"error", err)
+		return nil, status.Errorf(codes.InvalidArgument, "invalid observation ID: %s", req.ObservationId)
+	}
+
+	// Retrieve observation by ID
+	observation, err := s.observationRepo.FindByID(ctx, obsID)
+	if err != nil {
+		return nil, s.mapObservationDomainError(err, "RetrieveObservation", req.ObservationId)
+	}
+
+	// Apply knowledge_base_time filter if provided (bi-temporal query)
+	if req.KnowledgeBaseTime != nil {
+		knowledgeTime := req.KnowledgeBaseTime.AsTime()
+
+		// Check if the observation was known at the requested time
+		// An observation is "known" if it was created before the knowledge base time
+		// and not yet superseded at that time
+		if observation.CreatedAt().After(knowledgeTime) {
+			s.logger.Debug("observation not known at requested time",
+				"observation_id", req.ObservationId,
+				"knowledge_base_time", knowledgeTime,
+				"created_at", observation.CreatedAt())
+			return nil, status.Errorf(codes.NotFound, "observation %s was not known at %v", req.ObservationId, knowledgeTime)
+		}
+
+		// Check if superseded before the knowledge base time
+		if observation.SupersededAt() != nil && observation.SupersededAt().Before(knowledgeTime) {
+			s.logger.Debug("observation was superseded before requested time",
+				"observation_id", req.ObservationId,
+				"knowledge_base_time", knowledgeTime,
+				"superseded_at", observation.SupersededAt())
+			return nil, status.Errorf(codes.NotFound, "observation %s was superseded before %v", req.ObservationId, knowledgeTime)
+		}
+	}
+
+	return &pb.RetrieveObservationResponse{
+		Observation: domainObservationToProto(observation, nil),
+	}, nil
+}
+
+// ListObservations returns observations matching the filter criteria.
+// Supports filtering by data set, time ranges, quality level, and pagination.
+func (s *Server) ListObservations(ctx context.Context, req *pb.ListObservationsRequest) (*pb.ListObservationsResponse, error) {
+	// Build query from request filters
+	query := domain.ObservationQuery{
+		DataSetCode:       req.DatasetCode,
+		IncludeSuperseded: req.IncludeSuperseded,
+	}
+
+	// Apply resolution key filter
+	if req.ResolutionKeyValue != "" {
+		query.ResolutionKey = &req.ResolutionKeyValue
+	}
+
+	// Apply time range filters
+	if req.ObservedFrom != nil {
+		t := req.ObservedFrom.AsTime()
+		query.ObservedAfter = &t
+	}
+	if req.ObservedTo != nil {
+		t := req.ObservedTo.AsTime()
+		query.ObservedBefore = &t
+	}
+
+	// Apply quality filter
+	if req.QualityFilter != pb.QualityLevel_QUALITY_LEVEL_UNSPECIFIED {
+		qualityLevel := protoQualityLevelToDomain(req.QualityFilter)
+		query.QualityLevel = &qualityLevel
+	}
+
+	// Apply pagination
+	pageSize := int(req.PageSize)
+	if pageSize == 0 {
+		pageSize = 100 // Default
+	}
+	if pageSize > 1000 {
+		pageSize = 1000 // Max from proto validation
+	}
+	query.Limit = pageSize
+
+	// Execute query
+	observations, err := s.observationRepo.Query(ctx, query)
+	if err != nil {
+		s.logger.Error("failed to query observations",
+			"dataset_code", req.DatasetCode,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to query observations: %v", err)
+	}
+
+	// Convert to proto messages
+	pbObservations := make([]*pb.MarketPriceObservation, len(observations))
+	for i, obs := range observations {
+		pbObservations[i] = domainObservationToProto(obs, nil)
+	}
+
+	s.logger.Debug("listed observations",
+		"dataset_code", req.DatasetCode,
+		"count", len(pbObservations))
+
+	return &pb.ListObservationsResponse{
+		Observations:  pbObservations,
+		NextPageToken: "", // TODO: Implement cursor-based pagination
+		TotalCount:    int32(len(pbObservations)),
+	}, nil
+}
+
+// defaultResolutionKey is used when no resolution key can be computed.
+const defaultResolutionKey = "default"
+
+// computeResolutionKey evaluates the resolution key CEL expression.
+func (s *Server) computeResolutionKey(dataset domain.DataSetDefinition, observationContext map[string]string) (string, error) {
+	if s.celValidator == nil {
+		// Fallback: use a simple concatenation of all context values
+		if len(observationContext) == 0 {
+			return defaultResolutionKey, nil
+		}
+		// Simple fallback - just use first non-empty value or default
+		for _, v := range observationContext {
+			if v != "" {
+				return v, nil
+			}
+		}
+		return defaultResolutionKey, nil
+	}
+
+	expression := dataset.ResolutionKeyExpression()
+	if expression == "" {
+		return defaultResolutionKey, nil
+	}
+
+	prg, err := s.celValidator.CompileResolutionKey(expression)
+	if err != nil {
+		return "", fmt.Errorf("failed to compile resolution key expression: %w", err)
+	}
+
+	result, err := s.celValidator.EvaluateResolutionKey(prg, ResolutionKeyInput{
+		ObservationContext: observationContext,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to evaluate resolution key expression: %w", err)
+	}
+
+	return result, nil
+}
+
+// validateObservation evaluates the validation CEL expression.
+func (s *Server) validateObservation(dataset domain.DataSetDefinition, req *pb.RecordObservationRequest, observationContext map[string]string) error {
+	if s.celValidator == nil {
+		// No validator available - skip validation
+		return nil
+	}
+
+	expression := dataset.ValidationExpression()
+	if expression == "" {
+		return nil
+	}
+
+	// Determine valid_to for validation
+	validTo := time.Now().Add(100 * 365 * 24 * time.Hour)
+	if req.ValidTo != nil {
+		validTo = req.ValidTo.AsTime()
+	}
+
+	validationInput := ValidationInput{
+		Value:              req.Value,
+		ObservationContext: observationContext,
+		ObservedAt:         req.ObservedAt.AsTime(),
+		ValidFrom:          req.ValidFrom.AsTime(),
+		ValidTo:            validTo,
+		SourceID:           req.SourceCode,
+		Quality:            int(req.Quality),
+	}
+
+	prg, err := s.celValidator.CompileValidation(expression)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "validation expression compilation failed: %v", err)
+	}
+
+	valid, err := s.celValidator.EvaluateValidation(prg, validationInput)
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "validation evaluation failed: %v", err)
+	}
+
+	if !valid {
+		// Generate custom error message if expression is available
+		errMsg := s.generateValidationErrorMessage(dataset, req.Value, observationContext)
+		return status.Errorf(codes.InvalidArgument, "%s", errMsg)
+	}
+
+	return nil
+}
+
+// generateValidationErrorMessage generates a custom error message using CEL expression.
+func (s *Server) generateValidationErrorMessage(dataset domain.DataSetDefinition, value string, observationContext map[string]string) string {
+	defaultMsg := fmt.Sprintf("observation value %s failed validation for dataset %s", value, dataset.Code())
+
+	if s.celValidator == nil {
+		return defaultMsg
+	}
+
+	expression := dataset.ErrorMessageExpression()
+	if expression == "" {
+		return defaultMsg
+	}
+
+	prg, err := s.celValidator.CompileErrorMessage(expression)
+	if err != nil {
+		return defaultMsg
+	}
+
+	msg, err := s.celValidator.EvaluateErrorMessage(prg, ErrorMessageInput{
+		Value:              value,
+		ObservationContext: observationContext,
+		DatasetCode:        dataset.Code(),
+	})
+	if err != nil {
+		return defaultMsg
+	}
+
+	return msg
+}
+
+// mapObservationDomainError converts domain errors to appropriate gRPC status codes.
+func (s *Server) mapObservationDomainError(err error, operation, identifier string) error {
+	switch {
+	case errors.Is(err, domain.ErrObservationNotFound):
+		s.logger.Warn("observation not found",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.NotFound, "observation not found: %s", identifier)
+
+	case errors.Is(err, domain.ErrDataSetNotFound):
+		s.logger.Warn("dataset not found",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.NotFound, "dataset not found: %s", identifier)
+
+	case errors.Is(err, domain.ErrDataSourceNotFound):
+		s.logger.Warn("data source not found",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.NotFound, "data source not found: %s", identifier)
+
+	case errors.Is(err, domain.ErrDataSetDeprecated):
+		s.logger.Warn("dataset is deprecated",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.FailedPrecondition, "dataset is deprecated: %s", identifier)
+
+	case errors.Is(err, domain.ErrInvalidTemporalBounds):
+		s.logger.Warn("invalid temporal bounds",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.InvalidArgument, "invalid temporal bounds: valid_from must be before valid_to")
+
+	case errors.Is(err, domain.ErrInvalidQualityLevel):
+		s.logger.Warn("invalid quality level",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.InvalidArgument, "invalid quality level")
+
+	case errors.Is(err, domain.ErrDataSetCodeRequired):
+		s.logger.Warn("dataset code required",
+			"operation", operation)
+		return status.Errorf(codes.InvalidArgument, "dataset code is required")
+
+	case errors.Is(err, domain.ErrSourceIDRequired):
+		s.logger.Warn("source ID required",
+			"operation", operation)
+		return status.Errorf(codes.InvalidArgument, "source ID is required")
+
+	case errors.Is(err, domain.ErrResolutionKeyRequired):
+		s.logger.Warn("resolution key required",
+			"operation", operation)
+		return status.Errorf(codes.InvalidArgument, "resolution key is required")
+
+	case errors.Is(err, domain.ErrUnitRequired):
+		s.logger.Warn("unit required",
+			"operation", operation)
+		return status.Errorf(codes.InvalidArgument, "unit is required")
+
+	case errors.Is(err, domain.ErrCausationIDRequired):
+		s.logger.Warn("causation ID required",
+			"operation", operation)
+		return status.Errorf(codes.InvalidArgument, "causation ID is required")
+
+	case errors.Is(err, domain.ErrInvalidTrustLevel):
+		s.logger.Warn("invalid trust level",
+			"operation", operation)
+		return status.Errorf(codes.InvalidArgument, "trust level must be between 0 and 100")
+
+	default:
+		s.logger.Error("internal error",
+			"operation", operation,
+			"identifier", identifier,
+			"error", err)
+		return status.Errorf(codes.Internal, "internal error: %v", err)
+	}
+}
+
+// shouldPublishObservationEvent determines if an observation event should be published.
+// Only publish for ACTUAL and VERIFIED quality levels (not ESTIMATE).
+func shouldPublishObservationEvent(quality domain.QualityLevel) bool {
+	return quality == domain.QualityLevelActual || quality == domain.QualityLevelVerified
+}
+
+// protoQualityLevelToDomain converts proto QualityLevel to domain QualityLevel.
+func protoQualityLevelToDomain(protoQuality pb.QualityLevel) domain.QualityLevel {
+	switch protoQuality {
+	case pb.QualityLevel_QUALITY_LEVEL_UNSPECIFIED:
+		return domain.QualityLevelEstimate // Default to lowest quality
+	case pb.QualityLevel_QUALITY_LEVEL_ESTIMATE:
+		return domain.QualityLevelEstimate
+	case pb.QualityLevel_QUALITY_LEVEL_PROVISIONAL:
+		// Map PROVISIONAL to ESTIMATE (domain doesn't have PROVISIONAL)
+		return domain.QualityLevelEstimate
+	case pb.QualityLevel_QUALITY_LEVEL_ACTUAL:
+		return domain.QualityLevelActual
+	case pb.QualityLevel_QUALITY_LEVEL_REVISED:
+		// Map REVISED to VERIFIED (corrected values are verified)
+		return domain.QualityLevelVerified
+	default:
+		return domain.QualityLevelEstimate // Default to lowest quality
+	}
+}
+
+// domainQualityLevelToProto converts domain QualityLevel to proto QualityLevel.
+func domainQualityLevelToProto(domainQuality domain.QualityLevel) pb.QualityLevel {
+	switch domainQuality {
+	case domain.QualityLevelEstimate:
+		return pb.QualityLevel_QUALITY_LEVEL_ESTIMATE
+	case domain.QualityLevelActual:
+		return pb.QualityLevel_QUALITY_LEVEL_ACTUAL
+	case domain.QualityLevelVerified:
+		// Domain VERIFIED maps to proto ACTUAL (highest reliable quality)
+		return pb.QualityLevel_QUALITY_LEVEL_ACTUAL
+	default:
+		return pb.QualityLevel_QUALITY_LEVEL_UNSPECIFIED
+	}
+}
+
+// domainObservationToProto converts a domain MarketPriceObservation to proto.
+func domainObservationToProto(obs domain.MarketPriceObservation, attributes []*quantityv1.AttributeEntry) *pb.MarketPriceObservation {
+	pbObs := &pb.MarketPriceObservation{
+		Id:                 obs.ID().String(),
+		DatasetCode:        obs.DataSetCode(),
+		DatasetVersion:     1, // TODO: Track dataset version in observation
+		ResolutionKeyValue: obs.ResolutionKey(),
+		ObservedAt:         timestamppb.New(obs.ObservedAt()),
+		ValidFrom:          timestamppb.New(obs.ValidFrom()),
+		ValidTo:            timestamppb.New(obs.ValidTo()),
+		Value:              obs.Value().String(),
+		Quality:            domainQualityLevelToProto(obs.QualityLevel()),
+		SourceId:           obs.SourceID().String(),
+		CreatedAt:          timestamppb.New(obs.CreatedAt()),
+		Attributes:         attributes,
+	}
+
+	// Set optional superseded fields
+	if obs.SupersededAt() != nil {
+		pbObs.SupersededAt = timestamppb.New(*obs.SupersededAt())
+	}
+	if obs.SupersededBy() != nil {
+		pbObs.SupersededById = obs.SupersededBy().String()
+	}
+
+	return pbObs
+}

--- a/services/market-information/service/observation_service.go
+++ b/services/market-information/service/observation_service.go
@@ -76,7 +76,19 @@ func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservatio
 		return nil, err // Already formatted as gRPC status error
 	}
 
-	// 6. Parse the decimal value
+	// 6. Validate required timestamps (guard against nil dereference)
+	if req.ObservedAt == nil {
+		s.logger.Warn("observed_at timestamp is required",
+			"dataset_code", req.DatasetCode)
+		return nil, status.Errorf(codes.InvalidArgument, "observed_at timestamp is required")
+	}
+	if req.ValidFrom == nil {
+		s.logger.Warn("valid_from timestamp is required",
+			"dataset_code", req.DatasetCode)
+		return nil, status.Errorf(codes.InvalidArgument, "valid_from timestamp is required")
+	}
+
+	// 7. Parse the decimal value
 	value, err := decimal.NewFromString(req.Value)
 	if err != nil {
 		s.logger.Warn("invalid decimal value",
@@ -85,16 +97,16 @@ func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservatio
 		return nil, status.Errorf(codes.InvalidArgument, "invalid decimal value: %s", req.Value)
 	}
 
-	// 7. Convert proto QualityLevel to domain QualityLevel
+	// 8. Convert proto QualityLevel to domain QualityLevel
 	qualityLevel := protoQualityLevelToDomain(req.Quality)
 
-	// 8. Determine valid_to (use provided or default to 100 years in future)
+	// 9. Determine valid_to (use provided or default to 100 years in future)
 	validTo := time.Now().Add(100 * 365 * 24 * time.Hour) // Default: far future
 	if req.ValidTo != nil {
 		validTo = req.ValidTo.AsTime()
 	}
 
-	// 9. Create the domain observation
+	// 10. Create the domain observation
 	observation, err := domain.NewMarketPriceObservation(
 		req.DatasetCode,
 		source.ID(),
@@ -115,7 +127,7 @@ func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservatio
 		return nil, s.mapObservationDomainError(err, "RecordObservation", req.DatasetCode)
 	}
 
-	// 10. Persist the observation
+	// 11. Persist the observation
 	if err := s.observationRepo.Record(ctx, observation); err != nil {
 		s.logger.Error("failed to record observation",
 			"dataset_code", req.DatasetCode,
@@ -129,7 +141,7 @@ func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservatio
 		"resolution_key", resolutionKey,
 		"quality", qualityLevel.String())
 
-	// 11. Publish ObservationRecorded event to Kafka ONLY if quality is ACTUAL or VERIFIED (not ESTIMATE)
+	// 12. Publish ObservationRecorded event to Kafka ONLY if quality is ACTUAL or VERIFIED (not ESTIMATE)
 	if s.eventPublisher != nil && shouldPublishObservationEvent(qualityLevel) {
 		// Use the specialized publisher if available, otherwise use generic publisher
 		if obsPublisher, ok := s.eventPublisher.(ObservationEventPublisher); ok {
@@ -150,7 +162,7 @@ func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservatio
 		}
 	}
 
-	// 12. Return proto response
+	// 13. Return proto response
 	return &pb.RecordObservationResponse{
 		Observation: domainObservationToProto(observation, req.Attributes),
 	}, nil
@@ -239,6 +251,16 @@ func (s *Server) RecordObservationBatch(ctx context.Context, req *pb.RecordObser
 				// Verify source is active
 				if !source.IsActive() {
 					validationErrors.Store(i, fmt.Sprintf("source %s is not active", entry.SourceCode))
+					return
+				}
+
+				// Validate required timestamps (guard against nil dereference)
+				if entry.ObservedAt == nil {
+					validationErrors.Store(i, "observed_at timestamp is required")
+					return
+				}
+				if entry.ValidFrom == nil {
+					validationErrors.Store(i, "valid_from timestamp is required")
 					return
 				}
 
@@ -516,6 +538,9 @@ func (s *Server) ListObservations(ctx context.Context, req *pb.ListObservationsR
 
 	// Apply pagination
 	pageSize := int(req.PageSize)
+	if pageSize < 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "page_size cannot be negative")
+	}
 	if pageSize == 0 {
 		pageSize = 100 // Default
 	}

--- a/services/market-information/service/observation_service.go
+++ b/services/market-information/service/observation_service.go
@@ -572,7 +572,7 @@ func (s *Server) ListObservations(ctx context.Context, req *pb.ListObservationsR
 	return &pb.ListObservationsResponse{
 		Observations:  pbObservations,
 		NextPageToken: "", // TODO: Implement cursor-based pagination
-		TotalCount:    int32(len(pbObservations)),
+		TotalCount:    0,  // TODO: Add count query - 0 means unknown per proto spec
 	}, nil
 }
 

--- a/services/market-information/service/observation_service.go
+++ b/services/market-information/service/observation_service.go
@@ -55,28 +55,8 @@ func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservatio
 		return nil, status.Errorf(codes.FailedPrecondition, "data source %s is not active", req.SourceCode)
 	}
 
-	// 3. Convert observation context to CEL map
-	observationContext := ToContextMap(req.Attributes)
-
-	// 4. Compute resolution key via CEL evaluation (if celValidator is available)
-	resolutionKey, err := s.computeResolutionKey(dataset, observationContext)
-	if err != nil {
-		s.logger.Warn("resolution key computation failed",
-			"dataset_code", req.DatasetCode,
-			"error", err)
-		return nil, status.Errorf(codes.InvalidArgument, "failed to compute resolution key: %v", err)
-	}
-
-	// 5. Evaluate validation expression (reject if false)
-	if err := s.validateObservation(dataset, req, observationContext, source.ID().String()); err != nil {
-		s.logger.Warn("observation validation failed",
-			"dataset_code", req.DatasetCode,
-			"value", req.Value,
-			"error", err)
-		return nil, err // Already formatted as gRPC status error
-	}
-
-	// 6. Validate required timestamps (guard against nil dereference)
+	// 3. Validate required timestamps BEFORE any usage (guard against nil dereference)
+	// This must happen before validateObservation which calls AsTime() on these fields.
 	if req.ObservedAt == nil {
 		s.logger.Warn("observed_at timestamp is required",
 			"dataset_code", req.DatasetCode)
@@ -86,6 +66,27 @@ func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservatio
 		s.logger.Warn("valid_from timestamp is required",
 			"dataset_code", req.DatasetCode)
 		return nil, status.Errorf(codes.InvalidArgument, "valid_from timestamp is required")
+	}
+
+	// 4. Convert observation context to CEL map
+	observationContext := ToContextMap(req.Attributes)
+
+	// 5. Compute resolution key via CEL evaluation (if celValidator is available)
+	resolutionKey, err := s.computeResolutionKey(dataset, observationContext)
+	if err != nil {
+		s.logger.Warn("resolution key computation failed",
+			"dataset_code", req.DatasetCode,
+			"error", err)
+		return nil, status.Errorf(codes.InvalidArgument, "failed to compute resolution key: %v", err)
+	}
+
+	// 6. Evaluate validation expression (reject if false)
+	if err := s.validateObservation(dataset, req, observationContext, source.ID().String()); err != nil {
+		s.logger.Warn("observation validation failed",
+			"dataset_code", req.DatasetCode,
+			"value", req.Value,
+			"error", err)
+		return nil, err // Already formatted as gRPC status error
 	}
 
 	// 7. Parse the decimal value
@@ -106,7 +107,7 @@ func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservatio
 		validTo = req.ValidTo.AsTime()
 	}
 
-	// 10. Create the domain observation
+	// 10. Create the domain observation (timestamps already validated in step 3)
 	observation, err := domain.NewMarketPriceObservation(
 		req.DatasetCode,
 		source.ID(),

--- a/services/market-information/service/observation_service.go
+++ b/services/market-information/service/observation_service.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -67,7 +68,7 @@ func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservatio
 	}
 
 	// 5. Evaluate validation expression (reject if false)
-	if err := s.validateObservation(dataset, req, observationContext); err != nil {
+	if err := s.validateObservation(dataset, req, observationContext, source.ID().String()); err != nil {
 		s.logger.Warn("observation validation failed",
 			"dataset_code", req.DatasetCode,
 			"value", req.Value,
@@ -294,8 +295,11 @@ func (s *Server) RecordObservationBatch(ctx context.Context, req *pb.RecordObser
 
 	// Wait for all validations to complete
 	if err := g.Wait(); err != nil {
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, status.Errorf(codes.DeadlineExceeded, "batch validation timed out")
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, status.Errorf(codes.Canceled, "batch validation was canceled")
 		}
 		return nil, status.Errorf(codes.Internal, "batch validation failed: %v", err)
 	}
@@ -556,9 +560,14 @@ func (s *Server) computeResolutionKey(dataset domain.DataSetDefinition, observat
 		if len(observationContext) == 0 {
 			return defaultResolutionKey, nil
 		}
-		// Simple fallback - just use first non-empty value or default
-		for _, v := range observationContext {
-			if v != "" {
+		// Sort keys for deterministic selection of first non-empty value
+		keys := make([]string, 0, len(observationContext))
+		for k := range observationContext {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if v := observationContext[k]; v != "" {
 				return v, nil
 			}
 		}
@@ -586,7 +595,7 @@ func (s *Server) computeResolutionKey(dataset domain.DataSetDefinition, observat
 }
 
 // validateObservation evaluates the validation CEL expression.
-func (s *Server) validateObservation(dataset domain.DataSetDefinition, req *pb.RecordObservationRequest, observationContext map[string]string) error {
+func (s *Server) validateObservation(dataset domain.DataSetDefinition, req *pb.RecordObservationRequest, observationContext map[string]string, sourceID string) error {
 	if s.celValidator == nil {
 		// No validator available - skip validation
 		return nil
@@ -609,7 +618,7 @@ func (s *Server) validateObservation(dataset domain.DataSetDefinition, req *pb.R
 		ObservedAt:         req.ObservedAt.AsTime(),
 		ValidFrom:          req.ValidFrom.AsTime(),
 		ValidTo:            validTo,
-		SourceID:           req.SourceCode,
+		SourceID:           sourceID,
 		Quality:            int(req.Quality),
 	}
 

--- a/services/market-information/service/observation_service.go
+++ b/services/market-information/service/observation_service.go
@@ -538,6 +538,9 @@ func (s *Server) ListObservations(ctx context.Context, req *pb.ListObservationsR
 	}
 
 	// Apply pagination
+	if req.PageToken != "" {
+		return nil, status.Errorf(codes.Unimplemented, "cursor pagination not implemented, page_token must be empty")
+	}
 	pageSize := int(req.PageSize)
 	if pageSize < 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "page_size cannot be negative")

--- a/services/market-information/service/server.go
+++ b/services/market-information/service/server.go
@@ -1,0 +1,122 @@
+// Package service provides gRPC service implementations for the Market Information service.
+// BIAN Service Domain: Market Information Management
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+)
+
+// Service initialization errors.
+var (
+	// ErrDataSetRepositoryNil is returned when attempting to create a server with a nil DataSetRepository.
+	ErrDataSetRepositoryNil = errors.New("market information server: dataset repository cannot be nil")
+
+	// ErrObservationRepositoryNil is returned when attempting to create a server with a nil ObservationRepository.
+	ErrObservationRepositoryNil = errors.New("market information server: observation repository cannot be nil")
+
+	// ErrSourceRepositoryNil is returned when attempting to create a server with a nil SourceRepository.
+	ErrSourceRepositoryNil = errors.New("market information server: source repository cannot be nil")
+)
+
+// EventPublisher defines the interface for publishing domain events to Kafka.
+// Implementations should handle serialization and delivery to the messaging infrastructure.
+type EventPublisher interface {
+	// Publish publishes a domain event to the appropriate Kafka topic.
+	// Returns an error if publishing fails.
+	Publish(ctx context.Context, event any) error
+}
+
+// Server implements the MarketInformationService gRPC service.
+// It holds all required dependencies and embeds UnimplementedMarketInformationServiceServer
+// for forward compatibility.
+type Server struct {
+	marketinformationv1.UnimplementedMarketInformationServiceServer
+
+	dataSetRepo     domain.DataSetRepository
+	observationRepo domain.ObservationRepository
+	sourceRepo      domain.SourceRepository
+	celValidator    *CelValidator
+	eventPublisher  EventPublisher
+	logger          *slog.Logger
+}
+
+// Option configures optional dependencies for Server.
+type Option func(*Server)
+
+// WithCelValidator sets an optional CEL validator for expression validation.
+// If not set or set to nil, CEL validation is skipped for backwards compatibility.
+func WithCelValidator(validator *CelValidator) Option {
+	return func(s *Server) {
+		s.celValidator = validator
+	}
+}
+
+// WithEventPublisher sets an optional event publisher for Kafka publishing.
+// If not set or set to nil, event publishing is skipped.
+func WithEventPublisher(publisher EventPublisher) Option {
+	return func(s *Server) {
+		s.eventPublisher = publisher
+	}
+}
+
+// WithLogger sets a custom logger for the server.
+// If not set, defaults to a JSON handler writing to stdout.
+func WithLogger(logger *slog.Logger) Option {
+	return func(s *Server) {
+		s.logger = logger
+	}
+}
+
+// NewServer creates a new Market Information gRPC server with dependency injection.
+//
+// Required Dependencies:
+//   - dataSetRepo: Persistence layer for dataset definitions (must not be nil)
+//   - observationRepo: Persistence layer for market price observations (must not be nil)
+//   - sourceRepo: Persistence layer for data sources (must not be nil)
+//
+// Optional dependencies can be provided via Option functions:
+//   - WithCelValidator: Enables CEL validation of expressions
+//   - WithEventPublisher: Enables publishing domain events to Kafka
+//   - WithLogger: Sets a custom logger (defaults to JSON stdout)
+//
+// Returns an error if any required dependency is nil.
+func NewServer(
+	dataSetRepo domain.DataSetRepository,
+	observationRepo domain.ObservationRepository,
+	sourceRepo domain.SourceRepository,
+	opts ...Option,
+) (*Server, error) {
+	if dataSetRepo == nil {
+		return nil, ErrDataSetRepositoryNil
+	}
+	if observationRepo == nil {
+		return nil, ErrObservationRepositoryNil
+	}
+	if sourceRepo == nil {
+		return nil, ErrSourceRepositoryNil
+	}
+
+	srv := &Server{
+		dataSetRepo:     dataSetRepo,
+		observationRepo: observationRepo,
+		sourceRepo:      sourceRepo,
+	}
+
+	// Apply optional configurations
+	for _, opt := range opts {
+		opt(srv)
+	}
+
+	// Default logger to stdout JSON handler if not provided
+	if srv.logger == nil {
+		srv.logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+
+	return srv, nil
+}

--- a/services/market-information/service/source_service.go
+++ b/services/market-information/service/source_service.go
@@ -1,0 +1,275 @@
+// Package service provides gRPC service implementations for the Market Information service.
+// BIAN Service Domain: Market Information Management
+//
+// This file implements the DataSource-related gRPC methods for the MarketInformationService.
+package service
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/services/market-information/domain"
+)
+
+// RegisterDataSource creates a new data source.
+// Returns ALREADY_EXISTS if code exists.
+// Returns INVALID_ARGUMENT if validation fails.
+func (s *Server) RegisterDataSource(ctx context.Context, req *pb.RegisterDataSourceRequest) (*pb.RegisterDataSourceResponse, error) {
+	// Validate trust_level range (proto validation already covers 0-100, but belt-and-suspenders)
+	if req.TrustLevel < 0 || req.TrustLevel > 100 {
+		s.logger.Warn("invalid trust level",
+			"code", req.Code,
+			"trust_level", req.TrustLevel)
+		return nil, status.Errorf(codes.InvalidArgument, "trust_level must be between 0 and 100, got %d", req.TrustLevel)
+	}
+
+	// Create domain entity using NewDataSource constructor
+	// Default to SourceTypeAPI since proto doesn't include source_type
+	source, err := domain.NewDataSource(
+		req.Code,
+		req.Name,
+		req.Description,
+		domain.SourceTypeAPI,
+		int(req.TrustLevel),
+	)
+	if err != nil {
+		s.logger.Warn("failed to create data source entity",
+			"code", req.Code,
+			"error", err)
+		return nil, s.mapSourceDomainError(err, "RegisterDataSource", req.Code)
+	}
+
+	// Persist the data source
+	if err := s.sourceRepo.Save(ctx, source); err != nil {
+		return nil, s.mapSourceDomainError(err, "RegisterDataSource", req.Code)
+	}
+
+	s.logger.Info("data source registered",
+		"code", source.Code(),
+		"id", source.ID().String(),
+		"trust_level", source.TrustLevel())
+
+	return &pb.RegisterDataSourceResponse{
+		Source: domainSourceToProto(source),
+	}, nil
+}
+
+// UpdateDataSource modifies an existing data source.
+// Returns NOT_FOUND if data source doesn't exist.
+// Returns INVALID_ARGUMENT if validation fails.
+func (s *Server) UpdateDataSource(ctx context.Context, req *pb.UpdateDataSourceRequest) (*pb.UpdateDataSourceResponse, error) {
+	// Validate trust_level range if provided (proto allows 0, which is a valid value)
+	if req.TrustLevel < 0 || req.TrustLevel > 100 {
+		s.logger.Warn("invalid trust level",
+			"code", req.Code,
+			"trust_level", req.TrustLevel)
+		return nil, status.Errorf(codes.InvalidArgument, "trust_level must be between 0 and 100, got %d", req.TrustLevel)
+	}
+
+	// Retrieve existing source
+	existing, err := s.sourceRepo.FindByCode(ctx, req.Code)
+	if err != nil {
+		return nil, s.mapSourceDomainError(err, "UpdateDataSource", req.Code)
+	}
+
+	// Build updated source using builder pattern to preserve existing values
+	// Only update fields that are provided in the request
+	builder := domain.NewDataSourceBuilder().
+		WithID(existing.ID()).
+		WithCode(existing.Code()).
+		WithSourceType(existing.SourceType()).
+		WithIsActive(existing.IsActive()).
+		WithCreatedAt(existing.CreatedAt()).
+		WithUpdatedAt(time.Now())
+
+	// Update name if provided, otherwise keep existing
+	if req.Name != "" {
+		builder.WithName(req.Name)
+	} else {
+		builder.WithName(existing.Name())
+	}
+
+	// Update description (can be set to empty string intentionally)
+	// We always use the request value for description to allow clearing
+	builder.WithDescription(req.Description)
+
+	// Update trust level - proto int32 default is 0, which is valid
+	// Always use the request value as it's validated
+	builder.WithTrustLevel(int(req.TrustLevel))
+
+	updated := builder.Build()
+
+	// Persist the updated source
+	if err := s.sourceRepo.Save(ctx, updated); err != nil {
+		return nil, s.mapSourceDomainError(err, "UpdateDataSource", req.Code)
+	}
+
+	s.logger.Info("data source updated",
+		"code", updated.Code(),
+		"id", updated.ID().String(),
+		"trust_level", updated.TrustLevel())
+
+	return &pb.UpdateDataSourceResponse{
+		Source: domainSourceToProto(updated),
+	}, nil
+}
+
+// DeactivateDataSource marks a data source as inactive (soft delete).
+// Returns NOT_FOUND if data source doesn't exist.
+func (s *Server) DeactivateDataSource(ctx context.Context, req *pb.DeactivateDataSourceRequest) (*pb.DeactivateDataSourceResponse, error) {
+	// Retrieve existing source
+	existing, err := s.sourceRepo.FindByCode(ctx, req.Code)
+	if err != nil {
+		return nil, s.mapSourceDomainError(err, "DeactivateDataSource", req.Code)
+	}
+
+	// Check if already inactive (idempotent operation)
+	if !existing.IsActive() {
+		s.logger.Debug("data source already inactive",
+			"code", req.Code,
+			"id", existing.ID().String())
+		return &pb.DeactivateDataSourceResponse{
+			Source: domainSourceToProto(existing),
+		}, nil
+	}
+
+	// Build deactivated source
+	deactivated := domain.NewDataSourceBuilder().
+		WithID(existing.ID()).
+		WithCode(existing.Code()).
+		WithName(existing.Name()).
+		WithDescription(existing.Description()).
+		WithSourceType(existing.SourceType()).
+		WithTrustLevel(existing.TrustLevel()).
+		WithIsActive(false).
+		WithCreatedAt(existing.CreatedAt()).
+		WithUpdatedAt(time.Now()).
+		Build()
+
+	// Persist the deactivated source
+	if err := s.sourceRepo.Save(ctx, deactivated); err != nil {
+		return nil, s.mapSourceDomainError(err, "DeactivateDataSource", req.Code)
+	}
+
+	s.logger.Info("data source deactivated",
+		"code", deactivated.Code(),
+		"id", deactivated.ID().String())
+
+	return &pb.DeactivateDataSourceResponse{
+		Source: domainSourceToProto(deactivated),
+	}, nil
+}
+
+// ListDataSources returns data sources matching the filter criteria.
+func (s *Server) ListDataSources(ctx context.Context, req *pb.ListDataSourcesRequest) (*pb.ListDataSourcesResponse, error) {
+	// Delegate to repository with active/inactive filter
+	sources, err := s.sourceRepo.List(ctx, req.ActiveOnly)
+	if err != nil {
+		s.logger.Error("failed to list data sources",
+			"active_only", req.ActiveOnly,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to list data sources: %v", err)
+	}
+
+	// Apply pagination
+	pageSize := int(req.PageSize)
+	if pageSize == 0 {
+		pageSize = 50 // Default page size
+	}
+	if pageSize > 100 {
+		pageSize = 100 // Max page size from proto validation
+	}
+
+	// TODO: Implement proper cursor-based pagination
+	if len(sources) > pageSize {
+		sources = sources[:pageSize]
+	}
+
+	// Convert to proto messages
+	pbSources := make([]*pb.DataSource, len(sources))
+	for i, source := range sources {
+		pbSources[i] = domainSourceToProto(source)
+	}
+
+	s.logger.Debug("listed data sources",
+		"active_only", req.ActiveOnly,
+		"count", len(pbSources))
+
+	return &pb.ListDataSourcesResponse{
+		Sources:       pbSources,
+		NextPageToken: "", // TODO: Implement pagination token
+	}, nil
+}
+
+// mapSourceDomainError converts domain errors to appropriate gRPC status codes.
+func (s *Server) mapSourceDomainError(err error, operation, code string) error {
+	switch {
+	case errors.Is(err, domain.ErrDataSourceNotFound):
+		s.logger.Warn("data source not found",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.NotFound, "data source not found: %s", code)
+
+	case errors.Is(err, domain.ErrDuplicateDataSourceCode):
+		s.logger.Warn("data source code already exists",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.AlreadyExists, "data source already exists: %s", code)
+
+	case errors.Is(err, domain.ErrDataSourceCodeRequired):
+		s.logger.Warn("data source code required",
+			"operation", operation)
+		return status.Errorf(codes.InvalidArgument, "data source code is required")
+
+	case errors.Is(err, domain.ErrDataSourceNameRequired):
+		s.logger.Warn("data source name required",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.InvalidArgument, "data source name is required")
+
+	case errors.Is(err, domain.ErrInvalidSourceType):
+		s.logger.Warn("invalid source type",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.InvalidArgument, "invalid source type")
+
+	case errors.Is(err, domain.ErrInvalidTrustLevel):
+		s.logger.Warn("invalid trust level",
+			"operation", operation,
+			"code", code)
+		return status.Errorf(codes.InvalidArgument, "trust level must be between 0 and 100")
+
+	default:
+		s.logger.Error("internal error",
+			"operation", operation,
+			"code", code,
+			"error", err)
+		return status.Errorf(codes.Internal, "internal error: %v", err)
+	}
+}
+
+// domainSourceToProto converts a domain DataSource to proto DataSource.
+func domainSourceToProto(source domain.DataSource) *pb.DataSource {
+	pbSource := &pb.DataSource{
+		Id:          source.ID().String(),
+		Code:        source.Code(),
+		Name:        source.Name(),
+		Description: source.Description(),
+		TrustLevel:  int32(source.TrustLevel()),
+		IsActive:    source.IsActive(),
+		CreatedAt:   timestamppb.New(source.CreatedAt()),
+	}
+
+	// Only set UpdatedAt if it's different from CreatedAt (indicates an update occurred)
+	if !source.UpdatedAt().Equal(source.CreatedAt()) {
+		pbSource.UpdatedAt = timestamppb.New(source.UpdatedAt())
+	}
+
+	return pbSource
+}


### PR DESCRIPTION
## Summary

Implements the gRPC service layer for Market Information Management (Task Master: market-information-management.6) following BIAN v13.0 patterns with CEL-based validation and bi-temporal query support.

### Changes Made

**New files:**
- `server.go` - gRPC server bootstrap with dependency injection
- `dataset_service.go` - DataSet lifecycle management (CRUD + status transitions)
- `observation_service.go` - Observation ingestion with CEL validation and batch support
- `source_service.go` - DataSource CRUD operations
- `event_publisher.go` - Kafka publisher for ObservationRecorded events

**Key features:**
- CEL expression validation and caching for performance
- Quality ladder support (ESTIMATE < ACTUAL < VERIFIED)
- Bi-temporal query support via knowledge_base_time
- Batch observation ingestion with parallel CEL validation (50 concurrent limit)
- Event publishing only for ACTUAL/VERIFIED quality levels

### Technical Details

- Server struct follows position-keeping patterns with functional options for optional dependencies
- All six DataSet operations: RegisterDataSet, UpdateDataSet, ActivateDataSet, DeprecateDataSet, RetrieveDataSet, ListDataSets
- All four Observation operations: RecordObservation, RecordObservationBatch, RetrieveObservation, ListObservations
- All four DataSource operations: RegisterDataSource, UpdateDataSource, DeactivateDataSource, ListDataSources

## Test plan

- [x] Build passes (`go build ./services/market-information/...`)
- [x] Vet passes (`go vet ./services/market-information/...`)
- [x] Lint passes (`golangci-lint run ./services/market-information/...`)
- [x] Existing tests pass (`go test ./services/market-information/...`)
- [ ] CI pipeline passes

## Related

- Task Master: market-information-management.6
- Dependencies: market-information-management.4 (CEL validator), market-information-management.5 (repository adapters)