### PR TITLE
feat: Add bi-temporal knowledge_at propagation infrastructure (saga-script-versioning.7)

### DIFF
--- a/shared/pkg/clients/temporal.go
+++ b/shared/pkg/clients/temporal.go
@@ -1,0 +1,76 @@
+package clients
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// knowledgeAtKeyType is a custom type for the context key to avoid collisions.
+type knowledgeAtKeyType string
+
+// knowledgeAtContextKey is the context key used to store the knowledge_at timestamp.
+const knowledgeAtContextKey knowledgeAtKeyType = "knowledge_at"
+
+// PropagateKnowledgeAt stores a knowledge_at timestamp in context for
+// bi-temporal query routing. Services should use this timestamp instead
+// of time.Now() when querying data, enabling deterministic replay.
+//
+// The timestamp is stored in the context and can be retrieved using ExtractKnowledgeAt.
+// To propagate it across gRPC calls, use ApplyKnowledgeAt to add it to metadata headers.
+//
+// Example:
+//
+//	ctx := clients.PropagateKnowledgeAt(ctx, saga.KnowledgeAt)
+//	ctx = clients.ApplyKnowledgeAt(ctx)  // For gRPC calls
+//	result, err := service.Query(ctx, req)
+func PropagateKnowledgeAt(ctx context.Context, knowledgeAt time.Time) context.Context {
+	return context.WithValue(ctx, knowledgeAtContextKey, knowledgeAt)
+}
+
+// ExtractKnowledgeAt retrieves the knowledge_at timestamp from context.
+// Returns zero time if not present.
+//
+// This function is typically used to retrieve the timestamp stored by PropagateKnowledgeAt
+// or extracted from gRPC metadata by an interceptor.
+//
+// Example:
+//
+//	knowledgeAt := clients.ExtractKnowledgeAt(ctx)
+//	if !knowledgeAt.IsZero() {
+//	    // Use historical timestamp for queries
+//	}
+func ExtractKnowledgeAt(ctx context.Context) time.Time {
+	if ts, ok := ctx.Value(knowledgeAtContextKey).(time.Time); ok {
+		return ts
+	}
+	return time.Time{}
+}
+
+// ApplyKnowledgeAt adds the knowledge_at timestamp to gRPC metadata headers.
+// Services can intercept this header (using KnowledgeAtInterceptor) to override
+// time.Now() for bi-temporal queries.
+//
+// If no knowledge_at timestamp is present in the context (or if it's zero),
+// this function returns the context unchanged (no-op).
+//
+// The timestamp is formatted using RFC3339Nano for precision and transmitted
+// as the "x-knowledge-at" gRPC metadata header.
+//
+// Example:
+//
+//	ctx = clients.PropagateKnowledgeAt(ctx, saga.KnowledgeAt)
+//	ctx = clients.ApplyKnowledgeAt(ctx)
+//	result, err := service.Query(ctx, req)  // Header propagated automatically
+func ApplyKnowledgeAt(ctx context.Context) context.Context {
+	knowledgeAt := ExtractKnowledgeAt(ctx)
+	if knowledgeAt.IsZero() {
+		return ctx
+	}
+
+	// RFC3339Nano format for precision
+	return metadata.AppendToOutgoingContext(ctx,
+		"x-knowledge-at",
+		knowledgeAt.Format(time.RFC3339Nano))
+}

