### PR TITLE
test: Improve saga framework test coverage to 81%+

### DIFF
--- a/shared/pkg/saga/composition_coverage_test.go
+++ b/shared/pkg/saga/composition_coverage_test.go
@@ -1,0 +1,158 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComposer_ExecuteWithComposition(t *testing.T) {
+	mockRegistry := &MockRegistry{
+		Sagas: map[string]*MockSagaDef{
+			"simple-saga": {
+				Name:           "simple-saga",
+				Script:         `result = "ok"`,
+				StepsCompleted: 2,
+			},
+		},
+	}
+
+	composer := NewComposer(mockRegistry, nil)
+	ctx := context.Background()
+
+	result, err := composer.ExecuteWithComposition(ctx, "simple-saga", nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, ResultStatusCompleted, result.Status)
+}
+
+func TestComposer_CompensateSaga(t *testing.T) {
+	mockRegistry := &MockRegistry{
+		Sagas: map[string]*MockSagaDef{},
+	}
+
+	composer := NewComposer(mockRegistry, nil)
+	ctx := context.Background()
+
+	err := composer.CompensateSaga(ctx, uuid.New())
+	require.NoError(t, err)
+}
+
+func TestCallStack_PopEmpty(t *testing.T) {
+	stack := NewCallStack()
+	entry := stack.Pop()
+	assert.Equal(t, CallEntry{}, entry, "popping empty stack should return zero value")
+}
+
+func TestCallStack_GetSagaNames(t *testing.T) {
+	stack := NewCallStack()
+	_ = stack.Push(CallEntry{SagaName: "saga-A", ExecutionID: uuid.New()})
+	_ = stack.Push(CallEntry{SagaName: "saga-B", ExecutionID: uuid.New()})
+
+	names := stack.GetSagaNames()
+	assert.Equal(t, []string{"saga-A", "saga-B"}, names)
+}
+
+func TestCompensationCascade_CompensateAll_ChildFails(t *testing.T) {
+	compensateErr := errors.New("compensation failed for child")
+	cascade := NewCompensationCascade()
+
+	// Record child with failing compensation
+	cascade.RecordChildSaga(&Result{
+		ExecutionID: uuid.New(),
+		Status:      ResultStatusCompleted,
+		CompensateFunc: func(_ context.Context) error {
+			return compensateErr
+		},
+	})
+
+	err := cascade.CompensateAll(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to compensate child saga")
+
+	// Status should show child not compensated
+	status := cascade.GetCompensationStatus()
+	require.Len(t, status, 1)
+	assert.False(t, status[0].ChildCompensated)
+}
+
+func TestCompensationCascade_CompensateAll_NilCompensateFunc(t *testing.T) {
+	cascade := NewCompensationCascade()
+
+	// Record child without compensation function
+	cascade.RecordChildSaga(&Result{
+		ExecutionID:    uuid.New(),
+		Status:         ResultStatusCompleted,
+		CompensateFunc: nil,
+	})
+
+	err := cascade.CompensateAll(context.Background())
+	require.NoError(t, err)
+
+	status := cascade.GetCompensationStatus()
+	require.Len(t, status, 1)
+	assert.True(t, status[0].ChildCompensated)
+}
+
+func TestCompensationCascade_CompensateWithParentStep_NoParent(t *testing.T) {
+	cascade := NewCompensationCascade()
+	// No parent compensation set, no children
+
+	err := cascade.CompensateWithParentStep(context.Background())
+	require.NoError(t, err)
+}
+
+func TestComposer_InvokeSaga_NilStack(t *testing.T) {
+	mockRegistry := &MockRegistry{
+		Sagas: map[string]*MockSagaDef{
+			"saga": {Name: "saga", Script: `result = "ok"`, StepsCompleted: 1},
+		},
+	}
+
+	composer := NewComposer(mockRegistry, nil)
+	ctx := context.Background()
+
+	// nil stack should work (no depth checking)
+	result, err := composer.InvokeSaga(ctx, "saga", nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, ResultStatusCompleted, result.Status)
+}
+
+func TestComposer_InvokeSaga_SagaNotFound(t *testing.T) {
+	mockRegistry := &MockRegistry{
+		Sagas: map[string]*MockSagaDef{},
+	}
+
+	composer := NewComposer(mockRegistry, nil)
+	ctx := context.Background()
+
+	_, err := composer.InvokeSaga(ctx, "nonexistent", nil, nil, NewCallStack())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to load saga")
+}
+
+func TestComposer_InvokeSaga_StepLimitExceeded(t *testing.T) {
+	mockRegistry := &MockRegistry{
+		Sagas: map[string]*MockSagaDef{
+			"large-saga": {
+				Name:           "large-saga",
+				Script:         `result = "ok"`,
+				StepsCompleted: 100,
+			},
+		},
+	}
+
+	composer := NewComposer(mockRegistry, nil)
+	ctx := context.Background()
+
+	stack := NewCallStack()
+	stack.SetMaxTotalSteps(10)
+
+	_, err := composer.InvokeSaga(ctx, "large-saga", nil, nil, stack)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMaxTotalStepsExceeded)
+}

