### PR TITLE
feat(saga): add YAML handler schema format and registry

### DIFF
--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -1,0 +1,270 @@
+# Platform Default Handler Schemas
+# These schemas define the type signatures for all platform-provided saga handlers.
+# Handlers are invoked from Starlark scripts via invoke_handler("handler.name", params).
+
+service: platform
+version: "1.0"
+
+handlers:
+  # Position Keeping Service
+  position_keeping.initiate_log:
+    description: "Initiate a position log entry for a DEBIT or CREDIT transaction"
+    params:
+      position_id:
+        type: string
+        required: true
+        description: "Unique identifier for the position"
+      amount:
+        type: Decimal
+        required: true
+        description: "Transaction amount (must be positive)"
+      direction:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+        description: "Direction of the transaction"
+    returns:
+      log_id:
+        type: string
+        description: "Generated log entry identifier (UUID)"
+      position_id:
+        type: string
+        description: "Echo of the input position ID"
+      amount:
+        type: Decimal
+        description: "Echo of the input amount"
+      direction:
+        type: string
+        description: "Echo of the input direction"
+      status:
+        type: string
+        description: "Status of the log entry (INITIATED)"
+    compensate: position_keeping.cancel_log
+
+  position_keeping.update_log:
+    description: "Update an existing position log entry"
+    params:
+      log_id:
+        type: string
+        required: true
+        description: "Identifier of the log entry to update"
+    returns:
+      log_id:
+        type: string
+        description: "Echo of the input log ID"
+      status:
+        type: string
+        description: "Status of the log entry (UPDATED)"
+
+  position_keeping.cancel_log:
+    description: "Cancel a position log entry (compensation handler)"
+    params:
+      log_id:
+        type: string
+        required: true
+        description: "Identifier of the log entry to cancel"
+    returns:
+      log_id:
+        type: string
+        description: "Echo of the input log ID"
+      status:
+        type: string
+        description: "Status of the log entry (CANCELLED)"
+
+  # Financial Accounting Service
+  financial_accounting.post_entries:
+    description: "Post double-entry accounting entries to the ledger"
+    params:
+      entries:
+        type: array
+        required: true
+        description: "Array of accounting entries to post"
+    returns:
+      posting_ids:
+        type: array
+        description: "Array of generated posting IDs (UUIDs)"
+      status:
+        type: string
+        description: "Status of the posting (POSTED)"
+    compensate: financial_accounting.reverse_entries
+
+  financial_accounting.reverse_entries:
+    description: "Reverse previously posted accounting entries (compensation handler)"
+    params:
+      posting_ids:
+        type: array
+        required: true
+        description: "Array of posting IDs to reverse"
+    returns:
+      original_posting_ids:
+        type: array
+        description: "Echo of the input posting IDs"
+      status:
+        type: string
+        description: "Status of the reversal (REVERSED)"
+
+  financial_accounting.create_booking:
+    description: "Create a booking log entry for audit purposes"
+    params:
+      description:
+        type: string
+        required: true
+        description: "Human-readable description of the booking"
+    returns:
+      booking_id:
+        type: string
+        description: "Generated booking identifier (UUID)"
+      description:
+        type: string
+        description: "Echo of the input description"
+      status:
+        type: string
+        description: "Status of the booking (CREATED)"
+
+  # Current Account Service
+  current_account.create_lien:
+    description: "Create a lien (hold) on an account for a specified amount"
+    params:
+      account_id:
+        type: string
+        required: true
+        description: "Identifier of the account to place lien on"
+      amount:
+        type: Decimal
+        required: true
+        description: "Amount to hold (must be positive)"
+    returns:
+      lien_id:
+        type: string
+        description: "Generated lien identifier (UUID)"
+      account_id:
+        type: string
+        description: "Echo of the input account ID"
+      amount:
+        type: Decimal
+        description: "Echo of the input amount"
+      status:
+        type: string
+        description: "Status of the lien (ACTIVE)"
+    compensate: current_account.terminate_lien
+
+  current_account.execute_lien:
+    description: "Execute (consume) a previously created lien"
+    params:
+      lien_id:
+        type: string
+        required: true
+        description: "Identifier of the lien to execute"
+    returns:
+      lien_id:
+        type: string
+        description: "Echo of the input lien ID"
+      status:
+        type: string
+        description: "Status of the lien (EXECUTED)"
+
+  current_account.terminate_lien:
+    description: "Terminate (release) a lien without execution (compensation handler)"
+    params:
+      lien_id:
+        type: string
+        required: true
+        description: "Identifier of the lien to terminate"
+    returns:
+      lien_id:
+        type: string
+        description: "Echo of the input lien ID"
+      status:
+        type: string
+        description: "Status of the lien (TERMINATED)"
+
+  # Valuation Engine Service
+  valuation_engine.valuate:
+    description: "Valuate an instrument at a specific point in time"
+    params:
+      instrument:
+        type: string
+        required: true
+        description: "Instrument identifier or code"
+      quantity:
+        type: Decimal
+        required: true
+        description: "Quantity to valuate"
+      context_type:
+        type: string
+        required: true
+        description: "Valuation context (e.g., MARK_TO_MARKET, FAIR_VALUE)"
+    returns:
+      instrument:
+        type: string
+        description: "Echo of the input instrument"
+      quantity:
+        type: Decimal
+        description: "Echo of the input quantity"
+      unit_price:
+        type: Decimal
+        description: "Price per unit of the instrument"
+      value:
+        type: Decimal
+        description: "Total value (quantity * unit_price)"
+      context_type:
+        type: string
+        description: "Echo of the input context type"
+      currency:
+        type: string
+        description: "Currency of the valuation"
+      valued_at:
+        type: string
+        description: "Timestamp when valuation was computed"
+
+  # Repository Service
+  repository.save:
+    description: "Persist an entity to the repository"
+    params:
+      entity_type:
+        type: string
+        required: true
+        description: "Type of entity being saved (e.g., Account, Transaction)"
+      entity:
+        type: map
+        required: true
+        description: "Entity data to persist"
+    returns:
+      entity_id:
+        type: string
+        description: "Generated or existing entity identifier (UUID)"
+      entity_type:
+        type: string
+        description: "Echo of the input entity type"
+      entity:
+        type: map
+        description: "Echo of the saved entity"
+      status:
+        type: string
+        description: "Status of the save operation (SAVED)"
+
+  # Notification Service
+  notification.send:
+    description: "Send a notification to a recipient"
+    params:
+      type:
+        type: string
+        required: true
+        description: "Notification type (e.g., EMAIL, SMS, PUSH)"
+      recipient:
+        type: string
+        required: true
+        description: "Recipient identifier (email, phone, user ID)"
+    returns:
+      notification_id:
+        type: string
+        description: "Generated notification identifier (UUID)"
+      type:
+        type: string
+        description: "Echo of the input notification type"
+      recipient:
+        type: string
+        description: "Echo of the input recipient"
+      status:
+        type: string
+        description: "Status of the notification (SENT)"

