### PR TITLE
feat: ExecuteLien price lock enforcement and ReleaseReservation

### DIFF
--- a/services/current-account/service/client_interfaces.go
+++ b/services/current-account/service/client_interfaces.go
@@ -76,6 +76,13 @@ type PositionKeepingClient interface {
 	// Supports both currency and non-currency instruments.
 	GetAccountBalances(ctx context.Context, req *positionkeepingv1.GetAccountBalancesRequest) (*positionkeepingv1.GetAccountBalancesResponse, error)
 
+	// ReleaseReservation transitions a reservation to EXECUTED or TERMINATED status.
+	//
+	// Called after ExecuteLien (reason=EXECUTED) or TerminateLien (reason=TERMINATED) to release
+	// the Position Keeping reservation that was created during InitiateLien.
+	// Best-effort: failures are logged but do not fail the lien operation.
+	ReleaseReservation(ctx context.Context, req *positionkeepingv1.ReleaseReservationRequest) (*positionkeepingv1.ReleaseReservationResponse, error)
+
 	// Close terminates the client connection gracefully
 	Close() error
 }

--- a/services/current-account/service/grpc_service_integration_test.go
+++ b/services/current-account/service/grpc_service_integration_test.go
@@ -75,6 +75,11 @@ type mockPositionKeepingClient struct {
 	lastRequestedInstrumentCode string           // Track last requested instrument code
 	requireInstrumentCode       bool             // If true, return error when instrument_code is missing
 	returnInstrumentCode        string           // Override the instrument code in response (for testing mismatches)
+	// ReleaseReservation tracking
+	releaseReservationCalls  int
+	lastReleasedLienID       string
+	lastReleaseReason        positionkeepingv1.ReservationStatus
+	failOnReleaseReservation bool
 }
 
 func (m *mockPositionKeepingClient) InitiateFinancialPositionLog(_ context.Context, _ *positionkeepingv1.InitiateFinancialPositionLogRequest) (*positionkeepingv1.InitiateFinancialPositionLogResponse, error) {
@@ -222,6 +227,22 @@ func (m *mockPositionKeepingClient) GetAccountBalances(_ context.Context, req *p
 	return &positionkeepingv1.GetAccountBalancesResponse{
 		AccountId: req.AccountId,
 		Balances:  []*positionkeepingv1.BalanceEntry{},
+	}, nil
+}
+
+func (m *mockPositionKeepingClient) ReleaseReservation(_ context.Context, req *positionkeepingv1.ReleaseReservationRequest) (*positionkeepingv1.ReleaseReservationResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.releaseReservationCalls++
+	m.lastReleasedLienID = req.GetLienId()
+	m.lastReleaseReason = req.GetReason()
+
+	if m.failOnReleaseReservation {
+		return nil, status.Error(codes.Internal, "mock release reservation failure")
+	}
+
+	return &positionkeepingv1.ReleaseReservationResponse{
+		Released: true,
 	}, nil
 }
 

--- a/services/current-account/service/lien_service.go
+++ b/services/current-account/service/lien_service.go
@@ -3,6 +3,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -54,6 +55,10 @@ var (
 
 // Default termination reason when none provided
 const defaultTerminationReason = "Terminated via API"
+
+// basisDriftThreshold is the age beyond which a lien's valuation basis is considered stale.
+// If the basis knowledgeAt is older than this, a VALUATION_STALE warning is logged.
+const basisDriftThreshold = 30 * 24 * time.Hour // 30 days
 
 // Lien operation status constants for metrics
 const (
@@ -586,7 +591,18 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		"lien_id", lien.ID.String(),
 		"account_id", account.AccountID(),
 		"amount_cents", safeMinorUnits(lien.Amount),
+		"has_valuation", lien.HasValuation(),
 		"transaction_id", transactionID)
+
+	// Basis drift detection: warn if the valuation basis is stale.
+	// This does NOT block execution - the price lock is always used.
+	if lien.HasValuation() && lien.ValuationAnalysis != nil {
+		s.checkBasisDrift(lien)
+	}
+
+	// Release the Position Keeping reservation (best-effort).
+	// The lien execution succeeded, so the reservation should transition to EXECUTED.
+	s.releaseReservation(ctx, lien.ID.String(), positionkeepingv1.ReservationStatus_RESERVATION_STATUS_EXECUTED)
 
 	// Calculate available balance scoped to the lien's bucket (if any)
 	availableMoney := s.calculateAvailableBalanceByBucket(ctx, lien.AccountID, lien.BucketID, account.Balance())
@@ -750,6 +766,10 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 			"lien_id", lien.ID.String(),
 			"reason", reason)
 	}
