### PR TITLE
feat: add lien infrastructure to Internal Bank Account service

### DIFF
--- a/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
+++ b/api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto
@@ -282,6 +282,20 @@ message InternalBankAccountFacility {
   ClearingPurpose clearing_purpose = 12;
 }
 
+// LienStatus defines the lifecycle state of a fund reservation (lien).
+// A lien is a hold placed on funds to reserve them for a pending payment.
+// Invariant: Available Balance = Current Balance - Sum(Active Liens)
+enum LienStatus {
+  // LIEN_STATUS_UNSPECIFIED is the default value and should not be used.
+  LIEN_STATUS_UNSPECIFIED = 0;
+  // LIEN_STATUS_ACTIVE means the funds are currently reserved.
+  LIEN_STATUS_ACTIVE = 1;
+  // LIEN_STATUS_EXECUTED means the lien was converted to an actual debit (terminal).
+  LIEN_STATUS_EXECUTED = 2;
+  // LIEN_STATUS_TERMINATED means the lien was released without execution (terminal).
+  LIEN_STATUS_TERMINATED = 3;
+}
+
 // ========================================
 // Request/Response Messages
 // ========================================
@@ -800,6 +814,173 @@ message EvaluateAssetValuationResponse {
 }
 
 // ========================================
+// Lien Messages
+// ========================================
+
+// Lien represents a fund reservation (hold) on an internal bank account.
+// Used by Payment Order to reserve funds before executing payments.
+// Invariant: Available Balance = Current Balance - Sum(Active Liens)
+//
+// Multi-asset support: IBA liens use InstrumentAmount natively. When the input
+// instrument differs from the account's native instrument, atomic valuation is
+// performed to produce a price-locked valued_amount.
+message Lien {
+  // lien_id is the unique identifier for this lien.
+  string lien_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // account_id is the account this lien belongs to.
+  string account_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // amount is the reserved amount in the account's native instrument.
+  meridian.quantity.v1.InstrumentAmount amount = 3 [(buf.validate.field).required = true];
+
+  // status is the current lien lifecycle state.
+  LienStatus status = 4 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // payment_order_reference is the Payment Order that created this lien.
+  string payment_order_reference = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+    pattern: "^[a-zA-Z0-9_/-]+$"
+  }];
+
+  // created_at is when the lien was created.
+  google.protobuf.Timestamp created_at = 6 [(buf.validate.field).required = true];
+
+  // updated_at is when the lien was last modified.
+  google.protobuf.Timestamp updated_at = 7 [(buf.validate.field).required = true];
+
+  // bucket_id is the fungibility key for bucket-aware reservations.
+  // Empty string represents the default bucket.
+  string bucket_id = 8 [(buf.validate.field).string = {max_len: 255}];
+
+  // reserved_quantity is the original input amount before valuation (e.g., 100 kWh).
+  // Only present for liens that went through atomic valuation.
+  meridian.quantity.v1.InstrumentAmount reserved_quantity = 9;
+
+  // valued_amount is the price-locked valuation result in the account's native instrument.
+  // Only present for liens that went through atomic valuation.
+  meridian.quantity.v1.InstrumentAmount valued_amount = 10;
+
+  // termination_reason explains why the lien was terminated (only set when TERMINATED).
+  string termination_reason = 11;
+
+  // expires_at is the optional expiration time for automatic termination.
+  google.protobuf.Timestamp expires_at = 12;
+
+  // version is used for optimistic locking.
+  int32 version = 13 [(buf.validate.field).int32 = {gte: 0}];
+}
+
+// InitiateLienRequest creates a new lien on an internal bank account.
+// Supports multi-asset input with atomic valuation (price lock).
+message InitiateLienRequest {
+  // account_id is the account to place the lien on.
+  string account_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // input is the amount to reserve. For same-instrument liens, use the account's
+  // native instrument. For cross-instrument liens (e.g., kWh on GBP account),
+  // atomic valuation is performed using the configured ValuationFeature.
+  meridian.quantity.v1.InstrumentAmount input = 2 [(buf.validate.field).required = true];
+
+  // payment_order_reference identifies the Payment Order creating this lien.
+  string payment_order_reference = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+    pattern: "^[a-zA-Z0-9_/-]+$"
+  }];
+
+  // bucket_id is the fungibility key for bucket-aware reservations (optional).
+  string bucket_id = 4 [(buf.validate.field).string = {max_len: 255}];
+
+  // knowledge_at is the point-in-time for bi-temporal data resolution (optional, defaults to now).
+  google.protobuf.Timestamp knowledge_at = 5;
+
+  // expires_at is the optional expiration time for automatic termination of stale liens.
+  google.protobuf.Timestamp expires_at = 6;
+}
+
+// InitiateLienResponse returns the created lien.
+message InitiateLienResponse {
+  // lien is the created lien with ACTIVE status.
+  Lien lien = 1 [(buf.validate.field).required = true];
+
+  // valued_amount is the price-locked valuation result in the account's native instrument.
+  // Only present when the input instrument differs from the account's native instrument.
+  meridian.quantity.v1.InstrumentAmount valued_amount = 2;
+
+  // basis provides full transparency into the valuation computation.
+  // Only present when atomic valuation was performed.
+  ValuationAnalysis basis = 3;
+}
+
+// ExecuteLienRequest converts a lien reservation to an actual debit.
+message ExecuteLienRequest {
+  // lien_id is the lien to execute.
+  string lien_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+}
+
+// ExecuteLienResponse returns the executed lien.
+message ExecuteLienResponse {
+  // lien is the executed lien with EXECUTED status.
+  Lien lien = 1 [(buf.validate.field).required = true];
+}
+
+// TerminateLienRequest releases the reservation without executing.
+message TerminateLienRequest {
+  // lien_id is the lien to terminate.
+  string lien_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // reason is an optional explanation for termination (for audit trail).
+  string reason = 2 [(buf.validate.field).string = {max_len: 500}];
+}
+
+// TerminateLienResponse returns the terminated lien.
+message TerminateLienResponse {
+  // lien is the terminated lien with TERMINATED status.
+  Lien lien = 1 [(buf.validate.field).required = true];
+}
+
+// RetrieveLienRequest fetches a lien by ID.
+message RetrieveLienRequest {
+  // lien_id is the lien to retrieve.
+  string lien_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+}
+
+// RetrieveLienResponse returns the requested lien.
+message RetrieveLienResponse {
+  // lien is the requested lien.
+  Lien lien = 1 [(buf.validate.field).required = true];
+}
+
+// ========================================
 // Service Definition
 // ========================================
 
@@ -956,6 +1137,51 @@ service InternalBankAccountService {
     option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
       summary: "List valuation features for an internal bank account"
       description: "Retrieves all valuation features for an account with optional status filter"
+    };
+  }
+
+  // InitiateLien creates a new fund reservation on an internal bank account.
+  // Supports multi-asset input with atomic valuation for cross-instrument liens.
+  // CRITICAL: Uses valuateInternal() shared with EvaluateAssetValuation to prevent Ghost Pricing.
+  rpc InitiateLien(InitiateLienRequest) returns (InitiateLienResponse) {
+    option (google.api.http) = {
+      post: "/v1/internal-bank-accounts/{account_id}/liens"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      summary: "Create a fund reservation (lien) on an internal bank account"
+      description: "Reserves funds with optional multi-asset valuation. Uses the same pricing logic as inquiry to prevent Ghost Pricing."
+      responses: {
+        key: "201"
+        value: {
+          description: "Lien created successfully"
+        }
+      }
+    };
+  }
+
+  // ExecuteLien converts a lien reservation to an actual debit.
+  // Transitions lien from ACTIVE to EXECUTED (terminal, idempotent).
+  rpc ExecuteLien(ExecuteLienRequest) returns (ExecuteLienResponse) {
+    option (google.api.http) = {
+      post: "/v1/liens/{lien_id}/execute"
+      body: "*"
+    };
+  }
+
+  // TerminateLien releases reserved funds without executing.
+  // Transitions lien from ACTIVE to TERMINATED (terminal, idempotent).
+  rpc TerminateLien(TerminateLienRequest) returns (TerminateLienResponse) {
+    option (google.api.http) = {
+      post: "/v1/liens/{lien_id}/terminate"
+      body: "*"
+    };
+  }
+
+  // RetrieveLien fetches a lien by ID.
+  rpc RetrieveLien(RetrieveLienRequest) returns (RetrieveLienResponse) {
+    option (google.api.http) = {
+      get: "/v1/liens/{lien_id}"
     };
   }
 }

--- a/services/internal-bank-account/adapters/persistence/lien_entity.go
+++ b/services/internal-bank-account/adapters/persistence/lien_entity.go
@@ -1,0 +1,72 @@
+package persistence
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ErrUnsupportedJSONBType is returned when Scan receives an unexpected type.
+var ErrUnsupportedJSONBType = errors.New("unsupported type for JSONBMap")
+
+// LienEntity represents the database persistence model for liens.
+type LienEntity struct {
+	ID        uuid.UUID `gorm:"primaryKey"`
+	AccountID uuid.UUID `gorm:"not null;index:idx_lien_account_status"`
+
+	AmountCents int64  `gorm:"not null;check:amount_cents > 0"`
+	Currency    string `gorm:"not null;size:3"`
+
+	BucketID string `gorm:"column:bucket_id;size:255;not null;default:'';index:idx_lien_account_bucket"`
+	Status   string `gorm:"not null;size:20;index:idx_lien_account_status;check:status IN ('ACTIVE','EXECUTED','TERMINATED')"`
+
+	PaymentOrderReference string `gorm:"not null;size:255;uniqueIndex:idx_lien_payment_order"`
+	TerminationReason     string `gorm:"size:1000"`
+
+	ExpiresAt *time.Time `gorm:"index:idx_lien_expires_at"`
+
+	ReservedQuantity  JSONBMap `gorm:"column:reserved_quantity;type:jsonb"`
+	ValuedAmount      JSONBMap `gorm:"column:valued_amount;type:jsonb"`
+	ValuationAnalysis JSONBMap `gorm:"column:valuation_analysis;type:jsonb"`
+
+	CreatedAt time.Time `gorm:"not null"`
+	UpdatedAt time.Time `gorm:"not null"`
+	Version   int       `gorm:"not null;default:1"`
+}
+
+// TableName overrides the default table name.
+func (LienEntity) TableName() string {
+	return "lien"
+}
+
+// JSONBMap represents a JSONB column that can be null.
+type JSONBMap json.RawMessage
+
+// Value implements driver.Valuer for database writes.
+func (j JSONBMap) Value() (driver.Value, error) {
+	if j == nil {
+		return nil, nil //nolint:nilnil // driver.Valuer requires nil,nil for SQL NULL
+	}
+	return []byte(j), nil
+}
+
+// Scan implements sql.Scanner for database reads.
+func (j *JSONBMap) Scan(value interface{}) error {
+	if value == nil {
+		*j = nil
+		return nil
+	}
+	switch v := value.(type) {
+	case []byte:
+		*j = JSONBMap(v)
+	case string:
+		*j = JSONBMap(v)
+	default:
+		return fmt.Errorf("%w: %T", ErrUnsupportedJSONBType, value)
+	}
+	return nil
+}

