### PR TITLE
feat(saga): Add gRPC API for saga definition management

### DIFF
--- a/api/proto/meridian/saga/v1/saga_registry.proto
+++ b/api/proto/meridian/saga/v1/saga_registry.proto
@@ -297,7 +297,8 @@ message GetSagaRequest {
   // name is the saga name (required if id not provided).
   string name = 2;
 
-  // version is the specific version to retrieve (0 = latest).
+  // version is the specific version to retrieve.
+  // If 0 (default), returns the active version (same as GetActiveSaga).
   int32 version = 3;
 }
 
@@ -330,8 +331,9 @@ message ListSagasRequest {
   // status_filter filters by saga status. Unspecified returns all statuses.
   SagaStatus status_filter = 1;
 
-  // include_system includes system sagas in the response (default: true).
-  bool include_system = 2;
+  // exclude_system excludes system sagas from the response.
+  // When false (default), system sagas are included.
+  bool exclude_system = 2;
 
   // page_size is the maximum number of sagas to return.
   int32 page_size = 3 [(buf.validate.field).int32 = {

--- a/api/proto/meridian/saga/v1/saga_registry.proto
+++ b/api/proto/meridian/saga/v1/saga_registry.proto
@@ -235,21 +235,22 @@ message CreateSagaDraftResponse {
 }
 
 // UpdateSagaDefinitionRequest contains updates for a DRAFT saga.
+// All fields except id are optional - only provided fields are updated.
 message UpdateSagaDefinitionRequest {
   // id is the UUID of the saga to update (required).
   string id = 1 [(buf.validate.field).string.uuid = true];
 
   // script is the updated Starlark source code.
-  string script = 2;
+  optional string script = 2;
 
   // preconditions_expression is the updated CEL expression.
-  string preconditions_expression = 3;
+  optional string preconditions_expression = 3;
 
   // display_name is the updated human-readable name.
-  string display_name = 4;
+  optional string display_name = 4;
 
   // description is the updated description.
-  string description = 5;
+  optional string description = 5;
 }
 
 // UpdateSagaDefinitionResponse contains the updated saga definition.

--- a/api/proto/meridian/saga/v1/saga_registry.proto
+++ b/api/proto/meridian/saga/v1/saga_registry.proto
@@ -1,0 +1,386 @@
+syntax = "proto3";
+
+package meridian.saga.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/saga/v1;sagav1";
+
+// SagaStatus defines the lifecycle state of a saga definition.
+enum SagaStatus {
+  // SAGA_STATUS_UNSPECIFIED means the status is unknown.
+  SAGA_STATUS_UNSPECIFIED = 0;
+  // SAGA_STATUS_DRAFT means the saga is being defined and cannot be executed.
+  SAGA_STATUS_DRAFT = 1;
+  // SAGA_STATUS_ACTIVE means the saga is available for execution.
+  SAGA_STATUS_ACTIVE = 2;
+  // SAGA_STATUS_DEPRECATED means the saga is no longer recommended for new executions.
+  SAGA_STATUS_DEPRECATED = 3;
+}
+
+// SagaDefinition represents a Starlark saga workflow definition.
+message SagaDefinition {
+  // id is the unique identifier for this definition (UUID).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // name is the saga identifier (e.g., "current_account_withdrawal").
+  string name = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[a-z][a-z0-9_]*$"
+  }];
+
+  // version allows multiple versions of the same saga name.
+  int32 version = 3 [(buf.validate.field).int32.gte = 1];
+
+  // script is the Starlark source code defining the saga workflow.
+  string script = 4 [(buf.validate.field).string.max_len = 65536];
+
+  // status is the current lifecycle status.
+  SagaStatus status = 5;
+
+  // is_system indicates this is a system saga seeded during tenant provisioning.
+  // System sagas are read-only.
+  bool is_system = 6;
+
+  // preconditions_expression is an optional CEL expression for validating
+  // preconditions before saga execution.
+  string preconditions_expression = 7 [(buf.validate.field).string.max_len = 2048];
+
+  // display_name is a human-readable name.
+  string display_name = 8 [(buf.validate.field).string.max_len = 128];
+
+  // description provides additional context about this saga.
+  string description = 9 [(buf.validate.field).string.max_len = 2048];
+
+  // created_at is when this definition was created.
+  google.protobuf.Timestamp created_at = 10;
+
+  // updated_at is when this definition was last modified.
+  google.protobuf.Timestamp updated_at = 11;
+
+  // activated_at is when this definition transitioned to ACTIVE.
+  google.protobuf.Timestamp activated_at = 12;
+
+  // deprecated_at is when this definition transitioned to DEPRECATED.
+  google.protobuf.Timestamp deprecated_at = 13;
+
+  // successor_id is the UUID of the saga that replaces this one when deprecated.
+  string successor_id = 14;
+}
+
+// ValidationWarning represents a non-blocking validation issue.
+message ValidationWarning {
+  // reference_type is the type of reference (step_handler, instrument, saga, etc.).
+  string reference_type = 1;
+
+  // reference_key is the identifier that failed validation.
+  string reference_key = 2;
+
+  // line_number is the source line where the reference appears.
+  int32 line_number = 3;
+
+  // message describes the validation issue.
+  string message = 4;
+
+  // suggestion provides a hint for fixing the issue.
+  string suggestion = 5;
+}
+
+// ValidationResult contains the outcome of saga validation.
+message ValidationResult {
+  // status summarizes the validation outcome: "READY", "WARNINGS", or "BLOCKED".
+  string status = 1;
+
+  // warnings contains non-critical validation issues.
+  repeated ValidationWarning warnings = 2;
+
+  // critical_errors contains issues that block activation.
+  repeated ValidationWarning critical_errors = 3;
+}
+
+// SagaDependency represents a saga that depends on an external reference.
+message SagaDependency {
+  // saga_id is the UUID of the dependent saga.
+  string saga_id = 1;
+
+  // saga_name is the name of the dependent saga.
+  string saga_name = 2;
+
+  // saga_version is the version of the dependent saga.
+  int32 saga_version = 3;
+
+  // saga_status is the current status of the dependent saga.
+  SagaStatus saga_status = 4;
+
+  // line_number is where the dependency appears in the saga script.
+  int32 line_number = 5;
+}
+
+// SagaRegistryService provides management operations for saga definitions.
+// These endpoints allow creating, updating, and managing saga lifecycles.
+service SagaRegistryService {
+  // CreateSagaDraft creates a new saga definition in DRAFT status.
+  // The saga's script is NOT validated at creation time - validation occurs at activation.
+  rpc CreateSagaDraft(CreateSagaDraftRequest) returns (CreateSagaDraftResponse) {
+    option (google.api.http) = {
+      post: "/v1/sagas"
+      body: "*"
+    };
+  }
+
+  // UpdateSagaDefinition modifies a DRAFT saga definition.
+  // Returns error if the saga is not in DRAFT status or is a system saga.
+  rpc UpdateSagaDefinition(UpdateSagaDefinitionRequest) returns (UpdateSagaDefinitionResponse) {
+    option (google.api.http) = {
+      patch: "/v1/sagas/{id}"
+      body: "*"
+    };
+  }
+
+  // ActivateSaga transitions a saga from DRAFT to ACTIVE.
+  // Validates the saga script before activation.
+  // Once activated, the script becomes immutable.
+  rpc ActivateSaga(ActivateSagaRequest) returns (ActivateSagaResponse) {
+    option (google.api.http) = {
+      post: "/v1/sagas/{id}/activate"
+    };
+  }
+
+  // DeprecateSaga transitions a saga from ACTIVE to DEPRECATED.
+  // Optionally specifies a successor saga.
+  rpc DeprecateSaga(DeprecateSagaRequest) returns (DeprecateSagaResponse) {
+    option (google.api.http) = {
+      post: "/v1/sagas/{id}/deprecate"
+      body: "*"
+    };
+  }
+
+  // GetSaga retrieves a specific saga by ID or by name+version.
+  rpc GetSaga(GetSagaRequest) returns (GetSagaResponse) {
+    option (google.api.http) = {
+      get: "/v1/sagas/{id}"
+    };
+  }
+
+  // GetActiveSaga retrieves the active saga for a name using tenant resolution.
+  // Resolution order: tenant override (is_system=FALSE) > platform default (is_system=TRUE).
+  rpc GetActiveSaga(GetActiveSagaRequest) returns (GetActiveSagaResponse) {
+    option (google.api.http) = {
+      get: "/v1/sagas/active/{name}"
+    };
+  }
+
+  // ListSagas retrieves sagas matching the filter criteria.
+  rpc ListSagas(ListSagasRequest) returns (ListSagasResponse) {
+    option (google.api.http) = {
+      get: "/v1/sagas"
+    };
+  }
+
+  // ValidateSagaDraft validates a saga script without activating it.
+  // Returns warnings for missing references.
+  rpc ValidateSagaDraft(ValidateSagaDraftRequest) returns (ValidateSagaDraftResponse) {
+    option (google.api.http) = {
+      post: "/v1/sagas/{id}/validate"
+    };
+  }
+
+  // AnalyzeDeprecationImpact finds all sagas that reference a given instrument.
+  // Used to understand the impact before deprecating an instrument.
+  rpc AnalyzeDeprecationImpact(AnalyzeDeprecationImpactRequest) returns (AnalyzeDeprecationImpactResponse) {
+    option (google.api.http) = {
+      get: "/v1/sagas/deprecation-impact"
+    };
+  }
+}
+
+// CreateSagaDraftRequest contains the data for creating a new saga draft.
+message CreateSagaDraftRequest {
+  // name is the saga identifier (required).
+  string name = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[a-z][a-z0-9_]*$"
+  }];
+
+  // version allows multiple versions of the same saga name (default: 1).
+  int32 version = 2;
+
+  // script is the Starlark source code (required).
+  string script = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 65536
+  }];
+
+  // preconditions_expression is an optional CEL expression for preconditions.
+  string preconditions_expression = 4;
+
+  // display_name is a human-readable name.
+  string display_name = 5;
+
+  // description provides additional context.
+  string description = 6;
+}
+
+// CreateSagaDraftResponse contains the created saga definition.
+message CreateSagaDraftResponse {
+  // saga is the created saga definition.
+  SagaDefinition saga = 1;
+
+  // validation contains initial validation warnings (non-blocking).
+  ValidationResult validation = 2;
+}
+
+// UpdateSagaDefinitionRequest contains updates for a DRAFT saga.
+message UpdateSagaDefinitionRequest {
+  // id is the UUID of the saga to update (required).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // script is the updated Starlark source code.
+  string script = 2;
+
+  // preconditions_expression is the updated CEL expression.
+  string preconditions_expression = 3;
+
+  // display_name is the updated human-readable name.
+  string display_name = 4;
+
+  // description is the updated description.
+  string description = 5;
+}
+
+// UpdateSagaDefinitionResponse contains the updated saga definition.
+message UpdateSagaDefinitionResponse {
+  // saga is the updated saga definition.
+  SagaDefinition saga = 1;
+}
+
+// ActivateSagaRequest identifies the saga to activate.
+message ActivateSagaRequest {
+  // id is the UUID of the saga to activate (required).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// ActivateSagaResponse contains the activated saga definition.
+message ActivateSagaResponse {
+  // saga is the activated saga definition.
+  SagaDefinition saga = 1;
+
+  // validation contains the final validation result.
+  ValidationResult validation = 2;
+}
+
+// DeprecateSagaRequest identifies the saga to deprecate.
+message DeprecateSagaRequest {
+  // id is the UUID of the saga to deprecate (required).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // successor_id is the UUID of the replacement saga (optional).
+  // If provided, must be ACTIVE with the same name.
+  string successor_id = 2;
+}
+
+// DeprecateSagaResponse contains the deprecated saga definition.
+message DeprecateSagaResponse {
+  // saga is the deprecated saga definition.
+  SagaDefinition saga = 1;
+}
+
+// GetSagaRequest identifies the saga to retrieve.
+message GetSagaRequest {
+  // id is the UUID of the saga (required if name not provided).
+  string id = 1;
+
+  // name is the saga name (required if id not provided).
+  string name = 2;
+
+  // version is the specific version to retrieve (0 = latest).
+  int32 version = 3;
+}
+
+// GetSagaResponse contains the requested saga definition.
+message GetSagaResponse {
+  // saga is the requested saga definition.
+  SagaDefinition saga = 1;
+}
+
+// GetActiveSagaRequest identifies the saga name to resolve.
+message GetActiveSagaRequest {
+  // name is the saga name to resolve (required).
+  string name = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+  }];
+}
+
+// GetActiveSagaResponse contains the resolved active saga.
+message GetActiveSagaResponse {
+  // saga is the resolved active saga definition.
+  SagaDefinition saga = 1;
+
+  // is_tenant_override indicates if this is a tenant-specific override.
+  bool is_tenant_override = 2;
+}
+
+// ListSagasRequest specifies the filter criteria for listing sagas.
+message ListSagasRequest {
+  // status_filter filters by saga status. Unspecified returns all statuses.
+  SagaStatus status_filter = 1;
+
+  // include_system includes system sagas in the response (default: true).
+  bool include_system = 2;
+
+  // page_size is the maximum number of sagas to return.
+  int32 page_size = 3 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 100
+  }];
+
+  // page_token is the pagination token from a previous response.
+  string page_token = 4;
+}
+
+// ListSagasResponse contains the matching sagas.
+message ListSagasResponse {
+  // sagas is the list of saga definitions.
+  repeated SagaDefinition sagas = 1;
+
+  // next_page_token is the token for retrieving the next page.
+  string next_page_token = 2;
+}
+
+// ValidateSagaDraftRequest identifies the saga to validate.
+message ValidateSagaDraftRequest {
+  // id is the UUID of the saga to validate (required).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// ValidateSagaDraftResponse contains the validation result.
+message ValidateSagaDraftResponse {
+  // validation contains the validation result.
+  ValidationResult validation = 1;
+
+  // report is a human-readable validation report.
+  string report = 2;
+}
+
+// AnalyzeDeprecationImpactRequest specifies the instrument to analyze.
+message AnalyzeDeprecationImpactRequest {
+  // instrument_code is the instrument code to check (required).
+  string instrument_code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+  }];
+}
+
+// AnalyzeDeprecationImpactResponse contains the impact analysis.
+message AnalyzeDeprecationImpactResponse {
+  // dependencies lists all sagas that reference the instrument.
+  repeated SagaDependency dependencies = 1;
+
+  // total_count is the total number of affected sagas.
+  int32 total_count = 2;
+}

