### PR TITLE
feat: add reconciliation proto API and gRPC skeleton

### DIFF
--- a/api/proto/meridian/events/v1/reconciliation_events.proto
+++ b/api/proto/meridian/events/v1/reconciliation_events.proto
@@ -1,0 +1,305 @@
+syntax = "proto3";
+
+package meridian.events.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/events/v1;eventsv1";
+
+// ReconciliationRunStartedEvent is published when a settlement run begins execution.
+message ReconciliationRunStartedEvent {
+  // run_id uniquely identifies the settlement run.
+  string run_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // account_id identifies the primary account being reconciled.
+  string account_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // scope defines what is being reconciled (ACCOUNT, INSTRUMENT, PORTFOLIO, FULL).
+  string scope = 3 [(buf.validate.field).string = {
+    in: ["ACCOUNT", "INSTRUMENT", "PORTFOLIO", "FULL"]
+  }];
+
+  // settlement_type defines the settlement cycle (DAILY, WEEKLY, etc.).
+  string settlement_type = 4 [(buf.validate.field).string = {
+    in: ["DAILY", "WEEKLY", "MONTHLY", "ON_DEMAND", "END_OF_DAY", "REAL_TIME"]
+  }];
+
+  // period_start is the beginning of the reconciliation period.
+  google.protobuf.Timestamp period_start = 5 [(buf.validate.field).required = true];
+
+  // period_end is the end of the reconciliation period.
+  google.protobuf.Timestamp period_end = 6 [(buf.validate.field).required = true];
+
+  // initiated_by is the user or system that started the run.
+  string initiated_by = 7 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // correlation_id links related events across services.
+  string correlation_id = 8 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // timestamp when the event was created.
+  google.protobuf.Timestamp timestamp = 9 [(buf.validate.field).required = true];
+}
+
+// ReconciliationRunCompletedEvent is published when a settlement run finishes.
+message ReconciliationRunCompletedEvent {
+  // run_id uniquely identifies the settlement run.
+  string run_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // account_id identifies the primary account that was reconciled.
+  string account_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // status is the final status (COMPLETED, FAILED, CANCELLED).
+  string status = 3 [(buf.validate.field).string = {
+    in: ["COMPLETED", "FAILED", "CANCELLED"]
+  }];
+
+  // variance_count is the number of variances detected.
+  int32 variance_count = 4 [(buf.validate.field).int32.gte = 0];
+
+  // snapshot_count is the number of snapshots captured.
+  int32 snapshot_count = 5 [(buf.validate.field).int32.gte = 0];
+
+  // total_variance is the sum of absolute variance amounts as a decimal string.
+  string total_variance = 6 [(buf.validate.field).string = {
+    max_len: 50
+  }];
+
+  // failure_reason records why the run failed (empty if not failed).
+  string failure_reason = 7 [(buf.validate.field).string.max_len = 1000];
+
+  // correlation_id links related events across services.
+  string correlation_id = 8 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // timestamp when the event was created.
+  google.protobuf.Timestamp timestamp = 9 [(buf.validate.field).required = true];
+}
+
+// VarianceDetectedEvent is published when a variance is detected during reconciliation.
+message VarianceDetectedEvent {
+  // variance_id uniquely identifies the variance.
+  string variance_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // run_id references the settlement run.
+  string run_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // account_id identifies the account with the discrepancy.
+  string account_id = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // instrument_code identifies the asset type.
+  string instrument_code = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+  }];
+
+  // expected_amount as a decimal string.
+  string expected_amount = 5;
+
+  // actual_amount as a decimal string.
+  string actual_amount = 6;
+
+  // variance_amount as a decimal string.
+  string variance_amount = 7;
+
+  // reason classifies the discrepancy (AMOUNT_MISMATCH, MISSING_ENTRY, etc.).
+  string reason = 8 [(buf.validate.field).string = {
+    in: [
+      "AMOUNT_MISMATCH",
+      "MISSING_ENTRY",
+      "DUPLICATE_ENTRY",
+      "TIMING_DIFFERENCE",
+      "CURRENCY_MISMATCH",
+      "DIRECTION_ERROR",
+      "OTHER"
+    ]
+  }];
+
+  // correlation_id links related events across services.
+  string correlation_id = 9 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // timestamp when the event was created.
+  google.protobuf.Timestamp timestamp = 10 [(buf.validate.field).required = true];
+}
+
+// PositionLockRequestedEvent is published when reconciliation needs to lock positions
+// for a consistent snapshot. This is consumed by Position Keeping to pause writes.
+message PositionLockRequestedEvent {
+  // run_id references the settlement run requesting the lock.
+  string run_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // account_id identifies the account to lock.
+  string account_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // instrument_code is the instrument to lock (optional, empty for all instruments).
+  string instrument_code = 3 [(buf.validate.field).string.max_len = 32];
+
+  // lock_duration_seconds is the maximum time to hold the lock.
+  int32 lock_duration_seconds = 4 [(buf.validate.field).int32 = {
+    gte: 1
+    lte: 300
+  }];
+
+  // correlation_id links related events across services.
+  string correlation_id = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // timestamp when the event was created.
+  google.protobuf.Timestamp timestamp = 6 [(buf.validate.field).required = true];
+}
+
+// DisputeCreatedEvent is published when a formal dispute is raised.
+message DisputeCreatedEvent {
+  // dispute_id uniquely identifies the dispute.
+  string dispute_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // variance_id references the variance being disputed.
+  string variance_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // run_id references the settlement run.
+  string run_id = 3 [(buf.validate.field).string.uuid = true];
+
+  // account_id identifies the account.
+  string account_id = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // reason describes why the variance is being disputed.
+  string reason = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 1000
+  }];
+
+  // raised_by identifies who raised the dispute.
+  string raised_by = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // correlation_id links related events across services.
+  string correlation_id = 7 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // timestamp when the event was created.
+  google.protobuf.Timestamp timestamp = 8 [(buf.validate.field).required = true];
+}
+
+// DisputeResolvedEvent is published when a dispute is resolved or rejected.
+message DisputeResolvedEvent {
+  // dispute_id uniquely identifies the dispute.
+  string dispute_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // variance_id references the variance that was disputed.
+  string variance_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // account_id identifies the account.
+  string account_id = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // outcome indicates the resolution (RESOLVED or REJECTED).
+  string outcome = 4 [(buf.validate.field).string = {
+    in: ["RESOLVED", "REJECTED"]
+  }];
+
+  // resolution describes the resolution details.
+  string resolution = 5 [(buf.validate.field).string.max_len = 1000];
+
+  // resolved_by identifies who resolved the dispute.
+  string resolved_by = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // correlation_id links related events across services.
+  string correlation_id = 7 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // timestamp when the event was created.
+  google.protobuf.Timestamp timestamp = 8 [(buf.validate.field).required = true];
+}
+
+// BalanceImbalanceDetectedEvent is published when a balance assertion fails.
+// This is a P1 alert event that requires immediate attention.
+message BalanceImbalanceDetectedEvent {
+  // assertion_id uniquely identifies the assertion that failed.
+  string assertion_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // account_id identifies the account with the imbalance.
+  string account_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // instrument_code identifies the asset type.
+  string instrument_code = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+  }];
+
+  // expected_balance as a decimal string.
+  string expected_balance = 4;
+
+  // actual_balance as a decimal string.
+  string actual_balance = 5;
+
+  // expression is the assertion rule that failed.
+  string expression = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 1000
+  }];
+
+  // failure_reason explains why the assertion failed.
+  string failure_reason = 7 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 1000
+  }];
+
+  // severity indicates the alert level (always P1 for balance imbalances).
+  string severity = 8 [(buf.validate.field).string = {
+    in: ["P1", "P2", "P3"]
+  }];
+
+  // run_id references the settlement run (optional, empty for standalone assertions).
+  string run_id = 9;
+
+  // correlation_id links related events across services.
+  string correlation_id = 10 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // timestamp when the event was created.
+  google.protobuf.Timestamp timestamp = 11 [(buf.validate.field).required = true];
+}

--- a/api/proto/meridian/events/v1/reconciliation_events.proto
+++ b/api/proto/meridian/events/v1/reconciliation_events.proto
@@ -286,7 +286,7 @@ message BalanceImbalanceDetectedEvent {
     max_len: 1000
   }];
 
-  // severity indicates the alert level (always P1 for balance imbalances).
+  // severity indicates the alert level (P1=critical imbalance, P2=threshold warning, P3=informational drift).
   string severity = 8 [(buf.validate.field).string = {
     in: ["P1", "P2", "P3"]
   }];

