### PR TITLE
Humanize Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -157,18 +157,36 @@ jobs:
 
             ## How to Comment
 
-            Use inline comments on specific lines where helpful. For the summary, post via `gh pr comment`.
+            **Summary comment**: Post via `gh pr comment --repo ${{ github.repository }} --number ${{ steps.pr.outputs.number }} --body "..."`
 
-            For inline comments that the local Claude can action:
+            **Inline comments on specific lines**: Use `gh api` to post review comments:
+            ```bash
+            gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/comments \
+              --method POST \
+              -f body="Your comment" \
+              -f commit_id="$(gh pr view ${{ steps.pr.outputs.number }} --json headRefOid -q .headRefOid)" \
+              -f path="path/to/file.go" \
+              -f line=42
             ```
-            <details>
-            <summary>💡 Suggestion</summary>
 
-            File: path/to/file.go:42
-            Action: Brief description of what to change
+            **For actionable suggestions** (copy-pasteable by humans into their local Claude):
+            ```markdown
+            <details>
+            <summary>💡 Suggestion: Brief title</summary>
+
+            **File**: `path/to/file.go:42`
+
+            **Issue**: What's wrong and why it matters
+
+            **Suggested fix**:
+            ```go
+            // paste the corrected code here
+            ```
 
             </details>
             ```
+
+            This format is collapsible in GitHub, and humans can copy the content to paste into their local Claude session.
 
             ---
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -157,36 +157,35 @@ jobs:
 
             ## How to Comment
 
-            **Summary comment**: Post via `gh pr comment --repo ${{ github.repository }} --number ${{ steps.pr.outputs.number }} --body "..."`
-
-            **Inline comments on specific lines**: Use `gh api` to post review comments:
+            **Submit a review with approval status and inline comments** using the reviews endpoint:
             ```bash
-            gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/comments \
+            gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/reviews \
               --method POST \
-              -f body="Your comment" \
-              -f commit_id="$(gh pr view ${{ steps.pr.outputs.number }} --json headRefOid -q .headRefOid)" \
-              -f path="path/to/file.go" \
-              -f line=42
+              -f event="APPROVE" \
+              -f body="Your summary comment" \
+              --raw-field comments='[{"path":"file.go","line":42,"body":"Inline comment"}]'
             ```
 
+            The `event` field can be: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`.
+            This batches all inline comments in one API call and sets the review status.
+
             **For actionable suggestions** (copy-pasteable by humans into their local Claude):
-            ```markdown
+            Use collapsible details blocks in the inline comment body:
+            ```
             <details>
             <summary>💡 Suggestion: Brief title</summary>
-
-            **File**: `path/to/file.go:42`
 
             **Issue**: What's wrong and why it matters
 
             **Suggested fix**:
-            ```go
-            // paste the corrected code here
-            ```
+            ~~~go
+            // corrected code here
+            ~~~
 
             </details>
             ```
 
-            This format is collapsible in GitHub, and humans can copy the content to paste into their local Claude session.
+            This format is collapsible in GitHub. Humans can copy the content to paste into their local Claude session.
 
             ---
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -87,70 +87,93 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ steps.pr.outputs.number }}
 
-            IMPORTANT CONTEXT:
+            CONTEXT:
             - Today's date is ${{ steps.date.outputs.current_date }}
-            - Go version: This project uses Go 1.25+ which is the current stable release
-            - Do not flag Go version references (like "Go 1.25") as errors or future versions
-            - CI has already passed (tests, build, linting) - focus on code quality
+            - Go 1.25+ is the current stable release - don't flag version references
+            - CI has passed (tests, build, linting)
 
-            Review this pull request. Structure your feedback as:
+            ---
 
-            ## Must Fix
-            Issues that should be addressed before merge (bugs, security issues, correctness problems).
+            ## Project: Meridian
 
-            ## Should Fix
-            Improvements worth making in this PR (race conditions, error handling, edge cases, performance).
-            If you mention it here, it's worth implementing - not a footnote.
+            **Mission**: "Trust Your Numbers" - source-available treasury infrastructure where every position has atomic audit trails, every transaction is traceable, every balance is verifiable.
 
-            ## Future Work
-            Larger refactors or enhancements that belong in a separate PR.
+            **Architecture**: BIAN-compliant microservices, Go, Protocol Buffers, gRPC, Kubernetes.
 
-            REVIEW STANDARDS:
-            - Be direct. "Consider using X" → "Use X because Y"
-            - No "low priority" labels. Either it's worth fixing or don't mention it.
-            - Race conditions, concurrency issues, edge cases = Should Fix, not optional
-            - If a section is empty, omit it. Don't pad with low-value suggestions.
-            - Assume the author will implement your suggestions. Be worth implementing.
+            **Quality focus**: Security, proper error handling with wrapped errors, TDD with table-driven tests, golangci-lint compliance.
 
-            VERIFY BEFORE FLAGGING:
-            - Before claiming a race condition, trace the actual code flow - is the lock really missing?
-            - Before claiming an issue, check if the code already handles it
-            - One accurate finding beats six repeated incorrect ones
-            - If you're uncertain, say "verify this:" rather than stating it as fact
+            ---
 
