### PR TITLE
feat(reference-data): implement cursor-based pagination for ListInstruments

### DIFF
--- a/services/reference-data/handler/grpc_handler.go
+++ b/services/reference-data/handler/grpc_handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/google/uuid"
@@ -143,11 +144,16 @@ func (s *Service) RetrieveInstrument(ctx context.Context, req *pb.RetrieveInstru
 	}, nil
 }
 
-// ListInstruments returns instruments matching the filter criteria.
+// ListInstruments returns instruments matching the filter criteria with cursor-based pagination.
 // NOTE: The underlying registry only supports ListActive. Filtering by
 // DRAFT or DEPRECATED status will return empty results. This is a known
 // limitation that should be addressed by extending InstrumentRegistry.
 func (s *Service) ListInstruments(ctx context.Context, req *pb.ListInstrumentsRequest) (*pb.ListInstrumentsResponse, error) {
+	cursorTime, cursorID, err := parseCursorToken(req.PageToken)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid page token: %v", err)
+	}
+
 	// TODO(universal-asset-system.13): Add ListAll/ListByStatus to InstrumentRegistry
 	// Currently registry only supports ListActive, so non-ACTIVE filters return empty.
 	defs, err := s.registry.ListActive(ctx)
@@ -156,29 +162,11 @@ func (s *Service) ListInstruments(ctx context.Context, req *pb.ListInstrumentsRe
 		return nil, status.Errorf(codes.Internal, "failed to list instruments: %v", err)
 	}
 
