### PR TITLE
feat: Add validation caching layer for Starlark saga scripts

### DIFF
--- a/shared/pkg/saga/validation/cache.go
+++ b/shared/pkg/saga/validation/cache.go
@@ -1,0 +1,207 @@
+package validation
+
+import (
+	"container/list"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// Cache provides an in-memory cache for validation results.
+// It uses SHA256 hashing of script content as the cache key, LRU eviction
+// when the maximum size is reached, and TTL-based expiration.
+//
+// The cache is thread-safe and can be used concurrently from multiple goroutines.
+type Cache struct {
+	cache   map[string]*cacheEntry
+	lru     *list.List // Doubly-linked list for LRU tracking
+	mu      sync.RWMutex
+	ttl     time.Duration
+	maxSize int
+}
+
+// cacheEntry represents a single cached validation result.
+type cacheEntry struct {
+	Result     *ValidationResult
+	CachedAt   time.Time
+	ScriptHash string
+	element    *list.Element // Pointer to LRU list element for O(1) access
+}
+
+// NewCache creates a new validation cache.
+//
+// Parameters:
+//   - ttl: Time-to-live for cache entries. Use 0 for no expiration.
+//   - maxSize: Maximum number of entries. Use 0 for unlimited (not recommended).
+//
+// Default recommended values: ttl=1h, maxSize=1000
+func NewCache(ttl time.Duration, maxSize int) *Cache {
+	return &Cache{
+		cache:   make(map[string]*cacheEntry),
+		lru:     list.New(),
+		ttl:     ttl,
+		maxSize: maxSize,
+	}
+}
+
+// computeHash generates a SHA256 hash of the script content.
+func computeHash(script string) string {
+	hash := sha256.Sum256([]byte(script))
+	return hex.EncodeToString(hash[:])
+}
+
+// Get retrieves a cached validation result for the given script.
+// Returns (result, true) on cache hit, (nil, false) on cache miss or expiration.
+//
+// On cache hit, the entry is moved to the front of the LRU list.
+// Emits Prometheus metrics for cache hits and misses.
+func (c *Cache) Get(script string) (*ValidationResult, bool) {
+	hashStr := computeHash(script)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.cache[hashStr]
+	if !ok {
+		RecordCacheMiss()
+		return nil, false
+	}
+
+	// Check TTL expiration (skip if ttl is 0)
+	if c.ttl > 0 && time.Since(entry.CachedAt) > c.ttl {
+		// Entry expired - remove it
+		c.removeEntryWithEviction(hashStr, entry, "ttl")
+		RecordCacheMiss()
+		return nil, false
+	}
+
+	// Move to front of LRU list (most recently used)
+	c.lru.MoveToFront(entry.element)
+
+	RecordCacheHit()
+	return entry.Result, true
+}
+
+// Set stores a validation result in the cache.
+// If the cache is at capacity, the least recently used entry is evicted.
+// Updates Prometheus cache size gauge after modification.
+func (c *Cache) Set(script string, result *ValidationResult) {
+	hashStr := computeHash(script)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Check if entry already exists
+	if existing, ok := c.cache[hashStr]; ok {
+		// Update existing entry
+		existing.Result = result
+		existing.CachedAt = time.Now()
+		c.lru.MoveToFront(existing.element)
+		return
+	}
+
+	// Evict LRU entry if at capacity
+	if c.maxSize > 0 && len(c.cache) >= c.maxSize {
+		c.evictOldest()
+	}
+
+	// Create new entry
+	entry := &cacheEntry{
+		Result:     result,
+		CachedAt:   time.Now(),
+		ScriptHash: hashStr,
+	}
+
+	// Add to front of LRU list
+	entry.element = c.lru.PushFront(hashStr)
+	c.cache[hashStr] = entry
+
+	RecordCacheSize(len(c.cache))
+}
+
+// evictOldest removes the least recently used entry.
+// Must be called with lock held.
+func (c *Cache) evictOldest() {
+	oldest := c.lru.Back()
+	if oldest == nil {
+		return
+	}
+
+	hashStr, _ := oldest.Value.(string)
+	delete(c.cache, hashStr)
+	c.lru.Remove(oldest)
+	RecordCacheEviction("lru")
+}
+
+// removeEntry removes a specific entry from the cache without recording eviction metrics.
+// Must be called with lock held. Use removeEntryWithEviction when evicting for metrics.
+func (c *Cache) removeEntry(hashStr string, entry *cacheEntry) {
+	delete(c.cache, hashStr)
+	if entry.element != nil {
+		c.lru.Remove(entry.element)
+	}
+}
+
+// removeEntryWithEviction removes a specific entry and records the eviction metric.
+// Must be called with lock held.
+func (c *Cache) removeEntryWithEviction(hashStr string, entry *cacheEntry, reason string) {
+	c.removeEntry(hashStr, entry)
+	RecordCacheEviction(reason)
+}
+
+// EvictExpired removes all expired entries from the cache.
+// This is called periodically by the background eviction goroutine.
+// Records TTL eviction metrics for each removed entry.
+func (c *Cache) EvictExpired() {
+	if c.ttl == 0 {
+		return // No expiration configured
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for hashStr, entry := range c.cache {
+		if now.Sub(entry.CachedAt) > c.ttl {
+			c.removeEntryWithEviction(hashStr, entry, "ttl")
+		}
+	}
+	RecordCacheSize(len(c.cache))
+}
+
+// Start begins background eviction of expired entries.
+// The eviction goroutine runs every 10 minutes until the context is cancelled.
+func (c *Cache) Start(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Minute)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				c.EvictExpired()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// Size returns the current number of entries in the cache.
+func (c *Cache) Size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.cache)
+}
+
+// Clear removes all entries from the cache.
+// Updates Prometheus cache size gauge to 0.
+func (c *Cache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cache = make(map[string]*cacheEntry)
+	c.lru.Init()
+	RecordCacheSize(0)
+}

