### PR TITLE
feat: Add gRPC client library for Market Information service

### DIFF
--- a/services/market-information/client/client.go
+++ b/services/market-information/client/client.go
@@ -159,23 +159,16 @@ func New(ctx context.Context, cfg Config) (*Client, func() error, error) {
 		timeout:    cfg.Timeout,
 	}
 
-	cleanup := func() error {
-		if client.conn != nil {
-			if err := client.conn.Close(); err != nil {
-				return fmt.Errorf("close grpc: %w", err)
-			}
-		}
-		return nil
-	}
-
-	return client, cleanup, nil
+	return client, client.Close, nil
 }
 
 // createGRPCConnection creates the gRPC connection based on configuration.
 func createGRPCConnection(ctx context.Context, cfg Config) (*grpc.ClientConn, error) {
 	// Use platform gRPC factory when ServiceName is provided (preferred)
 	if cfg.ServiceName != "" {
-		dialOpts := cfg.DialOptions
+		// Copy dial options to avoid mutating caller's slice
+		dialOpts := make([]grpc.DialOption, len(cfg.DialOptions))
+		copy(dialOpts, cfg.DialOptions)
 
 		// Add tracing interceptors if tracer is provided
 		if cfg.Tracer != nil {
@@ -199,8 +192,12 @@ func createGRPCConnection(ctx context.Context, cfg Config) (*grpc.ClientConn, er
 
 	if cfg.Target != "" {
 		// Fallback to legacy direct connection
-		dialOpts := cfg.DialOptions
-		if dialOpts == nil {
+		// Copy dial options to avoid mutating caller's slice
+		var dialOpts []grpc.DialOption
+		if cfg.DialOptions != nil {
+			dialOpts = make([]grpc.DialOption, len(cfg.DialOptions))
+			copy(dialOpts, cfg.DialOptions)
+		} else {
 			dialOpts = []grpc.DialOption{
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			}
@@ -256,6 +253,8 @@ func (c *Client) GetRate(
 	ctx = clients.PropagateCorrelationID(ctx)
 	ctx = clients.PropagateOrganization(ctx)
 
+	// ListObservations returns observations ordered by valid_from DESC by default,
+	// so PageSize=1 retrieves the most recent matching observation
 	req := &marketinformationv1.ListObservationsRequest{
 		DatasetCode:        datasetCode,
 		ResolutionKeyValue: resolutionKey,

--- a/services/market-information/client/client.go
+++ b/services/market-information/client/client.go
@@ -155,7 +155,9 @@ func New(ctx context.Context, cfg Config) (*Client, func() error, error) {
 
 	cleanup := func() error {
 		if client.conn != nil {
-			if err := client.conn.Close(); err != nil {
+			conn := client.conn
+			client.conn = nil // Prevent double-close
+			if err := conn.Close(); err != nil {
 				return fmt.Errorf("close grpc: %w", err)
 			}
 		}
@@ -487,9 +489,12 @@ func (c *Client) ListObservations(
 }
 
 // Close releases the gRPC connection.
+// Safe to call multiple times - subsequent calls are no-ops.
 func (c *Client) Close() error {
 	if c.conn != nil {
-		if err := c.conn.Close(); err != nil {
+		conn := c.conn
+		c.conn = nil // Prevent double-close
+		if err := conn.Close(); err != nil {
 			return fmt.Errorf("close grpc: %w", err)
 		}
 	}

--- a/services/market-information/client/client.go
+++ b/services/market-information/client/client.go
@@ -1,0 +1,498 @@
+// Package client provides a gRPC client for the Market Information service
+// with retry, circuit breaker, and context propagation support.
+//
+// The client provides high-level APIs for:
+//   - Point-in-time rate queries (GetRate)
+//   - Bi-temporal queries for audit replay (GetRateWithKnowledgeTime)
+//   - Single observation ingestion (RecordObservation)
+//   - Batch observation ingestion (RecordObservationBatch)
+//   - Data set retrieval (GetDataSet)
+//
+// Usage with Kubernetes DNS-based discovery (recommended for production):
+//
+//	client, cleanup, err := client.New(ctx, client.Config{
+//	    ServiceName: "market-information",
+//	    Namespace:   "default",
+//	    Port:        50051,
+//	})
+//	if err != nil {
+//	    return err
+//	}
+//	defer cleanup()
+//
+//	// Get FX rate for USD/EUR as of a specific time
+//	obs, err := client.GetRate(ctx, "USD_EUR_FX", "spot", asOfTime, marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+//
+// Usage with direct address (development):
+//
+//	client, cleanup, err := client.New(ctx, client.Config{
+//	    Target: "localhost:50051",
+//	})
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+)
+
+const (
+	// DefaultPort is the default gRPC port for the Market Information service.
+	DefaultPort = 50051
+
+	// DefaultTimeout is the default timeout for gRPC calls.
+	DefaultTimeout = 30 * time.Second
+
+	// DefaultNamespace is the default Kubernetes namespace.
+	DefaultNamespace = "default"
+
+	// ServiceName is the Kubernetes service name for Market Information.
+	ServiceName = "market-information"
+)
+
+// Config holds configuration for the Market Information client.
+type Config struct {
+	// Target is the gRPC server address (e.g., "localhost:50051").
+	// If set, overrides Kubernetes DNS-based discovery.
+	//
+	// Deprecated: Use ServiceName, Namespace, and Port for DNS-based load balancing.
+	Target string
+
+	// ServiceName is the Kubernetes service name (e.g., "market-information").
+	// When specified, enables DNS-based client-side load balancing.
+	ServiceName string
+
+	// Namespace is the Kubernetes namespace (e.g., "default", "production").
+	// Defaults to "default" if not specified.
+	Namespace string
+
+	// Port is the service port number.
+	// Defaults to 50051 if not specified.
+	Port int
+
+	// Timeout is the default timeout for RPC calls.
+	// Defaults to 30 seconds if not specified.
+	Timeout time.Duration
+
+	// Tracer is an optional observability tracer for distributed tracing.
+	Tracer *observability.Tracer
+
+	// Resilience is an optional configuration for circuit breaker and retry.
+	Resilience *clients.ResilientClientConfig
+
+	// DialOptions allows custom gRPC dial options.
+	DialOptions []grpc.DialOption
+}
+
+// ErrTargetRequired is returned when neither Target nor ServiceName is provided.
+var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+
+// ErrObservationNotFound is returned when no observation matches the query criteria.
+var ErrObservationNotFound = errors.New("observation not found")
+
+// Client provides access to the Market Information service.
+type Client struct {
+	conn       *grpc.ClientConn
+	grpcClient marketinformationv1.MarketInformationServiceClient
+	tracer     *observability.Tracer
+	resilient  *clients.ResilientClient
+	timeout    time.Duration
+}
+
+// applyDefaults sets default values for unspecified configuration fields.
+func (cfg *Config) applyDefaults() {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+	if cfg.Port == 0 {
+		cfg.Port = DefaultPort
+	}
+	if cfg.Namespace == "" {
+		cfg.Namespace = DefaultNamespace
+	}
+}
+
+// New creates a new Market Information gRPC client.
+//
+// Returns the client, a cleanup function to close all resources, and any error.
+// The cleanup function should be deferred immediately after checking the error.
+func New(ctx context.Context, cfg Config) (*Client, func() error, error) {
+	cfg.applyDefaults()
+
+	conn, err := createGRPCConnection(ctx, cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	grpcClient := marketinformationv1.NewMarketInformationServiceClient(conn)
+
+	var resilient *clients.ResilientClient
+	if cfg.Resilience != nil {
+		resilient = clients.NewResilientClient(*cfg.Resilience)
+	}
+
+	client := &Client{
+		conn:       conn,
+		grpcClient: grpcClient,
+		tracer:     cfg.Tracer,
+		resilient:  resilient,
+		timeout:    cfg.Timeout,
+	}
+
+	cleanup := func() error {
+		if client.conn != nil {
+			if err := client.conn.Close(); err != nil {
+				return fmt.Errorf("close grpc: %w", err)
+			}
+		}
+		return nil
+	}
+
+	return client, cleanup, nil
+}
+
+// createGRPCConnection creates the gRPC connection based on configuration.
+func createGRPCConnection(ctx context.Context, cfg Config) (*grpc.ClientConn, error) {
+	// Use platform gRPC factory when ServiceName is provided (preferred)
+	if cfg.ServiceName != "" {
+		dialOpts := cfg.DialOptions
+
+		// Add tracing interceptors if tracer is provided
+		if cfg.Tracer != nil {
+			dialOpts = append(dialOpts,
+				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
+				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
+			)
+		}
+
+		conn, err := platformgrpc.NewClient(ctx, platformgrpc.ClientConfig{
+			ServiceName: cfg.ServiceName,
+			Namespace:   cfg.Namespace,
+			Port:        cfg.Port,
+			DialOptions: dialOpts,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("create grpc connection via platform factory: %w", err)
+		}
+		return conn, nil
+	}
+
+	if cfg.Target != "" {
+		// Fallback to legacy direct connection
+		dialOpts := cfg.DialOptions
+		if dialOpts == nil {
+			dialOpts = []grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			}
+		}
+
+		// Add tracing interceptors if tracer is provided
+		if cfg.Tracer != nil {
+			dialOpts = append(dialOpts,
+				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
+				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
+			)
+		}
+
+		conn, err := grpc.NewClient(cfg.Target, dialOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("create grpc connection to %s: %w", cfg.Target, err)
+		}
+		return conn, nil
+	}
+
+	return nil, ErrTargetRequired
+}
+
+// GetRate retrieves a market rate observation for a specific dataset and resolution key
+// at a point in time with minimum quality threshold.
+//
+// This is the primary method for point-in-time rate lookups such as FX rates,
+// commodity prices, or interest rates.
+//
+// Example - Get USD/EUR FX rate:
+//
+//	obs, err := client.GetRate(ctx, "USD_EUR_FX", "spot", asOfTime,
+//	    marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Printf("Rate: %s\n", obs.Value)
+//
+// Example - Get energy tariff:
+//
+//	obs, err := client.GetRate(ctx, "ELEC_TARIFF", "peak",
+//	    time.Now(), marketinformationv1.QualityLevel_QUALITY_LEVEL_PROVISIONAL)
+func (c *Client) GetRate(
+	ctx context.Context,
+	datasetCode string,
+	resolutionKey string,
+	asOf time.Time,
+	minQuality marketinformationv1.QualityLevel,
+) (*marketinformationv1.MarketPriceObservation, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	req := &marketinformationv1.ListObservationsRequest{
+		DatasetCode:        datasetCode,
+		ResolutionKeyValue: resolutionKey,
+		ValidAt:            timestamppb.New(asOf),
+		QualityFilter:      minQuality,
+		PageSize:           1,
+	}
+
+	if c.resilient != nil {
+		resp, err := clients.ExecuteWithResilience(ctx, c.resilient, "GetRate", func() (*marketinformationv1.ListObservationsResponse, error) {
+			return c.grpcClient.ListObservations(ctx, req)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("get rate: %w", err)
+		}
+		if len(resp.Observations) == 0 {
+			return nil, fmt.Errorf("get rate %s/%s at %v with quality >= %s: %w",
+				datasetCode, resolutionKey, asOf, minQuality, ErrObservationNotFound)
+		}
+		return resp.Observations[0], nil
+	}
+
+	resp, err := c.grpcClient.ListObservations(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("get rate: %w", err)
+	}
+	if len(resp.Observations) == 0 {
+		return nil, fmt.Errorf("get rate %s/%s at %v with quality >= %s: %w",
+			datasetCode, resolutionKey, asOf, minQuality, ErrObservationNotFound)
+	}
+	return resp.Observations[0], nil
+}
+
+// GetRateWithKnowledgeTime retrieves a market rate observation using bi-temporal query.
+// This is used for audit replay scenarios where you need to know what value was known
+// at a specific point in time (knowledge time) for a given valid time (asOf).
+//
+// Example - Audit replay: What FX rate did we know on Dec 1 for trades on Nov 15?
+//
+//	knowledgeTime := time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC)
+//	asOf := time.Date(2024, 11, 15, 0, 0, 0, 0, time.UTC)
+//	obs, err := client.GetRateWithKnowledgeTime(ctx, "USD_EUR_FX", "spot",
+//	    asOf, knowledgeTime, marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+func (c *Client) GetRateWithKnowledgeTime(
+	ctx context.Context,
+	datasetCode string,
+	resolutionKey string,
+	asOf time.Time,
+	knowledgeBaseTime time.Time,
+	minQuality marketinformationv1.QualityLevel,
+) (*marketinformationv1.MarketPriceObservation, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	req := &marketinformationv1.ListObservationsRequest{
+		DatasetCode:        datasetCode,
+		ResolutionKeyValue: resolutionKey,
+		ValidAt:            timestamppb.New(asOf),
+		KnowledgeBaseTime:  timestamppb.New(knowledgeBaseTime),
+		QualityFilter:      minQuality,
+		PageSize:           1,
+	}
+
+	if c.resilient != nil {
+		resp, err := clients.ExecuteWithResilience(ctx, c.resilient, "GetRateWithKnowledgeTime", func() (*marketinformationv1.ListObservationsResponse, error) {
+			return c.grpcClient.ListObservations(ctx, req)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("get rate with knowledge time: %w", err)
+		}
+		if len(resp.Observations) == 0 {
+			return nil, fmt.Errorf("get rate with knowledge time %s/%s at %v (known at %v) with quality >= %s: %w",
+				datasetCode, resolutionKey, asOf, knowledgeBaseTime, minQuality, ErrObservationNotFound)
+		}
+		return resp.Observations[0], nil
+	}
+
+	resp, err := c.grpcClient.ListObservations(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("get rate with knowledge time: %w", err)
+	}
+	if len(resp.Observations) == 0 {
+		return nil, fmt.Errorf("get rate with knowledge time %s/%s at %v (known at %v) with quality >= %s: %w",
+			datasetCode, resolutionKey, asOf, knowledgeBaseTime, minQuality, ErrObservationNotFound)
+	}
+	return resp.Observations[0], nil
+}
+
+// RecordObservation records a single market data observation.
+//
+// Example - Record FX rate observation:
+//
+//	resp, err := client.RecordObservation(ctx, &marketinformationv1.RecordObservationRequest{
+//	    DatasetCode: "USD_EUR_FX",
+//	    ObservedAt:  timestamppb.Now(),
+//	    ValidFrom:   timestamppb.Now(),
+//	    Value:       "1.0856",
+//	    Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+//	    SourceCode:  "BLOOMBERG",
+//	})
+func (c *Client) RecordObservation(
+	ctx context.Context,
+	req *marketinformationv1.RecordObservationRequest,
+) (*marketinformationv1.RecordObservationResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		// Use no-retry for mutations to avoid duplicates
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "RecordObservation", func() (*marketinformationv1.RecordObservationResponse, error) {
+			return c.grpcClient.RecordObservation(ctx, req)
+		})
+	}
+
+	return c.grpcClient.RecordObservation(ctx, req)
+}
+
+// RecordObservationBatch records multiple market data observations in a single call.
+// Returns a BatchObservationResult with success/failure details for each observation.
+//
+// Example - Batch ingest energy tariffs:
+//
+//	entries := []*marketinformationv1.BatchObservationEntry{
+//	    {
+//	        DatasetCode:     "ELEC_TARIFF",
+//	        ObservedAt:      timestamppb.Now(),
+//	        ValidFrom:       timestamppb.New(startOfDay),
+//	        Value:           "0.15",
+//	        Quality:         marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+//	        SourceCode:      "GRID_OPERATOR",
+//	        ClientReference: "tariff-001",
+//	    },
+//	    // ... more entries
+//	}
+//	resp, err := client.RecordObservationBatch(ctx, entries)
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Printf("Recorded %d/%d observations\n", resp.SuccessCount, resp.TotalCount)
+func (c *Client) RecordObservationBatch(
+	ctx context.Context,
+	observations []*marketinformationv1.BatchObservationEntry,
+) (*marketinformationv1.RecordObservationBatchResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	req := &marketinformationv1.RecordObservationBatchRequest{
+		Observations: observations,
+	}
+
+	if c.resilient != nil {
+		// Use no-retry for mutations to avoid duplicates
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "RecordObservationBatch", func() (*marketinformationv1.RecordObservationBatchResponse, error) {
+			return c.grpcClient.RecordObservationBatch(ctx, req)
+		})
+	}
+
+	return c.grpcClient.RecordObservationBatch(ctx, req)
+}
+
+// GetDataSet retrieves a data set definition by code.
+// If version is nil, returns the latest ACTIVE version.
+//
+// Example - Get FX rate dataset definition:
+//
+//	dataset, err := client.GetDataSet(ctx, "USD_EUR_FX", nil)
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Printf("Dataset: %s (version %d)\n", dataset.Code, dataset.Version)
+func (c *Client) GetDataSet(
+	ctx context.Context,
+	code string,
+	version *int32,
+) (*marketinformationv1.DataSetDefinition, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	req := &marketinformationv1.RetrieveDataSetRequest{
+		Code: code,
+	}
+	if version != nil {
+		req.Version = *version
+	}
+
+	if c.resilient != nil {
+		resp, err := clients.ExecuteWithResilience(ctx, c.resilient, "GetDataSet", func() (*marketinformationv1.RetrieveDataSetResponse, error) {
+			return c.grpcClient.RetrieveDataSet(ctx, req)
+		})
+		if err != nil {
+			return nil, fmt.Errorf("get dataset: %w", err)
+		}
+		return resp.Dataset, nil
+	}
+
+	resp, err := c.grpcClient.RetrieveDataSet(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("get dataset: %w", err)
+	}
+	return resp.Dataset, nil
+}
+
+// ListObservations returns observations matching the filter criteria.
+// This is a lower-level method for complex queries. For simple rate lookups,
+// prefer GetRate or GetRateWithKnowledgeTime.
+func (c *Client) ListObservations(
+	ctx context.Context,
+	req *marketinformationv1.ListObservationsRequest,
+) (*marketinformationv1.ListObservationsResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "ListObservations", func() (*marketinformationv1.ListObservationsResponse, error) {
+			return c.grpcClient.ListObservations(ctx, req)
+		})
+	}
+
+	return c.grpcClient.ListObservations(ctx, req)
+}
+
+// Close releases the gRPC connection.
+func (c *Client) Close() error {
+	if c.conn != nil {
+		if err := c.conn.Close(); err != nil {
+			return fmt.Errorf("close grpc: %w", err)
+		}
+	}
+	return nil
+}
+
+// Conn returns the underlying gRPC connection.
+func (c *Client) Conn() *grpc.ClientConn {
+	return c.conn
+}

--- a/services/market-information/client/client.go
+++ b/services/market-information/client/client.go
@@ -104,6 +104,12 @@ var ErrTargetRequired = errors.New("either Target or ServiceName must be provide
 // ErrObservationNotFound is returned when no observation matches the query criteria.
 var ErrObservationNotFound = errors.New("observation not found")
 
+// ErrNilRequest is returned when a nil request is passed to a method.
+var ErrNilRequest = errors.New("request cannot be nil")
+
+// ErrEmptyObservations is returned when an empty observations slice is passed to batch methods.
+var ErrEmptyObservations = errors.New("observations cannot be empty")
+
 // Client provides access to the Market Information service.
 type Client struct {
 	conn       *grpc.ClientConn
@@ -155,9 +161,7 @@ func New(ctx context.Context, cfg Config) (*Client, func() error, error) {
 
 	cleanup := func() error {
 		if client.conn != nil {
-			conn := client.conn
-			client.conn = nil // Prevent double-close
-			if err := conn.Close(); err != nil {
+			if err := client.conn.Close(); err != nil {
 				return fmt.Errorf("close grpc: %w", err)
 			}
 		}
@@ -359,6 +363,10 @@ func (c *Client) RecordObservation(
 	ctx context.Context,
 	req *marketinformationv1.RecordObservationRequest,
 ) (*marketinformationv1.RecordObservationResponse, error) {
+	if req == nil {
+		return nil, ErrNilRequest
+	}
+
 	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
@@ -401,6 +409,10 @@ func (c *Client) RecordObservationBatch(
 	ctx context.Context,
 	observations []*marketinformationv1.BatchObservationEntry,
 ) (*marketinformationv1.RecordObservationBatchResponse, error) {
+	if len(observations) == 0 {
+		return nil, ErrEmptyObservations
+	}
+
 	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
@@ -473,6 +485,10 @@ func (c *Client) ListObservations(
 	ctx context.Context,
 	req *marketinformationv1.ListObservationsRequest,
 ) (*marketinformationv1.ListObservationsResponse, error) {
+	if req == nil {
+		return nil, ErrNilRequest
+	}
+
 	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
 	defer cancel()
 
@@ -489,12 +505,9 @@ func (c *Client) ListObservations(
 }
 
 // Close releases the gRPC connection.
-// Safe to call multiple times - subsequent calls are no-ops.
 func (c *Client) Close() error {
 	if c.conn != nil {
-		conn := c.conn
-		c.conn = nil // Prevent double-close
-		if err := conn.Close(); err != nil {
+		if err := c.conn.Close(); err != nil {
 			return fmt.Errorf("close grpc: %w", err)
 		}
 	}

--- a/services/market-information/client/client.go
+++ b/services/market-information/client/client.go
@@ -91,6 +91,10 @@ type Config struct {
 	Resilience *clients.ResilientClientConfig
 
 	// DialOptions allows custom gRPC dial options.
+	// When using Target (direct connection), if DialOptions is nil, insecure credentials
+	// are added by default. If DialOptions is provided, the caller must include
+	// appropriate transport credentials (e.g., grpc.WithTransportCredentials).
+	// When using ServiceName (Kubernetes DNS), credentials are handled by the platform factory.
 	DialOptions []grpc.DialOption
 }
 

--- a/services/market-information/client/client_test.go
+++ b/services/market-information/client/client_test.go
@@ -583,47 +583,12 @@ func TestConcurrentCalls(t *testing.T) {
 
 func TestClose(t *testing.T) {
 	mock := &mockServer{}
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
 
-	// Manually set up the mock server to have more control over cleanup
-	lis := bufconn.Listen(bufSize)
-	server := grpc.NewServer()
-	marketinformationv1.RegisterMarketInformationServiceServer(server, mock)
-
-	go func() {
-		_ = server.Serve(lis)
-	}()
-
-	bufDialer := func(context.Context, string) (net.Conn, error) {
-		return lis.Dial()
-	}
-
-	conn, err := grpc.NewClient("passthrough:///bufnet",
-		grpc.WithContextDialer(bufDialer),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	// Close should succeed
+	err := client.Close()
 	require.NoError(t, err)
-
-	client := &Client{
-		conn:       conn,
-		grpcClient: marketinformationv1.NewMarketInformationServiceClient(conn),
-		timeout:    DefaultTimeout,
-	}
-
-	defer func() {
-		server.Stop()
-		lis.Close()
-	}()
-
-	// First close should succeed
-	err = client.Close()
-	require.NoError(t, err)
-
-	// Second close should be a no-op (idempotent)
-	err = client.Close()
-	require.NoError(t, err)
-
-	// Verify conn is now nil
-	assert.Nil(t, client.conn)
 }
 
 func TestConn(t *testing.T) {
@@ -633,6 +598,36 @@ func TestConn(t *testing.T) {
 
 	conn := client.Conn()
 	assert.NotNil(t, conn)
+}
+
+func TestRecordObservation_NilRequest(t *testing.T) {
+	mock := &mockServer{}
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	_, err := client.RecordObservation(context.Background(), nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNilRequest)
+}
+
+func TestRecordObservationBatch_EmptyObservations(t *testing.T) {
+	mock := &mockServer{}
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	_, err := client.RecordObservationBatch(context.Background(), []*marketinformationv1.BatchObservationEntry{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEmptyObservations)
+}
+
+func TestListObservations_NilRequest(t *testing.T) {
+	mock := &mockServer{}
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	_, err := client.ListObservations(context.Background(), nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNilRequest)
 }
 
 func TestListObservations_Success(t *testing.T) {

--- a/services/market-information/client/client_test.go
+++ b/services/market-information/client/client_test.go
@@ -1,0 +1,693 @@
+package client
+
+import (
+	"context"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+const bufSize = 1024 * 1024
+
+// mockServer implements the MarketInformationService for testing.
+type mockServer struct {
+	marketinformationv1.UnimplementedMarketInformationServiceServer
+
+	// Configurable responses
+	listObservationsResp  *marketinformationv1.ListObservationsResponse
+	listObservationsErr   error
+	recordObservationResp *marketinformationv1.RecordObservationResponse
+	recordObservationErr  error
+	batchResp             *marketinformationv1.RecordObservationBatchResponse
+	batchErr              error
+	retrieveDataSetResp   *marketinformationv1.RetrieveDataSetResponse
+	retrieveDataSetErr    error
+
+	// Call tracking
+	listObservationsCalls atomic.Int32
+	recordCalls           atomic.Int32
+	batchCalls            atomic.Int32
+	datasetCalls          atomic.Int32
+
+	// For verifying context propagation
+	lastMetadata metadata.MD
+	metadataMu   sync.Mutex
+
+	// For simulating transient failures
+	failsRemain  atomic.Int32
+	failureError error
+}
+
+func (m *mockServer) ListObservations(ctx context.Context, _ *marketinformationv1.ListObservationsRequest) (*marketinformationv1.ListObservationsResponse, error) {
+	m.listObservationsCalls.Add(1)
+
+	// Capture metadata for verification
+	m.metadataMu.Lock()
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		m.lastMetadata = md
+	}
+	m.metadataMu.Unlock()
+
+	// Simulate transient failures for retry testing
+	if remaining := m.failsRemain.Add(-1); remaining >= 0 {
+		return nil, m.failureError
+	}
+
+	if m.listObservationsErr != nil {
+		return nil, m.listObservationsErr
+	}
+	return m.listObservationsResp, nil
+}
+
+func (m *mockServer) RecordObservation(ctx context.Context, _ *marketinformationv1.RecordObservationRequest) (*marketinformationv1.RecordObservationResponse, error) {
+	m.recordCalls.Add(1)
+
+	m.metadataMu.Lock()
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		m.lastMetadata = md
+	}
+	m.metadataMu.Unlock()
+
+	if m.recordObservationErr != nil {
+		return nil, m.recordObservationErr
+	}
+	return m.recordObservationResp, nil
+}
+
+func (m *mockServer) RecordObservationBatch(ctx context.Context, _ *marketinformationv1.RecordObservationBatchRequest) (*marketinformationv1.RecordObservationBatchResponse, error) {
+	m.batchCalls.Add(1)
+
+	m.metadataMu.Lock()
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		m.lastMetadata = md
+	}
+	m.metadataMu.Unlock()
+
+	if m.batchErr != nil {
+		return nil, m.batchErr
+	}
+	return m.batchResp, nil
+}
+
+func (m *mockServer) RetrieveDataSet(ctx context.Context, _ *marketinformationv1.RetrieveDataSetRequest) (*marketinformationv1.RetrieveDataSetResponse, error) {
+	m.datasetCalls.Add(1)
+
+	m.metadataMu.Lock()
+	if md, ok := metadata.FromIncomingContext(ctx); ok {
+		m.lastMetadata = md
+	}
+	m.metadataMu.Unlock()
+
+	if m.retrieveDataSetErr != nil {
+		return nil, m.retrieveDataSetErr
+	}
+	return m.retrieveDataSetResp, nil
+}
+
+// setupMockServer creates a bufconn-based mock server and returns a client connected to it.
+func setupMockServer(t *testing.T, mock *mockServer) (*Client, func()) {
+	t.Helper()
+
+	lis := bufconn.Listen(bufSize)
+
+	server := grpc.NewServer()
+	marketinformationv1.RegisterMarketInformationServiceServer(server, mock)
+
+	go func() {
+		_ = server.Serve(lis)
+	}()
+
+	bufDialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	client := &Client{
+		conn:       conn,
+		grpcClient: marketinformationv1.NewMarketInformationServiceClient(conn),
+		timeout:    DefaultTimeout,
+	}
+
+	cleanup := func() {
+		conn.Close()
+		server.Stop()
+		lis.Close()
+	}
+
+	return client, cleanup
+}
+
+func TestNew_WithTarget(t *testing.T) {
+	// Just verify config parsing, not actual connection
+	cfg := Config{
+		Target:  "localhost:50051",
+		Timeout: 5 * time.Second,
+	}
+	cfg.applyDefaults()
+
+	assert.Equal(t, 5*time.Second, cfg.Timeout)
+	assert.Equal(t, DefaultPort, cfg.Port)
+	assert.Equal(t, DefaultNamespace, cfg.Namespace)
+}
+
+func TestNew_WithServiceName(t *testing.T) {
+	cfg := Config{
+		ServiceName: "market-information",
+		Namespace:   "production",
+		Port:        9090,
+	}
+	cfg.applyDefaults()
+
+	assert.Equal(t, "market-information", cfg.ServiceName)
+	assert.Equal(t, "production", cfg.Namespace)
+	assert.Equal(t, 9090, cfg.Port)
+	assert.Equal(t, DefaultTimeout, cfg.Timeout)
+}
+
+func TestNew_ErrTargetRequired(t *testing.T) {
+	_, _, err := New(context.Background(), Config{})
+	assert.ErrorIs(t, err, ErrTargetRequired)
+}
+
+func TestGetRate_Success(t *testing.T) {
+	now := time.Now()
+	mock := &mockServer{
+		listObservationsResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{
+					Id:                 "obs-1",
+					DatasetCode:        "USD_EUR_FX",
+					ResolutionKeyValue: "spot",
+					Value:              "1.0856",
+					Quality:            marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+					ObservedAt:         timestamppb.New(now),
+					ValidFrom:          timestamppb.New(now),
+				},
+			},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	obs, err := client.GetRate(context.Background(), "USD_EUR_FX", "spot", now,
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+
+	require.NoError(t, err)
+	assert.Equal(t, "1.0856", obs.Value)
+	assert.Equal(t, "USD_EUR_FX", obs.DatasetCode)
+	assert.Equal(t, int32(1), mock.listObservationsCalls.Load())
+}
+
+func TestGetRate_NotFound(t *testing.T) {
+	mock := &mockServer{
+		listObservationsResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	_, err := client.GetRate(context.Background(), "USD_EUR_FX", "spot", time.Now(),
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrObservationNotFound)
+}
+
+func TestGetRate_GRPCError(t *testing.T) {
+	mock := &mockServer{
+		listObservationsErr: status.Error(codes.Unavailable, "service unavailable"),
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	_, err := client.GetRate(context.Background(), "USD_EUR_FX", "spot", time.Now(),
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get rate")
+}
+
+func TestGetRateWithKnowledgeTime_Success(t *testing.T) {
+	asOf := time.Date(2024, 11, 15, 0, 0, 0, 0, time.UTC)
+	knowledgeTime := time.Date(2024, 12, 1, 0, 0, 0, 0, time.UTC)
+
+	mock := &mockServer{
+		listObservationsResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{
+					Id:                 "obs-1",
+					DatasetCode:        "USD_EUR_FX",
+					ResolutionKeyValue: "spot",
+					Value:              "1.0800",
+					Quality:            marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+					ObservedAt:         timestamppb.New(asOf),
+					ValidFrom:          timestamppb.New(asOf),
+				},
+			},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	obs, err := client.GetRateWithKnowledgeTime(context.Background(), "USD_EUR_FX", "spot",
+		asOf, knowledgeTime, marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+
+	require.NoError(t, err)
+	assert.Equal(t, "1.0800", obs.Value)
+}
+
+func TestRecordObservation_Success(t *testing.T) {
+	mock := &mockServer{
+		recordObservationResp: &marketinformationv1.RecordObservationResponse{
+			Observation: &marketinformationv1.MarketPriceObservation{
+				Id:          "obs-new",
+				DatasetCode: "USD_EUR_FX",
+				Value:       "1.0856",
+			},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	resp, err := client.RecordObservation(context.Background(), &marketinformationv1.RecordObservationRequest{
+		DatasetCode: "USD_EUR_FX",
+		ObservedAt:  timestamppb.Now(),
+		ValidFrom:   timestamppb.Now(),
+		Value:       "1.0856",
+		Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+		SourceCode:  "BLOOMBERG",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "obs-new", resp.Observation.Id)
+	assert.Equal(t, int32(1), mock.recordCalls.Load())
+}
+
+func TestRecordObservation_ValidationError(t *testing.T) {
+	mock := &mockServer{
+		recordObservationErr: status.Error(codes.InvalidArgument, "value must be positive"),
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	_, err := client.RecordObservation(context.Background(), &marketinformationv1.RecordObservationRequest{
+		DatasetCode: "USD_EUR_FX",
+		ObservedAt:  timestamppb.Now(),
+		ValidFrom:   timestamppb.Now(),
+		Value:       "-1.0",
+		Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+		SourceCode:  "BLOOMBERG",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestRecordObservationBatch_Success(t *testing.T) {
+	mock := &mockServer{
+		batchResp: &marketinformationv1.RecordObservationBatchResponse{
+			BatchId:      "batch-1",
+			TotalCount:   3,
+			SuccessCount: 3,
+			FailureCount: 0,
+			Results: []*marketinformationv1.BatchObservationResult{
+				{Success: true, Index: 0, Observation: &marketinformationv1.MarketPriceObservation{Id: "obs-1"}},
+				{Success: true, Index: 1, Observation: &marketinformationv1.MarketPriceObservation{Id: "obs-2"}},
+				{Success: true, Index: 2, Observation: &marketinformationv1.MarketPriceObservation{Id: "obs-3"}},
+			},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	entries := []*marketinformationv1.BatchObservationEntry{
+		{DatasetCode: "ELEC_TARIFF", ObservedAt: timestamppb.Now(), ValidFrom: timestamppb.Now(), Value: "0.15", Quality: marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL, SourceCode: "GRID"},
+		{DatasetCode: "ELEC_TARIFF", ObservedAt: timestamppb.Now(), ValidFrom: timestamppb.Now(), Value: "0.12", Quality: marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL, SourceCode: "GRID"},
+		{DatasetCode: "ELEC_TARIFF", ObservedAt: timestamppb.Now(), ValidFrom: timestamppb.Now(), Value: "0.18", Quality: marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL, SourceCode: "GRID"},
+	}
+
+	resp, err := client.RecordObservationBatch(context.Background(), entries)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), resp.TotalCount)
+	assert.Equal(t, int32(3), resp.SuccessCount)
+	assert.Equal(t, int32(0), resp.FailureCount)
+}
+
+func TestRecordObservationBatch_PartialFailure(t *testing.T) {
+	mock := &mockServer{
+		batchResp: &marketinformationv1.RecordObservationBatchResponse{
+			BatchId:      "batch-1",
+			TotalCount:   3,
+			SuccessCount: 2,
+			FailureCount: 1,
+			Results: []*marketinformationv1.BatchObservationResult{
+				{Success: true, Index: 0, Observation: &marketinformationv1.MarketPriceObservation{Id: "obs-1"}},
+				{Success: false, Index: 1, ErrorMessage: "validation failed: value out of range"},
+				{Success: true, Index: 2, Observation: &marketinformationv1.MarketPriceObservation{Id: "obs-3"}},
+			},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	entries := []*marketinformationv1.BatchObservationEntry{
+		{DatasetCode: "ELEC_TARIFF", ObservedAt: timestamppb.Now(), ValidFrom: timestamppb.Now(), Value: "0.15", Quality: marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL, SourceCode: "GRID"},
+		{DatasetCode: "ELEC_TARIFF", ObservedAt: timestamppb.Now(), ValidFrom: timestamppb.Now(), Value: "99999", Quality: marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL, SourceCode: "GRID"}, // Invalid
+		{DatasetCode: "ELEC_TARIFF", ObservedAt: timestamppb.Now(), ValidFrom: timestamppb.Now(), Value: "0.18", Quality: marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL, SourceCode: "GRID"},
+	}
+
+	resp, err := client.RecordObservationBatch(context.Background(), entries)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), resp.TotalCount)
+	assert.Equal(t, int32(2), resp.SuccessCount)
+	assert.Equal(t, int32(1), resp.FailureCount)
+	assert.False(t, resp.Results[1].Success)
+	assert.Contains(t, resp.Results[1].ErrorMessage, "validation failed")
+}
+
+func TestGetDataSet_Success(t *testing.T) {
+	mock := &mockServer{
+		retrieveDataSetResp: &marketinformationv1.RetrieveDataSetResponse{
+			Dataset: &marketinformationv1.DataSetDefinition{
+				Id:      "ds-1",
+				Code:    "USD_EUR_FX",
+				Version: 1,
+				Status:  marketinformationv1.DataSetStatus_DATA_SET_STATUS_ACTIVE,
+			},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	dataset, err := client.GetDataSet(context.Background(), "USD_EUR_FX", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "USD_EUR_FX", dataset.Code)
+	assert.Equal(t, int32(1), dataset.Version)
+}
+
+func TestGetDataSet_WithVersion(t *testing.T) {
+	mock := &mockServer{
+		retrieveDataSetResp: &marketinformationv1.RetrieveDataSetResponse{
+			Dataset: &marketinformationv1.DataSetDefinition{
+				Id:      "ds-1",
+				Code:    "USD_EUR_FX",
+				Version: 2,
+			},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	version := int32(2)
+	dataset, err := client.GetDataSet(context.Background(), "USD_EUR_FX", &version)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), dataset.Version)
+}
+
+func TestGetDataSet_NotFound(t *testing.T) {
+	mock := &mockServer{
+		retrieveDataSetErr: status.Error(codes.NotFound, "dataset not found"),
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	_, err := client.GetDataSet(context.Background(), "NONEXISTENT", nil)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get dataset")
+}
+
+func TestContextPropagation_TenantID(t *testing.T) {
+	mock := &mockServer{
+		listObservationsResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{Id: "obs-1", DatasetCode: "TEST", Value: "1.0"},
+			},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	// Create context with tenant ID
+	tenantID := tenant.MustNewTenantID("test_tenant_123")
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	_, err := client.GetRate(ctx, "TEST", "spot", time.Now(),
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+
+	require.NoError(t, err)
+
+	// Verify tenant ID was propagated
+	mock.metadataMu.Lock()
+	md := mock.lastMetadata
+	mock.metadataMu.Unlock()
+
+	tenantVals := md.Get(tenant.TenantIDKey)
+	require.Len(t, tenantVals, 1)
+	assert.Equal(t, tenantID.String(), tenantVals[0])
+}
+
+func TestContextPropagation_CorrelationID(t *testing.T) {
+	mock := &mockServer{
+		listObservationsResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{Id: "obs-1", DatasetCode: "TEST", Value: "1.0"},
+			},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	// Create context with correlation ID using string key to match production behavior
+	// in shared/pkg/clients/common.go which uses ctx.Value("x-correlation-id")
+	//nolint:staticcheck,revive // production code uses string keys
+	ctx := context.WithValue(context.Background(), "x-correlation-id", "test-correlation-123")
+
+	_, err := client.GetRate(ctx, "TEST", "spot", time.Now(),
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+
+	require.NoError(t, err)
+
+	// Verify correlation ID was propagated
+	mock.metadataMu.Lock()
+	md := mock.lastMetadata
+	mock.metadataMu.Unlock()
+
+	corrVals := md.Get("x-correlation-id")
+	require.Len(t, corrVals, 1)
+	assert.Equal(t, "test-correlation-123", corrVals[0])
+}
+
+func TestContextCancellation(t *testing.T) {
+	mock := &mockServer{
+		listObservationsResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{Id: "obs-1", DatasetCode: "TEST", Value: "1.0"},
+			},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	// Create already-cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := client.GetRate(ctx, "TEST", "spot", time.Now(),
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context canceled")
+}
+
+func TestConcurrentCalls(t *testing.T) {
+	mock := &mockServer{
+		listObservationsResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{Id: "obs-1", DatasetCode: "TEST", Value: "1.0"},
+			},
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	const numGoroutines = 100
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	errors := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := client.GetRate(context.Background(), "TEST", "spot", time.Now(),
+				marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+			if err != nil {
+				errors <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Errorf("concurrent call failed: %v", err)
+	}
+
+	assert.Equal(t, int32(numGoroutines), mock.listObservationsCalls.Load())
+}
+
+func TestClose(t *testing.T) {
+	mock := &mockServer{}
+	client, cleanup := setupMockServer(t, mock)
+
+	// Don't use defer cleanup() since we're testing Close explicitly
+	// Instead, manually stop the server after testing
+	defer func() {
+		// cleanup() would call Close() again, but we've already done that
+		// Just let the resources be cleaned up when the test ends
+		cleanup()
+	}()
+
+	err := client.Close()
+	require.NoError(t, err)
+
+	// Set conn to nil so the deferred cleanup doesn't try to close again
+	client.conn = nil
+}
+
+func TestConn(t *testing.T) {
+	mock := &mockServer{}
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	conn := client.Conn()
+	assert.NotNil(t, conn)
+}
+
+func TestListObservations_Success(t *testing.T) {
+	now := time.Now()
+	mock := &mockServer{
+		listObservationsResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{Id: "obs-1", DatasetCode: "USD_EUR_FX", Value: "1.0850", ObservedAt: timestamppb.New(now)},
+				{Id: "obs-2", DatasetCode: "USD_EUR_FX", Value: "1.0855", ObservedAt: timestamppb.New(now.Add(-time.Hour))},
+			},
+			NextPageToken: "token-123",
+			TotalCount:    10,
+		},
+	}
+
+	client, cleanup := setupMockServer(t, mock)
+	defer cleanup()
+
+	resp, err := client.ListObservations(context.Background(), &marketinformationv1.ListObservationsRequest{
+		DatasetCode: "USD_EUR_FX",
+		PageSize:    2,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, resp.Observations, 2)
+	assert.Equal(t, "token-123", resp.NextPageToken)
+	assert.Equal(t, int32(10), resp.TotalCount)
+}
+
+func TestWithResilience_RetryOnTransientError(t *testing.T) {
+	mock := &mockServer{
+		failsRemain:  atomic.Int32{},
+		failureError: status.Error(codes.Unavailable, "transient failure"),
+		listObservationsResp: &marketinformationv1.ListObservationsResponse{
+			Observations: []*marketinformationv1.MarketPriceObservation{
+				{Id: "obs-1", DatasetCode: "TEST", Value: "1.0"},
+			},
+		},
+	}
+	mock.failsRemain.Store(2) // Fail twice, succeed on third
+
+	// Create client with resilience
+	lis := bufconn.Listen(bufSize)
+	server := grpc.NewServer()
+	marketinformationv1.RegisterMarketInformationServiceServer(server, mock)
+
+	go func() {
+		_ = server.Serve(lis)
+	}()
+
+	bufDialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	resilientCfg := clients.DefaultResilientClientConfig("market-information-test")
+	resilientCfg.MaxRetries = 5
+	resilientCfg.InitialInterval = 10 * time.Millisecond
+
+	client := &Client{
+		conn:       conn,
+		grpcClient: marketinformationv1.NewMarketInformationServiceClient(conn),
+		resilient:  clients.NewResilientClient(resilientCfg),
+		timeout:    DefaultTimeout,
+	}
+
+	defer func() {
+		conn.Close()
+		server.Stop()
+		lis.Close()
+	}()
+
+	obs, err := client.GetRate(context.Background(), "TEST", "spot", time.Now(),
+		marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL)
+
+	require.NoError(t, err)
+	assert.Equal(t, "1.0", obs.Value)
+	assert.GreaterOrEqual(t, mock.listObservationsCalls.Load(), int32(3))
+}

--- a/services/market-information/client/client_test.go
+++ b/services/market-information/client/client_test.go
@@ -583,21 +583,47 @@ func TestConcurrentCalls(t *testing.T) {
 
 func TestClose(t *testing.T) {
 	mock := &mockServer{}
-	client, cleanup := setupMockServer(t, mock)
 
-	// Don't use defer cleanup() since we're testing Close explicitly
-	// Instead, manually stop the server after testing
-	defer func() {
-		// cleanup() would call Close() again, but we've already done that
-		// Just let the resources be cleaned up when the test ends
-		cleanup()
+	// Manually set up the mock server to have more control over cleanup
+	lis := bufconn.Listen(bufSize)
+	server := grpc.NewServer()
+	marketinformationv1.RegisterMarketInformationServiceServer(server, mock)
+
+	go func() {
+		_ = server.Serve(lis)
 	}()
 
-	err := client.Close()
+	bufDialer := func(context.Context, string) (net.Conn, error) {
+		return lis.Dial()
+	}
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	require.NoError(t, err)
 
-	// Set conn to nil so the deferred cleanup doesn't try to close again
-	client.conn = nil
+	client := &Client{
+		conn:       conn,
+		grpcClient: marketinformationv1.NewMarketInformationServiceClient(conn),
+		timeout:    DefaultTimeout,
+	}
+
+	defer func() {
+		server.Stop()
+		lis.Close()
+	}()
+
+	// First close should succeed
+	err = client.Close()
+	require.NoError(t, err)
+
+	// Second close should be a no-op (idempotent)
+	err = client.Close()
+	require.NoError(t, err)
+
+	// Verify conn is now nil
+	assert.Nil(t, client.conn)
 }
 
 func TestConn(t *testing.T) {

--- a/services/market-information/client/client_test.go
+++ b/services/market-information/client/client_test.go
@@ -64,9 +64,16 @@ func (m *mockServer) ListObservations(ctx context.Context, _ *marketinformationv
 	}
 	m.metadataMu.Unlock()
 
-	// Simulate transient failures for retry testing
-	if remaining := m.failsRemain.Add(-1); remaining >= 0 {
-		return nil, m.failureError
+	// Simulate transient failures for retry testing using compare-and-swap
+	// to avoid going negative
+	for {
+		current := m.failsRemain.Load()
+		if current <= 0 {
+			break
+		}
+		if m.failsRemain.CompareAndSwap(current, current-1) {
+			return nil, m.failureError
+		}
 	}
 
 	if m.listObservationsErr != nil {


### PR DESCRIPTION
## Summary

- Implements reusable gRPC client package for Market Information service following reference-data client pattern
- Provides high-level APIs for rate queries (point-in-time and bi-temporal), observation ingestion (single and batch), and data set retrieval
- Includes connection management via Kubernetes DNS-based discovery with optional circuit breaker and retry support

## Changes Made

- Added `services/market-information/client/client.go` with:
  - `Client` struct with gRPC connection and resilience support
  - `GetRate()` for point-in-time rate lookups (FX rates, commodity prices, energy tariffs)
  - `GetRateWithKnowledgeTime()` for bi-temporal audit replay queries
  - `RecordObservation()` and `RecordObservationBatch()` for observation ingestion
  - `GetDataSet()` and `ListObservations()` for data retrieval
  - Context propagation for tenant ID and correlation ID
- Added `services/market-information/client/client_test.go` with:
  - bufconn-based mock server for in-memory gRPC testing
  - Tests for all client methods (happy path and error cases)
  - Context propagation verification tests
  - Concurrent call safety test
  - Retry logic verification test

## Test Plan

- [x] All unit tests pass with race detector
- [x] Lint checks pass (golangci-lint)
- [ ] CI pipeline passes

## Task Master

Task: market-information-management.8