### PR TITLE
fix: Migrate MustFromContext to error-based handling in request paths

### DIFF
--- a/shared/platform/kafka/producer.go
+++ b/shared/platform/kafka/producer.go
@@ -233,10 +233,8 @@ func (p *ProtoProducer) ProduceRecord(ctx context.Context, record *kgo.Record) e
 // - key: Partition key as string (empty key will be null in Kafka)
 // - msg: Protocol Buffer message to serialize and send (must not be nil)
 //
-// Panics if the tenant context is missing - this is a fail-fast strategy to prevent
-// events without tenant attribution from being published.
-//
 // Returns an error if:
+// - tenant context is missing (tenant.ErrMissingTenantContext)
 // - topic is empty
 // - msg is nil
 // - protobuf marshaling fails
@@ -244,8 +242,11 @@ func (p *ProtoProducer) ProduceRecord(ctx context.Context, record *kgo.Record) e
 // - delivery confirmation indicates failure
 // - context is cancelled before delivery confirmation
 func (p *ProtoProducer) PublishWithTenant(ctx context.Context, topic string, key string, msg proto.Message) error {
-	// Extract tenant from context - panic if missing (fail-fast)
-	orgID := tenant.MustFromContext(ctx)
+	// Extract tenant from context - return error if missing
+	orgID, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot publish without tenant context: %w", err)
+	}
 
 	if topic == "" {
 		return ErrEmptyTopic

--- a/shared/platform/kafka/producer_test.go
+++ b/shared/platform/kafka/producer_test.go
@@ -191,16 +191,15 @@ func TestProtoProducer_PublishWithTenant_MissingContext(t *testing.T) {
 	}
 	defer producer.Close()
 
-	// Test that missing tenant context causes panic (fail-fast)
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("PublishWithTenant did not panic for context without tenant")
-		}
-	}()
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	// This should panic because tenant context is missing
-	_ = producer.PublishWithTenant(ctx, "test-topic", "test-key", timestamppb.Now())
+	// Missing tenant context should return an error wrapping ErrMissingTenantContext
+	err = producer.PublishWithTenant(ctx, "test-topic", "test-key", timestamppb.Now())
+	if err == nil {
+		t.Error("PublishWithTenant should return error for context without tenant")
+	}
+	if !errors.Is(err, tenant.ErrMissingTenantContext) {
+		t.Errorf("PublishWithTenant error = %v, want wrapped tenant.ErrMissingTenantContext", err)
+	}
 }

--- a/shared/platform/tenant/context.go
+++ b/shared/platform/tenant/context.go
@@ -27,6 +27,10 @@ func FromContext(ctx context.Context) (TenantID, bool) {
 // MustFromContext extracts the tenant ID from the context.
 // Panics if the tenant context is missing - this is a fail-fast strategy for
 // catching programming errors where tenant context propagation was not set up correctly.
+//
+// Deprecated: Use RequireFromContext in request handler paths (HTTP/gRPC) where
+// returning an error is preferable to panicking. MustFromContext is still appropriate
+// for init/startup code where a missing tenant context indicates a fatal configuration error.
 func MustFromContext(ctx context.Context) TenantID {
 	t, ok := FromContext(ctx)
 	if !ok {

--- a/shared/platform/tenant/tenant_test.go
+++ b/shared/platform/tenant/tenant_test.go
@@ -159,7 +159,7 @@ func TestMustFromContext_Success(t *testing.T) {
 	expected := tenant.MustNewTenantID("test_tenant")
 	ctx := tenant.WithTenant(context.Background(), expected)
 
-	got := tenant.MustFromContext(ctx)
+	got := tenant.MustFromContext(ctx) //nolint:staticcheck // intentionally testing deprecated function
 	if got != expected {
 		t.Errorf("MustFromContext returned %q, want %q", got, expected)
 	}
@@ -172,7 +172,7 @@ func TestMustFromContext_Panics(t *testing.T) {
 		}
 	}()
 
-	tenant.MustFromContext(context.Background())
+	tenant.MustFromContext(context.Background()) //nolint:staticcheck // intentionally testing deprecated function's panic behavior
 }
 
 func TestContextOverwrite(t *testing.T) {

--- a/tests/multi_tenant/isolation_test.go
+++ b/tests/multi_tenant/isolation_test.go
@@ -614,7 +614,7 @@ func TestMissingOrganizationContext(t *testing.T) {
 	t.Run("must_from_context_panics", func(t *testing.T) {
 		ctx := context.Background()
 		assert.Panics(t, func() {
-			_ = tenant.MustFromContext(ctx)
+			_ = tenant.MustFromContext(ctx) //nolint:staticcheck // intentionally testing deprecated function's panic behavior
 		}, "MustFromContext should panic when organization is missing")
 	})
 }


### PR DESCRIPTION
## Summary

- Replaces panic-based `MustFromContext()` with error-based `RequireFromContext()` in `ProtoProducer.PublishWithTenant`, the only request-path call site
- Adds deprecation comment to `MustFromContext` directing to `RequireFromContext` for handler paths
- Updates test from panic assertion to error assertion

## Audit Results

| Call Site | Path Type | Action |
|-----------|-----------|--------|
| `shared/platform/kafka/producer.go:248` | Request handler (Kafka publish) | Migrated to `RequireFromContext` |
| `tests/multi_tenant/isolation_test.go:617` | Test code (tests panic behavior) | Kept as-is |
| `shared/platform/tenant/tenant_test.go` | Unit test for `MustFromContext` | Kept as-is |

## Principle

Panic at boundaries (init/startup), return errors in operations (request handling).

## Test Plan

- [x] `go build ./shared/platform/kafka/... ./shared/platform/tenant/...` compiles
- [x] `go vet ./shared/platform/kafka/...` passes
- [x] `go test ./shared/platform/tenant/... -count=1` passes (all 15 tests)
- [x] Pre-commit hooks (gofumpt, golangci-lint) pass

Ref: codebase-health-audit.13