### PR TITLE
feat(current-account): add fungibility validation to deposit/withdrawal orchestrators

### DIFF
--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -351,6 +351,13 @@ message ExecuteDepositRequest {
 
   // idempotency_key ensures exactly-once deposit execution for retry scenarios
   meridian.common.v1.IdempotencyKey idempotency_key = 5;
+
+  // attributes contains optional key-value pairs for fungibility validation.
+  // For non-fungible instruments (e.g., RICE-KG with batch tracking), the deposit
+  // must have attributes that match the credit side's attributes according to
+  // the instrument's fungibility_key_expression.
+  // Example: {"batch_id": "2024-A", "grade": "premium"}
+  map<string, string> attributes = 6;
 }
 
 // Response for deposit execution
@@ -457,6 +464,13 @@ message InitiateWithdrawalRequest {
 
   // idempotency_key ensures exactly-once withdrawal initiation
   meridian.common.v1.IdempotencyKey idempotency_key = 5;
+
+  // attributes contains optional key-value pairs for fungibility validation.
+  // For non-fungible instruments (e.g., RICE-KG with batch tracking), the withdrawal
+  // must have attributes that match the debit side's attributes according to
+  // the instrument's fungibility_key_expression.
+  // Example: {"batch_id": "2024-A", "grade": "premium"}
+  map<string, string> attributes = 6;
 }
 
 // Response for initiating a withdrawal
@@ -501,6 +515,13 @@ message ExecuteWithdrawalRequest {
 
   // idempotency_key ensures exactly-once withdrawal execution
   meridian.common.v1.IdempotencyKey idempotency_key = 6;
+
+  // attributes contains optional key-value pairs for fungibility validation.
+  // For non-fungible instruments (e.g., RICE-KG with batch tracking), the withdrawal
+  // must have attributes that match the debit side's attributes according to
+  // the instrument's fungibility_key_expression.
+  // Example: {"batch_id": "2024-A", "grade": "premium"}
+  map<string, string> attributes = 7;
 }
 
 // Response for executing a withdrawal

--- a/services/current-account/cmd/main.go
+++ b/services/current-account/cmd/main.go
@@ -19,6 +19,7 @@ import (
 	internalbankaccountclient "github.com/meridianhub/meridian/services/internal-bank-account/client"
 	partyclient "github.com/meridianhub/meridian/services/party/client"
 	poskeepingclient "github.com/meridianhub/meridian/services/position-keeping/client"
+	refdataclient "github.com/meridianhub/meridian/services/reference-data/client"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
@@ -385,6 +386,36 @@ func createServiceWithClients(
 		}
 	}
 
+	// Create Reference Data client for instrument lookup (required for fungibility validation).
+	// This is optional - if it fails, fungibility validation is disabled.
+	var fungibilityValidator *service.FungibilityValidator
+
+	refDataClient, refDataCleanup, err := refdataclient.New(context.Background(), refdataclient.Config{
+		ServiceName: refdataclient.ServiceName,
+		Namespace:   namespace,
+		Port:        ports.ReferenceData,
+		Timeout:     defaults.DefaultRPCTimeout,
+		Tracer:      tracer,
+		Resilience: &sharedclients.ResilientClientConfig{
+			Logger:             logger,
+			CircuitBreakerName: "reference-data",
+			OnStateChange:      makeCircuitBreakerCallback(),
+		},
+	})
+	if err != nil {
+		logger.Warn("reference data client not available, fungibility validation disabled",
+			"error", err)
+	} else {
+		// Wrap the cleanup function to match expected signature (func() instead of func() error)
+		cleanupFuncs = append(cleanupFuncs, func() {
+			if closeErr := refDataCleanup(); closeErr != nil {
+				logger.Error("failed to close reference data client", "error", closeErr)
+			}
+		})
+		fungibilityValidator = service.NewFungibilityValidator(refDataClient)
+		logger.Info("fungibility validation enabled via Reference Data service")
+	}
+
 	// Create service with the pre-created clients
 	// The new service-owned clients implement the same interfaces as defined in
 	// services/current-account/service/client_interfaces.go
