### PR TITLE
feat(saga): Add bitemporal tracking for historical replay

### DIFF
--- a/services/reference-data/migrations/20260129000001_bitemporal_platform_sagas.sql
+++ b/services/reference-data/migrations/20260129000001_bitemporal_platform_sagas.sql
@@ -1,0 +1,29 @@
+-- Add bitemporal tracking columns to platform_saga_definition
+--
+-- This migration adds system-time temporal columns (valid_from, valid_to) to
+-- platform_saga_definition for historical replay and audit queries.
+--
+-- The temporal columns complement the existing status/version columns:
+-- - status (ACTIVE/DEPRECATED) controls which version is used for NEW executions
+-- - valid_from/valid_to records WHEN each version was the active version
+--
+-- This enables point-in-time queries: "Which version was active at time T?"
+-- which is essential for audit trails, regulatory reporting, and replay analysis.
+--
+-- IMPORTANT: This migration runs per-tenant but modifies objects in the shared
+-- public schema. All DDL statements must be idempotent to avoid errors when
+-- multiple tenant schemas apply the same migration.
+--
+-- NOTE: Constraints and indexes on the new columns are added in the next
+-- migration (20260129000002) because CockroachDB cannot create partial indexes
+-- on columns added in the same schema change batch.
+
+-- Add valid_from column: when this version became effective
+-- Default to NOW() so existing rows get a sensible baseline
+ALTER TABLE public.platform_saga_definition
+  ADD COLUMN IF NOT EXISTS valid_from TIMESTAMPTZ NOT NULL DEFAULT now();
+
+-- Add valid_to column: when this version ceased being the active version
+-- NULL means this is the currently active version
+ALTER TABLE public.platform_saga_definition
+  ADD COLUMN IF NOT EXISTS valid_to TIMESTAMPTZ NULL;

--- a/services/reference-data/migrations/20260129000002_bitemporal_platform_sagas_constraints.sql
+++ b/services/reference-data/migrations/20260129000002_bitemporal_platform_sagas_constraints.sql
@@ -1,0 +1,27 @@
+-- Add constraints and indexes for bitemporal tracking columns
+--
+-- This migration adds a CHECK constraint and index on the valid_from/valid_to
+-- columns added in the previous migration (20260129000001).
+--
+-- Separated into its own migration because CockroachDB cannot create indexes
+-- on columns added in the same schema change batch.
+--
+-- IMPORTANT: This migration runs per-tenant but modifies objects in the shared
+-- public schema. All DDL statements must be idempotent to avoid errors when
+-- multiple tenant schemas apply the same migration.
+
+-- Check constraint: valid_to must be strictly after valid_from
+ALTER TABLE public.platform_saga_definition
+  ADD CONSTRAINT IF NOT EXISTS chk_platform_saga_definition_validity_range
+    CHECK (valid_to IS NULL OR valid_to > valid_from);
+
+-- Index for temporal lookups: "which version of saga X was active at time T?"
+CREATE INDEX IF NOT EXISTS idx_platform_saga_definition_temporal_lookup
+  ON public.platform_saga_definition (name, valid_from, valid_to);
+
+-- Add column comments
+COMMENT ON COLUMN public.platform_saga_definition.valid_from IS
+  'System time when this version became effective. Set to NOW() on insert.';
+
+COMMENT ON COLUMN public.platform_saga_definition.valid_to IS
+  'System time when this version was superseded. NULL means currently active. Set when a newer version is activated.';

--- a/services/reference-data/saga/platform_sync.go
+++ b/services/reference-data/saga/platform_sync.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -51,6 +52,11 @@ type PlatformSagaDefinition struct {
 	PreviousVersion *string
 	DisplayName     string
 	Description     string
+	// ValidFrom is the system time when this version became effective.
+	ValidFrom time.Time
+	// ValidTo is the system time when this version was superseded.
+	// A nil value means this is the currently active version.
+	ValidTo *time.Time
 }
 
 // PlatformSync synchronizes embedded saga definitions to the platform_saga_definition table.
