### PR TITLE
chore: Complete .env.example with all environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,222 @@
-# Application Configuration
-APP_ENV="development"                                  # Environment: development, staging, production
-APP_PORT="8080"                                        # Server port
-APP_HOST="localhost"                                   # Server host
-LOG_LEVEL="info"                                       # Log level: debug, info, warn, error
+# =============================================================================
+# Meridian Platform - Environment Variables
+# =============================================================================
+# Copy this file to .env and adjust values for your environment.
+# For Tilt/K8s local development, most of these are set via ConfigMaps/Secrets
+# in the K8s manifests - this file is primarily for running services directly.
+#
+# Legend:
+#   [required]  - Must be set for the service to start
+#   [optional]  - Has a sensible default; override only if needed
+#   [service-specific] - Only needed by the named service(s)
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# General Application
+# -----------------------------------------------------------------------------
+ENVIRONMENT="development"                          # [optional] development | staging | production
+LOG_LEVEL="info"                                   # [optional] debug | info | warn | error
+
+# -----------------------------------------------------------------------------
+# Database (CockroachDB) - Per-Service URLs
+# -----------------------------------------------------------------------------
+# Each service connects to its own database with a dedicated user.
+# Local dev default uses CockroachDB in insecure mode (no password).
+# Production: use TLS, credentials from a secret manager, and separate hosts.
+
+# Shared bootstrap default (used when service doesn't have a specific URL)
+DATABASE_URL="postgres://meridian_user@localhost:26257/meridian?sslmode=disable"  # [required]
+
+# Service-specific database URLs (used by Tilt and the tenant provisioner)
+PLATFORM_DATABASE_URL="postgres://meridian_platform_user@cockroachdb:26257/meridian_platform?sslmode=disable"                              # [optional]
+CURRENT_ACCOUNT_DATABASE_URL="postgres://meridian_current_account_user@cockroachdb:26257/meridian_current_account?sslmode=disable"          # [optional]
+FINANCIAL_ACCOUNTING_DATABASE_URL="postgres://meridian_financial_accounting_user@cockroachdb:26257/meridian_financial_accounting?sslmode=disable"  # [optional]
+POSITION_KEEPING_DATABASE_URL="postgres://meridian_position_keeping_user@cockroachdb:26257/meridian_position_keeping?sslmode=disable"       # [optional]
+PAYMENT_ORDER_DATABASE_URL="postgres://meridian_payment_order_user@cockroachdb:26257/meridian_payment_order?sslmode=disable"                # [optional]
+PARTY_DATABASE_URL="postgres://meridian_party_user@cockroachdb:26257/meridian_party?sslmode=disable"                                       # [optional]
+INTERNAL_BANK_ACCOUNT_DATABASE_URL="postgres://meridian_internal_bank_account_user@cockroachdb:26257/meridian_internal_bank_account?sslmode=disable"  # [optional]
+MARKET_INFORMATION_DATABASE_URL="postgres://meridian_market_information_user@cockroachdb:26257/meridian_market_information?sslmode=disable"  # [optional]
+REFERENCE_DATA_DATABASE_URL="postgres://meridian_reference_data_user@cockroachdb:26257/meridian_reference_data?sslmode=disable"             # [optional]
+
+# -----------------------------------------------------------------------------
+# Kafka
+# -----------------------------------------------------------------------------
+KAFKA_BOOTSTRAP_SERVERS="localhost:9092"            # [required] Comma-separated broker addresses
+KAFKA_CLIENT_ID="meridian-service"                 # [optional] Client identifier for logging/metrics
+
+# Audit topic configuration
+AUDIT_KAFKA_TOPIC="audit.events"                   # [optional] Main audit events topic
+AUDIT_KAFKA_DLQ_TOPIC="audit.events.dlq"           # [optional] Dead letter queue topic
+AUDIT_KAFKA_CONSUMER_GROUP="audit-consumer-group"  # [optional] Consumer group for audit processing
+
+# -----------------------------------------------------------------------------
+# Redis
+# -----------------------------------------------------------------------------
+REDIS_URL="redis://localhost:6379"                 # [optional] Connection URL; used for slug caching
+
+# -----------------------------------------------------------------------------
+# Authentication & Authorization (Keycloak / JWKS)
+# -----------------------------------------------------------------------------
+# AUTH_MODE controls shared/platform/auth; AUTH_ENABLED controls bootstrap/gateway.
+# For local dev with Keycloak running in Tilt, use the defaults below.
+
+AUTH_ENABLED="false"                               # [optional] Enable auth for gRPC services (default: true in bootstrap)
+AUTH_MODE="jwks"                                   # [optional] jwks | oauth | disabled
+
+# JWKS mode (default)
+JWKS_URL="http://localhost:18080/realms/meridian/protocol/openid-connect/certs"  # [required when AUTH_ENABLED=true]
+JWKS_CACHE_TTL="24h"                              # [optional] How long to cache JWKS keys
+JWKS_REFRESH_TTL="1h"                             # [optional] Background refresh interval
+
+# JWT validation (gateway)
+JWT_ISSUER=""                                      # [optional] Expected JWT issuer (iss claim)
+JWT_AUDIENCE=""                                    # [optional] Expected JWT audience (aud claim)
+
+# OAuth mode (service-to-service)
+# OAUTH_CLIENT_ID=""                               # [required in oauth mode]
+# OAUTH_CLIENT_SECRET=""                           # [required in oauth mode]
+# OAUTH_TOKEN_URL=""                               # [required in oauth mode]
+# OAUTH_SCOPES=""                                  # [optional] Comma-separated scopes
+# OAUTH_INTROSPECTION_URL=""                       # [optional] Token introspection endpoint
+
+# -----------------------------------------------------------------------------
+# Gateway Service
+# -----------------------------------------------------------------------------
+BASE_DOMAIN="localhost"                            # [required] Base domain for subdomain tenant routing
+LOCAL_DEV_MODE="true"                              # [optional] Allow X-Tenant-Slug header (dev only)
+# PORT="8080"                                      # [optional] HTTP listen port (default: 8080)
+# BACKENDS='[{"prefix":"/v1/party","target":"party:50055"}]'  # [optional] Backend route JSON array
+# POD_NAMESPACE="default"                          # [optional] K8s namespace for namespace-aware features
+
+# API key authentication (gateway)
+# API_KEYS="key1:identity1,key2:identity2"         # [optional] Comma-separated key:identity pairs
+# API_KEY_RATE_LIMIT_PER_SECOND="100"              # [optional] Requests/sec per API key
+# API_KEY_RATE_LIMIT_BURST="200"                   # [optional] Burst size for rate limiting
+# API_KEY_CLEANUP_INTERVAL="10m"                   # [optional] Rate limiter cleanup interval
+# API_KEY_IDLE_TIMEOUT="1h"                        # [optional] Rate limiter idle timeout
+
+# -----------------------------------------------------------------------------
+# gRPC Service Ports
+# -----------------------------------------------------------------------------
+# Override default ports from shared/platform/ports/ports.go.
+# Typically only needed when running multiple services on the same host.
+# GRPC_PORT="50051"                                # [optional] Overrides per-service default port
+
+# -----------------------------------------------------------------------------
+# Audit Consumer (internal/audit-consumer)
+# -----------------------------------------------------------------------------
+# SERVICE_NAME="current-account"                   # [required] Which service's events to process
+# AUDIT_TOPIC="audit.events.current-account"       # [required] Kafka topic to consume from
+# KAFKA_GROUP_ID="audit-consumer-group"            # [optional] Consumer group ID
+# KAFKA_HANDLER_TIMEOUT="30s"                      # [optional] Max processing time per message
+# KAFKA_MAX_RETRIES="3"                            # [optional] Retries before sending to DLQ
+
+# -----------------------------------------------------------------------------
+# Audit Worker (services/audit-worker)
+# -----------------------------------------------------------------------------
+# AUDIT_SCHEMA=""                                  # [optional] Schema name for audit tables
+
+# -----------------------------------------------------------------------------
+# Database Connection Pool (audit-consumer)
+# -----------------------------------------------------------------------------
+# DB_MAX_OPEN_CONNS="25"                           # [optional] Max open connections
+# DB_MAX_IDLE_CONNS="5"                            # [optional] Max idle connections
+# DB_CONN_MAX_LIFETIME="5m"                        # [optional] Max connection lifetime
+# DB_CONN_MAX_IDLE_TIME="10m"                      # [optional] Max idle time before close
+# DB_POOL_STATS_INTERVAL="10s"                     # [optional] Pool statistics logging interval
+
+# -----------------------------------------------------------------------------
+# Utilization Metering Consumer
+# -----------------------------------------------------------------------------
+# POSITION_KEEPING_ENDPOINT="position-keeping:50053"  # [required] gRPC endpoint for Position Keeping
+# TENANT_ZERO_ID=""                                # [required] Platform billing tenant UUID
+# CONSUMER_GROUP_ID="utilization-metering-consumer" # [optional] Kafka consumer group
+# TENANT_ACCOUNT_MAPPING='{}'                      # [optional] JSON tenant-to-account UUID mapping
+# HTTP_PORT="8080"                                 # [optional] Health/metrics HTTP port
+
+# -----------------------------------------------------------------------------
+# Current Account Service
+# -----------------------------------------------------------------------------
+# DEPOSIT_CLEARING_ACCOUNT_ID=""                   # [service-specific] Clearing account for deposits
+# WITHDRAWAL_CLEARING_ACCOUNT_ID=""                # [service-specific] Clearing account for withdrawals
+# NOSTRO_ACCOUNT_ID=""                             # [service-specific] Nostro account ID
+# SAGA_ASSET_DIR=""                                # [service-specific] Directory for Starlark saga scripts
+
+# -----------------------------------------------------------------------------
+# Payment Order Service
+# -----------------------------------------------------------------------------
+# GATEWAY_ACCOUNT_MAPPING_FILE=""                  # [service-specific] Path to gateway account mapping config
+
+# -----------------------------------------------------------------------------
+# Party Service (KYC / Verification)
+# -----------------------------------------------------------------------------
+# KYC_STUB_ENABLED="true"                         # [optional] Use stub KYC provider (dev only)
+# VERIFICATION_PROVIDER=""                         # [optional] KYC verification provider name
+# VERIFICATION_API_KEY=""                          # [optional] Provider API key
+# VERIFICATION_API_SECRET=""                       # [optional] Provider API secret
+# VERIFICATION_BASE_URL=""                         # [optional] Provider API base URL
+# VERIFICATION_WEBHOOK_SECRET=""                   # [optional] Webhook signature secret
+# VERIFICATION_WEBHOOK_URL=""                      # [optional] Webhook callback URL
+
+# -----------------------------------------------------------------------------
+# Tenant Service
+# -----------------------------------------------------------------------------
+# SCHEMA_PROVISIONING_ENABLED="false"              # [optional] Enable automatic schema provisioning
+# PARTY_SERVICE_ENABLED="true"                     # [optional] Enable party registration on tenant create
+# REDIS_ENABLED="true"                             # [optional] Enable Redis-backed slug caching
+# K8S_NAMESPACE="default"                          # [optional] Kubernetes namespace
+# MIGRATIONS_BASE_PATH="/migrations"               # [optional] Base path for migration files
+
+# Provisioning worker configuration
+# PROVISIONING_WORKER_POLL_INTERVAL="10s"          # [optional] Poll interval for pending provisions
+# PROVISIONING_MAX_RETRIES="5"                     # [optional] Max retry attempts
+# PROVISIONING_RETRY_BASE_DELAY="2s"               # [optional] Initial retry backoff
+# PROVISIONING_RETRY_MAX_DELAY="30s"               # [optional] Maximum retry backoff
+# PROVISIONING_MAX_CONCURRENT="5"                  # [optional] Max concurrent provisioning tasks
+
+# Alerting (tenant service)
+# PAGERDUTY_ENABLED="false"                        # [optional] Enable PagerDuty alerting
+# PAGERDUTY_ROUTING_KEY=""                         # [required if PagerDuty enabled] Integration key
+# PAGERDUTY_SOURCE="tenant-service"                # [optional] Alert source identifier
+# SLACK_WEBHOOK_URL=""                             # [optional] Slack incoming webhook URL
+# SERVICE_NAME="tenant-service"                    # [optional] Service name for Slack alerts
+# ALERT_RATE_LIMIT_PER_MINUTE="10"                 # [optional] Max alerts per type per minute
+# ALERT_DLQ_MAX_SIZE="1000"                        # [optional] Max dead-letter queue entries
+# ALERT_RETRY_MAX_RETRIES="4"                      # [optional] Max alert retry attempts
+# ALERT_RETRY_INITIAL_BACKOFF="1"                  # [optional] Initial retry backoff (seconds)
+# ALERT_RETRY_MAX_BACKOFF="8"                      # [optional] Max retry backoff (seconds)
+
+# -----------------------------------------------------------------------------
+# OpenTelemetry / Observability
+# -----------------------------------------------------------------------------
+# OTEL_ENVIRONMENT="development"                   # [optional] Deployment environment
+# OTEL_EXPORTER_OTLP_ENDPOINT="alloy:4317"        # [optional] OTLP collector endpoint
+# OTEL_EXPORTER_OTLP_INSECURE="true"              # [optional] Disable TLS for OTLP (dev only)
+# OTEL_TRACES_ENABLED="true"                      # [optional] Enable distributed tracing
+# OTEL_TRACES_SAMPLER_ARG="1.0"                   # [optional] Trace sampling rate (0.0 - 1.0)
+
+# -----------------------------------------------------------------------------
+# Timeout Overrides (shared/platform/defaults)
+# -----------------------------------------------------------------------------
+# All timeouts accept Go duration strings (e.g., "5s", "30s", "2m").
+# Valid range for most: 1s to 5m. Retry delays: 10ms to 1m.
+#
+# TIMEOUT_RPC="5s"                                 # [optional] gRPC call timeout
+# TIMEOUT_HEALTH_CHECK="5s"                        # [optional] Health check timeout
+# TIMEOUT_CIRCUIT_BREAKER="30s"                    # [optional] Circuit breaker timeout
+# TIMEOUT_GRACEFUL_SHUTDOWN="30s"                  # [optional] Graceful shutdown deadline
+# TIMEOUT_CONTEXT="30s"                            # [optional] Generic context timeout
+# TIMEOUT_RETRY_DELAY="1s"                         # [optional] Initial retry delay
+# TIMEOUT_MAX_RETRY_INTERVAL="30s"                 # [optional] Maximum retry interval
+# TIMEOUT_HTTP_READ_HEADER="10s"                   # [optional] HTTP read header timeout
+# TIMEOUT_HTTP_READ="15s"                          # [optional] HTTP read timeout
+# TIMEOUT_HTTP_WRITE="15s"                         # [optional] HTTP write timeout
+# TIMEOUT_HTTP_IDLE="60s"                          # [optional] HTTP idle timeout
+
+# -----------------------------------------------------------------------------
+# Tilt / Local Development
+# -----------------------------------------------------------------------------
+# TILT_FAST_STARTUP="true"                         # [optional] Skip tests on Tilt startup
+# TILT_REGISTRY_NAME="ctlptl-registry"             # [optional] Local Docker registry name
+# TILT_REGISTRY_URL="localhost:5000"               # [optional] Local Docker registry URL
+# DOCKER_REGISTRY="ghcr.io/meridianhub"            # [optional] Docker image registry prefix