-	// Filter by status if specified
-	var filtered []*registry.InstrumentDefinition
-	if req.StatusFilter != pb.InstrumentStatus_INSTRUMENT_STATUS_UNSPECIFIED {
-		domainStatus := protoStatusToDomain(req.StatusFilter)
-		for _, def := range defs {
-			if def.Status == domainStatus {
-				filtered = append(filtered, def)
-			}
-		}
-	} else {
-		filtered = defs
-	}
-
-	// Apply pagination
-	pageSize := int(req.PageSize)
-	if pageSize == 0 {
-		pageSize = 50 // Default page size
-	}
-
-	// TODO: Implement proper cursor-based pagination
-	if len(filtered) > pageSize {
-		filtered = filtered[:pageSize]
-	}
+	filtered := filterByStatus(defs, req.StatusFilter)
+	sortByCreatedAtDesc(filtered)
+	filtered = applyCursorFilter(filtered, cursorTime, cursorID)
+	pageSize := normalizePageSize(int(req.PageSize))
+	filtered, hasMore := applyPageLimit(filtered, pageSize)
 
 	instruments := make([]*pb.InstrumentDefinition, len(filtered))
 	for i, def := range filtered {
@@ -187,8 +175,80 @@ func (s *Service) ListInstruments(ctx context.Context, req *pb.ListInstrumentsRe
 
 	return &pb.ListInstrumentsResponse{
 		Instruments:   instruments,
-		NextPageToken: "", // TODO: Implement pagination token
+		NextPageToken: generateNextPageToken(filtered, hasMore),
 	}, nil
+}
+
+// filterByStatus filters instruments by the requested status, returning all if unspecified.
+func filterByStatus(defs []*registry.InstrumentDefinition, statusFilter pb.InstrumentStatus) []*registry.InstrumentDefinition {
+	if statusFilter == pb.InstrumentStatus_INSTRUMENT_STATUS_UNSPECIFIED {
+		return defs
+	}
+	domainStatus := protoStatusToDomain(statusFilter)
+	var filtered []*registry.InstrumentDefinition
+	for _, def := range defs {
+		if def.Status == domainStatus {
+			filtered = append(filtered, def)
+		}
+	}
+	return filtered
+}
+
+// sortByCreatedAtDesc sorts instruments by CreatedAt DESC, ID DESC.
+func sortByCreatedAtDesc(defs []*registry.InstrumentDefinition) {
+	sort.Slice(defs, func(i, j int) bool {
+		ti := defs[i].CreatedAt.Truncate(time.Second)
+		tj := defs[j].CreatedAt.Truncate(time.Second)
+		if ti.Equal(tj) {
+			return defs[i].ID.String() > defs[j].ID.String()
+		}
+		return ti.After(tj)
+	})
+}
+
+// applyCursorFilter filters instruments to those after the cursor position.
+func applyCursorFilter(defs []*registry.InstrumentDefinition, cursorTime time.Time, cursorID uuid.UUID) []*registry.InstrumentDefinition {
+	if cursorTime.IsZero() {
+		return defs
+	}
+	cursorTimeCompare := cursorTime.Truncate(time.Second)
+	var filtered []*registry.InstrumentDefinition
+	for _, def := range defs {
+		defTime := def.CreatedAt.Truncate(time.Second)
+		if defTime.Before(cursorTimeCompare) ||
+			(defTime.Equal(cursorTimeCompare) && def.ID.String() < cursorID.String()) {
+			filtered = append(filtered, def)
+		}
+	}
+	return filtered
+}
+
+// normalizePageSize applies default and max limits to page size.
+func normalizePageSize(pageSize int) int {
+	if pageSize == 0 {
+		return DefaultPageSize
+	}
+	if pageSize > MaxPageSize {
+		return MaxPageSize
+	}
+	return pageSize
+}
+
+// applyPageLimit returns a page of results and whether more exist.
+func applyPageLimit(defs []*registry.InstrumentDefinition, pageSize int) ([]*registry.InstrumentDefinition, bool) {
+	if len(defs) <= pageSize {
+		return defs, false
+	}
+	return defs[:pageSize], true
+}
+
+// generateNextPageToken creates a token for the next page, or empty if no more results.
+func generateNextPageToken(defs []*registry.InstrumentDefinition, hasMore bool) string {
+	if !hasMore || len(defs) == 0 {
+		return ""
+	}
+	lastItem := defs[len(defs)-1]
+	return encodeCursorToken(lastItem.CreatedAt, lastItem.ID)
 }
 
 // ActivateInstrument transitions an instrument from DRAFT to ACTIVE.

--- a/services/reference-data/handler/grpc_handler_test.go
+++ b/services/reference-data/handler/grpc_handler_test.go
@@ -416,22 +416,25 @@ func TestListInstruments(t *testing.T) {
 	t.Run("list all active", func(t *testing.T) {
 		reg := newMockRegistry()
 		reg.definitions["USD:1"] = &registry.InstrumentDefinition{
-			ID:      uuid.New(),
-			Code:    "USD",
-			Version: 1,
-			Status:  registry.StatusActive,
+			ID:        uuid.New(),
+			Code:      "USD",
+			Version:   1,
+			Status:    registry.StatusActive,
+			CreatedAt: time.Now(),
 		}
 		reg.definitions["EUR:1"] = &registry.InstrumentDefinition{
-			ID:      uuid.New(),
-			Code:    "EUR",
-			Version: 1,
-			Status:  registry.StatusActive,
+			ID:        uuid.New(),
+			Code:      "EUR",
+			Version:   1,
+			Status:    registry.StatusActive,
+			CreatedAt: time.Now(),
 		}
 		reg.definitions["DRAFT:1"] = &registry.InstrumentDefinition{
-			ID:      uuid.New(),
-			Code:    "DRAFT",
-			Version: 1,
-			Status:  registry.StatusDraft, // Not active
+			ID:        uuid.New(),
+			Code:      "DRAFT",
+			Version:   1,
+			Status:    registry.StatusDraft, // Not active
+			CreatedAt: time.Now(),
 		}
 		svc, _ := NewService(reg, compiler, nil)
 
@@ -451,6 +454,282 @@ func TestListInstruments(t *testing.T) {
 		assert.Error(t, err)
 		st, _ := status.FromError(err)
 		assert.Equal(t, codes.Internal, st.Code())
+	})
+
+	t.Run("pagination first page with more results", func(t *testing.T) {
+		reg := newMockRegistry()
+		baseTime := time.Now()
+
+		// Populate with 75 instruments
+		for i := 0; i < 75; i++ {
+			code := "INST" + strconv.Itoa(i)
+			reg.definitions[code+":1"] = &registry.InstrumentDefinition{
+				ID:        uuid.New(),
+				Code:      code,
+				Version:   1,
+				Status:    registry.StatusActive,
+				CreatedAt: baseTime.Add(-time.Duration(i) * time.Minute),
+			}
+		}
+		svc, _ := NewService(reg, compiler, nil)
+
+		resp, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			PageSize: 50,
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, resp.Instruments, 50)
+		assert.NotEmpty(t, resp.NextPageToken)
+	})
+
+	t.Run("pagination second page", func(t *testing.T) {
+		reg := newMockRegistry()
+		baseTime := time.Now()
+
+		// Populate with 75 instruments
+		for i := 0; i < 75; i++ {
+			code := "INST" + strconv.Itoa(i)
+			reg.definitions[code+":1"] = &registry.InstrumentDefinition{
+				ID:        uuid.New(),
+				Code:      code,
+				Version:   1,
+				Status:    registry.StatusActive,
+				CreatedAt: baseTime.Add(-time.Duration(i) * time.Minute),
+			}
+		}
+		svc, _ := NewService(reg, compiler, nil)
+
+		// Get first page
+		resp1, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			PageSize: 50,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp1.NextPageToken)
+
+		// Get second page using token
+		resp2, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			PageSize:  50,
+			PageToken: resp1.NextPageToken,
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, resp2.Instruments, 25) // Remaining items
+		assert.Empty(t, resp2.NextPageToken) // No more pages
+
+		// Verify no overlap between pages
+		firstPageIDs := make(map[string]bool)
+		for _, inst := range resp1.Instruments {
+			firstPageIDs[inst.Id] = true
+		}
+		for _, inst := range resp2.Instruments {
+			assert.False(t, firstPageIDs[inst.Id], "Found duplicate instrument in second page: %s", inst.Id)
+		}
+	})
+
+	t.Run("pagination exact boundary", func(t *testing.T) {
+		reg := newMockRegistry()
+		baseTime := time.Now()
+
+		// Populate with exactly 100 instruments
+		for i := 0; i < 100; i++ {
+			code := "INST" + strconv.Itoa(i)
+			reg.definitions[code+":1"] = &registry.InstrumentDefinition{
+				ID:        uuid.New(),
+				Code:      code,
+				Version:   1,
+				Status:    registry.StatusActive,
+				CreatedAt: baseTime.Add(-time.Duration(i) * time.Minute),
+			}
+		}
+		svc, _ := NewService(reg, compiler, nil)
+
+		// First page
+		resp1, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			PageSize: 50,
+		})
+		require.NoError(t, err)
+		assert.Len(t, resp1.Instruments, 50)
+		assert.NotEmpty(t, resp1.NextPageToken)
+
+		// Second page
+		resp2, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			PageSize:  50,
+			PageToken: resp1.NextPageToken,
+		})
+		require.NoError(t, err)
+		assert.Len(t, resp2.Instruments, 50)
+		assert.Empty(t, resp2.NextPageToken) // No more pages
+	})
+
+	t.Run("pagination single page no more results", func(t *testing.T) {
+		reg := newMockRegistry()
+		baseTime := time.Now()
+
+		// Populate with 30 instruments
+		for i := 0; i < 30; i++ {
+			code := "INST" + strconv.Itoa(i)
+			reg.definitions[code+":1"] = &registry.InstrumentDefinition{
+				ID:        uuid.New(),
+				Code:      code,
+				Version:   1,
+				Status:    registry.StatusActive,
+				CreatedAt: baseTime.Add(-time.Duration(i) * time.Minute),
+			}
+		}
+		svc, _ := NewService(reg, compiler, nil)
+
+		resp, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			PageSize: 50,
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, resp.Instruments, 30)
+		assert.Empty(t, resp.NextPageToken) // No more pages
+	})
+
+	t.Run("pagination invalid page token", func(t *testing.T) {
+		reg := newMockRegistry()
+		svc, _ := NewService(reg, compiler, nil)
+
+		_, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			PageToken: "invalid_token",
+		})
+
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("pagination empty registry", func(t *testing.T) {
+		reg := newMockRegistry()
+		svc, _ := NewService(reg, compiler, nil)
+
+		resp, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{})
+
+		require.NoError(t, err)
+		assert.Len(t, resp.Instruments, 0)
+		assert.Empty(t, resp.NextPageToken)
+	})
+
+	t.Run("pagination default page size", func(t *testing.T) {
+		reg := newMockRegistry()
+		baseTime := time.Now()
+
+		// Populate with 100 instruments
+		for i := 0; i < 100; i++ {
+			code := "INST" + strconv.Itoa(i)
+			reg.definitions[code+":1"] = &registry.InstrumentDefinition{
+				ID:        uuid.New(),
+				Code:      code,
+				Version:   1,
+				Status:    registry.StatusActive,
+				CreatedAt: baseTime.Add(-time.Duration(i) * time.Minute),
+			}
+		}
+		svc, _ := NewService(reg, compiler, nil)
+
+		resp, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			PageSize: 0, // Should use default
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, resp.Instruments, 50) // Default page size is 50
+		assert.NotEmpty(t, resp.NextPageToken)
+	})
+
+	t.Run("pagination max page size enforcement", func(t *testing.T) {
+		reg := newMockRegistry()
+		baseTime := time.Now()
+
+		// Populate with 2000 instruments
+		for i := 0; i < 2000; i++ {
+			code := "INST" + strconv.Itoa(i)
+			reg.definitions[code+":1"] = &registry.InstrumentDefinition{
+				ID:        uuid.New(),
+				Code:      code,
+				Version:   1,
+				Status:    registry.StatusActive,
+				CreatedAt: baseTime.Add(-time.Duration(i) * time.Second),
+			}
+		}
+		svc, _ := NewService(reg, compiler, nil)
+
+		resp, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			PageSize: 5000, // Exceeds max
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, resp.Instruments, 1000) // Max page size is 1000
+		assert.NotEmpty(t, resp.NextPageToken)
+	})
+
+	t.Run("pagination ordering consistency", func(t *testing.T) {
+		reg := newMockRegistry()
+		// Create instruments with same timestamp but different IDs
+		sameTime := time.Now().Truncate(time.Second)
+
+		for i := 0; i < 10; i++ {
+			code := "INST" + strconv.Itoa(i)
+			reg.definitions[code+":1"] = &registry.InstrumentDefinition{
+				ID:        uuid.New(),
+				Code:      code,
+				Version:   1,
+				Status:    registry.StatusActive,
+				CreatedAt: sameTime, // All same timestamp
+			}
+		}
+		svc, _ := NewService(reg, compiler, nil)
+
+		// Get all instruments
+		resp, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			PageSize: 100,
+		})
+		require.NoError(t, err)
+		assert.Len(t, resp.Instruments, 10)
+
+		// Verify they are sorted by ID DESC when timestamps are equal
+		for i := 1; i < len(resp.Instruments); i++ {
+			prev := resp.Instruments[i-1].Id
+			curr := resp.Instruments[i].Id
+			assert.Greater(t, prev, curr, "Expected IDs to be in descending order")
+		}
+	})
+
+	t.Run("pagination status filter with pagination", func(t *testing.T) {
+		reg := newMockRegistry()
+		baseTime := time.Now()
+
+		// Create 60 ACTIVE instruments
+		for i := 0; i < 60; i++ {
+			code := "ACTIVE" + strconv.Itoa(i)
+			reg.definitions[code+":1"] = &registry.InstrumentDefinition{
+				ID:        uuid.New(),
+				Code:      code,
+				Version:   1,
+				Status:    registry.StatusActive,
+				CreatedAt: baseTime.Add(-time.Duration(i) * time.Minute),
+			}
+		}
+		svc, _ := NewService(reg, compiler, nil)
+
+		// First page
+		resp1, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			StatusFilter: pb.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+			PageSize:     50,
+		})
+		require.NoError(t, err)
+		assert.Len(t, resp1.Instruments, 50)
+		assert.NotEmpty(t, resp1.NextPageToken)
+
+		// Second page
+		resp2, err := svc.ListInstruments(context.Background(), &pb.ListInstrumentsRequest{
+			StatusFilter: pb.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+			PageSize:     50,
+			PageToken:    resp1.NextPageToken,
+		})
+		require.NoError(t, err)
+		assert.Len(t, resp2.Instruments, 10) // Remaining 10 ACTIVE instruments
+		assert.Empty(t, resp2.NextPageToken)
 	})
 }
 