--- a/shared/pkg/saga/decimal_coverage_test.go
+++ b/shared/pkg/saga/decimal_coverage_test.go
@@ -1,0 +1,121 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+func TestDecimalValue_Cmp(t *testing.T) {
+	t.Run("equal values return 0", func(t *testing.T) {
+		a, _ := NewDecimalValue("10.5")
+		b, _ := NewDecimalValue("10.5")
+		result, err := a.Cmp(b, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 0, result)
+	})
+
+	t.Run("less than returns -1", func(t *testing.T) {
+		a, _ := NewDecimalValue("5.0")
+		b, _ := NewDecimalValue("10.5")
+		result, err := a.Cmp(b, 0)
+		require.NoError(t, err)
+		assert.Equal(t, -1, result)
+	})
+
+	t.Run("greater than returns 1", func(t *testing.T) {
+		a, _ := NewDecimalValue("10.5")
+		b, _ := NewDecimalValue("5.0")
+		result, err := a.Cmp(b, 0)
+		require.NoError(t, err)
+		assert.Equal(t, 1, result)
+	})
+
+	t.Run("type mismatch returns error", func(t *testing.T) {
+		a, _ := NewDecimalValue("10.5")
+		_, err := a.Cmp(starlark.MakeInt(5), 0)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrDecimalTypeMismatch)
+	})
+}
+
+func TestDecimalValue_GetDecimal(t *testing.T) {
+	d, err := NewDecimalValue("123.45")
+	require.NoError(t, err)
+
+	dec := d.GetDecimal()
+	assert.Equal(t, "123.45", dec.String())
+}
+
+func TestDecimalValue_Binary_RightSide(t *testing.T) {
+	a, _ := NewDecimalValue("10")
+	b, _ := NewDecimalValue("3")
+
+	// Test subtraction from Right side: b - a
+	result, err := a.Binary(syntax.MINUS, b, starlark.Right)
+	require.NoError(t, err)
+	decResult := result.(*DecimalValue)
+	expected, _ := NewDecimalValue("-7")
+	assert.True(t, decResult.decimal.Equal(expected.decimal),
+		"expected -7, got %s", decResult.String())
+}
+
+func TestDecimalValue_Binary_DivisionRightSide(t *testing.T) {
+	a, _ := NewDecimalValue("2")
+	b, _ := NewDecimalValue("10")
+
+	// Right side division: b / a
+	result, err := a.Binary(syntax.SLASH, b, starlark.Right)
+	require.NoError(t, err)
+	decResult := result.(*DecimalValue)
+	expected, _ := NewDecimalValue("5")
+	assert.True(t, decResult.decimal.Equal(expected.decimal),
+		"expected 5, got %s", decResult.String())
+}
+
+func TestDecimalValue_Binary_DivisionByZeroRightSide(t *testing.T) {
+	zero, _ := NewDecimalValue("0")
+	b, _ := NewDecimalValue("10")
+
+	// Right side: b / zero, but a is the receiver with value 0
+	_, err := zero.Binary(syntax.SLASH, b, starlark.Right)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDivisionByZero)
+}
+
+func TestDecimalValue_Binary_UnsupportedOperator(t *testing.T) {
+	a, _ := NewDecimalValue("10")
+	b, _ := NewDecimalValue("3")
+
+	_, err := a.Binary(syntax.PERCENT, b, starlark.Left)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedDecimalOperation)
+}
+
+func TestDecimalValue_CompareSameType_UnsupportedOp(t *testing.T) {
+	a, _ := NewDecimalValue("10")
+	b, _ := NewDecimalValue("5")
+
+	// Use an unsupported token (e.g., IN)
+	_, err := a.CompareSameType(syntax.IN, b, 0)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedDecimalOperation)
+}
+
+func TestDecimalBuiltin_WrongArgCount(t *testing.T) {
+	builtin := DecimalBuiltin()
+	thread := &starlark.Thread{Name: "test"}
+
+	// No arguments
+	_, err := starlark.Call(thread, builtin, starlark.Tuple{}, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDecimalArgCount)
+
+	// Two arguments
+	_, err = starlark.Call(thread, builtin, starlark.Tuple{starlark.String("1"), starlark.String("2")}, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDecimalArgCount)
+}

