### PR TITLE
docs: Add implementation status headers to all PRDs

### DIFF
--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -64,19 +64,31 @@ These PRDs are used to generate Task Master tasks and are not tracked in git.
 |-----|-----------------|-------|
 | N/A (saga-script-versioning has no dedicated PRD) | `saga-script-versioning` | 2/3 done, 1 in-progress |
 
-#### Not Started (No Task Master Tasks)
+#### Implemented Under Other Tags (No Dedicated Tag)
+
+These PRDs were implemented by appending tasks to existing tags rather than creating dedicated tags.
+
+| PRD | Where Tracked | Notes |
+|-----|---------------|-------|
+| `prd-party-service.md` | `8-multi-tenancy`, `bian-alignment`, `tech-debt-cleanup`, `75-async-audit` | Party service fully operational at `services/party/` |
+| `api-gateway-service-prd.md` | `8-multi-tenancy`, `tech-debt-cleanup` | Gateway service at `services/gateway/`, JWT auth, subdomain routing |
+| `async-schema-provisioning-prd.md` | `8-multi-tenancy` (tasks 46-48) | Schema provisioner integrated into InitiateTenant workflow |
+| `external-tenant-isolation-prd.md` | `8-multi-tenancy`, `tech-debt-cleanup` | Subdomain resolution, slug cache, auth interceptor |
+| `prd-current-account-refactor.md` | `223-shared-client-patterns`, `position-keeping-balance`, `universal-asset-system`, `starlark-saga-orchestration` | Refactored across multiple initiatives |
+| `prd-docs-sync-q1-2026.md` | `tech-debt-cleanup` (task 53) | Documentation sync completed |
+| `prd-multi-tenancy-phase2.md` | `8-multi-tenancy` | Most critical gaps addressed (89/95 done), 1 deferred (K8s wildcard ingress) |
+
+#### Partially Addressed
+
+| PRD | Where Tracked | Remaining |
+|-----|---------------|-----------|
+| `prd-concurrency-reliability-q1-2026.md` | `tech-debt-cleanup` (deadlock fix), `8-multi-tenancy` (retry logic) | Needs review to identify unaddressed items |
+
+#### Not Started
 
 | PRD | Description | Date Created |
 |-----|-------------|--------------|
-| `api-gateway-service-prd.md` | Dynamic subdomain routing for tenant isolation | 2025-12-26 |
-| `async-schema-provisioning-prd.md` | Async schema provisioning for multi-tenant onboarding | 2025-12-26 |
-| `external-tenant-isolation-prd.md` | Edge isolation for multi-tenancy | 2025-12-26 |
-| `prd-concurrency-reliability-q1-2026.md` | Concurrency and reliability fixes | 2026-01-01 |
-| `prd-current-account-refactor.md` | Current account refactor (tag: `253-current-account-refactor`) | 2025-12-08 |
-| `prd-docs-sync-q1-2026.md` | Documentation sync after service client migration | 2026-01-01 |
 | `prd-internal-bank-account-integration-phase2.md` | Phase 2: FA, Payment Order, Position Keeping integration | 2026-01-15 |
-| `prd-multi-tenancy-phase2.md` | Multi-tenancy critical gap remediation | 2025-12-12 |
-| `prd-party-service.md` | Party service (tag: `252-party-service`) | 2025-12-08 |
 
 ### Other Documents (`.taskmaster/docs/`)
 

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -3,6 +3,87 @@
 This directory contains Product Requirements Documents for Meridian features. Like ADRs, these
 documents are configured as Claude Code skills that automatically load when relevant triggers match.
 
