### PR TITLE
feat: Add ValuationFeature schema and CRUD infrastructure

### DIFF
--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -874,6 +874,184 @@ message ControlCurrentAccountResponse {
   google.protobuf.Timestamp action_timestamp = 2 [(buf.validate.field).required = true];
 }
 
+// ValuationFeatureLifecycleStatus defines the lifecycle state of a valuation feature
+enum ValuationFeatureLifecycleStatus {
+  // VALUATION_FEATURE_LIFECYCLE_STATUS_UNSPECIFIED is the default value
+  VALUATION_FEATURE_LIFECYCLE_STATUS_UNSPECIFIED = 0;
+  // VALUATION_FEATURE_LIFECYCLE_STATUS_INITIATED means feature is created but not yet active
+  VALUATION_FEATURE_LIFECYCLE_STATUS_INITIATED = 1;
+  // VALUATION_FEATURE_LIFECYCLE_STATUS_ACTIVE means feature is active and can be used for valuation
+  VALUATION_FEATURE_LIFECYCLE_STATUS_ACTIVE = 2;
+  // VALUATION_FEATURE_LIFECYCLE_STATUS_TERMINATED means feature is no longer active (terminal state)
+  VALUATION_FEATURE_LIFECYCLE_STATUS_TERMINATED = 3;
+}
+
+// ValuationFeatureAction defines the control operations for valuation features
+enum ValuationFeatureAction {
+  // VALUATION_FEATURE_ACTION_UNSPECIFIED is the default value
+  VALUATION_FEATURE_ACTION_UNSPECIFIED = 0;
+  // VALUATION_FEATURE_ACTION_ACTIVATE transitions from INITIATED to ACTIVE
+  VALUATION_FEATURE_ACTION_ACTIVATE = 1;
+  // VALUATION_FEATURE_ACTION_TERMINATE transitions from ACTIVE to TERMINATED
+  VALUATION_FEATURE_ACTION_TERMINATE = 2;
+}
+
+// ValuationFeature represents a valuation method assignment for an account.
+// It maps an input instrument (e.g., USD) to the account's native instrument (e.g., GBP)
+// using a specific valuation method from the Valuation Engine Service.
+message ValuationFeature {
+  // id is the unique identifier for this valuation feature
+  string id = 1;
+
+  // account_id is the account this feature belongs to
+  string account_id = 2;
+
+  // instrument_code is the input instrument to be valued (e.g., "USD", "EUR", "kWh")
+  string instrument_code = 3;
+
+  // valuation_method_id references the valuation method in Valuation Engine Service
+  string valuation_method_id = 4;
+
+  // valuation_method_version is the specific version of the method
+  int32 valuation_method_version = 5;
+
+  // parameters contains method-specific configuration (JSON object)
+  string parameters = 6;
+
+  // lifecycle_status is the current state of this feature
+  ValuationFeatureLifecycleStatus lifecycle_status = 7;
+
+  // valid_from is the bi-temporal validity start timestamp
+  google.protobuf.Timestamp valid_from = 8;
+
+  // valid_to is the bi-temporal validity end timestamp
+  google.protobuf.Timestamp valid_to = 9;
+
+  // created_at is when this feature was created
+  google.protobuf.Timestamp created_at = 10;
+
+  // created_by is the user who created this feature
+  string created_by = 11;
+
+  // updated_at is when this feature was last updated
+  google.protobuf.Timestamp updated_at = 12;
+
+  // updated_by is the user who last updated this feature
+  string updated_by = 13;
+
+  // version is used for optimistic locking
+  int32 version = 14;
+}
+
+// Request to create a valuation feature for an account
+message CreateValuationFeatureRequest {
+  // account_id is the account to add the valuation feature to (required)
+  string account_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // instrument_code is the input instrument to be valued (required)
+  // Example: "USD" for a GBP account would create a USD→GBP valuation feature
+  string instrument_code = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+  }];
+
+  // valuation_method_id references the valuation method in Valuation Engine Service (required)
+  // The method's output_instrument MUST match the account's native instrument (currency)
+  string valuation_method_id = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+  }];
+
+  // valuation_method_version is the specific version of the method (required)
+  int32 valuation_method_version = 4 [(buf.validate.field).int32 = {gte: 1}];
+
+  // parameters contains method-specific configuration as JSON string (optional)
+  string parameters = 5;
+
+  // output_instrument is the expected output instrument of the valuation method (required)
+  // This MUST match the account's native instrument (currency)
+  // Used for validation - will return FAILED_PRECONDITION if mismatch
+  string output_instrument = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+  }];
+}
+
+// Response for creating a valuation feature
+message CreateValuationFeatureResponse {
+  // feature is the created valuation feature
+  ValuationFeature feature = 1;
+}
+
+// Request to update a valuation feature lifecycle status
+message UpdateValuationFeatureRequest {
+  // feature_id is the valuation feature to update (required)
+  string feature_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+  }];
+
+  // action is the lifecycle transition to perform (required)
+  ValuationFeatureAction action = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+}
+
+// Response for updating a valuation feature
+message UpdateValuationFeatureResponse {
+  // feature is the updated valuation feature
+  ValuationFeature feature = 1;
+}
+
+// Request to get a valuation feature
+// Supports two modes:
+// 1. By feature_id: Direct lookup
+// 2. By account_id + instrument_code + knowledge_at: Bi-temporal query
+message GetValuationFeatureRequest {
+  // feature_id for direct lookup (optional, mutually exclusive with account lookup)
+  string feature_id = 1;
+
+  // account_id for bi-temporal lookup (optional, requires instrument_code)
+  string account_id = 2;
+
+  // instrument_code for bi-temporal lookup (optional, requires account_id)
+  string instrument_code = 3;
+
+  // knowledge_at is the point-in-time for bi-temporal query (optional, defaults to now)
+  // Used with account_id + instrument_code to find the valid feature at that time
+  google.protobuf.Timestamp knowledge_at = 4;
+}
+
+// Response for getting a valuation feature
+message GetValuationFeatureResponse {
+  // feature is the requested valuation feature
+  ValuationFeature feature = 1;
+}
+
+// Request to list valuation features for an account
+message ListValuationFeaturesRequest {
+  // account_id to list features for (required)
+  string account_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // lifecycle_status to filter by (optional, returns all if not specified)
+  ValuationFeatureLifecycleStatus lifecycle_status = 2;
+}
+
+// Response for listing valuation features
+message ListValuationFeaturesResponse {
+  // features is the list of valuation features for the account
+  repeated ValuationFeature features = 1;
+}
+
 // CurrentAccountService provides BIAN-compliant current account operations.
 //
 // Design Notes:
@@ -1048,6 +1226,69 @@ service CurrentAccountService {
           description: "Control action executed successfully"
         }
       }
+    };
+  }
+
+  // CreateValuationFeature adds a valuation method assignment to an account.
+  // The valuation feature maps an input instrument to the account's native instrument.
+  // CRITICAL: The method's output_instrument MUST match the account's native instrument (currency).
+  // Returns FAILED_PRECONDITION if there's a mismatch (MethodOutputMismatchError).
+  rpc CreateValuationFeature(CreateValuationFeatureRequest) returns (CreateValuationFeatureResponse) {
+    option (google.api.http) = {
+      post: "/v1/current-accounts/{account_id}/valuation-features"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Create a valuation feature for an account"
+      description: "Adds a valuation method assignment to map an input instrument to the account's native currency"
+      responses: {
+        key: "201"
+        value: {
+          description: "Valuation feature created successfully"
+        }
+      }
+    };
+  }
+
+  // UpdateValuationFeature performs lifecycle transitions on a valuation feature.
+  // Supports ACTIVATE (INITIATED → ACTIVE) and TERMINATE (ACTIVE → TERMINATED) actions.
+  rpc UpdateValuationFeature(UpdateValuationFeatureRequest) returns (UpdateValuationFeatureResponse) {
+    option (google.api.http) = {
+      post: "/v1/valuation-features/{feature_id}/control"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Update valuation feature lifecycle status"
+      description: "Performs lifecycle transitions (activate/terminate) on a valuation feature"
+    };
+  }
+
+  // GetValuationFeature retrieves a valuation feature by ID or by account+instrument with bi-temporal query.
+  // Supports two query modes:
+  // 1. By feature_id: Direct lookup
+  // 2. By account_id + instrument_code + knowledge_at: Find the valid feature at a specific time
+  rpc GetValuationFeature(GetValuationFeatureRequest) returns (GetValuationFeatureResponse) {
+    option (google.api.http) = {
+      get: "/v1/valuation-features/{feature_id}"
+      additional_bindings: {
+        get: "/v1/current-accounts/{account_id}/valuation-features/lookup"
+      }
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Get a valuation feature"
+      description: "Retrieves a valuation feature by ID or by account+instrument with optional bi-temporal query"
+    };
+  }
+
+  // ListValuationFeatures retrieves all valuation features for an account.
+  // Optionally filters by lifecycle status.
+  rpc ListValuationFeatures(ListValuationFeaturesRequest) returns (ListValuationFeaturesResponse) {
+    option (google.api.http) = {
+      get: "/v1/current-accounts/{account_id}/valuation-features"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "List valuation features for an account"
+      description: "Retrieves all valuation features for an account with optional status filter"
     };
   }
 }

--- a/services/current-account/adapters/persistence/valuation_feature_entity.go
+++ b/services/current-account/adapters/persistence/valuation_feature_entity.go
@@ -1,0 +1,49 @@
+package persistence
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ValuationFeatureEntity represents the database persistence model for valuation features.
+// Optimized for database concerns: audit fields, indexes, constraints, bi-temporal validity.
+type ValuationFeatureEntity struct {
+	// Primary key
+	ID uuid.UUID `gorm:"primaryKey"`
+
+	// Foreign key to account table
+	AccountID uuid.UUID `gorm:"not null;index:idx_valuation_feature_account"`
+
+	// Input instrument code that will be valued
+	InstrumentCode string `gorm:"column:instrument_code;size:32;not null"`
+
+	// Reference to valuation method in Valuation Engine Service
+	ValuationMethodID      uuid.UUID `gorm:"column:valuation_method_id;not null;index:idx_valuation_feature_method"`
+	ValuationMethodVersion int       `gorm:"column:valuation_method_version;not null"`
+
+	// Method-specific parameters (JSON blob)
+	Parameters []byte `gorm:"type:jsonb"`
+
+	// Lifecycle status
+	LifecycleStatus string `gorm:"column:lifecycle_status;size:16;not null;check:lifecycle_status IN ('INITIATED','ACTIVE','TERMINATED')"`
+
+	// Bi-temporal validity
+	ValidFrom time.Time `gorm:"column:valid_from;not null;default:NOW();index:idx_valuation_feature_temporal"`
+	ValidTo   time.Time `gorm:"column:valid_to;not null;default:'9999-12-31 23:59:59+00';index:idx_valuation_feature_temporal"`
+
+	// Audit fields
+	CreatedAt time.Time `gorm:"not null"`
+	CreatedBy string    `gorm:"size:100;not null"`
+	UpdatedAt time.Time `gorm:"not null"`
+	UpdatedBy string    `gorm:"size:100;not null"`
+
+	// Optimistic locking
+	Version int `gorm:"not null;default:1"`
+}
+
+// TableName overrides the default table name.
+// Uses singular, unqualified name per database-per-service architecture.
+func (ValuationFeatureEntity) TableName() string {
+	return "valuation_features"
+}

