### PR TITLE
feat: Add starlark saga handler for market-information service

### DIFF
--- a/services/market-information/client/starlark.go
+++ b/services/market-information/client/starlark.go
@@ -1,0 +1,170 @@
+// Package client provides Starlark service bindings for Market Information.
+// These handlers adapt the Starlark interface (map[string]any) to gRPC client calls,
+// enabling saga step execution with real Market Information service integration.
+package client
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/shopspring/decimal"
+)
+
+// RegisterStarlarkHandlers registers all Starlark service bindings for Market Information.
+// These handlers adapt the Starlark interface (map[string]any) to gRPC client calls.
+//
+// This function is called during service initialization to register Market Information handlers
+// with the saga execution engine. Each handler includes metadata for conservation rule
+// enforcement and operational categorization.
+//
+// Example usage:
+//
+//	registry := saga.NewHandlerRegistry()
+//	client, cleanup, _ := client.New(client.Config{...})
+//	defer cleanup()
+//	err := RegisterStarlarkHandlers(registry, client)
+func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) error {
+	handlers := map[string]struct {
+		handler  saga.Handler
+		metadata saga.HandlerMetadata
+	}{
+		"market_information.get_rate": {
+			handler: getRateHandler(client),
+			metadata: saga.HandlerMetadata{
+				Category: saga.HandlerCategoryValuation,
+				// Read-only handler - provides reference data for valuation
+				// Does not produce instruments, only queries existing rates
+				ProducesInstruments: []string{},
+			},
+		},
+	}
+
+	for name, h := range handlers {
+		if err := registry.RegisterWithMetadata(name, h.handler, &h.metadata); err != nil {
+			return fmt.Errorf("failed to register %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// getRateHandler fetches FX rates for currency pair conversion via gRPC.
+// This handler adapts Starlark parameters to the GetRate RPC call,
+// propagating saga metadata for idempotency, tracing, and bi-temporal queries.
+//
+// FX rates are used in multi-currency payment sagas to calculate settlement amounts
+// when the payer and payee use different currencies.
+//
+// Parameters:
+//   - from_currency (string): The source currency code (e.g., "USD", "EUR")
+//   - to_currency (string): The destination currency code (e.g., "EUR", "GBP")
+//   - rate_date (optional time.Time): The date for which to fetch the rate (defaults to now)
+//
+// Returns a map containing:
+//   - from_currency: The source currency code
+//   - to_currency: The destination currency code
+//   - rate: The exchange rate as decimal (e.g., 1.0856 for USD/EUR)
+//   - rate_date: The effective date of the rate
+//   - source: The data source identifier
+//
+// Edge cases:
+//   - Same currency (USD->USD): Returns rate = 1.0 without calling the service
+//   - Rate not found: Returns error from service
+//   - Future date: Service validates and returns INVALID_ARGUMENT error
+func getRateHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		// 1. Parse Starlark params using helper functions from shared/pkg/saga
+		fromCurrency, err := saga.RequireStringParam(params, "from_currency")
+		if err != nil {
+			return nil, err
+		}
+
+		toCurrency, err := saga.RequireStringParam(params, "to_currency")
+		if err != nil {
+			return nil, err
+		}
+
+		// Handle same currency case without calling the service
+		if fromCurrency == toCurrency {
+			return map[string]any{
+				"from_currency": fromCurrency,
+				"to_currency":   toCurrency,
+				"rate":          decimal.NewFromInt(1),
+				"rate_date":     time.Now(),
+				"source":        "IDENTITY",
+			}, nil
+		}
+
+		// rate_date is optional - defaults to current time
+		rateDate := time.Now()
+		if val, ok := params["rate_date"].(time.Time); ok {
+			rateDate = val
+		}
+
+		// 2. Prepare client context with saga metadata propagation
+		clientCtx := prepareClientContext(ctx)
+
+		// 3. Build dataset code from currency pair (e.g., "USD_EUR_FX")
+		datasetCode := fmt.Sprintf("%s_%s_FX", fromCurrency, toCurrency)
+
+		// 4. Call REAL gRPC client using GetRate for point-in-time lookup
+		// Resolution key is "spot" for standard FX rates
+		obs, err := client.GetRate(
+			clientCtx,
+			datasetCode,
+			"spot",
+			rateDate,
+			marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("market_information.get_rate: %w", err)
+		}
+
+		// 5. Convert response to Starlark format (map[string]any)
+		rate, err := decimal.NewFromString(obs.Value)
+		if err != nil {
+			return nil, fmt.Errorf("market_information.get_rate: invalid rate value: %w", err)
+		}
+
+		return map[string]any{
+			"from_currency": fromCurrency,
+			"to_currency":   toCurrency,
+			"rate":          rate,
+			"rate_date":     obs.ValidFrom.AsTime(),
+			"source":        obs.SourceId,
+		}, nil
+	}
+}
+
+// prepareClientContext enriches the gRPC client context with saga metadata.
+// This function centralizes metadata propagation logic used by all handlers.
+//
+// Propagated metadata:
+//   - Idempotency key: Ensures duplicate saga replays don't create duplicate records
+//   - Knowledge_at timestamp: Enables bi-temporal queries (what we knew at a specific time)
+//   - Correlation ID: Links all related operations across the distributed system for tracing
+//
+// The propagation functions (clients.PropagateIdempotencyKey, etc.) add this metadata
+// to the gRPC context's outgoing metadata headers, which downstream services can extract.
+//
+// contextKey is a type for context keys to avoid collisions
+type contextKey string
+
+// correlationIDContextKey is the typed context key for correlation ID
+const correlationIDContextKey contextKey = "x-correlation-id"
+
+func prepareClientContext(ctx *saga.StarlarkContext) context.Context {
+	clientCtx := ctx.Context
+
+	// Add correlation ID to context value so the client's PropagateCorrelationID can extract it
+	clientCtx = context.WithValue(clientCtx, correlationIDContextKey, ctx.CorrelationID.String())
+
+	// Propagate idempotency key and knowledge_at timestamp
+	clientCtx = clients.PropagateIdempotencyKey(clientCtx, ctx.IdempotencyKey)
+	clientCtx = clients.PropagateKnowledgeAt(clientCtx, ctx.KnowledgeAt)
+
+	return clientCtx
+}

--- a/services/market-information/client/starlark.go
+++ b/services/market-information/client/starlark.go
@@ -149,22 +149,22 @@ func getRateHandler(client *Client) saga.Handler {
 //
 // The propagation functions (clients.PropagateIdempotencyKey, etc.) add this metadata
 // to the gRPC context's outgoing metadata headers, which downstream services can extract.
-//
-// contextKey is a type for context keys to avoid collisions
-type contextKey string
-
-// correlationIDContextKey is the typed context key for correlation ID
-const correlationIDContextKey contextKey = "x-correlation-id"
-
 func prepareClientContext(ctx *saga.StarlarkContext) context.Context {
 	clientCtx := ctx.Context
 
-	// Add correlation ID to context value so the client's PropagateCorrelationID can extract it
-	clientCtx = context.WithValue(clientCtx, correlationIDContextKey, ctx.CorrelationID.String())
+	// Add correlation ID to context value using string literal key so PropagateCorrelationID can extract it.
+	// ExtractCorrelationID in shared/pkg/clients/common.go uses ctx.Value("x-correlation-id") with
+	// string keys, so we must use the same type here despite the linter preference for typed keys.
+	//nolint:revive,staticcheck // SA1029,context-keys-type: string key required for PropagateCorrelationID/ExtractCorrelationID compatibility
+	clientCtx = context.WithValue(clientCtx, "x-correlation-id", ctx.CorrelationID.String())
+	clientCtx = clients.PropagateCorrelationID(clientCtx) // Adds to gRPC metadata headers
 
-	// Propagate idempotency key and knowledge_at timestamp
+	// Propagate and apply idempotency key and knowledge_at timestamp to gRPC metadata
 	clientCtx = clients.PropagateIdempotencyKey(clientCtx, ctx.IdempotencyKey)
+	clientCtx = clients.ApplyIdempotencyKey(clientCtx, nil) // Adds to gRPC metadata headers
+
 	clientCtx = clients.PropagateKnowledgeAt(clientCtx, ctx.KnowledgeAt)
+	clientCtx = clients.ApplyKnowledgeAt(clientCtx) // Adds to gRPC metadata headers
 
 	return clientCtx
 }

--- a/services/market-information/client/starlark_test.go
+++ b/services/market-information/client/starlark_test.go
@@ -1,0 +1,540 @@
+package client
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// mockMarketInformationServer implements MarketInformationServiceServer for testing
+type mockMarketInformationServer struct {
+	marketinformationv1.UnimplementedMarketInformationServiceServer
+
+	lastIdempotencyKey string
+	lastKnowledgeAt    time.Time
+	lastCorrelationID  uuid.UUID
+
+	listObservationsCalled bool
+
+	// Control response behavior
+	shouldError     bool
+	errorMessage    string
+	errorCode       codes.Code
+	observations    []*marketinformationv1.MarketPriceObservation
+	observationDate time.Time
+}
+
+func (m *mockMarketInformationServer) ListObservations(ctx context.Context, _ *marketinformationv1.ListObservationsRequest) (*marketinformationv1.ListObservationsResponse, error) {
+	m.listObservationsCalled = true
+
+	// Extract metadata from context
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		if keys := md.Get("x-idempotency-key"); len(keys) > 0 {
+			m.lastIdempotencyKey = keys[0]
+		}
+		if correlationIDs := md.Get("x-correlation-id"); len(correlationIDs) > 0 {
+			m.lastCorrelationID, _ = uuid.Parse(correlationIDs[0])
+		}
+		if knowledgeAts := md.Get("x-knowledge-at"); len(knowledgeAts) > 0 {
+			m.lastKnowledgeAt, _ = time.Parse(time.RFC3339, knowledgeAts[0])
+		}
+	}
+
+	if m.shouldError {
+		return nil, status.Error(m.errorCode, m.errorMessage)
+	}
+
+	return &marketinformationv1.ListObservationsResponse{
+		Observations: m.observations,
+	}, nil
+}
+
+// setupStarlarkMockServer creates a mock gRPC server and client for testing Starlark handlers
+func setupStarlarkMockServer(t *testing.T, mockServer *mockMarketInformationServer) (*Client, func()) {
+	// Create in-memory listener
+	buffer := 1024 * 1024
+	listener := bufconn.Listen(buffer)
+
+	// Create and start gRPC server
+	server := grpc.NewServer()
+	marketinformationv1.RegisterMarketInformationServiceServer(server, mockServer)
+
+	go func() {
+		if err := server.Serve(listener); err != nil {
+			t.Logf("Server error: %v", err)
+		}
+	}()
+
+	// Create client connection
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+
+	client := &Client{
+		conn:       conn,
+		grpcClient: marketinformationv1.NewMarketInformationServiceClient(conn),
+		timeout:    5 * time.Second,
+	}
+
+	cleanup := func() {
+		conn.Close()
+		server.Stop()
+		listener.Close()
+	}
+
+	return client, cleanup
+}
+
+func TestRegisterStarlarkHandlers(t *testing.T) {
+	t.Run("registers all handlers successfully", func(t *testing.T) {
+		registry := saga.NewHandlerRegistry()
+		mockServer := &mockMarketInformationServer{}
+		client, cleanup := setupStarlarkMockServer(t, mockServer)
+		defer cleanup()
+
+		err := RegisterStarlarkHandlers(registry, client)
+		require.NoError(t, err)
+
+		// Verify handler is registered
+		handler, metadata, err := registry.GetWithMetadata("market_information.get_rate")
+		assert.NoError(t, err, "Handler market_information.get_rate should be registered")
+		assert.NotNil(t, handler, "Handler market_information.get_rate should not be nil")
+
+		// Verify handler metadata
+		require.NotNil(t, metadata)
+		assert.Equal(t, saga.HandlerCategoryValuation, metadata.Category)
+		assert.Empty(t, metadata.ProducesInstruments, "get_rate is read-only, should not produce instruments")
+	})
+}
+
+func TestGetRateHandler(t *testing.T) {
+	t.Run("successful rate lookup", func(t *testing.T) {
+		mockServer := &mockMarketInformationServer{
+			observationDate: time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC),
+			observations: []*marketinformationv1.MarketPriceObservation{
+				{
+					Id:                 "obs-123",
+					DatasetCode:        "USD_EUR_FX",
+					DatasetVersion:     1,
+					ResolutionKeyValue: "spot",
+					Value:              "1.0856",
+					Quality:            marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+					SourceId:           "source-ecb-id",
+					ValidFrom:          timestamppb.New(time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC)),
+					ObservedAt:         timestamppb.New(time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC)),
+				},
+			},
+		}
+		client, cleanup := setupStarlarkMockServer(t, mockServer)
+		defer cleanup()
+
+		registry := saga.NewHandlerRegistry()
+		err := RegisterStarlarkHandlers(registry, client)
+		require.NoError(t, err)
+
+		handler, err := registry.Get("market_information.get_rate")
+		require.NoError(t, err)
+
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-idempotency-key",
+			CorrelationID:  uuid.New(),
+			KnowledgeAt:    time.Date(2024, 1, 15, 12, 0, 0, 0, time.UTC),
+		}
+
+		params := map[string]any{
+			"from_currency": "USD",
+			"to_currency":   "EUR",
+			"rate_date":     time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+		}
+
+		result, err := handler(ctx, params)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		resultMap, ok := result.(map[string]any)
+		require.True(t, ok, "Result should be a map")
+
+		assert.Equal(t, "USD", resultMap["from_currency"])
+		assert.Equal(t, "EUR", resultMap["to_currency"])
+		assert.Equal(t, decimal.RequireFromString("1.0856"), resultMap["rate"])
+		assert.Equal(t, "source-ecb-id", resultMap["source"])
+		assert.NotNil(t, resultMap["rate_date"])
+
+		// Verify service was called
+		assert.True(t, mockServer.listObservationsCalled)
+	})
+
+	t.Run("same currency returns rate 1.0", func(t *testing.T) {
+		mockServer := &mockMarketInformationServer{}
+		client, cleanup := setupStarlarkMockServer(t, mockServer)
+		defer cleanup()
+
+		registry := saga.NewHandlerRegistry()
+		err := RegisterStarlarkHandlers(registry, client)
+		require.NoError(t, err)
+
+		handler, err := registry.Get("market_information.get_rate")
+		require.NoError(t, err)
+
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			CorrelationID:  uuid.New(),
+			KnowledgeAt:    time.Now(),
+		}
+
+		params := map[string]any{
+			"from_currency": "USD",
+			"to_currency":   "USD",
+		}
+
+		result, err := handler(ctx, params)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		resultMap, ok := result.(map[string]any)
+		require.True(t, ok)
+
+		assert.Equal(t, "USD", resultMap["from_currency"])
+		assert.Equal(t, "USD", resultMap["to_currency"])
+		assert.Equal(t, decimal.NewFromInt(1), resultMap["rate"])
+		assert.Equal(t, "IDENTITY", resultMap["source"])
+
+		// Should not call the service for same currency
+		assert.False(t, mockServer.listObservationsCalled)
+	})
+
+	t.Run("missing from_currency returns error", func(t *testing.T) {
+		mockServer := &mockMarketInformationServer{}
+		client, cleanup := setupStarlarkMockServer(t, mockServer)
+		defer cleanup()
+
+		registry := saga.NewHandlerRegistry()
+		err := RegisterStarlarkHandlers(registry, client)
+		require.NoError(t, err)
+
+		handler, err := registry.Get("market_information.get_rate")
+		require.NoError(t, err)
+
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			CorrelationID:  uuid.New(),
+			KnowledgeAt:    time.Now(),
+		}
+
+		params := map[string]any{
+			"to_currency": "EUR",
+		}
+
+		result, err := handler(ctx, params)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "from_currency")
+	})
+
+	t.Run("missing to_currency returns error", func(t *testing.T) {
+		mockServer := &mockMarketInformationServer{}
+		client, cleanup := setupStarlarkMockServer(t, mockServer)
+		defer cleanup()
+
+		registry := saga.NewHandlerRegistry()
+		err := RegisterStarlarkHandlers(registry, client)
+		require.NoError(t, err)
+
+		handler, err := registry.Get("market_information.get_rate")
+		require.NoError(t, err)
+
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			CorrelationID:  uuid.New(),
+			KnowledgeAt:    time.Now(),
+		}
+
+		params := map[string]any{
+			"from_currency": "USD",
+		}
+
+		result, err := handler(ctx, params)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "to_currency")
+	})
+
+	t.Run("rate not found returns error", func(t *testing.T) {
+		mockServer := &mockMarketInformationServer{
+			shouldError:  true,
+			errorCode:    codes.NotFound,
+			errorMessage: "rate not found",
+		}
+		client, cleanup := setupStarlarkMockServer(t, mockServer)
+		defer cleanup()
+
+		registry := saga.NewHandlerRegistry()
+		err := RegisterStarlarkHandlers(registry, client)
+		require.NoError(t, err)
+
+		handler, err := registry.Get("market_information.get_rate")
+		require.NoError(t, err)
+
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			CorrelationID:  uuid.New(),
+			KnowledgeAt:    time.Now(),
+		}
+
+		params := map[string]any{
+			"from_currency": "USD",
+			"to_currency":   "XYZ", // Invalid currency
+		}
+
+		result, err := handler(ctx, params)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "market_information.get_rate")
+	})
+
+	t.Run("future date returns error", func(t *testing.T) {
+		mockServer := &mockMarketInformationServer{
+			shouldError:  true,
+			errorCode:    codes.InvalidArgument,
+			errorMessage: "rate_date cannot be in the future",
+		}
+		client, cleanup := setupStarlarkMockServer(t, mockServer)
+		defer cleanup()
+
+		registry := saga.NewHandlerRegistry()
+		err := RegisterStarlarkHandlers(registry, client)
+		require.NoError(t, err)
+
+		handler, err := registry.Get("market_information.get_rate")
+		require.NoError(t, err)
+
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			CorrelationID:  uuid.New(),
+			KnowledgeAt:    time.Now(),
+		}
+
+		// Future date (1 day from now)
+		futureDate := time.Now().Add(24 * time.Hour)
+		params := map[string]any{
+			"from_currency": "USD",
+			"to_currency":   "EUR",
+			"rate_date":     futureDate,
+		}
+
+		result, err := handler(ctx, params)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+	})
+
+	t.Run("defaults to current date when rate_date not provided", func(t *testing.T) {
+		now := time.Now()
+		mockServer := &mockMarketInformationServer{
+			observations: []*marketinformationv1.MarketPriceObservation{
+				{
+					Id:                 "obs-456",
+					DatasetCode:        "USD_EUR_FX",
+					DatasetVersion:     1,
+					ResolutionKeyValue: "spot",
+					Value:              "1.0900",
+					Quality:            marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+					SourceId:           "source-ecb-id",
+					ValidFrom:          timestamppb.New(now),
+					ObservedAt:         timestamppb.New(now),
+				},
+			},
+		}
+		client, cleanup := setupStarlarkMockServer(t, mockServer)
+		defer cleanup()
+
+		registry := saga.NewHandlerRegistry()
+		err := RegisterStarlarkHandlers(registry, client)
+		require.NoError(t, err)
+
+		handler, err := registry.Get("market_information.get_rate")
+		require.NoError(t, err)
+
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			CorrelationID:  uuid.New(),
+			KnowledgeAt:    now,
+		}
+
+		params := map[string]any{
+			"from_currency": "USD",
+			"to_currency":   "EUR",
+			// rate_date omitted - should default to now
+		}
+
+		result, err := handler(ctx, params)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		resultMap, ok := result.(map[string]any)
+		require.True(t, ok)
+
+		assert.Equal(t, decimal.RequireFromString("1.0900"), resultMap["rate"])
+		assert.True(t, mockServer.listObservationsCalled)
+	})
+
+	t.Run("uses knowledge_at for bi-temporal queries", func(t *testing.T) {
+		knowledgeTime := time.Date(2024, 1, 10, 12, 0, 0, 0, time.UTC)
+		mockServer := &mockMarketInformationServer{
+			observations: []*marketinformationv1.MarketPriceObservation{
+				{
+					Id:                 "obs-historical",
+					DatasetCode:        "USD_EUR_FX",
+					DatasetVersion:     1,
+					ResolutionKeyValue: "spot",
+					Value:              "1.0750",
+					Quality:            marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+					SourceId:           "source-ecb-id",
+					ValidFrom:          timestamppb.New(time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC)),
+					ObservedAt:         timestamppb.New(time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC)),
+				},
+			},
+		}
+		client, cleanup := setupStarlarkMockServer(t, mockServer)
+		defer cleanup()
+
+		registry := saga.NewHandlerRegistry()
+		err := RegisterStarlarkHandlers(registry, client)
+		require.NoError(t, err)
+
+		handler, err := registry.Get("market_information.get_rate")
+		require.NoError(t, err)
+
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			CorrelationID:  uuid.New(),
+			KnowledgeAt:    knowledgeTime,
+		}
+
+		params := map[string]any{
+			"from_currency": "USD",
+			"to_currency":   "EUR",
+			"rate_date":     time.Date(2024, 1, 5, 0, 0, 0, 0, time.UTC),
+		}
+
+		result, err := handler(ctx, params)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		// Verify service was called (knowledge_at propagation is tested at client level)
+		assert.True(t, mockServer.listObservationsCalled)
+	})
+}
+
+// TestGetRateHandler_DatasetCodeGeneration verifies the dataset code generation logic
+func TestGetRateHandler_DatasetCodeGeneration(t *testing.T) {
+	testCases := []struct {
+		name            string
+		fromCurrency    string
+		toCurrency      string
+		expectedDataset string
+		expectedResKey  string
+	}{
+		{
+			name:            "USD to EUR",
+			fromCurrency:    "USD",
+			toCurrency:      "EUR",
+			expectedDataset: "USD_EUR_FX",
+			expectedResKey:  "spot",
+		},
+		{
+			name:            "GBP to JPY",
+			fromCurrency:    "GBP",
+			toCurrency:      "JPY",
+			expectedDataset: "GBP_JPY_FX",
+			expectedResKey:  "spot",
+		},
+		{
+			name:            "EUR to USD (reverse pair)",
+			fromCurrency:    "EUR",
+			toCurrency:      "USD",
+			expectedDataset: "EUR_USD_FX",
+			expectedResKey:  "spot",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockServer := &mockMarketInformationServer{
+				observations: []*marketinformationv1.MarketPriceObservation{
+					{
+						Id:                 "obs-test",
+						DatasetCode:        tc.expectedDataset,
+						DatasetVersion:     1,
+						ResolutionKeyValue: tc.expectedResKey,
+						Value:              "1.1234",
+						Quality:            marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+						SourceId:           "source-test-id",
+						ValidFrom:          timestamppb.Now(),
+						ObservedAt:         timestamppb.Now(),
+					},
+				},
+			}
+			client, cleanup := setupStarlarkMockServer(t, mockServer)
+			defer cleanup()
+
+			registry := saga.NewHandlerRegistry()
+			err := RegisterStarlarkHandlers(registry, client)
+			require.NoError(t, err)
+
+			handler, err := registry.Get("market_information.get_rate")
+			require.NoError(t, err)
+
+			ctx := &saga.StarlarkContext{
+				Context:        context.Background(),
+				IdempotencyKey: "test-key",
+				CorrelationID:  uuid.New(),
+				KnowledgeAt:    time.Now(),
+			}
+
+			params := map[string]any{
+				"from_currency": tc.fromCurrency,
+				"to_currency":   tc.toCurrency,
+			}
+
+			result, err := handler(ctx, params)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			resultMap, ok := result.(map[string]any)
+			require.True(t, ok)
+
+			assert.Equal(t, tc.fromCurrency, resultMap["from_currency"])
+			assert.Equal(t, tc.toCurrency, resultMap["to_currency"])
+			assert.True(t, mockServer.listObservationsCalled)
+		})
+	}
+}

