### PR TITLE
feat(market-information): Add ECB daily FX rates adapter

### DIFF
--- a/services/market-information/adapters/external/ecb/ecb_client.go
+++ b/services/market-information/adapters/external/ecb/ecb_client.go
@@ -1,0 +1,138 @@
+// Package ecb provides an HTTP client for fetching daily FX rates from the European Central Bank.
+package ecb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// DefaultEndpoint is the ECB SDMX Web Service endpoint for daily FX rates.
+// D=daily, EUR=quote currency, SP00=spot, A=average.
+const DefaultEndpoint = "https://sdw-wsrest.ecb.europa.eu/service/data/EXR/D..EUR.SP00.A"
+
+// Default timeouts.
+const (
+	DefaultTimeout = 30 * time.Second
+)
+
+// Sentinel errors for specific conditions.
+var (
+	// ErrNotConfigured is returned when attempting to use an ECB client that is nil.
+	ErrNotConfigured = errors.New("ECB client not configured")
+	// ErrAPIError is returned when the ECB API returns a non-successful response.
+	ErrAPIError = errors.New("ECB API error")
+	// ErrRateLimited is returned when rate limited by the ECB API.
+	ErrRateLimited = errors.New("ECB API rate limited")
+	// ErrPartialIngestion is returned when some observations fail to record.
+	ErrPartialIngestion = errors.New("partial ingestion failure")
+)
+
+// Config holds ECB client configuration.
+type Config struct {
+	// Endpoint is the ECB SDMX Web Service URL.
+	// Defaults to DefaultEndpoint if empty.
+	Endpoint string
+
+	// Timeout is the HTTP request timeout.
+	// Defaults to DefaultTimeout (30s) if zero.
+	Timeout time.Duration
+}
+
+// Client fetches daily FX rates from the European Central Bank.
+type Client struct {
+	httpClient *http.Client
+	endpoint   string
+	logger     *slog.Logger
+}
+
+// ClientOption configures the ECB client.
+type ClientOption func(*Client)
+
+// WithHTTPClient sets a custom HTTP client for the ECB client.
+func WithHTTPClient(client *http.Client) ClientOption {
+	return func(c *Client) {
+		c.httpClient = client
+	}
+}
+
+// WithEndpoint sets a custom endpoint URL for the ECB client.
+func WithEndpoint(endpoint string) ClientOption {
+	return func(c *Client) {
+		c.endpoint = endpoint
+	}
+}
+
+// WithLogger sets a custom logger for the ECB client.
+func WithLogger(logger *slog.Logger) ClientOption {
+	return func(c *Client) {
+		c.logger = logger
+	}
+}
+
+// NewClient creates a new ECB client.
+func NewClient(cfg Config, opts ...ClientOption) *Client {
+	endpoint := cfg.Endpoint
+	if endpoint == "" {
+		endpoint = DefaultEndpoint
+	}
+
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = DefaultTimeout
+	}
+
+	client := &Client{
+		httpClient: &http.Client{Timeout: timeout},
+		endpoint:   endpoint,
+		logger:     slog.Default(),
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	client.logger = client.logger.With("component", "ecb_client")
+
+	return client
+}
+
+// FetchDailyRates retrieves the latest FX rates from ECB.
+// Returns raw CSV data for parsing. Caller must close the returned ReadCloser.
+func (c *Client) FetchDailyRates(ctx context.Context) (io.ReadCloser, error) {
+	if c == nil {
+		return nil, ErrNotConfigured
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ECB request: %w", err)
+	}
+
+	// Request CSV format instead of default XML
+	req.Header.Set("Accept", "text/csv")
+
+	c.logger.DebugContext(ctx, "fetching ECB daily rates", "endpoint", c.endpoint)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch ECB rates: %w", err)
+	}
+
+	// Handle HTTP status codes
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return resp.Body, nil
+	case http.StatusTooManyRequests:
+		_ = resp.Body.Close()
+		return nil, ErrRateLimited
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		return nil, fmt.Errorf("%w: status %d, body: %s", ErrAPIError, resp.StatusCode, string(body))
+	}
+}

--- a/services/market-information/adapters/external/ecb/ecb_client_test.go
+++ b/services/market-information/adapters/external/ecb/ecb_client_test.go
@@ -1,0 +1,230 @@
+package ecb_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/market-information/adapters/external/ecb"
+)
+
+func TestClient_FetchDailyRates_Success(t *testing.T) {
+	// Create mock ECB server
+	mockCSV := `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-15,1.0876`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "text/csv", r.Header.Get("Accept"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockCSV))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+
+	body, err := client.FetchDailyRates(context.Background())
+	require.NoError(t, err)
+	defer body.Close()
+
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "USD")
+}
+
+func TestClient_FetchDailyRates_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Intentional sleep: Delay response to test timeout handling
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	client := ecb.NewClient(ecb.Config{Timeout: 50 * time.Millisecond}, ecb.WithEndpoint(server.URL))
+
+	_, err := client.FetchDailyRates(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "context deadline exceeded")
+}
+
+func TestClient_FetchDailyRates_Non200Status(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		wantErr    error
+	}{
+		{"404 Not Found", http.StatusNotFound, ecb.ErrAPIError},
+		{"500 Server Error", http.StatusInternalServerError, ecb.ErrAPIError},
+		{"429 Rate Limited", http.StatusTooManyRequests, ecb.ErrRateLimited},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte("error"))
+			}))
+			defer server.Close()
+
+			client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+
+			_, err := client.FetchDailyRates(context.Background())
+			require.Error(t, err)
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestClient_FetchDailyRates_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Intentional sleep: Delay response to test context cancellation handling
+		time.Sleep(1 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+
+	_, err := client.FetchDailyRates(ctx)
+	require.Error(t, err)
+}
+
+func TestClient_NilClient(t *testing.T) {
+	var client *ecb.Client
+	_, err := client.FetchDailyRates(context.Background())
+	require.ErrorIs(t, err, ecb.ErrNotConfigured)
+}
+
+func TestClient_DefaultEndpoint(t *testing.T) {
+	client := ecb.NewClient(ecb.Config{})
+	// We can't test the default endpoint directly without making a real request,
+	// but we can verify the client is created successfully
+	require.NotNil(t, client)
+}
+
+func TestClient_WithCustomHTTPClient(t *testing.T) {
+	customClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithHTTPClient(customClient))
+
+	require.NotNil(t, client)
+}
+
+func TestClient_WithCustomEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("test data"))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+
+	body, err := client.FetchDailyRates(context.Background())
+	require.NoError(t, err)
+	defer body.Close()
+
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Equal(t, "test data", string(data))
+}
+
+func TestClient_ConfigEndpointTakesPrecedence(t *testing.T) {
+	// When Config.Endpoint is set, it should be used
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("config endpoint"))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{Endpoint: server.URL})
+
+	body, err := client.FetchDailyRates(context.Background())
+	require.NoError(t, err)
+	defer body.Close()
+
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Equal(t, "config endpoint", string(data))
+}
+
+func TestClient_OptionEndpointOverridesConfig(t *testing.T) {
+	// WithEndpoint option should override Config.Endpoint
+	configServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("config endpoint"))
+	}))
+	defer configServer.Close()
+
+	optionServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("option endpoint"))
+	}))
+	defer optionServer.Close()
+
+	client := ecb.NewClient(ecb.Config{Endpoint: configServer.URL}, ecb.WithEndpoint(optionServer.URL))
+
+	body, err := client.FetchDailyRates(context.Background())
+	require.NoError(t, err)
+	defer body.Close()
+
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Equal(t, "option endpoint", string(data))
+}
+
+func TestClient_ConfigTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Intentional sleep: Delay response to test timeout configuration
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Use a very short timeout that should trigger before response
+	client := ecb.NewClient(ecb.Config{
+		Endpoint: server.URL,
+		Timeout:  10 * time.Millisecond,
+	})
+
+	_, err := client.FetchDailyRates(context.Background())
+	require.Error(t, err)
+}
+
+func TestClient_FetchDailyRates_ErrorResponseBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("Invalid request parameters"))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+
+	_, err := client.FetchDailyRates(context.Background())
+	require.Error(t, err)
+	require.ErrorIs(t, err, ecb.ErrAPIError)
+	assert.Contains(t, err.Error(), "Invalid request parameters")
+	assert.Contains(t, err.Error(), "400")
+}
+
+func TestClient_FetchDailyRates_NetworkError(t *testing.T) {
+	// Use a URL that will fail to connect
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint("http://localhost:1"))
+
+	_, err := client.FetchDailyRates(context.Background())
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch ECB rates")
+}

