### PR TITLE
feat: implement cross-account balance assertions with imbalance detection

### DIFF
--- a/services/reconciliation/domain/assertion_scope.go
+++ b/services/reconciliation/domain/assertion_scope.go
@@ -1,0 +1,37 @@
+package domain
+
+// AssertionScope defines the scope of a balance assertion check.
+type AssertionScope string
+
+const (
+	// AssertionScopePositionLedger verifies a single account's position ledger.
+	AssertionScopePositionLedger AssertionScope = "POSITION_LEDGER"
+	// AssertionScopeCrossAccount performs system-wide balance verification per instrument.
+	AssertionScopeCrossAccount AssertionScope = "CROSS_ACCOUNT"
+	// AssertionScopeNostroVostro verifies nostro/vostro account reconciliation.
+	AssertionScopeNostroVostro AssertionScope = "NOSTRO_VOSTRO"
+)
+
+// IsValid checks if the assertion scope is a recognized value.
+func (s AssertionScope) IsValid() bool {
+	switch s {
+	case AssertionScopePositionLedger, AssertionScopeCrossAccount, AssertionScopeNostroVostro:
+		return true
+	}
+	return false
+}
+
+// String returns the string representation.
+func (s AssertionScope) String() string {
+	return string(s)
+}
+
+// ParseAssertionScope converts a string to AssertionScope.
+// Returns AssertionScopePositionLedger for unrecognized values.
+func ParseAssertionScope(s string) AssertionScope {
+	scope := AssertionScope(s)
+	if scope.IsValid() {
+		return scope
+	}
+	return AssertionScopePositionLedger
+}

--- a/services/reconciliation/domain/assertion_scope_test.go
+++ b/services/reconciliation/domain/assertion_scope_test.go
@@ -1,0 +1,41 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAssertionScope_IsValid(t *testing.T) {
+	tests := []struct {
+		scope domain.AssertionScope
+		valid bool
+	}{
+		{domain.AssertionScopePositionLedger, true},
+		{domain.AssertionScopeCrossAccount, true},
+		{domain.AssertionScopeNostroVostro, true},
+		{domain.AssertionScope("INVALID"), false},
+		{domain.AssertionScope(""), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.scope), func(t *testing.T) {
+			assert.Equal(t, tt.valid, tt.scope.IsValid())
+		})
+	}
+}
+
+func TestAssertionScope_String(t *testing.T) {
+	assert.Equal(t, "POSITION_LEDGER", domain.AssertionScopePositionLedger.String())
+	assert.Equal(t, "CROSS_ACCOUNT", domain.AssertionScopeCrossAccount.String())
+	assert.Equal(t, "NOSTRO_VOSTRO", domain.AssertionScopeNostroVostro.String())
+}
+
+func TestParseAssertionScope(t *testing.T) {
+	assert.Equal(t, domain.AssertionScopePositionLedger, domain.ParseAssertionScope("POSITION_LEDGER"))
+	assert.Equal(t, domain.AssertionScopeCrossAccount, domain.ParseAssertionScope("CROSS_ACCOUNT"))
+	assert.Equal(t, domain.AssertionScopeNostroVostro, domain.ParseAssertionScope("NOSTRO_VOSTRO"))
+	assert.Equal(t, domain.AssertionScopePositionLedger, domain.ParseAssertionScope("INVALID"),
+		"unrecognized values should default to POSITION_LEDGER")
+}

--- a/services/reconciliation/domain/balance_imbalance_event.go
+++ b/services/reconciliation/domain/balance_imbalance_event.go
@@ -1,0 +1,70 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// BalanceImbalanceDetectedEvent is published when a cross-account balance
+// assertion fails (total_debits != total_credits for an instrument).
+// This is a P1/Critical severity event indicating a ledger integrity violation.
+type BalanceImbalanceDetectedEvent struct {
+	// EventID uniquely identifies this event.
+	EventID uuid.UUID
+
+	// AssertionID references the balance assertion that detected the imbalance.
+	AssertionID uuid.UUID
+
+	// InstrumentCode identifies the asset type with the imbalance.
+	InstrumentCode string
+
+	// TotalDebits is the aggregated debit amount.
+	TotalDebits decimal.Decimal
+
+	// TotalCredits is the aggregated credit amount.
+	TotalCredits decimal.Decimal
+
+	// ImbalanceAmount is the difference (total_debits - total_credits).
+	ImbalanceAmount decimal.Decimal
+
+	// Scope is the assertion scope that detected this imbalance.
+	Scope AssertionScope
+
+	// Severity indicates this is a P1/Critical event.
+	Severity string
+
+	// IsPersistent indicates the imbalance has been detected for 3+ consecutive days.
+	IsPersistent bool
+
+	// ConsecutiveDays is the number of consecutive days the imbalance has persisted.
+	ConsecutiveDays int
+
+	// DetectedAt is when the imbalance was detected.
+	DetectedAt time.Time
+}
+
+// NewBalanceImbalanceDetectedEvent creates a new critical imbalance event.
+func NewBalanceImbalanceDetectedEvent(
+	assertionID uuid.UUID,
+	instrumentCode string,
+	totalDebits, totalCredits, imbalanceAmount decimal.Decimal,
+	scope AssertionScope,
+	isPersistent bool,
+	consecutiveDays int,
+) *BalanceImbalanceDetectedEvent {
+	return &BalanceImbalanceDetectedEvent{
+		EventID:         uuid.New(),
+		AssertionID:     assertionID,
+		InstrumentCode:  instrumentCode,
+		TotalDebits:     totalDebits,
+		TotalCredits:    totalCredits,
+		ImbalanceAmount: imbalanceAmount,
+		Scope:           scope,
+		Severity:        "P1_CRITICAL",
+		IsPersistent:    isPersistent,
+		ConsecutiveDays: consecutiveDays,
+		DetectedAt:      time.Now().UTC(),
+	}
+}

--- a/services/reconciliation/domain/errors.go
+++ b/services/reconciliation/domain/errors.go
@@ -35,4 +35,8 @@ var (
 	ErrEmptyAssertionExpression = errors.New("assertion expression is required")
 	// ErrEmptyInitiatedBy is returned when initiated by is empty.
 	ErrEmptyInitiatedBy = errors.New("initiated by cannot be empty")
+	// ErrUnauthorized is returned when the caller lacks required authorization.
+	ErrUnauthorized = errors.New("unauthorized: insufficient permissions")
+	// ErrUnimplemented is returned for features not yet implemented.
+	ErrUnimplemented = errors.New("not implemented")
 )

--- a/services/reconciliation/domain/imbalance_trend.go
+++ b/services/reconciliation/domain/imbalance_trend.go
@@ -1,0 +1,46 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// PersistentImbalanceThreshold is the number of consecutive days of imbalance
+// that triggers a persistent imbalance alert.
+const PersistentImbalanceThreshold = 3
+
+// ImbalanceTrend tracks imbalance history for an instrument code to detect
+// persistent imbalance patterns (P1 critical for ledger integrity).
+type ImbalanceTrend struct {
+	TrendID             uuid.UUID
+	InstrumentCode      string
+	ConsecutiveDays     int
+	LastImbalanceAmount decimal.Decimal
+	LastAssertionID     uuid.UUID
+	FirstDetectedAt     time.Time
+	LastDetectedAt      time.Time
+	ResolvedAt          *time.Time
+}
+
+// IsPersistent returns true if the imbalance has been present for 3+ consecutive days.
+func (t *ImbalanceTrend) IsPersistent() bool {
+	return t.ConsecutiveDays >= PersistentImbalanceThreshold
+}
+
+// RecordImbalance increments the trend for a new day of imbalance.
+func (t *ImbalanceTrend) RecordImbalance(amount decimal.Decimal, assertionID uuid.UUID) {
+	t.ConsecutiveDays++
+	t.LastImbalanceAmount = amount
+	t.LastAssertionID = assertionID
+	t.LastDetectedAt = time.Now().UTC()
+	t.ResolvedAt = nil
+}
+
+// Resolve marks the trend as resolved when balance is restored.
+func (t *ImbalanceTrend) Resolve() {
+	now := time.Now().UTC()
+	t.ResolvedAt = &now
+	t.ConsecutiveDays = 0
+}

