### PR TITLE
feat(saga): implement DSL builtins (cel_eval, resolve_account, resolve_instrument, invoke_saga)

### DIFF
--- a/shared/pkg/saga/builtins.go
+++ b/shared/pkg/saga/builtins.go
@@ -27,6 +27,9 @@ var (
 
 	// ErrInvalidClientType is returned when a client has invalid type.
 	ErrInvalidClientType = errors.New("invalid client type")
+
+	// ErrInvalidParameterType is returned when a parameter has an unexpected type.
+	ErrInvalidParameterType = errors.New("invalid parameter type")
 )
 
 // NewRestrictedBuiltins creates a hardened Starlark environment with whitelisted functions.
@@ -145,7 +148,8 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 	// cel_eval - evaluate a CEL expression
 	builtins["cel_eval"] = starlark.NewBuiltin("cel_eval", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var expression string
-		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "expression", &expression); err != nil {
+		var inputDict *starlark.Dict
+		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "expression", &expression, "variables?", &inputDict); err != nil {
 			return nil, err
 		}
 
@@ -171,6 +175,19 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 				"saga_execution_id": starlarkCtx.SagaExecutionID.String(),
 				"correlation_id":    starlarkCtx.CorrelationID.String(),
 			},
+		}
+
+		// Add optional input variables if provided
+		if inputDict != nil {
+			inputMap := make(map[string]interface{})
+			for _, item := range inputDict.Items() {
+				key, ok := item[0].(starlark.String)
+				if !ok {
+					return nil, fmt.Errorf("cel_eval: %w: variables keys must be strings, got %s", ErrInvalidParameterType, item[0].Type())
+				}
+				inputMap[string(key)] = convertStarlarkToGo(item[1])
+			}
+			variables["input"] = inputMap
 		}
 
 		// Evaluate expression
@@ -329,9 +346,11 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 		// Convert Starlark dict to Go map
 		input := make(map[string]interface{})
 		for _, item := range inputDict.Items() {
-			if key, ok := item[0].(starlark.String); ok {
-				input[string(key)] = convertStarlarkToGo(item[1])
+			key, ok := item[0].(starlark.String)
+			if !ok {
+				return nil, fmt.Errorf("invoke_saga: %w: input keys must be strings, got %s", ErrInvalidParameterType, item[0].Type())
 			}
+			input[string(key)] = convertStarlarkToGo(item[1])
 		}
 
 		// Invoke child saga with scope inheritance and circular detection
@@ -464,8 +483,12 @@ func convertStarlarkToGo(v starlark.Value) interface{} {
 	case starlark.String:
 		return string(val)
 	case starlark.Int:
-		if i, ok := val.Int64(); ok {
-			return i
+		if i64, ok := val.Int64(); ok {
+			// Preserve int vs int64 type: if value fits in int, return int
+			if i := int(i64); int64(i) == i64 {
+				return i
+			}
+			return i64
 		}
 		return val.String()
 	case starlark.Float:

--- a/shared/pkg/saga/builtins.go
+++ b/shared/pkg/saga/builtins.go
@@ -508,6 +508,11 @@ func convertStarlarkToGo(v starlark.Value) interface{} {
 		for _, item := range val.Items() {
 			if key, ok := item[0].(starlark.String); ok {
 				result[string(key)] = convertStarlarkToGo(item[1])
+			} else {
+				// Log warning - non-string keys are not supported in Go map conversion
+				slog.Warn("convertStarlarkToGo: ignoring non-string dict key",
+					"key_type", item[0].Type(),
+					"key_value", item[0].String())
 			}
 		}
 		return result

--- a/shared/pkg/saga/builtins.go
+++ b/shared/pkg/saga/builtins.go
@@ -131,43 +131,221 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 	})
 
 	// cel_eval - evaluate a CEL expression
-	builtins["cel_eval"] = starlark.NewBuiltin("cel_eval", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	builtins["cel_eval"] = starlark.NewBuiltin("cel_eval", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var expression string
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "expression", &expression); err != nil {
 			return nil, err
 		}
-		// Placeholder - actual CEL evaluation would happen at runtime
-		return starlark.String(expression), nil
+
+		// Get StarlarkContext from thread local storage
+		ctxVal := thread.Local("saga.StarlarkContext")
+		if ctxVal == nil {
+			return nil, fmt.Errorf("cel_eval: StarlarkContext not found in thread")
+		}
+		starlarkCtx, ok := ctxVal.(*StarlarkContext)
+		if !ok {
+			return nil, fmt.Errorf("cel_eval: invalid StarlarkContext type")
+		}
+
+		// Create CEL evaluator
+		evaluator, err := NewCELEvaluator()
+		if err != nil {
+			return nil, fmt.Errorf("cel_eval: %w", err)
+		}
+
+		// Build evaluation context with saga metadata
+		variables := map[string]interface{}{
+			"ctx": map[string]interface{}{
+				"saga_execution_id": starlarkCtx.SagaExecutionID.String(),
+				"correlation_id":    starlarkCtx.CorrelationID.String(),
+			},
+		}
+
+		// Evaluate expression
+		result, err := evaluator.Eval(expression, variables)
+		if err != nil {
+			return nil, fmt.Errorf("cel_eval: %w", err)
+		}
+
+		return goToStarlark(result), nil
 	})
 
 	// resolve_account - resolve account ID from reference
-	builtins["resolve_account"] = starlark.NewBuiltin("resolve_account", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	builtins["resolve_account"] = starlark.NewBuiltin("resolve_account", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var reference string
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "reference", &reference); err != nil {
 			return nil, err
 		}
-		// Placeholder - actual resolution happens at runtime
-		return starlark.String(reference), nil
+
+		// Get StarlarkContext from thread
+		ctxVal := thread.Local("saga.StarlarkContext")
+		if ctxVal == nil {
+			return nil, fmt.Errorf("resolve_account: StarlarkContext not found")
+		}
+		starlarkCtx, ok := ctxVal.(*StarlarkContext)
+		if !ok {
+			return nil, fmt.Errorf("resolve_account: invalid StarlarkContext type")
+		}
+
+		// Check lookup cache for deterministic replay (FR-34)
+		cacheKey := "account:" + reference
+		if starlarkCtx.LookupCache != nil {
+			if cached, found := starlarkCtx.LookupCache.Get(cacheKey); found {
+				if accountID, ok := cached.(string); ok {
+					return starlark.String(accountID), nil
+				}
+			}
+		}
+
+		// Get reference-data client from thread
+		clientVal := thread.Local("saga.ReferenceDataClient")
+		if clientVal == nil {
+			return nil, fmt.Errorf("resolve_account: reference-data client not configured")
+		}
+		refDataClient, ok := clientVal.(ReferenceDataClient)
+		if !ok {
+			return nil, fmt.Errorf("resolve_account: invalid client type")
+		}
+
+		// Query reference-data service with bi-temporal KnowledgeAt
+		accountID, err := refDataClient.ResolveAccount(starlarkCtx.Context, reference, starlarkCtx.KnowledgeAt)
+		if err != nil {
+			return nil, fmt.Errorf("resolve_account(%q): %w", reference, err)
+		}
+
+		// Cache result for replay
+		if starlarkCtx.LookupCache != nil {
+			starlarkCtx.LookupCache.Set(cacheKey, accountID)
+		}
+
+		return starlark.String(accountID), nil
 	})
 
 	// resolve_instrument - resolve instrument ID from reference
