### PR TITLE
Enable SC2086 shellcheck rule and fix quoting violations

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -19,5 +19,5 @@ disable=SC2120
 # Disable SC2262: Alias in same parsing unit (fix these scripts to use functions)
 disable=SC2262
 
-# TODO: Re-enable these and fix scripts incrementally:
-# - SC2086: Double quote to prevent globbing (many existing scripts need fixes)
+# SC2086 (Double quote to prevent globbing) is now ENABLED
+# All scripts have been fixed. Intentional word-splitting is documented with inline disable comments.

--- a/scripts/calculate-coupling-metrics.sh
+++ b/scripts/calculate-coupling-metrics.sh
@@ -30,7 +30,7 @@ echo -e "${YELLOW}[1/4] Running coupling analysis...${NC}"
 
 # Step 2: Extract services list
 SERVICES=$(jq -r '.services_analyzed[]' "${TEMP_ANALYSIS}")
-echo -e "${YELLOW}[2/4] Services analyzed: $(echo $SERVICES | tr '\n' ' ')${NC}"
+echo -e "${YELLOW}[2/4] Services analyzed: $(echo "$SERVICES" | tr '\n' ' ')${NC}"
 
 # Step 3: Calculate metrics using jq
 echo -e "${YELLOW}[3/4] Calculating coupling metrics...${NC}"

