### PR TITLE
feat: add reconciliation domain model and migrations

### DIFF
--- a/services/reconciliation/domain/assertion_status.go
+++ b/services/reconciliation/domain/assertion_status.go
@@ -28,17 +28,14 @@ func (s AssertionStatus) String() string {
 
 // IsFinal checks if the status is a terminal state.
 func (s AssertionStatus) IsFinal() bool {
-	return s == AssertionStatusPassed || s == AssertionStatusFailed || s == AssertionStatusOverride
+	return s == AssertionStatusPassed || s == AssertionStatusOverride
 }
 
 // CanTransitionTo checks if a transition to the target status is valid.
 func (s AssertionStatus) CanTransitionTo(target AssertionStatus) bool {
-	if s.IsFinal() {
-		return false
-	}
-
 	validTransitions := map[AssertionStatus][]AssertionStatus{
 		AssertionStatusPending: {AssertionStatusPassed, AssertionStatusFailed},
+		AssertionStatusFailed:  {AssertionStatusOverride},
 	}
 
 	allowed, exists := validTransitions[s]

--- a/services/reconciliation/domain/assertion_status.go
+++ b/services/reconciliation/domain/assertion_status.go
@@ -1,0 +1,65 @@
+package domain
+
+// AssertionStatus represents the result of a balance assertion check.
+type AssertionStatus string
+
+// Supported assertion statuses.
+const (
+	AssertionStatusPending  AssertionStatus = "PENDING"
+	AssertionStatusPassed   AssertionStatus = "PASSED"
+	AssertionStatusFailed   AssertionStatus = "FAILED"
+	AssertionStatusOverride AssertionStatus = "OVERRIDE"
+)
+
+// IsValid checks if the assertion status is a recognized value.
+func (s AssertionStatus) IsValid() bool {
+	switch s {
+	case AssertionStatusPending, AssertionStatusPassed,
+		AssertionStatusFailed, AssertionStatusOverride:
+		return true
+	}
+	return false
+}
+
+// String returns the string representation.
+func (s AssertionStatus) String() string {
+	return string(s)
+}
+
+// IsFinal checks if the status is a terminal state.
+func (s AssertionStatus) IsFinal() bool {
+	return s == AssertionStatusPassed || s == AssertionStatusFailed || s == AssertionStatusOverride
+}
+
+// CanTransitionTo checks if a transition to the target status is valid.
+func (s AssertionStatus) CanTransitionTo(target AssertionStatus) bool {
+	if s.IsFinal() {
+		return false
+	}
+
+	validTransitions := map[AssertionStatus][]AssertionStatus{
+		AssertionStatusPending: {AssertionStatusPassed, AssertionStatusFailed},
+	}
+
+	allowed, exists := validTransitions[s]
+	if !exists {
+		return false
+	}
+
+	for _, a := range allowed {
+		if target == a {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseAssertionStatus converts a string to AssertionStatus.
+// Returns AssertionStatusPending for unrecognized values.
+func ParseAssertionStatus(s string) AssertionStatus {
+	status := AssertionStatus(s)
+	if status.IsValid() {
+		return status
+	}
+	return AssertionStatusPending
+}

--- a/services/reconciliation/domain/assertion_status_test.go
+++ b/services/reconciliation/domain/assertion_status_test.go
@@ -33,7 +33,7 @@ func TestAssertionStatus_IsFinal(t *testing.T) {
 	}{
 		{"pending not final", AssertionStatusPending, false},
 		{"passed is final", AssertionStatusPassed, true},
-		{"failed is final", AssertionStatusFailed, true},
+		{"failed not final", AssertionStatusFailed, false},
 		{"override is final", AssertionStatusOverride, true},
 	}
 
@@ -58,9 +58,12 @@ func TestAssertionStatus_CanTransitionTo(t *testing.T) {
 		{"pending to failed", AssertionStatusPending, AssertionStatusFailed, true},
 		{"pending to override not allowed", AssertionStatusPending, AssertionStatusOverride, false},
 
+		// From FAILED
+		{"failed to override", AssertionStatusFailed, AssertionStatusOverride, true},
+		{"failed to passed not allowed", AssertionStatusFailed, AssertionStatusPassed, false},
+
 		// Final states
 		{"passed cannot transition", AssertionStatusPassed, AssertionStatusPending, false},
-		{"failed cannot transition", AssertionStatusFailed, AssertionStatusPending, false},
 		{"override cannot transition", AssertionStatusOverride, AssertionStatusPending, false},
 	}
 

--- a/services/reconciliation/domain/assertion_status_test.go
+++ b/services/reconciliation/domain/assertion_status_test.go
@@ -1,0 +1,98 @@
+package domain
+
+import "testing"
+
+func TestAssertionStatus_IsValid(t *testing.T) {
+	tests := []struct {
+		name   string
+		status AssertionStatus
+		want   bool
+	}{
+		{"valid pending", AssertionStatusPending, true},
+		{"valid passed", AssertionStatusPassed, true},
+		{"valid failed", AssertionStatusFailed, true},
+		{"valid override", AssertionStatusOverride, true},
+		{"invalid status", AssertionStatus("INVALID"), false},
+		{"empty status", AssertionStatus(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.IsValid(); got != tt.want {
+				t.Errorf("AssertionStatus.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAssertionStatus_IsFinal(t *testing.T) {
+	tests := []struct {
+		name   string
+		status AssertionStatus
+		want   bool
+	}{
+		{"pending not final", AssertionStatusPending, false},
+		{"passed is final", AssertionStatusPassed, true},
+		{"failed is final", AssertionStatusFailed, true},
+		{"override is final", AssertionStatusOverride, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.IsFinal(); got != tt.want {
+				t.Errorf("AssertionStatus.IsFinal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAssertionStatus_CanTransitionTo(t *testing.T) {
+	tests := []struct {
+		name    string
+		current AssertionStatus
+		target  AssertionStatus
+		want    bool
+	}{
+		// From PENDING
+		{"pending to passed", AssertionStatusPending, AssertionStatusPassed, true},
+		{"pending to failed", AssertionStatusPending, AssertionStatusFailed, true},
+		{"pending to override not allowed", AssertionStatusPending, AssertionStatusOverride, false},
+
+		// Final states
+		{"passed cannot transition", AssertionStatusPassed, AssertionStatusPending, false},
+		{"failed cannot transition", AssertionStatusFailed, AssertionStatusPending, false},
+		{"override cannot transition", AssertionStatusOverride, AssertionStatusPending, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.current.CanTransitionTo(tt.target); got != tt.want {
+				t.Errorf("AssertionStatus(%s).CanTransitionTo(%s) = %v, want %v",
+					tt.current, tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseAssertionStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected AssertionStatus
+	}{
+		{"valid pending", "PENDING", AssertionStatusPending},
+		{"valid passed", "PASSED", AssertionStatusPassed},
+		{"valid failed", "FAILED", AssertionStatusFailed},
+		{"valid override", "OVERRIDE", AssertionStatusOverride},
+		{"invalid defaults to pending", "INVALID", AssertionStatusPending},
+		{"empty defaults to pending", "", AssertionStatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseAssertionStatus(tt.input); got != tt.expected {
+				t.Errorf("ParseAssertionStatus(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/services/reconciliation/domain/balance_assertion.go
+++ b/services/reconciliation/domain/balance_assertion.go
@@ -75,7 +75,6 @@ func NewBalanceAssertion(
 		Expression:      expression,
 		ExpectedBalance: expectedBalance,
 		Status:          AssertionStatusPending,
-		AssertedAt:      now,
 		CreatedAt:       now,
 	}, nil
 }
@@ -87,6 +86,7 @@ func (a *BalanceAssertion) Pass(actualBalance decimal.Decimal) error {
 	}
 	a.Status = AssertionStatusPassed
 	a.ActualBalance = actualBalance
+	a.AssertedAt = time.Now().UTC()
 	return nil
 }
 
@@ -97,6 +97,17 @@ func (a *BalanceAssertion) Fail(actualBalance decimal.Decimal, reason string) er
 	}
 	a.Status = AssertionStatusFailed
 	a.ActualBalance = actualBalance
+	a.FailureReason = reason
+	a.AssertedAt = time.Now().UTC()
+	return nil
+}
+
+// Override marks a failed assertion as overridden by an operator.
+func (a *BalanceAssertion) Override(reason string) error {
+	if !a.Status.CanTransitionTo(AssertionStatusOverride) {
+		return ErrInvalidStatusTransition
+	}
+	a.Status = AssertionStatusOverride
 	a.FailureReason = reason
 	return nil
 }

--- a/services/reconciliation/domain/balance_assertion.go
+++ b/services/reconciliation/domain/balance_assertion.go
@@ -1,0 +1,102 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// BalanceAssertion is a Business Query (BQ) entity that represents a
+// cross-account balance assertion check. It verifies that the sum of
+// balances across a set of accounts equals an expected value.
+type BalanceAssertion struct {
+	// AssertionID is the unique identifier for this assertion.
+	AssertionID uuid.UUID
+
+	// RunID references the settlement run (optional, can be standalone).
+	RunID *uuid.UUID
+
+	// AccountID identifies the primary account being asserted.
+	AccountID string
+
+	// InstrumentCode identifies the asset type being asserted.
+	InstrumentCode string
+
+	// Expression is the assertion rule (e.g., a CEL expression).
+	Expression string
+
+	// ExpectedBalance is the expected balance value.
+	ExpectedBalance decimal.Decimal
+
+	// ActualBalance is the computed actual balance.
+	ActualBalance decimal.Decimal
+
+	// Status is the assertion result.
+	Status AssertionStatus
+
+	// FailureReason records why the assertion failed (if applicable).
+	FailureReason string
+
+	// Attributes stores flexible metadata.
+	Attributes map[string]string
+
+	// AssertedAt is when the assertion was evaluated.
+	AssertedAt time.Time
+
+	// CreatedAt is when this record was created.
+	CreatedAt time.Time
+}
+
+// NewBalanceAssertion creates a new BalanceAssertion with validation.
+func NewBalanceAssertion(
+	runID *uuid.UUID,
+	accountID string,
+	instrumentCode string,
+	expression string,
+	expectedBalance decimal.Decimal,
+) (*BalanceAssertion, error) {
+	if accountID == "" {
+		return nil, ErrEmptyAccountID
+	}
+	if instrumentCode == "" {
+		return nil, ErrEmptyInstrumentCode
+	}
+	if expression == "" {
+		return nil, ErrEmptyAssertionExpression
+	}
+
+	now := time.Now().UTC()
+	return &BalanceAssertion{
+		AssertionID:     uuid.New(),
+		RunID:           runID,
+		AccountID:       accountID,
+		InstrumentCode:  instrumentCode,
+		Expression:      expression,
+		ExpectedBalance: expectedBalance,
+		Status:          AssertionStatusPending,
+		AssertedAt:      now,
+		CreatedAt:       now,
+	}, nil
+}
+
+// Pass marks the assertion as passed with the actual balance.
+func (a *BalanceAssertion) Pass(actualBalance decimal.Decimal) error {
+	if !a.Status.CanTransitionTo(AssertionStatusPassed) {
+		return ErrInvalidStatusTransition
+	}
+	a.Status = AssertionStatusPassed
+	a.ActualBalance = actualBalance
+	return nil
+}
+
+// Fail marks the assertion as failed with the actual balance and reason.
+func (a *BalanceAssertion) Fail(actualBalance decimal.Decimal, reason string) error {
+	if !a.Status.CanTransitionTo(AssertionStatusFailed) {
+		return ErrInvalidStatusTransition
+	}
+	a.Status = AssertionStatusFailed
+	a.ActualBalance = actualBalance
+	a.FailureReason = reason
+	return nil
+}

--- a/services/reconciliation/domain/balance_assertion.go
+++ b/services/reconciliation/domain/balance_assertion.go
@@ -38,6 +38,9 @@ type BalanceAssertion struct {
 	// FailureReason records why the assertion failed (if applicable).
 	FailureReason string
 
+	// OverrideReason records why a failed assertion was overridden.
+	OverrideReason string
+
 	// Attributes stores flexible metadata.
 	Attributes map[string]string
 
@@ -103,11 +106,13 @@ func (a *BalanceAssertion) Fail(actualBalance decimal.Decimal, reason string) er
 }
 
 // Override marks a failed assertion as overridden by an operator.
+// The original FailureReason is preserved; the override justification
+// is stored in OverrideReason.
 func (a *BalanceAssertion) Override(reason string) error {
 	if !a.Status.CanTransitionTo(AssertionStatusOverride) {
 		return ErrInvalidStatusTransition
 	}
 	a.Status = AssertionStatusOverride
-	a.FailureReason = reason
+	a.OverrideReason = reason
 	return nil
 }

--- a/services/reconciliation/domain/balance_assertion_test.go
+++ b/services/reconciliation/domain/balance_assertion_test.go
@@ -90,36 +90,54 @@ func TestNewBalanceAssertion(t *testing.T) {
 				assert.Equal(t, tt.instrumentCode, a.InstrumentCode)
 				assert.Equal(t, tt.expression, a.Expression)
 				assert.Equal(t, domain.AssertionStatusPending, a.Status)
+				assert.True(t, a.AssertedAt.IsZero(), "AssertedAt should be zero until evaluation")
 			}
 		})
 	}
 }
 
 func TestBalanceAssertion_Pass(t *testing.T) {
-	runID := uuid.New()
-	a, err := domain.NewBalanceAssertion(
-		&runID, "ACC-001", "GBP",
-		"balance == 10000", decimal.NewFromFloat(10000.00),
-	)
-	require.NoError(t, err)
+	a := newTestAssertion(t)
 
 	require.NoError(t, a.Pass(decimal.NewFromFloat(10000.00)))
 	assert.Equal(t, domain.AssertionStatusPassed, a.Status)
 	assert.True(t, decimal.NewFromFloat(10000.00).Equal(a.ActualBalance))
+	assert.False(t, a.AssertedAt.IsZero(), "AssertedAt should be set after Pass")
 }
 
 func TestBalanceAssertion_Fail(t *testing.T) {
-	runID := uuid.New()
-	a, err := domain.NewBalanceAssertion(
-		&runID, "ACC-001", "GBP",
-		"balance == 10000", decimal.NewFromFloat(10000.00),
-	)
-	require.NoError(t, err)
+	a := newTestAssertion(t)
 
 	require.NoError(t, a.Fail(decimal.NewFromFloat(9500.00), "Balance mismatch: expected 10000, got 9500"))
 	assert.Equal(t, domain.AssertionStatusFailed, a.Status)
 	assert.True(t, decimal.NewFromFloat(9500.00).Equal(a.ActualBalance))
 	assert.Equal(t, "Balance mismatch: expected 10000, got 9500", a.FailureReason)
+	assert.False(t, a.AssertedAt.IsZero(), "AssertedAt should be set after Fail")
+}
+
+func TestBalanceAssertion_Override(t *testing.T) {
+	a := newTestAssertion(t)
+
+	require.NoError(t, a.Fail(decimal.NewFromFloat(9500.00), "mismatch"))
+	require.NoError(t, a.Override("approved by manager"))
+
+	assert.Equal(t, domain.AssertionStatusOverride, a.Status)
+	assert.Equal(t, "approved by manager", a.FailureReason)
+}
+
+func TestBalanceAssertion_OverrideFromNonFailed(t *testing.T) {
+	t.Run("cannot override from pending", func(t *testing.T) {
+		a := newTestAssertion(t)
+		err := a.Override("reason")
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot override from passed", func(t *testing.T) {
+		a := newTestAssertion(t)
+		require.NoError(t, a.Pass(decimal.NewFromFloat(10000.00)))
+		err := a.Override("reason")
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
 }
 
 func TestBalanceAssertion_InvalidTransitions(t *testing.T) {

--- a/services/reconciliation/domain/balance_assertion_test.go
+++ b/services/reconciliation/domain/balance_assertion_test.go
@@ -1,0 +1,157 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBalanceAssertion(t *testing.T) {
+	runID := uuid.New()
+
+	tests := []struct {
+		name           string
+		runID          *uuid.UUID
+		accountID      string
+		instrumentCode string
+		expression     string
+		expected       decimal.Decimal
+		wantErr        error
+	}{
+		{
+			name:           "valid assertion with run",
+			runID:          &runID,
+			accountID:      "ACC-001",
+			instrumentCode: "GBP",
+			expression:     "sum(positions) == expected",
+			expected:       decimal.NewFromFloat(10000.00),
+			wantErr:        nil,
+		},
+		{
+			name:           "valid standalone assertion",
+			runID:          nil,
+			accountID:      "ACC-001",
+			instrumentCode: "GBP",
+			expression:     "total_debits == total_credits",
+			expected:       decimal.Zero,
+			wantErr:        nil,
+		},
+		{
+			name:           "empty account ID",
+			runID:          &runID,
+			accountID:      "",
+			instrumentCode: "GBP",
+			expression:     "expr",
+			expected:       decimal.Zero,
+			wantErr:        domain.ErrEmptyAccountID,
+		},
+		{
+			name:           "empty instrument code",
+			runID:          &runID,
+			accountID:      "ACC-001",
+			instrumentCode: "",
+			expression:     "expr",
+			expected:       decimal.Zero,
+			wantErr:        domain.ErrEmptyInstrumentCode,
+		},
+		{
+			name:           "empty expression",
+			runID:          &runID,
+			accountID:      "ACC-001",
+			instrumentCode: "GBP",
+			expression:     "",
+			expected:       decimal.Zero,
+			wantErr:        domain.ErrEmptyAssertionExpression,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := domain.NewBalanceAssertion(
+				tt.runID, tt.accountID, tt.instrumentCode,
+				tt.expression, tt.expected,
+			)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, a)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, a)
+
+				assert.NotEqual(t, uuid.Nil, a.AssertionID)
+				assert.Equal(t, tt.runID, a.RunID)
+				assert.Equal(t, tt.accountID, a.AccountID)
+				assert.Equal(t, tt.instrumentCode, a.InstrumentCode)
+				assert.Equal(t, tt.expression, a.Expression)
+				assert.Equal(t, domain.AssertionStatusPending, a.Status)
+			}
+		})
+	}
+}
+
+func TestBalanceAssertion_Pass(t *testing.T) {
+	runID := uuid.New()
+	a, err := domain.NewBalanceAssertion(
+		&runID, "ACC-001", "GBP",
+		"balance == 10000", decimal.NewFromFloat(10000.00),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, a.Pass(decimal.NewFromFloat(10000.00)))
+	assert.Equal(t, domain.AssertionStatusPassed, a.Status)
+	assert.True(t, decimal.NewFromFloat(10000.00).Equal(a.ActualBalance))
+}
+
+func TestBalanceAssertion_Fail(t *testing.T) {
+	runID := uuid.New()
+	a, err := domain.NewBalanceAssertion(
+		&runID, "ACC-001", "GBP",
+		"balance == 10000", decimal.NewFromFloat(10000.00),
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, a.Fail(decimal.NewFromFloat(9500.00), "Balance mismatch: expected 10000, got 9500"))
+	assert.Equal(t, domain.AssertionStatusFailed, a.Status)
+	assert.True(t, decimal.NewFromFloat(9500.00).Equal(a.ActualBalance))
+	assert.Equal(t, "Balance mismatch: expected 10000, got 9500", a.FailureReason)
+}
+
+func TestBalanceAssertion_InvalidTransitions(t *testing.T) {
+	t.Run("cannot pass from passed", func(t *testing.T) {
+		a := newTestAssertion(t)
+		require.NoError(t, a.Pass(decimal.NewFromFloat(10000.00)))
+		err := a.Pass(decimal.NewFromFloat(10000.00))
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot fail from failed", func(t *testing.T) {
+		a := newTestAssertion(t)
+		require.NoError(t, a.Fail(decimal.NewFromFloat(9500.00), "mismatch"))
+		err := a.Fail(decimal.NewFromFloat(9500.00), "mismatch")
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot pass from failed", func(t *testing.T) {
+		a := newTestAssertion(t)
+		require.NoError(t, a.Fail(decimal.NewFromFloat(9500.00), "mismatch"))
+		err := a.Pass(decimal.NewFromFloat(10000.00))
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+}
+
+func newTestAssertion(t *testing.T) *domain.BalanceAssertion {
+	t.Helper()
+	runID := uuid.New()
+	a, err := domain.NewBalanceAssertion(
+		&runID, "ACC-001", "GBP",
+		"balance == 10000", decimal.NewFromFloat(10000.00),
+	)
+	require.NoError(t, err)
+	return a
+}

--- a/services/reconciliation/domain/balance_assertion_test.go
+++ b/services/reconciliation/domain/balance_assertion_test.go
@@ -122,7 +122,8 @@ func TestBalanceAssertion_Override(t *testing.T) {
 	require.NoError(t, a.Override("approved by manager"))
 
 	assert.Equal(t, domain.AssertionStatusOverride, a.Status)
-	assert.Equal(t, "approved by manager", a.FailureReason)
+	assert.Equal(t, "mismatch", a.FailureReason, "original failure reason should be preserved")
+	assert.Equal(t, "approved by manager", a.OverrideReason)
 }
 
 func TestBalanceAssertion_OverrideFromNonFailed(t *testing.T) {

--- a/services/reconciliation/domain/dispute.go
+++ b/services/reconciliation/domain/dispute.go
@@ -1,0 +1,130 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Dispute is a Business Query (BQ) entity representing a formal dispute
+// raised against a detected variance.
+type Dispute struct {
+	// DisputeID is the unique identifier for this dispute.
+	DisputeID uuid.UUID
+
+	// VarianceID references the variance being disputed.
+	VarianceID uuid.UUID
+
+	// RunID references the settlement run.
+	RunID uuid.UUID
+
+	// AccountID identifies the account.
+	AccountID string
+
+	// Status is the current state of the dispute.
+	Status DisputeStatus
+
+	// Reason describes why the variance is being disputed.
+	Reason string
+
+	// Resolution records how the dispute was resolved.
+	Resolution string
+
+	// RaisedBy records who raised the dispute.
+	RaisedBy string
+
+	// ResolvedBy records who resolved the dispute.
+	ResolvedBy string
+
+	// ResolvedAt records when the dispute was resolved.
+	ResolvedAt *time.Time
+
+	// Attributes stores flexible metadata.
+	Attributes map[string]string
+
+	// CreatedAt is when this record was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is when this record was last updated.
+	UpdatedAt time.Time
+}
+
+// NewDispute creates a new Dispute with validation.
+func NewDispute(
+	varianceID uuid.UUID,
+	runID uuid.UUID,
+	accountID string,
+	reason string,
+	raisedBy string,
+) (*Dispute, error) {
+	if varianceID == uuid.Nil {
+		return nil, ErrEmptyVarianceID
+	}
+	if accountID == "" {
+		return nil, ErrEmptyAccountID
+	}
+	if reason == "" {
+		return nil, ErrEmptyDisputeReason
+	}
+
+	now := time.Now().UTC()
+	return &Dispute{
+		DisputeID:  uuid.New(),
+		VarianceID: varianceID,
+		RunID:      runID,
+		AccountID:  accountID,
+		Status:     DisputeStatusOpen,
+		Reason:     reason,
+		RaisedBy:   raisedBy,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}, nil
+}
+
+// Review transitions the dispute to UNDER_REVIEW.
+func (d *Dispute) Review() error {
+	if !d.Status.CanTransitionTo(DisputeStatusUnderReview) {
+		return ErrInvalidStatusTransition
+	}
+	d.Status = DisputeStatusUnderReview
+	d.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+// Escalate transitions the dispute to ESCALATED.
+func (d *Dispute) Escalate() error {
+	if !d.Status.CanTransitionTo(DisputeStatusEscalated) {
+		return ErrInvalidStatusTransition
+	}
+	d.Status = DisputeStatusEscalated
+	d.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+// Resolve transitions the dispute to RESOLVED.
+func (d *Dispute) Resolve(resolution string, resolvedBy string) error {
+	if !d.Status.CanTransitionTo(DisputeStatusResolved) {
+		return ErrInvalidStatusTransition
+	}
+	now := time.Now().UTC()
+	d.Status = DisputeStatusResolved
+	d.Resolution = resolution
+	d.ResolvedBy = resolvedBy
+	d.ResolvedAt = &now
+	d.UpdatedAt = now
+	return nil
+}
+
+// Reject transitions the dispute to REJECTED.
+func (d *Dispute) Reject(resolution string, rejectedBy string) error {
+	if !d.Status.CanTransitionTo(DisputeStatusRejected) {
+		return ErrInvalidStatusTransition
+	}
+	now := time.Now().UTC()
+	d.Status = DisputeStatusRejected
+	d.Resolution = resolution
+	d.ResolvedBy = rejectedBy
+	d.ResolvedAt = &now
+	d.UpdatedAt = now
+	return nil
+}

--- a/services/reconciliation/domain/dispute_status.go
+++ b/services/reconciliation/domain/dispute_status.go
@@ -1,0 +1,69 @@
+package domain
+
+// DisputeStatus represents the state of a formal dispute.
+type DisputeStatus string
+
+// Supported dispute statuses.
+const (
+	DisputeStatusOpen        DisputeStatus = "OPEN"
+	DisputeStatusUnderReview DisputeStatus = "UNDER_REVIEW"
+	DisputeStatusEscalated   DisputeStatus = "ESCALATED"
+	DisputeStatusResolved    DisputeStatus = "RESOLVED"
+	DisputeStatusRejected    DisputeStatus = "REJECTED"
+)
+
+// IsValid checks if the dispute status is a recognized value.
+func (s DisputeStatus) IsValid() bool {
+	switch s {
+	case DisputeStatusOpen, DisputeStatusUnderReview,
+		DisputeStatusEscalated, DisputeStatusResolved,
+		DisputeStatusRejected:
+		return true
+	}
+	return false
+}
+
+// String returns the string representation.
+func (s DisputeStatus) String() string {
+	return string(s)
+}
+
+// IsFinal checks if the status is a terminal state.
+func (s DisputeStatus) IsFinal() bool {
+	return s == DisputeStatusResolved || s == DisputeStatusRejected
+}
+
+// CanTransitionTo checks if a transition to the target status is valid.
+func (s DisputeStatus) CanTransitionTo(target DisputeStatus) bool {
+	if s.IsFinal() {
+		return false
+	}
+
+	validTransitions := map[DisputeStatus][]DisputeStatus{
+		DisputeStatusOpen:        {DisputeStatusUnderReview, DisputeStatusResolved, DisputeStatusRejected},
+		DisputeStatusUnderReview: {DisputeStatusEscalated, DisputeStatusResolved, DisputeStatusRejected},
+		DisputeStatusEscalated:   {DisputeStatusUnderReview, DisputeStatusResolved, DisputeStatusRejected},
+	}
+
+	allowed, exists := validTransitions[s]
+	if !exists {
+		return false
+	}
+
+	for _, a := range allowed {
+		if target == a {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseDisputeStatus converts a string to DisputeStatus.
+// Returns DisputeStatusOpen for unrecognized values.
+func ParseDisputeStatus(s string) DisputeStatus {
+	status := DisputeStatus(s)
+	if status.IsValid() {
+		return status
+	}
+	return DisputeStatusOpen
+}

--- a/services/reconciliation/domain/dispute_status_test.go
+++ b/services/reconciliation/domain/dispute_status_test.go
@@ -1,0 +1,113 @@
+package domain
+
+import "testing"
+
+func TestDisputeStatus_IsValid(t *testing.T) {
+	tests := []struct {
+		name   string
+		status DisputeStatus
+		want   bool
+	}{
+		{"valid open", DisputeStatusOpen, true},
+		{"valid under review", DisputeStatusUnderReview, true},
+		{"valid escalated", DisputeStatusEscalated, true},
+		{"valid resolved", DisputeStatusResolved, true},
+		{"valid rejected", DisputeStatusRejected, true},
+		{"invalid status", DisputeStatus("INVALID"), false},
+		{"empty status", DisputeStatus(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.IsValid(); got != tt.want {
+				t.Errorf("DisputeStatus.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDisputeStatus_IsFinal(t *testing.T) {
+	tests := []struct {
+		name   string
+		status DisputeStatus
+		want   bool
+	}{
+		{"open not final", DisputeStatusOpen, false},
+		{"under review not final", DisputeStatusUnderReview, false},
+		{"escalated not final", DisputeStatusEscalated, false},
+		{"resolved is final", DisputeStatusResolved, true},
+		{"rejected is final", DisputeStatusRejected, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.IsFinal(); got != tt.want {
+				t.Errorf("DisputeStatus.IsFinal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDisputeStatus_CanTransitionTo(t *testing.T) {
+	tests := []struct {
+		name    string
+		current DisputeStatus
+		target  DisputeStatus
+		want    bool
+	}{
+		// From OPEN
+		{"open to under review", DisputeStatusOpen, DisputeStatusUnderReview, true},
+		{"open to resolved", DisputeStatusOpen, DisputeStatusResolved, true},
+		{"open to rejected", DisputeStatusOpen, DisputeStatusRejected, true},
+		{"open to escalated", DisputeStatusOpen, DisputeStatusEscalated, false},
+
+		// From UNDER_REVIEW
+		{"under review to escalated", DisputeStatusUnderReview, DisputeStatusEscalated, true},
+		{"under review to resolved", DisputeStatusUnderReview, DisputeStatusResolved, true},
+		{"under review to rejected", DisputeStatusUnderReview, DisputeStatusRejected, true},
+		{"under review to open", DisputeStatusUnderReview, DisputeStatusOpen, false},
+
+		// From ESCALATED
+		{"escalated to under review", DisputeStatusEscalated, DisputeStatusUnderReview, true},
+		{"escalated to resolved", DisputeStatusEscalated, DisputeStatusResolved, true},
+		{"escalated to rejected", DisputeStatusEscalated, DisputeStatusRejected, true},
+		{"escalated to open", DisputeStatusEscalated, DisputeStatusOpen, false},
+
+		// Final states
+		{"resolved cannot transition", DisputeStatusResolved, DisputeStatusOpen, false},
+		{"rejected cannot transition", DisputeStatusRejected, DisputeStatusOpen, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.current.CanTransitionTo(tt.target); got != tt.want {
+				t.Errorf("DisputeStatus(%s).CanTransitionTo(%s) = %v, want %v",
+					tt.current, tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseDisputeStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected DisputeStatus
+	}{
+		{"valid open", "OPEN", DisputeStatusOpen},
+		{"valid under review", "UNDER_REVIEW", DisputeStatusUnderReview},
+		{"valid escalated", "ESCALATED", DisputeStatusEscalated},
+		{"valid resolved", "RESOLVED", DisputeStatusResolved},
+		{"valid rejected", "REJECTED", DisputeStatusRejected},
+		{"invalid defaults to open", "INVALID", DisputeStatusOpen},
+		{"empty defaults to open", "", DisputeStatusOpen},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseDisputeStatus(tt.input); got != tt.expected {
+				t.Errorf("ParseDisputeStatus(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/services/reconciliation/domain/dispute_test.go
+++ b/services/reconciliation/domain/dispute_test.go
@@ -1,0 +1,151 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDispute(t *testing.T) {
+	varianceID := uuid.New()
+	runID := uuid.New()
+
+	tests := []struct {
+		name       string
+		varianceID uuid.UUID
+		runID      uuid.UUID
+		accountID  string
+		reason     string
+		raisedBy   string
+		wantErr    error
+	}{
+		{
+			name:       "valid dispute",
+			varianceID: varianceID,
+			runID:      runID,
+			accountID:  "ACC-001",
+			reason:     "Amount seems incorrect",
+			raisedBy:   "user-1",
+			wantErr:    nil,
+		},
+		{
+			name:       "nil variance ID",
+			varianceID: uuid.Nil,
+			runID:      runID,
+			accountID:  "ACC-001",
+			reason:     "Reason",
+			raisedBy:   "user-1",
+			wantErr:    domain.ErrEmptyVarianceID,
+		},
+		{
+			name:       "empty account ID",
+			varianceID: varianceID,
+			runID:      runID,
+			accountID:  "",
+			reason:     "Reason",
+			raisedBy:   "user-1",
+			wantErr:    domain.ErrEmptyAccountID,
+		},
+		{
+			name:       "empty reason",
+			varianceID: varianceID,
+			runID:      runID,
+			accountID:  "ACC-001",
+			reason:     "",
+			raisedBy:   "user-1",
+			wantErr:    domain.ErrEmptyDisputeReason,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := domain.NewDispute(
+				tt.varianceID, tt.runID, tt.accountID, tt.reason, tt.raisedBy,
+			)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, d)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, d)
+
+				assert.NotEqual(t, uuid.Nil, d.DisputeID)
+				assert.Equal(t, tt.varianceID, d.VarianceID)
+				assert.Equal(t, tt.runID, d.RunID)
+				assert.Equal(t, tt.accountID, d.AccountID)
+				assert.Equal(t, domain.DisputeStatusOpen, d.Status)
+				assert.Equal(t, tt.reason, d.Reason)
+				assert.Equal(t, tt.raisedBy, d.RaisedBy)
+				assert.Nil(t, d.ResolvedAt)
+			}
+		})
+	}
+}
+
+func TestDispute_Lifecycle(t *testing.T) {
+	d := newTestDispute(t)
+
+	// Review
+	require.NoError(t, d.Review())
+	assert.Equal(t, domain.DisputeStatusUnderReview, d.Status)
+
+	// Escalate
+	require.NoError(t, d.Escalate())
+	assert.Equal(t, domain.DisputeStatusEscalated, d.Status)
+
+	// Resolve
+	require.NoError(t, d.Resolve("Adjustment posted", "admin"))
+	assert.Equal(t, domain.DisputeStatusResolved, d.Status)
+	assert.Equal(t, "Adjustment posted", d.Resolution)
+	assert.Equal(t, "admin", d.ResolvedBy)
+	assert.NotNil(t, d.ResolvedAt)
+}
+
+func TestDispute_RejectLifecycle(t *testing.T) {
+	d := newTestDispute(t)
+
+	require.NoError(t, d.Review())
+	require.NoError(t, d.Reject("No evidence of error", "reviewer"))
+
+	assert.Equal(t, domain.DisputeStatusRejected, d.Status)
+	assert.Equal(t, "No evidence of error", d.Resolution)
+	assert.Equal(t, "reviewer", d.ResolvedBy)
+	assert.NotNil(t, d.ResolvedAt)
+}
+
+func TestDispute_InvalidTransitions(t *testing.T) {
+	t.Run("cannot escalate from open", func(t *testing.T) {
+		d := newTestDispute(t)
+		err := d.Escalate()
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot review from resolved", func(t *testing.T) {
+		d := newTestDispute(t)
+		require.NoError(t, d.Resolve("done", "admin"))
+		err := d.Review()
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot escalate from rejected", func(t *testing.T) {
+		d := newTestDispute(t)
+		require.NoError(t, d.Reject("rejected", "admin"))
+		err := d.Escalate()
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+}
+
+func newTestDispute(t *testing.T) *domain.Dispute {
+	t.Helper()
+	d, err := domain.NewDispute(
+		uuid.New(), uuid.New(), "ACC-001",
+		"Amount discrepancy noted", "user-1",
+	)
+	require.NoError(t, err)
+	return d
+}

--- a/services/reconciliation/domain/doc.go
+++ b/services/reconciliation/domain/doc.go
@@ -1,0 +1,4 @@
+// Package domain contains core domain logic for the reconciliation service.
+// It defines the entities, value objects, and repository interfaces for
+// settlement runs, snapshots, variances, disputes, and balance assertions.
+package domain

--- a/services/reconciliation/domain/errors.go
+++ b/services/reconciliation/domain/errors.go
@@ -33,4 +33,6 @@ var (
 	ErrEmptyVarianceID = errors.New("variance ID is required")
 	// ErrEmptyAssertionExpression is returned when the assertion expression is missing.
 	ErrEmptyAssertionExpression = errors.New("assertion expression is required")
+	// ErrEmptyInitiatedBy is returned when initiated by is empty.
+	ErrEmptyInitiatedBy = errors.New("initiated by cannot be empty")
 )

--- a/services/reconciliation/domain/errors.go
+++ b/services/reconciliation/domain/errors.go
@@ -1,0 +1,36 @@
+package domain
+
+import "errors"
+
+var (
+	// ErrNotFound is returned when a domain entity is not found.
+	ErrNotFound = errors.New("entity not found")
+	// ErrConflict is returned when there's a conflict (e.g., duplicate ID).
+	ErrConflict = errors.New("entity conflict")
+	// ErrOptimisticLock is returned when optimistic locking fails.
+	ErrOptimisticLock = errors.New("optimistic lock failure: resource was modified")
+	// ErrInvalidStatusTransition is returned when an invalid status transition is attempted.
+	ErrInvalidStatusTransition = errors.New("invalid status transition")
+	// ErrEmptyAccountID is returned when account ID is empty.
+	ErrEmptyAccountID = errors.New("account ID cannot be empty")
+	// ErrEmptyInstrumentCode is returned when instrument code is empty.
+	ErrEmptyInstrumentCode = errors.New("instrument code cannot be empty")
+	// ErrInvalidPeriod is returned when the period start is after end.
+	ErrInvalidPeriod = errors.New("period start must be before period end")
+	// ErrEmptyScope is returned when reconciliation scope is missing.
+	ErrEmptyScope = errors.New("reconciliation scope is required")
+	// ErrEmptySettlementType is returned when settlement type is missing.
+	ErrEmptySettlementType = errors.New("settlement type is required")
+	// ErrRunNotRunning is returned when attempting to complete a run that is not running.
+	ErrRunNotRunning = errors.New("settlement run is not in running state")
+	// ErrEmptyVarianceReason is returned when variance reason is missing.
+	ErrEmptyVarianceReason = errors.New("variance reason is required")
+	// ErrNegativeAmount is returned when a monetary amount is negative where not allowed.
+	ErrNegativeAmount = errors.New("amount cannot be negative")
+	// ErrEmptyDisputeReason is returned when dispute reason is missing.
+	ErrEmptyDisputeReason = errors.New("dispute reason is required")
+	// ErrEmptyVarianceID is returned when variance ID is missing for a dispute.
+	ErrEmptyVarianceID = errors.New("variance ID is required")
+	// ErrEmptyAssertionExpression is returned when the assertion expression is missing.
+	ErrEmptyAssertionExpression = errors.New("assertion expression is required")
+)

--- a/services/reconciliation/domain/reconciliation_scope.go
+++ b/services/reconciliation/domain/reconciliation_scope.go
@@ -1,0 +1,37 @@
+package domain
+
+// ReconciliationScope defines what is being reconciled.
+type ReconciliationScope string
+
+// Supported reconciliation scopes.
+const (
+	ReconciliationScopeAccount    ReconciliationScope = "ACCOUNT"
+	ReconciliationScopeInstrument ReconciliationScope = "INSTRUMENT"
+	ReconciliationScopePortfolio  ReconciliationScope = "PORTFOLIO"
+	ReconciliationScopeFull       ReconciliationScope = "FULL"
+)
+
+// IsValid checks if the scope is a recognized value.
+func (s ReconciliationScope) IsValid() bool {
+	switch s {
+	case ReconciliationScopeAccount, ReconciliationScopeInstrument,
+		ReconciliationScopePortfolio, ReconciliationScopeFull:
+		return true
+	}
+	return false
+}
+
+// String returns the string representation.
+func (s ReconciliationScope) String() string {
+	return string(s)
+}
+
+// ParseReconciliationScope converts a string to ReconciliationScope.
+// Returns ReconciliationScopeAccount for unrecognized values.
+func ParseReconciliationScope(s string) ReconciliationScope {
+	scope := ReconciliationScope(s)
+	if scope.IsValid() {
+		return scope
+	}
+	return ReconciliationScopeAccount
+}

--- a/services/reconciliation/domain/reconciliation_scope_test.go
+++ b/services/reconciliation/domain/reconciliation_scope_test.go
@@ -1,0 +1,47 @@
+package domain
+
+import "testing"
+
+func TestReconciliationScope_IsValid(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope ReconciliationScope
+		want  bool
+	}{
+		{"valid account", ReconciliationScopeAccount, true},
+		{"valid instrument", ReconciliationScopeInstrument, true},
+		{"valid portfolio", ReconciliationScopePortfolio, true},
+		{"valid full", ReconciliationScopeFull, true},
+		{"invalid", ReconciliationScope("INVALID"), false},
+		{"empty", ReconciliationScope(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.scope.IsValid(); got != tt.want {
+				t.Errorf("ReconciliationScope.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseReconciliationScope(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected ReconciliationScope
+	}{
+		{"valid account", "ACCOUNT", ReconciliationScopeAccount},
+		{"valid full", "FULL", ReconciliationScopeFull},
+		{"invalid defaults to account", "INVALID", ReconciliationScopeAccount},
+		{"empty defaults to account", "", ReconciliationScopeAccount},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseReconciliationScope(tt.input); got != tt.expected {
+				t.Errorf("ParseReconciliationScope(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/services/reconciliation/domain/repository.go
+++ b/services/reconciliation/domain/repository.go
@@ -127,6 +127,10 @@ type BalanceAssertionRepository interface {
 	// FindByRunID retrieves all assertions for a settlement run.
 	FindByRunID(ctx context.Context, runID uuid.UUID) ([]*BalanceAssertion, error)
 
+	// Update updates an existing BalanceAssertion.
+	// Returns ErrNotFound if the assertion doesn't exist.
+	Update(ctx context.Context, assertion *BalanceAssertion) error
+
 	// List retrieves assertions matching the given filter.
 	List(ctx context.Context, filter AssertionFilter) ([]*BalanceAssertion, error)
 }

--- a/services/reconciliation/domain/repository.go
+++ b/services/reconciliation/domain/repository.go
@@ -1,0 +1,141 @@
+package domain
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SettlementRunRepository defines the contract for persisting and retrieving settlement runs.
+type SettlementRunRepository interface {
+	// Create persists a new SettlementRun.
+	// Returns ErrConflict if a run with the same RunID already exists.
+	Create(ctx context.Context, run *SettlementRun) error
+
+	// FindByID retrieves a SettlementRun by its RunID.
+	// Returns ErrNotFound if the run doesn't exist.
+	FindByID(ctx context.Context, runID uuid.UUID) (*SettlementRun, error)
+
+	// Update updates an existing SettlementRun using optimistic locking.
+	// Returns ErrNotFound if the run doesn't exist.
+	// Returns ErrOptimisticLock if the version doesn't match.
+	Update(ctx context.Context, run *SettlementRun) error
+
+	// List retrieves settlement runs matching the given filter with pagination.
+	List(ctx context.Context, filter RunFilter) ([]*SettlementRun, error)
+}
+
+// RunFilter defines filtering and pagination for settlement runs.
+type RunFilter struct {
+	AccountID *string
+	Status    *RunStatus
+	Scope     *ReconciliationScope
+	FromDate  *time.Time
+	ToDate    *time.Time
+	Limit     int
+	Offset    int
+}
+
+// SettlementSnapshotRepository defines the contract for persisting settlement snapshots.
+type SettlementSnapshotRepository interface {
+	// Create persists a new SettlementSnapshot.
+	Create(ctx context.Context, snapshot *SettlementSnapshot) error
+
+	// CreateBatch persists multiple snapshots atomically.
+	CreateBatch(ctx context.Context, snapshots []*SettlementSnapshot) error
+
+	// FindByID retrieves a SettlementSnapshot by its SnapshotID.
+	// Returns ErrNotFound if the snapshot doesn't exist.
+	FindByID(ctx context.Context, snapshotID uuid.UUID) (*SettlementSnapshot, error)
+
+	// FindByRunID retrieves all snapshots for a settlement run.
+	FindByRunID(ctx context.Context, runID uuid.UUID) ([]*SettlementSnapshot, error)
+}
+
+// VarianceRepository defines the contract for persisting and retrieving variances.
+type VarianceRepository interface {
+	// Create persists a new Variance.
+	Create(ctx context.Context, variance *Variance) error
+
+	// CreateBatch persists multiple variances atomically.
+	CreateBatch(ctx context.Context, variances []*Variance) error
+
+	// FindByID retrieves a Variance by its VarianceID.
+	// Returns ErrNotFound if the variance doesn't exist.
+	FindByID(ctx context.Context, varianceID uuid.UUID) (*Variance, error)
+
+	// FindByRunID retrieves all variances for a settlement run.
+	FindByRunID(ctx context.Context, runID uuid.UUID) ([]*Variance, error)
+
+	// Update updates an existing Variance.
+	// Returns ErrNotFound if the variance doesn't exist.
+	Update(ctx context.Context, variance *Variance) error
+
+	// List retrieves variances matching the given filter.
+	List(ctx context.Context, filter VarianceFilter) ([]*Variance, error)
+}
+
+// VarianceFilter defines filtering and pagination for variances.
+type VarianceFilter struct {
+	RunID     *uuid.UUID
+	AccountID *string
+	Status    *VarianceStatus
+	Reason    *VarianceReason
+	Limit     int
+	Offset    int
+}
+
+// DisputeRepository defines the contract for persisting and retrieving disputes.
+type DisputeRepository interface {
+	// Create persists a new Dispute.
+	Create(ctx context.Context, dispute *Dispute) error
+
+	// FindByID retrieves a Dispute by its DisputeID.
+	// Returns ErrNotFound if the dispute doesn't exist.
+	FindByID(ctx context.Context, disputeID uuid.UUID) (*Dispute, error)
+
+	// FindByVarianceID retrieves all disputes for a variance.
+	FindByVarianceID(ctx context.Context, varianceID uuid.UUID) ([]*Dispute, error)
+
+	// Update updates an existing Dispute.
+	// Returns ErrNotFound if the dispute doesn't exist.
+	Update(ctx context.Context, dispute *Dispute) error
+
+	// List retrieves disputes matching the given filter.
+	List(ctx context.Context, filter DisputeFilter) ([]*Dispute, error)
+}
+
+// DisputeFilter defines filtering and pagination for disputes.
+type DisputeFilter struct {
+	RunID     *uuid.UUID
+	AccountID *string
+	Status    *DisputeStatus
+	Limit     int
+	Offset    int
+}
+
+// BalanceAssertionRepository defines the contract for persisting balance assertions.
+type BalanceAssertionRepository interface {
+	// Create persists a new BalanceAssertion.
+	Create(ctx context.Context, assertion *BalanceAssertion) error
+
+	// FindByID retrieves a BalanceAssertion by its AssertionID.
+	// Returns ErrNotFound if the assertion doesn't exist.
+	FindByID(ctx context.Context, assertionID uuid.UUID) (*BalanceAssertion, error)
+
+	// FindByRunID retrieves all assertions for a settlement run.
+	FindByRunID(ctx context.Context, runID uuid.UUID) ([]*BalanceAssertion, error)
+
+	// List retrieves assertions matching the given filter.
+	List(ctx context.Context, filter AssertionFilter) ([]*BalanceAssertion, error)
+}
+
+// AssertionFilter defines filtering and pagination for balance assertions.
+type AssertionFilter struct {
+	RunID     *uuid.UUID
+	AccountID *string
+	Status    *AssertionStatus
+	Limit     int
+	Offset    int
+}

--- a/services/reconciliation/domain/run_status.go
+++ b/services/reconciliation/domain/run_status.go
@@ -1,0 +1,67 @@
+package domain
+
+// RunStatus represents the current state of a settlement run.
+type RunStatus string
+
+// Supported run statuses through the settlement run lifecycle.
+const (
+	RunStatusPending   RunStatus = "PENDING"
+	RunStatusRunning   RunStatus = "RUNNING"
+	RunStatusCompleted RunStatus = "COMPLETED"
+	RunStatusFailed    RunStatus = "FAILED"
+	RunStatusCancelled RunStatus = "CANCELLED"
+)
+
+// IsValid checks if the run status is a recognized value.
+func (s RunStatus) IsValid() bool {
+	switch s {
+	case RunStatusPending, RunStatusRunning, RunStatusCompleted,
+		RunStatusFailed, RunStatusCancelled:
+		return true
+	}
+	return false
+}
+
+// String returns the string representation.
+func (s RunStatus) String() string {
+	return string(s)
+}
+
+// IsFinal checks if the status is a terminal state.
+func (s RunStatus) IsFinal() bool {
+	return s == RunStatusCompleted || s == RunStatusFailed || s == RunStatusCancelled
+}
+
+// CanTransitionTo checks if a transition to the target status is valid.
+func (s RunStatus) CanTransitionTo(target RunStatus) bool {
+	if s.IsFinal() {
+		return false
+	}
+
+	validTransitions := map[RunStatus][]RunStatus{
+		RunStatusPending: {RunStatusRunning, RunStatusCancelled},
+		RunStatusRunning: {RunStatusCompleted, RunStatusFailed, RunStatusCancelled},
+	}
+
+	allowed, exists := validTransitions[s]
+	if !exists {
+		return false
+	}
+
+	for _, a := range allowed {
+		if target == a {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseRunStatus converts a string to RunStatus.
+// Returns RunStatusPending for unrecognized values.
+func ParseRunStatus(s string) RunStatus {
+	status := RunStatus(s)
+	if status.IsValid() {
+		return status
+	}
+	return RunStatusPending
+}

--- a/services/reconciliation/domain/run_status_test.go
+++ b/services/reconciliation/domain/run_status_test.go
@@ -1,0 +1,133 @@
+package domain
+
+import "testing"
+
+func TestRunStatus_IsValid(t *testing.T) {
+	tests := []struct {
+		name   string
+		status RunStatus
+		want   bool
+	}{
+		{"valid pending", RunStatusPending, true},
+		{"valid running", RunStatusRunning, true},
+		{"valid completed", RunStatusCompleted, true},
+		{"valid failed", RunStatusFailed, true},
+		{"valid cancelled", RunStatusCancelled, true},
+		{"invalid status", RunStatus("INVALID"), false},
+		{"empty status", RunStatus(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.IsValid(); got != tt.want {
+				t.Errorf("RunStatus.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunStatus_IsFinal(t *testing.T) {
+	tests := []struct {
+		name   string
+		status RunStatus
+		want   bool
+	}{
+		{"pending not final", RunStatusPending, false},
+		{"running not final", RunStatusRunning, false},
+		{"completed is final", RunStatusCompleted, true},
+		{"failed is final", RunStatusFailed, true},
+		{"cancelled is final", RunStatusCancelled, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.IsFinal(); got != tt.want {
+				t.Errorf("RunStatus.IsFinal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunStatus_CanTransitionTo(t *testing.T) {
+	tests := []struct {
+		name    string
+		current RunStatus
+		target  RunStatus
+		want    bool
+	}{
+		// Valid transitions from PENDING
+		{"pending to running", RunStatusPending, RunStatusRunning, true},
+		{"pending to cancelled", RunStatusPending, RunStatusCancelled, true},
+
+		// Invalid transitions from PENDING
+		{"pending to completed", RunStatusPending, RunStatusCompleted, false},
+		{"pending to failed", RunStatusPending, RunStatusFailed, false},
+
+		// Valid transitions from RUNNING
+		{"running to completed", RunStatusRunning, RunStatusCompleted, true},
+		{"running to failed", RunStatusRunning, RunStatusFailed, true},
+		{"running to cancelled", RunStatusRunning, RunStatusCancelled, true},
+
+		// Invalid transitions from RUNNING
+		{"running to pending", RunStatusRunning, RunStatusPending, false},
+
+		// Final states cannot transition
+		{"completed cannot transition", RunStatusCompleted, RunStatusPending, false},
+		{"failed cannot transition", RunStatusFailed, RunStatusPending, false},
+		{"cancelled cannot transition", RunStatusCancelled, RunStatusPending, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.current.CanTransitionTo(tt.target); got != tt.want {
+				t.Errorf("RunStatus(%s).CanTransitionTo(%s) = %v, want %v",
+					tt.current, tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunStatus_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   RunStatus
+		expected string
+	}{
+		{"pending", RunStatusPending, "PENDING"},
+		{"running", RunStatusRunning, "RUNNING"},
+		{"completed", RunStatusCompleted, "COMPLETED"},
+		{"failed", RunStatusFailed, "FAILED"},
+		{"cancelled", RunStatusCancelled, "CANCELLED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.String(); got != tt.expected {
+				t.Errorf("RunStatus.String() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseRunStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected RunStatus
+	}{
+		{"valid pending", "PENDING", RunStatusPending},
+		{"valid running", "RUNNING", RunStatusRunning},
+		{"valid completed", "COMPLETED", RunStatusCompleted},
+		{"invalid defaults to pending", "INVALID", RunStatusPending},
+		{"empty defaults to pending", "", RunStatusPending},
+		{"lowercase defaults to pending", "pending", RunStatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseRunStatus(tt.input); got != tt.expected {
+				t.Errorf("ParseRunStatus(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/services/reconciliation/domain/settlement_run.go
+++ b/services/reconciliation/domain/settlement_run.go
@@ -79,6 +79,9 @@ func NewSettlementRun(
 	if !periodStart.Before(periodEnd) {
 		return nil, ErrInvalidPeriod
 	}
+	if initiatedBy == "" {
+		return nil, ErrEmptyInitiatedBy
+	}
 
 	now := time.Now().UTC()
 	return &SettlementRun{

--- a/services/reconciliation/domain/settlement_run.go
+++ b/services/reconciliation/domain/settlement_run.go
@@ -1,0 +1,149 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SettlementRun is the Command Record (CR) that orchestrates a reconciliation run.
+// It captures the scope, type, period, and outcome of a reconciliation process.
+//
+// The Version field implements optimistic concurrency control. The persistence
+// layer should use WHERE run_id = ? AND version = ? to detect conflicts.
+type SettlementRun struct {
+	// RunID is the unique identifier for this settlement run.
+	RunID uuid.UUID
+
+	// AccountID identifies the primary account being reconciled.
+	AccountID string
+
+	// Scope defines what is being reconciled (account, instrument, portfolio, full).
+	Scope ReconciliationScope
+
+	// SettlementType defines the type of settlement (daily, weekly, on-demand, etc.).
+	SettlementType SettlementType
+
+	// Status is the current state of the run.
+	Status RunStatus
+
+	// PeriodStart is the beginning of the reconciliation period.
+	PeriodStart time.Time
+
+	// PeriodEnd is the end of the reconciliation period.
+	PeriodEnd time.Time
+
+	// InitiatedBy is the user or system that started the run.
+	InitiatedBy string
+
+	// CompletedAt is when the run finished (nil if still in progress).
+	CompletedAt *time.Time
+
+	// VarianceCount is the number of variances detected during the run.
+	VarianceCount int
+
+	// FailureReason records why the run failed (empty if not failed).
+	FailureReason string
+
+	// Attributes stores flexible metadata for this run.
+	Attributes map[string]string
+
+	// CreatedAt is when this record was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is when this record was last updated.
+	UpdatedAt time.Time
+
+	// Version is the optimistic lock version, incremented on state changes.
+	Version int64
+}
+
+// NewSettlementRun creates a new SettlementRun with validation.
+func NewSettlementRun(
+	accountID string,
+	scope ReconciliationScope,
+	settlementType SettlementType,
+	periodStart time.Time,
+	periodEnd time.Time,
+	initiatedBy string,
+) (*SettlementRun, error) {
+	if accountID == "" {
+		return nil, ErrEmptyAccountID
+	}
+	if !scope.IsValid() {
+		return nil, ErrEmptyScope
+	}
+	if !settlementType.IsValid() {
+		return nil, ErrEmptySettlementType
+	}
+	if !periodStart.Before(periodEnd) {
+		return nil, ErrInvalidPeriod
+	}
+
+	now := time.Now().UTC()
+	return &SettlementRun{
+		RunID:          uuid.New(),
+		AccountID:      accountID,
+		Scope:          scope,
+		SettlementType: settlementType,
+		Status:         RunStatusPending,
+		PeriodStart:    periodStart,
+		PeriodEnd:      periodEnd,
+		InitiatedBy:    initiatedBy,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		Version:        1,
+	}, nil
+}
+
+// Start transitions the run to RUNNING.
+func (r *SettlementRun) Start() error {
+	if !r.Status.CanTransitionTo(RunStatusRunning) {
+		return ErrInvalidStatusTransition
+	}
+	r.Status = RunStatusRunning
+	r.UpdatedAt = time.Now().UTC()
+	r.Version++
+	return nil
+}
+
+// Complete transitions the run to COMPLETED with a final variance count.
+func (r *SettlementRun) Complete(varianceCount int) error {
+	if !r.Status.CanTransitionTo(RunStatusCompleted) {
+		return ErrInvalidStatusTransition
+	}
+	now := time.Now().UTC()
+	r.Status = RunStatusCompleted
+	r.CompletedAt = &now
+	r.VarianceCount = varianceCount
+	r.UpdatedAt = now
+	r.Version++
+	return nil
+}
+
+// Fail transitions the run to FAILED with a reason.
+func (r *SettlementRun) Fail(reason string) error {
+	if !r.Status.CanTransitionTo(RunStatusFailed) {
+		return ErrInvalidStatusTransition
+	}
+	now := time.Now().UTC()
+	r.Status = RunStatusFailed
+	r.CompletedAt = &now
+	r.FailureReason = reason
+	r.UpdatedAt = now
+	r.Version++
+	return nil
+}
+
+// Cancel transitions the run to CANCELLED.
+func (r *SettlementRun) Cancel() error {
+	if !r.Status.CanTransitionTo(RunStatusCancelled) {
+		return ErrInvalidStatusTransition
+	}
+	now := time.Now().UTC()
+	r.Status = RunStatusCancelled
+	r.CompletedAt = &now
+	r.UpdatedAt = now
+	r.Version++
+	return nil
+}

--- a/services/reconciliation/domain/settlement_run_test.go
+++ b/services/reconciliation/domain/settlement_run_test.go
@@ -1,0 +1,199 @@
+package domain_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSettlementRun(t *testing.T) {
+	now := time.Now().UTC()
+	periodStart := now.Add(-24 * time.Hour)
+	periodEnd := now
+
+	tests := []struct {
+		name           string
+		accountID      string
+		scope          domain.ReconciliationScope
+		settlementType domain.SettlementType
+		periodStart    time.Time
+		periodEnd      time.Time
+		initiatedBy    string
+		wantErr        error
+	}{
+		{
+			name:           "valid daily run",
+			accountID:      "ACC-001",
+			scope:          domain.ReconciliationScopeAccount,
+			settlementType: domain.SettlementTypeDaily,
+			periodStart:    periodStart,
+			periodEnd:      periodEnd,
+			initiatedBy:    "system",
+			wantErr:        nil,
+		},
+		{
+			name:           "empty account ID",
+			accountID:      "",
+			scope:          domain.ReconciliationScopeAccount,
+			settlementType: domain.SettlementTypeDaily,
+			periodStart:    periodStart,
+			periodEnd:      periodEnd,
+			initiatedBy:    "system",
+			wantErr:        domain.ErrEmptyAccountID,
+		},
+		{
+			name:           "invalid scope",
+			accountID:      "ACC-001",
+			scope:          domain.ReconciliationScope("INVALID"),
+			settlementType: domain.SettlementTypeDaily,
+			periodStart:    periodStart,
+			periodEnd:      periodEnd,
+			initiatedBy:    "system",
+			wantErr:        domain.ErrEmptyScope,
+		},
+		{
+			name:           "invalid settlement type",
+			accountID:      "ACC-001",
+			scope:          domain.ReconciliationScopeAccount,
+			settlementType: domain.SettlementType("INVALID"),
+			periodStart:    periodStart,
+			periodEnd:      periodEnd,
+			initiatedBy:    "system",
+			wantErr:        domain.ErrEmptySettlementType,
+		},
+		{
+			name:           "invalid period (start after end)",
+			accountID:      "ACC-001",
+			scope:          domain.ReconciliationScopeAccount,
+			settlementType: domain.SettlementTypeDaily,
+			periodStart:    periodEnd,
+			periodEnd:      periodStart,
+			initiatedBy:    "system",
+			wantErr:        domain.ErrInvalidPeriod,
+		},
+		{
+			name:           "invalid period (equal start and end)",
+			accountID:      "ACC-001",
+			scope:          domain.ReconciliationScopeAccount,
+			settlementType: domain.SettlementTypeDaily,
+			periodStart:    periodStart,
+			periodEnd:      periodStart,
+			initiatedBy:    "system",
+			wantErr:        domain.ErrInvalidPeriod,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			run, err := domain.NewSettlementRun(
+				tt.accountID, tt.scope, tt.settlementType,
+				tt.periodStart, tt.periodEnd, tt.initiatedBy,
+			)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, run)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, run)
+
+				assert.NotEqual(t, uuid.Nil, run.RunID)
+				assert.Equal(t, tt.accountID, run.AccountID)
+				assert.Equal(t, tt.scope, run.Scope)
+				assert.Equal(t, tt.settlementType, run.SettlementType)
+				assert.Equal(t, domain.RunStatusPending, run.Status)
+				assert.Equal(t, int64(1), run.Version)
+				assert.Nil(t, run.CompletedAt)
+				assert.Equal(t, 0, run.VarianceCount)
+				assert.Empty(t, run.FailureReason)
+			}
+		})
+	}
+}
+
+func TestSettlementRun_Lifecycle(t *testing.T) {
+	run := newTestRun(t)
+
+	// Start
+	require.NoError(t, run.Start())
+	assert.Equal(t, domain.RunStatusRunning, run.Status)
+	assert.Equal(t, int64(2), run.Version)
+
+	// Complete
+	require.NoError(t, run.Complete(5))
+	assert.Equal(t, domain.RunStatusCompleted, run.Status)
+	assert.Equal(t, 5, run.VarianceCount)
+	assert.NotNil(t, run.CompletedAt)
+	assert.Equal(t, int64(3), run.Version)
+}
+
+func TestSettlementRun_FailLifecycle(t *testing.T) {
+	run := newTestRun(t)
+
+	require.NoError(t, run.Start())
+	require.NoError(t, run.Fail("database timeout"))
+
+	assert.Equal(t, domain.RunStatusFailed, run.Status)
+	assert.Equal(t, "database timeout", run.FailureReason)
+	assert.NotNil(t, run.CompletedAt)
+	assert.Equal(t, int64(3), run.Version)
+}
+
+func TestSettlementRun_CancelLifecycle(t *testing.T) {
+	run := newTestRun(t)
+
+	require.NoError(t, run.Cancel())
+	assert.Equal(t, domain.RunStatusCancelled, run.Status)
+	assert.NotNil(t, run.CompletedAt)
+	assert.Equal(t, int64(2), run.Version)
+}
+
+func TestSettlementRun_InvalidTransitions(t *testing.T) {
+	t.Run("cannot complete from pending", func(t *testing.T) {
+		run := newTestRun(t)
+		err := run.Complete(0)
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot fail from pending", func(t *testing.T) {
+		run := newTestRun(t)
+		err := run.Fail("reason")
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot start from completed", func(t *testing.T) {
+		run := newTestRun(t)
+		require.NoError(t, run.Start())
+		require.NoError(t, run.Complete(0))
+		err := run.Start()
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot cancel from completed", func(t *testing.T) {
+		run := newTestRun(t)
+		require.NoError(t, run.Start())
+		require.NoError(t, run.Complete(0))
+		err := run.Cancel()
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+}
+
+func newTestRun(t *testing.T) *domain.SettlementRun {
+	t.Helper()
+	now := time.Now().UTC()
+	run, err := domain.NewSettlementRun(
+		"ACC-001",
+		domain.ReconciliationScopeAccount,
+		domain.SettlementTypeDaily,
+		now.Add(-24*time.Hour),
+		now,
+		"test-user",
+	)
+	require.NoError(t, err)
+	return run
+}

--- a/services/reconciliation/domain/settlement_run_test.go
+++ b/services/reconciliation/domain/settlement_run_test.go
@@ -85,6 +85,16 @@ func TestNewSettlementRun(t *testing.T) {
 			initiatedBy:    "system",
 			wantErr:        domain.ErrInvalidPeriod,
 		},
+		{
+			name:           "empty initiated by",
+			accountID:      "ACC-001",
+			scope:          domain.ReconciliationScopeAccount,
+			settlementType: domain.SettlementTypeDaily,
+			periodStart:    periodStart,
+			periodEnd:      periodEnd,
+			initiatedBy:    "",
+			wantErr:        domain.ErrEmptyInitiatedBy,
+		},
 	}
 
 	for _, tt := range tests {

--- a/services/reconciliation/domain/settlement_snapshot.go
+++ b/services/reconciliation/domain/settlement_snapshot.go
@@ -1,0 +1,83 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// SettlementSnapshot is a Business Query (BQ) entity that captures a point-in-time
+// balance for an account/instrument combination during a settlement run.
+type SettlementSnapshot struct {
+	// SnapshotID is the unique identifier for this snapshot.
+	SnapshotID uuid.UUID
+
+	// RunID references the settlement run that created this snapshot.
+	RunID uuid.UUID
+
+	// AccountID identifies the account whose balance was captured.
+	AccountID string
+
+	// InstrumentCode identifies the asset type (e.g., "GBP", "KWH").
+	InstrumentCode string
+
+	// ExpectedBalance is the balance expected based on transaction logs.
+	ExpectedBalance decimal.Decimal
+
+	// ActualBalance is the balance reported by the source system.
+	ActualBalance decimal.Decimal
+
+	// VarianceAmount is the difference (actual - expected).
+	VarianceAmount decimal.Decimal
+
+	// SourceSystem identifies where the actual balance came from.
+	SourceSystem string
+
+	// Attributes stores flexible metadata (e.g., bucket key, dimension).
+	Attributes map[string]string
+
+	// CapturedAt is when the snapshot was taken.
+	CapturedAt time.Time
+
+	// CreatedAt is when this record was created.
+	CreatedAt time.Time
+}
+
+// NewSettlementSnapshot creates a new snapshot with computed variance.
+func NewSettlementSnapshot(
+	runID uuid.UUID,
+	accountID string,
+	instrumentCode string,
+	expectedBalance decimal.Decimal,
+	actualBalance decimal.Decimal,
+	sourceSystem string,
+	attributes map[string]string,
+) (*SettlementSnapshot, error) {
+	if accountID == "" {
+		return nil, ErrEmptyAccountID
+	}
+	if instrumentCode == "" {
+		return nil, ErrEmptyInstrumentCode
+	}
+
+	now := time.Now().UTC()
+	return &SettlementSnapshot{
+		SnapshotID:      uuid.New(),
+		RunID:           runID,
+		AccountID:       accountID,
+		InstrumentCode:  instrumentCode,
+		ExpectedBalance: expectedBalance,
+		ActualBalance:   actualBalance,
+		VarianceAmount:  actualBalance.Sub(expectedBalance),
+		SourceSystem:    sourceSystem,
+		Attributes:      attributes,
+		CapturedAt:      now,
+		CreatedAt:       now,
+	}, nil
+}
+
+// HasVariance returns true if the expected and actual balances do not match.
+func (s *SettlementSnapshot) HasVariance() bool {
+	return !s.VarianceAmount.IsZero()
+}

--- a/services/reconciliation/domain/settlement_snapshot_test.go
+++ b/services/reconciliation/domain/settlement_snapshot_test.go
@@ -1,0 +1,119 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSettlementSnapshot(t *testing.T) {
+	runID := uuid.New()
+
+	tests := []struct {
+		name           string
+		runID          uuid.UUID
+		accountID      string
+		instrumentCode string
+		expected       decimal.Decimal
+		actual         decimal.Decimal
+		sourceSystem   string
+		wantErr        error
+	}{
+		{
+			name:           "valid snapshot with no variance",
+			runID:          runID,
+			accountID:      "ACC-001",
+			instrumentCode: "GBP",
+			expected:       decimal.NewFromFloat(1000.00),
+			actual:         decimal.NewFromFloat(1000.00),
+			sourceSystem:   "position-keeping",
+			wantErr:        nil,
+		},
+		{
+			name:           "valid snapshot with variance",
+			runID:          runID,
+			accountID:      "ACC-001",
+			instrumentCode: "GBP",
+			expected:       decimal.NewFromFloat(1000.00),
+			actual:         decimal.NewFromFloat(995.50),
+			sourceSystem:   "position-keeping",
+			wantErr:        nil,
+		},
+		{
+			name:           "empty account ID",
+			runID:          runID,
+			accountID:      "",
+			instrumentCode: "GBP",
+			expected:       decimal.NewFromFloat(1000.00),
+			actual:         decimal.NewFromFloat(1000.00),
+			sourceSystem:   "position-keeping",
+			wantErr:        domain.ErrEmptyAccountID,
+		},
+		{
+			name:           "empty instrument code",
+			runID:          runID,
+			accountID:      "ACC-001",
+			instrumentCode: "",
+			expected:       decimal.NewFromFloat(1000.00),
+			actual:         decimal.NewFromFloat(1000.00),
+			sourceSystem:   "position-keeping",
+			wantErr:        domain.ErrEmptyInstrumentCode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snap, err := domain.NewSettlementSnapshot(
+				tt.runID, tt.accountID, tt.instrumentCode,
+				tt.expected, tt.actual, tt.sourceSystem, nil,
+			)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, snap)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, snap)
+
+				assert.NotEqual(t, uuid.Nil, snap.SnapshotID)
+				assert.Equal(t, tt.runID, snap.RunID)
+				assert.Equal(t, tt.accountID, snap.AccountID)
+				assert.Equal(t, tt.instrumentCode, snap.InstrumentCode)
+				assert.True(t, tt.expected.Equal(snap.ExpectedBalance))
+				assert.True(t, tt.actual.Equal(snap.ActualBalance))
+
+				expectedVariance := tt.actual.Sub(tt.expected)
+				assert.True(t, expectedVariance.Equal(snap.VarianceAmount))
+			}
+		})
+	}
+}
+
+func TestSettlementSnapshot_HasVariance(t *testing.T) {
+	runID := uuid.New()
+
+	t.Run("no variance when balances match", func(t *testing.T) {
+		snap, err := domain.NewSettlementSnapshot(
+			runID, "ACC-001", "GBP",
+			decimal.NewFromFloat(1000.00), decimal.NewFromFloat(1000.00),
+			"position-keeping", nil,
+		)
+		require.NoError(t, err)
+		assert.False(t, snap.HasVariance())
+	})
+
+	t.Run("has variance when balances differ", func(t *testing.T) {
+		snap, err := domain.NewSettlementSnapshot(
+			runID, "ACC-001", "GBP",
+			decimal.NewFromFloat(1000.00), decimal.NewFromFloat(999.99),
+			"position-keeping", nil,
+		)
+		require.NoError(t, err)
+		assert.True(t, snap.HasVariance())
+	})
+}

--- a/services/reconciliation/domain/settlement_type.go
+++ b/services/reconciliation/domain/settlement_type.go
@@ -1,0 +1,39 @@
+package domain
+
+// SettlementType defines the type of settlement being performed.
+type SettlementType string
+
+// Supported settlement types.
+const (
+	SettlementTypeDaily    SettlementType = "DAILY"
+	SettlementTypeWeekly   SettlementType = "WEEKLY"
+	SettlementTypeMonthly  SettlementType = "MONTHLY"
+	SettlementTypeOnDemand SettlementType = "ON_DEMAND"
+	SettlementTypeEndOfDay SettlementType = "END_OF_DAY"
+	SettlementTypeRealTime SettlementType = "REAL_TIME"
+)
+
+// IsValid checks if the settlement type is a recognized value.
+func (s SettlementType) IsValid() bool {
+	switch s {
+	case SettlementTypeDaily, SettlementTypeWeekly, SettlementTypeMonthly,
+		SettlementTypeOnDemand, SettlementTypeEndOfDay, SettlementTypeRealTime:
+		return true
+	}
+	return false
+}
+
+// String returns the string representation.
+func (s SettlementType) String() string {
+	return string(s)
+}
+
+// ParseSettlementType converts a string to SettlementType.
+// Returns SettlementTypeOnDemand for unrecognized values.
+func ParseSettlementType(s string) SettlementType {
+	st := SettlementType(s)
+	if st.IsValid() {
+		return st
+	}
+	return SettlementTypeOnDemand
+}

--- a/services/reconciliation/domain/settlement_type_test.go
+++ b/services/reconciliation/domain/settlement_type_test.go
@@ -1,0 +1,50 @@
+package domain
+
+import "testing"
+
+func TestSettlementType_IsValid(t *testing.T) {
+	tests := []struct {
+		name string
+		st   SettlementType
+		want bool
+	}{
+		{"valid daily", SettlementTypeDaily, true},
+		{"valid weekly", SettlementTypeWeekly, true},
+		{"valid monthly", SettlementTypeMonthly, true},
+		{"valid on demand", SettlementTypeOnDemand, true},
+		{"valid end of day", SettlementTypeEndOfDay, true},
+		{"valid real time", SettlementTypeRealTime, true},
+		{"invalid", SettlementType("INVALID"), false},
+		{"empty", SettlementType(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.st.IsValid(); got != tt.want {
+				t.Errorf("SettlementType.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSettlementType(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected SettlementType
+	}{
+		{"valid daily", "DAILY", SettlementTypeDaily},
+		{"valid weekly", "WEEKLY", SettlementTypeWeekly},
+		{"valid real time", "REAL_TIME", SettlementTypeRealTime},
+		{"invalid defaults to on demand", "INVALID", SettlementTypeOnDemand},
+		{"empty defaults to on demand", "", SettlementTypeOnDemand},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseSettlementType(tt.input); got != tt.expected {
+				t.Errorf("ParseSettlementType(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/services/reconciliation/domain/variance.go
+++ b/services/reconciliation/domain/variance.go
@@ -1,0 +1,145 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// Variance is a Business Query (BQ) entity representing a detected discrepancy
+// between expected and actual balances.
+type Variance struct {
+	// VarianceID is the unique identifier for this variance.
+	VarianceID uuid.UUID
+
+	// RunID references the settlement run that detected this variance.
+	RunID uuid.UUID
+
+	// SnapshotID references the snapshot where the variance was found.
+	SnapshotID uuid.UUID
+
+	// AccountID identifies the account with the discrepancy.
+	AccountID string
+
+	// InstrumentCode identifies the asset type.
+	InstrumentCode string
+
+	// ExpectedAmount is the expected balance.
+	ExpectedAmount decimal.Decimal
+
+	// ActualAmount is the actual balance found.
+	ActualAmount decimal.Decimal
+
+	// VarianceAmount is the difference (actual - expected).
+	VarianceAmount decimal.Decimal
+
+	// Reason classifies the type of discrepancy.
+	Reason VarianceReason
+
+	// Status is the resolution state.
+	Status VarianceStatus
+
+	// ResolutionNote records how the variance was resolved.
+	ResolutionNote string
+
+	// ResolvedBy records who resolved the variance.
+	ResolvedBy string
+
+	// ResolvedAt records when the variance was resolved.
+	ResolvedAt *time.Time
+
+	// Attributes stores flexible metadata.
+	Attributes map[string]string
+
+	// CreatedAt is when this record was created.
+	CreatedAt time.Time
+
+	// UpdatedAt is when this record was last updated.
+	UpdatedAt time.Time
+}
+
+// NewVariance creates a new Variance with validation.
+func NewVariance(
+	runID uuid.UUID,
+	snapshotID uuid.UUID,
+	accountID string,
+	instrumentCode string,
+	expectedAmount decimal.Decimal,
+	actualAmount decimal.Decimal,
+	reason VarianceReason,
+) (*Variance, error) {
+	if accountID == "" {
+		return nil, ErrEmptyAccountID
+	}
+	if instrumentCode == "" {
+		return nil, ErrEmptyInstrumentCode
+	}
+	if !reason.IsValid() {
+		return nil, ErrEmptyVarianceReason
+	}
+
+	now := time.Now().UTC()
+	return &Variance{
+		VarianceID:     uuid.New(),
+		RunID:          runID,
+		SnapshotID:     snapshotID,
+		AccountID:      accountID,
+		InstrumentCode: instrumentCode,
+		ExpectedAmount: expectedAmount,
+		ActualAmount:   actualAmount,
+		VarianceAmount: actualAmount.Sub(expectedAmount),
+		Reason:         reason,
+		Status:         VarianceStatusOpen,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}, nil
+}
+
+// Investigate transitions the variance to INVESTIGATING.
+func (v *Variance) Investigate() error {
+	if !v.Status.CanTransitionTo(VarianceStatusInvestigating) {
+		return ErrInvalidStatusTransition
+	}
+	v.Status = VarianceStatusInvestigating
+	v.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+// Dispute transitions the variance to DISPUTED.
+func (v *Variance) Dispute() error {
+	if !v.Status.CanTransitionTo(VarianceStatusDisputed) {
+		return ErrInvalidStatusTransition
+	}
+	v.Status = VarianceStatusDisputed
+	v.UpdatedAt = time.Now().UTC()
+	return nil
+}
+
+// Resolve transitions the variance to RESOLVED with a note.
+func (v *Variance) Resolve(note string, resolvedBy string) error {
+	if !v.Status.CanTransitionTo(VarianceStatusResolved) {
+		return ErrInvalidStatusTransition
+	}
+	now := time.Now().UTC()
+	v.Status = VarianceStatusResolved
+	v.ResolutionNote = note
+	v.ResolvedBy = resolvedBy
+	v.ResolvedAt = &now
+	v.UpdatedAt = now
+	return nil
+}
+
+// Accept transitions the variance to ACCEPTED (accepted as a known difference).
+func (v *Variance) Accept(note string, acceptedBy string) error {
+	if !v.Status.CanTransitionTo(VarianceStatusAccepted) {
+		return ErrInvalidStatusTransition
+	}
+	now := time.Now().UTC()
+	v.Status = VarianceStatusAccepted
+	v.ResolutionNote = note
+	v.ResolvedBy = acceptedBy
+	v.ResolvedAt = &now
+	v.UpdatedAt = now
+	return nil
+}

--- a/services/reconciliation/domain/variance_reason.go
+++ b/services/reconciliation/domain/variance_reason.go
@@ -1,0 +1,42 @@
+package domain
+
+// VarianceReason classifies the type of discrepancy found.
+type VarianceReason string
+
+// Supported variance reasons.
+const (
+	VarianceReasonAmountMismatch   VarianceReason = "AMOUNT_MISMATCH"
+	VarianceReasonMissingEntry     VarianceReason = "MISSING_ENTRY"
+	VarianceReasonDuplicateEntry   VarianceReason = "DUPLICATE_ENTRY"
+	VarianceReasonTimingDifference VarianceReason = "TIMING_DIFFERENCE"
+	VarianceReasonCurrencyMismatch VarianceReason = "CURRENCY_MISMATCH"
+	VarianceReasonDirectionError   VarianceReason = "DIRECTION_ERROR"
+	VarianceReasonOther            VarianceReason = "OTHER"
+)
+
+// IsValid checks if the variance reason is a recognized value.
+func (r VarianceReason) IsValid() bool {
+	switch r {
+	case VarianceReasonAmountMismatch, VarianceReasonMissingEntry,
+		VarianceReasonDuplicateEntry, VarianceReasonTimingDifference,
+		VarianceReasonCurrencyMismatch, VarianceReasonDirectionError,
+		VarianceReasonOther:
+		return true
+	}
+	return false
+}
+
+// String returns the string representation.
+func (r VarianceReason) String() string {
+	return string(r)
+}
+
+// ParseVarianceReason converts a string to VarianceReason.
+// Returns VarianceReasonOther for unrecognized values.
+func ParseVarianceReason(s string) VarianceReason {
+	reason := VarianceReason(s)
+	if reason.IsValid() {
+		return reason
+	}
+	return VarianceReasonOther
+}

--- a/services/reconciliation/domain/variance_reason_test.go
+++ b/services/reconciliation/domain/variance_reason_test.go
@@ -1,0 +1,50 @@
+package domain
+
+import "testing"
+
+func TestVarianceReason_IsValid(t *testing.T) {
+	tests := []struct {
+		name   string
+		reason VarianceReason
+		want   bool
+	}{
+		{"valid amount mismatch", VarianceReasonAmountMismatch, true},
+		{"valid missing entry", VarianceReasonMissingEntry, true},
+		{"valid duplicate entry", VarianceReasonDuplicateEntry, true},
+		{"valid timing difference", VarianceReasonTimingDifference, true},
+		{"valid currency mismatch", VarianceReasonCurrencyMismatch, true},
+		{"valid direction error", VarianceReasonDirectionError, true},
+		{"valid other", VarianceReasonOther, true},
+		{"invalid", VarianceReason("INVALID"), false},
+		{"empty", VarianceReason(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.reason.IsValid(); got != tt.want {
+				t.Errorf("VarianceReason.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseVarianceReason(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected VarianceReason
+	}{
+		{"valid amount mismatch", "AMOUNT_MISMATCH", VarianceReasonAmountMismatch},
+		{"valid missing entry", "MISSING_ENTRY", VarianceReasonMissingEntry},
+		{"invalid defaults to other", "INVALID", VarianceReasonOther},
+		{"empty defaults to other", "", VarianceReasonOther},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseVarianceReason(tt.input); got != tt.expected {
+				t.Errorf("ParseVarianceReason(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/services/reconciliation/domain/variance_status.go
+++ b/services/reconciliation/domain/variance_status.go
@@ -1,0 +1,69 @@
+package domain
+
+// VarianceStatus represents the resolution state of a variance.
+type VarianceStatus string
+
+// Supported variance statuses.
+const (
+	VarianceStatusOpen          VarianceStatus = "OPEN"
+	VarianceStatusInvestigating VarianceStatus = "INVESTIGATING"
+	VarianceStatusDisputed      VarianceStatus = "DISPUTED"
+	VarianceStatusResolved      VarianceStatus = "RESOLVED"
+	VarianceStatusAccepted      VarianceStatus = "ACCEPTED"
+)
+
+// IsValid checks if the variance status is a recognized value.
+func (s VarianceStatus) IsValid() bool {
+	switch s {
+	case VarianceStatusOpen, VarianceStatusInvestigating,
+		VarianceStatusDisputed, VarianceStatusResolved,
+		VarianceStatusAccepted:
+		return true
+	}
+	return false
+}
+
+// String returns the string representation.
+func (s VarianceStatus) String() string {
+	return string(s)
+}
+
+// IsFinal checks if the status is a terminal state.
+func (s VarianceStatus) IsFinal() bool {
+	return s == VarianceStatusResolved || s == VarianceStatusAccepted
+}
+
+// CanTransitionTo checks if a transition to the target status is valid.
+func (s VarianceStatus) CanTransitionTo(target VarianceStatus) bool {
+	if s.IsFinal() {
+		return false
+	}
+
+	validTransitions := map[VarianceStatus][]VarianceStatus{
+		VarianceStatusOpen:          {VarianceStatusInvestigating, VarianceStatusDisputed, VarianceStatusResolved, VarianceStatusAccepted},
+		VarianceStatusInvestigating: {VarianceStatusDisputed, VarianceStatusResolved, VarianceStatusAccepted},
+		VarianceStatusDisputed:      {VarianceStatusInvestigating, VarianceStatusResolved, VarianceStatusAccepted},
+	}
+
+	allowed, exists := validTransitions[s]
+	if !exists {
+		return false
+	}
+
+	for _, a := range allowed {
+		if target == a {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseVarianceStatus converts a string to VarianceStatus.
+// Returns VarianceStatusOpen for unrecognized values.
+func ParseVarianceStatus(s string) VarianceStatus {
+	status := VarianceStatus(s)
+	if status.IsValid() {
+		return status
+	}
+	return VarianceStatusOpen
+}

--- a/services/reconciliation/domain/variance_status_test.go
+++ b/services/reconciliation/domain/variance_status_test.go
@@ -1,0 +1,113 @@
+package domain
+
+import "testing"
+
+func TestVarianceStatus_IsValid(t *testing.T) {
+	tests := []struct {
+		name   string
+		status VarianceStatus
+		want   bool
+	}{
+		{"valid open", VarianceStatusOpen, true},
+		{"valid investigating", VarianceStatusInvestigating, true},
+		{"valid disputed", VarianceStatusDisputed, true},
+		{"valid resolved", VarianceStatusResolved, true},
+		{"valid accepted", VarianceStatusAccepted, true},
+		{"invalid status", VarianceStatus("INVALID"), false},
+		{"empty status", VarianceStatus(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.IsValid(); got != tt.want {
+				t.Errorf("VarianceStatus.IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVarianceStatus_IsFinal(t *testing.T) {
+	tests := []struct {
+		name   string
+		status VarianceStatus
+		want   bool
+	}{
+		{"open not final", VarianceStatusOpen, false},
+		{"investigating not final", VarianceStatusInvestigating, false},
+		{"disputed not final", VarianceStatusDisputed, false},
+		{"resolved is final", VarianceStatusResolved, true},
+		{"accepted is final", VarianceStatusAccepted, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.status.IsFinal(); got != tt.want {
+				t.Errorf("VarianceStatus.IsFinal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVarianceStatus_CanTransitionTo(t *testing.T) {
+	tests := []struct {
+		name    string
+		current VarianceStatus
+		target  VarianceStatus
+		want    bool
+	}{
+		// From OPEN
+		{"open to investigating", VarianceStatusOpen, VarianceStatusInvestigating, true},
+		{"open to disputed", VarianceStatusOpen, VarianceStatusDisputed, true},
+		{"open to resolved", VarianceStatusOpen, VarianceStatusResolved, true},
+		{"open to accepted", VarianceStatusOpen, VarianceStatusAccepted, true},
+
+		// From INVESTIGATING
+		{"investigating to disputed", VarianceStatusInvestigating, VarianceStatusDisputed, true},
+		{"investigating to resolved", VarianceStatusInvestigating, VarianceStatusResolved, true},
+		{"investigating to accepted", VarianceStatusInvestigating, VarianceStatusAccepted, true},
+		{"investigating to open", VarianceStatusInvestigating, VarianceStatusOpen, false},
+
+		// From DISPUTED
+		{"disputed to investigating", VarianceStatusDisputed, VarianceStatusInvestigating, true},
+		{"disputed to resolved", VarianceStatusDisputed, VarianceStatusResolved, true},
+		{"disputed to accepted", VarianceStatusDisputed, VarianceStatusAccepted, true},
+		{"disputed to open", VarianceStatusDisputed, VarianceStatusOpen, false},
+
+		// Final states
+		{"resolved cannot transition", VarianceStatusResolved, VarianceStatusOpen, false},
+		{"accepted cannot transition", VarianceStatusAccepted, VarianceStatusOpen, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.current.CanTransitionTo(tt.target); got != tt.want {
+				t.Errorf("VarianceStatus(%s).CanTransitionTo(%s) = %v, want %v",
+					tt.current, tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseVarianceStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected VarianceStatus
+	}{
+		{"valid open", "OPEN", VarianceStatusOpen},
+		{"valid investigating", "INVESTIGATING", VarianceStatusInvestigating},
+		{"valid disputed", "DISPUTED", VarianceStatusDisputed},
+		{"valid resolved", "RESOLVED", VarianceStatusResolved},
+		{"valid accepted", "ACCEPTED", VarianceStatusAccepted},
+		{"invalid defaults to open", "INVALID", VarianceStatusOpen},
+		{"empty defaults to open", "", VarianceStatusOpen},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseVarianceStatus(tt.input); got != tt.expected {
+				t.Errorf("ParseVarianceStatus(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}

--- a/services/reconciliation/domain/variance_test.go
+++ b/services/reconciliation/domain/variance_test.go
@@ -1,0 +1,154 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVariance(t *testing.T) {
+	runID := uuid.New()
+	snapshotID := uuid.New()
+
+	tests := []struct {
+		name           string
+		accountID      string
+		instrumentCode string
+		expected       decimal.Decimal
+		actual         decimal.Decimal
+		reason         domain.VarianceReason
+		wantErr        error
+	}{
+		{
+			name:           "valid amount mismatch",
+			accountID:      "ACC-001",
+			instrumentCode: "GBP",
+			expected:       decimal.NewFromFloat(1000.00),
+			actual:         decimal.NewFromFloat(995.50),
+			reason:         domain.VarianceReasonAmountMismatch,
+			wantErr:        nil,
+		},
+		{
+			name:           "valid missing entry",
+			accountID:      "ACC-002",
+			instrumentCode: "KWH",
+			expected:       decimal.NewFromFloat(500.00),
+			actual:         decimal.Zero,
+			reason:         domain.VarianceReasonMissingEntry,
+			wantErr:        nil,
+		},
+		{
+			name:           "empty account ID",
+			accountID:      "",
+			instrumentCode: "GBP",
+			expected:       decimal.NewFromFloat(1000.00),
+			actual:         decimal.NewFromFloat(995.50),
+			reason:         domain.VarianceReasonAmountMismatch,
+			wantErr:        domain.ErrEmptyAccountID,
+		},
+		{
+			name:           "empty instrument code",
+			accountID:      "ACC-001",
+			instrumentCode: "",
+			expected:       decimal.NewFromFloat(1000.00),
+			actual:         decimal.NewFromFloat(995.50),
+			reason:         domain.VarianceReasonAmountMismatch,
+			wantErr:        domain.ErrEmptyInstrumentCode,
+		},
+		{
+			name:           "invalid reason",
+			accountID:      "ACC-001",
+			instrumentCode: "GBP",
+			expected:       decimal.NewFromFloat(1000.00),
+			actual:         decimal.NewFromFloat(995.50),
+			reason:         domain.VarianceReason("INVALID"),
+			wantErr:        domain.ErrEmptyVarianceReason,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := domain.NewVariance(
+				runID, snapshotID, tt.accountID, tt.instrumentCode,
+				tt.expected, tt.actual, tt.reason,
+			)
+
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, v)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, v)
+
+				assert.NotEqual(t, uuid.Nil, v.VarianceID)
+				assert.Equal(t, runID, v.RunID)
+				assert.Equal(t, snapshotID, v.SnapshotID)
+				assert.Equal(t, domain.VarianceStatusOpen, v.Status)
+
+				expectedVariance := tt.actual.Sub(tt.expected)
+				assert.True(t, expectedVariance.Equal(v.VarianceAmount))
+			}
+		})
+	}
+}
+
+func TestVariance_Lifecycle(t *testing.T) {
+	v := newTestVariance(t)
+
+	// Investigate
+	require.NoError(t, v.Investigate())
+	assert.Equal(t, domain.VarianceStatusInvestigating, v.Status)
+
+	// Resolve
+	require.NoError(t, v.Resolve("Manual correction applied", "admin"))
+	assert.Equal(t, domain.VarianceStatusResolved, v.Status)
+	assert.Equal(t, "Manual correction applied", v.ResolutionNote)
+	assert.Equal(t, "admin", v.ResolvedBy)
+	assert.NotNil(t, v.ResolvedAt)
+}
+
+func TestVariance_DisputeLifecycle(t *testing.T) {
+	v := newTestVariance(t)
+
+	require.NoError(t, v.Dispute())
+	assert.Equal(t, domain.VarianceStatusDisputed, v.Status)
+
+	require.NoError(t, v.Investigate())
+	assert.Equal(t, domain.VarianceStatusInvestigating, v.Status)
+
+	require.NoError(t, v.Accept("Known timing difference", "reviewer"))
+	assert.Equal(t, domain.VarianceStatusAccepted, v.Status)
+	assert.NotNil(t, v.ResolvedAt)
+}
+
+func TestVariance_InvalidTransitions(t *testing.T) {
+	t.Run("cannot investigate from resolved", func(t *testing.T) {
+		v := newTestVariance(t)
+		require.NoError(t, v.Resolve("done", "admin"))
+		err := v.Investigate()
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+
+	t.Run("cannot dispute from accepted", func(t *testing.T) {
+		v := newTestVariance(t)
+		require.NoError(t, v.Accept("accepted", "admin"))
+		err := v.Dispute()
+		assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+	})
+}
+
+func newTestVariance(t *testing.T) *domain.Variance {
+	t.Helper()
+	v, err := domain.NewVariance(
+		uuid.New(), uuid.New(), "ACC-001", "GBP",
+		decimal.NewFromFloat(1000.00), decimal.NewFromFloat(995.50),
+		domain.VarianceReasonAmountMismatch,
+	)
+	require.NoError(t, err)
+	return v
+}

--- a/services/reconciliation/migrations/20260209000001_initial.sql
+++ b/services/reconciliation/migrations/20260209000001_initial.sql
@@ -151,8 +151,9 @@ CREATE TABLE "balance_assertion" (
   "actual_balance" decimal(38, 18) NOT NULL DEFAULT 0,
   "status" character varying(20) NOT NULL DEFAULT 'PENDING',
   "failure_reason" text NULL,
+  "override_reason" text NULL,
   "attributes" jsonb NULL,
-  "asserted_at" timestamptz NOT NULL,
+  "asserted_at" timestamptz NULL,
   PRIMARY KEY ("id"),
   CONSTRAINT "fk_balance_assertion_run" FOREIGN KEY ("run_id")
     REFERENCES "settlement_run" ("id") ON UPDATE NO ACTION ON DELETE SET NULL

--- a/services/reconciliation/migrations/20260209000001_initial.sql
+++ b/services/reconciliation/migrations/20260209000001_initial.sql
@@ -1,0 +1,168 @@
+-- Reconciliation Service Schema
+-- Uses unqualified table names (relies on database-per-service architecture)
+-- Tenant isolation via SET LOCAL search_path TO org_{tenant_id}, public
+
+-- Create "settlement_run" table (CR - Command Record)
+CREATE TABLE "settlement_run" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  "run_id" uuid NOT NULL,
+  "account_id" character varying(34) NOT NULL,
+  "scope" character varying(20) NOT NULL,
+  "settlement_type" character varying(20) NOT NULL,
+  "status" character varying(20) NOT NULL DEFAULT 'PENDING',
+  "period_start" timestamptz NOT NULL,
+  "period_end" timestamptz NOT NULL,
+  "initiated_by" character varying(100) NOT NULL,
+  "completed_at" timestamptz NULL,
+  "variance_count" integer NOT NULL DEFAULT 0,
+  "failure_reason" text NULL,
+  "attributes" jsonb NULL,
+  "version" bigint NOT NULL DEFAULT 1,
+  PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "idx_settlement_run_run_id" ON "settlement_run" ("run_id");
+CREATE INDEX "idx_settlement_run_account_id" ON "settlement_run" ("account_id");
+CREATE INDEX "idx_settlement_run_status" ON "settlement_run" ("status");
+CREATE INDEX "idx_settlement_run_period" ON "settlement_run" ("period_start", "period_end");
+CREATE INDEX "idx_settlement_run_created_at" ON "settlement_run" ("created_at");
+
+ALTER TABLE "settlement_run"
+  ADD CONSTRAINT "chk_settlement_run_scope"
+  CHECK ("scope" IN ('ACCOUNT', 'INSTRUMENT', 'PORTFOLIO', 'FULL'));
+ALTER TABLE "settlement_run"
+  ADD CONSTRAINT "chk_settlement_run_settlement_type"
+  CHECK ("settlement_type" IN ('DAILY', 'WEEKLY', 'MONTHLY', 'ON_DEMAND', 'END_OF_DAY', 'REAL_TIME'));
+ALTER TABLE "settlement_run"
+  ADD CONSTRAINT "chk_settlement_run_status"
+  CHECK ("status" IN ('PENDING', 'RUNNING', 'COMPLETED', 'FAILED', 'CANCELLED'));
+ALTER TABLE "settlement_run"
+  ADD CONSTRAINT "chk_settlement_run_period"
+  CHECK ("period_start" < "period_end");
+
+-- Create "settlement_snapshot" table (BQ - Business Query)
+CREATE TABLE "settlement_snapshot" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "snapshot_id" uuid NOT NULL,
+  "run_id" uuid NOT NULL,
+  "account_id" character varying(34) NOT NULL,
+  "instrument_code" character varying(20) NOT NULL,
+  "expected_balance" decimal(38, 18) NOT NULL,
+  "actual_balance" decimal(38, 18) NOT NULL,
+  "variance_amount" decimal(38, 18) NOT NULL,
+  "source_system" character varying(100) NOT NULL,
+  "attributes" jsonb NULL,
+  "captured_at" timestamptz NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "fk_settlement_snapshot_run" FOREIGN KEY ("run_id")
+    REFERENCES "settlement_run" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX "idx_settlement_snapshot_snapshot_id" ON "settlement_snapshot" ("snapshot_id");
+CREATE INDEX "idx_settlement_snapshot_run_id" ON "settlement_snapshot" ("run_id");
+CREATE INDEX "idx_settlement_snapshot_account_id" ON "settlement_snapshot" ("account_id");
+CREATE INDEX "idx_settlement_snapshot_captured_at" ON "settlement_snapshot" ("captured_at");
+
+-- Create "variance" table (BQ - Business Query)
+CREATE TABLE "variance" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  "variance_id" uuid NOT NULL,
+  "run_id" uuid NOT NULL,
+  "snapshot_id" uuid NOT NULL,
+  "account_id" character varying(34) NOT NULL,
+  "instrument_code" character varying(20) NOT NULL,
+  "expected_amount" decimal(38, 18) NOT NULL,
+  "actual_amount" decimal(38, 18) NOT NULL,
+  "variance_amount" decimal(38, 18) NOT NULL,
+  "reason" character varying(30) NOT NULL,
+  "status" character varying(20) NOT NULL DEFAULT 'OPEN',
+  "resolution_note" text NULL,
+  "resolved_by" character varying(100) NULL,
+  "resolved_at" timestamptz NULL,
+  "attributes" jsonb NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "fk_variance_run" FOREIGN KEY ("run_id")
+    REFERENCES "settlement_run" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "fk_variance_snapshot" FOREIGN KEY ("snapshot_id")
+    REFERENCES "settlement_snapshot" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX "idx_variance_variance_id" ON "variance" ("variance_id");
+CREATE INDEX "idx_variance_run_id" ON "variance" ("run_id");
+CREATE INDEX "idx_variance_snapshot_id" ON "variance" ("snapshot_id");
+CREATE INDEX "idx_variance_account_id" ON "variance" ("account_id");
+CREATE INDEX "idx_variance_status" ON "variance" ("status");
+
+ALTER TABLE "variance"
+  ADD CONSTRAINT "chk_variance_reason"
+  CHECK ("reason" IN ('AMOUNT_MISMATCH', 'MISSING_ENTRY', 'DUPLICATE_ENTRY', 'TIMING_DIFFERENCE', 'CURRENCY_MISMATCH', 'DIRECTION_ERROR', 'OTHER'));
+ALTER TABLE "variance"
+  ADD CONSTRAINT "chk_variance_status"
+  CHECK ("status" IN ('OPEN', 'INVESTIGATING', 'DISPUTED', 'RESOLVED', 'ACCEPTED'));
+
+-- Create "dispute" table (BQ - Business Query)
+CREATE TABLE "dispute" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  "dispute_id" uuid NOT NULL,
+  "variance_id" uuid NOT NULL,
+  "run_id" uuid NOT NULL,
+  "account_id" character varying(34) NOT NULL,
+  "status" character varying(20) NOT NULL DEFAULT 'OPEN',
+  "reason" text NOT NULL,
+  "resolution" text NULL,
+  "raised_by" character varying(100) NOT NULL,
+  "resolved_by" character varying(100) NULL,
+  "resolved_at" timestamptz NULL,
+  "attributes" jsonb NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "fk_dispute_variance" FOREIGN KEY ("variance_id")
+    REFERENCES "variance" ("id") ON UPDATE NO ACTION ON DELETE CASCADE,
+  CONSTRAINT "fk_dispute_run" FOREIGN KEY ("run_id")
+    REFERENCES "settlement_run" ("id") ON UPDATE NO ACTION ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX "idx_dispute_dispute_id" ON "dispute" ("dispute_id");
+CREATE INDEX "idx_dispute_variance_id" ON "dispute" ("variance_id");
+CREATE INDEX "idx_dispute_run_id" ON "dispute" ("run_id");
+CREATE INDEX "idx_dispute_account_id" ON "dispute" ("account_id");
+CREATE INDEX "idx_dispute_status" ON "dispute" ("status");
+
+ALTER TABLE "dispute"
+  ADD CONSTRAINT "chk_dispute_status"
+  CHECK ("status" IN ('OPEN', 'UNDER_REVIEW', 'ESCALATED', 'RESOLVED', 'REJECTED'));
+
+-- Create "balance_assertion" table (BQ - Business Query)
+CREATE TABLE "balance_assertion" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "assertion_id" uuid NOT NULL,
+  "run_id" uuid NULL,
+  "account_id" character varying(34) NOT NULL,
+  "instrument_code" character varying(20) NOT NULL,
+  "expression" text NOT NULL,
+  "expected_balance" decimal(38, 18) NOT NULL,
+  "actual_balance" decimal(38, 18) NOT NULL DEFAULT 0,
+  "status" character varying(20) NOT NULL DEFAULT 'PENDING',
+  "failure_reason" text NULL,
+  "attributes" jsonb NULL,
+  "asserted_at" timestamptz NOT NULL,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "fk_balance_assertion_run" FOREIGN KEY ("run_id")
+    REFERENCES "settlement_run" ("id") ON UPDATE NO ACTION ON DELETE SET NULL
+);
+
+CREATE UNIQUE INDEX "idx_balance_assertion_assertion_id" ON "balance_assertion" ("assertion_id");
+CREATE INDEX "idx_balance_assertion_run_id" ON "balance_assertion" ("run_id");
+CREATE INDEX "idx_balance_assertion_account_id" ON "balance_assertion" ("account_id");
+CREATE INDEX "idx_balance_assertion_status" ON "balance_assertion" ("status");
+
+ALTER TABLE "balance_assertion"
+  ADD CONSTRAINT "chk_balance_assertion_status"
+  CHECK ("status" IN ('PENDING', 'PASSED', 'FAILED', 'OVERRIDE'));


### PR DESCRIPTION
## Summary

- Implement core domain entities for the reconciliation service: SettlementRun (CR), SettlementSnapshot (BQ), Variance (BQ), Dispute (BQ), and BalanceAssertion (BQ)
- Add enum types with state machine validation (RunStatus, ReconciliationScope, SettlementType, VarianceReason, VarianceStatus, DisputeStatus, AssertionStatus)
- Create CockroachDB Flyway migration with proper indexes, foreign keys, CHECK constraints, and decimal(38,18) precision

## Changes Made

**Domain entities** (`services/reconciliation/domain/`):
- `SettlementRun` - Orchestrates reconciliation runs with PENDING -> RUNNING -> COMPLETED/FAILED/CANCELLED lifecycle. Includes optimistic locking via `version` column
- `SettlementSnapshot` - Point-in-time balance capture with automatic variance computation (actual - expected)
- `Variance` - Detected discrepancies with OPEN -> INVESTIGATING -> DISPUTED -> RESOLVED/ACCEPTED lifecycle
- `Dispute` - Formal dispute workflow with OPEN -> UNDER_REVIEW -> ESCALATED -> RESOLVED/REJECTED lifecycle
- `BalanceAssertion` - Cross-account balance assertions with PENDING -> PASSED/FAILED lifecycle

**Enum types** with validation, parsing, and state machine guards:
- `RunStatus`, `ReconciliationScope`, `SettlementType`, `VarianceReason`, `VarianceStatus`, `DisputeStatus`, `AssertionStatus`

**Repository interfaces** with typed filters and pagination:
- `SettlementRunRepository`, `SettlementSnapshotRepository`, `VarianceRepository`, `DisputeRepository`, `BalanceAssertionRepository`

**Migration** (`services/reconciliation/migrations/20260209000001_initial.sql`):
- 5 tables with proper foreign key relationships
- CHECK constraints mirroring all domain enum values
- Period validation constraint (start < end)
- TIMESTAMPTZ for all temporal columns
- JSONB attributes for flexible metadata
- Appropriate indexes on query patterns

## Technical Details

- Follows position-keeping domain patterns (constructor validation, state machine methods, error sentinels)
- Uses `shopspring/decimal` for all monetary amounts
- Uses `google/uuid` for all identifiers
- All tests use table-driven patterns with both happy and unhappy paths

## Testing

- 100+ unit tests covering all enum validation, state transitions, entity construction, and lifecycle methods
- All tests pass: `go test ./services/reconciliation/domain/... -count=1`

## Task Master

Task: reconciliation-service.2 - Domain model and database migrations