### PR TITLE
feat(saga): Add platform_saga_definition table and sync mechanism

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20251209175733-2a1774d88802.1
 	buf.build/go/protovalidate v1.1.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/alicebob/miniredis/v2 v2.35.0
 	github.com/bits-and-blooms/bloom/v3 v3.7.1
 	github.com/golang-jwt/jwt/v5 v5.3.0
@@ -47,7 +48,6 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -657,6 +657,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.30.0
 github.com/IBM/sarama v1.42.1 h1:wugyWa15TDEHh2kvq2gAy1IHLjEjuYOYgXz/ruC/OSQ=
 github.com/IBM/sarama v1.42.1/go.mod h1:Xxho9HkHd4K/MDUo/T/sOqwtX/17D33++E9Wib6hUdQ=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/services/reference-data/migrations/20260125000001_platform_saga_definition.sql
+++ b/services/reference-data/migrations/20260125000001_platform_saga_definition.sql
@@ -1,0 +1,51 @@
+-- Platform Saga Definition Storage
+-- This table stores platform-level saga definitions that serve as defaults/templates
+-- for tenant schemas. Unlike saga_definition (per-tenant), this is in the PUBLIC schema.
+--
+-- Design decisions:
+-- - PUBLIC schema: Shared across all tenants (platform-level)
+-- - Semver versioning: Uses X.Y.Z format (not integer) for proper version comparison
+-- - Simpler lifecycle: No DRAFT/ACTIVE/DEPRECATED, just latest version wins
+-- - Embedded sync: Populated from embedded .star files at service startup
+
+-- Create "platform_saga_definition" table in public schema
+CREATE TABLE "public"."platform_saga_definition" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "name" character varying(64) NOT NULL,
+  "version" character varying(16) NOT NULL,
+  "script" text NOT NULL,
+  "display_name" character varying(128) NULL,
+  "description" text NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("id")
+);
+
+-- Add validation constraints
+-- Semver format: X.Y.Z where X, Y, Z are non-negative integers
+ALTER TABLE "public"."platform_saga_definition"
+  ADD CONSTRAINT "chk_platform_saga_definition_version"
+  CHECK ("version" ~ '^[0-9]+\.[0-9]+\.[0-9]+$');
+
+-- Limit script to 64KB to prevent abuse
+ALTER TABLE "public"."platform_saga_definition"
+  ADD CONSTRAINT "chk_platform_saga_definition_script_length"
+  CHECK (length("script") <= 65536);
+
+-- Ensure name is unique (only one version per name at a time)
+-- Unlike tenant sagas which can have multiple versions, platform sagas
+-- are always synced to the latest embedded version
+ALTER TABLE "public"."platform_saga_definition"
+  ADD CONSTRAINT "uq_platform_saga_definition_name"
+  UNIQUE ("name");
+
+-- Create indexes for efficient lookups
+-- Primary lookup by name
+CREATE INDEX "idx_platform_saga_definition_name" ON "public"."platform_saga_definition" ("name");
+
+-- Index for listing all platform sagas by updated time
+CREATE INDEX "idx_platform_saga_definition_updated_at" ON "public"."platform_saga_definition" ("updated_at" DESC);
+
+-- Comment on the table
+COMMENT ON TABLE "public"."platform_saga_definition" IS
+  'Platform-level saga definitions synced from embedded .star files. Serves as source for tenant saga seeding.';

--- a/services/reference-data/migrations/20260125000001_platform_saga_definition.sql
+++ b/services/reference-data/migrations/20260125000001_platform_saga_definition.sql
@@ -7,9 +7,14 @@
 -- - Semver versioning: Uses X.Y.Z format (not integer) for proper version comparison
 -- - Simpler lifecycle: No DRAFT/ACTIVE/DEPRECATED, just latest version wins
 -- - Embedded sync: Populated from embedded .star files at service startup
+--
+-- IMPORTANT: This migration runs per-tenant but creates objects in the shared public schema.
+-- All DDL statements must be idempotent (IF NOT EXISTS) to avoid errors when multiple
+-- tenant schemas apply the same migration.
 
