### PR TITLE
feat: Add production fail-fast for NoOp fallbacks in financial-accounting

### DIFF
--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -56,6 +56,12 @@ var (
 	ErrBankCashAccountIDInvalid  = errors.New("BANK_CASH_ACCOUNT_ID must be a valid UUID")
 )
 
+// Static errors for production environment requirements
+var (
+	ErrRedisRequiredInProduction = errors.New("redis required for idempotency in production environment")
+	ErrKafkaRequiredInProduction = errors.New("kafka required for event publishing in production environment")
+)
+
 func main() {
 	// Initialize structured logging with configurable log level
 	// Note: bootstrap.NewLogger hardcodes INFO level, so we create logger manually for LOG_LEVEL support
@@ -130,6 +136,7 @@ func run(logger *slog.Logger) error {
 
 	// Initialize Kafka producer for outbox worker (optional - depends on KAFKA_BOOTSTRAP_SERVERS)
 	var kafkaProducer *kafka.ProtoProducer
+	var usingNoopEventPublisher bool
 	bootstrapServers := env.GetEnvOrDefault("KAFKA_BOOTSTRAP_SERVERS", "")
 	if bootstrapServers != "" {
 		producer, err := kafka.NewProtoProducer(kafka.ProducerConfig{
@@ -140,15 +147,32 @@ func run(logger *slog.Logger) error {
 			Compression:      "snappy",
 		})
 		if err != nil {
-			logger.Warn("failed to create Kafka producer for outbox worker",
-				"error", err)
+			// Fail fast in production - Kafka is required for event publishing
+			if env.IsProduction() {
+				logger.Error("CRITICAL: Failed to create Kafka producer in production - failing fast",
+					"error", err)
+				return fmt.Errorf("%w: %w", ErrKafkaRequiredInProduction, err)
+			}
+			logger.Warn("failed to create Kafka producer for outbox worker - DEVELOPMENT ONLY",
+				"error", err,
+				"environment", os.Getenv("ENVIRONMENT"))
+			usingNoopEventPublisher = true
 		} else {
 			kafkaProducer = producer
 			logger.Info("Kafka producer initialized for outbox worker",
 				"bootstrap_servers", bootstrapServers)
 		}
 	} else {
-		logger.Info("outbox worker disabled: KAFKA_BOOTSTRAP_SERVERS not set")
+		// Fail fast in production - Kafka is required for event publishing
+		if env.IsProduction() {
+			logger.Error("CRITICAL: Kafka unavailable in production - failing fast",
+				"reason", "KAFKA_BOOTSTRAP_SERVERS not set")
+			return ErrKafkaRequiredInProduction
+		}
+		logger.Warn("outbox worker disabled - DEVELOPMENT ONLY",
+			"reason", "KAFKA_BOOTSTRAP_SERVERS not set",
+			"environment", os.Getenv("ENVIRONMENT"))
+		usingNoopEventPublisher = true
 	}
 
 	// Start outbox worker if Kafka producer is available
@@ -222,12 +246,21 @@ func run(logger *slog.Logger) error {
 	// Create Redis client and idempotency service
 	var idempotencySvc idempotency.Service
 	var redisSvc *idempotency.RedisService // Keep reference for cleanup worker
+	var usingNoopIdempotency bool
 	redisClient, err := createRedisClient(logger)
 	if err != nil {
-		// Non-fatal: fall back to noop service for development/testing
-		logger.Warn("failed to connect to Redis, using noop idempotency service",
-			"error", err)
+		// Fail fast in production - Redis is required for idempotency guarantees
+		if env.IsProduction() {
+			logger.Error("CRITICAL: Redis unavailable in production - failing fast",
+				"error", err)
+			return fmt.Errorf("%w: %w", ErrRedisRequiredInProduction, err)
+		}
+		// Non-fatal in non-production: fall back to noop service for development/testing
+		logger.Warn("using noop idempotency service - DEVELOPMENT ONLY",
+			"error", err,
+			"environment", os.Getenv("ENVIRONMENT"))
 		idempotencySvc = newNoopIdempotencyService()
+		usingNoopIdempotency = true
 	} else {
 		redisSvc = idempotency.NewRedisService(redisClient)
 		idempotencySvc = redisSvc
@@ -266,9 +299,16 @@ func run(logger *slog.Logger) error {
 		logger.Info("idempotency cleanup worker disabled by configuration")
 	}
 
-	// Create event publisher (noop for now - Kafka implementation for production)
+	// Create event publisher
+	// Note: The primary event publishing mechanism is the outbox pattern (transactional).
+	// This direct publisher is for optional synchronous publishing scenarios.
 	eventPublisher := &noopEventPublisher{}
-	logger.Info("event publisher initialized (noop mode)")
+	if usingNoopEventPublisher {
+		logger.Warn("using noop event publisher - DEVELOPMENT ONLY",
+			"environment", os.Getenv("ENVIRONMENT"))
+	} else {
+		logger.Info("event publisher initialized (noop mode for direct publishing, outbox handles primary events)")
+	}
 
 	// Initialize reference-data client for fungibility validation (optional)
 	var registryOption service.Option
@@ -337,10 +377,12 @@ func run(logger *slog.Logger) error {
 
 	// Register health check service with database connectivity check
 	healthChecker, err := serviceobs.NewHealthChecker(serviceobs.HealthCheckerConfig{
-		DB:           db,
-		Logger:       logger,
-		ServiceName:  "financial-accounting",
-		CheckTimeout: defaults.DefaultHealthCheckTimeout,
+		DB:                   db,
+		Logger:               logger,
+		ServiceName:          "financial-accounting",
+		CheckTimeout:         defaults.DefaultHealthCheckTimeout,
+		UsingNoopIdempotency: usingNoopIdempotency,
+		UsingNoopEvents:      usingNoopEventPublisher,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create health checker: %w", err)

--- a/services/financial-accounting/cmd/main_test.go
+++ b/services/financial-accounting/cmd/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsProductionEnvironmentDetection tests that environment detection works correctly
+// via the shared env package.
+func TestIsProductionEnvironmentDetection(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		expected bool
+	}{
+		{
+			name:     "production environment",
+			envValue: "production",
+			expected: true,
+		},
+		{
+			name:     "prod shorthand",
+			envValue: "prod",
+			expected: true,
+		},
+		{
+			name:     "development environment",
+			envValue: "development",
+			expected: false,
+		},
+		{
+			name:     "staging environment",
+			envValue: "staging",
+			expected: false,
+		},
+		{
+			name:     "empty environment",
+			envValue: "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("ENVIRONMENT", tt.envValue)
+			result := env.IsProduction()
+			assert.Equal(t, tt.expected, result, "IsProduction() should be %v for ENVIRONMENT=%q", tt.expected, tt.envValue)
+		})
+	}
+}
+
+// Note: Full integration tests for production startup requirements would need
+// to run the actual service and verify it fails to start without Redis/Kafka.
+// These are covered by the unit tests in:
+// - shared/platform/env/env_test.go (IsProduction)
+// - services/financial-accounting/observability/health_test.go (NoopFallbackChecker)
+//
+// The production fail-fast behavior is implemented in the run() function of main.go,
+// which checks env.IsProduction() before allowing NoOp fallbacks.
+//
+// To test the actual startup behavior, you would need to:
+// 1. Set ENVIRONMENT=production
+// 2. Ensure Redis/Kafka are not available
+// 3. Verify the service exits with an error
+//
+// This is typically done via:
+// - E2E tests in CI that spin up the service container
+// - Manual testing with `ENVIRONMENT=production go run ./services/financial-accounting/cmd`

--- a/services/financial-accounting/observability/health.go
+++ b/services/financial-accounting/observability/health.go
@@ -31,10 +31,12 @@ type HealthChecker struct {
 
 // HealthCheckerConfig contains configuration for creating a new HealthChecker.
 type HealthCheckerConfig struct {
-	DB           *gorm.DB
-	Logger       *slog.Logger
-	ServiceName  string        // Defaults to "financial-accounting"
-	CheckTimeout time.Duration // Defaults to 5 seconds
+	DB                   *gorm.DB
+	Logger               *slog.Logger
+	ServiceName          string        // Defaults to "financial-accounting"
+	CheckTimeout         time.Duration // Defaults to 5 seconds
+	UsingNoopIdempotency bool          // Set to true if using NoOp idempotency service
+	UsingNoopEvents      bool          // Set to true if using NoOp event publisher
 }
 
 // NewHealthChecker creates a new health checker with dependency checking.
@@ -67,6 +69,11 @@ func NewHealthChecker(config HealthCheckerConfig) (*HealthChecker, error) {
 	// Build list of health checkers
 	checkers := []health.Checker{
 		NewGormDatabaseHealthChecker(config.DB, config.CheckTimeout),
+	}
+
+	// Add NoOp fallback checker if any fallback is active
+	if config.UsingNoopIdempotency || config.UsingNoopEvents {
+		checkers = append(checkers, NewNoopFallbackChecker(config.UsingNoopIdempotency, config.UsingNoopEvents))
 	}
 
 	aggregator := health.NewAggregator(checkers)
@@ -265,6 +272,59 @@ func (h *HealthChecker) logHealthCheck(report *health.Report, overallStatus heal
 					"error", comp.Error)
 			}
 		}
+	}
+}
+
+// NoopFallbackChecker reports health degradation when NoOp fallback services are active.
+// This alerts operators that the service is running in a reduced functionality mode
+// (typically development/testing) where some guarantees are not enforced.
+type NoopFallbackChecker struct {
+	usingNoopIdempotency bool
+	usingNoopEvents      bool
+}
+
+// NewNoopFallbackChecker creates a checker that reports DEGRADED status when
+// NoOp fallback services are being used instead of production implementations.
+func NewNoopFallbackChecker(usingNoopIdempotency, usingNoopEvents bool) *NoopFallbackChecker {
+	return &NoopFallbackChecker{
+		usingNoopIdempotency: usingNoopIdempotency,
+		usingNoopEvents:      usingNoopEvents,
+	}
+}
+
+// Name returns the component name.
+func (n *NoopFallbackChecker) Name() string {
+	return "noop-fallbacks"
+}
+
+// Check returns the health status based on whether NoOp fallbacks are active.
+func (n *NoopFallbackChecker) Check(_ context.Context) health.ComponentResult {
+	start := time.Now()
+
+	if !n.usingNoopIdempotency && !n.usingNoopEvents {
+		return health.ComponentResult{
+			Name:         n.Name(),
+			Status:       health.StatusHealthy,
+			Message:      "all production services connected",
+			ResponseTime: time.Since(start),
+			CheckedAt:    start,
+		}
+	}
+
+	var degradedServices []string
+	if n.usingNoopIdempotency {
+		degradedServices = append(degradedServices, "idempotency (Redis)")
+	}
+	if n.usingNoopEvents {
+		degradedServices = append(degradedServices, "event publishing (Kafka)")
+	}
+
+	return health.ComponentResult{
+		Name:         n.Name(),
+		Status:       health.StatusDegraded,
+		Message:      fmt.Sprintf("using noop fallbacks for: %v - DEVELOPMENT ONLY", degradedServices),
+		ResponseTime: time.Since(start),
+		CheckedAt:    start,
 	}
 }
 

--- a/services/financial-accounting/observability/health_test.go
+++ b/services/financial-accounting/observability/health_test.go
@@ -217,3 +217,114 @@ func TestMapStatusToGRPC(t *testing.T) {
 		assert.Equal(t, tt.expected, result, "status %v should map to %v", tt.status, tt.expected)
 	}
 }
+
+func TestNoopFallbackChecker_Healthy(t *testing.T) {
+	checker := NewNoopFallbackChecker(false, false)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, "noop-fallbacks", result.Name)
+	assert.Equal(t, health.StatusHealthy, result.Status)
+	assert.Equal(t, "all production services connected", result.Message)
+	assert.Nil(t, result.Error)
+}
+
+func TestNoopFallbackChecker_DegradedIdempotency(t *testing.T) {
+	checker := NewNoopFallbackChecker(true, false)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, "noop-fallbacks", result.Name)
+	assert.Equal(t, health.StatusDegraded, result.Status)
+	assert.Contains(t, result.Message, "idempotency (Redis)")
+	assert.Contains(t, result.Message, "DEVELOPMENT ONLY")
+}
+
+func TestNoopFallbackChecker_DegradedEvents(t *testing.T) {
+	checker := NewNoopFallbackChecker(false, true)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, "noop-fallbacks", result.Name)
+	assert.Equal(t, health.StatusDegraded, result.Status)
+	assert.Contains(t, result.Message, "event publishing (Kafka)")
+	assert.Contains(t, result.Message, "DEVELOPMENT ONLY")
+}
+
+func TestNoopFallbackChecker_DegradedBoth(t *testing.T) {
+	checker := NewNoopFallbackChecker(true, true)
+
+	result := checker.Check(context.Background())
+
+	assert.Equal(t, "noop-fallbacks", result.Name)
+	assert.Equal(t, health.StatusDegraded, result.Status)
+	assert.Contains(t, result.Message, "idempotency (Redis)")
+	assert.Contains(t, result.Message, "event publishing (Kafka)")
+	assert.Contains(t, result.Message, "DEVELOPMENT ONLY")
+}
+
+func TestNoopFallbackChecker_Name(t *testing.T) {
+	checker := NewNoopFallbackChecker(false, false)
+	assert.Equal(t, "noop-fallbacks", checker.Name())
+}
+
+func TestHealthChecker_WithNoopFallbacks_Degraded(t *testing.T) {
+	gormDB, mock := setupMockDB(t)
+	mock.ExpectPing()
+
+	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
+		DB:                   gormDB,
+		CheckTimeout:         5 * time.Second,
+		UsingNoopIdempotency: true,
+		UsingNoopEvents:      false,
+	})
+	require.NoError(t, err)
+
+	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+
+	require.NoError(t, err)
+	// Degraded still returns SERVING per gRPC health protocol
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHealthChecker_WithNoopFallbacks_ChecksComponent(t *testing.T) {
+	gormDB, _ := setupMockDB(t)
+
+	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
+		DB:                   gormDB,
+		UsingNoopIdempotency: true,
+		UsingNoopEvents:      true,
+	})
+	require.NoError(t, err)
+
+	// Check noop-fallbacks component specifically
+	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: "noop-fallbacks",
+	})
+
+	require.NoError(t, err)
+	// Degraded maps to SERVING
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_SERVING, resp.Status)
+}
+
+func TestHealthChecker_WithoutNoopFallbacks_NoFallbackComponent(t *testing.T) {
+	gormDB, _ := setupMockDB(t)
+
+	healthChecker, err := NewHealthChecker(HealthCheckerConfig{
+		DB:                   gormDB,
+		UsingNoopIdempotency: false,
+		UsingNoopEvents:      false,
+	})
+	require.NoError(t, err)
+
+	// noop-fallbacks component should not exist when not using fallbacks
+	resp, err := healthChecker.Check(context.Background(), &grpc_health_v1.HealthCheckRequest{
+		Service: "noop-fallbacks",
+	})
+
+	require.NoError(t, err)
+	// Component not found returns UNKNOWN
+	assert.Equal(t, grpc_health_v1.HealthCheckResponse_UNKNOWN, resp.Status)
+}

