### PR TITLE
feat(gateway): Implement proper readiness health checks

### DIFF
--- a/services/gateway/cmd/main.go
+++ b/services/gateway/cmd/main.go
@@ -10,7 +10,11 @@ import (
 	"time"
 
 	"github.com/meridianhub/meridian/services/gateway"
+	gwhealth "github.com/meridianhub/meridian/services/gateway/health"
+	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/redis/go-redis/v9"
 )
 
 // Build information set via ldflags during compilation.
@@ -63,11 +67,48 @@ func run(logger *slog.Logger) error {
 		"redis_enabled", config.RedisURL != "",
 		"backend_routes", len(config.Backends))
 
-	// Create server
+	// Initialize database pool for tenant resolution and health checks
+	dbPool, err := db.NewPostgresPool(context.Background(), db.DefaultConfig(config.DatabaseURL))
+	if err != nil {
+		return fmt.Errorf("failed to create database pool: %w", err)
+	}
+	defer func() { _ = dbPool.Close() }()
+
+	logger.Info("database pool initialized")
+
+	// Build health checkers list
+	checkers := []health.Checker{
+		health.NewDatabaseChecker(dbPool), // Critical dependency
+	}
+
+	// Initialize Redis client if configured (optional dependency)
+	var redisClient *redis.Client
+	if config.RedisURL != "" {
+		redisClient = redis.NewClient(&redis.Options{
+			Addr: config.RedisURL,
+		})
+		defer func() { _ = redisClient.Close() }()
+
+		// Verify Redis connection (log warning on failure, don't fail startup)
+		if err := redisClient.Ping(context.Background()).Err(); err != nil {
+			logger.Warn("redis connection failed (will operate in degraded mode)", "error", err)
+		} else {
+			logger.Info("redis client initialized")
+			checkers = append(checkers, health.NewRedisChecker(redisClient))
+		}
+	}
+
+	// Create health checker with all components
+	healthChecker := gwhealth.NewGatewayHealthChecker(gwhealth.Config{
+		Checkers:     checkers,
+		CheckTimeout: 5 * time.Second,
+	})
+
+	// Create server with health checker
 	// Note: Tenant resolver will be initialized in a future task when database connection is available.
 	// For now, pass nil to allow the server to start without tenant resolution.
 	// Health endpoints will work regardless of tenant resolver configuration.
-	server := gateway.NewServer(config, logger, nil)
+	server := gateway.NewServer(config, logger, nil, gateway.WithHealthChecker(healthChecker))
 
 	// Start server in background
 	serverErrors := make(chan error, 1)