+## PRD Status Overview
+
+### Status Definitions
+
+| Status | Meaning |
+|--------|---------|
+| **Implemented** | All tasks completed (remaining tasks cancelled or deferred) |
+| **Paused** | Mostly implemented with deferred items remaining |
+| **In Progress** | Active work ongoing |
+| **Not Started** | PRD exists but no Task Master tasks created |
+
+### Git-Tracked PRDs (`docs/prd/`)
+
+| PRD | Status | Task Master Tag | Tasks |
+|-----|--------|-----------------|-------|
+| [Durable Execution Engine](durable-execution-engine.md) | Implemented | `starlark-saga-orchestration` | 24/24 done |
+| [Internal Bank Account](internal-bank-account.md) | Implemented | `internal-bank-account` | 33/33 done |
+| [Market Information Management](market-information-management.md) | Implemented | `market-information-management` | 17/18 done, 1 cancelled |
+| [Meridian Edge](meridian-edge.md) | Not Started | N/A | N/A |
+| [Starlark Saga Orchestration (Core)](starlark-saga-orchestration-core.md) | Implemented | `starlark-saga-orchestration` | 24/24 done |
+| [Starlark Typed Service Clients](starlark-typed-service-clients.md) | Implemented | `starlark-typed-clients` | 10/10 done |
+| [Universal Asset System](universal-asset-system.md) | Implemented | `universal-asset-system` | 36/36 done |
+
+### Task Master PRDs (`.taskmaster/docs/`)
+
+These PRDs are used to generate Task Master tasks and are not tracked in git.
+
+#### Implemented
+
+| PRD | Task Master Tag | Tasks |
+|-----|-----------------|-------|
+| `prd-infra.md` | `1-infra-completed-2025-10-30` | 11/11 done |
+| `prd-api-contracts.md` | `2-api-contracts-completed-2024-12-15` | 16/19 done, 3 cancelled |
+| `prd-platform.md` | `3-platform` | 10/10 done |
+| `prd-financial-accounting.md` | `4-financial-accounting` | 9/10 done, 1 cancelled |
+| `prd-position-keeping.md` | `5-position-keeping` | 15/15 done |
+| `prd-current-account.md` | `6-current-account` | 10/10 done |
+| `prd-payment-order.md` | `7-payment-order` | 19/19 done |
+| `prd-99-horizon-proof.md` | `99-horizon-proof` | 10/10 done |
+| `go-compile-time-safety-prd.md` | `go-compile-time-safety-completed-2024-12-15` | 7/10 done, 3 cancelled |
+| `prd-technical-debt-remediation.md` | `tech-debt-cleanup` | 71/71 done |
+| `prd-position-keeping-balance-ownership.md` | `position-keeping-balance` | 17/17 done |
+| `prd-database-per-service.md` | `database-per-service` | 14/15 done, 1 cancelled |
+| `prd.md` (Master) | `master` | 5/5 done |
+
+#### Paused (Deferred Items Remain)
+
+| PRD | Task Master Tag | Tasks | Deferred |
+|-----|-----------------|-------|----------|
+| `prd-multi-tenancy.md` | `8-multi-tenancy` | 89/95 done, 5 cancelled | 1 deferred |
+| `ledger-integrity-prd.md` | `ledger-integrity` | 14/15 done | 1 deferred |
+| `prd-audit-foundation.md` | `75-async-audit` | 19/20 done | 1 deferred |
+| `prd-bian-alignment.md` | `bian-alignment` | 6/15 done, 4 cancelled | 5 deferred |
+| `prd-iso-standards-alignment.md` | `iso-standards-alignment` | 4/15 done, 6 cancelled | 5 deferred |
+
+#### In Progress
+
+| PRD | Task Master Tag | Tasks |
+|-----|-----------------|-------|
+| N/A (saga-script-versioning has no dedicated PRD) | `saga-script-versioning` | 2/3 done, 1 in-progress |
+
+#### Not Started (No Task Master Tasks)
+
+| PRD | Description | Date Created |
+|-----|-------------|--------------|
+| `api-gateway-service-prd.md` | Dynamic subdomain routing for tenant isolation | 2025-12-26 |
+| `async-schema-provisioning-prd.md` | Async schema provisioning for multi-tenant onboarding | 2025-12-26 |
+| `external-tenant-isolation-prd.md` | Edge isolation for multi-tenancy | 2025-12-26 |
+| `prd-concurrency-reliability-q1-2026.md` | Concurrency and reliability fixes | 2026-01-01 |
+| `prd-current-account-refactor.md` | Current account refactor (tag: `253-current-account-refactor`) | 2025-12-08 |
+| `prd-docs-sync-q1-2026.md` | Documentation sync after service client migration | 2026-01-01 |
+| `prd-internal-bank-account-integration-phase2.md` | Phase 2: FA, Payment Order, Position Keeping integration | 2026-01-15 |
+| `prd-multi-tenancy-phase2.md` | Multi-tenancy critical gap remediation | 2025-12-12 |
+| `prd-party-service.md` | Party service (tag: `252-party-service`) | 2025-12-08 |
+
+### Other Documents (`.taskmaster/docs/`)
+
+| File | Type |
+|------|------|
+| `panic-audit-inventory.md` | Audit inventory (reference doc, not a PRD) |
+
 ## What are PRDs?
 
 PRDs define the requirements, design, and implementation approach for significant features. They:
