### PR TITLE
feat(saga): Add schema loader and integrate with validation pipeline

### DIFF
--- a/services/reference-data/saga/reference_validator.go
+++ b/services/reference-data/saga/reference_validator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	pkgsaga "github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"go.starlark.net/syntax"
 )
 
@@ -24,6 +25,9 @@ var (
 
 	// ErrPoolNotConfigured is returned when database pool is not configured for reference persistence.
 	ErrPoolNotConfigured = errors.New("database pool not configured")
+
+	// ErrHandlerParamValidationFailed is returned when handler parameter validation fails.
+	ErrHandlerParamValidationFailed = errors.New("handler parameter validation failed")
 )
 
 // Validation status constants.
@@ -76,6 +80,11 @@ type Reference struct {
 
 	// AttributeKey is set for attribute references to indicate the attribute name.
 	AttributeKey string
+
+	// Params holds extracted parameters for step handler references.
+	// Keys are parameter names extracted from the step() call.
+	// This enables schema validation of handler invocations.
+	Params map[string]bool
 }
 
 // ValidationError represents a validation issue found during reference checking.
@@ -207,6 +216,7 @@ type DefinitionChecker interface {
 // ReferenceValidator validates saga scripts by extracting and checking references.
 type ReferenceValidator struct {
 	handlerRegistry   *pkgsaga.DomainHandlerRegistry
+	schemaRegistry    *schema.Registry
 	instrumentChecker InstrumentChecker
 	definitionChecker DefinitionChecker
 	pool              *pgxpool.Pool
@@ -225,6 +235,12 @@ func NewReferenceValidator(
 		definitionChecker: definitionChecker,
 		pool:              pool,
 	}
+}
+
+// SetSchemaRegistry configures the schema registry for parameter validation.
+// If set, handler invocations will be validated against their schemas.
+func (v *ReferenceValidator) SetSchemaRegistry(registry *schema.Registry) {
+	v.schemaRegistry = registry
 }
 
 // ExtractReferences parses a Starlark script and extracts all external references.
@@ -451,6 +467,44 @@ func (v *ReferenceValidator) checkStepHandler(ref Reference, strict bool, result
 			Suggestion: suggestion,
 			IsCritical: strict,
 		})
+		return
+	}
+
+	// If schema registry is configured, validate parameters against schema
+	if v.schemaRegistry != nil && v.schemaRegistry.HasHandler(ref.Key) {
+		v.validateHandlerParams(ref, strict, result)
+	}
+}
+
+// validateHandlerParams validates that extracted parameter names match the handler schema.
+func (v *ReferenceValidator) validateHandlerParams(ref Reference, strict bool, result *ValidationResult) {
+	handlerDef, err := v.schemaRegistry.GetHandler(ref.Key)
+	if err != nil {
+		return // Schema not found - skip param validation
+	}
+
+	// Check for missing required parameters
+	for paramName, paramDef := range handlerDef.Params {
+		if paramDef.Required {
+			if _, provided := ref.Params[paramName]; !provided {
+				result.Errors = append(result.Errors, ValidationError{
+					Reference:  ref,
+					Message:    fmt.Sprintf("handler '%s' missing required parameter '%s'", ref.Key, paramName),
+					IsCritical: strict,
+				})
+			}
+		}
+	}
+
+	// Check for unknown parameters (params not in schema)
+	for paramName := range ref.Params {
+		if _, exists := handlerDef.Params[paramName]; !exists {
+			result.Errors = append(result.Errors, ValidationError{
+				Reference:  ref,
+				Message:    fmt.Sprintf("handler '%s' has unknown parameter '%s'", ref.Key, paramName),
+				IsCritical: false, // Unknown params are warnings, not errors
+			})
+		}
 	}
 }
 
@@ -821,20 +875,44 @@ func (e *referenceExtractor) walkExpr(expr syntax.Expr) {
 				}
 
 			case "step":