--- a/services/gateway/health/backend_checker.go
+++ b/services/gateway/health/backend_checker.go
@@ -1,0 +1,113 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// CheckClient defines the interface for gRPC health checking.
+// This interface exists to allow testing with mocks, since grpc_health_v1.HealthClient
+// has methods with unexported parameters that cannot be easily mocked.
+type CheckClient interface {
+	Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest, opts ...interface{}) (*grpc_health_v1.HealthCheckResponse, error)
+}
+
+// grpcHealthClientAdapter wraps grpc_health_v1.HealthClient to implement HealthCheckClient.
+type grpcHealthClientAdapter struct {
+	client grpc_health_v1.HealthClient
+}
+
+// NewGRPCHealthClientAdapter creates a new adapter for a gRPC health client.
+func NewGRPCHealthClientAdapter(client grpc_health_v1.HealthClient) CheckClient {
+	return &grpcHealthClientAdapter{client: client}
+}
+
+func (a *grpcHealthClientAdapter) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest, _ ...interface{}) (*grpc_health_v1.HealthCheckResponse, error) {
+	return a.client.Check(ctx, req)
+}
+
+// BackendServiceChecker checks the health of a backend gRPC service.
+// Backend services are optional dependencies - if unavailable, the gateway
+// operates in degraded mode (returning 502 for affected routes).
+type BackendServiceChecker struct {
+	name         string
+	healthClient CheckClient
+	timeout      time.Duration
+}
+
+// NewBackendServiceChecker creates a new backend service health checker.
+//
+// Parameters:
+//   - name: The service name used for identification in health reports
+//   - healthClient: A gRPC health client for the backend service
+//   - timeout: Maximum time to wait for health check response
+//
+// Backend services are optional - failures result in StatusDegraded rather than
+// StatusUnhealthy, allowing the gateway to remain ready for routes not requiring
+// that backend.
+func NewBackendServiceChecker(name string, healthClient CheckClient, timeout time.Duration) *BackendServiceChecker {
+	return &BackendServiceChecker{
+		name:         name,
+		healthClient: healthClient,
+		timeout:      timeout,
+	}
+}
+
+// Name returns the service name used for this checker.
+func (b *BackendServiceChecker) Name() string {
+	return b.name
+}
+
+// Check performs a health check on the backend service using the standard
+// gRPC health check protocol.
+//
+// Health status mapping:
+//   - SERVING: StatusHealthy
+//   - NOT_SERVING, SERVICE_UNKNOWN: StatusDegraded
+//   - Connection error or timeout: StatusDegraded
+//
+// Backend services are optional dependencies, so failures never return
+// StatusUnhealthy. This allows the gateway to remain ready while individual
+// backends may be unavailable.
+func (b *BackendServiceChecker) Check(ctx context.Context) health.ComponentResult {
+	start := time.Now()
+
+	// Create timeout context for the health check
+	checkCtx, cancel := context.WithTimeout(ctx, b.timeout)
+	defer cancel()
+
+	resp, err := b.healthClient.Check(checkCtx, &grpc_health_v1.HealthCheckRequest{
+		Service: "", // Empty service name checks overall health
+	})
+	responseTime := time.Since(start)
+
+	// Backend services are optional - degrade gracefully if unavailable
+	status := health.StatusHealthy
+	message := fmt.Sprintf("%s service reachable", b.name)
+
+	if err != nil {
+		status = health.StatusDegraded
+		if checkCtx.Err() != nil {
+			message = fmt.Sprintf("%s service timeout after %s (degraded)", b.name, b.timeout)
+			err = checkCtx.Err()
+		} else {
+			message = fmt.Sprintf("%s service unreachable (degraded): %v", b.name, err)
+		}
+	} else if resp.Status != grpc_health_v1.HealthCheckResponse_SERVING {
+		status = health.StatusDegraded
+		message = fmt.Sprintf("%s service not serving (status: %s)", b.name, resp.Status.String())
+	}
+
+	return health.ComponentResult{
+		Name:         b.Name(),
+		Status:       status,
+		Message:      message,
+		ResponseTime: responseTime,
+		CheckedAt:    start,
+		Error:        err,
+	}
+}