--- a/services/reconciliation/domain/imbalance_trend.go
+++ b/services/reconciliation/domain/imbalance_trend.go
@@ -29,13 +29,28 @@ func (t *ImbalanceTrend) IsPersistent() bool {
 	return t.ConsecutiveDays >= PersistentImbalanceThreshold
 }
 
-// RecordImbalance increments the trend for a new day of imbalance.
+// RecordImbalance records a new imbalance detection. The consecutive day count
+// only increments if the last detection was on a different calendar day (UTC),
+// preventing multiple assertions on the same day from inflating the count.
 func (t *ImbalanceTrend) RecordImbalance(amount decimal.Decimal, assertionID uuid.UUID) {
-	t.ConsecutiveDays++
+	now := time.Now().UTC()
+
+	// Only increment consecutive days if this is a new calendar day
+	if t.LastDetectedAt.IsZero() || !sameUTCDay(t.LastDetectedAt, now) {
+		t.ConsecutiveDays++
+	}
+
 	t.LastImbalanceAmount = amount
 	t.LastAssertionID = assertionID
-	t.LastDetectedAt = time.Now().UTC()
+	t.LastDetectedAt = now
 	t.ResolvedAt = nil
+}
+
+// sameUTCDay returns true if both timestamps fall on the same UTC calendar day.
+func sameUTCDay(a, b time.Time) bool {
+	ay, am, ad := a.UTC().Date()
+	by, bm, bd := b.UTC().Date()
+	return ay == by && am == bm && ad == bd
 }
 
 // Resolve marks the trend as resolved when balance is restored.

--- a/services/reconciliation/domain/repository.go
+++ b/services/reconciliation/domain/repository.go
@@ -141,9 +141,20 @@ type BalanceAssertionRepository interface {
 
 // AssertionFilter defines filtering and pagination for balance assertions.
 type AssertionFilter struct {
-	RunID     *uuid.UUID
-	AccountID *string
-	Status    *AssertionStatus
-	Limit     int
-	Offset    int
+	RunID          *uuid.UUID
+	AccountID      *string
+	InstrumentCode *string
+	Status         *AssertionStatus
+	Limit          int
+	Offset         int
+}
+
+// ImbalanceTrendRepository defines the contract for persisting imbalance trends.
+type ImbalanceTrendRepository interface {
+	// Upsert creates or updates an imbalance trend for an instrument code.
+	Upsert(ctx context.Context, trend *ImbalanceTrend) error
+
+	// FindByInstrumentCode retrieves the active (unresolved) trend for an instrument.
+	// Returns ErrNotFound if no active trend exists.
+	FindByInstrumentCode(ctx context.Context, instrumentCode string) (*ImbalanceTrend, error)
 }

--- a/services/reconciliation/migrations/20260209000002_imbalance_trend.sql
+++ b/services/reconciliation/migrations/20260209000002_imbalance_trend.sql
@@ -1,0 +1,21 @@
+-- Add imbalance trend tracking table for persistent imbalance detection.
+-- Tracks consecutive days of imbalance per instrument code.
+-- A threshold of 3+ consecutive days triggers P1/Critical alerts.
+
+CREATE TABLE "imbalance_trend" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "trend_id" uuid NOT NULL,
+  "instrument_code" character varying(20) NOT NULL,
+  "consecutive_days" integer NOT NULL DEFAULT 0,
+  "last_imbalance_amount" decimal(38, 18) NOT NULL DEFAULT 0,
+  "last_assertion_id" uuid NULL,
+  "first_detected_at" timestamptz NOT NULL,
+  "last_detected_at" timestamptz NOT NULL,
+  "resolved_at" timestamptz NULL,
+  PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "idx_imbalance_trend_trend_id" ON "imbalance_trend" ("trend_id");
+CREATE UNIQUE INDEX "idx_imbalance_trend_instrument_active"
+  ON "imbalance_trend" ("instrument_code") WHERE "resolved_at" IS NULL;
+CREATE INDEX "idx_imbalance_trend_instrument_code" ON "imbalance_trend" ("instrument_code");

--- a/services/reconciliation/observability/metrics.go
+++ b/services/reconciliation/observability/metrics.go
@@ -1,0 +1,43 @@
+package observability
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// BalanceImbalanceGauge tracks the current imbalance amount per instrument code.
+	// In a healthy system, this gauge should always be 0.
+	// A non-zero value indicates a P1/Critical ledger integrity violation.
+	BalanceImbalanceGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "meridian",
+			Subsystem: "reconciliation",
+			Name:      "balance_imbalance_amount",
+			Help:      "Current imbalance amount per instrument code. Should always be 0 in a healthy system.",
+		},
+		[]string{"instrument_code"},
+	)
+
+	// BalanceAssertionTotal counts the total number of balance assertions by status.
+	BalanceAssertionTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "reconciliation",
+			Name:      "balance_assertion_total",
+			Help:      "Total number of balance assertions executed, labeled by result status.",
+		},
+		[]string{"status", "scope"},
+	)
+
+	// PersistentImbalanceGauge tracks the number of consecutive days of persistent imbalance.
+	PersistentImbalanceGauge = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "meridian",
+			Subsystem: "reconciliation",
+			Name:      "persistent_imbalance_days",
+			Help:      "Number of consecutive days of imbalance per instrument code.",
+		},
+		[]string{"instrument_code"},
+	)
+)

--- a/services/reconciliation/service/balance_assertor.go
+++ b/services/reconciliation/service/balance_assertor.go
@@ -75,6 +75,8 @@ func NewBalanceAssertor(
 }
 
 // ExecuteBalanceAssertion performs a balance assertion check.