--- a/scripts/demo-seed-data.sh
+++ b/scripts/demo-seed-data.sh
@@ -116,6 +116,7 @@ create_account_with_deposit() {
 
     # Try to create account (will fail if exists - that's OK, idempotent)
     local create_result
+    # shellcheck disable=SC2086 # metadata_args must word-split for grpcurl -H flag
     create_result=$(grpcurl -plaintext ${metadata_args} \
         -d "{
             \"party_id\": \"${party_id}\",
@@ -155,6 +156,7 @@ create_account_with_deposit() {
         fi
 
         local deposit_result
+        # shellcheck disable=SC2086 # metadata_args must word-split for grpcurl -H flag
         deposit_result=$(grpcurl -plaintext ${metadata_args} \
             -d "{
                 \"account_id\": \"${target_account_id}\",
@@ -193,8 +195,8 @@ seed_post_office() {
 
     for i in {1..5}; do
         local acc_id="po-customer-${i}"
-        local party_id="PO-CUST-$(printf '%05d' $i)"
-        local iban="GB82WEST1234500000$(printf '%03d' $i)"
+        local party_id="PO-CUST-$(printf '%05d' "$i")"
+        local iban="GB82WEST1234500000$(printf '%03d' "$i")"
 
         create_account_with_deposit \
             "${org_id}" \
@@ -221,8 +223,8 @@ seed_motive() {
 
     for i in {1..3}; do
         local acc_id="motive-provider-${i}"
-        local party_id="MOT-PROV-$(printf '%05d' $i)"
-        local iban="GB82MOTI1234500000$(printf '%03d' $i)"
+        local party_id="MOT-PROV-$(printf '%05d' "$i")"
+        local iban="GB82MOTI1234500000$(printf '%03d' "$i")"
 
         # Note: GPU-HOUR is a non-standard currency, we use USD as proxy.
         # In production, use actual asset codes from the Dynamic Asset Registry.
@@ -251,8 +253,8 @@ seed_un_wfp() {
 
     for i in {1..10}; do
         local acc_id="wfp-beneficiary-${i}"
-        local party_id="WFP-BEN-$(printf '%05d' $i)"
-        local iban="GB82UNWF1234500000$(printf '%03d' $i)"
+        local party_id="WFP-BEN-$(printf '%05d' "$i")"
+        local iban="GB82UNWF1234500000$(printf '%03d' "$i")"
 
         # Note: RICE-VOUCHER is a non-standard currency, we use USD as proxy.
         # In production, use actual asset codes from the Dynamic Asset Registry.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -365,19 +365,19 @@ check_k8s_cluster() {
     local network_available=true
     if [ "$is_remote_cluster" = true ]; then
         # Check if timeout command is available (not default on macOS)
-        local has_timeout=false
+        # Use a variable instead of alias (aliases don't work in same parsing unit)
+        local timeout_cmd=""
         if command -v timeout &> /dev/null; then
-            has_timeout=true
+            timeout_cmd="timeout"
         elif command -v gtimeout &> /dev/null; then
             # GNU timeout on macOS (from coreutils)
-            alias timeout=gtimeout
-            has_timeout=true
+            timeout_cmd="gtimeout"
         fi
 
         # Use curl as primary check (more reliable cross-platform)
         if command -v curl &> /dev/null; then
-            if [ "$has_timeout" = true ]; then
-                if ! timeout 2 curl -sI --fail https://google.com &>/dev/null; then
+            if [ -n "$timeout_cmd" ]; then
+                if ! "$timeout_cmd" 2 curl -sI --fail https://google.com &>/dev/null; then
                     network_available=false
                 fi
             else
@@ -387,8 +387,8 @@ check_k8s_cluster() {
             fi
         # Fallback to nc and host if curl not available
         elif command -v nc &> /dev/null && command -v host &> /dev/null; then
-            if [ "$has_timeout" = true ]; then
-                if ! timeout 2 nc -z 8.8.8.8 53 2>/dev/null || ! timeout 2 host google.com >/dev/null 2>&1; then
+            if [ -n "$timeout_cmd" ]; then
+                if ! "$timeout_cmd" 2 nc -z 8.8.8.8 53 2>/dev/null || ! "$timeout_cmd" 2 host google.com >/dev/null 2>&1; then
                     network_available=false
                 fi
             else

--- a/scripts/kafka-watch.sh
+++ b/scripts/kafka-watch.sh
@@ -15,7 +15,7 @@ echo ""
 # Watch both topics in parallel
 {
   echo "=== current-account.deposits ==="
-  kubectl exec -it $KAFKA_POD -- kafka-console-consumer.sh \
+  kubectl exec -it "$KAFKA_POD" -- kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
     --topic current-account.deposits \
     --from-beginning
@@ -23,7 +23,7 @@ echo ""
 
 {
   echo "=== financial-accounting.postings ==="
-  kubectl exec -it $KAFKA_POD -- kafka-console-consumer.sh \
+  kubectl exec -it "$KAFKA_POD" -- kafka-console-consumer.sh \
     --bootstrap-server localhost:9092 \
     --topic financial-accounting.postings \
     --from-beginning


### PR DESCRIPTION
## Summary

- Re-enable the SC2086 shellcheck rule (double quote to prevent globbing) and fix all shell scripts to comply
- Fix SC2262 violation in doctor.sh by replacing alias with variable

## Changes Made

| File | Change |
|------|--------|
| `.shellcheckrc` | Mark SC2086 as enabled (was previously disabled via TODO) |
| `scripts/kafka-watch.sh` | Quote `$KAFKA_POD` variable |
| `scripts/calculate-coupling-metrics.sh` | Quote `$SERVICES` in echo |
| `scripts/demo-seed-data.sh` | Quote `$i` in printf calls, add inline disable for intentional word-splitting |
| `scripts/doctor.sh` | Replace alias with variable (fixes SC2262 - alias in same parsing unit) |

## Technical Details

**SC2086**: This rule warns when variables are unquoted, which can cause word splitting and globbing issues. All violations have been fixed by adding proper quoting.

**Intentional Word-Splitting**: The `metadata_args` variable in `demo-seed-data.sh` intentionally needs word-splitting for the grpcurl `-H` flag. This is documented with an inline `# shellcheck disable=SC2086` comment explaining the reason.

**SC2262 Fix**: The `alias timeout=gtimeout` pattern in `doctor.sh` didn't work because aliases can't be defined and used in the same parsing unit. Replaced with a `timeout_cmd` variable that stores either `timeout` or `gtimeout`.

## Test Plan

- [x] All shell scripts pass `shellcheck` with no warnings/errors
- [x] Intentional word-splitting cases documented with inline comments
- [x] Pre-commit hook runs successfully

## Task Master

Task: tech-debt-cleanup.59