### PR TITLE
feat: add Reservation Ledger and ProjectedBalance to Position Keeping

### DIFF
--- a/api/proto/meridian/position_keeping/v1/position_keeping.proto
+++ b/api/proto/meridian/position_keeping/v1/position_keeping.proto
@@ -770,6 +770,38 @@ service PositionKeepingService {
       }
     };
   }
+
+  // RecordReservation creates a reservation linked to a lien for projected balance calculations.
+  // Idempotent by lien_id - duplicate calls return the existing reservation.
+  rpc RecordReservation(RecordReservationRequest) returns (RecordReservationResponse) {
+    option (google.api.http) = {
+      post: "/v1/reservations"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "201"
+        value: {
+          description: "Reservation recorded successfully"
+        }
+      }
+    };
+  }
+
+  // ReleaseReservation transitions a reservation to EXECUTED or TERMINATED.
+  rpc ReleaseReservation(ReleaseReservationRequest) returns (ReleaseReservationResponse) {
+    option (google.api.http) = {
+      post: "/v1/reservations/{lien_id}/release"
+      body: "*"
+    };
+  }
+
+  // GetProjectedBalance calculates the projected balance accounting for active reservations.
+  rpc GetProjectedBalance(GetProjectedBalanceRequest) returns (GetProjectedBalanceResponse) {
+    option (google.api.http) = {
+      get: "/v1/accounts/{account_id}/projected-balance/{instrument_code}"
+    };
+  }
 }
 
 // UpdatePositionRequest is reserved for future use.
@@ -830,4 +862,142 @@ message MergePositionsRequest {
 // Currently blocked - positions use append-only write semantics.
 message MergePositionsResponse {
   // This response is never returned - the RPC always returns UNIMPLEMENTED.
+}
+
+// ReservationStatus represents the lifecycle state of a reservation.
+enum ReservationStatus {
+  // RESERVATION_STATUS_UNSPECIFIED is the default unset value.
+  RESERVATION_STATUS_UNSPECIFIED = 0;
+  // RESERVATION_STATUS_ACTIVE indicates the reservation is currently held.
+  RESERVATION_STATUS_ACTIVE = 1;
+  // RESERVATION_STATUS_EXECUTED indicates the reservation was fulfilled.
+  RESERVATION_STATUS_EXECUTED = 2;
+  // RESERVATION_STATUS_TERMINATED indicates the reservation was cancelled.
+  RESERVATION_STATUS_TERMINATED = 3;
+}
+
+// RecordReservationRequest creates a reservation linked to a lien.
+message RecordReservationRequest {
+  // account_id is the account that holds the reserved position.
+  string account_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 255
+      pattern: "^[a-zA-Z0-9_-]+$"
+    }
+  ];
+
+  // lien_id is the unique identifier of the lien this reservation is for.
+  // Used as the idempotency key - duplicate lien_ids return the existing reservation.
+  string lien_id = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // instrument_code identifies the asset being reserved.
+  string instrument_code = 3 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 32
+      pattern: "^[A-Z][A-Z0-9_]*$"
+    }
+  ];
+
+  // reserved_amount is the quantity being reserved.
+  string reserved_amount = 4 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 50
+      pattern: "^-?\\d+(\\.\\d+)?$"
+    }
+  ];
+
+  // bucket_id is the fungibility bucket for this reservation.
+  string bucket_id = 5 [(buf.validate.field).string.max_len = 256];
+
+  // knowledge_at is the timestamp when this reservation became known.
+  google.protobuf.Timestamp knowledge_at = 6;
+}
+
+// RecordReservationResponse returns the result of creating a reservation.
+message RecordReservationResponse {
+  // reservation_id is the unique identifier for the created reservation (same as lien_id).
+  string reservation_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // already_exists indicates this reservation was already recorded (idempotent return).
+  bool already_exists = 2;
+}
+
+// ReleaseReservationRequest releases a reservation by transitioning its status.
+message ReleaseReservationRequest {
+  // lien_id is the unique identifier of the lien whose reservation to release.
+  string lien_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // reason indicates why the reservation is being released.
+  ReservationStatus reason = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    in: [2, 3] /* Only EXECUTED or TERMINATED */
+  }];
+}
+
+// ReleaseReservationResponse returns the result of releasing a reservation.
+message ReleaseReservationResponse {
+  // released indicates whether the reservation was successfully released.
+  bool released = 1;
+}
+
+// GetProjectedBalanceRequest retrieves a projected balance accounting for active reservations.
+message GetProjectedBalanceRequest {
+  // account_id is the account to calculate the projected balance for.
+  string account_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 255
+      pattern: "^[a-zA-Z0-9_-]+$"
+    }
+  ];
+
+  // instrument_code identifies the asset to calculate the projected balance for.
+  string instrument_code = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 32
+      pattern: "^[A-Z][A-Z0-9_]*$"
+    }
+  ];
+
+  // bucket_id filters the balance to a specific fungibility bucket (optional).
+  string bucket_id = 3 [(buf.validate.field).string.max_len = 256];
+
+  // knowledge_at is the point-in-time for the balance query (optional, defaults to now).
+  google.protobuf.Timestamp knowledge_at = 4;
+}
+
+// GetProjectedBalanceResponse returns the projected balance with reservation breakdown.
+message GetProjectedBalanceResponse {
+  // current_balance is the sum of all position entries matching the filter.
+  string current_balance = 1;
+
+  // active_reservations_total is the sum of all active reservation amounts.
+  string active_reservations_total = 2;
+
+  // projected_balance is current_balance minus active_reservations_total.
+  string projected_balance = 3;
+
+  // bucket_id is the bucket that was filtered (empty if no filter applied).
+  string bucket_id = 4;
+
+  // instrument_code is the instrument that was queried.
+  string instrument_code = 5;
+
+  // as_of is the timestamp when this balance was calculated.
+  google.protobuf.Timestamp as_of = 6;
 }

