### PR TITLE
chore: triage and resolve feature stub TODOs in party and payment-order

### DIFF
--- a/services/party/service/grpc_service.go
+++ b/services/party/service/grpc_service.go
@@ -719,7 +719,10 @@ func (s *Service) ExchangeDemographics(ctx context.Context, req *pb.ExchangeDemo
 			"party_id", req.PartyId,
 			"environment", os.Getenv("ENVIRONMENT"))
 
-		// TODO: Integrate with external KYC/AML provider (Task 5 - Option 2)
+		// Stub: returns VERIFIED for all parties. Real KYC/AML integration requires
+		// an external provider (e.g., Onfido, Jumio). The VerificationService handles
+		// async webhook-based verification separately; this endpoint is a synchronous
+		// BIAN ExchangeDemographics operation that will delegate to the provider adapter.
 		verificationStatus := "VERIFIED"
 
 		return &pb.ExchangeDemographicsResponse{
@@ -729,8 +732,9 @@ func (s *Service) ExchangeDemographics(ctx context.Context, req *pb.ExchangeDemo
 		}, nil
 	}
 
-	// Default behavior for non-production environments without explicit flag
-	// TODO: Integrate with external KYC/AML provider (Task 5 - Option 2)
+	// Default behavior for non-production environments without explicit flag.
+	// Stub: returns VERIFIED for all parties. See KYC_STUB_ENABLED block above
+	// for context on the planned external provider integration.
 	verificationStatus := "VERIFIED"
 	s.logger.Info("demographics verified", "party_id", req.PartyId)
 

--- a/services/payment-order/adapters/clients/reference_data_client.go
+++ b/services/payment-order/adapters/clients/reference_data_client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
 	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
 	"github.com/meridianhub/meridian/services/payment-order/service"
 	"google.golang.org/grpc"
@@ -15,21 +16,23 @@ var (
 	// ErrSagaNotFound is returned when a saga definition is not found.
 	ErrSagaNotFound = errors.New("saga not found")
 
-	// ErrRetrieveInstrumentNotImplemented is returned when RetrieveInstrument is called.
-	ErrRetrieveInstrumentNotImplemented = errors.New("RetrieveInstrument not yet implemented")
+	// ErrInstrumentNotFound is returned when an instrument is not found.
+	ErrInstrumentNotFound = errors.New("instrument not found")
 )
 
 // ReferenceDataClientWrapper wraps the gRPC client for the reference-data service.
 type ReferenceDataClientWrapper struct {
-	conn       *grpc.ClientConn
-	sagaClient sagav1.SagaRegistryServiceClient
+	conn             *grpc.ClientConn
+	sagaClient       sagav1.SagaRegistryServiceClient
+	instrumentClient referencedatav1.ReferenceDataServiceClient
 }
 
 // NewReferenceDataClient creates a new reference-data client wrapper.
 func NewReferenceDataClient(conn *grpc.ClientConn) *ReferenceDataClientWrapper {
 	return &ReferenceDataClientWrapper{
-		conn:       conn,
-		sagaClient: sagav1.NewSagaRegistryServiceClient(conn),
+		conn:             conn,
+		sagaClient:       sagav1.NewSagaRegistryServiceClient(conn),
+		instrumentClient: referencedatav1.NewReferenceDataServiceClient(conn),
 	}
 }
 
@@ -60,11 +63,26 @@ func (c *ReferenceDataClientWrapper) GetSaga(ctx context.Context, name string, v
 	}, nil
 }
 