--- a/api/proto/meridian/reconciliation/v1/reconciliation.proto
+++ b/api/proto/meridian/reconciliation/v1/reconciliation.proto
@@ -377,7 +377,10 @@ message BalanceAssertionDetail {
   string assertion_id = 1 [(buf.validate.field).string.uuid = true];
 
   // run_id references the settlement run (optional, can be standalone).
-  string run_id = 2;
+  string run_id = 2 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string.uuid = true
+  ];
 
   // account_id identifies the primary account being asserted.
   string account_id = 3 [(buf.validate.field).string = {
@@ -632,7 +635,10 @@ message AssertBalanceRequest {
   ];
 
   // run_id links the assertion to a settlement run (optional).
-  string run_id = 5 [(buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE];
+  string run_id = 5 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string.uuid = true
+  ];
 
   // idempotency_key ensures exactly-once processing.
   meridian.common.v1.IdempotencyKey idempotency_key = 6;

--- a/api/proto/meridian/reconciliation/v1/reconciliation.proto
+++ b/api/proto/meridian/reconciliation/v1/reconciliation.proto
@@ -1,0 +1,840 @@
+syntax = "proto3";
+
+package meridian.reconciliation.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
+import "meridian/common/v1/types.proto";
+import "protoc-gen-openapiv2/options/annotations.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1;reconciliationv1";
+
+// OpenAPI specification metadata for Account Reconciliation Service
+option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+  info: {
+    title: "Meridian Account Reconciliation Service API"
+    version: "1.0"
+    description: "BIAN-compliant account reconciliation operations for settlement runs, "
+                 "variance detection, balance assertions, and dispute management."
+    contact: {
+      name: "Meridian API Team"
+      url: "https://github.com/meridianhub/meridian"
+    }
+    license: {
+      name: "Apache 2.0"
+      url: "https://www.apache.org/licenses/LICENSE-2.0"
+    }
+  }
+  schemes: HTTPS
+  consumes: "application/json"
+  produces: "application/json"
+  security_definitions: {
+    security: {
+      key: "Bearer"
+      value: {
+        type: TYPE_API_KEY
+        in: IN_HEADER
+        name: "Authorization"
+        description: "Bearer token authentication"
+      }
+    }
+  }
+  security: {
+    security_requirement: {
+      key: "Bearer"
+      value: {}
+    }
+  }
+};
+
+// ReconciliationScope defines what is being reconciled.
+enum ReconciliationScope {
+  // RECONCILIATION_SCOPE_UNSPECIFIED means the scope is unknown.
+  RECONCILIATION_SCOPE_UNSPECIFIED = 0;
+  // RECONCILIATION_SCOPE_ACCOUNT reconciles a single account.
+  RECONCILIATION_SCOPE_ACCOUNT = 1;
+  // RECONCILIATION_SCOPE_INSTRUMENT reconciles by instrument/asset type.
+  RECONCILIATION_SCOPE_INSTRUMENT = 2;
+  // RECONCILIATION_SCOPE_PORTFOLIO reconciles an entire portfolio.
+  RECONCILIATION_SCOPE_PORTFOLIO = 3;
+  // RECONCILIATION_SCOPE_FULL performs a full system reconciliation.
+  RECONCILIATION_SCOPE_FULL = 4;
+}
+
+// SettlementType defines the type of settlement being performed.
+enum SettlementType {
+  // SETTLEMENT_TYPE_UNSPECIFIED means the settlement type is unknown.
+  SETTLEMENT_TYPE_UNSPECIFIED = 0;
+  // SETTLEMENT_TYPE_DAILY is a daily settlement cycle.
+  SETTLEMENT_TYPE_DAILY = 1;
+  // SETTLEMENT_TYPE_WEEKLY is a weekly settlement cycle.
+  SETTLEMENT_TYPE_WEEKLY = 2;
+  // SETTLEMENT_TYPE_MONTHLY is a monthly settlement cycle.
+  SETTLEMENT_TYPE_MONTHLY = 3;
+  // SETTLEMENT_TYPE_ON_DEMAND is an ad-hoc settlement run.
+  SETTLEMENT_TYPE_ON_DEMAND = 4;
+  // SETTLEMENT_TYPE_END_OF_DAY is an end-of-day settlement.
+  SETTLEMENT_TYPE_END_OF_DAY = 5;
+  // SETTLEMENT_TYPE_REAL_TIME is a real-time settlement.
+  SETTLEMENT_TYPE_REAL_TIME = 6;
+}
+
+// RunStatus represents the current state of a settlement run.
+enum RunStatus {
+  // RUN_STATUS_UNSPECIFIED means the status is unknown.
+  RUN_STATUS_UNSPECIFIED = 0;
+  // RUN_STATUS_PENDING means the run has been created but not started.
+  RUN_STATUS_PENDING = 1;
+  // RUN_STATUS_RUNNING means the run is actively executing.
+  RUN_STATUS_RUNNING = 2;
+  // RUN_STATUS_COMPLETED means the run finished successfully.
+  RUN_STATUS_COMPLETED = 3;
+  // RUN_STATUS_FAILED means the run encountered an error.
+  RUN_STATUS_FAILED = 4;
+  // RUN_STATUS_CANCELLED means the run was cancelled.
+  RUN_STATUS_CANCELLED = 5;
+}
+
+// VarianceStatus represents the resolution state of a variance.
+enum VarianceStatus {
+  // VARIANCE_STATUS_UNSPECIFIED means the status is unknown.
+  VARIANCE_STATUS_UNSPECIFIED = 0;
+  // VARIANCE_STATUS_OPEN means the variance is newly detected.
+  VARIANCE_STATUS_OPEN = 1;
+  // VARIANCE_STATUS_INVESTIGATING means the variance is under investigation.
+  VARIANCE_STATUS_INVESTIGATING = 2;
+  // VARIANCE_STATUS_DISPUTED means a formal dispute has been raised.
+  VARIANCE_STATUS_DISPUTED = 3;
+  // VARIANCE_STATUS_RESOLVED means the variance has been resolved.
+  VARIANCE_STATUS_RESOLVED = 4;
+  // VARIANCE_STATUS_ACCEPTED means the variance is accepted as known.
+  VARIANCE_STATUS_ACCEPTED = 5;
+}
+
+// VarianceReason classifies the type of discrepancy.
+enum VarianceReason {
+  // VARIANCE_REASON_UNSPECIFIED means the reason is unknown.
+  VARIANCE_REASON_UNSPECIFIED = 0;
+  // VARIANCE_REASON_AMOUNT_MISMATCH means the amounts do not match.
+  VARIANCE_REASON_AMOUNT_MISMATCH = 1;
+  // VARIANCE_REASON_MISSING_ENTRY means a transaction is missing.
+  VARIANCE_REASON_MISSING_ENTRY = 2;
+  // VARIANCE_REASON_DUPLICATE_ENTRY means a duplicate transaction exists.
+  VARIANCE_REASON_DUPLICATE_ENTRY = 3;
+  // VARIANCE_REASON_TIMING_DIFFERENCE means transactions settled at different times.
+  VARIANCE_REASON_TIMING_DIFFERENCE = 4;
+  // VARIANCE_REASON_CURRENCY_MISMATCH means currencies do not match.
+  VARIANCE_REASON_CURRENCY_MISMATCH = 5;
+  // VARIANCE_REASON_DIRECTION_ERROR means debit/credit direction is incorrect.
+  VARIANCE_REASON_DIRECTION_ERROR = 6;
+  // VARIANCE_REASON_OTHER means an unclassified discrepancy.
+  VARIANCE_REASON_OTHER = 7;
+}
+
+// DisputeStatus represents the state of a formal dispute.
+enum DisputeStatus {
+  // DISPUTE_STATUS_UNSPECIFIED means the status is unknown.
+  DISPUTE_STATUS_UNSPECIFIED = 0;
+  // DISPUTE_STATUS_OPEN means the dispute has been raised.
+  DISPUTE_STATUS_OPEN = 1;
+  // DISPUTE_STATUS_UNDER_REVIEW means the dispute is being reviewed.
+  DISPUTE_STATUS_UNDER_REVIEW = 2;
+  // DISPUTE_STATUS_ESCALATED means the dispute has been escalated.
+  DISPUTE_STATUS_ESCALATED = 3;
+  // DISPUTE_STATUS_RESOLVED means the dispute has been resolved.
+  DISPUTE_STATUS_RESOLVED = 4;
+  // DISPUTE_STATUS_REJECTED means the dispute was rejected.
+  DISPUTE_STATUS_REJECTED = 5;
+}
+
+// AssertionStatus represents the result of a balance assertion.
+enum AssertionStatus {
+  // ASSERTION_STATUS_UNSPECIFIED means the status is unknown.
+  ASSERTION_STATUS_UNSPECIFIED = 0;
+  // ASSERTION_STATUS_PENDING means the assertion has not been evaluated.
+  ASSERTION_STATUS_PENDING = 1;
+  // ASSERTION_STATUS_PASSED means the assertion passed.
+  ASSERTION_STATUS_PASSED = 2;
+  // ASSERTION_STATUS_FAILED means the assertion failed.
+  ASSERTION_STATUS_FAILED = 3;
+  // ASSERTION_STATUS_OVERRIDE means a failed assertion was manually overridden.
+  ASSERTION_STATUS_OVERRIDE = 4;
+}
+
+// ControlAction defines the control actions available for settlement runs.
+enum ControlAction {
+  // CONTROL_ACTION_UNSPECIFIED means the action is unknown.
+  CONTROL_ACTION_UNSPECIFIED = 0;
+  // CONTROL_ACTION_CANCEL cancels a running or pending settlement run.
+  CONTROL_ACTION_CANCEL = 1;
+  // CONTROL_ACTION_PAUSE pauses a running settlement run.
+  CONTROL_ACTION_PAUSE = 2;
+  // CONTROL_ACTION_RESUME resumes a paused settlement run.
+  CONTROL_ACTION_RESUME = 3;
+}
+
+// DisputeControlAction defines the control actions for disputes.
+enum DisputeControlAction {
+  // DISPUTE_CONTROL_ACTION_UNSPECIFIED means the action is unknown.
+  DISPUTE_CONTROL_ACTION_UNSPECIFIED = 0;
+  // DISPUTE_CONTROL_ACTION_ESCALATE escalates a dispute.
+  DISPUTE_CONTROL_ACTION_ESCALATE = 1;
+  // DISPUTE_CONTROL_ACTION_RESOLVE resolves a dispute.
+  DISPUTE_CONTROL_ACTION_RESOLVE = 2;
+  // DISPUTE_CONTROL_ACTION_REJECT rejects a dispute.
+  DISPUTE_CONTROL_ACTION_REJECT = 3;
+}
+
+// SettlementRunSummary provides summary information about a settlement run.
+// Used in Retrieve responses - does NOT include detailed variance lists.
+message SettlementRunSummary {
+  // run_id is the unique identifier for this settlement run.
+  string run_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // account_id identifies the primary account being reconciled.
+  string account_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // scope defines what is being reconciled.
+  ReconciliationScope scope = 3 [(buf.validate.field).enum.defined_only = true];
+
+  // settlement_type defines the type of settlement.
+  SettlementType settlement_type = 4 [(buf.validate.field).enum.defined_only = true];
+
+  // status is the current state of the run.
+  RunStatus status = 5 [(buf.validate.field).enum.defined_only = true];
+
+  // period_start is the beginning of the reconciliation period.
+  google.protobuf.Timestamp period_start = 6 [(buf.validate.field).required = true];
+
+  // period_end is the end of the reconciliation period.
+  google.protobuf.Timestamp period_end = 7 [(buf.validate.field).required = true];
+
+  // initiated_by is the user or system that started the run.
+  string initiated_by = 8 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // completed_at is when the run finished (empty if still in progress).
+  google.protobuf.Timestamp completed_at = 9;
+
+  // variance_count is the number of variances detected.
+  int32 variance_count = 10 [(buf.validate.field).int32.gte = 0];
+
+  // total_variance is the sum of absolute variance amounts as a decimal string.
+  string total_variance = 11 [(buf.validate.field).string = {
+    max_len: 50
+    pattern: "^-?\\d+(\\.\\d+)?$"
+  }];
+
+  // snapshot_count is the number of balance snapshots captured.
+  int32 snapshot_count = 12 [(buf.validate.field).int32.gte = 0];
+
+  // failure_reason records why the run failed (empty if not failed).
+  string failure_reason = 13 [(buf.validate.field).string.max_len = 1000];
+
+  // attributes stores flexible metadata.
+  map<string, string> attributes = 14;
+
+  // created_at is when this record was created.
+  google.protobuf.Timestamp created_at = 15 [(buf.validate.field).required = true];
+
+  // updated_at is when this record was last updated.
+  google.protobuf.Timestamp updated_at = 16 [(buf.validate.field).required = true];
+
+  // version is used for optimistic concurrency control.
+  int64 version = 17 [(buf.validate.field).int64.gte = 0];
+}
+
+// VarianceDetail provides detailed information about a single variance.
+message VarianceDetail {
+  // variance_id is the unique identifier for this variance.
+  string variance_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // run_id references the settlement run that detected this variance.
+  string run_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // snapshot_id references the snapshot where the variance was found.
+  string snapshot_id = 3 [(buf.validate.field).string.uuid = true];
+
+  // account_id identifies the account with the discrepancy.
+  string account_id = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // instrument_code identifies the asset type.
+  string instrument_code = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // expected_amount is the expected balance as a decimal string.
+  string expected_amount = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^-?\\d+(\\.\\d+)?$"
+  }];
+
+  // actual_amount is the actual balance as a decimal string.
+  string actual_amount = 7 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^-?\\d+(\\.\\d+)?$"
+  }];
+
+  // variance_amount is the difference (actual - expected) as a decimal string.
+  string variance_amount = 8 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^-?\\d+(\\.\\d+)?$"
+  }];
+
+  // reason classifies the type of discrepancy.
+  VarianceReason reason = 9 [(buf.validate.field).enum.defined_only = true];
+
+  // status is the resolution state.
+  VarianceStatus status = 10 [(buf.validate.field).enum.defined_only = true];
+
+  // resolution_note records how the variance was resolved.
+  string resolution_note = 11 [(buf.validate.field).string.max_len = 1000];
+
+  // resolved_by records who resolved the variance.
+  string resolved_by = 12 [(buf.validate.field).string.max_len = 255];
+
+  // resolved_at records when the variance was resolved.
+  google.protobuf.Timestamp resolved_at = 13;
+
+  // attributes stores flexible metadata.
+  map<string, string> attributes = 14;
+
+  // created_at is when this variance was detected.
+  google.protobuf.Timestamp created_at = 15 [(buf.validate.field).required = true];
+
+  // updated_at is when this record was last updated.
+  google.protobuf.Timestamp updated_at = 16 [(buf.validate.field).required = true];
+}
+
+// DisputeDetail provides information about a formal dispute.
+message DisputeDetail {
+  // dispute_id is the unique identifier for this dispute.
+  string dispute_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // variance_id references the variance being disputed.
+  string variance_id = 2 [(buf.validate.field).string.uuid = true];
+
+  // run_id references the settlement run.
+  string run_id = 3 [(buf.validate.field).string.uuid = true];
+
+  // account_id identifies the account.
+  string account_id = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // status is the current state of the dispute.
+  DisputeStatus status = 5 [(buf.validate.field).enum.defined_only = true];
+
+  // reason describes why the variance is being disputed.
+  string reason = 6 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 1000
+  }];
+
+  // resolution records how the dispute was resolved.
+  string resolution = 7 [(buf.validate.field).string.max_len = 1000];
+
+  // raised_by records who raised the dispute.
+  string raised_by = 8 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // resolved_by records who resolved the dispute.
+  string resolved_by = 9 [(buf.validate.field).string.max_len = 255];
+
+  // resolved_at records when the dispute was resolved.
+  google.protobuf.Timestamp resolved_at = 10;
+
+  // attributes stores flexible metadata.
+  map<string, string> attributes = 11;
+
+  // created_at is when this dispute was raised.
+  google.protobuf.Timestamp created_at = 12 [(buf.validate.field).required = true];
+
+  // updated_at is when this record was last updated.
+  google.protobuf.Timestamp updated_at = 13 [(buf.validate.field).required = true];
+}
+
+// BalanceAssertionDetail provides information about a balance assertion.
+message BalanceAssertionDetail {
+  // assertion_id is the unique identifier for this assertion.
+  string assertion_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // run_id references the settlement run (optional, can be standalone).
+  string run_id = 2;
+
+  // account_id identifies the primary account being asserted.
+  string account_id = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // instrument_code identifies the asset type being asserted.
+  string instrument_code = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+    pattern: "^[A-Z][A-Z0-9_]*$"
+  }];
+
+  // expression is the assertion rule (e.g., a CEL expression).
+  string expression = 5 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 1000
+  }];
+
+  // expected_balance is the expected balance value as a decimal string.
+  string expected_balance = 6 [(buf.validate.field).string = {
+    max_len: 50
+    pattern: "^-?\\d+(\\.\\d+)?$"
+  }];
+
+  // actual_balance is the computed actual balance as a decimal string.
+  string actual_balance = 7 [(buf.validate.field).string = {
+    max_len: 50
+    pattern: "^-?\\d+(\\.\\d+)?$"
+  }];
+
+  // status is the assertion result.
+  AssertionStatus status = 8 [(buf.validate.field).enum.defined_only = true];
+
+  // failure_reason records why the assertion failed (if applicable).
+  string failure_reason = 9 [(buf.validate.field).string.max_len = 1000];
+
+  // override_reason records why a failed assertion was overridden.
+  string override_reason = 10 [(buf.validate.field).string.max_len = 1000];
+
+  // asserted_at is when the assertion was evaluated.
+  google.protobuf.Timestamp asserted_at = 11;
+
+  // created_at is when this record was created.
+  google.protobuf.Timestamp created_at = 12 [(buf.validate.field).required = true];
+}
+
+// --- Initiate: Start a new settlement run ---
+
+// InitiateAccountReconciliationRequest starts a new settlement run.
+message InitiateAccountReconciliationRequest {
+  // account_id identifies the primary account to reconcile.
+  string account_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 255
+      pattern: "^[a-zA-Z0-9_-]+$"
+    }
+  ];
+
+  // scope defines what is being reconciled.
+  ReconciliationScope scope = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // settlement_type defines the type of settlement.
+  SettlementType settlement_type = 3 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // period_start is the beginning of the reconciliation period.
+  google.protobuf.Timestamp period_start = 4 [(buf.validate.field).required = true];
+
+  // period_end is the end of the reconciliation period.
+  google.protobuf.Timestamp period_end = 5 [(buf.validate.field).required = true];
+
+  // initiated_by is the user or system starting the run.
+  string initiated_by = 6 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 255
+    }
+  ];
+
+  // instrument_code filters reconciliation to a specific instrument (optional).
+  string instrument_code = 7 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string = {
+      max_len: 32
+      pattern: "^[A-Z][A-Z0-9_]*$"
+    }
+  ];
+
+  // attributes stores flexible metadata for this run.
+  map<string, string> attributes = 8 [(buf.validate.field).map.max_pairs = 50];
+
+  // idempotency_key ensures exactly-once processing.
+  meridian.common.v1.IdempotencyKey idempotency_key = 9;
+}
+
+// InitiateAccountReconciliationResponse returns the created settlement run.
+message InitiateAccountReconciliationResponse {
+  // run is the created settlement run summary.
+  SettlementRunSummary run = 1 [(buf.validate.field).required = true];
+}
+
+// --- Execute: Trigger execution of a pending settlement run ---
+
+// ExecuteAccountReconciliationRequest triggers a pending settlement run.
+message ExecuteAccountReconciliationRequest {
+  // run_id is the identifier of the settlement run to execute.
+  string run_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+}
+
+// ExecuteAccountReconciliationResponse returns the run after execution begins.
+message ExecuteAccountReconciliationResponse {
+  // run is the settlement run summary after execution started.
+  SettlementRunSummary run = 1 [(buf.validate.field).required = true];
+}
+
+// --- Retrieve: Get summary of a settlement run ---
+
+// RetrieveAccountReconciliationRequest retrieves a settlement run summary.
+message RetrieveAccountReconciliationRequest {
+  // run_id is the identifier of the settlement run to retrieve.
+  string run_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+}
+
+// RetrieveAccountReconciliationResponse returns summary data only.
+// For detailed variance lists, use ListReconciliationResults with pagination.
+message RetrieveAccountReconciliationResponse {
+  // run is the settlement run summary.
+  SettlementRunSummary run = 1 [(buf.validate.field).required = true];
+}
+
+// --- Control: Cancel, pause, or resume a settlement run ---
+
+// ControlAccountReconciliationRequest controls a settlement run lifecycle.
+message ControlAccountReconciliationRequest {
+  // run_id is the identifier of the settlement run to control.
+  string run_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // action is the control action to perform.
+  ControlAction action = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // reason provides context for the control action.
+  string reason = 3 [(buf.validate.field).string.max_len = 500];
+}
+
+// ControlAccountReconciliationResponse returns the run after the control action.
+message ControlAccountReconciliationResponse {
+  // run is the settlement run summary after the control action.
+  SettlementRunSummary run = 1 [(buf.validate.field).required = true];
+}
+
+// --- ListReconciliationResults: Paginated variance list ---
+
+// ListReconciliationResultsRequest retrieves detailed variance results with pagination.
+message ListReconciliationResultsRequest {
+  // run_id is the identifier of the settlement run to list results for.
+  string run_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // page_size is the maximum number of results to return (default: 50, max: 1000).
+  int32 page_size = 2 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 1000
+  }];
+
+  // page_token is an opaque cursor for fetching the next page.
+  string page_token = 3;
+
+  // filter_status filters results by variance status (optional).
+  VarianceStatus filter_status = 4;
+
+  // filter_reason filters results by variance reason (optional).
+  VarianceReason filter_reason = 5;
+}
+
+// ListReconciliationResultsResponse returns paginated variance details.
+message ListReconciliationResultsResponse {
+  // variances are the matching variance details.
+  repeated VarianceDetail variances = 1;
+
+  // next_page_token is the cursor for fetching the next page (empty if last page).
+  string next_page_token = 2;
+
+  // total_count is the total number of variances for this run (-1 if unknown).
+  int64 total_count = 3;
+}
+
+// --- Balance Assertion ---
+
+// AssertBalanceRequest evaluates a balance assertion.
+message AssertBalanceRequest {
+  // account_id identifies the account to assert.
+  string account_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 255
+      pattern: "^[a-zA-Z0-9_-]+$"
+    }
+  ];
+
+  // instrument_code identifies the asset type to assert.
+  string instrument_code = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 32
+      pattern: "^[A-Z][A-Z0-9_]*$"
+    }
+  ];
+
+  // expression is the assertion rule (e.g., a CEL expression).
+  string expression = 3 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 1000
+    }
+  ];
+
+  // expected_balance is the expected balance value as a decimal string.
+  string expected_balance = 4 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 50
+      pattern: "^-?\\d+(\\.\\d+)?$"
+    }
+  ];
+
+  // run_id links the assertion to a settlement run (optional).
+  string run_id = 5 [(buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE];
+
+  // idempotency_key ensures exactly-once processing.
+  meridian.common.v1.IdempotencyKey idempotency_key = 6;
+}
+
+// AssertBalanceResponse returns the assertion result.
+message AssertBalanceResponse {
+  // assertion is the evaluated balance assertion.
+  BalanceAssertionDetail assertion = 1 [(buf.validate.field).required = true];
+}
+
+// --- Dispute Management ---
+
+// InitiateDisputeRequest raises a formal dispute against a variance.
+message InitiateDisputeRequest {
+  // variance_id references the variance being disputed.
+  string variance_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // run_id references the settlement run.
+  string run_id = 2 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // account_id identifies the account.
+  string account_id = 3 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 255
+      pattern: "^[a-zA-Z0-9_-]+$"
+    }
+  ];
+
+  // reason describes why the variance is being disputed.
+  string reason = 4 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 1000
+    }
+  ];
+
+  // raised_by identifies who is raising the dispute.
+  string raised_by = 5 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string = {
+      min_len: 1
+      max_len: 255
+    }
+  ];
+
+  // attributes stores flexible metadata.
+  map<string, string> attributes = 6 [(buf.validate.field).map.max_pairs = 50];
+
+  // idempotency_key ensures exactly-once processing.
+  meridian.common.v1.IdempotencyKey idempotency_key = 7;
+}
+
+// InitiateDisputeResponse returns the created dispute.
+message InitiateDisputeResponse {
+  // dispute is the created dispute.
+  DisputeDetail dispute = 1 [(buf.validate.field).required = true];
+}
+
+// ControlDisputeRequest controls a dispute lifecycle.
+message ControlDisputeRequest {
+  // dispute_id is the identifier of the dispute to control.
+  string dispute_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // action is the control action to perform.
+  DisputeControlAction action = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // resolution provides details for resolve/reject actions.
+  string resolution = 3 [(buf.validate.field).string.max_len = 1000];
+
+  // resolved_by identifies who is resolving/rejecting the dispute.
+  string resolved_by = 4 [(buf.validate.field).string.max_len = 255];
+}
+
+// ControlDisputeResponse returns the dispute after the control action.
+message ControlDisputeResponse {
+  // dispute is the dispute after the control action.
+  DisputeDetail dispute = 1 [(buf.validate.field).required = true];
+}
+
+// RetrieveDisputeRequest retrieves a dispute by ID.
+message RetrieveDisputeRequest {
+  // dispute_id is the identifier of the dispute to retrieve.
+  string dispute_id = 1 [
+    (buf.validate.field).required = true,
+    (buf.validate.field).string.uuid = true
+  ];
+}
+
+// RetrieveDisputeResponse returns the requested dispute.
+message RetrieveDisputeResponse {
+  // dispute is the requested dispute.
+  DisputeDetail dispute = 1 [(buf.validate.field).required = true];
+}
+
+// AccountReconciliationService provides BIAN-compliant reconciliation operations.
+service AccountReconciliationService {
+  // InitiateAccountReconciliation creates a new settlement run.
+  rpc InitiateAccountReconciliation(InitiateAccountReconciliationRequest) returns (InitiateAccountReconciliationResponse) {
+    option (google.api.http) = {
+      post: "/v1/reconciliation/runs"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "201"
+        value: {
+          description: "Settlement run created successfully"
+        }
+      }
+    };
+  }
+
+  // ExecuteAccountReconciliation triggers execution of a pending settlement run.
+  rpc ExecuteAccountReconciliation(ExecuteAccountReconciliationRequest) returns (ExecuteAccountReconciliationResponse) {
+    option (google.api.http) = {
+      post: "/v1/reconciliation/runs/{run_id}/execute"
+      body: "*"
+    };
+  }
+
+  // RetrieveAccountReconciliation retrieves a settlement run summary.
+  rpc RetrieveAccountReconciliation(RetrieveAccountReconciliationRequest) returns (RetrieveAccountReconciliationResponse) {
+    option (google.api.http) = {
+      get: "/v1/reconciliation/runs/{run_id}"
+    };
+  }
+
+  // ControlAccountReconciliation controls a settlement run (cancel, pause, resume).
+  rpc ControlAccountReconciliation(ControlAccountReconciliationRequest) returns (ControlAccountReconciliationResponse) {
+    option (google.api.http) = {
+      post: "/v1/reconciliation/runs/{run_id}/control"
+      body: "*"
+    };
+  }
+
+  // ListReconciliationResults returns paginated variance details for a run.
+  rpc ListReconciliationResults(ListReconciliationResultsRequest) returns (ListReconciliationResultsResponse) {
+    option (google.api.http) = {
+      get: "/v1/reconciliation/runs/{run_id}/results"
+    };
+  }
+
+  // AssertBalance evaluates a balance assertion against current positions.
+  rpc AssertBalance(AssertBalanceRequest) returns (AssertBalanceResponse) {
+    option (google.api.http) = {
+      post: "/v1/reconciliation/assertions"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "201"
+        value: {
+          description: "Balance assertion evaluated successfully"
+        }
+      }
+    };
+  }
+
+  // InitiateDispute raises a formal dispute against a variance.
+  rpc InitiateDispute(InitiateDisputeRequest) returns (InitiateDisputeResponse) {
+    option (google.api.http) = {
+      post: "/v1/reconciliation/disputes"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "201"
+        value: {
+          description: "Dispute created successfully"
+        }
+      }
+    };
+  }
+
+  // ControlDispute controls a dispute lifecycle (escalate, resolve, reject).
+  rpc ControlDispute(ControlDisputeRequest) returns (ControlDisputeResponse) {
+    option (google.api.http) = {
+      post: "/v1/reconciliation/disputes/{dispute_id}/control"
+      body: "*"
+    };
+  }
+
+  // RetrieveDispute retrieves a dispute by ID.
+  rpc RetrieveDispute(RetrieveDisputeRequest) returns (RetrieveDisputeResponse) {
+    option (google.api.http) = {
+      get: "/v1/reconciliation/disputes/{dispute_id}"
+    };
+  }
+}

