### PR TITLE
feat: Enable database persistence in market-information service

### DIFF
--- a/services/market-information/cmd/main.go
+++ b/services/market-information/cmd/main.go
@@ -14,7 +14,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	"github.com/meridianhub/meridian/services/market-information/adapters/external/ecb"
+	"github.com/meridianhub/meridian/services/market-information/adapters/persistence"
 	"github.com/meridianhub/meridian/services/market-information/config"
 	"github.com/meridianhub/meridian/services/market-information/service"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
@@ -72,16 +75,36 @@ func run(logger *slog.Logger) error {
 	}
 	defer bootstrap.ShutdownTracer(tracer, logger)
 
-	// TODO: Wire database into repository once persistence layer is implemented (Task 3)
-	// Currently scaffolding without database to avoid holding idle connections.
-	// Uncomment when ready:
-	// dbConfig := bootstrap.DefaultDatabaseConfig()
-	// dbConfig.Logger = logger
-	// db, err := bootstrap.NewDatabase(ctx, dbConfig)
-	// if err != nil {
-	// 	return fmt.Errorf("failed to initialize database: %w", err)
-	// }
-	// logger.Info("database connection established")
+	// Initialize database connection using pgxpool
+	dbURL := env.GetEnvOrDefault("DATABASE_URL", "postgres://meridian_user@localhost:26257/meridian?sslmode=disable")
+	dbPool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		return fmt.Errorf("failed to create database connection pool: %w", err)
+	}
+	defer dbPool.Close()
+
+	// Verify database connectivity
+	if err := dbPool.Ping(ctx); err != nil {
+		return fmt.Errorf("failed to ping database: %w", err)
+	}
+	logger.Info("database connection established", "url", dbURL)
+
+	// Create repositories for persistence
+	masterTenantID := env.GetEnvOrDefault("MASTER_TENANT_ID", "meridian_master")
+	repos := persistence.NewRepositories(dbPool, masterTenantID)
+	logger.Info("repositories initialized", "master_tenant_id", masterTenantID)
+
+	// Create Market Information service server
+	marketInformationServer, err := service.NewServer(
+		repos.DataSet,
+		repos.Observation,
+		repos.Source,
+		service.WithLogger(logger.With("component", "market_information_server")),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create market information server: %w", err)
+	}
+	logger.Info("market information server created")
 
 	// Initialize auth interceptor (optional - based on AUTH_ENABLED)
 	authConfig := bootstrap.DefaultAuthConfig(logger)
