### PR TITLE
feat: scaffold reconciliation service

### DIFF
--- a/services/reconciliation/README.md
+++ b/services/reconciliation/README.md
@@ -1,0 +1,100 @@
+---
+name: reconciliation-service
+description: BIAN Account Reconciliation service for matching and reconciling positions across services
+triggers:
+  - Reconciling account positions between services
+  - Matching financial transactions across ledgers
+  - Settlement processing and scheduling
+  - Investigating reconciliation discrepancies
+instructions: |
+  Reconciliation manages the matching and verification of account positions across
+  Position Keeping, Financial Accounting, and Current Account services.
+
+  Key concepts:
+  - Reconciliation runs compare positions across multiple sources
+  - Discrepancies are identified and tracked for resolution
+  - Settlement scheduler automates periodic reconciliation
+
+  Port: 50060 (gRPC)
+---
+
+# Reconciliation Service
+
+BIAN-compliant Account Reconciliation service for matching and reconciling positions across Meridian services.
+
+## Overview
+
+| Attribute | Value |
+|-----------|-------|
+| **BIAN Domain** | Account Reconciliation |
+| **Port** | 50060 (gRPC) |
+| **Language** | Go |
+| **Database** | CockroachDB |
+| **Standalone** | Yes |
+
+## Architecture
+
+The Reconciliation service acts as a cross-cutting concern, comparing positions across
+multiple upstream services to verify consistency and identify discrepancies.
+
+### Service Dependencies
+
+| Service | Purpose |
+|---------|---------|
+| Position Keeping | Source of transaction logs and balance positions |
+| Financial Accounting | Source of ledger entries and journal postings |
+| Current Account | Source of account state and balances |
+| Reference Data | Instrument definitions and validation rules |
+| Payment Order | Settlement execution for resolved discrepancies |
+
+## Configuration
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `GRPC_PORT` | 50060 | gRPC server port |
+| `METRICS_PORT` | 9090 | HTTP metrics and health port |
+| `DATABASE_URL` | - | CockroachDB connection string |
+| `KAFKA_BROKERS` | - | Kafka broker addresses |
+| `REDIS_URL` | - | Redis connection URL |
+| `POSITION_KEEPING_URL` | - | Position Keeping gRPC address |
+| `FINANCIAL_ACCOUNTING_URL` | - | Financial Accounting gRPC address |
+| `CURRENT_ACCOUNT_URL` | - | Current Account gRPC address |
+| `REFERENCE_DATA_URL` | - | Reference Data gRPC address |
+| `PAYMENT_ORDER_URL` | - | Payment Order gRPC address |
+| `SETTLEMENT_SCHEDULER_ENABLED` | false | Enable automated settlement scheduling |
+
+## Local Development
+
+### Prerequisites
+
+- Go 1.25+
+- CockroachDB (via Docker or local install)
+- Protocol Buffers compiler (`buf`)
+
+### Running Locally
+
+```bash
+# Set required environment variables
+export DATABASE_URL="postgres://meridian_reconciliation_user@localhost:26257/meridian_reconciliation?sslmode=disable"
+
+# Run the service
+go run ./services/reconciliation/cmd
+
+# Run tests
+go test ./services/reconciliation/...
+```
+
+### Building
+
+```bash
+# Build binary
+go build -o reconciliation ./services/reconciliation/cmd
+
+# Build Docker image
+docker build -f services/reconciliation/cmd/Dockerfile -t reconciliation:latest .
+```
+
+## References
+
+- [BIAN Account Reconciliation](https://bian.org/semantic-apis/account-reconciliation/)
+- [Service Architecture](../README.md)

--- a/services/reconciliation/cmd/Dockerfile
+++ b/services/reconciliation/cmd/Dockerfile
@@ -1,0 +1,56 @@
+# Reconciliation Service - Multi-Stage Dockerfile
+# Optimized for security, size, and performance
+# Uses distroless base image (~2MB) enabled by pure-Go dependencies
+
+# Build stage
+FROM golang:1.25.7-bookworm AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum* ./
+RUN go mod download && go mod verify
+
+# Copy source code
+COPY . .
+
+# Build static binary (no CGO required)
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -o reconciliation \
+    ./services/reconciliation/cmd
+
+# Verify the binary exists and is executable
+RUN test -x reconciliation && echo "Binary built successfully"
+
+# Runtime stage - distroless for minimal attack surface (~2MB base)
+FROM gcr.io/distroless/static-debian12
+
+# Copy timezone data from builder for time-sensitive operations
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary from builder
+COPY --from=builder /build/reconciliation /reconciliation
+
+# Use non-root user (distroless provides nonroot user at uid 65532)
+USER nonroot:nonroot
+
+# Expose gRPC and metrics ports
+EXPOSE 50060 9090
+
+# Note: Health checks handled by gRPC health check service
+
+# Run the binary
+ENTRYPOINT ["/reconciliation"]

--- a/services/reconciliation/cmd/main.go
+++ b/services/reconciliation/cmd/main.go
@@ -1,0 +1,242 @@
+// Package main is the entry point for the Reconciliation service.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/meridianhub/meridian/services/reconciliation/config"
+	"github.com/meridianhub/meridian/services/reconciliation/observability"
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+// Build information set via ldflags during compilation.
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+func main() {
+	logLevel := parseLogLevel(os.Getenv("LOG_LEVEL"))
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting reconciliation service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	if err := run(logger); err != nil {
+		logger.Error("service failed", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	ctx := context.Background()
+
+	// Load configuration
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load configuration: %w", err)
+	}
+
+	logger.Info("configuration loaded",
+		"environment", cfg.Observability.Environment,
+		"grpc_port", cfg.Server.Port,
+		"metrics_port", cfg.Observability.MetricsPort)
+
+	// Initialize OpenTelemetry tracer
+	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
+		ServiceName:    cfg.Observability.ServiceName,
+		ServiceVersion: Version,
+		Logger:         logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	defer bootstrap.ShutdownTracer(tracer, logger)
+
+	// Initialize database connection
+	dbConfig := bootstrap.DefaultDatabaseConfig()
+	dbConfig.DSN = cfg.Database.URL
+	dbConfig.MaxOpenConns = cfg.Database.MaxOpenConns
+	dbConfig.MaxIdleConns = cfg.Database.MaxIdleConns
+	dbConfig.ConnMaxLifetime = cfg.Database.ConnMaxLifetime
+	dbConfig.ConnMaxIdleTime = cfg.Database.ConnMaxIdleTime
+	dbConfig.Logger = logger
+
+	db, err := bootstrap.NewDatabase(ctx, dbConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize database: %w", err)
+	}
+	defer bootstrap.CloseDatabase(db, logger)
+
+	logger.Info("database connection established")
+
+	// Initialize auth interceptor
+	authConfig := bootstrap.DefaultAuthConfig(logger)
+	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+
+	// Create gRPC server with interceptor chain
+	grpcServer := bootstrap.NewGrpcServerBuilder(tracer, logger).
+		WithAuthInterceptor(authInterceptor).
+		Build()
+
+	// Register health check service
+	healthAggregator := health.NewAggregator([]health.Checker{
+		observability.NewDatabaseChecker(db),
+	})
+	healthServer := newHealthServer(healthAggregator, logger)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+
+	// Register reflection service for debugging
+	reflection.Register(grpcServer)
+
+	logger.Info("gRPC services registered",
+		"services", []string{"Health", "Reflection"})
+
+	// Create gRPC listener
+	grpcAddress := fmt.Sprintf(":%s", cfg.Server.Port)
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", grpcAddress)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", grpcAddress, err)
+	}
+
+	// Start gRPC server in background
+	serverErrors := make(chan error, 2)
+	go func() {
+		logger.Info("starting gRPC server", "address", grpcAddress)
+		if err := grpcServer.Serve(listener); err != nil {
+			serverErrors <- err
+		}
+	}()
+
+	// Start HTTP server for metrics and health endpoints
+	httpMux := http.NewServeMux()
+	httpMux.Handle("/metrics", promhttp.Handler())
+
+	healthHandler := health.NewHTTPHandler(healthAggregator)
+	healthHandler.RegisterHandlers(httpMux)
+
+	httpServer := &http.Server{
+		Addr:              fmt.Sprintf(":%s", cfg.Observability.MetricsPort),
+		Handler:           httpMux,
+		ReadHeaderTimeout: 10 * time.Second,
+		WriteTimeout:      30 * time.Second,
+	}
+
+	go func() {
+		logger.Info("starting HTTP server for health and metrics",
+			"address", httpServer.Addr)
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serverErrors <- fmt.Errorf("HTTP server error: %w", err)
+		}
+	}()
+
+	// Wait for interrupt signal or server error
+	sigChan, signalCleanup := bootstrap.SignalHandler()
+	defer signalCleanup()
+
+	select {
+	case sig := <-sigChan:
+		logger.Info("received signal", "signal", sig)
+	case err := <-serverErrors:
+		return fmt.Errorf("server error: %w", err)
+	}
+
+	// Graceful shutdown
+	logger.Info("shutting down servers...")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.Server.GracefulShutdownTimeout)
+	defer cancel()
+
+	// Shutdown HTTP server
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		logger.Error("HTTP server shutdown error", "error", err)
+	} else {
+		logger.Info("HTTP server stopped")
+	}
+
+	// Gracefully stop gRPC server
+	stopped := make(chan struct{})
+	go func() {
+		grpcServer.GracefulStop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+		logger.Info("gRPC server stopped gracefully")
+	case <-shutdownCtx.Done():
+		logger.Warn("graceful shutdown timeout, forcing stop")
+		grpcServer.Stop()
+	}
+
+	return nil
+}
+
+// healthServer implements the gRPC health checking protocol.
+type healthServer struct {
+	grpc_health_v1.UnimplementedHealthServer
+	aggregator *health.Aggregator
+	logger     *slog.Logger
+}
+
+func newHealthServer(aggregator *health.Aggregator, logger *slog.Logger) *healthServer {
+	return &healthServer{
+		aggregator: aggregator,
+		logger:     logger,
+	}
+}
+
+// Check performs a health check.
+func (h *healthServer) Check(ctx context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	report := h.aggregator.CheckAll(ctx)
+
+	grpcStatus := grpc_health_v1.HealthCheckResponse_SERVING
+	overallStatus := report.OverallStatus()
+	if overallStatus == health.StatusUnhealthy || overallStatus == health.StatusDegraded {
+		grpcStatus = grpc_health_v1.HealthCheckResponse_NOT_SERVING
+		h.logger.Warn("health check failed",
+			"status", overallStatus,
+			"checked_at", report.CheckedAt)
+	}
+
+	return &grpc_health_v1.HealthCheckResponse{
+		Status: grpcStatus,
+	}, nil
+}
+
+// parseLogLevel converts a string log level to slog.Level.
+func parseLogLevel(levelStr string) slog.Level {
+	switch strings.ToLower(levelStr) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/services/reconciliation/cmd/main.go
+++ b/services/reconciliation/cmd/main.go
@@ -144,6 +144,15 @@ func run(logger *slog.Logger) error {
 		ReadHeaderTimeout: 10 * time.Second,
 		WriteTimeout:      30 * time.Second,
 	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			logger.Error("HTTP server shutdown error", "error", err)
+		} else {
+			logger.Info("HTTP server stopped")
+		}
+	}()
 
 	go func() {
 		logger.Info("starting HTTP server for health and metrics",
@@ -169,13 +178,6 @@ func run(logger *slog.Logger) error {
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.Server.GracefulShutdownTimeout)
 	defer cancel()
-
-	// Shutdown HTTP server
-	if err := httpServer.Shutdown(shutdownCtx); err != nil {
-		logger.Error("HTTP server shutdown error", "error", err)
-	} else {
-		logger.Info("HTTP server stopped")
-	}
 
 	// Gracefully stop gRPC server
 	stopped := make(chan struct{})
@@ -232,6 +234,8 @@ func parseLogLevel(levelStr string) slog.Level {
 	switch strings.ToLower(levelStr) {
 	case "debug":
 		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
 	case "warn", "warning":
 		return slog.LevelWarn
 	case "error":

--- a/services/reconciliation/config/config.go
+++ b/services/reconciliation/config/config.go
@@ -1,0 +1,201 @@
+// Package config provides configuration for the reconciliation service.
+package config
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/meridianhub/meridian/shared/platform/ports"
+)
+
+// Config holds all configuration for the reconciliation service.
+type Config struct {
+	Server        ServerConfig
+	Database      DatabaseConfig
+	Kafka         KafkaConfig
+	Redis         RedisConfig
+	Observability ObservabilityConfig
+	Services      ServiceURLsConfig
+	Scheduler     SchedulerConfig
+}
+
+// ServerConfig holds gRPC server configuration.
+type ServerConfig struct {
+	// Port is the gRPC server port.
+	Port string
+	// GracefulShutdownTimeout is the maximum time to wait for graceful shutdown.
+	GracefulShutdownTimeout time.Duration
+}
+
+// DatabaseConfig holds database connection configuration.
+type DatabaseConfig struct {
+	// URL is the database connection string.
+	URL string
+	// MaxOpenConns is the maximum number of open connections to the database.
+	MaxOpenConns int
+	// MaxIdleConns is the maximum number of idle connections in the pool.
+	MaxIdleConns int
+	// ConnMaxLifetime is the maximum amount of time a connection may be reused.
+	ConnMaxLifetime time.Duration
+	// ConnMaxIdleTime is the maximum time a connection may be idle before being closed.
+	ConnMaxIdleTime time.Duration
+}
+
+// KafkaConfig holds Kafka event configuration.
+type KafkaConfig struct {
+	// Brokers is the list of Kafka broker addresses.
+	Brokers string
+	// Enabled indicates if Kafka is enabled.
+	Enabled bool
+}
+
+// RedisConfig holds Redis configuration.
+type RedisConfig struct {
+	// URL is the Redis connection URL.
+	URL string
+	// Enabled indicates if Redis is enabled.
+	Enabled bool
+}
+
+// ObservabilityConfig holds observability configuration.
+type ObservabilityConfig struct {
+	// ServiceName is the service name for tracing and metrics.
+	ServiceName string
+	// ServiceVersion is the service version for tracing.
+	ServiceVersion string
+	// Environment is the deployment environment.
+	Environment string
+	// MetricsPort is the port for the HTTP metrics and health endpoint.
+	MetricsPort string
+	// LogLevel is the logging level.
+	LogLevel string
+}
+
+// ServiceURLsConfig holds URLs for upstream service dependencies.
+type ServiceURLsConfig struct {
+	// PositionKeepingURL is the gRPC address of the Position Keeping service.
+	PositionKeepingURL string
+	// FinancialAccountingURL is the gRPC address of the Financial Accounting service.
+	FinancialAccountingURL string
+	// CurrentAccountURL is the gRPC address of the Current Account service.
+	CurrentAccountURL string
+	// ReferenceDataURL is the gRPC address of the Reference Data service.
+	ReferenceDataURL string
+	// PaymentOrderURL is the gRPC address of the Payment Order service.
+	PaymentOrderURL string
+}
+
+// SchedulerConfig holds configuration for the settlement scheduler.
+type SchedulerConfig struct {
+	// Enabled indicates if the settlement scheduler is enabled.
+	Enabled bool
+}
+
+// Validation errors.
+var (
+	ErrEmptyPort           = fmt.Errorf("server port must not be empty")
+	ErrEmptyDatabaseURL    = fmt.Errorf("database URL must not be empty")
+	ErrInvalidMaxOpenConns = fmt.Errorf("database max open connections must be at least 1")
+	ErrInvalidMaxIdleConns = fmt.Errorf("database max idle connections must be non-negative")
+	ErrInvalidMetricsPort  = fmt.Errorf("metrics port must not be empty")
+)
+
+// LoadConfig loads configuration from environment variables with defaults.
+func LoadConfig() (*Config, error) {
+	config := &Config{
+		Server:        loadServerConfig(),
+		Database:      loadDatabaseConfig(),
+		Kafka:         loadKafkaConfig(),
+		Redis:         loadRedisConfig(),
+		Observability: loadObservabilityConfig(),
+		Services:      loadServiceURLsConfig(),
+		Scheduler:     loadSchedulerConfig(),
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid configuration: %w", err)
+	}
+
+	return config, nil
+}
+
+func loadServerConfig() ServerConfig {
+	return ServerConfig{
+		Port:                    env.GetEnvOrDefault("GRPC_PORT", strconv.Itoa(ports.Reconciliation)),
+		GracefulShutdownTimeout: env.GetEnvAsDuration("GRACEFUL_SHUTDOWN_TIMEOUT", 30*time.Second),
+	}
+}
+
+func loadDatabaseConfig() DatabaseConfig {
+	return DatabaseConfig{
+		URL:             env.GetEnvOrDefault("DATABASE_URL", ""),
+		MaxOpenConns:    env.GetEnvAsInt("DB_MAX_OPEN_CONNS", 25),
+		MaxIdleConns:    env.GetEnvAsInt("DB_MAX_IDLE_CONNS", 5),
+		ConnMaxLifetime: env.GetEnvAsDuration("DB_CONN_MAX_LIFETIME", 5*time.Minute),
+		ConnMaxIdleTime: env.GetEnvAsDuration("DB_CONN_MAX_IDLE_TIME", 10*time.Minute),
+	}
+}
+
+func loadKafkaConfig() KafkaConfig {
+	brokers := env.GetEnvOrDefault("KAFKA_BROKERS", "")
+	return KafkaConfig{
+		Brokers: brokers,
+		Enabled: brokers != "",
+	}
+}
+
+func loadRedisConfig() RedisConfig {
+	url := env.GetEnvOrDefault("REDIS_URL", "")
+	return RedisConfig{
+		URL:     url,
+		Enabled: url != "",
+	}
+}
+
+func loadObservabilityConfig() ObservabilityConfig {
+	return ObservabilityConfig{
+		ServiceName:    "reconciliation-service",
+		ServiceVersion: "dev",
+		Environment:    env.GetEnvOrDefault("ENVIRONMENT", "development"),
+		MetricsPort:    env.GetEnvOrDefault("METRICS_PORT", "9090"),
+		LogLevel:       env.GetEnvOrDefault("LOG_LEVEL", "info"),
+	}
+}
+
+func loadServiceURLsConfig() ServiceURLsConfig {
+	return ServiceURLsConfig{
+		PositionKeepingURL:     env.GetEnvOrDefault("POSITION_KEEPING_URL", ""),
+		FinancialAccountingURL: env.GetEnvOrDefault("FINANCIAL_ACCOUNTING_URL", ""),
+		CurrentAccountURL:      env.GetEnvOrDefault("CURRENT_ACCOUNT_URL", ""),
+		ReferenceDataURL:       env.GetEnvOrDefault("REFERENCE_DATA_URL", ""),
+		PaymentOrderURL:        env.GetEnvOrDefault("PAYMENT_ORDER_URL", ""),
+	}
+}
+
+func loadSchedulerConfig() SchedulerConfig {
+	return SchedulerConfig{
+		Enabled: env.GetEnvAsBool("SETTLEMENT_SCHEDULER_ENABLED", false),
+	}
+}
+
+// Validate validates the configuration.
+func (c *Config) Validate() error {
+	if c.Server.Port == "" {
+		return ErrEmptyPort
+	}
+	if c.Database.URL == "" {
+		return ErrEmptyDatabaseURL
+	}
+	if c.Database.MaxOpenConns < 1 {
+		return ErrInvalidMaxOpenConns
+	}
+	if c.Database.MaxIdleConns < 0 {
+		return ErrInvalidMaxIdleConns
+	}
+	if c.Observability.MetricsPort == "" {
+		return ErrInvalidMetricsPort
+	}
+	return nil
+}

--- a/services/reconciliation/config/config.go
+++ b/services/reconciliation/config/config.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -95,11 +96,12 @@ type SchedulerConfig struct {
 
 // Validation errors.
 var (
-	ErrEmptyPort           = fmt.Errorf("server port must not be empty")
-	ErrEmptyDatabaseURL    = fmt.Errorf("database URL must not be empty")
-	ErrInvalidMaxOpenConns = fmt.Errorf("database max open connections must be at least 1")
-	ErrInvalidMaxIdleConns = fmt.Errorf("database max idle connections must be non-negative")
-	ErrInvalidMetricsPort  = fmt.Errorf("metrics port must not be empty")
+	ErrEmptyPort           = errors.New("server port must not be empty")
+	ErrEmptyDatabaseURL    = errors.New("database URL must not be empty")
+	ErrInvalidMaxOpenConns = errors.New("database max open connections must be at least 1")
+	ErrInvalidMaxIdleConns = errors.New("database max idle connections must be non-negative")
+	ErrInvalidMetricsPort  = errors.New("metrics port must not be empty")
+	ErrInvalidPortNumber   = errors.New("port must be a valid number")
 )
 
 // LoadConfig loads configuration from environment variables with defaults.
@@ -185,6 +187,9 @@ func (c *Config) Validate() error {
 	if c.Server.Port == "" {
 		return ErrEmptyPort
 	}
+	if _, err := strconv.Atoi(c.Server.Port); err != nil {
+		return fmt.Errorf("server %w: %w", ErrInvalidPortNumber, err)
+	}
 	if c.Database.URL == "" {
 		return ErrEmptyDatabaseURL
 	}
@@ -196,6 +201,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Observability.MetricsPort == "" {
 		return ErrInvalidMetricsPort
+	}
+	if _, err := strconv.Atoi(c.Observability.MetricsPort); err != nil {
+		return fmt.Errorf("metrics %w: %w", ErrInvalidPortNumber, err)
 	}
 	return nil
 }

--- a/services/reconciliation/config/config_test.go
+++ b/services/reconciliation/config/config_test.go
@@ -99,6 +99,28 @@ func TestValidate_EmptyMetricsPort(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidMetricsPort)
 }
 
+func TestValidate_InvalidServerPort(t *testing.T) {
+	cfg := &Config{
+		Server:        ServerConfig{Port: "abc"},
+		Database:      DatabaseConfig{URL: "postgres://...", MaxOpenConns: 25, MaxIdleConns: 5},
+		Observability: ObservabilityConfig{MetricsPort: "9090"},
+	}
+
+	err := cfg.Validate()
+	assert.ErrorIs(t, err, ErrInvalidPortNumber)
+}
+
+func TestValidate_InvalidMetricsPort(t *testing.T) {
+	cfg := &Config{
+		Server:        ServerConfig{Port: "50060"},
+		Database:      DatabaseConfig{URL: "postgres://...", MaxOpenConns: 25, MaxIdleConns: 5},
+		Observability: ObservabilityConfig{MetricsPort: "abc"},
+	}
+
+	err := cfg.Validate()
+	assert.ErrorIs(t, err, ErrInvalidPortNumber)
+}
+
 func TestValidate_Success(t *testing.T) {
 	cfg := &Config{
 		Server:        ServerConfig{Port: "50060"},

--- a/services/reconciliation/config/config_test.go
+++ b/services/reconciliation/config/config_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig_RequiresDatabaseURL(t *testing.T) {
+	t.Setenv("DATABASE_URL", "")
+
+	_, err := LoadConfig()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEmptyDatabaseURL)
+}
+
+func TestLoadConfig_Success(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://user@localhost:26257/reconciliation?sslmode=disable")
+	t.Setenv("GRPC_PORT", "50060")
+	t.Setenv("KAFKA_BROKERS", "kafka:9092")
+	t.Setenv("REDIS_URL", "redis://localhost:6379")
+	t.Setenv("POSITION_KEEPING_URL", "position-keeping:50053")
+	t.Setenv("SETTLEMENT_SCHEDULER_ENABLED", "true")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, "50060", cfg.Server.Port)
+	assert.Equal(t, "postgres://user@localhost:26257/reconciliation?sslmode=disable", cfg.Database.URL)
+	assert.Equal(t, "kafka:9092", cfg.Kafka.Brokers)
+	assert.True(t, cfg.Kafka.Enabled)
+	assert.Equal(t, "redis://localhost:6379", cfg.Redis.URL)
+	assert.True(t, cfg.Redis.Enabled)
+	assert.Equal(t, "position-keeping:50053", cfg.Services.PositionKeepingURL)
+	assert.True(t, cfg.Scheduler.Enabled)
+}
+
+func TestLoadConfig_DefaultPort(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://user@localhost:26257/reconciliation?sslmode=disable")
+	// Don't set GRPC_PORT - should default to 50060
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, "50060", cfg.Server.Port)
+}
+
+func TestLoadConfig_KafkaDisabledWhenBrokersEmpty(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://user@localhost:26257/reconciliation?sslmode=disable")
+	t.Setenv("KAFKA_BROKERS", "")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+
+	assert.False(t, cfg.Kafka.Enabled)
+}
+
+func TestLoadConfig_RedisDisabledWhenURLEmpty(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://user@localhost:26257/reconciliation?sslmode=disable")
+	t.Setenv("REDIS_URL", "")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+
+	assert.False(t, cfg.Redis.Enabled)
+}
+
+func TestValidate_InvalidMaxOpenConns(t *testing.T) {
+	cfg := &Config{
+		Server:        ServerConfig{Port: "50060"},
+		Database:      DatabaseConfig{URL: "postgres://...", MaxOpenConns: 0, MaxIdleConns: 0},
+		Observability: ObservabilityConfig{MetricsPort: "9090"},
+	}
+
+	err := cfg.Validate()
+	assert.ErrorIs(t, err, ErrInvalidMaxOpenConns)
+}
+
+func TestValidate_InvalidMaxIdleConns(t *testing.T) {
+	cfg := &Config{
+		Server:        ServerConfig{Port: "50060"},
+		Database:      DatabaseConfig{URL: "postgres://...", MaxOpenConns: 25, MaxIdleConns: -1},
+		Observability: ObservabilityConfig{MetricsPort: "9090"},
+	}
+
+	err := cfg.Validate()
+	assert.ErrorIs(t, err, ErrInvalidMaxIdleConns)
+}
+
+func TestValidate_EmptyMetricsPort(t *testing.T) {
+	cfg := &Config{
+		Server:        ServerConfig{Port: "50060"},
+		Database:      DatabaseConfig{URL: "postgres://...", MaxOpenConns: 25, MaxIdleConns: 5},
+		Observability: ObservabilityConfig{MetricsPort: ""},
+	}
+
+	err := cfg.Validate()
+	assert.ErrorIs(t, err, ErrInvalidMetricsPort)
+}
+
+func TestValidate_Success(t *testing.T) {
+	cfg := &Config{
+		Server:        ServerConfig{Port: "50060"},
+		Database:      DatabaseConfig{URL: "postgres://...", MaxOpenConns: 25, MaxIdleConns: 5},
+		Observability: ObservabilityConfig{MetricsPort: "9090"},
+	}
+
+	err := cfg.Validate()
+	assert.NoError(t, err)
+}

--- a/services/reconciliation/k8s/configmap.yaml
+++ b/services/reconciliation/k8s/configmap.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: reconciliation-config
+  labels:
+    app: reconciliation
+    component: microservice
+data:
+  # Logging configuration
+  LOG_LEVEL: "info"
+
+  # Database connection pool settings
+  DB_MAX_OPEN_CONNS: "25"
+  DB_MAX_IDLE_CONNS: "5"
+  DB_CONN_MAX_LIFETIME: "5m"
+  DB_CONN_MAX_IDLE_TIME: "10m"
+
+  # gRPC server configuration
+  GRPC_PORT: "50060"
+
+  # Metrics configuration
+  METRICS_PORT: "9090"
+
+  # Upstream service URLs
+  POSITION_KEEPING_URL: "position-keeping:50053"
+  FINANCIAL_ACCOUNTING_URL: "financial-accounting:50052"
+  CURRENT_ACCOUNT_URL: "current-account:50051"
+  REFERENCE_DATA_URL: "reference-data:50059"
+  PAYMENT_ORDER_URL: "payment-order:50054"
+
+  # Settlement scheduler
+  SETTLEMENT_SCHEDULER_ENABLED: "false"
+
+  # OpenTelemetry configuration
+  OTEL_SERVICE_NAME: "reconciliation-service"
+  OTEL_SAMPLING_RATE: "0.1"

--- a/services/reconciliation/k8s/deployment.yaml
+++ b/services/reconciliation/k8s/deployment.yaml
@@ -1,0 +1,112 @@
+# Port Configuration: See shared/platform/ports/ports.go for canonical port assignments.
+# This service uses ports.Reconciliation (50060) for gRPC.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reconciliation
+  labels:
+    app: reconciliation
+    component: microservice
+    tier: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: reconciliation
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: reconciliation
+        component: microservice
+        tier: backend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: reconciliation
+        image: reconciliation:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grpc
+          containerPort: 50060
+          protocol: TCP
+        - name: metrics
+          containerPort: 9090
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: reconciliation-config
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: reconciliation-db
+              key: DATABASE_URL
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        livenessProbe:
+          grpc:
+            port: 50060
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          grpc:
+            port: 50060
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        startupProbe:
+          grpc:
+            port: 50060
+          initialDelaySeconds: 0
+          periodSeconds: 2
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 30
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      terminationGracePeriodSeconds: 30

--- a/services/reconciliation/k8s/secret.yaml
+++ b/services/reconciliation/k8s/secret.yaml
@@ -1,0 +1,17 @@
+# SECURITY NOTE: This secret contains development credentials only.
+# For production deployments:
+# - Use external secret management (e.g., Sealed Secrets, External Secrets Operator)
+# - Rotate credentials regularly
+# - Use RBAC to restrict secret access
+# - Enable encryption at rest for secrets
+apiVersion: v1
+kind: Secret
+metadata:
+  name: reconciliation-db
+  labels:
+    app: reconciliation
+type: Opaque
+stringData:
+  # Local development connection string - CockroachDB in insecure mode
+  # Service connects to its own isolated database with dedicated user
+  DATABASE_URL: "postgres://meridian_reconciliation_user@cockroachdb:26257/meridian_reconciliation?sslmode=disable"

--- a/services/reconciliation/k8s/service.yaml
+++ b/services/reconciliation/k8s/service.yaml
@@ -1,0 +1,19 @@
+# Port Configuration: See shared/platform/ports/ports.go for canonical port assignments.
+# This service uses ports.Reconciliation (50060) for gRPC.
+apiVersion: v1
+kind: Service
+metadata:
+  name: reconciliation
+  labels:
+    app: reconciliation
+    component: microservice
+spec:
+  type: ClusterIP
+  clusterIP: None  # Headless service for gRPC client-side load balancing
+  ports:
+  - name: grpc
+    port: 50060
+    targetPort: grpc
+    protocol: TCP
+  selector:
+    app: reconciliation

--- a/services/reconciliation/observability/health.go
+++ b/services/reconciliation/observability/health.go
@@ -1,0 +1,66 @@
+// Package observability provides health checks and metrics for the reconciliation service.
+package observability
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/health"
+	"gorm.io/gorm"
+)
+
+// DatabaseChecker checks the health of a GORM database connection.
+type DatabaseChecker struct {
+	db *gorm.DB
+}
+
+// NewDatabaseChecker creates a new database health checker.
+func NewDatabaseChecker(db *gorm.DB) *DatabaseChecker {
+	if db == nil {
+		panic("NewDatabaseChecker: db cannot be nil")
+	}
+	return &DatabaseChecker{db: db}
+}
+
+// Name returns the component name.
+func (d *DatabaseChecker) Name() string {
+	return "database"
+}
+
+// Check performs a database health check by pinging the connection.
+func (d *DatabaseChecker) Check(ctx context.Context) health.ComponentResult {
+	start := time.Now()
+
+	sqlDB, err := d.db.DB()
+	if err != nil {
+		return health.ComponentResult{
+			Name:         d.Name(),
+			Status:       health.StatusUnhealthy,
+			Message:      fmt.Sprintf("failed to get database instance: %v", err),
+			ResponseTime: time.Since(start),
+			CheckedAt:    start,
+			Error:        err,
+		}
+	}
+
+	err = sqlDB.PingContext(ctx)
+	responseTime := time.Since(start)
+
+	status := health.StatusHealthy
+	message := "database connection successful"
+
+	if err != nil {
+		status = health.StatusUnhealthy
+		message = fmt.Sprintf("database ping failed: %v", err)
+	}
+
+	return health.ComponentResult{
+		Name:         d.Name(),
+		Status:       status,
+		Message:      message,
+		ResponseTime: responseTime,
+		CheckedAt:    start,
+		Error:        err,
+	}
+}

--- a/shared/platform/ports/ports.go
+++ b/shared/platform/ports/ports.go
@@ -105,6 +105,13 @@ const (
 	// Protocol: gRPC (internal)
 	// Visibility: Cluster-internal only
 	ReferenceData = 50059
+
+	// Reconciliation is the gRPC port for the Account Reconciliation service.
+	// BIAN Service Domain: Account Reconciliation
+	// Manages reconciliation of account positions across services.
+	// Protocol: gRPC (internal)
+	// Visibility: Cluster-internal only
+	Reconciliation = 50060
 )
 
 // HTTP service ports (various protocols).


### PR DESCRIPTION
## Summary

- Add foundational service structure for the Account Reconciliation service
- Register port 50060 in `shared/platform/ports/ports.go`
- Follow existing Meridian service patterns (position-keeping, financial-accounting)

## Changes

### New: `services/reconciliation/`

| Component | File | Purpose |
|-----------|------|---------|
| Entry point | `cmd/main.go` | gRPC server with health checks, tracing, auth interceptor chain |
| Config | `config/config.go` | Environment variable loading with validation |
| Config tests | `config/config_test.go` | 9 tests covering validation and defaults |
| Health | `observability/health.go` | GORM database health checker |
| Dockerfile | `cmd/Dockerfile` | Multi-stage distroless build |
| K8s | `k8s/deployment.yaml` | Deployment with security context, probes, resource limits |
| K8s | `k8s/service.yaml` | Headless ClusterIP for gRPC load balancing |
| K8s | `k8s/configmap.yaml` | Non-secret configuration |
| K8s | `k8s/secret.yaml` | Development database credentials |
| Docs | `README.md` | Service overview, config reference, local dev setup |

### Modified: `shared/platform/ports/ports.go`

- Add `Reconciliation = 50060` port constant

## Configuration

| Variable | Default | Purpose |
|----------|---------|---------|
| `DATABASE_URL` | (required) | CockroachDB connection string |
| `GRPC_PORT` | 50060 | gRPC server port |
| `METRICS_PORT` | 9090 | HTTP metrics/health port |
| `KAFKA_BROKERS` | - | Kafka broker addresses |
| `REDIS_URL` | - | Redis URL |
| `POSITION_KEEPING_URL` | - | Upstream service URL |
| `FINANCIAL_ACCOUNTING_URL` | - | Upstream service URL |
| `CURRENT_ACCOUNT_URL` | - | Upstream service URL |
| `REFERENCE_DATA_URL` | - | Upstream service URL |
| `PAYMENT_ORDER_URL` | - | Upstream service URL |
| `SETTLEMENT_SCHEDULER_ENABLED` | false | Enable settlement scheduler |

## Test plan

- [x] `go build ./services/reconciliation/cmd/` compiles successfully
- [x] `go test ./services/reconciliation/config/` - 9/9 tests pass
- [x] `go vet ./services/reconciliation/...` - no issues
- [x] Pre-commit hooks (markdownlint, gofumpt, golangci-lint) all pass