--- a/services/reference-data/handler/pagination.go
+++ b/services/reference-data/handler/pagination.go
@@ -1,0 +1,73 @@
+// Package handler implements gRPC service handlers for the reference-data domain.
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Constants for pagination.
+const (
+	// DefaultPageSize is the default number of results returned per page.
+	DefaultPageSize = 50
+	// MaxPageSize is the maximum number of results allowed per page.
+	MaxPageSize = 1000
+)
+
+// ErrInvalidPageToken is returned when the pagination token has an invalid format.
+var ErrInvalidPageToken = errors.New("invalid page token format")
+
+// Timestamp bounds for security validation.
+// Records before Unix epoch (1970) or far in the future are unexpected
+// and could indicate token manipulation.
+var (
+	minValidTimestamp = int64(0)                                           // Unix epoch (1970-01-01)
+	maxValidTimestamp = time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC).Unix() // Year 2100
+)
+
+// parseCursorToken parses a pagination token in format "timestamp_uuid".
+// Returns the timestamp and UUID, or an error if the format is invalid.
+// An empty token returns zero values with no error (indicating first page).
+func parseCursorToken(token string) (time.Time, uuid.UUID, error) {
+	if token == "" {
+		return time.Time{}, uuid.Nil, nil
+	}
+
+	// Use SplitN to split only on the first underscore, ensuring the UUID portion
+	// (which uses hyphens, not underscores) remains intact.
+	parts := strings.SplitN(token, "_", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return time.Time{}, uuid.Nil, ErrInvalidPageToken
+	}
+
+	// Parse timestamp
+	timestampUnix, err := strconv.ParseInt(parts[0], 10, 64)
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("%w: invalid timestamp", ErrInvalidPageToken)
+	}
+
+	// Validate timestamp bounds for security - records should be within reasonable range
+	if timestampUnix < minValidTimestamp || timestampUnix > maxValidTimestamp {
+		return time.Time{}, uuid.Nil, fmt.Errorf("%w: timestamp out of valid range", ErrInvalidPageToken)
+	}
+
+	timestamp := time.Unix(timestampUnix, 0).UTC()
+
+	// Parse UUID
+	id, err := uuid.Parse(parts[1])
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("%w: invalid uuid", ErrInvalidPageToken)
+	}
+
+	return timestamp, id, nil
+}
+
+// encodeCursorToken creates a "timestamp_uuid" format pagination token.
+func encodeCursorToken(timestamp time.Time, id uuid.UUID) string {
+	return fmt.Sprintf("%d_%s", timestamp.Unix(), id.String())
+}