--- a/services/internal-bank-account/adapters/persistence/lien_repository.go
+++ b/services/internal-bank-account/adapters/persistence/lien_repository.go
@@ -41,7 +41,10 @@ func (r *LienRepository) withTenantTransaction(ctx context.Context, fn func(tx *
 
 // Create inserts a new lien.
 func (r *LienRepository) Create(ctx context.Context, lien *domain.Lien) error {
-	entity := toLienEntity(lien)
+	entity, err := toLienEntity(lien)
+	if err != nil {
+		return fmt.Errorf("failed to convert lien to entity: %w", err)
+	}
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		return tx.Create(entity).Error
 	})
@@ -152,10 +155,13 @@ func (r *LienRepository) FindByPaymentOrderReference(ctx context.Context, refere
 
 // Update updates an existing lien with optimistic locking.
 func (r *LienRepository) Update(ctx context.Context, lien *domain.Lien) error {
-	entity := toLienEntity(lien)
+	entity, err := toLienEntity(lien)
+	if err != nil {
+		return fmt.Errorf("failed to convert lien to entity: %w", err)
+	}
 	var rowsAffected int64
 
-	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+	err = r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		result := tx.Model(&LienEntity{}).
 			Where("id = ? AND version = ?", entity.ID, lien.Version).
 			Updates(map[string]interface{}{
@@ -228,7 +234,7 @@ func (r *LienRepository) SumActiveAmountByAccountIDAndBucket(ctx context.Context
 }
 
 // toLienEntity converts domain model to database entity.
-func toLienEntity(lien *domain.Lien) *LienEntity {
+func toLienEntity(lien *domain.Lien) (*LienEntity, error) {
 	entity := &LienEntity{
 		ID:                    lien.ID,
 		AccountID:             lien.AccountID,
@@ -245,20 +251,24 @@ func toLienEntity(lien *domain.Lien) *LienEntity {
 	}
 
 	if lien.ReservedQuantity != nil {
-		if data, err := json.Marshal(lien.ReservedQuantity); err == nil {
-			entity.ReservedQuantity = JSONBMap(data)
+		data, err := json.Marshal(lien.ReservedQuantity)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal reserved_quantity: %w", err)
 		}
+		entity.ReservedQuantity = JSONBMap(data)
 	}
 	if lien.ValuedAmount != nil {
-		if data, err := json.Marshal(lien.ValuedAmount); err == nil {
-			entity.ValuedAmount = JSONBMap(data)
+		data, err := json.Marshal(lien.ValuedAmount)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal valued_amount: %w", err)
 		}
+		entity.ValuedAmount = JSONBMap(data)
 	}
 	if lien.ValuationAnalysis != nil {
 		entity.ValuationAnalysis = JSONBMap(lien.ValuationAnalysis)
 	}
 
-	return entity
+	return entity, nil
 }
 
 // toLienDomain converts database entity to domain model.

--- a/services/internal-bank-account/adapters/persistence/lien_repository.go
+++ b/services/internal-bank-account/adapters/persistence/lien_repository.go
@@ -1,0 +1,313 @@
+package persistence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Lien repository errors
+var (
+	ErrLienNotFound        = errors.New("lien not found")
+	ErrLienVersionConflict = errors.New("version conflict: lien was modified by another transaction")
+)
+
+// LienRepository provides persistence operations for liens.
+type LienRepository struct {
+	db *gorm.DB
+}
+
+// NewLienRepository creates a new lien repository.
+func NewLienRepository(db *gorm.DB) *LienRepository {
+	return &LienRepository{db: db}
+}
+
+// WithTx returns a new LienRepository that uses the provided transaction.
+func (r *LienRepository) WithTx(tx *gorm.DB) *LienRepository {
+	return &LienRepository{db: tx}
+}
+
+func (r *LienRepository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// Create inserts a new lien.
+func (r *LienRepository) Create(ctx context.Context, lien *domain.Lien) error {
+	entity := toLienEntity(lien)
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Create(entity).Error
+	})
+}
+
+// FindByID retrieves a lien by its UUID.
+func (r *LienRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.Lien, error) {
+	var entity LienEntity
+	var queryErr error
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("id = ?", id).First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, ErrLienNotFound
+		}
+		return nil, err
+	}
+
+	return toLienDomain(&entity)
+}
+
+// FindByIDForUpdate retrieves a lien by its UUID with a pessimistic lock.
+func (r *LienRepository) FindByIDForUpdate(ctx context.Context, id uuid.UUID) (*domain.Lien, error) {
+	var entity LienEntity
+	var queryErr error
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			Where("id = ?", id).
+			First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, ErrLienNotFound
+		}
+		return nil, err
+	}
+
+	return toLienDomain(&entity)
+}
+
+// FindByAccountID retrieves all liens for an account.
+func (r *LienRepository) FindByAccountID(ctx context.Context, accountID uuid.UUID) ([]*domain.Lien, error) {
+	var entities []LienEntity
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Where("account_id = ?", accountID).Find(&entities).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toLienDomainSlice(entities)
+}
+
+// FindActiveByAccountID retrieves all active non-expired liens for an account.
+func (r *LienRepository) FindActiveByAccountID(ctx context.Context, accountID uuid.UUID) ([]*domain.Lien, error) {
+	var entities []LienEntity
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		now := time.Now()
+		return tx.Where(
+			"account_id = ? AND status = ? AND (expires_at IS NULL OR expires_at > ?)",
+			accountID, string(domain.LienStatusActive), now,
+		).Find(&entities).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toLienDomainSlice(entities)
+}
+
+// FindByPaymentOrderReference retrieves a lien by its payment order reference.
+func (r *LienRepository) FindByPaymentOrderReference(ctx context.Context, reference string) (*domain.Lien, error) {
+	var entity LienEntity
+	var queryErr error
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("payment_order_reference = ?", reference).First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, ErrLienNotFound
+		}
+		return nil, err
+	}
+
+	return toLienDomain(&entity)
+}
+
+// Update updates an existing lien with optimistic locking.
+func (r *LienRepository) Update(ctx context.Context, lien *domain.Lien) error {
+	entity := toLienEntity(lien)
+	var rowsAffected int64
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Model(&LienEntity{}).
+			Where("id = ? AND version = ?", entity.ID, lien.Version).
+			Updates(map[string]interface{}{
+				"status":             entity.Status,
+				"termination_reason": entity.TerminationReason,
+				"updated_at":         entity.UpdatedAt,
+				"version":            lien.Version + 1,
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return ErrLienVersionConflict
+	}
+
+	lien.Version++
+	return nil
+}
+
+// CountActiveByAccountID returns the count of active non-expired liens for an account.
+func (r *LienRepository) CountActiveByAccountID(ctx context.Context, accountID uuid.UUID) (int64, error) {
+	var count int64
+	now := time.Now()
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Model(&LienEntity{}).
+			Where("account_id = ? AND status = ? AND (expires_at IS NULL OR expires_at > ?)",
+				accountID, string(domain.LienStatusActive), now).
+			Count(&count).Error
+	})
+	return count, err
+}
+
+// SumActiveAmountByAccountID returns the total amount of active non-expired liens for an account.
+func (r *LienRepository) SumActiveAmountByAccountID(ctx context.Context, accountID uuid.UUID) (int64, error) {
+	var totalCents int64
+	now := time.Now()
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Model(&LienEntity{}).
+			Where("account_id = ? AND status = ? AND (expires_at IS NULL OR expires_at > ?)",
+				accountID, string(domain.LienStatusActive), now).
+			Select("COALESCE(SUM(amount_cents), 0)").
+			Scan(&totalCents).Error
+	})
+	return totalCents, err
+}
+
+// SumActiveAmountByAccountIDAndBucket returns the total amount of active non-expired liens
+// for a specific account and bucket.
+func (r *LienRepository) SumActiveAmountByAccountIDAndBucket(ctx context.Context, accountID uuid.UUID, bucketID string) (int64, error) {
+	var totalCents int64
+	now := time.Now()
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Model(&LienEntity{}).
+			Where("account_id = ? AND bucket_id = ? AND status = ? AND (expires_at IS NULL OR expires_at > ?)",
+				accountID, bucketID, string(domain.LienStatusActive), now).
+			Select("COALESCE(SUM(amount_cents), 0)").
+			Scan(&totalCents).Error
+	})
+	return totalCents, err
+}
+
+// toLienEntity converts domain model to database entity.
+func toLienEntity(lien *domain.Lien) *LienEntity {
+	entity := &LienEntity{
+		ID:                    lien.ID,
+		AccountID:             lien.AccountID,
+		AmountCents:           lien.AmountCents,
+		Currency:              lien.Currency,
+		BucketID:              lien.BucketID,
+		Status:                string(lien.Status),
+		PaymentOrderReference: lien.PaymentOrderReference,
+		TerminationReason:     lien.TerminationReason,
+		ExpiresAt:             lien.ExpiresAt,
+		CreatedAt:             lien.CreatedAt,
+		UpdatedAt:             lien.UpdatedAt,
+		Version:               lien.Version,
+	}
+
+	if lien.ReservedQuantity != nil {
+		if data, err := json.Marshal(lien.ReservedQuantity); err == nil {
+			entity.ReservedQuantity = JSONBMap(data)
+		}
+	}
+	if lien.ValuedAmount != nil {
+		if data, err := json.Marshal(lien.ValuedAmount); err == nil {
+			entity.ValuedAmount = JSONBMap(data)
+		}
+	}
+	if lien.ValuationAnalysis != nil {
+		entity.ValuationAnalysis = JSONBMap(lien.ValuationAnalysis)
+	}
+
+	return entity
+}
+
+// toLienDomain converts database entity to domain model.
+func toLienDomain(entity *LienEntity) (*domain.Lien, error) {
+	lien := &domain.Lien{
+		ID:                    entity.ID,
+		AccountID:             entity.AccountID,
+		AmountCents:           entity.AmountCents,
+		Currency:              entity.Currency,
+		BucketID:              entity.BucketID,
+		Status:                domain.LienStatus(entity.Status),
+		PaymentOrderReference: entity.PaymentOrderReference,
+		TerminationReason:     entity.TerminationReason,
+		ExpiresAt:             entity.ExpiresAt,
+		Version:               entity.Version,
+		CreatedAt:             entity.CreatedAt,
+		UpdatedAt:             entity.UpdatedAt,
+	}
+
+	if entity.ReservedQuantity != nil {
+		var rq domain.InstrumentAmount
+		if err := json.Unmarshal(entity.ReservedQuantity, &rq); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal reserved_quantity: %w", err)
+		}
+		lien.ReservedQuantity = &rq
+	}
+	if entity.ValuedAmount != nil {
+		var va domain.InstrumentAmount
+		if err := json.Unmarshal(entity.ValuedAmount, &va); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal valued_amount: %w", err)
+		}
+		lien.ValuedAmount = &va
+	}
+	if entity.ValuationAnalysis != nil {
+		lien.ValuationAnalysis = json.RawMessage(entity.ValuationAnalysis)
+	}
+
+	return lien, nil
+}
+
+// toLienDomainSlice converts a slice of entities to domain models.
+func toLienDomainSlice(entities []LienEntity) ([]*domain.Lien, error) {
+	liens := make([]*domain.Lien, 0, len(entities))
+	for _, entity := range entities {
+		lien, err := toLienDomain(&entity)
+		if err != nil {
+			return nil, err
+		}
+		liens = append(liens, lien)
+	}
+	return liens, nil
+}

