### PR TITLE
feat: Atomic valuation in InitiateLien with price lock

### DIFF
--- a/api/proto/meridian/current_account/v1/current_account.proto
+++ b/api/proto/meridian/current_account/v1/current_account.proto
@@ -301,6 +301,15 @@ message Lien {
   // For Phase 1, this is stored for future bucket-aware position tracking.
   // Empty string represents the default bucket.
   string bucket_id = 8 [(buf.validate.field).string = {max_len: 255}];
+
+  // reserved_quantity is the original input amount before valuation (e.g., 100 kWh).
+  // Only present for multi-asset liens that went through atomic valuation.
+  meridian.quantity.v1.InstrumentAmount reserved_quantity = 9;
+
+  // valued_amount is the price-locked valuation result in the account's native instrument.
+  // This is the amount actually reserved against the account balance (e.g., 35.00 GBP).
+  // Only present for multi-asset liens that went through atomic valuation.
+  meridian.quantity.v1.InstrumentAmount valued_amount = 10;
 }
 
 // Request to initiate a new current account
@@ -633,6 +642,9 @@ message RetrieveCurrentAccountResponse {
 
 // Request to initiate a lien (reserve funds) on an account
 // BQ: Initiate - Creates a new fund reservation
+// Supports both legacy MoneyAmount (currency-only) and multi-asset InstrumentAmount.
+// When input (InstrumentAmount) is provided, atomic valuation is performed using
+// the account's valuation features to produce a valued_amount (price lock).
 message InitiateLienRequest {
   // account_id is the account to place the lien on
   string account_id = 1 [(buf.validate.field).string = {
@@ -641,8 +653,10 @@ message InitiateLienRequest {
     pattern: "^[a-zA-Z0-9_-]+$"
   }];
 
-  // amount is the amount to reserve
-  meridian.common.v1.MoneyAmount amount = 2 [(buf.validate.field).required = true];
+  // amount is the amount to reserve (legacy, currency-only).
+  // Use this for same-currency liens (e.g., GBP lien on GBP account).
+  // Mutually exclusive with input - if both provided, input takes precedence.
+  meridian.common.v1.MoneyAmount amount = 2;
 
   // payment_order_reference identifies the Payment Order creating this lien
   // Forward slash allowed for hierarchical Payment Order references
@@ -659,6 +673,16 @@ message InitiateLienRequest {
   // For Phase 1, this is optional - if not provided, defaults to empty string (default bucket).
   // Future phases will support CEL expressions to compute bucket_id from transaction attributes.
   string bucket_id = 5 [(buf.validate.field).string = {max_len: 255}];
+
+  // input is the multi-asset amount to reserve (e.g., 100 kWh, 50 USD).
+  // When provided, atomic valuation is performed: the input instrument is converted
+  // to the account's native instrument using the configured ValuationFeature.
+  // The resulting valued_amount becomes the price lock for this lien.
+  meridian.quantity.v1.InstrumentAmount input = 6;
+
+  // knowledge_at is the point-in-time for bi-temporal data resolution (optional, defaults to now).
+  // Controls which valuation feature and market data are used for the price lock.
+  google.protobuf.Timestamp knowledge_at = 7;
 }
 
 // Response for initiating a lien
@@ -668,6 +692,15 @@ message InitiateLienResponse {
 
   // available_balance is the updated available balance after reservation
   meridian.common.v1.MoneyAmount available_balance = 2 [(buf.validate.field).required = true];
+
+  // valued_amount is the price-locked valuation result in the account's native instrument.
+  // Only present when the request used InstrumentAmount input (multi-asset valuation).
+  // For same-currency liens (legacy MoneyAmount), this field is not set.
+  meridian.quantity.v1.InstrumentAmount valued_amount = 3;
+
+  // basis provides full transparency into the valuation computation.
+  // Only present when atomic valuation was performed (input field was provided).
+  ValuationAnalysis basis = 4;
 }
 
 // Request to execute a lien (convert reservation to actual debit)

--- a/services/current-account/adapters/persistence/lien_entity.go
+++ b/services/current-account/adapters/persistence/lien_entity.go
@@ -1,10 +1,17 @@
 package persistence
 
 import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
 )
+
+// ErrUnsupportedJSONBType is returned when Scan receives an unexpected type.
+var ErrUnsupportedJSONBType = errors.New("unsupported type for JSONBMap")
 
 // LienEntity represents the database persistence model for liens
 // Optimized for database concerns: audit fields, indexes, constraints
@@ -35,10 +42,48 @@ type LienEntity struct {
 	// Optional expiration time for automatic termination of stale liens
 	ExpiresAt *time.Time `gorm:"index:idx_lien_expires_at"`
 
+	// Valuation fields for atomic price lock (nullable for backward compatibility)
+	// ReservedQuantity stores the original input before valuation (e.g., 100 kWh)
+	ReservedQuantity JSONBMap `gorm:"column:reserved_quantity;type:jsonb"`
+	// ValuedAmount stores the price-locked valuation result (e.g., 35.00 GBP)
+	ValuedAmount JSONBMap `gorm:"column:valued_amount;type:jsonb"`
+	// ValuationAnalysis stores the full valuation audit trail
+	ValuationAnalysis JSONBMap `gorm:"column:valuation_analysis;type:jsonb"`
+
 	// Audit fields
 	CreatedAt time.Time `gorm:"not null"`
 	UpdatedAt time.Time `gorm:"not null"`
 	Version   int       `gorm:"not null;default:1"`
+}
+
+// JSONBMap represents a JSONB column that can be null.
+// It implements the driver.Valuer and sql.Scanner interfaces for GORM.
+type JSONBMap json.RawMessage
+
+// Value implements driver.Valuer for database writes.
+// Returns nil for SQL NULL per driver.Valuer contract.
+func (j JSONBMap) Value() (driver.Value, error) {
+	if j == nil {
+		return nil, nil //nolint:nilnil // driver.Valuer requires nil,nil for SQL NULL
+	}
+	return []byte(j), nil
+}
+
+// Scan implements sql.Scanner for database reads.
+func (j *JSONBMap) Scan(value interface{}) error {
+	if value == nil {
+		*j = nil
+		return nil
+	}
+	switch v := value.(type) {
+	case []byte:
+		*j = JSONBMap(v)
+	case string:
+		*j = JSONBMap(v)
+	default:
+		return fmt.Errorf("%w: %T", ErrUnsupportedJSONBType, value)
+	}
+	return nil
 }
 
 // TableName overrides the default table name.

--- a/services/current-account/adapters/persistence/lien_repository.go
+++ b/services/current-account/adapters/persistence/lien_repository.go
@@ -382,18 +382,20 @@ func toLienDomain(entity *LienEntity) (*domain.Lien, error) {
 		UpdatedAt:             entity.UpdatedAt,
 	}
 
-	// Unmarshal valuation fields from JSONB (nil-safe)
+	// Unmarshal valuation fields from JSONB (nil-safe, fail-fast on corruption)
 	if entity.ReservedQuantity != nil {
 		var rq domain.InstrumentAmount
-		if err := json.Unmarshal(entity.ReservedQuantity, &rq); err == nil {
-			lien.ReservedQuantity = &rq
+		if err := json.Unmarshal(entity.ReservedQuantity, &rq); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal reserved_quantity: %w", err)
 		}
+		lien.ReservedQuantity = &rq
 	}
 	if entity.ValuedAmount != nil {
 		var va domain.InstrumentAmount
-		if err := json.Unmarshal(entity.ValuedAmount, &va); err == nil {
-			lien.ValuedAmount = &va
+		if err := json.Unmarshal(entity.ValuedAmount, &va); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal valued_amount: %w", err)
 		}
+		lien.ValuedAmount = &va
 	}
 	if entity.ValuationAnalysis != nil {
 		lien.ValuationAnalysis = json.RawMessage(entity.ValuationAnalysis)

--- a/services/current-account/adapters/persistence/lien_repository.go
+++ b/services/current-account/adapters/persistence/lien_repository.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -327,7 +328,7 @@ func (r *LienRepository) SumActiveAmountByAccountIDAndBucket(ctx context.Context
 func toLienEntity(lien *domain.Lien) *LienEntity {
 	// ToMinorUnitsUnchecked is safe here: domain layer validates amounts before persistence,
 	// so overflow (>92 quadrillion cents) cannot occur for valid liens
-	return &LienEntity{
+	entity := &LienEntity{
 		ID:                    lien.ID,
 		AccountID:             lien.AccountID,
 		AmountCents:           lien.Amount.ToMinorUnitsUnchecked(),
@@ -341,6 +342,23 @@ func toLienEntity(lien *domain.Lien) *LienEntity {
 		UpdatedAt:             lien.UpdatedAt,
 		Version:               lien.Version,
 	}
+
+	// Marshal valuation fields to JSONB (nil-safe)
+	if lien.ReservedQuantity != nil {
+		if data, err := json.Marshal(lien.ReservedQuantity); err == nil {
+			entity.ReservedQuantity = JSONBMap(data)
+		}
+	}
+	if lien.ValuedAmount != nil {
+		if data, err := json.Marshal(lien.ValuedAmount); err == nil {
+			entity.ValuedAmount = JSONBMap(data)
+		}
+	}
+	if lien.ValuationAnalysis != nil {
+		entity.ValuationAnalysis = JSONBMap(lien.ValuationAnalysis)
+	}
+
+	return entity
 }
 
 // toLienDomain converts database entity to domain model
@@ -350,7 +368,7 @@ func toLienDomain(entity *LienEntity) (*domain.Lien, error) {
 		return nil, fmt.Errorf("failed to create lien amount from database: %w", err)
 	}
 
-	return &domain.Lien{
+	lien := &domain.Lien{
 		ID:                    entity.ID,
 		AccountID:             entity.AccountID,
 		Amount:                amount,
@@ -362,5 +380,24 @@ func toLienDomain(entity *LienEntity) (*domain.Lien, error) {
 		Version:               entity.Version,
 		CreatedAt:             entity.CreatedAt,
 		UpdatedAt:             entity.UpdatedAt,
-	}, nil
+	}
+
+	// Unmarshal valuation fields from JSONB (nil-safe)
+	if entity.ReservedQuantity != nil {
+		var rq domain.InstrumentAmount
+		if err := json.Unmarshal(entity.ReservedQuantity, &rq); err == nil {
+			lien.ReservedQuantity = &rq
+		}
+	}
+	if entity.ValuedAmount != nil {
+		var va domain.InstrumentAmount
+		if err := json.Unmarshal(entity.ValuedAmount, &va); err == nil {
+			lien.ValuedAmount = &va
+		}
+	}
+	if entity.ValuationAnalysis != nil {
+		lien.ValuationAnalysis = json.RawMessage(entity.ValuationAnalysis)
+	}
+
+	return lien, nil
 }

--- a/services/current-account/adapters/persistence/lien_repository_test.go
+++ b/services/current-account/adapters/persistence/lien_repository_test.go
@@ -43,6 +43,9 @@ func setupLienTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		payment_order_reference VARCHAR(255) NOT NULL UNIQUE,
 		termination_reason TEXT,
 		expires_at TIMESTAMP WITH TIME ZONE,
+		reserved_quantity JSONB,
+		valued_amount JSONB,
+		valuation_analysis JSONB,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		version INT NOT NULL DEFAULT 1
@@ -666,7 +669,10 @@ func setupMultiTenantLienTestDB(t *testing.T, tenantIDs ...string) (*gorm.DB, ma
 			expires_at TIMESTAMP WITH TIME ZONE,
 			created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 			updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
-			version INT NOT NULL DEFAULT 1
+			version INT NOT NULL DEFAULT 1,
+			reserved_quantity JSONB,
+			valued_amount JSONB,
+			valuation_analysis JSONB
 		)`, pq.QuoteIdentifier(schemaName))).Error
 		require.NoError(t, err)
 

--- a/services/current-account/domain/lien.go
+++ b/services/current-account/domain/lien.go
@@ -1,10 +1,12 @@
 package domain
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 )
 
 // Lien domain errors
@@ -14,7 +16,19 @@ var (
 	ErrLienExpired           = errors.New("lien has expired")
 	ErrInvalidLienAmount     = errors.New("lien amount must be positive")
 	ErrLienAlreadyExists     = errors.New("lien already exists for this idempotency key")
+	ErrValuedAmountImmutable = errors.New("valued_amount cannot be modified on an active lien")
 )
+
+// InstrumentAmount represents a quantity of a specific instrument for domain-level valuation tracking.
+type InstrumentAmount struct {
+	Amount         decimal.Decimal `json:"amount"`
+	InstrumentCode string          `json:"instrument_code"`
+}
+
+// IsZero returns true if the instrument amount has not been set.
+func (ia InstrumentAmount) IsZero() bool {
+	return ia.Amount.IsZero() && ia.InstrumentCode == ""
+}
 
 // LienStatus represents the lifecycle state of a lien
 type LienStatus string
@@ -45,6 +59,16 @@ type Lien struct {
 	Version               int
 	CreatedAt             time.Time
 	UpdatedAt             time.Time
+	// ReservedQuantity stores the original input before valuation (e.g., 100 kWh).
+	// Only set for multi-asset liens that went through atomic valuation.
+	ReservedQuantity *InstrumentAmount
+	// ValuedAmount stores the price-locked valuation result in the account's native instrument.
+	// This is the amount actually reserved against the account balance (e.g., 35.00 GBP).
+	// IMMUTABLE once the lien is ACTIVE - cannot be modified to prevent Ghost Pricing.
+	ValuedAmount *InstrumentAmount
+	// ValuationAnalysis stores the full audit trail of the valuation computation as JSON.
+	// Contains method_id, version, applied_rates, observation_ids, etc.
+	ValuationAnalysis json.RawMessage
 }
 
 // NewLien creates a new lien in ACTIVE status.
@@ -68,6 +92,35 @@ func NewLien(accountID uuid.UUID, amount Money, bucketID string, paymentOrderRef
 		CreatedAt:             now,
 		UpdatedAt:             now,
 	}, nil
+}
+
+// NewValuedLien creates a new lien in ACTIVE status with atomic valuation data (price lock).
+// The reservedQuantity is the original input (e.g., 100 kWh), valuedAmount is the
+// price-locked conversion (e.g., 35.00 GBP), and analysisJSON is the full audit trail.
+// The lien's Amount is set to the valued amount (the actual reservation against balance).
+func NewValuedLien(
+	accountID uuid.UUID,
+	amount Money,
+	bucketID string,
+	paymentOrderReference string,
+	expiresAt *time.Time,
+	reservedQuantity *InstrumentAmount,
+	valuedAmount *InstrumentAmount,
+	analysisJSON json.RawMessage,
+) (*Lien, error) {
+	lien, err := NewLien(accountID, amount, bucketID, paymentOrderReference, expiresAt)
+	if err != nil {
+		return nil, err
+	}
+	lien.ReservedQuantity = reservedQuantity
+	lien.ValuedAmount = valuedAmount
+	lien.ValuationAnalysis = analysisJSON
+	return lien, nil
+}
+
+// HasValuation returns true if this lien was created through atomic valuation.
+func (l *Lien) HasValuation() bool {
+	return l.ValuedAmount != nil && !l.ValuedAmount.IsZero()
 }
 
 // Execute transitions the lien to EXECUTED status (terminal state)

--- a/services/current-account/domain/lien.go
+++ b/services/current-account/domain/lien.go
@@ -11,12 +11,13 @@ import (
 
 // Lien domain errors
 var (
-	ErrLienNotActive         = errors.New("lien is not in active status")
-	ErrInvalidLienTransition = errors.New("invalid lien status transition")
-	ErrLienExpired           = errors.New("lien has expired")
-	ErrInvalidLienAmount     = errors.New("lien amount must be positive")
-	ErrLienAlreadyExists     = errors.New("lien already exists for this idempotency key")
-	ErrValuedAmountImmutable = errors.New("valued_amount cannot be modified on an active lien")
+	ErrLienNotActive           = errors.New("lien is not in active status")
+	ErrInvalidLienTransition   = errors.New("invalid lien status transition")
+	ErrLienExpired             = errors.New("lien has expired")
+	ErrInvalidLienAmount       = errors.New("lien amount must be positive")
+	ErrLienAlreadyExists       = errors.New("lien already exists for this idempotency key")
+	ErrValuedAmountImmutable   = errors.New("valued_amount cannot be modified on an active lien")
+	ErrInvalidInstrumentAmount = errors.New("instrument amount must be positive with instrument code")
 )
 
 // InstrumentAmount represents a quantity of a specific instrument for domain-level valuation tracking.
@@ -108,6 +109,12 @@ func NewValuedLien(
 	valuedAmount *InstrumentAmount,
 	analysisJSON json.RawMessage,
 ) (*Lien, error) {
+	if reservedQuantity == nil || reservedQuantity.InstrumentCode == "" || reservedQuantity.Amount.Sign() <= 0 {
+		return nil, ErrInvalidInstrumentAmount
+	}
+	if valuedAmount == nil || valuedAmount.InstrumentCode == "" || valuedAmount.Amount.Sign() <= 0 {
+		return nil, ErrInvalidInstrumentAmount
+	}
 	lien, err := NewLien(accountID, amount, bucketID, paymentOrderReference, expiresAt)
 	if err != nil {
 		return nil, err

--- a/services/current-account/migrations/20260206000003_add_lien_valuation_fields.sql
+++ b/services/current-account/migrations/20260206000003_add_lien_valuation_fields.sql
@@ -1,0 +1,7 @@
+-- Add valuation fields to lien table for atomic price lock support.
+-- These columns are nullable for backward compatibility: existing liens created
+-- before valuation engine integration will have NULL values.
+
+ALTER TABLE lien ADD COLUMN IF NOT EXISTS reserved_quantity JSONB;
+ALTER TABLE lien ADD COLUMN IF NOT EXISTS valued_amount JSONB;
+ALTER TABLE lien ADD COLUMN IF NOT EXISTS valuation_analysis JSONB;

--- a/services/current-account/migrations/atlas.sum
+++ b/services/current-account/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:7upMlkevtJhGO6v6OALfxux7UNzUm+dTeIWXpHFx6d8=
+h1:XmsUK+pRaDBuSytzOcbJc1rw/9F/xohBkw+UKJFQlkY=
 20251216000001_initial.sql h1:nyRf35O3eYNJqShAvOEhvliXKLIR6e/V8B9JhOHde9w=
 20251216000002_audit_system.sql h1:X/0ZHt9cGTYmFbUUvKAkBgEiGw9fYEqfnbMB8I4SCR8=
 20251217000001_fix_audit_status_constraint.sql h1:yQxsHxbUp5g+ehkKFjOhZs59SbfaQIPw4/sA2xE2rwU=
@@ -10,3 +10,4 @@ h1:7upMlkevtJhGO6v6OALfxux7UNzUm+dTeIWXpHFx6d8=
 20260204000001_create_event_outbox.sql h1:I/qe9fY9RaojTVqgSP0Rjou7yOT3GBaFh0oenOxf7h4=
 20260206000001_create_valuation_features.sql h1:afkwAHh/DQwXK6yxkI6/mIM2gHxCtl0We8tLryTkuBM=
 20260206000002_backfill_identity_valuation_features.sql h1:wIVobmzXhvXQxrVmLobT9q7j/Tjq7gkCu409B5893Ug=
+20260206000003_add_lien_valuation_fields.sql h1:j1n+Fi0GhHa8oLPrl4NRB0TkdeCpS8hE7y3PB2SIhWg=

--- a/services/current-account/service/account_control_integration_test.go
+++ b/services/current-account/service/account_control_integration_test.go
@@ -68,13 +68,17 @@ func setupControlTestDB(t *testing.T) (*persistence.Repository, *persistence.Lie
 		account_id UUID NOT NULL,
 		amount_cents BIGINT NOT NULL,
 		currency VARCHAR(3) NOT NULL,
+		bucket_id VARCHAR(255) NOT NULL DEFAULT '',
 		status VARCHAR(20) NOT NULL,
 		payment_order_reference VARCHAR(255) NOT NULL UNIQUE,
 		termination_reason TEXT,
 		expires_at TIMESTAMP WITH TIME ZONE,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
-		version BIGINT NOT NULL DEFAULT 1
+		version BIGINT NOT NULL DEFAULT 1,
+		reserved_quantity JSONB,
+		valued_amount JSONB,
+		valuation_analysis JSONB
 	)`
 	testdb.CreateTable(t, tc.DB, tc.Tenant, lienDDL)
 

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -12,6 +12,7 @@ import (
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
@@ -21,6 +22,7 @@ import (
 	"github.com/shopspring/decimal"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
@@ -78,7 +80,11 @@ const (
 	opStatusUpdateFailed          = "update_failed"
 )
 
-// InitiateLien creates a fund reservation on an account
+// InitiateLien creates a fund reservation on an account.
+// Supports two modes:
+//  1. Legacy (MoneyAmount): Same-currency lien, no valuation needed.
+//  2. Multi-asset (InstrumentAmount input): Atomic valuation using valuateInternal(),
+//     producing a price-locked valued_amount and full audit trail.
 func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest) (*pb.InitiateLienResponse, error) {
 	start := time.Now()
 	operationStatus := operationStatusSuccess
@@ -100,11 +106,70 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		return idempotentResp, nil
 	}
 
-	// Convert and validate amount first (before transaction)
-	lienAmount, err := s.protoToMoney(req.Amount)
-	if err != nil {
-		operationStatus = opStatusInvalidAmount
-		return nil, status.Errorf(codes.InvalidArgument, "invalid amount: %v", err)
+	// Determine mode: multi-asset (input) or legacy (amount)
+	useValuation := req.Input != nil && req.Input.Amount != "" && req.Input.InstrumentCode != ""
+
+	var lienAmount domain.Money
+	var valuationResult *valuateInternalResult
+
+	if useValuation {
+		// Multi-asset mode: parse input and run atomic valuation
+		inputAmount, err := decimal.NewFromString(req.Input.Amount)
+		if err != nil {
+			operationStatus = opStatusInvalidInputAmount
+			return nil, status.Errorf(codes.InvalidArgument, "invalid input amount: %v", err)
+		}
+		if !inputAmount.IsPositive() {
+			operationStatus = opStatusInputAmountNonPositive
+			return nil, status.Error(codes.InvalidArgument, "input amount must be positive")
+		}
+
+		knowledgeAt := time.Now()
+		if req.KnowledgeAt != nil {
+			knowledgeAt = req.KnowledgeAt.AsTime()
+		}
+
+		// Run shared valuation function (same logic as EvaluateAssetValuation - Ghost Pricing prevention)
+		valuationResult, err = s.valuateInternal(ctx, req.AccountId, inputAmount, req.Input.InstrumentCode, knowledgeAt)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrValuationAccountNotFound):
+				operationStatus = opStatusAccountNotFound
+				return nil, status.Errorf(codes.NotFound, "%v", err)
+			case errors.Is(err, ErrNoActiveValuationFeature):
+				operationStatus = opStatusNoValuationFeature
+				return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+			case errors.Is(err, ErrValuationFeatureNotActive):
+				operationStatus = opStatusFeatureNotActive
+				return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+			case errors.Is(err, ErrValuationRepoNotConfigured):
+				operationStatus = opStatusValuationFeatureRepoNil
+				return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+			case errors.Is(err, ErrValuationEngineFailed):
+				operationStatus = opStatusValuationFailed
+				return nil, status.Errorf(codes.Internal, "%v", err)
+			default:
+				operationStatus = opStatusValuationFailed
+				return nil, status.Errorf(codes.Internal, "valuation failed: %v", err)
+			}
+		}
+
+		// Convert valued output to domain Money for lien amount (the actual reservation)
+		// The valued amount is in the account's native instrument (currency)
+		valuedCents := valuationResult.OutputAmount.Mul(decimal.NewFromInt(100)).RoundBank(0)
+		lienAmount, err = domain.NewMoney(valuationResult.OutputCode, valuedCents.IntPart())
+		if err != nil {
+			operationStatus = opStatusInvalidAmount
+			return nil, status.Errorf(codes.Internal, "failed to create valued amount: %v", err)
+		}
+	} else {
+		// Legacy mode: convert and validate MoneyAmount
+		var err error
+		lienAmount, err = s.protoToMoney(req.Amount)
+		if err != nil {
+			operationStatus = opStatusInvalidAmount
+			return nil, status.Errorf(codes.InvalidArgument, "invalid amount: %v", err)
+		}
 	}
 
 	if !lienAmount.IsPositive() {
@@ -114,15 +179,6 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 
 	// Prefetch account and balance from Position Keeping BEFORE entering transaction
 	// to avoid holding database locks during external service calls (deadlock prevention).
-	// We'll re-validate sufficient funds inside the transaction with fresh lien totals.
-	//
-	// RACE WINDOW NOTE: There's a small window between prefetch and transaction lock where
-	// the balance could change. However, this is acceptable because:
-	// 1. Position Keeping's ExecuteDebit operation will atomically verify and debit funds
-	// 2. Liens are reservations - actual fund movement happens only on ExecuteLien
-	// 3. The alternative (external calls inside transaction) risks deadlocks
-	// 4. False rejections are recoverable (retry), false acceptances fail at execution time
-	// Verify account exists before prefetching balance from Position Keeping
 	if _, err := s.repo.FindByID(ctx, req.AccountId); err != nil {
 		if errors.Is(err, persistence.ErrAccountNotFound) {
 			operationStatus = opStatusAccountNotFound
@@ -132,14 +188,8 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		return nil, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
 	}
 
-	// Get bucket_id from request (may be empty for non-bucket-scoped liens)
 	bucketID := req.BucketId
 
-	// Prefetch balance from Position Keeping.
-	// Note: Currently Position Keeping returns total balance regardless of bucket.
-	// Bucket-aware balance tracking will be added in future iterations when Position Keeping
-	// supports bucket-scoped balance queries. For now, we validate against total balance
-	// but scope lien reservations to buckets.
 	prefetchedBalanceCents, err := s.getAccountBalanceCents(ctx, req.AccountId)
 	if err != nil {
 		operationStatus = opStatusRetrieveFailed
@@ -151,8 +201,6 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 	}
 
 	// Use a transaction with pessimistic locking to prevent race conditions.
-	// Without FOR UPDATE, concurrent InitiateLien calls could both check available
-	// balance, see sufficient funds, and both create liens - resulting in over-reservation.
 	var lien *domain.Lien
 	var account *domain.CurrentAccount
 	var availableBalance int64
@@ -161,7 +209,6 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		txRepo := s.repo.WithTx(tx)
 		txLienRepo := s.lienRepo.WithTx(tx)
 
-		// Retrieve account with FOR UPDATE lock to prevent concurrent modifications
 		var txErr error
 		accountResult, txErr := txRepo.FindByIDForUpdate(ctx, req.AccountId)
 		if txErr != nil {
@@ -169,7 +216,6 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		}
 		account = &accountResult
 
-		// Validate account is active
 		if account.Status() != domain.AccountStatusActive {
 			return errTxAccountNotActive
 		}
@@ -179,10 +225,7 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 			return errTxCurrencyMismatch
 		}
 
-		// Calculate available balance using pre-fetched balance (no external call inside tx).
-		// When bucket_id is provided, sum only liens scoped to that bucket for solvency validation.
-		// This ensures liens within a bucket don't exceed the bucket's share of funds, providing
-		// partial isolation even though Position Keeping doesn't yet support bucket-scoped balances.
+		// Calculate available balance
 		var activeLiensTotal int64
 		if bucketID != "" {
 			activeLiensTotal, err = txLienRepo.SumActiveAmountByAccountIDAndBucket(ctx, account.ID(), bucketID)
@@ -193,11 +236,8 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 			return fmt.Errorf("%w: %v", errTxSumLiensFailed, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
-		// Available = Pre-fetched Balance - Active Liens (scoped to bucket if bucket_id provided)
-		// Balance was fetched from Position Keeping before entering transaction.
 		availableBalance = prefetchedBalanceCents - activeLiensTotal
 
-		// Check sufficient funds
 		lienCents, err := lienAmount.ToMinorUnits()
 		if err != nil {
 			return fmt.Errorf("%w: %v", errTxDomainError, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
@@ -206,14 +246,26 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 			return errTxInsufficientFunds
 		}
 
-		// Create lien domain object with bucket awareness
-		// bucket_id was extracted from request before entering transaction
-		lien, err = domain.NewLien(account.ID(), lienAmount, bucketID, req.PaymentOrderReference, nil)
+		// Create lien domain object
+		if useValuation {
+			// Multi-asset: create valued lien with price lock
+			reservedQty := &domain.InstrumentAmount{
+				Amount:         decimal.RequireFromString(req.Input.Amount),
+				InstrumentCode: req.Input.InstrumentCode,
+			}
+			valuedAmt := &domain.InstrumentAmount{
+				Amount:         valuationResult.OutputAmount,
+				InstrumentCode: valuationResult.OutputCode,
+			}
+			analysisJSONB, _ := protojson.Marshal(valuationResult.Analysis) //nolint:errcheck // best-effort serialization for audit trail
+			lien, err = domain.NewValuedLien(account.ID(), lienAmount, bucketID, req.PaymentOrderReference, nil, reservedQty, valuedAmt, analysisJSONB)
+		} else {
+			lien, err = domain.NewLien(account.ID(), lienAmount, bucketID, req.PaymentOrderReference, nil)
+		}
 		if err != nil {
 			return fmt.Errorf("%w: %v", errTxDomainError, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
 
-		// Persist lien (within the transaction)
 		if err := txLienRepo.Create(ctx, lien); err != nil {
 			return fmt.Errorf("%w: %v", errTxSaveLien, err) //nolint:errorlint // second error is context-only to preserve errors.Is() for sentinel
 		}
@@ -221,7 +273,6 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		return nil
 	})
 
-	// Handle transaction errors with appropriate status codes
 	if txErr != nil {
 		switch {
 		case errors.Is(txErr, persistence.ErrAccountNotFound):
@@ -252,21 +303,32 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		"lien_id", lien.ID.String(),
 		"account_id", account.AccountID(),
 		"amount_cents", safeMinorUnits(lienAmount),
+		"has_valuation", lien.HasValuation(),
 		"payment_order_ref", req.PaymentOrderReference)
 
 	// Calculate new available balance after this lien
-	// ToMinorUnitsUnchecked is safe here: amount was validated in transaction above (line 151)
 	newAvailableBalance := availableBalance - lienAmount.ToMinorUnitsUnchecked()
 	availableMoney, err := domain.NewMoney(string(account.Balance().Currency()), newAvailableBalance)
 	if err != nil {
-		// This should never happen if validation passed - log and return without available balance
 		s.logger.Error("failed to create available balance money", "error", err)
 	}
 
-	return &pb.InitiateLienResponse{
+	resp := &pb.InitiateLienResponse{
 		Lien:             toLienProto(lien),
 		AvailableBalance: toMoneyAmount(availableMoney),
-	}, nil
+	}
+
+	// Add valuation fields to response when atomic valuation was performed
+	if useValuation && valuationResult != nil {
+		resp.ValuedAmount = &quantityv1.InstrumentAmount{
+			Amount:         valuationResult.OutputAmount.String(),
+			InstrumentCode: valuationResult.OutputCode,
+			Version:        1,
+		}
+		resp.Basis = valuationResult.Analysis
+	}
+
+	return resp, nil
 }
 
 // ExecuteLien converts a reservation to an actual debit atomically with Redis idempotency
@@ -771,7 +833,7 @@ func (s *Service) protoToMoney(amount *commonpb.MoneyAmount) (domain.Money, erro
 
 // toLienProto converts a domain Lien to proto Lien
 func toLienProto(lien *domain.Lien) *pb.Lien {
-	return &pb.Lien{
+	pbLien := &pb.Lien{
 		LienId:                lien.ID.String(),
 		AccountId:             lien.AccountID.String(),
 		Amount:                toMoneyAmount(lien.Amount),
@@ -781,6 +843,24 @@ func toLienProto(lien *domain.Lien) *pb.Lien {
 		UpdatedAt:             timestamppb.New(lien.UpdatedAt),
 		BucketId:              lien.BucketID,
 	}
+
+	// Add valuation fields if present
+	if lien.ReservedQuantity != nil && !lien.ReservedQuantity.IsZero() {
+		pbLien.ReservedQuantity = &quantityv1.InstrumentAmount{
+			Amount:         lien.ReservedQuantity.Amount.String(),
+			InstrumentCode: lien.ReservedQuantity.InstrumentCode,
+			Version:        1,
+		}
+	}
+	if lien.ValuedAmount != nil && !lien.ValuedAmount.IsZero() {
+		pbLien.ValuedAmount = &quantityv1.InstrumentAmount{
+			Amount:         lien.ValuedAmount.Amount.String(),
+			InstrumentCode: lien.ValuedAmount.InstrumentCode,
+			Version:        1,
+		}
+	}
+
+	return pbLien
 }
 
 // mapLienStatusToProto maps domain LienStatus to proto LienStatus
@@ -856,10 +936,32 @@ func (s *Service) checkLienIdempotency(ctx context.Context, paymentOrderRef stri
 	}
 	// Calculate available balance scoped to the lien's bucket (if any)
 	availableMoney := s.calculateAvailableBalanceByBucket(ctx, existingLien.AccountID, existingLien.BucketID, account.Balance())
-	return &pb.InitiateLienResponse{
+	resp := &pb.InitiateLienResponse{
 		Lien:             toLienProto(existingLien),
 		AvailableBalance: toMoneyAmount(availableMoney),
-	}, true, nil
+	}
+
+	// Reconstruct valuation fields for price lock preservation on idempotent retry
+	if existingLien.HasValuation() {
+		if existingLien.ValuedAmount != nil {
+			resp.ValuedAmount = &quantityv1.InstrumentAmount{
+				Amount:         existingLien.ValuedAmount.Amount.String(),
+				InstrumentCode: existingLien.ValuedAmount.InstrumentCode,
+				Version:        1,
+			}
+		}
+		if existingLien.ValuationAnalysis != nil {
+			var analysis pb.ValuationAnalysis
+			if err := protojson.Unmarshal(existingLien.ValuationAnalysis, &analysis); err == nil {
+				resp.Basis = &analysis
+			} else {
+				s.logger.Warn("failed to unmarshal valuation analysis for idempotent response",
+					"lien_id", existingLien.ID.String(), "error", err)
+			}
+		}
+	}
+
+	return resp, true, nil
 }
 
 // hydrateAccountWithBalance returns a new CurrentAccount with balance populated from Position Keeping.

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -157,6 +157,12 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		// Convert valued output to domain Money for lien amount (the actual reservation)
 		// The valued amount is in the account's native instrument (currency)
 		valuedCents := valuationResult.OutputAmount.Mul(decimal.NewFromInt(100)).RoundBank(0)
+		maxInt64 := decimal.NewFromInt(math.MaxInt64)
+		minInt64 := decimal.NewFromInt(math.MinInt64)
+		if valuedCents.GreaterThan(maxInt64) || valuedCents.LessThan(minInt64) {
+			operationStatus = opStatusInvalidAmount
+			return nil, status.Error(codes.InvalidArgument, ErrAmountOverflow.Error())
+		}
 		lienAmount, err = domain.NewMoney(valuationResult.OutputCode, valuedCents.IntPart())
 		if err != nil {
 			operationStatus = opStatusInvalidAmount

--- a/services/current-account/service/lien_service_test.go
+++ b/services/current-account/service/lien_service_test.go
@@ -12,11 +12,13 @@ import (
 	"github.com/google/uuid"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	"github.com/meridianhub/meridian/shared/pkg/idempotency"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/grpc/codes"
@@ -67,6 +69,9 @@ func setupLienTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
 		payment_order_reference VARCHAR(255) NOT NULL UNIQUE,
 		termination_reason TEXT,
 		expires_at TIMESTAMP WITH TIME ZONE,
+		reserved_quantity JSONB,
+		valued_amount JSONB,
+		valuation_analysis JSONB,
 		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
 		version INT NOT NULL DEFAULT 1
@@ -1393,4 +1398,440 @@ func TestGetActiveAmountBlocks_MapsAmountCorrectly(t *testing.T) {
 	require.Equal(t, int64(123), block.Amount.Amount.Units, "should map to £123")
 	require.Equal(t, int32(450000000), block.Amount.Amount.Nanos, "should map to .45")
 	require.Equal(t, "Payment Order: PO-AMOUNT-TEST", block.Purpose)
+}
+
+// ============================================================================
+// Atomic Valuation in InitiateLien Tests
+// ============================================================================
+
+// setupAtomicValuationLienTest creates a test environment with lien repo, valuation feature repo,
+// mock valuation engine, and mock position keeping client for testing atomic valuation in InitiateLien.
+func setupAtomicValuationLienTest(t *testing.T, engine ValuationEngine, accountBalances map[string]int64) (*Service, context.Context, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupPostgres(t, nil)
+
+	tid := tenant.TenantID(lienSvcTestTenantID)
+	schemaName := tid.SchemaName()
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Create account table (uses "account" table name like valuation engine tests)
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.account (
+		id UUID PRIMARY KEY,
+		account_id VARCHAR(100) NOT NULL UNIQUE,
+		account_identification VARCHAR(34) NOT NULL UNIQUE,
+		party_id UUID NOT NULL,
+		balance BIGINT NOT NULL DEFAULT 0,
+		available_balance BIGINT NOT NULL DEFAULT 0,
+		currency VARCHAR(3) NOT NULL DEFAULT 'GBP',
+		status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+		overdraft_limit BIGINT NOT NULL DEFAULT 0,
+		overdraft_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+		overdraft_rate NUMERIC(5,4) NOT NULL DEFAULT 0,
+		balance_updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		created_by VARCHAR(100) NOT NULL DEFAULT 'system',
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		updated_by VARCHAR(100) NOT NULL DEFAULT 'system',
+		deleted_at TIMESTAMP WITH TIME ZONE,
+		opened_at TIMESTAMP WITH TIME ZONE,
+		closed_at TIMESTAMP WITH TIME ZONE,
+		freeze_reason TEXT,
+		version BIGINT NOT NULL DEFAULT 1
+	)`, pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Create lien table
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.lien (
+		id UUID PRIMARY KEY,
+		account_id UUID NOT NULL,
+		amount_cents BIGINT NOT NULL,
+		currency VARCHAR(3) NOT NULL,
+		bucket_id VARCHAR(255) NOT NULL DEFAULT '',
+		status VARCHAR(20) NOT NULL,
+		payment_order_reference VARCHAR(255) NOT NULL UNIQUE,
+		termination_reason TEXT,
+		expires_at TIMESTAMP WITH TIME ZONE,
+		reserved_quantity JSONB,
+		valued_amount JSONB,
+		valuation_analysis JSONB,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		version INT NOT NULL DEFAULT 1
+	)`, pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Create valuation_features table
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.valuation_features (
+		id UUID PRIMARY KEY,
+		account_id UUID NOT NULL,
+		instrument_code VARCHAR(32) NOT NULL,
+		valuation_method_id UUID NOT NULL,
+		valuation_method_version INT NOT NULL,
+		parameters JSONB,
+		lifecycle_status VARCHAR(16) NOT NULL,
+		valid_from TIMESTAMP WITH TIME ZONE NOT NULL,
+		valid_to TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(100) NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_by VARCHAR(100) NOT NULL,
+		version INT NOT NULL DEFAULT 1,
+		CONSTRAINT chk_valuation_feature_lifecycle_status CHECK (lifecycle_status IN ('INITIATED','ACTIVE','TERMINATED'))
+	)`, pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Create unique index for active features
+	err = db.Exec(fmt.Sprintf(`CREATE UNIQUE INDEX IF NOT EXISTS idx_valuation_feature_account_instrument_active
+		ON %s.valuation_features (account_id, instrument_code)
+		WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00'`, pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	ctx := tenant.WithTenant(context.Background(), tid)
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	valuationFeatureRepo := persistence.NewValuationFeatureRepository(db)
+
+	svc, err := NewService(repo, lienRepo)
+	require.NoError(t, err)
+
+	// Inject valuation feature repo and engine
+	svc.valuationFeatureRepo = valuationFeatureRepo
+	if engine != nil {
+		svc.valuationEngine = engine
+	}
+
+	// Inject position keeping mock
+	if accountBalances == nil {
+		accountBalances = make(map[string]int64)
+	}
+	mockPosKeeping := &mockPositionKeepingClient{accountBalances: accountBalances}
+	svc.posKeepingClient = mockPosKeeping
+
+	return svc, ctx, cleanup
+}
+
+func TestInitiateLien_AtomicValuation_Success(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Mock engine: 100 kWh * 0.15 GBP/kWh = 15.00 GBP
+	engine := &mockValuationEngine{
+		evaluateFn: func(_ context.Context, params ValuationParams) (*ValuationResult, error) {
+			return &ValuationResult{
+				OutputAmount:    params.InputAmount.Mul(decimal.NewFromFloat(0.15)),
+				OutputCode:      params.OutputCode,
+				AppliedRates:    map[string]string{"energy_rate": "0.15"},
+				ObservationIDs:  []string{"obs-energy-001"},
+				ComputedAt:      time.Now(),
+				CalculationPath: []string{"lookup_rate", "apply_energy_rate"},
+			}, nil
+		},
+	}
+
+	svc, ctx, cleanup := setupAtomicValuationLienTest(t, engine, map[string]int64{
+		"ACC-VALUED-001": 500000, // £5000
+	})
+	defer cleanup()
+
+	tid := tenant.TenantID(lienSvcTestTenantID)
+	schemaName := tid.SchemaName()
+
+	// Create account and valuation feature
+	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-VALUED-001", "GBP")
+	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "kWh")
+
+	// Initiate lien with multi-asset input
+	resp, err := svc.InitiateLien(ctx, &pb.InitiateLienRequest{
+		AccountId: "ACC-VALUED-001",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "100.00",
+			InstrumentCode: "kWh",
+			Version:        1,
+		},
+		PaymentOrderReference: "PO-VALUED-001",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Lien)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_ACTIVE, resp.Lien.Status)
+
+	// Verify lien amount is the valued amount (100 * 0.15 = 15.00 GBP = 1500 cents)
+	require.Equal(t, "GBP", resp.Lien.Amount.Amount.CurrencyCode)
+	require.Equal(t, int64(15), resp.Lien.Amount.Amount.Units)
+
+	// Verify reserved quantity on the lien
+	require.NotNil(t, resp.Lien.ReservedQuantity, "reserved_quantity should be set on lien")
+	require.Equal(t, "100", resp.Lien.ReservedQuantity.Amount)
+	require.Equal(t, "kWh", resp.Lien.ReservedQuantity.InstrumentCode)
+
+	// Verify valued amount on the lien
+	require.NotNil(t, resp.Lien.ValuedAmount, "valued_amount should be set on lien")
+	require.Equal(t, "GBP", resp.Lien.ValuedAmount.InstrumentCode)
+
+	// Verify top-level response fields
+	require.NotNil(t, resp.ValuedAmount, "response valued_amount should be set")
+	require.Equal(t, "GBP", resp.ValuedAmount.InstrumentCode)
+
+	require.NotNil(t, resp.Basis, "response basis should be set")
+	require.Equal(t, "0.15", resp.Basis.AppliedRates["energy_rate"])
+	require.Contains(t, resp.Basis.ObservationIds, "obs-energy-001")
+}
+
+func TestInitiateLien_AtomicValuation_NoValuationFeature(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	engine := &mockValuationEngine{}
+
+	svc, ctx, cleanup := setupAtomicValuationLienTest(t, engine, map[string]int64{
+		"ACC-NOFEAT-001": 500000,
+	})
+	defer cleanup()
+
+	tid := tenant.TenantID(lienSvcTestTenantID)
+	schemaName := tid.SchemaName()
+
+	// Create account WITHOUT valuation feature
+	createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-NOFEAT-001", "GBP")
+
+	// Attempt InitiateLien with multi-asset input
+	_, err := svc.InitiateLien(ctx, &pb.InitiateLienRequest{
+		AccountId: "ACC-NOFEAT-001",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "100.00",
+			InstrumentCode: "kWh",
+			Version:        1,
+		},
+		PaymentOrderReference: "PO-NOFEAT-001",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestInitiateLien_AtomicValuation_IdempotencyReturnsPriceLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Mock engine: 50 USD * 0.80 = 40.00 GBP
+	engine := &mockValuationEngine{
+		evaluateFn: func(_ context.Context, params ValuationParams) (*ValuationResult, error) {
+			return &ValuationResult{
+				OutputAmount:    params.InputAmount.Mul(decimal.NewFromFloat(0.80)),
+				OutputCode:      params.OutputCode,
+				AppliedRates:    map[string]string{"fx_rate": "0.80"},
+				ObservationIDs:  []string{"obs-fx-001"},
+				ComputedAt:      time.Now(),
+				CalculationPath: []string{"lookup_fx", "apply_rate"},
+			}, nil
+		},
+	}
+
+	svc, ctx, cleanup := setupAtomicValuationLienTest(t, engine, map[string]int64{
+		"ACC-IDEMP-001": 500000, // £5000
+	})
+	defer cleanup()
+
+	tid := tenant.TenantID(lienSvcTestTenantID)
+	schemaName := tid.SchemaName()
+
+	// Create account and valuation feature
+	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-IDEMP-001", "GBP")
+	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "USD")
+
+	// First call: creates the lien
+	req := &pb.InitiateLienRequest{
+		AccountId: "ACC-IDEMP-001",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "50.00",
+			InstrumentCode: "USD",
+			Version:        1,
+		},
+		PaymentOrderReference: "PO-IDEMP-001",
+	}
+
+	resp1, err := svc.InitiateLien(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp1.ValuedAmount)
+	require.NotNil(t, resp1.Basis)
+
+	// Second call (idempotent retry): should return same price lock
+	resp2, err := svc.InitiateLien(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp2)
+
+	// Verify same lien is returned
+	require.Equal(t, resp1.Lien.LienId, resp2.Lien.LienId, "idempotent retry should return same lien")
+
+	// Verify price lock is preserved (valued_amount on response)
+	require.NotNil(t, resp2.ValuedAmount, "idempotent response should include valued_amount")
+	require.Equal(t, resp1.ValuedAmount.Amount, resp2.ValuedAmount.Amount, "price lock should be identical")
+	require.Equal(t, resp1.ValuedAmount.InstrumentCode, resp2.ValuedAmount.InstrumentCode)
+
+	// Verify basis is preserved
+	require.NotNil(t, resp2.Basis, "idempotent response should include basis")
+	require.Equal(t, resp1.Basis.AppliedRates["fx_rate"], resp2.Basis.AppliedRates["fx_rate"])
+
+	// Verify lien proto fields preserved
+	require.NotNil(t, resp2.Lien.ReservedQuantity)
+	require.Equal(t, "50", resp2.Lien.ReservedQuantity.Amount)
+	require.Equal(t, "USD", resp2.Lien.ReservedQuantity.InstrumentCode)
+}
+
+func TestInitiateLien_AtomicValuation_InsufficientFunds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Mock engine: 1000 kWh * 10.00 GBP/kWh = 10000.00 GBP (exceeds balance)
+	engine := &mockValuationEngine{
+		evaluateFn: func(_ context.Context, params ValuationParams) (*ValuationResult, error) {
+			return &ValuationResult{
+				OutputAmount:    params.InputAmount.Mul(decimal.NewFromFloat(10.00)),
+				OutputCode:      params.OutputCode,
+				AppliedRates:    map[string]string{"energy_rate": "10.00"},
+				ObservationIDs:  []string{"obs-energy-002"},
+				ComputedAt:      time.Now(),
+				CalculationPath: []string{"lookup_rate"},
+			}, nil
+		},
+	}
+
+	svc, ctx, cleanup := setupAtomicValuationLienTest(t, engine, map[string]int64{
+		"ACC-INSUF-001": 100000, // £1000 (valued amount will be £10000)
+	})
+	defer cleanup()
+
+	tid := tenant.TenantID(lienSvcTestTenantID)
+	schemaName := tid.SchemaName()
+
+	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-INSUF-001", "GBP")
+	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "kWh")
+
+	_, err := svc.InitiateLien(ctx, &pb.InitiateLienRequest{
+		AccountId: "ACC-INSUF-001",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "1000.00",
+			InstrumentCode: "kWh",
+			Version:        1,
+		},
+		PaymentOrderReference: "PO-INSUF-001",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, codes.FailedPrecondition, st.Code())
+	require.Contains(t, st.Message(), "insufficient available balance")
+}
+
+func TestInitiateLien_AtomicValuation_LegacyModeStillWorks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Even with valuation engine configured, legacy MoneyAmount mode should still work
+	engine := &mockValuationEngine{}
+	svc, ctx, cleanup := setupAtomicValuationLienTest(t, engine, map[string]int64{
+		"ACC-LEGACY-001": 500000,
+	})
+	defer cleanup()
+
+	tid := tenant.TenantID(lienSvcTestTenantID)
+	schemaName := tid.SchemaName()
+	createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-LEGACY-001", "GBP")
+
+	// Legacy mode: use MoneyAmount, no Input field
+	resp, err := svc.InitiateLien(ctx, &pb.InitiateLienRequest{
+		AccountId: "ACC-LEGACY-001",
+		Amount: &commonpb.MoneyAmount{
+			Amount: &money.Money{
+				CurrencyCode: "GBP",
+				Units:        100,
+				Nanos:        0,
+			},
+		},
+		PaymentOrderReference: "PO-LEGACY-001",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Lien)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_ACTIVE, resp.Lien.Status)
+
+	// Legacy mode should NOT have valuation fields
+	require.Nil(t, resp.Lien.ReservedQuantity, "legacy lien should not have reserved_quantity")
+	require.Nil(t, resp.Lien.ValuedAmount, "legacy lien should not have valued_amount")
+	require.Nil(t, resp.ValuedAmount, "legacy response should not have valued_amount")
+	require.Nil(t, resp.Basis, "legacy response should not have basis")
+}
+
+func TestInitiateLien_AtomicValuation_ValuationImmutable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	// Create a valued lien and verify that termination does not change valuation fields
+	engine := &mockValuationEngine{
+		evaluateFn: func(_ context.Context, params ValuationParams) (*ValuationResult, error) {
+			return &ValuationResult{
+				OutputAmount:    params.InputAmount.Mul(decimal.NewFromFloat(0.50)),
+				OutputCode:      params.OutputCode,
+				AppliedRates:    map[string]string{"rate": "0.50"},
+				ObservationIDs:  []string{"obs-001"},
+				ComputedAt:      time.Now(),
+				CalculationPath: []string{"apply"},
+			}, nil
+		},
+	}
+
+	svc, ctx, cleanup := setupAtomicValuationLienTest(t, engine, map[string]int64{
+		"ACC-IMMUT-001": 500000,
+	})
+	defer cleanup()
+
+	tid := tenant.TenantID(lienSvcTestTenantID)
+	schemaName := tid.SchemaName()
+	accountUUID := createTestAccountForValuation(t, ctx, svc.repo.DB(), schemaName, "ACC-IMMUT-001", "GBP")
+	createTestValuationFeature(t, ctx, svc.repo.DB(), schemaName, accountUUID, "UNIT")
+
+	// Create valued lien
+	initResp, err := svc.InitiateLien(ctx, &pb.InitiateLienRequest{
+		AccountId: "ACC-IMMUT-001",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "200.00",
+			InstrumentCode: "UNIT",
+			Version:        1,
+		},
+		PaymentOrderReference: "PO-IMMUT-001",
+	})
+	require.NoError(t, err)
+	lienID := initResp.Lien.LienId
+
+	// Terminate the lien
+	_, err = svc.TerminateLien(ctx, &pb.TerminateLienRequest{
+		LienId: lienID,
+		Reason: "test termination",
+	})
+	require.NoError(t, err)
+
+	// Retrieve and verify valuation fields are still intact
+	retrieveResp, err := svc.RetrieveLien(ctx, &pb.RetrieveLienRequest{LienId: lienID})
+	require.NoError(t, err)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_TERMINATED, retrieveResp.Lien.Status)
+	require.NotNil(t, retrieveResp.Lien.ReservedQuantity, "valuation fields should survive termination")
+	require.Equal(t, "200", retrieveResp.Lien.ReservedQuantity.Amount)
+	require.Equal(t, "UNIT", retrieveResp.Lien.ReservedQuantity.InstrumentCode)
+	require.NotNil(t, retrieveResp.Lien.ValuedAmount)
+	require.Equal(t, "GBP", retrieveResp.Lien.ValuedAmount.InstrumentCode)
 }


### PR DESCRIPTION
## Summary

- Enhance `InitiateLien` to support multi-asset inputs with atomic valuation, sharing `valuateInternal()` with `EvaluateAssetValuation` to prevent Ghost Pricing
- Store price-locked `reserved_quantity`, `valued_amount`, and `valuation_analysis` as immutable JSONB fields on lien records
- Preserve price lock on idempotent retries by reconstructing `valued_amount` and `basis` from persisted data

## Changes

### Proto (`current_account.proto`)
- `InitiateLienRequest`: Add `input` (InstrumentAmount) and `knowledge_at` (Timestamp) fields
- `InitiateLienResponse`: Add `valued_amount` (InstrumentAmount) and `basis` (ValuationAnalysis) fields
- `Lien` message: Add `reserved_quantity` and `valued_amount` fields

### Domain (`domain/lien.go`)
- Add `InstrumentAmount` struct with `Amount` (decimal.Decimal) and `InstrumentCode`
- Add `NewValuedLien` constructor, `HasValuation()` method
- Add `ErrValuedAmountImmutable` sentinel error

### Persistence
- `JSONBMap` type implementing `driver.Valuer` / `sql.Scanner` for JSONB columns
- `LienEntity`: 3 new nullable JSONB columns (`reserved_quantity`, `valued_amount`, `valuation_analysis`)
- Repository: Marshal/unmarshal valuation fields in `toLienEntity`/`toLienDomain`
- Migration `20260206000003`: `ALTER TABLE lien ADD COLUMN IF NOT EXISTS` for backward compatibility

### Service (`lien_service.go`)
- Dual-mode `InitiateLien`: legacy `MoneyAmount` (unchanged) vs multi-asset `InstrumentAmount` input (runs valuation)
- Multi-asset flow: parse input -> `valuateInternal()` -> convert to domain Money -> `NewValuedLien` -> persist
- Immutability: `Update()` only touches `status`, `termination_reason`, `updated_at`, `version` -- valuation fields are write-once
- Idempotency (subtask 6.6): `checkLienIdempotency` reconstructs `valued_amount` and `basis` from persisted lien

### Subtask 6.4 (RecordReservation)
Position Keeping does not yet have a `RecordReservation` RPC. This is cross-service work that should be addressed in a follow-up task.

## Test plan

- [x] `TestInitiateLien_AtomicValuation_Success` -- multi-asset input produces valued lien with price lock
- [x] `TestInitiateLien_AtomicValuation_NoValuationFeature` -- missing feature returns FailedPrecondition
- [x] `TestInitiateLien_AtomicValuation_IdempotencyReturnsPriceLock` -- retry returns identical price lock
- [x] `TestInitiateLien_AtomicValuation_InsufficientFunds` -- valued amount exceeding balance is rejected
- [x] `TestInitiateLien_AtomicValuation_LegacyModeStillWorks` -- MoneyAmount mode unaffected, no valuation fields
- [x] `TestInitiateLien_AtomicValuation_ValuationImmutable` -- valuation fields survive termination
- [x] All 8 existing test packages pass (persistence, service, domain, etc.)

## Task Master

Task: `valuation-engine.6` -- Atomic valuation in InitiateLien with price lock

Subtasks completed: 6.1 (proto), 6.2 (domain+entity+migration), 6.3 (service wiring), 6.5 (immutability), 6.6 (idempotency with price lock)

Subtask deferred: 6.4 (RecordReservation in Position Keeping -- RPC does not exist yet)