@@ -95,8 +118,8 @@ func run(logger *slog.Logger) error {
 		WithAuthInterceptor(authInterceptor).
 		Build()
 
-	// TODO: Register Market Information service when proto definitions are available
-	// pb.RegisterMarketInformationServiceServer(grpcServer, marketInformationService)
+	// Register Market Information service
+	marketinformationv1.RegisterMarketInformationServiceServer(grpcServer, marketInformationServer)
 
 	// Register health check service
 	healthChecker := service.NewHealthChecker(service.HealthCheckerConfig{
@@ -199,48 +222,37 @@ func run(logger *slog.Logger) error {
 	orchestrator := bootstrap.NewShutdownOrchestrator(grpcServer, logger)
 
 	// Initialize ECB adapter worker (if enabled)
-	// Note: This requires the Market Information service to be fully wired up.
-	// The ECB worker calls RecordObservation on the service to ingest FX rates.
+	// Note: The ECB worker calls RecordObservation on the Server to ingest FX rates.
 	if cfg.ECB.Enabled {
-		// TODO: Enable ECB worker once marketInformationServer is available
-		// The ECB worker needs a MarketInformationClient interface which the Server implements.
-		// Once the Server is created above, uncomment and wire up:
-		//
-		// ecbClient := ecb.NewClient(ecb.Config{
-		// 	Endpoint: cfg.ECB.Endpoint,
-		// 	Timeout:  cfg.ECB.Timeout,
-		// }, ecb.WithLogger(logger))
-		//
-		// ecbWorker := ecb.NewWorker(
-		// 	ecbClient,
-		// 	marketInformationServer, // Server implements MarketInformationClient interface
-		// 	ecb.WorkerConfig{
-		// 		DatasetCode:   cfg.ECB.DatasetCode,
-		// 		SourceCode:    cfg.ECB.SourceCode,
-		// 		FetchInterval: cfg.ECB.Interval,
-		// 		MaxRetries:    cfg.ECB.MaxRetries,
-		// 	},
-		// 	logger,
-		// )
-		//
-		// ecbWorker.Start(ctx)
-		//
-		// // Register cleanup to stop ECB worker before other services
-		// orchestrator.AddCleanup(func() error {
-		// 	ecbWorker.Stop()
-		// 	return nil
-		// })
-		//
-		// logger.Info("ECB adapter initialized",
-		// 	"interval", cfg.ECB.Interval,
-		// 	"source_code", cfg.ECB.SourceCode,
-		// 	"dataset_code", cfg.ECB.DatasetCode)
+		ecbClient := ecb.NewClient(ecb.Config{
+			Endpoint: cfg.ECB.Endpoint,
+			Timeout:  cfg.ECB.Timeout,
+		}, ecb.WithLogger(logger))
 
-		logger.Warn("ECB adapter enabled but Market Information service not yet wired up",
-			"ecb_enabled", cfg.ECB.Enabled)
+		ecbWorker := ecb.NewWorker(
+			ecbClient,
+			marketInformationServer, // Server implements MarketInformationClient interface
+			ecb.WorkerConfig{
+				DatasetCode:   cfg.ECB.DatasetCode,
+				SourceCode:    cfg.ECB.SourceCode,
+				FetchInterval: cfg.ECB.Interval,
+				MaxRetries:    cfg.ECB.MaxRetries,
+			},
+			logger,
+		)
 
-		// Suppress unused import warning - remove this block when ECB worker is wired up
-		_ = ecb.NewClient
+		ecbWorker.Start(ctx)
+
+		// Register cleanup to stop ECB worker before other services
+		orchestrator.AddCleanup(func() error {
+			ecbWorker.Stop()
+			return nil
+		})
+
+		logger.Info("ECB adapter initialized",
+			"interval", cfg.ECB.Interval,
+			"source_code", cfg.ECB.SourceCode,
+			"dataset_code", cfg.ECB.DatasetCode)
 	}
 
 	// Register cleanup functions (LIFO order - HTTP server first, then database)
@@ -255,11 +267,8 @@ func run(logger *slog.Logger) error {
 		return nil
 	})
 
-	// TODO: Re-enable database cleanup when persistence layer is implemented
-	// orchestrator.AddCleanup(func() error {
-	// 	bootstrap.CloseDatabase(db, logger)
-	// 	return nil
-	// })
+	// Note: Database pool cleanup is handled via defer dbPool.Close() above
+	// This ensures the pool is closed even if orchestrator.Wait returns early
 
 	return orchestrator.Wait(serverErrors)
 }


### PR DESCRIPTION
## Summary

Wire database connectivity and ECB worker into market-information service by enabling previously scaffolded code. This completes the integration layer between domain logic and persistence.

## Changes Made

### Database Integration
- Replace GORM-based bootstrap with direct pgxpool connection (repositories require pgxpool)
- Initialize DataSet, Observation, and Source repositories with connection pool
- Add database connectivity verification with Ping

### Service Wiring
- Instantiate Server with all three repositories
- Register Server with gRPC (implements MarketInformationServiceServer)
- Configure master tenant ID via MASTER_TENANT_ID env (default: meridian_master)

### ECB Worker
- Enable ECB worker with marketInformationServer as client
- Configure dataset code (ECB_FX), source code (ECB), and fetch interval (24h)
- Register worker cleanup in shutdown orchestrator

### Connection Lifecycle
- Use defer dbPool.Close() for pool cleanup
- Ensures cleanup even if orchestrator.Wait returns early

## Testing

E2E integration test results (6/7 passing):

| Test | Status | Notes |
|------|--------|-------|
| TestE2E_FXRateIngestionAndQuery | ✅ PASS | FX rate storage and retrieval with real database |
| TestE2E_BatchIngestionAndSupersession | ✅ PASS | Quality ladder supersession logic |
| TestE2E_AuditTrailAndKnowledgeLineage | ✅ PASS | Bi-temporal audit trail with transaction_time and valid_time |
| TestE2E_MultiTenantIsolation | ✅ PASS | Tenant-specific observation isolation |
| TestE2E_ConcurrentIngestion | ✅ PASS | Concurrent writes without deadlock |
| TestE2E_AsyncOperationsWithAwait | ✅ PASS | Async operations with await package |
| TestE2E_EnergyTariffTemporalValidity | ❌ FAIL | Pre-existing test bug (also fails on develop) |

**Note on failing test:** TestE2E_EnergyTariffTemporalValidity fails because it uses `time.Now()` for queries but creates observations with future `observedAt` timestamps (Apr 1, Jul 1, 2026). When today is Jan 28, 2026, queries for "now" cannot find observations recorded in the future. This is a test design issue that exists on the develop branch and is not introduced by this PR.

## Implementation Notes

**Why pgxpool instead of GORM?**
The persistence layer (`services/market-information/adapters/persistence`) was designed to use pgx directly for better control over CockroachDB-specific features. GORM abstracts away too much for bi-temporal queries and quality ladder logic.

**Master Tenant ID:**
The repository layer supports hierarchical dataset lookup (tenant-first, then master fallback). The master tenant hosts shared/public market data like ECB FX rates. Configurable via `MASTER_TENANT_ID` environment variable.

## Risk Assessment

**Low Risk:**
- No schema changes (migrations already exist)
- E2E tests cover all critical paths
- ECB worker is opt-in via `ECB_ENABLED` env variable (default: false)
- Changes are localized to service initialization in main.go

## Deployment

**Environment Variables:**
- `DATABASE_URL` - CockroachDB connection string (default: localhost:26257)
- `MASTER_TENANT_ID` - Master tenant for shared datasets (default: meridian_master)
- `ECB_ENABLED` - Enable ECB FX rate worker (default: false)

**Database Requirements:**
- Migrations in `services/market-information/migrations/` must be applied
- CockroachDB cluster must be accessible

## Follow-up

None required - this PR completes Task Master production-readiness.6.

Resolves: production-readiness.6