--- a/services/gateway/health/backend_checker_test.go
+++ b/services/gateway/health/backend_checker_test.go
@@ -1,0 +1,124 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// Test error sentinels
+var (
+	errNotImplemented    = errors.New("not implemented")
+	errConnectionRefused = errors.New("connection refused")
+)
+
+// mockHealthClient implements grpc_health_v1.HealthClient for testing.
+type mockHealthClient struct {
+	response *grpc_health_v1.HealthCheckResponse
+	err      error
+	delay    time.Duration
+}
+
+func (m *mockHealthClient) Check(ctx context.Context, _ *grpc_health_v1.HealthCheckRequest, _ ...interface{}) (*grpc_health_v1.HealthCheckResponse, error) {
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return m.response, m.err
+}
+
+func (m *mockHealthClient) Watch(_ context.Context, _ *grpc_health_v1.HealthCheckRequest, _ ...interface{}) (grpc_health_v1.Health_WatchClient, error) {
+	return nil, errNotImplemented
+}
+
+func TestBackendServiceChecker_Name(t *testing.T) {
+	checker := NewBackendServiceChecker("party-service", nil, 5*time.Second)
+	assert.Equal(t, "party-service", checker.Name())
+}
+
+func TestBackendServiceChecker_Healthy(t *testing.T) {
+	mock := &mockHealthClient{
+		response: &grpc_health_v1.HealthCheckResponse{
+			Status: grpc_health_v1.HealthCheckResponse_SERVING,
+		},
+	}
+	checker := NewBackendServiceChecker("party-service", mock, 5*time.Second)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, "party-service", result.Name)
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Contains(t, result.Message, "reachable")
+	assert.Nil(t, result.Error)
+	assert.True(t, result.ResponseTime > 0)
+	assert.False(t, result.CheckedAt.IsZero())
+}
+
+func TestBackendServiceChecker_NotServing(t *testing.T) {
+	mock := &mockHealthClient{
+		response: &grpc_health_v1.HealthCheckResponse{
+			Status: grpc_health_v1.HealthCheckResponse_NOT_SERVING,
+		},
+	}
+	checker := NewBackendServiceChecker("party-service", mock, 5*time.Second)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, "party-service", result.Name)
+	assert.Equal(t, health.StatusDegraded, result.Status, "backend not serving should be degraded, not unhealthy")
+	assert.Contains(t, result.Message, "not serving")
+	assert.Nil(t, result.Error)
+}
+
+func TestBackendServiceChecker_Unreachable(t *testing.T) {
+	mock := &mockHealthClient{
+		err: errConnectionRefused,
+	}
+	checker := NewBackendServiceChecker("party-service", mock, 5*time.Second)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, "party-service", result.Name)
+	assert.Equal(t, health.StatusDegraded, result.Status, "backend unreachable should be degraded, not unhealthy")
+	assert.Contains(t, result.Message, "unreachable")
+	assert.Error(t, result.Error)
+}
+
+func TestBackendServiceChecker_Timeout(t *testing.T) {
+	mock := &mockHealthClient{
+		delay: 2 * time.Second, // Will exceed timeout
+	}
+	checker := NewBackendServiceChecker("party-service", mock, 50*time.Millisecond)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, "party-service", result.Name)
+	assert.Equal(t, health.StatusDegraded, result.Status, "backend timeout should be degraded")
+	assert.Contains(t, result.Message, "timeout")
+	require.Error(t, result.Error)
+	assert.True(t, errors.Is(result.Error, context.DeadlineExceeded))
+}
+
+func TestBackendServiceChecker_ServiceSpecific(t *testing.T) {
+	mock := &mockHealthClient{
+		response: &grpc_health_v1.HealthCheckResponse{
+			Status: grpc_health_v1.HealthCheckResponse_SERVICE_UNKNOWN,
+		},
+	}
+	checker := NewBackendServiceChecker("current-account", mock, 5*time.Second)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, "current-account", result.Name)
+	assert.Equal(t, health.StatusDegraded, result.Status)
+	assert.Contains(t, result.Message, "not serving")
+}

