### PR TITLE
fix: Trigger Claude review only after Test workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -155,6 +155,11 @@ jobs:
             - **Be proportional**: Don't pad reviews with low-value suggestions
             - **Be yourself**: Genuine engagement, not robotic checklist. You care about the code and the person who wrote it.
 
+            ## Priority Signals
+
+            Use 🔴 for blocking issues that must be fixed before merge.
+            Use 🟡 for suggestions and improvements that aren't blocking.
+
             ## How to Comment
 
             **Submit a review with approval status and inline comments** using the reviews endpoint:
@@ -169,7 +174,7 @@ jobs:
             The `event` field can be: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`.
             This batches all inline comments in one API call and sets the review status.
 
-            **Important**: Only mention inline comments in your summary if you actually include them in the `comments` array. Don't say "see inline comment below" without posting one.
+            **CRITICAL**: Post inline comments BEFORE referencing them. Include them in the `comments` array when submitting the review. Never say "see inline comment below" without actually posting one.
 
             **For actionable suggestions** (copy-pasteable by humans into their local Claude):
             Use collapsible details blocks in the inline comment body:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   workflow_run:
-    workflows: ["Test", "Build & Test", "Code Quality"]
+    workflows: ["Test"]
     types: [completed]
 
 # Prevent duplicate reviews for the same PR branch

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -169,6 +169,8 @@ jobs:
             The `event` field can be: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`.
             This batches all inline comments in one API call and sets the review status.
 
+            **Important**: Only mention inline comments in your summary if you actually include them in the `comments` array. Don't say "see inline comment below" without posting one.
+
             **For actionable suggestions** (copy-pasteable by humans into their local Claude):
             Use collapsible details blocks in the inline comment body:
             ```


### PR DESCRIPTION
## Summary

Fixes two issues with Claude Code reviews:

1. **Duplicate reviews** - Changed trigger from 3 workflows to 1 (Test only)
2. **Missing actionable polish** - Added priority signals and execution guidance

## Changes

- Trigger only on "Test" workflow (was: Test, Build & Test, Code Quality)
- Added 🔴/🟡 priority signals for blocking vs suggestions
- Strengthened inline comment guidance: "Post BEFORE referencing"

## Problem

PR #629 received 3 identical Claude review comments, and one said "One minor inline comment below" but posted 0 inline comments.

**Root cause** (from Six Hats analysis):
- Duplicate reviews: Multiple workflow triggers
- Phantom inline comments: Prompt had INTENT but removed MECHANISM (execution guidance)

## Test plan

- [ ] Push a commit to a PR
- [ ] Verify only 1 Claude review comment appears
- [ ] Verify inline comments are posted when referenced
- [ ] Verify 🔴/🟡 signals appear for blocking/suggestions