### PR TITLE
fix: Correct Claude review workflow triggers and concurrency

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,13 +2,13 @@ name: Claude Code Review
 
 on:
   workflow_run:
-    workflows: ["Test", "Build", "Quality"]
+    workflows: ["Test", "Build & Test", "Code Quality"]
     types: [completed]
 
-# Prevent concurrent Claude Code installations which cause lock conflicts
-# Only one Claude review can run at a time per repo
+# Prevent duplicate reviews for the same PR branch
+# Uses branch name so different PRs can be reviewed in parallel
 concurrency:
-  group: claude-code-review-${{ github.repository }}
+  group: claude-code-review-${{ github.repository }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
## Summary

PR #619 did not receive a Claude review due to two issues in the workflow configuration.

## Root Cause Analysis

**Issue 1: Mismatched workflow names**

The trigger was configured for workflows that don't exist:
```yaml
workflows: ["Test", "Build", "Quality"]  # ❌ "Build" and "Quality" don't exist
```

Actual workflow names:
- `Test` ✓
- `Build & Test` (not "Build")
- `Code Quality` (not "Quality")

**Issue 2: Repo-wide concurrency causing PR interference**

```yaml
concurrency:
  group: claude-code-review-${{ github.repository }}  # Same group for ALL PRs
```

When multiple PRs' workflows complete near-simultaneously:
1. Multiple `workflow_run` events fire
2. All target the same concurrency group
3. GitHub deduplicates, causing some PRs to miss reviews

Timeline for PR #619:
| Time | Event |
|------|-------|
| 10:17:48Z | PR #618's Test started |
| 10:19:34Z | PR #619's Test started |
| ~10:25Z | Both completed |
| 10:30:25Z | Claude Review ran → found PR #618 only |

## Changes

1. **Fixed workflow names**: `["Test", "Build & Test", "Code Quality"]`
2. **Branch-specific concurrency**: `claude-code-review-${{ github.repository }}-${{ github.event.workflow_run.head_branch }}`

This ensures:
- Each PR gets its own review
- Multiple triggers for the SAME PR still deduplicate (preventing duplicate reviews)

## Test Plan

- [ ] Merge this PR
- [ ] Push a change to PR #619 to trigger new workflow runs
- [ ] Verify Claude review appears on PR #619