### PR TITLE
feat(health): Add HTTPChecker and ECB health checks to market-information

### DIFF
--- a/services/market-information/cmd/main.go
+++ b/services/market-information/cmd/main.go
@@ -100,9 +100,10 @@ func run(logger *slog.Logger) error {
 
 	// Register health check service
 	healthChecker := service.NewHealthChecker(service.HealthCheckerConfig{
-		Logger:       logger,
-		ServiceName:  "market-information",
-		CheckTimeout: defaults.DefaultHealthCheckTimeout,
+		Logger:        logger,
+		ServiceName:   "market-information",
+		CheckTimeout:  defaults.DefaultHealthCheckTimeout,
+		ServiceConfig: cfg,
 	})
 	grpc_health_v1.RegisterHealthServer(grpcServer, healthChecker)
 

--- a/services/market-information/service/health.go
+++ b/services/market-information/service/health.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
+	"github.com/meridianhub/meridian/services/market-information/config"
 	"github.com/meridianhub/meridian/services/market-information/observability"
 	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/meridianhub/meridian/shared/platform/db"
@@ -24,6 +26,8 @@ type HealthCheckerConfig struct {
 	ServiceName string
 	// CheckTimeout is the maximum duration for health checks
 	CheckTimeout time.Duration
+	// ServiceConfig holds service-specific configuration for external dependencies
+	ServiceConfig config.Config
 }
 
 // HealthChecker implements the gRPC health check protocol with dependency aggregation.
@@ -35,6 +39,9 @@ type HealthChecker struct {
 	timeout     time.Duration
 }
 
+// DefaultECBHealthCheckEndpoint is the base ECB SDMX Web Service URL used for health checks.
+const DefaultECBHealthCheckEndpoint = "https://sdw-wsrest.ecb.europa.eu"
+
 // NewHealthChecker creates a new HealthChecker with health check aggregation.
 func NewHealthChecker(cfg HealthCheckerConfig) *HealthChecker {
 	// Build list of health checkers
@@ -44,8 +51,26 @@ func NewHealthChecker(cfg HealthCheckerConfig) *HealthChecker {
 	if cfg.Database != nil {
 		checkers = append(checkers, health.NewDatabaseChecker(cfg.Database))
 	}
-	// TODO: Add external service checkers when dependencies are added
-	// Example: checkers = append(checkers, NewExternalServiceChecker(...))
+
+	// Add ECB API health checker if ECB integration is enabled
+	if cfg.ServiceConfig.ECB.Enabled {
+		endpoint := cfg.ServiceConfig.ECB.Endpoint
+		if endpoint == "" {
+			endpoint = DefaultECBHealthCheckEndpoint
+		}
+
+		timeout := cfg.ServiceConfig.ECB.Timeout
+		if timeout == 0 {
+			timeout = 5 * time.Second // Default health check timeout
+		}
+
+		checkers = append(checkers, health.NewHTTPChecker(health.HTTPCheckerConfig{
+			Name:       "ecb-api",
+			Endpoint:   endpoint,
+			Timeout:    timeout,
+			HTTPClient: &http.Client{Timeout: timeout},
+		}))
+	}
 
 	aggregator := health.NewAggregator(checkers)
 

--- a/services/market-information/service/health_test.go
+++ b/services/market-information/service/health_test.go
@@ -3,10 +3,13 @@ package service
 import (
 	"context"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/meridianhub/meridian/services/market-information/config"
 	"github.com/meridianhub/meridian/shared/pkg/health"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,6 +73,185 @@ func TestHealthChecker_Check(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, grpc_health_v1.HealthCheckResponse_UNKNOWN, resp.Status)
+	})
+}
+
+func TestNewHealthChecker_WithECBEnabled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	// Start mock ECB server
+	ecbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ecbServer.Close()
+
+	t.Run("registers ECB checker when enabled", func(t *testing.T) {
+		checker := NewHealthChecker(HealthCheckerConfig{
+			Logger:       logger,
+			ServiceName:  "test-service",
+			CheckTimeout: 5 * time.Second,
+			ServiceConfig: config.Config{
+				ECB: config.ECBConfig{
+					Enabled:  true,
+					Endpoint: ecbServer.URL,
+					Timeout:  5 * time.Second,
+				},
+			},
+		})
+
+		require.NotNil(t, checker)
+
+		// Check that ECB component is registered by querying for it
+		resp, err := checker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+			Service: "ecb-api",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+	})
+
+	t.Run("ECB healthy when endpoint responds 200", func(t *testing.T) {
+		checker := NewHealthChecker(HealthCheckerConfig{
+			Logger:       logger,
+			ServiceName:  "test-service",
+			CheckTimeout: 5 * time.Second,
+			ServiceConfig: config.Config{
+				ECB: config.ECBConfig{
+					Enabled:  true,
+					Endpoint: ecbServer.URL,
+					Timeout:  5 * time.Second,
+				},
+			},
+		})
+
+		// Overall check should be SERVING
+		resp, err := checker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+	})
+}
+
+func TestNewHealthChecker_WithECBDisabled(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	t.Run("does not register ECB checker when disabled", func(t *testing.T) {
+		checker := NewHealthChecker(HealthCheckerConfig{
+			Logger:       logger,
+			ServiceName:  "test-service",
+			CheckTimeout: 5 * time.Second,
+			ServiceConfig: config.Config{
+				ECB: config.ECBConfig{
+					Enabled: false,
+				},
+			},
+		})
+
+		require.NotNil(t, checker)
+
+		// ECB component should not be registered, returning UNKNOWN
+		resp, err := checker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+			Service: "ecb-api",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, grpc_health_v1.HealthCheckResponse_UNKNOWN, resp.Status)
+	})
+
+	t.Run("still returns SERVING when ECB disabled", func(t *testing.T) {
+		checker := NewHealthChecker(HealthCheckerConfig{
+			Logger:       logger,
+			ServiceName:  "test-service",
+			CheckTimeout: 5 * time.Second,
+			ServiceConfig: config.Config{
+				ECB: config.ECBConfig{
+					Enabled: false,
+				},
+			},
+		})
+
+		// Overall check should still be SERVING (no ECB dependency)
+		resp, err := checker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+	})
+}
+
+func TestNewHealthChecker_WithECBUnhealthy(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	t.Run("returns NOT_SERVING when ECB returns 503", func(t *testing.T) {
+		// Start mock ECB server that returns 503
+		ecbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer ecbServer.Close()
+
+		checker := NewHealthChecker(HealthCheckerConfig{
+			Logger:       logger,
+			ServiceName:  "test-service",
+			CheckTimeout: 5 * time.Second,
+			ServiceConfig: config.Config{
+				ECB: config.ECBConfig{
+					Enabled:  true,
+					Endpoint: ecbServer.URL,
+					Timeout:  5 * time.Second,
+				},
+			},
+		})
+
+		// Overall check should be NOT_SERVING when ECB is unhealthy
+		resp, err := checker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING, resp.Status)
+	})
+
+	t.Run("returns NOT_SERVING when ECB unreachable", func(t *testing.T) {
+		checker := NewHealthChecker(HealthCheckerConfig{
+			Logger:       logger,
+			ServiceName:  "test-service",
+			CheckTimeout: 1 * time.Second,
+			ServiceConfig: config.Config{
+				ECB: config.ECBConfig{
+					Enabled:  true,
+					Endpoint: "http://192.0.2.1:9999", // Unreachable
+					Timeout:  500 * time.Millisecond,
+				},
+			},
+		})
+
+		// Overall check should be NOT_SERVING when ECB is unreachable
+		resp, err := checker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, grpc_health_v1.HealthCheckResponse_NOT_SERVING, resp.Status)
+	})
+}
+
+func TestNewHealthChecker_UsesDefaultEndpoint(t *testing.T) {
+	// This test verifies that the default ECB endpoint is used when not specified
+	// We can't actually test connectivity to ECB, but we can verify the checker is created
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	t.Run("uses default ECB endpoint when not specified", func(t *testing.T) {
+		checker := NewHealthChecker(HealthCheckerConfig{
+			Logger:       logger,
+			ServiceName:  "test-service",
+			CheckTimeout: 5 * time.Second,
+			ServiceConfig: config.Config{
+				ECB: config.ECBConfig{
+					Enabled:  true,
+					Endpoint: "", // Empty = use default
+					Timeout:  5 * time.Second,
+				},
+			},
+		})
+
+		require.NotNil(t, checker)
+
+		// ECB component should be registered (will be unhealthy in test env but that's OK)
+		resp, err := checker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+			Service: "ecb-api",
+		})
+		require.NoError(t, err)
+		// Can be SERVING or NOT_SERVING depending on network, but should NOT be UNKNOWN
+		assert.NotEqual(t, grpc_health_v1.HealthCheckResponse_UNKNOWN, resp.Status)
 	})
 }
 

