### PR TITLE
feat: Implement causation tree visualization API (FR-32, SAGA-070)

### DIFF
--- a/api/proto/meridian/saga/v1/saga_admin.proto
+++ b/api/proto/meridian/saga/v1/saga_admin.proto
@@ -1,0 +1,100 @@
+syntax = "proto3";
+
+package meridian.saga.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/saga/v1;sagav1";
+
+// SagaAdminService provides administrative operations for saga debugging and visualization.
+// These endpoints are intended for support teams to debug complex nested workflow failures.
+service SagaAdminService {
+  // GetCausationTree returns the full parent->child saga hierarchy for debugging.
+  // The tree includes all descendant sagas spawned from the root saga,
+  // along with their step execution details and failure information.
+  //
+  // Per FR-32: Enables Ken's support team to debug complex nested saga failures
+  // (e.g., energy settlement with 1 parent + 3 child sagas across pod restarts).
+  rpc GetCausationTree(GetCausationTreeRequest) returns (GetCausationTreeResponse) {
+    option (google.api.http) = {
+      get: "/admin/sagas/{saga_id}/causation-tree"
+    };
+  }
+}
+
+// GetCausationTreeRequest identifies the root saga for tree retrieval.
+message GetCausationTreeRequest {
+  // saga_id is the UUID of the root saga instance.
+  string saga_id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// GetCausationTreeResponse contains the complete causation tree.
+message GetCausationTreeResponse {
+  // tree is the root node of the causation tree.
+  CausationTreeNode tree = 1;
+
+  // depth is the maximum depth of the tree (for observability).
+  int32 depth = 2;
+}
+
+// CausationTreeNode represents a saga instance in the causation tree.
+message CausationTreeNode {
+  // saga_id is the unique identifier for this saga instance.
+  string saga_id = 1;
+
+  // saga_name is the human-readable name of the saga definition.
+  string saga_name = 2;
+
+  // status is the current lifecycle state (PENDING, RUNNING, COMPLETED, FAILED, etc.).
+  string status = 3;
+
+  // steps contains the execution history of this saga.
+  repeated StepNode steps = 4;
+
+  // effective_at is when this saga's business logic took effect (bi-temporal).
+  google.protobuf.Timestamp effective_at = 5;
+
+  // knowledge_at is the point-in-time knowledge context for replay (bi-temporal).
+  google.protobuf.Timestamp knowledge_at = 6;
+
+  // failed_step contains details about the step that caused the saga to fail.
+  // Only populated if the saga failed.
+  FailedStep failed_step = 7;
+}
+
+// StepNode represents an executed step within a saga.
+message StepNode {
+  // index is the 0-based position of this step in the saga execution sequence.
+  int32 index = 1;
+
+  // name is the human-readable step identifier.
+  string name = 2;
+
+  // status is the step execution status (COMPLETED or FAILED).
+  string status = 3;
+
+  // executed_at is when this step was executed.
+  google.protobuf.Timestamp executed_at = 4;
+
+  // child_sagas contains sagas spawned by this step.
+  // Empty if this step did not spawn any child sagas.
+  repeated CausationTreeNode child_sagas = 5;
+
+  // error contains the error message if this step failed.
+  string error = 6;
+}
+
+// FailedStep contains information about a failed step for debugging.
+message FailedStep {
+  // index is the step index where the failure occurred.
+  int32 index = 1;
+
+  // error is the error message from the failed step.
+  string error = 2;
+
+  // error_category classifies the failure as TRANSIENT or FATAL.
+  // TRANSIENT errors may be retried, FATAL errors require manual intervention.
+  string error_category = 3;
+}

--- a/shared/pkg/saga/admin_handler.go
+++ b/shared/pkg/saga/admin_handler.go
@@ -1,0 +1,143 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+)
+
+// AdminHandler implements the SagaAdminService gRPC service.
+// It provides debugging and visualization endpoints for saga instances.
+type AdminHandler struct {
+	sagav1.UnimplementedSagaAdminServiceServer
+	treeRepo *CausationTreeRepository
+	logger   *slog.Logger
+}
+
+// NewAdminHandler creates a new AdminHandler.
+func NewAdminHandler(treeRepo *CausationTreeRepository, logger *slog.Logger) *AdminHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &AdminHandler{
+		treeRepo: treeRepo,
+		logger:   logger,
+	}
+}
+
+// GetCausationTree returns the full parent->child saga hierarchy for debugging.
+func (h *AdminHandler) GetCausationTree(
+	ctx context.Context,
+	req *sagav1.GetCausationTreeRequest,
+) (*sagav1.GetCausationTreeResponse, error) {
+	sagaID, err := uuid.Parse(req.SagaId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid saga_id: %v", err)
+	}
+
+	h.logger.Debug("fetching causation tree",
+		"saga_id", sagaID,
+	)
+
+	tree, err := h.treeRepo.GetCausationTree(ctx, sagaID)
+	if err != nil {
+		if errors.Is(err, ErrSagaNotFound) {
+			return nil, status.Errorf(codes.NotFound, "saga not found: %s", sagaID)
+		}
+		h.logger.Error("failed to get causation tree",
+			"saga_id", sagaID,
+			"error", err,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to retrieve causation tree")
+	}
+
+	// Get tree depth for observability
+	depth, err := h.treeRepo.GetTreeDepth(ctx, sagaID)
+	if err != nil {
+		h.logger.Warn("failed to get tree depth",
+			"saga_id", sagaID,
+			"error", err,
+		)
+		// Don't fail the request for this
+		depth = 0
+	}
+
+	h.logger.Info("causation tree retrieved",
+		"saga_id", sagaID,
+		"depth", depth,
+	)
+
+	return &sagav1.GetCausationTreeResponse{
+		Tree:  h.treeNodeToProto(tree),
+		Depth: int32(depth),
+	}, nil
+}
+
+// treeNodeToProto converts a domain CausationTreeNode to proto.
+func (h *AdminHandler) treeNodeToProto(node *CausationTreeNode) *sagav1.CausationTreeNode {
+	if node == nil {
+		return nil
+	}
+
+	proto := &sagav1.CausationTreeNode{
+		SagaId:   node.SagaID.String(),
+		SagaName: node.SagaName,
+		Status:   node.Status,
+		Steps:    make([]*sagav1.StepNode, 0, len(node.Steps)),
+	}
+
+	if node.EffectiveAt != nil {
+		proto.EffectiveAt = timestamppb.New(*node.EffectiveAt)
+	}
+	if node.KnowledgeAt != nil {
+		proto.KnowledgeAt = timestamppb.New(*node.KnowledgeAt)
+	}
+	if node.FailedStep != nil {
+		proto.FailedStep = &sagav1.FailedStep{
+			Index:         int32(node.FailedStep.Index),
+			Error:         node.FailedStep.Error,
+			ErrorCategory: node.FailedStep.ErrorCategory,
+		}
+	}
+
+	for _, step := range node.Steps {
+		proto.Steps = append(proto.Steps, h.stepNodeToProto(&step))
+	}
+
+	return proto
+}
+
+// stepNodeToProto converts a domain StepNode to proto.
+func (h *AdminHandler) stepNodeToProto(step *StepNode) *sagav1.StepNode {
+	if step == nil {
+		return nil
+	}
+
+	proto := &sagav1.StepNode{
+		Index:      int32(step.Index),
+		Name:       step.Name,
+		Status:     step.Status,
+		ChildSagas: make([]*sagav1.CausationTreeNode, 0, len(step.ChildSagas)),
+	}
+
+	if step.ExecutedAt != nil {
+		proto.ExecutedAt = timestamppb.New(*step.ExecutedAt)
+	}
+	if step.Error != nil {
+		proto.Error = *step.Error
+	}
+
+	for _, child := range step.ChildSagas {
+		proto.ChildSagas = append(proto.ChildSagas, h.treeNodeToProto(child))
+	}
+
+	return proto
+}

--- a/shared/pkg/saga/admin_handler_test.go
+++ b/shared/pkg/saga/admin_handler_test.go
@@ -1,0 +1,198 @@
+package saga
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+)
+
+// TestAdminHandler_GetCausationTree_InvalidUUID tests that invalid UUID returns InvalidArgument.
+func TestAdminHandler_GetCausationTree_InvalidUUID(t *testing.T) {
+	// Create handler with nil repo (won't be reached)
+	handler := NewAdminHandler(nil, nil)
+
+	req := &sagav1.GetCausationTreeRequest{
+		SagaId: "not-a-valid-uuid",
+	}
+
+	_, err := handler.GetCausationTree(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid saga_id")
+}
+
+// TestAdminHandler_GetCausationTree_NotFound tests that missing saga returns NotFound.
+func TestAdminHandler_GetCausationTree_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	repo := NewCausationTreeRepository(db)
+	handler := NewAdminHandler(repo, nil)
+
+	req := &sagav1.GetCausationTreeRequest{
+		SagaId: uuid.New().String(),
+	}
+
+	_, err = handler.GetCausationTree(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+	assert.Contains(t, st.Message(), "saga not found")
+}
+
+// TestAdminHandler_GetCausationTree_Success tests successful causation tree retrieval.
+func TestAdminHandler_GetCausationTree_Success(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create test data
+	parentID := uuid.New()
+	knowledgeAt := time.Now().Add(-1 * time.Hour)
+
+	parent := &SagaInstance{
+		ID:               parentID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "test_saga",
+		Status:           SagaStatusCompleted,
+		CorrelationID:    uuid.New(),
+		KnowledgeAt:      &knowledgeAt,
+		CurrentStepIndex: 2,
+	}
+	err = db.Create(parent).Error
+	require.NoError(t, err)
+
+	// Create step results
+	for i := 0; i < 2; i++ {
+		stepResult := &SagaStepResult{
+			ID:             uuid.New(),
+			SagaInstanceID: parentID,
+			StepIndex:      i,
+			StepName:       "step_" + string(rune('0'+i)),
+			IdempotencyKey: FormatIdempotencyKey(parentID, i),
+			Status:         StepStatusCompleted,
+		}
+		err = db.Create(stepResult).Error
+		require.NoError(t, err)
+	}
+
+	// Create child saga
+	childID := uuid.New()
+	childStepIdx := 1
+	child := &SagaInstance{
+		ID:               childID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "child_saga",
+		Status:           SagaStatusCompleted,
+		CorrelationID:    parent.CorrelationID,
+		ParentSagaID:     &parentID,
+		ParentStepIndex:  &childStepIdx,
+		CurrentStepIndex: 1,
+	}
+	err = db.Create(child).Error
+	require.NoError(t, err)
+
+	repo := NewCausationTreeRepository(db)
+	handler := NewAdminHandler(repo, nil)
+
+	req := &sagav1.GetCausationTreeRequest{
+		SagaId: parentID.String(),
+	}
+
+	resp, err := handler.GetCausationTree(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Tree)
+
+	// Verify proto conversion
+	assert.Equal(t, parentID.String(), resp.Tree.SagaId)
+	assert.Equal(t, "test_saga", resp.Tree.SagaName)
+	assert.Equal(t, string(SagaStatusCompleted), resp.Tree.Status)
+	assert.Len(t, resp.Tree.Steps, 2)
+
+	// Verify bi-temporal field conversion
+	require.NotNil(t, resp.Tree.KnowledgeAt)
+	assert.WithinDuration(t, knowledgeAt, resp.Tree.KnowledgeAt.AsTime(), time.Second)
+
+	// Verify child saga is nested under step 1
+	require.Len(t, resp.Tree.Steps[1].ChildSagas, 1)
+	assert.Equal(t, childID.String(), resp.Tree.Steps[1].ChildSagas[0].SagaId)
+	assert.Equal(t, "child_saga", resp.Tree.Steps[1].ChildSagas[0].SagaName)
+
+	// Verify depth is returned
+	assert.Equal(t, int32(2), resp.Depth)
+}
+
+// TestAdminHandler_GetCausationTree_FailedStepConversion tests that failed step info is converted correctly.
+func TestAdminHandler_GetCausationTree_FailedStepConversion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create a failed saga
+	sagaID := uuid.New()
+	failedStepIdx := 1
+	errorMsg := "Database connection timeout"
+	errorCat := string(ErrorCategoryTransient)
+
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "failing_saga",
+		Status:           SagaStatusFailed,
+		CorrelationID:    uuid.New(),
+		CurrentStepIndex: 1,
+		FailedStepIndex:  &failedStepIdx,
+		ErrorMessage:     &errorMsg,
+		ErrorCategory:    &errorCat,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	repo := NewCausationTreeRepository(db)
+	handler := NewAdminHandler(repo, nil)
+
+	req := &sagav1.GetCausationTreeRequest{
+		SagaId: sagaID.String(),
+	}
+
+	resp, err := handler.GetCausationTree(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Tree.FailedStep)
+
+	assert.Equal(t, int32(1), resp.Tree.FailedStep.Index)
+	assert.Equal(t, "Database connection timeout", resp.Tree.FailedStep.Error)
+	assert.Equal(t, "TRANSIENT", resp.Tree.FailedStep.ErrorCategory)
+}

