### PR TITLE
docs: Add saga validation guide and validation failure runbook

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -12,6 +12,9 @@ This directory contains how-to guides and usage documentation for Meridian devel
 | [Testcontainers Usage](testcontainers-usage.md) | PostgreSQL testcontainers for integration testing |
 | [Financial Accounting Proto](financial-accounting-proto.md) | Protocol buffer schemas for Financial Accounting service |
 | [Coupling Analysis](coupling-analysis.md) | Analyzing service coupling using dependency graphs |
+| [Saga Validation](saga-validation.md) | Automatic validation workflow, error interpretation, and troubleshooting |
+| [Starlark Style Guide](starlark-style-guide.md) | Writing conventions and syntax for Starlark saga scripts |
+| [Starlark Built-ins Reference](starlark-built-ins-reference.md) | Available functions, types, and DSL built-ins |
 
 ## Documentation Organization
 

--- a/docs/guides/saga-validation.md
+++ b/docs/guides/saga-validation.md
@@ -1,0 +1,308 @@
+# Saga Validation Guide
+
+Starlark saga scripts are automatically validated before deployment using
+auto-generated mocks from `handlers.yaml`. This catches the majority of runtime
+errors at upload time with zero tenant effort.
+
+## Overview
+
+Meridian validates saga scripts at multiple levels:
+
+| Layer | What It Catches | When It Runs |
+|-------|----------------|--------------|
+| **Static validation** | Syntax errors, blocked functions, loop nesting depth, script size | Script parse time |
+| **Semantic linting** | Decimal arithmetic outside CEL, magic numbers, missing pre-checks, hardcoded codes | Draft upload |
+| **Dry-run execution** | Undefined handlers, type mismatches, runtime failures, timeouts | Activation / CLI |
+| **Reference validation** | Missing instruments, accounts, sagas, handler parameters | Service-level validation |
+| **Visibility validation** | Party scope violations, unauthorized lookups | Pre-flight check |
+
+## What Validation Catches
+
+### Static Validation
+
+Runs at parse time before any execution. Enforces security constraints:
+
+- **Syntax errors**: Starlark parse failures (e.g., using `is` instead of `==`)
+- **Blocked functions**: `load`, `exec`, `compile`, `open`, `eval`, `__import__`, `setattr`, `delattr`
+- **Excessive loop nesting**: Maximum 3 levels of nested loops
+- **Script too large**: Maximum 64KB script size
+
+### Semantic Linting
+
+AST-based analysis that catches common mistakes:
+
+| Issue | Severity | Description |
+|-------|----------|-------------|
+| Decimal arithmetic | Warning | Decimal math should use CEL expressions |
+| Magic numbers | Warning | Hardcoded numeric literals |
+| Nested conditionals | Warning | Deep if/else nesting |
+| Hardcoded codes | Error | Hardcoded instrument or account codes |
+| Missing pre-check | Error | External handler call without `verify_external_state` |
+
+**Warning** severity allows activation but is reported. **Error** severity blocks activation.
+
+### Dry-Run Execution
+
+Executes the script with mock handlers generated from `handlers.yaml`:
+
+- **Undefined handlers**: Typos or wrong module names (category: `UNDEFINED_HANDLER`)
+- **Type mismatches**: Wrong parameter types (category: `TYPE_MISMATCH`)
+- **Runtime errors**: Script calls `fail()` or raises an exception (category: `RUNTIME`)
+- **Timeouts**: Execution exceeds 5 seconds (category: `TIMEOUT`)
+
+### Complexity Metrics
+
+Every validation produces complexity metrics:
+
+| Metric | Description | Formula |
+|--------|-------------|---------|
+| Handler Call Count | Number of service handler calls | Direct count from execution |
+| Operation Count | Starlark operations (loops, conditionals, assignments) | AST analysis |
+| Complexity Score | 0-10 scale | `min(10, HandlerCallCount / 2)` |
+| Estimated Duration | Projected execution time | `HandlerCallCount * 10ms` |
+
+## Usage
+
+### CLI (Local Testing)
+
+Validate a script before deployment:
+
+```bash
+# Validate with human-readable output
+meridian-cli saga validate withdrawal.star
+
+# JSON output for CI/CD pipelines
+meridian-cli saga validate --json deposit.star
+
+# Custom handlers.yaml path
+meridian-cli saga validate --handlers /path/to/handlers.yaml transfer.star
+```
+
+Exit codes:
+
+- `0` - Script is valid
+- `1` - Validation failed
+
+The CLI automatically loads `shared/pkg/saga/schema/handlers.yaml` when run
+from the repository root. Use `--handlers` to specify an alternative schema file.
+
+**Example output (success):**
+
+```text
+Validation Result: PASS
+
+Complexity Metrics:
+  Handler Calls:    6
+  Operations:       24
+  Complexity Score: 3/10
+  Est. Duration:    60ms
+
+No errors found.
+```
+
+**Example output (failure):**
+
+```text
+Validation Result: FAIL
+
+Errors:
+  [UNDEFINED_HANDLER] line 15: handler "position_keeping.initiate_logg" not found
+    Did you mean: position_keeping.initiate_log?
+
+  [TYPE_MISMATCH] line 22: parameter "amount" expects Decimal, got string
+
+2 error(s) found.
+```
+
+### gRPC API
+
+#### ValidateSaga (Dry-Run)
+
+Validates a script without deployment:
+
+```bash
+grpcurl -d '{
+  "saga_name": "withdrawal",
+  "script": "withdrawal_saga = saga(name=\"current_account_withdrawal\")\n...",
+  "version": "1.0.0"
+}' localhost:9090 meridian.saga.v1.SagaRegistry/ValidateSaga
+```
+
+Response includes `success`, `errors[]`, `metrics`, and `formatted_report`.
+
+#### ValidateSagaDraft
+
+Validates an existing draft saga by ID:
+
+```bash
+grpcurl -d '{
+  "id": "550e8400-e29b-41d4-a716-446655440000"
+}' localhost:9090 meridian.saga.v1.SagaRegistry/ValidateSagaDraft
+```
+
+Returns `ValidationResult` with status (`READY`, `WARNINGS`, `BLOCKED`), warnings, and critical errors.
+
+#### ActivateSaga
+
+Transitions a draft to active, running full validation including semantic linting:
+
+```bash
+grpcurl -d '{
+  "id": "550e8400-e29b-41d4-a716-446655440000"
+}' localhost:9090 meridian.saga.v1.SagaRegistry/ActivateSaga
+```
+
+Activation fails if the script has any errors or blocking lint issues.
+
+### Validation Levels
+
+| Level | Function | Use Case |
+|-------|----------|----------|
+| `ValidateSagaScript()` | Basic syntax + security | Quick parse check |
+| `ValidateDraft()` | Full validation, warnings allowed | Draft upload |
+| `ValidateActivation()` | Strict, errors block activation | Production deployment |
+| `DryRunValidator.Validate()` | Mock execution with metrics | CLI and API |
+
+## Security Constraints
+
+The Starlark runtime enforces strict security boundaries:
+
+| Constraint | Value | Rationale |
+|------------|-------|-----------|
+| Max script size | 64 KB | Prevent resource exhaustion |
+| Max loop nesting | 3 levels | Bound computational complexity |
+| Execution timeout | 5 seconds | Prevent runaway scripts |
+| Memory warning | 10 MB | Early detection of memory issues |
+| Max steps | 1,000,000 | Hard limit on Starlark operations |
+| `while` loops | Forbidden | Guarantees termination |
+| Recursion | Forbidden | Prevents stack overflow |
+| `load()` / imports | Blocked | Sandboxed execution |
+
+## Capacity Planning
+
+Use complexity metrics for capacity estimation:
+
+**Formula**: `Expected RPS * Avg Handler Calls * 10ms = Required concurrency`
+
+**Example**: If average complexity is 5 handler calls and expected RPS is 100:
+
+- Load: 100 RPS *5 handlers* 10ms = 5,000 ms/s
+- Required: 5 concurrent workers minimum
+
+## Monitoring
+
+### Prometheus Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `saga_validation_total` | Counter | `saga_name`, `status` | Validation count (success/failed) |
+| `saga_validation_errors_total` | Counter | `saga_name`, `error_category` | Errors by category |
+| `saga_complexity_score` | Histogram | `saga_name` | Complexity distribution (0-10) |
+| `saga_handler_call_count` | Histogram | `saga_name` | Handler calls per validation |
+
+**Error categories for `saga_validation_errors_total`:**
+
+- `SYNTAX` - Parse failures
+- `UNDEFINED_HANDLER` - Unknown handler references
+- `TYPE_MISMATCH` - Wrong parameter types
+- `RUNTIME` - Script execution errors
+- `TIMEOUT` - Execution exceeded 5s
+
+### Useful PromQL Queries
+
+```promql
+# Validation failure rate (last 1h)
+rate(saga_validation_total{status="failed"}[1h])
+  / rate(saga_validation_total[1h])
+
+# Most common error categories
+topk(5, sum by (error_category) (
+  rate(saga_validation_errors_total[1h])
+))
+
+# Average complexity by saga
+avg by (saga_name) (saga_complexity_score)
+
+# Sagas with high handler call counts (potential performance concern)
+histogram_quantile(0.95, rate(saga_handler_call_count[1h]))
+```
+
+## Troubleshooting
+
+### Validation passes but script fails in production
+
+Validation uses mock handlers. Real handlers may fail due to:
+
+- Database constraints (insufficient balance, account frozen)
+- External API failures (gateway timeouts, rate limiting)
+- Business rule violations (amount limits, duplicate transactions)
+
+Validation catches syntax and type errors, not business logic failures.
+For production issues, see the
+[Saga Failure Recovery Runbook](../runbooks/saga-failure-recovery.md).
+
+### How do I see available handlers?
+
+Check the schema file directly:
+
+```bash
+cat shared/pkg/saga/schema/handlers.yaml
+```
+
+Or use the CLI (when available):
+
+```bash
+meridian-cli saga list-handlers
+```
+
+Available service modules: `position_keeping`, `financial_accounting`,
+`current_account`, `valuation_engine`, `repository`, `notification`,
+`payment_order`.
+
+### Validation timeout (5 seconds exceeded)
+
+Causes:
+
+- Too many handler calls (reduce operations or simplify loops)
+- Complex conditional logic creating many execution paths
+- Iterating over large collections
+
+**Fix**: Reduce handler calls or simplify the script. Check the complexity
+score -- scripts scoring above 7 should be reviewed for simplification.
+
+### "Undefined handler" but I'm sure it exists
+
+1. Verify the handler name matches `handlers.yaml` exactly (case-sensitive, snake_case)
+2. Check you're using `module.handler()` format (e.g., `position_keeping.initiate_log`)
+3. If using the CLI with `--handlers`, verify the path is correct
+
+### "Blocked function" error
+
+The following functions are blocked for security:
+
+```text
+load, exec, compile, open, eval, __import__, setattr, delattr
+```
+
+These prevent module loading, code execution, and file system access.
+Saga scripts must use only built-in functions and registered service modules.
+
+### Semantic lint blocking activation
+
+If activation is blocked by a lint error:
+
+- `LintIssueTypeHardcodedCode`: Replace hardcoded instrument/account codes
+  with `resolve_instrument()` or `resolve_account()`
+- `LintIssueTypeMissingPreCheck`: Add `verify_external_state()` before
+  external handler calls
+
+Lint warnings (non-blocking) are informational and reported but do not prevent activation.
+
+## Related Resources
+
+- [Starlark Style Guide](starlark-style-guide.md) - Writing conventions for saga scripts
+- [Starlark Built-ins Reference](starlark-built-ins-reference.md) - Available functions and types
+- [Saga Failure Recovery Runbook](../runbooks/saga-failure-recovery.md) - Production incident response
+- [Saga Validation Failure Runbook](../runbooks/saga-validation-failure.md) - Validation-specific incident response
+- Handler schema: `shared/pkg/saga/schema/handlers.yaml`
+- Proto definition: `api/proto/meridian/saga/v1/saga_registry.proto`

