### PR TITLE
feat: Implement step error severity classification (TRANSIENT vs FATAL)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,6 +79,7 @@ linters:
           - gocritic         # Style checks less critical in tests
           - nilnil           # Tests may use (nil, nil) for mock implementations
           - govet            # unusedwrite and nilness checks too strict for test scaffolding
+          - err113           # Tests need dynamic errors to test error pattern matching
 
       # Allow context-as-argument after *testing.T in test helper functions
       - path: _test\.go

--- a/shared/pkg/saga/error_classification.go
+++ b/shared/pkg/saga/error_classification.go
@@ -132,10 +132,10 @@ var transientPatterns = []string{
 //  4. Check if error message matches TRANSIENT patterns
 //  5. Default to FATAL for unknown errors (fail-safe: don't retry unknowns)
 //
-// Returns ErrorCategoryFatal or ErrorCategoryTransient.
+// Returns ErrorCategoryFatal or ErrorCategoryTransient. Returns "" when err is nil.
 func ClassifyError(err error) ErrorCategory {
 	if err == nil {
-		return ErrorCategoryTransient
+		return ""
 	}
 
 	// Check for explicit wrapper types first (highest priority)
@@ -187,13 +187,15 @@ func ClassifyErrorString(err error) string {
 }
 
 // IsFatalError returns true if the error is classified as FATAL.
+// Returns false for nil errors.
 func IsFatalError(err error) bool {
-	return ClassifyError(err) == ErrorCategoryFatal
+	return err != nil && ClassifyError(err) == ErrorCategoryFatal
 }
 
 // IsTransientError returns true if the error is classified as TRANSIENT.
+// Returns false for nil errors.
 func IsTransientError(err error) bool {
-	return ClassifyError(err) == ErrorCategoryTransient
+	return err != nil && ClassifyError(err) == ErrorCategoryTransient
 }
 
 // FatalError wraps an error to be classified as FATAL.

--- a/shared/pkg/saga/error_classification.go
+++ b/shared/pkg/saga/error_classification.go
@@ -12,7 +12,7 @@ var (
 	// ErrInsufficientFunds indicates the account lacks required funds (business rule violation).
 	ErrInsufficientFunds = errors.New("insufficient funds")
 
-	// ErrInsufficientBalance is an alias for ErrInsufficientFunds for compatibility.
+	// ErrInsufficientBalance indicates insufficient account balance (same semantic as ErrInsufficientFunds).
 	ErrInsufficientBalance = errors.New("insufficient balance")
 
 	// ErrAccountClosed indicates the account is closed and cannot process transactions.

--- a/shared/pkg/saga/error_classification.go
+++ b/shared/pkg/saga/error_classification.go
@@ -100,10 +100,10 @@ var transientPatterns = []string{
 	"unavailable",
 	"retry",
 	"retryable",
-	"EAGAIN",
-	"ETIMEDOUT",
-	"ECONNRESET",
-	"ECONNREFUSED",
+	"eagain",
+	"etimedout",
+	"econnreset",
+	"econnrefused",
 	"network error",
 	"network unreachable",
 	"host unreachable",
@@ -118,7 +118,7 @@ var transientPatterns = []string{
 	"could not serialize",
 	"serialization failure",
 	"i/o timeout",
-	"EOF",
+	"eof",
 	"broken pipe",
 }
 

--- a/shared/pkg/saga/error_classification.go
+++ b/shared/pkg/saga/error_classification.go
@@ -1,0 +1,272 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"errors"
+	"strings"
+)
+
+// Sentinel errors for FATAL business rule violations.
+// These errors indicate non-retryable conditions where compensation should begin immediately.
+var (
+	// ErrInsufficientFunds indicates the account lacks required funds (business rule violation).
+	ErrInsufficientFunds = errors.New("insufficient funds")
+
+	// ErrInsufficientBalance is an alias for ErrInsufficientFunds for compatibility.
+	ErrInsufficientBalance = errors.New("insufficient balance")
+
+	// ErrAccountClosed indicates the account is closed and cannot process transactions.
+	ErrAccountClosed = errors.New("account closed")
+
+	// ErrAccountFrozen indicates the account is frozen and cannot process transactions.
+	ErrAccountFrozen = errors.New("account frozen")
+
+	// ErrInvalidAmount indicates the transaction amount is invalid (e.g., negative, zero).
+	ErrInvalidAmount = errors.New("invalid amount")
+
+	// ErrDuplicateTransaction indicates a duplicate idempotency key was detected.
+	ErrDuplicateTransaction = errors.New("duplicate transaction")
+
+	// ErrBusinessRuleViolation is a generic fatal error for business rule violations.
+	ErrBusinessRuleViolation = errors.New("business rule violation")
+
+	// ErrValidationFailed indicates input validation failed.
+	ErrValidationFailed = errors.New("validation failed")
+
+	// ErrNotFound indicates a required resource was not found.
+	ErrNotFound = errors.New("not found")
+
+	// ErrUnauthorized indicates the operation is not authorized.
+	ErrUnauthorized = errors.New("unauthorized")
+
+	// ErrForbidden indicates the operation is forbidden.
+	ErrForbidden = errors.New("forbidden")
+)
+
+// fatalErrors is the list of sentinel errors that are always classified as FATAL.
+var fatalErrors = []error{
+	ErrInsufficientFunds,
+	ErrInsufficientBalance,
+	ErrAccountClosed,
+	ErrAccountFrozen,
+	ErrInvalidAmount,
+	ErrDuplicateTransaction,
+	ErrBusinessRuleViolation,
+	ErrValidationFailed,
+	ErrNotFound,
+	ErrUnauthorized,
+	ErrForbidden,
+	ErrMissingParam,
+	ErrInvalidParamType,
+	ErrInvalidDirection,
+}
+
+// fatalPatterns are string patterns in error messages that indicate FATAL errors.
+var fatalPatterns = []string{
+	"insufficient funds",
+	"insufficient balance",
+	"account closed",
+	"account frozen",
+	"invalid amount",
+	"duplicate",
+	"business rule",
+	"validation failed",
+	"validation error",
+	"not found",
+	"does not exist",
+	"unauthorized",
+	"forbidden",
+	"permission denied",
+	"access denied",
+	"constraint violation",
+	"unique constraint",
+	"foreign key constraint",
+	"check constraint",
+	"null constraint",
+}
+
+// transientPatterns are string patterns in error messages that indicate TRANSIENT errors.
+var transientPatterns = []string{
+	"timeout",
+	"deadline exceeded",
+	"context canceled",
+	"context cancelled",
+	"connection refused",
+	"connection reset",
+	"connection closed",
+	"temporary failure",
+	"temporarily unavailable",
+	"service unavailable",
+	"unavailable",
+	"retry",
+	"retryable",
+	"EAGAIN",
+	"ETIMEDOUT",
+	"ECONNRESET",
+	"ECONNREFUSED",
+	"network error",
+	"network unreachable",
+	"host unreachable",
+	"no route to host",
+	"dns lookup failed",
+	"too many requests",
+	"rate limit",
+	"throttle",
+	"circuit breaker",
+	"deadlock",
+	"lock timeout",
+	"could not serialize",
+	"serialization failure",
+	"i/o timeout",
+	"EOF",
+	"broken pipe",
+}
+
+// ClassifyError determines the error category for a given error.
+// It checks sentinel errors first using errors.Is, then falls back to pattern matching.
+//
+// Classification order:
+//  1. Check if error is explicitly wrapped as TransientError or FatalError
+//  2. Check if error is a known FATAL sentinel error
+//  3. Check if error message matches FATAL patterns
+//  4. Check if error message matches TRANSIENT patterns
+//  5. Default to FATAL for unknown errors (fail-safe: don't retry unknowns)
+//
+// Returns ErrorCategoryFatal or ErrorCategoryTransient.
+func ClassifyError(err error) ErrorCategory {
+	if err == nil {
+		return ErrorCategoryTransient
+	}
+
+	// Check for explicit wrapper types first (highest priority)
+	var transientErr *TransientError
+	if errors.As(err, &transientErr) {
+		return ErrorCategoryTransient
+	}
+
+	var fatalErr *FatalError
+	if errors.As(err, &fatalErr) {
+		return ErrorCategoryFatal
+	}
+
+	// Check sentinel errors using errors.Is (supports wrapped errors)
+	for _, sentinelErr := range fatalErrors {
+		if errors.Is(err, sentinelErr) {
+			return ErrorCategoryFatal
+		}
+	}
+
+	// Pattern-based classification on error message
+	errStr := strings.ToLower(err.Error())
+
+	// Check for FATAL patterns first (business rule violations take precedence)
+	for _, pattern := range fatalPatterns {
+		if strings.Contains(errStr, pattern) {
+			return ErrorCategoryFatal
+		}
+	}
+
+	// Check for TRANSIENT patterns
+	for _, pattern := range transientPatterns {
+		if strings.Contains(errStr, pattern) {
+			return ErrorCategoryTransient
+		}
+	}
+
+	// Default to FATAL for unknown errors
+	// Rationale: Unknown errors are more likely to be programming errors or
+	// permanent conditions. Retrying them would waste resources and delay
+	// compensation. Better to fail fast and let operators investigate.
+	return ErrorCategoryFatal
+}
+
+// ClassifyErrorString returns the string representation of the error category.
+// Convenience function that wraps ClassifyError.
+func ClassifyErrorString(err error) string {
+	return string(ClassifyError(err))
+}
+
+// IsFatalError returns true if the error is classified as FATAL.
+func IsFatalError(err error) bool {
+	return ClassifyError(err) == ErrorCategoryFatal
+}
+
+// IsTransientError returns true if the error is classified as TRANSIENT.
+func IsTransientError(err error) bool {
+	return ClassifyError(err) == ErrorCategoryTransient
+}
+
+// FatalError wraps an error to be classified as FATAL.
+// Use this to explicitly mark an error as non-retryable.
+type FatalError struct {
+	Err error
+}
+
+func (e *FatalError) Error() string {
+	if e.Err == nil {
+		return "fatal error"
+	}
+	return e.Err.Error()
+}
+
+func (e *FatalError) Unwrap() error {
+	return e.Err
+}
+
+// Is implements errors.Is for FatalError.
+// Any FatalError is considered a business rule violation.
+func (e *FatalError) Is(target error) bool {
+	return errors.Is(target, ErrBusinessRuleViolation)
+}
+
+// NewFatalError wraps an error as a FATAL error.
+func NewFatalError(err error) error {
+	return &FatalError{Err: err}
+}
+
+// TransientError wraps an error to be classified as TRANSIENT.
+// Use this to explicitly mark an error as retryable.
+type TransientError struct {
+	Err error
+}
+
+func (e *TransientError) Error() string {
+	if e.Err == nil {
+		return "transient error"
+	}
+	return e.Err.Error()
+}
+
+func (e *TransientError) Unwrap() error {
+	return e.Err
+}
+
+// NewTransientError wraps an error as a TRANSIENT error.
+func NewTransientError(err error) error {
+	return &TransientError{Err: err}
+}
+
+// GetErrorCategory returns the error category from a SagaStepResult.
+// Returns the ErrorCategory enum or empty string if not set.
+func (r *SagaStepResult) GetErrorCategory() ErrorCategory {
+	if r.ErrorCategory == nil {
+		return ""
+	}
+	return ErrorCategory(*r.ErrorCategory)
+}
+
+// IsFatal returns true if this step result has a FATAL error.
+func (r *SagaStepResult) IsFatal() bool {
+	return r.GetErrorCategory() == ErrorCategoryFatal
+}
+
+// IsTransient returns true if this step result has a TRANSIENT error.
+func (r *SagaStepResult) IsTransient() bool {
+	return r.GetErrorCategory() == ErrorCategoryTransient
+}
+
+// SetErrorCategory sets the error category on a SagaStepResult.
+func (r *SagaStepResult) SetErrorCategory(category ErrorCategory) {
+	cat := string(category)
+	r.ErrorCategory = &cat
+}

--- a/shared/pkg/saga/error_classification_test.go
+++ b/shared/pkg/saga/error_classification_test.go
@@ -145,10 +145,14 @@ func TestClassifyError_CaseInsensitive(t *testing.T) {
 	}
 }
 
-// TestClassifyError_NilError verifies nil error returns TRANSIENT.
+// TestClassifyError_NilError verifies nil error returns empty category.
 func TestClassifyError_NilError(t *testing.T) {
 	result := ClassifyError(nil)
-	assert.Equal(t, ErrorCategoryTransient, result, "nil error should return TRANSIENT")
+	assert.Equal(t, ErrorCategory(""), result, "nil error should return empty category")
+
+	// Also verify helper functions return false for nil
+	assert.False(t, IsFatalError(nil), "IsFatalError(nil) should return false")
+	assert.False(t, IsTransientError(nil), "IsTransientError(nil) should return false")
 }
 
 // TestClassifyError_UnknownError verifies unknown errors default to FATAL.
@@ -189,7 +193,7 @@ func TestIsFatalError(t *testing.T) {
 // TestIsTransientError verifies the IsTransientError helper.
 func TestIsTransientError(t *testing.T) {
 	assert.True(t, IsTransientError(errTestNetworkTimeout))
-	assert.True(t, IsTransientError(nil))
+	assert.False(t, IsTransientError(nil)) // nil is not a transient error
 	assert.False(t, IsTransientError(ErrInsufficientFunds))
 }
 

--- a/shared/pkg/saga/error_classification_test.go
+++ b/shared/pkg/saga/error_classification_test.go
@@ -325,6 +325,38 @@ func TestClassifyError_HTTPErrors(t *testing.T) {
 	}
 }
 
+// TestClassifyError_SyscallErrors verifies that syscall error patterns are correctly classified as TRANSIENT.
+// These patterns must be lowercase since ClassifyError normalizes error strings to lowercase.
+func TestClassifyError_SyscallErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected ErrorCategory
+	}{
+		// Unix syscall errors - should be TRANSIENT (retriable)
+		{"EAGAIN uppercase", "syscall error: EAGAIN", ErrorCategoryTransient},
+		{"eagain lowercase", "resource temporarily unavailable: eagain", ErrorCategoryTransient},
+		{"ETIMEDOUT uppercase", "connection ETIMEDOUT after 30s", ErrorCategoryTransient},
+		{"etimedout lowercase", "socket etimedout", ErrorCategoryTransient},
+		{"ECONNRESET uppercase", "read tcp: ECONNRESET by peer", ErrorCategoryTransient},
+		{"econnreset lowercase", "connection econnreset", ErrorCategoryTransient},
+		{"ECONNREFUSED uppercase", "dial tcp: ECONNREFUSED", ErrorCategoryTransient},
+		{"econnrefused lowercase", "econnrefused on port 5432", ErrorCategoryTransient},
+		{"EOF uppercase", "unexpected EOF", ErrorCategoryTransient},
+		{"eof lowercase", "eof reached", ErrorCategoryTransient},
+		{"broken pipe", "write: broken pipe", ErrorCategoryTransient},
+		{"i/o timeout", "read i/o timeout", ErrorCategoryTransient},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := errors.New(tc.errMsg)
+			result := ClassifyError(err)
+			assert.Equal(t, tc.expected, result, "Syscall error '%s' should be classified as %s", tc.errMsg, tc.expected)
+		})
+	}
+}
+
 // TestFatalErrorNilWrapping verifies FatalError handles nil correctly.
 func TestFatalErrorNilWrapping(t *testing.T) {
 	fatalErr := NewFatalError(nil)

--- a/shared/pkg/saga/error_classification_test.go
+++ b/shared/pkg/saga/error_classification_test.go
@@ -1,0 +1,346 @@
+package saga
+
+// Tests for error classification require dynamic errors to test pattern matching.
+// This is intentional and cannot be avoided for comprehensive testing.
+//nolint:err113 // Dynamic errors are required for testing error message pattern matching
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test sentinel errors.
+var errTestNetworkTimeout = errors.New("network timeout")
+
+// TestClassifyError_SentinelErrors verifies that known sentinel errors are classified correctly.
+func TestClassifyError_SentinelErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected ErrorCategory
+	}{
+		// FATAL sentinel errors
+		{"ErrInsufficientFunds", ErrInsufficientFunds, ErrorCategoryFatal},
+		{"ErrInsufficientBalance", ErrInsufficientBalance, ErrorCategoryFatal},
+		{"ErrAccountClosed", ErrAccountClosed, ErrorCategoryFatal},
+		{"ErrAccountFrozen", ErrAccountFrozen, ErrorCategoryFatal},
+		{"ErrInvalidAmount", ErrInvalidAmount, ErrorCategoryFatal},
+		{"ErrDuplicateTransaction", ErrDuplicateTransaction, ErrorCategoryFatal},
+		{"ErrBusinessRuleViolation", ErrBusinessRuleViolation, ErrorCategoryFatal},
+		{"ErrValidationFailed", ErrValidationFailed, ErrorCategoryFatal},
+		{"ErrNotFound", ErrNotFound, ErrorCategoryFatal},
+		{"ErrUnauthorized", ErrUnauthorized, ErrorCategoryFatal},
+		{"ErrForbidden", ErrForbidden, ErrorCategoryFatal},
+		// Handler validation errors from handlers.go
+		{"ErrMissingParam", ErrMissingParam, ErrorCategoryFatal},
+		{"ErrInvalidParamType", ErrInvalidParamType, ErrorCategoryFatal},
+		{"ErrInvalidDirection", ErrInvalidDirection, ErrorCategoryFatal},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ClassifyError(tc.err)
+			assert.Equal(t, tc.expected, result, "Error %v should be classified as %s", tc.err, tc.expected)
+		})
+	}
+}
+
+// TestClassifyError_WrappedSentinelErrors verifies that wrapped sentinel errors are classified correctly.
+func TestClassifyError_WrappedSentinelErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected ErrorCategory
+	}{
+		{
+			name:     "wrapped ErrInsufficientFunds",
+			err:      fmt.Errorf("failed to process payment: %w", ErrInsufficientFunds),
+			expected: ErrorCategoryFatal,
+		},
+		{
+			name:     "double-wrapped ErrAccountClosed",
+			err:      fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", ErrAccountClosed)),
+			expected: ErrorCategoryFatal,
+		},
+		{
+			name:     "wrapped ErrValidationFailed",
+			err:      fmt.Errorf("input validation: %w", ErrValidationFailed),
+			expected: ErrorCategoryFatal,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ClassifyError(tc.err)
+			assert.Equal(t, tc.expected, result, "Wrapped error %v should be classified as %s", tc.err, tc.expected)
+		})
+	}
+}
+
+// TestClassifyError_PatternMatching verifies pattern-based classification.
+func TestClassifyError_PatternMatching(t *testing.T) {
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected ErrorCategory
+	}{
+		// TRANSIENT patterns
+		{"network timeout", "network timeout after 30s", ErrorCategoryTransient},
+		{"deadline exceeded", "context deadline exceeded", ErrorCategoryTransient},
+		{"connection refused", "dial tcp: connection refused", ErrorCategoryTransient},
+		{"connection reset", "read: connection reset by peer", ErrorCategoryTransient},
+		{"temporarily unavailable", "service temporarily unavailable", ErrorCategoryTransient},
+		{"retry", "please retry later", ErrorCategoryTransient},
+		{"rate limit", "rate limit exceeded", ErrorCategoryTransient},
+		{"deadlock", "database deadlock detected", ErrorCategoryTransient},
+		{"lock timeout", "lock wait timeout exceeded", ErrorCategoryTransient},
+		{"serialization failure", "could not serialize access", ErrorCategoryTransient},
+
+		// FATAL patterns
+		{"insufficient funds", "account has insufficient funds", ErrorCategoryFatal},
+		{"validation error", "validation error: email format invalid", ErrorCategoryFatal},
+		{"constraint violation", "unique constraint violation on key 'id'", ErrorCategoryFatal},
+		{"foreign key constraint", "foreign key constraint violation", ErrorCategoryFatal},
+		{"not found", "customer not found", ErrorCategoryFatal},
+		{"does not exist", "resource does not exist", ErrorCategoryFatal},
+		{"unauthorized", "unauthorized access", ErrorCategoryFatal},
+		{"forbidden", "forbidden operation", ErrorCategoryFatal},
+		{"permission denied", "permission denied for user", ErrorCategoryFatal},
+		{"duplicate", "duplicate entry for key 'txn_id'", ErrorCategoryFatal},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := errors.New(tc.errMsg)
+			result := ClassifyError(err)
+			assert.Equal(t, tc.expected, result, "Error message '%s' should be classified as %s", tc.errMsg, tc.expected)
+		})
+	}
+}
+
+// TestClassifyError_CaseInsensitive verifies pattern matching is case-insensitive.
+func TestClassifyError_CaseInsensitive(t *testing.T) {
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected ErrorCategory
+	}{
+		{"uppercase TIMEOUT", "NETWORK TIMEOUT", ErrorCategoryTransient},
+		{"mixed case Timeout", "Connection Timeout Occurred", ErrorCategoryTransient},
+		{"uppercase NOT FOUND", "RESOURCE NOT FOUND", ErrorCategoryFatal},
+		{"mixed case Insufficient Funds", "Account Has Insufficient Funds", ErrorCategoryFatal},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := errors.New(tc.errMsg)
+			result := ClassifyError(err)
+			assert.Equal(t, tc.expected, result, "Case-insensitive pattern matching failed for '%s'", tc.errMsg)
+		})
+	}
+}
+
+// TestClassifyError_NilError verifies nil error returns TRANSIENT.
+func TestClassifyError_NilError(t *testing.T) {
+	result := ClassifyError(nil)
+	assert.Equal(t, ErrorCategoryTransient, result, "nil error should return TRANSIENT")
+}
+
+// TestClassifyError_UnknownError verifies unknown errors default to FATAL.
+func TestClassifyError_UnknownError(t *testing.T) {
+	unknownErr := errors.New("xyz123 strange error")
+	result := ClassifyError(unknownErr)
+	assert.Equal(t, ErrorCategoryFatal, result, "Unknown errors should default to FATAL for fail-safe behavior")
+}
+
+// TestClassifyError_ContextErrors verifies context errors are TRANSIENT.
+func TestClassifyError_ContextErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected ErrorCategory
+	}{
+		{"context.DeadlineExceeded", context.DeadlineExceeded, ErrorCategoryTransient},
+		{"context.Canceled", context.Canceled, ErrorCategoryTransient},
+		{"wrapped DeadlineExceeded", fmt.Errorf("timeout: %w", context.DeadlineExceeded), ErrorCategoryTransient},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ClassifyError(tc.err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+// TestIsFatalError verifies the IsFatalError helper.
+func TestIsFatalError(t *testing.T) {
+	assert.True(t, IsFatalError(ErrInsufficientFunds))
+	assert.True(t, IsFatalError(ErrValidationFailed))
+	assert.False(t, IsFatalError(errTestNetworkTimeout))
+	assert.False(t, IsFatalError(nil))
+}
+
+// TestIsTransientError verifies the IsTransientError helper.
+func TestIsTransientError(t *testing.T) {
+	assert.True(t, IsTransientError(errTestNetworkTimeout))
+	assert.True(t, IsTransientError(nil))
+	assert.False(t, IsTransientError(ErrInsufficientFunds))
+}
+
+// TestFatalErrorWrapper verifies NewFatalError creates a FATAL-classified error.
+func TestFatalErrorWrapper(t *testing.T) {
+	originalErr := errors.New("some error")
+	fatalErr := NewFatalError(originalErr)
+
+	// Should be classified as FATAL (via errors.Is(ErrBusinessRuleViolation))
+	assert.True(t, errors.Is(fatalErr, ErrBusinessRuleViolation), "FatalError should match ErrBusinessRuleViolation")
+	assert.True(t, IsFatalError(fatalErr), "FatalError should be classified as FATAL")
+
+	// Should preserve original error
+	assert.True(t, errors.Is(fatalErr, originalErr), "Should unwrap to original error")
+	assert.Contains(t, fatalErr.Error(), originalErr.Error())
+}
+
+// TestTransientErrorWrapper verifies NewTransientError creates a TRANSIENT-classified error.
+func TestTransientErrorWrapper(t *testing.T) {
+	originalErr := errors.New("some error")
+	transientErr := NewTransientError(originalErr)
+
+	// Should be classified as TRANSIENT (contains "retryable" pattern in type name)
+	assert.True(t, IsTransientError(transientErr), "TransientError should be classified as TRANSIENT")
+
+	// Should preserve original error
+	assert.True(t, errors.Is(transientErr, originalErr), "Should unwrap to original error")
+	assert.Contains(t, transientErr.Error(), originalErr.Error())
+}
+
+// TestSagaStepResult_ErrorCategoryHelpers verifies helper methods on SagaStepResult.
+func TestSagaStepResult_ErrorCategoryHelpers(t *testing.T) {
+	t.Run("GetErrorCategory returns enum", func(t *testing.T) {
+		fatal := string(ErrorCategoryFatal)
+		result := &SagaStepResult{ErrorCategory: &fatal}
+		assert.Equal(t, ErrorCategoryFatal, result.GetErrorCategory())
+	})
+
+	t.Run("GetErrorCategory returns empty for nil", func(t *testing.T) {
+		result := &SagaStepResult{ErrorCategory: nil}
+		assert.Equal(t, ErrorCategory(""), result.GetErrorCategory())
+	})
+
+	t.Run("IsFatal returns true for FATAL", func(t *testing.T) {
+		fatal := string(ErrorCategoryFatal)
+		result := &SagaStepResult{ErrorCategory: &fatal}
+		assert.True(t, result.IsFatal())
+		assert.False(t, result.IsTransient())
+	})
+
+	t.Run("IsTransient returns true for TRANSIENT", func(t *testing.T) {
+		transient := string(ErrorCategoryTransient)
+		result := &SagaStepResult{ErrorCategory: &transient}
+		assert.True(t, result.IsTransient())
+		assert.False(t, result.IsFatal())
+	})
+
+	t.Run("SetErrorCategory sets value", func(t *testing.T) {
+		result := &SagaStepResult{}
+		result.SetErrorCategory(ErrorCategoryFatal)
+		assert.NotNil(t, result.ErrorCategory)
+		assert.Equal(t, string(ErrorCategoryFatal), *result.ErrorCategory)
+	})
+}
+
+// TestClassifyErrorString verifies the string helper.
+func TestClassifyErrorString(t *testing.T) {
+	assert.Equal(t, "FATAL", ClassifyErrorString(ErrInsufficientFunds))
+	assert.Equal(t, "TRANSIENT", ClassifyErrorString(errTestNetworkTimeout))
+}
+
+// TestClassifyError_FatalPatternsPrecedence verifies FATAL patterns take precedence over TRANSIENT.
+func TestClassifyError_FatalPatternsPrecedence(t *testing.T) {
+	// An error message that contains both FATAL and TRANSIENT patterns
+	// FATAL should take precedence because we check it first
+	err := errors.New("timeout while checking insufficient funds")
+	result := ClassifyError(err)
+	assert.Equal(t, ErrorCategoryFatal, result, "FATAL pattern 'insufficient funds' should take precedence over TRANSIENT pattern 'timeout'")
+}
+
+// TestClassifyError_DatabaseErrors verifies database-specific error classification.
+func TestClassifyError_DatabaseErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected ErrorCategory
+	}{
+		// TRANSIENT database errors (can retry)
+		{"deadlock", "ERROR: deadlock detected", ErrorCategoryTransient},
+		{"lock timeout", "ERROR: lock wait timeout exceeded", ErrorCategoryTransient},
+		{"serialization failure", "ERROR: could not serialize access due to concurrent update", ErrorCategoryTransient},
+
+		// FATAL database errors (schema/constraint issues)
+		{"unique constraint", "ERROR: duplicate key value violates unique constraint", ErrorCategoryFatal},
+		{"foreign key", "ERROR: insert or update on table violates foreign key constraint", ErrorCategoryFatal},
+		{"check constraint", "ERROR: new row for relation violates check constraint", ErrorCategoryFatal},
+		{"null constraint", "ERROR: null value in column violates not-null constraint", ErrorCategoryFatal},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := errors.New(tc.errMsg)
+			result := ClassifyError(err)
+			assert.Equal(t, tc.expected, result, "Database error '%s' should be classified as %s", tc.errMsg, tc.expected)
+		})
+	}
+}
+
+// TestClassifyError_HTTPErrors verifies HTTP-related error classification.
+func TestClassifyError_HTTPErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		errMsg   string
+		expected ErrorCategory
+	}{
+		// TRANSIENT HTTP errors
+		{"503 service unavailable", "HTTP 503: Service Unavailable", ErrorCategoryTransient},
+		{"429 too many requests", "HTTP 429: Too Many Requests", ErrorCategoryTransient},
+		{"connection reset", "http: server closed connection: connection reset", ErrorCategoryTransient},
+
+		// FATAL HTTP errors
+		{"404 not found", "HTTP 404: Resource not found", ErrorCategoryFatal},
+		{"401 unauthorized", "HTTP 401: Unauthorized", ErrorCategoryFatal},
+		{"403 forbidden", "HTTP 403: Forbidden", ErrorCategoryFatal},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := errors.New(tc.errMsg)
+			result := ClassifyError(err)
+			assert.Equal(t, tc.expected, result, "HTTP error '%s' should be classified as %s", tc.errMsg, tc.expected)
+		})
+	}
+}
+
+// TestFatalErrorNilWrapping verifies FatalError handles nil correctly.
+func TestFatalErrorNilWrapping(t *testing.T) {
+	fatalErr := NewFatalError(nil)
+	assert.Equal(t, "fatal error", fatalErr.Error())
+
+	var fe *FatalError
+	require.True(t, errors.As(fatalErr, &fe))
+	assert.Nil(t, fe.Unwrap())
+}
+
+// TestTransientErrorNilWrapping verifies TransientError handles nil correctly.
+func TestTransientErrorNilWrapping(t *testing.T) {
+	transientErr := NewTransientError(nil)
+	assert.Equal(t, "transient error", transientErr.Error())
+
+	var te *TransientError
+	require.True(t, errors.As(transientErr, &te))
+	assert.Nil(t, te.Unwrap())
+}

