### PR TITLE
feat: Define Meridian Manifest Protobuf Schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOMOD=$(GOCMD) mod
 GOGET=$(GOCMD) get
 GOFMT=$(GOCMD) fmt
 
-.PHONY: all help build test lint clean proto proto-v1 proto-v2 proto-openapi proto-lint proto-breaking docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt validate-semconv validate-sagas migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all migrate-apply-orgs migrate-status-orgs docs generate-saga-docs
+.PHONY: all help build test lint clean proto proto-v1 proto-v2 proto-openapi proto-lint proto-breaking docker deploy-local fmt tidy deps coverage install proto-validate proto-deps-update proto-deps-graph proto-plugins-info validate-tilt validate-semconv validate-sagas proto-jsonschema validate-manifest-jsonschema migrate-diff-all migrate-diff-current migrate-diff-position migrate-apply-all migrate-status-all migrate-lint-all migrate-hash-all migrate-apply-orgs migrate-status-orgs docs generate-saga-docs
 
 # Default target
 all: help
@@ -56,6 +56,8 @@ help:
 	@echo "  make proto-deps-update - Update buf.lock with latest dependencies"
 	@echo "  make proto-deps-graph  - Display dependency graph"
 	@echo "  make proto-plugins-info - Display current protoc plugin versions"
+	@echo "  make proto-jsonschema  - Generate JSON Schema from manifest proto"
+	@echo "  make validate-manifest-jsonschema - Validate JSON Schema is in sync with proto"
 	@echo "  make docker            - Build Docker images"
 	@echo "  make deploy-local      - Deploy to local Kubernetes using Tilt"
 	@echo "  make coverage          - Generate and open HTML coverage report"
@@ -288,6 +290,22 @@ proto-plugins-info:
 	@echo "  2. Update versions in buf.gen.yaml"
 	@echo "  3. Run 'make proto' to test generation"
 	@echo "  4. Commit buf.gen.yaml with updated versions"
+
+## proto-jsonschema: Generate JSON Schema from manifest protobuf definition
+proto-jsonschema:
+	@echo "Generating JSON Schema from manifest proto..."
+	@which protoc-gen-jsonschema > /dev/null 2>&1 || \
+		([ -f "$$(go env GOPATH)/bin/protoc-gen-jsonschema" ] && export PATH="$$PATH:$$(go env GOPATH)/bin") || \
+		(echo "protoc-gen-jsonschema not installed. Run: go install github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@latest"; exit 1)
+	@export PATH="$$PATH:$$(go env GOPATH)/bin" && \
+		$(BUF) generate --template buf.gen.jsonschema.yaml --path api/proto/meridian/control_plane/v1/manifest.proto
+	@cp api/jsonschema/meridian.control_plane.v1/Manifest.json api/jsonschema/manifest.v1.schema.json
+	@rm -rf api/jsonschema/meridian.control_plane.v1
+	@echo "JSON Schema generated: api/jsonschema/manifest.v1.schema.json"
+
+## validate-manifest-jsonschema: Validate JSON Schema is in sync with manifest proto
+validate-manifest-jsonschema:
+	@./scripts/validate-manifest-jsonschema.sh
 
 ## migrate-diff-all: Generate migrations for all schemas
 migrate-diff-all: migrate-diff-current migrate-diff-position