--- a/docs/guides/starlark-style-guide.md
+++ b/docs/guides/starlark-style-guide.md
@@ -857,8 +857,54 @@ Before committing a Starlark saga script:
 
 ---
 
+## Validation
+
+All saga scripts are validated before deployment. Run validation locally to catch errors early:
+
+```bash
+# Validate before committing
+meridian-cli saga validate my_saga.star
+
+# JSON output for CI integration
+meridian-cli saga validate --json my_saga.star
+```
+
+### What Validation Catches
+
+```python
+# SYNTAX - Parse errors caught immediately
+if value is not None:  # "got is, want ':'" error
+    process(value)
+
+# UNDEFINED_HANDLER - Unknown handler references
+result = position_keeping.initiate_logg(...)  # Typo: "logg" vs "log"
+
+# TYPE_MISMATCH - Wrong parameter types
+position_keeping.initiate_log(
+    amount="100.50",  # Should be Decimal("100.50")
+)
+
+# RUNTIME - Script logic errors
+fail("Amount must be positive")  # Caught during dry-run
+```
+
+### Passing Validation
+
+Scripts that follow this style guide will pass validation. The key rules:
+
+1. Use `==` / `!=` instead of `is` / `is not`
+2. Use `Decimal()` for all monetary amounts
+3. Only call handlers defined in `handlers.yaml`
+4. Match parameter types to the schema exactly
+5. Keep complexity score below 7 (check with `--json` output)
+
+For detailed validation documentation, see the [Saga Validation Guide](saga-validation.md).
+
+---
+
 ## Further Reading
 
