### PR TITLE
feat: Implement ApplyManifest Differ with last-applied comparison

### DIFF
--- a/services/control-plane/internal/differ/drift.go
+++ b/services/control-plane/internal/differ/drift.go
@@ -1,0 +1,24 @@
+package differ
+
+import (
+	"context"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+)
+
+// DriftDetector compares the current database state against a manifest
+// to surface manual changes made outside the manifest apply workflow.
+type DriftDetector interface {
+	// DetectDrift compares the given manifest against current DB state
+	// and returns warnings for any discrepancies found.
+	DetectDrift(ctx context.Context, lastApplied *controlplanev1.Manifest) ([]DriftWarning, error)
+}
+
+// NoOpDriftDetector returns no drift warnings. Used when drift detection
+// is not configured or during testing.
+type NoOpDriftDetector struct{}
+
+// DetectDrift returns no warnings (drift detection disabled).
+func (n *NoOpDriftDetector) DetectDrift(_ context.Context, _ *controlplanev1.Manifest) ([]DriftWarning, error) {
+	return nil, nil
+}

--- a/services/control-plane/internal/differ/manifest_differ.go
+++ b/services/control-plane/internal/differ/manifest_differ.go
@@ -1,0 +1,406 @@
+package differ
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// ManifestDiffer compares a last-applied manifest against a new manifest
+// to produce a plan of CREATE/UPDATE/DELETE/NO_CHANGE actions.
+//
+// It follows Kubernetes apply semantics:
+//   - Codes are immutable primary keys (like metadata.name in k8s)
+//   - Resources present in new but not in last-applied -> CREATE
+//   - Resources present in both with field changes -> UPDATE
+//   - Resources present in last-applied but not in new -> DELETE (with safety checks)
+//   - Resources identical in both -> NO_CHANGE
+type ManifestDiffer struct {
+	safety SafetyChecker
+	drift  DriftDetector
+}
+
+// New creates a ManifestDiffer with the given safety checker and drift detector.
+func New(safety SafetyChecker, drift DriftDetector) *ManifestDiffer {
+	if safety == nil {
+		safety = &NoOpSafetyChecker{}
+	}
+	if drift == nil {
+		drift = &NoOpDriftDetector{}
+	}
+	return &ManifestDiffer{
+		safety: safety,
+		drift:  drift,
+	}
+}
+
+// Diff compares lastApplied against newManifest and returns a plan.
+// If lastApplied is nil, all resources in newManifest are treated as CREATE.
+func (d *ManifestDiffer) Diff(ctx context.Context, lastApplied, newManifest *controlplanev1.Manifest) (*DiffPlan, error) {
+	if newManifest == nil {
+		return nil, ErrNilManifest
+	}
+
+	plan := &DiffPlan{}
+
+	// Diff each resource type independently
+	d.diffInstruments(lastApplied, newManifest, plan)
+	d.diffAccountTypes(lastApplied, newManifest, plan)
+	d.diffValuationRules(lastApplied, newManifest, plan)
+	d.diffSagas(lastApplied, newManifest, plan)
+
+	// Run safety checks on all DELETE actions
+	if err := d.runSafetyChecks(ctx, plan); err != nil {
+		return nil, fmt.Errorf("safety check failed: %w", err)
+	}
+
+	// Flag breaking changes
+	for i := range plan.Actions {
+		if plan.Actions[i].Action == ActionDelete {
+			plan.Actions[i].Breaking = true
+			plan.HasBreakingChanges = true
+		}
+	}
+
+	// Detect drift if we have a last-applied manifest
+	if lastApplied != nil {
+		warnings, err := d.drift.DetectDrift(ctx, lastApplied)
+		if err != nil {
+			return nil, fmt.Errorf("drift detection failed: %w", err)
+		}
+		plan.DriftWarnings = warnings
+	}
+
+	// Sort actions for deterministic output
+	sort.Slice(plan.Actions, func(i, j int) bool {
+		if plan.Actions[i].ResourceType != plan.Actions[j].ResourceType {
+			return plan.Actions[i].ResourceType < plan.Actions[j].ResourceType
+		}
+		return plan.Actions[i].ResourceCode < plan.Actions[j].ResourceCode
+	})
+
+	return plan, nil
+}
+
+func (d *ManifestDiffer) diffInstruments(lastApplied, newManifest *controlplanev1.Manifest, plan *DiffPlan) {
+	oldMap := instrumentMap(getInstruments(lastApplied))
+	newMap := instrumentMap(newManifest.GetInstruments())
+
+	for code, updated := range newMap {
+		prev, exists := oldMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstrument,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create instrument %s (%s)", code, updated.GetName()),
+			})
+			continue
+		}
+		if !proto.Equal(prev, updated) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstrument,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeInstrumentChanges(code, prev, updated),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstrument,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Instrument %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range oldMap {
+		if _, exists := newMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceInstrument,
+				ResourceCode: code,
+				Action:       ActionDelete,
+				Description:  fmt.Sprintf("Delete instrument %s", code),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffAccountTypes(lastApplied, newManifest *controlplanev1.Manifest, plan *DiffPlan) {
+	oldMap := accountTypeMap(getAccountTypes(lastApplied))
+	newMap := accountTypeMap(newManifest.GetAccountTypes())
+
+	for code, updated := range newMap {
+		prev, exists := oldMap[code]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceAccountType,
+				ResourceCode: code,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create account type %s (%s)", code, updated.GetName()),
+			})
+			continue
+		}
+		if !proto.Equal(prev, updated) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceAccountType,
+				ResourceCode: code,
+				Action:       ActionUpdate,
+				Description:  describeAccountTypeChanges(code, prev, updated),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceAccountType,
+				ResourceCode: code,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Account type %s unchanged", code),
+			})
+		}
+	}
+
+	for code := range oldMap {
+		if _, exists := newMap[code]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceAccountType,
+				ResourceCode: code,
+				Action:       ActionDelete,
+				Description:  fmt.Sprintf("Delete account type %s", code),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffValuationRules(lastApplied, newManifest *controlplanev1.Manifest, plan *DiffPlan) {
+	oldMap := valuationRuleMap(getValuationRules(lastApplied))
+	newMap := valuationRuleMap(newManifest.GetValuationRules())
+
+	for key, updated := range newMap {
+		prev, exists := oldMap[key]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceValuationRule,
+				ResourceCode: key,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create valuation rule %s", key),
+			})
+			continue
+		}
+		if !proto.Equal(prev, updated) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceValuationRule,
+				ResourceCode: key,
+				Action:       ActionUpdate,
+				Description:  fmt.Sprintf("Update valuation rule %s", key),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceValuationRule,
+				ResourceCode: key,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Valuation rule %s unchanged", key),
+			})
+		}
+	}
+
+	for key := range oldMap {
+		if _, exists := newMap[key]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceValuationRule,
+				ResourceCode: key,
+				Action:       ActionDelete,
+				Description:  fmt.Sprintf("Delete valuation rule %s", key),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) diffSagas(lastApplied, newManifest *controlplanev1.Manifest, plan *DiffPlan) {
+	oldMap := sagaMap(getSagas(lastApplied))
+	newMap := sagaMap(newManifest.GetSagas())
+
+	for name, updated := range newMap {
+		prev, exists := oldMap[name]
+		if !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceSaga,
+				ResourceCode: name,
+				Action:       ActionCreate,
+				Description:  fmt.Sprintf("Create saga %s (trigger: %s)", name, updated.GetTrigger()),
+			})
+			continue
+		}
+		if !proto.Equal(prev, updated) {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceSaga,
+				ResourceCode: name,
+				Action:       ActionUpdate,
+				Description:  describeSagaChanges(name, prev, updated),
+			})
+		} else {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceSaga,
+				ResourceCode: name,
+				Action:       ActionNoChange,
+				Description:  fmt.Sprintf("Saga %s unchanged", name),
+			})
+		}
+	}
+
+	for name := range oldMap {
+		if _, exists := newMap[name]; !exists {
+			plan.Actions = append(plan.Actions, PlannedAction{
+				ResourceType: ResourceSaga,
+				ResourceCode: name,
+				Action:       ActionDelete,
+				Description:  fmt.Sprintf("Delete saga %s", name),
+			})
+		}
+	}
+}
+
+func (d *ManifestDiffer) runSafetyChecks(ctx context.Context, plan *DiffPlan) error {
+	for _, action := range plan.Actions {
+		if action.Action != ActionDelete {
+			continue
+		}
+		var blocked *BlockedDeletion
+		var err error
+
+		switch action.ResourceType {
+		case ResourceAccountType:
+			blocked, err = d.safety.CheckAccountTypeDeletion(ctx, action.ResourceCode)
+		case ResourceInstrument:
+			blocked, err = d.safety.CheckInstrumentDeletion(ctx, action.ResourceCode)
+		case ResourceSaga:
+			blocked, err = d.safety.CheckSagaDeletion(ctx, action.ResourceCode)
+		case ResourceValuationRule:
+			// Valuation rules have no downstream dependencies to check
+		}
+
+		if err != nil {
+			return fmt.Errorf("safety check for %s %s: %w", action.ResourceType, action.ResourceCode, err)
+		}
+		if blocked != nil {
+			plan.BlockedDeletions = append(plan.BlockedDeletions, *blocked)
+		}
+	}
+	return nil
+}
+
+// Helper functions to safely extract slices from possibly-nil manifests.
+
+func getInstruments(m *controlplanev1.Manifest) []*controlplanev1.InstrumentDefinition {
+	if m == nil {
+		return nil
+	}
+	return m.GetInstruments()
+}
+
+func getAccountTypes(m *controlplanev1.Manifest) []*controlplanev1.AccountTypeDefinition {
+	if m == nil {
+		return nil
+	}
+	return m.GetAccountTypes()
+}
+
+func getValuationRules(m *controlplanev1.Manifest) []*controlplanev1.ValuationRule {
+	if m == nil {
+		return nil
+	}
+	return m.GetValuationRules()
+}
+
+func getSagas(m *controlplanev1.Manifest) []*controlplanev1.SagaDefinition {
+	if m == nil {
+		return nil
+	}
+	return m.GetSagas()
+}
+
+// Map-building helpers keyed by stable identifiers.
+
+func instrumentMap(instruments []*controlplanev1.InstrumentDefinition) map[string]*controlplanev1.InstrumentDefinition {
+	m := make(map[string]*controlplanev1.InstrumentDefinition, len(instruments))
+	for _, inst := range instruments {
+		m[inst.GetCode()] = inst
+	}
+	return m
+}
+
+func accountTypeMap(types []*controlplanev1.AccountTypeDefinition) map[string]*controlplanev1.AccountTypeDefinition {
+	m := make(map[string]*controlplanev1.AccountTypeDefinition, len(types))
+	for _, at := range types {
+		m[at.GetCode()] = at
+	}
+	return m
+}
+
+func valuationRuleMap(rules []*controlplanev1.ValuationRule) map[string]*controlplanev1.ValuationRule {
+	m := make(map[string]*controlplanev1.ValuationRule, len(rules))
+	for _, r := range rules {
+		m[valRuleKey(r.GetFromInstrument(), r.GetToInstrument())] = r
+	}
+	return m
+}
+
+func sagaMap(sagas []*controlplanev1.SagaDefinition) map[string]*controlplanev1.SagaDefinition {
+	m := make(map[string]*controlplanev1.SagaDefinition, len(sagas))
+	for _, s := range sagas {
+		m[s.GetName()] = s
+	}
+	return m
+}
+
+// Change description helpers.
+
+func describeInstrumentChanges(code string, prev, updated *controlplanev1.InstrumentDefinition) string {
+	var changes []string
+	if prev.GetName() != updated.GetName() {
+		changes = append(changes, fmt.Sprintf("name: %q -> %q", prev.GetName(), updated.GetName()))
+	}
+	if prev.GetType() != updated.GetType() {
+		changes = append(changes, fmt.Sprintf("type: %s -> %s", prev.GetType(), updated.GetType()))
+	}
+	if !proto.Equal(prev.GetDimensions(), updated.GetDimensions()) {
+		changes = append(changes, "dimensions changed")
+	}
+	if len(changes) == 0 {
+		return fmt.Sprintf("Update instrument %s", code)
+	}
+	return fmt.Sprintf("Update instrument %s (%s)", code, strings.Join(changes, "; "))
+}
+
+func describeAccountTypeChanges(code string, prev, updated *controlplanev1.AccountTypeDefinition) string {
+	var changes []string
+	if prev.GetName() != updated.GetName() {
+		changes = append(changes, fmt.Sprintf("name: %q -> %q", prev.GetName(), updated.GetName()))
+	}
+	if prev.GetNormalBalance() != updated.GetNormalBalance() {
+		changes = append(changes, fmt.Sprintf("normal_balance: %s -> %s", prev.GetNormalBalance(), updated.GetNormalBalance()))
+	}
+	if !proto.Equal(prev.GetPolicies(), updated.GetPolicies()) {
+		changes = append(changes, "policies changed")
+	}
+	if len(changes) == 0 {
+		return fmt.Sprintf("Update account type %s", code)
+	}
+	return fmt.Sprintf("Update account type %s (%s)", code, strings.Join(changes, "; "))
+}
+
+func describeSagaChanges(name string, prev, updated *controlplanev1.SagaDefinition) string {
+	var changes []string
+	if prev.GetTrigger() != updated.GetTrigger() {
+		changes = append(changes, fmt.Sprintf("trigger: %q -> %q", prev.GetTrigger(), updated.GetTrigger()))
+	}
+	if prev.GetScript() != updated.GetScript() {
+		changes = append(changes, "script changed")
+	}
+	if len(changes) == 0 {
+		return fmt.Sprintf("Update saga %s", name)
+	}
+	return fmt.Sprintf("Update saga %s (%s)", name, strings.Join(changes, "; "))
+}

