### PR TITLE
feat: Add quality standards to Claude Code review prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -155,6 +155,22 @@ jobs:
             - **Be proportional**: Don't pad reviews with low-value suggestions
             - **Be yourself**: Genuine engagement, not robotic checklist. You care about the code and the person who wrote it.
 
+            ## Quality Standards
+
+            Hold PRs against these standards. Ask: **"What didn't we think about?"**
+
+            - **Both paths tested?** Happy path AND unhappy path (error conditions, edge cases, null handling)
+            - **Boundary conditions?** Invalid inputs, concurrent access, retry behavior, timeout handling
+            - **Scale and performance?** What happens at 10x, 100x load? Are there N+1 queries, unbounded loops, missing indexes?
+            - **Production readiness?** Observability (logs, metrics), graceful degradation, blast radius if this fails
+            - **Cross-system impact?** Dependencies on other services, data contracts, migration concerns
+            - **Security?** Input validation, authentication/authorization, secrets handling
+
+            For PRDs and architecture docs, also ask:
+            - What edge cases are missing from the spec?
+            - What will break at scale that isn't addressed?
+            - What cross-system dependencies are implied but not stated?
+
             ## Priority Signals
 
             Use 🔴 for blocking issues that must be fixed before merge.


### PR DESCRIPTION
## Summary

Embeds engineering values into the Claude Code review workflow so reviews ask **"What didn't we think about?"** - producing the kind of substantive feedback that Gemini gave on PR #631.

## Problem

PR #631 (Starlark Saga PRD) got a surface-level Claude approval, while Gemini identified 4 actionable gaps:
1. 5-minute lease expiry too slow for energy transactions → need reactive wake-up
2. Missing `correlation_id` for unified position view
3. Missing `emit_progress()` for mobile UX
4. UUID seed must be stable on replay for idempotency

These are exactly the questions our internal engineering standards (CLAUDE.md) say to ask - but the review prompt didn't reference them.

## Solution

Add a "Quality Standards" section that tells Claude to ask:
- **Both paths tested?** Happy + unhappy (error conditions, edge cases)
- **Boundary conditions?** Invalid inputs, concurrent access, retries, timeouts
- **Scale/performance?** 10x, 100x load, N+1 queries, missing indexes
- **Production readiness?** Observability, graceful degradation, blast radius
- **Cross-system impact?** Dependencies, data contracts, migrations
- **Security?** Input validation, auth, secrets

Plus PRD-specific questions about missing edge cases and unstated dependencies.

## Test plan

- [ ] Next PR should get more substantive review feedback
- [ ] Reviews should surface "what's missing" not just "what's wrong"