--- a/shared/pkg/saga/validation/cache.go
+++ b/shared/pkg/saga/validation/cache.go
@@ -73,6 +73,7 @@ func (c *Cache) Get(script string) (*ValidationResult, bool) {
 	if c.ttl > 0 && time.Since(entry.CachedAt) > c.ttl {
 		// Entry expired - remove it
 		c.removeEntryWithEviction(hashStr, entry, "ttl")
+		RecordCacheSize(len(c.cache))
 		RecordCacheMiss()
 		return nil, false
 	}

--- a/shared/pkg/saga/validation/cache_metrics.go
+++ b/shared/pkg/saga/validation/cache_metrics.go
@@ -1,0 +1,76 @@
+package validation
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// cacheHitsTotal tracks the total number of validation cache hits.
+	cacheHitsTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "saga_validation_cache_hits_total",
+			Help: "Total number of validation cache hits",
+		},
+	)
+
+	// cacheMissesTotal tracks the total number of validation cache misses.
+	cacheMissesTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "saga_validation_cache_misses_total",
+			Help: "Total number of validation cache misses",
+		},
+	)
+
+	// cacheSize tracks the current number of entries in the validation cache.
+	cacheSize = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "saga_validation_cache_size",
+			Help: "Current number of entries in validation cache",
+		},
+	)
+
+	// cacheEvictionsTotal tracks the total cache evictions by reason.
+	// Labels: reason ("ttl" for TTL expiration, "lru" for LRU eviction)
+	cacheEvictionsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "saga_validation_cache_evictions_total",
+			Help: "Total cache evictions by reason",
+		},
+		[]string{"reason"},
+	)
+)
+
+// RecordCacheHit records a validation cache hit.
+func RecordCacheHit() {
+	cacheHitsTotal.Inc()
+}
+
+// RecordCacheMiss records a validation cache miss.
+func RecordCacheMiss() {
+	cacheMissesTotal.Inc()
+}
+
+// RecordCacheSize updates the cache size gauge.
+func RecordCacheSize(size int) {
+	cacheSize.Set(float64(size))
+}
+
+// RecordCacheEviction records a cache eviction with the given reason.
+// Valid reasons: "ttl" (TTL expiration), "lru" (LRU eviction)
+func RecordCacheEviction(reason string) {
+	cacheEvictionsTotal.WithLabelValues(reason).Inc()
+}
+
+// ExposeValidationCacheMetricsForTesting provides access to raw Prometheus metrics for testing.
+var ExposeValidationCacheMetricsForTesting = struct {
+	HitsTotal      prometheus.Counter
+	MissesTotal    prometheus.Counter
+	Size           prometheus.Gauge
+	EvictionsTotal *prometheus.CounterVec
+}{
+	HitsTotal:      cacheHitsTotal,
+	MissesTotal:    cacheMissesTotal,
+	Size:           cacheSize,
+	EvictionsTotal: cacheEvictionsTotal,
+}