--- a/services/market-information/adapters/external/ecb/ecb_parser.go
+++ b/services/market-information/adapters/external/ecb/ecb_parser.go
@@ -1,0 +1,296 @@
+// Package ecb provides an HTTP client and parser for fetching daily FX rates from the European Central Bank.
+package ecb
+
+import (
+	"bufio"
+	"encoding/csv"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+)
+
+// ECB CSV column indices (based on SDMX format).
+const (
+	colKEY         = 0
+	colFREQ        = 1
+	colCurrency    = 2
+	colCurrencyDen = 3
+	colExrType     = 4
+	colExrSuffix   = 5
+	colTimePeriod  = 6
+	colObsValue    = 7
+	minColumns     = 8
+)
+
+// Expected header columns for ECB SDMX CSV format.
+var expectedHeaders = []string{
+	"KEY", "FREQ", "CURRENCY", "CURRENCY_DENOM",
+	"EXR_TYPE", "EXR_SUFFIX", "TIME_PERIOD", "OBS_VALUE",
+}
+
+// Sentinel errors for parsing.
+var (
+	// ErrInvalidCSVFormat is returned when the CSV format is not recognized.
+	ErrInvalidCSVFormat = errors.New("invalid ECB CSV format")
+	// ErrNoData is returned when the CSV contains no data rows.
+	ErrNoData = errors.New("no data in ECB CSV response")
+	// ErrInvalidRate is returned when a rate value cannot be parsed.
+	ErrInvalidRate = errors.New("invalid rate value")
+	// ErrInvalidDate is returned when a date cannot be parsed.
+	ErrInvalidDate = errors.New("invalid date format")
+	// ErrTooFewColumns is returned when a row has fewer columns than required.
+	ErrTooFewColumns = errors.New("row has too few columns")
+)
+
+// Rate represents a single exchange rate from the ECB feed.
+type Rate struct {
+	// BaseCurrency is the currency being quoted (e.g., USD, GBP).
+	BaseCurrency string
+	// QuoteCurrency is always EUR for ECB rates.
+	QuoteCurrency string
+	// Value is the exchange rate value with high precision.
+	Value decimal.Decimal
+	// ObservedDate is the date when the rate was observed.
+	ObservedDate time.Time
+	// Frequency is the data frequency (D=daily, M=monthly, etc.).
+	Frequency string
+	// ExchangeRateType is the rate type (SP00=spot).
+	ExchangeRateType string
+	// ExchangeRateSuffix is the series variation (A=average).
+	ExchangeRateSuffix string
+}
+
+// Parser parses ECB SDMX CSV data into structured rates.
+type Parser struct {
+	logger *slog.Logger
+}
+
+// ParserOption configures the ECB parser.
+type ParserOption func(*Parser)
+
+// WithParserLogger sets a custom logger for the parser.
+func WithParserLogger(logger *slog.Logger) ParserOption {
+	return func(p *Parser) {
+		p.logger = logger
+	}
+}
+
+// NewParser creates a new ECB CSV parser.
+func NewParser(opts ...ParserOption) *Parser {
+	p := &Parser{
+		logger: slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	p.logger = p.logger.With("component", "ecb_parser")
+	return p
+}
+
+// ParseCSV parses ECB SDMX CSV data from the provided reader.
+// It handles the standard ECB CSV format with headers and returns parsed rates.
+// Malformed rows are logged and skipped rather than causing the entire parse to fail.
+func (p *Parser) ParseCSV(r io.Reader) ([]Rate, error) {
+	reader := csv.NewReader(bufio.NewReader(r))
+	reader.FieldsPerRecord = -1 // Allow variable number of fields
+
+	// Read and validate header
+	header, err := reader.Read()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, ErrNoData
+		}
+		return nil, fmt.Errorf("%w: failed to read header: %w", ErrInvalidCSVFormat, err)
+	}
+
+	if err := p.validateHeader(header); err != nil {
+		return nil, err
+	}
+
+	// Parse data rows
+	var rates []Rate
+	lineNum := 1 // Header was line 1
+
+	for {
+		lineNum++
+		record, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			p.logger.Warn("skipping malformed CSV row", "line", lineNum, "error", err)
+			continue
+		}
+
+		rate, err := p.parseRow(record)
+		if err != nil {
+			p.logger.Warn("skipping invalid row", "line", lineNum, "error", err)
+			continue
+		}
+
+		rates = append(rates, rate)
+	}
+
+	if len(rates) == 0 {
+		return nil, ErrNoData
+	}
+
+	p.logger.Debug("parsed ECB rates", "count", len(rates))
+	return rates, nil
+}
+
+// validateHeader checks that the CSV has the expected ECB SDMX column headers.
+func (p *Parser) validateHeader(header []string) error {
+	if len(header) < minColumns {
+		return fmt.Errorf("%w: expected at least %d columns, got %d",
+			ErrInvalidCSVFormat, minColumns, len(header))
+	}
+
+	// Check that required columns are present (case-insensitive)
+	for i, expected := range expectedHeaders {
+		if i >= len(header) {
+			break
+		}
+		if !strings.EqualFold(strings.TrimSpace(header[i]), expected) {
+			return fmt.Errorf("%w: column %d expected '%s', got '%s'",
+				ErrInvalidCSVFormat, i, expected, header[i])
+		}
+	}
+
+	return nil
+}
+
+// parseRow parses a single CSV row into a Rate.
+func (p *Parser) parseRow(record []string) (Rate, error) {
+	if len(record) < minColumns {
+		return Rate{}, fmt.Errorf("%w: has %d columns, expected at least %d",
+			ErrTooFewColumns, len(record), minColumns)
+	}
+
+	// Parse the rate value
+	rateStr := strings.TrimSpace(record[colObsValue])
+	if rateStr == "" {
+		return Rate{}, fmt.Errorf("%w: empty rate value", ErrInvalidRate)
+	}
+
+	rate, err := decimal.NewFromString(rateStr)
+	if err != nil {
+		return Rate{}, fmt.Errorf("%w: %w", ErrInvalidRate, err)
+	}
+
+	// Parse the date (format: YYYY-MM-DD)
+	dateStr := strings.TrimSpace(record[colTimePeriod])
+	observedDate, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return Rate{}, fmt.Errorf("%w: %w", ErrInvalidDate, err)
+	}
+
+	return Rate{
+		BaseCurrency:       strings.TrimSpace(record[colCurrency]),
+		QuoteCurrency:      strings.TrimSpace(record[colCurrencyDen]),
+		Value:              rate,
+		ObservedDate:       observedDate,
+		Frequency:          strings.TrimSpace(record[colFREQ]),
+		ExchangeRateType:   strings.TrimSpace(record[colExrType]),
+		ExchangeRateSuffix: strings.TrimSpace(record[colExrSuffix]),
+	}, nil
+}
+
+// TransformConfig holds configuration for transforming rates to observations.
+type TransformConfig struct {
+	// SourceCode is the data source code (e.g., "ECB").
+	SourceCode string
+	// DatasetCodeTemplate is a template for generating dataset codes.
+	// Use %s placeholders for BaseCurrency and QuoteCurrency.
+	// Default: "%s_%s_FX" (e.g., "USD_EUR_FX")
+	DatasetCodeTemplate string
+}
+
+// DefaultTransformConfig returns the default transformation configuration.
+func DefaultTransformConfig() TransformConfig {
+	return TransformConfig{
+		SourceCode:          "ECB",
+		DatasetCodeTemplate: "%s_%s_FX",
+	}
+}
+
+// TransformToObservations converts parsed ECB rates to RecordObservationRequest protobufs.
+// The causation ID format is: ecb-feed-YYYY-MM-DD based on the observation date.
+func TransformToObservations(rates []Rate, cfg TransformConfig) []*marketinformationv1.RecordObservationRequest {
+	if cfg.SourceCode == "" {
+		cfg.SourceCode = "ECB"
+	}
+	if cfg.DatasetCodeTemplate == "" {
+		cfg.DatasetCodeTemplate = "%s_%s_FX"
+	}
+
+	requests := make([]*marketinformationv1.RecordObservationRequest, 0, len(rates))
+
+	for _, rate := range rates {
+		// Generate dataset code (e.g., "USD_EUR_FX")
+		datasetCode := fmt.Sprintf(cfg.DatasetCodeTemplate,
+			strings.ToUpper(rate.BaseCurrency),
+			strings.ToUpper(rate.QuoteCurrency))
+
+		// Generate causation ID: ecb-feed-YYYY-MM-DD
+		causationID := fmt.Sprintf("ecb-feed-%s", rate.ObservedDate.Format("2006-01-02"))
+
+		// Set observed_at to the observation date at midnight UTC
+		observedAt := time.Date(
+			rate.ObservedDate.Year(),
+			rate.ObservedDate.Month(),
+			rate.ObservedDate.Day(),
+			0, 0, 0, 0, time.UTC,
+		)
+
+		// For spot rates, valid_from equals observed_at
+		// ECB rates are typically published at 16:00 CET and valid for that business day
+		validFrom := observedAt
+
+		req := &marketinformationv1.RecordObservationRequest{
+			DatasetCode:    datasetCode,
+			DatasetVersion: 0, // Use latest version
+			ObservedAt:     timestamppb.New(observedAt),
+			ValidFrom:      timestamppb.New(validFrom),
+			Value:          rate.Value.String(),
+			Quality:        marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+			SourceCode:     cfg.SourceCode,
+			Attributes:     buildAttributes(rate, causationID),
+		}
+
+		requests = append(requests, req)
+	}
+
+	return requests
+}
+
+// buildAttributes creates the attribute entries for an observation.
+func buildAttributes(rate Rate, causationID string) []*quantityv1.AttributeEntry {
+	return []*quantityv1.AttributeEntry{
+		{Key: "causation_id", Value: causationID},
+		{Key: "frequency", Value: rate.Frequency},
+		{Key: "exchange_rate_type", Value: rate.ExchangeRateType},
+		{Key: "exchange_rate_suffix", Value: rate.ExchangeRateSuffix},
+		{Key: "base_currency", Value: rate.BaseCurrency},
+		{Key: "quote_currency", Value: rate.QuoteCurrency},
+	}
+}
+
+// ParseAndTransform is a convenience function that parses CSV data and transforms
+// it to observation requests in a single call.
+func (p *Parser) ParseAndTransform(r io.Reader, cfg TransformConfig) ([]*marketinformationv1.RecordObservationRequest, error) {
+	rates, err := p.ParseCSV(r)
+	if err != nil {
+		return nil, err
+	}
+	return TransformToObservations(rates, cfg), nil
+}

