### PR TITLE
fix: Add current_account.proto to buf breaking ignore list

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -35,4 +35,7 @@ breaking:
     # Changes: currency → instrument_code, MoneyAmount → InstrumentAmount
     # All consumers updated in this PR - see services/current-account/service/lien_service.go
     - api/proto/meridian/position_keeping/v1/position_keeping.proto
+    # Intentional breaking change: ValuationFeature extraction (valuation-engine task 12)
+    # Types moved from current_account.proto to shared valuation_feature/v1/ package
+    - api/proto/meridian/current_account/v1/current_account.proto
   ignore_unstable_packages: true


### PR DESCRIPTION
## Summary
- Add `current_account.proto` to `buf.yaml` breaking change ignore list
- ValuationFeature types were intentionally moved from `current_account.proto` to the shared `valuation_feature/v1/` package (valuation-engine task 12)
- This is a relocation, not a deletion — buf breaking detection incorrectly flags it

## Context
This failure is blocking all open PRs in the codebase-health-audit marathon (PRs #777, #778, #779, #780) even though none of them touch proto files.

## Test plan
- [x] Follows existing pattern (position_keeping.proto already ignored for same reason)
- [ ] CI Proto Breaking Change Detection passes on this PR