--- Create "platform_saga_definition" table in public schema
-CREATE TABLE "public"."platform_saga_definition" (
+-- Create "platform_saga_definition" table in public schema with all constraints inline
+-- Using IF NOT EXISTS because this migration runs per-tenant but creates in shared public schema
+CREATE TABLE IF NOT EXISTS "public"."platform_saga_definition" (
   "id" uuid NOT NULL DEFAULT gen_random_uuid(),
   "name" character varying(64) NOT NULL,
   "version" character varying(16) NOT NULL,
@@ -18,34 +23,27 @@ CREATE TABLE "public"."platform_saga_definition" (
   "description" text NULL,
   "created_at" timestamptz NOT NULL DEFAULT now(),
   "updated_at" timestamptz NOT NULL DEFAULT now(),
-  PRIMARY KEY ("id")
+  PRIMARY KEY ("id"),
+  -- Semver format: X.Y.Z where X, Y, Z are non-negative integers
+  CONSTRAINT "chk_platform_saga_definition_version"
+    CHECK ("version" ~ '^[0-9]+\.[0-9]+\.[0-9]+$'),
+  -- Limit script to 64KB to prevent abuse
+  CONSTRAINT "chk_platform_saga_definition_script_length"
+    CHECK (length("script") <= 65536),
+  -- Ensure name is unique (only one version per name at a time)
+  -- Unlike tenant sagas which can have multiple versions, platform sagas
+  -- are always synced to the latest embedded version
+  CONSTRAINT "uq_platform_saga_definition_name"
+    UNIQUE ("name")
 );
 
--- Add validation constraints
--- Semver format: X.Y.Z where X, Y, Z are non-negative integers
-ALTER TABLE "public"."platform_saga_definition"
-  ADD CONSTRAINT "chk_platform_saga_definition_version"
-  CHECK ("version" ~ '^[0-9]+\.[0-9]+\.[0-9]+$');
-
--- Limit script to 64KB to prevent abuse
-ALTER TABLE "public"."platform_saga_definition"
-  ADD CONSTRAINT "chk_platform_saga_definition_script_length"
-  CHECK (length("script") <= 65536);
-
--- Ensure name is unique (only one version per name at a time)
--- Unlike tenant sagas which can have multiple versions, platform sagas
--- are always synced to the latest embedded version
-ALTER TABLE "public"."platform_saga_definition"
-  ADD CONSTRAINT "uq_platform_saga_definition_name"
-  UNIQUE ("name");
-
--- Create indexes for efficient lookups
+-- Create indexes for efficient lookups (idempotent)
 -- Primary lookup by name
-CREATE INDEX "idx_platform_saga_definition_name" ON "public"."platform_saga_definition" ("name");
+CREATE INDEX IF NOT EXISTS "idx_platform_saga_definition_name" ON "public"."platform_saga_definition" ("name");
 
 -- Index for listing all platform sagas by updated time
-CREATE INDEX "idx_platform_saga_definition_updated_at" ON "public"."platform_saga_definition" ("updated_at" DESC);
+CREATE INDEX IF NOT EXISTS "idx_platform_saga_definition_updated_at" ON "public"."platform_saga_definition" ("updated_at" DESC);
 
--- Comment on the table
+-- Comment on the table (idempotent - replaces if exists)
 COMMENT ON TABLE "public"."platform_saga_definition" IS
   'Platform-level saga definitions synced from embedded .star files. Serves as source for tenant saga seeding.';

--- a/services/reference-data/saga/defaults/deposit.star
+++ b/services/reference-data/saga/defaults/deposit.star
@@ -1,4 +1,5 @@
 # Deposit Saga Definition
+# Version: 1.0.0
 #
 # This Starlark script defines the deposit saga workflow for the Current Account service.
 # The saga executes a multi-step deposit operation with compensation on failure.

--- a/services/reference-data/saga/defaults/payment_execution.star
+++ b/services/reference-data/saga/defaults/payment_execution.star
@@ -1,4 +1,5 @@
 # payment_execution.star
+# Version: 1.0.0
 # Payment Order execution saga with bucket-aware lien, gateway submission, and ledger posting.
 #
 # This saga orchestrates the complete payment flow:

--- a/services/reference-data/saga/defaults/withdrawal.star
+++ b/services/reference-data/saga/defaults/withdrawal.star
@@ -1,4 +1,5 @@
 # Withdrawal Saga Definition
+# Version: 1.0.0
 #
 # This Starlark script defines the withdrawal saga workflow for the Current Account service.
 # The saga executes a multi-step withdrawal operation with compensation on failure.

--- a/services/reference-data/saga/platform_sync.go
+++ b/services/reference-data/saga/platform_sync.go
@@ -1,0 +1,240 @@
+// Package saga provides platform saga definition sync functionality.
+package saga
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// versionCommentRegex matches "# Version: X.Y.Z" comments at the start of the script.
+var versionCommentRegex = regexp.MustCompile(`(?m)^#\s*Version:\s*(\d+\.\d+\.\d+)\s*$`)
+
+// ErrEmbeddedScriptNotFound is returned when a saga script is not found in the embedded filesystem.
+var ErrEmbeddedScriptNotFound = errors.New("embedded script not found")
+
+// PlatformSagaDefinition represents a saga definition in the platform table.
+type PlatformSagaDefinition struct {
+	ID          uuid.UUID
+	Name        string
+	Version     string
+	Script      string
+	DisplayName string
+	Description string
+}
+
+// PlatformSync synchronizes embedded saga definitions to the platform_saga_definition table.
+type PlatformSync struct {
+	pool   *pgxpool.Pool
+	logger *slog.Logger
+}
+
+// NewPlatformSync creates a new PlatformSync instance.
+func NewPlatformSync(pool *pgxpool.Pool) *PlatformSync {
+	return &PlatformSync{
+		pool:   pool,
+		logger: slog.Default().With("component", "platform_saga_sync"),
+	}
+}
+
+// SyncPlatformDefaults synchronizes all embedded saga definitions to the platform table.
+// This method is idempotent - running it multiple times with the same versions has no effect.
+//
+// The sync logic:
+//  1. Loads all embedded .star files from the defaults directory
+//  2. Extracts version from "# Version: X.Y.Z" comment in each script
+//  3. For each saga, compares embedded version with database version
+//  4. Updates if embedded version is newer (semver comparison)
+//  5. Inserts if saga doesn't exist in database
+func (s *PlatformSync) SyncPlatformDefaults(ctx context.Context) error {
+	s.logger.Info("starting platform saga sync")
+
+	// Load all embedded sagas
+	sagas, err := s.loadEmbeddedSagas()
+	if err != nil {
+		return fmt.Errorf("load embedded sagas: %w", err)
+	}
+
+	s.logger.Info("loaded embedded sagas", "count", len(sagas))
+
+	// Sync each saga
+	var syncedCount, skippedCount int
+	for _, saga := range sagas {
+		synced, err := s.syncSaga(ctx, saga)
+		if err != nil {
+			return fmt.Errorf("sync saga %s: %w", saga.Name, err)
+		}
+		if synced {
+			syncedCount++
+		} else {
+			skippedCount++
+		}
+	}
+
+	s.logger.Info("platform saga sync completed",
+		"synced", syncedCount,
+		"skipped", skippedCount,
+		"total", len(sagas))
+
+	return nil
+}
+
+// loadEmbeddedSagas reads all embedded .star files and parses their metadata.
+func (s *PlatformSync) loadEmbeddedSagas() ([]PlatformSagaDefinition, error) {
+	defaults := PlatformDefaults()
+	sagas := make([]PlatformSagaDefinition, 0, len(defaults))
+
+	for _, meta := range defaults {
+		// Read embedded script
+		script, err := s.readEmbeddedScript(meta.Filename)
+		if err != nil {
+			return nil, fmt.Errorf("read script %s: %w", meta.Filename, err)
+		}
+
+		// Extract version from script
+		version := extractVersionFromScript(script)
+		if version == "" {
+			// Default to 1.0.0 if no version comment found
+			version = "1.0.0"
+			s.logger.Warn("no version comment found in script, using default",
+				"filename", meta.Filename,
+				"default_version", version)
+		}
+
+		// Generate deterministic UUID based on name
+		id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga."+meta.Name))
+
+		sagas = append(sagas, PlatformSagaDefinition{
+			ID:          id,
+			Name:        meta.Name,
+			Version:     version,
+			Script:      script,
+			DisplayName: meta.DisplayName,
+			Description: meta.Description,
+		})
+	}
+
+	return sagas, nil
+}
+
+// readEmbeddedScript reads a saga script from the embedded filesystem.
+func (s *PlatformSync) readEmbeddedScript(filename string) (string, error) {
+	scripts, err := GetEmbeddedScripts()
+	if err != nil {
+		return "", err
+	}
+
+	script, ok := scripts[filename]
+	if !ok {
+		return "", fmt.Errorf("%w: %s", ErrEmbeddedScriptNotFound, filename)
+	}
+
+	return script, nil
+}
+
+// syncSaga syncs a single saga to the database.
+// Returns true if the saga was inserted/updated, false if skipped.
+func (s *PlatformSync) syncSaga(ctx context.Context, saga PlatformSagaDefinition) (bool, error) {
+	// Check if saga exists and get current version
+	var existingVersion string
+	err := s.pool.QueryRow(ctx, `
+		SELECT version FROM public.platform_saga_definition WHERE name = $1
+	`, saga.Name).Scan(&existingVersion)
+
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return false, fmt.Errorf("query existing version: %w", err)
+	}
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		// Insert new saga
+		_, err = s.pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(id, name, version, script, display_name, description)
+			VALUES ($1, $2, $3, $4, $5, $6)
+		`, saga.ID, saga.Name, saga.Version, saga.Script, saga.DisplayName, saga.Description)
+		if err != nil {
+			return false, fmt.Errorf("insert saga: %w", err)
+		}
+
+		s.logger.Info("inserted platform saga",
+			"name", saga.Name,
+			"version", saga.Version)
+		return true, nil
+	}
+
+	// Compare versions using semver
+	shouldUpdate, err := shouldUpdateVersion(existingVersion, saga.Version)
+	if err != nil {
+		return false, fmt.Errorf("compare versions: %w", err)
+	}
+
+	if !shouldUpdate {
+		s.logger.Debug("skipping saga (version not newer)",
+			"name", saga.Name,
+			"existing_version", existingVersion,
+			"embedded_version", saga.Version)
+		return false, nil
+	}
+
+	// Update saga with newer version
+	_, err = s.pool.Exec(ctx, `
+		UPDATE public.platform_saga_definition
+		SET version = $1, script = $2, display_name = $3, description = $4, updated_at = NOW()
+		WHERE name = $5
+	`, saga.Version, saga.Script, saga.DisplayName, saga.Description, saga.Name)
+	if err != nil {
+		return false, fmt.Errorf("update saga: %w", err)
+	}
+
+	s.logger.Info("updated platform saga",
+		"name", saga.Name,
+		"old_version", existingVersion,
+		"new_version", saga.Version)
+	return true, nil
+}
+
+// extractVersionFromScript extracts the version from a "# Version: X.Y.Z" comment.
+// Returns empty string if no version comment is found.
+func extractVersionFromScript(script string) string {
+	matches := versionCommentRegex.FindStringSubmatch(script)
+	if len(matches) < 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+// shouldUpdateVersion returns true if newVersion is greater than existingVersion.
+// Uses semver comparison for proper version ordering.
+func shouldUpdateVersion(existingVersion, newVersion string) (bool, error) {
+	existingVer, err := semver.NewVersion(existingVersion)
+	if err != nil {
+		return false, fmt.Errorf("parse existing version %q: %w", existingVersion, err)
+	}
+
+	newVer, err := semver.NewVersion(newVersion)
+	if err != nil {
+		return false, fmt.Errorf("parse new version %q: %w", newVersion, err)
+	}
+
+	return newVer.GreaterThan(existingVer), nil
+}
+
+// humanizeName converts snake_case to Title Case.
+// Example: "current_account_withdrawal" -> "Current Account Withdrawal"
+func humanizeName(name string) string {
+	words := strings.Split(name, "_")
+	for i, word := range words {
+		if len(word) > 0 {
+			words[i] = strings.ToUpper(word[:1]) + word[1:]
+		}
+	}
+	return strings.Join(words, " ")
+}

--- a/services/reference-data/saga/platform_sync_test.go
+++ b/services/reference-data/saga/platform_sync_test.go
@@ -1,0 +1,487 @@
+package saga
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func TestExtractVersionFromScript(t *testing.T) {
+	tests := []struct {
+		name     string
+		script   string
+		expected string
+	}{
+		{
+			name:     "version at start of file",
+			script:   "# Version: 1.2.3\n# Comment\ndef foo(): pass",
+			expected: "1.2.3",
+		},
+		{
+			name:     "version with leading whitespace in comment",
+			script:   "#   Version:   2.0.0  \ncode here",
+			expected: "2.0.0",
+		},
+		{
+			name:     "version in middle of file",
+			script:   "# Header\n# Version: 3.1.4\n# Footer",
+			expected: "3.1.4",
+		},
+		{
+			name:     "no version comment",
+			script:   "# Just a comment\ndef foo(): pass",
+			expected: "",
+		},
+		{
+			name:     "invalid version format",
+			script:   "# Version: 1.2\n# Missing patch",
+			expected: "",
+		},
+		{
+			name:     "version with text after",
+			script:   "# Version: 1.0.0 - initial release\ndef foo(): pass",
+			expected: "",
+		},
+		{
+			name:     "multiple version comments (takes first)",
+			script:   "# Version: 1.0.0\n# Version: 2.0.0\n",
+			expected: "1.0.0",
+		},
+		{
+			name:     "zero version",
+			script:   "# Version: 0.0.0\ncode",
+			expected: "0.0.0",
+		},
+		{
+			name:     "large version numbers",
+			script:   "# Version: 123.456.789\ncode",
+			expected: "123.456.789",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractVersionFromScript(tt.script)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestShouldUpdateVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing string
+		new      string
+		expected bool
+		wantErr  bool
+	}{
+		{
+			name:     "new major version",
+			existing: "1.0.0",
+			new:      "2.0.0",
+			expected: true,
+		},
+		{
+			name:     "new minor version",
+			existing: "1.0.0",
+			new:      "1.1.0",
+			expected: true,
+		},
+		{
+			name:     "new patch version",
+			existing: "1.0.0",
+			new:      "1.0.1",
+			expected: true,
+		},
+		{
+			name:     "same version",
+			existing: "1.0.0",
+			new:      "1.0.0",
+			expected: false,
+		},
+		{
+			name:     "older version",
+			existing: "2.0.0",
+			new:      "1.0.0",
+			expected: false,
+		},
+		{
+			name:     "older minor version",
+			existing: "1.5.0",
+			new:      "1.4.9",
+			expected: false,
+		},
+		{
+			name:     "invalid existing version",
+			existing: "not-a-version",
+			new:      "1.0.0",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid new version",
+			existing: "1.0.0",
+			new:      "invalid",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := shouldUpdateVersion(tt.existing, tt.new)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestHumanizeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "single word",
+			input:    "withdrawal",
+			expected: "Withdrawal",
+		},
+		{
+			name:     "two words",
+			input:    "current_account",
+			expected: "Current Account",
+		},
+		{
+			name:     "three words",
+			input:    "current_account_withdrawal",
+			expected: "Current Account Withdrawal",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "already capitalized",
+			input:    "Already_Capitalized",
+			expected: "Already Capitalized",
+		},
+		{
+			name:     "all uppercase",
+			input:    "ALL_UPPERCASE",
+			expected: "ALL UPPERCASE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := humanizeName(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEmbeddedScriptsHaveVersionComments(t *testing.T) {
+	scripts, err := GetEmbeddedScripts()
+	require.NoError(t, err)
+	require.NotEmpty(t, scripts, "should have embedded scripts")
+
+	for filename, script := range scripts {
+		t.Run(filename, func(t *testing.T) {
+			version := extractVersionFromScript(script)
+			assert.NotEmpty(t, version,
+				"embedded script %s should have a Version: comment", filename)
+			assert.Regexp(t, `^\d+\.\d+\.\d+$`, version,
+				"version should be valid semver format X.Y.Z")
+		})
+	}
+}
+
+// setupPlatformTestDB creates a CockroachDB testcontainer with the platform migration applied.
+func setupPlatformTestDB(t *testing.T) (*pgxpool.Pool, func()) {
+	t.Helper()
+
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	ctx := context.Background()
+
+	// Start CockroachDB container
+	container, err := cockroachdb.Run(ctx,
+		"cockroachdb/cockroach:v24.3.8",
+		cockroachdb.WithDatabase("test_platform_sync"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("CockroachDB node starting").
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	require.NoError(t, err)
+
+	// Get connection string
+	connStr, err := container.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	// Create pool
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+
+	// Apply platform saga definition migration
+	migrationPath := filepath.Join("..", "migrations", "20260125000001_platform_saga_definition.sql")
+	migrationSQL, err := os.ReadFile(migrationPath)
+	require.NoError(t, err, "failed to read migration file")
+
+	_, err = pool.Exec(ctx, string(migrationSQL))
+	require.NoError(t, err, "failed to apply migration")
+
+	cleanup := func() {
+		pool.Close()
+		_ = container.Terminate(ctx)
+	}
+
+	return pool, cleanup
+}
+
+func TestPlatformSync_SyncPlatformDefaults(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	sync := NewPlatformSync(pool)
+
+	t.Run("initial sync inserts all sagas", func(t *testing.T) {
+		err := sync.SyncPlatformDefaults(ctx)
+		require.NoError(t, err)
+
+		// Verify sagas were inserted
+		var count int
+		err = pool.QueryRow(ctx, `SELECT COUNT(*) FROM public.platform_saga_definition`).Scan(&count)
+		require.NoError(t, err)
+		assert.Equal(t, len(PlatformDefaults()), count, "expected all platform defaults to be inserted")
+
+		// Verify each saga has correct fields
+		for _, meta := range PlatformDefaults() {
+			var name, displayName, description string
+			var version string
+			err := pool.QueryRow(ctx, `
+				SELECT name, version, display_name, description
+				FROM public.platform_saga_definition
+				WHERE name = $1
+			`, meta.Name).Scan(&name, &version, &displayName, &description)
+			require.NoError(t, err, "saga %s should exist", meta.Name)
+			assert.Equal(t, meta.Name, name)
+			assert.Equal(t, meta.DisplayName, displayName)
+			assert.Equal(t, meta.Description, description)
+			// Version should be either from script or default 1.0.0
+			assert.Regexp(t, `^\d+\.\d+\.\d+$`, version)
+		}
+	})
+
+	t.Run("idempotent sync - no changes when same version", func(t *testing.T) {
+		// Get initial updated_at timestamps
+		type sagaTimestamp struct {
+			name      string
+			updatedAt time.Time
+		}
+		var initialTimestamps []sagaTimestamp
+
+		rows, err := pool.Query(ctx, `SELECT name, updated_at FROM public.platform_saga_definition`)
+		require.NoError(t, err)
+		defer rows.Close()
+
+		for rows.Next() {
+			var ts sagaTimestamp
+			err := rows.Scan(&ts.name, &ts.updatedAt)
+			require.NoError(t, err)
+			initialTimestamps = append(initialTimestamps, ts)
+		}
+		require.NoError(t, rows.Err())
+
+		// Wait a bit to ensure timestamp difference would be visible
+		time.Sleep(10 * time.Millisecond)
+
+		// Run sync again
+		err = sync.SyncPlatformDefaults(ctx)
+		require.NoError(t, err)
+
+		// Verify timestamps haven't changed
+		for _, initial := range initialTimestamps {
+			var currentUpdatedAt time.Time
+			err := pool.QueryRow(ctx, `
+				SELECT updated_at FROM public.platform_saga_definition WHERE name = $1
+			`, initial.name).Scan(&currentUpdatedAt)
+			require.NoError(t, err)
+			assert.Equal(t, initial.updatedAt.Unix(), currentUpdatedAt.Unix(),
+				"updated_at should not change for %s when version is same", initial.name)
+		}
+	})
+
+	t.Run("deterministic UUIDs", func(t *testing.T) {
+		// Verify UUIDs are deterministic based on saga name
+		for _, meta := range PlatformDefaults() {
+			expectedID := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga."+meta.Name))
+
+			var actualID uuid.UUID
+			err := pool.QueryRow(ctx, `
+				SELECT id FROM public.platform_saga_definition WHERE name = $1
+			`, meta.Name).Scan(&actualID)
+			require.NoError(t, err)
+			assert.Equal(t, expectedID, actualID,
+				"UUID for %s should be deterministic", meta.Name)
+		}
+	})
+}
+
+func TestPlatformSync_VersionUpdate(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("updates saga when version is newer", func(t *testing.T) {
+		// Insert a saga with old version directly
+		id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.test_saga"))
+		_, err := pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(id, name, version, script, display_name, description)
+			VALUES ($1, 'test_saga', '0.0.1', 'old script', 'Old Name', 'Old description')
+		`, id)
+		require.NoError(t, err)
+
+		// Create sync and manually sync a newer version
+		sync := NewPlatformSync(pool)
+		synced, err := sync.syncSaga(ctx, PlatformSagaDefinition{
+			ID:          id,
+			Name:        "test_saga",
+			Version:     "1.0.0",
+			Script:      "new script",
+			DisplayName: "New Name",
+			Description: "New description",
+		})
+		require.NoError(t, err)
+		assert.True(t, synced, "saga should be updated with newer version")
+
+		// Verify update
+		var version, script, displayName string
+		err = pool.QueryRow(ctx, `
+			SELECT version, script, display_name
+			FROM public.platform_saga_definition
+			WHERE name = 'test_saga'
+		`).Scan(&version, &script, &displayName)
+		require.NoError(t, err)
+		assert.Equal(t, "1.0.0", version)
+		assert.Equal(t, "new script", script)
+		assert.Equal(t, "New Name", displayName)
+	})
+
+	t.Run("skips saga when version is older", func(t *testing.T) {
+		// Insert a saga with newer version directly
+		id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.skip_test"))
+		_, err := pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(id, name, version, script, display_name, description)
+			VALUES ($1, 'skip_test', '2.0.0', 'existing script', 'Existing Name', 'Existing description')
+		`, id)
+		require.NoError(t, err)
+
+		// Try to sync with older version
+		sync := NewPlatformSync(pool)
+		synced, err := sync.syncSaga(ctx, PlatformSagaDefinition{
+			ID:          id,
+			Name:        "skip_test",
+			Version:     "1.0.0",
+			Script:      "older script",
+			DisplayName: "Older Name",
+			Description: "Older description",
+		})
+		require.NoError(t, err)
+		assert.False(t, synced, "saga should not be updated with older version")
+
+		// Verify no update
+		var version, script string
+		err = pool.QueryRow(ctx, `
+			SELECT version, script
+			FROM public.platform_saga_definition
+			WHERE name = 'skip_test'
+		`).Scan(&version, &script)
+		require.NoError(t, err)
+		assert.Equal(t, "2.0.0", version, "version should remain unchanged")
+		assert.Equal(t, "existing script", script, "script should remain unchanged")
+	})
+}
+
+func TestPlatformSync_MigrationConstraints(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	t.Run("rejects invalid semver version", func(t *testing.T) {
+		_, err := pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(name, version, script)
+			VALUES ('invalid_version', '1.2', 'script')
+		`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "chk_platform_saga_definition_version")
+	})
+
+	t.Run("rejects duplicate name", func(t *testing.T) {
+		_, err := pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(name, version, script)
+			VALUES ('duplicate_test', '1.0.0', 'script1')
+		`)
+		require.NoError(t, err)
+
+		_, err = pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(name, version, script)
+			VALUES ('duplicate_test', '2.0.0', 'script2')
+		`)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uq_platform_saga_definition_name")
+	})
+
+	t.Run("accepts script up to 64KB", func(t *testing.T) {
+		largeScript := make([]byte, 65536)
+		for i := range largeScript {
+			largeScript[i] = 'x'
+		}
+
+		_, err := pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(name, version, script)
+			VALUES ('large_script', '1.0.0', $1)
+		`, string(largeScript))
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects script over 64KB", func(t *testing.T) {
+		tooLargeScript := make([]byte, 65537)
+		for i := range tooLargeScript {
+			tooLargeScript[i] = 'x'
+		}
+
+		_, err := pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(name, version, script)
+			VALUES ('too_large_script', '1.0.0', $1)
+		`, string(tooLargeScript))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "chk_platform_saga_definition_script_length")
+	})
+}

