### PR TITLE
fix: Resolve nightly test timeout in shared/pkg/saga

### DIFF
--- a/shared/pkg/saga/migrations.go
+++ b/shared/pkg/saga/migrations.go
@@ -23,10 +23,17 @@ import (
 //	    }
 //	}
 func RunSagaMigrations(db *gorm.DB) error {
-	// Run AutoMigrate for the saga models
-	// This creates the tables and standard indexes defined in struct tags
-	if err := db.AutoMigrate(&SagaInstance{}, &SagaStepResult{}); err != nil {
-		return fmt.Errorf("failed to auto-migrate saga models: %w", err)
+	// Only run AutoMigrate when tables don't yet exist.
+	// GORM's AutoMigrate is not idempotent on CockroachDB: re-running it
+	// fails with SQLSTATE 42704 because CockroachDB names unique constraints
+	// differently than what GORM expects when checking existing schema.
+	// The partial indexes and composite constraint below are already
+	// idempotent (IF NOT EXISTS / information_schema checks).
+	migrator := db.Migrator()
+	if !migrator.HasTable(&SagaInstance{}) || !migrator.HasTable(&SagaStepResult{}) {
+		if err := db.AutoMigrate(&SagaInstance{}, &SagaStepResult{}); err != nil {
+			return fmt.Errorf("failed to auto-migrate saga models: %w", err)
+		}
 	}
 
 	// Create the partial index for orphan detection

--- a/shared/pkg/saga/test_helpers_test.go
+++ b/shared/pkg/saga/test_helpers_test.go
@@ -1,15 +1,114 @@
 package saga
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
 	"testing"
+	"time"
 
-	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
+	gormpg "gorm.io/driver/postgres"
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
-// setupTestPostgres creates a CockroachDB testcontainer for integration testing.
-// Named setupTestPostgres for historical compatibility - CockroachDB is wire-compatible
-// with PostgreSQL and is our production database.
+// sharedDB holds the shared CockroachDB connection for all integration tests.
+// Lazily initialized on first use via sync.Once to avoid starting the container
+// when only unit tests run (e.g. -short mode).
+var (
+	sharedDB      *gorm.DB
+	sharedOnce    sync.Once
+	sharedInitErr error
+	sharedCleanup func()
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	if sharedCleanup != nil {
+		sharedCleanup()
+	}
+	os.Exit(code)
+}
+
+func initSharedContainer() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	crdbContainer, err := cockroachdb.Run(ctx,
+		"cockroachdb/cockroach:v24.3.0",
+		cockroachdb.WithDatabase("test_db"),
+		cockroachdb.WithUser("root"),
+		cockroachdb.WithInsecure(),
+	)
+	if err != nil {
+		return fmt.Errorf("start container: %w", err)
+	}
+
+	connConfig, err := crdbContainer.ConnectionConfig(ctx)
+	if err != nil {
+		_ = crdbContainer.Terminate(ctx)
+		return fmt.Errorf("connection config: %w", err)
+	}
+
+	db, err := gorm.Open(gormpg.Open(connConfig.ConnString()), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		_ = crdbContainer.Terminate(ctx)
+		return fmt.Errorf("gorm open: %w", err)
+	}
+
+	// Run migrations once — subsequent RunSagaMigrations calls in tests
+	// are idempotent no-ops (tables/indexes already exist).
+	if err := RunSagaMigrations(db); err != nil {
+		_ = crdbContainer.Terminate(ctx)
+		return fmt.Errorf("migrations: %w", err)
+	}
+
+	sharedDB = db
+	sharedCleanup = func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+		_ = crdbContainer.Terminate(cleanupCtx)
+	}
+
+	return nil
+}
+
+// setupTestPostgres returns the shared CockroachDB connection with per-test
+// data cleanup. Named setupTestPostgres for historical compatibility —
+// CockroachDB is wire-compatible with PostgreSQL and is our production database.
+//
+// Previously each test started its own CockroachDB container (~15s startup).
+// With ~60 integration tests the package exceeded the 15-minute timeout.
+// Sharing one container reduces total overhead from ~15 minutes to ~15 seconds.
 func setupTestPostgres(t *testing.T) (*gorm.DB, func()) {
-	return testdb.SetupCockroachDB(t, nil)
+	t.Helper()
+
+	sharedOnce.Do(func() {
+		sharedInitErr = initSharedContainer()
+	})
+	if sharedInitErr != nil {
+		t.Fatalf("shared CockroachDB setup failed: %v", sharedInitErr)
+	}
+
+	// Clean tables before each test (FK order: children first).
+	if err := sharedDB.Exec("DELETE FROM saga_step_results").Error; err != nil {
+		t.Fatalf("Failed to clean saga_step_results: %v", err)
+	}
+	if err := sharedDB.Exec("DELETE FROM saga_instances").Error; err != nil {
+		t.Fatalf("Failed to clean saga_instances: %v", err)
+	}
+
+	return sharedDB, func() {
+		// No-op: container lifecycle managed by TestMain.
+	}
 }

--- a/shared/pkg/saga/timeout_worker.go
+++ b/shared/pkg/saga/timeout_worker.go
@@ -107,44 +107,51 @@ func (w *TimeoutWorker) processExpiredSuspensions(ctx context.Context) error {
 	var expired []expiredSaga
 
 	err := w.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		// Find and transition expired suspensions atomically
-		// Use CTE to capture idempotency_key before clearing suspend_data
-		// The JSONB query extracts the timeout_at field and compares with NOW()
-		result := tx.Raw(`
-			WITH expired_sagas AS (
-				SELECT id, correlation_id, suspend_data->>'idempotency_key' as idempotency_key
-				FROM saga_instances
-				WHERE status = ?
-				  AND (suspend_data->>'timeout_at')::timestamptz < ?
-				FOR UPDATE SKIP LOCKED
-				LIMIT ?
-			)
-			UPDATE saga_instances si
-			SET
-				status = ?,
-				error_message = ?,
-				error_category = ?,
-				updated_at = ?,
-				suspend_reason = NULL,
-				suspend_data = NULL
-			FROM expired_sagas es
-			WHERE si.id = es.id
-			RETURNING si.id, es.correlation_id, es.idempotency_key
+		// Step 1: Find expired suspensions with row-level locking.
+		// CockroachDB requires FOR UPDATE at the top level of a SELECT (not in
+		// CTEs or subqueries). SKIP LOCKED is omitted because CockroachDB's
+		// serializable isolation silently returns empty results when it's used.
+		// Serializable isolation provides equivalent concurrency safety.
+		if err := tx.Raw(`
+			SELECT id, correlation_id, suspend_data->>'idempotency_key' as idempotency_key
+			FROM saga_instances
+			WHERE status = ?
+			  AND (suspend_data->>'timeout_at')::timestamptz < ?
+			ORDER BY id
+			FOR UPDATE
+			LIMIT ?
 		`,
 			SagaStatusWaitingForEvent,
 			now,
 			w.config.BatchSize,
-			SagaStatusFailed,
-			"Suspend timeout exceeded - external event not received within deadline",
-			string(ErrorCategoryFatal),
-			now,
-		).Scan(&expired)
-
-		if result.Error != nil {
-			return result.Error
+		).Scan(&expired).Error; err != nil {
+			return fmt.Errorf("failed to find expired suspensions: %w", err)
 		}
 
-		// Also update the corresponding step results to FAILED
+		if len(expired) == 0 {
+			return nil
+		}
+
+		// Step 2: Transition expired sagas to FAILED.
+		// Capture idempotency_key in step 1 before clearing suspend_data here.
+		ids := make([]uuid.UUID, len(expired))
+		for i, s := range expired {
+			ids[i] = s.ID
+		}
+		if err := tx.Model(&SagaInstance{}).
+			Where("id IN ?", ids).
+			Updates(map[string]interface{}{
+				"status":         SagaStatusFailed,
+				"error_message":  "Suspend timeout exceeded - external event not received within deadline",
+				"error_category": string(ErrorCategoryFatal),
+				"updated_at":     now,
+				"suspend_reason": nil,
+				"suspend_data":   nil,
+			}).Error; err != nil {
+			return fmt.Errorf("failed to update expired sagas: %w", err)
+		}
+
+		// Step 3: Update the corresponding step results to FAILED.
 		for _, saga := range expired {
 			stepUpdate := tx.Model(&SagaStepResult{}).
 				Where("saga_instance_id = ? AND status = ?", saga.ID, StepStatusSuspended).


### PR DESCRIPTION
## Summary

- Resolve nightly "Slow Integration Tests" timeout caused by ~60 integration tests each starting their own CockroachDB testcontainer (~15s startup each), exceeding the 15-minute per-package timeout
- Fix CockroachDB `FOR UPDATE SKIP LOCKED` incompatibility in `timeout_worker.go` (same class of issue fixed in `claiming.go` by PR #689)
- Guard `RunSagaMigrations` against re-invocation failures on CockroachDB (GORM AutoMigrate SQLSTATE 42704 on constraint naming mismatch)

## Changes Made

### `shared/pkg/saga/test_helpers_test.go`
- Add `TestMain` with a shared CockroachDB container for all integration tests
- Use `sync.Once` lazy initialization so the container is only started when integration tests actually run (not in `-short` mode)
- Each test gets clean tables via `DELETE FROM` before execution (FK-safe ordering)
- **Result**: Package test time reduced from >15 minutes to ~22 seconds

### `shared/pkg/saga/timeout_worker.go`
- Remove `SKIP LOCKED` from `FOR UPDATE` clause (CockroachDB serializable isolation silently returns empty results with `SKIP LOCKED`)
- Split CTE+UPDATE into separate SELECT and UPDATE steps (CockroachDB requires `FOR UPDATE` at the top level of SELECT statements, not inside CTEs)
- Same pattern applied in `claiming.go` by PR #689

### `shared/pkg/saga/migrations.go`
- Skip `AutoMigrate` when tables already exist to avoid CockroachDB constraint naming mismatch (SQLSTATE 42704)
- Partial indexes and composite constraints remain idempotent via `IF NOT EXISTS` / `information_schema` checks

## Testing

- [x] All saga integration tests pass (~22s total)
- [x] Short mode tests pass (no container started)
- [x] `TestIntegration_TimeoutWorker_ExpiresSuspendedSagas` passes (previously failing on CockroachDB)
- [x] `TestIntegration_MultipleSuspensions_SameSaga` passes (previously timing out)
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)

## Risk Assessment

**Low risk**. The shared container pattern is a standard testcontainers best practice. The `RunSagaMigrations` guard only skips AutoMigrate when tables already exist (production starts from Flyway migrations, not GORM AutoMigrate). The timeout worker fix follows the same CockroachDB-compatible pattern already established in `claiming.go`.