### PR TITLE
feat: add saga validation metrics to Prometheus

### DIFF
--- a/services/reference-data/saga/grpc_handler.go
+++ b/services/reference-data/saga/grpc_handler.go
@@ -453,6 +453,9 @@ func (h *RegistryHandler) ValidateSaga(
 		return nil, status.Errorf(codes.Internal, "validation error: %v", err)
 	}
 
+	// Record validation metrics
+	validation.RecordValidation(req.SagaName, result)
+
 	// Log validation attempt
 	h.logger.Info("saga script validated",
 		"saga_name", req.SagaName,

--- a/shared/pkg/saga/validation/metrics.go
+++ b/shared/pkg/saga/validation/metrics.go
@@ -1,0 +1,86 @@
+package validation
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// validationTotal tracks total saga validations by outcome.
+	// Labels: saga_name (saga identifier), status ("success" or "failed")
+	validationTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "saga_validation_total",
+			Help: "Total saga validations performed",
+		},
+		[]string{"saga_name", "status"},
+	)
+
+	// validationErrorsTotal tracks validation errors by category.
+	// Labels: saga_name, error_category (SYNTAX, UNDEFINED_HANDLER, TYPE_MISMATCH, RUNTIME, TIMEOUT)
+	validationErrorsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "saga_validation_errors_total",
+			Help: "Total validation errors by category",
+		},
+		[]string{"saga_name", "error_category"},
+	)
+
+	// complexityScore tracks the distribution of saga complexity scores (0-10).
+	complexityScore = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "saga_complexity_score",
+			Help:    "Complexity score distribution (0-10)",
+			Buckets: []float64{1, 2, 3, 5, 7, 10},
+		},
+		[]string{"saga_name"},
+	)
+
+	// handlerCallCount tracks handler calls per saga validation.
+	handlerCallCount = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "saga_handler_call_count",
+			Help:    "Handler calls per saga validation",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 10),
+		},
+		[]string{"saga_name"},
+	)
+)
+
+// RecordValidation records Prometheus metrics for a validation result.
+func RecordValidation(sagaName string, result *ValidationResult) {
+	if result == nil {
+		return
+	}
+
+	status := "success"
+	if !result.Success {
+		status = "failed"
+	}
+	validationTotal.WithLabelValues(sagaName, status).Inc()
+
+	for _, err := range result.Errors {
+		validationErrorsTotal.WithLabelValues(sagaName, string(err.Category)).Inc()
+	}
+
+	score := result.Metrics.HandlerCallCount / 2
+	if score > 10 {
+		score = 10
+	}
+	complexityScore.WithLabelValues(sagaName).Observe(float64(score))
+
+	handlerCallCount.WithLabelValues(sagaName).Observe(float64(result.Metrics.HandlerCallCount))
+}
+
+// ExposeValidationMetricsForTesting provides access to raw Prometheus metrics for testing.
+var ExposeValidationMetricsForTesting = struct {
+	ValidationTotal  *prometheus.CounterVec
+	ErrorsTotal      *prometheus.CounterVec
+	ComplexityScore  *prometheus.HistogramVec
+	HandlerCallCount *prometheus.HistogramVec
+}{
+	ValidationTotal:  validationTotal,
+	ErrorsTotal:      validationErrorsTotal,
+	ComplexityScore:  complexityScore,
+	HandlerCallCount: handlerCallCount,
+}

--- a/shared/pkg/saga/validation/metrics.go
+++ b/shared/pkg/saga/validation/metrics.go
@@ -63,11 +63,7 @@ func RecordValidation(sagaName string, result *ValidationResult) {
 		validationErrorsTotal.WithLabelValues(sagaName, string(err.Category)).Inc()
 	}
 
-	score := result.Metrics.HandlerCallCount / 2
-	if score > 10 {
-		score = 10
-	}
-	complexityScore.WithLabelValues(sagaName).Observe(float64(score))
+	complexityScore.WithLabelValues(sagaName).Observe(float64(calculateComplexityScore(result.Metrics.HandlerCallCount)))
 
 	handlerCallCount.WithLabelValues(sagaName).Observe(float64(result.Metrics.HandlerCallCount))
 }