--- a/services/reference-data/saga/platform_sync_test.go
+++ b/services/reference-data/saga/platform_sync_test.go
@@ -317,14 +317,14 @@ func TestPlatformSync_SyncPlatformDefaults(t *testing.T) {
 		err = sync.SyncPlatformDefaults(ctx)
 		require.NoError(t, err)
 
-		// Verify timestamps haven't changed
+		// Verify timestamps haven't changed (compare full timestamps, not just Unix seconds)
 		for _, initial := range initialTimestamps {
 			var currentUpdatedAt time.Time
 			err := pool.QueryRow(ctx, `
 				SELECT updated_at FROM public.platform_saga_definition WHERE name = $1
 			`, initial.name).Scan(&currentUpdatedAt)
 			require.NoError(t, err)
-			assert.Equal(t, initial.updatedAt.Unix(), currentUpdatedAt.Unix(),
+			require.True(t, currentUpdatedAt.Equal(initial.updatedAt),
 				"updated_at should not change for %s when version is same", initial.name)
 		}
 	})


### PR DESCRIPTION
## Summary

Implements Task `starlark-typed-clients.6` - Creates a platform-level saga definition table and sync mechanism for maintaining platform default sagas.

**Changes:**
- Add Flyway migration for `public.platform_saga_definition` table with semver versioning
- Implement `PlatformSync` with `SyncPlatformDefaults()` method for startup sync from embedded `.star` files
- Add `# Version: X.Y.Z` comments to all embedded saga definitions
- Add `github.com/Masterminds/semver/v3` dependency for proper version comparison

