### PR TITLE
feat(position-keeping): add instrument validation to InitiateWithOpeningBalance

### DIFF
--- a/api/proto/meridian/position_keeping/v1/position_keeping.proto
+++ b/api/proto/meridian/position_keeping/v1/position_keeping.proto
@@ -337,6 +337,19 @@ message InitiateWithOpeningBalanceRequest {
 
   // idempotency_key ensures exactly-once processing.
   meridian.common.v1.IdempotencyKey idempotency_key = 5;
+
+  // instrument_code is the instrument code for CEL validation (optional).
+  // When provided, the opening balance attributes are validated against the instrument's
+  // validation expression (e.g., "USD", "EUR_ELECTRICITY_KWH").
+  // If empty, validation is skipped for backwards compatibility with legacy migrations.
+  string instrument_code = 6 [(buf.validate.field).string = {
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // attributes are optional key-value pairs for CEL validation (e.g., batch_id, grade, vintage).
+  // These are validated against the instrument's validation expression when instrument_code is set.
+  map<string, string> attributes = 7 [(buf.validate.field).map.max_pairs = 50];
 }
 
 // InitiateWithOpeningBalanceResponse returns the created log with opening balance.

--- a/api/proto/meridian/position_keeping/v1/position_keeping.proto
+++ b/api/proto/meridian/position_keeping/v1/position_keeping.proto
@@ -342,10 +342,13 @@ message InitiateWithOpeningBalanceRequest {
   // When provided, the opening balance attributes are validated against the instrument's
   // validation expression (e.g., "USD", "EUR_ELECTRICITY_KWH").
   // If empty, validation is skipped for backwards compatibility with legacy migrations.
-  string instrument_code = 6 [(buf.validate.field).string = {
-    max_len: 32
-    pattern: "^[A-Z][A-Z0-9_]*$"
-  }];
+  string instrument_code = 6 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string = {
+      max_len: 32
+      pattern: "^[A-Z][A-Z0-9_]*$"
+    }
+  ];
 
   // attributes are optional key-value pairs for CEL validation (e.g., batch_id, grade, vintage).
   // These are validated against the instrument's validation expression when instrument_code is set.

--- a/services/position-keeping/service/initiate_migration.go
+++ b/services/position-keeping/service/initiate_migration.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"google.golang.org/grpc/codes"
@@ -11,6 +12,7 @@ import (
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/meridianhub/meridian/pkg/platform/quantity"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
@@ -55,6 +57,14 @@ func (s *PositionKeepingService) InitiateWithOpeningBalance(
 	openingBalance, err := protoMoneyAmountToDomain(req.OpeningBalance)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid opening_balance: %v", err)
+	}
+
+	// Validate instrument and attributes using CEL (if instrument_code provided)
+	if req.InstrumentCode != "" {
+		amountStr := fmt.Sprintf("%d.%09d", req.OpeningBalance.Amount.Units, req.OpeningBalance.Amount.Nanos)
+		if err := s.validateOpeningBalanceWithCEL(ctx, req.InstrumentCode, amountStr, req.Attributes); err != nil {
+			return nil, err // Already a gRPC status error
+		}
 	}
 
 	// Extract effective date from proto timestamp
@@ -216,4 +226,104 @@ func (s *PositionKeepingService) checkMigrationIdempotencyAndAcquireLock(
 	}
 
 	return &key, nil, nil
+}
+
+// validateOpeningBalanceWithCEL validates opening balance attributes against the instrument definition.
+// This is optional - if instrumentCache is nil or instrumentCode is empty, validation is skipped
+// for backwards compatibility.
+//
+// The CEL program receives the following variables:
+//   - attributes: map[string]string of opening balance attributes
+//   - amount: string representation of the opening balance amount
+//   - valid_from: zero time (for future use)
+//   - valid_to: zero time (for future use)
+//   - source: extracted from attributes["source"] or empty string
+//
+// Returns nil if validation passes or is skipped.
+// Returns gRPC INVALID_ARGUMENT error if validation fails.
+// Returns gRPC NOT_FOUND error if instrument is not found.
+// Returns gRPC FAILED_PRECONDITION error if instrument is not active.
+func (s *PositionKeepingService) validateOpeningBalanceWithCEL(
+	ctx context.Context,
+	instrumentCode string,
+	amount string,
+	attributes map[string]string,
+) error {
+	// Skip validation if instrument cache is not configured (backwards compatibility)
+	if s.instrumentCache == nil {
+		return nil
+	}
+
+	// Skip validation if no instrument code provided (backwards compatibility)
+	if instrumentCode == "" {
+		return nil
+	}
+
+	// Acquire an AttributeBag from pool for efficient memory reuse
+	bag := quantity.AcquireAttributeBag()
+	defer quantity.ReleaseAttributeBag(bag)
+
+	// Populate AttributeBag from attributes
+	for k, v := range attributes {
+		bag.Set(k, v)
+	}
+
+	// Look up instrument from cache using instrument_code
+	// Use version=1 for now; could be made configurable in the future
+	const instrumentVersion = 1
+	instrument, err := s.instrumentCache.GetOrLoad(ctx, instrumentCode, instrumentVersion, func() (*CachedInstrument, error) {
+		// The loadFn should never be called if the cache is properly configured
+		// with a backing repository. For now, return not found to trigger the error path.
+		return nil, fmt.Errorf("%w: %s", ErrInstrumentNotFound, instrumentCode)
+	})
+	if err != nil {
+		// Instrument not found - record metric and return error
+		RecordOpeningBalanceValidationFailure(instrumentCode, ValidationFailureReasonInstrumentNotFound)
+		return status.Errorf(codes.NotFound,
+			"instrument definition not found for instrument code '%s': %v", instrumentCode, err)
+	}
+
+	// Build the activation context for CEL evaluation
+	// The CEL program expects these specific variable names
+	source := ""
+	if attributes != nil {
+		source = attributes["source"]
+	}
+	attributesMap := bag.ToMap()
+	activation := map[string]any{
+		"attributes": attributesMap,
+		"amount":     amount,
+		"valid_from": time.Time{}, // Zero time for now
+		"valid_to":   time.Time{}, // Zero time for now
+		"source":     source,
+	}
+
+	// Run validation if instrument has a validation program
+	if instrument.ValidationProgram != nil {
+		result, _, err := instrument.ValidationProgram.Eval(activation)
+		if err != nil {
+			// CEL evaluation error - record metric and return error
+			RecordOpeningBalanceValidationFailure(instrumentCode, ValidationFailureReasonCELError)
+			return status.Errorf(codes.InvalidArgument,
+				"validation error for instrument '%s': %v", instrumentCode, err)
+		}
+
+		// The validation program should return a boolean
+		valid, ok := result.Value().(bool)
+		if !ok {
+			// Unexpected return type from CEL - treat as error
+			RecordOpeningBalanceValidationFailure(instrumentCode, ValidationFailureReasonCELError)
+			return status.Errorf(codes.InvalidArgument,
+				"validation error for instrument '%s': expression did not return boolean", instrumentCode)
+		}
+
+		if !valid {
+			// Validation rejected the opening balance - record metric and return error
+			RecordOpeningBalanceValidationFailure(instrumentCode, ValidationFailureReasonCELRejected)
+			return status.Errorf(codes.InvalidArgument,
+				"opening balance validation failed for instrument '%s': attributes do not satisfy validation rules", instrumentCode)
+		}
+	}
+
+	return nil
 }

--- a/services/position-keeping/service/initiate_migration.go
+++ b/services/position-keeping/service/initiate_migration.go
@@ -61,7 +61,23 @@ func (s *PositionKeepingService) InitiateWithOpeningBalance(
 
 	// Validate instrument and attributes using CEL (if instrument_code provided)
 	if req.InstrumentCode != "" {
-		amountStr := fmt.Sprintf("%d.%09d", req.OpeningBalance.Amount.Units, req.OpeningBalance.Amount.Nanos)
+		// Format amount as decimal string, handling negative values correctly.
+		// money.Money spec requires Units and Nanos to have the same sign.
+		units := req.OpeningBalance.Amount.Units
+		nanos := req.OpeningBalance.Amount.Nanos
+		var amountStr string
+		if units < 0 || nanos < 0 {
+			// For negative amounts, use absolute values and prepend minus
+			if units < 0 {
+				units = -units
+			}
+			if nanos < 0 {
+				nanos = -nanos
+			}
+			amountStr = fmt.Sprintf("-%d.%09d", units, nanos)
+		} else {
+			amountStr = fmt.Sprintf("%d.%09d", units, nanos)
+		}
 		if err := s.validateOpeningBalanceWithCEL(ctx, req.InstrumentCode, amountStr, req.Attributes); err != nil {
 			return nil, err // Already a gRPC status error
 		}
@@ -285,10 +301,8 @@ func (s *PositionKeepingService) validateOpeningBalanceWithCEL(
 
 	// Build the activation context for CEL evaluation
 	// The CEL program expects these specific variable names
-	source := ""
-	if attributes != nil {
-		source = attributes["source"]
-	}
+	// Note: Go map access on nil returns zero value, so no nil check needed
+	source := attributes["source"]
 	attributesMap := bag.ToMap()
 	activation := map[string]any{
 		"attributes": attributesMap,

--- a/services/position-keeping/service/initiate_migration.go
+++ b/services/position-keeping/service/initiate_migration.go
@@ -61,23 +61,9 @@ func (s *PositionKeepingService) InitiateWithOpeningBalance(
 
 	// Validate instrument and attributes using CEL (if instrument_code provided)
 	if req.InstrumentCode != "" {
-		// Format amount as decimal string, handling negative values correctly.
-		// money.Money spec requires Units and Nanos to have the same sign.
-		units := req.OpeningBalance.Amount.Units
-		nanos := req.OpeningBalance.Amount.Nanos
-		var amountStr string
-		if units < 0 || nanos < 0 {
-			// For negative amounts, use absolute values and prepend minus
-			if units < 0 {
-				units = -units
-			}
-			if nanos < 0 {
-				nanos = -nanos
-			}
-			amountStr = fmt.Sprintf("-%d.%09d", units, nanos)
-		} else {
-			amountStr = fmt.Sprintf("%d.%09d", units, nanos)
-		}
+		// Reuse the already-converted domain amount for string formatting.
+		// This uses the battle-tested decimal library and handles all edge cases correctly.
+		amountStr := openingBalance.Amount.String()
 		if err := s.validateOpeningBalanceWithCEL(ctx, req.InstrumentCode, amountStr, req.Attributes); err != nil {
 			return nil, err // Already a gRPC status error
 		}

--- a/services/position-keeping/service/initiate_migration.go
+++ b/services/position-keeping/service/initiate_migration.go
@@ -279,10 +279,16 @@ func (s *PositionKeepingService) validateOpeningBalanceWithCEL(
 		return nil, fmt.Errorf("%w: %s", ErrInstrumentNotFound, instrumentCode)
 	})
 	if err != nil {
-		// Instrument not found - record metric and return error
-		RecordOpeningBalanceValidationFailure(instrumentCode, ValidationFailureReasonInstrumentNotFound)
-		return status.Errorf(codes.NotFound,
-			"instrument definition not found for instrument code '%s': %v", instrumentCode, err)
+		// Distinguish instrument-not-found from other cache/backend errors
+		if errors.Is(err, ErrInstrumentNotFound) {
+			RecordOpeningBalanceValidationFailure(instrumentCode, ValidationFailureReasonInstrumentNotFound)
+			return status.Errorf(codes.NotFound,
+				"instrument definition not found for instrument code '%s': %v", instrumentCode, err)
+		}
+		// Other errors (cache failures, backend timeouts, etc.) are internal errors
+		RecordOpeningBalanceValidationFailure(instrumentCode, ValidationFailureReasonCELError)
+		return status.Errorf(codes.Internal,
+			"failed to load instrument definition for instrument code '%s': %v", instrumentCode, err)
 	}
 
 	// Build the activation context for CEL evaluation

--- a/services/position-keeping/service/initiate_migration_test.go
+++ b/services/position-keeping/service/initiate_migration_test.go
@@ -970,3 +970,67 @@ func TestInitiateWithOpeningBalance_CEL_ComplexValidationFails(t *testing.T) {
 	mockRepo.AssertNotCalled(t, "Create")
 	mockCache.AssertExpectations(t)
 }
+
+func TestInitiateWithOpeningBalance_CEL_NegativeAmountPassesValidation(t *testing.T) {
+	// Test that negative opening balances (e.g., overdraft positions) are correctly
+	// formatted and passed to CEL validation. This covers the edge case for
+	// migrating accounts with negative balances.
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	effectiveDate := time.Now().Add(-24 * time.Hour)
+
+	// Create a CEL program that validates the batch_id attribute exists
+	// (doesn't check the amount value, just ensures CEL receives it correctly)
+	validationProgram := createMigrationTestCELProgram(t, `"batch_id" in attributes`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:    "USD",
+		ValidationProgram: validationProgram,
+	}
+
+	mockCache.On("GetOrLoad", ctx, "USD", 1).Return(cachedInstrument, nil)
+	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	// Negative opening balance: -$500.50 (overdraft position)
+	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
+		AccountId: "overdraft-account-001",
+		OpeningBalance: &commonv1.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "USD",
+				Units:        -500,
+				Nanos:        -500000000, // -$500.50 (money.Money requires same sign)
+			},
+		},
+		EffectiveDate:  timestamppb.New(effectiveDate),
+		InstrumentCode: "USD",
+		Attributes: map[string]string{
+			"batch_id": "OVERDRAFT-MIGRATION-2024",
+		},
+	}
+
+	resp, err := svc.InitiateWithOpeningBalance(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Log)
+	assert.NotEmpty(t, resp.Log.LogId)
+	// Verify the transaction entry shows DEBIT direction for negative balance
+	assert.Len(t, resp.Log.TransactionLogEntries, 1)
+	assert.Equal(t, commonv1.PostingDirection_POSTING_DIRECTION_DEBIT, resp.Log.TransactionLogEntries[0].Direction)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+}

--- a/services/position-keeping/service/initiate_migration_test.go
+++ b/services/position-keeping/service/initiate_migration_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/cel-go/cel"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -17,6 +18,7 @@ import (
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/services/position-keeping/service"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 )
 
@@ -523,4 +525,448 @@ func TestInitiateWithOpeningBalance_IdempotencyCheckError(t *testing.T) {
 	// Verify that MarkPending was NOT called since we returned early
 	mockIdempotency.AssertNotCalled(t, "MarkPending")
 	mockRepo.AssertNotCalled(t, "Create")
+}
+
+// =============================================================================
+// CEL Validation Tests for InitiateWithOpeningBalance
+// =============================================================================
+
+// createMigrationTestCELProgram creates a CEL program for testing validation.
+// The expression should evaluate to a boolean.
+func createMigrationTestCELProgram(t *testing.T, expression string) cel.Program {
+	t.Helper()
+	env, err := cel.NewEnv(
+		cel.Variable("attributes", cel.MapType(cel.StringType, cel.StringType)),
+		cel.Variable("amount", cel.StringType),
+		cel.Variable("valid_from", cel.TimestampType),
+		cel.Variable("valid_to", cel.TimestampType),
+		cel.Variable("source", cel.StringType),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(expression)
+	require.NoError(t, issues.Err())
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	return prg
+}
+
+func TestInitiateWithOpeningBalance_CEL_ValidationPasses(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	// Create service with instrument cache
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	effectiveDate := time.Now().Add(-24 * time.Hour)
+
+	// Create a CEL program that validates the batch_id attribute exists
+	validationProgram := createMigrationTestCELProgram(t, `"batch_id" in attributes`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:    "USD",
+		ValidationProgram: validationProgram,
+	}
+
+	// Setup mock expectations
+	mockCache.On("GetOrLoad", ctx, "USD", 1).Return(cachedInstrument, nil)
+	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
+		AccountId: "migrated-account-001",
+		OpeningBalance: &commonv1.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "USD",
+				Units:        1500,
+				Nanos:        500000000,
+			},
+		},
+		EffectiveDate:  timestamppb.New(effectiveDate),
+		InstrumentCode: "USD",
+		Attributes: map[string]string{
+			"batch_id": "2024-Q1", // This satisfies the CEL expression
+		},
+	}
+
+	resp, err := svc.InitiateWithOpeningBalance(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Log)
+	assert.NotEmpty(t, resp.Log.LogId)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+}
+
+func TestInitiateWithOpeningBalance_CEL_ValidationRejects(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	effectiveDate := time.Now().Add(-24 * time.Hour)
+
+	// Create a CEL program that requires a specific batch_id format
+	validationProgram := createMigrationTestCELProgram(t, `"batch_id" in attributes && attributes["batch_id"] != ""`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:    "USD",
+		ValidationProgram: validationProgram,
+	}
+
+	mockCache.On("GetOrLoad", ctx, "USD", 1).Return(cachedInstrument, nil)
+
+	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
+		AccountId: "migrated-account-001",
+		OpeningBalance: &commonv1.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "USD",
+				Units:        1500,
+				Nanos:        0,
+			},
+		},
+		EffectiveDate:  timestamppb.New(effectiveDate),
+		InstrumentCode: "USD",
+		Attributes:     map[string]string{}, // Missing batch_id - should fail
+	}
+
+	resp, err := svc.InitiateWithOpeningBalance(ctx, req)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "validation failed")
+	mockRepo.AssertNotCalled(t, "Create")
+	mockCache.AssertExpectations(t)
+}
+
+func TestInitiateWithOpeningBalance_CEL_NilCacheSkipsValidation(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+
+	// Create service WITHOUT instrument cache (nil)
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		// No WithInstrumentCache - cache is nil
+	)
+	require.NoError(t, err)
+
+	effectiveDate := time.Now().Add(-24 * time.Hour)
+
+	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
+		AccountId: "migrated-account-001",
+		OpeningBalance: &commonv1.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "USD",
+				Units:        1500,
+				Nanos:        0,
+			},
+		},
+		EffectiveDate:  timestamppb.New(effectiveDate),
+		InstrumentCode: "USD", // Instrument code provided but no cache
+		Attributes: map[string]string{
+			"batch_id": "2024-Q1",
+		},
+	}
+
+	resp, err := svc.InitiateWithOpeningBalance(ctx, req)
+
+	// Should succeed - validation skipped because cache is nil
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.Log.LogId)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestInitiateWithOpeningBalance_CEL_EmptyInstrumentCodeSkipsValidation(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	effectiveDate := time.Now().Add(-24 * time.Hour)
+
+	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
+		AccountId: "migrated-account-001",
+		OpeningBalance: &commonv1.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "USD",
+				Units:        1500,
+				Nanos:        0,
+			},
+		},
+		EffectiveDate:  timestamppb.New(effectiveDate),
+		InstrumentCode: "", // Empty - legacy mode, skip validation
+		// No attributes
+	}
+
+	resp, err := svc.InitiateWithOpeningBalance(ctx, req)
+
+	// Should succeed - validation skipped because instrument_code is empty
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.Log.LogId)
+	// Verify cache was NOT called since instrument_code is empty
+	mockCache.AssertNotCalled(t, "GetOrLoad")
+	mockRepo.AssertExpectations(t)
+}
+
+func TestInitiateWithOpeningBalance_CEL_NilValidationProgramPasses(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	effectiveDate := time.Now().Add(-24 * time.Hour)
+
+	// Instrument with NO validation program (nil) - fully fungible
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:    "USD",
+		ValidationProgram: nil, // No validation expression defined
+	}
+
+	mockCache.On("GetOrLoad", ctx, "USD", 1).Return(cachedInstrument, nil)
+	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
+		AccountId: "migrated-account-001",
+		OpeningBalance: &commonv1.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "USD",
+				Units:        1500,
+				Nanos:        0,
+			},
+		},
+		EffectiveDate:  timestamppb.New(effectiveDate),
+		InstrumentCode: "USD",
+		// No attributes - validation is skipped because program is nil
+	}
+
+	resp, err := svc.InitiateWithOpeningBalance(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.Log.LogId)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+}
+
+func TestInitiateWithOpeningBalance_CEL_InstrumentNotFound(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	effectiveDate := time.Now().Add(-24 * time.Hour)
+
+	// Cache returns not found error
+	mockCache.On("GetOrLoad", ctx, "UNKNOWN_INSTRUMENT", 1).Return(nil, service.ErrInstrumentNotFound)
+
+	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
+		AccountId: "migrated-account-001",
+		OpeningBalance: &commonv1.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "USD",
+				Units:        1500,
+				Nanos:        0,
+			},
+		},
+		EffectiveDate:  timestamppb.New(effectiveDate),
+		InstrumentCode: "UNKNOWN_INSTRUMENT",
+	}
+
+	resp, err := svc.InitiateWithOpeningBalance(ctx, req)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+	assert.Contains(t, st.Message(), "instrument definition not found")
+	mockRepo.AssertNotCalled(t, "Create")
+	mockCache.AssertExpectations(t)
+}
+
+func TestInitiateWithOpeningBalance_CEL_ComplexValidationExpression(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	effectiveDate := time.Now().Add(-24 * time.Hour)
+
+	// Create a CEL program with complex validation:
+	// batch_id must exist AND grade must be "1" or "2"
+	validationProgram := createMigrationTestCELProgram(t, `"batch_id" in attributes && "grade" in attributes && attributes["grade"] in ["1", "2"]`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:    "ELECTRICITY_KWH",
+		ValidationProgram: validationProgram,
+	}
+
+	mockCache.On("GetOrLoad", ctx, "ELECTRICITY_KWH", 1).Return(cachedInstrument, nil)
+	mockRepo.On("Create", ctx, mock.AnythingOfType("*domain.FinancialPositionLog")).Return(nil)
+
+	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
+		AccountId: "migrated-account-001",
+		OpeningBalance: &commonv1.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "USD",
+				Units:        1000,
+				Nanos:        0,
+			},
+		},
+		EffectiveDate:  timestamppb.New(effectiveDate),
+		InstrumentCode: "ELECTRICITY_KWH",
+		Attributes: map[string]string{
+			"batch_id": "2024-Q1",
+			"grade":    "1", // Valid grade
+		},
+	}
+
+	resp, err := svc.InitiateWithOpeningBalance(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.NotEmpty(t, resp.Log.LogId)
+	mockRepo.AssertExpectations(t)
+	mockCache.AssertExpectations(t)
+}
+
+func TestInitiateWithOpeningBalance_CEL_ComplexValidationFails(t *testing.T) {
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	effectiveDate := time.Now().Add(-24 * time.Hour)
+
+	// Create a CEL program with complex validation
+	validationProgram := createMigrationTestCELProgram(t, `"batch_id" in attributes && "grade" in attributes && attributes["grade"] in ["1", "2"]`)
+
+	cachedInstrument := &service.CachedInstrument{
+		InstrumentCode:    "ELECTRICITY_KWH",
+		ValidationProgram: validationProgram,
+	}
+
+	mockCache.On("GetOrLoad", ctx, "ELECTRICITY_KWH", 1).Return(cachedInstrument, nil)
+
+	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
+		AccountId: "migrated-account-001",
+		OpeningBalance: &commonv1.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "USD",
+				Units:        1000,
+				Nanos:        0,
+			},
+		},
+		EffectiveDate:  timestamppb.New(effectiveDate),
+		InstrumentCode: "ELECTRICITY_KWH",
+		Attributes: map[string]string{
+			"batch_id": "2024-Q1",
+			"grade":    "3", // Invalid grade - not in ["1", "2"]
+		},
+	}
+
+	resp, err := svc.InitiateWithOpeningBalance(ctx, req)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "validation failed")
+	mockRepo.AssertNotCalled(t, "Create")
+	mockCache.AssertExpectations(t)
 }