### PR DESCRIPTION
## Summary

- Expand `.env.example` from 4 generic variables to a documented reference covering all environment variables discovered across the codebase
- Organized into 14 categories: general, database URLs (per-service), Kafka, Redis, authentication/Keycloak, gateway, gRPC ports, audit consumer, audit worker, utilization metering, current-account, payment-order, party/KYC, tenant service, OpenTelemetry, timeout overrides, and Tilt/local dev
- Each variable annotated with `[required]`, `[optional]`, or `[service-specific]` and includes local dev defaults

## Changes

Variables sourced from:
- `shared/platform/bootstrap` (DATABASE_URL, REDIS_URL, AUTH_ENABLED, OTEL_*)
- `shared/platform/kafka/config.go` (KAFKA_BOOTSTRAP_SERVERS, KAFKA_CLIENT_ID, audit topic config)
- `shared/platform/auth/config.go` (AUTH_MODE, JWKS_*, OAUTH_*)
- `shared/platform/defaults/env.go` (TIMEOUT_* overrides)
- `services/gateway/config.go` (BASE_DOMAIN, API_KEYS, rate limiting)
- `services/tenant/cmd/main.go` and `config/alerting.go` (provisioning, alerting)
- `services/current-account/config/accounts.go` (clearing accounts, saga dir)
- `services/party/config/verification.go` (KYC/verification config)
- `services/utilization-metering-consumer/app/config.go` (metering consumer)
- `internal/audit-consumer/app/config.go` (audit consumer)
- `Tiltfile` (per-service database URLs, Tilt config)

## Test Plan

- [ ] Verify all listed variables match actual `os.Getenv()` calls in codebase
- [ ] Confirm local dev defaults are consistent with Tiltfile and K8s manifests
- [ ] Check that no secrets or real credentials are included

## References

Task: codebase-health-audit.3