### PR TITLE
feat: implement dispute workflow with state machine and resolution handlers

### DIFF
--- a/services/reconciliation/adapters/persistence/dispute_repository.go
+++ b/services/reconciliation/adapters/persistence/dispute_repository.go
@@ -1,0 +1,366 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+// Compile-time check that DisputeRepository implements domain.DisputeRepository.
+var _ domain.DisputeRepository = (*DisputeRepository)(nil)
+
+// DisputeRepository provides GORM-based persistence for disputes.
+type DisputeRepository struct {
+	db *gorm.DB
+}
+
+// NewDisputeRepository creates a new dispute repository.
+func NewDisputeRepository(db *gorm.DB) *DisputeRepository {
+	return &DisputeRepository{db: db}
+}
+
+// withTenantTransaction executes fn within a tenant-scoped transaction.
+func (r *DisputeRepository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if r.isInTransaction() {
+		tx, err := db.WithGormTenantScope(ctx, r.db.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+		return fn(tx)
+	}
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// isInTransaction checks if the repository's db connection is already within a transaction.
+func (r *DisputeRepository) isInTransaction() bool {
+	if r.db.Statement == nil || r.db.Statement.ConnPool == nil {
+		return false
+	}
+	committer, ok := r.db.Statement.ConnPool.(gorm.TxCommitter)
+	return ok && committer != nil
+}
+
+// Create persists a new Dispute.
+func (r *DisputeRepository) Create(ctx context.Context, dispute *domain.Dispute) error {
+	entity := toDisputeEntity(dispute)
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Create(entity).Error
+	})
+}
+
+// FindByID retrieves a Dispute by its DisputeID.
+func (r *DisputeRepository) FindByID(ctx context.Context, disputeID uuid.UUID) (*domain.Dispute, error) {
+	var entity DisputeEntity
+	var queryErr error
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("dispute_id = ?", disputeID).First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+
+	return toDisputeDomain(&entity), nil
+}
+
+// FindByVarianceID retrieves all disputes for a variance.
+func (r *DisputeRepository) FindByVarianceID(ctx context.Context, varianceID uuid.UUID) ([]*domain.Dispute, error) {
+	var entities []DisputeEntity
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Where("variance_id = ?", varianceID).
+			Order("created_at ASC").
+			Find(&entities).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toDisputeDomainSlice(entities), nil
+}
+
+// Update updates an existing Dispute.
+func (r *DisputeRepository) Update(ctx context.Context, dispute *domain.Dispute) error {
+	entity := toDisputeEntity(dispute)
+	var rowsAffected int64
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Model(&DisputeEntity{}).
+			Where("dispute_id = ?", entity.DisputeID).
+			Updates(map[string]interface{}{
+				"status":      entity.Status,
+				"resolution":  entity.Resolution,
+				"resolved_by": entity.ResolvedBy,
+				"resolved_at": entity.ResolvedAt,
+				"updated_at":  time.Now().UTC(),
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+// List retrieves disputes matching the given filter.
+func (r *DisputeRepository) List(ctx context.Context, filter domain.DisputeFilter) ([]*domain.Dispute, error) {
+	var entities []DisputeEntity
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		query := tx.Model(&DisputeEntity{})
+
+		if filter.RunID != nil {
+			query = query.Where("run_id = ?", *filter.RunID)
+		}
+		if filter.AccountID != nil {
+			query = query.Where("account_id = ?", *filter.AccountID)
+		}
+		if filter.Status != nil {
+			query = query.Where("status = ?", string(*filter.Status))
+		}
+
+		limit := filter.Limit
+		if limit <= 0 {
+			limit = 50
+		}
+		if limit > 1000 {
+			limit = 1000
+		}
+		query = query.Limit(limit)
+
+		if filter.Offset > 0 {
+			query = query.Offset(filter.Offset)
+		}
+
+		return query.Order("created_at DESC").Find(&entities).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toDisputeDomainSlice(entities), nil
+}
+
+// toDisputeEntity converts a domain Dispute to a persistence entity.
+func toDisputeEntity(d *domain.Dispute) *DisputeEntity {
+	entity := &DisputeEntity{
+		DisputeID:  d.DisputeID,
+		VarianceID: d.VarianceID,
+		RunID:      d.RunID,
+		AccountID:  d.AccountID,
+		Status:     string(d.Status),
+		Reason:     d.Reason,
+		RaisedBy:   d.RaisedBy,
+		ResolvedAt: d.ResolvedAt,
+		CreatedAt:  d.CreatedAt,
+		UpdatedAt:  d.UpdatedAt,
+	}
+
+	if d.Resolution != "" {
+		entity.Resolution = &d.Resolution
+	}
+	if d.ResolvedBy != "" {
+		entity.ResolvedBy = &d.ResolvedBy
+	}
+	if d.Attributes != nil {
+		entity.Attributes = JSONMap(d.Attributes)
+	}
+
+	return entity
+}
+
+// toDisputeDomain converts a persistence entity to a domain Dispute.
+func toDisputeDomain(e *DisputeEntity) *domain.Dispute {
+	d := &domain.Dispute{
+		DisputeID:  e.DisputeID,
+		VarianceID: e.VarianceID,
+		RunID:      e.RunID,
+		AccountID:  e.AccountID,
+		Status:     domain.DisputeStatus(e.Status),
+		Reason:     e.Reason,
+		RaisedBy:   e.RaisedBy,
+		ResolvedAt: e.ResolvedAt,
+		CreatedAt:  e.CreatedAt,
+		UpdatedAt:  e.UpdatedAt,
+	}
+
+	if e.Resolution != nil {
+		d.Resolution = *e.Resolution
+	}
+	if e.ResolvedBy != nil {
+		d.ResolvedBy = *e.ResolvedBy
+	}
+	if e.Attributes != nil {
+		d.Attributes = map[string]string(e.Attributes)
+	}
+
+	return d
+}
+
+// toDisputeDomainSlice converts a slice of entities to domain objects.
+func toDisputeDomainSlice(entities []DisputeEntity) []*domain.Dispute {
+	disputes := make([]*domain.Dispute, 0, len(entities))
+	for i := range entities {
+		disputes = append(disputes, toDisputeDomain(&entities[i]))
+	}
+	return disputes
+}
+
+// VarianceRepository provides GORM-based persistence for variances.
+// This is a minimal repository scoped to operations needed by the dispute workflow.
+type VarianceRepository struct {
+	db *gorm.DB
+}
+
+// NewVarianceRepository creates a new variance repository.
+func NewVarianceRepository(db *gorm.DB) *VarianceRepository {
+	return &VarianceRepository{db: db}
+}
+
+// withTenantTransaction executes fn within a tenant-scoped transaction.
+func (r *VarianceRepository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if r.isInTransaction() {
+		tx, err := db.WithGormTenantScope(ctx, r.db.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+		return fn(tx)
+	}
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// isInTransaction checks if the repository's db connection is already within a transaction.
+func (r *VarianceRepository) isInTransaction() bool {
+	if r.db.Statement == nil || r.db.Statement.ConnPool == nil {
+		return false
+	}
+	committer, ok := r.db.Statement.ConnPool.(gorm.TxCommitter)
+	return ok && committer != nil
+}
+
+// FindByID retrieves a Variance by its VarianceID (needed to validate disputes).
+func (r *VarianceRepository) FindByID(ctx context.Context, varianceID uuid.UUID) (*domain.Variance, error) {
+	var entity VarianceEntity
+	var queryErr error
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("variance_id = ?", varianceID).First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+
+	return toVarianceDomain(&entity), nil
+}
+
+// UpdateStatus updates the status of a variance by its VarianceID.
+func (r *VarianceRepository) UpdateStatus(ctx context.Context, varianceID uuid.UUID, status domain.VarianceStatus) error {
+	var rowsAffected int64
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Model(&VarianceEntity{}).
+			Where("variance_id = ?", varianceID).
+			Updates(map[string]interface{}{
+				"status":     string(status),
+				"updated_at": time.Now().UTC(),
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		return domain.ErrNotFound
+	}
+	return nil
+}
+
+// toVarianceDomain converts a persistence entity to a domain Variance.
+func toVarianceDomain(e *VarianceEntity) *domain.Variance {
+	v := &domain.Variance{
+		VarianceID:     e.VarianceID,
+		RunID:          e.RunID,
+		SnapshotID:     e.SnapshotID,
+		AccountID:      e.AccountID,
+		InstrumentCode: e.InstrumentCode,
+		ExpectedAmount: e.ExpectedAmount,
+		ActualAmount:   e.ActualAmount,
+		VarianceAmount: e.VarianceAmount,
+		Reason:         domain.VarianceReason(e.Reason),
+		Status:         domain.VarianceStatus(e.Status),
+		ResolvedAt:     e.ResolvedAt,
+		CreatedAt:      e.CreatedAt,
+		UpdatedAt:      e.UpdatedAt,
+	}
+
+	if e.ResolutionNote != nil {
+		v.ResolutionNote = *e.ResolutionNote
+	}
+	if e.ResolvedBy != nil {
+		v.ResolvedBy = *e.ResolvedBy
+	}
+	if e.Attributes != nil {
+		v.Attributes = map[string]string(e.Attributes)
+	}
+
+	return v
+}
+
+// VarianceEntity is the GORM entity for the variance table.
+type VarianceEntity struct {
+	ID             uuid.UUID       `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	CreatedAt      time.Time       `gorm:"not null;default:now()"`
+	UpdatedAt      time.Time       `gorm:"not null;default:now()"`
+	VarianceID     uuid.UUID       `gorm:"column:variance_id;uniqueIndex;type:uuid;not null"`
+	RunID          uuid.UUID       `gorm:"column:run_id;index;type:uuid;not null"`
+	SnapshotID     uuid.UUID       `gorm:"column:snapshot_id;index;type:uuid;not null"`
+	AccountID      string          `gorm:"column:account_id;index;size:34;not null"`
+	InstrumentCode string          `gorm:"column:instrument_code;size:20;not null"`
+	ExpectedAmount decimal.Decimal `gorm:"column:expected_amount;type:decimal(38,18);not null"`
+	ActualAmount   decimal.Decimal `gorm:"column:actual_amount;type:decimal(38,18);not null"`
+	VarianceAmount decimal.Decimal `gorm:"column:variance_amount;type:decimal(38,18);not null"`
+	Reason         string          `gorm:"column:reason;size:30;not null"`
+	Status         string          `gorm:"column:status;size:20;not null;default:OPEN"`
+	ResolutionNote *string         `gorm:"column:resolution_note;type:text"`
+	ResolvedBy     *string         `gorm:"column:resolved_by;size:100"`
+	ResolvedAt     *time.Time      `gorm:"column:resolved_at"`
+	Attributes     JSONMap         `gorm:"column:attributes;type:jsonb"`
+}
+
+// TableName returns the table name for the variance entity.
+func (VarianceEntity) TableName() string {
+	return "variance"
+}

--- a/services/reconciliation/adapters/persistence/dispute_repository_test.go
+++ b/services/reconciliation/adapters/persistence/dispute_repository_test.go
@@ -1,0 +1,347 @@
+package persistence_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupTestDB(t *testing.T) (*gorm.DB, func()) {
+	t.Helper()
+	if os.Getenv("INTEGRATION_TEST") == "" && testing.Short() {
+		t.Skip("Skipping integration test (set INTEGRATION_TEST=1 or remove -short)")
+	}
+
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+
+	// Create tenant schema and tables
+	tid := tenant.TenantID("test-tenant-01")
+	schemaName := tid.SchemaName()
+
+	err := db.Exec("CREATE SCHEMA IF NOT EXISTS " + schemaName).Error
+	require.NoError(t, err)
+
+	// Run migrations in the tenant schema
+	migrationSQL := `
+		SET search_path TO ` + schemaName + `, public;
+
+		CREATE TABLE IF NOT EXISTS "settlement_run" (
+			"id" uuid NOT NULL DEFAULT gen_random_uuid(),
+			"created_at" timestamptz NOT NULL DEFAULT now(),
+			"updated_at" timestamptz NOT NULL DEFAULT now(),
+			"run_id" uuid NOT NULL,
+			"account_id" character varying(34) NOT NULL,
+			"scope" character varying(20) NOT NULL DEFAULT 'ACCOUNT',
+			"settlement_type" character varying(20) NOT NULL DEFAULT 'DAILY',
+			"status" character varying(20) NOT NULL DEFAULT 'PENDING',
+			"period_start" timestamptz NOT NULL,
+			"period_end" timestamptz NOT NULL,
+			"initiated_by" character varying(100) NOT NULL,
+			"completed_at" timestamptz NULL,
+			"variance_count" integer NOT NULL DEFAULT 0,
+			"failure_reason" text NULL,
+			"attributes" jsonb NULL,
+			"version" bigint NOT NULL DEFAULT 1,
+			PRIMARY KEY ("id")
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS "idx_sr_run_id" ON "settlement_run" ("run_id");
+
+		CREATE TABLE IF NOT EXISTS "settlement_snapshot" (
+			"id" uuid NOT NULL DEFAULT gen_random_uuid(),
+			"created_at" timestamptz NOT NULL DEFAULT now(),
+			"snapshot_id" uuid NOT NULL,
+			"run_id" uuid NOT NULL REFERENCES "settlement_run" ("id") ON DELETE CASCADE,
+			"account_id" character varying(34) NOT NULL,
+			"instrument_code" character varying(20) NOT NULL,
+			"expected_balance" decimal(38, 18) NOT NULL,
+			"actual_balance" decimal(38, 18) NOT NULL,
+			"variance_amount" decimal(38, 18) NOT NULL,
+			"source_system" character varying(100) NOT NULL,
+			"attributes" jsonb NULL,
+			"captured_at" timestamptz NOT NULL,
+			PRIMARY KEY ("id")
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS "idx_ss_snap_id" ON "settlement_snapshot" ("snapshot_id");
+
+		CREATE TABLE IF NOT EXISTS "variance" (
+			"id" uuid NOT NULL DEFAULT gen_random_uuid(),
+			"created_at" timestamptz NOT NULL DEFAULT now(),
+			"updated_at" timestamptz NOT NULL DEFAULT now(),
+			"variance_id" uuid NOT NULL,
+			"run_id" uuid NOT NULL REFERENCES "settlement_run" ("id") ON DELETE CASCADE,
+			"snapshot_id" uuid NOT NULL REFERENCES "settlement_snapshot" ("id") ON DELETE CASCADE,
+			"account_id" character varying(34) NOT NULL,
+			"instrument_code" character varying(20) NOT NULL,
+			"expected_amount" decimal(38, 18) NOT NULL,
+			"actual_amount" decimal(38, 18) NOT NULL,
+			"variance_amount" decimal(38, 18) NOT NULL,
+			"reason" character varying(30) NOT NULL,
+			"status" character varying(20) NOT NULL DEFAULT 'OPEN',
+			"resolution_note" text NULL,
+			"resolved_by" character varying(100) NULL,
+			"resolved_at" timestamptz NULL,
+			"attributes" jsonb NULL,
+			PRIMARY KEY ("id")
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS "idx_v_var_id" ON "variance" ("variance_id");
+
+		CREATE TABLE IF NOT EXISTS "dispute" (
+			"id" uuid NOT NULL DEFAULT gen_random_uuid(),
+			"created_at" timestamptz NOT NULL DEFAULT now(),
+			"updated_at" timestamptz NOT NULL DEFAULT now(),
+			"dispute_id" uuid NOT NULL,
+			"variance_id" uuid NOT NULL REFERENCES "variance" ("id") ON DELETE CASCADE,
+			"run_id" uuid NOT NULL REFERENCES "settlement_run" ("id") ON DELETE CASCADE,
+			"account_id" character varying(34) NOT NULL,
+			"status" character varying(20) NOT NULL DEFAULT 'OPEN',
+			"reason" text NOT NULL,
+			"resolution" text NULL,
+			"raised_by" character varying(100) NOT NULL,
+			"resolved_by" character varying(100) NULL,
+			"resolved_at" timestamptz NULL,
+			"attributes" jsonb NULL,
+			PRIMARY KEY ("id")
+		);
+		CREATE UNIQUE INDEX IF NOT EXISTS "idx_d_disp_id" ON "dispute" ("dispute_id");
+
+		SET search_path TO public;
+	`
+	err = db.Exec(migrationSQL).Error
+	require.NoError(t, err)
+
+	return db, cleanup
+}
+
+func tenantCtx() context.Context {
+	tid := tenant.TenantID("test-tenant-01")
+	return tenant.WithTenant(context.Background(), tid)
+}
+
+// seedRunAndVariance creates prerequisite settlement_run, snapshot, and variance records.
+func seedRunAndVariance(t *testing.T, db *gorm.DB, runID, snapshotID, varianceID uuid.UUID) {
+	t.Helper()
+	ctx := tenantCtx()
+	tid := tenant.TenantID("test-tenant-01")
+	schemaName := tid.SchemaName()
+
+	// Insert settlement_run
+	err := db.WithContext(ctx).Exec(
+		`INSERT INTO "`+schemaName+`"."settlement_run" (run_id, account_id, scope, settlement_type, period_start, period_end, initiated_by) VALUES (?, 'ACC-001', 'ACCOUNT', 'DAILY', NOW() - INTERVAL '1 day', NOW(), 'system')`,
+		runID,
+	).Error
+	require.NoError(t, err)
+
+	// Insert settlement_snapshot
+	err = db.WithContext(ctx).Exec(
+		`INSERT INTO "`+schemaName+`"."settlement_snapshot" (snapshot_id, run_id, account_id, instrument_code, expected_balance, actual_balance, variance_amount, source_system, captured_at) SELECT ?, sr.id, 'ACC-001', 'GBP', 100.00, 90.00, -10.00, 'test', NOW() FROM "`+schemaName+`"."settlement_run" sr WHERE sr.run_id = ?`,
+		snapshotID, runID,
+	).Error
+	require.NoError(t, err)
+
+	// Insert variance
+	err = db.WithContext(ctx).Exec(
+		`INSERT INTO "`+schemaName+`"."variance" (variance_id, run_id, snapshot_id, account_id, instrument_code, expected_amount, actual_amount, variance_amount, reason) SELECT ?, sr.id, ss.id, 'ACC-001', 'GBP', 100.00, 90.00, -10.00, 'AMOUNT_MISMATCH' FROM "`+schemaName+`"."settlement_run" sr JOIN "`+schemaName+`"."settlement_snapshot" ss ON ss.run_id = sr.id WHERE sr.run_id = ? AND ss.snapshot_id = ?`,
+		varianceID, runID, snapshotID,
+	).Error
+	require.NoError(t, err)
+}
+
+func TestDisputeRepository_Create(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewDisputeRepository(db)
+	ctx := tenantCtx()
+
+	runID := uuid.New()
+	snapshotID := uuid.New()
+	varianceID := uuid.New()
+	seedRunAndVariance(t, db, runID, snapshotID, varianceID)
+
+	dispute, err := domain.NewDispute(varianceID, runID, "ACC-001", "Amount mismatch", "user-1")
+	require.NoError(t, err)
+
+	err = repo.Create(ctx, dispute)
+	require.NoError(t, err)
+
+	// Verify retrieval
+	found, err := repo.FindByID(ctx, dispute.DisputeID)
+	require.NoError(t, err)
+	assert.Equal(t, dispute.DisputeID, found.DisputeID)
+	assert.Equal(t, "ACC-001", found.AccountID)
+	assert.Equal(t, domain.DisputeStatusOpen, found.Status)
+	assert.Equal(t, "Amount mismatch", found.Reason)
+	assert.Equal(t, "user-1", found.RaisedBy)
+}
+
+func TestDisputeRepository_Update(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewDisputeRepository(db)
+	ctx := tenantCtx()
+
+	runID := uuid.New()
+	snapshotID := uuid.New()
+	varianceID := uuid.New()
+	seedRunAndVariance(t, db, runID, snapshotID, varianceID)
+
+	dispute, err := domain.NewDispute(varianceID, runID, "ACC-001", "Reason", "user-1")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, dispute))
+
+	// Resolve the dispute
+	require.NoError(t, dispute.Resolve("Fixed", "admin"))
+	err = repo.Update(ctx, dispute)
+	require.NoError(t, err)
+
+	// Verify update persisted
+	found, err := repo.FindByID(ctx, dispute.DisputeID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.DisputeStatusResolved, found.Status)
+	assert.Equal(t, "Fixed", found.Resolution)
+	assert.Equal(t, "admin", found.ResolvedBy)
+	assert.NotNil(t, found.ResolvedAt)
+}
+
+func TestDisputeRepository_FindByVarianceID(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewDisputeRepository(db)
+	ctx := tenantCtx()
+
+	runID := uuid.New()
+	snapshotID := uuid.New()
+	varianceID := uuid.New()
+	seedRunAndVariance(t, db, runID, snapshotID, varianceID)
+
+	// Create two disputes for the same variance
+	d1, err := domain.NewDispute(varianceID, runID, "ACC-001", "First dispute", "user-1")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, d1))
+
+	d2, err := domain.NewDispute(varianceID, runID, "ACC-001", "Second dispute", "user-2")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, d2))
+
+	found, err := repo.FindByVarianceID(ctx, varianceID)
+	require.NoError(t, err)
+	assert.Len(t, found, 2)
+}
+
+func TestDisputeRepository_List(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewDisputeRepository(db)
+	ctx := tenantCtx()
+
+	runID := uuid.New()
+	snapshotID := uuid.New()
+	varianceID := uuid.New()
+	seedRunAndVariance(t, db, runID, snapshotID, varianceID)
+
+	d1, err := domain.NewDispute(varianceID, runID, "ACC-001", "Reason 1", "user-1")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, d1))
+
+	d2, err := domain.NewDispute(varianceID, runID, "ACC-002", "Reason 2", "user-2")
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, d2))
+
+	t.Run("list all", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.DisputeFilter{})
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+	})
+
+	t.Run("filter by account", func(t *testing.T) {
+		accountID := "ACC-001"
+		found, err := repo.List(ctx, domain.DisputeFilter{AccountID: &accountID})
+		require.NoError(t, err)
+		assert.Len(t, found, 1)
+		assert.Equal(t, "ACC-001", found[0].AccountID)
+	})
+
+	t.Run("filter by status", func(t *testing.T) {
+		s := domain.DisputeStatusOpen
+		found, err := repo.List(ctx, domain.DisputeFilter{Status: &s})
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+	})
+}
+
+func TestDisputeRepository_NotFound(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewDisputeRepository(db)
+	ctx := tenantCtx()
+
+	_, err := repo.FindByID(ctx, uuid.New())
+	assert.ErrorIs(t, err, domain.ErrNotFound)
+}
+
+func TestVarianceRepository_FindByID(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewVarianceRepository(db)
+	ctx := tenantCtx()
+
+	runID := uuid.New()
+	snapshotID := uuid.New()
+	varianceID := uuid.New()
+	seedRunAndVariance(t, db, runID, snapshotID, varianceID)
+
+	found, err := repo.FindByID(ctx, varianceID)
+	require.NoError(t, err)
+	assert.Equal(t, varianceID, found.VarianceID)
+	assert.Equal(t, "ACC-001", found.AccountID)
+	assert.Equal(t, "GBP", found.InstrumentCode)
+	assert.True(t, decimal.NewFromFloat(100.0).Equal(found.ExpectedAmount))
+	assert.True(t, decimal.NewFromFloat(90.0).Equal(found.ActualAmount))
+	assert.Equal(t, domain.VarianceStatusOpen, found.Status)
+}
+
+func TestVarianceRepository_UpdateStatus(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewVarianceRepository(db)
+	ctx := tenantCtx()
+
+	runID := uuid.New()
+	snapshotID := uuid.New()
+	varianceID := uuid.New()
+	seedRunAndVariance(t, db, runID, snapshotID, varianceID)
+
+	err := repo.UpdateStatus(ctx, varianceID, domain.VarianceStatusDisputed)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, varianceID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.VarianceStatusDisputed, found.Status)
+}
+
+func TestVarianceRepository_NotFound(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewVarianceRepository(db)
+	ctx := tenantCtx()
+
+	_, err := repo.FindByID(ctx, uuid.New())
+	assert.ErrorIs(t, err, domain.ErrNotFound)
+}

--- a/services/reconciliation/adapters/persistence/entity.go
+++ b/services/reconciliation/adapters/persistence/entity.go
@@ -1,0 +1,72 @@
+// Package persistence provides GORM-based persistence implementations
+// for the reconciliation service domain entities.
+package persistence
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ErrUnsupportedJSONMapType is returned when a JSONMap Scan receives an unsupported type.
+var ErrUnsupportedJSONMapType = errors.New("unsupported type for JSONMap")
+
+// DisputeEntity is the GORM entity for the dispute table.
+type DisputeEntity struct {
+	ID         uuid.UUID  `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	CreatedAt  time.Time  `gorm:"not null;default:now()"`
+	UpdatedAt  time.Time  `gorm:"not null;default:now()"`
+	DisputeID  uuid.UUID  `gorm:"column:dispute_id;uniqueIndex:idx_dispute_dispute_id;type:uuid;not null"`
+	VarianceID uuid.UUID  `gorm:"column:variance_id;index:idx_dispute_variance_id;type:uuid;not null"`
+	RunID      uuid.UUID  `gorm:"column:run_id;index:idx_dispute_run_id;type:uuid;not null"`
+	AccountID  string     `gorm:"column:account_id;index:idx_dispute_account_id;size:34;not null"`
+	Status     string     `gorm:"column:status;index:idx_dispute_status;size:20;not null;default:OPEN"`
+	Reason     string     `gorm:"column:reason;type:text;not null"`
+	Resolution *string    `gorm:"column:resolution;type:text"`
+	RaisedBy   string     `gorm:"column:raised_by;size:100;not null"`
+	ResolvedBy *string    `gorm:"column:resolved_by;size:100"`
+	ResolvedAt *time.Time `gorm:"column:resolved_at"`
+	Attributes JSONMap    `gorm:"column:attributes;type:jsonb"`
+}
+
+// TableName returns the table name for the dispute entity.
+func (DisputeEntity) TableName() string {
+	return "dispute"
+}
+
+// JSONMap is a map[string]string that implements driver.Valuer and sql.Scanner for JSONB.
+type JSONMap map[string]string
+
+// Value implements the driver.Valuer interface for JSONMap.
+func (m JSONMap) Value() (driver.Value, error) {
+	if m == nil {
+		return []byte("null"), nil
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal JSONMap: %w", err)
+	}
+	return b, nil
+}
+
+// Scan implements the sql.Scanner interface for JSONMap.
+func (m *JSONMap) Scan(value interface{}) error {
+	if value == nil {
+		*m = nil
+		return nil
+	}
+	var bytes []byte
+	switch v := value.(type) {
+	case []byte:
+		bytes = v
+	case string:
+		bytes = []byte(v)
+	default:
+		return fmt.Errorf("%w: %T", ErrUnsupportedJSONMapType, value)
+	}
+	return json.Unmarshal(bytes, m)
+}

--- a/services/reconciliation/service/dispute_handler.go
+++ b/services/reconciliation/service/dispute_handler.go
@@ -1,0 +1,306 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/google/uuid"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// SagaRuntime defines the contract for invoking Starlark sagas.
+type SagaRuntime interface {
+	InvokeSaga(ctx context.Context, sagaName string, params map[string]interface{}) error
+}
+
+// EventPublisher defines the contract for publishing domain events.
+type EventPublisher interface {
+	Publish(ctx context.Context, topic string, event interface{}) error
+}
+
+// VarianceFinder retrieves variances for dispute validation.
+type VarianceFinder interface {
+	FindByID(ctx context.Context, varianceID uuid.UUID) (*domain.Variance, error)
+	UpdateStatus(ctx context.Context, varianceID uuid.UUID, status domain.VarianceStatus) error
+}
+
+// DisputeCreatedEvent is published when a dispute is created.
+type DisputeCreatedEvent struct {
+	DisputeID  string `json:"dispute_id"`
+	VarianceID string `json:"variance_id"`
+	RunID      string `json:"run_id"`
+	AccountID  string `json:"account_id"`
+	Reason     string `json:"reason"`
+	RaisedBy   string `json:"raised_by"`
+}
+
+// DisputeResolvedEvent is published when a dispute is resolved.
+type DisputeResolvedEvent struct {
+	DisputeID  string `json:"dispute_id"`
+	VarianceID string `json:"variance_id"`
+	RunID      string `json:"run_id"`
+	AccountID  string `json:"account_id"`
+	Action     string `json:"action"`
+	Resolution string `json:"resolution"`
+	ResolvedBy string `json:"resolved_by"`
+}
+
+// InitiateDispute raises a formal dispute against a variance.
+func (s *AccountReconciliationService) InitiateDispute(
+	ctx context.Context,
+	req *reconciliationv1.InitiateDisputeRequest,
+) (*reconciliationv1.InitiateDisputeResponse, error) {
+	if s.disputeRepo == nil {
+		return nil, status.Error(codes.Unimplemented, "InitiateDispute not yet implemented")
+	}
+
+	varianceID, err := uuid.Parse(req.GetVarianceId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid variance_id: %v", err)
+	}
+
+	runID, err := uuid.Parse(req.GetRunId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid run_id: %v", err)
+	}
+
+	// Validate that the variance exists
+	if s.varianceRepo != nil {
+		_, err := s.varianceRepo.FindByID(ctx, varianceID)
+		if err != nil {
+			if errors.Is(err, domain.ErrNotFound) {
+				return nil, status.Errorf(codes.NotFound, "variance %s not found", varianceID)
+			}
+			return nil, status.Errorf(codes.Internal, "failed to validate variance: %v", err)
+		}
+	}
+
+	dispute, err := domain.NewDispute(
+		varianceID,
+		runID,
+		req.GetAccountId(),
+		req.GetReason(),
+		req.GetRaisedBy(),
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid dispute: %v", err)
+	}
+
+	if req.GetAttributes() != nil {
+		dispute.Attributes = req.GetAttributes()
+	}
+
+	if err := s.disputeRepo.Create(ctx, dispute); err != nil {
+		slog.ErrorContext(ctx, "failed to create dispute", "error", err)
+		return nil, status.Errorf(codes.Internal, "failed to create dispute: %v", err)
+	}
+
+	// Mark variance as disputed
+	if s.varianceRepo != nil {
+		if err := s.varianceRepo.UpdateStatus(ctx, varianceID, domain.VarianceStatusDisputed); err != nil {
+			slog.WarnContext(ctx, "failed to update variance status to disputed",
+				"variance_id", varianceID, "error", err)
+		}
+	}
+
+	// Publish event
+	if s.eventPublisher != nil {
+		event := DisputeCreatedEvent{
+			DisputeID:  dispute.DisputeID.String(),
+			VarianceID: dispute.VarianceID.String(),
+			RunID:      dispute.RunID.String(),
+			AccountID:  dispute.AccountID,
+			Reason:     dispute.Reason,
+			RaisedBy:   dispute.RaisedBy,
+		}
+		if err := s.eventPublisher.Publish(ctx, "reconciliation.dispute.created", event); err != nil {
+			slog.WarnContext(ctx, "failed to publish DisputeCreatedEvent",
+				"dispute_id", dispute.DisputeID, "error", err)
+		}
+	}
+
+	return &reconciliationv1.InitiateDisputeResponse{
+		Dispute: toDisputeDetailProto(dispute),
+	}, nil
+}
+
+// ControlDispute controls a dispute lifecycle (escalate, resolve, reject).
+func (s *AccountReconciliationService) ControlDispute(
+	ctx context.Context,
+	req *reconciliationv1.ControlDisputeRequest,
+) (*reconciliationv1.ControlDisputeResponse, error) {
+	if s.disputeRepo == nil {
+		return nil, status.Error(codes.Unimplemented, "ControlDispute not yet implemented")
+	}
+
+	disputeID, err := uuid.Parse(req.GetDisputeId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid dispute_id: %v", err)
+	}
+
+	dispute, err := s.disputeRepo.FindByID(ctx, disputeID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "dispute %s not found", disputeID)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to retrieve dispute: %v", err)
+	}
+
+	action := req.GetAction()
+
+	switch action { //nolint:exhaustive // UNSPECIFIED handled by default
+	case reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_ESCALATE:
+		if err := dispute.Escalate(); err != nil {
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot escalate dispute: %v", err)
+		}
+
+	case reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_RESOLVE:
+		// Resolve requires admin or operator role
+		if err := requireAdminOrOperator(ctx); err != nil {
+			return nil, err
+		}
+		if err := dispute.Resolve(req.GetResolution(), req.GetResolvedBy()); err != nil {
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot resolve dispute: %v", err)
+		}
+
+		// Invoke reconciliation_adjustment saga for resolved disputes
+		if s.sagaRuntime != nil {
+			sagaParams := map[string]interface{}{
+				"variance_id": dispute.VarianceID.String(),
+				"dispute_id":  dispute.DisputeID.String(),
+				"account_id":  dispute.AccountID,
+				"resolved_by": dispute.ResolvedBy,
+				"resolution":  dispute.Resolution,
+			}
+			if err := s.sagaRuntime.InvokeSaga(ctx, "reconciliation_adjustment", sagaParams); err != nil {
+				slog.WarnContext(ctx, "failed to invoke reconciliation_adjustment saga",
+					"dispute_id", dispute.DisputeID, "error", err)
+			}
+		}
+
+	case reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_REJECT:
+		// Reject requires admin or operator role
+		if err := requireAdminOrOperator(ctx); err != nil {
+			return nil, err
+		}
+		if err := dispute.Reject(req.GetResolution(), req.GetResolvedBy()); err != nil {
+			return nil, status.Errorf(codes.FailedPrecondition, "cannot reject dispute: %v", err)
+		}
+
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unknown dispute control action: %v", action)
+	}
+
+	if err := s.disputeRepo.Update(ctx, dispute); err != nil {
+		slog.ErrorContext(ctx, "failed to update dispute", "error", err)
+		return nil, status.Errorf(codes.Internal, "failed to update dispute: %v", err)
+	}
+
+	// Publish resolved event for terminal states
+	if dispute.Status.IsFinal() && s.eventPublisher != nil {
+		event := DisputeResolvedEvent{
+			DisputeID:  dispute.DisputeID.String(),
+			VarianceID: dispute.VarianceID.String(),
+			RunID:      dispute.RunID.String(),
+			AccountID:  dispute.AccountID,
+			Action:     action.String(),
+			Resolution: dispute.Resolution,
+			ResolvedBy: dispute.ResolvedBy,
+		}
+		if err := s.eventPublisher.Publish(ctx, "reconciliation.dispute.resolved", event); err != nil {
+			slog.WarnContext(ctx, "failed to publish DisputeResolvedEvent",
+				"dispute_id", dispute.DisputeID, "error", err)
+		}
+	}
+
+	return &reconciliationv1.ControlDisputeResponse{
+		Dispute: toDisputeDetailProto(dispute),
+	}, nil
+}
+
+// RetrieveDispute retrieves a dispute by ID.
+func (s *AccountReconciliationService) RetrieveDispute(
+	ctx context.Context,
+	req *reconciliationv1.RetrieveDisputeRequest,
+) (*reconciliationv1.RetrieveDisputeResponse, error) {
+	if s.disputeRepo == nil {
+		return nil, status.Error(codes.Unimplemented, "RetrieveDispute not yet implemented")
+	}
+
+	disputeID, err := uuid.Parse(req.GetDisputeId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid dispute_id: %v", err)
+	}
+
+	dispute, err := s.disputeRepo.FindByID(ctx, disputeID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "dispute %s not found", disputeID)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to retrieve dispute: %v", err)
+	}
+
+	return &reconciliationv1.RetrieveDisputeResponse{
+		Dispute: toDisputeDetailProto(dispute),
+	}, nil
+}
+
+// requireAdminOrOperator checks that the caller has admin or operator role.
+func requireAdminOrOperator(ctx context.Context) error {
+	claims, ok := auth.GetClaimsFromContext(ctx)
+	if !ok {
+		return status.Error(codes.Unauthenticated, "missing authentication context")
+	}
+	if err := auth.CheckAnyRole(claims, auth.RoleAdmin, auth.RoleOperator); err != nil {
+		return status.Errorf(codes.PermissionDenied, "resolve/reject dispute requires admin or operator role: %v", err)
+	}
+	return nil
+}
+
+// toDisputeDetailProto converts a domain Dispute to a proto DisputeDetail.
+func toDisputeDetailProto(d *domain.Dispute) *reconciliationv1.DisputeDetail {
+	detail := &reconciliationv1.DisputeDetail{
+		DisputeId:  d.DisputeID.String(),
+		VarianceId: d.VarianceID.String(),
+		RunId:      d.RunID.String(),
+		AccountId:  d.AccountID,
+		Status:     toDisputeStatusProto(d.Status),
+		Reason:     d.Reason,
+		Resolution: d.Resolution,
+		RaisedBy:   d.RaisedBy,
+		ResolvedBy: d.ResolvedBy,
+		Attributes: d.Attributes,
+		CreatedAt:  timestamppb.New(d.CreatedAt),
+		UpdatedAt:  timestamppb.New(d.UpdatedAt),
+	}
+
+	if d.ResolvedAt != nil {
+		detail.ResolvedAt = timestamppb.New(*d.ResolvedAt)
+	}
+
+	return detail
+}
+
+// toDisputeStatusProto converts a domain DisputeStatus to proto enum.
+func toDisputeStatusProto(s domain.DisputeStatus) reconciliationv1.DisputeStatus {
+	switch s {
+	case domain.DisputeStatusOpen:
+		return reconciliationv1.DisputeStatus_DISPUTE_STATUS_OPEN
+	case domain.DisputeStatusUnderReview:
+		return reconciliationv1.DisputeStatus_DISPUTE_STATUS_UNDER_REVIEW
+	case domain.DisputeStatusEscalated:
+		return reconciliationv1.DisputeStatus_DISPUTE_STATUS_ESCALATED
+	case domain.DisputeStatusResolved:
+		return reconciliationv1.DisputeStatus_DISPUTE_STATUS_RESOLVED
+	case domain.DisputeStatusRejected:
+		return reconciliationv1.DisputeStatus_DISPUTE_STATUS_REJECTED
+	default:
+		return reconciliationv1.DisputeStatus_DISPUTE_STATUS_UNSPECIFIED
+	}
+}

--- a/services/reconciliation/service/dispute_handler_test.go
+++ b/services/reconciliation/service/dispute_handler_test.go
@@ -1,0 +1,411 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/services/reconciliation/service"
+	"github.com/meridianhub/meridian/shared/platform/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mockDisputeRepo implements domain.DisputeRepository for testing.
+type mockDisputeRepo struct {
+	disputes map[uuid.UUID]*domain.Dispute
+}
+
+func newMockDisputeRepo() *mockDisputeRepo {
+	return &mockDisputeRepo{disputes: make(map[uuid.UUID]*domain.Dispute)}
+}
+
+func (m *mockDisputeRepo) Create(_ context.Context, d *domain.Dispute) error {
+	m.disputes[d.DisputeID] = d
+	return nil
+}
+
+func (m *mockDisputeRepo) FindByID(_ context.Context, id uuid.UUID) (*domain.Dispute, error) {
+	for _, d := range m.disputes {
+		if d.DisputeID == id {
+			return d, nil
+		}
+	}
+	return nil, domain.ErrNotFound
+}
+
+func (m *mockDisputeRepo) FindByVarianceID(_ context.Context, varianceID uuid.UUID) ([]*domain.Dispute, error) {
+	result := make([]*domain.Dispute, 0, len(m.disputes))
+	for _, d := range m.disputes {
+		if d.VarianceID == varianceID {
+			result = append(result, d)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockDisputeRepo) Update(_ context.Context, d *domain.Dispute) error {
+	if _, ok := m.disputes[d.DisputeID]; !ok {
+		return domain.ErrNotFound
+	}
+	m.disputes[d.DisputeID] = d
+	return nil
+}
+
+func (m *mockDisputeRepo) List(_ context.Context, filter domain.DisputeFilter) ([]*domain.Dispute, error) {
+	result := make([]*domain.Dispute, 0, len(m.disputes))
+	for _, d := range m.disputes {
+		if filter.Status != nil && d.Status != *filter.Status {
+			continue
+		}
+		if filter.AccountID != nil && d.AccountID != *filter.AccountID {
+			continue
+		}
+		result = append(result, d)
+	}
+	return result, nil
+}
+
+// mockVarianceRepo implements service.VarianceFinder for testing.
+type mockVarianceRepo struct {
+	variances map[uuid.UUID]*domain.Variance
+}
+
+func newMockVarianceRepo() *mockVarianceRepo {
+	return &mockVarianceRepo{variances: make(map[uuid.UUID]*domain.Variance)}
+}
+
+func (m *mockVarianceRepo) FindByID(_ context.Context, id uuid.UUID) (*domain.Variance, error) {
+	v, ok := m.variances[id]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return v, nil
+}
+
+func (m *mockVarianceRepo) UpdateStatus(_ context.Context, id uuid.UUID, s domain.VarianceStatus) error {
+	v, ok := m.variances[id]
+	if !ok {
+		return domain.ErrNotFound
+	}
+	v.Status = s
+	return nil
+}
+
+// mockEventPublisher implements service.EventPublisher for testing.
+type mockEventPublisher struct {
+	events []interface{}
+}
+
+func (m *mockEventPublisher) Publish(_ context.Context, _ string, event interface{}) error {
+	m.events = append(m.events, event)
+	return nil
+}
+
+// mockSagaRuntime implements service.SagaRuntime for testing.
+type mockSagaRuntime struct {
+	invocations []string
+}
+
+func (m *mockSagaRuntime) InvokeSaga(_ context.Context, name string, _ map[string]interface{}) error {
+	m.invocations = append(m.invocations, name)
+	return nil
+}
+
+// ctxWithClaims creates a context with the given auth claims.
+func ctxWithClaims(roles ...string) context.Context {
+	claims := &auth.Claims{
+		UserID: "test-user",
+		Roles:  roles,
+	}
+	return context.WithValue(context.Background(), auth.ClaimsContextKey, claims)
+}
+
+func TestInitiateDispute(t *testing.T) {
+	varianceID := uuid.New()
+	runID := uuid.New()
+
+	varianceRepo := newMockVarianceRepo()
+	varianceRepo.variances[varianceID] = &domain.Variance{
+		VarianceID: varianceID,
+		RunID:      runID,
+		AccountID:  "ACC-001",
+		Status:     domain.VarianceStatusOpen,
+	}
+
+	disputeRepo := newMockDisputeRepo()
+	eventPub := &mockEventPublisher{}
+
+	svc := service.NewAccountReconciliationService(
+		service.WithDisputeRepository(disputeRepo),
+		service.WithVarianceRepository(varianceRepo),
+		service.WithEventPublisher(eventPub),
+	)
+
+	t.Run("successful dispute creation", func(t *testing.T) {
+		resp, err := svc.InitiateDispute(context.Background(), &reconciliationv1.InitiateDisputeRequest{
+			VarianceId: varianceID.String(),
+			RunId:      runID.String(),
+			AccountId:  "ACC-001",
+			Reason:     "Amount seems incorrect",
+			RaisedBy:   "user-1",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.Dispute)
+
+		assert.Equal(t, "ACC-001", resp.Dispute.AccountId)
+		assert.Equal(t, reconciliationv1.DisputeStatus_DISPUTE_STATUS_OPEN, resp.Dispute.Status)
+		assert.Equal(t, "Amount seems incorrect", resp.Dispute.Reason)
+		assert.Equal(t, "user-1", resp.Dispute.RaisedBy)
+		assert.Equal(t, varianceID.String(), resp.Dispute.VarianceId)
+
+		// Verify variance was marked as disputed
+		assert.Equal(t, domain.VarianceStatusDisputed, varianceRepo.variances[varianceID].Status)
+
+		// Verify event was published
+		assert.Len(t, eventPub.events, 1)
+	})
+
+	t.Run("invalid variance ID", func(t *testing.T) {
+		_, err := svc.InitiateDispute(context.Background(), &reconciliationv1.InitiateDisputeRequest{
+			VarianceId: "not-a-uuid",
+			RunId:      runID.String(),
+			AccountId:  "ACC-001",
+			Reason:     "Reason",
+			RaisedBy:   "user-1",
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("variance not found", func(t *testing.T) {
+		_, err := svc.InitiateDispute(context.Background(), &reconciliationv1.InitiateDisputeRequest{
+			VarianceId: uuid.New().String(),
+			RunId:      runID.String(),
+			AccountId:  "ACC-001",
+			Reason:     "Reason",
+			RaisedBy:   "user-1",
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("empty reason", func(t *testing.T) {
+		_, err := svc.InitiateDispute(context.Background(), &reconciliationv1.InitiateDisputeRequest{
+			VarianceId: varianceID.String(),
+			RunId:      runID.String(),
+			AccountId:  "ACC-001",
+			Reason:     "",
+			RaisedBy:   "user-1",
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+}
+
+func TestControlDispute_Escalate(t *testing.T) {
+	disputeRepo := newMockDisputeRepo()
+
+	// Create a dispute in UNDER_REVIEW state (escalate requires UNDER_REVIEW)
+	d := createTestDispute(t)
+	require.NoError(t, d.Review())
+	disputeRepo.disputes[d.DisputeID] = d
+
+	svc := service.NewAccountReconciliationService(
+		service.WithDisputeRepository(disputeRepo),
+	)
+
+	resp, err := svc.ControlDispute(context.Background(), &reconciliationv1.ControlDisputeRequest{
+		DisputeId: d.DisputeID.String(),
+		Action:    reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_ESCALATE,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, reconciliationv1.DisputeStatus_DISPUTE_STATUS_ESCALATED, resp.Dispute.Status)
+}
+
+func TestControlDispute_Resolve(t *testing.T) {
+	disputeRepo := newMockDisputeRepo()
+	sagaRT := &mockSagaRuntime{}
+	eventPub := &mockEventPublisher{}
+
+	d := createTestDispute(t)
+	disputeRepo.disputes[d.DisputeID] = d
+
+	svc := service.NewAccountReconciliationService(
+		service.WithDisputeRepository(disputeRepo),
+		service.WithSagaRuntime(sagaRT),
+		service.WithEventPublisher(eventPub),
+	)
+
+	t.Run("requires admin or operator role", func(t *testing.T) {
+		// No claims in context
+		_, err := svc.ControlDispute(context.Background(), &reconciliationv1.ControlDisputeRequest{
+			DisputeId:  d.DisputeID.String(),
+			Action:     reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_RESOLVE,
+			Resolution: "Adjustment posted",
+			ResolvedBy: "admin-user",
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+	})
+
+	t.Run("auditor role denied", func(t *testing.T) {
+		ctx := ctxWithClaims("auditor")
+		_, err := svc.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
+			DisputeId:  d.DisputeID.String(),
+			Action:     reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_RESOLVE,
+			Resolution: "Adjustment posted",
+			ResolvedBy: "auditor-user",
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.PermissionDenied, st.Code())
+	})
+
+	t.Run("admin can resolve", func(t *testing.T) {
+		ctx := ctxWithClaims("admin")
+		resp, err := svc.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
+			DisputeId:  d.DisputeID.String(),
+			Action:     reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_RESOLVE,
+			Resolution: "Adjustment posted",
+			ResolvedBy: "admin-user",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, reconciliationv1.DisputeStatus_DISPUTE_STATUS_RESOLVED, resp.Dispute.Status)
+		assert.Equal(t, "Adjustment posted", resp.Dispute.Resolution)
+		assert.Equal(t, "admin-user", resp.Dispute.ResolvedBy)
+
+		// Verify saga was invoked
+		assert.Contains(t, sagaRT.invocations, "reconciliation_adjustment")
+
+		// Verify event was published
+		assert.Len(t, eventPub.events, 1)
+	})
+}
+
+func TestControlDispute_Reject(t *testing.T) {
+	disputeRepo := newMockDisputeRepo()
+	eventPub := &mockEventPublisher{}
+
+	d := createTestDispute(t)
+	disputeRepo.disputes[d.DisputeID] = d
+
+	svc := service.NewAccountReconciliationService(
+		service.WithDisputeRepository(disputeRepo),
+		service.WithEventPublisher(eventPub),
+	)
+
+	ctx := ctxWithClaims("operator")
+	resp, err := svc.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
+		DisputeId:  d.DisputeID.String(),
+		Action:     reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_REJECT,
+		Resolution: "No evidence of error",
+		ResolvedBy: "operator-user",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, reconciliationv1.DisputeStatus_DISPUTE_STATUS_REJECTED, resp.Dispute.Status)
+	assert.Equal(t, "No evidence of error", resp.Dispute.Resolution)
+
+	// Verify event was published
+	assert.Len(t, eventPub.events, 1)
+}
+
+func TestControlDispute_InvalidTransition(t *testing.T) {
+	disputeRepo := newMockDisputeRepo()
+
+	// Create resolved dispute - no further transitions allowed
+	d := createTestDispute(t)
+	require.NoError(t, d.Resolve("done", "admin"))
+	disputeRepo.disputes[d.DisputeID] = d
+
+	svc := service.NewAccountReconciliationService(
+		service.WithDisputeRepository(disputeRepo),
+	)
+
+	ctx := ctxWithClaims("admin")
+	_, err := svc.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
+		DisputeId:  d.DisputeID.String(),
+		Action:     reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_REJECT,
+		Resolution: "Trying to reject resolved",
+		ResolvedBy: "admin-user",
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestControlDispute_NotFound(t *testing.T) {
+	disputeRepo := newMockDisputeRepo()
+
+	svc := service.NewAccountReconciliationService(
+		service.WithDisputeRepository(disputeRepo),
+	)
+
+	_, err := svc.ControlDispute(context.Background(), &reconciliationv1.ControlDisputeRequest{
+		DisputeId: uuid.New().String(),
+		Action:    reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_ESCALATE,
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestRetrieveDispute(t *testing.T) {
+	disputeRepo := newMockDisputeRepo()
+	d := createTestDispute(t)
+	disputeRepo.disputes[d.DisputeID] = d
+
+	svc := service.NewAccountReconciliationService(
+		service.WithDisputeRepository(disputeRepo),
+	)
+
+	t.Run("found", func(t *testing.T) {
+		resp, err := svc.RetrieveDispute(context.Background(), &reconciliationv1.RetrieveDisputeRequest{
+			DisputeId: d.DisputeID.String(),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		assert.Equal(t, d.DisputeID.String(), resp.Dispute.DisputeId)
+		assert.Equal(t, d.AccountID, resp.Dispute.AccountId)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := svc.RetrieveDispute(context.Background(), &reconciliationv1.RetrieveDisputeRequest{
+			DisputeId: uuid.New().String(),
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("invalid UUID", func(t *testing.T) {
+		_, err := svc.RetrieveDispute(context.Background(), &reconciliationv1.RetrieveDisputeRequest{
+			DisputeId: "bad-uuid",
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+}
+
+func createTestDispute(t *testing.T) *domain.Dispute {
+	t.Helper()
+	d, err := domain.NewDispute(
+		uuid.New(), uuid.New(), "ACC-001",
+		"Amount discrepancy", "user-1",
+	)
+	require.NoError(t, err)
+	return d
+}

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -1,13 +1,14 @@
 // Package service implements the gRPC AccountReconciliationService.
 //
-// All RPCs currently return UNIMPLEMENTED status. Business logic will be
-// added in subsequent tasks after the persistence layer is integrated.
+// Dispute RPCs are implemented in dispute_handler.go. Other RPCs currently
+// return UNIMPLEMENTED status and will be added in subsequent tasks.
 package service
 
 import (
 	"context"
 
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -15,11 +16,51 @@ import (
 // AccountReconciliationService implements the gRPC service for reconciliation operations.
 type AccountReconciliationService struct {
 	reconciliationv1.UnimplementedAccountReconciliationServiceServer
+
+	disputeRepo    domain.DisputeRepository
+	varianceRepo   VarianceFinder
+	sagaRuntime    SagaRuntime
+	eventPublisher EventPublisher
+}
+
+// Option configures the AccountReconciliationService.
+type Option func(*AccountReconciliationService)
+
+// WithDisputeRepository sets the dispute repository.
+func WithDisputeRepository(repo domain.DisputeRepository) Option {
+	return func(s *AccountReconciliationService) {
+		s.disputeRepo = repo
+	}
+}
+
+// WithVarianceRepository sets the variance finder for dispute validation.
+func WithVarianceRepository(repo VarianceFinder) Option {
+	return func(s *AccountReconciliationService) {
+		s.varianceRepo = repo
+	}
+}
+
+// WithSagaRuntime sets the saga runtime for dispute resolution.
+func WithSagaRuntime(rt SagaRuntime) Option {
+	return func(s *AccountReconciliationService) {
+		s.sagaRuntime = rt
+	}
+}
+
+// WithEventPublisher sets the event publisher for domain events.
+func WithEventPublisher(pub EventPublisher) Option {
+	return func(s *AccountReconciliationService) {
+		s.eventPublisher = pub
+	}
 }
 
 // NewAccountReconciliationService creates a new AccountReconciliationService.
-func NewAccountReconciliationService() *AccountReconciliationService {
-	return &AccountReconciliationService{}
+func NewAccountReconciliationService(opts ...Option) *AccountReconciliationService {
+	svc := &AccountReconciliationService{}
+	for _, opt := range opts {
+		opt(svc)
+	}
+	return svc
 }
 
 // InitiateAccountReconciliation creates a new settlement run.
@@ -68,28 +109,4 @@ func (s *AccountReconciliationService) AssertBalance(
 	_ *reconciliationv1.AssertBalanceRequest,
 ) (*reconciliationv1.AssertBalanceResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "AssertBalance not yet implemented")
-}
-
-// InitiateDispute raises a formal dispute against a variance.
-func (s *AccountReconciliationService) InitiateDispute(
-	_ context.Context,
-	_ *reconciliationv1.InitiateDisputeRequest,
-) (*reconciliationv1.InitiateDisputeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "InitiateDispute not yet implemented")
-}
-
-// ControlDispute controls a dispute lifecycle (escalate, resolve, reject).
-func (s *AccountReconciliationService) ControlDispute(
-	_ context.Context,
-	_ *reconciliationv1.ControlDisputeRequest,
-) (*reconciliationv1.ControlDisputeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ControlDispute not yet implemented")
-}
-
-// RetrieveDispute retrieves a dispute by ID.
-func (s *AccountReconciliationService) RetrieveDispute(
-	_ context.Context,
-	_ *reconciliationv1.RetrieveDisputeRequest,
-) (*reconciliationv1.RetrieveDisputeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "RetrieveDispute not yet implemented")
 }


### PR DESCRIPTION
## Summary

- Implement dispute creation (`InitiateDispute`), escalation/resolution/rejection (`ControlDispute`), and retrieval (`RetrieveDispute`) gRPC handlers
- Add GORM-based `DisputeRepository` and `VarianceRepository` with tenant-scoped transactions using `shared/platform/db.WithGormTenantTransaction`
- Enforce role-based authorization: resolve/reject requires `admin` or `operator` role
- Integrate saga runtime interface for `reconciliation_adjustment` saga invocation on dispute resolution
- Publish `DisputeCreatedEvent` and `DisputeResolvedEvent` via event publisher interface
- Mark associated variance as `DISPUTED` when a dispute is initiated

## Changes Made

- **`services/reconciliation/adapters/persistence/entity.go`**: GORM entities for `dispute` and `variance` tables with JSONB support
- **`services/reconciliation/adapters/persistence/dispute_repository.go`**: `DisputeRepository` (CRUD + filter queries) and `VarianceRepository` (find + status update) implementations
- **`services/reconciliation/adapters/persistence/dispute_repository_test.go`**: Integration tests with CockroachDB testcontainer
- **`services/reconciliation/service/dispute_handler.go`**: gRPC handler implementations with validation, auth, saga, and event publishing
- **`services/reconciliation/service/dispute_handler_test.go`**: Unit tests covering creation, escalation, resolve/reject authorization, invalid transitions, and retrieval
- **`services/reconciliation/service/service.go`**: Refactored to accept optional dependencies via functional options pattern

## Test plan

- [x] Unit tests for dispute handler (mock repos, saga runtime, event publisher)
- [x] Unit tests for authorization enforcement (admin/operator required for resolve/reject)
- [x] Unit tests for invalid state transitions (FailedPrecondition)
- [x] Integration tests for dispute repository CRUD with CockroachDB testcontainer
- [x] Integration tests for variance repository find/update with CockroachDB testcontainer
- [x] All existing tests continue to pass (backwards-compatible constructor)