+- **[Saga Validation Guide](saga-validation.md)** - Validation workflow, error interpretation, and monitoring
 - **[Saga Handlers Schema](../saga-handlers.schema.json)** - Available service modules and handlers
 - **[Saga Service Catalog](../saga-service-catalog.md)** - Service module documentation
 - **[ADR-0028: Starlark Saga & CEL Valuation](../adr/0028-starlark-saga-cel-valuation.md)** - Architecture decision

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -19,6 +19,8 @@ scenarios.
   restoration, and business continuity
 - **[saga-failure-recovery.md](saga-failure-recovery.md)** - Recovering from failed saga executions,
   compensation, and rollback
+- **[saga-validation-failure.md](saga-validation-failure.md)** - Responding to saga validation failures
+  in upload, activation, and CI pipelines
 
 ### Operations & Troubleshooting
 

--- a/docs/runbooks/saga-validation-failure.md
+++ b/docs/runbooks/saga-validation-failure.md
@@ -1,0 +1,261 @@
+---
+name: saga-validation-failure
+description: Incident response procedures for saga validation failures in upload, activation, and CI pipelines
+triggers:
+  - Spike in saga_validation_errors_total metric
+  - Tenant reports unable to upload or activate a saga script
+  - CI pipeline fails on saga validation step
+  - saga_validation_total{status="failed"} rate increase
+instructions: |
+  Classify the validation error category. Use the error message and line number
+  to identify the root cause. Follow the resolution steps for each category.
+  Escalate if the issue is in the platform validation code, not the tenant script.
+---
+
+# Saga Validation Failure Runbook
+
+**When to use this runbook**: Saga validation failures are reported through
+metrics, tenant support requests, or CI pipeline failures.
+
+## Quick Reference
+
+| Error Category | Typical Cause | Recovery Time | Escalation |
+|---------------|---------------|---------------|------------|
+| **SYNTAX** | Script parse error | Immediate | None - tenant fixes script |
+| **UNDEFINED_HANDLER** | Typo in handler name | Immediate | None - check handlers.yaml |
+| **TYPE_MISMATCH** | Wrong parameter type | Immediate | None - check schema |
+| **RUNTIME** | Script calls fail() | Minutes | None - review script logic |
+| **TIMEOUT** | Script too complex | Minutes | Platform team if under 5s |
+
+## 1. Triage
+
+### Check validation metrics
+
+```promql
+# Failure rate (last 15 minutes)
+rate(saga_validation_total{status="failed"}[15m])
+
+# Errors by category
+sum by (error_category) (
+  rate(saga_validation_errors_total[15m])
+)
+
+# Affected sagas
+topk(10, sum by (saga_name) (
+  rate(saga_validation_errors_total[15m])
+))
+```
+
+### Classify the failure
+
+**Single tenant, single saga**: Likely a script issue. Proceed to section 2.
+
+**Multiple tenants, same error category**: Possible platform issue. Proceed to section 3.
+
+**All validations failing**: Platform service issue. Proceed to section 4.
+
+## 2. Script-Level Failures (Single Tenant)
+
+### SYNTAX errors
+
+**Symptoms**: `saga_validation_errors_total{error_category="SYNTAX"}` increasing for one saga.
+
+**Common causes**:
+
+- Using `is` / `is not` instead of `==` / `!=` (most common)
+- Using `while` loops (forbidden in Starlark)
+- Using `import` statements
+- Missing colons, brackets, or indentation
+
+**Resolution**:
+
+1. Ask the tenant for their script or retrieve from the saga registry
+2. Run local validation: `meridian-cli saga validate <script.star>`
+3. The error message includes line and column numbers
+4. Direct the tenant to the [Starlark Style Guide](../guides/starlark-style-guide.md)
+
+### UNDEFINED_HANDLER errors
+
+**Symptoms**: `saga_validation_errors_total{error_category="UNDEFINED_HANDLER"}` for specific saga.
+
+**Resolution**:
+
+1. Check the error message for the handler name and suggestion
+2. Verify the handler exists in `shared/pkg/saga/schema/handlers.yaml`
+3. Common issues:
+   - Typo in module or handler name (`initiate_logg` vs `initiate_log`)
+   - Wrong module prefix (`pos_keeping` vs `position_keeping`)
+   - Handler removed in a schema update
+
+### TYPE_MISMATCH errors
+
+**Symptoms**: `saga_validation_errors_total{error_category="TYPE_MISMATCH"}` for specific saga.
+
+**Resolution**:
+
+1. Check the error message for the parameter name and expected type
+2. Verify parameter types against `handlers.yaml` schema
+3. Common issues:
+   - Passing string instead of `Decimal` for amount fields
+   - Passing integer instead of string for IDs
+   - Wrong enum values for direction fields
+
+### RUNTIME errors
+
+**Symptoms**: `saga_validation_errors_total{error_category="RUNTIME"}` for specific saga.
+
+**Resolution**:
+
+1. Check if the script explicitly calls `fail()` during validation
+2. Review the script logic for conditions that trigger failure with mock data
+3. Mock handlers return default values - ensure the script handles them
+
+### TIMEOUT errors
+
+**Symptoms**: `saga_validation_errors_total{error_category="TIMEOUT"}` for specific saga.
+
+**Resolution**:
+
+1. Check the saga's complexity metrics: `saga_complexity_score{saga_name="<name>"}`
+2. If handler call count is high (>20), suggest script simplification
+3. If the script has deeply nested loops (up to 3 levels), suggest flattening
+4. The timeout is 5 seconds - most scripts complete in under 100ms
+
+## 3. Platform-Level Failures (Multiple Tenants)
+
+### Schema registry issue
+
+**Symptoms**: Multiple tenants getting UNDEFINED_HANDLER for previously valid handlers.
+
+**Check**:
+
+```bash
+# Verify handlers.yaml is intact
+cat shared/pkg/saga/schema/handlers.yaml | head -20
+
+# Check schema loading in service logs
+kubectl logs -l app=reference-data -n meridian --tail=100 | grep -i "schema\|handler"
+```
+
+**Resolution**:
+
+1. Verify `handlers.yaml` hasn't been modified incorrectly
+2. Check if a deployment changed the schema
+3. Roll back the schema change if needed
+
+### Mock registry generation failure
+
+**Symptoms**: All validations failing with internal errors (not categorized).
+
+**Check**:
+
+```bash
+kubectl logs -l app=reference-data -n meridian --tail=100 | grep -i "mock\|registry\|validation"
+```
+
+**Resolution**:
+
+1. Check if the mock registry generates successfully from the current schema
+2. Verify the schema format is valid YAML
+3. Check for new handler parameter types that the mock generator doesn't support
+
+## 4. Service-Level Failures (All Validations)
+
+### Validation service unavailable
+
+**Symptoms**: gRPC errors on ValidateSaga / ValidateSagaDraft endpoints.
+
+**Check**:
+
+```bash
+# Check pod status
+kubectl get pods -l app=reference-data -n meridian
+
+# Check service health
+grpcurl -plaintext localhost:9090 grpc.health.v1.Health/Check
+
+# Check recent events
+kubectl get events -n meridian --sort-by='.lastTimestamp' | head -20
+```
+
+**Resolution**:
+
+1. If pods are crashing, check logs for OOM or panic
+2. If pods are healthy but endpoints fail, check gRPC routing
+3. Restart the service: `kubectl rollout restart deployment/reference-data -n meridian`
+
+### Runtime initialization failure
+
+**Symptoms**: Validation returns internal errors mentioning "runtime" or "timeout".
+
+**Check**:
+
+```bash
+kubectl logs -l app=reference-data -n meridian --tail=100 | grep -i "runtime\|starlark"
+```
+
+**Resolution**:
+
+1. The Starlark runtime is created per validation request
+2. Check for resource exhaustion (CPU, memory) on the node
+3. Check if the 5-second timeout is appropriate for the workload
+
+## 5. CI Pipeline Failures
+
+### Validation step fails in CI
+
+**Symptoms**: CI job fails on `meridian-cli saga validate` step.
+
+**Check**:
+
+1. Review CI logs for the specific validation error
+2. Verify `handlers.yaml` is available in the CI environment
+3. Check if the script was modified in the PR
+
+**Resolution**:
+
+1. Fix the script based on the error message
+2. If using `--handlers`, verify the path is correct in CI
+3. Run validation locally first: `meridian-cli saga validate --json <script.star>`
+
+## 6. Prevention
+
+### Pre-deployment checklist
+
+- [ ] Run `meridian-cli saga validate` locally before pushing
+- [ ] Check complexity score is below 7
+- [ ] Verify all handler names exist in `handlers.yaml`
+- [ ] Review semantic lint warnings even if not blocking
+
+### Monitoring alerts
+
+Recommended alert rules:
+
+```yaml
+# High validation failure rate
+- alert: SagaValidationFailureRateHigh
+  expr: |
+    rate(saga_validation_total{status="failed"}[15m])
+    / rate(saga_validation_total[15m]) > 0.5
+  for: 10m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Saga validation failure rate above 50%"
+
+# Unexpected error category spike
+- alert: SagaValidationErrorSpike
+  expr: |
+    rate(saga_validation_errors_total[5m]) > 10
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Spike in saga validation errors"
+```
+
+## Related Resources
+
+- [Saga Validation Guide](../guides/saga-validation.md) - Usage documentation
+- [Saga Failure Recovery Runbook](saga-failure-recovery.md) - Production saga execution failures
+- [Starlark Style Guide](../guides/starlark-style-guide.md) - Script writing conventions


### PR DESCRIPTION
## Summary

- Add `docs/guides/saga-validation.md` covering the full validation pipeline: static
  validation, semantic linting, dry-run execution, reference validation, and visibility checks
- Add `docs/runbooks/saga-validation-failure.md` with incident response procedures for each
  error category (SYNTAX, UNDEFINED_HANDLER, TYPE_MISMATCH, RUNTIME, TIMEOUT)
- Update `docs/guides/starlark-style-guide.md` with a validation examples section
- Update guides and runbooks README indexes

## Changes Made

| File | Change |
|------|--------|
| `docs/guides/saga-validation.md` | New comprehensive guide |
| `docs/runbooks/saga-validation-failure.md` | New incident response runbook |
| `docs/guides/starlark-style-guide.md` | Added validation section |
| `docs/guides/README.md` | Added index entries |
| `docs/runbooks/README.md` | Added index entry |

## Task Master

saga-script-versioning.33 - Documentation and runbook for validation

## Test Plan

- [ ] All markdown lint checks pass (verified locally)
- [ ] Links to related docs are valid
- [ ] Code examples match actual CLI flags and API endpoints
- [ ] Prometheus metric names match source code
- [ ] Runbook follows existing runbook format conventions