--- a/services/current-account/service/saga_handlers.go
+++ b/services/current-account/service/saga_handlers.go
@@ -118,6 +118,14 @@ func RegisterCurrentAccountHandlers(registry *saga.HandlerRegistry) error {
 		{"payment_order.terminate_lien", stubNotImplemented("payment_order.terminate_lien")},
 		{"repository.save", stubNotImplemented("repository.save")},
 		{"valuation_engine.valuate", stubNotImplemented("valuation_engine.valuate")},
+
+		// Reconciliation handlers (stubs - defined in schema for reconciliation service)
+		{"reconciliation.initiate_run", stubNotImplemented("reconciliation.initiate_run")},
+		{"reconciliation.execute_run", stubNotImplemented("reconciliation.execute_run")},
+		{"reconciliation.retrieve_run", stubNotImplemented("reconciliation.retrieve_run")},
+		{"reconciliation.cancel_run", stubNotImplemented("reconciliation.cancel_run")},
+		{"reconciliation.assert_balance", stubNotImplemented("reconciliation.assert_balance")},
+		{"reconciliation.initiate_dispute", stubNotImplemented("reconciliation.initiate_dispute")},
 	}
 
 	for _, h := range handlers {

--- a/services/reconciliation/client/client.go
+++ b/services/reconciliation/client/client.go
@@ -1,0 +1,391 @@
+// Package client provides a gRPC client for the AccountReconciliation service.
+//
+// The AccountReconciliation service manages settlement runs, variance detection,
+// balance assertions, and dispute management. This client enables inter-service
+// communication with proper context propagation, tracing, and resilience patterns.
+//
+// Usage with Kubernetes DNS-based load balancing (recommended for production):
+//
+//	client, cleanup, err := client.New(client.Config{
+//	    ServiceName: "reconciliation",
+//	    Namespace:   "default",
+//	    Port:        50058,
+//	    Tracer:      tracer,
+//	})
+//	if err != nil {
+//	    return err
+//	}
+//	defer cleanup()
+//
+// Usage with direct connection (for local development):
+//
+//	client, cleanup, err := client.New(client.Config{
+//	    Target:  "localhost:50058",
+//	    Timeout: 30 * time.Second,
+//	})
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
+	"github.com/meridianhub/meridian/shared/platform/observability"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	// DefaultPort is the default gRPC port for the AccountReconciliation service.
+	DefaultPort = 50058
+
+	// DefaultTimeout is the default timeout for gRPC calls.
+	DefaultTimeout = 30 * time.Second
+
+	// DefaultNamespace is the default Kubernetes namespace.
+	DefaultNamespace = "default"
+
+	// ServiceName is the Kubernetes service name for AccountReconciliation.
+	ServiceName = "reconciliation"
+)
+
+// ErrTargetRequired is returned when neither Target nor ServiceName is provided.
+var ErrTargetRequired = errors.New("either Target or ServiceName must be provided")
+
+// Config holds configuration for the AccountReconciliation client.
+type Config struct {
+	// Target is the gRPC server address (e.g., "localhost:50058" or "reconciliation:50058").
+	// If set, overrides Kubernetes DNS-based discovery.
+	Target string
+
+	// ServiceName is the Kubernetes service name (e.g., "reconciliation").
+	// When specified, enables DNS-based client-side load balancing via pkg/platform/grpc.
+	ServiceName string
+
+	// Namespace is the Kubernetes namespace (e.g., "default", "production").
+	// Defaults to "default" if not specified.
+	Namespace string
+
+	// Port is the service port number.
+	// Defaults to 50058 if not specified.
+	Port int
+
+	// Timeout is the default timeout for RPC calls.
+	// Defaults to 30 seconds if not specified.
+	Timeout time.Duration
+
+	// Tracer is an optional observability tracer for distributed tracing.
+	Tracer *observability.Tracer
+
+	// Resilience is an optional configuration for circuit breaker and retry.
+	Resilience *clients.ResilientClientConfig
+
+	// DialOptions allows custom gRPC dial options.
+	DialOptions []grpc.DialOption
+}
+
+// Client provides access to the AccountReconciliation service.
+type Client struct {
+	conn           *grpc.ClientConn
+	reconciliation reconciliationv1.AccountReconciliationServiceClient
+	tracer         *observability.Tracer
+	resilient      *clients.ResilientClient
+	timeout        time.Duration
+}
+
+// New creates a new AccountReconciliation gRPC client.
+//
+// Returns the client, a cleanup function to close the connection, and any error.
+// The cleanup function should be deferred immediately after checking the error.
+func New(cfg Config) (*Client, func(), error) {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+	if cfg.Port == 0 {
+		cfg.Port = DefaultPort
+	}
+	if cfg.Namespace == "" {
+		cfg.Namespace = DefaultNamespace
+	}
+
+	var conn *grpc.ClientConn
+	var err error
+
+	if cfg.ServiceName != "" {
+		dialOpts := cfg.DialOptions
+		if cfg.Tracer != nil {
+			dialOpts = append(dialOpts,
+				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
+				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
+			)
+		}
+
+		conn, err = platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
+			ServiceName: cfg.ServiceName,
+			Namespace:   cfg.Namespace,
+			Port:        cfg.Port,
+			DialOptions: dialOpts,
+		})
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create reconciliation gRPC connection via platform factory: %w", err)
+		}
+	} else if cfg.Target != "" {
+		dialOpts := cfg.DialOptions
+		if dialOpts == nil {
+			dialOpts = []grpc.DialOption{
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			}
+		}
+		if cfg.Tracer != nil {
+			dialOpts = append(dialOpts,
+				grpc.WithChainUnaryInterceptor(cfg.Tracer.UnaryClientInterceptor()),
+				grpc.WithChainStreamInterceptor(cfg.Tracer.StreamClientInterceptor()),
+			)
+		}
+
+		conn, err = grpc.NewClient(cfg.Target, dialOpts...)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create reconciliation gRPC connection to %s: %w", cfg.Target, err)
+		}
+	} else {
+		return nil, nil, ErrTargetRequired
+	}
+
+	var resilient *clients.ResilientClient
+	if cfg.Resilience != nil {
+		resilient = clients.NewResilientClient(*cfg.Resilience)
+	}
+
+	client := &Client{
+		conn:           conn,
+		reconciliation: reconciliationv1.NewAccountReconciliationServiceClient(conn),
+		tracer:         cfg.Tracer,
+		resilient:      resilient,
+		timeout:        cfg.Timeout,
+	}
+
+	cleanup := func() {
+		if client.conn != nil {
+			_ = client.conn.Close()
+		}
+	}
+
+	return client, cleanup, nil
+}
+
+// InitiateAccountReconciliation creates a new settlement run.
+// This is a non-idempotent operation, so it uses circuit breaker without retry.
+func (c *Client) InitiateAccountReconciliation(ctx context.Context, req *reconciliationv1.InitiateAccountReconciliationRequest) (*reconciliationv1.InitiateAccountReconciliationResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "InitiateAccountReconciliation", func() (*reconciliationv1.InitiateAccountReconciliationResponse, error) {
+			return c.reconciliation.InitiateAccountReconciliation(ctx, req)
+		})
+	}
+
+	resp, err := c.reconciliation.InitiateAccountReconciliation(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initiate account reconciliation: %w", err)
+	}
+	return resp, nil
+}
+
+// ExecuteAccountReconciliation triggers execution of a pending settlement run.
+// This is a non-idempotent operation, so it uses circuit breaker without retry.
+func (c *Client) ExecuteAccountReconciliation(ctx context.Context, req *reconciliationv1.ExecuteAccountReconciliationRequest) (*reconciliationv1.ExecuteAccountReconciliationResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "ExecuteAccountReconciliation", func() (*reconciliationv1.ExecuteAccountReconciliationResponse, error) {
+			return c.reconciliation.ExecuteAccountReconciliation(ctx, req)
+		})
+	}
+
+	resp, err := c.reconciliation.ExecuteAccountReconciliation(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute account reconciliation: %w", err)
+	}
+	return resp, nil
+}
+
+// RetrieveAccountReconciliation retrieves a settlement run summary.
+// This is an idempotent read operation, so it uses circuit breaker with retry.
+func (c *Client) RetrieveAccountReconciliation(ctx context.Context, req *reconciliationv1.RetrieveAccountReconciliationRequest) (*reconciliationv1.RetrieveAccountReconciliationResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "RetrieveAccountReconciliation", func() (*reconciliationv1.RetrieveAccountReconciliationResponse, error) {
+			return c.reconciliation.RetrieveAccountReconciliation(ctx, req)
+		})
+	}
+
+	resp, err := c.reconciliation.RetrieveAccountReconciliation(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve account reconciliation: %w", err)
+	}
+	return resp, nil
+}
+
+// ControlAccountReconciliation controls a settlement run (cancel, pause, resume).
+// This is a non-idempotent operation, so it uses circuit breaker without retry.
+func (c *Client) ControlAccountReconciliation(ctx context.Context, req *reconciliationv1.ControlAccountReconciliationRequest) (*reconciliationv1.ControlAccountReconciliationResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "ControlAccountReconciliation", func() (*reconciliationv1.ControlAccountReconciliationResponse, error) {
+			return c.reconciliation.ControlAccountReconciliation(ctx, req)
+		})
+	}
+
+	resp, err := c.reconciliation.ControlAccountReconciliation(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to control account reconciliation: %w", err)
+	}
+	return resp, nil
+}
+
+// ListReconciliationResults returns paginated variance details for a run.
+// This is an idempotent read operation, so it uses circuit breaker with retry.
+func (c *Client) ListReconciliationResults(ctx context.Context, req *reconciliationv1.ListReconciliationResultsRequest) (*reconciliationv1.ListReconciliationResultsResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "ListReconciliationResults", func() (*reconciliationv1.ListReconciliationResultsResponse, error) {
+			return c.reconciliation.ListReconciliationResults(ctx, req)
+		})
+	}
+
+	resp, err := c.reconciliation.ListReconciliationResults(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list reconciliation results: %w", err)
+	}
+	return resp, nil
+}
+
+// AssertBalance evaluates a balance assertion against current positions.
+// This is a non-idempotent operation, so it uses circuit breaker without retry.
+func (c *Client) AssertBalance(ctx context.Context, req *reconciliationv1.AssertBalanceRequest) (*reconciliationv1.AssertBalanceResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "AssertBalance", func() (*reconciliationv1.AssertBalanceResponse, error) {
+			return c.reconciliation.AssertBalance(ctx, req)
+		})
+	}
+
+	resp, err := c.reconciliation.AssertBalance(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to assert balance: %w", err)
+	}
+	return resp, nil
+}
+
+// InitiateDispute raises a formal dispute against a variance.
+// This is a non-idempotent operation, so it uses circuit breaker without retry.
+func (c *Client) InitiateDispute(ctx context.Context, req *reconciliationv1.InitiateDisputeRequest) (*reconciliationv1.InitiateDisputeResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "InitiateDispute", func() (*reconciliationv1.InitiateDisputeResponse, error) {
+			return c.reconciliation.InitiateDispute(ctx, req)
+		})
+	}
+
+	resp, err := c.reconciliation.InitiateDispute(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initiate dispute: %w", err)
+	}
+	return resp, nil
+}
+
+// ControlDispute controls a dispute lifecycle (escalate, resolve, reject).
+// This is a non-idempotent operation, so it uses circuit breaker without retry.
+func (c *Client) ControlDispute(ctx context.Context, req *reconciliationv1.ControlDisputeRequest) (*reconciliationv1.ControlDisputeResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "ControlDispute", func() (*reconciliationv1.ControlDisputeResponse, error) {
+			return c.reconciliation.ControlDispute(ctx, req)
+		})
+	}
+
+	resp, err := c.reconciliation.ControlDispute(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to control dispute: %w", err)
+	}
+	return resp, nil
+}
+
+// RetrieveDispute retrieves a dispute by ID.
+// This is an idempotent read operation, so it uses circuit breaker with retry.
+func (c *Client) RetrieveDispute(ctx context.Context, req *reconciliationv1.RetrieveDisputeRequest) (*reconciliationv1.RetrieveDisputeResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "RetrieveDispute", func() (*reconciliationv1.RetrieveDisputeResponse, error) {
+			return c.reconciliation.RetrieveDispute(ctx, req)
+		})
+	}
+
+	resp, err := c.reconciliation.RetrieveDispute(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve dispute: %w", err)
+	}
+	return resp, nil
+}
+
+// Close terminates the gRPC connection gracefully.
+func (c *Client) Close() error {
+	if c.conn != nil {
+		if err := c.conn.Close(); err != nil {
+			return fmt.Errorf("failed to close reconciliation client connection: %w", err)
+		}
+	}
+	return nil
+}
+
+// Conn returns the underlying gRPC connection for creating additional clients.
+func (c *Client) Conn() *grpc.ClientConn {
+	return c.conn
+}

