### PR TITLE
chore: remove speculative future enhancement TODOs

### DIFF
--- a/services/current-account/domain/account.go
+++ b/services/current-account/domain/account.go
@@ -393,7 +393,7 @@ func (a CurrentAccount) Unfreeze() (CurrentAccount, error) {
 // The original account is not modified.
 //
 // Deprecated: Use Unfreeze() instead for transitioning from FROZEN to ACTIVE.
-// TODO(bian-alignment): Remove in next major version once all callers migrate to Unfreeze().
+// NOTE: Migrate callers to Unfreeze() before removing this method.
 func (a CurrentAccount) Activate() (CurrentAccount, error) {
 	if a.status == AccountStatusClosed {
 		return CurrentAccount{}, ErrInvalidStatusTransition

--- a/shared/pkg/clients/idempotency.go
+++ b/shared/pkg/clients/idempotency.go
@@ -89,10 +89,5 @@ func ApplyIdempotencyKey(ctx context.Context, _ interface{}) context.Context {
 	// Apply to gRPC metadata header
 	ctx = metadata.AppendToOutgoingContext(ctx, "x-idempotency-key", key)
 
-	// TODO: Future enhancement - Apply to protobuf field if message supports it
-	// This would require reflection to detect and set the IdempotencyKey field
-	// on proto messages that have it. For now, we focus on metadata propagation
-	// which works universally across all gRPC calls.
-
 	return ctx
 }


### PR DESCRIPTION
## Summary

- Remove proto field idempotency TODO in `shared/pkg/clients/idempotency.go` -- the metadata-based approach is correct and universal, no proto field enhancement needed
- Convert stale `bian-alignment` TODO to NOTE in `services/current-account/domain/account.go` -- `Activate()` still has 16 callers; keeps `Deprecated` godoc annotation intact for Go tooling

## Task Master

tech-debt-cleanup.75

## Test plan

- [x] `go build ./shared/pkg/clients/...` passes
- [x] `go build ./services/current-account/domain/...` passes
- [x] Pre-commit hooks (gofumpt, golangci-lint) pass