--- a/services/reference-data/handler/pagination_test.go
+++ b/services/reference-data/handler/pagination_test.go
@@ -1,0 +1,126 @@
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCursorToken(t *testing.T) {
+	tests := []struct {
+		name        string
+		token       string
+		wantErr     bool
+		wantErrType error
+	}{
+		{
+			name:    "empty token",
+			token:   "",
+			wantErr: false,
+		},
+		{
+			name:    "valid token",
+			token:   "1734567890_123e4567-e89b-12d3-a456-426614174000",
+			wantErr: false,
+		},
+		{
+			name:        "missing underscore",
+			token:       "1734567890",
+			wantErr:     true,
+			wantErrType: ErrInvalidPageToken,
+		},
+		{
+			name:        "empty timestamp",
+			token:       "_123e4567-e89b-12d3-a456-426614174000",
+			wantErr:     true,
+			wantErrType: ErrInvalidPageToken,
+		},
+		{
+			name:        "empty uuid",
+			token:       "1734567890_",
+			wantErr:     true,
+			wantErrType: ErrInvalidPageToken,
+		},
+		{
+			name:        "invalid timestamp",
+			token:       "invalid_123e4567-e89b-12d3-a456-426614174000",
+			wantErr:     true,
+			wantErrType: ErrInvalidPageToken,
+		},
+		{
+			name:        "invalid uuid",
+			token:       "1734567890_not-a-uuid",
+			wantErr:     true,
+			wantErrType: ErrInvalidPageToken,
+		},
+		{
+			name:        "timestamp too old (negative)",
+			token:       "-100_123e4567-e89b-12d3-a456-426614174000",
+			wantErr:     true,
+			wantErrType: ErrInvalidPageToken,
+		},
+		{
+			name:        "timestamp too far future",
+			token:       "9999999999999_123e4567-e89b-12d3-a456-426614174000",
+			wantErr:     true,
+			wantErrType: ErrInvalidPageToken,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timestamp, id, err := parseCursorToken(tt.token)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrType != nil {
+					assert.ErrorIs(t, err, tt.wantErrType)
+				}
+			} else {
+				require.NoError(t, err)
+				if tt.token == "" {
+					assert.True(t, timestamp.IsZero())
+					assert.Equal(t, uuid.Nil, id)
+				} else {
+					assert.False(t, timestamp.IsZero())
+					assert.NotEqual(t, uuid.Nil, id)
+				}
+			}
+		})
+	}
+}
+
+func TestEncodeCursorToken(t *testing.T) {
+	ts := time.Unix(1734567890, 0).UTC()
+	id := uuid.MustParse("123e4567-e89b-12d3-a456-426614174000")
+
+	token := encodeCursorToken(ts, id)
+
+	assert.Equal(t, "1734567890_123e4567-e89b-12d3-a456-426614174000", token)
+}
+
+func TestParseCursorToken_RoundTrip(t *testing.T) {
+	originalTime := time.Unix(1734567890, 0).UTC()
+	originalID := uuid.New()
+
+	token := encodeCursorToken(originalTime, originalID)
+
+	parsedTime, parsedID, err := parseCursorToken(token)
+
+	require.NoError(t, err)
+	assert.Equal(t, originalTime, parsedTime)
+	assert.Equal(t, originalID, parsedID)
+}
+
+func TestPaginationConstants(t *testing.T) {
+	t.Run("default page size", func(t *testing.T) {
+		assert.Equal(t, 50, DefaultPageSize)
+	})
+
+	t.Run("max page size", func(t *testing.T) {
+		assert.Equal(t, 1000, MaxPageSize)
+	})
+}


