### PR TITLE
feat: Add Gitleaks secret scanning to pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Pre-commit hook for Meridian
 # Runs validation on staged files:
+# - Gitleaks secret scanning on all files
 # - gofumpt and golangci-lint on Go files
 # - buf lint and buf breaking on proto files
 
@@ -23,12 +24,34 @@ STAGED_GO_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$'
 STAGED_PROTO_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.proto$' || true)
 STAGED_MD_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.md$' || true)
 
-if [ -z "$STAGED_GO_FILES" ] && [ -z "$STAGED_PROTO_FILES" ] && [ -z "$STAGED_MD_FILES" ]; then
-    echo -e "${GREEN}✓${NC} No Go, proto, or markdown files to check"
-    exit 0
+echo -e "${YELLOW}Running pre-commit checks...${NC}"
+
+# ============================================================================
+# SECRET SCANNING (Gitleaks)
+# ============================================================================
+
+# Gitleaks runs on all staged files regardless of type - secrets can be anywhere
+if command -v gitleaks &> /dev/null; then
+    echo -e "${YELLOW}→${NC} Running Gitleaks secret scan on staged files..."
+    if gitleaks protect --staged --no-banner; then
+        echo -e "${GREEN}✓${NC} Gitleaks passed (no secrets detected)"
+    else
+        echo -e "${RED}✗${NC} Gitleaks detected potential secrets in staged files"
+        echo -e "${RED}Please remove secrets before committing${NC}"
+        echo -e "${YELLOW}Tip:${NC} If this is a false positive, add the fingerprint to .gitleaksignore"
+        echo -e "${YELLOW}Tip:${NC} Run 'gitleaks protect --staged' for details"
+        exit 1
+    fi
+else
+    echo -e "${YELLOW}⚠${NC}  gitleaks not found, skipping secret scanning"
+    echo -e "${YELLOW}   Install: brew install gitleaks (macOS) or see https://github.com/gitleaks/gitleaks#installing${NC}"
 fi
 
-echo -e "${YELLOW}Running pre-commit checks...${NC}"
+if [ -z "$STAGED_GO_FILES" ] && [ -z "$STAGED_PROTO_FILES" ] && [ -z "$STAGED_MD_FILES" ]; then
+    echo -e "${GREEN}✓${NC} No Go, proto, or markdown files to check"
+    echo -e "${GREEN}✓${NC} All pre-commit checks passed"
+    exit 0
+fi
 
 # ============================================================================
 # PROTO FILE CHECKS


### PR DESCRIPTION
## Summary

- Integrate Gitleaks secret scanning into `.githooks/pre-commit` as the first check, running before all language-specific checks
- Scans all staged files for secrets using `gitleaks protect --staged`
- Gracefully degrades if gitleaks is not installed (warns and provides install instructions)
- Aligns local pre-commit scanning with CI Gitleaks scanning in `security.yml`

## Changes Made

- `.githooks/pre-commit`: Added "SECRET SCANNING (Gitleaks)" section at the top of the check pipeline, following the existing pattern of tool detection and graceful degradation

## Technical Details

- Uses `gitleaks protect --staged --no-banner` to scan only staged files
- Positioned before proto/markdown/Go checks so secrets are caught first regardless of file type
- On failure, provides actionable tips: add fingerprint to `.gitleaksignore` for false positives
- The repo already has `.gitleaks.toml` and `.gitleaksignore` configured for allowlisting

## Test Plan

- [ ] Verify hook runs successfully when gitleaks is installed and no secrets staged
- [ ] Verify hook warns and skips gracefully when gitleaks is not installed
- [ ] Verify hook blocks commit when a secret is staged
- [ ] Verify existing Go/proto/markdown checks still run after Gitleaks passes

## References

- Task: codebase-health-audit.6