--- a/shared/platform/env/env.go
+++ b/shared/platform/env/env.go
@@ -118,3 +118,11 @@ func GetEnvAsSlice(key string, defaultValue []string) []string {
 	}
 	return result
 }
+
+// IsProduction returns true if the ENVIRONMENT variable indicates a production
+// environment. Recognized production values (case-insensitive): "production", "prod".
+// Returns false for all other values including empty string.
+func IsProduction() bool {
+	environment := strings.ToLower(strings.TrimSpace(os.Getenv("ENVIRONMENT")))
+	return environment == "production" || environment == "prod"
+}

--- a/shared/platform/env/env_test.go
+++ b/shared/platform/env/env_test.go
@@ -549,3 +549,82 @@ func slicesEqual(a, b []string) bool {
 	}
 	return true
 }
+
+func TestIsProduction(t *testing.T) {
+	tests := []struct {
+		name     string
+		envValue string
+		setEnv   bool
+		expected bool
+	}{
+		{
+			name:     "returns true for 'production'",
+			envValue: "production",
+			setEnv:   true,
+			expected: true,
+		},
+		{
+			name:     "returns true for 'prod'",
+			envValue: "prod",
+			setEnv:   true,
+			expected: true,
+		},
+		{
+			name:     "returns true for 'PRODUCTION' (case-insensitive)",
+			envValue: "PRODUCTION",
+			setEnv:   true,
+			expected: true,
+		},
+		{
+			name:     "returns true for 'Prod' (case-insensitive)",
+			envValue: "Prod",
+			setEnv:   true,
+			expected: true,
+		},
+		{
+			name:     "returns false for 'development'",
+			envValue: "development",
+			setEnv:   true,
+			expected: false,
+		},
+		{
+			name:     "returns false for 'staging'",
+			envValue: "staging",
+			setEnv:   true,
+			expected: false,
+		},
+		{
+			name:     "returns false for empty string",
+			envValue: "",
+			setEnv:   true,
+			expected: false,
+		},
+		{
+			name:     "returns false for missing var",
+			envValue: "",
+			setEnv:   false,
+			expected: false,
+		},
+		{
+			name:     "trims whitespace around 'production'",
+			envValue: "  production  ",
+			setEnv:   true,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := "ENVIRONMENT"
+			if tt.setEnv {
+				t.Setenv(key, tt.envValue)
+			}
+
+			result := IsProduction()
+			if result != tt.expected {
+				t.Errorf("IsProduction() = %v, expected %v (env=%q)",
+					result, tt.expected, tt.envValue)
+			}
+		})
+	}
+}

