### PR TITLE
feat: implement settlement snapshot capture with streaming pagination

### DIFF
--- a/services/reconciliation/domain/repository.go
+++ b/services/reconciliation/domain/repository.go
@@ -51,6 +51,10 @@ type SettlementSnapshotRepository interface {
 
 	// FindByRunID retrieves all snapshots for a settlement run.
 	FindByRunID(ctx context.Context, runID uuid.UUID) ([]*SettlementSnapshot, error)
+
+	// DeleteByRunID removes all snapshots for a given settlement run.
+	// Used for idempotent cleanup before retrying a failed capture.
+	DeleteByRunID(ctx context.Context, runID uuid.UUID) error
 }
 
 // VarianceRepository defines the contract for persisting and retrieving variances.

--- a/services/reconciliation/service/pk_position_provider.go
+++ b/services/reconciliation/service/pk_position_provider.go
@@ -1,0 +1,86 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/shopspring/decimal"
+	"google.golang.org/genproto/googleapis/type/money"
+)
+
+// ErrNilMoneyValue is returned when a nil money value is encountered during conversion.
+var ErrNilMoneyValue = errors.New("nil money value")
+
+// PKPositionProvider implements PositionDataProvider using PK's gRPC client.
+// It uses ListFinancialPositionLogs with cursor-based pagination to fetch
+// current position data for reconciliation.
+type PKPositionProvider struct {
+	client positionkeepingv1.PositionKeepingServiceClient
+}
+
+// NewPKPositionProvider creates a new provider backed by the PK gRPC service.
+func NewPKPositionProvider(client positionkeepingv1.PositionKeepingServiceClient) *PKPositionProvider {
+	return &PKPositionProvider{client: client}
+}
+
+// FetchPositions retrieves a page of position logs from PK and maps them to PositionRecords.
+func (p *PKPositionProvider) FetchPositions(ctx context.Context, accountID string, pageSize int32, pageToken string) (*PositionPage, error) {
+	resp, err := p.client.ListFinancialPositionLogs(ctx, &positionkeepingv1.ListFinancialPositionLogsRequest{
+		AccountId: accountID,
+		Pagination: &commonv1.Pagination{
+			PageSize:  pageSize,
+			PageToken: pageToken,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list financial position logs from PK: %w", err)
+	}
+
+	records := make([]PositionRecord, 0, len(resp.GetLogs()))
+	for _, log := range resp.GetLogs() {
+		balance := decimal.Zero
+		for _, entry := range log.GetTransactionLogEntries() {
+			amount, err := moneyToDecimal(entry.GetAmount().GetAmount())
+			if err != nil {
+				continue
+			}
+			if entry.GetDirection() == commonv1.PostingDirection_POSTING_DIRECTION_CREDIT {
+				balance = balance.Add(amount)
+			} else {
+				balance = balance.Sub(amount)
+			}
+		}
+
+		records = append(records, PositionRecord{
+			AccountID:      log.GetAccountId(),
+			InstrumentCode: "DEFAULT",
+			Balance:        balance,
+			SourceSystem:   "position-keeping",
+			Attributes:     map[string]string{"log_id": log.GetLogId()},
+		})
+	}
+
+	nextToken := ""
+	if resp.GetPagination() != nil {
+		nextToken = resp.GetPagination().GetNextPageToken()
+	}
+
+	return &PositionPage{
+		Records:       records,
+		NextPageToken: nextToken,
+	}, nil
+}
+
+// moneyToDecimal converts a google.type.Money to a decimal.Decimal.
+// Money stores amounts as units (int64) + nanos (int32, 0-999999999).
+func moneyToDecimal(m *money.Money) (decimal.Decimal, error) {
+	if m == nil {
+		return decimal.Zero, ErrNilMoneyValue
+	}
+	units := decimal.NewFromInt(m.GetUnits())
+	nanos := decimal.NewFromInt(int64(m.GetNanos())).Div(decimal.NewFromInt(1_000_000_000))
+	return units.Add(nanos), nil
+}

--- a/services/reconciliation/service/pk_position_provider.go
+++ b/services/reconciliation/service/pk_position_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
 	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
@@ -42,21 +43,43 @@ func (p *PKPositionProvider) FetchPositions(ctx context.Context, accountID strin
 	records := make([]PositionRecord, 0, len(resp.GetLogs()))
 	for _, log := range resp.GetLogs() {
 		balance := decimal.Zero
+		instrumentCode := ""
 		for _, entry := range log.GetTransactionLogEntries() {
 			amount, err := moneyToDecimal(entry.GetAmount().GetAmount())
 			if err != nil {
+				slog.WarnContext(ctx, "skipping entry with invalid amount",
+					"log_id", log.GetLogId(),
+					"error", err,
+				)
 				continue
 			}
-			if entry.GetDirection() == commonv1.PostingDirection_POSTING_DIRECTION_CREDIT {
-				balance = balance.Add(amount)
-			} else {
-				balance = balance.Sub(amount)
+
+			// Extract currency code from the first entry that has one.
+			if instrumentCode == "" {
+				if m := entry.GetAmount().GetAmount(); m != nil {
+					instrumentCode = m.GetCurrencyCode()
+				}
 			}
+
+			switch entry.GetDirection() {
+			case commonv1.PostingDirection_POSTING_DIRECTION_CREDIT:
+				balance = balance.Add(amount)
+			case commonv1.PostingDirection_POSTING_DIRECTION_DEBIT:
+				balance = balance.Sub(amount)
+			case commonv1.PostingDirection_POSTING_DIRECTION_UNSPECIFIED:
+				slog.WarnContext(ctx, "skipping entry with unspecified direction",
+					"log_id", log.GetLogId(),
+				)
+			}
+		}
+
+		if instrumentCode == "" {
+			instrumentCode = "UNKNOWN"
 		}
 
 		records = append(records, PositionRecord{
 			AccountID:      log.GetAccountId(),
-			InstrumentCode: "DEFAULT",
+			InstrumentCode: instrumentCode,
 			Balance:        balance,
 			SourceSystem:   "position-keeping",
 			Attributes:     map[string]string{"log_id": log.GetLogId()},

--- a/services/reconciliation/service/position_provider.go
+++ b/services/reconciliation/service/position_provider.go
@@ -1,0 +1,32 @@
+package service
+
+import (
+	"context"
+
+	"github.com/shopspring/decimal"
+)
+
+// PositionRecord represents a single position entry fetched from Position Keeping.
+// This is the reconciliation service's view of PK data, decoupled from the proto types.
+type PositionRecord struct {
+	AccountID      string
+	InstrumentCode string
+	Balance        decimal.Decimal
+	SourceSystem   string
+	Attributes     map[string]string
+}
+
+// PositionPage represents a page of position records with cursor-based pagination.
+type PositionPage struct {
+	Records       []PositionRecord
+	NextPageToken string
+}
+
+// PositionDataProvider abstracts fetching position data from Position Keeping.
+// This interface decouples the snapshot capturer from the PK gRPC client,
+// enabling unit testing with mocks and allowing future changes to the data source.
+type PositionDataProvider interface {
+	// FetchPositions retrieves a page of current position balances for the given account.
+	// Use an empty pageToken for the first page. Returns empty NextPageToken when no more pages.
+	FetchPositions(ctx context.Context, accountID string, pageSize int32, pageToken string) (*PositionPage, error)
+}

--- a/services/reconciliation/service/snapshot_capturer.go
+++ b/services/reconciliation/service/snapshot_capturer.go
@@ -1,0 +1,212 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// defaultPageSize is the number of positions fetched per page from PK.
+	defaultPageSize int32 = 500
+
+	// maxPages is the upper bound on pages to prevent runaway pagination.
+	maxPages = 1000
+
+	// snapshotBatchSize is the number of snapshots inserted per batch.
+	snapshotBatchSize = 100
+
+	// captureTimeout is the maximum time allowed for the entire capture operation.
+	captureTimeout = 10 * time.Minute
+
+	// maxConcurrentInserts limits the number of concurrent batch insert goroutines.
+	maxConcurrentInserts = 5
+)
+
+// SnapshotCapturer orchestrates capturing point-in-time position snapshots from
+// Position Keeping during a settlement run. It fetches positions using cursor-based
+// pagination, transforms them to SettlementSnapshot domain objects, and batch-inserts
+// them into the database.
+type SnapshotCapturer struct {
+	provider PositionDataProvider
+	runRepo  domain.SettlementRunRepository
+	snapRepo domain.SettlementSnapshotRepository
+}
+
+// NewSnapshotCapturer creates a new SnapshotCapturer with the given dependencies.
+func NewSnapshotCapturer(
+	provider PositionDataProvider,
+	runRepo domain.SettlementRunRepository,
+	snapRepo domain.SettlementSnapshotRepository,
+) *SnapshotCapturer {
+	return &SnapshotCapturer{
+		provider: provider,
+		runRepo:  runRepo,
+		snapRepo: snapRepo,
+	}
+}
+
+// CaptureSnapshots executes the snapshot capture phase of a settlement run.
+//
+// It performs the following steps:
+//  1. Loads the settlement run and validates it is in PENDING state
+//  2. Transitions the run to RUNNING (capturing)
+//  3. Cleans up any existing snapshots for idempotent retry
+//  4. Paginates through PK positions, converting each page to snapshots
+//  5. Batch-inserts snapshots using bounded concurrency
+//  6. On success: transitions the run to COMPLETED
+//  7. On failure: transitions the run to FAILED with the error reason
+func (sc *SnapshotCapturer) CaptureSnapshots(ctx context.Context, runID uuid.UUID) error {
+	ctx, cancel := context.WithTimeout(ctx, captureTimeout)
+	defer cancel()
+
+	run, err := sc.runRepo.FindByID(ctx, runID)
+	if err != nil {
+		return fmt.Errorf("failed to find settlement run %s: %w", runID, err)
+	}
+
+	if err := run.Start(); err != nil {
+		return fmt.Errorf("failed to start settlement run %s: %w", runID, err)
+	}
+	if err := sc.runRepo.Update(ctx, run); err != nil {
+		return fmt.Errorf("failed to update settlement run to RUNNING: %w", err)
+	}
+
+	slog.InfoContext(ctx, "snapshot capture started",
+		"run_id", runID,
+		"account_id", run.AccountID,
+		"scope", run.Scope,
+	)
+
+	captureErr := sc.capturePositions(ctx, run)
+	if captureErr != nil {
+		slog.ErrorContext(ctx, "snapshot capture failed",
+			"run_id", runID,
+			"error", captureErr,
+		)
+		if failErr := run.Fail(captureErr.Error()); failErr != nil {
+			slog.ErrorContext(ctx, "failed to transition run to FAILED state",
+				"run_id", runID,
+				"error", failErr,
+			)
+			return fmt.Errorf("capture failed: %w; additionally failed to mark run as FAILED: %w", captureErr, failErr)
+		}
+		if updateErr := sc.runRepo.Update(ctx, run); updateErr != nil {
+			slog.ErrorContext(ctx, "failed to persist FAILED state",
+				"run_id", runID,
+				"error", updateErr,
+			)
+		}
+		return fmt.Errorf("snapshot capture failed: %w", captureErr)
+	}
+
+	if err := run.Complete(0); err != nil {
+		return fmt.Errorf("failed to transition run to COMPLETED: %w", err)
+	}
+	if err := sc.runRepo.Update(ctx, run); err != nil {
+		return fmt.Errorf("failed to persist COMPLETED state: %w", err)
+	}
+
+	slog.InfoContext(ctx, "snapshot capture completed",
+		"run_id", runID,
+	)
+	return nil
+}
+
+// capturePositions handles the paginated fetch-and-store loop.
+func (sc *SnapshotCapturer) capturePositions(ctx context.Context, run *domain.SettlementRun) error {
+	// Idempotent cleanup: remove any snapshots from a previous failed attempt
+	if err := sc.snapRepo.DeleteByRunID(ctx, run.RunID); err != nil {
+		return fmt.Errorf("failed to clean up existing snapshots: %w", err)
+	}
+
+	g, gCtx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrentInserts)
+
+	pageToken := ""
+	totalCaptured := 0
+
+	for page := 0; page < maxPages; page++ {
+		positionPage, err := sc.provider.FetchPositions(gCtx, run.AccountID, defaultPageSize, pageToken)
+		if err != nil {
+			return fmt.Errorf("failed to fetch positions (page %d): %w", page, err)
+		}
+
+		if len(positionPage.Records) == 0 {
+			break
+		}
+
+		snapshots, err := sc.transformToSnapshots(run, positionPage.Records)
+		if err != nil {
+			return fmt.Errorf("failed to transform positions to snapshots (page %d): %w", page, err)
+		}
+
+		// Batch insert concurrently with bounded parallelism.
+		// Copy snapshots slice to capture in closure.
+		for i := 0; i < len(snapshots); i += snapshotBatchSize {
+			end := i + snapshotBatchSize
+			if end > len(snapshots) {
+				end = len(snapshots)
+			}
+			batch := snapshots[i:end]
+
+			g.Go(func() error {
+				return sc.snapRepo.CreateBatch(gCtx, batch)
+			})
+		}
+
+		totalCaptured += len(snapshots)
+
+		slog.DebugContext(ctx, "captured snapshot page",
+			"run_id", run.RunID,
+			"page", page,
+			"records", len(positionPage.Records),
+			"total_captured", totalCaptured,
+		)
+
+		pageToken = positionPage.NextPageToken
+		if pageToken == "" {
+			break
+		}
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("batch insert failed: %w", err)
+	}
+
+	slog.InfoContext(ctx, "all snapshots captured",
+		"run_id", run.RunID,
+		"total_snapshots", totalCaptured,
+	)
+	return nil
+}
+
+// transformToSnapshots converts PK position records into SettlementSnapshot domain objects.
+func (sc *SnapshotCapturer) transformToSnapshots(run *domain.SettlementRun, records []PositionRecord) ([]*domain.SettlementSnapshot, error) {
+	snapshots := make([]*domain.SettlementSnapshot, 0, len(records))
+	for _, rec := range records {
+		// For the capture phase, expected balance comes from PK.
+		// Actual balance will be filled during the reconciliation phase.
+		// During capture, we store both as the PK balance (no variance yet).
+		snap, err := domain.NewSettlementSnapshot(
+			run.RunID,
+			rec.AccountID,
+			rec.InstrumentCode,
+			rec.Balance,  // expected balance from PK
+			decimal.Zero, // actual balance - populated during reconciliation
+			rec.SourceSystem,
+			rec.Attributes,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create snapshot for account %s: %w", rec.AccountID, err)
+		}
+		snapshots = append(snapshots, snap)
+	}
+	return snapshots, nil
+}

--- a/services/reconciliation/service/snapshot_capturer.go
+++ b/services/reconciliation/service/snapshot_capturer.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/services/reconciliation/domain"
-	"github.com/shopspring/decimal"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -120,7 +119,7 @@ func (sc *SnapshotCapturer) CaptureSnapshots(ctx context.Context, runID uuid.UUI
 }
 
 // capturePositions handles the paginated fetch-and-store loop.
-func (sc *SnapshotCapturer) capturePositions(ctx context.Context, run *domain.SettlementRun) error {
+func (sc *SnapshotCapturer) capturePositions(ctx context.Context, run *domain.SettlementRun) (retErr error) {
 	// Idempotent cleanup: remove any snapshots from a previous failed attempt
 	if err := sc.snapRepo.DeleteByRunID(ctx, run.RunID); err != nil {
 		return fmt.Errorf("failed to clean up existing snapshots: %w", err)
@@ -128,6 +127,18 @@ func (sc *SnapshotCapturer) capturePositions(ctx context.Context, run *domain.Se
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(maxConcurrentInserts)
+
+	// Always wait for in-flight goroutines before returning, to avoid leaking
+	// goroutines when the pagination loop exits early on error.
+	defer func() {
+		if waitErr := g.Wait(); waitErr != nil {
+			if retErr != nil {
+				retErr = fmt.Errorf("%w; additionally batch insert failed: %w", retErr, waitErr)
+			} else {
+				retErr = fmt.Errorf("batch insert failed: %w", waitErr)
+			}
+		}
+	}()
 
 	pageToken := ""
 	totalCaptured := 0
@@ -176,10 +187,6 @@ func (sc *SnapshotCapturer) capturePositions(ctx context.Context, run *domain.Se
 		}
 	}
 
-	if err := g.Wait(); err != nil {
-		return fmt.Errorf("batch insert failed: %w", err)
-	}
-
 	slog.InfoContext(ctx, "all snapshots captured",
 		"run_id", run.RunID,
 		"total_snapshots", totalCaptured,
@@ -191,15 +198,15 @@ func (sc *SnapshotCapturer) capturePositions(ctx context.Context, run *domain.Se
 func (sc *SnapshotCapturer) transformToSnapshots(run *domain.SettlementRun, records []PositionRecord) ([]*domain.SettlementSnapshot, error) {
 	snapshots := make([]*domain.SettlementSnapshot, 0, len(records))
 	for _, rec := range records {
-		// For the capture phase, expected balance comes from PK.
-		// Actual balance will be filled during the reconciliation phase.
-		// During capture, we store both as the PK balance (no variance yet).
+		// During capture, both expected and actual are set to the PK balance
+		// so that variance is zero. The actual balance will be overwritten
+		// during the reconciliation phase when the second source is compared.
 		snap, err := domain.NewSettlementSnapshot(
 			run.RunID,
 			rec.AccountID,
 			rec.InstrumentCode,
-			rec.Balance,  // expected balance from PK
-			decimal.Zero, // actual balance - populated during reconciliation
+			rec.Balance, // expected balance from PK
+			rec.Balance, // actual balance - same as expected until reconciliation
 			rec.SourceSystem,
 			rec.Attributes,
 		)

--- a/services/reconciliation/service/snapshot_capturer_integration_test.go
+++ b/services/reconciliation/service/snapshot_capturer_integration_test.go
@@ -226,6 +226,10 @@ func entityToRun(e *settlementRunEntity) *domain.SettlementRun {
 	if e.FailureReason != nil {
 		failureReason = *e.FailureReason
 	}
+	var attrs map[string]string
+	if e.Attributes != nil {
+		_ = json.Unmarshal([]byte(*e.Attributes), &attrs)
+	}
 	return &domain.SettlementRun{
 		RunID:          e.RunID,
 		AccountID:      e.AccountID,
@@ -238,6 +242,7 @@ func entityToRun(e *settlementRunEntity) *domain.SettlementRun {
 		CompletedAt:    e.CompletedAt,
 		VarianceCount:  e.VarianceCount,
 		FailureReason:  failureReason,
+		Attributes:     attrs,
 		CreatedAt:      e.CreatedAt,
 		UpdatedAt:      e.UpdatedAt,
 		Version:        e.Version,

--- a/services/reconciliation/service/snapshot_capturer_integration_test.go
+++ b/services/reconciliation/service/snapshot_capturer_integration_test.go
@@ -1,0 +1,500 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// --- GORM entity models for the integration test ---
+// These mirror the migration schema where `id` is the PK and `run_id`/`snapshot_id` are business keys.
+
+type settlementRunEntity struct {
+	ID             uuid.UUID  `gorm:"column:id;type:uuid;primaryKey"`
+	CreatedAt      time.Time  `gorm:"column:created_at"`
+	UpdatedAt      time.Time  `gorm:"column:updated_at"`
+	RunID          uuid.UUID  `gorm:"column:run_id;type:uuid"`
+	AccountID      string     `gorm:"column:account_id"`
+	Scope          string     `gorm:"column:scope"`
+	SettlementType string     `gorm:"column:settlement_type"`
+	Status         string     `gorm:"column:status"`
+	PeriodStart    time.Time  `gorm:"column:period_start"`
+	PeriodEnd      time.Time  `gorm:"column:period_end"`
+	InitiatedBy    string     `gorm:"column:initiated_by"`
+	CompletedAt    *time.Time `gorm:"column:completed_at"`
+	VarianceCount  int        `gorm:"column:variance_count"`
+	FailureReason  *string    `gorm:"column:failure_reason"`
+	Attributes     *string    `gorm:"column:attributes"`
+	Version        int64      `gorm:"column:version"`
+}
+
+func (settlementRunEntity) TableName() string { return "settlement_run" }
+
+type settlementSnapshotEntity struct {
+	ID              uuid.UUID `gorm:"column:id;type:uuid;primaryKey"`
+	CreatedAt       time.Time `gorm:"column:created_at"`
+	SnapshotID      uuid.UUID `gorm:"column:snapshot_id;type:uuid"`
+	RunID           uuid.UUID `gorm:"column:run_id;type:uuid"` // FK to settlement_run.id (the PK)
+	AccountID       string    `gorm:"column:account_id"`
+	InstrumentCode  string    `gorm:"column:instrument_code"`
+	ExpectedBalance string    `gorm:"column:expected_balance"`
+	ActualBalance   string    `gorm:"column:actual_balance"`
+	VarianceAmount  string    `gorm:"column:variance_amount"`
+	SourceSystem    string    `gorm:"column:source_system"`
+	Attributes      *string   `gorm:"column:attributes"`
+	CapturedAt      time.Time `gorm:"column:captured_at"`
+}
+
+func (settlementSnapshotEntity) TableName() string { return "settlement_snapshot" }
+
+// --- GORM-based repository implementations ---
+
+type gormRunRepo struct {
+	db *gorm.DB
+}
+
+func (r *gormRunRepo) Create(_ context.Context, run *domain.SettlementRun) error {
+	entity := runToEntity(run)
+	return r.db.Create(&entity).Error
+}
+
+func (r *gormRunRepo) FindByID(_ context.Context, runID uuid.UUID) (*domain.SettlementRun, error) {
+	var entity settlementRunEntity
+	err := r.db.Where("run_id = ?", runID).First(&entity).Error
+	if err != nil {
+		return nil, domain.ErrNotFound
+	}
+	return entityToRun(&entity), nil
+}
+
+func (r *gormRunRepo) Update(_ context.Context, run *domain.SettlementRun) error {
+	// Find the existing entity to get its DB id
+	var existing settlementRunEntity
+	if err := r.db.Where("run_id = ?", run.RunID).First(&existing).Error; err != nil {
+		return domain.ErrNotFound
+	}
+
+	// Build the update with optimistic lock on previous version
+	entity := runToEntityWithID(existing.ID, run)
+	result := r.db.Model(&settlementRunEntity{}).
+		Where("id = ? AND version = ?", existing.ID, run.Version-1).
+		Updates(map[string]interface{}{
+			"status":         entity.Status,
+			"completed_at":   entity.CompletedAt,
+			"variance_count": entity.VarianceCount,
+			"failure_reason": entity.FailureReason,
+			"version":        entity.Version,
+			"updated_at":     time.Now().UTC(),
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return domain.ErrOptimisticLock
+	}
+	return nil
+}
+
+func (r *gormRunRepo) List(_ context.Context, _ domain.RunFilter) ([]*domain.SettlementRun, error) {
+	return nil, nil
+}
+
+// getDBRunID resolves the settlement_run.id (DB PK) from the business run_id.
+func (r *gormRunRepo) getDBRunID(runID uuid.UUID) (uuid.UUID, error) {
+	var entity settlementRunEntity
+	err := r.db.Select("id").Where("run_id = ?", runID).First(&entity).Error
+	if err != nil {
+		return uuid.Nil, err
+	}
+	return entity.ID, nil
+}
+
+type gormSnapshotRepo struct {
+	db      *gorm.DB
+	runRepo *gormRunRepo
+}
+
+func (r *gormSnapshotRepo) Create(_ context.Context, snap *domain.SettlementSnapshot) error {
+	dbRunID, err := r.runRepo.getDBRunID(snap.RunID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve run ID: %w", err)
+	}
+	entity := snapshotToEntity(snap, dbRunID)
+	return r.db.Create(&entity).Error
+}
+
+func (r *gormSnapshotRepo) CreateBatch(_ context.Context, snaps []*domain.SettlementSnapshot) error {
+	if len(snaps) == 0 {
+		return nil
+	}
+	dbRunID, err := r.runRepo.getDBRunID(snaps[0].RunID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve run ID: %w", err)
+	}
+	entities := make([]settlementSnapshotEntity, len(snaps))
+	for i, s := range snaps {
+		entities[i] = snapshotToEntity(s, dbRunID)
+	}
+	return r.db.CreateInBatches(entities, 100).Error
+}
+
+func (r *gormSnapshotRepo) FindByID(_ context.Context, snapshotID uuid.UUID) (*domain.SettlementSnapshot, error) {
+	var entity settlementSnapshotEntity
+	err := r.db.Where("snapshot_id = ?", snapshotID).First(&entity).Error
+	if err != nil {
+		return nil, domain.ErrNotFound
+	}
+	return entityToSnapshot(&entity), nil
+}
+
+func (r *gormSnapshotRepo) FindByRunID(_ context.Context, runID uuid.UUID) ([]*domain.SettlementSnapshot, error) {
+	dbRunID, err := r.runRepo.getDBRunID(runID)
+	if err != nil {
+		return nil, err
+	}
+	var entities []settlementSnapshotEntity
+	if err := r.db.Where("run_id = ?", dbRunID).Find(&entities).Error; err != nil {
+		return nil, err
+	}
+	result := make([]*domain.SettlementSnapshot, len(entities))
+	for i, e := range entities {
+		s := entityToSnapshot(&e)
+		s.RunID = runID // Map back to business run_id
+		result[i] = s
+	}
+	return result, nil
+}
+
+func (r *gormSnapshotRepo) DeleteByRunID(_ context.Context, runID uuid.UUID) error {
+	dbRunID, err := r.runRepo.getDBRunID(runID)
+	if err != nil {
+		// If run doesn't exist in DB, nothing to delete
+		return nil //nolint:nilerr // intentional: missing run means no snapshots to clean up
+	}
+	return r.db.Where("run_id = ?", dbRunID).Delete(&settlementSnapshotEntity{}).Error
+}
+
+// --- Entity mappers ---
+
+func runToEntity(run *domain.SettlementRun) settlementRunEntity {
+	return runToEntityWithID(uuid.New(), run)
+}
+
+func runToEntityWithID(dbID uuid.UUID, run *domain.SettlementRun) settlementRunEntity {
+	var failureReason *string
+	if run.FailureReason != "" {
+		failureReason = &run.FailureReason
+	}
+	var attrs *string
+	if run.Attributes != nil {
+		b, _ := json.Marshal(run.Attributes)
+		s := string(b)
+		attrs = &s
+	}
+	return settlementRunEntity{
+		ID:             dbID,
+		RunID:          run.RunID,
+		AccountID:      run.AccountID,
+		Scope:          string(run.Scope),
+		SettlementType: string(run.SettlementType),
+		Status:         string(run.Status),
+		PeriodStart:    run.PeriodStart,
+		PeriodEnd:      run.PeriodEnd,
+		InitiatedBy:    run.InitiatedBy,
+		CompletedAt:    run.CompletedAt,
+		VarianceCount:  run.VarianceCount,
+		FailureReason:  failureReason,
+		Attributes:     attrs,
+		Version:        run.Version,
+		CreatedAt:      run.CreatedAt,
+		UpdatedAt:      run.UpdatedAt,
+	}
+}
+
+func entityToRun(e *settlementRunEntity) *domain.SettlementRun {
+	failureReason := ""
+	if e.FailureReason != nil {
+		failureReason = *e.FailureReason
+	}
+	return &domain.SettlementRun{
+		RunID:          e.RunID,
+		AccountID:      e.AccountID,
+		Scope:          domain.ReconciliationScope(e.Scope),
+		SettlementType: domain.SettlementType(e.SettlementType),
+		Status:         domain.RunStatus(e.Status),
+		PeriodStart:    e.PeriodStart,
+		PeriodEnd:      e.PeriodEnd,
+		InitiatedBy:    e.InitiatedBy,
+		CompletedAt:    e.CompletedAt,
+		VarianceCount:  e.VarianceCount,
+		FailureReason:  failureReason,
+		CreatedAt:      e.CreatedAt,
+		UpdatedAt:      e.UpdatedAt,
+		Version:        e.Version,
+	}
+}
+
+func snapshotToEntity(s *domain.SettlementSnapshot, dbRunID uuid.UUID) settlementSnapshotEntity {
+	var attrs *string
+	if s.Attributes != nil {
+		b, _ := json.Marshal(s.Attributes)
+		str := string(b)
+		attrs = &str
+	}
+	return settlementSnapshotEntity{
+		ID:              uuid.New(),
+		SnapshotID:      s.SnapshotID,
+		RunID:           dbRunID, // FK references settlement_run.id (PK)
+		AccountID:       s.AccountID,
+		InstrumentCode:  s.InstrumentCode,
+		ExpectedBalance: s.ExpectedBalance.StringFixed(18),
+		ActualBalance:   s.ActualBalance.StringFixed(18),
+		VarianceAmount:  s.VarianceAmount.StringFixed(18),
+		SourceSystem:    s.SourceSystem,
+		Attributes:      attrs,
+		CapturedAt:      s.CapturedAt,
+	}
+}
+
+func entityToSnapshot(e *settlementSnapshotEntity) *domain.SettlementSnapshot {
+	expected, _ := decimal.NewFromString(e.ExpectedBalance)
+	actual, _ := decimal.NewFromString(e.ActualBalance)
+	variance, _ := decimal.NewFromString(e.VarianceAmount)
+	var attrs map[string]string
+	if e.Attributes != nil {
+		_ = json.Unmarshal([]byte(*e.Attributes), &attrs)
+	}
+	return &domain.SettlementSnapshot{
+		SnapshotID:      e.SnapshotID,
+		RunID:           e.RunID,
+		AccountID:       e.AccountID,
+		InstrumentCode:  e.InstrumentCode,
+		ExpectedBalance: expected,
+		ActualBalance:   actual,
+		VarianceAmount:  variance,
+		SourceSystem:    e.SourceSystem,
+		Attributes:      attrs,
+		CapturedAt:      e.CapturedAt,
+		CreatedAt:       e.CreatedAt,
+	}
+}
+
+// --- Test setup ---
+
+func setupTestDB(t *testing.T) (*gorm.DB, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+
+	err := db.Exec(`
+		CREATE TABLE settlement_run (
+			id UUID NOT NULL DEFAULT gen_random_uuid(),
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			run_id UUID NOT NULL,
+			account_id VARCHAR(34) NOT NULL,
+			scope VARCHAR(20) NOT NULL,
+			settlement_type VARCHAR(20) NOT NULL,
+			status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+			period_start TIMESTAMPTZ NOT NULL,
+			period_end TIMESTAMPTZ NOT NULL,
+			initiated_by VARCHAR(100) NOT NULL,
+			completed_at TIMESTAMPTZ NULL,
+			variance_count INTEGER NOT NULL DEFAULT 0,
+			failure_reason TEXT NULL,
+			attributes JSONB NULL,
+			version BIGINT NOT NULL DEFAULT 1,
+			PRIMARY KEY (id)
+		)
+	`).Error
+	require.NoError(t, err)
+
+	err = db.Exec(`CREATE UNIQUE INDEX idx_settlement_run_run_id ON settlement_run (run_id)`).Error
+	require.NoError(t, err)
+
+	err = db.Exec(`
+		CREATE TABLE settlement_snapshot (
+			id UUID NOT NULL DEFAULT gen_random_uuid(),
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			snapshot_id UUID NOT NULL,
+			run_id UUID NOT NULL REFERENCES settlement_run(id) ON DELETE CASCADE,
+			account_id VARCHAR(34) NOT NULL,
+			instrument_code VARCHAR(20) NOT NULL,
+			expected_balance DECIMAL(38, 18) NOT NULL,
+			actual_balance DECIMAL(38, 18) NOT NULL,
+			variance_amount DECIMAL(38, 18) NOT NULL,
+			source_system VARCHAR(100) NOT NULL,
+			attributes JSONB NULL,
+			captured_at TIMESTAMPTZ NOT NULL,
+			PRIMARY KEY (id)
+		)
+	`).Error
+	require.NoError(t, err)
+
+	err = db.Exec(`CREATE UNIQUE INDEX idx_settlement_snapshot_snapshot_id ON settlement_snapshot (snapshot_id)`).Error
+	require.NoError(t, err)
+
+	return db, cleanup
+}
+
+// --- Integration tests ---
+
+func TestIntegration_CaptureSnapshots_EndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	runRepo := &gormRunRepo{db: db}
+	snapRepo := &gormSnapshotRepo{db: db, runRepo: runRepo}
+
+	run, err := domain.NewSettlementRun(
+		"ACC-001",
+		domain.ReconciliationScopeAccount,
+		domain.SettlementTypeDaily,
+		time.Now().Add(-24*time.Hour),
+		time.Now(),
+		"integration-test",
+	)
+	require.NoError(t, err)
+	require.NoError(t, runRepo.Create(context.Background(), run))
+
+	provider := &mockPositionProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(1000.50), SourceSystem: "pk", Attributes: map[string]string{"log_id": "log-1"}},
+					{AccountID: "ACC-002", InstrumentCode: "KWH", Balance: decimal.NewFromFloat(500.25), SourceSystem: "pk", Attributes: map[string]string{"log_id": "log-2"}},
+				},
+				NextPageToken: "page2",
+			},
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-003", InstrumentCode: "USD", Balance: decimal.NewFromFloat(999.99), SourceSystem: "pk", Attributes: map[string]string{"log_id": "log-3"}},
+				},
+				NextPageToken: "",
+			},
+		},
+	}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err = capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	updatedRun, err := runRepo.FindByID(context.Background(), run.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.RunStatusCompleted, updatedRun.Status)
+
+	snapshots, err := snapRepo.FindByRunID(context.Background(), run.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, 3, len(snapshots))
+
+	for _, snap := range snapshots {
+		assert.Equal(t, run.RunID, snap.RunID)
+		assert.NotEqual(t, uuid.Nil, snap.SnapshotID)
+		assert.NotEmpty(t, snap.AccountID)
+		assert.NotEmpty(t, snap.InstrumentCode)
+		assert.NotEmpty(t, snap.SourceSystem)
+	}
+}
+
+func TestIntegration_CaptureSnapshots_FailureMarksRunFailed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	runRepo := &gormRunRepo{db: db}
+	snapRepo := &gormSnapshotRepo{db: db, runRepo: runRepo}
+
+	run, err := domain.NewSettlementRun(
+		"ACC-001",
+		domain.ReconciliationScopeAccount,
+		domain.SettlementTypeDaily,
+		time.Now().Add(-24*time.Hour),
+		time.Now(),
+		"integration-test",
+	)
+	require.NoError(t, err)
+	require.NoError(t, runRepo.Create(context.Background(), run))
+
+	provider := &mockPositionProvider{err: fmt.Errorf("PK service unavailable")}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err = capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.Error(t, err)
+
+	updatedRun, err := runRepo.FindByID(context.Background(), run.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.RunStatusFailed, updatedRun.Status)
+	assert.Contains(t, updatedRun.FailureReason, "PK service unavailable")
+}
+
+func TestIntegration_CaptureSnapshots_IdempotentRetry(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	runRepo := &gormRunRepo{db: db}
+	snapRepo := &gormSnapshotRepo{db: db, runRepo: runRepo}
+
+	run, err := domain.NewSettlementRun(
+		"ACC-001",
+		domain.ReconciliationScopeAccount,
+		domain.SettlementTypeDaily,
+		time.Now().Add(-24*time.Hour),
+		time.Now(),
+		"integration-test",
+	)
+	require.NoError(t, err)
+	require.NoError(t, runRepo.Create(context.Background(), run))
+
+	// Insert a leftover snapshot from a previous failed attempt
+	leftover, err := domain.NewSettlementSnapshot(
+		run.RunID, "ACC-OLD", "GBP",
+		decimal.NewFromFloat(999), decimal.Zero, "old-system", nil,
+	)
+	require.NoError(t, err)
+	require.NoError(t, snapRepo.Create(context.Background(), leftover))
+
+	// Verify leftover exists
+	snaps, err := snapRepo.FindByRunID(context.Background(), run.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(snaps))
+
+	provider := &mockPositionProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-NEW", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(500), SourceSystem: "pk"},
+				},
+			},
+		},
+	}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err = capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	// Verify only the new snapshot exists (leftover was deleted)
+	snaps, err = snapRepo.FindByRunID(context.Background(), run.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, len(snaps))
+	assert.Equal(t, "ACC-NEW", snaps[0].AccountID)
+}

--- a/services/reconciliation/service/snapshot_capturer_test.go
+++ b/services/reconciliation/service/snapshot_capturer_test.go
@@ -1,0 +1,427 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock PositionDataProvider ---
+
+type mockPositionProvider struct {
+	pages []PositionPage
+	calls int
+	err   error
+}
+
+func (m *mockPositionProvider) FetchPositions(_ context.Context, _ string, _ int32, _ string) (*PositionPage, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.calls >= len(m.pages) {
+		return &PositionPage{}, nil
+	}
+	page := m.pages[m.calls]
+	m.calls++
+	return &page, nil
+}
+
+// --- Mock SettlementRunRepository ---
+
+type mockRunRepo struct {
+	mu   sync.Mutex
+	runs map[uuid.UUID]*domain.SettlementRun
+
+	findErr   error
+	updateErr error
+}
+
+func newMockRunRepo() *mockRunRepo {
+	return &mockRunRepo{runs: make(map[uuid.UUID]*domain.SettlementRun)}
+}
+
+func (m *mockRunRepo) Create(_ context.Context, run *domain.SettlementRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *mockRunRepo) FindByID(_ context.Context, runID uuid.UUID) (*domain.SettlementRun, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	run, ok := m.runs[runID]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return run, nil
+}
+
+func (m *mockRunRepo) Update(_ context.Context, run *domain.SettlementRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *mockRunRepo) List(_ context.Context, _ domain.RunFilter) ([]*domain.SettlementRun, error) {
+	return nil, nil
+}
+
+// --- Mock SettlementSnapshotRepository ---
+
+type mockSnapshotRepo struct {
+	mu        sync.Mutex
+	snapshots []*domain.SettlementSnapshot
+	deleted   []uuid.UUID
+
+	createBatchErr error
+	deleteErr      error
+}
+
+func (m *mockSnapshotRepo) Create(_ context.Context, snap *domain.SettlementSnapshot) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.snapshots = append(m.snapshots, snap)
+	return nil
+}
+
+func (m *mockSnapshotRepo) CreateBatch(_ context.Context, snaps []*domain.SettlementSnapshot) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.createBatchErr != nil {
+		return m.createBatchErr
+	}
+	m.snapshots = append(m.snapshots, snaps...)
+	return nil
+}
+
+func (m *mockSnapshotRepo) FindByID(_ context.Context, _ uuid.UUID) (*domain.SettlementSnapshot, error) {
+	return nil, domain.ErrNotFound
+}
+
+func (m *mockSnapshotRepo) FindByRunID(_ context.Context, _ uuid.UUID) ([]*domain.SettlementSnapshot, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.snapshots, nil
+}
+
+func (m *mockSnapshotRepo) DeleteByRunID(_ context.Context, runID uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	m.deleted = append(m.deleted, runID)
+	return nil
+}
+
+func (m *mockSnapshotRepo) snapshotCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.snapshots)
+}
+
+// --- Helper to create a test run ---
+
+func newTestRun(t *testing.T) *domain.SettlementRun {
+	t.Helper()
+	run, err := domain.NewSettlementRun(
+		"ACC-001",
+		domain.ReconciliationScopeAccount,
+		domain.SettlementTypeDaily,
+		time.Now().Add(-24*time.Hour),
+		time.Now(),
+		"test-user",
+	)
+	require.NoError(t, err)
+	return run
+}
+
+// --- Tests ---
+
+func TestCaptureSnapshots_SinglePage(t *testing.T) {
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapshotRepo{}
+
+	run := newTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	provider := &mockPositionProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(1000.00), SourceSystem: "pk"},
+					{AccountID: "ACC-002", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(2500.50), SourceSystem: "pk"},
+				},
+				NextPageToken: "",
+			},
+		},
+	}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err := capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, snapRepo.snapshotCount())
+	assert.Equal(t, domain.RunStatusCompleted, runRepo.runs[run.RunID].Status)
+}
+
+func TestCaptureSnapshots_MultiplePages(t *testing.T) {
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapshotRepo{}
+
+	run := newTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	provider := &mockPositionProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(100), SourceSystem: "pk"},
+				},
+				NextPageToken: "page2",
+			},
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-002", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(200), SourceSystem: "pk"},
+				},
+				NextPageToken: "page3",
+			},
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-003", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(300), SourceSystem: "pk"},
+				},
+				NextPageToken: "",
+			},
+		},
+	}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err := capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, snapRepo.snapshotCount())
+	assert.Equal(t, 3, provider.calls)
+}
+
+func TestCaptureSnapshots_EmptyPage(t *testing.T) {
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapshotRepo{}
+
+	run := newTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	provider := &mockPositionProvider{
+		pages: []PositionPage{
+			{Records: []PositionRecord{}, NextPageToken: ""},
+		},
+	}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err := capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, snapRepo.snapshotCount())
+	assert.Equal(t, domain.RunStatusCompleted, runRepo.runs[run.RunID].Status)
+}
+
+func TestCaptureSnapshots_ProviderError(t *testing.T) {
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapshotRepo{}
+
+	run := newTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	providerErr := errors.New("connection refused")
+	provider := &mockPositionProvider{err: providerErr}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err := capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+	assert.Equal(t, domain.RunStatusFailed, runRepo.runs[run.RunID].Status)
+}
+
+func TestCaptureSnapshots_RunNotFound(t *testing.T) {
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapshotRepo{}
+	provider := &mockPositionProvider{}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err := capturer.CaptureSnapshots(context.Background(), uuid.New())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrNotFound)
+}
+
+func TestCaptureSnapshots_RunAlreadyRunning(t *testing.T) {
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapshotRepo{}
+	provider := &mockPositionProvider{}
+
+	run := newTestRun(t)
+	_ = run.Start() // Transition to RUNNING
+	_ = runRepo.Create(context.Background(), run)
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err := capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, domain.ErrInvalidStatusTransition)
+}
+
+func TestCaptureSnapshots_BatchInsertError(t *testing.T) {
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapshotRepo{createBatchErr: errors.New("db connection lost")}
+
+	run := newTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	provider := &mockPositionProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(100), SourceSystem: "pk"},
+				},
+				NextPageToken: "",
+			},
+		},
+	}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err := capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db connection lost")
+	assert.Equal(t, domain.RunStatusFailed, runRepo.runs[run.RunID].Status)
+}
+
+func TestCaptureSnapshots_IdempotentCleanup(t *testing.T) {
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapshotRepo{}
+
+	run := newTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	provider := &mockPositionProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(100), SourceSystem: "pk"},
+				},
+			},
+		},
+	}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err := capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	// Verify DeleteByRunID was called for idempotent cleanup
+	assert.Contains(t, snapRepo.deleted, run.RunID)
+}
+
+func TestCaptureSnapshots_DeleteCleanupError(t *testing.T) {
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapshotRepo{deleteErr: errors.New("cleanup failed")}
+
+	run := newTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	provider := &mockPositionProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(100), SourceSystem: "pk"},
+				},
+			},
+		},
+	}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err := capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "clean up existing snapshots")
+	assert.Equal(t, domain.RunStatusFailed, runRepo.runs[run.RunID].Status)
+}
+
+func TestCaptureSnapshots_LargeDataset(t *testing.T) {
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapshotRepo{}
+
+	run := newTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	// Create 5 pages of 500 records each (2500 total)
+	pages := make([]PositionPage, 5)
+	for i := range pages {
+		records := make([]PositionRecord, 500)
+		for j := range records {
+			records[j] = PositionRecord{
+				AccountID:      "ACC-001",
+				InstrumentCode: "GBP",
+				Balance:        decimal.NewFromInt(int64(i*500 + j)),
+				SourceSystem:   "pk",
+			}
+		}
+		nextToken := ""
+		if i < 4 {
+			nextToken = "next"
+		}
+		pages[i] = PositionPage{
+			Records:       records,
+			NextPageToken: nextToken,
+		}
+	}
+
+	provider := &mockPositionProvider{pages: pages}
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err := capturer.CaptureSnapshots(context.Background(), run.RunID)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2500, snapRepo.snapshotCount())
+	assert.Equal(t, domain.RunStatusCompleted, runRepo.runs[run.RunID].Status)
+}
+
+func TestCaptureSnapshots_ContextCancelled(t *testing.T) {
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapshotRepo{}
+
+	run := newTestRun(t)
+	_ = runRepo.Create(context.Background(), run)
+
+	// Provider that returns a page but the context will be cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &mockPositionProvider{
+		pages: []PositionPage{
+			{
+				Records: []PositionRecord{
+					{AccountID: "ACC-001", InstrumentCode: "GBP", Balance: decimal.NewFromFloat(100), SourceSystem: "pk"},
+				},
+				NextPageToken: "page2",
+			},
+		},
+		err: context.Canceled,
+	}
+
+	// Cancel context before calling
+	cancel()
+
+	capturer := NewSnapshotCapturer(provider, runRepo, snapRepo)
+	err := capturer.CaptureSnapshots(ctx, run.RunID)
+	// Should fail - either context cancelled or provider returns error
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- Implements `SnapshotCapturer` service with `CaptureSnapshots(ctx, runID)` for the reconciliation settlement run lifecycle
- Cursor-based pagination via `PositionDataProvider` interface (page_size=500, max 1000 pages) with bounded memory - processes one page at a time
- Batch insert with GORM `CreateInBatches` and `errgroup`-based concurrent processing (limit 5 goroutines)
- State machine transitions: PENDING -> RUNNING -> COMPLETED/FAILED with 10-minute context deadline
- Partial failure recovery via idempotent cleanup (`DeleteByRunID`) before retry
- `PKPositionProvider` gRPC adapter maps PK `ListFinancialPositionLogs` responses to domain `SettlementSnapshot` objects

## Test plan
- [x] 10 unit tests with mocked PK client covering: single page, multi-page pagination, empty results, provider errors, run-not-found, invalid state transition, batch insert errors, idempotent cleanup, large dataset (2500 records), context cancellation
- [x] 3 integration tests against CockroachDB testcontainer: end-to-end capture, failure marks run as FAILED, idempotent retry with leftover cleanup