--- a/services/internal-bank-account/domain/lien.go
+++ b/services/internal-bank-account/domain/lien.go
@@ -1,0 +1,201 @@
+package domain
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// Lien domain errors
+var (
+	ErrLienNotActive                = errors.New("lien is not in active status")
+	ErrInvalidLienTransition        = errors.New("invalid lien status transition")
+	ErrLienExpired                  = errors.New("lien has expired")
+	ErrInvalidLienAmount            = errors.New("lien amount must be positive")
+	ErrInvalidLienCurrency          = errors.New("lien currency must not be empty")
+	ErrInvalidPaymentOrderReference = errors.New("payment order reference must not be empty")
+	ErrInvalidInstrumentAmount      = errors.New("instrument amount must be positive with instrument code")
+)
+
+// InstrumentAmount represents a quantity of a specific instrument for valuation tracking.
+type InstrumentAmount struct {
+	Amount         decimal.Decimal `json:"amount"`
+	InstrumentCode string          `json:"instrument_code"`
+}
+
+// IsZero returns true if the instrument amount has not been set.
+func (ia InstrumentAmount) IsZero() bool {
+	return ia.Amount.IsZero() && ia.InstrumentCode == ""
+}
+
+// LienStatus represents the lifecycle state of a lien.
+type LienStatus string
+
+// Lien lifecycle states.
+const (
+	LienStatusActive     LienStatus = "ACTIVE"
+	LienStatusExecuted   LienStatus = "EXECUTED"
+	LienStatusTerminated LienStatus = "TERMINATED"
+)
+
+// Lien represents a fund reservation on an internal bank account.
+// Liens are used by the Payment Order saga to reserve funds before executing payments.
+// Invariant: Available Balance = Current Balance - Sum(Active Liens)
+//
+// Unlike Current Account liens which use a Money type restricted to known currencies,
+// IBA liens store amount_cents + currency directly to support any instrument code
+// (GBP, kWh, GPU_HOUR, TONNE_CO2E, etc.).
+type Lien struct {
+	ID        uuid.UUID
+	AccountID uuid.UUID
+
+	// AmountCents is the reserved amount in minor units of the account's native instrument.
+	AmountCents int64
+	// Currency is the instrument code of the reserved amount (matches account's native instrument).
+	Currency string
+
+	BucketID              string
+	Status                LienStatus
+	PaymentOrderReference string
+	TerminationReason     string
+	ExpiresAt             *time.Time
+	Version               int
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+
+	// ReservedQuantity stores the original input before valuation (e.g., 100 kWh).
+	ReservedQuantity *InstrumentAmount
+	// ValuedAmount stores the price-locked valuation result in the account's native instrument.
+	// IMMUTABLE once the lien is ACTIVE — cannot be modified to prevent Ghost Pricing.
+	ValuedAmount *InstrumentAmount
+	// ValuationAnalysis stores the full audit trail of the valuation computation as JSON.
+	ValuationAnalysis json.RawMessage
+}
+
+// NewLien creates a new lien in ACTIVE status.
+func NewLien(accountID uuid.UUID, amountCents int64, currency, bucketID, paymentOrderReference string, expiresAt *time.Time) (*Lien, error) {
+	if amountCents <= 0 {
+		return nil, ErrInvalidLienAmount
+	}
+	if currency == "" {
+		return nil, ErrInvalidLienCurrency
+	}
+	if paymentOrderReference == "" {
+		return nil, ErrInvalidPaymentOrderReference
+	}
+
+	now := time.Now()
+	return &Lien{
+		ID:                    uuid.New(),
+		AccountID:             accountID,
+		AmountCents:           amountCents,
+		Currency:              currency,
+		BucketID:              bucketID,
+		Status:                LienStatusActive,
+		PaymentOrderReference: paymentOrderReference,
+		ExpiresAt:             expiresAt,
+		Version:               1,
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	}, nil
+}
+
+// NewValuedLien creates a new lien in ACTIVE status with atomic valuation data (price lock).
+// The reservedQuantity is the original input (e.g., 100 kWh), valuedAmount is the
+// price-locked conversion (e.g., 35.00 GBP), and analysisJSON is the full audit trail.
+func NewValuedLien(
+	accountID uuid.UUID,
+	amountCents int64,
+	currency, bucketID, paymentOrderReference string,
+	expiresAt *time.Time,
+	reservedQuantity *InstrumentAmount,
+	valuedAmount *InstrumentAmount,
+	analysisJSON json.RawMessage,
+) (*Lien, error) {
+	if reservedQuantity == nil || reservedQuantity.InstrumentCode == "" || reservedQuantity.Amount.Sign() <= 0 {
+		return nil, ErrInvalidInstrumentAmount
+	}
+	if valuedAmount == nil || valuedAmount.InstrumentCode == "" || valuedAmount.Amount.Sign() <= 0 {
+		return nil, ErrInvalidInstrumentAmount
+	}
+
+	lien, err := NewLien(accountID, amountCents, currency, bucketID, paymentOrderReference, expiresAt)
+	if err != nil {
+		return nil, err
+	}
+	lien.ReservedQuantity = reservedQuantity
+	lien.ValuedAmount = valuedAmount
+	lien.ValuationAnalysis = analysisJSON
+	return lien, nil
+}
+
+// HasValuation returns true if this lien was created through atomic valuation.
+func (l *Lien) HasValuation() bool {
+	return l.ValuedAmount != nil && !l.ValuedAmount.IsZero()
+}
+
+// Execute transitions the lien to EXECUTED status (terminal state).
+// Idempotent: returns nil if already executed.
+// Returns ErrLienExpired if the lien has passed its expiration time.
+func (l *Lien) Execute() error {
+	if l.Status == LienStatusExecuted {
+		return nil
+	}
+	if l.Status != LienStatusActive {
+		return ErrLienNotActive
+	}
+	if l.IsExpired() {
+		return ErrLienExpired
+	}
+
+	l.Status = LienStatusExecuted
+	l.UpdatedAt = time.Now()
+	return nil
+}
+
+// Terminate transitions the lien to TERMINATED status (terminal state).
+// Idempotent: returns nil if already terminated (preserves original reason).
+func (l *Lien) Terminate(reason string) error {
+	if l.Status == LienStatusTerminated {
+		return nil
+	}
+	if l.Status != LienStatusActive {
+		return ErrLienNotActive
+	}
+
+	l.Status = LienStatusTerminated
+	l.TerminationReason = reason
+	l.UpdatedAt = time.Now()
+	return nil
+}
+
+// IsActive returns true if the lien is in ACTIVE status.
+func (l *Lien) IsActive() bool {
+	return l.Status == LienStatusActive
+}
+
+// IsTerminal returns true if the lien is in a terminal state (EXECUTED or TERMINATED).
+func (l *Lien) IsTerminal() bool {
+	return l.Status == LienStatusExecuted || l.Status == LienStatusTerminated
+}
+
+// IsExpired returns true if the lien has an expiration time that has passed.
+func (l *Lien) IsExpired() bool {
+	if l.ExpiresAt == nil {
+		return false
+	}
+	return time.Now().After(*l.ExpiresAt)
+}
+
+// CanExecute returns true if the lien can be executed.
+func (l *Lien) CanExecute() bool {
+	return l.Status == LienStatusActive && !l.IsExpired()
+}
+
+// CanTerminate returns true if the lien can be terminated.
+func (l *Lien) CanTerminate() bool {
+	return l.Status == LienStatusActive
+}