--- a/services/gateway/health/health.go
+++ b/services/gateway/health/health.go
@@ -1,0 +1,68 @@
+// Package health provides health checking capabilities for the Gateway service.
+package health
+
+import (
+	"context"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/health"
+)
+
+// DefaultCheckTimeout is the default timeout for health checks.
+const DefaultCheckTimeout = 5 * time.Second
+
+// Config contains configuration for creating a GatewayHealthChecker.
+type Config struct {
+	// Checkers is the list of health checkers to aggregate.
+	// Typically includes database, Redis, and backend service checkers.
+	Checkers []health.Checker
+
+	// CheckTimeout is the maximum time to wait for all health checks.
+	// Defaults to DefaultCheckTimeout (5s) if zero.
+	CheckTimeout time.Duration
+}
+
+// GatewayHealthChecker aggregates health checks from multiple components
+// for the Gateway service.
+//
+// Health Status Semantics:
+//   - Database: Critical dependency - unhealthy if down
+//   - Redis: Optional dependency - degrades gracefully
+//   - Backend services: Optional dependencies - degrade gracefully
+type GatewayHealthChecker struct {
+	aggregator   *health.Aggregator
+	checkTimeout time.Duration
+}
+
+// NewGatewayHealthChecker creates a new health checker with the provided configuration.
+//
+// The checker aggregates health from all provided checkers. The overall status
+// follows these rules:
+//   - If any component is Unhealthy: Overall is Unhealthy
+//   - If any component is Degraded (and none Unhealthy): Overall is Degraded
+//   - If all components are Healthy: Overall is Healthy
+func NewGatewayHealthChecker(config Config) *GatewayHealthChecker {
+	timeout := config.CheckTimeout
+	if timeout == 0 {
+		timeout = DefaultCheckTimeout
+	}
+
+	return &GatewayHealthChecker{
+		aggregator:   health.NewAggregator(config.Checkers),
+		checkTimeout: timeout,
+	}
+}
+
+// Check performs health checks on all registered components.
+// Returns a report containing the status of each component.
+func (g *GatewayHealthChecker) Check(ctx context.Context) *health.Report {
+	checkCtx, cancel := context.WithTimeout(ctx, g.checkTimeout)
+	defer cancel()
+
+	return g.aggregator.CheckAll(checkCtx)
+}
+
+// CheckTimeout returns the configured timeout for health checks.
+func (g *GatewayHealthChecker) CheckTimeout() time.Duration {
+	return g.checkTimeout
+}

--- a/services/gateway/health/health_test.go
+++ b/services/gateway/health/health_test.go
@@ -1,0 +1,139 @@
+package health
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test error sentinels
+var (
+	errHealthConnectionRefused = errors.New("connection refused")
+	errHealthConnectionTimeout = errors.New("connection timeout")
+)
+
+// mockChecker implements health.Checker for testing.
+type mockChecker struct {
+	name   string
+	status health.Status
+	err    error
+}
+
+func (m *mockChecker) Name() string {
+	return m.name
+}
+
+func (m *mockChecker) Check(_ context.Context) health.ComponentResult {
+	message := m.name + " check successful"
+	if m.err != nil {
+		message = m.name + " check failed: " + m.err.Error()
+	}
+	return health.ComponentResult{
+		Name:         m.name,
+		Status:       m.status,
+		Message:      message,
+		ResponseTime: 10 * time.Millisecond,
+		CheckedAt:    time.Now(),
+		Error:        m.err,
+	}
+}
+
+func TestGatewayHealthChecker_AllHealthy(t *testing.T) {
+	checkers := []health.Checker{
+		&mockChecker{name: "database", status: health.StatusHealthy},
+		&mockChecker{name: "redis", status: health.StatusHealthy},
+		&mockChecker{name: "backend-1", status: health.StatusHealthy},
+	}
+
+	checker := NewGatewayHealthChecker(Config{
+		Checkers:     checkers,
+		CheckTimeout: 5 * time.Second,
+	})
+
+	report := checker.Check(context.Background())
+
+	assert.Equal(t, health.StatusHealthy, report.OverallStatus())
+	assert.Len(t, report.Components, 3)
+}
+
+func TestGatewayHealthChecker_DatabaseUnhealthy(t *testing.T) {
+	checkers := []health.Checker{
+		&mockChecker{name: "database", status: health.StatusUnhealthy, err: errHealthConnectionRefused},
+		&mockChecker{name: "redis", status: health.StatusHealthy},
+		&mockChecker{name: "backend-1", status: health.StatusHealthy},
+	}
+
+	checker := NewGatewayHealthChecker(Config{
+		Checkers:     checkers,
+		CheckTimeout: 5 * time.Second,
+	})
+
+	report := checker.Check(context.Background())
+
+	assert.Equal(t, health.StatusUnhealthy, report.OverallStatus(), "database unhealthy should make overall unhealthy")
+}
+
+func TestGatewayHealthChecker_RedisDegraded(t *testing.T) {
+	checkers := []health.Checker{
+		&mockChecker{name: "database", status: health.StatusHealthy},
+		&mockChecker{name: "redis", status: health.StatusDegraded, err: errHealthConnectionTimeout},
+	}
+
+	checker := NewGatewayHealthChecker(Config{
+		Checkers:     checkers,
+		CheckTimeout: 5 * time.Second,
+	})
+
+	report := checker.Check(context.Background())
+
+	assert.Equal(t, health.StatusDegraded, report.OverallStatus(), "redis degraded should make overall degraded")
+}
+
+func TestGatewayHealthChecker_BackendDegraded(t *testing.T) {
+	checkers := []health.Checker{
+		&mockChecker{name: "database", status: health.StatusHealthy},
+		&mockChecker{name: "party-service", status: health.StatusDegraded},
+	}
+
+	checker := NewGatewayHealthChecker(Config{
+		Checkers:     checkers,
+		CheckTimeout: 5 * time.Second,
+	})
+
+	report := checker.Check(context.Background())
+
+	assert.Equal(t, health.StatusDegraded, report.OverallStatus(), "backend degraded should make overall degraded")
+}
+
+func TestGatewayHealthChecker_NoCheckers(t *testing.T) {
+	checker := NewGatewayHealthChecker(Config{
+		Checkers:     []health.Checker{},
+		CheckTimeout: 5 * time.Second,
+	})
+
+	report := checker.Check(context.Background())
+
+	assert.Equal(t, health.StatusHealthy, report.OverallStatus(), "empty checkers should be healthy")
+	assert.Empty(t, report.Components)
+}
+
+func TestGatewayHealthChecker_CheckTimeout(t *testing.T) {
+	checker := NewGatewayHealthChecker(Config{
+		Checkers:     []health.Checker{&mockChecker{name: "database", status: health.StatusHealthy}},
+		CheckTimeout: 5 * time.Second,
+	})
+
+	assert.Equal(t, 5*time.Second, checker.CheckTimeout())
+}
+
+func TestGatewayHealthChecker_DefaultTimeout(t *testing.T) {
+	checker := NewGatewayHealthChecker(Config{
+		Checkers: []health.Checker{&mockChecker{name: "database", status: health.StatusHealthy}},
+	})
+
+	assert.Equal(t, DefaultCheckTimeout, checker.CheckTimeout())
+}