--- a/shared/pkg/saga/schema/handlers_test.go
+++ b/shared/pkg/saga/schema/handlers_test.go
@@ -1,0 +1,103 @@
+package schema
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed handlers.yaml
+var platformHandlersYAML []byte
+
+func TestPlatformHandlersSchema(t *testing.T) {
+	schema, err := Parse(platformHandlersYAML)
+	require.NoError(t, err, "platform handlers.yaml should parse without errors")
+
+	assert.Equal(t, "platform", schema.Service)
+	assert.Equal(t, "1.0", schema.Version)
+
+	// Expected handlers from handlers.go
+	expectedHandlers := []string{
+		"position_keeping.initiate_log",
+		"position_keeping.update_log",
+		"position_keeping.cancel_log",
+		"financial_accounting.post_entries",
+		"financial_accounting.reverse_entries",
+		"financial_accounting.create_booking",
+		"current_account.create_lien",
+		"current_account.execute_lien",
+		"current_account.terminate_lien",
+		"valuation_engine.valuate",
+		"repository.save",
+		"notification.send",
+	}
+
+	assert.Len(t, schema.Handlers, len(expectedHandlers),
+		"schema should define all %d platform handlers", len(expectedHandlers))
+
+	for _, name := range expectedHandlers {
+		handler, exists := schema.Handlers[name]
+		assert.True(t, exists, "handler %q should be defined in schema", name)
+		if exists {
+			assert.NotEmpty(t, handler.Description, "handler %q should have a description", name)
+		}
+	}
+}
+
+func TestCompensationHandlersExist(t *testing.T) {
+	schema, err := Parse(platformHandlersYAML)
+	require.NoError(t, err)
+
+	// Check that all compensate references point to existing handlers
+	for name, handler := range schema.Handlers {
+		if handler.Compensate != "" {
+			_, exists := schema.Handlers[handler.Compensate]
+			assert.True(t, exists,
+				"handler %q references compensate handler %q which does not exist",
+				name, handler.Compensate)
+		}
+	}
+}
+
+func TestHandlerParamTypes(t *testing.T) {
+	schema, err := Parse(platformHandlersYAML)
+	require.NoError(t, err)
+
+	// Validate specific handler param types
+	initLog := schema.Handlers["position_keeping.initiate_log"]
+	require.NotNil(t, initLog)
+
+	assert.Equal(t, TypeString, initLog.Params["position_id"].Type)
+	assert.Equal(t, TypeDecimal, initLog.Params["amount"].Type)
+	assert.Equal(t, TypeEnum, initLog.Params["direction"].Type)
+	assert.Equal(t, []string{"DEBIT", "CREDIT"}, initLog.Params["direction"].Values)
+
+	// Validate lien handler
+	createLien := schema.Handlers["current_account.create_lien"]
+	require.NotNil(t, createLien)
+	assert.Equal(t, TypeString, createLien.Params["account_id"].Type)
+	assert.Equal(t, TypeDecimal, createLien.Params["amount"].Type)
+
+	// Validate array param
+	postEntries := schema.Handlers["financial_accounting.post_entries"]
+	require.NotNil(t, postEntries)
+	assert.Equal(t, TypeArray, postEntries.Params["entries"].Type)
+}
+
+func TestRegistryLoadPlatformHandlers(t *testing.T) {
+	registry := NewRegistry()
+	err := registry.LoadFromYAML(platformHandlersYAML)
+	require.NoError(t, err)
+
+	handlers := registry.ListHandlers()
+	assert.Len(t, handlers, 12, "registry should contain all 12 platform handlers")
+
+	// Verify we can get each handler
+	for _, name := range handlers {
+		handler, err := registry.GetHandler(name)
+		require.NoError(t, err, "should be able to get handler %q", name)
+		assert.NotNil(t, handler)
+	}
+}