-	builtins["resolve_instrument"] = starlark.NewBuiltin("resolve_instrument", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	builtins["resolve_instrument"] = starlark.NewBuiltin("resolve_instrument", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var reference string
 		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "reference", &reference); err != nil {
 			return nil, err
 		}
-		// Placeholder - actual resolution happens at runtime
-		return starlark.String(reference), nil
+
+		// Get StarlarkContext from thread
+		ctxVal := thread.Local("saga.StarlarkContext")
+		if ctxVal == nil {
+			return nil, fmt.Errorf("resolve_instrument: StarlarkContext not found")
+		}
+		starlarkCtx, ok := ctxVal.(*StarlarkContext)
+		if !ok {
+			return nil, fmt.Errorf("resolve_instrument: invalid StarlarkContext type")
+		}
+
+		// Check cache
+		cacheKey := "instrument:" + reference
+		if starlarkCtx.LookupCache != nil {
+			if cached, found := starlarkCtx.LookupCache.Get(cacheKey); found {
+				if instrumentID, ok := cached.(string); ok {
+					return starlark.String(instrumentID), nil
+				}
+			}
+		}
+
+		// Get reference-data client from thread
+		clientVal := thread.Local("saga.ReferenceDataClient")
+		if clientVal == nil {
+			return nil, fmt.Errorf("resolve_instrument: reference-data client not configured")
+		}
+		refDataClient, ok := clientVal.(ReferenceDataClient)
+		if !ok {
+			return nil, fmt.Errorf("resolve_instrument: invalid client type")
+		}
+
+		// Query with KnowledgeAt for bi-temporal lookup
+		instrumentID, err := refDataClient.ResolveInstrument(starlarkCtx.Context, reference, starlarkCtx.KnowledgeAt)
+		if err != nil {
+			return nil, fmt.Errorf("resolve_instrument(%q): %w", reference, err)
+		}
+
+		// Cache result
+		if starlarkCtx.LookupCache != nil {
+			starlarkCtx.LookupCache.Set(cacheKey, instrumentID)
+		}
+
+		return starlark.String(instrumentID), nil
 	})
 
 	// invoke_saga - invoke a child saga