--- a/shared/pkg/saga/events_coverage_test.go
+++ b/shared/pkg/saga/events_coverage_test.go
@@ -1,0 +1,48 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStepCompletedEvent_GetCorrelationID(t *testing.T) {
+	correlationID := uuid.New()
+	event := &StepCompletedEvent{
+		CorrelationID: correlationID,
+	}
+	assert.Equal(t, correlationID, event.GetCorrelationID())
+}
+
+func TestStepCompletedEvent_SagaID(t *testing.T) {
+	sagaID := uuid.New()
+	event := &StepCompletedEvent{
+		SagaInstanceID: sagaID,
+	}
+	assert.Equal(t, sagaID, event.SagaID())
+}
+
+func TestStepFailedEvent_GetCorrelationID(t *testing.T) {
+	correlationID := uuid.New()
+	event := &StepFailedEvent{
+		CorrelationID: correlationID,
+	}
+	assert.Equal(t, correlationID, event.GetCorrelationID())
+}
+
+func TestStepFailedEvent_SagaID(t *testing.T) {
+	sagaID := uuid.New()
+	event := &StepFailedEvent{
+		SagaInstanceID: sagaID,
+	}
+	assert.Equal(t, sagaID, event.SagaID())
+}
+
+func TestProgressEvent_GetCorrelationID(t *testing.T) {
+	correlationID := uuid.New()
+	event := &ProgressEvent{
+		CorrelationID: correlationID,
+	}
+	assert.Equal(t, correlationID, event.GetCorrelationID())
+}

--- a/shared/pkg/saga/executor_coverage_test.go
+++ b/shared/pkg/saga/executor_coverage_test.go
@@ -1,0 +1,138 @@
+package saga
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSagaExecutor_WithLogger(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	logger := slog.Default()
+	result := executor.WithLogger(logger)
+	assert.Same(t, executor, result, "WithLogger should return the same executor for chaining")
+	assert.Same(t, logger, executor.logger)
+}
+
+func TestSagaExecutor_ProcessStepResult_Success(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      3,
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	// Success case: err is nil
+	failureResult, err := executor.ProcessStepResult(
+		context.Background(),
+		instance,
+		0,
+		"test_step",
+		map[string]interface{}{"result": "ok"},
+		nil, // no error = success
+		5,
+	)
+
+	require.NoError(t, err)
+	assert.Nil(t, failureResult, "success should return nil failure result")
+
+	// Verify replay count was reset
+	updated, _ := instanceRepo.FindByID(context.Background(), sagaID)
+	assert.Equal(t, 0, updated.ReplayCount)
+}
+
+func TestSagaExecutor_ProcessStepResult_Failure(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      0,
+	}
+	instanceRepo.Add(instance)
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	// Failure case: err is non-nil FATAL error
+	failureResult, err := executor.ProcessStepResult(
+		context.Background(),
+		instance,
+		1,
+		"debit_account",
+		nil,
+		ErrInsufficientFunds,
+		5,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, failureResult)
+	assert.Equal(t, ErrorCategoryFatal, failureResult.ErrorCategory)
+	assert.Equal(t, FailureActionCompensate, failureResult.Action)
+}
+
+func TestSagaExecutor_HandleStepFailure_UpdateStatusError(t *testing.T) {
+	instanceRepo := NewMockSagaInstanceRepositoryForExecutor()
+	stepResultRepo := NewMockStepResultRepository()
+
+	sagaID := uuid.New()
+	instance := &SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		CorrelationID:    uuid.New(),
+		Status:           SagaStatusRunning,
+		ReplayCount:      0,
+	}
+	instanceRepo.Add(instance)
+	instanceRepo.updateStatusErr = errors.New("database connection lost")
+
+	executor := NewSagaExecutor(instanceRepo, stepResultRepo, nil, nil)
+
+	// FATAL error but UpdateStatusWithError fails
+	result, err := executor.HandleStepFailure(
+		context.Background(),
+		sagaID,
+		0,
+		"step",
+		ErrInsufficientFunds,
+		5,
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to transition saga to COMPENSATING")
+	assert.Nil(t, result)
+}
+
+func TestUpdateSagaError_NilError(t *testing.T) {
+	instance := &SagaInstance{
+		ID:     uuid.New(),
+		Status: SagaStatusRunning,
+	}
+
+	UpdateSagaError(instance, 2, nil, ErrorCategoryFatal)
+
+	assert.NotNil(t, instance.FailedStepIndex)
+	assert.Equal(t, 2, *instance.FailedStepIndex)
+	assert.Nil(t, instance.ErrorMessage, "nil error should not set error message")
+	assert.NotNil(t, instance.ErrorCategory)
+	assert.Equal(t, string(ErrorCategoryFatal), *instance.ErrorCategory)
+}

--- a/shared/pkg/saga/metrics_coverage_test.go
+++ b/shared/pkg/saga/metrics_coverage_test.go
@@ -1,0 +1,42 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Tests for previously uncovered metric recording functions.
+// These verify the functions don't panic and exercise the Prometheus counter paths.
+
+func TestRecordSuspend(t *testing.T) {
+	assert.NotPanics(t, func() {
+		RecordSuspend()
+	})
+}
+
+func TestRecordResume(t *testing.T) {
+	assert.NotPanics(t, func() {
+		RecordResume()
+	})
+}
+
+func TestRecordResumeIdempotent(t *testing.T) {
+	assert.NotPanics(t, func() {
+		RecordResumeIdempotent()
+	})
+}
+
+func TestRecordOrphanScanError(t *testing.T) {
+	assert.NotPanics(t, func() {
+		RecordOrphanScanError()
+	})
+}
+
+func TestRecordStepFailure_Placeholder(t *testing.T) {
+	// RecordStepFailure is a placeholder that currently does nothing.
+	// Verify it doesn't panic.
+	assert.NotPanics(t, func() {
+		RecordStepFailure("step_name", "FATAL")
+	})
+}