--- a/services/reconciliation/client/client_test.go
+++ b/services/reconciliation/client/client_test.go
@@ -1,0 +1,146 @@
+package client_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/client"
+)
+
+// mockReconciliationServer implements the AccountReconciliationServiceServer for testing.
+type mockReconciliationServer struct {
+	reconciliationv1.UnimplementedAccountReconciliationServiceServer
+
+	initiateResp *reconciliationv1.InitiateAccountReconciliationResponse
+	initiateErr  error
+
+	retrieveResp *reconciliationv1.RetrieveAccountReconciliationResponse
+	retrieveErr  error
+}
+
+func (m *mockReconciliationServer) InitiateAccountReconciliation(
+	_ context.Context,
+	_ *reconciliationv1.InitiateAccountReconciliationRequest,
+) (*reconciliationv1.InitiateAccountReconciliationResponse, error) {
+	if m.initiateErr != nil {
+		return nil, m.initiateErr
+	}
+	return m.initiateResp, nil
+}
+
+func (m *mockReconciliationServer) RetrieveAccountReconciliation(
+	_ context.Context,
+	_ *reconciliationv1.RetrieveAccountReconciliationRequest,
+) (*reconciliationv1.RetrieveAccountReconciliationResponse, error) {
+	if m.retrieveErr != nil {
+		return nil, m.retrieveErr
+	}
+	return m.retrieveResp, nil
+}
+
+func setupTestServer(t *testing.T, mock *mockReconciliationServer) (client.Config, func()) {
+	t.Helper()
+
+	var lc net.ListenConfig
+	lis, err := lc.Listen(context.Background(), "tcp", "localhost:0")
+	require.NoError(t, err)
+
+	grpcServer := grpc.NewServer()
+	reconciliationv1.RegisterAccountReconciliationServiceServer(grpcServer, mock)
+
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			t.Logf("gRPC server error: %v", err)
+		}
+	}()
+
+	cleanup := func() {
+		grpcServer.GracefulStop()
+	}
+
+	return client.Config{
+		Target:  lis.Addr().String(),
+		Timeout: 5 * time.Second,
+		DialOptions: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		},
+	}, cleanup
+}
+
+func TestNew_RequiresTarget(t *testing.T) {
+	_, _, err := client.New(client.Config{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, client.ErrTargetRequired)
+}
+
+func TestNew_DirectConnection(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+	require.NotNil(t, c)
+}
+
+func TestInitiateAccountReconciliation_Unimplemented(t *testing.T) {
+	mock := &mockReconciliationServer{
+		initiateErr: status.Error(codes.Unimplemented, "not implemented"),
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.InitiateAccountReconciliation(context.Background(), &reconciliationv1.InitiateAccountReconciliationRequest{})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to initiate account reconciliation")
+}
+
+func TestRetrieveAccountReconciliation_NotFound(t *testing.T) {
+	mock := &mockReconciliationServer{
+		retrieveErr: status.Error(codes.NotFound, "run not found"),
+	}
+
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, clientCleanup, err := client.New(cfg)
+	require.NoError(t, err)
+	defer clientCleanup()
+
+	resp, err := c.RetrieveAccountReconciliation(context.Background(), &reconciliationv1.RetrieveAccountReconciliationRequest{
+		RunId: "00000000-0000-0000-0000-000000000001",
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "failed to retrieve account reconciliation")
+}
+
+func TestClose(t *testing.T) {
+	mock := &mockReconciliationServer{}
+	cfg, cleanup := setupTestServer(t, mock)
+	defer cleanup()
+
+	c, _, err := client.New(cfg)
+	require.NoError(t, err)
+
+	err = c.Close()
+	assert.NoError(t, err)
+}

--- a/services/reconciliation/client/starlark.go
+++ b/services/reconciliation/client/starlark.go
@@ -1,0 +1,398 @@
+// Package client provides Starlark service bindings for Account Reconciliation.
+// These handlers adapt the Starlark interface (map[string]any) to gRPC client calls,
+// enabling saga step execution with real Reconciliation service integration.
+package client
+
+import (
+	"context"
+	"fmt"
+
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+// RegisterStarlarkHandlers registers all Starlark service bindings for Account Reconciliation.
+// These handlers adapt the Starlark interface (map[string]any) to gRPC client calls.
+//
+// Example usage:
+//
+//	registry := saga.NewHandlerRegistry()
+//	client, cleanup, _ := client.New(client.Config{...})
+//	defer cleanup()
+//	err := RegisterStarlarkHandlers(registry, client)
+func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) error {
+	handlers := map[string]struct {
+		handler  saga.Handler
+		metadata saga.HandlerMetadata
+	}{
+		"reconciliation.initiate_run": {
+			handler: initiateRunHandler(client),
+			metadata: saga.HandlerMetadata{
+				Category: saga.HandlerCategorySettlement,
+			},
+		},
+		"reconciliation.execute_run": {
+			handler: executeRunHandler(client),
+			metadata: saga.HandlerMetadata{
+				Category: saga.HandlerCategorySettlement,
+			},
+		},
+		"reconciliation.retrieve_run": {
+			handler: retrieveRunHandler(client),
+			metadata: saga.HandlerMetadata{
+				Category: saga.HandlerCategorySettlement,
+			},
+		},
+		"reconciliation.cancel_run": {
+			handler: cancelRunHandler(client),
+			metadata: saga.HandlerMetadata{
+				Category: saga.HandlerCategorySettlement,
+			},
+		},
+		"reconciliation.assert_balance": {
+			handler: assertBalanceHandler(client),
+			metadata: saga.HandlerMetadata{
+				Category: saga.HandlerCategorySettlement,
+			},
+		},
+		"reconciliation.initiate_dispute": {
+			handler: initiateDisputeHandler(client),
+			metadata: saga.HandlerMetadata{
+				Category: saga.HandlerCategorySettlement,
+			},
+		},
+	}
+
+	for name, h := range handlers {
+		if err := registry.RegisterWithMetadata(name, h.handler, &h.metadata); err != nil {
+			return fmt.Errorf("failed to register %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// initiateRunHandler starts a new settlement run via gRPC.
+//
+// Parameters:
+//   - account_id (string): The account identifier to reconcile
+//   - scope (string): Reconciliation scope (ACCOUNT, INSTRUMENT, PORTFOLIO, FULL)
+//   - settlement_type (string): Settlement cycle (DAILY, WEEKLY, etc.)
+//   - initiated_by (string): User or system starting the run
+//
+// Returns a map containing:
+//   - run_id: The unique settlement run identifier
+//   - status: The run status (PENDING)
+func initiateRunHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		accountID, err := saga.RequireStringParam(params, "account_id")
+		if err != nil {
+			return nil, err
+		}
+		initiatedBy, err := saga.RequireStringParam(params, "initiated_by")
+		if err != nil {
+			return nil, err
+		}
+
+		clientCtx := prepareClientContext(ctx)
+
+		req := &reconciliationv1.InitiateAccountReconciliationRequest{
+			AccountId:   accountID,
+			Scope:       parseScope(params),
+			InitiatedBy: initiatedBy,
+		}
+
+		if st := parseSettlementType(params); st != reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED {
+			req.SettlementType = st
+		}
+
+		if ps, ok := params["period_start"]; ok {
+			if ts, ok := ps.(string); ok {
+				_ = ts // Period parsing would be added with business logic
+			}
+		}
+
+		resp, err := client.InitiateAccountReconciliation(clientCtx, req)
+		if err != nil {
+			return nil, fmt.Errorf("reconciliation.initiate_run: %w", err)
+		}
+
+		run := resp.GetRun()
+		return map[string]any{
+			"run_id": run.GetRunId(),
+			"status": "PENDING",
+		}, nil
+	}
+}
+
+// executeRunHandler triggers execution of a pending settlement run.
+//
+// Parameters:
+//   - run_id (string): The settlement run identifier to execute
+//
+// Returns a map containing:
+//   - run_id: The settlement run identifier
+//   - status: The run status (RUNNING)
+func executeRunHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		runID, err := saga.RequireStringParam(params, "run_id")
+		if err != nil {
+			return nil, err
+		}
+
+		clientCtx := prepareClientContext(ctx)
+
+		resp, err := client.ExecuteAccountReconciliation(clientCtx, &reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: runID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("reconciliation.execute_run: %w", err)
+		}
+
+		run := resp.GetRun()
+		return map[string]any{
+			"run_id": run.GetRunId(),
+			"status": "RUNNING",
+		}, nil
+	}
+}
+
+// retrieveRunHandler retrieves a settlement run summary.
+//
+// Parameters:
+//   - run_id (string): The settlement run identifier to retrieve
+//
+// Returns a map containing:
+//   - run_id: The settlement run identifier
+//   - status: The current run status
+//   - variance_count: Number of variances detected
+func retrieveRunHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		runID, err := saga.RequireStringParam(params, "run_id")
+		if err != nil {
+			return nil, err
+		}
+
+		clientCtx := prepareClientContext(ctx)
+
+		resp, err := client.RetrieveAccountReconciliation(clientCtx, &reconciliationv1.RetrieveAccountReconciliationRequest{
+			RunId: runID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("reconciliation.retrieve_run: %w", err)
+		}
+
+		run := resp.GetRun()
+		return map[string]any{
+			"run_id":         run.GetRunId(),
+			"status":         run.GetStatus().String(),
+			"variance_count": int64(run.GetVarianceCount()),
+		}, nil
+	}
+}
+
+// cancelRunHandler cancels a settlement run.
+//
+// Parameters:
+//   - run_id (string): The settlement run identifier to cancel
+//   - reason (string): Optional reason for cancellation
+//
+// Returns a map containing:
+//   - run_id: The settlement run identifier
+//   - status: The run status (CANCELLED)
+func cancelRunHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		runID, err := saga.RequireStringParam(params, "run_id")
+		if err != nil {
+			return nil, err
+		}
+
+		reason := optionalString(params, "reason")
+
+		clientCtx := prepareClientContext(ctx)
+
+		resp, err := client.ControlAccountReconciliation(clientCtx, &reconciliationv1.ControlAccountReconciliationRequest{
+			RunId:  runID,
+			Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+			Reason: reason,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("reconciliation.cancel_run: %w", err)
+		}
+
+		run := resp.GetRun()
+		return map[string]any{
+			"run_id": run.GetRunId(),
+			"status": "CANCELLED",
+		}, nil
+	}
+}
+
+// assertBalanceHandler evaluates a balance assertion.
+//
+// Parameters:
+//   - account_id (string): The account to assert
+//   - instrument_code (string): The asset type to assert
+//   - expression (string): The assertion rule (CEL expression)
+//   - expected_balance (string): Expected balance as decimal string
+//
+// Returns a map containing:
+//   - assertion_id: The assertion identifier
+//   - status: The assertion result (PASSED, FAILED)
+func assertBalanceHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		accountID, err := saga.RequireStringParam(params, "account_id")
+		if err != nil {
+			return nil, err
+		}
+		instrumentCode, err := saga.RequireStringParam(params, "instrument_code")
+		if err != nil {
+			return nil, err
+		}
+		expression, err := saga.RequireStringParam(params, "expression")
+		if err != nil {
+			return nil, err
+		}
+		expectedBalance, err := saga.RequireStringParam(params, "expected_balance")
+		if err != nil {
+			return nil, err
+		}
+
+		clientCtx := prepareClientContext(ctx)
+
+		resp, err := client.AssertBalance(clientCtx, &reconciliationv1.AssertBalanceRequest{
+			AccountId:       accountID,
+			InstrumentCode:  instrumentCode,
+			Expression:      expression,
+			ExpectedBalance: expectedBalance,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("reconciliation.assert_balance: %w", err)
+		}
+
+		assertion := resp.GetAssertion()
+		return map[string]any{
+			"assertion_id": assertion.GetAssertionId(),
+			"status":       assertion.GetStatus().String(),
+		}, nil
+	}
+}
+
+// initiateDisputeHandler raises a formal dispute against a variance.
+//
+// Parameters:
+//   - variance_id (string): The variance being disputed
+//   - run_id (string): The settlement run
+//   - account_id (string): The account
+//   - reason (string): Why the variance is being disputed
+//   - raised_by (string): Who is raising the dispute
+//
+// Returns a map containing:
+//   - dispute_id: The dispute identifier
+//   - status: The dispute status (OPEN)
+func initiateDisputeHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		varianceID, err := saga.RequireStringParam(params, "variance_id")
+		if err != nil {
+			return nil, err
+		}
+		runID, err := saga.RequireStringParam(params, "run_id")
+		if err != nil {
+			return nil, err
+		}
+		accountID, err := saga.RequireStringParam(params, "account_id")
+		if err != nil {
+			return nil, err
+		}
+		reason, err := saga.RequireStringParam(params, "reason")
+		if err != nil {
+			return nil, err
+		}
+		raisedBy, err := saga.RequireStringParam(params, "raised_by")
+		if err != nil {
+			return nil, err
+		}
+
+		clientCtx := prepareClientContext(ctx)
+
+		resp, err := client.InitiateDispute(clientCtx, &reconciliationv1.InitiateDisputeRequest{
+			VarianceId: varianceID,
+			RunId:      runID,
+			AccountId:  accountID,
+			Reason:     reason,
+			RaisedBy:   raisedBy,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("reconciliation.initiate_dispute: %w", err)
+		}
+
+		dispute := resp.GetDispute()
+		return map[string]any{
+			"dispute_id": dispute.GetDisputeId(),
+			"status":     "OPEN",
+		}, nil
+	}
+}
+
+// contextKey is a type for context keys to avoid collisions.
+type contextKey string
+
+// correlationIDContextKey is the typed context key for correlation ID.
+const correlationIDContextKey contextKey = "x-correlation-id"
+
+func prepareClientContext(ctx *saga.StarlarkContext) context.Context {
+	clientCtx := ctx.Context
+	clientCtx = context.WithValue(clientCtx, correlationIDContextKey, ctx.CorrelationID.String())
+	clientCtx = clients.PropagateIdempotencyKey(clientCtx, ctx.IdempotencyKey)
+	clientCtx = clients.PropagateKnowledgeAt(clientCtx, ctx.KnowledgeAt)
+	return clientCtx
+}
+
+func parseScope(params map[string]any) reconciliationv1.ReconciliationScope {
+	scopeStr := optionalString(params, "scope")
+	switch scopeStr {
+	case "ACCOUNT":
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT
+	case "INSTRUMENT":
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_INSTRUMENT
+	case "PORTFOLIO":
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_PORTFOLIO
+	case "FULL":
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_FULL
+	default:
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT
+	}
+}
+
+func parseSettlementType(params map[string]any) reconciliationv1.SettlementType {
+	stStr := optionalString(params, "settlement_type")
+	switch stStr {
+	case "DAILY":
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY
+	case "WEEKLY":
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_WEEKLY
+	case "MONTHLY":
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_MONTHLY
+	case "ON_DEMAND":
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND
+	case "END_OF_DAY":
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_END_OF_DAY
+	case "REAL_TIME":
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_REAL_TIME
+	default:
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED
+	}
+}
+
+// optionalString extracts a string parameter from the params map or returns empty string.
+func optionalString(params map[string]any, key string) string {
+	v, ok := params[key]
+	if !ok {
+		return ""
+	}
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return s
+}

