### PR TITLE
ci: Enable Trivy scanning for PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,24 @@ jobs:
             COMMIT=${{ github.sha }}
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
 
-      - name: Run Trivy vulnerability scanner on image
+      - name: Run Trivy vulnerability scanner (filesystem)
+        if: github.event_name == 'pull_request'
+        uses: aquasecurity/trivy-action@0.33.1
+        continue-on-error: true
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'sarif'
+          output: 'trivy-fs-results.sarif'
+
+      - name: Upload Trivy filesystem results to GitHub Security tab
+        if: github.event_name == 'pull_request'
+        uses: github/codeql-action/upload-sarif@v4
+        continue-on-error: true
+        with:
+          sarif_file: trivy-fs-results.sarif
+
+      - name: Run Trivy vulnerability scanner (image)
         if: github.event_name != 'pull_request'
         uses: aquasecurity/trivy-action@0.33.1
         with:
@@ -93,7 +110,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-image-results.sarif'
 
-      - name: Upload Trivy results to GitHub Security tab
+      - name: Upload Trivy image results to GitHub Security tab
         if: github.event_name != 'pull_request'
         uses: github/codeql-action/upload-sarif@v4
         with:


### PR DESCRIPTION
## Summary

- Enable Trivy vulnerability scanning on PR builds using filesystem scan mode (`scan-type: 'fs'`)
- PR scans use `continue-on-error: true` so findings are non-blocking warnings
- Image-based Trivy scanning remains blocking for main/develop pushes (unchanged)
- Both paths upload SARIF results to the GitHub Security tab

## Changes

Previously, Trivy was completely skipped on PRs via `if: github.event_name != 'pull_request'`. This meant vulnerability issues were only discovered after merging to main/develop.

Now PRs get filesystem-level vulnerability scanning (dependencies, configs, IaC), giving developers early feedback. The scan is non-blocking to avoid disrupting PRs over upstream CVEs that may not be actionable.

Image scanning on main/develop remains blocking and unchanged.

## Test plan

- [ ] PR build triggers Trivy filesystem scan step
- [ ] Trivy scan does not block PR merge (continue-on-error)
- [ ] Push to main/develop still runs image-based Trivy scan (blocking)
- [ ] SARIF results appear in GitHub Security tab for both paths

Ref: codebase-health-audit.7