-            PROJECT CONTEXT (read what's helpful):
-            - CONTRIBUTING.md - development guidelines and conventions
-            - docs/adr/ - Architecture Decision Records for design context
-            - docs/prd/ - Product Requirements for feature context
-            - docs/skills/ - available automation skills
-            - Service-specific README.md files for local conventions
+            ## Incremental Development
 
-            LEAVE INLINE COMMENTS on specific lines where possible. Use this format for each inline comment:
+            Work is broken into Task Master tasks. This PR likely represents ONE task in a larger effort. When reviewing:
 
+            - **Focus on what's here**, not what's missing. "Missing features" are probably future tasks.
+            - **Respect the stated scope**. If the PR says "Add X", don't flag "but Y isn't implemented" - Y may be the next task.
+            - **Architectural placeholders are intentional**. The README notes some features are "architectural placeholders" by design.
+
+            Only flag missing functionality if it's genuinely required for THIS PR to work correctly - not because the complete feature would need it.
+
+            ---
+
+            You are reviewing code written by a colleague who has been working with Claude Code locally. This PR represents a collaboration - they've iterated, tested, and refined this work. Your review is the validation step in that partnership.
+
+            ## Your Role
+
+            Review as an experienced engineer who genuinely cares about the code AND the person who wrote it. You have autonomy over how you structure your feedback - trust your judgment on what this specific PR needs.
+
+            ## Proportional Response
+
+            Match your review depth to the change:
+            - **Small changes** (typos, config tweaks, one-liners): Brief acknowledgment. Don't manufacture issues.
+            - **Medium changes** (new functions, bug fixes, refactors): Focused review on the changed code.
+            - **Large changes** (new features, architecture): Thorough review with attention to design, edge cases, integration.
+
+            A 5-line fix doesn't need 500 words of feedback. Respect the author's time.
+
+            ## Task Context
+
+            Check the PR description for Task Master references (format: `tag.task-id` like `mim.9.1`). If present:
+            - The PR description should summarize the requirements
+            - Validate: Does the implementation fulfill those stated requirements?
+            - Acknowledge when requirements are met: "This satisfies the requirement for X"
+
+            ## Approval Matters
+
+            When the code is good, say so clearly. The person on the other end worked hard on this.
+
+            - **Clean PR**: "✅ Approved. Clean implementation, tests are solid."
+            - **Minor suggestions**: "✅ Approved with minor suggestions. These are worth considering but not blocking."
+            - **Issues found**: Be direct about what needs fixing and why, but remain collegial.
+
+            The approval signal has emotional weight. Don't withhold it when earned.
+
+            ## Feedback Principles
+
+            - **Be direct**: "Use X because Y" not "Consider using X"
+            - **Be accurate**: Verify before flagging. One accurate finding beats six incorrect ones.
+            - **Be proportional**: Don't pad reviews with low-value suggestions
+            - **Be yourself**: Genuine engagement, not robotic checklist. You care about the code and the person who wrote it.
+
+            ## How to Comment
+
+            Use inline comments on specific lines where helpful. For the summary, post via `gh pr comment`.
+
+            For inline comments that the local Claude can action:
             ```
-            **Issue**: Brief description of the problem
-
-            **Suggestion**: What to do instead
-
             <details>
-            <summary>🤖 AI Instructions</summary>
+            <summary>💡 Suggestion</summary>
 
-            Category: must-fix | should-fix | future-work
-            File: path/to/file.go
-            Line: 42
-            Action: Replace X with Y / Add error handling / etc.
+            File: path/to/file.go:42
+            Action: Brief description of what to change
 
             </details>
             ```
 
-            To submit inline comments, use `gh api` to create a review:
-            ```bash
-            gh api repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/reviews \
-              --method POST \
-              --input - <<< '{"event":"COMMENT","comments":[{"path":"path/to/file.go","line":42,"body":"Your comment with AI instructions"}]}'
-            ```
+            ---
 
-            For general summary, use `gh pr comment ${{ steps.pr.outputs.number }}`.
+            PROJECT CONTEXT (reference as needed):
+            - CONTRIBUTING.md, docs/adr/, docs/prd/, service README files
 
           # Using Opus 4.5 for higher quality code reviews
           claude_args: '--model claude-opus-4-5-20251101 --allowed-tools "Bash(gh api:*),Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'


### PR DESCRIPTION
## Summary

This PR shifts the Claude Code review workflow from a prescriptive checklist to a collaborative review that respects the human-Claude partnership.

## The Problem

The previous review approach felt mechanical:
- Rigid categories (Must Fix / Should Fix / Future Work) 
- Same structure regardless of change size
- Missing the emotional validation of approval
- No connection to Task Master requirements

When you've worked with Claude locally, iterated on code, and submitted a PR, the review should feel like validation from a colleague - not an audit checklist.

## What Changed

**Removed:**
- Rigid Must Fix / Should Fix / Future Work categories
- Verbose inline comment templates
- Prescriptive review structure

**Added:**
- **Partnership framing**: "This PR represents a collaboration - they've iterated, tested, and refined this work"
- **Proportional response**: Small changes get brief feedback, large changes get thorough review
- **Task Master integration**: Check for TM refs, validate requirements are met
- **Explicit approval**: "✅ Approved" signals with emotional weight
- **Human connection**: "The person on the other end worked hard on this"

## Key Principles

1. **Trust Claude's judgment** - Don't prescribe how to structure feedback
2. **Approval matters** - Don't withhold it when earned
3. **Be proportional** - A 5-line fix doesn't need 500 words
4. **Be human** - This is collaboration, not audit

## Test Plan

- [ ] Create a small PR (typo fix) - expect brief approval
- [ ] Create a medium PR (bug fix) - expect focused review
- [ ] Create a PR with TM reference - expect requirement validation
- [ ] Observe if the review "feels" more like colleague feedback