--- a/services/gateway/server.go
+++ b/services/gateway/server.go
@@ -8,8 +8,11 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/meridianhub/meridian/services/gateway/auth"
+	gwhealth "github.com/meridianhub/meridian/services/gateway/health"
+	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	platformgateway "github.com/meridianhub/meridian/shared/platform/gateway"
 )
@@ -24,6 +27,7 @@ type Server struct {
 	tenantResolver        *platformgateway.TenantResolverMiddleware
 	authMiddleware        *auth.CombinedAuthMiddleware
 	tenantAuthzMiddleware *auth.TenantAuthorizationMiddleware
+	healthChecker         *gwhealth.GatewayHealthChecker
 }
 
 // ServerOption is a functional option for configuring the server.
@@ -33,6 +37,13 @@ type ServerOption func(*Server)
 func WithAuthMiddleware(authMiddleware *auth.CombinedAuthMiddleware) ServerOption {
 	return func(s *Server) {
 		s.authMiddleware = authMiddleware
+	}
+}
+
+// WithHealthChecker sets the health checker for readiness probes.
+func WithHealthChecker(healthChecker *gwhealth.GatewayHealthChecker) ServerOption {
+	return func(s *Server) {
+		s.healthChecker = healthChecker
 	}
 }
 
@@ -132,15 +143,89 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 // handleReady is the readiness probe endpoint.
 // Returns 200 OK if the server is ready to accept traffic.
 // This endpoint does NOT require tenant context.
