### PR TITLE
Fix visible HTML comment marker and add bot comment gate in Claude review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -219,7 +219,7 @@ jobs:
             ```bash
             EXISTING_ID=$(gh api \
               repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-              --jq '[.[] | select(.user.login == "claude[bot]") | select(.body | contains("## Claude Code Review"))] | last | .id')
+              --jq '[.[] | select(.user.login == "claude[bot]") | select(.body | contains("## Claude Code Review"))] | last | .id // empty')
             ```
 
             **Step 2: Build summary content**

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -116,6 +116,40 @@ jobs:
 
             Don't block on CI status alone. Your review provides value regardless of CI state.
 
+            ## Bot Comment Gate (Check Before Approving)
+
+            Before deciding your review outcome, check whether other
+            bots (CodeRabbit, etc.) have unresolved review threads on
+            this PR. If they do, you MUST NOT approve - use `COMMENT`
+            instead so the author addresses that feedback first.
+
+            ```bash
+            BOT_THREADS=$(gh api graphql -f query='
+            query {
+              repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") {
+                pullRequest(number: ${{ github.event.pull_request.number }}) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      isResolved
+                      comments(first: 1) {
+                        nodes {
+                          author { login }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login != "claude[bot]") | select(.comments.nodes[0].author.login | test("\\[bot\\]$|coderabbitai"))] | length')
+            ```
+
+            - If `BOT_THREADS` > 0: Other bots have unresolved
+              comments. Downgrade your review to `COMMENT` and note
+              which bot(s) have unresolved threads the author should
+              address.
+            - If `BOT_THREADS` == 0: Proceed with your normal review
+              outcome (may approve if no issues found).
+
             ## Review Outcomes (Three States)
 
             GitHub supports three review states. Use them precisely:
@@ -124,12 +158,12 @@ jobs:
             |-------|--------------|-------------|
             | 🔴 **Blocking** | `REQUEST_CHANGES` | Critical issues that MUST be fixed before merge: security vulnerabilities, bugs, data loss risks, correctness problems |
             | 🟡 **Suggestions** | `COMMENT` | Improvements that SHOULD be addressed but don't block merge: code quality, edge cases, performance, style with objective benefit |
-            | 🟢 **Approve** | `APPROVE` | Ready to merge as-is, possibly with minor informational notes |
+            | 🟢 **Approve** | `APPROVE` | Ready to merge as-is, possibly with minor informational notes. **Only if no unresolved bot threads exist** (see Bot Comment Gate above). |
 
             **Decision criteria:**
             - **🔴 Blocking (REQUEST_CHANGES)**: Would this cause a bug, security issue, data loss, or break functionality? Use sparingly - this blocks the merge.
             - **🟡 Suggestions (COMMENT)**: Is this an improvement that doesn't affect correctness? Use for "should fix" items that shouldn't hold up the merge.
-            - **🟢 Approve (APPROVE)**: Does the code meet requirements and pass tests with no actionable feedback?
+            - **🟢 Approve (APPROVE)**: Does the code meet requirements and pass tests with no actionable feedback? **AND no other bots have unresolved threads.**
 
             **Important**: `REQUEST_CHANGES` is reserved for genuine blockers. Using it for minor suggestions frustrates authors and slows velocity. If it's not a blocker, use `COMMENT`.
 
@@ -176,19 +210,27 @@ jobs:
             than posting a new one.
 
             **Step 1: Find existing summary comment**
+
+            Find the existing summary comment by matching the author
+            (`claude[bot]`) and the heading (`## Claude Code Review`).
+            Do NOT use HTML comments as markers - they render as visible
+            text when posted via the GitHub API.
+
             ```bash
             EXISTING_ID=$(gh api \
               repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
-              --jq '[.[] | select(.body | contains("<!-- claude-code-review -->"))] | last | .id')
+              --jq '[.[] | select(.user.login == "claude[bot]") | select(.body | contains("## Claude Code Review"))] | last | .id')
             ```
 
             **Step 2: Build summary content**
 
-            Always start with `<!-- claude-code-review -->` marker.
+            Do NOT include HTML comments (e.g. `<!-- ... -->`) in the
+            comment body - they render as visible text when posted via
+            the API. Start directly with the heading.
+
             Structure:
 
             ```markdown
-            <!-- claude-code-review -->
             ## Claude Code Review
 
             **Commit**: `<sha>` | **CI**: passing/running/failing


### PR DESCRIPTION
## Summary

- Remove `<!-- claude-code-review -->` HTML comment marker from Claude Code review workflow. This HTML comment was rendering as visible text in PR comments when posted via the GitHub API. Replace with author-based detection (`claude[bot]` + `## Claude Code Review` heading match) to find existing summary comments for in-place updates.
- Add a bot comment gate: Claude will not approve a PR if other bots (CodeRabbit, etc.) have unresolved review threads. Instead it downgrades to `COMMENT` and notes which bots have outstanding feedback the author should address first.

## Changes Made

**`.github/workflows/claude-code-review.yml`**:

1. **Comment detection**: Changed `jq` selector from `contains("<!-- claude-code-review -->")` to `select(.user.login == "claude[bot]") | select(.body | contains("## Claude Code Review"))` - matches by author + heading instead of HTML comment marker
2. **Template cleanup**: Removed `<!-- claude-code-review -->` from the summary comment template and added explicit instructions to never use HTML comments in comment bodies
3. **Bot comment gate**: Added new section before Review Outcomes that queries for unresolved review threads from other bots via GraphQL. If any exist, Claude must downgrade from `APPROVE` to `COMMENT`
4. **Updated approval criteria**: APPROVE outcome now explicitly requires no unresolved bot threads

## Test plan

- [ ] Push a commit to an existing PR and verify the Claude review comment no longer shows `<!-- claude-code-review -->` as visible text
- [ ] Verify Claude can still find and update its existing summary comment (author-based detection works)
- [ ] Verify Claude does not approve when CodeRabbit has unresolved threads
- [ ] Verify Claude can approve when all bot threads are resolved