-				// Extract step handler from 'action' keyword argument
+				// Extract step handler and params from keyword arguments
+				var handler string
+				var lineNum int
+				paramNames := make(map[string]bool)
+
 				for _, kwarg := range ex.Args {
 					if binExpr, ok := kwarg.(*syntax.BinaryExpr); ok && binExpr.Op == syntax.EQ {
-						if nameIdent, ok := binExpr.X.(*syntax.Ident); ok && nameIdent.Name == "action" {
-							if lit, ok := binExpr.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
-								handler := strings.Trim(lit.Raw, `"'`)
-								e.references = append(e.references, Reference{
-									Type:       ReferenceTypeStepHandler,
-									Key:        handler,
-									LineNumber: int(ident.NamePos.Line),
-								})
+						if nameIdent, ok := binExpr.X.(*syntax.Ident); ok {
+							switch nameIdent.Name {
+							case "action":
+								if lit, ok := binExpr.Y.(*syntax.Literal); ok && lit.Token == syntax.STRING {
+									handler = strings.Trim(lit.Raw, `"'`)
+									lineNum = int(ident.NamePos.Line)
+								}
+							case "params":
+								// Extract param names from the params dict
+								if dictExpr, ok := binExpr.Y.(*syntax.DictExpr); ok {
+									for _, entry := range dictExpr.List {
+										if dictEntry, ok := entry.(*syntax.DictEntry); ok {
+											if keyLit, ok := dictEntry.Key.(*syntax.Literal); ok && keyLit.Token == syntax.STRING {
+												paramName := strings.Trim(keyLit.Raw, `"'`)
+												paramNames[paramName] = true
+											}
+										}
+									}
+								}
 							}
 						}
 					}
+				}
+
+				if handler != "" {
+					e.references = append(e.references, Reference{
+						Type:       ReferenceTypeStepHandler,
+						Key:        handler,
+						LineNumber: lineNum,
+						Params:     paramNames,
+					})
 				}
 			}
 		}

--- a/services/reference-data/saga/reference_validator.go
+++ b/services/reference-data/saga/reference_validator.go
@@ -85,6 +85,10 @@ type Reference struct {
 	// Keys are parameter names extracted from the step() call.
 	// This enables schema validation of handler invocations.
 	Params map[string]bool
+
+	// ParamsKnown indicates whether params were statically extractable.
+	// When false (e.g., params passed as a variable), skip validation.
+	ParamsKnown bool
 }
 
 // ValidationError represents a validation issue found during reference checking.
