### PR TITLE
feat(saga): Implement async/await pattern with suspend/resume flow

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.39.0
 	go.opentelemetry.io/otel/sdk v1.39.0
 	go.opentelemetry.io/otel/trace v1.39.0
+	go.starlark.net v0.0.0-20260102030733-3fee463870c9
 	go.uber.org/goleak v1.3.0
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 	google.golang.org/grpc v1.78.0
@@ -58,7 +59,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0 // indirect
-	go.starlark.net v0.0.0-20260102030733-3fee463870c9 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 )

--- a/shared/pkg/saga/metrics.go
+++ b/shared/pkg/saga/metrics.go
@@ -38,6 +38,38 @@ var (
 			Help: "Total number of times saga replay counts were incremented",
 		},
 	)
+
+	// sagaSuspendedTotal tracks the total number of saga suspensions.
+	sagaSuspendedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "saga_suspended_total",
+			Help: "Total number of times sagas were suspended waiting for external events",
+		},
+	)
+
+	// sagaSuspendTimeoutTotal tracks the total number of suspend timeouts.
+	sagaSuspendTimeoutTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "saga_suspend_timeout_total",
+			Help: "Total number of saga suspensions that timed out",
+		},
+	)
+
+	// sagaResumedTotal tracks the total number of successful saga resumptions.
+	sagaResumedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "saga_resumed_total",
+			Help: "Total number of sagas successfully resumed from suspension",
+		},
+	)
+
+	// sagaResumeIdempotentTotal tracks idempotent resume calls.
+	sagaResumeIdempotentTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "saga_resume_idempotent_total",
+			Help: "Total number of idempotent saga resume calls (already resumed)",
+		},
+	)
 )
 
 // RecordZombieSagaDetected records that a zombie saga was detected.
@@ -57,14 +89,42 @@ func RecordReplayIncrement() {
 	sagaReplayIncrementedTotal.Inc()
 }
 
+// RecordSuspend records that a saga was suspended.
+func RecordSuspend() {
+	sagaSuspendedTotal.Inc()
+}
+
+// RecordSuspendTimeout records that a saga suspension timed out.
+func RecordSuspendTimeout() {
+	sagaSuspendTimeoutTotal.Inc()
+}
+
+// RecordResume records that a saga was successfully resumed.
+func RecordResume() {
+	sagaResumedTotal.Inc()
+}
+
+// RecordResumeIdempotent records an idempotent resume call.
+func RecordResumeIdempotent() {
+	sagaResumeIdempotentTotal.Inc()
+}
+
 // ExposeMetricsForTesting provides access to the raw Prometheus metrics for testing.
 // This should only be used in test code.
 var ExposeMetricsForTesting = struct {
 	ZombieDetectedTotal    *prometheus.CounterVec
 	ReplayCount            prometheus.Histogram
 	ReplayIncrementedTotal prometheus.Counter
+	SuspendedTotal         prometheus.Counter
+	SuspendTimeoutTotal    prometheus.Counter
+	ResumedTotal           prometheus.Counter
+	ResumeIdempotentTotal  prometheus.Counter
 }{
 	ZombieDetectedTotal:    sagaZombieDetectedTotal,
 	ReplayCount:            sagaReplayCount,
 	ReplayIncrementedTotal: sagaReplayIncrementedTotal,
+	SuspendedTotal:         sagaSuspendedTotal,
+	SuspendTimeoutTotal:    sagaSuspendTimeoutTotal,
+	ResumedTotal:           sagaResumedTotal,
+	ResumeIdempotentTotal:  sagaResumeIdempotentTotal,
 }