@@ -259,6 +265,10 @@ func (s *PlatformSync) syncSaga(ctx context.Context, saga PlatformSagaDefinition
 // activateLatestVersions sets status=ACTIVE for the highest version per saga
 // and DEPRECATED for all other versions in a single statement to avoid a
 // transient window where no ACTIVE rows exist.
+//
+// Temporal tracking: when a version transitions to DEPRECATED, valid_to is set
+// to NOW() to record when it ceased being the active version. The new ACTIVE
+// version retains its valid_from (set at insert time) with valid_to = NULL.
 func (s *PlatformSync) activateLatestVersions(ctx context.Context) error {
 	_, err := s.pool.Exec(ctx, `
 		WITH ranked_versions AS (
@@ -273,7 +283,12 @@ func (s *PlatformSync) activateLatestVersions(ctx context.Context) error {
 			FROM public.platform_saga_definition
 		)
 		UPDATE public.platform_saga_definition psd
-		SET status = CASE WHEN rv.rn = 1 THEN 'ACTIVE' ELSE 'DEPRECATED' END
+		SET status = CASE WHEN rv.rn = 1 THEN 'ACTIVE' ELSE 'DEPRECATED' END,
+			valid_to = CASE
+				WHEN rv.rn = 1 THEN NULL
+				WHEN psd.valid_to IS NULL THEN now()
+				ELSE psd.valid_to
+			END
 		FROM ranked_versions rv
 		WHERE psd.name = rv.name
 			AND psd.version = rv.version

--- a/services/reference-data/saga/platform_sync_test.go
+++ b/services/reference-data/saga/platform_sync_test.go
@@ -246,6 +246,8 @@ func setupPlatformTestDB(t *testing.T) (*pgxpool.Pool, func()) {
 		"20260127000001_fix_platform_saga_unique_constraint.sql",
 		"20260128000001_versioned_platform_sagas.sql",
 		"20260128000002_versioned_platform_sagas_constraints.sql",
+		"20260129000001_bitemporal_platform_sagas.sql",
+		"20260129000002_bitemporal_platform_sagas_constraints.sql",
 	}
 
 	for _, migration := range migrations {
@@ -924,6 +926,324 @@ func TestPlatformSync_MigrationConstraints(t *testing.T) {
 		// CockroachDB uses SQLSTATE 23514 for CHECK violations.
 		assert.Contains(t, err.Error(), "23514")
 	})
+}
+
+func TestPlatformSync_BitemporalTracking(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	sync := NewPlatformSync(pool)
+
+	t.Run("new versions have valid_from set and valid_to NULL", func(t *testing.T) {
+		id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.temporal_test.1.0.0"))
+		beforeInsert := time.Now().Add(-1 * time.Second)
+
+		_, err := sync.syncSaga(ctx, PlatformSagaDefinition{
+			ID:      id,
+			Name:    "temporal_test",
+			Version: "1.0.0",
+			Script:  "temporal script v1",
+		})
+		require.NoError(t, err)
+
+		var validFrom time.Time
+		var validTo *time.Time
+		err = pool.QueryRow(ctx, `
+			SELECT valid_from, valid_to FROM public.platform_saga_definition
+			WHERE name = 'temporal_test' AND version = '1.0.0'
+		`).Scan(&validFrom, &validTo)
+		require.NoError(t, err)
+
+		assert.True(t, validFrom.After(beforeInsert), "valid_from should be set to approximately now")
+		assert.Nil(t, validTo, "valid_to should be NULL for newly inserted version")
+	})
+
+	t.Run("deprecated version gets valid_to set during activation", func(t *testing.T) {
+		// Insert v1.0.0 and activate it
+		v1ID := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.temporal_deprecation.1.0.0"))
+		_, err := sync.syncSaga(ctx, PlatformSagaDefinition{
+			ID:      v1ID,
+			Name:    "temporal_deprecation",
+			Version: "1.0.0",
+			Script:  "v1 script",
+		})
+		require.NoError(t, err)
+		err = sync.activateLatestVersions(ctx)
+		require.NoError(t, err)
+
+		// Verify v1.0.0 is ACTIVE with valid_to NULL
+		var v1ValidTo *time.Time
+		err = pool.QueryRow(ctx, `
+			SELECT valid_to FROM public.platform_saga_definition
+			WHERE name = 'temporal_deprecation' AND version = '1.0.0'
+		`).Scan(&v1ValidTo)
+		require.NoError(t, err)
+		assert.Nil(t, v1ValidTo, "active version should have NULL valid_to")
+
+		// Insert v2.0.0 and activate
+		v2ID := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.temporal_deprecation.2.0.0"))
+		_, err = sync.syncSaga(ctx, PlatformSagaDefinition{
+			ID:      v2ID,
+			Name:    "temporal_deprecation",
+			Version: "2.0.0",
+			Script:  "v2 script",
+		})
+		require.NoError(t, err)
+		err = sync.activateLatestVersions(ctx)
+		require.NoError(t, err)
+
+		// v1.0.0 should now have valid_to set (deprecated)
+		err = pool.QueryRow(ctx, `
+			SELECT valid_to FROM public.platform_saga_definition
+			WHERE name = 'temporal_deprecation' AND version = '1.0.0'
+		`).Scan(&v1ValidTo)
+		require.NoError(t, err)
+		require.NotNil(t, v1ValidTo, "deprecated version should have valid_to set")
+
+		// v2.0.0 should have valid_to NULL (active)
+		var v2ValidTo *time.Time
+		err = pool.QueryRow(ctx, `
+			SELECT valid_to FROM public.platform_saga_definition
+			WHERE name = 'temporal_deprecation' AND version = '2.0.0'
+		`).Scan(&v2ValidTo)
+		require.NoError(t, err)
+		assert.Nil(t, v2ValidTo, "active version should have NULL valid_to")
+	})
+
+	t.Run("valid_to is preserved for already-deprecated versions", func(t *testing.T) {
+		// Insert three versions: v1, v2, v3
+		for _, v := range []string{"1.0.0", "2.0.0"} {
+			id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.preserve_valid_to."+v))
+			_, err := sync.syncSaga(ctx, PlatformSagaDefinition{
+				ID: id, Name: "preserve_valid_to", Version: v,
+				Script: "script " + v,
+			})
+			require.NoError(t, err)
+		}
+
+		// Activate: v2.0.0 active, v1.0.0 deprecated
+		err := sync.activateLatestVersions(ctx)
+		require.NoError(t, err)
+
+		// Record v1.0.0's valid_to timestamp
+		var v1ValidToOriginal *time.Time
+		err = pool.QueryRow(ctx, `
+			SELECT valid_to FROM public.platform_saga_definition
+			WHERE name = 'preserve_valid_to' AND version = '1.0.0'
+		`).Scan(&v1ValidToOriginal)
+		require.NoError(t, err)
+		require.NotNil(t, v1ValidToOriginal)
+
+		// Insert v3.0.0 and re-activate
+		v3ID := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.preserve_valid_to.3.0.0"))
+		_, err = sync.syncSaga(ctx, PlatformSagaDefinition{
+			ID: v3ID, Name: "preserve_valid_to", Version: "3.0.0",
+			Script: "script 3.0.0",
+		})
+		require.NoError(t, err)
+		err = sync.activateLatestVersions(ctx)
+		require.NoError(t, err)
+
+		// v1.0.0's valid_to should be unchanged (preserved, not overwritten)
+		var v1ValidToAfter *time.Time
+		err = pool.QueryRow(ctx, `
+			SELECT valid_to FROM public.platform_saga_definition
+			WHERE name = 'preserve_valid_to' AND version = '1.0.0'
+		`).Scan(&v1ValidToAfter)
+		require.NoError(t, err)
+		require.NotNil(t, v1ValidToAfter)
+		assert.True(t, v1ValidToOriginal.Equal(*v1ValidToAfter),
+			"v1.0.0 valid_to should be preserved, not overwritten on re-activation")
+	})
+
+	t.Run("validity range constraint rejects valid_to before valid_from", func(t *testing.T) {
+		past := time.Now().Add(-24 * time.Hour)
+		future := time.Now().Add(24 * time.Hour)
+
+		// valid_to < valid_from should fail the CHECK constraint
+		_, err := pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(name, version, script, status, valid_from, valid_to)
+			VALUES ('constraint_test', '1.0.0', 'script', 'ACTIVE', $1, $2)
+		`, future, past)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "23514", "should violate CHECK constraint")
+	})
+
+	t.Run("validity range constraint allows valid_to after valid_from", func(t *testing.T) {
+		past := time.Now().Add(-24 * time.Hour)
+		future := time.Now().Add(24 * time.Hour)
+
+		_, err := pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(name, version, script, status, valid_from, valid_to)
+			VALUES ('constraint_ok', '1.0.0', 'script', 'ACTIVE', $1, $2)
+		`, past, future)
+		require.NoError(t, err)
+	})
+
+	t.Run("validity range constraint allows NULL valid_to", func(t *testing.T) {
+		_, err := pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(name, version, script, status, valid_from, valid_to)
+			VALUES ('constraint_null', '1.0.0', 'script', 'ACTIVE', now(), NULL)
+		`)
+		require.NoError(t, err)
+	})
+
+	t.Run("validity range constraint rejects equal valid_from and valid_to", func(t *testing.T) {
+		now := time.Now()
+		_, err := pool.Exec(ctx, `
+			INSERT INTO public.platform_saga_definition
+				(name, version, script, status, valid_from, valid_to)
+			VALUES ('constraint_equal', '1.0.0', 'script', 'ACTIVE', $1, $2)
+		`, now, now)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "23514", "equal valid_from/valid_to should violate CHECK (strict >)")
+	})
+}
+
+func TestGetPlatformSagaAtTime(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+
+	// Create a registry for the GetPlatformSagaAtTime method
+	registry := NewPostgresRegistry(pool, nil)
+
+	// Set up timeline:
+	// t0: v1.0.0 inserted (valid_from=t0, valid_to=t1)
+	// t1: v2.0.0 inserted (valid_from=t1, valid_to=NULL) -- currently active
+	t0 := time.Now().Add(-2 * time.Hour)
+	t1 := time.Now().Add(-1 * time.Hour)
+
+	// Insert v1.0.0: was active from t0 to t1
+	v1ID := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.at_time_test.1.0.0"))
+	_, err := pool.Exec(ctx, `
+		INSERT INTO public.platform_saga_definition
+			(id, name, version, script, status, valid_from, valid_to, display_name, description)
+		VALUES ($1, 'at_time_test', '1.0.0', 'v1 script content', 'DEPRECATED', $2, $3, 'At Time Test', 'Version 1')
+	`, v1ID, t0, t1)
+	require.NoError(t, err)
+
+	// Insert v2.0.0: active from t1 onwards
+	v2ID := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.at_time_test.2.0.0"))
+	_, err = pool.Exec(ctx, `
+		INSERT INTO public.platform_saga_definition
+			(id, name, version, script, status, valid_from, valid_to, display_name, description)
+		VALUES ($1, 'at_time_test', '2.0.0', 'v2 script content', 'ACTIVE', $2, NULL, 'At Time Test', 'Version 2')
+	`, v2ID, t1)
+	require.NoError(t, err)
+
+	t.Run("resolves v1 when querying between t0 and t1", func(t *testing.T) {
+		queryTime := t0.Add(30 * time.Minute) // midpoint between t0 and t1
+		result, err := registry.GetPlatformSagaAtTime(ctx, "at_time_test", queryTime)
+		require.NoError(t, err)
+		assert.Equal(t, v1ID, result.ID)
+		assert.Equal(t, "1.0.0", result.Version)
+		assert.Equal(t, "v1 script content", result.Script)
+		assert.Equal(t, "At Time Test", result.DisplayName)
+	})
+
+	t.Run("resolves v2 when querying after t1", func(t *testing.T) {
+		queryTime := t1.Add(30 * time.Minute)
+		result, err := registry.GetPlatformSagaAtTime(ctx, "at_time_test", queryTime)
+		require.NoError(t, err)
+		assert.Equal(t, v2ID, result.ID)
+		assert.Equal(t, "2.0.0", result.Version)
+		assert.Equal(t, "v2 script content", result.Script)
+	})
+
+	t.Run("resolves v1 exactly at valid_from boundary", func(t *testing.T) {
+		result, err := registry.GetPlatformSagaAtTime(ctx, "at_time_test", t0)
+		require.NoError(t, err)
+		assert.Equal(t, v1ID, result.ID, "exactly at valid_from should match (using <=)")
+	})
+
+	t.Run("resolves v2 exactly at t1 boundary", func(t *testing.T) {
+		// At t1: v1.0.0 has valid_to=t1 (exclusive), v2.0.0 has valid_from=t1 (inclusive)
+		result, err := registry.GetPlatformSagaAtTime(ctx, "at_time_test", t1)
+		require.NoError(t, err)
+		assert.Equal(t, v2ID, result.ID,
+			"at the transition boundary, the new version should be resolved (v1.valid_to=t1 is exclusive, v2.valid_from=t1 is inclusive)")
+	})
+
+	t.Run("returns not found before first version", func(t *testing.T) {
+		queryTime := t0.Add(-1 * time.Hour) // before v1.0.0 existed
+		_, err := registry.GetPlatformSagaAtTime(ctx, "at_time_test", queryTime)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPlatformDefinitionNotFound)
+	})
+
+	t.Run("returns not found for non-existent saga name", func(t *testing.T) {
+		_, err := registry.GetPlatformSagaAtTime(ctx, "nonexistent_saga", time.Now())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPlatformDefinitionNotFound)
+	})
+
+	t.Run("resolves current time for currently active version", func(t *testing.T) {
+		result, err := registry.GetPlatformSagaAtTime(ctx, "at_time_test", time.Now())
+		require.NoError(t, err)
+		assert.Equal(t, v2ID, result.ID, "current time should resolve to the active version with NULL valid_to")
+		assert.Nil(t, result.ValidTo, "active version should have nil ValidTo")
+		assert.False(t, result.ValidFrom.IsZero(), "ValidFrom should be populated")
+	})
+
+	t.Run("populates temporal fields on returned struct", func(t *testing.T) {
+		queryTime := t0.Add(30 * time.Minute)
+		result, err := registry.GetPlatformSagaAtTime(ctx, "at_time_test", queryTime)
+		require.NoError(t, err)
+
+		assert.False(t, result.ValidFrom.IsZero(), "ValidFrom should be populated")
+		require.NotNil(t, result.ValidTo, "ValidTo should be populated for deprecated version")
+		assert.True(t, result.ValidFrom.Before(*result.ValidTo),
+			"ValidFrom should be before ValidTo")
+	})
+}
+
+func TestGetPlatformSagaByID_IncludesTemporalFields(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	registry := NewPostgresRegistry(pool, nil)
+
+	past := time.Now().Add(-1 * time.Hour)
+	id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.byid_temporal.1.0.0"))
+	_, err := pool.Exec(ctx, `
+		INSERT INTO public.platform_saga_definition
+			(id, name, version, script, status, valid_from, valid_to)
+		VALUES ($1, 'byid_temporal', '1.0.0', 'script', 'DEPRECATED', $2, $3)
+	`, id, past, time.Now())
+	require.NoError(t, err)
+
+	result, err := registry.GetPlatformSagaByID(ctx, id)
+	require.NoError(t, err)
+	assert.False(t, result.ValidFrom.IsZero(), "GetPlatformSagaByID should populate ValidFrom")
+	assert.NotNil(t, result.ValidTo, "GetPlatformSagaByID should populate ValidTo for deprecated versions")
+}
+
+func TestGetPlatformSagaByName_IncludesTemporalFields(t *testing.T) {
+	pool, cleanup := setupPlatformTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	registry := NewPostgresRegistry(pool, nil)
+
+	id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.byname_temporal.1.0.0"))
+	_, err := pool.Exec(ctx, `
+		INSERT INTO public.platform_saga_definition
+			(id, name, version, script, status, valid_from, valid_to)
+		VALUES ($1, 'byname_temporal', '1.0.0', 'script', 'ACTIVE', now(), NULL)
+	`, id)
+	require.NoError(t, err)
+
+	result, err := registry.GetPlatformSagaByName(ctx, "byname_temporal")
+	require.NoError(t, err)
+	assert.False(t, result.ValidFrom.IsZero(), "GetPlatformSagaByName should populate ValidFrom")
+	assert.Nil(t, result.ValidTo, "active version should have nil ValidTo")
 }
 
 func TestPlatformSync_EmbeddedMetadataHeaders(t *testing.T) {

--- a/services/reference-data/saga/postgres_registry.go
+++ b/services/reference-data/saga/postgres_registry.go
@@ -707,7 +707,7 @@ func nullString(s string) sql.NullString {
 // version ID is recorded so replay always uses the same script.
 func (r *PostgresRegistry) GetPlatformSagaByID(ctx context.Context, id uuid.UUID) (*PlatformSagaDefinition, error) {
 	query := `
-		SELECT id, name, version, script, display_name, description
+		SELECT id, name, version, script, display_name, description, valid_from, valid_to
 		FROM public.platform_saga_definition
 		WHERE id = $1`
 
@@ -715,10 +715,12 @@ func (r *PostgresRegistry) GetPlatformSagaByID(ctx context.Context, id uuid.UUID
 
 	var psd PlatformSagaDefinition
 	var displayName, description sql.NullString
+	var validTo *time.Time
 
 	err := row.Scan(
 		&psd.ID, &psd.Name, &psd.Version, &psd.Script,
 		&displayName, &description,
+		&psd.ValidFrom, &validTo,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -727,6 +729,7 @@ func (r *PostgresRegistry) GetPlatformSagaByID(ctx context.Context, id uuid.UUID
 		return nil, fmt.Errorf("failed to query platform saga definition: %w", err)
 	}
 
+	psd.ValidTo = validTo
 	if displayName.Valid {
 		psd.DisplayName = displayName.String
 	}
@@ -742,7 +745,7 @@ func (r *PostgresRegistry) GetPlatformSagaByID(ctx context.Context, id uuid.UUID
 // with the highest semver version string.
 func (r *PostgresRegistry) GetPlatformSagaByName(ctx context.Context, name string) (*PlatformSagaDefinition, error) {
 	query := `
-		SELECT id, name, version, script, display_name, description
+		SELECT id, name, version, script, display_name, description, valid_from, valid_to
 		FROM public.platform_saga_definition
 		WHERE name = $1
 		ORDER BY
@@ -755,10 +758,12 @@ func (r *PostgresRegistry) GetPlatformSagaByName(ctx context.Context, name strin
 
 	var psd PlatformSagaDefinition
 	var displayName, description sql.NullString
+	var validTo *time.Time
 
 	err := row.Scan(
 		&psd.ID, &psd.Name, &psd.Version, &psd.Script,
 		&displayName, &description,
+		&psd.ValidFrom, &validTo,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -767,6 +772,55 @@ func (r *PostgresRegistry) GetPlatformSagaByName(ctx context.Context, name strin
 		return nil, fmt.Errorf("failed to query platform saga definition by name: %w", err)
 	}
 
+	psd.ValidTo = validTo
+	if displayName.Valid {
+		psd.DisplayName = displayName.String
+	}
+	if description.Valid {
+		psd.Description = description.String
+	}
+
+	return &psd, nil
+}
+
+// GetPlatformSagaAtTime retrieves the platform saga definition that was active
+// for the given saga name at the specified point in time.
+//
+// This enables historical audit queries: "Which version of saga X was active at time T?"
+// The query uses the bitemporal valid_from/valid_to range to find the version where:
+//   - valid_from <= asOfTime (version was effective at or before the query time)
+//   - valid_to IS NULL OR valid_to > asOfTime (version had not yet been superseded)
+//
+// Returns ErrPlatformDefinitionNotFound if no version was active at the specified time.
+func (r *PostgresRegistry) GetPlatformSagaAtTime(ctx context.Context, sagaName string, asOfTime time.Time) (*PlatformSagaDefinition, error) {
+	query := `
+		SELECT id, name, version, script, display_name, description, valid_from, valid_to
+		FROM public.platform_saga_definition
+		WHERE name = $1
+			AND valid_from <= $2
+			AND (valid_to IS NULL OR valid_to > $2)
+		ORDER BY valid_from DESC
+		LIMIT 1`
+
+	row := r.pool.QueryRow(ctx, query, sagaName, asOfTime)
+
+	var psd PlatformSagaDefinition
+	var displayName, description sql.NullString
+	var validTo *time.Time
+
+	err := row.Scan(
+		&psd.ID, &psd.Name, &psd.Version, &psd.Script,
+		&displayName, &description,
+		&psd.ValidFrom, &validTo,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrPlatformDefinitionNotFound
+		}
+		return nil, fmt.Errorf("failed to query platform saga at time: %w", err)
+	}
+
+	psd.ValidTo = validTo
 	if displayName.Valid {
 		psd.DisplayName = displayName.String
 	}


### PR DESCRIPTION
## Summary
- Add valid_from/valid_to temporal columns to platform_saga_definition for point-in-time version resolution
- Update PlatformSync to set valid_to on deprecated versions during activation, preserving already-set timestamps
- Add GetPlatformSagaAtTime query method for historical audit: "Which version was active at time T?"
- Update GetPlatformSagaByID and GetPlatformSagaByName to include temporal fields in results

## Technical Details

The temporal columns complement the existing status/version lifecycle columns from Task 1:
- **status** (ACTIVE/DEPRECATED) controls which version is used for new executions
- **valid_from/valid_to** records when each version was the active version, enabling temporal queries

Temporal semantics:
- valid_from is set to NOW() on insert (DB default)
- valid_to is set to NOW() when a version is deprecated via activateLatestVersions
- valid_to is NULL for the currently active version
- Already-set valid_to timestamps are preserved (not overwritten on re-activation)
- CHECK constraint enforces valid_to > valid_from (strict inequality)

### Migration strategy
Two migrations (following CockroachDB split pattern):
1. `20260129000001` - Add valid_from/valid_to columns with IF NOT EXISTS for idempotency
2. `20260129000002` - Add CHECK constraint and temporal lookup index

## Task Master
saga-script-versioning.2

## Test plan
- [x] Migration applies cleanly on CockroachDB testcontainer
- [x] Temporal constraint validation (valid_to > valid_from, rejects equal/reversed)
- [x] NULL valid_to allowed (currently active versions)
- [x] PlatformSync sets valid_to on deprecated versions during activation
- [x] PlatformSync preserves already-set valid_to timestamps
- [x] GetPlatformSagaAtTime resolves correct historical version
- [x] Boundary conditions: exactly at valid_from (inclusive), exactly at valid_to (exclusive)
- [x] Returns not found before first version existed
- [x] Returns not found for non-existent saga name
- [x] GetPlatformSagaByID includes temporal fields
- [x] GetPlatformSagaByName includes temporal fields
- [x] All existing tests pass (no regressions)