@@ -12,16 +93,6 @@ PRDs define the requirements, design, and implementation approach for significan
 - Define Task Master tags for tracking work
 - Link to related ADRs for architectural decisions
 
-## PRD Index
-
-| PRD | Title | Status | Task Master Tag |
-|-----|-------|--------|-----------------|
-| [Universal Asset System](universal-asset-system.md) | Multi-asset ledger support | Draft | `universal-asset-system` |
-| [Internal Bank Account](internal-bank-account.md) | Non-customer-facing account management | Draft | `internal-bank-account` |
-| [Market Information Management](market-information-management.md) | Market data, pricing feeds, and external datasets | Draft | `market-information-management` |
-| [Meridian Edge](meridian-edge.md) | Embedded financial kernel for IoT/Browser | Proposed | `meridian-edge` |
-| [Starlark Typed Service Clients](starlark-typed-service-clients.md) | Type-safe service handlers for saga orchestration | Draft | `starlark-typed-clients` |
-
 ## Categories
 
 ### Core Platform
@@ -30,6 +101,11 @@ PRDs define the requirements, design, and implementation approach for significan
 - [Internal Bank Account](internal-bank-account.md) - BIAN service for clearing, nostro/vostro accounts
 - [Market Information Management](market-information-management.md) - BIAN service for market data and pricing
 - [Starlark Typed Service Clients](starlark-typed-service-clients.md) - Type-safe service handlers for saga orchestration
+
+### Execution Engine
+
+- [Starlark Saga Orchestration (Core)](starlark-saga-orchestration-core.md) - Runtime-configurable saga definitions
+- [Durable Execution Engine](durable-execution-engine.md) - Resilience layer for saga execution
 
 ### Deployment Targets
 
@@ -66,8 +142,9 @@ Claude Code loads PRDs when:
    - `triggers`: List of scenarios when this PRD should load
    - `instructions`: Key guidance for Claude Code
 3. Write the PRD content following the existing structure
-4. Update this README with the new entry
-5. If applicable, create related ADRs for architectural decisions
+4. Set **Status** to `Not Started` until Task Master tasks are created
+5. Update this README with the new entry
+6. If applicable, create related ADRs for architectural decisions
 
 ## PRD Structure
 

--- a/docs/prd/durable-execution-engine.md
+++ b/docs/prd/durable-execution-engine.md
@@ -1,7 +1,8 @@
 # PRD: Durable Execution Engine
 
-**Status:** Production-Ready
+**Status:** Implemented
 **Version:** 1.1
+**Task Master Tag:** `starlark-saga-orchestration` (24/24 tasks done)
 **Companion PRD:** [Starlark Saga Orchestration (Core)](./starlark-saga-orchestration-core.md)
 
 ---

--- a/docs/prd/internal-bank-account.md
+++ b/docs/prd/internal-bank-account.md
@@ -18,10 +18,11 @@ instructions: |
 
 # PRD: Internal Bank Account Service
 
-**Status:** Draft
+**Status:** Implemented
 **Version:** 1.0
 **Date:** 2026-01-06
 **Author:** Architecture Team
+**Task Master Tag:** `internal-bank-account` (33/33 tasks done)
 
 **ADRs:**
 

--- a/docs/prd/market-information-management.md
+++ b/docs/prd/market-information-management.md
@@ -18,10 +18,11 @@ instructions: |
 
 # PRD: Market Information Management Service
 