--- a/shared/pkg/clients/temporal_test.go
+++ b/shared/pkg/clients/temporal_test.go
@@ -1,0 +1,148 @@
+package clients_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+// TestPropagateKnowledgeAt_StoresAndRetrievesTimestamp verifies that PropagateKnowledgeAt stores
+// a timestamp that can be retrieved with ExtractKnowledgeAt
+func TestPropagateKnowledgeAt_StoresAndRetrievesTimestamp(t *testing.T) {
+	t.Parallel()
+
+	knowledgeAt := time.Date(2024, 1, 15, 10, 30, 45, 123456789, time.UTC)
+	ctx := clients.PropagateKnowledgeAt(context.Background(), knowledgeAt)
+
+	result := clients.ExtractKnowledgeAt(ctx)
+
+	assert.Equal(t, knowledgeAt, result)
+}
+
+// TestExtractKnowledgeAt_ReturnsZeroTimeWhenNotPresent verifies that ExtractKnowledgeAt
+// returns zero time when no knowledge_at timestamp is in context
+func TestExtractKnowledgeAt_ReturnsZeroTimeWhenNotPresent(t *testing.T) {
+	t.Parallel()
+
+	result := clients.ExtractKnowledgeAt(context.Background())
+
+	assert.True(t, result.IsZero(), "Expected zero time when knowledge_at not present")
+}
+
+// TestApplyKnowledgeAt_AddsHeaderWithRFC3339NanoFormat verifies that ApplyKnowledgeAt
+// adds x-knowledge-at header to outgoing gRPC metadata with RFC3339Nano format
+func TestApplyKnowledgeAt_AddsHeaderWithRFC3339NanoFormat(t *testing.T) {
+	t.Parallel()
+
+	knowledgeAt := time.Date(2024, 1, 15, 10, 30, 45, 123456789, time.UTC)
+	ctx := clients.PropagateKnowledgeAt(context.Background(), knowledgeAt)
+	ctx = clients.ApplyKnowledgeAt(ctx)
+
+	// Extract metadata from context
+	md, ok := metadata.FromOutgoingContext(ctx)
+	require.True(t, ok, "Expected outgoing metadata to be present")
+
+	values := md.Get("x-knowledge-at")
+	require.Len(t, values, 1, "Expected exactly one x-knowledge-at header")
+
+	// Verify format is RFC3339Nano
+	expectedFormat := knowledgeAt.Format(time.RFC3339Nano)
+	assert.Equal(t, expectedFormat, values[0])
+
+	// Verify it can be parsed back
+	parsed, err := time.Parse(time.RFC3339Nano, values[0])
+	require.NoError(t, err)
+	assert.Equal(t, knowledgeAt, parsed)
+}
+
+// TestApplyKnowledgeAt_NoOpWhenZeroTime verifies that ApplyKnowledgeAt does not
+// add header when knowledge_at is zero time
+func TestApplyKnowledgeAt_NoOpWhenZeroTime(t *testing.T) {
+	t.Parallel()
+
+	ctx := clients.ApplyKnowledgeAt(context.Background())
+
+	// Should not have added metadata
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if ok {
+		values := md.Get("x-knowledge-at")
+		assert.Empty(t, values, "Expected no x-knowledge-at header when timestamp is zero")
+	}
+}
+
+// TestApplyKnowledgeAt_NoOpWhenNotPropagated verifies that ApplyKnowledgeAt is a no-op
+// when knowledge_at was never propagated to context
+func TestApplyKnowledgeAt_NoOpWhenNotPropagated(t *testing.T) {
+	t.Parallel()
+
+	ctx := clients.ApplyKnowledgeAt(context.Background())
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	if ok {
+		values := md.Get("x-knowledge-at")
+		assert.Empty(t, values, "Expected no x-knowledge-at header when not propagated")
+	}
+}
+
+// TestContextImmutability_PropagateDoesNotMutateOriginal verifies that PropagateKnowledgeAt
+// does not mutate the original context
+func TestContextImmutability_PropagateDoesNotMutateOriginal(t *testing.T) {
+	t.Parallel()
+
+	originalCtx := context.Background()
+	knowledgeAt := time.Date(2024, 1, 15, 10, 30, 45, 0, time.UTC)
+
+	_ = clients.PropagateKnowledgeAt(originalCtx, knowledgeAt)
+
+	// Original context should not have knowledge_at
+	result := clients.ExtractKnowledgeAt(originalCtx)
+	assert.True(t, result.IsZero(), "Original context should not be mutated")
+}
+
+// TestContextImmutability_ApplyDoesNotMutateOriginal verifies that ApplyKnowledgeAt
+// does not mutate the original context
+func TestContextImmutability_ApplyDoesNotMutateOriginal(t *testing.T) {
+	t.Parallel()
+
+	knowledgeAt := time.Date(2024, 1, 15, 10, 30, 45, 0, time.UTC)
+	originalCtx := clients.PropagateKnowledgeAt(context.Background(), knowledgeAt)
+
+	_ = clients.ApplyKnowledgeAt(originalCtx)
+
+	// Original context should not have outgoing metadata added
+	md, ok := metadata.FromOutgoingContext(originalCtx)
+	if ok {
+		values := md.Get("x-knowledge-at")
+		assert.Empty(t, values, "Original context should not be mutated")
+	}
+}
+
+// TestApplyKnowledgeAt_PreservesExistingMetadata verifies that ApplyKnowledgeAt
+// preserves existing outgoing metadata
+func TestApplyKnowledgeAt_PreservesExistingMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Start with context that already has metadata
+	ctx := metadata.AppendToOutgoingContext(context.Background(), "x-tenant-id", "tenant-123")
+
+	knowledgeAt := time.Date(2024, 1, 15, 10, 30, 45, 0, time.UTC)
+	ctx = clients.PropagateKnowledgeAt(ctx, knowledgeAt)
+	ctx = clients.ApplyKnowledgeAt(ctx)
+
+	md, ok := metadata.FromOutgoingContext(ctx)
+	require.True(t, ok)
+
+	// Both headers should be present
+	tenantValues := md.Get("x-tenant-id")
+	require.Len(t, tenantValues, 1)
+	assert.Equal(t, "tenant-123", tenantValues[0])
+
+	knowledgeAtValues := md.Get("x-knowledge-at")
+	require.Len(t, knowledgeAtValues, 1)
+	assert.NotEmpty(t, knowledgeAtValues[0])
+}

