### PR TITLE
fix: Upgrade Go to 1.25.6 to address security vulnerabilities

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.6'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.6'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,7 +64,7 @@ jobs:
       if: matrix.language == 'go'
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.5'
+        go-version: '1.25.6'
         cache: true
 
     # Set up buf for protobuf generation (pinned version for reproducibility)

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.6'
           cache: true
 
       - name: Install Atlas CLI
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.6'
           cache: true
 
       - name: Install Atlas CLI
@@ -241,7 +241,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.6'
           cache: true
 
       - name: Install Atlas CLI

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.6'
           cache: true
 
       - name: Set up buf
@@ -98,7 +98,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.5'
+        go-version: '1.25.6'
         cache: true
 
     - name: Set up buf

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.6'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.5'
+        go-version: '1.25.6'
         cache: true
 
     - name: Set up buf
@@ -51,7 +51,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.5'
+        go-version: '1.25.6'
         cache: true
 
     - name: Set up buf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.5'
+          go-version: '1.25.6'
           cache: true
 
       - name: Set up buf


### PR DESCRIPTION
## Summary

Upgrades Go from 1.25.6 to 1.25.6 across all GitHub Actions workflows to address two critical security vulnerabilities identified by `govulncheck`.

## Security Vulnerabilities Fixed

### 1. GO-2026-4341: Memory exhaustion in query parameter parsing
- **Package**: `net/url`
- **Severity**: Critical
- **Impact**: Attackers could cause memory exhaustion through malicious query parameters
- **Affected code**:
  - `services/gateway/proxy.go:113` - ReverseProxy.ServeHTTP calls url.ParseQuery
  - `shared/platform/bootstrap/bootstrap.go:179` - Redis URL parsing calls url.URL.Query

### 2. GO-2026-4340: TLS handshake processing at incorrect encryption level
- **Package**: `crypto/tls`
- **Severity**: Critical
- **Impact**: TLS handshake messages could be processed at the wrong encryption level
- **Affected code**:
  - Multiple database connection paths
  - Gateway HTTPS server
  - OAuth introspection
  - Redis connections with TLS

## Changes Made

Updated `go-version` from `1.25.5` to `1.25.6` in the following workflows:
- `.github/workflows/security.yml` (2 instances)
- `.github/workflows/build.yml`
- `.github/workflows/benchmarks.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/migrations.yml` (3 instances)
- `.github/workflows/nightly.yml` (2 instances)
- `.github/workflows/quality.yml`
- `.github/workflows/test.yml`

## Testing

The security scanning workflow should pass once this PR is merged, confirming both vulnerabilities are resolved.

## References

- [GO-2026-4341 Details](https://pkg.go.dev/vuln/GO-2026-4341)
- [GO-2026-4340 Details](https://pkg.go.dev/vuln/GO-2026-4340)