--- a/services/internal-bank-account/domain/lien_test.go
+++ b/services/internal-bank-account/domain/lien_test.go
@@ -1,0 +1,394 @@
+package domain
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- NewLien tests ---
+
+func TestNewLien_Success(t *testing.T) {
+	accountID := uuid.New()
+
+	lien, err := NewLien(accountID, 10000, "GBP", "bucket-123", "PO-001", nil)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, lien.ID)
+	assert.Equal(t, accountID, lien.AccountID)
+	assert.Equal(t, int64(10000), lien.AmountCents)
+	assert.Equal(t, "GBP", lien.Currency)
+	assert.Equal(t, "bucket-123", lien.BucketID)
+	assert.Equal(t, LienStatusActive, lien.Status)
+	assert.Equal(t, "PO-001", lien.PaymentOrderReference)
+	assert.Equal(t, 1, lien.Version)
+	assert.Nil(t, lien.ExpiresAt)
+	assert.Nil(t, lien.ReservedQuantity)
+	assert.Nil(t, lien.ValuedAmount)
+	assert.Nil(t, lien.ValuationAnalysis)
+}
+
+func TestNewLien_EmptyBucketID(t *testing.T) {
+	accountID := uuid.New()
+
+	lien, err := NewLien(accountID, 10000, "GBP", "", "PO-001", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, "", lien.BucketID)
+}
+
+func TestNewLien_WithExpiration(t *testing.T) {
+	accountID := uuid.New()
+	expiresAt := time.Now().Add(24 * time.Hour)
+
+	lien, err := NewLien(accountID, 10000, "GBP", "", "PO-001", &expiresAt)
+
+	require.NoError(t, err)
+	require.NotNil(t, lien.ExpiresAt)
+	assert.Equal(t, expiresAt.Unix(), lien.ExpiresAt.Unix())
+}
+
+func TestNewLien_MultiAssetInstrument(t *testing.T) {
+	accountID := uuid.New()
+
+	// IBA supports any instrument code, not just currencies
+	lien, err := NewLien(accountID, 50000, "kWh", "", "PO-ENERGY-001", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(50000), lien.AmountCents)
+	assert.Equal(t, "kWh", lien.Currency)
+}
+
+func TestNewLien_ZeroAmount_Fails(t *testing.T) {
+	_, err := NewLien(uuid.New(), 0, "GBP", "", "PO-001", nil)
+	assert.ErrorIs(t, err, ErrInvalidLienAmount)
+}
+
+func TestNewLien_NegativeAmount_Fails(t *testing.T) {
+	_, err := NewLien(uuid.New(), -10000, "GBP", "", "PO-001", nil)
+	assert.ErrorIs(t, err, ErrInvalidLienAmount)
+}
+
+func TestNewLien_EmptyCurrency_Fails(t *testing.T) {
+	_, err := NewLien(uuid.New(), 10000, "", "", "PO-001", nil)
+	assert.ErrorIs(t, err, ErrInvalidLienCurrency)
+}
+
+func TestNewLien_EmptyPaymentOrderReference_Fails(t *testing.T) {
+	_, err := NewLien(uuid.New(), 10000, "GBP", "", "", nil)
+	assert.ErrorIs(t, err, ErrInvalidPaymentOrderReference)
+}
+
+// --- NewValuedLien tests ---
+
+func TestNewValuedLien_Success(t *testing.T) {
+	accountID := uuid.New()
+	reserved := &InstrumentAmount{
+		Amount:         decimal.NewFromInt(100),
+		InstrumentCode: "kWh",
+	}
+	valued := &InstrumentAmount{
+		Amount:         decimal.NewFromFloat(35.50),
+		InstrumentCode: "GBP",
+	}
+	analysis := json.RawMessage(`{"method_id":"test","version":"1"}`)
+
+	lien, err := NewValuedLien(accountID, 3550, "GBP", "", "PO-VALUED-001", nil, reserved, valued, analysis)
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(3550), lien.AmountCents)
+	assert.Equal(t, "GBP", lien.Currency)
+	assert.True(t, lien.HasValuation())
+	assert.Equal(t, "kWh", lien.ReservedQuantity.InstrumentCode)
+	assert.True(t, lien.ReservedQuantity.Amount.Equal(decimal.NewFromInt(100)))
+	assert.Equal(t, "GBP", lien.ValuedAmount.InstrumentCode)
+	assert.True(t, lien.ValuedAmount.Amount.Equal(decimal.NewFromFloat(35.50)))
+	assert.NotNil(t, lien.ValuationAnalysis)
+}
+
+func TestNewValuedLien_NilReservedQuantity_Fails(t *testing.T) {
+	valued := &InstrumentAmount{Amount: decimal.NewFromInt(35), InstrumentCode: "GBP"}
+
+	_, err := NewValuedLien(uuid.New(), 3500, "GBP", "", "PO-001", nil, nil, valued, nil)
+
+	assert.ErrorIs(t, err, ErrInvalidInstrumentAmount)
+}
+
+func TestNewValuedLien_NilValuedAmount_Fails(t *testing.T) {
+	reserved := &InstrumentAmount{Amount: decimal.NewFromInt(100), InstrumentCode: "kWh"}
+
+	_, err := NewValuedLien(uuid.New(), 3500, "GBP", "", "PO-001", nil, reserved, nil, nil)
+
+	assert.ErrorIs(t, err, ErrInvalidInstrumentAmount)
+}
+
+func TestNewValuedLien_EmptyReservedInstrumentCode_Fails(t *testing.T) {
+	reserved := &InstrumentAmount{Amount: decimal.NewFromInt(100), InstrumentCode: ""}
+	valued := &InstrumentAmount{Amount: decimal.NewFromInt(35), InstrumentCode: "GBP"}
+
+	_, err := NewValuedLien(uuid.New(), 3500, "GBP", "", "PO-001", nil, reserved, valued, nil)
+
+	assert.ErrorIs(t, err, ErrInvalidInstrumentAmount)
+}
+
+func TestNewValuedLien_ZeroReservedAmount_Fails(t *testing.T) {
+	reserved := &InstrumentAmount{Amount: decimal.Zero, InstrumentCode: "kWh"}
+	valued := &InstrumentAmount{Amount: decimal.NewFromInt(35), InstrumentCode: "GBP"}
+
+	_, err := NewValuedLien(uuid.New(), 3500, "GBP", "", "PO-001", nil, reserved, valued, nil)
+
+	assert.ErrorIs(t, err, ErrInvalidInstrumentAmount)
+}
+
+func TestNewValuedLien_ZeroValuedAmount_Fails(t *testing.T) {
+	reserved := &InstrumentAmount{Amount: decimal.NewFromInt(100), InstrumentCode: "kWh"}
+	valued := &InstrumentAmount{Amount: decimal.Zero, InstrumentCode: "GBP"}
+
+	_, err := NewValuedLien(uuid.New(), 3500, "GBP", "", "PO-001", nil, reserved, valued, nil)
+
+	assert.ErrorIs(t, err, ErrInvalidInstrumentAmount)
+}
+
+// --- Execute tests ---
+
+func TestLien_Execute_FromActive(t *testing.T) {
+	lien := createTestLien(t, LienStatusActive)
+
+	err := lien.Execute()
+
+	assert.NoError(t, err)
+	assert.Equal(t, LienStatusExecuted, lien.Status)
+}
+
+func TestLien_Execute_Idempotent(t *testing.T) {
+	lien := createTestLien(t, LienStatusActive)
+
+	err := lien.Execute()
+	require.NoError(t, err)
+
+	err = lien.Execute()
+	assert.NoError(t, err)
+	assert.Equal(t, LienStatusExecuted, lien.Status)
+}
+
+func TestLien_Execute_FromTerminated_Fails(t *testing.T) {
+	lien := createTestLien(t, LienStatusTerminated)
+
+	err := lien.Execute()
+
+	assert.ErrorIs(t, err, ErrLienNotActive)
+}
+
+func TestLien_Execute_Expired_Fails(t *testing.T) {
+	lien := createTestLien(t, LienStatusActive)
+	past := time.Now().Add(-1 * time.Hour)
+	lien.ExpiresAt = &past
+
+	err := lien.Execute()
+
+	assert.ErrorIs(t, err, ErrLienExpired)
+	assert.Equal(t, LienStatusActive, lien.Status)
+}
+
+// --- Terminate tests ---
+
+func TestLien_Terminate_FromActive(t *testing.T) {
+	lien := createTestLien(t, LienStatusActive)
+
+	err := lien.Terminate("Payment cancelled")
+
+	assert.NoError(t, err)
+	assert.Equal(t, LienStatusTerminated, lien.Status)
+	assert.Equal(t, "Payment cancelled", lien.TerminationReason)
+}
+
+func TestLien_Terminate_Idempotent(t *testing.T) {
+	lien := createTestLien(t, LienStatusActive)
+
+	err := lien.Terminate("Payment cancelled")
+	require.NoError(t, err)
+
+	err = lien.Terminate("Different reason")
+	assert.NoError(t, err)
+	assert.Equal(t, LienStatusTerminated, lien.Status)
+	assert.Equal(t, "Payment cancelled", lien.TerminationReason)
+}
+
+func TestLien_Terminate_FromExecuted_Fails(t *testing.T) {
+	lien := createTestLien(t, LienStatusExecuted)
+
+	err := lien.Terminate("Payment cancelled")
+
+	assert.ErrorIs(t, err, ErrLienNotActive)
+}
+
+// --- Status helper tests ---
+
+func TestLien_IsActive(t *testing.T) {
+	tests := []struct {
+		status   LienStatus
+		expected bool
+	}{
+		{LienStatusActive, true},
+		{LienStatusExecuted, false},
+		{LienStatusTerminated, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			lien := createTestLien(t, tc.status)
+			assert.Equal(t, tc.expected, lien.IsActive())
+		})
+	}
+}
+
+func TestLien_IsTerminal(t *testing.T) {
+	tests := []struct {
+		status   LienStatus
+		expected bool
+	}{
+		{LienStatusActive, false},
+		{LienStatusExecuted, true},
+		{LienStatusTerminated, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			lien := createTestLien(t, tc.status)
+			assert.Equal(t, tc.expected, lien.IsTerminal())
+		})
+	}
+}
+
+func TestLien_IsExpired(t *testing.T) {
+	t.Run("no expiration", func(t *testing.T) {
+		lien := createTestLien(t, LienStatusActive)
+		lien.ExpiresAt = nil
+		assert.False(t, lien.IsExpired())
+	})
+
+	t.Run("future expiration", func(t *testing.T) {
+		lien := createTestLien(t, LienStatusActive)
+		future := time.Now().Add(24 * time.Hour)
+		lien.ExpiresAt = &future
+		assert.False(t, lien.IsExpired())
+	})
+
+	t.Run("past expiration", func(t *testing.T) {
+		lien := createTestLien(t, LienStatusActive)
+		past := time.Now().Add(-1 * time.Hour)
+		lien.ExpiresAt = &past
+		assert.True(t, lien.IsExpired())
+	})
+}
+
+func TestLien_CanExecute(t *testing.T) {
+	t.Run("active not expired", func(t *testing.T) {
+		lien := createTestLien(t, LienStatusActive)
+		assert.True(t, lien.CanExecute())
+	})
+
+	t.Run("active but expired", func(t *testing.T) {
+		lien := createTestLien(t, LienStatusActive)
+		past := time.Now().Add(-1 * time.Hour)
+		lien.ExpiresAt = &past
+		assert.False(t, lien.CanExecute())
+	})
+
+	t.Run("executed", func(t *testing.T) {
+		lien := createTestLien(t, LienStatusExecuted)
+		assert.False(t, lien.CanExecute())
+	})
+
+	t.Run("terminated", func(t *testing.T) {
+		lien := createTestLien(t, LienStatusTerminated)
+		assert.False(t, lien.CanExecute())
+	})
+}
+
+func TestLien_CanTerminate(t *testing.T) {
+	tests := []struct {
+		status   LienStatus
+		expected bool
+	}{
+		{LienStatusActive, true},
+		{LienStatusExecuted, false},
+		{LienStatusTerminated, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			lien := createTestLien(t, tc.status)
+			assert.Equal(t, tc.expected, lien.CanTerminate())
+		})
+	}
+}
+
+// --- HasValuation tests ---
+
+func TestLien_HasValuation(t *testing.T) {
+	t.Run("without valuation", func(t *testing.T) {
+		lien := createTestLien(t, LienStatusActive)
+		assert.False(t, lien.HasValuation())
+	})
+
+	t.Run("with valuation", func(t *testing.T) {
+		lien := createTestLien(t, LienStatusActive)
+		lien.ValuedAmount = &InstrumentAmount{
+			Amount:         decimal.NewFromFloat(35.50),
+			InstrumentCode: "GBP",
+		}
+		assert.True(t, lien.HasValuation())
+	})
+
+	t.Run("with zero valued amount", func(t *testing.T) {
+		lien := createTestLien(t, LienStatusActive)
+		lien.ValuedAmount = &InstrumentAmount{
+			Amount:         decimal.Zero,
+			InstrumentCode: "",
+		}
+		assert.False(t, lien.HasValuation())
+	})
+}
+
+// --- InstrumentAmount tests ---
+
+func TestInstrumentAmount_IsZero(t *testing.T) {
+	t.Run("zero amount empty code", func(t *testing.T) {
+		ia := InstrumentAmount{}
+		assert.True(t, ia.IsZero())
+	})
+
+	t.Run("non-zero amount", func(t *testing.T) {
+		ia := InstrumentAmount{Amount: decimal.NewFromInt(100), InstrumentCode: "kWh"}
+		assert.False(t, ia.IsZero())
+	})
+
+	t.Run("zero amount with code", func(t *testing.T) {
+		ia := InstrumentAmount{Amount: decimal.Zero, InstrumentCode: "kWh"}
+		assert.False(t, ia.IsZero())
+	})
+}
+
+// --- Test helper ---
+
+func createTestLien(t *testing.T, status LienStatus) *Lien {
+	t.Helper()
+	now := time.Now()
+	return &Lien{
+		ID:                    uuid.New(),
+		AccountID:             uuid.New(),
+		AmountCents:           10000,
+		Currency:              "GBP",
+		Status:                status,
+		PaymentOrderReference: "PO-TEST-001",
+		Version:               1,
+		CreatedAt:             now,
+		UpdatedAt:             now,
+	}
+}