--- a/services/market-information/client/starlark_test.go
+++ b/services/market-information/client/starlark_test.go
@@ -184,6 +184,11 @@ func TestGetRateHandler(t *testing.T) {
 
 		// Verify service was called
 		assert.True(t, mockServer.listObservationsCalled)
+
+		// Verify metadata propagation (CodeRabbit suggestion)
+		assert.Equal(t, "test-idempotency-key", mockServer.lastIdempotencyKey, "idempotency key should be propagated")
+		assert.Equal(t, ctx.CorrelationID, mockServer.lastCorrelationID, "correlation ID should be propagated")
+		assert.Equal(t, ctx.KnowledgeAt, mockServer.lastKnowledgeAt, "knowledge_at should be propagated")
 	})
 
 	t.Run("same currency returns rate 1.0", func(t *testing.T) {
@@ -449,8 +454,12 @@ func TestGetRateHandler(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
-		// Verify service was called (knowledge_at propagation is tested at client level)
+		// Verify service was called
 		assert.True(t, mockServer.listObservationsCalled)
+
+		// Verify knowledge_at was propagated (CodeRabbit suggestion)
+		assert.Equal(t, knowledgeTime, mockServer.lastKnowledgeAt, "knowledge_at should be propagated for bi-temporal queries")
+		assert.Equal(t, ctx.CorrelationID, mockServer.lastCorrelationID, "correlation ID should be propagated")
 	})
 }
 