--- a/shared/platform/env/env_test.go
+++ b/shared/platform/env/env_test.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"os"
 	"testing"
 	"time"
 )
@@ -618,6 +619,15 @@ func TestIsProduction(t *testing.T) {
 			key := "ENVIRONMENT"
 			if tt.setEnv {
 				t.Setenv(key, tt.envValue)
+			} else {
+				// Explicitly unset ENVIRONMENT to ensure test isolation
+				// CI environments may have ENVIRONMENT set
+				if old, ok := os.LookupEnv(key); ok {
+					t.Cleanup(func() { _ = os.Setenv(key, old) })
+				} else {
+					t.Cleanup(func() { _ = os.Unsetenv(key) })
+				}
+				_ = os.Unsetenv(key)
 			}
 
 			result := IsProduction()


### PR DESCRIPTION
## Summary

- Add `env.IsProduction()` helper for environment detection (production/prod)
- Fail service startup in production when Redis unavailable (idempotency)
- Fail service startup in production when Kafka unavailable (event publishing)
- Add `NoopFallbackChecker` for health check degradation when fallbacks active
- Development mode continues to allow NoOp fallbacks with clear warnings

## Changes Made

### `shared/platform/env/env.go`
- Added `IsProduction()` function that checks ENVIRONMENT variable for "production" or "prod" (case-insensitive)

### `services/financial-accounting/cmd/main.go`
- Added static errors `ErrRedisRequiredInProduction` and `ErrKafkaRequiredInProduction`
- Modified Redis client creation to fail-fast in production if unavailable
- Modified Kafka producer creation to fail-fast in production if unavailable
- Pass NoOp fallback flags to health checker for degradation reporting

### `services/financial-accounting/observability/health.go`
- Added `NoopFallbackChecker` health component that reports DEGRADED when fallbacks active
- Extended `HealthCheckerConfig` with `UsingNoopIdempotency` and `UsingNoopEvents` flags
- NoOp fallback checker only added to aggregator when fallbacks are active

## Test Plan

- [x] `TestIsProduction` - Verifies environment detection for production/prod/development/staging/empty
- [x] `TestNoopFallbackChecker_*` - Verifies health degradation reporting for various fallback combinations
- [x] `TestHealthChecker_WithNoopFallbacks_*` - Verifies health checker integration with NoOp detection
- [x] All existing financial-accounting tests pass
- [ ] Manual verification: Set `ENVIRONMENT=production` without Redis/Kafka and verify service fails to start

## Task Master

- Tag: `production-readiness`
- Task: `7` - Remove NoOp Fallbacks from Financial-Accounting Service