-	builtins["invoke_saga"] = starlark.NewBuiltin("invoke_saga", func(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	builtins["invoke_saga"] = starlark.NewBuiltin("invoke_saga", func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var sagaName string
-		if err := starlark.UnpackArgs(b.Name(), args, kwargs, "saga_name", &sagaName); err != nil {
+		inputDict := starlark.NewDict(0)
+
+		if err := starlark.UnpackArgs(b.Name(), args, kwargs,
+			"saga_name", &sagaName,
+			"input?", &inputDict,
+		); err != nil {
 			return nil, err
 		}
-		// Placeholder - actual invocation happens at runtime
-		return starlark.None, nil
+
+		// Get StarlarkContext
+		ctxVal := thread.Local("saga.StarlarkContext")
+		if ctxVal == nil {
+			return nil, fmt.Errorf("invoke_saga: StarlarkContext not found")
+		}
+		starlarkCtx, ok := ctxVal.(*StarlarkContext)
+		if !ok {
+			return nil, fmt.Errorf("invoke_saga: invalid StarlarkContext type")
+		}
+
+		// Get Composer from thread
+		composerVal := thread.Local("saga.Composer")
+		if composerVal == nil {
+			return nil, fmt.Errorf("invoke_saga: Composer not configured")
+		}
+		composer, ok := composerVal.(*Composer)
+		if !ok {
+			return nil, fmt.Errorf("invoke_saga: invalid Composer type")
+		}
+
+		// Get CallStack for nesting tracking
+		stackVal := thread.Local("saga.CallStack")
+		if stackVal == nil {
+			return nil, fmt.Errorf("invoke_saga: CallStack not found")
+		}
+		stack, ok := stackVal.(*CallStack)
+		if !ok {
+			return nil, fmt.Errorf("invoke_saga: invalid CallStack type")
+		}
+
+		// Convert Starlark dict to Go map
+		input := make(map[string]interface{})
+		for _, item := range inputDict.Items() {
+			if key, ok := item[0].(starlark.String); ok {
+				input[string(key)] = convertStarlarkToGo(item[1])
+			}
+		}
+
+		// Invoke child saga with scope inheritance and circular detection
+		result, err := composer.InvokeSaga(
+			starlarkCtx.Context,
+			sagaName,
+			input,
+			starlarkCtx.PartyScope, // Inherit parent scope - child cannot escalate
+			stack,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("invoke_saga(%q): %w", sagaName, err)
+		}
+
+		// Return sagaResultValue from composition.go
+		// goToStarlark handles map[string]interface{} -> *starlark.Dict conversion
+		outputDict, ok := goToStarlark(result.Output).(*starlark.Dict)
+		if !ok {
+			outputDict = starlark.NewDict(0)
+		}
+		return &sagaResultValue{
+			executionID:    result.ExecutionID,
+			status:         result.Status,
+			output:         outputDict,
+			stepsCompleted: result.StepsCompleted,
+		}, nil
 	})
 
 	// fail - explicitly fail the saga
@@ -262,3 +440,43 @@ func (p *postingValue) Truth() starlark.Bool { return starlark.True }
 
 // Hash implements starlark.Value.
 func (p *postingValue) Hash() (uint32, error) { return 0, fmt.Errorf("%w: Posting", ErrUnhashable) }
+
+// convertStarlarkToGo converts a Starlark value to a Go value.
+// This is used when passing input parameters to child sagas.
+func convertStarlarkToGo(v starlark.Value) interface{} {
+	if v == nil {
+		return nil
+	}
+
+	switch val := v.(type) {
+	case starlark.String:
+		return string(val)
+	case starlark.Int:
+		if i, ok := val.Int64(); ok {
+			return i
+		}
+		return val.String()
+	case starlark.Float:
+		return float64(val)
+	case starlark.Bool:
+		return bool(val)
+	case starlark.NoneType:
+		return nil
+	case *starlark.List:
+		result := make([]interface{}, val.Len())
+		for i := 0; i < val.Len(); i++ {
+			result[i] = convertStarlarkToGo(val.Index(i))
+		}
+		return result
+	case *starlark.Dict:
+		result := make(map[string]interface{})
+		for _, item := range val.Items() {
+			if key, ok := item[0].(starlark.String); ok {
+				result[string(key)] = convertStarlarkToGo(item[1])
+			}
+		}
+		return result
+	default:
+		return val.String()
+	}
+}

--- a/shared/pkg/saga/builtins.go
+++ b/shared/pkg/saga/builtins.go
@@ -15,6 +15,18 @@ var (
 
 	// ErrUnhashable is returned when attempting to hash an unhashable type.
 	ErrUnhashable = errors.New("unhashable type")
+
+	// ErrMissingStarlarkContext is returned when StarlarkContext is not found in thread locals.
+	ErrMissingStarlarkContext = errors.New("StarlarkContext not found in thread")
+
+	// ErrInvalidStarlarkContext is returned when StarlarkContext has invalid type.
+	ErrInvalidStarlarkContext = errors.New("invalid StarlarkContext type")
+
+	// ErrMissingClient is returned when a required client is not configured in thread locals.
+	ErrMissingClient = errors.New("required client not configured")
+
+	// ErrInvalidClientType is returned when a client has invalid type.
+	ErrInvalidClientType = errors.New("invalid client type")
 )
 
 // NewRestrictedBuiltins creates a hardened Starlark environment with whitelisted functions.
@@ -36,7 +48,7 @@ var (
 //
 // BLOCKED: load(), print() (redirected), time.now(), random(), exec(), compile(), open(), http
 //
-//nolint:gocognit // This function deliberately configures many builtins; complexity is unavoidable
+//nolint:gocognit,gocyclo // This function deliberately configures many builtins; complexity is unavoidable
 func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 	if logger == nil {
 		logger = slog.Default()
@@ -140,11 +152,11 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 		// Get StarlarkContext from thread local storage
 		ctxVal := thread.Local("saga.StarlarkContext")
 		if ctxVal == nil {
-			return nil, fmt.Errorf("cel_eval: StarlarkContext not found in thread")
+			return nil, fmt.Errorf("cel_eval: %w", ErrMissingStarlarkContext)
 		}
 		starlarkCtx, ok := ctxVal.(*StarlarkContext)
 		if !ok {
-			return nil, fmt.Errorf("cel_eval: invalid StarlarkContext type")
+			return nil, fmt.Errorf("cel_eval: %w", ErrInvalidStarlarkContext)
 		}
 
 		// Create CEL evaluator
@@ -180,11 +192,11 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 		// Get StarlarkContext from thread
 		ctxVal := thread.Local("saga.StarlarkContext")
 		if ctxVal == nil {
-			return nil, fmt.Errorf("resolve_account: StarlarkContext not found")
+			return nil, fmt.Errorf("resolve_account: %w", ErrMissingStarlarkContext)
 		}
 		starlarkCtx, ok := ctxVal.(*StarlarkContext)
 		if !ok {
-			return nil, fmt.Errorf("resolve_account: invalid StarlarkContext type")
+			return nil, fmt.Errorf("resolve_account: %w", ErrInvalidStarlarkContext)
 		}
 
 		// Check lookup cache for deterministic replay (FR-34)
@@ -200,11 +212,11 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 		// Get reference-data client from thread
 		clientVal := thread.Local("saga.ReferenceDataClient")
 		if clientVal == nil {
-			return nil, fmt.Errorf("resolve_account: reference-data client not configured")
+			return nil, fmt.Errorf("resolve_account: %w", ErrMissingClient)
 		}
 		refDataClient, ok := clientVal.(ReferenceDataClient)
 		if !ok {
-			return nil, fmt.Errorf("resolve_account: invalid client type")
+			return nil, fmt.Errorf("resolve_account: %w", ErrInvalidClientType)
 		}
 
 		// Query reference-data service with bi-temporal KnowledgeAt
@@ -231,11 +243,11 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 		// Get StarlarkContext from thread
 		ctxVal := thread.Local("saga.StarlarkContext")
 		if ctxVal == nil {
-			return nil, fmt.Errorf("resolve_instrument: StarlarkContext not found")
+			return nil, fmt.Errorf("resolve_instrument: %w", ErrMissingStarlarkContext)
 		}
 		starlarkCtx, ok := ctxVal.(*StarlarkContext)
 		if !ok {
-			return nil, fmt.Errorf("resolve_instrument: invalid StarlarkContext type")
+			return nil, fmt.Errorf("resolve_instrument: %w", ErrInvalidStarlarkContext)
 		}
 
 		// Check cache
@@ -251,11 +263,11 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 		// Get reference-data client from thread
 		clientVal := thread.Local("saga.ReferenceDataClient")
 		if clientVal == nil {
-			return nil, fmt.Errorf("resolve_instrument: reference-data client not configured")
+			return nil, fmt.Errorf("resolve_instrument: %w", ErrMissingClient)
 		}
 		refDataClient, ok := clientVal.(ReferenceDataClient)
 		if !ok {
-			return nil, fmt.Errorf("resolve_instrument: invalid client type")
+			return nil, fmt.Errorf("resolve_instrument: %w", ErrInvalidClientType)
 		}
 
 		// Query with KnowledgeAt for bi-temporal lookup
@@ -287,31 +299,31 @@ func NewRestrictedBuiltins(logger *slog.Logger) starlark.StringDict {
 		// Get StarlarkContext
 		ctxVal := thread.Local("saga.StarlarkContext")
 		if ctxVal == nil {
-			return nil, fmt.Errorf("invoke_saga: StarlarkContext not found")
+			return nil, fmt.Errorf("invoke_saga: %w", ErrMissingStarlarkContext)
 		}
 		starlarkCtx, ok := ctxVal.(*StarlarkContext)
 		if !ok {
-			return nil, fmt.Errorf("invoke_saga: invalid StarlarkContext type")
+			return nil, fmt.Errorf("invoke_saga: %w", ErrInvalidStarlarkContext)
 		}
 
 		// Get Composer from thread
 		composerVal := thread.Local("saga.Composer")
 		if composerVal == nil {
-			return nil, fmt.Errorf("invoke_saga: Composer not configured")
+			return nil, fmt.Errorf("invoke_saga: %w", ErrMissingClient)
 		}
 		composer, ok := composerVal.(*Composer)
 		if !ok {
-			return nil, fmt.Errorf("invoke_saga: invalid Composer type")
+			return nil, fmt.Errorf("invoke_saga: %w", ErrInvalidClientType)
 		}
 
 		// Get CallStack for nesting tracking
 		stackVal := thread.Local("saga.CallStack")
 		if stackVal == nil {
-			return nil, fmt.Errorf("invoke_saga: CallStack not found")
+			return nil, fmt.Errorf("invoke_saga: %w", ErrMissingClient)
 		}
 		stack, ok := stackVal.(*CallStack)
 		if !ok {
-			return nil, fmt.Errorf("invoke_saga: invalid CallStack type")
+			return nil, fmt.Errorf("invoke_saga: %w", ErrInvalidClientType)
 		}
 
 		// Convert Starlark dict to Go map

--- a/shared/pkg/saga/builtins_dsl_test.go
+++ b/shared/pkg/saga/builtins_dsl_test.go
@@ -82,7 +82,7 @@ func TestCelEvalBuiltin(t *testing.T) {
 		_, err := celEval.CallInternal(thread, args, nil)
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "StarlarkContext not found")
+		assert.ErrorIs(t, err, ErrMissingStarlarkContext)
 	})
 }
 
@@ -176,7 +176,7 @@ func TestResolveAccountBuiltin(t *testing.T) {
 		_, err := resolveAccount.CallInternal(thread, args, nil)
 
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "client not configured")
+		assert.ErrorIs(t, err, ErrMissingClient)
 	})
 }
 

