### PR TITLE
chore: Pin golangci-lint version to v2.7.2 matching CI

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,6 +6,9 @@
 
 set -e
 
+# Pinned tool versions (keep in sync with .github/workflows/quality.yml)
+GOLANGCI_LINT_VERSION="v2.7.2"
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -131,7 +134,7 @@ fi
 # Check if golangci-lint is installed
 if ! command -v golangci-lint &> /dev/null; then
     echo -e "${YELLOW}⚠${NC}  golangci-lint not found, installing..."
-    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.5.0
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)/bin" "$GOLANGCI_LINT_VERSION"
 fi
 
 # Format staged Go files with gofumpt


### PR DESCRIPTION
## Summary
- Update .githooks/pre-commit golangci-lint version from v2.5.0 to v2.7.2 to match .github/workflows/quality.yml
- Extract version to a shared variable (`GOLANGCI_LINT_VERSION`) at top of pre-commit script for easier future updates

## Task Reference
codebase-health-audit.4

## Test plan
- [x] Verified version matches CI workflow
- [x] Pre-commit hook script syntax is valid