--- a/services/internal-bank-account/migrations/20260207000001_create_lien_table.sql
+++ b/services/internal-bank-account/migrations/20260207000001_create_lien_table.sql
@@ -1,0 +1,66 @@
+-- Create lien table for fund reservations on internal bank accounts
+-- Mirrors the Current Account lien infrastructure for multi-asset valuation support
+-- Liens reserve funds (available balance = current balance - sum of active liens)
+
+CREATE TABLE IF NOT EXISTS lien (
+    -- Primary key
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Foreign key to internal bank account
+    account_id UUID NOT NULL,
+
+    -- Monetary amount (stored in account's native instrument as minor units)
+    amount_cents BIGINT NOT NULL,
+    currency VARCHAR(3) NOT NULL,
+
+    -- Bucket identifier for bucket-aware reservations (fungibility key)
+    -- Empty string represents the default bucket for backward compatibility
+    bucket_id VARCHAR(255) NOT NULL DEFAULT '',
+
+    -- Lifecycle state: ACTIVE -> EXECUTED or TERMINATED (terminal)
+    status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+
+    -- Reference to the payment order that created this lien (unique per payment order)
+    payment_order_reference VARCHAR(255) NOT NULL,
+
+    -- Reason for termination (only set when status is TERMINATED)
+    termination_reason VARCHAR(1000),
+
+    -- Optional expiration time for automatic termination of stale liens
+    expires_at TIMESTAMPTZ,
+
+    -- Valuation fields for atomic price lock (nullable for backward compatibility)
+    -- reserved_quantity stores the original input before valuation (e.g., 100 kWh)
+    reserved_quantity JSONB,
+    -- valued_amount stores the price-locked valuation result (e.g., 35.00 GBP)
+    valued_amount JSONB,
+    -- valuation_analysis stores the full valuation audit trail
+    valuation_analysis JSONB,
+
+    -- Audit fields
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version INT NOT NULL DEFAULT 1,
+
+    -- Constraints
+    CONSTRAINT chk_lien_amount_positive CHECK (amount_cents > 0),
+    CONSTRAINT chk_lien_status CHECK (status IN ('ACTIVE', 'EXECUTED', 'TERMINATED')),
+    CONSTRAINT fk_lien_internal_bank_account
+        FOREIGN KEY (account_id) REFERENCES "internal_bank_account" (id)
+        ON UPDATE NO ACTION ON DELETE RESTRICT
+);
+
+-- Composite index for querying active liens per account
+CREATE INDEX idx_lien_account_status ON lien(account_id, status);
+
+-- Composite index for bucket-scoped queries
+CREATE INDEX idx_lien_account_bucket ON lien(account_id, bucket_id);
+
+-- Index for finding stale/expired liens for cleanup
+CREATE INDEX idx_lien_expires_at ON lien(expires_at);
+
+-- Unique index for idempotency: each payment order has at most one lien
+CREATE UNIQUE INDEX idx_lien_payment_order ON lien(payment_order_reference);
+
+COMMENT ON TABLE lien IS
+    'Fund reservations on internal bank accounts. Invariant: Available Balance = Current Balance - Sum(Active Liens). Supports multi-asset valuation with price lock for Ghost Pricing prevention.';

--- a/services/internal-bank-account/service/lien_service.go
+++ b/services/internal-bank-account/service/lien_service.go
@@ -82,7 +82,11 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 	// Check idempotency: if a lien already exists for this payment order reference, return it
 	existingLien, err := s.lienRepo.FindByPaymentOrderReference(ctx, req.PaymentOrderReference)
 	if err == nil {
-		// Lien already exists - return it for idempotency
+		if existingLien.AccountID != account.ID() {
+			operationStatus = opStatusInvalidRequest
+			return nil, status.Errorf(codes.InvalidArgument,
+				"payment_order_reference already used for a different account")
+		}
 		operationStatus = opStatusLienAlreadyExists
 		return s.buildInitiateLienResponse(existingLien), nil
 	}

--- a/services/internal-bank-account/service/lien_service.go
+++ b/services/internal-bank-account/service/lien_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"strconv"
 	"strings"
 	"time"
 
@@ -81,16 +80,7 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 	if err == nil {
 		// Lien already exists - return it for idempotency
 		operationStatus = opStatusLienAlreadyExists
-		resp := &pb.InitiateLienResponse{
-			Lien: s.domainToProtoLien(existingLien),
-		}
-		if existingLien.HasValuation() {
-			resp.ValuedAmount = &quantityv1.InstrumentAmount{
-				Amount:         existingLien.ValuedAmount.Amount.String(),
-				InstrumentCode: existingLien.ValuedAmount.InstrumentCode,
-			}
-		}
-		return resp, nil
+		return s.buildInitiateLienResponse(existingLien), nil
 	}
 	if !errors.Is(err, persistence.ErrLienNotFound) {
 		operationStatus = operationStatusFailed
@@ -154,9 +144,10 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 			}
 		}
 
-		// Build valued lien
+		// Build valued lien: convert output amount to minor units.
+		// TODO: Use instrument precision from reference data instead of hardcoded 2.
 		amountCents := result.OutputAmount.Shift(2).IntPart()
-		if amountCents <= 0 {
+		if amountCents == 0 {
 			amountCents = result.OutputAmount.IntPart()
 		}
 
@@ -195,9 +186,7 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 				operationStatus = opStatusLienCreateFailed
 				return nil, status.Errorf(codes.Internal, "lien creation race condition: %v", err)
 			}
-			return &pb.InitiateLienResponse{
-				Lien: s.domainToProtoLien(existingLien),
-			}, nil
+			return s.buildInitiateLienResponse(existingLien), nil
 		}
 		operationStatus = opStatusLienCreateFailed
 		return nil, status.Errorf(codes.Internal, "failed to create lien: %v", err)
@@ -210,23 +199,7 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		"currency", lien.Currency,
 		"has_valuation", lien.HasValuation())
 
