### PR TITLE
feat(saga): Add Starlark service module generation from handler schemas

### DIFF
--- a/shared/pkg/saga/schema/service_modules.go
+++ b/shared/pkg/saga/schema/service_modules.go
@@ -1,0 +1,556 @@
+// Package schema provides Starlark service module generation from handler schemas.
+// This implements typed service clients that replace magic string handler references
+// with direct method calls like `position_keeping.initiate_log(...)`.
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/shopspring/decimal"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// Thread-local storage key for StarlarkContext.
+// This key is used to pass the StarlarkContext through the Starlark thread
+// so handlers can access it during execution.
+const starlarkContextKey = "saga.StarlarkContext"
+
+// Service module generation errors.
+var (
+	// ErrHandlerMissingFromRegistry is returned when a schema defines a handler
+	// that is not registered in the DomainHandlerRegistry.
+	ErrHandlerMissingFromRegistry = errors.New("handler defined in schema but not in registry")
+
+	// ErrHandlerMissingSchema is returned when a registered handler has no schema.
+	ErrHandlerMissingSchema = errors.New("handler registered but has no schema definition")
+
+	// ErrNamingConflict is returned when a handler name creates a conflict
+	// (e.g., "foo.bar" and "foo.bar.baz" where "bar" would be both a handler and namespace).
+	ErrNamingConflict = errors.New("handler naming conflict: name used as both handler and namespace")
+
+	// ErrMissingStarlarkContext is returned when the StarlarkContext is not set on the thread.
+	ErrMissingStarlarkContext = errors.New("StarlarkContext not set on thread")
+
+	// ErrPositionalArgsNotAllowed is returned when a handler is called with positional args.
+	ErrPositionalArgsNotAllowed = errors.New("positional arguments not allowed, use keyword arguments")
+
+	// ErrDictKeyNotString is returned when a Starlark dict has a non-string key.
+	ErrDictKeyNotString = errors.New("dict key must be string")
+
+	// ErrDecimalConversion is returned when a value cannot be converted to Decimal.
+	ErrDecimalConversion = errors.New("cannot convert to Decimal")
+)
+
+// handlerTree represents a hierarchical tree of handler names.
+// Handler names like "service.domain.action" are split into a tree structure:
+//
+//	service
+//	  └─ domain
+//	       └─ action (handler)
+type handlerTree struct {
+	children map[string]*handlerTree // Nested namespaces
+	handlers map[string]string       // Handler names at this level (name -> full qualified name)
+}
+
+// newHandlerTree creates a new empty handler tree.
+func newHandlerTree() *handlerTree {
+	return &handlerTree{
+		children: make(map[string]*handlerTree),
+		handlers: make(map[string]string),
+	}
+}
+
+// parseHandlerTree builds a handler tree from a list of handler names.
+// Handler names are expected in the format "service.action" or "service.domain.action".
+func parseHandlerTree(handlerNames []string) *handlerTree {
+	root := newHandlerTree()
+
+	for _, name := range handlerNames {
+		parts := strings.Split(name, ".")
+		if len(parts) < 2 {
+			// Invalid handler name, skip
+			continue
+		}
+
+		current := root
+
+		// Navigate/create the tree structure for all parts except the last
+		for i := 0; i < len(parts)-1; i++ {
+			part := parts[i]
+			if current.children[part] == nil {
+				current.children[part] = newHandlerTree()
+			}
+			current = current.children[part]
+		}
+
+		// The last part is the handler name
+		handlerName := parts[len(parts)-1]
+		current.handlers[handlerName] = name
+	}
+
+	return root
+}
+
+// findNode finds a node at the given dot-separated path.
+// Returns nil if the path does not exist.
+func (t *handlerTree) findNode(path string) *handlerTree {
+	parts := strings.Split(path, ".")
+	current := t
+
+	for _, part := range parts {
+		if current.children[part] == nil {
+			return nil
+		}
+		current = current.children[part]
+	}
+
+	return current
+}
+
+// validate checks the tree for naming conflicts.
+// A conflict occurs when a name is used as both a handler and a namespace.
+func (t *handlerTree) validate() error {
+	return t.validateNode("")
+}
+
+func (t *handlerTree) validateNode(path string) error {
+	// Check for conflicts at this level
+	for handlerName := range t.handlers {
+		if _, exists := t.children[handlerName]; exists {
+			fullPath := handlerName
+			if path != "" {
+				fullPath = path + "." + handlerName
+			}
+			return fmt.Errorf("%w: %q is used as both a handler and a namespace", ErrNamingConflict, fullPath)
+		}
+	}
+
+	// Recursively validate children
+	for name, child := range t.children {
+		childPath := name
+		if path != "" {
+			childPath = path + "." + name
+		}
+		if err := child.validateNode(childPath); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// BuildServiceModules creates Starlark service modules from the handler registry and schema.
+// It returns a StringDict containing all top-level service structs that can be injected
+// into the Starlark runtime.
+//
+// The resulting modules enable typed handler calls like:
+//
+//	position_keeping.initiate_log(position_id="123", amount="100.00", direction="DEBIT")
+//
+// Instead of:
+//
+//	invoke_handler(handler="position_keeping.initiate_log", params={...})
+func BuildServiceModules(registry *saga.DomainHandlerRegistry, schemaRegistry *Registry) (starlark.StringDict, error) {
+	// Get all handler names from the schema registry
+	schemaHandlers := schemaRegistry.ListHandlers()
+
+	// Get all handler names from the domain registry
+	registryHandlers := registry.List()
+
+	// Validate that all schema handlers exist in registry
+	registrySet := make(map[string]bool, len(registryHandlers))
+	for _, name := range registryHandlers {
+		registrySet[name] = true
+	}
+	for _, name := range schemaHandlers {
+		if !registrySet[name] {
+			return nil, fmt.Errorf("%w: %s", ErrHandlerMissingFromRegistry, name)
+		}
+	}
+
+	// Validate that all registry handlers have schemas
+	schemaSet := make(map[string]bool, len(schemaHandlers))
+	for _, name := range schemaHandlers {
+		schemaSet[name] = true
+	}
+	for _, name := range registryHandlers {
+		if !schemaSet[name] {
+			return nil, fmt.Errorf("%w: %s", ErrHandlerMissingSchema, name)
+		}
+	}
+
+	// Build handler tree
+	tree := parseHandlerTree(schemaHandlers)
+
+	// Validate tree structure
+	if err := tree.validate(); err != nil {
+		return nil, err
+	}
+
+	// Build Starlark structs from tree
+	modules := make(starlark.StringDict)
+	for name, child := range tree.children {
+		module, err := buildServiceStruct(name, child, registry, schemaRegistry)
+		if err != nil {
+			return nil, err
+		}
+		modules[name] = module
+	}
+
+	return modules, nil
+}
+
+// buildServiceStruct recursively builds a starlarkstruct from a handler tree node.
+func buildServiceStruct(name string, node *handlerTree, registry *saga.DomainHandlerRegistry, schemaRegistry *Registry) (*starlarkstruct.Struct, error) {
+	members := make(starlark.StringDict)
+
+	// Add child namespaces as nested structs
+	for childName, childNode := range node.children {
+		childStruct, err := buildServiceStruct(childName, childNode, registry, schemaRegistry)
+		if err != nil {
+			return nil, err
+		}
+		members[childName] = childStruct
+	}
+
+	// Add handlers as builtin functions
+	for handlerName, fullName := range node.handlers {
+		handler, err := registry.Get(fullName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get handler %s: %w", fullName, err)
+		}
+
+		handlerDef, err := schemaRegistry.GetHandler(fullName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get handler schema %s: %w", fullName, err)
+		}
+
+		members[handlerName] = wrapHandler(fullName, handler, handlerDef)
+	}
+
+	return starlarkstruct.FromStringDict(starlark.String(name), members), nil
+}
+
+// wrapHandler creates a Starlark builtin that wraps a Go DomainHandler.
+// It handles parameter validation against the schema and type conversion.
+//
+//nolint:gocognit // Handler wrapping inherently requires checking multiple conditions
+func wrapHandler(fullName string, handler saga.DomainHandler, handlerDef *HandlerDef) *starlark.Builtin {
+	return starlark.NewBuiltin(fullName, func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		// Handle positional args (should be empty for handlers) - check first for fast fail
+		if len(args) > 0 {
+			return nil, fmt.Errorf("%w: handler %s", ErrPositionalArgsNotAllowed, fullName)
+		}
+
+		// Get StarlarkContext from thread-local storage
+		ctx := getStarlarkContext(thread)
+		if ctx == nil {
+			return nil, ErrMissingStarlarkContext
+		}
+
+		// Convert kwargs to Go map
+		params, err := convertKwargsToParams(kwargs)
+		if err != nil {
+			return nil, err
+		}
+
+		// Convert Decimal parameters from string/int/float
+		if err := convertDecimalParams(params, handlerDef); err != nil {
+			return nil, err
+		}
+
+		// Validate parameters against schema
+		if err := handlerDef.ValidateParams(params); err != nil {
+			return nil, fmt.Errorf("handler %s: %w", fullName, err)
+		}
+
+		// Call the handler
+		result, err := handler(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+
+		// Convert result to Starlark value
+		return goToStarlarkResult(fullName, result)
+	})
+}
+
+// convertKwargsToParams converts Starlark kwargs to a Go map.
+func convertKwargsToParams(kwargs []starlark.Tuple) (map[string]any, error) {
+	params := make(map[string]any, len(kwargs))
+	for _, kwarg := range kwargs {
+		keyVal, ok := kwarg[0].(starlark.String)
+		if !ok {
+			return nil, fmt.Errorf("%w: got %s", ErrDictKeyNotString, kwarg[0].Type())
+		}
+		key := string(keyVal)
+		value, err := starlarkToGoValue(kwarg[1])
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert parameter %s: %w", key, err)
+		}
+		params[key] = value
+	}
+	return params, nil
+}
+
+// convertDecimalParams converts Decimal-typed parameters from string/int/float to decimal.Decimal.
+func convertDecimalParams(params map[string]any, handlerDef *HandlerDef) error {
+	for paramName, fieldDef := range handlerDef.Params {
+		if fieldDef.Type == TypeDecimal {
+			if val, ok := params[paramName]; ok {
+				dec, err := toDecimal(val)
+				if err != nil {
+					return fmt.Errorf("parameter %s: %w", paramName, err)
+				}
+				params[paramName] = dec
+			}
+		}
+	}
+	return nil
+}
+
+// setStarlarkContext stores the StarlarkContext in thread-local storage.
+func setStarlarkContext(thread *starlark.Thread, ctx *saga.StarlarkContext) {
+	thread.SetLocal(starlarkContextKey, ctx)
+}
+
+// getStarlarkContext retrieves the StarlarkContext from thread-local storage.
+func getStarlarkContext(thread *starlark.Thread) *saga.StarlarkContext {
+	val := thread.Local(starlarkContextKey)
+	if val == nil {
+		return nil
+	}
+	ctx, ok := val.(*saga.StarlarkContext)
+	if !ok {
+		return nil
+	}
+	return ctx
+}
+
+// starlarkToGoValue converts a Starlark value to a Go value.
+//
+//nolint:gocognit // Type switch for Starlark values requires checking multiple types
+func starlarkToGoValue(v starlark.Value) (any, error) {
+	switch val := v.(type) {
+	case starlark.String:
+		return string(val), nil
+	case starlark.Int:
+		return starlarkIntToGo(val), nil
+	case starlark.Float:
+		return float64(val), nil
+	case starlark.Bool:
+		return bool(val), nil
+	case starlark.NoneType:
+		//nolint:nilnil // nil,nil is the correct representation of Starlark None
+		return nil, nil
+	case *starlark.List:
+		return starlarkListToGo(val)
+	case *starlark.Dict:
+		return starlarkDictToGo(val)
+	case *starlarkstruct.Struct:
+		return starlarkStructToGo(val)
+	default:
+		// For custom types, try to convert to string
+		return val.String(), nil
+	}
+}
+
+// starlarkIntToGo converts a Starlark Int to Go int64 or string (for very large ints).
+func starlarkIntToGo(val starlark.Int) any {
+	if i, ok := val.Int64(); ok {
+		return i
+	}
+	// Fall back to string for very large ints
+	return val.String()
+}
+
+// starlarkListToGo converts a Starlark List to Go []any.
+func starlarkListToGo(val *starlark.List) ([]any, error) {
+	result := make([]any, val.Len())
+	for i := 0; i < val.Len(); i++ {
+		elem, err := starlarkToGoValue(val.Index(i))
+		if err != nil {
+			return nil, err
+		}
+		result[i] = elem
+	}
+	return result, nil
+}
+
+// starlarkDictToGo converts a Starlark Dict to Go map[string]any.
+func starlarkDictToGo(val *starlark.Dict) (map[string]any, error) {
+	result := make(map[string]any)
+	for _, item := range val.Items() {
+		key, ok := item[0].(starlark.String)
+		if !ok {
+			return nil, fmt.Errorf("%w: got %s", ErrDictKeyNotString, item[0].Type())
+		}
+		value, err := starlarkToGoValue(item[1])
+		if err != nil {
+			return nil, err
+		}
+		result[string(key)] = value
+	}
+	return result, nil
+}
+
+// starlarkStructToGo converts a Starlark Struct to Go map[string]any.
+func starlarkStructToGo(val *starlarkstruct.Struct) (map[string]any, error) {
+	result := make(map[string]any)
+	for _, attrName := range val.AttrNames() {
+		attrVal, _ := val.Attr(attrName)
+		converted, err := starlarkToGoValue(attrVal)
+		if err != nil {
+			return nil, err
+		}
+		result[attrName] = converted
+	}
+	return result, nil
+}
+
+// toDecimal converts various Go types to decimal.Decimal.
+func toDecimal(v any) (decimal.Decimal, error) {
+	switch val := v.(type) {
+	case decimal.Decimal:
+		return val, nil
+	case string:
+		return decimal.NewFromString(val)
+	case int:
+		return decimal.NewFromInt(int64(val)), nil
+	case int64:
+		return decimal.NewFromInt(val), nil
+	case float64:
+		return decimal.NewFromFloat(val), nil
+	default:
+		return decimal.Zero, fmt.Errorf("%w: unsupported type %T", ErrDecimalConversion, v)
+	}
+}
+
+// goToStarlarkResult converts a Go handler result to a Starlark struct.
+// Handler results are expected to be map[string]any which gets converted
+// to a branded starlarkstruct.Struct for type-safe field access.
+func goToStarlarkResult(handlerName string, result any) (starlark.Value, error) {
+	if result == nil {
+		return starlark.None, nil
+	}
+
+	resultMap, ok := result.(map[string]any)
+	if !ok {
+		// If not a map, convert directly to Starlark value
+		return goToStarlarkValue(result)
+	}
+
+	// Build struct from map
+	members := make(starlark.StringDict, len(resultMap))
+
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(resultMap))
+	for k := range resultMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		val, err := goToStarlarkValue(resultMap[key])
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert result field %s: %w", key, err)
+		}
+		members[key] = val
+	}
+
+	// Create a branded struct with handler name as the type
+	// This allows scripts to check type(result) == "position_keeping.initiate_log.Result"
+	typeName := handlerName + ".Result"
+	return starlarkstruct.FromStringDict(starlark.String(typeName), members), nil
+}
+
+// goToStarlarkValue converts a Go value to a Starlark value.
+//
+//nolint:gocyclo // Type switch for Go values requires checking multiple types
+func goToStarlarkValue(v any) (starlark.Value, error) {
+	if v == nil {
+		return starlark.None, nil
+	}
+
+	switch val := v.(type) {
+	case string:
+		return starlark.String(val), nil
+	case int:
+		return starlark.MakeInt(val), nil
+	case int64:
+		return starlark.MakeInt64(val), nil
+	case int32:
+		return starlark.MakeInt(int(val)), nil
+	case uint32:
+		return starlark.MakeUint(uint(val)), nil
+	case float64:
+		return starlark.Float(val), nil
+	case bool:
+		return starlark.Bool(val), nil
+	case decimal.Decimal:
+		// Convert Decimal to string for lossless representation in Starlark
+		// Starlark scripts should use Decimal() builtin to work with these values
+		return starlark.String(val.String()), nil
+	case []any:
+		return goSliceToStarlark(val)
+	case []string:
+		return goStringSliceToStarlark(val), nil
+	case map[string]any:
+		return goMapToStarlark(val)
+	default:
+		// Try to convert to string as fallback
+		return starlark.String(fmt.Sprintf("%v", v)), nil
+	}
+}
+
+// goSliceToStarlark converts a Go []any to a Starlark List.
+func goSliceToStarlark(val []any) (*starlark.List, error) {
+	list := make([]starlark.Value, len(val))
+	for i, elem := range val {
+		converted, err := goToStarlarkValue(elem)
+		if err != nil {
+			return nil, err
+		}
+		list[i] = converted
+	}
+	return starlark.NewList(list), nil
+}
+
+// goStringSliceToStarlark converts a Go []string to a Starlark List.
+func goStringSliceToStarlark(val []string) *starlark.List {
+	list := make([]starlark.Value, len(val))
+	for i, elem := range val {
+		list[i] = starlark.String(elem)
+	}
+	return starlark.NewList(list)
+}
+
+// goMapToStarlark converts a Go map[string]any to a Starlark Dict.
+func goMapToStarlark(val map[string]any) (*starlark.Dict, error) {
+	dict := starlark.NewDict(len(val))
+	for k, v := range val {
+		converted, err := goToStarlarkValue(v)
+		if err != nil {
+			return nil, err
+		}
+		if err := dict.SetKey(starlark.String(k), converted); err != nil {
+			return nil, err
+		}
+	}
+	return dict, nil
+}
+
+// SetStarlarkContext is the exported version for external packages to set context.
+func SetStarlarkContext(thread *starlark.Thread, ctx *saga.StarlarkContext) {
+	setStarlarkContext(thread, ctx)
+}
+
+// GetStarlarkContext is the exported version for external packages to get context.
+func GetStarlarkContext(thread *starlark.Thread) *saga.StarlarkContext {
+	return getStarlarkContext(thread)
+}