--- a/shared/pkg/saga/suspend.go
+++ b/shared/pkg/saga/suspend.go
@@ -140,7 +140,10 @@ func (s *SuspendService) SuspendSaga(
 	stepName string,
 	req *SuspendRequest,
 ) (*SuspendResult, error) {
-	// Validate request
+	// Validate inputs
+	if instance == nil {
+		return nil, fmt.Errorf("%w: saga instance is required", ErrSuspendSagaNotFound)
+	}
 	if req == nil {
 		return nil, fmt.Errorf("%w: suspend request is required", ErrIdempotencyKeyRequired)
 	}

--- a/shared/pkg/saga/suspend.go
+++ b/shared/pkg/saga/suspend.go
@@ -1,0 +1,395 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Suspend-related errors.
+var (
+	// ErrSuspended is returned by ctx.Suspend() to signal the runtime to pause execution.
+	// This is not a failure - it's the normal control flow for suspending a saga.
+	ErrSuspended = errors.New("saga suspended waiting for external event")
+
+	// ErrDuplicateIdempotencyKey is returned when attempting to suspend with a key that's already in use.
+	ErrDuplicateIdempotencyKey = errors.New("suspend idempotency key already exists")
+
+	// ErrInvalidTimeout is returned when timeout is not positive.
+	ErrInvalidTimeout = errors.New("suspend timeout must be positive")
+
+	// ErrSuspendSagaNotFound is returned when a saga cannot be found for suspension operations.
+	ErrSuspendSagaNotFound = errors.New("saga not found")
+
+	// ErrInvalidSagaState is returned when trying to complete a saga that's not waiting for an event.
+	ErrInvalidSagaState = errors.New("saga is not waiting for external event")
+
+	// ErrIdempotencyKeyMismatch is returned when the idempotency key doesn't match.
+	ErrIdempotencyKeyMismatch = errors.New("idempotency key does not match suspended saga")
+
+	// ErrIdempotencyKeyRequired is returned when idempotency key is empty.
+	ErrIdempotencyKeyRequired = errors.New("idempotency key is required")
+)
+
+// StepStatusSuspended indicates the step is suspended waiting for external event.
+const StepStatusSuspended StepStatus = "SUSPENDED"
+
+// SuspendRequest contains the parameters for suspending a saga.
+type SuspendRequest struct {
+	// IdempotencyKey is a unique key for this suspension (used by external systems to resume).
+	IdempotencyKey string
+
+	// Timeout is the maximum time to wait for the external event before auto-failing.
+	Timeout time.Duration
+
+	// Reason is an optional human-readable description of why the saga is suspended.
+	Reason string
+
+	// Data contains optional context data to store with the suspension.
+	Data map[string]interface{}
+}
+
+// SuspendResult contains the result of a successful suspension.
+type SuspendResult struct {
+	// SagaInstanceID is the ID of the suspended saga.
+	SagaInstanceID uuid.UUID
+
+	// IdempotencyKey is the key that external systems use to resume the saga.
+	IdempotencyKey string
+
+	// TimeoutAt is when the saga will auto-fail if not resumed.
+	TimeoutAt time.Time
+}
+
+// CompleteSagaStepRequest contains the parameters for completing a suspended saga step.
+type CompleteSagaStepRequest struct {
+	// SagaInstanceID is the ID of the saga to resume (optional if IdempotencyKey is unique).
+	SagaInstanceID *uuid.UUID
+
+	// IdempotencyKey is the key provided when the saga was suspended.
+	IdempotencyKey string
+
+	// Result is the data from the external event (e.g., payment confirmation).
+	Result interface{}
+}
+
+// CompleteSagaStepResponse contains the result of completing a suspended saga step.
+type CompleteSagaStepResponse struct {
+	// SagaInstanceID is the ID of the resumed saga.
+	SagaInstanceID uuid.UUID
+
+	// WasAlreadyCompleted indicates this is an idempotent no-op (saga already resumed).
+	WasAlreadyCompleted bool
+
+	// NewStatus is the saga's status after completion.
+	NewStatus SagaStatus
+}
+
+// SuspendService handles saga suspension and resumption.
+type SuspendService struct {
+	db     *gorm.DB
+	config *SuspendConfig
+}
+
+// SuspendConfig holds configuration for the suspend service.
+type SuspendConfig struct {
+	// DefaultTimeout is the default suspension timeout if not specified.
+	DefaultTimeout time.Duration
+
+	// MaxTimeout is the maximum allowed suspension timeout.
+	MaxTimeout time.Duration
+}
+
+// DefaultSuspendConfig returns the default suspend configuration.
+func DefaultSuspendConfig() *SuspendConfig {
+	return &SuspendConfig{
+		DefaultTimeout: 24 * time.Hour,     // 1 day default
+		MaxTimeout:     7 * 24 * time.Hour, // 1 week maximum
+	}
+}
+
+// NewSuspendService creates a new SuspendService.
+func NewSuspendService(db *gorm.DB, config *SuspendConfig) *SuspendService {
+	if config == nil {
+		config = DefaultSuspendConfig()
+	}
+	return &SuspendService{
+		db:     db,
+		config: config,
+	}
+}
+
+// SuspendSaga suspends a saga waiting for an external event.
+// This method:
+// 1. Creates a step result with SUSPENDED status
+// 2. Updates the saga to WAITING_FOR_EVENT status
+// 3. Sets the suspend timeout
+// 4. CRITICALLY: Releases the pod lease so other work can proceed
+//
+// All operations happen in a single transaction for atomicity.
+func (s *SuspendService) SuspendSaga(
+	ctx context.Context,
+	instance *SagaInstance,
+	stepIndex int,
+	stepName string,
+	req *SuspendRequest,
+) (*SuspendResult, error) {
+	// Validate request
+	if req.IdempotencyKey == "" {
+		return nil, fmt.Errorf("%w: idempotency key required", ErrInvalidTimeout)
+	}
+
+	timeout := req.Timeout
+	if timeout <= 0 {
+		timeout = s.config.DefaultTimeout
+	}
+	if timeout > s.config.MaxTimeout {
+		timeout = s.config.MaxTimeout
+	}
+
+	now := time.Now()
+	timeoutAt := now.Add(timeout)
+
+	// Generate idempotency key for the step result
+	stepIdempotencyKey := FormatIdempotencyKey(instance.ID, stepIndex)
+
+	// Generate causation ID
+	causationID := GenerateCausationID(instance.ID, stepIndex)
+
+	// Prepare step result with SUSPENDED status
+	stepResult := &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: instance.ID,
+		StepIndex:      stepIndex,
+		StepName:       stepName,
+		IdempotencyKey: stepIdempotencyKey,
+		Status:         StepStatusSuspended,
+		CausationID:    &causationID,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	// Store suspend request data in step result, including the idempotency key for lookups
+	stepResult.Result = JSONB{
+		"idempotency_key": req.IdempotencyKey,
+	}
+	if req.Data != nil {
+		for k, v := range req.Data {
+			stepResult.Result[k] = v
+		}
+	}
+
+	// Execute in transaction
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// 1. Save step result with SUSPENDED status
+		if err := tx.Create(stepResult).Error; err != nil {
+			// Check for duplicate idempotency key
+			if isDuplicateKeyError(err) {
+				return fmt.Errorf("%w: %s", ErrDuplicateIdempotencyKey, req.IdempotencyKey)
+			}
+			return fmt.Errorf("failed to save suspended step result: %w", err)
+		}
+
+		// 2. Update saga instance:
+		//    - Status = WAITING_FOR_EVENT
+		//    - Set suspend fields
+		//    - CRITICAL: Release lease (claimed_by_pod = NULL)
+		updates := map[string]interface{}{
+			"status":         SagaStatusWaitingForEvent,
+			"suspend_reason": req.Reason,
+			"suspend_data":   JSONB{"idempotency_key": req.IdempotencyKey, "timeout_at": timeoutAt},
+			"updated_at":     now,
+			// CRITICAL: Release the lease so other sagas can be processed
+			"claimed_by_pod":   nil,
+			"claimed_at":       nil,
+			"lease_expires_at": nil,
+		}
+
+		result := tx.Model(&SagaInstance{}).
+			Where("id = ?", instance.ID).
+			Updates(updates)
+
+		if result.Error != nil {
+			return fmt.Errorf("failed to update saga instance: %w", result.Error)
+		}
+		if result.RowsAffected == 0 {
+			return ErrSuspendSagaNotFound
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &SuspendResult{
+		SagaInstanceID: instance.ID,
+		IdempotencyKey: req.IdempotencyKey,
+		TimeoutAt:      timeoutAt,
+	}, nil
+}
+
+// CompleteSagaStep resumes a suspended saga with the result from an external event.
+// This method is called by external systems (e.g., webhook handlers) when the
+// awaited event occurs.
+//
+// Idempotency guarantee: If the saga has already been resumed (status != WAITING_FOR_EVENT),
+// this method returns success with WasAlreadyCompleted=true.
+//
+// Lookup strategy:
+// 1. First, try to find a saga that's still WAITING_FOR_EVENT with matching idempotency key
+// 2. If not found, check if we already processed this by looking at step results
+//
+//nolint:gocognit // Transaction with multiple lookup strategies requires sequential branches
+func (s *SuspendService) CompleteSagaStep(
+	ctx context.Context,
+	req *CompleteSagaStepRequest,
+) (*CompleteSagaStepResponse, error) {
+	if req.IdempotencyKey == "" {
+		return nil, ErrIdempotencyKeyRequired
+	}
+
+	var response CompleteSagaStepResponse
+	now := time.Now()
+
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Strategy 1: Find saga by suspend idempotency key in suspend_data (still waiting)
+		var saga SagaInstance
+		query := tx.Where("suspend_data->>'idempotency_key' = ?", req.IdempotencyKey)
+		if req.SagaInstanceID != nil {
+			query = query.Where("id = ?", *req.SagaInstanceID)
+		}
+
+		// Use FOR UPDATE to lock the row
+		err := query.Clauses(clause.Locking{Strength: "UPDATE"}).First(&saga).Error
+
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			// Strategy 2: Check if this idempotency key was already processed
+			// Look for a step result that had this suspend idempotency key
+			// The step result's idempotency key format includes the saga ID, but we need to
+			// find which saga had this suspend key. We can look it up via the step result's
+			// data or find the saga by checking step results with matching suspend data.
+			//
+			// For idempotency, we need to find any saga where the step result had this key
+			// in its original suspension. We store the suspend key in the step result's
+			// Result field when suspended.
+
+			// Look for a step result that was previously suspended with this idempotency key
+			// We stored the suspend data in Result when suspending
+			var stepWithKey SagaStepResult
+			lookupErr := tx.Where("result->>'idempotency_key' = ? OR result->>'_suspend_key' = ?",
+				req.IdempotencyKey, req.IdempotencyKey).
+				Order("created_at DESC").
+				First(&stepWithKey).Error
+
+			if lookupErr == nil {
+				// Found a step that had this idempotency key - fetch the saga
+				if sagaErr := tx.First(&saga, "id = ?", stepWithKey.SagaInstanceID).Error; sagaErr != nil {
+					return fmt.Errorf("failed to find saga for step result: %w", sagaErr)
+				}
+				// This is an idempotent call - saga was already processed
+				response.SagaInstanceID = saga.ID
+				response.WasAlreadyCompleted = true
+				response.NewStatus = saga.Status
+				return nil
+			}
+
+			// No saga found at all
+			return fmt.Errorf("%w: no saga found with idempotency key %s", ErrSuspendSagaNotFound, req.IdempotencyKey)
+		}
+		if err != nil {
+			return fmt.Errorf("failed to find saga: %w", err)
+		}
+
+		response.SagaInstanceID = saga.ID
+
+		// Check current status for idempotency
+		if saga.Status != SagaStatusWaitingForEvent {
+			// Already resumed - this is an idempotent no-op
+			response.WasAlreadyCompleted = true
+			response.NewStatus = saga.Status
+			return nil
+		}
+
+		// Find the suspended step result to update
+		var stepResult SagaStepResult
+		if err := tx.Where("saga_instance_id = ? AND status = ?", saga.ID, StepStatusSuspended).
+			Order("step_index DESC").
+			First(&stepResult).Error; err != nil {
+			return fmt.Errorf("failed to find suspended step result: %w", err)
+		}
+
+		// Update step result with callback data
+		// Store both the result and the original suspend key for idempotency lookups
+		resultData := toJSONB(req.Result)
+		if resultData == nil {
+			resultData = JSONB{}
+		}
+		resultData["_suspend_key"] = req.IdempotencyKey
+
+		stepUpdates := map[string]interface{}{
+			"status":     StepStatusCompleted,
+			"result":     resultData,
+			"updated_at": now,
+		}
+		if err := tx.Model(&stepResult).Updates(stepUpdates).Error; err != nil {
+			return fmt.Errorf("failed to update step result: %w", err)
+		}
+
+		// Update saga instance:
+		// - Status back to PENDING (will be claimed by next worker cycle)
+		// - Clear suspend fields
+		sagaUpdates := map[string]interface{}{
+			"status":         SagaStatusPending,
+			"suspend_reason": nil,
+			"suspend_data":   nil,
+			"updated_at":     now,
+		}
+		if err := tx.Model(&saga).Updates(sagaUpdates).Error; err != nil {
+			return fmt.Errorf("failed to update saga instance: %w", err)
+		}
+
+		response.NewStatus = SagaStatusPending
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &response, nil
+}
+
+// FindSuspendedByIdempotencyKey finds a saga that's suspended with the given idempotency key.
+func (s *SuspendService) FindSuspendedByIdempotencyKey(ctx context.Context, key string) (*SagaInstance, error) {
+	var saga SagaInstance
+	err := s.db.WithContext(ctx).
+		Where("suspend_data->>'idempotency_key' = ?", key).
+		Where("status = ?", SagaStatusWaitingForEvent).
+		First(&saga).Error
+
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil //nolint:nilnil // Standard Go pattern for "not found, no error"
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to find suspended saga: %w", err)
+	}
+	return &saga, nil
+}
+
+// isDuplicateKeyError checks if the error is a duplicate key violation.
+func isDuplicateKeyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	// PostgreSQL duplicate key error codes/messages
+	return containsIgnoreCase(errStr, "duplicate key") ||
+		containsIgnoreCase(errStr, "unique constraint") ||
+		containsIgnoreCase(errStr, "23505") // PostgreSQL unique_violation error code
+}