--- a/shared/pkg/saga/models_coverage_test.go
+++ b/shared/pkg/saga/models_coverage_test.go
@@ -1,0 +1,90 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidSagaStatuses_ReturnsAllStatuses(t *testing.T) {
+	statuses := ValidSagaStatuses()
+	require.Len(t, statuses, 9)
+
+	expected := []SagaStatus{
+		SagaStatusPending,
+		SagaStatusRunning,
+		SagaStatusWaitingForEvent,
+		SagaStatusCompleted,
+		SagaStatusCompensating,
+		SagaStatusCompensated,
+		SagaStatusFailed,
+		SagaStatusFailedManualIntervention,
+		SagaStatusSuspended,
+	}
+	assert.Equal(t, expected, statuses)
+}
+
+func TestIsValidSagaStatus(t *testing.T) {
+	t.Run("valid statuses return true", func(t *testing.T) {
+		for _, status := range ValidSagaStatuses() {
+			assert.True(t, IsValidSagaStatus(status), "expected %q to be valid", status)
+		}
+	})
+
+	t.Run("invalid statuses return false", func(t *testing.T) {
+		assert.False(t, IsValidSagaStatus(SagaStatus("INVALID")))
+		assert.False(t, IsValidSagaStatus(SagaStatus("")))
+		assert.False(t, IsValidSagaStatus(SagaStatus("running"))) // lowercase
+	})
+}
+
+func TestJSONB_Value_NilReturnsEmptyObject(t *testing.T) {
+	var j JSONB
+	val, err := j.Value()
+	require.NoError(t, err)
+	assert.Equal(t, []byte("{}"), val)
+}
+
+func TestJSONB_Value_NonNilMarshals(t *testing.T) {
+	j := JSONB{"key": "value", "num": float64(42)}
+	val, err := j.Value()
+	require.NoError(t, err)
+	assert.NotNil(t, val)
+}
+
+func TestJSONB_Scan_NilSetsNil(t *testing.T) {
+	j := JSONB{"existing": "data"}
+	err := j.Scan(nil)
+	require.NoError(t, err)
+	assert.Nil(t, j)
+}
+
+func TestJSONB_Scan_Bytes(t *testing.T) {
+	var j JSONB
+	err := j.Scan([]byte(`{"key":"value"}`))
+	require.NoError(t, err)
+	assert.Equal(t, "value", j["key"])
+}
+
+func TestJSONB_Scan_String(t *testing.T) {
+	var j JSONB
+	err := j.Scan(`{"key":"value"}`)
+	require.NoError(t, err)
+	assert.Equal(t, "value", j["key"])
+}
+
+func TestJSONB_Scan_UnsupportedType(t *testing.T) {
+	var j JSONB
+	err := j.Scan(42)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedJSONBType)
+}
+
+func TestSagaInstance_TableName(t *testing.T) {
+	assert.Equal(t, "saga_instances", SagaInstance{}.TableName())
+}
+
+func TestSagaStepResult_TableName(t *testing.T) {
+	assert.Equal(t, "saga_step_results", SagaStepResult{}.TableName())
+}

--- a/shared/pkg/saga/replay_coverage_test.go
+++ b/shared/pkg/saga/replay_coverage_test.go
@@ -1,0 +1,31 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrderedMarshalSlice(t *testing.T) {
+	t.Run("empty slice", func(t *testing.T) {
+		result := orderedMarshalSlice([]any{})
+		assert.Equal(t, "[]", string(result))
+	})
+
+	t.Run("single element", func(t *testing.T) {
+		result := orderedMarshalSlice([]any{"hello"})
+		assert.Equal(t, `["hello"]`, string(result))
+	})
+
+	t.Run("multiple elements", func(t *testing.T) {
+		result := orderedMarshalSlice([]any{"a", "b", "c"})
+		assert.Equal(t, `["a","b","c"]`, string(result))
+	})
+
+	t.Run("mixed types", func(t *testing.T) {
+		result := orderedMarshalSlice([]any{"hello", float64(42), true})
+		assert.Contains(t, string(result), `"hello"`)
+		assert.Contains(t, string(result), "42")
+		assert.Contains(t, string(result), "true")
+	})
+}