--- a/services/reference-data/saga/grpc_handler.go
+++ b/services/reference-data/saga/grpc_handler.go
@@ -44,6 +44,9 @@ func (h *RegistryHandler) CreateSagaDraft(
 	req *sagav1.CreateSagaDraftRequest,
 ) (*sagav1.CreateSagaDraftResponse, error) {
 	version := int(req.Version)
+	if version < 0 {
+		return nil, status.Errorf(codes.InvalidArgument, "version must be non-negative")
+	}
 	if version == 0 {
 		version = 1
 	}
@@ -305,7 +308,7 @@ func (h *RegistryHandler) ListSagas(
 	}
 
 	// Filter out system sagas if requested
-	if !req.IncludeSystem {
+	if req.ExcludeSystem {
 		filtered := make([]*Definition, 0, len(defs))
 		for _, def := range defs {
 			if !def.IsSystem {

--- a/services/reference-data/saga/grpc_handler.go
+++ b/services/reference-data/saga/grpc_handler.go
@@ -250,6 +250,9 @@ func (h *RegistryHandler) GetSaga(
 		}
 		def, err = h.registry.GetByID(ctx, id)
 	} else if req.Name != "" {
+		if req.Version < 0 {
+			return nil, status.Errorf(codes.InvalidArgument, "version must be >= 0")
+		}
 		if req.Version == 0 {
 			def, err = h.registry.GetActive(ctx, req.Name)
 		} else {

--- a/services/reference-data/saga/grpc_handler.go
+++ b/services/reference-data/saga/grpc_handler.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"sort"
+	"strconv"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -98,6 +100,7 @@ func (h *RegistryHandler) CreateSagaDraft(
 }
 
 // UpdateSagaDefinition modifies a DRAFT saga definition.
+// Only fields that are explicitly set in the request are updated.
 func (h *RegistryHandler) UpdateSagaDefinition(
 	ctx context.Context,
 	req *sagav1.UpdateSagaDefinitionRequest,
@@ -107,11 +110,19 @@ func (h *RegistryHandler) UpdateSagaDefinition(
 		return nil, status.Errorf(codes.InvalidArgument, "invalid saga id: %v", err)
 	}
 
-	updates := &Definition{
-		Script:                  req.Script,
-		PreconditionsExpression: req.PreconditionsExpression,
-		DisplayName:             req.DisplayName,
-		Description:             req.Description,
+	// Only update fields that are explicitly provided (proto3 optional fields)
+	updates := &Definition{}
+	if req.Script != nil {
+		updates.Script = *req.Script
+	}
+	if req.PreconditionsExpression != nil {
+		updates.PreconditionsExpression = *req.PreconditionsExpression
+	}
+	if req.DisplayName != nil {
+		updates.DisplayName = *req.DisplayName
+	}
+	if req.Description != nil {
+		updates.Description = *req.Description
 	}
 
 	if err := h.registry.UpdateDefinition(ctx, id, updates); err != nil {
@@ -282,65 +293,131 @@ func (h *RegistryHandler) ListSagas(
 	ctx context.Context,
 	req *sagav1.ListSagasRequest,
 ) (*sagav1.ListSagasResponse, error) {
-	var defs []*Definition
-	var err error
-
-	// Filter by status if specified
-	if req.StatusFilter != sagav1.SagaStatus_SAGA_STATUS_UNSPECIFIED {
-		domainStatus := h.protoStatusToDomain(req.StatusFilter)
-		defs, err = h.registry.ListByStatus(ctx, domainStatus)
-	} else {
-		// Get all sagas by listing each status
-		drafts, err1 := h.registry.ListByStatus(ctx, StatusDraft)
-		actives, err2 := h.registry.ListByStatus(ctx, StatusActive)
-		deprecated, err3 := h.registry.ListByStatus(ctx, StatusDeprecated)
-
-		if err1 != nil || err2 != nil || err3 != nil {
-			return nil, status.Errorf(codes.Internal, "failed to list sagas")
-		}
-		defs = append(defs, drafts...)
-		defs = append(defs, actives...)
-		defs = append(defs, deprecated...)
-	}
-
+	defs, err := h.fetchSagas(ctx, req.StatusFilter)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to list sagas: %v", err)
 	}
 
 	// Filter out system sagas if requested
 	if req.ExcludeSystem {
-		filtered := make([]*Definition, 0, len(defs))
-		for _, def := range defs {
-			if !def.IsSystem {
-				filtered = append(filtered, def)
-			}
-		}
-		defs = filtered
+		defs = h.filterNonSystemSagas(defs)
 	}
 
-	// Apply pagination (simple implementation)
-	pageSize := int(req.PageSize)
-	if pageSize == 0 {
-		pageSize = 50
-	}
-	if pageSize > 100 {
-		pageSize = 100
+	// Sort for stable pagination
+	h.sortDefinitions(defs)
+
+	// Parse and validate pagination
+	offset, err := h.parsePageToken(req.PageToken)
+	if err != nil {
+		return nil, err
 	}
 
-	// TODO: Implement proper cursor-based pagination
-	if len(defs) > pageSize {
-		defs = defs[:pageSize]
-	}
+	// Apply pagination
+	pageSize := h.normalizePageSize(int(req.PageSize))
+	paginatedDefs, nextToken := h.paginate(defs, offset, pageSize)
 
-	sagas := make([]*sagav1.SagaDefinition, len(defs))
-	for i, def := range defs {
+	// Convert to proto
+	sagas := make([]*sagav1.SagaDefinition, len(paginatedDefs))
+	for i, def := range paginatedDefs {
 		sagas[i] = h.definitionToProto(def)
 	}
 
 	return &sagav1.ListSagasResponse{
 		Sagas:         sagas,
-		NextPageToken: "", // TODO: Implement pagination
+		NextPageToken: nextToken,
 	}, nil
+}
+
+// fetchSagas retrieves sagas filtered by status.
+func (h *RegistryHandler) fetchSagas(ctx context.Context, statusFilter sagav1.SagaStatus) ([]*Definition, error) {
+	if statusFilter != sagav1.SagaStatus_SAGA_STATUS_UNSPECIFIED {
+		domainStatus := h.protoStatusToDomain(statusFilter)
+		return h.registry.ListByStatus(ctx, domainStatus)
+	}
+
+	// Get all sagas by listing each status
+	drafts, err1 := h.registry.ListByStatus(ctx, StatusDraft)
+	actives, err2 := h.registry.ListByStatus(ctx, StatusActive)
+	deprecated, err3 := h.registry.ListByStatus(ctx, StatusDeprecated)
+
+	if err1 != nil {
+		return nil, err1
+	}
+	if err2 != nil {
+		return nil, err2
+	}
+	if err3 != nil {
+		return nil, err3
+	}
+
+	defs := make([]*Definition, 0, len(drafts)+len(actives)+len(deprecated))
+	defs = append(defs, drafts...)
+	defs = append(defs, actives...)
+	defs = append(defs, deprecated...)
+	return defs, nil
+}
+
+// filterNonSystemSagas returns only non-system sagas.
+func (h *RegistryHandler) filterNonSystemSagas(defs []*Definition) []*Definition {
+	filtered := make([]*Definition, 0, len(defs))
+	for _, def := range defs {
+		if !def.IsSystem {
+			filtered = append(filtered, def)
+		}
+	}
+	return filtered
+}
+
+// sortDefinitions sorts definitions by name, then version for stable pagination.
+func (h *RegistryHandler) sortDefinitions(defs []*Definition) {
+	sort.Slice(defs, func(i, j int) bool {
+		if defs[i].Name == defs[j].Name {
+			return defs[i].Version < defs[j].Version
+		}
+		return defs[i].Name < defs[j].Name
+	})
+}
+
+// parsePageToken parses the offset from a page token.
+func (h *RegistryHandler) parsePageToken(token string) (int, error) {
+	if token == "" {
+		return 0, nil
+	}
+	offset, err := strconv.Atoi(token)
+	if err != nil || offset < 0 {
+		return 0, status.Error(codes.InvalidArgument, "invalid page_token")
+	}
+	return offset, nil
+}
+
+// normalizePageSize ensures page size is within valid bounds.
+func (h *RegistryHandler) normalizePageSize(pageSize int) int {
+	if pageSize <= 0 {
+		return 50
+	}
+	if pageSize > 100 {
+		return 100
+	}
+	return pageSize
+}
+
+// paginate returns a slice of definitions and the next page token.
+func (h *RegistryHandler) paginate(defs []*Definition, offset, pageSize int) ([]*Definition, string) {
+	if offset > len(defs) {
+		offset = len(defs)
+	}
+
+	end := offset + pageSize
+	if end > len(defs) {
+		end = len(defs)
+	}
+
+	nextToken := ""
+	if end < len(defs) {
+		nextToken = strconv.Itoa(end)
+	}
+
+	return defs[offset:end], nextToken
 }
 
 // ValidateSagaDraft validates a saga script without activating it.

--- a/services/reference-data/saga/grpc_handler.go
+++ b/services/reference-data/saga/grpc_handler.go
@@ -1,0 +1,572 @@
+// Package saga provides gRPC handlers for saga definition management.
+package saga
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+)
+
+// RegistryHandler implements the SagaRegistryService gRPC service.
+// It provides management operations for saga definitions including
+// creating drafts, updating definitions, activation, and deprecation.
+type RegistryHandler struct {
+	sagav1.UnimplementedSagaRegistryServiceServer
+	registry  Registry
+	validator *ReferenceValidator
+	logger    *slog.Logger
+}
+
+// NewRegistryHandler creates a new saga registry gRPC handler.
+// The validator is optional - if nil, ValidateSagaDraft will return empty results.
+func NewRegistryHandler(registry Registry, validator *ReferenceValidator, logger *slog.Logger) *RegistryHandler {
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+	return &RegistryHandler{
+		registry:  registry,
+		validator: validator,
+		logger:    logger,
+	}
+}
+
+// CreateSagaDraft creates a new saga definition in DRAFT status.
+func (h *RegistryHandler) CreateSagaDraft(
+	ctx context.Context,
+	req *sagav1.CreateSagaDraftRequest,
+) (*sagav1.CreateSagaDraftResponse, error) {
+	version := int(req.Version)
+	if version == 0 {
+		version = 1
+	}
+
+	def := &Definition{
+		ID:                      uuid.New(),
+		Name:                    req.Name,
+		Version:                 version,
+		Script:                  req.Script,
+		Status:                  StatusDraft,
+		IsSystem:                false,
+		PreconditionsExpression: req.PreconditionsExpression,
+		DisplayName:             req.DisplayName,
+		Description:             req.Description,
+	}
+
+	if err := h.registry.CreateDraft(ctx, def); err != nil {
+		return nil, h.mapDomainError(err, "CreateSagaDraft", req.Name)
+	}
+
+	h.logger.Info("saga draft created",
+		"name", def.Name,
+		"version", def.Version,
+		"id", def.ID)
+
+	// Perform initial validation (non-blocking)
+	var validationResult *sagav1.ValidationResult
+	if h.validator != nil {
+		result, err := h.validator.ValidateDraft(ctx, def.ID, def.Script)
+		if err != nil {
+			h.logger.Warn("validation failed during draft creation",
+				"saga_id", def.ID,
+				"error", err)
+		} else {
+			validationResult = h.validationResultToProto(result)
+		}
+	}
+
+	// Re-fetch the saga to get timestamps set by the database
+	created, err := h.registry.GetByID(ctx, def.ID)
+	if err != nil {
+		return nil, h.mapDomainError(err, "CreateSagaDraft", req.Name)
+	}
+
+	return &sagav1.CreateSagaDraftResponse{
+		Saga:       h.definitionToProto(created),
+		Validation: validationResult,
+	}, nil
+}
+
+// UpdateSagaDefinition modifies a DRAFT saga definition.
+func (h *RegistryHandler) UpdateSagaDefinition(
+	ctx context.Context,
+	req *sagav1.UpdateSagaDefinitionRequest,
+) (*sagav1.UpdateSagaDefinitionResponse, error) {
+	id, err := uuid.Parse(req.Id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid saga id: %v", err)
+	}
+
+	updates := &Definition{
+		Script:                  req.Script,
+		PreconditionsExpression: req.PreconditionsExpression,
+		DisplayName:             req.DisplayName,
+		Description:             req.Description,
+	}
+
+	if err := h.registry.UpdateDefinition(ctx, id, updates); err != nil {
+		return nil, h.mapDomainError(err, "UpdateSagaDefinition", id.String())
+	}
+
+	// Retrieve the updated definition
+	updated, err := h.registry.GetByID(ctx, id)
+	if err != nil {
+		return nil, h.mapDomainError(err, "UpdateSagaDefinition", id.String())
+	}
+
+	h.logger.Info("saga definition updated",
+		"id", id,
+		"name", updated.Name)
+
+	return &sagav1.UpdateSagaDefinitionResponse{
+		Saga: h.definitionToProto(updated),
+	}, nil
+}
+
+// ActivateSaga transitions a saga from DRAFT to ACTIVE.
+func (h *RegistryHandler) ActivateSaga(
+	ctx context.Context,
+	req *sagav1.ActivateSagaRequest,
+) (*sagav1.ActivateSagaResponse, error) {
+	id, err := uuid.Parse(req.Id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid saga id: %v", err)
+	}
+
+	// Perform activation validation if validator is configured
+	var validationResult *sagav1.ValidationResult
+	if h.validator != nil {
+		saga, err := h.registry.GetByID(ctx, id)
+		if err != nil {
+			return nil, h.mapDomainError(err, "ActivateSaga", id.String())
+		}
+
+		result, err := h.validator.ValidateActivation(ctx, id, saga.Script)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "validation error: %v", err)
+		}
+		validationResult = h.validationResultToProto(result)
+
+		// If validation blocked, don't proceed with activation
+		if result.Status == statusBlocked {
+			return nil, status.Errorf(codes.FailedPrecondition, "saga validation failed: %s", result.FormatReport())
+		}
+	}
+
+	if err := h.registry.ActivateSaga(ctx, id); err != nil {
+		return nil, h.mapDomainError(err, "ActivateSaga", id.String())
+	}
+
+	// Retrieve the activated definition
+	activated, err := h.registry.GetByID(ctx, id)
+	if err != nil {
+		return nil, h.mapDomainError(err, "ActivateSaga", id.String())
+	}
+
+	h.logger.Info("saga activated",
+		"id", id,
+		"name", activated.Name,
+		"version", activated.Version)
+
+	return &sagav1.ActivateSagaResponse{
+		Saga:       h.definitionToProto(activated),
+		Validation: validationResult,
+	}, nil
+}
+
+// DeprecateSaga transitions a saga from ACTIVE to DEPRECATED.
+func (h *RegistryHandler) DeprecateSaga(
+	ctx context.Context,
+	req *sagav1.DeprecateSagaRequest,
+) (*sagav1.DeprecateSagaResponse, error) {
+	id, err := uuid.Parse(req.Id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid saga id: %v", err)
+	}
+
+	var successorID *uuid.UUID
+	if req.SuccessorId != "" {
+		parsed, err := uuid.Parse(req.SuccessorId)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid successor_id: %v", err)
+		}
+		successorID = &parsed
+	}
+
+	if err := h.registry.DeprecateSaga(ctx, id, successorID); err != nil {
+		return nil, h.mapDomainError(err, "DeprecateSaga", id.String())
+	}
+
+	// Retrieve the deprecated definition
+	deprecated, err := h.registry.GetByID(ctx, id)
+	if err != nil {
+		return nil, h.mapDomainError(err, "DeprecateSaga", id.String())
+	}
+
+	h.logger.Info("saga deprecated",
+		"id", id,
+		"name", deprecated.Name,
+		"version", deprecated.Version,
+		"successorId", req.SuccessorId)
+
+	return &sagav1.DeprecateSagaResponse{
+		Saga: h.definitionToProto(deprecated),
+	}, nil
+}
+
+// GetSaga retrieves a specific saga by ID or by name+version.
+func (h *RegistryHandler) GetSaga(
+	ctx context.Context,
+	req *sagav1.GetSagaRequest,
+) (*sagav1.GetSagaResponse, error) {
+	var def *Definition
+	var err error
+
+	if req.Id != "" {
+		id, parseErr := uuid.Parse(req.Id)
+		if parseErr != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid saga id: %v", parseErr)
+		}
+		def, err = h.registry.GetByID(ctx, id)
+	} else if req.Name != "" {
+		if req.Version == 0 {
+			def, err = h.registry.GetActive(ctx, req.Name)
+		} else {
+			def, err = h.registry.GetDefinition(ctx, req.Name, int(req.Version))
+		}
+	} else {
+		return nil, status.Errorf(codes.InvalidArgument, "either id or name must be provided")
+	}
+
+	if err != nil {
+		identifier := req.Id
+		if identifier == "" {
+			identifier = req.Name
+		}
+		return nil, h.mapDomainError(err, "GetSaga", identifier)
+	}
+
+	return &sagav1.GetSagaResponse{
+		Saga: h.definitionToProto(def),
+	}, nil
+}
+
+// GetActiveSaga retrieves the active saga for a name using tenant resolution.
+func (h *RegistryHandler) GetActiveSaga(
+	ctx context.Context,
+	req *sagav1.GetActiveSagaRequest,
+) (*sagav1.GetActiveSagaResponse, error) {
+	def, err := h.registry.GetActive(ctx, req.Name)
+	if err != nil {
+		return nil, h.mapDomainError(err, "GetActiveSaga", req.Name)
+	}
+
+	return &sagav1.GetActiveSagaResponse{
+		Saga:             h.definitionToProto(def),
+		IsTenantOverride: !def.IsSystem,
+	}, nil
+}
+
+// ListSagas retrieves sagas matching the filter criteria.
+func (h *RegistryHandler) ListSagas(
+	ctx context.Context,
+	req *sagav1.ListSagasRequest,
+) (*sagav1.ListSagasResponse, error) {
+	var defs []*Definition
+	var err error
+
+	// Filter by status if specified
+	if req.StatusFilter != sagav1.SagaStatus_SAGA_STATUS_UNSPECIFIED {
+		domainStatus := h.protoStatusToDomain(req.StatusFilter)
+		defs, err = h.registry.ListByStatus(ctx, domainStatus)
+	} else {
+		// Get all sagas by listing each status
+		drafts, err1 := h.registry.ListByStatus(ctx, StatusDraft)
+		actives, err2 := h.registry.ListByStatus(ctx, StatusActive)
+		deprecated, err3 := h.registry.ListByStatus(ctx, StatusDeprecated)
+
+		if err1 != nil || err2 != nil || err3 != nil {
+			return nil, status.Errorf(codes.Internal, "failed to list sagas")
+		}
+		defs = append(defs, drafts...)
+		defs = append(defs, actives...)
+		defs = append(defs, deprecated...)
+	}
+
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to list sagas: %v", err)
+	}
+
+	// Filter out system sagas if requested
+	if !req.IncludeSystem {
+		filtered := make([]*Definition, 0, len(defs))
+		for _, def := range defs {
+			if !def.IsSystem {
+				filtered = append(filtered, def)
+			}
+		}
+		defs = filtered
+	}
+
+	// Apply pagination (simple implementation)
+	pageSize := int(req.PageSize)
+	if pageSize == 0 {
+		pageSize = 50
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
+
+	// TODO: Implement proper cursor-based pagination
+	if len(defs) > pageSize {
+		defs = defs[:pageSize]
+	}
+
+	sagas := make([]*sagav1.SagaDefinition, len(defs))
+	for i, def := range defs {
+		sagas[i] = h.definitionToProto(def)
+	}
+
+	return &sagav1.ListSagasResponse{
+		Sagas:         sagas,
+		NextPageToken: "", // TODO: Implement pagination
+	}, nil
+}
+
+// ValidateSagaDraft validates a saga script without activating it.
+func (h *RegistryHandler) ValidateSagaDraft(
+	ctx context.Context,
+	req *sagav1.ValidateSagaDraftRequest,
+) (*sagav1.ValidateSagaDraftResponse, error) {
+	id, err := uuid.Parse(req.Id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid saga id: %v", err)
+	}
+
+	// Get the saga
+	saga, err := h.registry.GetByID(ctx, id)
+	if err != nil {
+		return nil, h.mapDomainError(err, "ValidateSagaDraft", id.String())
+	}
+
+	// Validate
+	if h.validator == nil {
+		return &sagav1.ValidateSagaDraftResponse{
+			Validation: &sagav1.ValidationResult{
+				Status: "READY",
+			},
+			Report: "No validator configured",
+		}, nil
+	}
+
+	result, err := h.validator.ValidateDraft(ctx, id, saga.Script)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "validation error: %v", err)
+	}
+
+	return &sagav1.ValidateSagaDraftResponse{
+		Validation: h.validationResultToProto(result),
+		Report:     result.FormatReport(),
+	}, nil
+}
+
+// AnalyzeDeprecationImpact finds all sagas that reference a given instrument.
+func (h *RegistryHandler) AnalyzeDeprecationImpact(
+	ctx context.Context,
+	req *sagav1.AnalyzeDeprecationImpactRequest,
+) (*sagav1.AnalyzeDeprecationImpactResponse, error) {
+	if h.validator == nil {
+		return &sagav1.AnalyzeDeprecationImpactResponse{
+			Dependencies: nil,
+			TotalCount:   0,
+		}, nil
+	}
+
+	deps, err := h.validator.DeprecationImpactAnalysis(ctx, req.InstrumentCode)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to analyze deprecation impact: %v", err)
+	}
+
+	protoDeps := make([]*sagav1.SagaDependency, len(deps))
+	for i, dep := range deps {
+		protoDeps[i] = &sagav1.SagaDependency{
+			SagaId:      dep.SagaID.String(),
+			SagaName:    dep.SagaName,
+			SagaVersion: int32(dep.SagaVersion),
+			SagaStatus:  h.domainStatusToProto(dep.SagaStatus),
+			LineNumber:  int32(dep.LineNumber),
+		}
+	}
+
+	return &sagav1.AnalyzeDeprecationImpactResponse{
+		Dependencies: protoDeps,
+		TotalCount:   int32(len(deps)),
+	}, nil
+}
+
+// mapDomainError converts domain errors to appropriate gRPC status codes.
+func (h *RegistryHandler) mapDomainError(err error, operation, identifier string) error {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		h.logger.Warn("saga not found",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.NotFound, "saga not found: %s", identifier)
+
+	case errors.Is(err, ErrSystemSagaReadOnly):
+		h.logger.Warn("system saga modification attempted",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.PermissionDenied, "cannot modify system saga: %s", identifier)
+
+	case errors.Is(err, ErrNotDraft):
+		h.logger.Warn("saga not in draft status",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.FailedPrecondition, "saga must be in DRAFT status: %s", identifier)
+
+	case errors.Is(err, ErrNotActive):
+		h.logger.Warn("saga not in active status",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.FailedPrecondition, "saga must be in ACTIVE status: %s", identifier)
+
+	case errors.Is(err, ErrAlreadyExists):
+		h.logger.Warn("saga already exists",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.AlreadyExists, "saga already exists: %s", identifier)
+
+	case errors.Is(err, ErrOptimisticLock):
+		h.logger.Warn("optimistic lock failure",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.Aborted, "saga was modified by another transaction: %s", identifier)
+
+	case errors.Is(err, ErrInvalidStateTransition):
+		h.logger.Warn("invalid state transition",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.FailedPrecondition, "invalid state transition: %v", err)
+
+	case errors.Is(err, ErrSuccessorInvalid):
+		h.logger.Warn("invalid successor saga",
+			"operation", operation,
+			"identifier", identifier)
+		return status.Errorf(codes.FailedPrecondition, "successor saga is invalid: must exist, be ACTIVE, and have same name")
+
+	case errors.Is(err, ErrValidationFailed):
+		h.logger.Warn("saga validation failed",
+			"operation", operation,
+			"identifier", identifier,
+			"error", err)
+		return status.Errorf(codes.FailedPrecondition, "saga validation failed: %v", err)
+
+	default:
+		h.logger.Error("internal error",
+			"operation", operation,
+			"identifier", identifier,
+			"error", err)
+		return status.Errorf(codes.Internal, "internal error: %v", err)
+	}
+}
+
+// definitionToProto converts a domain Definition to proto SagaDefinition.
+func (h *RegistryHandler) definitionToProto(def *Definition) *sagav1.SagaDefinition {
+	if def == nil {
+		return nil
+	}
+
+	proto := &sagav1.SagaDefinition{
+		Id:                      def.ID.String(),
+		Name:                    def.Name,
+		Version:                 int32(def.Version),
+		Script:                  def.Script,
+		Status:                  h.domainStatusToProto(def.Status),
+		IsSystem:                def.IsSystem,
+		PreconditionsExpression: def.PreconditionsExpression,
+		DisplayName:             def.DisplayName,
+		Description:             def.Description,
+		CreatedAt:               timestamppb.New(def.CreatedAt),
+		UpdatedAt:               timestamppb.New(def.UpdatedAt),
+	}
+
+	if def.ActivatedAt != nil {
+		proto.ActivatedAt = timestamppb.New(*def.ActivatedAt)
+	}
+	if def.DeprecatedAt != nil {
+		proto.DeprecatedAt = timestamppb.New(*def.DeprecatedAt)
+	}
+	if def.SuccessorID != nil {
+		proto.SuccessorId = def.SuccessorID.String()
+	}
+
+	return proto
+}
+
+// domainStatusToProto converts domain Status to proto SagaStatus.
+func (h *RegistryHandler) domainStatusToProto(s Status) sagav1.SagaStatus {
+	switch s {
+	case StatusDraft:
+		return sagav1.SagaStatus_SAGA_STATUS_DRAFT
+	case StatusActive:
+		return sagav1.SagaStatus_SAGA_STATUS_ACTIVE
+	case StatusDeprecated:
+		return sagav1.SagaStatus_SAGA_STATUS_DEPRECATED
+	default:
+		return sagav1.SagaStatus_SAGA_STATUS_UNSPECIFIED
+	}
+}
+
+// protoStatusToDomain converts proto SagaStatus to domain Status.
+func (h *RegistryHandler) protoStatusToDomain(s sagav1.SagaStatus) Status {
+	switch s {
+	case sagav1.SagaStatus_SAGA_STATUS_DRAFT:
+		return StatusDraft
+	case sagav1.SagaStatus_SAGA_STATUS_ACTIVE:
+		return StatusActive
+	case sagav1.SagaStatus_SAGA_STATUS_DEPRECATED:
+		return StatusDeprecated
+	case sagav1.SagaStatus_SAGA_STATUS_UNSPECIFIED:
+		return ""
+	default:
+		return ""
+	}
+}
+
+// validationResultToProto converts a domain ValidationResult to proto.
+func (h *RegistryHandler) validationResultToProto(result *ValidationResult) *sagav1.ValidationResult {
+	if result == nil {
+		return nil
+	}
+
+	proto := &sagav1.ValidationResult{
+		Status:         result.Status,
+		Warnings:       make([]*sagav1.ValidationWarning, 0),
+		CriticalErrors: make([]*sagav1.ValidationWarning, 0),
+	}
+
+	for _, err := range result.Errors {
+		warning := &sagav1.ValidationWarning{
+			ReferenceType: string(err.Reference.Type),
+			ReferenceKey:  err.Reference.Key,
+			LineNumber:    int32(err.Reference.LineNumber),
+			Message:       err.Message,
+			Suggestion:    err.Suggestion,
+		}
+		if err.IsCritical {
+			proto.CriticalErrors = append(proto.CriticalErrors, warning)
+		} else {
+			proto.Warnings = append(proto.Warnings, warning)
+		}
+	}
+
+	return proto
+}

--- a/services/reference-data/saga/grpc_handler_test.go
+++ b/services/reference-data/saga/grpc_handler_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // setupTestPostgres starts a PostgreSQL container and returns the pool and cleanup function.
@@ -166,9 +167,9 @@ func TestRegistryHandler_UpdateSagaDefinition(t *testing.T) {
 	t.Run("updates draft successfully", func(t *testing.T) {
 		req := &sagav1.UpdateSagaDefinitionRequest{
 			Id:          sagaID,
-			Script:      `saga(name="updatable_saga", version="2.0")`,
-			DisplayName: "Updated Saga",
-			Description: "Updated description",
+			Script:      proto.String(`saga(name="updatable_saga", version="2.0")`),
+			DisplayName: proto.String("Updated Saga"),
+			Description: proto.String("Updated description"),
 		}
 
 		resp, err := handler.UpdateSagaDefinition(ctx, req)
@@ -182,7 +183,7 @@ func TestRegistryHandler_UpdateSagaDefinition(t *testing.T) {
 	t.Run("rejects invalid saga id", func(t *testing.T) {
 		req := &sagav1.UpdateSagaDefinitionRequest{
 			Id:     "not-a-uuid",
-			Script: `saga(name="test")`,
+			Script: proto.String(`saga(name="test")`),
 		}
 
 		_, err := handler.UpdateSagaDefinition(ctx, req)
@@ -196,7 +197,7 @@ func TestRegistryHandler_UpdateSagaDefinition(t *testing.T) {
 	t.Run("rejects non-existent saga", func(t *testing.T) {
 		req := &sagav1.UpdateSagaDefinitionRequest{
 			Id:     uuid.New().String(),
-			Script: `saga(name="test")`,
+			Script: proto.String(`saga(name="test")`),
 		}
 
 		_, err := handler.UpdateSagaDefinition(ctx, req)
@@ -507,8 +508,8 @@ func TestRegistryHandler_SagaLifecycle(t *testing.T) {
 		// Step 2: Update draft
 		updateResp, err := handler.UpdateSagaDefinition(ctx, &sagav1.UpdateSagaDefinitionRequest{
 			Id:          sagaID,
-			Script:      `saga(name="lifecycle_saga", version="1.1")`,
-			Description: "Updated description",
+			Script:      proto.String(`saga(name="lifecycle_saga", version="1.1")`),
+			Description: proto.String("Updated description"),
 		})
 		require.NoError(t, err)
 		assert.Contains(t, updateResp.Saga.Script, "version=\"1.1\"")
@@ -524,7 +525,7 @@ func TestRegistryHandler_SagaLifecycle(t *testing.T) {
 		// Step 4: Try to update (should fail - not in draft)
 		_, err = handler.UpdateSagaDefinition(ctx, &sagav1.UpdateSagaDefinitionRequest{
 			Id:     sagaID,
-			Script: `saga(name="lifecycle_saga", version="1.2")`,
+			Script: proto.String(`saga(name="lifecycle_saga", version="1.2")`),
 		})
 		require.Error(t, err)
 		st, _ := status.FromError(err)
@@ -596,7 +597,7 @@ func TestRegistryHandler_TenantOverride(t *testing.T) {
 		// Try to update it
 		_, err = handler.UpdateSagaDefinition(ctx, &sagav1.UpdateSagaDefinitionRequest{
 			Id:     systemID,
-			Script: `saga(name="modified_system")`,
+			Script: proto.String(`saga(name="modified_system")`),
 		})
 		require.Error(t, err)
 

--- a/services/reference-data/saga/grpc_handler_test.go
+++ b/services/reference-data/saga/grpc_handler_test.go
@@ -445,7 +445,7 @@ func TestRegistryHandler_ListSagas(t *testing.T) {
 
 	t.Run("lists all sagas", func(t *testing.T) {
 		req := &sagav1.ListSagasRequest{
-			IncludeSystem: true,
+			ExcludeSystem: false,
 		}
 
 		resp, err := handler.ListSagas(ctx, req)
@@ -456,7 +456,7 @@ func TestRegistryHandler_ListSagas(t *testing.T) {
 	t.Run("filters by status", func(t *testing.T) {
 		req := &sagav1.ListSagasRequest{
 			StatusFilter:  sagav1.SagaStatus_SAGA_STATUS_DRAFT,
-			IncludeSystem: true,
+			ExcludeSystem: false,
 		}
 
 		resp, err := handler.ListSagas(ctx, req)
@@ -470,7 +470,7 @@ func TestRegistryHandler_ListSagas(t *testing.T) {
 	t.Run("respects page size", func(t *testing.T) {
 		req := &sagav1.ListSagasRequest{
 			PageSize:      2,
-			IncludeSystem: true,
+			ExcludeSystem: false,
 		}
 
 		resp, err := handler.ListSagas(ctx, req)

--- a/services/reference-data/saga/grpc_handler_test.go
+++ b/services/reference-data/saga/grpc_handler_test.go
@@ -1,0 +1,607 @@
+package saga
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// setupTestPostgres starts a PostgreSQL container and returns the pool and cleanup function.
+func setupTestPostgres(t *testing.T) (*pgxpool.Pool, tenant.TenantID, func()) {
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(ctx,
+		"postgres:16-alpine",
+		postgres.WithDatabase("testdb"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second),
+		),
+	)
+	require.NoError(t, err)
+
+	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+
+	// Create tenant schema and saga_definition table
+	tenantID, err := tenant.NewTenantID("test_grpc_handler")
+	require.NoError(t, err)
+
+	schemaName := tenantID.SchemaName()
+	_, err = pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+schemaName)
+	require.NoError(t, err)
+
+	createTableSQL := `
+		CREATE TABLE ` + schemaName + `.saga_definition (
+			id uuid NOT NULL DEFAULT gen_random_uuid(),
+			name varchar(64) NOT NULL,
+			version integer NOT NULL DEFAULT 1,
+			script text NOT NULL,
+			status varchar(16) NOT NULL DEFAULT 'DRAFT',
+			is_system boolean NOT NULL DEFAULT FALSE,
+			preconditions_expression text NULL,
+			display_name varchar(128) NULL,
+			description text NULL,
+			created_at timestamptz NOT NULL DEFAULT now(),
+			updated_at timestamptz NOT NULL DEFAULT now(),
+			activated_at timestamptz NULL,
+			deprecated_at timestamptz NULL,
+			successor_id uuid NULL,
+			PRIMARY KEY (id),
+			CONSTRAINT uq_saga_definition_name_version UNIQUE (name, version)
+		)`
+	_, err = pool.Exec(ctx, createTableSQL)
+	require.NoError(t, err)
+
+	cleanup := func() {
+		pool.Close()
+		_ = pgContainer.Terminate(ctx)
+	}
+
+	return pool, tenantID, cleanup
+}
+
+func TestRegistryHandler_CreateSagaDraft(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	t.Run("creates draft saga successfully", func(t *testing.T) {
+		req := &sagav1.CreateSagaDraftRequest{
+			Name:        "test_saga",
+			Script:      `saga(name="test_saga")`,
+			DisplayName: "Test Saga",
+			Description: "A test saga for unit testing",
+		}
+
+		resp, err := handler.CreateSagaDraft(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Saga)
+
+		assert.Equal(t, "test_saga", resp.Saga.Name)
+		assert.Equal(t, int32(1), resp.Saga.Version)
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_DRAFT, resp.Saga.Status)
+		assert.Equal(t, `saga(name="test_saga")`, resp.Saga.Script)
+		assert.False(t, resp.Saga.IsSystem)
+		assert.NotEmpty(t, resp.Saga.Id)
+		assert.NotNil(t, resp.Saga.CreatedAt)
+	})
+
+	t.Run("creates draft with specific version", func(t *testing.T) {
+		req := &sagav1.CreateSagaDraftRequest{
+			Name:    "versioned_saga",
+			Version: 2,
+			Script:  `saga(name="versioned_saga")`,
+		}
+
+		resp, err := handler.CreateSagaDraft(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), resp.Saga.Version)
+	})
+
+	t.Run("rejects duplicate name+version", func(t *testing.T) {
+		req := &sagav1.CreateSagaDraftRequest{
+			Name:   "test_saga",
+			Script: `saga(name="test_saga")`,
+		}
+
+		_, err := handler.CreateSagaDraft(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.AlreadyExists, st.Code())
+	})
+}
+
+func TestRegistryHandler_UpdateSagaDefinition(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	// Create a draft first
+	createReq := &sagav1.CreateSagaDraftRequest{
+		Name:   "updatable_saga",
+		Script: `saga(name="updatable_saga")`,
+	}
+	createResp, err := handler.CreateSagaDraft(ctx, createReq)
+	require.NoError(t, err)
+
+	sagaID := createResp.Saga.Id
+
+	t.Run("updates draft successfully", func(t *testing.T) {
+		req := &sagav1.UpdateSagaDefinitionRequest{
+			Id:          sagaID,
+			Script:      `saga(name="updatable_saga", version="2.0")`,
+			DisplayName: "Updated Saga",
+			Description: "Updated description",
+		}
+
+		resp, err := handler.UpdateSagaDefinition(ctx, req)
+		require.NoError(t, err)
+
+		assert.Equal(t, `saga(name="updatable_saga", version="2.0")`, resp.Saga.Script)
+		assert.Equal(t, "Updated Saga", resp.Saga.DisplayName)
+		assert.Equal(t, "Updated description", resp.Saga.Description)
+	})
+
+	t.Run("rejects invalid saga id", func(t *testing.T) {
+		req := &sagav1.UpdateSagaDefinitionRequest{
+			Id:     "not-a-uuid",
+			Script: `saga(name="test")`,
+		}
+
+		_, err := handler.UpdateSagaDefinition(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("rejects non-existent saga", func(t *testing.T) {
+		req := &sagav1.UpdateSagaDefinitionRequest{
+			Id:     uuid.New().String(),
+			Script: `saga(name="test")`,
+		}
+
+		_, err := handler.UpdateSagaDefinition(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+}
+
+func TestRegistryHandler_ActivateSaga(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	// Create a draft first
+	createReq := &sagav1.CreateSagaDraftRequest{
+		Name:   "activatable_saga",
+		Script: `saga(name="activatable_saga")`,
+	}
+	createResp, err := handler.CreateSagaDraft(ctx, createReq)
+	require.NoError(t, err)
+
+	sagaID := createResp.Saga.Id
+
+	t.Run("activates saga successfully", func(t *testing.T) {
+		req := &sagav1.ActivateSagaRequest{
+			Id: sagaID,
+		}
+
+		resp, err := handler.ActivateSaga(ctx, req)
+		require.NoError(t, err)
+
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_ACTIVE, resp.Saga.Status)
+		assert.NotNil(t, resp.Saga.ActivatedAt)
+	})
+
+	t.Run("rejects activation of already active saga", func(t *testing.T) {
+		req := &sagav1.ActivateSagaRequest{
+			Id: sagaID,
+		}
+
+		_, err := handler.ActivateSaga(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+}
+
+func TestRegistryHandler_DeprecateSaga(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	// Create and activate a saga
+	createReq := &sagav1.CreateSagaDraftRequest{
+		Name:   "deprecatable_saga",
+		Script: `saga(name="deprecatable_saga")`,
+	}
+	createResp, err := handler.CreateSagaDraft(ctx, createReq)
+	require.NoError(t, err)
+
+	_, err = handler.ActivateSaga(ctx, &sagav1.ActivateSagaRequest{Id: createResp.Saga.Id})
+	require.NoError(t, err)
+
+	t.Run("deprecates saga successfully", func(t *testing.T) {
+		req := &sagav1.DeprecateSagaRequest{
+			Id: createResp.Saga.Id,
+		}
+
+		resp, err := handler.DeprecateSaga(ctx, req)
+		require.NoError(t, err)
+
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_DEPRECATED, resp.Saga.Status)
+		assert.NotNil(t, resp.Saga.DeprecatedAt)
+	})
+
+	t.Run("rejects deprecation of non-active saga", func(t *testing.T) {
+		// Create a draft saga
+		draftReq := &sagav1.CreateSagaDraftRequest{
+			Name:   "draft_saga",
+			Script: `saga(name="draft_saga")`,
+		}
+		draftResp, err := handler.CreateSagaDraft(ctx, draftReq)
+		require.NoError(t, err)
+
+		req := &sagav1.DeprecateSagaRequest{
+			Id: draftResp.Saga.Id,
+		}
+
+		_, err = handler.DeprecateSaga(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+}
+
+func TestRegistryHandler_GetSaga(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	// Create a saga
+	createReq := &sagav1.CreateSagaDraftRequest{
+		Name:        "get_saga_test",
+		Script:      `saga(name="get_saga_test")`,
+		DisplayName: "Get Saga Test",
+	}
+	createResp, err := handler.CreateSagaDraft(ctx, createReq)
+	require.NoError(t, err)
+
+	t.Run("gets saga by id", func(t *testing.T) {
+		req := &sagav1.GetSagaRequest{
+			Id: createResp.Saga.Id,
+		}
+
+		resp, err := handler.GetSaga(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, "get_saga_test", resp.Saga.Name)
+	})
+
+	t.Run("gets saga by name and version", func(t *testing.T) {
+		req := &sagav1.GetSagaRequest{
+			Name:    "get_saga_test",
+			Version: 1,
+		}
+
+		resp, err := handler.GetSaga(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, "get_saga_test", resp.Saga.Name)
+	})
+
+	t.Run("requires either id or name", func(t *testing.T) {
+		req := &sagav1.GetSagaRequest{}
+
+		_, err := handler.GetSaga(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+}
+
+func TestRegistryHandler_GetActiveSaga(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	// Create and activate a saga
+	createReq := &sagav1.CreateSagaDraftRequest{
+		Name:   "active_saga",
+		Script: `saga(name="active_saga")`,
+	}
+	createResp, err := handler.CreateSagaDraft(ctx, createReq)
+	require.NoError(t, err)
+
+	_, err = handler.ActivateSaga(ctx, &sagav1.ActivateSagaRequest{Id: createResp.Saga.Id})
+	require.NoError(t, err)
+
+	t.Run("gets active saga by name", func(t *testing.T) {
+		req := &sagav1.GetActiveSagaRequest{
+			Name: "active_saga",
+		}
+
+		resp, err := handler.GetActiveSaga(ctx, req)
+		require.NoError(t, err)
+		assert.Equal(t, "active_saga", resp.Saga.Name)
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_ACTIVE, resp.Saga.Status)
+		assert.True(t, resp.IsTenantOverride) // Not a system saga
+	})
+
+	t.Run("returns not found for non-existent saga", func(t *testing.T) {
+		req := &sagav1.GetActiveSagaRequest{
+			Name: "non_existent",
+		}
+
+		_, err := handler.GetActiveSaga(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+}
+
+func TestRegistryHandler_ListSagas(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	// Create multiple sagas
+	for i := 0; i < 3; i++ {
+		createReq := &sagav1.CreateSagaDraftRequest{
+			Name:   "list_saga_" + string(rune('a'+i)),
+			Script: `saga(name="list_saga")`,
+		}
+		_, err := handler.CreateSagaDraft(ctx, createReq)
+		require.NoError(t, err)
+	}
+
+	t.Run("lists all sagas", func(t *testing.T) {
+		req := &sagav1.ListSagasRequest{
+			IncludeSystem: true,
+		}
+
+		resp, err := handler.ListSagas(ctx, req)
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(resp.Sagas), 3)
+	})
+
+	t.Run("filters by status", func(t *testing.T) {
+		req := &sagav1.ListSagasRequest{
+			StatusFilter:  sagav1.SagaStatus_SAGA_STATUS_DRAFT,
+			IncludeSystem: true,
+		}
+
+		resp, err := handler.ListSagas(ctx, req)
+		require.NoError(t, err)
+
+		for _, saga := range resp.Sagas {
+			assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_DRAFT, saga.Status)
+		}
+	})
+
+	t.Run("respects page size", func(t *testing.T) {
+		req := &sagav1.ListSagasRequest{
+			PageSize:      2,
+			IncludeSystem: true,
+		}
+
+		resp, err := handler.ListSagas(ctx, req)
+		require.NoError(t, err)
+		assert.LessOrEqual(t, len(resp.Sagas), 2)
+	})
+}
+
+func TestRegistryHandler_SagaLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	t.Run("full lifecycle: create -> update -> activate -> deprecate", func(t *testing.T) {
+		// Step 1: Create draft
+		createResp, err := handler.CreateSagaDraft(ctx, &sagav1.CreateSagaDraftRequest{
+			Name:        "lifecycle_saga",
+			Script:      `saga(name="lifecycle_saga")`,
+			DisplayName: "Lifecycle Test Saga",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_DRAFT, createResp.Saga.Status)
+
+		sagaID := createResp.Saga.Id
+
+		// Step 2: Update draft
+		updateResp, err := handler.UpdateSagaDefinition(ctx, &sagav1.UpdateSagaDefinitionRequest{
+			Id:          sagaID,
+			Script:      `saga(name="lifecycle_saga", version="1.1")`,
+			Description: "Updated description",
+		})
+		require.NoError(t, err)
+		assert.Contains(t, updateResp.Saga.Script, "version=\"1.1\"")
+
+		// Step 3: Activate
+		activateResp, err := handler.ActivateSaga(ctx, &sagav1.ActivateSagaRequest{
+			Id: sagaID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_ACTIVE, activateResp.Saga.Status)
+		assert.NotNil(t, activateResp.Saga.ActivatedAt)
+
+		// Step 4: Try to update (should fail - not in draft)
+		_, err = handler.UpdateSagaDefinition(ctx, &sagav1.UpdateSagaDefinitionRequest{
+			Id:     sagaID,
+			Script: `saga(name="lifecycle_saga", version="1.2")`,
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+
+		// Step 5: Deprecate
+		deprecateResp, err := handler.DeprecateSaga(ctx, &sagav1.DeprecateSagaRequest{
+			Id: sagaID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_DEPRECATED, deprecateResp.Saga.Status)
+		assert.NotNil(t, deprecateResp.Saga.DeprecatedAt)
+	})
+}
+
+func TestRegistryHandler_TenantOverride(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+	schemaName := tenantID.SchemaName()
+
+	// Seed a system saga
+	_, err := pool.Exec(ctx, `
+		INSERT INTO `+schemaName+`.saga_definition
+			(name, version, script, status, is_system, display_name, activated_at)
+		VALUES
+			('system_saga', 1, 'saga(name="system_saga")', 'ACTIVE', true, 'System Saga', now())`)
+	require.NoError(t, err)
+
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, nil)
+
+	t.Run("tenant override takes precedence over system saga", func(t *testing.T) {
+		// Create and activate a tenant override
+		createResp, err := handler.CreateSagaDraft(ctx, &sagav1.CreateSagaDraftRequest{
+			Name:   "system_saga",
+			Script: `saga(name="system_saga", tenant_override=True)`,
+		})
+		require.NoError(t, err)
+
+		_, err = handler.ActivateSaga(ctx, &sagav1.ActivateSagaRequest{
+			Id: createResp.Saga.Id,
+		})
+		require.NoError(t, err)
+
+		// GetActiveSaga should return the tenant override
+		activeResp, err := handler.GetActiveSaga(ctx, &sagav1.GetActiveSagaRequest{
+			Name: "system_saga",
+		})
+		require.NoError(t, err)
+
+		assert.True(t, activeResp.IsTenantOverride)
+		assert.Contains(t, activeResp.Saga.Script, "tenant_override")
+	})
+
+	t.Run("cannot modify system saga", func(t *testing.T) {
+		// Try to get the system saga's ID
+		var systemID string
+		err := pool.QueryRow(ctx, `
+			SELECT id FROM `+schemaName+`.saga_definition
+			WHERE name = 'system_saga' AND is_system = true`).Scan(&systemID)
+		require.NoError(t, err)
+
+		// Try to update it
+		_, err = handler.UpdateSagaDefinition(ctx, &sagav1.UpdateSagaDefinitionRequest{
+			Id:     systemID,
+			Script: `saga(name="modified_system")`,
+		})
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+	})
+}


### PR DESCRIPTION
## Summary

- Add `SagaRegistryService` gRPC API with complete saga lifecycle management
- Implement `RegistryHandler` wrapping `PostgresRegistry` with tenant isolation
- Add comprehensive integration tests for saga lifecycle flows

## Changes Made

### New Proto Definition (`api/proto/meridian/saga/v1/saga_registry.proto`)

| RPC | Description |
|-----|-------------|
| `CreateSagaDraft` | Create new saga in DRAFT status |
| `UpdateSagaDefinition` | Modify DRAFT saga script and metadata |
| `ActivateSaga` | Transition DRAFT → ACTIVE with validation |
| `DeprecateSaga` | Transition ACTIVE → DEPRECATED with optional successor |
| `GetSaga` | Retrieve saga by ID or name+version |
| `GetActiveSaga` | Resolve active saga with tenant override priority |
| `ListSagas` | List sagas with status filtering and pagination |
| `ValidateSagaDraft` | Validate without activating (returns warnings) |
| `AnalyzeDeprecationImpact` | Find dependent sagas before deprecating an instrument |

### gRPC Handler (`services/reference-data/saga/grpc_handler.go`)

- Wraps existing `PostgresRegistry` with gRPC interface
- Tenant context extraction via `tenant.FromContext(ctx)`
- Error mapping to gRPC status codes (NotFound, FailedPrecondition, etc.)
- Integration with `ReferenceValidator` for saga validation

### Tests (`services/reference-data/saga/grpc_handler_test.go`)

- Full lifecycle tests: create → update → activate → deprecate
- Tenant override precedence over system sagas
- Error handling for invalid operations

## Task Master Reference

| Task | Description |
|------|-------------|
| starlark-saga-orchestration.10 | Create gRPC API and seed platform default sagas |
| starlark-saga-orchestration.10.1 | Define protobuf service and implement gRPC handler |

## Test Plan

- [x] Code compiles without errors
- [x] Linting passes (golangci-lint)
- [x] Pre-commit hooks pass (buf lint, proto breaking check)
- [ ] Integration tests pass (require Docker for testcontainers)
- [ ] CI passes