## Test plan

- [x] Unit tests for version extraction from scripts (`TestExtractVersionFromScript`)
- [x] Unit tests for semver comparison (`TestShouldUpdateVersion`)
- [x] Unit tests for name humanization (`TestHumanizeName`)
- [x] Unit test verifying all embedded scripts have version comments (`TestEmbeddedScriptsHaveVersionComments`)
- [x] Integration tests for sync logic (with CockroachDB testcontainer)
- [x] Integration tests for migration constraints (semver format, uniqueness, size limits)
- [x] Lint passes with 0 issues

## Migration Details

The migration creates `public.platform_saga_definition` table with:
- `id` (UUID, primary key)
- `name` (VARCHAR 64, UNIQUE) - saga identifier
- `version` (VARCHAR 16) - semver format X.Y.Z
- `script` (TEXT, max 64KB) - Starlark code
- `display_name`, `description` - human-readable metadata
- `created_at`, `updated_at` - timestamps

## Architecture Notes

The platform table differs from tenant-specific `saga_definition`:
- **PUBLIC schema**: Shared across all tenants
- **Semver versioning**: Enables proper version ordering (1.9.0 < 1.10.0)
- **Unique name**: Only one version per saga at a time (latest wins)
- **No lifecycle states**: No DRAFT/ACTIVE/DEPRECATED - just latest version

The sync mechanism:
1. Reads embedded `.star` files at startup
2. Extracts version from `# Version: X.Y.Z` comment
3. Compares with database version using semver
4. Updates only if embedded version is newer
5. Idempotent - safe to run multiple times