### PR TITLE
feat: Add observability for silent failures and production readiness monitoring

### DIFF
--- a/deployments/grafana/dashboards/production-readiness.json
+++ b/deployments/grafana/dashboards/production-readiness.json
@@ -1,0 +1,1384 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Production Readiness Monitoring - Silent failures, degraded services, and regulatory compliance metrics.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "panels": [],
+      "title": "Production Readiness Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "HEALTHY"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "from": 1,
+                "result": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "DEGRADED"
+                },
+                "to": 100
+              },
+              "type": "range"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "financial_accounting_noop_idempotency_active + financial_accounting_noop_event_publisher_active",
+          "legendFormat": "NoOp Services Active",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "NoOp Services Status",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "increase(payment_order_lien_execution_retries_exhausted_total[1h])",
+          "legendFormat": "Exhausted",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Lien Retries Exhausted (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(current_account_webhook_delivery_exhausted_total[1h]))",
+          "legendFormat": "Failed",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Webhook Delivery Failures (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(payment_order_bucket_evaluation_failures_total[1h]))",
+          "legendFormat": "Failures",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Bucket Eval Failures (1h)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Bucket Evaluation (Payment Order)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(payment_order_bucket_evaluations_total[5m])) by (status)",
+          "legendFormat": "{{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Bucket Evaluation Rate by Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(payment_order_bucket_evaluation_failures_total[5m])) by (error_type)",
+          "legendFormat": "{{error_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Bucket Evaluation Failures by Error Type",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "p99"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(payment_order_bucket_evaluation_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(payment_order_bucket_evaluation_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(payment_order_bucket_evaluation_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Bucket Evaluation Latency",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 10,
+      "panels": [],
+      "title": "Webhook Delivery (Current Account)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*failed.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*success.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(current_account_webhook_delivery_attempts_total[5m])) by (event_type, status)",
+          "legendFormat": "{{event_type}} - {{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Webhook Delivery Rate by Event Type and Status",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(current_account_webhook_delivery_exhausted_total[1h])) by (event_type)",
+          "legendFormat": "{{event_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Webhook Delivery Exhausted (Regulatory Risk)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 13,
+      "panels": [],
+      "title": "Lien Execution (Payment Order)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*exhausted.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*success.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*failed.*"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(payment_order_lien_execution_retries_total[5m])) by (outcome)",
+          "legendFormat": "{{outcome}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Lien Execution Retry Rate by Outcome",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "increase(payment_order_lien_execution_retries_exhausted_total[1h])",
+          "legendFormat": "Retries Exhausted",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "increase(payment_order_lien_execution_status_update_exhausted_total[1h])",
+          "legendFormat": "Status Update Exhausted",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Lien Execution Exhaustion Events (Payment Stuck Risk)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 16,
+      "panels": [],
+      "title": "NoOp Fallback Status (Financial Accounting)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "PRODUCTION READY"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "NOOP ACTIVE"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 41
+      },
+      "id": 17,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "financial_accounting_noop_idempotency_active",
+          "legendFormat": "Idempotency",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Idempotency Service",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "PRODUCTION READY"
+                },
+                "1": {
+                  "color": "red",
+                  "index": 1,
+                  "text": "NOOP ACTIVE"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 41
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "financial_accounting_noop_event_publisher_active",
+          "legendFormat": "Event Publisher",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Event Publisher",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 19,
+      "options": {
+        "legend": {
+          "calcs": ["sum"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(financial_accounting_service_degradation_events_total[24h])) by (component, reason)",
+          "legendFormat": "{{component}} - {{reason}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Service Degradation Events (24h)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["production-readiness", "silent-failures", "regulatory-compliance"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Production Readiness Monitoring",
+  "uid": "production-readiness",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deployments/prometheus/alerts/production-readiness.yml
+++ b/deployments/prometheus/alerts/production-readiness.yml
@@ -21,8 +21,8 @@ groups:
       - alert: BucketEvaluationFailureRateHigh
         expr: |
           (
-            rate(payment_order_bucket_evaluation_failures_total[5m])
-            / clamp_min(rate(payment_order_bucket_evaluations_total[5m]), 0.0001)
+            sum(rate(payment_order_bucket_evaluation_failures_total[5m]))
+            / clamp_min(sum(rate(payment_order_bucket_evaluations_total[5m])), 0.0001)
           ) > 0.10
         for: 5m
         labels:
@@ -30,9 +30,9 @@ groups:
           service: payment-order
           category: silent_failure
         annotations:
-          summary: "High bucket evaluation failure rate ({{ $labels.instrument_code }})"
+          summary: "High bucket evaluation failure rate"
           description: |
-            Bucket evaluation is failing at {{ $value | humanizePercentage }} for instrument {{ $labels.instrument_code }}.
+            Bucket evaluation is failing at {{ $value | humanizePercentage }}.
             This may indicate reference-data service unavailability or invalid CEL expressions.
             Payments will continue with default bucket (graceful degradation), but bucket-aware solvency validation is compromised.
           runbook_url: "https://docs.meridian.io/runbooks/bucket-evaluation-failure"
@@ -40,7 +40,7 @@ groups:
       # Sustained bucket evaluation failures - degraded solvency validation
       - alert: BucketEvaluationFailuresSustained
         expr: |
-          increase(payment_order_bucket_evaluation_failures_total[15m]) > 50
+          sum(increase(payment_order_bucket_evaluation_failures_total[15m])) > 50
         for: 10m
         labels:
           severity: critical
@@ -50,7 +50,6 @@ groups:
           summary: "Sustained bucket evaluation failures detected"
           description: |
             More than 50 bucket evaluation failures in the last 15 minutes.
-            Error type: {{ $labels.error_type }}, Instrument: {{ $labels.instrument_code }}.
             Bucket-aware solvency validation is severely degraded.
           runbook_url: "https://docs.meridian.io/runbooks/bucket-evaluation-failure"
 
@@ -63,8 +62,8 @@ groups:
       - alert: WebhookDeliveryFailureRateHigh
         expr: |
           (
-            rate(current_account_webhook_delivery_attempts_total{status="failed"}[5m])
-            / clamp_min(rate(current_account_webhook_delivery_attempts_total{status!="skipped"}[5m]), 0.0001)
+            sum by (event_type) (rate(current_account_webhook_delivery_attempts_total{status="failed"}[5m]))
+            / clamp_min(sum by (event_type) (rate(current_account_webhook_delivery_attempts_total{status!="skipped"}[5m])), 0.0001)
           ) > 0.05
         for: 5m
         labels:
@@ -192,8 +191,8 @@ groups:
       - alert: LienExecutionFailureRateHigh
         expr: |
           (
-            rate(payment_order_lien_execution_retries_total{outcome="failed"}[5m])
-            / clamp_min(rate(payment_order_lien_execution_retries_total{outcome="attempt"}[5m]), 0.0001)
+            sum(rate(payment_order_lien_execution_retries_total{outcome="failed"}[5m]))
+            / clamp_min(sum(rate(payment_order_lien_execution_retries_total{outcome="attempt"}[5m])), 0.0001)
           ) > 0.20
         for: 5m
         labels:
@@ -235,9 +234,9 @@ groups:
       - record: production_readiness:silent_failure_rate:5m
         expr: |
           (
-            rate(payment_order_bucket_evaluation_failures_total[5m]) +
-            rate(current_account_webhook_delivery_attempts_total{status="failed"}[5m]) +
-            rate(payment_order_lien_execution_retries_exhausted_total[5m])
+            sum(rate(payment_order_bucket_evaluation_failures_total[5m])) +
+            sum(rate(current_account_webhook_delivery_attempts_total{status="failed"}[5m])) +
+            sum(rate(payment_order_lien_execution_retries_exhausted_total[5m]))
           )
 
       # NoOp services running (should be 0 in production)

--- a/deployments/prometheus/alerts/production-readiness.yml
+++ b/deployments/prometheus/alerts/production-readiness.yml
@@ -59,11 +59,12 @@ groups:
       # =============================================================================
 
       # Webhook delivery failures - regulatory compliance risk
+      # Note: Excludes status="skipped" from denominator since skipped webhooks (no config) aren't failures
       - alert: WebhookDeliveryFailureRateHigh
         expr: |
           (
             rate(current_account_webhook_delivery_attempts_total{status="failed"}[5m])
-            / clamp_min(rate(current_account_webhook_delivery_attempts_total[5m]), 0.0001)
+            / clamp_min(rate(current_account_webhook_delivery_attempts_total{status!="skipped"}[5m]), 0.0001)
           ) > 0.05
         for: 5m
         labels:
@@ -230,12 +231,13 @@ groups:
       # =============================================================================
 
       # Overall silent failure budget consumption
+      # Uses dedicated exhaustion counters for consistency with alerting rules
       - record: production_readiness:silent_failure_rate:5m
         expr: |
           (
             rate(payment_order_bucket_evaluation_failures_total[5m]) +
             rate(current_account_webhook_delivery_attempts_total{status="failed"}[5m]) +
-            rate(payment_order_lien_execution_retries_total{outcome="exhausted"}[5m])
+            rate(payment_order_lien_execution_retries_exhausted_total[5m])
           )
 
       # NoOp services running (should be 0 in production)

--- a/deployments/prometheus/alerts/production-readiness.yml
+++ b/deployments/prometheus/alerts/production-readiness.yml
@@ -1,0 +1,260 @@
+# Production Readiness Alert Rules
+#
+# These alerts monitor silent failures and degraded service states that could
+# impact production reliability and regulatory compliance.
+#
+# Categories:
+# 1. Bucket Evaluation Failures (payment-order)
+# 2. Webhook Delivery Failures (current-account) - Regulatory compliance risk
+# 3. NoOp Fallback Detection (financial-accounting) - Development mode in production
+# 4. Lien Execution Retry Exhaustion (payment-order) - Payment stuck risk
+
+groups:
+  - name: production_readiness_silent_failures
+    interval: 30s
+    rules:
+      # =============================================================================
+      # BUCKET EVALUATION ALERTS
+      # =============================================================================
+
+      # High bucket evaluation failure rate - may indicate reference-data service issues
+      - alert: BucketEvaluationFailureRateHigh
+        expr: |
+          (
+            rate(payment_order_bucket_evaluation_failures_total[5m])
+            / clamp_min(rate(payment_order_bucket_evaluations_total[5m]), 0.0001)
+          ) > 0.10
+        for: 5m
+        labels:
+          severity: warning
+          service: payment-order
+          category: silent_failure
+        annotations:
+          summary: "High bucket evaluation failure rate ({{ $labels.instrument_code }})"
+          description: |
+            Bucket evaluation is failing at {{ $value | humanizePercentage }} for instrument {{ $labels.instrument_code }}.
+            This may indicate reference-data service unavailability or invalid CEL expressions.
+            Payments will continue with default bucket (graceful degradation), but bucket-aware solvency validation is compromised.
+          runbook_url: "https://docs.meridian.io/runbooks/bucket-evaluation-failure"
+
+      # Sustained bucket evaluation failures - degraded solvency validation
+      - alert: BucketEvaluationFailuresSustained
+        expr: |
+          increase(payment_order_bucket_evaluation_failures_total[15m]) > 50
+        for: 10m
+        labels:
+          severity: critical
+          service: payment-order
+          category: silent_failure
+        annotations:
+          summary: "Sustained bucket evaluation failures detected"
+          description: |
+            More than 50 bucket evaluation failures in the last 15 minutes.
+            Error type: {{ $labels.error_type }}, Instrument: {{ $labels.instrument_code }}.
+            Bucket-aware solvency validation is severely degraded.
+          runbook_url: "https://docs.meridian.io/runbooks/bucket-evaluation-failure"
+
+      # =============================================================================
+      # WEBHOOK DELIVERY ALERTS (Regulatory Compliance)
+      # =============================================================================
+
+      # Webhook delivery failures - regulatory compliance risk
+      - alert: WebhookDeliveryFailureRateHigh
+        expr: |
+          (
+            rate(current_account_webhook_delivery_attempts_total{status="failed"}[5m])
+            / clamp_min(rate(current_account_webhook_delivery_attempts_total[5m]), 0.0001)
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+          service: current-account
+          category: regulatory_compliance
+        annotations:
+          summary: "High webhook delivery failure rate for {{ $labels.event_type }}"
+          description: |
+            Webhook delivery failure rate is {{ $value | humanizePercentage }} for event type {{ $labels.event_type }}.
+            REGULATORY COMPLIANCE RISK: Account freeze/close notifications may not be delivered to tenants.
+            Immediate investigation required.
+          runbook_url: "https://docs.meridian.io/runbooks/webhook-delivery-failure"
+
+      # Webhook delivery exhausted - critical regulatory alert
+      - alert: WebhookDeliveryExhausted
+        expr: |
+          increase(current_account_webhook_delivery_exhausted_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+          service: current-account
+          category: regulatory_compliance
+        annotations:
+          summary: "Webhook delivery failed after all retries for {{ $labels.event_type }}"
+          description: |
+            {{ $value }} webhook deliveries have exhausted all retries for {{ $labels.event_type }} events.
+            REGULATORY COMPLIANCE RISK: Tenants have not received required notifications.
+            Manual notification may be required.
+          runbook_url: "https://docs.meridian.io/runbooks/webhook-delivery-failure"
+
+      # High webhook retry rate - indicates endpoint instability
+      - alert: WebhookDeliveryHighRetryRate
+        expr: |
+          rate(current_account_webhook_delivery_retries_total[5m]) > 0.5
+        for: 10m
+        labels:
+          severity: warning
+          service: current-account
+          category: reliability
+        annotations:
+          summary: "High webhook delivery retry rate"
+          description: |
+            Webhook deliveries are retrying at {{ $value }} retries/second for {{ $labels.event_type }}.
+            This may indicate tenant webhook endpoint instability or network issues.
+          runbook_url: "https://docs.meridian.io/runbooks/webhook-delivery-failure"
+
+      # =============================================================================
+      # NOOP FALLBACK ALERTS (Development Mode in Production)
+      # =============================================================================
+
+      # NoOp idempotency service active - CRITICAL in production
+      - alert: NoopIdempotencyActiveInProduction
+        expr: |
+          financial_accounting_noop_idempotency_active == 1
+        for: 1m
+        labels:
+          severity: critical
+          service: financial-accounting
+          category: production_safety
+        annotations:
+          summary: "NoOp idempotency service active - DUPLICATE TRANSACTION RISK"
+          description: |
+            The financial-accounting service is running with a NoOp idempotency service.
+            CRITICAL: Duplicate transactions cannot be detected. This mode should NEVER run in production.
+            Immediate investigation of Redis connectivity required.
+          runbook_url: "https://docs.meridian.io/runbooks/noop-fallback-active"
+
+      # NoOp event publisher active - CRITICAL in production
+      - alert: NoopEventPublisherActiveInProduction
+        expr: |
+          financial_accounting_noop_event_publisher_active == 1
+        for: 1m
+        labels:
+          severity: critical
+          service: financial-accounting
+          category: production_safety
+        annotations:
+          summary: "NoOp event publisher active - EVENT DELIVERY DISABLED"
+          description: |
+            The financial-accounting service is running with a NoOp event publisher.
+            CRITICAL: Downstream services will not receive transaction events.
+            This mode should NEVER run in production.
+            Immediate investigation of Kafka connectivity required.
+          runbook_url: "https://docs.meridian.io/runbooks/noop-fallback-active"
+
+      # Service degradation events - warning for any component
+      - alert: ServiceDegradationDetected
+        expr: |
+          increase(financial_accounting_service_degradation_events_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          service: financial-accounting
+          category: reliability
+        annotations:
+          summary: "Service degradation detected in {{ $labels.component }}"
+          description: |
+            Financial accounting service has degraded functionality in {{ $labels.component }}.
+            Reason: {{ $labels.reason }}. This may indicate infrastructure issues.
+          runbook_url: "https://docs.meridian.io/runbooks/service-degradation"
+
+      # =============================================================================
+      # LIEN EXECUTION RETRY ALERTS
+      # =============================================================================
+
+      # Lien execution retries exhausted - payment stuck risk
+      - alert: LienExecutionRetriesExhausted
+        expr: |
+          increase(payment_order_lien_execution_retries_exhausted_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: critical
+          service: payment-order
+          category: payment_integrity
+        annotations:
+          summary: "Lien execution retries exhausted - payments may be stuck"
+          description: |
+            {{ $value }} payment orders have exhausted all lien execution retry attempts.
+            CRITICAL: These payments may be stuck in PENDING state requiring manual reconciliation.
+            Check current-account service health and database connectivity.
+          runbook_url: "https://docs.meridian.io/runbooks/lien-execution-failure"
+
+      # High lien execution failure rate
+      - alert: LienExecutionFailureRateHigh
+        expr: |
+          (
+            rate(payment_order_lien_execution_retries_total{outcome="failed"}[5m])
+            / clamp_min(rate(payment_order_lien_execution_retries_total{outcome="attempt"}[5m]), 0.0001)
+          ) > 0.20
+        for: 5m
+        labels:
+          severity: warning
+          service: payment-order
+          category: reliability
+        annotations:
+          summary: "High lien execution failure rate"
+          description: |
+            Lien execution is failing at {{ $value | humanizePercentage }} of attempts.
+            This may indicate current-account service issues or database contention.
+          runbook_url: "https://docs.meridian.io/runbooks/lien-execution-failure"
+
+      # Lien execution status update exhausted - reconciliation needed
+      - alert: LienExecutionStatusUpdateExhausted
+        expr: |
+          increase(payment_order_lien_execution_status_update_exhausted_total[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          service: payment-order
+          category: payment_integrity
+        annotations:
+          summary: "Lien execution status update failed - reconciliation needed"
+          description: |
+            {{ $value }} lien execution status updates failed after all retries due to version conflicts.
+            Payment orders may be stuck in PENDING state. Check idx_payment_orders_lien_execution partial index for affected records.
+          runbook_url: "https://docs.meridian.io/runbooks/lien-execution-failure"
+
+  - name: production_readiness_slo
+    interval: 60s
+    rules:
+      # =============================================================================
+      # SERVICE LEVEL OBJECTIVES
+      # =============================================================================
+
+      # Overall silent failure budget consumption
+      - record: production_readiness:silent_failure_rate:5m
+        expr: |
+          (
+            rate(payment_order_bucket_evaluation_failures_total[5m]) +
+            rate(current_account_webhook_delivery_attempts_total{status="failed"}[5m]) +
+            rate(payment_order_lien_execution_retries_total{outcome="exhausted"}[5m])
+          )
+
+      # NoOp services running (should be 0 in production)
+      - record: production_readiness:noop_services_active
+        expr: |
+          financial_accounting_noop_idempotency_active +
+          financial_accounting_noop_event_publisher_active
+
+      # Alert if any NoOp services are running
+      - alert: ProductionReadinessCompromised
+        expr: |
+          production_readiness:noop_services_active > 0
+        for: 1m
+        labels:
+          severity: critical
+          category: production_safety
+        annotations:
+          summary: "Production readiness compromised - {{ $value }} NoOp services active"
+          description: |
+            Production readiness is compromised with {{ $value }} NoOp fallback services active.
+            This represents a critical production safety risk. Immediate remediation required.
+          runbook_url: "https://docs.meridian.io/runbooks/production-readiness-compromised"

--- a/services/current-account/observability/metrics.go
+++ b/services/current-account/observability/metrics.go
@@ -146,6 +146,40 @@ var (
 		},
 		[]string{"clearing_type"},
 	)
+
+	// Webhook delivery metrics - tracks delivery attempts and failures for regulatory notifications
+	webhookDeliveryAttempts = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "current_account_webhook_delivery_attempts_total",
+			Help: "Total number of webhook delivery attempts by event type and status",
+		},
+		[]string{"event_type", "status"},
+	)
+
+	webhookDeliveryDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "current_account_webhook_delivery_duration_seconds",
+			Help:    "Time spent delivering webhooks by event type",
+			Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0},
+		},
+		[]string{"event_type"},
+	)
+
+	webhookDeliveryRetries = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "current_account_webhook_delivery_retries_total",
+			Help: "Total number of webhook delivery retries by event type",
+		},
+		[]string{"event_type"},
+	)
+
+	webhookDeliveryExhausted = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "current_account_webhook_delivery_exhausted_total",
+			Help: "Total number of webhook deliveries that failed after all retries (regulatory compliance risk)",
+		},
+		[]string{"event_type"},
+	)
 )
 
 // RecordOperationDuration records the duration of a current account operation
