### PR TITLE
feat: add EvaluateAssetValuation RPC and valuation engine to IBA

### DIFF
--- a/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
+++ b/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
@@ -4,6 +4,7 @@ package meridian.internal_bank_account.v1;
 
 import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
+import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 import "meridian/common/v1/types.proto";
 import "meridian/quantity/v1/quantity.proto";
@@ -682,6 +683,123 @@ message ListValuationFeaturesResponse {
 }
 
 // ========================================
+// Valuation Analysis Messages
+// ========================================
+
+// ValuationWarning represents a warning generated during valuation execution.
+// Warnings indicate degraded conditions that did not prevent computation
+// but may affect result confidence.
+message ValuationWarning {
+  // code is a machine-readable warning code (e.g., "STALE_MARKET_DATA", "MISSING_POLICY")
+  string code = 1;
+
+  // message is a human-readable description of the warning
+  string message = 2;
+
+  // severity indicates the warning impact: "INFO", "WARNING", "DEGRADED"
+  string severity = 3;
+}
+
+// MarketDataQuality describes the quality assessment of market data used in valuation.
+message MarketDataQuality {
+  // source identifies where the market data came from (e.g., "live_feed", "cache", "fallback")
+  string source = 1;
+
+  // quality_level indicates data quality: "ACTUAL", "ESTIMATE", "STALE", "FALLBACK"
+  string quality_level = 2;
+
+  // observed_at is when the market data was observed
+  google.protobuf.Timestamp observed_at = 3;
+
+  // staleness_seconds indicates how old the data is relative to valuation time
+  int64 staleness_seconds = 4;
+}
+
+// ValuationAnalysis provides transparency into how a valuation was computed.
+// Returned with both inquiry (EvaluateAssetValuation) and binding operations
+// to enable audit trails and Ghost Pricing prevention.
+message ValuationAnalysis {
+  // method_id is the valuation method used
+  string method_id = 1;
+
+  // method_version is the specific version of the method
+  string method_version = 2;
+
+  // applied_rates contains the rates/factors applied during valuation
+  // Key: rate name (e.g., "fx_rate", "spread"), Value: rate value as string
+  map<string, string> applied_rates = 3;
+
+  // observation_ids references the market data observations used
+  repeated string observation_ids = 4;
+
+  // computed_at is when the valuation was computed
+  google.protobuf.Timestamp computed_at = 5;
+
+  // knowledge_at is the point-in-time used for bi-temporal data resolution
+  google.protobuf.Timestamp knowledge_at = 6;
+
+  // account_parameters contains the account-specific valuation parameters (from ValuationFeature)
+  google.protobuf.Struct account_parameters = 7;
+
+  // market_data_qualities describes the quality of each market data source used
+  repeated MarketDataQuality market_data_qualities = 8;
+
+  // calculation_path describes the sequence of operations performed
+  repeated string calculation_path = 9;
+
+  // degraded_mode indicates whether the valuation ran in degraded mode
+  // (e.g., using stale cache data because live market data was unavailable)
+  bool degraded_mode = 10;
+
+  // warnings contains any warnings generated during valuation
+  repeated ValuationWarning warnings = 11;
+}
+
+// ========================================
+// Asset Valuation Messages
+// ========================================
+
+// Request to evaluate an asset valuation (inquiry-only, non-binding).
+// Returns the valuation result without creating any financial commitment.
+// CRITICAL: Uses the same valuateInternal() logic as any binding operation to prevent Ghost Pricing.
+message EvaluateAssetValuationRequest {
+  // account_id is the account to evaluate valuation for (required)
+  string account_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // input is the amount and instrument to be valued (required)
+  // Example: { amount: "100.00", instrument_code: "USD" } for a GBP account
+  meridian.quantity.v1.InstrumentAmount input = 2 [(buf.validate.field).required = true];
+
+  // knowledge_at is the point-in-time for bi-temporal data resolution (optional, defaults to now)
+  // Controls which valuation feature and market data are used
+  google.protobuf.Timestamp knowledge_at = 3;
+}
+
+// Response for evaluating an asset valuation (inquiry-only).
+message EvaluateAssetValuationResponse {
+  // output is the valued amount in the account's native instrument
+  // Example: { amount: "79.50", instrument_code: "GBP" } for USD->GBP conversion
+  meridian.quantity.v1.InstrumentAmount output = 1;
+
+  // basis provides full transparency into the valuation computation
+  ValuationAnalysis basis = 2;
+
+  // execution_time_ms is how long the valuation took to compute
+  string execution_time_ms = 3;
+
+  // cache_hit indicates whether the result was served from cache
+  bool cache_hit = 4;
+
+  // is_estimate indicates this is a non-binding inquiry result
+  // Always true for EvaluateAssetValuation responses
+  bool is_estimate = 5;
+}
+
+// ========================================
 // Service Definition
 // ========================================
 
@@ -811,6 +929,21 @@ service InternalBankAccountService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "Get a valuation feature"
       description: "Retrieves a valuation feature by ID or by account+instrument with optional bi-temporal query"
+    };
+  }
+
+  // EvaluateAssetValuation performs an inquiry-only (non-binding) valuation.
+  // Returns the estimated valued amount without creating any financial commitment.
+  // CRITICAL: Uses the same valuateInternal() logic as binding operations to prevent Ghost Pricing -
+  // ensuring inquiry and binding always produce identical results for identical inputs.
+  rpc EvaluateAssetValuation(EvaluateAssetValuationRequest) returns (EvaluateAssetValuationResponse) {
+    option (google.api.http) = {
+      post: "/v1/internal-bank-accounts/{account_id}/evaluate-valuation"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Evaluate asset valuation (inquiry-only)"
+      description: "Performs a non-binding valuation using the same logic as binding operations to prevent Ghost Pricing"
     };
   }
 

--- a/services/internal-bank-account/adapters/grpc/position_keeping_client.go
+++ b/services/internal-bank-account/adapters/grpc/position_keeping_client.go
@@ -244,6 +244,55 @@ func (c *PositionKeepingGRPCClient) handleGetAccountBalancesError(err error, acc
 	}
 }
 