--- a/shared/pkg/saga/schema/service_modules_test.go
+++ b/shared/pkg/saga/schema/service_modules_test.go
@@ -1,0 +1,848 @@
+package schema
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+	"go.starlark.net/syntax"
+)
+
+// TestParseHandlerTree tests the tree building from handler names.
+func TestParseHandlerTree(t *testing.T) {
+	tests := []struct {
+		name       string
+		handlers   []string
+		wantNodes  []string // Expected top-level service names
+		wantLeaves map[string][]string
+	}{
+		{
+			name:       "empty",
+			handlers:   []string{},
+			wantNodes:  []string{},
+			wantLeaves: map[string][]string{},
+		},
+		{
+			name:       "single 2-part handler",
+			handlers:   []string{"repository.save"},
+			wantNodes:  []string{"repository"},
+			wantLeaves: map[string][]string{"repository": {"save"}},
+		},
+		{
+			name: "multiple 2-part handlers same service",
+			handlers: []string{
+				"notification.send",
+				"notification.cancel",
+			},
+			wantNodes:  []string{"notification"},
+			wantLeaves: map[string][]string{"notification": {"cancel", "send"}},
+		},
+		{
+			name: "3-part handlers",
+			handlers: []string{
+				"current_account.position_keeping.initiate_log",
+				"current_account.position_keeping.cancel_log",
+			},
+			wantNodes: []string{"current_account"},
+			// position_keeping is a branch, initiate_log and cancel_log are leaves
+			wantLeaves: map[string][]string{"current_account.position_keeping": {"cancel_log", "initiate_log"}},
+		},
+		{
+			name: "mixed 2 and 3 part handlers",
+			handlers: []string{
+				"repository.save",
+				"position_keeping.initiate_log",
+				"position_keeping.cancel_log",
+			},
+			wantNodes: []string{"position_keeping", "repository"},
+			wantLeaves: map[string][]string{
+				"repository":       {"save"},
+				"position_keeping": {"cancel_log", "initiate_log"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tree := parseHandlerTree(tt.handlers)
+
+			// Check top-level nodes
+			var topLevelNames []string
+			for name := range tree.children {
+				topLevelNames = append(topLevelNames, name)
+			}
+			assert.ElementsMatch(t, tt.wantNodes, topLevelNames)
+
+			// Check leaves at each path
+			for path, wantLeaves := range tt.wantLeaves {
+				node := tree.findNode(path)
+				require.NotNil(t, node, "node at path %q should exist", path)
+
+				var leafNames []string
+				for name := range node.handlers {
+					leafNames = append(leafNames, name)
+				}
+				assert.ElementsMatch(t, wantLeaves, leafNames, "leaves at %q", path)
+			}
+		})
+	}
+}
+
+// TestParseHandlerTree_ConflictDetection tests that conflicts are detected.
+func TestParseHandlerTree_ConflictDetection(t *testing.T) {
+	// This tests that a name cannot be both a branch and a leaf.
+	// For example: "foo.bar" and "foo.bar.baz" would conflict because
+	// "bar" would need to be both a handler and a namespace.
+
+	handlers := []string{
+		"foo.bar",     // "bar" is a handler under "foo"
+		"foo.bar.baz", // "bar" would need to be a namespace containing "baz"
+	}
+
+	tree := parseHandlerTree(handlers)
+	err := tree.validate()
+	assert.Error(t, err, "should detect naming conflict")
+	assert.Contains(t, err.Error(), "conflict")
+}
+
+// TestBuildServiceModules tests the module building from handler registry and schema.
+func TestBuildServiceModules(t *testing.T) {
+	// Create a minimal handler registry
+	registry := saga.NewDomainHandlerRegistry()
+	_ = registry.Register("position_keeping.initiate_log", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return map[string]any{"log_id": "test-123", "status": "INITIATED"}, nil
+	})
+	_ = registry.Register("repository.save", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return map[string]any{"entity_id": "saved-456", "status": "SAVED"}, nil
+	})
+
+	// Create schema registry
+	schemaRegistry := NewRegistry()
+	err := schemaRegistry.LoadFromYAML([]byte(`
+service: test
+version: "1.0"
+handlers:
+  position_keeping.initiate_log:
+    description: "Test handler"
+    params:
+      position_id:
+        type: string
+        required: true
+      amount:
+        type: Decimal
+        required: true
+      direction:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+    returns:
+      log_id:
+        type: string
+      status:
+        type: string
+  repository.save:
+    description: "Save entity"
+    params:
+      entity_type:
+        type: string
+        required: true
+      entity:
+        type: map
+        required: true
+    returns:
+      entity_id:
+        type: string
+      status:
+        type: string
+`))
+	require.NoError(t, err)
+
+	modules, err := BuildServiceModules(registry, schemaRegistry)
+	require.NoError(t, err)
+
+	// Should have top-level modules
+	assert.Contains(t, modules, "position_keeping")
+	assert.Contains(t, modules, "repository")
+
+	// position_keeping should be a struct
+	pkModule, ok := modules["position_keeping"].(*starlarkstruct.Struct)
+	require.True(t, ok, "position_keeping should be a struct")
+
+	// initiate_log should be a builtin function
+	initLogVal, err := pkModule.Attr("initiate_log")
+	require.NoError(t, err)
+	_, ok = initLogVal.(*starlark.Builtin)
+	assert.True(t, ok, "initiate_log should be a builtin")
+
+	// repository.save should be accessible
+	repoModule, ok := modules["repository"].(*starlarkstruct.Struct)
+	require.True(t, ok, "repository should be a struct")
+
+	saveVal, err := repoModule.Attr("save")
+	require.NoError(t, err)
+	_, ok = saveVal.(*starlark.Builtin)
+	assert.True(t, ok, "save should be a builtin")
+}
+
+// TestBuildServiceModules_NestedModules tests 3-level nested modules.
+func TestBuildServiceModules_NestedModules(t *testing.T) {
+	registry := saga.NewDomainHandlerRegistry()
+	_ = registry.Register("current_account.position_keeping.initiate_log", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return map[string]any{"log_id": "test-123"}, nil
+	})
+	_ = registry.Register("current_account.position_keeping.cancel_log", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return map[string]any{"log_id": "test-123"}, nil
+	})
+
+	schemaRegistry := NewRegistry()
+	err := schemaRegistry.LoadFromYAML([]byte(`
+service: current_account
+version: "1.0"
+handlers:
+  current_account.position_keeping.initiate_log:
+    description: "Initiate log"
+    params:
+      position_id:
+        type: string
+        required: true
+    returns:
+      log_id:
+        type: string
+  current_account.position_keeping.cancel_log:
+    description: "Cancel log"
+    params:
+      log_id:
+        type: string
+        required: true
+    returns:
+      log_id:
+        type: string
+`))
+	require.NoError(t, err)
+
+	modules, err := BuildServiceModules(registry, schemaRegistry)
+	require.NoError(t, err)
+
+	// Should have current_account at top level
+	assert.Contains(t, modules, "current_account")
+
+	caModule, ok := modules["current_account"].(*starlarkstruct.Struct)
+	require.True(t, ok, "current_account should be a struct")
+
+	// position_keeping should be a nested struct
+	pkVal, err := caModule.Attr("position_keeping")
+	require.NoError(t, err)
+	pkModule, ok := pkVal.(*starlarkstruct.Struct)
+	require.True(t, ok, "position_keeping should be a struct")
+
+	// initiate_log should be a builtin
+	initLogVal, err := pkModule.Attr("initiate_log")
+	require.NoError(t, err)
+	_, ok = initLogVal.(*starlark.Builtin)
+	assert.True(t, ok, "initiate_log should be a builtin")
+}
+
+// TestWrapHandler_ParameterValidation tests that wrapHandler validates params against schema.
+func TestWrapHandler_ParameterValidation(t *testing.T) {
+	handlerCalled := false
+	handler := func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		handlerCalled = true
+		return map[string]any{"result": "success"}, nil
+	}
+
+	handlerDef := &HandlerDef{
+		Description: "Test handler",
+		Params: map[string]*FieldDef{
+			"required_param": {Type: TypeString, Required: true},
+			"optional_param": {Type: TypeString, Required: false},
+			"direction":      {Type: TypeEnum, Required: true, Values: []string{"DEBIT", "CREDIT"}},
+		},
+		Returns: map[string]*FieldDef{
+			"result": {Type: TypeString},
+		},
+	}
+
+	// Create a StarlarkContext
+	starlarkCtx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		CorrelationID:   uuid.New(),
+		KnowledgeAt:     time.Now(),
+		Logger:          slog.Default(),
+	}
+
+	builtin := wrapHandler("test.handler", handler, handlerDef)
+
+	t.Run("valid params", func(t *testing.T) {
+		handlerCalled = false
+		thread := &starlark.Thread{Name: "test"}
+		setStarlarkContext(thread, starlarkCtx)
+
+		kwargs := []starlark.Tuple{
+			{starlark.String("required_param"), starlark.String("value")},
+			{starlark.String("direction"), starlark.String("DEBIT")},
+		}
+		_, err := builtin.CallInternal(thread, nil, kwargs)
+		require.NoError(t, err)
+		assert.True(t, handlerCalled, "handler should have been called")
+	})
+
+	t.Run("missing required param", func(t *testing.T) {
+		handlerCalled = false
+		thread := &starlark.Thread{Name: "test"}
+		setStarlarkContext(thread, starlarkCtx)
+
+		kwargs := []starlark.Tuple{
+			{starlark.String("direction"), starlark.String("DEBIT")},
+			// missing required_param
+		}
+		_, err := builtin.CallInternal(thread, nil, kwargs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "required_param")
+		assert.False(t, handlerCalled, "handler should not have been called")
+	})
+
+	t.Run("invalid enum value", func(t *testing.T) {
+		handlerCalled = false
+		thread := &starlark.Thread{Name: "test"}
+		setStarlarkContext(thread, starlarkCtx)
+
+		kwargs := []starlark.Tuple{
+			{starlark.String("required_param"), starlark.String("value")},
+			{starlark.String("direction"), starlark.String("INVALID")},
+		}
+		_, err := builtin.CallInternal(thread, nil, kwargs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "INVALID")
+		assert.False(t, handlerCalled, "handler should not have been called")
+	})
+}
+
+// TestStarlarkContextThreading tests that StarlarkContext is properly passed via thread-local.
+func TestStarlarkContextThreading(t *testing.T) {
+	sagaExecID := uuid.New()
+	correlationID := uuid.New()
+
+	starlarkCtx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: sagaExecID,
+		CorrelationID:   correlationID,
+		KnowledgeAt:     time.Now(),
+		Logger:          slog.Default(),
+	}
+
+	thread := &starlark.Thread{Name: "test"}
+	setStarlarkContext(thread, starlarkCtx)
+
+	// Should be able to retrieve it
+	retrieved := getStarlarkContext(thread)
+	require.NotNil(t, retrieved)
+	assert.Equal(t, sagaExecID, retrieved.SagaExecutionID)
+	assert.Equal(t, correlationID, retrieved.CorrelationID)
+}
+
+// TestStarlarkContextThreading_NilContext tests behavior when no context is set.
+func TestStarlarkContextThreading_NilContext(t *testing.T) {
+	thread := &starlark.Thread{Name: "test"}
+
+	retrieved := getStarlarkContext(thread)
+	assert.Nil(t, retrieved)
+}
+
+// TestWrapHandler_DecimalConversion tests Decimal type conversion from Starlark.
+func TestWrapHandler_DecimalConversion(t *testing.T) {
+	var receivedAmount decimal.Decimal
+	handler := func(_ *saga.StarlarkContext, params map[string]any) (any, error) {
+		if amt, ok := params["amount"]; ok {
+			receivedAmount = amt.(decimal.Decimal)
+		}
+		return map[string]any{"result": "success"}, nil
+	}
+
+	handlerDef := &HandlerDef{
+		Params: map[string]*FieldDef{
+			"amount": {Type: TypeDecimal, Required: true},
+		},
+		Returns: map[string]*FieldDef{
+			"result": {Type: TypeString},
+		},
+	}
+
+	starlarkCtx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          slog.Default(),
+	}
+
+	builtin := wrapHandler("test.handler", handler, handlerDef)
+	thread := &starlark.Thread{Name: "test"}
+	setStarlarkContext(thread, starlarkCtx)
+
+	t.Run("string to Decimal", func(t *testing.T) {
+		kwargs := []starlark.Tuple{
+			{starlark.String("amount"), starlark.String("123.45")},
+		}
+		_, err := builtin.CallInternal(thread, nil, kwargs)
+		require.NoError(t, err)
+		assert.Equal(t, "123.45", receivedAmount.String())
+	})
+
+	t.Run("int to Decimal", func(t *testing.T) {
+		kwargs := []starlark.Tuple{
+			{starlark.String("amount"), starlark.MakeInt(100)},
+		}
+		_, err := builtin.CallInternal(thread, nil, kwargs)
+		require.NoError(t, err)
+		assert.Equal(t, "100", receivedAmount.String())
+	})
+
+	t.Run("float to Decimal", func(t *testing.T) {
+		kwargs := []starlark.Tuple{
+			{starlark.String("amount"), starlark.Float(99.99)},
+		}
+		_, err := builtin.CallInternal(thread, nil, kwargs)
+		require.NoError(t, err)
+		// Float conversion might have precision differences
+		assert.True(t, receivedAmount.GreaterThan(decimal.NewFromFloat(99.98)))
+		assert.True(t, receivedAmount.LessThan(decimal.NewFromFloat(100)))
+	})
+}
+
+// TestWrapHandler_ReturnValueConversion tests that Go return values are converted to Starlark.
+func TestWrapHandler_ReturnValueConversion(t *testing.T) {
+	handler := func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return map[string]any{
+			"string_val":  "hello",
+			"int_val":     int64(42),
+			"decimal_val": decimal.NewFromFloat(123.45),
+			"bool_val":    true,
+		}, nil
+	}
+
+	handlerDef := &HandlerDef{
+		Params:  map[string]*FieldDef{},
+		Returns: map[string]*FieldDef{},
+	}
+
+	starlarkCtx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          slog.Default(),
+	}
+
+	builtin := wrapHandler("test.handler", handler, handlerDef)
+	thread := &starlark.Thread{Name: "test"}
+	setStarlarkContext(thread, starlarkCtx)
+
+	result, err := builtin.CallInternal(thread, nil, nil)
+	require.NoError(t, err)
+
+	// Result should be a struct
+	resultStruct, ok := result.(*starlarkstruct.Struct)
+	require.True(t, ok, "result should be a struct, got %T", result)
+
+	// Check values
+	strVal, err := resultStruct.Attr("string_val")
+	require.NoError(t, err)
+	assert.Equal(t, starlark.String("hello"), strVal)
+
+	intVal, err := resultStruct.Attr("int_val")
+	require.NoError(t, err)
+	assert.Equal(t, starlark.MakeInt64(42), intVal)
+
+	boolVal, err := resultStruct.Attr("bool_val")
+	require.NoError(t, err)
+	assert.Equal(t, starlark.Bool(true), boolVal)
+}
+
+// TestIntegration_StarlarkExecution tests end-to-end execution with a real Starlark script.
+func TestIntegration_StarlarkExecution(t *testing.T) {
+	// Set up handler registry
+	registry := saga.NewDomainHandlerRegistry()
+	_ = registry.Register("position_keeping.initiate_log", func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		return map[string]any{
+			"log_id":   ctx.NewUUID(ctx.SagaExecutionID, "position_log").String(),
+			"status":   "INITIATED",
+			"position": params["position_id"],
+		}, nil
+	})
+
+	// Set up schema registry
+	schemaRegistry := NewRegistry()
+	err := schemaRegistry.LoadFromYAML([]byte(`
+service: test
+version: "1.0"
+handlers:
+  position_keeping.initiate_log:
+    description: "Initiate position log"
+    params:
+      position_id:
+        type: string
+        required: true
+      amount:
+        type: Decimal
+        required: true
+      direction:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+    returns:
+      log_id:
+        type: string
+      status:
+        type: string
+      position:
+        type: string
+`))
+	require.NoError(t, err)
+
+	// Build service modules
+	modules, err := BuildServiceModules(registry, schemaRegistry)
+	require.NoError(t, err)
+
+	// Create Starlark context
+	starlarkCtx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		CorrelationID:   uuid.New(),
+		KnowledgeAt:     time.Now(),
+		Logger:          slog.Default(),
+	}
+
+	// Create thread with context
+	thread := &starlark.Thread{
+		Name: "test_saga",
+	}
+	setStarlarkContext(thread, starlarkCtx)
+
+	// Build predeclared with our service modules
+	predeclared := starlark.StringDict{
+		"True":  starlark.True,
+		"False": starlark.False,
+		"None":  starlark.None,
+	}
+	for name, module := range modules {
+		predeclared[name] = module
+	}
+
+	// Execute a simple Starlark script that calls our handler
+	script := `
+result = position_keeping.initiate_log(
+    position_id="pos-123",
+    amount="100.00",
+    direction="DEBIT"
+)
+output_log_id = result.log_id
+output_status = result.status
+`
+
+	globals, err := starlark.ExecFileOptions(&syntax.FileOptions{}, thread, "test.star", script, predeclared)
+	require.NoError(t, err)
+
+	// Check outputs
+	logID, ok := globals["output_log_id"]
+	require.True(t, ok, "output_log_id should be in globals")
+	assert.NotEmpty(t, logID.String())
+
+	status, ok := globals["output_status"]
+	require.True(t, ok, "output_status should be in globals")
+	assert.Equal(t, `"INITIATED"`, status.String())
+}
+
+// TestHandlerTree_FindNode tests the findNode helper.
+func TestHandlerTree_FindNode(t *testing.T) {
+	tree := parseHandlerTree([]string{
+		"service.domain.action",
+		"service.domain.other_action",
+		"simple.handler",
+	})
+
+	t.Run("finds top-level node", func(t *testing.T) {
+		node := tree.findNode("service")
+		require.NotNil(t, node)
+	})
+
+	t.Run("finds nested node", func(t *testing.T) {
+		node := tree.findNode("service.domain")
+		require.NotNil(t, node)
+		assert.Contains(t, node.handlers, "action")
+		assert.Contains(t, node.handlers, "other_action")
+	})
+
+	t.Run("returns nil for non-existent", func(t *testing.T) {
+		node := tree.findNode("nonexistent")
+		assert.Nil(t, node)
+	})
+
+	t.Run("returns nil for non-existent nested", func(t *testing.T) {
+		node := tree.findNode("service.nonexistent")
+		assert.Nil(t, node)
+	})
+}
+
+// TestBuildServiceModules_MissingHandler tests error when registry is missing a handler.
+func TestBuildServiceModules_MissingHandler(t *testing.T) {
+	// Empty handler registry
+	registry := saga.NewDomainHandlerRegistry()
+
+	// Schema registry with a handler
+	schemaRegistry := NewRegistry()
+	err := schemaRegistry.LoadFromYAML([]byte(`
+service: test
+version: "1.0"
+handlers:
+  test.missing:
+    description: "This handler is not in registry"
+    params: {}
+    returns: {}
+`))
+	require.NoError(t, err)
+
+	_, err = BuildServiceModules(registry, schemaRegistry)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "test.missing")
+}
+
+// TestBuildServiceModules_NoSchema tests handler without schema definition.
+func TestBuildServiceModules_NoSchema(t *testing.T) {
+	// Handler registry with a handler
+	registry := saga.NewDomainHandlerRegistry()
+	_ = registry.Register("test.orphan", func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	})
+
+	// Empty schema registry
+	schemaRegistry := NewRegistry()
+
+	_, err := BuildServiceModules(registry, schemaRegistry)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "test.orphan")
+}
+
+// TestWrapHandler_PositionalArgsRejected tests that positional args are rejected.
+func TestWrapHandler_PositionalArgsRejected(t *testing.T) {
+	handler := func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	}
+
+	handlerDef := &HandlerDef{
+		Params:  map[string]*FieldDef{},
+		Returns: map[string]*FieldDef{},
+	}
+
+	starlarkCtx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          slog.Default(),
+	}
+
+	builtin := wrapHandler("test.handler", handler, handlerDef)
+	thread := &starlark.Thread{Name: "test"}
+	setStarlarkContext(thread, starlarkCtx)
+
+	// Try calling with positional arguments
+	args := starlark.Tuple{starlark.String("value")}
+	_, err := builtin.CallInternal(thread, args, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "positional")
+}
+
+// TestWrapHandler_MissingContext tests behavior when context is not set.
+func TestWrapHandler_MissingContext(t *testing.T) {
+	handler := func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	}
+
+	handlerDef := &HandlerDef{
+		Params:  map[string]*FieldDef{},
+		Returns: map[string]*FieldDef{},
+	}
+
+	builtin := wrapHandler("test.handler", handler, handlerDef)
+	thread := &starlark.Thread{Name: "test"}
+	// Not setting StarlarkContext
+
+	_, err := builtin.CallInternal(thread, nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingStarlarkContext)
+}
+
+// TestWrapHandler_HandlerError tests that handler errors are propagated.
+func TestWrapHandler_HandlerError(t *testing.T) {
+	expectedErr := errors.New("handler failed")
+	handler := func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, expectedErr
+	}
+
+	handlerDef := &HandlerDef{
+		Params:  map[string]*FieldDef{},
+		Returns: map[string]*FieldDef{},
+	}
+
+	starlarkCtx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          slog.Default(),
+	}
+
+	builtin := wrapHandler("test.handler", handler, handlerDef)
+	thread := &starlark.Thread{Name: "test"}
+	setStarlarkContext(thread, starlarkCtx)
+
+	_, err := builtin.CallInternal(thread, nil, nil)
+	require.Error(t, err)
+	assert.Equal(t, expectedErr, err)
+}
+
+// TestWrapHandler_NilReturn tests that nil return is handled correctly.
+func TestWrapHandler_NilReturn(t *testing.T) {
+	handler := func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+		return nil, nil
+	}
+
+	handlerDef := &HandlerDef{
+		Params:  map[string]*FieldDef{},
+		Returns: map[string]*FieldDef{},
+	}
+
+	starlarkCtx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          slog.Default(),
+	}
+
+	builtin := wrapHandler("test.handler", handler, handlerDef)
+	thread := &starlark.Thread{Name: "test"}
+	setStarlarkContext(thread, starlarkCtx)
+
+	result, err := builtin.CallInternal(thread, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, starlark.None, result)
+}
+
+// TestWrapHandler_ArrayParameter tests array parameter handling.
+func TestWrapHandler_ArrayParameter(t *testing.T) {
+	var receivedEntries []any
+	handler := func(_ *saga.StarlarkContext, params map[string]any) (any, error) {
+		if entries, ok := params["entries"]; ok {
+			receivedEntries = entries.([]any)
+		}
+		return map[string]any{"count": len(receivedEntries)}, nil
+	}
+
+	handlerDef := &HandlerDef{
+		Params: map[string]*FieldDef{
+			"entries": {Type: TypeArray, Required: true},
+		},
+		Returns: map[string]*FieldDef{
+			"count": {Type: TypeInt32},
+		},
+	}
+
+	starlarkCtx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          slog.Default(),
+	}
+
+	builtin := wrapHandler("test.handler", handler, handlerDef)
+	thread := &starlark.Thread{Name: "test"}
+	setStarlarkContext(thread, starlarkCtx)
+
+	// Create a Starlark list
+	entriesList := starlark.NewList([]starlark.Value{
+		starlark.String("entry1"),
+		starlark.String("entry2"),
+		starlark.String("entry3"),
+	})
+
+	kwargs := []starlark.Tuple{
+		{starlark.String("entries"), entriesList},
+	}
+	_, err := builtin.CallInternal(thread, nil, kwargs)
+	require.NoError(t, err)
+	assert.Len(t, receivedEntries, 3)
+}
+
+// TestWrapHandler_MapParameter tests map parameter handling.
+func TestWrapHandler_MapParameter(t *testing.T) {
+	var receivedEntity map[string]any
+	handler := func(_ *saga.StarlarkContext, params map[string]any) (any, error) {
+		if entity, ok := params["entity"]; ok {
+			receivedEntity = entity.(map[string]any)
+		}
+		return map[string]any{"status": "saved"}, nil
+	}
+
+	handlerDef := &HandlerDef{
+		Params: map[string]*FieldDef{
+			"entity": {Type: TypeMap, Required: true},
+		},
+		Returns: map[string]*FieldDef{
+			"status": {Type: TypeString},
+		},
+	}
+
+	starlarkCtx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          slog.Default(),
+	}
+
+	builtin := wrapHandler("test.handler", handler, handlerDef)
+	thread := &starlark.Thread{Name: "test"}
+	setStarlarkContext(thread, starlarkCtx)
+
+	// Create a Starlark dict
+	entityDict := starlark.NewDict(2)
+	_ = entityDict.SetKey(starlark.String("id"), starlark.String("123"))
+	_ = entityDict.SetKey(starlark.String("name"), starlark.String("Test"))
+
+	kwargs := []starlark.Tuple{
+		{starlark.String("entity"), entityDict},
+	}
+	_, err := builtin.CallInternal(thread, nil, kwargs)
+	require.NoError(t, err)
+	assert.Equal(t, "123", receivedEntity["id"])
+	assert.Equal(t, "Test", receivedEntity["name"])
+}
+
+// TestExportedContextFunctions tests the exported context functions.
+func TestExportedContextFunctions(t *testing.T) {
+	starlarkCtx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		Logger:          slog.Default(),
+	}
+
+	thread := &starlark.Thread{Name: "test"}
+
+	// Use exported functions
+	SetStarlarkContext(thread, starlarkCtx)
+	retrieved := GetStarlarkContext(thread)
+
+	require.NotNil(t, retrieved)
+	assert.Equal(t, starlarkCtx.SagaExecutionID, retrieved.SagaExecutionID)
+}
+
+// TestParseHandlerTree_SinglePart tests that single-part names are ignored.
+func TestParseHandlerTree_SinglePart(t *testing.T) {
+	tree := parseHandlerTree([]string{
+		"invalid", // Single part - should be ignored
+		"valid.handler",
+	})
+
+	// Should only have "valid" as top-level
+	assert.Len(t, tree.children, 1)
+	assert.Contains(t, tree.children, "valid")
+}


