### PR TITLE
feat(party): Add UpdateVerificationMetadata method to persist provider metadata

### DIFF
--- a/services/party/adapters/persistence/verification_repository.go
+++ b/services/party/adapters/persistence/verification_repository.go
@@ -171,3 +171,33 @@ func (r *VerificationRepository) ListPendingVerifications(ctx context.Context) (
 	})
 	return verifications, err
 }
+
+// UpdateVerificationMetadata updates only the metadata field for a verification.
+// This is separate from status updates to allow metadata enrichment without
+// triggering optimistic locking checks.
+func (r *VerificationRepository) UpdateVerificationMetadata(
+	ctx context.Context,
+	verificationID uuid.UUID,
+	metadata string,
+) error {
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		updates := map[string]interface{}{
+			"metadata":   metadata,
+			"updated_at": time.Now(),
+		}
+
+		result := tx.Model(&PartyVerificationEntity{}).
+			Where("id = ?", verificationID).
+			Updates(updates)
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		if result.RowsAffected == 0 {
+			return ErrVerificationNotFound
+		}
+
+		return nil
+	})
+}

--- a/services/party/adapters/persistence/verification_repository_test.go
+++ b/services/party/adapters/persistence/verification_repository_test.go
@@ -390,3 +390,42 @@ func TestListPendingVerifications(t *testing.T) {
 		assert.Equal(t, "PENDING", v.Status)
 	}
 }
+
+func TestUpdateVerificationMetadata(t *testing.T) {
+	db, ctx, cleanup := setupVerificationTestDB(t)
+	defer cleanup()
+
+	partyID := createTestParty(t, db, ctx)
+	repo := NewVerificationRepository(db)
+
+	// Create verification
+	verification := &PartyVerificationEntity{
+		PartyID:        partyID,
+		VerificationID: "prov-metadata-test",
+		Provider:       "onfido",
+		Status:         "PENDING",
+	}
+	err := repo.CreateVerification(ctx, verification)
+	require.NoError(t, err)
+
+	// Update metadata
+	metadata := `{"document_type":"passport","confidence":0.95}`
+	err = repo.UpdateVerificationMetadata(ctx, verification.ID, metadata)
+	require.NoError(t, err)
+
+	// Verify metadata persisted
+	updated, err := repo.GetVerificationByID(ctx, verification.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.Metadata)
+	assert.JSONEq(t, metadata, *updated.Metadata)
+}
+
+func TestUpdateVerificationMetadata_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupVerificationTestDB(t)
+	defer cleanup()
+
+	repo := NewVerificationRepository(db)
+
+	err := repo.UpdateVerificationMetadata(ctx, uuid.New(), `{"test": "data"}`)
+	assert.ErrorIs(t, err, ErrVerificationNotFound)
+}

--- a/services/party/service/verification_service.go
+++ b/services/party/service/verification_service.go
@@ -62,6 +62,7 @@ type PartyRepository interface {
 type VerificationRepository interface {
 	CreateVerification(ctx context.Context, verification *persistence.PartyVerificationEntity) error
 	UpdateVerificationStatus(ctx context.Context, verificationID uuid.UUID, status string, riskScore *float64, reason *string, completedAt *time.Time, currentVersion int64) error
+	UpdateVerificationMetadata(ctx context.Context, verificationID uuid.UUID, metadata string) error
 	GetVerificationByID(ctx context.Context, id uuid.UUID) (*persistence.PartyVerificationEntity, error)
 	GetVerificationByProviderID(ctx context.Context, verificationID string) (*persistence.PartyVerificationEntity, error)
 	ListVerificationsByParty(ctx context.Context, partyID uuid.UUID) ([]persistence.PartyVerificationEntity, error)
@@ -267,8 +268,15 @@ func (s *VerificationService) UpdateVerification(ctx context.Context, req Update
 		}
 	}
 
-	// Update metadata separately if provided (simplified approach)
-	_ = metadataJSON // TODO: Add metadata update to repository if needed
+	// Update metadata separately if provided
+	if metadataJSON != nil {
+		if err := s.verificationRepo.UpdateVerificationMetadata(ctx, entity.ID, *metadataJSON); err != nil {
+			s.logger.Error("failed to update verification metadata",
+				"verification_id", entity.ID,
+				"error", err)
+			// Don't fail the overall operation - metadata is supplementary
+		}
+	}
 
 	return nil
 }

