### PR TITLE
feat: Implement external lookup result capture for replay safety (FR-34)

### DIFF
--- a/shared/pkg/saga/handlers.go
+++ b/shared/pkg/saga/handlers.go
@@ -63,6 +63,11 @@ type StarlarkContext struct {
 	// Logger for structured logging within handlers.
 	Logger *slog.Logger
 
+	// LookupCache stores external lookup results for deterministic replay (FR-34).
+	// When replaying a saga, this cache is pre-populated from the input snapshot
+	// to ensure the same lookup results are returned even if Reference Data changed.
+	LookupCache *LookupResultCache
+
 	// Suspension state
 	suspended     bool
 	SuspendReason string

--- a/shared/pkg/saga/replay.go
+++ b/shared/pkg/saga/replay.go
@@ -1,0 +1,295 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// LookupResultCache provides thread-safe caching of external lookup results
+// for deterministic saga replay. When a saga is replayed, builtins like
+// resolve_account and resolve_instrument check this cache first to ensure
+// the same values are returned even if Reference Data has changed.
+//
+// Per PRD FR-34: Capture external lookup results for replay safety.
+type LookupResultCache struct {
+	mu    sync.RWMutex
+	cache map[string]any
+}
+
+// NewLookupResultCache creates a new empty lookup result cache.
+func NewLookupResultCache() *LookupResultCache {
+	return &LookupResultCache{
+		cache: make(map[string]any),
+	}
+}
+
+// Get retrieves a cached lookup result by key.
+// Returns the value and true if found, or nil and false if not cached.
+func (c *LookupResultCache) Get(key string) (any, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	val, ok := c.cache[key]
+	return val, ok
+}
+
+// Set stores a lookup result in the cache.
+// The key should be generated using GenerateCacheKey for consistency.
+func (c *LookupResultCache) Set(key string, value any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache[key] = value
+}
+
+// Serialize converts the cache contents to JSON for persistence.
+// The serialized form is stored in saga_execution_log.input_snapshot.lookup_results.
+func (c *LookupResultCache) Serialize() ([]byte, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return json.Marshal(c.cache)
+}
+
+// Deserialize populates the cache from JSON data.
+// Used when replaying a saga to restore the original lookup results.
+func (c *LookupResultCache) Deserialize(data []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	newCache := make(map[string]any)
+	if err := json.Unmarshal(data, &newCache); err != nil {
+		return fmt.Errorf("failed to deserialize lookup cache: %w", err)
+	}
+	c.cache = newCache
+	return nil
+}
+
+// Clear removes all entries from the cache.
+func (c *LookupResultCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cache = make(map[string]any)
+}
+
+// Len returns the number of entries in the cache.
+func (c *LookupResultCache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.cache)
+}
+
+// GenerateCacheKey creates a deterministic cache key for a builtin call.
+// The key format is "builtin_name:sha256_hash" where the hash is computed
+// from the ordered JSON serialization of the arguments.
+//
+// This ensures:
+// - Same arguments in different order produce the same key
+// - Different builtins with same args produce different keys
+// - Nested structures are handled correctly
+func GenerateCacheKey(builtinName string, args map[string]any) string {
+	orderedJSON := orderedMarshal(args)
+	hash := sha256.Sum256(orderedJSON)
+	return fmt.Sprintf("%s:%s", builtinName, hex.EncodeToString(hash[:]))
+}
+
+// orderedMarshal produces a deterministic JSON representation of a map.
+// Keys are sorted alphabetically at all nesting levels.
+func orderedMarshal(v any) []byte {
+	if v == nil {
+		return []byte("null")
+	}
+
+	switch val := v.(type) {
+	case map[string]any:
+		return orderedMarshalMap(val)
+	case []any:
+		return orderedMarshalSlice(val)
+	default:
+		// For primitive types, standard JSON marshal is deterministic
+		b, _ := json.Marshal(val)
+		return b
+	}
+}
+
+func orderedMarshalMap(m map[string]any) []byte {
+	if len(m) == 0 {
+		return []byte("{}")
+	}
+
+	// Sort keys
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Build JSON manually to preserve key order
+	result := []byte("{")
+	for i, k := range keys {
+		if i > 0 {
+			result = append(result, ',')
+		}
+		keyJSON, _ := json.Marshal(k)
+		result = append(result, keyJSON...)
+		result = append(result, ':')
+		result = append(result, orderedMarshal(m[k])...)
+	}
+	result = append(result, '}')
+	return result
+}
+
+func orderedMarshalSlice(s []any) []byte {
+	if len(s) == 0 {
+		return []byte("[]")
+	}
+
+	result := []byte("[")
+	for i, v := range s {
+		if i > 0 {
+			result = append(result, ',')
+		}
+		result = append(result, orderedMarshal(v)...)
+	}
+	result = append(result, ']')
+	return result
+}
+
+// AccountResolver defines the interface for resolving account IDs from Reference Data.
+// Implementations query the reference_data.accounts table or equivalent.
+type AccountResolver interface {
+	ResolveAccount(purpose, currency string) (map[string]any, error)
+}
+
+// InstrumentResolver defines the interface for resolving instrument IDs from Reference Data.
+// Implementations query the reference_data.instruments table or equivalent.
+type InstrumentResolver interface {
+	ResolveInstrument(code, version string) (map[string]any, error)
+}
+
+// CachedResolveAccount resolves an account with cache-first lookup for replay safety.
+// On cache miss, calls the resolver and stores the result for future replays.
+// On cache hit, returns the cached value without calling the resolver.
+//
+// This ensures deterministic replay: even if Reference Data changes between
+// the original execution and a replay, the same account ID is returned.
+func CachedResolveAccount(cache *LookupResultCache, resolver AccountResolver, purpose, currency string) (map[string]any, error) {
+	args := map[string]any{
+		"purpose":  purpose,
+		"currency": currency,
+	}
+	key := GenerateCacheKey("resolve_account", args)
+
+	// Check cache first
+	if cached, ok := cache.Get(key); ok {
+		// Cache hit - return cached value for deterministic replay
+		result, _ := cached.(map[string]any)
+		return result, nil
+	}
+
+	// Cache miss - call resolver
+	result, err := resolver.ResolveAccount(purpose, currency)
+	if err != nil {
+		// Do NOT cache errors - they should be retried on replay
+		return nil, err
+	}
+
+	// Store successful result in cache
+	cache.Set(key, result)
+	return result, nil
+}
+
+// CachedResolveInstrument resolves an instrument with cache-first lookup for replay safety.
+// On cache miss, calls the resolver and stores the result for future replays.
+// On cache hit, returns the cached value without calling the resolver.
+func CachedResolveInstrument(cache *LookupResultCache, resolver InstrumentResolver, code, version string) (map[string]any, error) {
+	args := map[string]any{
+		"code":    code,
+		"version": version,
+	}
+	key := GenerateCacheKey("resolve_instrument", args)
+
+	// Check cache first
+	if cached, ok := cache.Get(key); ok {
+		// Cache hit - return cached value for deterministic replay
+		result, _ := cached.(map[string]any)
+		return result, nil
+	}
+
+	// Cache miss - call resolver
+	result, err := resolver.ResolveInstrument(code, version)
+	if err != nil {
+		// Do NOT cache errors - they should be retried on replay
+		return nil, err
+	}
+
+	// Store successful result in cache
+	cache.Set(key, result)
+	return result, nil
+}
+
+// LookupResultsKey is the field name used to store lookup results in the input snapshot.
+const LookupResultsKey = "lookup_results"
+
+// ExtractLookupCache extracts a LookupResultCache from an input snapshot.
+// If the input contains a "lookup_results" field, it is used to pre-populate
+// the cache for deterministic replay. Otherwise, an empty cache is returned.
+//
+// This is called at the start of saga execution to restore lookup results
+// from a previous execution (replay scenario).
+func ExtractLookupCache(input map[string]any) (*LookupResultCache, error) {
+	cache := NewLookupResultCache()
+
+	if input == nil {
+		return cache, nil
+	}
+
+	lookupResults, ok := input[LookupResultsKey]
+	if !ok {
+		return cache, nil
+	}
+
+	// Convert the lookup results to JSON and deserialize into the cache
+	lookupMap, ok := lookupResults.(map[string]any)
+	if !ok {
+		return cache, nil
+	}
+
+	// Directly populate the cache from the map
+	for key, value := range lookupMap {
+		cache.Set(key, value)
+	}
+
+	return cache, nil
+}
+
+// MergeLookupCacheToInput merges the lookup cache contents into the input snapshot.
+// This creates a new map containing the original input plus a "lookup_results" field
+// with all cached lookup results.
+//
+// This is called after saga completion to persist lookup results for future replays.
+func MergeLookupCacheToInput(input map[string]any, cache *LookupResultCache) (map[string]any, error) {
+	// Create a new map to avoid mutating the original
+	result := make(map[string]any)
+
+	// Copy original input fields
+	for k, v := range input {
+		result[k] = v
+	}
+
+	// Serialize and deserialize to get a clean map
+	cacheData, err := cache.Serialize()
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize lookup cache: %w", err)
+	}
+
+	var lookupResults map[string]any
+	if err := json.Unmarshal(cacheData, &lookupResults); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal lookup cache: %w", err)
+	}
+
+	result[LookupResultsKey] = lookupResults
+	return result, nil
+}