+
+	// Release the Position Keeping reservation (best-effort).
+	// The lien termination succeeded, so the reservation should transition to TERMINATED.
+	s.releaseReservation(ctx, lien.ID.String(), positionkeepingv1.ReservationStatus_RESERVATION_STATUS_TERMINATED)
 
 	// Calculate new available balance (funds released)
 	account, err := s.repo.FindByUUID(ctx, lien.AccountID)
@@ -1166,6 +1186,73 @@ func (s *Service) calculateAvailableBalanceByBucket(ctx context.Context, account
 		return currentBalance // Best effort
 	}
 	return availableMoney
+}
+
+// releaseReservation calls Position Keeping to release the reservation associated with a lien.
+// This is best-effort: failures are logged but do not fail the lien operation, because the
+// lien state transition has already been committed to the database.
+func (s *Service) releaseReservation(ctx context.Context, lienID string, reason positionkeepingv1.ReservationStatus) {
+	if s.posKeepingClient == nil {
+		return
+	}
+
+	releaseCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	_, err := s.posKeepingClient.ReleaseReservation(releaseCtx, &positionkeepingv1.ReleaseReservationRequest{
+		LienId: lienID,
+		Reason: reason,
+	})
+	if err != nil {
+		// Best-effort: log and continue. The reservation will remain ACTIVE in Position Keeping
+		// but the lien is already in its terminal state. A background reconciliation process
+		// can clean up orphaned reservations.
+		s.logger.Warn("failed to release Position Keeping reservation (best-effort)",
+			"lien_id", lienID,
+			"reason", reason.String(),
+			"error", err)
+	} else {
+		s.logger.Info("released Position Keeping reservation",
+			"lien_id", lienID,
+			"reason", reason.String())
+	}
+}
+
+// checkBasisDrift checks if a valued lien's valuation basis is stale and logs a warning.
+// This detects situations where the price lock was computed long ago and the underlying
+// rate may have changed significantly. The execution still proceeds with the price lock.
+func (s *Service) checkBasisDrift(lien *domain.Lien) {
+	if lien.ValuationAnalysis == nil {
+		return
+	}
+
+	// Parse the knowledgeAt from the valuation analysis JSON.
+	// The analysis contains a "knowledge_at" field from the valuation computation.
+	var analysis struct {
+		KnowledgeAt string `json:"knowledgeAt"`
+	}
+	if err := json.Unmarshal(lien.ValuationAnalysis, &analysis); err != nil {
+		// Cannot parse - skip drift detection
+		return
+	}
+
+	if analysis.KnowledgeAt == "" {
+		return
+	}
+
+	knowledgeAt, err := time.Parse(time.RFC3339, analysis.KnowledgeAt)
+	if err != nil {
+		return
+	}
+
+	basisAge := time.Since(knowledgeAt)
+	if basisAge > basisDriftThreshold {
+		s.logger.Warn("VALUATION_STALE: lien valuation basis exceeds drift threshold",
+			"lien_id", lien.ID.String(),
+			"knowledge_at", knowledgeAt.Format(time.RFC3339),
+			"basis_age_days", int(basisAge.Hours()/24),
+			"threshold_days", int(basisDriftThreshold.Hours()/24))
+	}
 }
 
 // GetActiveAmountBlocks retrieves active fund reservations for Position Keeping.

--- a/services/current-account/service/lien_service_test.go
+++ b/services/current-account/service/lien_service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
 	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
