### PR TITLE
feat(utilization-metering-consumer): Add configurable tenant-to-account mapping

### DIFF
--- a/services/utilization-metering-consumer/app/config.go
+++ b/services/utilization-metering-consumer/app/config.go
@@ -32,6 +32,9 @@ type Config struct {
 	// Tenant Zero configuration
 	TenantZeroID string // Required: Tenant ID for Meridian's platform billing tenant
 
+	// Tenant-to-Account Mapping
+	TenantAccountMapping string // Optional: JSON mapping of tenant UUIDs to account UUIDs
+
 	// HTTP server configuration
 	HTTPPort string // HTTP port for health checks and metrics (default: "8080")
 }
@@ -55,6 +58,7 @@ func LoadConfig() (*Config, error) {
 		AuditTopics:             defaultAuditTopics, // Use default topics
 		PositionKeepingEndpoint: env.GetEnvOrDefault("POSITION_KEEPING_ENDPOINT", ""),
 		TenantZeroID:            env.GetEnvOrDefault("TENANT_ZERO_ID", ""),
+		TenantAccountMapping:    env.GetEnvOrDefault("TENANT_ACCOUNT_MAPPING", ""),
 		HTTPPort:                env.GetEnvOrDefault("HTTP_PORT", "8080"),
 	}
 

--- a/services/utilization-metering-consumer/cmd/main.go
+++ b/services/utilization-metering-consumer/cmd/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/meridianhub/meridian/services/utilization-metering-consumer/adapters/grpc"
 	"github.com/meridianhub/meridian/services/utilization-metering-consumer/adapters/messaging"
 	"github.com/meridianhub/meridian/services/utilization-metering-consumer/app"
+	"github.com/meridianhub/meridian/services/utilization-metering-consumer/domain"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	"github.com/meridianhub/meridian/shared/platform/env"
@@ -182,12 +183,21 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("invalid TENANT_ZERO_ID: %w", err)
 	}
 
-	// For now, we map all tenants to tenant-zero's billing account
-	// In a real implementation, this would be loaded from configuration or a database
-	// TODO: Load tenant-to-account mapping from configuration or database
-	tenantAccountMap := make(map[uuid.UUID]uuid.UUID)
-	// Map tenant-zero to itself for self-billing
-	tenantAccountMap[tenantZeroID] = tenantZeroID
+	// Load tenant-to-account mapping from configuration
+	tenantAccountMap, err := domain.ParseTenantAccountMapping(config.TenantAccountMapping)
+	if err != nil {
+		return fmt.Errorf("failed to load tenant account mapping: %w", err)
+	}
+
+	// Ensure tenant-zero maps to itself if not explicitly configured
+	if _, exists := tenantAccountMap[tenantZeroID]; !exists {
+		logger.Info("tenant-zero not found in TENANT_ACCOUNT_MAPPING, mapping to itself",
+			"tenant_zero_id", tenantZeroID)
+		tenantAccountMap[tenantZeroID] = tenantZeroID
+	}
+
+	logger.Info("tenant account mapping loaded",
+		"mapping_count", len(tenantAccountMap))
 
 	// Initialize transformer with tenant account mapping
 	transformer := auditdomain.NewAuditEventTransformer(tenantAccountMap)

--- a/services/utilization-metering-consumer/domain/tenant_mapping.go
+++ b/services/utilization-metering-consumer/domain/tenant_mapping.go
@@ -1,0 +1,38 @@
+// Package domain provides core domain logic for the utilization-metering-consumer service.
+package domain
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// ParseTenantAccountMapping parses a JSON string mapping tenant UUIDs to account UUIDs.
+// Expected format: {"tenant_id_1": "account_id_1", "tenant_id_2": "account_id_2"}
+// Returns an empty map if the input string is empty.
+func ParseTenantAccountMapping(jsonStr string) (map[uuid.UUID]uuid.UUID, error) {
+	if jsonStr == "" {
+		return make(map[uuid.UUID]uuid.UUID), nil
+	}
+
+	var rawMap map[string]string
+	if err := json.Unmarshal([]byte(jsonStr), &rawMap); err != nil {
+		return nil, fmt.Errorf("failed to parse tenant account mapping JSON: %w", err)
+	}
+
+	result := make(map[uuid.UUID]uuid.UUID)
+	for tenantIDStr, accountIDStr := range rawMap {
+		tenantID, err := uuid.Parse(tenantIDStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid tenant_id '%s': %w", tenantIDStr, err)
+		}
+		accountID, err := uuid.Parse(accountIDStr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid account_id '%s' for tenant %s: %w", accountIDStr, tenantIDStr, err)
+		}
+		result[tenantID] = accountID
+	}
+
+	return result, nil
+}