+// GetAccountBalance retrieves a specific balance type for an account by instrument.
+//
+// Used by the valuation engine to query the current balance for an account's native instrument.
+// Includes the same retry logic as GetAccountBalances.
+func (c *PositionKeepingGRPCClient) GetAccountBalance(ctx context.Context, req *positionkeepingv1.GetAccountBalanceRequest) (*positionkeepingv1.GetAccountBalanceResponse, error) {
+	// Apply timeout
+	ctx, cancel := sharedclients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	// Propagate context metadata
+	ctx = sharedclients.PropagateCorrelationID(ctx)
+	ctx = sharedclients.PropagateOrganization(ctx)
+
+	var lastErr error
+	var resp *positionkeepingv1.GetAccountBalanceResponse
+
+	startTime := time.Now()
+
+	err := sharedclients.Retry(ctx, c.retryConfig, func() error {
+		var err error
+		resp, err = c.client.GetAccountBalance(ctx, req)
+		if err != nil {
+			lastErr = err
+			c.handleGetAccountBalancesError(err, req.AccountId)
+			return err
+		}
+		return nil
+	})
+
+	duration := time.Since(startTime)
+
+	if err != nil {
+		observability.RecordOperationDuration("get_account_balance", "error", duration)
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, err
+	}
+
+	observability.RecordOperationDuration("get_account_balance", "success", duration)
+	c.logger.Debug("retrieved account balance from Position Keeping",
+		"account_id", req.AccountId,
+		"instrument_code", req.InstrumentCode,
+		"duration_seconds", duration.Seconds(),
+	)
+
+	return resp, nil
+}
+
 // Close releases the gRPC client connection.
 func (c *PositionKeepingGRPCClient) Close() error {
 	if c.conn != nil {

--- a/services/internal-bank-account/benchmarks/helpers_test.go
+++ b/services/internal-bank-account/benchmarks/helpers_test.go
@@ -94,6 +94,28 @@ func (m *mockPositionKeepingClient) GetAccountBalances(ctx context.Context, req 
 	}, nil
 }
 
+// GetAccountBalance returns mock balance data for a single balance type.
+func (m *mockPositionKeepingClient) GetAccountBalance(ctx context.Context, req *positionkeepingv1.GetAccountBalanceRequest) (*positionkeepingv1.GetAccountBalanceResponse, error) {
+	if m.latency > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(m.latency):
+		}
+	}
+
+	return &positionkeepingv1.GetAccountBalanceResponse{
+		AccountId:   req.AccountId,
+		BalanceType: req.BalanceType,
+		Amount: &quantityv1.InstrumentAmount{
+			Amount:         "10000.00",
+			InstrumentCode: req.InstrumentCode,
+			Version:        1,
+		},
+		AsOf: timestamppb.Now(),
+	}, nil
+}
+
 // Close implements the PositionKeepingClient interface.
 func (m *mockPositionKeepingClient) Close() error {
 	return nil

--- a/services/internal-bank-account/e2e/e2e_test.go
+++ b/services/internal-bank-account/e2e/e2e_test.go
@@ -605,6 +605,18 @@ func (m *mockPositionKeepingClient) SetBalance(accountID, instrumentCode string,
 	}
 }
 
+func (m *mockPositionKeepingClient) GetAccountBalance(ctx context.Context, req *positionkeepingv1.GetAccountBalanceRequest) (*positionkeepingv1.GetAccountBalanceResponse, error) {
+	return &positionkeepingv1.GetAccountBalanceResponse{
+		AccountId:   req.AccountId,
+		BalanceType: req.BalanceType,
+		Amount: &quantitypb.InstrumentAmount{
+			Amount:         "0",
+			InstrumentCode: req.InstrumentCode,
+		},
+		AsOf: timestamppb.Now(),
+	}, nil
+}
+
 func (m *mockPositionKeepingClient) Close() error {
 	return nil
 }