@@ -478,6 +482,11 @@ func (v *ReferenceValidator) checkStepHandler(ref Reference, strict bool, result
 
 // validateHandlerParams validates that extracted parameter names match the handler schema.
 func (v *ReferenceValidator) validateHandlerParams(ref Reference, strict bool, result *ValidationResult) {
+	// Skip validation if params weren't statically extractable (e.g., passed as variable)
+	if !ref.ParamsKnown {
+		return
+	}
+
 	handlerDef, err := v.schemaRegistry.GetHandler(ref.Key)
 	if err != nil {
 		return // Schema not found - skip param validation
@@ -879,6 +888,7 @@ func (e *referenceExtractor) walkExpr(expr syntax.Expr) {
 				var handler string
 				var lineNum int
 				paramNames := make(map[string]bool)
+				paramsKnown := true // Assume known unless we encounter non-literal params
 
 				for _, kwarg := range ex.Args {
 					if binExpr, ok := kwarg.(*syntax.BinaryExpr); ok && binExpr.Op == syntax.EQ {
@@ -894,12 +904,19 @@ func (e *referenceExtractor) walkExpr(expr syntax.Expr) {
 								if dictExpr, ok := binExpr.Y.(*syntax.DictExpr); ok {
 									for _, entry := range dictExpr.List {
 										if dictEntry, ok := entry.(*syntax.DictEntry); ok {
-											if keyLit, ok := dictEntry.Key.(*syntax.Literal); ok && keyLit.Token == syntax.STRING {
-												paramName := strings.Trim(keyLit.Raw, `"'`)
-												paramNames[paramName] = true
+											keyLit, ok := dictEntry.Key.(*syntax.Literal)
+											if !ok || keyLit.Token != syntax.STRING {
+												// Non-literal key (e.g., variable) - can't extract
+												paramsKnown = false
+												continue
 											}
+											paramName := strings.Trim(keyLit.Raw, `"'`)
+											paramNames[paramName] = true
 										}
 									}
+								} else {
+									// params is not a literal dict (e.g., a variable)
+									paramsKnown = false
 								}
 							}
 						}
@@ -908,10 +925,11 @@ func (e *referenceExtractor) walkExpr(expr syntax.Expr) {
 
 				if handler != "" {
 					e.references = append(e.references, Reference{
-						Type:       ReferenceTypeStepHandler,
-						Key:        handler,
-						LineNumber: lineNum,
-						Params:     paramNames,
+						Type:        ReferenceTypeStepHandler,
+						Key:         handler,
+						LineNumber:  lineNum,
+						Params:      paramNames,
+						ParamsKnown: paramsKnown,
 					})
 				}
 			}

--- a/services/reference-data/saga/reference_validator_test.go
+++ b/services/reference-data/saga/reference_validator_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	pkgsaga "github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -635,4 +636,193 @@ func TestListHandlers(t *testing.T) {
 
 	// Should be sorted alphabetically
 	assert.Equal(t, []string{"a_handler", "m_handler", "z_handler"}, handlers)
+}
+
+func TestExtractReferences_StepHandlerWithParams(t *testing.T) {
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def execute(ctx):
+    step(
+        action = "position_keeping.initiate_log",
+        params = {
+            "position_id": ctx.position_id,
+            "amount": ctx.amount,
+            "direction": "DEBIT",
+        }
+    )
+`
+
+	refs, err := v.ExtractReferences(script)
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+
+	ref := refs[0]
+	assert.Equal(t, ReferenceTypeStepHandler, ref.Type)
+	assert.Equal(t, "position_keeping.initiate_log", ref.Key)
+	assert.NotNil(t, ref.Params)
+	assert.True(t, ref.Params["position_id"])
+	assert.True(t, ref.Params["amount"])
+	assert.True(t, ref.Params["direction"])
+}
+
+func TestValidateDraft_WithSchemaRegistry(t *testing.T) {
+	// Register the handler in DomainHandlerRegistry
+	handlerRegistry := pkgsaga.NewDomainHandlerRegistry()
+	_ = handlerRegistry.Register("test.handler", nil)
+
+	// Create schema registry with handler schema
+	schemaRegistry := schema.NewRegistry()
+	schemaYAML := `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test handler"
+    params:
+      required_field:
+        type: string
+        required: true
+      optional_field:
+        type: string
+        required: false
+`
+	require.NoError(t, schemaRegistry.LoadFromYAML([]byte(schemaYAML)))
+
+	v := NewReferenceValidator(handlerRegistry, nil, nil, nil)
+	v.SetSchemaRegistry(schemaRegistry)
+
+	tests := []struct {
+		name       string
+		script     string
+		wantErrors int
+		checkMsg   string
+	}{
+		{
+			name: "valid params - all required present",
+			script: `
+def execute(ctx):
+    step(
+        action = "test.handler",
+        params = {
+            "required_field": "value",
+        }
+    )
+`,
+			wantErrors: 0,
+		},
+		{
+			name: "missing required param",
+			script: `
+def execute(ctx):
+    step(
+        action = "test.handler",
+        params = {
+            "optional_field": "value",
+        }
+    )
+`,
+			wantErrors: 1,
+			checkMsg:   "missing required parameter 'required_field'",
+		},
+		{
+			name: "unknown param (warning)",
+			script: `
+def execute(ctx):
+    step(
+        action = "test.handler",
+        params = {
+            "required_field": "value",
+            "unknown_field": "value",
+        }
+    )
+`,
+			wantErrors: 1,
+			checkMsg:   "unknown parameter 'unknown_field'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sagaID := uuid.New()
+			result, err := v.ValidateDraft(context.Background(), sagaID, tt.script)
+			require.NoError(t, err)
+
+			assert.Len(t, result.Errors, tt.wantErrors)
+			if tt.checkMsg != "" && len(result.Errors) > 0 {
+				assert.Contains(t, result.Errors[0].Message, tt.checkMsg)
+			}
+		})
+	}
+}
+
+func TestValidateActivation_BlocksOnMissingRequiredParams(t *testing.T) {
+	// Register the handler
+	handlerRegistry := pkgsaga.NewDomainHandlerRegistry()
+	_ = handlerRegistry.Register("test.handler", nil)
+
+	// Create schema registry
+	schemaRegistry := schema.NewRegistry()
+	schemaYAML := `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test handler"
+    params:
+      required_field:
+        type: string
+        required: true
+`
+	require.NoError(t, schemaRegistry.LoadFromYAML([]byte(schemaYAML)))
+
+	v := NewReferenceValidator(handlerRegistry, nil, nil, nil)
+	v.SetSchemaRegistry(schemaRegistry)
+
+	script := `
+def execute(ctx):
+    step(
+        action = "test.handler",
+        params = {}
+    )
+`
+
+	sagaID := uuid.New()
+	result, err := v.ValidateActivation(context.Background(), sagaID, script)
+	require.NoError(t, err)
+
+	// Activation should be blocked
+	assert.Equal(t, statusBlocked, result.Status)
+	assert.Len(t, result.Errors, 1)
+	assert.True(t, result.Errors[0].IsCritical)
+	assert.Contains(t, result.Errors[0].Message, "missing required parameter")
+}
+
+func TestValidateDraft_NoSchemaRegistry(t *testing.T) {
+	// When no schema registry is set, validation should still work
+	// but skip parameter validation
+	handlerRegistry := pkgsaga.NewDomainHandlerRegistry()
+	_ = handlerRegistry.Register("test.handler", nil)
+
+	v := NewReferenceValidator(handlerRegistry, nil, nil, nil)
+	// Note: NOT setting schema registry
+
+	script := `
+def execute(ctx):
+    step(
+        action = "test.handler",
+        params = {
+            "any_field": "value",
+        }
+    )
+`
+
+	sagaID := uuid.New()
+	result, err := v.ValidateDraft(context.Background(), sagaID, script)
+	require.NoError(t, err)
+
+	// Should pass with no errors (no schema to validate against)
+	assert.Empty(t, result.Errors)
+	assert.Equal(t, statusReady, result.Status)
 }

--- a/services/reference-data/saga/reference_validator_test.go
+++ b/services/reference-data/saga/reference_validator_test.go
@@ -661,6 +661,7 @@ def execute(ctx):
 	ref := refs[0]
 	assert.Equal(t, ReferenceTypeStepHandler, ref.Type)
 	assert.Equal(t, "position_keeping.initiate_log", ref.Key)
+	assert.True(t, ref.ParamsKnown, "ParamsKnown should be true for literal dict")
 	assert.NotNil(t, ref.Params)
 	assert.True(t, ref.Params["position_id"])
 	assert.True(t, ref.Params["amount"])
@@ -823,6 +824,71 @@ def execute(ctx):
 	require.NoError(t, err)
 
 	// Should pass with no errors (no schema to validate against)
+	assert.Empty(t, result.Errors)
+	assert.Equal(t, statusReady, result.Status)
+}
+
+func TestExtractReferences_StepHandlerWithVariableParams(t *testing.T) {
+	// When params is a variable, we can't statically extract it
+	registry := pkgsaga.NewDomainHandlerRegistry()
+	v := NewReferenceValidator(registry, nil, nil, nil)
+
+	script := `
+def execute(ctx):
+    my_params = {"position_id": ctx.position_id}
+    step(
+        action = "position_keeping.initiate_log",
+        params = my_params  # Variable, not a literal dict
+    )
+`
+
+	refs, err := v.ExtractReferences(script)
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+
+	ref := refs[0]
+	assert.Equal(t, ReferenceTypeStepHandler, ref.Type)
+	assert.Equal(t, "position_keeping.initiate_log", ref.Key)
+	assert.False(t, ref.ParamsKnown, "ParamsKnown should be false for variable params")
+	assert.Empty(t, ref.Params)
+}
+
+func TestValidateDraft_SkipsValidationForVariableParams(t *testing.T) {
+	// When params is a variable, we should skip validation (no false positives)
+	handlerRegistry := pkgsaga.NewDomainHandlerRegistry()
+	_ = handlerRegistry.Register("test.handler", nil)
+
+	schemaRegistry := schema.NewRegistry()
+	schemaYAML := `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test handler"
+    params:
+      required_field:
+        type: string
+        required: true
+`
+	require.NoError(t, schemaRegistry.LoadFromYAML([]byte(schemaYAML)))
+
+	v := NewReferenceValidator(handlerRegistry, nil, nil, nil)
+	v.SetSchemaRegistry(schemaRegistry)
+
+	script := `
+def execute(ctx):
+    params_dict = {"required_field": "value"}
+    step(
+        action = "test.handler",
+        params = params_dict  # Variable - can't validate statically
+    )
+`
+
+	sagaID := uuid.New()
+	result, err := v.ValidateDraft(context.Background(), sagaID, script)
+	require.NoError(t, err)
+
+	// Should pass - we skip validation for non-static params
 	assert.Empty(t, result.Errors)
 	assert.Equal(t, statusReady, result.Status)
 }

--- a/shared/pkg/saga/schema/schema.go
+++ b/shared/pkg/saga/schema/schema.go
@@ -5,6 +5,8 @@ package schema
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 
@@ -290,4 +292,50 @@ func (r *Registry) HasHandler(name string) bool {
 
 	_, ok := r.handlers[name]
 	return ok
+}
+
+// LoadFromFile loads a schema from a YAML file.
+func (r *Registry) LoadFromFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read schema file %s: %w", path, err)
+	}
+	return r.LoadFromYAML(data)
+}
+
+// LoadFromDirectory loads all YAML schema files from a directory.
+// Files must have .yaml or .yml extension. Subdirectories are not traversed.
+func (r *Registry) LoadFromDirectory(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to read schema directory %s: %w", dir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		ext := filepath.Ext(entry.Name())
+		if ext != ".yaml" && ext != ".yml" {
+			continue
+		}
+
+		path := filepath.Join(dir, entry.Name())
+		if err := r.LoadFromFile(path); err != nil {
+			return fmt.Errorf("failed to load schema %s: %w", path, err)
+		}
+	}
+
+	return nil
+}
+
+// ValidateHandlerParams validates parameters for a named handler.
+// Returns ErrHandlerNotFound if the handler schema is not registered.
+func (r *Registry) ValidateHandlerParams(handlerName string, params map[string]any) error {
+	handler, err := r.GetHandler(handlerName)
+	if err != nil {
+		return err
+	}
+	return handler.ValidateParams(params)
 }

--- a/shared/pkg/saga/schema/schema_test.go
+++ b/shared/pkg/saga/schema/schema_test.go
@@ -1,6 +1,8 @@
 package schema
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -303,4 +305,152 @@ handlers:
 			}
 		})
 	}
+}
+
+func TestLoadFromFile(t *testing.T) {
+	// Create a temporary YAML file
+	tmpDir := t.TempDir()
+	schemaPath := filepath.Join(tmpDir, "test_handlers.yaml")
+
+	yamlContent := `
+service: file_test
+version: "1.0"
+handlers:
+  file_test.handler:
+    description: "Handler loaded from file"
+    params:
+      id:
+        type: string
+        required: true
+    returns:
+      status:
+        type: string
+`
+	err := os.WriteFile(schemaPath, []byte(yamlContent), 0o644)
+	require.NoError(t, err)
+
+	registry := NewRegistry()
+	err = registry.LoadFromFile(schemaPath)
+	require.NoError(t, err)
+
+	handler, err := registry.GetHandler("file_test.handler")
+	require.NoError(t, err)
+	assert.Equal(t, "Handler loaded from file", handler.Description)
+}
+
+func TestLoadFromFile_NotFound(t *testing.T) {
+	registry := NewRegistry()
+	err := registry.LoadFromFile("/nonexistent/path/schema.yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read schema file")
+}
+
+func TestLoadFromDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create multiple YAML files
+	files := map[string]string{
+		"service_a.yaml": `
+service: service_a
+version: "1.0"
+handlers:
+  service_a.method1:
+    description: "Method 1 from service A"
+`,
+		"service_b.yml": `
+service: service_b
+version: "1.0"
+handlers:
+  service_b.method1:
+    description: "Method 1 from service B"
+`,
+		"not_a_schema.txt": `This should be ignored`,
+	}
+
+	for name, content := range files {
+		path := filepath.Join(tmpDir, name)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+
+	// Create a subdirectory (should be skipped)
+	subDir := filepath.Join(tmpDir, "subdir")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(subDir, "ignored.yaml"),
+		[]byte(`service: ignored`),
+		0o644,
+	))
+
+	registry := NewRegistry()
+	err := registry.LoadFromDirectory(tmpDir)
+	require.NoError(t, err)
+
+	handlers := registry.ListHandlers()
+	assert.Len(t, handlers, 2)
+	assert.Contains(t, handlers, "service_a.method1")
+	assert.Contains(t, handlers, "service_b.method1")
+}
+
+func TestLoadFromDirectory_InvalidSchema(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create an invalid YAML file
+	invalidPath := filepath.Join(tmpDir, "invalid.yaml")
+	err := os.WriteFile(invalidPath, []byte(`
+service: ""
+handlers: {}
+`), 0o644)
+	require.NoError(t, err)
+
+	registry := NewRegistry()
+	err = registry.LoadFromDirectory(tmpDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service is required")
+}
+
+func TestLoadFromDirectory_NotFound(t *testing.T) {
+	registry := NewRegistry()
+	err := registry.LoadFromDirectory("/nonexistent/directory")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read schema directory")
+}
+
+func TestRegistryValidateHandlerParams(t *testing.T) {
+	registry := NewRegistry()
+
+	yamlContent := `
+service: test
+version: "1.0"
+handlers:
+  test.handler:
+    description: "Test handler"
+    params:
+      required_field:
+        type: string
+        required: true
+      direction:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+`
+	require.NoError(t, registry.LoadFromYAML([]byte(yamlContent)))
+
+	// Valid params
+	err := registry.ValidateHandlerParams("test.handler", map[string]any{
+		"required_field": "value",
+		"direction":      "DEBIT",
+	})
+	require.NoError(t, err)
+
+	// Missing required field
+	err = registry.ValidateHandlerParams("test.handler", map[string]any{
+		"direction": "DEBIT",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingRequiredParam)
+
+	// Handler not found
+	err = registry.ValidateHandlerParams("nonexistent.handler", map[string]any{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrHandlerNotFound)
 }


### PR DESCRIPTION
## Summary

Implements Task Master task starlark-typed-clients.2: Build schema loader and integrate with validation pipeline.

This PR adds file-based schema loading and integrates the SchemaRegistry with the ReferenceValidator to enable compile-time parameter validation for handler invocations in Starlark saga scripts.

## Changes Made

### Schema Registry Enhancements (`shared/pkg/saga/schema/schema.go`)
- **LoadFromFile**: Load a single YAML schema file into the registry
- **LoadFromDirectory**: Scan and load all `.yaml`/`.yml` files from a directory
- **ValidateHandlerParams**: Convenience method to validate params by handler name

### Reference Validator Integration (`services/reference-data/saga/reference_validator.go`)
- Added `schemaRegistry` field to `ReferenceValidator` struct
- Implemented `SetSchemaRegistry()` to configure schema-based validation
- Modified `checkStepHandler()` to validate parameters against schemas when configured
- Added `validateHandlerParams()` to check for:
  - Missing required parameters (critical error during activation)
  - Unknown parameters (warning during draft, not critical)
- Enhanced `referenceExtractor` to extract parameter names from `step()` calls' `params` dict

### Reference struct enhancement
- Added `Params map[string]bool` field to capture which parameters are passed to handlers

## Test Strategy
- Unit tests for LoadFromFile and LoadFromDirectory
- Unit test for ValidateHandlerParams at registry level
- Integration tests for schema validation in ReferenceValidator:
  - Valid params pass validation
  - Missing required params generate errors
  - Unknown params generate warnings
  - No schema registry configured gracefully skips validation

## Notes
- Some pre-existing test failures in `grpc_handler_test.go` and `platform_sync_test.go` are unrelated to this change (they fail on develop as well)
- Schema validation is opt-in via `SetSchemaRegistry()` - existing code without schemas configured will continue to work unchanged