+// On PK client failure, it returns BOTH a result (with FAILED assertion) and an error.
+// This allows callers to access the persisted assertion even when PK is unreachable.
 func (ba *BalanceAssertor) ExecuteBalanceAssertion(ctx context.Context, req AssertBalanceRequest) (*AssertBalanceResult, error) {
 	// Validate scope
 	if !req.Scope.IsValid() {
@@ -258,7 +260,10 @@ func (ba *BalanceAssertor) resolveTrend(ctx context.Context, instrumentCode stri
 
 	trend, err := ba.trendRepo.FindByInstrumentCode(ctx, instrumentCode)
 	if err != nil {
-		return // No active trend, nothing to resolve
+		if !errors.Is(err, domain.ErrNotFound) {
+			ba.logger.Error("failed to find imbalance trend for resolution", "error", err, "instrument_code", instrumentCode)
+		}
+		return
 	}
 
 	trend.Resolve()
@@ -293,7 +298,7 @@ func (ba *BalanceAssertor) enrichWithDiagnostics(ctx context.Context, assertion 
 // getTrendDays safely extracts consecutive days from a trend that may be nil.
 func (ba *BalanceAssertor) getTrendDays(trend *domain.ImbalanceTrend) int {
 	if trend == nil {
-		return 1
+		return 0
 	}
 	return trend.ConsecutiveDays
 }

--- a/services/reconciliation/service/balance_assertor.go
+++ b/services/reconciliation/service/balance_assertor.go
@@ -1,0 +1,299 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/services/reconciliation/observability"
+	"github.com/shopspring/decimal"
+)
+
+// CallerRole represents the authorization role of the calling user.
+type CallerRole string
+
+// Supported caller roles for authorization checks.
+const (
+	CallerRoleTenantAdmin CallerRole = "TENANT_ADMIN"
+	CallerRoleSystem      CallerRole = "SYSTEM"
+	CallerRoleAuditor     CallerRole = "AUDITOR"
+)
+
+// AssertBalanceRequest is the input for executing a balance assertion.
+type AssertBalanceRequest struct {
+	AccountID       string
+	InstrumentCode  string
+	Expression      string
+	ExpectedBalance decimal.Decimal
+	RunID           *uuid.UUID
+	Scope           domain.AssertionScope
+	CallerRole      CallerRole
+}
+
+// AssertBalanceResult is the output of a balance assertion execution.
+type AssertBalanceResult struct {
+	Assertion *domain.BalanceAssertion
+	Event     *domain.BalanceImbalanceDetectedEvent
+}
+
+// ImbalanceEventPublisher publishes balance imbalance domain events.
+type ImbalanceEventPublisher interface {
+	PublishBalanceImbalanceDetected(ctx context.Context, event *domain.BalanceImbalanceDetectedEvent) error
+}
+
+// BalanceAssertor executes balance assertion checks against Position Keeping.
+type BalanceAssertor struct {
+	assertionRepo domain.BalanceAssertionRepository
+	trendRepo     domain.ImbalanceTrendRepository
+	pkClient      PositionKeepingClient
+	faClient      FinancialAccountingClient
+	publisher     ImbalanceEventPublisher
+	logger        *slog.Logger
+}
+
+// NewBalanceAssertor creates a new BalanceAssertor.
+func NewBalanceAssertor(
+	assertionRepo domain.BalanceAssertionRepository,
+	trendRepo domain.ImbalanceTrendRepository,
+	pkClient PositionKeepingClient,
+	faClient FinancialAccountingClient,
+	publisher ImbalanceEventPublisher,
+	logger *slog.Logger,
+) *BalanceAssertor {
+	return &BalanceAssertor{
+		assertionRepo: assertionRepo,
+		trendRepo:     trendRepo,
+		pkClient:      pkClient,
+		faClient:      faClient,
+		publisher:     publisher,
+		logger:        logger,
+	}
+}
+
+// ExecuteBalanceAssertion performs a balance assertion check.
+func (ba *BalanceAssertor) ExecuteBalanceAssertion(ctx context.Context, req AssertBalanceRequest) (*AssertBalanceResult, error) {
+	// Validate scope
+	if !req.Scope.IsValid() {
+		req.Scope = domain.AssertionScopePositionLedger
+	}
+
+	// NOSTRO_VOSTRO is not yet implemented
+	if req.Scope == domain.AssertionScopeNostroVostro {
+		return nil, domain.ErrUnimplemented
+	}
+
+	// Authorization: CROSS_ACCOUNT requires SYSTEM or AUDITOR role
+	if req.Scope == domain.AssertionScopeCrossAccount {
+		if req.CallerRole != CallerRoleSystem && req.CallerRole != CallerRoleAuditor {
+			ba.logger.Warn("unauthorized cross-account assertion attempt",
+				"caller_role", req.CallerRole,
+				"instrument_code", req.InstrumentCode)
+			return nil, domain.ErrUnauthorized
+		}
+	}
+
+	// Create the assertion domain entity
+	assertion, err := domain.NewBalanceAssertion(
+		req.RunID,
+		req.AccountID,
+		req.InstrumentCode,
+		req.Expression,
+		req.ExpectedBalance,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating balance assertion: %w", err)
+	}
+
+	// Persist the pending assertion
+	if err := ba.assertionRepo.Create(ctx, assertion); err != nil {
+		return nil, fmt.Errorf("persisting assertion: %w", err)
+	}
+
+	// Query Position Keeping for aggregated debits/credits
+	summary, err := ba.pkClient.GetPositionSummary(ctx, req.AccountID, req.InstrumentCode)
+	if err != nil {
+		failReason := fmt.Sprintf("failed to query position keeping: %v", err)
+		if failErr := assertion.Fail(decimal.Zero, failReason); failErr != nil {
+			ba.logger.Error("failed to mark assertion as failed", "error", failErr)
+		}
+		_ = ba.assertionRepo.Update(ctx, assertion)
+		observability.BalanceAssertionTotal.WithLabelValues("FAILED", req.Scope.String()).Inc()
+		return &AssertBalanceResult{Assertion: assertion}, fmt.Errorf("querying position keeping: %w", err)
+	}
+
+	// Calculate imbalance: total_debits - total_credits
+	imbalanceAmount := summary.TotalDebits.Sub(summary.TotalCredits)
+	actualBalance := summary.TotalCredits.Sub(summary.TotalDebits) // net balance
+
+	result := &AssertBalanceResult{}
+
+	if imbalanceAmount.IsZero() {
+		// BALANCED: debits == credits
+		if err := assertion.Pass(actualBalance); err != nil {
+			return nil, fmt.Errorf("marking assertion passed: %w", err)
+		}
+
+		observability.BalanceImbalanceGauge.WithLabelValues(req.InstrumentCode).Set(0)
+		observability.BalanceAssertionTotal.WithLabelValues("PASSED", req.Scope.String()).Inc()
+
+		// Resolve any existing trend
+		ba.resolveTrend(ctx, req.InstrumentCode)
+	} else {
+		// IMBALANCED: P1/Critical severity - ledger integrity violation
+		failureReason := fmt.Sprintf(
+			"CRITICAL: Ledger imbalance detected for instrument %s: total_debits=%s, total_credits=%s, imbalance=%s",
+			req.InstrumentCode,
+			summary.TotalDebits.String(),
+			summary.TotalCredits.String(),
+			imbalanceAmount.String(),
+		)
+
+		if err := assertion.Fail(actualBalance, failureReason); err != nil {
+			return nil, fmt.Errorf("marking assertion failed: %w", err)
+		}
+
+		// Set imbalance gauge (absolute value)
+		absImbalance, _ := imbalanceAmount.Abs().Float64()
+		observability.BalanceImbalanceGauge.WithLabelValues(req.InstrumentCode).Set(absImbalance)
+		observability.BalanceAssertionTotal.WithLabelValues("FAILED", req.Scope.String()).Inc()
+
+		// Track trend and check persistence
+		trend := ba.updateTrend(ctx, req.InstrumentCode, imbalanceAmount, assertion.AssertionID)
+
+		// Gather FA diagnostics if available
+		ba.enrichWithDiagnostics(ctx, assertion, req.AccountID, req.InstrumentCode)
+
+		// Publish critical imbalance event
+		event := domain.NewBalanceImbalanceDetectedEvent(
+			assertion.AssertionID,
+			req.InstrumentCode,
+			summary.TotalDebits,
+			summary.TotalCredits,
+			imbalanceAmount,
+			req.Scope,
+			trend != nil && trend.IsPersistent(),
+			ba.getTrendDays(trend),
+		)
+
+		if ba.publisher != nil {
+			if pubErr := ba.publisher.PublishBalanceImbalanceDetected(ctx, event); pubErr != nil {
+				ba.logger.Error("failed to publish imbalance event",
+					"error", pubErr,
+					"assertion_id", assertion.AssertionID,
+					"instrument_code", req.InstrumentCode)
+			}
+		}
+
+		result.Event = event
+
+		ba.logger.Error("CRITICAL: Balance imbalance detected",
+			"assertion_id", assertion.AssertionID,
+			"instrument_code", req.InstrumentCode,
+			"total_debits", summary.TotalDebits.String(),
+			"total_credits", summary.TotalCredits.String(),
+			"imbalance", imbalanceAmount.String(),
+			"is_persistent", trend != nil && trend.IsPersistent(),
+			"severity", "P1_CRITICAL")
+	}
+
+	// Update the assertion with result
+	if err := ba.assertionRepo.Update(ctx, assertion); err != nil {
+		return nil, fmt.Errorf("updating assertion result: %w", err)
+	}
+
+	result.Assertion = assertion
+	return result, nil
+}
+
+// updateTrend updates or creates an imbalance trend for the instrument code.
+func (ba *BalanceAssertor) updateTrend(ctx context.Context, instrumentCode string, imbalanceAmount decimal.Decimal, assertionID uuid.UUID) *domain.ImbalanceTrend {
+	if ba.trendRepo == nil {
+		return nil
+	}
+
+	trend, err := ba.trendRepo.FindByInstrumentCode(ctx, instrumentCode)
+	if err != nil {
+		if !errors.Is(err, domain.ErrNotFound) {
+			ba.logger.Error("failed to find imbalance trend", "error", err, "instrument_code", instrumentCode)
+			return nil
+		}
+		// Create new trend
+		trend = &domain.ImbalanceTrend{
+			TrendID:         uuid.New(),
+			InstrumentCode:  instrumentCode,
+			FirstDetectedAt: time.Now().UTC(),
+		}
+	}
+
+	trend.RecordImbalance(imbalanceAmount, assertionID)
+
+	if err := ba.trendRepo.Upsert(ctx, trend); err != nil {
+		ba.logger.Error("failed to upsert imbalance trend", "error", err, "instrument_code", instrumentCode)
+		return trend
+	}
+
+	// Update persistent imbalance gauge
+	observability.PersistentImbalanceGauge.WithLabelValues(instrumentCode).Set(float64(trend.ConsecutiveDays))
+
+	if trend.IsPersistent() {
+		ba.logger.Error("CRITICAL: Persistent imbalance detected",
+			"instrument_code", instrumentCode,
+			"consecutive_days", trend.ConsecutiveDays,
+			"first_detected", trend.FirstDetectedAt,
+			"severity", "P1_CRITICAL")
+	}
+
+	return trend
+}
+
+// resolveTrend resolves any active imbalance trend for the instrument code.
+func (ba *BalanceAssertor) resolveTrend(ctx context.Context, instrumentCode string) {
+	if ba.trendRepo == nil {
+		return
+	}
+
+	trend, err := ba.trendRepo.FindByInstrumentCode(ctx, instrumentCode)
+	if err != nil {
+		return // No active trend, nothing to resolve
+	}
+
+	trend.Resolve()
+	if err := ba.trendRepo.Upsert(ctx, trend); err != nil {
+		ba.logger.Error("failed to resolve imbalance trend", "error", err, "instrument_code", instrumentCode)
+	}
+
+	observability.PersistentImbalanceGauge.WithLabelValues(instrumentCode).Set(0)
+}
+
+// enrichWithDiagnostics adds FA diagnostic details to the assertion attributes.
+func (ba *BalanceAssertor) enrichWithDiagnostics(ctx context.Context, assertion *domain.BalanceAssertion, accountID, instrumentCode string) {
+	if ba.faClient == nil {
+		return
+	}
+
+	detail, err := ba.faClient.GetDiagnosticDetail(ctx, accountID, instrumentCode)
+	if err != nil {
+		ba.logger.Warn("failed to retrieve FA diagnostics",
+			"error", err,
+			"account_id", accountID,
+			"instrument_code", instrumentCode)
+		return
+	}
+
+	if assertion.Attributes == nil {
+		assertion.Attributes = make(map[string]string)
+	}
+	assertion.Attributes["fa_diagnostic_message"] = detail.Message
+}
+
+// getTrendDays safely extracts consecutive days from a trend that may be nil.
+func (ba *BalanceAssertor) getTrendDays(trend *domain.ImbalanceTrend) int {
+	if trend == nil {
+		return 1
+	}
+	return trend.ConsecutiveDays
+}

--- a/services/reconciliation/service/balance_assertor.go
+++ b/services/reconciliation/service/balance_assertor.go
@@ -56,6 +56,8 @@ type BalanceAssertor struct {
 }
 
 // NewBalanceAssertor creates a new BalanceAssertor.
+// assertionRepo and pkClient are required; nil values will panic.
+// trendRepo, faClient, and publisher are optional (nil-guarded at call sites).
 func NewBalanceAssertor(
 	assertionRepo domain.BalanceAssertionRepository,
 	trendRepo domain.ImbalanceTrendRepository,
@@ -64,6 +66,15 @@ func NewBalanceAssertor(
 	publisher ImbalanceEventPublisher,
 	logger *slog.Logger,
 ) *BalanceAssertor {
+	if assertionRepo == nil {
+		panic("balance assertor: assertionRepo is required")
+	}
+	if pkClient == nil {
+		panic("balance assertor: pkClient is required")
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &BalanceAssertor{
 		assertionRepo: assertionRepo,
 		trendRepo:     trendRepo,
@@ -127,7 +138,9 @@ func (ba *BalanceAssertor) ExecuteBalanceAssertion(ctx context.Context, req Asse
 		return &AssertBalanceResult{Assertion: assertion}, fmt.Errorf("querying position keeping: %w", err)
 	}
 
-	// Calculate imbalance: total_debits - total_credits
+	// Calculate imbalance: total_debits - total_credits.
+	// The assertion validates ledger equilibrium (debits == credits), not a user-supplied
+	// expected balance. ExpectedBalance is stored for audit trail context only.
 	imbalanceAmount := summary.TotalDebits.Sub(summary.TotalCredits)
 	actualBalance := summary.TotalCredits.Sub(summary.TotalDebits) // net balance
 

--- a/services/reconciliation/service/balance_assertor_test.go
+++ b/services/reconciliation/service/balance_assertor_test.go
@@ -373,24 +373,52 @@ func TestExecuteBalanceAssertion_TrendTracking(t *testing.T) {
 
 	assertor := NewBalanceAssertor(newMockAssertionRepo(), trendRepo, imbalancedPK, nil, publisher, testLogger())
 
-	// Simulate 3 consecutive days of imbalance
-	for i := 0; i < 3; i++ {
-		result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
-			AccountID:       "ACC-001",
-			InstrumentCode:  "GBP",
-			Expression:      "total_debits == total_credits",
-			ExpectedBalance: decimal.Zero,
-			Scope:           domain.AssertionScopePositionLedger,
-			CallerRole:      CallerRoleTenantAdmin,
-		})
+	// First assertion creates trend with 1 consecutive day
+	result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, domain.AssertionStatusFailed, result.Assertion.Status)
 
-		require.NoError(t, err)
-		assert.Equal(t, domain.AssertionStatusFailed, result.Assertion.Status)
-	}
-
-	// Verify trend is now persistent (3 consecutive days)
+	// Trend should exist with 1 day (same-day calls don't increment)
 	trend := trendRepo.trends["GBP"]
 	require.NotNil(t, trend)
+	assert.Equal(t, 1, trend.ConsecutiveDays)
+
+	// Simulate multi-day persistence by backdating the last detection
+	trend.LastDetectedAt = trend.LastDetectedAt.AddDate(0, 0, -1)
+
+	// Second assertion (now appears to be next day) increments to 2
+	_, err = assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 2, trend.ConsecutiveDays)
+	assert.False(t, trend.IsPersistent())
+
+	// Backdate again
+	trend.LastDetectedAt = trend.LastDetectedAt.AddDate(0, 0, -1)
+
+	// Third assertion reaches threshold
+	_, err = assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+	require.NoError(t, err)
 	assert.Equal(t, 3, trend.ConsecutiveDays)
 	assert.True(t, trend.IsPersistent())
 
@@ -399,6 +427,38 @@ func TestExecuteBalanceAssertion_TrendTracking(t *testing.T) {
 	lastEvent := publisher.events[len(publisher.events)-1]
 	assert.True(t, lastEvent.IsPersistent)
 	assert.Equal(t, 3, lastEvent.ConsecutiveDays)
+}
+
+func TestExecuteBalanceAssertion_SameDayDoesNotIncrementTrend(t *testing.T) {
+	trendRepo := newMockTrendRepo()
+
+	imbalancedPK := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.NewFromFloat(50000.00),
+			TotalCredits:   decimal.NewFromFloat(49000.00),
+		},
+	}
+
+	assertor := NewBalanceAssertor(newMockAssertionRepo(), trendRepo, imbalancedPK, nil, nil, testLogger())
+
+	// Run multiple assertions on the same day
+	for i := 0; i < 5; i++ {
+		_, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+			AccountID:       "ACC-001",
+			InstrumentCode:  "GBP",
+			Expression:      "total_debits == total_credits",
+			ExpectedBalance: decimal.Zero,
+			Scope:           domain.AssertionScopePositionLedger,
+			CallerRole:      CallerRoleTenantAdmin,
+		})
+		require.NoError(t, err)
+	}
+
+	// Should only count as 1 consecutive day despite 5 assertions
+	trend := trendRepo.trends["GBP"]
+	require.NotNil(t, trend)
+	assert.Equal(t, 1, trend.ConsecutiveDays)
 }
 
 func TestExecuteBalanceAssertion_TrendResolution(t *testing.T) {
@@ -656,6 +716,12 @@ func TestImbalanceTrend_RecordAndResolve(t *testing.T) {
 	assert.Equal(t, 1, trend.ConsecutiveDays)
 	assert.Equal(t, assertionID, trend.LastAssertionID)
 	assert.Nil(t, trend.ResolvedAt)
+
+	// Same day call should not increment
+	assertionID2 := uuid.New()
+	trend.RecordImbalance(decimal.NewFromFloat(600), assertionID2)
+	assert.Equal(t, 1, trend.ConsecutiveDays, "same-day call should not increment")
+	assert.Equal(t, assertionID2, trend.LastAssertionID)
 
 	trend.Resolve()
 	assert.Equal(t, 0, trend.ConsecutiveDays)

--- a/services/reconciliation/service/balance_assertor_test.go
+++ b/services/reconciliation/service/balance_assertor_test.go
@@ -1,0 +1,669 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock implementations ---
+
+type mockAssertionRepo struct {
+	assertions map[uuid.UUID]*domain.BalanceAssertion
+	createErr  error
+	updateErr  error
+}
+
+func newMockAssertionRepo() *mockAssertionRepo {
+	return &mockAssertionRepo{
+		assertions: make(map[uuid.UUID]*domain.BalanceAssertion),
+	}
+}
+
+func (m *mockAssertionRepo) Create(_ context.Context, a *domain.BalanceAssertion) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.assertions[a.AssertionID] = a
+	return nil
+}
+
+func (m *mockAssertionRepo) FindByID(_ context.Context, id uuid.UUID) (*domain.BalanceAssertion, error) {
+	a, ok := m.assertions[id]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return a, nil
+}
+
+func (m *mockAssertionRepo) FindByRunID(_ context.Context, _ uuid.UUID) ([]*domain.BalanceAssertion, error) {
+	return nil, nil
+}
+
+func (m *mockAssertionRepo) Update(_ context.Context, a *domain.BalanceAssertion) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.assertions[a.AssertionID] = a
+	return nil
+}
+
+func (m *mockAssertionRepo) List(_ context.Context, _ domain.AssertionFilter) ([]*domain.BalanceAssertion, error) {
+	return nil, nil
+}
+
+type mockTrendRepo struct {
+	trends   map[string]*domain.ImbalanceTrend
+	upserted []*domain.ImbalanceTrend
+}
+
+func newMockTrendRepo() *mockTrendRepo {
+	return &mockTrendRepo{
+		trends: make(map[string]*domain.ImbalanceTrend),
+	}
+}
+
+func (m *mockTrendRepo) Upsert(_ context.Context, trend *domain.ImbalanceTrend) error {
+	m.trends[trend.InstrumentCode] = trend
+	m.upserted = append(m.upserted, trend)
+	return nil
+}
+
+func (m *mockTrendRepo) FindByInstrumentCode(_ context.Context, code string) (*domain.ImbalanceTrend, error) {
+	t, ok := m.trends[code]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	if t.ResolvedAt != nil {
+		return nil, domain.ErrNotFound
+	}
+	return t, nil
+}
+
+type mockPKClient struct {
+	summary *PositionSummary
+	err     error
+}
+
+func (m *mockPKClient) GetPositionSummary(_ context.Context, _, _ string) (*PositionSummary, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.summary, nil
+}
+
+type mockFAClient struct {
+	detail *DiagnosticDetail
+	err    error
+}
+
+func (m *mockFAClient) GetDiagnosticDetail(_ context.Context, _, _ string) (*DiagnosticDetail, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.detail, nil
+}
+
+type mockEventPublisher struct {
+	events []*domain.BalanceImbalanceDetectedEvent
+	err    error
+}
+
+func (m *mockEventPublisher) PublishBalanceImbalanceDetected(_ context.Context, event *domain.BalanceImbalanceDetectedEvent) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.events = append(m.events, event)
+	return nil
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+}
+
+// --- Tests ---
+
+func TestExecuteBalanceAssertion_Balanced(t *testing.T) {
+	repo := newMockAssertionRepo()
+	trendRepo := newMockTrendRepo()
+	publisher := &mockEventPublisher{}
+
+	pkClient := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.NewFromFloat(50000.00),
+			TotalCredits:   decimal.NewFromFloat(50000.00),
+		},
+	}
+
+	assertor := NewBalanceAssertor(repo, trendRepo, pkClient, nil, publisher, testLogger())
+
+	result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Assertion)
+	assert.Equal(t, domain.AssertionStatusPassed, result.Assertion.Status)
+	assert.Nil(t, result.Event, "no imbalance event for balanced assertion")
+	assert.Empty(t, publisher.events, "no events published for balanced assertion")
+}
+
+func TestExecuteBalanceAssertion_Imbalanced(t *testing.T) {
+	repo := newMockAssertionRepo()
+	trendRepo := newMockTrendRepo()
+	publisher := &mockEventPublisher{}
+
+	pkClient := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.NewFromFloat(50000.00),
+			TotalCredits:   decimal.NewFromFloat(49500.00),
+		},
+	}
+
+	assertor := NewBalanceAssertor(repo, trendRepo, pkClient, nil, publisher, testLogger())
+
+	result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.Assertion)
+	assert.Equal(t, domain.AssertionStatusFailed, result.Assertion.Status)
+	assert.Contains(t, result.Assertion.FailureReason, "CRITICAL")
+	assert.Contains(t, result.Assertion.FailureReason, "imbalance=500")
+
+	// Event should be published
+	require.NotNil(t, result.Event)
+	assert.Equal(t, "P1_CRITICAL", result.Event.Severity)
+	assert.Equal(t, "GBP", result.Event.InstrumentCode)
+	assert.True(t, decimal.NewFromFloat(500.00).Equal(result.Event.ImbalanceAmount))
+
+	require.Len(t, publisher.events, 1)
+	assert.Equal(t, "P1_CRITICAL", publisher.events[0].Severity)
+}
+
+func TestExecuteBalanceAssertion_DecimalPrecision(t *testing.T) {
+	repo := newMockAssertionRepo()
+	trendRepo := newMockTrendRepo()
+
+	// Test with very precise decimal amounts
+	pkClient := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "KWH",
+			TotalDebits:    decimal.RequireFromString("123456.789012345678"),
+			TotalCredits:   decimal.RequireFromString("123456.789012345678"),
+		},
+	}
+
+	assertor := NewBalanceAssertor(repo, trendRepo, pkClient, nil, nil, testLogger())
+
+	result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "KWH",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, domain.AssertionStatusPassed, result.Assertion.Status)
+}
+
+func TestExecuteBalanceAssertion_SmallImbalance(t *testing.T) {
+	repo := newMockAssertionRepo()
+	trendRepo := newMockTrendRepo()
+
+	// Test with tiny precision difference - should still detect
+	pkClient := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.RequireFromString("100000.000000000001"),
+			TotalCredits:   decimal.RequireFromString("100000.000000000000"),
+		},
+	}
+
+	assertor := NewBalanceAssertor(repo, trendRepo, pkClient, nil, nil, testLogger())
+
+	result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, domain.AssertionStatusFailed, result.Assertion.Status,
+		"even tiny imbalances must be detected")
+}
+
+func TestExecuteBalanceAssertion_CrossAccountAuthorization(t *testing.T) {
+	repo := newMockAssertionRepo()
+	trendRepo := newMockTrendRepo()
+	pkClient := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.NewFromFloat(50000.00),
+			TotalCredits:   decimal.NewFromFloat(50000.00),
+		},
+	}
+
+	assertor := NewBalanceAssertor(repo, trendRepo, pkClient, nil, nil, testLogger())
+
+	t.Run("tenant admin denied for cross-account", func(t *testing.T) {
+		_, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+			AccountID:       "ACC-001",
+			InstrumentCode:  "GBP",
+			Expression:      "total_debits == total_credits",
+			ExpectedBalance: decimal.Zero,
+			Scope:           domain.AssertionScopeCrossAccount,
+			CallerRole:      CallerRoleTenantAdmin,
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrUnauthorized)
+	})
+
+	t.Run("system role allowed for cross-account", func(t *testing.T) {
+		result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+			AccountID:       "ACC-001",
+			InstrumentCode:  "GBP",
+			Expression:      "total_debits == total_credits",
+			ExpectedBalance: decimal.Zero,
+			Scope:           domain.AssertionScopeCrossAccount,
+			CallerRole:      CallerRoleSystem,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, domain.AssertionStatusPassed, result.Assertion.Status)
+	})
+
+	t.Run("auditor role allowed for cross-account", func(t *testing.T) {
+		result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+			AccountID:       "ACC-001",
+			InstrumentCode:  "GBP",
+			Expression:      "total_debits == total_credits",
+			ExpectedBalance: decimal.Zero,
+			Scope:           domain.AssertionScopeCrossAccount,
+			CallerRole:      CallerRoleAuditor,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, domain.AssertionStatusPassed, result.Assertion.Status)
+	})
+}
+
+func TestExecuteBalanceAssertion_NostroVostroUnimplemented(t *testing.T) {
+	repo := newMockAssertionRepo()
+	assertor := NewBalanceAssertor(repo, nil, nil, nil, nil, testLogger())
+
+	_, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopeNostroVostro,
+		CallerRole:      CallerRoleSystem,
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrUnimplemented)
+}
+
+func TestExecuteBalanceAssertion_PKClientError(t *testing.T) {
+	repo := newMockAssertionRepo()
+	pkClient := &mockPKClient{
+		err: errors.New("connection refused"),
+	}
+
+	assertor := NewBalanceAssertor(repo, nil, pkClient, nil, nil, testLogger())
+
+	result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "querying position keeping")
+
+	// The assertion should still be persisted with FAILED status
+	require.NotNil(t, result)
+	assert.Equal(t, domain.AssertionStatusFailed, result.Assertion.Status)
+}
+
+func TestExecuteBalanceAssertion_TrendTracking(t *testing.T) {
+	trendRepo := newMockTrendRepo()
+	publisher := &mockEventPublisher{}
+
+	imbalancedPK := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.NewFromFloat(50000.00),
+			TotalCredits:   decimal.NewFromFloat(49000.00),
+		},
+	}
+
+	assertor := NewBalanceAssertor(newMockAssertionRepo(), trendRepo, imbalancedPK, nil, publisher, testLogger())
+
+	// Simulate 3 consecutive days of imbalance
+	for i := 0; i < 3; i++ {
+		result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+			AccountID:       "ACC-001",
+			InstrumentCode:  "GBP",
+			Expression:      "total_debits == total_credits",
+			ExpectedBalance: decimal.Zero,
+			Scope:           domain.AssertionScopePositionLedger,
+			CallerRole:      CallerRoleTenantAdmin,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, domain.AssertionStatusFailed, result.Assertion.Status)
+	}
+
+	// Verify trend is now persistent (3 consecutive days)
+	trend := trendRepo.trends["GBP"]
+	require.NotNil(t, trend)
+	assert.Equal(t, 3, trend.ConsecutiveDays)
+	assert.True(t, trend.IsPersistent())
+
+	// The last event should indicate persistence
+	require.True(t, len(publisher.events) >= 3)
+	lastEvent := publisher.events[len(publisher.events)-1]
+	assert.True(t, lastEvent.IsPersistent)
+	assert.Equal(t, 3, lastEvent.ConsecutiveDays)
+}
+
+func TestExecuteBalanceAssertion_TrendResolution(t *testing.T) {
+	trendRepo := newMockTrendRepo()
+
+	imbalancedPK := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.NewFromFloat(50000.00),
+			TotalCredits:   decimal.NewFromFloat(49000.00),
+		},
+	}
+
+	assertor := NewBalanceAssertor(newMockAssertionRepo(), trendRepo, imbalancedPK, nil, nil, testLogger())
+
+	// Create imbalance
+	_, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+	require.NoError(t, err)
+
+	trend := trendRepo.trends["GBP"]
+	require.NotNil(t, trend)
+	assert.Equal(t, 1, trend.ConsecutiveDays)
+
+	// Now resolve with balanced PK
+	balancedPK := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.NewFromFloat(50000.00),
+			TotalCredits:   decimal.NewFromFloat(50000.00),
+		},
+	}
+
+	assertor2 := NewBalanceAssertor(newMockAssertionRepo(), trendRepo, balancedPK, nil, nil, testLogger())
+
+	result, err := assertor2.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, domain.AssertionStatusPassed, result.Assertion.Status)
+
+	// Trend should be resolved
+	trend = trendRepo.trends["GBP"]
+	require.NotNil(t, trend)
+	assert.NotNil(t, trend.ResolvedAt)
+	assert.Equal(t, 0, trend.ConsecutiveDays)
+}
+
+func TestExecuteBalanceAssertion_FADiagnosticEnrichment(t *testing.T) {
+	repo := newMockAssertionRepo()
+
+	pkClient := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.NewFromFloat(50000.00),
+			TotalCredits:   decimal.NewFromFloat(49000.00),
+		},
+	}
+
+	faClient := &mockFAClient{
+		detail: &DiagnosticDetail{
+			AccountID:       "ACC-001",
+			InstrumentCode:  "GBP",
+			JournalEntryIDs: []string{"JE-001", "JE-002"},
+			Message:         "Missing contra-entry for JE-001",
+		},
+	}
+
+	assertor := NewBalanceAssertor(repo, newMockTrendRepo(), pkClient, faClient, nil, testLogger())
+
+	result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, domain.AssertionStatusFailed, result.Assertion.Status)
+
+	// FA diagnostics should be in attributes
+	require.NotNil(t, result.Assertion.Attributes)
+	assert.Equal(t, "Missing contra-entry for JE-001", result.Assertion.Attributes["fa_diagnostic_message"])
+}
+
+func TestExecuteBalanceAssertion_FAClientError(t *testing.T) {
+	repo := newMockAssertionRepo()
+
+	pkClient := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.NewFromFloat(50000.00),
+			TotalCredits:   decimal.NewFromFloat(49000.00),
+		},
+	}
+
+	faClient := &mockFAClient{
+		err: errors.New("FA service unavailable"),
+	}
+
+	assertor := NewBalanceAssertor(repo, newMockTrendRepo(), pkClient, faClient, nil, testLogger())
+
+	// FA failure should not prevent assertion from completing
+	result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, domain.AssertionStatusFailed, result.Assertion.Status)
+}
+
+func TestExecuteBalanceAssertion_WithRunID(t *testing.T) {
+	repo := newMockAssertionRepo()
+
+	pkClient := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.NewFromFloat(50000.00),
+			TotalCredits:   decimal.NewFromFloat(50000.00),
+		},
+	}
+
+	runID := uuid.New()
+	assertor := NewBalanceAssertor(repo, nil, pkClient, nil, nil, testLogger())
+
+	result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		RunID:           &runID,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, &runID, result.Assertion.RunID)
+}
+
+func TestExecuteBalanceAssertion_ValidationErrors(t *testing.T) {
+	assertor := NewBalanceAssertor(newMockAssertionRepo(), nil, &mockPKClient{}, nil, nil, testLogger())
+
+	t.Run("empty account ID", func(t *testing.T) {
+		_, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+			AccountID:       "",
+			InstrumentCode:  "GBP",
+			Expression:      "expr",
+			ExpectedBalance: decimal.Zero,
+			Scope:           domain.AssertionScopePositionLedger,
+			CallerRole:      CallerRoleTenantAdmin,
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrEmptyAccountID)
+	})
+
+	t.Run("empty instrument code", func(t *testing.T) {
+		_, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+			AccountID:       "ACC-001",
+			InstrumentCode:  "",
+			Expression:      "expr",
+			ExpectedBalance: decimal.Zero,
+			Scope:           domain.AssertionScopePositionLedger,
+			CallerRole:      CallerRoleTenantAdmin,
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrEmptyInstrumentCode)
+	})
+
+	t.Run("empty expression", func(t *testing.T) {
+		_, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+			AccountID:       "ACC-001",
+			InstrumentCode:  "GBP",
+			Expression:      "",
+			ExpectedBalance: decimal.Zero,
+			Scope:           domain.AssertionScopePositionLedger,
+			CallerRole:      CallerRoleTenantAdmin,
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, domain.ErrEmptyAssertionExpression)
+	})
+}
+
+func TestExecuteBalanceAssertion_EventPublisherError(t *testing.T) {
+	repo := newMockAssertionRepo()
+	publisher := &mockEventPublisher{
+		err: errors.New("kafka unavailable"),
+	}
+
+	pkClient := &mockPKClient{
+		summary: &PositionSummary{
+			InstrumentCode: "GBP",
+			TotalDebits:    decimal.NewFromFloat(50000.00),
+			TotalCredits:   decimal.NewFromFloat(49000.00),
+		},
+	}
+
+	assertor := NewBalanceAssertor(repo, newMockTrendRepo(), pkClient, nil, publisher, testLogger())
+
+	// Publisher error should not prevent assertion from completing
+	result, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		Expression:      "total_debits == total_credits",
+		ExpectedBalance: decimal.Zero,
+		Scope:           domain.AssertionScopePositionLedger,
+		CallerRole:      CallerRoleTenantAdmin,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, domain.AssertionStatusFailed, result.Assertion.Status)
+}
+
+func TestImbalanceTrend_IsPersistent(t *testing.T) {
+	trend := &domain.ImbalanceTrend{
+		InstrumentCode:  "GBP",
+		ConsecutiveDays: 2,
+	}
+	assert.False(t, trend.IsPersistent())
+
+	trend.ConsecutiveDays = 3
+	assert.True(t, trend.IsPersistent())
+
+	trend.ConsecutiveDays = 10
+	assert.True(t, trend.IsPersistent())
+}
+
+func TestImbalanceTrend_RecordAndResolve(t *testing.T) {
+	trend := &domain.ImbalanceTrend{
+		TrendID:        uuid.New(),
+		InstrumentCode: "GBP",
+	}
+
+	assertionID := uuid.New()
+	trend.RecordImbalance(decimal.NewFromFloat(500), assertionID)
+
+	assert.Equal(t, 1, trend.ConsecutiveDays)
+	assert.Equal(t, assertionID, trend.LastAssertionID)
+	assert.Nil(t, trend.ResolvedAt)
+
+	trend.Resolve()
+	assert.Equal(t, 0, trend.ConsecutiveDays)
+	assert.NotNil(t, trend.ResolvedAt)
+}
+
+func TestInferScope(t *testing.T) {
+	assert.Equal(t, domain.AssertionScopeCrossAccount, inferScope("any", "SYSTEM"))
+	assert.Equal(t, domain.AssertionScopeCrossAccount, inferScope("any", "*"))
+	assert.Equal(t, domain.AssertionScopePositionLedger, inferScope("any", "ACC-001"))
+}

