### PR TITLE
feat: Implement saga registry with CRUD, lifecycle, and tenant resolution

### DIFF
--- a/services/reference-data/saga/cache.go
+++ b/services/reference-data/saga/cache.go
@@ -1,0 +1,429 @@
+// Package saga provides caching infrastructure for saga definitions
+// with tenant isolation and TTL-based expiration.
+package saga
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/redis/go-redis/v9"
+)
+
+// Default Redis cache configuration values.
+const (
+	// DefaultCacheTTL is the base TTL for saga cache entries (1 hour).
+	DefaultCacheTTL = 1 * time.Hour
+
+	// DefaultCacheTTLJitter is the maximum random variation added to TTL.
+	// This prevents thundering herd when many entries expire simultaneously.
+	DefaultCacheTTLJitter = 5 * time.Minute
+
+	// DefaultCacheKeyPrefix is the default key prefix for saga cache entries.
+	DefaultCacheKeyPrefix = "saga"
+)
+
+// ErrCacheClientRequired is returned when Redis client is nil.
+var ErrCacheClientRequired = errors.New("redis client is required")
+
+// CacheOption configures a Cache.
+type CacheOption func(*Cache)
+
+// WithCacheKeyPrefix sets the key prefix for Redis keys.
+func WithCacheKeyPrefix(prefix string) CacheOption {
+	return func(c *Cache) {
+		c.keyPrefix = prefix
+	}
+}
+
+// WithCacheTTL sets the base TTL and jitter for cache entries.
+func WithCacheTTL(baseTTL, jitter time.Duration) CacheOption {
+	return func(c *Cache) {
+		c.baseTTL = baseTTL
+		c.ttlJitter = jitter
+	}
+}
+
+// Cache provides Redis-based caching for saga definitions.
+// It stores JSON-serialized Definition objects with tenant-scoped keys.
+//
+// Key formats:
+//   - By ID: {keyPrefix}:id:{tenantID}:{id}
+//   - By name+version: {keyPrefix}:def:{tenantID}:{name}:{version}
+//   - Active resolution: {keyPrefix}:active:{tenantID}:{name}
+//
+// Thread-safety: All methods are safe for concurrent use.
+type Cache struct {
+	// client is the Redis client for cache operations.
+	client redis.Cmdable
+
+	// keyPrefix is the prefix for all Redis keys.
+	keyPrefix string
+
+	// baseTTL is the base time-to-live for cache entries.
+	baseTTL time.Duration
+
+	// ttlJitter is the maximum random variation added to TTL.
+	ttlJitter time.Duration
+}
+
+// NewCache creates a new Redis saga cache.
+// The client can be *redis.Client, *redis.ClusterClient, or any redis.Cmdable.
+func NewCache(client redis.Cmdable, opts ...CacheOption) (*Cache, error) {
+	if client == nil {
+		return nil, ErrCacheClientRequired
+	}
+
+	c := &Cache{
+		client:    client,
+		keyPrefix: DefaultCacheKeyPrefix,
+		baseTTL:   DefaultCacheTTL,
+		ttlJitter: DefaultCacheTTLJitter,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c, nil
+}
+
+// cachedSaga is the JSON-serializable cache representation.
+type cachedSaga struct {
+	ID                      string     `json:"id"`
+	Name                    string     `json:"name"`
+	Version                 int        `json:"version"`
+	Script                  string     `json:"script"`
+	Status                  string     `json:"status"`
+	IsSystem                bool       `json:"is_system"`
+	PreconditionsExpression string     `json:"preconditions_expression,omitempty"`
+	DisplayName             string     `json:"display_name,omitempty"`
+	Description             string     `json:"description,omitempty"`
+	CreatedAt               time.Time  `json:"created_at"`
+	UpdatedAt               time.Time  `json:"updated_at"`
+	ActivatedAt             *time.Time `json:"activated_at,omitempty"`
+	DeprecatedAt            *time.Time `json:"deprecated_at,omitempty"`
+	SuccessorID             *string    `json:"successor_id,omitempty"`
+}
+
+// GetByID retrieves a saga definition by ID from the cache.
+// Returns nil if the entry is not found or tenant context is missing.
+func (c *Cache) GetByID(ctx context.Context, id uuid.UUID) *Definition {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	key := c.idKey(tenantID, id)
+	data, err := c.client.Get(ctx, key).Bytes()
+	if err != nil {
+		return nil
+	}
+
+	return c.deserialize(data)
+}
+
+// Get retrieves a saga definition by name and version from the cache.
+// Returns nil if the entry is not found or tenant context is missing.
+func (c *Cache) Get(ctx context.Context, name string, version int) *Definition {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	key := c.definitionKey(tenantID, name, version)
+	data, err := c.client.Get(ctx, key).Bytes()
+	if err != nil {
+		return nil
+	}
+
+	return c.deserialize(data)
+}
+
+// GetActive retrieves the active saga for a name from the cache.
+// Returns nil if the entry is not found or tenant context is missing.
+func (c *Cache) GetActive(ctx context.Context, name string) *Definition {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	key := c.activeKey(tenantID, name)
+	data, err := c.client.Get(ctx, key).Bytes()
+	if err != nil {
+		return nil
+	}
+
+	return c.deserialize(data)
+}
+
+// PutByID stores a saga definition in the cache by ID.
+// Does nothing if tenant context is missing.
+func (c *Cache) PutByID(ctx context.Context, def *Definition) {
+	if def == nil {
+		return
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	data := c.serialize(def)
+	if data == nil {
+		return
+	}
+
+	key := c.idKey(tenantID, def.ID)
+	ttl := c.jitteredTTL()
+	_ = c.client.Set(ctx, key, data, ttl).Err()
+}
+
+// Put stores a saga definition in the cache by name and version.
+// Does nothing if tenant context is missing.
+func (c *Cache) Put(ctx context.Context, def *Definition) {
+	if def == nil {
+		return
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	data := c.serialize(def)
+	if data == nil {
+		return
+	}
+
+	key := c.definitionKey(tenantID, def.Name, def.Version)
+	ttl := c.jitteredTTL()
+	_ = c.client.Set(ctx, key, data, ttl).Err()
+}
+
+// PutActive stores a saga definition as the active version for its name.
+// Does nothing if tenant context is missing.
+func (c *Cache) PutActive(ctx context.Context, def *Definition) {
+	if def == nil {
+		return
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	data := c.serialize(def)
+	if data == nil {
+		return
+	}
+
+	key := c.activeKey(tenantID, def.Name)
+	ttl := c.jitteredTTL()
+	_ = c.client.Set(ctx, key, data, ttl).Err()
+}
+
+// InvalidateByID removes a saga from the cache by ID.
+func (c *Cache) InvalidateByID(ctx context.Context, id uuid.UUID) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	key := c.idKey(tenantID, id)
+	_ = c.client.Del(ctx, key).Err()
+}
+
+// Invalidate removes a specific entry from the cache.
+func (c *Cache) Invalidate(ctx context.Context, name string, version int) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	key := c.definitionKey(tenantID, name, version)
+	_ = c.client.Del(ctx, key).Err()
+}
+
+// InvalidateName removes all versions and the active cache for a saga name.
+// Uses pattern matching with SCAN to find and delete all matching keys.
+// Uses UNLINK instead of DEL for non-blocking deletion.
+func (c *Cache) InvalidateName(ctx context.Context, name string) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	// Delete active cache
+	activeKey := c.activeKey(tenantID, name)
+	_ = c.client.Del(ctx, activeKey).Err()
+
+	// Pattern to match all versions: {prefix}:def:{tenantID}:{name}:*
+	pattern := c.definitionKeyPattern(tenantID, name)
+
+	// Use SCAN to find matching keys (safer than KEYS for production)
+	var cursor uint64
+	for {
+		keys, nextCursor, err := c.client.Scan(ctx, cursor, pattern, 100).Result()
+		if err != nil {
+			return // Best effort invalidation
+		}
+
+		if len(keys) > 0 {
+			_ = c.client.Unlink(ctx, keys...).Err()
+		}
+
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+}
+
+// InvalidateAll removes all saga cache entries for the tenant.
+// Uses pattern matching with SCAN to find and delete all matching keys.
+func (c *Cache) InvalidateAll(ctx context.Context) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return
+	}
+
+	// Pattern to match all tenant entries: {prefix}:*:{tenantID}:*
+	patterns := []string{
+		c.tenantKeyPattern(tenantID, "id"),
+		c.tenantKeyPattern(tenantID, "def"),
+		c.tenantKeyPattern(tenantID, "active"),
+	}
+
+	for _, pattern := range patterns {
+		var cursor uint64
+		for {
+			keys, nextCursor, err := c.client.Scan(ctx, cursor, pattern, 100).Result()
+			if err != nil {
+				break
+			}
+
+			if len(keys) > 0 {
+				_ = c.client.Unlink(ctx, keys...).Err()
+			}
+
+			cursor = nextCursor
+			if cursor == 0 {
+				break
+			}
+		}
+	}
+}
+
+// idKey generates the Redis key for a saga by ID.
+// Format: {keyPrefix}:id:{tenantID}:{id}
+func (c *Cache) idKey(tenantID tenant.TenantID, id uuid.UUID) string {
+	return fmt.Sprintf("%s:id:%s:%s", c.keyPrefix, tenantID, id)
+}
+
+// definitionKey generates the Redis key for a specific saga version.
+// Format: {keyPrefix}:def:{tenantID}:{name}:{version}
+func (c *Cache) definitionKey(tenantID tenant.TenantID, name string, version int) string {
+	return fmt.Sprintf("%s:def:%s:%s:%d", c.keyPrefix, tenantID, name, version)
+}
+
+// activeKey generates the Redis key for the active saga resolution.
+// Format: {keyPrefix}:active:{tenantID}:{name}
+func (c *Cache) activeKey(tenantID tenant.TenantID, name string) string {
+	return fmt.Sprintf("%s:active:%s:%s", c.keyPrefix, tenantID, name)
+}
+
+// definitionKeyPattern generates a pattern to match all versions of a saga.
+// Format: {keyPrefix}:def:{tenantID}:{name}:*
+func (c *Cache) definitionKeyPattern(tenantID tenant.TenantID, name string) string {
+	return fmt.Sprintf("%s:def:%s:%s:*", c.keyPrefix, tenantID, name)
+}
+
+// tenantKeyPattern generates a pattern to match all entries of a type for a tenant.
+// Format: {keyPrefix}:{type}:{tenantID}:*
+func (c *Cache) tenantKeyPattern(tenantID tenant.TenantID, keyType string) string {
+	return fmt.Sprintf("%s:%s:%s:*", c.keyPrefix, keyType, tenantID)
+}
+
+// jitteredTTL returns the base TTL plus a random jitter.
+func (c *Cache) jitteredTTL() time.Duration {
+	if c.ttlJitter == 0 {
+		return c.baseTTL
+	}
+
+	// Generate random jitter in range [-ttlJitter, +ttlJitter]
+	jitterRange := int64(c.ttlJitter) * 2
+	jitter := rand.Int64N(jitterRange) - int64(c.ttlJitter)
+
+	return c.baseTTL + time.Duration(jitter)
+}
+
+// serialize converts a Definition to JSON bytes.
+func (c *Cache) serialize(def *Definition) []byte {
+	cached := &cachedSaga{
+		ID:                      def.ID.String(),
+		Name:                    def.Name,
+		Version:                 def.Version,
+		Script:                  def.Script,
+		Status:                  string(def.Status),
+		IsSystem:                def.IsSystem,
+		PreconditionsExpression: def.PreconditionsExpression,
+		DisplayName:             def.DisplayName,
+		Description:             def.Description,
+		CreatedAt:               def.CreatedAt,
+		UpdatedAt:               def.UpdatedAt,
+		ActivatedAt:             def.ActivatedAt,
+		DeprecatedAt:            def.DeprecatedAt,
+	}
+
+	if def.SuccessorID != nil {
+		s := def.SuccessorID.String()
+		cached.SuccessorID = &s
+	}
+
+	data, err := json.Marshal(cached)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+// deserialize converts JSON bytes to a Definition.
+func (c *Cache) deserialize(data []byte) *Definition {
+	var cached cachedSaga
+	if err := json.Unmarshal(data, &cached); err != nil {
+		return nil
+	}
+
+	def := &Definition{
+		Name:                    cached.Name,
+		Version:                 cached.Version,
+		Script:                  cached.Script,
+		Status:                  Status(cached.Status),
+		IsSystem:                cached.IsSystem,
+		PreconditionsExpression: cached.PreconditionsExpression,
+		DisplayName:             cached.DisplayName,
+		Description:             cached.Description,
+		CreatedAt:               cached.CreatedAt,
+		UpdatedAt:               cached.UpdatedAt,
+		ActivatedAt:             cached.ActivatedAt,
+		DeprecatedAt:            cached.DeprecatedAt,
+	}
+
+	if id, err := uuid.Parse(cached.ID); err == nil {
+		def.ID = id
+	}
+
+	if cached.SuccessorID != nil {
+		if id, err := uuid.Parse(*cached.SuccessorID); err == nil {
+			def.SuccessorID = &id
+		}
+	}
+
+	return def
+}

--- a/services/reference-data/saga/cached_registry.go
+++ b/services/reference-data/saga/cached_registry.go
@@ -1,0 +1,160 @@
+// Package saga provides a cached wrapper for Registry implementations.
+package saga
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// CachedRegistry wraps a Registry with a Redis cache layer.
+// Cache is read-through: misses fetch from the underlying registry.
+// Cache is invalidated on write operations.
+type CachedRegistry struct {
+	registry Registry
+	cache    *Cache
+}
+
+// NewCachedRegistry creates a new cached saga registry.
+func NewCachedRegistry(registry Registry, cache *Cache) *CachedRegistry {
+	return &CachedRegistry{
+		registry: registry,
+		cache:    cache,
+	}
+}
+
+// GetByID retrieves a specific saga by its UUID.
+// Checks cache first, then falls back to the underlying registry.
+func (r *CachedRegistry) GetByID(ctx context.Context, id uuid.UUID) (*Definition, error) {
+	// Try cache first
+	if cached := r.cache.GetByID(ctx, id); cached != nil {
+		return cached, nil
+	}
+
+	// Fetch from registry
+	def, err := r.registry.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the result
+	r.cache.PutByID(ctx, def)
+	r.cache.Put(ctx, def)
+
+	return def, nil
+}
+
+// GetDefinition retrieves a specific saga by name and version.
+// Checks cache first, then falls back to the underlying registry.
+func (r *CachedRegistry) GetDefinition(ctx context.Context, name string, version int) (*Definition, error) {
+	// Try cache first
+	if cached := r.cache.Get(ctx, name, version); cached != nil {
+		return cached, nil
+	}
+
+	// Fetch from registry
+	def, err := r.registry.GetDefinition(ctx, name, version)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the result
+	r.cache.Put(ctx, def)
+	r.cache.PutByID(ctx, def)
+
+	return def, nil
+}
+
+// GetActive retrieves the active saga for a name using tenant resolution.
+// Checks cache first, then falls back to the underlying registry.
+func (r *CachedRegistry) GetActive(ctx context.Context, name string) (*Definition, error) {
+	// Try cache first
+	if cached := r.cache.GetActive(ctx, name); cached != nil {
+		return cached, nil
+	}
+
+	// Fetch from registry
+	def, err := r.registry.GetActive(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	// Cache the result
+	r.cache.PutActive(ctx, def)
+	r.cache.Put(ctx, def)
+	r.cache.PutByID(ctx, def)
+
+	return def, nil
+}
+
+// ListByStatus retrieves all sagas with the specified status.
+// This is not cached as it returns potentially large result sets.
+func (r *CachedRegistry) ListByStatus(ctx context.Context, status Status) ([]*Definition, error) {
+	return r.registry.ListByStatus(ctx, status)
+}
+
+// CreateDraft creates a new saga definition in DRAFT status.
+// No cache invalidation needed as drafts are not cached for active resolution.
+func (r *CachedRegistry) CreateDraft(ctx context.Context, def *Definition) error {
+	return r.registry.CreateDraft(ctx, def)
+}
+
+// UpdateDefinition updates a DRAFT saga definition.
+// Invalidates the cache for the updated saga.
+func (r *CachedRegistry) UpdateDefinition(ctx context.Context, id uuid.UUID, updates *Definition) error {
+	// Get the current saga to know its name for cache invalidation
+	current, err := r.registry.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if err := r.registry.UpdateDefinition(ctx, id, updates); err != nil {
+		return err
+	}
+
+	// Invalidate cache
+	r.cache.InvalidateByID(ctx, id)
+	r.cache.Invalidate(ctx, current.Name, current.Version)
+
+	return nil
+}
+
+// ActivateSaga transitions a saga from DRAFT to ACTIVE.
+// Invalidates the active cache for the saga's name as the resolution may change.
+func (r *CachedRegistry) ActivateSaga(ctx context.Context, id uuid.UUID) error {
+	// Get the current saga to know its name for cache invalidation
+	current, err := r.registry.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if err := r.registry.ActivateSaga(ctx, id); err != nil {
+		return err
+	}
+
+	// Invalidate all cache entries for this saga name
+	// because active resolution may have changed
+	r.cache.InvalidateName(ctx, current.Name)
+
+	return nil
+}
+
+// DeprecateSaga transitions a saga from ACTIVE to DEPRECATED.
+// Invalidates the active cache for the saga's name as the resolution may change.
+func (r *CachedRegistry) DeprecateSaga(ctx context.Context, id uuid.UUID, successorID *uuid.UUID) error {
+	// Get the current saga to know its name for cache invalidation
+	current, err := r.registry.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if err := r.registry.DeprecateSaga(ctx, id, successorID); err != nil {
+		return err
+	}
+
+	// Invalidate all cache entries for this saga name
+	// because active resolution may have changed
+	r.cache.InvalidateName(ctx, current.Name)
+
+	return nil
+}

--- a/services/reference-data/saga/cached_registry.go
+++ b/services/reference-data/saga/cached_registry.go
@@ -134,6 +134,7 @@ func (r *CachedRegistry) ActivateSaga(ctx context.Context, id uuid.UUID) error {
 
 	// Invalidate all cache entries for this saga name
 	// because active resolution may have changed
+	r.cache.InvalidateByID(ctx, id)
 	r.cache.InvalidateName(ctx, current.Name)
 
 	return nil
@@ -154,6 +155,7 @@ func (r *CachedRegistry) DeprecateSaga(ctx context.Context, id uuid.UUID, succes
 
 	// Invalidate all cache entries for this saga name
 	// because active resolution may have changed
+	r.cache.InvalidateByID(ctx, id)
 	r.cache.InvalidateName(ctx, current.Name)
 
 	return nil

--- a/services/reference-data/saga/postgres_registry.go
+++ b/services/reference-data/saga/postgres_registry.go
@@ -1,0 +1,544 @@
+// Package saga provides the SagaRegistry implementation backed by PostgreSQL.
+package saga
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// PostgresRegistry implements SagaRegistry using PostgreSQL.
+type PostgresRegistry struct {
+	pool      *pgxpool.Pool
+	validator Validator
+}
+
+// NewPostgresRegistry creates a new PostgreSQL-backed saga registry.
+// The validator is optional - if nil, activation will succeed without validation.
+func NewPostgresRegistry(pool *pgxpool.Pool, validator Validator) *PostgresRegistry {
+	return &PostgresRegistry{
+		pool:      pool,
+		validator: validator,
+	}
+}
+
+// setSearchPath sets the PostgreSQL search_path for the transaction.
+// In multi-tenant mode, it sets the search_path to the tenant's schema.
+func (r *PostgresRegistry) setSearchPath(ctx context.Context, tx pgx.Tx) error {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return tenant.ErrMissingTenantContext
+	}
+
+	// Quote the schema name to prevent SQL injection
+	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
+
+	// SET LOCAL is transaction-scoped - automatically reverts on commit/rollback
+	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	_, err := tx.Exec(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to set tenant schema scope: %w", err)
+	}
+
+	return nil
+}
+
+// withReadTransaction executes a read-only function within a transaction with tenant scoping.
+func (r *PostgresRegistry) withReadTransaction(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit read transaction: %w", err)
+	}
+
+	return nil
+}
+
+// withWriteTransaction executes a write function within a transaction with tenant scoping.
+func (r *PostgresRegistry) withWriteTransaction(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// GetByID retrieves a specific saga by its UUID.
+func (r *PostgresRegistry) GetByID(ctx context.Context, id uuid.UUID) (*Definition, error) {
+	var result *Definition
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, name, version, script, status, is_system,
+				preconditions_expression, display_name, description,
+				created_at, updated_at, activated_at, deprecated_at, successor_id
+			FROM saga_definition
+			WHERE id = $1`
+
+		row := tx.QueryRow(ctx, query, id)
+		def, err := r.scanDefinition(row)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to query saga definition: %w", err)
+		}
+
+		result = def
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetDefinition retrieves a specific saga by name and version.
+func (r *PostgresRegistry) GetDefinition(ctx context.Context, name string, version int) (*Definition, error) {
+	var result *Definition
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, name, version, script, status, is_system,
+				preconditions_expression, display_name, description,
+				created_at, updated_at, activated_at, deprecated_at, successor_id
+			FROM saga_definition
+			WHERE name = $1 AND version = $2`
+
+		row := tx.QueryRow(ctx, query, name, version)
+		def, err := r.scanDefinition(row)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to query saga definition: %w", err)
+		}
+
+		result = def
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetActive retrieves the active saga for a name using tenant resolution.
+// Resolution order:
+//  1. Tenant override (is_system=FALSE, status=ACTIVE, highest version)
+//  2. Platform default (is_system=TRUE, status=ACTIVE, highest version)
+func (r *PostgresRegistry) GetActive(ctx context.Context, name string) (*Definition, error) {
+	var result *Definition
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		// Step 1: Try tenant override (is_system=FALSE)
+		tenantQuery := `
+			SELECT id, name, version, script, status, is_system,
+				preconditions_expression, display_name, description,
+				created_at, updated_at, activated_at, deprecated_at, successor_id
+			FROM saga_definition
+			WHERE name = $1 AND status = 'ACTIVE' AND is_system = FALSE
+			ORDER BY version DESC
+			LIMIT 1`
+
+		row := tx.QueryRow(ctx, tenantQuery, name)
+		def, err := r.scanDefinition(row)
+		if err == nil {
+			result = def
+			return nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("failed to query tenant saga: %w", err)
+		}
+
+		// Step 2: Fall back to platform default (is_system=TRUE)
+		platformQuery := `
+			SELECT id, name, version, script, status, is_system,
+				preconditions_expression, display_name, description,
+				created_at, updated_at, activated_at, deprecated_at, successor_id
+			FROM saga_definition
+			WHERE name = $1 AND status = 'ACTIVE' AND is_system = TRUE
+			ORDER BY version DESC
+			LIMIT 1`
+
+		row = tx.QueryRow(ctx, platformQuery, name)
+		def, err = r.scanDefinition(row)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to query platform saga: %w", err)
+		}
+
+		result = def
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// ListByStatus retrieves all sagas with the specified status.
+func (r *PostgresRegistry) ListByStatus(ctx context.Context, status Status) ([]*Definition, error) {
+	var result []*Definition
+
+	err := r.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			SELECT id, name, version, script, status, is_system,
+				preconditions_expression, display_name, description,
+				created_at, updated_at, activated_at, deprecated_at, successor_id
+			FROM saga_definition
+			WHERE status = $1
+			ORDER BY name, version DESC`
+
+		rows, err := tx.Query(ctx, query, string(status))
+		if err != nil {
+			return fmt.Errorf("failed to query sagas by status: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			def, err := r.scanDefinitionFromRows(rows)
+			if err != nil {
+				return err
+			}
+			result = append(result, def)
+		}
+
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// CreateDraft creates a new saga definition in DRAFT status.
+func (r *PostgresRegistry) CreateDraft(ctx context.Context, def *Definition) error {
+	// Reject system saga creation
+	if def.IsSystem {
+		return ErrSystemSagaReadOnly
+	}
+
+	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		query := `
+			INSERT INTO saga_definition (
+				id, name, version, script, status, is_system,
+				preconditions_expression, display_name, description,
+				created_at, updated_at
+			) VALUES (
+				$1, $2, $3, $4, $5, $6,
+				$7, $8, $9,
+				$10, $11
+			)`
+
+		// Generate ID if not set
+		if def.ID == uuid.Nil {
+			def.ID = uuid.New()
+		}
+
+		now := time.Now()
+		def.CreatedAt = now
+		def.UpdatedAt = now
+		def.Status = StatusDraft
+
+		_, err := tx.Exec(ctx, query,
+			def.ID, def.Name, def.Version, def.Script, string(def.Status), def.IsSystem,
+			nullString(def.PreconditionsExpression), nullString(def.DisplayName), nullString(def.Description),
+			def.CreatedAt, def.UpdatedAt,
+		)
+		if err != nil {
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "23505" { // unique_violation
+				return ErrAlreadyExists
+			}
+			return fmt.Errorf("failed to insert saga definition: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// UpdateDefinition updates a DRAFT saga definition.
+func (r *PostgresRegistry) UpdateDefinition(ctx context.Context, id uuid.UUID, updates *Definition) error {
+	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		// First, check if the saga exists and is not a system saga
+		var isSystem bool
+		var currentStatus string
+		var currentUpdatedAt time.Time
+
+		checkQuery := `SELECT is_system, status, updated_at FROM saga_definition WHERE id = $1`
+		err := tx.QueryRow(ctx, checkQuery, id).Scan(&isSystem, &currentStatus, &currentUpdatedAt)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to check saga: %w", err)
+		}
+
+		if isSystem {
+			return ErrSystemSagaReadOnly
+		}
+
+		if currentStatus != string(StatusDraft) {
+			return ErrNotDraft
+		}
+
+		// Update the saga
+		updateQuery := `
+			UPDATE saga_definition SET
+				script = COALESCE(NULLIF($1, ''), script),
+				preconditions_expression = $2,
+				display_name = $3,
+				description = $4,
+				updated_at = $5
+			WHERE id = $6 AND updated_at = $7`
+
+		now := time.Now()
+		result, err := tx.Exec(ctx, updateQuery,
+			updates.Script,
+			nullString(updates.PreconditionsExpression),
+			nullString(updates.DisplayName),
+			nullString(updates.Description),
+			now,
+			id, currentUpdatedAt,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to update saga definition: %w", err)
+		}
+
+		if result.RowsAffected() == 0 {
+			return ErrOptimisticLock
+		}
+
+		return nil
+	})
+}
+
+// ActivateSaga transitions a saga from DRAFT to ACTIVE.
+func (r *PostgresRegistry) ActivateSaga(ctx context.Context, id uuid.UUID) error {
+	// First get the saga to validate it
+	saga, err := r.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if saga.IsSystem {
+		return ErrSystemSagaReadOnly
+	}
+
+	if saga.Status != StatusDraft {
+		return ErrNotDraft
+	}
+
+	// Validate the saga if a validator is configured
+	if r.validator != nil {
+		if err := r.validator.Validate(ctx, saga); err != nil {
+			return errors.Join(ErrValidationFailed, err)
+		}
+	}
+
+	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		// Re-check status within transaction
+		var currentStatus string
+		checkQuery := `SELECT status FROM saga_definition WHERE id = $1`
+		err := tx.QueryRow(ctx, checkQuery, id).Scan(&currentStatus)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to check saga: %w", err)
+		}
+
+		if currentStatus != string(StatusDraft) {
+			return ErrNotDraft
+		}
+
+		// Transition to ACTIVE (trigger will set activated_at)
+		updateQuery := `
+			UPDATE saga_definition SET
+				status = 'ACTIVE'
+			WHERE id = $1`
+
+		_, err = tx.Exec(ctx, updateQuery, id)
+		if err != nil {
+			return fmt.Errorf("failed to activate saga: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// DeprecateSaga transitions a saga from ACTIVE to DEPRECATED.
+func (r *PostgresRegistry) DeprecateSaga(ctx context.Context, id uuid.UUID, successorID *uuid.UUID) error {
+	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		// Check current state
+		var isSystem bool
+		var currentStatus string
+
+		checkQuery := `SELECT is_system, status FROM saga_definition WHERE id = $1`
+		err := tx.QueryRow(ctx, checkQuery, id).Scan(&isSystem, &currentStatus)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to check saga: %w", err)
+		}
+
+		if isSystem {
+			return ErrSystemSagaReadOnly
+		}
+
+		if currentStatus != string(StatusActive) {
+			return ErrNotActive
+		}
+
+		// Transition to DEPRECATED with optional successor
+		// The database trigger will validate the successor and set deprecated_at
+		updateQuery := `
+			UPDATE saga_definition SET
+				status = 'DEPRECATED',
+				successor_id = $2
+			WHERE id = $1`
+
+		_, err = tx.Exec(ctx, updateQuery, id, successorID)
+		if err != nil {
+			// Check if the error is from the successor validation trigger
+			var pgErr *pgconn.PgError
+			if errors.As(err, &pgErr) && pgErr.Code == "P0001" { // raise_exception
+				msg := pgErr.Message
+				msgLower := strings.ToLower(msg)
+				switch {
+				case strings.Contains(msgLower, "successor"):
+					return ErrSuccessorInvalid
+				case strings.Contains(msgLower, "cannot transition"):
+					return ErrInvalidStateTransition
+				case strings.Contains(msgLower, "cannot modify"):
+					return ErrInvalidStatus
+				default:
+					return fmt.Errorf("%w: %s", ErrInvalidStatus, msg)
+				}
+			}
+			return fmt.Errorf("failed to deprecate saga: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// scanDefinition scans a single row into a Definition.
+func (r *PostgresRegistry) scanDefinition(row pgx.Row) (*Definition, error) {
+	var def Definition
+	var status string
+	var preconditionsExpr, displayName, description sql.NullString
+	var successorID *uuid.UUID
+
+	err := row.Scan(
+		&def.ID, &def.Name, &def.Version, &def.Script, &status, &def.IsSystem,
+		&preconditionsExpr, &displayName, &description,
+		&def.CreatedAt, &def.UpdatedAt, &def.ActivatedAt, &def.DeprecatedAt, &successorID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	def.Status = Status(status)
+	def.SuccessorID = successorID
+
+	if preconditionsExpr.Valid {
+		def.PreconditionsExpression = preconditionsExpr.String
+	}
+	if displayName.Valid {
+		def.DisplayName = displayName.String
+	}
+	if description.Valid {
+		def.Description = description.String
+	}
+
+	return &def, nil
+}
+
+// scanDefinitionFromRows scans from pgx.Rows.
+func (r *PostgresRegistry) scanDefinitionFromRows(rows pgx.Rows) (*Definition, error) {
+	var def Definition
+	var status string
+	var preconditionsExpr, displayName, description sql.NullString
+	var successorID *uuid.UUID
+
+	err := rows.Scan(
+		&def.ID, &def.Name, &def.Version, &def.Script, &status, &def.IsSystem,
+		&preconditionsExpr, &displayName, &description,
+		&def.CreatedAt, &def.UpdatedAt, &def.ActivatedAt, &def.DeprecatedAt, &successorID,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	def.Status = Status(status)
+	def.SuccessorID = successorID
+
+	if preconditionsExpr.Valid {
+		def.PreconditionsExpression = preconditionsExpr.String
+	}
+	if displayName.Valid {
+		def.DisplayName = displayName.String
+	}
+	if description.Valid {
+		def.Description = description.String
+	}
+
+	return &def, nil
+}
+
+// nullString converts a string to sql.NullString, treating empty strings as NULL.
+func nullString(s string) sql.NullString {
+	if s == "" {
+		return sql.NullString{Valid: false}
+	}
+	return sql.NullString{String: s, Valid: true}
+}

--- a/services/reference-data/saga/postgres_registry.go
+++ b/services/reference-data/saga/postgres_registry.go
@@ -330,21 +330,22 @@ func (r *PostgresRegistry) UpdateDefinition(ctx context.Context, id uuid.UUID, u
 		}
 
 		// Update the saga
+		// Use COALESCE(NULLIF(...)) pattern to preserve existing values when empty string is passed
 		updateQuery := `
 			UPDATE saga_definition SET
 				script = COALESCE(NULLIF($1, ''), script),
-				preconditions_expression = $2,
-				display_name = $3,
-				description = $4,
+				preconditions_expression = COALESCE(NULLIF($2, ''), preconditions_expression),
+				display_name = COALESCE(NULLIF($3, ''), display_name),
+				description = COALESCE(NULLIF($4, ''), description),
 				updated_at = $5
 			WHERE id = $6 AND updated_at = $7`
 
 		now := time.Now()
 		result, err := tx.Exec(ctx, updateQuery,
 			updates.Script,
-			nullString(updates.PreconditionsExpression),
-			nullString(updates.DisplayName),
-			nullString(updates.Description),
+			updates.PreconditionsExpression,
+			updates.DisplayName,
+			updates.Description,
 			now,
 			id, currentUpdatedAt,
 		)

--- a/services/reference-data/saga/postgres_registry_test.go
+++ b/services/reference-data/saga/postgres_registry_test.go
@@ -1,0 +1,759 @@
+package saga_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+	"github.com/meridianhub/meridian/services/reference-data/saga"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestRegistry(t *testing.T) (*saga.PostgresRegistry, *pgxpool.Pool) {
+	t.Helper()
+
+	pool := testdb.NewTestPool(t)
+
+	reg := saga.NewPostgresRegistry(pool, nil)
+
+	return reg, pool
+}
+
+func setupTenantContext(t *testing.T, pool *pgxpool.Pool, tenantID string) context.Context {
+	t.Helper()
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, tenantID, "reference-data")
+	t.Cleanup(cleanup)
+	return ctx
+}
+
+func seedSystemSaga(t *testing.T, pool *pgxpool.Pool, ctx context.Context, name string) uuid.UUID {
+	t.Helper()
+
+	tenantID, _ := tenant.FromContext(ctx)
+	schemaName := tenantID.SchemaName()
+
+	id := uuid.New()
+
+	// Seed a system saga directly via SQL (simulating provisioning)
+	query := `
+		INSERT INTO saga_definition (
+			id, name, version, script, status, is_system,
+			created_at, updated_at, activated_at
+		) VALUES (
+			$1, $2, 1, 'def posting_rules(ctx): pass', 'ACTIVE', true,
+			NOW(), NOW(), NOW()
+		)`
+
+	// Set search_path and insert
+	tx, err := pool.Begin(ctx)
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+	require.NoError(t, err)
+
+	_, err = tx.Exec(ctx, query, id, name)
+	require.NoError(t, err)
+
+	require.NoError(t, tx.Commit(ctx))
+
+	return id
+}
+
+func TestPostgresRegistry_CreateDraft(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-1")
+
+	t.Run("creates draft saga successfully", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:        "withdrawal",
+			Version:     1,
+			Script:      "def posting_rules(ctx):\n    return []",
+			DisplayName: "Withdrawal Saga",
+			Description: "Handles withdrawal workflow",
+		}
+
+		err := reg.CreateDraft(ctx, def)
+		require.NoError(t, err)
+		assert.NotEqual(t, uuid.Nil, def.ID)
+		assert.Equal(t, saga.StatusDraft, def.Status)
+		assert.False(t, def.IsSystem)
+	})
+
+	t.Run("rejects system saga creation", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:     "system_saga",
+			Version:  1,
+			Script:   "def posting_rules(ctx): pass",
+			IsSystem: true,
+		}
+
+		err := reg.CreateDraft(ctx, def)
+		require.ErrorIs(t, err, saga.ErrSystemSagaReadOnly)
+	})
+
+	t.Run("rejects duplicate name+version", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:    "duplicate_test",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+
+		err := reg.CreateDraft(ctx, def)
+		require.NoError(t, err)
+
+		// Try to create again
+		def2 := &saga.Definition{
+			Name:    "duplicate_test",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+
+		err = reg.CreateDraft(ctx, def2)
+		require.ErrorIs(t, err, saga.ErrAlreadyExists)
+	})
+
+	t.Run("allows same name with different version", func(t *testing.T) {
+		def1 := &saga.Definition{
+			Name:    "versioned_saga",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def1))
+
+		def2 := &saga.Definition{
+			Name:    "versioned_saga",
+			Version: 2,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		err := reg.CreateDraft(ctx, def2)
+		require.NoError(t, err)
+	})
+}
+
+func TestPostgresRegistry_GetByID(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-2")
+
+	// Create a test saga
+	def := &saga.Definition{
+		Name:        "get_by_id_test",
+		Version:     1,
+		Script:      "def posting_rules(ctx): pass",
+		DisplayName: "Get By ID Test",
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+
+	t.Run("retrieves existing saga by ID", func(t *testing.T) {
+		result, err := reg.GetByID(ctx, def.ID)
+		require.NoError(t, err)
+		assert.Equal(t, def.ID, result.ID)
+		assert.Equal(t, "get_by_id_test", result.Name)
+		assert.Equal(t, 1, result.Version)
+		assert.Equal(t, saga.StatusDraft, result.Status)
+	})
+
+	t.Run("returns ErrNotFound for missing ID", func(t *testing.T) {
+		_, err := reg.GetByID(ctx, uuid.New())
+		require.ErrorIs(t, err, saga.ErrNotFound)
+	})
+}
+
+func TestPostgresRegistry_GetDefinition(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-3")
+
+	// Create a test saga
+	def := &saga.Definition{
+		Name:        "get_def_test",
+		Version:     1,
+		Script:      "def posting_rules(ctx): pass",
+		DisplayName: "Get Definition Test",
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+
+	t.Run("retrieves existing saga", func(t *testing.T) {
+		result, err := reg.GetDefinition(ctx, "get_def_test", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "get_def_test", result.Name)
+		assert.Equal(t, 1, result.Version)
+		assert.Equal(t, saga.StatusDraft, result.Status)
+	})
+
+	t.Run("returns ErrNotFound for missing saga", func(t *testing.T) {
+		_, err := reg.GetDefinition(ctx, "nonexistent", 1)
+		require.ErrorIs(t, err, saga.ErrNotFound)
+	})
+}
+
+func TestPostgresRegistry_GetActive_TenantResolution(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-4")
+
+	t.Run("returns tenant override over platform default", func(t *testing.T) {
+		// Seed a platform default (system saga)
+		seedSystemSaga(t, pool, ctx, "transfer")
+
+		// Create a tenant override with version 2 (since system saga has version 1)
+		tenantDef := &saga.Definition{
+			Name:        "transfer",
+			Version:     2,
+			Script:      "def posting_rules(ctx): return 'tenant_override'",
+			DisplayName: "Tenant Transfer Override",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, tenantDef))
+		require.NoError(t, reg.ActivateSaga(ctx, tenantDef.ID))
+
+		// GetActive should return tenant override
+		result, err := reg.GetActive(ctx, "transfer")
+		require.NoError(t, err)
+		assert.False(t, result.IsSystem, "should return tenant override, not system saga")
+		assert.Equal(t, "Tenant Transfer Override", result.DisplayName)
+	})
+
+	t.Run("returns platform default when no tenant override", func(t *testing.T) {
+		// Seed a platform default
+		seedSystemSaga(t, pool, ctx, "deposit")
+
+		// No tenant override created
+
+		// GetActive should return platform default
+		result, err := reg.GetActive(ctx, "deposit")
+		require.NoError(t, err)
+		assert.True(t, result.IsSystem, "should return system saga")
+	})
+
+	t.Run("returns highest version tenant override", func(t *testing.T) {
+		// Create v1 and activate
+		v1 := &saga.Definition{
+			Name:    "versioned_active",
+			Version: 1,
+			Script:  "def posting_rules(ctx): return 'v1'",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, v1))
+		require.NoError(t, reg.ActivateSaga(ctx, v1.ID))
+
+		// Create v2 and activate
+		v2 := &saga.Definition{
+			Name:    "versioned_active",
+			Version: 2,
+			Script:  "def posting_rules(ctx): return 'v2'",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, v2))
+		require.NoError(t, reg.ActivateSaga(ctx, v2.ID))
+
+		// GetActive should return v2
+		result, err := reg.GetActive(ctx, "versioned_active")
+		require.NoError(t, err)
+		assert.Equal(t, 2, result.Version)
+	})
+
+	t.Run("returns ErrNotFound when no active version exists", func(t *testing.T) {
+		// Create draft but don't activate
+		draft := &saga.Definition{
+			Name:    "draft_only",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, draft))
+
+		_, err := reg.GetActive(ctx, "draft_only")
+		require.ErrorIs(t, err, saga.ErrNotFound)
+	})
+}
+
+func TestPostgresRegistry_ListByStatus(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-5")
+
+	// Seed a system saga
+	seedSystemSaga(t, pool, ctx, "system_list_test")
+
+	// Create and activate a tenant saga
+	def := &saga.Definition{
+		Name:    "tenant_list_test",
+		Version: 1,
+		Script:  "def posting_rules(ctx): pass",
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+	require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+	t.Run("returns both system and tenant sagas", func(t *testing.T) {
+		results, err := reg.ListByStatus(ctx, saga.StatusActive)
+		require.NoError(t, err)
+
+		names := make(map[string]bool)
+		for _, r := range results {
+			names[r.Name] = true
+		}
+
+		assert.True(t, names["system_list_test"], "expected system saga")
+		assert.True(t, names["tenant_list_test"], "expected tenant saga")
+	})
+
+	t.Run("filters by status", func(t *testing.T) {
+		// Create a draft saga
+		draft := &saga.Definition{
+			Name:    "draft_list_test",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, draft))
+
+		// List DRAFT only
+		drafts, err := reg.ListByStatus(ctx, saga.StatusDraft)
+		require.NoError(t, err)
+
+		for _, d := range drafts {
+			assert.Equal(t, saga.StatusDraft, d.Status)
+		}
+	})
+}
+
+func TestPostgresRegistry_SystemSagaProtection(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-6")
+
+	// Seed system sagas
+	systemID := seedSystemSaga(t, pool, ctx, "protected_saga")
+
+	t.Run("CreateDraft rejects is_system=true", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:     "fake_system",
+			Version:  1,
+			Script:   "def posting_rules(ctx): pass",
+			IsSystem: true,
+		}
+		err := reg.CreateDraft(ctx, def)
+		require.ErrorIs(t, err, saga.ErrSystemSagaReadOnly)
+	})
+
+	t.Run("UpdateDefinition rejects system saga", func(t *testing.T) {
+		updates := &saga.Definition{
+			DisplayName: "Modified System Saga",
+		}
+		err := reg.UpdateDefinition(ctx, systemID, updates)
+		require.ErrorIs(t, err, saga.ErrSystemSagaReadOnly)
+	})
+
+	t.Run("ActivateSaga rejects system saga", func(t *testing.T) {
+		err := reg.ActivateSaga(ctx, systemID)
+		require.ErrorIs(t, err, saga.ErrSystemSagaReadOnly)
+	})
+
+	t.Run("DeprecateSaga rejects system saga", func(t *testing.T) {
+		err := reg.DeprecateSaga(ctx, systemID, nil)
+		require.ErrorIs(t, err, saga.ErrSystemSagaReadOnly)
+	})
+
+	t.Run("GetByID still works for system sagas", func(t *testing.T) {
+		def, err := reg.GetByID(ctx, systemID)
+		require.NoError(t, err)
+		assert.Equal(t, "protected_saga", def.Name)
+		assert.True(t, def.IsSystem)
+		assert.Equal(t, saga.StatusActive, def.Status)
+	})
+}
+
+func TestPostgresRegistry_LifecycleTransitions(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-7")
+
+	t.Run("DRAFT to ACTIVE succeeds", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:    "lifecycle1",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		err := reg.ActivateSaga(ctx, def.ID)
+		require.NoError(t, err)
+
+		// Verify status changed
+		result, err := reg.GetByID(ctx, def.ID)
+		require.NoError(t, err)
+		assert.Equal(t, saga.StatusActive, result.Status)
+		assert.NotNil(t, result.ActivatedAt)
+	})
+
+	t.Run("ACTIVE to DEPRECATED succeeds", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:    "lifecycle2",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+		err := reg.DeprecateSaga(ctx, def.ID, nil)
+		require.NoError(t, err)
+
+		// Verify status changed
+		result, err := reg.GetByID(ctx, def.ID)
+		require.NoError(t, err)
+		assert.Equal(t, saga.StatusDeprecated, result.Status)
+		assert.NotNil(t, result.DeprecatedAt)
+	})
+
+	t.Run("ACTIVE to ACTIVE fails", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:    "lifecycle3",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+		err := reg.ActivateSaga(ctx, def.ID)
+		require.ErrorIs(t, err, saga.ErrNotDraft)
+	})
+
+	t.Run("DRAFT to DEPRECATED fails", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:    "lifecycle4",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		err := reg.DeprecateSaga(ctx, def.ID, nil)
+		require.ErrorIs(t, err, saga.ErrNotActive)
+	})
+}
+
+func TestPostgresRegistry_UpdateDefinition(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-8")
+
+	t.Run("updates draft saga successfully", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:    "update1",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+
+		updates := &saga.Definition{
+			Script:                  "def posting_rules(ctx): return []",
+			DisplayName:             "Updated Display Name",
+			Description:             "Updated Description",
+			PreconditionsExpression: "true",
+		}
+		err := reg.UpdateDefinition(ctx, def.ID, updates)
+		require.NoError(t, err)
+
+		// Verify updates
+		result, err := reg.GetByID(ctx, def.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated Display Name", result.DisplayName)
+		assert.Equal(t, "Updated Description", result.Description)
+		assert.Equal(t, "true", result.PreconditionsExpression)
+		assert.Contains(t, result.Script, "return []")
+	})
+
+	t.Run("rejects update on active saga", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:    "update2",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+		updates := &saga.Definition{
+			DisplayName: "Should Fail",
+		}
+		err := reg.UpdateDefinition(ctx, def.ID, updates)
+		require.ErrorIs(t, err, saga.ErrNotDraft)
+	})
+
+	t.Run("returns ErrNotFound for missing saga", func(t *testing.T) {
+		updates := &saga.Definition{
+			DisplayName: "Does not exist",
+		}
+		err := reg.UpdateDefinition(ctx, uuid.New(), updates)
+		require.ErrorIs(t, err, saga.ErrNotFound)
+	})
+}
+
+func TestPostgresRegistry_TenantIsolation(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx1 := setupTenantContext(t, pool, "tenant-iso-1")
+	ctx2 := setupTenantContext(t, pool, "tenant-iso-2")
+
+	// Create saga in tenant 1
+	def1 := &saga.Definition{
+		Name:    "isolated_saga",
+		Version: 1,
+		Script:  "def posting_rules(ctx): pass",
+	}
+	require.NoError(t, reg.CreateDraft(ctx1, def1))
+
+	t.Run("tenant 1 can see its saga", func(t *testing.T) {
+		result, err := reg.GetDefinition(ctx1, "isolated_saga", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "isolated_saga", result.Name)
+	})
+
+	t.Run("tenant 2 cannot see tenant 1's saga", func(t *testing.T) {
+		_, err := reg.GetDefinition(ctx2, "isolated_saga", 1)
+		require.ErrorIs(t, err, saga.ErrNotFound)
+	})
+
+	t.Run("tenants can have same name independently", func(t *testing.T) {
+		def2 := &saga.Definition{
+			Name:        "isolated_saga",
+			Version:     1,
+			Script:      "def posting_rules(ctx): return 'tenant2'",
+			DisplayName: "Tenant 2 version",
+		}
+		require.NoError(t, reg.CreateDraft(ctx2, def2))
+
+		// Verify both exist independently
+		result1, err := reg.GetDefinition(ctx1, "isolated_saga", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "", result1.DisplayName)
+
+		result2, err := reg.GetDefinition(ctx2, "isolated_saga", 1)
+		require.NoError(t, err)
+		assert.Equal(t, "Tenant 2 version", result2.DisplayName)
+	})
+}
+
+func TestPostgresRegistry_DeprecateWithSuccessor(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-successor")
+
+	t.Run("deprecate with valid successor succeeds", func(t *testing.T) {
+		// Create and activate the old saga
+		oldDef := &saga.Definition{
+			Name:    "successor_old",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, oldDef))
+		require.NoError(t, reg.ActivateSaga(ctx, oldDef.ID))
+
+		// Create and activate the successor saga (same name, higher version)
+		newDef := &saga.Definition{
+			Name:    "successor_old",
+			Version: 2,
+			Script:  "def posting_rules(ctx): return []",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, newDef))
+		require.NoError(t, reg.ActivateSaga(ctx, newDef.ID))
+
+		// Deprecate old with successor
+		err := reg.DeprecateSaga(ctx, oldDef.ID, &newDef.ID)
+		require.NoError(t, err)
+
+		// Verify successor was set
+		result, err := reg.GetByID(ctx, oldDef.ID)
+		require.NoError(t, err)
+		assert.Equal(t, saga.StatusDeprecated, result.Status)
+		assert.NotNil(t, result.SuccessorID)
+		assert.Equal(t, newDef.ID, *result.SuccessorID)
+	})
+
+	t.Run("deprecate with non-existent successor fails", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:    "no_successor",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+		// Try to deprecate with non-existent successor
+		fakeID := uuid.New()
+		err := reg.DeprecateSaga(ctx, def.ID, &fakeID)
+		require.ErrorIs(t, err, saga.ErrSuccessorInvalid)
+	})
+
+	t.Run("deprecate with DRAFT successor fails", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:    "draft_succ1",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+		// Create successor but keep in DRAFT
+		successor := &saga.Definition{
+			Name:    "draft_succ1",
+			Version: 2,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, successor))
+		// NOT activated - still DRAFT
+
+		err := reg.DeprecateSaga(ctx, def.ID, &successor.ID)
+		require.ErrorIs(t, err, saga.ErrSuccessorInvalid)
+	})
+
+	t.Run("deprecate with different name successor fails", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:    "name_test1",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+		// Create successor with different name
+		successor := &saga.Definition{
+			Name:    "name_test2", // Different name!
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, successor))
+		require.NoError(t, reg.ActivateSaga(ctx, successor.ID))
+
+		err := reg.DeprecateSaga(ctx, def.ID, &successor.ID)
+		require.ErrorIs(t, err, saga.ErrSuccessorInvalid)
+	})
+
+	t.Run("deprecate with self as successor fails", func(t *testing.T) {
+		def := &saga.Definition{
+			Name:    "self_ref",
+			Version: 1,
+			Script:  "def posting_rules(ctx): pass",
+		}
+		require.NoError(t, reg.CreateDraft(ctx, def))
+		require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+		// Try to set self as successor
+		err := reg.DeprecateSaga(ctx, def.ID, &def.ID)
+		require.ErrorIs(t, err, saga.ErrSuccessorInvalid)
+	})
+}
+
+func TestPostgresRegistry_SuccessorWriteOnce(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-writeonce")
+
+	// Create old saga and two potential successors
+	oldDef := &saga.Definition{
+		Name:    "writeonce_old",
+		Version: 1,
+		Script:  "def posting_rules(ctx): pass",
+	}
+	require.NoError(t, reg.CreateDraft(ctx, oldDef))
+	require.NoError(t, reg.ActivateSaga(ctx, oldDef.ID))
+
+	successor1 := &saga.Definition{
+		Name:    "writeonce_old",
+		Version: 2,
+		Script:  "def posting_rules(ctx): pass",
+	}
+	require.NoError(t, reg.CreateDraft(ctx, successor1))
+	require.NoError(t, reg.ActivateSaga(ctx, successor1.ID))
+
+	successor2 := &saga.Definition{
+		Name:    "writeonce_old",
+		Version: 3,
+		Script:  "def posting_rules(ctx): pass",
+	}
+	require.NoError(t, reg.CreateDraft(ctx, successor2))
+	require.NoError(t, reg.ActivateSaga(ctx, successor2.ID))
+
+	t.Run("cannot change successor_id once set", func(t *testing.T) {
+		// Deprecate with first successor
+		err := reg.DeprecateSaga(ctx, oldDef.ID, &successor1.ID)
+		require.NoError(t, err)
+
+		// Verify successor was set
+		result, err := reg.GetByID(ctx, oldDef.ID)
+		require.NoError(t, err)
+		assert.Equal(t, successor1.ID, *result.SuccessorID)
+
+		// Try to change successor via direct SQL - this should fail via trigger
+		tenantID, _ := tenant.FromContext(ctx)
+		schemaName := tenantID.SchemaName()
+
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx, `UPDATE saga_definition SET successor_id = $1 WHERE id = $2`, successor2.ID, oldDef.ID)
+		// Should fail due to write-once trigger
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "write-once")
+
+		_ = tx.Rollback(ctx)
+	})
+}
+
+func TestPostgresRegistry_ImmutableScriptOnActive(t *testing.T) {
+	reg, pool := setupTestRegistry(t)
+	ctx := setupTenantContext(t, pool, "test-tenant-immutable")
+
+	// Create and activate a saga
+	def := &saga.Definition{
+		Name:                    "immutable_test",
+		Version:                 1,
+		Script:                  "def posting_rules(ctx): pass",
+		PreconditionsExpression: "true",
+	}
+	require.NoError(t, reg.CreateDraft(ctx, def))
+	require.NoError(t, reg.ActivateSaga(ctx, def.ID))
+
+	t.Run("script cannot be modified on ACTIVE saga", func(t *testing.T) {
+		tenantID, _ := tenant.FromContext(ctx)
+		schemaName := tenantID.SchemaName()
+
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx, `UPDATE saga_definition SET script = 'modified' WHERE id = $1`, def.ID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Cannot modify script")
+
+		_ = tx.Rollback(ctx)
+	})
+
+	t.Run("preconditions cannot be modified on ACTIVE saga", func(t *testing.T) {
+		tenantID, _ := tenant.FromContext(ctx)
+		schemaName := tenantID.SchemaName()
+
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx, `UPDATE saga_definition SET preconditions_expression = 'false' WHERE id = $1`, def.ID)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Cannot modify preconditions_expression")
+
+		_ = tx.Rollback(ctx)
+	})
+
+	t.Run("display_name can be modified on ACTIVE saga", func(t *testing.T) {
+		tenantID, _ := tenant.FromContext(ctx)
+		schemaName := tenantID.SchemaName()
+
+		tx, err := pool.Begin(ctx)
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", pq.QuoteIdentifier(schemaName)))
+		require.NoError(t, err)
+
+		_, err = tx.Exec(ctx, `UPDATE saga_definition SET display_name = 'New Name' WHERE id = $1`, def.ID)
+		require.NoError(t, err)
+
+		require.NoError(t, tx.Commit(ctx))
+	})
+}

--- a/services/reference-data/saga/registry.go
+++ b/services/reference-data/saga/registry.go
@@ -39,7 +39,7 @@ var (
 	ErrInvalidStatus = errors.New("invalid saga status")
 
 	// ErrInvalidStateTransition is returned for illegal status transitions.
-	// Valid transitions: DRAFT→ACTIVE, DRAFT→DEPRECATED, ACTIVE→DEPRECATED.
+	// Valid transitions: DRAFT→ACTIVE, ACTIVE→DEPRECATED.
 	ErrInvalidStateTransition = errors.New("invalid state transition")
 
 	// ErrNotDraft is returned when attempting to modify a saga that is not in DRAFT status.

--- a/services/reference-data/saga/registry.go
+++ b/services/reference-data/saga/registry.go
@@ -1,0 +1,189 @@
+// Package saga provides the SagaRegistry interface and implementation
+// for managing saga definitions with lifecycle management.
+package saga
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Status represents the lifecycle status of a saga definition.
+type Status string
+
+const (
+	// StatusDraft indicates a saga that is not yet active and can be modified.
+	StatusDraft Status = "DRAFT"
+
+	// StatusActive indicates a saga that is in use and immutable (script frozen).
+	StatusActive Status = "ACTIVE"
+
+	// StatusDeprecated indicates a saga that should no longer be used for new executions
+	// but existing executions with this saga remain valid.
+	StatusDeprecated Status = "DEPRECATED"
+)
+
+// Error types for the saga registry.
+var (
+	// ErrNotFound is returned when a saga definition cannot be found.
+	ErrNotFound = errors.New("saga definition not found")
+
+	// ErrSystemSagaReadOnly is returned when attempting to modify a system saga.
+	// System sagas are seeded during tenant provisioning with is_system=true
+	// and cannot be modified through the registry API.
+	ErrSystemSagaReadOnly = errors.New("system sagas are read-only")
+
+	// ErrInvalidStatus is returned when a saga is not in the required status.
+	ErrInvalidStatus = errors.New("invalid saga status")
+
+	// ErrInvalidStateTransition is returned for illegal status transitions.
+	// Valid transitions: DRAFT→ACTIVE, DRAFT→DEPRECATED, ACTIVE→DEPRECATED.
+	ErrInvalidStateTransition = errors.New("invalid state transition")
+
+	// ErrNotDraft is returned when attempting to modify a saga that is not in DRAFT status.
+	ErrNotDraft = errors.New("saga must be in DRAFT status")
+
+	// ErrNotActive is returned when attempting operations that require ACTIVE status.
+	ErrNotActive = errors.New("saga must be in ACTIVE status")
+
+	// ErrOptimisticLock is returned when concurrent modification is detected.
+	ErrOptimisticLock = errors.New("optimistic lock failure: saga was modified")
+
+	// ErrAlreadyExists is returned when creating a saga with existing name+version.
+	ErrAlreadyExists = errors.New("saga with this name and version already exists")
+
+	// ErrSuccessorInvalid is returned when the specified successor saga is invalid.
+	// A valid successor must exist, be in ACTIVE status, have the same name, and not be self-referential.
+	ErrSuccessorInvalid = errors.New("successor saga is invalid: must exist, be ACTIVE, have same name, and not be self-referential")
+
+	// ErrValidationFailed is returned when the saga script fails validation.
+	ErrValidationFailed = errors.New("saga validation failed")
+)
+
+// Definition represents a Starlark saga workflow definition
+// that can be executed by the saga orchestrator.
+type Definition struct {
+	// ID is the unique identifier for this definition.
+	ID uuid.UUID
+
+	// Name is the human-readable saga name (e.g., "withdrawal", "deposit").
+	Name string
+
+	// Version allows multiple versions of the same saga name.
+	// Versions start at 1. Use GetActive to retrieve the latest active version.
+	Version int
+
+	// Script is the Starlark source code defining the saga workflow.
+	Script string
+
+	// Status is the current lifecycle status.
+	Status Status
+
+	// IsSystem indicates this is a system saga seeded during tenant provisioning.
+	// System sagas are read-only - CreateDraft, UpdateDefinition, ActivateSaga,
+	// and DeprecateSaga all reject operations on is_system=true sagas.
+	IsSystem bool
+
+	// PreconditionsExpression is an optional CEL expression for validating
+	// preconditions before saga execution. Available variables depend on context.
+	PreconditionsExpression string
+
+	// DisplayName is a human-readable name.
+	DisplayName string
+
+	// Description provides additional context about this saga.
+	Description string
+
+	// CreatedAt is when this definition was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is when this definition was last modified.
+	UpdatedAt time.Time
+
+	// ActivatedAt is when this definition transitioned to ACTIVE (nil if never activated).
+	ActivatedAt *time.Time
+
+	// DeprecatedAt is when this definition transitioned to DEPRECATED (nil if not deprecated).
+	DeprecatedAt *time.Time
+
+	// SuccessorID is the UUID of the saga that replaces this one when deprecated.
+	// This creates a forward lineage chain: when querying a deprecated saga,
+	// clients can follow SuccessorID to find the current replacement.
+	// Only set when Status is DEPRECATED. Nil if no successor designated.
+	SuccessorID *uuid.UUID
+}
+
+// Validator validates saga definitions before activation.
+// Implementations may check Starlark syntax, required functions, etc.
+type Validator interface {
+	// Validate checks if the saga definition is valid for activation.
+	// Returns nil if valid, or an error describing validation failures.
+	Validate(ctx context.Context, def *Definition) error
+}
+
+// Registry defines the interface for managing saga definitions.
+// All methods extract tenant context from ctx using shared/platform/tenant.
+// Schema routing is handled by PostgreSQL search_path.
+//
+// System Saga Semantics:
+// System sagas are COPIED into each tenant's schema during tenant provisioning
+// with is_system=true. This registry does NOT seed system sagas - it only
+// enforces the read-only constraint.
+//
+// Tenant Resolution (GetActive):
+// When resolving the active saga for a name, the registry checks in order:
+//  1. Tenant's custom saga (is_system=FALSE, status=ACTIVE, highest version)
+//  2. Platform default saga (is_system=TRUE, status=ACTIVE, highest version)
+//
+// This allows tenants to override platform defaults with custom sagas.
+type Registry interface {
+	// GetByID retrieves a specific saga by its UUID.
+	// Returns ErrNotFound if the saga doesn't exist.
+	GetByID(ctx context.Context, id uuid.UUID) (*Definition, error)
+
+	// GetDefinition retrieves a specific saga by name and version.
+	// Returns ErrNotFound if the saga doesn't exist.
+	// The tenant schema is determined from ctx via tenant.FromContext.
+	GetDefinition(ctx context.Context, name string, version int) (*Definition, error)
+
+	// GetActive retrieves the active saga for a name using tenant resolution.
+	// Resolution order:
+	//  1. Tenant override (is_system=FALSE, status=ACTIVE, highest version)
+	//  2. Platform default (is_system=TRUE, status=ACTIVE, highest version)
+	// Returns ErrNotFound if no active version exists.
+	GetActive(ctx context.Context, name string) (*Definition, error)
+
+	// ListByStatus retrieves all sagas with the specified status.
+	// Returns both system sagas (is_system=true) and tenant-specific sagas.
+	ListByStatus(ctx context.Context, status Status) ([]*Definition, error)
+
+	// CreateDraft creates a new saga definition in DRAFT status.
+	// Returns ErrSystemSagaReadOnly if is_system=true is attempted.
+	// Returns ErrAlreadyExists if a saga with the same name+version exists.
+	// The saga's script is NOT validated at creation time - validation
+	// occurs at activation (see ActivateSaga).
+	CreateDraft(ctx context.Context, def *Definition) error
+
+	// UpdateDefinition updates a DRAFT saga definition.
+	// Returns ErrSystemSagaReadOnly if the saga has is_system=true.
+	// Returns ErrNotDraft if the saga is not in DRAFT status.
+	// Uses optimistic locking via UpdatedAt.
+	UpdateDefinition(ctx context.Context, id uuid.UUID, updates *Definition) error
+
+	// ActivateSaga transitions a saga from DRAFT to ACTIVE.
+	// Returns ErrSystemSagaReadOnly if the saga has is_system=true.
+	// Returns ErrNotDraft if not currently in DRAFT status.
+	// Returns ErrValidationFailed if the saga script fails validation.
+	// Once activated, the script becomes immutable.
+	ActivateSaga(ctx context.Context, id uuid.UUID) error
+
+	// DeprecateSaga transitions a saga from ACTIVE to DEPRECATED.
+	// Returns ErrSystemSagaReadOnly if the saga has is_system=true.
+	// Returns ErrNotActive if not currently in ACTIVE status.
+	// Returns ErrSuccessorInvalid if successorID is provided but refers to an invalid saga.
+	// Sagas in DEPRECATED status remain valid for existing executions but are not used for new ones.
+	// The successorID optionally points to the replacement saga (must be ACTIVE with same name).
+	DeprecateSaga(ctx context.Context, id uuid.UUID, successorID *uuid.UUID) error
+}


### PR DESCRIPTION
## Summary

- Add `saga.Registry` interface with lifecycle management (DRAFT→ACTIVE→DEPRECATED)
- Implement `PostgresRegistry` with tenant-scoped schema routing via `SET LOCAL search_path`
- Implement two-tier tenant resolution in `GetActive` (tenant override beats platform default)
- Add Redis caching layer with TTL jitter and invalidation on lifecycle changes
- Create `CachedRegistry` wrapper for read-through caching

## Technical Details

### Tenant Resolution
When resolving the active saga for a name via `GetActive`:
1. First query for tenant override: `is_system=FALSE, status=ACTIVE, highest version`
2. If not found, fall back to platform default: `is_system=TRUE, status=ACTIVE, highest version`

This allows tenants to override platform-seeded sagas with custom implementations.

### Cache Invalidation
Cache is invalidated on lifecycle changes:
- `ActivateSaga`: Invalidates all cache entries for the saga's name (active resolution may have changed)
- `DeprecateSaga`: Same invalidation pattern
- `UpdateDefinition`: Invalidates the specific saga entry

### Files Added
| File | Description |
|------|-------------|
| `services/reference-data/saga/registry.go` | Interface and types |
| `services/reference-data/saga/postgres_registry.go` | PostgreSQL implementation |
| `services/reference-data/saga/cache.go` | Redis caching layer |
| `services/reference-data/saga/cached_registry.go` | Read-through cache wrapper |
| `services/reference-data/saga/postgres_registry_test.go` | Integration tests |

## Test Plan
- [x] Unit tests for all CRUD operations
- [x] Test tenant isolation (tenant A cannot see tenant B's sagas)
- [x] Test tenant resolution priority (override beats default)
- [x] Test lifecycle transitions and immutability enforcement
- [x] Test successor validation on deprecation
- [x] Test write-once semantics for successor_id

## Task Reference
Task: starlark-saga-orchestration.3