--- a/services/current-account/adapters/persistence/valuation_feature_repository.go
+++ b/services/current-account/adapters/persistence/valuation_feature_repository.go
@@ -1,0 +1,291 @@
+package persistence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/current-account/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ValuationFeature repository errors
+var (
+	ErrValuationFeatureNotFound        = errors.New("valuation feature not found")
+	ErrValuationFeatureVersionConflict = errors.New("version conflict: valuation feature was modified by another transaction")
+	ErrValuationFeatureAlreadyExists   = errors.New("valuation feature already exists for this account and instrument")
+)
+
+// ValuationFeatureRepository provides persistence operations for valuation features
+type ValuationFeatureRepository struct {
+	db *gorm.DB
+}
+
+// NewValuationFeatureRepository creates a new valuation feature repository
+func NewValuationFeatureRepository(db *gorm.DB) *ValuationFeatureRepository {
+	return &ValuationFeatureRepository{db: db}
+}
+
+// WithTx returns a new ValuationFeatureRepository that uses the provided transaction.
+// This enables multiple repository operations within a single transaction.
+func (r *ValuationFeatureRepository) WithTx(tx *gorm.DB) *ValuationFeatureRepository {
+	return &ValuationFeatureRepository{db: tx}
+}
+
+// withTenantTransaction executes the given function with tenant scoping in a transaction.
+// The system is always multi-tenant - tenant context is ALWAYS required.
+// This wraps the function in a transaction and sets the search_path to the tenant's schema.
+func (r *ValuationFeatureRepository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// Create inserts a new valuation feature.
+// In multi-org mode, this operation is scoped to the organization from context.
+func (r *ValuationFeatureRepository) Create(ctx context.Context, feature *domain.ValuationFeature) error {
+	entity := toValuationFeatureEntity(feature)
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Create(entity).Error
+	})
+}
+
+// FindByID retrieves a valuation feature by its UUID.
+// In multi-org mode, this query is scoped to the organization from context.
+func (r *ValuationFeatureRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.ValuationFeature, error) {
+	var entity ValuationFeatureEntity
+	var queryErr error
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("id = ?", id).First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, ErrValuationFeatureNotFound
+		}
+		return nil, err
+	}
+
+	return toValuationFeatureDomain(&entity)
+}
+
+// FindByAccountIDAndInstrument retrieves an active valuation feature for a specific account and instrument.
+// This uses bi-temporal query: finds features valid at the given knowledge time.
+// In multi-org mode, this query is scoped to the organization from context.
+func (r *ValuationFeatureRepository) FindByAccountIDAndInstrument(
+	ctx context.Context,
+	accountID uuid.UUID,
+	instrumentCode string,
+	knowledgeAt time.Time,
+) (*domain.ValuationFeature, error) {
+	var entity ValuationFeatureEntity
+	var queryErr error
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where(
+			"account_id = ? AND instrument_code = ? AND lifecycle_status = ? AND valid_from <= ? AND valid_to > ?",
+			accountID, instrumentCode, string(domain.ValuationFeatureLifecycleStatusActive), knowledgeAt, knowledgeAt,
+		).First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, ErrValuationFeatureNotFound
+		}
+		return nil, err
+	}
+
+	return toValuationFeatureDomain(&entity)
+}
+
+// FindByAccountID retrieves all valuation features for an account.
+// Optionally filters by lifecycle status if provided.
+// In multi-org mode, this query is scoped to the organization from context.
+func (r *ValuationFeatureRepository) FindByAccountID(
+	ctx context.Context,
+	accountID uuid.UUID,
+	lifecycleStatus *domain.ValuationFeatureLifecycleStatus,
+) ([]*domain.ValuationFeature, error) {
+	var entities []ValuationFeatureEntity
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		query := tx.Where("account_id = ?", accountID)
+		if lifecycleStatus != nil {
+			query = query.Where("lifecycle_status = ?", string(*lifecycleStatus))
+		}
+		result := query.Order("created_at ASC").Find(&entities)
+		return result.Error
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	features := make([]*domain.ValuationFeature, 0, len(entities))
+	for _, entity := range entities {
+		feature, err := toValuationFeatureDomain(&entity)
+		if err != nil {
+			return nil, err
+		}
+		features = append(features, feature)
+	}
+
+	return features, nil
+}
+
+// FindByMethodID retrieves all active valuation features using a specific valuation method.
+// This is useful when a valuation method is updated and we need to find all affected features.
+// In multi-org mode, this query is scoped to the organization from context.
+func (r *ValuationFeatureRepository) FindByMethodID(ctx context.Context, methodID uuid.UUID) ([]*domain.ValuationFeature, error) {
+	var entities []ValuationFeatureEntity
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where(
+			"valuation_method_id = ? AND lifecycle_status = ?",
+			methodID, string(domain.ValuationFeatureLifecycleStatusActive),
+		).Find(&entities)
+		return result.Error
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	features := make([]*domain.ValuationFeature, 0, len(entities))
+	for _, entity := range entities {
+		feature, err := toValuationFeatureDomain(&entity)
+		if err != nil {
+			return nil, err
+		}
+		features = append(features, feature)
+	}
+
+	return features, nil
+}
+
+// Update updates an existing valuation feature with optimistic locking.
+// In multi-org mode, this operation is scoped to the organization from context.
+func (r *ValuationFeatureRepository) Update(ctx context.Context, feature *domain.ValuationFeature) error {
+	entity := toValuationFeatureEntity(feature)
+	var rowsAffected int64
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		// Optimistic locking: use WHERE clause with version check
+		result := tx.Model(&ValuationFeatureEntity{}).
+			Where("id = ? AND version = ?", entity.ID, feature.Version).
+			Updates(map[string]interface{}{
+				"lifecycle_status": entity.LifecycleStatus,
+				"valid_to":         entity.ValidTo,
+				"updated_at":       entity.UpdatedAt,
+				"updated_by":       entity.UpdatedBy,
+				"version":          feature.Version + 1,
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return ErrValuationFeatureVersionConflict
+	}
+
+	// Update domain model version
+	feature.Version++
+
+	return nil
+}
+
+// FindByIDForUpdate retrieves a valuation feature by its UUID with a pessimistic lock.
+// Use this within a transaction when you need to prevent concurrent modifications.
+// In multi-org mode, this query is scoped to the organization from context.
+func (r *ValuationFeatureRepository) FindByIDForUpdate(ctx context.Context, id uuid.UUID) (*domain.ValuationFeature, error) {
+	var entity ValuationFeatureEntity
+	var queryErr error
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", id).
+			First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, ErrValuationFeatureNotFound
+		}
+		return nil, err
+	}
+
+	return toValuationFeatureDomain(&entity)
+}
+
+// toValuationFeatureEntity converts domain model to database entity
+func toValuationFeatureEntity(feature *domain.ValuationFeature) *ValuationFeatureEntity {
+	var parametersJSON []byte
+	if feature.Parameters != nil {
+		// Ignore error - if JSON marshaling fails, we store nil
+		parametersJSON, _ = json.Marshal(feature.Parameters)
+	}
+
+	return &ValuationFeatureEntity{
+		ID:                     feature.ID,
+		AccountID:              feature.AccountID,
+		InstrumentCode:         feature.InstrumentCode,
+		ValuationMethodID:      feature.ValuationMethodID,
+		ValuationMethodVersion: feature.ValuationMethodVersion,
+		Parameters:             parametersJSON,
+		LifecycleStatus:        string(feature.LifecycleStatus),
+		ValidFrom:              feature.ValidFrom,
+		ValidTo:                feature.ValidTo,
+		CreatedAt:              feature.CreatedAt,
+		CreatedBy:              feature.CreatedBy,
+		UpdatedAt:              feature.UpdatedAt,
+		UpdatedBy:              feature.UpdatedBy,
+		Version:                feature.Version,
+	}
+}
+
+// toValuationFeatureDomain converts database entity to domain model
+func toValuationFeatureDomain(entity *ValuationFeatureEntity) (*domain.ValuationFeature, error) {
+	var parameters map[string]interface{}
+	if entity.Parameters != nil {
+		if err := json.Unmarshal(entity.Parameters, &parameters); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal valuation feature parameters: %w", err)
+		}
+	}
+
+	return &domain.ValuationFeature{
+		ID:                     entity.ID,
+		AccountID:              entity.AccountID,
+		InstrumentCode:         entity.InstrumentCode,
+		ValuationMethodID:      entity.ValuationMethodID,
+		ValuationMethodVersion: entity.ValuationMethodVersion,
+		Parameters:             parameters,
+		LifecycleStatus:        domain.ValuationFeatureLifecycleStatus(entity.LifecycleStatus),
+		ValidFrom:              entity.ValidFrom,
+		ValidTo:                entity.ValidTo,
+		CreatedAt:              entity.CreatedAt,
+		CreatedBy:              entity.CreatedBy,
+		UpdatedAt:              entity.UpdatedAt,
+		UpdatedBy:              entity.UpdatedBy,
+		Version:                entity.Version,
+	}, nil
+}

--- a/services/current-account/adapters/persistence/valuation_feature_repository.go
+++ b/services/current-account/adapters/persistence/valuation_feature_repository.go
@@ -37,17 +37,53 @@ func (r *ValuationFeatureRepository) WithTx(tx *gorm.DB) *ValuationFeatureReposi
 	return &ValuationFeatureRepository{db: tx}
 }
 
+// withTenantScope returns a GORM DB instance scoped to the tenant from context.
+// The system is always multi-tenant - tenant context is ALWAYS required.
+// This sets the PostgreSQL search_path to the tenant's schema (org_<tenant_id>).
+//
+// This must be called within a transaction for the search_path setting to work correctly.
+func (r *ValuationFeatureRepository) withTenantScope(ctx context.Context, tx *gorm.DB) (*gorm.DB, error) {
+	return db.WithGormTenantScope(ctx, tx)
+}
+
 // withTenantTransaction executes the given function with tenant scoping in a transaction.
 // The system is always multi-tenant - tenant context is ALWAYS required.
 // This wraps the function in a transaction and sets the search_path to the tenant's schema.
