### PR TITLE
feat(reference-data): Add saga definition and reference schema

### DIFF
--- a/services/reference-data/migrations/20260124000001_saga_definitions.sql
+++ b/services/reference-data/migrations/20260124000001_saga_definitions.sql
@@ -1,0 +1,160 @@
+-- Saga Definition Storage
+-- Implements FR-1: Saga definitions stored in Reference Data with lifecycle management
+-- Multi-tenancy: Schema-per-tenant architecture means no tenant_id column needed
+-- Each tenant's database connection routes to their isolated schema
+
+-- Create "saga_definition" table (singular, unqualified)
+-- Stores Starlark saga definitions with lifecycle management (DRAFT/ACTIVE/DEPRECATED)
+CREATE TABLE "saga_definition" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "name" character varying(64) NOT NULL,
+  "version" integer NOT NULL DEFAULT 1,
+  "script" text NOT NULL,
+  "status" character varying(16) NOT NULL DEFAULT 'DRAFT',
+  "is_system" boolean NOT NULL DEFAULT FALSE,
+  "preconditions_expression" text NULL,
+  "display_name" character varying(128) NULL,
+  "description" text NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  "activated_at" timestamptz NULL,
+  "deprecated_at" timestamptz NULL,
+  "successor_id" uuid NULL,
+  PRIMARY KEY ("id")
+);
+
+-- Add validation constraints
+ALTER TABLE "saga_definition"
+  ADD CONSTRAINT "chk_saga_definition_status"
+  CHECK ("status" IN ('DRAFT', 'ACTIVE', 'DEPRECATED'));
+
+-- Limit script to 64KB to prevent abuse
+ALTER TABLE "saga_definition"
+  ADD CONSTRAINT "chk_saga_definition_script_length"
+  CHECK (length("script") <= 65536);
+
+-- Limit preconditions expression to 4KB
+ALTER TABLE "saga_definition"
+  ADD CONSTRAINT "chk_saga_definition_preconditions_length"
+  CHECK ("preconditions_expression" IS NULL OR length("preconditions_expression") <= 4096);
+
+-- Ensure name+version is unique (allows multiple versions of same saga)
+ALTER TABLE "saga_definition"
+  ADD CONSTRAINT "uq_saga_definition_name_version"
+  UNIQUE ("name", "version");
+
+-- Self-referential foreign key for successor lineage
+ALTER TABLE "saga_definition"
+  ADD CONSTRAINT "fk_saga_definition_successor"
+  FOREIGN KEY ("successor_id") REFERENCES "saga_definition" ("id");
+
+-- Create indexes for efficient lookups
+-- Partial index for quickly finding active sagas by name
+CREATE INDEX "idx_saga_definition_name_active" ON "saga_definition" ("name") WHERE "status" = 'ACTIVE';
+
+-- Index for listing sagas by name and status (tenant default resolution)
+CREATE INDEX "idx_saga_definition_lookup" ON "saga_definition" ("name", "status");
+
+-- Index for bi-temporal queries: What saga was active at a given point in time?
+CREATE INDEX "idx_saga_definition_temporal" ON "saga_definition" ("name", "activated_at", "deprecated_at");
+
+-- Index for successor lineage traversal
+CREATE INDEX "idx_saga_definition_successor_id" ON "saga_definition" ("successor_id")
+  WHERE "successor_id" IS NOT NULL;
+
+-- Trigger function to enforce saga lifecycle rules
+-- Immutable fields cannot be changed once saga is ACTIVE or DEPRECATED
+-- Status transitions are strictly controlled
+CREATE OR REPLACE FUNCTION "enforce_saga_lifecycle"()
+RETURNS TRIGGER AS $$
+DECLARE
+  successor_record RECORD;
+BEGIN
+  -- Always update updated_at on any change
+  NEW."updated_at" = NOW();
+
+  -- Enforce write-once semantics for successor_id
+  -- Once set, successor_id cannot be changed (regardless of status)
+  IF OLD."successor_id" IS NOT NULL AND OLD."successor_id" IS DISTINCT FROM NEW."successor_id" THEN
+    RAISE EXCEPTION 'Cannot modify successor_id once set (write-once semantics)';
+  END IF;
+
+  -- Allow all edits when status is DRAFT
+  IF OLD."status" = 'DRAFT' THEN
+    -- If transitioning from DRAFT to ACTIVE, set activated_at
+    IF NEW."status" = 'ACTIVE' THEN
+      NEW."activated_at" = NOW();
+    -- If transitioning from DRAFT to DEPRECATED, set deprecated_at
+    ELSIF NEW."status" = 'DEPRECATED' THEN
+      NEW."deprecated_at" = NOW();
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  -- For ACTIVE or DEPRECATED sagas, script and preconditions become immutable
+  IF OLD."status" IN ('ACTIVE', 'DEPRECATED') THEN
+    -- Prevent changes to immutable fields (workflow logic that affects execution)
+    IF OLD."script" IS DISTINCT FROM NEW."script" THEN
+      RAISE EXCEPTION 'Cannot modify script for % saga', OLD."status";
+    END IF;
+    IF OLD."preconditions_expression" IS DISTINCT FROM NEW."preconditions_expression" THEN
+      RAISE EXCEPTION 'Cannot modify preconditions_expression for % saga', OLD."status";
+    END IF;
+  END IF;
+
+  -- Prevent invalid status transitions
+  IF OLD."status" = 'ACTIVE' THEN
+    IF NEW."status" = 'DRAFT' THEN
+      RAISE EXCEPTION 'Cannot transition from ACTIVE back to DRAFT';
+    END IF;
+    -- Allow ACTIVE to DEPRECATED, set deprecated_at and validate successor
+    IF NEW."status" = 'DEPRECATED' THEN
+      NEW."deprecated_at" = NOW();
+
+      -- If successor_id is provided, validate it
+      IF NEW."successor_id" IS NOT NULL THEN
+        -- Cannot designate self as successor
+        IF NEW."successor_id" = NEW."id" THEN
+          RAISE EXCEPTION 'Saga cannot designate itself as its own successor';
+        END IF;
+
+        -- Look up the successor saga
+        SELECT "id", "status", "name"
+        INTO successor_record
+        FROM "saga_definition"
+        WHERE "id" = NEW."successor_id";
+
+        -- Successor must exist
+        IF successor_record.id IS NULL THEN
+          RAISE EXCEPTION 'Successor saga does not exist: %', NEW."successor_id";
+        END IF;
+
+        -- Successor must be ACTIVE
+        IF successor_record.status != 'ACTIVE' THEN
+          RAISE EXCEPTION 'Successor saga must be ACTIVE, but is %', successor_record.status;
+        END IF;
+
+        -- Successor must have same name (it's a newer version of the same saga)
+        IF successor_record.name != NEW."name" THEN
+          RAISE EXCEPTION 'Successor saga name (%) must match current saga name (%)',
+            successor_record.name, NEW."name";
+        END IF;
+      END IF;
+    END IF;
+  END IF;
+
+  IF OLD."status" = 'DEPRECATED' THEN
+    IF NEW."status" IN ('DRAFT', 'ACTIVE') THEN
+      RAISE EXCEPTION 'Cannot transition from DEPRECATED to %', NEW."status";
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger to enforce lifecycle rules on UPDATE
+CREATE TRIGGER "trg_enforce_saga_lifecycle"
+  BEFORE UPDATE ON "saga_definition"
+  FOR EACH ROW
+  EXECUTE FUNCTION "enforce_saga_lifecycle"();

--- a/services/reference-data/migrations/20260124000002_saga_references.sql
+++ b/services/reference-data/migrations/20260124000002_saga_references.sql
@@ -1,0 +1,37 @@
+-- Saga Reference Tracking
+-- Implements FR-9 and FR-10: Reference validation and deprecation impact analysis
+-- Tracks all external references made by saga definitions for validation and impact analysis
+
+-- Create "saga_reference" table (singular, unqualified)
+-- Stores extracted references from saga definitions for impact analysis
+CREATE TABLE "saga_reference" (
+  "saga_definition_id" uuid NOT NULL,
+  "reference_type" character varying(32) NOT NULL,
+  "reference_key" character varying(128) NOT NULL,
+  "instrument_code" character varying(50) NULL,
+  "attribute_key" character varying(128) NULL,
+  "line_number" integer NULL,
+  "extracted_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("saga_definition_id", "reference_type", "reference_key"),
+  CONSTRAINT "fk_saga_reference_definition"
+    FOREIGN KEY ("saga_definition_id") REFERENCES "saga_definition" ("id") ON DELETE CASCADE
+);
+
+-- Add validation constraints for reference_type
+ALTER TABLE "saga_reference"
+  ADD CONSTRAINT "chk_saga_reference_type"
+  CHECK ("reference_type" IN ('step_handler', 'instrument', 'account', 'saga', 'attribute'));
+
+-- Query: What sagas reference this target (instrument, account, saga, etc.)?
+CREATE INDEX "idx_saga_reference_by_target"
+  ON "saga_reference" ("reference_type", "reference_key");
+
+-- Query: What does this saga reference?
+CREATE INDEX "idx_saga_reference_by_saga"
+  ON "saga_reference" ("saga_definition_id");
+
+-- Query: Which sagas reference a specific instrument's attribute?
+-- Used for attribute schema change impact analysis
+CREATE INDEX "idx_saga_reference_attribute"
+  ON "saga_reference" ("instrument_code", "attribute_key")
+  WHERE "reference_type" = 'attribute';

--- a/services/reference-data/saga_migrations_test.go
+++ b/services/reference-data/saga_migrations_test.go
@@ -1,0 +1,950 @@
+package migrations_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+// sagaTestContainer holds the test database container and connection pool for saga tests
+type sagaTestContainer struct {
+	container *postgres.PostgresContainer
+	pool      *pgxpool.Pool
+}
+
+// setupSagaTestContainer creates a PostgreSQL testcontainer with all migrations applied
+func setupSagaTestContainer(t *testing.T) *sagaTestContainer {
+	t.Helper()
+
+	ctx := context.Background()
+
+	// Create PostgreSQL container
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("test_reference_data"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second)),
+	)
+	require.NoError(t, err)
+
+	// Get connection string
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	// Create connection pool
+	poolConfig, err := pgxpool.ParseConfig(connStr)
+	require.NoError(t, err)
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	require.NoError(t, err)
+
+	// Apply all migrations in order
+	applySagaMigrations(t, pool)
+
+	return &sagaTestContainer{
+		container: pgContainer,
+		pool:      pool,
+	}
+}
+
+// cleanup closes the pool and terminates the container
+func (tc *sagaTestContainer) cleanup(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	if tc.pool != nil {
+		tc.pool.Close()
+	}
+
+	if tc.container != nil {
+		require.NoError(t, tc.container.Terminate(ctx))
+	}
+}
+
+// applySagaMigrations reads and executes all migration SQL files in order
+func applySagaMigrations(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Apply migrations in order
+	migrations := []string{
+		"20260124000001_saga_definitions.sql",
+		"20260124000002_saga_references.sql",
+	}
+
+	for _, migration := range migrations {
+		migrationPath := filepath.Join("migrations", migration)
+		migrationSQL, err := os.ReadFile(migrationPath)
+		require.NoError(t, err, "failed to read migration file: %s", migration)
+
+		_, err = pool.Exec(ctx, string(migrationSQL))
+		require.NoError(t, err, "failed to apply migration: %s", migration)
+	}
+}
+
+// insertSaga is a helper to insert a saga definition for testing
+func insertSaga(ctx context.Context, t *testing.T, pool *pgxpool.Pool, name string, version int, script string, status string) uuid.UUID {
+	t.Helper()
+
+	id := uuid.New()
+	_, err := pool.Exec(ctx, `
+		INSERT INTO saga_definition (id, name, version, script, status)
+		VALUES ($1, $2, $3, $4, $5)
+	`, id, name, version, script, status)
+	require.NoError(t, err)
+
+	return id
+}
+
+// insertSagaWithExpressions inserts a saga with preconditions expression
+func insertSagaWithExpressions(ctx context.Context, t *testing.T, pool *pgxpool.Pool, name string, version int, script string, status string, preconditions string) uuid.UUID {
+	t.Helper()
+
+	id := uuid.New()
+	_, err := pool.Exec(ctx, `
+		INSERT INTO saga_definition (id, name, version, script, status, preconditions_expression)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, id, name, version, script, status, preconditions)
+	require.NoError(t, err)
+
+	return id
+}
+
+func TestSagaMigration_AppliesCleanly(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	// Verify saga_definition table exists
+	var tableName string
+	err := tc.pool.QueryRow(ctx, `
+		SELECT table_name
+		FROM information_schema.tables
+		WHERE table_name = 'saga_definition'
+	`).Scan(&tableName)
+	require.NoError(t, err)
+	assert.Equal(t, "saga_definition", tableName)
+
+	// Verify all expected columns exist
+	expectedColumns := []string{
+		"id", "name", "version", "script", "status", "is_system",
+		"preconditions_expression", "display_name", "description",
+		"created_at", "updated_at", "activated_at", "deprecated_at", "successor_id",
+	}
+
+	rows, err := tc.pool.Query(ctx, `
+		SELECT column_name
+		FROM information_schema.columns
+		WHERE table_name = 'saga_definition'
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var columns []string
+	for rows.Next() {
+		var col string
+		require.NoError(t, rows.Scan(&col))
+		columns = append(columns, col)
+	}
+
+	for _, expected := range expectedColumns {
+		assert.Contains(t, columns, expected, "missing column: %s", expected)
+	}
+
+	// Verify trigger function exists
+	var triggerFuncName string
+	err = tc.pool.QueryRow(ctx, `
+		SELECT routine_name
+		FROM information_schema.routines
+		WHERE routine_name = 'enforce_saga_lifecycle'
+	`).Scan(&triggerFuncName)
+	require.NoError(t, err)
+	assert.Equal(t, "enforce_saga_lifecycle", triggerFuncName)
+
+	// Verify trigger exists
+	var triggerName string
+	err = tc.pool.QueryRow(ctx, `
+		SELECT trigger_name
+		FROM information_schema.triggers
+		WHERE trigger_name = 'trg_enforce_saga_lifecycle'
+	`).Scan(&triggerName)
+	require.NoError(t, err)
+	assert.Equal(t, "trg_enforce_saga_lifecycle", triggerName)
+}
+
+func TestSagaMigration_ReferenceTableAppliesCleanly(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	// Verify saga_reference table exists
+	var tableName string
+	err := tc.pool.QueryRow(ctx, `
+		SELECT table_name
+		FROM information_schema.tables
+		WHERE table_name = 'saga_reference'
+	`).Scan(&tableName)
+	require.NoError(t, err)
+	assert.Equal(t, "saga_reference", tableName)
+
+	// Verify all expected columns exist
+	expectedColumns := []string{
+		"saga_definition_id", "reference_type", "reference_key",
+		"instrument_code", "attribute_key", "line_number", "extracted_at",
+	}
+
+	rows, err := tc.pool.Query(ctx, `
+		SELECT column_name
+		FROM information_schema.columns
+		WHERE table_name = 'saga_reference'
+	`)
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var columns []string
+	for rows.Next() {
+		var col string
+		require.NoError(t, rows.Scan(&col))
+		columns = append(columns, col)
+	}
+
+	for _, expected := range expectedColumns {
+		assert.Contains(t, columns, expected, "missing column: %s", expected)
+	}
+}
+
+func TestSagaMigration_UniqueConstraint(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	// Insert first saga
+	insertSaga(ctx, t, tc.pool, "withdrawal", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+	// Attempt to insert duplicate name+version - should fail
+	_, err := tc.pool.Exec(ctx, `
+		INSERT INTO saga_definition (id, name, version, script, status)
+		VALUES ($1, 'withdrawal', 1, 'def posting_rules(ctx): pass', 'DRAFT')
+	`, uuid.New())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uq_saga_definition_name_version")
+
+	// Insert same name with different version - should succeed
+	_, err = tc.pool.Exec(ctx, `
+		INSERT INTO saga_definition (id, name, version, script, status)
+		VALUES ($1, 'withdrawal', 2, 'def posting_rules(ctx): pass', 'DRAFT')
+	`, uuid.New())
+	require.NoError(t, err)
+
+	// Insert different name with same version - should succeed
+	_, err = tc.pool.Exec(ctx, `
+		INSERT INTO saga_definition (id, name, version, script, status)
+		VALUES ($1, 'deposit', 1, 'def posting_rules(ctx): pass', 'DRAFT')
+	`, uuid.New())
+	require.NoError(t, err)
+}
+
+func TestSagaMigration_CheckConstraints(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("status constraint accepts valid values", func(t *testing.T) {
+		validStatuses := []string{"DRAFT", "ACTIVE", "DEPRECATED"}
+		for i, status := range validStatuses {
+			name := "TEST_STATUS_" + status
+			_, err := tc.pool.Exec(ctx, `
+				INSERT INTO saga_definition (id, name, version, script, status)
+				VALUES ($1, $2, $3, 'def posting_rules(ctx): pass', $4)
+			`, uuid.New(), name, i+1, status)
+			require.NoError(t, err, "status %s should be valid", status)
+		}
+	})
+
+	t.Run("status constraint rejects invalid values", func(t *testing.T) {
+		invalidStatuses := []string{"INVALID", "draft", "Active", "", "PENDING"}
+		for _, status := range invalidStatuses {
+			_, err := tc.pool.Exec(ctx, `
+				INSERT INTO saga_definition (id, name, version, script, status)
+				VALUES ($1, 'INVALID_STATUS', 1, 'def posting_rules(ctx): pass', $2)
+			`, uuid.New(), status)
+			require.Error(t, err, "status %s should be rejected", status)
+			assert.Contains(t, err.Error(), "chk_saga_definition_status")
+		}
+	})
+
+	t.Run("script length constraint accepts up to 64KB", func(t *testing.T) {
+		// Exactly 65536 bytes should be accepted
+		validScript := strings.Repeat("x", 65536)
+		_, err := tc.pool.Exec(ctx, `
+			INSERT INTO saga_definition (id, name, version, script, status)
+			VALUES ($1, 'VALID_SCRIPT', 1, $2, 'DRAFT')
+		`, uuid.New(), validScript)
+		require.NoError(t, err)
+	})
+
+	t.Run("script length constraint rejects over 64KB", func(t *testing.T) {
+		// 65537 bytes should be rejected
+		invalidScript := strings.Repeat("x", 65537)
+		_, err := tc.pool.Exec(ctx, `
+			INSERT INTO saga_definition (id, name, version, script, status)
+			VALUES ($1, 'INVALID_SCRIPT', 1, $2, 'DRAFT')
+		`, uuid.New(), invalidScript)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "chk_saga_definition_script_length")
+	})
+
+	t.Run("preconditions_expression length constraint accepts up to 4KB", func(t *testing.T) {
+		// Exactly 4096 bytes should be accepted
+		validExpr := strings.Repeat("x", 4096)
+		_, err := tc.pool.Exec(ctx, `
+			INSERT INTO saga_definition (id, name, version, script, status, preconditions_expression)
+			VALUES ($1, 'VALID_PRECOND', 1, 'def posting_rules(ctx): pass', 'DRAFT', $2)
+		`, uuid.New(), validExpr)
+		require.NoError(t, err)
+
+		// NULL should be accepted
+		_, err = tc.pool.Exec(ctx, `
+			INSERT INTO saga_definition (id, name, version, script, status, preconditions_expression)
+			VALUES ($1, 'NULL_PRECOND', 1, 'def posting_rules(ctx): pass', 'DRAFT', NULL)
+		`, uuid.New())
+		require.NoError(t, err)
+	})
+
+	t.Run("preconditions_expression length constraint rejects over 4KB", func(t *testing.T) {
+		// 4097 bytes should be rejected
+		invalidExpr := strings.Repeat("x", 4097)
+		_, err := tc.pool.Exec(ctx, `
+			INSERT INTO saga_definition (id, name, version, script, status, preconditions_expression)
+			VALUES ($1, 'INVALID_PRECOND', 1, 'def posting_rules(ctx): pass', 'DRAFT', $2)
+		`, uuid.New(), invalidExpr)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "chk_saga_definition_preconditions_length")
+	})
+}
+
+func TestSagaMigration_ReferenceTypeConstraint(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	// Create a saga to reference
+	sagaID := insertSaga(ctx, t, tc.pool, "test_saga", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+	t.Run("reference_type constraint accepts valid values", func(t *testing.T) {
+		validTypes := []string{"step_handler", "instrument", "account", "saga", "attribute"}
+		for i, refType := range validTypes {
+			_, err := tc.pool.Exec(ctx, `
+				INSERT INTO saga_reference (saga_definition_id, reference_type, reference_key)
+				VALUES ($1, $2, $3)
+			`, sagaID, refType, "key_"+string(rune('A'+i)))
+			require.NoError(t, err, "reference_type %s should be valid", refType)
+		}
+	})
+
+	t.Run("reference_type constraint rejects invalid values", func(t *testing.T) {
+		invalidTypes := []string{"INVALID", "handler", "Step_Handler", "", "other"}
+		for _, refType := range invalidTypes {
+			_, err := tc.pool.Exec(ctx, `
+				INSERT INTO saga_reference (saga_definition_id, reference_type, reference_key)
+				VALUES ($1, $2, 'some_key')
+			`, sagaID, refType)
+			require.Error(t, err, "reference_type %s should be rejected", refType)
+			assert.Contains(t, err.Error(), "chk_saga_reference_type")
+		}
+	})
+}
+
+func TestSagaMigration_ReferenceCascadeDelete(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	// Create a saga
+	sagaID := insertSaga(ctx, t, tc.pool, "cascade_test", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+	// Insert references
+	_, err := tc.pool.Exec(ctx, `
+		INSERT INTO saga_reference (saga_definition_id, reference_type, reference_key)
+		VALUES ($1, 'step_handler', 'position_keeping.initiate_log'),
+		       ($1, 'instrument', 'KWH'),
+		       ($1, 'account', 'clearing_GBP')
+	`, sagaID)
+	require.NoError(t, err)
+
+	// Verify references exist
+	var count int
+	err = tc.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM saga_reference WHERE saga_definition_id = $1
+	`, sagaID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count)
+
+	// Delete the saga
+	_, err = tc.pool.Exec(ctx, `DELETE FROM saga_definition WHERE id = $1`, sagaID)
+	require.NoError(t, err)
+
+	// Verify references are deleted (CASCADE)
+	err = tc.pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM saga_reference WHERE saga_definition_id = $1
+	`, sagaID).Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count, "references should be deleted on cascade")
+}
+
+func TestSagaMigration_LifecycleTrigger_DraftAllowsEdits(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	// Insert a DRAFT saga with preconditions
+	id := insertSagaWithExpressions(ctx, t, tc.pool, "DRAFT_EDITABLE", 1, "original_script", "DRAFT", "original_precondition")
+
+	// All fields should be editable in DRAFT status
+	editTests := []struct {
+		name  string
+		query string
+		args  []interface{}
+	}{
+		{
+			name:  "update script",
+			query: `UPDATE saga_definition SET script = $1 WHERE id = $2`,
+			args:  []interface{}{"new_script", id},
+		},
+		{
+			name:  "update preconditions_expression",
+			query: `UPDATE saga_definition SET preconditions_expression = $1 WHERE id = $2`,
+			args:  []interface{}{"new_precondition", id},
+		},
+		{
+			name:  "update display_name",
+			query: `UPDATE saga_definition SET display_name = $1 WHERE id = $2`,
+			args:  []interface{}{"New Display Name", id},
+		},
+		{
+			name:  "update description",
+			query: `UPDATE saga_definition SET description = $1 WHERE id = $2`,
+			args:  []interface{}{"New Description", id},
+		},
+		{
+			name:  "update is_system",
+			query: `UPDATE saga_definition SET is_system = $1 WHERE id = $2`,
+			args:  []interface{}{true, id},
+		},
+	}
+
+	for _, tt := range editTests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := tc.pool.Exec(ctx, tt.query, tt.args...)
+			require.NoError(t, err, "DRAFT saga should allow editing %s", tt.name)
+		})
+	}
+}
+
+func TestSagaMigration_LifecycleTrigger_ActiveBlocksScriptChanges(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	// Insert ACTIVE sagas for testing immutable fields
+	blockedFields := []struct {
+		name       string
+		column     string
+		initialVal string
+		newVal     string
+	}{
+		{
+			name:       "script",
+			column:     "script",
+			initialVal: "original_script",
+			newVal:     "modified_script",
+		},
+		{
+			name:       "preconditions_expression",
+			column:     "preconditions_expression",
+			initialVal: "original_precondition",
+			newVal:     "modified_precondition",
+		},
+	}
+
+	for i, tt := range blockedFields {
+		t.Run("ACTIVE blocks "+tt.name, func(t *testing.T) {
+			// Insert ACTIVE saga
+			id := uuid.New()
+			name := "ACTIVE_BLOCKED_" + string(rune('A'+i))
+			_, err := tc.pool.Exec(ctx, `
+				INSERT INTO saga_definition (id, name, version, script, status, preconditions_expression, activated_at)
+				VALUES ($1, $2, 1, $3, 'ACTIVE', $4, NOW())
+			`, id, name, "orig_script", "orig_precond")
+			require.NoError(t, err)
+
+			// Attempt to modify field - should fail
+			_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET `+tt.column+` = $1 WHERE id = $2`, tt.newVal, id)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "Cannot modify "+tt.column)
+		})
+	}
+
+	// Test that non-script fields CAN be modified on ACTIVE sagas
+	t.Run("ACTIVE allows non-script edits", func(t *testing.T) {
+		id := insertSaga(ctx, t, tc.pool, "ACTIVE_EDITABLE", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+		// Activate the saga
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// These should succeed
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET display_name = 'Updated' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET description = 'Updated description' WHERE id = $1`, id)
+		require.NoError(t, err)
+	})
+}
+
+func TestSagaMigration_LifecycleTrigger_StatusTransitions(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("DRAFT to ACTIVE allowed", func(t *testing.T) {
+		id := insertSaga(ctx, t, tc.pool, "DRAFT_TO_ACTIVE", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		var status string
+		err = tc.pool.QueryRow(ctx, `SELECT status FROM saga_definition WHERE id = $1`, id).Scan(&status)
+		require.NoError(t, err)
+		assert.Equal(t, "ACTIVE", status)
+	})
+
+	t.Run("DRAFT to DEPRECATED allowed", func(t *testing.T) {
+		id := insertSaga(ctx, t, tc.pool, "DRAFT_TO_DEPRECATED", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DEPRECATED' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		var status string
+		err = tc.pool.QueryRow(ctx, `SELECT status FROM saga_definition WHERE id = $1`, id).Scan(&status)
+		require.NoError(t, err)
+		assert.Equal(t, "DEPRECATED", status)
+	})
+
+	t.Run("ACTIVE to DEPRECATED allowed", func(t *testing.T) {
+		id := insertSaga(ctx, t, tc.pool, "ACTIVE_TO_DEPRECATED", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+		// First activate
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// Then deprecate
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DEPRECATED' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		var status string
+		err = tc.pool.QueryRow(ctx, `SELECT status FROM saga_definition WHERE id = $1`, id).Scan(&status)
+		require.NoError(t, err)
+		assert.Equal(t, "DEPRECATED", status)
+	})
+
+	t.Run("ACTIVE to DRAFT blocked", func(t *testing.T) {
+		id := insertSaga(ctx, t, tc.pool, "ACTIVE_TO_DRAFT", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+		// Activate
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// Attempt to go back to DRAFT - should fail
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DRAFT' WHERE id = $1`, id)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Cannot transition from ACTIVE back to DRAFT")
+	})
+
+	t.Run("DEPRECATED to DRAFT blocked", func(t *testing.T) {
+		id := insertSaga(ctx, t, tc.pool, "DEPRECATED_TO_DRAFT", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+		// Activate then deprecate
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.NoError(t, err)
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DEPRECATED' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// Attempt to go back to DRAFT - should fail
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DRAFT' WHERE id = $1`, id)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Cannot transition from DEPRECATED")
+	})
+
+	t.Run("DEPRECATED to ACTIVE blocked", func(t *testing.T) {
+		id := insertSaga(ctx, t, tc.pool, "DEPRECATED_TO_ACTIVE", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+		// Activate then deprecate
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.NoError(t, err)
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DEPRECATED' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// Attempt to go to ACTIVE - should fail
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Cannot transition from DEPRECATED")
+	})
+}
+
+func TestSagaMigration_LifecycleTrigger_TimestampPopulation(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("activated_at populated on DRAFT to ACTIVE transition", func(t *testing.T) {
+		id := insertSaga(ctx, t, tc.pool, "ACTIVATION_TIMESTAMP", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+		// Verify activated_at is NULL initially
+		var activatedAt *time.Time
+		err := tc.pool.QueryRow(ctx, `SELECT activated_at FROM saga_definition WHERE id = $1`, id).Scan(&activatedAt)
+		require.NoError(t, err)
+		assert.Nil(t, activatedAt)
+
+		// Activate
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// Verify activated_at is now set (non-nil is sufficient - clock sync issues with containers)
+		err = tc.pool.QueryRow(ctx, `SELECT activated_at FROM saga_definition WHERE id = $1`, id).Scan(&activatedAt)
+		require.NoError(t, err)
+		require.NotNil(t, activatedAt, "activated_at should be populated after activation")
+	})
+
+	t.Run("deprecated_at populated on ACTIVE to DEPRECATED transition", func(t *testing.T) {
+		id := insertSaga(ctx, t, tc.pool, "DEPRECATION_TIMESTAMP", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+		// Activate first
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// Verify deprecated_at is NULL
+		var deprecatedAt *time.Time
+		err = tc.pool.QueryRow(ctx, `SELECT deprecated_at FROM saga_definition WHERE id = $1`, id).Scan(&deprecatedAt)
+		require.NoError(t, err)
+		assert.Nil(t, deprecatedAt)
+
+		// Deprecate
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DEPRECATED' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// Verify deprecated_at is now set (non-nil is sufficient - clock sync issues with containers)
+		err = tc.pool.QueryRow(ctx, `SELECT deprecated_at FROM saga_definition WHERE id = $1`, id).Scan(&deprecatedAt)
+		require.NoError(t, err)
+		require.NotNil(t, deprecatedAt, "deprecated_at should be populated after deprecation")
+	})
+
+	t.Run("created_at defaults to now on insert", func(t *testing.T) {
+		id := insertSaga(ctx, t, tc.pool, "CREATED_TIMESTAMP", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+		var createdAt time.Time
+		err := tc.pool.QueryRow(ctx, `SELECT created_at FROM saga_definition WHERE id = $1`, id).Scan(&createdAt)
+		require.NoError(t, err)
+		// Verify created_at is non-zero (populated by default)
+		assert.False(t, createdAt.IsZero(), "created_at should be populated on insert")
+	})
+
+	t.Run("updated_at populated on any update", func(t *testing.T) {
+		id := insertSaga(ctx, t, tc.pool, "UPDATED_TIMESTAMP", 1, "def posting_rules(ctx): pass", "DRAFT")
+
+		// Get initial updated_at
+		var initialUpdatedAt time.Time
+		err := tc.pool.QueryRow(ctx, `SELECT updated_at FROM saga_definition WHERE id = $1`, id).Scan(&initialUpdatedAt)
+		require.NoError(t, err)
+
+		// Wait a tiny bit to ensure time difference
+		time.Sleep(10 * time.Millisecond)
+
+		// Update display_name
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET display_name = 'Updated Name' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// Verify updated_at changed
+		var newUpdatedAt time.Time
+		err = tc.pool.QueryRow(ctx, `SELECT updated_at FROM saga_definition WHERE id = $1`, id).Scan(&newUpdatedAt)
+		require.NoError(t, err)
+		assert.True(t, newUpdatedAt.After(initialUpdatedAt), "updated_at should be after the initial value")
+	})
+}
+
+func TestSagaMigration_SuccessorValidation(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("successor must be ACTIVE", func(t *testing.T) {
+		// Create successor saga and activate it
+		successorID := insertSaga(ctx, t, tc.pool, "withdrawal", 2, "def posting_rules(ctx): pass", "DRAFT")
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, successorID)
+		require.NoError(t, err)
+
+		// Create and activate original saga
+		originalID := insertSaga(ctx, t, tc.pool, "withdrawal", 1, "def posting_rules(ctx): pass", "DRAFT")
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, originalID)
+		require.NoError(t, err)
+
+		// Deprecate with valid successor - should work
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DEPRECATED', successor_id = $1 WHERE id = $2`, successorID, originalID)
+		require.NoError(t, err)
+	})
+
+	t.Run("successor must exist", func(t *testing.T) {
+		// Create and activate a saga
+		id := insertSaga(ctx, t, tc.pool, "nonexistent_successor", 1, "def posting_rules(ctx): pass", "DRAFT")
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// Attempt to deprecate with non-existent successor
+		fakeSuccessorID := uuid.New()
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DEPRECATED', successor_id = $1 WHERE id = $2`, fakeSuccessorID, id)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Successor saga does not exist")
+	})
+
+	t.Run("successor cannot be self", func(t *testing.T) {
+		// Create and activate a saga
+		id := insertSaga(ctx, t, tc.pool, "self_successor", 1, "def posting_rules(ctx): pass", "DRAFT")
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// Attempt to deprecate with self as successor
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DEPRECATED', successor_id = $1 WHERE id = $1`, id)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot designate itself as its own successor")
+	})
+
+	t.Run("successor must have same name", func(t *testing.T) {
+		// Create and activate a "different_name" saga
+		differentNameID := insertSaga(ctx, t, tc.pool, "different_name", 1, "def posting_rules(ctx): pass", "DRAFT")
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, differentNameID)
+		require.NoError(t, err)
+
+		// Create and activate original saga with different name
+		originalID := insertSaga(ctx, t, tc.pool, "original_name", 1, "def posting_rules(ctx): pass", "DRAFT")
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, originalID)
+		require.NoError(t, err)
+
+		// Attempt to deprecate with successor of different name - should fail
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DEPRECATED', successor_id = $1 WHERE id = $2`, differentNameID, originalID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "Successor saga name")
+	})
+
+	t.Run("successor_id is write-once", func(t *testing.T) {
+		// Create two potential successors
+		successor1ID := insertSaga(ctx, t, tc.pool, "write_once_test", 2, "def posting_rules(ctx): pass", "DRAFT")
+		_, err := tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, successor1ID)
+		require.NoError(t, err)
+
+		successor2ID := insertSaga(ctx, t, tc.pool, "write_once_test", 3, "def posting_rules(ctx): pass", "DRAFT")
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, successor2ID)
+		require.NoError(t, err)
+
+		// Create and activate original saga
+		originalID := insertSaga(ctx, t, tc.pool, "write_once_test", 1, "def posting_rules(ctx): pass", "DRAFT")
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, originalID)
+		require.NoError(t, err)
+
+		// Set successor first time - should work
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'DEPRECATED', successor_id = $1 WHERE id = $2`, successor1ID, originalID)
+		require.NoError(t, err)
+
+		// Attempt to change successor - should fail
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET successor_id = $1 WHERE id = $2`, successor2ID, originalID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "write-once")
+	})
+}
+
+func TestSagaMigration_Indexes(t *testing.T) {
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("verify expected indexes exist", func(t *testing.T) {
+		expectedIndexes := []string{
+			"idx_saga_definition_name_active",
+			"idx_saga_definition_lookup",
+			"idx_saga_definition_temporal",
+			"idx_saga_definition_successor_id",
+			"idx_saga_reference_by_target",
+			"idx_saga_reference_by_saga",
+			"idx_saga_reference_attribute",
+		}
+
+		for _, indexName := range expectedIndexes {
+			var exists bool
+			err := tc.pool.QueryRow(ctx, `
+				SELECT EXISTS(
+					SELECT 1 FROM pg_indexes
+					WHERE indexname = $1
+				)
+			`, indexName).Scan(&exists)
+			require.NoError(t, err)
+			assert.True(t, exists, "index %s should exist", indexName)
+		}
+	})
+
+	t.Run("verify unique constraint index exists", func(t *testing.T) {
+		var exists bool
+		err := tc.pool.QueryRow(ctx, `
+			SELECT EXISTS(
+				SELECT 1 FROM pg_indexes
+				WHERE tablename = 'saga_definition'
+				AND indexname = 'uq_saga_definition_name_version'
+			)
+		`).Scan(&exists)
+		require.NoError(t, err)
+		assert.True(t, exists, "unique constraint index should exist")
+	})
+}
+
+func TestSagaMigration_SchemaIsolation(t *testing.T) {
+	// This test creates multiple schemas to simulate tenant isolation
+	tc := setupSagaTestContainer(t)
+	defer tc.cleanup(t)
+
+	ctx := context.Background()
+
+	// Create tenant schemas and apply migrations
+	tenants := []string{"tenant_alpha", "tenant_beta", "tenant_gamma"}
+
+	for _, tenant := range tenants {
+		// Create schema for tenant
+		_, err := tc.pool.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS `+tenant)
+		require.NoError(t, err)
+
+		// Apply saga migrations to this tenant's schema
+		migrations := []string{
+			"20260124000001_saga_definitions.sql",
+			"20260124000002_saga_references.sql",
+		}
+
+		for _, migration := range migrations {
+			migrationPath := filepath.Join("migrations", migration)
+			migrationSQL, err := os.ReadFile(migrationPath)
+			require.NoError(t, err)
+
+			// Set search_path to tenant schema and apply migration
+			_, err = tc.pool.Exec(ctx, `SET search_path TO `+tenant)
+			require.NoError(t, err)
+			_, err = tc.pool.Exec(ctx, string(migrationSQL))
+			require.NoError(t, err)
+		}
+	}
+
+	t.Run("data inserted in one tenant is not visible in another", func(t *testing.T) {
+		// Insert data into tenant_alpha
+		_, err := tc.pool.Exec(ctx, `SET search_path TO tenant_alpha`)
+		require.NoError(t, err)
+		_, err = tc.pool.Exec(ctx, `
+			INSERT INTO saga_definition (id, name, version, script, status)
+			VALUES ($1, 'ALPHA_ONLY', 1, 'def posting_rules(ctx): pass', 'DRAFT')
+		`, uuid.New())
+		require.NoError(t, err)
+
+		// Verify it exists in tenant_alpha
+		var count int
+		err = tc.pool.QueryRow(ctx, `SELECT COUNT(*) FROM saga_definition WHERE name = 'ALPHA_ONLY'`).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+
+		// Verify it does NOT exist in tenant_beta
+		_, err = tc.pool.Exec(ctx, `SET search_path TO tenant_beta`)
+		require.NoError(t, err)
+		err = tc.pool.QueryRow(ctx, `SELECT COUNT(*) FROM saga_definition WHERE name = 'ALPHA_ONLY'`).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+
+		// Verify it does NOT exist in tenant_gamma
+		_, err = tc.pool.Exec(ctx, `SET search_path TO tenant_gamma`)
+		require.NoError(t, err)
+		err = tc.pool.QueryRow(ctx, `SELECT COUNT(*) FROM saga_definition WHERE name = 'ALPHA_ONLY'`).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, 0, count)
+	})
+
+	t.Run("same name+version can exist in different tenants", func(t *testing.T) {
+		// Insert same name+version in each tenant
+		for _, tenant := range tenants {
+			_, err := tc.pool.Exec(ctx, `SET search_path TO `+tenant)
+			require.NoError(t, err)
+			_, err = tc.pool.Exec(ctx, `
+				INSERT INTO saga_definition (id, name, version, script, status)
+				VALUES ($1, 'SHARED_NAME', 1, 'def posting_rules(ctx): pass', 'DRAFT')
+			`, uuid.New())
+			require.NoError(t, err, "tenant %s should allow inserting SHARED_NAME", tenant)
+		}
+
+		// Verify each tenant has exactly one record
+		for _, tenant := range tenants {
+			_, err := tc.pool.Exec(ctx, `SET search_path TO `+tenant)
+			require.NoError(t, err)
+
+			var count int
+			err = tc.pool.QueryRow(ctx, `SELECT COUNT(*) FROM saga_definition WHERE name = 'SHARED_NAME'`).Scan(&count)
+			require.NoError(t, err)
+			assert.Equal(t, 1, count, "tenant %s should have exactly one SHARED_NAME", tenant)
+		}
+	})
+
+	t.Run("trigger functions work independently per tenant", func(t *testing.T) {
+		// Activate saga in tenant_alpha
+		_, err := tc.pool.Exec(ctx, `SET search_path TO tenant_alpha`)
+		require.NoError(t, err)
+
+		var id uuid.UUID
+		err = tc.pool.QueryRow(ctx, `SELECT id FROM saga_definition WHERE name = 'SHARED_NAME'`).Scan(&id)
+		require.NoError(t, err)
+
+		_, err = tc.pool.Exec(ctx, `UPDATE saga_definition SET status = 'ACTIVE' WHERE id = $1`, id)
+		require.NoError(t, err)
+
+		// Verify activated_at was set in tenant_alpha
+		var activatedAt *time.Time
+		err = tc.pool.QueryRow(ctx, `SELECT activated_at FROM saga_definition WHERE id = $1`, id).Scan(&activatedAt)
+		require.NoError(t, err)
+		require.NotNil(t, activatedAt)
+
+		// Verify tenant_beta's saga is still DRAFT
+		_, err = tc.pool.Exec(ctx, `SET search_path TO tenant_beta`)
+		require.NoError(t, err)
+
+		var status string
+		err = tc.pool.QueryRow(ctx, `SELECT status FROM saga_definition WHERE name = 'SHARED_NAME'`).Scan(&status)
+		require.NoError(t, err)
+		assert.Equal(t, "DRAFT", status, "tenant_beta saga should still be DRAFT")
+	})
+}


### PR DESCRIPTION
## Summary

- Implements FR-1 (Saga Definition Storage) from Starlark Saga Orchestration PRD
- Implements FR-9/FR-10 (Reference Validation and Deprecation Impact Analysis)
- Adds `saga_definition` table for storing Starlark scripts with lifecycle management
- Adds `saga_reference` table for tracking external references for validation

## Changes Made

### New Migration Files
- `20260124000001_saga_definitions.sql`: Creates saga_definition table with:
  - Lifecycle management (DRAFT/ACTIVE/DEPRECATED)
  - CEL preconditions expression support
  - Bi-temporal timestamps (activated_at, deprecated_at)
  - Successor lineage for deprecation handling
  - Lifecycle trigger enforcing immutability and status transitions

- `20260124000002_saga_references.sql`: Creates saga_reference table with:
  - Reference tracking for step_handler, instrument, account, saga, and attribute types
  - Cascade delete on saga definition removal
  - Indexes for impact analysis queries

### Tests
- Comprehensive migration tests covering:
  - Schema creation and constraints
  - Lifecycle trigger behavior (status transitions, immutability)
  - Successor validation rules
  - Multi-tenant schema isolation
  - Reference cascade deletion

## Technical Details

- Follows ADR-0016 schema-based tenant isolation (no tenant_id column)
- Script limited to 64KB, preconditions expression to 4KB
- Successor must be ACTIVE and have matching name
- successor_id is write-once (cannot be changed after set)

## Test Plan

- [x] All saga migration tests pass locally
- [ ] CI pipeline passes
- [ ] Reference-data service integration tests pass

## Task Master

starlark-saga-orchestration.1 - Create database schema for saga definitions and references