--- a/services/control-plane/internal/differ/manifest_differ_test.go
+++ b/services/control-plane/internal/differ/manifest_differ_test.go
@@ -1,0 +1,706 @@
+package differ
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testManifest returns a fully populated manifest for testing.
+func testManifest() *controlplanev1.Manifest {
+	return &controlplanev1.Manifest{
+		Version: "1.0",
+		Metadata: &controlplanev1.ManifestMetadata{
+			Name:     "Test Manifest",
+			Industry: "energy",
+		},
+		Instruments: []*controlplanev1.InstrumentDefinition{
+			{
+				Code: "GBP",
+				Name: "British Pound Sterling",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "GBP",
+					Precision: 2,
+				},
+			},
+			{
+				Code: "KWH",
+				Name: "Kilowatt Hour",
+				Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_COMMODITY,
+				Dimensions: &controlplanev1.InstrumentDimensions{
+					Unit:      "kWh",
+					Precision: 3,
+				},
+			},
+		},
+		AccountTypes: []*controlplanev1.AccountTypeDefinition{
+			{
+				Code:               "SETTLEMENT",
+				Name:               "Settlement Account",
+				NormalBalance:      controlplanev1.NormalBalance_NORMAL_BALANCE_DEBIT,
+				AllowedInstruments: []string{"GBP"},
+				Policies: &controlplanev1.AccountTypePolicies{
+					Validation: "amount > 0",
+				},
+			},
+		},
+		ValuationRules: []*controlplanev1.ValuationRule{
+			{
+				FromInstrument: "KWH",
+				ToInstrument:   "GBP",
+				Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE,
+				Source:         "nordpool_spot",
+			},
+		},
+		Sagas: []*controlplanev1.SagaDefinition{
+			{
+				Name:    "process_settlement",
+				Trigger: "api:/v1/settlements",
+				Script:  "def execute(ctx):\n    return {\"status\": \"ok\"}\n",
+			},
+		},
+	}
+}
+
+func TestDiff_NilLastApplied_AllCreates(t *testing.T) {
+	d := New(nil, nil)
+	manifest := testManifest()
+
+	plan, err := d.Diff(context.Background(), nil, manifest)
+	require.NoError(t, err)
+
+	creates := filterActions(plan.Actions, ActionCreate)
+	assert.Len(t, creates, 5, "expected 5 creates: 2 instruments + 1 account type + 1 valuation rule + 1 saga")
+
+	noChanges := filterActions(plan.Actions, ActionNoChange)
+	assert.Empty(t, noChanges)
+
+	deletes := filterActions(plan.Actions, ActionDelete)
+	assert.Empty(t, deletes)
+}
+
+func TestDiff_NilNewManifest_ReturnsError(t *testing.T) {
+	d := New(nil, nil)
+	_, err := d.Diff(context.Background(), testManifest(), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "new manifest cannot be nil")
+}
+
+func TestDiff_IdenticalManifests_AllNoChange(t *testing.T) {
+	d := New(nil, nil)
+	manifest := testManifest()
+
+	plan, err := d.Diff(context.Background(), manifest, manifest)
+	require.NoError(t, err)
+
+	noChanges := filterActions(plan.Actions, ActionNoChange)
+	assert.Len(t, noChanges, 5, "expected all 5 resources as NO_CHANGE")
+
+	creates := filterActions(plan.Actions, ActionCreate)
+	assert.Empty(t, creates)
+
+	assert.False(t, plan.HasBreakingChanges)
+}
+
+func TestDiff_AddedInstrument_Create(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Instruments = append(newManifest.Instruments, &controlplanev1.InstrumentDefinition{
+		Code: "EUR",
+		Name: "Euro",
+		Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+		Dimensions: &controlplanev1.InstrumentDimensions{
+			Unit:      "EUR",
+			Precision: 2,
+		},
+	})
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActions(plan.Actions, ActionCreate)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "EUR", creates[0].ResourceCode)
+	assert.Equal(t, ResourceInstrument, creates[0].ResourceType)
+}
+
+func TestDiff_RemovedInstrument_Delete(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Instruments = newManifest.Instruments[:1] // keep only GBP, remove KWH
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	deletes := filterActions(plan.Actions, ActionDelete)
+	assert.Len(t, deletes, 1)
+	assert.Equal(t, "KWH", deletes[0].ResourceCode)
+	assert.True(t, deletes[0].Breaking)
+	assert.True(t, plan.HasBreakingChanges)
+}
+
+func TestDiff_ModifiedInstrument_Update(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Instruments[0].Name = "GBP (Updated)"
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActions(plan.Actions, ActionUpdate)
+	assert.Len(t, updates, 1)
+	assert.Equal(t, "GBP", updates[0].ResourceCode)
+	assert.Contains(t, updates[0].Description, "name:")
+}
+
+func TestDiff_ModifiedInstrumentType_DescribesChange(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Instruments[1].Type = controlplanev1.InstrumentType_INSTRUMENT_TYPE_VOUCHER
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActions(plan.Actions, ActionUpdate)
+	assert.Len(t, updates, 1)
+	assert.Equal(t, "KWH", updates[0].ResourceCode)
+	assert.Contains(t, updates[0].Description, "type:")
+}
+
+func TestDiff_ModifiedAccountType_Update(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.AccountTypes[0].Policies.Validation = "amount > 0 && amount < 1000000"
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceAccountType)
+	assert.Len(t, updates, 1)
+	assert.Equal(t, "SETTLEMENT", updates[0].ResourceCode)
+	assert.Contains(t, updates[0].Description, "policies changed")
+}
+
+func TestDiff_ModifiedAccountTypeName_DescribesChange(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.AccountTypes[0].Name = "Updated Settlement Account"
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceAccountType)
+	assert.Len(t, updates, 1)
+	assert.Contains(t, updates[0].Description, "name:")
+}
+
+func TestDiff_ModifiedSaga_Update(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Sagas[0].Script = "def execute(ctx):\n    return {\"status\": \"updated\"}\n"
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceSaga)
+	assert.Len(t, updates, 1)
+	assert.Equal(t, "process_settlement", updates[0].ResourceCode)
+	assert.Contains(t, updates[0].Description, "script changed")
+}
+
+func TestDiff_ModifiedSagaTrigger_DescribesChange(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Sagas[0].Trigger = "api:/v2/settlements"
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceSaga)
+	assert.Len(t, updates, 1)
+	assert.Contains(t, updates[0].Description, "trigger:")
+}
+
+func TestDiff_AddedSaga_Create(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Sagas = append(newManifest.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "daily_reconciliation",
+		Trigger: "scheduled:daily_at_0200",
+		Script:  "def execute(ctx):\n    return {}\n",
+	})
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceSaga)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "daily_reconciliation", creates[0].ResourceCode)
+	assert.Contains(t, creates[0].Description, "trigger: scheduled:")
+}
+
+func TestDiff_RemovedSaga_Delete(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Sagas = nil
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceSaga)
+	assert.Len(t, deletes, 1)
+	assert.Equal(t, "process_settlement", deletes[0].ResourceCode)
+	assert.True(t, deletes[0].Breaking)
+}
+
+func TestDiff_RemovedAccountType_Delete(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.AccountTypes = nil
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceAccountType)
+	assert.Len(t, deletes, 1)
+	assert.Equal(t, "SETTLEMENT", deletes[0].ResourceCode)
+}
+
+func TestDiff_ValuationRuleAdded(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.ValuationRules = append(newManifest.ValuationRules, &controlplanev1.ValuationRule{
+		FromInstrument: "EUR",
+		ToInstrument:   "GBP",
+		Method:         controlplanev1.ValuationMethod_VALUATION_METHOD_SPOT_RATE,
+		Source:         "ecb_fx_daily",
+	})
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActionsByResource(plan.Actions, ActionCreate, ResourceValuationRule)
+	assert.Len(t, creates, 1)
+	assert.Equal(t, "EUR->GBP", creates[0].ResourceCode)
+}
+
+func TestDiff_ValuationRuleModified(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.ValuationRules[0].Method = controlplanev1.ValuationMethod_VALUATION_METHOD_FIXED
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	updates := filterActionsByResource(plan.Actions, ActionUpdate, ResourceValuationRule)
+	assert.Len(t, updates, 1)
+	assert.Equal(t, "KWH->GBP", updates[0].ResourceCode)
+}
+
+func TestDiff_ValuationRuleRemoved(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.ValuationRules = nil
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	deletes := filterActionsByResource(plan.Actions, ActionDelete, ResourceValuationRule)
+	assert.Len(t, deletes, 1)
+	assert.Equal(t, "KWH->GBP", deletes[0].ResourceCode)
+}
+
+func TestDiff_MultipleChanges_MixedActions(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	// Remove KWH instrument
+	newManifest.Instruments = newManifest.Instruments[:1]
+	// Add EUR instrument
+	newManifest.Instruments = append(newManifest.Instruments, &controlplanev1.InstrumentDefinition{
+		Code: "EUR",
+		Name: "Euro",
+		Type: controlplanev1.InstrumentType_INSTRUMENT_TYPE_FIAT,
+		Dimensions: &controlplanev1.InstrumentDimensions{
+			Unit:      "EUR",
+			Precision: 2,
+		},
+	})
+	// Modify settlement account type
+	newManifest.AccountTypes[0].Name = "Updated Settlement"
+	// Add new saga
+	newManifest.Sagas = append(newManifest.Sagas, &controlplanev1.SagaDefinition{
+		Name:    "new_workflow",
+		Trigger: "api:/v1/workflows",
+		Script:  "def execute(ctx):\n    pass\n",
+	})
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	creates := filterActions(plan.Actions, ActionCreate)
+	updates := filterActions(plan.Actions, ActionUpdate)
+	deletes := filterActions(plan.Actions, ActionDelete)
+	noChanges := filterActions(plan.Actions, ActionNoChange)
+
+	assert.Len(t, creates, 2, "EUR instrument + new_workflow saga")
+	assert.Len(t, updates, 1, "modified SETTLEMENT account type")
+	assert.Len(t, deletes, 1, "removed KWH instrument")
+	assert.Len(t, noChanges, 3, "GBP unchanged, valuation rule unchanged, process_settlement saga unchanged")
+
+	assert.True(t, plan.HasBreakingChanges, "should be breaking due to DELETE")
+}
+
+func TestDiff_EmptyManifests_NoActions(t *testing.T) {
+	d := New(nil, nil)
+	empty := &controlplanev1.Manifest{
+		Version:  "1.0",
+		Metadata: &controlplanev1.ManifestMetadata{Name: "Empty"},
+	}
+
+	plan, err := d.Diff(context.Background(), empty, empty)
+	require.NoError(t, err)
+	assert.Empty(t, plan.Actions)
+	assert.False(t, plan.HasBreakingChanges)
+}
+
+func TestDiff_SafetyChecker_BlocksDeletion(t *testing.T) {
+	checker := &mockSafetyChecker{
+		accountBlocked: map[string]*BlockedDeletion{
+			"SETTLEMENT": {
+				ResourceType: ResourceAccountType,
+				ResourceCode: "SETTLEMENT",
+				Reason:       "1,234 accounts with non-zero balances exist",
+			},
+		},
+	}
+	d := New(checker, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.AccountTypes = nil
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	assert.True(t, plan.HasBlockedDeletions())
+	assert.Len(t, plan.BlockedDeletions, 1)
+	assert.Equal(t, "SETTLEMENT", plan.BlockedDeletions[0].ResourceCode)
+	assert.Contains(t, plan.BlockedDeletions[0].Reason, "1,234 accounts")
+}
+
+func TestDiff_SafetyChecker_BlocksInstrumentDeletion(t *testing.T) {
+	checker := &mockSafetyChecker{
+		instrumentBlocked: map[string]*BlockedDeletion{
+			"KWH": {
+				ResourceType: ResourceInstrument,
+				ResourceCode: "KWH",
+				Reason:       "referenced by 3 active valuation rules",
+			},
+		},
+	}
+	d := New(checker, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Instruments = newManifest.Instruments[:1] // remove KWH
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	assert.True(t, plan.HasBlockedDeletions())
+	assert.Len(t, plan.BlockedDeletions, 1)
+	assert.Contains(t, plan.BlockedDeletions[0].Reason, "3 active valuation rules")
+}
+
+func TestDiff_SafetyChecker_BlocksSagaDeletion(t *testing.T) {
+	checker := &mockSafetyChecker{
+		sagaBlocked: map[string]*BlockedDeletion{
+			"process_settlement": {
+				ResourceType: ResourceSaga,
+				ResourceCode: "process_settlement",
+				Reason:       "5 pending/running saga instances",
+			},
+		},
+	}
+	d := New(checker, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Sagas = nil
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	assert.True(t, plan.HasBlockedDeletions())
+	assert.Len(t, plan.BlockedDeletions, 1)
+	assert.Contains(t, plan.BlockedDeletions[0].Reason, "5 pending/running")
+}
+
+func TestDiff_SafetyChecker_AllowsDeletionWhenNothingBlocked(t *testing.T) {
+	checker := &mockSafetyChecker{} // no blocked resources
+	d := New(checker, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.AccountTypes = nil
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	assert.False(t, plan.HasBlockedDeletions())
+	assert.Empty(t, plan.BlockedDeletions)
+}
+
+func TestDiff_SafetyChecker_ErrorPropagates(t *testing.T) {
+	checker := &mockSafetyChecker{
+		err: fmt.Errorf("connection refused"),
+	}
+	d := New(checker, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.AccountTypes = nil
+
+	_, err := d.Diff(context.Background(), oldManifest, newManifest)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+func TestDiff_DriftDetector_WarningsIncluded(t *testing.T) {
+	detector := &mockDriftDetector{
+		warnings: []DriftWarning{
+			{
+				ResourceType: ResourceInstrument,
+				ResourceCode: "GBP",
+				Description:  "precision manually changed from 2 to 4 in database",
+			},
+		},
+	}
+	d := New(nil, detector)
+	manifest := testManifest()
+
+	plan, err := d.Diff(context.Background(), manifest, manifest)
+	require.NoError(t, err)
+
+	assert.Len(t, plan.DriftWarnings, 1)
+	assert.Equal(t, "GBP", plan.DriftWarnings[0].ResourceCode)
+	assert.Contains(t, plan.DriftWarnings[0].Description, "precision manually changed")
+}
+
+func TestDiff_DriftDetector_NotCalledWhenNoLastApplied(t *testing.T) {
+	detector := &mockDriftDetector{
+		called: false,
+	}
+	d := New(nil, detector)
+
+	plan, err := d.Diff(context.Background(), nil, testManifest())
+	require.NoError(t, err)
+
+	assert.False(t, detector.called, "drift detector should not be called when no last-applied manifest")
+	assert.Empty(t, plan.DriftWarnings)
+}
+
+func TestDiff_DriftDetector_ErrorPropagates(t *testing.T) {
+	detector := &mockDriftDetector{
+		err: fmt.Errorf("database unreachable"),
+	}
+	d := New(nil, detector)
+	manifest := testManifest()
+
+	_, err := d.Diff(context.Background(), manifest, manifest)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "database unreachable")
+}
+
+func TestDiff_DeterministicOrdering(t *testing.T) {
+	d := New(nil, nil)
+
+	plan, err := d.Diff(context.Background(), nil, testManifest())
+	require.NoError(t, err)
+
+	// Verify actions are sorted by resource type then code
+	for i := 1; i < len(plan.Actions); i++ {
+		prev := plan.Actions[i-1]
+		curr := plan.Actions[i]
+		if prev.ResourceType == curr.ResourceType {
+			assert.LessOrEqual(t, prev.ResourceCode, curr.ResourceCode,
+				"actions within same resource type should be sorted by code")
+		}
+	}
+}
+
+func TestDiffPlan_Summary(t *testing.T) {
+	plan := &DiffPlan{
+		Actions: []PlannedAction{
+			{Action: ActionCreate},
+			{Action: ActionCreate},
+			{Action: ActionUpdate},
+			{Action: ActionNoChange},
+			{Action: ActionNoChange},
+			{Action: ActionNoChange},
+		},
+	}
+
+	summary := plan.Summary()
+	assert.Equal(t, "2 to create, 1 to update, 0 to delete, 3 no-change", summary)
+}
+
+func TestDiffPlan_BlockedDeletionErrors(t *testing.T) {
+	plan := &DiffPlan{
+		BlockedDeletions: []BlockedDeletion{
+			{
+				ResourceType: ResourceAccountType,
+				ResourceCode: "CUSTOMER_PREPAID",
+				Reason:       "1,234 accounts with balances exist",
+			},
+			{
+				ResourceType: ResourceInstrument,
+				ResourceCode: "KWH",
+				Reason:       "referenced by active valuation rules",
+			},
+		},
+	}
+
+	errors := plan.BlockedDeletionErrors()
+	assert.Len(t, errors, 2)
+	assert.Equal(t, "Cannot delete account_type CUSTOMER_PREPAID: 1,234 accounts with balances exist", errors[0])
+	assert.Equal(t, "Cannot delete instrument KWH: referenced by active valuation rules", errors[1])
+}
+
+func TestDiff_BreakingChangeFlagging(t *testing.T) {
+	d := New(nil, nil)
+	oldManifest := testManifest()
+
+	newManifest := testManifest()
+	newManifest.Instruments = newManifest.Instruments[:1] // remove KWH
+
+	plan, err := d.Diff(context.Background(), oldManifest, newManifest)
+	require.NoError(t, err)
+
+	assert.True(t, plan.HasBreakingChanges)
+
+	for _, action := range plan.Actions {
+		if action.Action == ActionDelete {
+			assert.True(t, action.Breaking, "DELETE actions should be flagged as breaking")
+		}
+		if action.Action == ActionNoChange || action.Action == ActionCreate {
+			assert.False(t, action.Breaking, "non-DELETE actions should not be breaking")
+		}
+	}
+}
+
+func TestValRuleKey(t *testing.T) {
+	assert.Equal(t, "KWH->GBP", valRuleKey("KWH", "GBP"))
+	assert.Equal(t, "EUR->GBP", valRuleKey("eur", "gbp"))
+	assert.Equal(t, "A->B", valRuleKey("a", "B"))
+}
+
+// --- Mock implementations ---
+
+type mockSafetyChecker struct {
+	accountBlocked    map[string]*BlockedDeletion
+	instrumentBlocked map[string]*BlockedDeletion
+	sagaBlocked       map[string]*BlockedDeletion
+	err               error
+}
+
+func (m *mockSafetyChecker) CheckAccountTypeDeletion(_ context.Context, code string) (*BlockedDeletion, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.accountBlocked != nil {
+		return m.accountBlocked[code], nil
+	}
+	return nil, nil
+}
+
+func (m *mockSafetyChecker) CheckInstrumentDeletion(_ context.Context, code string) (*BlockedDeletion, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.instrumentBlocked != nil {
+		return m.instrumentBlocked[code], nil
+	}
+	return nil, nil
+}
+
+func (m *mockSafetyChecker) CheckSagaDeletion(_ context.Context, name string) (*BlockedDeletion, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.sagaBlocked != nil {
+		return m.sagaBlocked[name], nil
+	}
+	return nil, nil
+}
+
+type mockDriftDetector struct {
+	warnings []DriftWarning
+	err      error
+	called   bool
+}
+
+func (m *mockDriftDetector) DetectDrift(_ context.Context, _ *controlplanev1.Manifest) ([]DriftWarning, error) {
+	m.called = true
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.warnings, nil
+}
+
+// --- Test helpers ---
+
+func filterActions(actions []PlannedAction, actionType ActionType) []PlannedAction {
+	var result []PlannedAction
+	for _, a := range actions {
+		if a.Action == actionType {
+			result = append(result, a)
+		}
+	}
+	return result
+}
+
+func filterActionsByResource(actions []PlannedAction, actionType ActionType, resourceType ResourceType) []PlannedAction {
+	var result []PlannedAction
+	for _, a := range actions {
+		if a.Action == actionType && a.ResourceType == resourceType {
+			result = append(result, a)
+		}
+	}
+	return result
+}

--- a/services/control-plane/internal/differ/persistence/manifest_version_store.go
+++ b/services/control-plane/internal/differ/persistence/manifest_version_store.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/lib/pq"
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
 	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -117,7 +116,7 @@ func (s *PostgresManifestVersionStore) setSearchPath(ctx context.Context, tx pgx
 		return nil
 	}
 
-	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
+	schemaName := pgx.Identifier{tenantID.SchemaName()}.Sanitize()
 	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
 	_, err := tx.Exec(ctx, query)
 	if err != nil {

--- a/services/control-plane/internal/differ/persistence/manifest_version_store.go
+++ b/services/control-plane/internal/differ/persistence/manifest_version_store.go
@@ -1,0 +1,170 @@
+// Package persistence provides PostgreSQL/CockroachDB storage for
+// manifest version snapshots used by the differ.
+package persistence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/lib/pq"
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// ErrInvalidManifestJSON is returned when marshaled manifest JSON is not valid.
+var ErrInvalidManifestJSON = errors.New("marshaled manifest is not valid JSON")
+
+// PostgresManifestVersionStore implements differ.ManifestVersionStore
+// using PostgreSQL/CockroachDB as the backing store.
+type PostgresManifestVersionStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewPostgresManifestVersionStore creates a store backed by a pgx connection pool.
+func NewPostgresManifestVersionStore(pool *pgxpool.Pool) *PostgresManifestVersionStore {
+	return &PostgresManifestVersionStore{pool: pool}
+}
+
+// GetLatestApplied returns the most recently applied manifest version.
+// Returns nil, nil if no manifest has been applied yet.
+func (s *PostgresManifestVersionStore) GetLatestApplied(ctx context.Context) (*differ.ManifestVersion, error) {
+	var result *differ.ManifestVersion
+	err := s.withReadTransaction(ctx, func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `
+			SELECT id, version, manifest_json, applied_at, applied_by
+			FROM manifest_version
+			ORDER BY version DESC
+			LIMIT 1
+		`)
+
+		var (
+			id           string
+			version      int
+			manifestJSON []byte
+			appliedAt    time.Time
+			appliedBy    string
+		)
+
+		err := row.Scan(&id, &version, &manifestJSON, &appliedAt, &appliedBy)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil
+			}
+			return fmt.Errorf("scan manifest version: %w", err)
+		}
+
+		manifest := &controlplanev1.Manifest{}
+		if err := protojson.Unmarshal(manifestJSON, manifest); err != nil {
+			return fmt.Errorf("unmarshal manifest JSON: %w", err)
+		}
+
+		result = &differ.ManifestVersion{
+			ID:        id,
+			Version:   version,
+			Manifest:  manifest,
+			AppliedAt: appliedAt,
+			AppliedBy: appliedBy,
+		}
+		return nil
+	})
+	return result, err
+}
+
+// Save stores a new manifest version after successful application.
+func (s *PostgresManifestVersionStore) Save(ctx context.Context, manifest *controlplanev1.Manifest, appliedBy string) error {
+	return s.withWriteTransaction(ctx, func(tx pgx.Tx) error {
+		var nextVersion int
+		err := tx.QueryRow(ctx, `
+			SELECT COALESCE(MAX(version), 0) + 1
+			FROM manifest_version
+		`).Scan(&nextVersion)
+		if err != nil {
+			return fmt.Errorf("get next version: %w", err)
+		}
+
+		manifestJSON, err := protojson.Marshal(manifest)
+		if err != nil {
+			return fmt.Errorf("marshal manifest to JSON: %w", err)
+		}
+
+		if !json.Valid(manifestJSON) {
+			return ErrInvalidManifestJSON
+		}
+
+		_, err = tx.Exec(ctx, `
+			INSERT INTO manifest_version (version, manifest_json, applied_by)
+			VALUES ($1, $2, $3)
+		`, nextVersion, manifestJSON, appliedBy)
+		if err != nil {
+			return fmt.Errorf("insert manifest version: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// setSearchPath sets the PostgreSQL search_path for tenant isolation.
+func (s *PostgresManifestVersionStore) setSearchPath(ctx context.Context, tx pgx.Tx) error {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil
+	}
+
+	schemaName := pq.QuoteIdentifier(tenantID.SchemaName())
+	query := fmt.Sprintf("SET LOCAL search_path TO %s, public", schemaName)
+	_, err := tx.Exec(ctx, query)
+	if err != nil {
+		return fmt.Errorf("failed to set tenant schema scope: %w", err)
+	}
+
+	return nil
+}
+
+// withReadTransaction executes a read-only function within a transaction with tenant scoping.
+func (s *PostgresManifestVersionStore) withReadTransaction(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := s.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+// withWriteTransaction executes a write function within a transaction with tenant scoping.
+func (s *PostgresManifestVersionStore) withWriteTransaction(ctx context.Context, fn func(tx pgx.Tx) error) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() {
+		_ = tx.Rollback(ctx)
+	}()
+
+	if err := s.setSearchPath(ctx, tx); err != nil {
+		return err
+	}
+
+	if err := fn(tx); err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}

--- a/services/control-plane/internal/differ/safety.go
+++ b/services/control-plane/internal/differ/safety.go
@@ -1,0 +1,45 @@
+package differ
+
+import "context"
+
+// SafetyChecker verifies whether a resource can be safely deleted.
+// Implementations query downstream services (Position Keeping, Reference Data)
+// to detect live usage that would block deletion.
+type SafetyChecker interface {
+	// CheckAccountTypeDeletion returns a BlockedDeletion if the account type
+	// has positions with non-zero balances. Returns nil, nil if safe to delete.
+	CheckAccountTypeDeletion(ctx context.Context, accountTypeCode string) (*BlockedDeletion, error)
+
+	// CheckInstrumentDeletion returns a BlockedDeletion if the instrument is
+	// referenced by active valuation rules or has live positions. Returns nil, nil if safe.
+	CheckInstrumentDeletion(ctx context.Context, instrumentCode string) (*BlockedDeletion, error)
+
+	// CheckSagaDeletion returns a BlockedDeletion if the saga has pending or
+	// running instances. Returns nil, nil if safe to delete.
+	CheckSagaDeletion(ctx context.Context, sagaName string) (*BlockedDeletion, error)
+}
+
+// NoOpSafetyChecker always allows deletions. Useful for dry-run or testing
+// where downstream services are not available.
+type NoOpSafetyChecker struct{}
+
+// CheckAccountTypeDeletion always returns nil (safe to delete).
+//
+//nolint:nilnil // nil,nil is the documented interface contract for "safe to delete"
+func (n *NoOpSafetyChecker) CheckAccountTypeDeletion(_ context.Context, _ string) (*BlockedDeletion, error) {
+	return nil, nil
+}
+
+// CheckInstrumentDeletion always returns nil (safe to delete).
+//
+//nolint:nilnil // nil,nil is the documented interface contract for "safe to delete"
+func (n *NoOpSafetyChecker) CheckInstrumentDeletion(_ context.Context, _ string) (*BlockedDeletion, error) {
+	return nil, nil
+}
+
+// CheckSagaDeletion always returns nil (safe to delete).
+//
+//nolint:nilnil // nil,nil is the documented interface contract for "safe to delete"
+func (n *NoOpSafetyChecker) CheckSagaDeletion(_ context.Context, _ string) (*BlockedDeletion, error) {
+	return nil, nil
+}

--- a/services/control-plane/internal/differ/store.go
+++ b/services/control-plane/internal/differ/store.go
@@ -1,0 +1,29 @@
+package differ
+
+import (
+	"context"
+	"time"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+)
+
+// ManifestVersion represents a stored snapshot of a previously applied manifest.
+type ManifestVersion struct {
+	ID        string
+	Version   int
+	Manifest  *controlplanev1.Manifest
+	AppliedAt time.Time
+	AppliedBy string
+}
+
+// ManifestVersionStore persists and retrieves applied manifest snapshots.
+// Each successful apply stores a new version, following Kubernetes
+// last-applied-configuration semantics.
+type ManifestVersionStore interface {
+	// GetLatestApplied returns the most recently applied manifest version.
+	// Returns nil, nil if no manifest has been applied yet (first apply).
+	GetLatestApplied(ctx context.Context) (*ManifestVersion, error)
+
+	// Save stores a new manifest version after successful application.
+	Save(ctx context.Context, manifest *controlplanev1.Manifest, appliedBy string) error
+}

--- a/services/control-plane/internal/differ/types.go
+++ b/services/control-plane/internal/differ/types.go
@@ -1,0 +1,101 @@
+// Package differ implements the manifest diff engine that compares
+// a last-applied manifest against a new manifest to produce a plan
+// of CREATE/UPDATE/DELETE/NO_CHANGE actions with safety checks.
+package differ
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrNilManifest is returned when the new manifest is nil.
+var ErrNilManifest = errors.New("new manifest cannot be nil")
+
+// ActionType classifies how a resource should change during manifest application.
+type ActionType string
+
+// Action type constants for diff plan entries.
+const (
+	ActionCreate   ActionType = "CREATE"
+	ActionUpdate   ActionType = "UPDATE"
+	ActionDelete   ActionType = "DELETE"
+	ActionNoChange ActionType = "NO_CHANGE"
+)
+
+// ResourceType identifies the category of resource being planned.
+type ResourceType string
+
+// Resource type constants matching manifest sections.
+const (
+	ResourceInstrument    ResourceType = "instrument"
+	ResourceAccountType   ResourceType = "account_type"
+	ResourceValuationRule ResourceType = "valuation_rule"
+	ResourceSaga          ResourceType = "saga"
+)
+
+// PlannedAction represents a single action in the diff plan.
+type PlannedAction struct {
+	ResourceType ResourceType
+	ResourceCode string
+	Action       ActionType
+	Description  string
+	Breaking     bool
+	Warnings     []string
+}
+
+// BlockedDeletion holds context about why a deletion was rejected.
+type BlockedDeletion struct {
+	ResourceType ResourceType
+	ResourceCode string
+	Reason       string
+}
+
+// DriftWarning indicates where database state differs from the last-applied manifest.
+type DriftWarning struct {
+	ResourceType ResourceType
+	ResourceCode string
+	Description  string
+}
+
+// DiffPlan is the complete result of comparing last-applied vs new manifest.
+type DiffPlan struct {
+	Actions            []PlannedAction
+	BlockedDeletions   []BlockedDeletion
+	DriftWarnings      []DriftWarning
+	HasBreakingChanges bool
+}
+
+// Summary returns a human-readable summary of the plan.
+func (p *DiffPlan) Summary() string {
+	counts := map[ActionType]int{}
+	for _, a := range p.Actions {
+		counts[a.Action]++
+	}
+	return fmt.Sprintf(
+		"%d to create, %d to update, %d to delete, %d no-change",
+		counts[ActionCreate],
+		counts[ActionUpdate],
+		counts[ActionDelete],
+		counts[ActionNoChange],
+	)
+}
+
+// HasBlockedDeletions returns true if any deletions were rejected by safety checks.
+func (p *DiffPlan) HasBlockedDeletions() bool {
+	return len(p.BlockedDeletions) > 0
+}
+
+// BlockedDeletionErrors formats blocked deletions as actionable error strings.
+func (p *DiffPlan) BlockedDeletionErrors() []string {
+	msgs := make([]string, len(p.BlockedDeletions))
+	for i, bd := range p.BlockedDeletions {
+		msgs[i] = fmt.Sprintf("Cannot delete %s %s: %s", bd.ResourceType, bd.ResourceCode, bd.Reason)
+	}
+	return msgs
+}
+
+// valRuleKey produces a stable identifier for a valuation rule (from->to pair).
+func valRuleKey(from, to string) string {
+	return strings.ToUpper(from) + "->" + strings.ToUpper(to)
+}

--- a/services/control-plane/migrations/20260209000001_create_manifest_versions.sql
+++ b/services/control-plane/migrations/20260209000001_create_manifest_versions.sql
@@ -1,0 +1,27 @@
+-- Manifest Versions Table
+-- Stores versioned snapshots of successfully applied manifests.
+-- Follows Kubernetes last-applied-configuration semantics:
+-- each apply stores the full manifest JSON for comparison on the next apply.
+-- Multi-tenancy: Schema-per-tenant architecture means no tenant_id column needed.
+
+CREATE TABLE "manifest_version" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "version" integer NOT NULL,
+  "manifest_json" jsonb NOT NULL,
+  "applied_at" timestamptz NOT NULL DEFAULT now(),
+  "applied_by" character varying(255) NOT NULL,
+  PRIMARY KEY ("id")
+);
+
+-- Ensure version numbers are unique and monotonically increasing
+ALTER TABLE "manifest_version"
+  ADD CONSTRAINT "uq_manifest_version_version"
+  UNIQUE ("version");
+
+-- Index for quickly finding the latest applied version
+CREATE INDEX "idx_manifest_version_applied_at" ON "manifest_version" ("applied_at" DESC);
+
+-- Index for version-ordered lookups
+CREATE INDEX "idx_manifest_version_version" ON "manifest_version" ("version" DESC);
+
+COMMENT ON TABLE "manifest_version" IS 'Versioned snapshots of applied manifests. Each successful apply stores the full manifest for diff comparison on subsequent applies.';


### PR DESCRIPTION
## Summary

- Implement the manifest diff engine that compares a last-applied manifest against a new manifest to produce a plan of CREATE/UPDATE/DELETE/NO_CHANGE actions
- Add safety check interfaces that query downstream services before allowing deletions of resources with live usage
- Add drift detection interface to surface warnings when database state differs from the last-applied manifest
- Create manifest_version table migration for storing versioned manifest snapshots

## Changes

### New Package: `services/control-plane/internal/differ/`

**Core diff algorithm** (`manifest_differ.go`):
- Compares each resource type (instruments, account types, valuation rules, sagas) independently
- Uses resource code as stable immutable primary key (Kubernetes apply semantics)
- Produces deterministic, sorted output for reproducible plans
- Flags DELETE actions as breaking changes with `has_breaking_changes` on the plan

**Interfaces** (`safety.go`, `drift.go`, `store.go`):
- `SafetyChecker`: pluggable safety checks for account type deletions (live balances), instrument deletions (active references), and saga deletions (pending instances)
- `DriftDetector`: compares DB state against last-applied manifest to surface manual changes
- `ManifestVersionStore`: stores versioned manifest snapshots following Kubernetes last-applied-configuration pattern

**Domain types** (`types.go`):
- `DiffPlan` with actions, blocked deletions, drift warnings, and breaking change flag
- `PlannedAction` with resource type, code, action, description, and breaking flag
- Human-readable `Summary()` and `BlockedDeletionErrors()` for actionable output

### Persistence: `services/control-plane/internal/differ/persistence/`

- PostgreSQL/CockroachDB implementation of `ManifestVersionStore` using pgx
- Tenant isolation via `SET LOCAL search_path` (schema-per-tenant pattern)
- Automatic version numbering with monotonic increment

### Migration: `services/control-plane/migrations/`

- `20260209000001_create_manifest_versions.sql`: manifest_version table with unique version constraint and indexes

## Task Master

| TM Task | Description |
|---------|-------------|
| control-plane.5 | ApplyManifest Differ with last-applied comparison |
| control-plane.5.1 | Manifest version table schema and storage interface |
| control-plane.5.2 | Three-way diff algorithm with resource code comparison |
| control-plane.5.3 | Safety check queries for live balance detection |
| control-plane.5.4 | Breaking change detection and flagging logic |
| control-plane.5.5 | Drift detection comparing DB state to last-applied manifest |
| control-plane.5.6 | Actionable error messages for blocked deletions |

## Testing

32 unit tests covering:
- First-time apply (nil last-applied -> all CREATE)
- Identical manifests (all NO_CHANGE)
- Added/removed/modified resources for all 4 resource types
- Mixed changes across multiple resource types
- Safety checker blocking deletions (account types, instruments, sagas)
- Safety checker allowing deletions
- Safety checker error propagation
- Drift detector warnings inclusion
- Drift detector not called when no last-applied manifest
- Breaking change flagging
- Deterministic output ordering
- Plan summary formatting
- Blocked deletion error formatting

## Risk Assessment

Low risk - this is a new package with no modifications to existing code. The differ is a pure function that takes two manifests and produces a plan. No database writes occur during diffing (only reads via safety checks and drift detection).