-**Status:** Draft
+**Status:** Implemented
 **Version:** 1.3
 **Date:** 2026-01-17
 **Author:** Architecture Team
+**Task Master Tag:** `market-information-management` (17/18 tasks done, 1 cancelled)
 
 **Version History:**
 

--- a/docs/prd/meridian-edge.md
+++ b/docs/prd/meridian-edge.md
@@ -24,7 +24,7 @@ instructions: |
 | Meta | Details |
 |:-----|:--------|
 | **Project Name** | Meridian Edge |
-| **Status** | Proposed |
+| **Status** | Not Started |
 | **Type** | New Build Target (Modular Monolith) |
 | **Target Hardware** | Raspberry Pi Zero 2 W / ARM64 / Android / Linux IoT / Browser (WASM) |
 | **Core Philosophy** | "Local Authority, Global Consistency" |

--- a/docs/prd/starlark-saga-orchestration-core.md
+++ b/docs/prd/starlark-saga-orchestration-core.md
@@ -1,8 +1,9 @@
 # PRD: Starlark Saga Orchestration (Core)
 
-**Status:** Production-Ready
+**Status:** Implemented
 **Version:** 1.1
 **Author:** Architecture Team
+**Task Master Tag:** `starlark-saga-orchestration` (24/24 tasks done)
 **ADR Reference:** [ADR-028](../adr/0028-starlark-saga-cel-valuation.md)
 **Companion PRD:** [Durable Execution Engine](./durable-execution-engine.md)
 

--- a/docs/prd/starlark-typed-service-clients.md
+++ b/docs/prd/starlark-typed-service-clients.md
@@ -1,5 +1,8 @@
 # PRD: Starlark Typed Service Clients
 
+**Status:** Implemented
+**Task Master Tag:** `starlark-typed-clients` (10/10 tasks done)
+
 ## Problem Statement
 
 Currently, Meridian's saga definitions use magic strings to reference service handlers:

--- a/docs/prd/universal-asset-system.md
+++ b/docs/prd/universal-asset-system.md
@@ -18,13 +18,12 @@ instructions: |
 
 # PRD: Universal Asset System
 
-**Status:** Draft
+**Status:** Implemented
+**Task Master Tag:** `universal-asset-system` (36/36 tasks done)
 **ADRs:**
 
 - [0013 - Universal Quantity Type System](../adr/0013-generic-asset-quantity-types.md)
 - [0014 - Financial Instrument Reference Data](../adr/0014-financial-instrument-reference-data.md)
-
-**Target Task Master Tag:** `universal-asset-system`
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Update all 7 git-tracked PRDs with accurate implementation status based on Task Master completion data
- Replace stale "Draft" and "Proposed" statuses with "Implemented" or "Not Started"
- Add Task Master tag references and task counts to each PRD header
- Overhaul `docs/prd/README.md` with comprehensive PRD inventory covering all 35+ PRDs across both `docs/prd/` and `.taskmaster/docs/`

## Changes Made

**PRD status updates (6 Implemented, 1 Not Started):**
- `durable-execution-engine.md`: Production-Ready -> Implemented (24/24 tasks)
- `internal-bank-account.md`: Draft -> Implemented (33/33 tasks)
- `market-information-management.md`: Draft -> Implemented (17/18 tasks, 1 cancelled)
- `starlark-saga-orchestration-core.md`: Production-Ready -> Implemented (24/24 tasks)
- `starlark-typed-service-clients.md`: (no status) -> Implemented (10/10 tasks)
- `universal-asset-system.md`: Draft -> Implemented (36/36 tasks)
- `meridian-edge.md`: Proposed -> Not Started (no Task Master tasks)

**README overhaul:**
- Status definitions table (Implemented, Paused, In Progress, Not Started)
- Git-tracked PRDs inventory with status and task counts
- `.taskmaster/docs/` PRDs inventory organized by status
- 9 PRDs identified as Not Started (no Task Master tasks created)
- Updated "Creating New PRDs" section to reference status headers

## Test plan

- [ ] Verify markdown renders correctly in GitHub
- [ ] Confirm task counts match Task Master data