+//
+// Health status to HTTP mapping:
+//   - Healthy: 200 OK (all critical dependencies up)
+//   - Degraded: 200 OK (critical dependencies up, optional may be down)
+//   - Unhealthy: 503 Service Unavailable (critical dependencies down)
+//   - Unknown: 503 Service Unavailable (cannot determine)
 func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
-	// TODO: Add actual readiness checks (database, redis, backends)
-	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write([]byte("READY")); err != nil {
-		s.logger.Warn("failed to write readiness response",
-			"error", err,
-			"endpoint", r.URL.Path,
-			"remote_addr", r.RemoteAddr)
+	// If no health checker configured, fail open (return ready)
+	// This maintains backwards compatibility during migration
+	if s.healthChecker == nil {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("READY")); err != nil {
+			s.logger.Warn("failed to write readiness response",
+				"error", err,
+				"endpoint", r.URL.Path,
+				"remote_addr", r.RemoteAddr)
+		}
+		return
+	}
+
+	// Execute health checks with timeout
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	report := s.healthChecker.Check(ctx)
+	overallStatus := report.OverallStatus()
+
+	// Map health status to HTTP status
+	if overallStatus == health.StatusHealthy || overallStatus == health.StatusDegraded {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("READY")); err != nil {
+			s.logger.Warn("failed to write readiness response",
+				"error", err,
+				"endpoint", r.URL.Path,
+				"remote_addr", r.RemoteAddr)
+		}
+
+		// Log degraded status as warning
+		if overallStatus == health.StatusDegraded {
+			s.logHealthCheckResult(ctx, report, overallStatus, slog.LevelWarn)
+		}
+	} else {
+		// Unhealthy or Unknown - not ready for traffic
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		if _, err := w.Write([]byte("NOT READY")); err != nil {
+			s.logger.Warn("failed to write readiness response",
+				"error", err,
+				"endpoint", r.URL.Path,
+				"remote_addr", r.RemoteAddr)
+		}
+
+		s.logHealthCheckResult(ctx, report, overallStatus, slog.LevelError)
+	}
+}
+
+// logHealthCheckResult logs the health check result with structured details.
+func (s *Server) logHealthCheckResult(ctx context.Context, report *health.Report, overallStatus health.Status, level slog.Level) {
+	// Build component status map for structured logging
+	componentStatuses := make(map[string]string)
+	for _, comp := range report.Components {
+		componentStatuses[comp.Name] = comp.Status.String()
+	}
+
+	s.logger.Log(ctx, level, "gateway readiness check",
+		"overall_status", overallStatus.String(),
+		"component_count", len(report.Components),
+		"components", componentStatuses)
+
+	// Log individual component failures at error level
+	if level >= slog.LevelWarn {
+		for _, comp := range report.Components {
+			if comp.Status == health.StatusUnhealthy || comp.Status == health.StatusUnknown {
+				s.logger.Error("component unhealthy",
+					"component", comp.Name,
+					"status", comp.Status.String(),
+					"message", comp.Message,
+					"response_time_ms", comp.ResponseTime.Milliseconds(),
+					"error", comp.Error)
+			}
+		}
 	}
 }
 

--- a/services/gateway/server_test.go
+++ b/services/gateway/server_test.go
@@ -2,6 +2,7 @@ package gateway
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -9,8 +10,17 @@ import (
 	"testing"
 	"time"
 
+	gwhealth "github.com/meridianhub/meridian/services/gateway/health"
+	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+// Test error sentinels
+var (
+	errConnectionTimeout = errors.New("connection timeout")
+	errConnectionRefused = errors.New("connection refused")
+	errServiceDown       = errors.New("down")
 )
 
 // TestHealthEndpoints_NoTenantContext verifies that health endpoints
@@ -438,4 +448,217 @@ func TestHealthEndpoints_NoPanicOnWriteError(t *testing.T) {
 			assert.Equal(t, http.StatusOK, w.statusCode)
 		})
 	}