@@ -1774,6 +1775,225 @@ func TestInitiateLien_AtomicValuation_LegacyModeStillWorks(t *testing.T) {
 	require.Nil(t, resp.Lien.ValuedAmount, "legacy lien should not have valued_amount")
 	require.Nil(t, resp.ValuedAmount, "legacy response should not have valued_amount")
 	require.Nil(t, resp.Basis, "legacy response should not have basis")
+}
+
+// ============================================================================
+// ExecuteLien & TerminateLien - ReleaseReservation Tests
+// ============================================================================
+
+func TestExecuteLien_CallsReleaseReservation_WithExecutedReason(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := mustNewServiceWithPositionKeeping(t, repo, lienRepo, map[string]int64{
+		"ACC-RELEASE-001": 100000, // £1000
+	})
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-RELEASE-001", 100000)
+
+	// Create lien for £500
+	lienAmount, err := domain.NewMoney("GBP", 50000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "", "PO-RELEASE-001", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(ctx, lien))
+
+	// Execute the lien
+	resp, err := svc.ExecuteLien(ctx, &pb.ExecuteLienRequest{LienId: lien.ID.String()})
+	require.NoError(t, err)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_EXECUTED, resp.Lien.Status)
+
+	// Assert ReleaseReservation was called with EXECUTED reason
+	mockPK := svc.posKeepingClient.(*mockPositionKeepingClient)
+	mockPK.mu.Lock()
+	defer mockPK.mu.Unlock()
+	require.Equal(t, 1, mockPK.releaseReservationCalls, "ReleaseReservation should be called once")
+	require.Equal(t, lien.ID.String(), mockPK.lastReleasedLienID, "should release the correct lien ID")
+	require.Equal(t, positionkeepingv1.ReservationStatus_RESERVATION_STATUS_EXECUTED, mockPK.lastReleaseReason,
+		"reason should be EXECUTED")
+}
+
+func TestTerminateLien_CallsReleaseReservation_WithTerminatedReason(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := mustNewServiceWithPositionKeeping(t, repo, lienRepo, map[string]int64{
+		"ACC-RELEASE-002": 100000, // £1000
+	})
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-RELEASE-002", 100000)
+
+	// Create lien for £500
+	lienAmount, err := domain.NewMoney("GBP", 50000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "", "PO-RELEASE-002", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(ctx, lien))
+
+	// Terminate the lien
+	resp, err := svc.TerminateLien(ctx, &pb.TerminateLienRequest{
+		LienId: lien.ID.String(),
+		Reason: "Payment cancelled",
+	})
+	require.NoError(t, err)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_TERMINATED, resp.Lien.Status)
+
+	// Assert ReleaseReservation was called with TERMINATED reason
+	mockPK := svc.posKeepingClient.(*mockPositionKeepingClient)
+	mockPK.mu.Lock()
+	defer mockPK.mu.Unlock()
+	require.Equal(t, 1, mockPK.releaseReservationCalls, "ReleaseReservation should be called once")
+	require.Equal(t, lien.ID.String(), mockPK.lastReleasedLienID, "should release the correct lien ID")
+	require.Equal(t, positionkeepingv1.ReservationStatus_RESERVATION_STATUS_TERMINATED, mockPK.lastReleaseReason,
+		"reason should be TERMINATED")
+}
+
+func TestExecuteLien_ReleaseReservationFailure_DoesNotFailLienExecution(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := mustNewServiceWithPositionKeeping(t, repo, lienRepo, map[string]int64{
+		"ACC-RELEASE-003": 100000, // £1000
+	})
+
+	// Configure mock to fail on ReleaseReservation
+	mockPK := svc.posKeepingClient.(*mockPositionKeepingClient)
+	mockPK.mu.Lock()
+	mockPK.failOnReleaseReservation = true
+	mockPK.mu.Unlock()
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-RELEASE-003", 100000)
+
+	// Create lien for £500
+	lienAmount, err := domain.NewMoney("GBP", 50000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "", "PO-RELEASE-003", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(ctx, lien))
+
+	// Execute the lien - should succeed even though ReleaseReservation fails
+	resp, err := svc.ExecuteLien(ctx, &pb.ExecuteLienRequest{LienId: lien.ID.String()})
+	require.NoError(t, err, "ExecuteLien should succeed even when ReleaseReservation fails (best-effort)")
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_EXECUTED, resp.Lien.Status)
+	require.NotEmpty(t, resp.TransactionId)
+
+	// Verify ReleaseReservation was attempted
+	mockPK.mu.Lock()
+	defer mockPK.mu.Unlock()
+	require.Equal(t, 1, mockPK.releaseReservationCalls, "ReleaseReservation should still be attempted")
+}
+
+func TestTerminateLien_ReleaseReservationFailure_DoesNotFailTermination(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := mustNewServiceWithPositionKeeping(t, repo, lienRepo, map[string]int64{
+		"ACC-RELEASE-004": 100000, // £1000
+	})
+
+	// Configure mock to fail on ReleaseReservation
+	mockPK := svc.posKeepingClient.(*mockPositionKeepingClient)
+	mockPK.mu.Lock()
+	mockPK.failOnReleaseReservation = true
+	mockPK.mu.Unlock()
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-RELEASE-004", 100000)
+
+	// Create lien for £500
+	lienAmount, err := domain.NewMoney("GBP", 50000)
+	require.NoError(t, err)
+	lien, err := domain.NewLien(account.ID(), lienAmount, "", "PO-RELEASE-004", nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(ctx, lien))
+
+	// Terminate the lien - should succeed even though ReleaseReservation fails
+	resp, err := svc.TerminateLien(ctx, &pb.TerminateLienRequest{
+		LienId: lien.ID.String(),
+		Reason: "Payment cancelled",
+	})
+	require.NoError(t, err, "TerminateLien should succeed even when ReleaseReservation fails (best-effort)")
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_TERMINATED, resp.Lien.Status)
+
+	// Verify ReleaseReservation was attempted
+	mockPK.mu.Lock()
+	defer mockPK.mu.Unlock()
+	require.Equal(t, 1, mockPK.releaseReservationCalls, "ReleaseReservation should still be attempted")
+}
+
+// ============================================================================
+// ExecuteLien - Price Lock Immutability Tests
+// ============================================================================
+
+func TestExecuteLien_UsesStoredPriceLock_NoRecalculation(t *testing.T) {
+	db, ctx, cleanup := setupLienTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewRepository(db)
+	lienRepo := persistence.NewLienRepository(db)
+	svc := mustNewServiceWithPositionKeeping(t, repo, lienRepo, map[string]int64{
+		"ACC-PRICELOCK-001": 100000, // £1000
+	})
+
+	// Track if valuation engine is called during ExecuteLien.
+	// Inject a mock engine that would fail if called (proving it's never invoked).
+	callCount := 0
+	svc.valuationEngine = &mockValuationEngine{
+		evaluateFn: func(_ context.Context, _ ValuationParams) (*ValuationResult, error) {
+			callCount++
+			return &ValuationResult{
+				OutputAmount: decimal.NewFromFloat(999.99),
+				OutputCode:   "GBP",
+			}, nil
+		},
+	}
+
+	// Create account with £1000 balance
+	account := createTestAccountWithBalance(t, ctx, repo, "ACC-PRICELOCK-001", 100000)
+
+	// Create a valued lien (simulates what InitiateLien would produce for multi-asset)
+	// The valued_amount is the price lock - it was set at InitiateLien time.
+	lienAmount, err := domain.NewMoney("GBP", 50000) // £500 - the valued amount
+	require.NoError(t, err)
+	reservedQty := &domain.InstrumentAmount{
+		Amount:         decimal.NewFromFloat(100.0),
+		InstrumentCode: "kWh",
+	}
+	valuedAmt := &domain.InstrumentAmount{
+		Amount:         decimal.NewFromFloat(500.0),
+		InstrumentCode: "GBP",
+	}
+	lien, err := domain.NewValuedLien(account.ID(), lienAmount, "", "PO-PRICELOCK-001", nil, reservedQty, valuedAmt, nil)
+	require.NoError(t, err)
+	require.NoError(t, lienRepo.Create(ctx, lien))
+
+	// Execute the lien - should NOT call valuation engine (price lock is immutable)
+	execResp, err := svc.ExecuteLien(ctx, &pb.ExecuteLienRequest{
+		LienId: lien.ID.String(),
+	})
+	require.NoError(t, err)
+	require.Equal(t, pb.LienStatus_LIEN_STATUS_EXECUTED, execResp.Lien.Status)
+	require.Equal(t, 0, callCount, "valuation engine should NOT be called during ExecuteLien - price lock is immutable")
+
+	// Verify the lien used the original £500 price lock (not recalculated)
+	require.Equal(t, "GBP", execResp.Lien.Amount.Amount.CurrencyCode)
+	require.Equal(t, int64(500), execResp.Lien.Amount.Amount.Units)
+
+	// Verify the reserved quantity is preserved
+	require.NotNil(t, execResp.Lien.ReservedQuantity)
+	require.Equal(t, "kWh", execResp.Lien.ReservedQuantity.InstrumentCode)
+	require.Equal(t, "100", execResp.Lien.ReservedQuantity.Amount)
 }
 
 func TestInitiateLien_AtomicValuation_ValuationImmutable(t *testing.T) {

--- a/services/position-keeping/client/client.go
+++ b/services/position-keeping/client/client.go
@@ -399,6 +399,30 @@ func (c *Client) GetAccountBalances(ctx context.Context, req *positionkeepingv1.
 	return resp, nil
 }
 
+// ReleaseReservation transitions a reservation to EXECUTED or TERMINATED status.
+// This is idempotent (releasing an already-released reservation returns success),
+// so it uses circuit breaker with retry.
+func (c *Client) ReleaseReservation(ctx context.Context, req *positionkeepingv1.ReleaseReservationRequest) (*positionkeepingv1.ReleaseReservationResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "ReleaseReservation", func() (*positionkeepingv1.ReleaseReservationResponse, error) {
+			return c.positionKeeping.ReleaseReservation(ctx, req)
+		})
+	}
+
+	resp, err := c.positionKeeping.ReleaseReservation(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to release reservation: %w", err)
+	}
+
+	return resp, nil
+}
+
 // Close terminates the gRPC connection gracefully.
 func (c *Client) Close() error {
 	if c.conn != nil {


### PR DESCRIPTION
## Summary

- ExecuteLien and TerminateLien now call `ReleaseReservation` on Position Keeping after the lien state transition commits (best-effort with 5s timeout)
- Adds basis drift detection that logs `VALUATION_STALE` when a valued lien's `knowledgeAt` exceeds 30 days (warning only, does not block execution)
- Verifies price lock immutability: the valuation engine is never called during ExecuteLien -- the stored `valued_amount` is used as-is

## Changes Made

| File | Change |
|------|--------|
| `services/current-account/service/client_interfaces.go` | Add `ReleaseReservation` to `PositionKeepingClient` interface |
| `services/position-keeping/client/client.go` | Add `ReleaseReservation` method to PK gRPC client wrapper (with resilience) |
| `services/current-account/service/lien_service.go` | Add `releaseReservation` helper (best-effort), `checkBasisDrift` helper, wire both into ExecuteLien/TerminateLien |
| `services/current-account/service/grpc_service_integration_test.go` | Add ReleaseReservation tracking fields and method to mock PK client |
| `services/current-account/service/lien_service_test.go` | Add 5 new tests covering reservation release, failure resilience, and price lock immutability |

## Test Plan

- [x] `TestExecuteLien_CallsReleaseReservation_WithExecutedReason` -- verifies EXECUTED reason
- [x] `TestTerminateLien_CallsReleaseReservation_WithTerminatedReason` -- verifies TERMINATED reason
- [x] `TestExecuteLien_ReleaseReservationFailure_DoesNotFailLienExecution` -- best-effort resilience
- [x] `TestTerminateLien_ReleaseReservationFailure_DoesNotFailTermination` -- best-effort resilience
- [x] `TestExecuteLien_UsesStoredPriceLock_NoRecalculation` -- price lock immutability
- [x] Full `services/current-account/...` test suite passes (all packages)

## Task Master

Tag: `valuation-engine`, Task: `10` -- Update ExecuteLien to use price lock and release reservation

Subtasks addressed:
- `valuation-engine.10.1`: ExecuteLien uses stored `valued_amount` immutably (no recalculation)
- `valuation-engine.10.2`: Already done -- `ExecuteLienRequest` proto only has `lien_id` + `idempotency_key`
- `valuation-engine.10.3`: Basis drift detection with `VALUATION_STALE` log warning
- `valuation-engine.10.4`: `ReleaseReservation` called with `EXECUTED` after successful ExecuteLien
- `valuation-engine.10.5`: `ReleaseReservation` called with `TERMINATED` after successful TerminateLien