### PR TITLE
feat(saga): Update SagaSeeder for reference-based tenant provisioning

### DIFF
--- a/services/reference-data/saga/e2e_seeder_test.go
+++ b/services/reference-data/saga/e2e_seeder_test.go
@@ -1,0 +1,299 @@
+package saga
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2E_ProvisioningOverrideMigration exercises the full lifecycle:
+// 1. Sync platform defaults
+// 2. Provision a new tenant (seeder creates platform_ref entries)
+// 3. Verify platform fallback resolution works
+// 4. Override a saga with custom script
+// 5. Verify override takes priority over platform default
+// 6. Provision another tenant with old-style copies
+// 7. Migrate old tenant to platform refs
+func TestE2E_ProvisioningOverrideMigration(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Step 1: Sync platform defaults
+	platformSync := NewPlatformSync(pool)
+	err := platformSync.SyncPlatformDefaults(ctx)
+	require.NoError(t, err)
+
+	// Step 2: Provision tenant alpha (new-style with platform_ref)
+	alphaID := tenant.TenantID("alpha_corp")
+	alphaSchema := alphaID.SchemaName()
+	setupTenantSchemaForSeeder(t, pool, ctx, alphaSchema)
+	createSagaReferenceTable(t, pool, ctx, alphaSchema)
+
+	seeder := NewSeeder(pool)
+	err = seeder.SeedTenant(ctx, alphaID)
+	require.NoError(t, err)
+
+	// Step 3: Verify platform fallback resolution
+	alphaCtx := tenant.WithTenant(ctx, alphaID)
+	registry := NewPostgresRegistry(pool, nil)
+
+	activeDef, err := registry.GetActive(alphaCtx, "current_account_withdrawal")
+	require.NoError(t, err)
+	assert.True(t, activeDef.IsSystem, "should resolve system saga")
+	assert.True(t, activeDef.UsedPlatformFallback, "should use platform fallback")
+	assert.NotEmpty(t, activeDef.ResolvedScript, "resolved script should not be empty")
+	assert.NotNil(t, activeDef.PlatformRef, "platform_ref should be set")
+
+	// Step 4: Create tenant override
+	overrideSvc := NewOverrideService(pool, registry)
+
+	customScript := `# Version: 1.0.0
+# Alpha Corp custom withdrawal
+def posting_rules(ctx):
+    """Alpha Corp's specialized withdrawal saga."""
+    step(
+        action = "alpha_debit",
+        params = {"account": ctx.source, "amount": ctx.amount},
+    )
+    step(
+        action = "alpha_compliance_check",
+        params = {"amount": ctx.amount, "jurisdiction": "UK"},
+    )
+    step(
+        action = "alpha_credit",
+        params = {"account": ctx.target, "amount": ctx.amount},
+    )
+    return {"status": "completed", "compliance_checked": True}`
+
+	overrideResult, err := overrideSvc.CreateTenantOverride(alphaCtx, OverrideRequest{
+		SagaName:       "current_account_withdrawal",
+		Script:         customScript,
+		OverrideReason: "Alpha Corp requires UK compliance checks on all withdrawals",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, StatusDraft, overrideResult.OverrideDefinition.Status)
+	assert.NotEmpty(t, overrideResult.PlatformVersion)
+
+	// Activate the override
+	err = registry.ActivateSaga(alphaCtx, overrideResult.OverrideDefinition.ID)
+	require.NoError(t, err)
+
+	// Step 5: Verify override takes priority
+	activeDef, err = registry.GetActive(alphaCtx, "current_account_withdrawal")
+	require.NoError(t, err)
+	assert.False(t, activeDef.IsSystem, "should resolve tenant override, not system saga")
+	assert.False(t, activeDef.UsedPlatformFallback, "should use tenant script, not platform")
+	assert.Contains(t, activeDef.Script, "alpha_compliance_check",
+		"should use the custom override script")
+	assert.Equal(t, "Alpha Corp requires UK compliance checks on all withdrawals",
+		activeDef.OverrideReason)
+
+	// Non-overridden sagas should still use platform fallback
+	depositDef, err := registry.GetActive(alphaCtx, "current_account_deposit")
+	require.NoError(t, err)
+	assert.True(t, depositDef.IsSystem, "deposit should still use system saga")
+	assert.True(t, depositDef.UsedPlatformFallback, "deposit should use platform fallback")
+
+	// Step 6: Provision tenant beta (old-style with script copies)
+	betaID := tenant.TenantID("beta_corp")
+	betaSchema := betaID.SchemaName()
+	setupTenantSchemaForSeeder(t, pool, ctx, betaSchema)
+
+	// Insert old-style script-copied sagas
+	scripts, err := GetEmbeddedScripts()
+	require.NoError(t, err)
+
+	for _, meta := range PlatformDefaults() {
+		script := scripts[meta.Filename]
+		_, err := pool.Exec(ctx, `
+			INSERT INTO `+betaSchema+`.saga_definition (
+				name, version, script, status, is_system,
+				display_name, description, created_at, updated_at, activated_at
+			) VALUES ($1, 1, $2, 'ACTIVE', true, $3, $4, now(), now(), now())`,
+			meta.Name, script, meta.DisplayName, meta.Description)
+		require.NoError(t, err)
+	}
+
+	// Step 7: Migrate beta to platform refs
+	migrationResults, err := overrideSvc.MigrateToPlatformRef(ctx, betaID, false)
+	require.NoError(t, err)
+
+	migratedCount := 0
+	for _, r := range migrationResults {
+		if r.Action == "migrated" {
+			migratedCount++
+		}
+	}
+	assert.Equal(t, 3, migratedCount, "all 3 sagas should be migrated")
+
+	// Verify beta's sagas now use platform_ref
+	betaCtx := tenant.WithTenant(ctx, betaID)
+	betaWithdrawal, err := registry.GetActive(betaCtx, "current_account_withdrawal")
+	require.NoError(t, err)
+	assert.True(t, betaWithdrawal.IsSystem)
+	assert.NotNil(t, betaWithdrawal.PlatformRef, "should now have platform_ref")
+	assert.True(t, betaWithdrawal.UsedPlatformFallback, "should use platform fallback after migration")
+}
+
+// TestE2E_SeededSagasAreActive verifies that seeded sagas are immediately ACTIVE.
+func TestE2E_SeededSagasAreActive(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	platformSync := NewPlatformSync(pool)
+	err := platformSync.SyncPlatformDefaults(ctx)
+	require.NoError(t, err)
+
+	tenantID := tenant.TenantID("active_check")
+	schemaName := tenantID.SchemaName()
+	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
+
+	seeder := NewSeeder(pool)
+	err = seeder.SeedTenant(ctx, tenantID)
+	require.NoError(t, err)
+
+	// Verify all seeded sagas are ACTIVE
+	rows, err := pool.Query(ctx,
+		"SELECT name, status FROM "+schemaName+".saga_definition WHERE is_system = true ORDER BY name")
+	require.NoError(t, err)
+	defer rows.Close()
+
+	var count int
+	for rows.Next() {
+		var name, status string
+		err := rows.Scan(&name, &status)
+		require.NoError(t, err)
+		assert.Equal(t, "ACTIVE", status, "seeded saga %s should be ACTIVE", name)
+		count++
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, 3, count, "should have 3 seeded sagas")
+}
+
+// TestE2E_ReseedingDoesNotDuplicate verifies ON CONFLICT idempotency.
+func TestE2E_ReseedingDoesNotDuplicate(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	platformSync := NewPlatformSync(pool)
+	err := platformSync.SyncPlatformDefaults(ctx)
+	require.NoError(t, err)
+
+	tenantID := tenant.TenantID("reseed_test")
+	schemaName := tenantID.SchemaName()
+	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
+
+	seeder := NewSeeder(pool)
+
+	// Seed once
+	err = seeder.SeedTenant(ctx, tenantID)
+	require.NoError(t, err)
+
+	// Seed again
+	err = seeder.SeedTenant(ctx, tenantID)
+	require.NoError(t, err)
+
+	// Seed a third time
+	err = seeder.SeedTenant(ctx, tenantID)
+	require.NoError(t, err)
+
+	// Count should still be exactly 3
+	var count int
+	err = pool.QueryRow(ctx,
+		"SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true").
+		Scan(&count)
+	require.NoError(t, err)
+	assert.Equal(t, 3, count, "re-seeding should not create duplicates")
+}
+
+// TestE2E_PlatformRefIntegrityConstraint verifies the CHECK constraint:
+// platform_ref and script cannot both be set.
+func TestE2E_PlatformRefIntegrityConstraint(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	platformSync := NewPlatformSync(pool)
+	err := platformSync.SyncPlatformDefaults(ctx)
+	require.NoError(t, err)
+
+	tenantID := tenant.TenantID("constraint_test")
+	schemaName := tenantID.SchemaName()
+	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
+
+	// Get a platform saga ID
+	var platformRefID uuid.UUID
+	err = pool.QueryRow(ctx,
+		"SELECT id FROM public.platform_saga_definition LIMIT 1").
+		Scan(&platformRefID)
+	require.NoError(t, err)
+
+	// Try to insert with BOTH platform_ref and script - should fail
+	_, err = pool.Exec(ctx, `
+		INSERT INTO `+schemaName+`.saga_definition (
+			name, version, script, platform_ref, status, is_system,
+			created_at, updated_at
+		) VALUES ('bad_saga', 1, 'some script', $1, 'DRAFT', false, now(), now())`,
+		platformRefID)
+	require.Error(t, err, "should reject saga with both platform_ref and script")
+	assert.Contains(t, err.Error(), "23514", "should be a CHECK constraint violation")
+}
+
+// TestE2E_MigratorReport verifies the FormatReport function produces readable output.
+func TestE2E_MigratorReport(t *testing.T) {
+	summaries := []TenantMigrationSummary{
+		{
+			TenantID: "acme_corp",
+			Results: []MigrationResult{
+				{SagaName: "withdrawal", Action: "migrated", Reason: "100% similar"},
+				{SagaName: "deposit", Action: "migrated", Reason: "99% similar"},
+				{SagaName: "custom_saga", Action: "skipped", Reason: "no matching platform saga"},
+			},
+		},
+		{
+			TenantID: "beta_corp",
+			Results: []MigrationResult{
+				{SagaName: "withdrawal", Action: "skipped", Reason: "already has platform_ref"},
+			},
+		},
+	}
+
+	report := FormatReport(summaries, false)
+	assert.Contains(t, report, "acme_corp")
+	assert.Contains(t, report, "beta_corp")
+	assert.Contains(t, report, "[migrated]")
+	assert.Contains(t, report, "[skipped]")
+	assert.Contains(t, report, "Migrated: 2")
+	assert.Contains(t, report, "Skipped: 2")
+}
+
+// createSagaReferenceTable creates the saga_reference table needed by the validator.
+func createSagaReferenceTable(t *testing.T, pool *pgxpool.Pool, ctx context.Context, schemaName string) {
+	t.Helper()
+
+	_, err := pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS `+schemaName+`.saga_reference (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			saga_definition_id UUID NOT NULL,
+			reference_type VARCHAR(32) NOT NULL,
+			reference_key VARCHAR(256) NOT NULL,
+			instrument_code VARCHAR(64),
+			attribute_key VARCHAR(128),
+			line_number INT NOT NULL DEFAULT 0,
+			extracted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			CONSTRAINT uq_saga_ref UNIQUE (saga_definition_id, reference_type, reference_key)
+		)`)
+	require.NoError(t, err)
+}

--- a/services/reference-data/saga/migrate_platform_ref.go
+++ b/services/reference-data/saga/migrate_platform_ref.go
@@ -1,0 +1,153 @@
+// Package saga provides the admin migration tool for converting existing tenant
+// saga definitions from script-copied to platform-referenced model.
+//
+// Usage:
+//
+//	migrator := saga.NewPlatformRefMigrator(pool, registry)
+//	results, err := migrator.MigrateAllTenants(ctx, tenantIDs, true)  // dry-run
+//	results, err := migrator.MigrateAllTenants(ctx, tenantIDs, false) // apply
+package saga
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Migration action constants for MigrationResult.Action.
+const (
+	// MigrationActionMigrated indicates the saga was successfully migrated.
+	MigrationActionMigrated = "migrated"
+	// MigrationActionSkipped indicates the saga was skipped.
+	MigrationActionSkipped = "skipped"
+	// MigrationActionWouldMigrate indicates the saga would be migrated (dry-run).
+	MigrationActionWouldMigrate = "would_migrate"
+)
+
+// PlatformRefMigrator migrates existing tenant saga definitions from
+// script-copied to platform-referenced model.
+type PlatformRefMigrator struct {
+	overrideService *OverrideService
+	logger          *slog.Logger
+}
+
+// NewPlatformRefMigrator creates a new migration tool.
+func NewPlatformRefMigrator(pool *pgxpool.Pool, registry *PostgresRegistry) *PlatformRefMigrator {
+	return &PlatformRefMigrator{
+		overrideService: NewOverrideService(pool, registry),
+		logger:          slog.Default().With("component", "platform_ref_migrator"),
+	}
+}
+
+// TenantMigrationSummary summarizes the migration results for a single tenant.
+type TenantMigrationSummary struct {
+	TenantID string
+	Results  []MigrationResult
+	Error    error
+}
+
+// Counts returns the migration action counts.
+func (s *TenantMigrationSummary) Counts() (migrated, skipped, wouldMigrate int) {
+	for _, r := range s.Results {
+		switch r.Action {
+		case MigrationActionMigrated:
+			migrated++
+		case MigrationActionSkipped:
+			skipped++
+		case MigrationActionWouldMigrate:
+			wouldMigrate++
+		}
+	}
+	return migrated, skipped, wouldMigrate
+}
+
+// MigrateAllTenants runs the migration for multiple tenants.
+// When dryRun is true, reports what would change without making modifications.
+func (m *PlatformRefMigrator) MigrateAllTenants(
+	ctx context.Context,
+	tenantIDs []tenant.TenantID,
+	dryRun bool,
+) ([]TenantMigrationSummary, error) {
+	m.logger.Info("starting bulk platform reference migration",
+		"tenant_count", len(tenantIDs),
+		"dry_run", dryRun)
+
+	summaries := make([]TenantMigrationSummary, 0, len(tenantIDs))
+
+	for _, tid := range tenantIDs {
+		results, err := m.overrideService.MigrateToPlatformRef(ctx, tid, dryRun)
+		summary := TenantMigrationSummary{
+			TenantID: tid.String(),
+			Results:  results,
+			Error:    err,
+		}
+		summaries = append(summaries, summary)
+
+		if err != nil {
+			m.logger.Error("migration failed for tenant",
+				"tenant_id", tid.String(),
+				"error", err)
+			continue
+		}
+
+		migrated, skipped, wouldMigrate := summary.Counts()
+		m.logger.Info("tenant migration completed",
+			"tenant_id", tid.String(),
+			"migrated", migrated,
+			"skipped", skipped,
+			"would_migrate", wouldMigrate)
+	}
+
+	return summaries, nil
+}
+
+// FormatReport generates a human-readable migration report.
+func FormatReport(summaries []TenantMigrationSummary, dryRun bool) string {
+	var totalMigrated, totalSkipped, totalWouldMigrate, totalErrors int
+
+	var report string
+	if dryRun {
+		report = "=== Platform Reference Migration Report (DRY RUN) ===\n\n"
+	} else {
+		report = "=== Platform Reference Migration Report ===\n\n"
+	}
+
+	for _, s := range summaries {
+		report += fmt.Sprintf("Tenant: %s\n", s.TenantID)
+
+		if s.Error != nil {
+			report += fmt.Sprintf("  ERROR: %v\n", s.Error)
+			totalErrors++
+			continue
+		}
+
+		migrated, skipped, wouldMigrate := s.Counts()
+		totalMigrated += migrated
+		totalSkipped += skipped
+		totalWouldMigrate += wouldMigrate
+
+		for _, r := range s.Results {
+			report += fmt.Sprintf("  [%s] %s: %s", r.Action, r.SagaName, r.Reason)
+			if r.PlatformRefID != nil {
+				report += fmt.Sprintf(" (platform_ref=%s)", r.PlatformRefID)
+			}
+			report += "\n"
+		}
+		report += "\n"
+	}
+
+	report += "=== Summary ===\n"
+	report += fmt.Sprintf("Tenants processed: %d\n", len(summaries))
+	if dryRun {
+		report += fmt.Sprintf("Would migrate: %d\n", totalWouldMigrate)
+	} else {
+		report += fmt.Sprintf("Migrated: %d\n", totalMigrated)
+	}
+	report += fmt.Sprintf("Skipped: %d\n", totalSkipped)
+	report += fmt.Sprintf("Errors: %d\n", totalErrors)
+
+	return report
+}

--- a/services/reference-data/saga/migrate_platform_ref.go
+++ b/services/reference-data/saga/migrate_platform_ref.go
@@ -10,6 +10,7 @@ package saga
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -65,8 +66,13 @@ func (s *TenantMigrationSummary) Counts() (migrated, skipped, wouldMigrate int) 
 	return migrated, skipped, wouldMigrate
 }
 
+// ErrPartialMigrationFailure is returned when some tenants failed migration
+// while others succeeded. The summaries contain per-tenant details.
+var ErrPartialMigrationFailure = errors.New("some tenant migrations failed")
+
 // MigrateAllTenants runs the migration for multiple tenants.
 // When dryRun is true, reports what would change without making modifications.
+// Returns ErrPartialMigrationFailure if any tenant migration fails.
 func (m *PlatformRefMigrator) MigrateAllTenants(
 	ctx context.Context,
 	tenantIDs []tenant.TenantID,
@@ -77,6 +83,7 @@ func (m *PlatformRefMigrator) MigrateAllTenants(
 		"dry_run", dryRun)
 
 	summaries := make([]TenantMigrationSummary, 0, len(tenantIDs))
+	var failedCount int
 
 	for _, tid := range tenantIDs {
 		results, err := m.overrideService.MigrateToPlatformRef(ctx, tid, dryRun)
@@ -88,6 +95,7 @@ func (m *PlatformRefMigrator) MigrateAllTenants(
 		summaries = append(summaries, summary)
 
 		if err != nil {
+			failedCount++
 			m.logger.Error("migration failed for tenant",
 				"tenant_id", tid.String(),
 				"error", err)
@@ -100,6 +108,11 @@ func (m *PlatformRefMigrator) MigrateAllTenants(
 			"migrated", migrated,
 			"skipped", skipped,
 			"would_migrate", wouldMigrate)
+	}
+
+	if failedCount > 0 {
+		return summaries, fmt.Errorf("%w: %d of %d tenants failed",
+			ErrPartialMigrationFailure, failedCount, len(tenantIDs))
 	}
 
 	return summaries, nil

--- a/services/reference-data/saga/migrate_platform_ref.go
+++ b/services/reference-data/saga/migrate_platform_ref.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -107,19 +108,19 @@ func (m *PlatformRefMigrator) MigrateAllTenants(
 // FormatReport generates a human-readable migration report.
 func FormatReport(summaries []TenantMigrationSummary, dryRun bool) string {
 	var totalMigrated, totalSkipped, totalWouldMigrate, totalErrors int
+	var b strings.Builder
 
-	var report string
 	if dryRun {
-		report = "=== Platform Reference Migration Report (DRY RUN) ===\n\n"
+		b.WriteString("=== Platform Reference Migration Report (DRY RUN) ===\n\n")
 	} else {
-		report = "=== Platform Reference Migration Report ===\n\n"
+		b.WriteString("=== Platform Reference Migration Report ===\n\n")
 	}
 
 	for _, s := range summaries {
-		report += fmt.Sprintf("Tenant: %s\n", s.TenantID)
+		fmt.Fprintf(&b, "Tenant: %s\n", s.TenantID)
 
 		if s.Error != nil {
-			report += fmt.Sprintf("  ERROR: %v\n", s.Error)
+			fmt.Fprintf(&b, "  ERROR: %v\n", s.Error)
 			totalErrors++
 			continue
 		}
@@ -130,24 +131,24 @@ func FormatReport(summaries []TenantMigrationSummary, dryRun bool) string {
 		totalWouldMigrate += wouldMigrate
 
 		for _, r := range s.Results {
-			report += fmt.Sprintf("  [%s] %s: %s", r.Action, r.SagaName, r.Reason)
+			fmt.Fprintf(&b, "  [%s] %s: %s", r.Action, r.SagaName, r.Reason)
 			if r.PlatformRefID != nil {
-				report += fmt.Sprintf(" (platform_ref=%s)", r.PlatformRefID)
+				fmt.Fprintf(&b, " (platform_ref=%s)", r.PlatformRefID)
 			}
-			report += "\n"
+			b.WriteString("\n")
 		}
-		report += "\n"
+		b.WriteString("\n")
 	}
 
-	report += "=== Summary ===\n"
-	report += fmt.Sprintf("Tenants processed: %d\n", len(summaries))
+	b.WriteString("=== Summary ===\n")
+	fmt.Fprintf(&b, "Tenants processed: %d\n", len(summaries))
 	if dryRun {
-		report += fmt.Sprintf("Would migrate: %d\n", totalWouldMigrate)
+		fmt.Fprintf(&b, "Would migrate: %d\n", totalWouldMigrate)
 	} else {
-		report += fmt.Sprintf("Migrated: %d\n", totalMigrated)
+		fmt.Fprintf(&b, "Migrated: %d\n", totalMigrated)
 	}
-	report += fmt.Sprintf("Skipped: %d\n", totalSkipped)
-	report += fmt.Sprintf("Errors: %d\n", totalErrors)
+	fmt.Fprintf(&b, "Skipped: %d\n", totalSkipped)
+	fmt.Fprintf(&b, "Errors: %d\n", totalErrors)
 
-	return report
+	return b.String()
 }

--- a/services/reference-data/saga/override_api.go
+++ b/services/reference-data/saga/override_api.go
@@ -1,0 +1,434 @@
+// Package saga provides the CreateTenantOverride API for replacing platform
+// references with custom tenant scripts.
+//
+// When a tenant is provisioned, saga_definition rows are created with platform_ref
+// pointing to public.platform_saga_definition (no script copy). This API allows
+// tenants to replace these references with custom scripts when they need different
+// saga behavior.
+//
+// Validation rules:
+//   - The override script must be meaningfully different from the platform default
+//     (similarity check via Levenshtein distance)
+//   - The saga must currently use a platform reference (platform_ref IS NOT NULL)
+//   - A saga that already has a custom script cannot be overridden again through this API
+//   - The override creates a new version of the saga (is_system=false) and
+//     records audit metadata (override_reason, platform_version_at_override)
+package saga
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Override error types.
+var (
+	// ErrAlreadyOverridden is returned when attempting to override a saga that
+	// already has a custom script (is not using platform reference).
+	ErrAlreadyOverridden = errors.New("saga already has a custom override")
+
+	// ErrNotPlatformReferenced is returned when attempting to override a saga
+	// that does not use a platform reference.
+	ErrNotPlatformReferenced = errors.New("saga does not use a platform reference")
+
+	// ErrOverrideReasonRequired is returned when no override reason is provided.
+	ErrOverrideReasonRequired = errors.New("override reason is required for audit trail")
+
+	// ErrOverrideScriptEmpty is returned when the override script is empty.
+	ErrOverrideScriptEmpty = errors.New("override script must not be empty")
+)
+
+// OverrideRequest contains the parameters for creating a tenant override.
+type OverrideRequest struct {
+	// SagaName is the name of the saga to override.
+	SagaName string
+
+	// Script is the custom Starlark script for the override.
+	Script string
+
+	// OverrideReason explains why the tenant needs a custom script.
+	OverrideReason string
+
+	// SimilarityThreshold overrides the default similarity threshold (0.0-1.0).
+	// If zero, DefaultSimilarityThreshold is used.
+	SimilarityThreshold float64
+}
+
+// OverrideResult contains the outcome of a tenant override operation.
+type OverrideResult struct {
+	// OverrideDefinition is the newly created saga definition with the custom script.
+	OverrideDefinition *Definition
+
+	// PlatformVersion is the version of the platform saga that was active at override time.
+	PlatformVersion string
+
+	// SimilarityRatio is the similarity between the override and platform scripts.
+	SimilarityRatio float64
+}
+
+// OverrideService provides the tenant override API.
+type OverrideService struct {
+	pool     *pgxpool.Pool
+	registry *PostgresRegistry
+	logger   *slog.Logger
+}
+
+// NewOverrideService creates a new override service.
+func NewOverrideService(pool *pgxpool.Pool, registry *PostgresRegistry) *OverrideService {
+	return &OverrideService{
+		pool:     pool,
+		registry: registry,
+		logger:   slog.Default().With("component", "saga_override"),
+	}
+}
+
+// CreateTenantOverride replaces a platform-referenced saga with a custom script.
+//
+// The process:
+//  1. Look up the existing saga definition (must have platform_ref)
+//  2. Load the platform script for similarity comparison
+//  3. Reject if override is too similar to platform default
+//  4. Create a new saga version with the custom script (DRAFT status)
+//  5. Record audit metadata: override_reason, platform_version_at_override
+//
+// The new override is created as a DRAFT - the caller must activate it separately.
+func (s *OverrideService) CreateTenantOverride(ctx context.Context, req OverrideRequest) (*OverrideResult, error) {
+	logger := s.logger.With("saga_name", req.SagaName)
+
+	// Validate input
+	if err := s.validateRequest(req); err != nil {
+		return nil, err
+	}
+
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil, tenant.ErrMissingTenantContext
+	}
+
+	logger = logger.With("tenant_id", tenantID.String())
+
+	// Look up the current active saga definition
+	existingDef, err := s.registry.GetActive(ctx, req.SagaName)
+	if err != nil {
+		return nil, fmt.Errorf("look up active saga %q: %w", req.SagaName, err)
+	}
+
+	// Verify the saga uses a platform reference
+	if existingDef.PlatformRef == nil {
+		return nil, fmt.Errorf("%w: saga %q (id=%s)", ErrNotPlatformReferenced, req.SagaName, existingDef.ID)
+	}
+
+	// Check if there's already a non-system override for this saga
+	if !existingDef.IsSystem && existingDef.Script != "" {
+		return nil, fmt.Errorf("%w: saga %q already has custom script", ErrAlreadyOverridden, req.SagaName)
+	}
+
+	// Load the platform script for similarity comparison
+	platformDef, err := s.registry.GetPlatformSagaByID(ctx, *existingDef.PlatformRef)
+	if err != nil {
+		return nil, fmt.Errorf("load platform saga for comparison: %w", err)
+	}
+
+	// Check similarity
+	threshold := req.SimilarityThreshold
+	if threshold == 0 {
+		threshold = DefaultSimilarityThreshold
+	}
+
+	simResult := ComputeSimilarityWithThreshold(req.Script, platformDef.Script, threshold)
+	if simResult.TooSimilar {
+		return nil, fmt.Errorf(
+			"%w: override is %.1f%% similar to platform default (threshold: %.1f%%)",
+			ErrScriptTooSimilar,
+			simResult.Ratio*100,
+			threshold*100,
+		)
+	}
+
+	logger.Info("similarity check passed",
+		"similarity_ratio", simResult.Ratio,
+		"threshold", threshold)
+
+	// Create the override as a new version
+	newVersion := existingDef.Version + 1
+
+	overrideDef := &Definition{
+		Name:                      req.SagaName,
+		Version:                   newVersion,
+		Script:                    req.Script,
+		DisplayName:               existingDef.DisplayName,
+		Description:               existingDef.Description,
+		OverrideReason:            req.OverrideReason,
+		PlatformVersionAtOverride: platformDef.Version,
+	}
+
+	if err := s.registry.CreateDraft(ctx, overrideDef); err != nil {
+		return nil, fmt.Errorf("create override draft: %w", err)
+	}
+
+	logger.Info("tenant override created",
+		"override_id", overrideDef.ID,
+		"version", overrideDef.Version,
+		"platform_version", platformDef.Version,
+		"similarity_ratio", simResult.Ratio)
+
+	return &OverrideResult{
+		OverrideDefinition: overrideDef,
+		PlatformVersion:    platformDef.Version,
+		SimilarityRatio:    simResult.Ratio,
+	}, nil
+}
+
+// validateRequest checks the override request for required fields.
+func (s *OverrideService) validateRequest(req OverrideRequest) error {
+	if req.SagaName == "" {
+		return ErrNotFound
+	}
+	if req.Script == "" {
+		return ErrOverrideScriptEmpty
+	}
+	if req.OverrideReason == "" {
+		return ErrOverrideReasonRequired
+	}
+	return nil
+}
+
+// MigrateToPlatformRef converts existing script-copied saga definitions to
+// platform-referenced ones. This is used by the admin migration tool.
+//
+// For each tenant saga that has a script identical to a platform default:
+//  1. Set platform_ref to the matching platform saga
+//  2. Clear the script field (set to NULL)
+//  3. Set is_system=true
+//
+// Returns the number of sagas migrated and any errors encountered.
+func (s *OverrideService) MigrateToPlatformRef(
+	ctx context.Context,
+	tenantID tenant.TenantID,
+	dryRun bool,
+) ([]MigrationResult, error) {
+	logger := s.logger.With("tenant_id", tenantID.String(), "dry_run", dryRun)
+	logger.Info("starting platform reference migration")
+
+	// Get all platform sagas
+	platformSagas, err := s.loadPlatformSagas(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("load platform sagas: %w", err)
+	}
+
+	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	_, err = tx.Exec(ctx, fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName))
+	if err != nil {
+		return nil, fmt.Errorf("set search_path: %w", err)
+	}
+
+	candidates, err := s.loadTenantSagaCandidates(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]MigrationResult, 0, len(candidates))
+	for _, ts := range candidates {
+		result, migrateErr := s.evaluateCandidate(ctx, tx, ts, platformSagas, dryRun, logger)
+		if migrateErr != nil {
+			return nil, migrateErr
+		}
+		results = append(results, result)
+	}
+
+	if !dryRun {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, fmt.Errorf("commit migration: %w", err)
+		}
+	}
+
+	logger.Info("platform reference migration completed",
+		"total", len(results),
+		"dry_run", dryRun)
+
+	return results, nil
+}
+
+// tenantSaga represents a tenant's saga definition candidate for migration.
+type tenantSaga struct {
+	id          uuid.UUID
+	name        string
+	version     int
+	script      string
+	isSystem    bool
+	platformRef *uuid.UUID
+}
+
+// loadTenantSagaCandidates queries all active saga definitions from the tenant schema.
+func (s *OverrideService) loadTenantSagaCandidates(ctx context.Context, tx pgx.Tx) ([]tenantSaga, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT id, name, version, script, is_system, platform_ref
+		FROM saga_definition
+		WHERE status = 'ACTIVE'
+		ORDER BY name, version`)
+	if err != nil {
+		return nil, fmt.Errorf("query tenant sagas: %w", err)
+	}
+	defer rows.Close()
+
+	var candidates []tenantSaga
+	for rows.Next() {
+		var ts tenantSaga
+		var script *string
+		err := rows.Scan(&ts.id, &ts.name, &ts.version, &script, &ts.isSystem, &ts.platformRef)
+		if err != nil {
+			return nil, fmt.Errorf("scan tenant saga: %w", err)
+		}
+		if script != nil {
+			ts.script = *script
+		}
+		candidates = append(candidates, ts)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate tenant sagas: %w", err)
+	}
+	return candidates, nil
+}
+
+// evaluateCandidate determines the migration action for a single tenant saga.
+func (s *OverrideService) evaluateCandidate(
+	ctx context.Context,
+	tx pgx.Tx,
+	ts tenantSaga,
+	platformSagas map[string]PlatformSagaDefinition,
+	dryRun bool,
+	logger *slog.Logger,
+) (MigrationResult, error) {
+	if ts.platformRef != nil {
+		return MigrationResult{
+			SagaName: ts.name,
+			SagaID:   ts.id,
+			Action:   MigrationActionSkipped,
+			Reason:   "already has platform_ref",
+		}, nil
+	}
+
+	platformSaga, ok := platformSagas[ts.name]
+	if !ok {
+		return MigrationResult{
+			SagaName: ts.name,
+			SagaID:   ts.id,
+			Action:   MigrationActionSkipped,
+			Reason:   "no matching platform saga",
+		}, nil
+	}
+
+	simResult := ComputeSimilarityWithThreshold(ts.script, platformSaga.Script, 0.95)
+	if !simResult.TooSimilar {
+		return MigrationResult{
+			SagaName:        ts.name,
+			SagaID:          ts.id,
+			Action:          "skipped",
+			Reason:          fmt.Sprintf("script differs from platform (%.1f%% similar)", simResult.Ratio*100),
+			SimilarityRatio: simResult.Ratio,
+		}, nil
+	}
+
+	if dryRun {
+		return MigrationResult{
+			SagaName:        ts.name,
+			SagaID:          ts.id,
+			Action:          MigrationActionWouldMigrate,
+			Reason:          fmt.Sprintf("script matches platform (%.1f%% similar)", simResult.Ratio*100),
+			SimilarityRatio: simResult.Ratio,
+			PlatformRefID:   &platformSaga.ID,
+		}, nil
+	}
+
+	_, err := tx.Exec(ctx, `
+		UPDATE saga_definition
+		SET script = NULL, platform_ref = $1, is_system = true, updated_at = now()
+		WHERE id = $2`,
+		platformSaga.ID, ts.id)
+	if err != nil {
+		return MigrationResult{}, fmt.Errorf("migrate saga %s: %w", ts.name, err)
+	}
+
+	logger.Info("migrated saga to platform reference",
+		"saga_name", ts.name,
+		"saga_id", ts.id,
+		"platform_ref", platformSaga.ID,
+		"similarity", simResult.Ratio)
+
+	return MigrationResult{
+		SagaName:        ts.name,
+		SagaID:          ts.id,
+		Action:          MigrationActionMigrated,
+		Reason:          fmt.Sprintf("script matches platform (%.1f%% similar)", simResult.Ratio*100),
+		SimilarityRatio: simResult.Ratio,
+		PlatformRefID:   &platformSaga.ID,
+	}, nil
+}
+
+// MigrationResult represents the outcome of migrating a single saga definition.
+type MigrationResult struct {
+	// SagaName is the name of the saga.
+	SagaName string
+
+	// SagaID is the UUID of the saga definition.
+	SagaID uuid.UUID
+
+	// Action describes what happened: "migrated", "skipped", "would_migrate" (dry-run).
+	Action string
+
+	// Reason explains why the action was taken.
+	Reason string
+
+	// SimilarityRatio is the similarity between tenant and platform scripts.
+	SimilarityRatio float64
+
+	// PlatformRefID is the platform saga ID (set when migrated or would_migrate).
+	PlatformRefID *uuid.UUID
+}
+
+// loadPlatformSagas loads all platform saga definitions indexed by name.
+func (s *OverrideService) loadPlatformSagas(ctx context.Context) (map[string]PlatformSagaDefinition, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, name, version, script, display_name, description
+		FROM public.platform_saga_definition
+		ORDER BY name`)
+	if err != nil {
+		return nil, fmt.Errorf("query platform sagas: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]PlatformSagaDefinition)
+	for rows.Next() {
+		var psd PlatformSagaDefinition
+		var displayName, description *string
+		err := rows.Scan(&psd.ID, &psd.Name, &psd.Version, &psd.Script, &displayName, &description)
+		if err != nil {
+			return nil, fmt.Errorf("scan platform saga: %w", err)
+		}
+		if displayName != nil {
+			psd.DisplayName = *displayName
+		}
+		if description != nil {
+			psd.Description = *description
+		}
+		result[psd.Name] = psd
+	}
+
+	return result, rows.Err()
+}

--- a/services/reference-data/saga/override_api.go
+++ b/services/reference-data/saga/override_api.go
@@ -28,6 +28,11 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
+// migrationSimilarityThreshold is the threshold for considering a tenant script
+// identical to the platform default during migration. Intentionally stricter (0.95)
+// than the override threshold (0.90) because migration targets near-identical copies.
+const migrationSimilarityThreshold = 0.95
+
 // Override error types.
 var (
 	// ErrAlreadyOverridden is returned when attempting to override a saga that
@@ -334,12 +339,12 @@ func (s *OverrideService) evaluateCandidate(
 		}, nil
 	}
 
-	simResult := ComputeSimilarityWithThreshold(ts.script, platformSaga.Script, 0.95)
+	simResult := ComputeSimilarityWithThreshold(ts.script, platformSaga.Script, migrationSimilarityThreshold)
 	if !simResult.TooSimilar {
 		return MigrationResult{
 			SagaName:        ts.name,
 			SagaID:          ts.id,
-			Action:          "skipped",
+			Action:          MigrationActionSkipped,
 			Reason:          fmt.Sprintf("script differs from platform (%.1f%% similar)", simResult.Ratio*100),
 			SimilarityRatio: simResult.Ratio,
 		}, nil

--- a/services/reference-data/saga/override_api_test.go
+++ b/services/reference-data/saga/override_api_test.go
@@ -1,0 +1,232 @@
+package saga
+
+import (
+	"context"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverrideService_CreateTenantOverride(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Sync platform defaults
+	platformSync := NewPlatformSync(pool)
+	err := platformSync.SyncPlatformDefaults(ctx)
+	require.NoError(t, err)
+
+	// Create tenant schema with saga_definition table
+	tenantID := tenant.TenantID("override_tenant")
+	schemaName := tenantID.SchemaName()
+	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
+
+	// Seed tenant with platform refs
+	seeder := NewSeeder(pool)
+	err = seeder.SeedTenant(ctx, tenantID)
+	require.NoError(t, err)
+
+	// Create registry and override service
+	tenantCtx := tenant.WithTenant(ctx, tenantID)
+	registry := NewPostgresRegistry(pool, nil)
+	overrideSvc := NewOverrideService(pool, registry)
+
+	t.Run("95% similar script is rejected", func(t *testing.T) {
+		// Get the platform script for withdrawal
+		platformDef, err := registry.GetPlatformSagaByName(ctx, "current_account_withdrawal")
+		require.NoError(t, err)
+
+		// Create a script that's nearly identical (change just one character)
+		nearlyIdentical := platformDef.Script + " "
+
+		_, err = overrideSvc.CreateTenantOverride(tenantCtx, OverrideRequest{
+			SagaName:       "current_account_withdrawal",
+			Script:         nearlyIdentical,
+			OverrideReason: "Testing similarity rejection",
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrScriptTooSimilar)
+	})
+
+	t.Run("50% similar script is accepted", func(t *testing.T) {
+		customScript := `# Version: 1.0.0
+# Custom withdrawal saga with completely different logic
+def posting_rules(ctx):
+    """Custom withdrawal saga for override_tenant."""
+    step(
+        action = "custom_debit_handler",
+        params = {
+            "account": ctx.source_account,
+            "amount": ctx.amount,
+            "custom_field": "custom_value",
+        },
+    )
+    step(
+        action = "custom_credit_handler",
+        params = {
+            "account": ctx.target_account,
+            "amount": ctx.amount,
+            "routing": "express",
+        },
+    )
+    step(
+        action = "custom_notification_handler",
+        params = {
+            "template": "withdrawal_complete",
+            "recipient": ctx.customer_email,
+        },
+    )
+    return {"status": "completed", "custom": True}`
+
+		result, err := overrideSvc.CreateTenantOverride(tenantCtx, OverrideRequest{
+			SagaName:       "current_account_withdrawal",
+			Script:         customScript,
+			OverrideReason: "Need custom routing logic for express withdrawals",
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.NotNil(t, result.OverrideDefinition)
+		assert.Equal(t, "current_account_withdrawal", result.OverrideDefinition.Name)
+		assert.Equal(t, StatusDraft, result.OverrideDefinition.Status)
+		assert.NotEmpty(t, result.PlatformVersion)
+		assert.True(t, result.SimilarityRatio < DefaultSimilarityThreshold,
+			"similarity ratio should be below threshold")
+	})
+
+	t.Run("already overridden saga is rejected", func(t *testing.T) {
+		// Try to override again - should fail because there's now a non-system override
+		anotherScript := `# Another completely different script
+def posting_rules(ctx):
+    """Another override attempt."""
+    return {"error": "should not work"}`
+
+		_, err := overrideSvc.CreateTenantOverride(tenantCtx, OverrideRequest{
+			SagaName:       "current_account_withdrawal",
+			Script:         anotherScript,
+			OverrideReason: "Second override attempt",
+		})
+
+		// This should either get ErrAlreadyOverridden or ErrNotPlatformReferenced
+		// depending on whether the first override's DRAFT takes priority in GetActive
+		require.Error(t, err)
+	})
+
+	t.Run("missing override reason is rejected", func(t *testing.T) {
+		_, err := overrideSvc.CreateTenantOverride(tenantCtx, OverrideRequest{
+			SagaName: "current_account_deposit",
+			Script:   "def posting_rules(ctx): return {}",
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrOverrideReasonRequired)
+	})
+
+	t.Run("empty script is rejected", func(t *testing.T) {
+		_, err := overrideSvc.CreateTenantOverride(tenantCtx, OverrideRequest{
+			SagaName:       "current_account_deposit",
+			OverrideReason: "Testing",
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrOverrideScriptEmpty)
+	})
+}
+
+func TestOverrideService_MigrateToPlatformRef(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Sync platform defaults
+	platformSync := NewPlatformSync(pool)
+	err := platformSync.SyncPlatformDefaults(ctx)
+	require.NoError(t, err)
+
+	// Create tenant schema with saga_definition table
+	tenantID := tenant.TenantID("migrate_tenant")
+	schemaName := tenantID.SchemaName()
+	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
+
+	// Manually insert script-copied sagas (old style, without platform_ref)
+	scripts, err := GetEmbeddedScripts()
+	require.NoError(t, err)
+
+	for _, meta := range PlatformDefaults() {
+		script := scripts[meta.Filename]
+		_, err := pool.Exec(ctx, `
+			INSERT INTO `+schemaName+`.saga_definition (
+				name, version, script, status, is_system,
+				display_name, description, created_at, updated_at, activated_at
+			) VALUES ($1, 1, $2, 'ACTIVE', true, $3, $4, now(), now(), now())`,
+			meta.Name, script, meta.DisplayName, meta.Description)
+		require.NoError(t, err)
+	}
+
+	// Create override service
+	registry := NewPostgresRegistry(pool, nil)
+	overrideSvc := NewOverrideService(pool, registry)
+
+	t.Run("dry run shows what would be migrated", func(t *testing.T) {
+		results, err := overrideSvc.MigrateToPlatformRef(ctx, tenantID, true)
+		require.NoError(t, err)
+
+		// Should find all 3 platform sagas as "would_migrate"
+		wouldMigrateCount := 0
+		for _, r := range results {
+			if r.Action == "would_migrate" {
+				wouldMigrateCount++
+				assert.NotNil(t, r.PlatformRefID)
+				assert.True(t, r.SimilarityRatio >= 0.95,
+					"identical scripts should have >= 95%% similarity")
+			}
+		}
+		assert.Equal(t, 3, wouldMigrateCount, "all 3 platform sagas should be candidates")
+
+		// Verify nothing actually changed
+		var scriptCount int
+		err = pool.QueryRow(ctx,
+			"SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE script IS NOT NULL AND script != ''").
+			Scan(&scriptCount)
+		require.NoError(t, err)
+		assert.Equal(t, 3, scriptCount, "dry run should not modify data")
+	})
+
+	t.Run("apply migration converts to platform refs", func(t *testing.T) {
+		results, err := overrideSvc.MigrateToPlatformRef(ctx, tenantID, false)
+		require.NoError(t, err)
+
+		migratedCount := 0
+		for _, r := range results {
+			if r.Action == "migrated" {
+				migratedCount++
+			}
+		}
+		assert.Equal(t, 3, migratedCount, "all 3 platform sagas should be migrated")
+
+		// Verify scripts are now NULL and platform_ref is set
+		var refCount int
+		err = pool.QueryRow(ctx,
+			"SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE platform_ref IS NOT NULL AND (script IS NULL OR script = '')").
+			Scan(&refCount)
+		require.NoError(t, err)
+		assert.Equal(t, 3, refCount, "all sagas should now use platform_ref")
+	})
+
+	t.Run("re-running migration skips already-migrated sagas", func(t *testing.T) {
+		results, err := overrideSvc.MigrateToPlatformRef(ctx, tenantID, false)
+		require.NoError(t, err)
+
+		for _, r := range results {
+			assert.Equal(t, "skipped", r.Action,
+				"all sagas should be skipped on re-run")
+			assert.Equal(t, "already has platform_ref", r.Reason)
+		}
+	})
+}

--- a/services/reference-data/saga/seeder.go
+++ b/services/reference-data/saga/seeder.go
@@ -4,6 +4,7 @@ package saga
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path"
@@ -19,6 +20,10 @@ import (
 
 //go:embed defaults/*.star
 var defaultSagas embed.FS
+
+// ErrPlatformSagaNotSynced is returned when a platform saga referenced by the seeder
+// has not been synced to the platform_saga_definition table.
+var ErrPlatformSagaNotSynced = errors.New("platform saga not synced: run PlatformSync.SyncPlatformDefaults first")
 
 // Metadata defines metadata for a platform default saga.
 type Metadata struct {
@@ -64,8 +69,15 @@ func PlatformDefaults() []Metadata {
 }
 
 // Seeder seeds platform default saga definitions into tenant schemas.
-// Platform defaults are seeded with is_system=true and status=ACTIVE,
-// making them read-only and immediately usable.
+// Platform defaults are seeded with is_system=true, status=ACTIVE, and a platform_ref
+// pointing to the corresponding entry in public.platform_saga_definition.
+//
+// The seeder creates reference-based entries (platform_ref) rather than copying
+// script content. This means:
+//   - Tenant saga_definition rows have script=NULL and platform_ref set
+//   - The actual script is resolved at query time via COALESCE with platform_saga_definition
+//   - Platform script updates automatically propagate to all tenants using references
+//   - Tenants can override by creating their own saga with a custom script
 type Seeder struct {
 	pool   *pgxpool.Pool
 	logger *slog.Logger
@@ -82,13 +94,17 @@ func NewSeeder(pool *pgxpool.Pool) *Seeder {
 // SeedTenant seeds all platform default sagas into a specific tenant's schema.
 // This is called during tenant provisioning after the schema is created.
 //
+// Prerequisites: PlatformSync.SyncPlatformDefaults must have been called first
+// to populate the public.platform_saga_definition table.
+//
 // Idempotency: Uses ON CONFLICT (name, version) DO NOTHING, so calling this
 // multiple times for the same tenant is safe - existing sagas are skipped.
 //
 // The function:
-//  1. Sets search_path to the tenant's schema
-//  2. For each platform default saga:
-//     - Reads the embedded .star file
+//  1. Looks up each platform default in public.platform_saga_definition
+//  2. Sets search_path to the tenant's schema
+//  3. For each platform default saga:
+//     - Creates a saga_definition with platform_ref (no script copy)
 //     - Inserts with is_system=true, status=ACTIVE, version=1
 //     - Skips if already exists (idempotent)
 func (s *Seeder) SeedTenant(ctx context.Context, tenantID tenant.TenantID) error {
@@ -96,17 +112,28 @@ func (s *Seeder) SeedTenant(ctx context.Context, tenantID tenant.TenantID) error
 	logger.Info("seeding platform default sagas")
 
 	defaults := PlatformDefaults()
+
+	// Look up platform saga IDs from public.platform_saga_definition
+	platformRefs, err := s.lookupPlatformRefs(ctx, defaults)
+	if err != nil {
+		logger.Error("failed to look up platform saga references", "error", err)
+		return err
+	}
+
 	seededCount := 0
 
-	err := s.withTenantTransaction(ctx, tenantID, func(tx pgx.Tx) error {
+	err = s.withTenantTransaction(ctx, tenantID, func(tx pgx.Tx) error {
 		for _, meta := range defaults {
-			seeded, err := s.seedSaga(ctx, tx, meta)
-			if err != nil {
-				return fmt.Errorf("seed %s: %w", meta.Name, err)
+			platformRefID := platformRefs[meta.Name]
+			seeded, seedErr := s.seedSaga(ctx, tx, meta, platformRefID)
+			if seedErr != nil {
+				return fmt.Errorf("seed %s: %w", meta.Name, seedErr)
 			}
 			if seeded {
 				seededCount++
-				logger.Debug("seeded platform saga", "name", meta.Name)
+				logger.Debug("seeded platform saga reference",
+					"name", meta.Name,
+					"platform_ref", platformRefID)
 			} else {
 				logger.Debug("platform saga already exists", "name", meta.Name)
 			}
@@ -123,6 +150,29 @@ func (s *Seeder) SeedTenant(ctx context.Context, tenantID tenant.TenantID) error
 		"seeded", seededCount,
 		"skipped", len(defaults)-seededCount)
 	return nil
+}
+
+// lookupPlatformRefs resolves the platform_saga_definition IDs for each default saga.
+// Returns a map of saga name to platform saga definition UUID.
+func (s *Seeder) lookupPlatformRefs(ctx context.Context, defaults []Metadata) (map[string]uuid.UUID, error) {
+	refs := make(map[string]uuid.UUID, len(defaults))
+
+	for _, meta := range defaults {
+		var platformID uuid.UUID
+		err := s.pool.QueryRow(ctx,
+			`SELECT id FROM public.platform_saga_definition WHERE name = $1`,
+			meta.Name,
+		).Scan(&platformID)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, fmt.Errorf("%w: %s", ErrPlatformSagaNotSynced, meta.Name)
+			}
+			return nil, fmt.Errorf("lookup platform saga %s: %w", meta.Name, err)
+		}
+		refs[meta.Name] = platformID
+	}
+
+	return refs, nil
 }
 
 // withTenantTransaction executes a function within a transaction scoped to a tenant's schema.
@@ -149,15 +199,11 @@ func (s *Seeder) withTenantTransaction(ctx context.Context, tenantID tenant.Tena
 	return tx.Commit(ctx)
 }
 
-// seedSaga inserts a single platform saga if it doesn't already exist.
+// seedSaga inserts a single platform saga reference if it doesn't already exist.
+// The saga_definition row has script=NULL and platform_ref pointing to the
+// platform_saga_definition entry. The script is resolved at query time.
 // Returns true if the saga was inserted, false if it already existed.
-func (s *Seeder) seedSaga(ctx context.Context, tx pgx.Tx, meta Metadata) (bool, error) {
-	// Read embedded script
-	script, err := s.readEmbeddedScript(meta.Filename)
-	if err != nil {
-		return false, err
-	}
-
+func (s *Seeder) seedSaga(ctx context.Context, tx pgx.Tx, meta Metadata, platformRefID uuid.UUID) (bool, error) {
 	// Generate deterministic UUID based on name for idempotency
 	// Using UUIDv5 with the saga name ensures the same saga always gets the same ID
 	id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("saga.meridian."+meta.Name))
@@ -165,23 +211,26 @@ func (s *Seeder) seedSaga(ctx context.Context, tx pgx.Tx, meta Metadata) (bool, 
 	now := time.Now()
 
 	// Insert with ON CONFLICT DO NOTHING for idempotency
-	// Note: We insert directly as ACTIVE since these are platform defaults
+	// Note: script is NULL because the saga inherits its script via platform_ref
 	query := `
 		INSERT INTO saga_definition (
 			id, name, version, script, status, is_system,
-			display_name, description, created_at, updated_at, activated_at
+			platform_ref, display_name, description,
+			created_at, updated_at, activated_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11
+			$1, $2, $3, NULL, $4, $5,
+			$6, $7, $8,
+			$9, $10, $11
 		)
 		ON CONFLICT (name, version) DO NOTHING`
 
 	result, err := tx.Exec(ctx, query,
-		id,        // id
-		meta.Name, // name
-		1,         // version (always 1 for platform defaults)
-		script,    // script
-		"ACTIVE",  // status (platform defaults are immediately active)
-		true,      // is_system (platform defaults are system sagas)
+		id,            // id
+		meta.Name,     // name
+		1,             // version (always 1 for platform defaults)
+		"ACTIVE",      // status (platform defaults are immediately active)
+		true,          // is_system (platform defaults are system sagas)
+		platformRefID, // platform_ref -> public.platform_saga_definition
 		meta.DisplayName,
 		meta.Description,
 		now, // created_at
@@ -194,15 +243,6 @@ func (s *Seeder) seedSaga(ctx context.Context, tx pgx.Tx, meta Metadata) (bool, 
 
 	// Check if row was inserted
 	return result.RowsAffected() > 0, nil
-}
-
-// readEmbeddedScript reads a saga script from the embedded filesystem.
-func (s *Seeder) readEmbeddedScript(filename string) (string, error) {
-	content, err := defaultSagas.ReadFile(path.Join("defaults", filename))
-	if err != nil {
-		return "", fmt.Errorf("read embedded file %s: %w", filename, err)
-	}
-	return strings.TrimSpace(string(content)), nil
 }
 
 // GetEmbeddedScripts returns all embedded saga scripts.

--- a/services/reference-data/saga/seeder_test.go
+++ b/services/reference-data/saga/seeder_test.go
@@ -3,16 +3,12 @@ package saga
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 func TestGetEmbeddedScripts(t *testing.T) {
@@ -57,73 +53,25 @@ func TestPlatformDefaults(t *testing.T) {
 }
 
 func TestSeeder_SeedTenant(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
 
 	ctx := context.Background()
 
-	// Start PostgreSQL container
-	pgContainer, err := postgres.Run(ctx,
-		"postgres:16-alpine",
-		postgres.WithDatabase("testdb"),
-		postgres.WithUsername("test"),
-		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
-		),
-	)
+	// First, sync platform defaults (prerequisite for seeder)
+	platformSync := NewPlatformSync(pool)
+	err := platformSync.SyncPlatformDefaults(ctx)
 	require.NoError(t, err)
-	defer func() {
-		_ = pgContainer.Terminate(ctx)
-	}()
-
-	// Get connection string
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
-
-	// Create pool
-	pool, err := pgxpool.New(ctx, connStr)
-	require.NoError(t, err)
-	defer pool.Close()
 
 	// Create tenant schema and saga_definition table
-	tenantID, err := tenant.NewTenantID("test_tenant")
-	require.NoError(t, err)
-
+	tenantID := tenant.TenantID("test_tenant")
 	schemaName := tenantID.SchemaName()
-	_, err = pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+schemaName)
-	require.NoError(t, err)
-
-	// Create saga_definition table in tenant schema
-	createTableSQL := `
-		CREATE TABLE ` + schemaName + `.saga_definition (
-			id uuid NOT NULL DEFAULT gen_random_uuid(),
-			name varchar(64) NOT NULL,
-			version integer NOT NULL DEFAULT 1,
-			script text NOT NULL,
-			status varchar(16) NOT NULL DEFAULT 'DRAFT',
-			is_system boolean NOT NULL DEFAULT FALSE,
-			preconditions_expression text NULL,
-			display_name varchar(128) NULL,
-			description text NULL,
-			created_at timestamptz NOT NULL DEFAULT now(),
-			updated_at timestamptz NOT NULL DEFAULT now(),
-			activated_at timestamptz NULL,
-			deprecated_at timestamptz NULL,
-			successor_id uuid NULL,
-			PRIMARY KEY (id),
-			CONSTRAINT uq_saga_definition_name_version UNIQUE (name, version)
-		)`
-	_, err = pool.Exec(ctx, createTableSQL)
-	require.NoError(t, err)
+	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
 
 	// Create seeder and seed
 	seeder := NewSeeder(pool)
 
-	t.Run("initial seed", func(t *testing.T) {
+	t.Run("initial seed creates platform_ref entries", func(t *testing.T) {
 		err := seeder.SeedTenant(ctx, tenantID)
 		require.NoError(t, err)
 
@@ -133,45 +81,45 @@ func TestSeeder_SeedTenant(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 3, count, "expected 3 system sagas")
 
-		// Verify each saga has correct attributes
+		// Verify each saga has platform_ref and no script
 		rows, err := pool.Query(ctx, `
-			SELECT name, version, status, is_system, display_name, activated_at
+			SELECT name, version, status, is_system, platform_ref, script, display_name, activated_at
 			FROM `+schemaName+`.saga_definition
 			WHERE is_system = true
 			ORDER BY name`)
 		require.NoError(t, err)
 		defer rows.Close()
 
-		var sagas []struct {
-			name        string
-			version     int
-			status      string
-			isSystem    bool
-			displayName *string
-			activatedAt *time.Time
-		}
-
 		for rows.Next() {
-			var s struct {
-				name        string
-				version     int
-				status      string
-				isSystem    bool
-				displayName *string
-				activatedAt *time.Time
-			}
-			err := rows.Scan(&s.name, &s.version, &s.status, &s.isSystem, &s.displayName, &s.activatedAt)
+			var name string
+			var version int
+			var status string
+			var isSystem bool
+			var platformRef *uuid.UUID
+			var script *string
+			var displayName *string
+			var activatedAt interface{}
+
+			err := rows.Scan(&name, &version, &status, &isSystem, &platformRef, &script, &displayName, &activatedAt)
 			require.NoError(t, err)
-			sagas = append(sagas, s)
+
+			assert.Equal(t, 1, version, "platform default should have version 1")
+			assert.Equal(t, "ACTIVE", status, "platform default should be ACTIVE")
+			assert.True(t, isSystem, "platform default should be is_system=true")
+			assert.NotNil(t, platformRef, "platform default should have platform_ref set")
+			assert.True(t, script == nil || *script == "", "platform default should NOT have a copied script")
+			assert.NotNil(t, activatedAt, "platform default should have activated_at")
+
+			// Verify platform_ref points to actual platform saga
+			var platformName string
+			err = pool.QueryRow(ctx,
+				"SELECT name FROM public.platform_saga_definition WHERE id = $1",
+				*platformRef,
+			).Scan(&platformName)
+			require.NoError(t, err, "platform_ref should point to existing platform saga")
+			assert.Equal(t, name, platformName, "platform_ref should point to same-named platform saga")
 		}
 		require.NoError(t, rows.Err())
-
-		for _, s := range sagas {
-			assert.Equal(t, 1, s.version, "platform default should have version 1")
-			assert.Equal(t, "ACTIVE", s.status, "platform default should be ACTIVE")
-			assert.True(t, s.isSystem, "platform default should be is_system=true")
-			assert.NotNil(t, s.activatedAt, "platform default should have activated_at")
-		}
 	})
 
 	t.Run("idempotent seed", func(t *testing.T) {
@@ -210,56 +158,61 @@ func TestSeeder_SeedTenant(t *testing.T) {
 
 		assert.Equal(t, expectedIDs, ids, "UUIDs should be deterministic")
 	})
+
+	t.Run("seeded sagas resolve script via platform fallback", func(t *testing.T) {
+		// Query using LEFT JOIN to resolve the script, matching how postgres_registry.go works
+		var resolvedScript string
+		var usedFallback bool
+		err := pool.QueryRow(ctx, `
+			SELECT
+				COALESCE(NULLIF(sd.script, ''), psd.script, '') AS resolved_script,
+				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback
+			FROM `+schemaName+`.saga_definition sd
+			LEFT JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
+			WHERE sd.name = 'current_account_withdrawal' AND sd.is_system = true
+		`).Scan(&resolvedScript, &usedFallback)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, resolvedScript, "resolved script should not be empty")
+		assert.True(t, usedFallback, "script should come from platform fallback")
+		assert.Contains(t, resolvedScript, "current_account_withdrawal",
+			"resolved script should contain withdrawal saga content")
+	})
 }
 
-func TestSeeder_SeedTenant_TenantOverride(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test in short mode")
-	}
+func TestSeeder_SeedTenant_FailsWithoutPlatformSync(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
 
 	ctx := context.Background()
 
-	// Start PostgreSQL container
-	pgContainer, err := postgres.Run(ctx,
-		"postgres:16-alpine",
-		postgres.WithDatabase("testdb"),
-		postgres.WithUsername("test"),
-		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second),
-		),
-	)
-	require.NoError(t, err)
-	defer func() {
-		_ = pgContainer.Terminate(ctx)
-	}()
-
-	// Get connection string
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	require.NoError(t, err)
-
-	// Create pool
-	pool, err := pgxpool.New(ctx, connStr)
-	require.NoError(t, err)
-	defer pool.Close()
-
+	// Do NOT sync platform defaults
 	// Create tenant schema
-	tenantID, err := tenant.NewTenantID("override_test")
-	require.NoError(t, err)
-
+	tenantID := tenant.TenantID("no_sync_tenant")
 	schemaName := tenantID.SchemaName()
-	_, err = pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+schemaName)
+	setupTenantSchemaForSeeder(t, pool, ctx, schemaName)
+
+	seeder := NewSeeder(pool)
+	err := seeder.SeedTenant(ctx, tenantID)
+	require.Error(t, err, "seeding should fail when platform sagas are not synced")
+	assert.ErrorIs(t, err, ErrPlatformSagaNotSynced)
+}
+
+// setupTenantSchemaForSeeder creates the tenant schema and saga_definition table
+// for seeder integration tests. It applies the relevant migrations.
+func setupTenantSchemaForSeeder(t *testing.T, pool *pgxpool.Pool, ctx context.Context, schemaName string) {
+	t.Helper()
+
+	_, err := pool.Exec(ctx, "CREATE SCHEMA IF NOT EXISTS "+schemaName)
 	require.NoError(t, err)
 
-	// Create saga_definition table
+	// Create saga_definition table matching the full migrated schema
 	createTableSQL := `
-		CREATE TABLE ` + schemaName + `.saga_definition (
+		CREATE TABLE IF NOT EXISTS ` + schemaName + `.saga_definition (
 			id uuid NOT NULL DEFAULT gen_random_uuid(),
 			name varchar(64) NOT NULL,
 			version integer NOT NULL DEFAULT 1,
-			script text NOT NULL,
+			script text NULL,
 			status varchar(16) NOT NULL DEFAULT 'DRAFT',
 			is_system boolean NOT NULL DEFAULT FALSE,
 			preconditions_expression text NULL,
@@ -270,56 +223,14 @@ func TestSeeder_SeedTenant_TenantOverride(t *testing.T) {
 			activated_at timestamptz NULL,
 			deprecated_at timestamptz NULL,
 			successor_id uuid NULL,
+			platform_ref uuid NULL REFERENCES public.platform_saga_definition(id) ON DELETE SET NULL,
+			override_reason text NULL,
+			platform_version_at_override varchar(16) NULL,
 			PRIMARY KEY (id),
-			CONSTRAINT uq_saga_definition_name_version UNIQUE (name, version)
+			CONSTRAINT uq_saga_definition_name_version UNIQUE (name, version),
+			CONSTRAINT chk_saga_definition_script_source
+				CHECK (NOT (platform_ref IS NOT NULL AND script IS NOT NULL AND script != ''))
 		)`
 	_, err = pool.Exec(ctx, createTableSQL)
 	require.NoError(t, err)
-
-	// Seed platform defaults
-	seeder := NewSeeder(pool)
-	err = seeder.SeedTenant(ctx, tenantID)
-	require.NoError(t, err)
-
-	// Create a tenant override saga (is_system=false) with a different version
-	overrideScript := `
-# Custom tenant withdrawal saga
-withdrawal_saga = saga(name="current_account_withdrawal")
-# Custom logic here
-`
-	_, err = pool.Exec(ctx, `
-		INSERT INTO `+schemaName+`.saga_definition
-			(name, version, script, status, is_system, activated_at)
-		VALUES
-			('current_account_withdrawal', 2, $1, 'ACTIVE', false, now())`,
-		overrideScript)
-	require.NoError(t, err)
-
-	// Test that both platform default and tenant override exist
-	var systemCount, tenantCount int
-	err = pool.QueryRow(ctx, `
-		SELECT
-			COUNT(*) FILTER (WHERE is_system = true) as system_count,
-			COUNT(*) FILTER (WHERE is_system = false) as tenant_count
-		FROM `+schemaName+`.saga_definition
-		WHERE name = 'current_account_withdrawal'`).
-		Scan(&systemCount, &tenantCount)
-	require.NoError(t, err)
-
-	assert.Equal(t, 1, systemCount, "should have 1 system saga")
-	assert.Equal(t, 1, tenantCount, "should have 1 tenant override saga")
-
-	// Verify tenant override has higher version
-	var systemVersion, tenantVersion int
-	err = pool.QueryRow(ctx, `
-		SELECT
-			MAX(version) FILTER (WHERE is_system = true),
-			MAX(version) FILTER (WHERE is_system = false)
-		FROM `+schemaName+`.saga_definition
-		WHERE name = 'current_account_withdrawal'`).
-		Scan(&systemVersion, &tenantVersion)
-	require.NoError(t, err)
-
-	assert.Equal(t, 1, systemVersion, "system saga should be version 1")
-	assert.Equal(t, 2, tenantVersion, "tenant override should be version 2")
 }

--- a/services/reference-data/saga/similarity.go
+++ b/services/reference-data/saga/similarity.go
@@ -1,0 +1,148 @@
+// Package saga provides script similarity detection for tenant override validation.
+//
+// When tenants create custom overrides of platform saga definitions, the system
+// validates that the override is meaningfully different from the platform default.
+// This prevents tenants from creating "overrides" that are near-identical copies
+// of platform scripts, which would create maintenance burden without benefit.
+package saga
+
+import (
+	"errors"
+	"strings"
+)
+
+// Similarity detection thresholds and errors.
+var (
+	// DefaultSimilarityThreshold is the maximum allowed similarity ratio (0.0-1.0)
+	// between a tenant override and the platform default script.
+	// Scripts with similarity above this threshold are rejected.
+	DefaultSimilarityThreshold = 0.90
+
+	// ErrScriptTooSimilar is returned when a tenant override script is too similar
+	// to the platform default it replaces.
+	ErrScriptTooSimilar = errors.New("override script is too similar to platform default")
+)
+
+// SimilarityResult holds the result of a script similarity comparison.
+type SimilarityResult struct {
+	// Ratio is the similarity ratio between 0.0 (completely different) and 1.0 (identical).
+	Ratio float64
+
+	// Distance is the raw Levenshtein edit distance.
+	Distance int
+
+	// MaxLength is the length of the longer string (used for ratio calculation).
+	MaxLength int
+
+	// TooSimilar is true when Ratio exceeds the threshold.
+	TooSimilar bool
+}
+
+// ComputeSimilarity compares two scripts and returns a SimilarityResult.
+// The comparison normalizes whitespace to avoid false positives from
+// formatting-only differences.
+//
+// Similarity is calculated as: 1 - (levenshtein_distance / max_length).
+// An empty override compared to a non-empty default yields ratio 0.0.
+// Two empty scripts yield ratio 1.0.
+func ComputeSimilarity(script1, script2 string) SimilarityResult {
+	return ComputeSimilarityWithThreshold(script1, script2, DefaultSimilarityThreshold)
+}
+
+// ComputeSimilarityWithThreshold compares two scripts with a custom threshold.
+func ComputeSimilarityWithThreshold(script1, script2 string, threshold float64) SimilarityResult {
+	// Normalize whitespace for comparison
+	norm1 := normalizeScript(script1)
+	norm2 := normalizeScript(script2)
+
+	// Handle edge cases
+	if len(norm1) == 0 && len(norm2) == 0 {
+		return SimilarityResult{
+			Ratio:      1.0,
+			Distance:   0,
+			MaxLength:  0,
+			TooSimilar: true,
+		}
+	}
+
+	maxLen := len(norm1)
+	if len(norm2) > maxLen {
+		maxLen = len(norm2)
+	}
+
+	dist := levenshteinDistance(norm1, norm2)
+	ratio := 1.0 - float64(dist)/float64(maxLen)
+
+	return SimilarityResult{
+		Ratio:      ratio,
+		Distance:   dist,
+		MaxLength:  maxLen,
+		TooSimilar: ratio >= threshold,
+	}
+}
+
+// normalizeScript normalizes a script for similarity comparison.
+// Removes leading/trailing whitespace from each line and collapses
+// multiple blank lines into one. This prevents formatting-only
+// differences from inflating the distance.
+func normalizeScript(script string) string {
+	lines := strings.Split(script, "\n")
+	normalized := make([]string, 0, len(lines))
+	prevBlank := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			if !prevBlank {
+				normalized = append(normalized, "")
+				prevBlank = true
+			}
+			continue
+		}
+		prevBlank = false
+		normalized = append(normalized, trimmed)
+	}
+
+	return strings.Join(normalized, "\n")
+}
+
+// levenshteinDistance computes the Levenshtein edit distance between two strings.
+// Uses the standard dynamic programming approach with O(min(m,n)) space.
+func levenshteinDistance(a, b string) int {
+	la := len(a)
+	lb := len(b)
+
+	// Ensure a is the shorter string for space optimization
+	if la > lb {
+		a, b = b, a
+		la, lb = lb, la
+	}
+
+	// Use two rows instead of full matrix
+	prev := make([]int, la+1)
+	curr := make([]int, la+1)
+
+	// Initialize first row
+	for i := 0; i <= la; i++ {
+		prev[i] = i
+	}
+
+	// Fill the matrix
+	for j := 1; j <= lb; j++ {
+		curr[0] = j
+		for i := 1; i <= la; i++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[i] = min(
+				prev[i]+1,      // deletion
+				curr[i-1]+1,    // insertion
+				prev[i-1]+cost, // substitution
+			)
+		}
+		prev, curr = curr, prev
+	}
+
+	return prev[la]
+}

--- a/services/reference-data/saga/similarity_test.go
+++ b/services/reference-data/saga/similarity_test.go
@@ -1,0 +1,174 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevenshteinDistance(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        string
+		b        string
+		expected int
+	}{
+		{name: "identical strings", a: "abc", b: "abc", expected: 0},
+		{name: "empty strings", a: "", b: "", expected: 0},
+		{name: "one empty", a: "abc", b: "", expected: 3},
+		{name: "other empty", a: "", b: "abc", expected: 3},
+		{name: "single substitution", a: "abc", b: "aXc", expected: 1},
+		{name: "single insertion", a: "abc", b: "abXc", expected: 1},
+		{name: "single deletion", a: "abXc", b: "abc", expected: 1},
+		{name: "kitten to sitting", a: "kitten", b: "sitting", expected: 3},
+		{name: "completely different", a: "abcdef", b: "ghijkl", expected: 6},
+		{name: "single char", a: "a", b: "b", expected: 1},
+		{name: "same single char", a: "a", b: "a", expected: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := levenshteinDistance(tt.a, tt.b)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestLevenshteinDistance_Symmetry(t *testing.T) {
+	// Levenshtein distance should be symmetric
+	pairs := [][2]string{
+		{"hello", "world"},
+		{"abc", "def"},
+		{"test", "testing"},
+	}
+
+	for _, pair := range pairs {
+		t.Run(pair[0]+"_"+pair[1], func(t *testing.T) {
+			d1 := levenshteinDistance(pair[0], pair[1])
+			d2 := levenshteinDistance(pair[1], pair[0])
+			assert.Equal(t, d1, d2, "levenshtein distance should be symmetric")
+		})
+	}
+}
+
+func TestNormalizeScript(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "trims line whitespace",
+			input:    "  abc  \n  def  ",
+			expected: "abc\ndef",
+		},
+		{
+			name:     "collapses blank lines",
+			input:    "abc\n\n\n\ndef",
+			expected: "abc\n\ndef",
+		},
+		{
+			name:     "handles tabs",
+			input:    "\tabc\t\n\tdef\t",
+			expected: "abc\ndef",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "only whitespace",
+			input:    "   \n   \n   ",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeScript(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestComputeSimilarity(t *testing.T) {
+	t.Run("identical scripts are 100% similar", func(t *testing.T) {
+		script := "def posting_rules(ctx):\n    return ['step1', 'step2']"
+		result := ComputeSimilarity(script, script)
+		assert.Equal(t, 1.0, result.Ratio)
+		assert.Equal(t, 0, result.Distance)
+		assert.True(t, result.TooSimilar, "identical scripts should be flagged as too similar")
+	})
+
+	t.Run("completely different scripts are 0% similar", func(t *testing.T) {
+		script1 := "aaaaaaaaaa"
+		script2 := "bbbbbbbbbb"
+		result := ComputeSimilarity(script1, script2)
+		assert.Equal(t, 0.0, result.Ratio)
+		assert.False(t, result.TooSimilar)
+	})
+
+	t.Run("two empty scripts are identical", func(t *testing.T) {
+		result := ComputeSimilarity("", "")
+		assert.Equal(t, 1.0, result.Ratio)
+		assert.True(t, result.TooSimilar)
+	})
+
+	t.Run("empty vs non-empty is 0% similar", func(t *testing.T) {
+		result := ComputeSimilarity("", "def posting_rules(ctx): pass")
+		assert.Equal(t, 0.0, result.Ratio)
+		assert.False(t, result.TooSimilar)
+	})
+
+	t.Run("95% similar script is rejected at default threshold", func(t *testing.T) {
+		// Create a script where only 5% is different - nearly identical
+		base := "def posting_rules(ctx):\n    return ['step1', 'step2', 'step3', 'step4', 'step5', 'step6', 'step7', 'step8', 'step9', 'step10']"
+		modified := "def posting_rules(ctx):\n    return ['step1', 'step2', 'step3', 'step4', 'step5', 'step6', 'step7', 'step8', 'step9', 'stepAA']" // Changed last step
+		result := ComputeSimilarity(base, modified)
+
+		// With only 2 chars changed out of ~120, similarity should be very high
+		assert.True(t, result.Ratio > 0.90, "scripts with minor changes should be > 90%% similar, got %.4f", result.Ratio)
+		assert.True(t, result.TooSimilar, "nearly identical scripts should be flagged")
+	})
+
+	t.Run("50% similar script is allowed at default threshold", func(t *testing.T) {
+		script1 := "def posting_rules(ctx):\n    return ['step1', 'step2']"
+		script2 := "def execute(ctx):\n    result = validate(ctx)\n    return process(result)"
+		result := ComputeSimilarity(script1, script2)
+
+		assert.True(t, result.Ratio < 0.90, "significantly different scripts should be < 90%% similar, got %.4f", result.Ratio)
+		assert.False(t, result.TooSimilar, "significantly different scripts should be allowed")
+	})
+
+	t.Run("whitespace-only differences are normalized", func(t *testing.T) {
+		script1 := "def foo():\n    return 1"
+		script2 := "def foo():\n        return 1" // More indentation
+		result := ComputeSimilarity(script1, script2)
+
+		assert.Equal(t, 1.0, result.Ratio, "whitespace-only differences should be normalized to identical")
+	})
+}
+
+func TestComputeSimilarityWithThreshold(t *testing.T) {
+	t.Run("custom threshold 0.80", func(t *testing.T) {
+		script1 := "def posting_rules(ctx):\n    return ['step1', 'step2', 'step3']"
+		// Change ~15% of the script - small but meaningful change
+		script2 := "def posting_rules(ctx):\n    return ['stepA', 'stepB', 'step3']"
+		result := ComputeSimilarityWithThreshold(script1, script2, 0.80)
+
+		assert.True(t, result.Ratio > 0.80, "scripts with ~15%% changes should be above 80%% threshold")
+		assert.True(t, result.TooSimilar, "should be flagged at 80%% threshold")
+	})
+
+	t.Run("custom threshold 0.99 only rejects near-identical", func(t *testing.T) {
+		script1 := "def posting_rules(ctx):\n    return ['step1', 'step2', 'step3']"
+		script2 := "def posting_rules(ctx):\n    return ['step1', 'step2', 'step4']"
+		result := ComputeSimilarityWithThreshold(script1, script2, 0.99)
+
+		// Small change should pass strict threshold
+		require.True(t, result.Ratio < 0.99)
+		assert.False(t, result.TooSimilar, "small changes should pass at 99%% threshold")
+	})
+}


### PR DESCRIPTION
## Summary

- Refactor SagaSeeder to create platform_ref entries instead of copying script content during tenant provisioning
- Implement Levenshtein distance similarity detection to validate tenant override scripts are meaningfully different from platform defaults
- Build CreateTenantOverride API for tenants to replace platform references with custom scripts, with audit trail
- Add admin migration tool (PlatformRefMigrator) to convert existing script-copied tenants to platform-referenced model
- Comprehensive integration and end-to-end test suite covering the full provisioning/override/migration lifecycle

## Changes Made

### 9.1: Refactor SagaSeeder (`seeder.go`)
- SeedTenant now creates saga_definition rows with `platform_ref` pointing to `public.platform_saga_definition` instead of copying script content
- Added `lookupPlatformRefs` to resolve platform saga IDs before seeding
- Fails fast with `ErrPlatformSagaNotSynced` if platform sagas have not been synced
- Script is NULL in seeded rows; resolved at query time via COALESCE with platform_saga_definition

### 9.2: Similarity Detection (`similarity.go`)
- Levenshtein distance implementation with O(min(m,n)) space optimization
- Whitespace normalization to prevent formatting-only false positives
- Configurable similarity threshold (default 90%)
- `ComputeSimilarity` and `ComputeSimilarityWithThreshold` public APIs

### 9.3: CreateTenantOverride API (`override_api.go`)
- `OverrideService.CreateTenantOverride` validates:
  - Override script is meaningfully different from platform default (similarity check)
  - Saga currently uses platform_ref (not already overridden)
  - Override reason provided for audit trail
- Creates new version in DRAFT status with audit metadata (override_reason, platform_version_at_override)
- `MigrateToPlatformRef` converts existing script-copied tenants to platform-referenced model with dry-run support

### 9.4: Admin Migration Tool (`migrate_platform_ref.go`)
- `PlatformRefMigrator` for bulk tenant migration with progress reporting
- `FormatReport` generates human-readable migration reports
- Migration action constants for type-safe action tracking

### 9.5: Integration Tests (`seeder_test.go`, `override_api_test.go`, `e2e_seeder_test.go`, `similarity_test.go`)
- **Seeder tests**: Platform ref creation, idempotency, deterministic UUIDs, platform fallback resolution, failure without sync
- **Similarity tests**: Levenshtein distance correctness, symmetry, whitespace normalization, threshold behavior
- **Override tests**: Similarity rejection at 95%, acceptance at 50%, double-override prevention, input validation
- **Migration tests**: Dry-run preview, apply migration, re-run idempotency
- **E2E tests**: Full lifecycle (sync -> seed -> override -> activate -> verify priority -> migrate old tenant)
- **Constraint tests**: CHECK constraint preventing platform_ref + script coexistence

## Technical Details

The key architectural change is moving from **script-copied** to **reference-based** tenant provisioning:

```
Before: saga_definition.script = <copied content>  (per-tenant copy)
After:  saga_definition.platform_ref = <platform_saga_definition.id>, script = NULL
```

Script resolution happens at query time via LEFT JOIN + COALESCE, already implemented in the postgres_registry from task starlark-typed-clients.8. This means platform script updates automatically propagate to all tenants using references.

## Testing

All tests pass locally with CockroachDB testcontainers:
- 12 unit tests (similarity, normalization, Levenshtein)
- 20+ integration tests (seeder, override, migration, E2E)
- Pre-commit hooks (gofumpt, golangci-lint) pass with 0 issues

## Risk Assessment

**Low risk**: Changes are additive - new seeding behavior uses existing platform_ref column and COALESCE resolution from task starlark-typed-clients.8. The migration tool has dry-run capability for safe rollout. The CHECK constraint (`chk_saga_definition_script_source`) prevents data integrity issues at the database level.

## Task Master Reference

Task: starlark-typed-clients.9