+//
+// If already in a transaction (via WithTx), it uses the existing transaction directly
+// with tenant scope set. This avoids creating unnecessary savepoints in GORM v1.31+.
 func (r *ValuationFeatureRepository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if r.isInTransaction() {
+		// Already in a transaction (via WithTx) - use it directly with tenant scope
+		tx, err := r.withTenantScope(ctx, r.db.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+		return fn(tx)
+	}
 	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// isInTransaction checks if the repository's db connection is already within a transaction.
+// This is used to avoid creating nested transactions when the caller has already established one.
+func (r *ValuationFeatureRepository) isInTransaction() bool {
+	// Guard against uninitialized Statement (can happen if no query has been executed yet)
+	if r.db.Statement == nil || r.db.Statement.ConnPool == nil {
+		return false
+	}
+	// GORM sets ConnPool to a transaction object when in transaction mode.
+	// In a transaction, Statement.ConnPool will be of type *sql.Tx (or GORM's tx wrapper).
+	committer, ok := r.db.Statement.ConnPool.(gorm.TxCommitter)
+	return ok && committer != nil
 }
 
 // Create inserts a new valuation feature.
 // In multi-org mode, this operation is scoped to the organization from context.
 func (r *ValuationFeatureRepository) Create(ctx context.Context, feature *domain.ValuationFeature) error {
-	entity := toValuationFeatureEntity(feature)
+	entity, err := toValuationFeatureEntity(feature)
+	if err != nil {
+		return fmt.Errorf("%w: %w", domain.ErrInvalidValuationFeatureParameters, err)
+	}
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		return tx.Create(entity).Error
 	})
@@ -176,10 +212,13 @@ func (r *ValuationFeatureRepository) FindByMethodID(ctx context.Context, methodI
 // Update updates an existing valuation feature with optimistic locking.
 // In multi-org mode, this operation is scoped to the organization from context.
 func (r *ValuationFeatureRepository) Update(ctx context.Context, feature *domain.ValuationFeature) error {
-	entity := toValuationFeatureEntity(feature)
+	entity, err := toValuationFeatureEntity(feature)
+	if err != nil {
+		return fmt.Errorf("%w: %w", domain.ErrInvalidValuationFeatureParameters, err)
+	}
 	var rowsAffected int64
 
-	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+	err = r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		// Optimistic locking: use WHERE clause with version check
 		result := tx.Model(&ValuationFeatureEntity{}).
 			Where("id = ? AND version = ?", entity.ID, feature.Version).
@@ -237,12 +276,16 @@ func (r *ValuationFeatureRepository) FindByIDForUpdate(ctx context.Context, id u
 	return toValuationFeatureDomain(&entity)
 }
 
-// toValuationFeatureEntity converts domain model to database entity
-func toValuationFeatureEntity(feature *domain.ValuationFeature) *ValuationFeatureEntity {
+// toValuationFeatureEntity converts domain model to database entity.
+// Returns an error if parameter marshaling fails (e.g., unsupported types, cyclic structures).
+func toValuationFeatureEntity(feature *domain.ValuationFeature) (*ValuationFeatureEntity, error) {
 	var parametersJSON []byte
+	var err error
 	if feature.Parameters != nil {
-		// Ignore error - if JSON marshaling fails, we store nil
-		parametersJSON, _ = json.Marshal(feature.Parameters)
+		parametersJSON, err = json.Marshal(feature.Parameters)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal parameters: %w", err)
+		}
 	}
 
 	return &ValuationFeatureEntity{
@@ -260,7 +303,7 @@ func toValuationFeatureEntity(feature *domain.ValuationFeature) *ValuationFeatur
 		UpdatedAt:              feature.UpdatedAt,
 		UpdatedBy:              feature.UpdatedBy,
 		Version:                feature.Version,
-	}
+	}, nil
 }
 
 // toValuationFeatureDomain converts database entity to domain model

--- a/services/current-account/adapters/persistence/valuation_feature_repository_test.go
+++ b/services/current-account/adapters/persistence/valuation_feature_repository_test.go
@@ -1,0 +1,382 @@
+package persistence
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/current-account/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupValuationFeatureTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{&ValuationFeatureEntity{}})
+
+	// Create the tenant schema for tests
+	tid := tenant.TenantID(testTenantID)
+	schemaName := tid.SchemaName()
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
+	require.NoError(t, err)
+
+	// Create the valuation_features table in the tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.valuation_features (
+		id UUID PRIMARY KEY,
+		account_id UUID NOT NULL,
+		instrument_code VARCHAR(32) NOT NULL,
+		valuation_method_id UUID NOT NULL,
+		valuation_method_version INT NOT NULL,
+		parameters JSONB,
+		lifecycle_status VARCHAR(16) NOT NULL,
+		valid_from TIMESTAMP WITH TIME ZONE NOT NULL,
+		valid_to TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(100) NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_by VARCHAR(100) NOT NULL,
+		version INT NOT NULL DEFAULT 1,
+		CONSTRAINT chk_valuation_feature_lifecycle_status CHECK (lifecycle_status IN ('INITIATED','ACTIVE','TERMINATED'))
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create unique index for active features
+	err = db.Exec(fmt.Sprintf(`CREATE UNIQUE INDEX idx_valuation_feature_account_instrument_active
+		ON %q.valuation_features (account_id, instrument_code)
+		WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00'`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Set default search_path to include tenant schema
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	require.NoError(t, err)
+
+	// Create context with tenant
+	ctx := tenant.WithTenant(context.Background(), tid)
+
+	return db, ctx, cleanup
+}
+
+func TestValuationFeatureRepository_Create(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+	accountID := uuid.New()
+	methodID := uuid.New()
+	parameters := map[string]interface{}{
+		"source": "ECB",
+		"lag":    "1D",
+	}
+
+	feature, err := domain.NewValuationFeature(accountID, "USD", methodID, 1, parameters, "creator")
+	require.NoError(t, err)
+
+	err = repo.Create(ctx, feature)
+	require.NoError(t, err)
+
+	// Verify feature was saved
+	retrieved, err := repo.FindByID(ctx, feature.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, feature.ID, retrieved.ID)
+	assert.Equal(t, accountID, retrieved.AccountID)
+	assert.Equal(t, "USD", retrieved.InstrumentCode)
+	assert.Equal(t, methodID, retrieved.ValuationMethodID)
+	assert.Equal(t, 1, retrieved.ValuationMethodVersion)
+	assert.Equal(t, domain.ValuationFeatureLifecycleStatusInitiated, retrieved.LifecycleStatus)
+	assert.Equal(t, "creator", retrieved.CreatedBy)
+	assert.Equal(t, parameters, retrieved.Parameters)
+}
+
+func TestValuationFeatureRepository_FindByID_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+
+	_, err := repo.FindByID(ctx, uuid.New())
+	assert.ErrorIs(t, err, ErrValuationFeatureNotFound)
+}
+
+func TestValuationFeatureRepository_FindByAccountIDAndInstrument(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	// Create and activate a feature
+	feature, err := domain.NewValuationFeature(accountID, "USD", methodID, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, feature.Activate("activator"))
+	require.NoError(t, repo.Create(ctx, feature))
+
+	// Find the feature
+	knowledgeAt := time.Now()
+	retrieved, err := repo.FindByAccountIDAndInstrument(ctx, accountID, "USD", knowledgeAt)
+	require.NoError(t, err)
+
+	assert.Equal(t, feature.ID, retrieved.ID)
+	assert.Equal(t, accountID, retrieved.AccountID)
+	assert.Equal(t, "USD", retrieved.InstrumentCode)
+	assert.Equal(t, domain.ValuationFeatureLifecycleStatusActive, retrieved.LifecycleStatus)
+}
+
+func TestValuationFeatureRepository_FindByAccountIDAndInstrument_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+	accountID := uuid.New()
+
+	knowledgeAt := time.Now()
+	_, err := repo.FindByAccountIDAndInstrument(ctx, accountID, "USD", knowledgeAt)
+	assert.ErrorIs(t, err, ErrValuationFeatureNotFound)
+}
+
+func TestValuationFeatureRepository_FindByAccountIDAndInstrument_BiTemporal(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	// Create and activate a feature
+	feature, err := domain.NewValuationFeature(accountID, "USD", methodID, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, feature.Activate("activator"))
+
+	// Set specific validity range
+	validFrom := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	validTo := time.Date(2024, 12, 31, 23, 59, 59, 0, time.UTC)
+	feature.ValidFrom = validFrom
+	feature.ValidTo = validTo
+
+	require.NoError(t, repo.Create(ctx, feature))
+
+	// Query within validity range - should find
+	knowledgeAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	retrieved, err := repo.FindByAccountIDAndInstrument(ctx, accountID, "USD", knowledgeAt)
+	require.NoError(t, err)
+	assert.Equal(t, feature.ID, retrieved.ID)
+
+	// Query before validity range - should not find
+	knowledgeAt = time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+	_, err = repo.FindByAccountIDAndInstrument(ctx, accountID, "USD", knowledgeAt)
+	assert.ErrorIs(t, err, ErrValuationFeatureNotFound)
+
+	// Query after validity range - should not find
+	knowledgeAt = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, err = repo.FindByAccountIDAndInstrument(ctx, accountID, "USD", knowledgeAt)
+	assert.ErrorIs(t, err, ErrValuationFeatureNotFound)
+}
+
+func TestValuationFeatureRepository_FindByAccountID(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	// Create multiple features
+	feature1, err := domain.NewValuationFeature(accountID, "USD", methodID, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, feature1))
+
+	feature2, err := domain.NewValuationFeature(accountID, "EUR", methodID, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, feature2.Activate("activator"))
+	require.NoError(t, repo.Create(ctx, feature2))
+
+	// Create feature for different account
+	otherAccountID := uuid.New()
+	feature3, err := domain.NewValuationFeature(otherAccountID, "USD", methodID, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, feature3))
+
+	// Find all features for account
+	features, err := repo.FindByAccountID(ctx, accountID, nil)
+	require.NoError(t, err)
+	assert.Len(t, features, 2)
+
+	// Find only active features for account
+	activeStatus := domain.ValuationFeatureLifecycleStatusActive
+	features, err = repo.FindByAccountID(ctx, accountID, &activeStatus)
+	require.NoError(t, err)
+	assert.Len(t, features, 1)
+	assert.Equal(t, "EUR", features[0].InstrumentCode)
+}
+
+func TestValuationFeatureRepository_FindByMethodID(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+	accountID := uuid.New()
+	methodID1 := uuid.New()
+	methodID2 := uuid.New()
+
+	// Create active feature with methodID1
+	feature1, err := domain.NewValuationFeature(accountID, "USD", methodID1, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, feature1.Activate("activator"))
+	require.NoError(t, repo.Create(ctx, feature1))
+
+	// Create inactive feature with methodID1 (should not be returned)
+	feature2, err := domain.NewValuationFeature(accountID, "EUR", methodID1, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, feature2))
+
+	// Create active feature with methodID2
+	feature3, err := domain.NewValuationFeature(accountID, "GBP", methodID2, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, feature3.Activate("activator"))
+	require.NoError(t, repo.Create(ctx, feature3))
+
+	// Find active features for methodID1
+	features, err := repo.FindByMethodID(ctx, methodID1)
+	require.NoError(t, err)
+	assert.Len(t, features, 1)
+	assert.Equal(t, "USD", features[0].InstrumentCode)
+}
+
+func TestValuationFeatureRepository_Update(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	// Create feature
+	feature, err := domain.NewValuationFeature(accountID, "USD", methodID, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, feature))
+	initialVersion := feature.Version
+
+	// Activate feature
+	require.NoError(t, feature.Activate("activator"))
+	err = repo.Update(ctx, feature)
+	require.NoError(t, err)
+
+	// Verify version was incremented
+	assert.Equal(t, initialVersion+1, feature.Version)
+
+	// Retrieve and verify update
+	retrieved, err := repo.FindByID(ctx, feature.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.ValuationFeatureLifecycleStatusActive, retrieved.LifecycleStatus)
+	assert.Equal(t, "activator", retrieved.UpdatedBy)
+}
+
+func TestValuationFeatureRepository_Update_OptimisticLocking(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	// Create feature
+	feature, err := domain.NewValuationFeature(accountID, "USD", methodID, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, feature))
+
+	// Retrieve twice to simulate concurrent access
+	feature1, err := repo.FindByID(ctx, feature.ID)
+	require.NoError(t, err)
+	feature2, err := repo.FindByID(ctx, feature.ID)
+	require.NoError(t, err)
+
+	// First update succeeds
+	require.NoError(t, feature1.Activate("user1"))
+	err = repo.Update(ctx, feature1)
+	require.NoError(t, err)
+
+	// Second update fails due to version conflict
+	require.NoError(t, feature2.Activate("user2"))
+	err = repo.Update(ctx, feature2)
+	assert.ErrorIs(t, err, ErrValuationFeatureVersionConflict)
+}
+
+func TestValuationFeatureRepository_FindByIDForUpdate(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	// Create feature
+	feature, err := domain.NewValuationFeature(accountID, "USD", methodID, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, feature))
+
+	// Retrieve with pessimistic lock
+	locked, err := repo.FindByIDForUpdate(ctx, feature.ID)
+	require.NoError(t, err)
+	assert.Equal(t, feature.ID, locked.ID)
+}
+
+func TestValuationFeatureRepository_UniqueConstraint(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	// Create and activate first feature
+	feature1, err := domain.NewValuationFeature(accountID, "USD", methodID, 1, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, feature1.Activate("activator"))
+	require.NoError(t, repo.Create(ctx, feature1))
+
+	// Create and activate second feature with same account and instrument - should fail unique constraint
+	feature2, err := domain.NewValuationFeature(accountID, "USD", methodID, 2, nil, "creator")
+	require.NoError(t, err)
+	require.NoError(t, feature2.Activate("activator"))
+	err = repo.Create(ctx, feature2)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "idx_valuation_feature_account_instrument_active")
+}
+
+func TestValuationFeatureRepository_ParametersMarshaling(t *testing.T) {
+	db, ctx, cleanup := setupValuationFeatureTestDB(t)
+	defer cleanup()
+
+	repo := NewValuationFeatureRepository(db)
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	// Create feature with complex parameters
+	parameters := map[string]interface{}{
+		"source":          "ECB",
+		"lag":             "1D",
+		"fallback_source": "Bloomberg",
+		"precision":       6,
+		"rounding":        "half_up",
+	}
+
+	feature, err := domain.NewValuationFeature(accountID, "USD", methodID, 1, parameters, "creator")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, feature))
+
+	// Retrieve and verify parameters are unmarshaled correctly
+	retrieved, err := repo.FindByID(ctx, feature.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "ECB", retrieved.Parameters["source"])
+	assert.Equal(t, "1D", retrieved.Parameters["lag"])
+	assert.Equal(t, "Bloomberg", retrieved.Parameters["fallback_source"])
+	// JSON unmarshaling converts numbers to float64
+	assert.Equal(t, float64(6), retrieved.Parameters["precision"])
+	assert.Equal(t, "half_up", retrieved.Parameters["rounding"])
+}

