### PR TITLE
feat: Implement lease renewal background worker for saga execution

### DIFF
--- a/shared/pkg/saga/lease_renewer.go
+++ b/shared/pkg/saga/lease_renewer.go
@@ -1,0 +1,198 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/env"
+)
+
+// Default lease renewal configuration.
+const (
+	// DefaultRenewalInterval is the default interval between lease renewals.
+	// Must be less than the lease duration (default 5 minutes) to prevent expiry.
+	DefaultRenewalInterval = 2 * time.Minute
+)
+
+// LeaseRenewalConfig holds configuration for lease renewal.
+type LeaseRenewalConfig struct {
+	// RenewalInterval is how often to renew the lease.
+	// Default: 2 minutes (SAGA_LEASE_RENEWAL_INTERVAL)
+	RenewalInterval time.Duration
+}
+
+// NewLeaseRenewalConfig creates a LeaseRenewalConfig populated from environment variables.
+// Environment variables:
+//   - SAGA_LEASE_RENEWAL_INTERVAL: Duration string (e.g., "2m", "90s"). Default: "2m"
+func NewLeaseRenewalConfig() *LeaseRenewalConfig {
+	return &LeaseRenewalConfig{
+		RenewalInterval: env.GetEnvAsDuration("SAGA_LEASE_RENEWAL_INTERVAL", DefaultRenewalInterval),
+	}
+}
+
+// LeaseRenewer periodically renews the lease on a saga to prevent it from being
+// claimed by another pod while execution is in progress.
+//
+// The renewer runs a background goroutine that calls RenewLease on the ClaimService
+// at regular intervals. It supports graceful shutdown via context cancellation or
+// explicit Stop() call.
+//
+// Example usage:
+//
+//	renewer := saga.NewLeaseRenewer(sagaID, claimService, logger)
+//	renewer.Start(ctx)
+//	defer renewer.Stop()
+//	// ... saga execution ...
+type LeaseRenewer struct {
+	sagaID       uuid.UUID
+	claimService *ClaimService
+	logger       *slog.Logger
+
+	renewalInterval time.Duration
+	callback        func() // optional callback after each renewal attempt (for testing)
+
+	mu       sync.Mutex
+	running  bool
+	done     chan struct{}
+	wg       sync.WaitGroup
+	stopOnce sync.Once
+}
+
+// LeaseRenewerOption is a functional option for configuring a LeaseRenewer.
+type LeaseRenewerOption func(*LeaseRenewer)
+
+// WithRenewalInterval sets the interval between lease renewals.
+// Default: 2 minutes (must be less than lease duration to prevent expiry)
+func WithRenewalInterval(interval time.Duration) LeaseRenewerOption {
+	return func(r *LeaseRenewer) {
+		if interval > 0 {
+			r.renewalInterval = interval
+		}
+	}
+}
+
+// WithRenewalCallback sets a callback function that is called after each renewal attempt.
+// Useful for testing to track renewal frequency.
+func WithRenewalCallback(callback func()) LeaseRenewerOption {
+	return func(r *LeaseRenewer) {
+		r.callback = callback
+	}
+}
+
+// NewLeaseRenewer creates a new LeaseRenewer for the specified saga.
+//
+// Parameters:
+//   - sagaID: The UUID of the saga whose lease should be renewed
+//   - claimService: The ClaimService to use for renewal (must have correct PodID)
+//   - logger: Structured logger (uses slog.Default() if nil)
+//   - opts: Optional functional options for configuration
+func NewLeaseRenewer(sagaID uuid.UUID, claimService *ClaimService, logger *slog.Logger, opts ...LeaseRenewerOption) *LeaseRenewer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	r := &LeaseRenewer{
+		sagaID:          sagaID,
+		claimService:    claimService,
+		logger:          logger.With("saga_id", sagaID.String()),
+		renewalInterval: DefaultRenewalInterval,
+		done:            make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// Start begins the background lease renewal goroutine.
+// The renewer will continue until the context is cancelled or Stop() is called.
+//
+// It is safe to call Start multiple times, but only the first call will have effect.
+// Subsequent calls while the renewer is running will be ignored.
+func (r *LeaseRenewer) Start(ctx context.Context) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.running {
+		r.logger.Debug("lease renewer already running, ignoring Start() call")
+		return
+	}
+
+	r.running = true
+	r.wg.Add(1)
+
+	go r.run(ctx)
+
+	r.logger.Info("lease renewer started",
+		"renewal_interval", r.renewalInterval)
+}
+
+// Stop signals the renewer to stop and waits for the goroutine to exit.
+// It is safe to call Stop multiple times; subsequent calls will block until
+// the first Stop completes.
+func (r *LeaseRenewer) Stop() {
+	r.stopOnce.Do(func() {
+		r.logger.Debug("stopping lease renewer")
+		close(r.done)
+	})
+
+	r.wg.Wait()
+
+	r.mu.Lock()
+	r.running = false
+	r.mu.Unlock()
+
+	r.logger.Info("lease renewer stopped")
+}
+
+// run is the main renewal loop that periodically calls RenewLease.
+func (r *LeaseRenewer) run(ctx context.Context) {
+	defer r.wg.Done()
+
+	ticker := time.NewTicker(r.renewalInterval)
+	defer ticker.Stop()
+
+	r.logger.Debug("lease renewer loop started")
+
+	for {
+		select {
+		case <-ctx.Done():
+			r.logger.Debug("lease renewer stopping due to context cancellation")
+			return
+		case <-r.done:
+			r.logger.Debug("lease renewer stopping due to Stop() call")
+			return
+		case <-ticker.C:
+			r.renewLease(ctx)
+		}
+	}
+}
+
+// renewLease performs a single lease renewal operation.
+func (r *LeaseRenewer) renewLease(ctx context.Context) {
+	// Create a child context with a reasonable timeout for the database operation
+	renewCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	err := r.claimService.RenewLease(renewCtx, r.sagaID)
+	if err != nil {
+		// Log the error but don't stop - renewal failures are non-fatal.
+		// The saga will eventually be claimed by another pod if renewals
+		// continue to fail and the lease expires.
+		r.logger.Warn("failed to renew saga lease",
+			"error", err)
+	} else {
+		r.logger.Debug("saga lease renewed successfully")
+	}
+
+	// Call the optional callback (for testing)
+	if r.callback != nil {
+		r.callback()
+	}
+}