--- a/shared/pkg/saga/saga_executor.go
+++ b/shared/pkg/saga/saga_executor.go
@@ -1,0 +1,343 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ErrNilError is returned when HandleStepFailure is called with a nil error.
+var ErrNilError = errors.New("nil error passed to failure handler")
+
+// SagaExecutor orchestrates the execution of saga instances with error classification
+// and compensation handling per FR-28.
+//
+//nolint:revive // SagaExecutor naming is intentional for clarity at call sites
+type SagaExecutor struct {
+	instanceRepo    SagaInstanceRepository
+	stepResultRepo  StepResultRepository
+	handlerRegistry *DomainHandlerRegistry
+	claimService    *ClaimService
+	logger          *slog.Logger
+}
+
+// SagaInstanceRepository provides persistence operations for saga instances.
+//
+//nolint:revive // SagaInstanceRepository naming is intentional for clarity
+type SagaInstanceRepository interface {
+	// FindByID retrieves a saga instance by ID.
+	FindByID(ctx context.Context, id uuid.UUID) (*SagaInstance, error)
+
+	// Update persists changes to a saga instance.
+	Update(ctx context.Context, instance *SagaInstance) error
+
+	// UpdateStatus updates the saga status atomically.
+	UpdateStatus(ctx context.Context, id uuid.UUID, status SagaStatus) error
+
+	// UpdateStatusWithError updates status and records error information.
+	UpdateStatusWithError(ctx context.Context, id uuid.UUID, status SagaStatus, stepIndex int, err error, category ErrorCategory) error
+
+	// ResetReplayCount resets the replay count to 0 (used when moving to next step).
+	ResetReplayCount(ctx context.Context, id uuid.UUID) error
+}
+
+// NewSagaExecutor creates a new SagaExecutor.
+func NewSagaExecutor(
+	instanceRepo SagaInstanceRepository,
+	stepResultRepo StepResultRepository,
+	handlerRegistry *DomainHandlerRegistry,
+	claimService *ClaimService,
+) *SagaExecutor {
+	return &SagaExecutor{
+		instanceRepo:    instanceRepo,
+		stepResultRepo:  stepResultRepo,
+		handlerRegistry: handlerRegistry,
+		claimService:    claimService,
+		logger:          slog.Default(),
+	}
+}
+
+// WithLogger sets the logger for the executor.
+func (e *SagaExecutor) WithLogger(logger *slog.Logger) *SagaExecutor {
+	e.logger = logger
+	return e
+}
+
+// StepFailureResult captures the outcome of a step failure for decision making.
+type StepFailureResult struct {
+	// SagaID is the saga instance ID.
+	SagaID uuid.UUID
+
+	// StepIndex is the index of the failed step.
+	StepIndex int
+
+	// StepName is the name of the failed step.
+	StepName string
+
+	// Error is the original error from the step handler.
+	Error error
+
+	// ErrorCategory is the classified error category.
+	ErrorCategory ErrorCategory
+
+	// Action is the recommended action based on error category.
+	Action FailureAction
+
+	// ReplayCount is the current replay count before any increment.
+	ReplayCount int
+}
+
+// FailureAction represents the action to take after a step failure.
+type FailureAction string
+
+const (
+	// FailureActionRetry indicates the step should be retried (TRANSIENT error).
+	// The saga remains in RUNNING status, replay_count is incremented, lease is released.
+	FailureActionRetry FailureAction = "RETRY"
+
+	// FailureActionCompensate indicates compensation should begin immediately (FATAL error).
+	// The saga transitions to COMPENSATING status, replay_count is NOT incremented.
+	FailureActionCompensate FailureAction = "COMPENSATE"
+
+	// FailureActionManualIntervention indicates the saga requires operator attention.
+	// The saga transitions to FAILED_MANUAL_INTERVENTION (max retries exceeded).
+	FailureActionManualIntervention FailureAction = "MANUAL_INTERVENTION"
+)
+
+// HandleStepFailure processes a step failure and determines the appropriate action.
+// This is the core decision logic for FATAL vs TRANSIENT error handling (FR-28).
+//
+// Decision logic:
+//   - FATAL errors -> Transition to COMPENSATING immediately, don't increment replay_count
+//   - TRANSIENT errors -> Increment replay_count, release lease for retry
+//   - If replay_count >= MaxReplays -> Transition to FAILED_MANUAL_INTERVENTION
+//
+// Parameters:
+//   - ctx: Context for cancellation and timeouts
+//   - sagaID: The saga instance ID
+//   - stepIndex: The index of the failed step
+//   - stepName: The name of the failed step
+//   - err: The error from the step handler
+//   - maxReplays: Maximum replay attempts before zombie detection
+//
+// Returns:
+//   - StepFailureResult with the classified error and recommended action
+//   - Error if there was a problem processing the failure
+func (e *SagaExecutor) HandleStepFailure(
+	ctx context.Context,
+	sagaID uuid.UUID,
+	stepIndex int,
+	stepName string,
+	err error,
+	maxReplays int,
+) (*StepFailureResult, error) {
+	if err == nil {
+		return nil, ErrNilError
+	}
+
+	// Classify the error
+	category := ClassifyError(err)
+
+	// Get current saga state
+	instance, fetchErr := e.instanceRepo.FindByID(ctx, sagaID)
+	if fetchErr != nil {
+		return nil, fmt.Errorf("failed to fetch saga instance: %w", fetchErr)
+	}
+	if instance == nil {
+		return nil, fmt.Errorf("%w: %s", ErrSagaNotFound, sagaID)
+	}
+
+	result := &StepFailureResult{
+		SagaID:        sagaID,
+		StepIndex:     stepIndex,
+		StepName:      stepName,
+		Error:         err,
+		ErrorCategory: category,
+		ReplayCount:   instance.ReplayCount,
+	}
+
+	e.logger.Info("handling step failure",
+		"saga_id", sagaID,
+		"step_index", stepIndex,
+		"step_name", stepName,
+		"error", err.Error(),
+		"error_category", category,
+		"replay_count", instance.ReplayCount,
+		"max_replays", maxReplays,
+	)
+
+	// Decision logic based on error category
+	switch category {
+	case ErrorCategoryFatal:
+		// FATAL errors: Transition to COMPENSATING immediately
+		// Do NOT increment replay_count (FR-28)
+		result.Action = FailureActionCompensate
+
+		if updateErr := e.instanceRepo.UpdateStatusWithError(
+			ctx, sagaID, SagaStatusCompensating, stepIndex, err, category,
+		); updateErr != nil {
+			return nil, fmt.Errorf("failed to transition saga to COMPENSATING: %w", updateErr)
+		}
+
+		RecordStepFailure(stepName, string(category))
+
+		e.logger.Warn("FATAL error detected, transitioning to COMPENSATING",
+			"saga_id", sagaID,
+			"step_index", stepIndex,
+			"step_name", stepName,
+			"error", err.Error(),
+		)
+
+	case ErrorCategoryTransient:
+		// TRANSIENT errors: Check if max replays exceeded
+		if instance.ReplayCount >= maxReplays {
+			// Max replays exceeded - zombie detected
+			result.Action = FailureActionManualIntervention
+
+			if updateErr := e.instanceRepo.UpdateStatusWithError(
+				ctx, sagaID, SagaStatusFailedManualIntervention, stepIndex, err, category,
+			); updateErr != nil {
+				return nil, fmt.Errorf("failed to transition saga to FAILED_MANUAL_INTERVENTION: %w", updateErr)
+			}
+
+			RecordZombieSagaDetected(instance.SagaDefinitionID.String())
+
+			e.logger.Error("max replays exceeded, transitioning to FAILED_MANUAL_INTERVENTION",
+				"saga_id", sagaID,
+				"step_index", stepIndex,
+				"replay_count", instance.ReplayCount,
+				"max_replays", maxReplays,
+			)
+		} else {
+			// Retry: Release lease and let claiming service pick it up
+			result.Action = FailureActionRetry
+
+			// Release the lease so another worker can claim it
+			// The claiming service will increment replay_count when claiming
+			if e.claimService != nil {
+				if releaseErr := e.claimService.ReleaseLease(ctx, sagaID); releaseErr != nil {
+					e.logger.Error("failed to release lease for retry",
+						"saga_id", sagaID,
+						"error", releaseErr,
+					)
+					// Don't fail the operation, just log the error
+				}
+			}
+
+			RecordStepFailure(stepName, string(category))
+
+			e.logger.Info("TRANSIENT error, releasing lease for retry",
+				"saga_id", sagaID,
+				"step_index", stepIndex,
+				"step_name", stepName,
+				"replay_count", instance.ReplayCount,
+			)
+		}
+
+	default:
+		// Unknown category - treat as FATAL (fail-safe)
+		result.Action = FailureActionCompensate
+		result.ErrorCategory = ErrorCategoryFatal
+
+		if updateErr := e.instanceRepo.UpdateStatusWithError(
+			ctx, sagaID, SagaStatusCompensating, stepIndex, err, ErrorCategoryFatal,
+		); updateErr != nil {
+			return nil, fmt.Errorf("failed to transition saga to COMPENSATING: %w", updateErr)
+		}
+
+		e.logger.Warn("unknown error category, treating as FATAL",
+			"saga_id", sagaID,
+			"step_index", stepIndex,
+			"error", err.Error(),
+		)
+	}
+
+	return result, nil
+}
+
+// ShouldRetry returns true if the error category indicates the step should be retried.
+func ShouldRetry(category ErrorCategory) bool {
+	return category == ErrorCategoryTransient
+}
+
+// ShouldCompensate returns true if the error category indicates compensation should begin.
+func ShouldCompensate(category ErrorCategory) bool {
+	return category == ErrorCategoryFatal
+}
+
+// DetermineFailureAction determines the action to take based on error category and replay state.
+// This is a stateless helper function for testing decision logic.
+func DetermineFailureAction(category ErrorCategory, replayCount, maxReplays int) FailureAction {
+	switch category {
+	case ErrorCategoryFatal:
+		return FailureActionCompensate
+	case ErrorCategoryTransient:
+		if replayCount >= maxReplays {
+			return FailureActionManualIntervention
+		}
+		return FailureActionRetry
+	default:
+		// Unknown category - fail-safe to compensation
+		return FailureActionCompensate
+	}
+}
+
+// RecordStepFailure records a step failure metric.
+// This is a placeholder that calls the metrics system.
+//
+//nolint:revive // Parameters kept for future implementation
+func RecordStepFailure(_, _ string) {
+	// The metrics package already has recording functions
+	// This is a convenience wrapper for step-specific failures
+}
+
+// ProcessStepResult processes the result of a step execution and handles errors.
+// This is a convenience method that combines step execution and failure handling.
+//
+// Returns:
+//   - (*StepFailureResult, nil) on step failure (with classification)
+//   - (nil, error) on infrastructure error (e.g., failed to reset replay count)
+//   - (nil, nil) should not occur - on success, the first return is always nil
+//
+//nolint:nilnil // Returns nil, nil on success - this is intentional behavior
+func (e *SagaExecutor) ProcessStepResult(
+	ctx context.Context,
+	instance *SagaInstance,
+	stepIndex int,
+	stepName string,
+	_ interface{}, // result is unused, kept for API consistency
+	err error,
+	maxReplays int,
+) (*StepFailureResult, error) {
+	if err == nil {
+		// Success - reset replay count and move to next step
+		if resetErr := e.instanceRepo.ResetReplayCount(ctx, instance.ID); resetErr != nil {
+			return nil, fmt.Errorf("failed to reset replay count: %w", resetErr)
+		}
+		return nil, nil
+	}
+
+	// Handle failure
+	return e.HandleStepFailure(ctx, instance.ID, stepIndex, stepName, err, maxReplays)
+}
+
+// UpdateSagaError updates the saga instance with error information.
+// This is a helper for updating the error fields on the saga instance.
+func UpdateSagaError(instance *SagaInstance, stepIndex int, err error, category ErrorCategory) {
+	now := time.Now()
+	instance.UpdatedAt = now
+	instance.FailedStepIndex = &stepIndex
+
+	if err != nil {
+		errMsg := err.Error()
+		instance.ErrorMessage = &errMsg
+	}
+
+	catStr := string(category)
+	instance.ErrorCategory = &catStr
+}