### PR DESCRIPTION
## Summary

- Implements cursor-based pagination for the `ListInstruments` endpoint in the reference-data service
- Uses the `timestamp_uuid` pattern consistent with other Meridian services (financial-accounting, market-information)
- Replaces naive array truncation that prevented clients from paginating through large instrument lists

## Changes

- **New file: `pagination.go`** - Cursor token parsing and encoding utilities with security validation
- **Updated: `grpc_handler.go`** - ListInstruments now parses page tokens, sorts by CreatedAt/ID DESC, and generates next page tokens
- **New file: `pagination_test.go`** - Unit tests for cursor token utilities
- **Updated: `grpc_handler_test.go`** - Comprehensive integration tests for pagination

## Test Plan

- [x] Unit tests for `parseCursorToken` (valid tokens, edge cases, security bounds)
- [x] Unit tests for `encodeCursorToken` and round-trip verification
- [x] Integration tests for ListInstruments pagination:
  - [x] Multi-page traversal (75 items across 2 pages)
  - [x] Exact boundary conditions (100 items exactly)
  - [x] Single page (fewer items than page size)
  - [x] Invalid page token returns InvalidArgument
  - [x] Empty registry returns empty list
  - [x] Default page size (50) enforcement
  - [x] Max page size (1000) enforcement
  - [x] Ordering consistency with timestamp collisions
  - [x] Status filter combined with pagination