--- a/services/reconciliation/client/starlark.go
+++ b/services/reconciliation/client/starlark.go
@@ -106,12 +106,6 @@ func initiateRunHandler(client *Client) saga.Handler {
 			req.SettlementType = st
 		}
 
-		if ps, ok := params["period_start"]; ok {
-			if ts, ok := ps.(string); ok {
-				_ = ts // Period parsing would be added with business logic
-			}
-		}
-
 		resp, err := client.InitiateAccountReconciliation(clientCtx, req)
 		if err != nil {
 			return nil, fmt.Errorf("reconciliation.initiate_run: %w", err)

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -1,0 +1,95 @@
+// Package service implements the gRPC AccountReconciliationService.
+//
+// All RPCs currently return UNIMPLEMENTED status. Business logic will be
+// added in subsequent tasks after the persistence layer is integrated.
+package service
+
+import (
+	"context"
+
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// AccountReconciliationService implements the gRPC service for reconciliation operations.
+type AccountReconciliationService struct {
+	reconciliationv1.UnimplementedAccountReconciliationServiceServer
+}
+
+// NewAccountReconciliationService creates a new AccountReconciliationService.
+func NewAccountReconciliationService() *AccountReconciliationService {
+	return &AccountReconciliationService{}
+}
+
+// InitiateAccountReconciliation creates a new settlement run.
+func (s *AccountReconciliationService) InitiateAccountReconciliation(
+	_ context.Context,
+	_ *reconciliationv1.InitiateAccountReconciliationRequest,
+) (*reconciliationv1.InitiateAccountReconciliationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "InitiateAccountReconciliation not yet implemented")
+}
+
+// ExecuteAccountReconciliation triggers execution of a pending settlement run.
+func (s *AccountReconciliationService) ExecuteAccountReconciliation(
+	_ context.Context,
+	_ *reconciliationv1.ExecuteAccountReconciliationRequest,
+) (*reconciliationv1.ExecuteAccountReconciliationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "ExecuteAccountReconciliation not yet implemented")
+}
+
+// RetrieveAccountReconciliation retrieves a settlement run summary.
+func (s *AccountReconciliationService) RetrieveAccountReconciliation(
+	_ context.Context,
+	_ *reconciliationv1.RetrieveAccountReconciliationRequest,
+) (*reconciliationv1.RetrieveAccountReconciliationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "RetrieveAccountReconciliation not yet implemented")
+}
+
+// ControlAccountReconciliation controls a settlement run (cancel, pause, resume).
+func (s *AccountReconciliationService) ControlAccountReconciliation(
+	_ context.Context,
+	_ *reconciliationv1.ControlAccountReconciliationRequest,
+) (*reconciliationv1.ControlAccountReconciliationResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "ControlAccountReconciliation not yet implemented")
+}
+
+// ListReconciliationResults returns paginated variance details for a run.
+func (s *AccountReconciliationService) ListReconciliationResults(
+	_ context.Context,
+	_ *reconciliationv1.ListReconciliationResultsRequest,
+) (*reconciliationv1.ListReconciliationResultsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "ListReconciliationResults not yet implemented")
+}
+
+// AssertBalance evaluates a balance assertion against current positions.
+func (s *AccountReconciliationService) AssertBalance(
+	_ context.Context,
+	_ *reconciliationv1.AssertBalanceRequest,
+) (*reconciliationv1.AssertBalanceResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "AssertBalance not yet implemented")
+}
+
+// InitiateDispute raises a formal dispute against a variance.
+func (s *AccountReconciliationService) InitiateDispute(
+	_ context.Context,
+	_ *reconciliationv1.InitiateDisputeRequest,
+) (*reconciliationv1.InitiateDisputeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "InitiateDispute not yet implemented")
+}
+
+// ControlDispute controls a dispute lifecycle (escalate, resolve, reject).
+func (s *AccountReconciliationService) ControlDispute(
+	_ context.Context,
+	_ *reconciliationv1.ControlDisputeRequest,
+) (*reconciliationv1.ControlDisputeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "ControlDispute not yet implemented")
+}
+
+// RetrieveDispute retrieves a dispute by ID.
+func (s *AccountReconciliationService) RetrieveDispute(
+	_ context.Context,
+	_ *reconciliationv1.RetrieveDisputeRequest,
+) (*reconciliationv1.RetrieveDisputeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "RetrieveDispute not yet implemented")
+}