@@ -399,7 +430,8 @@ func createServiceWithClients(
 		idempotencyService,
 		logger,
 		tracer,
-		accountResolver, // Optional: dynamic clearing account resolution
+		accountResolver,      // Optional: dynamic clearing account resolution
+		fungibilityValidator, // Optional: validates fungibility for non-fungible instruments
 	)
 	if err != nil {
 		// Cleanup all clients before returning

--- a/services/current-account/service/deposit_orchestrator.go
+++ b/services/current-account/service/deposit_orchestrator.go
@@ -31,12 +31,13 @@ import (
 // It handles the multi-step deposit workflow including position keeping logging,
 // ledger posting with double-entry bookkeeping, and account balance persistence.
 type DepositOrchestrator struct {
-	logger           *slog.Logger
-	repo             *persistence.Repository
-	posKeepingClient PositionKeepingClient
-	finAcctClient    FinancialAccountingClient
-	accountConfig    *config.AccountConfig
-	accountResolver  *AccountResolver
+	logger               *slog.Logger
+	repo                 *persistence.Repository
+	posKeepingClient     PositionKeepingClient
+	finAcctClient        FinancialAccountingClient
+	accountConfig        *config.AccountConfig
+	accountResolver      *AccountResolver
+	fungibilityValidator *FungibilityValidator
 }
 
 // DepositOrchestratorConfig contains dependencies for creating a DepositOrchestrator
@@ -50,6 +51,9 @@ type DepositOrchestratorConfig struct {
 	// If provided, takes precedence over AccountConfig for clearing account lookup.
 	// If nil, falls back to static AccountConfig environment variables.
 	AccountResolver *AccountResolver
+	// FungibilityValidator validates fungibility for non-fungible instruments.
+	// If nil, fungibility validation is skipped (fully fungible instruments only).
+	FungibilityValidator *FungibilityValidator
 }
 
 // NewDepositOrchestrator creates a new deposit orchestrator with the given dependencies.
@@ -68,12 +72,13 @@ func NewDepositOrchestrator(cfg DepositOrchestratorConfig) (*DepositOrchestrator
 		return nil, ErrOrchestratorFinAcctClientNil
 	}
 	return &DepositOrchestrator{
-		logger:           cfg.Logger,
-		repo:             cfg.Repo,
-		posKeepingClient: cfg.PosKeepingClient,
-		finAcctClient:    cfg.FinAcctClient,
-		accountConfig:    cfg.AccountConfig,
-		accountResolver:  cfg.AccountResolver,
+		logger:               cfg.Logger,
+		repo:                 cfg.Repo,
+		posKeepingClient:     cfg.PosKeepingClient,
+		finAcctClient:        cfg.FinAcctClient,
+		accountConfig:        cfg.AccountConfig,
+		accountResolver:      cfg.AccountResolver,
+		fungibilityValidator: cfg.FungibilityValidator,
 	}, nil
 }
 
@@ -96,7 +101,13 @@ func NewDepositOrchestrator(cfg DepositOrchestratorConfig) (*DepositOrchestrator
 // Callers must use optimistic locking (version field) or database-level locking when
 // processing deposits for the same account concurrently. The repository layer enforces
 // optimistic locking via ErrVersionConflict.
-func (o *DepositOrchestrator) Orchestrate(ctx context.Context, account domain.CurrentAccount, amount domain.Money, transactionID string) (*pb.ExecuteDepositResponse, error) {
+//
+// Parameters:
+//   - attributes: Optional key-value pairs for fungibility validation. For non-fungible
+//     instruments (e.g., RICE-KG with batch tracking), both debit and credit sides
+//     of the double-entry must have matching fungibility keys. If nil, no fungibility
+//     validation is performed (suitable for fully fungible instruments like USD).
+func (o *DepositOrchestrator) Orchestrate(ctx context.Context, account domain.CurrentAccount, amount domain.Money, transactionID string, attributes map[string]string) (*pb.ExecuteDepositResponse, error) {
 	sagaStart := time.Now()
 	sagaStatus := operationStatusSuccess
 	defer func() {
@@ -111,6 +122,25 @@ func (o *DepositOrchestrator) Orchestrate(ctx context.Context, account domain.Cu
 		ctx = observability.WithCorrelationID(ctx, correlationID)
 	} else {
 		o.logger.Info("using existing correlation ID", "correlation_id", correlationID)
+	}
+
+	// Validate fungibility before starting the saga.
+	// For double-entry deposits: DEBIT from clearing account, CREDIT to customer account
+	// Both sides use the same attributes since this is a single incoming deposit.
+	if o.fungibilityValidator != nil {
+		instrumentCode := string(amount.Currency())
+		if err := o.fungibilityValidator.ValidateDoubleEntry(ctx, instrumentCode, 1, attributes, attributes); err != nil {
+			sagaStatus = operationStatusFailed
+			o.logger.Error("fungibility validation failed",
+				"account_id", account.AccountID(),
+				"transaction_id", transactionID,
+				"instrument", instrumentCode,
+				"error", err)
+			return nil, status.Errorf(codes.InvalidArgument, "fungibility validation failed: %v", err)
+		}
+		o.logger.Debug("fungibility validation passed",
+			"account_id", account.AccountID(),
+			"instrument", instrumentCode)
 	}
 
 	// Create saga orchestrator

--- a/services/current-account/service/fungibility_validator.go
+++ b/services/current-account/service/fungibility_validator.go
@@ -1,0 +1,186 @@
+// Package service provides fungibility validation for double-entry transactions.
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+
+	"github.com/meridianhub/meridian/services/reference-data/cache"
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+)
+
+// Fungibility validation errors.
+var (
+	// ErrFungibilityMismatch is returned when debit and credit postings have attributes
+	// that evaluate to different fungibility keys.
+	ErrFungibilityMismatch = errors.New("fungibility validation failed: debit and credit have incompatible attributes")
+
+	// ErrFungibilityKeyEvaluation is returned when the CEL program fails to evaluate
+	// the fungibility key expression.
+	ErrFungibilityKeyEvaluation = errors.New("failed to evaluate fungibility key expression")
+
+	// ErrInstrumentNotFound is returned when the instrument cannot be found in the
+	// reference data service.
+	ErrInstrumentNotFound = errors.New("instrument not found")
+
+	// ErrFungibilityKeyType is returned when the fungibility key expression returns
+	// a non-string type.
+	ErrFungibilityKeyType = errors.New("fungibility key expression must return string")
+)
+
+// InstrumentGetter retrieves instrument definitions with pre-compiled CEL programs.
+// This interface is implemented by the reference-data client.
+type InstrumentGetter interface {
+	GetInstrument(ctx context.Context, code string, version int) (*cache.CachedInstrument, error)
+}
+
+// FungibilityKeyEvaluator evaluates fungibility key expressions.
+// This interface enables testing without depending on the actual CEL runtime.
+type FungibilityKeyEvaluator interface {
+	Eval(activation interface{}) (interface{}, error)
+}
+
+// FungibilityValidator validates that debit and credit postings have compatible
+// fungibility attributes as defined by the instrument's fungibility_key_expression.
+//
+// Thread-safety: Safe for concurrent use.
+type FungibilityValidator struct {
+	getter    InstrumentGetter
+	evaluator FungibilityKeyEvaluator // Optional: for testing only. If nil, uses instrument's BucketKeyProgram.
+}
+
+// NewFungibilityValidator creates a new fungibility validator.
+// Returns nil if getter is nil.
+func NewFungibilityValidator(getter InstrumentGetter) *FungibilityValidator {
+	if getter == nil {
+		return nil
+	}
+	return &FungibilityValidator{
+		getter: getter,
+	}
+}
+
+// ValidateDoubleEntry validates that debit and credit attributes are compatible
+// according to the instrument's fungibility rules.
+//
+// Parameters:
+//   - ctx: Context with tenant information
+//   - instrumentCode: The instrument code (e.g., "USD", "RICE-KG")
+//   - instrumentVersion: The instrument version (use 1 for latest active)
+//   - debitAttrs: Attributes from the debit posting (may be nil)
+//   - creditAttrs: Attributes from the credit posting (may be nil)
+//
+// Returns:
+//   - nil if fungibility validation passes (keys match or instrument is fully fungible)
+//   - ErrInstrumentNotFound if instrument cannot be found
+//   - ErrFungibilityMismatch if keys don't match
+//   - ErrFungibilityKeyEvaluation if CEL evaluation fails
+func (v *FungibilityValidator) ValidateDoubleEntry(
+	ctx context.Context,
+	instrumentCode string,
+	instrumentVersion int,
+	debitAttrs map[string]string,
+	creditAttrs map[string]string,
+) error {
+	// Retrieve instrument with pre-compiled CEL program
+	instrument, err := v.getter.GetInstrument(ctx, instrumentCode, instrumentVersion)
+	if err != nil {
+		if errors.Is(err, registry.ErrNotFound) {
+			return fmt.Errorf("%w: %s v%d", ErrInstrumentNotFound, instrumentCode, instrumentVersion)
+		}
+		return fmt.Errorf("failed to retrieve instrument %s: %w", instrumentCode, err)
+	}
+
+	// If no fungibility key expression, instrument is fully fungible
+	if instrument.Definition.FungibilityKeyExpression == "" {
+		return nil
+	}
+
+	// Determine which evaluator to use
+	var evaluator FungibilityKeyEvaluator
+	if v.evaluator != nil {
+		// Use injected evaluator (for testing)
+		evaluator = v.evaluator
+	} else if instrument.BucketKeyProgram != nil {
+		// Use the instrument's pre-compiled CEL program (production path)
+		evaluator = &celProgramAdapter{program: instrument.BucketKeyProgram}
+	} else {
+		// No program available - treat as fully fungible
+		return nil
+	}
+
+	// Normalize nil attributes to empty maps for CEL evaluation
+	if debitAttrs == nil {
+		debitAttrs = make(map[string]string)
+	}
+	if creditAttrs == nil {
+		creditAttrs = make(map[string]string)
+	}
+
+	// Evaluate fungibility key for debit posting
+	debitKey, err := evaluateFungibilityKey(evaluator, debitAttrs)
+	if err != nil {
+		return fmt.Errorf("%w: debit attributes: %w", ErrFungibilityKeyEvaluation, err)
+	}
+
+	// Evaluate fungibility key for credit posting
+	creditKey, err := evaluateFungibilityKey(evaluator, creditAttrs)
+	if err != nil {
+		return fmt.Errorf("%w: credit attributes: %w", ErrFungibilityKeyEvaluation, err)
+	}
+
+	// Compare keys - they must match for the transaction to be valid
+	if debitKey != creditKey {
+		return fmt.Errorf("%w: debit key %q does not match credit key %q (instrument=%s)",
+			ErrFungibilityMismatch,
+			debitKey,
+			creditKey,
+			instrumentCode)
+	}
+
+	return nil
+}
+
+// celProgramAdapter wraps a cel.Program to implement FungibilityKeyEvaluator.
+type celProgramAdapter struct {
+	program cel.Program
+}
+
+// Eval evaluates the CEL program with the given activation.
+func (a *celProgramAdapter) Eval(activation interface{}) (interface{}, error) {
+	result, _, err := a.program.Eval(activation)
+	if err != nil {
+		return nil, err
+	}
+	if result != nil {
+		return result.Value(), nil
+	}
+	return "", nil
+}
+
+// evaluateFungibilityKey evaluates the evaluator with the given attributes
+// and returns the resulting fungibility key string.
+func evaluateFungibilityKey(evaluator FungibilityKeyEvaluator, attributes map[string]string) (string, error) {
+	// Build CEL activation with attributes variable
+	activation := map[string]interface{}{
+		"attributes": attributes,
+	}
+
+	result, err := evaluator.Eval(activation)
+	if err != nil {
+		return "", err
+	}
+
+	// Extract string value from result
+	switch v := result.(type) {
+	case string:
+		return v, nil
+	case nil:
+		return "", nil
+	default:
+		return "", fmt.Errorf("%w: got %T", ErrFungibilityKeyType, result)
+	}
+}

--- a/services/current-account/service/fungibility_validator_test.go
+++ b/services/current-account/service/fungibility_validator_test.go
@@ -1,0 +1,274 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/reference-data/cache"
+	"github.com/meridianhub/meridian/services/reference-data/registry"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Test sentinel errors for wrapping.
+var (
+	errFungibilityTestConnRefused = errors.New("connection refused")
+	errFungibilityTestCELEval     = errors.New("CEL evaluation failed")
+)
+
+// mockInstrumentGetter is a mock implementation of InstrumentGetter for testing.
+type mockInstrumentGetter struct {
+	instruments map[string]*cache.CachedInstrument
+	err         error
+}
+
+func (m *mockInstrumentGetter) GetInstrument(_ context.Context, code string, _ int) (*cache.CachedInstrument, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	key := code
+	if inst, ok := m.instruments[key]; ok {
+		return inst, nil
+	}
+	return nil, registry.ErrNotFound
+}
+
+// mockFungibilityKeyProgram implements a simple mock for fungibility key evaluation.
+// This returns a deterministic key based on the attributes passed in.
+type mockFungibilityKeyProgram struct {
+	keyFunc func(attrs map[string]string) string
+	err     error
+}
+
+// Eval evaluates the mock fungibility key program.
+func (m *mockFungibilityKeyProgram) Eval(activation interface{}) (interface{}, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	// Extract attributes from activation map
+	if act, ok := activation.(map[string]interface{}); ok {
+		if attrs, ok := act["attributes"].(map[string]string); ok {
+			return m.keyFunc(attrs), nil
+		}
+	}
+	// Return empty string for missing/invalid attributes
+	return m.keyFunc(map[string]string{}), nil
+}
+
+func TestFungibilityValidator_ValidateDoubleEntry_FullyFungible(t *testing.T) {
+	// Instrument with empty fungibility_key_expression is fully fungible
+	ctx := tenant.WithTenant(context.Background(), "test-tenant")
+
+	mock := &mockInstrumentGetter{
+		instruments: map[string]*cache.CachedInstrument{
+			"USD": {
+				Definition: &registry.InstrumentDefinition{
+					Code:                     "USD",
+					Version:                  1,
+					FungibilityKeyExpression: "", // Empty = fully fungible
+				},
+				BucketKeyProgram: nil, // No CEL program for fully fungible
+			},
+		},
+	}
+
+	validator := NewFungibilityValidator(mock)
+
+	err := validator.ValidateDoubleEntry(ctx, "USD", 1, nil, nil)
+	assert.NoError(t, err, "fully fungible instrument should pass validation")
+}
+
+func TestFungibilityValidator_ValidateDoubleEntry_MatchingKeys(t *testing.T) {
+	// Instrument with fungibility_key_expression where attributes produce matching keys
+	ctx := tenant.WithTenant(context.Background(), "test-tenant")
+
+	mock := &mockInstrumentGetter{
+		instruments: map[string]*cache.CachedInstrument{
+			"RICE-KG": {
+				Definition: &registry.InstrumentDefinition{
+					Code:                     "RICE-KG",
+					Version:                  1,
+					FungibilityKeyExpression: "attributes.batch_id",
+				},
+				// Note: BucketKeyProgram is nil for test - we override via FungibilityKeyEvaluator
+			},
+		},
+	}
+
+	// Use a validator with a custom evaluator for testing
+	validator := &FungibilityValidator{
+		getter: mock,
+		evaluator: &mockFungibilityKeyProgram{
+			keyFunc: func(attrs map[string]string) string {
+				return attrs["batch_id"]
+			},
+		},
+	}
+
+	debitAttrs := map[string]string{"batch_id": "2024-A"}
+	creditAttrs := map[string]string{"batch_id": "2024-A"}
+
+	err := validator.ValidateDoubleEntry(ctx, "RICE-KG", 1, debitAttrs, creditAttrs)
+	assert.NoError(t, err, "matching fungibility keys should pass validation")
+}
+
+func TestFungibilityValidator_ValidateDoubleEntry_MismatchedKeys(t *testing.T) {
+	// Instrument with fungibility_key_expression where attributes produce different keys
+	ctx := tenant.WithTenant(context.Background(), "test-tenant")
+
+	mock := &mockInstrumentGetter{
+		instruments: map[string]*cache.CachedInstrument{
+			"RICE-KG": {
+				Definition: &registry.InstrumentDefinition{
+					Code:                     "RICE-KG",
+					Version:                  1,
+					FungibilityKeyExpression: "attributes.batch_id",
+				},
+			},
+		},
+	}
+
+	validator := &FungibilityValidator{
+		getter: mock,
+		evaluator: &mockFungibilityKeyProgram{
+			keyFunc: func(attrs map[string]string) string {
+				return attrs["batch_id"]
+			},
+		},
+	}
+
+	debitAttrs := map[string]string{"batch_id": "2024-A"}
+	creditAttrs := map[string]string{"batch_id": "2024-B"} // Different batch_id
+
+	err := validator.ValidateDoubleEntry(ctx, "RICE-KG", 1, debitAttrs, creditAttrs)
+	assert.Error(t, err, "mismatched fungibility keys should fail validation")
+	assert.ErrorIs(t, err, ErrFungibilityMismatch)
+}
+
+func TestFungibilityValidator_ValidateDoubleEntry_InstrumentNotFound(t *testing.T) {
+	ctx := tenant.WithTenant(context.Background(), "test-tenant")
+
+	mock := &mockInstrumentGetter{
+		instruments: map[string]*cache.CachedInstrument{}, // Empty - no instruments
+	}
+
+	validator := NewFungibilityValidator(mock)
+
+	err := validator.ValidateDoubleEntry(ctx, "UNKNOWN", 1, nil, nil)
+	assert.Error(t, err, "unknown instrument should fail validation")
+	assert.ErrorIs(t, err, ErrInstrumentNotFound)
+}
+
+func TestFungibilityValidator_ValidateDoubleEntry_InstrumentLookupError(t *testing.T) {
+	ctx := tenant.WithTenant(context.Background(), "test-tenant")
+
+	mock := &mockInstrumentGetter{
+		err: fmt.Errorf("lookup failed: %w", errFungibilityTestConnRefused),
+	}
+
+	validator := NewFungibilityValidator(mock)
+
+	err := validator.ValidateDoubleEntry(ctx, "USD", 1, nil, nil)
+	assert.Error(t, err, "instrument lookup error should fail validation")
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+func TestFungibilityValidator_ValidateDoubleEntry_NilAttributes(t *testing.T) {
+	// Test that nil attributes are handled gracefully
+	ctx := tenant.WithTenant(context.Background(), "test-tenant")
+
+	mock := &mockInstrumentGetter{
+		instruments: map[string]*cache.CachedInstrument{
+			"RICE-KG": {
+				Definition: &registry.InstrumentDefinition{
+					Code:                     "RICE-KG",
+					Version:                  1,
+					FungibilityKeyExpression: "attributes.batch_id",
+				},
+			},
+		},
+	}
+
+	validator := &FungibilityValidator{
+		getter: mock,
+		evaluator: &mockFungibilityKeyProgram{
+			keyFunc: func(attrs map[string]string) string {
+				return attrs["batch_id"] // Returns empty for nil/empty attrs
+			},
+		},
+	}
+
+	// Both nil - should produce same (empty) key
+	err := validator.ValidateDoubleEntry(ctx, "RICE-KG", 1, nil, nil)
+	assert.NoError(t, err, "both nil attributes should produce matching empty keys")
+}
+
+func TestFungibilityValidator_ValidateDoubleEntry_CELEvaluationError(t *testing.T) {
+	ctx := tenant.WithTenant(context.Background(), "test-tenant")
+
+	mock := &mockInstrumentGetter{
+		instruments: map[string]*cache.CachedInstrument{
+			"RICE-KG": {
+				Definition: &registry.InstrumentDefinition{
+					Code:                     "RICE-KG",
+					Version:                  1,
+					FungibilityKeyExpression: "bad_expression",
+				},
+			},
+		},
+	}
+
+	validator := &FungibilityValidator{
+		getter: mock,
+		evaluator: &mockFungibilityKeyProgram{
+			err: fmt.Errorf("expression error: %w", errFungibilityTestCELEval),
+		},
+	}
+
+	err := validator.ValidateDoubleEntry(ctx, "RICE-KG", 1, nil, nil)
+	assert.Error(t, err, "CEL evaluation error should fail validation")
+	assert.ErrorIs(t, err, ErrFungibilityKeyEvaluation)
+}
+
+func TestFungibilityValidator_NilGetter(t *testing.T) {
+	validator := NewFungibilityValidator(nil)
+	assert.Nil(t, validator, "nil getter should return nil validator")
+}
+
+func TestNewFungibilityValidator(t *testing.T) {
+	mock := &mockInstrumentGetter{}
+	validator := NewFungibilityValidator(mock)
+	require.NotNil(t, validator)
+}
+
+func TestFungibilityValidator_UseCELProgramFromInstrument(t *testing.T) {
+	// Test that when no custom evaluator is set, the validator uses the instrument's BucketKeyProgram
+	ctx := tenant.WithTenant(context.Background(), "test-tenant")
+
+	// This test verifies the production path works when BucketKeyProgram is nil (fully fungible)
+	mock := &mockInstrumentGetter{
+		instruments: map[string]*cache.CachedInstrument{
+			"USD": {
+				Definition: &registry.InstrumentDefinition{
+					Code:                     "USD",
+					Version:                  1,
+					FungibilityKeyExpression: "", // Fully fungible
+				},
+				BucketKeyProgram: nil,
+			},
+		},
+	}
+
+	validator := NewFungibilityValidator(mock)
+
+	// Should pass because instrument is fully fungible (no BucketKeyProgram)
+	err := validator.ValidateDoubleEntry(ctx, "USD", 1,
+		map[string]string{"any": "attr"},
+		map[string]string{"different": "attr"},
+	)
+	assert.NoError(t, err)
+}

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -207,6 +207,7 @@ func NewServiceWithIdempotency(repo *persistence.Repository, lienRepo *persisten
 // Optional parameters:
 //   - accountConfig: Static clearing account configuration (environment variables)
 //   - accountResolver: Dynamic clearing account resolution from Internal Bank Account service
+//   - fungibilityValidator: Validates fungibility for non-fungible instruments
 //
 // If both accountConfig and accountResolver are provided, the resolver takes precedence
 // with fallback to static config.
@@ -222,6 +223,7 @@ func NewServiceWithExistingClients(
 	logger *slog.Logger,
 	tracer *observability.Tracer,
 	accountResolver *AccountResolver, // Optional: dynamic clearing account resolution
+	fungibilityValidator *FungibilityValidator, // Optional: validates fungibility for non-fungible instruments
 ) (*Service, error) {
 	if repo == nil {
 		return nil, ErrRepositoryNil
@@ -234,12 +236,13 @@ func NewServiceWithExistingClients(
 
 	// Create deposit orchestrator
 	depositOrchestrator, err := NewDepositOrchestrator(DepositOrchestratorConfig{
-		Logger:           logger,
-		Repo:             repo,
-		PosKeepingClient: posKeepingClient,
-		FinAcctClient:    finAcctClient,
-		AccountConfig:    accountConfig,
-		AccountResolver:  accountResolver,
+		Logger:               logger,
+		Repo:                 repo,
+		PosKeepingClient:     posKeepingClient,
+		FinAcctClient:        finAcctClient,
+		AccountConfig:        accountConfig,
+		AccountResolver:      accountResolver,
+		FungibilityValidator: fungibilityValidator,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create deposit orchestrator: %w", err)
@@ -247,12 +250,13 @@ func NewServiceWithExistingClients(
 
 	// Create withdrawal orchestrator
 	withdrawalOrchestrator, err := NewWithdrawalOrchestrator(WithdrawalOrchestratorConfig{
-		Logger:           logger,
-		Repo:             repo,
-		PosKeepingClient: posKeepingClient,
-		FinAcctClient:    finAcctClient,
-		AccountConfig:    accountConfig,
-		AccountResolver:  accountResolver,
+		Logger:               logger,
+		Repo:                 repo,
+		PosKeepingClient:     posKeepingClient,
+		FinAcctClient:        finAcctClient,
+		AccountConfig:        accountConfig,
+		AccountResolver:      accountResolver,
+		FungibilityValidator: fungibilityValidator,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create withdrawal orchestrator: %w", err)
@@ -519,7 +523,7 @@ func (s *Service) ExecuteDeposit(ctx context.Context, req *pb.ExecuteDepositRequ
 	}
 
 	// Orchestrate transaction with saga pattern - Position Keeping is the source of truth for balance
-	resp, err := s.depositOrchestrator.Orchestrate(ctx, account, amount, transactionID)
+	resp, err := s.depositOrchestrator.Orchestrate(ctx, account, amount, transactionID, req.Attributes)
 	if err != nil {
 		operationStatus = opStatusSagaFailed
 		return nil, err
@@ -862,7 +866,7 @@ func (s *Service) ExecuteWithdrawal(ctx context.Context, req *pb.ExecuteWithdraw
 	}
 
 	// Orchestrate transaction with saga pattern - Position Keeping is the source of truth for balance
-	resp, err := s.withdrawalOrchestrator.Orchestrate(ctx, account, amount, transactionID)
+	resp, err := s.withdrawalOrchestrator.Orchestrate(ctx, account, amount, transactionID, req.Attributes)
 	if err != nil {
 		operationStatus = opStatusSagaFailed
 		return nil, err

--- a/services/current-account/service/withdrawal_orchestrator.go
+++ b/services/current-account/service/withdrawal_orchestrator.go
@@ -31,12 +31,13 @@ import (
 // It handles the multi-step withdrawal workflow including position keeping logging,
 // ledger posting with double-entry bookkeeping (reversed from deposits), and account balance persistence.
 type WithdrawalOrchestrator struct {
-	logger           *slog.Logger
-	repo             *persistence.Repository
-	posKeepingClient PositionKeepingClient
-	finAcctClient    FinancialAccountingClient
-	accountConfig    *config.AccountConfig
-	accountResolver  *AccountResolver
+	logger               *slog.Logger
+	repo                 *persistence.Repository
+	posKeepingClient     PositionKeepingClient
+	finAcctClient        FinancialAccountingClient
+	accountConfig        *config.AccountConfig
+	accountResolver      *AccountResolver
+	fungibilityValidator *FungibilityValidator
 }
 
 // WithdrawalOrchestratorConfig contains dependencies for creating a WithdrawalOrchestrator
@@ -50,6 +51,9 @@ type WithdrawalOrchestratorConfig struct {
 	// If provided, takes precedence over AccountConfig for clearing account lookup.
 	// If nil, falls back to static AccountConfig environment variables.
 	AccountResolver *AccountResolver
+	// FungibilityValidator validates fungibility for non-fungible instruments.
+	// If nil, fungibility validation is skipped (fully fungible instruments only).
+	FungibilityValidator *FungibilityValidator
 }
 
 // NewWithdrawalOrchestrator creates a new withdrawal orchestrator with the given dependencies.
@@ -68,12 +72,13 @@ func NewWithdrawalOrchestrator(cfg WithdrawalOrchestratorConfig) (*WithdrawalOrc
 		return nil, ErrOrchestratorFinAcctClientNil
 	}
 	return &WithdrawalOrchestrator{
-		logger:           cfg.Logger,
-		repo:             cfg.Repo,
-		posKeepingClient: cfg.PosKeepingClient,
-		finAcctClient:    cfg.FinAcctClient,
-		accountConfig:    cfg.AccountConfig,
-		accountResolver:  cfg.AccountResolver,
+		logger:               cfg.Logger,
+		repo:                 cfg.Repo,
+		posKeepingClient:     cfg.PosKeepingClient,
+		finAcctClient:        cfg.FinAcctClient,
+		accountConfig:        cfg.AccountConfig,
+		accountResolver:      cfg.AccountResolver,
+		fungibilityValidator: cfg.FungibilityValidator,
 	}, nil
 }
 
@@ -97,7 +102,13 @@ func NewWithdrawalOrchestrator(cfg WithdrawalOrchestratorConfig) (*WithdrawalOrc
 // Callers must use optimistic locking (version field) or database-level locking when
 // processing withdrawals for the same account concurrently. The repository layer enforces
 // optimistic locking via ErrVersionConflict.
-func (o *WithdrawalOrchestrator) Orchestrate(ctx context.Context, account domain.CurrentAccount, amount domain.Money, transactionID string) (*pb.ExecuteWithdrawalResponse, error) {
+//
+// Parameters:
+//   - attributes: Optional key-value pairs for fungibility validation. For non-fungible
+//     instruments (e.g., RICE-KG with batch tracking), both debit and credit sides
+//     of the double-entry must have matching fungibility keys. If nil, no fungibility
+//     validation is performed (suitable for fully fungible instruments like USD).
+func (o *WithdrawalOrchestrator) Orchestrate(ctx context.Context, account domain.CurrentAccount, amount domain.Money, transactionID string, attributes map[string]string) (*pb.ExecuteWithdrawalResponse, error) {
 	sagaStart := time.Now()
 	sagaStatus := operationStatusSuccess
 	defer func() {
@@ -112,6 +123,25 @@ func (o *WithdrawalOrchestrator) Orchestrate(ctx context.Context, account domain
 		ctx = observability.WithCorrelationID(ctx, correlationID)
 	} else {
 		o.logger.Info("using existing correlation ID", "correlation_id", correlationID)
+	}
+
+	// Validate fungibility before starting the saga.
+	// For double-entry withdrawals: DEBIT from customer account, CREDIT to clearing account
+	// Both sides use the same attributes since this is a single outgoing withdrawal.
+	if o.fungibilityValidator != nil {
+		instrumentCode := string(amount.Currency())
+		if err := o.fungibilityValidator.ValidateDoubleEntry(ctx, instrumentCode, 1, attributes, attributes); err != nil {
+			sagaStatus = operationStatusFailed
+			o.logger.Error("fungibility validation failed",
+				"account_id", account.AccountID(),
+				"transaction_id", transactionID,
+				"instrument", instrumentCode,
+				"error", err)
+			return nil, status.Errorf(codes.InvalidArgument, "fungibility validation failed: %v", err)
+		}
+		o.logger.Debug("fungibility validation passed",
+			"account_id", account.AccountID(),
+			"instrument", instrumentCode)
 	}
 
 	// Create saga orchestrator

--- a/shared/platform/ports/ports.go
+++ b/shared/platform/ports/ports.go
@@ -98,6 +98,13 @@ const (
 	// Protocol: gRPC (internal)
 	// Visibility: Cluster-internal only
 	MarketInformation = 50058
+
+	// ReferenceData is the gRPC port for the Reference Data service.
+	// BIAN Service Domain: Reference Data Directory
+	// Manages instrument definitions, validation rules, and fungibility expressions.
+	// Protocol: gRPC (internal)
+	// Visibility: Cluster-internal only
+	ReferenceData = 50059
 )
 
 // HTTP service ports (various protocols).


### PR DESCRIPTION
## Summary

- Add `FungibilityValidator` using reference-data client to validate double-entry transactions
- Validate debit/credit postings have compatible fungibility keys based on instrument's `fungibility_key_expression` (CEL program)
- Add `attributes` field to deposit/withdrawal proto messages for passing fungibility-relevant metadata

## Changes Made

- **`services/current-account/service/fungibility_validator.go`** (NEW): Core validation logic with `InstrumentGetter` interface and `celProgramAdapter` for CEL program integration
- **`services/current-account/service/fungibility_validator_test.go`** (NEW): Comprehensive TDD tests covering fully fungible instruments, matching/mismatched keys, instrument lookup errors, and CEL evaluation errors
- **`api/proto/meridian/current_account/v1/current_account.proto`**: Added `attributes` field (map<string, string>) to `ExecuteDepositRequest` (field 6), `InitiateWithdrawalRequest` (field 6), `ExecuteWithdrawalRequest` (field 7)
- **`services/current-account/service/deposit_orchestrator.go`**: Integrated validator before saga execution
- **`services/current-account/service/withdrawal_orchestrator.go`**: Integrated validator before saga execution
- **`services/current-account/service/grpc_service.go`**: Updated service constructor to accept validator, pass attributes from requests
- **`services/current-account/cmd/main.go`**: Wire reference-data client and FungibilityValidator
- **`shared/platform/ports/ports.go`**: Added `ReferenceData = 50059` port constant

## Technical Details

The `FungibilityValidator` follows these steps:
1. Retrieve instrument definition with pre-compiled CEL program via reference-data client
2. If no `fungibility_key_expression`, instrument is fully fungible (validation passes)
3. Evaluate CEL program with debit/credit attributes to compute fungibility keys
4. Compare keys - if they match, validation passes; if mismatched, returns `ErrFungibilityMismatch`

## Testing

- Unit tests for all validation paths (TDD approach)
- All existing tests pass
- Pre-commit checks pass (buf lint, golangci-lint, gofumpt)

## Task Reference

Task: tech-debt-cleanup.68