--- a/shared/platform/db/interceptor.go
+++ b/shared/platform/db/interceptor.go
@@ -1,0 +1,77 @@
+package db
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// contextKey is a custom type for context keys to avoid collisions.
+type contextKey string
+
+// knowledgeAtKey is the context key for storing knowledge_at timestamp.
+const knowledgeAtKey contextKey = "knowledge_at"
+
+// KnowledgeAtInterceptor extracts the x-knowledge-at header from incoming gRPC metadata
+// and stores it in the request context. This enables bi-temporal query routing where
+// services can query historical data as it existed at a specific point in time.
+//
+// The interceptor:
+//   - Extracts the "x-knowledge-at" header from incoming gRPC metadata
+//   - Parses it as RFC3339Nano timestamp
+//   - Stores the parsed timestamp in context with key "knowledge_at"
+//   - Gracefully handles malformed or missing timestamps (passes request through)
+//
+// Services should use GetKnowledgeAt(ctx) to retrieve the timestamp and use it
+// instead of time.Now() for data access queries to enable deterministic saga replay.
+//
+// Example usage in service initialization:
+//
+//	server := grpc.NewServer(
+//	    grpc.ChainUnaryInterceptor(
+//	        db.KnowledgeAtInterceptor(),
+//	        // ... other interceptors
+//	    ),
+//	)
+func KnowledgeAtInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if values := md.Get("x-knowledge-at"); len(values) > 0 {
+				if knowledgeAt, err := time.Parse(time.RFC3339Nano, values[0]); err == nil {
+					// Store parsed timestamp in context for downstream use
+					ctx = context.WithValue(ctx, knowledgeAtKey, knowledgeAt)
+				}
+				// Silently ignore parse errors - the request should proceed with current time
+			}
+		}
+		return handler(ctx, req)
+	}
+}
+
+// GetKnowledgeAt returns the knowledge_at timestamp from context,
+// falling back to time.Now() if not present or zero.
+//
+// This function provides the abstraction layer for bi-temporal queries:
+//   - During saga replay with historical timestamp: returns the knowledge_at from context
+//   - During normal execution: returns time.Now()
+//
+// Services should use this function instead of time.Now() for all timestamp-sensitive
+// data access operations to enable deterministic saga replay.
+//
+// Example usage in a repository:
+//
+//	func (r *Repository) GetActivePositions(ctx context.Context) ([]Position, error) {
+//	    queryTime := db.GetKnowledgeAt(ctx)  // Historical or current time
+//	    return r.db.Query(`
+//	        SELECT * FROM positions
+//	        WHERE valid_from <= $1 AND (valid_to IS NULL OR valid_to > $1)
+//	    `, queryTime)
+//	}
+func GetKnowledgeAt(ctx context.Context) time.Time {
+	if ts, ok := ctx.Value(knowledgeAtKey).(time.Time); ok && !ts.IsZero() {
+		return ts
+	}
+	return time.Now()
+}

