### PR TITLE
Revert "chore: Update Go to 1.25.7 (#745)"

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.6'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.6'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,8 +51,8 @@ jobs:
             IMPORTANT: Today's date is ${{ steps.date.outputs.current_date }}.
 
             Key project facts:
-            - This project uses Go 1.25.7 (latest stable release)
-            - Go 1.25.7 is a valid version - do not question or flag it
+            - This project uses Go 1.25.4 (latest stable release)
+            - Go 1.25.4 is a valid version - do not question or flag it
             - Architecture: BIAN-compliant microservices
             - Stack: Go, Protocol Buffers, gRPC, Kubernetes
             - Security: All security scans must remain BLOCKING (never suggest making them non-blocking)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,8 +51,8 @@ jobs:
             IMPORTANT: Today's date is ${{ steps.date.outputs.current_date }}.
 
             Key project facts:
-            - This project uses Go 1.25.4 (latest stable release)
-            - Go 1.25.4 is a valid version - do not question or flag it
+            - This project uses Go 1.25.6 (latest stable release)
+            - Go 1.25.6 is a valid version - do not question or flag it
             - Architecture: BIAN-compliant microservices
             - Stack: Go, Protocol Buffers, gRPC, Kubernetes
             - Security: All security scans must remain BLOCKING (never suggest making them non-blocking)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,7 +64,7 @@ jobs:
       if: matrix.language == 'go'
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.25.6'
         cache: true
 
     # Set up buf for protobuf generation (pinned version for reproducibility)

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.6'
           cache: true
 
       - name: Install Atlas CLI
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.6'
           cache: true
 
       - name: Install Atlas CLI
@@ -241,7 +241,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.6'
           cache: true
 
       - name: Install Atlas CLI

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.6'
           cache: true
 
       - name: Set up buf
@@ -98,7 +98,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.25.6'
         cache: true
 
     - name: Set up buf

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.6'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25'
           cache: true
 
       - name: Install protoc

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.25.6'
         cache: true
 
     - name: Set up buf
@@ -51,7 +51,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.25.6'
         cache: true
 
     - name: Set up buf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.6'
           cache: true
 
       - name: Set up buf

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # audit-worker - Development Dockerfile for Tilt Live Update
 # Uses Debian bookworm for CGO support (required by confluent-kafka-go/librdkafka)
 
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies for CGO (librdkafka)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # audit-worker - Development Dockerfile for Tilt Live Update
 # Uses Debian bookworm for CGO support (required by confluent-kafka-go/librdkafka)
 
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies for CGO (librdkafka)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docs/adr/0006-tilt-local-development.md
+++ b/docs/adr/0006-tilt-local-development.md
@@ -548,7 +548,7 @@ Provided scripts make onboarding easy:
 
 # Output:
 
-# ✓ Go 1.25.7 installed
+# ✓ Go 1.25.3 installed
 
 # ✓ Docker running
 

--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -576,7 +576,7 @@ Create a multi-stage Docker build.
 
 ```dockerfile
 # Stage 1: Build
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-alpine AS builder
 
 ARG VERSION=dev
 ARG COMMIT=unknown

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meridianhub/meridian
 
-go 1.25.7
+go 1.25.5
 
 require (
 	ariga.io/atlas-provider-gorm v0.6.0

--- a/services/current-account/cmd/Dockerfile
+++ b/services/current-account/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/current-account/cmd/Dockerfile
+++ b/services/current-account/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/financial-accounting/cmd/Dockerfile
+++ b/services/financial-accounting/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/financial-accounting/cmd/Dockerfile
+++ b/services/financial-accounting/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/gateway/cmd/Dockerfile
+++ b/services/gateway/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/gateway/cmd/Dockerfile
+++ b/services/gateway/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/internal-bank-account/cmd/Dockerfile
+++ b/services/internal-bank-account/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/internal-bank-account/cmd/Dockerfile
+++ b/services/internal-bank-account/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/market-information/cmd/Dockerfile
+++ b/services/market-information/cmd/Dockerfile
@@ -4,7 +4,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/market-information/cmd/Dockerfile
+++ b/services/market-information/cmd/Dockerfile
@@ -4,7 +4,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/party/cmd/Dockerfile
+++ b/services/party/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/party/cmd/Dockerfile
+++ b/services/party/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/payment-order/cmd/Dockerfile
+++ b/services/payment-order/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/payment-order/cmd/Dockerfile
+++ b/services/payment-order/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/position-keeping/cmd/Dockerfile
+++ b/services/position-keeping/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/position-keeping/cmd/Dockerfile
+++ b/services/position-keeping/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/tenant/cmd/Dockerfile
+++ b/services/tenant/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/tenant/cmd/Dockerfile
+++ b/services/tenant/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/utilization-metering-consumer/cmd/Dockerfile
+++ b/services/utilization-metering-consumer/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25-bookworm AS builder
+FROM golang:1.25.6-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/utilization-metering-consumer/cmd/Dockerfile
+++ b/services/utilization-metering-consumer/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.25-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

Reverts #745 which updated Go to 1.25.7, as the Docker image `golang:1.25.7-bookworm` is not yet available on Docker Hub.

## Issue

PR #745 updated:
- `go.mod` to Go 1.25.7 ✅ (correct - toolchain version)
- All Dockerfiles to `golang:1.25.7-bookworm` ❌ (image doesn't exist yet)

This causes Docker builds to fail with:
```
Error response from daemon: failed to resolve reference "docker.io/library/golang:1.25.7-bookworm": not found
```

## What This Revert Does

Reverts back to:
- **go.mod**: Go 1.25.5 (previous working version)
- **Dockerfiles**: `golang:1.25-bookworm` (floating tag, currently points to 1.25.6)

This ensures all Docker builds work immediately.

## Next Steps

We can re-apply the Go 1.25.7 update once:
1. Docker Hub publishes the `golang:1.25.7-bookworm` image
2. We verify it's available with `docker pull golang:1.25.7-bookworm`

## Files Changed

- 25 files reverted (go.mod, Dockerfiles, workflow files, documentation)

## Verification

Checked Docker Hub availability:
```bash
$ docker pull golang:1.25.7-bookworm
Error: not found

$ docker pull golang:1.25.6-bookworm
✓ Success (latest available)
```