### PR TITLE
feat: Integrate dry-run validation into CreateSagaDraft workflow

### DIFF
--- a/services/reference-data/migrations/20260130000001_saga_validation_metadata.sql
+++ b/services/reference-data/migrations/20260130000001_saga_validation_metadata.sql
@@ -1,0 +1,7 @@
+-- Add validation metadata columns to saga_definition.
+-- These store results from the mandatory DryRunValidator that runs
+-- during CreateSagaDraft, enabling capacity planning and audit.
+ALTER TABLE saga_definition ADD COLUMN IF NOT EXISTS validation_status TEXT NOT NULL DEFAULT 'UNVALIDATED';
+ALTER TABLE saga_definition ADD COLUMN IF NOT EXISTS complexity_score INT;
+ALTER TABLE saga_definition ADD COLUMN IF NOT EXISTS handler_call_count INT;
+ALTER TABLE saga_definition ADD COLUMN IF NOT EXISTS validated_at TIMESTAMPTZ;

--- a/services/reference-data/saga/grpc_handler.go
+++ b/services/reference-data/saga/grpc_handler.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc/codes"
@@ -45,6 +46,8 @@ func NewRegistryHandler(registry Registry, validator *ReferenceValidator, dryRun
 }
 
 // CreateSagaDraft creates a new saga definition in DRAFT status.