--- a/services/current-account/domain/valuation_feature.go
+++ b/services/current-account/domain/valuation_feature.go
@@ -1,0 +1,147 @@
+package domain
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ValuationFeature domain errors
+var (
+	ErrInvalidValuationFeatureTransition = errors.New("invalid valuation feature lifecycle transition")
+	ErrValuationFeatureNotActive         = errors.New("valuation feature is not in active status")
+	ErrInvalidValuationFeatureParameters = errors.New("invalid valuation feature parameters")
+	ErrInvalidTemporalRange              = errors.New("valid_from must be before valid_to")
+	ErrInstrumentCodeEmpty               = errors.New("instrument_code cannot be empty")
+)
+
+// ValuationFeatureLifecycleStatus represents the lifecycle state of a valuation feature
+type ValuationFeatureLifecycleStatus string
+
+// Valuation feature lifecycle status constants following ADR-012
+const (
+	ValuationFeatureLifecycleStatusInitiated  ValuationFeatureLifecycleStatus = "INITIATED"
+	ValuationFeatureLifecycleStatusActive     ValuationFeatureLifecycleStatus = "ACTIVE"
+	ValuationFeatureLifecycleStatusTerminated ValuationFeatureLifecycleStatus = "TERMINATED"
+)
+
+// ValuationFeature represents a valuation method assignment to an account.
+// It maps an input instrument (e.g., USD) to the account's native instrument (e.g., GBP)
+// using a specific valuation method from the Valuation Engine Service.
+//
+// Invariant: One account can have at most one ACTIVE valuation feature per input instrument.
+// Example: Account with native_instrument=GBP can have:
+//   - USD→GBP feature (active)
+//   - EUR→GBP feature (active)
+//     But NOT two active USD→GBP features
+//
+// Note: Fields are exported for persistence layer access. State transitions should only be
+// performed via Activate() and Terminate() methods which enforce the state machine invariants.
+// The Version field is a persistence concern exposed here for optimistic locking support.
+type ValuationFeature struct {
+	ID                     uuid.UUID
+	AccountID              uuid.UUID
+	InstrumentCode         string                 // Input instrument to be valued
+	ValuationMethodID      uuid.UUID              // Reference to Valuation Engine Service method
+	ValuationMethodVersion int                    // Method version for immutability
+	Parameters             map[string]interface{} // Method-specific parameters (JSON)
+	LifecycleStatus        ValuationFeatureLifecycleStatus
+	ValidFrom              time.Time // Bi-temporal validity start
+	ValidTo                time.Time // Bi-temporal validity end
+	CreatedAt              time.Time
+	CreatedBy              string
+	UpdatedAt              time.Time
+	UpdatedBy              string
+	Version                int
+}
+
+// NewValuationFeature creates a new valuation feature in INITIATED status.
+// The feature will need to be activated via Activate() before it can be used.
+func NewValuationFeature(
+	accountID uuid.UUID,
+	instrumentCode string,
+	methodID uuid.UUID,
+	methodVersion int,
+	parameters map[string]interface{},
+	createdBy string,
+) (*ValuationFeature, error) {
+	if instrumentCode == "" {
+		return nil, ErrInstrumentCodeEmpty
+	}
+
+	now := time.Now()
+	maxTime := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+
+	return &ValuationFeature{
+		ID:                     uuid.New(),
+		AccountID:              accountID,
+		InstrumentCode:         instrumentCode,
+		ValuationMethodID:      methodID,
+		ValuationMethodVersion: methodVersion,
+		Parameters:             parameters,
+		LifecycleStatus:        ValuationFeatureLifecycleStatusInitiated,
+		ValidFrom:              now,
+		ValidTo:                maxTime,
+		CreatedAt:              now,
+		CreatedBy:              createdBy,
+		UpdatedAt:              now,
+		UpdatedBy:              createdBy,
+		Version:                1,
+	}, nil
+}
+
+// Activate transitions the valuation feature to ACTIVE status.
+// This makes the feature available for use in valuation operations.
+// Idempotent: Returns nil if already active.
+func (vf *ValuationFeature) Activate(updatedBy string) error {
+	if vf.LifecycleStatus == ValuationFeatureLifecycleStatusActive {
+		return nil // Idempotent
+	}
+
+	if vf.LifecycleStatus != ValuationFeatureLifecycleStatusInitiated {
+		return ErrInvalidValuationFeatureTransition
+	}
+
+	vf.LifecycleStatus = ValuationFeatureLifecycleStatusActive
+	vf.UpdatedAt = time.Now()
+	vf.UpdatedBy = updatedBy
+	return nil
+}
+
+// Terminate transitions the valuation feature to TERMINATED status (terminal state).
+// This is called when the feature is no longer needed or being replaced.
+// The valid_to timestamp is set to the current time to end bi-temporal validity.
+// Idempotent: Returns nil if already terminated.
+func (vf *ValuationFeature) Terminate(updatedBy string) error {
+	if vf.LifecycleStatus == ValuationFeatureLifecycleStatusTerminated {
+		return nil // Idempotent
+	}
+
+	if vf.LifecycleStatus != ValuationFeatureLifecycleStatusActive {
+		return ErrInvalidValuationFeatureTransition
+	}
+
+	now := time.Now()
+	vf.LifecycleStatus = ValuationFeatureLifecycleStatusTerminated
+	vf.ValidTo = now
+	vf.UpdatedAt = now
+	vf.UpdatedBy = updatedBy
+	return nil
+}
+
+// IsActive returns true if the valuation feature is in ACTIVE status
+func (vf *ValuationFeature) IsActive() bool {
+	return vf.LifecycleStatus == ValuationFeatureLifecycleStatusActive
+}
+
+// IsTerminal returns true if the valuation feature is in a terminal state (TERMINATED)
+func (vf *ValuationFeature) IsTerminal() bool {
+	return vf.LifecycleStatus == ValuationFeatureLifecycleStatusTerminated
+}
+
+// IsValidAt returns true if the valuation feature is valid at the given knowledge time
+// using bi-temporal validity checking.
+func (vf *ValuationFeature) IsValidAt(knowledgeAt time.Time) bool {
+	return !knowledgeAt.Before(vf.ValidFrom) && knowledgeAt.Before(vf.ValidTo)
+}

