### PR TITLE
feat: Add starlark saga handler for reference-data service

### DIFF
--- a/services/reference-data/client/starlark.go
+++ b/services/reference-data/client/starlark.go
@@ -119,15 +119,14 @@ func retrieveInstrumentHandler(client *Client) saga.Handler {
 //
 // The propagation functions (clients.PropagateIdempotencyKey, etc.) add this metadata
 // to the gRPC context's outgoing metadata headers, which downstream services can extract.
-type contextKey string
-
-const correlationIDContextKey contextKey = "x-correlation-id"
-
 func prepareClientContext(ctx *saga.StarlarkContext) context.Context {
 	clientCtx := ctx.Context
 
-	// Add correlation ID to context value so the client's PropagateCorrelationID can extract it
-	clientCtx = context.WithValue(clientCtx, correlationIDContextKey, ctx.CorrelationID.String())
+	// Add correlation ID to context value using string literal key so ExtractCorrelationID can find it.
+	// ExtractCorrelationID in shared/pkg/clients/common.go uses ctx.Value("x-correlation-id") with
+	// string keys, so we must use the same type here despite the linter preference for typed keys.
+	//nolint:revive,staticcheck // SA1029,context-keys-type: string key required for ExtractCorrelationID compatibility
+	clientCtx = context.WithValue(clientCtx, "x-correlation-id", ctx.CorrelationID.String())
 
 	// Propagate idempotency key and knowledge_at timestamp
 	clientCtx = clients.PropagateIdempotencyKey(clientCtx, ctx.IdempotencyKey)

--- a/services/reference-data/client/starlark.go
+++ b/services/reference-data/client/starlark.go
@@ -1,0 +1,166 @@
+// Package client provides Starlark service bindings for Reference Data.
+// These handlers adapt the Starlark interface (map[string]any) to gRPC client calls,
+// enabling saga step execution with real Reference Data service integration.
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+// ErrInvalidVersionType is returned when version parameter is not an integer type.
+var ErrInvalidVersionType = errors.New("version must be an integer")
+
+// RegisterStarlarkHandlers registers all Starlark service bindings for Reference Data.
+// These handlers adapt the Starlark interface (map[string]any) to gRPC client calls.
+//
+// This function is called during service initialization to register Reference Data handlers
+// with the saga execution engine. Each handler includes metadata for conservation rule
+// enforcement and operational categorization.
+//
+// Example usage:
+//
+//	registry := saga.NewHandlerRegistry()
+//	client, cleanup, _ := client.New(client.Config{...})
+//	defer cleanup()
+//	err := RegisterStarlarkHandlers(registry, client)
+func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) error {
+	handlers := map[string]struct {
+		handler  saga.Handler
+		metadata saga.HandlerMetadata
+	}{
+		"reference_data.retrieve_instrument": {
+			handler: retrieveInstrumentHandler(client),
+			metadata: saga.HandlerMetadata{
+				Category: saga.HandlerCategoryValuation,
+				// Reference data handlers are read-only lookups, they don't produce new instruments
+				ProducesInstruments: []string{},
+			},
+		},
+	}
+
+	for name, h := range handlers {
+		if err := registry.RegisterWithMetadata(name, h.handler, &h.metadata); err != nil {
+			return fmt.Errorf("failed to register %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// retrieveInstrumentHandler fetches an instrument definition by code and version.
+// This handler provides read-only access to instrument metadata including fungibility
+// expressions used in bucket-aware solvency validation.
+//
+// Parameters:
+//   - instrument_code (string): The instrument code (e.g., "USD", "KWH")
+//   - version (int): The instrument version (use 0 for latest ACTIVE version)
+//
+// Returns a map containing:
+//   - instrument_code: The instrument code
+//   - version: The instrument version
+//   - fungibility_key_expression: CEL expression for bucket key generation
+//   - is_fungible: Whether the instrument is fungible (true if fungibility_key_expression is set)
+//   - dimension: The instrument dimension (e.g., "CURRENCY", "ENERGY")
+func retrieveInstrumentHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		// 1. Parse Starlark params using helper functions from shared/pkg/saga
+		instrumentCode, err := saga.RequireStringParam(params, "instrument_code")
+		if err != nil {
+			return nil, err
+		}
+
+		// Version defaults to 0 (latest ACTIVE version) if not provided
+		version := int32(0)
+		if v, ok := params["version"]; ok {
+			if vInt, ok := v.(int64); ok {
+				version = int32(vInt)
+			} else if vInt32, ok := v.(int32); ok {
+				version = vInt32
+			} else {
+				return nil, fmt.Errorf("%w: got %T", ErrInvalidVersionType, v)
+			}
+		}
+
+		// 2. Prepare client context with saga metadata propagation
+		clientCtx := prepareClientContext(ctx)
+
+		// 3. Call gRPC client to retrieve instrument
+		instrument, err := client.RetrieveInstrument(clientCtx, instrumentCode, int(version))
+		if err != nil {
+			return nil, fmt.Errorf("reference_data.retrieve_instrument: %w", err)
+		}
+
+		// 4. Convert dimension enum to string
+		dimensionStr := dimensionToString(instrument.Dimension)
+
+		// 5. Convert response to Starlark format (map[string]any)
+		return map[string]any{
+			"instrument_code":            instrument.Code,
+			"version":                    instrument.Version,
+			"fungibility_key_expression": instrument.FungibilityKeyExpression,
+			"is_fungible":                instrument.FungibilityKeyExpression != "",
+			"dimension":                  dimensionStr,
+		}, nil
+	}
+}
+
+// prepareClientContext enriches the gRPC client context with saga metadata.
+// This function centralizes metadata propagation logic used by all handlers.
+//
+// Propagated metadata:
+//   - Idempotency key: Ensures duplicate saga replays don't create duplicate records
+//   - Knowledge_at timestamp: Enables bi-temporal queries (what we knew at a specific time)
+//   - Correlation ID: Links all related operations across the distributed system for tracing
+//
+// The propagation functions (clients.PropagateIdempotencyKey, etc.) add this metadata
+// to the gRPC context's outgoing metadata headers, which downstream services can extract.
+type contextKey string
+
+const correlationIDContextKey contextKey = "x-correlation-id"
+
+func prepareClientContext(ctx *saga.StarlarkContext) context.Context {
+	clientCtx := ctx.Context
+
+	// Add correlation ID to context value so the client's PropagateCorrelationID can extract it
+	clientCtx = context.WithValue(clientCtx, correlationIDContextKey, ctx.CorrelationID.String())
+
+	// Propagate idempotency key and knowledge_at timestamp
+	clientCtx = clients.PropagateIdempotencyKey(clientCtx, ctx.IdempotencyKey)
+	clientCtx = clients.PropagateKnowledgeAt(clientCtx, ctx.KnowledgeAt)
+
+	// Note: PropagateCorrelationID is called by the Client methods
+	return clientCtx
+}
+
+// dimensionToString converts a Dimension enum to a readable string.
+func dimensionToString(d referencedatav1.Dimension) string {
+	switch d {
+	case referencedatav1.Dimension_DIMENSION_UNSPECIFIED:
+		return "UNSPECIFIED"
+	case referencedatav1.Dimension_DIMENSION_CURRENCY:
+		return "CURRENCY"
+	case referencedatav1.Dimension_DIMENSION_ENERGY:
+		return "ENERGY"
+	case referencedatav1.Dimension_DIMENSION_MASS:
+		return "MASS"
+	case referencedatav1.Dimension_DIMENSION_VOLUME:
+		return "VOLUME"
+	case referencedatav1.Dimension_DIMENSION_TIME:
+		return "TIME"
+	case referencedatav1.Dimension_DIMENSION_COMPUTE:
+		return "COMPUTE"
+	case referencedatav1.Dimension_DIMENSION_CARBON:
+		return "CARBON"
+	case referencedatav1.Dimension_DIMENSION_DATA:
+		return "DATA"
+	case referencedatav1.Dimension_DIMENSION_COUNT:
+		return "COUNT"
+	default:
+		return "UNSPECIFIED"
+	}
+}

--- a/services/reference-data/client/starlark_test.go
+++ b/services/reference-data/client/starlark_test.go
@@ -1,0 +1,270 @@
+package client
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestRegisterStarlarkHandlers_Success verifies handler is registered.
+func TestRegisterStarlarkHandlers_Success(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+
+	// Create a mock client (nil is fine for registration test)
+	client := &Client{}
+
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	// Verify handler is registered
+	handlers := registry.List()
+	assert.Contains(t, handlers, "reference_data.retrieve_instrument")
+}
+
+// TestRetrieveInstrumentHandler_Success verifies instrument retrieval with fungibility_key_expression.
+func TestRetrieveInstrumentHandler_Success(t *testing.T) {
+	// Start mock gRPC server
+	server, addr := startMockServer(t)
+
+	// Configure mock response
+	mockInstrument := &referencedatav1.InstrumentDefinition{
+		Id:                       uuid.New().String(),
+		Code:                     "USD",
+		Version:                  1,
+		Dimension:                referencedatav1.Dimension_DIMENSION_CURRENCY,
+		Precision:                2,
+		Status:                   referencedatav1.InstrumentStatus_INSTRUMENT_STATUS_ACTIVE,
+		FungibilityKeyExpression: "code + ':' + string(version)",
+		DisplayName:              "US Dollar",
+		CreatedAt:                timestamppb.Now(),
+	}
+	server.RegisterInstrumentFunc = func(_ context.Context, _ *referencedatav1.RegisterInstrumentRequest) (*referencedatav1.RegisterInstrumentResponse, error) {
+		return &referencedatav1.RegisterInstrumentResponse{
+			Instrument: mockInstrument,
+		}, nil
+	}
+	server.RetrieveInstrumentFunc = func(_ context.Context, _ *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error) {
+		return &referencedatav1.RetrieveInstrumentResponse{
+			Instrument: mockInstrument,
+		}, nil
+	}
+
+	// Create client
+	ctx := context.Background()
+	client, cleanup, err := New(ctx, Config{
+		Target:  addr,
+		Timeout: 5 * time.Second,
+		DialOptions: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	// Register handlers
+	registry := saga.NewHandlerRegistry()
+	err = RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	// Get handler
+	handler, err := registry.Get("reference_data.retrieve_instrument")
+	require.NoError(t, err)
+
+	// Execute handler
+	sagaCtx := &saga.StarlarkContext{
+		Context:        ctx,
+		CorrelationID:  uuid.New(),
+		IdempotencyKey: "test-key",
+		KnowledgeAt:    time.Now(),
+	}
+	params := map[string]any{
+		"instrument_code": "USD",
+		"version":         int64(1),
+	}
+
+	result, err := handler(sagaCtx, params)
+	require.NoError(t, err)
+
+	// Verify response structure
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok, "result should be a map")
+
+	assert.Equal(t, "USD", resultMap["instrument_code"])
+	assert.Equal(t, int32(1), resultMap["version"])
+	assert.Equal(t, "code + ':' + string(version)", resultMap["fungibility_key_expression"])
+	assert.Equal(t, true, resultMap["is_fungible"])
+	assert.Equal(t, "CURRENCY", resultMap["dimension"])
+}
+
+// TestRetrieveInstrumentHandler_NotFound verifies NOT_FOUND error handling.
+func TestRetrieveInstrumentHandler_NotFound(t *testing.T) {
+	// Start mock gRPC server
+	server, addr := startMockServer(t)
+
+	// Configure mock to return NOT_FOUND
+	server.RetrieveInstrumentFunc = func(_ context.Context, _ *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error) {
+		return nil, status.Error(codes.NotFound, "instrument not found")
+	}
+
+	// Create client
+	ctx := context.Background()
+	client, cleanup, err := New(ctx, Config{
+		Target:  addr,
+		Timeout: 5 * time.Second,
+		DialOptions: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cleanup() }()
+
+	// Register handlers
+	registry := saga.NewHandlerRegistry()
+	err = RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	// Get handler
+	handler, err := registry.Get("reference_data.retrieve_instrument")
+	require.NoError(t, err)
+
+	// Execute handler
+	sagaCtx := &saga.StarlarkContext{
+		Context:        ctx,
+		CorrelationID:  uuid.New(),
+		IdempotencyKey: "test-key",
+		KnowledgeAt:    time.Now(),
+	}
+	params := map[string]any{
+		"instrument_code": "NONEXISTENT",
+		"version":         int64(1),
+	}
+
+	_, err = handler(sagaCtx, params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestRetrieveInstrumentHandler_MissingInstrumentCode verifies parameter validation.
+func TestRetrieveInstrumentHandler_MissingInstrumentCode(t *testing.T) {
+	client := &Client{}
+
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("reference_data.retrieve_instrument")
+	require.NoError(t, err)
+
+	sagaCtx := &saga.StarlarkContext{
+		Context:        context.Background(),
+		CorrelationID:  uuid.New(),
+		IdempotencyKey: "test-key",
+		KnowledgeAt:    time.Now(),
+	}
+	params := map[string]any{
+		"version": int64(1),
+		// missing instrument_code
+	}
+
+	_, err = handler(sagaCtx, params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "instrument_code")
+}
+
+// TestHandlerMetadata_Category verifies Category is HandlerCategoryValuation.
+func TestHandlerMetadata_Category(t *testing.T) {
+	client := &Client{}
+
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	_, metadata, err := registry.GetWithMetadata("reference_data.retrieve_instrument")
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Equal(t, saga.HandlerCategoryValuation, metadata.Category)
+}
+
+// TestHandlerMetadata_ProducesInstruments verifies ProducesInstruments is empty.
+func TestHandlerMetadata_ProducesInstruments(t *testing.T) {
+	client := &Client{}
+
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	_, metadata, err := registry.GetWithMetadata("reference_data.retrieve_instrument")
+	require.NoError(t, err)
+	require.NotNil(t, metadata)
+	assert.Empty(t, metadata.ProducesInstruments)
+}
+
+// ========================================
+// Mock gRPC Server
+// ========================================
+
+type mockReferenceDataServer struct {
+	referencedatav1.UnimplementedReferenceDataServiceServer
+	RegisterInstrumentFunc  func(context.Context, *referencedatav1.RegisterInstrumentRequest) (*referencedatav1.RegisterInstrumentResponse, error)
+	RetrieveInstrumentFunc  func(context.Context, *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error)
+	ListInstrumentsFunc     func(context.Context, *referencedatav1.ListInstrumentsRequest) (*referencedatav1.ListInstrumentsResponse, error)
+	UpdateInstrumentFunc    func(context.Context, *referencedatav1.UpdateInstrumentRequest) (*referencedatav1.UpdateInstrumentResponse, error)
+	ActivateInstrumentFunc  func(context.Context, *referencedatav1.ActivateInstrumentRequest) (*referencedatav1.ActivateInstrumentResponse, error)
+	DeprecateInstrumentFunc func(context.Context, *referencedatav1.DeprecateInstrumentRequest) (*referencedatav1.DeprecateInstrumentResponse, error)
+}
+
+func (m *mockReferenceDataServer) RegisterInstrument(ctx context.Context, req *referencedatav1.RegisterInstrumentRequest) (*referencedatav1.RegisterInstrumentResponse, error) {
+	if m.RegisterInstrumentFunc != nil {
+		return m.RegisterInstrumentFunc(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockReferenceDataServer) RetrieveInstrument(ctx context.Context, req *referencedatav1.RetrieveInstrumentRequest) (*referencedatav1.RetrieveInstrumentResponse, error) {
+	if m.RetrieveInstrumentFunc != nil {
+		return m.RetrieveInstrumentFunc(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockReferenceDataServer) ListInstruments(ctx context.Context, req *referencedatav1.ListInstrumentsRequest) (*referencedatav1.ListInstrumentsResponse, error) {
+	if m.ListInstrumentsFunc != nil {
+		return m.ListInstrumentsFunc(ctx, req)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func startMockServer(t *testing.T) (*mockReferenceDataServer, string) {
+	t.Helper()
+
+	// Create TCP listener on random port
+	lc := &net.ListenConfig{}
+	lis, err := lc.Listen(context.Background(), "tcp", "localhost:0")
+	require.NoError(t, err)
+
+	server := &mockReferenceDataServer{}
+	grpcServer := grpc.NewServer()
+	referencedatav1.RegisterReferenceDataServiceServer(grpcServer, server)
+
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
+
+	t.Cleanup(func() {
+		grpcServer.GracefulStop()
+	})
+
+	return server, lis.Addr().String()
+}


### PR DESCRIPTION
## Summary

Implements `reference_data.retrieve_instrument` starlark saga handler for the reference-data service.

**Key features:**
- Read-only instrument lookup by code and version
- HandlerCategoryValuation metadata (no instrument production)
- Dimension enum to string conversion for starlark compatibility
- Leverages existing tiered caching (L1/L2/L3) for performance

**Test coverage:**
- Handler registration validation
- Successful instrument retrieval
- NOT_FOUND error handling
- Parameter validation
- Metadata category and ProducesInstruments verification

## Technical Details

The handler maps to the existing `RetrieveInstrument` gRPC method and returns instrument metadata including:
- `instrument_code`: Instrument identifier
- `version`: Schema version
- `fungibility_key_expression`: CEL expression for bucket pooling
- `is_fungible`: Boolean derived from expression presence
- `dimension`: Human-readable dimension string

Used in bucket-aware solvency validation saga scripts where instrument fungibility rules determine transaction pooling behavior.

## Note on Task Scope

Task 19.3 originally mentioned implementing `lookup_account` handler, but this method does not exist in the reference-data proto definition. Only `retrieve_instrument` was implemented as it maps to the existing gRPC API.

## Test Plan

- [x] All unit tests pass
- [x] Mock gRPC server validates handler behavior
- [x] Metadata validation tests confirm category and instrument production rules
- [x] golangci-lint passes

## Related

Part of task saga-script-versioning.19.3