### PR DESCRIPTION
## Summary

Implements typed service clients that replace magic string handler references with direct method calls. This enables:

**Before:**
```starlark
invoke_handler(handler="position_keeping.initiate_log", params={...})
```

**After:**
```starlark
position_keeping.initiate_log(position_id="123", amount="100.00", direction="DEBIT")
```

## Changes Made

- **`parseHandlerTree`**: Builds hierarchical tree from handler names (e.g., `service.domain.action`)
- **`BuildServiceModules`**: Creates `starlarkstruct` hierarchies from handler registry and schema
- **`wrapHandler`**: Wraps Go handlers as Starlark builtins with parameter validation
- **StarlarkContext threading**: Thread-local storage for passing context through execution

## Technical Details

- Parameter validation against schema before handler execution
- Decimal type coercion from string/int/float
- Branded return structs (`handler.Result`) for type-safe field access
- Conflict detection for naming issues (name used as both handler and namespace)
- Full type conversion between Go and Starlark values

## Test Plan

- [x] Unit tests for `parseHandlerTree` with various handler name formats
- [x] Unit tests for `BuildServiceModules` including nested modules
- [x] Unit tests for `wrapHandler` parameter validation (required, enum, types)
- [x] Unit tests for StarlarkContext threading (set/get)
- [x] Unit tests for Decimal type conversion
- [x] Unit tests for return value conversion to Starlark
- [x] Integration test with real Starlark script execution
- [x] Edge case tests (missing handler, missing schema, naming conflicts)
- [x] All linter checks passing

## Related Tasks

Task Master: starlark-typed-clients.3 - Design and implement Starlark service module structure