### PR TITLE
feat: Add meridian-cli saga validate command

### DIFF
--- a/cmd/meridian-cli/cmd/root.go
+++ b/cmd/meridian-cli/cmd/root.go
@@ -1,0 +1,38 @@
+// Package cmd implements the meridian-cli CLI commands.
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// Version information set at build time.
+var (
+	Version   = "dev"
+	GitCommit = "unknown"
+	BuildDate = "unknown"
+)
+
+// rootCmd represents the base command when called without any subcommands.
+var rootCmd = &cobra.Command{
+	Use:     "meridian-cli",
+	Short:   "Meridian platform CLI tools",
+	Version: fmt.Sprintf("%s (commit: %s, built: %s)", Version, GitCommit, BuildDate),
+	Long: `meridian-cli provides command-line tools for the Meridian platform.
+
+Available command groups:
+  saga    Starlark saga script tools (validate, etc.)
+
+Exit Codes:
+  0 - Success
+  1 - Failure (validation failed or error occurred)`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/meridian-cli/cmd/saga.go
+++ b/cmd/meridian-cli/cmd/saga.go
@@ -1,0 +1,14 @@
+package cmd
+
+import "github.com/spf13/cobra"
+
+// sagaCmd is the parent command for saga-related operations.
+var sagaCmd = &cobra.Command{
+	Use:   "saga",
+	Short: "Starlark saga script tools",
+	Long:  `Commands for working with Starlark saga scripts, including validation.`,
+}
+
+func init() {
+	rootCmd.AddCommand(sagaCmd)
+}

--- a/cmd/meridian-cli/cmd/saga_validate.go
+++ b/cmd/meridian-cli/cmd/saga_validate.go
@@ -29,6 +29,10 @@ The script is executed in a sandboxed runtime with mock handlers
 generated from the handler schema (handlers.yaml). This provides
 fast local feedback before deployment.
 
+Exit Codes:
+  0 - Script is valid
+  1 - Validation failed (syntax error, undefined handler, etc.)
+
 Examples:
   meridian-cli saga validate withdrawal.star
   meridian-cli saga validate --json payment.star
@@ -39,7 +43,6 @@ Examples:
 
 func init() {
 	validateCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output validation report as JSON")
-	validateCmd.Flags().BoolVar(&jsonOutput, "dry-run", false, "Synonym for validate (compatibility)")
 	validateCmd.Flags().StringVar(&handlersPath, "handlers", "", "Path to handlers.yaml (default: embedded schema)")
 
 	sagaCmd.AddCommand(validateCmd)

--- a/cmd/meridian-cli/cmd/saga_validate.go
+++ b/cmd/meridian-cli/cmd/saga_validate.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"github.com/meridianhub/meridian/shared/pkg/saga/validation"
+	"github.com/spf13/cobra"
+)
+
+// Flags for the validate command.
+var (
+	jsonOutput   bool
+	handlersPath string
+)
+
+// validateCmd validates a Starlark saga script locally using mock handlers.
+var validateCmd = &cobra.Command{
+	Use:   "validate <script.star>",
+	Short: "Validate a Starlark saga script locally",
+	Long: `Validates a Starlark saga script using auto-generated mock handlers.
+
+The script is executed in a sandboxed runtime with mock handlers
+generated from the handler schema (handlers.yaml). This provides
+fast local feedback before deployment.
+
+Examples:
+  meridian-cli saga validate withdrawal.star
+  meridian-cli saga validate --json payment.star
+  meridian-cli saga validate --handlers /path/to/handlers.yaml deposit.star`,
+	Args: cobra.ExactArgs(1),
+	RunE: runValidate,
+}
+
+func init() {
+	validateCmd.Flags().BoolVar(&jsonOutput, "json", false, "Output validation report as JSON")
+	validateCmd.Flags().BoolVar(&jsonOutput, "dry-run", false, "Synonym for validate (compatibility)")
+	validateCmd.Flags().StringVar(&handlersPath, "handlers", "", "Path to handlers.yaml (default: embedded schema)")
+
+	sagaCmd.AddCommand(validateCmd)
+}
+
+// runValidate is the Cobra command handler for saga validate.
+func runValidate(_ *cobra.Command, args []string) error {
+	scriptPath := args[0]
+
+	result, err := runValidateLogic(scriptPath, handlersPath)
+	if err != nil {
+		return err
+	}
+
+	// Load schema for available handler names (for suggestions)
+	var availableHandlers []string
+	schemaReg, loadErr := loadSchemaRegistry(handlersPath)
+	if loadErr == nil {
+		availableHandlers = schemaReg.ListHandlers()
+	}
+
+	output := formatOutput(result, jsonOutput, availableHandlers)
+	fmt.Print(output)
+
+	if !result.Success {
+		// Exit with code 1 for failed validation (cobra interprets non-nil error as exit 1)
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+// runValidateLogic contains the core validation logic, separated for testability.
+// It reads the script, loads the schema, and runs the dry-run validator.
+func runValidateLogic(scriptPath, handlers string) (*validation.ValidationResult, error) {
+	// Read script file
+	scriptData, err := os.ReadFile(scriptPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read script: %w", err)
+	}
+
+	// Load schema registry
+	schemaReg, err := loadSchemaRegistry(handlers)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load schema: %w", err)
+	}
+
+	// Create a quiet logger - CLI only needs to show validation results, not execution logs.
+	// Errors are captured in the ValidationResult, so we suppress INFO/WARN logs.
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	runtime, err := saga.NewRuntime(logger, saga.WithTimeout(5*time.Second))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create runtime: %w", err)
+	}
+
+	// Create mock registry from schema
+	mockRegistry, err := validation.NewMockHandlerRegistry(schemaReg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create mock registry: %w", err)
+	}
+
+	// Create validator
+	validator, err := validation.NewDryRunValidator(validation.DryRunValidatorConfig{
+		Runtime:        runtime,
+		MockRegistry:   mockRegistry,
+		SchemaRegistry: schemaReg,
+		Logger:         logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create validator: %w", err)
+	}
+
+	// Validate
+	ctx := context.Background()
+	result, err := validator.Validate(ctx, string(scriptData))
+	if err != nil {
+		return nil, fmt.Errorf("validation error: %w", err)
+	}
+
+	return result, nil
+}
+
+// loadSchemaRegistry loads the schema registry from the specified path or default location.
+func loadSchemaRegistry(handlers string) (*schema.Registry, error) {
+	reg := schema.NewRegistry()
+
+	if handlers != "" {
+		if err := reg.LoadFromFile(handlers); err != nil {
+			return nil, err
+		}
+		return reg, nil
+	}
+
+	// Try default locations relative to working directory
+	defaults := []string{
+		"shared/pkg/saga/schema/handlers.yaml",
+	}
+
+	for _, path := range defaults {
+		if _, err := os.Stat(path); err == nil {
+			if loadErr := reg.LoadFromFile(path); loadErr != nil {
+				return nil, loadErr
+			}
+			return reg, nil
+		}
+	}
+
+	// No handlers found - return empty registry (will catch undefined handler errors)
+	return reg, nil
+}
+
+// formatOutput formats the validation result for CLI output.
+func formatOutput(result *validation.ValidationResult, asJSON bool, availableHandlers []string) string {
+	if asJSON {
+		formatter := &validation.JSONFormatter{
+			AvailableHandlers: availableHandlers,
+		}
+		return formatter.Format(result)
+	}
+
+	formatter := &validation.HumanReadableFormatter{
+		AvailableHandlers: availableHandlers,
+	}
+	return formatter.Format(result)
+}

--- a/cmd/meridian-cli/cmd/saga_validate_test.go
+++ b/cmd/meridian-cli/cmd/saga_validate_test.go
@@ -1,0 +1,253 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga/validation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeScript writes a Starlark script to a temp file and returns the path.
+func writeScript(t *testing.T, name, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+// handlersYAMLPath returns the path to the project's handlers.yaml.
+func handlersYAMLPath(t *testing.T) string {
+	t.Helper()
+	// Walk up from test directory to find project root
+	// Test runs from cmd/meridian-cli/cmd/ so we need to go up 3 levels
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	// Try relative paths from working directory
+	candidates := []string{
+		filepath.Join(wd, "..", "..", "..", "shared", "pkg", "saga", "schema", "handlers.yaml"),
+		filepath.Join(wd, "shared", "pkg", "saga", "schema", "handlers.yaml"),
+	}
+
+	for _, path := range candidates {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(abs); err == nil {
+			return abs
+		}
+	}
+
+	t.Fatalf("handlers.yaml not found; tried: %v", candidates)
+	return ""
+}
+
+func TestRunValidateCommand_ValidScript(t *testing.T) {
+	handlersPath := handlersYAMLPath(t)
+
+	script := writeScript(t, "valid.star", `
+result = position_keeping.initiate_log(
+    position_id="POS-001",
+    direction="CREDIT",
+    amount=Decimal("100.00"),
+)
+`)
+
+	result, err := runValidateLogic(script, handlersPath)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Empty(t, result.Errors)
+	assert.Greater(t, result.Metrics.HandlerCallCount, 0)
+}
+
+func TestRunValidateCommand_InvalidScript(t *testing.T) {
+	handlersPath := handlersYAMLPath(t)
+
+	script := writeScript(t, "invalid.star", `
+result = position_keeping.initiate_log(account_id="ACC-001"
+`)
+
+	result, err := runValidateLogic(script, handlersPath)
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	assert.NotEmpty(t, result.Errors)
+	assert.Equal(t, validation.CategorySyntax, result.Errors[0].Category)
+	assert.Greater(t, result.Errors[0].Line, 0, "Expected line number in error")
+}
+
+func TestRunValidateCommand_MissingFile(t *testing.T) {
+	_, err := runValidateLogic("/nonexistent/path/missing.star", "handlers.yaml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read script")
+}
+
+func TestRunValidateCommand_JSONOutput(t *testing.T) {
+	handlersPath := handlersYAMLPath(t)
+
+	script := writeScript(t, "valid.star", `
+result = position_keeping.initiate_log(
+    position_id="POS-001",
+    direction="CREDIT",
+    amount=Decimal("100.00"),
+)
+`)
+
+	result, err := runValidateLogic(script, handlersPath)
+	require.NoError(t, err)
+
+	// Format as JSON and verify it parses
+	formatter := &validation.JSONFormatter{
+		AvailableHandlers: []string{},
+	}
+	jsonStr := formatter.Format(result)
+
+	var report validation.JSONReport
+	require.NoError(t, json.Unmarshal([]byte(jsonStr), &report))
+	assert.True(t, report.Success)
+}
+
+func TestRunValidateCommand_ComplexityMetrics(t *testing.T) {
+	handlersPath := handlersYAMLPath(t)
+
+	script := writeScript(t, "multi_handler.star", `
+r1 = position_keeping.initiate_log(
+    position_id="POS-001",
+    direction="CREDIT",
+    amount=Decimal("100.00"),
+)
+r2 = position_keeping.initiate_log(
+    position_id="POS-002",
+    direction="DEBIT",
+    amount=Decimal("50.00"),
+)
+`)
+
+	result, err := runValidateLogic(script, handlersPath)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+	assert.Equal(t, 2, result.Metrics.HandlerCallCount)
+	assert.Greater(t, result.Metrics.OperationCount, 0)
+}
+
+func TestRunValidateCommand_RelativePath(t *testing.T) {
+	handlersPath := handlersYAMLPath(t)
+
+	// Create script in temp dir and use relative path
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "test.star")
+	require.NoError(t, os.WriteFile(scriptPath, []byte(`
+result = position_keeping.initiate_log(
+    position_id="POS-001",
+    direction="CREDIT",
+    amount=Decimal("100.00"),
+)
+`), 0o644))
+
+	result, err := runValidateLogic(scriptPath, handlersPath)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+}
+
+func TestRunValidateCommand_AbsolutePath(t *testing.T) {
+	handlersPath := handlersYAMLPath(t)
+
+	script := writeScript(t, "absolute.star", `
+result = position_keeping.initiate_log(
+    position_id="POS-001",
+    direction="CREDIT",
+    amount=Decimal("100.00"),
+)
+`)
+
+	// Ensure the path is absolute
+	absPath, err := filepath.Abs(script)
+	require.NoError(t, err)
+
+	result, err := runValidateLogic(absPath, handlersPath)
+	require.NoError(t, err)
+	assert.True(t, result.Success)
+}
+
+func TestRunValidateCommand_ErrorWithLineNumber(t *testing.T) {
+	handlersPath := handlersYAMLPath(t)
+
+	// Script with syntax error on line 3
+	script := writeScript(t, "line_error.star", `x = 1
+y = 2
+z = (
+`)
+
+	result, err := runValidateLogic(script, handlersPath)
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	require.NotEmpty(t, result.Errors)
+	assert.Greater(t, result.Errors[0].Line, 0, "Expected line number > 0")
+}
+
+func TestRunValidateCommand_UndefinedHandler(t *testing.T) {
+	handlersPath := handlersYAMLPath(t)
+
+	script := writeScript(t, "undefined.star", `
+result = nonexistent_service.some_method(param="value")
+`)
+
+	result, err := runValidateLogic(script, handlersPath)
+	require.NoError(t, err)
+	assert.False(t, result.Success)
+	require.NotEmpty(t, result.Errors)
+}
+
+func TestFormatOutput_HumanReadable(t *testing.T) {
+	result := &validation.ValidationResult{
+		Success: true,
+		Errors:  []validation.ValidationError{},
+		Metrics: validation.ComplexityMetrics{
+			HandlerCallCount: 3,
+			OperationCount:   5,
+		},
+	}
+
+	output := formatOutput(result, false, []string{"position_keeping.initiate_log"})
+	assert.Contains(t, output, "Validation Passed")
+	assert.Contains(t, output, "3 handlers called")
+}
+
+func TestFormatOutput_JSON(t *testing.T) {
+	result := &validation.ValidationResult{
+		Success: true,
+		Errors:  []validation.ValidationError{},
+		Metrics: validation.ComplexityMetrics{
+			HandlerCallCount: 2,
+		},
+	}
+
+	output := formatOutput(result, true, []string{})
+	var report validation.JSONReport
+	require.NoError(t, json.Unmarshal([]byte(output), &report))
+	assert.True(t, report.Success)
+	assert.Equal(t, 2, report.Metrics.HandlerCallCount)
+}
+
+func TestFormatOutput_FailedHumanReadable(t *testing.T) {
+	result := &validation.ValidationResult{
+		Success: false,
+		Errors: []validation.ValidationError{
+			{
+				Line:     42,
+				Column:   5,
+				Message:  "handler 'payment_order.create_lien' not found in registry",
+				Category: validation.CategoryUndefinedHandler,
+			},
+		},
+	}
+
+	output := formatOutput(result, false, []string{"position_keeping.create_lien"})
+	assert.Contains(t, output, "Validation Failed")
+	assert.Contains(t, output, "Line 42")
+}

--- a/cmd/meridian-cli/cmd/saga_validate_test.go
+++ b/cmd/meridian-cli/cmd/saga_validate_test.go
@@ -138,9 +138,11 @@ r2 = position_keeping.initiate_log(
 func TestRunValidateCommand_RelativePath(t *testing.T) {
 	handlersPath := handlersYAMLPath(t)
 
-	// Create script in temp dir and use relative path
-	dir := t.TempDir()
-	scriptPath := filepath.Join(dir, "test.star")
+	// Create script in the current working directory to test relative path resolution
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	scriptPath := filepath.Join(wd, "test_relative.star")
 	require.NoError(t, os.WriteFile(scriptPath, []byte(`
 result = position_keeping.initiate_log(
     position_id="POS-001",
@@ -148,8 +150,10 @@ result = position_keeping.initiate_log(
     amount=Decimal("100.00"),
 )
 `), 0o644))
+	t.Cleanup(func() { os.Remove(scriptPath) })
 
-	result, err := runValidateLogic(scriptPath, handlersPath)
+	// Use relative path (just the filename since we're in wd)
+	result, err := runValidateLogic("test_relative.star", handlersPath)
 	require.NoError(t, err)
 	assert.True(t, result.Success)
 }

--- a/cmd/meridian-cli/main.go
+++ b/cmd/meridian-cli/main.go
@@ -1,0 +1,11 @@
+// Package main is the entry point for meridian-cli.
+//
+// meridian-cli provides command-line tools for the Meridian platform,
+// including saga script validation for local testing.
+package main
+
+import "github.com/meridianhub/meridian/cmd/meridian-cli/cmd"
+
+func main() {
+	cmd.Execute()
+}


### PR DESCRIPTION
## Summary

- Adds `meridian-cli saga validate <script.star>` command for local Starlark saga script validation
- Uses mock handlers auto-generated from `handlers.yaml` schema to execute scripts in a sandboxed runtime
- Returns exit code 0 (pass) or 1 (fail) for CI integration

## Changes Made

**New files:**
- `cmd/meridian-cli/main.go` - CLI entry point
- `cmd/meridian-cli/cmd/root.go` - Root Cobra command
- `cmd/meridian-cli/cmd/saga.go` - Saga command group
- `cmd/meridian-cli/cmd/saga_validate.go` - Validate subcommand with schema loading, mock generation, dry-run execution, and output formatting
- `cmd/meridian-cli/cmd/saga_validate_test.go` - 12 tests covering valid/invalid scripts, JSON output, missing files, line numbers, undefined handlers, complexity metrics, and path handling

## Technical Details

- Reuses existing `validation.DryRunValidator`, `validation.NewMockHandlerRegistry`, and formatter infrastructure from `shared/pkg/saga/validation`
- Follows the same Cobra CLI pattern as `instrument-cli`
- Suppresses INFO-level slog output for clean CLI experience (errors captured in ValidationResult)
- Supports `--json` flag for structured output, `--handlers` flag for custom schema path, `--dry-run` as compatibility alias

## Testing

12 unit tests:
- Valid script passes with exit 0 and handler metrics
- Syntax errors detected with line numbers
- Missing file returns descriptive error
- JSON output format parses correctly
- Multiple handlers counted in complexity metrics
- Relative and absolute paths work
- Undefined handlers detected
- Human-readable and JSON formatters produce correct output

## Task Master

Task: saga-script-versioning.29 - Add CLI validation command for local testing