### PR TITLE
feat: Implement Manifest Validator with CEL and Starlark compilation

### DIFF
--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -1,0 +1,792 @@
+// Package validator provides manifest validation for the control plane.
+// It performs structural schema validation, CEL type-checking for policy
+// expressions, Starlark compilation for saga scripts, cross-reference
+// validation, and immutability checks. All errors are structured with
+// location paths and suggestions for AI-friendly feedback loops.
+package validator
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"buf.build/go/protovalidate"
+	"github.com/google/cel-go/cel"
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+// Known service bindings available on the saga context object.
+// These are the service modules that Starlark scripts can call via ctx.<service>.
+var knownServiceBindings = []string{
+	"position_keeping",
+	"financial_accounting",
+	"current_account",
+	"valuation_engine",
+	"repository",
+	"notification",
+	"payment_order",
+	"reconciliation",
+	"reference_data",
+}
+
+// Known top-level Starlark builtins provided by the saga runtime.
+var knownStarlarkBuiltins = []string{
+	"input_data",
+	"invoke_handler",
+	"party_scope",
+	"Decimal",
+	"print",
+	"len",
+	"range",
+	"str",
+	"int",
+	"float",
+	"bool",
+	"list",
+	"dict",
+	"tuple",
+	"type",
+	"True",
+	"False",
+	"None",
+	"hasattr",
+	"getattr",
+	"enumerate",
+	"zip",
+	"sorted",
+	"reversed",
+	"min",
+	"max",
+	"any",
+	"all",
+	"hash",
+	"repr",
+	"fail",
+}
+
+// ErrUnhashable is returned when hashing a starlark module is attempted.
+var ErrUnhashable = errors.New("unhashable: module")
+
+// CEL Balance type fields available in account type policy expressions.
+var celBalanceFields = []string{
+	"quantity",
+	"instrument",
+	"bucket_id",
+	"as_of",
+	"amount",
+}
+
+// Severity indicates the severity of a validation finding.
+type Severity string
+
+const (
+	// SeverityError blocks manifest activation.
+	SeverityError Severity = "error"
+	// SeverityWarning allows activation but should be reviewed.
+	SeverityWarning Severity = "warning"
+)
+
+// ValidationError represents a single validation finding with structured
+// location information and optional suggestions for AI feedback.
+type ValidationError struct {
+	// Severity indicates whether this blocks activation.
+	Severity Severity `json:"severity"`
+
+	// Path is the location within the manifest (e.g., "instruments[0].code").
+	Path string `json:"path"`
+
+	// Code is a machine-readable error code (e.g., "CEL_TYPE_ERROR").
+	Code string `json:"code"`
+
+	// Message is a human-readable description of the issue.
+	Message string `json:"message"`
+
+	// Line is the source line number (for script errors).
+	Line int `json:"line,omitempty"`
+
+	// Column is the source column number (for script errors).
+	Column int `json:"column,omitempty"`
+
+	// Suggestion is a "Did you mean...?" hint for typos.
+	Suggestion string `json:"suggestion,omitempty"`
+
+	// AvailableFields lists valid field names when an unknown field is referenced.
+	AvailableFields []string `json:"available_fields,omitempty"`
+}
+
+// Error implements the error interface.
+func (e ValidationError) Error() string {
+	msg := fmt.Sprintf("[%s] %s: %s", e.Severity, e.Path, e.Message)
+	if e.Suggestion != "" {
+		msg += fmt.Sprintf(" (suggestion: %s)", e.Suggestion)
+	}
+	return msg
+}
+
+// ValidationResult contains the outcome of manifest validation.
+type ValidationResult struct {
+	// Valid is true when there are no errors (warnings are allowed).
+	Valid bool `json:"valid"`
+
+	// Errors contains all error-severity findings.
+	Errors []ValidationError `json:"errors"`
+
+	// Warnings contains all warning-severity findings.
+	Warnings []ValidationError `json:"warnings"`
+}
+
+// ManifestValidator validates Meridian manifests.
+type ManifestValidator struct {
+	protoValidator protovalidate.Validator
+	celEnv         *cel.Env
+	bucketCelEnv   *cel.Env
+}
+
+// New creates a new ManifestValidator.
+func New() (*ManifestValidator, error) {
+	pv, err := protovalidate.New()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create proto validator: %w", err)
+	}
+
+	// CEL environment for account type validation policies.
+	// These expressions operate on balance state.
+	// Use DynType for numeric fields to allow both int and double literals
+	// (e.g., "amount > 0" and "amount > 0.0" both work).
+	celEnv, err := cel.NewEnv(
+		cel.Variable("quantity", cel.DynType),
+		cel.Variable("instrument", cel.StringType),
+		cel.Variable("bucket_id", cel.StringType),
+		cel.Variable("as_of", cel.TimestampType),
+		cel.Variable("amount", cel.DynType),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+
+	// CEL environment for bucketing expressions.
+	bucketCelEnv, err := cel.NewEnv(
+		cel.Variable("instrument_code", cel.StringType),
+		cel.Variable("attributes", cel.MapType(cel.StringType, cel.StringType)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create bucket CEL environment: %w", err)
+	}
+
+	return &ManifestValidator{
+		protoValidator: pv,
+		celEnv:         celEnv,
+		bucketCelEnv:   bucketCelEnv,
+	}, nil
+}
+
+// Validate performs full validation of a manifest.
+// If previousManifest is non-nil, immutability checks are also performed.
+func (v *ManifestValidator) Validate(
+	manifest *controlplanev1.Manifest,
+	previousManifest *controlplanev1.Manifest,
+) *ValidationResult {
+	result := &ValidationResult{Valid: true}
+
+	// 1. Structural validation (protobuf constraints)
+	v.validateStructural(manifest, result)
+
+	// 2. Duplicate code detection
+	v.validateDuplicates(manifest, result)
+
+	// 3. CEL expression validation
+	v.validateCELExpressions(manifest, result)
+
+	// 4. Starlark script compilation
+	v.validateStarlarkScripts(manifest, result)
+
+	// 5. Cross-reference validation
+	v.validateCrossReferences(manifest, result)
+
+	// 6. Immutability checks
+	if previousManifest != nil {
+		v.validateImmutability(manifest, previousManifest, result)
+	}
+
+	// Set valid flag based on error count
+	result.Valid = len(result.Errors) == 0
+
+	return result
+}
+
+// validateStructural uses protovalidate to check protobuf constraints.
+func (v *ManifestValidator) validateStructural(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	err := v.protoValidator.Validate(manifest)
+	if err == nil {
+		return
+	}
+
+	var valErr *protovalidate.ValidationError
+	if errors.As(err, &valErr) {
+		for _, violation := range valErr.Violations {
+			path := buildFieldPath(violation)
+			message := ""
+			if violation.Proto != nil {
+				message = violation.Proto.GetMessage()
+			}
+			if message == "" {
+				message = violation.String()
+			}
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     path,
+				Code:     "PROTO_VALIDATION",
+				Message:  message,
+			})
+		}
+	} else {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     "",
+			Code:     "PROTO_VALIDATION",
+			Message:  err.Error(),
+		})
+	}
+}
+
+// validateDuplicates checks for duplicate codes within the manifest.
+func (v *ManifestValidator) validateDuplicates(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	// Check duplicate instrument codes
+	instrumentCodes := make(map[string]int)
+	for i, inst := range manifest.GetInstruments() {
+		if prev, exists := instrumentCodes[inst.GetCode()]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("instruments[%d].code", i),
+				Code:     "DUPLICATE_CODE",
+				Message:  fmt.Sprintf("duplicate instrument code %q (first defined at instruments[%d])", inst.GetCode(), prev),
+			})
+		} else {
+			instrumentCodes[inst.GetCode()] = i
+		}
+	}
+
+	// Check duplicate account type codes
+	accountTypeCodes := make(map[string]int)
+	for i, acct := range manifest.GetAccountTypes() {
+		if prev, exists := accountTypeCodes[acct.GetCode()]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("account_types[%d].code", i),
+				Code:     "DUPLICATE_CODE",
+				Message:  fmt.Sprintf("duplicate account type code %q (first defined at account_types[%d])", acct.GetCode(), prev),
+			})
+		} else {
+			accountTypeCodes[acct.GetCode()] = i
+		}
+	}
+
+	// Check duplicate saga names
+	sagaNames := make(map[string]int)
+	for i, saga := range manifest.GetSagas() {
+		if prev, exists := sagaNames[saga.GetName()]; exists {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     fmt.Sprintf("sagas[%d].name", i),
+				Code:     "DUPLICATE_NAME",
+				Message:  fmt.Sprintf("duplicate saga name %q (first defined at sagas[%d])", saga.GetName(), prev),
+			})
+		} else {
+			sagaNames[saga.GetName()] = i
+		}
+	}
+}
+
+// validateCELExpressions type-checks CEL expressions in account type policies.
+func (v *ManifestValidator) validateCELExpressions(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	for i, acctType := range manifest.GetAccountTypes() {
+		policies := acctType.GetPolicies()
+		if policies == nil {
+			continue
+		}
+
+		// Validate validation expression
+		if expr := policies.GetValidation(); expr != "" {
+			v.validateCELExpression(
+				expr,
+				fmt.Sprintf("account_types[%d].policies.validation", i),
+				v.celEnv,
+				celBalanceFields,
+				result,
+			)
+		}
+
+		// Validate bucketing expression
+		if expr := policies.GetBucketing(); expr != "" {
+			v.validateCELExpression(
+				expr,
+				fmt.Sprintf("account_types[%d].policies.bucketing", i),
+				v.bucketCelEnv,
+				[]string{"instrument_code", "attributes"},
+				result,
+			)
+		}
+	}
+}
+
+// validateCELExpression compiles a single CEL expression and produces structured errors.
+func (v *ManifestValidator) validateCELExpression(
+	expression string,
+	path string,
+	env *cel.Env,
+	availableFields []string,
+	result *ValidationResult,
+) {
+	// Check length constraint
+	if len(expression) > 4096 {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     path,
+			Code:     "CEL_EXPRESSION_TOO_LONG",
+			Message:  fmt.Sprintf("CEL expression exceeds maximum length of 4096 bytes (got %d)", len(expression)),
+		})
+		return
+	}
+
+	_, issues := env.Compile(expression)
+	if issues == nil || issues.Err() == nil {
+		return
+	}
+
+	errMsg := issues.Err().Error()
+
+	// Check for undeclared reference errors to provide field suggestions
+	if strings.Contains(errMsg, "undeclared reference") {
+		// Extract the undeclared field name from the error
+		undeclaredField := extractUndeclaredReference(errMsg)
+		suggestion := ""
+		if undeclaredField != "" {
+			suggestion = findClosestMatch(undeclaredField, availableFields)
+			if suggestion != "" {
+				suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+			}
+		}
+
+		addError(result, ValidationError{
+			Severity:        SeverityError,
+			Path:            path,
+			Code:            "CEL_UNDECLARED_REFERENCE",
+			Message:         errMsg,
+			Suggestion:      suggestion,
+			AvailableFields: availableFields,
+		})
+		return
+	}
+
+	addError(result, ValidationError{
+		Severity: SeverityError,
+		Path:     path,
+		Code:     "CEL_COMPILATION_ERROR",
+		Message:  errMsg,
+	})
+}
+
+// validateStarlarkScripts compiles each saga's Starlark script.
+func (v *ManifestValidator) validateStarlarkScripts(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	for i, saga := range manifest.GetSagas() {
+		script := saga.GetScript()
+		if script == "" {
+			continue
+		}
+		v.validateSingleStarlarkScript(saga, script, fmt.Sprintf("sagas[%d].script", i), result)
+	}
+}
+
+// validateSingleStarlarkScript compiles and validates one Starlark script.
+func (v *ManifestValidator) validateSingleStarlarkScript(
+	saga *controlplanev1.SagaDefinition,
+	script string,
+	path string,
+	result *ValidationResult,
+) {
+	if len(script) > 65536 {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     path,
+			Code:     "STARLARK_SCRIPT_TOO_LARGE",
+			Message:  fmt.Sprintf("Starlark script exceeds maximum size of 65536 bytes (got %d)", len(script)),
+		})
+		return
+	}
+
+	fileOpts := &syntax.FileOptions{}
+	_, parseErr := fileOpts.Parse(saga.GetName()+".star", script, 0)
+	if parseErr != nil {
+		addError(result, parseStarlarkError(parseErr, path))
+		return
+	}
+
+	predeclared := buildStarlarkPredeclared()
+	thread := &starlark.Thread{
+		Name:  saga.GetName(),
+		Print: func(_ *starlark.Thread, _ string) {},
+	}
+
+	_, execErr := starlark.ExecFileOptions(fileOpts, thread, saga.GetName()+".star", script, predeclared)
+	if execErr != nil {
+		ve := parseStarlarkError(execErr, path)
+		addStarlarkUndefinedSuggestion(execErr, &ve)
+		addError(result, ve)
+	}
+}
+
+// addStarlarkUndefinedSuggestion enriches a validation error with a "Did you mean?" suggestion
+// when the Starlark error is about an undefined name.
+func addStarlarkUndefinedSuggestion(execErr error, ve *ValidationError) {
+	if !strings.Contains(execErr.Error(), "undefined") {
+		return
+	}
+	undefinedName := extractUndefinedStarlarkName(execErr.Error())
+	if undefinedName == "" {
+		return
+	}
+	allNames := make([]string, 0, len(knownServiceBindings)+len(knownStarlarkBuiltins))
+	allNames = append(allNames, knownServiceBindings...)
+	allNames = append(allNames, knownStarlarkBuiltins...)
+	if suggestion := findClosestMatch(undefinedName, allNames); suggestion != "" {
+		ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+	}
+}
+
+// validateCrossReferences checks that all references between manifest sections are valid.
+func (v *ManifestValidator) validateCrossReferences(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	instrumentCodes := make(map[string]bool)
+	for _, inst := range manifest.GetInstruments() {
+		instrumentCodes[inst.GetCode()] = true
+	}
+	codeList := mapKeys(instrumentCodes)
+
+	for i, acctType := range manifest.GetAccountTypes() {
+		for j, instrCode := range acctType.GetAllowedInstruments() {
+			checkInstrumentRef(
+				instrCode, instrumentCodes, codeList,
+				fmt.Sprintf("account_types[%d].allowed_instruments[%d]", i, j),
+				result,
+			)
+		}
+	}
+
+	for i, rule := range manifest.GetValuationRules() {
+		checkInstrumentRef(
+			rule.GetFromInstrument(), instrumentCodes, codeList,
+			fmt.Sprintf("valuation_rules[%d].from_instrument", i),
+			result,
+		)
+		checkInstrumentRef(
+			rule.GetToInstrument(), instrumentCodes, codeList,
+			fmt.Sprintf("valuation_rules[%d].to_instrument", i),
+			result,
+		)
+	}
+}
+
+// checkInstrumentRef validates that a referenced instrument code exists in the manifest.
+func checkInstrumentRef(
+	code string,
+	validCodes map[string]bool,
+	codeList []string,
+	path string,
+	result *ValidationResult,
+) {
+	if validCodes[code] {
+		return
+	}
+	ve := ValidationError{
+		Severity:        SeverityError,
+		Path:            path,
+		Code:            "UNDEFINED_INSTRUMENT_REFERENCE",
+		Message:         fmt.Sprintf("instrument code %q is not defined in instruments[]", code),
+		AvailableFields: codeList,
+	}
+	if suggestion := findClosestMatch(code, codeList); suggestion != "" {
+		ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+	}
+	addError(result, ve)
+}
+
+// validateImmutability checks that immutable code fields have not been changed.
+func (v *ManifestValidator) validateImmutability(
+	current *controlplanev1.Manifest,
+	previous *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	// Build maps of previous codes by index position to detect renames
+	prevInstrumentsByIdx := make(map[int]string)
+	for i, inst := range previous.GetInstruments() {
+		prevInstrumentsByIdx[i] = inst.GetCode()
+	}
+
+	prevAccountTypesByIdx := make(map[int]string)
+	for i, acct := range previous.GetAccountTypes() {
+		prevAccountTypesByIdx[i] = acct.GetCode()
+	}
+
+	// Build lookup maps for previous codes
+	prevInstruments := make(map[string]bool)
+	for _, inst := range previous.GetInstruments() {
+		prevInstruments[inst.GetCode()] = true
+	}
+	prevAccountTypes := make(map[string]bool)
+	for _, acct := range previous.GetAccountTypes() {
+		prevAccountTypes[acct.GetCode()] = true
+	}
+
+	// Check instruments: detect code changes at same index position
+	for i, inst := range current.GetInstruments() {
+		if prevCode, existed := prevInstrumentsByIdx[i]; existed {
+			if inst.GetCode() != prevCode {
+				addError(result, ValidationError{
+					Severity: SeverityError,
+					Path:     fmt.Sprintf("instruments[%d].code", i),
+					Code:     "IMMUTABLE_FIELD_CHANGED",
+					Message:  fmt.Sprintf("instrument code changed from %q to %q; codes are immutable primary keys", prevCode, inst.GetCode()),
+				})
+			}
+		}
+	}
+
+	// Check account types: detect code changes at same index position
+	for i, acct := range current.GetAccountTypes() {
+		if prevCode, existed := prevAccountTypesByIdx[i]; existed {
+			if acct.GetCode() != prevCode {
+				addError(result, ValidationError{
+					Severity: SeverityError,
+					Path:     fmt.Sprintf("account_types[%d].code", i),
+					Code:     "IMMUTABLE_FIELD_CHANGED",
+					Message:  fmt.Sprintf("account type code changed from %q to %q; codes are immutable primary keys", prevCode, acct.GetCode()),
+				})
+			}
+		}
+	}
+}
+
+// buildStarlarkPredeclared creates the predeclared dictionary for Starlark compilation.
+// This includes service modules as simple struct values and known builtins.
+func buildStarlarkPredeclared() starlark.StringDict {
+	predeclared := make(starlark.StringDict)
+
+	// Add service modules as empty structs (enough for compilation checking)
+	for _, svc := range knownServiceBindings {
+		predeclared[svc] = &starlarkModule{name: svc}
+	}
+
+	// Add common builtins
+	predeclared["input_data"] = starlark.NewDict(0)
+	predeclared["invoke_handler"] = starlark.NewBuiltin("invoke_handler",
+		func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+			return starlark.None, nil
+		})
+	predeclared["party_scope"] = starlark.NewDict(0)
+	predeclared["Decimal"] = starlark.NewBuiltin("Decimal",
+		func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+			return starlark.String("0"), nil
+		})
+
+	return predeclared
+}
+
+// starlarkModule is a simple stub module for compilation checking.
+// It accepts any attribute access, returning another module or a no-op function.
+type starlarkModule struct {
+	name string
+}
+
+func (m *starlarkModule) String() string        { return m.name }
+func (m *starlarkModule) Type() string          { return "module" }
+func (m *starlarkModule) Freeze()               {}
+func (m *starlarkModule) Truth() starlark.Bool  { return true }
+func (m *starlarkModule) Hash() (uint32, error) { return 0, ErrUnhashable }
+
+func (m *starlarkModule) Attr(name string) (starlark.Value, error) {
+	// Return a callable for any attribute access (simulates service methods)
+	return starlark.NewBuiltin(m.name+"."+name,
+		func(_ *starlark.Thread, _ *starlark.Builtin, _ starlark.Tuple, _ []starlark.Tuple) (starlark.Value, error) {
+			return starlark.NewDict(0), nil
+		}), nil
+}
+
+func (m *starlarkModule) AttrNames() []string {
+	return nil
+}
+
+// buildFieldPath extracts a dotted field path from a protovalidate Violation.
+func buildFieldPath(violation *protovalidate.Violation) string {
+	if violation.Proto == nil || violation.Proto.GetField() == nil {
+		return ""
+	}
+	elements := violation.Proto.GetField().GetElements()
+	if len(elements) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(elements))
+	for _, elem := range elements {
+		parts = append(parts, elem.GetFieldName())
+	}
+	return strings.Join(parts, ".")
+}
+
+// addError appends a validation error to the result in the appropriate list.
+func addError(result *ValidationResult, ve ValidationError) {
+	if ve.Severity == SeverityWarning {
+		result.Warnings = append(result.Warnings, ve)
+	} else {
+		result.Errors = append(result.Errors, ve)
+	}
+}
+
+// parseStarlarkError converts a Starlark error into a structured ValidationError.
+func parseStarlarkError(err error, basePath string) ValidationError {
+	ve := ValidationError{
+		Severity: SeverityError,
+		Path:     basePath,
+		Code:     "STARLARK_COMPILATION_ERROR",
+		Message:  err.Error(),
+	}
+
+	// Try to extract line/column from Starlark error format "file:line:col: message"
+	errStr := err.Error()
+	parts := strings.SplitN(errStr, ":", 4)
+	if len(parts) >= 3 {
+		var line, col int
+		if _, scanErr := fmt.Sscanf(parts[1], "%d", &line); scanErr == nil {
+			ve.Line = line
+		}
+		if _, scanErr := fmt.Sscanf(parts[2], "%d", &col); scanErr == nil {
+			ve.Column = col
+		}
+	}
+
+	// Detect syntax errors vs execution errors
+	if strings.Contains(errStr, "syntax") || strings.Contains(errStr, "got ") {
+		ve.Code = "STARLARK_SYNTAX_ERROR"
+	}
+
+	return ve
+}
+
+// extractUndeclaredReference extracts the field name from a CEL undeclared reference error.
+// Example: "undeclared reference to 'quanity'" -> "quanity"
+func extractUndeclaredReference(errMsg string) string {
+	const prefix = "undeclared reference to '"
+	idx := strings.Index(errMsg, prefix)
+	if idx < 0 {
+		return ""
+	}
+	rest := errMsg[idx+len(prefix):]
+	endIdx := strings.Index(rest, "'")
+	if endIdx < 0 {
+		return ""
+	}
+	return rest[:endIdx]
+}
+
+// extractUndefinedStarlarkName extracts the name from a Starlark "undefined: X" error.
+func extractUndefinedStarlarkName(errMsg string) string {
+	const marker = "undefined: "
+	idx := strings.Index(errMsg, marker)
+	if idx < 0 {
+		return ""
+	}
+	rest := errMsg[idx+len(marker):]
+	// The name goes until the end of the line or end of string
+	endIdx := strings.IndexAny(rest, " \n\t")
+	if endIdx < 0 {
+		return rest
+	}
+	return rest[:endIdx]
+}
+
+// findClosestMatch finds the closest string in candidates to the target using
+// Levenshtein distance. Returns empty string if no candidate is close enough.
+func findClosestMatch(target string, candidates []string) string {
+	if len(candidates) == 0 || target == "" {
+		return ""
+	}
+
+	bestMatch := ""
+	bestDist := len(target)/2 + 1 // Threshold: must be within half the target length
+
+	for _, candidate := range candidates {
+		dist := levenshteinDistance(strings.ToLower(target), strings.ToLower(candidate))
+		if dist < bestDist {
+			bestDist = dist
+			bestMatch = candidate
+		}
+	}
+
+	return bestMatch
+}
+
+// levenshteinDistance computes the edit distance between two strings.
+func levenshteinDistance(a, b string) int {
+	la := len(a)
+	lb := len(b)
+
+	if la > lb {
+		a, b = b, a
+		la, lb = lb, la
+	}
+
+	prev := make([]int, la+1)
+	curr := make([]int, la+1)
+
+	for i := 0; i <= la; i++ {
+		prev[i] = i
+	}
+
+	for j := 1; j <= lb; j++ {
+		curr[0] = j
+		for i := 1; i <= la; i++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			del := prev[i] + 1
+			ins := curr[i-1] + 1
+			sub := prev[i-1] + cost
+			curr[i] = del
+			if ins < curr[i] {
+				curr[i] = ins
+			}
+			if sub < curr[i] {
+				curr[i] = sub
+			}
+		}
+		prev, curr = curr, prev
+	}
+
+	return prev[la]
+}
+
+// mapKeys returns the sorted keys of a map[string]bool.
+func mapKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -1,0 +1,948 @@
+package validator
+
+import (
+	"strings"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// validManifest returns a fully-populated valid manifest for testing.
+func validManifest() *controlplanev1.Manifest {
+	seedData, _ := structpb.NewStruct(map[string]interface{}{
+		"default_market": "nordpool",
+	})
+	return &controlplanev1.Manifest{
+		Version: "1.0",
+		Metadata: &controlplanev1.ManifestMetadata{
+			Name:        "Test Manifest",
+			Industry:    "energy",
+			Description: "A test manifest for energy trading",
+		},
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{
+				Code: "GBP",
+				Name: "British Pound Sterling",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "GBP",
+					Precision: 2,
+				},
+			},
+			{
+				Code: "KWH",
+				Name: "Kilowatt Hour",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "kWh",
+					Precision: 3,
+				},
+			},
+		},
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{
+				Code:               "SETTLEMENT",
+				Name:               "Settlement Account",
+				NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT,
+				AllowedInstruments: []string{"GBP"},
+				Policies: &controlplanev1.AccountTypePolicies{
+					Validation: "amount > 0",
+					Bucketing:  "",
+				},
+			},
+		},
+		ValuationRules: []*controlplanev1.ValuationRule{
+			{
+				FromInstrument: "KWH",
+				ToInstrument:   "GBP",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE,
+				Source:         "nordpool_spot",
+			},
+		},
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "process_settlement",
+				Trigger: "api:/v1/settlements",
+				Script:  "def execute(ctx):\n    return {\"status\": \"ok\"}\n",
+			},
+		},
+		SeedData: seedData,
+	}
+}
+
+func TestNew(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() returned error: %v", err)
+	}
+	if v == nil {
+		t.Fatal("New() returned nil validator")
+	}
+}
+
+func TestValidateValidManifest(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	result := v.Validate(validManifest(), nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest, got errors: %v", result.Errors)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(result.Errors), result.Errors)
+	}
+}
+
+func TestValidateStructural_MissingVersion(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Version = ""
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for missing version")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "PROTO_VALIDATION" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected PROTO_VALIDATION error for missing version")
+	}
+}
+
+func TestValidateStructural_MissingMetadata(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Metadata = nil
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for missing metadata")
+	}
+}
+
+func TestValidateStructural_InvalidVersion(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Version = "v1.0" // Invalid: must match ^[0-9]+\.[0-9]+$
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for bad version format")
+	}
+}
+
+func TestValidateDuplicate_InstrumentCodes(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Instruments = append(m.Instruments, &controlplanev1.InstrumentDefinition{
+		Code: "GBP", // Duplicate
+		Name: "Pound Sterling Again",
+		Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+		Dimensions: &controlplanev1.InstrumentDimensions{
+			Unit:      "GBP",
+			Precision: 2,
+		},
+	})
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for duplicate instrument code")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DUPLICATE_CODE" && strings.Contains(e.Path, "instruments") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected DUPLICATE_CODE error for instruments")
+	}
+}
+
+func TestValidateDuplicate_AccountTypeCodes(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.AccountTypes = append(m.AccountTypes, &controlplanev1.AccountTypeDefinition{
+		Code:          "SETTLEMENT", // Duplicate
+		Name:          "Settlement Again",
+		NormalBalance: controlplanev1.NormalBalance_NORMAL_BALANCE_CREDIT,
+	})
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for duplicate account type code")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DUPLICATE_CODE" && strings.Contains(e.Path, "account_types") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected DUPLICATE_CODE error for account_types")
+	}
+}
+
+func TestValidateDuplicate_SagaNames(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Sagas = append(m.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "process_settlement", // Duplicate
+		Trigger: "api:/v1/other",
+		Script:  "def execute(ctx):\n    pass\n",
+	})
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for duplicate saga name")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "DUPLICATE_NAME" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected DUPLICATE_NAME error for sagas")
+	}
+}
+
+func TestValidateCEL_ValidExpression(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.AccountTypes[0].Policies = &controlplanev1.AccountTypePolicies{
+		Validation: "amount > 0 && quantity >= 0.0",
+	}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateCEL_UndeclaredReference_WithSuggestion(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	// "quanity" is a typo for "quantity"
+	m.AccountTypes[0].Policies = &controlplanev1.AccountTypePolicies{
+		Validation: "quanity >= 0",
+	}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for CEL undeclared reference")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "CEL_UNDECLARED_REFERENCE" {
+			found = true
+			if e.Suggestion == "" {
+				t.Error("expected suggestion for typo 'quanity'")
+			}
+			if !strings.Contains(e.Suggestion, "quantity") {
+				t.Errorf("expected suggestion to contain 'quantity', got %q", e.Suggestion)
+			}
+			if len(e.AvailableFields) == 0 {
+				t.Error("expected available_fields to be populated")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected CEL_UNDECLARED_REFERENCE error, got: %v", result.Errors)
+	}
+}
+
+func TestValidateCEL_TypeError(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	// Type error: comparing string to int
+	m.AccountTypes[0].Policies = &controlplanev1.AccountTypePolicies{
+		Validation: "instrument + 42",
+	}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for CEL type error")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "CEL_COMPILATION_ERROR" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected CEL_COMPILATION_ERROR, got: %v", result.Errors)
+	}
+}
+
+func TestValidateCEL_ExpressionTooLong(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.AccountTypes[0].Policies = &controlplanev1.AccountTypePolicies{
+		Validation: strings.Repeat("a", 4097),
+	}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for oversized CEL expression")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "CEL_EXPRESSION_TOO_LONG" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected CEL_EXPRESSION_TOO_LONG error")
+	}
+}
+
+func TestValidateCEL_BucketingExpression(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.AccountTypes[0].Policies = &controlplanev1.AccountTypePolicies{
+		Bucketing: "instrument_code + ':' + attributes.batch_id",
+	}
+
+	result := v.Validate(m, nil)
+	// CEL map access with dot notation on a map type creates a type error,
+	// but the expression should at least attempt compilation
+	// The exact behavior depends on CEL version - just verify we get a result
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestValidateStarlark_ValidScript(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Sagas[0].Script = `def execute(ctx):
+    data = input_data
+    amount = Decimal("100.00")
+    return {"status": "ok", "amount": amount}
+`
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateStarlark_SyntaxError(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Sagas[0].Script = "def execute(ctx)\n    return {}\n" // Missing colon
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for Starlark syntax error")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "STARLARK_SYNTAX_ERROR" || e.Code == "STARLARK_COMPILATION_ERROR" {
+			found = true
+			if e.Line == 0 && e.Column == 0 {
+				// Line info may not always be extractable, but let's not fail on this
+				t.Log("line/column info not extracted from syntax error (may be format-dependent)")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected STARLARK_SYNTAX_ERROR, got: %v", result.Errors)
+	}
+}
+
+func TestValidateStarlark_UndefinedName_WithSuggestion(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	// "position_keepng" is a typo for "position_keeping"
+	m.Sagas[0].Script = `def execute(ctx):
+    result = position_keepng.initiate_log(amount="100.00")
+    return result
+`
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for undefined Starlark name")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if strings.Contains(e.Message, "undefined") {
+			found = true
+			if e.Suggestion == "" {
+				t.Error("expected suggestion for typo 'position_keepng'")
+			}
+			if !strings.Contains(e.Suggestion, "position_keeping") {
+				t.Errorf("expected suggestion to contain 'position_keeping', got %q", e.Suggestion)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected undefined name error, got: %v", result.Errors)
+	}
+}
+
+func TestValidateStarlark_ServiceModuleAccess(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Sagas[0].Script = `def execute(ctx):
+    result = position_keeping.initiate_log(
+        position_id="123",
+        amount=Decimal("100.00"),
+        direction="CREDIT",
+    )
+    return {"log_id": result["log_id"]}
+`
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with service module calls, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateStarlark_ScriptTooLarge(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Sagas[0].Script = strings.Repeat("x", 65537)
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for oversized script")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "STARLARK_SCRIPT_TOO_LARGE" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected STARLARK_SCRIPT_TOO_LARGE error")
+	}
+}
+
+func TestValidateCrossRef_UndefinedInstrumentInAccountType(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.AccountTypes[0].AllowedInstruments = []string{"GBP", "NONEXISTENT"}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for undefined instrument reference")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "UNDEFINED_INSTRUMENT_REFERENCE" && strings.Contains(e.Path, "allowed_instruments") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected UNDEFINED_INSTRUMENT_REFERENCE error for allowed_instruments")
+	}
+}
+
+func TestValidateCrossRef_UndefinedInstrumentInValuationRule(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.ValuationRules[0].FromInstrument = "NONEXISTENT"
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for undefined from_instrument")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "UNDEFINED_INSTRUMENT_REFERENCE" && strings.Contains(e.Path, "from_instrument") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected UNDEFINED_INSTRUMENT_REFERENCE error for from_instrument")
+	}
+}
+
+func TestValidateCrossRef_WithSuggestion(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	// "GBQ" is close to "GBP"
+	m.AccountTypes[0].AllowedInstruments = []string{"GBQ"}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for undefined instrument reference")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "UNDEFINED_INSTRUMENT_REFERENCE" {
+			found = true
+			if e.Suggestion == "" {
+				t.Error("expected suggestion for typo 'GBQ'")
+			}
+			if !strings.Contains(e.Suggestion, "GBP") {
+				t.Errorf("expected suggestion to contain 'GBP', got %q", e.Suggestion)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected UNDEFINED_INSTRUMENT_REFERENCE error with suggestion")
+	}
+}
+
+func TestValidateImmutability_InstrumentCodeChanged(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	prev := validManifest()
+	curr := validManifest()
+	curr.Instruments[0].Code = "USD" // Changed from GBP
+
+	result := v.Validate(curr, prev)
+	if result.Valid {
+		t.Error("expected invalid manifest for changed instrument code")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "IMMUTABLE_FIELD_CHANGED" && strings.Contains(e.Path, "instruments") {
+			found = true
+			if !strings.Contains(e.Message, "GBP") || !strings.Contains(e.Message, "USD") {
+				t.Errorf("expected message to mention old and new codes, got: %s", e.Message)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected IMMUTABLE_FIELD_CHANGED error for instruments")
+	}
+}
+
+func TestValidateImmutability_AccountTypeCodeChanged(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	prev := validManifest()
+	curr := validManifest()
+	curr.AccountTypes[0].Code = "SAVINGS" // Changed from SETTLEMENT
+
+	result := v.Validate(curr, prev)
+	if result.Valid {
+		t.Error("expected invalid manifest for changed account type code")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "IMMUTABLE_FIELD_CHANGED" && strings.Contains(e.Path, "account_types") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected IMMUTABLE_FIELD_CHANGED error for account_types")
+	}
+}
+
+func TestValidateImmutability_DisplayNameChangeAllowed(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	prev := validManifest()
+	curr := validManifest()
+	curr.Instruments[0].Name = "Pounds Sterling"  // Name change OK
+	curr.AccountTypes[0].Name = "Settlement Acct" // Name change OK
+
+	result := v.Validate(curr, prev)
+	if !result.Valid {
+		t.Errorf("expected valid manifest when only display names changed, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateImmutability_NoChanges(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	prev := validManifest()
+	curr := validManifest()
+
+	result := v.Validate(curr, prev)
+	if !result.Valid {
+		t.Errorf("expected valid manifest when nothing changed, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateImmutability_NilPrevious(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	result := v.Validate(validManifest(), nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with nil previous, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMinimalManifest(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := &controlplanev1.Manifest{
+		Version: "1.0",
+		Metadata: &controlplanev1.ManifestMetadata{
+			Name: "Minimal",
+		},
+	}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid minimal manifest, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateMultipleErrors(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	// Multiple issues at once
+	m.AccountTypes[0].AllowedInstruments = []string{"NONEXISTENT"}
+	m.AccountTypes[0].Policies = &controlplanev1.AccountTypePolicies{
+		Validation: "undeclared_var > 0",
+	}
+	m.ValuationRules[0].FromInstrument = "MISSING"
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest with multiple errors")
+	}
+	if len(result.Errors) < 3 {
+		t.Errorf("expected at least 3 errors, got %d: %v", len(result.Errors), result.Errors)
+	}
+}
+
+func TestLevenshteinDistance(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"a", "", 1},
+		{"", "a", 1},
+		{"kitten", "sitting", 3},
+		{"quantity", "quanity", 1},
+		{"position_keeping", "position_keepng", 1},
+		{"GBP", "GBQ", 1},
+		{"abc", "xyz", 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.a+"->"+tt.b, func(t *testing.T) {
+			got := levenshteinDistance(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("levenshteinDistance(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindClosestMatch(t *testing.T) {
+	candidates := []string{"quantity", "instrument", "bucket_id", "as_of", "amount"}
+
+	tests := []struct {
+		target string
+		want   string
+	}{
+		{"quanity", "quantity"},
+		{"amout", "amount"},
+		{"instrumnt", "instrument"},
+		{"completely_different_very_long_name", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			got := findClosestMatch(tt.target, candidates)
+			if got != tt.want {
+				t.Errorf("findClosestMatch(%q) = %q, want %q", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractUndeclaredReference(t *testing.T) {
+	tests := []struct {
+		errMsg string
+		want   string
+	}{
+		{"ERROR: <input>:1:1: undeclared reference to 'quanity'", "quanity"},
+		{"no undeclared reference here", ""},
+		{"undeclared reference to 'foo'", "foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.errMsg, func(t *testing.T) {
+			got := extractUndeclaredReference(tt.errMsg)
+			if got != tt.want {
+				t.Errorf("extractUndeclaredReference(%q) = %q, want %q", tt.errMsg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractUndefinedStarlarkName(t *testing.T) {
+	tests := []struct {
+		errMsg string
+		want   string
+	}{
+		{"script.star:2:14: undefined: position_keepng", "position_keepng"},
+		{"no undefined here", ""},
+		{"undefined: foo", "foo"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.errMsg, func(t *testing.T) {
+			got := extractUndefinedStarlarkName(tt.errMsg)
+			if got != tt.want {
+				t.Errorf("extractUndefinedStarlarkName(%q) = %q, want %q", tt.errMsg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidationErrorInterface(t *testing.T) {
+	ve := ValidationError{
+		Severity:   SeverityError,
+		Path:       "instruments[0].code",
+		Code:       "TEST",
+		Message:    "test message",
+		Suggestion: "try something else",
+	}
+
+	errStr := ve.Error()
+	if !strings.Contains(errStr, "instruments[0].code") {
+		t.Errorf("Error() should contain path, got: %s", errStr)
+	}
+	if !strings.Contains(errStr, "test message") {
+		t.Errorf("Error() should contain message, got: %s", errStr)
+	}
+	if !strings.Contains(errStr, "try something else") {
+		t.Errorf("Error() should contain suggestion, got: %s", errStr)
+	}
+}
+
+func TestValidateCrossRef_ValuationRuleToInstrument(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.ValuationRules[0].ToInstrument = "NONEXISTENT"
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for undefined to_instrument")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "UNDEFINED_INSTRUMENT_REFERENCE" && strings.Contains(e.Path, "to_instrument") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected UNDEFINED_INSTRUMENT_REFERENCE error for to_instrument")
+	}
+}
+
+func TestValidateCEL_EmptyExpression(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.AccountTypes[0].Policies = &controlplanev1.AccountTypePolicies{
+		Validation: "", // Empty is allowed
+	}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with empty CEL expression, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateCEL_NilPolicies(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.AccountTypes[0].Policies = nil
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with nil policies, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidateStarlark_EmptyScript(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.Sagas[0].Script = "" // Empty is skipped (proto validation would catch this)
+
+	result := v.Validate(m, nil)
+	// Proto validation should catch empty script requirement
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+}
+
+func TestValidateImmutability_AddNewInstrument(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	prev := validManifest()
+	curr := validManifest()
+	curr.Instruments = append(curr.Instruments, &controlplanev1.InstrumentDefinition{
+		Code: "EUR",
+		Name: "Euro",
+		Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+		Dimensions: &controlplanev1.InstrumentDimensions{
+			Unit:      "EUR",
+			Precision: 2,
+		},
+	})
+
+	result := v.Validate(curr, prev)
+	if !result.Valid {
+		t.Errorf("expected valid manifest when adding new instrument, got errors: %v", result.Errors)
+	}
+}


### PR DESCRIPTION
## Summary

- Implement `ManifestValidator` in `services/control-plane/internal/validator/` that validates Meridian tenant manifests before activation
- Performs 6 layers of validation: structural (protovalidate), duplicate detection, CEL type-checking, Starlark compilation, cross-reference validation, and immutability checks
- Returns AI-friendly structured errors with location paths, error codes, "Did you mean?" suggestions via Levenshtein distance, and available field lists

## Changes Made

### `services/control-plane/internal/validator/manifest_validator.go`
- **Structural validation**: Delegates to `protovalidate` for protobuf constraint checking (required fields, enum values, regex patterns)
- **Duplicate detection**: Catches duplicate instrument codes, account type codes, and saga names
- **CEL validation**: Type-checks `account_types[].policies.validation` and `bucketing` expressions against Balance/bucketing environments. Uses `DynType` for numeric fields to accept both `amount > 0` and `amount > 0.0`
- **Starlark compilation**: Parses and compiles each saga script with stub service modules (`position_keeping`, `financial_accounting`, etc.) to catch syntax errors and undefined references
- **Cross-reference validation**: Verifies `allowed_instruments` and `valuation_rules` reference instrument codes that actually exist in the manifest
- **Immutability checks**: Detects when code fields (instrument codes, account type codes) are changed between manifest versions, as these are immutable primary keys
- **AI feedback**: On typos, suggests closest match using Levenshtein distance (e.g., `"quanity"` -> `"quantity"`, `"position_keepng"` -> `"position_keeping"`)

### `services/control-plane/internal/validator/manifest_validator_test.go`
- 36 test cases covering all 6 validation layers
- Tests for happy paths, error paths, suggestions, edge cases (nil/empty inputs)
- Unit tests for helper functions (Levenshtein distance, string extraction)

## Technical Details

- Reuses existing patterns from `shared/pkg/valuation/policy_runtime.go` (CEL), `shared/pkg/saga/runtime.go` (Starlark), and `services/reference-data/cel/compiler.go`
- `starlarkModule` type implements `starlark.HasAttrs` to act as a permissive service module stub during compilation
- Uses `starlark.ExecFileOptions` (non-deprecated API) for Starlark compilation
- All lint checks pass (gofumpt, golangci-lint)

## Testing

```bash
go test ./services/control-plane/internal/validator/ -v -count=1
# 36 tests, all passing
```

## Task Master

| TM Task | Description |
|---------|-------------|
| control-plane.2 | Manifest Validator with CEL and Starlark compilation |
| control-plane.2.1 | Structural JSON Schema validation |
| control-plane.2.2 | CEL expression validator for account type policies |
| control-plane.2.3 | Starlark script compilation validation |
| control-plane.2.4 | AI-friendly error formatting with suggestions |
| control-plane.2.5 | Cross-reference validation |
| control-plane.2.6 | Immutability validation |