### PR TITLE
feat: Add instructions for Claude to read existing PR comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -168,6 +168,31 @@ jobs:
 
             ## How to Post Inline Comments
 
+            ## Reading Existing Comments (Do This First)
+
+            Before posting your review, check for existing feedback to avoid duplicates and understand context:
+
+            **Step 1: Read existing inline comments (CodeRabbit, previous Claude reviews, etc.)**
+            ```bash
+            gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments \
+              --jq '.[] | {author: .user.login, path, line, body: .body[0:300], created: .created_at}'
+            ```
+
+            **Step 2: Read PR conversation comments**
+            ```bash
+            gh pr view ${{ github.event.pull_request.number }} --comments
+            ```
+
+            **How to use this context:**
+            - **Don't duplicate**: If CodeRabbit or a previous review already flagged an issue, don't repeat it
+            - **Acknowledge fixes**: If the author addressed feedback in subsequent commits, note it positively
+            - **Build on discussions**: Reference ongoing conversations where relevant
+            - **Disagree respectfully**: If you disagree with previous feedback, explain why with evidence
+
+            ---
+
+            ## How to Post Inline Comments
+
             **Step 1: Get the PR diff to find file paths and line numbers**
             ```bash
             gh pr diff ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Adds instructions for Claude Code reviews to read existing inline comments before posting
- Checks for CodeRabbit comments, previous Claude reviews, and PR conversation
- Prevents duplicate feedback and helps build on ongoing discussions

## Changes Made

Added new section "Reading Existing Comments (Do This First)" with:
- Command to fetch existing inline comments via `gh api`
- Command to read PR conversation comments
- Guidance on how to use this context (don't duplicate, acknowledge fixes, build on discussions)

## Test plan

- [ ] Create a PR with CodeRabbit enabled
- [ ] Verify Claude review reads existing comments before posting
- [ ] Confirm no duplicate feedback when CodeRabbit already flagged an issue