### PR TITLE
refactor(utilization-metering-consumer): Extract createHTTPServer for testability

### DIFF
--- a/services/utilization-metering-consumer/cmd/main.go
+++ b/services/utilization-metering-consumer/cmd/main.go
@@ -35,51 +35,14 @@ var (
 	BuildDate = "unknown"
 )
 
-func main() {
-	// Initialize structured logging
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	}))
-	slog.SetDefault(logger)
-
-	logger.Info("starting utilization-metering-consumer service",
-		"version", Version,
-		"commit", Commit,
-		"build_date", BuildDate)
-
-	// Run the service
-	if err := run(logger); err != nil {
-		logger.Error("service failed", "error", err)
-		os.Exit(1)
-	}
-
-	logger.Info("service stopped gracefully")
+// readinessState tracks the readiness of service components for the /ready probe.
+type readinessState struct {
+	consumerInitialized bool
 }
 
-func run(logger *slog.Logger) error {
-	// Load configuration
-	config, err := app.LoadConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load configuration: %w", err)
-	}
-
-	logger.Info("configuration loaded",
-		"kafka_bootstrap_servers", config.KafkaBootstrapServers,
-		"consumer_group_id", config.ConsumerGroupID,
-		"audit_topics", config.AuditTopics,
-		"position_keeping_endpoint", config.PositionKeepingEndpoint,
-		"tenant_zero_id", config.TenantZeroID)
-
-	// Create readiness tracker
-	type readinessState struct {
-		consumerInitialized bool
-	}
-	var (
-		readiness   = &readinessState{}
-		readinessMu = &sync.RWMutex{}
-	)
-
-	// Create HTTP server for health checks and metrics
+// createHTTPServer creates an HTTP server with health checks and metrics.
+// Extracted from run() to enable unit testing without starting full service.
+func createHTTPServer(httpPort string, readiness *readinessState, readinessMu *sync.RWMutex, logger *slog.Logger) *http.Server {
 	httpMux := http.NewServeMux()
 
 	// Health check endpoints
@@ -118,13 +81,58 @@ func run(logger *slog.Logger) error {
 	// Prometheus metrics endpoint
 	httpMux.Handle("/metrics", promhttp.Handler())
 
-	httpServer := &http.Server{
-		Addr:              fmt.Sprintf(":%s", config.HTTPPort),
+	return &http.Server{
+		Addr:              fmt.Sprintf(":%s", httpPort),
 		Handler:           httpMux,
 		ReadHeaderTimeout: 10 * time.Second,
 		WriteTimeout:      30 * time.Second,
 		IdleTimeout:       120 * time.Second,
 	}
+}
+
+func main() {
+	// Initialize structured logging
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelInfo,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting utilization-metering-consumer service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	// Run the service
+	if err := run(logger); err != nil {
+		logger.Error("service failed", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	// Load configuration
+	config, err := app.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	logger.Info("configuration loaded",
+		"kafka_bootstrap_servers", config.KafkaBootstrapServers,
+		"consumer_group_id", config.ConsumerGroupID,
+		"audit_topics", config.AuditTopics,
+		"position_keeping_endpoint", config.PositionKeepingEndpoint,
+		"tenant_zero_id", config.TenantZeroID)
+
+	// Create readiness tracker
+	var (
+		readiness   = &readinessState{}
+		readinessMu = &sync.RWMutex{}
+	)
+
+	// Create HTTP server for health checks and metrics
+	httpServer := createHTTPServer(config.HTTPPort, readiness, readinessMu, logger)
 
 	// Start HTTP server in background
 	serverErrors := make(chan error, 1)

--- a/services/utilization-metering-consumer/cmd/main_test.go
+++ b/services/utilization-metering-consumer/cmd/main_test.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -41,64 +45,66 @@ func TestHealthEndpoint_Liveness(_ *testing.T) {
 	// This test just verifies environment variable handling and basic setup.
 }
 
+func TestCreateHTTPServer(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	readiness := &readinessState{}
+	readinessMu := &sync.RWMutex{}
+
+	server := createHTTPServer("18082", readiness, readinessMu, logger)
+
+	// Verify server configuration
+	if server.Addr != ":18082" {
+		t.Errorf("Expected Addr ':18082', got '%s'", server.Addr)
+	}
+
+	if server.ReadHeaderTimeout != 10*time.Second {
+		t.Errorf("Expected ReadHeaderTimeout 10s, got %v", server.ReadHeaderTimeout)
+	}
+
+	if server.WriteTimeout != 30*time.Second {
+		t.Errorf("Expected WriteTimeout 30s, got %v", server.WriteTimeout)
+	}
+
+	if server.IdleTimeout != 120*time.Second {
+		t.Errorf("Expected IdleTimeout 120s, got %v", server.IdleTimeout)
+	}
+
+	// Verify handler is set
+	if server.Handler == nil {
+		t.Error("Expected Handler to be set, got nil")
+	}
+}
+
 func TestHealthEndpoint_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
 
-	// Set required environment variables
-	envVars := map[string]string{
-		"KAFKA_BOOTSTRAP_SERVERS":   "kafka:9092",
-		"CONSUMER_GROUP_ID":         "test-group",
-		"POSITION_KEEPING_ENDPOINT": "position-keeping:50051",
-		"TENANT_ZERO_ID":            "00000000-0000-0000-0000-000000000000",
-		"HTTP_PORT":                 "18081",
-	}
+	// Initialize logger for test
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	backup := make(map[string]string)
-	for key, value := range envVars {
-		backup[key] = os.Getenv(key)
-		os.Setenv(key, value)
-	}
-	defer func() {
-		for key, value := range backup {
-			if value == "" {
-				os.Unsetenv(key)
-			} else {
-				os.Setenv(key, value)
-			}
-		}
-	}()
+	// Create readiness state
+	readiness := &readinessState{}
+	readinessMu := &sync.RWMutex{}
 
-	// Start the server in background
+	// Create HTTP server using extracted function
+	httpServer := createHTTPServer("18081", readiness, readinessMu, logger)
+
+	// Start server in background
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	serverReady := make(chan bool)
+	serverErrors := make(chan error, 1)
 	go func() {
-		// TODO: Start actual server when fully implemented
-		// For now, create a simple test server with dedicated ServeMux
-		mux := http.NewServeMux()
-		mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("OK"))
-		})
-		server := &http.Server{
-			Addr:    ":18081",
-			Handler: mux,
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErrors <- err
 		}
-		serverReady <- true
-		go func() {
-			_ = server.ListenAndServe()
-		}()
-		<-ctx.Done()
-		shutdownCtx, shutdownCancel := context.WithTimeout(ctx, 5*time.Second)
-		defer shutdownCancel()
-		_ = server.Shutdown(shutdownCtx)
 	}()
-
-	// Wait for server to be ready
-	<-serverReady
+	defer func() {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		_ = httpServer.Shutdown(shutdownCtx)
+	}()
 
 	// Wait for health endpoint to respond
 	err := await.New().
@@ -120,30 +126,77 @@ func TestHealthEndpoint_Integration(t *testing.T) {
 		t.Fatalf("Health endpoint did not become ready: %v", err)
 	}
 
-	// Verify health endpoint response
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:18081/healthz", nil)
+	// Test 1: Verify liveness endpoint
+	testEndpoint(t, ctx, "http://localhost:18081/healthz", http.StatusOK, "OK")
+
+	// Test 2: Verify readiness endpoint (should be NOT_READY initially)
+	testEndpoint(t, ctx, "http://localhost:18081/ready", http.StatusServiceUnavailable, "NOT_READY")
+
+	// Test 3: Mark consumer as ready and verify readiness probe
+	readinessMu.Lock()
+	readiness.consumerInitialized = true
+	readinessMu.Unlock()
+
+	testEndpoint(t, ctx, "http://localhost:18081/ready", http.StatusOK, "READY")
+
+	// Test 4: Verify metrics endpoint returns Prometheus format
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://localhost:18081/metrics", nil)
 	if err != nil {
-		t.Fatalf("Failed to create request: %v", err)
+		t.Fatalf("Failed to create metrics request: %v", err)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		t.Fatalf("Failed to call health endpoint: %v", err)
+		t.Fatalf("Failed to call metrics endpoint: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+		t.Errorf("Metrics endpoint: expected status 200, got %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		t.Fatalf("Failed to read response body: %v", err)
+		t.Fatalf("Failed to read metrics response: %v", err)
 	}
 
-	if string(body) != "OK" {
-		t.Errorf("Expected body 'OK', got '%s'", string(body))
+	// Verify Prometheus format (contains # HELP and # TYPE comments)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "# HELP") || !strings.Contains(bodyStr, "# TYPE") {
+		t.Errorf("Metrics endpoint did not return Prometheus format")
 	}
 
-	// Clean up
-	cancel()
+	// Verify no server errors occurred
+	select {
+	case err := <-serverErrors:
+		t.Fatalf("Server error occurred: %v", err)
+	default:
+		// No errors, test passed
+	}
+}
+
+// testEndpoint is a helper function to test HTTP endpoints.
+func testEndpoint(t *testing.T, ctx context.Context, url string, expectedStatus int, expectedBody string) {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("Failed to create request for %s: %v", url, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Failed to call %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != expectedStatus {
+		t.Errorf("%s: expected status %d, got %d", url, expectedStatus, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Failed to read response body from %s: %v", url, err)
+	}
+
+	if string(body) != expectedBody {
+		t.Errorf("%s: expected body '%s', got '%s'", url, expectedBody, string(body))
+	}
 }


### PR DESCRIPTION
## Summary

- Extracts `createHTTPServer()` function from `run()` for testability
- Replaces mock HTTP server in `TestHealthEndpoint_Integration` with actual service HTTP server
- Adds unit test for `createHTTPServer` configuration validation
- Tests full HTTP layer including health checks, readiness probes, and metrics

## Changes Made

- Extract `readinessState` type to package level for test access
- Add `createHTTPServer()` function separated from `run()` for testability
- Update `run()` to use extracted function
- Add `TestCreateHTTPServer` unit test for configuration validation
- Rewrite `TestHealthEndpoint_Integration` to use real server lifecycle
- Add `testEndpoint` helper for consistent endpoint testing
- Test readiness state transitions (NOT_READY → READY)
- Verify Prometheus metrics format on `/metrics` endpoint

## Test plan

- [x] `TestCreateHTTPServer` verifies server configuration (port, timeouts, handler)
- [x] `TestHealthEndpoint_Integration` verifies:
  - `/healthz` returns 200 OK with body "OK"
  - `/ready` returns 503 NOT_READY before consumer init
  - `/ready` returns 200 READY after marking consumer initialized
  - `/metrics` returns Prometheus format (contains # HELP and # TYPE)
- [x] Race detector passes: `go test -race`
- [x] Short mode skips integration test: `go test -short`