### PR TITLE
Wire ECB adapter into multi-tenant market data architecture

### DIFF
--- a/services/market-information/adapters/persistence/dataset_repository.go
+++ b/services/market-information/adapters/persistence/dataset_repository.go
@@ -215,7 +215,7 @@ func (r *DataSetRepository) List(ctx context.Context, filters domain.DataSetFilt
 		query := `
 			SELECT id, code, version, name, description, data_category,
 				validation_expression, resolution_key_expression, error_message_expression,
-				status, created_at, updated_at, activated_at, deprecated_at
+				status, is_shared, access_level, created_at, updated_at, activated_at, deprecated_at
 			FROM dataset_definition
 			WHERE deleted_at IS NULL`
 

--- a/services/market-information/adapters/persistence/dataset_repository.go
+++ b/services/market-information/adapters/persistence/dataset_repository.go
@@ -54,13 +54,13 @@ func (r *DataSetRepository) insertDataSet(ctx context.Context, tx pgx.Tx, entity
 		INSERT INTO dataset_definition (
 			id, code, version, name, description, data_category,
 			validation_expression, resolution_key_expression, error_message_expression,
-			status, created_at, created_by, updated_at, updated_by,
+			status, is_shared, access_level, created_at, created_by, updated_at, updated_by,
 			activated_at, deprecated_at
 		) VALUES (
 			$1, $2, $3, $4, $5, $6,
 			$7, $8, $9,
-			$10, $11, $12, $13, $14,
-			$15, $16
+			$10, $11, $12, $13, $14, $15, $16,
+			$17, $18
 		)`
 
 	_, err := tx.Exec(ctx, query,
@@ -74,6 +74,8 @@ func (r *DataSetRepository) insertDataSet(ctx context.Context, tx pgx.Tx, entity
 		entity.ResolutionKeyExpression,
 		nullStringPtr(entity.ErrorMessageExpression),
 		entity.Status,
+		entity.IsShared,
+		entity.AccessLevel,
 		entity.CreatedAt,
 		userID,
 		entity.UpdatedAt,
@@ -110,12 +112,14 @@ func (r *DataSetRepository) updateDataSet(ctx context.Context, tx pgx.Tx, entity
 			resolution_key_expression = $5,
 			error_message_expression = $6,
 			status = $7,
-			version = $8,
-			updated_at = $9,
-			updated_by = $10,
-			activated_at = $11,
-			deprecated_at = $12
-		WHERE id = $13 AND version = $14 AND deleted_at IS NULL`
+			is_shared = $8,
+			access_level = $9,
+			version = $10,
+			updated_at = $11,
+			updated_by = $12,
+			activated_at = $13,
+			deprecated_at = $14
+		WHERE id = $15 AND version = $16 AND deleted_at IS NULL`
 
 	result, err := tx.Exec(ctx, query,
 		entity.Name,
@@ -125,6 +129,8 @@ func (r *DataSetRepository) updateDataSet(ctx context.Context, tx pgx.Tx, entity
 		entity.ResolutionKeyExpression,
 		nullStringPtr(entity.ErrorMessageExpression),
 		entity.Status,
+		entity.IsShared,
+		entity.AccessLevel,
 		entity.Version,
 		entity.UpdatedAt,
 		userID,
@@ -155,7 +161,7 @@ func (r *DataSetRepository) FindByCode(ctx context.Context, code string) (domain
 		query := `
 			SELECT id, code, version, name, description, data_category,
 				validation_expression, resolution_key_expression, error_message_expression,
-				status, created_at, updated_at, activated_at, deprecated_at
+				status, is_shared, access_level, created_at, updated_at, activated_at, deprecated_at
 			FROM dataset_definition
 			WHERE code = $1 AND deleted_at IS NULL
 			ORDER BY
@@ -184,7 +190,7 @@ func (r *DataSetRepository) FindByCodeAndVersion(ctx context.Context, code strin
 		query := `
 			SELECT id, code, version, name, description, data_category,
 				validation_expression, resolution_key_expression, error_message_expression,
-				status, created_at, updated_at, activated_at, deprecated_at
+				status, is_shared, access_level, created_at, updated_at, activated_at, deprecated_at
 			FROM dataset_definition
 			WHERE code = $1 AND version = $2 AND deleted_at IS NULL`
 
@@ -301,6 +307,8 @@ func (r *DataSetRepository) scanDataSetDefinition(ctx context.Context, tx pgx.Tx
 		&entity.ResolutionKeyExpression,
 		&entity.ErrorMessageExpression,
 		&entity.Status,
+		&entity.IsShared,
+		&entity.AccessLevel,
 		&entity.CreatedAt,
 		&entity.UpdatedAt,
 		&entity.ActivatedAt,
@@ -331,6 +339,8 @@ func (r *DataSetRepository) scanDataSetDefinitionFromRows(rows pgx.Rows) (DataSe
 		&entity.ResolutionKeyExpression,
 		&entity.ErrorMessageExpression,
 		&entity.Status,
+		&entity.IsShared,
+		&entity.AccessLevel,
 		&entity.CreatedAt,
 		&entity.UpdatedAt,
 		&entity.ActivatedAt,

--- a/services/market-information/adapters/persistence/entities.go
+++ b/services/market-information/adapters/persistence/entities.go
@@ -21,6 +21,8 @@ type DataSetDefinitionEntity struct {
 	ResolutionKeyExpression string
 	ErrorMessageExpression  sql.NullString
 	Status                  string
+	IsShared                bool
+	AccessLevel             string
 	CreatedAt               time.Time
 	UpdatedAt               time.Time
 	ActivatedAt             sql.NullTime

--- a/services/market-information/adapters/persistence/mappers.go
+++ b/services/market-information/adapters/persistence/mappers.go
@@ -56,7 +56,7 @@ func EntityToDataSetDefinition(e DataSetDefinitionEntity) domain.DataSetDefiniti
 		WithResolutionKeyExpression(e.ResolutionKeyExpression).
 		WithStatus(parseDataSetStatus(e.Status)).
 		WithIsShared(e.IsShared).
-		WithAccessLevel(domain.DataAccessLevel(e.AccessLevel)).
+		WithAccessLevel(parseAccessLevel(e.AccessLevel)).
 		WithCreatedAt(e.CreatedAt).
 		WithUpdatedAt(e.UpdatedAt)
 
@@ -96,6 +96,16 @@ func parseDataSetStatus(s string) domain.DataSetStatus {
 	default:
 		return domain.DataSetStatusDraft
 	}
+}
+
+// parseAccessLevel converts a string to domain.DataAccessLevel with validation.
+// Returns AccessLevelPrivate (the safest default) if the value is invalid.
+func parseAccessLevel(s string) domain.DataAccessLevel {
+	level := domain.DataAccessLevel(s)
+	if !level.IsValid() {
+		return domain.AccessLevelPrivate
+	}
+	return level
 }
 
 // DataSourceToEntity converts a domain DataSource to a database entity.

--- a/services/market-information/adapters/persistence/mappers.go
+++ b/services/market-information/adapters/persistence/mappers.go
@@ -18,6 +18,8 @@ func DataSetDefinitionToEntity(d domain.DataSetDefinition) DataSetDefinitionEnti
 		Name:                    d.Name(),
 		ResolutionKeyExpression: d.ResolutionKeyExpression(),
 		Status:                  d.Status().String(),
+		IsShared:                d.IsShared(),
+		AccessLevel:             d.AccessLevel().String(),
 		CreatedAt:               d.CreatedAt(),
 		UpdatedAt:               d.UpdatedAt(),
 	}
@@ -53,6 +55,8 @@ func EntityToDataSetDefinition(e DataSetDefinitionEntity) domain.DataSetDefiniti
 		WithName(e.Name).
 		WithResolutionKeyExpression(e.ResolutionKeyExpression).
 		WithStatus(parseDataSetStatus(e.Status)).
+		WithIsShared(e.IsShared).
+		WithAccessLevel(domain.DataAccessLevel(e.AccessLevel)).
 		WithCreatedAt(e.CreatedAt).
 		WithUpdatedAt(e.UpdatedAt)
 

--- a/services/market-information/adapters/persistence/observation_repository.go
+++ b/services/market-information/adapters/persistence/observation_repository.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meridianhub/meridian/services/market-information/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/shopspring/decimal"
 )
 
@@ -19,12 +20,16 @@ import (
 // Supports bi-temporal queries with quality ladder resolution.
 type ObservationRepository struct {
 	baseRepository
+	datasetRepo    *DataSetRepository
+	masterTenantID string
 }
 
 // NewObservationRepository creates a new PostgreSQL observation repository.
-func NewObservationRepository(pool *pgxpool.Pool) *ObservationRepository {
+func NewObservationRepository(pool *pgxpool.Pool, datasetRepo *DataSetRepository, masterTenantID string) *ObservationRepository {
 	return &ObservationRepository{
 		baseRepository: newBaseRepository(pool),
+		datasetRepo:    datasetRepo,
+		masterTenantID: masterTenantID,
 	}
 }
 
@@ -237,45 +242,11 @@ func (r *ObservationRepository) Query(ctx context.Context, query domain.Observat
 // GetLatest retrieves the most recent non-superseded observation
 // for a specific dataset and resolution key combination.
 // Uses the quality ladder for precedence: VERIFIED > ACTUAL > ESTIMATE.
+// For shared datasets, implements hierarchical lookup: tenant-first, then master fallback.
 // Returns ErrObservationNotFound if no matching observation exists.
 func (r *ObservationRepository) GetLatest(ctx context.Context, dataSetCode string, resolutionKey string) (domain.MarketPriceObservation, error) {
-	var result domain.MarketPriceObservation
-
-	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
-		// First, resolve dataset definition ID from code
-		dataSetDefID, err := r.resolveDataSetDefinitionID(ctx, tx, dataSetCode)
-		if err != nil {
-			return err
-		}
-
-		// Use the bi-temporal index for efficient query
-		// Order by quality DESC (VERIFIED > ACTUAL > ESTIMATE), then observed_at DESC, then trust_level DESC
-		query := `
-			SELECT o.id, o.dataset_definition_id, o.data_source_id, o.resolution_key,
-				o.observed_at, o.valid_from, o.valid_to, o.created_at,
-				o.quality, o.numeric_value, o.text_value,
-				o.superseded_by, o.causation_id,
-				d.code as dataset_code,
-				s.trust_level
-			FROM market_price_observation o
-			JOIN dataset_definition d ON o.dataset_definition_id = d.id
-			JOIN data_source s ON o.data_source_id = s.id
-			WHERE o.dataset_definition_id = $1
-				AND o.resolution_key = $2
-				AND o.superseded_by IS NULL
-			ORDER BY o.quality DESC, o.observed_at DESC, s.trust_level DESC, o.created_at DESC
-			LIMIT 1`
-
-		obs, err := r.scanObservation(ctx, tx, query, dataSetDefID, resolutionKey)
-		if err != nil {
-			return err
-		}
-
-		result = obs
-		return nil
-	})
-
-	return result, err
+	// Delegate to RetrieveObservation with zero time (current knowledge)
+	return r.RetrieveObservation(ctx, dataSetCode, resolutionKey, time.Time{})
 }
 
 // RetrieveObservation retrieves the best observation for a resolution key at a specific knowledge time.
@@ -283,15 +254,74 @@ func (r *ObservationRepository) GetLatest(ctx context.Context, dataSetCode strin
 // Uses the quality ladder with trust level tiebreaker:
 // ORDER BY quality DESC, observed_at DESC, trust_level DESC, created_at DESC
 //
+// For shared datasets, implements hierarchical lookup:
+// 1. Query tenant-specific schema first
+// 2. If shared dataset and not found, fall through to master tenant schema
+// 3. For RESTRICTED datasets, verify tenant has active entitlements
+//
 // Parameters:
 //   - dataSetCode: The dataset code to query
 //   - resolutionKey: The unique resolution key (e.g., "EUR/USD")
 //   - knowledgeBaseTime: The point in time to query "what was known". Use time.Time{} for current knowledge.
 func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSetCode string, resolutionKey string, knowledgeBaseTime time.Time) (domain.MarketPriceObservation, error) {
+	// If knowledgeBaseTime is zero, use current time
+	kbt := knowledgeBaseTime
+	if kbt.IsZero() {
+		kbt = time.Now()
+	}
+
+	// Step 1: Check if dataset is shared (determines whether fallback is allowed)
+	dataset, err := r.datasetRepo.FindByCode(ctx, dataSetCode)
+	if err != nil {
+		return domain.MarketPriceObservation{}, err
+	}
+
+	// Step 2: Query tenant-specific schema first
+	tenantID, hasTenantContext := tenant.FromContext(ctx)
+	if hasTenantContext {
+		obs, err := r.queryObservationInSchema(ctx, dataSetCode, resolutionKey, kbt)
+		if err == nil {
+			return obs, nil // Found in tenant schema
+		}
+		if !errors.Is(err, domain.ErrObservationNotFound) {
+			return domain.MarketPriceObservation{}, err // Real error
+		}
+		// Not found in tenant schema - proceed to fallback check
+	}
+
+	// Step 3: If shared dataset and not found in tenant schema, try master fallback
+	if dataset.IsShared() {
+		// Verify tenant has access rights for RESTRICTED datasets
+		if hasTenantContext && dataset.AccessLevel() == domain.AccessLevelRestricted {
+			hasAccess, err := r.checkTenantAccess(ctx, tenantID, dataSetCode)
+			if err != nil {
+				return domain.MarketPriceObservation{}, err
+			}
+			if !hasAccess {
+				return domain.MarketPriceObservation{}, domain.ErrAccessDenied
+			}
+		}
+
+		// Fall through to master tenant schema
+		masterTenantID, err := tenant.NewTenantID(r.masterTenantID)
+		if err != nil {
+			return domain.MarketPriceObservation{}, fmt.Errorf("invalid master tenant ID: %w", err)
+		}
+		masterCtx := tenant.WithTenant(ctx, masterTenantID)
+		return r.queryObservationInSchema(masterCtx, dataSetCode, resolutionKey, kbt)
+	}
+
+	// Not shared, not found in tenant schema
+	return domain.MarketPriceObservation{}, domain.ErrObservationNotFound
+}
+
+// queryObservationInSchema performs the actual database query in the current tenant scope.
+// This method respects the search_path set by baseRepository's transaction wrapper.
+func (r *ObservationRepository) queryObservationInSchema(ctx context.Context, dataSetCode string, resolutionKey string, knowledgeBaseTime time.Time) (domain.MarketPriceObservation, error) {
 	var result domain.MarketPriceObservation
 
 	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
-		// First, resolve dataset definition ID from code
+		// Resolve dataset definition ID from code
 		dataSetDefID, err := r.resolveDataSetDefinitionID(ctx, tx, dataSetCode)
 		if err != nil {
 			return err
@@ -316,13 +346,7 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 			ORDER BY o.quality DESC, o.observed_at DESC, s.trust_level DESC, o.created_at DESC
 			LIMIT 1`
 
-		// If knowledgeBaseTime is zero, use current time
-		kbt := knowledgeBaseTime
-		if kbt.IsZero() {
-			kbt = time.Now()
-		}
-
-		obs, err := r.scanObservation(ctx, tx, query, dataSetDefID, resolutionKey, kbt)
+		obs, err := r.scanObservation(ctx, tx, query, dataSetDefID, resolutionKey, knowledgeBaseTime)
 		if err != nil {
 			return err
 		}
@@ -332,6 +356,25 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 	})
 
 	return result, err
+}
+
+// checkTenantAccess verifies tenant has rights to access shared dataset.
+// Queries the tenant_data_entitlements table to check for active entitlements.
+func (r *ObservationRepository) checkTenantAccess(ctx context.Context, tenantID tenant.TenantID, dataSetCode string) (bool, error) {
+	query := `
+		SELECT EXISTS(
+			SELECT 1 FROM tenant_data_entitlements
+			WHERE tenant_id = $1 AND dataset_code = $2 AND is_active = TRUE
+			AND (expires_at IS NULL OR expires_at > NOW())
+		)`
+
+	var hasAccess bool
+	err := r.pool.QueryRow(ctx, query, tenantID.String(), dataSetCode).Scan(&hasAccess)
+	if err != nil {
+		return false, fmt.Errorf("failed to check tenant access: %w", err)
+	}
+
+	return hasAccess, nil
 }
 
 // resolveDataSetDefinitionID looks up the dataset definition ID from code.

--- a/services/market-information/adapters/persistence/observation_repository.go
+++ b/services/market-information/adapters/persistence/observation_repository.go
@@ -276,8 +276,20 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 		return domain.MarketPriceObservation{}, err
 	}
 
-	// Step 2: Query current schema first (tenant-specific or default/public)
+	// Step 2: For RESTRICTED datasets with tenant context, verify entitlements upfront
+	// This check applies regardless of where the data is stored (tenant or master schema)
 	tenantID, hasTenantContext := tenant.FromContext(ctx)
+	if dataset.AccessLevel() == domain.AccessLevelRestricted && hasTenantContext {
+		hasAccess, err := r.checkTenantAccess(ctx, tenantID, dataSetCode)
+		if err != nil {
+			return domain.MarketPriceObservation{}, err
+		}
+		if !hasAccess {
+			return domain.MarketPriceObservation{}, domain.ErrAccessDenied
+		}
+	}
+
+	// Step 3: Query current schema first (tenant-specific or default/public)
 	obs, err := r.queryObservationInSchema(ctx, dataSetCode, resolutionKey, kbt)
 	if err == nil {
 		return obs, nil // Found in current schema
@@ -287,19 +299,8 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 	}
 	// Not found in current schema - proceed to hierarchical fallback if applicable
 
-	// Step 3: If shared dataset and not found in tenant schema, try master fallback
+	// Step 4: If shared dataset and not found in tenant schema, try master fallback
 	if dataset.IsShared() && hasTenantContext {
-		// Verify tenant has access rights for RESTRICTED datasets
-		if dataset.AccessLevel() == domain.AccessLevelRestricted {
-			hasAccess, err := r.checkTenantAccess(ctx, tenantID, dataSetCode)
-			if err != nil {
-				return domain.MarketPriceObservation{}, err
-			}
-			if !hasAccess {
-				return domain.MarketPriceObservation{}, domain.ErrAccessDenied
-			}
-		}
-
 		// Fall through to master tenant schema
 		masterTenantID, err := tenant.NewTenantID(r.masterTenantID)
 		if err != nil {

--- a/services/market-information/adapters/persistence/observation_repository.go
+++ b/services/market-information/adapters/persistence/observation_repository.go
@@ -21,15 +21,21 @@ import (
 type ObservationRepository struct {
 	baseRepository
 	datasetRepo    *DataSetRepository
-	masterTenantID string
+	masterTenantID tenant.TenantID // Pre-parsed at construction for efficiency
 }
 
 // NewObservationRepository creates a new PostgreSQL observation repository.
+// The masterTenantID is parsed once at construction to avoid repeated parsing on every query.
+// Panics if masterTenantID is invalid - this should be caught at startup.
 func NewObservationRepository(pool *pgxpool.Pool, datasetRepo *DataSetRepository, masterTenantID string) *ObservationRepository {
+	parsedID, err := tenant.NewTenantID(masterTenantID)
+	if err != nil {
+		panic(fmt.Sprintf("invalid masterTenantID %q: %v", masterTenantID, err))
+	}
 	return &ObservationRepository{
 		baseRepository: newBaseRepository(pool),
 		datasetRepo:    datasetRepo,
-		masterTenantID: masterTenantID,
+		masterTenantID: parsedID,
 	}
 }
 
@@ -270,24 +276,17 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 		kbt = time.Now()
 	}
 
-	// Parse master tenant ID once upfront - this is reused for both config lookup and data fallback.
-	// The validation in NewRepositories ensures this won't be empty, but we handle errors defensively.
-	masterTenantIDParsed, err := tenant.NewTenantID(r.masterTenantID)
-	if err != nil {
-		return domain.MarketPriceObservation{}, fmt.Errorf("invalid master tenant ID: %w", err)
-	}
-
 	// Step 1: Check if dataset is shared (determines whether fallback is allowed)
 	// IMPORTANT: Dataset metadata lookups must use master tenant context, not the tenant-scoped context.
-	// The dataset_definition table structure (is_shared, access_level) is configuration data that exists
-	// in the master schema, not duplicated per tenant. Using tenant context here would fail for tenants
-	// without dataset_definition in their schema.
+	// The dataset_definition table (is_shared, access_level) is the authoritative source of truth
+	// for sharing configuration and lives in the master schema. Even though test helpers may copy
+	// dataset definitions to tenant schemas, the master schema is canonical for configuration decisions.
 	//
 	// There is a benign race condition here: if dataset config is updated between this check and the
 	// actual observation query, we may use stale is_shared/access_level values. This is acceptable
 	// because dataset config changes are rare and eventual consistency is sufficient.
 	tenantID, hasTenantContext := tenant.FromContext(ctx)
-	masterCtx := tenant.WithTenant(ctx, masterTenantIDParsed)
+	masterCtx := tenant.WithTenant(ctx, r.masterTenantID)
 	dataset, err := r.datasetRepo.FindByCode(masterCtx, dataSetCode)
 	if err != nil {
 		return domain.MarketPriceObservation{}, err
@@ -297,6 +296,11 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 	// This check applies regardless of where the data is stored (tenant or master schema).
 	// For RESTRICTED datasets, access is only granted if the tenant has an active entitlement.
 	// PUBLIC datasets skip this check entirely. PRIVATE datasets are tenant-isolated by schema.
+	//
+	// Security note: When no tenant context exists (system/background jobs), RESTRICTED datasets
+	// are accessible without entitlement checks. This is intentional - system processes need
+	// full data access for operations like ingestion, reconciliation, and reporting. Tenant context
+	// should always be set for user-facing API requests to enforce proper access control.
 	if dataset.AccessLevel() == domain.AccessLevelRestricted && hasTenantContext {
 		hasAccess, err := r.checkTenantAccess(ctx, tenantID, dataSetCode)
 		if err != nil {
@@ -324,7 +328,7 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 	// When no tenant context exists (e.g., background jobs, system queries), we're already
 	// querying the default schema (likely master), so no fallback is needed.
 	if dataset.IsShared() && hasTenantContext {
-		// Fall through to master tenant schema (reusing the already-parsed masterTenantIDParsed)
+		// Fall through to master tenant schema (masterCtx was created with r.masterTenantID above)
 		return r.queryObservationInSchema(masterCtx, dataSetCode, resolutionKey, kbt)
 	}
 

--- a/services/market-information/adapters/persistence/observation_repository.go
+++ b/services/market-information/adapters/persistence/observation_repository.go
@@ -271,14 +271,32 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 	}
 
 	// Step 1: Check if dataset is shared (determines whether fallback is allowed)
-	dataset, err := r.datasetRepo.FindByCode(ctx, dataSetCode)
+	// IMPORTANT: Dataset metadata lookups must use master tenant context, not the tenant-scoped context.
+	// The dataset_definition table structure (is_shared, access_level) is configuration data that exists
+	// in the master schema, not duplicated per tenant. Using tenant context here would fail for tenants
+	// without dataset_definition in their schema.
+	//
+	// There is a benign race condition here: if dataset config is updated between this check and the
+	// actual observation query, we may use stale is_shared/access_level values. This is acceptable
+	// because dataset config changes are rare and eventual consistency is sufficient.
+	tenantID, hasTenantContext := tenant.FromContext(ctx)
+	masterCtxForConfig := ctx
+	if hasTenantContext {
+		masterTenantID, err := tenant.NewTenantID(r.masterTenantID)
+		if err != nil {
+			return domain.MarketPriceObservation{}, fmt.Errorf("invalid master tenant ID: %w", err)
+		}
+		masterCtxForConfig = tenant.WithTenant(ctx, masterTenantID)
+	}
+	dataset, err := r.datasetRepo.FindByCode(masterCtxForConfig, dataSetCode)
 	if err != nil {
 		return domain.MarketPriceObservation{}, err
 	}
 
-	// Step 2: For RESTRICTED datasets with tenant context, verify entitlements upfront
-	// This check applies regardless of where the data is stored (tenant or master schema)
-	tenantID, hasTenantContext := tenant.FromContext(ctx)
+	// Step 2: For RESTRICTED datasets with tenant context, verify entitlements upfront.
+	// This check applies regardless of where the data is stored (tenant or master schema).
+	// For RESTRICTED datasets, access is only granted if the tenant has an active entitlement.
+	// PUBLIC datasets skip this check entirely. PRIVATE datasets are tenant-isolated by schema.
 	if dataset.AccessLevel() == domain.AccessLevelRestricted && hasTenantContext {
 		hasAccess, err := r.checkTenantAccess(ctx, tenantID, dataSetCode)
 		if err != nil {
@@ -299,18 +317,20 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 	}
 	// Not found in current schema - proceed to hierarchical fallback if applicable
 
-	// Step 4: If shared dataset and not found in tenant schema, try master fallback
+	// Step 4: If shared dataset and not found in tenant schema, try master fallback.
+	// When no tenant context exists (e.g., background jobs, system queries), we're already
+	// querying the default schema (likely master), so no fallback is needed.
 	if dataset.IsShared() && hasTenantContext {
 		// Fall through to master tenant schema
-		masterTenantID, err := tenant.NewTenantID(r.masterTenantID)
+		masterTenantIDForData, err := tenant.NewTenantID(r.masterTenantID)
 		if err != nil {
 			return domain.MarketPriceObservation{}, fmt.Errorf("invalid master tenant ID: %w", err)
 		}
-		masterCtx := tenant.WithTenant(ctx, masterTenantID)
+		masterCtx := tenant.WithTenant(ctx, masterTenantIDForData)
 		return r.queryObservationInSchema(masterCtx, dataSetCode, resolutionKey, kbt)
 	}
 
-	// Not found (either not shared, or already queried master fallback)
+	// Not found (either not shared, or already queried master fallback, or no tenant context)
 	return domain.MarketPriceObservation{}, domain.ErrObservationNotFound
 }
 
@@ -359,10 +379,13 @@ func (r *ObservationRepository) queryObservationInSchema(ctx context.Context, da
 
 // checkTenantAccess verifies tenant has rights to access shared dataset.
 // Queries the tenant_data_entitlements table to check for active entitlements.
+// IMPORTANT: This query intentionally uses the public schema (not tenant-scoped).
+// The tenant_data_entitlements table is a global registry that lives in the public schema,
+// not replicated per tenant. Using pool.QueryRow directly ensures we query public.tenant_data_entitlements.
 func (r *ObservationRepository) checkTenantAccess(ctx context.Context, tenantID tenant.TenantID, dataSetCode string) (bool, error) {
 	query := `
 		SELECT EXISTS(
-			SELECT 1 FROM tenant_data_entitlements
+			SELECT 1 FROM public.tenant_data_entitlements
 			WHERE tenant_id = $1 AND dataset_code = $2 AND is_active = TRUE
 			AND (expires_at IS NULL OR expires_at > NOW())
 		)`

--- a/services/market-information/adapters/persistence/observation_repository.go
+++ b/services/market-information/adapters/persistence/observation_repository.go
@@ -377,9 +377,14 @@ func (r *ObservationRepository) queryObservationInSchema(ctx context.Context, da
 
 // checkTenantAccess verifies tenant has rights to access shared dataset.
 // Queries the tenant_data_entitlements table to check for active entitlements.
+//
 // IMPORTANT: This query intentionally uses the public schema (not tenant-scoped).
 // The tenant_data_entitlements table is a global registry that lives in the public schema,
 // not replicated per tenant. Using pool.QueryRow directly ensures we query public.tenant_data_entitlements.
+//
+// Note: This check runs outside the observation query transaction. There's a small TOCTOU window
+// where entitlement could be revoked between this check and data access. This is acceptable
+// because entitlement revocations are rare and eventual consistency is sufficient for this use case.
 func (r *ObservationRepository) checkTenantAccess(ctx context.Context, tenantID tenant.TenantID, dataSetCode string) (bool, error) {
 	query := `
 		SELECT EXISTS(

--- a/services/market-information/adapters/persistence/observation_repository.go
+++ b/services/market-information/adapters/persistence/observation_repository.go
@@ -276,23 +276,21 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 		return domain.MarketPriceObservation{}, err
 	}
 
-	// Step 2: Query tenant-specific schema first
+	// Step 2: Query current schema first (tenant-specific or default/public)
 	tenantID, hasTenantContext := tenant.FromContext(ctx)
-	if hasTenantContext {
-		obs, err := r.queryObservationInSchema(ctx, dataSetCode, resolutionKey, kbt)
-		if err == nil {
-			return obs, nil // Found in tenant schema
-		}
-		if !errors.Is(err, domain.ErrObservationNotFound) {
-			return domain.MarketPriceObservation{}, err // Real error
-		}
-		// Not found in tenant schema - proceed to fallback check
+	obs, err := r.queryObservationInSchema(ctx, dataSetCode, resolutionKey, kbt)
+	if err == nil {
+		return obs, nil // Found in current schema
 	}
+	if !errors.Is(err, domain.ErrObservationNotFound) {
+		return domain.MarketPriceObservation{}, err // Real error
+	}
+	// Not found in current schema - proceed to hierarchical fallback if applicable
 
 	// Step 3: If shared dataset and not found in tenant schema, try master fallback
-	if dataset.IsShared() {
+	if dataset.IsShared() && hasTenantContext {
 		// Verify tenant has access rights for RESTRICTED datasets
-		if hasTenantContext && dataset.AccessLevel() == domain.AccessLevelRestricted {
+		if dataset.AccessLevel() == domain.AccessLevelRestricted {
 			hasAccess, err := r.checkTenantAccess(ctx, tenantID, dataSetCode)
 			if err != nil {
 				return domain.MarketPriceObservation{}, err
@@ -311,7 +309,7 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 		return r.queryObservationInSchema(masterCtx, dataSetCode, resolutionKey, kbt)
 	}
 
-	// Not shared, not found in tenant schema
+	// Not found (either not shared, or already queried master fallback)
 	return domain.MarketPriceObservation{}, domain.ErrObservationNotFound
 }
 

--- a/services/market-information/adapters/persistence/observation_repository.go
+++ b/services/market-information/adapters/persistence/observation_repository.go
@@ -270,6 +270,13 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 		kbt = time.Now()
 	}
 
+	// Parse master tenant ID once upfront - this is reused for both config lookup and data fallback.
+	// The validation in NewRepositories ensures this won't be empty, but we handle errors defensively.
+	masterTenantIDParsed, err := tenant.NewTenantID(r.masterTenantID)
+	if err != nil {
+		return domain.MarketPriceObservation{}, fmt.Errorf("invalid master tenant ID: %w", err)
+	}
+
 	// Step 1: Check if dataset is shared (determines whether fallback is allowed)
 	// IMPORTANT: Dataset metadata lookups must use master tenant context, not the tenant-scoped context.
 	// The dataset_definition table structure (is_shared, access_level) is configuration data that exists
@@ -280,15 +287,8 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 	// actual observation query, we may use stale is_shared/access_level values. This is acceptable
 	// because dataset config changes are rare and eventual consistency is sufficient.
 	tenantID, hasTenantContext := tenant.FromContext(ctx)
-	masterCtxForConfig := ctx
-	if hasTenantContext {
-		masterTenantID, err := tenant.NewTenantID(r.masterTenantID)
-		if err != nil {
-			return domain.MarketPriceObservation{}, fmt.Errorf("invalid master tenant ID: %w", err)
-		}
-		masterCtxForConfig = tenant.WithTenant(ctx, masterTenantID)
-	}
-	dataset, err := r.datasetRepo.FindByCode(masterCtxForConfig, dataSetCode)
+	masterCtx := tenant.WithTenant(ctx, masterTenantIDParsed)
+	dataset, err := r.datasetRepo.FindByCode(masterCtx, dataSetCode)
 	if err != nil {
 		return domain.MarketPriceObservation{}, err
 	}
@@ -312,8 +312,11 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 	if err == nil {
 		return obs, nil // Found in current schema
 	}
+	// Non-NotFound errors indicate real database issues (connection, permissions, etc.).
+	// We intentionally do NOT fall back to master for real errors - this prevents masking
+	// underlying issues that should be surfaced and investigated.
 	if !errors.Is(err, domain.ErrObservationNotFound) {
-		return domain.MarketPriceObservation{}, err // Real error
+		return domain.MarketPriceObservation{}, err
 	}
 	// Not found in current schema - proceed to hierarchical fallback if applicable
 
@@ -321,12 +324,7 @@ func (r *ObservationRepository) RetrieveObservation(ctx context.Context, dataSet
 	// When no tenant context exists (e.g., background jobs, system queries), we're already
 	// querying the default schema (likely master), so no fallback is needed.
 	if dataset.IsShared() && hasTenantContext {
-		// Fall through to master tenant schema
-		masterTenantIDForData, err := tenant.NewTenantID(r.masterTenantID)
-		if err != nil {
-			return domain.MarketPriceObservation{}, fmt.Errorf("invalid master tenant ID: %w", err)
-		}
-		masterCtx := tenant.WithTenant(ctx, masterTenantIDForData)
+		// Fall through to master tenant schema (reusing the already-parsed masterTenantIDParsed)
 		return r.queryObservationInSchema(masterCtx, dataSetCode, resolutionKey, kbt)
 	}
 

--- a/services/market-information/adapters/persistence/observation_repository_test.go
+++ b/services/market-information/adapters/persistence/observation_repository_test.go
@@ -521,3 +521,433 @@ func TestObservationRepository_Record_InvalidDataSetCode(t *testing.T) {
 	err = tc.Repos.Observation.Record(ctx, obs)
 	assert.ErrorIs(t, err, domain.ErrDataSetNotFound)
 }
+
+// setupSharedDataSetAndSource creates a shared dataset with specified access level.
+func setupSharedDataSetAndSource(t *testing.T, tc *testhelpers.TestContainer, code string, accessLevel domain.DataAccessLevel) (domain.DataSetDefinition, domain.DataSource) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Create and activate a shared dataset
+	dataset, err := domain.NewDataSetDefinition(
+		code,
+		"Shared "+code,
+		"Shared test dataset for multi-tenant observations",
+		domain.DataCategoryPricing,
+		"value > 0",
+		"observation_context.key",
+		"",
+	)
+	require.NoError(t, err)
+
+	// Build with shared flags - copy all fields manually
+	builder := domain.NewDataSetDefinitionBuilder().
+		WithID(dataset.ID()).
+		WithCode(dataset.Code()).
+		WithVersion(dataset.Version()).
+		WithName(dataset.Name()).
+		WithDescription(dataset.Description()).
+		WithDataCategory(dataset.DataCategory()).
+		WithValidationExpression(dataset.ValidationExpression()).
+		WithResolutionKeyExpression(dataset.ResolutionKeyExpression()).
+		WithErrorMessageExpression(dataset.ErrorMessageExpression()).
+		WithStatus(dataset.Status()).
+		WithIsShared(true).
+		WithAccessLevel(accessLevel).
+		WithCreatedAt(dataset.CreatedAt()).
+		WithUpdatedAt(dataset.UpdatedAt())
+	sharedDataset := builder.Build()
+
+	err = tc.Repos.DataSet.Save(ctx, sharedDataset)
+	require.NoError(t, err)
+
+	// Retrieve to get the generated ID
+	sharedDataset, err = tc.Repos.DataSet.FindByCode(ctx, code)
+	require.NoError(t, err)
+
+	// Activate the dataset
+	activatedDataset, err := sharedDataset.ActivateDataSet()
+	require.NoError(t, err)
+	err = tc.Repos.DataSet.Save(ctx, activatedDataset)
+	require.NoError(t, err)
+
+	// Create a data source
+	source, err := domain.NewDataSource(
+		"ECB_SHARED_TEST",
+		"ECB Shared Test",
+		"European Central Bank shared test feed",
+		domain.SourceTypeAPI,
+		90,
+	)
+	require.NoError(t, err)
+
+	err = tc.Repos.Source.Save(ctx, source)
+	require.NoError(t, err)
+
+	source, err = tc.Repos.Source.FindByCode(ctx, "ECB_SHARED_TEST")
+	require.NoError(t, err)
+
+	return activatedDataset, source
+}
+
+func TestObservationRepository_HierarchicalLookup_TenantOverride(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupSharedDataSetAndSource(t, tc, "SHARED_FX_RATE", domain.AccessLevelPublic)
+
+	now := time.Now()
+
+	// Record observation in master tenant (test_master)
+	masterObs, err := domain.NewMarketPriceObservation(
+		"SHARED_FX_RATE",
+		source.ID(),
+		"EUR/USD",
+		decimal.NewFromFloat(1.0850),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, masterObs)
+	require.NoError(t, err)
+
+	// Create tenant context
+	tenantID, err := tc.CreateTenantSchema("tenant_a")
+	require.NoError(t, err)
+	tenantCtx := tc.WithTenant(ctx, tenantID)
+
+	// Record tenant-specific observation with different value
+	tenantObs, err := domain.NewMarketPriceObservation(
+		"SHARED_FX_RATE",
+		source.ID(),
+		"EUR/USD",
+		decimal.NewFromFloat(1.1000), // Different value
+		"USD",
+		now.Add(1*time.Minute),
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(tenantCtx, tenantObs)
+	require.NoError(t, err)
+
+	// Query from tenant context - should get tenant-specific observation
+	result, err := tc.Repos.Observation.GetLatest(tenantCtx, "SHARED_FX_RATE", "EUR/USD")
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromFloat(1.1000).Equal(result.Value()),
+		"Expected tenant override value, got master value")
+	assert.Equal(t, tenantObs.ID(), result.ID(),
+		"Should return tenant observation, not master")
+}
+
+func TestObservationRepository_HierarchicalLookup_MasterFallback(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupSharedDataSetAndSource(t, tc, "SHARED_FX_RATE_FALLBACK", domain.AccessLevelPublic)
+
+	now := time.Now()
+
+	// Record observation in master tenant only
+	masterObs, err := domain.NewMarketPriceObservation(
+		"SHARED_FX_RATE_FALLBACK",
+		source.ID(),
+		"GBP/USD",
+		decimal.NewFromFloat(1.2500),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, masterObs)
+	require.NoError(t, err)
+
+	// Create tenant context
+	tenantID, err := tc.CreateTenantSchema("tenant_b")
+	require.NoError(t, err)
+	tenantCtx := tc.WithTenant(ctx, tenantID)
+
+	// Query from tenant context - should fall back to master
+	result, err := tc.Repos.Observation.GetLatest(tenantCtx, "SHARED_FX_RATE_FALLBACK", "GBP/USD")
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromFloat(1.2500).Equal(result.Value()),
+		"Should fall back to master tenant data")
+	assert.Equal(t, masterObs.ID(), result.ID(),
+		"Should return master observation via fallback")
+}
+
+func TestObservationRepository_HierarchicalLookup_PrivateDatasetNoFallback(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create a PRIVATE (non-shared) dataset
+	dataset, err := domain.NewDataSetDefinition(
+		"PRIVATE_FX_RATE",
+		"Private FX Rate",
+		"Private test dataset - no sharing",
+		domain.DataCategoryPricing,
+		"value > 0",
+		"observation_context.key",
+		"",
+	)
+	require.NoError(t, err)
+	// Default is private, but be explicit
+	builder := domain.NewDataSetDefinitionBuilder().
+		WithID(dataset.ID()).
+		WithCode(dataset.Code()).
+		WithVersion(dataset.Version()).
+		WithName(dataset.Name()).
+		WithDescription(dataset.Description()).
+		WithDataCategory(dataset.DataCategory()).
+		WithValidationExpression(dataset.ValidationExpression()).
+		WithResolutionKeyExpression(dataset.ResolutionKeyExpression()).
+		WithErrorMessageExpression(dataset.ErrorMessageExpression()).
+		WithStatus(dataset.Status()).
+		WithIsShared(false).
+		WithAccessLevel(domain.AccessLevelPrivate).
+		WithCreatedAt(dataset.CreatedAt()).
+		WithUpdatedAt(dataset.UpdatedAt())
+	privateDataset := builder.Build()
+
+	err = tc.Repos.DataSet.Save(ctx, privateDataset)
+	require.NoError(t, err)
+
+	privateDataset, err = tc.Repos.DataSet.FindByCode(ctx, "PRIVATE_FX_RATE")
+	require.NoError(t, err)
+
+	activatedDataset, err := privateDataset.ActivateDataSet()
+	require.NoError(t, err)
+	err = tc.Repos.DataSet.Save(ctx, activatedDataset)
+	require.NoError(t, err)
+
+	// Create data source
+	source, err := domain.NewDataSource(
+		"PRIVATE_SOURCE",
+		"Private Source",
+		"Private data source",
+		domain.SourceTypeAPI,
+		90,
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Source.Save(ctx, source)
+	require.NoError(t, err)
+	source, err = tc.Repos.Source.FindByCode(ctx, "PRIVATE_SOURCE")
+	require.NoError(t, err)
+
+	now := time.Now()
+
+	// Record observation in master tenant
+	masterObs, err := domain.NewMarketPriceObservation(
+		"PRIVATE_FX_RATE",
+		source.ID(),
+		"CHF/USD",
+		decimal.NewFromFloat(1.0900),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, masterObs)
+	require.NoError(t, err)
+
+	// Create tenant context
+	tenantID, err := tc.CreateTenantSchema("tenant_c")
+	require.NoError(t, err)
+	tenantCtx := tc.WithTenant(ctx, tenantID)
+
+	// Query from tenant context - should NOT fall back to master for private dataset
+	// Private datasets don't get copied to tenant schemas, so we get ErrDataSetNotFound
+	_, err = tc.Repos.Observation.GetLatest(tenantCtx, "PRIVATE_FX_RATE", "CHF/USD")
+	assert.ErrorIs(t, err, domain.ErrDataSetNotFound,
+		"Private datasets should not be accessible from tenant schemas")
+}
+
+func TestObservationRepository_HierarchicalLookup_RestrictedAccessDenied(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupSharedDataSetAndSource(t, tc, "RESTRICTED_FX_RATE", domain.AccessLevelRestricted)
+
+	now := time.Now()
+
+	// Record observation in master tenant
+	masterObs, err := domain.NewMarketPriceObservation(
+		"RESTRICTED_FX_RATE",
+		source.ID(),
+		"JPY/USD",
+		decimal.NewFromFloat(0.0085),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, masterObs)
+	require.NoError(t, err)
+
+	// Create tenant context WITHOUT entitlement
+	tenantID, err := tc.CreateTenantSchema("tenant_d")
+	require.NoError(t, err)
+	tenantCtx := tc.WithTenant(ctx, tenantID)
+
+	// Query from tenant context - should be denied access
+	_, err = tc.Repos.Observation.GetLatest(tenantCtx, "RESTRICTED_FX_RATE", "JPY/USD")
+	assert.ErrorIs(t, err, domain.ErrAccessDenied,
+		"RESTRICTED dataset should deny access without entitlement")
+}
+
+func TestObservationRepository_HierarchicalLookup_RestrictedAccessGranted(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupSharedDataSetAndSource(t, tc, "RESTRICTED_FX_RATE_GRANTED", domain.AccessLevelRestricted)
+
+	now := time.Now()
+
+	// Record observation in master tenant
+	masterObs, err := domain.NewMarketPriceObservation(
+		"RESTRICTED_FX_RATE_GRANTED",
+		source.ID(),
+		"CAD/USD",
+		decimal.NewFromFloat(0.7200),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, masterObs)
+	require.NoError(t, err)
+
+	// Create tenant context
+	tenantID, err := tc.CreateTenantSchema("tenant_e")
+	require.NoError(t, err)
+	tenantCtx := tc.WithTenant(ctx, tenantID)
+
+	// Grant entitlement to tenant
+	err = tc.GrantTenantEntitlement(ctx, tenantID, "RESTRICTED_FX_RATE_GRANTED", nil)
+	require.NoError(t, err)
+
+	// Query from tenant context - should succeed with entitlement
+	result, err := tc.Repos.Observation.GetLatest(tenantCtx, "RESTRICTED_FX_RATE_GRANTED", "CAD/USD")
+	require.NoError(t, err, "RESTRICTED dataset should allow access with valid entitlement")
+	assert.True(t, decimal.NewFromFloat(0.7200).Equal(result.Value()),
+		"Should access master data with valid entitlement")
+	assert.Equal(t, masterObs.ID(), result.ID())
+}
+
+func TestObservationRepository_HierarchicalLookup_RestrictedAccessExpired(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupSharedDataSetAndSource(t, tc, "RESTRICTED_FX_RATE_EXPIRED", domain.AccessLevelRestricted)
+
+	now := time.Now()
+
+	// Record observation in master tenant
+	masterObs, err := domain.NewMarketPriceObservation(
+		"RESTRICTED_FX_RATE_EXPIRED",
+		source.ID(),
+		"AUD/USD",
+		decimal.NewFromFloat(0.6500),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, masterObs)
+	require.NoError(t, err)
+
+	// Create tenant context
+	tenantID, err := tc.CreateTenantSchema("tenant_f")
+	require.NoError(t, err)
+	tenantCtx := tc.WithTenant(ctx, tenantID)
+
+	// Grant entitlement with past expiration date
+	expiresAt := now.Add(-24 * time.Hour) // Already expired
+	err = tc.GrantTenantEntitlement(ctx, tenantID, "RESTRICTED_FX_RATE_EXPIRED", &expiresAt)
+	require.NoError(t, err)
+
+	// Query from tenant context - should be denied due to expired entitlement
+	_, err = tc.Repos.Observation.GetLatest(tenantCtx, "RESTRICTED_FX_RATE_EXPIRED", "AUD/USD")
+	assert.ErrorIs(t, err, domain.ErrAccessDenied,
+		"RESTRICTED dataset should deny access with expired entitlement")
+}
+
+func TestObservationRepository_HierarchicalLookup_RestrictedAccessInactive(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupSharedDataSetAndSource(t, tc, "RESTRICTED_FX_RATE_INACTIVE", domain.AccessLevelRestricted)
+
+	now := time.Now()
+
+	// Record observation in master tenant
+	masterObs, err := domain.NewMarketPriceObservation(
+		"RESTRICTED_FX_RATE_INACTIVE",
+		source.ID(),
+		"NZD/USD",
+		decimal.NewFromFloat(0.6000),
+		"USD",
+		now,
+		now,
+		now.Add(24*time.Hour),
+		uuid.New(),
+		domain.QualityLevelActual,
+		source.TrustLevel(),
+	)
+	require.NoError(t, err)
+	err = tc.Repos.Observation.Record(ctx, masterObs)
+	require.NoError(t, err)
+
+	// Create tenant context
+	tenantID, err := tc.CreateTenantSchema("tenant_g")
+	require.NoError(t, err)
+	tenantCtx := tc.WithTenant(ctx, tenantID)
+
+	// Grant inactive entitlement
+	err = tc.GrantTenantEntitlement(ctx, tenantID, "RESTRICTED_FX_RATE_INACTIVE", nil)
+	require.NoError(t, err)
+
+	// Revoke entitlement (set is_active = false)
+	err = tc.RevokeTenantEntitlement(ctx, tenantID, "RESTRICTED_FX_RATE_INACTIVE")
+	require.NoError(t, err)
+
+	// Query from tenant context - should be denied due to inactive entitlement
+	_, err = tc.Repos.Observation.GetLatest(tenantCtx, "RESTRICTED_FX_RATE_INACTIVE", "NZD/USD")
+	assert.ErrorIs(t, err, domain.ErrAccessDenied,
+		"RESTRICTED dataset should deny access with inactive entitlement")
+}

--- a/services/market-information/adapters/persistence/repositories.go
+++ b/services/market-information/adapters/persistence/repositories.go
@@ -16,7 +16,12 @@ type Repositories struct {
 
 // NewRepositories creates all repository implementations with a shared connection pool.
 // This is the recommended way to create repositories for production use.
+//
 // masterTenantID is the tenant ID that hosts shared/public market data (e.g., "master").
+// This should be sourced from the MASTER_TENANT_ID environment variable in production.
+// The master tenant's schema contains canonical shared datasets that other tenants
+// can access via hierarchical lookup (tenant-first, then master fallback).
+//
 // Panics if masterTenantID is empty - this is a fatal configuration error that should be caught at startup.
 func NewRepositories(pool *pgxpool.Pool, masterTenantID string) *Repositories {
 	// Validate masterTenantID upfront - fail fast if misconfigured

--- a/services/market-information/adapters/persistence/repositories.go
+++ b/services/market-information/adapters/persistence/repositories.go
@@ -26,7 +26,7 @@ type Repositories struct {
 func NewRepositories(pool *pgxpool.Pool, masterTenantID string) *Repositories {
 	// Validate masterTenantID upfront - fail fast if misconfigured
 	if masterTenantID == "" {
-		panic("masterTenantID cannot be empty - this is a required configuration parameter for multi-tenant data access")
+		panic("masterTenantID cannot be empty - set MASTER_TENANT_ID environment variable for multi-tenant data access")
 	}
 
 	datasetRepo := NewDataSetRepository(pool)

--- a/services/market-information/adapters/persistence/repositories.go
+++ b/services/market-information/adapters/persistence/repositories.go
@@ -16,10 +16,12 @@ type Repositories struct {
 
 // NewRepositories creates all repository implementations with a shared connection pool.
 // This is the recommended way to create repositories for production use.
-func NewRepositories(pool *pgxpool.Pool) *Repositories {
+// masterTenantID is the tenant ID that hosts shared/public market data (e.g., "master").
+func NewRepositories(pool *pgxpool.Pool, masterTenantID string) *Repositories {
+	datasetRepo := NewDataSetRepository(pool)
 	return &Repositories{
-		DataSet:     NewDataSetRepository(pool),
-		Observation: NewObservationRepository(pool),
+		DataSet:     datasetRepo,
+		Observation: NewObservationRepository(pool, datasetRepo, masterTenantID),
 		Source:      NewSourceRepository(pool),
 	}
 }

--- a/services/market-information/adapters/persistence/repositories.go
+++ b/services/market-information/adapters/persistence/repositories.go
@@ -17,7 +17,13 @@ type Repositories struct {
 // NewRepositories creates all repository implementations with a shared connection pool.
 // This is the recommended way to create repositories for production use.
 // masterTenantID is the tenant ID that hosts shared/public market data (e.g., "master").
+// Panics if masterTenantID is empty - this is a fatal configuration error that should be caught at startup.
 func NewRepositories(pool *pgxpool.Pool, masterTenantID string) *Repositories {
+	// Validate masterTenantID upfront - fail fast if misconfigured
+	if masterTenantID == "" {
+		panic("masterTenantID cannot be empty - this is a required configuration parameter for multi-tenant data access")
+	}
+
 	datasetRepo := NewDataSetRepository(pool)
 	return &Repositories{
 		DataSet:     datasetRepo,

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -3,11 +3,13 @@ package testhelpers
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meridianhub/meridian/services/market-information/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
@@ -232,4 +234,213 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 			WHERE expires_at IS NOT NULL AND is_active = TRUE;
 	`)
 	require.NoError(t, err, "Failed to create tenant_data_entitlements indexes")
+}
+
+// CreateTenantSchema creates a tenant-specific schema for testing multi-tenant scenarios.
+func (tc *TestContainer) CreateTenantSchema(tenantIDStr string) (tenant.TenantID, error) {
+	ctx := context.Background()
+
+	tenantID, err := tenant.NewTenantID(tenantIDStr)
+	if err != nil {
+		return tenant.TenantID(""), fmt.Errorf("invalid tenant ID: %w", err)
+	}
+
+	schemaName := tenantID.SchemaName()
+
+	// Create schema
+	_, err = tc.Pool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schemaName))
+	if err != nil {
+		return tenant.TenantID(""), fmt.Errorf("failed to create schema %s: %w", schemaName, err)
+	}
+
+	// Set search path and create tables in tenant schema
+	_, err = tc.Pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", schemaName))
+	if err != nil {
+		return tenant.TenantID(""), fmt.Errorf("failed to set search_path: %w", err)
+	}
+
+	// Create tenant-specific tables (same structure as public schema)
+	err = loadSchemaInSchema(ctx, tc.Pool, schemaName)
+	if err != nil {
+		return tenant.TenantID(""), fmt.Errorf("failed to load schema: %w", err)
+	}
+
+	// Copy shared datasets from public schema to tenant schema
+	// This allows tenant observations to reference shared dataset definitions
+	_, err = tc.Pool.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.dataset_definition
+		SELECT * FROM public.dataset_definition
+		WHERE is_shared = TRUE
+	`, schemaName))
+	if err != nil {
+		return tenant.TenantID(""), fmt.Errorf("failed to copy shared datasets: %w", err)
+	}
+
+	// Copy data sources from public schema to tenant schema
+	// Data sources are needed for observations to have valid foreign keys
+	_, err = tc.Pool.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO %s.data_source
+		SELECT * FROM public.data_source
+	`, schemaName))
+	if err != nil {
+		return tenant.TenantID(""), fmt.Errorf("failed to copy data sources: %w", err)
+	}
+
+	// Reset search path to default
+	_, err = tc.Pool.Exec(ctx, "SET search_path TO public")
+	if err != nil {
+		return tenant.TenantID(""), fmt.Errorf("failed to reset search_path: %w", err)
+	}
+
+	return tenantID, nil
+}
+
+// WithTenant wraps a context with tenant information.
+func (tc *TestContainer) WithTenant(ctx context.Context, tenantID tenant.TenantID) context.Context {
+	return tenant.WithTenant(ctx, tenantID)
+}
+
+// GrantTenantEntitlement grants access to a dataset for a tenant.
+func (tc *TestContainer) GrantTenantEntitlement(ctx context.Context, tenantID tenant.TenantID, datasetCode string, expiresAt *time.Time) error {
+	query := `
+		INSERT INTO tenant_data_entitlements (tenant_id, dataset_code, is_active, expires_at)
+		VALUES ($1, $2, TRUE, $3)
+		ON CONFLICT (tenant_id, dataset_code)
+		DO UPDATE SET is_active = TRUE, expires_at = EXCLUDED.expires_at`
+
+	_, err := tc.Pool.Exec(ctx, query, tenantID.String(), datasetCode, expiresAt)
+	if err != nil {
+		return fmt.Errorf("failed to grant entitlement: %w", err)
+	}
+	return nil
+}
+
+// RevokeTenantEntitlement revokes access to a dataset for a tenant.
+func (tc *TestContainer) RevokeTenantEntitlement(ctx context.Context, tenantID tenant.TenantID, datasetCode string) error {
+	query := `
+		UPDATE tenant_data_entitlements
+		SET is_active = FALSE
+		WHERE tenant_id = $1 AND dataset_code = $2`
+
+	_, err := tc.Pool.Exec(ctx, query, tenantID.String(), datasetCode)
+	if err != nil {
+		return fmt.Errorf("failed to revoke entitlement: %w", err)
+	}
+	return nil
+}
+
+// loadSchemaInSchema creates tables within a specific schema for multi-tenant testing.
+func loadSchemaInSchema(ctx context.Context, pool *pgxpool.Pool, schemaName string) error {
+	// Set search path to tenant schema
+	_, err := pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", schemaName))
+	if err != nil {
+		return fmt.Errorf("failed to set search_path: %w", err)
+	}
+
+	// Create tables (same as public schema)
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE data_source (
+			id uuid NOT NULL DEFAULT gen_random_uuid(),
+			code character varying(50) NOT NULL,
+			name character varying(255) NOT NULL,
+			description text NULL,
+			trust_level integer NOT NULL DEFAULT 50,
+			created_at timestamptz NOT NULL DEFAULT now(),
+			created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+			updated_at timestamptz NOT NULL DEFAULT now(),
+			updated_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+			deleted_at timestamptz NULL,
+			version bigint NOT NULL DEFAULT 1,
+			PRIMARY KEY (id),
+			CONSTRAINT uq_data_source_code UNIQUE (code),
+			CONSTRAINT chk_data_source_trust_level CHECK (trust_level >= 0 AND trust_level <= 100)
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create data_source table: %w", err)
+	}
+
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE dataset_definition (
+			id uuid NOT NULL DEFAULT gen_random_uuid(),
+			code character varying(50) NOT NULL,
+			version integer NOT NULL DEFAULT 1,
+			name character varying(255) NOT NULL,
+			description text NULL,
+			data_category character varying(50) NULL,
+			validation_expression text NULL,
+			resolution_key_expression text NOT NULL,
+			error_message_expression text NULL,
+			attribute_schema jsonb NULL,
+			status character varying(20) NOT NULL DEFAULT 'DRAFT',
+			is_shared BOOLEAN NOT NULL DEFAULT FALSE,
+			access_level VARCHAR(50) NOT NULL DEFAULT 'PRIVATE',
+			created_at timestamptz NOT NULL DEFAULT now(),
+			created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+			updated_at timestamptz NOT NULL DEFAULT now(),
+			updated_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+			deleted_at timestamptz NULL,
+			activated_at timestamptz NULL,
+			deprecated_at timestamptz NULL,
+			PRIMARY KEY (id),
+			CONSTRAINT uq_dataset_definition_code_version UNIQUE (code, version),
+			CONSTRAINT chk_dataset_definition_status CHECK (status IN ('DRAFT', 'ACTIVE', 'DEPRECATED')),
+			CONSTRAINT chk_dataset_definition_access_level CHECK (access_level IN ('PUBLIC', 'PRIVATE', 'RESTRICTED'))
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create dataset_definition table: %w", err)
+	}
+
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE market_price_observation (
+			id uuid NOT NULL DEFAULT gen_random_uuid(),
+			dataset_definition_id uuid NOT NULL,
+			data_source_id uuid NOT NULL,
+			resolution_key character varying(255) NOT NULL,
+			observed_at timestamptz NOT NULL,
+			valid_from timestamptz NULL,
+			valid_to timestamptz NULL,
+			created_at timestamptz NOT NULL DEFAULT now(),
+			created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
+			quality integer NOT NULL,
+			observation_context jsonb NOT NULL DEFAULT '{}'::jsonb,
+			numeric_value numeric NULL,
+			text_value text NULL,
+			superseded_by uuid NULL,
+			causation_id uuid NULL,
+			PRIMARY KEY (id),
+			CONSTRAINT fk_observation_dataset_definition
+				FOREIGN KEY (dataset_definition_id) REFERENCES dataset_definition(id) ON DELETE RESTRICT,
+			CONSTRAINT fk_observation_data_source
+				FOREIGN KEY (data_source_id) REFERENCES data_source(id) ON DELETE RESTRICT,
+			CONSTRAINT fk_observation_superseded_by
+				FOREIGN KEY (superseded_by) REFERENCES market_price_observation(id) ON DELETE SET NULL,
+			CONSTRAINT chk_observation_quality CHECK (quality IN (1, 2, 3)),
+			CONSTRAINT chk_observation_value_present CHECK (numeric_value IS NOT NULL OR text_value IS NOT NULL)
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create market_price_observation table: %w", err)
+	}
+
+	// Create indexes
+	_, err = pool.Exec(ctx, `
+		CREATE INDEX idx_dataset_definition_code_active ON dataset_definition (code) WHERE status = 'ACTIVE';
+		CREATE INDEX idx_observation_resolution_bitemporal
+			ON market_price_observation (resolution_key, quality DESC, observed_at DESC, created_at DESC)
+			WHERE superseded_by IS NULL;
+		CREATE INDEX idx_data_source_trust_level ON data_source (trust_level DESC);
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to create indexes: %w", err)
+	}
+
+	// Reset search path
+	_, err = pool.Exec(ctx, "SET search_path TO public")
+	if err != nil {
+		return fmt.Errorf("failed to reset search_path: %w", err)
+	}
+
+	return nil
 }

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -270,7 +270,7 @@ func (tc *TestContainer) CreateTenantSchema(tenantIDStr string) (tenant.TenantID
 
 	// Copy shared datasets from public schema to tenant schema.
 	// This allows tenant observations to reference shared dataset definitions.
-	// Note: quotedSchema is safely quoted via pgx.Identifier.Sanitize() above (line 251).
+	// Note: quotedSchema is safely quoted via pgx.Identifier.Sanitize() above.
 	_, err = tc.Pool.Exec(ctx, fmt.Sprintf(`
 		INSERT INTO %s.dataset_definition
 		SELECT * FROM public.dataset_definition

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -268,8 +268,9 @@ func (tc *TestContainer) CreateTenantSchema(tenantIDStr string) (tenant.TenantID
 		return tenant.TenantID(""), fmt.Errorf("failed to load schema: %w", err)
 	}
 
-	// Copy shared datasets from public schema to tenant schema
-	// This allows tenant observations to reference shared dataset definitions
+	// Copy shared datasets from public schema to tenant schema.
+	// This allows tenant observations to reference shared dataset definitions.
+	// Note: quotedSchema is safely quoted via pgx.Identifier.Sanitize() above (line 251).
 	_, err = tc.Pool.Exec(ctx, fmt.Sprintf(`
 		INSERT INTO %s.dataset_definition
 		SELECT * FROM public.dataset_definition

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -55,8 +55,8 @@ func SetupTestContainer(t *testing.T) *TestContainer {
 	// Load schema
 	loadSchema(t, pool)
 
-	// Create repositories
-	repos := persistence.NewRepositories(pool)
+	// Create repositories with test master tenant
+	repos := persistence.NewRepositories(pool, "test_master")
 
 	return &TestContainer{
 		container: pgContainer,

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meridianhub/meridian/services/market-information/adapters/persistence"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -246,15 +247,17 @@ func (tc *TestContainer) CreateTenantSchema(tenantIDStr string) (tenant.TenantID
 	}
 
 	schemaName := tenantID.SchemaName()
+	// Use pgx.Identifier for proper SQL identifier quoting to prevent injection
+	quotedSchema := pgx.Identifier{schemaName}.Sanitize()
 
 	// Create schema
-	_, err = tc.Pool.Exec(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", schemaName))
+	_, err = tc.Pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+quotedSchema)
 	if err != nil {
 		return tenant.TenantID(""), fmt.Errorf("failed to create schema %s: %w", schemaName, err)
 	}
 
 	// Set search path and create tables in tenant schema
-	_, err = tc.Pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", schemaName))
+	_, err = tc.Pool.Exec(ctx, "SET search_path TO "+quotedSchema)
 	if err != nil {
 		return tenant.TenantID(""), fmt.Errorf("failed to set search_path: %w", err)
 	}
@@ -271,7 +274,7 @@ func (tc *TestContainer) CreateTenantSchema(tenantIDStr string) (tenant.TenantID
 		INSERT INTO %s.dataset_definition
 		SELECT * FROM public.dataset_definition
 		WHERE is_shared = TRUE
-	`, schemaName))
+	`, quotedSchema))
 	if err != nil {
 		return tenant.TenantID(""), fmt.Errorf("failed to copy shared datasets: %w", err)
 	}
@@ -281,7 +284,7 @@ func (tc *TestContainer) CreateTenantSchema(tenantIDStr string) (tenant.TenantID
 	_, err = tc.Pool.Exec(ctx, fmt.Sprintf(`
 		INSERT INTO %s.data_source
 		SELECT * FROM public.data_source
-	`, schemaName))
+	`, quotedSchema))
 	if err != nil {
 		return tenant.TenantID(""), fmt.Errorf("failed to copy data sources: %w", err)
 	}
@@ -331,8 +334,9 @@ func (tc *TestContainer) RevokeTenantEntitlement(ctx context.Context, tenantID t
 
 // loadSchemaInSchema creates tables within a specific schema for multi-tenant testing.
 func loadSchemaInSchema(ctx context.Context, pool *pgxpool.Pool, schemaName string) error {
-	// Set search path to tenant schema
-	_, err := pool.Exec(ctx, fmt.Sprintf("SET search_path TO %s", schemaName))
+	// Set search path to tenant schema (use pgx.Identifier for proper quoting)
+	quotedSchema := pgx.Identifier{schemaName}.Sanitize()
+	_, err := pool.Exec(ctx, "SET search_path TO "+quotedSchema)
 	if err != nil {
 		return fmt.Errorf("failed to set search_path: %w", err)
 	}

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -119,6 +119,8 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 			error_message_expression text NULL,
 			attribute_schema jsonb NULL,
 			status character varying(20) NOT NULL DEFAULT 'DRAFT',
+			is_shared BOOLEAN NOT NULL DEFAULT FALSE,
+			access_level VARCHAR(50) NOT NULL DEFAULT 'PRIVATE',
 			created_at timestamptz NOT NULL DEFAULT now(),
 			created_by character varying(100) NOT NULL DEFAULT 'SYSTEM',
 			updated_at timestamptz NOT NULL DEFAULT now(),
@@ -128,7 +130,8 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 			deprecated_at timestamptz NULL,
 			PRIMARY KEY (id),
 			CONSTRAINT uq_dataset_definition_code_version UNIQUE (code, version),
-			CONSTRAINT chk_dataset_definition_status CHECK (status IN ('DRAFT', 'ACTIVE', 'DEPRECATED'))
+			CONSTRAINT chk_dataset_definition_status CHECK (status IN ('DRAFT', 'ACTIVE', 'DEPRECATED')),
+			CONSTRAINT chk_dataset_definition_access_level CHECK (access_level IN ('PUBLIC', 'PRIVATE', 'RESTRICTED'))
 		)
 	`)
 	require.NoError(t, err, "Failed to create dataset_definition table")
@@ -200,4 +203,33 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 		CREATE INDEX idx_data_source_deleted_at ON data_source (deleted_at);
 	`)
 	require.NoError(t, err, "Failed to create data_source indexes")
+
+	// Create tenant_data_entitlements table
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE tenant_data_entitlements (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			tenant_id VARCHAR(255) NOT NULL,
+			dataset_code VARCHAR(255) NOT NULL,
+			is_active BOOLEAN NOT NULL DEFAULT TRUE,
+			granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			expires_at TIMESTAMPTZ NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			created_by VARCHAR(100) NOT NULL DEFAULT 'SYSTEM',
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_by VARCHAR(100) NOT NULL DEFAULT 'SYSTEM',
+			CONSTRAINT uq_tenant_dataset UNIQUE (tenant_id, dataset_code)
+		)
+	`)
+	require.NoError(t, err, "Failed to create tenant_data_entitlements table")
+
+	// Create tenant_data_entitlements indexes
+	_, err = pool.Exec(ctx, `
+		CREATE INDEX idx_entitlements_tenant_dataset
+			ON tenant_data_entitlements(tenant_id, dataset_code, is_active)
+			WHERE is_active = TRUE;
+		CREATE INDEX idx_entitlements_expires_at
+			ON tenant_data_entitlements(expires_at)
+			WHERE expires_at IS NOT NULL AND is_active = TRUE;
+	`)
+	require.NoError(t, err, "Failed to create tenant_data_entitlements indexes")
 }

--- a/services/market-information/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/market-information/adapters/persistence/testhelpers/testcontainer.go
@@ -334,15 +334,24 @@ func (tc *TestContainer) RevokeTenantEntitlement(ctx context.Context, tenantID t
 
 // loadSchemaInSchema creates tables within a specific schema for multi-tenant testing.
 func loadSchemaInSchema(ctx context.Context, pool *pgxpool.Pool, schemaName string) error {
+	// Acquire a single connection for all operations to ensure search_path persists.
+	// Using pool.Exec can get different connections from the pool, causing SET search_path
+	// to not apply to subsequent operations.
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire connection: %w", err)
+	}
+	defer conn.Release()
+
 	// Set search path to tenant schema (use pgx.Identifier for proper quoting)
 	quotedSchema := pgx.Identifier{schemaName}.Sanitize()
-	_, err := pool.Exec(ctx, "SET search_path TO "+quotedSchema)
+	_, err = conn.Exec(ctx, "SET search_path TO "+quotedSchema)
 	if err != nil {
 		return fmt.Errorf("failed to set search_path: %w", err)
 	}
 
 	// Create tables (same as public schema)
-	_, err = pool.Exec(ctx, `
+	_, err = conn.Exec(ctx, `
 		CREATE TABLE data_source (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			code character varying(50) NOT NULL,
@@ -364,7 +373,7 @@ func loadSchemaInSchema(ctx context.Context, pool *pgxpool.Pool, schemaName stri
 		return fmt.Errorf("failed to create data_source table: %w", err)
 	}
 
-	_, err = pool.Exec(ctx, `
+	_, err = conn.Exec(ctx, `
 		CREATE TABLE dataset_definition (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			code character varying(50) NOT NULL,
@@ -396,7 +405,7 @@ func loadSchemaInSchema(ctx context.Context, pool *pgxpool.Pool, schemaName stri
 		return fmt.Errorf("failed to create dataset_definition table: %w", err)
 	}
 
-	_, err = pool.Exec(ctx, `
+	_, err = conn.Exec(ctx, `
 		CREATE TABLE market_price_observation (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			dataset_definition_id uuid NOT NULL,
@@ -429,7 +438,7 @@ func loadSchemaInSchema(ctx context.Context, pool *pgxpool.Pool, schemaName stri
 	}
 
 	// Create indexes
-	_, err = pool.Exec(ctx, `
+	_, err = conn.Exec(ctx, `
 		CREATE INDEX idx_dataset_definition_code_active ON dataset_definition (code) WHERE status = 'ACTIVE';
 		CREATE INDEX idx_observation_resolution_bitemporal
 			ON market_price_observation (resolution_key, quality DESC, observed_at DESC, created_at DESC)
@@ -441,7 +450,7 @@ func loadSchemaInSchema(ctx context.Context, pool *pgxpool.Pool, schemaName stri
 	}
 
 	// Reset search path
-	_, err = pool.Exec(ctx, "SET search_path TO public")
+	_, err = conn.Exec(ctx, "SET search_path TO public")
 	if err != nil {
 		return fmt.Errorf("failed to reset search_path: %w", err)
 	}

--- a/services/market-information/domain/access_level.go
+++ b/services/market-information/domain/access_level.go
@@ -1,0 +1,38 @@
+// Package domain contains the domain models for the Market Information service.
+package domain
+
+// DataAccessLevel defines the visibility and access control level for a dataset.
+// This determines who can access the dataset and whether hierarchical lookup is enabled.
+type DataAccessLevel string
+
+const (
+	// AccessLevelPublic indicates the dataset is publicly available to all tenants.
+	// No entitlement checks are performed. Shared datasets with PUBLIC access
+	// enable hierarchical lookup (tenant-first, then master fallback).
+	AccessLevelPublic DataAccessLevel = "PUBLIC"
+
+	// AccessLevelPrivate indicates the dataset is private to the owning tenant.
+	// No sharing or hierarchical lookup is performed. Only the tenant that created
+	// the dataset can access it.
+	AccessLevelPrivate DataAccessLevel = "PRIVATE"
+
+	// AccessLevelRestricted indicates the dataset is shared but requires explicit entitlements.
+	// Hierarchical lookup is enabled for tenants with active entitlements.
+	// Access control checks are performed before allowing fallback to master data.
+	AccessLevelRestricted DataAccessLevel = "RESTRICTED"
+)
+
+// IsValid checks if the access level is a recognized value.
+func (a DataAccessLevel) IsValid() bool {
+	switch a {
+	case AccessLevelPublic, AccessLevelPrivate, AccessLevelRestricted:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the string representation of the access level.
+func (a DataAccessLevel) String() string {
+	return string(a)
+}

--- a/services/market-information/domain/dataset.go
+++ b/services/market-information/domain/dataset.go
@@ -28,15 +28,23 @@ type DataSetDefinition struct {
 	description             string
 	dataCategory            DataCategory
 	status                  DataSetStatus
-	validationExpression    string          // CEL expression for data validation
-	resolutionKeyExpression string          // CEL expression for extracting resolution key
-	errorMessageExpression  string          // CEL expression for error message generation
-	isShared                bool            // Enables hierarchical lookup (tenant-first, master fallback)
-	accessLevel             DataAccessLevel // Controls visibility and entitlement requirements
-	createdAt               time.Time
-	updatedAt               time.Time
-	activatedAt             *time.Time // Set when transitioning to ACTIVE
-	deprecatedAt            *time.Time // Set when transitioning to DEPRECATED
+	validationExpression    string // CEL expression for data validation
+	resolutionKeyExpression string // CEL expression for extracting resolution key
+	errorMessageExpression  string // CEL expression for error message generation
+	// isShared enables hierarchical lookup (tenant-first, then master fallback).
+	// When true, if observation not found in tenant schema, query falls through to master.
+	// Note: isShared=true with accessLevel=PRIVATE is valid but unusual - it means
+	// shared data exists but each tenant must have their own copy to access it.
+	isShared bool
+	// accessLevel controls visibility and entitlement requirements for shared data.
+	// PUBLIC: all tenants can access, no entitlements needed
+	// PRIVATE: tenant-isolated, no sharing (default)
+	// RESTRICTED: shared but requires explicit entitlements
+	accessLevel  DataAccessLevel
+	createdAt    time.Time
+	updatedAt    time.Time
+	activatedAt  *time.Time // Set when transitioning to ACTIVE
+	deprecatedAt *time.Time // Set when transitioning to DEPRECATED
 }
 
 // NewDataSetDefinition creates a new DataSetDefinition with validated fields.

--- a/services/market-information/domain/dataset.go
+++ b/services/market-information/domain/dataset.go
@@ -28,9 +28,11 @@ type DataSetDefinition struct {
 	description             string
 	dataCategory            DataCategory
 	status                  DataSetStatus
-	validationExpression    string // CEL expression for data validation
-	resolutionKeyExpression string // CEL expression for extracting resolution key
-	errorMessageExpression  string // CEL expression for error message generation
+	validationExpression    string          // CEL expression for data validation
+	resolutionKeyExpression string          // CEL expression for extracting resolution key
+	errorMessageExpression  string          // CEL expression for error message generation
+	isShared                bool            // Enables hierarchical lookup (tenant-first, master fallback)
+	accessLevel             DataAccessLevel // Controls visibility and entitlement requirements
 	createdAt               time.Time
 	updatedAt               time.Time
 	activatedAt             *time.Time // Set when transitioning to ACTIVE
@@ -85,6 +87,8 @@ func NewDataSetDefinition(
 		validationExpression:    validationExpression,
 		resolutionKeyExpression: resolutionKeyExpression,
 		errorMessageExpression:  errorMessageExpression,
+		isShared:                false,              // Default: private to tenant
+		accessLevel:             AccessLevelPrivate, // Default: no sharing
 		createdAt:               now,
 		updatedAt:               now,
 		activatedAt:             nil,
@@ -276,6 +280,18 @@ func (d DataSetDefinition) DeprecatedAt() *time.Time {
 	return d.deprecatedAt
 }
 
+// IsShared returns whether this dataset enables hierarchical lookup.
+// If true, queries will fall through to master tenant data when not found in tenant schema.
+func (d DataSetDefinition) IsShared() bool {
+	return d.isShared
+}
+
+// AccessLevel returns the access control level for this dataset.
+// Controls visibility and entitlement requirements.
+func (d DataSetDefinition) AccessLevel() DataAccessLevel {
+	return d.accessLevel
+}
+
 // DataSetDefinitionBuilder provides a builder pattern for reconstructing
 // DataSetDefinition from persistence layer. This bypasses normal validation
 // since we assume persisted data was already validated.
@@ -371,6 +387,18 @@ func (b *DataSetDefinitionBuilder) WithActivatedAt(activatedAt *time.Time) *Data
 // WithDeprecatedAt sets the deprecation timestamp.
 func (b *DataSetDefinitionBuilder) WithDeprecatedAt(deprecatedAt *time.Time) *DataSetDefinitionBuilder {
 	b.dataset.deprecatedAt = deprecatedAt
+	return b
+}
+
+// WithIsShared sets whether the dataset enables hierarchical lookup.
+func (b *DataSetDefinitionBuilder) WithIsShared(isShared bool) *DataSetDefinitionBuilder {
+	b.dataset.isShared = isShared
+	return b
+}
+
+// WithAccessLevel sets the access control level.
+func (b *DataSetDefinitionBuilder) WithAccessLevel(accessLevel DataAccessLevel) *DataSetDefinitionBuilder {
+	b.dataset.accessLevel = accessLevel
 	return b
 }
 

--- a/services/market-information/domain/errors.go
+++ b/services/market-information/domain/errors.go
@@ -74,6 +74,10 @@ var (
 	// ErrCausationIDRequired indicates the causation ID was not provided for an observation.
 	ErrCausationIDRequired = errors.New("causation ID is required")
 
+	// ErrAccessDenied indicates the tenant lacks permission to access the dataset.
+	// This occurs when attempting to access a RESTRICTED shared dataset without valid entitlements.
+	ErrAccessDenied = errors.New("access denied: tenant not entitled to dataset")
+
 	// DataSource errors for repository operations.
 
 	// ErrDataSourceNotFound indicates the requested data source does not exist.

--- a/services/market-information/migrations/20260119000002_add_shared_dataset_support.sql
+++ b/services/market-information/migrations/20260119000002_add_shared_dataset_support.sql
@@ -40,6 +40,8 @@ CREATE TABLE tenant_data_entitlements (
   tenant_id VARCHAR(255) NOT NULL,
   dataset_code VARCHAR(255) NOT NULL,
   is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  -- granted_at may differ from created_at when backdating historical entitlements
+  -- imported from external access control systems during migration.
   granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   expires_at TIMESTAMPTZ NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/services/market-information/migrations/20260119000002_add_shared_dataset_support.sql
+++ b/services/market-information/migrations/20260119000002_add_shared_dataset_support.sql
@@ -63,11 +63,19 @@ CREATE INDEX idx_entitlements_expires_at
   WHERE expires_at IS NOT NULL AND is_active = TRUE;
 
 --------------------------------------------------------------------------------
--- Section 3: Mark ECB FX_RATE dataset as shared/public
+-- Section 3: Mark ECB FX_RATE datasets as shared/public
 --------------------------------------------------------------------------------
 
--- Update ECB FX_RATE dataset to be shared and public
+-- Update ECB FX_RATE datasets to be shared and public
 -- This allows all tenants to access ECB rates without per-tenant ingestion
+--
+-- Pattern 'ECB_%_FX' intentionally matches all ECB foreign exchange datasets:
+--   - ECB_EUR_USD_FX (Euro to US Dollar)
+--   - ECB_EUR_GBP_FX (Euro to British Pound)
+--   - etc.
+--
+-- This broad match ensures new ECB currency pairs are automatically shared.
+-- If specific datasets need different access levels, create a follow-up migration.
 UPDATE dataset_definition
 SET
   is_shared = TRUE,

--- a/services/market-information/migrations/20260119000002_add_shared_dataset_support.sql
+++ b/services/market-information/migrations/20260119000002_add_shared_dataset_support.sql
@@ -32,6 +32,9 @@ CREATE INDEX idx_dataset_definition_is_shared ON dataset_definition (is_shared) 
 -- Section 2: Create tenant_data_entitlements table
 --------------------------------------------------------------------------------
 
+-- Ensure pgcrypto extension is available for UUID generation (gen_random_uuid)
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 CREATE TABLE tenant_data_entitlements (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   tenant_id VARCHAR(255) NOT NULL,
@@ -69,20 +72,18 @@ CREATE INDEX idx_entitlements_expires_at
 -- Update ECB FX_RATE datasets to be shared and public
 -- This allows all tenants to access ECB rates without per-tenant ingestion
 --
--- Pattern 'ECB_%_FX' intentionally matches all ECB foreign exchange datasets:
---   - ECB_EUR_USD_FX (Euro to US Dollar)
---   - ECB_EUR_GBP_FX (Euro to British Pound)
---   - etc.
+-- Explicit list of ECB foreign exchange datasets to mark as shared:
+--   - ECB_DAILY_FX: Daily ECB foreign exchange reference rates
 --
--- This broad match ensures new ECB currency pairs are automatically shared.
--- If specific datasets need different access levels, create a follow-up migration.
+-- Using explicit IN clause rather than LIKE pattern for predictability.
+-- If additional ECB datasets need to be shared, add them here explicitly.
 UPDATE dataset_definition
 SET
   is_shared = TRUE,
   access_level = 'PUBLIC',
   updated_at = NOW(),
   updated_by = 'MIGRATION'
-WHERE code LIKE 'ECB_%_FX'
+WHERE code IN ('ECB_DAILY_FX')
   AND status = 'ACTIVE'
   AND deleted_at IS NULL;
 

--- a/services/market-information/migrations/20260119000002_add_shared_dataset_support.sql
+++ b/services/market-information/migrations/20260119000002_add_shared_dataset_support.sql
@@ -1,0 +1,82 @@
+-- Migration: Add Shared Dataset Support with Multi-Tenant Hierarchical Lookup
+-- This migration enables datasets to be shared across tenants with hierarchical lookup:
+-- 1. Tenant-specific schema is queried first
+-- 2. If dataset is shared and not found, falls through to master tenant schema
+-- 3. Access control via tenant_data_entitlements for RESTRICTED datasets
+
+--------------------------------------------------------------------------------
+-- Section 1: Add IsShared and AccessLevel to dataset_definition
+--------------------------------------------------------------------------------
+
+-- Add is_shared column: enables hierarchical lookup for this dataset
+ALTER TABLE dataset_definition
+  ADD COLUMN is_shared BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN dataset_definition.is_shared IS 'Enables hierarchical lookup: query tenant schema first, then fall through to master tenant if not found';
+
+-- Add access_level column: controls visibility and entitlement requirements
+ALTER TABLE dataset_definition
+  ADD COLUMN access_level VARCHAR(50) NOT NULL DEFAULT 'PRIVATE';
+
+COMMENT ON COLUMN dataset_definition.access_level IS 'Access control level: PUBLIC (all tenants), PRIVATE (tenant-only), RESTRICTED (requires entitlements)';
+
+-- Ensure access_level has valid values
+ALTER TABLE dataset_definition
+  ADD CONSTRAINT chk_dataset_definition_access_level
+  CHECK (access_level IN ('PUBLIC', 'PRIVATE', 'RESTRICTED'));
+
+-- Index for finding shared datasets
+CREATE INDEX idx_dataset_definition_is_shared ON dataset_definition (is_shared) WHERE is_shared = TRUE;
+
+--------------------------------------------------------------------------------
+-- Section 2: Create tenant_data_entitlements table
+--------------------------------------------------------------------------------
+
+CREATE TABLE tenant_data_entitlements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id VARCHAR(255) NOT NULL,
+  dataset_code VARCHAR(255) NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by VARCHAR(100) NOT NULL DEFAULT 'SYSTEM',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by VARCHAR(100) NOT NULL DEFAULT 'SYSTEM',
+  CONSTRAINT uq_tenant_dataset UNIQUE (tenant_id, dataset_code)
+);
+
+COMMENT ON TABLE tenant_data_entitlements IS 'Controls which tenants can access RESTRICTED shared datasets';
+COMMENT ON COLUMN tenant_data_entitlements.tenant_id IS 'Tenant ID (matches TenantID type in Go code)';
+COMMENT ON COLUMN tenant_data_entitlements.dataset_code IS 'Dataset code (e.g., "FX_RATE")';
+COMMENT ON COLUMN tenant_data_entitlements.is_active IS 'Whether entitlement is currently active';
+COMMENT ON COLUMN tenant_data_entitlements.expires_at IS 'Optional expiration timestamp for time-limited access';
+
+-- Index for fast entitlement lookups
+CREATE INDEX idx_entitlements_tenant_dataset
+  ON tenant_data_entitlements(tenant_id, dataset_code, is_active)
+  WHERE is_active = TRUE;
+
+-- Index for expiration checks
+CREATE INDEX idx_entitlements_expires_at
+  ON tenant_data_entitlements(expires_at)
+  WHERE expires_at IS NOT NULL AND is_active = TRUE;
+
+--------------------------------------------------------------------------------
+-- Section 3: Mark ECB FX_RATE dataset as shared/public
+--------------------------------------------------------------------------------
+
+-- Update ECB FX_RATE dataset to be shared and public
+-- This allows all tenants to access ECB rates without per-tenant ingestion
+UPDATE dataset_definition
+SET
+  is_shared = TRUE,
+  access_level = 'PUBLIC',
+  updated_at = NOW(),
+  updated_by = 'MIGRATION'
+WHERE code LIKE 'ECB_%_FX'
+  AND status = 'ACTIVE'
+  AND deleted_at IS NULL;
+
+-- Note: No need to populate tenant_data_entitlements for PUBLIC datasets
+-- PUBLIC datasets skip entitlement checks and allow access to all tenants

--- a/services/market-information/migrations/20260119000002_add_shared_dataset_support.sql
+++ b/services/market-information/migrations/20260119000002_add_shared_dataset_support.sql
@@ -32,8 +32,8 @@ CREATE INDEX idx_dataset_definition_is_shared ON dataset_definition (is_shared) 
 -- Section 2: Create tenant_data_entitlements table
 --------------------------------------------------------------------------------
 
--- Ensure pgcrypto extension is available for UUID generation (gen_random_uuid)
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
+-- Note: gen_random_uuid() is built-in since PostgreSQL 13 (no extension needed).
+-- Meridian targets PostgreSQL 15+ where this function is natively available.
 
 CREATE TABLE tenant_data_entitlements (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -66,14 +66,18 @@ CREATE INDEX idx_entitlements_expires_at
   WHERE expires_at IS NOT NULL AND is_active = TRUE;
 
 --------------------------------------------------------------------------------
--- Section 3: Mark ECB FX_RATE datasets as shared/public
+-- Section 3: Mark ECB datasets as shared/public (forward-looking)
 --------------------------------------------------------------------------------
 
--- Update ECB FX_RATE datasets to be shared and public
--- This allows all tenants to access ECB rates without per-tenant ingestion
+-- This UPDATE is idempotent and forward-looking: it will mark ECB datasets as shared
+-- when they are created by the ECB adapter worker. Until then, this safely matches
+-- zero rows since seed data uses 'FX_RATE' (a generic test dataset), not ECB-specific codes.
+--
+-- When the ECB adapter creates datasets (e.g., ECB_DAILY_FX), re-running this migration
+-- or creating a new migration with the same logic will enable multi-tenant sharing.
 --
 -- Explicit list of ECB foreign exchange datasets to mark as shared:
---   - ECB_DAILY_FX: Daily ECB foreign exchange reference rates
+--   - ECB_DAILY_FX: Daily ECB foreign exchange reference rates (created by ECB adapter)
 --
 -- Using explicit IN clause rather than LIKE pattern for predictability.
 -- If additional ECB datasets need to be shared, add them here explicitly.
@@ -87,5 +91,5 @@ WHERE code IN ('ECB_DAILY_FX')
   AND status = 'ACTIVE'
   AND deleted_at IS NULL;
 
--- Note: No need to populate tenant_data_entitlements for PUBLIC datasets
--- PUBLIC datasets skip entitlement checks and allow access to all tenants
+-- Note: No need to populate tenant_data_entitlements for PUBLIC datasets.
+-- PUBLIC datasets skip entitlement checks and allow access to all tenants.


### PR DESCRIPTION
## Summary

Implements multi-tenant hierarchical lookup for market data observations:

- **Tenant override**: Tenant-specific data takes precedence over master data
- **Master fallback**: Shared datasets automatically fall back to master when no tenant data exists
- **Private isolation**: Non-shared datasets remain private to owning tenant
- **Access control**: RESTRICTED datasets require active entitlements with expiration support

## Changes

### Domain Model Extensions (17.2)
- Added `IsShared` flag to enable hierarchical lookup for datasets
- Added `AccessLevel` enum (PUBLIC, PRIVATE, RESTRICTED) for sharing control
- Extended `DataSetDefinition` with sharing metadata

### Hierarchical Lookup Implementation (17.3)
- **RetrieveObservation** implements tenant-first, master-fallback pattern
- Queries tenant schema first for observations
- Falls back to master tenant for shared datasets when tenant data not found
- Respects privacy for non-shared datasets (no fallback)

### Database Migration (17.4)
- Created `tenant_data_entitlements` table for access control
- Tracks tenant permissions for RESTRICTED datasets
- Supports expiration dates and active/inactive states

### Access Control (17.5)
- `ErrAccessDenied` returned when tenant lacks entitlement for RESTRICTED dataset
- Entitlement checks verify: tenant_id, dataset_code, is_active, expires_at > NOW()
- Public datasets bypass entitlement checks

### Test Coverage (17.6)
7 comprehensive integration tests validating:
- ✅ Tenant data overrides master data
- ✅ Master fallback for shared datasets
- ✅ Private datasets remain isolated
- ✅ RESTRICTED access denied without entitlement
- ✅ RESTRICTED access granted with valid entitlement
- ✅ RESTRICTED access denied with expired entitlement
- ✅ RESTRICTED access denied with revoked entitlement

## ADR Alignment

Aligns with **ADR-0026 (Canonical Ingestion Contract)**:
- Market-information service implements the hierarchical lookup logic (data tier)
- External adapters (ECB) will be restructured as standalone CLI tools (ingestion tier)
- Subtask 17.1 (ECB worker context) deferred as it's handled by external adapter design

## Task Master Reference

**Tag**: market-information-management  
**Task**: 17 - Wire ECB adapter into multi-tenant market data architecture

**Subtasks**:
- 17.1: ⏸️ Deferred (per ADR-0026 - ECB adapter moving to standalone CLI)
- 17.2: ✅ Dataset model extension
- 17.3: ✅ Hierarchical lookup
- 17.4: ✅ Entitlements migration
- 17.5: ✅ Access control errors
- 17.6: ✅ Tests

## Test Plan

- [x] Unit tests for hierarchical lookup logic
- [x] Access control tests for restricted datasets
- [x] Entitlement expiration and revocation tests
- [x] Private dataset isolation tests
- [ ] Migration applies cleanly
- [ ] Build passes
- [ ] CI passes

## Database Changes

**Migration**: `V23__tenant_data_entitlements.sql`

```sql
CREATE TABLE tenant_data_entitlements (
    id UUID PRIMARY KEY,
    tenant_id VARCHAR(255) NOT NULL,
    dataset_code VARCHAR(255) NOT NULL,
    is_active BOOLEAN NOT NULL DEFAULT TRUE,
    granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
    expires_at TIMESTAMPTZ NULL,
    UNIQUE (tenant_id, dataset_code)
);
```