### PR TITLE
chore: clean up dry-run validator TODO and commented code

### DIFF
--- a/shared/pkg/saga/validator_production_test.go
+++ b/shared/pkg/saga/validator_production_test.go
@@ -28,10 +28,4 @@ func TestValidateSagaScript_ProductionScript(t *testing.T) {
 	// Validate syntax and static analysis
 	err = saga.ValidateSagaScript(script)
 	assert.NoError(t, err, "Script validation failed for %s", *scriptPath)
-
-	// TODO: In Task 25-28, add dry-run execution validation here:
-	// validator := saga.NewDryRunValidator(handlerRegistry, schemaRegistry)
-	// result, err := validator.Validate(script)
-	// require.NoError(t, err)
-	// assert.True(t, result.Success, "Dry-run validation failed")
 }


### PR DESCRIPTION
## Summary

- Remove stale TODO referencing non-existent tasks 25-28 in `shared/pkg/saga/validator_production_test.go`
- Remove commented-out `DryRunValidator` code that was dead code adding noise

The `DryRunValidator` is already fully implemented in `shared/pkg/saga/validation/` and integrated into:
- Reference-data service's `RegistryHandler` (saga draft creation validation)
- `meridian-cli` saga validate command

The CI production script test (`TestValidateSagaScript_ProductionScript`) performs static analysis via `saga.ValidateSagaScript()`, which is the appropriate level of validation for CI script discovery. Dry-run execution validation belongs in the service layer where handler and schema registries are available.

## Task Master

Tag: `tech-debt-cleanup`, Task: 77

## Test plan

- [x] `go test ./shared/pkg/saga/... -v` passes (all tests pass, production test skips as expected without `-script` flag)
- [x] Pre-commit checks (gofumpt, golangci-lint) pass