--- a/shared/platform/db/interceptor_test.go
+++ b/shared/platform/db/interceptor_test.go
@@ -1,0 +1,270 @@
+package db_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// TestKnowledgeAtInterceptor_ExtractsValidHeader verifies that the interceptor
+// extracts a valid x-knowledge-at header and stores it in context
+func TestKnowledgeAtInterceptor_ExtractsValidHeader(t *testing.T) {
+	t.Parallel()
+
+	interceptor := db.KnowledgeAtInterceptor()
+
+	expectedTime := time.Date(2024, 1, 15, 10, 30, 45, 123456789, time.UTC)
+	md := metadata.New(map[string]string{
+		"x-knowledge-at": expectedTime.Format(time.RFC3339Nano),
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	var capturedCtx context.Context
+	handler := func(ctx context.Context, _ interface{}) (interface{}, error) {
+		capturedCtx = ctx
+		return "ok", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.Service/Method",
+	}
+
+	_, err := interceptor(ctx, nil, info, handler)
+
+	require.NoError(t, err)
+	require.NotNil(t, capturedCtx)
+
+	// Verify the timestamp was extracted and stored in context
+	knowledgeAt := db.GetKnowledgeAt(capturedCtx)
+	assert.Equal(t, expectedTime, knowledgeAt)
+}
+
+// TestKnowledgeAtInterceptor_IgnoresMalformedTimestamp verifies that the interceptor
+// gracefully ignores malformed timestamps without failing the request
+func TestKnowledgeAtInterceptor_IgnoresMalformedTimestamp(t *testing.T) {
+	t.Parallel()
+
+	interceptor := db.KnowledgeAtInterceptor()
+
+	md := metadata.New(map[string]string{
+		"x-knowledge-at": "not-a-valid-timestamp",
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return "ok", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.Service/Method",
+	}
+
+	resp, err := interceptor(ctx, nil, info, handler)
+
+	// Request should succeed despite malformed timestamp
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+// TestKnowledgeAtInterceptor_PassThroughWithoutHeader verifies that the interceptor
+// passes through requests without x-knowledge-at header
+func TestKnowledgeAtInterceptor_PassThroughWithoutHeader(t *testing.T) {
+	t.Parallel()
+
+	interceptor := db.KnowledgeAtInterceptor()
+
+	handler := func(_ context.Context, _ interface{}) (interface{}, error) {
+		return "ok", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.Service/Method",
+	}
+
+	resp, err := interceptor(context.Background(), nil, info, handler)
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp)
+}
+
+// TestKnowledgeAtInterceptor_ContextValueRetrievableDownstream verifies that
+// the extracted knowledge_at value can be retrieved downstream in the handler chain
+func TestKnowledgeAtInterceptor_ContextValueRetrievableDownstream(t *testing.T) {
+	t.Parallel()
+
+	interceptor := db.KnowledgeAtInterceptor()
+
+	expectedTime := time.Date(2024, 1, 15, 10, 30, 45, 0, time.UTC)
+	md := metadata.New(map[string]string{
+		"x-knowledge-at": expectedTime.Format(time.RFC3339Nano),
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	var retrievedTime time.Time
+	handler := func(ctx context.Context, _ interface{}) (interface{}, error) {
+		retrievedTime = db.GetKnowledgeAt(ctx)
+		return "ok", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.Service/Method",
+	}
+
+	_, err := interceptor(ctx, nil, info, handler)
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedTime, retrievedTime)
+}
+
+// TestKnowledgeAtInterceptor_CanBeChained verifies that multiple interceptors
+// can be chained without conflict
+func TestKnowledgeAtInterceptor_CanBeChained(t *testing.T) {
+	t.Parallel()
+
+	knowledgeAtInterceptor := db.KnowledgeAtInterceptor()
+
+	// contextKeyTest is a typed context key for testing
+	type contextKeyTest string
+	const testKey contextKeyTest = "test-key"
+
+	// Simulated second interceptor that adds something to context
+	secondInterceptor := func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+		// Add something else to context
+		ctx = context.WithValue(ctx, testKey, "test-value")
+		return handler(ctx, req)
+	}
+
+	expectedTime := time.Date(2024, 1, 15, 10, 30, 45, 0, time.UTC)
+	md := metadata.New(map[string]string{
+		"x-knowledge-at": expectedTime.Format(time.RFC3339Nano),
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	var capturedCtx context.Context
+	handler := func(ctx context.Context, _ interface{}) (interface{}, error) {
+		capturedCtx = ctx
+		return "ok", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.Service/Method",
+	}
+
+	// Chain interceptors
+	_, err := knowledgeAtInterceptor(ctx, nil, info, func(ctx context.Context, req interface{}) (interface{}, error) {
+		return secondInterceptor(ctx, req, info, handler)
+	})
+
+	require.NoError(t, err)
+
+	// Both values should be present in context
+	knowledgeAt := db.GetKnowledgeAt(capturedCtx)
+	assert.Equal(t, expectedTime, knowledgeAt)
+
+	testValue := capturedCtx.Value(testKey)
+	assert.Equal(t, "test-value", testValue)
+}
+
+// TestGetKnowledgeAt_ReturnsContextTimestamp verifies that GetKnowledgeAt
+// returns the timestamp when present in context (set via interceptor)
+func TestGetKnowledgeAt_ReturnsContextTimestamp(t *testing.T) {
+	t.Parallel()
+
+	interceptor := db.KnowledgeAtInterceptor()
+
+	expectedTime := time.Date(2024, 1, 15, 10, 30, 45, 0, time.UTC)
+	md := metadata.New(map[string]string{
+		"x-knowledge-at": expectedTime.Format(time.RFC3339Nano),
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	var result time.Time
+	handler := func(ctx context.Context, _ interface{}) (interface{}, error) {
+		result = db.GetKnowledgeAt(ctx)
+		return "ok", nil
+	}
+
+	info := &grpc.UnaryServerInfo{
+		FullMethod: "/test.Service/Method",
+	}
+
+	_, err := interceptor(ctx, nil, info, handler)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedTime, result)
+}
+
+// TestGetKnowledgeAt_FallbackToTimeNow verifies that GetKnowledgeAt
+// falls back to time.Now() when context lacks timestamp
+func TestGetKnowledgeAt_FallbackToTimeNow(t *testing.T) {
+	t.Parallel()
+
+	before := time.Now()
+	result := db.GetKnowledgeAt(context.Background())
+	after := time.Now()
+
+	// Result should be between before and after (allowing for execution time)
+	assert.True(t, !result.Before(before) && !result.After(after),
+		"Expected result to be current time (between %v and %v), got %v",
+		before, after, result)
+}
+
+// TestGetKnowledgeAt_FallbackWhenZeroTime verifies that GetKnowledgeAt
+// falls back to time.Now() when no header is provided (resulting in zero time)
+func TestGetKnowledgeAt_FallbackWhenZeroTime(t *testing.T) {
+	t.Parallel()
+
+	// Context without knowledge_at header - should fallback to time.Now()
+	before := time.Now()
+	result := db.GetKnowledgeAt(context.Background())
+	after := time.Now()
+
+	assert.True(t, !result.Before(before) && !result.After(after),
+		"Expected fallback to current time when timestamp is zero")
+}
+
+// TestGetKnowledgeAt_ConcurrentSafety verifies that concurrent calls to
+// GetKnowledgeAt are safe
+func TestGetKnowledgeAt_ConcurrentSafety(t *testing.T) {
+	t.Parallel()
+
+	interceptor := db.KnowledgeAtInterceptor()
+
+	expectedTime := time.Date(2024, 1, 15, 10, 30, 45, 0, time.UTC)
+	md := metadata.New(map[string]string{
+		"x-knowledge-at": expectedTime.Format(time.RFC3339Nano),
+	})
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	// Set up context via interceptor first
+	var enrichedCtx context.Context
+	handler := func(ctx context.Context, _ interface{}) (interface{}, error) {
+		enrichedCtx = ctx
+		return "ok", nil
+	}
+	info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+	_, err := interceptor(ctx, nil, info, handler)
+	require.NoError(t, err)
+
+	// Launch multiple goroutines calling GetKnowledgeAt concurrently
+	const numGoroutines = 100
+	results := make(chan time.Time, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			results <- db.GetKnowledgeAt(enrichedCtx)
+		}()
+	}
+
+	// Collect all results
+	for i := 0; i < numGoroutines; i++ {
+		result := <-results
+		assert.Equal(t, expectedTime, result)
+	}
+}


### PR DESCRIPTION
## Summary

Implements knowledge_at timestamp propagation through gRPC clients and service interceptors to enable deterministic saga replay with historical data queries.

This PR delivers the first 3 subtasks of saga-script-versioning.7:
- Client-side context propagation utilities (`PropagateKnowledgeAt`, `ExtractKnowledgeAt`)
- gRPC metadata header transmission (`ApplyKnowledgeAt` with `x-knowledge-at` header)
- Server-side interceptor (`KnowledgeAtInterceptor`) to extract and store timestamp
- Data access abstraction (`GetKnowledgeAt`) with `time.Now()` fallback

## Changes Made

### New Files Created

1. **`shared/pkg/clients/temporal.go`** (78 lines)
   - `PropagateKnowledgeAt(ctx, time.Time)` - Store timestamp in context
   - `ExtractKnowledgeAt(ctx)` - Retrieve timestamp from context
   - `ApplyKnowledgeAt(ctx)` - Add timestamp to gRPC metadata as `x-knowledge-at` header

2. **`shared/pkg/clients/temporal_test.go`** (148 lines)
   - Comprehensive unit tests for all temporal functions
   - Tests cover propagation, extraction, metadata application, zero-time handling, context immutability

3. **`shared/platform/db/interceptor.go`** (74 lines)
   - `KnowledgeAtInterceptor()` - gRPC unary server interceptor to extract `x-knowledge-at` header
   - `GetKnowledgeAt(ctx)` - Retrieve timestamp from context or fallback to `time.Now()`

4. **`shared/platform/db/interceptor_test.go`** (237 lines)
   - Unit tests for interceptor and `GetKnowledgeAt` function
   - Tests cover header extraction, malformed timestamp handling, fallback behavior, concurrency

## Technical Details

**Bi-temporal Query Pattern:**
```go
// Client side - propagate timestamp through gRPC calls
ctx = clients.PropagateKnowledgeAt(ctx, saga.KnowledgeAt)
ctx = clients.ApplyKnowledgeAt(ctx)  // Adds x-knowledge-at header
result, err := service.Query(ctx, req)

// Server side - extract timestamp in interceptor
server := grpc.NewServer(
    grpc.UnaryInterceptor(db.KnowledgeAtInterceptor()),
)

// Data access layer - use timestamp instead of time.Now()
func (r *Repository) GetActivePositions(ctx context.Context) ([]Position, error) {
    queryTime := db.GetKnowledgeAt(ctx)  // Historical or current time
    return r.db.Query(`
        SELECT * FROM positions
        WHERE valid_from <= $1 AND (valid_to IS NULL OR valid_to > $1)
    `, queryTime)
}
```

## Test Strategy

TDD approach used throughout:
1. Write tests first (Red phase)
2. Implement to make tests pass (Green phase)
3. All tests passing: ✅

Test coverage includes:
- Timestamp propagation and extraction
- gRPC metadata header transmission with RFC3339Nano format
- Server-side header extraction and context storage
- Graceful handling of malformed/missing timestamps
- Context immutability verification
- Concurrent access safety
- Fallback to `time.Now()` when no historical timestamp present

## Next Steps (Future PRs)

Remaining subtasks for saga-script-versioning.7:
- **Subtask 4**: Update saga step execution to set `KnowledgeAt` in `StarlarkContext`
- **Subtask 5**: Refactor service data access layers to use `GetKnowledgeAt(ctx)` instead of `time.Now()`
- **Subtask 6**: Integration tests with testcontainers verifying time-travel query behavior

## Risk Assessment

**Low risk** - Pure infrastructure addition:
- No existing code modified
- All changes are additive (new functions and tests)
- No services using this infrastructure yet (adoption in future PRs)
- Graceful degradation: if services don't propagate `knowledge_at`, `GetKnowledgeAt` falls back to `time.Now()`

## Performance Considerations

- Minimal overhead: context value lookups and metadata header operations
- No database schema changes required
- No additional network round trips