### PR TITLE
feat(saga): Migrate all .star scripts from invoke_handler to typed service modules

### DIFF
--- a/services/current-account/sagas/deposit.star
+++ b/services/current-account/sagas/deposit.star
@@ -13,6 +13,7 @@
 #
 # Compensation Order (LIFO - Last In, First Out):
 #   Failures trigger compensation of completed steps in reverse order.
+#   Compensation handlers are declared in handlers.yaml schema.
 #
 # Input data (provided via input_data dictionary):
 #   - account_id: string - Account identifier
@@ -34,115 +35,69 @@ transaction_id = input_data["transaction_id"]
 clearing_account_id = input_data.get("clearing_account_id", "")
 
 # Step 1: Log position in PositionKeeping service with CREDIT direction
-log_position_step = step(name="log_position")
-log_position_result = invoke_handler(
-    handler="current_account.position_keeping.initiate_log",
-    params={
-        "account_id": account_identification,
-        "amount": amount,
-        "currency": currency,
-        "direction": "CREDIT",
-        "transaction_id": transaction_id,
-    },
-    compensate_handler="current_account.position_keeping.cancel_log",
-    compensate_params={
-        "log_id": "${log_position_result.log_id}",
-        "version": "${log_position_result.version}",
-        "transaction_id": transaction_id,
-        "account_id": account_identification,
-        "direction": "CREDIT",
-    },
+step(name="log_position")
+log_position_result = position_keeping.initiate_log(
+    account_id=account_identification,
+    amount=amount,
+    currency=currency,
+    direction="CREDIT",
+    transaction_id=transaction_id,
 )
 
 # Step 2: Initiate booking log in FinancialAccounting service
-initiate_booking_step = step(name="initiate_booking_log")
-booking_log_result = invoke_handler(
-    handler="current_account.financial_accounting.initiate_booking_log",
-    params={
-        "account_id": account_id,
-        "currency": currency,
-        "transaction_id": transaction_id,
-        "transaction_type": "DEPOSIT",
-    },
+step(name="initiate_booking_log")
+booking_log_result = financial_accounting.initiate_booking_log(
+    account_id=account_id,
+    currency=currency,
+    transaction_id=transaction_id,
+    transaction_type="DEPOSIT",
 )
 
 # Step 3: Capture DEBIT posting to clearing account (if double-entry enabled)
 # For deposits: DEBIT the clearing account (where funds come from)
 if clearing_account_id != "":
-    debit_posting_step = step(name="capture_debit_posting")
-    debit_result = invoke_handler(
-        handler="current_account.financial_accounting.capture_posting",
-        params={
-            "booking_log_id": "${booking_log_result.booking_log_id}",
-            "account_id": clearing_account_id,
-            "amount": amount,
-            "currency": currency,
-            "direction": "DEBIT",
-            "transaction_id": transaction_id,
-            "posting_type": "debit",
-        },
-        compensate_handler="current_account.financial_accounting.compensate_posting",
-        compensate_params={
-            "booking_log_id": "${booking_log_result.booking_log_id}",
-            "account_id": clearing_account_id,
-            "amount": amount,
-            "currency": currency,
-            "direction": "CREDIT",  # Reverse direction for compensation
-            "transaction_id": transaction_id,
-            "posting_type": "debit",
-        },
+    step(name="capture_debit_posting")
+    debit_result = financial_accounting.capture_posting(
+        booking_log_id=booking_log_result.booking_log_id,
+        account_id=clearing_account_id,
+        amount=amount,
+        currency=currency,
+        direction="DEBIT",
+        transaction_id=transaction_id,
+        posting_type="debit",
     )
 
 # Step 4: Capture CREDIT posting to customer account
-credit_posting_step = step(name="capture_credit_posting")
-credit_result = invoke_handler(
-    handler="current_account.financial_accounting.capture_posting",
-    params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "account_id": account_id,
-        "amount": amount,
-        "currency": currency,
-        "direction": "CREDIT",
-        "transaction_id": transaction_id,
-        "posting_type": "credit",
-    },
-    compensate_handler="current_account.financial_accounting.compensate_posting",
-    compensate_params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "account_id": account_id,
-        "amount": amount,
-        "currency": currency,
-        "direction": "DEBIT",  # Reverse direction for compensation
-        "transaction_id": transaction_id,
-        "posting_type": "credit",
-    },
+step(name="capture_credit_posting")
+credit_result = financial_accounting.capture_posting(
+    booking_log_id=booking_log_result.booking_log_id,
+    account_id=account_id,
+    amount=amount,
+    currency=currency,
+    direction="CREDIT",
+    transaction_id=transaction_id,
+    posting_type="credit",
 )
 
 # Step 5: Finalize booking log (transition to POSTED)
-finalize_booking_step = step(name="finalize_booking_log")
-finalize_result = invoke_handler(
-    handler="current_account.financial_accounting.update_booking_log",
-    params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "status": "POSTED",
-    },
+step(name="finalize_booking_log")
+finalize_result = financial_accounting.update_booking_log(
+    booking_log_id=booking_log_result.booking_log_id,
+    status="POSTED",
 )
 
 # Step 6: Save account metadata
-save_account_step = step(name="save_account")
-save_result = invoke_handler(
-    handler="current_account.repository.save",
-    params={
-        "account_id": account_id,
-        "transaction_id": transaction_id,
-    },
+step(name="save_account")
+save_result = current_account.save(
+    account_id=account_id,
+    transaction_id=transaction_id,
 )
 
 # Output the saga result
 result = {
     "status": "COMPLETED",
     "transaction_id": transaction_id,
-    "position_log_id": log_position_result["log_id"],
-    "booking_log_id": booking_log_result["booking_log_id"],
-    "credit_posting_id": credit_result["posting_id"],
+    "position_log_id": log_position_result.log_id,
+    "booking_log_id": booking_log_result.booking_log_id,
+    "credit_posting_id": credit_result.posting_id,
 }

--- a/services/current-account/sagas/withdrawal.star
+++ b/services/current-account/sagas/withdrawal.star
@@ -13,6 +13,7 @@
 #
 # Compensation Order (LIFO - Last In, First Out):
 #   Failures trigger compensation of completed steps in reverse order.
+#   Compensation handlers are declared in handlers.yaml schema.
 #
 # Input data (provided via input_data dictionary):
 #   - account_id: string - Account identifier
@@ -34,114 +35,68 @@ transaction_id = input_data["transaction_id"]
 clearing_account_id = input_data.get("clearing_account_id", "")
 
 # Step 1: Log position in PositionKeeping service with DEBIT direction
-log_position_step = step(name="log_position")
-log_position_result = invoke_handler(
-    handler="current_account.position_keeping.initiate_log",
-    params={
-        "account_id": account_identification,
-        "amount": amount,
-        "currency": currency,
-        "direction": "DEBIT",
-        "transaction_id": transaction_id,
-    },
-    compensate_handler="current_account.position_keeping.cancel_log",
-    compensate_params={
-        "log_id": "${log_position_result.log_id}",
-        "version": "${log_position_result.version}",
-        "transaction_id": transaction_id,
-        "account_id": account_identification,
-        "direction": "DEBIT",
-    },
+step(name="log_position")
+log_position_result = position_keeping.initiate_log(
+    account_id=account_identification,
+    amount=amount,
+    currency=currency,
+    direction="DEBIT",
+    transaction_id=transaction_id,
 )
 
 # Step 2: Initiate booking log in FinancialAccounting service
-initiate_booking_step = step(name="initiate_booking_log")
-booking_log_result = invoke_handler(
-    handler="current_account.financial_accounting.initiate_booking_log",
-    params={
-        "account_id": account_id,
-        "currency": currency,
-        "transaction_id": transaction_id,
-        "transaction_type": "WITHDRAWAL",
-    },
+step(name="initiate_booking_log")
+booking_log_result = financial_accounting.initiate_booking_log(
+    account_id=account_id,
+    currency=currency,
+    transaction_id=transaction_id,
+    transaction_type="WITHDRAWAL",
 )
 
 # Step 3: Capture DEBIT posting to customer account
-debit_posting_step = step(name="capture_debit_posting")
-debit_result = invoke_handler(
-    handler="current_account.financial_accounting.capture_posting",
-    params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "account_id": account_id,
-        "amount": amount,
-        "currency": currency,
-        "direction": "DEBIT",
-        "transaction_id": transaction_id,
-        "posting_type": "debit",
-    },
-    compensate_handler="current_account.financial_accounting.compensate_posting",
-    compensate_params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "account_id": account_id,
-        "amount": amount,
-        "currency": currency,
-        "direction": "CREDIT",  # Reverse direction for compensation
-        "transaction_id": transaction_id,
-        "posting_type": "debit",
-    },
+step(name="capture_debit_posting")
+debit_result = financial_accounting.capture_posting(
+    booking_log_id=booking_log_result.booking_log_id,
+    account_id=account_id,
+    amount=amount,
+    currency=currency,
+    direction="DEBIT",
+    transaction_id=transaction_id,
+    posting_type="debit",
 )
 
 # Step 4: Capture CREDIT posting to clearing account (if double-entry enabled)
 if clearing_account_id != "":
-    credit_posting_step = step(name="capture_credit_posting")
-    credit_result = invoke_handler(
-        handler="current_account.financial_accounting.capture_posting",
-        params={
-            "booking_log_id": "${booking_log_result.booking_log_id}",
-            "account_id": clearing_account_id,
-            "amount": amount,
-            "currency": currency,
-            "direction": "CREDIT",
-            "transaction_id": transaction_id,
-            "posting_type": "credit",
-        },
-        compensate_handler="current_account.financial_accounting.compensate_posting",
-        compensate_params={
-            "booking_log_id": "${booking_log_result.booking_log_id}",
-            "account_id": clearing_account_id,
-            "amount": amount,
-            "currency": currency,
-            "direction": "DEBIT",  # Reverse direction for compensation
-            "transaction_id": transaction_id,
-            "posting_type": "credit",
-        },
+    step(name="capture_credit_posting")
+    credit_result = financial_accounting.capture_posting(
+        booking_log_id=booking_log_result.booking_log_id,
+        account_id=clearing_account_id,
+        amount=amount,
+        currency=currency,
+        direction="CREDIT",
+        transaction_id=transaction_id,
+        posting_type="credit",
     )
 
 # Step 5: Finalize booking log (transition to POSTED)
-finalize_booking_step = step(name="finalize_booking_log")
-finalize_result = invoke_handler(
-    handler="current_account.financial_accounting.update_booking_log",
-    params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "status": "POSTED",
-    },
+step(name="finalize_booking_log")
+finalize_result = financial_accounting.update_booking_log(
+    booking_log_id=booking_log_result.booking_log_id,
+    status="POSTED",
 )
 
 # Step 6: Save account metadata
-save_account_step = step(name="save_account")
-save_result = invoke_handler(
-    handler="current_account.repository.save",
-    params={
-        "account_id": account_id,
-        "transaction_id": transaction_id,
-    },
+step(name="save_account")
+save_result = current_account.save(
+    account_id=account_id,
+    transaction_id=transaction_id,
 )
 
 # Output the saga result
 result = {
     "status": "COMPLETED",
     "transaction_id": transaction_id,
-    "position_log_id": log_position_result["log_id"],
-    "booking_log_id": booking_log_result["booking_log_id"],
-    "debit_posting_id": debit_result["posting_id"],
+    "position_log_id": log_position_result.log_id,
+    "booking_log_id": booking_log_result.booking_log_id,
+    "debit_posting_id": debit_result.posting_id,
 }

--- a/services/payment-order/sagas/payment_execution.star
+++ b/services/payment-order/sagas/payment_execution.star
@@ -10,6 +10,8 @@
 # Steps 3 and 4 are conditional - they are invoked asynchronously by webhook handlers
 # rather than immediately after step 2.
 #
+# Compensation handlers are declared in handlers.yaml schema.
+#
 # Input parameters (from input_data dict):
 #   - payment_order_id: string (required)
 #   - debtor_account_id: string (required)
@@ -39,47 +41,33 @@ def payment_execution():
     ctx = input_data
 
     # Step 1: Reserve funds with bucket-aware lien
-    lien_result = step(
-        name = "reserve_funds",
-        action = "payment_order.create_lien",
-        params = {
-            "account_id": ctx.get("debtor_account_id"),
-            "amount_cents": ctx.get("amount_cents"),
-            "currency": ctx.get("currency"),
-            "payment_order_id": ctx.get("payment_order_id"),
-            "instrument_code": ctx.get("instrument_code", ""),
-            "payment_attributes": ctx.get("payment_attributes", {}),
-        },
-        compensate = {
-            "action": "payment_order.terminate_lien",
-            "params_from_result": ["lien_id"],
-            "additional_params": {
-                "reason": "Payment order saga compensation",
-            },
-        },
+    step(name="reserve_funds")
+    lien_result = payment_order.create_lien(
+        account_id=ctx.get("debtor_account_id"),
+        amount_cents=ctx.get("amount_cents"),
+        currency=ctx.get("currency"),
+        payment_order_id=ctx.get("payment_order_id"),
+        instrument_code=ctx.get("instrument_code", ""),
+        payment_attributes=ctx.get("payment_attributes", {}),
     )
 
     # Store lien results in context for subsequent steps
-    lien_id = lien_result.get("lien_id", "")
-    bucket_id = lien_result.get("bucket_id", "")
+    lien_id = lien_result.lien_id
+    bucket_id = lien_result.bucket_id
 
     # Step 2: Send payment to gateway
-    gateway_result = step(
-        name = "send_to_gateway",
-        action = "payment_order.send_to_gateway",
-        params = {
-            "payment_order_id": ctx.get("payment_order_id"),
-            "debtor_account_id": ctx.get("debtor_account_id"),
-            "creditor_reference": ctx.get("creditor_reference"),
-            "amount_cents": ctx.get("amount_cents"),
-            "currency": ctx.get("currency"),
-            "idempotency_key": ctx.get("idempotency_key"),
-        },
-        # No compensation for gateway send - lien release handles rollback
+    step(name="send_to_gateway")
+    gateway_result = payment_order.send_to_gateway(
+        payment_order_id=ctx.get("payment_order_id"),
+        debtor_account_id=ctx.get("debtor_account_id"),
+        creditor_reference=ctx.get("creditor_reference"),
+        amount_cents=ctx.get("amount_cents"),
+        currency=ctx.get("currency"),
+        idempotency_key=ctx.get("idempotency_key"),
     )
 
-    gateway_reference_id = gateway_result.get("gateway_reference_id", "")
-    gateway_status = gateway_result.get("gateway_status", "")
+    gateway_reference_id = gateway_result.gateway_reference_id
+    gateway_status = gateway_result.gateway_status
 
     # Build initial result (returned after step 2 completes)
     # Steps 3 and 4 are conditional based on webhook flags
@@ -93,33 +81,27 @@ def payment_execution():
     # Step 3: Post ledger entries (conditional - triggered by webhook)
     # This step is called after the gateway confirms the payment via webhook
     if ctx.get("should_post_ledger", False):
-        ledger_result = step(
-            name = "post_ledger_entries",
-            action = "payment_order.post_ledger_entries",
-            params = {
-                "payment_order_id": ctx.get("payment_order_id"),
-                "debtor_account_id": ctx.get("debtor_account_id"),
-                "gateway_reference_id": gateway_reference_id,
-                "amount_cents": ctx.get("amount_cents"),
-                "currency": ctx.get("currency"),
-                "idempotency_key": ctx.get("idempotency_key"),
-                "internal_clearing_enabled": ctx.get("internal_clearing_enabled", False),
-            },
+        step(name="post_ledger_entries")
+        ledger_result = payment_order.post_ledger_entries(
+            payment_order_id=ctx.get("payment_order_id"),
+            debtor_account_id=ctx.get("debtor_account_id"),
+            gateway_reference_id=gateway_reference_id,
+            amount_cents=ctx.get("amount_cents"),
+            currency=ctx.get("currency"),
+            idempotency_key=ctx.get("idempotency_key"),
+            internal_clearing_enabled=ctx.get("internal_clearing_enabled", False),
         )
-        result["booking_log_id"] = ledger_result.get("booking_log_id", "")
+        result["booking_log_id"] = ledger_result.booking_log_id
 
     # Step 4: Execute lien (conditional - triggered by webhook after ledger posted)
     # This converts the reservation to an actual debit
     if ctx.get("should_execute_lien", False):
         if lien_id:
-            execution_result = step(
-                name = "execute_lien",
-                action = "payment_order.execute_lien",
-                params = {
-                    "lien_id": lien_id,
-                },
+            step(name="execute_lien")
+            execution_result = payment_order.execute_lien(
+                lien_id=lien_id,
             )
-            result["lien_execution_status"] = execution_result.get("execution_status", {})
+            result["lien_execution_status"] = execution_result.execution_status
 
     return result
 

--- a/services/reference-data/saga/defaults/deposit/v1.0.0.star
+++ b/services/reference-data/saga/defaults/deposit/v1.0.0.star
@@ -1,9 +1,9 @@
 # Saga: current_account_deposit
 # Version: 1.0.0
 # Previous: none
-# Changed: Initial version
+# Changed: Migrated from invoke_handler() to typed service modules
 # Author: Platform Team
-# Date: 2026-01-26
+# Date: 2026-01-27
 #
 # This Starlark script defines the deposit saga workflow for the Current Account service.
 # The saga executes a multi-step deposit operation with compensation on failure.
@@ -18,6 +18,7 @@
 #
 # Compensation Order (LIFO - Last In, First Out):
 #   Failures trigger compensation of completed steps in reverse order.
+#   Compensation handlers are declared in handlers.yaml schema.
 #
 # Input data (provided via input_data dictionary):
 #   - account_id: string - Account identifier
@@ -39,108 +40,62 @@ transaction_id = input_data["transaction_id"]
 clearing_account_id = input_data.get("clearing_account_id", "")
 
 # Step 1: Log position in PositionKeeping service with CREDIT direction
-log_position_step = step(name="log_position")
-log_position_result = invoke_handler(
-    handler="current_account.position_keeping.initiate_log",
-    params={
-        "account_id": account_identification,
-        "amount": amount,
-        "currency": currency,
-        "direction": "CREDIT",
-        "transaction_id": transaction_id,
-    },
-    compensate_handler="current_account.position_keeping.cancel_log",
-    compensate_params={
-        "log_id": "${log_position_result.log_id}",
-        "version": "${log_position_result.version}",
-        "transaction_id": transaction_id,
-        "account_id": account_identification,
-        "direction": "CREDIT",
-    },
+step(name="log_position")
+log_position_result = position_keeping.initiate_log(
+    account_id=account_identification,
+    amount=amount,
+    currency=currency,
+    direction="CREDIT",
+    transaction_id=transaction_id,
 )
 
 # Step 2: Initiate booking log in FinancialAccounting service
-initiate_booking_step = step(name="initiate_booking_log")
-booking_log_result = invoke_handler(
-    handler="current_account.financial_accounting.initiate_booking_log",
-    params={
-        "account_id": account_id,
-        "currency": currency,
-        "transaction_id": transaction_id,
-        "transaction_type": "DEPOSIT",
-    },
+step(name="initiate_booking_log")
+booking_log_result = financial_accounting.initiate_booking_log(
+    account_id=account_id,
+    currency=currency,
+    transaction_id=transaction_id,
+    transaction_type="DEPOSIT",
 )
 
 # Step 3: Capture DEBIT posting to clearing account (if double-entry enabled)
 # For deposits: DEBIT the clearing account (where funds come from)
 if clearing_account_id != "":
-    debit_posting_step = step(name="capture_debit_posting")
-    debit_result = invoke_handler(
-        handler="current_account.financial_accounting.capture_posting",
-        params={
-            "booking_log_id": "${booking_log_result.booking_log_id}",
-            "account_id": clearing_account_id,
-            "amount": amount,
-            "currency": currency,
-            "direction": "DEBIT",
-            "transaction_id": transaction_id,
-            "posting_type": "debit",
-        },
-        compensate_handler="current_account.financial_accounting.compensate_posting",
-        compensate_params={
-            "booking_log_id": "${booking_log_result.booking_log_id}",
-            "account_id": clearing_account_id,
-            "amount": amount,
-            "currency": currency,
-            "direction": "CREDIT",  # Reverse direction for compensation
-            "transaction_id": transaction_id,
-            "posting_type": "debit",
-        },
+    step(name="capture_debit_posting")
+    debit_result = financial_accounting.capture_posting(
+        booking_log_id=booking_log_result.booking_log_id,
+        account_id=clearing_account_id,
+        amount=amount,
+        currency=currency,
+        direction="DEBIT",
+        transaction_id=transaction_id,
+        posting_type="debit",
     )
 
 # Step 4: Capture CREDIT posting to customer account
-credit_posting_step = step(name="capture_credit_posting")
-credit_result = invoke_handler(
-    handler="current_account.financial_accounting.capture_posting",
-    params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "account_id": account_id,
-        "amount": amount,
-        "currency": currency,
-        "direction": "CREDIT",
-        "transaction_id": transaction_id,
-        "posting_type": "credit",
-    },
-    compensate_handler="current_account.financial_accounting.compensate_posting",
-    compensate_params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "account_id": account_id,
-        "amount": amount,
-        "currency": currency,
-        "direction": "DEBIT",  # Reverse direction for compensation
-        "transaction_id": transaction_id,
-        "posting_type": "credit",
-    },
+step(name="capture_credit_posting")
+credit_result = financial_accounting.capture_posting(
+    booking_log_id=booking_log_result.booking_log_id,
+    account_id=account_id,
+    amount=amount,
+    currency=currency,
+    direction="CREDIT",
+    transaction_id=transaction_id,
+    posting_type="credit",
 )
 
 # Step 5: Finalize booking log (transition to POSTED)
-finalize_booking_step = step(name="finalize_booking_log")
-finalize_result = invoke_handler(
-    handler="current_account.financial_accounting.update_booking_log",
-    params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "status": "POSTED",
-    },
+step(name="finalize_booking_log")
+finalize_result = financial_accounting.update_booking_log(
+    booking_log_id=booking_log_result.booking_log_id,
+    status="POSTED",
 )
 
 # Step 6: Save account metadata
-save_account_step = step(name="save_account")
-save_result = invoke_handler(
-    handler="current_account.repository.save",
-    params={
-        "account_id": account_id,
-        "transaction_id": transaction_id,
-    },
+step(name="save_account")
+save_result = current_account.save(
+    account_id=account_id,
+    transaction_id=transaction_id,
 )
 
 # Output the saga result

--- a/services/reference-data/saga/defaults/payment_execution/v1.0.0.star
+++ b/services/reference-data/saga/defaults/payment_execution/v1.0.0.star
@@ -1,9 +1,9 @@
 # Saga: payment_execution
 # Version: 1.0.0
 # Previous: none
-# Changed: Initial version
+# Changed: Migrated from step(action=...) to typed service modules
 # Author: Platform Team
-# Date: 2026-01-26
+# Date: 2026-01-27
 #
 # Payment Order execution saga with bucket-aware lien, gateway submission, and ledger posting.
 #
@@ -15,6 +15,8 @@
 #
 # Steps 3 and 4 are conditional - they are invoked asynchronously by webhook handlers
 # rather than immediately after step 2.
+#
+# Compensation handlers are declared in handlers.yaml schema.
 #
 # Input parameters (from input_data dict):
 #   - payment_order_id: string (required)
@@ -45,47 +47,33 @@ def payment_execution():
     ctx = input_data
 
     # Step 1: Reserve funds with bucket-aware lien
-    lien_result = step(
-        name = "reserve_funds",
-        action = "payment_order.create_lien",
-        params = {
-            "account_id": ctx.get("debtor_account_id"),
-            "amount_cents": ctx.get("amount_cents"),
-            "currency": ctx.get("currency"),
-            "payment_order_id": ctx.get("payment_order_id"),
-            "instrument_code": ctx.get("instrument_code", ""),
-            "payment_attributes": ctx.get("payment_attributes", {}),
-        },
-        compensate = {
-            "action": "payment_order.terminate_lien",
-            "params_from_result": ["lien_id"],
-            "additional_params": {
-                "reason": "Payment order saga compensation",
-            },
-        },
+    step(name="reserve_funds")
+    lien_result = payment_order.create_lien(
+        account_id=ctx.get("debtor_account_id"),
+        amount_cents=ctx.get("amount_cents"),
+        currency=ctx.get("currency"),
+        payment_order_id=ctx.get("payment_order_id"),
+        instrument_code=ctx.get("instrument_code", ""),
+        payment_attributes=ctx.get("payment_attributes", {}),
     )
 
     # Store lien results in context for subsequent steps
-    lien_id = lien_result.get("lien_id", "")
-    bucket_id = lien_result.get("bucket_id", "")
+    lien_id = lien_result.lien_id
+    bucket_id = lien_result.bucket_id
 
     # Step 2: Send payment to gateway
-    gateway_result = step(
-        name = "send_to_gateway",
-        action = "payment_order.send_to_gateway",
-        params = {
-            "payment_order_id": ctx.get("payment_order_id"),
-            "debtor_account_id": ctx.get("debtor_account_id"),
-            "creditor_reference": ctx.get("creditor_reference"),
-            "amount_cents": ctx.get("amount_cents"),
-            "currency": ctx.get("currency"),
-            "idempotency_key": ctx.get("idempotency_key"),
-        },
-        # No compensation for gateway send - lien release handles rollback
+    step(name="send_to_gateway")
+    gateway_result = payment_order.send_to_gateway(
+        payment_order_id=ctx.get("payment_order_id"),
+        debtor_account_id=ctx.get("debtor_account_id"),
+        creditor_reference=ctx.get("creditor_reference"),
+        amount_cents=ctx.get("amount_cents"),
+        currency=ctx.get("currency"),
+        idempotency_key=ctx.get("idempotency_key"),
     )
 
-    gateway_reference_id = gateway_result.get("gateway_reference_id", "")
-    gateway_status = gateway_result.get("gateway_status", "")
+    gateway_reference_id = gateway_result.gateway_reference_id
+    gateway_status = gateway_result.gateway_status
 
     # Build initial result (returned after step 2 completes)
     # Steps 3 and 4 are conditional based on webhook flags
@@ -99,33 +87,27 @@ def payment_execution():
     # Step 3: Post ledger entries (conditional - triggered by webhook)
     # This step is called after the gateway confirms the payment via webhook
     if ctx.get("should_post_ledger", False):
-        ledger_result = step(
-            name = "post_ledger_entries",
-            action = "payment_order.post_ledger_entries",
-            params = {
-                "payment_order_id": ctx.get("payment_order_id"),
-                "debtor_account_id": ctx.get("debtor_account_id"),
-                "gateway_reference_id": gateway_reference_id,
-                "amount_cents": ctx.get("amount_cents"),
-                "currency": ctx.get("currency"),
-                "idempotency_key": ctx.get("idempotency_key"),
-                "internal_clearing_enabled": ctx.get("internal_clearing_enabled", False),
-            },
+        step(name="post_ledger_entries")
+        ledger_result = payment_order.post_ledger_entries(
+            payment_order_id=ctx.get("payment_order_id"),
+            debtor_account_id=ctx.get("debtor_account_id"),
+            gateway_reference_id=gateway_reference_id,
+            amount_cents=ctx.get("amount_cents"),
+            currency=ctx.get("currency"),
+            idempotency_key=ctx.get("idempotency_key"),
+            internal_clearing_enabled=ctx.get("internal_clearing_enabled", False),
         )
-        result["booking_log_id"] = ledger_result.get("booking_log_id", "")
+        result["booking_log_id"] = ledger_result.booking_log_id
 
     # Step 4: Execute lien (conditional - triggered by webhook after ledger posted)
     # This converts the reservation to an actual debit
     if ctx.get("should_execute_lien", False):
         if lien_id:
-            execution_result = step(
-                name = "execute_lien",
-                action = "payment_order.execute_lien",
-                params = {
-                    "lien_id": lien_id,
-                },
+            step(name="execute_lien")
+            execution_result = payment_order.execute_lien(
+                lien_id=lien_id,
             )
-            result["lien_execution_status"] = execution_result.get("execution_status", {})
+            result["lien_execution_status"] = execution_result.execution_status
 
     return result
 

--- a/services/reference-data/saga/defaults/withdrawal/v1.0.0.star
+++ b/services/reference-data/saga/defaults/withdrawal/v1.0.0.star
@@ -1,9 +1,9 @@
 # Saga: current_account_withdrawal
 # Version: 1.0.0
 # Previous: none
-# Changed: Initial version
+# Changed: Migrated from invoke_handler() to typed service modules
 # Author: Platform Team
-# Date: 2026-01-26
+# Date: 2026-01-27
 #
 # This Starlark script defines the withdrawal saga workflow for the Current Account service.
 # The saga executes a multi-step withdrawal operation with compensation on failure.
@@ -18,6 +18,7 @@
 #
 # Compensation Order (LIFO - Last In, First Out):
 #   Failures trigger compensation of completed steps in reverse order.
+#   Compensation handlers are declared in handlers.yaml schema.
 #
 # Input data (provided via input_data dictionary):
 #   - account_id: string - Account identifier
@@ -39,107 +40,61 @@ transaction_id = input_data["transaction_id"]
 clearing_account_id = input_data.get("clearing_account_id", "")
 
 # Step 1: Log position in PositionKeeping service with DEBIT direction
-log_position_step = step(name="log_position")
-log_position_result = invoke_handler(
-    handler="current_account.position_keeping.initiate_log",
-    params={
-        "account_id": account_identification,
-        "amount": amount,
-        "currency": currency,
-        "direction": "DEBIT",
-        "transaction_id": transaction_id,
-    },
-    compensate_handler="current_account.position_keeping.cancel_log",
-    compensate_params={
-        "log_id": "${log_position_result.log_id}",
-        "version": "${log_position_result.version}",
-        "transaction_id": transaction_id,
-        "account_id": account_identification,
-        "direction": "DEBIT",
-    },
+step(name="log_position")
+log_position_result = position_keeping.initiate_log(
+    account_id=account_identification,
+    amount=amount,
+    currency=currency,
+    direction="DEBIT",
+    transaction_id=transaction_id,
 )
 
 # Step 2: Initiate booking log in FinancialAccounting service
-initiate_booking_step = step(name="initiate_booking_log")
-booking_log_result = invoke_handler(
-    handler="current_account.financial_accounting.initiate_booking_log",
-    params={
-        "account_id": account_id,
-        "currency": currency,
-        "transaction_id": transaction_id,
-        "transaction_type": "WITHDRAWAL",
-    },
+step(name="initiate_booking_log")
+booking_log_result = financial_accounting.initiate_booking_log(
+    account_id=account_id,
+    currency=currency,
+    transaction_id=transaction_id,
+    transaction_type="WITHDRAWAL",
 )
 
 # Step 3: Capture DEBIT posting to customer account
-debit_posting_step = step(name="capture_debit_posting")
-debit_result = invoke_handler(
-    handler="current_account.financial_accounting.capture_posting",
-    params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "account_id": account_id,
-        "amount": amount,
-        "currency": currency,
-        "direction": "DEBIT",
-        "transaction_id": transaction_id,
-        "posting_type": "debit",
-    },
-    compensate_handler="current_account.financial_accounting.compensate_posting",
-    compensate_params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "account_id": account_id,
-        "amount": amount,
-        "currency": currency,
-        "direction": "CREDIT",  # Reverse direction for compensation
-        "transaction_id": transaction_id,
-        "posting_type": "debit",
-    },
+step(name="capture_debit_posting")
+debit_result = financial_accounting.capture_posting(
+    booking_log_id=booking_log_result.booking_log_id,
+    account_id=account_id,
+    amount=amount,
+    currency=currency,
+    direction="DEBIT",
+    transaction_id=transaction_id,
+    posting_type="debit",
 )
 
 # Step 4: Capture CREDIT posting to clearing account (if double-entry enabled)
 if clearing_account_id != "":
-    credit_posting_step = step(name="capture_credit_posting")
-    credit_result = invoke_handler(
-        handler="current_account.financial_accounting.capture_posting",
-        params={
-            "booking_log_id": "${booking_log_result.booking_log_id}",
-            "account_id": clearing_account_id,
-            "amount": amount,
-            "currency": currency,
-            "direction": "CREDIT",
-            "transaction_id": transaction_id,
-            "posting_type": "credit",
-        },
-        compensate_handler="current_account.financial_accounting.compensate_posting",
-        compensate_params={
-            "booking_log_id": "${booking_log_result.booking_log_id}",
-            "account_id": clearing_account_id,
-            "amount": amount,
-            "currency": currency,
-            "direction": "DEBIT",  # Reverse direction for compensation
-            "transaction_id": transaction_id,
-            "posting_type": "credit",
-        },
+    step(name="capture_credit_posting")
+    credit_result = financial_accounting.capture_posting(
+        booking_log_id=booking_log_result.booking_log_id,
+        account_id=clearing_account_id,
+        amount=amount,
+        currency=currency,
+        direction="CREDIT",
+        transaction_id=transaction_id,
+        posting_type="credit",
     )
 
 # Step 5: Finalize booking log (transition to POSTED)
-finalize_booking_step = step(name="finalize_booking_log")
-finalize_result = invoke_handler(
-    handler="current_account.financial_accounting.update_booking_log",
-    params={
-        "booking_log_id": "${booking_log_result.booking_log_id}",
-        "status": "POSTED",
-    },
+step(name="finalize_booking_log")
+finalize_result = financial_accounting.update_booking_log(
+    booking_log_id=booking_log_result.booking_log_id,
+    status="POSTED",
 )
 
 # Step 6: Save account metadata
-save_account_step = step(name="save_account")
-save_result = invoke_handler(
-    handler="current_account.repository.save",
-    params={
-        "account_id": account_id,
-        "transaction_id": transaction_id,
-    },
+step(name="save_account")
+save_result = current_account.save(
+    account_id=account_id,
+    transaction_id=transaction_id,
 )
 
 # Output the saga result

--- a/shared/pkg/saga/handlers.go
+++ b/shared/pkg/saga/handlers.go
@@ -371,11 +371,17 @@ func requireInt64Param(params map[string]any, key string) (int64, error) {
 	case int:
 		return int64(v), nil
 	case float64:
+		if v != float64(int64(v)) {
+			return 0, fmt.Errorf("%w: %s must be a whole number, got %v", ErrInvalidParamType, key, v)
+		}
 		return int64(v), nil
 	case string:
 		d, err := decimal.NewFromString(v)
 		if err != nil {
 			return 0, fmt.Errorf("%w: %s must be int64, got invalid string", ErrInvalidParamType, key)
+		}
+		if !d.Equal(d.Truncate(0)) {
+			return 0, fmt.Errorf("%w: %s must be a whole number, got %s", ErrInvalidParamType, key, v)
 		}
 		return d.IntPart(), nil
 	default:

--- a/shared/pkg/saga/handlers.go
+++ b/shared/pkg/saga/handlers.go
@@ -41,6 +41,12 @@ var (
 	ErrPartyScopeViolation = errors.New("party scope violation: party_id not in visible_parties")
 )
 
+// Direction constants for transaction operations.
+const (
+	DirectionDebit  = "DEBIT"
+	DirectionCredit = "CREDIT"
+)
+
 // DomainHandler is the function signature for domain-specific saga step handlers.
 // These handlers receive a rich StarlarkContext for platform features (PartyScope,
 // deterministic UUIDs, progress emission, suspension) and return typed results.
@@ -287,11 +293,16 @@ func registerDefaultHandlers(r *DomainHandlerRegistry) {
 	_ = r.Register("financial_accounting.post_entries", financialAccountingPostEntries)
 	_ = r.Register("financial_accounting.reverse_entries", financialAccountingReverseEntries)
 	_ = r.Register("financial_accounting.create_booking", financialAccountingCreateBooking)
+	_ = r.Register("financial_accounting.initiate_booking_log", financialAccountingInitiateBookingLog)
+	_ = r.Register("financial_accounting.capture_posting", financialAccountingCapturePosting)
+	_ = r.Register("financial_accounting.compensate_posting", financialAccountingCompensatePosting)
+	_ = r.Register("financial_accounting.update_booking_log", financialAccountingUpdateBookingLog)
 
 	// Current Account handlers
 	_ = r.Register("current_account.create_lien", currentAccountCreateLien)
 	_ = r.Register("current_account.execute_lien", currentAccountExecuteLien)
 	_ = r.Register("current_account.terminate_lien", currentAccountTerminateLien)
+	_ = r.Register("current_account.save", currentAccountSave)
 
 	// Valuation Engine handler
 	_ = r.Register("valuation_engine.valuate", valuationEngineValuate)
@@ -301,6 +312,13 @@ func registerDefaultHandlers(r *DomainHandlerRegistry) {
 
 	// Notification handler
 	_ = r.Register("notification.send", notificationSend)
+
+	// Payment Order handlers
+	_ = r.Register("payment_order.create_lien", paymentOrderCreateLien)
+	_ = r.Register("payment_order.terminate_lien", paymentOrderTerminateLien)
+	_ = r.Register("payment_order.send_to_gateway", paymentOrderSendToGateway)
+	_ = r.Register("payment_order.post_ledger_entries", paymentOrderPostLedgerEntries)
+	_ = r.Register("payment_order.execute_lien", paymentOrderExecuteLien)
 }
 
 // Helper functions for parameter validation
@@ -342,6 +360,53 @@ func requireDecimalParam(params map[string]any, key string) (decimal.Decimal, er
 	}
 }
 
+func requireInt64Param(params map[string]any, key string) (int64, error) {
+	val, ok := params[key]
+	if !ok {
+		return 0, fmt.Errorf("%w: %s", ErrMissingParam, key)
+	}
+	switch v := val.(type) {
+	case int64:
+		return v, nil
+	case int:
+		return int64(v), nil
+	case float64:
+		return int64(v), nil
+	case string:
+		d, err := decimal.NewFromString(v)
+		if err != nil {
+			return 0, fmt.Errorf("%w: %s must be int64, got invalid string", ErrInvalidParamType, key)
+		}
+		return d.IntPart(), nil
+	default:
+		return 0, fmt.Errorf("%w: %s must be int64, got %T", ErrInvalidParamType, key, val)
+	}
+}
+
+func optionalStringParam(params map[string]any, key string, defaultVal string) string {
+	val, ok := params[key]
+	if !ok {
+		return defaultVal
+	}
+	str, ok := val.(string)
+	if !ok {
+		return defaultVal
+	}
+	return str
+}
+
+func optionalBoolParam(params map[string]any, key string, defaultVal bool) bool {
+	val, ok := params[key]
+	if !ok {
+		return defaultVal
+	}
+	b, ok := val.(bool)
+	if !ok {
+		return defaultVal
+	}
+	return b
+}
+
 func wrapHandlerError(handlerName string, err error) error {
 	return fmt.Errorf("%s: %w", handlerName, err)
 }
@@ -351,9 +416,16 @@ func wrapHandlerError(handlerName string, err error) error {
 func positionKeepingInitiateLog(ctx *StarlarkContext, params map[string]any) (any, error) {
 	const handlerName = "position_keeping.initiate_log"
 
+	// Accept either "position_id" or "account_id" as the position identifier.
+	// The deposit/withdrawal .star scripts pass "account_id" while the canonical
+	// parameter name is "position_id".
 	positionID, err := requireStringParam(params, "position_id")
 	if err != nil {
-		return nil, wrapHandlerError(handlerName, err)
+		// Fall back to account_id if position_id is missing
+		positionID, err = requireStringParam(params, "account_id")
+		if err != nil {
+			return nil, wrapHandlerError(handlerName, fmt.Errorf("%w: position_id (or account_id)", ErrMissingParam))
+		}
 	}
 
 	amount, err := requireDecimalParam(params, "amount")
@@ -367,7 +439,7 @@ func positionKeepingInitiateLog(ctx *StarlarkContext, params map[string]any) (an
 	}
 
 	// Validate direction
-	if direction != "DEBIT" && direction != "CREDIT" {
+	if direction != DirectionDebit && direction != DirectionCredit {
 		return nil, wrapHandlerError(handlerName, fmt.Errorf("%w: got %s", ErrInvalidDirection, direction))
 	}
 
@@ -498,6 +570,186 @@ func financialAccountingCreateBooking(ctx *StarlarkContext, params map[string]an
 	}, nil
 }
 
+func financialAccountingInitiateBookingLog(ctx *StarlarkContext, params map[string]any) (any, error) {
+	const handlerName = "financial_accounting.initiate_booking_log"
+
+	accountID, err := requireStringParam(params, "account_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	currency, err := requireStringParam(params, "currency")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	transactionID, err := requireStringParam(params, "transaction_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	transactionType, err := requireStringParam(params, "transaction_type")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	ctx.Logger.Info("initiating booking log",
+		"saga_execution_id", ctx.SagaExecutionID,
+		"account_id", accountID,
+		"currency", currency,
+		"transaction_id", transactionID,
+		"transaction_type", transactionType,
+	)
+
+	return map[string]any{
+		"booking_log_id": ctx.NewUUID(ctx.SagaExecutionID, "booking_log_"+transactionID).String(),
+		"status":         "INITIATED",
+	}, nil
+}
+
+func financialAccountingCapturePosting(ctx *StarlarkContext, params map[string]any) (any, error) {
+	const handlerName = "financial_accounting.capture_posting"
+
+	bookingLogID, err := requireStringParam(params, "booking_log_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	accountID, err := requireStringParam(params, "account_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	amount, err := requireDecimalParam(params, "amount")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	currency, err := requireStringParam(params, "currency")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	direction, err := requireStringParam(params, "direction")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	if direction != DirectionDebit && direction != DirectionCredit {
+		return nil, wrapHandlerError(handlerName, fmt.Errorf("%w: got %s", ErrInvalidDirection, direction))
+	}
+
+	transactionID, err := requireStringParam(params, "transaction_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	postingType, err := requireStringParam(params, "posting_type")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	ctx.Logger.Info("capturing posting",
+		"saga_execution_id", ctx.SagaExecutionID,
+		"booking_log_id", bookingLogID,
+		"account_id", accountID,
+		"amount", amount.String(),
+		"currency", currency,
+		"direction", direction,
+		"transaction_id", transactionID,
+		"posting_type", postingType,
+	)
+
+	return map[string]any{
+		"posting_id": ctx.NewUUID(ctx.SagaExecutionID, "posting_"+transactionID+"_"+postingType).String(),
+		"status":     "CAPTURED",
+	}, nil
+}
+
+func financialAccountingCompensatePosting(ctx *StarlarkContext, params map[string]any) (any, error) {
+	const handlerName = "financial_accounting.compensate_posting"
+
+	bookingLogID, err := requireStringParam(params, "booking_log_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	accountID, err := requireStringParam(params, "account_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	amount, err := requireDecimalParam(params, "amount")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	currency, err := requireStringParam(params, "currency")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	direction, err := requireStringParam(params, "direction")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	if direction != DirectionDebit && direction != DirectionCredit {
+		return nil, wrapHandlerError(handlerName, fmt.Errorf("%w: got %s", ErrInvalidDirection, direction))
+	}
+
+	transactionID, err := requireStringParam(params, "transaction_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	postingType, err := requireStringParam(params, "posting_type")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	ctx.Logger.Info("compensating posting",
+		"saga_execution_id", ctx.SagaExecutionID,
+		"booking_log_id", bookingLogID,
+		"account_id", accountID,
+		"amount", amount.String(),
+		"currency", currency,
+		"direction", direction,
+		"transaction_id", transactionID,
+		"posting_type", postingType,
+	)
+
+	return map[string]any{
+		"posting_id": ctx.NewUUID(ctx.SagaExecutionID, "compensate_posting_"+transactionID+"_"+postingType).String(),
+		"status":     "COMPENSATED",
+	}, nil
+}
+
+func financialAccountingUpdateBookingLog(ctx *StarlarkContext, params map[string]any) (any, error) {
+	const handlerName = "financial_accounting.update_booking_log"
+
+	bookingLogID, err := requireStringParam(params, "booking_log_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	status, err := requireStringParam(params, "status")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	ctx.Logger.Info("updating booking log",
+		"saga_execution_id", ctx.SagaExecutionID,
+		"booking_log_id", bookingLogID,
+		"status", status,
+	)
+
+	return map[string]any{
+		"booking_log_id": bookingLogID,
+		"status":         status,
+	}, nil
+}
+
 // Current Account handlers
 
 func currentAccountCreateLien(ctx *StarlarkContext, params map[string]any) (any, error) {
@@ -562,6 +814,31 @@ func currentAccountTerminateLien(ctx *StarlarkContext, params map[string]any) (a
 	return map[string]any{
 		"lien_id": lienID,
 		"status":  "TERMINATED",
+	}, nil
+}
+
+func currentAccountSave(ctx *StarlarkContext, params map[string]any) (any, error) {
+	const handlerName = "current_account.save"
+
+	accountID, err := requireStringParam(params, "account_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	transactionID, err := requireStringParam(params, "transaction_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	ctx.Logger.Info("saving current account",
+		"saga_execution_id", ctx.SagaExecutionID,
+		"account_id", accountID,
+		"transaction_id", transactionID,
+	)
+
+	return map[string]any{
+		"account_id": accountID,
+		"status":     "SAVED",
 	}, nil
 }
 
@@ -665,5 +942,192 @@ func notificationSend(ctx *StarlarkContext, params map[string]any) (any, error) 
 		"type":            notificationType,
 		"recipient":       recipient,
 		"status":          "SENT",
+	}, nil
+}
+
+// Payment Order handlers
+
+func paymentOrderCreateLien(ctx *StarlarkContext, params map[string]any) (any, error) {
+	const handlerName = "payment_order.create_lien"
+
+	accountID, err := requireStringParam(params, "account_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	amountCents, err := requireInt64Param(params, "amount_cents")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	currency, err := requireStringParam(params, "currency")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	paymentOrderID, err := requireStringParam(params, "payment_order_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	instrumentCode := optionalStringParam(params, "instrument_code", "")
+	_ = instrumentCode // Used for bucket-aware solvency evaluation
+
+	// payment_attributes is optional and may be a map
+	_ = params["payment_attributes"] // Used for CEL bucket expression evaluation
+
+	ctx.Logger.Info("creating payment order lien",
+		"saga_execution_id", ctx.SagaExecutionID,
+		"account_id", accountID,
+		"amount_cents", amountCents,
+		"currency", currency,
+		"payment_order_id", paymentOrderID,
+	)
+
+	return map[string]any{
+		"lien_id":   ctx.NewUUID(ctx.SagaExecutionID, "po_lien_"+paymentOrderID).String(),
+		"bucket_id": ctx.NewUUID(ctx.SagaExecutionID, "bucket_"+accountID).String(),
+		"status":    "ACTIVE",
+	}, nil
+}
+
+func paymentOrderTerminateLien(ctx *StarlarkContext, params map[string]any) (any, error) {
+	const handlerName = "payment_order.terminate_lien"
+
+	lienID, err := requireStringParam(params, "lien_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	reason := optionalStringParam(params, "reason", "")
+
+	ctx.Logger.Info("terminating payment order lien",
+		"saga_execution_id", ctx.SagaExecutionID,
+		"lien_id", lienID,
+		"reason", reason,
+	)
+
+	return map[string]any{
+		"lien_id": lienID,
+		"status":  "TERMINATED",
+	}, nil
+}
+
+func paymentOrderSendToGateway(ctx *StarlarkContext, params map[string]any) (any, error) {
+	const handlerName = "payment_order.send_to_gateway"
+
+	paymentOrderID, err := requireStringParam(params, "payment_order_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	debtorAccountID, err := requireStringParam(params, "debtor_account_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	creditorReference, err := requireStringParam(params, "creditor_reference")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	amountCents, err := requireInt64Param(params, "amount_cents")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	currency, err := requireStringParam(params, "currency")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	idempotencyKey, err := requireStringParam(params, "idempotency_key")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	ctx.Logger.Info("sending payment to gateway",
+		"saga_execution_id", ctx.SagaExecutionID,
+		"payment_order_id", paymentOrderID,
+		"debtor_account_id", debtorAccountID,
+		"creditor_reference", creditorReference,
+		"amount_cents", amountCents,
+		"currency", currency,
+		"idempotency_key", idempotencyKey,
+	)
+
+	return map[string]any{
+		"gateway_reference_id": ctx.NewUUID(ctx.SagaExecutionID, "gw_ref_"+paymentOrderID).String(),
+		"gateway_status":       "ACCEPTED",
+	}, nil
+}
+
+func paymentOrderPostLedgerEntries(ctx *StarlarkContext, params map[string]any) (any, error) {
+	const handlerName = "payment_order.post_ledger_entries"
+
+	paymentOrderID, err := requireStringParam(params, "payment_order_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	debtorAccountID, err := requireStringParam(params, "debtor_account_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	gatewayReferenceID, err := requireStringParam(params, "gateway_reference_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	amountCents, err := requireInt64Param(params, "amount_cents")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	currency, err := requireStringParam(params, "currency")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	idempotencyKey, err := requireStringParam(params, "idempotency_key")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	internalClearingEnabled := optionalBoolParam(params, "internal_clearing_enabled", false)
+
+	ctx.Logger.Info("posting ledger entries for payment order",
+		"saga_execution_id", ctx.SagaExecutionID,
+		"payment_order_id", paymentOrderID,
+		"debtor_account_id", debtorAccountID,
+		"gateway_reference_id", gatewayReferenceID,
+		"amount_cents", amountCents,
+		"currency", currency,
+		"idempotency_key", idempotencyKey,
+		"internal_clearing_enabled", internalClearingEnabled,
+	)
+
+	return map[string]any{
+		"booking_log_id": ctx.NewUUID(ctx.SagaExecutionID, "po_booking_"+paymentOrderID).String(),
+		"status":         "POSTED",
+	}, nil
+}
+
+func paymentOrderExecuteLien(ctx *StarlarkContext, params map[string]any) (any, error) {
+	const handlerName = "payment_order.execute_lien"
+
+	lienID, err := requireStringParam(params, "lien_id")
+	if err != nil {
+		return nil, wrapHandlerError(handlerName, err)
+	}
+
+	ctx.Logger.Info("executing payment order lien",
+		"saga_execution_id", ctx.SagaExecutionID,
+		"lien_id", lienID,
+	)
+
+	return map[string]any{
+		"execution_status": "EXECUTED",
 	}, nil
 }

--- a/shared/pkg/saga/handlers_test.go
+++ b/shared/pkg/saga/handlers_test.go
@@ -251,12 +251,22 @@ func TestDefaultHandlers_Registered(t *testing.T) {
 		"financial_accounting.post_entries",
 		"financial_accounting.reverse_entries",
 		"financial_accounting.create_booking",
+		"financial_accounting.initiate_booking_log",
+		"financial_accounting.capture_posting",
+		"financial_accounting.compensate_posting",
+		"financial_accounting.update_booking_log",
 		"current_account.create_lien",
 		"current_account.execute_lien",
 		"current_account.terminate_lien",
+		"current_account.save",
 		"valuation_engine.valuate",
 		"repository.save",
 		"notification.send",
+		"payment_order.create_lien",
+		"payment_order.terminate_lien",
+		"payment_order.send_to_gateway",
+		"payment_order.post_ledger_entries",
+		"payment_order.execute_lien",
 	}
 
 	for _, name := range expectedHandlers {
@@ -287,7 +297,22 @@ func TestHandler_PositionKeeping_InitiateLog(t *testing.T) {
 		assert.NotNil(t, result)
 	})
 
-	t.Run("missing position_id", func(t *testing.T) {
+	t.Run("accepts account_id as alias for position_id", func(t *testing.T) {
+		params := map[string]any{
+			"account_id": uuid.New().String(),
+			"amount":     decimal.NewFromInt(100),
+			"direction":  "CREDIT",
+		}
+		result, err := handler(ctx, params)
+		require.NoError(t, err)
+		assert.NotNil(t, result)
+
+		resultMap, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "INITIATED", resultMap["status"])
+	})
+
+	t.Run("missing both position_id and account_id", func(t *testing.T) {
 		params := map[string]any{
 			"amount":    decimal.NewFromInt(100),
 			"direction": "DEBIT",

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -13,7 +13,11 @@ handlers:
       position_id:
         type: string
         required: true
-        description: "Unique identifier for the position"
+        description: "Unique identifier for the position (alias: account_id)"
+      account_id:
+        type: string
+        required: false
+        description: "Alternative name for position_id, used by deposit/withdrawal scripts"
       amount:
         type: Decimal
         required: true
@@ -121,6 +125,133 @@ handlers:
         type: string
         description: "Status of the booking (CREATED)"
 
+  financial_accounting.initiate_booking_log:
+    description: "Initiate a booking log for a deposit or withdrawal transaction"
+    params:
+      account_id:
+        type: string
+        required: true
+        description: "Account identifier for the booking"
+      currency:
+        type: string
+        required: true
+        description: "Currency code (e.g., GBP, USD)"
+      transaction_id:
+        type: string
+        required: true
+        description: "Unique transaction identifier"
+      transaction_type:
+        type: string
+        required: true
+        description: "Type of transaction (e.g., DEPOSIT, WITHDRAWAL)"
+    returns:
+      booking_log_id:
+        type: string
+        description: "Generated booking log identifier (UUID)"
+      status:
+        type: string
+        description: "Status of the booking log (INITIATED)"
+
+  financial_accounting.capture_posting:
+    description: "Capture a single-sided posting entry within a booking log"
+    params:
+      booking_log_id:
+        type: string
+        required: true
+        description: "Booking log to attach this posting to"
+      account_id:
+        type: string
+        required: true
+        description: "Account identifier for the posting"
+      amount:
+        type: Decimal
+        required: true
+        description: "Posting amount (must be positive)"
+      currency:
+        type: string
+        required: true
+        description: "Currency code (e.g., GBP, USD)"
+      direction:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+        description: "Direction of the posting"
+      transaction_id:
+        type: string
+        required: true
+        description: "Unique transaction identifier"
+      posting_type:
+        type: string
+        required: true
+        description: "Type of posting (e.g., debit, credit)"
+    returns:
+      posting_id:
+        type: string
+        description: "Generated posting identifier (UUID)"
+      status:
+        type: string
+        description: "Status of the posting (CAPTURED)"
+    compensate: financial_accounting.compensate_posting
+
+  financial_accounting.compensate_posting:
+    description: "Compensate (reverse) a captured posting entry"
+    params:
+      booking_log_id:
+        type: string
+        required: true
+        description: "Booking log containing the posting to compensate"
+      account_id:
+        type: string
+        required: true
+        description: "Account identifier for the compensation posting"
+      amount:
+        type: Decimal
+        required: true
+        description: "Compensation amount (must be positive)"
+      currency:
+        type: string
+        required: true
+        description: "Currency code (e.g., GBP, USD)"
+      direction:
+        type: enum
+        values: [DEBIT, CREDIT]
+        required: true
+        description: "Direction of the compensation (reversed from original)"
+      transaction_id:
+        type: string
+        required: true
+        description: "Unique transaction identifier"
+      posting_type:
+        type: string
+        required: true
+        description: "Type of posting being compensated (e.g., debit, credit)"
+    returns:
+      posting_id:
+        type: string
+        description: "Generated compensation posting identifier (UUID)"
+      status:
+        type: string
+        description: "Status of the compensation posting (COMPENSATED)"
+
+  financial_accounting.update_booking_log:
+    description: "Update the status of an existing booking log"
+    params:
+      booking_log_id:
+        type: string
+        required: true
+        description: "Identifier of the booking log to update"
+      status:
+        type: string
+        required: true
+        description: "New status for the booking log (e.g., POSTED)"
+    returns:
+      booking_log_id:
+        type: string
+        description: "Echo of the input booking log ID"
+      status:
+        type: string
+        description: "Echo of the updated status"
+
   # Current Account Service
   current_account.create_lien:
     description: "Create a lien (hold) on an account for a specified amount"
@@ -177,6 +308,25 @@ handlers:
       status:
         type: string
         description: "Status of the lien (TERMINATED)"
+
+  current_account.save:
+    description: "Persist current account metadata for a transaction"
+    params:
+      account_id:
+        type: string
+        required: true
+        description: "Identifier of the account to save"
+      transaction_id:
+        type: string
+        required: true
+        description: "Identifier of the transaction triggering the save"
+    returns:
+      account_id:
+        type: string
+        description: "Echo of the input account ID"
+      status:
+        type: string
+        description: "Status of the save operation (SAVED)"
 
   # Valuation Engine Service
   valuation_engine.valuate:
@@ -268,3 +418,148 @@ handlers:
       status:
         type: string
         description: "Status of the notification (SENT)"
+
+  # Payment Order Service
+  payment_order.create_lien:
+    description: "Create a bucket-aware lien (hold) for a payment order"
+    params:
+      account_id:
+        type: string
+        required: true
+        description: "Debtor account identifier"
+      amount_cents:
+        type: int64
+        required: true
+        description: "Amount in minor currency units (cents)"
+      currency:
+        type: string
+        required: true
+        description: "Currency code (e.g., GBP, USD)"
+      payment_order_id:
+        type: string
+        required: true
+        description: "Identifier of the payment order"
+      instrument_code:
+        type: string
+        required: false
+        description: "Instrument code for bucket-aware solvency evaluation"
+      payment_attributes:
+        type: map
+        required: false
+        description: "Attributes for CEL bucket expression evaluation"
+    returns:
+      lien_id:
+        type: string
+        description: "Generated lien identifier (UUID)"
+      bucket_id:
+        type: string
+        description: "Bucket identifier used for solvency evaluation (UUID)"
+      status:
+        type: string
+        description: "Status of the lien (ACTIVE)"
+    compensate: payment_order.terminate_lien
+
+  payment_order.terminate_lien:
+    description: "Terminate (release) a payment order lien (compensation handler)"
+    params:
+      lien_id:
+        type: string
+        required: true
+        description: "Identifier of the lien to terminate"
+      reason:
+        type: string
+        required: false
+        description: "Reason for termination"
+    returns:
+      lien_id:
+        type: string
+        description: "Echo of the input lien ID"
+      status:
+        type: string
+        description: "Status of the lien (TERMINATED)"
+
+  payment_order.send_to_gateway:
+    description: "Send a payment order to the external payment gateway"
+    params:
+      payment_order_id:
+        type: string
+        required: true
+        description: "Identifier of the payment order"
+      debtor_account_id:
+        type: string
+        required: true
+        description: "Debtor account identifier"
+      creditor_reference:
+        type: string
+        required: true
+        description: "Creditor reference for the payment"
+      amount_cents:
+        type: int64
+        required: true
+        description: "Amount in minor currency units (cents)"
+      currency:
+        type: string
+        required: true
+        description: "Currency code (e.g., GBP, USD)"
+      idempotency_key:
+        type: string
+        required: true
+        description: "Idempotency key for gateway deduplication"
+    returns:
+      gateway_reference_id:
+        type: string
+        description: "Gateway-assigned reference identifier (UUID)"
+      gateway_status:
+        type: string
+        description: "Status from the gateway (ACCEPTED)"
+
+  payment_order.post_ledger_entries:
+    description: "Post ledger entries for a confirmed payment order"
+    params:
+      payment_order_id:
+        type: string
+        required: true
+        description: "Identifier of the payment order"
+      debtor_account_id:
+        type: string
+        required: true
+        description: "Debtor account identifier"
+      gateway_reference_id:
+        type: string
+        required: true
+        description: "Gateway-assigned reference identifier"
+      amount_cents:
+        type: int64
+        required: true
+        description: "Amount in minor currency units (cents)"
+      currency:
+        type: string
+        required: true
+        description: "Currency code (e.g., GBP, USD)"
+      idempotency_key:
+        type: string
+        required: true
+        description: "Idempotency key for ledger deduplication"
+      internal_clearing_enabled:
+        type: bool
+        required: false
+        description: "Whether to use 4-posting internal clearing flow (default: false)"
+    returns:
+      booking_log_id:
+        type: string
+        description: "Generated booking log identifier (UUID)"
+      status:
+        type: string
+        description: "Status of the ledger posting (POSTED)"
+
+  payment_order.execute_lien:
+    description: "Execute (finalize) a payment order lien after ledger posting"
+    params:
+      lien_id:
+        type: string
+        required: true
+        description: "Identifier of the lien to execute"
+    returns:
+      execution_status:
+        type: string
+        description: "Status of the lien execution (EXECUTED)"

--- a/shared/pkg/saga/schema/handlers_test.go
+++ b/shared/pkg/saga/schema/handlers_test.go
@@ -26,12 +26,22 @@ func TestPlatformHandlersSchema(t *testing.T) {
 		"financial_accounting.post_entries",
 		"financial_accounting.reverse_entries",
 		"financial_accounting.create_booking",
+		"financial_accounting.initiate_booking_log",
+		"financial_accounting.capture_posting",
+		"financial_accounting.compensate_posting",
+		"financial_accounting.update_booking_log",
 		"current_account.create_lien",
 		"current_account.execute_lien",
 		"current_account.terminate_lien",
+		"current_account.save",
 		"valuation_engine.valuate",
 		"repository.save",
 		"notification.send",
+		"payment_order.create_lien",
+		"payment_order.terminate_lien",
+		"payment_order.send_to_gateway",
+		"payment_order.post_ledger_entries",
+		"payment_order.execute_lien",
 	}
 
 	assert.Len(t, schema.Handlers, len(expectedHandlers),
@@ -92,7 +102,7 @@ func TestRegistryLoadPlatformHandlers(t *testing.T) {
 	require.NoError(t, err)
 
 	handlers := registry.ListHandlers()
-	assert.Len(t, handlers, 12, "registry should contain all 12 platform handlers")
+	assert.Len(t, handlers, 22, "registry should contain all 22 platform handlers")
 
 	// Verify we can get each handler
 	for _, name := range handlers {


### PR DESCRIPTION
## Summary

- Migrate all 6 saga `.star` scripts from string-based `invoke_handler()` calls to typed service module function calls, eliminating magic string handler references
- Add 10 new domain handlers (`financial_accounting.*`, `current_account.save`, `payment_order.*`) with full schema definitions in `handlers.yaml`
- Accept `account_id` as alias for `position_id` in `position_keeping.initiate_log` for backward compatibility

## Changes Made

### New handlers registered (`handlers.go`)
| Handler | Purpose |
|---------|---------|
| `financial_accounting.initiate_booking_log` | Create booking log for audit |
| `financial_accounting.capture_posting` | Capture a ledger posting |
| `financial_accounting.compensate_posting` | Compensate a posting (reversal) |
| `financial_accounting.update_booking_log` | Update booking log status |
| `current_account.save` | Persist account metadata |
| `payment_order.create_lien` | Reserve funds with bucket awareness |
| `payment_order.terminate_lien` | Release a lien (compensation) |
| `payment_order.send_to_gateway` | Submit payment to external gateway |
| `payment_order.post_ledger_entries` | Post ledger entries after gateway confirmation |
| `payment_order.execute_lien` | Convert reservation to actual debit |

### Script migrations
| Script | Before | After |
|--------|--------|-------|
| `deposit.star` | `invoke_handler(handler="current_account.position_keeping.initiate_log", params={...})` | `position_keeping.initiate_log(account_id=..., amount=..., direction="CREDIT")` |
| `withdrawal.star` | Same pattern | Same typed call pattern |
| `payment_execution.star` | `step(action="payment_order.create_lien", params={...})` | `payment_order.create_lien(account_id=..., amount_cents=...)` |
| Reference-data defaults | All 3 default scripts updated to match |

### Key improvements
- **Type safety**: Parameters validated against schema at call time
- **IDE discoverability**: `position_keeping.` auto-completes to available methods
- **No more `${template}` strings**: Direct `result.field` access replaces string interpolation
- **Compensation declared in schema**: Removed inline `compensate_handler` / `compensate_params`
- **Direction constants**: Extracted `DirectionDebit` / `DirectionCredit` to satisfy goconst

## Test plan

- [x] All existing saga package tests pass (`go test ./shared/pkg/saga/...`)
- [x] Handler registration test updated with all 22 handlers
- [x] Schema test updated to validate all new handler definitions
- [x] `position_keeping.initiate_log` alias test for `account_id` fallback
- [x] Pre-commit lint (gofumpt + golangci-lint) passing

## Risk Assessment

Low risk. The `invoke_handler` shim remains in `starlark_runner.go` for any scripts not yet migrated. The new handlers follow the same mock implementation pattern as existing handlers.

## Task Master

saga-script-versioning.4