### PR TITLE
chore: remove disabled metadata propagation test code and redundant TODOs

### DIFF
--- a/services/current-account/e2e/saga_compensation_test.go
+++ b/services/current-account/e2e/saga_compensation_test.go
@@ -100,9 +100,6 @@ func setupE2EEnvironment(t *testing.T, _ context.Context) *E2ETestEnvironment {
 	env.FinancialAccountingDB = FinancialAccountingDBHelper{db: db, ctx: tenantCtx}
 	env.CurrentAccountDB = CurrentAccountDBHelper{db: db, ctx: tenantCtx}
 
-	// TODO: Initialize service clients (for now, we'll use direct DB access)
-	// In a full E2E test, these would be real gRPC clients
-
 	return env
 }
 

--- a/services/position-keeping/client/starlark_test.go
+++ b/services/position-keeping/client/starlark_test.go
@@ -165,14 +165,6 @@ func TestInitiateLogHandler_Success(t *testing.T) {
 	// Verify mock server was called
 	assert.True(t, mockServer.initiateCalled)
 
-	// TODO: Metadata propagation tests are currently disabled because the Client methods
-	// (InitiateFinancialPositionLog etc.) manipulate the context and metadata propagation
-	// is complex to test with mock servers. These work in real integration tests.
-	// For now, we verify the handler calls the right method with the right params.
-	// assert.Equal(t, idempotencyKey, mockServer.lastIdempotencyKey)
-	// assert.Equal(t, correlationID, mockServer.lastCorrelationID)
-	// assert.WithinDuration(t, knowledgeAt, mockServer.lastKnowledgeAt, time.Second)
-
 	// Verify result structure
 	resultMap, ok := result.(map[string]any)
 	require.True(t, ok)
@@ -248,8 +240,6 @@ func TestUpdateLogHandler_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.True(t, mockServer.updateCalled)
-	// Metadata propagation tested in integration tests
-	// assert.Equal(t, "test-key", mockServer.lastIdempotencyKey)
 
 	resultMap, ok := result.(map[string]any)
 	require.True(t, ok)


### PR DESCRIPTION
## Summary
- Remove commented-out metadata propagation assertions in `services/position-keeping/client/starlark_test.go` that were disabled with a TODO explaining they work in real integration tests
- Remove redundant TODO about initializing gRPC service clients in `services/current-account/e2e/saga_compensation_test.go` where direct DB access is the established E2E test pattern

## Task Master
- Tag: `tech-debt-cleanup`
- Task: `tech-debt-cleanup.78` - Remove disabled metadata propagation test code and redundant TODOs

## Test plan
- [x] `go build ./services/position-keeping/...` passes
- [x] `go build ./services/current-account/...` passes
- [x] Unit tests for starlark handlers pass (`TestInitiateLogHandler_*`, `TestUpdateLogHandler_*`)
- [x] Pre-commit hooks (gofumpt, golangci-lint) pass