--- a/services/reconciliation/service/service_test.go
+++ b/services/reconciliation/service/service_test.go
@@ -1,0 +1,101 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNewAccountReconciliationService(t *testing.T) {
+	svc := NewAccountReconciliationService()
+	require.NotNil(t, svc)
+}
+
+func TestAllRPCsReturnUnimplemented(t *testing.T) {
+	svc := NewAccountReconciliationService()
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "InitiateAccountReconciliation",
+			call: func() error {
+				_, err := svc.InitiateAccountReconciliation(ctx, &reconciliationv1.InitiateAccountReconciliationRequest{})
+				return err
+			},
+		},
+		{
+			name: "ExecuteAccountReconciliation",
+			call: func() error {
+				_, err := svc.ExecuteAccountReconciliation(ctx, &reconciliationv1.ExecuteAccountReconciliationRequest{})
+				return err
+			},
+		},
+		{
+			name: "RetrieveAccountReconciliation",
+			call: func() error {
+				_, err := svc.RetrieveAccountReconciliation(ctx, &reconciliationv1.RetrieveAccountReconciliationRequest{})
+				return err
+			},
+		},
+		{
+			name: "ControlAccountReconciliation",
+			call: func() error {
+				_, err := svc.ControlAccountReconciliation(ctx, &reconciliationv1.ControlAccountReconciliationRequest{})
+				return err
+			},
+		},
+		{
+			name: "ListReconciliationResults",
+			call: func() error {
+				_, err := svc.ListReconciliationResults(ctx, &reconciliationv1.ListReconciliationResultsRequest{})
+				return err
+			},
+		},
+		{
+			name: "AssertBalance",
+			call: func() error {
+				_, err := svc.AssertBalance(ctx, &reconciliationv1.AssertBalanceRequest{})
+				return err
+			},
+		},
+		{
+			name: "InitiateDispute",
+			call: func() error {
+				_, err := svc.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{})
+				return err
+			},
+		},
+		{
+			name: "ControlDispute",
+			call: func() error {
+				_, err := svc.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{})
+				return err
+			},
+		},
+		{
+			name: "RetrieveDispute",
+			call: func() error {
+				_, err := svc.RetrieveDispute(ctx, &reconciliationv1.RetrieveDisputeRequest{})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			require.Error(t, err)
+			st, ok := status.FromError(err)
+			require.True(t, ok, "error should be a gRPC status")
+			assert.Equal(t, codes.Unimplemented, st.Code())
+		})
+	}
+}

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -568,3 +568,144 @@ handlers:
       execution_status:
         type: string
         description: "Status of the lien execution (EXECUTED)"