--- a/services/party/service/verification_service_test.go
+++ b/services/party/service/verification_service_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -43,6 +44,7 @@ type mockVerificationRepository struct {
 	verificationsByProvID map[string]*persistence.PartyVerificationEntity
 	createFn              func(ctx context.Context, v *persistence.PartyVerificationEntity) error
 	updateStatusFn        func(ctx context.Context, id uuid.UUID, status string, riskScore *float64, reason *string, completedAt *time.Time, version int64) error
+	updateMetadataFn      func(ctx context.Context, id uuid.UUID, metadata string) error
 	getByIDFn             func(ctx context.Context, id uuid.UUID) (*persistence.PartyVerificationEntity, error)
 	getByProviderIDFn     func(ctx context.Context, verificationID string) (*persistence.PartyVerificationEntity, error)
 	listByPartyFn         func(ctx context.Context, partyID uuid.UUID) ([]persistence.PartyVerificationEntity, error)
@@ -129,6 +131,19 @@ func (m *mockVerificationRepository) ListVerificationsByParty(ctx context.Contex
 		}
 	}
 	return result, nil
+}
+
+func (m *mockVerificationRepository) UpdateVerificationMetadata(ctx context.Context, id uuid.UUID, metadata string) error {
+	if m.updateMetadataFn != nil {
+		return m.updateMetadataFn(ctx, id, metadata)
+	}
+	v, ok := m.verifications[id]
+	if !ok {
+		return persistence.ErrVerificationNotFound
+	}
+	v.Metadata = &metadata
+	v.UpdatedAt = time.Now()
+	return nil
 }
 
 // mockEventPublisher implements VerificationEventPublisher for testing
@@ -502,4 +517,57 @@ func TestListVerificationsForParty(t *testing.T) {
 	verifications, err := svc.ListVerificationsForParty(ctx, partyID)
 	require.NoError(t, err)
 	assert.Len(t, verifications, 3)
+}
+
+func TestUpdateVerification_WithMetadata(t *testing.T) {
+	partyID := uuid.New()
+	partyRepo := &mockPartyRepository{}
+	verificationRepo := newMockVerificationRepository()
+	eventPublisher := &mockEventPublisher{}
+	provider := &mockProvider{}
+
+	svc, err := NewVerificationService(partyRepo, verificationRepo, provider, eventPublisher, nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+
+	// Create a pending verification
+	providerVerificationID := "prov-metadata"
+	entity := &persistence.PartyVerificationEntity{
+		PartyID:        partyID,
+		VerificationID: providerVerificationID,
+		Provider:       "onfido",
+		Status:         "PENDING",
+	}
+	err = verificationRepo.CreateVerification(ctx, entity)
+	require.NoError(t, err)
+
+	// Update with metadata
+	riskScore := 0.1
+	err = svc.UpdateVerification(ctx, UpdateVerificationRequest{
+		ProviderVerificationID: providerVerificationID,
+		Status:                 "APPROVED",
+		RiskScore:              &riskScore,
+		Metadata: map[string]string{
+			"document_type": "passport",
+			"confidence":    "0.95",
+		},
+	})
+	require.NoError(t, err)
+
+	// Verify metadata was persisted
+	updated, err := verificationRepo.GetVerificationByProviderID(ctx, providerVerificationID)
+	require.NoError(t, err)
+	require.NotNil(t, updated.Metadata, "metadata should be persisted")
+
+	// Verify metadata content is valid JSON with expected keys
+	var metadata map[string]string
+	err = json.Unmarshal([]byte(*updated.Metadata), &metadata)
+	require.NoError(t, err)
+	assert.Equal(t, "passport", metadata["document_type"])
+	assert.Equal(t, "0.95", metadata["confidence"])
+
+	// Verify event was still published
+	require.Len(t, eventPublisher.publishedEvents, 1)
+	assert.Equal(t, "APPROVED", eventPublisher.publishedEvents[0].Status)
 }


### PR DESCRIPTION
## Summary

- Adds `UpdateVerificationMetadata` method to `VerificationRepository` to persist provider-specific metadata to the `party_verification.metadata` JSONB column
- Resolves the TODO at `verification_service.go:271` that was leaving metadata unpersisted after webhook updates
- Metadata persistence uses non-blocking error handling (failures are logged but don't fail the overall status update)

## Changes Made

- **verification_repository.go**: Added `UpdateVerificationMetadata` method that updates only the metadata field without optimistic locking (metadata updates are enrichment operations)
- **verification_service.go**: Updated `VerificationRepository` interface with new method and replaced TODO with actual persistence call
- **verification_repository_test.go**: Added tests for `UpdateVerificationMetadata` success and not-found cases
- **verification_service_test.go**: Added test for end-to-end metadata persistence flow including mock implementation

## Technical Details

The implementation separates metadata updates from status updates because:
1. Status updates require version checking (optimistic locking) to prevent race conditions
2. Metadata updates are enrichment operations where last-write-wins is acceptable
3. Provider webhooks may send additional metadata details independently

## Test Plan

- [x] Unit tests for `UpdateVerificationMetadata` repository method
- [x] Unit test for not-found error case
- [x] Service-level test for metadata persistence flow
- [x] All existing tests continue to pass
- [x] golangci-lint passes with no issues

## Task Reference

Closes tech-debt-cleanup.58