--- a/shared/pkg/saga/schema/handlers_test.go
+++ b/shared/pkg/saga/schema/handlers_test.go
@@ -18,7 +18,7 @@ func TestPlatformHandlersSchema(t *testing.T) {
 	assert.Equal(t, "platform", schema.Service)
 	assert.Equal(t, "1.0", schema.Version)
 
-	// Expected handlers from handlers.go
+	// Expected handlers from handlers.yaml
 	expectedHandlers := []string{
 		"position_keeping.initiate_log",
 		"position_keeping.update_log",

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -1,0 +1,293 @@
+// Package schema provides YAML-based handler schema definitions for saga orchestration.
+// It enables compile-time validation and IDE support for handler references in Starlark scripts.
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// FieldType represents the type of a handler parameter or return value.
+type FieldType string
+
+// Supported field types aligned with protobuf types where applicable.
+const (
+	TypeString  FieldType = "string"
+	TypeInt32   FieldType = "int32"
+	TypeInt64   FieldType = "int64"
+	TypeUint32  FieldType = "uint32"
+	TypeBool    FieldType = "bool"
+	TypeDecimal FieldType = "Decimal" // maps to shopspring/decimal
+	TypeEnum    FieldType = "enum"
+	TypeArray   FieldType = "array"
+	TypeMap     FieldType = "map"
+	TypeUUID    FieldType = "uuid"
+)
+
+// validFieldTypes is the set of allowed field types.
+var validFieldTypes = map[FieldType]bool{
+	TypeString:  true,
+	TypeInt32:   true,
+	TypeInt64:   true,
+	TypeUint32:  true,
+	TypeBool:    true,
+	TypeDecimal: true,
+	TypeEnum:    true,
+	TypeArray:   true,
+	TypeMap:     true,
+	TypeUUID:    true,
+}
+
+// ParseFieldType converts a string to a FieldType, validating it exists.
+func ParseFieldType(s string) (FieldType, error) {
+	ft := FieldType(s)
+	if !validFieldTypes[ft] {
+		return "", fmt.Errorf("%w: %q", ErrUnknownType, s)
+	}
+	return ft, nil
+}
+
+// Schema errors.
+var (
+	ErrServiceRequired      = errors.New("service is required")
+	ErrUnknownType          = errors.New("unknown type")
+	ErrEnumRequiresValues   = errors.New("enum type requires values")
+	ErrHandlerNotFound      = errors.New("handler not found")
+	ErrMissingRequiredParam = errors.New("missing required parameter")
+	ErrInvalidEnumValue     = errors.New("invalid enum value")
+)
+
+// Schema represents a collection of handler definitions for a service.
+type Schema struct {
+	// Service is the service name (e.g., "current_account").
+	Service string `yaml:"service"`
+
+	// Version is the schema version (e.g., "1.0").
+	Version string `yaml:"version"`
+
+	// Handlers maps handler names to their definitions.
+	Handlers map[string]*HandlerDef `yaml:"handlers"`
+}
+
+// HandlerDef defines the schema for a single handler.
+type HandlerDef struct {
+	// Description provides human-readable documentation.
+	Description string `yaml:"description"`
+
+	// Params defines the input parameters.
+	Params map[string]*FieldDef `yaml:"params"`
+
+	// Returns defines the return value fields.
+	Returns map[string]*FieldDef `yaml:"returns"`
+
+	// Compensate is the handler name used for compensation/rollback.
+	Compensate string `yaml:"compensate,omitempty"`
+}
+
+// FieldDef defines a single field (parameter or return value).
+type FieldDef struct {
+	// Type is the field type.
+	Type FieldType `yaml:"type"`
+
+	// Required indicates if the field must be provided.
+	Required bool `yaml:"required"`
+
+	// Description provides human-readable documentation.
+	Description string `yaml:"description,omitempty"`
+
+	// Values lists allowed values for enum types.
+	Values []string `yaml:"values,omitempty"`
+
+	// ItemType specifies the element type for array types.
+	ItemType FieldType `yaml:"item_type,omitempty"`
+
+	// KeyType specifies the key type for map types.
+	KeyType FieldType `yaml:"key_type,omitempty"`
+
+	// ValueType specifies the value type for map types.
+	ValueType FieldType `yaml:"value_type,omitempty"`
+}
+
+// Parse parses YAML bytes into a Schema, validating the structure.
+func Parse(data []byte) (*Schema, error) {
+	var schema Schema
+	if err := yaml.Unmarshal(data, &schema); err != nil {
+		return nil, fmt.Errorf("failed to parse YAML: %w", err)
+	}
+
+	if err := schema.Validate(); err != nil {
+		return nil, err
+	}
+
+	return &schema, nil
+}
+
+// Validate checks that the schema is well-formed.
+func (s *Schema) Validate() error {
+	if s.Service == "" {
+		return ErrServiceRequired
+	}
+
+	for handlerName, handler := range s.Handlers {
+		if err := handler.Validate(handlerName); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Validate checks that the handler definition is well-formed.
+func (h *HandlerDef) Validate(handlerName string) error {
+	for fieldName, field := range h.Params {
+		if err := field.Validate(fmt.Sprintf("%s.params.%s", handlerName, fieldName)); err != nil {
+			return err
+		}
+	}
+
+	for fieldName, field := range h.Returns {
+		if err := field.Validate(fmt.Sprintf("%s.returns.%s", handlerName, fieldName)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Validate checks that the field definition is well-formed.
+func (f *FieldDef) Validate(context string) error {
+	if !validFieldTypes[f.Type] {
+		return fmt.Errorf("%w: %s has type %q", ErrUnknownType, context, f.Type)
+	}
+
+	if f.Type == TypeEnum && len(f.Values) == 0 {
+		return fmt.Errorf("%w: %s", ErrEnumRequiresValues, context)
+	}
+
+	return nil
+}
+
+// ValidateParams validates that the provided params match the handler schema.
+func (h *HandlerDef) ValidateParams(params map[string]any) error {
+	if err := h.validateRequiredParams(params); err != nil {
+		return err
+	}
+	return h.validateEnumParams(params)
+}
+
+// validateRequiredParams checks all required fields are present.
+func (h *HandlerDef) validateRequiredParams(params map[string]any) error {
+	for name, field := range h.Params {
+		if field.Required {
+			if _, ok := params[name]; !ok {
+				return fmt.Errorf("%w: %s", ErrMissingRequiredParam, name)
+			}
+		}
+	}
+	return nil
+}
+
+// validateEnumParams validates enum field values against allowed values.
+func (h *HandlerDef) validateEnumParams(params map[string]any) error {
+	for name, field := range h.Params {
+		if err := field.validateEnumValue(name, params); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateEnumValue validates a single enum field if applicable.
+func (f *FieldDef) validateEnumValue(name string, params map[string]any) error {
+	if f.Type != TypeEnum || len(f.Values) == 0 {
+		return nil
+	}
+
+	val, ok := params[name]
+	if !ok {
+		return nil
+	}
+
+	strVal, ok := val.(string)
+	if !ok {
+		return fmt.Errorf("%w: %s must be string", ErrInvalidEnumValue, name)
+	}
+
+	for _, allowed := range f.Values {
+		if strVal == allowed {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: %s got %q, allowed: %v", ErrInvalidEnumValue, name, strVal, f.Values)
+}
+
+// Registry manages multiple handler schemas.
+type Registry struct {
+	mu       sync.RWMutex
+	schemas  []*Schema
+	handlers map[string]*HandlerDef
+}
+
+// NewRegistry creates a new empty schema registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		schemas:  make([]*Schema, 0),
+		handlers: make(map[string]*HandlerDef),
+	}
+}
+
+// LoadFromYAML parses and loads a schema from YAML bytes.
+func (r *Registry) LoadFromYAML(data []byte) error {
+	schema, err := Parse(data)
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.schemas = append(r.schemas, schema)
+	for name, handler := range schema.Handlers {
+		r.handlers[name] = handler
+	}
+
+	return nil
+}
+
+// GetHandler returns the handler definition for the given name.
+func (r *Registry) GetHandler(name string) (*HandlerDef, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	handler, ok := r.handlers[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrHandlerNotFound, name)
+	}
+	return handler, nil
+}
+
+// ListHandlers returns a sorted list of all registered handler names.
+func (r *Registry) ListHandlers() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	names := make([]string, 0, len(r.handlers))
+	for name := range r.handlers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// HasHandler returns true if the handler is registered.
+func (r *Registry) HasHandler(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	_, ok := r.handlers[name]
+	return ok
+}

--- a/shared/pkg/saga/schema/schema_test.go
+++ b/shared/pkg/saga/schema/schema_test.go
@@ -1,0 +1,306 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHandlerSchema(t *testing.T) {
+	yaml := `
+service: current_account
+version: "1.0"
+handlers:
+  position_keeping.initiate_log:
+    description: "Create DEBIT/CREDIT entry in PositionKeeping service"
+    params:
+      position_id:
+        type: string
+        required: true
+        description: "Unique identifier for the position"
+      amount:
+        type: Decimal
+        required: true
+        description: "Transaction amount"
+      direction:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+        description: "Direction of the transaction"
+    returns:
+      log_id:
+        type: string
+        description: "Generated log identifier"
+      status:
+        type: string
+        description: "Status of the log entry"
+    compensate: position_keeping.cancel_log
+`
+
+	schema, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+
+	assert.Equal(t, "current_account", schema.Service)
+	assert.Equal(t, "1.0", schema.Version)
+	assert.Len(t, schema.Handlers, 1)
+
+	handler, exists := schema.Handlers["position_keeping.initiate_log"]
+	require.True(t, exists)
+	assert.Equal(t, "Create DEBIT/CREDIT entry in PositionKeeping service", handler.Description)
+	assert.Equal(t, "position_keeping.cancel_log", handler.Compensate)
+
+	// Check params
+	assert.Len(t, handler.Params, 3)
+
+	positionID := handler.Params["position_id"]
+	assert.Equal(t, TypeString, positionID.Type)
+	assert.True(t, positionID.Required)
+
+	amount := handler.Params["amount"]
+	assert.Equal(t, TypeDecimal, amount.Type)
+	assert.True(t, amount.Required)
+
+	direction := handler.Params["direction"]
+	assert.Equal(t, TypeEnum, direction.Type)
+	assert.True(t, direction.Required)
+	assert.Equal(t, []string{"DEBIT", "CREDIT"}, direction.Values)
+
+	// Check returns
+	assert.Len(t, handler.Returns, 2)
+	logID := handler.Returns["log_id"]
+	assert.Equal(t, TypeString, logID.Type)
+}
+
+func TestParseHandlerSchemaValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "missing service",
+			yaml: `
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test"
+`,
+			wantErr: "service is required",
+		},
+		{
+			name: "invalid type",
+			yaml: `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test"
+    params:
+      foo:
+        type: invalid_type
+        required: true
+`,
+			wantErr: "unknown type",
+		},
+		{
+			name: "enum without values",
+			yaml: `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test"
+    params:
+      direction:
+        type: enum
+        required: true
+`,
+			wantErr: "enum type requires values",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Parse([]byte(tt.yaml))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestFieldTypeValidation(t *testing.T) {
+	tests := []struct {
+		typeStr string
+		want    FieldType
+		valid   bool
+	}{
+		{"string", TypeString, true},
+		{"int32", TypeInt32, true},
+		{"int64", TypeInt64, true},
+		{"uint32", TypeUint32, true},
+		{"bool", TypeBool, true},
+		{"Decimal", TypeDecimal, true},
+		{"enum", TypeEnum, true},
+		{"array", TypeArray, true},
+		{"map", TypeMap, true},
+		{"uuid", TypeUUID, true},
+		{"invalid", "", false},
+		{"", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.typeStr, func(t *testing.T) {
+			ft, err := ParseFieldType(tt.typeStr)
+			if tt.valid {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, ft)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestSchemaRegistry(t *testing.T) {
+	registry := NewRegistry()
+
+	yaml := `
+service: test_service
+version: "1.0"
+handlers:
+  test.handler:
+    description: "A test handler"
+    params:
+      id:
+        type: string
+        required: true
+    returns:
+      result:
+        type: string
+`
+
+	err := registry.LoadFromYAML([]byte(yaml))
+	require.NoError(t, err)
+
+	// Get handler schema
+	handler, err := registry.GetHandler("test.handler")
+	require.NoError(t, err)
+	assert.Equal(t, "A test handler", handler.Description)
+
+	// List handlers
+	handlers := registry.ListHandlers()
+	assert.Contains(t, handlers, "test.handler")
+
+	// Non-existent handler
+	_, err = registry.GetHandler("nonexistent")
+	assert.Error(t, err)
+}
+
+func TestLoadMultipleSchemas(t *testing.T) {
+	registry := NewRegistry()
+
+	yaml1 := `
+service: service_a
+version: "1.0"
+handlers:
+  service_a.method1:
+    description: "Method 1"
+`
+
+	yaml2 := `
+service: service_b
+version: "1.0"
+handlers:
+  service_b.method1:
+    description: "Method 1 in B"
+`
+
+	require.NoError(t, registry.LoadFromYAML([]byte(yaml1)))
+	require.NoError(t, registry.LoadFromYAML([]byte(yaml2)))
+
+	handlers := registry.ListHandlers()
+	assert.Len(t, handlers, 2)
+	assert.Contains(t, handlers, "service_a.method1")
+	assert.Contains(t, handlers, "service_b.method1")
+}
+
+func TestValidateHandlerParams(t *testing.T) {
+	yaml := `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test handler"
+    params:
+      required_field:
+        type: string
+        required: true
+      optional_field:
+        type: string
+        required: false
+      amount:
+        type: Decimal
+        required: true
+      direction:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+`
+
+	schema, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+
+	handler := schema.Handlers["test.handler"]
+
+	tests := []struct {
+		name    string
+		params  map[string]any
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid params",
+			params: map[string]any{
+				"required_field": "value",
+				"amount":         "100.50",
+				"direction":      "DEBIT",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing required field",
+			params: map[string]any{
+				"amount":    "100.50",
+				"direction": "DEBIT",
+			},
+			wantErr: true,
+			errMsg:  "required_field",
+		},
+		{
+			name: "invalid enum value",
+			params: map[string]any{
+				"required_field": "value",
+				"amount":         "100.50",
+				"direction":      "INVALID",
+			},
+			wantErr: true,
+			errMsg:  "direction",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := handler.ValidateParams(tt.params)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.True(t, strings.Contains(err.Error(), tt.errMsg),
+					"expected error to contain %q, got %q", tt.errMsg, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Implement typed handler schema definitions for saga orchestration, enabling compile-time validation of handler references in Starlark scripts.

## Changes Made

- **New `shared/pkg/saga/schema/` package** with YAML parsing and validation
- **FieldType enum** with protobuf-aligned types: string, int32, int64, uint32, bool, Decimal, enum, array, map, uuid
- **HandlerDef struct** for handler metadata (params, returns, compensate handler)
- **Schema Registry** for loading and querying handler schemas
- **handlers.yaml** with schemas for all 12 platform handlers:
  - `position_keeping.initiate_log`, `update_log`, `cancel_log`
  - `financial_accounting.post_entries`, `reverse_entries`, `create_booking`
  - `current_account.create_lien`, `execute_lien`, `terminate_lien`
  - `valuation_engine.valuate`
  - `repository.save`
  - `notification.send`

## Technical Details

The schema format supports:
- Required/optional field markers
- Enum types with allowed values validation
- Compensation handler references
- Array and map types for complex parameters

Example schema:
```yaml
handlers:
  position_keeping.initiate_log:
    description: "Initiate a position log entry"
    params:
      position_id:
        type: string
        required: true
      amount:
        type: Decimal
        required: true
      direction:
        type: enum
        values: [DEBIT, CREDIT]
        required: true
    returns:
      log_id:
        type: string
    compensate: position_keeping.cancel_log
```

## Test Plan

- [x] Unit tests for YAML parsing and validation
- [x] Tests for field type validation (all 10 types)
- [x] Tests for schema validation errors (missing service, invalid type, enum without values)
- [x] Tests for parameter validation (required fields, enum values)
- [x] Integration test loading platform handlers.yaml
- [x] Test that all compensate references point to existing handlers

## Related

Task Master: starlark-typed-clients.1
PRD: docs/prd/starlark-typed-service-clients.md