--- a/services/market-information/adapters/external/ecb/ecb_parser_test.go
+++ b/services/market-information/adapters/external/ecb/ecb_parser_test.go
@@ -1,0 +1,472 @@
+package ecb_test
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/services/market-information/adapters/external/ecb"
+)
+
+// Sample ECB CSV data matching the real format.
+const validECBCSV = `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-15,1.0876
+EXR.D.GBP.EUR.SP00.A,D,GBP,EUR,SP00,A,2024-01-15,0.8612
+EXR.D.JPY.EUR.SP00.A,D,JPY,EUR,SP00,A,2024-01-15,160.89
+EXR.D.CHF.EUR.SP00.A,D,CHF,EUR,SP00,A,2024-01-15,0.9412`
+
+const multiDayECBCSV = `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-15,1.0876
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-16,1.0901
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-17,1.0888`
+
+func TestParser_ParseCSV_ValidData(t *testing.T) {
+	parser := ecb.NewParser()
+
+	rates, err := parser.ParseCSV(strings.NewReader(validECBCSV))
+	require.NoError(t, err)
+	require.Len(t, rates, 4)
+
+	// Verify first rate (USD)
+	usd := rates[0]
+	assert.Equal(t, "USD", usd.BaseCurrency)
+	assert.Equal(t, "EUR", usd.QuoteCurrency)
+	assert.True(t, decimal.NewFromFloat(1.0876).Equal(usd.Value))
+	assert.Equal(t, time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC), usd.ObservedDate)
+	assert.Equal(t, "D", usd.Frequency)
+	assert.Equal(t, "SP00", usd.ExchangeRateType)
+	assert.Equal(t, "A", usd.ExchangeRateSuffix)
+
+	// Verify GBP rate
+	gbp := rates[1]
+	assert.Equal(t, "GBP", gbp.BaseCurrency)
+	assert.True(t, decimal.NewFromFloat(0.8612).Equal(gbp.Value))
+
+	// Verify JPY rate (larger value)
+	jpy := rates[2]
+	assert.Equal(t, "JPY", jpy.BaseCurrency)
+	assert.True(t, decimal.NewFromFloat(160.89).Equal(jpy.Value))
+
+	// Verify CHF rate
+	chf := rates[3]
+	assert.Equal(t, "CHF", chf.BaseCurrency)
+	assert.True(t, decimal.NewFromFloat(0.9412).Equal(chf.Value))
+}
+
+func TestParser_ParseCSV_EmptyData(t *testing.T) {
+	parser := ecb.NewParser()
+
+	_, err := parser.ParseCSV(strings.NewReader(""))
+	require.ErrorIs(t, err, ecb.ErrNoData)
+}
+
+func TestParser_ParseCSV_HeaderOnly(t *testing.T) {
+	parser := ecb.NewParser()
+
+	csv := `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE`
+	_, err := parser.ParseCSV(strings.NewReader(csv))
+	require.ErrorIs(t, err, ecb.ErrNoData)
+}
+
+func TestParser_ParseCSV_InvalidHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		csv  string
+	}{
+		{
+			name: "wrong column names",
+			csv:  "WRONG,COLUMNS,HERE\n1,2,3",
+		},
+		{
+			name: "too few columns",
+			csv:  "KEY,FREQ,CURRENCY\ndata,D,USD",
+		},
+		{
+			name: "incorrect column order",
+			csv:  "FREQ,KEY,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE\nD,key,USD,EUR,SP00,A,2024-01-15,1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := ecb.NewParser()
+			_, err := parser.ParseCSV(strings.NewReader(tt.csv))
+			require.ErrorIs(t, err, ecb.ErrInvalidCSVFormat)
+		})
+	}
+}
+
+func TestParser_ParseCSV_MalformedRows(t *testing.T) {
+	parser := ecb.NewParser()
+
+	// CSV with some malformed rows - parser should skip them and continue
+	csv := `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-15,1.0876
+EXR.D.GBP.EUR.SP00.A,D,GBP,EUR,SP00,A,INVALID-DATE,0.8612
+EXR.D.JPY.EUR.SP00.A,D,JPY,EUR,SP00,A,2024-01-15,NOT_A_NUMBER
+EXR.D.CHF.EUR.SP00.A,D,CHF,EUR,SP00,A,2024-01-15,0.9412`
+
+	rates, err := parser.ParseCSV(strings.NewReader(csv))
+	require.NoError(t, err)
+	// Should only have valid rows (USD and CHF)
+	require.Len(t, rates, 2)
+	assert.Equal(t, "USD", rates[0].BaseCurrency)
+	assert.Equal(t, "CHF", rates[1].BaseCurrency)
+}
+
+func TestParser_ParseCSV_EmptyRateValue(t *testing.T) {
+	parser := ecb.NewParser()
+
+	csv := `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-15,
+EXR.D.GBP.EUR.SP00.A,D,GBP,EUR,SP00,A,2024-01-15,0.8612`
+
+	rates, err := parser.ParseCSV(strings.NewReader(csv))
+	require.NoError(t, err)
+	// Should only have the valid GBP row
+	require.Len(t, rates, 1)
+	assert.Equal(t, "GBP", rates[0].BaseCurrency)
+}
+
+func TestParser_ParseCSV_HighPrecisionDecimals(t *testing.T) {
+	parser := ecb.NewParser()
+
+	csv := `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-15,1.08765432109876`
+
+	rates, err := parser.ParseCSV(strings.NewReader(csv))
+	require.NoError(t, err)
+	require.Len(t, rates, 1)
+
+	expected, _ := decimal.NewFromString("1.08765432109876")
+	assert.True(t, expected.Equal(rates[0].Value),
+		"expected %s, got %s", expected.String(), rates[0].Value.String())
+}
+
+func TestParser_ParseCSV_NegativeRate(t *testing.T) {
+	parser := ecb.NewParser()
+
+	// While unusual for FX rates, the parser should handle negative numbers
+	csv := `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-15,-0.5`
+
+	rates, err := parser.ParseCSV(strings.NewReader(csv))
+	require.NoError(t, err)
+	require.Len(t, rates, 1)
+
+	expected := decimal.NewFromFloat(-0.5)
+	assert.True(t, expected.Equal(rates[0].Value))
+}
+
+func TestParser_ParseCSV_TrimWhitespace(t *testing.T) {
+	parser := ecb.NewParser()
+
+	csv := `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE
+EXR.D.USD.EUR.SP00.A, D , USD , EUR , SP00 , A , 2024-01-15 , 1.0876 `
+
+	rates, err := parser.ParseCSV(strings.NewReader(csv))
+	require.NoError(t, err)
+	require.Len(t, rates, 1)
+	assert.Equal(t, "D", rates[0].Frequency)
+	assert.Equal(t, "USD", rates[0].BaseCurrency)
+	assert.Equal(t, "EUR", rates[0].QuoteCurrency)
+}
+
+func TestParser_ParseCSV_CaseInsensitiveHeaders(t *testing.T) {
+	parser := ecb.NewParser()
+
+	csv := `key,freq,currency,currency_denom,exr_type,exr_suffix,time_period,obs_value
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-15,1.0876`
+
+	rates, err := parser.ParseCSV(strings.NewReader(csv))
+	require.NoError(t, err)
+	require.Len(t, rates, 1)
+}
+
+func TestParser_ParseCSV_ReaderError(t *testing.T) {
+	parser := ecb.NewParser()
+
+	_, err := parser.ParseCSV(&errorReader{})
+	require.Error(t, err)
+}
+
+// errorReader is a reader that always returns an error.
+type errorReader struct{}
+
+func (e *errorReader) Read(_ []byte) (n int, err error) {
+	return 0, io.ErrUnexpectedEOF
+}
+
+func TestTransformToObservations_ValidRates(t *testing.T) {
+	rates := []ecb.Rate{
+		{
+			BaseCurrency:       "USD",
+			QuoteCurrency:      "EUR",
+			Value:              decimal.NewFromFloat(1.0876),
+			ObservedDate:       time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			Frequency:          "D",
+			ExchangeRateType:   "SP00",
+			ExchangeRateSuffix: "A",
+		},
+		{
+			BaseCurrency:       "GBP",
+			QuoteCurrency:      "EUR",
+			Value:              decimal.NewFromFloat(0.8612),
+			ObservedDate:       time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			Frequency:          "D",
+			ExchangeRateType:   "SP00",
+			ExchangeRateSuffix: "A",
+		},
+	}
+
+	cfg := ecb.DefaultTransformConfig()
+	requests := ecb.TransformToObservations(rates, cfg)
+
+	require.Len(t, requests, 2)
+
+	// Verify USD observation
+	usdReq := requests[0]
+	assert.Equal(t, "USD_EUR_FX", usdReq.DatasetCode)
+	assert.Equal(t, int32(0), usdReq.DatasetVersion)
+	assert.Equal(t, "1.0876", usdReq.Value)
+	assert.Equal(t, marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL, usdReq.Quality)
+	assert.Equal(t, "ECB", usdReq.SourceCode)
+
+	// Verify timestamps
+	expectedTime := time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, expectedTime, usdReq.ObservedAt.AsTime())
+	assert.Equal(t, expectedTime, usdReq.ValidFrom.AsTime())
+
+	// Verify attributes
+	require.NotNil(t, usdReq.Attributes)
+	attrMap := make(map[string]string)
+	for _, attr := range usdReq.Attributes {
+		attrMap[attr.Key] = attr.Value
+	}
+	assert.Equal(t, "ecb-feed-2024-01-15", attrMap["causation_id"])
+	assert.Equal(t, "D", attrMap["frequency"])
+	assert.Equal(t, "SP00", attrMap["exchange_rate_type"])
+	assert.Equal(t, "A", attrMap["exchange_rate_suffix"])
+	assert.Equal(t, "USD", attrMap["base_currency"])
+	assert.Equal(t, "EUR", attrMap["quote_currency"])
+
+	// Verify GBP observation
+	gbpReq := requests[1]
+	assert.Equal(t, "GBP_EUR_FX", gbpReq.DatasetCode)
+	assert.Equal(t, "0.8612", gbpReq.Value)
+}
+
+func TestTransformToObservations_CustomConfig(t *testing.T) {
+	rates := []ecb.Rate{
+		{
+			BaseCurrency:       "USD",
+			QuoteCurrency:      "EUR",
+			Value:              decimal.NewFromFloat(1.0876),
+			ObservedDate:       time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			Frequency:          "D",
+			ExchangeRateType:   "SP00",
+			ExchangeRateSuffix: "A",
+		},
+	}
+
+	cfg := ecb.TransformConfig{
+		SourceCode:          "ECB_DAILY",
+		DatasetCodeTemplate: "FX_%s%s",
+	}
+	requests := ecb.TransformToObservations(rates, cfg)
+
+	require.Len(t, requests, 1)
+	assert.Equal(t, "FX_USDEUR", requests[0].DatasetCode)
+	assert.Equal(t, "ECB_DAILY", requests[0].SourceCode)
+}
+
+func TestTransformToObservations_DefaultConfigFallback(t *testing.T) {
+	rates := []ecb.Rate{
+		{
+			BaseCurrency:       "USD",
+			QuoteCurrency:      "EUR",
+			Value:              decimal.NewFromFloat(1.0876),
+			ObservedDate:       time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			Frequency:          "D",
+			ExchangeRateType:   "SP00",
+			ExchangeRateSuffix: "A",
+		},
+	}
+
+	// Empty config should use defaults
+	requests := ecb.TransformToObservations(rates, ecb.TransformConfig{})
+
+	require.Len(t, requests, 1)
+	assert.Equal(t, "USD_EUR_FX", requests[0].DatasetCode)
+	assert.Equal(t, "ECB", requests[0].SourceCode)
+}
+
+func TestTransformToObservations_EmptyRates(t *testing.T) {
+	cfg := ecb.DefaultTransformConfig()
+	requests := ecb.TransformToObservations([]ecb.Rate{}, cfg)
+
+	require.Empty(t, requests)
+}
+
+func TestTransformToObservations_CausationIDFormat(t *testing.T) {
+	rates := []ecb.Rate{
+		{
+			BaseCurrency:  "USD",
+			QuoteCurrency: "EUR",
+			Value:         decimal.NewFromFloat(1.0876),
+			ObservedDate:  time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	cfg := ecb.DefaultTransformConfig()
+	requests := ecb.TransformToObservations(rates, cfg)
+
+	require.Len(t, requests, 1)
+	attrMap := make(map[string]string)
+	for _, attr := range requests[0].Attributes {
+		attrMap[attr.Key] = attr.Value
+	}
+	assert.Equal(t, "ecb-feed-2024-12-31", attrMap["causation_id"])
+}
+
+func TestTransformToObservations_PreservesDecimalPrecision(t *testing.T) {
+	// Note: decimal.Decimal normalizes trailing zeros, so we use a value without them
+	highPrecisionRate, _ := decimal.NewFromString("1.0876543210987654321")
+
+	rates := []ecb.Rate{
+		{
+			BaseCurrency:  "USD",
+			QuoteCurrency: "EUR",
+			Value:         highPrecisionRate,
+			ObservedDate:  time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	cfg := ecb.DefaultTransformConfig()
+	requests := ecb.TransformToObservations(rates, cfg)
+
+	require.Len(t, requests, 1)
+	// Verify the value can be parsed back to the same decimal
+	parsedValue, err := decimal.NewFromString(requests[0].Value)
+	require.NoError(t, err)
+	assert.True(t, highPrecisionRate.Equal(parsedValue),
+		"expected %s, got %s", highPrecisionRate.String(), parsedValue.String())
+}
+
+func TestParser_ParseAndTransform(t *testing.T) {
+	parser := ecb.NewParser()
+	cfg := ecb.DefaultTransformConfig()
+
+	requests, err := parser.ParseAndTransform(strings.NewReader(validECBCSV), cfg)
+	require.NoError(t, err)
+	require.Len(t, requests, 4)
+
+	// Verify all currencies are present
+	currencies := make(map[string]bool)
+	for _, req := range requests {
+		// Extract currency from dataset code (e.g., "USD_EUR_FX" -> "USD")
+		parts := strings.Split(req.DatasetCode, "_")
+		if len(parts) > 0 {
+			currencies[parts[0]] = true
+		}
+	}
+	assert.True(t, currencies["USD"])
+	assert.True(t, currencies["GBP"])
+	assert.True(t, currencies["JPY"])
+	assert.True(t, currencies["CHF"])
+}
+
+func TestParser_ParseAndTransform_Error(t *testing.T) {
+	parser := ecb.NewParser()
+	cfg := ecb.DefaultTransformConfig()
+
+	_, err := parser.ParseAndTransform(strings.NewReader(""), cfg)
+	require.ErrorIs(t, err, ecb.ErrNoData)
+}
+
+func TestParser_ParseCSV_MultiDay(t *testing.T) {
+	parser := ecb.NewParser()
+
+	rates, err := parser.ParseCSV(strings.NewReader(multiDayECBCSV))
+	require.NoError(t, err)
+	require.Len(t, rates, 3)
+
+	// Verify dates are different
+	assert.Equal(t, time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC), rates[0].ObservedDate)
+	assert.Equal(t, time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC), rates[1].ObservedDate)
+	assert.Equal(t, time.Date(2024, 1, 17, 0, 0, 0, 0, time.UTC), rates[2].ObservedDate)
+
+	// Verify rates are different
+	assert.True(t, decimal.NewFromFloat(1.0876).Equal(rates[0].Value))
+	assert.True(t, decimal.NewFromFloat(1.0901).Equal(rates[1].Value))
+	assert.True(t, decimal.NewFromFloat(1.0888).Equal(rates[2].Value))
+}
+
+func TestDefaultTransformConfig(t *testing.T) {
+	cfg := ecb.DefaultTransformConfig()
+
+	assert.Equal(t, "ECB", cfg.SourceCode)
+	assert.Equal(t, "%s_%s_FX", cfg.DatasetCodeTemplate)
+}
+
+func TestParser_ParseCSV_ExtraColumns(t *testing.T) {
+	parser := ecb.NewParser()
+
+	// CSV with extra columns should still work
+	csv := `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE,EXTRA1,EXTRA2
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-15,1.0876,extra,data`
+
+	rates, err := parser.ParseCSV(strings.NewReader(csv))
+	require.NoError(t, err)
+	require.Len(t, rates, 1)
+	assert.Equal(t, "USD", rates[0].BaseCurrency)
+}
+
+func TestTransformToObservations_QualityLevel(t *testing.T) {
+	rates := []ecb.Rate{
+		{
+			BaseCurrency:  "USD",
+			QuoteCurrency: "EUR",
+			Value:         decimal.NewFromFloat(1.0876),
+			ObservedDate:  time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	cfg := ecb.DefaultTransformConfig()
+	requests := ecb.TransformToObservations(rates, cfg)
+
+	require.Len(t, requests, 1)
+	// ECB data should always be ACTUAL quality
+	assert.Equal(t, marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL, requests[0].Quality)
+}
+
+func TestParser_ParseCSV_AllMalformedRows(t *testing.T) {
+	parser := ecb.NewParser()
+
+	// All data rows are malformed
+	csv := `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,INVALID-DATE,1.0876
+EXR.D.GBP.EUR.SP00.A,D,GBP,EUR,SP00,A,2024-01-15,NOT_A_NUMBER`
+
+	_, err := parser.ParseCSV(strings.NewReader(csv))
+	require.ErrorIs(t, err, ecb.ErrNoData)
+}
+
+func TestParser_ParseCSV_TooFewColumnsInRow(t *testing.T) {
+	parser := ecb.NewParser()
+
+	csv := `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE
+EXR.D.USD.EUR.SP00.A,D,USD,EUR
+EXR.D.GBP.EUR.SP00.A,D,GBP,EUR,SP00,A,2024-01-15,0.8612`
+
+	rates, err := parser.ParseCSV(strings.NewReader(csv))
+	require.NoError(t, err)
+	require.Len(t, rates, 1)
+	assert.Equal(t, "GBP", rates[0].BaseCurrency)
+}

--- a/services/market-information/adapters/external/ecb/ecb_worker.go
+++ b/services/market-information/adapters/external/ecb/ecb_worker.go
@@ -1,0 +1,343 @@
+// Package ecb provides a scheduled worker for ingesting FX rates from the European Central Bank.
+package ecb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"sync"
+	"time"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+)
+
+// Default worker configuration values.
+const (
+	defaultFetchInterval = 24 * time.Hour
+	defaultMaxRetries    = 3
+)
+
+// MarketInformationClient is the interface for recording observations.
+// This allows the worker to be tested with a mock client.
+type MarketInformationClient interface {
+	RecordObservation(ctx context.Context, req *marketinformationv1.RecordObservationRequest) (*marketinformationv1.RecordObservationResponse, error)
+}
+
+// WorkerConfig holds configuration for the ECB ingestion worker.
+type WorkerConfig struct {
+	// DatasetCode is the dataset code prefix for observations (e.g., "ECB_FX").
+	DatasetCode string
+
+	// SourceCode is the data source code (e.g., "ECB").
+	SourceCode string
+
+	// FetchInterval is how often to fetch new rates.
+	// Default: 24 hours
+	FetchInterval time.Duration
+
+	// MaxRetries is the maximum number of retry attempts for failed operations.
+	// Default: 3
+	MaxRetries int
+}
+
+// DefaultWorkerConfig returns a WorkerConfig with sensible defaults.
+func DefaultWorkerConfig() WorkerConfig {
+	return WorkerConfig{
+		DatasetCode:   "ECB_FX",
+		SourceCode:    "ECB",
+		FetchInterval: defaultFetchInterval,
+		MaxRetries:    defaultMaxRetries,
+	}
+}
+
+// Worker is a background worker that fetches and ingests ECB FX rates on a schedule.
+// It implements graceful shutdown following the pattern from shared/platform/events/worker.go.
+type Worker struct {
+	client           *Client
+	marketInfoClient MarketInformationClient
+	parser           *Parser
+	config           WorkerConfig
+	logger           *slog.Logger
+	shutdown         chan struct{}
+	shutdownOnce     sync.Once
+	wg               sync.WaitGroup
+}
+
+// NewWorker creates a new ECB ingestion worker.
+//
+// Parameters:
+//   - client: The ECB HTTP client for fetching rates
+//   - marketInfoClient: gRPC client for recording observations
+//   - config: Worker configuration
+//   - logger: Structured logger (uses slog.Default() if nil)
+//
+// Returns a configured Worker ready to start processing.
+func NewWorker(
+	client *Client,
+	marketInfoClient MarketInformationClient,
+	config WorkerConfig,
+	logger *slog.Logger,
+) *Worker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	// Apply defaults
+	if config.FetchInterval <= 0 {
+		config.FetchInterval = defaultFetchInterval
+	}
+	if config.MaxRetries <= 0 {
+		config.MaxRetries = defaultMaxRetries
+	}
+	if config.SourceCode == "" {
+		config.SourceCode = "ECB"
+	}
+
+	return &Worker{
+		client:           client,
+		marketInfoClient: marketInfoClient,
+		parser:           NewParser(WithParserLogger(logger)),
+		config:           config,
+		logger:           logger.With("component", "ecb_worker"),
+		shutdown:         make(chan struct{}),
+	}
+}
+
+// Start begins background processing of ECB rate ingestion.
+// This method spawns a goroutine and returns immediately.
+// The worker will continue processing until Stop() is called or the context is cancelled.
+func (w *Worker) Start(ctx context.Context) {
+	w.wg.Add(1)
+	go w.run(ctx)
+
+	w.logger.Info("ECB worker started",
+		"fetch_interval", w.config.FetchInterval,
+		"source_code", w.config.SourceCode,
+		"max_retries", w.config.MaxRetries)
+}
+
+// Stop initiates graceful shutdown of the worker.
+// It signals the worker to stop and waits for the current operation to complete.
+// Safe to call multiple times - subsequent calls will block until shutdown completes.
+func (w *Worker) Stop() {
+	w.shutdownOnce.Do(func() {
+		w.logger.Info("ECB worker stopping")
+		close(w.shutdown)
+	})
+	w.wg.Wait()
+
+	w.logger.Info("ECB worker stopped")
+}
+
+// run is the main processing loop that polls ECB on the configured interval.
+func (w *Worker) run(ctx context.Context) {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(w.config.FetchInterval)
+	defer ticker.Stop()
+
+	w.logger.Info("ECB worker processing loop started")
+
+	// Perform initial fetch immediately
+	w.ingestRates(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("ECB worker context cancelled")
+			return
+		case <-w.shutdown:
+			w.logger.Info("ECB worker shutdown signal received")
+			return
+		case <-ticker.C:
+			w.ingestRates(ctx)
+		}
+	}
+}
+
+// ingestRates fetches ECB rates and records them as observations with retry logic.
+// It handles transient failures with exponential backoff and logs errors but does not
+// block the worker on permanent failures.
+func (w *Worker) ingestRates(ctx context.Context) {
+	causationID := fmt.Sprintf("ecb-feed-%s", time.Now().UTC().Format("2006-01-02"))
+
+	var lastErr error
+	for attempt := 1; attempt <= w.config.MaxRetries; attempt++ {
+		err := w.attemptIngestion(ctx, causationID)
+		if err == nil {
+			w.logger.Info("ECB rates ingestion successful", "causation_id", causationID)
+			return
+		}
+
+		lastErr = err
+
+		// Check if error is retryable
+		if !IsRetryableError(err) {
+			w.logger.Error("ECB rates ingestion failed with permanent error",
+				"error", err,
+				"causation_id", causationID)
+			return
+		}
+
+		// Don't log retry warning or wait on the last attempt
+		if attempt == w.config.MaxRetries {
+			break
+		}
+
+		w.logger.Warn("ECB rates ingestion failed, retrying",
+			"attempt", attempt,
+			"max_retries", w.config.MaxRetries,
+			"error", err)
+
+		// Exponential backoff: 1s, 2s, 4s, ...
+		backoff := time.Duration(1<<(attempt-1)) * time.Second
+		select {
+		case <-ctx.Done():
+			w.logger.Warn("ECB ingestion retry interrupted by context cancellation",
+				"causation_id", causationID,
+				"attempt", attempt)
+			return
+		case <-w.shutdown:
+			w.logger.Warn("ECB ingestion retry interrupted by shutdown",
+				"causation_id", causationID,
+				"attempt", attempt)
+			return
+		case <-time.After(backoff):
+			continue
+		}
+	}
+
+	w.logger.Error("ECB rates ingestion failed after retries",
+		"error", lastErr,
+		"causation_id", causationID,
+		"attempts", w.config.MaxRetries)
+}
+
+// attemptIngestion performs a single ingestion attempt: fetch -> parse -> transform -> record.
+func (w *Worker) attemptIngestion(ctx context.Context, causationID string) error {
+	start := time.Now()
+
+	w.logger.Info("starting ECB rate ingestion", "causation_id", causationID)
+
+	// Fetch CSV from ECB
+	body, err := w.client.FetchDailyRates(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to fetch ECB rates: %w", err)
+	}
+	defer func() { _ = body.Close() }()
+
+	// Parse CSV
+	rates, err := w.parser.ParseCSV(body)
+	if err != nil {
+		return fmt.Errorf("failed to parse ECB CSV: %w", err)
+	}
+
+	w.logger.Debug("parsed ECB rates", "count", len(rates))
+
+	// Transform to observations
+	transformCfg := TransformConfig{
+		SourceCode:          w.config.SourceCode,
+		DatasetCodeTemplate: "%s_%s_FX",
+	}
+	observations := TransformToObservations(rates, transformCfg)
+
+	// Record observations
+	var successCount, failCount int
+	for _, obs := range observations {
+		// Check for shutdown or context cancellation before each gRPC call
+		select {
+		case <-ctx.Done():
+			w.logger.Warn("ingestion interrupted by context cancellation",
+				"processed", successCount,
+				"remaining", len(observations)-successCount-failCount)
+			return ctx.Err()
+		case <-w.shutdown:
+			w.logger.Warn("ingestion interrupted by shutdown",
+				"processed", successCount,
+				"remaining", len(observations)-successCount-failCount)
+			return nil
+		default:
+		}
+
+		_, err := w.marketInfoClient.RecordObservation(ctx, obs)
+		if err != nil {
+			w.logger.Warn("failed to record observation",
+				"dataset_code", obs.DatasetCode,
+				"observed_at", obs.ObservedAt.AsTime(),
+				"error", err)
+			failCount++
+			continue
+		}
+		successCount++
+	}
+
+	duration := time.Since(start)
+	w.logger.Info("ECB rate ingestion completed",
+		"causation_id", causationID,
+		"success_count", successCount,
+		"fail_count", failCount,
+		"total_rates", len(rates),
+		"duration", duration)
+
+	if failCount > 0 {
+		return fmt.Errorf("%w: %d/%d observations failed", ErrPartialIngestion, failCount, len(observations))
+	}
+
+	return nil
+}
+
+// IsRetryableError determines if an error should trigger a retry.
+// Network errors and HTTP 5xx are retryable; 4xx and parse errors are permanent.
+func IsRetryableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Rate limiting (HTTP 429) is retryable
+	if errors.Is(err, ErrRateLimited) {
+		return true
+	}
+
+	// Parse errors are permanent - the data won't change on retry
+	if errors.Is(err, ErrInvalidCSVFormat) ||
+		errors.Is(err, ErrNoData) ||
+		errors.Is(err, ErrInvalidRate) ||
+		errors.Is(err, ErrInvalidDate) ||
+		errors.Is(err, ErrTooFewColumns) {
+		return false
+	}
+
+	// Client not configured is permanent
+	if errors.Is(err, ErrNotConfigured) {
+		return false
+	}
+
+	// Context cancellation is not retryable
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	// Network errors are retryable
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	// URL errors (DNS failures, etc.) are retryable
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+
+	// ErrAPIError wraps HTTP errors - these are generally 5xx which are retryable
+	// HTTP 4xx errors would typically return a different error type or be checked above
+	if errors.Is(err, ErrAPIError) {
+		return true
+	}
+
+	// Default to retryable for unknown errors (safer for transient issues)
+	return true
+}