--- a/shared/pkg/saga/saga_executor_test.go
+++ b/shared/pkg/saga/saga_executor_test.go
@@ -1,0 +1,502 @@
+package saga
+
+// Tests for saga executor require dynamic errors to simulate different failure scenarios.
+//nolint:err113 // Dynamic errors are required for testing transient/fatal error patterns
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDetermineFailureAction verifies the stateless decision logic.
+func TestDetermineFailureAction(t *testing.T) {
+	t.Run("FATAL error returns COMPENSATE", func(t *testing.T) {
+		action := DetermineFailureAction(ErrorCategoryFatal, 0, 5)
+		assert.Equal(t, FailureActionCompensate, action)
+	})
+
+	t.Run("FATAL error with high replay count still returns COMPENSATE", func(t *testing.T) {
+		// FATAL errors should compensate regardless of replay count
+		action := DetermineFailureAction(ErrorCategoryFatal, 10, 5)
+		assert.Equal(t, FailureActionCompensate, action)
+	})
+
+	t.Run("TRANSIENT error with replays remaining returns RETRY", func(t *testing.T) {
+		action := DetermineFailureAction(ErrorCategoryTransient, 2, 5)
+		assert.Equal(t, FailureActionRetry, action)
+	})
+
+	t.Run("TRANSIENT error at max replays returns MANUAL_INTERVENTION", func(t *testing.T) {
+		action := DetermineFailureAction(ErrorCategoryTransient, 5, 5)
+		assert.Equal(t, FailureActionManualIntervention, action)
+	})
+
+	t.Run("TRANSIENT error exceeding max replays returns MANUAL_INTERVENTION", func(t *testing.T) {
+		action := DetermineFailureAction(ErrorCategoryTransient, 10, 5)
+		assert.Equal(t, FailureActionManualIntervention, action)
+	})
+
+	t.Run("unknown category returns COMPENSATE (fail-safe)", func(t *testing.T) {
+		action := DetermineFailureAction(ErrorCategory("UNKNOWN"), 0, 5)
+		assert.Equal(t, FailureActionCompensate, action)
+	})
+
+	t.Run("empty category returns COMPENSATE (fail-safe)", func(t *testing.T) {
+		action := DetermineFailureAction(ErrorCategory(""), 0, 5)
+		assert.Equal(t, FailureActionCompensate, action)
+	})
+}
+
+// TestShouldRetry verifies the retry decision helper.
+func TestShouldRetry(t *testing.T) {
+	assert.True(t, ShouldRetry(ErrorCategoryTransient))
+	assert.False(t, ShouldRetry(ErrorCategoryFatal))
+	assert.False(t, ShouldRetry(ErrorCategory("")))
+}
+
+// TestShouldCompensate verifies the compensation decision helper.
+func TestShouldCompensate(t *testing.T) {
+	assert.True(t, ShouldCompensate(ErrorCategoryFatal))
+	assert.False(t, ShouldCompensate(ErrorCategoryTransient))
+	assert.False(t, ShouldCompensate(ErrorCategory("")))
+}
+
+// MockSagaInstanceRepository is a mock implementation for testing.
+type MockSagaInstanceRepositoryForExecutor struct {
+	instances       map[uuid.UUID]*SagaInstance
+	updateStatusErr error
+	lastStatus      SagaStatus
+	lastStepIndex   int
+	lastError       error
+	lastCategory    ErrorCategory
+}
+
+func NewMockSagaInstanceRepositoryForExecutor() *MockSagaInstanceRepositoryForExecutor {
+	return &MockSagaInstanceRepositoryForExecutor{
+		instances: make(map[uuid.UUID]*SagaInstance),
+	}
+}
+
+func (r *MockSagaInstanceRepositoryForExecutor) FindByID(_ context.Context, id uuid.UUID) (*SagaInstance, error) {
+	instance, exists := r.instances[id]
+	if !exists {
+		return nil, nil
+	}
+	return instance, nil
+}
+
+func (r *MockSagaInstanceRepositoryForExecutor) Update(_ context.Context, instance *SagaInstance) error {
+	r.instances[instance.ID] = instance
+	return nil
+}
+
+func (r *MockSagaInstanceRepositoryForExecutor) UpdateStatus(_ context.Context, id uuid.UUID, status SagaStatus) error {
+	if r.updateStatusErr != nil {
+		return r.updateStatusErr
+	}
+	r.lastStatus = status
+	if instance, exists := r.instances[id]; exists {
+		instance.Status = status
+	}
+	return nil
+}
+
+func (r *MockSagaInstanceRepositoryForExecutor) UpdateStatusWithError(_ context.Context, id uuid.UUID, status SagaStatus, stepIndex int, err error, category ErrorCategory) error {
+	if r.updateStatusErr != nil {
+		return r.updateStatusErr
+	}
+	r.lastStatus = status
+	r.lastStepIndex = stepIndex
+	r.lastError = err
+	r.lastCategory = category
+	if instance, exists := r.instances[id]; exists {
+		instance.Status = status
+		instance.FailedStepIndex = &stepIndex
+		if err != nil {
+			errMsg := err.Error()
+			instance.ErrorMessage = &errMsg
+		}
+		catStr := string(category)
+		instance.ErrorCategory = &catStr
+	}
+	return nil
+}
+
+func (r *MockSagaInstanceRepositoryForExecutor) ResetReplayCount(_ context.Context, id uuid.UUID) error {
+	if instance, exists := r.instances[id]; exists {
+		instance.ReplayCount = 0
+	}
+	return nil
+}
+
+func (r *MockSagaInstanceRepositoryForExecutor) Add(instance *SagaInstance) {
+	r.instances[instance.ID] = instance
+}
+
+// TestSagaExecutor_HandleStepFailure_FatalError tests FATAL error handling.
+func TestSagaExecutor_HandleStepFailure_FatalError(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      0,
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	// Use a FATAL error (insufficient funds)
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		2,
+		"create_lien",
+		ErrInsufficientFunds,
+		5,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify classification and action
+	assert.Equal(t, ErrorCategoryFatal, result.ErrorCategory)
+	assert.Equal(t, FailureActionCompensate, result.Action)
+	assert.Equal(t, 2, result.StepIndex)
+	assert.Equal(t, "create_lien", result.StepName)
+
+	// Verify saga was transitioned to COMPENSATING
+	assert.Equal(t, SagaStatusCompensating, instanceRepo.lastStatus)
+	assert.Equal(t, 2, instanceRepo.lastStepIndex)
+	assert.Equal(t, ErrorCategoryFatal, instanceRepo.lastCategory)
+
+	// Verify saga instance was updated
+	updated, _ := instanceRepo.FindByID(context.Background(), sagaID)
+	assert.Equal(t, SagaStatusCompensating, updated.Status)
+}
+
+// TestSagaExecutor_HandleStepFailure_TransientError tests TRANSIENT error handling.
+func TestSagaExecutor_HandleStepFailure_TransientError(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      2, // Has some replays but not at max
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	// Use a TRANSIENT error (network timeout)
+	transientErr := errors.New("connection timeout")
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		1,
+		"post_entries",
+		transientErr,
+		5, // max replays
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify classification and action
+	assert.Equal(t, ErrorCategoryTransient, result.ErrorCategory)
+	assert.Equal(t, FailureActionRetry, result.Action)
+	assert.Equal(t, 2, result.ReplayCount) // Current count before any increment
+
+	// Saga should NOT be transitioned to COMPENSATING
+	// It stays in RUNNING and waits for claiming service to retry
+	updated, _ := instanceRepo.FindByID(context.Background(), sagaID)
+	assert.Equal(t, SagaStatusRunning, updated.Status)
+}
+
+// TestSagaExecutor_HandleStepFailure_TransientExceedsMaxReplays tests zombie detection.
+func TestSagaExecutor_HandleStepFailure_TransientExceedsMaxReplays(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      5, // At max replays
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	// Use a TRANSIENT error when already at max replays
+	transientErr := errors.New("database deadlock")
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		1,
+		"post_entries",
+		transientErr,
+		5, // max replays
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Even though it's TRANSIENT, max replays exceeded -> MANUAL_INTERVENTION
+	assert.Equal(t, ErrorCategoryTransient, result.ErrorCategory)
+	assert.Equal(t, FailureActionManualIntervention, result.Action)
+
+	// Verify saga was transitioned to FAILED_MANUAL_INTERVENTION
+	assert.Equal(t, SagaStatusFailedManualIntervention, instanceRepo.lastStatus)
+
+	updated, _ := instanceRepo.FindByID(context.Background(), sagaID)
+	assert.Equal(t, SagaStatusFailedManualIntervention, updated.Status)
+}
+
+// TestSagaExecutor_HandleStepFailure_FatalDoesNotCheckReplayCount tests that FATAL errors
+// bypass replay count checks and go directly to COMPENSATING.
+func TestSagaExecutor_HandleStepFailure_FatalDoesNotCheckReplayCount(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      0, // Low replay count, but FATAL should still compensate
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	// FATAL error should go to COMPENSATING regardless of replay count
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		0,
+		"validate_input",
+		ErrValidationFailed,
+		5,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// FATAL error -> COMPENSATE (not RETRY, not MANUAL_INTERVENTION)
+	assert.Equal(t, ErrorCategoryFatal, result.ErrorCategory)
+	assert.Equal(t, FailureActionCompensate, result.Action)
+	assert.Equal(t, SagaStatusCompensating, instanceRepo.lastStatus)
+}
+
+// TestSagaExecutor_HandleStepFailure_WrappedFatalError tests that wrapped FATAL errors are detected.
+func TestSagaExecutor_HandleStepFailure_WrappedFatalError(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      0,
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	// Wrapped FATAL error should be detected via errors.Is
+	wrappedErr := NewFatalError(errors.New("business logic failed"))
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		1,
+		"process_order",
+		wrappedErr,
+		5,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, ErrorCategoryFatal, result.ErrorCategory)
+	assert.Equal(t, FailureActionCompensate, result.Action)
+}
+
+// TestSagaExecutor_HandleStepFailure_NilError tests that nil error is rejected.
+func TestSagaExecutor_HandleStepFailure_NilError(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		uuid.New(),
+		0,
+		"step",
+		nil, // nil error
+		5,
+	)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrNilError)
+	assert.Nil(t, result)
+}
+
+// TestSagaExecutor_HandleStepFailure_SagaNotFound tests handling of missing saga.
+func TestSagaExecutor_HandleStepFailure_SagaNotFound(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	// Don't add any saga to the repo
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		uuid.New(), // Non-existent saga
+		0,
+		"step",
+		ErrBusinessRuleViolation, // Use a known error
+		5,
+	)
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrSagaNotFound)
+	assert.Nil(t, result)
+}
+
+// TestUpdateSagaError verifies the error update helper.
+func TestUpdateSagaError(t *testing.T) {
+	instance := &SagaInstance{
+		ID:     uuid.New(),
+		Status: SagaStatusRunning,
+	}
+
+	testErr := errors.New("test error message")
+	UpdateSagaError(instance, 3, testErr, ErrorCategoryFatal)
+
+	assert.NotNil(t, instance.FailedStepIndex)
+	assert.Equal(t, 3, *instance.FailedStepIndex)
+	assert.NotNil(t, instance.ErrorMessage)
+	assert.Equal(t, "test error message", *instance.ErrorMessage)
+	assert.NotNil(t, instance.ErrorCategory)
+	assert.Equal(t, string(ErrorCategoryFatal), *instance.ErrorCategory)
+}
+
+// TestIntegration_FatalErrorSkipsToCompensation is an integration-style test that
+// verifies the complete flow: FATAL error -> immediate compensation, no retry.
+func TestIntegration_FatalErrorSkipsToCompensation(t *testing.T) {
+	// This test verifies FR-28: FATAL errors should skip to compensation immediately
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		CurrentStepIndex: 2,
+		ReplayCount:      0,
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	// Simulate a step handler returning insufficient funds error
+	insufficientFundsErr := ErrInsufficientFunds
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		2,
+		"debit_account",
+		insufficientFundsErr,
+		5,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify: FATAL -> COMPENSATE action (not RETRY)
+	assert.Equal(t, FailureActionCompensate, result.Action,
+		"FATAL error should result in COMPENSATE action, not RETRY")
+
+	// Verify: Saga transitioned to COMPENSATING (not still RUNNING)
+	updated, _ := instanceRepo.FindByID(context.Background(), sagaID)
+	assert.Equal(t, SagaStatusCompensating, updated.Status,
+		"Saga should be in COMPENSATING status after FATAL error")
+
+	// Verify: Error category recorded correctly
+	assert.NotNil(t, updated.ErrorCategory)
+	assert.Equal(t, string(ErrorCategoryFatal), *updated.ErrorCategory)
+
+	// Verify: Failed step index recorded
+	assert.NotNil(t, updated.FailedStepIndex)
+	assert.Equal(t, 2, *updated.FailedStepIndex)
+
+	// Verify: Error message recorded
+	assert.NotNil(t, updated.ErrorMessage)
+	assert.Contains(t, *updated.ErrorMessage, "insufficient funds")
+}
+
+// TestIntegration_TransientErrorAllowsRetry is an integration-style test that
+// verifies the complete flow: TRANSIENT error -> retry allowed, no compensation.
+func TestIntegration_TransientErrorAllowsRetry(t *testing.T) {
+	// This test verifies FR-28: TRANSIENT errors should allow retry
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		CurrentStepIndex: 1,
+		ReplayCount:      1, // Has been retried once, still under limit
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	// Simulate a step handler returning network timeout error
+	timeoutErr := errors.New("connection timeout exceeded")
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		1,
+		"call_external_service",
+		timeoutErr,
+		5, // max 5 replays
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify: TRANSIENT -> RETRY action (not COMPENSATE)
+	assert.Equal(t, FailureActionRetry, result.Action,
+		"TRANSIENT error should result in RETRY action, not COMPENSATE")
+
+	// Verify: Saga stays in RUNNING (not COMPENSATING)
+	updated, _ := instanceRepo.FindByID(context.Background(), sagaID)
+	assert.Equal(t, SagaStatusRunning, updated.Status,
+		"Saga should remain in RUNNING status for TRANSIENT error (waiting for retry)")
+}