--- a/services/position-keeping/adapters/persistence/reservation_repository.go
+++ b/services/position-keeping/adapters/persistence/reservation_repository.go
@@ -1,0 +1,251 @@
+package persistence
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/shopspring/decimal"
+)
+
+// ReservationRepository implements domain.ReservationRepository using PostgreSQL.
+type ReservationRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewReservationRepository creates a new PostgreSQL reservation repository.
+func NewReservationRepository(pool *pgxpool.Pool) *ReservationRepository {
+	return &ReservationRepository{pool: pool}
+}
+
+func (r *ReservationRepository) setSearchPath(ctx context.Context, tx pgx.Tx) error {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	schemaName := pgx.Identifier{tenantID.SchemaName()}.Sanitize()
+	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	_, err := tx.Exec(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to set tenant schema scope: %w", err)
+	}
+
+	return nil
+}
+
+// Create persists a new Reservation.
+// Returns domain.ErrConflict if a reservation with the same lien_id already exists.
+func (r *ReservationRepository) Create(ctx context.Context, reservation *domain.Reservation) error {
+	if reservation == nil {
+		return fmt.Errorf("create reservation: %w", domain.ErrReservationNotFound)
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	query := `
+		INSERT INTO reservation (
+			lien_id, account_id, instrument_code, bucket_id,
+			reserved_amount, status, created_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $7)`
+
+	_, err = tx.Exec(ctx, query,
+		reservation.LienID,
+		reservation.AccountID,
+		reservation.InstrumentCode,
+		reservation.BucketID,
+		reservation.ReservedAmount,
+		reservation.Status.String(),
+		reservation.CreatedAt,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return domain.ErrConflict
+		}
+		return fmt.Errorf("failed to insert reservation: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// FindByLienID retrieves a Reservation by its lien_id.
+func (r *ReservationRepository) FindByLienID(ctx context.Context, lienID uuid.UUID) (*domain.Reservation, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return nil, err
+	}
+
+	query := `
+		SELECT lien_id, account_id, instrument_code, bucket_id,
+			reserved_amount, status, created_at, executed_at, terminated_at
+		FROM reservation
+		WHERE lien_id = $1`
+
+	var res domain.Reservation
+	var status string
+	var executedAt, terminatedAt sql.NullTime
+
+	err = tx.QueryRow(ctx, query, lienID).Scan(
+		&res.LienID, &res.AccountID, &res.InstrumentCode, &res.BucketID,
+		&res.ReservedAmount, &status, &res.CreatedAt, &executedAt, &terminatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrReservationNotFound
+		}
+		return nil, fmt.Errorf("failed to query reservation: %w", err)
+	}
+
+	res.Status = domain.ReservationStatus(status)
+	if executedAt.Valid {
+		res.ExecutedAt = &executedAt.Time
+	}
+	if terminatedAt.Valid {
+		res.TerminatedAt = &terminatedAt.Time
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return &res, nil
+}
+
+// UpdateStatus transitions a reservation's status and sets the appropriate timestamp.
+func (r *ReservationRepository) UpdateStatus(ctx context.Context, lienID uuid.UUID, newStatus domain.ReservationStatus) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+
+	var query string
+	var args []any
+
+	switch newStatus {
+	case domain.ReservationStatusActive:
+		return domain.ErrInvalidReservationState
+	case domain.ReservationStatusExecuted:
+		query = `UPDATE reservation SET status = $1, executed_at = $2 WHERE lien_id = $3 AND status = 'ACTIVE'`
+		args = []any{newStatus.String(), now, lienID}
+	case domain.ReservationStatusTerminated:
+		query = `UPDATE reservation SET status = $1, terminated_at = $2 WHERE lien_id = $3 AND status = 'ACTIVE'`
+		args = []any{newStatus.String(), now, lienID}
+	}
+
+	result, err := tx.Exec(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("failed to update reservation status: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		// Check if the reservation exists at all
+		var exists bool
+		err = tx.QueryRow(ctx, "SELECT EXISTS(SELECT 1 FROM reservation WHERE lien_id = $1)", lienID).Scan(&exists)
+		if err != nil {
+			return fmt.Errorf("failed to check reservation existence: %w", err)
+		}
+		if !exists {
+			return domain.ErrReservationNotFound
+		}
+		return domain.ErrReservationAlreadyFinal
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return nil
+}
+
+// SumActiveReservations returns the total reserved amount for active reservations.
+// If bucketID is empty, sums across all buckets.
+func (r *ReservationRepository) SumActiveReservations(ctx context.Context, accountID, instrumentCode, bucketID string) (decimal.Decimal, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := r.setSearchPath(ctx, tx); err != nil {
+		return decimal.Zero, err
+	}
+
+	var total decimal.NullDecimal
+
+	if bucketID != "" {
+		query := `
+			SELECT SUM(reserved_amount)
+			FROM reservation
+			WHERE account_id = $1
+				AND instrument_code = $2
+				AND status = 'ACTIVE'
+				AND bucket_id = $3`
+		err = tx.QueryRow(ctx, query, accountID, instrumentCode, bucketID).Scan(&total)
+	} else {
+		query := `
+			SELECT SUM(reserved_amount)
+			FROM reservation
+			WHERE account_id = $1
+				AND instrument_code = $2
+				AND status = 'ACTIVE'`
+		err = tx.QueryRow(ctx, query, accountID, instrumentCode).Scan(&total)
+	}
+
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("failed to sum active reservations: %w", err)
+	}
+
+	if !total.Valid {
+		return decimal.Zero, nil
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return decimal.Zero, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return total.Decimal, nil
+}
+
+// Ensure ReservationRepository implements the interface at compile time.
+var _ domain.ReservationRepository = (*ReservationRepository)(nil)

--- a/services/position-keeping/adapters/persistence/reservation_repository_test.go
+++ b/services/position-keeping/adapters/persistence/reservation_repository_test.go
@@ -1,0 +1,258 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/position-keeping/adapters/persistence/testhelpers"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReservationRepository_Create(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("creates reservation successfully", func(t *testing.T) {
+		lienID := uuid.New()
+		r, err := domain.NewReservation(lienID, "ACC-001", "GBP", "bucket-1", decimal.NewFromInt(100))
+		require.NoError(t, err)
+
+		err = tc.ReservationRepo.Create(ctx, r)
+		require.NoError(t, err)
+
+		// Verify we can retrieve it
+		found, err := tc.ReservationRepo.FindByLienID(ctx, lienID)
+		require.NoError(t, err)
+		assert.Equal(t, lienID, found.LienID)
+		assert.Equal(t, "ACC-001", found.AccountID)
+		assert.Equal(t, "GBP", found.InstrumentCode)
+		assert.Equal(t, "bucket-1", found.BucketID)
+		assert.True(t, decimal.NewFromInt(100).Equal(found.ReservedAmount))
+		assert.Equal(t, domain.ReservationStatusActive, found.Status)
+	})
+
+	t.Run("returns conflict for duplicate lien_id", func(t *testing.T) {
+		lienID := uuid.New()
+		r1, err := domain.NewReservation(lienID, "ACC-001", "GBP", "", decimal.NewFromInt(50))
+		require.NoError(t, err)
+
+		err = tc.ReservationRepo.Create(ctx, r1)
+		require.NoError(t, err)
+
+		r2, err := domain.NewReservation(lienID, "ACC-002", "USD", "", decimal.NewFromInt(75))
+		require.NoError(t, err)
+
+		err = tc.ReservationRepo.Create(ctx, r2)
+		assert.ErrorIs(t, err, domain.ErrConflict)
+	})
+}
+
+func TestReservationRepository_FindByLienID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("returns not found for missing lien_id", func(t *testing.T) {
+		_, err := tc.ReservationRepo.FindByLienID(ctx, uuid.New())
+		assert.ErrorIs(t, err, domain.ErrReservationNotFound)
+	})
+}
+
+func TestReservationRepository_UpdateStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("transitions active to executed", func(t *testing.T) {
+		lienID := uuid.New()
+		r, _ := domain.NewReservation(lienID, "ACC-001", "GBP", "", decimal.NewFromInt(100))
+		require.NoError(t, tc.ReservationRepo.Create(ctx, r))
+
+		err := tc.ReservationRepo.UpdateStatus(ctx, lienID, domain.ReservationStatusExecuted)
+		require.NoError(t, err)
+
+		found, err := tc.ReservationRepo.FindByLienID(ctx, lienID)
+		require.NoError(t, err)
+		assert.Equal(t, domain.ReservationStatusExecuted, found.Status)
+		assert.NotNil(t, found.ExecutedAt)
+		assert.Nil(t, found.TerminatedAt)
+	})
+
+	t.Run("transitions active to terminated", func(t *testing.T) {
+		lienID := uuid.New()
+		r, _ := domain.NewReservation(lienID, "ACC-001", "GBP", "", decimal.NewFromInt(100))
+		require.NoError(t, tc.ReservationRepo.Create(ctx, r))
+
+		err := tc.ReservationRepo.UpdateStatus(ctx, lienID, domain.ReservationStatusTerminated)
+		require.NoError(t, err)
+
+		found, err := tc.ReservationRepo.FindByLienID(ctx, lienID)
+		require.NoError(t, err)
+		assert.Equal(t, domain.ReservationStatusTerminated, found.Status)
+		assert.Nil(t, found.ExecutedAt)
+		assert.NotNil(t, found.TerminatedAt)
+	})
+
+	t.Run("returns already final for executed reservation", func(t *testing.T) {
+		lienID := uuid.New()
+		r, _ := domain.NewReservation(lienID, "ACC-001", "GBP", "", decimal.NewFromInt(100))
+		require.NoError(t, tc.ReservationRepo.Create(ctx, r))
+		require.NoError(t, tc.ReservationRepo.UpdateStatus(ctx, lienID, domain.ReservationStatusExecuted))
+
+		err := tc.ReservationRepo.UpdateStatus(ctx, lienID, domain.ReservationStatusTerminated)
+		assert.ErrorIs(t, err, domain.ErrReservationAlreadyFinal)
+	})
+
+	t.Run("returns not found for missing lien_id", func(t *testing.T) {
+		err := tc.ReservationRepo.UpdateStatus(ctx, uuid.New(), domain.ReservationStatusExecuted)
+		assert.ErrorIs(t, err, domain.ErrReservationNotFound)
+	})
+}
+
+func TestReservationRepository_SumActiveReservations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	t.Run("returns zero when no reservations exist", func(t *testing.T) {
+		total, err := tc.ReservationRepo.SumActiveReservations(ctx, "ACC-EMPTY", "GBP", "")
+		require.NoError(t, err)
+		assert.True(t, decimal.Zero.Equal(total))
+	})
+
+	t.Run("sums only active reservations", func(t *testing.T) {
+		accountID := "ACC-SUM-" + uuid.New().String()[:8]
+
+		// Create 3 active reservations
+		for i := 0; i < 3; i++ {
+			r, _ := domain.NewReservation(uuid.New(), accountID, "GBP", "bucket-1", decimal.NewFromInt(100))
+			require.NoError(t, tc.ReservationRepo.Create(ctx, r))
+		}
+
+		// Create 1 executed reservation
+		executedLienID := uuid.New()
+		r, _ := domain.NewReservation(executedLienID, accountID, "GBP", "bucket-1", decimal.NewFromInt(50))
+		require.NoError(t, tc.ReservationRepo.Create(ctx, r))
+		require.NoError(t, tc.ReservationRepo.UpdateStatus(ctx, executedLienID, domain.ReservationStatusExecuted))
+
+		// Sum should only include active reservations (3 * 100 = 300)
+		total, err := tc.ReservationRepo.SumActiveReservations(ctx, accountID, "GBP", "bucket-1")
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(300).Equal(total), "expected 300, got %s", total)
+	})
+
+	t.Run("filters by bucket_id", func(t *testing.T) {
+		accountID := "ACC-BUCKET-" + uuid.New().String()[:8]
+
+		// Create reservation in bucket-1
+		r1, _ := domain.NewReservation(uuid.New(), accountID, "GBP", "bucket-1", decimal.NewFromInt(100))
+		require.NoError(t, tc.ReservationRepo.Create(ctx, r1))
+
+		// Create reservation in bucket-2
+		r2, _ := domain.NewReservation(uuid.New(), accountID, "GBP", "bucket-2", decimal.NewFromInt(200))
+		require.NoError(t, tc.ReservationRepo.Create(ctx, r2))
+
+		// Sum for bucket-1 only
+		total, err := tc.ReservationRepo.SumActiveReservations(ctx, accountID, "GBP", "bucket-1")
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(100).Equal(total))
+
+		// Sum across all buckets
+		totalAll, err := tc.ReservationRepo.SumActiveReservations(ctx, accountID, "GBP", "")
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(300).Equal(totalAll))
+	})
+
+	t.Run("isolates by instrument_code", func(t *testing.T) {
+		accountID := "ACC-INST-" + uuid.New().String()[:8]
+
+		r1, _ := domain.NewReservation(uuid.New(), accountID, "GBP", "", decimal.NewFromInt(100))
+		require.NoError(t, tc.ReservationRepo.Create(ctx, r1))
+
+		r2, _ := domain.NewReservation(uuid.New(), accountID, "USD", "", decimal.NewFromInt(200))
+		require.NoError(t, tc.ReservationRepo.Create(ctx, r2))
+
+		gbpTotal, err := tc.ReservationRepo.SumActiveReservations(ctx, accountID, "GBP", "")
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(100).Equal(gbpTotal))
+
+		usdTotal, err := tc.ReservationRepo.SumActiveReservations(ctx, accountID, "USD", "")
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(200).Equal(usdTotal))
+	})
+}
+
+// TestReservationLifecycle_Integration tests the full lifecycle:
+// RecordReservation -> GetProjectedBalance -> ReleaseReservation
+func TestReservationLifecycle_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	accountID := "ACC-LIFECYCLE-" + uuid.New().String()[:8]
+
+	// Step 1: Insert some position entries
+	pos1, _ := domain.NewPosition(accountID, "GBP", "default", decimal.NewFromInt(1000), "Monetary", nil, uuid.Nil, "system")
+	require.NoError(t, tc.PositionRepo.Insert(ctx, pos1))
+
+	// Step 2: Create reservations
+	lien1 := uuid.New()
+	lien2 := uuid.New()
+	r1, _ := domain.NewReservation(lien1, accountID, "GBP", "default", decimal.NewFromInt(200))
+	r2, _ := domain.NewReservation(lien2, accountID, "GBP", "default", decimal.NewFromInt(300))
+	require.NoError(t, tc.ReservationRepo.Create(ctx, r1))
+	require.NoError(t, tc.ReservationRepo.Create(ctx, r2))
+
+	// Step 3: Verify projected balance
+	agg, err := tc.PositionRepo.GetAggregatedPosition(ctx, accountID, "GBP", "default")
+	require.NoError(t, err)
+	require.NotNil(t, agg)
+	assert.True(t, decimal.NewFromInt(1000).Equal(agg.TotalAmount))
+
+	reservedTotal, err := tc.ReservationRepo.SumActiveReservations(ctx, accountID, "GBP", "default")
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(500).Equal(reservedTotal))
+
+	projectedBalance := agg.TotalAmount.Sub(reservedTotal)
+	assert.True(t, decimal.NewFromInt(500).Equal(projectedBalance))
+
+	// Step 4: Release one reservation
+	require.NoError(t, tc.ReservationRepo.UpdateStatus(ctx, lien1, domain.ReservationStatusExecuted))
+
+	// Step 5: Verify projected balance updated
+	reservedTotal2, err := tc.ReservationRepo.SumActiveReservations(ctx, accountID, "GBP", "default")
+	require.NoError(t, err)
+	assert.True(t, decimal.NewFromInt(300).Equal(reservedTotal2))
+
+	projectedBalance2 := agg.TotalAmount.Sub(reservedTotal2)
+	assert.True(t, decimal.NewFromInt(700).Equal(projectedBalance2))
+}

