### PR TITLE
feat: Add K8s manifests for reference-data service

### DIFF
--- a/services/reference-data/k8s/configmap.yaml
+++ b/services/reference-data/k8s/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: reference-data-config
+  labels:
+    app: reference-data
+    component: microservice
+data:
+  # Logging configuration
+  LOG_LEVEL: "info"
+  LOG_FORMAT: "json"
+
+  # Database connection pool settings
+  DB_MAX_OPEN_CONNS: "25"
+  DB_MAX_IDLE_CONNS: "5"
+  DB_CONN_MAX_LIFETIME: "5m"
+  DB_CONN_MAX_IDLE_TIME: "10m"
+
+  # gRPC server configuration
+  GRPC_PORT: "50059"
+  GRPC_MAX_CONCURRENT_STREAMS: "100"
+
+  # OpenTelemetry configuration
+  OTEL_SERVICE_NAME: "reference-data-service"
+  OTEL_SAMPLING_RATE: "0.1"
+
+  # Authentication configuration
+  AUTH_ENABLED: "false"

--- a/services/reference-data/k8s/deployment.yaml
+++ b/services/reference-data/k8s/deployment.yaml
@@ -1,0 +1,109 @@
+# Port Configuration: See shared/platform/ports/ports.go for canonical port assignments.
+# This service uses ports.ReferenceData (50059) for gRPC.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reference-data
+  labels:
+    app: reference-data
+    component: microservice
+    tier: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: reference-data
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: reference-data
+        component: microservice
+        tier: backend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: reference-data
+        image: reference-data:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grpc
+          containerPort: 50059
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: reference-data-config
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: reference-data-db
+              key: DATABASE_URL
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        livenessProbe:
+          grpc:
+            port: 50059
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          grpc:
+            port: 50059
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        startupProbe:
+          grpc:
+            port: 50059
+          initialDelaySeconds: 0
+          periodSeconds: 2
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 30
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      terminationGracePeriodSeconds: 30

--- a/services/reference-data/k8s/secret.yaml
+++ b/services/reference-data/k8s/secret.yaml
@@ -1,0 +1,17 @@
+# SECURITY NOTE: This secret contains development credentials only.
+# For production deployments:
+# - Use external secret management (e.g., Sealed Secrets, External Secrets Operator)
+# - Rotate credentials regularly
+# - Use RBAC to restrict secret access
+# - Enable encryption at rest for secrets
+apiVersion: v1
+kind: Secret
+metadata:
+  name: reference-data-db
+  labels:
+    app: reference-data
+type: Opaque
+stringData:
+  # Local development connection string - CockroachDB in insecure mode
+  # Service connects to its own isolated database with dedicated user
+  DATABASE_URL: "postgres://meridian_reference_data_user@cockroachdb:26257/meridian_reference_data?sslmode=disable"

--- a/services/reference-data/k8s/service.yaml
+++ b/services/reference-data/k8s/service.yaml
@@ -1,0 +1,19 @@
+# Port Configuration: See shared/platform/ports/ports.go for canonical port assignments.
+# This service uses ports.ReferenceData for gRPC.
+apiVersion: v1
+kind: Service
+metadata:
+  name: reference-data
+  labels:
+    app: reference-data
+    component: microservice
+spec:
+  type: ClusterIP
+  clusterIP: None  # Headless service for gRPC client-side load balancing
+  ports:
+  - name: grpc
+    port: 50059
+    targetPort: grpc
+    protocol: TCP
+  selector:
+    app: reference-data


### PR DESCRIPTION
## Summary
- Add Kubernetes manifests (Deployment, Service, ConfigMap, Secret) for the reference-data service
- Uses port 50059 per `ports.ReferenceData` constant in `shared/platform/ports/ports.go`
- Follows existing service patterns (party, market-information) exactly

## Changes
- `services/reference-data/k8s/deployment.yaml` - Deployment with gRPC health probes, security context, resource limits
- `services/reference-data/k8s/service.yaml` - Headless ClusterIP service for gRPC client-side load balancing
- `services/reference-data/k8s/configmap.yaml` - Standard config (logging, DB pool, gRPC, OTEL, auth)
- `services/reference-data/k8s/secret.yaml` - Dev-only CockroachDB connection string

## Task Reference
codebase-health-audit.20

## Test plan
- [ ] Verify manifests match existing service patterns (party, market-information)
- [ ] Verify port 50059 matches `ports.ReferenceData` constant
- [ ] Verify YAML is valid and well-formed