--- a/shared/pkg/saga/builtins_dsl_test.go
+++ b/shared/pkg/saga/builtins_dsl_test.go
@@ -1,0 +1,298 @@
+package saga
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+)
+
+// mockReferenceDataClient implements ReferenceDataClient for testing.
+type mockReferenceDataClient struct {
+	accounts    map[string]string
+	instruments map[string]string
+	calls       []string // Track method calls for verification
+}
+
+func newMockReferenceDataClient() *mockReferenceDataClient {
+	return &mockReferenceDataClient{
+		accounts: map[string]string{
+			"customer-001": "account-123",
+			"customer-002": "account-456",
+		},
+		instruments: map[string]string{
+			"USD": "instr-usd",
+			"KWH": "instr-kwh",
+		},
+		calls: []string{},
+	}
+}
+
+func (m *mockReferenceDataClient) ResolveAccount(_ context.Context, reference string, _ time.Time) (string, error) {
+	m.calls = append(m.calls, fmt.Sprintf("ResolveAccount(%s)", reference))
+	if accountID, ok := m.accounts[reference]; ok {
+		return accountID, nil
+	}
+	return "", fmt.Errorf("account not found: %s", reference)
+}
+
+func (m *mockReferenceDataClient) ResolveInstrument(_ context.Context, reference string, _ time.Time) (string, error) {
+	m.calls = append(m.calls, fmt.Sprintf("ResolveInstrument(%s)", reference))
+	if instrumentID, ok := m.instruments[reference]; ok {
+		return instrumentID, nil
+	}
+	return "", fmt.Errorf("instrument not found: %s", reference)
+}
+
+func TestCelEvalBuiltin(t *testing.T) {
+	t.Run("evaluates simple expression", func(t *testing.T) {
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:         context.Background(),
+			SagaExecutionID: uuid.New(),
+			CorrelationID:   uuid.New(),
+			KnowledgeAt:     time.Now(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+
+		builtins := NewRestrictedBuiltins(nil)
+		celEval := builtins["cel_eval"].(*starlark.Builtin)
+
+		// Call cel_eval("1 + 1")
+		args := starlark.Tuple{starlark.String("1 + 1")}
+		result, err := celEval.CallInternal(thread, args, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "2", result.String())
+	})
+
+	t.Run("handles missing context", func(t *testing.T) {
+		thread := &starlark.Thread{Name: "test"}
+		// Don't set StarlarkContext
+
+		builtins := NewRestrictedBuiltins(nil)
+		celEval := builtins["cel_eval"].(*starlark.Builtin)
+
+		args := starlark.Tuple{starlark.String("1 + 1")}
+		_, err := celEval.CallInternal(thread, args, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "StarlarkContext not found")
+	})
+}
+
+func TestResolveAccountBuiltin(t *testing.T) {
+	t.Run("resolves account successfully", func(t *testing.T) {
+		mockClient := newMockReferenceDataClient()
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:     context.Background(),
+			KnowledgeAt: time.Now(),
+			LookupCache: NewLookupResultCache(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+		thread.SetLocal("saga.ReferenceDataClient", mockClient)
+
+		builtins := NewRestrictedBuiltins(nil)
+		resolveAccount := builtins["resolve_account"].(*starlark.Builtin)
+
+		// Call resolve_account("customer-001")
+		args := starlark.Tuple{starlark.String("customer-001")}
+		result, err := resolveAccount.CallInternal(thread, args, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, `"account-123"`, result.String())
+		assert.Contains(t, mockClient.calls, "ResolveAccount(customer-001)")
+	})
+
+	t.Run("uses cache on second call", func(t *testing.T) {
+		mockClient := newMockReferenceDataClient()
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:     context.Background(),
+			KnowledgeAt: time.Now(),
+			LookupCache: NewLookupResultCache(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+		thread.SetLocal("saga.ReferenceDataClient", mockClient)
+
+		builtins := NewRestrictedBuiltins(nil)
+		resolveAccount := builtins["resolve_account"].(*starlark.Builtin)
+
+		// First call
+		args := starlark.Tuple{starlark.String("customer-001")}
+		result1, err := resolveAccount.CallInternal(thread, args, nil)
+		require.NoError(t, err)
+		assert.Equal(t, `"account-123"`, result1.String())
+		assert.Len(t, mockClient.calls, 1)
+
+		// Second call - should use cache
+		result2, err := resolveAccount.CallInternal(thread, args, nil)
+		require.NoError(t, err)
+		assert.Equal(t, `"account-123"`, result2.String())
+		assert.Len(t, mockClient.calls, 1, "Should not make second client call (cached)")
+	})
+
+	t.Run("handles unknown account", func(t *testing.T) {
+		mockClient := newMockReferenceDataClient()
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:     context.Background(),
+			KnowledgeAt: time.Now(),
+			LookupCache: NewLookupResultCache(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+		thread.SetLocal("saga.ReferenceDataClient", mockClient)
+
+		builtins := NewRestrictedBuiltins(nil)
+		resolveAccount := builtins["resolve_account"].(*starlark.Builtin)
+
+		args := starlark.Tuple{starlark.String("unknown")}
+		_, err := resolveAccount.CallInternal(thread, args, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "account not found")
+	})
+
+	t.Run("handles missing client", func(t *testing.T) {
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:     context.Background(),
+			KnowledgeAt: time.Now(),
+			LookupCache: NewLookupResultCache(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+		// Don't set ReferenceDataClient
+
+		builtins := NewRestrictedBuiltins(nil)
+		resolveAccount := builtins["resolve_account"].(*starlark.Builtin)
+
+		args := starlark.Tuple{starlark.String("customer-001")}
+		_, err := resolveAccount.CallInternal(thread, args, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "client not configured")
+	})
+}
+
+func TestResolveInstrumentBuiltin(t *testing.T) {
+	t.Run("resolves instrument successfully", func(t *testing.T) {
+		mockClient := newMockReferenceDataClient()
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:     context.Background(),
+			KnowledgeAt: time.Now(),
+			LookupCache: NewLookupResultCache(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+		thread.SetLocal("saga.ReferenceDataClient", mockClient)
+
+		builtins := NewRestrictedBuiltins(nil)
+		resolveInstrument := builtins["resolve_instrument"].(*starlark.Builtin)
+
+		// Call resolve_instrument("USD")
+		args := starlark.Tuple{starlark.String("USD")}
+		result, err := resolveInstrument.CallInternal(thread, args, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, `"instr-usd"`, result.String())
+		assert.Contains(t, mockClient.calls, "ResolveInstrument(USD)")
+	})
+
+	t.Run("uses cache on second call", func(t *testing.T) {
+		mockClient := newMockReferenceDataClient()
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:     context.Background(),
+			KnowledgeAt: time.Now(),
+			LookupCache: NewLookupResultCache(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+		thread.SetLocal("saga.ReferenceDataClient", mockClient)
+
+		builtins := NewRestrictedBuiltins(nil)
+		resolveInstrument := builtins["resolve_instrument"].(*starlark.Builtin)
+
+		// First call
+		args := starlark.Tuple{starlark.String("KWH")}
+		result1, err := resolveInstrument.CallInternal(thread, args, nil)
+		require.NoError(t, err)
+		assert.Equal(t, `"instr-kwh"`, result1.String())
+		assert.Len(t, mockClient.calls, 1)
+
+		// Second call - should use cache
+		result2, err := resolveInstrument.CallInternal(thread, args, nil)
+		require.NoError(t, err)
+		assert.Equal(t, `"instr-kwh"`, result2.String())
+		assert.Len(t, mockClient.calls, 1, "Should not make second client call (cached)")
+	})
+}
+
+func TestConvertStarlarkToGo(t *testing.T) {
+	tests := []struct {
+		name  string
+		input starlark.Value
+		want  interface{}
+	}{
+		{
+			name:  "string",
+			input: starlark.String("test"),
+			want:  "test",
+		},
+		{
+			name:  "int",
+			input: starlark.MakeInt(42),
+			want:  int64(42),
+		},
+		{
+			name:  "float",
+			input: starlark.Float(3.14),
+			want:  float64(3.14),
+		},
+		{
+			name:  "bool true",
+			input: starlark.Bool(true),
+			want:  true,
+		},
+		{
+			name:  "bool false",
+			input: starlark.Bool(false),
+			want:  false,
+		},
+		{
+			name:  "None",
+			input: starlark.None,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertStarlarkToGo(tt.input)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+
+	t.Run("list", func(t *testing.T) {
+		input := starlark.NewList([]starlark.Value{
+			starlark.String("a"),
+			starlark.String("b"),
+		})
+		result := convertStarlarkToGo(input)
+		expected := []interface{}{"a", "b"}
+		assert.Equal(t, expected, result)
+	})
+
+	t.Run("dict", func(t *testing.T) {
+		input := starlark.NewDict(1)
+		_ = input.SetKey(starlark.String("key"), starlark.String("value"))
+		result := convertStarlarkToGo(input)
+		expected := map[string]interface{}{"key": "value"}
+		assert.Equal(t, expected, result)
+	})
+}

--- a/shared/pkg/saga/builtins_dsl_test.go
+++ b/shared/pkg/saga/builtins_dsl_test.go
@@ -71,6 +71,53 @@ func TestCelEvalBuiltin(t *testing.T) {
 		assert.Equal(t, "2", result.String())
 	})
 
+	t.Run("evaluates expression with input variables", func(t *testing.T) {
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:         context.Background(),
+			SagaExecutionID: uuid.New(),
+			CorrelationID:   uuid.New(),
+			KnowledgeAt:     time.Now(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+
+		builtins := NewRestrictedBuiltins(nil)
+		celEval := builtins["cel_eval"].(*starlark.Builtin)
+
+		// Call cel_eval("input.amount > 100", {"amount": 150})
+		inputDict := starlark.NewDict(1)
+		_ = inputDict.SetKey(starlark.String("amount"), starlark.MakeInt(150))
+		args := starlark.Tuple{starlark.String("input.amount > 100"), inputDict}
+		result, err := celEval.CallInternal(thread, args, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "True", result.String())
+	})
+
+	t.Run("rejects non-string keys in variables", func(t *testing.T) {
+		thread := &starlark.Thread{Name: "test"}
+		ctx := &StarlarkContext{
+			Context:         context.Background(),
+			SagaExecutionID: uuid.New(),
+			CorrelationID:   uuid.New(),
+			KnowledgeAt:     time.Now(),
+		}
+		thread.SetLocal("saga.StarlarkContext", ctx)
+
+		builtins := NewRestrictedBuiltins(nil)
+		celEval := builtins["cel_eval"].(*starlark.Builtin)
+
+		// Call cel_eval with non-string key
+		inputDict := starlark.NewDict(1)
+		_ = inputDict.SetKey(starlark.MakeInt(42), starlark.String("value"))
+		args := starlark.Tuple{starlark.String("1 + 1"), inputDict}
+		_, err := celEval.CallInternal(thread, args, nil)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidParameterType)
+		assert.Contains(t, err.Error(), "variables keys must be strings")
+	})
+
 	t.Run("handles missing context", func(t *testing.T) {
 		thread := &starlark.Thread{Name: "test"}
 		// Don't set StarlarkContext
@@ -247,7 +294,7 @@ func TestConvertStarlarkToGo(t *testing.T) {
 		{
 			name:  "int",
 			input: starlark.MakeInt(42),
-			want:  int64(42),
+			want:  int(42), // Now returns int for values that fit
 		},
 		{
 			name:  "float",
@@ -277,6 +324,34 @@ func TestConvertStarlarkToGo(t *testing.T) {
 			assert.Equal(t, tt.want, result)
 		})
 	}
+
+	// Test round-trip preservation: Go int -> Starlark -> Go should preserve type
+	t.Run("round-trip preserves int type", func(t *testing.T) {
+		originalInt := int(123)
+		starlarkVal := goToStarlark(originalInt)
+		result := convertStarlarkToGo(starlarkVal)
+		assert.Equal(t, originalInt, result)
+		assert.IsType(t, int(0), result, "should preserve int type on round-trip")
+	})
+
+	t.Run("int64 values convert to int when they fit", func(t *testing.T) {
+		// On 64-bit systems, int and int64 have same range, so int64 values
+		// are converted to int when they fit in int (which is always on amd64)
+		originalInt64 := int64(9223372036854775807)
+		starlarkVal := goToStarlark(originalInt64)
+		result := convertStarlarkToGo(starlarkVal)
+		// On 64-bit systems, result will be int (same value, different type)
+		// On 32-bit systems, this would overflow int and remain int64
+		// We verify the numeric value is preserved
+		switch v := result.(type) {
+		case int:
+			assert.Equal(t, int64(v), originalInt64, "numeric value should be preserved")
+		case int64:
+			assert.Equal(t, v, originalInt64, "numeric value should be preserved")
+		default:
+			t.Fatalf("unexpected type: %T", result)
+		}
+	})
 
 	t.Run("list", func(t *testing.T) {
 		input := starlark.NewList([]starlark.Value{

--- a/shared/pkg/saga/builtins_dsl_test.go
+++ b/shared/pkg/saga/builtins_dsl_test.go
@@ -370,4 +370,17 @@ func TestConvertStarlarkToGo(t *testing.T) {
 		expected := map[string]interface{}{"key": "value"}
 		assert.Equal(t, expected, result)
 	})
+
+	t.Run("nested dict with non-string keys logs warning", func(t *testing.T) {
+		// Create nested dict with non-string key
+		nestedDict := starlark.NewDict(2)
+		_ = nestedDict.SetKey(starlark.String("valid"), starlark.String("value"))
+		_ = nestedDict.SetKey(starlark.MakeInt(42), starlark.String("invalid"))
+
+		result := convertStarlarkToGo(nestedDict)
+
+		// Should only contain the valid key, non-string key is logged and dropped
+		expected := map[string]interface{}{"valid": "value"}
+		assert.Equal(t, expected, result)
+	})
 }

--- a/shared/pkg/saga/cel_evaluator.go
+++ b/shared/pkg/saga/cel_evaluator.go
@@ -1,0 +1,65 @@
+package saga
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/cel-go/cel"
+)
+
+// CEL evaluation errors.
+var (
+	// ErrCELCompilationFailed is returned when CEL expression compilation fails.
+	ErrCELCompilationFailed = errors.New("CEL compilation failed")
+
+	// ErrCELEvaluationFailed is returned when CEL expression evaluation fails.
+	ErrCELEvaluationFailed = errors.New("CEL evaluation failed")
+)
+
+// CELEvaluator provides CEL expression evaluation for saga scripts.
+// It maintains a CEL environment with saga-specific variables and provides
+// methods to compile and evaluate CEL expressions within the saga context.
+type CELEvaluator struct {
+	env *cel.Env
+}
+
+// NewCELEvaluator creates a CEL evaluator with saga-specific environment.
+// The environment includes the following variables:
+//   - input: map[string]any - saga input parameters
+//   - ctx: map[string]string - saga context metadata (saga_execution_id, correlation_id)
+func NewCELEvaluator() (*CELEvaluator, error) {
+	env, err := cel.NewEnv(
+		cel.Variable("input", cel.DynType),
+		cel.Variable("ctx", cel.MapType(cel.StringType, cel.DynType)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+	return &CELEvaluator{env: env}, nil
+}
+
+// Eval compiles and evaluates a CEL expression with the given variables.
+// Returns the evaluation result as a native Go value, or an error if compilation
+// or evaluation fails.
+func (e *CELEvaluator) Eval(expression string, variables map[string]interface{}) (interface{}, error) {
+	// Compile expression
+	ast, issues := e.env.Compile(expression)
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("%w: %w", ErrCELCompilationFailed, issues.Err())
+	}
+
+	// Create program
+	prg, err := e.env.Program(ast)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL program: %w", err)
+	}
+
+	// Evaluate
+	result, _, err := prg.Eval(variables)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrCELEvaluationFailed, err)
+	}
+
+	// Convert CEL result to Go value
+	return result.Value(), nil
+}

--- a/shared/pkg/saga/cel_evaluator_test.go
+++ b/shared/pkg/saga/cel_evaluator_test.go
@@ -1,0 +1,208 @@
+package saga
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCELEvaluator(t *testing.T) {
+	evaluator, err := NewCELEvaluator()
+	require.NoError(t, err)
+	require.NotNil(t, evaluator)
+	require.NotNil(t, evaluator.env)
+}
+
+func TestCELEvaluator_Eval_SimpleExpressions(t *testing.T) {
+	evaluator, err := NewCELEvaluator()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		variables  map[string]interface{}
+		want       interface{}
+	}{
+		{
+			name:       "string concatenation",
+			expression: `"hello" + " " + "world"`,
+			variables:  map[string]interface{}{},
+			want:       "hello world",
+		},
+		{
+			name:       "arithmetic",
+			expression: "1 + 1",
+			variables:  map[string]interface{}{},
+			want:       int64(2),
+		},
+		{
+			name:       "boolean expression",
+			expression: "5 > 3",
+			variables:  map[string]interface{}{},
+			want:       true,
+		},
+		{
+			name:       "input variable access",
+			expression: "input.amount > 100",
+			variables: map[string]interface{}{
+				"input": map[string]interface{}{
+					"amount": int64(150),
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "ctx variable access",
+			expression: `ctx.saga_execution_id != ""`,
+			variables: map[string]interface{}{
+				"ctx": map[string]interface{}{
+					"saga_execution_id": "test-123",
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := evaluator.Eval(tt.expression, tt.variables)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestCELEvaluator_Eval_CompilationErrors(t *testing.T) {
+	evaluator, err := NewCELEvaluator()
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		expression string
+		variables  map[string]interface{}
+	}{
+		{
+			name:       "invalid syntax",
+			expression: "1 ++ 2",
+			variables:  map[string]interface{}{},
+		},
+		{
+			name:       "undefined variable",
+			expression: "unknown_var",
+			variables:  map[string]interface{}{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := evaluator.Eval(tt.expression, tt.variables)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrCELCompilationFailed)
+		})
+	}
+}
+
+func TestCELEvaluator_Eval_EvaluationErrors(t *testing.T) {
+	evaluator, err := NewCELEvaluator()
+	require.NoError(t, err)
+
+	t.Run("type mismatch", func(t *testing.T) {
+		// This should compile but fail at evaluation
+		_, err := evaluator.Eval("input.value + 5", map[string]interface{}{
+			"input": map[string]interface{}{
+				"value": "string", // String + int should fail
+			},
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrCELEvaluationFailed)
+	})
+}
+
+func TestGoToStarlark(t *testing.T) {
+	tests := []struct {
+		name  string
+		input interface{}
+		check func(t *testing.T, result interface{})
+	}{
+		{
+			name:  "nil",
+			input: nil,
+			check: func(t *testing.T, result interface{}) {
+				assert.Equal(t, "None", result.(fmt.Stringer).String())
+			},
+		},
+		{
+			name:  "string",
+			input: "test",
+			check: func(t *testing.T, result interface{}) {
+				assert.Equal(t, `"test"`, result.(fmt.Stringer).String())
+			},
+		},
+		{
+			name:  "int",
+			input: 42,
+			check: func(t *testing.T, result interface{}) {
+				assert.Equal(t, "42", result.(fmt.Stringer).String())
+			},
+		},
+		{
+			name:  "int64",
+			input: int64(42),
+			check: func(t *testing.T, result interface{}) {
+				assert.Equal(t, "42", result.(fmt.Stringer).String())
+			},
+		},
+		{
+			name:  "float64",
+			input: 3.14,
+			check: func(t *testing.T, result interface{}) {
+				assert.Equal(t, "3.14", result.(fmt.Stringer).String())
+			},
+		},
+		{
+			name:  "bool true",
+			input: true,
+			check: func(t *testing.T, result interface{}) {
+				assert.Equal(t, "True", result.(fmt.Stringer).String())
+			},
+		},
+		{
+			name:  "bool false",
+			input: false,
+			check: func(t *testing.T, result interface{}) {
+				assert.Equal(t, "False", result.(fmt.Stringer).String())
+			},
+		},
+		{
+			name: "map",
+			input: map[string]interface{}{
+				"key": "value",
+			},
+			check: func(t *testing.T, result interface{}) {
+				str := result.(fmt.Stringer).String()
+				assert.Contains(t, str, "key")
+				assert.Contains(t, str, "value")
+			},
+		},
+		{
+			name:  "list",
+			input: []interface{}{"a", "b", "c"},
+			check: func(t *testing.T, result interface{}) {
+				str := result.(fmt.Stringer).String()
+				assert.Contains(t, str, "a")
+				assert.Contains(t, str, "b")
+				assert.Contains(t, str, "c")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := goToStarlark(tt.input)
+			require.NotNil(t, result)
+			tt.check(t, result)
+		})
+	}
+}

--- a/shared/pkg/saga/reference_data_client.go
+++ b/shared/pkg/saga/reference_data_client.go
@@ -1,0 +1,30 @@
+package saga
+
+import (
+	"context"
+	"time"
+)
+
+// ReferenceDataClient provides saga runtime access to reference data lookups.
+// This interface abstracts the reference-data service gRPC client, allowing
+// builtins to remain decoupled from implementation details.
+//
+// The knowledgeAt parameter enables bi-temporal queries - lookups are resolved
+// as they existed at a specific point in time, supporting FR-34 deterministic
+// replay requirements. When a saga is replayed, the same lookup results are
+// guaranteed by using the saga's original execution timestamp.
+type ReferenceDataClient interface {
+	// ResolveAccount resolves an account reference to an account ID.
+	// The reference can be any identifier (account number, alias, etc).
+	// Uses bi-temporal KnowledgeAt for deterministic replay.
+	//
+	// Returns the account ID as a string, or an error if resolution fails.
+	ResolveAccount(ctx context.Context, reference string, knowledgeAt time.Time) (string, error)
+
+	// ResolveInstrument resolves an instrument reference to an instrument ID.
+	// The reference can be an instrument code, ISIN, ticker, or any other identifier.
+	// Uses bi-temporal KnowledgeAt for deterministic replay.
+	//
+	// Returns the instrument ID as a string, or an error if resolution fails.
+	ResolveInstrument(ctx context.Context, reference string, knowledgeAt time.Time) (string, error)
+}


### PR DESCRIPTION
## Summary

Implements functional versions of the four advanced DSL builtins that were previously placeholders in `shared/pkg/saga/builtins.go`.

## Changes

### cel_eval
- Evaluates CEL expressions using `github.com/google/cel-go`
- Provides saga context variables (execution_id, correlation_id)
- Returns converted Starlark values
- New file: `shared/pkg/saga/cel_evaluator.go`

### resolve_account & resolve_instrument
- Resolves references via `ReferenceDataClient` interface
- Bi-temporal lookup using `KnowledgeAt` timestamp
- Caches results in `LookupCache` for deterministic replay (FR-34)
- New file: `shared/pkg/saga/reference_data_client.go`

### invoke_saga
- Invokes child sagas via `Composer`
- Inherits parent `PartyScope` (prevents privilege escalation)
- Uses `CallStack` for circular reference and nesting detection
- Returns `sagaResultValue` with execution metadata

## Test Plan

New test files provide comprehensive coverage:
- `cel_evaluator_test.go`: Unit tests for CEL evaluation
- `builtins_dsl_test.go`: Integration tests with mocks

Tests verify:
- Successful operations with mocked dependencies
- Cache behavior (no redundant client calls)
- Error cases (missing context, invalid types, not found)
- Type conversions bidirectionally

## Implementation Notes

All builtins:
- Access dependencies via thread locals (StarlarkContext, ReferenceDataClient, Composer, CallStack)
- Handle missing dependencies with clear error messages
- Support deterministic replay through caching

Helper functions:
- `convertStarlarkToGo`: Converts Starlark values to Go (for invoke_saga input)
- Uses existing `goToStarlark` from runtime.go for reverse conversion

## Follow-on Work

Runtime integration (dependency injection into thread locals) is deferred to follow-on PR as the `StarlarkSagaRunner` needs to be wired up to provide `ReferenceDataClient` and `Composer` via thread locals.

## Related

- Task Master task: saga-script-versioning.18