--- a/shared/pkg/saga/step_execution.go
+++ b/shared/pkg/saga/step_execution.go
@@ -186,11 +186,11 @@ func (e *StepExecutor) ExecuteStep(
 	}
 
 	if handlerErr != nil {
-		// Persist failure
+		// Persist failure with error classification (FR-28)
 		errStr := handlerErr.Error()
 		stepResult.Status = StepStatusFailed
 		stepResult.Error = &errStr
-		stepResult.ErrorCategory = categorizeError(handlerErr)
+		stepResult.SetErrorCategory(ClassifyError(handlerErr))
 	} else {
 		// Deep-copy output before persistence to prevent pointer leaks (FR-31)
 		deepCopiedOutput, copyErr := DeepCopyJSON(output)
@@ -342,10 +342,11 @@ func (e *TransactionalStepExecutor) ExecuteStepInTx(
 	}
 
 	if handlerErr != nil {
+		// Persist failure with error classification (FR-28)
 		errStr := handlerErr.Error()
 		stepResult.Status = StepStatusFailed
 		stepResult.Error = &errStr
-		stepResult.ErrorCategory = categorizeError(handlerErr)
+		stepResult.SetErrorCategory(ClassifyError(handlerErr))
 	} else {
 		// Deep-copy output (FR-31)
 		deepCopiedOutput, copyErr := DeepCopyJSON(output)
@@ -473,7 +474,7 @@ func (e *TransactionalStepExecutor) ExecuteStepWithOutbox(
 		errStr := handlerErr.Error()
 		stepResult.Status = StepStatusFailed
 		stepResult.Error = &errStr
-		stepResult.ErrorCategory = categorizeError(handlerErr)
+		stepResult.SetErrorCategory(ClassifyError(handlerErr))
 
 		// Create step failed event
 		errCat := ErrorCategoryFatal
@@ -649,85 +650,4 @@ func toJSONB(v interface{}) JSONB {
 		// For non-map types, wrap in a result key
 		return JSONB{"_value": v}
 	}
-}
-
-// categorizeError determines if an error is TRANSIENT (retryable) or FATAL (FR-28).
-// Returns a pointer to the error category string, or nil if uncategorized.
-func categorizeError(err error) *string {
-	if err == nil {
-		return nil
-	}
-
-	// Check for common transient error patterns
-	errStr := err.Error()
-
-	// Network/timeout errors are transient
-	transientPatterns := []string{
-		"timeout",
-		"deadline exceeded",
-		"connection refused",
-		"connection reset",
-		"temporary failure",
-		"unavailable",
-		"retry",
-		"EAGAIN",
-		"ETIMEDOUT",
-	}
-
-	for _, pattern := range transientPatterns {
-		if containsIgnoreCase(errStr, pattern) {
-			cat := string(ErrorCategoryTransient)
-			return &cat
-		}
-	}
-
-	// Default to fatal for unrecognized errors
-	cat := string(ErrorCategoryFatal)
-	return &cat
-}
-
-// containsIgnoreCase checks if s contains substr (case-insensitive).
-func containsIgnoreCase(s, substr string) bool {
-	sLower := make([]byte, len(s))
-	substrLower := make([]byte, len(substr))
-
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c >= 'A' && c <= 'Z' {
-			c += 'a' - 'A'
-		}
-		sLower[i] = c
-	}
-
-	for i := 0; i < len(substr); i++ {
-		c := substr[i]
-		if c >= 'A' && c <= 'Z' {
-			c += 'a' - 'A'
-		}
-		substrLower[i] = c
-	}
-
-	return containsBytes(sLower, substrLower)
-}
-
-func containsBytes(s, substr []byte) bool {
-	if len(substr) == 0 {
-		return true
-	}
-	if len(s) < len(substr) {
-		return false
-	}
-	for i := 0; i <= len(s)-len(substr); i++ {
-		match := true
-		for j := 0; j < len(substr); j++ {
-			if s[i+j] != substr[j] {
-				match = false
-				break
-			}
-		}
-		if match {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary

Implements FR-28 error categorization to distinguish retriable errors from business rule violations:

- **TRANSIENT errors** (network timeouts, connection issues, deadlocks) → Allow retries up to max_replay_count
- **FATAL errors** (insufficient funds, validation failures, business rule violations) → Trigger immediate compensation without wasting retry attempts
- **Unknown errors** default to FATAL as a fail-safe to prevent infinite retries

## Changes Made

| File | Description |
|------|-------------|
| `error_classification.go` | New `ClassifyError()` function with sentinel errors and pattern matching |
| `saga_executor.go` | New `SagaExecutor` with `HandleStepFailure()` decision logic |
| `step_execution.go` | Updated to use new classification system |
| `.golangci.yml` | Added err113 exclusion for test files |

## Test plan

- [x] Unit tests for error classification (sentinel errors, wrapped errors, patterns)
- [x] Unit tests for saga executor decision logic (FATAL skips to compensation, TRANSIENT allows retry)
- [x] All existing saga tests pass
- [ ] CI pipeline

## Task Master

`starlark-saga-orchestration.17` - Implement step error severity classification (TRANSIENT vs FATAL)