--- a/services/position-keeping/service/initiate_migration_test.go
+++ b/services/position-keeping/service/initiate_migration_test.go
@@ -856,6 +856,54 @@ func TestInitiateWithOpeningBalance_CEL_InstrumentNotFound(t *testing.T) {
 	mockCache.AssertExpectations(t)
 }
 
+func TestInitiateWithOpeningBalance_CEL_CacheFailure(t *testing.T) {
+	// Test that cache/backend failures return codes.Internal (not NotFound)
+	ctx := context.Background()
+	mockRepo := new(MockRepository)
+	mockMeasurementRepo := new(MockMeasurementRepository)
+	mockEventPublisher := domain.NewInMemoryEventPublisher()
+	mockIdempotency := new(MockIdempotencyService)
+	mockCache := new(MockInstrumentCache)
+
+	svc, err := service.NewPositionKeepingService(
+		mockRepo,
+		mockMeasurementRepo,
+		mockEventPublisher,
+		mockIdempotency,
+		service.WithInstrumentCache(mockCache),
+	)
+	require.NoError(t, err)
+
+	effectiveDate := time.Now().Add(-24 * time.Hour)
+
+	// Cache returns a generic error (e.g., Redis timeout, backend failure)
+	mockCache.On("GetOrLoad", ctx, "USD", 1).Return(nil, assert.AnError)
+
+	req := &positionkeepingv1.InitiateWithOpeningBalanceRequest{
+		AccountId: "migrated-account-001",
+		OpeningBalance: &commonv1.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "USD",
+				Units:        1500,
+				Nanos:        0,
+			},
+		},
+		EffectiveDate:  timestamppb.New(effectiveDate),
+		InstrumentCode: "USD",
+	}
+
+	resp, err := svc.InitiateWithOpeningBalance(ctx, req)
+
+	require.Error(t, err)
+	require.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "failed to load instrument definition")
+	mockRepo.AssertNotCalled(t, "Create")
+	mockCache.AssertExpectations(t)
+}
+
 func TestInitiateWithOpeningBalance_CEL_ComplexValidationExpression(t *testing.T) {
 	ctx := context.Background()
 	mockRepo := new(MockRepository)

--- a/services/position-keeping/service/metrics.go
+++ b/services/position-keeping/service/metrics.go
@@ -61,12 +61,33 @@ func RecordCardinalityViolation(instrumentCode string) {
 	bucketCardinalityViolationsTotal.WithLabelValues(instrumentCode).Inc()
 }
 
+// openingBalanceValidationFailuresTotal counts validation failures for opening balances.
+// Labels:
+//   - instrument_code: the instrument code being validated
+//   - failure_reason: bounded set (cel_rejected, cel_error, instrument_not_found)
+var openingBalanceValidationFailuresTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "meridian",
+		Subsystem: "position_keeping",
+		Name:      "opening_balance_validation_failures_total",
+		Help:      "Total number of opening balance validation failures by instrument code and reason",
+	},
+	[]string{"instrument_code", "failure_reason"},
+)
+
+// RecordOpeningBalanceValidationFailure increments the opening balance validation failure counter.
+func RecordOpeningBalanceValidationFailure(instrumentCode string, reason string) {
+	openingBalanceValidationFailuresTotal.WithLabelValues(instrumentCode, reason).Inc()
+}
+
 // ExposeMetricsForTesting provides access to the raw Prometheus metrics for testing.
 // This should only be used in test code.
 var ExposeMetricsForTesting = struct {
-	MeasurementValidationFailuresTotal *prometheus.CounterVec
-	BucketCardinalityViolationsTotal   *prometheus.CounterVec
+	MeasurementValidationFailuresTotal    *prometheus.CounterVec
+	BucketCardinalityViolationsTotal      *prometheus.CounterVec
+	OpeningBalanceValidationFailuresTotal *prometheus.CounterVec
 }{
-	MeasurementValidationFailuresTotal: measurementValidationFailuresTotal,
-	BucketCardinalityViolationsTotal:   bucketCardinalityViolationsTotal,
+	MeasurementValidationFailuresTotal:    measurementValidationFailuresTotal,
+	BucketCardinalityViolationsTotal:      bucketCardinalityViolationsTotal,
+	OpeningBalanceValidationFailuresTotal: openingBalanceValidationFailuresTotal,
 }


### PR DESCRIPTION
## Summary

- Add optional CEL-based instrument validation to the `InitiateWithOpeningBalance` RPC for validating opening balances during legacy system migrations
- Add `instrument_code` and `attributes` fields to `InitiateWithOpeningBalanceRequest` proto
- Implement `validateOpeningBalanceWithCEL` helper that validates against instrument definitions from the cache
- Add Prometheus metric `meridian_position_keeping_opening_balance_validation_failures_total` for observability
- Add 8 comprehensive unit tests covering validation passes, rejections, and edge cases

The validation is backwards-compatible: when `instrument_code` is empty or the instrument cache is not configured, validation is skipped to support legacy migrations without instrument definitions.

## Test plan

- [x] Unit tests pass for all validation scenarios (8 new tests)
- [x] All existing position-keeping tests pass (no regressions)
- [x] Linter passes with no issues
- [ ] CI pipeline passes

## Task Master

`tech-debt-cleanup.69` - Add instrument validation to Position-Keeping InitiateWithOpeningBalance