--- a/shared/pkg/saga/validation/cache_test.go
+++ b/shared/pkg/saga/validation/cache_test.go
@@ -1,0 +1,316 @@
+// Package validation provides dry-run validation for Starlark saga scripts.
+package validation
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidationCache_GetMiss(t *testing.T) {
+	cache := NewCache(time.Hour, 1000)
+
+	result, ok := cache.Get("new script")
+	assert.False(t, ok, "expected cache miss for new script")
+	assert.Nil(t, result, "expected nil result on cache miss")
+}
+
+func TestValidationCache_SetAndGet(t *testing.T) {
+	cache := NewCache(time.Hour, 1000)
+
+	expected := &ValidationResult{
+		Success: true,
+		Errors:  []ValidationError{},
+		Metrics: ComplexityMetrics{HandlerCallCount: 5},
+	}
+
+	cache.Set("test script", expected)
+	result, ok := cache.Get("test script")
+
+	assert.True(t, ok, "expected cache hit")
+	require.NotNil(t, result)
+	assert.Equal(t, expected.Success, result.Success)
+	assert.Equal(t, expected.Metrics.HandlerCallCount, result.Metrics.HandlerCallCount)
+}
+
+func TestValidationCache_DifferentScriptsMiss(t *testing.T) {
+	cache := NewCache(time.Hour, 1000)
+
+	result1 := &ValidationResult{Success: true}
+	cache.Set("script 1", result1)
+
+	result, ok := cache.Get("script 2")
+	assert.False(t, ok, "expected cache miss for different script")
+	assert.Nil(t, result)
+}
+
+func TestValidationCache_SameHashForIdenticalScripts(t *testing.T) {
+	cache := NewCache(time.Hour, 1000)
+
+	expected := &ValidationResult{Success: true}
+	cache.Set("identical script", expected)
+
+	// Same content should produce same hash and cache hit
+	result, ok := cache.Get("identical script")
+	assert.True(t, ok, "expected cache hit for identical script")
+	require.NotNil(t, result)
+	assert.Equal(t, expected.Success, result.Success)
+}
+
+func TestValidationCache_TTLExpiration(t *testing.T) {
+	// Use very short TTL for testing
+	cache := NewCache(50*time.Millisecond, 1000)
+
+	expected := &ValidationResult{Success: true}
+	cache.Set("expiring script", expected)
+
+	// Should hit immediately
+	result, ok := cache.Get("expiring script")
+	assert.True(t, ok, "expected cache hit before TTL")
+	require.NotNil(t, result)
+
+	// Wait for TTL to expire
+	time.Sleep(60 * time.Millisecond)
+
+	// Should miss after TTL
+	result, ok = cache.Get("expiring script")
+	assert.False(t, ok, "expected cache miss after TTL expiration")
+	assert.Nil(t, result)
+}
+
+func TestValidationCache_LRUEviction(t *testing.T) {
+	// Create small cache to test LRU eviction
+	cache := NewCache(time.Hour, 3)
+
+	// Add 3 entries
+	cache.Set("script1", &ValidationResult{Success: true})
+	cache.Set("script2", &ValidationResult{Success: true})
+	cache.Set("script3", &ValidationResult{Success: true})
+
+	// All 3 should be present
+	_, ok1 := cache.Get("script1")
+	_, ok2 := cache.Get("script2")
+	_, ok3 := cache.Get("script3")
+	assert.True(t, ok1 && ok2 && ok3, "all 3 entries should be present")
+
+	// Access script1 to make it most recently used
+	cache.Get("script1")
+
+	// Add 4th entry - should evict script2 (least recently used)
+	cache.Set("script4", &ValidationResult{Success: true})
+
+	// script1, script3, script4 should be present; script2 should be evicted
+	_, ok1 = cache.Get("script1")
+	_, ok2 = cache.Get("script2")
+	_, ok3 = cache.Get("script3")
+	_, ok4 := cache.Get("script4")
+
+	assert.True(t, ok1, "script1 should still be present (was accessed)")
+	assert.False(t, ok2, "script2 should be evicted (LRU)")
+	assert.True(t, ok3, "script3 should still be present")
+	assert.True(t, ok4, "script4 should be present")
+}
+
+func TestValidationCache_EvictExpired(t *testing.T) {
+	cache := NewCache(50*time.Millisecond, 1000)
+
+	cache.Set("script1", &ValidationResult{Success: true})
+	cache.Set("script2", &ValidationResult{Success: true})
+
+	// Wait for TTL to expire
+	time.Sleep(60 * time.Millisecond)
+
+	// Add a new entry that won't be expired
+	cache.Set("script3", &ValidationResult{Success: true})
+
+	// Evict expired entries
+	cache.EvictExpired()
+
+	// script1 and script2 should be gone, script3 should remain
+	_, ok1 := cache.Get("script1")
+	_, ok2 := cache.Get("script2")
+	_, ok3 := cache.Get("script3")
+
+	assert.False(t, ok1, "script1 should be evicted (expired)")
+	assert.False(t, ok2, "script2 should be evicted (expired)")
+	assert.True(t, ok3, "script3 should still be present")
+}
+
+func TestValidationCache_ConcurrentAccess(_ *testing.T) {
+	cache := NewCache(time.Hour, 1000)
+
+	const numGoroutines = 50
+	const numOperations = 100
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < numOperations; j++ {
+				script := "script content " + string(rune('A'+(id+j)%26))
+				cache.Set(script, &ValidationResult{Success: true})
+				cache.Get(script)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	// If we get here without deadlock or panic, concurrent access is safe
+}
+
+func TestValidationCache_ConcurrentMixedOperations(_ *testing.T) {
+	cache := NewCache(100*time.Millisecond, 100)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start background eviction
+	cache.Start(ctx)
+
+	const numGoroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				script := "mixed script " + string(rune('A'+(id+j)%26))
+				cache.Set(script, &ValidationResult{Success: true})
+				cache.Get(script)
+				time.Sleep(5 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	// Test passes if no deadlock or race condition
+}
+
+func TestValidationCache_StartStop(t *testing.T) {
+	cache := NewCache(50*time.Millisecond, 1000)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cache.Set("script1", &ValidationResult{Success: true})
+
+	// Start background eviction
+	cache.Start(ctx)
+
+	// Let some eviction cycles run
+	time.Sleep(200 * time.Millisecond)
+
+	// Cancel context to stop background eviction
+	cancel()
+
+	// Give goroutine time to stop
+	time.Sleep(50 * time.Millisecond)
+
+	// Cache should still work after stop
+	cache.Set("script2", &ValidationResult{Success: true})
+	result, ok := cache.Get("script2")
+	assert.True(t, ok, "cache should work after background eviction stopped")
+	require.NotNil(t, result)
+}
+
+func TestValidationCache_Size(t *testing.T) {
+	cache := NewCache(time.Hour, 1000)
+
+	assert.Equal(t, 0, cache.Size(), "empty cache should have size 0")
+
+	cache.Set("script1", &ValidationResult{Success: true})
+	assert.Equal(t, 1, cache.Size())
+
+	cache.Set("script2", &ValidationResult{Success: true})
+	assert.Equal(t, 2, cache.Size())
+
+	// Same script should not increase size
+	cache.Set("script1", &ValidationResult{Success: false})
+	assert.Equal(t, 2, cache.Size())
+}
+
+func TestValidationCache_Clear(t *testing.T) {
+	cache := NewCache(time.Hour, 1000)
+
+	cache.Set("script1", &ValidationResult{Success: true})
+	cache.Set("script2", &ValidationResult{Success: true})
+
+	cache.Clear()
+
+	assert.Equal(t, 0, cache.Size())
+	_, ok := cache.Get("script1")
+	assert.False(t, ok, "cache should be empty after clear")
+}
+
+func TestValidationCache_ZeroTTL(t *testing.T) {
+	// Zero TTL means no expiration
+	cache := NewCache(0, 1000)
+
+	cache.Set("script", &ValidationResult{Success: true})
+
+	time.Sleep(10 * time.Millisecond)
+
+	result, ok := cache.Get("script")
+	assert.True(t, ok, "entry should not expire with zero TTL")
+	require.NotNil(t, result)
+}
+
+func TestValidationCache_UnlimitedSize(t *testing.T) {
+	// Zero maxSize means unlimited
+	cache := NewCache(time.Hour, 0)
+
+	for i := 0; i < 100; i++ {
+		cache.Set("script "+string(rune('A'+i%26))+string(rune('0'+i/26)), &ValidationResult{Success: true})
+	}
+
+	assert.Equal(t, 100, cache.Size(), "unlimited cache should hold all entries")
+}
+
+func BenchmarkValidationCache_Get(b *testing.B) {
+	cache := NewCache(time.Hour, 10000)
+
+	// Pre-populate cache
+	for i := 0; i < 1000; i++ {
+		cache.Set("benchmark script "+string(rune(i)), &ValidationResult{Success: true})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Get("benchmark script " + string(rune(i%1000)))
+	}
+}
+
+func BenchmarkValidationCache_Set(b *testing.B) {
+	cache := NewCache(time.Hour, 10000)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.Set("benchmark script "+string(rune(i%1000)), &ValidationResult{Success: true})
+	}
+}
+
+func BenchmarkValidationCache_ConcurrentAccess(b *testing.B) {
+	cache := NewCache(time.Hour, 10000)
+
+	// Pre-populate cache
+	for i := 0; i < 1000; i++ {
+		cache.Set("benchmark script "+string(rune(i)), &ValidationResult{Success: true})
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			script := "benchmark script " + string(rune(i%1000))
+			cache.Get(script)
+			cache.Set(script, &ValidationResult{Success: true})
+			i++
+		}
+	})
+}

