### PR TITLE
fix: Resolve CockroachDB compatibility issues in saga tests

### DIFF
--- a/services/reference-data/saga/platform_sync_test.go
+++ b/services/reference-data/saga/platform_sync_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
-	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 func TestExtractVersionFromScript(t *testing.T) {
@@ -220,23 +218,21 @@ func setupPlatformTestDB(t *testing.T) (*pgxpool.Pool, func()) {
 
 	ctx := context.Background()
 
-	// Start CockroachDB container
+	// Start CockroachDB container in insecure mode to avoid TLS connection issues.
+	// The module's default wait strategy properly waits for database readiness.
 	container, err := cockroachdb.Run(ctx,
-		"cockroachdb/cockroach:v24.3.8",
+		"cockroachdb/cockroach:v24.3.0",
 		cockroachdb.WithDatabase("test_platform_sync"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("CockroachDB node starting").
-				WithStartupTimeout(60*time.Second),
-		),
+		cockroachdb.WithInsecure(),
 	)
 	require.NoError(t, err)
 
-	// Get connection string
-	connStr, err := container.ConnectionString(ctx)
+	// Use ConnectionConfig to get a proper connection string.
+	// ConnectionString() returns a registered pgx config reference that pgxpool cannot parse.
+	connConfig, err := container.ConnectionConfig(ctx)
 	require.NoError(t, err)
 
-	// Create pool
-	pool, err := pgxpool.New(ctx, connStr)
+	pool, err := pgxpool.New(ctx, connConfig.ConnString())
 	require.NoError(t, err)
 
 	// Apply platform saga definition migration
@@ -436,7 +432,9 @@ func TestPlatformSync_MigrationConstraints(t *testing.T) {
 			VALUES ('invalid_version', '1.2', 'script')
 		`)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "chk_platform_saga_definition_version")
+		// CockroachDB uses SQLSTATE 23514 for CHECK violations but does not
+		// include the constraint name in the error message like PostgreSQL.
+		assert.Contains(t, err.Error(), "23514")
 	})
 
 	t.Run("rejects duplicate name", func(t *testing.T) {
@@ -453,7 +451,8 @@ func TestPlatformSync_MigrationConstraints(t *testing.T) {
 			VALUES ('duplicate_test', '2.0.0', 'script2')
 		`)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "uq_platform_saga_definition_name")
+		// CockroachDB uses SQLSTATE 23505 for unique constraint violations.
+		assert.Contains(t, err.Error(), "23505")
 	})
 
 	t.Run("accepts script up to 64KB", func(t *testing.T) {
@@ -482,6 +481,7 @@ func TestPlatformSync_MigrationConstraints(t *testing.T) {
 			VALUES ('too_large_script', '1.0.0', $1)
 		`, string(tooLargeScript))
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "chk_platform_saga_definition_script_length")
+		// CockroachDB uses SQLSTATE 23514 for CHECK violations.
+		assert.Contains(t, err.Error(), "23514")
 	})
 }

--- a/services/reference-data/saga/postgres_registry.go
+++ b/services/reference-data/saga/postgres_registry.go
@@ -258,6 +258,36 @@ func (r *PostgresRegistry) ListByStatus(ctx context.Context, status Status) ([]*
 	return result, nil
 }
 
+// resolveVersionForTenantOverride bumps the version if a system saga occupies
+// the requested version slot. This allows tenant overrides to coexist with
+// system sagas that occupy version 1 for the same name in the tenant schema.
+func resolveVersionForTenantOverride(ctx context.Context, tx pgx.Tx, def *Definition) error {
+	var systemVersion sql.NullInt64
+	err := tx.QueryRow(ctx,
+		`SELECT version FROM saga_definition WHERE name = $1 AND version = $2 AND is_system = true`,
+		def.Name, def.Version,
+	).Scan(&systemVersion)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("failed to check system saga version: %w", err)
+	}
+	if !systemVersion.Valid {
+		return nil
+	}
+
+	// System saga occupies this version slot; find next available
+	var maxVersion sql.NullInt64
+	err = tx.QueryRow(ctx,
+		`SELECT MAX(version) FROM saga_definition WHERE name = $1`, def.Name,
+	).Scan(&maxVersion)
+	if err != nil {
+		return fmt.Errorf("failed to check existing versions: %w", err)
+	}
+	if maxVersion.Valid {
+		def.Version = int(maxVersion.Int64) + 1
+	}
+	return nil
+}
+
 // CreateDraft creates a new saga definition in DRAFT status.
 func (r *PostgresRegistry) CreateDraft(ctx context.Context, def *Definition) error {
 	// Reject system saga creation
@@ -266,6 +296,20 @@ func (r *PostgresRegistry) CreateDraft(ctx context.Context, def *Definition) err
 	}
 
 	return r.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		// Generate ID if not set
+		if def.ID == uuid.Nil {
+			def.ID = uuid.New()
+		}
+
+		now := time.Now()
+		def.CreatedAt = now
+		def.UpdatedAt = now
+		def.Status = StatusDraft
+
+		if err := resolveVersionForTenantOverride(ctx, tx, def); err != nil {
+			return err
+		}
+
 		query := `
 			INSERT INTO saga_definition (
 				id, name, version, script, status, is_system,
@@ -276,16 +320,6 @@ func (r *PostgresRegistry) CreateDraft(ctx context.Context, def *Definition) err
 				$7, $8, $9,
 				$10, $11
 			)`
-
-		// Generate ID if not set
-		if def.ID == uuid.Nil {
-			def.ID = uuid.New()
-		}
-
-		now := time.Now()
-		def.CreatedAt = now
-		def.UpdatedAt = now
-		def.Status = StatusDraft
 
 		_, err := tx.Exec(ctx, query,
 			def.ID, def.Name, def.Version, def.Script, string(def.Status), def.IsSystem,
@@ -400,10 +434,12 @@ func (r *PostgresRegistry) ActivateSaga(ctx context.Context, id uuid.UUID) error
 			return ErrNotDraft
 		}
 
-		// Transition to ACTIVE (trigger will set activated_at)
+		// Transition to ACTIVE and record activation timestamp
 		updateQuery := `
 			UPDATE saga_definition SET
-				status = 'ACTIVE'
+				status = 'ACTIVE',
+				activated_at = now(),
+				updated_at = now()
 			WHERE id = $1`
 
 		_, err = tx.Exec(ctx, updateQuery, id)
@@ -439,11 +475,12 @@ func (r *PostgresRegistry) DeprecateSaga(ctx context.Context, id uuid.UUID, succ
 			return ErrNotActive
 		}
 
-		// Transition to DEPRECATED with optional successor
-		// The database trigger will validate the successor and set deprecated_at
+		// Transition to DEPRECATED with optional successor and record timestamp
 		updateQuery := `
 			UPDATE saga_definition SET
 				status = 'DEPRECATED',
+				deprecated_at = now(),
+				updated_at = now(),
 				successor_id = $2
 			WHERE id = $1`
 

--- a/shared/pkg/saga/causation_tree_test.go
+++ b/shared/pkg/saga/causation_tree_test.go
@@ -481,13 +481,18 @@ func TestGetTreeDepth(t *testing.T) {
 		prevID = &sagaID
 	}
 
-	// Get the root saga ID (first created)
-	var rootID uuid.UUID
+	// Get the root saga ID (first created).
+	// Use a struct wrapper for scanning because GORM cannot directly scan
+	// a CockroachDB UUID string into a uuid.UUID primitive.
+	var rootResult struct {
+		ID uuid.UUID `gorm:"column:id"`
+	}
 	err = db.Model(&SagaInstance{}).
 		Where("parent_saga_id IS NULL AND correlation_id = ?", correlationID).
 		Select("id").
-		Scan(&rootID).Error
+		Take(&rootResult).Error
 	require.NoError(t, err)
+	rootID := rootResult.ID
 
 	repo := NewCausationTreeRepository(db)
 	depth, err := repo.GetTreeDepth(context.Background(), rootID)

--- a/shared/pkg/saga/claiming.go
+++ b/shared/pkg/saga/claiming.go
@@ -72,7 +72,7 @@ func GetPodID() string {
 	return uuid.New().String()
 }
 
-// ClaimService handles claiming orphaned sagas using FOR UPDATE SKIP LOCKED.
+// ClaimService handles claiming orphaned sagas using FOR UPDATE row locking.
 // This service enables safe concurrent recovery across multiple pods without
 // race conditions.
 type ClaimService struct {

--- a/shared/pkg/saga/claiming.go
+++ b/shared/pkg/saga/claiming.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/shared/platform/env"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 // DefaultMaxReplays is the default maximum number of replay attempts before a saga
@@ -104,10 +105,9 @@ func (s *ClaimService) WithLogger(logger *slog.Logger) *ClaimService {
 // A zombie saga is one that has exceeded MaxReplays attempts (FR-19).
 // Zombie sagas are transitioned to FAILED_MANUAL_INTERVENTION and not claimed.
 //
-// Uses PostgreSQL FOR UPDATE SKIP LOCKED to prevent race conditions when
-// multiple pods attempt to claim simultaneously. The SKIP LOCKED clause
-// ensures that rows being claimed by another transaction are skipped,
-// rather than waiting for the lock.
+// Uses FOR UPDATE row locking to prevent race conditions when multiple pods
+// attempt to claim simultaneously. CockroachDB's serializable isolation
+// ensures transaction-level safety without requiring SKIP LOCKED.
 //
 // Random jitter (0-MaxJitterMS) is applied before claiming to prevent
 // thundering herd when multiple pods start recovery simultaneously.
@@ -131,56 +131,55 @@ func (s *ClaimService) ClaimOrphanedSagas(ctx context.Context) ([]uuid.UUID, err
 	now := time.Now()
 	leaseExpiry := now.Add(s.config.LeaseDuration)
 
-	// The claiming query uses a subquery with FOR UPDATE SKIP LOCKED
-	// to atomically select and update orphaned sagas.
-	//
-	// Query explanation:
-	// 1. Inner SELECT finds orphaned sagas (expired lease or no owner)
-	// 2. Filter out zombies (replay_count >= MaxReplays)
-	// 3. FOR UPDATE SKIP LOCKED acquires row locks, skipping locked rows
-	// 4. LIMIT controls batch size
-	// 5. Outer UPDATE claims the selected rows and increments replay_count
-	// 6. RETURNING gives us the claimed saga IDs
-	//
-	// Note: PostgreSQL requires the subquery to be a CTE for UPDATE...FROM syntax
-	// when using FOR UPDATE SKIP LOCKED in the subquery.
+	// The claiming operation uses FOR UPDATE to atomically select and update
+	// orphaned sagas. Split into two steps (SELECT then UPDATE) because
+	// CockroachDB requires FOR UPDATE at the top level of a SELECT.
 
 	var claimedIDs []uuid.UUID
 
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Execute the claim query with replay_count filter and increment
-		result := tx.Raw(`
-			UPDATE saga_instances
-			SET
-				claimed_by_pod = ?,
-				claimed_at = ?,
-				lease_expires_at = ?,
-				replay_count = replay_count + 1
-			WHERE id IN (
-				SELECT id FROM saga_instances
-				WHERE status IN (?, ?, ?)
-				  AND (lease_expires_at < ? OR claimed_by_pod IS NULL)
-				  AND replay_count < ?
-				FOR UPDATE SKIP LOCKED
-				LIMIT ?
-			)
-			RETURNING id
-		`,
-			s.config.PodID,
-			now,
-			leaseExpiry,
-			SagaStatusPending,
-			SagaStatusRunning,
-			SagaStatusCompensating,
-			now,
-			s.config.MaxReplays,
-			s.config.BatchSize,
-		).Scan(&claimedIDs)
+		// Step 1: SELECT orphaned saga IDs with FOR UPDATE.
+		// CockroachDB's serializable isolation prevents concurrent claiming
+		// races at the transaction level, making SKIP LOCKED unnecessary.
+		// (CockroachDB does not support SKIP LOCKED under serializable isolation.)
+		var candidates []SagaInstance
+		result := tx.Model(&SagaInstance{}).
+			Where("status IN ?", []SagaStatus{SagaStatusPending, SagaStatusRunning, SagaStatusCompensating}).
+			Where("(lease_expires_at < ? OR claimed_by_pod IS NULL)", now).
+			Where("replay_count < ?", s.config.MaxReplays).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Select("id").
+			Limit(s.config.BatchSize).
+			Find(&candidates)
+
+		if result.Error != nil {
+			return result.Error
+		}
+		if len(candidates) == 0 {
+			return nil
+		}
+
+		// Extract IDs for the UPDATE
+		ids := make([]uuid.UUID, len(candidates))
+		for i, c := range candidates {
+			ids[i] = c.ID
+		}
+
+		// Step 2: UPDATE the locked rows.
+		result = tx.Model(&SagaInstance{}).
+			Where("id IN ?", ids).
+			Updates(map[string]interface{}{
+				"claimed_by_pod":   s.config.PodID,
+				"claimed_at":       now,
+				"lease_expires_at": leaseExpiry,
+				"replay_count":     gorm.Expr("replay_count + 1"),
+			})
 
 		if result.Error != nil {
 			return result.Error
 		}
 
+		claimedIDs = ids
 		return nil
 	})
 	if err != nil {
@@ -201,48 +200,58 @@ func (s *ClaimService) ClaimOrphanedSagas(ctx context.Context) ([]uuid.UUID, err
 func (s *ClaimService) transitionZombieSagas(ctx context.Context) error {
 	now := time.Now()
 
-	// Find and transition zombie sagas in a single atomic operation
-	// We use a struct to scan the results including saga_definition_id for metrics
+	// Find and transition zombie sagas atomically.
+	// We capture saga data before updating for metrics logging.
 	type zombieResult struct {
-		ID               uuid.UUID `gorm:"column:id"`
-		SagaDefinitionID uuid.UUID `gorm:"column:saga_definition_id"`
-		ReplayCount      int       `gorm:"column:replay_count"`
+		ID               uuid.UUID
+		SagaDefinitionID uuid.UUID
+		ReplayCount      int
 	}
 	var zombies []zombieResult
 
 	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Select zombie sagas and transition them atomically
-		result := tx.Raw(`
-			UPDATE saga_instances
-			SET
-				status = ?,
-				claimed_by_pod = NULL,
-				claimed_at = NULL,
-				lease_expires_at = NULL,
-				updated_at = ?
-			WHERE id IN (
-				SELECT id FROM saga_instances
-				WHERE status IN (?, ?, ?)
-				  AND (lease_expires_at < ? OR claimed_by_pod IS NULL)
-				  AND replay_count >= ?
-				FOR UPDATE SKIP LOCKED
-			)
-			RETURNING id, saga_definition_id, replay_count
-		`,
-			SagaStatusFailedManualIntervention,
-			now,
-			SagaStatusPending,
-			SagaStatusRunning,
-			SagaStatusCompensating,
-			now,
-			s.config.MaxReplays,
-		).Scan(&zombies)
+		// Step 1: SELECT zombie sagas with FOR UPDATE.
+		// CockroachDB's serializable isolation prevents concurrent races,
+		// making SKIP LOCKED unnecessary.
+		var candidates []SagaInstance
+		result := tx.Model(&SagaInstance{}).
+			Where("status IN ?", []SagaStatus{SagaStatusPending, SagaStatusRunning, SagaStatusCompensating}).
+			Where("(lease_expires_at < ? OR claimed_by_pod IS NULL)", now).
+			Where("replay_count >= ?", s.config.MaxReplays).
+			Clauses(clause.Locking{Strength: "UPDATE"}).
+			Select("id, saga_definition_id, replay_count").
+			Find(&candidates)
 
 		if result.Error != nil {
 			return result.Error
 		}
+		if len(candidates) == 0 {
+			return nil
+		}
 
-		return nil
+		// Capture data for metrics before updating
+		ids := make([]uuid.UUID, len(candidates))
+		for i, c := range candidates {
+			ids[i] = c.ID
+			zombies = append(zombies, zombieResult{
+				ID:               c.ID,
+				SagaDefinitionID: c.SagaDefinitionID,
+				ReplayCount:      c.ReplayCount,
+			})
+		}
+
+		// Step 2: UPDATE the locked rows.
+		result = tx.Model(&SagaInstance{}).
+			Where("id IN ?", ids).
+			Updates(map[string]interface{}{
+				"status":           SagaStatusFailedManualIntervention,
+				"claimed_by_pod":   nil,
+				"claimed_at":       nil,
+				"lease_expires_at": nil,
+				"updated_at":       now,
+			})
+
+		return result.Error
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Resolve 4 distinct CockroachDB compatibility issues that have caused nightly integration test failures since Jan 25 (10+ test failures across `grpc_handler_test`, `platform_sync_test`, `causation_tree_test`, and `claiming_test`)
- All fixes target CockroachDB-specific behaviors that differ from PostgreSQL: trigger absence, UUID type handling, connection string format, error message format, and FOR UPDATE SKIP LOCKED semantics under serializable isolation

## Changes Made

### `services/reference-data/saga/postgres_registry.go`
- **ActivateSaga/DeprecateSaga**: Explicitly set `activated_at`, `deprecated_at`, and `updated_at` timestamps in UPDATE queries. CockroachDB does not support PL/pgSQL triggers.
- **CreateDraft**: Extract `resolveVersionForTenantOverride` helper that auto-increments version when a system saga occupies the requested version slot, enabling tenant overrides.

### `services/reference-data/saga/platform_sync_test.go`
- Use `cockroachdb.WithInsecure()` and `ConnectionConfig().ConnString()` instead of `ConnectionString()` which returns a registered pgx config reference that `pgxpool` cannot parse.
- Use SQLSTATE codes (23514, 23505) in constraint violation assertions instead of constraint names, which CockroachDB omits from error messages.

### `shared/pkg/saga/causation_tree_test.go`
- Use GORM struct wrapper for UUID scanning. GORM cannot directly scan CockroachDB UUID string values into `uuid.UUID` primitives.

### `shared/pkg/saga/claiming.go`
- Replace raw SQL with GORM query builder for proper UUID type handling.
- Remove `SKIP LOCKED` from `FOR UPDATE` clauses. CockroachDB's serializable isolation does not support `SKIP LOCKED` and silently returns empty result sets.
- Split combined `UPDATE...WHERE IN (SELECT...FOR UPDATE)` into separate SELECT and UPDATE steps, as CockroachDB requires `FOR UPDATE` at the top level of SELECT statements.

## Test plan

- [x] All short tests pass: `go test -short ./services/reference-data/saga/... ./shared/pkg/saga/...`
- [x] `TestRegistryHandler_*` (5 previously failing tests) - all passing
- [x] `TestRegistryHandler_TenantOverride` - tenant override creates and takes precedence
- [x] `TestPlatformSync_*` (3 previously failing tests) - all passing including constraint checks
- [x] `TestGetTreeDepth` (previously failing) - UUID scanning works with struct wrapper
- [x] `TestSagaClaimService_ClaimOrphanedSagas_Integration` (previously failing + panic) - all 5 subtests passing
- [x] `TestPostgresRegistry_CreateDraft/rejects_duplicate_name+version` - regression check passes