@@ -253,4 +287,47 @@ func RecordClearingAccountLookupDuration(duration time.Duration) {
 // RecordClearingAccountLookupError records a clearing account lookup error
 func RecordClearingAccountLookupError(clearingType string) {
 	clearingAccountLookupErrors.WithLabelValues(clearingType).Inc()
+}
+
+// Webhook delivery status constants for bounded cardinality.
+const (
+	WebhookStatusSuccess = "success"
+	WebhookStatusFailed  = "failed"
+	WebhookStatusSkipped = "skipped"
+)
+
+// Webhook event type constants for bounded cardinality.
+const (
+	WebhookEventAccountFrozen = "account_frozen"
+	WebhookEventAccountClosed = "account_closed"
+)
+
+// RecordWebhookDeliveryAttempt records a webhook delivery attempt.
+// eventType should be one of the WebhookEvent* constants.
+// status should be one of the WebhookStatus* constants.
+func RecordWebhookDeliveryAttempt(eventType, status string) {
+	webhookDeliveryAttempts.WithLabelValues(eventType, status).Inc()
+}
+
+// RecordWebhookDeliveryDuration records the duration of a webhook delivery attempt.
+func RecordWebhookDeliveryDuration(eventType string, duration time.Duration) {
+	webhookDeliveryDuration.WithLabelValues(eventType).Observe(duration.Seconds())
+}
+
+// RecordWebhookDeliveryRetry records a webhook delivery retry attempt.
+func RecordWebhookDeliveryRetry(eventType string) {
+	webhookDeliveryRetries.WithLabelValues(eventType).Inc()
+}
+
+// RecordWebhookDeliveryExhausted records when webhook delivery retries are exhausted.
+// This indicates a regulatory compliance risk - freeze/close notifications not delivered.
+//
+// ALERTING: This metric MUST have a Prometheus alert configured:
+//
+//	alert: WebhookDeliveryExhausted
+//	expr: increase(current_account_webhook_delivery_exhausted_total[5m]) > 0
+//	severity: critical
+//	runbook: docs/runbooks/webhook-delivery-failure.md
+func RecordWebhookDeliveryExhausted(eventType string) {
+	webhookDeliveryExhausted.WithLabelValues(eventType).Inc()
 }

--- a/services/current-account/observability/metrics_test.go
+++ b/services/current-account/observability/metrics_test.go
@@ -185,6 +185,79 @@ func TestCircuitBreakerStateConstants(t *testing.T) {
 	}
 }
 