+
+  # Account Reconciliation Service
+  reconciliation.initiate_run:
+    description: "Initiate a new settlement reconciliation run"
+    params:
+      account_id:
+        type: string
+        required: true
+        description: "Account identifier to reconcile"
+      scope:
+        type: enum
+        values: [ACCOUNT, INSTRUMENT, PORTFOLIO, FULL]
+        required: false
+        description: "Reconciliation scope (default: ACCOUNT)"
+      settlement_type:
+        type: enum
+        values: [DAILY, WEEKLY, MONTHLY, ON_DEMAND, END_OF_DAY, REAL_TIME]
+        required: false
+        description: "Settlement cycle type"
+      initiated_by:
+        type: string
+        required: true
+        description: "User or system starting the run"
+    returns:
+      run_id:
+        type: string
+        description: "Generated settlement run identifier (UUID)"
+      status:
+        type: string
+        description: "Status of the run (PENDING)"
+    compensate: reconciliation.cancel_run
+
+  reconciliation.execute_run:
+    description: "Trigger execution of a pending settlement run"
+    params:
+      run_id:
+        type: string
+        required: true
+        description: "Identifier of the settlement run to execute"
+    returns:
+      run_id:
+        type: string
+        description: "Echo of the input run ID"
+      status:
+        type: string
+        description: "Status of the run (RUNNING)"
+
+  reconciliation.retrieve_run:
+    description: "Retrieve a settlement run summary"
+    params:
+      run_id:
+        type: string
+        required: true
+        description: "Identifier of the settlement run to retrieve"
+    returns:
+      run_id:
+        type: string
+        description: "Echo of the input run ID"
+      status:
+        type: string
+        description: "Current status of the run"
+      variance_count:
+        type: int64
+        description: "Number of variances detected"
+
+  reconciliation.cancel_run:
+    description: "Cancel a settlement run (compensation handler)"
+    params:
+      run_id:
+        type: string
+        required: true
+        description: "Identifier of the settlement run to cancel"
+      reason:
+        type: string
+        required: false
+        description: "Reason for cancellation"
+    returns:
+      run_id:
+        type: string
+        description: "Echo of the input run ID"
+      status:
+        type: string
+        description: "Status of the run (CANCELLED)"
+
+  reconciliation.assert_balance:
+    description: "Evaluate a balance assertion against current positions"
+    params:
+      account_id:
+        type: string
+        required: true
+        description: "Account identifier to assert"
+      instrument_code:
+        type: string
+        required: true
+        description: "Asset type to assert (e.g., GBP, KWH)"
+      expression:
+        type: string
+        required: true
+        description: "Assertion rule (CEL expression)"
+      expected_balance:
+        type: string
+        required: true
+        description: "Expected balance as decimal string"
+    returns:
+      assertion_id:
+        type: string
+        description: "Generated assertion identifier (UUID)"
+      status:
+        type: string
+        description: "Assertion result (PASSED, FAILED)"
+
+  reconciliation.initiate_dispute:
+    description: "Raise a formal dispute against a detected variance"
+    params:
+      variance_id:
+        type: string
+        required: true
+        description: "Identifier of the variance being disputed"
+      run_id:
+        type: string
+        required: true
+        description: "Identifier of the settlement run"
+      account_id:
+        type: string
+        required: true
+        description: "Account identifier"
+      reason:
+        type: string
+        required: true
+        description: "Reason for the dispute"
+      raised_by:
+        type: string
+        required: true
+        description: "User or system raising the dispute"
+    returns:
+      dispute_id:
+        type: string
+        description: "Generated dispute identifier (UUID)"
+      status:
+        type: string
+        description: "Status of the dispute (OPEN)"