--- a/shared/pkg/saga/replay_test.go
+++ b/shared/pkg/saga/replay_test.go
@@ -1,0 +1,467 @@
+package saga
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupResultCache_GetSet(t *testing.T) {
+	cache := NewLookupResultCache()
+
+	// Test setting and getting a value
+	cache.Set("resolve_account:abc123", map[string]any{
+		"account_id": "ACC-001",
+		"currency":   "GBP",
+	})
+
+	val, ok := cache.Get("resolve_account:abc123")
+	require.True(t, ok, "expected cache hit")
+	require.NotNil(t, val)
+
+	result := val.(map[string]any)
+	assert.Equal(t, "ACC-001", result["account_id"])
+	assert.Equal(t, "GBP", result["currency"])
+}
+
+func TestLookupResultCache_GetMiss(t *testing.T) {
+	cache := NewLookupResultCache()
+
+	val, ok := cache.Get("nonexistent")
+	assert.False(t, ok, "expected cache miss")
+	assert.Nil(t, val)
+}
+
+func TestLookupResultCache_SetNilValue(t *testing.T) {
+	cache := NewLookupResultCache()
+
+	// Setting nil is allowed (represents "lookup returned nothing")
+	cache.Set("resolve_account:empty", nil)
+
+	val, ok := cache.Get("resolve_account:empty")
+	assert.True(t, ok, "nil value should still be a cache hit")
+	assert.Nil(t, val)
+}
+
+func TestGenerateCacheKey_Deterministic(t *testing.T) {
+	args1 := map[string]any{
+		"purpose":  "clearing",
+		"currency": "GBP",
+	}
+	args2 := map[string]any{
+		"currency": "GBP", // Different order
+		"purpose":  "clearing",
+	}
+
+	key1 := GenerateCacheKey("resolve_account", args1)
+	key2 := GenerateCacheKey("resolve_account", args2)
+
+	assert.Equal(t, key1, key2, "same args with different order should produce same hash")
+	assert.Contains(t, key1, "resolve_account:", "key should contain builtin name prefix")
+}
+
+func TestGenerateCacheKey_DifferentArgs(t *testing.T) {
+	args1 := map[string]any{
+		"purpose":  "clearing",
+		"currency": "GBP",
+	}
+	args2 := map[string]any{
+		"purpose":  "settlement",
+		"currency": "GBP",
+	}
+
+	key1 := GenerateCacheKey("resolve_account", args1)
+	key2 := GenerateCacheKey("resolve_account", args2)
+
+	assert.NotEqual(t, key1, key2, "different args should produce different hashes")
+}
+
+func TestGenerateCacheKey_DifferentBuiltins(t *testing.T) {
+	args := map[string]any{
+		"code":    "ELEC-NZ",
+		"version": "1",
+	}
+
+	key1 := GenerateCacheKey("resolve_account", args)
+	key2 := GenerateCacheKey("resolve_instrument", args)
+
+	assert.NotEqual(t, key1, key2, "different builtin names should produce different hashes")
+}
+
+func TestGenerateCacheKey_NestedMaps(t *testing.T) {
+	args1 := map[string]any{
+		"outer": map[string]any{
+			"inner_a": "value_a",
+			"inner_b": "value_b",
+		},
+	}
+	args2 := map[string]any{
+		"outer": map[string]any{
+			"inner_b": "value_b", // Different order
+			"inner_a": "value_a",
+		},
+	}
+
+	key1 := GenerateCacheKey("test_builtin", args1)
+	key2 := GenerateCacheKey("test_builtin", args2)
+
+	assert.Equal(t, key1, key2, "nested maps with different order should produce same hash")
+}
+
+func TestGenerateCacheKey_EmptyArgs(t *testing.T) {
+	key1 := GenerateCacheKey("no_args_builtin", map[string]any{})
+	key2 := GenerateCacheKey("no_args_builtin", map[string]any{})
+
+	assert.Equal(t, key1, key2, "empty args should produce consistent hash")
+	assert.Contains(t, key1, "no_args_builtin:")
+}
+
+func TestLookupResultCache_Serialize(t *testing.T) {
+	cache := NewLookupResultCache()
+
+	cache.Set("resolve_account:key1", map[string]any{
+		"account_id": "ACC-001",
+	})
+	cache.Set("resolve_instrument:key2", map[string]any{
+		"instrument_id": "INST-001",
+	})
+
+	data, err := cache.Serialize()
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	// Deserialize into a new cache
+	newCache := NewLookupResultCache()
+	err = newCache.Deserialize(data)
+	require.NoError(t, err)
+
+	// Verify the values are preserved
+	val1, ok := newCache.Get("resolve_account:key1")
+	require.True(t, ok)
+	result1 := val1.(map[string]any)
+	assert.Equal(t, "ACC-001", result1["account_id"])
+
+	val2, ok := newCache.Get("resolve_instrument:key2")
+	require.True(t, ok)
+	result2 := val2.(map[string]any)
+	assert.Equal(t, "INST-001", result2["instrument_id"])
+}
+
+func TestLookupResultCache_DeserializeEmpty(t *testing.T) {
+	cache := NewLookupResultCache()
+
+	err := cache.Deserialize([]byte("{}"))
+	require.NoError(t, err)
+
+	_, ok := cache.Get("anything")
+	assert.False(t, ok)
+}
+
+func TestLookupResultCache_DeserializeInvalid(t *testing.T) {
+	cache := NewLookupResultCache()
+
+	err := cache.Deserialize([]byte("not json"))
+	assert.Error(t, err)
+}
+
+func TestLookupResultCache_ThreadSafety(t *testing.T) {
+	cache := NewLookupResultCache()
+	var wg sync.WaitGroup
+
+	// Concurrent writes
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := GenerateCacheKey("concurrent_test", map[string]any{"n": n})
+			cache.Set(key, map[string]any{"value": n})
+		}(i)
+	}
+
+	// Concurrent reads
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			key := GenerateCacheKey("concurrent_test", map[string]any{"n": n})
+			cache.Get(key)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify at least some entries were stored
+	data, err := cache.Serialize()
+	require.NoError(t, err)
+	assert.NotEmpty(t, data)
+}
+
+func TestLookupResultCache_Clear(t *testing.T) {
+	cache := NewLookupResultCache()
+
+	cache.Set("key1", "value1")
+	cache.Set("key2", "value2")
+
+	cache.Clear()
+
+	_, ok := cache.Get("key1")
+	assert.False(t, ok, "cache should be empty after Clear")
+}
+
+func TestLookupResultCache_Len(t *testing.T) {
+	cache := NewLookupResultCache()
+	assert.Equal(t, 0, cache.Len())
+
+	cache.Set("key1", "value1")
+	assert.Equal(t, 1, cache.Len())
+
+	cache.Set("key2", "value2")
+	assert.Equal(t, 2, cache.Len())
+
+	// Setting same key doesn't increase count
+	cache.Set("key1", "updated")
+	assert.Equal(t, 2, cache.Len())
+}
+
+// Test for AccountResolver integration with cache
+
+var (
+	errAccountNotFound    = errors.New("account not found")
+	errInstrumentNotFound = errors.New("instrument not found")
+)
+
+type mockAccountResolver struct {
+	calls   int
+	results map[string]map[string]any
+}
+
+func (m *mockAccountResolver) ResolveAccount(purpose, currency string) (map[string]any, error) {
+	m.calls++
+	key := purpose + ":" + currency
+	if result, ok := m.results[key]; ok {
+		return result, nil
+	}
+	return nil, errAccountNotFound
+}
+
+type mockInstrumentResolver struct {
+	calls   int
+	results map[string]map[string]any
+}
+
+func (m *mockInstrumentResolver) ResolveInstrument(code, version string) (map[string]any, error) {
+	m.calls++
+	key := code + ":" + version
+	if result, ok := m.results[key]; ok {
+		return result, nil
+	}
+	return nil, errInstrumentNotFound
+}
+
+func TestCachedResolveAccount_CacheMiss(t *testing.T) {
+	cache := NewLookupResultCache()
+	resolver := &mockAccountResolver{
+		results: map[string]map[string]any{
+			"clearing:GBP": {"account_id": "ACC-001", "currency": "GBP"},
+		},
+	}
+
+	result, err := CachedResolveAccount(cache, resolver, "clearing", "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, "ACC-001", result["account_id"])
+	assert.Equal(t, 1, resolver.calls, "resolver should be called on cache miss")
+
+	// Verify the result was cached
+	key := GenerateCacheKey("resolve_account", map[string]any{"purpose": "clearing", "currency": "GBP"})
+	cachedVal, ok := cache.Get(key)
+	require.True(t, ok, "result should be cached")
+	assert.Equal(t, "ACC-001", cachedVal.(map[string]any)["account_id"])
+}
+
+func TestCachedResolveAccount_CacheHit(t *testing.T) {
+	cache := NewLookupResultCache()
+	resolver := &mockAccountResolver{
+		results: map[string]map[string]any{
+			"clearing:GBP": {"account_id": "ACC-NEW", "currency": "GBP"},
+		},
+	}
+
+	// Pre-populate cache with old value
+	key := GenerateCacheKey("resolve_account", map[string]any{"purpose": "clearing", "currency": "GBP"})
+	cache.Set(key, map[string]any{"account_id": "ACC-OLD", "currency": "GBP"})
+
+	result, err := CachedResolveAccount(cache, resolver, "clearing", "GBP")
+	require.NoError(t, err)
+	assert.Equal(t, "ACC-OLD", result["account_id"], "should return cached value even if resolver would return different")
+	assert.Equal(t, 0, resolver.calls, "resolver should NOT be called on cache hit")
+}
+
+func TestCachedResolveInstrument_CacheMiss(t *testing.T) {
+	cache := NewLookupResultCache()
+	resolver := &mockInstrumentResolver{
+		results: map[string]map[string]any{
+			"ELEC-NZ:1": {"instrument_id": "INST-001", "code": "ELEC-NZ"},
+		},
+	}
+
+	result, err := CachedResolveInstrument(cache, resolver, "ELEC-NZ", "1")
+	require.NoError(t, err)
+	assert.Equal(t, "INST-001", result["instrument_id"])
+	assert.Equal(t, 1, resolver.calls, "resolver should be called on cache miss")
+
+	// Verify the result was cached
+	key := GenerateCacheKey("resolve_instrument", map[string]any{"code": "ELEC-NZ", "version": "1"})
+	cachedVal, ok := cache.Get(key)
+	require.True(t, ok, "result should be cached")
+	assert.Equal(t, "INST-001", cachedVal.(map[string]any)["instrument_id"])
+}
+
+func TestCachedResolveInstrument_CacheHit(t *testing.T) {
+	cache := NewLookupResultCache()
+	resolver := &mockInstrumentResolver{
+		results: map[string]map[string]any{
+			"ELEC-NZ:1": {"instrument_id": "INST-NEW", "code": "ELEC-NZ"},
+		},
+	}
+
+	// Pre-populate cache with old value
+	key := GenerateCacheKey("resolve_instrument", map[string]any{"code": "ELEC-NZ", "version": "1"})
+	cache.Set(key, map[string]any{"instrument_id": "INST-OLD", "code": "ELEC-NZ"})
+
+	result, err := CachedResolveInstrument(cache, resolver, "ELEC-NZ", "1")
+	require.NoError(t, err)
+	assert.Equal(t, "INST-OLD", result["instrument_id"], "should return cached value")
+	assert.Equal(t, 0, resolver.calls, "resolver should NOT be called on cache hit")
+}
+
+func TestCachedResolveAccount_ResolverError(t *testing.T) {
+	cache := NewLookupResultCache()
+	resolver := &mockAccountResolver{
+		results: map[string]map[string]any{}, // No results = error
+	}
+
+	_, err := CachedResolveAccount(cache, resolver, "unknown", "XYZ")
+	assert.Error(t, err)
+	assert.Equal(t, 1, resolver.calls)
+
+	// Error results should NOT be cached
+	key := GenerateCacheKey("resolve_account", map[string]any{"purpose": "unknown", "currency": "XYZ"})
+	_, ok := cache.Get(key)
+	assert.False(t, ok, "error results should not be cached")
+}
+
+// Tests for InputSnapshot integration
+
+func TestInputSnapshot_WithLookupResults(t *testing.T) {
+	// Create input with lookup_results field
+	input := map[string]any{
+		"amount":   "100.00",
+		"currency": "GBP",
+		"lookup_results": map[string]any{
+			"resolve_account:abc123": map[string]any{
+				"account_id": "ACC-001",
+			},
+		},
+	}
+
+	cache, err := ExtractLookupCache(input)
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+
+	// The cache should contain the lookup results
+	val, ok := cache.Get("resolve_account:abc123")
+	require.True(t, ok)
+	assert.Equal(t, "ACC-001", val.(map[string]any)["account_id"])
+}
+
+func TestInputSnapshot_WithoutLookupResults(t *testing.T) {
+	// Input without lookup_results field
+	input := map[string]any{
+		"amount":   "100.00",
+		"currency": "GBP",
+	}
+
+	cache, err := ExtractLookupCache(input)
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+	assert.Equal(t, 0, cache.Len(), "cache should be empty when no lookup_results in input")
+}
+
+func TestInputSnapshot_NilInput(t *testing.T) {
+	cache, err := ExtractLookupCache(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cache)
+	assert.Equal(t, 0, cache.Len())
+}
+
+func TestMergeLookupCacheToInput(t *testing.T) {
+	cache := NewLookupResultCache()
+	cache.Set("resolve_account:key1", map[string]any{"account_id": "ACC-001"})
+	cache.Set("resolve_instrument:key2", map[string]any{"instrument_id": "INST-001"})
+
+	input := map[string]any{
+		"amount":   "100.00",
+		"currency": "GBP",
+	}
+
+	result, err := MergeLookupCacheToInput(input, cache)
+	require.NoError(t, err)
+
+	// Original fields should be preserved
+	assert.Equal(t, "100.00", result["amount"])
+	assert.Equal(t, "GBP", result["currency"])
+
+	// lookup_results should be added
+	lookupResults, ok := result["lookup_results"].(map[string]any)
+	require.True(t, ok, "lookup_results should be present")
+
+	assert.Equal(t, "ACC-001", lookupResults["resolve_account:key1"].(map[string]any)["account_id"])
+	assert.Equal(t, "INST-001", lookupResults["resolve_instrument:key2"].(map[string]any)["instrument_id"])
+}
+
+func TestMergeLookupCacheToInput_NilInput(t *testing.T) {
+	cache := NewLookupResultCache()
+	cache.Set("key1", "value1")
+
+	result, err := MergeLookupCacheToInput(nil, cache)
+	require.NoError(t, err)
+
+	lookupResults, ok := result["lookup_results"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "value1", lookupResults["key1"])
+}
+
+func TestMergeLookupCacheToInput_EmptyCache(t *testing.T) {
+	cache := NewLookupResultCache()
+	input := map[string]any{"foo": "bar"}
+
+	result, err := MergeLookupCacheToInput(input, cache)
+	require.NoError(t, err)
+
+	// With empty cache, lookup_results should still be present but empty
+	lookupResults, ok := result["lookup_results"].(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, lookupResults)
+}
+
+func TestRoundTrip_ExtractAndMerge(t *testing.T) {
+	// Start with a cache
+	originalCache := NewLookupResultCache()
+	originalCache.Set("resolve_account:key1", map[string]any{"account_id": "ACC-001"})
+
+	// Merge into input
+	input, err := MergeLookupCacheToInput(map[string]any{"data": "test"}, originalCache)
+	require.NoError(t, err)
+
+	// Extract cache from input
+	extractedCache, err := ExtractLookupCache(input)
+	require.NoError(t, err)
+
+	// The extracted cache should contain the same data
+	val, ok := extractedCache.Get("resolve_account:key1")
+	require.True(t, ok)
+	assert.Equal(t, "ACC-001", val.(map[string]any)["account_id"])
+}


### PR DESCRIPTION
## Summary

Implements Task starlark-saga-orchestration.8 - external lookup result capture for deterministic saga replay.

- Add `LookupResultCache` with thread-safe map storage and deterministic SHA256-based cache key generation
- Add `CachedResolveAccount` and `CachedResolveInstrument` functions that check cache before calling resolvers
- Add `ExtractLookupCache` and `MergeLookupCacheToInput` for input snapshot persistence
- Add `LookupCache` field to `StarlarkContext` for runtime integration

## Changes Made

| File | Description |
|------|-------------|
| `shared/pkg/saga/replay.go` | New file with LookupResultCache and cached resolve functions |
| `shared/pkg/saga/replay_test.go` | Comprehensive test coverage for all new functionality |
| `shared/pkg/saga/handlers.go` | Added LookupCache field to StarlarkContext |

## Technical Details

**Cache Key Generation**: Uses SHA256 hash of `builtin_name + ordered_json(args)` for deterministic keys regardless of argument order.

**Replay Safety Guarantee**: When a saga is replayed, the cache is pre-populated from the input snapshot, ensuring the same lookup results are returned even if Reference Data has changed.

**Thread Safety**: LookupResultCache uses RWMutex for concurrent access.

## Test plan

- [x] Unit tests for LookupResultCache Get/Set operations
- [x] Tests for deterministic cache key generation (same args → same hash)
- [x] Tests for cached resolve functions (cache hit/miss scenarios)
- [x] Tests for input snapshot extraction and merging
- [x] Thread safety test with concurrent reads/writes
- [x] Round-trip test: merge → extract preserves data