--- a/services/internal-bank-account/service/client_interfaces.go
+++ b/services/internal-bank-account/service/client_interfaces.go
@@ -61,6 +61,17 @@ type PositionKeepingClient interface {
 	//   - InvalidArgument error if account_id format is invalid
 	GetAccountBalances(ctx context.Context, req *positionkeepingv1.GetAccountBalancesRequest) (*positionkeepingv1.GetAccountBalancesResponse, error)
 
+	// GetAccountBalance retrieves a specific balance type for an account by instrument.
+	//
+	// Used by the valuation engine to query the current balance for an account's native instrument.
+	// Returns the balance amount as InstrumentAmount with the requested balance type.
+	//
+	// Returns:
+	//   - GetAccountBalanceResponse with the balance amount on success
+	//   - NotFound error if no position exists for the account/instrument combination
+	//   - InvalidArgument error if account_id format is invalid
+	GetAccountBalance(ctx context.Context, req *positionkeepingv1.GetAccountBalanceRequest) (*positionkeepingv1.GetAccountBalanceResponse, error)
+
 	// Close terminates the client connection gracefully.
 	// Should be called during service shutdown to release gRPC resources.
 	Close() error

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -47,6 +47,7 @@ type Service struct {
 	valuationFeatureRepo  *persistence.ValuationFeatureRepository
 	positionKeepingClient PositionKeepingClient
 	referenceDataClient   ReferenceDataClient
+	valuationEngine       ValuationEngine // Optional: executes valuation method logic
 	logger                *slog.Logger
 	tracer                *observability.Tracer
 }
@@ -623,7 +624,7 @@ func (s *Service) findAccountByID(ctx context.Context, accountID string) (domain
 	if id, err := uuid.Parse(accountID); err == nil {
 		account, err := s.repo.FindByID(ctx, id)
 		if err != nil {
-			if errors.Is(err, domain.ErrAccountNotFound) {
+			if errors.Is(err, domain.ErrAccountNotFound) || errors.Is(err, persistence.ErrAccountNotFound) {
 				return domain.InternalBankAccount{}, status.Errorf(codes.NotFound, "account not found: %s", accountID)
 			}
 			return domain.InternalBankAccount{}, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)
@@ -634,7 +635,7 @@ func (s *Service) findAccountByID(ctx context.Context, accountID string) (domain
 	// Try to find by account code
 	account, err := s.repo.FindByCode(ctx, accountID)
 	if err != nil {
-		if errors.Is(err, domain.ErrAccountNotFound) {
+		if errors.Is(err, domain.ErrAccountNotFound) || errors.Is(err, persistence.ErrAccountNotFound) {
 			return domain.InternalBankAccount{}, status.Errorf(codes.NotFound, "account not found: %s", accountID)
 		}
 		return domain.InternalBankAccount{}, status.Errorf(codes.Internal, "failed to retrieve account: %v", err)

--- a/services/internal-bank-account/service/server_test.go
+++ b/services/internal-bank-account/service/server_test.go
@@ -89,8 +89,10 @@ func (m *mockRepository) ExistsByCode(_ context.Context, accountCode string) (bo
 
 // mockPositionKeepingClient implements PositionKeepingClient for testing.
 type mockPositionKeepingClient struct {
-	balances []*positionkeepingv1.BalanceEntry
-	err      error
+	balances       []*positionkeepingv1.BalanceEntry
+	err            error
+	singleBalance  *quantityv1.InstrumentAmount
+	singleBalError error
 }
 
 func (m *mockPositionKeepingClient) GetAccountBalances(_ context.Context, req *positionkeepingv1.GetAccountBalancesRequest) (*positionkeepingv1.GetAccountBalancesResponse, error) {
@@ -101,6 +103,25 @@ func (m *mockPositionKeepingClient) GetAccountBalances(_ context.Context, req *p
 		AccountId: req.AccountId,
 		Balances:  m.balances,
 		AsOf:      timestamppb.Now(), // Provide timestamp for balance calculation time
+	}, nil
+}
+
+func (m *mockPositionKeepingClient) GetAccountBalance(_ context.Context, req *positionkeepingv1.GetAccountBalanceRequest) (*positionkeepingv1.GetAccountBalanceResponse, error) {
+	if m.singleBalError != nil {
+		return nil, m.singleBalError
+	}
+	if m.singleBalance != nil {
+		return &positionkeepingv1.GetAccountBalanceResponse{
+			AccountId: req.AccountId,
+			Amount:    m.singleBalance,
+		}, nil
+	}
+	return &positionkeepingv1.GetAccountBalanceResponse{
+		AccountId: req.AccountId,
+		Amount: &quantityv1.InstrumentAmount{
+			InstrumentCode: req.InstrumentCode,
+			Amount:         "0",
+		},
 	}, nil
 }
 

--- a/services/internal-bank-account/service/valuation_engine.go
+++ b/services/internal-bank-account/service/valuation_engine.go
@@ -194,6 +194,9 @@ func (s *Service) valuateInternal(ctx context.Context, accountID string, inputAm
 		if err != nil {
 			return nil, fmt.Errorf("%w: %w", ErrValuationEngineFailed, err)
 		}
+		if result == nil {
+			return nil, fmt.Errorf("%w: nil result", ErrValuationEngineFailed)
+		}
 
 		executionMs := time.Since(start).Milliseconds()
 

--- a/services/internal-bank-account/service/valuation_engine.go
+++ b/services/internal-bank-account/service/valuation_engine.go
@@ -1,0 +1,367 @@
+// Package service implements gRPC services for the internal bank account domain.
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"github.com/meridianhub/meridian/services/internal-bank-account/adapters/persistence"
+	ibaobservability "github.com/meridianhub/meridian/services/internal-bank-account/observability"
+	"github.com/shopspring/decimal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// ValuationEngine defines the interface for executing valuations.
+// This abstraction allows the Internal Bank Account service to invoke valuation logic
+// without coupling to the implementation details of the valuation method execution.
+type ValuationEngine interface {
+	// Evaluate executes a valuation method with the given parameters.
+	// Returns the output amount and analysis, or an error if execution fails.
+	Evaluate(ctx context.Context, params ValuationParams) (*ValuationResult, error)
+}
+
+// ValuationParams contains the parameters for a valuation execution.
+type ValuationParams struct {
+	MethodID      uuid.UUID
+	MethodVersion int
+	InputAmount   decimal.Decimal
+	InputCode     string
+	OutputCode    string
+	Parameters    map[string]interface{}
+	KnowledgeAt   time.Time
+}
+
+// ValuationResult contains the result of a valuation execution.
+type ValuationResult struct {
+	OutputAmount    decimal.Decimal
+	OutputCode      string
+	AppliedRates    map[string]string
+	ObservationIDs  []string
+	ComputedAt      time.Time
+	CalculationPath []string
+	DegradedMode    bool
+	CacheHit        bool
+	Warnings        []ValuationWarningResult
+	MarketQualities []MarketDataQualityResult
+}
+
+// ValuationWarningResult holds warning information from valuation execution.
+type ValuationWarningResult struct {
+	Code     string
+	Message  string
+	Severity string
+}
+
+// MarketDataQualityResult holds market data quality information.
+type MarketDataQualityResult struct {
+	Source           string
+	QualityLevel     string
+	ObservedAt       time.Time
+	StalenessSeconds int64
+}
+
+// Valuation-specific sentinel errors for valuateInternal.
+var (
+	ErrValuationRepoNotConfigured = errors.New("valuation feature repository not configured")
+	ErrValuationAccountNotFound   = errors.New("account not found")
+	ErrNoActiveValuationFeature   = errors.New("no active valuation feature")
+	ErrValuationFeatureNotActive  = errors.New("valuation feature not active")
+	ErrValuationEngineFailed      = errors.New("valuation engine failed")
+)
+
+// Valuation operation status constants for metrics
+const (
+	opStatusValuationEngineNil     = "valuation_engine_nil"
+	opStatusNoValuationFeature     = "no_valuation_feature"
+	opStatusValuationFailed        = "valuation_failed"
+	opStatusInvalidInputAmount     = "invalid_input_amount"
+	opStatusFeatureNotActive       = "feature_not_active"
+	opStatusInputInstrumentEmpty   = "input_instrument_empty"
+	opStatusInputAmountNonPositive = "input_amount_non_positive"
+	opStatusMissingAccountID       = "missing_account_id"
+)
+
+// valuateInternalResult contains the result of an internal valuation operation.
+// This is the shared result type used by both EvaluateAssetValuation (inquiry)
+// and any binding operations to guarantee identical pricing logic.
+type valuateInternalResult struct {
+	OutputAmount decimal.Decimal
+	OutputCode   string
+	Analysis     *pb.ValuationAnalysis
+	CacheHit     bool
+	ExecutionMs  int64
+}
+
+// valuateInternal is the SINGLE valuation function shared by both:
+//   - EvaluateAssetValuation (inquiry-only)
+//   - Any future binding operations (e.g., InitiateLien with valuation)
+//
+// CRITICAL: This function MUST be used for ALL valuation operations to prevent Ghost Pricing.
+// Ghost Pricing occurs when an inquiry shows one price but the binding operation uses a different price.
+// By routing both through this function, we guarantee identical results for identical inputs.
+//
+// Key difference from Current Account: Internal accounts may use wholesale pricing methods
+// and regulatory accounts require full audit trail in ValuationAnalysis.
+func (s *Service) valuateInternal(ctx context.Context, accountID string, inputAmount decimal.Decimal, inputCode string, knowledgeAt time.Time) (*valuateInternalResult, error) {
+	start := time.Now()
+
+	// Validate valuation feature repository is configured
+	if s.valuationFeatureRepo == nil {
+		return nil, ErrValuationRepoNotConfigured
+	}
+
+	// Retrieve account to get native instrument.
+	// findAccountByID returns gRPC status errors; check the code to map to our sentinels.
+	account, err := s.findAccountByID(ctx, accountID)
+	if err != nil {
+		if st, ok := status.FromError(err); ok {
+			if st.Code() == codes.NotFound {
+				return nil, fmt.Errorf("%w: %s", ErrValuationAccountNotFound, accountID)
+			}
+		}
+		return nil, fmt.Errorf("failed to retrieve account %s: %w", accountID, err)
+	}
+
+	nativeInstrument := account.InstrumentCode()
+
+	// If input instrument matches native instrument, no conversion needed
+	if inputCode == nativeInstrument {
+		executionMs := time.Since(start).Milliseconds()
+		return &valuateInternalResult{
+			OutputAmount: inputAmount,
+			OutputCode:   nativeInstrument,
+			Analysis: &pb.ValuationAnalysis{
+				MethodId:        "identity",
+				MethodVersion:   "1",
+				AppliedRates:    map[string]string{"identity_rate": "1.0"},
+				ComputedAt:      timestamppb.New(time.Now()),
+				KnowledgeAt:     timestamppb.New(knowledgeAt),
+				CalculationPath: []string{"identity_conversion"},
+				DegradedMode:    false,
+			},
+			CacheHit:    false,
+			ExecutionMs: executionMs,
+		}, nil
+	}
+
+	// Resolve the active valuation feature for this account+instrument at knowledgeAt
+	feature, err := s.valuationFeatureRepo.FindByAccountIDAndInstrument(ctx, account.ID(), inputCode, knowledgeAt)
+	if err != nil {
+		if errors.Is(err, persistence.ErrValuationFeatureNotFound) {
+			return nil, fmt.Errorf("%w for account %s and instrument %s", ErrNoActiveValuationFeature, accountID, inputCode)
+		}
+		return nil, fmt.Errorf("failed to resolve valuation feature: %w", err)
+	}
+
+	// Verify feature is active
+	if !feature.IsActive() {
+		return nil, fmt.Errorf("%w: %s (status: %s)", ErrValuationFeatureNotActive, feature.ID, feature.LifecycleStatus)
+	}
+
+	// Convert parameters to proto Struct for analysis
+	var accountParams *structpb.Struct
+	if feature.Parameters != nil {
+		accountParams, err = structpb.NewStruct(feature.Parameters)
+		if err != nil {
+			s.logger.Warn("failed to convert valuation feature parameters to proto struct",
+				"account_id", accountID,
+				"feature_id", feature.ID,
+				"error", err)
+			// Continue without account parameters rather than failing the valuation
+		}
+	}
+
+	// If a valuation engine is configured, delegate to it
+	if s.valuationEngine != nil {
+		result, err := s.valuationEngine.Evaluate(ctx, ValuationParams{
+			MethodID:      feature.ValuationMethodID,
+			MethodVersion: feature.ValuationMethodVersion,
+			InputAmount:   inputAmount,
+			InputCode:     inputCode,
+			OutputCode:    nativeInstrument,
+			Parameters:    feature.Parameters,
+			KnowledgeAt:   knowledgeAt,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrValuationEngineFailed, err)
+		}
+
+		executionMs := time.Since(start).Milliseconds()
+
+		// Build analysis from engine result
+		analysis := &pb.ValuationAnalysis{
+			MethodId:          feature.ValuationMethodID.String(),
+			MethodVersion:     strconv.Itoa(feature.ValuationMethodVersion),
+			AppliedRates:      result.AppliedRates,
+			ObservationIds:    result.ObservationIDs,
+			ComputedAt:        timestamppb.New(result.ComputedAt),
+			KnowledgeAt:       timestamppb.New(knowledgeAt),
+			AccountParameters: accountParams,
+			CalculationPath:   result.CalculationPath,
+			DegradedMode:      result.DegradedMode,
+		}
+
+		// Convert warnings
+		for _, w := range result.Warnings {
+			analysis.Warnings = append(analysis.Warnings, &pb.ValuationWarning{
+				Code:     w.Code,
+				Message:  w.Message,
+				Severity: w.Severity,
+			})
+		}
+
+		// Convert market data qualities
+		for _, q := range result.MarketQualities {
+			analysis.MarketDataQualities = append(analysis.MarketDataQualities, &pb.MarketDataQuality{
+				Source:           q.Source,
+				QualityLevel:     q.QualityLevel,
+				ObservedAt:       timestamppb.New(q.ObservedAt),
+				StalenessSeconds: q.StalenessSeconds,
+			})
+		}
+
+		return &valuateInternalResult{
+			OutputAmount: result.OutputAmount,
+			OutputCode:   result.OutputCode,
+			Analysis:     analysis,
+			CacheHit:     result.CacheHit,
+			ExecutionMs:  executionMs,
+		}, nil
+	}
+
+	// Fallback: No valuation engine configured.
+	// Use the feature's method reference to build a stub analysis.
+	// In production, the valuation engine MUST be configured.
+	executionMs := time.Since(start).Milliseconds()
+
+	s.logger.Warn("no valuation engine configured, returning unvalued amount with degraded analysis",
+		"account_id", accountID,
+		"input_code", inputCode,
+		"method_id", feature.ValuationMethodID.String())
+
+	return &valuateInternalResult{
+		OutputAmount: inputAmount, // Passthrough (no actual conversion)
+		OutputCode:   nativeInstrument,
+		Analysis: &pb.ValuationAnalysis{
+			MethodId:          feature.ValuationMethodID.String(),
+			MethodVersion:     strconv.Itoa(feature.ValuationMethodVersion),
+			AppliedRates:      map[string]string{"passthrough": "1.0"},
+			ComputedAt:        timestamppb.New(time.Now()),
+			KnowledgeAt:       timestamppb.New(knowledgeAt),
+			AccountParameters: accountParams,
+			CalculationPath:   []string{"passthrough_no_engine"},
+			DegradedMode:      true,
+			Warnings: []*pb.ValuationWarning{
+				{
+					Code:     "NO_VALUATION_ENGINE",
+					Message:  "Valuation engine not configured; returning passthrough amount",
+					Severity: "DEGRADED",
+				},
+			},
+		},
+		CacheHit:    false,
+		ExecutionMs: executionMs,
+	}, nil
+}
+
+// EvaluateAssetValuation performs an inquiry-only (non-binding) valuation.
+// Returns the estimated valued amount without creating any financial commitment.
+// CRITICAL: Uses valuateInternal() which is shared with binding operations to prevent Ghost Pricing.
+func (s *Service) EvaluateAssetValuation(ctx context.Context, req *pb.EvaluateAssetValuationRequest) (*pb.EvaluateAssetValuationResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		ibaobservability.RecordOperationDuration("evaluate_asset_valuation", operationStatus, time.Since(start))
+	}()
+
+	// Validate valuation feature repository is configured
+	if s.valuationFeatureRepo == nil {
+		operationStatus = opStatusValuationFeatureRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "valuation feature operations not configured")
+	}
+
+	// Validate input
+	if req.AccountId == "" {
+		operationStatus = opStatusMissingAccountID
+		return nil, status.Error(codes.InvalidArgument, "account_id is required")
+	}
+	if req.Input == nil {
+		operationStatus = opStatusInvalidRequest
+		return nil, status.Error(codes.InvalidArgument, "input amount is required")
+	}
+	if req.Input.InstrumentCode == "" {
+		operationStatus = opStatusInputInstrumentEmpty
+		return nil, status.Error(codes.InvalidArgument, "input instrument_code is required")
+	}
+	if req.Input.Amount == "" {
+		operationStatus = opStatusInvalidInputAmount
+		return nil, status.Error(codes.InvalidArgument, "input amount value is required")
+	}
+
+	// Parse input amount
+	inputAmount, err := decimal.NewFromString(req.Input.Amount)
+	if err != nil {
+		operationStatus = opStatusInvalidInputAmount
+		return nil, status.Errorf(codes.InvalidArgument, "invalid input amount: %v", err)
+	}
+
+	if !inputAmount.IsPositive() {
+		operationStatus = opStatusInputAmountNonPositive
+		return nil, status.Error(codes.InvalidArgument, "input amount must be positive")
+	}
+
+	// Determine knowledge_at time
+	knowledgeAt := time.Now()
+	if req.KnowledgeAt != nil {
+		knowledgeAt = req.KnowledgeAt.AsTime()
+	}
+
+	// Execute valuation via shared function (prevents Ghost Pricing)
+	result, err := s.valuateInternal(ctx, req.AccountId, inputAmount, req.Input.InstrumentCode, knowledgeAt)
+	if err != nil {
+		// Map internal errors to gRPC status codes using sentinel errors
+		switch {
+		case errors.Is(err, ErrValuationAccountNotFound):
+			operationStatus = opStatusAccountNotFound
+			return nil, status.Errorf(codes.NotFound, "%v", err)
+		case errors.Is(err, ErrNoActiveValuationFeature):
+			operationStatus = opStatusNoValuationFeature
+			return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+		case errors.Is(err, ErrValuationFeatureNotActive):
+			operationStatus = opStatusFeatureNotActive
+			return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+		case errors.Is(err, ErrValuationRepoNotConfigured):
+			operationStatus = opStatusValuationFeatureRepoNil
+			return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+		case errors.Is(err, ErrValuationEngineFailed):
+			operationStatus = opStatusValuationFailed
+			return nil, status.Errorf(codes.Internal, "%v", err)
+		default:
+			operationStatus = opStatusValuationFailed
+			return nil, status.Errorf(codes.Internal, "valuation failed: %v", err)
+		}
+	}
+
+	executionMs := time.Since(start).Milliseconds()
+
+	return &pb.EvaluateAssetValuationResponse{
+		Output: &quantityv1.InstrumentAmount{
+			Amount:         result.OutputAmount.String(),
+			InstrumentCode: result.OutputCode,
+			Version:        1,
+		},
+		Basis:           result.Analysis,
+		ExecutionTimeMs: strconv.FormatInt(executionMs, 10),
+		CacheHit:        result.CacheHit,
+		IsEstimate:      true, // Always true for inquiry operations
+	}, nil
+}

--- a/services/internal-bank-account/service/valuation_engine_test.go
+++ b/services/internal-bank-account/service/valuation_engine_test.go
@@ -1,0 +1,575 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"github.com/meridianhub/meridian/services/internal-bank-account/adapters/persistence"
+	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"gorm.io/gorm"
+)
+
+// mockValuationEngine implements ValuationEngine for testing.
+type mockValuationEngine struct {
+	result *ValuationResult
+	err    error
+}
+
+func (m *mockValuationEngine) Evaluate(_ context.Context, _ ValuationParams) (*ValuationResult, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.result, nil
+}
+
+const testTenantIDForVE = "test_tenant_ve"
+
+func setupValuationEngineTest(t *testing.T) (*Service, *gorm.DB, context.Context, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupPostgres(t, nil)
+
+	tid := tenant.TenantID(testTenantIDForVE)
+	schemaName := tid.SchemaName()
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %q", schemaName)).Error
+	require.NoError(t, err)
+
+	// Create the internal_bank_account table in the tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.internal_bank_account (
+		id UUID PRIMARY KEY,
+		account_id VARCHAR(100) NOT NULL UNIQUE,
+		account_code VARCHAR(50) NOT NULL UNIQUE,
+		name VARCHAR(255) NOT NULL,
+		account_type VARCHAR(20) NOT NULL DEFAULT 'CLEARING',
+		clearing_purpose VARCHAR(20) NOT NULL DEFAULT 'UNSPECIFIED',
+		instrument_code VARCHAR(32) NOT NULL DEFAULT 'GBP',
+		dimension VARCHAR(32) NOT NULL DEFAULT 'CURRENCY',
+		status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+		correspondent_bank_id VARCHAR(100),
+		correspondent_bank_name VARCHAR(255),
+		correspondent_external_ref VARCHAR(255),
+		correspondent_swift_code VARCHAR(11),
+		attributes JSONB,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		created_by VARCHAR(100) NOT NULL DEFAULT 'system',
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+		updated_by VARCHAR(100) NOT NULL DEFAULT 'system',
+		deleted_at TIMESTAMP WITH TIME ZONE,
+		version BIGINT NOT NULL DEFAULT 1
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create the valuation_features table in the tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %q.valuation_features (
+		id UUID PRIMARY KEY,
+		account_id UUID NOT NULL,
+		instrument_code VARCHAR(32) NOT NULL,
+		valuation_method_id UUID NOT NULL,
+		valuation_method_version INT NOT NULL,
+		parameters JSONB,
+		lifecycle_status VARCHAR(16) NOT NULL,
+		valid_from TIMESTAMP WITH TIME ZONE NOT NULL,
+		valid_to TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		created_by VARCHAR(100) NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_by VARCHAR(100) NOT NULL,
+		version INT NOT NULL DEFAULT 1,
+		CONSTRAINT chk_ve_lifecycle_status CHECK (lifecycle_status IN ('INITIATED','ACTIVE','TERMINATED'))
+	)`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Create unique index for active features
+	err = db.Exec(fmt.Sprintf(`CREATE UNIQUE INDEX IF NOT EXISTS idx_ve_feature_account_instrument_active
+		ON %q.valuation_features (account_id, instrument_code)
+		WHERE lifecycle_status = 'ACTIVE' AND valid_to = '9999-12-31 23:59:59+00'`, schemaName)).Error
+	require.NoError(t, err)
+
+	// Set default search_path to include tenant schema
+	err = db.Exec(fmt.Sprintf("SET search_path TO %q, public", schemaName)).Error
+	require.NoError(t, err)
+
+	ctx := tenant.WithTenant(context.Background(), tid)
+
+	repo := persistence.NewRepository(db)
+	valuationFeatureRepo := persistence.NewValuationFeatureRepository(db)
+
+	svc, err := NewServiceWithValuationFeatures(repo, valuationFeatureRepo)
+	require.NoError(t, err)
+
+	return svc, db, ctx, cleanup
+}
+
+func createTestIBAForVE(t *testing.T, db *gorm.DB, instrumentCode string) (uuid.UUID, string, string) {
+	t.Helper()
+	accountUUID := uuid.New()
+	accountID := fmt.Sprintf("IBA-%s", uuid.New().String()[:8])
+	accountCode := fmt.Sprintf("IBA-VE-%s", uuid.New().String()[:6])
+
+	err := db.Exec(`INSERT INTO internal_bank_account (id, account_id, account_code, name, account_type, clearing_purpose, instrument_code, dimension, status, created_by, updated_by)
+		VALUES (?, ?, ?, 'Test VE Account', 'CLEARING', 'GENERAL', ?, 'CURRENCY', 'ACTIVE', 'test', 'test')`,
+		accountUUID, accountID, accountCode, instrumentCode).Error
+	require.NoError(t, err)
+
+	return accountUUID, accountID, accountCode
+}
+
+func createTestValuationFeature(t *testing.T, db *gorm.DB, accountUUID uuid.UUID, inputInstrument string) uuid.UUID {
+	t.Helper()
+	featureID := uuid.New()
+	methodID := uuid.New()
+	now := time.Now()
+	farFuture := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+
+	err := db.Exec(`INSERT INTO valuation_features (id, account_id, instrument_code, valuation_method_id, valuation_method_version, parameters, lifecycle_status, valid_from, valid_to, created_at, created_by, updated_at, updated_by, version)
+		VALUES (?, ?, ?, ?, 1, '{"source":"ECB"}', 'ACTIVE', ?, ?, ?, 'test', ?, 'test', 1)`,
+		featureID, accountUUID, inputInstrument, methodID, now, farFuture, now, now).Error
+	require.NoError(t, err)
+
+	return featureID
+}
+
+// ========================================
+// EvaluateAssetValuation - Unit Tests (mock repo)
+// ========================================
+
+func TestEvaluateAssetValuation_RepoNotConfigured(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+
+	resp, err := svc.EvaluateAssetValuation(context.Background(), &pb.EvaluateAssetValuationRequest{
+		AccountId: "test-id",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "100.00",
+			InstrumentCode: "USD",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestEvaluateAssetValuation_MissingAccountID(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewServiceWithValuationFeatures(repo, &persistence.ValuationFeatureRepository{})
+	require.NoError(t, err)
+
+	resp, err := svc.EvaluateAssetValuation(context.Background(), &pb.EvaluateAssetValuationRequest{
+		AccountId: "",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "100.00",
+			InstrumentCode: "USD",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestEvaluateAssetValuation_NilInput(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewServiceWithValuationFeatures(repo, &persistence.ValuationFeatureRepository{})
+	require.NoError(t, err)
+
+	resp, err := svc.EvaluateAssetValuation(context.Background(), &pb.EvaluateAssetValuationRequest{
+		AccountId: "test-id",
+		Input:     nil,
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestEvaluateAssetValuation_EmptyInstrumentCode(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewServiceWithValuationFeatures(repo, &persistence.ValuationFeatureRepository{})
+	require.NoError(t, err)
+
+	resp, err := svc.EvaluateAssetValuation(context.Background(), &pb.EvaluateAssetValuationRequest{
+		AccountId: "test-id",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "100.00",
+			InstrumentCode: "",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestEvaluateAssetValuation_EmptyAmount(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewServiceWithValuationFeatures(repo, &persistence.ValuationFeatureRepository{})
+	require.NoError(t, err)
+
+	resp, err := svc.EvaluateAssetValuation(context.Background(), &pb.EvaluateAssetValuationRequest{
+		AccountId: "test-id",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "",
+			InstrumentCode: "USD",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestEvaluateAssetValuation_InvalidAmount(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewServiceWithValuationFeatures(repo, &persistence.ValuationFeatureRepository{})
+	require.NoError(t, err)
+
+	resp, err := svc.EvaluateAssetValuation(context.Background(), &pb.EvaluateAssetValuationRequest{
+		AccountId: "test-id",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "not-a-number",
+			InstrumentCode: "USD",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestEvaluateAssetValuation_NonPositiveAmount(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewServiceWithValuationFeatures(repo, &persistence.ValuationFeatureRepository{})
+	require.NoError(t, err)
+
+	resp, err := svc.EvaluateAssetValuation(context.Background(), &pb.EvaluateAssetValuationRequest{
+		AccountId: "test-id",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "-50.00",
+			InstrumentCode: "USD",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// ========================================
+// EvaluateAssetValuation - Integration Tests (real DB)
+// ========================================
+
+func TestEvaluateAssetValuation_IdentityConversion(t *testing.T) {
+	svc, db, ctx, cleanup := setupValuationEngineTest(t)
+	defer cleanup()
+
+	// Create account with GBP native instrument
+	_, _, accountCode := createTestIBAForVE(t, db, "GBP")
+
+	// Request valuation with same instrument as native -> identity conversion
+	resp, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
+		AccountId: accountCode,
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "100.00",
+			InstrumentCode: "GBP", // Same as native
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Output)
+	assert.Equal(t, "100", resp.Output.Amount)
+	assert.Equal(t, "GBP", resp.Output.InstrumentCode)
+	assert.True(t, resp.IsEstimate)
+	require.NotNil(t, resp.Basis)
+	assert.Equal(t, "identity", resp.Basis.MethodId)
+	assert.Equal(t, "1", resp.Basis.MethodVersion)
+	assert.Contains(t, resp.Basis.CalculationPath, "identity_conversion")
+	assert.False(t, resp.Basis.DegradedMode)
+}
+
+func TestEvaluateAssetValuation_WithValuationFeature_NoEngine(t *testing.T) {
+	svc, db, ctx, cleanup := setupValuationEngineTest(t)
+	defer cleanup()
+
+	// Create account with GBP native instrument
+	accountUUID, _, accountCode := createTestIBAForVE(t, db, "GBP")
+
+	// Create a valuation feature for USD -> GBP
+	createTestValuationFeature(t, db, accountUUID, "USD")
+
+	// Request valuation with USD (requires conversion, no engine configured)
+	resp, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
+		AccountId: accountCode,
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "100.00",
+			InstrumentCode: "USD",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Output)
+	// Passthrough when no engine configured
+	assert.Equal(t, "100", resp.Output.Amount)
+	assert.Equal(t, "GBP", resp.Output.InstrumentCode) // Output in native instrument
+	assert.True(t, resp.IsEstimate)
+	require.NotNil(t, resp.Basis)
+	assert.True(t, resp.Basis.DegradedMode)
+	assert.Contains(t, resp.Basis.CalculationPath, "passthrough_no_engine")
+	require.Len(t, resp.Basis.Warnings, 1)
+	assert.Equal(t, "NO_VALUATION_ENGINE", resp.Basis.Warnings[0].Code)
+}
+
+func TestEvaluateAssetValuation_WithValuationEngine(t *testing.T) {
+	svc, db, ctx, cleanup := setupValuationEngineTest(t)
+	defer cleanup()
+
+	// Create account with GBP native instrument
+	accountUUID, _, accountCode := createTestIBAForVE(t, db, "GBP")
+
+	// Create a valuation feature for USD -> GBP
+	createTestValuationFeature(t, db, accountUUID, "USD")
+
+	// Configure a mock valuation engine
+	svc.valuationEngine = &mockValuationEngine{
+		result: &ValuationResult{
+			OutputAmount:    decimal.NewFromFloat(79.50),
+			OutputCode:      "GBP",
+			AppliedRates:    map[string]string{"fx_rate": "0.795"},
+			ObservationIDs:  []string{"obs-001"},
+			ComputedAt:      time.Now(),
+			CalculationPath: []string{"spot_fx_conversion"},
+			DegradedMode:    false,
+			CacheHit:        false,
+			Warnings:        nil,
+			MarketQualities: []MarketDataQualityResult{
+				{
+					Source:           "live_feed",
+					QualityLevel:     "ACTUAL",
+					ObservedAt:       time.Now(),
+					StalenessSeconds: 2,
+				},
+			},
+		},
+	}
+
+	// Request valuation with USD
+	resp, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
+		AccountId: accountCode,
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "100.00",
+			InstrumentCode: "USD",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Output)
+	assert.Equal(t, "79.5", resp.Output.Amount)
+	assert.Equal(t, "GBP", resp.Output.InstrumentCode)
+	assert.True(t, resp.IsEstimate)
+	assert.False(t, resp.CacheHit)
+	require.NotNil(t, resp.Basis)
+	assert.False(t, resp.Basis.DegradedMode)
+	assert.Contains(t, resp.Basis.AppliedRates, "fx_rate")
+	assert.Equal(t, "0.795", resp.Basis.AppliedRates["fx_rate"])
+	assert.Contains(t, resp.Basis.CalculationPath, "spot_fx_conversion")
+	require.Len(t, resp.Basis.MarketDataQualities, 1)
+	assert.Equal(t, "live_feed", resp.Basis.MarketDataQualities[0].Source)
+	assert.Equal(t, "ACTUAL", resp.Basis.MarketDataQualities[0].QualityLevel)
+}
+
+func TestEvaluateAssetValuation_WithKnowledgeAt(t *testing.T) {
+	svc, db, ctx, cleanup := setupValuationEngineTest(t)
+	defer cleanup()
+
+	// Create account with GBP native instrument
+	_, _, accountCode := createTestIBAForVE(t, db, "GBP")
+
+	// Use custom knowledge_at - same instrument identity should work regardless
+	knowledgeAt := timestamppb.New(time.Now().Add(-1 * time.Hour))
+
+	resp, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
+		AccountId: accountCode,
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "50.00",
+			InstrumentCode: "GBP",
+		},
+		KnowledgeAt: knowledgeAt,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Output)
+	assert.Equal(t, "50", resp.Output.Amount)
+	assert.Equal(t, "GBP", resp.Output.InstrumentCode)
+	// Verify knowledge_at was passed through to analysis
+	require.NotNil(t, resp.Basis)
+	require.NotNil(t, resp.Basis.KnowledgeAt)
+}
+
+func TestEvaluateAssetValuation_AccountNotFound(t *testing.T) {
+	svc, _, ctx, cleanup := setupValuationEngineTest(t)
+	defer cleanup()
+
+	resp, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
+		AccountId: "nonexistent-account",
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "100.00",
+			InstrumentCode: "USD",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestEvaluateAssetValuation_NoValuationFeature(t *testing.T) {
+	svc, db, ctx, cleanup := setupValuationEngineTest(t)
+	defer cleanup()
+
+	// Create account with GBP native instrument (no valuation feature)
+	_, _, accountCode := createTestIBAForVE(t, db, "GBP")
+
+	// Request valuation with different instrument - no feature exists
+	resp, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
+		AccountId: accountCode,
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "100.00",
+			InstrumentCode: "USD",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestEvaluateAssetValuation_ValuationEngineFailed(t *testing.T) {
+	svc, db, ctx, cleanup := setupValuationEngineTest(t)
+	defer cleanup()
+
+	// Create account and valuation feature
+	accountUUID, _, accountCode := createTestIBAForVE(t, db, "GBP")
+	createTestValuationFeature(t, db, accountUUID, "USD")
+
+	// Configure a failing valuation engine
+	svc.valuationEngine = &mockValuationEngine{
+		err: fmt.Errorf("market data unavailable"),
+	}
+
+	resp, err := svc.EvaluateAssetValuation(ctx, &pb.EvaluateAssetValuationRequest{
+		AccountId: accountCode,
+		Input: &quantityv1.InstrumentAmount{
+			Amount:         "100.00",
+			InstrumentCode: "USD",
+		},
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+// ========================================
+// valuateInternal - Unit Tests
+// ========================================
+
+func TestValuateInternal_IdentityConversion_NoDbNeeded(t *testing.T) {
+	// For identity conversion, only need account lookup (mock repo)
+	repo := newMockRepository()
+	accountUUID := uuid.New()
+	account := buildTestAccount(t, accountUUID, "IBA-001", "GBP")
+	repo.accounts[accountUUID] = account
+	repo.accountsByCode["IBA-001"] = account
+
+	svc, err := NewServiceWithValuationFeatures(repo, &persistence.ValuationFeatureRepository{})
+	require.NoError(t, err)
+
+	result, err := svc.valuateInternal(
+		context.Background(),
+		"IBA-001",
+		decimal.NewFromFloat(100.00),
+		"GBP", // Same as native
+		time.Now(),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.OutputAmount.Equal(decimal.NewFromFloat(100.00)))
+	assert.Equal(t, "GBP", result.OutputCode)
+	assert.Equal(t, "identity", result.Analysis.MethodId)
+}
+
+func TestValuateInternal_RepoNotConfigured(t *testing.T) {
+	repo := newMockRepository()
+	svc, err := NewService(repo)
+	require.NoError(t, err)
+	// valuationFeatureRepo is nil
+
+	result, err := svc.valuateInternal(
+		context.Background(),
+		"IBA-001",
+		decimal.NewFromFloat(100.00),
+		"USD",
+		time.Now(),
+	)
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrValuationRepoNotConfigured)
+}
+
+// buildTestAccount creates an InternalBankAccount using the builder (for unit tests).
+func buildTestAccount(t *testing.T, id uuid.UUID, accountCode, instrumentCode string) domain.InternalBankAccount {
+	t.Helper()
+	return domain.NewInternalBankAccountBuilder().
+		WithID(id).
+		WithAccountID(accountCode).
+		WithAccountCode(accountCode).
+		WithName("Test Account").
+		WithAccountType(domain.AccountTypeClearing).
+		WithClearingPurpose(domain.ClearingPurposeGeneral).
+		WithInstrumentCode(instrumentCode).
+		WithDimension("CURRENCY").
+		WithStatus(domain.AccountStatusActive).
+		WithVersion(1).
+		WithCreatedAt(time.Now()).
+		WithUpdatedAt(time.Now()).
+		Build()
+}

--- a/services/internal-bank-account/service/valuation_feature_service_test.go
+++ b/services/internal-bank-account/service/valuation_feature_service_test.go
@@ -466,12 +466,9 @@ func TestListValuationFeatures_AccountNotFound(t *testing.T) {
 	assert.Nil(t, resp)
 	st, ok := status.FromError(err)
 	require.True(t, ok)
-	// The persistence layer returns its own ErrAccountNotFound which is a different
-	// error instance from domain.ErrAccountNotFound. The findAccountByID helper in
-	// server.go checks errors.Is(err, domain.ErrAccountNotFound) which does not match,
-	// so it falls through to codes.Internal. This is consistent with the existing
-	// IBA service behavior for real database lookups.
-	assert.Equal(t, codes.Internal, st.Code())
+	// findAccountByID checks both domain.ErrAccountNotFound and persistence.ErrAccountNotFound,
+	// so a non-existent account correctly returns NotFound.
+	assert.Equal(t, codes.NotFound, st.Code())
 }
 
 func TestValuationFeatureRepoNil(t *testing.T) {


### PR DESCRIPTION
## Summary

- Integrate the atomic valuation pattern from Current Account (PR #798) into the Internal Bank Account service
- Add `ValuationEngine` interface and `valuateInternal()` shared valuation function that prevents Ghost Pricing between inquiry and future binding operations
- Add `EvaluateAssetValuation` RPC for inquiry-only (non-binding) asset valuation
- Add proto messages: `ValuationAnalysis`, `ValuationWarning`, `MarketDataQuality`, request/response for `EvaluateAssetValuation`
- Extend `PositionKeepingClient` interface with `GetAccountBalance` singular method
- Fix pre-existing bug in `findAccountByID` where `persistence.ErrAccountNotFound` was not matched (only `domain.ErrAccountNotFound` was checked)

## Scope Note

This PR implements the **valuation engine integration** portion of Task Master task `valuation-engine.9`. The full `InitiateLien` with lien infrastructure (domain model, entity, repository, persistence, migrations, proto lien messages) does not exist in IBA and is deferred to a follow-up task.

## Key Design Decisions

- **Ghost Pricing Prevention**: `valuateInternal()` is the single shared function for all valuation operations (inquiry and future binding), guaranteeing identical pricing for identical inputs
- **Identity Conversion**: When input instrument matches the account's native instrument, returns a passthrough result without calling the valuation engine
- **Degraded Mode**: When no valuation engine is configured, returns passthrough amount with degraded analysis and `NO_VALUATION_ENGINE` warning
- **Error Sentinel Pattern**: Uses wrapped sentinel errors (`ErrValuationAccountNotFound`, `ErrNoActiveValuationFeature`, etc.) mapped to appropriate gRPC status codes

## Test Plan

- [x] 9 unit tests covering input validation, identity conversion, and error paths
- [x] 7 integration tests with testcontainer PostgreSQL covering identity conversion, valuation feature with/without engine, knowledge_at propagation, account not found, no valuation feature, engine failure
- [x] Full IBA test suite passes (all packages including adapters, persistence, benchmarks, service, migrations, domain)
- [x] Pre-commit checks pass (buf lint, proto breaking changes, gofumpt, golangci-lint)