### PR TITLE
feat: Implement zombie saga detection and FAILED_MANUAL_INTERVENTION transition

### DIFF
--- a/shared/pkg/saga/claiming.go
+++ b/shared/pkg/saga/claiming.go
@@ -3,6 +3,7 @@ package saga
 
 import (
 	"context"
+	"log/slog"
 	"math/rand/v2"
 	"os"
 	"strings"
@@ -12,6 +13,11 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/env"
 	"gorm.io/gorm"
 )
+
+// DefaultMaxReplays is the default maximum number of replay attempts before a saga
+// is considered a zombie and transitions to FAILED_MANUAL_INTERVENTION.
+// This prevents infinite retry loops (FR-19).
+const DefaultMaxReplays = 5
 
 // ClaimConfig holds configuration for the saga claim service.
 type ClaimConfig struct {
@@ -30,6 +36,11 @@ type ClaimConfig struct {
 	// PodID identifies this pod instance for claiming purposes.
 	// Default: HOSTNAME env var or generated UUID
 	PodID string
+
+	// MaxReplays is the maximum number of replay attempts before a saga is considered
+	// a zombie and transitions to FAILED_MANUAL_INTERVENTION.
+	// Default: 5 (SAGA_MAX_REPLAYS)
+	MaxReplays int
 }
 
 // NewClaimConfig creates a ClaimConfig populated from environment variables.
@@ -37,12 +48,14 @@ type ClaimConfig struct {
 //   - SAGA_LEASE_DURATION: Duration string (e.g., "5m", "10m"). Default: "5m"
 //   - SAGA_CLAIM_BATCH_SIZE: Integer. Default: 10
 //   - SAGA_CLAIM_JITTER_MS: Integer milliseconds. Default: 500
+//   - SAGA_MAX_REPLAYS: Maximum replay attempts before zombie detection. Default: 5
 //   - HOSTNAME: Pod identifier (Kubernetes sets this). Fallback: generated UUID
 func NewClaimConfig() *ClaimConfig {
 	return &ClaimConfig{
 		LeaseDuration: env.GetEnvAsDuration("SAGA_LEASE_DURATION", 5*time.Minute),
 		BatchSize:     env.GetEnvAsInt("SAGA_CLAIM_BATCH_SIZE", 10),
 		MaxJitterMS:   env.GetEnvAsInt("SAGA_CLAIM_JITTER_MS", 500),
+		MaxReplays:    env.GetEnvAsInt("SAGA_MAX_REPLAYS", DefaultMaxReplays),
 		PodID:         GetPodID(),
 	}
 }
@@ -64,6 +77,7 @@ func GetPodID() string {
 type ClaimService struct {
 	db     *gorm.DB
 	config *ClaimConfig
+	logger *slog.Logger
 }
 
 // NewClaimService creates a new ClaimService with the given configuration.
@@ -71,13 +85,24 @@ func NewClaimService(db *gorm.DB, config *ClaimConfig) *ClaimService {
 	return &ClaimService{
 		db:     db,
 		config: config,
+		logger: slog.Default(),
 	}
+}
+
+// WithLogger sets the logger for the claim service.
+func (s *ClaimService) WithLogger(logger *slog.Logger) *ClaimService {
+	s.logger = logger
+	return s
 }
 
 // ClaimOrphanedSagas finds and claims orphaned saga instances.
 // A saga is considered orphaned if:
 //   - Status is PENDING, RUNNING, or COMPENSATING (active states)
 //   - AND (lease_expires_at < NOW() OR claimed_by_pod IS NULL)
+//
+// Before claiming, this method detects and transitions zombie sagas.
+// A zombie saga is one that has exceeded MaxReplays attempts (FR-19).
+// Zombie sagas are transitioned to FAILED_MANUAL_INTERVENTION and not claimed.
 //
 // Uses PostgreSQL FOR UPDATE SKIP LOCKED to prevent race conditions when
 // multiple pods attempt to claim simultaneously. The SKIP LOCKED clause
@@ -95,6 +120,14 @@ func (s *ClaimService) ClaimOrphanedSagas(ctx context.Context) ([]uuid.UUID, err
 		time.Sleep(jitter)
 	}
 
+	// First, detect and transition zombie sagas (replay_count >= MaxReplays)
+	if err := s.transitionZombieSagas(ctx); err != nil {
+		s.logger.Error("failed to transition zombie sagas",
+			"error", err,
+		)
+		// Continue with claiming - zombie detection is best-effort
+	}
+
 	now := time.Now()
 	leaseExpiry := now.Add(s.config.LeaseDuration)
 
@@ -103,10 +136,11 @@ func (s *ClaimService) ClaimOrphanedSagas(ctx context.Context) ([]uuid.UUID, err
 	//
 	// Query explanation:
 	// 1. Inner SELECT finds orphaned sagas (expired lease or no owner)
-	// 2. FOR UPDATE SKIP LOCKED acquires row locks, skipping locked rows
-	// 3. LIMIT controls batch size
-	// 4. Outer UPDATE claims the selected rows
-	// 5. RETURNING gives us the claimed saga IDs
+	// 2. Filter out zombies (replay_count >= MaxReplays)
+	// 3. FOR UPDATE SKIP LOCKED acquires row locks, skipping locked rows
+	// 4. LIMIT controls batch size
+	// 5. Outer UPDATE claims the selected rows and increments replay_count
+	// 6. RETURNING gives us the claimed saga IDs
 	//
 	// Note: PostgreSQL requires the subquery to be a CTE for UPDATE...FROM syntax
 	// when using FOR UPDATE SKIP LOCKED in the subquery.
@@ -114,17 +148,19 @@ func (s *ClaimService) ClaimOrphanedSagas(ctx context.Context) ([]uuid.UUID, err
 	var claimedIDs []uuid.UUID
 
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Execute the claim query
+		// Execute the claim query with replay_count filter and increment
 		result := tx.Raw(`
 			UPDATE saga_instances
 			SET
 				claimed_by_pod = ?,
 				claimed_at = ?,
-				lease_expires_at = ?
+				lease_expires_at = ?,
+				replay_count = replay_count + 1
 			WHERE id IN (
 				SELECT id FROM saga_instances
 				WHERE status IN (?, ?, ?)
 				  AND (lease_expires_at < ? OR claimed_by_pod IS NULL)
+				  AND replay_count < ?
 				FOR UPDATE SKIP LOCKED
 				LIMIT ?
 			)
@@ -137,6 +173,7 @@ func (s *ClaimService) ClaimOrphanedSagas(ctx context.Context) ([]uuid.UUID, err
 			SagaStatusRunning,
 			SagaStatusCompensating,
 			now,
+			s.config.MaxReplays,
 			s.config.BatchSize,
 		).Scan(&claimedIDs)
 
@@ -150,7 +187,80 @@ func (s *ClaimService) ClaimOrphanedSagas(ctx context.Context) ([]uuid.UUID, err
 		return nil, err
 	}
 
+	// Record metrics for replay count increments
+	for range claimedIDs {
+		RecordReplayIncrement()
+	}
+
 	return claimedIDs, nil
+}
+
+// transitionZombieSagas finds sagas that have exceeded MaxReplays and
+// transitions them to FAILED_MANUAL_INTERVENTION status.
+// This prevents infinite retry loops (FR-19).
+func (s *ClaimService) transitionZombieSagas(ctx context.Context) error {
+	now := time.Now()
+
+	// Find and transition zombie sagas in a single atomic operation
+	// We use a struct to scan the results including saga_definition_id for metrics
+	type zombieResult struct {
+		ID               uuid.UUID `gorm:"column:id"`
+		SagaDefinitionID uuid.UUID `gorm:"column:saga_definition_id"`
+		ReplayCount      int       `gorm:"column:replay_count"`
+	}
+	var zombies []zombieResult
+
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Select zombie sagas and transition them atomically
+		result := tx.Raw(`
+			UPDATE saga_instances
+			SET
+				status = ?,
+				claimed_by_pod = NULL,
+				claimed_at = NULL,
+				lease_expires_at = NULL,
+				updated_at = ?
+			WHERE id IN (
+				SELECT id FROM saga_instances
+				WHERE status IN (?, ?, ?)
+				  AND (lease_expires_at < ? OR claimed_by_pod IS NULL)
+				  AND replay_count >= ?
+				FOR UPDATE SKIP LOCKED
+			)
+			RETURNING id, saga_definition_id, replay_count
+		`,
+			SagaStatusFailedManualIntervention,
+			now,
+			SagaStatusPending,
+			SagaStatusRunning,
+			SagaStatusCompensating,
+			now,
+			s.config.MaxReplays,
+		).Scan(&zombies)
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Log and record metrics for each detected zombie
+	for _, zombie := range zombies {
+		s.logger.Error("zombie saga detected - transitioned to FAILED_MANUAL_INTERVENTION",
+			"saga_id", zombie.ID,
+			"saga_definition_id", zombie.SagaDefinitionID,
+			"replay_count", zombie.ReplayCount,
+			"max_replays", s.config.MaxReplays,
+		)
+		RecordZombieSagaDetected(zombie.SagaDefinitionID.String())
+		RecordReplayCount(zombie.ReplayCount)
+	}
+
+	return nil
 }
 
 // RenewLease extends the lease on a saga the current pod owns.

--- a/shared/pkg/saga/claiming_test.go
+++ b/shared/pkg/saga/claiming_test.go
@@ -97,6 +97,7 @@ func TestSagaClaimService_ClaimOrphanedSagas_Integration(t *testing.T) {
 		LeaseDuration: 5 * time.Minute,
 		BatchSize:     10,
 		MaxJitterMS:   0, // Disable jitter for deterministic tests
+		MaxReplays:    DefaultMaxReplays,
 		PodID:         "test-pod-1",
 	}
 	service := NewClaimService(db, config)
@@ -161,6 +162,7 @@ func TestSagaClaimService_ClaimOrphanedSagas_Integration(t *testing.T) {
 			LeaseDuration: 5 * time.Minute,
 			BatchSize:     2,
 			MaxJitterMS:   0,
+			MaxReplays:    DefaultMaxReplays,
 			PodID:         "batch-test-pod",
 		}
 		smallBatchService := NewClaimService(db, configSmallBatch)
@@ -197,12 +199,14 @@ func TestSagaClaimService_Concurrency_Integration(t *testing.T) {
 		LeaseDuration: 5 * time.Minute,
 		BatchSize:     10,
 		MaxJitterMS:   0,
+		MaxReplays:    DefaultMaxReplays,
 		PodID:         "pod-1",
 	})
 	service2 := NewClaimService(db, &ClaimConfig{
 		LeaseDuration: 5 * time.Minute,
 		BatchSize:     10,
 		MaxJitterMS:   0,
+		MaxReplays:    DefaultMaxReplays,
 		PodID:         "pod-2",
 	})
 
@@ -269,6 +273,7 @@ func TestSagaClaimService_LeaseExpiry_Integration(t *testing.T) {
 		LeaseDuration: 5 * time.Minute,
 		BatchSize:     10,
 		MaxJitterMS:   0,
+		MaxReplays:    DefaultMaxReplays,
 		PodID:         "recovery-pod",
 	})
 
@@ -300,6 +305,7 @@ func TestSagaClaimService_ClaimsCorrectStatuses(t *testing.T) {
 		LeaseDuration: 5 * time.Minute,
 		BatchSize:     100,
 		MaxJitterMS:   0,
+		MaxReplays:    DefaultMaxReplays,
 		PodID:         "status-test-pod",
 	})
 

--- a/shared/pkg/saga/metrics.go
+++ b/shared/pkg/saga/metrics.go
@@ -1,0 +1,70 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+// This file provides Prometheus metrics for saga zombie detection and replay count observability.
+package saga
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// sagaZombieDetectedTotal tracks the number of zombie sagas detected.
+	// A zombie saga is one that has exceeded the maximum replay count.
+	// Labels: saga_definition_id (the saga type identifier)
+	sagaZombieDetectedTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "saga_zombie_detected_total",
+			Help: "Total number of zombie sagas detected (exceeded MAX_REPLAYS)",
+		},
+		[]string{"saga_definition_id"},
+	)
+
+	// sagaReplayCount tracks the distribution of replay counts.
+	// This helps identify sagas that are frequently retrying.
+	// Buckets: 0, 1, 2, 3, 5, 10, 20 to capture distribution of retries.
+	sagaReplayCount = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "saga_replay_count",
+			Help:    "Distribution of replay counts before saga success or failure",
+			Buckets: []float64{0, 1, 2, 3, 5, 10, 20},
+		},
+	)
+
+	// sagaReplayIncrementedTotal tracks when replay counts are incremented.
+	// This is useful for monitoring saga retry patterns.
+	sagaReplayIncrementedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "saga_replay_incremented_total",
+			Help: "Total number of times saga replay counts were incremented",
+		},
+	)
+)
+
+// RecordZombieSagaDetected records that a zombie saga was detected.
+// sagaDefinitionID is the UUID string of the saga definition.
+func RecordZombieSagaDetected(sagaDefinitionID string) {
+	sagaZombieDetectedTotal.WithLabelValues(sagaDefinitionID).Inc()
+}
+
+// RecordReplayCount records the replay count for observability.
+// This should be called when a saga is claimed for replay.
+func RecordReplayCount(count int) {
+	sagaReplayCount.Observe(float64(count))
+}
+
+// RecordReplayIncrement records that a saga's replay count was incremented.
+func RecordReplayIncrement() {
+	sagaReplayIncrementedTotal.Inc()
+}
+
+// ExposeMetricsForTesting provides access to the raw Prometheus metrics for testing.
+// This should only be used in test code.
+var ExposeMetricsForTesting = struct {
+	ZombieDetectedTotal    *prometheus.CounterVec
+	ReplayCount            prometheus.Histogram
+	ReplayIncrementedTotal prometheus.Counter
+}{
+	ZombieDetectedTotal:    sagaZombieDetectedTotal,
+	ReplayCount:            sagaReplayCount,
+	ReplayIncrementedTotal: sagaReplayIncrementedTotal,
+}

--- a/shared/pkg/saga/metrics_test.go
+++ b/shared/pkg/saga/metrics_test.go
@@ -1,0 +1,64 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRecordZombieSagaDetected verifies the zombie detection metric is incremented.
+func TestRecordZombieSagaDetected(t *testing.T) {
+	// Reset metric for clean test
+	ExposeMetricsForTesting.ZombieDetectedTotal.Reset()
+
+	sagaDefID := uuid.New().String()
+
+	// Record zombie detection
+	RecordZombieSagaDetected(sagaDefID)
+
+	// Verify counter incremented
+	count := testutil.ToFloat64(ExposeMetricsForTesting.ZombieDetectedTotal.WithLabelValues(sagaDefID))
+	assert.Equal(t, float64(1), count, "Counter should be incremented to 1")
+
+	// Record another for same saga definition
+	RecordZombieSagaDetected(sagaDefID)
+	count = testutil.ToFloat64(ExposeMetricsForTesting.ZombieDetectedTotal.WithLabelValues(sagaDefID))
+	assert.Equal(t, float64(2), count, "Counter should be incremented to 2")
+
+	// Record for different saga definition
+	otherSagaDefID := uuid.New().String()
+	RecordZombieSagaDetected(otherSagaDefID)
+	otherCount := testutil.ToFloat64(ExposeMetricsForTesting.ZombieDetectedTotal.WithLabelValues(otherSagaDefID))
+	assert.Equal(t, float64(1), otherCount, "Other saga def counter should be 1")
+}
+
+// TestRecordReplayCount verifies the replay count histogram is observed.
+func TestRecordReplayCount(t *testing.T) {
+	// Record various replay counts
+	RecordReplayCount(0)
+	RecordReplayCount(1)
+	RecordReplayCount(3)
+	RecordReplayCount(5)
+	RecordReplayCount(10)
+
+	// Verify histogram has observations
+	// Note: We can't easily verify individual bucket values with testutil,
+	// but we can verify the metric exists and doesn't panic
+	assert.NotNil(t, ExposeMetricsForTesting.ReplayCount, "Histogram should exist")
+}
+
+// TestRecordReplayIncrement verifies the replay increment counter.
+func TestRecordReplayIncrement(t *testing.T) {
+	// Get initial count
+	initialCount := testutil.ToFloat64(ExposeMetricsForTesting.ReplayIncrementedTotal)
+
+	// Record increment
+	RecordReplayIncrement()
+
+	// Verify incremented
+	newCount := testutil.ToFloat64(ExposeMetricsForTesting.ReplayIncrementedTotal)
+	assert.Equal(t, initialCount+1, newCount, "Counter should be incremented by 1")
+}

--- a/shared/pkg/saga/zombie_test.go
+++ b/shared/pkg/saga/zombie_test.go
@@ -1,0 +1,336 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// TestNewClaimConfig_MaxReplays verifies MaxReplays configuration.
+func TestNewClaimConfig_MaxReplays(t *testing.T) {
+	t.Run("uses default when not set", func(t *testing.T) {
+		os.Unsetenv("SAGA_MAX_REPLAYS")
+
+		config := NewClaimConfig()
+
+		assert.Equal(t, DefaultMaxReplays, config.MaxReplays, "Should use DefaultMaxReplays")
+		assert.Equal(t, 5, config.MaxReplays, "DefaultMaxReplays should be 5")
+	})
+
+	t.Run("uses SAGA_MAX_REPLAYS from env", func(t *testing.T) {
+		t.Setenv("SAGA_MAX_REPLAYS", "10")
+
+		config := NewClaimConfig()
+
+		assert.Equal(t, 10, config.MaxReplays, "Should use SAGA_MAX_REPLAYS from env")
+	})
+
+	t.Run("falls back to default on invalid env", func(t *testing.T) {
+		t.Setenv("SAGA_MAX_REPLAYS", "invalid")
+
+		config := NewClaimConfig()
+
+		assert.Equal(t, DefaultMaxReplays, config.MaxReplays, "Invalid value should fallback to default")
+	})
+}
+
+// TestSagaClaimService_ZombieDetection_Integration tests zombie saga detection and transition.
+func TestSagaClaimService_ZombieDetection_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	t.Run("transitions zombie saga to FAILED_MANUAL_INTERVENTION", func(t *testing.T) {
+		// Create a saga that has exceeded max replays
+		zombieSaga := createTestSagaWithReplayCount(t, db, SagaStatusRunning, nil, nil, 5)
+
+		config := &ClaimConfig{
+			LeaseDuration: 5 * time.Minute,
+			BatchSize:     10,
+			MaxJitterMS:   0,
+			MaxReplays:    5, // Saga has replay_count=5, which equals MaxReplays
+			PodID:         "test-pod",
+		}
+		service := NewClaimService(db, config)
+
+		// Claim should NOT include the zombie saga
+		claimed, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+		assert.NotContains(t, claimed, zombieSaga.ID, "Zombie saga should not be claimed")
+
+		// Verify saga was transitioned to FAILED_MANUAL_INTERVENTION
+		var updated SagaInstance
+		db.First(&updated, "id = ?", zombieSaga.ID)
+		assert.Equal(t, SagaStatusFailedManualIntervention, updated.Status, "Zombie should be transitioned")
+		assert.Nil(t, updated.ClaimedByPod, "Zombie should not be claimed")
+		assert.Nil(t, updated.LeaseExpiresAt, "Zombie should have no lease")
+	})
+
+	t.Run("claims healthy saga while transitioning zombie", func(t *testing.T) {
+		// Create one zombie (replay_count >= MaxReplays)
+		zombieSaga := createTestSagaWithReplayCount(t, db, SagaStatusRunning, nil, nil, 10)
+		// Create one healthy saga (replay_count < MaxReplays)
+		healthySaga := createTestSagaWithReplayCount(t, db, SagaStatusRunning, nil, nil, 2)
+
+		config := &ClaimConfig{
+			LeaseDuration: 5 * time.Minute,
+			BatchSize:     10,
+			MaxJitterMS:   0,
+			MaxReplays:    5,
+			PodID:         "test-pod-2",
+		}
+		service := NewClaimService(db, config)
+
+		claimed, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+
+		// Should claim healthy saga
+		assert.Contains(t, claimed, healthySaga.ID, "Healthy saga should be claimed")
+		// Should NOT claim zombie
+		assert.NotContains(t, claimed, zombieSaga.ID, "Zombie saga should not be claimed")
+
+		// Verify healthy saga's replay_count was incremented
+		var healthy SagaInstance
+		db.First(&healthy, "id = ?", healthySaga.ID)
+		assert.Equal(t, 3, healthy.ReplayCount, "Healthy saga replay_count should be incremented")
+		assert.Equal(t, "test-pod-2", *healthy.ClaimedByPod, "Healthy saga should be claimed by pod")
+
+		// Verify zombie was transitioned
+		var zombie SagaInstance
+		db.First(&zombie, "id = ?", zombieSaga.ID)
+		assert.Equal(t, SagaStatusFailedManualIntervention, zombie.Status, "Zombie should be transitioned")
+	})
+
+	t.Run("saga becomes zombie on replay attempt after exceeding threshold", func(t *testing.T) {
+		// Create saga at threshold - 1 (will be claimed, then on next claim will be zombie)
+		saga := createTestSagaWithReplayCount(t, db, SagaStatusRunning, nil, nil, 4)
+
+		config := &ClaimConfig{
+			LeaseDuration: 5 * time.Minute,
+			BatchSize:     10,
+			MaxJitterMS:   0,
+			MaxReplays:    5,
+			PodID:         "test-pod-3",
+		}
+		service := NewClaimService(db, config)
+
+		// First claim - should succeed and increment replay_count to 5
+		claimed1, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+		assert.Contains(t, claimed1, saga.ID, "Should claim saga at threshold-1")
+
+		// Verify replay_count is now 5 (at threshold)
+		var afterFirst SagaInstance
+		db.First(&afterFirst, "id = ?", saga.ID)
+		assert.Equal(t, 5, afterFirst.ReplayCount, "Replay count should be incremented to 5")
+
+		// Simulate saga failure by expiring lease
+		expiredLease := time.Now().Add(-1 * time.Minute)
+		db.Model(&SagaInstance{}).Where("id = ?", saga.ID).Updates(map[string]interface{}{
+			"lease_expires_at": expiredLease,
+		})
+
+		// Second claim attempt - saga should be detected as zombie
+		claimed2, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+		assert.NotContains(t, claimed2, saga.ID, "Should NOT claim zombie saga")
+
+		// Verify saga was transitioned to FAILED_MANUAL_INTERVENTION
+		var afterSecond SagaInstance
+		db.First(&afterSecond, "id = ?", saga.ID)
+		assert.Equal(t, SagaStatusFailedManualIntervention, afterSecond.Status, "Should transition to FAILED_MANUAL_INTERVENTION")
+	})
+
+	t.Run("does not transition sagas with active lease as zombies", func(t *testing.T) {
+		// Create high replay_count saga with active lease (should NOT be transitioned)
+		activeLease := time.Now().Add(10 * time.Minute)
+		otherPod := "active-pod"
+		saga := createTestSagaWithReplayCount(t, db, SagaStatusRunning, &activeLease, &otherPod, 10)
+
+		config := &ClaimConfig{
+			LeaseDuration: 5 * time.Minute,
+			BatchSize:     10,
+			MaxJitterMS:   0,
+			MaxReplays:    5,
+			PodID:         "test-pod-4",
+		}
+		service := NewClaimService(db, config)
+
+		claimed, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+		assert.NotContains(t, claimed, saga.ID, "Active lease saga should not be claimed")
+
+		// Verify saga was NOT transitioned (still has original status)
+		var updated SagaInstance
+		db.First(&updated, "id = ?", saga.ID)
+		assert.Equal(t, SagaStatusRunning, updated.Status, "Active saga should keep RUNNING status")
+		assert.Equal(t, "active-pod", *updated.ClaimedByPod, "Active saga should keep original owner")
+	})
+
+	t.Run("does not transition completed sagas as zombies", func(t *testing.T) {
+		// Create completed saga with high replay count (should never be touched)
+		saga := createTestSagaWithReplayCount(t, db, SagaStatusCompleted, nil, nil, 20)
+
+		config := &ClaimConfig{
+			LeaseDuration: 5 * time.Minute,
+			BatchSize:     10,
+			MaxJitterMS:   0,
+			MaxReplays:    5,
+			PodID:         "test-pod-5",
+		}
+		service := NewClaimService(db, config)
+
+		claimed, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+		assert.NotContains(t, claimed, saga.ID)
+
+		// Verify saga status unchanged
+		var updated SagaInstance
+		db.First(&updated, "id = ?", saga.ID)
+		assert.Equal(t, SagaStatusCompleted, updated.Status, "Completed saga should stay completed")
+	})
+}
+
+// TestSagaClaimService_ReplayCountIncrement_Integration tests that replay_count is incremented on claim.
+func TestSagaClaimService_ReplayCountIncrement_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	t.Run("increments replay_count when claiming orphaned saga", func(t *testing.T) {
+		saga := createTestSagaWithReplayCount(t, db, SagaStatusRunning, nil, nil, 0)
+
+		config := &ClaimConfig{
+			LeaseDuration: 5 * time.Minute,
+			BatchSize:     10,
+			MaxJitterMS:   0,
+			MaxReplays:    5,
+			PodID:         "replay-test-pod",
+		}
+		service := NewClaimService(db, config)
+
+		claimed, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+		require.Contains(t, claimed, saga.ID)
+
+		var updated SagaInstance
+		db.First(&updated, "id = ?", saga.ID)
+		assert.Equal(t, 1, updated.ReplayCount, "replay_count should be incremented from 0 to 1")
+	})
+
+	t.Run("increments replay_count for each subsequent claim", func(t *testing.T) {
+		saga := createTestSagaWithReplayCount(t, db, SagaStatusRunning, nil, nil, 2)
+
+		config := &ClaimConfig{
+			LeaseDuration: 5 * time.Minute,
+			BatchSize:     10,
+			MaxJitterMS:   0,
+			MaxReplays:    5,
+			PodID:         "replay-test-pod-2",
+		}
+		service := NewClaimService(db, config)
+
+		// First claim
+		claimed1, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+		require.Contains(t, claimed1, saga.ID)
+
+		var after1 SagaInstance
+		db.First(&after1, "id = ?", saga.ID)
+		assert.Equal(t, 3, after1.ReplayCount, "Should increment from 2 to 3")
+
+		// Expire lease to allow re-claim
+		expiredLease := time.Now().Add(-1 * time.Minute)
+		db.Model(&SagaInstance{}).Where("id = ?", saga.ID).Updates(map[string]interface{}{
+			"lease_expires_at": expiredLease,
+		})
+
+		// Second claim
+		claimed2, err := service.ClaimOrphanedSagas(context.Background())
+		require.NoError(t, err)
+		require.Contains(t, claimed2, saga.ID)
+
+		var after2 SagaInstance
+		db.First(&after2, "id = ?", saga.ID)
+		assert.Equal(t, 4, after2.ReplayCount, "Should increment from 3 to 4")
+	})
+}
+
+// TestZombieDetection_AllActiveStatuses tests that zombie detection works for all active statuses.
+func TestZombieDetection_AllActiveStatuses_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	activeStatuses := []SagaStatus{
+		SagaStatusPending,
+		SagaStatusRunning,
+		SagaStatusCompensating,
+	}
+
+	for _, status := range activeStatuses {
+		t.Run(string(status), func(t *testing.T) {
+			zombieSaga := createTestSagaWithReplayCount(t, db, status, nil, nil, 10)
+
+			config := &ClaimConfig{
+				LeaseDuration: 5 * time.Minute,
+				BatchSize:     10,
+				MaxJitterMS:   0,
+				MaxReplays:    5,
+				PodID:         "status-test-pod",
+			}
+			service := NewClaimService(db, config)
+
+			claimed, err := service.ClaimOrphanedSagas(context.Background())
+			require.NoError(t, err)
+			assert.NotContains(t, claimed, zombieSaga.ID, "Zombie %s should not be claimed", status)
+
+			var updated SagaInstance
+			db.First(&updated, "id = ?", zombieSaga.ID)
+			assert.Equal(t, SagaStatusFailedManualIntervention, updated.Status,
+				"Zombie %s should be transitioned to FAILED_MANUAL_INTERVENTION", status)
+		})
+	}
+}
+
+// createTestSagaWithReplayCount is a helper to create test saga instances with a specific replay count.
+func createTestSagaWithReplayCount(t *testing.T, db *gorm.DB, status SagaStatus, leaseExpires *time.Time, claimedBy *string, replayCount int) *SagaInstance {
+	t.Helper()
+	saga := &SagaInstance{
+		ID:               uuid.New(),
+		SagaDefinitionID: uuid.New(),
+		Status:           status,
+		CorrelationID:    uuid.New(),
+		LeaseExpiresAt:   leaseExpires,
+		ClaimedByPod:     claimedBy,
+		ReplayCount:      replayCount,
+	}
+	err := db.Create(saga).Error
+	require.NoError(t, err)
+	return saga
+}


### PR DESCRIPTION
## Summary
- Implement zombie saga detection per FR-19 to prevent infinite retry loops
- Add replay_count tracking with automatic increment on saga claim/resume
- Transition zombie sagas (replay_count >= MaxReplays) to FAILED_MANUAL_INTERVENTION
- Add Prometheus metrics for monitoring zombie detection

## Changes Made
- **claiming.go**: Added MaxReplays config, transitionZombieSagas(), updated ClaimOrphanedSagas to increment replay_count and filter zombies
- **metrics.go**: New Prometheus metrics (saga_zombie_detected_total, saga_replay_count histogram, saga_replay_incremented_total)
- **zombie_test.go**: Comprehensive integration tests for zombie detection
- **metrics_test.go**: Unit tests for metrics
- **claiming_test.go**: Updated existing tests to include MaxReplays config

## Technical Details
**Configuration:**
- `SAGA_MAX_REPLAYS`: Maximum replay attempts before zombie detection (default: 5)

**Zombie Detection Flow:**
1. Before claiming, detect zombie sagas (orphaned + replay_count >= MaxReplays)
2. Transition zombies atomically to FAILED_MANUAL_INTERVENTION
3. Log error with saga_id, saga_definition_id, and replay_count
4. Record Prometheus metrics
5. Claim remaining healthy sagas with incremented replay_count

**Prometheus Metrics:**
- `saga_zombie_detected_total{saga_definition_id}`: Counter for zombie sagas
- `saga_replay_count`: Histogram of replay counts (buckets: 0, 1, 2, 3, 5, 10, 20)
- `saga_replay_incremented_total`: Counter for replay count increments

## Test Plan
- [x] Unit tests for MaxReplays configuration
- [x] Unit tests for Prometheus metrics
- [x] Integration test: zombie saga transitions to FAILED_MANUAL_INTERVENTION
- [x] Integration test: healthy saga still claimed while zombie transitions
- [x] Integration test: saga becomes zombie after exceeding threshold
- [x] Integration test: active lease sagas not mistakenly transitioned
- [x] Integration test: completed sagas not touched
- [x] Integration test: replay_count increment on each claim
- [x] Integration test: all active statuses (PENDING, RUNNING, COMPENSATING) trigger zombie detection
- [x] All existing claiming tests still pass

## Task Master
- Task: starlark-saga-orchestration.16