### PR TITLE
fix: resolve goroutine panic in gRPC test server cleanup

### DIFF
--- a/services/current-account/client/starlark_test.go
+++ b/services/current-account/client/starlark_test.go
@@ -139,10 +139,10 @@ func setupMockServer(t *testing.T, mockServer *mockCurrentAccountServer) (*Clien
 	server := grpc.NewServer()
 	currentaccountv1.RegisterCurrentAccountServiceServer(server, mockServer)
 
+	serveDone := make(chan struct{})
 	go func() {
-		if err := server.Serve(listener); err != nil {
-			t.Logf("Server error: %v", err)
-		}
+		defer close(serveDone)
+		_ = server.Serve(listener)
 	}()
 
 	// Create client connection
@@ -163,7 +163,8 @@ func setupMockServer(t *testing.T, mockServer *mockCurrentAccountServer) (*Clien
 
 	cleanup := func() {
 		conn.Close()
-		server.Stop()
+		server.GracefulStop()
+		<-serveDone
 		listener.Close()
 	}
 

--- a/services/internal-bank-account/client/starlark_test.go
+++ b/services/internal-bank-account/client/starlark_test.go
@@ -94,10 +94,10 @@ func setupTestClient(t *testing.T) (*Client, *mockInternalBankAccountServer, fun
 	srv := grpc.NewServer()
 	internalbankaccountv1.RegisterInternalBankAccountServiceServer(srv, mock)
 
+	serveDone := make(chan struct{})
 	go func() {
-		if err := srv.Serve(listener); err != nil {
-			t.Logf("Server error: %v", err)
-		}
+		defer close(serveDone)
+		_ = srv.Serve(listener)
 	}()
 
 	// Create client connection using bufconn
@@ -118,7 +118,8 @@ func setupTestClient(t *testing.T) (*Client, *mockInternalBankAccountServer, fun
 
 	fullCleanup := func() {
 		conn.Close()
-		srv.Stop()
+		srv.GracefulStop()
+		<-serveDone
 		listener.Close()
 	}
 

--- a/services/market-information/client/starlark_test.go
+++ b/services/market-information/client/starlark_test.go
@@ -75,10 +75,10 @@ func setupStarlarkMockServer(t *testing.T, mockServer *mockMarketInformationServ
 	server := grpc.NewServer()
 	marketinformationv1.RegisterMarketInformationServiceServer(server, mockServer)
 
+	serveDone := make(chan struct{})
 	go func() {
-		if err := server.Serve(listener); err != nil {
-			t.Logf("Server error: %v", err)
-		}
+		defer close(serveDone)
+		_ = server.Serve(listener)
 	}()
 
 	// Create client connection
@@ -99,7 +99,8 @@ func setupStarlarkMockServer(t *testing.T, mockServer *mockMarketInformationServ
 
 	cleanup := func() {
 		conn.Close()
-		server.Stop()
+		server.GracefulStop()
+		<-serveDone
 		listener.Close()
 	}
 

--- a/services/position-keeping/client/starlark_test.go
+++ b/services/position-keeping/client/starlark_test.go
@@ -105,10 +105,10 @@ func setupMockServer(t *testing.T, mockServer *mockPositionKeepingServer) (*Clie
 	server := grpc.NewServer()
 	positionkeepingv1.RegisterPositionKeepingServiceServer(server, mockServer)
 
+	serveDone := make(chan struct{})
 	go func() {
-		if err := server.Serve(listener); err != nil {
-			t.Logf("Server error: %v", err)
-		}
+		defer close(serveDone)
+		_ = server.Serve(listener)
 	}()
 
 	// Create client connection
@@ -129,7 +129,8 @@ func setupMockServer(t *testing.T, mockServer *mockPositionKeepingServer) (*Clie
 
 	cleanup := func() {
 		conn.Close()
-		server.Stop()
+		server.GracefulStop()
+		<-serveDone
 		listener.Close()
 	}
 


### PR DESCRIPTION
## Summary

- Fix goroutine panic (`Log in goroutine after Test has completed`) in gRPC test server cleanup across all four affected service client test files
- Root cause: `srv.Serve()` goroutine called `t.Logf()` after the test had already returned, which panics in Go's testing framework
- Fix: discard the expected shutdown error from `Serve()`, use `GracefulStop()` instead of `Stop()`, and synchronize goroutine exit with a done channel before cleanup returns

## Changes Made

| File | Fix |
|------|-----|
| `services/internal-bank-account/client/starlark_test.go` | Goroutine sync + GracefulStop (CI-reported panic) |
| `services/position-keeping/client/starlark_test.go` | Same pattern (latent bug) |
| `services/market-information/client/starlark_test.go` | Same pattern (latent bug) |
| `services/current-account/client/starlark_test.go` | Same pattern (latent bug) |

## Test plan

- [x] All four test packages pass with `-race -count=10`
- [ ] CI Build and Test passes