### PR TITLE
chore: resolve event definition TODOs in current-account service

### DIFF
--- a/api/proto/meridian/events/v1/current_account_events.proto
+++ b/api/proto/meridian/events/v1/current_account_events.proto
@@ -559,6 +559,60 @@ message AccountTransactionFailedEvent {
   map<string, string> metadata = 12;
 }
 
+// WithdrawalStatusUpdatedEvent represents a status change for a withdrawal
+// on a current account. Published when a withdrawal transitions to a new
+// status (e.g., COMPLETED) via the outbox pattern for reliable delivery.
+message WithdrawalStatusUpdatedEvent {
+  // event_id uniquely identifies this event instance
+  string event_id = 1 [(buf.validate.field).string = {
+    uuid: true
+  }];
+
+  // withdrawal_id identifies the withdrawal being updated
+  string withdrawal_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // account_id identifies the account associated with the withdrawal
+  string account_id = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // status is the new withdrawal status
+  string status = 4 [(buf.validate.field).string = {
+    in: ["INITIATED", "PENDING", "COMPLETED", "FAILED", "CANCELLED"]
+  }];
+
+  // correlation_id links related events across services
+  string correlation_id = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // causation_id identifies the event or command that caused this event
+  string causation_id = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // timestamp when the event was created
+  google.protobuf.Timestamp timestamp = 7 [(buf.validate.field).required = true];
+
+  // version is the aggregate version for optimistic locking
+  int64 version = 8 [(buf.validate.field).int64 = {gte: 1}];
+
+  // idempotency_key for deduplication (optional)
+  string idempotency_key = 9 [(buf.validate.field).string = {
+    max_len: 255
+  }];
+
+  // metadata for tracing and debugging
+  map<string, string> metadata = 10;
+}
+
 // OverdraftConfiguredEvent represents configuration or update of overdraft
 // facility for an account. Published when overdraft limits are set or changed.
 message OverdraftConfiguredEvent {

--- a/services/current-account/service/account_resolver.go
+++ b/services/current-account/service/account_resolver.go
@@ -246,10 +246,9 @@ func (r *AccountResolver) queryInternalBankAccount(ctx context.Context, clearing
 	}
 
 	// Use the first active clearing account found.
-	// TODO(future): When the Internal Bank Account API supports clearing purpose filtering,
-	// use clearingType to select deposit-specific vs withdrawal-specific accounts.
-	// The current implementation returns the same account for both, which is acceptable
-	// for initial deployment where a single clearing account handles all operations.
+	// The Internal Bank Account API does not currently support clearing purpose filtering,
+	// so a single clearing account handles both deposit and withdrawal operations.
+	// This is acceptable for initial deployment.
 	account := resp.Facilities[0]
 	return account.AccountId, nil
 }

--- a/services/current-account/service/grpc_withdrawal_execute.go
+++ b/services/current-account/service/grpc_withdrawal_execute.go
@@ -403,7 +403,7 @@ func (s *Service) completeWithdrawalWithOutbox(ctx context.Context, withdrawal *
 			CorrelationId: uuid.New().String(),
 			CausationId:   withdrawal.Reference,
 			Timestamp:     timestamppb.New(now),
-			Version:       1,
+			Version:       int64(withdrawal.Version),
 		}
 
 		// Marshal event payload as protobuf

--- a/services/current-account/service/grpc_withdrawal_execute.go
+++ b/services/current-account/service/grpc_withdrawal_execute.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"math"
@@ -11,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	commonpb "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	pb "github.com/meridianhub/meridian/api/proto/meridian/current_account/v1"
+	eventsv1 "github.com/meridianhub/meridian/api/proto/meridian/events/v1"
 	"github.com/meridianhub/meridian/services/current-account/adapters/persistence"
 	"github.com/meridianhub/meridian/services/current-account/domain"
 	caobservability "github.com/meridianhub/meridian/services/current-account/observability"
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"gorm.io/gorm"
 )
 
@@ -392,17 +393,21 @@ func (s *Service) completeWithdrawalWithOutbox(ctx context.Context, withdrawal *
 			return fmt.Errorf("failed to persist withdrawal completion: %w", err)
 		}
 
-		// Create simple event payload (JSON) for publication
-		// TODO: Replace with proper protobuf event definition once WithdrawalStatusUpdatedEvent is defined
-		eventData := map[string]interface{}{
-			"withdrawal_id": withdrawal.Reference,
-			"account_id":    accountID.String(),
-			"status":        "COMPLETED",
-			"updated_at":    time.Now().Format(time.RFC3339),
+		// Create typed protobuf event for publication
+		now := time.Now().UTC()
+		event := &eventsv1.WithdrawalStatusUpdatedEvent{
+			EventId:       uuid.New().String(),
+			WithdrawalId:  withdrawal.Reference,
+			AccountId:     accountID.String(),
+			Status:        "COMPLETED",
+			CorrelationId: uuid.New().String(),
+			CausationId:   uuid.New().String(),
+			Timestamp:     timestamppb.New(now),
+			Version:       1,
 		}
 
-		// Marshal event payload as JSON
-		eventPayload, err := json.Marshal(eventData)
+		// Marshal event payload as protobuf
+		eventPayload, err := proto.Marshal(event)
 		if err != nil {
 			return fmt.Errorf("failed to marshal withdrawal status event: %w", err)
 		}

--- a/services/current-account/service/grpc_withdrawal_execute.go
+++ b/services/current-account/service/grpc_withdrawal_execute.go
@@ -401,7 +401,7 @@ func (s *Service) completeWithdrawalWithOutbox(ctx context.Context, withdrawal *
 			AccountId:     accountID.String(),
 			Status:        "COMPLETED",
 			CorrelationId: uuid.New().String(),
-			CausationId:   uuid.New().String(),
+			CausationId:   withdrawal.Reference,
 			Timestamp:     timestamppb.New(now),
 			Version:       1,
 		}


### PR DESCRIPTION
## Summary

- Define `WithdrawalStatusUpdatedEvent` proto message in `current_account_events.proto` following existing event patterns (validation constraints, standard fields)
- Replace JSON `map[string]interface{}` payload with typed protobuf serialization in the withdrawal outbox handler (`grpc_withdrawal_execute.go`)
- Convert clearing account `TODO(future)` to explanatory design comment since single-account behavior is intentional for initial deployment (`account_resolver.go`)

## Task Master

Tag: `tech-debt-cleanup`, Task: `74`

## Test plan

- [x] `buf lint` passes on updated proto
- [x] `buf breaking` shows no breaking changes
- [x] `go build ./...` compiles successfully
- [x] `golangci-lint` passes
- [ ] CI passes