--- a/shared/pkg/saga/lease_renewer.go
+++ b/shared/pkg/saga/lease_renewer.go
@@ -153,7 +153,12 @@ func (r *LeaseRenewer) Stop() {
 
 // run is the main renewal loop that periodically calls RenewLease.
 func (r *LeaseRenewer) run(ctx context.Context) {
-	defer r.wg.Done()
+	defer func() {
+		r.mu.Lock()
+		r.running = false
+		r.mu.Unlock()
+		r.wg.Done()
+	}()
 
 	ticker := time.NewTicker(r.renewalInterval)
 	defer ticker.Stop()

--- a/shared/pkg/saga/lease_renewer_test.go
+++ b/shared/pkg/saga/lease_renewer_test.go
@@ -1,0 +1,385 @@
+package saga
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/meridianhub/meridian/shared/platform/await"
+)
+
+// createLeaseTestSaga creates a saga instance for lease renewal testing with specific pod ownership.
+func createLeaseTestSaga(t *testing.T, db *gorm.DB, podID string, leaseExpiresAt time.Time) uuid.UUID {
+	t.Helper()
+
+	sagaID := uuid.New()
+	now := time.Now()
+
+	// Use raw SQL to insert with specific lease data
+	err := db.Exec(`
+		INSERT INTO saga_instances (id, saga_definition_id, correlation_id, status, claimed_by_pod, claimed_at, lease_expires_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, sagaID, uuid.New(), uuid.New(), SagaStatusRunning, podID, now, leaseExpiresAt, now, now).Error
+
+	require.NoError(t, err, "Failed to create test saga")
+
+	return sagaID
+}
+
+// getLeaseExpiresAtForTest retrieves the lease_expires_at timestamp for a saga.
+func getLeaseExpiresAtForTest(t *testing.T, db *gorm.DB, sagaID uuid.UUID) time.Time {
+	t.Helper()
+
+	var result struct {
+		LeaseExpiresAt time.Time `gorm:"column:lease_expires_at"`
+	}
+
+	err := db.Table("saga_instances").Select("lease_expires_at").Where("id = ?", sagaID).Scan(&result).Error
+	require.NoError(t, err, "Failed to get lease_expires_at")
+
+	return result.LeaseExpiresAt
+}
+
+func TestLeaseRenewer_RenewsLeaseAtInterval(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	t.Cleanup(cleanup)
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	podID := "test-pod-lease-1"
+	initialExpiry := time.Now().Add(1 * time.Minute)
+	sagaID := createLeaseTestSaga(t, db, podID, initialExpiry)
+
+	claimService := NewClaimService(db, &ClaimConfig{
+		LeaseDuration: 5 * time.Minute,
+		PodID:         podID,
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Use fast interval for testing (100ms)
+	renewer := NewLeaseRenewer(sagaID, claimService, logger, WithRenewalInterval(100*time.Millisecond))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	renewer.Start(ctx)
+	defer renewer.Stop()
+
+	// Wait for at least 2 renewals
+	err = await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			expiry := getLeaseExpiresAtForTest(t, db, sagaID)
+			// Lease should be extended to ~5 minutes in future (with some tolerance)
+			return expiry.After(time.Now().Add(4 * time.Minute))
+		})
+	require.NoError(t, err, "Lease should be renewed")
+
+	// Verify multiple renewals occurred by waiting and checking again
+	firstExpiry := getLeaseExpiresAtForTest(t, db, sagaID)
+	time.Sleep(200 * time.Millisecond)
+	secondExpiry := getLeaseExpiresAtForTest(t, db, sagaID)
+
+	// The claimed_at should have been updated
+	assert.True(t, secondExpiry.After(firstExpiry) || secondExpiry.Equal(firstExpiry),
+		"Lease should continue to be renewed")
+}
+
+func TestLeaseRenewer_StopsOnContextCancellation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	t.Cleanup(cleanup)
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	podID := "test-pod-lease-2"
+	sagaID := createLeaseTestSaga(t, db, podID, time.Now().Add(5*time.Minute))
+
+	claimService := NewClaimService(db, &ClaimConfig{
+		LeaseDuration: 5 * time.Minute,
+		PodID:         podID,
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	renewer := NewLeaseRenewer(sagaID, claimService, logger, WithRenewalInterval(50*time.Millisecond))
+
+	// Track goroutine count before starting
+	initialGoroutines := runtime.NumGoroutine()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	renewer.Start(ctx)
+
+	// Verify goroutine is running
+	err = await.New().
+		AtMost(1 * time.Second).
+		PollInterval(10 * time.Millisecond).
+		Until(func() bool {
+			return runtime.NumGoroutine() > initialGoroutines
+		})
+	require.NoError(t, err, "Renewer goroutine should be running")
+
+	// Cancel context
+	cancel()
+
+	// Wait for goroutine to exit
+	err = await.New().
+		AtMost(1 * time.Second).
+		PollInterval(10 * time.Millisecond).
+		Until(func() bool {
+			return runtime.NumGoroutine() <= initialGoroutines
+		})
+	require.NoError(t, err, "Renewer goroutine should stop after context cancellation")
+}
+
+func TestLeaseRenewer_StopsOnStopCall(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	t.Cleanup(cleanup)
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	podID := "test-pod-lease-3"
+	sagaID := createLeaseTestSaga(t, db, podID, time.Now().Add(5*time.Minute))
+
+	claimService := NewClaimService(db, &ClaimConfig{
+		LeaseDuration: 5 * time.Minute,
+		PodID:         podID,
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	renewer := NewLeaseRenewer(sagaID, claimService, logger, WithRenewalInterval(50*time.Millisecond))
+
+	ctx := context.Background()
+	renewer.Start(ctx)
+
+	// Verify renewer is running
+	time.Sleep(100 * time.Millisecond)
+
+	// Call Stop and verify it completes within reasonable time
+	stopped := make(chan struct{})
+	go func() {
+		renewer.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		// Success
+	case <-time.After(1 * time.Second):
+		t.Fatal("Stop() did not complete within 1 second")
+	}
+}
+
+func TestLeaseRenewer_StopIsIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	t.Cleanup(cleanup)
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	podID := "test-pod-lease-4"
+	sagaID := createLeaseTestSaga(t, db, podID, time.Now().Add(5*time.Minute))
+
+	claimService := NewClaimService(db, &ClaimConfig{
+		LeaseDuration: 5 * time.Minute,
+		PodID:         podID,
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	renewer := NewLeaseRenewer(sagaID, claimService, logger, WithRenewalInterval(50*time.Millisecond))
+
+	ctx := context.Background()
+	renewer.Start(ctx)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Call Stop() multiple times - should not panic
+	renewer.Stop()
+	renewer.Stop()
+	renewer.Stop()
+}
+
+func TestLeaseRenewer_ContinuesOnRenewalFailure(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	t.Cleanup(cleanup)
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	podID := "test-pod-lease-5"
+	sagaID := createLeaseTestSaga(t, db, podID, time.Now().Add(5*time.Minute))
+
+	claimService := NewClaimService(db, &ClaimConfig{
+		LeaseDuration: 5 * time.Minute,
+		PodID:         podID,
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	var renewalCount atomic.Int32
+
+	// Create renewer with callback to count renewals
+	renewer := NewLeaseRenewer(sagaID, claimService, logger,
+		WithRenewalInterval(50*time.Millisecond),
+		WithRenewalCallback(func() {
+			renewalCount.Add(1)
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	renewer.Start(ctx)
+	defer renewer.Stop()
+
+	// Wait for multiple renewals
+	err = await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return renewalCount.Load() >= 3
+		})
+	require.NoError(t, err, "Should have multiple renewals")
+
+	// Now delete the saga to cause renewal failures
+	db.Exec("DELETE FROM saga_instances WHERE id = ?", sagaID)
+
+	// Renewer should continue running (not crash) even with failures
+	beforeCount := renewalCount.Load()
+	time.Sleep(200 * time.Millisecond)
+	afterCount := renewalCount.Load()
+
+	// The callback should still be called even though the DB operation fails
+	assert.Greater(t, afterCount, beforeCount, "Renewer should continue attempting renewals despite failures")
+}
+
+func TestLeaseRenewer_ConfigurationFromEnvironment(t *testing.T) {
+	// Test that NewLeaseRenewalConfig reads from environment
+	t.Setenv("SAGA_LEASE_RENEWAL_INTERVAL", "3m")
+
+	config := NewLeaseRenewalConfig()
+	assert.Equal(t, 3*time.Minute, config.RenewalInterval)
+}
+
+func TestLeaseRenewer_DefaultConfiguration(t *testing.T) {
+	// Without env var, should use default of 2 minutes
+	os.Unsetenv("SAGA_LEASE_RENEWAL_INTERVAL")
+	config := NewLeaseRenewalConfig()
+	assert.Equal(t, 2*time.Minute, config.RenewalInterval)
+}
+
+func TestLeaseRenewer_NoGoroutineLeak(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	t.Cleanup(cleanup)
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	initialGoroutines := runtime.NumGoroutine()
+
+	// Start and stop multiple renewers
+	for i := 0; i < 5; i++ {
+		podID := "test-pod-leak-" + string(rune('a'+i))
+		sagaID := createLeaseTestSaga(t, db, podID, time.Now().Add(5*time.Minute))
+
+		claimService := NewClaimService(db, &ClaimConfig{
+			LeaseDuration: 5 * time.Minute,
+			PodID:         podID,
+		})
+
+		logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+		renewer := NewLeaseRenewer(sagaID, claimService, logger, WithRenewalInterval(50*time.Millisecond))
+
+		ctx, cancel := context.WithCancel(context.Background())
+		renewer.Start(ctx)
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+		renewer.Stop()
+	}
+
+	// Wait for goroutines to clean up
+	err = await.New().
+		AtMost(5 * time.Second).
+		PollInterval(100 * time.Millisecond).
+		Until(func() bool {
+			return runtime.NumGoroutine() <= initialGoroutines+1 // Allow 1 for test framework
+		})
+	require.NoError(t, err, "Should not leak goroutines")
+}
+
+func TestLeaseRenewer_StartIsIdempotent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	t.Cleanup(cleanup)
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	podID := "test-pod-start-idempotent"
+	sagaID := createLeaseTestSaga(t, db, podID, time.Now().Add(5*time.Minute))
+
+	claimService := NewClaimService(db, &ClaimConfig{
+		LeaseDuration: 5 * time.Minute,
+		PodID:         podID,
+	})
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	renewer := NewLeaseRenewer(sagaID, claimService, logger, WithRenewalInterval(50*time.Millisecond))
+
+	ctx := context.Background()
+
+	initialGoroutines := runtime.NumGoroutine()
+
+	// Start multiple times
+	renewer.Start(ctx)
+	renewer.Start(ctx) // Should be ignored
+	renewer.Start(ctx) // Should be ignored
+
+	// Wait a bit for goroutine to start
+	time.Sleep(100 * time.Millisecond)
+
+	// Should only have started one goroutine
+	currentGoroutines := runtime.NumGoroutine()
+	assert.LessOrEqual(t, currentGoroutines, initialGoroutines+2, "Multiple Start() calls should not spawn multiple goroutines")
+
+	renewer.Stop()
+}


### PR DESCRIPTION
## Summary
- Implement `LeaseRenewer` component that periodically extends saga leases to prevent expiry during long-running executions
- Background goroutine uses `time.NewTicker` for 2-minute renewal intervals (configurable via `SAGA_LEASE_RENEWAL_INTERVAL`)
- Graceful shutdown via context cancellation or explicit `Stop()` call
- Non-fatal handling of renewal failures (logs warning, continues operation)

## Test plan
- [x] Unit tests: Verify ticker creates renewal requests at correct interval
- [x] Integration tests: Verify `lease_expires_at` updated in database
- [x] Shutdown tests: Context cancellation stops renewals cleanly
- [x] Idempotency tests: Multiple `Start()` and `Stop()` calls are safe
- [x] Goroutine leak tests: No leaked goroutines after stop

## Task Reference
Task Master: starlark-saga-orchestration.14