--- a/shared/pkg/saga/suspend.go
+++ b/shared/pkg/saga/suspend.go
@@ -141,8 +141,11 @@ func (s *SuspendService) SuspendSaga(
 	req *SuspendRequest,
 ) (*SuspendResult, error) {
 	// Validate request
+	if req == nil {
+		return nil, fmt.Errorf("%w: suspend request is required", ErrIdempotencyKeyRequired)
+	}
 	if req.IdempotencyKey == "" {
-		return nil, fmt.Errorf("%w: idempotency key required", ErrInvalidTimeout)
+		return nil, ErrIdempotencyKeyRequired
 	}
 
 	timeout := req.Timeout
@@ -283,10 +286,13 @@ func (s *SuspendService) CompleteSagaStep(
 			// Look for a step result that was previously suspended with this idempotency key
 			// We stored the suspend data in Result when suspending
 			var stepWithKey SagaStepResult
-			lookupErr := tx.Where("result->>'idempotency_key' = ? OR result->>'_suspend_key' = ?",
-				req.IdempotencyKey, req.IdempotencyKey).
-				Order("created_at DESC").
-				First(&stepWithKey).Error
+			stepQuery := tx.Where("result->>'idempotency_key' = ? OR result->>'_suspend_key' = ?",
+				req.IdempotencyKey, req.IdempotencyKey)
+			// If SagaInstanceID provided, filter by it for consistency
+			if req.SagaInstanceID != nil {
+				stepQuery = stepQuery.Where("saga_instance_id = ?", *req.SagaInstanceID)
+			}
+			lookupErr := stepQuery.Order("created_at DESC").First(&stepWithKey).Error
 
 			if lookupErr == nil {
 				// Found a step that had this idempotency key - fetch the saga

--- a/shared/pkg/saga/suspend_test.go
+++ b/shared/pkg/saga/suspend_test.go
@@ -37,6 +37,16 @@ func TestSuspendSaga_ValidationErrors(t *testing.T) {
 	ctx := context.Background()
 	instance := &SagaInstance{ID: uuid.New()}
 
+	t.Run("nil instance returns error", func(t *testing.T) {
+		req := &SuspendRequest{
+			IdempotencyKey: "test-key",
+			Timeout:        time.Hour,
+		}
+		result, err := suspendService.SuspendSaga(ctx, nil, 0, "step", req)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, ErrSuspendSagaNotFound)
+	})
+
 	t.Run("nil request returns error", func(t *testing.T) {
 		result, err := suspendService.SuspendSaga(ctx, instance, 0, "step", nil)
 		assert.Nil(t, result)

--- a/shared/pkg/saga/suspend_test.go
+++ b/shared/pkg/saga/suspend_test.go
@@ -1,0 +1,818 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Unit Tests ---
+
+func TestSuspendRequest_Validation(t *testing.T) {
+	t.Run("empty idempotency key fails", func(t *testing.T) {
+		req := &SuspendRequest{
+			IdempotencyKey: "",
+			Timeout:        time.Hour,
+		}
+		assert.Empty(t, req.IdempotencyKey)
+	})
+
+	t.Run("negative timeout uses default", func(t *testing.T) {
+		config := DefaultSuspendConfig()
+		assert.True(t, config.DefaultTimeout > 0)
+		assert.True(t, config.MaxTimeout > config.DefaultTimeout)
+	})
+}
+
+func TestStepStatusSuspended(t *testing.T) {
+	assert.Equal(t, StepStatus("SUSPENDED"), StepStatusSuspended)
+}
+
+// --- Integration Tests ---
+
+func TestIntegration_Suspend_BasicFlow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create saga instance
+	instanceID := uuid.New()
+	correlationID := uuid.New()
+	instance := &SagaInstance{
+		ID:               instanceID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    correlationID,
+		Status:           SagaStatusRunning,
+		CurrentStepIndex: 2,
+		ClaimedByPod:     stringPtr("pod-123"),
+		ClaimedAt:        timePtr(time.Now()),
+		LeaseExpiresAt:   timePtr(time.Now().Add(5 * time.Minute)),
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	suspendService := NewSuspendService(db, DefaultSuspendConfig())
+	ctx := context.Background()
+
+	// Suspend the saga
+	suspendReq := &SuspendRequest{
+		IdempotencyKey: "payment-confirmation-12345",
+		Timeout:        2 * time.Hour,
+		Reason:         "Waiting for DNO payment confirmation",
+		Data: map[string]interface{}{
+			"payment_ref": "PAY-ABC-123",
+			"amount":      1000.50,
+		},
+	}
+
+	result, err := suspendService.SuspendSaga(ctx, instance, 2, "await_payment", suspendReq)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// Verify suspension result
+	assert.Equal(t, instanceID, result.SagaInstanceID)
+	assert.Equal(t, "payment-confirmation-12345", result.IdempotencyKey)
+	assert.True(t, result.TimeoutAt.After(time.Now()))
+	assert.True(t, result.TimeoutAt.Before(time.Now().Add(3*time.Hour)))
+
+	// Verify saga instance was updated correctly
+	var updatedSaga SagaInstance
+	err = db.First(&updatedSaga, "id = ?", instanceID).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, SagaStatusWaitingForEvent, updatedSaga.Status)
+	assert.Nil(t, updatedSaga.ClaimedByPod, "Lease should be released")
+	assert.Nil(t, updatedSaga.ClaimedAt, "Claim time should be cleared")
+	assert.Nil(t, updatedSaga.LeaseExpiresAt, "Lease expiry should be cleared")
+	assert.Equal(t, "Waiting for DNO payment confirmation", *updatedSaga.SuspendReason)
+
+	// Verify step result was created with SUSPENDED status
+	var stepResult SagaStepResult
+	idempotencyKey := FormatIdempotencyKey(instanceID, 2)
+	err = db.First(&stepResult, "idempotency_key = ?", idempotencyKey).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, StepStatusSuspended, stepResult.Status)
+	assert.Equal(t, "await_payment", stepResult.StepName)
+	assert.Equal(t, 2, stepResult.StepIndex)
+}
+
+func TestIntegration_Suspend_LeaseRelease(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create saga instance with active lease
+	instanceID := uuid.New()
+	podID := "worker-pod-xyz"
+	claimedAt := time.Now()
+	leaseExpiry := time.Now().Add(5 * time.Minute)
+
+	instance := &SagaInstance{
+		ID:               instanceID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		CurrentStepIndex: 0,
+		ClaimedByPod:     &podID,
+		ClaimedAt:        &claimedAt,
+		LeaseExpiresAt:   &leaseExpiry,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	suspendService := NewSuspendService(db, DefaultSuspendConfig())
+	ctx := context.Background()
+
+	// Suspend
+	suspendReq := &SuspendRequest{
+		IdempotencyKey: "test-lease-release",
+		Timeout:        time.Hour,
+	}
+	_, err = suspendService.SuspendSaga(ctx, instance, 0, "step", suspendReq)
+	require.NoError(t, err)
+
+	// Verify lease was released
+	var updatedSaga SagaInstance
+	err = db.First(&updatedSaga, "id = ?", instanceID).Error
+	require.NoError(t, err)
+
+	assert.Nil(t, updatedSaga.ClaimedByPod, "claimed_by_pod should be NULL after suspend")
+	assert.Nil(t, updatedSaga.ClaimedAt, "claimed_at should be NULL after suspend")
+	assert.Nil(t, updatedSaga.LeaseExpiresAt, "lease_expires_at should be NULL after suspend")
+
+	// Verify status changed to WAITING_FOR_EVENT
+	assert.Equal(t, SagaStatusWaitingForEvent, updatedSaga.Status)
+}
+
+func TestIntegration_CompleteSagaStep_BasicFlow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create and suspend a saga
+	instanceID := uuid.New()
+	idempotencyKey := "webhook-callback-key"
+	instance := &SagaInstance{
+		ID:               instanceID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		CurrentStepIndex: 1,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	suspendService := NewSuspendService(db, DefaultSuspendConfig())
+	ctx := context.Background()
+
+	// Suspend the saga
+	suspendReq := &SuspendRequest{
+		IdempotencyKey: idempotencyKey,
+		Timeout:        time.Hour,
+	}
+	_, err = suspendService.SuspendSaga(ctx, instance, 1, "await_callback", suspendReq)
+	require.NoError(t, err)
+
+	// Complete the saga step (webhook callback)
+	completeReq := &CompleteSagaStepRequest{
+		IdempotencyKey: idempotencyKey,
+		Result: map[string]interface{}{
+			"payment_status": "CONFIRMED",
+			"transaction_id": "TXN-987654",
+			"confirmed_at":   time.Now().Format(time.RFC3339),
+		},
+	}
+
+	response, err := suspendService.CompleteSagaStep(ctx, completeReq)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+
+	// Verify response
+	assert.Equal(t, instanceID, response.SagaInstanceID)
+	assert.False(t, response.WasAlreadyCompleted)
+	assert.Equal(t, SagaStatusPending, response.NewStatus)
+
+	// Verify saga was resumed (status back to PENDING for worker to claim)
+	var resumedSaga SagaInstance
+	err = db.First(&resumedSaga, "id = ?", instanceID).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, SagaStatusPending, resumedSaga.Status)
+	assert.Nil(t, resumedSaga.SuspendReason, "suspend_reason should be cleared")
+
+	// Verify step result was updated with callback data
+	stepKey := FormatIdempotencyKey(instanceID, 1)
+	var stepResult SagaStepResult
+	err = db.First(&stepResult, "idempotency_key = ?", stepKey).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, StepStatusCompleted, stepResult.Status)
+	assert.NotNil(t, stepResult.Result)
+	assert.Equal(t, "CONFIRMED", stepResult.Result["payment_status"])
+}
+
+func TestIntegration_CompleteSagaStep_Idempotency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create and suspend a saga
+	instanceID := uuid.New()
+	idempotencyKey := "idempotent-callback"
+	instance := &SagaInstance{
+		ID:               instanceID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		CurrentStepIndex: 0,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	suspendService := NewSuspendService(db, DefaultSuspendConfig())
+	ctx := context.Background()
+
+	// Suspend
+	suspendReq := &SuspendRequest{
+		IdempotencyKey: idempotencyKey,
+		Timeout:        time.Hour,
+	}
+	_, err = suspendService.SuspendSaga(ctx, instance, 0, "step", suspendReq)
+	require.NoError(t, err)
+
+	// First completion
+	completeReq := &CompleteSagaStepRequest{
+		IdempotencyKey: idempotencyKey,
+		Result:         map[string]interface{}{"attempt": 1},
+	}
+	response1, err := suspendService.CompleteSagaStep(ctx, completeReq)
+	require.NoError(t, err)
+	assert.False(t, response1.WasAlreadyCompleted)
+	assert.Equal(t, SagaStatusPending, response1.NewStatus)
+
+	// Second completion (idempotent - saga already resumed)
+	completeReq.Result = map[string]interface{}{"attempt": 2}
+	response2, err := suspendService.CompleteSagaStep(ctx, completeReq)
+	require.NoError(t, err)
+	assert.True(t, response2.WasAlreadyCompleted, "Second call should be idempotent no-op")
+	assert.Equal(t, SagaStatusPending, response2.NewStatus)
+
+	// Third completion
+	response3, err := suspendService.CompleteSagaStep(ctx, completeReq)
+	require.NoError(t, err)
+	assert.True(t, response3.WasAlreadyCompleted)
+
+	// Verify saga was only updated once (step result should have attempt: 1)
+	stepKey := FormatIdempotencyKey(instanceID, 0)
+	var stepResult SagaStepResult
+	err = db.First(&stepResult, "idempotency_key = ?", stepKey).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, float64(1), stepResult.Result["attempt"],
+		"Result should be from first completion, not overwritten by idempotent calls")
+}
+
+func TestIntegration_CompleteSagaStep_ConcurrentCalls(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create and suspend a saga
+	instanceID := uuid.New()
+	idempotencyKey := "concurrent-callback"
+	instance := &SagaInstance{
+		ID:               instanceID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		CurrentStepIndex: 0,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	suspendService := NewSuspendService(db, DefaultSuspendConfig())
+	ctx := context.Background()
+
+	// Suspend
+	suspendReq := &SuspendRequest{
+		IdempotencyKey: idempotencyKey,
+		Timeout:        time.Hour,
+	}
+	_, err = suspendService.SuspendSaga(ctx, instance, 0, "step", suspendReq)
+	require.NoError(t, err)
+
+	// Call CompleteSagaStep concurrently 10 times
+	numGoroutines := 10
+	var wg sync.WaitGroup
+	responses := make([]*CompleteSagaStepResponse, numGoroutines)
+	errs := make([]error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			req := &CompleteSagaStepRequest{
+				IdempotencyKey: idempotencyKey,
+				Result:         map[string]interface{}{"caller": idx},
+			}
+			responses[idx], errs[idx] = suspendService.CompleteSagaStep(ctx, req)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All calls should succeed
+	for i, err := range errs {
+		assert.NoError(t, err, "Call %d should not error", i)
+	}
+
+	// Exactly one should be the "first" completion, others idempotent
+	firstCount := 0
+	idempotentCount := 0
+	for _, resp := range responses {
+		if resp == nil {
+			continue // Skip failed calls
+		}
+		if resp.WasAlreadyCompleted {
+			idempotentCount++
+		} else {
+			firstCount++
+		}
+	}
+
+	assert.Equal(t, 1, firstCount, "Exactly one call should be the first completion")
+	assert.Equal(t, numGoroutines-1, idempotentCount, "Other calls should be idempotent")
+}
+
+func TestIntegration_CompleteSagaStep_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	suspendService := NewSuspendService(db, DefaultSuspendConfig())
+	ctx := context.Background()
+
+	// Try to complete a non-existent saga
+	completeReq := &CompleteSagaStepRequest{
+		IdempotencyKey: "non-existent-key",
+		Result:         map[string]interface{}{},
+	}
+
+	_, err = suspendService.CompleteSagaStep(ctx, completeReq)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "saga not found")
+}
+
+func TestIntegration_FindSuspendedByIdempotencyKey(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create and suspend a saga
+	instanceID := uuid.New()
+	idempotencyKey := "find-test-key"
+	instance := &SagaInstance{
+		ID:               instanceID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		CurrentStepIndex: 0,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	suspendService := NewSuspendService(db, DefaultSuspendConfig())
+	ctx := context.Background()
+
+	// Before suspend - should not find
+	found, err := suspendService.FindSuspendedByIdempotencyKey(ctx, idempotencyKey)
+	require.NoError(t, err)
+	assert.Nil(t, found)
+
+	// Suspend
+	suspendReq := &SuspendRequest{
+		IdempotencyKey: idempotencyKey,
+		Timeout:        time.Hour,
+	}
+	_, err = suspendService.SuspendSaga(ctx, instance, 0, "step", suspendReq)
+	require.NoError(t, err)
+
+	// After suspend - should find
+	found, err = suspendService.FindSuspendedByIdempotencyKey(ctx, idempotencyKey)
+	require.NoError(t, err)
+	require.NotNil(t, found)
+	assert.Equal(t, instanceID, found.ID)
+
+	// Complete the saga
+	completeReq := &CompleteSagaStepRequest{
+		IdempotencyKey: idempotencyKey,
+		Result:         map[string]interface{}{},
+	}
+	_, err = suspendService.CompleteSagaStep(ctx, completeReq)
+	require.NoError(t, err)
+
+	// After completion - should not find (status is no longer WAITING_FOR_EVENT)
+	found, err = suspendService.FindSuspendedByIdempotencyKey(ctx, idempotencyKey)
+	require.NoError(t, err)
+	assert.Nil(t, found)
+}
+
+func TestIntegration_TimeoutWorker_ExpiresSuspendedSagas(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create a saga that's already past its timeout
+	instanceID := uuid.New()
+	pastTimeout := time.Now().Add(-1 * time.Hour) // 1 hour ago
+	suspendData := JSONB{
+		"idempotency_key": "expired-saga-key",
+		"timeout_at":      pastTimeout,
+	}
+	suspendReason := "Waiting for callback"
+
+	instance := &SagaInstance{
+		ID:               instanceID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusWaitingForEvent,
+		CurrentStepIndex: 1,
+		SuspendReason:    &suspendReason,
+		SuspendData:      suspendData,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	// Create corresponding step result with SUSPENDED status
+	stepKey := FormatIdempotencyKey(instanceID, 1)
+	stepResult := &SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: instanceID,
+		StepIndex:      1,
+		StepName:       "await_callback",
+		IdempotencyKey: stepKey,
+		Status:         StepStatusSuspended,
+	}
+	err = db.Create(stepResult).Error
+	require.NoError(t, err)
+
+	// Create timeout worker and process
+	workerConfig := &TimeoutWorkerConfig{
+		PollInterval: time.Second,
+		BatchSize:    10,
+	}
+	worker := NewTimeoutWorker(db, workerConfig)
+	ctx := context.Background()
+
+	err = worker.ProcessExpiredSuspensions(ctx)
+	require.NoError(t, err)
+
+	// Verify saga was transitioned to FAILED
+	var updatedSaga SagaInstance
+	err = db.First(&updatedSaga, "id = ?", instanceID).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, SagaStatusFailed, updatedSaga.Status)
+	assert.Contains(t, *updatedSaga.ErrorMessage, "Suspend timeout exceeded")
+	assert.Equal(t, string(ErrorCategoryFatal), *updatedSaga.ErrorCategory)
+	assert.Nil(t, updatedSaga.SuspendReason)
+	assert.Nil(t, updatedSaga.SuspendData)
+
+	// Verify step result was updated to FAILED
+	var updatedStep SagaStepResult
+	err = db.First(&updatedStep, "idempotency_key = ?", stepKey).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, StepStatusFailed, updatedStep.Status)
+	assert.Contains(t, *updatedStep.Error, "Timeout waiting for external event")
+}
+
+func TestIntegration_TimeoutWorker_DoesNotExpireActiveSagas(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Create a saga with future timeout
+	instanceID := uuid.New()
+	futureTimeout := time.Now().Add(2 * time.Hour)
+	suspendData := JSONB{
+		"idempotency_key": "active-saga-key",
+		"timeout_at":      futureTimeout,
+	}
+
+	instance := &SagaInstance{
+		ID:               instanceID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusWaitingForEvent,
+		CurrentStepIndex: 0,
+		SuspendData:      suspendData,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	// Process expired suspensions
+	worker := NewTimeoutWorker(db, DefaultTimeoutWorkerConfig())
+	ctx := context.Background()
+
+	err = worker.ProcessExpiredSuspensions(ctx)
+	require.NoError(t, err)
+
+	// Verify saga was NOT touched
+	var unchanged SagaInstance
+	err = db.First(&unchanged, "id = ?", instanceID).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, SagaStatusWaitingForEvent, unchanged.Status,
+		"Saga with future timeout should not be expired")
+}
+
+func TestIntegration_TimeoutWorker_GracefulShutdown(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	workerConfig := &TimeoutWorkerConfig{
+		PollInterval: 100 * time.Millisecond,
+		BatchSize:    10,
+	}
+	worker := NewTimeoutWorker(db, workerConfig)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Start worker in goroutine
+	workerDone := make(chan error, 1)
+	go func() {
+		workerDone <- worker.Start(ctx)
+	}()
+
+	// Let it run for a bit
+	time.Sleep(250 * time.Millisecond)
+
+	// Cancel context to stop worker
+	cancel()
+
+	// Worker should stop cleanly within reasonable time
+	err = await.New().
+		AtMost(2 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			select {
+			case <-workerDone:
+				return true
+			default:
+				return false
+			}
+		})
+	require.NoError(t, err, "Worker should stop after context cancellation")
+}
+
+func TestIntegration_SuspendAndResume_EndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	// Scenario: DNO Payment Confirmation
+	// 1. Saga starts processing a payment order
+	// 2. Saga calls external DNO API to initiate payment
+	// 3. Saga suspends waiting for webhook confirmation
+	// 4. Hours later, webhook arrives with confirmation
+	// 5. Saga resumes and completes
+
+	instanceID := uuid.New()
+	correlationID := uuid.New()
+	instance := &SagaInstance{
+		ID:               instanceID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    correlationID,
+		Status:           SagaStatusRunning,
+		CurrentStepIndex: 3, // Already completed steps 0-2
+		ClaimedByPod:     stringPtr("payment-worker-1"),
+		ClaimedAt:        timePtr(time.Now()),
+		LeaseExpiresAt:   timePtr(time.Now().Add(5 * time.Minute)),
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	suspendService := NewSuspendService(db, DefaultSuspendConfig())
+	ctx := context.Background()
+
+	// Step 3: Suspend waiting for DNO confirmation
+	paymentRef := "DNO-PAY-" + uuid.New().String()[:8]
+	suspendReq := &SuspendRequest{
+		IdempotencyKey: paymentRef,
+		Timeout:        72 * time.Hour, // 3 days to receive confirmation
+		Reason:         "Awaiting DNO payment settlement confirmation",
+		Data: map[string]interface{}{
+			"payment_ref":      paymentRef,
+			"amount_cents":     150000,
+			"recipient_msisdn": "+254700123456",
+		},
+	}
+
+	suspendResult, err := suspendService.SuspendSaga(ctx, instance, 3, "await_dno_confirmation", suspendReq)
+	require.NoError(t, err)
+
+	// Verify suspension
+	assert.Equal(t, paymentRef, suspendResult.IdempotencyKey)
+
+	// Verify saga state changed correctly
+	var suspendedSaga SagaInstance
+	err = db.First(&suspendedSaga, "id = ?", instanceID).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, SagaStatusWaitingForEvent, suspendedSaga.Status)
+	assert.Nil(t, suspendedSaga.ClaimedByPod, "Worker should release lease when suspending")
+
+	// Simulate webhook callback (hours later)
+	webhookPayload := map[string]interface{}{
+		"status":         "SETTLED",
+		"transaction_id": "TXN-" + uuid.New().String()[:8],
+		"settled_at":     time.Now().Format(time.RFC3339),
+		"settlement_ref": "SETTLE-12345",
+	}
+
+	completeReq := &CompleteSagaStepRequest{
+		IdempotencyKey: paymentRef,
+		Result:         webhookPayload,
+	}
+
+	completeResp, err := suspendService.CompleteSagaStep(ctx, completeReq)
+	require.NoError(t, err)
+
+	assert.Equal(t, instanceID, completeResp.SagaInstanceID)
+	assert.False(t, completeResp.WasAlreadyCompleted)
+	assert.Equal(t, SagaStatusPending, completeResp.NewStatus)
+
+	// Verify saga is ready to be claimed by worker again
+	var resumedSaga SagaInstance
+	err = db.First(&resumedSaga, "id = ?", instanceID).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, SagaStatusPending, resumedSaga.Status,
+		"Saga should be PENDING so worker can claim and continue execution")
+	assert.Nil(t, resumedSaga.ClaimedByPod, "No worker has claimed yet")
+	assert.Nil(t, resumedSaga.SuspendReason, "Suspend reason should be cleared")
+
+	// Verify step result contains the webhook data
+	stepKey := FormatIdempotencyKey(instanceID, 3)
+	var stepResult SagaStepResult
+	err = db.First(&stepResult, "idempotency_key = ?", stepKey).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, StepStatusCompleted, stepResult.Status)
+	assert.Equal(t, "SETTLED", stepResult.Result["status"])
+	assert.Equal(t, "await_dno_confirmation", stepResult.StepName)
+}
+
+func TestIntegration_MultipleSuspensions_SameSaga(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	err := RunSagaMigrations(db)
+	require.NoError(t, err)
+
+	instanceID := uuid.New()
+	instance := &SagaInstance{
+		ID:               instanceID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		CurrentStepIndex: 0,
+	}
+	err = db.Create(instance).Error
+	require.NoError(t, err)
+
+	suspendService := NewSuspendService(db, DefaultSuspendConfig())
+	ctx := context.Background()
+
+	// First suspension (step 0)
+	_, err = suspendService.SuspendSaga(ctx, instance, 0, "first_suspend", &SuspendRequest{
+		IdempotencyKey: "first-key",
+		Timeout:        time.Hour,
+	})
+	require.NoError(t, err)
+
+	// Complete first suspension
+	_, err = suspendService.CompleteSagaStep(ctx, &CompleteSagaStepRequest{
+		IdempotencyKey: "first-key",
+		Result:         map[string]interface{}{"step": 0},
+	})
+	require.NoError(t, err)
+
+	// Update saga to running for next step
+	err = db.Model(&SagaInstance{}).Where("id = ?", instanceID).
+		Updates(map[string]interface{}{"status": SagaStatusRunning}).Error
+	require.NoError(t, err)
+
+	// Second suspension (step 1)
+	_, err = suspendService.SuspendSaga(ctx, instance, 1, "second_suspend", &SuspendRequest{
+		IdempotencyKey: "second-key",
+		Timeout:        time.Hour,
+	})
+	require.NoError(t, err)
+
+	// Complete second suspension
+	_, err = suspendService.CompleteSagaStep(ctx, &CompleteSagaStepRequest{
+		IdempotencyKey: "second-key",
+		Result:         map[string]interface{}{"step": 1},
+	})
+	require.NoError(t, err)
+
+	// Verify both step results exist with correct data
+	var steps []SagaStepResult
+	err = db.Where("saga_instance_id = ?", instanceID).Order("step_index").Find(&steps).Error
+	require.NoError(t, err)
+
+	assert.Len(t, steps, 2)
+	assert.Equal(t, float64(0), steps[0].Result["step"])
+	assert.Equal(t, float64(1), steps[1].Result["step"])
+}
+
+// Helper functions for tests
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func timePtr(t time.Time) *time.Time {
+	return &t
+}