+// Tests for webhook delivery metrics (production readiness monitoring)
+
+func TestRecordWebhookDeliveryAttempt(t *testing.T) {
+	webhookDeliveryAttempts.Reset()
+
+	RecordWebhookDeliveryAttempt(WebhookEventAccountFrozen, WebhookStatusSuccess)
+	RecordWebhookDeliveryAttempt(WebhookEventAccountClosed, WebhookStatusFailed)
+	RecordWebhookDeliveryAttempt(WebhookEventAccountFrozen, WebhookStatusSkipped)
+
+	count := testutil.CollectAndCount(webhookDeliveryAttempts)
+	if count == 0 {
+		t.Error("Expected webhook delivery attempt metric to be recorded")
+	}
+}
+
+func TestRecordWebhookDeliveryDuration(t *testing.T) {
+	webhookDeliveryDuration.Reset()
+
+	RecordWebhookDeliveryDuration(WebhookEventAccountFrozen, 500*time.Millisecond)
+	RecordWebhookDeliveryDuration(WebhookEventAccountClosed, 2*time.Second)
+
+	count := testutil.CollectAndCount(webhookDeliveryDuration)
+	if count == 0 {
+		t.Error("Expected webhook delivery duration metric to be recorded")
+	}
+}
+
+func TestRecordWebhookDeliveryRetry(t *testing.T) {
+	webhookDeliveryRetries.Reset()
+
+	RecordWebhookDeliveryRetry(WebhookEventAccountFrozen)
+	RecordWebhookDeliveryRetry(WebhookEventAccountClosed)
+
+	count := testutil.CollectAndCount(webhookDeliveryRetries)
+	if count == 0 {
+		t.Error("Expected webhook delivery retry metric to be recorded")
+	}
+}
+
+func TestRecordWebhookDeliveryExhausted(t *testing.T) {
+	webhookDeliveryExhausted.Reset()
+
+	RecordWebhookDeliveryExhausted(WebhookEventAccountFrozen)
+
+	count := testutil.CollectAndCount(webhookDeliveryExhausted)
+	if count == 0 {
+		t.Error("Expected webhook delivery exhausted metric to be recorded")
+	}
+}
+
+func TestWebhookEventTypeConstants(t *testing.T) {
+	// Verify webhook event type constants are properly defined
+	if WebhookEventAccountFrozen != "account_frozen" {
+		t.Errorf("WebhookEventAccountFrozen should be 'account_frozen', got '%s'", WebhookEventAccountFrozen)
+	}
+	if WebhookEventAccountClosed != "account_closed" {
+		t.Errorf("WebhookEventAccountClosed should be 'account_closed', got '%s'", WebhookEventAccountClosed)
+	}
+}
+
+func TestWebhookStatusConstants(t *testing.T) {
+	// Verify webhook status constants are properly defined
+	if WebhookStatusSuccess != "success" {
+		t.Errorf("WebhookStatusSuccess should be 'success', got '%s'", WebhookStatusSuccess)
+	}
+	if WebhookStatusFailed != "failed" {
+		t.Errorf("WebhookStatusFailed should be 'failed', got '%s'", WebhookStatusFailed)
+	}
+	if WebhookStatusSkipped != "skipped" {
+		t.Errorf("WebhookStatusSkipped should be 'skipped', got '%s'", WebhookStatusSkipped)
+	}
+}
+
 func TestMetricsLabels(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/services/current-account/webhook/notifier.go
+++ b/services/current-account/webhook/notifier.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/current-account/observability"
 )
 
 // Notifier errors.