--- a/shared/pkg/saga/validation/cached_validator.go
+++ b/shared/pkg/saga/validation/cached_validator.go
@@ -2,8 +2,12 @@ package validation
 
 import (
 	"context"
+	"errors"
 	"time"
 )
+
+// ErrValidatorRequired is returned when NewCachedValidator is called with a nil Validator.
+var ErrValidatorRequired = errors.New("validator is required")
 
 // CachedValidator wraps a DryRunValidator with a caching layer.
 // It caches successful validation results by script content hash,
@@ -36,9 +40,14 @@ const DefaultCacheTTL = time.Hour
 const DefaultCacheMaxSize = 1000
 
 // NewCachedValidator creates a new CachedValidator wrapping the given validator.
+// Returns ErrValidatorRequired if cfg.Validator is nil.
 // If cfg.TTL is 0, DefaultCacheTTL (1 hour) is used.
 // If cfg.MaxSize is 0, DefaultCacheMaxSize (1000) is used.
-func NewCachedValidator(cfg CachedValidatorConfig) *CachedValidator {
+func NewCachedValidator(cfg CachedValidatorConfig) (*CachedValidator, error) {
+	if cfg.Validator == nil {
+		return nil, ErrValidatorRequired
+	}
+
 	ttl := cfg.TTL
 	if ttl == 0 {
 		ttl = DefaultCacheTTL
@@ -52,7 +61,7 @@ func NewCachedValidator(cfg CachedValidatorConfig) *CachedValidator {
 	return &CachedValidator{
 		validator: cfg.Validator,
 		cache:     NewCache(ttl, maxSize),
-	}
+	}, nil
 }
 
 // Validate validates a Starlark script, using cached results when available.

--- a/shared/pkg/saga/validation/cached_validator.go
+++ b/shared/pkg/saga/validation/cached_validator.go
@@ -1,0 +1,115 @@
+package validation
+
+import (
+	"context"
+	"time"
+)
+
+// CachedValidator wraps a DryRunValidator with a caching layer.
+// It caches successful validation results by script content hash,
+// avoiding redundant validations for unchanged scripts.
+//
+// Only successful validation results are cached. Failed validations
+// are not cached to avoid caching transient failures or scripts
+// that might be fixed and re-validated.
+type CachedValidator struct {
+	validator *DryRunValidator
+	cache     *Cache
+}
+
+// CachedValidatorConfig configures a CachedValidator.
+type CachedValidatorConfig struct {
+	// Validator is the underlying DryRunValidator to wrap.
+	Validator *DryRunValidator
+
+	// TTL is the time-to-live for cache entries. Default: 1 hour.
+	TTL time.Duration
+
+	// MaxSize is the maximum number of cached entries. Default: 1000.
+	MaxSize int
+}
+
+// DefaultCacheTTL is the default cache entry time-to-live.
+const DefaultCacheTTL = time.Hour
+
+// DefaultCacheMaxSize is the default maximum cache size.
+const DefaultCacheMaxSize = 1000
+
+// NewCachedValidator creates a new CachedValidator wrapping the given validator.
+// If cfg.TTL is 0, DefaultCacheTTL (1 hour) is used.
+// If cfg.MaxSize is 0, DefaultCacheMaxSize (1000) is used.
+func NewCachedValidator(cfg CachedValidatorConfig) *CachedValidator {
+	ttl := cfg.TTL
+	if ttl == 0 {
+		ttl = DefaultCacheTTL
+	}
+
+	maxSize := cfg.MaxSize
+	if maxSize == 0 {
+		maxSize = DefaultCacheMaxSize
+	}
+
+	return &CachedValidator{
+		validator: cfg.Validator,
+		cache:     NewCache(ttl, maxSize),
+	}
+}
+
+// Validate validates a Starlark script, using cached results when available.
+//
+// If the script has been successfully validated before and the cache entry
+// hasn't expired, the cached result is returned immediately without
+// re-executing the validation.
+//
+// Only successful validation results are cached. Failed validations
+// always trigger a fresh validation to ensure updated scripts or
+// fixed issues are detected.
+func (v *CachedValidator) Validate(ctx context.Context, script string) (*ValidationResult, error) {
+	// Check cache first
+	if result, ok := v.cache.Get(script); ok {
+		return result, nil
+	}
+
+	// Cache miss - perform actual validation
+	result, err := v.validator.Validate(ctx, script)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only cache successful results
+	if result.Success {
+		v.cache.Set(script, result)
+	}
+
+	return result, nil
+}
+
+// Start begins background eviction of expired cache entries.
+// Call this method once during application startup.
+// The background goroutine runs until the context is cancelled.
+func (v *CachedValidator) Start(ctx context.Context) {
+	v.cache.Start(ctx)
+}
+
+// CacheSize returns the current number of entries in the cache.
+func (v *CachedValidator) CacheSize() int {
+	return v.cache.Size()
+}
+
+// ClearCache removes all entries from the cache.
+func (v *CachedValidator) ClearCache() {
+	v.cache.Clear()
+}
+
+// Cache returns the underlying ValidationCache for advanced operations.
+// This is primarily useful for testing or exposing cache metrics.
+func (v *CachedValidator) Cache() *Cache {
+	return v.cache
+}
+
+// UnderlyingValidator returns the wrapped DryRunValidator.
+// This allows access to the original validator for operations
+// that should bypass the cache.
+func (v *CachedValidator) UnderlyingValidator() *DryRunValidator {
+	return v.validator
+}

--- a/shared/pkg/saga/validation/cached_validator_test.go
+++ b/shared/pkg/saga/validation/cached_validator_test.go
@@ -34,11 +34,12 @@ handlers:
 	require.NoError(t, err)
 
 	// Create cached validator with short TTL for testing
-	cached := NewCachedValidator(CachedValidatorConfig{
+	cached, err := NewCachedValidator(CachedValidatorConfig{
 		Validator: validator,
 		TTL:       time.Minute,
 		MaxSize:   100,
 	})
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	script := `result = test.echo(message="hello")`
@@ -82,11 +83,12 @@ handlers:
 	validator, err := NewMockValidatorForTesting(schemaReg)
 	require.NoError(t, err)
 
-	cached := NewCachedValidator(CachedValidatorConfig{
+	cached, err := NewCachedValidator(CachedValidatorConfig{
 		Validator: validator,
 		TTL:       time.Minute,
 		MaxSize:   100,
 	})
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	script1 := `result = test.handler1()`
@@ -122,11 +124,12 @@ handlers:
 	validator, err := NewMockValidatorForTesting(schemaReg)
 	require.NoError(t, err)
 
-	cached := NewCachedValidator(CachedValidatorConfig{
+	cached, err := NewCachedValidator(CachedValidatorConfig{
 		Validator: validator,
 		TTL:       time.Minute,
 		MaxSize:   100,
 	})
+	require.NoError(t, err)
 
 	ctx := context.Background()
 
@@ -159,11 +162,12 @@ handlers:
 	validator, err := NewMockValidatorForTesting(schemaReg)
 	require.NoError(t, err)
 
-	cached := NewCachedValidator(CachedValidatorConfig{
+	cached, err := NewCachedValidator(CachedValidatorConfig{
 		Validator: validator,
 		TTL:       time.Minute,
 		MaxSize:   100,
 	})
+	require.NoError(t, err)
 
 	ctx := context.Background()
 	script := `result = test.handler()`
@@ -196,9 +200,10 @@ handlers:
 	require.NoError(t, err)
 
 	// Create with zero values - should use defaults
-	cached := NewCachedValidator(CachedValidatorConfig{
+	cached, err := NewCachedValidator(CachedValidatorConfig{
 		Validator: validator,
 	})
+	require.NoError(t, err)
 
 	// Should work with default TTL and MaxSize
 	ctx := context.Background()
@@ -210,14 +215,23 @@ handlers:
 	assert.Equal(t, 1, cached.CacheSize())
 }
 
+func TestCachedValidator_NilValidator(t *testing.T) {
+	_, err := NewCachedValidator(CachedValidatorConfig{
+		Validator: nil,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrValidatorRequired)
+}
+
 func TestCachedValidator_UnderlyingValidator(t *testing.T) {
 	schemaReg := schema.NewRegistry()
 	validator, err := NewMockValidatorForTesting(schemaReg)
 	require.NoError(t, err)
 
-	cached := NewCachedValidator(CachedValidatorConfig{
+	cached, err := NewCachedValidator(CachedValidatorConfig{
 		Validator: validator,
 	})
+	require.NoError(t, err)
 
 	// Should return the same validator
 	assert.Equal(t, validator, cached.UnderlyingValidator())
@@ -228,9 +242,10 @@ func TestCachedValidator_Cache(t *testing.T) {
 	validator, err := NewMockValidatorForTesting(schemaReg)
 	require.NoError(t, err)
 
-	cached := NewCachedValidator(CachedValidatorConfig{
+	cached, err := NewCachedValidator(CachedValidatorConfig{
 		Validator: validator,
 	})
+	require.NoError(t, err)
 
 	// Should return non-nil cache
 	assert.NotNil(t, cached.Cache())
@@ -253,11 +268,12 @@ handlers:
 	validator, err := NewMockValidatorForTesting(schemaReg)
 	require.NoError(t, err)
 
-	cached := NewCachedValidator(CachedValidatorConfig{
+	cached, err := NewCachedValidator(CachedValidatorConfig{
 		Validator: validator,
 		TTL:       50 * time.Millisecond,
 		MaxSize:   100,
 	})
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/shared/pkg/saga/validation/cached_validator_test.go
+++ b/shared/pkg/saga/validation/cached_validator_test.go
@@ -1,0 +1,280 @@
+package validation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCachedValidator_CacheHit(t *testing.T) {
+	// Create a schema registry with a mock handler
+	schemaReg := schema.NewRegistry()
+	schemaYAML := `
+service: test
+version: 1.0
+handlers:
+  test.echo:
+    description: Test echo handler
+    params:
+      message:
+        type: string
+        required: false
+    returns:
+      result:
+        type: string
+`
+	require.NoError(t, schemaReg.LoadFromYAML([]byte(schemaYAML)))
+
+	// Create the underlying validator
+	validator, err := NewMockValidatorForTesting(schemaReg)
+	require.NoError(t, err)
+
+	// Create cached validator with short TTL for testing
+	cached := NewCachedValidator(CachedValidatorConfig{
+		Validator: validator,
+		TTL:       time.Minute,
+		MaxSize:   100,
+	})
+
+	ctx := context.Background()
+	script := `result = test.echo(message="hello")`
+
+	// First call - cache miss
+	result1, err := cached.Validate(ctx, script)
+	require.NoError(t, err)
+	assert.True(t, result1.Success)
+
+	// Second call - should be cache hit
+	result2, err := cached.Validate(ctx, script)
+	require.NoError(t, err)
+	assert.True(t, result2.Success)
+
+	// Results should be the same object (from cache)
+	assert.Equal(t, result1, result2)
+
+	// Cache should have 1 entry
+	assert.Equal(t, 1, cached.CacheSize())
+}
+
+func TestCachedValidator_CacheMissOnDifferentScript(t *testing.T) {
+	schemaReg := schema.NewRegistry()
+	schemaYAML := `
+service: test
+version: 1.0
+handlers:
+  test.handler1:
+    params: {}
+    returns:
+      result:
+        type: string
+  test.handler2:
+    params: {}
+    returns:
+      result:
+        type: string
+`
+	require.NoError(t, schemaReg.LoadFromYAML([]byte(schemaYAML)))
+
+	validator, err := NewMockValidatorForTesting(schemaReg)
+	require.NoError(t, err)
+
+	cached := NewCachedValidator(CachedValidatorConfig{
+		Validator: validator,
+		TTL:       time.Minute,
+		MaxSize:   100,
+	})
+
+	ctx := context.Background()
+	script1 := `result = test.handler1()`
+	script2 := `result = test.handler2()`
+
+	// Validate both scripts
+	result1, err := cached.Validate(ctx, script1)
+	require.NoError(t, err)
+	assert.True(t, result1.Success)
+
+	result2, err := cached.Validate(ctx, script2)
+	require.NoError(t, err)
+	assert.True(t, result2.Success)
+
+	// Cache should have 2 entries
+	assert.Equal(t, 2, cached.CacheSize())
+}
+
+func TestCachedValidator_DoesNotCacheFailures(t *testing.T) {
+	schemaReg := schema.NewRegistry()
+	schemaYAML := `
+service: test
+version: 1.0
+handlers:
+  test.valid_handler:
+    params: {}
+    returns:
+      result:
+        type: string
+`
+	require.NoError(t, schemaReg.LoadFromYAML([]byte(schemaYAML)))
+
+	validator, err := NewMockValidatorForTesting(schemaReg)
+	require.NoError(t, err)
+
+	cached := NewCachedValidator(CachedValidatorConfig{
+		Validator: validator,
+		TTL:       time.Minute,
+		MaxSize:   100,
+	})
+
+	ctx := context.Background()
+
+	// Script with syntax error
+	invalidScript := `this is not valid starlark (`
+
+	result, err := cached.Validate(ctx, invalidScript)
+	require.NoError(t, err) // Validation errors are in result, not returned as error
+	assert.False(t, result.Success)
+	assert.NotEmpty(t, result.Errors)
+
+	// Cache should be empty - failed validations are not cached
+	assert.Equal(t, 0, cached.CacheSize())
+}
+
+func TestCachedValidator_ClearCache(t *testing.T) {
+	schemaReg := schema.NewRegistry()
+	schemaYAML := `
+service: test
+version: 1.0
+handlers:
+  test.handler:
+    params: {}
+    returns:
+      result:
+        type: string
+`
+	require.NoError(t, schemaReg.LoadFromYAML([]byte(schemaYAML)))
+
+	validator, err := NewMockValidatorForTesting(schemaReg)
+	require.NoError(t, err)
+
+	cached := NewCachedValidator(CachedValidatorConfig{
+		Validator: validator,
+		TTL:       time.Minute,
+		MaxSize:   100,
+	})
+
+	ctx := context.Background()
+	script := `result = test.handler()`
+
+	// Validate to populate cache
+	_, err = cached.Validate(ctx, script)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cached.CacheSize())
+
+	// Clear cache
+	cached.ClearCache()
+	assert.Equal(t, 0, cached.CacheSize())
+}
+
+func TestCachedValidator_DefaultConfig(t *testing.T) {
+	schemaReg := schema.NewRegistry()
+	schemaYAML := `
+service: test
+version: 1.0
+handlers:
+  test.handler:
+    params: {}
+    returns:
+      result:
+        type: string
+`
+	require.NoError(t, schemaReg.LoadFromYAML([]byte(schemaYAML)))
+
+	validator, err := NewMockValidatorForTesting(schemaReg)
+	require.NoError(t, err)
+
+	// Create with zero values - should use defaults
+	cached := NewCachedValidator(CachedValidatorConfig{
+		Validator: validator,
+	})
+
+	// Should work with default TTL and MaxSize
+	ctx := context.Background()
+	script := `result = test.handler()`
+
+	result, err := cached.Validate(ctx, script)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, 1, cached.CacheSize())
+}
+
+func TestCachedValidator_UnderlyingValidator(t *testing.T) {
+	schemaReg := schema.NewRegistry()
+	validator, err := NewMockValidatorForTesting(schemaReg)
+	require.NoError(t, err)
+
+	cached := NewCachedValidator(CachedValidatorConfig{
+		Validator: validator,
+	})
+
+	// Should return the same validator
+	assert.Equal(t, validator, cached.UnderlyingValidator())
+}
+
+func TestCachedValidator_Cache(t *testing.T) {
+	schemaReg := schema.NewRegistry()
+	validator, err := NewMockValidatorForTesting(schemaReg)
+	require.NoError(t, err)
+
+	cached := NewCachedValidator(CachedValidatorConfig{
+		Validator: validator,
+	})
+
+	// Should return non-nil cache
+	assert.NotNil(t, cached.Cache())
+}
+
+func TestCachedValidator_StartStop(t *testing.T) {
+	schemaReg := schema.NewRegistry()
+	schemaYAML := `
+service: test
+version: 1.0
+handlers:
+  test.handler:
+    params: {}
+    returns:
+      result:
+        type: string
+`
+	require.NoError(t, schemaReg.LoadFromYAML([]byte(schemaYAML)))
+
+	validator, err := NewMockValidatorForTesting(schemaReg)
+	require.NoError(t, err)
+
+	cached := NewCachedValidator(CachedValidatorConfig{
+		Validator: validator,
+		TTL:       50 * time.Millisecond,
+		MaxSize:   100,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start background eviction
+	cached.Start(ctx)
+
+	// Validate to populate cache
+	script := `result = test.handler()`
+	_, err = cached.Validate(ctx, script)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cached.CacheSize())
+
+	// Cancel context to stop background eviction
+	cancel()
+
+	// Validator should still work after stop
+	_, err = cached.Validate(context.Background(), script)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary

Add in-memory caching layer for Starlark saga script validation results to optimize repeated validations, especially useful for CI/CD pipelines.

## Changes Made

- **cache.go**: Core `Cache` struct with SHA256 content hashing, LRU eviction, TTL expiration, and thread-safe operations
- **cache_metrics.go**: Prometheus metrics for observability (hits, misses, size, evictions by reason)
- **cached_validator.go**: `CachedValidator` wrapper that integrates cache with `DryRunValidator`
- **cache_test.go**: Comprehensive tests for cache behavior including concurrent access, LRU eviction, TTL expiration
- **cached_validator_test.go**: Integration tests for cached validation

## Technical Details

- **Cache key**: SHA256 hash of script content (collision-resistant)
- **Default TTL**: 1 hour (configurable)
- **Default max size**: 1000 entries (configurable)
- **Eviction**: LRU when at capacity, TTL-based with background goroutine every 10 minutes
- **Thread safety**: `sync.RWMutex` for concurrent access
- **Caching policy**: Only successful validations are cached to avoid caching transient failures

## Testing

- Unit tests with race detector pass
- Concurrent access tests verify thread safety
- TTL and LRU eviction tests verify correct behavior
- Benchmarks included for performance measurement

## Task Master Reference

| TM Task | Description |
|---------|-------------|
| saga-script-versioning.31 | Create validation caching layer |