-// RetrieveInstrument fetches an instrument definition by code.
-// This method is not yet implemented - placeholder for future implementation.
-func (c *ReferenceDataClientWrapper) RetrieveInstrument(_ context.Context, _ string) (*service.InstrumentInfo, error) {
-	// TODO: Implement instrument retrieval when reference-data service exposes this RPC
-	return nil, ErrRetrieveInstrumentNotImplemented
+// RetrieveInstrument fetches an instrument definition by code from the reference-data service.
+// Passes version=0 to retrieve the latest ACTIVE version.
+func (c *ReferenceDataClientWrapper) RetrieveInstrument(ctx context.Context, code string) (*service.InstrumentInfo, error) {
+	resp, err := c.instrumentClient.RetrieveInstrument(ctx, &referencedatav1.RetrieveInstrumentRequest{
+		Code:    code,
+		Version: 0, // 0 = latest ACTIVE version
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve instrument %s: %w", code, err)
+	}
+
+	if resp.Instrument == nil {
+		return nil, fmt.Errorf("%w: %s", ErrInstrumentNotFound, code)
+	}
+
+	return &service.InstrumentInfo{
+		Code:                     resp.Instrument.Code,
+		Version:                  resp.Instrument.Version,
+		FungibilityKeyExpression: resp.Instrument.FungibilityKeyExpression,
+	}, nil
 }
 
 // Close terminates the gRPC connection.

--- a/services/payment-order/adapters/clients/reference_data_client_test.go
+++ b/services/payment-order/adapters/clients/reference_data_client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
 	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,4 +133,81 @@ func TestReferenceDataClientWrapper_GetSaga_NilResponse(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "saga not found: payment_execution v1")
+}
+
+// mockReferenceDataServiceClient is a mock implementation of ReferenceDataServiceClient.
+type mockReferenceDataServiceClient struct {
+	referencedatav1.ReferenceDataServiceClient
+	retrieveInstrumentFunc func(ctx context.Context, in *referencedatav1.RetrieveInstrumentRequest, opts ...grpc.CallOption) (*referencedatav1.RetrieveInstrumentResponse, error)
+}
+
+func (m *mockReferenceDataServiceClient) RetrieveInstrument(ctx context.Context, in *referencedatav1.RetrieveInstrumentRequest, opts ...grpc.CallOption) (*referencedatav1.RetrieveInstrumentResponse, error) {
+	if m.retrieveInstrumentFunc != nil {
+		return m.retrieveInstrumentFunc(ctx, in, opts...)
+	}
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
+func TestReferenceDataClientWrapper_RetrieveInstrument_Success(t *testing.T) {
+	mockClient := &mockReferenceDataServiceClient{
+		retrieveInstrumentFunc: func(_ context.Context, in *referencedatav1.RetrieveInstrumentRequest, _ ...grpc.CallOption) (*referencedatav1.RetrieveInstrumentResponse, error) {
+			assert.Equal(t, "USD", in.Code)
+			assert.Equal(t, int32(0), in.Version)
+
+			return &referencedatav1.RetrieveInstrumentResponse{
+				Instrument: &referencedatav1.InstrumentDefinition{
+					Code:                     "USD",
+					Version:                  1,
+					FungibilityKeyExpression: "instrument_code + ':' + string(version)",
+				},
+			}, nil
+		},
+	}
+
+	client := &ReferenceDataClientWrapper{
+		instrumentClient: mockClient,
+	}
+
+	result, err := client.RetrieveInstrument(context.Background(), "USD")
+
+	require.NoError(t, err)
+	assert.Equal(t, "USD", result.Code)
+	assert.Equal(t, int32(1), result.Version)
+	assert.Equal(t, "instrument_code + ':' + string(version)", result.FungibilityKeyExpression)
+}
+
+func TestReferenceDataClientWrapper_RetrieveInstrument_NotFound(t *testing.T) {
+	mockClient := &mockReferenceDataServiceClient{
+		retrieveInstrumentFunc: func(_ context.Context, _ *referencedatav1.RetrieveInstrumentRequest, _ ...grpc.CallOption) (*referencedatav1.RetrieveInstrumentResponse, error) {
+			return nil, status.Error(codes.NotFound, "instrument not found")
+		},
+	}
+
+	client := &ReferenceDataClientWrapper{
+		instrumentClient: mockClient,
+	}
+
+	result, err := client.RetrieveInstrument(context.Background(), "NONEXISTENT")
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "failed to retrieve instrument NONEXISTENT")
+}
+
+func TestReferenceDataClientWrapper_RetrieveInstrument_NilResponse(t *testing.T) {
+	mockClient := &mockReferenceDataServiceClient{
+		retrieveInstrumentFunc: func(_ context.Context, _ *referencedatav1.RetrieveInstrumentRequest, _ ...grpc.CallOption) (*referencedatav1.RetrieveInstrumentResponse, error) {
+			return &referencedatav1.RetrieveInstrumentResponse{Instrument: nil}, nil
+		},
+	}
+
+	client := &ReferenceDataClientWrapper{
+		instrumentClient: mockClient,
+	}
+
+	result, err := client.RetrieveInstrument(context.Background(), "USD")
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrInstrumentNotFound)
 }


### PR DESCRIPTION
## Summary

Resolves tech-debt-cleanup.73: Triage and resolve feature stub TODOs in party and payment-order services.

- **Party service**: Replace 2 KYC/AML integration TODO comments with explanatory documentation. The `ExchangeDemographics` endpoint stubs are intentional dev-mode behavior, guarded by production safety checks (`ENVIRONMENT=production` blocks usage, `KYC_STUB_ENABLED=true` required to opt-in). The separate `VerificationService` handles async webhook-based KYC/AML verification; this BIAN endpoint awaits external provider adapter integration.
- **Payment-order service**: Implement `RetrieveInstrument` client call. The `RetrieveInstrument` RPC already exists in the reference-data proto definition and generated code, but the client was returning a stub error. Now makes the actual gRPC call with `version=0` to fetch the latest ACTIVE instrument version, mapping the response to the `InstrumentInfo` domain type.

## Changes

| File | Change |
|------|--------|
| `services/party/service/grpc_service.go` | Replace TODO comments (lines 722, 733) with architecture decision documentation |
| `services/payment-order/adapters/clients/reference_data_client.go` | Implement `RetrieveInstrument` gRPC call, add `instrumentClient` field, remove `ErrRetrieveInstrumentNotImplemented` |
| `services/payment-order/adapters/clients/reference_data_client_test.go` | Add 3 unit tests for `RetrieveInstrument` (success, not-found, nil-response) |

## Test plan

- [x] All 7 unit tests pass in `services/payment-order/adapters/clients/`
- [x] Full `go build ./...` passes
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)
- [ ] CI pipeline passes