### PR TITLE
feat(market-information): add observation count and dataset version to proto responses

### DIFF
--- a/services/market-information/adapters/persistence/observation_repository.go
+++ b/services/market-information/adapters/persistence/observation_repository.go
@@ -578,5 +578,39 @@ func (r *ObservationRepository) buildObservation(
 	return builder.Build()
 }
 
+// CountByDataset returns the total number of observations for a dataset.
+// When includeSuperseded is false, only active (non-superseded) observations are counted.
+// Returns 0 (not an error) if the dataset exists but has no observations.
+// Returns ErrDataSetNotFound if the dataset does not exist.
+func (r *ObservationRepository) CountByDataset(ctx context.Context, dataSetCode string, includeSuperseded bool) (int64, error) {
+	var count int64
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		// Resolve dataset definition ID from code
+		dataSetDefID, err := r.resolveDataSetDefinitionID(ctx, tx, dataSetCode)
+		if err != nil {
+			return err
+		}
+
+		query := `
+			SELECT COUNT(*)
+			FROM market_price_observation
+			WHERE dataset_definition_id = $1`
+
+		if !includeSuperseded {
+			query += " AND superseded_by IS NULL"
+		}
+
+		err = tx.QueryRow(ctx, query, dataSetDefID).Scan(&count)
+		if err != nil {
+			return fmt.Errorf("failed to count observations: %w", err)
+		}
+
+		return nil
+	})
+
+	return count, err
+}
+
 // Ensure ObservationRepository implements domain.ObservationRepository.
 var _ domain.ObservationRepository = (*ObservationRepository)(nil)

--- a/services/market-information/adapters/persistence/observation_repository_test.go
+++ b/services/market-information/adapters/persistence/observation_repository_test.go
@@ -951,3 +951,113 @@ func TestObservationRepository_HierarchicalLookup_RestrictedAccessInactive(t *te
 	assert.ErrorIs(t, err, domain.ErrAccessDenied,
 		"RESTRICTED dataset should deny access with inactive entitlement")
 }
