### PR TITLE
feat(saga): Implement orphan watcher with polling for CockroachDB

### DIFF
--- a/shared/pkg/saga/metrics.go
+++ b/shared/pkg/saga/metrics.go
@@ -3,6 +3,8 @@
 package saga
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -70,6 +72,41 @@ var (
 			Help: "Total number of idempotent saga resume calls (already resumed)",
 		},
 	)
+
+	// Orphan watcher metrics
+
+	// sagaOrphanScansTotal tracks orphan scan operations.
+	sagaOrphanScansTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "saga_orphan_scans_total",
+			Help: "Total number of orphan scan operations performed",
+		},
+	)
+
+	// sagaOrphanScanErrorsTotal tracks orphan scan failures.
+	sagaOrphanScanErrorsTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "saga_orphan_scan_errors_total",
+			Help: "Total number of orphan scan errors",
+		},
+	)
+
+	// sagaOrphansClaimedTotal tracks sagas claimed during orphan scans.
+	sagaOrphansClaimedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "saga_orphans_claimed_total",
+			Help: "Total number of orphaned sagas claimed",
+		},
+	)
+
+	// sagaOrphanScanDuration tracks the duration of orphan scan operations.
+	sagaOrphanScanDuration = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "saga_orphan_scan_duration_seconds",
+			Help:    "Duration of orphan scan operations in seconds",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5},
+		},
+	)
 )
 
 // RecordZombieSagaDetected records that a zombie saga was detected.
@@ -107,6 +144,22 @@ func RecordResume() {
 // RecordResumeIdempotent records an idempotent resume call.
 func RecordResumeIdempotent() {
 	sagaResumeIdempotentTotal.Inc()
+}
+
+// RecordOrphanScan records an orphan scan operation with its duration.
+func RecordOrphanScan(duration time.Duration) {
+	sagaOrphanScansTotal.Inc()
+	sagaOrphanScanDuration.Observe(duration.Seconds())
+}
+
+// RecordOrphanScanError records an orphan scan error.
+func RecordOrphanScanError() {
+	sagaOrphanScanErrorsTotal.Inc()
+}
+
+// RecordOrphansClaimed records the number of sagas claimed during an orphan scan.
+func RecordOrphansClaimed(count int) {
+	sagaOrphansClaimedTotal.Add(float64(count))
 }
 
 // ExposeMetricsForTesting provides access to the raw Prometheus metrics for testing.

--- a/shared/pkg/saga/migrations.go
+++ b/shared/pkg/saga/migrations.go
@@ -49,6 +49,12 @@ func RunSagaMigrations(db *gorm.DB) error {
 		return fmt.Errorf("failed to create composite unique constraint: %w", err)
 	}
 
+	// Create the orphan notification trigger (FR-23)
+	// This enables reactive orphan wake-up with <10 second latency target
+	if err := createOrphanNotifyTrigger(db); err != nil {
+		return fmt.Errorf("failed to create orphan notify trigger: %w", err)
+	}
+
 	return nil
 }
 
@@ -99,6 +105,55 @@ func createCompositeUniqueConstraint(db *gorm.DB) error {
 		UNIQUE (saga_instance_id, step_index)
 	`
 	return db.Exec(sql).Error
+}
+
+// createOrphanNotifyTrigger creates the PostgreSQL trigger function and trigger
+// that fires NOTIFY 'saga_orphaned' when a saga's lease is released.
+// This enables reactive orphan detection with <10 second latency target (FR-23).
+//
+// The trigger fires when:
+// - claimed_by_pod changes from a non-NULL value to NULL
+// - This typically happens when a pod crashes (lease expires) or gracefully releases
+//
+// The notification payload includes the saga instance ID for targeted handling.
+func createOrphanNotifyTrigger(db *gorm.DB) error {
+	// Create the trigger function
+	functionSQL := `
+		CREATE OR REPLACE FUNCTION notify_saga_orphaned()
+		RETURNS TRIGGER AS $$
+		BEGIN
+			-- Fire notification when claimed_by_pod is set to NULL from a non-NULL value
+			IF OLD.claimed_by_pod IS NOT NULL AND NEW.claimed_by_pod IS NULL THEN
+				PERFORM pg_notify('saga_orphaned', NEW.id::text);
+			END IF;
+			RETURN NEW;
+		END;
+		$$ LANGUAGE plpgsql;
+	`
+	if err := db.Exec(functionSQL).Error; err != nil {
+		return fmt.Errorf("failed to create notify_saga_orphaned function: %w", err)
+	}
+
+	// Create the trigger (use IF NOT EXISTS pattern via conditional drop/create)
+	// First drop if exists to ensure clean state, then create
+	dropTriggerSQL := `
+		DROP TRIGGER IF EXISTS saga_orphaned_trigger ON saga_instances;
+	`
+	if err := db.Exec(dropTriggerSQL).Error; err != nil {
+		return fmt.Errorf("failed to drop existing saga_orphaned_trigger: %w", err)
+	}
+
+	createTriggerSQL := `
+		CREATE TRIGGER saga_orphaned_trigger
+		AFTER UPDATE ON saga_instances
+		FOR EACH ROW
+		EXECUTE FUNCTION notify_saga_orphaned();
+	`
+	if err := db.Exec(createTriggerSQL).Error; err != nil {
+		return fmt.Errorf("failed to create saga_orphaned_trigger: %w", err)
+	}
+
+	return nil
 }
 
 // DropSagaTables removes all saga-related tables.

--- a/shared/pkg/saga/migrations.go
+++ b/shared/pkg/saga/migrations.go
@@ -49,12 +49,6 @@ func RunSagaMigrations(db *gorm.DB) error {
 		return fmt.Errorf("failed to create composite unique constraint: %w", err)
 	}
 
-	// Create the orphan notification trigger (FR-23)
-	// This enables reactive orphan wake-up with <10 second latency target
-	if err := createOrphanNotifyTrigger(db); err != nil {
-		return fmt.Errorf("failed to create orphan notify trigger: %w", err)
-	}
-
 	return nil
 }
 
@@ -81,16 +75,14 @@ func createPartialIndexForOrphanDetection(db *gorm.DB) error {
 // This ensures that each step in a saga instance can only have one result.
 func createCompositeUniqueConstraint(db *gorm.DB) error {
 	// Check if constraint already exists to make migration idempotent
-	// Query is schema-aware for multi-schema deployments
+	// Uses information_schema which is compatible with both PostgreSQL and CockroachDB
 	var count int64
 	if err := db.Raw(`
 		SELECT COUNT(*)
-		FROM pg_constraint c
-		JOIN pg_class r ON r.oid = c.conrelid
-		JOIN pg_namespace n ON n.oid = r.relnamespace
-		WHERE c.conname = 'uq_saga_step_results_instance_step'
-		  AND r.relname = 'saga_step_results'
-		  AND n.nspname = current_schema()
+		FROM information_schema.table_constraints
+		WHERE constraint_name = 'uq_saga_step_results_instance_step'
+		  AND table_name = 'saga_step_results'
+		  AND constraint_type = 'UNIQUE'
 	`).Scan(&count).Error; err != nil {
 		return fmt.Errorf("failed to check constraint existence: %w", err)
 	}
@@ -105,55 +97,6 @@ func createCompositeUniqueConstraint(db *gorm.DB) error {
 		UNIQUE (saga_instance_id, step_index)
 	`
 	return db.Exec(sql).Error
-}
-
-// createOrphanNotifyTrigger creates the PostgreSQL trigger function and trigger
-// that fires NOTIFY 'saga_orphaned' when a saga's lease is released.
-// This enables reactive orphan detection with <10 second latency target (FR-23).
-//
-// The trigger fires when:
-// - claimed_by_pod changes from a non-NULL value to NULL
-// - This typically happens when a pod crashes (lease expires) or gracefully releases
-//
-// The notification payload includes the saga instance ID for targeted handling.
-func createOrphanNotifyTrigger(db *gorm.DB) error {
-	// Create the trigger function
-	functionSQL := `
-		CREATE OR REPLACE FUNCTION notify_saga_orphaned()
-		RETURNS TRIGGER AS $$
-		BEGIN
-			-- Fire notification when claimed_by_pod is set to NULL from a non-NULL value
-			IF OLD.claimed_by_pod IS NOT NULL AND NEW.claimed_by_pod IS NULL THEN
-				PERFORM pg_notify('saga_orphaned', NEW.id::text);
-			END IF;
-			RETURN NEW;
-		END;
-		$$ LANGUAGE plpgsql;
-	`
-	if err := db.Exec(functionSQL).Error; err != nil {
-		return fmt.Errorf("failed to create notify_saga_orphaned function: %w", err)
-	}
-
-	// Create the trigger (use IF NOT EXISTS pattern via conditional drop/create)
-	// First drop if exists to ensure clean state, then create
-	dropTriggerSQL := `
-		DROP TRIGGER IF EXISTS saga_orphaned_trigger ON saga_instances;
-	`
-	if err := db.Exec(dropTriggerSQL).Error; err != nil {
-		return fmt.Errorf("failed to drop existing saga_orphaned_trigger: %w", err)
-	}
-
-	createTriggerSQL := `
-		CREATE TRIGGER saga_orphaned_trigger
-		AFTER UPDATE ON saga_instances
-		FOR EACH ROW
-		EXECUTE FUNCTION notify_saga_orphaned();
-	`
-	if err := db.Exec(createTriggerSQL).Error; err != nil {
-		return fmt.Errorf("failed to create saga_orphaned_trigger: %w", err)
-	}
-
-	return nil
 }
 
 // DropSagaTables removes all saga-related tables.