-	resp := &pb.InitiateLienResponse{
-		Lien: s.domainToProtoLien(lien),
-	}
-	if lien.HasValuation() {
-		resp.ValuedAmount = &quantityv1.InstrumentAmount{
-			Amount:         lien.ValuedAmount.Amount.String(),
-			InstrumentCode: lien.ValuedAmount.InstrumentCode,
-		}
-		if lien.ValuationAnalysis != nil {
-			var analysis pb.ValuationAnalysis
-			if err := json.Unmarshal(lien.ValuationAnalysis, &analysis); err == nil {
-				resp.Basis = &analysis
-			}
-		}
-	}
-
-	return resp, nil
+	return s.buildInitiateLienResponse(lien), nil
 }
 
 // ExecuteLien converts a lien reservation to an actual debit.
@@ -276,6 +249,13 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		}
 		operationStatus = operationStatusFailed
 		return nil, status.Errorf(codes.Internal, "failed to lock lien: %v", err)
+	}
+
+	// Re-check after lock: another request may have executed between read and lock
+	if lien.Status == domain.LienStatusExecuted {
+		return &pb.ExecuteLienResponse{
+			Lien: s.domainToProtoLien(lien),
+		}, nil
 	}
 
 	// Execute the domain transition
@@ -360,6 +340,13 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		return nil, status.Errorf(codes.Internal, "failed to lock lien: %v", err)
 	}
 
+	// Re-check after lock: another request may have terminated between read and lock
+	if lien.Status == domain.LienStatusTerminated {
+		return &pb.TerminateLienResponse{
+			Lien: s.domainToProtoLien(lien),
+		}, nil
+	}
+
 	// Terminate the domain transition
 	if err := lien.Terminate(req.Reason); err != nil {
 		if errors.Is(err, domain.ErrLienNotActive) {
@@ -424,13 +411,38 @@ func (s *Service) RetrieveLien(ctx context.Context, req *pb.RetrieveLienRequest)
 	}, nil
 }
 
+// buildInitiateLienResponse constructs a consistent InitiateLienResponse
+// including valuation fields when present.
+func (s *Service) buildInitiateLienResponse(lien *domain.Lien) *pb.InitiateLienResponse {
+	resp := &pb.InitiateLienResponse{
+		Lien: s.domainToProtoLien(lien),
+	}
+	if lien.HasValuation() {
+		resp.ValuedAmount = &quantityv1.InstrumentAmount{
+			Amount:         lien.ValuedAmount.Amount.String(),
+			InstrumentCode: lien.ValuedAmount.InstrumentCode,
+		}
+		if lien.ValuationAnalysis != nil {
+			var analysis pb.ValuationAnalysis
+			if err := json.Unmarshal(lien.ValuationAnalysis, &analysis); err == nil {
+				resp.Basis = &analysis
+			}
+		}
+	}
+	return resp
+}
+
 // domainToProtoLien converts a domain Lien to proto Lien.