--- a/shared/pkg/saga/causation_tree.go
+++ b/shared/pkg/saga/causation_tree.go
@@ -1,0 +1,336 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// MaxCausationTreeDepth is the defensive limit to prevent runaway recursive queries.
+// If a saga hierarchy exceeds this depth, the query stops to avoid performance issues.
+const MaxCausationTreeDepth = 10
+
+// ErrSagaNotFound is returned when a saga instance cannot be found.
+var ErrSagaNotFound = errors.New("saga instance not found")
+
+// CausationTreeNode represents a node in the causation tree hierarchy.
+// It contains the saga instance details along with its executed steps and child sagas.
+type CausationTreeNode struct {
+	SagaID      uuid.UUID   `json:"saga_id"`
+	SagaName    string      `json:"saga_name"`
+	Status      string      `json:"status"`
+	Steps       []StepNode  `json:"steps"`
+	EffectiveAt *time.Time  `json:"effective_at,omitempty"`
+	KnowledgeAt *time.Time  `json:"knowledge_at,omitempty"`
+	FailedStep  *FailedStep `json:"failed_step,omitempty"`
+}
+
+// StepNode represents a step in the saga execution.
+type StepNode struct {
+	Index      int                  `json:"index"`
+	Name       string               `json:"name"`
+	Status     string               `json:"status"`
+	ExecutedAt *time.Time           `json:"executed_at,omitempty"`
+	Error      *string              `json:"error,omitempty"`
+	ChildSagas []*CausationTreeNode `json:"child_sagas,omitempty"`
+}
+
+// FailedStep contains information about the failed step in a saga.
+type FailedStep struct {
+	Index         int    `json:"index"`
+	Error         string `json:"error"`
+	ErrorCategory string `json:"error_category,omitempty"`
+}
+
+// CausationTreeRepository provides methods for querying causation trees.
+type CausationTreeRepository struct {
+	db *gorm.DB
+}
+
+// NewCausationTreeRepository creates a new CausationTreeRepository.
+func NewCausationTreeRepository(db *gorm.DB) *CausationTreeRepository {
+	return &CausationTreeRepository{db: db}
+}
+
+// causationTreeRow represents a row from the causation tree query result.
+type causationTreeRow struct {
+	// Saga instance fields
+	SagaID          uuid.UUID
+	SagaName        sql.NullString
+	Status          string
+	EffectiveAt     sql.NullTime
+	KnowledgeAt     sql.NullTime
+	ParentSagaID    *uuid.UUID
+	ParentStepIndex sql.NullInt32
+	Depth           int
+	// Error fields
+	ErrorMessage  sql.NullString
+	ErrorCategory sql.NullString
+	FailedStepIdx sql.NullInt32
+	// Step result fields (may be null if no step results)
+	StepIndex     sql.NullInt32
+	StepName      sql.NullString
+	StepStatus    sql.NullString
+	StepError     sql.NullString
+	StepErrorCat  sql.NullString
+	StepCreatedAt sql.NullTime
+}
+
+// GetCausationTree retrieves the full causation tree for a given root saga.
+// It uses a recursive CTE to efficiently fetch all descendant sagas and their step results.
+func (r *CausationTreeRepository) GetCausationTree(ctx context.Context, rootSagaID uuid.UUID) (*CausationTreeNode, error) {
+	// The recursive CTE query fetches:
+	// 1. The root saga and all descendant sagas (via parent_saga_id)
+	// 2. Step results for each saga
+	// 3. Ordered by depth, parent_step_index, step_index for proper tree construction
+	query := `
+		WITH RECURSIVE causation_tree AS (
+			-- Base case: start from root saga
+			SELECT
+				si.id,
+				si.saga_name,
+				si.status,
+				si.knowledge_at,
+				si.parent_saga_id,
+				si.parent_step_index,
+				si.error_message,
+				si.error_category,
+				si.failed_step_index,
+				1 as depth
+			FROM saga_instances si
+			WHERE si.id = $1
+
+			UNION ALL
+
+			-- Recursive case: find child sagas
+			SELECT
+				child.id,
+				child.saga_name,
+				child.status,
+				child.knowledge_at,
+				child.parent_saga_id,
+				child.parent_step_index,
+				child.error_message,
+				child.error_category,
+				child.failed_step_index,
+				ct.depth + 1
+			FROM saga_instances child
+			INNER JOIN causation_tree ct ON child.parent_saga_id = ct.id
+			WHERE ct.depth < $2
+		)
+		SELECT
+			ct.id as saga_id,
+			ct.saga_name,
+			ct.status,
+			ct.knowledge_at,
+			ct.parent_saga_id,
+			ct.parent_step_index,
+			ct.depth,
+			ct.error_message,
+			ct.error_category,
+			ct.failed_step_index,
+			ssr.step_index,
+			ssr.step_name,
+			ssr.status as step_status,
+			ssr.error as step_error,
+			ssr.error_category as step_error_category,
+			ssr.created_at as step_created_at
+		FROM causation_tree ct
+		LEFT JOIN saga_step_results ssr ON ct.id = ssr.saga_instance_id
+		ORDER BY ct.depth, ct.parent_step_index NULLS FIRST, ct.id, ssr.step_index NULLS FIRST
+	`
+
+	rows, err := r.db.WithContext(ctx).Raw(query, rootSagaID, MaxCausationTreeDepth).Rows()
+	if err != nil {
+		return nil, fmt.Errorf("causation tree query failed: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	return r.buildTreeFromRows(rows, rootSagaID)
+}
+
+// buildTreeFromRows constructs the nested tree structure from the flat query result set.
+//
+//nolint:gocognit,gocyclo // Complexity is inherent to tree construction from flat row data; extraction would reduce clarity
+func (r *CausationTreeRepository) buildTreeFromRows(rows *sql.Rows, rootSagaID uuid.UUID) (*CausationTreeNode, error) {
+	// Map to store all saga nodes by their ID
+	sagaNodes := make(map[uuid.UUID]*CausationTreeNode)
+	// Map to track step indices we've seen for each saga (to avoid duplicates)
+	seenSteps := make(map[uuid.UUID]map[int]bool)
+	// Track parent relationships for building the tree
+	parentRelations := make(map[uuid.UUID]struct {
+		parentID        uuid.UUID
+		parentStepIndex int
+	})
+
+	rowCount := 0
+	for rows.Next() {
+		rowCount++
+		var row causationTreeRow
+
+		if err := rows.Scan(
+			&row.SagaID,
+			&row.SagaName,
+			&row.Status,
+			&row.KnowledgeAt,
+			&row.ParentSagaID,
+			&row.ParentStepIndex,
+			&row.Depth,
+			&row.ErrorMessage,
+			&row.ErrorCategory,
+			&row.FailedStepIdx,
+			&row.StepIndex,
+			&row.StepName,
+			&row.StepStatus,
+			&row.StepError,
+			&row.StepErrorCat,
+			&row.StepCreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan causation tree row: %w", err)
+		}
+
+		// Get or create the saga node
+		node, exists := sagaNodes[row.SagaID]
+		if !exists {
+			node = &CausationTreeNode{
+				SagaID: row.SagaID,
+				Status: row.Status,
+				Steps:  []StepNode{},
+			}
+			if row.SagaName.Valid {
+				node.SagaName = row.SagaName.String
+			}
+			if row.KnowledgeAt.Valid {
+				t := row.KnowledgeAt.Time
+				node.KnowledgeAt = &t
+			}
+			// Add failed step info if present
+			if row.FailedStepIdx.Valid {
+				node.FailedStep = &FailedStep{
+					Index: int(row.FailedStepIdx.Int32),
+				}
+				if row.ErrorMessage.Valid {
+					node.FailedStep.Error = row.ErrorMessage.String
+				}
+				if row.ErrorCategory.Valid {
+					node.FailedStep.ErrorCategory = row.ErrorCategory.String
+				}
+			}
+			sagaNodes[row.SagaID] = node
+			seenSteps[row.SagaID] = make(map[int]bool)
+		}
+
+		// Track parent relationship
+		if row.ParentSagaID != nil && row.ParentStepIndex.Valid {
+			parentRelations[row.SagaID] = struct {
+				parentID        uuid.UUID
+				parentStepIndex int
+			}{
+				parentID:        *row.ParentSagaID,
+				parentStepIndex: int(row.ParentStepIndex.Int32),
+			}
+		}
+
+		// Add step result if present and not already added
+		if row.StepIndex.Valid {
+			stepIdx := int(row.StepIndex.Int32)
+			if !seenSteps[row.SagaID][stepIdx] {
+				seenSteps[row.SagaID][stepIdx] = true
+				step := StepNode{
+					Index:      stepIdx,
+					ChildSagas: []*CausationTreeNode{},
+				}
+				if row.StepName.Valid {
+					step.Name = row.StepName.String
+				}
+				if row.StepStatus.Valid {
+					step.Status = row.StepStatus.String
+				}
+				if row.StepCreatedAt.Valid {
+					t := row.StepCreatedAt.Time
+					step.ExecutedAt = &t
+				}
+				if row.StepError.Valid {
+					step.Error = &row.StepError.String
+				}
+				node.Steps = append(node.Steps, step)
+			}
+		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating causation tree rows: %w", err)
+	}
+
+	// If no rows found, the saga doesn't exist
+	if rowCount == 0 {
+		return nil, ErrSagaNotFound
+	}
+
+	// Build the tree by attaching child sagas to their parent steps
+	for childID, parent := range parentRelations {
+		childNode := sagaNodes[childID]
+		parentNode := sagaNodes[parent.parentID]
+		if parentNode == nil || childNode == nil {
+			continue
+		}
+
+		// Find or create the parent step
+		found := false
+		for i := range parentNode.Steps {
+			if parentNode.Steps[i].Index == parent.parentStepIndex {
+				parentNode.Steps[i].ChildSagas = append(parentNode.Steps[i].ChildSagas, childNode)
+				found = true
+				break
+			}
+		}
+		// If parent step doesn't exist in results (no step result yet), create a placeholder
+		if !found {
+			parentNode.Steps = append(parentNode.Steps, StepNode{
+				Index:      parent.parentStepIndex,
+				ChildSagas: []*CausationTreeNode{childNode},
+			})
+		}
+	}
+
+	// Return the root node
+	rootNode := sagaNodes[rootSagaID]
+	if rootNode == nil {
+		return nil, ErrSagaNotFound
+	}
+
+	return rootNode, nil
+}
+
+// GetTreeDepth returns the maximum depth of a causation tree.
+// This is useful for observability metrics.
+func (r *CausationTreeRepository) GetTreeDepth(ctx context.Context, rootSagaID uuid.UUID) (int, error) {
+	query := `
+		WITH RECURSIVE causation_tree AS (
+			SELECT id, 1 as depth
+			FROM saga_instances
+			WHERE id = $1
+
+			UNION ALL
+
+			SELECT child.id, ct.depth + 1
+			FROM saga_instances child
+			INNER JOIN causation_tree ct ON child.parent_saga_id = ct.id
+			WHERE ct.depth < $2
+		)
+		SELECT COALESCE(MAX(depth), 0) FROM causation_tree
+	`
+
+	var depth int
+	if err := r.db.WithContext(ctx).Raw(query, rootSagaID, MaxCausationTreeDepth).Scan(&depth).Error; err != nil {
+		return 0, fmt.Errorf("failed to get tree depth: %w", err)
+	}
+
+	return depth, nil
+}

--- a/shared/pkg/saga/causation_tree_test.go
+++ b/shared/pkg/saga/causation_tree_test.go
@@ -1,0 +1,588 @@
+package saga
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetCausationTree_SingleSaga tests retrieving a causation tree for a single saga without children.
+func TestGetCausationTree_SingleSaga(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create a single saga instance
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "test_saga",
+		Status:           SagaStatusCompleted,
+		CorrelationID:    uuid.New(),
+		CurrentStepIndex: 2,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	// Create step results
+	for i := 0; i < 2; i++ {
+		stepResult := &SagaStepResult{
+			ID:             uuid.New(),
+			SagaInstanceID: sagaID,
+			StepIndex:      i,
+			StepName:       "step_" + string(rune('0'+i)),
+			IdempotencyKey: FormatIdempotencyKey(sagaID, i),
+			Status:         StepStatusCompleted,
+		}
+		err = db.Create(stepResult).Error
+		require.NoError(t, err)
+	}
+
+	// Test the causation tree repository
+	repo := NewCausationTreeRepository(db)
+	tree, err := repo.GetCausationTree(context.Background(), sagaID)
+	require.NoError(t, err)
+
+	assert.Equal(t, sagaID, tree.SagaID)
+	assert.Equal(t, "test_saga", tree.SagaName)
+	assert.Equal(t, string(SagaStatusCompleted), tree.Status)
+	assert.Len(t, tree.Steps, 2)
+	assert.Empty(t, tree.Steps[0].ChildSagas)
+	assert.Empty(t, tree.Steps[1].ChildSagas)
+}
+
+// TestGetCausationTree_ParentWithChildren tests retrieving a causation tree with parent-child relationships.
+func TestGetCausationTree_ParentWithChildren(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create parent saga
+	parentID := uuid.New()
+	parent := &SagaInstance{
+		ID:               parentID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "parent_saga",
+		Status:           SagaStatusRunning,
+		CorrelationID:    uuid.New(),
+		CurrentStepIndex: 2,
+	}
+	err = db.Create(parent).Error
+	require.NoError(t, err)
+
+	// Create parent step results (validate, split)
+	stepNames := []string{"validate", "split"}
+	for i, name := range stepNames {
+		stepResult := &SagaStepResult{
+			ID:             uuid.New(),
+			SagaInstanceID: parentID,
+			StepIndex:      i,
+			StepName:       name,
+			IdempotencyKey: FormatIdempotencyKey(parentID, i),
+			Status:         StepStatusCompleted,
+		}
+		err = db.Create(stepResult).Error
+		require.NoError(t, err)
+	}
+
+	// Create child sagas spawned from step 1 (split)
+	childNames := []string{"child_saga_1", "child_saga_2", "child_saga_3"}
+	childStatuses := []SagaStatus{SagaStatusCompleted, SagaStatusFailed, SagaStatusRunning}
+	parentStepIndex := 1
+
+	for i, name := range childNames {
+		childID := uuid.New()
+		child := &SagaInstance{
+			ID:               childID,
+			SagaDefinitionID: uuid.New(),
+			SagaName:         name,
+			Status:           childStatuses[i],
+			CorrelationID:    parent.CorrelationID,
+			ParentSagaID:     &parentID,
+			ParentStepIndex:  &parentStepIndex,
+			CurrentStepIndex: 1,
+		}
+		err = db.Create(child).Error
+		require.NoError(t, err)
+
+		// Create a step result for each child
+		childStep := &SagaStepResult{
+			ID:             uuid.New(),
+			SagaInstanceID: childID,
+			StepIndex:      0,
+			StepName:       "process",
+			IdempotencyKey: FormatIdempotencyKey(childID, 0),
+			Status:         StepStatusCompleted,
+		}
+		err = db.Create(childStep).Error
+		require.NoError(t, err)
+	}
+
+	// Test the causation tree repository
+	repo := NewCausationTreeRepository(db)
+	tree, err := repo.GetCausationTree(context.Background(), parentID)
+	require.NoError(t, err)
+
+	assert.Equal(t, parentID, tree.SagaID)
+	assert.Equal(t, "parent_saga", tree.SagaName)
+	assert.Len(t, tree.Steps, 2)
+
+	// Step 0 (validate) should have no children
+	assert.Equal(t, "validate", tree.Steps[0].Name)
+	assert.Empty(t, tree.Steps[0].ChildSagas)
+
+	// Step 1 (split) should have 3 children
+	assert.Equal(t, "split", tree.Steps[1].Name)
+	assert.Len(t, tree.Steps[1].ChildSagas, 3)
+
+	// Verify child sagas
+	childSagas := tree.Steps[1].ChildSagas
+	sagaNames := make([]string, len(childSagas))
+	for i, child := range childSagas {
+		sagaNames[i] = child.SagaName
+	}
+	assert.ElementsMatch(t, childNames, sagaNames)
+}
+
+// TestGetCausationTree_ThreeLevels tests a three-level causation tree (parent -> child -> grandchild).
+func TestGetCausationTree_ThreeLevels(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	correlationID := uuid.New()
+
+	// Create grandparent saga
+	grandparentID := uuid.New()
+	grandparent := &SagaInstance{
+		ID:               grandparentID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "grandparent_saga",
+		Status:           SagaStatusCompleted,
+		CorrelationID:    correlationID,
+		CurrentStepIndex: 1,
+	}
+	err = db.Create(grandparent).Error
+	require.NoError(t, err)
+
+	// Create grandparent step
+	grandparentStep := &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: grandparentID,
+		StepIndex:      0,
+		StepName:       "spawn_child",
+		IdempotencyKey: FormatIdempotencyKey(grandparentID, 0),
+		Status:         StepStatusCompleted,
+	}
+	err = db.Create(grandparentStep).Error
+	require.NoError(t, err)
+
+	// Create parent saga (child of grandparent)
+	parentID := uuid.New()
+	parentStepIdx := 0
+	parent := &SagaInstance{
+		ID:               parentID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "parent_saga",
+		Status:           SagaStatusCompleted,
+		CorrelationID:    correlationID,
+		ParentSagaID:     &grandparentID,
+		ParentStepIndex:  &parentStepIdx,
+		CurrentStepIndex: 1,
+	}
+	err = db.Create(parent).Error
+	require.NoError(t, err)
+
+	// Create parent step
+	parentStep := &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: parentID,
+		StepIndex:      0,
+		StepName:       "spawn_grandchild",
+		IdempotencyKey: FormatIdempotencyKey(parentID, 0),
+		Status:         StepStatusCompleted,
+	}
+	err = db.Create(parentStep).Error
+	require.NoError(t, err)
+
+	// Create child saga (grandchild of grandparent)
+	childID := uuid.New()
+	childStepIdx := 0
+	child := &SagaInstance{
+		ID:               childID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "child_saga",
+		Status:           SagaStatusCompleted,
+		CorrelationID:    correlationID,
+		ParentSagaID:     &parentID,
+		ParentStepIndex:  &childStepIdx,
+		CurrentStepIndex: 1,
+	}
+	err = db.Create(child).Error
+	require.NoError(t, err)
+
+	// Create child step
+	childStep := &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: childID,
+		StepIndex:      0,
+		StepName:       "process",
+		IdempotencyKey: FormatIdempotencyKey(childID, 0),
+		Status:         StepStatusCompleted,
+	}
+	err = db.Create(childStep).Error
+	require.NoError(t, err)
+
+	// Test the causation tree repository
+	repo := NewCausationTreeRepository(db)
+	tree, err := repo.GetCausationTree(context.Background(), grandparentID)
+	require.NoError(t, err)
+
+	// Verify three-level hierarchy
+	assert.Equal(t, grandparentID, tree.SagaID)
+	assert.Equal(t, "grandparent_saga", tree.SagaName)
+	require.Len(t, tree.Steps, 1)
+	require.Len(t, tree.Steps[0].ChildSagas, 1)
+
+	parentNode := tree.Steps[0].ChildSagas[0]
+	assert.Equal(t, parentID, parentNode.SagaID)
+	assert.Equal(t, "parent_saga", parentNode.SagaName)
+	require.Len(t, parentNode.Steps, 1)
+	require.Len(t, parentNode.Steps[0].ChildSagas, 1)
+
+	childNode := parentNode.Steps[0].ChildSagas[0]
+	assert.Equal(t, childID, childNode.SagaID)
+	assert.Equal(t, "child_saga", childNode.SagaName)
+
+	// Verify depth
+	depth, err := repo.GetTreeDepth(context.Background(), grandparentID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, depth)
+}
+
+// TestGetCausationTree_FailedStepInfo tests that failed step information is included in the tree.
+func TestGetCausationTree_FailedStepInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create a failed saga
+	sagaID := uuid.New()
+	failedStepIdx := 2
+	errorMsg := "Insufficient balance: required 1000.00, available 500.00"
+	errorCat := string(ErrorCategoryFatal)
+
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "payment_saga",
+		Status:           SagaStatusFailed,
+		CorrelationID:    uuid.New(),
+		CurrentStepIndex: 2,
+		FailedStepIndex:  &failedStepIdx,
+		ErrorMessage:     &errorMsg,
+		ErrorCategory:    &errorCat,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	// Create step results including the failed one
+	steps := []struct {
+		index  int
+		name   string
+		status StepStatus
+		err    *string
+	}{
+		{0, "validate", StepStatusCompleted, nil},
+		{1, "reserve", StepStatusCompleted, nil},
+		{2, "debit", StepStatusFailed, &errorMsg},
+	}
+
+	for _, s := range steps {
+		stepResult := &SagaStepResult{
+			ID:             uuid.New(),
+			SagaInstanceID: sagaID,
+			StepIndex:      s.index,
+			StepName:       s.name,
+			IdempotencyKey: FormatIdempotencyKey(sagaID, s.index),
+			Status:         s.status,
+			Error:          s.err,
+		}
+		err = db.Create(stepResult).Error
+		require.NoError(t, err)
+	}
+
+	// Test the causation tree repository
+	repo := NewCausationTreeRepository(db)
+	tree, err := repo.GetCausationTree(context.Background(), sagaID)
+	require.NoError(t, err)
+
+	assert.Equal(t, string(SagaStatusFailed), tree.Status)
+	require.NotNil(t, tree.FailedStep)
+	assert.Equal(t, 2, tree.FailedStep.Index)
+	assert.Contains(t, tree.FailedStep.Error, "Insufficient balance")
+	assert.Equal(t, "FATAL", tree.FailedStep.ErrorCategory)
+
+	// Also verify the step's error is populated
+	require.Len(t, tree.Steps, 3)
+	assert.Equal(t, string(StepStatusFailed), tree.Steps[2].Status)
+	require.NotNil(t, tree.Steps[2].Error)
+	assert.Contains(t, *tree.Steps[2].Error, "Insufficient balance")
+}
+
+// TestGetCausationTree_NotFound tests that ErrSagaNotFound is returned for non-existent sagas.
+func TestGetCausationTree_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	repo := NewCausationTreeRepository(db)
+	_, err = repo.GetCausationTree(context.Background(), uuid.New())
+
+	assert.ErrorIs(t, err, ErrSagaNotFound)
+}
+
+// TestGetCausationTree_BiTemporalFields tests that bi-temporal fields are properly populated.
+func TestGetCausationTree_BiTemporalFields(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create a saga with bi-temporal fields
+	sagaID := uuid.New()
+	knowledgeAt := time.Now().Add(-24 * time.Hour)
+
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "bi_temporal_saga",
+		Status:           SagaStatusCompleted,
+		CorrelationID:    uuid.New(),
+		KnowledgeAt:      &knowledgeAt,
+		CurrentStepIndex: 1,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	// Create a step result
+	stepResult := &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: sagaID,
+		StepIndex:      0,
+		StepName:       "process",
+		IdempotencyKey: FormatIdempotencyKey(sagaID, 0),
+		Status:         StepStatusCompleted,
+	}
+	err = db.Create(stepResult).Error
+	require.NoError(t, err)
+
+	// Test the causation tree repository
+	repo := NewCausationTreeRepository(db)
+	tree, err := repo.GetCausationTree(context.Background(), sagaID)
+	require.NoError(t, err)
+
+	require.NotNil(t, tree.KnowledgeAt)
+	// Truncate to second precision for comparison (database may lose some precision)
+	assert.WithinDuration(t, knowledgeAt, *tree.KnowledgeAt, time.Second)
+}
+
+// TestGetTreeDepth tests the GetTreeDepth method.
+func TestGetTreeDepth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	correlationID := uuid.New()
+
+	// Create a chain of sagas with depth 5
+	var prevID *uuid.UUID
+	for depth := 1; depth <= 5; depth++ {
+		sagaID := uuid.New()
+		var parentStepIdx *int
+		if prevID != nil {
+			idx := 0
+			parentStepIdx = &idx
+		}
+
+		instance := &SagaInstance{
+			ID:               sagaID,
+			SagaDefinitionID: uuid.New(),
+			SagaName:         "saga_depth_" + string(rune('0'+depth)),
+			Status:           SagaStatusCompleted,
+			CorrelationID:    correlationID,
+			ParentSagaID:     prevID,
+			ParentStepIndex:  parentStepIdx,
+			CurrentStepIndex: 1,
+		}
+		err = db.Create(instance).Error
+		require.NoError(t, err)
+
+		// Create step result if not root
+		if prevID != nil {
+			stepResult := &SagaStepResult{
+				ID:             uuid.New(),
+				SagaInstanceID: *prevID,
+				StepIndex:      0,
+				StepName:       "spawn",
+				IdempotencyKey: FormatIdempotencyKey(*prevID, 0),
+				Status:         StepStatusCompleted,
+			}
+			err = db.Create(stepResult).Error
+			require.NoError(t, err)
+		}
+
+		prevID = &sagaID
+	}
+
+	// Get the root saga ID (first created)
+	var rootID uuid.UUID
+	err = db.Model(&SagaInstance{}).
+		Where("parent_saga_id IS NULL AND correlation_id = ?", correlationID).
+		Select("id").
+		Scan(&rootID).Error
+	require.NoError(t, err)
+
+	repo := NewCausationTreeRepository(db)
+	depth, err := repo.GetTreeDepth(context.Background(), rootID)
+	require.NoError(t, err)
+	assert.Equal(t, 5, depth)
+}
+
+// TestGetCausationTree_SagaWithNoSteps tests a saga that has no step results yet.
+func TestGetCausationTree_SagaWithNoSteps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create a saga with no step results (just started)
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "pending_saga",
+		Status:           SagaStatusPending,
+		CorrelationID:    uuid.New(),
+		CurrentStepIndex: 0,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	// Test the causation tree repository
+	repo := NewCausationTreeRepository(db)
+	tree, err := repo.GetCausationTree(context.Background(), sagaID)
+	require.NoError(t, err)
+
+	assert.Equal(t, sagaID, tree.SagaID)
+	assert.Equal(t, "pending_saga", tree.SagaName)
+	assert.Equal(t, string(SagaStatusPending), tree.Status)
+	assert.Empty(t, tree.Steps)
+}
+
+// TestGetCausationTree_ChildWithoutParentStep tests a child saga when parent step has no result.
+// This can happen if parent is mid-execution when child is spawned.
+func TestGetCausationTree_ChildWithoutParentStep(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create parent saga with no step results
+	parentID := uuid.New()
+	parent := &SagaInstance{
+		ID:               parentID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "parent_saga",
+		Status:           SagaStatusRunning,
+		CorrelationID:    uuid.New(),
+		CurrentStepIndex: 1,
+	}
+	err = db.Create(parent).Error
+	require.NoError(t, err)
+
+	// Create child saga linked to parent step 0 (which has no step result)
+	childID := uuid.New()
+	childStepIdx := 0
+	child := &SagaInstance{
+		ID:               childID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "child_saga",
+		Status:           SagaStatusRunning,
+		CorrelationID:    parent.CorrelationID,
+		ParentSagaID:     &parentID,
+		ParentStepIndex:  &childStepIdx,
+		CurrentStepIndex: 0,
+	}
+	err = db.Create(child).Error
+	require.NoError(t, err)
+
+	// Test the causation tree repository
+	repo := NewCausationTreeRepository(db)
+	tree, err := repo.GetCausationTree(context.Background(), parentID)
+	require.NoError(t, err)
+
+	assert.Equal(t, parentID, tree.SagaID)
+	// Parent should have a placeholder step created for the child
+	require.Len(t, tree.Steps, 1)
+	assert.Equal(t, 0, tree.Steps[0].Index)
+	assert.Empty(t, tree.Steps[0].Name) // Placeholder has no name
+	require.Len(t, tree.Steps[0].ChildSagas, 1)
+	assert.Equal(t, childID, tree.Steps[0].ChildSagas[0].SagaID)
+}