@@ -268,12 +269,18 @@ func (n *HTTPNotifier) NotifyAccountClosed(ctx context.Context, tenantID, accoun
 }
 
 // sendWebhook sends a webhook with retry logic.
+// Records metrics for monitoring webhook delivery health.
 func (n *HTTPNotifier) sendWebhook(ctx context.Context, payload Payload) error {
+	start := time.Now()
+	eventType := mapEventType(payload.EventType)
+
 	webhookURL, err := n.getWebhookURL(ctx, payload)
 	if err != nil {
+		observability.RecordWebhookDeliveryAttempt(eventType, observability.WebhookStatusFailed)
 		return err
 	}
 	if webhookURL == "" {
+		observability.RecordWebhookDeliveryAttempt(eventType, observability.WebhookStatusSkipped)
 		return nil // No webhook configured, skip silently
 	}
 
@@ -283,16 +290,36 @@ func (n *HTTPNotifier) sendWebhook(ctx context.Context, payload Payload) error {
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
 		n.logger.Error("failed to serialize webhook payload", "event_id", payload.EventID, "error", err)
+		observability.RecordWebhookDeliveryAttempt(eventType, observability.WebhookStatusFailed)
 		return fmt.Errorf("failed to serialize payload: %w", err)
 	}
 
 	lastErr := n.executeWithRetries(ctx, webhookURL, payloadBytes, record, payload)
+
+	// Record delivery duration regardless of outcome
+	observability.RecordWebhookDeliveryDuration(eventType, time.Since(start))
+
 	if lastErr == nil {
+		observability.RecordWebhookDeliveryAttempt(eventType, observability.WebhookStatusSuccess)
 		return nil
 	}
 
+	observability.RecordWebhookDeliveryAttempt(eventType, observability.WebhookStatusFailed)
+	observability.RecordWebhookDeliveryExhausted(eventType)
 	n.markDeliveryFailed(ctx, record, payload, lastErr)
 	return fmt.Errorf("%w: %w", ErrWebhookDeliveryFailed, lastErr)
+}
+
+// mapEventType maps webhook EventType to metric label.
+func mapEventType(eventType EventType) string {
+	switch eventType {
+	case EventTypeAccountFrozen:
+		return observability.WebhookEventAccountFrozen
+	case EventTypeAccountClosed:
+		return observability.WebhookEventAccountClosed
+	default:
+		return string(eventType)
+	}
 }
 
 // getWebhookURL retrieves the webhook URL for the tenant.