+
+func TestObservationRepository_CountByDataset_Basic(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupTestDataSetAndSource(t, tc)
+
+	now := time.Now()
+
+	// Insert 5 observations
+	for i := 0; i < 5; i++ {
+		obs, err := domain.NewMarketPriceObservation(
+			"FX_RATE_TEST",
+			source.ID(),
+			"EUR/USD/"+string(rune('0'+i)),
+			decimal.NewFromFloat(1.08+float64(i)*0.001),
+			"USD",
+			now.Add(time.Duration(i)*time.Minute),
+			now,
+			now.Add(24*time.Hour),
+			uuid.New(),
+			domain.QualityLevelActual,
+			source.TrustLevel(),
+		)
+		require.NoError(t, err)
+		err = tc.Repos.Observation.Record(ctx, obs)
+		require.NoError(t, err)
+	}
+
+	// Count should be 5
+	count, err := tc.Repos.Observation.CountByDataset(ctx, "FX_RATE_TEST", false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), count)
+}
+
+func TestObservationRepository_CountByDataset_ExcludesSuperseded(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	_, source := setupTestDataSetAndSource(t, tc)
+
+	now := time.Now()
+
+	// Insert 5 observations for the same resolution key
+	// They will progressively supersede each other based on quality
+	for i := 0; i < 5; i++ {
+		quality := domain.QualityLevelEstimate
+		if i >= 3 {
+			quality = domain.QualityLevelActual
+		}
+		if i >= 4 {
+			quality = domain.QualityLevelVerified
+		}
+		obs, err := domain.NewMarketPriceObservation(
+			"FX_RATE_TEST",
+			source.ID(),
+			"EUR/USD",
+			decimal.NewFromFloat(1.08+float64(i)*0.001),
+			"USD",
+			now.Add(time.Duration(i)*time.Minute),
+			now,
+			now.Add(24*time.Hour),
+			uuid.New(),
+			quality,
+			source.TrustLevel(),
+		)
+		require.NoError(t, err)
+		err = tc.Repos.Observation.Record(ctx, obs)
+		require.NoError(t, err)
+	}
+
+	// Count without superseded - should exclude the ones that were superseded
+	countWithoutSuperseded, err := tc.Repos.Observation.CountByDataset(ctx, "FX_RATE_TEST", false)
+	require.NoError(t, err)
+
+	// Count with superseded - should include all 5
+	countWithSuperseded, err := tc.Repos.Observation.CountByDataset(ctx, "FX_RATE_TEST", true)
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(5), countWithSuperseded)
+	assert.Less(t, countWithoutSuperseded, countWithSuperseded,
+		"Non-superseded count should be less than total count")
+}
+
+func TestObservationRepository_CountByDataset_EmptyDataset(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	// Setup creates dataset but we don't insert any observations
+	setupTestDataSetAndSource(t, tc)
+
+	// Count for empty dataset should be 0
+	count, err := tc.Repos.Observation.CountByDataset(ctx, "FX_RATE_TEST", false)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestObservationRepository_CountByDataset_NonExistentDataset(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Count for non-existent dataset should return ErrDataSetNotFound
+	_, err := tc.Repos.Observation.CountByDataset(ctx, "NON_EXISTENT_DATASET", false)
+	assert.ErrorIs(t, err, domain.ErrDataSetNotFound)
+}

--- a/services/market-information/domain/repository.go
+++ b/services/market-information/domain/repository.go
@@ -93,6 +93,12 @@ type ObservationRepository interface {
 	//
 	// Returns ErrObservationNotFound if no matching observation exists.
 	RetrieveObservation(ctx context.Context, dataSetCode string, resolutionKey string, knowledgeBaseTime time.Time) (MarketPriceObservation, error)
+
+	// CountByDataset returns the total number of observations for a dataset.
+	// When includeSuperseded is false, only active (non-superseded) observations are counted.
+	// Returns 0 (not an error) if the dataset exists but has no observations.
+	// Returns ErrDataSetNotFound if the dataset does not exist.
+	CountByDataset(ctx context.Context, dataSetCode string, includeSuperseded bool) (int64, error)
 }
 
 // ObservationQuery specifies criteria for querying market price observations.

--- a/services/market-information/domain/repository_test.go
+++ b/services/market-information/domain/repository_test.go
@@ -82,6 +82,10 @@ func (m *mockObservationRepository) RetrieveObservation(_ context.Context, _ str
 	return MarketPriceObservation{}, ErrObservationNotFound
 }
 
+func (m *mockObservationRepository) CountByDataset(_ context.Context, _ string, _ bool) (int64, error) {
+	return int64(len(m.recordedObservations)), nil
+}
+
 // Verify mockObservationRepository implements ObservationRepository
 var _ ObservationRepository = (*mockObservationRepository)(nil)
 

--- a/services/market-information/service/observation_service.go
+++ b/services/market-information/service/observation_service.go
@@ -165,7 +165,7 @@ func (s *Server) RecordObservation(ctx context.Context, req *pb.RecordObservatio
 
 	// 13. Return proto response
 	return &pb.RecordObservationResponse{
-		Observation: domainObservationToProto(observation, req.Attributes),
+		Observation: domainObservationToProto(observation, req.Attributes, dataset.Version()),
 	}, nil
 }
 
@@ -437,7 +437,7 @@ func (s *Server) RecordObservationBatch(ctx context.Context, req *pb.RecordObser
 
 		results[i] = &pb.BatchObservationResult{
 			Success:         true,
-			Observation:     domainObservationToProto(observation, entry.Attributes),
+			Observation:     domainObservationToProto(observation, entry.Attributes, dataset.Version()),
 			ClientReference: entry.ClientReference,
 			Index:           int32(i),
 		}
@@ -457,6 +457,19 @@ func (s *Server) RecordObservationBatch(ctx context.Context, req *pb.RecordObser
 		SuccessCount: successCount,
 		FailureCount: failureCount,
 	}, nil
+}
+
+// getDatasetVersion looks up the version for a dataset by code.
+// Returns 1 as fallback if the dataset cannot be found.
+func (s *Server) getDatasetVersion(ctx context.Context, datasetCode string) int {
+	dataset, err := s.dataSetRepo.FindByCode(ctx, datasetCode)
+	if err != nil {
+		s.logger.Warn("failed to get dataset version, using fallback",
+			"dataset_code", datasetCode,
+			"error", err)
+		return 1 // Fallback to version 1
+	}
+	return dataset.Version()
 }
 
 // RetrieveObservation fetches a specific observation with bi-temporal query support.
@@ -502,8 +515,11 @@ func (s *Server) RetrieveObservation(ctx context.Context, req *pb.RetrieveObserv
 		}
 	}
 
+	// Get dataset version for proto conversion
+	datasetVersion := s.getDatasetVersion(ctx, observation.DataSetCode())
+
 	return &pb.RetrieveObservationResponse{
-		Observation: domainObservationToProto(observation, nil),
+		Observation: domainObservationToProto(observation, nil, datasetVersion),
 	}, nil
 }
 
@@ -562,20 +578,34 @@ func (s *Server) ListObservations(ctx context.Context, req *pb.ListObservationsR
 		return nil, status.Errorf(codes.Internal, "failed to query observations: %v", err)
 	}
 
