### PR TITLE
feat(tenant): Add service-specific provisioning failure observability

### DIFF
--- a/services/tenant/observability/metrics.go
+++ b/services/tenant/observability/metrics.go
@@ -142,3 +142,9 @@ func RecordAlertSent(provider, severity, status string) {
 func SetAlertDLQDepth(depth int) {
 	alertDLQDepth.Set(float64(depth))
 }
+
+// GetServiceProvisioningFailuresMetric returns the service provisioning failures counter
+// for use in tests that need to verify metric behavior.
+func GetServiceProvisioningFailuresMetric() *prometheus.CounterVec {
+	return serviceProvisioningFailures
+}

--- a/services/tenant/provisioner/postgres_provisioner.go
+++ b/services/tenant/provisioner/postgres_provisioner.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/meridianhub/meridian/services/tenant/observability"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/sony/gobreaker/v2"
 	"gorm.io/driver/postgres"
@@ -313,6 +314,7 @@ func (p *PostgresProvisioner) provisionAllServices(ctx context.Context, status *
 		serviceDB, ok := p.serviceDbs[svc.Name]
 		if !ok {
 			logger.Error("service database not found", "service", svc.Name)
+			observability.IncrementServiceFailure(svc.Name)
 			p.markProvisioningFailed(ctx, status, fmt.Sprintf("no database connection for service: %s", svc.Name))
 			return fmt.Errorf("%w: %s", ErrServiceDatabaseNotFound, svc.Name)
 		}
@@ -340,6 +342,7 @@ func (p *PostgresProvisioner) provisionAllServices(ctx context.Context, status *
 				"service", svc.Name,
 				"breaker_state", "open",
 				"retry_after", retryAfter.Format(time.RFC3339))
+			observability.IncrementServiceFailure(svc.Name)
 			status.Services[i].State = ServiceStateCircuitOpen
 			status.Services[i].ErrorMessage = fmt.Sprintf(
 				"circuit breaker open for %s: too many recent failures. Retry after %s",
@@ -352,6 +355,7 @@ func (p *PostgresProvisioner) provisionAllServices(ctx context.Context, status *
 				"service", svc.Name,
 				"breaker_state", "half-open",
 				"max_requests", BreakerMaxRequests)
+			observability.IncrementServiceFailure(svc.Name)
 			status.Services[i].State = ServiceStateCircuitOpen
 			status.Services[i].ErrorMessage = fmt.Sprintf(
 				"circuit breaker half-open for %s: max test requests (%d) exceeded. Waiting for test results",
@@ -362,6 +366,7 @@ func (p *PostgresProvisioner) provisionAllServices(ctx context.Context, status *
 
 		if err != nil {
 			logger.Error("service migration failed", "service", svc.Name, "error", err)
+			observability.IncrementServiceFailure(svc.Name)
 			status.Services[i].State = ServiceStateFailed
 			status.Services[i].ErrorMessage = err.Error()
 			p.markProvisioningFailed(ctx, status, fmt.Sprintf("%s migrations failed: %v", svc.Name, err))

--- a/services/tenant/provisioner/postgres_provisioner_test.go
+++ b/services/tenant/provisioner/postgres_provisioner_test.go
@@ -1681,8 +1681,9 @@ func TestPostgresProvisioner_MigrationFailure_IncrementsServiceFailureMetric(t *
 	require.NoError(t, err)
 	defer prov.Close()
 
-	// Get initial metric count
-	initialCount := testutil.CollectAndCount(observability.GetServiceProvisioningFailuresMetric())
+	// Get initial metric value for the specific service label
+	counter := observability.GetServiceProvisioningFailuresMetric().WithLabelValues("failing-service")
+	initialVal := testutil.ToFloat64(counter)
 
 	// Attempt provisioning - should fail
 	err = prov.ProvisionSchemas(context.Background(), tenantID)
@@ -1690,6 +1691,6 @@ func TestPostgresProvisioner_MigrationFailure_IncrementsServiceFailureMetric(t *
 	assert.ErrorIs(t, err, ErrMigrationFailed)
 
 	// Verify the service failure metric was incremented
-	finalCount := testutil.CollectAndCount(observability.GetServiceProvisioningFailuresMetric())
-	assert.Greater(t, finalCount, initialCount, "Service failure metric should be incremented on migration failure")
+	finalVal := testutil.ToFloat64(counter)
+	assert.Equal(t, initialVal+1, finalVal, "Service failure metric should be incremented on migration failure")
 }

--- a/services/tenant/provisioner/postgres_provisioner_test.go
+++ b/services/tenant/provisioner/postgres_provisioner_test.go
@@ -8,7 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/meridianhub/meridian/services/tenant/observability"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -1645,4 +1647,49 @@ func TestFilterMigrationsAfter(t *testing.T) {
 			}
 		})
 	}
+}
+
+// =============================================================================
+// Service Failure Observability Tests
+// =============================================================================
+
+// TestPostgresProvisioner_MigrationFailure_IncrementsServiceFailureMetric verifies that
+// when a service migration fails, the observability.IncrementServiceFailure metric is called.
+func TestPostgresProvisioner_MigrationFailure_IncrementsServiceFailureMetric(t *testing.T) {
+	tc := setupTestContainer(t)
+	defer tc.cleanup(t)
+
+	// Create tenant
+	tenantID := tenant.MustNewTenantID("metric_test_tenant")
+	createTestTenant(t, tc.db, tenantID.String())
+
+	// Create a migration directory with invalid SQL that will fail
+	failingDir := filepath.Join(tc.migDir, "failing-service")
+	require.NoError(t, os.MkdirAll(failingDir, 0o755))
+	createTestMigration(t, failingDir, "20251201000000_broken.sql", `
+		THIS IS NOT VALID SQL AND WILL FAIL;
+	`)
+
+	config := &Config{
+		Services: []ServiceConfig{
+			{Name: "failing-service", MigrationPath: failingDir, DatabaseURL: tc.connStr},
+		},
+		ProvisioningTimeout: 30 * time.Second,
+	}
+
+	prov, err := NewPostgresProvisioner(tc.db, config)
+	require.NoError(t, err)
+	defer prov.Close()
+
+	// Get initial metric count
+	initialCount := testutil.CollectAndCount(observability.GetServiceProvisioningFailuresMetric())
+
+	// Attempt provisioning - should fail
+	err = prov.ProvisionSchemas(context.Background(), tenantID)
+	require.Error(t, err, "Provisioning should fail with invalid SQL")
+	assert.ErrorIs(t, err, ErrMigrationFailed)
+
+	// Verify the service failure metric was incremented
+	finalCount := testutil.CollectAndCount(observability.GetServiceProvisioningFailuresMetric())
+	assert.Greater(t, finalCount, initialCount, "Service failure metric should be incremented on migration failure")
 }

--- a/services/tenant/worker/provisioning_worker.go
+++ b/services/tenant/worker/provisioning_worker.go
@@ -505,9 +505,9 @@ func (w *ProvisioningWorker) markTenantAsActive(ctx context.Context, tenantID te
 }
 
 // markTenantAsFailed updates tenant status to provisioning_failed with error details.
-// TODO: When service-specific provisioning is implemented, call observability.IncrementServiceFailure(serviceName)
-// here based on which service (database, kafka, etc.) caused the failure. Currently, the provisioner
-// returns generic errors without service attribution.
+// Service-specific failure tracking is implemented in postgres_provisioner.go:provisionAllServices()
+// which calls observability.IncrementServiceFailure(serviceName) for each service failure type:
+// database connection errors, circuit breaker open/half-open states, and migration failures.
 func (w *ProvisioningWorker) markTenantAsFailed(ctx context.Context, tenantID tenant.TenantID, lastErr error, attempts int) {
 	tenant, getErr := w.repo.GetByID(ctx, tenantID)
 	if getErr != nil {


### PR DESCRIPTION
## Summary
- Add `observability.IncrementServiceFailure()` calls in `postgres_provisioner.go` to track which specific services fail during tenant provisioning
- Update comment in `provisioning_worker.go` to document that service-specific tracking is now implemented
- Add test to verify metric increments on migration failure

## Technical Details

Failure points now tracked by service name:
| Failure Type | Location | Description |
|--------------|----------|-------------|
| Database not found | `provisionAllServices()` | Missing DB connection for service |
| Circuit breaker open | `provisionAllServices()` | Service unavailable due to repeated failures |
| Circuit breaker half-open | `provisionAllServices()` | Max test requests exceeded during recovery |
| Migration failure | `provisionAllServices()` | SQL execution error |

## Prometheus Metric Output

After this change, Prometheus exposes per-service failure counts:
```
tenant_service_provisioning_failures_total{service_name="party"} 5
tenant_service_provisioning_failures_total{service_name="current-account"} 2
```

## Test Plan
- [x] Unit tests for observability package pass
- [x] Integration tests for provisioner pass
- [x] New test `TestPostgresProvisioner_MigrationFailure_IncrementsServiceFailureMetric` verifies metric increment
- [x] TODO comment removed from provisioning_worker.go

## Related
Completes tech-debt-cleanup.61