### PR TITLE
Verify Task 16: Zombie Saga Detection Implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.5
 
 require (
 	ariga.io/atlas-provider-gorm v0.6.0
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20251209175733-2a1774d88802.1
 	buf.build/go/protovalidate v1.1.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/alicebob/miniredis/v2 v2.36.1
@@ -46,7 +47,6 @@ require (
 )
 
 require (
-	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20251209175733-2a1774d88802.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -117,7 +117,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/googleapis/go-gorm-spanner v1.8.6 // indirect
 	github.com/googleapis/go-sql-spanner v1.17.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -167,7 +167,7 @@ require (
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.14.0
 	google.golang.org/api v0.247.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.5.7 // indirect


### PR DESCRIPTION
## Summary

This PR verifies that Task 16 (zombie saga detection and FAILED_MANUAL_INTERVENTION transition) is fully implemented and production-ready.

## Implementation Status

✅ **All features implemented and tested**

The zombie saga detection feature was already complete in the codebase. This PR:
1. Verifies the implementation against Task 16 requirements
2. Confirms all tests pass (250+ tests in saga package)
3. Updates go.mod after proto regeneration

## Implementation Details

### Configuration (claiming.go)
- `DefaultMaxReplays = 5` constant
- Environment variable: `SAGA_MAX_REPLAYS` (configurable)
- Falls back to default if invalid or not set

### Zombie Detection Logic (claiming.go:197-273)
- `transitionZombieSagas()` finds sagas with `replay_count >= MaxReplays`
- Transitions to `FAILED_MANUAL_INTERVENTION` status
- Uses FOR UPDATE locking for atomicity
- Only processes orphaned sagas (expired/no lease)
- Excludes active leases and completed sagas

### Claiming Integration (claiming.go:116-195)
- `ClaimOrphanedSagas()` calls `transitionZombieSagas()` first
- Filters zombies: `WHERE replay_count < MaxReplays`
- Increments on each claim: `replay_count + 1`
- Records Prometheus metrics

### Prometheus Metrics (metrics.go)
- `saga_zombie_detected_total`: Counter with saga_definition_id label
- `saga_replay_count`: Histogram [0,1,2,3,5,10,20]
- `saga_replay_incremented_total`: Counter
- Functions: `RecordZombieSagaDetected()`, `RecordReplayCount()`, `RecordReplayIncrement()`

### Models (models.go)
- `SagaInstance.ReplayCount int`: Column with default 0
- `SagaStatusFailedManualIntervention`: Status constant

### Saga Executor Integration (saga_executor.go)
- TRANSIENT errors: Release lease, replay_count incremented on re-claim
- FATAL errors: Transition to COMPENSATING, replay_count NOT incremented
- Max replays check in `HandleStepFailure()`

## Test Coverage

### Unit Tests (zombie_test.go:16-42)
- ✅ Configuration from SAGA_MAX_REPLAYS env
- ✅ Default value fallback (5)
- ✅ Invalid value handling

### Integration Tests (zombie_test.go:44-337)
- ✅ Zombie transition to FAILED_MANUAL_INTERVENTION
- ✅ Claims healthy while transitioning zombie
- ✅ Becomes zombie on threshold crossing
- ✅ Ignores active leases
- ✅ Ignores completed sagas
- ✅ Replay count increment on claim
- ✅ All active statuses (PENDING, RUNNING, COMPENSATING)

### Metrics Tests (metrics_test.go:12-64)
- ✅ Counter incrementation
- ✅ Histogram observation
- ✅ Label handling

## Test Results

```
✓ TestNewClaimConfig_MaxReplays (3 scenarios)
✓ TestSagaClaimService_ZombieDetection_Integration (5 scenarios)
✓ TestSagaClaimService_ReplayCountIncrement_Integration (2 scenarios)
✓ TestZombieDetection_AllActiveStatuses_Integration (3 statuses)
✓ TestRecordZombieSagaDetected
✓ Full saga package test suite: PASS (250+ tests)
```

## Task Master Status

| Subtask | Status | Description |
|---------|--------|-------------|
| 16.1 | ✅ Complete | Replay count tracking and zombie detection in claiming logic |
| 16.2 | ✅ Complete | Prometheus metrics implementation |

## Related Tasks

- Task 11 (schema): `replay_count` column already in migrations
- Task 12 (claiming): Zombie detection integrated
- Task 13 (execution): Replay increment on claim

## Changes in This PR

- `go.mod`: Updated dependencies after proto generation (moves buf.build and grpc-gateway from indirect to direct)
- Verification commit documenting complete implementation

## Risk Assessment

**Risk Level: None**

This is a verification-only PR. The implementation was already complete and tested. No behavioral changes.

## Deployment Notes

No deployment changes needed. The feature is already active in all environments with default `MaxReplays=5`.

To override: Set `SAGA_MAX_REPLAYS` environment variable.