+	// Get total count for pagination info
+	totalCount, err := s.observationRepo.CountByDataset(ctx, req.DatasetCode, req.IncludeSuperseded)
+	if err != nil {
+		// Log warning but don't fail the request - 0 means unknown per proto spec
+		s.logger.Warn("failed to get observation count",
+			"dataset_code", req.DatasetCode,
+			"error", err)
+		totalCount = 0
+	}
+
+	// Get dataset version for proto conversion
+	datasetVersion := s.getDatasetVersion(ctx, req.DatasetCode)
+
 	// Convert to proto messages
 	pbObservations := make([]*pb.MarketPriceObservation, len(observations))
 	for i, obs := range observations {
-		pbObservations[i] = domainObservationToProto(obs, nil)
+		pbObservations[i] = domainObservationToProto(obs, nil, datasetVersion)
 	}
 
 	s.logger.Debug("listed observations",
 		"dataset_code", req.DatasetCode,
-		"count", len(pbObservations))
+		"count", len(pbObservations),
+		"total_count", totalCount)
 
 	return &pb.ListObservationsResponse{
 		Observations:  pbObservations,
 		NextPageToken: "", // TODO: Implement cursor-based pagination
-		TotalCount:    0,  // TODO: Add count query - 0 means unknown per proto spec
+		TotalCount:    int32(totalCount),
 	}, nil
 }
 
@@ -820,11 +850,13 @@ func domainQualityLevelToProto(domainQuality domain.QualityLevel) pb.QualityLeve
 }
 
 // domainObservationToProto converts a domain MarketPriceObservation to proto.