+// AmountCents is stored as minor units (e.g. 10000 = 100.00 GBP).
+// TODO: Use instrument precision from reference data instead of hardcoded 2.
 func (s *Service) domainToProtoLien(lien *domain.Lien) *pb.Lien {
+	displayAmount := decimal.NewFromInt(lien.AmountCents).Shift(-2).String()
+
 	protoLien := &pb.Lien{
 		LienId:    lien.ID.String(),
 		AccountId: lien.AccountID.String(),
 		Amount: &quantityv1.InstrumentAmount{
-			Amount:         strconv.FormatInt(lien.AmountCents, 10),
+			Amount:         displayAmount,
 			InstrumentCode: lien.Currency,
 		},
 		Status:                mapLienStatusToProto(lien.Status),

--- a/services/internal-bank-account/service/lien_service.go
+++ b/services/internal-bank-account/service/lien_service.go
@@ -1,0 +1,466 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/internal_bank_account/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"github.com/meridianhub/meridian/services/internal-bank-account/adapters/persistence"
+	"github.com/meridianhub/meridian/services/internal-bank-account/domain"
+	ibaobservability "github.com/meridianhub/meridian/services/internal-bank-account/observability"
+	"github.com/shopspring/decimal"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Lien-specific operation status constants for metrics.
+const (
+	opStatusLienRepoNil         = "lien_repo_nil"
+	opStatusLienNotFound        = "lien_not_found"
+	opStatusLienAlreadyExists   = "lien_already_exists"
+	opStatusLienExpired         = "lien_expired"
+	opStatusLienNotActive       = "lien_not_active"
+	opStatusLienVersionConflict = "lien_version_conflict"
+	opStatusLienCreateFailed    = "lien_create_failed"
+	opStatusLienUpdateFailed    = "lien_update_failed"
+)
+
+// InitiateLien creates a new fund reservation on an internal bank account.
+// Supports multi-asset input with atomic valuation (price lock) via valuateInternal().
+// CRITICAL: Uses the same valuateInternal() logic as EvaluateAssetValuation to prevent Ghost Pricing.
+func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest) (*pb.InitiateLienResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		ibaobservability.RecordOperationDuration("initiate_lien", operationStatus, time.Since(start))
+	}()
+
+	if s.lienRepo == nil {
+		operationStatus = opStatusLienRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
+	}
+
+	// Validate input
+	if req.Input == nil || req.Input.Amount == "" {
+		operationStatus = opStatusInvalidRequest
+		return nil, status.Error(codes.InvalidArgument, "input amount is required")
+	}
+	if req.Input.InstrumentCode == "" {
+		operationStatus = opStatusInvalidRequest
+		return nil, status.Error(codes.InvalidArgument, "input instrument_code is required")
+	}
+
+	inputAmount, err := decimal.NewFromString(req.Input.Amount)
+	if err != nil {
+		operationStatus = opStatusInvalidInputAmount
+		return nil, status.Errorf(codes.InvalidArgument, "invalid input amount: %v", err)
+	}
+	if !inputAmount.IsPositive() {
+		operationStatus = opStatusInputAmountNonPositive
+		return nil, status.Error(codes.InvalidArgument, "input amount must be positive")
+	}
+
+	// Resolve account
+	account, err := s.findAccountByID(ctx, req.AccountId)
+	if err != nil {
+		operationStatus = opStatusAccountNotFound
+		return nil, err
+	}
+
+	nativeInstrument := account.InstrumentCode()
+
+	// Check idempotency: if a lien already exists for this payment order reference, return it
+	existingLien, err := s.lienRepo.FindByPaymentOrderReference(ctx, req.PaymentOrderReference)
+	if err == nil {
+		// Lien already exists - return it for idempotency
+		operationStatus = opStatusLienAlreadyExists
+		resp := &pb.InitiateLienResponse{
+			Lien: s.domainToProtoLien(existingLien),
+		}
+		if existingLien.HasValuation() {
+			resp.ValuedAmount = &quantityv1.InstrumentAmount{
+				Amount:         existingLien.ValuedAmount.Amount.String(),
+				InstrumentCode: existingLien.ValuedAmount.InstrumentCode,
+			}
+		}
+		return resp, nil
+	}
+	if !errors.Is(err, persistence.ErrLienNotFound) {
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to check lien idempotency: %v", err)
+	}
+
+	// Determine knowledge_at for valuation
+	knowledgeAt := time.Now()
+	if req.KnowledgeAt != nil {
+		knowledgeAt = req.KnowledgeAt.AsTime()
+	}
+
+	// Determine expires_at
+	var expiresAt *time.Time
+	if req.ExpiresAt != nil {
+		t := req.ExpiresAt.AsTime()
+		expiresAt = &t
+	}
+
+	var lien *domain.Lien
+
+	if req.Input.InstrumentCode == nativeInstrument {
+		// Same-instrument lien: no valuation needed
+		// Convert decimal amount to cents (minor units)
+		amountCents := inputAmount.Shift(2).IntPart() // Assume 2 decimal places for native instrument
+		if amountCents <= 0 {
+			// For instruments with no decimal places, use the raw amount
+			amountCents = inputAmount.IntPart()
+		}
+
+		lien, err = domain.NewLien(account.ID(), amountCents, nativeInstrument, req.BucketId, req.PaymentOrderReference, expiresAt)
+		if err != nil {
+			operationStatus = opStatusInvalidRequest
+			return nil, status.Errorf(codes.InvalidArgument, "failed to create lien: %v", err)
+		}
+	} else {
+		// Cross-instrument lien: perform atomic valuation via valuateInternal()
+		result, err := s.valuateInternal(ctx, req.AccountId, inputAmount, req.Input.InstrumentCode, knowledgeAt)
+		if err != nil {
+			switch {
+			case errors.Is(err, ErrValuationAccountNotFound):
+				operationStatus = opStatusAccountNotFound
+				return nil, status.Errorf(codes.NotFound, "%v", err)
+			case errors.Is(err, ErrNoActiveValuationFeature):
+				operationStatus = opStatusNoValuationFeature
+				return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+			case errors.Is(err, ErrValuationFeatureNotActive):
+				operationStatus = opStatusFeatureNotActive
+				return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+			case errors.Is(err, ErrValuationRepoNotConfigured):
+				operationStatus = opStatusValuationFeatureRepoNil
+				return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+			case errors.Is(err, ErrValuationEngineFailed):
+				operationStatus = opStatusValuationFailed
+				return nil, status.Errorf(codes.Internal, "%v", err)
+			default:
+				operationStatus = opStatusValuationFailed
+				return nil, status.Errorf(codes.Internal, "valuation failed: %v", err)
+			}
+		}
+
+		// Build valued lien
+		amountCents := result.OutputAmount.Shift(2).IntPart()
+		if amountCents <= 0 {
+			amountCents = result.OutputAmount.IntPart()
+		}
+
+		reservedQuantity := &domain.InstrumentAmount{
+			Amount:         inputAmount,
+			InstrumentCode: req.Input.InstrumentCode,
+		}
+		valuedAmount := &domain.InstrumentAmount{
+			Amount:         result.OutputAmount,
+			InstrumentCode: result.OutputCode,
+		}
+
+		var analysisJSON json.RawMessage
+		if result.Analysis != nil {
+			analysisJSON, _ = json.Marshal(result.Analysis)
+		}
+
+		lien, err = domain.NewValuedLien(
+			account.ID(), amountCents, nativeInstrument, req.BucketId,
+			req.PaymentOrderReference, expiresAt,
+			reservedQuantity, valuedAmount, analysisJSON,
+		)
+		if err != nil {
+			operationStatus = opStatusInvalidRequest
+			return nil, status.Errorf(codes.InvalidArgument, "failed to create valued lien: %v", err)
+		}
+	}
+
+	// Persist the lien
+	if err := s.lienRepo.Create(ctx, lien); err != nil {
+		if isDuplicatePaymentOrderRef(err) {
+			// Race condition: another request created the lien between our check and create.
+			// Return the existing lien for idempotency.
+			existingLien, findErr := s.lienRepo.FindByPaymentOrderReference(ctx, req.PaymentOrderReference)
+			if findErr != nil {
+				operationStatus = opStatusLienCreateFailed
+				return nil, status.Errorf(codes.Internal, "lien creation race condition: %v", err)
+			}
+			return &pb.InitiateLienResponse{
+				Lien: s.domainToProtoLien(existingLien),
+			}, nil
+		}
+		operationStatus = opStatusLienCreateFailed
+		return nil, status.Errorf(codes.Internal, "failed to create lien: %v", err)
+	}
+
+	s.logger.Info("created lien",
+		"lien_id", lien.ID,
+		"account_id", req.AccountId,
+		"amount_cents", lien.AmountCents,
+		"currency", lien.Currency,
+		"has_valuation", lien.HasValuation())
+
+	resp := &pb.InitiateLienResponse{
+		Lien: s.domainToProtoLien(lien),
+	}
+	if lien.HasValuation() {
+		resp.ValuedAmount = &quantityv1.InstrumentAmount{
+			Amount:         lien.ValuedAmount.Amount.String(),
+			InstrumentCode: lien.ValuedAmount.InstrumentCode,
+		}
+		if lien.ValuationAnalysis != nil {
+			var analysis pb.ValuationAnalysis
+			if err := json.Unmarshal(lien.ValuationAnalysis, &analysis); err == nil {
+				resp.Basis = &analysis
+			}
+		}
+	}
+
+	return resp, nil
+}
+
+// ExecuteLien converts a lien reservation to an actual debit.
+// Transitions the lien from ACTIVE to EXECUTED (terminal state, idempotent).
+func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (*pb.ExecuteLienResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		ibaobservability.RecordOperationDuration("execute_lien", operationStatus, time.Since(start))
+	}()
+
+	if s.lienRepo == nil {
+		operationStatus = opStatusLienRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
+	}
+
+	lienID, err := uuid.Parse(req.LienId)
+	if err != nil {
+		operationStatus = opStatusInvalidRequest
+		return nil, status.Errorf(codes.InvalidArgument, "invalid lien_id: %v", err)
+	}
+
+	// Read-only idempotency check: if already executed, return directly
+	lien, err := s.lienRepo.FindByID(ctx, lienID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrLienNotFound) {
+			operationStatus = opStatusLienNotFound
+			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
+		}
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve lien: %v", err)
+	}
+
+	if lien.Status == domain.LienStatusExecuted {
+		// Idempotent: already executed
+		return &pb.ExecuteLienResponse{
+			Lien: s.domainToProtoLien(lien),
+		}, nil
+	}
+
+	// Execute the domain transition
+	if err := lien.Execute(); err != nil {
+		if errors.Is(err, domain.ErrLienNotActive) {
+			operationStatus = opStatusLienNotActive
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot execute lien: %v", err)
+		}
+		if errors.Is(err, domain.ErrLienExpired) {
+			operationStatus = opStatusLienExpired
+			return nil, status.Errorf(codes.FailedPrecondition, "lien has expired: %s", req.LienId)
+		}
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to execute lien: %v", err)
+	}
+
+	// Persist with optimistic locking
+	if err := s.lienRepo.Update(ctx, lien); err != nil {
+		if errors.Is(err, persistence.ErrLienVersionConflict) {
+			operationStatus = opStatusLienVersionConflict
+			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+		}
+		operationStatus = opStatusLienUpdateFailed
+		return nil, status.Errorf(codes.Internal, "failed to update lien: %v", err)
+	}
+
+	s.logger.Info("executed lien",
+		"lien_id", lien.ID,
+		"account_id", lien.AccountID)
+
+	return &pb.ExecuteLienResponse{
+		Lien: s.domainToProtoLien(lien),
+	}, nil
+}
+
+// TerminateLien releases reserved funds without executing.
+// Transitions the lien from ACTIVE to TERMINATED (terminal state, idempotent).
+func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienRequest) (*pb.TerminateLienResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		ibaobservability.RecordOperationDuration("terminate_lien", operationStatus, time.Since(start))
+	}()
+
+	if s.lienRepo == nil {
+		operationStatus = opStatusLienRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
+	}
+
+	lienID, err := uuid.Parse(req.LienId)
+	if err != nil {
+		operationStatus = opStatusInvalidRequest
+		return nil, status.Errorf(codes.InvalidArgument, "invalid lien_id: %v", err)
+	}
+
+	// Read-only idempotency check
+	lien, err := s.lienRepo.FindByID(ctx, lienID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrLienNotFound) {
+			operationStatus = opStatusLienNotFound
+			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
+		}
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve lien: %v", err)
+	}
+
+	if lien.Status == domain.LienStatusTerminated {
+		// Idempotent: already terminated
+		return &pb.TerminateLienResponse{
+			Lien: s.domainToProtoLien(lien),
+		}, nil
+	}
+
+	// Execute the domain transition
+	if err := lien.Terminate(req.Reason); err != nil {
+		if errors.Is(err, domain.ErrLienNotActive) {
+			operationStatus = opStatusLienNotActive
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot terminate lien: %v", err)
+		}
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to terminate lien: %v", err)
+	}
+
+	// Persist with optimistic locking
+	if err := s.lienRepo.Update(ctx, lien); err != nil {
+		if errors.Is(err, persistence.ErrLienVersionConflict) {
+			operationStatus = opStatusLienVersionConflict
+			return nil, status.Error(codes.Aborted, "concurrent modification detected, please retry")
+		}
+		operationStatus = opStatusLienUpdateFailed
+		return nil, status.Errorf(codes.Internal, "failed to update lien: %v", err)
+	}
+
+	s.logger.Info("terminated lien",
+		"lien_id", lien.ID,
+		"account_id", lien.AccountID,
+		"reason", req.Reason)
+
+	return &pb.TerminateLienResponse{
+		Lien: s.domainToProtoLien(lien),
+	}, nil
+}
+
+// RetrieveLien fetches a lien by ID.
+func (s *Service) RetrieveLien(ctx context.Context, req *pb.RetrieveLienRequest) (*pb.RetrieveLienResponse, error) {
+	start := time.Now()
+	operationStatus := operationStatusSuccess
+	defer func() {
+		ibaobservability.RecordOperationDuration("retrieve_lien", operationStatus, time.Since(start))
+	}()
+
+	if s.lienRepo == nil {
+		operationStatus = opStatusLienRepoNil
+		return nil, status.Error(codes.FailedPrecondition, "lien operations not configured")
+	}
+
+	lienID, err := uuid.Parse(req.LienId)
+	if err != nil {
+		operationStatus = opStatusInvalidRequest
+		return nil, status.Errorf(codes.InvalidArgument, "invalid lien_id: %v", err)
+	}
+
+	lien, err := s.lienRepo.FindByID(ctx, lienID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrLienNotFound) {
+			operationStatus = opStatusLienNotFound
+			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
+		}
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to retrieve lien: %v", err)
+	}
+
+	return &pb.RetrieveLienResponse{
+		Lien: s.domainToProtoLien(lien),
+	}, nil
+}
+
+// domainToProtoLien converts a domain Lien to proto Lien.
+func (s *Service) domainToProtoLien(lien *domain.Lien) *pb.Lien {
+	protoLien := &pb.Lien{
+		LienId:    lien.ID.String(),
+		AccountId: lien.AccountID.String(),
+		Amount: &quantityv1.InstrumentAmount{
+			Amount:         strconv.FormatInt(lien.AmountCents, 10),
+			InstrumentCode: lien.Currency,
+		},
+		Status:                mapLienStatusToProto(lien.Status),
+		PaymentOrderReference: lien.PaymentOrderReference,
+		CreatedAt:             timestamppb.New(lien.CreatedAt),
+		UpdatedAt:             timestamppb.New(lien.UpdatedAt),
+		BucketId:              lien.BucketID,
+		TerminationReason:     lien.TerminationReason,
+		Version:               int32(lien.Version),
+	}
+
+	if lien.ExpiresAt != nil {
+		protoLien.ExpiresAt = timestamppb.New(*lien.ExpiresAt)
+	}
+
+	if lien.ReservedQuantity != nil {
+		protoLien.ReservedQuantity = &quantityv1.InstrumentAmount{
+			Amount:         lien.ReservedQuantity.Amount.String(),
+			InstrumentCode: lien.ReservedQuantity.InstrumentCode,
+		}
+	}
+
+	if lien.ValuedAmount != nil {
+		protoLien.ValuedAmount = &quantityv1.InstrumentAmount{
+			Amount:         lien.ValuedAmount.Amount.String(),
+			InstrumentCode: lien.ValuedAmount.InstrumentCode,
+		}
+	}
+
+	return protoLien
+}
+
+// mapLienStatusToProto converts domain LienStatus to proto LienStatus.
+func mapLienStatusToProto(status domain.LienStatus) pb.LienStatus {
+	switch status {
+	case domain.LienStatusActive:
+		return pb.LienStatus_LIEN_STATUS_ACTIVE
+	case domain.LienStatusExecuted:
+		return pb.LienStatus_LIEN_STATUS_EXECUTED
+	case domain.LienStatusTerminated:
+		return pb.LienStatus_LIEN_STATUS_TERMINATED
+	default:
+		return pb.LienStatus_LIEN_STATUS_UNSPECIFIED
+	}
+}
+
+// isDuplicatePaymentOrderRef checks if the error indicates a unique constraint violation
+// on the payment_order_reference column.
+func isDuplicatePaymentOrderRef(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+	return strings.Contains(errStr, "idx_lien_payment_order") ||
+		strings.Contains(errStr, "23505") ||
+		strings.Contains(errStr, "duplicate key")
+}

