### PR TITLE
feat(saga): Add reference validation system with AST extraction

### DIFF
--- a/services/reference-data/saga/reference_validator.go
+++ b/services/reference-data/saga/reference_validator.go
@@ -1,0 +1,968 @@
+// Package saga provides saga definition management including reference validation.
+package saga
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	pkgsaga "github.com/meridianhub/meridian/shared/pkg/saga"
+	"go.starlark.net/syntax"
+)
+
+// Validation error types.
+var (
+	// ErrHandlerNotRegistered is returned when a step handler is not found in the registry.
+	ErrHandlerNotRegistered = errors.New("step handler not registered")
+
+	// ErrReferenceValidationFailed is returned when saga reference validation fails.
+	ErrReferenceValidationFailed = errors.New("reference validation failed")
+
+	// ErrPoolNotConfigured is returned when database pool is not configured for reference persistence.
+	ErrPoolNotConfigured = errors.New("database pool not configured")
+)
+
+// Validation status constants.
+const (
+	statusReady    = "READY"
+	statusWarnings = "WARNINGS"
+	statusBlocked  = "BLOCKED"
+)
+
+// Report icon constants.
+const (
+	iconOK      = "[OK]"
+	iconError   = "[X]"
+	iconWarning = "[!]"
+)
+
+// ReferenceType identifies the type of external reference in a saga script.
+type ReferenceType string
+
+const (
+	// ReferenceTypeStepHandler represents a reference to a registered step handler.
+	ReferenceTypeStepHandler ReferenceType = "step_handler"
+
+	// ReferenceTypeInstrument represents a reference to an instrument via resolve_instrument().
+	ReferenceTypeInstrument ReferenceType = "instrument"
+
+	// ReferenceTypeAccount represents a reference to an account via resolve_account().
+	ReferenceTypeAccount ReferenceType = "account"
+
+	// ReferenceTypeSaga represents a reference to another saga via invoke_saga().
+	ReferenceTypeSaga ReferenceType = "saga"
+
+	// ReferenceTypeAttribute represents a reference to an instrument attribute.
+	ReferenceTypeAttribute ReferenceType = "attribute"
+)
+
+// Reference represents an external reference extracted from a saga script.
+type Reference struct {
+	// Type identifies what kind of reference this is.
+	Type ReferenceType
+
+	// Key is the identifier for the reference (handler name, instrument code, etc.).
+	Key string
+
+	// LineNumber is the source line where this reference appears.
+	LineNumber int
+
+	// InstrumentCode is set for attribute references to indicate which instrument.
+	InstrumentCode string
+
+	// AttributeKey is set for attribute references to indicate the attribute name.
+	AttributeKey string
+}
+
+// ValidationError represents a validation issue found during reference checking.
+type ValidationError struct {
+	// Reference is the reference that failed validation.
+	Reference Reference
+
+	// Message describes the validation failure.
+	Message string
+
+	// Suggestion provides a hint for fixing the issue (e.g., "Did you mean...").
+	Suggestion string
+
+	// IsCritical indicates if this blocks activation (true) or is just a warning (false).
+	IsCritical bool
+}
+
+// ValidationResult contains the outcome of saga validation.
+type ValidationResult struct {
+	// Status summarizes the validation outcome: "READY", "WARNINGS", or "BLOCKED".
+	Status string
+
+	// Errors contains all validation issues found.
+	Errors []ValidationError
+
+	// References contains all extracted references from the script.
+	References []Reference
+}
+
+// FormatReport generates a human-readable validation report.
+//
+//nolint:gocognit // Report formatting has inherent complexity from multiple sections
+func (r *ValidationResult) FormatReport() string {
+	var b strings.Builder
+
+	b.WriteString("=== Saga Validation Report ===\n\n")
+
+	// Group errors by type
+	errorsByType := r.groupErrorsByType()
+
+	// Write each section
+	writeSection(&b, "Step Handlers", "All step handlers are registered", errorsByType[ReferenceTypeStepHandler])
+	writeSection(&b, "Instrument References", "All instrument references are valid", errorsByType[ReferenceTypeInstrument])
+	writeSection(&b, "Account References", "All account references are valid", errorsByType[ReferenceTypeAccount])
+	writeSection(&b, "Saga References", "All saga references are valid", errorsByType[ReferenceTypeSaga])
+	writeSection(&b, "Attribute References", "All attribute references are valid", errorsByType[ReferenceTypeAttribute])
+
+	// Summary
+	r.writeSummary(&b)
+
+	return b.String()
+}
+
+// groupErrorsByType groups validation errors by their reference type.
+func (r *ValidationResult) groupErrorsByType() map[ReferenceType][]ValidationError {
+	result := make(map[ReferenceType][]ValidationError)
+	for _, err := range r.Errors {
+		result[err.Reference.Type] = append(result[err.Reference.Type], err)
+	}
+	return result
+}
+
+// writeSection writes a single validation section to the builder.
+func writeSection(b *strings.Builder, title, okMessage string, errors []ValidationError) {
+	b.WriteString(title + ":\n")
+	if len(errors) == 0 {
+		_, _ = fmt.Fprintf(b, "  %s %s\n", iconOK, okMessage)
+	} else {
+		for _, err := range errors {
+			icon := iconWarning
+			if err.IsCritical {
+				icon = iconError
+			}
+			_, _ = fmt.Fprintf(b, "  %s Line %d: %s\n", icon, err.Reference.LineNumber, err.Message)
+			if err.Suggestion != "" {
+				_, _ = fmt.Fprintf(b, "      Suggestion: %s\n", err.Suggestion)
+			}
+		}
+	}
+	b.WriteString("\n")
+}
+
+// writeSummary writes the summary section to the builder.
+func (r *ValidationResult) writeSummary(b *strings.Builder) {
+	b.WriteString("=== Summary ===\n")
+	_, _ = fmt.Fprintf(b, "Status: %s\n", r.Status)
+	_, _ = fmt.Fprintf(b, "Total References: %d\n", len(r.References))
+
+	critical := 0
+	warnings := 0
+	for _, err := range r.Errors {
+		if err.IsCritical {
+			critical++
+		} else {
+			warnings++
+		}
+	}
+	_, _ = fmt.Fprintf(b, "Critical Errors: %d\n", critical)
+	_, _ = fmt.Fprintf(b, "Warnings: %d\n", warnings)
+}
+
+// InstrumentChecker provides methods to check instrument validity.
+type InstrumentChecker interface {
+	// InstrumentExists checks if an instrument with the given code exists.
+	InstrumentExists(ctx context.Context, code string) (bool, error)
+
+	// InstrumentIsActive checks if an instrument is in ACTIVE status.
+	InstrumentIsActive(ctx context.Context, code string) (bool, error)
+
+	// GetAttributeSchema returns the attribute schema for an instrument (nil if none).
+	GetAttributeSchema(ctx context.Context, code string) (map[string]interface{}, error)
+
+	// ListActiveInstrumentCodes returns all active instrument codes (for suggestions).
+	ListActiveInstrumentCodes(ctx context.Context) ([]string, error)
+}
+
+// DefinitionChecker provides methods to check saga definition validity.
+type DefinitionChecker interface {
+	// SagaExists checks if a saga with the given name exists (any status).
+	SagaExists(ctx context.Context, name string) (bool, error)
+
+	// SagaIsActive checks if a saga with the given name has an ACTIVE version.
+	SagaIsActive(ctx context.Context, name string) (bool, error)
+
+	// ListActiveSagaNames returns all active saga names (for suggestions).
+	ListActiveSagaNames(ctx context.Context) ([]string, error)
+}
+
+// ReferenceValidator validates saga scripts by extracting and checking references.
+type ReferenceValidator struct {
+	handlerRegistry   *pkgsaga.DomainHandlerRegistry
+	instrumentChecker InstrumentChecker
+	definitionChecker DefinitionChecker
+	pool              *pgxpool.Pool
+}
+
+// NewReferenceValidator creates a new reference validator.
+func NewReferenceValidator(
+	handlerRegistry *pkgsaga.DomainHandlerRegistry,
+	instrumentChecker InstrumentChecker,
+	definitionChecker DefinitionChecker,
+	pool *pgxpool.Pool,
+) *ReferenceValidator {
+	return &ReferenceValidator{
+		handlerRegistry:   handlerRegistry,
+		instrumentChecker: instrumentChecker,
+		definitionChecker: definitionChecker,
+		pool:              pool,
+	}
+}
+
+// ExtractReferences parses a Starlark script and extracts all external references.
+func (v *ReferenceValidator) ExtractReferences(script string) ([]Reference, error) {
+	if script == "" {
+		return nil, nil
+	}
+
+	// Parse the script
+	fileOpts := &syntax.FileOptions{}
+	file, err := fileOpts.Parse("script.star", script, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse script: %w", err)
+	}
+
+	// Walk the AST to extract references
+	extractor := &referenceExtractor{
+		references: make([]Reference, 0),
+	}
+
+	for _, stmt := range file.Stmts {
+		extractor.walkStmt(stmt)
+	}
+
+	return extractor.references, nil
+}
+
+// ValidateDraft validates a saga script for DRAFT status.
+// Returns warnings for missing references but allows save.
+// Populates saga_references table for impact analysis.
+func (v *ReferenceValidator) ValidateDraft(ctx context.Context, sagaID uuid.UUID, script string) (*ValidationResult, error) {
+	refs, err := v.ExtractReferences(script)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ValidationResult{
+		Status:     statusReady,
+		References: refs,
+		Errors:     make([]ValidationError, 0),
+	}
+
+	// Check each reference (collect warnings, don't fail)
+	for _, ref := range refs {
+		if err := v.checkReference(ctx, ref, false, result); err != nil {
+			return nil, err
+		}
+	}
+
+	// Update status based on errors
+	for _, err := range result.Errors {
+		if err.IsCritical {
+			result.Status = statusBlocked
+			break
+		}
+		result.Status = statusWarnings
+	}
+
+	// Persist references for impact analysis
+	if err := v.persistReferences(ctx, sagaID, refs); err != nil {
+		return nil, fmt.Errorf("failed to persist references: %w", err)
+	}
+
+	return result, nil
+}
+
+// ValidateActivation validates a saga for activation.
+// Re-validates ALL references (state may have changed since DRAFT).
+// Returns error if any reference is invalid.
+func (v *ReferenceValidator) ValidateActivation(ctx context.Context, sagaID uuid.UUID, script string) (*ValidationResult, error) {
+	refs, err := v.ExtractReferences(script)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ValidationResult{
+		Status:     statusReady,
+		References: refs,
+		Errors:     make([]ValidationError, 0),
+	}
+
+	// Check each reference (strict mode - all errors are critical)
+	for _, ref := range refs {
+		if err := v.checkReference(ctx, ref, true, result); err != nil {
+			return nil, err
+		}
+	}
+
+	// Update status based on errors
+	for _, err := range result.Errors {
+		if err.IsCritical {
+			result.Status = statusBlocked
+			break
+		}
+	}
+
+	// Update persisted references
+	if err := v.persistReferences(ctx, sagaID, refs); err != nil {
+		return nil, fmt.Errorf("failed to persist references: %w", err)
+	}
+
+	return result, nil
+}
+
+// ValidateRuntime performs lightweight validation before saga execution.
+// Verifies handlers are still registered.
+func (v *ReferenceValidator) ValidateRuntime(_ context.Context, def *Definition) error {
+	refs, err := v.ExtractReferences(def.Script)
+	if err != nil {
+		return err
+	}
+
+	// Only check step handlers for runtime validation (fast path)
+	for _, ref := range refs {
+		if ref.Type == ReferenceTypeStepHandler {
+			if !v.handlerRegistry.Has(ref.Key) {
+				return fmt.Errorf("%w: %s (line %d)", ErrHandlerNotRegistered, ref.Key, ref.LineNumber)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Validate implements the Validator interface for use with PostgresRegistry.
+func (v *ReferenceValidator) Validate(ctx context.Context, def *Definition) error {
+	result, err := v.ValidateActivation(ctx, def.ID, def.Script)
+	if err != nil {
+		return err
+	}
+
+	if result.Status == statusBlocked {
+		// Build error message from all critical errors
+		var msgs []string
+		for _, e := range result.Errors {
+			if e.IsCritical {
+				msgs = append(msgs, fmt.Sprintf("line %d: %s", e.Reference.LineNumber, e.Message))
+			}
+		}
+		return fmt.Errorf("%w: %s", ErrReferenceValidationFailed, strings.Join(msgs, "; "))
+	}
+
+	return nil
+}
+
+// DeprecationImpactAnalysis finds all sagas that reference a given instrument.
+func (v *ReferenceValidator) DeprecationImpactAnalysis(ctx context.Context, instrumentCode string) ([]Dependency, error) {
+	if v.pool == nil {
+		return nil, ErrPoolNotConfigured
+	}
+
+	query := `
+		SELECT sd.id, sd.name, sd.version, sd.status, sr.line_number
+		FROM saga_reference sr
+		JOIN saga_definition sd ON sd.id = sr.saga_definition_id
+		WHERE sr.reference_type = 'instrument' AND sr.reference_key = $1
+		   OR (sr.reference_type = 'attribute' AND sr.instrument_code = $1)
+		ORDER BY sd.name, sd.version`
+
+	rows, err := v.pool.Query(ctx, query, instrumentCode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query saga dependencies: %w", err)
+	}
+	defer rows.Close()
+
+	var deps []Dependency
+	for rows.Next() {
+		var dep Dependency
+		var status string
+		if err := rows.Scan(&dep.SagaID, &dep.SagaName, &dep.SagaVersion, &status, &dep.LineNumber); err != nil {
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+		dep.SagaStatus = Status(status)
+		deps = append(deps, dep)
+	}
+
+	return deps, rows.Err()
+}
+
+// Dependency represents a saga that depends on an external reference.
+type Dependency struct {
+	SagaID      uuid.UUID
+	SagaName    string
+	SagaVersion int
+	SagaStatus  Status
+	LineNumber  int
+}
+
+// checkReference validates a single reference and adds any errors to the result.
+//
+//nolint:gocognit // Reference checking has inherent complexity from multiple reference types
+func (v *ReferenceValidator) checkReference(ctx context.Context, ref Reference, strict bool, result *ValidationResult) error {
+	switch ref.Type {
+	case ReferenceTypeStepHandler:
+		v.checkStepHandler(ref, strict, result)
+	case ReferenceTypeInstrument:
+		if err := v.checkInstrument(ctx, ref, strict, result); err != nil {
+			return err
+		}
+	case ReferenceTypeSaga:
+		if err := v.checkSagaReference(ctx, ref, strict, result); err != nil {
+			return err
+		}
+	case ReferenceTypeAttribute:
+		if err := v.checkAttribute(ctx, ref, strict, result); err != nil {
+			return err
+		}
+
+	case ReferenceTypeAccount:
+		// Account validation would require an AccountChecker interface
+		// For now, we just collect the references without validation
+	}
+
+	return nil
+}
+
+// checkStepHandler validates a step handler reference.
+func (v *ReferenceValidator) checkStepHandler(ref Reference, strict bool, result *ValidationResult) {
+	if !v.handlerRegistry.Has(ref.Key) {
+		suggestion := v.suggestHandler(ref.Key)
+		result.Errors = append(result.Errors, ValidationError{
+			Reference:  ref,
+			Message:    fmt.Sprintf("step handler '%s' is not registered", ref.Key),
+			Suggestion: suggestion,
+			IsCritical: strict,
+		})
+	}
+}
+
+// checkInstrument validates an instrument reference.
+func (v *ReferenceValidator) checkInstrument(ctx context.Context, ref Reference, strict bool, result *ValidationResult) error {
+	if v.instrumentChecker == nil {
+		return nil
+	}
+
+	exists, err := v.instrumentChecker.InstrumentExists(ctx, ref.Key)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		suggestion := v.suggestInstrument(ctx, ref.Key)
+		result.Errors = append(result.Errors, ValidationError{
+			Reference:  ref,
+			Message:    fmt.Sprintf("instrument '%s' does not exist", ref.Key),
+			Suggestion: suggestion,
+			IsCritical: strict,
+		})
+		return nil
+	}
+
+	if strict {
+		active, err := v.instrumentChecker.InstrumentIsActive(ctx, ref.Key)
+		if err != nil {
+			return err
+		}
+		if !active {
+			result.Errors = append(result.Errors, ValidationError{
+				Reference:  ref,
+				Message:    fmt.Sprintf("instrument '%s' is not in ACTIVE status", ref.Key),
+				IsCritical: true,
+			})
+		}
+	}
+
+	return nil
+}
+
+// checkSagaReference validates a saga reference.
+func (v *ReferenceValidator) checkSagaReference(ctx context.Context, ref Reference, strict bool, result *ValidationResult) error {
+	if v.definitionChecker == nil {
+		return nil
+	}
+
+	exists, err := v.definitionChecker.SagaExists(ctx, ref.Key)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		suggestion := v.suggestSaga(ctx, ref.Key)
+		result.Errors = append(result.Errors, ValidationError{
+			Reference:  ref,
+			Message:    fmt.Sprintf("saga '%s' does not exist", ref.Key),
+			Suggestion: suggestion,
+			IsCritical: strict,
+		})
+		return nil
+	}
+
+	if strict {
+		active, err := v.definitionChecker.SagaIsActive(ctx, ref.Key)
+		if err != nil {
+			return err
+		}
+		if !active {
+			result.Errors = append(result.Errors, ValidationError{
+				Reference:  ref,
+				Message:    fmt.Sprintf("saga '%s' does not have an ACTIVE version", ref.Key),
+				IsCritical: true,
+			})
+		}
+	}
+
+	return nil
+}
+
+// checkAttribute validates an attribute reference.
+func (v *ReferenceValidator) checkAttribute(ctx context.Context, ref Reference, strict bool, result *ValidationResult) error {
+	if v.instrumentChecker == nil || ref.InstrumentCode == "" {
+		return nil
+	}
+
+	schema, err := v.instrumentChecker.GetAttributeSchema(ctx, ref.InstrumentCode)
+	if err != nil {
+		return err
+	}
+
+	if schema != nil {
+		if _, ok := schema[ref.AttributeKey]; !ok {
+			suggestion := v.suggestAttribute(schema, ref.AttributeKey)
+			result.Errors = append(result.Errors, ValidationError{
+				Reference:  ref,
+				Message:    fmt.Sprintf("attribute '%s' not found in instrument '%s' schema", ref.AttributeKey, ref.InstrumentCode),
+				Suggestion: suggestion,
+				IsCritical: strict,
+			})
+		}
+	}
+
+	return nil
+}
+
+// suggestHandler finds a similar handler name for suggestions.
+func (v *ReferenceValidator) suggestHandler(name string) string {
+	handlers := v.handlerRegistry.List()
+	if match := findSimilar(name, handlers); match != "" {
+		return fmt.Sprintf("Did you mean '%s'?", match)
+	}
+	return ""
+}
+
+// suggestInstrument finds a similar instrument code for suggestions.
+func (v *ReferenceValidator) suggestInstrument(ctx context.Context, code string) string {
+	if v.instrumentChecker == nil {
+		return ""
+	}
+	codes, err := v.instrumentChecker.ListActiveInstrumentCodes(ctx)
+	if err != nil {
+		return ""
+	}
+	if match := findSimilar(code, codes); match != "" {
+		return fmt.Sprintf("Did you mean '%s'?", match)
+	}
+	return ""
+}
+
+// suggestSaga finds a similar saga name for suggestions.
+func (v *ReferenceValidator) suggestSaga(ctx context.Context, name string) string {
+	if v.definitionChecker == nil {
+		return ""
+	}
+	names, err := v.definitionChecker.ListActiveSagaNames(ctx)
+	if err != nil {
+		return ""
+	}
+	if match := findSimilar(name, names); match != "" {
+		return fmt.Sprintf("Did you mean '%s'?", match)
+	}
+	return ""
+}
+
+// suggestAttribute finds a similar attribute key for suggestions.
+func (v *ReferenceValidator) suggestAttribute(schema map[string]interface{}, key string) string {
+	keys := make([]string, 0, len(schema))
+	for k := range schema {
+		keys = append(keys, k)
+	}
+	if match := findSimilar(key, keys); match != "" {
+		return fmt.Sprintf("Did you mean '%s'?", match)
+	}
+	return ""
+}
+
+// findSimilar finds the most similar string in candidates using Levenshtein distance.
+func findSimilar(target string, candidates []string) string {
+	if len(candidates) == 0 {
+		return ""
+	}
+
+	target = strings.ToLower(target)
+	var bestMatch string
+	bestScore := -1
+
+	for _, candidate := range candidates {
+		score := similarity(target, strings.ToLower(candidate))
+		if score > bestScore {
+			bestScore = score
+			bestMatch = candidate
+		}
+	}
+
+	// Only suggest if similarity is above threshold (at least 50% similar)
+	if bestScore >= len(target)/2 {
+		return bestMatch
+	}
+	return ""
+}
+
+// similarity calculates the similarity between two strings.
+// Returns higher scores for more similar strings.
+func similarity(a, b string) int {
+	if a == b {
+		return len(a) * 2
+	}
+
+	// Simple prefix/suffix matching
+	score := 0
+
+	// Common prefix
+	minLen := len(a)
+	if len(b) < minLen {
+		minLen = len(b)
+	}
+	for i := 0; i < minLen && a[i] == b[i]; i++ {
+		score++
+	}
+
+	// Common suffix (only if different from prefix)
+	for i := 1; i <= minLen && a[len(a)-i] == b[len(b)-i]; i++ {
+		if len(a)-i >= score || len(b)-i >= score { // Don't double-count
+			score++
+		}
+	}
+
+	// Substring matching
+	if strings.Contains(a, b) || strings.Contains(b, a) {
+		score += minLen / 2
+	}
+
+	return score
+}
+
+// persistReferences saves extracted references to the saga_reference table.
+func (v *ReferenceValidator) persistReferences(ctx context.Context, sagaID uuid.UUID, refs []Reference) error {
+	if v.pool == nil {
+		return nil // No database configured, skip persistence
+	}
+
+	// Start a transaction
+	tx, err := v.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	// Delete existing references for this saga
+	_, err = tx.Exec(ctx, "DELETE FROM saga_reference WHERE saga_definition_id = $1", sagaID)
+	if err != nil {
+		return fmt.Errorf("failed to delete existing references: %w", err)
+	}
+
+	// Insert new references
+	for _, ref := range refs {
+		_, err = tx.Exec(ctx, `
+			INSERT INTO saga_reference (saga_definition_id, reference_type, reference_key, instrument_code, attribute_key, line_number)
+			VALUES ($1, $2, $3, $4, $5, $6)
+			ON CONFLICT (saga_definition_id, reference_type, reference_key) DO UPDATE
+			SET instrument_code = EXCLUDED.instrument_code,
+				attribute_key = EXCLUDED.attribute_key,
+				line_number = EXCLUDED.line_number,
+				extracted_at = now()`,
+			sagaID, string(ref.Type), ref.Key, nullString(ref.InstrumentCode), nullString(ref.AttributeKey), ref.LineNumber)
+		if err != nil {
+			return fmt.Errorf("failed to insert reference: %w", err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// referenceExtractor walks the Starlark AST to extract references.
+type referenceExtractor struct {
+	references []Reference
+}
+
+// walkStmt walks a statement node.
+func (e *referenceExtractor) walkStmt(stmt syntax.Stmt) {
+	switch s := stmt.(type) {
+	case *syntax.ExprStmt:
+		e.walkExpr(s.X)
+
+	case *syntax.AssignStmt:
+		e.walkExpr(s.LHS)
+		e.walkExpr(s.RHS)
+
+	case *syntax.DefStmt:
+		for _, stmt := range s.Body {
+			e.walkStmt(stmt)
+		}
+
+	case *syntax.IfStmt:
+		e.walkExpr(s.Cond)
+		for _, stmt := range s.True {
+			e.walkStmt(stmt)
+		}
+		for _, stmt := range s.False {
+			e.walkStmt(stmt)
+		}
+
+	case *syntax.ForStmt:
+		e.walkExpr(s.X)
+		for _, stmt := range s.Body {
+			e.walkStmt(stmt)
+		}
+
+	case *syntax.WhileStmt:
+		e.walkExpr(s.Cond)
+		for _, stmt := range s.Body {
+			e.walkStmt(stmt)
+		}
+
+	case *syntax.ReturnStmt:
+		if s.Result != nil {
+			e.walkExpr(s.Result)
+		}
+	}
+}
+
+// walkExpr walks an expression node and extracts references.
+//
+//nolint:gocognit,gocyclo // AST walking requires handling many expression types
+func (e *referenceExtractor) walkExpr(expr syntax.Expr) {
+	if expr == nil {
+		return
+	}
+
+	switch ex := expr.(type) {
+	case *syntax.CallExpr:
+		// Check for specific function calls
+		if ident, ok := ex.Fn.(*syntax.Ident); ok {
+			switch ident.Name {
+			case "resolve_instrument":
+				// Extract instrument code from first argument
+				if len(ex.Args) > 0 {
+					if lit, ok := ex.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
+						// Remove quotes from string literal
+						code := strings.Trim(lit.Raw, `"'`)
+						e.references = append(e.references, Reference{
+							Type:       ReferenceTypeInstrument,
+							Key:        code,
+							LineNumber: int(ident.NamePos.Line),
+						})
+					}
+				}
+
+			case "resolve_account":
+				// Extract account reference from first argument
+				if len(ex.Args) > 0 {
+					if lit, ok := ex.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
+						code := strings.Trim(lit.Raw, `"'`)
+						e.references = append(e.references, Reference{
+							Type:       ReferenceTypeAccount,
+							Key:        code,
+							LineNumber: int(ident.NamePos.Line),
+						})
+					}
+				}
+
+			case "invoke_saga":
+				// Extract saga name from first argument (positional or keyword "saga_name")
+				var sagaName string
+				lineNum := int(ident.NamePos.Line)
+
+				// Check positional arguments first
+				if len(ex.Args) > 0 {
+					if lit, ok := ex.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
+						sagaName = strings.Trim(lit.Raw, `"'`)
+					}
+				}
+
+				if sagaName != "" {
+					e.references = append(e.references, Reference{
+						Type:       ReferenceTypeSaga,
+						Key:        sagaName,
+						LineNumber: lineNum,
+					})
+				}
+
+			case "step":
+				// Extract step handler from 'action' keyword argument
+				for _, kwarg := range ex.Args {
+					if binExpr, ok := kwarg.(*syntax.BinaryExpr); ok && binExpr.Op == syntax.EQ {
+						if nameIdent, ok := binExpr.X.(*syntax.Ident); ok && nameIdent.Name == "action" {
+							if lit, ok := binExpr.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
+								handler := strings.Trim(lit.Raw, `"'`)
+								e.references = append(e.references, Reference{
+									Type:       ReferenceTypeStepHandler,
+									Key:        handler,
+									LineNumber: int(ident.NamePos.Line),
+								})
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Walk function expression and arguments
+		e.walkExpr(ex.Fn)
+		for _, arg := range ex.Args {
+			e.walkExpr(arg)
+		}
+
+	case *syntax.IndexExpr:
+		// Check for attribute access pattern: ctx.position.attributes["key"]
+		// or instrument.attributes["key"]
+		e.walkExpr(ex.X)
+		e.walkExpr(ex.Y)
+
+		// Try to extract attribute reference
+		if e.isAttributeAccess(ex) {
+			if lit, ok := ex.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
+				attrKey := strings.Trim(lit.Raw, `"'`)
+				// Try to extract instrument code from the expression
+				instrumentCode := e.extractInstrumentCode(ex.X)
+				e.references = append(e.references, Reference{
+					Type:           ReferenceTypeAttribute,
+					Key:            attrKey,
+					AttributeKey:   attrKey,
+					InstrumentCode: instrumentCode,
+					LineNumber:     int(lit.TokenPos.Line),
+				})
+			}
+		}
+
+	case *syntax.BinaryExpr:
+		e.walkExpr(ex.X)
+		e.walkExpr(ex.Y)
+
+	case *syntax.UnaryExpr:
+		e.walkExpr(ex.X)
+
+	case *syntax.CondExpr:
+		e.walkExpr(ex.Cond)
+		e.walkExpr(ex.True)
+		e.walkExpr(ex.False)
+
+	case *syntax.SliceExpr:
+		e.walkExpr(ex.X)
+		e.walkExpr(ex.Lo)
+		e.walkExpr(ex.Hi)
+		e.walkExpr(ex.Step)
+
+	case *syntax.ListExpr:
+		for _, elem := range ex.List {
+			e.walkExpr(elem)
+		}
+
+	case *syntax.DictExpr:
+		for _, entry := range ex.List {
+			if dictEntry, ok := entry.(*syntax.DictEntry); ok {
+				e.walkExpr(dictEntry.Key)
+				e.walkExpr(dictEntry.Value)
+			}
+		}
+
+	case *syntax.TupleExpr:
+		for _, elem := range ex.List {
+			e.walkExpr(elem)
+		}
+
+	case *syntax.Comprehension:
+		for _, clause := range ex.Clauses {
+			if forClause, ok := clause.(*syntax.ForClause); ok {
+				e.walkExpr(forClause.X)
+			}
+			if ifClause, ok := clause.(*syntax.IfClause); ok {
+				e.walkExpr(ifClause.Cond)
+			}
+		}
+		e.walkExpr(ex.Body)
+
+	case *syntax.LambdaExpr:
+		e.walkExpr(ex.Body)
+
+	case *syntax.DotExpr:
+		e.walkExpr(ex.X)
+
+	case *syntax.ParenExpr:
+		e.walkExpr(ex.X)
+	}
+}
+
+// isAttributeAccess checks if an index expression is accessing .attributes[...]
+func (e *referenceExtractor) isAttributeAccess(expr *syntax.IndexExpr) bool {
+	if dotExpr, ok := expr.X.(*syntax.DotExpr); ok {
+		return dotExpr.Name.Name == "attributes"
+	}
+	return false
+}
+
+// extractInstrumentCode tries to extract instrument code from attribute access context.
+//
+//nolint:gocognit // Nested type assertions for AST pattern matching have inherent complexity
+func (e *referenceExtractor) extractInstrumentCode(expr syntax.Expr) string {
+	// Look for patterns like:
+	// - instrument.attributes["key"] where instrument is a variable
+	// - ctx.instrument.attributes["key"]
+	// - resolve_instrument("CODE").attributes["key"]
+
+	if dotExpr, ok := expr.(*syntax.DotExpr); ok {
+		if dotExpr.Name.Name == "attributes" {
+			// Check if the base is a call to resolve_instrument
+			if callExpr, ok := dotExpr.X.(*syntax.CallExpr); ok {
+				if ident, ok := callExpr.Fn.(*syntax.Ident); ok && ident.Name == "resolve_instrument" {
+					if len(callExpr.Args) > 0 {
+						if lit, ok := callExpr.Args[0].(*syntax.Literal); ok && lit.Token == syntax.STRING {
+							return strings.Trim(lit.Raw, `"'`)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+// ListHandlers returns all registered handler names sorted alphabetically.
+func (v *ReferenceValidator) ListHandlers() []string {
+	handlers := v.handlerRegistry.List()
+	sort.Strings(handlers)
+	return handlers
+}

--- a/services/reference-data/saga/reference_validator_test.go
+++ b/services/reference-data/saga/reference_validator_test.go
@@ -1,0 +1,638 @@
+package saga
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	pkgsaga "github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockInstrumentChecker implements InstrumentChecker for testing.
+type mockInstrumentChecker struct {
+	instruments      map[string]bool // code -> isActive
+	attributeSchemas map[string]map[string]interface{}
+	existsError      error
+	activeError      error
+	schemaError      error
+	listCodesError   error
+}
+
+func newMockInstrumentChecker() *mockInstrumentChecker {
+	return &mockInstrumentChecker{
+		instruments:      make(map[string]bool),
+		attributeSchemas: make(map[string]map[string]interface{}),
+	}
+}
+
+func (m *mockInstrumentChecker) InstrumentExists(_ context.Context, code string) (bool, error) {
+	if m.existsError != nil {
+		return false, m.existsError
+	}
+	_, exists := m.instruments[code]
+	return exists, nil
+}
+
+func (m *mockInstrumentChecker) InstrumentIsActive(_ context.Context, code string) (bool, error) {
+	if m.activeError != nil {
+		return false, m.activeError
+	}
+	active, exists := m.instruments[code]
+	return exists && active, nil
+}
+
+func (m *mockInstrumentChecker) GetAttributeSchema(_ context.Context, code string) (map[string]interface{}, error) {
+	if m.schemaError != nil {
+		return nil, m.schemaError
+	}
+	return m.attributeSchemas[code], nil
+}
+
+func (m *mockInstrumentChecker) ListActiveInstrumentCodes(_ context.Context) ([]string, error) {
+	if m.listCodesError != nil {
+		return nil, m.listCodesError
+	}
+	var codes []string
+	for code, active := range m.instruments {
+		if active {
+			codes = append(codes, code)
+		}
+	}
+	return codes, nil
+}
+
+// mockDefinitionChecker implements SagaChecker for testing.
+type mockDefinitionChecker struct {
+	sagas          map[string]bool // name -> isActive
+	existsError    error
+	activeError    error
+	listNamesError error
+}
+
+func newMockDefinitionChecker() *mockDefinitionChecker {
+	return &mockDefinitionChecker{
+		sagas: make(map[string]bool),
+	}
+}
+
+func (m *mockDefinitionChecker) SagaExists(_ context.Context, name string) (bool, error) {
+	if m.existsError != nil {
+		return false, m.existsError
+	}
+	_, exists := m.sagas[name]
+	return exists, nil
+}
+
+func (m *mockDefinitionChecker) SagaIsActive(_ context.Context, name string) (bool, error) {
+	if m.activeError != nil {
+		return false, m.activeError
+	}
+	active, exists := m.sagas[name]
+	return exists && active, nil
+}
+
+func (m *mockDefinitionChecker) ListActiveSagaNames(_ context.Context) ([]string, error) {
+	if m.listNamesError != nil {
+		return nil, m.listNamesError
+	}
+	var names []string
+	for name, active := range m.sagas {
+		if active {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+func TestExtractReferences_Empty(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	refs, err := v.ExtractReferences("")
+	require.NoError(t, err)
+	assert.Empty(t, refs)
+}
+
+func TestExtractReferences_InstrumentReferences(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def my_saga():
+    instrument = resolve_instrument("KWH")
+    other = resolve_instrument("USD")
+    return instrument
+`
+	refs, err := v.ExtractReferences(script)
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+
+	assert.Equal(t, ReferenceTypeInstrument, refs[0].Type)
+	assert.Equal(t, "KWH", refs[0].Key)
+	assert.Equal(t, 3, refs[0].LineNumber)
+
+	assert.Equal(t, ReferenceTypeInstrument, refs[1].Type)
+	assert.Equal(t, "USD", refs[1].Key)
+	assert.Equal(t, 4, refs[1].LineNumber)
+}
+
+func TestExtractReferences_AccountReferences(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def my_saga():
+    account = resolve_account("clearing_GBP")
+    other = resolve_account("settlement_EUR")
+    return account
+`
+	refs, err := v.ExtractReferences(script)
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+
+	assert.Equal(t, ReferenceTypeAccount, refs[0].Type)
+	assert.Equal(t, "clearing_GBP", refs[0].Key)
+	assert.Equal(t, 3, refs[0].LineNumber)
+
+	assert.Equal(t, ReferenceTypeAccount, refs[1].Type)
+	assert.Equal(t, "settlement_EUR", refs[1].Key)
+	assert.Equal(t, 4, refs[1].LineNumber)
+}
+
+func TestExtractReferences_SagaReferences(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def my_saga():
+    invoke_saga("withdrawal")
+    invoke_saga("deposit")
+`
+	refs, err := v.ExtractReferences(script)
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+
+	assert.Equal(t, ReferenceTypeSaga, refs[0].Type)
+	assert.Equal(t, "withdrawal", refs[0].Key)
+	assert.Equal(t, 3, refs[0].LineNumber)
+
+	assert.Equal(t, ReferenceTypeSaga, refs[1].Type)
+	assert.Equal(t, "deposit", refs[1].Key)
+	assert.Equal(t, 4, refs[1].LineNumber)
+}
+
+func TestExtractReferences_StepHandlerReferences(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def my_saga():
+    step(name="init", action="position_keeping.initiate_log")
+    step(name="post", action="financial_accounting.post_entries")
+`
+	refs, err := v.ExtractReferences(script)
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+
+	assert.Equal(t, ReferenceTypeStepHandler, refs[0].Type)
+	assert.Equal(t, "position_keeping.initiate_log", refs[0].Key)
+	assert.Equal(t, 3, refs[0].LineNumber)
+
+	assert.Equal(t, ReferenceTypeStepHandler, refs[1].Type)
+	assert.Equal(t, "financial_accounting.post_entries", refs[1].Key)
+	assert.Equal(t, 4, refs[1].LineNumber)
+}
+
+func TestExtractReferences_AttributeReferences(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def my_saga(ctx):
+    value = ctx.position.attributes["meter_reading"]
+    other = ctx.instrument.attributes["serial_number"]
+`
+	refs, err := v.ExtractReferences(script)
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+
+	assert.Equal(t, ReferenceTypeAttribute, refs[0].Type)
+	assert.Equal(t, "meter_reading", refs[0].AttributeKey)
+	assert.Equal(t, 3, refs[0].LineNumber)
+
+	assert.Equal(t, ReferenceTypeAttribute, refs[1].Type)
+	assert.Equal(t, "serial_number", refs[1].AttributeKey)
+	assert.Equal(t, 4, refs[1].LineNumber)
+}
+
+func TestExtractReferences_AllTypes(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def my_saga(ctx):
+    # Step handler
+    step(name="init", action="position_keeping.initiate_log")
+
+    # Instrument
+    instrument = resolve_instrument("KWH")
+
+    # Account
+    account = resolve_account("clearing_GBP")
+
+    # Saga
+    invoke_saga("withdrawal")
+
+    # Attribute
+    value = ctx.position.attributes["meter_reading"]
+`
+	refs, err := v.ExtractReferences(script)
+	require.NoError(t, err)
+	require.Len(t, refs, 5)
+
+	// Verify all types are present
+	types := make(map[ReferenceType]bool)
+	for _, ref := range refs {
+		types[ref.Type] = true
+	}
+
+	assert.True(t, types[ReferenceTypeStepHandler])
+	assert.True(t, types[ReferenceTypeInstrument])
+	assert.True(t, types[ReferenceTypeAccount])
+	assert.True(t, types[ReferenceTypeSaga])
+	assert.True(t, types[ReferenceTypeAttribute])
+}
+
+func TestExtractReferences_SyntaxError(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def my_saga(
+    # Missing closing parenthesis
+`
+	_, err := v.ExtractReferences(script)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse script")
+}
+
+func TestValidateDraft_AllowsWarnings(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	instrumentChecker := newMockInstrumentChecker()
+	// KWH exists but is not active
+	instrumentChecker.instruments["KWH"] = false
+
+	v := NewReferenceValidator(registry, instrumentChecker, nil, nil)
+
+	script := `
+def my_saga():
+    instrument = resolve_instrument("KWH")
+    missing = resolve_instrument("NONEXISTENT")
+`
+	result, err := v.ValidateDraft(context.Background(), uuid.New(), script)
+	require.NoError(t, err)
+
+	// Should have warnings but still be allowed (not BLOCKED)
+	assert.Equal(t, "WARNINGS", result.Status)
+	assert.Len(t, result.Errors, 1) // Only NONEXISTENT doesn't exist
+
+	// The error should be a warning, not critical
+	assert.False(t, result.Errors[0].IsCritical)
+	assert.Equal(t, "NONEXISTENT", result.Errors[0].Reference.Key)
+}
+
+func TestValidateActivation_BlocksOnMissingHandler(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	// Don't register any handlers
+
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def my_saga():
+    step(name="init", action="nonexistent_handler")
+`
+	result, err := v.ValidateActivation(context.Background(), uuid.New(), script)
+	require.NoError(t, err)
+
+	assert.Equal(t, "BLOCKED", result.Status)
+	require.Len(t, result.Errors, 1)
+	assert.True(t, result.Errors[0].IsCritical)
+	assert.Contains(t, result.Errors[0].Message, "nonexistent_handler")
+}
+
+func TestValidateActivation_BlocksOnDeprecatedInstrument(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	instrumentChecker := newMockInstrumentChecker()
+	// KWH exists but is not active (deprecated)
+	instrumentChecker.instruments["KWH"] = false
+
+	v := NewReferenceValidator(registry, instrumentChecker, nil, nil)
+
+	script := `
+def my_saga():
+    instrument = resolve_instrument("KWH")
+`
+	result, err := v.ValidateActivation(context.Background(), uuid.New(), script)
+	require.NoError(t, err)
+
+	assert.Equal(t, "BLOCKED", result.Status)
+	require.Len(t, result.Errors, 1)
+	assert.True(t, result.Errors[0].IsCritical)
+	assert.Contains(t, result.Errors[0].Message, "not in ACTIVE status")
+}
+
+func TestValidateActivation_BlocksOnMissingSaga(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	sagaChecker := newMockDefinitionChecker()
+	// No sagas registered
+
+	v := NewReferenceValidator(registry, nil, sagaChecker, nil)
+
+	script := `
+def my_saga():
+    invoke_saga("nonexistent_saga")
+`
+	result, err := v.ValidateActivation(context.Background(), uuid.New(), script)
+	require.NoError(t, err)
+
+	assert.Equal(t, "BLOCKED", result.Status)
+	require.Len(t, result.Errors, 1)
+	assert.True(t, result.Errors[0].IsCritical)
+	assert.Contains(t, result.Errors[0].Message, "does not exist")
+}
+
+func TestValidateActivation_BlocksOnInactiveSaga(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	sagaChecker := newMockDefinitionChecker()
+	sagaChecker.sagas["withdrawal"] = false // exists but not active
+
+	v := NewReferenceValidator(registry, nil, sagaChecker, nil)
+
+	script := `
+def my_saga():
+    invoke_saga("withdrawal")
+`
+	result, err := v.ValidateActivation(context.Background(), uuid.New(), script)
+	require.NoError(t, err)
+
+	assert.Equal(t, "BLOCKED", result.Status)
+	require.Len(t, result.Errors, 1)
+	assert.True(t, result.Errors[0].IsCritical)
+	assert.Contains(t, result.Errors[0].Message, "does not have an ACTIVE version")
+}
+
+func TestValidateActivation_BlocksOnMissingAttribute(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	instrumentChecker := newMockInstrumentChecker()
+	instrumentChecker.instruments["KWH"] = true
+	instrumentChecker.attributeSchemas["KWH"] = map[string]interface{}{
+		"meter_id":  "string",
+		"reading":   "decimal",
+		"timestamp": "datetime",
+	}
+
+	v := NewReferenceValidator(registry, instrumentChecker, nil, nil)
+
+	script := `
+def my_saga():
+    # Typo in attribute name
+    value = resolve_instrument("KWH").attributes["meteer_reading"]
+`
+	result, err := v.ValidateActivation(context.Background(), uuid.New(), script)
+	require.NoError(t, err)
+
+	// Should find the attribute reference with a typo
+	assert.Equal(t, "BLOCKED", result.Status)
+	require.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0].Message, "not found in instrument")
+}
+
+func TestValidateActivation_SuggestsSimilarNames(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	_ = registry.Register("position_keeping.initiate_log", nil)
+	_ = registry.Register("position_keeping.update_log", nil)
+	_ = registry.Register("financial_accounting.post_entries", nil)
+
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def my_saga():
+    # Typo - missing underscore
+    step(name="init", action="positionkeeping.initiate_log")
+`
+	result, err := v.ValidateActivation(context.Background(), uuid.New(), script)
+	require.NoError(t, err)
+
+	assert.Equal(t, "BLOCKED", result.Status)
+	require.Len(t, result.Errors, 1)
+	// Should suggest similar handler
+	assert.Contains(t, result.Errors[0].Suggestion, "position_keeping")
+}
+
+func TestValidateActivation_PassesWithValidReferences(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	_ = registry.Register("position_keeping.initiate_log", nil)
+
+	instrumentChecker := newMockInstrumentChecker()
+	instrumentChecker.instruments["KWH"] = true
+
+	sagaChecker := newMockDefinitionChecker()
+	sagaChecker.sagas["withdrawal"] = true
+
+	v := NewReferenceValidator(registry, instrumentChecker, sagaChecker, nil)
+
+	script := `
+def my_saga():
+    step(name="init", action="position_keeping.initiate_log")
+    instrument = resolve_instrument("KWH")
+    invoke_saga("withdrawal")
+`
+	result, err := v.ValidateActivation(context.Background(), uuid.New(), script)
+	require.NoError(t, err)
+
+	assert.Equal(t, "READY", result.Status)
+	assert.Empty(t, result.Errors)
+	assert.Len(t, result.References, 3)
+}
+
+func TestValidateRuntime_ChecksHandlersOnly(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	_ = registry.Register("position_keeping.initiate_log", nil)
+
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	// Script with valid handler
+	def := &Definition{
+		ID:     uuid.New(),
+		Script: `step(name="init", action="position_keeping.initiate_log")`,
+	}
+
+	err := v.ValidateRuntime(context.Background(), def)
+	require.NoError(t, err)
+
+	// Script with invalid handler
+	def.Script = `step(name="init", action="nonexistent_handler")`
+	err = v.ValidateRuntime(context.Background(), def)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "step handler not registered")
+}
+
+func TestValidationResult_FormatReport(t *testing.T) {
+	result := &ValidationResult{
+		Status: "BLOCKED",
+		References: []Reference{
+			{Type: ReferenceTypeStepHandler, Key: "handler1", LineNumber: 5},
+			{Type: ReferenceTypeInstrument, Key: "KWH", LineNumber: 10},
+		},
+		Errors: []ValidationError{
+			{
+				Reference:  Reference{Type: ReferenceTypeStepHandler, Key: "bad_handler", LineNumber: 15},
+				Message:    "step handler 'bad_handler' is not registered",
+				Suggestion: "Did you mean 'position_keeping.initiate_log'?",
+				IsCritical: true,
+			},
+			{
+				Reference:  Reference{Type: ReferenceTypeInstrument, Key: "XYZ", LineNumber: 20},
+				Message:    "instrument 'XYZ' does not exist",
+				IsCritical: false,
+			},
+		},
+	}
+
+	report := result.FormatReport()
+
+	// Check report contains expected sections
+	assert.Contains(t, report, "=== Saga Validation Report ===")
+	assert.Contains(t, report, "Step Handlers:")
+	assert.Contains(t, report, "Instrument References:")
+	assert.Contains(t, report, "[X]") // Critical error icon
+	assert.Contains(t, report, "[!]") // Warning icon
+	assert.Contains(t, report, "bad_handler")
+	assert.Contains(t, report, "Did you mean")
+	assert.Contains(t, report, "Status: BLOCKED")
+	assert.Contains(t, report, "Critical Errors: 1")
+	assert.Contains(t, report, "Warnings: 1")
+}
+
+func TestValidator_ImplementsValidatorInterface(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	_ = registry.Register("position_keeping.initiate_log", nil)
+
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	def := &Definition{
+		ID:     uuid.New(),
+		Script: `step(name="init", action="position_keeping.initiate_log")`,
+	}
+
+	// Should satisfy the Validator interface
+	err := v.Validate(context.Background(), def)
+	require.NoError(t, err)
+
+	// Invalid script should return error
+	def.Script = `step(name="init", action="nonexistent")`
+	err = v.Validate(context.Background(), def)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validation failed")
+}
+
+func TestExtractReferences_NestedExpressions(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def my_saga(ctx):
+    if ctx.amount > 100:
+        instrument = resolve_instrument("USD")
+    else:
+        instrument = resolve_instrument("EUR")
+
+    for i in range(10):
+        step(name="process_" + str(i), action="financial_accounting.post_entries")
+`
+	refs, err := v.ExtractReferences(script)
+	require.NoError(t, err)
+
+	// Should find all references in nested structures
+	instrumentRefs := 0
+	handlerRefs := 0
+	for _, ref := range refs {
+		if ref.Type == ReferenceTypeInstrument {
+			instrumentRefs++
+		}
+		if ref.Type == ReferenceTypeStepHandler {
+			handlerRefs++
+		}
+	}
+	assert.Equal(t, 2, instrumentRefs)
+	assert.Equal(t, 1, handlerRefs)
+}
+
+func TestExtractReferences_ListComprehension(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def my_saga():
+    codes = ["USD", "EUR", "GBP"]
+    instruments = [resolve_instrument(code) for code in codes]
+`
+	refs, err := v.ExtractReferences(script)
+	require.NoError(t, err)
+
+	// resolve_instrument is called with a variable, not a literal
+	// So we won't extract a reference (can't determine the value statically)
+	assert.Empty(t, refs)
+}
+
+func TestFindSimilar(t *testing.T) {
+	tests := []struct {
+		target     string
+		candidates []string
+		want       string
+	}{
+		{
+			target:     "position_keeping.initiate",
+			candidates: []string{"position_keeping.initiate_log", "position_keeping.update_log"},
+			want:       "position_keeping.initiate_log",
+		},
+		{
+			target:     "positionkeeping.initiate_log",
+			candidates: []string{"position_keeping.initiate_log", "financial_accounting.post_entries"},
+			want:       "position_keeping.initiate_log",
+		},
+		{
+			target:     "completely_different",
+			candidates: []string{"position_keeping.initiate_log"},
+			want:       "", // No good match
+		},
+		{
+			target:     "usd",
+			candidates: []string{"USD", "EUR", "GBP"},
+			want:       "USD",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			got := findSimilar(tt.target, tt.candidates)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestListHandlers(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	_ = registry.Register("z_handler", nil)
+	_ = registry.Register("a_handler", nil)
+	_ = registry.Register("m_handler", nil)
+
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	handlers := v.ListHandlers()
+
+	// Should be sorted alphabetically
+	assert.Equal(t, []string{"a_handler", "m_handler", "z_handler"}, handlers)
+}


### PR DESCRIPTION
## Summary

- Implements reference validation system for Starlark saga scripts (Task starlark-saga-orchestration.4)
- AST-based extraction of external references from saga scripts
- Three-phase validation: DRAFT (warnings), ACTIVATION (strict), RUNTIME (fast fail)

## Changes Made

- `services/reference-data/saga/reference_validator.go`: New ReferenceValidator struct that:
  - Parses Starlark scripts and extracts references to step handlers, instruments, accounts, sagas, and attributes
  - Validates references at DRAFT phase (collect warnings, allow save)
  - Validates references at ACTIVATION phase (strict, block on errors)
  - Provides fast RUNTIME validation for step handler registration
  - Offers deprecation impact analysis for instruments
  - Suggests similar names for typos/mistakes

- `services/reference-data/saga/reference_validator_test.go`: Comprehensive test coverage for:
  - Reference extraction from various AST patterns
  - DRAFT validation (allows warnings)
  - ACTIVATION validation (blocks on errors)
  - RUNTIME validation (fast path)
  - Similarity suggestions

## Technical Details

### Reference Types Extracted
| Type | Source | Example |
|------|--------|---------|
| `step_handler` | `step(action="...")` | `position_keeping.initiate_log` |
| `instrument` | `resolve_instrument("...")` | `KWH`, `USD` |
| `account` | `resolve_account("...")` | `clearing_GBP` |
| `saga` | `invoke_saga("...")` | `withdrawal` |
| `attribute` | `.attributes["..."]` | `meter_reading` |

### Validation Phases
1. **DRAFT**: Collects warnings, allows save, populates `saga_reference` table
2. **ACTIVATION**: Re-validates all references, blocks on missing/inactive references
3. **RUNTIME**: Fast check for handler registration only

## Test Plan

- [x] Unit tests for reference extraction from various AST patterns
- [x] Unit tests for DRAFT validation (warnings collected, save allowed)
- [x] Unit tests for ACTIVATION validation (blocks on errors)
- [x] Unit tests for RUNTIME validation (fast handler check)
- [x] Unit tests for similarity suggestions
- [x] Integration with existing saga test suite
- [x] golangci-lint passes with 0 issues