+// If a DryRunValidator is configured, the script is validated before persistence.
+// Invalid scripts are rejected with INVALID_ARGUMENT status.
 func (h *RegistryHandler) CreateSagaDraft(
 	ctx context.Context,
 	req *sagav1.CreateSagaDraftRequest,
@@ -69,6 +72,39 @@ func (h *RegistryHandler) CreateSagaDraft(
 		Description:             req.Description,
 	}
 
+	// Mandatory dry-run validation: reject invalid scripts before persistence
+	if h.dryRunValidator != nil && req.Script != "" {
+		dryRunResult, err := h.dryRunValidator.Validate(ctx, req.Script)
+		if err != nil {
+			h.logger.Error("dry-run validation error during draft creation",
+				"saga_name", req.Name,
+				"error", err)
+			return nil, status.Errorf(codes.Internal, "validation error: %v", err)
+		}
+
+		if !dryRunResult.Success {
+			formatter := &validation.HumanReadableFormatter{}
+			errMsg := formatter.Format(dryRunResult)
+
+			h.logger.Warn("saga script validation failed",
+				"saga_name", req.Name,
+				"version", version,
+				"error_count", len(dryRunResult.Errors))
+
+			return nil, status.Errorf(codes.InvalidArgument,
+				"saga script validation failed:\n%s", errMsg)
+		}
+
+		// Store validation metadata on the definition
+		now := time.Now()
+		complexityScore := calculateComplexityScore(dryRunResult.Metrics.HandlerCallCount)
+		handlerCallCount := dryRunResult.Metrics.HandlerCallCount
+		def.ValidationStatus = "PASSED"
+		def.ComplexityScore = &complexityScore
+		def.HandlerCallCount = &handlerCallCount
+		def.ValidatedAt = &now
+	}
+
 	if err := h.registry.CreateDraft(ctx, def); err != nil {
 		return nil, h.mapDomainError(err, "CreateSagaDraft", req.Name)
 	}
@@ -78,12 +114,12 @@ func (h *RegistryHandler) CreateSagaDraft(
 		"version", def.Version,
 		"id", def.ID)
 
-	// Perform initial validation (non-blocking)
+	// Perform reference validation (non-blocking)
 	var validationResult *sagav1.ValidationResult
 	if h.validator != nil {
 		result, err := h.validator.ValidateDraft(ctx, def.ID, def.Script)
 		if err != nil {
-			h.logger.Warn("validation failed during draft creation",
+			h.logger.Warn("reference validation failed during draft creation",
 				"saga_id", def.ID,
 				"error", err)
 		} else {

--- a/services/reference-data/saga/grpc_handler_test.go
+++ b/services/reference-data/saga/grpc_handler_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"github.com/meridianhub/meridian/shared/pkg/saga/validation"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,6 +88,10 @@ func setupTestPostgres(t *testing.T) (*pgxpool.Pool, tenant.TenantID, func()) {
 			platform_ref uuid NULL,
 			override_reason text NULL,
 			platform_version_at_override varchar(16) NULL,
+			validation_status text NOT NULL DEFAULT 'UNVALIDATED',
+			complexity_score integer NULL,
+			handler_call_count integer NULL,
+			validated_at timestamptz NULL,
 			PRIMARY KEY (id),
 			CONSTRAINT uq_saga_definition_name_version UNIQUE (name, version),
 			CONSTRAINT fk_saga_definition_platform_ref
@@ -628,5 +634,244 @@ func TestRegistryHandler_TenantOverride(t *testing.T) {
 		st, ok := status.FromError(err)
 		require.True(t, ok)
 		assert.Equal(t, codes.PermissionDenied, st.Code())
+	})
+}
+
+// setupTestDryRunValidator creates a DryRunValidator for testing with common handlers.
+func setupTestDryRunValidator(t *testing.T) *validation.DryRunValidator {
+	t.Helper()
+
+	schemaRegistry := schema.NewRegistry()
+	schemaYAML := `
+service: test
+version: 1.0
+handlers:
+  test_service.test_method:
+    description: Test method
+    params: {}
+    returns:
+      result:
+        type: string
+      error:
+        type: string
+  payment.create_lien:
+    description: Create payment lien
+    params:
+      amount:
+        type: string
+        required: true
+      customer_id:
+        type: string
+        required: true
+    returns:
+      lien_id:
+        type: string
+      error:
+        type: string
+`
+	require.NoError(t, schemaRegistry.LoadFromYAML([]byte(schemaYAML)))
+
+	validator, err := validation.NewMockValidatorForTesting(schemaRegistry)
+	require.NoError(t, err)
+	return validator
+}
+
+func TestRegistryHandler_CreateSagaDraft_WithDryRunValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	dryRunValidator := setupTestDryRunValidator(t)
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, dryRunValidator, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	t.Run("valid script registers successfully with validation metadata", func(t *testing.T) {
+		req := &sagav1.CreateSagaDraftRequest{
+			Name:        "validated_saga",
+			Script:      `result = test_service.test_method()`,
+			DisplayName: "Validated Saga",
+		}
+
+		resp, err := handler.CreateSagaDraft(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Saga)
+
+		assert.Equal(t, "validated_saga", resp.Saga.Name)
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_DRAFT, resp.Saga.Status)
+
+		// Verify validation metadata was stored by re-fetching from DB
+		fetched, err := registry.GetByID(ctx, uuid.MustParse(resp.Saga.Id))
+		require.NoError(t, err)
+
+		assert.Equal(t, "PASSED", fetched.ValidationStatus)
+		require.NotNil(t, fetched.ComplexityScore, "complexity score should be stored")
+		assert.GreaterOrEqual(t, *fetched.ComplexityScore, 0)
+		require.NotNil(t, fetched.HandlerCallCount, "handler call count should be stored")
+		assert.Equal(t, 1, *fetched.HandlerCallCount)
+		require.NotNil(t, fetched.ValidatedAt, "validated_at should be stored")
+		assert.WithinDuration(t, time.Now(), *fetched.ValidatedAt, 5*time.Second)
+	})
+
+	t.Run("invalid script rejected with INVALID_ARGUMENT", func(t *testing.T) {
+		req := &sagav1.CreateSagaDraftRequest{
+			Name:   "invalid_saga",
+			Script: `result = test_service.test_method(  # Missing closing paren`,
+		}
+
+		_, err := handler.CreateSagaDraft(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "saga script validation failed")
+	})
+
+	t.Run("runtime error in script rejected", func(t *testing.T) {
+		req := &sagav1.CreateSagaDraftRequest{
+			Name:   "runtime_error_saga",
+			Script: `fail("intentional failure")`,
+		}
+
+		_, err := handler.CreateSagaDraft(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "saga script validation failed")
+	})
+
+	t.Run("undefined handler in script rejected", func(t *testing.T) {
+		req := &sagav1.CreateSagaDraftRequest{
+			Name:   "undefined_handler_saga",
+			Script: `result = nonexistent_service.some_method()`,
+		}
+
+		_, err := handler.CreateSagaDraft(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("invalid script not persisted to database", func(t *testing.T) {
+		req := &sagav1.CreateSagaDraftRequest{
+			Name:   "should_not_persist",
+			Script: `fail("should not be saved")`,
+		}
+
+		_, err := handler.CreateSagaDraft(ctx, req)
+		require.Error(t, err)
+
+		// Verify it was NOT persisted
+		_, getErr := registry.GetDefinition(ctx, "should_not_persist", 1)
+		assert.ErrorIs(t, getErr, ErrNotFound)
+	})
+
+	t.Run("multiple handler calls stores correct metrics", func(t *testing.T) {
+		req := &sagav1.CreateSagaDraftRequest{
+			Name: "multi_handler_saga",
+			Script: `
+lien_result = payment.create_lien(amount="100.00", customer_id="cust_123")
+result = test_service.test_method()
+verify = test_service.test_method()
+`,
+		}
+
+		resp, err := handler.CreateSagaDraft(ctx, req)
+		require.NoError(t, err)
+
+		fetched, err := registry.GetByID(ctx, uuid.MustParse(resp.Saga.Id))
+		require.NoError(t, err)
+
+		assert.Equal(t, "PASSED", fetched.ValidationStatus)
+		require.NotNil(t, fetched.HandlerCallCount)
+		assert.Equal(t, 3, *fetched.HandlerCallCount)
+		require.NotNil(t, fetched.ComplexityScore)
+		assert.Equal(t, 1, *fetched.ComplexityScore) // 3/2 = 1
+	})
+}
+
+func TestRegistryHandler_CreateSagaDraft_WithoutDryRunValidator(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	registry := NewPostgresRegistry(pool, nil)
+	// Handler without dryRunValidator - backward compatible
+	handler := NewRegistryHandler(registry, nil, nil, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	t.Run("creates draft without validation when validator not configured", func(t *testing.T) {
+		req := &sagav1.CreateSagaDraftRequest{
+			Name:   "no_validation_saga",
+			Script: `fail("this would fail validation but no validator configured")`,
+		}
+
+		resp, err := handler.CreateSagaDraft(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Saga)
+		assert.Equal(t, "no_validation_saga", resp.Saga.Name)
+
+		// Validation metadata should be default/empty
+		fetched, err := registry.GetByID(ctx, uuid.MustParse(resp.Saga.Id))
+		require.NoError(t, err)
+		assert.Equal(t, "UNVALIDATED", fetched.ValidationStatus)
+		assert.Nil(t, fetched.ComplexityScore)
+		assert.Nil(t, fetched.HandlerCallCount)
+		assert.Nil(t, fetched.ValidatedAt)
+	})
+}
+
+func TestRegistryHandler_ExistingTests_StillPass_WithValidator(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	pool, tenantID, cleanup := setupTestPostgres(t)
+	defer cleanup()
+
+	dryRunValidator := setupTestDryRunValidator(t)
+	registry := NewPostgresRegistry(pool, nil)
+	handler := NewRegistryHandler(registry, nil, dryRunValidator, nil)
+
+	ctx := tenant.WithTenant(context.Background(), tenantID)
+
+	t.Run("full lifecycle works with validation enabled", func(t *testing.T) {
+		// Create - valid script passes validation
+		createResp, err := handler.CreateSagaDraft(ctx, &sagav1.CreateSagaDraftRequest{
+			Name:        "lifecycle_validated",
+			Script:      `test_service.test_method()`,
+			DisplayName: "Lifecycle with validation",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_DRAFT, createResp.Saga.Status)
+
+		sagaID := createResp.Saga.Id
+
+		// Activate
+		activateResp, err := handler.ActivateSaga(ctx, &sagav1.ActivateSagaRequest{
+			Id: sagaID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_ACTIVE, activateResp.Saga.Status)
+
+		// Deprecate
+		deprecateResp, err := handler.DeprecateSaga(ctx, &sagav1.DeprecateSagaRequest{
+			Id: sagaID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, sagav1.SagaStatus_SAGA_STATUS_DEPRECATED, deprecateResp.Saga.Status)
 	})
 }

--- a/services/reference-data/saga/postgres_registry.go
+++ b/services/reference-data/saga/postgres_registry.go
@@ -121,7 +121,8 @@ func (r *PostgresRegistry) GetByID(ctx context.Context, id uuid.UUID) (*Definiti
 				sd.preconditions_expression, sd.display_name, sd.description,
 				sd.created_at, sd.updated_at, sd.activated_at, sd.deprecated_at, sd.successor_id,
 				sd.platform_ref, sd.override_reason, sd.platform_version_at_override,
-				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback
+				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback,
+				sd.validation_status, sd.complexity_score, sd.handler_call_count, sd.validated_at
 			FROM saga_definition sd
 			LEFT JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
 			WHERE sd.id = $1`
@@ -158,7 +159,8 @@ func (r *PostgresRegistry) GetDefinition(ctx context.Context, name string, versi
 				sd.preconditions_expression, sd.display_name, sd.description,
 				sd.created_at, sd.updated_at, sd.activated_at, sd.deprecated_at, sd.successor_id,
 				sd.platform_ref, sd.override_reason, sd.platform_version_at_override,
-				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback
+				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback,
+				sd.validation_status, sd.complexity_score, sd.handler_call_count, sd.validated_at
 			FROM saga_definition sd
 			LEFT JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
 			WHERE sd.name = $1 AND sd.version = $2`
@@ -201,7 +203,8 @@ func (r *PostgresRegistry) GetActive(ctx context.Context, name string) (*Definit
 				sd.preconditions_expression, sd.display_name, sd.description,
 				sd.created_at, sd.updated_at, sd.activated_at, sd.deprecated_at, sd.successor_id,
 				sd.platform_ref, sd.override_reason, sd.platform_version_at_override,
-				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback
+				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback,
+				sd.validation_status, sd.complexity_score, sd.handler_call_count, sd.validated_at
 			FROM saga_definition sd
 			LEFT JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
 			WHERE sd.name = $1 AND sd.status = 'ACTIVE' AND sd.is_system = FALSE
@@ -237,7 +240,8 @@ func (r *PostgresRegistry) GetActive(ctx context.Context, name string) (*Definit
 				sd.preconditions_expression, sd.display_name, sd.description,
 				sd.created_at, sd.updated_at, sd.activated_at, sd.deprecated_at, sd.successor_id,
 				sd.platform_ref, sd.override_reason, sd.platform_version_at_override,
-				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback
+				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback,
+				sd.validation_status, sd.complexity_score, sd.handler_call_count, sd.validated_at
 			FROM saga_definition sd
 			LEFT JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
 			WHERE sd.name = $1 AND sd.status = 'ACTIVE' AND sd.is_system = TRUE
@@ -280,7 +284,8 @@ func (r *PostgresRegistry) ListByStatus(ctx context.Context, status Status) ([]*
 				sd.preconditions_expression, sd.display_name, sd.description,
 				sd.created_at, sd.updated_at, sd.activated_at, sd.deprecated_at, sd.successor_id,
 				sd.platform_ref, sd.override_reason, sd.platform_version_at_override,
-				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback
+				psd.script IS NOT NULL AND (sd.script IS NULL OR sd.script = '') AS used_platform_fallback,
+				sd.validation_status, sd.complexity_score, sd.handler_call_count, sd.validated_at
 			FROM saga_definition sd
 			LEFT JOIN public.platform_saga_definition psd ON sd.platform_ref = psd.id
 			WHERE sd.status = $1
@@ -371,12 +376,14 @@ func (r *PostgresRegistry) CreateDraft(ctx context.Context, def *Definition) err
 				id, name, version, script, status, is_system,
 				preconditions_expression, display_name, description,
 				platform_ref, override_reason, platform_version_at_override,
-				created_at, updated_at
+				created_at, updated_at,
+				validation_status, complexity_score, handler_call_count, validated_at
 			) VALUES (
 				$1, $2, $3, $4, $5, $6,
 				$7, $8, $9,
 				$10, $11, $12,
-				$13, $14
+				$13, $14,
+				$15, $16, $17, $18
 			)`
 
 		// Handle script: if platform_ref is set and no script, pass NULL
@@ -387,11 +394,18 @@ func (r *PostgresRegistry) CreateDraft(ctx context.Context, def *Definition) err
 			scriptValue = def.Script
 		}
 
+		// Default validation_status to UNVALIDATED if not set
+		validationStatus := def.ValidationStatus
+		if validationStatus == "" {
+			validationStatus = "UNVALIDATED"
+		}
+
 		_, err := tx.Exec(ctx, query,
 			def.ID, def.Name, def.Version, scriptValue, string(def.Status), def.IsSystem,
 			nullString(def.PreconditionsExpression), nullString(def.DisplayName), nullString(def.Description),
 			def.PlatformRef, nullString(def.OverrideReason), nullString(def.PlatformVersionAtOverride),
 			def.CreatedAt, def.UpdatedAt,
+			validationStatus, def.ComplexityScore, def.HandlerCallCount, def.ValidatedAt,
 		)
 		if err != nil {
 			var pgErr *pgconn.PgError
@@ -594,6 +608,8 @@ func (r *PostgresRegistry) scanDefinitionWithFallback(row pgx.Row) (*Definition,
 	var platformRef *uuid.UUID
 	var overrideReason, platformVersionAtOverride sql.NullString
 	var usedPlatformFallback sql.NullBool
+	var validationStatus sql.NullString
+	var complexityScore, handlerCallCount sql.NullInt64
 
 	err := row.Scan(
 		&def.ID, &def.Name, &def.Version,
@@ -604,6 +620,7 @@ func (r *PostgresRegistry) scanDefinitionWithFallback(row pgx.Row) (*Definition,
 		&def.CreatedAt, &def.UpdatedAt, &def.ActivatedAt, &def.DeprecatedAt, &successorID,
 		&platformRef, &overrideReason, &platformVersionAtOverride,
 		&usedPlatformFallback,
+		&validationStatus, &complexityScore, &handlerCallCount, &def.ValidatedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -635,6 +652,17 @@ func (r *PostgresRegistry) scanDefinitionWithFallback(row pgx.Row) (*Definition,
 	if platformVersionAtOverride.Valid {
 		def.PlatformVersionAtOverride = platformVersionAtOverride.String
 	}
+	if validationStatus.Valid {
+		def.ValidationStatus = validationStatus.String
+	}
+	if complexityScore.Valid {
+		v := int(complexityScore.Int64)
+		def.ComplexityScore = &v
+	}
+	if handlerCallCount.Valid {
+		v := int(handlerCallCount.Int64)
+		def.HandlerCallCount = &v
+	}
 
 	return &def, nil
 }
@@ -650,6 +678,8 @@ func (r *PostgresRegistry) scanDefinitionWithFallbackFromRows(rows pgx.Rows) (*D
 	var platformRef *uuid.UUID
 	var overrideReason, platformVersionAtOverride sql.NullString
 	var usedPlatformFallback sql.NullBool
+	var validationStatus sql.NullString
+	var complexityScore, handlerCallCount sql.NullInt64
 
 	err := rows.Scan(
 		&def.ID, &def.Name, &def.Version,
@@ -660,6 +690,7 @@ func (r *PostgresRegistry) scanDefinitionWithFallbackFromRows(rows pgx.Rows) (*D
 		&def.CreatedAt, &def.UpdatedAt, &def.ActivatedAt, &def.DeprecatedAt, &successorID,
 		&platformRef, &overrideReason, &platformVersionAtOverride,
 		&usedPlatformFallback,
+		&validationStatus, &complexityScore, &handlerCallCount, &def.ValidatedAt,
 	)
 	if err != nil {
 		return nil, err
@@ -689,6 +720,17 @@ func (r *PostgresRegistry) scanDefinitionWithFallbackFromRows(rows pgx.Rows) (*D
 	}
 	if platformVersionAtOverride.Valid {
 		def.PlatformVersionAtOverride = platformVersionAtOverride.String
+	}
+	if validationStatus.Valid {
+		def.ValidationStatus = validationStatus.String
+	}
+	if complexityScore.Valid {
+		v := int(complexityScore.Int64)
+		def.ComplexityScore = &v
+	}
+	if handlerCallCount.Valid {
+		v := int(handlerCallCount.Int64)
+		def.HandlerCallCount = &v
 	}
 
 	return &def, nil

--- a/services/reference-data/saga/registry.go
+++ b/services/reference-data/saga/registry.go
@@ -151,6 +151,19 @@ type Definition struct {
 	// the platform definition (true) or the tenant's own script (false).
 	// This is populated during query resolution, not stored in the database.
 	UsedPlatformFallback bool
+
+	// ValidationStatus records the result of dry-run validation at draft creation.
+	// Values: "PASSED", "FAILED", "UNVALIDATED" (legacy rows or validator not configured).
+	ValidationStatus string
+
+	// ComplexityScore is the 0-10 complexity score from dry-run validation metrics.
+	ComplexityScore *int
+
+	// HandlerCallCount is the number of handler calls detected during dry-run validation.
+	HandlerCallCount *int
+
+	// ValidatedAt is when the script was last validated via dry-run.
+	ValidatedAt *time.Time
 }
 
 // Validator validates saga definitions before activation.

--- a/services/reference-data/saga/seeder_test.go
+++ b/services/reference-data/saga/seeder_test.go
@@ -240,6 +240,10 @@ func setupTenantSchemaForSeeder(t *testing.T, pool *pgxpool.Pool, ctx context.Co
 			platform_ref uuid NULL REFERENCES public.platform_saga_definition(id) ON DELETE SET NULL,
 			override_reason text NULL,
 			platform_version_at_override varchar(16) NULL,
+			validation_status text NOT NULL DEFAULT 'UNVALIDATED',
+			complexity_score integer NULL,
+			handler_call_count integer NULL,
+			validated_at timestamptz NULL,
 			PRIMARY KEY (id),
 			CONSTRAINT uq_saga_definition_name_version UNIQUE (name, version),
 			CONSTRAINT chk_saga_definition_script_source


### PR DESCRIPTION
## Summary

- Integrates `DryRunValidator` into the `CreateSagaDraft` gRPC handler, making script validation mandatory before persistence
- Invalid scripts (syntax errors, undefined handlers, runtime errors) are rejected with `INVALID_ARGUMENT` status before any database write
- Validation metadata (status, complexity score, handler call count, timestamp) is stored on successful creation for capacity planning
- Adds database migration for validation columns on `saga_definition` table

## Changes Made

- **Migration** (`20260130000001_saga_validation_metadata.sql`): Adds `validation_status`, `complexity_score`, `handler_call_count`, `validated_at` columns to `saga_definition`
- **`registry.go`**: Adds validation metadata fields to `Definition` struct
- **`postgres_registry.go`**: Updates INSERT query and all scan methods to include validation columns
- **`grpc_handler.go`**: `CreateSagaDraft` now runs `DryRunValidator.Validate()` before persistence. Failure rejects with `INVALID_ARGUMENT`; success stores metrics
- **Test schemas** (`grpc_handler_test.go`, `seeder_test.go`): Updated inline table schemas to include new columns

## Backward Compatibility

- Handler without `DryRunValidator` configured continues to work unchanged
- Existing rows default to `UNVALIDATED` status
- Reference validation (non-blocking) still runs after persistence as before

## Task Master

saga-script-versioning.28 - Integrate validation into RegisterSagaDefinition workflow

## Test Plan

- [x] Valid script registers successfully with validation metadata stored (PASSED status, correct handler count, complexity score, timestamp)
- [x] Invalid script (syntax error) rejected with `INVALID_ARGUMENT` and not persisted
- [x] Runtime error in script rejected with `INVALID_ARGUMENT`
- [x] Undefined handler in script rejected with `INVALID_ARGUMENT`
- [x] Invalid script not persisted to database
- [x] Multiple handler calls stores correct metrics (3 handlers = count 3, complexity 1)
- [x] Handler without validator creates draft without validation (backward compat, UNVALIDATED status)
- [x] Full lifecycle (create/activate/deprecate) works with validation enabled
- [x] All existing tests pass (277s full suite)