### PR TITLE
fix: Replace Python 'is not' with Starlark-compatible '!=' in withdrawal saga

### DIFF
--- a/services/reference-data/saga/defaults/withdrawal/v1.0.0.star
+++ b/services/reference-data/saga/defaults/withdrawal/v1.0.0.star
@@ -73,7 +73,7 @@ def execute_withdrawal():
     )
     
     # Step 4: Capture CREDIT posting to clearing account (if double-entry enabled)
-    if clearing_account_id is not None and clearing_account_id.strip() != "":
+    if clearing_account_id != None and clearing_account_id.strip() != "":
         step(name="capture_credit_posting")
         credit_result = financial_accounting.capture_posting(
             booking_log_id=booking_log_result.booking_log_id,


### PR DESCRIPTION
## Summary
- Fixed Starlark syntax error causing all withdrawal tests to fail on develop
- Changed `is not None` to `!= None` at line 76 of withdrawal saga script
- Starlark doesn't support Python's identity operators (is/is not)

## Root Cause
The withdrawal saga script (services/reference-data/saga/defaults/withdrawal/v1.0.0.star) contained Python-style identity operator `is not None` which is not valid Starlark syntax. Starlark parser expected `:` but got `is`, causing all withdrawal tests to fail.

## Changes Made
- Line 76: `if clearing_account_id is not None` → `if clearing_account_id != None`

## Tests Fixed
All 8 failing withdrawal tests now pass:
- ✅ TestExecuteWithdrawal_Success
- ✅ TestExecuteWithdrawal_ConcurrentWithdrawals
- ✅ TestExecuteWithdrawal_DoubleEntry_CompensatesOnFailure
- ✅ TestExecuteWithdrawal_DoubleEntry_CreatesDualPostings
- ✅ TestExecuteWithdrawal_ExactBalanceWithdrawal
- ✅ TestExecuteWithdrawal_IdempotencyProceedsWithoutKey
- ✅ TestExecuteWithdrawal_WithOrchestration_FinancialAccountingFailure
- ✅ TestExecuteWithdrawal_WithOrchestration_PositionKeepingFailure

## Test Plan
- ✅ All withdrawal tests pass locally
- ✅ Verified syntax is valid Starlark
- ✅ No other Starlark files affected