--- a/services/reconciliation/service/balance_assertor_test.go
+++ b/services/reconciliation/service/balance_assertor_test.go
@@ -319,7 +319,8 @@ func TestExecuteBalanceAssertion_CrossAccountAuthorization(t *testing.T) {
 
 func TestExecuteBalanceAssertion_NostroVostroUnimplemented(t *testing.T) {
 	repo := newMockAssertionRepo()
-	assertor := NewBalanceAssertor(repo, nil, nil, nil, nil, testLogger())
+	pkClient := &mockPKClient{} // not used; scope check returns before PK call
+	assertor := NewBalanceAssertor(repo, nil, pkClient, nil, nil, testLogger())
 
 	_, err := assertor.ExecuteBalanceAssertion(context.Background(), AssertBalanceRequest{
 		AccountID:       "ACC-001",

--- a/services/reconciliation/service/fa_client.go
+++ b/services/reconciliation/service/fa_client.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"context"
+)
+
+// DiagnosticDetail holds drill-down information from Financial Accounting.
+type DiagnosticDetail struct {
+	AccountID       string
+	InstrumentCode  string
+	JournalEntryIDs []string
+	Message         string
+}
+
+// FinancialAccountingClient defines the interface for querying Financial Accounting
+// service for diagnostic drill-down on balance assertion failures.
+type FinancialAccountingClient interface {
+	// GetDiagnosticDetail retrieves detailed journal entry information
+	// for a given account and instrument to help diagnose imbalances.
+	GetDiagnosticDetail(ctx context.Context, accountID, instrumentCode string) (*DiagnosticDetail, error)
+}

--- a/services/reconciliation/service/pk_client.go
+++ b/services/reconciliation/service/pk_client.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"context"
+
+	"github.com/shopspring/decimal"
+)
+
+// PositionSummary holds aggregated debit/credit totals for an instrument code.
+type PositionSummary struct {
+	InstrumentCode string
+	TotalDebits    decimal.Decimal
+	TotalCredits   decimal.Decimal
+}
+
+// PositionKeepingClient defines the interface for querying Position Keeping service
+// to retrieve aggregated position summaries for balance assertion checks.
+type PositionKeepingClient interface {
+	// GetPositionSummary returns aggregated debits and credits for an account
+	// and instrument code. If accountID is empty for cross-account scope,
+	// the implementation should aggregate across all accounts for the instrument.
+	GetPositionSummary(ctx context.Context, accountID, instrumentCode string) (*PositionSummary, error)
+}

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -1,16 +1,22 @@
 // Package service implements the gRPC AccountReconciliationService.
 //
-// Dispute RPCs are implemented in dispute_handler.go. Other RPCs currently
-// return UNIMPLEMENTED status and will be added in subsequent tasks.
+// Dispute RPCs are implemented in dispute_handler.go. The AssertBalance RPC
+// is implemented with cross-account balance assertion logic. Other RPCs
+// currently return UNIMPLEMENTED status and will be added in subsequent tasks.
 package service
 
 import (
 	"context"
+	"errors"
 
+	"github.com/google/uuid"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
 	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // AccountReconciliationService implements the gRPC service for reconciliation operations.
@@ -21,6 +27,7 @@ type AccountReconciliationService struct {
 	varianceRepo   VarianceFinder
 	sagaRuntime    SagaRuntime
 	eventPublisher EventPublisher
+	assertor       *BalanceAssertor
 }
 
 // Option configures the AccountReconciliationService.
@@ -54,7 +61,15 @@ func WithEventPublisher(pub EventPublisher) Option {
 	}
 }
 
+// WithBalanceAssertor sets the balance assertor for the service.
+func WithBalanceAssertor(assertor *BalanceAssertor) Option {
+	return func(s *AccountReconciliationService) {
+		s.assertor = assertor
+	}
+}
+
 // NewAccountReconciliationService creates a new AccountReconciliationService.
+// The assertor is optional; if nil, AssertBalance returns UNIMPLEMENTED.
 func NewAccountReconciliationService(opts ...Option) *AccountReconciliationService {
 	svc := &AccountReconciliationService{}
 	for _, opt := range opts {
@@ -105,8 +120,131 @@ func (s *AccountReconciliationService) ListReconciliationResults(
 
 // AssertBalance evaluates a balance assertion against current positions.
 func (s *AccountReconciliationService) AssertBalance(
-	_ context.Context,
-	_ *reconciliationv1.AssertBalanceRequest,
+	ctx context.Context,
+	req *reconciliationv1.AssertBalanceRequest,
 ) (*reconciliationv1.AssertBalanceResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "AssertBalance not yet implemented")
+	if s.assertor == nil {
+		return nil, status.Error(codes.Unimplemented, "AssertBalance not yet implemented")
+	}
+
+	expectedBalance, err := decimal.NewFromString(req.GetExpectedBalance())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid expected_balance: %v", err)
+	}
+
+	var runID *uuid.UUID
+	if req.GetRunId() != "" {
+		parsed, err := uuid.Parse(req.GetRunId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid run_id: %v", err)
+		}
+		runID = &parsed
+	}
+
+	// Extract caller role from gRPC metadata
+	callerRole := extractCallerRole(ctx)
+
+	// Determine scope from expression or default
+	scope := inferScope(req.GetExpression(), req.GetAccountId())
+
+	result, err := s.assertor.ExecuteBalanceAssertion(ctx, AssertBalanceRequest{
+		AccountID:       req.GetAccountId(),
+		InstrumentCode:  req.GetInstrumentCode(),
+		Expression:      req.GetExpression(),
+		ExpectedBalance: expectedBalance,
+		RunID:           runID,
+		Scope:           scope,
+		CallerRole:      callerRole,
+	})
+	if err != nil {
+		if errors.Is(err, domain.ErrUnauthorized) {
+			return nil, status.Error(codes.PermissionDenied, err.Error())
+		}
+		if errors.Is(err, domain.ErrUnimplemented) {
+			return nil, status.Error(codes.Unimplemented, "NOSTRO_VOSTRO scope not yet implemented")
+		}
+		return nil, status.Error(codes.Internal, "balance assertion failed")
+	}
+
+	return &reconciliationv1.AssertBalanceResponse{
+		Assertion: toProtoAssertionDetail(result.Assertion),
+	}, nil
+}
+
+// extractCallerRole reads the caller's role from gRPC metadata.
+func extractCallerRole(ctx context.Context) CallerRole {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return CallerRoleTenantAdmin
+	}
+
+	roles := md.Get("x-meridian-role")
+	if len(roles) == 0 {
+		return CallerRoleTenantAdmin
+	}
+
+	switch roles[0] {
+	case "SYSTEM":
+		return CallerRoleSystem
+	case "AUDITOR":
+		return CallerRoleAuditor
+	default:
+		return CallerRoleTenantAdmin
+	}
+}
+
+// inferScope determines the assertion scope from the expression and account ID.
+func inferScope(expression, accountID string) domain.AssertionScope {
+	// If the expression mentions cross-account or the account is a system marker
+	if accountID == "SYSTEM" || accountID == "*" {
+		return domain.AssertionScopeCrossAccount
+	}
+	_ = expression // Expression-based scope inference can be added later
+	return domain.AssertionScopePositionLedger
+}
+
+// toProtoAssertionDetail converts a domain BalanceAssertion to proto.
+func toProtoAssertionDetail(a *domain.BalanceAssertion) *reconciliationv1.BalanceAssertionDetail {
+	if a == nil {
+		return nil
+	}
+
+	detail := &reconciliationv1.BalanceAssertionDetail{
+		AssertionId:     a.AssertionID.String(),
+		AccountId:       a.AccountID,
+		InstrumentCode:  a.InstrumentCode,
+		Expression:      a.Expression,
+		ExpectedBalance: a.ExpectedBalance.String(),
+		ActualBalance:   a.ActualBalance.String(),
+		Status:          toProtoAssertionStatus(a.Status),
+		FailureReason:   a.FailureReason,
+		OverrideReason:  a.OverrideReason,
+		CreatedAt:       timestamppb.New(a.CreatedAt),
+	}
+
+	if a.RunID != nil {
+		detail.RunId = a.RunID.String()
+	}
+
+	if !a.AssertedAt.IsZero() {
+		detail.AssertedAt = timestamppb.New(a.AssertedAt)
+	}
+
+	return detail
+}
+
+// toProtoAssertionStatus converts domain AssertionStatus to proto enum.
+func toProtoAssertionStatus(s domain.AssertionStatus) reconciliationv1.AssertionStatus {
+	switch s {
+	case domain.AssertionStatusPending:
+		return reconciliationv1.AssertionStatus_ASSERTION_STATUS_PENDING
+	case domain.AssertionStatusPassed:
+		return reconciliationv1.AssertionStatus_ASSERTION_STATUS_PASSED
+	case domain.AssertionStatusFailed:
+		return reconciliationv1.AssertionStatus_ASSERTION_STATUS_FAILED
+	case domain.AssertionStatusOverride:
+		return reconciliationv1.AssertionStatus_ASSERTION_STATUS_OVERRIDE
+	default:
+		return reconciliationv1.AssertionStatus_ASSERTION_STATUS_UNSPECIFIED
+	}
 }

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -163,6 +163,11 @@ func (s *AccountReconciliationService) AssertBalance(
 		if errors.Is(err, domain.ErrUnimplemented) {
 			return nil, status.Error(codes.Unimplemented, "NOSTRO_VOSTRO scope not yet implemented")
 		}
+		if errors.Is(err, domain.ErrEmptyAccountID) ||
+			errors.Is(err, domain.ErrEmptyInstrumentCode) ||
+			errors.Is(err, domain.ErrEmptyAssertionExpression) {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
 		return nil, status.Error(codes.Internal, "balance assertion failed")
 	}
 

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -172,6 +172,9 @@ func (s *AccountReconciliationService) AssertBalance(
 }
 
 // extractCallerRole reads the caller's role from gRPC metadata.
+// TODO: Replace with validated role from auth interceptor/gateway. Currently
+// trusts client-supplied metadata which is acceptable for internal service-to-service
+// calls but must be secured before external exposure.
 func extractCallerRole(ctx context.Context) CallerRole {
 	md, ok := metadata.FromIncomingContext(ctx)
 	if !ok {


### PR DESCRIPTION
## Summary

- Implement balance assertion checks for accounting integrity (Task reconciliation-service.9)
- `BalanceAssertor` queries Position Keeping for aggregated debits/credits per instrument, detects imbalances (total_debits != total_credits), and publishes P1/Critical `BalanceImbalanceDetectedEvent` alerts
- Authorization enforcement: `CROSS_ACCOUNT` scope requires `SYSTEM` or `AUDITOR` role (not standard tenant admin)
- Persistent imbalance trend tracking with 3-consecutive-day threshold triggers escalated critical alerts
- Financial Accounting client adapter enriches failed assertions with diagnostic drill-down details
- Prometheus `balance_imbalance_amount` gauge (should always be 0 in healthy system) and assertion counters
- `NOSTRO_VOSTRO` scope deferred (returns unimplemented error)

## Changes Made

### Domain Layer
- `assertion_scope.go`: `POSITION_LEDGER`, `CROSS_ACCOUNT`, `NOSTRO_VOSTRO` enum
- `imbalance_trend.go`: Tracks consecutive days of imbalance per instrument
- `balance_imbalance_event.go`: P1/Critical event for ledger integrity violations
- `errors.go`: Added `ErrUnauthorized`, `ErrUnimplemented`
- `repository.go`: Added `ImbalanceTrendRepository`, extended `AssertionFilter`

### Service Layer
- `balance_assertor.go`: Core business logic with PK integration, authorization, trend tracking, FA diagnostics
- `pk_client.go`: `PositionKeepingClient` interface for position summary queries
- `fa_client.go`: `FinancialAccountingClient` interface for diagnostic drill-down
- `service.go`: Wired `AssertBalance` gRPC handler with scope inference and role extraction

### Observability
- `metrics.go`: `balance_imbalance_amount` gauge, `balance_assertion_total` counter, `persistent_imbalance_days` gauge

### Migration
- `20260209000002_imbalance_trend.sql`: Trend tracking table with partial unique index on active trends

## Test plan

- [x] Balanced assertion returns PASSED status, no event published
- [x] Imbalanced assertion returns FAILED status with P1_CRITICAL event
- [x] Decimal precision preserved (18 decimal places)
- [x] Tiny imbalances (0.000000000001) detected
- [x] CROSS_ACCOUNT denied for TENANT_ADMIN, allowed for SYSTEM/AUDITOR
- [x] NOSTRO_VOSTRO returns ErrUnimplemented
- [x] PK client errors result in FAILED assertion with error propagation
- [x] 3-day persistent imbalance trend detection and resolution
- [x] FA diagnostic enrichment on failure (graceful degradation on FA error)
- [x] Event publisher errors do not block assertion completion
- [x] Validation: empty account ID, instrument code, expression
- [x] Run ID association preserved
- [x] Existing service tests pass (backward compatibility via optional assertor)