--- a/services/market-information/adapters/external/ecb/ecb_worker_test.go
+++ b/services/market-information/adapters/external/ecb/ecb_worker_test.go
@@ -1,0 +1,810 @@
+package ecb_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/services/market-information/adapters/external/ecb"
+	"github.com/meridianhub/meridian/shared/platform/await"
+)
+
+// Test sentinel errors for use in test cases.
+var (
+	errGRPC    = errors.New("gRPC error")
+	errUnknown = errors.New("some unknown error")
+)
+
+// mockMarketInfoClient implements the MarketInformationClient interface for testing.
+type mockMarketInfoClient struct {
+	mu              sync.Mutex
+	recordedObs     []*marketinformationv1.RecordObservationRequest
+	recordErr       error
+	recordCallCount atomic.Int32
+}
+
+func newMockMarketInfoClient() *mockMarketInfoClient {
+	return &mockMarketInfoClient{
+		recordedObs: make([]*marketinformationv1.RecordObservationRequest, 0),
+	}
+}
+
+func (m *mockMarketInfoClient) RecordObservation(
+	_ context.Context,
+	req *marketinformationv1.RecordObservationRequest,
+) (*marketinformationv1.RecordObservationResponse, error) {
+	m.recordCallCount.Add(1)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.recordErr != nil {
+		return nil, m.recordErr
+	}
+
+	m.recordedObs = append(m.recordedObs, req)
+	return &marketinformationv1.RecordObservationResponse{
+		Observation: &marketinformationv1.MarketPriceObservation{
+			Id: "test-obs-id",
+		},
+	}, nil
+}
+
+func (m *mockMarketInfoClient) getRecordedObservations() []*marketinformationv1.RecordObservationRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]*marketinformationv1.RecordObservationRequest{}, m.recordedObs...)
+}
+
+func (m *mockMarketInfoClient) setError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.recordErr = err
+}
+
+// sampleECBCSV provides valid ECB CSV data for testing.
+const sampleECBCSV = `KEY,FREQ,CURRENCY,CURRENCY_DENOM,EXR_TYPE,EXR_SUFFIX,TIME_PERIOD,OBS_VALUE
+EXR.D.USD.EUR.SP00.A,D,USD,EUR,SP00,A,2024-01-15,1.0876
+EXR.D.GBP.EUR.SP00.A,D,GBP,EUR,SP00,A,2024-01-15,0.8612
+EXR.D.JPY.EUR.SP00.A,D,JPY,EUR,SP00,A,2024-01-15,160.52`
+
+func TestNewWorker_Defaults(t *testing.T) {
+	client := ecb.NewClient(ecb.Config{})
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{}, nil)
+	require.NotNil(t, worker)
+}
+
+func TestNewWorker_CustomConfig(t *testing.T) {
+	client := ecb.NewClient(ecb.Config{})
+	mockClient := newMockMarketInfoClient()
+
+	config := ecb.WorkerConfig{
+		DatasetCode:   "CUSTOM_FX",
+		SourceCode:    "CUSTOM_ECB",
+		FetchInterval: 12 * time.Hour,
+		MaxRetries:    5,
+	}
+
+	worker := ecb.NewWorker(client, mockClient, config, nil)
+	require.NotNil(t, worker)
+}
+
+func TestDefaultWorkerConfig(t *testing.T) {
+	config := ecb.DefaultWorkerConfig()
+
+	assert.Equal(t, "ECB_FX", config.DatasetCode)
+	assert.Equal(t, "ECB", config.SourceCode)
+	assert.Equal(t, 24*time.Hour, config.FetchInterval)
+	assert.Equal(t, 3, config.MaxRetries)
+}
+
+func TestWorker_StartStop(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleECBCSV))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 100 * time.Millisecond,
+		SourceCode:    "ECB",
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait for initial ingestion to complete using await
+	err := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mockClient.recordCallCount.Load() >= 3
+		})
+	require.NoError(t, err, "expected at least 3 observations to be recorded")
+
+	worker.Stop()
+
+	// Verify observations were recorded
+	obs := mockClient.getRecordedObservations()
+	require.GreaterOrEqual(t, len(obs), 3)
+
+	// Verify observation content
+	foundUSD := false
+	foundGBP := false
+	for _, o := range obs {
+		if o.DatasetCode == "USD_EUR_FX" {
+			foundUSD = true
+			assert.Equal(t, "ECB", o.SourceCode)
+			assert.Equal(t, "1.0876", o.Value)
+		}
+		if o.DatasetCode == "GBP_EUR_FX" {
+			foundGBP = true
+			assert.Equal(t, "0.8612", o.Value)
+		}
+	}
+	assert.True(t, foundUSD, "expected USD_EUR_FX observation")
+	assert.True(t, foundGBP, "expected GBP_EUR_FX observation")
+}
+
+func TestWorker_StopIdempotent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleECBCSV))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 1 * time.Hour, // Long interval so we don't tick during test
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait for initial ingestion
+	err := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mockClient.recordCallCount.Load() >= 1
+		})
+	require.NoError(t, err)
+
+	// Stop multiple times - should not panic
+	worker.Stop()
+	worker.Stop()
+	worker.Stop()
+}
+
+func TestWorker_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleECBCSV))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 100 * time.Millisecond,
+	}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+
+	// Wait for initial ingestion
+	err := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mockClient.recordCallCount.Load() >= 1
+		})
+	require.NoError(t, err)
+
+	// Cancel context
+	cancel()
+
+	// Worker should stop gracefully - use Stop() to wait for completion
+	worker.Stop()
+}
+
+func TestWorker_FetchError(t *testing.T) {
+	// Server returns error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("internal error"))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 100 * time.Millisecond,
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait briefly to allow the initial fetch to fail
+	// Since fetch fails, no observations should be recorded
+	time.Sleep(200 * time.Millisecond)
+
+	worker.Stop()
+
+	// Verify no observations were recorded due to fetch error
+	obs := mockClient.getRecordedObservations()
+	assert.Empty(t, obs)
+}
+
+func TestWorker_ParseError(t *testing.T) {
+	// Server returns invalid CSV
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("invalid,csv,format"))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 100 * time.Millisecond,
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait briefly for initial fetch
+	time.Sleep(200 * time.Millisecond)
+
+	worker.Stop()
+
+	// Verify no observations were recorded due to parse error
+	obs := mockClient.getRecordedObservations()
+	assert.Empty(t, obs)
+}
+
+func TestWorker_RecordObservationError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleECBCSV))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+	mockClient.setError(errGRPC)
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 1 * time.Hour, // Long interval
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait for attempt to record
+	err := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mockClient.recordCallCount.Load() >= 3
+		})
+	require.NoError(t, err)
+
+	worker.Stop()
+
+	// Verify no observations were successfully recorded (all failed)
+	obs := mockClient.getRecordedObservations()
+	assert.Empty(t, obs)
+}
+
+func TestWorker_PartialRecordError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleECBCSV))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := &partialErrorMockClient{
+		failOnCall: 2, // Fail on second call
+	}
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 1 * time.Hour, // Long interval
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait for all calls to complete
+	err := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mockClient.callCount.Load() >= 3
+		})
+	require.NoError(t, err)
+
+	worker.Stop()
+
+	// Verify 2 observations were recorded (1st and 3rd succeeded, 2nd failed)
+	obs := mockClient.getRecordedObservations()
+	assert.Len(t, obs, 2)
+}
+
+// partialErrorMockClient fails on specific call numbers for testing partial failures.
+type partialErrorMockClient struct {
+	mu          sync.Mutex
+	recordedObs []*marketinformationv1.RecordObservationRequest
+	failOnCall  int32
+	callCount   atomic.Int32
+}
+
+func (m *partialErrorMockClient) RecordObservation(
+	_ context.Context,
+	req *marketinformationv1.RecordObservationRequest,
+) (*marketinformationv1.RecordObservationResponse, error) {
+	callNum := m.callCount.Add(1)
+
+	if callNum == m.failOnCall {
+		return nil, errGRPC
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.recordedObs = append(m.recordedObs, req)
+
+	return &marketinformationv1.RecordObservationResponse{
+		Observation: &marketinformationv1.MarketPriceObservation{
+			Id: "test-obs-id",
+		},
+	}, nil
+}
+
+func (m *partialErrorMockClient) getRecordedObservations() []*marketinformationv1.RecordObservationRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]*marketinformationv1.RecordObservationRequest{}, m.recordedObs...)
+}
+
+func TestWorker_MultipleTickCycles(t *testing.T) {
+	var callCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleECBCSV))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 50 * time.Millisecond, // Short interval for testing
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait for at least 3 fetch cycles (initial + 2 ticks)
+	err := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(25 * time.Millisecond).
+		Until(func() bool {
+			return callCount.Load() >= 3
+		})
+	require.NoError(t, err)
+
+	worker.Stop()
+
+	// Verify multiple fetch cycles occurred
+	assert.GreaterOrEqual(t, callCount.Load(), int32(3))
+}
+
+func TestWorker_ObservationAttributes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleECBCSV))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 1 * time.Hour,
+		SourceCode:    "ECB",
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait for observations to be recorded
+	err := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mockClient.recordCallCount.Load() >= 3
+		})
+	require.NoError(t, err)
+
+	worker.Stop()
+
+	obs := mockClient.getRecordedObservations()
+	require.NotEmpty(t, obs)
+
+	// Find USD observation and verify attributes
+	var usdObs *marketinformationv1.RecordObservationRequest
+	for _, o := range obs {
+		if o.DatasetCode == "USD_EUR_FX" {
+			usdObs = o
+			break
+		}
+	}
+	require.NotNil(t, usdObs, "expected USD_EUR_FX observation")
+
+	// Verify attributes are set
+	attrs := make(map[string]string)
+	for _, attr := range usdObs.Attributes {
+		attrs[attr.Key] = attr.Value
+	}
+
+	assert.Contains(t, attrs, "causation_id")
+	assert.Contains(t, attrs["causation_id"], "ecb-feed-")
+	assert.Equal(t, "D", attrs["frequency"])
+	assert.Equal(t, "SP00", attrs["exchange_rate_type"])
+	assert.Equal(t, "A", attrs["exchange_rate_suffix"])
+	assert.Equal(t, "USD", attrs["base_currency"])
+	assert.Equal(t, "EUR", attrs["quote_currency"])
+}
+
+func TestWorker_RateLimited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("rate limited"))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 100 * time.Millisecond,
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait briefly for fetch attempt
+	time.Sleep(200 * time.Millisecond)
+
+	worker.Stop()
+
+	// Verify no observations were recorded due to rate limiting
+	obs := mockClient.getRecordedObservations()
+	assert.Empty(t, obs)
+}
+
+// retryCountingServer tracks fetch attempts and fails N times before succeeding.
+type retryCountingServer struct {
+	fetchCount   atomic.Int32
+	failCount    int32 // Number of times to fail before succeeding
+	failWithCode int   // HTTP status code to return on failure (default 500)
+	csvData      string
+}
+
+func newRetryCountingServer(failCount int, csvData string) *retryCountingServer {
+	return &retryCountingServer{
+		failCount:    int32(failCount),
+		failWithCode: http.StatusInternalServerError,
+		csvData:      csvData,
+	}
+}
+
+func (s *retryCountingServer) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	attempt := s.fetchCount.Add(1)
+	if attempt <= s.failCount {
+		w.WriteHeader(s.failWithCode)
+		_, _ = w.Write([]byte("server error"))
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(s.csvData))
+}
+
+func TestWorker_RetrySuccessAfterTransientFailure(t *testing.T) {
+	// Server fails twice (500), then succeeds on third attempt
+	retryServer := newRetryCountingServer(2, sampleECBCSV)
+	server := httptest.NewServer(retryServer)
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 1 * time.Hour, // Long interval, we only care about initial fetch
+		MaxRetries:    5,             // More than enough retries
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait for retry logic to succeed (fail twice, succeed on third)
+	// Backoff is 1s, 2s, so we need ~3s plus processing time
+	err := await.New().
+		AtMost(10 * time.Second).
+		PollInterval(100 * time.Millisecond).
+		Until(func() bool {
+			return mockClient.recordCallCount.Load() >= 3
+		})
+	require.NoError(t, err, "expected observations to be recorded after retries")
+
+	worker.Stop()
+
+	// Verify server was called 3 times (2 failures + 1 success)
+	assert.Equal(t, int32(3), retryServer.fetchCount.Load())
+
+	// Verify observations were recorded successfully
+	obs := mockClient.getRecordedObservations()
+	assert.GreaterOrEqual(t, len(obs), 3)
+}
+
+func TestWorker_MaxRetriesExhausted(t *testing.T) {
+	// Server always fails with 500
+	var fetchCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("server error"))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	maxRetries := 3
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 1 * time.Hour,
+		MaxRetries:    maxRetries,
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait for all retries to be exhausted
+	// With MaxRetries=3 and backoff of 1s, 2s between attempts, total time is ~3s
+	err := await.New().
+		AtMost(10 * time.Second).
+		PollInterval(100 * time.Millisecond).
+		Until(func() bool {
+			return fetchCount.Load() >= int32(maxRetries)
+		})
+	require.NoError(t, err, "expected all retry attempts to be made")
+
+	worker.Stop()
+
+	// Verify server was called exactly MaxRetries times
+	assert.Equal(t, int32(maxRetries), fetchCount.Load())
+
+	// Verify no observations were recorded (all attempts failed)
+	obs := mockClient.getRecordedObservations()
+	assert.Empty(t, obs)
+}
+
+func TestWorker_ImmediateFailureOnPermanentError(t *testing.T) {
+	// Server returns invalid CSV (parse error = permanent failure, no retry)
+	var fetchCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+		// Return invalid CSV header that won't parse
+		_, _ = w.Write([]byte("invalid,csv,format"))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 1 * time.Hour,
+		MaxRetries:    5, // High retry count, but shouldn't be used for permanent errors
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait briefly for initial fetch to fail permanently
+	err := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return fetchCount.Load() >= 1
+		})
+	require.NoError(t, err)
+
+	// Wait a bit more to ensure no retries happen
+	time.Sleep(500 * time.Millisecond)
+
+	worker.Stop()
+
+	// Verify server was called only once (no retries for permanent parse error)
+	assert.Equal(t, int32(1), fetchCount.Load())
+
+	// Verify no observations were recorded
+	obs := mockClient.getRecordedObservations()
+	assert.Empty(t, obs)
+}
+
+func TestWorker_ContextCancellationDuringBackoff(t *testing.T) {
+	// Server always fails to trigger backoff
+	var fetchCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fetchCount.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("server error"))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 1 * time.Hour,
+		MaxRetries:    10, // Many retries, but we'll cancel during first backoff
+	}, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+
+	// Wait for first fetch attempt
+	err := await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return fetchCount.Load() >= 1
+		})
+	require.NoError(t, err)
+
+	// Cancel context during backoff wait (before second attempt)
+	// First backoff is 1s, so cancel immediately after first failure
+	time.Sleep(100 * time.Millisecond) // Small delay to ensure we're in backoff
+	cancel()
+
+	// Worker should stop gracefully
+	worker.Stop()
+
+	// Should have made 1-2 attempts max (cancelled during or shortly after first backoff)
+	attempts := fetchCount.Load()
+	assert.LessOrEqual(t, attempts, int32(2), "expected at most 2 attempts before cancellation")
+}
+
+func TestWorker_RetryOnRateLimiting(t *testing.T) {
+	// Server returns 429 twice, then succeeds
+	var fetchCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempt := fetchCount.Add(1)
+		if attempt <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte("rate limited"))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(sampleECBCSV))
+	}))
+	defer server.Close()
+
+	client := ecb.NewClient(ecb.Config{}, ecb.WithEndpoint(server.URL))
+	mockClient := newMockMarketInfoClient()
+
+	worker := ecb.NewWorker(client, mockClient, ecb.WorkerConfig{
+		FetchInterval: 1 * time.Hour,
+		MaxRetries:    5,
+	}, nil)
+
+	ctx := context.Background()
+	worker.Start(ctx)
+
+	// Wait for successful ingestion after rate limiting retries
+	err := await.New().
+		AtMost(10 * time.Second).
+		PollInterval(100 * time.Millisecond).
+		Until(func() bool {
+			return mockClient.recordCallCount.Load() >= 3
+		})
+	require.NoError(t, err, "expected observations after rate limit retries")
+
+	worker.Stop()
+
+	// Verify server was called 3 times (2 rate limits + 1 success)
+	assert.Equal(t, int32(3), fetchCount.Load())
+
+	// Verify observations were recorded
+	obs := mockClient.getRecordedObservations()
+	assert.GreaterOrEqual(t, len(obs), 3)
+}
+
+func TestIsRetryableError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{
+			name:      "nil error",
+			err:       nil,
+			retryable: false,
+		},
+		{
+			name:      "rate limited error",
+			err:       ecb.ErrRateLimited,
+			retryable: true,
+		},
+		{
+			name:      "wrapped rate limited error",
+			err:       fmt.Errorf("fetch failed: %w", ecb.ErrRateLimited),
+			retryable: true, // Rate limited errors are retryable
+		},
+		{
+			name:      "API error (5xx)",
+			err:       ecb.ErrAPIError,
+			retryable: true,
+		},
+		{
+			name:      "invalid CSV format",
+			err:       ecb.ErrInvalidCSVFormat,
+			retryable: false,
+		},
+		{
+			name:      "no data error",
+			err:       ecb.ErrNoData,
+			retryable: false,
+		},
+		{
+			name:      "not configured error",
+			err:       ecb.ErrNotConfigured,
+			retryable: false,
+		},
+		{
+			name:      "context canceled",
+			err:       context.Canceled,
+			retryable: false,
+		},
+		{
+			name:      "context deadline exceeded",
+			err:       context.DeadlineExceeded,
+			retryable: false,
+		},
+		{
+			name:      "generic error defaults to retryable",
+			err:       errUnknown,
+			retryable: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ecb.IsRetryableError(tc.err)
+			assert.Equal(t, tc.retryable, result)
+		})
+	}
+}