### PR DESCRIPTION
## Summary

Implements the Admin API endpoint for causation tree visualization as specified in FR-32 and SAGA-070.

- Adds `GET /admin/sagas/{id}/causation-tree` endpoint for debugging nested saga failures
- Returns recursive JSON visualization of parent->step->child saga hierarchy
- Includes bi-temporal support (knowledge_at) for debugging replays

## Changes Made

### New Files
- `api/proto/meridian/saga/v1/saga_admin.proto` - Proto definition for SagaAdminService
- `shared/pkg/saga/causation_tree.go` - CausationTreeRepository with recursive CTE query
- `shared/pkg/saga/admin_handler.go` - gRPC handler implementation
- `shared/pkg/saga/causation_tree_test.go` - Integration tests
- `shared/pkg/saga/admin_handler_test.go` - Unit tests

### Technical Details
- Recursive CTE query efficiently fetches entire tree in single database roundtrip
- Defensive depth limit of 10 prevents runaway queries
- Tree construction handles edge cases:
  - Sagas with no step results yet
  - Child sagas spawned before parent step completes
  - Failed step information propagation

## Test Plan

- [x] All new integration tests pass (12 test cases)
- [x] Build passes with all linting checks
- [ ] CI pipeline passes
- [ ] Manual verification with test data (optional)

## Task Master

Task: `starlark-saga-orchestration.21`
Dependencies: Tasks 11 (parent tracking columns) and 13 - both complete