### PR TITLE
fix: wire up valuation builtins and add run_policy CEL bridge

### DIFF
--- a/shared/pkg/valuation/internal/builtins/builtins.go
+++ b/shared/pkg/valuation/internal/builtins/builtins.go
@@ -12,15 +12,26 @@
 package builtins
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/shopspring/decimal"
 	"go.starlark.net/starlark"
 )
 
+// PolicyEvaluator compiles and evaluates a CEL expression in one call.
+// This callback decouples the builtins package from the parent valuation package,
+// avoiding circular imports while enabling Starlark scripts to delegate
+// mathematical calculations to CEL.
+type PolicyEvaluator func(ctx context.Context, expression string, variables map[string]interface{}) (interface{}, error)
+
 // Registry holds configuration for creating Starlark builtins.
 type Registry struct {
-	// Future: Add PolicyResolver, MarketDataClient (read-only) when needed
+	// EvalPolicy evaluates a CEL expression. When set, the run_policy builtin
+	// is available in Starlark scripts, enforcing the architectural constraint
+	// that all mathematical calculations are performed by CEL, not inline Starlark.
+	EvalPolicy PolicyEvaluator
 }
 
 // NewRegistry creates a new builtin registry.
@@ -31,12 +42,19 @@ func NewRegistry() *Registry {
 // CreateBuiltins returns a StringDict of builtin functions available in Starlark.
 // These functions are read-only and cannot perform mutations.
 func (r *Registry) CreateBuiltins() starlark.StringDict {
-	return starlark.StringDict{
+	dict := starlark.StringDict{
 		"Decimal":     starlark.NewBuiltin("Decimal", r.decimalBuiltin),
 		"quantity":    starlark.NewBuiltin("quantity", r.quantityBuiltin),
 		"record_path": starlark.NewBuiltin("record_path", r.recordPathBuiltin),
-		// Future: "run_policy", "market_data" when integrated with dependencies
 	}
+
+	// run_policy delegates mathematical calculations to CEL, enforcing the
+	// architectural constraint that Starlark orchestrates and CEL calculates.
+	if r.EvalPolicy != nil {
+		dict["run_policy"] = starlark.NewBuiltin("run_policy", r.runPolicyBuiltin)
+	}
+
+	return dict
 }
 
 // decimalBuiltin creates a Decimal value from a string.
@@ -133,6 +151,108 @@ func (r *Registry) recordPathBuiltin(thread *starlark.Thread, fn *starlark.Built
 
 	return starlark.None, nil
 }
+
+// runPolicyBuiltin evaluates a CEL expression with the given variables.
+// Usage: run_policy(expression="amount * rate", variables={"amount": 100.0, "rate": 0.35})
+//
+// This is the primary mechanism for mathematical calculations in valuation scripts.
+// Starlark scripts MUST use run_policy for arithmetic rather than inline operators,
+// ensuring all calculations are CEL-evaluated with cost tracking and audit trails.
+func (r *Registry) runPolicyBuiltin(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var expression string
+	var variablesDict *starlark.Dict
+
+	if err := starlark.UnpackArgs(fn.Name(), args, kwargs,
+		"expression", &expression,
+		"variables?", &variablesDict,
+	); err != nil {
+		return nil, err
+	}
+
+	// Build Go map from Starlark dict
+	variables := make(map[string]interface{})
+	if variablesDict != nil {
+		for _, item := range variablesDict.Items() {
+			key, ok := item[0].(starlark.String)
+			if !ok {
+				return nil, fmt.Errorf("%w, got %s", ErrRunPolicyInvalidKey, item[0].Type())
+			}
+			variables[string(key)] = starlarkToGo(item[1])
+		}
+	}
+
+	// Get Go context from thread-local storage
+	ctx, _ := thread.Local("ctx").(context.Context)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Evaluate via CEL PolicyRuntime
+	result, err := r.EvalPolicy(ctx, expression, variables)
+	if err != nil {
+		return nil, fmt.Errorf("run_policy: %w", err)
+	}
+
+	return goToStarlark(result), nil
+}
+
+// starlarkToGo converts a Starlark value to a Go value for CEL evaluation.
+func starlarkToGo(v starlark.Value) interface{} {
+	switch val := v.(type) {
+	case starlark.String:
+		return string(val)
+	case starlark.Int:
+		if i64, ok := val.Int64(); ok {
+			return i64
+		}
+		return val.String()
+	case starlark.Float:
+		return float64(val)
+	case starlark.Bool:
+		return bool(val)
+	case starlark.NoneType:
+		return nil
+	case *starlark.Dict:
+		m := make(map[string]interface{})
+		for _, item := range val.Items() {
+			if key, ok := item[0].(starlark.String); ok {
+				m[string(key)] = starlarkToGo(item[1])
+			}
+		}
+		return m
+	case *starlark.List:
+		list := make([]interface{}, val.Len())
+		for i := 0; i < val.Len(); i++ {
+			list[i] = starlarkToGo(val.Index(i))
+		}
+		return list
+	default:
+		return val.String()
+	}
+}
+
+// goToStarlark converts a Go value from CEL evaluation to a Starlark value.
+func goToStarlark(v interface{}) starlark.Value {
+	switch val := v.(type) {
+	case float64:
+		return starlark.Float(val)
+	case int64:
+		return starlark.MakeInt64(val)
+	case int:
+		return starlark.MakeInt(val)
+	case string:
+		return starlark.String(val)
+	case bool:
+		return starlark.Bool(val)
+	case nil:
+		return starlark.None
+	default:
+		return starlark.String(fmt.Sprintf("%v", val))
+	}
+}
+
+// ErrRunPolicyInvalidKey is returned when a run_policy variables dict contains a non-string key.
+var ErrRunPolicyInvalidKey = errors.New("run_policy: variable keys must be strings")
 
 // PathEntry represents a calculation step recorded via record_path().
 type PathEntry struct {

--- a/shared/pkg/valuation/internal/builtins/builtins_test.go
+++ b/shared/pkg/valuation/internal/builtins/builtins_test.go
@@ -1,6 +1,8 @@
 package builtins_test
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/shopspring/decimal"
@@ -26,6 +28,22 @@ func TestRegistry_CreateBuiltins(t *testing.T) {
 
 	_, ok = dict["record_path"]
 	assert.True(t, ok, "record_path builtin should be present")
+
+	// run_policy should NOT be present without PolicyEvaluator
+	_, ok = dict["run_policy"]
+	assert.False(t, ok, "run_policy should not be present without PolicyEvaluator")
+}
+
+func TestRegistry_CreateBuiltins_WithPolicyEvaluator(t *testing.T) {
+	registry := builtins.NewRegistry()
+	registry.EvalPolicy = func(_ context.Context, _ string, _ map[string]interface{}) (interface{}, error) {
+		return 0.0, nil
+	}
+
+	dict := registry.CreateBuiltins()
+
+	_, ok := dict["run_policy"]
+	assert.True(t, ok, "run_policy should be present when PolicyEvaluator is set")
 }
 
 func TestDecimal_Builtin(t *testing.T) {
@@ -133,4 +151,80 @@ func TestRecordPath_Builtin(t *testing.T) {
 
 	// In the real implementation, this would append to analysis.CalculationPath
 	// For now, just verify the function is callable
+}
+
+func TestRunPolicy_Builtin(t *testing.T) {
+	registry := builtins.NewRegistry()
+	registry.EvalPolicy = func(_ context.Context, expression string, variables map[string]interface{}) (interface{}, error) {
+		// Simulate CEL evaluation for "amount * rate"
+		if expression == "amount * rate" {
+			amount, _ := variables["amount"].(float64)
+			rate, _ := variables["rate"].(float64)
+			return amount * rate, nil
+		}
+		return nil, fmt.Errorf("unknown expression: %s", expression)
+	}
+
+	dict := registry.CreateBuiltins()
+	runPolicyFn := dict["run_policy"]
+	require.NotNil(t, runPolicyFn)
+
+	thread := &starlark.Thread{Name: "test"}
+
+	// Build variables dict
+	varsDict := &starlark.Dict{}
+	require.NoError(t, varsDict.SetKey(starlark.String("amount"), starlark.Float(100.0)))
+	require.NoError(t, varsDict.SetKey(starlark.String("rate"), starlark.Float(0.35)))
+
+	kwargs := []starlark.Tuple{
+		{starlark.String("expression"), starlark.String("amount * rate")},
+		{starlark.String("variables"), varsDict},
+	}
+
+	result, err := starlark.Call(thread, runPolicyFn, nil, kwargs)
+	require.NoError(t, err)
+
+	// Result should be a float
+	floatVal, ok := result.(starlark.Float)
+	require.True(t, ok, "run_policy should return a float, got %T", result)
+	assert.InDelta(t, 35.0, float64(floatVal), 0.001)
+}
+
+func TestRunPolicy_Builtin_MissingExpression(t *testing.T) {
+	registry := builtins.NewRegistry()
+	registry.EvalPolicy = func(_ context.Context, _ string, _ map[string]interface{}) (interface{}, error) {
+		return nil, nil
+	}
+
+	dict := registry.CreateBuiltins()
+	runPolicyFn := dict["run_policy"]
+	require.NotNil(t, runPolicyFn)
+
+	thread := &starlark.Thread{Name: "test"}
+
+	// Call without required expression kwarg
+	_, err := starlark.Call(thread, runPolicyFn, nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expression")
+}
+
+func TestRunPolicy_Builtin_EvalError(t *testing.T) {
+	registry := builtins.NewRegistry()
+	registry.EvalPolicy = func(_ context.Context, _ string, _ map[string]interface{}) (interface{}, error) {
+		return nil, fmt.Errorf("CEL compilation failed: undefined variable")
+	}
+
+	dict := registry.CreateBuiltins()
+	runPolicyFn := dict["run_policy"]
+	require.NotNil(t, runPolicyFn)
+
+	thread := &starlark.Thread{Name: "test"}
+
+	kwargs := []starlark.Tuple{
+		{starlark.String("expression"), starlark.String("bad_var * 2")},
+	}
+
+	_, err := starlark.Call(thread, runPolicyFn, nil, kwargs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "run_policy")
 }

--- a/shared/pkg/valuation/starlark_runtime.go
+++ b/shared/pkg/valuation/starlark_runtime.go
@@ -40,7 +40,8 @@ var (
 
 // defaultStarlarkRuntime implements StarlarkRuntime.
 type defaultStarlarkRuntime struct {
-	timeout time.Duration
+	timeout  time.Duration
+	builtins starlark.StringDict
 }
 
 // StarlarkRuntimeConfig holds configuration for creating a StarlarkRuntime.
@@ -48,6 +49,11 @@ type StarlarkRuntimeConfig struct {
 	// Timeout is the maximum execution time for a script.
 	// If zero, DefaultStarlarkTimeout (5s) is used.
 	Timeout time.Duration
+
+	// PolicyRuntime provides CEL evaluation for run_policy builtin.
+	// When set, valuation scripts can delegate mathematical calculations to CEL
+	// via run_policy(expression="...", variables={...}).
+	PolicyRuntime PolicyRuntime
 }
 
 // NewStarlarkRuntime creates a new StarlarkRuntime with security constraints.
@@ -57,8 +63,22 @@ func NewStarlarkRuntime(cfg StarlarkRuntimeConfig) StarlarkRuntime {
 		timeout = DefaultStarlarkTimeout
 	}
 
+	// Build builtins registry with optional CEL policy evaluator
+	registry := builtins.NewRegistry()
+	if cfg.PolicyRuntime != nil {
+		registry.EvalPolicy = func(ctx context.Context, expression string, variables map[string]interface{}) (interface{}, error) {
+			compiled, err := cfg.PolicyRuntime.CompilePolicy(expression)
+			if err != nil {
+				return nil, err
+			}
+			result, _, err := cfg.PolicyRuntime.EvaluatePolicy(ctx, compiled, variables)
+			return result, err
+		}
+	}
+
 	return &defaultStarlarkRuntime{
-		timeout: timeout,
+		timeout:  timeout,
+		builtins: registry.CreateBuiltins(),
 	}
 }
 
@@ -106,10 +126,12 @@ func (r *defaultStarlarkRuntime) Execute(ctx context.Context, script string, req
 	const maxSteps = 5_000_000
 	thread.SetMaxExecutionSteps(maxSteps)
 
-	// Build predeclared variables
-	predeclared := starlark.StringDict{
-		"ctx": r.toStarlarkValue(scriptCtx),
+	// Build predeclared variables: builtins + script context
+	predeclared := make(starlark.StringDict, len(r.builtins)+1)
+	for name, val := range r.builtins {
+		predeclared[name] = val
 	}
+	predeclared["ctx"] = r.toStarlarkValue(scriptCtx)
 
 	// Parse and execute script using the non-deprecated API
 	globals, err := starlark.ExecFileOptions(&syntax.FileOptions{}, thread, "valuation.star", script, predeclared)

--- a/shared/pkg/valuation/starlark_runtime_test.go
+++ b/shared/pkg/valuation/starlark_runtime_test.go
@@ -15,19 +15,27 @@ import (
 )
 
 func TestStarlarkRuntime_Execute_Success(t *testing.T) {
+	// Create PolicyRuntime so run_policy builtin is available
+	policyRuntime, err := valuation.NewPolicyRuntime()
+	require.NoError(t, err)
+
 	runtime := valuation.NewStarlarkRuntime(valuation.StarlarkRuntimeConfig{
-		Timeout: 5 * time.Second,
+		Timeout:       5 * time.Second,
+		PolicyRuntime: policyRuntime,
 	})
 
 	script := `
-# Simple valuation script
+# Valuation script using CEL for calculations (no inline arithmetic)
 def valuate(ctx):
     # Access input quantity
     amount = ctx["amount"]
     rate = ctx["rate"]
 
-    # Calculate valued amount
-    valued = amount * rate
+    # Delegate calculation to CEL via run_policy
+    valued = run_policy(
+        expression="amount * rate",
+        variables={"amount": amount, "rate": rate},
+    )
 
     return {
         "valued_amount": valued,


### PR DESCRIPTION
## Summary

- The valuation `StarlarkRuntime` was not injecting builtins (`Decimal`, `quantity`, `record_path`) into the Starlark predeclared scope — scripts only had access to `ctx`
- No mechanism existed for valuation scripts to delegate mathematical calculations to CEL, forcing inline arithmetic in Starlark which violates the architectural constraint that Starlark orchestrates and CEL calculates
- Added `run_policy` builtin backed by a `PolicyEvaluator` callback that bridges Starlark to CEL `CompilePolicy` + `EvaluatePolicy`

## Changes Made

| File | Change |
|------|--------|
| `shared/pkg/valuation/internal/builtins/builtins.go` | Added `PolicyEvaluator` type, `run_policy` builtin, `starlarkToGo`/`goToStarlark` converters |
| `shared/pkg/valuation/starlark_runtime.go` | Accept optional `PolicyRuntime` in config, create builtins registry, inject into predeclared scope |
| `shared/pkg/valuation/starlark_runtime_test.go` | Updated success test to use `run_policy` instead of inline `amount * rate` |
| `shared/pkg/valuation/internal/builtins/builtins_test.go` | Added tests for `run_policy` (success, missing expression, eval error, registry presence) |

## Architectural Context

The Meridian architecture mandates separation of concerns between Starlark (orchestration) and CEL (calculation). The saga runtime already enforced this via `cel_eval()` in its builtins. The valuation runtime had a `// Future: "run_policy"` placeholder but never implemented the bridge, meaning the only way to compute values was inline arithmetic in Starlark.

Now valuation scripts use:
```python
valued = run_policy(
    expression="amount * rate",
    variables={"amount": amount, "rate": rate},
)
```

instead of:
```python
valued = amount * rate  # architectural violation
```

## Test plan

- [x] All 31 valuation package tests pass (including 5 new tests)
- [x] Pre-commit hooks pass (gofumpt + golangci-lint)
- [ ] CI passes