### PR DESCRIPTION
## Summary

Implements `market_information.get_rate` starlark handler for FX rate lookups in multi-currency payment sagas.

## Changes Made

- Created `services/market-information/client/starlark.go` with:
  - `RegisterStarlarkHandlers()` function to register handlers with saga engine
  - `getRateHandler()` for currency pair rate lookups
  - `prepareClientContext()` for saga metadata propagation
  
- Created comprehensive test suite in `starlark_test.go` with:
  - Handler registration and metadata verification
  - Successful rate lookup scenarios
  - Edge case handling (same currency, missing params, errors)
  - Bi-temporal query support validation
  - Dataset code generation tests

## Handler Characteristics

- **Category**: `HandlerCategoryValuation` (read-only reference data)
- **ProducesInstruments**: `[]` (does not create financial instruments)
- **Use Case**: Multi-currency payment sagas requiring FX rates for conversion

## Edge Cases Handled

1. **Same currency conversion** (USD→USD): Returns rate 1.0 without service call
2. **Missing parameters**: Validation errors for missing from/to currency
3. **Rate not found**: Propagates service errors appropriately
4. **Future dates**: Service layer validation
5. **Optional rate_date**: Defaults to current time when not provided

## Test Coverage

All tests passing:
- ✅ Handler registration with correct metadata
- ✅ Successful rate lookup with metadata propagation
- ✅ Same currency optimization
- ✅ Parameter validation
- ✅ Error propagation (not found, future date)
- ✅ Default rate_date behavior
- ✅ Bi-temporal query support
- ✅ Dataset code generation for currency pairs

## Related Task

Task Master: saga-script-versioning.19.4