--- a/services/market-information/cmd/main.go
+++ b/services/market-information/cmd/main.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/meridianhub/meridian/services/market-information/adapters/external/ecb"
+	"github.com/meridianhub/meridian/services/market-information/config"
 	"github.com/meridianhub/meridian/services/market-information/service"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
@@ -55,6 +57,9 @@ func main() {
 
 func run(logger *slog.Logger) error {
 	ctx := context.Background()
+
+	// Load service configuration
+	cfg := config.LoadConfig()
 
 	// Initialize OpenTelemetry tracer
 	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
@@ -191,6 +196,51 @@ func run(logger *slog.Logger) error {
 
 	// Wait for shutdown signal and orchestrate graceful shutdown
 	orchestrator := bootstrap.NewShutdownOrchestrator(grpcServer, logger)
+
+	// Initialize ECB adapter worker (if enabled)
+	// Note: This requires the Market Information service to be fully wired up.
+	// The ECB worker calls RecordObservation on the service to ingest FX rates.
+	if cfg.ECB.Enabled {
+		// TODO: Enable ECB worker once marketInformationServer is available
+		// The ECB worker needs a MarketInformationClient interface which the Server implements.
+		// Once the Server is created above, uncomment and wire up:
+		//
+		// ecbClient := ecb.NewClient(ecb.Config{
+		// 	Endpoint: cfg.ECB.Endpoint,
+		// 	Timeout:  cfg.ECB.Timeout,
+		// }, ecb.WithLogger(logger))
+		//
+		// ecbWorker := ecb.NewWorker(
+		// 	ecbClient,
+		// 	marketInformationServer, // Server implements MarketInformationClient interface
+		// 	ecb.WorkerConfig{
+		// 		DatasetCode:   cfg.ECB.DatasetCode,
+		// 		SourceCode:    cfg.ECB.SourceCode,
+		// 		FetchInterval: cfg.ECB.Interval,
+		// 		MaxRetries:    cfg.ECB.MaxRetries,
+		// 	},
+		// 	logger,
+		// )
+		//
+		// ecbWorker.Start(ctx)
+		//
+		// // Register cleanup to stop ECB worker before other services
+		// orchestrator.AddCleanup(func() error {
+		// 	ecbWorker.Stop()
+		// 	return nil
+		// })
+		//
+		// logger.Info("ECB adapter initialized",
+		// 	"interval", cfg.ECB.Interval,
+		// 	"source_code", cfg.ECB.SourceCode,
+		// 	"dataset_code", cfg.ECB.DatasetCode)
+
+		logger.Warn("ECB adapter enabled but Market Information service not yet wired up",
+			"ecb_enabled", cfg.ECB.Enabled)
+
+		// Suppress unused import warning - remove this block when ECB worker is wired up
+		_ = ecb.NewClient
+	}
 
 	// Register cleanup functions (LIFO order - HTTP server first, then database)
 	orchestrator.AddCleanup(func() error {

--- a/services/market-information/config/config.go
+++ b/services/market-information/config/config.go
@@ -2,9 +2,89 @@
 // BIAN Service Domain: Market Information Management
 package config
 
-// TODO: Add configuration when implementing Task 3 (External Dependencies)
+import (
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/env"
+)
+
+// ECBConfig holds configuration for the ECB daily FX rates adapter.
+type ECBConfig struct {
+	// Enabled controls whether the ECB worker runs.
+	// Default: false (opt-in)
+	Enabled bool
+
+	// Endpoint is the ECB SDMX Web Service URL.
+	// Default: uses the ECB client's default endpoint
+	Endpoint string
+
+	// SourceCode is the data source code registered in Market Information.
+	// Default: "ECB"
+	SourceCode string
+
+	// DatasetCode is the dataset code prefix for ECB FX rates.
+	// Default: "ECB_FX"
+	DatasetCode string
+
+	// Interval is how often to fetch new rates from ECB.
+	// Default: 24 hours
+	Interval time.Duration
+
+	// Timeout is the HTTP request timeout for ECB API calls.
+	// Default: 30 seconds
+	Timeout time.Duration
+
+	// MaxRetries is the maximum number of retry attempts for failed operations.
+	// Default: 3
+	MaxRetries int
+}
+
+// DefaultECBConfig returns the default ECB configuration.
+func DefaultECBConfig() ECBConfig {
+	return ECBConfig{
+		Enabled:     false,
+		Endpoint:    "", // Uses ECB client's default
+		SourceCode:  "ECB",
+		DatasetCode: "ECB_FX",
+		Interval:    24 * time.Hour,
+		Timeout:     30 * time.Second,
+		MaxRetries:  3,
+	}
+}
+
+// LoadECBConfig loads ECB configuration from environment variables.
 //
-// Expected configuration:
-// - ExternalDataFeedConfig: URLs and credentials for market data feeds
-// - CacheConfig: TTL and refresh settings for price caching
-// - RateLimitConfig: Throttling for external API calls
+// Environment variables:
+//   - ECB_ENABLED: Enable/disable the ECB worker (default: false)
+//   - ECB_ENDPOINT: ECB SDMX Web Service URL (default: uses client default)
+//   - ECB_SOURCE_CODE: Data source code in Market Information (default: ECB)
+//   - ECB_DATASET_CODE: Dataset code prefix for FX rates (default: ECB_FX)
+//   - ECB_INTERVAL: How often to fetch rates (default: 24h)
+//   - ECB_TIMEOUT: HTTP request timeout (default: 30s)
+//   - ECB_MAX_RETRIES: Maximum retry attempts (default: 3)
+func LoadECBConfig() ECBConfig {
+	defaults := DefaultECBConfig()
+
+	return ECBConfig{
+		Enabled:     env.GetEnvAsBool("ECB_ENABLED", defaults.Enabled),
+		Endpoint:    env.GetEnvOrDefault("ECB_ENDPOINT", defaults.Endpoint),
+		SourceCode:  env.GetEnvOrDefault("ECB_SOURCE_CODE", defaults.SourceCode),
+		DatasetCode: env.GetEnvOrDefault("ECB_DATASET_CODE", defaults.DatasetCode),
+		Interval:    env.GetEnvAsDuration("ECB_INTERVAL", defaults.Interval),
+		Timeout:     env.GetEnvAsDuration("ECB_TIMEOUT", defaults.Timeout),
+		MaxRetries:  env.GetEnvAsInt("ECB_MAX_RETRIES", defaults.MaxRetries),
+	}
+}
+
+// Config holds all configuration for the Market Information service.
+type Config struct {
+	// ECB holds the ECB adapter configuration.
+	ECB ECBConfig
+}
+
+// LoadConfig loads all service configuration from environment variables.
+func LoadConfig() Config {
+	return Config{
+		ECB: LoadECBConfig(),
+	}
+}

--- a/services/market-information/config/config_test.go
+++ b/services/market-information/config/config_test.go
@@ -1,0 +1,95 @@
+package config
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultECBConfig(t *testing.T) {
+	cfg := DefaultECBConfig()
+
+	assert.False(t, cfg.Enabled, "ECB should be disabled by default")
+	assert.Empty(t, cfg.Endpoint, "Endpoint should be empty by default (uses client default)")
+	assert.Equal(t, "ECB", cfg.SourceCode)
+	assert.Equal(t, "ECB_FX", cfg.DatasetCode)
+	assert.Equal(t, 24*time.Hour, cfg.Interval)
+	assert.Equal(t, 30*time.Second, cfg.Timeout)
+	assert.Equal(t, 3, cfg.MaxRetries)
+}
+
+func TestLoadECBConfig_Defaults(t *testing.T) {
+	// Clear any existing env vars
+	envVars := []string{
+		"ECB_ENABLED",
+		"ECB_ENDPOINT",
+		"ECB_SOURCE_CODE",
+		"ECB_DATASET_CODE",
+		"ECB_INTERVAL",
+		"ECB_TIMEOUT",
+		"ECB_MAX_RETRIES",
+	}
+	for _, env := range envVars {
+		os.Unsetenv(env)
+	}
+
+	cfg := LoadECBConfig()
+
+	assert.False(t, cfg.Enabled)
+	assert.Empty(t, cfg.Endpoint)
+	assert.Equal(t, "ECB", cfg.SourceCode)
+	assert.Equal(t, "ECB_FX", cfg.DatasetCode)
+	assert.Equal(t, 24*time.Hour, cfg.Interval)
+	assert.Equal(t, 30*time.Second, cfg.Timeout)
+	assert.Equal(t, 3, cfg.MaxRetries)
+}
+
+func TestLoadECBConfig_FromEnv(t *testing.T) {
+	// Set test environment variables
+	t.Setenv("ECB_ENABLED", "true")
+	t.Setenv("ECB_ENDPOINT", "https://custom.endpoint.com/api")
+	t.Setenv("ECB_SOURCE_CODE", "CUSTOM_ECB")
+	t.Setenv("ECB_DATASET_CODE", "CUSTOM_FX")
+	t.Setenv("ECB_INTERVAL", "12h")
+	t.Setenv("ECB_TIMEOUT", "45s")
+	t.Setenv("ECB_MAX_RETRIES", "5")
+
+	cfg := LoadECBConfig()
+
+	assert.True(t, cfg.Enabled)
+	assert.Equal(t, "https://custom.endpoint.com/api", cfg.Endpoint)
+	assert.Equal(t, "CUSTOM_ECB", cfg.SourceCode)
+	assert.Equal(t, "CUSTOM_FX", cfg.DatasetCode)
+	assert.Equal(t, 12*time.Hour, cfg.Interval)
+	assert.Equal(t, 45*time.Second, cfg.Timeout)
+	assert.Equal(t, 5, cfg.MaxRetries)
+}
+
+func TestLoadECBConfig_InvalidValues_UsesDefaults(t *testing.T) {
+	// Set invalid values - should fall back to defaults
+	t.Setenv("ECB_ENABLED", "invalid")
+	t.Setenv("ECB_INTERVAL", "invalid-duration")
+	t.Setenv("ECB_TIMEOUT", "not-a-duration")
+	t.Setenv("ECB_MAX_RETRIES", "not-a-number")
+
+	cfg := LoadECBConfig()
+
+	defaults := DefaultECBConfig()
+	assert.Equal(t, defaults.Enabled, cfg.Enabled)
+	assert.Equal(t, defaults.Interval, cfg.Interval)
+	assert.Equal(t, defaults.Timeout, cfg.Timeout)
+	assert.Equal(t, defaults.MaxRetries, cfg.MaxRetries)
+}
+
+func TestLoadConfig(t *testing.T) {
+	// Clear environment
+	os.Unsetenv("ECB_ENABLED")
+
+	cfg := LoadConfig()
+
+	// Verify ECB config is loaded
+	assert.False(t, cfg.ECB.Enabled)
+	assert.Equal(t, "ECB", cfg.ECB.SourceCode)
+}


### PR DESCRIPTION
## Summary

Implements the first production market data feed adapter for the Market Information service - European Central Bank daily FX rates.

- **HTTP Client**: Fetches daily FX rates from ECB's SDMX Web Service CSV endpoint
- **CSV Parser**: Parses ECB rate format and transforms to MarketPriceObservation protobufs  
- **Scheduled Worker**: Background ingestion with configurable interval (default 24h, aligned with ECB's 16:00 CET update schedule)
- **Retry Logic**: Exponential backoff for transient failures (1s, 2s, 4s...)
- **Configuration**: Environment-based config (ECB_ENABLED, ECB_INTERVAL, etc.)

### Task Master Reference
market-information-management.12

### Key Implementation Details

The adapter validates the end-to-end ingestion pipeline:
```
HTTP fetch → CSV parse → Protobuf transform → gRPC RecordObservation
```

**Files Added:**
- `services/market-information/adapters/external/ecb/ecb_client.go` - HTTP client
- `services/market-information/adapters/external/ecb/ecb_parser.go` - CSV parser + transformer
- `services/market-information/adapters/external/ecb/ecb_worker.go` - Background worker
- `services/market-information/config/config.go` - Service configuration

**Files Modified:**
- `services/market-information/cmd/main.go` - Bootstrap integration (TODO: wire up when server ready)

## Test plan

- [x] Unit tests for HTTP client (httptest mock server)
- [x] Unit tests for CSV parser with real ECB CSV format
- [x] Unit tests for worker lifecycle, retry logic, graceful shutdown
- [x] All 54 tests passing, linter clean
- [ ] Integration test with testcontainers (future PR)