--- a/shared/pkg/saga/schema/schema_coverage_test.go
+++ b/shared/pkg/saga/schema/schema_coverage_test.go
@@ -1,0 +1,40 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry_HasHandler(t *testing.T) {
+	r := NewRegistry()
+
+	yamlData := []byte(`
+service: position_keeping
+version: "1.0"
+handlers:
+  position_keeping.initiate_log:
+    description: "Initiate a log entry"
+    params:
+      amount:
+        type: Decimal
+        required: true
+    returns:
+      log_id:
+        type: string
+        required: true
+`)
+
+	err := r.LoadFromYAML(yamlData)
+	require.NoError(t, err)
+
+	t.Run("existing handler returns true", func(t *testing.T) {
+		assert.True(t, r.HasHandler("position_keeping.initiate_log"))
+	})
+
+	t.Run("nonexistent handler returns false", func(t *testing.T) {
+		assert.False(t, r.HasHandler("position_keeping.nonexistent"))
+		assert.False(t, r.HasHandler("totally_unknown"))
+	})
+}

--- a/shared/pkg/saga/schema/service_modules_coverage_test.go
+++ b/shared/pkg/saga/schema/service_modules_coverage_test.go
@@ -1,0 +1,119 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+)
+
+func TestGoToStarlarkValue(t *testing.T) {
+	t.Run("nil returns None", func(t *testing.T) {
+		val, err := goToStarlarkValue(nil)
+		require.NoError(t, err)
+		assert.Equal(t, starlark.None, val)
+	})
+
+	t.Run("string", func(t *testing.T) {
+		val, err := goToStarlarkValue("hello")
+		require.NoError(t, err)
+		assert.Equal(t, starlark.String("hello"), val)
+	})
+
+	t.Run("int", func(t *testing.T) {
+		val, err := goToStarlarkValue(42)
+		require.NoError(t, err)
+		assert.Equal(t, starlark.MakeInt(42), val)
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		val, err := goToStarlarkValue(int64(100))
+		require.NoError(t, err)
+		assert.Equal(t, starlark.MakeInt64(100), val)
+	})
+
+	t.Run("int32", func(t *testing.T) {
+		val, err := goToStarlarkValue(int32(50))
+		require.NoError(t, err)
+		assert.Equal(t, starlark.MakeInt(50), val)
+	})
+
+	t.Run("uint32", func(t *testing.T) {
+		val, err := goToStarlarkValue(uint32(999))
+		require.NoError(t, err)
+		assert.Equal(t, starlark.MakeUint(999), val)
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		val, err := goToStarlarkValue(3.14)
+		require.NoError(t, err)
+		assert.Equal(t, starlark.Float(3.14), val)
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		val, err := goToStarlarkValue(true)
+		require.NoError(t, err)
+		assert.Equal(t, starlark.Bool(true), val)
+	})
+
+	t.Run("decimal", func(t *testing.T) {
+		d := decimal.NewFromFloat(123.45)
+		val, err := goToStarlarkValue(d)
+		require.NoError(t, err)
+		// Decimal is converted to string for lossless representation
+		assert.Equal(t, starlark.String(d.String()), val)
+	})
+
+	t.Run("unknown type falls back to string", func(t *testing.T) {
+		type custom struct{ X int }
+		val, err := goToStarlarkValue(custom{X: 42})
+		require.NoError(t, err)
+		assert.Equal(t, starlark.String("{42}"), val)
+	})
+}
+
+func TestGoSliceToStarlark(t *testing.T) {
+	t.Run("empty slice", func(t *testing.T) {
+		list, err := goSliceToStarlark([]any{})
+		require.NoError(t, err)
+		assert.Equal(t, 0, list.Len())
+	})
+
+	t.Run("mixed types", func(t *testing.T) {
+		list, err := goSliceToStarlark([]any{"hello", 42, true})
+		require.NoError(t, err)
+		assert.Equal(t, 3, list.Len())
+	})
+}
+
+func TestGoStringSliceToStarlark(t *testing.T) {
+	list := goStringSliceToStarlark([]string{"a", "b", "c"})
+	assert.Equal(t, 3, list.Len())
+
+	val := list.Index(0)
+	assert.Equal(t, starlark.String("a"), val)
+}
+
+func TestGoMapToStarlark(t *testing.T) {
+	t.Run("empty map", func(t *testing.T) {
+		dict, err := goMapToStarlark(map[string]any{})
+		require.NoError(t, err)
+		assert.Equal(t, 0, dict.Len())
+	})
+
+	t.Run("map with values", func(t *testing.T) {
+		dict, err := goMapToStarlark(map[string]any{
+			"key": "value",
+			"num": 42,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 2, dict.Len())
+
+		val, found, err := dict.Get(starlark.String("key"))
+		require.NoError(t, err)
+		assert.True(t, found)
+		assert.Equal(t, starlark.String("value"), val)
+	})
+}

--- a/shared/pkg/saga/starlark_values_test.go
+++ b/shared/pkg/saga/starlark_values_test.go
@@ -1,0 +1,179 @@
+package saga
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+)
+
+// Tests for sagaDefinitionValue Starlark interface methods.
+func TestSagaDefinitionValue(t *testing.T) {
+	v := &sagaDefinitionValue{name: "test-saga"}
+
+	t.Run("String", func(t *testing.T) {
+		assert.Equal(t, `saga("test-saga")`, v.String())
+	})
+
+	t.Run("Type", func(t *testing.T) {
+		assert.Equal(t, "SagaDefinition", v.Type())
+	})
+
+	t.Run("Freeze", func(t *testing.T) {
+		assert.False(t, v.frozen)
+		v.Freeze()
+		assert.True(t, v.frozen)
+	})
+
+	t.Run("Truth", func(t *testing.T) {
+		assert.Equal(t, starlark.True, v.Truth())
+	})
+
+	t.Run("Hash", func(t *testing.T) {
+		h, err := v.Hash()
+		require.NoError(t, err)
+		// Should match the hash of the name string
+		expectedHash, _ := starlark.String("test-saga").Hash()
+		assert.Equal(t, expectedHash, h)
+	})
+}
+
+// Tests for stepDefinitionValue Starlark interface methods.
+func TestStepDefinitionValue(t *testing.T) {
+	v := &stepDefinitionValue{name: "validate_balance"}
+
+	t.Run("String", func(t *testing.T) {
+		assert.Equal(t, `step("validate_balance")`, v.String())
+	})
+
+	t.Run("Type", func(t *testing.T) {
+		assert.Equal(t, "StepDefinition", v.Type())
+	})
+
+	t.Run("Freeze", func(t *testing.T) {
+		assert.False(t, v.frozen)
+		v.Freeze()
+		assert.True(t, v.frozen)
+	})
+
+	t.Run("Truth", func(t *testing.T) {
+		assert.Equal(t, starlark.True, v.Truth())
+	})
+
+	t.Run("Hash", func(t *testing.T) {
+		h, err := v.Hash()
+		require.NoError(t, err)
+		expectedHash, _ := starlark.String("validate_balance").Hash()
+		assert.Equal(t, expectedHash, h)
+	})
+}
+
+// Tests for postingValue Starlark interface methods.
+func TestPostingValue(t *testing.T) {
+	v := &postingValue{debit: "ACC001", credit: "ACC002", amount: "100.00"}
+
+	t.Run("String", func(t *testing.T) {
+		assert.Equal(t, `posting("ACC001", "ACC002", "100.00")`, v.String())
+	})
+
+	t.Run("Type", func(t *testing.T) {
+		assert.Equal(t, "Posting", v.Type())
+	})
+
+	t.Run("Freeze", func(t *testing.T) {
+		assert.False(t, v.frozen)
+		v.Freeze()
+		assert.True(t, v.frozen)
+	})
+
+	t.Run("Truth", func(t *testing.T) {
+		assert.Equal(t, starlark.True, v.Truth())
+	})
+
+	t.Run("Hash returns unhashable error", func(t *testing.T) {
+		_, err := v.Hash()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnhashable)
+	})
+}
+
+// Tests for sagaResultValue Starlark interface methods.
+func TestSagaResultValue(t *testing.T) {
+	execID := uuid.New()
+	output := starlark.NewDict(1)
+	_ = output.SetKey(starlark.String("key"), starlark.String("value"))
+
+	v := &sagaResultValue{
+		executionID:    execID,
+		status:         ResultStatusCompleted,
+		output:         output,
+		stepsCompleted: 3,
+	}
+
+	t.Run("String", func(t *testing.T) {
+		expected := fmt.Sprintf(`Result(execution_id=%q, status=%q)`, execID, ResultStatusCompleted)
+		assert.Equal(t, expected, v.String())
+	})
+
+	t.Run("Type", func(t *testing.T) {
+		assert.Equal(t, "Result", v.Type())
+	})
+
+	t.Run("Freeze", func(t *testing.T) {
+		assert.False(t, v.frozen)
+		v.Freeze()
+		assert.True(t, v.frozen)
+	})
+
+	t.Run("Truth is true for COMPLETED", func(t *testing.T) {
+		assert.Equal(t, starlark.True, v.Truth())
+	})
+
+	t.Run("Truth is false for FAILED", func(t *testing.T) {
+		failed := &sagaResultValue{status: ResultStatusFailed}
+		assert.Equal(t, starlark.False, failed.Truth())
+	})
+
+	t.Run("Hash returns unhashable error", func(t *testing.T) {
+		_, err := v.Hash()
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnhashable)
+	})
+
+	t.Run("Attr returns execution_id", func(t *testing.T) {
+		val, err := v.Attr("execution_id")
+		require.NoError(t, err)
+		assert.Equal(t, starlark.String(execID.String()), val)
+	})
+
+	t.Run("Attr returns status", func(t *testing.T) {
+		val, err := v.Attr("status")
+		require.NoError(t, err)
+		assert.Equal(t, starlark.String(ResultStatusCompleted), val)
+	})
+
+	t.Run("Attr returns output", func(t *testing.T) {
+		val, err := v.Attr("output")
+		require.NoError(t, err)
+		assert.Equal(t, output, val)
+	})
+
+	t.Run("Attr returns steps_completed", func(t *testing.T) {
+		val, err := v.Attr("steps_completed")
+		require.NoError(t, err)
+		assert.Equal(t, starlark.MakeInt(3), val)
+	})
+
+	t.Run("Attr returns error for unknown attribute", func(t *testing.T) {
+		_, err := v.Attr("nonexistent")
+		require.Error(t, err)
+	})
+
+	t.Run("AttrNames returns all attribute names", func(t *testing.T) {
+		names := v.AttrNames()
+		assert.Equal(t, []string{"execution_id", "status", "output", "steps_completed"}, names)
+	})
+}