--- a/services/current-account/domain/valuation_feature_test.go
+++ b/services/current-account/domain/valuation_feature_test.go
@@ -1,0 +1,210 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewValuationFeature(t *testing.T) {
+	accountID := uuid.New()
+	methodID := uuid.New()
+	instrumentCode := "USD"
+	methodVersion := 1
+	parameters := map[string]interface{}{
+		"source": "ECB",
+		"lag":    "1D",
+	}
+	createdBy := "test-user"
+
+	feature, err := NewValuationFeature(accountID, instrumentCode, methodID, methodVersion, parameters, createdBy)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, feature.ID)
+	assert.Equal(t, accountID, feature.AccountID)
+	assert.Equal(t, instrumentCode, feature.InstrumentCode)
+	assert.Equal(t, methodID, feature.ValuationMethodID)
+	assert.Equal(t, methodVersion, feature.ValuationMethodVersion)
+	assert.Equal(t, parameters, feature.Parameters)
+	assert.Equal(t, ValuationFeatureLifecycleStatusInitiated, feature.LifecycleStatus)
+	assert.Equal(t, createdBy, feature.CreatedBy)
+	assert.Equal(t, createdBy, feature.UpdatedBy)
+	assert.Equal(t, 1, feature.Version)
+	assert.False(t, feature.ValidFrom.IsZero())
+	assert.True(t, feature.ValidTo.Year() == 9999) // Max timestamp
+}
+
+func TestNewValuationFeature_EmptyInstrumentCode(t *testing.T) {
+	accountID := uuid.New()
+	methodID := uuid.New()
+
+	_, err := NewValuationFeature(accountID, "", methodID, 1, nil, "test-user")
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInstrumentCodeEmpty)
+}
+
+func TestValuationFeature_Activate(t *testing.T) {
+	feature, err := NewValuationFeature(uuid.New(), "USD", uuid.New(), 1, nil, "creator")
+	require.NoError(t, err)
+
+	updatedBy := "activator"
+	err = feature.Activate(updatedBy)
+
+	require.NoError(t, err)
+	assert.Equal(t, ValuationFeatureLifecycleStatusActive, feature.LifecycleStatus)
+	assert.Equal(t, updatedBy, feature.UpdatedBy)
+	assert.True(t, feature.IsActive())
+}
+
+func TestValuationFeature_Activate_Idempotent(t *testing.T) {
+	feature, err := NewValuationFeature(uuid.New(), "USD", uuid.New(), 1, nil, "creator")
+	require.NoError(t, err)
+
+	// First activation
+	err = feature.Activate("user1")
+	require.NoError(t, err)
+
+	// Second activation - should be idempotent
+	err = feature.Activate("user2")
+	require.NoError(t, err)
+	assert.Equal(t, ValuationFeatureLifecycleStatusActive, feature.LifecycleStatus)
+}
+
+func TestValuationFeature_Activate_InvalidTransition(t *testing.T) {
+	feature, err := NewValuationFeature(uuid.New(), "USD", uuid.New(), 1, nil, "creator")
+	require.NoError(t, err)
+
+	// Terminate the feature first
+	err = feature.Activate("user1")
+	require.NoError(t, err)
+	err = feature.Terminate("user1")
+	require.NoError(t, err)
+
+	// Try to activate a terminated feature - should fail
+	err = feature.Activate("user2")
+	require.Error(t, err)
+	assert.Equal(t, ErrInvalidValuationFeatureTransition, err)
+}
+
+func TestValuationFeature_Terminate(t *testing.T) {
+	feature, err := NewValuationFeature(uuid.New(), "USD", uuid.New(), 1, nil, "creator")
+	require.NoError(t, err)
+
+	// Activate first
+	err = feature.Activate("activator")
+	require.NoError(t, err)
+
+	// Terminate
+	beforeTerminate := time.Now()
+	updatedBy := "terminator"
+	err = feature.Terminate(updatedBy)
+
+	require.NoError(t, err)
+	assert.Equal(t, ValuationFeatureLifecycleStatusTerminated, feature.LifecycleStatus)
+	assert.Equal(t, updatedBy, feature.UpdatedBy)
+	assert.True(t, feature.IsTerminal())
+	// ValidTo should be set to current time (within reasonable tolerance)
+	assert.True(t, feature.ValidTo.After(beforeTerminate))
+	assert.True(t, feature.ValidTo.Before(time.Now().Add(1*time.Second)))
+}
+
+func TestValuationFeature_Terminate_Idempotent(t *testing.T) {
+	feature, err := NewValuationFeature(uuid.New(), "USD", uuid.New(), 1, nil, "creator")
+	require.NoError(t, err)
+
+	// Activate and terminate
+	err = feature.Activate("user1")
+	require.NoError(t, err)
+	err = feature.Terminate("user1")
+	require.NoError(t, err)
+
+	// Second termination - should be idempotent
+	err = feature.Terminate("user2")
+	require.NoError(t, err)
+	assert.Equal(t, ValuationFeatureLifecycleStatusTerminated, feature.LifecycleStatus)
+}
+
+func TestValuationFeature_Terminate_InvalidTransition(t *testing.T) {
+	feature, err := NewValuationFeature(uuid.New(), "USD", uuid.New(), 1, nil, "creator")
+	require.NoError(t, err)
+
+	// Try to terminate without activating first - should fail
+	err = feature.Terminate("user1")
+	require.Error(t, err)
+	assert.Equal(t, ErrInvalidValuationFeatureTransition, err)
+}
+
+func TestValuationFeature_IsValidAt(t *testing.T) {
+	feature, err := NewValuationFeature(uuid.New(), "USD", uuid.New(), 1, nil, "creator")
+	require.NoError(t, err)
+
+	// Set specific validity range for testing
+	validFrom := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	validTo := time.Date(2024, 12, 31, 23, 59, 59, 0, time.UTC)
+	feature.ValidFrom = validFrom
+	feature.ValidTo = validTo
+
+	testCases := []struct {
+		name        string
+		knowledgeAt time.Time
+		expected    bool
+	}{
+		{
+			name:        "before validity range",
+			knowledgeAt: time.Date(2023, 12, 31, 23, 59, 59, 0, time.UTC),
+			expected:    false,
+		},
+		{
+			name:        "at start of validity range",
+			knowledgeAt: validFrom,
+			expected:    true,
+		},
+		{
+			name:        "within validity range",
+			knowledgeAt: time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC),
+			expected:    true,
+		},
+		{
+			name:        "at end of validity range",
+			knowledgeAt: validTo,
+			expected:    false, // ValidTo is exclusive
+		},
+		{
+			name:        "after validity range",
+			knowledgeAt: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := feature.IsValidAt(tc.knowledgeAt)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestValuationFeature_LifecycleStates(t *testing.T) {
+	feature, err := NewValuationFeature(uuid.New(), "USD", uuid.New(), 1, nil, "creator")
+	require.NoError(t, err)
+
+	// INITIATED state
+	assert.False(t, feature.IsActive())
+	assert.False(t, feature.IsTerminal())
+
+	// ACTIVE state
+	err = feature.Activate("user1")
+	require.NoError(t, err)
+	assert.True(t, feature.IsActive())
+	assert.False(t, feature.IsTerminal())
+
+	// TERMINATED state
+	err = feature.Terminate("user1")
+	require.NoError(t, err)
+	assert.False(t, feature.IsActive())
+	assert.True(t, feature.IsTerminal())
+}

--- a/services/current-account/migrations/20260206000001_create_valuation_features.sql
+++ b/services/current-account/migrations/20260206000001_create_valuation_features.sql
@@ -1,0 +1,71 @@
+-- Create valuation_features table for storing valuation method assignments
+-- This table links accounts to valuation methods for specific instrument transformations
+-- Example: Account with native_instrument=GBP has a valuation feature mapping USD→GBP
+
+CREATE TABLE IF NOT EXISTS valuation_features (
+    -- Primary key
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Foreign key to account table
+    account_id UUID NOT NULL,
+
+    -- Input instrument that will be valued (e.g., "USD", "EUR", "kWh")
+    instrument_code VARCHAR(32) NOT NULL,
+
+    -- Reference to the valuation method (managed by Valuation Engine Service)
+    valuation_method_id UUID NOT NULL,
+    valuation_method_version INT NOT NULL,
+
+    -- Method-specific parameters (JSON blob for flexibility)
+    parameters JSONB,
+
+    -- Lifecycle status following ADR-012 pattern
+    lifecycle_status VARCHAR(16) NOT NULL,
+
+    -- Bi-temporal validity tracking
+    valid_from TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    valid_to TIMESTAMPTZ NOT NULL DEFAULT '9999-12-31 23:59:59+00',
+
+    -- Audit fields
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by VARCHAR(100) NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by VARCHAR(100) NOT NULL,
+
+    -- Optimistic locking
+    version INT NOT NULL DEFAULT 1,
+
+    -- Constraints
+    CONSTRAINT chk_valuation_feature_lifecycle_status
+        CHECK (lifecycle_status IN ('INITIATED', 'ACTIVE', 'TERMINATED')),
+    CONSTRAINT chk_valuation_feature_temporal_range
+        CHECK (valid_from < valid_to),
+
+    -- Foreign key to account
+    CONSTRAINT fk_valuation_feature_account
+        FOREIGN KEY (account_id) REFERENCES "account" (id)
+        ON UPDATE NO ACTION ON DELETE RESTRICT
+);
+
+-- Unique constraint: one active valuation method per (account, instrument) combination
+-- This ensures we don't have conflicting methods for the same input instrument
+CREATE UNIQUE INDEX idx_valuation_feature_account_instrument_active
+    ON valuation_features (account_id, instrument_code)
+    WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00';
+
+-- Index for efficient queries by valuation method
+CREATE INDEX idx_valuation_feature_method
+    ON valuation_features (valuation_method_id)
+    WHERE lifecycle_status = 'ACTIVE';
+
+-- Bi-temporal query index
+CREATE INDEX idx_valuation_feature_temporal
+    ON valuation_features (account_id, valid_from, valid_to);
+
+-- Index for finding all features for an account
+CREATE INDEX idx_valuation_feature_account
+    ON valuation_features (account_id);
+
+-- Comment documenting the table purpose
+COMMENT ON TABLE valuation_features IS
+    'Stores valuation method assignments for accounts. Each feature maps an input instrument to the account native instrument using a specific valuation method.';

--- a/services/current-account/migrations/20260206000002_backfill_identity_valuation_features.sql
+++ b/services/current-account/migrations/20260206000002_backfill_identity_valuation_features.sql
@@ -1,0 +1,66 @@
+-- Backfill identity valuation methods for existing accounts
+-- This migration creates valuation features for all existing accounts
+-- mapping their native currency to itself (e.g., USD→USD, GBP→GBP)
+
+-- Note: This migration assumes the Valuation Engine Service has been deployed
+-- with identity methods registered. The method IDs are placeholders and should
+-- be updated with actual method IDs from the Valuation Engine Service.
+
+-- TODO: Replace these placeholder UUIDs with actual identity method IDs from Valuation Engine Service
+-- These would be retrieved via: SELECT id FROM valuation_methods WHERE method_type = 'IDENTITY' AND input_instrument = output_instrument
+
+-- For now, this migration is a template. The actual backfill should be done via
+-- an application-level data migration that:
+-- 1. Queries all accounts
+-- 2. For each account currency, looks up the identity method from Valuation Engine Service
+-- 3. Creates an ACTIVE valuation feature for that account
+
+-- Example of what the backfill would look like (commented out as it requires runtime data):
+/*
+INSERT INTO valuation_features (
+    id,
+    account_id,
+    instrument_code,
+    valuation_method_id,
+    valuation_method_version,
+    parameters,
+    lifecycle_status,
+    valid_from,
+    valid_to,
+    created_at,
+    created_by,
+    updated_at,
+    updated_by,
+    version
+)
+SELECT
+    gen_random_uuid() as id,
+    a.id as account_id,
+    a.currency as instrument_code,
+    '00000000-0000-0000-0000-000000000000'::uuid as valuation_method_id, -- Placeholder - needs actual identity method ID
+    1 as valuation_method_version,
+    NULL as parameters,
+    'ACTIVE' as lifecycle_status,
+    NOW() as valid_from,
+    '9999-12-31 23:59:59+00'::timestamptz as valid_to,
+    NOW() as created_at,
+    'system-migration' as created_by,
+    NOW() as updated_at,
+    'system-migration' as updated_by,
+    1 as version
+FROM account a
+WHERE NOT EXISTS (
+    -- Don't create duplicate features
+    SELECT 1 FROM valuation_features vf
+    WHERE vf.account_id = a.id
+    AND vf.instrument_code = a.currency
+    AND vf.lifecycle_status = 'ACTIVE'
+);
+*/
+
+-- This migration intentionally left empty - backfill will be done via application code
+-- after the Valuation Engine Service is deployed and identity methods are registered.
+
+-- Comment documenting the backfill strategy
+COMMENT ON TABLE valuation_features IS
+    'Stores valuation method assignments for accounts. Each feature maps an input instrument to the account native instrument using a specific valuation method. Backfill migration postponed until Valuation Engine Service is deployed.';

--- a/services/current-account/migrations/atlas.sum
+++ b/services/current-account/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:yhR9DC3nL++Yh8bB6NZKK8rC5Msyg2wAZwKzLnyKT30=
+h1:7upMlkevtJhGO6v6OALfxux7UNzUm+dTeIWXpHFx6d8=
 20251216000001_initial.sql h1:nyRf35O3eYNJqShAvOEhvliXKLIR6e/V8B9JhOHde9w=
 20251216000002_audit_system.sql h1:X/0ZHt9cGTYmFbUUvKAkBgEiGw9fYEqfnbMB8I4SCR8=
 20251217000001_fix_audit_status_constraint.sql h1:yQxsHxbUp5g+ehkKFjOhZs59SbfaQIPw4/sA2xE2rwU=
@@ -8,3 +8,5 @@ h1:yhR9DC3nL++Yh8bB6NZKK8rC5Msyg2wAZwKzLnyKT30=
 20260105000001_add_lien_bucket_id.sql h1:nGbCuQ/wY4lIukHaroCRBSkY2dvYYP6+7ngTWM1ioF0=
 20260108000001_remove_balance_columns.sql h1:FtFNJFJ4Qq6uak6lMcQ8HeIWKmLOBCL9xKcJy082src=
 20260204000001_create_event_outbox.sql h1:I/qe9fY9RaojTVqgSP0Rjou7yOT3GBaFh0oenOxf7h4=
+20260206000001_create_valuation_features.sql h1:afkwAHh/DQwXK6yxkI6/mIM2gHxCtl0We8tLryTkuBM=
+20260206000002_backfill_identity_valuation_features.sql h1:wIVobmzXhvXQxrVmLobT9q7j/Tjq7gkCu409B5893Ug=

--- a/services/current-account/service/grpc_service.go
+++ b/services/current-account/service/grpc_service.go
@@ -141,8 +141,9 @@ type Service struct {
 	repo                   *persistence.Repository
 	lienRepo               *persistence.LienRepository
 	withdrawalRepo         *persistence.WithdrawalRepository
-	outboxRepo             events.OutboxRepository // Outbox repository for reliable event delivery
-	db                     *gorm.DB                // Database connection for transaction management
+	valuationFeatureRepo   *persistence.ValuationFeatureRepository // ValuationFeature repository for valuation method assignments
+	outboxRepo             events.OutboxRepository                 // Outbox repository for reliable event delivery
+	db                     *gorm.DB                                // Database connection for transaction management
 	posKeepingClient       PositionKeepingClient
 	finAcctClient          FinancialAccountingClient
 	partyClient            PartyClient
@@ -158,9 +159,10 @@ type Service struct {
 
 // Config contains configuration for creating a new Service with external clients
 type Config struct {
-	Repository           *persistence.Repository
-	LienRepository       *persistence.LienRepository
-	WithdrawalRepository *persistence.WithdrawalRepository
+	Repository                 *persistence.Repository
+	LienRepository             *persistence.LienRepository
+	WithdrawalRepository       *persistence.WithdrawalRepository
+	ValuationFeatureRepository *persistence.ValuationFeatureRepository
 	// Namespace is the Kubernetes namespace for service discovery (e.g., "default")
 	Namespace string
 	// PositionKeepingServiceName is the Kubernetes service name (e.g., "position-keeping")
@@ -205,6 +207,20 @@ func NewServiceWithIdempotency(repo *persistence.Repository, lienRepo *persisten
 		lienRepo:           lienRepo,
 		idempotencyService: idempotencyService,
 		logger:             slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	}, nil
+}
+
+// NewServiceWithValuationFeatures creates a new current account service with valuation feature support.
+// This is primarily used for testing valuation feature operations.
+// Returns an error if repository is nil.
+func NewServiceWithValuationFeatures(repo *persistence.Repository, valuationFeatureRepo *persistence.ValuationFeatureRepository) (*Service, error) {
+	if repo == nil {
+		return nil, ErrRepositoryNil
+	}
+	return &Service{
+		repo:                 repo,
+		valuationFeatureRepo: valuationFeatureRepo,
+		logger:               slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	}, nil
 }
 

--- a/services/current-account/service/valuation_feature_service.go
+++ b/services/current-account/service/valuation_feature_service.go
@@ -1,0 +1,395 @@
+// Package service implements gRPC services for the current account domain
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
+	"github.com/meridianhub/meridian/services/current-account/domain"
+	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Valuation feature specific errors
+var (
+	ErrValuationFeatureRepoNil       = errors.New("valuation feature repository cannot be nil")
+	ErrMethodOutputMismatch          = errors.New("valuation method output_instrument does not match account native instrument")
+	ErrInvalidValuationFeatureAction = errors.New("invalid valuation feature action")
+)
+
+// Valuation feature operation status constants for metrics
+const (
+	opStatusValuationFeatureRepoNil      = "valuation_feature_repo_nil"
+	opStatusInvalidFeatureID             = "invalid_feature_id"
+	opStatusFeatureNotFound              = "feature_not_found"
+	opStatusFeatureAlreadyExists         = "feature_already_exists"
+	opStatusMethodOutputMismatch         = "method_output_mismatch"
+	opStatusInvalidFeatureAction         = "invalid_feature_action"
+	opStatusFeatureLifecycleError        = "feature_lifecycle_error"
+	opStatusMissingAccountOrInstrument   = "missing_account_or_instrument"
+	opStatusInvalidRequest               = "invalid_request"
+	opStatusValuationFeatureVersionError = "version_conflict"
+
+	// defaultSystemUser is the fallback user when no auth context is available
+	defaultSystemUser = "system"
+)
+
+// CreateValuationFeature creates a valuation method assignment for an account.
+// CRITICAL: Validates that output_instrument matches account's native instrument (currency).
+func (s *Service) CreateValuationFeature(ctx context.Context, req *pb.CreateValuationFeatureRequest) (*pb.CreateValuationFeatureResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		caobservability.RecordOperationDuration("create_valuation_feature", operationStatus, time.Since(start))
+	}()
+
+	// Validate valuation feature repository is configured
+	if s.valuationFeatureRepo == nil {
+		operationStatus = opStatusValuationFeatureRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "valuation feature operations not configured")
+	}
+
+	// Get creator from auth context
+	createdBy := defaultSystemUser
+	if claims, ok := auth.GetClaimsFromContext(ctx); ok && claims != nil {
+		createdBy = claims.Subject
+	}
+
+	// Retrieve account to validate native instrument
+	account, err := s.repo.FindByID(ctx, req.AccountId)
+	if err != nil {
+		if errors.Is(err, persistence.ErrAccountNotFound) {
+			operationStatus = opStatusAccountNotFound
+			return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
+		}
+		operationStatus = opStatusRetrieveFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+
+	// CRITICAL VALIDATION: Method output_instrument must match account's native instrument
+	nativeInstrument := string(account.Balance().Currency())
+	if req.OutputInstrument != nativeInstrument {
+		operationStatus = opStatusMethodOutputMismatch
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"method output_instrument mismatch: expected %s (account native instrument), got %s",
+			nativeInstrument, req.OutputInstrument)
+	}
+
+	// Parse method ID
+	methodID, err := uuid.Parse(req.ValuationMethodId)
+	if err != nil {
+		operationStatus = opStatusInvalidRequest
+		return nil, status.Errorf(codes.InvalidArgument, "invalid valuation_method_id: %v", err)
+	}
+
+	// Parse parameters JSON if provided
+	var parameters map[string]interface{}
+	if req.Parameters != "" {
+		if err := json.Unmarshal([]byte(req.Parameters), &parameters); err != nil {
+			operationStatus = opStatusInvalidRequest
+			return nil, status.Errorf(codes.InvalidArgument, "invalid parameters JSON: %v", err)
+		}
+	}
+
+	// Create the domain entity
+	feature, err := domain.NewValuationFeature(
+		account.ID(),
+		req.InstrumentCode,
+		methodID,
+		int(req.ValuationMethodVersion),
+		parameters,
+		createdBy,
+	)
+	if err != nil {
+		operationStatus = opStatusInvalidRequest
+		return nil, status.Errorf(codes.InvalidArgument, "failed to create valuation feature: %v", err)
+	}
+
+	// Activate the feature immediately (standard flow)
+	if err := feature.Activate(createdBy); err != nil {
+		operationStatus = opStatusFeatureLifecycleError
+		return nil, status.Errorf(codes.Internal, "failed to activate valuation feature: %v", err)
+	}
+
+	// Save to database
+	if err := s.valuationFeatureRepo.Create(ctx, feature); err != nil {
+		if errors.Is(err, persistence.ErrValuationFeatureAlreadyExists) {
+			operationStatus = opStatusFeatureAlreadyExists
+			return nil, status.Errorf(codes.AlreadyExists, "valuation feature already exists for account %s and instrument %s", req.AccountId, req.InstrumentCode)
+		}
+		operationStatus = opStatusSaveFailed
+		return nil, status.Errorf(codes.Internal, "failed to save valuation feature: %v", err)
+	}
+
+	return &pb.CreateValuationFeatureResponse{
+		Feature: s.domainToProtoValuationFeature(feature),
+	}, nil
+}
+
+// UpdateValuationFeature performs lifecycle transitions on a valuation feature.
+func (s *Service) UpdateValuationFeature(ctx context.Context, req *pb.UpdateValuationFeatureRequest) (*pb.UpdateValuationFeatureResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		caobservability.RecordOperationDuration("update_valuation_feature", operationStatus, time.Since(start))
+	}()
+
+	// Validate valuation feature repository is configured
+	if s.valuationFeatureRepo == nil {
+		operationStatus = opStatusValuationFeatureRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "valuation feature operations not configured")
+	}
+
+	// Get updater from auth context
+	updatedBy := defaultSystemUser
+	if claims, ok := auth.GetClaimsFromContext(ctx); ok && claims != nil {
+		updatedBy = claims.Subject
+	}
+
+	// Parse feature ID
+	featureID, err := uuid.Parse(req.FeatureId)
+	if err != nil {
+		operationStatus = opStatusInvalidFeatureID
+		return nil, status.Errorf(codes.InvalidArgument, "invalid feature_id: %v", err)
+	}
+
+	// Retrieve feature
+	feature, err := s.valuationFeatureRepo.FindByID(ctx, featureID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrValuationFeatureNotFound) {
+			operationStatus = opStatusFeatureNotFound
+			return nil, status.Errorf(codes.NotFound, "valuation feature not found: %s", req.FeatureId)
+		}
+		operationStatus = opStatusRetrieveFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve valuation feature: %v", err)
+	}
+
+	// Apply lifecycle transition based on action
+	switch req.Action {
+	case pb.ValuationFeatureAction_VALUATION_FEATURE_ACTION_ACTIVATE:
+		if err := feature.Activate(updatedBy); err != nil {
+			if errors.Is(err, domain.ErrInvalidValuationFeatureTransition) {
+				operationStatus = opStatusFeatureLifecycleError
+				return nil, status.Errorf(codes.FailedPrecondition, "cannot activate feature: %v", err)
+			}
+			operationStatus = opStatusFeatureLifecycleError
+			return nil, status.Errorf(codes.Internal, "failed to activate valuation feature: %v", err)
+		}
+
+	case pb.ValuationFeatureAction_VALUATION_FEATURE_ACTION_TERMINATE:
+		if err := feature.Terminate(updatedBy); err != nil {
+			if errors.Is(err, domain.ErrInvalidValuationFeatureTransition) {
+				operationStatus = opStatusFeatureLifecycleError
+				return nil, status.Errorf(codes.FailedPrecondition, "cannot terminate feature: %v", err)
+			}
+			operationStatus = opStatusFeatureLifecycleError
+			return nil, status.Errorf(codes.Internal, "failed to terminate valuation feature: %v", err)
+		}
+
+	case pb.ValuationFeatureAction_VALUATION_FEATURE_ACTION_UNSPECIFIED:
+		operationStatus = opStatusInvalidFeatureAction
+		return nil, status.Error(codes.InvalidArgument, "action must be specified")
+	}
+
+	// Save changes
+	if err := s.valuationFeatureRepo.Update(ctx, feature); err != nil {
+		if errors.Is(err, persistence.ErrValuationFeatureVersionConflict) {
+			operationStatus = opStatusValuationFeatureVersionError
+			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+		}
+		operationStatus = opStatusSaveFailed
+		return nil, status.Errorf(codes.Internal, "failed to update valuation feature: %v", err)
+	}
+
+	return &pb.UpdateValuationFeatureResponse{
+		Feature: s.domainToProtoValuationFeature(feature),
+	}, nil
+}
+
+// GetValuationFeature retrieves a valuation feature by ID or by account+instrument with bi-temporal query.
+func (s *Service) GetValuationFeature(ctx context.Context, req *pb.GetValuationFeatureRequest) (*pb.GetValuationFeatureResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		caobservability.RecordOperationDuration("get_valuation_feature", operationStatus, time.Since(start))
+	}()
+
+	// Validate valuation feature repository is configured
+	if s.valuationFeatureRepo == nil {
+		operationStatus = opStatusValuationFeatureRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "valuation feature operations not configured")
+	}
+
+	var feature *domain.ValuationFeature
+	var err error
+
+	// Mode 1: Direct lookup by feature_id
+	if req.FeatureId != "" {
+		featureID, parseErr := uuid.Parse(req.FeatureId)
+		if parseErr != nil {
+			operationStatus = opStatusInvalidFeatureID
+			return nil, status.Errorf(codes.InvalidArgument, "invalid feature_id: %v", parseErr)
+		}
+
+		feature, err = s.valuationFeatureRepo.FindByID(ctx, featureID)
+		if err != nil {
+			if errors.Is(err, persistence.ErrValuationFeatureNotFound) {
+				operationStatus = opStatusFeatureNotFound
+				return nil, status.Errorf(codes.NotFound, "valuation feature not found: %s", req.FeatureId)
+			}
+			operationStatus = opStatusRetrieveFailed
+			return nil, status.Errorf(codes.Internal, "failed to retrieve valuation feature: %v", err)
+		}
+	} else if req.AccountId != "" && req.InstrumentCode != "" {
+		// Mode 2: Bi-temporal lookup by account_id + instrument_code + knowledge_at
+		// Resolve account ID from string to UUID
+		account, accountErr := s.repo.FindByID(ctx, req.AccountId)
+		if accountErr != nil {
+			if errors.Is(accountErr, persistence.ErrAccountNotFound) {
+				operationStatus = opStatusAccountNotFound
+				return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
+			}
+			operationStatus = opStatusRetrieveFailed
+			return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", accountErr)
+		}
+
+		// Determine knowledge_at time
+		knowledgeAt := time.Now()
+		if req.KnowledgeAt != nil {
+			knowledgeAt = req.KnowledgeAt.AsTime()
+		}
+
+		feature, err = s.valuationFeatureRepo.FindByAccountIDAndInstrument(ctx, account.ID(), req.InstrumentCode, knowledgeAt)
+		if err != nil {
+			if errors.Is(err, persistence.ErrValuationFeatureNotFound) {
+				operationStatus = opStatusFeatureNotFound
+				return nil, status.Errorf(codes.NotFound, "no active valuation feature found for account %s and instrument %s at %v",
+					req.AccountId, req.InstrumentCode, knowledgeAt)
+			}
+			operationStatus = opStatusRetrieveFailed
+			return nil, status.Errorf(codes.Internal, "failed to retrieve valuation feature: %v", err)
+		}
+	} else {
+		operationStatus = opStatusMissingAccountOrInstrument
+		return nil, status.Error(codes.InvalidArgument, "must provide either feature_id or (account_id + instrument_code)")
+	}
+
+	return &pb.GetValuationFeatureResponse{
+		Feature: s.domainToProtoValuationFeature(feature),
+	}, nil
+}
+
+// ListValuationFeatures retrieves all valuation features for an account.
+func (s *Service) ListValuationFeatures(ctx context.Context, req *pb.ListValuationFeaturesRequest) (*pb.ListValuationFeaturesResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		caobservability.RecordOperationDuration("list_valuation_features", operationStatus, time.Since(start))
+	}()
+
+	// Validate valuation feature repository is configured
+	if s.valuationFeatureRepo == nil {
+		operationStatus = opStatusValuationFeatureRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "valuation feature operations not configured")
+	}
+
+	// Resolve account ID from string to UUID
+	account, err := s.repo.FindByID(ctx, req.AccountId)
+	if err != nil {
+		if errors.Is(err, persistence.ErrAccountNotFound) {
+			operationStatus = opStatusAccountNotFound
+			return nil, status.Errorf(codes.NotFound, "account not found: %s", req.AccountId)
+		}
+		operationStatus = opStatusRetrieveFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
+	}
+
+	// Convert lifecycle status filter if provided
+	var statusFilter *domain.ValuationFeatureLifecycleStatus
+	if req.LifecycleStatus != pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_UNSPECIFIED {
+		domainStatus := s.protoToDomainLifecycleStatus(req.LifecycleStatus)
+		statusFilter = &domainStatus
+	}
+
+	// Retrieve features
+	features, err := s.valuationFeatureRepo.FindByAccountID(ctx, account.ID(), statusFilter)
+	if err != nil {
+		operationStatus = opStatusRetrieveFailed
+		return nil, status.Errorf(codes.Internal, "failed to list valuation features: %v", err)
+	}
+
+	// Convert to proto
+	protoFeatures := make([]*pb.ValuationFeature, len(features))
+	for i, f := range features {
+		protoFeatures[i] = s.domainToProtoValuationFeature(f)
+	}
+
+	return &pb.ListValuationFeaturesResponse{
+		Features: protoFeatures,
+	}, nil
+}
+
+// domainToProtoValuationFeature converts a domain valuation feature to proto
+func (s *Service) domainToProtoValuationFeature(f *domain.ValuationFeature) *pb.ValuationFeature {
+	var parametersJSON string
+	if f.Parameters != nil {
+		if jsonBytes, err := json.Marshal(f.Parameters); err == nil {
+			parametersJSON = string(jsonBytes)
+		}
+	}
+
+	return &pb.ValuationFeature{
+		Id:                     f.ID.String(),
+		AccountId:              f.AccountID.String(),
+		InstrumentCode:         f.InstrumentCode,
+		ValuationMethodId:      f.ValuationMethodID.String(),
+		ValuationMethodVersion: int32(f.ValuationMethodVersion),
+		Parameters:             parametersJSON,
+		LifecycleStatus:        s.domainToProtoLifecycleStatus(f.LifecycleStatus),
+		ValidFrom:              timestamppb.New(f.ValidFrom),
+		ValidTo:                timestamppb.New(f.ValidTo),
+		CreatedAt:              timestamppb.New(f.CreatedAt),
+		CreatedBy:              f.CreatedBy,
+		UpdatedAt:              timestamppb.New(f.UpdatedAt),
+		UpdatedBy:              f.UpdatedBy,
+		Version:                int32(f.Version),
+	}
+}
+
+// domainToProtoLifecycleStatus converts domain lifecycle status to proto enum
+func (s *Service) domainToProtoLifecycleStatus(domainStatus domain.ValuationFeatureLifecycleStatus) pb.ValuationFeatureLifecycleStatus {
+	switch domainStatus {
+	case domain.ValuationFeatureLifecycleStatusInitiated:
+		return pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_INITIATED
+	case domain.ValuationFeatureLifecycleStatusActive:
+		return pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_ACTIVE
+	case domain.ValuationFeatureLifecycleStatusTerminated:
+		return pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_TERMINATED
+	default:
+		return pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_UNSPECIFIED
+	}
+}
+
+// protoToDomainLifecycleStatus converts proto enum to domain lifecycle status
+func (s *Service) protoToDomainLifecycleStatus(protoStatus pb.ValuationFeatureLifecycleStatus) domain.ValuationFeatureLifecycleStatus {
+	switch protoStatus {
+	case pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_INITIATED:
+		return domain.ValuationFeatureLifecycleStatusInitiated
+	case pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_ACTIVE:
+		return domain.ValuationFeatureLifecycleStatusActive
+	case pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_TERMINATED:
+		return domain.ValuationFeatureLifecycleStatusTerminated
+	case pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_UNSPECIFIED:
+		return domain.ValuationFeatureLifecycleStatusInitiated
+	default:
+		return domain.ValuationFeatureLifecycleStatusInitiated
+	}
+}

