### PR TITLE
docs: Fix Go version mismatch in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ needed for custom setups or unsupported platforms.
 
 #### 1. Core Tools
 
-#### Go 1.23+
+#### Go 1.25+
 
 ```bash
 


### PR DESCRIPTION
## Summary
- Update CONTRIBUTING.md Go version requirement from 1.23+ to 1.25+ to match go.mod (1.25.7) and README.md (1.25+)

## Task Reference
codebase-health-audit.1

## Test plan
- [x] Verified Go version consistency across CONTRIBUTING.md, README.md, and go.mod