--- a/api/jsonschema/manifest.v1.schema.json
+++ b/api/jsonschema/manifest.v1.schema.json
@@ -1,0 +1,309 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/Manifest",
+    "definitions": {
+        "Manifest": {
+            "required": [
+                "version",
+                "metadata",
+                "instruments",
+                "accountTypes",
+                "valuationRules",
+                "sagas",
+                "seedData"
+            ],
+            "properties": {
+                "version": {
+                    "type": "string",
+                    "description": "version is the manifest schema version (e.g., \"1.0\"). Used for forward-compatible parsing of manifest files."
+                },
+                "metadata": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.ManifestMetadata",
+                    "additionalProperties": false,
+                    "description": "metadata contains identifying information about this manifest."
+                },
+                "instruments": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.InstrumentDefinition"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "instruments defines the asset types available to this tenant."
+                },
+                "accountTypes": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.AccountTypeDefinition"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "account_types defines the account classifications available to this tenant."
+                },
+                "valuationRules": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.ValuationRule"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "valuation_rules defines how instruments are converted between each other."
+                },
+                "sagas": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.SagaDefinition"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "sagas defines the workflow definitions available to this tenant."
+                },
+                "seedData": {
+                    "additionalProperties": true,
+                    "type": "object",
+                    "description": "seed_data contains tenant-specific reference data (e.g., default parties, initial chart of accounts, industry-specific lookups). Uses google.protobuf.Struct for flexible JSONB representation."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "========================================\n Manifest Root\n ========================================",
+            "description": "======================================== Manifest Root ========================================  Manifest is the atomic configuration snapshot for a Meridian tenant. It declares the complete business model: instruments, account types, valuation rules, and saga workflows. A manifest is self-contained with no external dependencies - all scripts are inline strings and all references resolve within the manifest itself. Codes (instrument codes, account type codes) are immutable primary keys. To change a code, delete the old definition and create a new one."
+        },
+        "meridian.control_plane.v1.AccountTypeDefinition": {
+            "required": [
+                "code",
+                "name",
+                "normalBalance",
+                "allowedInstruments",
+                "policies"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "code is the unique, immutable identifier for this account type (e.g., \"CURRENT\", \"SAVINGS\", \"CARBON_INVENTORY\"). Must be uppercase alphanumeric with underscores, 1-50 characters."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "name is the human-readable display name (e.g., \"Current Account\")."
+                },
+                "normalBalance": {
+                    "enum": [
+                        "NORMAL_BALANCE_UNSPECIFIED",
+                        0,
+                        "NORMAL_BALANCE_DEBIT",
+                        1,
+                        "NORMAL_BALANCE_CREDIT",
+                        2
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "========================================\n Account Type Definitions\n ========================================",
+                    "description": "======================================== Account Type Definitions ========================================  NormalBalance defines the natural balance direction for an account type."
+                },
+                "allowedInstruments": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "description": "allowed_instruments lists the instrument codes that this account type can hold. Each value must match a code from the manifest's instruments list. Empty list means all instruments defined in the manifest are allowed."
+                },
+                "policies": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.AccountTypePolicies",
+                    "additionalProperties": false,
+                    "description": "policies contains CEL expressions governing this account type's behavior."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Account Type Definition",
+            "description": "AccountTypeDefinition declares an account classification within the manifest. The code field is the immutable primary key - to change a code, delete the old definition and create a new one."
+        },
+        "meridian.control_plane.v1.AccountTypePolicies": {
+            "required": [
+                "validation",
+                "bucketing"
+            ],
+            "properties": {
+                "validation": {
+                    "type": "string",
+                    "description": "validation is a CEL expression evaluated before allowing transactions on this account type. Example: \"amount \u003e 0 \u0026\u0026 amount \u003c= 1000000\" Empty string means no additional validation beyond standard checks."
+                },
+                "bucketing": {
+                    "type": "string",
+                    "description": "bucketing is a CEL expression that determines how amounts are grouped into fungibility buckets. Example: \"instrument_code + ':' + attributes.batch_id\" Empty string means all amounts are fully fungible (single default bucket)."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Account Type Policies",
+            "description": "AccountTypePolicies contains CEL expressions that govern account behavior. CEL syntax validation is deferred to the runtime validator - the manifest only stores the expression strings."
+        },
+        "meridian.control_plane.v1.InstrumentDefinition": {
+            "required": [
+                "code",
+                "name",
+                "type",
+                "dimensions"
+            ],
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "description": "code is the unique, immutable identifier for this instrument (e.g., \"GBP\", \"KWH\", \"CARBON_CREDIT\"). Must be uppercase alphanumeric with underscores, 1-50 characters."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "name is the human-readable display name (e.g., \"British Pound Sterling\")."
+                },
+                "type": {
+                    "enum": [
+                        "INSTRUMENT_TYPE_UNSPECIFIED",
+                        0,
+                        "INSTRUMENT_TYPE_FIAT",
+                        1,
+                        "INSTRUMENT_TYPE_COMMODITY",
+                        2,
+                        "INSTRUMENT_TYPE_VOUCHER",
+                        3
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "========================================\n Instrument Definitions\n ========================================",
+                    "description": "======================================== Instrument Definitions ========================================  InstrumentType classifies the broad category of an instrument."
+                },
+                "dimensions": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.InstrumentDimensions",
+                    "additionalProperties": false,
+                    "description": "dimensions describes the unit and precision of this instrument's quantities."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Instrument Definition",
+            "description": "InstrumentDefinition declares an asset type within the manifest. The code field is the immutable primary key - to change a code, delete the old definition and create a new one."
+        },
+        "meridian.control_plane.v1.InstrumentDimensions": {
+            "required": [
+                "unit",
+                "precision"
+            ],
+            "properties": {
+                "unit": {
+                    "type": "string",
+                    "description": "unit is the display unit for this instrument (e.g., \"GBP\", \"kWh\", \"TONNE_CO2E\")."
+                },
+                "precision": {
+                    "type": "integer",
+                    "description": "precision is the number of decimal places for this instrument (0-18)."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Instrument Dimensions",
+            "description": "InstrumentDimensions describes the unit and precision of an instrument's quantities."
+        },
+        "meridian.control_plane.v1.ManifestMetadata": {
+            "required": [
+                "name",
+                "industry",
+                "description"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "name is the human-readable name for this manifest (e.g., \"Acme Energy Trading\")."
+                },
+                "industry": {
+                    "type": "string",
+                    "description": "industry describes the target industry vertical (e.g., \"energy\", \"banking\", \"carbon\")."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "description provides additional context about this manifest's purpose."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "========================================\n Manifest Metadata\n ========================================",
+            "description": "======================================== Manifest Metadata ========================================  ManifestMetadata contains identifying information about a manifest."
+        },
+        "meridian.control_plane.v1.SagaDefinition": {
+            "required": [
+                "name",
+                "trigger",
+                "script"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "name is the unique identifier for this saga (e.g., \"process_energy_settlement\"). Must be lowercase alphanumeric with underscores."
+                },
+                "trigger": {
+                    "type": "string",
+                    "description": "trigger defines what initiates this saga. Supported prefixes:   \"api:\" - triggered by an API call (e.g., \"api:/v1/settlements\")   \"webhook:\" - triggered by an external webhook (e.g., \"webhook:stripe_payment\")   \"scheduled:\" - triggered on a schedule (e.g., \"scheduled:daily_reconciliation\")"
+                },
+                "script": {
+                    "type": "string",
+                    "description": "script is the inline Starlark source code defining the saga workflow. Must not be empty - all saga logic is defined inline in the manifest. Starlark guarantees termination (no while loops, no recursion)."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "========================================\n Saga Definitions\n ========================================",
+            "description": "======================================== Saga Definitions ========================================  SagaDefinition declares a workflow within the manifest. Sagas are triggered by API calls, webhooks, or scheduled events, and contain inline Starlark scripts that orchestrate service interactions."
+        },
+        "meridian.control_plane.v1.ValuationRule": {
+            "required": [
+                "fromInstrument",
+                "toInstrument",
+                "method",
+                "source"
+            ],
+            "properties": {
+                "fromInstrument": {
+                    "type": "string",
+                    "description": "from_instrument is the source instrument code for conversion. Must match a code from the manifest's instruments list."
+                },
+                "toInstrument": {
+                    "type": "string",
+                    "description": "to_instrument is the target instrument code for conversion. Must match a code from the manifest's instruments list."
+                },
+                "method": {
+                    "enum": [
+                        "VALUATION_METHOD_UNSPECIFIED",
+                        0,
+                        "VALUATION_METHOD_SPOT_RATE",
+                        1,
+                        "VALUATION_METHOD_FIXED",
+                        2
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "========================================\n Valuation Rules\n ========================================",
+                    "description": "======================================== Valuation Rules ========================================  ValuationMethod defines how instrument conversion rates are determined."
+                },
+                "source": {
+                    "type": "string",
+                    "description": "source identifies the rate source for this rule. For SPOT_RATE: the feed identifier (e.g., \"ecb_fx_daily\", \"nordpool_spot\"). For FIXED: a description of who sets the rate (e.g., \"admin_override\", \"contract_rate\")."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Valuation Rule",
+            "description": "ValuationRule defines how one instrument is converted to another. Used for cross-instrument transactions (e.g., kWh to GBP, USD to EUR)."
+        }
+    }
+}

--- a/api/proto/meridian/control_plane/v1/examples/carbon_credits.manifest.json
+++ b/api/proto/meridian/control_plane/v1/examples/carbon_credits.manifest.json
@@ -1,0 +1,130 @@
+{
+  "version": "1.0",
+  "metadata": {
+    "name": "Carbon Credit Registry",
+    "industry": "carbon",
+    "description": "Manifest for carbon credit trading and retirement, supporting verified emission reductions (VERs) and certified emission reductions (CERs) with full provenance tracking."
+  },
+  "instruments": [
+    {
+      "code": "USD",
+      "name": "United States Dollar",
+      "type": "INSTRUMENT_TYPE_FIAT",
+      "dimensions": {
+        "unit": "USD",
+        "precision": 2
+      }
+    },
+    {
+      "code": "EUR",
+      "name": "Euro",
+      "type": "INSTRUMENT_TYPE_FIAT",
+      "dimensions": {
+        "unit": "EUR",
+        "precision": 2
+      }
+    },
+    {
+      "code": "TONNE_CO2E",
+      "name": "Tonne of CO2 Equivalent",
+      "type": "INSTRUMENT_TYPE_COMMODITY",
+      "dimensions": {
+        "unit": "tCO2e",
+        "precision": 3
+      }
+    },
+    {
+      "code": "VER",
+      "name": "Verified Emission Reduction",
+      "type": "INSTRUMENT_TYPE_VOUCHER",
+      "dimensions": {
+        "unit": "VER",
+        "precision": 0
+      }
+    },
+    {
+      "code": "CER",
+      "name": "Certified Emission Reduction",
+      "type": "INSTRUMENT_TYPE_VOUCHER",
+      "dimensions": {
+        "unit": "CER",
+        "precision": 0
+      }
+    }
+  ],
+  "accountTypes": [
+    {
+      "code": "CASH",
+      "name": "Cash Account",
+      "normalBalance": "NORMAL_BALANCE_DEBIT",
+      "allowedInstruments": ["USD", "EUR"],
+      "policies": {
+        "validation": "amount > 0",
+        "bucketing": ""
+      }
+    },
+    {
+      "code": "CARBON_INVENTORY",
+      "name": "Carbon Credit Inventory",
+      "normalBalance": "NORMAL_BALANCE_DEBIT",
+      "allowedInstruments": ["TONNE_CO2E", "VER", "CER"],
+      "policies": {
+        "validation": "amount > 0",
+        "bucketing": "instrument_code + ':' + attributes.vintage_year + ':' + attributes.project_id"
+      }
+    },
+    {
+      "code": "RETIREMENT",
+      "name": "Retirement Account",
+      "normalBalance": "NORMAL_BALANCE_DEBIT",
+      "allowedInstruments": ["TONNE_CO2E", "VER", "CER"],
+      "policies": {
+        "validation": "amount > 0",
+        "bucketing": "instrument_code + ':' + attributes.vintage_year + ':' + attributes.retirement_reason"
+      }
+    }
+  ],
+  "valuationRules": [
+    {
+      "fromInstrument": "VER",
+      "toInstrument": "USD",
+      "method": "VALUATION_METHOD_SPOT_RATE",
+      "source": "verra_registry"
+    },
+    {
+      "fromInstrument": "CER",
+      "toInstrument": "USD",
+      "method": "VALUATION_METHOD_SPOT_RATE",
+      "source": "gold_standard_registry"
+    },
+    {
+      "fromInstrument": "TONNE_CO2E",
+      "toInstrument": "USD",
+      "method": "VALUATION_METHOD_SPOT_RATE",
+      "source": "eu_ets_spot"
+    },
+    {
+      "fromInstrument": "EUR",
+      "toInstrument": "USD",
+      "method": "VALUATION_METHOD_SPOT_RATE",
+      "source": "ecb_fx_daily"
+    }
+  ],
+  "sagas": [
+    {
+      "name": "purchase_carbon_credits",
+      "trigger": "api:/v1/carbon/purchases",
+      "script": "def execute(ctx):\n    purchase = ctx.input\n    \n    # Reserve funds for the purchase\n    lien = current_account.initiate_lien(\n        account_id=purchase.buyer_cash_account,\n        instrument_code=purchase.credit_type,\n        amount=purchase.quantity,\n        payment_order_reference=\"carbon-purchase:\" + purchase.order_id,\n    )\n    \n    # Credit carbon inventory to the buyer\n    position_keeping.initiate_log(\n        account_id=purchase.buyer_inventory_account,\n        amount=purchase.quantity,\n        instrument_code=purchase.credit_type,\n        direction=\"CREDIT\",\n        attributes={\n            \"vintage_year\": purchase.vintage_year,\n            \"project_id\": purchase.project_id,\n        },\n    )\n    \n    # Execute the payment\n    current_account.execute_lien(lien_id=lien.lien_id)\n    \n    return {\"status\": \"purchased\", \"order_id\": purchase.order_id}\n"
+    },
+    {
+      "name": "retire_carbon_credits",
+      "trigger": "api:/v1/carbon/retirements",
+      "script": "def execute(ctx):\n    retirement = ctx.input\n    \n    # Debit from inventory\n    position_keeping.initiate_log(\n        account_id=retirement.inventory_account,\n        amount=retirement.quantity,\n        instrument_code=retirement.credit_type,\n        direction=\"DEBIT\",\n        attributes={\n            \"vintage_year\": retirement.vintage_year,\n            \"project_id\": retirement.project_id,\n        },\n    )\n    \n    # Credit to retirement account (permanent, non-reversible)\n    position_keeping.initiate_log(\n        account_id=retirement.retirement_account,\n        amount=retirement.quantity,\n        instrument_code=retirement.credit_type,\n        direction=\"CREDIT\",\n        attributes={\n            \"vintage_year\": retirement.vintage_year,\n            \"retirement_reason\": retirement.reason,\n        },\n    )\n    \n    return {\"status\": \"retired\", \"retirement_id\": retirement.retirement_id}\n"
+    }
+  ],
+  "seedData": {
+    "registries": ["verra", "gold_standard", "eu_ets"],
+    "credit_types": ["VER", "CER", "TONNE_CO2E"],
+    "vintage_years": ["2020", "2021", "2022", "2023", "2024", "2025"]
+  }
+}

--- a/api/proto/meridian/control_plane/v1/examples/energy_trading.manifest.json
+++ b/api/proto/meridian/control_plane/v1/examples/energy_trading.manifest.json
@@ -1,0 +1,114 @@
+{
+  "version": "1.0",
+  "metadata": {
+    "name": "Nordic Energy Trading",
+    "industry": "energy",
+    "description": "Manifest for energy trading operations supporting electricity spot market trading, carbon credit management, and cross-currency settlement."
+  },
+  "instruments": [
+    {
+      "code": "GBP",
+      "name": "British Pound Sterling",
+      "type": "INSTRUMENT_TYPE_FIAT",
+      "dimensions": {
+        "unit": "GBP",
+        "precision": 2
+      }
+    },
+    {
+      "code": "EUR",
+      "name": "Euro",
+      "type": "INSTRUMENT_TYPE_FIAT",
+      "dimensions": {
+        "unit": "EUR",
+        "precision": 2
+      }
+    },
+    {
+      "code": "KWH",
+      "name": "Kilowatt Hour",
+      "type": "INSTRUMENT_TYPE_COMMODITY",
+      "dimensions": {
+        "unit": "kWh",
+        "precision": 3
+      }
+    },
+    {
+      "code": "MWH",
+      "name": "Megawatt Hour",
+      "type": "INSTRUMENT_TYPE_COMMODITY",
+      "dimensions": {
+        "unit": "MWh",
+        "precision": 3
+      }
+    }
+  ],
+  "accountTypes": [
+    {
+      "code": "SETTLEMENT",
+      "name": "Settlement Account",
+      "normalBalance": "NORMAL_BALANCE_DEBIT",
+      "allowedInstruments": ["GBP", "EUR"],
+      "policies": {
+        "validation": "amount > 0",
+        "bucketing": ""
+      }
+    },
+    {
+      "code": "ENERGY_INVENTORY",
+      "name": "Energy Inventory Account",
+      "normalBalance": "NORMAL_BALANCE_DEBIT",
+      "allowedInstruments": ["KWH", "MWH"],
+      "policies": {
+        "validation": "amount > 0",
+        "bucketing": "instrument_code + ':' + attributes.delivery_period"
+      }
+    },
+    {
+      "code": "REVENUE",
+      "name": "Revenue Account",
+      "normalBalance": "NORMAL_BALANCE_CREDIT",
+      "allowedInstruments": ["GBP", "EUR"],
+      "policies": {
+        "validation": "",
+        "bucketing": ""
+      }
+    }
+  ],
+  "valuationRules": [
+    {
+      "fromInstrument": "KWH",
+      "toInstrument": "GBP",
+      "method": "VALUATION_METHOD_SPOT_RATE",
+      "source": "nordpool_spot"
+    },
+    {
+      "fromInstrument": "MWH",
+      "toInstrument": "GBP",
+      "method": "VALUATION_METHOD_SPOT_RATE",
+      "source": "nordpool_spot"
+    },
+    {
+      "fromInstrument": "EUR",
+      "toInstrument": "GBP",
+      "method": "VALUATION_METHOD_SPOT_RATE",
+      "source": "ecb_fx_daily"
+    }
+  ],
+  "sagas": [
+    {
+      "name": "process_energy_settlement",
+      "trigger": "api:/v1/energy/settlements",
+      "script": "def execute(ctx):\n    # Validate the settlement request\n    meter_data = ctx.input\n    \n    # Record energy delivery in inventory\n    position_keeping.initiate_log(\n        account_id=meter_data.supplier_account,\n        amount=meter_data.quantity,\n        instrument_code=\"KWH\",\n        direction=\"CREDIT\",\n    )\n    \n    # Value the energy in settlement currency\n    valuation = current_account.evaluate_asset_valuation(\n        account_id=meter_data.buyer_account,\n        instrument_code=\"KWH\",\n        amount=meter_data.quantity,\n    )\n    \n    # Debit the buyer\n    current_account.execute_withdrawal(\n        account_id=meter_data.buyer_account,\n        amount=valuation.output.amount,\n        instrument_code=valuation.output.instrument_code,\n        reference=\"energy-settlement:\" + meter_data.settlement_id,\n    )\n    \n    # Credit the supplier\n    current_account.execute_deposit(\n        account_id=meter_data.supplier_account,\n        amount=valuation.output.amount,\n        instrument_code=valuation.output.instrument_code,\n        reference=\"energy-settlement:\" + meter_data.settlement_id,\n    )\n    \n    return {\"status\": \"settled\", \"settlement_id\": meter_data.settlement_id}\n"
+    },
+    {
+      "name": "daily_energy_reconciliation",
+      "trigger": "scheduled:daily_reconciliation",
+      "script": "def execute(ctx):\n    # Reconcile metered vs settled energy quantities\n    accounts = position_keeping.list_accounts(\n        account_type=\"ENERGY_INVENTORY\",\n    )\n    \n    for account in accounts:\n        position_keeping.assert_balance(\n            account_id=account.account_id,\n            instrument_code=\"KWH\",\n        )\n    \n    return {\"status\": \"reconciled\", \"accounts_checked\": len(accounts)}\n"
+    }
+  ],
+  "seedData": {
+    "delivery_periods": ["HH01", "HH02", "HH03", "HH04", "HH05", "HH06", "HH07", "HH08", "HH09", "HH10", "HH11", "HH12", "HH13", "HH14", "HH15", "HH16", "HH17", "HH18", "HH19", "HH20", "HH21", "HH22", "HH23", "HH24", "HH25", "HH26", "HH27", "HH28", "HH29", "HH30", "HH31", "HH32", "HH33", "HH34", "HH35", "HH36", "HH37", "HH38", "HH39", "HH40", "HH41", "HH42", "HH43", "HH44", "HH45", "HH46", "HH47", "HH48"],
+    "default_market": "nordpool"
+  }
+}

--- a/api/proto/meridian/control_plane/v1/examples/saas_billing.manifest.json
+++ b/api/proto/meridian/control_plane/v1/examples/saas_billing.manifest.json
@@ -1,0 +1,143 @@
+{
+  "version": "1.0",
+  "metadata": {
+    "name": "AI Cloud Billing",
+    "industry": "saas",
+    "description": "Manifest for AI cloud compute billing supporting GPU-hour metering, multi-currency settlement, and usage-based subscription management."
+  },
+  "instruments": [
+    {
+      "code": "USD",
+      "name": "United States Dollar",
+      "type": "INSTRUMENT_TYPE_FIAT",
+      "dimensions": {
+        "unit": "USD",
+        "precision": 2
+      }
+    },
+    {
+      "code": "GPU_HOUR",
+      "name": "GPU Compute Hour",
+      "type": "INSTRUMENT_TYPE_COMMODITY",
+      "dimensions": {
+        "unit": "GPU-hr",
+        "precision": 6
+      }
+    },
+    {
+      "code": "API_CALL",
+      "name": "API Call Unit",
+      "type": "INSTRUMENT_TYPE_COMMODITY",
+      "dimensions": {
+        "unit": "calls",
+        "precision": 0
+      }
+    },
+    {
+      "code": "STORAGE_GB",
+      "name": "Storage Gigabyte-Month",
+      "type": "INSTRUMENT_TYPE_COMMODITY",
+      "dimensions": {
+        "unit": "GB-mo",
+        "precision": 3
+      }
+    },
+    {
+      "code": "CREDIT",
+      "name": "Platform Credit",
+      "type": "INSTRUMENT_TYPE_VOUCHER",
+      "dimensions": {
+        "unit": "credits",
+        "precision": 2
+      }
+    }
+  ],
+  "accountTypes": [
+    {
+      "code": "BILLING",
+      "name": "Billing Account",
+      "normalBalance": "NORMAL_BALANCE_DEBIT",
+      "allowedInstruments": ["USD"],
+      "policies": {
+        "validation": "",
+        "bucketing": ""
+      }
+    },
+    {
+      "code": "USAGE",
+      "name": "Usage Metering Account",
+      "normalBalance": "NORMAL_BALANCE_DEBIT",
+      "allowedInstruments": ["GPU_HOUR", "API_CALL", "STORAGE_GB"],
+      "policies": {
+        "validation": "amount > 0",
+        "bucketing": "instrument_code + ':' + attributes.billing_period"
+      }
+    },
+    {
+      "code": "CREDIT_BALANCE",
+      "name": "Credit Balance Account",
+      "normalBalance": "NORMAL_BALANCE_CREDIT",
+      "allowedInstruments": ["CREDIT"],
+      "policies": {
+        "validation": "amount > 0",
+        "bucketing": ""
+      }
+    },
+    {
+      "code": "REVENUE",
+      "name": "Revenue Account",
+      "normalBalance": "NORMAL_BALANCE_CREDIT",
+      "allowedInstruments": ["USD"],
+      "policies": {
+        "validation": "",
+        "bucketing": ""
+      }
+    }
+  ],
+  "valuationRules": [
+    {
+      "fromInstrument": "GPU_HOUR",
+      "toInstrument": "USD",
+      "method": "VALUATION_METHOD_FIXED",
+      "source": "pricing_table_v2"
+    },
+    {
+      "fromInstrument": "API_CALL",
+      "toInstrument": "USD",
+      "method": "VALUATION_METHOD_FIXED",
+      "source": "pricing_table_v2"
+    },
+    {
+      "fromInstrument": "STORAGE_GB",
+      "toInstrument": "USD",
+      "method": "VALUATION_METHOD_FIXED",
+      "source": "pricing_table_v2"
+    },
+    {
+      "fromInstrument": "CREDIT",
+      "toInstrument": "USD",
+      "method": "VALUATION_METHOD_FIXED",
+      "source": "credit_exchange_rate"
+    }
+  ],
+  "sagas": [
+    {
+      "name": "record_gpu_usage",
+      "trigger": "webhook:gpu_meter_event",
+      "script": "def execute(ctx):\n    event = ctx.input\n    \n    # Record usage in metering account\n    position_keeping.initiate_log(\n        account_id=event.usage_account,\n        amount=event.gpu_hours,\n        instrument_code=\"GPU_HOUR\",\n        direction=\"DEBIT\",\n        attributes={\n            \"billing_period\": event.billing_period,\n            \"gpu_type\": event.gpu_type,\n            \"job_id\": event.job_id,\n        },\n    )\n    \n    return {\"status\": \"recorded\", \"job_id\": event.job_id}\n"
+    },
+    {
+      "name": "generate_monthly_invoice",
+      "trigger": "scheduled:monthly_billing",
+      "script": "def execute(ctx):\n    billing_period = ctx.input.billing_period\n    \n    # Get all usage accounts for this period\n    accounts = position_keeping.list_accounts(\n        account_type=\"USAGE\",\n    )\n    \n    for account in accounts:\n        # Calculate total usage cost\n        for instrument in [\"GPU_HOUR\", \"API_CALL\", \"STORAGE_GB\"]:\n            balance = position_keeping.retrieve_balance(\n                account_id=account.account_id,\n                instrument_code=instrument,\n            )\n            \n            if balance.amount > 0:\n                # Value usage in USD\n                valuation = current_account.evaluate_asset_valuation(\n                    account_id=account.billing_account_id,\n                    instrument_code=instrument,\n                    amount=balance.amount,\n                )\n                \n                # Charge billing account\n                current_account.execute_withdrawal(\n                    account_id=account.billing_account_id,\n                    amount=valuation.output.amount,\n                    instrument_code=\"USD\",\n                    reference=\"invoice:\" + billing_period + \":\" + instrument,\n                )\n    \n    return {\"status\": \"invoiced\", \"billing_period\": billing_period}\n"
+    }
+  ],
+  "seedData": {
+    "gpu_types": ["A100", "H100", "H200"],
+    "pricing_tiers": {
+      "free": {"gpu_hours": 10, "api_calls": 1000, "storage_gb": 5},
+      "starter": {"gpu_hours": 100, "api_calls": 100000, "storage_gb": 100},
+      "enterprise": {"gpu_hours": 10000, "api_calls": 10000000, "storage_gb": 10000}
+    }
+  }
+}

--- a/api/proto/meridian/control_plane/v1/manifest.proto
+++ b/api/proto/meridian/control_plane/v1/manifest.proto
@@ -1,0 +1,279 @@
+syntax = "proto3";
+
+package meridian.control_plane.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/struct.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1;controlplanev1";
+
+// ========================================
+// Manifest Root
+// ========================================
+
+// Manifest is the atomic configuration snapshot for a Meridian tenant.
+// It declares the complete business model: instruments, account types,
+// valuation rules, and saga workflows. A manifest is self-contained
+// with no external dependencies - all scripts are inline strings and
+// all references resolve within the manifest itself.
+//
+// Codes (instrument codes, account type codes) are immutable primary keys.
+// To change a code, delete the old definition and create a new one.
+message Manifest {
+  // version is the manifest schema version (e.g., "1.0").
+  // Used for forward-compatible parsing of manifest files.
+  string version = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 20
+    pattern: "^[0-9]+\\.[0-9]+$"
+  }];
+
+  // metadata contains identifying information about this manifest.
+  ManifestMetadata metadata = 2 [(buf.validate.field).required = true];
+
+  // instruments defines the asset types available to this tenant.
+  repeated InstrumentDefinition instruments = 3;
+
+  // account_types defines the account classifications available to this tenant.
+  repeated AccountTypeDefinition account_types = 4;
+
+  // valuation_rules defines how instruments are converted between each other.
+  repeated ValuationRule valuation_rules = 5;
+
+  // sagas defines the workflow definitions available to this tenant.
+  repeated SagaDefinition sagas = 6;
+
+  // seed_data contains tenant-specific reference data (e.g., default parties,
+  // initial chart of accounts, industry-specific lookups).
+  // Uses google.protobuf.Struct for flexible JSONB representation.
+  google.protobuf.Struct seed_data = 7;
+}
+
+// ========================================
+// Manifest Metadata
+// ========================================
+
+// ManifestMetadata contains identifying information about a manifest.
+message ManifestMetadata {
+  // name is the human-readable name for this manifest (e.g., "Acme Energy Trading").
+  string name = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // industry describes the target industry vertical (e.g., "energy", "banking", "carbon").
+  string industry = 2 [(buf.validate.field).string.max_len = 100];
+
+  // description provides additional context about this manifest's purpose.
+  string description = 3 [(buf.validate.field).string.max_len = 2048];
+}
+
+// ========================================
+// Instrument Definitions
+// ========================================
+
+// InstrumentType classifies the broad category of an instrument.
+enum InstrumentType {
+  // INSTRUMENT_TYPE_UNSPECIFIED means the type is unknown.
+  INSTRUMENT_TYPE_UNSPECIFIED = 0;
+  // INSTRUMENT_TYPE_FIAT represents government-issued currencies (USD, EUR, GBP).
+  INSTRUMENT_TYPE_FIAT = 1;
+  // INSTRUMENT_TYPE_COMMODITY represents physical or virtual commodities (kWh, TONNE_CO2E, GPU_HOUR).
+  INSTRUMENT_TYPE_COMMODITY = 2;
+  // INSTRUMENT_TYPE_VOUCHER represents digital vouchers or tokens (loyalty points, aid vouchers).
+  INSTRUMENT_TYPE_VOUCHER = 3;
+}
+
+// InstrumentDimensions describes the unit and precision of an instrument's quantities.
+message InstrumentDimensions {
+  // unit is the display unit for this instrument (e.g., "GBP", "kWh", "TONNE_CO2E").
+  string unit = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+  }];
+
+  // precision is the number of decimal places for this instrument (0-18).
+  int32 precision = 2 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 18
+  }];
+}
+
+// InstrumentDefinition declares an asset type within the manifest.
+// The code field is the immutable primary key - to change a code,
+// delete the old definition and create a new one.
+message InstrumentDefinition {
+  // code is the unique, immutable identifier for this instrument (e.g., "GBP", "KWH", "CARBON_CREDIT").
+  // Must be uppercase alphanumeric with underscores, 1-50 characters.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^[A-Z0-9_]{1,50}$"
+  }];
+
+  // name is the human-readable display name (e.g., "British Pound Sterling").
+  string name = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // type classifies the broad category of this instrument.
+  InstrumentType type = 3 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // dimensions describes the unit and precision of this instrument's quantities.
+  InstrumentDimensions dimensions = 4 [(buf.validate.field).required = true];
+}
+
+// ========================================
+// Account Type Definitions
+// ========================================
+
+// NormalBalance defines the natural balance direction for an account type.
+enum NormalBalance {
+  // NORMAL_BALANCE_UNSPECIFIED means the balance direction is unknown.
+  NORMAL_BALANCE_UNSPECIFIED = 0;
+  // NORMAL_BALANCE_DEBIT means the account naturally holds a debit balance (assets, expenses).
+  NORMAL_BALANCE_DEBIT = 1;
+  // NORMAL_BALANCE_CREDIT means the account naturally holds a credit balance (liabilities, equity, revenue).
+  NORMAL_BALANCE_CREDIT = 2;
+}
+
+// AccountTypePolicies contains CEL expressions that govern account behavior.
+// CEL syntax validation is deferred to the runtime validator - the manifest
+// only stores the expression strings.
+message AccountTypePolicies {
+  // validation is a CEL expression evaluated before allowing transactions on this account type.
+  // Example: "amount > 0 && amount <= 1000000"
+  // Empty string means no additional validation beyond standard checks.
+  string validation = 1 [(buf.validate.field).string.max_len = 4096];
+
+  // bucketing is a CEL expression that determines how amounts are grouped into fungibility buckets.
+  // Example: "instrument_code + ':' + attributes.batch_id"
+  // Empty string means all amounts are fully fungible (single default bucket).
+  string bucketing = 2 [(buf.validate.field).string.max_len = 4096];
+}
+
+// AccountTypeDefinition declares an account classification within the manifest.
+// The code field is the immutable primary key - to change a code,
+// delete the old definition and create a new one.
+message AccountTypeDefinition {
+  // code is the unique, immutable identifier for this account type (e.g., "CURRENT", "SAVINGS", "CARBON_INVENTORY").
+  // Must be uppercase alphanumeric with underscores, 1-50 characters.
+  string code = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^[A-Z0-9_]{1,50}$"
+  }];
+
+  // name is the human-readable display name (e.g., "Current Account").
+  string name = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // normal_balance defines the natural balance direction for this account type.
+  NormalBalance normal_balance = 3 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // allowed_instruments lists the instrument codes that this account type can hold.
+  // Each value must match a code from the manifest's instruments list.
+  // Empty list means all instruments defined in the manifest are allowed.
+  repeated string allowed_instruments = 4 [(buf.validate.field).repeated = {
+    items: {
+      string: {
+        min_len: 1
+        max_len: 50
+        pattern: "^[A-Z0-9_]{1,50}$"
+      }
+    }
+  }];
+
+  // policies contains CEL expressions governing this account type's behavior.
+  AccountTypePolicies policies = 5;
+}
+
+// ========================================
+// Valuation Rules
+// ========================================
+
+// ValuationMethod defines how instrument conversion rates are determined.
+enum ValuationMethod {
+  // VALUATION_METHOD_UNSPECIFIED means the method is unknown.
+  VALUATION_METHOD_UNSPECIFIED = 0;
+  // VALUATION_METHOD_SPOT_RATE uses real-time market rates from an external feed.
+  VALUATION_METHOD_SPOT_RATE = 1;
+  // VALUATION_METHOD_FIXED uses a fixed, administratively-set conversion rate.
+  VALUATION_METHOD_FIXED = 2;
+}
+
+// ValuationRule defines how one instrument is converted to another.
+// Used for cross-instrument transactions (e.g., kWh to GBP, USD to EUR).
+message ValuationRule {
+  // from_instrument is the source instrument code for conversion.
+  // Must match a code from the manifest's instruments list.
+  string from_instrument = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^[A-Z0-9_]{1,50}$"
+  }];
+
+  // to_instrument is the target instrument code for conversion.
+  // Must match a code from the manifest's instruments list.
+  string to_instrument = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+    pattern: "^[A-Z0-9_]{1,50}$"
+  }];
+
+  // method defines how the conversion rate is determined.
+  ValuationMethod method = 3 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // source identifies the rate source for this rule.
+  // For SPOT_RATE: the feed identifier (e.g., "ecb_fx_daily", "nordpool_spot").
+  // For FIXED: a description of who sets the rate (e.g., "admin_override", "contract_rate").
+  string source = 4 [(buf.validate.field).string.max_len = 255];
+}
+
+// ========================================
+// Saga Definitions
+// ========================================
+
+// SagaDefinition declares a workflow within the manifest.
+// Sagas are triggered by API calls, webhooks, or scheduled events,
+// and contain inline Starlark scripts that orchestrate service interactions.
+message SagaDefinition {
+  // name is the unique identifier for this saga (e.g., "process_energy_settlement").
+  // Must be lowercase alphanumeric with underscores.
+  string name = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+    pattern: "^[a-z][a-z0-9_]*$"
+  }];
+
+  // trigger defines what initiates this saga.
+  // Supported prefixes:
+  //   "api:" - triggered by an API call (e.g., "api:/v1/settlements")
+  //   "webhook:" - triggered by an external webhook (e.g., "webhook:stripe_payment")
+  //   "scheduled:" - triggered on a schedule (e.g., "scheduled:daily_reconciliation")
+  string trigger = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+    pattern: "^(api:|webhook:|scheduled:).+$"
+  }];
+
+  // script is the inline Starlark source code defining the saga workflow.
+  // Must not be empty - all saga logic is defined inline in the manifest.
+  // Starlark guarantees termination (no while loops, no recursion).
+  string script = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 65536
+  }];
+}