--- a/services/current-account/service/valuation_feature_service_test.go
+++ b/services/current-account/service/valuation_feature_service_test.go
@@ -1,0 +1,522 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+const testTenantIDForVF = "test_tenant"
+
+func setupValuationFeatureServiceTest(t *testing.T) (*Service, context.Context, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupPostgres(t, nil)
+
+	// Create the tenant schema for tests
+	tid := tenant.TenantID(testTenantIDForVF)
+	schemaName := tid.SchemaName()
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
+	require.NoError(t, err)
+
+	// Create the account table in the tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.account (
+		id UUID PRIMARY KEY,
+		account_id VARCHAR(100) NOT NULL UNIQUE,
+		account_identification VARCHAR(34) NOT NULL UNIQUE,
+		party_id UUID NOT NULL,
+		balance BIGINT NOT NULL DEFAULT 0,
+		available_balance BIGINT NOT NULL DEFAULT 0,
+		currency VARCHAR(3) NOT NULL DEFAULT 'GBP',
+		status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+		overdraft_limit BIGINT NOT NULL DEFAULT 0,
+		overdraft_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+		overdraft_rate NUMERIC(5,4) NOT NULL DEFAULT 0,
+		balance_updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		created_by VARCHAR(100) NOT NULL DEFAULT 'system',
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		updated_by VARCHAR(100) NOT NULL DEFAULT 'system',
+		deleted_at TIMESTAMP WITH TIME ZONE,
+		opened_at TIMESTAMP WITH TIME ZONE,
+		closed_at TIMESTAMP WITH TIME ZONE,
+		freeze_reason TEXT,
+		version BIGINT NOT NULL DEFAULT 1
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create the valuation_features table in the tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.valuation_features (
+		id UUID PRIMARY KEY,
+		account_id UUID NOT NULL,
+		instrument_code VARCHAR(32) NOT NULL,
+		valuation_method_id UUID NOT NULL,
+		valuation_method_version INT NOT NULL,
+		parameters JSONB,
+		lifecycle_status VARCHAR(16) NOT NULL,
+		valid_from TIMESTAMP WITH TIME ZONE NOT NULL,
+		valid_to TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(100) NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_by VARCHAR(100) NOT NULL,
+		version INT NOT NULL DEFAULT 1,
+		CONSTRAINT chk_valuation_feature_lifecycle_status CHECK (lifecycle_status IN ('INITIATED','ACTIVE','TERMINATED'))
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create unique index for active features
+	err = db.Exec(fmt.Sprintf(`CREATE UNIQUE INDEX IF NOT EXISTS idx_valuation_feature_account_instrument_active
+		ON %q.valuation_features (account_id, instrument_code)
+		WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00'`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Set default search_path to include tenant schema
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	require.NoError(t, err)
+
+	// Create context with tenant
+	ctx := tenant.WithTenant(context.Background(), tid)
+
+	// Create repositories
+	repo := persistence.NewRepository(db)
+	valuationFeatureRepo := persistence.NewValuationFeatureRepository(db)
+
+	// Create service
+	svc, err := NewServiceWithValuationFeatures(repo, valuationFeatureRepo)
+	require.NoError(t, err)
+
+	return svc, ctx, cleanup
+}
+
+func createTestAccountForVF(t *testing.T, db *gorm.DB, currency string) (uuid.UUID, string) {
+	t.Helper()
+	accountUUID := uuid.New()
+	accountID := fmt.Sprintf("ACC-%s", uuid.New().String()[:8])
+	iban := fmt.Sprintf("GB%s", uuid.New().String()[:20])
+
+	err := db.Exec(`INSERT INTO account (id, account_id, account_identification, party_id, currency, status, created_by, updated_by)
+		VALUES (?, ?, ?, ?, ?, 'ACTIVE', 'test', 'test')`,
+		accountUUID, accountID, iban, uuid.New(), currency).Error
+	require.NoError(t, err)
+
+	return accountUUID, accountID
+}
+
+func TestCreateValuationFeature_Success(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	// Create a test account with GBP currency
+	_, accountID := createTestAccountForVF(t, svc.repo.DB(), "GBP")
+
+	methodID := uuid.New()
+	req := &pb.CreateValuationFeatureRequest{
+		AccountId:              accountID,
+		InstrumentCode:         "USD",
+		ValuationMethodId:      methodID.String(),
+		ValuationMethodVersion: 1,
+		OutputInstrument:       "GBP", // Matches account native instrument
+		Parameters:             `{"source": "ECB"}`,
+	}
+
+	resp, err := svc.CreateValuationFeature(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Feature)
+	assert.NotEmpty(t, resp.Feature.Id)
+	assert.Equal(t, "USD", resp.Feature.InstrumentCode)
+	assert.Equal(t, methodID.String(), resp.Feature.ValuationMethodId)
+	assert.Equal(t, int32(1), resp.Feature.ValuationMethodVersion)
+	assert.Equal(t, pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_ACTIVE, resp.Feature.LifecycleStatus)
+	assert.Contains(t, resp.Feature.Parameters, "ECB")
+}
+
+func TestCreateValuationFeature_MethodOutputMismatch(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	// Create a test account with GBP currency
+	_, accountID := createTestAccountForVF(t, svc.repo.DB(), "GBP")
+
+	methodID := uuid.New()
+	req := &pb.CreateValuationFeatureRequest{
+		AccountId:              accountID,
+		InstrumentCode:         "USD",
+		ValuationMethodId:      methodID.String(),
+		ValuationMethodVersion: 1,
+		OutputInstrument:       "EUR", // Does NOT match account native instrument (GBP)
+		Parameters:             `{}`,
+	}
+
+	resp, err := svc.CreateValuationFeature(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "output_instrument mismatch")
+	assert.Contains(t, st.Message(), "expected GBP")
+	assert.Contains(t, st.Message(), "got EUR")
+}
+
+func TestCreateValuationFeature_AccountNotFound(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	req := &pb.CreateValuationFeatureRequest{
+		AccountId:              "non-existent-account",
+		InstrumentCode:         "USD",
+		ValuationMethodId:      uuid.New().String(),
+		ValuationMethodVersion: 1,
+		OutputInstrument:       "GBP",
+	}
+
+	resp, err := svc.CreateValuationFeature(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestCreateValuationFeature_InvalidMethodID(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	_, accountID := createTestAccountForVF(t, svc.repo.DB(), "GBP")
+
+	req := &pb.CreateValuationFeatureRequest{
+		AccountId:              accountID,
+		InstrumentCode:         "USD",
+		ValuationMethodId:      "not-a-uuid",
+		ValuationMethodVersion: 1,
+		OutputInstrument:       "GBP",
+	}
+
+	resp, err := svc.CreateValuationFeature(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestUpdateValuationFeature_Terminate(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	// Create a test account and feature
+	_, accountID := createTestAccountForVF(t, svc.repo.DB(), "GBP")
+
+	// First create a feature
+	createReq := &pb.CreateValuationFeatureRequest{
+		AccountId:              accountID,
+		InstrumentCode:         "USD",
+		ValuationMethodId:      uuid.New().String(),
+		ValuationMethodVersion: 1,
+		OutputInstrument:       "GBP",
+	}
+	createResp, err := svc.CreateValuationFeature(ctx, createReq)
+	require.NoError(t, err)
+
+	// Now terminate it
+	updateReq := &pb.UpdateValuationFeatureRequest{
+		FeatureId: createResp.Feature.Id,
+		Action:    pb.ValuationFeatureAction_VALUATION_FEATURE_ACTION_TERMINATE,
+	}
+
+	updateResp, err := svc.UpdateValuationFeature(ctx, updateReq)
+
+	require.NoError(t, err)
+	require.NotNil(t, updateResp)
+	assert.Equal(t, pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_TERMINATED, updateResp.Feature.LifecycleStatus)
+}
+
+func TestUpdateValuationFeature_FeatureNotFound(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	req := &pb.UpdateValuationFeatureRequest{
+		FeatureId: uuid.New().String(),
+		Action:    pb.ValuationFeatureAction_VALUATION_FEATURE_ACTION_TERMINATE,
+	}
+
+	resp, err := svc.UpdateValuationFeature(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestUpdateValuationFeature_InvalidAction(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	// Create a test account and feature
+	_, accountID := createTestAccountForVF(t, svc.repo.DB(), "GBP")
+
+	createReq := &pb.CreateValuationFeatureRequest{
+		AccountId:              accountID,
+		InstrumentCode:         "USD",
+		ValuationMethodId:      uuid.New().String(),
+		ValuationMethodVersion: 1,
+		OutputInstrument:       "GBP",
+	}
+	createResp, err := svc.CreateValuationFeature(ctx, createReq)
+	require.NoError(t, err)
+
+	// Try with unspecified action
+	updateReq := &pb.UpdateValuationFeatureRequest{
+		FeatureId: createResp.Feature.Id,
+		Action:    pb.ValuationFeatureAction_VALUATION_FEATURE_ACTION_UNSPECIFIED,
+	}
+
+	resp, err := svc.UpdateValuationFeature(ctx, updateReq)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestGetValuationFeature_ByID(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	// Create a test account and feature
+	_, accountID := createTestAccountForVF(t, svc.repo.DB(), "GBP")
+
+	createReq := &pb.CreateValuationFeatureRequest{
+		AccountId:              accountID,
+		InstrumentCode:         "USD",
+		ValuationMethodId:      uuid.New().String(),
+		ValuationMethodVersion: 1,
+		OutputInstrument:       "GBP",
+	}
+	createResp, err := svc.CreateValuationFeature(ctx, createReq)
+	require.NoError(t, err)
+
+	// Get by ID
+	getReq := &pb.GetValuationFeatureRequest{
+		FeatureId: createResp.Feature.Id,
+	}
+
+	getResp, err := svc.GetValuationFeature(ctx, getReq)
+
+	require.NoError(t, err)
+	require.NotNil(t, getResp)
+	assert.Equal(t, createResp.Feature.Id, getResp.Feature.Id)
+	assert.Equal(t, "USD", getResp.Feature.InstrumentCode)
+}
+
+func TestGetValuationFeature_ByAccountAndInstrument(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	// Create a test account and feature
+	_, accountID := createTestAccountForVF(t, svc.repo.DB(), "GBP")
+
+	createReq := &pb.CreateValuationFeatureRequest{
+		AccountId:              accountID,
+		InstrumentCode:         "USD",
+		ValuationMethodId:      uuid.New().String(),
+		ValuationMethodVersion: 1,
+		OutputInstrument:       "GBP",
+	}
+	createResp, err := svc.CreateValuationFeature(ctx, createReq)
+	require.NoError(t, err)
+
+	// Get by account ID and instrument
+	getReq := &pb.GetValuationFeatureRequest{
+		AccountId:      accountID,
+		InstrumentCode: "USD",
+	}
+
+	getResp, err := svc.GetValuationFeature(ctx, getReq)
+
+	require.NoError(t, err)
+	require.NotNil(t, getResp)
+	assert.Equal(t, createResp.Feature.Id, getResp.Feature.Id)
+	assert.Equal(t, "USD", getResp.Feature.InstrumentCode)
+}
+
+func TestGetValuationFeature_NotFound(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	req := &pb.GetValuationFeatureRequest{
+		FeatureId: uuid.New().String(),
+	}
+
+	resp, err := svc.GetValuationFeature(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestGetValuationFeature_MissingIdentifiers(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	// Missing both feature_id and (account_id + instrument_code)
+	req := &pb.GetValuationFeatureRequest{}
+
+	resp, err := svc.GetValuationFeature(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "must provide either feature_id or")
+}
+
+func TestListValuationFeatures_Success(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	// Create a test account
+	_, accountID := createTestAccountForVF(t, svc.repo.DB(), "GBP")
+
+	// Create multiple features
+	for _, instrument := range []string{"USD", "EUR", "CHF"} {
+		createReq := &pb.CreateValuationFeatureRequest{
+			AccountId:              accountID,
+			InstrumentCode:         instrument,
+			ValuationMethodId:      uuid.New().String(),
+			ValuationMethodVersion: 1,
+			OutputInstrument:       "GBP",
+		}
+		_, err := svc.CreateValuationFeature(ctx, createReq)
+		require.NoError(t, err)
+	}
+
+	// List all features
+	listReq := &pb.ListValuationFeaturesRequest{
+		AccountId: accountID,
+	}
+
+	listResp, err := svc.ListValuationFeatures(ctx, listReq)
+
+	require.NoError(t, err)
+	require.NotNil(t, listResp)
+	assert.Len(t, listResp.Features, 3)
+}
+
+func TestListValuationFeatures_FilterByStatus(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	// Create a test account
+	_, accountID := createTestAccountForVF(t, svc.repo.DB(), "GBP")
+
+	// Create first feature (will remain active)
+	createReq1 := &pb.CreateValuationFeatureRequest{
+		AccountId:              accountID,
+		InstrumentCode:         "USD",
+		ValuationMethodId:      uuid.New().String(),
+		ValuationMethodVersion: 1,
+		OutputInstrument:       "GBP",
+	}
+	_, err := svc.CreateValuationFeature(ctx, createReq1)
+	require.NoError(t, err)
+
+	// Create second feature and terminate it
+	createReq2 := &pb.CreateValuationFeatureRequest{
+		AccountId:              accountID,
+		InstrumentCode:         "EUR",
+		ValuationMethodId:      uuid.New().String(),
+		ValuationMethodVersion: 1,
+		OutputInstrument:       "GBP",
+	}
+	createResp2, err := svc.CreateValuationFeature(ctx, createReq2)
+	require.NoError(t, err)
+
+	// Terminate the second feature
+	_, err = svc.UpdateValuationFeature(ctx, &pb.UpdateValuationFeatureRequest{
+		FeatureId: createResp2.Feature.Id,
+		Action:    pb.ValuationFeatureAction_VALUATION_FEATURE_ACTION_TERMINATE,
+	})
+	require.NoError(t, err)
+
+	// List only active features
+	listReq := &pb.ListValuationFeaturesRequest{
+		AccountId:       accountID,
+		LifecycleStatus: pb.ValuationFeatureLifecycleStatus_VALUATION_FEATURE_LIFECYCLE_STATUS_ACTIVE,
+	}
+
+	listResp, err := svc.ListValuationFeatures(ctx, listReq)
+
+	require.NoError(t, err)
+	require.NotNil(t, listResp)
+	assert.Len(t, listResp.Features, 1)
+	assert.Equal(t, "USD", listResp.Features[0].InstrumentCode)
+}
+
+func TestListValuationFeatures_AccountNotFound(t *testing.T) {
+	svc, ctx, cleanup := setupValuationFeatureServiceTest(t)
+	defer cleanup()
+
+	req := &pb.ListValuationFeaturesRequest{
+		AccountId: "non-existent-account",
+	}
+
+	resp, err := svc.ListValuationFeatures(ctx, req)
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestValuationFeatureRepoNil(t *testing.T) {
+	// Create service without valuation feature repo
+	repo := &persistence.Repository{}
+	svc, err := NewService(repo, nil)
+	require.NoError(t, err)
+
+	ctx := tenant.WithTenant(context.Background(), tenant.TenantID(testTenantIDForVF))
+
+	// All valuation feature operations should fail
+	_, err = svc.CreateValuationFeature(ctx, &pb.CreateValuationFeatureRequest{})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+
+	_, err = svc.UpdateValuationFeature(ctx, &pb.UpdateValuationFeatureRequest{})
+	require.Error(t, err)
+	st, _ = status.FromError(err)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+
+	_, err = svc.GetValuationFeature(ctx, &pb.GetValuationFeatureRequest{})
+	require.Error(t, err)
+	st, _ = status.FromError(err)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+
+	_, err = svc.ListValuationFeatures(ctx, &pb.ListValuationFeaturesRequest{})
+	require.Error(t, err)
+	st, _ = status.FromError(err)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}


### PR DESCRIPTION
## Summary
Implements core ValuationFeature infrastructure for the Current Account service to support valuation engine integration.

## Changes Made
1. **Database Schema** (`20260206000001_create_valuation_features.sql`)
   - Created `valuation_features` table with bi-temporal validity tracking
   - Unique constraint on `(account_id, instrument_code)` for ACTIVE features
   - Indexes for efficient querying by method, account, and temporal range
   - Lifecycle status constraint (INITIATED, ACTIVE, TERMINATED)

2. **Domain Model** (`domain/valuation_feature.go`)
   - Lifecycle state machine with idempotent transitions
   - Bi-temporal validity support (`IsValidAt()` method)
   - Optimistic locking via version field

3. **Repository Layer** (`adapters/persistence/valuation_feature_repository.go`)
   - Full CRUD operations with tenant isolation
   - Bi-temporal query support (`FindByAccountIDAndInstrument` with `knowledge_at`)
   - Optimistic locking for concurrent updates
   - JSONB parameter marshaling/unmarshaling

4. **Migration Template** (`20260206000002_backfill_identity_valuation_features.sql`)
   - Placeholder for identity method backfill
   - Will be completed after Valuation Engine Service deployment

## Test Coverage
- ✅ Domain model unit tests (lifecycle transitions, bi-temporal validity)
- ✅ Repository integration tests (CRUD, optimistic locking, unique constraints)
- ✅ All tests passing with testcontainers

## Design Decisions
- **Bi-temporal validity**: Supports time-travel queries for regulatory compliance
- **Unique constraint**: Prevents conflicting valuation methods for same (account, instrument)
- **JSONB parameters**: Flexible method-specific configuration without schema changes
- **Lifecycle status**: Follows ADR-012 pattern (INITIATED → ACTIVE → TERMINATED)

## Next Steps
- [ ] Implement gRPC handlers (CreateValuationFeature, UpdateValuationFeature, GetValuationFeature, ListValuationFeatures)
- [ ] Add native instrument validation (method.output_instrument must match account.currency)
- [ ] Implement application-level backfill after Valuation Engine Service deployment

## Test Plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Migration runs successfully
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)