### PR TITLE
Add CockroachDB CLI installation to doctor script

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -140,6 +140,9 @@ get_version() {
         grpcurl)
             version=$(grpcurl --version 2>&1 | head -1 | awk '{print $2}')
             ;;
+        cockroach)
+            version=$(cockroach version 2>/dev/null | head -1 | awk '{print $3}')
+            ;;
         make)
             version=$(make --version 2>/dev/null | head -1 | awk '{print $3}')
             ;;
@@ -177,6 +180,7 @@ get_install_cmd() {
         macos-grpcurl) echo "brew install grpcurl" ;;
         macos-golangci-lint) echo "brew install golangci-lint" ;;
         macos-node) echo "brew install node" ;;
+        macos-cockroach) echo "brew install cockroachdb/tap/cockroach" ;;
 
         linux-go) echo "sudo ${PKG_MANAGER} install -y golang-go" ;;
         linux-git) echo "sudo ${PKG_MANAGER} install -y git" ;;
@@ -191,6 +195,7 @@ get_install_cmd() {
         linux-grpcurl) echo "go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest" ;;
         linux-golangci-lint) echo "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$(go env GOPATH)/bin" ;;
         linux-node) echo "sudo ${PKG_MANAGER} install -y nodejs npm" ;;
+        linux-cockroach) echo "curl https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz | tar -xz && sudo cp -i cockroach-*/cockroach /usr/local/bin/ && sudo mkdir -p /usr/local/lib/cockroach && sudo cp -i cockroach-*/lib/* /usr/local/lib/cockroach/ && rm -rf cockroach-*" ;;
 
         *) echo "" ;;  # Unknown combination
     esac
@@ -652,6 +657,15 @@ check_tool "protoc" "3.x+"
 echo ""
 
 check_tool "grpcurl" ""
+echo ""
+
+# Database Tools
+echo "═══════════════════════════════════════"
+echo " Database Tools"
+echo "═══════════════════════════════════════"
+echo ""
+
+check_tool "cockroach" "23.x+"
 echo ""
 
 # Code Quality

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -141,7 +141,7 @@ get_version() {
             version=$(grpcurl --version 2>&1 | head -1 | awk '{print $2}')
             ;;
         cockroach)
-            version=$(cockroach version 2>/dev/null | head -1 | awk '{print $3}')
+            version=$(cockroach version --build-tag 2>/dev/null)
             ;;
         make)
             version=$(make --version 2>/dev/null | head -1 | awk '{print $3}')
@@ -195,7 +195,7 @@ get_install_cmd() {
         linux-grpcurl) echo "go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest" ;;
         linux-golangci-lint) echo "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b \$(go env GOPATH)/bin" ;;
         linux-node) echo "sudo ${PKG_MANAGER} install -y nodejs npm" ;;
-        linux-cockroach) echo "curl https://binaries.cockroachdb.com/cockroach-latest.linux-amd64.tgz | tar -xz && sudo cp -i cockroach-*/cockroach /usr/local/bin/ && sudo mkdir -p /usr/local/lib/cockroach && sudo cp -i cockroach-*/lib/* /usr/local/lib/cockroach/ && rm -rf cockroach-*" ;;
+        linux-cockroach) echo "ARCH=\$(uname -m); case \"\$ARCH\" in x86_64) ARCH=amd64;; aarch64|arm64) ARCH=arm64;; *) echo 'Unsupported arch: '\$ARCH; exit 1;; esac; tmpdir=\$(mktemp -d); curl -fsSL \"https://binaries.cockroachdb.com/cockroach-latest.linux-\${ARCH}.tgz\" -o \"\$tmpdir/cockroach.tgz\" && tar -xzf \"\$tmpdir/cockroach.tgz\" -C \"\$tmpdir\" && sudo cp -f \"\$tmpdir\"/cockroach-*/cockroach /usr/local/bin/ && sudo mkdir -p /usr/local/lib/cockroach && sudo cp -f \"\$tmpdir\"/cockroach-*/lib/* /usr/local/lib/cockroach/ && rm -rf \"\$tmpdir\"" ;;
 
         *) echo "" ;;  # Unknown combination
     esac


### PR DESCRIPTION
## Summary

Adds CockroachDB CLI detection and automated installation to the `meridian doctor` script. This ensures developers have the `cockroach` CLI tool available for working with CockroachDB, which is Meridian's production database.

## Changes Made

- Added `cockroach` version detection to `get_version()` function
- Added installation commands for both macOS and Linux platforms:
  - **macOS**: `brew install cockroachdb/tap/cockroach`
  - **Linux**: Downloads and installs from official CockroachDB binaries
- Created new "Database Tools" section in the doctor output
- Added `check_tool "cockroach" "23.x+"` to verify installation

## Testing

Tested on macOS:
- Ran `scripts/doctor.sh --check` to verify detection of missing tool
- Ran `scripts/doctor.sh --fix` to verify automatic installation
- Confirmed `cockroach version` works after installation (v25.4.3)

## Impact

- Developers running `scripts/doctor.sh --fix` will now have CockroachDB CLI automatically installed
- No breaking changes to existing functionality
- Adds visibility of database tooling requirements in doctor output