--- a/services/internal-bank-account/service/lien_service.go
+++ b/services/internal-bank-account/service/lien_service.go
@@ -55,6 +55,10 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 		operationStatus = opStatusInvalidRequest
 		return nil, status.Error(codes.InvalidArgument, "input instrument_code is required")
 	}
+	if strings.TrimSpace(req.PaymentOrderReference) == "" {
+		operationStatus = opStatusInvalidRequest
+		return nil, status.Error(codes.InvalidArgument, "payment_order_reference is required")
+	}
 
 	inputAmount, err := decimal.NewFromString(req.Input.Amount)
 	if err != nil {
@@ -162,7 +166,12 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 
 		var analysisJSON json.RawMessage
 		if result.Analysis != nil {
-			analysisJSON, _ = json.Marshal(result.Analysis)
+			data, marshalErr := json.Marshal(result.Analysis)
+			if marshalErr != nil {
+				s.logger.Warn("failed to marshal valuation analysis", "error", marshalErr)
+			} else {
+				analysisJSON = data
+			}
 		}
 
 		lien, err = domain.NewValuedLien(

--- a/services/internal-bank-account/service/lien_service.go
+++ b/services/internal-bank-account/service/lien_service.go
@@ -113,11 +113,13 @@ func (s *Service) InitiateLien(ctx context.Context, req *pb.InitiateLienRequest)
 	var lien *domain.Lien
 
 	if req.Input.InstrumentCode == nativeInstrument {
-		// Same-instrument lien: no valuation needed
-		// Convert decimal amount to cents (minor units)
-		amountCents := inputAmount.Shift(2).IntPart() // Assume 2 decimal places for native instrument
-		if amountCents <= 0 {
-			// For instruments with no decimal places, use the raw amount
+		// Same-instrument lien: no valuation needed.
+		// Store the amount in minor units (cents). For fiat currencies this is
+		// amount * 100; for non-decimal instruments (kWh, GPU_HOUR) the raw
+		// integer part is used (the proto contract sends whole units).
+		amountCents := inputAmount.Shift(2).IntPart()
+		if amountCents == 0 {
+			// Non-decimal instrument — use integer part directly
 			amountCents = inputAmount.IntPart()
 		}
 
@@ -247,7 +249,7 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		return nil, status.Errorf(codes.InvalidArgument, "invalid lien_id: %v", err)
 	}
 
-	// Read-only idempotency check: if already executed, return directly
+	// Read-only idempotency check: if already executed, return without lock
 	lien, err := s.lienRepo.FindByID(ctx, lienID)
 	if err != nil {
 		if errors.Is(err, persistence.ErrLienNotFound) {
@@ -263,6 +265,17 @@ func (s *Service) ExecuteLien(ctx context.Context, req *pb.ExecuteLienRequest) (
 		return &pb.ExecuteLienResponse{
 			Lien: s.domainToProtoLien(lien),
 		}, nil
+	}
+
+	// Acquire pessimistic lock for mutation
+	lien, err = s.lienRepo.FindByIDForUpdate(ctx, lienID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrLienNotFound) {
+			operationStatus = opStatusLienNotFound
+			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
+		}
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to lock lien: %v", err)
 	}
 
 	// Execute the domain transition
@@ -318,7 +331,7 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		return nil, status.Errorf(codes.InvalidArgument, "invalid lien_id: %v", err)
 	}
 
-	// Read-only idempotency check
+	// Read-only idempotency check: if already terminated, return without lock
 	lien, err := s.lienRepo.FindByID(ctx, lienID)
 	if err != nil {
 		if errors.Is(err, persistence.ErrLienNotFound) {
@@ -336,7 +349,18 @@ func (s *Service) TerminateLien(ctx context.Context, req *pb.TerminateLienReques
 		}, nil
 	}
 
-	// Execute the domain transition
+	// Acquire pessimistic lock for mutation
+	lien, err = s.lienRepo.FindByIDForUpdate(ctx, lienID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrLienNotFound) {
+			operationStatus = opStatusLienNotFound
+			return nil, status.Errorf(codes.NotFound, "lien not found: %s", req.LienId)
+		}
+		operationStatus = operationStatusFailed
+		return nil, status.Errorf(codes.Internal, "failed to lock lien: %v", err)
+	}
+
+	// Terminate the domain transition
 	if err := lien.Terminate(req.Reason); err != nil {
 		if errors.Is(err, domain.ErrLienNotActive) {
 			operationStatus = opStatusLienNotActive

--- a/services/internal-bank-account/service/server.go
+++ b/services/internal-bank-account/service/server.go
@@ -45,6 +45,7 @@ type Service struct {
 	pb.UnimplementedInternalBankAccountServiceServer
 	repo                  domain.Repository
 	valuationFeatureRepo  *persistence.ValuationFeatureRepository
+	lienRepo              *persistence.LienRepository
 	positionKeepingClient PositionKeepingClient
 	referenceDataClient   ReferenceDataClient
 	valuationEngine       ValuationEngine // Optional: executes valuation method logic
@@ -104,6 +105,59 @@ func NewServiceWithValuationFeatures(repo domain.Repository, valuationFeatureRep
 		valuationFeatureRepo: valuationFeatureRepo,
 		logger:               slog.New(slog.NewJSONHandler(os.Stdout, nil)),
 	}, nil
+}
+
+// Option configures optional Service dependencies.
+type Option func(*Service)
+
+// WithLienRepo sets the lien repository.
+func WithLienRepo(lienRepo *persistence.LienRepository) Option {
+	return func(s *Service) {
+		s.lienRepo = lienRepo
+	}
+}
+
+// WithValuationEngine sets the valuation engine.
+func WithValuationEngine(engine ValuationEngine) Option {
+	return func(s *Service) {
+		s.valuationEngine = engine
+	}
+}
+
+// WithValuationFeatureRepo sets the valuation feature repository.
+func WithValuationFeatureRepo(repo *persistence.ValuationFeatureRepository) Option {
+	return func(s *Service) {
+		s.valuationFeatureRepo = repo
+	}
+}
+
+// NewServiceFull creates a service with all dependencies using functional options.
+func NewServiceFull(
+	repo domain.Repository,
+	posKeepingClient PositionKeepingClient,
+	refDataClient ReferenceDataClient,
+	logger *slog.Logger,
+	tracer *observability.Tracer,
+	opts ...Option,
+) (*Service, error) {
+	if repo == nil {
+		return nil, ErrRepositoryNil
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+
+	svc := &Service{
+		repo:                  repo,
+		positionKeepingClient: posKeepingClient,
+		referenceDataClient:   refDataClient,
+		logger:                logger,
+		tracer:                tracer,
+	}
+	for _, opt := range opts {
+		opt(svc)
+	}
+	return svc, nil
 }
 
 // InitiateInternalBankAccount creates a new internal bank account.


### PR DESCRIPTION
## Summary

- Add lien infrastructure and atomic valuation lifecycle to the Internal Bank Account (IBA) service, mirroring the Current Account lien patterns but adapted for multi-asset instruments
- Implement full lien lifecycle (ACTIVE/EXECUTED/TERMINATED) with Flyway migration, domain model, persistence layer, proto definitions, and gRPC service handlers
- Support any instrument code (kWh, GPU_HOUR, TONNE_CO2E, etc.) by using AmountCents+Currency directly instead of CA's Money type

## Changes Made

### valuation-engine.13.1 - Atlas Migration
- `services/internal-bank-account/migrations/20260207000001_create_lien_table.sql`: CockroachDB-compatible lien table with JSONB valuation columns (reserved_quantity, valued_amount, valuation_analysis), composite indexes, check constraints, and optimistic locking version column

### valuation-engine.13.2 - Domain Model
- `services/internal-bank-account/domain/lien.go`: Lien aggregate with ACTIVE→EXECUTED|TERMINATED state machine, InstrumentAmount value object for valuation tracking, NewLien/NewValuedLien constructors with validation
- `services/internal-bank-account/domain/lien_test.go`: 26 unit tests covering constructors, state transitions, expiration, idempotency guards, and edge cases

### valuation-engine.13.3 - Entity and Repository
- `services/internal-bank-account/adapters/persistence/lien_entity.go`: LienEntity with GORM tags, JSONBMap type for JSONB column handling
- `services/internal-bank-account/adapters/persistence/lien_repository.go`: Full repository with tenant-scoped CRUD, pessimistic locking (FindByIDForUpdate), optimistic locking (Update with version check), and aggregate queries (SumActiveAmountByAccountID, SumActiveAmountByAccountIDAndBucket)

### valuation-engine.13.4 - Proto Messages and RPCs
- `api/proto/meridian/internal_bank_account/v1/internal_bank_account.proto`: LienStatus enum, Lien message with InstrumentAmount fields, InitiateLien/ExecuteLien/TerminateLien/RetrieveLien request/response messages and RPCs

### valuation-engine.13.5 - Service Handlers
- `services/internal-bank-account/service/lien_service.go`: InitiateLien with PaymentOrderReference idempotency and atomic valuation via valuateInternal(), Execute/Terminate with read-only idempotency checks, RetrieveLien for lookups
- `services/internal-bank-account/service/server.go`: Added lienRepo field, Option functional options pattern, NewServiceFull constructor

## Technical Details

- **Multi-asset support**: Uses `AmountCents int64` + `Currency string` instead of CA's `Money` type (which only supports known currencies via `currencyInstrument()`). This allows any instrument code.
- **Atomic valuation**: InitiateLien reuses `valuateInternal()` (same as EvaluateAssetValuation) to prevent ghost pricing - inquiry and binding prices are identical.
- **Idempotency**: InitiateLien uses PaymentOrderReference unique constraint; ExecuteLien/TerminateLien use read-only status checks (already in target state returns success).
- **Optimistic locking**: Update checks version column to prevent stale writes in concurrent scenarios.

## Test Plan

- [x] 26 domain unit tests passing (constructors, state transitions, expiration, validation)
- [ ] Integration tests for repository layer (requires CockroachDB testcontainer)
- [ ] Service handler tests with mocked dependencies
- [ ] CI pipeline passes (lint, build, test)