--- a/shared/pkg/saga/migrations_integration_test.go
+++ b/shared/pkg/saga/migrations_integration_test.go
@@ -311,10 +311,10 @@ func TestSagaMigrations_PartialIndex(t *testing.T) {
 	// CockroachDB uses information_schema for index queries
 	t.Run("partial index exists for orphan query", func(t *testing.T) {
 		var idxCount int64
-		// CockroachDB stores indexes in crdb_internal.table_indexes
-		// Fall back to checking the index exists by name
+		// CockroachDB stores indexes in information_schema.statistics
+		// Use COUNT(DISTINCT index_name) since multi-column indexes return one row per column
 		err := db.Raw(`
-			SELECT COUNT(*)
+			SELECT COUNT(DISTINCT index_name)
 			FROM information_schema.statistics
 			WHERE table_name = 'saga_instances'
 			  AND index_name = 'idx_saga_instances_orphaned'

--- a/shared/pkg/saga/migrations_integration_test.go
+++ b/shared/pkg/saga/migrations_integration_test.go
@@ -2,19 +2,12 @@
 package saga
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
-	gormpg "gorm.io/driver/postgres"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 // TestSagaMigrations_SchemaCreation verifies that RunSagaMigrations creates
@@ -314,60 +307,19 @@ func TestSagaMigrations_PartialIndex(t *testing.T) {
 		assert.Equal(t, orphanedSaga.ID, orphans[0].ID, "Orphaned saga should be the one with expired lease")
 	}
 
-	// Verify the partial index exists using pg_indexes catalog
-	// Note: EXPLAIN ANALYZE is unreliable on tiny test tables as Postgres
-	// will choose sequential scan for small datasets regardless of index presence
+	// Verify the partial index exists
+	// CockroachDB uses information_schema for index queries
 	t.Run("partial index exists for orphan query", func(t *testing.T) {
 		var idxCount int64
+		// CockroachDB stores indexes in crdb_internal.table_indexes
+		// Fall back to checking the index exists by name
 		err := db.Raw(`
 			SELECT COUNT(*)
-			FROM pg_indexes
-			WHERE schemaname = current_schema()
-			  AND tablename = 'saga_instances'
-			  AND indexname = 'idx_saga_instances_orphaned'
+			FROM information_schema.statistics
+			WHERE table_name = 'saga_instances'
+			  AND index_name = 'idx_saga_instances_orphaned'
 		`).Scan(&idxCount).Error
 		require.NoError(t, err)
 		assert.Equal(t, int64(1), idxCount, "partial index idx_saga_instances_orphaned should exist")
 	})
-}
-
-// setupTestPostgres creates a PostgreSQL testcontainer and returns a GORM DB connection.
-func setupTestPostgres(t *testing.T) (*gorm.DB, func()) {
-	t.Helper()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
-	defer cancel()
-
-	pgContainer, err := postgres.Run(ctx,
-		"postgres:15-alpine",
-		postgres.WithDatabase("saga_test"),
-		postgres.WithUsername("test_user"),
-		postgres.WithPassword("test_password"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(60*time.Second)),
-	)
-	require.NoError(t, err, "Failed to start PostgreSQL container")
-
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err, "Failed to get connection string")
-
-	db, err := gorm.Open(gormpg.Open(connStr), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
-	require.NoError(t, err, "Failed to connect to database")
-
-	cleanup := func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cleanupCancel()
-
-		sqlDB, _ := db.DB()
-		if sqlDB != nil {
-			_ = sqlDB.Close()
-		}
-		_ = pgContainer.Terminate(cleanupCtx)
-	}
-
-	return db, cleanup
 }

--- a/shared/pkg/saga/orphan_watcher.go
+++ b/shared/pkg/saga/orphan_watcher.go
@@ -353,12 +353,31 @@ func (w *OrphanWatcher) handleNotification(ctx context.Context, notification *pq
 		// Too soon - queue a scan for later if not already queued
 		if !w.scanQueued {
 			w.scanQueued = true
+			delay := w.watchConfig.NotificationDebounce - timeSinceLastScan
+			// Intentionally not passing ctx - the goroutine will use context.Background()
+			// since the original ctx may be cancelled by the time the debounce delay completes.
+			//nolint:contextcheck // Intentional: uses fresh context.Background() for delayed scan
 			go func() {
-				time.Sleep(w.watchConfig.NotificationDebounce - timeSinceLastScan)
+				// Wait for debounce delay or shutdown signal
+				select {
+				case <-time.After(delay):
+				case <-w.done:
+					w.scanMu.Lock()
+					w.scanQueued = false
+					w.scanMu.Unlock()
+					return
+				}
 				w.scanMu.Lock()
 				w.scanQueued = false
 				w.scanMu.Unlock()
-				w.performScan(ctx)
+				// Check if watcher is still running before scanning
+				select {
+				case <-w.done:
+					return
+				default:
+					// Use fresh context since original ctx may be cancelled
+					w.performScan(context.Background())
+				}
 			}()
 		}
 		w.scanMu.Unlock()

--- a/shared/pkg/saga/orphan_watcher.go
+++ b/shared/pkg/saga/orphan_watcher.go
@@ -7,43 +7,34 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lib/pq"
 	"github.com/meridianhub/meridian/shared/platform/env"
 	"gorm.io/gorm"
 )
 
-// OrphanNotifyChannel is the PostgreSQL channel name for LISTEN/NOTIFY.
-const OrphanNotifyChannel = "saga_orphaned"
-
-// DefaultFallbackScanInterval is the default fallback scan interval when LISTEN is not available.
-const DefaultFallbackScanInterval = 5 * time.Minute
+// DefaultScanInterval is the default interval for scanning orphaned sagas.
+// This provides a balance between timely detection and database load.
+// For faster detection, configure SAGA_ORPHAN_SCAN_INTERVAL to a lower value.
+const DefaultScanInterval = 10 * time.Second
 
 // OrphanWatcherConfig holds configuration for the orphan watcher.
 type OrphanWatcherConfig struct {
-	// FallbackScanInterval is how often to scan for orphans when LISTEN fails.
-	// Default: 5 minutes (SAGA_ORPHAN_SCAN_INTERVAL)
-	FallbackScanInterval time.Duration
-
-	// NotificationDebounce is the minimum time between scans triggered by notifications.
-	// Prevents thundering herd when multiple pods crash simultaneously.
-	// Default: 500ms (SAGA_ORPHAN_DEBOUNCE_MS)
-	NotificationDebounce time.Duration
+	// ScanInterval is how often to scan for orphaned sagas.
+	// Default: 10 seconds (SAGA_ORPHAN_SCAN_INTERVAL)
+	ScanInterval time.Duration
 }
 
 // NewOrphanWatcherConfig creates an OrphanWatcherConfig from environment variables.
 func NewOrphanWatcherConfig() *OrphanWatcherConfig {
 	return &OrphanWatcherConfig{
-		FallbackScanInterval: env.GetEnvAsDuration("SAGA_ORPHAN_SCAN_INTERVAL", DefaultFallbackScanInterval),
-		NotificationDebounce: env.GetEnvAsDuration("SAGA_ORPHAN_DEBOUNCE_MS", 500*time.Millisecond),
+		ScanInterval: env.GetEnvAsDuration("SAGA_ORPHAN_SCAN_INTERVAL", DefaultScanInterval),
 	}
 }
 
-// OrphanWatcher listens for PostgreSQL NOTIFY events when sagas become orphaned
-// (i.e., when claimed_by_pod is set to NULL). This enables fast-path resumption
-// with a target latency of <10 seconds from pod crash to saga resume.
+// OrphanWatcher periodically scans for orphaned sagas (sagas with expired leases
+// or NULL claimed_by_pod) and claims them for the current pod.
 //
-// When LISTEN fails or is unavailable, the watcher falls back to periodic scanning
-// every 5 minutes (configurable).
+// This implements a polling-based approach compatible with CockroachDB, which
+// does not support PostgreSQL's LISTEN/NOTIFY mechanism.
 //
 // Usage:
 //
@@ -60,20 +51,12 @@ type OrphanWatcher struct {
 	// callback is called after each scan (for testing)
 	callback func()
 
-	// listener is the PostgreSQL LISTEN connection
-	listener *pq.Listener
-
 	// state management
 	mu       sync.Mutex
 	running  bool
 	done     chan struct{}
 	wg       sync.WaitGroup
 	stopOnce sync.Once
-
-	// debounce state
-	lastScan   time.Time
-	scanMu     sync.Mutex
-	scanQueued bool
 }
 
 // OrphanWatcherOption is a functional option for configuring an OrphanWatcher.
@@ -87,20 +70,11 @@ func WithOrphanScanCallback(callback func()) OrphanWatcherOption {
 	}
 }
 
-// WithFallbackScanInterval sets the fallback periodic scan interval.
-func WithFallbackScanInterval(interval time.Duration) OrphanWatcherOption {
+// WithScanInterval sets the periodic scan interval.
+func WithScanInterval(interval time.Duration) OrphanWatcherOption {
 	return func(w *OrphanWatcher) {
 		if interval > 0 {
-			w.watchConfig.FallbackScanInterval = interval
-		}
-	}
-}
-
-// WithNotificationDebounce sets the minimum time between notification-triggered scans.
-func WithNotificationDebounce(duration time.Duration) OrphanWatcherOption {
-	return func(w *OrphanWatcher) {
-		if duration > 0 {
-			w.watchConfig.NotificationDebounce = duration
+			w.watchConfig.ScanInterval = interval
 		}
 	}
 }
@@ -108,7 +82,7 @@ func WithNotificationDebounce(duration time.Duration) OrphanWatcherOption {
 // NewOrphanWatcher creates a new OrphanWatcher.
 //
 // Parameters:
-//   - db: GORM database connection (used for claims and to extract connection string)
+//   - db: GORM database connection
 //   - claimConfig: Configuration for the ClaimService (includes PodID, batch size, etc.)
 //   - logger: Structured logger (uses slog.Default() if nil)
 //   - opts: Optional functional options
@@ -133,9 +107,7 @@ func NewOrphanWatcher(db *gorm.DB, claimConfig *ClaimConfig, logger *slog.Logger
 	return w
 }
 
-// Start begins the orphan watching process.
-// It attempts to set up PostgreSQL LISTEN/NOTIFY, falling back to periodic scanning
-// if LISTEN is not available.
+// Start begins the orphan watching process with periodic scanning.
 //
 // It is safe to call Start multiple times, but only the first call will have effect.
 func (w *OrphanWatcher) Start(ctx context.Context) {
@@ -153,8 +125,7 @@ func (w *OrphanWatcher) Start(ctx context.Context) {
 	go w.run(ctx)
 
 	w.logger.Info("orphan watcher started",
-		"fallback_interval", w.watchConfig.FallbackScanInterval,
-		"debounce", w.watchConfig.NotificationDebounce,
+		"scan_interval", w.watchConfig.ScanInterval,
 		"pod_id", w.claimConfig.PodID,
 	)
 }
@@ -170,17 +141,13 @@ func (w *OrphanWatcher) Stop() {
 	w.wg.Wait()
 
 	w.mu.Lock()
-	if w.listener != nil {
-		_ = w.listener.Close()
-		w.listener = nil
-	}
 	w.running = false
 	w.mu.Unlock()
 
 	w.logger.Info("orphan watcher stopped")
 }
 
-// run is the main event loop.
+// run is the main event loop that periodically scans for orphaned sagas.
 func (w *OrphanWatcher) run(ctx context.Context) {
 	defer func() {
 		w.mu.Lock()
@@ -189,14 +156,11 @@ func (w *OrphanWatcher) run(ctx context.Context) {
 		w.wg.Done()
 	}()
 
-	// Try to set up LISTEN/NOTIFY
-	listenOK := w.setupListener(ctx)
-
-	// Set up fallback periodic ticker
-	ticker := time.NewTicker(w.watchConfig.FallbackScanInterval)
+	// Set up periodic ticker
+	ticker := time.NewTicker(w.watchConfig.ScanInterval)
 	defer ticker.Stop()
 
-	// Initial scan
+	// Initial scan on startup
 	w.performScan(ctx)
 
 	for {
@@ -210,190 +174,13 @@ func (w *OrphanWatcher) run(ctx context.Context) {
 			return
 
 		case <-ticker.C:
-			// Periodic fallback scan
-			w.logger.Debug("periodic fallback scan triggered")
 			w.performScan(ctx)
-
-		default:
-			// Check for notifications (non-blocking)
-			if listenOK && w.listener != nil {
-				select {
-				case notification := <-w.listener.Notify:
-					if notification != nil {
-						w.handleNotification(ctx, notification)
-					}
-				case <-ctx.Done():
-					return
-				case <-w.done:
-					return
-				case <-time.After(100 * time.Millisecond):
-					// Continue loop
-				}
-			} else {
-				// No listener, just wait a bit before next iteration
-				select {
-				case <-ctx.Done():
-					return
-				case <-w.done:
-					return
-				case <-time.After(100 * time.Millisecond):
-					// Continue loop
-				}
-			}
 		}
 	}
-}
-
-// setupListener attempts to create a PostgreSQL LISTEN connection.
-// Returns true if successful, false if LISTEN is not available.
-func (w *OrphanWatcher) setupListener(ctx context.Context) bool {
-	// Get connection string from GORM
-	sqlDB, err := w.db.DB()
-	if err != nil {
-		w.logger.Warn("failed to get sql.DB from GORM, falling back to periodic scan",
-			"error", err)
-		return false
-	}
-
-	// Get DSN - we need to extract it from the existing connection
-	// Since GORM doesn't expose the DSN directly, we'll get it from an env var
-	dsn := env.GetEnvOrDefault("DATABASE_URL", "")
-	if dsn == "" {
-		// Try to construct from individual components
-		dsn = constructDSNFromEnv()
-	}
-
-	if dsn == "" {
-		w.logger.Warn("DATABASE_URL not set, falling back to periodic scan")
-		return false
-	}
-
-	// Create pq.Listener with reconnection logic
-	minReconn := 10 * time.Second
-	maxReconn := time.Minute
-
-	listener := pq.NewListener(dsn, minReconn, maxReconn, func(ev pq.ListenerEventType, err error) {
-		switch ev {
-		case pq.ListenerEventConnected:
-			w.logger.Info("PostgreSQL LISTEN connected")
-		case pq.ListenerEventDisconnected:
-			w.logger.Warn("PostgreSQL LISTEN disconnected", "error", err)
-		case pq.ListenerEventReconnected:
-			w.logger.Info("PostgreSQL LISTEN reconnected")
-		case pq.ListenerEventConnectionAttemptFailed:
-			w.logger.Warn("PostgreSQL LISTEN connection attempt failed", "error", err)
-		}
-	})
-
-	// Subscribe to orphan channel
-	if err := listener.Listen(OrphanNotifyChannel); err != nil {
-		w.logger.Warn("failed to LISTEN on saga_orphaned channel, falling back to periodic scan",
-			"error", err)
-		_ = listener.Close()
-		return false
-	}
-
-	// Ping to verify connection
-	ctx2, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-	if err := listener.Ping(); err != nil {
-		w.logger.Warn("failed to ping LISTEN connection, falling back to periodic scan",
-			"error", err)
-		_ = listener.Close()
-		return false
-	}
-	_ = ctx2 // suppress unused variable warning
-
-	w.mu.Lock()
-	w.listener = listener
-	w.mu.Unlock()
-
-	_ = sqlDB // suppress unused variable warning
-
-	w.logger.Info("PostgreSQL LISTEN/NOTIFY enabled for orphan detection",
-		"channel", OrphanNotifyChannel)
-	return true
-}
-
-// constructDSNFromEnv builds a DSN from common environment variables.
-func constructDSNFromEnv() string {
-	host := env.GetEnvOrDefault("DB_HOST", "")
-	port := env.GetEnvOrDefault("DB_PORT", "5432")
-	user := env.GetEnvOrDefault("DB_USER", "")
-	password := env.GetEnvOrDefault("DB_PASSWORD", "")
-	dbname := env.GetEnvOrDefault("DB_NAME", "")
-	sslmode := env.GetEnvOrDefault("DB_SSLMODE", "disable")
-
-	if host == "" || user == "" || dbname == "" {
-		return ""
-	}
-
-	dsn := "host=" + host + " port=" + port + " user=" + user
-	if password != "" {
-		dsn += " password=" + password
-	}
-	dsn += " dbname=" + dbname + " sslmode=" + sslmode
-
-	return dsn
-}
-
-// handleNotification processes an incoming NOTIFY event.
-func (w *OrphanWatcher) handleNotification(ctx context.Context, notification *pq.Notification) {
-	w.logger.Debug("received orphan notification",
-		"saga_id", notification.Extra,
-		"channel", notification.Channel,
-	)
-
-	RecordOrphanNotificationReceived()
-
-	// Debounce: don't scan too frequently
-	w.scanMu.Lock()
-	timeSinceLastScan := time.Since(w.lastScan)
-	if timeSinceLastScan < w.watchConfig.NotificationDebounce {
-		// Too soon - queue a scan for later if not already queued
-		if !w.scanQueued {
-			w.scanQueued = true
-			delay := w.watchConfig.NotificationDebounce - timeSinceLastScan
-			// Intentionally not passing ctx - the goroutine will use context.Background()
-			// since the original ctx may be cancelled by the time the debounce delay completes.
-			//nolint:contextcheck // Intentional: uses fresh context.Background() for delayed scan
-			go func() {
-				// Wait for debounce delay or shutdown signal
-				select {
-				case <-time.After(delay):
-				case <-w.done:
-					w.scanMu.Lock()
-					w.scanQueued = false
-					w.scanMu.Unlock()
-					return
-				}
-				w.scanMu.Lock()
-				w.scanQueued = false
-				w.scanMu.Unlock()
-				// Check if watcher is still running before scanning
-				select {
-				case <-w.done:
-					return
-				default:
-					// Use fresh context since original ctx may be cancelled
-					w.performScan(context.Background())
-				}
-			}()
-		}
-		w.scanMu.Unlock()
-		return
-	}
-	w.scanMu.Unlock()
-
-	w.performScan(ctx)
 }
 
 // performScan executes an orphan claiming scan.
 func (w *OrphanWatcher) performScan(ctx context.Context) {
-	w.scanMu.Lock()
-	w.lastScan = time.Now()
-	w.scanMu.Unlock()
-
 	start := time.Now()
 
 	claimedIDs, err := w.claimService.ClaimOrphanedSagas(ctx)

--- a/shared/pkg/saga/orphan_watcher.go
+++ b/shared/pkg/saga/orphan_watcher.go
@@ -1,0 +1,405 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"gorm.io/gorm"
+)
+
+// OrphanNotifyChannel is the PostgreSQL channel name for LISTEN/NOTIFY.
+const OrphanNotifyChannel = "saga_orphaned"
+
+// DefaultFallbackScanInterval is the default fallback scan interval when LISTEN is not available.
+const DefaultFallbackScanInterval = 5 * time.Minute
+
+// OrphanWatcherConfig holds configuration for the orphan watcher.
+type OrphanWatcherConfig struct {
+	// FallbackScanInterval is how often to scan for orphans when LISTEN fails.
+	// Default: 5 minutes (SAGA_ORPHAN_SCAN_INTERVAL)
+	FallbackScanInterval time.Duration
+
+	// NotificationDebounce is the minimum time between scans triggered by notifications.
+	// Prevents thundering herd when multiple pods crash simultaneously.
+	// Default: 500ms (SAGA_ORPHAN_DEBOUNCE_MS)
+	NotificationDebounce time.Duration
+}
+
+// NewOrphanWatcherConfig creates an OrphanWatcherConfig from environment variables.
+func NewOrphanWatcherConfig() *OrphanWatcherConfig {
+	return &OrphanWatcherConfig{
+		FallbackScanInterval: env.GetEnvAsDuration("SAGA_ORPHAN_SCAN_INTERVAL", DefaultFallbackScanInterval),
+		NotificationDebounce: env.GetEnvAsDuration("SAGA_ORPHAN_DEBOUNCE_MS", 500*time.Millisecond),
+	}
+}
+
+// OrphanWatcher listens for PostgreSQL NOTIFY events when sagas become orphaned
+// (i.e., when claimed_by_pod is set to NULL). This enables fast-path resumption
+// with a target latency of <10 seconds from pod crash to saga resume.
+//
+// When LISTEN fails or is unavailable, the watcher falls back to periodic scanning
+// every 5 minutes (configurable).
+//
+// Usage:
+//
+//	watcher := saga.NewOrphanWatcher(db, claimConfig, logger)
+//	watcher.Start(ctx)
+//	defer watcher.Stop()
+type OrphanWatcher struct {
+	db           *gorm.DB
+	claimConfig  *ClaimConfig
+	watchConfig  *OrphanWatcherConfig
+	claimService *ClaimService
+	logger       *slog.Logger
+
+	// callback is called after each scan (for testing)
+	callback func()
+
+	// listener is the PostgreSQL LISTEN connection
+	listener *pq.Listener
+
+	// state management
+	mu       sync.Mutex
+	running  bool
+	done     chan struct{}
+	wg       sync.WaitGroup
+	stopOnce sync.Once
+
+	// debounce state
+	lastScan   time.Time
+	scanMu     sync.Mutex
+	scanQueued bool
+}
+
+// OrphanWatcherOption is a functional option for configuring an OrphanWatcher.
+type OrphanWatcherOption func(*OrphanWatcher)
+
+// WithOrphanScanCallback sets a callback function called after each orphan scan.
+// Useful for testing to track scan frequency.
+func WithOrphanScanCallback(callback func()) OrphanWatcherOption {
+	return func(w *OrphanWatcher) {
+		w.callback = callback
+	}
+}
+
+// WithFallbackScanInterval sets the fallback periodic scan interval.
+func WithFallbackScanInterval(interval time.Duration) OrphanWatcherOption {
+	return func(w *OrphanWatcher) {
+		if interval > 0 {
+			w.watchConfig.FallbackScanInterval = interval
+		}
+	}
+}
+
+// WithNotificationDebounce sets the minimum time between notification-triggered scans.
+func WithNotificationDebounce(duration time.Duration) OrphanWatcherOption {
+	return func(w *OrphanWatcher) {
+		if duration > 0 {
+			w.watchConfig.NotificationDebounce = duration
+		}
+	}
+}
+
+// NewOrphanWatcher creates a new OrphanWatcher.
+//
+// Parameters:
+//   - db: GORM database connection (used for claims and to extract connection string)
+//   - claimConfig: Configuration for the ClaimService (includes PodID, batch size, etc.)
+//   - logger: Structured logger (uses slog.Default() if nil)
+//   - opts: Optional functional options
+func NewOrphanWatcher(db *gorm.DB, claimConfig *ClaimConfig, logger *slog.Logger, opts ...OrphanWatcherOption) *OrphanWatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	w := &OrphanWatcher{
+		db:           db,
+		claimConfig:  claimConfig,
+		watchConfig:  NewOrphanWatcherConfig(),
+		claimService: NewClaimService(db, claimConfig).WithLogger(logger),
+		logger:       logger.With("component", "orphan_watcher"),
+		done:         make(chan struct{}),
+	}
+
+	for _, opt := range opts {
+		opt(w)
+	}
+
+	return w
+}
+
+// Start begins the orphan watching process.
+// It attempts to set up PostgreSQL LISTEN/NOTIFY, falling back to periodic scanning
+// if LISTEN is not available.
+//
+// It is safe to call Start multiple times, but only the first call will have effect.
+func (w *OrphanWatcher) Start(ctx context.Context) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.running {
+		w.logger.Debug("orphan watcher already running, ignoring Start() call")
+		return
+	}
+
+	w.running = true
+	w.wg.Add(1)
+
+	go w.run(ctx)
+
+	w.logger.Info("orphan watcher started",
+		"fallback_interval", w.watchConfig.FallbackScanInterval,
+		"debounce", w.watchConfig.NotificationDebounce,
+		"pod_id", w.claimConfig.PodID,
+	)
+}
+
+// Stop signals the watcher to stop and waits for goroutines to exit.
+// It is safe to call Stop multiple times.
+func (w *OrphanWatcher) Stop() {
+	w.stopOnce.Do(func() {
+		w.logger.Debug("stopping orphan watcher")
+		close(w.done)
+	})
+
+	w.wg.Wait()
+
+	w.mu.Lock()
+	if w.listener != nil {
+		_ = w.listener.Close()
+		w.listener = nil
+	}
+	w.running = false
+	w.mu.Unlock()
+
+	w.logger.Info("orphan watcher stopped")
+}
+
+// run is the main event loop.
+func (w *OrphanWatcher) run(ctx context.Context) {
+	defer func() {
+		w.mu.Lock()
+		w.running = false
+		w.mu.Unlock()
+		w.wg.Done()
+	}()
+
+	// Try to set up LISTEN/NOTIFY
+	listenOK := w.setupListener(ctx)
+
+	// Set up fallback periodic ticker
+	ticker := time.NewTicker(w.watchConfig.FallbackScanInterval)
+	defer ticker.Stop()
+
+	// Initial scan
+	w.performScan(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Debug("orphan watcher stopping due to context cancellation")
+			return
+
+		case <-w.done:
+			w.logger.Debug("orphan watcher stopping due to Stop() call")
+			return
+
+		case <-ticker.C:
+			// Periodic fallback scan
+			w.logger.Debug("periodic fallback scan triggered")
+			w.performScan(ctx)
+
+		default:
+			// Check for notifications (non-blocking)
+			if listenOK && w.listener != nil {
+				select {
+				case notification := <-w.listener.Notify:
+					if notification != nil {
+						w.handleNotification(ctx, notification)
+					}
+				case <-ctx.Done():
+					return
+				case <-w.done:
+					return
+				case <-time.After(100 * time.Millisecond):
+					// Continue loop
+				}
+			} else {
+				// No listener, just wait a bit before next iteration
+				select {
+				case <-ctx.Done():
+					return
+				case <-w.done:
+					return
+				case <-time.After(100 * time.Millisecond):
+					// Continue loop
+				}
+			}
+		}
+	}
+}
+
+// setupListener attempts to create a PostgreSQL LISTEN connection.
+// Returns true if successful, false if LISTEN is not available.
+func (w *OrphanWatcher) setupListener(ctx context.Context) bool {
+	// Get connection string from GORM
+	sqlDB, err := w.db.DB()
+	if err != nil {
+		w.logger.Warn("failed to get sql.DB from GORM, falling back to periodic scan",
+			"error", err)
+		return false
+	}
+
+	// Get DSN - we need to extract it from the existing connection
+	// Since GORM doesn't expose the DSN directly, we'll get it from an env var
+	dsn := env.GetEnvOrDefault("DATABASE_URL", "")
+	if dsn == "" {
+		// Try to construct from individual components
+		dsn = constructDSNFromEnv()
+	}
+
+	if dsn == "" {
+		w.logger.Warn("DATABASE_URL not set, falling back to periodic scan")
+		return false
+	}
+
+	// Create pq.Listener with reconnection logic
+	minReconn := 10 * time.Second
+	maxReconn := time.Minute
+
+	listener := pq.NewListener(dsn, minReconn, maxReconn, func(ev pq.ListenerEventType, err error) {
+		switch ev {
+		case pq.ListenerEventConnected:
+			w.logger.Info("PostgreSQL LISTEN connected")
+		case pq.ListenerEventDisconnected:
+			w.logger.Warn("PostgreSQL LISTEN disconnected", "error", err)
+		case pq.ListenerEventReconnected:
+			w.logger.Info("PostgreSQL LISTEN reconnected")
+		case pq.ListenerEventConnectionAttemptFailed:
+			w.logger.Warn("PostgreSQL LISTEN connection attempt failed", "error", err)
+		}
+	})
+
+	// Subscribe to orphan channel
+	if err := listener.Listen(OrphanNotifyChannel); err != nil {
+		w.logger.Warn("failed to LISTEN on saga_orphaned channel, falling back to periodic scan",
+			"error", err)
+		_ = listener.Close()
+		return false
+	}
+
+	// Ping to verify connection
+	ctx2, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := listener.Ping(); err != nil {
+		w.logger.Warn("failed to ping LISTEN connection, falling back to periodic scan",
+			"error", err)
+		_ = listener.Close()
+		return false
+	}
+	_ = ctx2 // suppress unused variable warning
+
+	w.mu.Lock()
+	w.listener = listener
+	w.mu.Unlock()
+
+	_ = sqlDB // suppress unused variable warning
+
+	w.logger.Info("PostgreSQL LISTEN/NOTIFY enabled for orphan detection",
+		"channel", OrphanNotifyChannel)
+	return true
+}
+
+// constructDSNFromEnv builds a DSN from common environment variables.
+func constructDSNFromEnv() string {
+	host := env.GetEnvOrDefault("DB_HOST", "")
+	port := env.GetEnvOrDefault("DB_PORT", "5432")
+	user := env.GetEnvOrDefault("DB_USER", "")
+	password := env.GetEnvOrDefault("DB_PASSWORD", "")
+	dbname := env.GetEnvOrDefault("DB_NAME", "")
+	sslmode := env.GetEnvOrDefault("DB_SSLMODE", "disable")
+
+	if host == "" || user == "" || dbname == "" {
+		return ""
+	}
+
+	dsn := "host=" + host + " port=" + port + " user=" + user
+	if password != "" {
+		dsn += " password=" + password
+	}
+	dsn += " dbname=" + dbname + " sslmode=" + sslmode
+
+	return dsn
+}
+
+// handleNotification processes an incoming NOTIFY event.
+func (w *OrphanWatcher) handleNotification(ctx context.Context, notification *pq.Notification) {
+	w.logger.Debug("received orphan notification",
+		"saga_id", notification.Extra,
+		"channel", notification.Channel,
+	)
+
+	RecordOrphanNotificationReceived()
+
+	// Debounce: don't scan too frequently
+	w.scanMu.Lock()
+	timeSinceLastScan := time.Since(w.lastScan)
+	if timeSinceLastScan < w.watchConfig.NotificationDebounce {
+		// Too soon - queue a scan for later if not already queued
+		if !w.scanQueued {
+			w.scanQueued = true
+			go func() {
+				time.Sleep(w.watchConfig.NotificationDebounce - timeSinceLastScan)
+				w.scanMu.Lock()
+				w.scanQueued = false
+				w.scanMu.Unlock()
+				w.performScan(ctx)
+			}()
+		}
+		w.scanMu.Unlock()
+		return
+	}
+	w.scanMu.Unlock()
+
+	w.performScan(ctx)
+}
+
+// performScan executes an orphan claiming scan.
+func (w *OrphanWatcher) performScan(ctx context.Context) {
+	w.scanMu.Lock()
+	w.lastScan = time.Now()
+	w.scanMu.Unlock()
+
+	start := time.Now()
+
+	claimedIDs, err := w.claimService.ClaimOrphanedSagas(ctx)
+	if err != nil {
+		w.logger.Error("failed to claim orphaned sagas",
+			"error", err,
+		)
+		RecordOrphanScanError()
+	} else if len(claimedIDs) > 0 {
+		w.logger.Info("claimed orphaned sagas",
+			"count", len(claimedIDs),
+			"saga_ids", claimedIDs,
+			"duration", time.Since(start),
+		)
+		RecordOrphansClaimed(len(claimedIDs))
+	} else {
+		w.logger.Debug("no orphaned sagas found",
+			"duration", time.Since(start),
+		)
+	}
+
+	RecordOrphanScan(time.Since(start))
+
+	// Call test callback if set
+	if w.callback != nil {
+		w.callback()
+	}
+}

--- a/shared/pkg/saga/orphan_watcher_test.go
+++ b/shared/pkg/saga/orphan_watcher_test.go
@@ -1,0 +1,479 @@
+package saga
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOrphanNotifyTriggerCreated verifies the PostgreSQL trigger and function
+// are created by RunSagaMigrations.
+func TestOrphanNotifyTriggerCreated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err, "RunSagaMigrations should succeed")
+
+	// Verify the trigger function exists
+	t.Run("notify_saga_orphaned function exists", func(t *testing.T) {
+		var count int64
+		err := db.Raw(`
+			SELECT COUNT(*)
+			FROM pg_proc p
+			JOIN pg_namespace n ON n.oid = p.pronamespace
+			WHERE p.proname = 'notify_saga_orphaned'
+			  AND n.nspname = current_schema()
+		`).Scan(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count, "notify_saga_orphaned function should exist")
+	})
+
+	// Verify the trigger exists
+	t.Run("saga_orphaned_trigger exists", func(t *testing.T) {
+		var count int64
+		err := db.Raw(`
+			SELECT COUNT(*)
+			FROM pg_trigger t
+			JOIN pg_class c ON c.oid = t.tgrelid
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE t.tgname = 'saga_orphaned_trigger'
+			  AND c.relname = 'saga_instances'
+			  AND n.nspname = current_schema()
+		`).Scan(&count).Error
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), count, "saga_orphaned_trigger should exist")
+	})
+}
+
+// TestOrphanNotifyTriggerFires verifies the PostgreSQL trigger fires
+// NOTIFY when a saga's lease is released (claimed_by_pod becomes NULL).
+func TestOrphanNotifyTriggerFires(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err, "RunSagaMigrations should succeed")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Create a saga instance with a lease
+	sagaID := uuid.New()
+	now := time.Now()
+	pod := "test-pod-1"
+	saga := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		PartyID:          uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ClaimedByPod:     &pod,
+		ClaimedAt:        &now,
+		LeaseExpiresAt:   timePtr(now.Add(5 * time.Minute)),
+	}
+	require.NoError(t, db.Create(saga).Error)
+
+	// Release the lease (set claimed_by_pod to NULL)
+	// This should trigger the NOTIFY (we verify the trigger fired by checking the saga state)
+	err = db.Model(&SagaInstance{}).
+		Where("id = ?", sagaID).
+		Updates(map[string]interface{}{
+			"claimed_by_pod":   nil,
+			"claimed_at":       nil,
+			"lease_expires_at": nil,
+		}).Error
+	require.NoError(t, err)
+
+	// Verify the saga now has NULL claimed_by_pod
+	var updated SagaInstance
+	err = db.First(&updated, "id = ?", sagaID).Error
+	require.NoError(t, err)
+	assert.Nil(t, updated.ClaimedByPod, "claimed_by_pod should be NULL after release")
+
+	_ = ctx // Used for timeout context
+}
+
+// TestOrphanWatcherFallbackToPeriodicScan verifies that when LISTEN fails or
+// DATABASE_URL is not set, the watcher falls back to periodic scanning.
+func TestOrphanWatcherFallbackToPeriodicScan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Track claim scan invocations
+	var scanCount atomic.Int32
+
+	config := NewClaimConfig()
+	config.MaxJitterMS = 0 // Disable jitter for deterministic tests
+	config.PodID = "test-fallback-pod"
+
+	// Create watcher with short fallback interval
+	// Note: DATABASE_URL is not set, so LISTEN will fail and fallback kicks in
+	watcher := NewOrphanWatcher(
+		db,
+		config,
+		slog.Default(),
+		WithOrphanScanCallback(func() {
+			scanCount.Add(1)
+		}),
+		WithFallbackScanInterval(500*time.Millisecond), // Short interval for testing
+	)
+
+	// Start the watcher
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// Wait for periodic scans to occur (should be at least initial + 2 periodic)
+	err = await.New().
+		AtMost(5 * time.Second).
+		PollInterval(100 * time.Millisecond).
+		Until(func() bool {
+			return scanCount.Load() >= 3 // Initial + at least 2 periodic scans
+		})
+	require.NoError(t, err, "expected periodic fallback scans to occur")
+	t.Logf("Fallback scan count: %d", scanCount.Load())
+}
+
+// TestOrphanWatcherClaimsOrphanedSagas verifies the watcher claims orphaned sagas.
+func TestOrphanWatcherClaimsOrphanedSagas(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	config := NewClaimConfig()
+	config.MaxJitterMS = 0
+	config.PodID = "claimer-pod"
+
+	var scanCompleted atomic.Int32
+
+	watcher := NewOrphanWatcher(
+		db,
+		config,
+		slog.Default(),
+		WithOrphanScanCallback(func() {
+			scanCompleted.Add(1)
+		}),
+		WithFallbackScanInterval(200*time.Millisecond),
+	)
+
+	// Create orphaned sagas before starting watcher
+	for i := 0; i < 5; i++ {
+		createTestSaga(t, db, SagaStatusRunning, nil, nil)
+	}
+
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// Wait for sagas to be claimed
+	err = await.New().
+		AtMost(10 * time.Second).
+		PollInterval(100 * time.Millisecond).
+		Until(func() bool {
+			var claimed int64
+			db.Model(&SagaInstance{}).
+				Where("claimed_by_pod = ?", config.PodID).
+				Count(&claimed)
+			return claimed == 5
+		})
+	require.NoError(t, err, "expected all 5 sagas to be claimed")
+
+	// Verify all sagas are claimed by our pod
+	var claimedSagas []SagaInstance
+	err = db.Where("claimed_by_pod = ?", config.PodID).Find(&claimedSagas).Error
+	require.NoError(t, err)
+	assert.Len(t, claimedSagas, 5, "all 5 sagas should be claimed")
+}
+
+// TestOrphanWatcherConcurrentNotifications verifies the watcher handles
+// multiple simultaneous orphan events correctly.
+func TestOrphanWatcherConcurrentNotifications(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var scanCount atomic.Int32
+	var mu sync.Mutex
+	claimedSagas := make(map[uuid.UUID]bool)
+
+	config := NewClaimConfig()
+	config.PodID = "concurrent-test-pod"
+	config.MaxJitterMS = 0
+	config.BatchSize = 50 // Larger batch for concurrent test
+
+	watcher := NewOrphanWatcher(
+		db,
+		config,
+		slog.Default(),
+		WithOrphanScanCallback(func() {
+			scanCount.Add(1)
+		}),
+		WithFallbackScanInterval(100*time.Millisecond),
+	)
+
+	// Create 100 sagas, all with a different "dying" pod
+	now := time.Now()
+	for i := 0; i < 100; i++ {
+		dyingPod := "dying-pod"
+		saga := &SagaInstance{
+			ID:               uuid.New(),
+			SagaDefinitionID: uuid.New(),
+			PartyID:          uuid.New(),
+			CorrelationID:    uuid.New(),
+			Status:           SagaStatusRunning,
+			ClaimedByPod:     &dyingPod,
+			ClaimedAt:        &now,
+			LeaseExpiresAt:   timePtr(now.Add(5 * time.Minute)),
+		}
+		require.NoError(t, db.Create(saga).Error)
+	}
+
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// Simulate pod crash: release all leases at once using raw SQL
+	// This triggers multiple NOTIFY events
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	_, err = sqlDB.ExecContext(ctx, `
+		UPDATE saga_instances
+		SET claimed_by_pod = NULL, claimed_at = NULL, lease_expires_at = NULL
+		WHERE claimed_by_pod = 'dying-pod'
+	`)
+	require.NoError(t, err)
+
+	// Wait for all sagas to be claimed
+	err = await.New().
+		AtMost(30 * time.Second).
+		PollInterval(200 * time.Millisecond).
+		Until(func() bool {
+			var claimed []SagaInstance
+			db.Where("claimed_by_pod = ?", config.PodID).Find(&claimed)
+			mu.Lock()
+			for _, s := range claimed {
+				claimedSagas[s.ID] = true
+			}
+			count := len(claimedSagas)
+			mu.Unlock()
+			return count == 100
+		})
+	require.NoError(t, err, "expected all 100 sagas to be claimed")
+
+	t.Logf("Total scans performed: %d", scanCount.Load())
+	t.Logf("Sagas claimed: %d", len(claimedSagas))
+}
+
+// TestOrphanWatcherGracefulShutdown verifies the watcher shuts down cleanly.
+func TestOrphanWatcherGracefulShutdown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	watcher := NewOrphanWatcher(
+		db,
+		NewClaimConfig(),
+		slog.Default(),
+	)
+
+	// Start and immediately stop
+	watcher.Start(ctx)
+
+	// Stop should complete quickly
+	done := make(chan struct{})
+	go func() {
+		watcher.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success
+	case <-time.After(5 * time.Second):
+		t.Fatal("watcher did not shut down within timeout")
+	}
+}
+
+// TestOrphanWatcherIdempotentStartStop verifies Start/Stop are idempotent.
+func TestOrphanWatcherIdempotentStartStop(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	watcher := NewOrphanWatcher(
+		db,
+		NewClaimConfig(),
+		slog.Default(),
+	)
+
+	// Start multiple times - should not panic or create multiple goroutines
+	watcher.Start(ctx)
+	watcher.Start(ctx) // Second start should be no-op
+	watcher.Start(ctx) // Third start should be no-op
+
+	// Stop multiple times - should not panic
+	watcher.Stop()
+	watcher.Stop() // Second stop should block briefly then return
+	watcher.Stop() // Third stop should block briefly then return
+}
+
+// TestOrphanWatcherDebounce verifies the debounce mechanism prevents
+// excessive scans from rapid notifications.
+func TestOrphanWatcherDebounce(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var scanCount atomic.Int32
+
+	config := NewClaimConfig()
+	config.PodID = "debounce-test-pod"
+	config.MaxJitterMS = 0
+
+	watcher := NewOrphanWatcher(
+		db,
+		config,
+		slog.Default(),
+		WithOrphanScanCallback(func() {
+			scanCount.Add(1)
+		}),
+		WithFallbackScanInterval(5*time.Second), // Long fallback to isolate debounce behavior
+		WithNotificationDebounce(500*time.Millisecond),
+	)
+
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// Wait for initial scan
+	err = await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return scanCount.Load() >= 1
+		})
+	require.NoError(t, err)
+
+	initialScans := scanCount.Load()
+	t.Logf("Initial scans: %d", initialScans)
+
+	// Create multiple orphans in rapid succession to trigger debounce
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+
+	// Create 10 sagas with leases
+	now := time.Now()
+	for i := 0; i < 10; i++ {
+		dyingPod := "rapid-dying-pod"
+		saga := &SagaInstance{
+			ID:               uuid.New(),
+			SagaDefinitionID: uuid.New(),
+			PartyID:          uuid.New(),
+			CorrelationID:    uuid.New(),
+			Status:           SagaStatusRunning,
+			ClaimedByPod:     &dyingPod,
+			ClaimedAt:        &now,
+			LeaseExpiresAt:   timePtr(now.Add(5 * time.Minute)),
+		}
+		require.NoError(t, db.Create(saga).Error)
+	}
+
+	// Release all leases in rapid succession (simulating rapid notifications)
+	for i := 0; i < 10; i++ {
+		_, _ = sqlDB.ExecContext(ctx, `
+			UPDATE saga_instances
+			SET claimed_by_pod = NULL, claimed_at = NULL, lease_expires_at = NULL
+			WHERE claimed_by_pod = 'rapid-dying-pod'
+			LIMIT 1
+		`)
+		// Ignore errors - some updates may not match any rows
+		time.Sleep(10 * time.Millisecond) // Small delay between updates
+	}
+
+	// Wait a bit for any scans to complete
+	time.Sleep(1 * time.Second)
+
+	finalScans := scanCount.Load()
+	additionalScans := finalScans - initialScans
+
+	t.Logf("Final scans: %d, Additional scans: %d", finalScans, additionalScans)
+
+	// Due to debouncing, we should have far fewer scans than notifications
+	// (10 rapid notifications should not result in 10 scans)
+	// The fallback interval is 5s, so within 1s we should see debounced behavior
+	assert.Less(t, additionalScans, int32(10),
+		"debouncing should reduce number of scans from rapid notifications")
+}
+
+// Helper functions
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/shared/pkg/saga/orphan_watcher_test.go
+++ b/shared/pkg/saga/orphan_watcher_test.go
@@ -3,7 +3,6 @@ package saga
 import (
 	"context"
 	"log/slog"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,105 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestOrphanNotifyTriggerCreated verifies the PostgreSQL trigger and function
-// are created by RunSagaMigrations.
-func TestOrphanNotifyTriggerCreated(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
-	db, cleanup := setupTestPostgres(t)
-	defer cleanup()
-
-	err := RunSagaMigrations(db)
-	require.NoError(t, err, "RunSagaMigrations should succeed")
-
-	// Verify the trigger function exists
-	t.Run("notify_saga_orphaned function exists", func(t *testing.T) {
-		var count int64
-		err := db.Raw(`
-			SELECT COUNT(*)
-			FROM pg_proc p
-			JOIN pg_namespace n ON n.oid = p.pronamespace
-			WHERE p.proname = 'notify_saga_orphaned'
-			  AND n.nspname = current_schema()
-		`).Scan(&count).Error
-		require.NoError(t, err)
-		assert.Equal(t, int64(1), count, "notify_saga_orphaned function should exist")
-	})
-
-	// Verify the trigger exists
-	t.Run("saga_orphaned_trigger exists", func(t *testing.T) {
-		var count int64
-		err := db.Raw(`
-			SELECT COUNT(*)
-			FROM pg_trigger t
-			JOIN pg_class c ON c.oid = t.tgrelid
-			JOIN pg_namespace n ON n.oid = c.relnamespace
-			WHERE t.tgname = 'saga_orphaned_trigger'
-			  AND c.relname = 'saga_instances'
-			  AND n.nspname = current_schema()
-		`).Scan(&count).Error
-		require.NoError(t, err)
-		assert.Equal(t, int64(1), count, "saga_orphaned_trigger should exist")
-	})
-}
-
-// TestOrphanNotifyTriggerFires verifies the PostgreSQL trigger fires
-// NOTIFY when a saga's lease is released (claimed_by_pod becomes NULL).
-func TestOrphanNotifyTriggerFires(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
-
-	db, cleanup := setupTestPostgres(t)
-	defer cleanup()
-
-	err := RunSagaMigrations(db)
-	require.NoError(t, err, "RunSagaMigrations should succeed")
-
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	// Create a saga instance with a lease
-	sagaID := uuid.New()
-	now := time.Now()
-	pod := "test-pod-1"
-	saga := &SagaInstance{
-		ID:               sagaID,
-		SagaDefinitionID: uuid.New(),
-		PartyID:          uuid.New(),
-		CorrelationID:    uuid.New(),
-		Status:           SagaStatusRunning,
-		ClaimedByPod:     &pod,
-		ClaimedAt:        &now,
-		LeaseExpiresAt:   timePtr(now.Add(5 * time.Minute)),
-	}
-	require.NoError(t, db.Create(saga).Error)
-
-	// Release the lease (set claimed_by_pod to NULL)
-	// This should trigger the NOTIFY (we verify the trigger fired by checking the saga state)
-	err = db.Model(&SagaInstance{}).
-		Where("id = ?", sagaID).
-		Updates(map[string]interface{}{
-			"claimed_by_pod":   nil,
-			"claimed_at":       nil,
-			"lease_expires_at": nil,
-		}).Error
-	require.NoError(t, err)
-
-	// Verify the saga now has NULL claimed_by_pod
-	var updated SagaInstance
-	err = db.First(&updated, "id = ?", sagaID).Error
-	require.NoError(t, err)
-	assert.Nil(t, updated.ClaimedByPod, "claimed_by_pod should be NULL after release")
-
-	_ = ctx // Used for timeout context
-}
-
-// TestOrphanWatcherFallbackToPeriodicScan verifies that when LISTEN fails or
-// DATABASE_URL is not set, the watcher falls back to periodic scanning.
-func TestOrphanWatcherFallbackToPeriodicScan(t *testing.T) {
+// TestOrphanWatcherPeriodicScan verifies that the watcher performs periodic scans.
+func TestOrphanWatcherPeriodicScan(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -126,15 +28,14 @@ func TestOrphanWatcherFallbackToPeriodicScan(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	// Track claim scan invocations
+	// Track scan invocations
 	var scanCount atomic.Int32
 
 	config := NewClaimConfig()
 	config.MaxJitterMS = 0 // Disable jitter for deterministic tests
-	config.PodID = "test-fallback-pod"
+	config.PodID = "test-periodic-pod"
 
-	// Create watcher with short fallback interval
-	// Note: DATABASE_URL is not set, so LISTEN will fail and fallback kicks in
+	// Create watcher with short scan interval
 	watcher := NewOrphanWatcher(
 		db,
 		config,
@@ -142,7 +43,7 @@ func TestOrphanWatcherFallbackToPeriodicScan(t *testing.T) {
 		WithOrphanScanCallback(func() {
 			scanCount.Add(1)
 		}),
-		WithFallbackScanInterval(500*time.Millisecond), // Short interval for testing
+		WithScanInterval(200*time.Millisecond), // Short interval for testing
 	)
 
 	// Start the watcher
@@ -156,8 +57,8 @@ func TestOrphanWatcherFallbackToPeriodicScan(t *testing.T) {
 		Until(func() bool {
 			return scanCount.Load() >= 3 // Initial + at least 2 periodic scans
 		})
-	require.NoError(t, err, "expected periodic fallback scans to occur")
-	t.Logf("Fallback scan count: %d", scanCount.Load())
+	require.NoError(t, err, "expected periodic scans to occur")
+	t.Logf("Scan count: %d", scanCount.Load())
 }
 
 // TestOrphanWatcherClaimsOrphanedSagas verifies the watcher claims orphaned sagas.
@@ -188,7 +89,7 @@ func TestOrphanWatcherClaimsOrphanedSagas(t *testing.T) {
 		WithOrphanScanCallback(func() {
 			scanCompleted.Add(1)
 		}),
-		WithFallbackScanInterval(200*time.Millisecond),
+		WithScanInterval(200*time.Millisecond),
 	)
 
 	// Create orphaned sagas before starting watcher
@@ -219,9 +120,9 @@ func TestOrphanWatcherClaimsOrphanedSagas(t *testing.T) {
 	assert.Len(t, claimedSagas, 5, "all 5 sagas should be claimed")
 }
 
-// TestOrphanWatcherConcurrentNotifications verifies the watcher handles
-// multiple simultaneous orphan events correctly.
-func TestOrphanWatcherConcurrentNotifications(t *testing.T) {
+// TestOrphanWatcherClaimsConcurrentOrphans verifies the watcher handles
+// multiple orphaned sagas correctly.
+func TestOrphanWatcherClaimsConcurrentOrphans(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -236,8 +137,6 @@ func TestOrphanWatcherConcurrentNotifications(t *testing.T) {
 	defer cancel()
 
 	var scanCount atomic.Int32
-	var mu sync.Mutex
-	claimedSagas := make(map[uuid.UUID]bool)
 
 	config := NewClaimConfig()
 	config.PodID = "concurrent-test-pod"
@@ -251,59 +150,31 @@ func TestOrphanWatcherConcurrentNotifications(t *testing.T) {
 		WithOrphanScanCallback(func() {
 			scanCount.Add(1)
 		}),
-		WithFallbackScanInterval(100*time.Millisecond),
+		WithScanInterval(100*time.Millisecond),
 	)
 
-	// Create 100 sagas, all with a different "dying" pod
-	now := time.Now()
+	// Create 100 orphaned sagas (no claimed_by_pod)
 	for i := 0; i < 100; i++ {
-		dyingPod := "dying-pod"
-		saga := &SagaInstance{
-			ID:               uuid.New(),
-			SagaDefinitionID: uuid.New(),
-			PartyID:          uuid.New(),
-			CorrelationID:    uuid.New(),
-			Status:           SagaStatusRunning,
-			ClaimedByPod:     &dyingPod,
-			ClaimedAt:        &now,
-			LeaseExpiresAt:   timePtr(now.Add(5 * time.Minute)),
-		}
-		require.NoError(t, db.Create(saga).Error)
+		createTestSaga(t, db, SagaStatusRunning, nil, nil)
 	}
 
 	watcher.Start(ctx)
 	defer watcher.Stop()
-
-	// Simulate pod crash: release all leases at once using raw SQL
-	// This triggers multiple NOTIFY events
-	sqlDB, err := db.DB()
-	require.NoError(t, err)
-	_, err = sqlDB.ExecContext(ctx, `
-		UPDATE saga_instances
-		SET claimed_by_pod = NULL, claimed_at = NULL, lease_expires_at = NULL
-		WHERE claimed_by_pod = 'dying-pod'
-	`)
-	require.NoError(t, err)
 
 	// Wait for all sagas to be claimed
 	err = await.New().
 		AtMost(30 * time.Second).
 		PollInterval(200 * time.Millisecond).
 		Until(func() bool {
-			var claimed []SagaInstance
-			db.Where("claimed_by_pod = ?", config.PodID).Find(&claimed)
-			mu.Lock()
-			for _, s := range claimed {
-				claimedSagas[s.ID] = true
-			}
-			count := len(claimedSagas)
-			mu.Unlock()
-			return count == 100
+			var claimed int64
+			db.Model(&SagaInstance{}).
+				Where("claimed_by_pod = ?", config.PodID).
+				Count(&claimed)
+			return claimed == 100
 		})
 	require.NoError(t, err, "expected all 100 sagas to be claimed")
 
 	t.Logf("Total scans performed: %d", scanCount.Load())
-	t.Logf("Sagas claimed: %d", len(claimedSagas))
 }
 
 // TestOrphanWatcherGracefulShutdown verifies the watcher shuts down cleanly.
@@ -377,9 +248,9 @@ func TestOrphanWatcherIdempotentStartStop(t *testing.T) {
 	watcher.Stop() // Third stop should block briefly then return
 }
 
-// TestOrphanWatcherDebounce verifies the debounce mechanism prevents
-// excessive scans from rapid notifications.
-func TestOrphanWatcherDebounce(t *testing.T) {
+// TestOrphanWatcherClaimsExpiredLeases verifies the watcher claims sagas
+// with expired leases (simulating pod crash scenario).
+func TestOrphanWatcherClaimsExpiredLeases(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -393,95 +264,49 @@ func TestOrphanWatcherDebounce(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	var scanCount atomic.Int32
-
 	config := NewClaimConfig()
-	config.PodID = "debounce-test-pod"
 	config.MaxJitterMS = 0
+	config.PodID = "new-claimer-pod"
 
 	watcher := NewOrphanWatcher(
 		db,
 		config,
 		slog.Default(),
-		WithOrphanScanCallback(func() {
-			scanCount.Add(1)
-		}),
-		WithFallbackScanInterval(5*time.Second), // Long fallback to isolate debounce behavior
-		WithNotificationDebounce(500*time.Millisecond),
+		WithScanInterval(200*time.Millisecond),
 	)
 
-	watcher.Start(ctx)
-	defer watcher.Stop()
-
-	// Wait for initial scan
-	err = await.New().
-		AtMost(2 * time.Second).
-		PollInterval(50 * time.Millisecond).
-		Until(func() bool {
-			return scanCount.Load() >= 1
-		})
-	require.NoError(t, err)
-
-	initialScans := scanCount.Load()
-	t.Logf("Initial scans: %d", initialScans)
-
-	// Create multiple orphans in rapid succession to trigger debounce
-	sqlDB, err := db.DB()
-	require.NoError(t, err)
-
-	// Create 10 sagas with leases
+	// Create sagas with expired leases (simulating crashed pod)
 	now := time.Now()
-	for i := 0; i < 10; i++ {
-		dyingPod := "rapid-dying-pod"
+	expiredLease := now.Add(-10 * time.Minute)
+	deadPod := "dead-pod"
+
+	for i := 0; i < 5; i++ {
 		saga := &SagaInstance{
 			ID:               uuid.New(),
 			SagaDefinitionID: uuid.New(),
 			PartyID:          uuid.New(),
 			CorrelationID:    uuid.New(),
 			Status:           SagaStatusRunning,
-			ClaimedByPod:     &dyingPod,
+			ClaimedByPod:     &deadPod,
 			ClaimedAt:        &now,
-			LeaseExpiresAt:   timePtr(now.Add(5 * time.Minute)),
+			LeaseExpiresAt:   &expiredLease, // Lease already expired
 		}
 		require.NoError(t, db.Create(saga).Error)
 	}
 
-	// Release all leases in rapid succession (simulating rapid notifications)
-	// PostgreSQL doesn't support LIMIT in UPDATE, so use CTE with ctid
-	for i := 0; i < 10; i++ {
-		_, _ = sqlDB.ExecContext(ctx, `
-			WITH to_upd AS (
-				SELECT ctid
-				FROM saga_instances
-				WHERE claimed_by_pod = 'rapid-dying-pod'
-				LIMIT 1
-				FOR UPDATE SKIP LOCKED
-			)
-			UPDATE saga_instances
-			SET claimed_by_pod = NULL, claimed_at = NULL, lease_expires_at = NULL
-			FROM to_upd
-			WHERE saga_instances.ctid = to_upd.ctid
-		`)
-		// Ignore errors - some updates may not match any rows
-		time.Sleep(10 * time.Millisecond) // Small delay between updates
-	}
+	watcher.Start(ctx)
+	defer watcher.Stop()
 
-	// Wait a bit for any scans to complete
-	time.Sleep(1 * time.Second)
-
-	finalScans := scanCount.Load()
-	additionalScans := finalScans - initialScans
-
-	t.Logf("Final scans: %d, Additional scans: %d", finalScans, additionalScans)
-
-	// Due to debouncing, we should have far fewer scans than notifications
-	// (10 rapid notifications should not result in 10 scans)
-	// The fallback interval is 5s, so within 1s we should see debounced behavior
-	assert.Less(t, additionalScans, int32(10),
-		"debouncing should reduce number of scans from rapid notifications")
-}
-
-// Helper functions
-func timePtr(t time.Time) *time.Time {
-	return &t
+	// Wait for sagas to be claimed by the new pod
+	err = await.New().
+		AtMost(10 * time.Second).
+		PollInterval(100 * time.Millisecond).
+		Until(func() bool {
+			var claimed int64
+			db.Model(&SagaInstance{}).
+				Where("claimed_by_pod = ?", config.PodID).
+				Count(&claimed)
+			return claimed == 5
+		})
+	require.NoError(t, err, "expected all 5 sagas with expired leases to be claimed")
 }

--- a/shared/pkg/saga/orphan_watcher_test.go
+++ b/shared/pkg/saga/orphan_watcher_test.go
@@ -447,12 +447,20 @@ func TestOrphanWatcherDebounce(t *testing.T) {
 	}
 
 	// Release all leases in rapid succession (simulating rapid notifications)
+	// PostgreSQL doesn't support LIMIT in UPDATE, so use CTE with ctid
 	for i := 0; i < 10; i++ {
 		_, _ = sqlDB.ExecContext(ctx, `
+			WITH to_upd AS (
+				SELECT ctid
+				FROM saga_instances
+				WHERE claimed_by_pod = 'rapid-dying-pod'
+				LIMIT 1
+				FOR UPDATE SKIP LOCKED
+			)
 			UPDATE saga_instances
 			SET claimed_by_pod = NULL, claimed_at = NULL, lease_expires_at = NULL
-			WHERE claimed_by_pod = 'rapid-dying-pod'
-			LIMIT 1
+			FROM to_upd
+			WHERE saga_instances.ctid = to_upd.ctid
 		`)
 		// Ignore errors - some updates may not match any rows
 		time.Sleep(10 * time.Millisecond) // Small delay between updates

--- a/shared/pkg/saga/suspend.go
+++ b/shared/pkg/saga/suspend.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -397,8 +398,13 @@ func isDuplicateKeyError(err error) bool {
 		return false
 	}
 	errStr := err.Error()
-	// PostgreSQL duplicate key error codes/messages
+	// PostgreSQL/CockroachDB duplicate key error codes/messages
 	return containsIgnoreCase(errStr, "duplicate key") ||
 		containsIgnoreCase(errStr, "unique constraint") ||
 		containsIgnoreCase(errStr, "23505") // PostgreSQL unique_violation error code
+}
+
+// containsIgnoreCase checks if s contains substr, case-insensitively.
+func containsIgnoreCase(s, substr string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
 }

--- a/shared/pkg/saga/test_helpers_test.go
+++ b/shared/pkg/saga/test_helpers_test.go
@@ -1,0 +1,15 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"gorm.io/gorm"
+)
+
+// setupTestPostgres creates a CockroachDB testcontainer for integration testing.
+// Named setupTestPostgres for historical compatibility - CockroachDB is wire-compatible
+// with PostgreSQL and is our production database.
+func setupTestPostgres(t *testing.T) (*gorm.DB, func()) {
+	return testdb.SetupCockroachDB(t, nil)
+}

--- a/shared/pkg/saga/validator.go
+++ b/shared/pkg/saga/validator.go
@@ -65,9 +65,6 @@ var (
 
 	// ErrExcessiveLoopNesting is returned when loop nesting exceeds MaxLoopNestingDepth.
 	ErrExcessiveLoopNesting = errors.New("excessive loop nesting")
-
-	// ErrValidationFailed is returned when activation validation fails.
-	ErrValidationFailed = errors.New("validation failed")
 )
 
 // blockedFunctions is the set of function names that are not allowed in saga scripts.


### PR DESCRIPTION
## Summary
Implements reactive orphan wake-up for saga recovery using a polling-based approach compatible with CockroachDB. This ensures orphaned sagas (from pod crashes) are detected and re-claimed within seconds.

## Changes Made
- Added `OrphanWatcher` with configurable scan intervals (default 10s)
- Implemented efficient orphan detection using existing partial index
- Added Prometheus metrics for scan operations, errors, and claimed sagas
- Updated migrations to use CockroachDB-compatible SQL (information_schema instead of pg_constraint)
- Added comprehensive integration tests using CockroachDB testcontainers

## Technical Details
- **Polling-based approach**: CockroachDB doesn't support PostgreSQL LISTEN/NOTIFY or PL/pgSQL triggers, so we use periodic scanning
- **Default scan interval**: 10 seconds (configurable via `WithScanInterval`)
- **Graceful shutdown**: Clean stop with context cancellation and WaitGroup
- **Single-use lifecycle**: Watcher is designed for one start/stop cycle per instance
- **Metrics exposed**: `saga_orphan_scans_total`, `saga_orphan_scan_errors_total`, `saga_orphans_claimed_total`, `saga_orphan_scan_duration_seconds`

## Testing
- Unit tests for watcher lifecycle (start/stop/idempotency)
- Integration tests with CockroachDB testcontainers
- Verified graceful shutdown behavior
- Tested concurrent orphan claiming

## Task Reference
Task Master: starlark-saga-orchestration.18

---
Related to FR-23: Reactive orphan wake-up with <10 second latency target.