-func domainObservationToProto(obs domain.MarketPriceObservation, attributes []*quantityv1.AttributeEntry) *pb.MarketPriceObservation {
+// The datasetVersion parameter should be obtained from the dataset definition.
+// If the version cannot be determined, pass 1 as a fallback.
+func domainObservationToProto(obs domain.MarketPriceObservation, attributes []*quantityv1.AttributeEntry, datasetVersion int) *pb.MarketPriceObservation {
 	pbObs := &pb.MarketPriceObservation{
 		Id:                 obs.ID().String(),
 		DatasetCode:        obs.DataSetCode(),
-		DatasetVersion:     1, // TODO: Track dataset version in observation
+		DatasetVersion:     int32(datasetVersion),
 		ResolutionKeyValue: obs.ResolutionKey(),
 		ObservedAt:         timestamppb.New(obs.ObservedAt()),
 		ValidFrom:          timestamppb.New(obs.ValidFrom()),

--- a/services/market-information/service/observation_service_test.go
+++ b/services/market-information/service/observation_service_test.go
@@ -1312,3 +1312,157 @@ func TestRecordObservationBatch_NonExistentSource(t *testing.T) {
 	assert.False(t, resp.Results[0].Success)
 	assert.Contains(t, resp.Results[0].ErrorMessage, "source not found")
 }
+
+// ============================================
+// TotalCount and DatasetVersion Tests
+// ============================================
+
+func TestListObservations_TotalCountPopulated(t *testing.T) {
+	server, _, cleanup := setupTestServerForObservation(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	datasetCode, sourceCode := setupTestDataSetAndSource(t, server, ctx)
+
+	now := time.Now()
+
+	// Record 10 observations
+	for i := 0; i < 10; i++ {
+		req := &pb.RecordObservationRequest{
+			DatasetCode: datasetCode,
+			SourceCode:  sourceCode,
+			Value:       "1.0",
+			ObservedAt:  timestamppb.New(now.Add(time.Duration(i) * time.Minute)),
+			ValidFrom:   timestamppb.New(now.Add(time.Duration(i) * time.Minute)),
+			Quality:     pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+			Attributes: []*quantityv1.AttributeEntry{
+				{Key: "currency_pair", Value: "EUR/USD"},
+			},
+		}
+		_, err := server.RecordObservation(ctx, req)
+		require.NoError(t, err)
+	}
+
+	// List with page size of 5 - should get 5 observations but TotalCount should be 10
+	listReq := &pb.ListObservationsRequest{
+		DatasetCode: datasetCode,
+		PageSize:    5,
+	}
+
+	listResp, err := server.ListObservations(ctx, listReq)
+	require.NoError(t, err)
+	require.NotNil(t, listResp)
+
+	assert.Len(t, listResp.Observations, 5)
+	assert.Equal(t, int32(10), listResp.TotalCount, "TotalCount should reflect total observations in dataset")
+}
+
+func TestRecordObservation_DatasetVersionPopulated(t *testing.T) {
+	server, _, cleanup := setupTestServerForObservation(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	datasetCode, sourceCode := setupTestDataSetAndSource(t, server, ctx)
+
+	now := time.Now()
+	req := &pb.RecordObservationRequest{
+		DatasetCode: datasetCode,
+		SourceCode:  sourceCode,
+		Value:       "1.2345",
+		ObservedAt:  timestamppb.New(now),
+		ValidFrom:   timestamppb.New(now),
+		Quality:     pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+		Attributes: []*quantityv1.AttributeEntry{
+			{Key: "currency_pair", Value: "EUR/USD"},
+		},
+	}
+
+	resp, err := server.RecordObservation(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Observation)
+
+	// The dataset was registered (v1) and activated (v2), so version should be 2
+	assert.Equal(t, int32(2), resp.Observation.DatasetVersion,
+		"DatasetVersion should match the activated dataset version")
+}
+
+func TestRetrieveObservation_DatasetVersionPopulated(t *testing.T) {
+	server, _, cleanup := setupTestServerForObservation(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	datasetCode, sourceCode := setupTestDataSetAndSource(t, server, ctx)
+
+	// First, record an observation
+	now := time.Now()
+	recordReq := &pb.RecordObservationRequest{
+		DatasetCode: datasetCode,
+		SourceCode:  sourceCode,
+		Value:       "3.14",
+		ObservedAt:  timestamppb.New(now),
+		ValidFrom:   timestamppb.New(now),
+		Quality:     pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+		Attributes: []*quantityv1.AttributeEntry{
+			{Key: "currency_pair", Value: "EUR/USD"},
+		},
+	}
+
+	recordResp, err := server.RecordObservation(ctx, recordReq)
+	require.NoError(t, err)
+
+	// Retrieve it
+	retrieveReq := &pb.RetrieveObservationRequest{
+		ObservationId: recordResp.Observation.Id,
+	}
+
+	retrieveResp, err := server.RetrieveObservation(ctx, retrieveReq)
+	require.NoError(t, err)
+	require.NotNil(t, retrieveResp)
+	require.NotNil(t, retrieveResp.Observation)
+
+	// The dataset was registered (v1) and activated (v2), so version should be 2
+	assert.Equal(t, int32(2), retrieveResp.Observation.DatasetVersion,
+		"DatasetVersion should match the activated dataset version")
+}
+
+func TestListObservations_DatasetVersionPopulated(t *testing.T) {
+	server, _, cleanup := setupTestServerForObservation(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	datasetCode, sourceCode := setupTestDataSetAndSource(t, server, ctx)
+
+	// Record an observation
+	now := time.Now()
+	req := &pb.RecordObservationRequest{
+		DatasetCode: datasetCode,
+		SourceCode:  sourceCode,
+		Value:       "1.0",
+		ObservedAt:  timestamppb.New(now),
+		ValidFrom:   timestamppb.New(now),
+		Quality:     pb.QualityLevel_QUALITY_LEVEL_ACTUAL,
+		Attributes: []*quantityv1.AttributeEntry{
+			{Key: "currency_pair", Value: "EUR/USD"},
+		},
+	}
+	_, err := server.RecordObservation(ctx, req)
+	require.NoError(t, err)
+
+	// List observations
+	listReq := &pb.ListObservationsRequest{
+		DatasetCode: datasetCode,
+		PageSize:    10,
+	}
+
+	listResp, err := server.ListObservations(ctx, listReq)
+	require.NoError(t, err)
+	require.NotNil(t, listResp)
+	require.NotEmpty(t, listResp.Observations)
+
+	// All observations should have the correct dataset version
+	for _, obs := range listResp.Observations {
+		assert.Equal(t, int32(2), obs.DatasetVersion,
+			"DatasetVersion should match the activated dataset version")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `CountByDataset` method to `ObservationRepository` interface for counting observations in a dataset with optional superseded filtering
- Update `domainObservationToProto` to accept and use dataset version parameter instead of hardcoded value
- Populate `TotalCount` in `ListObservationsResponse` using the new count method
- Add helper method to look up dataset versions for proto conversions

## Test plan

- [x] Add repository tests for `CountByDataset` (basic, excludes superseded, empty dataset, non-existent dataset)
- [x] Add service tests for `TotalCount` population in `ListObservations`
- [x] Add service tests for `DatasetVersion` population in `RecordObservation`, `RetrieveObservation`, and `ListObservations`
- [x] Run full market-information test suite - all tests pass

## Technical Details

### Repository Changes

Added `CountByDataset(ctx, dataSetCode string, includeSuperseded bool) (int64, error)` method that:
- Resolves dataset definition ID from code (returns `ErrDataSetNotFound` if not found)
- Counts observations with optional superseded filtering
- Returns 0 for empty datasets (not an error)

### Service Changes

- Added `getDatasetVersion` helper that looks up dataset version with fallback to 1
- Updated `domainObservationToProto` signature to accept `datasetVersion int` parameter
- Updated all callers to pass the correct dataset version:
  - `RecordObservation`: Uses `dataset.Version()` from the fetched dataset
  - `RecordObservationBatch`: Uses `dataset.Version()` from the cached datasets map
  - `RetrieveObservation`: Uses `getDatasetVersion` helper
  - `ListObservations`: Uses `getDatasetVersion` helper
- `ListObservations` now populates `TotalCount` from `CountByDataset` (0 on error per proto spec)