--- a/shared/pkg/saga/suspend_test.go
+++ b/shared/pkg/saga/suspend_test.go
@@ -31,6 +31,29 @@ func TestSuspendRequest_Validation(t *testing.T) {
 	})
 }
 
+func TestSuspendSaga_ValidationErrors(t *testing.T) {
+	// These tests don't need a database - they test validation before DB calls
+	suspendService := &SuspendService{config: DefaultSuspendConfig()}
+	ctx := context.Background()
+	instance := &SagaInstance{ID: uuid.New()}
+
+	t.Run("nil request returns error", func(t *testing.T) {
+		result, err := suspendService.SuspendSaga(ctx, instance, 0, "step", nil)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, ErrIdempotencyKeyRequired)
+	})
+
+	t.Run("empty idempotency key returns error", func(t *testing.T) {
+		req := &SuspendRequest{
+			IdempotencyKey: "",
+			Timeout:        time.Hour,
+		}
+		result, err := suspendService.SuspendSaga(ctx, instance, 0, "step", req)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, ErrIdempotencyKeyRequired)
+	})
+}
+
 func TestStepStatusSuspended(t *testing.T) {
 	assert.Equal(t, StepStatus("SUSPENDED"), StepStatusSuspended)
 }

--- a/shared/pkg/saga/timeout_worker.go
+++ b/shared/pkg/saga/timeout_worker.go
@@ -1,0 +1,179 @@
+// Package saga provides saga orchestration runtime and persistence for durable execution.
+package saga
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// TimeoutWorkerConfig holds configuration for the timeout worker.
+type TimeoutWorkerConfig struct {
+	// PollInterval is how often to check for expired suspensions.
+	// Default: 1 minute
+	PollInterval time.Duration
+
+	// BatchSize is the maximum number of sagas to process in a single poll.
+	// Default: 100
+	BatchSize int
+}
+
+// DefaultTimeoutWorkerConfig returns the default timeout worker configuration.
+func DefaultTimeoutWorkerConfig() *TimeoutWorkerConfig {
+	return &TimeoutWorkerConfig{
+		PollInterval: 1 * time.Minute,
+		BatchSize:    100,
+	}
+}
+
+// TimeoutWorker periodically checks for expired suspended sagas and transitions
+// them to FAILED status. This ensures sagas don't wait indefinitely for external
+// events that may never arrive.
+type TimeoutWorker struct {
+	db     *gorm.DB
+	config *TimeoutWorkerConfig
+	logger *slog.Logger
+}
+
+// NewTimeoutWorker creates a new TimeoutWorker.
+func NewTimeoutWorker(db *gorm.DB, config *TimeoutWorkerConfig) *TimeoutWorker {
+	if config == nil {
+		config = DefaultTimeoutWorkerConfig()
+	}
+	return &TimeoutWorker{
+		db:     db,
+		config: config,
+		logger: slog.Default(),
+	}
+}
+
+// WithLogger sets the logger for the timeout worker.
+func (w *TimeoutWorker) WithLogger(logger *slog.Logger) *TimeoutWorker {
+	w.logger = logger
+	return w
+}
+
+// Start begins the timeout worker loop. It runs until the context is cancelled.
+func (w *TimeoutWorker) Start(ctx context.Context) error {
+	w.logger.Info("timeout worker starting",
+		"poll_interval", w.config.PollInterval,
+		"batch_size", w.config.BatchSize,
+	)
+
+	ticker := time.NewTicker(w.config.PollInterval)
+	defer ticker.Stop()
+
+	// Run immediately on start
+	if err := w.processExpiredSuspensions(ctx); err != nil {
+		w.logger.Error("failed to process expired suspensions on startup", "error", err)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("timeout worker stopping")
+			return ctx.Err()
+		case <-ticker.C:
+			if err := w.processExpiredSuspensions(ctx); err != nil {
+				w.logger.Error("failed to process expired suspensions", "error", err)
+				// Continue running - don't exit on transient errors
+			}
+		}
+	}
+}
+
+// processExpiredSuspensions finds and fails sagas that have exceeded their suspend timeout.
+func (w *TimeoutWorker) processExpiredSuspensions(ctx context.Context) error {
+	now := time.Now()
+
+	// expiredSaga holds the result of the timeout query
+	type expiredSaga struct {
+		ID             uuid.UUID `gorm:"column:id"`
+		CorrelationID  uuid.UUID `gorm:"column:correlation_id"`
+		IdempotencyKey string    `gorm:"column:idempotency_key"`
+	}
+
+	var expired []expiredSaga
+
+	err := w.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// Find and transition expired suspensions atomically
+		// The JSONB query extracts the timeout_at field and compares with NOW()
+		result := tx.Raw(`
+			UPDATE saga_instances
+			SET
+				status = ?,
+				error_message = ?,
+				error_category = ?,
+				updated_at = ?,
+				suspend_reason = NULL,
+				suspend_data = NULL
+			WHERE id IN (
+				SELECT id FROM saga_instances
+				WHERE status = ?
+				  AND (suspend_data->>'timeout_at')::timestamptz < ?
+				FOR UPDATE SKIP LOCKED
+				LIMIT ?
+			)
+			RETURNING id, correlation_id, suspend_data->>'idempotency_key' as idempotency_key
+		`,
+			SagaStatusFailed,
+			"Suspend timeout exceeded - external event not received within deadline",
+			string(ErrorCategoryFatal),
+			now,
+			SagaStatusWaitingForEvent,
+			now,
+			w.config.BatchSize,
+		).Scan(&expired)
+
+		if result.Error != nil {
+			return result.Error
+		}
+
+		// Also update the corresponding step results to FAILED
+		for _, saga := range expired {
+			stepUpdate := tx.Model(&SagaStepResult{}).
+				Where("saga_instance_id = ? AND status = ?", saga.ID, StepStatusSuspended).
+				Updates(map[string]interface{}{
+					"status":         StepStatusFailed,
+					"error":          "Timeout waiting for external event",
+					"error_category": string(ErrorCategoryFatal),
+					"updated_at":     now,
+				})
+			if stepUpdate.Error != nil {
+				return fmt.Errorf("failed to update step result for saga %s: %w", saga.ID, stepUpdate.Error)
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Log and record metrics for each timed-out saga
+	for _, saga := range expired {
+		w.logger.Warn("saga suspension timed out",
+			"saga_id", saga.ID,
+			"correlation_id", saga.CorrelationID,
+			"idempotency_key", saga.IdempotencyKey,
+		)
+		RecordSuspendTimeout()
+	}
+
+	if len(expired) > 0 {
+		w.logger.Info("processed expired suspensions",
+			"count", len(expired),
+		)
+	}
+
+	return nil
+}
+
+// ProcessExpiredSuspensions is exposed for testing - allows manual trigger of timeout processing.
+func (w *TimeoutWorker) ProcessExpiredSuspensions(ctx context.Context) error {
+	return w.processExpiredSuspensions(ctx)
+}

--- a/shared/pkg/saga/timeout_worker.go
+++ b/shared/pkg/saga/timeout_worker.go
@@ -44,6 +44,13 @@ func NewTimeoutWorker(db *gorm.DB, config *TimeoutWorkerConfig) *TimeoutWorker {
 	if config == nil {
 		config = DefaultTimeoutWorkerConfig()
 	}
+	// Guard against invalid configuration values
+	if config.PollInterval <= 0 {
+		config.PollInterval = DefaultTimeoutWorkerConfig().PollInterval
+	}
+	if config.BatchSize <= 0 {
+		config.BatchSize = DefaultTimeoutWorkerConfig().BatchSize
+	}
 	return &TimeoutWorker{
 		db:     db,
 		config: config,
@@ -101,9 +108,18 @@ func (w *TimeoutWorker) processExpiredSuspensions(ctx context.Context) error {
 
 	err := w.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Find and transition expired suspensions atomically
+		// Use CTE to capture idempotency_key before clearing suspend_data
 		// The JSONB query extracts the timeout_at field and compares with NOW()
 		result := tx.Raw(`
-			UPDATE saga_instances
+			WITH expired_sagas AS (
+				SELECT id, correlation_id, suspend_data->>'idempotency_key' as idempotency_key
+				FROM saga_instances
+				WHERE status = ?
+				  AND (suspend_data->>'timeout_at')::timestamptz < ?
+				FOR UPDATE SKIP LOCKED
+				LIMIT ?
+			)
+			UPDATE saga_instances si
 			SET
 				status = ?,
 				error_message = ?,
@@ -111,22 +127,17 @@ func (w *TimeoutWorker) processExpiredSuspensions(ctx context.Context) error {
 				updated_at = ?,
 				suspend_reason = NULL,
 				suspend_data = NULL
-			WHERE id IN (
-				SELECT id FROM saga_instances
-				WHERE status = ?
-				  AND (suspend_data->>'timeout_at')::timestamptz < ?
-				FOR UPDATE SKIP LOCKED
-				LIMIT ?
-			)
-			RETURNING id, correlation_id, suspend_data->>'idempotency_key' as idempotency_key
+			FROM expired_sagas es
+			WHERE si.id = es.id
+			RETURNING si.id, es.correlation_id, es.idempotency_key
 		`,
+			SagaStatusWaitingForEvent,
+			now,
+			w.config.BatchSize,
 			SagaStatusFailed,
 			"Suspend timeout exceeded - external event not received within deadline",
 			string(ErrorCategoryFatal),
 			now,
-			SagaStatusWaitingForEvent,
-			now,
-			w.config.BatchSize,
 		).Scan(&expired)
 
 		if result.Error != nil {


### PR DESCRIPTION
## Summary

Implements async/await pattern for saga orchestration to support long-running operations that require external event completion (e.g., webhook callbacks, payment confirmations).

- Add `SuspendService` with `SuspendSaga` and `CompleteSagaStep` methods
- Implement lease release on suspend to allow other sagas to proceed
- Add `TimeoutWorker` for auto-failing expired suspensions
- Provide full idempotency guarantees for `CompleteSagaStep`

## Design Highlights

- **Lease Release**: `ctx.suspend()` releases pod lease immediately - the worker doesn't hold the lease during the wait period
- **Idempotency**: `CompleteSagaStep` supports idempotent retries by looking up previously processed keys in step results
- **Timeout Worker**: Uses `SKIP LOCKED` for safe concurrent processing across multiple pods
- **Status Flow**: `RUNNING` → `WAITING_FOR_EVENT` → `PENDING` (on completion) → claimed again by worker

## Test Plan

- [x] Integration tests for basic suspend/resume flow
- [x] Integration tests for lease release on suspend
- [x] Integration tests for `CompleteSagaStep` idempotency
- [x] Integration tests for concurrent completion calls
- [x] Integration tests for timeout worker expiring suspended sagas
- [x] Integration tests for timeout worker not affecting active sagas
- [x] Integration tests for timeout worker graceful shutdown
- [x] End-to-end test for DNO payment confirmation scenario
- [x] Integration tests for multiple suspensions on same saga

## Task Master

Closes starlark-saga-orchestration.20