### PR TITLE
feat(saga): Add semantic linter for Starlark scripts (FR-33)

### DIFF
--- a/shared/pkg/saga/linter.go
+++ b/shared/pkg/saga/linter.go
@@ -1,0 +1,595 @@
+package saga
+
+import (
+	"fmt"
+	"strings"
+
+	"go.starlark.net/syntax"
+)
+
+// LintIssueType categorizes the kind of lint issue detected.
+type LintIssueType string
+
+const (
+	// LintIssueTypeDecimalArithmetic indicates Decimal math that should be in CEL.
+	LintIssueTypeDecimalArithmetic LintIssueType = "DECIMAL_ARITHMETIC"
+
+	// LintIssueTypeMagicNumber indicates a hardcoded numeric literal.
+	LintIssueTypeMagicNumber LintIssueType = "MAGIC_NUMBER"
+
+	// LintIssueTypeNestedConditional indicates excessive if/else nesting.
+	LintIssueTypeNestedConditional LintIssueType = "NESTED_CONDITIONAL"
+
+	// LintIssueTypeHardcodedCode indicates a hardcoded instrument/account code.
+	LintIssueTypeHardcodedCode LintIssueType = "HARDCODED_CODE"
+
+	// LintIssueTypeMissingPreCheck indicates an external step without verify_external_state.
+	LintIssueTypeMissingPreCheck LintIssueType = "MISSING_PRE_CHECK"
+)
+
+// LintSeverity indicates how severe the lint issue is.
+type LintSeverity string
+
+const (
+	// LintSeverityWarning allows save/activation but logs a warning.
+	LintSeverityWarning LintSeverity = "WARNING"
+
+	// LintSeverityError blocks activation.
+	LintSeverityError LintSeverity = "ERROR"
+)
+
+// EnforcementLevel configures how strictly a rule is enforced.
+type EnforcementLevel string
+
+const (
+	// EnforcementLevelWarning logs warnings but allows activation.
+	EnforcementLevelWarning EnforcementLevel = "WARNING"
+
+	// EnforcementLevelError blocks activation.
+	EnforcementLevelError EnforcementLevel = "ERROR"
+)
+
+// LintIssue represents a single lint finding.
+type LintIssue struct {
+	Type         LintIssueType
+	Severity     LintSeverity
+	LineNumber   int
+	Message      string
+	SuggestedFix string
+}
+
+// HandlerMetadata describes a step handler's characteristics.
+type HandlerMetadata struct {
+	// IsExternal indicates the handler calls external systems (non-idempotent).
+	IsExternal bool
+
+	// RequiresPreCheck indicates verify_external_state must be called before this handler.
+	RequiresPreCheck bool
+}
+
+// SemanticLinter performs AST-based semantic analysis on Starlark scripts.
+// It detects financial math, complex logic, and Pre-Step Check violations.
+type SemanticLinter struct {
+	// enforcementLevels maps issue types to their enforcement level.
+	enforcementLevels map[LintIssueType]EnforcementLevel
+
+	// handlerMetadata maps handler names to their metadata.
+	handlerMetadata map[string]HandlerMetadata
+}
+
+// NewSemanticLinter creates a new linter with default enforcement levels.
+func NewSemanticLinter() *SemanticLinter {
+	return &SemanticLinter{
+		enforcementLevels: map[LintIssueType]EnforcementLevel{
+			LintIssueTypeDecimalArithmetic: EnforcementLevelWarning,
+			LintIssueTypeMagicNumber:       EnforcementLevelWarning,
+			LintIssueTypeNestedConditional: EnforcementLevelWarning,
+			LintIssueTypeHardcodedCode:     EnforcementLevelWarning,
+			LintIssueTypeMissingPreCheck:   EnforcementLevelError, // External handlers require pre-check
+		},
+		handlerMetadata: make(map[string]HandlerMetadata),
+	}
+}
+
+// SetEnforcementLevel configures the enforcement level for a specific issue type.
+func (l *SemanticLinter) SetEnforcementLevel(issueType LintIssueType, level EnforcementLevel) {
+	l.enforcementLevels[issueType] = level
+}
+
+// SetHandlerMetadata configures the known handler metadata for Pre-Step Check validation.
+func (l *SemanticLinter) SetHandlerMetadata(metadata map[string]HandlerMetadata) {
+	l.handlerMetadata = metadata
+}
+
+// Analyze parses and lints a Starlark script, returning any issues found.
+func (l *SemanticLinter) Analyze(script string) ([]LintIssue, error) {
+	if script == "" {
+		return nil, nil
+	}
+
+	fileOpts := &syntax.FileOptions{}
+	file, err := fileOpts.Parse("script.star", script, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	visitor := &lintVisitor{
+		linter:           l,
+		issues:           make([]LintIssue, 0),
+		ifDepth:          0,
+		verifiedHandlers: make(map[string]bool),
+		decimalVars:      make(map[string]bool),
+		counterVars:      make(map[string]bool),
+		inLoopInit:       false,
+	}
+
+	for _, stmt := range file.Stmts {
+		visitor.walkStmt(stmt)
+	}
+
+	return visitor.issues, nil
+}
+
+// HasBlockingIssues returns true if any issues have ERROR severity.
+func (l *SemanticLinter) HasBlockingIssues(issues []LintIssue) bool {
+	for _, issue := range issues {
+		if issue.Severity == LintSeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// lintVisitor walks the AST to detect lint issues.
+type lintVisitor struct {
+	linter           *SemanticLinter
+	issues           []LintIssue
+	ifDepth          int
+	verifiedHandlers map[string]bool // handlers that have verify_external_state called
+	decimalVars      map[string]bool // variables that hold Decimal values
+	counterVars      map[string]bool // variables that are loop counters
+	inLoopInit       bool            // true when walking loop initialization
+}
+
+// walkStmt walks a statement node.
+//
+//nolint:gocognit,gocyclo // AST walking requires handling many statement types
+func (v *lintVisitor) walkStmt(stmt syntax.Stmt) {
+	switch s := stmt.(type) {
+	case *syntax.ExprStmt:
+		v.walkExpr(s.X)
+
+	case *syntax.AssignStmt:
+		// Track Decimal variable assignments
+		if ident, ok := s.LHS.(*syntax.Ident); ok {
+			if v.isDecimalExpr(s.RHS) {
+				v.decimalVars[ident.Name] = true
+			}
+			// Track counter patterns: i = i + 1 or i = 0
+			if v.isCounterAssignment(ident.Name, s.RHS) {
+				v.counterVars[ident.Name] = true
+			}
+		}
+		v.walkExpr(s.LHS)
+		v.walkExpr(s.RHS)
+
+	case *syntax.DefStmt:
+		for _, stmt := range s.Body {
+			v.walkStmt(stmt)
+		}
+
+	case *syntax.IfStmt:
+		v.ifDepth++
+		if v.ifDepth > 3 {
+			v.addIssue(LintIssueTypeNestedConditional, int(s.If.Line),
+				fmt.Sprintf("Nested conditionals exceed 3 levels (found %d)", v.ifDepth),
+				"Refactor to flatten conditionals or extract to helper functions")
+		}
+
+		v.walkExpr(s.Cond)
+		for _, stmt := range s.True {
+			v.walkStmt(stmt)
+		}
+		for _, stmt := range s.False {
+			v.walkStmt(stmt)
+		}
+		v.ifDepth--
+
+	case *syntax.ForStmt:
+		// Track loop variable as counter
+		if ident, ok := s.Vars.(*syntax.Ident); ok {
+			v.counterVars[ident.Name] = true
+		}
+		v.inLoopInit = true
+		v.walkExpr(s.X)
+		v.inLoopInit = false
+		for _, stmt := range s.Body {
+			v.walkStmt(stmt)
+		}
+
+	case *syntax.WhileStmt:
+		v.walkExpr(s.Cond)
+		for _, stmt := range s.Body {
+			v.walkStmt(stmt)
+		}
+
+	case *syntax.ReturnStmt:
+		if s.Result != nil {
+			v.walkExpr(s.Result)
+		}
+	}
+}
+
+// walkExpr walks an expression node.
+//
+//nolint:gocognit,gocyclo // AST walking requires handling many expression types
+func (v *lintVisitor) walkExpr(expr syntax.Expr) {
+	if expr == nil {
+		return
+	}
+
+	switch e := expr.(type) {
+	case *syntax.CallExpr:
+		v.checkCallExpr(e)
+
+		v.walkExpr(e.Fn)
+		for _, arg := range e.Args {
+			v.walkExpr(arg)
+		}
+
+	case *syntax.BinaryExpr:
+		v.checkBinaryExpr(e)
+
+		v.walkExpr(e.X)
+		v.walkExpr(e.Y)
+
+	case *syntax.UnaryExpr:
+		v.walkExpr(e.X)
+
+	case *syntax.CondExpr:
+		v.walkExpr(e.Cond)
+		v.walkExpr(e.True)
+		v.walkExpr(e.False)
+
+	case *syntax.IndexExpr:
+		v.walkExpr(e.X)
+		v.walkExpr(e.Y)
+
+	case *syntax.SliceExpr:
+		v.walkExpr(e.X)
+		v.walkExpr(e.Lo)
+		v.walkExpr(e.Hi)
+		v.walkExpr(e.Step)
+
+	case *syntax.ListExpr:
+		for _, elem := range e.List {
+			v.walkExpr(elem)
+		}
+
+	case *syntax.DictExpr:
+		for _, entry := range e.List {
+			if dictEntry, ok := entry.(*syntax.DictEntry); ok {
+				v.walkExpr(dictEntry.Key)
+				v.walkExpr(dictEntry.Value)
+			}
+		}
+
+	case *syntax.TupleExpr:
+		for _, elem := range e.List {
+			v.walkExpr(elem)
+		}
+
+	case *syntax.Comprehension:
+		for _, clause := range e.Clauses {
+			if forClause, ok := clause.(*syntax.ForClause); ok {
+				// Track comprehension variable as counter
+				if ident, ok := forClause.Vars.(*syntax.Ident); ok {
+					v.counterVars[ident.Name] = true
+				}
+				v.walkExpr(forClause.X)
+			}
+			if ifClause, ok := clause.(*syntax.IfClause); ok {
+				v.walkExpr(ifClause.Cond)
+			}
+		}
+		v.walkExpr(e.Body)
+
+	case *syntax.LambdaExpr:
+		v.walkExpr(e.Body)
+
+	case *syntax.DotExpr:
+		v.walkExpr(e.X)
+
+	case *syntax.ParenExpr:
+		v.walkExpr(e.X)
+
+	case *syntax.Literal:
+		v.checkLiteral(e)
+	}
+}
+
+// checkCallExpr checks function calls for lint issues.
+func (v *lintVisitor) checkCallExpr(e *syntax.CallExpr) {
+	ident, ok := e.Fn.(*syntax.Ident)
+	if !ok {
+		return
+	}
+
+	switch ident.Name {
+	case "verify_external_state":
+		v.handleVerifyExternalState(e)
+	case "step":
+		v.handleStepCall(e)
+	case "valuate":
+		v.handleValuateCall(e)
+	case "resolve_account", "resolve_instrument":
+		v.handleResolveCall(e)
+	}
+}
+
+// handleVerifyExternalState tracks verified handlers.
+func (v *lintVisitor) handleVerifyExternalState(e *syntax.CallExpr) {
+	if handlerName := v.extractHandlerArg(e); handlerName != "" {
+		v.verifiedHandlers[handlerName] = true
+	}
+}
+
+// handleStepCall checks if external handler has Pre-Step Check.
+func (v *lintVisitor) handleStepCall(e *syntax.CallExpr) {
+	handlerName := v.extractHandlerArg(e)
+	if handlerName == "" {
+		return
+	}
+
+	meta, ok := v.linter.handlerMetadata[handlerName]
+	if !ok || !meta.IsExternal || !meta.RequiresPreCheck {
+		return
+	}
+
+	if v.verifiedHandlers[handlerName] {
+		return
+	}
+
+	stepName := v.extractStepName(e)
+	v.addIssue(LintIssueTypeMissingPreCheck, int(e.Lparen.Line),
+		fmt.Sprintf("External handler %q requires Pre-Step Check", handlerName),
+		fmt.Sprintf("Add verify_external_state before step '%s'", stepName))
+}
+
+// handleValuateCall checks for hardcoded instrument codes.
+func (v *lintVisitor) handleValuateCall(e *syntax.CallExpr) {
+	if hardcoded := v.extractHardcodedArg(e, "instrument"); hardcoded != "" {
+		v.addIssue(LintIssueTypeHardcodedCode, int(e.Lparen.Line),
+			fmt.Sprintf("Hardcoded instrument code %q detected", hardcoded),
+			"Use parameters or resolve_instrument(reference=...) instead")
+	}
+}
+
+// handleResolveCall checks for hardcoded reference strings.
+func (v *lintVisitor) handleResolveCall(e *syntax.CallExpr) {
+	if hardcoded := v.extractHardcodedArg(e, "reference"); hardcoded != "" {
+		v.addIssue(LintIssueTypeHardcodedCode, int(e.Lparen.Line),
+			fmt.Sprintf("Hardcoded reference %q detected", hardcoded),
+			"Use parameters from saga input instead of hardcoded references")
+	}
+}
+
+// checkBinaryExpr checks binary operations for Decimal arithmetic.
+//
+//nolint:exhaustive // We only care about arithmetic operators
+func (v *lintVisitor) checkBinaryExpr(e *syntax.BinaryExpr) {
+	// Only check arithmetic operators
+	switch e.Op {
+	case syntax.PLUS, syntax.MINUS, syntax.STAR, syntax.SLASH:
+		// OK
+	default:
+		return
+	}
+
+	// Check if either operand involves Decimal
+	leftIsDecimal := v.isDecimalExpr(e.X)
+	rightIsDecimal := v.isDecimalExpr(e.Y)
+
+	if !leftIsDecimal && !rightIsDecimal {
+		return
+	}
+
+	// Exempt counter arithmetic (i + 1, count - 1)
+	if v.isCounterArithmetic(e) {
+		return
+	}
+
+	// Exempt index expressions (items[i + offset])
+	// This is handled by not flagging when we're in an index expression context
+	// The parent IndexExpr will contain this, so we check if operands are counters
+	if v.isIndexArithmetic(e) {
+		return
+	}
+
+	v.addIssue(LintIssueTypeDecimalArithmetic, int(e.OpPos.Line),
+		"Financial math detected. Move this to a CEL Valuation Strategy in Reference Data.",
+		"Extract to CEL expression: cel_eval('qty * rate', {...})")
+}
+
+// checkLiteral checks literals for magic numbers.
+func (v *lintVisitor) checkLiteral(e *syntax.Literal) {
+	// Only check float literals (magic decimal numbers)
+	if e.Token != syntax.FLOAT {
+		return
+	}
+
+	// Skip if we're in loop initialization (range bounds)
+	if v.inLoopInit {
+		return
+	}
+
+	v.addIssue(LintIssueTypeMagicNumber, int(e.TokenPos.Line),
+		"Magic number detected. Use a named constant or configuration.",
+		"Define as a constant: RATE = Decimal(\"...\") or use config lookup")
+}
+
+// isDecimalExpr returns true if the expression produces a Decimal value.
+func (v *lintVisitor) isDecimalExpr(expr syntax.Expr) bool {
+	switch e := expr.(type) {
+	case *syntax.CallExpr:
+		// Decimal("...") constructor
+		if ident, ok := e.Fn.(*syntax.Ident); ok {
+			if ident.Name == "Decimal" {
+				return true
+			}
+			// valuate() returns validated rates - not subject to linting
+			if ident.Name == "valuate" {
+				return false
+			}
+		}
+		return false
+
+	case *syntax.Ident:
+		// Check if variable is known to hold a Decimal
+		return v.decimalVars[e.Name]
+
+	case *syntax.BinaryExpr:
+		// Arithmetic on Decimals produces Decimal
+		return v.isDecimalExpr(e.X) || v.isDecimalExpr(e.Y)
+
+	case *syntax.ParenExpr:
+		return v.isDecimalExpr(e.X)
+
+	default:
+		return false
+	}
+}
+
+// isCounterAssignment checks if this is a counter variable assignment.
+func (v *lintVisitor) isCounterAssignment(varName string, rhs syntax.Expr) bool {
+	// i = 0 pattern
+	if lit, ok := rhs.(*syntax.Literal); ok {
+		if lit.Token == syntax.INT {
+			val := lit.Value
+			if val == 0 || val == 1 {
+				return true
+			}
+		}
+	}
+
+	// i = i + 1 pattern
+	if bin, ok := rhs.(*syntax.BinaryExpr); ok {
+		if bin.Op == syntax.PLUS || bin.Op == syntax.MINUS {
+			if ident, ok := bin.X.(*syntax.Ident); ok && ident.Name == varName {
+				if lit, ok := bin.Y.(*syntax.Literal); ok && lit.Token == syntax.INT {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// isCounterArithmetic checks if the binary expression is counter arithmetic.
+func (v *lintVisitor) isCounterArithmetic(e *syntax.BinaryExpr) bool {
+	// Only + or - can be counter arithmetic
+	if e.Op != syntax.PLUS && e.Op != syntax.MINUS {
+		return false
+	}
+
+	// Check if left operand is a counter variable
+	if ident, ok := e.X.(*syntax.Ident); ok {
+		if v.counterVars[ident.Name] {
+			// Check if right operand is a small integer
+			if lit, ok := e.Y.(*syntax.Literal); ok && lit.Token == syntax.INT {
+				return true
+			}
+		}
+	}
+
+	// Check reverse: 1 + i
+	if ident, ok := e.Y.(*syntax.Ident); ok {
+		if v.counterVars[ident.Name] {
+			if lit, ok := e.X.(*syntax.Literal); ok && lit.Token == syntax.INT {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// isIndexArithmetic checks if this is index arithmetic (i + offset).
+func (v *lintVisitor) isIndexArithmetic(e *syntax.BinaryExpr) bool {
+	// Both operands should be counter variables or integers
+	leftOK := v.isCounterOrInt(e.X)
+	rightOK := v.isCounterOrInt(e.Y)
+
+	return leftOK && rightOK
+}
+
+// isCounterOrInt returns true if expr is a counter variable or integer.
+func (v *lintVisitor) isCounterOrInt(expr syntax.Expr) bool {
+	if ident, ok := expr.(*syntax.Ident); ok {
+		return v.counterVars[ident.Name]
+	}
+	if lit, ok := expr.(*syntax.Literal); ok {
+		return lit.Token == syntax.INT
+	}
+	return false
+}
+
+// extractNamedStringArg extracts a named string argument from a function call.
+// Returns the string value if found, empty string otherwise.
+func (v *lintVisitor) extractNamedStringArg(e *syntax.CallExpr, argName string) string {
+	for _, arg := range e.Args {
+		binExpr, ok := arg.(*syntax.BinaryExpr)
+		if !ok || binExpr.Op != syntax.EQ {
+			continue
+		}
+
+		ident, ok := binExpr.X.(*syntax.Ident)
+		if !ok || ident.Name != argName {
+			continue
+		}
+
+		lit, ok := binExpr.Y.(*syntax.Literal)
+		if !ok || lit.Token != syntax.STRING {
+			continue
+		}
+
+		if str, ok := lit.Value.(string); ok {
+			return strings.Trim(str, "\"")
+		}
+	}
+	return ""
+}
+
+// extractHandlerArg extracts the "handler" argument from a function call.
+func (v *lintVisitor) extractHandlerArg(e *syntax.CallExpr) string {
+	return v.extractNamedStringArg(e, "handler")
+}
+
+// extractStepName extracts the "name" argument from a step() call.
+func (v *lintVisitor) extractStepName(e *syntax.CallExpr) string {
+	return v.extractNamedStringArg(e, "name")
+}
+
+// extractHardcodedArg checks if a named argument is a hardcoded string literal.
+// Returns the hardcoded value if found, empty string otherwise.
+func (v *lintVisitor) extractHardcodedArg(e *syntax.CallExpr, argName string) string {
+	return v.extractNamedStringArg(e, argName)
+}
+
+// addIssue creates a lint issue with the configured severity.
+func (v *lintVisitor) addIssue(issueType LintIssueType, line int, message, suggestedFix string) {
+	level := v.linter.enforcementLevels[issueType]
+	severity := LintSeverityWarning
+	if level == EnforcementLevelError {
+		severity = LintSeverityError
+	}
+
+	v.issues = append(v.issues, LintIssue{
+		Type:         issueType,
+		Severity:     severity,
+		LineNumber:   line,
+		Message:      message,
+		SuggestedFix: suggestedFix,
+	})
+}

--- a/shared/pkg/saga/linter_test.go
+++ b/shared/pkg/saga/linter_test.go
@@ -1,0 +1,528 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSemanticLinter_DecimalArithmetic(t *testing.T) {
+	tests := []struct {
+		name       string
+		script     string
+		wantIssues int
+		wantType   LintIssueType
+	}{
+		{
+			name: "Decimal multiplication triggers warning",
+			script: `
+qty = Decimal("10")
+rate = Decimal("0.05")
+result = qty * rate
+`,
+			wantIssues: 1,
+			wantType:   LintIssueTypeDecimalArithmetic,
+		},
+		{
+			name: "Decimal addition triggers warning",
+			script: `
+a = Decimal("100.00")
+b = Decimal("50.00")
+total = a + b
+`,
+			wantIssues: 1,
+			wantType:   LintIssueTypeDecimalArithmetic,
+		},
+		{
+			name: "Decimal division triggers warning",
+			script: `
+amount = Decimal("100")
+shares = Decimal("4")
+each = amount / shares
+`,
+			wantIssues: 1,
+			wantType:   LintIssueTypeDecimalArithmetic,
+		},
+		{
+			name: "Loop counter increment is exempt",
+			script: `
+i = 0
+for item in items:
+    i = i + 1
+`,
+			wantIssues: 0,
+		},
+		{
+			name: "List indexing with offset is exempt",
+			script: `
+items = [1, 2, 3]
+offset = 1
+x = items[i + offset]
+`,
+			wantIssues: 0,
+		},
+		{
+			name: "Integer arithmetic is exempt",
+			script: `
+count = 5
+total = count + 10
+`,
+			wantIssues: 0,
+		},
+		{
+			name: "Valuation engine result usage is allowed",
+			script: `
+def process(instrument_code):
+    result = valuate(instrument=instrument_code, quantity=Decimal("100"))
+    # Using the pre-validated rate from Valuation Engine is OK
+    # No Decimal arithmetic needed - result is already calculated
+    return result
+`,
+			wantIssues: 0,
+		},
+		{
+			name: "String concatenation is exempt",
+			script: `
+prefix = "account_"
+suffix = "001"
+name = prefix + suffix
+`,
+			wantIssues: 0,
+		},
+		{
+			name: "Multiple Decimal operations trigger multiple warnings",
+			script: `
+a = Decimal("10")
+b = Decimal("20")
+c = Decimal("30")
+sum1 = a + b
+sum2 = sum1 + c
+`,
+			wantIssues: 2,
+			wantType:   LintIssueTypeDecimalArithmetic,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			linter := NewSemanticLinter()
+			issues, err := linter.Analyze(tt.script)
+			require.NoError(t, err)
+
+			if tt.wantIssues == 0 {
+				assert.Empty(t, issues, "expected no lint issues")
+			} else {
+				assert.Len(t, issues, tt.wantIssues, "unexpected number of lint issues")
+				if len(issues) > 0 && tt.wantType != "" {
+					assert.Equal(t, tt.wantType, issues[0].Type)
+				}
+			}
+		})
+	}
+}
+
+func TestSemanticLinter_MagicNumbers(t *testing.T) {
+	tests := []struct {
+		name       string
+		script     string
+		wantIssues int
+	}{
+		{
+			name: "Magic decimal literal triggers warning",
+			script: `
+rate = 0.05
+amount = calculate(rate)
+`,
+			wantIssues: 1,
+		},
+		{
+			name: "Small integers (0, 1, -1) are exempt",
+			script: `
+x = 0
+y = 1
+z = -1
+`,
+			wantIssues: 0,
+		},
+		{
+			name: "Named constant pattern is OK",
+			script: `
+TAX_RATE = Decimal("0.15")
+amount = valuate(rate=TAX_RATE)
+`,
+			wantIssues: 0,
+		},
+		{
+			name: "Range boundaries are exempt",
+			script: `
+for i in range(10):
+    process(i)
+`,
+			wantIssues: 0,
+		},
+		{
+			name: "List index is exempt",
+			script: `
+items = [1, 2, 3]
+first = items[0]
+second = items[1]
+`,
+			wantIssues: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			linter := NewSemanticLinter()
+			issues, err := linter.Analyze(tt.script)
+			require.NoError(t, err)
+
+			magicNumIssues := filterByType(issues, LintIssueTypeMagicNumber)
+			assert.Len(t, magicNumIssues, tt.wantIssues)
+		})
+	}
+}
+
+func TestSemanticLinter_NestedConditionals(t *testing.T) {
+	tests := []struct {
+		name       string
+		script     string
+		wantIssues int
+	}{
+		{
+			name: "3 levels of nesting is OK",
+			script: `
+if a:
+    if b:
+        if c:
+            do_something()
+`,
+			wantIssues: 0,
+		},
+		{
+			name: "4 levels of nesting triggers warning",
+			script: `
+if a:
+    if b:
+        if c:
+            if d:
+                do_something()
+`,
+			wantIssues: 1,
+		},
+		{
+			name: "Flat conditionals are OK",
+			script: `
+if a:
+    do_a()
+if b:
+    do_b()
+if c:
+    do_c()
+`,
+			wantIssues: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			linter := NewSemanticLinter()
+			issues, err := linter.Analyze(tt.script)
+			require.NoError(t, err)
+
+			nestedIssues := filterByType(issues, LintIssueTypeNestedConditional)
+			assert.Len(t, nestedIssues, tt.wantIssues)
+		})
+	}
+}
+
+func TestSemanticLinter_HardcodedInstrumentCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		script     string
+		wantIssues int
+	}{
+		{
+			name: "Hardcoded instrument code in valuate call triggers warning",
+			script: `
+def process():
+    return valuate(instrument="ELEC_NZD")
+`,
+			wantIssues: 1,
+		},
+		{
+			name: "Parameterized instrument is OK",
+			script: `
+def process(instrument):
+    return valuate(instrument=instrument)
+`,
+			wantIssues: 0,
+		},
+		{
+			name: "resolve_instrument result is OK",
+			script: `
+def process(ref):
+    instrument = resolve_instrument(reference=ref)
+    return valuate(instrument=instrument)
+`,
+			wantIssues: 0,
+		},
+		{
+			name: "Hardcoded account code in resolve_account triggers warning",
+			script: `
+def process():
+    account = resolve_account(reference="ACC_001")
+    return account
+`,
+			wantIssues: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			linter := NewSemanticLinter()
+			issues, err := linter.Analyze(tt.script)
+			require.NoError(t, err)
+
+			hardcodedIssues := filterByType(issues, LintIssueTypeHardcodedCode)
+			assert.Len(t, hardcodedIssues, tt.wantIssues)
+		})
+	}
+}
+
+func TestSemanticLinter_PreStepCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		script     string
+		handlers   map[string]HandlerMetadata
+		wantIssues int
+	}{
+		{
+			name: "External step without pre-check triggers error",
+			script: `
+def execute(ctx):
+    result = step(name="send_payment", handler="payment_gateway.send", params={"amount": Decimal("100")})
+    return result
+`,
+			handlers: map[string]HandlerMetadata{
+				"payment_gateway.send": {IsExternal: true, RequiresPreCheck: true},
+			},
+			wantIssues: 1,
+		},
+		{
+			name: "External step with verify_external_state is OK",
+			script: `
+def execute(ctx):
+    verify_external_state(handler="payment_gateway.send", check_fn=check_payment_status)
+    result = step(name="send_payment", handler="payment_gateway.send", params={"amount": Decimal("100")})
+    return result
+`,
+			handlers: map[string]HandlerMetadata{
+				"payment_gateway.send": {IsExternal: true, RequiresPreCheck: true},
+			},
+			wantIssues: 0,
+		},
+		{
+			name: "Internal handler without pre-check is OK",
+			script: `
+def execute(ctx):
+    result = step(name="create_booking", handler="financial_accounting.create_booking", params={})
+    return result
+`,
+			handlers: map[string]HandlerMetadata{
+				"financial_accounting.create_booking": {IsExternal: false, RequiresPreCheck: false},
+			},
+			wantIssues: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			linter := NewSemanticLinter()
+			linter.SetHandlerMetadata(tt.handlers)
+			issues, err := linter.Analyze(tt.script)
+			require.NoError(t, err)
+
+			preCheckIssues := filterByType(issues, LintIssueTypeMissingPreCheck)
+			assert.Len(t, preCheckIssues, tt.wantIssues)
+		})
+	}
+}
+
+func TestSemanticLinter_EnforcementLevels(t *testing.T) {
+	tests := []struct {
+		name          string
+		script        string
+		level         EnforcementLevel
+		wantSeverity  LintSeverity
+		expectBlocked bool
+	}{
+		{
+			name: "Warning level allows activation",
+			script: `
+qty = Decimal("10")
+rate = Decimal("0.05")
+result = qty * rate
+`,
+			level:         EnforcementLevelWarning,
+			wantSeverity:  LintSeverityWarning,
+			expectBlocked: false,
+		},
+		{
+			name: "Error level blocks activation",
+			script: `
+qty = Decimal("10")
+rate = Decimal("0.05")
+result = qty * rate
+`,
+			level:         EnforcementLevelError,
+			wantSeverity:  LintSeverityError,
+			expectBlocked: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			linter := NewSemanticLinter()
+			linter.SetEnforcementLevel(LintIssueTypeDecimalArithmetic, tt.level)
+			issues, err := linter.Analyze(tt.script)
+			require.NoError(t, err)
+
+			if len(issues) > 0 {
+				assert.Equal(t, tt.wantSeverity, issues[0].Severity)
+			}
+
+			blocked := linter.HasBlockingIssues(issues)
+			assert.Equal(t, tt.expectBlocked, blocked)
+		})
+	}
+}
+
+func TestSemanticLinter_SuggestedFixes(t *testing.T) {
+	t.Run("Decimal arithmetic has suggested fix", func(t *testing.T) {
+		linter := NewSemanticLinter()
+		issues, err := linter.Analyze(`
+qty = Decimal("10")
+rate = Decimal("0.05")
+result = qty * rate
+`)
+		require.NoError(t, err)
+		require.Len(t, issues, 1)
+		assert.Contains(t, issues[0].SuggestedFix, "cel_eval")
+	})
+
+	t.Run("Missing pre-check has suggested fix", func(t *testing.T) {
+		linter := NewSemanticLinter()
+		linter.SetHandlerMetadata(map[string]HandlerMetadata{
+			"payment_gateway.send": {IsExternal: true, RequiresPreCheck: true},
+		})
+		issues, err := linter.Analyze(`
+def execute(ctx):
+    result = step(name="send_payment", handler="payment_gateway.send", params={})
+    return result
+`)
+		require.NoError(t, err)
+
+		preCheckIssues := filterByType(issues, LintIssueTypeMissingPreCheck)
+		require.Len(t, preCheckIssues, 1)
+		assert.Contains(t, preCheckIssues[0].SuggestedFix, "verify_external_state")
+	})
+}
+
+func TestSemanticLinter_LineNumbers(t *testing.T) {
+	linter := NewSemanticLinter()
+	issues, err := linter.Analyze(`
+# Line 1: comment
+qty = Decimal("10")
+rate = Decimal("0.05")
+result = qty * rate
+`)
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	assert.Equal(t, 5, issues[0].LineNumber, "expected issue on line 5")
+}
+
+func TestSemanticLinter_EmptyScript(t *testing.T) {
+	linter := NewSemanticLinter()
+	issues, err := linter.Analyze("")
+	require.NoError(t, err)
+	assert.Empty(t, issues)
+}
+
+func TestSemanticLinter_SyntaxError(t *testing.T) {
+	linter := NewSemanticLinter()
+	_, err := linter.Analyze("def broken(")
+	assert.Error(t, err)
+}
+
+// filterByType is a helper to filter lint issues by type.
+func filterByType(issues []LintIssue, issueType LintIssueType) []LintIssue {
+	var filtered []LintIssue
+	for _, issue := range issues {
+		if issue.Type == issueType {
+			filtered = append(filtered, issue)
+		}
+	}
+	return filtered
+}
+
+func TestValidateDraft_IncludesLintWarnings(t *testing.T) {
+	script := `
+qty = Decimal("10")
+rate = Decimal("0.05")
+result = qty * rate
+`
+	result, err := ValidateDraft(script)
+	require.NoError(t, err)
+	assert.False(t, result.HasErrors())
+	assert.Len(t, result.LintIssues, 1)
+	assert.Equal(t, LintSeverityWarning, result.LintIssues[0].Severity)
+	assert.True(t, result.IsValid(), "draft validation should pass with warnings")
+}
+
+func TestValidateActivation_BlocksDecimalArithmetic(t *testing.T) {
+	script := `
+qty = Decimal("10")
+rate = Decimal("0.05")
+result = qty * rate
+`
+	err := ValidateActivation(script)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validation failed")
+}
+
+func TestValidateActivation_AllowsCleanScript(t *testing.T) {
+	script := `
+def process(input):
+    account = input["account"]
+    amount = input["amount"]
+    return {"account": account, "amount": amount}
+`
+	err := ValidateActivation(script)
+	require.NoError(t, err)
+}
+
+func TestValidationResult_Summary(t *testing.T) {
+	result := &ValidationResult{
+		LintIssues: []LintIssue{
+			{
+				Type:       LintIssueTypeDecimalArithmetic,
+				Severity:   LintSeverityWarning,
+				LineNumber: 5,
+				Message:    "Financial math detected",
+			},
+		},
+	}
+
+	summary := result.Summary()
+	assert.Contains(t, summary, "WARNING")
+	assert.Contains(t, summary, "line 5")
+	assert.Contains(t, summary, "Financial math detected")
+}
+
+func TestValidationResult_NoIssues(t *testing.T) {
+	result := &ValidationResult{}
+	assert.Equal(t, "No issues found", result.Summary())
+	assert.True(t, result.IsValid())
+}

--- a/shared/pkg/saga/validator.go
+++ b/shared/pkg/saga/validator.go
@@ -3,9 +3,60 @@ package saga
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"go.starlark.net/syntax"
 )
+
+// ValidationResult contains both validation errors and lint warnings.
+type ValidationResult struct {
+	// Errors contains fatal validation errors that block execution.
+	Errors []error
+
+	// LintIssues contains semantic lint issues (warnings and errors).
+	LintIssues []LintIssue
+}
+
+// HasErrors returns true if there are any fatal errors.
+func (r *ValidationResult) HasErrors() bool {
+	return len(r.Errors) > 0
+}
+
+// HasBlockingLintIssues returns true if any lint issues have ERROR severity.
+func (r *ValidationResult) HasBlockingLintIssues() bool {
+	for _, issue := range r.LintIssues {
+		if issue.Severity == LintSeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// IsValid returns true if the script can be activated (no errors and no blocking lint issues).
+func (r *ValidationResult) IsValid() bool {
+	return !r.HasErrors() && !r.HasBlockingLintIssues()
+}
+
+// Summary returns a human-readable summary of all issues.
+func (r *ValidationResult) Summary() string {
+	totalIssues := len(r.Errors) + len(r.LintIssues)
+	if totalIssues == 0 {
+		return "No issues found"
+	}
+
+	parts := make([]string, 0, totalIssues)
+
+	for _, err := range r.Errors {
+		parts = append(parts, fmt.Sprintf("ERROR: %s", err.Error()))
+	}
+
+	for _, issue := range r.LintIssues {
+		parts = append(parts, fmt.Sprintf("%s [line %d]: %s",
+			issue.Severity, issue.LineNumber, issue.Message))
+	}
+
+	return strings.Join(parts, "\n")
+}
 
 // Validation errors.
 var (
@@ -14,6 +65,9 @@ var (
 
 	// ErrExcessiveLoopNesting is returned when loop nesting exceeds MaxLoopNestingDepth.
 	ErrExcessiveLoopNesting = errors.New("excessive loop nesting")
+
+	// ErrValidationFailed is returned when activation validation fails.
+	ErrValidationFailed = errors.New("validation failed")
 )
 
 // blockedFunctions is the set of function names that are not allowed in saga scripts.
@@ -314,4 +368,51 @@ func (v *validationVisitor) walkExpr(expr syntax.Expr) error {
 	}
 
 	return nil
+}
+
+// ValidateDraft performs full validation including semantic linting for draft scripts.
+// This is used during script development and returns warnings that may be addressed.
+func ValidateDraft(script string) (*ValidationResult, error) {
+	return ValidateWithLinter(script, NewSemanticLinter())
+}
+
+// ValidateActivation performs strict validation for scripts being activated.
+// Returns an error if any blocking issues are found.
+func ValidateActivation(script string) error {
+	linter := NewSemanticLinter()
+	// Enforce ERROR level for Decimal arithmetic in activation
+	linter.SetEnforcementLevel(LintIssueTypeDecimalArithmetic, EnforcementLevelError)
+
+	result, err := ValidateWithLinter(script, linter)
+	if err != nil {
+		return err
+	}
+
+	if !result.IsValid() {
+		return fmt.Errorf("%w: %s", ErrValidationFailed, result.Summary())
+	}
+
+	return nil
+}
+
+// ValidateWithLinter performs validation using a custom linter configuration.
+func ValidateWithLinter(script string, linter *SemanticLinter) (*ValidationResult, error) {
+	result := &ValidationResult{}
+
+	// First, run basic validation
+	if err := ValidateSagaScript(script); err != nil {
+		result.Errors = append(result.Errors, err)
+	}
+
+	// If basic validation passed, run semantic linting
+	if len(result.Errors) == 0 && linter != nil {
+		lintIssues, err := linter.Analyze(script)
+		if err != nil {
+			// Lint errors are also added to the result
+			result.Errors = append(result.Errors, fmt.Errorf("lint error: %w", err))
+		}
+		result.LintIssues = lintIssues
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
## Summary

Implements AST-based semantic linter for Starlark saga scripts per FR-33:

- **Decimal arithmetic detection**: Warns when scripts perform financial calculations that should be in CEL Valuation Strategies. Exempts loop counters and index arithmetic.
- **Magic number detection**: Flags floating-point literals that should be named constants
- **Nested conditional warnings**: Warns when if/else nesting exceeds 3 levels
- **Hardcoded code detection**: Detects hardcoded instrument/account codes in `valuate()` and `resolve_*()` calls
- **Pre-Step Check enforcement**: Requires `verify_external_state()` before external (non-idempotent) handlers
- **Configurable enforcement levels**: WARNING (allows activation) vs ERROR (blocks activation)

## Changes Made

- `shared/pkg/saga/linter.go`: New `SemanticLinter` with AST walking and issue detection
- `shared/pkg/saga/linter_test.go`: Comprehensive tests for all lint rules
- `shared/pkg/saga/validator.go`: Integration with `ValidateDraft()` and `ValidateActivation()` functions

## Technical Details

The linter tracks variable types (Decimal vs counter) through AST analysis to distinguish financial calculations from safe index arithmetic. External handler metadata can be configured to enforce Pre-Step Check patterns for non-idempotent operations.

## Test Plan

- [x] All new linter tests pass
- [x] Existing validator tests pass
- [x] Full saga package test suite passes
- [ ] CI pipeline passes

## Related

Task: starlark-saga-orchestration.9