--- a/services/position-keeping/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/position-keeping/adapters/persistence/testhelpers/testcontainer.go
@@ -37,10 +37,11 @@ import (
 // TestContainer holds the test database container, connection pool, and repository instance.
 // It provides a complete testing environment with proper cleanup.
 type TestContainer struct {
-	container    *postgres.PostgresContainer
-	Pool         *pgxpool.Pool
-	Repo         *persistence.PostgresRepository
-	PositionRepo *persistence.PositionRepository
+	container       *postgres.PostgresContainer
+	Pool            *pgxpool.Pool
+	Repo            *persistence.PostgresRepository
+	PositionRepo    *persistence.PositionRepository
+	ReservationRepo *persistence.ReservationRepository
 }
 
 // SetupTestContainer creates a PostgreSQL testcontainer with the position_keeping schema loaded.
@@ -102,12 +103,14 @@ func SetupTestContainer(t *testing.T) *TestContainer {
 	// Create repositories
 	repo := persistence.NewPostgresRepository(pool)
 	positionRepo := persistence.NewPositionRepository(pool)
+	reservationRepo := persistence.NewReservationRepository(pool)
 
 	return &TestContainer{
-		container:    pgContainer,
-		Pool:         pool,
-		Repo:         repo,
-		PositionRepo: positionRepo,
+		container:       pgContainer,
+		Pool:            pool,
+		Repo:            repo,
+		PositionRepo:    positionRepo,
+		ReservationRepo: reservationRepo,
 	}
 }
 
@@ -334,4 +337,32 @@ func loadSchema(t *testing.T, pool *pgxpool.Pool) {
 			EXECUTE FUNCTION position_keeping.positions_append_only()
 	`)
 	require.NoError(t, err, "Failed to create append-only trigger")
+
+	// Create reservation table (matches production migration 20260207000001_reservations.sql)
+	_, err = pool.Exec(ctx, `
+		CREATE TABLE position_keeping.reservation (
+			lien_id uuid NOT NULL,
+			account_id character varying(255) NOT NULL,
+			instrument_code character varying(32) NOT NULL,
+			bucket_id character varying(256) NOT NULL DEFAULT '',
+			reserved_amount decimal(38, 18) NOT NULL,
+			status character varying(16) NOT NULL DEFAULT 'ACTIVE',
+			created_at timestamptz NOT NULL DEFAULT now(),
+			executed_at timestamptz NULL,
+			terminated_at timestamptz NULL,
+			PRIMARY KEY (lien_id),
+			CONSTRAINT chk_reservation_status CHECK (status IN ('ACTIVE', 'EXECUTED', 'TERMINATED'))
+		)
+	`)
+	require.NoError(t, err, "Failed to create reservation table")
+
+	// Create reservation indexes
+	_, err = pool.Exec(ctx, `
+		CREATE INDEX idx_reservation_projected_balance
+			ON position_keeping.reservation (account_id, instrument_code, status, bucket_id);
+		CREATE INDEX idx_reservation_active
+			ON position_keeping.reservation (account_id, instrument_code, bucket_id)
+			WHERE status = 'ACTIVE';
+	`)
+	require.NoError(t, err, "Failed to create reservation indexes")
 }

--- a/services/position-keeping/domain/repository.go
+++ b/services/position-keeping/domain/repository.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
 )
 
 var (
@@ -164,4 +165,24 @@ type PositionRepository interface {
 	//
 	// Use case: Drill-down from aggregated view to individual position records.
 	GetBucketDetails(ctx context.Context, accountID, instrumentCode, bucketKey string, limit, offset int) ([]*Position, error)
+}
+
+// ReservationRepository defines the contract for persisting and querying reservations.
+type ReservationRepository interface {
+	// Create persists a new Reservation.
+	// Returns ErrConflict if a reservation with the same lien_id already exists.
+	Create(ctx context.Context, reservation *Reservation) error
+
+	// FindByLienID retrieves a Reservation by its lien_id.
+	// Returns ErrReservationNotFound if not found.
+	FindByLienID(ctx context.Context, lienID uuid.UUID) (*Reservation, error)
+
+	// UpdateStatus transitions a reservation's status and sets the appropriate timestamp.
+	// Returns ErrReservationNotFound if not found.
+	UpdateStatus(ctx context.Context, lienID uuid.UUID, newStatus ReservationStatus) error
+
+	// SumActiveReservations returns the total reserved amount for active reservations
+	// matching the given account, instrument, and optional bucket filter.
+	// Returns zero if no active reservations exist.
+	SumActiveReservations(ctx context.Context, accountID, instrumentCode, bucketID string) (decimal.Decimal, error)
 }

--- a/services/position-keeping/domain/reservation.go
+++ b/services/position-keeping/domain/reservation.go
@@ -1,0 +1,125 @@
+package domain
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// ReservationStatus represents the lifecycle state of a reservation.
+type ReservationStatus string
+
+// Reservation lifecycle states.
+const (
+	ReservationStatusActive     ReservationStatus = "ACTIVE"
+	ReservationStatusExecuted   ReservationStatus = "EXECUTED"
+	ReservationStatusTerminated ReservationStatus = "TERMINATED"
+)
+
+// IsValid checks if the reservation status is a recognized value.
+func (s ReservationStatus) IsValid() bool {
+	switch s {
+	case ReservationStatusActive, ReservationStatusExecuted, ReservationStatusTerminated:
+		return true
+	}
+	return false
+}
+
+// IsTerminal returns true if this status represents a final state.
+func (s ReservationStatus) IsTerminal() bool {
+	return s == ReservationStatusExecuted || s == ReservationStatusTerminated
+}
+
+// String returns the string representation.
+func (s ReservationStatus) String() string {
+	return string(s)
+}
+
+// Reservation domain errors
+var (
+	ErrReservationNotFound     = errors.New("reservation not found")
+	ErrReservationAlreadyFinal = errors.New("reservation is already in a terminal state")
+	ErrInvalidReservationState = errors.New("invalid reservation status transition")
+	ErrEmptyLienID             = errors.New("lien_id cannot be empty")
+	ErrZeroReservedAmount      = errors.New("reserved_amount must be non-zero")
+)
+
+// Reservation represents a lien-based reservation against an account's position.
+// The lien_id serves as the primary key and natural idempotency key.
+type Reservation struct {
+	LienID         uuid.UUID
+	AccountID      string
+	InstrumentCode string
+	BucketID       string
+	ReservedAmount decimal.Decimal
+	Status         ReservationStatus
+	CreatedAt      time.Time
+	ExecutedAt     *time.Time
+	TerminatedAt   *time.Time
+}
+
+// NewReservation creates a new active reservation with validation.
+func NewReservation(
+	lienID uuid.UUID,
+	accountID string,
+	instrumentCode string,
+	bucketID string,
+	reservedAmount decimal.Decimal,
+) (*Reservation, error) {
+	if lienID == uuid.Nil {
+		return nil, ErrEmptyLienID
+	}
+	if accountID == "" {
+		return nil, ErrEmptyAccountID
+	}
+	if instrumentCode == "" {
+		return nil, ErrEmptyInstrumentCode
+	}
+	if reservedAmount.IsZero() {
+		return nil, ErrZeroReservedAmount
+	}
+
+	return &Reservation{
+		LienID:         lienID,
+		AccountID:      accountID,
+		InstrumentCode: instrumentCode,
+		BucketID:       bucketID,
+		ReservedAmount: reservedAmount,
+		Status:         ReservationStatusActive,
+		CreatedAt:      time.Now().UTC(),
+	}, nil
+}
+
+// Release transitions the reservation to a terminal state.
+func (r *Reservation) Release(reason ReservationStatus) error {
+	if r.Status.IsTerminal() {
+		return ErrReservationAlreadyFinal
+	}
+	if !reason.IsTerminal() {
+		return ErrInvalidReservationState
+	}
+
+	now := time.Now().UTC()
+	r.Status = reason
+	switch reason {
+	case ReservationStatusActive:
+		return ErrInvalidReservationState
+	case ReservationStatusExecuted:
+		r.ExecutedAt = &now
+	case ReservationStatusTerminated:
+		r.TerminatedAt = &now
+	}
+	return nil
+}
+
+// ProjectedBalance represents a calculated balance with reservation adjustments.
+type ProjectedBalance struct {
+	CurrentBalance          decimal.Decimal
+	ActiveReservationsTotal decimal.Decimal
+	ProjectedBalance        decimal.Decimal
+	BucketID                string
+	InstrumentCode          string
+	AsOf                    time.Time
+}

--- a/services/position-keeping/domain/reservation_test.go
+++ b/services/position-keeping/domain/reservation_test.go
@@ -1,0 +1,122 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewReservation(t *testing.T) {
+	t.Run("creates valid reservation", func(t *testing.T) {
+		lienID := uuid.New()
+		r, err := NewReservation(lienID, "acc-1", "GBP", "bucket-1", decimal.NewFromInt(100))
+		require.NoError(t, err)
+		assert.Equal(t, lienID, r.LienID)
+		assert.Equal(t, "acc-1", r.AccountID)
+		assert.Equal(t, "GBP", r.InstrumentCode)
+		assert.Equal(t, "bucket-1", r.BucketID)
+		assert.True(t, decimal.NewFromInt(100).Equal(r.ReservedAmount))
+		assert.Equal(t, ReservationStatusActive, r.Status)
+		assert.False(t, r.CreatedAt.IsZero())
+		assert.Nil(t, r.ExecutedAt)
+		assert.Nil(t, r.TerminatedAt)
+	})
+
+	t.Run("rejects nil lien_id", func(t *testing.T) {
+		_, err := NewReservation(uuid.Nil, "acc-1", "GBP", "", decimal.NewFromInt(100))
+		assert.ErrorIs(t, err, ErrEmptyLienID)
+	})
+
+	t.Run("rejects empty account_id", func(t *testing.T) {
+		_, err := NewReservation(uuid.New(), "", "GBP", "", decimal.NewFromInt(100))
+		assert.ErrorIs(t, err, ErrEmptyAccountID)
+	})
+
+	t.Run("rejects empty instrument_code", func(t *testing.T) {
+		_, err := NewReservation(uuid.New(), "acc-1", "", "", decimal.NewFromInt(100))
+		assert.ErrorIs(t, err, ErrEmptyInstrumentCode)
+	})
+
+	t.Run("rejects zero amount", func(t *testing.T) {
+		_, err := NewReservation(uuid.New(), "acc-1", "GBP", "", decimal.Zero)
+		assert.ErrorIs(t, err, ErrZeroReservedAmount)
+	})
+
+	t.Run("allows empty bucket_id", func(t *testing.T) {
+		r, err := NewReservation(uuid.New(), "acc-1", "GBP", "", decimal.NewFromInt(50))
+		require.NoError(t, err)
+		assert.Equal(t, "", r.BucketID)
+	})
+
+	t.Run("allows negative amount (debit reservation)", func(t *testing.T) {
+		r, err := NewReservation(uuid.New(), "acc-1", "GBP", "", decimal.NewFromInt(-50))
+		require.NoError(t, err)
+		assert.True(t, decimal.NewFromInt(-50).Equal(r.ReservedAmount))
+	})
+}
+
+func TestReservation_Release(t *testing.T) {
+	t.Run("transitions to executed", func(t *testing.T) {
+		r, err := NewReservation(uuid.New(), "acc-1", "GBP", "", decimal.NewFromInt(100))
+		require.NoError(t, err)
+
+		err = r.Release(ReservationStatusExecuted)
+		require.NoError(t, err)
+		assert.Equal(t, ReservationStatusExecuted, r.Status)
+		assert.NotNil(t, r.ExecutedAt)
+		assert.Nil(t, r.TerminatedAt)
+	})
+
+	t.Run("transitions to terminated", func(t *testing.T) {
+		r, err := NewReservation(uuid.New(), "acc-1", "GBP", "", decimal.NewFromInt(100))
+		require.NoError(t, err)
+
+		err = r.Release(ReservationStatusTerminated)
+		require.NoError(t, err)
+		assert.Equal(t, ReservationStatusTerminated, r.Status)
+		assert.Nil(t, r.ExecutedAt)
+		assert.NotNil(t, r.TerminatedAt)
+	})
+
+	t.Run("rejects release of already executed reservation", func(t *testing.T) {
+		r, err := NewReservation(uuid.New(), "acc-1", "GBP", "", decimal.NewFromInt(100))
+		require.NoError(t, err)
+		require.NoError(t, r.Release(ReservationStatusExecuted))
+
+		err = r.Release(ReservationStatusTerminated)
+		assert.ErrorIs(t, err, ErrReservationAlreadyFinal)
+	})
+
+	t.Run("rejects release of already terminated reservation", func(t *testing.T) {
+		r, err := NewReservation(uuid.New(), "acc-1", "GBP", "", decimal.NewFromInt(100))
+		require.NoError(t, err)
+		require.NoError(t, r.Release(ReservationStatusTerminated))
+
+		err = r.Release(ReservationStatusExecuted)
+		assert.ErrorIs(t, err, ErrReservationAlreadyFinal)
+	})
+
+	t.Run("rejects release to ACTIVE", func(t *testing.T) {
+		r, err := NewReservation(uuid.New(), "acc-1", "GBP", "", decimal.NewFromInt(100))
+		require.NoError(t, err)
+
+		err = r.Release(ReservationStatusActive)
+		assert.ErrorIs(t, err, ErrInvalidReservationState)
+	})
+}
+
+func TestReservationStatus_IsValid(t *testing.T) {
+	assert.True(t, ReservationStatusActive.IsValid())
+	assert.True(t, ReservationStatusExecuted.IsValid())
+	assert.True(t, ReservationStatusTerminated.IsValid())
+	assert.False(t, ReservationStatus("INVALID").IsValid())
+}
+
+func TestReservationStatus_IsTerminal(t *testing.T) {
+	assert.False(t, ReservationStatusActive.IsTerminal())
+	assert.True(t, ReservationStatusExecuted.IsTerminal())
+	assert.True(t, ReservationStatusTerminated.IsTerminal())
+}

--- a/services/position-keeping/migrations/20260207000001_reservations.sql
+++ b/services/position-keeping/migrations/20260207000001_reservations.sql
@@ -1,0 +1,33 @@
+-- Reservations Table Migration
+-- Tracks lien-based reservations for projected balance calculations.
+-- Each reservation is linked to a lien_id from Current Account and holds a reserved amount
+-- against an account's position until the reservation is executed or terminated.
+
+CREATE TABLE "reservation" (
+  "lien_id" uuid NOT NULL,
+  "account_id" character varying(255) NOT NULL,
+  "instrument_code" character varying(32) NOT NULL,
+  "bucket_id" character varying(256) NOT NULL DEFAULT '',
+  "reserved_amount" decimal(38, 18) NOT NULL,
+  "status" character varying(16) NOT NULL DEFAULT 'ACTIVE',
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "executed_at" timestamptz NULL,
+  "terminated_at" timestamptz NULL,
+  PRIMARY KEY ("lien_id")
+);
+
+-- Check constraint for valid status values
+ALTER TABLE "reservation"
+  ADD CONSTRAINT "chk_reservation_status"
+  CHECK ("status" IN ('ACTIVE', 'EXECUTED', 'TERMINATED'));
+
+-- Index for projected balance queries: filter by account, instrument, status, and bucket
+CREATE INDEX "idx_reservation_projected_balance"
+  ON "reservation" ("account_id", "instrument_code", "status", "bucket_id");
+
+-- Index for active reservations lookup (partial index for efficiency)
+CREATE INDEX "idx_reservation_active"
+  ON "reservation" ("account_id", "instrument_code", "bucket_id")
+  WHERE "status" = 'ACTIVE';
+
+COMMENT ON TABLE "reservation" IS 'Lien-based reservations for projected balance calculations. Primary key is lien_id for natural idempotency.';

--- a/services/position-keeping/migrations/atlas.sum
+++ b/services/position-keeping/migrations/atlas.sum
@@ -1,4 +1,4 @@
-h1:nNkef7wRc4/Z8mrf3G3lv79HsN1hy20ZAmgdJrxLBqs=
+h1:QJ2b6FxLJmoE5P9J7aJt0Tkrq35StF8P5lKL5rlNeHs=
 20251216000001_initial.sql h1:4EgK5DDjh15OYo42dfUlBrTzhBlS4CJb8JntemJZxhU=
 20251217000001_audit_system.sql h1:f4dmYIvuu7PO3v7Vhcpb05RNo+EQEakHJ0mMv2tbZ6I=
 20251223000001_event_outbox.sql h1:NgNG789HKYeLuHhlb96LuVXEv2L4m/tRUfk03kZOXj4=
@@ -9,3 +9,4 @@ h1:nNkef7wRc4/Z8mrf3G3lv79HsN1hy20ZAmgdJrxLBqs=
 20260105000002_positions_append_only.sql h1:MidtRAkkNMPYJ+Nj3qkqf8TirH6lwyjmxV16e8LqeTM=
 20260105000003_rebucketing_audit_log.sql h1:8sX9nNzhkm39LZZJ+SpGczdz59sP2EVehLKiHFU765A=
 20260105000004_import_manifest.sql h1:LAxAXwZgNoGtAhJzl7KYkHF/6K1pVY9fLSzd7bvNp6Q=
+20260207000001_reservations.sql h1:WqCeC3OwofKNttN3jVQPDKPonOzAGlHkzrkdltD0c34=

--- a/services/position-keeping/service/reservation.go
+++ b/services/position-keeping/service/reservation.go
@@ -1,0 +1,187 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+)
+
+// RecordReservation creates a reservation linked to a lien.
+// Idempotent by lien_id: if a reservation already exists, returns success with already_exists=true.
+func (s *PositionKeepingService) RecordReservation(
+	ctx context.Context,
+	req *positionkeepingv1.RecordReservationRequest,
+) (*positionkeepingv1.RecordReservationResponse, error) {
+	if s.reservationRepo == nil {
+		return nil, status.Error(codes.FailedPrecondition, "reservation repository not configured")
+	}
+
+	// Parse and validate lien_id
+	lienID, err := parseUUID(req.GetLienId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid lien_id: %v", err)
+	}
+
+	// Parse reserved amount
+	reservedAmount, err := decimal.NewFromString(req.GetReservedAmount())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid reserved_amount: %v", err)
+	}
+
+	// Validate required fields
+	if req.GetAccountId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_id is required")
+	}
+	if req.GetInstrumentCode() == "" {
+		return nil, status.Error(codes.InvalidArgument, "instrument_code is required")
+	}
+
+	// Create domain reservation
+	reservation, err := domain.NewReservation(
+		lienID,
+		req.GetAccountId(),
+		req.GetInstrumentCode(),
+		req.GetBucketId(),
+		reservedAmount,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid reservation: %v", err)
+	}
+
+	// Persist
+	err = s.reservationRepo.Create(ctx, reservation)
+	if err != nil {
+		if errors.Is(err, domain.ErrConflict) {
+			// Idempotent: reservation already exists for this lien_id
+			return &positionkeepingv1.RecordReservationResponse{
+				ReservationId: lienID.String(),
+				AlreadyExists: true,
+			}, nil
+		}
+		return nil, status.Errorf(codes.Internal, "failed to create reservation: %v", err)
+	}
+
+	return &positionkeepingv1.RecordReservationResponse{
+		ReservationId: lienID.String(),
+		AlreadyExists: false,
+	}, nil
+}
+
+// ReleaseReservation transitions a reservation to EXECUTED or TERMINATED.
+func (s *PositionKeepingService) ReleaseReservation(
+	ctx context.Context,
+	req *positionkeepingv1.ReleaseReservationRequest,
+) (*positionkeepingv1.ReleaseReservationResponse, error) {
+	if s.reservationRepo == nil {
+		return nil, status.Error(codes.FailedPrecondition, "reservation repository not configured")
+	}
+
+	// Parse lien_id
+	lienID, err := parseUUID(req.GetLienId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid lien_id: %v", err)
+	}
+
+	// Convert proto reason to domain status
+	var newStatus domain.ReservationStatus
+	switch req.GetReason() {
+	case positionkeepingv1.ReservationStatus_RESERVATION_STATUS_EXECUTED:
+		newStatus = domain.ReservationStatusExecuted
+	case positionkeepingv1.ReservationStatus_RESERVATION_STATUS_TERMINATED:
+		newStatus = domain.ReservationStatusTerminated
+	case positionkeepingv1.ReservationStatus_RESERVATION_STATUS_UNSPECIFIED,
+		positionkeepingv1.ReservationStatus_RESERVATION_STATUS_ACTIVE:
+		return nil, status.Errorf(codes.InvalidArgument, "reason must be EXECUTED or TERMINATED, got %v", req.GetReason())
+	}
+
+	// Update status
+	err = s.reservationRepo.UpdateStatus(ctx, lienID, newStatus)
+	if err != nil {
+		if errors.Is(err, domain.ErrReservationNotFound) {
+			return nil, status.Errorf(codes.NotFound, "reservation not found for lien_id: %s", lienID)
+		}
+		if errors.Is(err, domain.ErrReservationAlreadyFinal) {
+			return nil, status.Errorf(codes.FailedPrecondition, "reservation is already in a terminal state")
+		}
+		return nil, status.Errorf(codes.Internal, "failed to release reservation: %v", err)
+	}
+
+	return &positionkeepingv1.ReleaseReservationResponse{
+		Released: true,
+	}, nil
+}
+
+// GetProjectedBalance calculates the projected balance accounting for active reservations.
+func (s *PositionKeepingService) GetProjectedBalance(
+	ctx context.Context,
+	req *positionkeepingv1.GetProjectedBalanceRequest,
+) (*positionkeepingv1.GetProjectedBalanceResponse, error) {
+	if s.reservationRepo == nil {
+		return nil, status.Error(codes.FailedPrecondition, "reservation repository not configured")
+	}
+	if s.positionRepo == nil {
+		return nil, status.Error(codes.FailedPrecondition, "position repository not configured")
+	}
+
+	// Validate required fields
+	if req.GetAccountId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_id is required")
+	}
+	if req.GetInstrumentCode() == "" {
+		return nil, status.Error(codes.InvalidArgument, "instrument_code is required")
+	}
+
+	accountID := req.GetAccountId()
+	instrumentCode := req.GetInstrumentCode()
+	bucketID := req.GetBucketId()
+
+	// Get current balance from position entries
+	var currentBalance decimal.Decimal
+	if bucketID != "" {
+		// Query specific bucket
+		agg, err := s.positionRepo.GetAggregatedPosition(ctx, accountID, instrumentCode, bucketID)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to query position balance: %v", err)
+		}
+		if agg != nil {
+			currentBalance = agg.TotalAmount
+		}
+	} else {
+		// Query all buckets for this account/instrument
+		aggs, err := s.positionRepo.GetAggregatedPositions(ctx, accountID, instrumentCode)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to query position balances: %v", err)
+		}
+		for _, agg := range aggs {
+			currentBalance = currentBalance.Add(agg.TotalAmount)
+		}
+	}
+
+	// Get sum of active reservations
+	activeReservationsTotal, err := s.reservationRepo.SumActiveReservations(ctx, accountID, instrumentCode, bucketID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to sum active reservations: %v", err)
+	}
+
+	// Calculate projected balance = current - active_reservations
+	projectedBalance := currentBalance.Sub(activeReservationsTotal)
+
+	asOf := time.Now().UTC()
+
+	return &positionkeepingv1.GetProjectedBalanceResponse{
+		CurrentBalance:          currentBalance.String(),
+		ActiveReservationsTotal: activeReservationsTotal.String(),
+		ProjectedBalance:        projectedBalance.String(),
+		BucketId:                bucketID,
+		InstrumentCode:          instrumentCode,
+		AsOf:                    timestamppb.New(asOf),
+	}, nil
+}

--- a/services/position-keeping/service/reservation_test.go
+++ b/services/position-keeping/service/reservation_test.go
@@ -1,0 +1,474 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/meridianhub/meridian/services/position-keeping/domain"
+	"github.com/meridianhub/meridian/services/position-keeping/service"
+)
+
+// MockReservationRepository is a mock implementation of domain.ReservationRepository.
+type MockReservationRepository struct {
+	mock.Mock
+}
+
+func (m *MockReservationRepository) Create(ctx context.Context, reservation *domain.Reservation) error {
+	args := m.Called(ctx, reservation)
+	return args.Error(0)
+}
+
+func (m *MockReservationRepository) FindByLienID(ctx context.Context, lienID uuid.UUID) (*domain.Reservation, error) {
+	args := m.Called(ctx, lienID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Reservation), args.Error(1)
+}
+
+func (m *MockReservationRepository) UpdateStatus(ctx context.Context, lienID uuid.UUID, newStatus domain.ReservationStatus) error {
+	args := m.Called(ctx, lienID, newStatus)
+	return args.Error(0)
+}
+
+func (m *MockReservationRepository) SumActiveReservations(ctx context.Context, accountID, instrumentCode, bucketID string) (decimal.Decimal, error) {
+	args := m.Called(ctx, accountID, instrumentCode, bucketID)
+	return args.Get(0).(decimal.Decimal), args.Error(1)
+}
+
+// MockPositionRepository is a mock implementation of domain.PositionRepository.
+type MockPositionRepository struct {
+	mock.Mock
+}
+
+func (m *MockPositionRepository) Insert(ctx context.Context, position *domain.Position) error {
+	args := m.Called(ctx, position)
+	return args.Error(0)
+}
+
+func (m *MockPositionRepository) InsertBatch(ctx context.Context, positions []*domain.Position) error {
+	args := m.Called(ctx, positions)
+	return args.Error(0)
+}
+
+func (m *MockPositionRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.Position, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Position), args.Error(1)
+}
+
+func (m *MockPositionRepository) GetAggregatedPosition(ctx context.Context, accountID, instrumentCode, bucketKey string) (*domain.AggregatedPosition, error) {
+	args := m.Called(ctx, accountID, instrumentCode, bucketKey)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.AggregatedPosition), args.Error(1)
+}
+
+func (m *MockPositionRepository) ListByAccount(ctx context.Context, accountID string, limit, offset int) ([]*domain.Position, error) {
+	args := m.Called(ctx, accountID, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.Position), args.Error(1)
+}
+
+func (m *MockPositionRepository) ListAggregatedByAccount(ctx context.Context, accountID string) ([]*domain.AggregatedPosition, error) {
+	args := m.Called(ctx, accountID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.AggregatedPosition), args.Error(1)
+}
+
+func (m *MockPositionRepository) GetPositionCount(ctx context.Context, accountID string) (int64, error) {
+	args := m.Called(ctx, accountID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockPositionRepository) GetAggregatedPositions(ctx context.Context, accountID, instrumentCode string) ([]*domain.AggregatedPosition, error) {
+	args := m.Called(ctx, accountID, instrumentCode)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.AggregatedPosition), args.Error(1)
+}
+
+func (m *MockPositionRepository) GetBucketDetails(ctx context.Context, accountID, instrumentCode, bucketKey string, limit, offset int) ([]*domain.Position, error) {
+	args := m.Called(ctx, accountID, instrumentCode, bucketKey, limit, offset)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.Position), args.Error(1)
+}
+
+func newServiceWithReservation(t *testing.T, reservationRepo domain.ReservationRepository, positionRepo domain.PositionRepository) *service.PositionKeepingService {
+	t.Helper()
+	repo := new(MockRepository)
+	measurementRepo := new(MockMeasurementRepository)
+	publisher := domain.NewInMemoryEventPublisher()
+	idempotencySvc := new(MockIdempotencyService)
+
+	var opts []service.Option
+	if reservationRepo != nil {
+		opts = append(opts, service.WithReservationRepository(reservationRepo))
+	}
+	if positionRepo != nil {
+		opts = append(opts, service.WithPositionRepository(positionRepo))
+	}
+
+	svc, err := service.NewPositionKeepingService(repo, measurementRepo, publisher, idempotencySvc, opts...)
+	require.NoError(t, err)
+	return svc
+}
+
+func TestRecordReservation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("creates new reservation", func(t *testing.T) {
+		reservationRepo := new(MockReservationRepository)
+		reservationRepo.On("Create", ctx, mock.AnythingOfType("*domain.Reservation")).Return(nil)
+
+		svc := newServiceWithReservation(t, reservationRepo, nil)
+		lienID := uuid.New()
+
+		resp, err := svc.RecordReservation(ctx, &positionkeepingv1.RecordReservationRequest{
+			AccountId:      "acc-1",
+			LienId:         lienID.String(),
+			InstrumentCode: "GBP",
+			ReservedAmount: "100.00",
+			BucketId:       "bucket-1",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, lienID.String(), resp.ReservationId)
+		assert.False(t, resp.AlreadyExists)
+		reservationRepo.AssertExpectations(t)
+	})
+
+	t.Run("returns already_exists for duplicate lien_id", func(t *testing.T) {
+		reservationRepo := new(MockReservationRepository)
+		reservationRepo.On("Create", ctx, mock.AnythingOfType("*domain.Reservation")).Return(domain.ErrConflict)
+
+		svc := newServiceWithReservation(t, reservationRepo, nil)
+		lienID := uuid.New()
+
+		resp, err := svc.RecordReservation(ctx, &positionkeepingv1.RecordReservationRequest{
+			AccountId:      "acc-1",
+			LienId:         lienID.String(),
+			InstrumentCode: "GBP",
+			ReservedAmount: "100.00",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, lienID.String(), resp.ReservationId)
+		assert.True(t, resp.AlreadyExists)
+	})
+
+	t.Run("rejects empty account_id", func(t *testing.T) {
+		svc := newServiceWithReservation(t, new(MockReservationRepository), nil)
+
+		_, err := svc.RecordReservation(ctx, &positionkeepingv1.RecordReservationRequest{
+			LienId:         uuid.New().String(),
+			InstrumentCode: "GBP",
+			ReservedAmount: "100.00",
+		})
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("rejects invalid lien_id", func(t *testing.T) {
+		svc := newServiceWithReservation(t, new(MockReservationRepository), nil)
+
+		_, err := svc.RecordReservation(ctx, &positionkeepingv1.RecordReservationRequest{
+			AccountId:      "acc-1",
+			LienId:         "not-a-uuid",
+			InstrumentCode: "GBP",
+			ReservedAmount: "100.00",
+		})
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("rejects invalid amount", func(t *testing.T) {
+		svc := newServiceWithReservation(t, new(MockReservationRepository), nil)
+
+		_, err := svc.RecordReservation(ctx, &positionkeepingv1.RecordReservationRequest{
+			AccountId:      "acc-1",
+			LienId:         uuid.New().String(),
+			InstrumentCode: "GBP",
+			ReservedAmount: "not-a-number",
+		})
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns FailedPrecondition when repo not configured", func(t *testing.T) {
+		svc := newServiceWithReservation(t, nil, nil)
+
+		_, err := svc.RecordReservation(ctx, &positionkeepingv1.RecordReservationRequest{
+			AccountId:      "acc-1",
+			LienId:         uuid.New().String(),
+			InstrumentCode: "GBP",
+			ReservedAmount: "100.00",
+		})
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+}
+
+func TestReleaseReservation(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("releases to EXECUTED", func(t *testing.T) {
+		reservationRepo := new(MockReservationRepository)
+		lienID := uuid.New()
+		reservationRepo.On("UpdateStatus", ctx, lienID, domain.ReservationStatusExecuted).Return(nil)
+
+		svc := newServiceWithReservation(t, reservationRepo, nil)
+
+		resp, err := svc.ReleaseReservation(ctx, &positionkeepingv1.ReleaseReservationRequest{
+			LienId: lienID.String(),
+			Reason: positionkeepingv1.ReservationStatus_RESERVATION_STATUS_EXECUTED,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, resp.Released)
+		reservationRepo.AssertExpectations(t)
+	})
+
+	t.Run("releases to TERMINATED", func(t *testing.T) {
+		reservationRepo := new(MockReservationRepository)
+		lienID := uuid.New()
+		reservationRepo.On("UpdateStatus", ctx, lienID, domain.ReservationStatusTerminated).Return(nil)
+
+		svc := newServiceWithReservation(t, reservationRepo, nil)
+
+		resp, err := svc.ReleaseReservation(ctx, &positionkeepingv1.ReleaseReservationRequest{
+			LienId: lienID.String(),
+			Reason: positionkeepingv1.ReservationStatus_RESERVATION_STATUS_TERMINATED,
+		})
+
+		require.NoError(t, err)
+		assert.True(t, resp.Released)
+	})
+
+	t.Run("returns NotFound for missing reservation", func(t *testing.T) {
+		reservationRepo := new(MockReservationRepository)
+		lienID := uuid.New()
+		reservationRepo.On("UpdateStatus", ctx, lienID, domain.ReservationStatusExecuted).Return(domain.ErrReservationNotFound)
+
+		svc := newServiceWithReservation(t, reservationRepo, nil)
+
+		_, err := svc.ReleaseReservation(ctx, &positionkeepingv1.ReleaseReservationRequest{
+			LienId: lienID.String(),
+			Reason: positionkeepingv1.ReservationStatus_RESERVATION_STATUS_EXECUTED,
+		})
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("returns FailedPrecondition for already terminal reservation", func(t *testing.T) {
+		reservationRepo := new(MockReservationRepository)
+		lienID := uuid.New()
+		reservationRepo.On("UpdateStatus", ctx, lienID, domain.ReservationStatusExecuted).Return(domain.ErrReservationAlreadyFinal)
+
+		svc := newServiceWithReservation(t, reservationRepo, nil)
+
+		_, err := svc.ReleaseReservation(ctx, &positionkeepingv1.ReleaseReservationRequest{
+			LienId: lienID.String(),
+			Reason: positionkeepingv1.ReservationStatus_RESERVATION_STATUS_EXECUTED,
+		})
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+
+	t.Run("rejects invalid reason", func(t *testing.T) {
+		svc := newServiceWithReservation(t, new(MockReservationRepository), nil)
+
+		_, err := svc.ReleaseReservation(ctx, &positionkeepingv1.ReleaseReservationRequest{
+			LienId: uuid.New().String(),
+			Reason: positionkeepingv1.ReservationStatus_RESERVATION_STATUS_ACTIVE,
+		})
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+}
+
+func TestGetProjectedBalance(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns projected balance with bucket filter", func(t *testing.T) {
+		reservationRepo := new(MockReservationRepository)
+		positionRepo := new(MockPositionRepository)
+
+		positionRepo.On("GetAggregatedPosition", ctx, "acc-1", "GBP", "bucket-1").
+			Return(&domain.AggregatedPosition{TotalAmount: decimal.NewFromInt(1000)}, nil)
+		reservationRepo.On("SumActiveReservations", ctx, "acc-1", "GBP", "bucket-1").
+			Return(decimal.NewFromInt(200), nil)
+
+		svc := newServiceWithReservation(t, reservationRepo, positionRepo)
+
+		resp, err := svc.GetProjectedBalance(ctx, &positionkeepingv1.GetProjectedBalanceRequest{
+			AccountId:      "acc-1",
+			InstrumentCode: "GBP",
+			BucketId:       "bucket-1",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "1000", resp.CurrentBalance)
+		assert.Equal(t, "200", resp.ActiveReservationsTotal)
+		assert.Equal(t, "800", resp.ProjectedBalance)
+		assert.Equal(t, "bucket-1", resp.BucketId)
+		assert.Equal(t, "GBP", resp.InstrumentCode)
+	})
+
+	t.Run("returns projected balance without bucket filter", func(t *testing.T) {
+		reservationRepo := new(MockReservationRepository)
+		positionRepo := new(MockPositionRepository)
+
+		positionRepo.On("GetAggregatedPositions", ctx, "acc-1", "GBP").
+			Return([]*domain.AggregatedPosition{
+				{TotalAmount: decimal.NewFromInt(500)},
+				{TotalAmount: decimal.NewFromInt(300)},
+			}, nil)
+		reservationRepo.On("SumActiveReservations", ctx, "acc-1", "GBP", "").
+			Return(decimal.NewFromInt(100), nil)
+
+		svc := newServiceWithReservation(t, reservationRepo, positionRepo)
+
+		resp, err := svc.GetProjectedBalance(ctx, &positionkeepingv1.GetProjectedBalanceRequest{
+			AccountId:      "acc-1",
+			InstrumentCode: "GBP",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "800", resp.CurrentBalance)
+		assert.Equal(t, "100", resp.ActiveReservationsTotal)
+		assert.Equal(t, "700", resp.ProjectedBalance)
+	})
+
+	t.Run("returns zero balance when no positions exist", func(t *testing.T) {
+		reservationRepo := new(MockReservationRepository)
+		positionRepo := new(MockPositionRepository)
+
+		positionRepo.On("GetAggregatedPosition", ctx, "acc-1", "GBP", "bucket-1").
+			Return(nil, nil)
+		reservationRepo.On("SumActiveReservations", ctx, "acc-1", "GBP", "bucket-1").
+			Return(decimal.Zero, nil)
+
+		svc := newServiceWithReservation(t, reservationRepo, positionRepo)
+
+		resp, err := svc.GetProjectedBalance(ctx, &positionkeepingv1.GetProjectedBalanceRequest{
+			AccountId:      "acc-1",
+			InstrumentCode: "GBP",
+			BucketId:       "bucket-1",
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, "0", resp.CurrentBalance)
+		assert.Equal(t, "0", resp.ActiveReservationsTotal)
+		assert.Equal(t, "0", resp.ProjectedBalance)
+	})
+
+	t.Run("rejects empty account_id", func(t *testing.T) {
+		svc := newServiceWithReservation(t, new(MockReservationRepository), new(MockPositionRepository))
+
+		_, err := svc.GetProjectedBalance(ctx, &positionkeepingv1.GetProjectedBalanceRequest{
+			InstrumentCode: "GBP",
+		})
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("rejects empty instrument_code", func(t *testing.T) {
+		svc := newServiceWithReservation(t, new(MockReservationRepository), new(MockPositionRepository))
+
+		_, err := svc.GetProjectedBalance(ctx, &positionkeepingv1.GetProjectedBalanceRequest{
+			AccountId: "acc-1",
+		})
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("returns FailedPrecondition when repos not configured", func(t *testing.T) {
+		svc := newServiceWithReservation(t, nil, nil)
+
+		_, err := svc.GetProjectedBalance(ctx, &positionkeepingv1.GetProjectedBalanceRequest{
+			AccountId:      "acc-1",
+			InstrumentCode: "GBP",
+		})
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.FailedPrecondition, st.Code())
+	})
+}
+
+func TestRecordReservation_Idempotency(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("three retries with same lien_id all succeed", func(t *testing.T) {
+		reservationRepo := new(MockReservationRepository)
+
+		// First call: create succeeds
+		reservationRepo.On("Create", ctx, mock.AnythingOfType("*domain.Reservation")).Return(nil).Once()
+		// Second and third calls: conflict (already exists)
+		reservationRepo.On("Create", ctx, mock.AnythingOfType("*domain.Reservation")).Return(domain.ErrConflict).Twice()
+
+		svc := newServiceWithReservation(t, reservationRepo, nil)
+		lienID := uuid.New()
+
+		req := &positionkeepingv1.RecordReservationRequest{
+			AccountId:      "acc-1",
+			LienId:         lienID.String(),
+			InstrumentCode: "GBP",
+			ReservedAmount: "100.00",
+		}
+
+		// First call
+		resp1, err := svc.RecordReservation(ctx, req)
+		require.NoError(t, err)
+		assert.False(t, resp1.AlreadyExists)
+		assert.Equal(t, lienID.String(), resp1.ReservationId)
+
+		// Second call
+		resp2, err := svc.RecordReservation(ctx, req)
+		require.NoError(t, err)
+		assert.True(t, resp2.AlreadyExists)
+
+		// Third call
+		resp3, err := svc.RecordReservation(ctx, req)
+		require.NoError(t, err)
+		assert.True(t, resp3.AlreadyExists)
+	})
+}

--- a/services/position-keeping/service/service.go
+++ b/services/position-keeping/service/service.go
@@ -58,6 +58,10 @@ type PositionKeepingService struct {
 	// Both this flag and accountValidator must be set for validation to occur.
 	// Defaults to false for backwards compatibility.
 	accountValidationEnabled bool
+	// reservationRepo is OPTIONAL - if nil, reservation RPCs return FailedPrecondition.
+	reservationRepo domain.ReservationRepository
+	// positionRepo is OPTIONAL - if nil, projected balance RPCs return FailedPrecondition.
+	positionRepo domain.PositionRepository
 }
 
 // Option configures optional dependencies for PositionKeepingService.
@@ -107,6 +111,22 @@ func WithAccountValidator(validator AccountValidator) Option {
 func WithAccountValidationEnabled(enabled bool) Option {
 	return func(s *PositionKeepingService) {
 		s.accountValidationEnabled = enabled
+	}
+}
+
+// WithReservationRepository sets the reservation repository for reservation RPCs.
+// If not set, RecordReservation, ReleaseReservation, and GetProjectedBalance return FailedPrecondition.
+func WithReservationRepository(repo domain.ReservationRepository) Option {
+	return func(s *PositionKeepingService) {
+		s.reservationRepo = repo
+	}
+}
+
+// WithPositionRepository sets the position repository for projected balance queries.
+// If not set, GetProjectedBalance returns FailedPrecondition.
+func WithPositionRepository(repo domain.PositionRepository) Option {
+	return func(s *PositionKeepingService) {
+		s.positionRepo = repo
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add reservation table migration with ACTIVE/EXECUTED/TERMINATED lifecycle constraints and lien_id as natural idempotency key
- Implement RecordReservation, ReleaseReservation, and GetProjectedBalance gRPC RPCs with proto definitions
- Add ReservationRepository with PostgreSQL persistence including conflict detection, terminal state guards, and SumActiveReservations with bucket filtering
- Projected balance formula: current_balance - active_reservations_total, with optional bucket-level scoping

## Changes

### Migration (subtask 7.1)
- `services/position-keeping/migrations/20260207000001_reservations.sql`: Creates `reservation` table with CHECK constraint on status, composite indexes for projected balance queries, and partial index on active reservations

### Domain (subtask 7.1)
- `services/position-keeping/domain/reservation.go`: ReservationStatus type with lifecycle states, Reservation struct with validation, Release() method for status transitions, ProjectedBalance struct, domain errors

### Proto (subtasks 7.2-7.4)
- `api/proto/meridian/position_keeping/v1/position_keeping.proto`: ReservationStatus enum, request/response messages, and three new RPCs on PositionKeepingService

### Persistence (subtask 7.2-7.4)
- `services/position-keeping/adapters/persistence/reservation_repository.go`: PostgreSQL implementation with multi-tenant search_path support, lien_id conflict detection for idempotency, terminal state guards, and SUM aggregation with optional bucket filtering
- `services/position-keeping/domain/repository.go`: Added ReservationRepository interface

### Service Layer (subtasks 7.2-7.4)
- `services/position-keeping/service/reservation.go`: gRPC handlers for RecordReservation (idempotent by lien_id), ReleaseReservation (EXECUTED/TERMINATED transitions), GetProjectedBalance (current - active reservations)
- `services/position-keeping/service/service.go`: Added WithReservationRepository and WithPositionRepository optional dependency injection

### Tests
- `services/position-keeping/domain/reservation_test.go`: 12 unit tests covering validation, status transitions, edge cases
- `services/position-keeping/service/reservation_test.go`: 18 unit tests with mock repositories covering all RPCs, error paths, and idempotency
- `services/position-keeping/adapters/persistence/reservation_repository_test.go`: 12 integration tests with testcontainers covering CRUD, conflict detection, bucket filtering, instrument isolation, and full lifecycle

## Task Master
- Tag: `valuation-engine`
- Task: `valuation-engine.7` - Reservation Ledger and ProjectedBalance in Position Keeping
- Subtasks 7.1-7.4 implemented. Subtask 7.5 (bucket_id on existing Balance queries) deferred as it depends on the bucketing library (`shared/pkg/bucketing`) which does not yet exist.

## Test Plan
- [x] Domain unit tests pass (`go test -short ./services/position-keeping/domain/...`)
- [x] Service unit tests pass (`go test -short ./services/position-keeping/service/...`)
- [x] Integration tests pass (`go test ./services/position-keeping/adapters/persistence/...`)
- [ ] CI pipeline passes