--- a/shared/pkg/health/checkers.go
+++ b/shared/pkg/health/checkers.go
@@ -2,12 +2,17 @@ package health
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/meridianhub/meridian/shared/platform/db"
 	"github.com/redis/go-redis/v9"
 )
+
+// ErrUnexpectedStatusCode is returned when an HTTP health check receives a non-2xx status code.
+var ErrUnexpectedStatusCode = errors.New("unexpected HTTP status code")
 
 // DatabaseChecker checks the health of a PostgreSQL database connection pool.
 type DatabaseChecker struct {
@@ -141,6 +146,113 @@ func (k *KafkaChecker) Check(ctx context.Context) ComponentResult {
 
 	return ComponentResult{
 		Name:         k.Name(),
+		Status:       status,
+		Message:      message,
+		ResponseTime: responseTime,
+		CheckedAt:    start,
+		Error:        err,
+	}
+}
+
+// HTTPChecker checks the health of an HTTP endpoint.
+type HTTPChecker struct {
+	name       string
+	endpoint   string
+	httpClient *http.Client
+	timeout    time.Duration
+}
+
+// HTTPCheckerConfig configures an HTTP health checker.
+type HTTPCheckerConfig struct {
+	// Name is the component name (e.g., "ecb-api", "external-service")
+	Name string
+	// Endpoint is the URL to check
+	Endpoint string
+	// Timeout is the maximum duration for the health check request
+	Timeout time.Duration
+	// HTTPClient is an optional custom HTTP client (uses default if nil)
+	HTTPClient *http.Client
+}
+
+// NewHTTPChecker creates a new HTTP health checker.
+// Performs a HEAD request to the endpoint to verify connectivity.
+func NewHTTPChecker(cfg HTTPCheckerConfig) *HTTPChecker {
+	if cfg.Name == "" {
+		panic("NewHTTPChecker: name cannot be empty")
+	}
+	if cfg.Endpoint == "" {
+		panic("NewHTTPChecker: endpoint cannot be empty")
+	}
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 5 * time.Second // Default health check timeout
+	}
+
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: cfg.Timeout}
+	}
+
+	return &HTTPChecker{
+		name:       cfg.Name,
+		endpoint:   cfg.Endpoint,
+		httpClient: client,
+		timeout:    cfg.Timeout,
+	}
+}
+
+// Name returns the component name.
+func (h *HTTPChecker) Name() string {
+	return h.name
+}
+
+// Check performs an HTTP health check by sending a HEAD request to the endpoint.
+// Returns healthy if the endpoint responds with any 2xx status code.
+func (h *HTTPChecker) Check(ctx context.Context) ComponentResult {
+	start := time.Now()
+
+	// Create context with timeout for the health check
+	checkCtx, cancel := context.WithTimeout(ctx, h.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(checkCtx, http.MethodHead, h.endpoint, nil)
+	if err != nil {
+		return ComponentResult{
+			Name:         h.name,
+			Status:       StatusUnhealthy,
+			Message:      fmt.Sprintf("failed to create HTTP request: %v", err),
+			ResponseTime: time.Since(start),
+			CheckedAt:    start,
+			Error:        err,
+		}
+	}
+
+	resp, err := h.httpClient.Do(req)
+	responseTime := time.Since(start)
+
+	if err != nil {
+		return ComponentResult{
+			Name:         h.name,
+			Status:       StatusUnhealthy,
+			Message:      fmt.Sprintf("HTTP request failed: %v", err),
+			ResponseTime: responseTime,
+			CheckedAt:    start,
+			Error:        err,
+		}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	status := StatusHealthy
+	message := fmt.Sprintf("HTTP endpoint accessible (status %d)", resp.StatusCode)
+
+	// Accept any 2xx status code as healthy
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		status = StatusUnhealthy
+		message = fmt.Sprintf("HTTP endpoint returned non-success status: %d", resp.StatusCode)
+		err = fmt.Errorf("%w: %d", ErrUnexpectedStatusCode, resp.StatusCode)
+	}
+
+	return ComponentResult{
+		Name:         h.name,
 		Status:       status,
 		Message:      message,
 		ResponseTime: responseTime,

--- a/shared/pkg/health/checkers_test.go
+++ b/shared/pkg/health/checkers_test.go
@@ -3,6 +3,8 @@ package health
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -273,6 +275,200 @@ func TestKafkaChecker_Check_Unhealthy(t *testing.T) {
 	}
 	if result.Error == nil {
 		t.Error("Error should not be nil for unhealthy Kafka")
+	}
+}
+
+const componentNameHTTP = "http-test"
+
+// TestNewHTTPChecker_PanicsEmptyName verifies panic on empty name
+func TestNewHTTPChecker_PanicsEmptyName(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic for empty name")
+		}
+	}()
+	NewHTTPChecker(HTTPCheckerConfig{
+		Name:     "",
+		Endpoint: "http://example.com",
+	})
+}
+
+// TestNewHTTPChecker_PanicsEmptyEndpoint verifies panic on empty endpoint
+func TestNewHTTPChecker_PanicsEmptyEndpoint(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected panic for empty endpoint")
+		}
+	}()
+	NewHTTPChecker(HTTPCheckerConfig{
+		Name:     "test",
+		Endpoint: "",
+	})
+}
+
+// TestHTTPChecker_Name verifies the checker name
+func TestHTTPChecker_Name(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	checker := NewHTTPChecker(HTTPCheckerConfig{
+		Name:     componentNameHTTP,
+		Endpoint: server.URL,
+	})
+	if checker.Name() != componentNameHTTP {
+		t.Errorf("Name() = %v, want %s", checker.Name(), componentNameHTTP)
+	}
+}
+
+// TestHTTPChecker_Check_Healthy tests successful HTTP check with 200 OK
+func TestHTTPChecker_Check_Healthy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Errorf("Expected HEAD request, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	checker := NewHTTPChecker(HTTPCheckerConfig{
+		Name:     componentNameHTTP,
+		Endpoint: server.URL,
+		Timeout:  5 * time.Second,
+	})
+
+	result := checker.Check(context.Background())
+
+	if result.Name != componentNameHTTP {
+		t.Errorf("Name = %v, want %s", result.Name, componentNameHTTP)
+	}
+	if result.Status != StatusHealthy {
+		t.Errorf("Status = %v, want %v (error: %v)", result.Status, StatusHealthy, result.Error)
+	}
+	if result.Error != nil {
+		t.Errorf("Error = %v, want nil", result.Error)
+	}
+	if result.ResponseTime <= 0 {
+		t.Error("ResponseTime should be > 0")
+	}
+}
+
+// TestHTTPChecker_Check_Healthy2xx tests various 2xx status codes
+func TestHTTPChecker_Check_Healthy2xx(t *testing.T) {
+	statusCodes := []int{200, 201, 202, 204, 299}
+
+	for _, code := range statusCodes {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer server.Close()
+
+			checker := NewHTTPChecker(HTTPCheckerConfig{
+				Name:     componentNameHTTP,
+				Endpoint: server.URL,
+			})
+
+			result := checker.Check(context.Background())
+
+			if result.Status != StatusHealthy {
+				t.Errorf("Status = %v, want %v for status code %d", result.Status, StatusHealthy, code)
+			}
+		})
+	}
+}
+
+// TestHTTPChecker_Check_UnhealthyStatusCode tests non-2xx status codes
+func TestHTTPChecker_Check_UnhealthyStatusCode(t *testing.T) {
+	statusCodes := []int{400, 404, 500, 503}
+
+	for _, code := range statusCodes {
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(code)
+			}))
+			defer server.Close()
+
+			checker := NewHTTPChecker(HTTPCheckerConfig{
+				Name:     componentNameHTTP,
+				Endpoint: server.URL,
+			})
+
+			result := checker.Check(context.Background())
+
+			if result.Status != StatusUnhealthy {
+				t.Errorf("Status = %v, want %v for status code %d", result.Status, StatusUnhealthy, code)
+			}
+			if result.Error == nil {
+				t.Error("Error should not be nil for non-2xx status")
+			}
+		})
+	}
+}
+
+// TestHTTPChecker_Check_Timeout tests timeout behavior
+func TestHTTPChecker_Check_Timeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	checker := NewHTTPChecker(HTTPCheckerConfig{
+		Name:     componentNameHTTP,
+		Endpoint: server.URL,
+		Timeout:  50 * time.Millisecond,
+	})
+
+	result := checker.Check(context.Background())
+
+	if result.Status != StatusUnhealthy {
+		t.Errorf("Status = %v, want %v", result.Status, StatusUnhealthy)
+	}
+	if result.Error == nil {
+		t.Error("Error should not be nil for timeout")
+	}
+}
+
+// TestHTTPChecker_Check_NetworkError tests network error handling
+func TestHTTPChecker_Check_NetworkError(t *testing.T) {
+	// Use non-routable IP to simulate network failure
+	checker := NewHTTPChecker(HTTPCheckerConfig{
+		Name:     componentNameHTTP,
+		Endpoint: "http://192.0.2.1:9999", // TEST-NET-1, guaranteed to fail
+		Timeout:  1 * time.Second,
+	})
+
+	result := checker.Check(context.Background())
+
+	if result.Status != StatusUnhealthy {
+		t.Errorf("Status = %v, want %v", result.Status, StatusUnhealthy)
+	}
+	if result.Error == nil {
+		t.Error("Error should not be nil for network error")
+	}
+}
+
+// TestHTTPChecker_Check_CustomHTTPClient tests using a custom HTTP client
+func TestHTTPChecker_Check_CustomHTTPClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	customClient := &http.Client{Timeout: 10 * time.Second}
+
+	checker := NewHTTPChecker(HTTPCheckerConfig{
+		Name:       componentNameHTTP,
+		Endpoint:   server.URL,
+		HTTPClient: customClient,
+	})
+
+	result := checker.Check(context.Background())
+
+	if result.Status != StatusHealthy {
+		t.Errorf("Status = %v, want %v", result.Status, StatusHealthy)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add generic `HTTPChecker` to `shared/pkg/health` for reusable HTTP endpoint health checking
- Integrate ECB API health monitoring in market-information service when ECB integration is enabled (`ECB_ENABLED=true`)
- Use HEAD requests for efficient health probing (no response body parsing)
- Accept any 2xx status code as healthy

## Changes Made

### shared/pkg/health/checkers.go
- Add `HTTPChecker` struct with configurable name, endpoint, timeout, and HTTP client
- Add `HTTPCheckerConfig` for clean configuration
- Add `NewHTTPChecker` constructor with validation (panics on empty name/endpoint)
- Add `ErrUnexpectedStatusCode` static error for non-2xx responses

### services/market-information/service/health.go
- Add `ServiceConfig` field to `HealthCheckerConfig`
- Conditionally register ECB health checker when `ECB.Enabled` is true
- Use default endpoint (`https://sdw-wsrest.ecb.europa.eu`) when not specified

### services/market-information/cmd/main.go
- Pass `ServiceConfig: cfg` to health checker initialization

## Technical Details

The `HTTPChecker` follows existing patterns (DatabaseChecker, RedisChecker, KafkaChecker):
- Implements `Checker` interface with `Name()` and `Check(ctx)` methods
- Returns `ComponentResult` with status, message, response time, and error
- Uses context with timeout for health check requests

## Test Plan

- [x] Unit tests for HTTPChecker (panic, healthy, unhealthy status codes, timeout, network error)
- [x] Integration tests for ECB health check scenarios:
  - ECB enabled and healthy (mock server returns 200)
  - ECB enabled and unhealthy (mock server returns 503)
  - ECB enabled but unreachable (network timeout)
  - ECB disabled (no checker registered)
  - Default endpoint used when not specified
- [x] All existing health package tests pass
- [x] Linting passes

## Risk Assessment

Low risk:
- New functionality is additive (no changes to existing health check behavior)
- ECB checker only registered when `ECB_ENABLED=true` (opt-in)
- Follows established patterns in the codebase

## Related

Addresses TODO at `services/market-information/service/health.go:47`

Task: tech-debt-cleanup.65