--- a/shared/pkg/saga/schema/handlers_test.go
+++ b/shared/pkg/saga/schema/handlers_test.go
@@ -42,6 +42,12 @@ func TestPlatformHandlersSchema(t *testing.T) {
 		"payment_order.send_to_gateway",
 		"payment_order.post_ledger_entries",
 		"payment_order.execute_lien",
+		"reconciliation.initiate_run",
+		"reconciliation.execute_run",
+		"reconciliation.retrieve_run",
+		"reconciliation.cancel_run",
+		"reconciliation.assert_balance",
+		"reconciliation.initiate_dispute",
 	}
 
 	assert.Len(t, schema.Handlers, len(expectedHandlers),
@@ -102,7 +108,7 @@ func TestRegistryLoadPlatformHandlers(t *testing.T) {
 	require.NoError(t, err)
 
 	handlers := registry.ListHandlers()
-	assert.Len(t, handlers, 22, "registry should contain all 22 platform handlers")
+	assert.Len(t, handlers, 28, "registry should contain all 28 platform handlers")
 
 	// Verify we can get each handler
 	for _, name := range handlers {


### PR DESCRIPTION
## Summary

- Define `AccountReconciliationService` protobuf API with BIAN-compliant action terms (Initiate, Execute, Retrieve, Control) plus paginated `ListReconciliationResults` for variance detail retrieval
- Add Kafka event payload protos (`reconciliation_events.proto`) for run lifecycle, variance detection, disputes, and balance imbalance alerts
- Implement gRPC handler skeleton with all 9 RPCs returning UNIMPLEMENTED, client library with circuit breaker/retry resilience patterns, Starlark saga bindings, and `handlers.yaml` schema entries

## Changes Made

### Proto definitions
- `api/proto/meridian/reconciliation/v1/reconciliation.proto` - Service with 9 RPCs, enums for all domain statuses, message types for settlement runs (summary only), variances, disputes, balance assertions. Cursor-based pagination for `ListReconciliationResults`.
- `api/proto/meridian/events/v1/reconciliation_events.proto` - 7 event payload messages for async integration via Kafka

### gRPC service skeleton
- `services/reconciliation/service/service.go` - All RPCs return `codes.Unimplemented`
- `services/reconciliation/service/service_test.go` - Verifies all RPCs return UNIMPLEMENTED

### Client library
- `services/reconciliation/client/client.go` - gRPC client wrapper (port 50058) with DNS-based and direct connection modes, resilience patterns (retry for reads, no-retry for writes)
- `services/reconciliation/client/client_test.go` - Connection, error handling, and cleanup tests
- `services/reconciliation/client/starlark.go` - 6 Starlark saga bindings for reconciliation operations

### Schema
- `shared/pkg/saga/schema/handlers.yaml` - 6 new reconciliation handler definitions with params, returns, and compensation references

## Design Decisions

- **Retrieve returns summary only** - `RetrieveAccountReconciliationResponse` contains `SettlementRunSummary` with `variance_count` but no inline variances. Variance details are fetched via the separate paginated `ListReconciliationResults` RPC.
- **Cursor-based pagination** - `ListReconciliationResults` uses opaque `page_token` / `next_page_token` pattern consistent with `common.v1.Pagination`
- **Event severity field** - `BalanceImbalanceDetectedEvent` includes severity (INFO/WARNING/CRITICAL) for P1 alert routing

## Test Plan

- [x] All service tests pass (`go test ./services/reconciliation/...`)
- [x] `buf lint` passes
- [x] `go vet` passes
- [x] Pre-commit hooks pass (buf lint, gofumpt, golangci-lint)
- [ ] CI pipeline

## Task Reference

Task Master: reconciliation-service.3