--- a/shared/pkg/saga/suspend_coverage_test.go
+++ b/shared/pkg/saga/suspend_coverage_test.go
@@ -1,0 +1,55 @@
+package saga
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContainsIgnoreCase(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		substr string
+		want   bool
+	}{
+		{"exact match", "hello world", "hello", true},
+		{"case insensitive match", "Hello World", "hello", true},
+		{"case insensitive substr", "hello world", "WORLD", true},
+		{"no match", "hello world", "xyz", false},
+		{"empty substr matches", "hello", "", true},
+		{"empty string no match", "", "hello", false},
+		{"both empty", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := containsIgnoreCase(tt.s, tt.substr)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestIsDuplicateKeyError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"duplicate key", errors.New("duplicate key value violates unique constraint"), true},
+		{"unique constraint", errors.New("unique constraint violation on column id"), true},
+		{"postgres error code", errors.New("ERROR: 23505 duplicate key"), true},
+		{"unrelated error", errors.New("connection timeout"), false},
+		{"case insensitive duplicate key", errors.New("DUPLICATE KEY detected"), true},
+		{"case insensitive unique constraint", errors.New("UNIQUE CONSTRAINT violated"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isDuplicateKeyError(tt.err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}

--- a/shared/pkg/saga/uuid_generator_coverage_test.go
+++ b/shared/pkg/saga/uuid_generator_coverage_test.go
@@ -1,0 +1,24 @@
+package saga
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStepContext_CallIndex(t *testing.T) {
+	instanceID := uuid.New()
+	ctx := NewStepContext(instanceID, 3)
+
+	// Initially 0
+	assert.Equal(t, int32(0), ctx.CallIndex())
+
+	// Generate a UUID - call index should increment
+	_ = ctx.NewUUID()
+	assert.Equal(t, int32(1), ctx.CallIndex())
+
+	// Generate another
+	_ = ctx.NewUUID()
+	assert.Equal(t, int32(2), ctx.CallIndex())
+}

--- a/shared/pkg/saga/validation/mock_generator_coverage_test.go
+++ b/shared/pkg/saga/validation/mock_generator_coverage_test.go
@@ -1,0 +1,116 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateByType(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldName string
+		fieldDef  *schema.FieldDef
+		expected  any
+	}{
+		{
+			name:      "string type",
+			fieldName: "name",
+			fieldDef:  &schema.FieldDef{Type: schema.TypeString},
+			expected:  "mock_name",
+		},
+		{
+			name:      "decimal type",
+			fieldName: "amount",
+			fieldDef:  &schema.FieldDef{Type: schema.TypeDecimal},
+			expected:  decimal.NewFromFloat(100.00),
+		},
+		{
+			name:      "int32 type",
+			fieldName: "count",
+			fieldDef:  &schema.FieldDef{Type: schema.TypeInt32},
+			expected:  int32(1000),
+		},
+		{
+			name:      "int64 type",
+			fieldName: "count",
+			fieldDef:  &schema.FieldDef{Type: schema.TypeInt64},
+			expected:  int64(1000),
+		},
+		{
+			name:      "uint32 type",
+			fieldName: "count",
+			fieldDef:  &schema.FieldDef{Type: schema.TypeUint32},
+			expected:  uint32(1000),
+		},
+		{
+			name:      "bool type",
+			fieldName: "active",
+			fieldDef:  &schema.FieldDef{Type: schema.TypeBool},
+			expected:  true,
+		},
+		{
+			name:      "array type",
+			fieldName: "items",
+			fieldDef:  &schema.FieldDef{Type: schema.TypeArray},
+			expected:  []any{},
+		},
+		{
+			name:      "map type",
+			fieldName: "metadata",
+			fieldDef:  &schema.FieldDef{Type: schema.TypeMap},
+			expected:  map[string]any{},
+		},
+		{
+			name:      "uuid type",
+			fieldName: "id",
+			fieldDef:  &schema.FieldDef{Type: schema.TypeUUID},
+			expected:  uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		},
+		{
+			name:      "unknown type returns nil",
+			fieldName: "unknown",
+			fieldDef:  &schema.FieldDef{Type: "unknown_type"},
+			expected:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := generateByType(tt.fieldName, tt.fieldDef)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGenerateEnumValue(t *testing.T) {
+	t.Run("returns first value when values exist", func(t *testing.T) {
+		fieldDef := &schema.FieldDef{
+			Type:   schema.TypeEnum,
+			Values: []string{"ACTIVE", "INACTIVE", "SUSPENDED"},
+		}
+		result := generateEnumValue(fieldDef)
+		assert.Equal(t, "ACTIVE", result)
+	})
+
+	t.Run("returns UNKNOWN when no values", func(t *testing.T) {
+		fieldDef := &schema.FieldDef{
+			Type:   schema.TypeEnum,
+			Values: []string{},
+		}
+		result := generateEnumValue(fieldDef)
+		assert.Equal(t, "UNKNOWN", result)
+	})
+}
+
+func TestGenerateByType_EnumWithValues(t *testing.T) {
+	fieldDef := &schema.FieldDef{
+		Type:   schema.TypeEnum,
+		Values: []string{"CREDIT", "DEBIT"},
+	}
+	result := generateByType("direction", fieldDef)
+	assert.Equal(t, "CREDIT", result)
+}

--- a/shared/pkg/saga/withlogger_coverage_test.go
+++ b/shared/pkg/saga/withlogger_coverage_test.go
@@ -1,0 +1,49 @@
+package saga
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStarlarkSagaRunner_WithLogger(t *testing.T) {
+	runtime, err := NewRuntime(nil)
+	require.NoError(t, err)
+
+	registry := NewHandlerRegistry()
+	runner, err := NewStarlarkSagaRunner(StarlarkSagaRunnerConfig{
+		Runtime:  runtime,
+		Registry: registry,
+	})
+	require.NoError(t, err)
+
+	t.Run("sets logger", func(t *testing.T) {
+		logger := slog.Default()
+		result := runner.WithLogger(logger)
+		assert.NotNil(t, result)
+	})
+
+	t.Run("nil logger falls back to default", func(t *testing.T) {
+		result := runner.WithLogger(nil)
+		assert.NotNil(t, result)
+	})
+}
+
+func TestStepExecutor_WithLogger(t *testing.T) {
+	executor := NewStepExecutor(nil, nil)
+	logger := slog.Default()
+	result := executor.WithLogger(logger)
+	assert.Same(t, executor, result, "WithLogger should return same executor for chaining")
+}
+
+func TestTransactionalStepExecutor_WithEventPublisher(t *testing.T) {
+	executor := NewTransactionalStepExecutor(nil)
+	publisher := &MockEventPublisher{
+		PublishFunc: func(_ context.Context, _ Event) error { return nil },
+	}
+	result := executor.WithEventPublisher(publisher)
+	assert.Same(t, executor, result, "WithEventPublisher should return same executor for chaining")
+}


### PR DESCRIPTION
## Summary

- Add 14 targeted unit test files covering previously uncovered critical paths in `shared/pkg/saga/`, `shared/pkg/saga/schema/`, and `shared/pkg/saga/validation/`
- Focus on saga correctness: state machine transitions, compensation cascades, error classification, Starlark value interfaces, and schema validation

## Coverage Improvements

| Package | Before | After | Delta |
|---------|--------|-------|-------|
| `shared/pkg/saga` | 77.8% | 81.8% | +4.0% |
| `shared/pkg/saga/schema` | 77.6% | 83.9% | +6.3% |
| `shared/pkg/saga/validation` | 84.5% | 87.7% | +3.2% |

## Test Areas Covered

- **State validation**: `ValidSagaStatuses`, `IsValidSagaStatus`, JSONB serialization
- **Starlark value interfaces**: `sagaDefinitionValue`, `stepDefinitionValue`, `postingValue`, `sagaResultValue` (String, Type, Freeze, Truth, Hash, Attr)
- **SagaExecutor**: `ProcessStepResult` success/failure paths, `HandleStepFailure` with UpdateStatus errors, nil error handling
- **Composition**: `ExecuteWithComposition`, `CompensateSaga`, child failure cascades, nil compensation functions, step limit enforcement
- **Decimal operations**: `Cmp`, `GetDecimal`, right-side binary operations, unsupported operators
- **Events**: `GetCorrelationID` for all event types
- **Metrics**: Recording functions for suspend, resume, orphan scan
- **Suspend helpers**: `containsIgnoreCase`, `isDuplicateKeyError`
- **Schema**: `HasHandler`, Starlark value conversion helpers (`goToStarlarkValue`, `goSliceToStarlark`, `goStringSliceToStarlark`, `goMapToStarlark`)
- **Validation**: Mock generator type-specific generation, enum value generation
- **UUID generator**: `CallIndex` tracking
- **Builder patterns**: `WithLogger`, `WithEventPublisher`
- **Replay**: `orderedMarshalSlice` serialization

## Test Plan

- [x] All new tests pass locally
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)
- [x] No existing tests broken
- [ ] CI passes

## Reference

codebase-health-audit.15