@@ -355,7 +382,7 @@ func (n *HTTPNotifier) executeWithRetries(
 	var lastErr error
 
 	for attempt := 0; attempt <= n.maxRetries; attempt++ {
-		if err := n.waitForRetry(ctx, attempt, payload.EventID); err != nil {
+		if err := n.waitForRetry(ctx, attempt, payload.EventID, payload.EventType); err != nil {
 			return err
 		}
 
@@ -378,10 +405,14 @@ func (n *HTTPNotifier) executeWithRetries(
 }
 
 // waitForRetry waits before a retry attempt (skips for first attempt).
-func (n *HTTPNotifier) waitForRetry(ctx context.Context, attempt int, eventID string) error {
+// Records retry metrics for monitoring.
+func (n *HTTPNotifier) waitForRetry(ctx context.Context, attempt int, eventID string, eventType EventType) error {
 	if attempt == 0 {
 		return nil
 	}
+
+	// Record retry attempt metric
+	observability.RecordWebhookDeliveryRetry(mapEventType(eventType))
 
 	delayIdx := attempt - 1
 	if delayIdx >= len(n.retryDelays) {

--- a/services/financial-accounting/cmd/main.go
+++ b/services/financial-accounting/cmd/main.go
@@ -261,9 +261,13 @@ func run(logger *slog.Logger) error {
 			"environment", os.Getenv("ENVIRONMENT"))
 		idempotencySvc = newNoopIdempotencyService()
 		usingNoopIdempotency = true
+		// Record degradation metrics
+		serviceobs.SetNoopIdempotencyActive(true)
+		serviceobs.RecordServiceDegradation(serviceobs.ComponentIdempotency, serviceobs.DegradationReasonStartupFallback)
 	} else {
 		redisSvc = idempotency.NewRedisService(redisClient)
 		idempotencySvc = redisSvc
+		serviceobs.SetNoopIdempotencyActive(false)
 		logger.Info("idempotency service initialized with Redis")
 		defer func() {
 			if err := redisClient.Close(); err != nil {
@@ -306,7 +310,10 @@ func run(logger *slog.Logger) error {
 	if usingNoopEventPublisher {
 		logger.Warn("using noop event publisher - DEVELOPMENT ONLY",
 			"environment", os.Getenv("ENVIRONMENT"))
+		serviceobs.SetNoopEventPublisherActive(true)
+		serviceobs.RecordServiceDegradation(serviceobs.ComponentEventPublisher, serviceobs.DegradationReasonStartupFallback)
 	} else {
+		serviceobs.SetNoopEventPublisherActive(false)
 		logger.Info("event publisher initialized (noop mode for direct publishing, outbox handles primary events)")
 	}
 

--- a/services/financial-accounting/observability/metrics.go
+++ b/services/financial-accounting/observability/metrics.go
@@ -194,6 +194,32 @@ var (
 		},
 		[]string{"instrument_code", "operation"},
 	)
+
+	// NoOp fallback metrics - indicates degraded service functionality
+	// These metrics track when the service is running with fallback implementations
+	// instead of production-ready dependencies (Redis for idempotency, Kafka for events)
+	noopIdempotencyActive = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "financial_accounting_noop_idempotency_active",
+			Help: "1 if NoOp idempotency service is active (production risk), 0 otherwise",
+		},
+	)
+
+	noopEventPublisherActive = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "financial_accounting_noop_event_publisher_active",
+			Help: "1 if NoOp event publisher is active (production risk), 0 otherwise",
+		},
+	)
+
+	// Service degradation counter - tracks transitions to degraded mode
+	serviceDegradationEvents = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "financial_accounting_service_degradation_events_total",
+			Help: "Total number of service degradation events by component",
+		},
+		[]string{"component", "reason"},
+	)
 )
 
 // RecordOperationDuration records the duration of a financial accounting operation.
@@ -334,4 +360,60 @@ func RecordClearingAccountLookupError(clearingType string) {
 // RecordResolverFallback records when the posting service falls back to static clearing account.
 func RecordResolverFallback(instrumentCode, operation string) {
 	resolverFallbackTotal.WithLabelValues(instrumentCode, operation).Inc()
+}
+
+// Service component constants for degradation metrics.
+const (
+	ComponentIdempotency    = "idempotency"
+	ComponentEventPublisher = "event_publisher"
+	ComponentKafkaProducer  = "kafka_producer"
+	ComponentRedis          = "redis"
+)
+
+// Degradation reason constants.
+const (
+	DegradationReasonUnavailable      = "unavailable"
+	DegradationReasonConnectionFailed = "connection_failed"
+	DegradationReasonStartupFallback  = "startup_fallback"
+)
+
+// SetNoopIdempotencyActive sets the gauge indicating whether NoOp idempotency is active.
+// This metric MUST trigger a critical alert in production environments.
+//
+// ALERTING: This metric MUST have a Prometheus alert configured:
+//
+//	alert: NoopIdempotencyActiveInProduction
+//	expr: financial_accounting_noop_idempotency_active == 1 AND environment == "production"
+//	severity: critical
+//	runbook: docs/runbooks/noop-fallback-active.md
+func SetNoopIdempotencyActive(active bool) {
+	if active {
+		noopIdempotencyActive.Set(1)
+	} else {
+		noopIdempotencyActive.Set(0)
+	}
+}
+
+// SetNoopEventPublisherActive sets the gauge indicating whether NoOp event publisher is active.
+// This metric MUST trigger a critical alert in production environments.
+//
+// ALERTING: This metric MUST have a Prometheus alert configured:
+//
+//	alert: NoopEventPublisherActiveInProduction
+//	expr: financial_accounting_noop_event_publisher_active == 1 AND environment == "production"
+//	severity: critical
+//	runbook: docs/runbooks/noop-fallback-active.md
+func SetNoopEventPublisherActive(active bool) {
+	if active {
+		noopEventPublisherActive.Set(1)
+	} else {
+		noopEventPublisherActive.Set(0)
+	}
+}
+
+// RecordServiceDegradation records a service degradation event.
+// component should be one of the Component* constants.
+// reason should be one of the DegradationReason* constants.
+func RecordServiceDegradation(component, reason string) {
+	serviceDegradationEvents.WithLabelValues(component, reason).Inc()
 }

--- a/services/financial-accounting/observability/metrics_test.go
+++ b/services/financial-accounting/observability/metrics_test.go
@@ -241,3 +241,59 @@ func TestOperationNameConstants(t *testing.T) {
 		assert.NotEmpty(t, op, "operation name constant should not be empty")
 	}
 }
+
+// Tests for NoOp fallback metrics (production readiness monitoring)
+
+func TestSetNoopIdempotencyActive(t *testing.T) {
+	// Test setting active
+	SetNoopIdempotencyActive(true)
+	value := testutil.ToFloat64(noopIdempotencyActive)
+	assert.Equal(t, float64(1), value, "NoOp idempotency gauge should be 1 when active")
+
+	// Test setting inactive
+	SetNoopIdempotencyActive(false)
+	value = testutil.ToFloat64(noopIdempotencyActive)
+	assert.Equal(t, float64(0), value, "NoOp idempotency gauge should be 0 when inactive")
+}
+
+func TestSetNoopEventPublisherActive(t *testing.T) {
+	// Test setting active
+	SetNoopEventPublisherActive(true)
+	value := testutil.ToFloat64(noopEventPublisherActive)
+	assert.Equal(t, float64(1), value, "NoOp event publisher gauge should be 1 when active")
+
+	// Test setting inactive
+	SetNoopEventPublisherActive(false)
+	value = testutil.ToFloat64(noopEventPublisherActive)
+	assert.Equal(t, float64(0), value, "NoOp event publisher gauge should be 0 when inactive")
+}
+
+func TestRecordServiceDegradation(t *testing.T) {
+	serviceDegradationEvents.Reset()
+
+	// Record degradation events
+	RecordServiceDegradation(ComponentIdempotency, DegradationReasonStartupFallback)
+	RecordServiceDegradation(ComponentEventPublisher, DegradationReasonUnavailable)
+	RecordServiceDegradation(ComponentRedis, DegradationReasonConnectionFailed)
+
+	// Verify counter was incremented
+	count := testutil.CollectAndCount(serviceDegradationEvents)
+	if count == 0 {
+		t.Error("Expected service degradation events metric to be recorded")
+	}
+}
+
+func TestServiceComponentConstants(t *testing.T) {
+	// Verify component constants are properly defined
+	assert.Equal(t, "idempotency", ComponentIdempotency)
+	assert.Equal(t, "event_publisher", ComponentEventPublisher)
+	assert.Equal(t, "kafka_producer", ComponentKafkaProducer)
+	assert.Equal(t, "redis", ComponentRedis)
+}
+
+func TestDegradationReasonConstants(t *testing.T) {
+	// Verify degradation reason constants are properly defined
+	assert.Equal(t, "unavailable", DegradationReasonUnavailable)
+	assert.Equal(t, "connection_failed", DegradationReasonConnectionFailed)
+	assert.Equal(t, "startup_fallback", DegradationReasonStartupFallback)
+}

--- a/services/payment-order/observability/metrics.go
+++ b/services/payment-order/observability/metrics.go
@@ -236,6 +236,47 @@ var (
 			Buckets: []float64{.001, .005, .01, .05, .1, .5, 1.0, 5.0},
 		},
 	)