--- a/api/proto/meridian/control_plane/v1/manifest_test.go
+++ b/api/proto/meridian/control_plane/v1/manifest_test.go
@@ -1,0 +1,830 @@
+package controlplanev1_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"buf.build/go/protovalidate"
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// testValidator is the shared validator instance for all validation tests.
+var testValidator protovalidate.Validator
+
+func TestMain(m *testing.M) {
+	var err error
+	testValidator, err = protovalidate.New()
+	if err != nil {
+		panic(fmt.Sprintf("failed to create validator: %v", err))
+	}
+	os.Exit(m.Run())
+}
+
+// validManifest returns a fully-populated valid manifest for testing.
+func validManifest() *controlplanev1.Manifest {
+	seedData, _ := structpb.NewStruct(map[string]interface{}{
+		"default_market": "nordpool",
+	})
+	return &controlplanev1.Manifest{
+		Version: "1.0",
+		Metadata: &controlplanev1.ManifestMetadata{
+			Name:        "Test Manifest",
+			Industry:    "energy",
+			Description: "A test manifest for energy trading",
+		},
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{
+				Code: "GBP",
+				Name: "British Pound Sterling",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "GBP",
+					Precision: 2,
+				},
+			},
+			{
+				Code: "KWH",
+				Name: "Kilowatt Hour",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "kWh",
+					Precision: 3,
+				},
+			},
+		},
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{
+				Code:               "SETTLEMENT",
+				Name:               "Settlement Account",
+				NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT,
+				AllowedInstruments: []string{"GBP"},
+				Policies: &controlplanev1.AccountTypePolicies{
+					Validation: "amount > 0",
+					Bucketing:  "",
+				},
+			},
+		},
+		ValuationRules: []*controlplanev1.ValuationRule{
+			{
+				FromInstrument: "KWH",
+				ToInstrument:   "GBP",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE,
+				Source:         "nordpool_spot",
+			},
+		},
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "process_settlement",
+				Trigger: "api:/v1/settlements",
+				Script:  "def execute(ctx):\n    return {\"status\": \"ok\"}\n",
+			},
+		},
+		SeedData: seedData,
+	}
+}
+
+// TestManifestValidation verifies Manifest validation constraints.
+func TestManifestValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(m *controlplanev1.Manifest)
+		wantErr bool
+	}{
+		{
+			name:    "valid full manifest",
+			modify:  func(_ *controlplanev1.Manifest) {},
+			wantErr: false,
+		},
+		{
+			name: "valid minimal manifest (no optional fields)",
+			modify: func(m *controlplanev1.Manifest) {
+				m.Instruments = nil
+				m.AccountTypes = nil
+				m.ValuationRules = nil
+				m.Sagas = nil
+				m.SeedData = nil
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: missing version",
+			modify: func(m *controlplanev1.Manifest) {
+				m.Version = ""
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: bad version format",
+			modify: func(m *controlplanev1.Manifest) {
+				m.Version = "v1.0"
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: version without minor",
+			modify: func(m *controlplanev1.Manifest) {
+				m.Version = "1"
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: missing metadata",
+			modify: func(m *controlplanev1.Manifest) {
+				m.Metadata = nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := validManifest()
+			tt.modify(m)
+			err := testValidator.Validate(m)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestManifestMetadataValidation verifies ManifestMetadata constraints.
+func TestManifestMetadataValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		meta    *controlplanev1.ManifestMetadata
+		wantErr bool
+	}{
+		{
+			name: "valid metadata",
+			meta: &controlplanev1.ManifestMetadata{
+				Name:        "Nordic Energy Trading",
+				Industry:    "energy",
+				Description: "Energy trading manifest",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid: minimal (only name required)",
+			meta: &controlplanev1.ManifestMetadata{
+				Name: "Minimal",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: empty name",
+			meta: &controlplanev1.ManifestMetadata{
+				Name: "",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: name exceeds max length",
+			meta: &controlplanev1.ManifestMetadata{
+				Name: strings.Repeat("x", 256),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testValidator.Validate(tt.meta)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestInstrumentDefinitionValidation verifies InstrumentDefinition constraints in the manifest context.
+func TestInstrumentDefinitionValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		inst    *controlplanev1.InstrumentDefinition
+		wantErr bool
+	}{
+		{
+			name: "valid fiat instrument",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "USD",
+				Name: "United States Dollar",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "USD",
+					Precision: 2,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid commodity instrument",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "TONNE_CO2E",
+				Name: "Tonne of CO2 Equivalent",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "tCO2e",
+					Precision: 3,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid voucher instrument",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "AID_VOUCHER",
+				Name: "Humanitarian Aid Voucher",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_VOUCHER,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "vouchers",
+					Precision: 0,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: empty code",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "",
+				Name: "Test",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "TST",
+					Precision: 2,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: lowercase code",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "usd",
+				Name: "Test",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "TST",
+					Precision: 2,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: code with hyphens",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "CO2-E",
+				Name: "Test",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "tCO2e",
+					Precision: 3,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: code exceeds 50 chars",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: strings.Repeat("A", 51),
+				Name: "Test",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "TST",
+					Precision: 2,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: unspecified type",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "TEST",
+				Name: "Test",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_UNSPECIFIED,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "TST",
+					Precision: 2,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: missing dimensions",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "TEST",
+				Name: "Test",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: missing name",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "TEST",
+				Name: "",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "TST",
+					Precision: 2,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: precision exceeds 18",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "TEST",
+				Name: "Test",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "TST",
+					Precision: 19,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid: code with numbers",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "H2O",
+				Name: "Water",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "liters",
+					Precision: 0,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid: code with underscores",
+			inst: &controlplanev1.InstrumentDefinition{
+				Code: "GPU_HOUR",
+				Name: "GPU Compute Hour",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "GPU-hr",
+					Precision: 6,
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testValidator.Validate(tt.inst)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestAccountTypeDefinitionValidation verifies AccountTypeDefinition constraints.
+func TestAccountTypeDefinitionValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		acct    *controlplanev1.AccountTypeDefinition
+		wantErr bool
+	}{
+		{
+			name: "valid debit account type",
+			acct: &controlplanev1.AccountTypeDefinition{
+				Code:               "CURRENT",
+				Name:               "Current Account",
+				NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT,
+				AllowedInstruments: []string{"GBP", "USD"},
+				Policies: &controlplanev1.AccountTypePolicies{
+					Validation: "amount > 0",
+					Bucketing:  "",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid credit account type",
+			acct: &controlplanev1.AccountTypeDefinition{
+				Code:          "REVENUE",
+				Name:          "Revenue Account",
+				NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: empty code",
+			acct: &controlplanev1.AccountTypeDefinition{
+				Code:          "",
+				Name:          "Test",
+				NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: lowercase code",
+			acct: &controlplanev1.AccountTypeDefinition{
+				Code:          "current",
+				Name:          "Test",
+				NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: unspecified normal balance",
+			acct: &controlplanev1.AccountTypeDefinition{
+				Code:          "TEST",
+				Name:          "Test",
+				NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_UNSPECIFIED,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: allowed_instruments with lowercase code",
+			acct: &controlplanev1.AccountTypeDefinition{
+				Code:               "TEST",
+				Name:               "Test",
+				NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT,
+				AllowedInstruments: []string{"gbp"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testValidator.Validate(tt.acct)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestValuationRuleValidation verifies ValuationRule constraints.
+func TestValuationRuleValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    *controlplanev1.ValuationRule
+		wantErr bool
+	}{
+		{
+			name: "valid spot rate rule",
+			rule: &controlplanev1.ValuationRule{
+				FromInstrument: "KWH",
+				ToInstrument:   "GBP",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE,
+				Source:         "nordpool_spot",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid fixed rate rule",
+			rule: &controlplanev1.ValuationRule{
+				FromInstrument: "CREDIT",
+				ToInstrument:   "USD",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_FIXED,
+				Source:         "admin_override",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: empty from_instrument",
+			rule: &controlplanev1.ValuationRule{
+				FromInstrument: "",
+				ToInstrument:   "GBP",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: empty to_instrument",
+			rule: &controlplanev1.ValuationRule{
+				FromInstrument: "KWH",
+				ToInstrument:   "",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: unspecified method",
+			rule: &controlplanev1.ValuationRule{
+				FromInstrument: "KWH",
+				ToInstrument:   "GBP",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_UNSPECIFIED,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testValidator.Validate(tt.rule)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestSagaDefinitionValidation verifies SagaDefinition constraints.
+func TestSagaDefinitionValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		saga    *controlplanev1.SagaDefinition
+		wantErr bool
+	}{
+		{
+			name: "valid API trigger",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "process_payment",
+				Trigger: "api:/v1/payments",
+				Script:  "def execute(ctx):\n    return {}\n",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid webhook trigger",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "handle_stripe_event",
+				Trigger: "webhook:stripe_payment_confirmed",
+				Script:  "def execute(ctx):\n    return {}\n",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid scheduled trigger",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "daily_reconciliation",
+				Trigger: "scheduled:daily_at_0200",
+				Script:  "def execute(ctx):\n    return {}\n",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid multi-line script",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "complex_workflow",
+				Trigger: "api:/v1/workflows",
+				Script: `def execute(ctx):
+    order = ctx.input
+
+    # Create lien
+    lien = current_account.initiate_lien(
+        account_id=order.account_id,
+        amount=order.amount,
+        instrument_code="GBP",
+    )
+
+    # Process payment
+    current_account.execute_lien(lien_id=lien.lien_id)
+
+    return {"status": "completed"}
+`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid: empty name",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "",
+				Trigger: "api:/v1/test",
+				Script:  "def execute(ctx):\n    pass\n",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: uppercase name",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "ProcessPayment",
+				Trigger: "api:/v1/test",
+				Script:  "def execute(ctx):\n    pass\n",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: name starting with number",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "1_invalid_name",
+				Trigger: "api:/v1/test",
+				Script:  "def execute(ctx):\n    pass\n",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: trigger without prefix",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "test_saga",
+				Trigger: "no_prefix",
+				Script:  "def execute(ctx):\n    pass\n",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: empty trigger",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "test_saga",
+				Trigger: "",
+				Script:  "def execute(ctx):\n    pass\n",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid: empty script",
+			saga: &controlplanev1.SagaDefinition{
+				Name:    "test_saga",
+				Trigger: "api:/v1/test",
+				Script:  "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := testValidator.Validate(tt.saga)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestManifestRoundtrip verifies proto -> marshal -> unmarshal preserves all fields.
+func TestManifestRoundtrip(t *testing.T) {
+	original := validManifest()
+
+	data, err := proto.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	decoded := &controlplanev1.Manifest{}
+	if err := proto.Unmarshal(data, decoded); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if !proto.Equal(original, decoded) {
+		t.Error("round-trip proto serialization produced different message")
+	}
+
+	// Verify specific fields survived the roundtrip
+	if decoded.Version != "1.0" {
+		t.Errorf("version mismatch: got %v, want 1.0", decoded.Version)
+	}
+	if decoded.Metadata.Name != "Test Manifest" {
+		t.Errorf("metadata.name mismatch: got %v", decoded.Metadata.Name)
+	}
+	if len(decoded.Instruments) != 2 {
+		t.Errorf("instruments count mismatch: got %d, want 2", len(decoded.Instruments))
+	}
+	if len(decoded.AccountTypes) != 1 {
+		t.Errorf("account_types count mismatch: got %d, want 1", len(decoded.AccountTypes))
+	}
+	if len(decoded.ValuationRules) != 1 {
+		t.Errorf("valuation_rules count mismatch: got %d, want 1", len(decoded.ValuationRules))
+	}
+	if len(decoded.Sagas) != 1 {
+		t.Errorf("sagas count mismatch: got %d, want 1", len(decoded.Sagas))
+	}
+	if decoded.Sagas[0].Script != original.Sagas[0].Script {
+		t.Error("saga script not preserved after roundtrip")
+	}
+}
+
+// TestManifestJSONRoundtrip verifies proto -> JSON -> proto preserves all fields.
+func TestManifestJSONRoundtrip(t *testing.T) {
+	original := validManifest()
+
+	// Marshal to JSON
+	marshaler := protojson.MarshalOptions{
+		Multiline: true,
+		Indent:    "  ",
+	}
+	jsonData, err := marshaler.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal to JSON: %v", err)
+	}
+
+	// Verify it's valid JSON
+	if !json.Valid(jsonData) {
+		t.Fatal("marshaled data is not valid JSON")
+	}
+
+	// Unmarshal from JSON
+	decoded := &controlplanev1.Manifest{}
+	if err := protojson.Unmarshal(jsonData, decoded); err != nil {
+		t.Fatalf("failed to unmarshal from JSON: %v", err)
+	}
+
+	if !proto.Equal(original, decoded) {
+		t.Error("round-trip JSON serialization produced different message")
+	}
+
+	// Verify multi-line script survived JSON encoding
+	if decoded.Sagas[0].Script != original.Sagas[0].Script {
+		t.Error("multi-line Starlark script not preserved through JSON roundtrip")
+	}
+}
+
+// TestEnumValues verifies enum values are correctly defined.
+func TestEnumValues(t *testing.T) {
+	t.Run("InstrumentType", func(t *testing.T) {
+		expected := map[int32]string{
+			0: "INSTRUMENT_TYPE_UNSPECIFIED",
+			1: "INSTRUMENT_TYPE_FIAT",
+			2: "INSTRUMENT_TYPE_COMMODITY",
+			3: "INSTRUMENT_TYPE_VOUCHER",
+		}
+		for val, name := range expected {
+			if controlplanev1.InstrumentType_name[val] != name {
+				t.Errorf("InstrumentType %d: got %s, want %s",
+					val, controlplanev1.InstrumentType_name[val], name)
+			}
+		}
+	})
+
+	t.Run("NormalBalance", func(t *testing.T) {
+		expected := map[int32]string{
+			0: "NORMAL_BALANCE_UNSPECIFIED",
+			1: "NORMAL_BALANCE_DEBIT",
+			2: "NORMAL_BALANCE_CREDIT",
+		}
+		for val, name := range expected {
+			if controlplanev1.NormalBalance_name[val] != name {
+				t.Errorf("NormalBalance %d: got %s, want %s",
+					val, controlplanev1.NormalBalance_name[val], name)
+			}
+		}
+	})
+
+	t.Run("ValuationMethod", func(t *testing.T) {
+		expected := map[int32]string{
+			0: "VALUATION_METHOD_UNSPECIFIED",
+			1: "VALUATION_METHOD_SPOT_RATE",
+			2: "VALUATION_METHOD_FIXED",
+		}
+		for val, name := range expected {
+			if controlplanev1.ValuationMethod_name[val] != name {
+				t.Errorf("ValuationMethod %d: got %s, want %s",
+					val, controlplanev1.ValuationMethod_name[val], name)
+			}
+		}
+	})
+}
+
+// TestInstrumentCodeRegex verifies the ^[A-Z0-9_]{1,50}$ pattern works correctly.
+func TestInstrumentCodeRegex(t *testing.T) {
+	validCodes := []string{
+		"GBP", "USD", "EUR", "KWH", "MWH",
+		"TONNE_CO2E", "GPU_HOUR", "CARBON_CREDIT",
+		"A", "ABC123", "A_B_C",
+		strings.Repeat("A", 50), // max length
+	}
+
+	invalidCodes := []string{
+		"", "gbp", "usd", // empty/lowercase
+		"CO2-E", "test.code", // special chars
+		"abc", "a_b", // lowercase
+		strings.Repeat("A", 51), // exceeds max
+	}
+
+	for _, code := range validCodes {
+		t.Run("valid:"+code, func(t *testing.T) {
+			inst := &controlplanev1.InstrumentDefinition{
+				Code: code,
+				Name: "Test",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "TST",
+					Precision: 2,
+				},
+			}
+			if err := testValidator.Validate(inst); err != nil {
+				t.Errorf("code %q should be valid: %v", code, err)
+			}
+		})
+	}
+
+	for _, code := range invalidCodes {
+		t.Run("invalid:"+code, func(t *testing.T) {
+			inst := &controlplanev1.InstrumentDefinition{
+				Code: code,
+				Name: "Test",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "TST",
+					Precision: 2,
+				},
+			}
+			if err := testValidator.Validate(inst); err == nil {
+				t.Errorf("code %q should be invalid", code)
+			}
+		})
+	}
+}

--- a/buf.gen.jsonschema.yaml
+++ b/buf.gen.jsonschema.yaml
@@ -1,0 +1,13 @@
+version: v2
+plugins:
+  # JSON Schema generator for Manifest proto
+  # Generates JSON Schema from protobuf definitions for validation tooling.
+  # Usage: buf generate --template buf.gen.jsonschema.yaml --path api/proto/meridian/control_plane/v1/manifest.proto
+  - local: protoc-gen-jsonschema
+    out: api/jsonschema
+    opt:
+      - all_fields_required
+      - enforce_oneof
+      - json_fieldnames
+      - prefix_schema_files_with_package
+      - disallow_additional_properties

--- a/scripts/validate-manifest-jsonschema.sh
+++ b/scripts/validate-manifest-jsonschema.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# validate-manifest-jsonschema.sh
+#
+# Validates that the generated JSON Schema (api/jsonschema/manifest.v1.schema.json)
+# is in sync with the protobuf definition (api/proto/meridian/control_plane/v1/manifest.proto).
+#
+# This script regenerates the JSON Schema into a temp directory and compares it
+# against the committed version. If they differ, the proto was changed without
+# regenerating the schema.
+#
+# Usage: ./scripts/validate-manifest-jsonschema.sh
+# Exit code: 0 if in sync, 1 if out of sync or error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+SCHEMA_FILE="${PROJECT_ROOT}/api/jsonschema/manifest.v1.schema.json"
+PROTO_FILE="api/proto/meridian/control_plane/v1/manifest.proto"
+
+# Check prerequisites
+if ! command -v buf &> /dev/null; then
+    echo "ERROR: buf is not installed. Run 'make install'."
+    exit 1
+fi
+
+if ! command -v protoc-gen-jsonschema &> /dev/null; then
+    # Check in ~/go/bin as fallback
+    if [ -f "${HOME}/go/bin/protoc-gen-jsonschema" ]; then
+        export PATH="${PATH}:${HOME}/go/bin"
+    else
+        echo "ERROR: protoc-gen-jsonschema is not installed."
+        echo "Install: go install github.com/chrusty/protoc-gen-jsonschema/cmd/protoc-gen-jsonschema@latest"
+        exit 1
+    fi
+fi
+
+if [ ! -f "${SCHEMA_FILE}" ]; then
+    echo "ERROR: ${SCHEMA_FILE} not found. Run 'make proto-jsonschema' to generate it."
+    exit 1
+fi
+
+# Generate into a temp directory
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TEMP_DIR}"' EXIT
+
+cd "${PROJECT_ROOT}"
+
+buf generate \
+    --template buf.gen.jsonschema.yaml \
+    --path "${PROTO_FILE}" \
+    2>/dev/null
+
+# The generator creates files in a subdirectory
+GENERATED_FILE="${PROJECT_ROOT}/api/jsonschema/meridian.control_plane.v1/Manifest.json"
+
+if [ ! -f "${GENERATED_FILE}" ]; then
+    echo "ERROR: JSON Schema generation produced no output."
+    exit 1
+fi
+
+# Compare
+if diff -q "${SCHEMA_FILE}" "${GENERATED_FILE}" > /dev/null 2>&1; then
+    echo "JSON Schema is in sync with proto definition."
+    rm -rf "${PROJECT_ROOT}/api/jsonschema/meridian.control_plane.v1"
+    exit 0
+else
+    echo "ERROR: JSON Schema is out of sync with proto definition."
+    echo ""
+    echo "The file api/jsonschema/manifest.v1.schema.json does not match"
+    echo "the current proto definition at ${PROTO_FILE}."
+    echo ""
+    echo "To fix: run 'make proto-jsonschema' and commit the updated schema."
+    echo ""
+    echo "Diff:"
+    diff "${SCHEMA_FILE}" "${GENERATED_FILE}" || true
+    rm -rf "${PROJECT_ROOT}/api/jsonschema/meridian.control_plane.v1"
+    exit 1
+fi

--- a/scripts/validate-manifest-jsonschema.sh
+++ b/scripts/validate-manifest-jsonschema.sh
@@ -41,19 +41,33 @@ if [ ! -f "${SCHEMA_FILE}" ]; then
     exit 1
 fi
 
-# Generate into a temp directory
+# Generate into a temp directory to avoid leaving artifacts in the project
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf "${TEMP_DIR}"' EXIT
+
+# Create a temporary buf.gen template that outputs to the temp directory
+cat > "${TEMP_DIR}/buf.gen.jsonschema.yaml" <<TMPL
+version: v2
+plugins:
+  - local: protoc-gen-jsonschema
+    out: ${TEMP_DIR}/out
+    opt:
+      - all_fields_required
+      - enforce_oneof
+      - json_fieldnames
+      - prefix_schema_files_with_package
+      - disallow_additional_properties
+TMPL
 
 cd "${PROJECT_ROOT}"
 
 buf generate \
-    --template buf.gen.jsonschema.yaml \
+    --template "${TEMP_DIR}/buf.gen.jsonschema.yaml" \
     --path "${PROTO_FILE}" \
     2>/dev/null
 
 # The generator creates files in a subdirectory
-GENERATED_FILE="${PROJECT_ROOT}/api/jsonschema/meridian.control_plane.v1/Manifest.json"
+GENERATED_FILE="${TEMP_DIR}/out/meridian.control_plane.v1/Manifest.json"
 
 if [ ! -f "${GENERATED_FILE}" ]; then
     echo "ERROR: JSON Schema generation produced no output."
@@ -63,7 +77,6 @@ fi
 # Compare
 if diff -q "${SCHEMA_FILE}" "${GENERATED_FILE}" > /dev/null 2>&1; then
     echo "JSON Schema is in sync with proto definition."
-    rm -rf "${PROJECT_ROOT}/api/jsonschema/meridian.control_plane.v1"
     exit 0
 else
     echo "ERROR: JSON Schema is out of sync with proto definition."
@@ -75,6 +88,5 @@ else
     echo ""
     echo "Diff:"
     diff "${SCHEMA_FILE}" "${GENERATED_FILE}" || true
-    rm -rf "${PROJECT_ROOT}/api/jsonschema/meridian.control_plane.v1"
     exit 1
 fi


### PR DESCRIPTION
## Summary

- Define the core Manifest protobuf at `api/proto/meridian/control_plane/v1/manifest.proto` with message types for instruments, account types, valuation rules, saga definitions, and seed data
- Configure JSON Schema generation via `protoc-gen-jsonschema` with CI sync validation
- Add example manifests for three industry verticals: energy trading, carbon credits, and SaaS billing

## Changes Made

### Proto Definition (`manifest.proto`)
Root `Manifest` message containing:
- `ManifestMetadata`: name, industry, description
- `InstrumentDefinition`: code (immutable PK), name, type (FIAT/COMMODITY/VOUCHER), dimensions (unit, precision)
- `AccountTypeDefinition`: code (immutable PK), name, normal_balance (DEBIT/CREDIT), allowed_instruments, policies (validation CEL, bucketing CEL)
- `ValuationRule`: from/to instrument, method (SPOT_RATE/FIXED), source
- `SagaDefinition`: name, trigger (api:/webhook:/scheduled:), inline Starlark script
- `seed_data`: flexible JSONB via `google.protobuf.Struct`

### Validation Constraints (buf.validate)
- Code fields: `^[A-Z0-9_]{1,50}$` (uppercase immutable identifiers)
- Saga names: `^[a-z][a-z0-9_]*$` (lowercase snake_case)
- Trigger prefixes: `^(api:|webhook:|scheduled:).+$`
- Script fields: `min_len = 1` (must not be empty)
- CEL expressions: stored as strings, syntax validation deferred to runtime

### JSON Schema
- `buf.gen.jsonschema.yaml` for protoc-gen-jsonschema plugin config
- Generated `api/jsonschema/manifest.v1.schema.json` (self-contained)
- `scripts/validate-manifest-jsonschema.sh` for CI sync validation
- Makefile targets: `proto-jsonschema`, `validate-manifest-jsonschema`

### Example Manifests
- `energy_trading.manifest.json`: GBP/EUR/KWH/MWH instruments, energy settlement saga
- `carbon_credits.manifest.json`: USD/TONNE_CO2E/VER/CER instruments, purchase/retirement sagas
- `saas_billing.manifest.json`: USD/GPU_HOUR/API_CALL/STORAGE_GB instruments, usage metering saga

## Testing
- 50 test cases covering all message types, validation constraints, and edge cases
- Proto roundtrip (marshal/unmarshal) preserves all fields
- JSON roundtrip (proto -> JSON -> proto) preserves multi-line Starlark scripts
- Code regex `^[A-Z0-9_]{1,50}$` tested with valid and invalid patterns
- Enum values verified for correct numbering
- buf lint and buf build pass cleanly

## Task Master Reference
Task: control-plane.1 - Define Meridian Manifest Protobuf Schema