+}
+
+// mockChecker implements health.Checker for testing.
+type mockChecker struct {
+	name   string
+	status health.Status
+	err    error
+}
+
+func (m *mockChecker) Name() string {
+	return m.name
+}
+
+func (m *mockChecker) Check(_ context.Context) health.ComponentResult {
+	message := m.name + " check successful"
+	if m.err != nil {
+		message = m.name + " check failed: " + m.err.Error()
+	}
+	return health.ComponentResult{
+		Name:         m.name,
+		Status:       m.status,
+		Message:      message,
+		ResponseTime: 10 * time.Millisecond,
+		CheckedAt:    time.Now(),
+		Error:        m.err,
+	}
+}
+
+// TestHandleReady_NoHealthChecker verifies backwards compatibility when health checker is nil.
+func TestHandleReady_NoHealthChecker(t *testing.T) {
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	server := NewServer(config, logger, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "READY", rec.Body.String())
+}
+
+// TestHandleReady_AllHealthy verifies 200 OK when all checks pass.
+func TestHandleReady_AllHealthy(t *testing.T) {
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	checkers := []health.Checker{
+		&mockChecker{name: "database", status: health.StatusHealthy},
+		&mockChecker{name: "redis", status: health.StatusHealthy},
+	}
+	healthChecker := gwhealth.NewGatewayHealthChecker(gwhealth.Config{
+		Checkers:     checkers,
+		CheckTimeout: 5 * time.Second,
+	})
+
+	server := NewServer(config, logger, nil, WithHealthChecker(healthChecker))
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "READY", rec.Body.String())
+}
+
+// TestHandleReady_Degraded verifies 200 OK when system is degraded (optional deps down).
+func TestHandleReady_Degraded(t *testing.T) {
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+
+	logHandler := &logCapture{}
+	logger := slog.New(logHandler)
+
+	checkers := []health.Checker{
+		&mockChecker{name: "database", status: health.StatusHealthy},
+		&mockChecker{name: "redis", status: health.StatusDegraded, err: errConnectionTimeout},
+	}
+	healthChecker := gwhealth.NewGatewayHealthChecker(gwhealth.Config{
+		Checkers:     checkers,
+		CheckTimeout: 5 * time.Second,
+	})
+
+	server := NewServer(config, logger, nil, WithHealthChecker(healthChecker))
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "degraded system should still return 200 OK")
+	assert.Equal(t, "READY", rec.Body.String())
+
+	// Verify warning was logged
+	require.GreaterOrEqual(t, len(logHandler.entries), 1)
+	found := false
+	for _, entry := range logHandler.entries {
+		if entry["level"] == "WARN" && entry["msg"] == "gateway readiness check" {
+			found = true
+			assert.Equal(t, "degraded", entry["overall_status"])
+			break
+		}
+	}
+	assert.True(t, found, "expected warning log for degraded status")
+}
+
+// TestHandleReady_Unhealthy verifies 503 when critical deps are down.
+func TestHandleReady_Unhealthy(t *testing.T) {
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+
+	logHandler := &logCapture{}
+	logger := slog.New(logHandler)
+
+	checkers := []health.Checker{
+		&mockChecker{name: "database", status: health.StatusUnhealthy, err: errConnectionRefused},
+		&mockChecker{name: "redis", status: health.StatusHealthy},
+	}
+	healthChecker := gwhealth.NewGatewayHealthChecker(gwhealth.Config{
+		Checkers:     checkers,
+		CheckTimeout: 5 * time.Second,
+	})
+
+	server := NewServer(config, logger, nil, WithHealthChecker(healthChecker))
+
+	req := httptest.NewRequest(http.MethodGet, "/ready", nil)
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code, "unhealthy system should return 503")
+	assert.Equal(t, "NOT READY", rec.Body.String())
+
+	// Verify error was logged
+	require.GreaterOrEqual(t, len(logHandler.entries), 1)
+	foundReadinessLog := false
+	foundComponentLog := false
+	for _, entry := range logHandler.entries {
+		if entry["level"] == "ERROR" && entry["msg"] == "gateway readiness check" {
+			foundReadinessLog = true
+			assert.Equal(t, "unhealthy", entry["overall_status"])
+		}
+		if entry["level"] == "ERROR" && entry["msg"] == "component unhealthy" {
+			foundComponentLog = true
+			assert.Equal(t, "database", entry["component"])
+		}
+	}
+	assert.True(t, foundReadinessLog, "expected error log for unhealthy status")
+	assert.True(t, foundComponentLog, "expected error log for unhealthy component")
+}
+
+// TestHandleReady_WithHealthChecker_LegacyEndpoints verifies legacy endpoints also use health checker.
+func TestHandleReady_WithHealthChecker_LegacyEndpoints(t *testing.T) {
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	checkers := []health.Checker{
+		&mockChecker{name: "database", status: health.StatusUnhealthy, err: errServiceDown},
+	}
+	healthChecker := gwhealth.NewGatewayHealthChecker(gwhealth.Config{
+		Checkers:     checkers,
+		CheckTimeout: 5 * time.Second,
+	})
+
+	server := NewServer(config, logger, nil, WithHealthChecker(healthChecker))
+
+	// Test /readyz legacy endpoint
+	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	rec := httptest.NewRecorder()
+
+	server.mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rec.Code, "/readyz should also use health checker")
+	assert.Equal(t, "NOT READY", rec.Body.String())
+}
+
+// TestWithHealthChecker verifies the functional option works correctly.
+func TestWithHealthChecker(t *testing.T) {
+	config := &Config{
+		Port:        8080,
+		BaseDomain:  "api.example.com",
+		DatabaseURL: "postgres://localhost/test",
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	healthChecker := gwhealth.NewGatewayHealthChecker(gwhealth.Config{
+		Checkers:     []health.Checker{},
+		CheckTimeout: 5 * time.Second,
+	})
+
+	server := NewServer(config, logger, nil, WithHealthChecker(healthChecker))
+
+	assert.Equal(t, healthChecker, server.healthChecker)
 }


### PR DESCRIPTION
## Summary

- Replace the placeholder `handleReady` endpoint with real health checks that verify database and Redis connectivity
- Kubernetes readiness probes now accurately reflect Gateway service health
- Maintains backwards compatibility when health checker is not configured

## Changes Made

- **New `services/gateway/health/` package**:
  - `GatewayHealthChecker`: Aggregates health checks from multiple components
  - `BackendServiceChecker`: Checks backend gRPC services using standard health protocol
  - `CheckClient` interface: Allows mocking gRPC health clients in tests

- **Updated `services/gateway/server.go`**:
  - Added `healthChecker` field to Server struct
  - Added `WithHealthChecker` functional option
  - Implemented real health checks in `handleReady`:
    - Returns 200 OK for Healthy/Degraded status
    - Returns 503 Service Unavailable for Unhealthy/Unknown status
  - Added structured logging for health check results

- **Updated `services/gateway/cmd/main.go`**:
  - Initialize database pool for health checks
  - Optionally initialize Redis client if configured
  - Create and wire up GatewayHealthChecker with dependencies

## Technical Details

### Health Status Semantics
- **Database**: Critical dependency - unhealthy if down
- **Redis**: Optional dependency - degrades gracefully if unavailable
- **Backend services**: Optional dependencies - degrade gracefully

### HTTP Response Mapping
| Health Status | HTTP Response |
|--------------|---------------|
| Healthy | 200 OK |
| Degraded | 200 OK (logs warning) |
| Unhealthy | 503 Service Unavailable |
| Unknown | 503 Service Unavailable |

## Test Plan

- [x] Unit tests for BackendServiceChecker (healthy, not serving, unreachable, timeout)
- [x] Unit tests for GatewayHealthChecker (all healthy, database unhealthy, redis degraded, backend degraded, no checkers)
- [x] Integration tests for handleReady (no health checker, all healthy, degraded, unhealthy, legacy endpoints)
- [x] All existing gateway tests pass
- [x] Linter passes with no issues