+
+	// Bucket evaluation metrics - tracks CEL expression evaluation for non-fungible instruments
+	bucketEvaluationFailures = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "payment_order_bucket_evaluation_failures_total",
+			Help: "Total number of bucket ID evaluation failures by instrument and error type",
+		},
+		[]string{"instrument_code", "error_type"},
+	)
+
+	bucketEvaluationDuration = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "payment_order_bucket_evaluation_duration_seconds",
+			Help:    "Time spent evaluating bucket ID via CEL expression",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5},
+		},
+	)
+
+	bucketEvaluationsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "payment_order_bucket_evaluations_total",
+			Help: "Total number of bucket ID evaluations by result status",
+		},
+		[]string{"status"},
+	)
+
+	// Lien execution retry metrics - tracks retry behavior and exhaustion
+	lienExecutionRetries = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "payment_order_lien_execution_retries_total",
+			Help: "Total number of lien execution retry attempts by outcome",
+		},
+		[]string{"outcome"},
+	)
+
+	lienExecutionRetriesExhausted = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "payment_order_lien_execution_retries_exhausted_total",
+			Help: "Total number of payment orders where lien execution retries were exhausted",
+		},
+	)
 )
 
 // RecordPaymentOrder records a payment order by status.
@@ -380,4 +421,56 @@ func RecordLienExecutionLockContention() {
 // the distributed lock for lien execution status updates.
 func RecordLienExecutionLockWaitDuration(seconds float64) {
 	lienExecutionLockWaitDuration.Observe(seconds)
+}
+
+// Bucket evaluation error type constants for bounded cardinality.
+const (
+	BucketEvalErrNoClient        = "no_client"
+	BucketEvalErrNoEvaluator     = "no_evaluator"
+	BucketEvalErrInstrumentFetch = "instrument_fetch"
+	BucketEvalErrCELEvaluation   = "cel_evaluation"
+)
+
+// Bucket evaluation status constants.
+const (
+	BucketEvalStatusSuccess  = "success"
+	BucketEvalStatusSkipped  = "skipped"
+	BucketEvalStatusFallback = "fallback"
+)
+
+// RecordBucketEvaluationFailure records a bucket evaluation failure.
+// errorType should be one of the BucketEvalErr* constants to ensure bounded cardinality.
+func RecordBucketEvaluationFailure(instrumentCode, errorType string) {
+	bucketEvaluationFailures.WithLabelValues(instrumentCode, errorType).Inc()
+}
+
+// RecordBucketEvaluationDuration records the duration of a bucket ID evaluation.
+func RecordBucketEvaluationDuration(duration time.Duration) {
+	bucketEvaluationDuration.Observe(duration.Seconds())
+}
+
+// RecordBucketEvaluation records the outcome of a bucket evaluation attempt.
+// status should be one of the BucketEvalStatus* constants.
+func RecordBucketEvaluation(status string) {
+	bucketEvaluationsTotal.WithLabelValues(status).Inc()
+}
+
+// Lien execution retry outcome constants for bounded cardinality.
+const (
+	LienRetryOutcomeAttempt   = "attempt"
+	LienRetryOutcomeSuccess   = "success"
+	LienRetryOutcomeFailed    = "failed"
+	LienRetryOutcomeExhausted = "exhausted"
+)
+
+// RecordLienExecutionRetry records a lien execution retry attempt.
+// outcome should be one of the LienRetryOutcome* constants.
+func RecordLienExecutionRetry(outcome string) {
+	lienExecutionRetries.WithLabelValues(outcome).Inc()
+}
+
+// RecordLienExecutionRetriesExhausted records when lien execution retries are exhausted.
+// This indicates the payment order may require manual reconciliation.
+func RecordLienExecutionRetriesExhausted() {
+	lienExecutionRetriesExhausted.Inc()
 }

--- a/services/payment-order/observability/metrics.go
+++ b/services/payment-order/observability/metrics.go
@@ -238,12 +238,15 @@ var (
 	)
 
 	// Bucket evaluation metrics - tracks CEL expression evaluation for non-fungible instruments
+	// Note: instrument_code is intentionally excluded to prevent cardinality explosion
+	// in multi-tenant environments where tenants can define custom instruments (ADR-0014).
+	// Instrument details are preserved in structured logs for debugging.
 	bucketEvaluationFailures = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "payment_order_bucket_evaluation_failures_total",
-			Help: "Total number of bucket ID evaluation failures by instrument and error type",
+			Help: "Total number of bucket ID evaluation failures by error type",
 		},