--- a/shared/pkg/saga/validation/metrics_test.go
+++ b/shared/pkg/saga/validation/metrics_test.go
@@ -1,0 +1,124 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecordValidation_Success(t *testing.T) {
+	ExposeValidationMetricsForTesting.ValidationTotal.Reset()
+	ExposeValidationMetricsForTesting.ErrorsTotal.Reset()
+
+	result := &ValidationResult{
+		Success: true,
+		Errors:  []ValidationError{},
+		Metrics: ComplexityMetrics{
+			HandlerCallCount: 4,
+			OperationCount:   10,
+		},
+	}
+
+	RecordValidation("test-saga", result)
+
+	successCount := testutil.ToFloat64(
+		ExposeValidationMetricsForTesting.ValidationTotal.WithLabelValues("test-saga", "success"),
+	)
+	assert.Equal(t, float64(1), successCount)
+
+	failedCount := testutil.ToFloat64(
+		ExposeValidationMetricsForTesting.ValidationTotal.WithLabelValues("test-saga", "failed"),
+	)
+	assert.Equal(t, float64(0), failedCount)
+}
+
+func TestRecordValidation_Failed(t *testing.T) {
+	ExposeValidationMetricsForTesting.ValidationTotal.Reset()
+	ExposeValidationMetricsForTesting.ErrorsTotal.Reset()
+
+	result := &ValidationResult{
+		Success: false,
+		Errors: []ValidationError{
+			{Line: 1, Column: 5, Message: "syntax error", Category: CategorySyntax},
+			{Line: 3, Column: 1, Message: "unknown handler", Category: CategoryUndefinedHandler},
+		},
+		Metrics: ComplexityMetrics{
+			HandlerCallCount: 2,
+		},
+	}
+
+	RecordValidation("broken-saga", result)
+
+	failedCount := testutil.ToFloat64(
+		ExposeValidationMetricsForTesting.ValidationTotal.WithLabelValues("broken-saga", "failed"),
+	)
+	assert.Equal(t, float64(1), failedCount)
+
+	syntaxErrors := testutil.ToFloat64(
+		ExposeValidationMetricsForTesting.ErrorsTotal.WithLabelValues("broken-saga", "SYNTAX"),
+	)
+	assert.Equal(t, float64(1), syntaxErrors)
+
+	undefinedErrors := testutil.ToFloat64(
+		ExposeValidationMetricsForTesting.ErrorsTotal.WithLabelValues("broken-saga", "UNDEFINED_HANDLER"),
+	)
+	assert.Equal(t, float64(1), undefinedErrors)
+}
+
+func TestRecordValidation_NilResult(_ *testing.T) {
+	// Should not panic
+	RecordValidation("nil-saga", nil)
+}
+
+func TestRecordValidation_ComplexityScoreCapped(t *testing.T) {
+	ExposeValidationMetricsForTesting.ValidationTotal.Reset()
+
+	result := &ValidationResult{
+		Success: true,
+		Errors:  []ValidationError{},
+		Metrics: ComplexityMetrics{
+			HandlerCallCount: 100, // score = 100/2 = 50, capped at 10
+		},
+	}
+
+	// Should not panic; complexity score should be capped at 10
+	RecordValidation("complex-saga", result)
+
+	successCount := testutil.ToFloat64(
+		ExposeValidationMetricsForTesting.ValidationTotal.WithLabelValues("complex-saga", "success"),
+	)
+	assert.Equal(t, float64(1), successCount)
+}
+
+func TestRecordValidation_MultipleCategories(t *testing.T) {
+	ExposeValidationMetricsForTesting.ErrorsTotal.Reset()
+
+	result := &ValidationResult{
+		Success: false,
+		Errors: []ValidationError{
+			{Category: CategorySyntax, Message: "parse error"},
+			{Category: CategorySyntax, Message: "another parse error"},
+			{Category: CategoryRuntime, Message: "runtime failure"},
+			{Category: CategoryTypeMismatch, Message: "wrong type"},
+		},
+		Metrics: ComplexityMetrics{HandlerCallCount: 3},
+	}
+
+	RecordValidation("multi-error-saga", result)
+
+	syntaxErrors := testutil.ToFloat64(
+		ExposeValidationMetricsForTesting.ErrorsTotal.WithLabelValues("multi-error-saga", "SYNTAX"),
+	)
+	assert.Equal(t, float64(2), syntaxErrors)
+
+	runtimeErrors := testutil.ToFloat64(
+		ExposeValidationMetricsForTesting.ErrorsTotal.WithLabelValues("multi-error-saga", "RUNTIME"),
+	)
+	assert.Equal(t, float64(1), runtimeErrors)
+
+	typeMismatchErrors := testutil.ToFloat64(
+		ExposeValidationMetricsForTesting.ErrorsTotal.WithLabelValues("multi-error-saga", "TYPE_MISMATCH"),
+	)
+	assert.Equal(t, float64(1), typeMismatchErrors)
+}


### PR DESCRIPTION
## Summary

- Add four new Prometheus metrics for saga validation observability:
  - `saga_validation_total` (counter, labels: saga_name, status) - tracks success/failure counts
  - `saga_validation_errors_total` (counter, labels: saga_name, error_category) - tracks errors by category (SYNTAX, UNDEFINED_HANDLER, TYPE_MISMATCH, RUNTIME, TIMEOUT)
  - `saga_complexity_score` (histogram, label: saga_name) - complexity score distribution (0-10)
  - `saga_handler_call_count` (histogram, label: saga_name) - handler calls per validation
- Integrate `RecordValidation()` into gRPC `ValidateSaga` handler
- Follows existing `promauto` + `ExposeMetricsForTesting` pattern from `metrics.go` and `cache_metrics.go`

## Task Master

Tag: saga-script-versioning, Task: 30

## Test plan

- [x] Unit tests for all metric recording paths (success, failure, nil result, capped complexity, multiple error categories)
- [x] All existing validation package tests pass
- [x] All reference-data saga handler tests pass
- [x] Pre-commit lint checks pass
- [ ] CI passes