--- a/services/utilization-metering-consumer/domain/tenant_mapping_test.go
+++ b/services/utilization-metering-consumer/domain/tenant_mapping_test.go
@@ -1,0 +1,100 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTenantAccountMapping_ValidJSON(t *testing.T) {
+	tenantID1 := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	accountID1 := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	tenantID2 := uuid.MustParse("00000000-0000-0000-0000-000000000002")
+	accountID2 := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	json := `{
+		"00000000-0000-0000-0000-000000000001": "11111111-1111-1111-1111-111111111111",
+		"00000000-0000-0000-0000-000000000002": "22222222-2222-2222-2222-222222222222"
+	}`
+
+	result, err := ParseTenantAccountMapping(json)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, accountID1, result[tenantID1])
+	assert.Equal(t, accountID2, result[tenantID2])
+}
+
+func TestParseTenantAccountMapping_SingleMapping(t *testing.T) {
+	tenantID := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	accountID := uuid.MustParse("12345678-1234-1234-1234-123456789012")
+
+	json := `{"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee": "12345678-1234-1234-1234-123456789012"}`
+
+	result, err := ParseTenantAccountMapping(json)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, accountID, result[tenantID])
+}
+
+func TestParseTenantAccountMapping_EmptyString(t *testing.T) {
+	result, err := ParseTenantAccountMapping("")
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+func TestParseTenantAccountMapping_EmptyJSON(t *testing.T) {
+	result, err := ParseTenantAccountMapping("{}")
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Empty(t, result)
+}
+
+func TestParseTenantAccountMapping_InvalidJSON(t *testing.T) {
+	_, err := ParseTenantAccountMapping(`{invalid json}`)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse tenant account mapping JSON")
+}
+
+func TestParseTenantAccountMapping_InvalidTenantUUID(t *testing.T) {
+	json := `{"not-a-uuid": "11111111-1111-1111-1111-111111111111"}`
+
+	_, err := ParseTenantAccountMapping(json)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid tenant_id")
+}
+
+func TestParseTenantAccountMapping_InvalidAccountUUID(t *testing.T) {
+	json := `{"00000000-0000-0000-0000-000000000001": "not-a-uuid"}`
+
+	_, err := ParseTenantAccountMapping(json)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid account_id")
+}
+
+func TestParseTenantAccountMapping_WhitespacePreserved(t *testing.T) {
+	// Ensure whitespace in JSON is handled correctly
+	tenantID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	accountID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	json := `
+	{
+		"00000000-0000-0000-0000-000000000001" : "11111111-1111-1111-1111-111111111111"
+	}
+	`
+
+	result, err := ParseTenantAccountMapping(json)
+
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, accountID, result[tenantID])
+}

--- a/services/utilization-metering-consumer/k8s/configmap.yaml
+++ b/services/utilization-metering-consumer/k8s/configmap.yaml
@@ -41,6 +41,18 @@ data:
   # WARNING: This should be set via Secret in production, not ConfigMap
   TENANT_ZERO_ID: "00000000-0000-0000-0000-000000000000"
 
+  # Tenant-to-Account Mapping (optional)
+  # JSON mapping of tenant UUIDs to account UUIDs for multi-tenant billing.
+  # If not specified or empty, tenant-zero will automatically map to itself.
+  # Format: {"tenant_id": "account_id", ...}
+  # Example:
+  #   TENANT_ACCOUNT_MAPPING: |
+  #     {
+  #       "00000000-0000-0000-0000-000000000001": "11111111-1111-1111-1111-111111111111",
+  #       "22222222-2222-2222-2222-222222222222": "33333333-3333-3333-3333-333333333333"
+  #     }
+  TENANT_ACCOUNT_MAPPING: ""
+
   # OpenTelemetry configuration
   OTEL_SERVICE_NAME: "utilization-metering-consumer"
   OTEL_SAMPLING_RATE: "0.1"


### PR DESCRIPTION
## Summary
- Replace hardcoded tenant-zero-only mapping with environment variable configuration that supports multi-tenant billing
- Add `TENANT_ACCOUNT_MAPPING` env var to config (JSON format: `{"tenant_id": "account_id"}`)
- Create `ParseTenantAccountMapping()` for UUID parsing and validation
- Tenant-zero fallback remains automatic when not configured
- Update Kubernetes configmap with documentation

## Changes Made
1. **app/config.go**: Add `TenantAccountMapping` field to Config struct
2. **domain/tenant_mapping.go**: Create JSON parser with UUID validation
3. **domain/tenant_mapping_test.go**: Comprehensive unit tests (valid JSON, empty string, invalid JSON, invalid UUIDs)
4. **cmd/main.go**: Integrate parsed mapping with tenant-zero fallback logic
5. **k8s/configmap.yaml**: Add environment variable documentation

## Technical Details
The implementation parses a JSON string mapping tenant IDs to account IDs:
```json
{
  "00000000-0000-0000-0000-000000000001": "11111111-1111-1111-1111-111111111111",
  "00000000-0000-0000-0000-000000000002": "22222222-2222-2222-2222-222222222222"
}
```

If tenant-zero is not explicitly configured, it's automatically mapped to itself (backward compatible).

## Testing
- [x] Unit tests for `ParseTenantAccountMapping` (8 test cases)
- [x] Build verification
- [x] All existing tests pass

## Task Master
- Tag: `tech-debt-cleanup`
- Task: `62` - Implement tenant-to-account mapping configuration in utilization-metering-consumer