-		[]string{"instrument_code", "error_type"},
+		[]string{"error_type"},
 	)
 
 	bucketEvaluationDuration = promauto.NewHistogram(
@@ -440,8 +443,10 @@ const (
 
 // RecordBucketEvaluationFailure records a bucket evaluation failure.
 // errorType should be one of the BucketEvalErr* constants to ensure bounded cardinality.
-func RecordBucketEvaluationFailure(instrumentCode, errorType string) {
-	bucketEvaluationFailures.WithLabelValues(instrumentCode, errorType).Inc()
+// Note: instrumentCode is intentionally not included as a metric label to prevent
+// cardinality explosion; use structured logging for instrument-specific debugging.
+func RecordBucketEvaluationFailure(errorType string) {
+	bucketEvaluationFailures.WithLabelValues(errorType).Inc()
 }
 
 // RecordBucketEvaluationDuration records the duration of a bucket ID evaluation.

--- a/services/payment-order/observability/metrics_test.go
+++ b/services/payment-order/observability/metrics_test.go
@@ -225,7 +225,7 @@ func TestPaymentOrdersInFlight(t *testing.T) {
 func TestRecordBucketEvaluationFailure(t *testing.T) {
 	bucketEvaluationFailures.Reset()
 
-	RecordBucketEvaluationFailure("ENERGY_KWH", BucketEvalErrCELEvaluation)
+	RecordBucketEvaluationFailure(BucketEvalErrCELEvaluation)
 
 	count := testutil.CollectAndCount(bucketEvaluationFailures)
 	if count == 0 {
@@ -268,7 +268,7 @@ func TestBucketEvaluationErrorTypes(t *testing.T) {
 	}
 
 	for _, errType := range errorTypes {
-		RecordBucketEvaluationFailure("TEST_INSTRUMENT", errType)
+		RecordBucketEvaluationFailure(errType)
 	}
 
 	count := testutil.CollectAndCount(bucketEvaluationFailures)

--- a/services/payment-order/observability/metrics_test.go
+++ b/services/payment-order/observability/metrics_test.go
@@ -220,6 +220,89 @@ func TestPaymentOrdersInFlight(t *testing.T) {
 	DecPaymentOrdersInFlight()
 }
 
+// Tests for bucket evaluation metrics (production readiness monitoring)
+
+func TestRecordBucketEvaluationFailure(t *testing.T) {
+	bucketEvaluationFailures.Reset()
+
+	RecordBucketEvaluationFailure("ENERGY_KWH", BucketEvalErrCELEvaluation)
+
+	count := testutil.CollectAndCount(bucketEvaluationFailures)
+	if count == 0 {
+		t.Error("Expected bucket evaluation failure metric to be recorded")
+	}
+}
+
+func TestRecordBucketEvaluationDuration(t *testing.T) {
+	// Note: Histograms don't have Reset(), but we can verify recording doesn't panic
+	RecordBucketEvaluationDuration(50 * time.Millisecond)
+
+	count := testutil.CollectAndCount(bucketEvaluationDuration)
+	if count == 0 {
+		t.Error("Expected bucket evaluation duration metric to be recorded")
+	}
+}
+
+func TestRecordBucketEvaluation(t *testing.T) {
+	bucketEvaluationsTotal.Reset()
+
+	RecordBucketEvaluation(BucketEvalStatusSuccess)
+	RecordBucketEvaluation(BucketEvalStatusFallback)
+	RecordBucketEvaluation(BucketEvalStatusSkipped)
+
+	count := testutil.CollectAndCount(bucketEvaluationsTotal)
+	if count == 0 {
+		t.Error("Expected bucket evaluation total metric to be recorded")
+	}
+}
+
+func TestBucketEvaluationErrorTypes(t *testing.T) {
+	bucketEvaluationFailures.Reset()
+
+	// Test all error type constants are valid
+	errorTypes := []string{
+		BucketEvalErrNoClient,
+		BucketEvalErrNoEvaluator,
+		BucketEvalErrInstrumentFetch,
+		BucketEvalErrCELEvaluation,
+	}
+
+	for _, errType := range errorTypes {
+		RecordBucketEvaluationFailure("TEST_INSTRUMENT", errType)
+	}
+
+	count := testutil.CollectAndCount(bucketEvaluationFailures)
+	if count != len(errorTypes) {
+		t.Errorf("Expected %d bucket evaluation failure metrics, got count result", len(errorTypes))
+	}
+}
+
+// Tests for lien execution retry metrics (production readiness monitoring)
+
+func TestRecordLienExecutionRetry(t *testing.T) {
+	lienExecutionRetries.Reset()
+
+	RecordLienExecutionRetry(LienRetryOutcomeAttempt)
+	RecordLienExecutionRetry(LienRetryOutcomeFailed)
+	RecordLienExecutionRetry(LienRetryOutcomeSuccess)
+	RecordLienExecutionRetry(LienRetryOutcomeExhausted)
+
+	count := testutil.CollectAndCount(lienExecutionRetries)
+	if count == 0 {
+		t.Error("Expected lien execution retry metric to be recorded")
+	}
+}
+
+func TestRecordLienExecutionRetriesExhausted(t *testing.T) {
+	// Note: prometheus.Counter doesn't have Reset(), but we can verify recording doesn't panic
+	RecordLienExecutionRetriesExhausted()
+
+	count := testutil.CollectAndCount(lienExecutionRetriesExhausted)
+	if count == 0 {
+		t.Error("Expected lien execution retries exhausted metric to be recorded")
+	}
+}
+
 func TestMetricsLabels(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/services/payment-order/service/saga_handlers.go
+++ b/services/payment-order/service/saga_handlers.go
@@ -12,6 +12,7 @@ import (
 	currentaccountv1 "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
 	"github.com/meridianhub/meridian/services/payment-order/domain"
+	poobservability "github.com/meridianhub/meridian/services/payment-order/observability"
 	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
@@ -324,6 +325,7 @@ func postLedgerEntriesHandler(deps *PaymentOrderHandlerDeps, logger *slog.Logger
 
 // executeLienHandler creates a handler for the payment_order.execute_lien step.
 // This handler includes retry logic with exponential backoff.
+// Records metrics for monitoring lien execution health and retry exhaustion.
 func executeLienHandler(deps *PaymentOrderHandlerDeps, logger *slog.Logger) saga.Handler {
 	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
 		const handlerName = "payment_order.execute_lien"
@@ -360,6 +362,7 @@ func executeLienHandler(deps *PaymentOrderHandlerDeps, logger *slog.Logger) saga
 
 		err = sharedclients.Retry(ctx.Context, *retryConfig, func() error {
 			attempts++
+			poobservability.RecordLienExecutionRetry(poobservability.LienRetryOutcomeAttempt)
 			logger.Info("attempting lien execution", "attempt", attempts, "lien_id", lienID)
 
 			_, execErr := deps.CurrentAccountClient.ExecuteLien(ctx.Context, &currentaccountv1.ExecuteLienRequest{
@@ -367,6 +370,7 @@ func executeLienHandler(deps *PaymentOrderHandlerDeps, logger *slog.Logger) saga
 			})
 			if execErr != nil {
 				lastErr = execErr
+				poobservability.RecordLienExecutionRetry(poobservability.LienRetryOutcomeFailed)
 				logger.Warn("lien execution attempt failed",
 					"attempt", attempts,
 					"lien_id", lienID,
@@ -389,6 +393,9 @@ func executeLienHandler(deps *PaymentOrderHandlerDeps, logger *slog.Logger) saga
 		}
 
 		if err != nil {
+			// Record retry exhaustion metric - indicates payment may require manual reconciliation
+			poobservability.RecordLienExecutionRetry(poobservability.LienRetryOutcomeExhausted)
+			poobservability.RecordLienExecutionRetriesExhausted()
 			logger.Error("lien execution failed after retries",
 				"saga_execution_id", ctx.SagaExecutionID,
 				"lien_id", lienID,
@@ -400,6 +407,7 @@ func executeLienHandler(deps *PaymentOrderHandlerDeps, logger *slog.Logger) saga
 			}, wrapHandlerError(handlerName, fmt.Errorf("lien execution failed after %d attempts: %w", attempts, err))
 		}
 
+		poobservability.RecordLienExecutionRetry(poobservability.LienRetryOutcomeSuccess)
 		logger.Info("lien executed successfully",
 			"saga_execution_id", ctx.SagaExecutionID,
 			"lien_id", lienID,
@@ -460,6 +468,7 @@ func terminateLienHandler(deps *PaymentOrderHandlerDeps, logger *slog.Logger) sa
 
 // evaluateBucketIDForHandler evaluates the bucket ID for bucket-aware solvency.
 // Returns empty string if bucket evaluation is not applicable or fails gracefully.
+// Records metrics for monitoring bucket evaluation health.
 func evaluateBucketIDForHandler(
 	ctx context.Context,
 	deps *PaymentOrderHandlerDeps,
@@ -468,8 +477,11 @@ func evaluateBucketIDForHandler(
 	paymentOrderID string,
 	logger *slog.Logger,
 ) (string, error) {
+	start := time.Now()
+
 	// Skip if no instrument code
 	if instrumentCode == "" {
+		poobservability.RecordBucketEvaluation(poobservability.BucketEvalStatusSkipped)
 		return "", nil
 	}
 
@@ -477,6 +489,8 @@ func evaluateBucketIDForHandler(
 	if deps.ReferenceDataClient == nil {
 		logger.Debug("bucket evaluation skipped - reference data client not configured",
 			"payment_order_id", paymentOrderID)
+		poobservability.RecordBucketEvaluationFailure(instrumentCode, poobservability.BucketEvalErrNoClient)
+		poobservability.RecordBucketEvaluation(poobservability.BucketEvalStatusFallback)
 		return "", nil
 	}
 
@@ -488,6 +502,8 @@ func evaluateBucketIDForHandler(
 			"payment_order_id", paymentOrderID,
 			"instrument_code", instrumentCode,
 			"error", err)
+		poobservability.RecordBucketEvaluationFailure(instrumentCode, poobservability.BucketEvalErrInstrumentFetch)
+		poobservability.RecordBucketEvaluation(poobservability.BucketEvalStatusFallback)
 		return "", nil
 	}
 
@@ -496,6 +512,7 @@ func evaluateBucketIDForHandler(
 		logger.Debug("instrument has no fungibility expression, using default bucket",
 			"payment_order_id", paymentOrderID,
 			"instrument_code", instrumentCode)
+		poobservability.RecordBucketEvaluation(poobservability.BucketEvalStatusSkipped)
 		return "", nil
 	}
 
@@ -503,6 +520,8 @@ func evaluateBucketIDForHandler(
 	if deps.BucketEvaluator == nil {
 		logger.Debug("bucket evaluation skipped - bucket evaluator not configured",
 			"payment_order_id", paymentOrderID)
+		poobservability.RecordBucketEvaluationFailure(instrumentCode, poobservability.BucketEvalErrNoEvaluator)
+		poobservability.RecordBucketEvaluation(poobservability.BucketEvalStatusFallback)
 		return "", nil
 	}
 
@@ -511,6 +530,10 @@ func evaluateBucketIDForHandler(
 		InstrumentCode: instrumentCode,
 		Attributes:     paymentAttributes,
 	})
+
+	// Record duration for successful or failed evaluations (not skipped)
+	poobservability.RecordBucketEvaluationDuration(time.Since(start))
+
 	if err != nil {
 		// Gracefully degrade to default bucket on CEL evaluation failures
 		// (e.g., missing required attributes, invalid expressions)
@@ -518,6 +541,8 @@ func evaluateBucketIDForHandler(
 			"payment_order_id", paymentOrderID,
 			"instrument_code", instrumentCode,
 			"error", err)
+		poobservability.RecordBucketEvaluationFailure(instrumentCode, poobservability.BucketEvalErrCELEvaluation)
+		poobservability.RecordBucketEvaluation(poobservability.BucketEvalStatusFallback)
 		return "", nil
 	}
 
@@ -525,6 +550,7 @@ func evaluateBucketIDForHandler(
 		"payment_order_id", paymentOrderID,
 		"instrument_code", instrumentCode,
 		"bucket_id", bucketID)
+	poobservability.RecordBucketEvaluation(poobservability.BucketEvalStatusSuccess)
 
 	return bucketID, nil
 }

--- a/services/payment-order/service/saga_handlers.go
+++ b/services/payment-order/service/saga_handlers.go
@@ -489,7 +489,7 @@ func evaluateBucketIDForHandler(
 	if deps.ReferenceDataClient == nil {
 		logger.Debug("bucket evaluation skipped - reference data client not configured",
 			"payment_order_id", paymentOrderID)
-		poobservability.RecordBucketEvaluationFailure(instrumentCode, poobservability.BucketEvalErrNoClient)
+		poobservability.RecordBucketEvaluationFailure(poobservability.BucketEvalErrNoClient)
 		poobservability.RecordBucketEvaluation(poobservability.BucketEvalStatusFallback)
 		return "", nil
 	}
@@ -502,7 +502,7 @@ func evaluateBucketIDForHandler(
 			"payment_order_id", paymentOrderID,
 			"instrument_code", instrumentCode,
 			"error", err)
-		poobservability.RecordBucketEvaluationFailure(instrumentCode, poobservability.BucketEvalErrInstrumentFetch)
+		poobservability.RecordBucketEvaluationFailure(poobservability.BucketEvalErrInstrumentFetch)
 		poobservability.RecordBucketEvaluation(poobservability.BucketEvalStatusFallback)
 		return "", nil
 	}
@@ -520,7 +520,7 @@ func evaluateBucketIDForHandler(
 	if deps.BucketEvaluator == nil {
 		logger.Debug("bucket evaluation skipped - bucket evaluator not configured",
 			"payment_order_id", paymentOrderID)
-		poobservability.RecordBucketEvaluationFailure(instrumentCode, poobservability.BucketEvalErrNoEvaluator)
+		poobservability.RecordBucketEvaluationFailure(poobservability.BucketEvalErrNoEvaluator)
 		poobservability.RecordBucketEvaluation(poobservability.BucketEvalStatusFallback)
 		return "", nil
 	}
@@ -541,7 +541,7 @@ func evaluateBucketIDForHandler(
 			"payment_order_id", paymentOrderID,
 			"instrument_code", instrumentCode,
 			"error", err)
-		poobservability.RecordBucketEvaluationFailure(instrumentCode, poobservability.BucketEvalErrCELEvaluation)
+		poobservability.RecordBucketEvaluationFailure(poobservability.BucketEvalErrCELEvaluation)
 		poobservability.RecordBucketEvaluation(poobservability.BucketEvalStatusFallback)
 		return "", nil
 	}


### PR DESCRIPTION
## Summary

This PR adds observability infrastructure for monitoring silent failures and production readiness across Meridian services. It implements metrics, alerting, and dashboards for:

- **Bucket evaluation failures** (payment-order): Tracks CEL expression evaluation failures for non-fungible instruments
- **Lien execution retry exhaustion** (payment-order): Monitors when payment orders may be stuck due to retry exhaustion
- **Webhook delivery failures** (current-account): Regulatory compliance risk monitoring for freeze/close notifications
- **NoOp fallback detection** (financial-accounting): Alerts when development-only fallbacks are active

## Changes Made

### Metrics (Services)

| Service | Metric | Purpose |
|---------|--------|---------|
| payment-order | `bucket_evaluation_failures_total` | Silent failures in bucket ID evaluation |
| payment-order | `bucket_evaluation_duration_seconds` | CEL evaluation latency |
| payment-order | `lien_execution_retries_total` | Retry attempt outcomes |
| payment-order | `lien_execution_retries_exhausted_total` | Payment stuck risk indicator |
| current-account | `webhook_delivery_attempts_total` | Delivery success/failure by event type |
| current-account | `webhook_delivery_exhausted_total` | Regulatory compliance risk |
| financial-accounting | `noop_idempotency_active` | Development mode detection |
| financial-accounting | `noop_event_publisher_active` | Development mode detection |

### Prometheus Alerting Rules

Created `deployments/prometheus/alerts/production-readiness.yml` with alerts for:
- `BucketEvaluationFailureRateHigh` (warning)
- `WebhookDeliveryExhausted` (critical - regulatory)
- `NoopIdempotencyActiveInProduction` (critical)
- `LienExecutionRetriesExhausted` (critical)

### Grafana Dashboard

Created `deployments/grafana/dashboards/production-readiness.json` with:
- Production readiness overview (NoOp status, failure counts)
- Bucket evaluation rate and latency panels
- Webhook delivery status panels
- Lien execution retry outcome visualization

### Tests

Added unit tests for all new metric recording functions in each service's `observability/metrics_test.go`.

## Technical Details

- Metrics use bounded cardinality with constant labels (e.g., `BucketEvalErrCELEvaluation`)
- Graceful degradation maintained - metrics record failures but don't block operations
- Gauge metrics for NoOp detection (1 = active, 0 = inactive)
- Counter metrics for failure tracking with appropriate label dimensions

## Test Plan

- [x] All new metric tests pass locally
- [ ] CI passes
- [ ] Verify metrics appear in Prometheus after deployment
- [ ] Verify Grafana dashboard loads correctly
- [ ] Validate alerting rules syntax with `promtool check rules`

## Task Reference

Task Master: production-readiness.10 - Add Observability for Silent Failures and Production Readiness Monitoring