### PR TITLE
feat: Extend Gateway to validate API keys via Control Plane RPC

### DIFF
--- a/api/proto/meridian/control_plane/v1/auth.proto
+++ b/api/proto/meridian/control_plane/v1/auth.proto
@@ -1,0 +1,41 @@
+syntax = "proto3";
+
+package meridian.control_plane.v1;
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1;controlplanev1";
+
+// AuthService provides authentication operations for the Control Plane.
+// The Gateway calls ValidateAPIKey to verify API keys against tenant schemas.
+service AuthService {
+  // ValidateAPIKey verifies an API key by prefix and plaintext value.
+  // The gateway extracts the tenant slug from the key prefix (pk_{slug}_{entropy}),
+  // resolves the tenant, and calls this RPC which queries the tenant's api_key table.
+  rpc ValidateAPIKey(ValidateAPIKeyRequest) returns (ValidateAPIKeyResponse);
+}
+
+// ValidateAPIKeyRequest contains the API key components for validation.
+message ValidateAPIKeyRequest {
+  // key_prefix is the routing prefix extracted from the API key (e.g., "pk_acme_abc12345").
+  string key_prefix = 1;
+
+  // plaintext_key is the full API key for hash verification.
+  string plaintext_key = 2;
+}
+
+// ValidateAPIKeyResponse contains the validation result and associated metadata.
+message ValidateAPIKeyResponse {
+  // valid indicates whether the API key passed validation.
+  bool valid = 1;
+
+  // tenant_id is the resolved tenant identifier (populated when valid=true).
+  string tenant_id = 2;
+
+  // identity is the display name or email of the staff user owning this key.
+  string identity = 3;
+
+  // scopes contains the permission scopes granted to this key.
+  repeated string scopes = 4;
+
+  // rate_limit_rps is the per-key rate limit in requests per second.
+  int32 rate_limit_rps = 5;
+}

--- a/services/control-plane/internal/apiauth/service.go
+++ b/services/control-plane/internal/apiauth/service.go
@@ -1,0 +1,69 @@
+// Package apiauth implements the AuthService gRPC server for API key validation.
+// The Gateway calls ValidateAPIKey to verify keys stored in tenant schemas.
+package apiauth
+
+import (
+	"context"
+	"log/slog"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/staff"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gorm.io/gorm"
+)
+
+// Service implements the AuthService gRPC server.
+type Service struct {
+	controlplanev1.UnimplementedAuthServiceServer
+
+	staffSvc *staff.Service
+	logger   *slog.Logger
+}
+
+// NewService creates a new AuthService.
+func NewService(gormDB *gorm.DB, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{
+		staffSvc: staff.NewService(gormDB, logger),
+		logger:   logger,
+	}
+}
+
+// ValidateAPIKey verifies an API key by querying the tenant schema.
+// The tenant ID must be present in the context (set by the gateway before calling).
+func (s *Service) ValidateAPIKey(ctx context.Context, req *controlplanev1.ValidateAPIKeyRequest) (*controlplanev1.ValidateAPIKeyResponse, error) {
+	if req.GetKeyPrefix() == "" || req.GetPlaintextKey() == "" {
+		return nil, status.Error(codes.InvalidArgument, "key_prefix and plaintext_key are required")
+	}
+
+	// Tenant context must be set by the caller (gateway resolves slug -> tenant_id)
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil, status.Error(codes.FailedPrecondition, "tenant context required")
+	}
+
+	result, err := s.staffSvc.ValidateAPIKeyFull(ctx, req.GetKeyPrefix(), req.GetPlaintextKey())
+	if err != nil {
+		s.logger.WarnContext(ctx, "API key validation failed",
+			"key_prefix", req.GetKeyPrefix(),
+			"error", err)
+		return &controlplanev1.ValidateAPIKeyResponse{Valid: false}, nil
+	}
+
+	identity := result.User.Email
+	if result.User.Name != "" {
+		identity = result.User.Name
+	}
+
+	return &controlplanev1.ValidateAPIKeyResponse{
+		Valid:        true,
+		TenantId:     tenantID.String(),
+		Identity:     identity,
+		Scopes:       result.Scopes,
+		RateLimitRps: int32(result.RateLimitRPS),
+	}, nil
+}

--- a/services/control-plane/internal/apiauth/service_test.go
+++ b/services/control-plane/internal/apiauth/service_test.go
@@ -1,0 +1,261 @@
+package apiauth_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/services/control-plane/internal/apiauth"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+const testTenantID = "test_tenant"
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, cleanup := testdb.SetupCockroachDB(t, nil)
+	t.Cleanup(cleanup)
+
+	schemaName := tenant.MustNewTenantID(testTenantID).SchemaName()
+	q := fmt.Sprintf("%q", schemaName)
+
+	ddls := []string{
+		fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", q),
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s."staff_user" (
+			"id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			"email" VARCHAR(255) NOT NULL,
+			"name" VARCHAR(255),
+			"role" VARCHAR(50) NOT NULL DEFAULT 'operator',
+			"status" VARCHAR(20) NOT NULL DEFAULT 'invited',
+			"auth_provider_id" VARCHAR(255),
+			"created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			"updated_at" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)`, q),
+		fmt.Sprintf(`CREATE UNIQUE INDEX IF NOT EXISTS "idx_staff_user_email_%s" ON %s."staff_user" ("email")`, testTenantID, q),
+		fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s."api_key" (
+			"id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			"staff_user_id" UUID NOT NULL,
+			"key_prefix" VARCHAR(100) NOT NULL,
+			"key_hash" BYTEA NOT NULL,
+			"name" VARCHAR(255),
+			"scopes" TEXT[],
+			"rate_limit_rps" INTEGER NOT NULL DEFAULT 100,
+			"last_used_at" TIMESTAMPTZ,
+			"expires_at" TIMESTAMPTZ,
+			"created_at" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			"revoked_at" TIMESTAMPTZ
+		)`, q),
+	}
+
+	for _, ddl := range ddls {
+		require.NoError(t, db.Exec(ddl).Error, "DDL failed: %s", ddl)
+	}
+
+	return db
+}
+
+func insertTestStaffAndKey(t *testing.T, db *gorm.DB, staffID uuid.UUID, email, name, status, keyPrefix, plaintextKey string, scopes []string, rateLimitRPS int) {
+	t.Helper()
+	schemaName := tenant.MustNewTenantID(testTenantID).SchemaName()
+	q := fmt.Sprintf("%q", schemaName)
+
+	require.NoError(t, db.Exec(
+		fmt.Sprintf(`INSERT INTO %s."staff_user" (id, email, name, role, status) VALUES (?, ?, ?, 'operator', ?)`, q),
+		staffID, email, name, status,
+	).Error)
+
+	hash := sha256.Sum256([]byte(plaintextKey))
+	keyID := uuid.New()
+
+	if scopes == nil {
+		require.NoError(t, db.Exec(
+			fmt.Sprintf(`INSERT INTO %s."api_key" (id, staff_user_id, key_prefix, key_hash, rate_limit_rps) VALUES (?, ?, ?, ?, ?)`, q),
+			keyID, staffID, keyPrefix, hash[:], rateLimitRPS,
+		).Error)
+	} else {
+		scopeArray := "{" + joinScopes(scopes) + "}"
+		require.NoError(t, db.Exec(
+			fmt.Sprintf(`INSERT INTO %s."api_key" (id, staff_user_id, key_prefix, key_hash, scopes, rate_limit_rps) VALUES (?, ?, ?, ?, ?::text[], ?)`, q),
+			keyID, staffID, keyPrefix, hash[:], scopeArray, rateLimitRPS,
+		).Error)
+	}
+}
+
+func joinScopes(scopes []string) string {
+	result := ""
+	for i, s := range scopes {
+		if i > 0 {
+			result += ","
+		}
+		result += fmt.Sprintf(`"%s"`, s)
+	}
+	return result
+}
+
+func ctxWithTenant() context.Context {
+	tenantID := tenant.MustNewTenantID(testTenantID)
+	return tenant.WithTenant(context.Background(), tenantID)
+}
+
+func TestValidateAPIKey_ValidKey(t *testing.T) {
+	db := setupTestDB(t)
+	svc := apiauth.NewService(db, slog.Default())
+
+	staffID := uuid.New()
+	keyPrefix := "pk_acme_abc12345"
+	plaintextKey := "pk_acme_abc12345_fullentropy"
+	insertTestStaffAndKey(t, db, staffID, "alice@acme.com", "Alice", "active", keyPrefix, plaintextKey, []string{"read", "write"}, 50)
+
+	ctx := ctxWithTenant()
+	resp, err := svc.ValidateAPIKey(ctx, &controlplanev1.ValidateAPIKeyRequest{
+		KeyPrefix:    keyPrefix,
+		PlaintextKey: plaintextKey,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, resp.GetValid())
+	assert.Equal(t, testTenantID, resp.GetTenantId())
+	assert.Equal(t, "Alice", resp.GetIdentity())
+	assert.Equal(t, []string{"read", "write"}, resp.GetScopes())
+	assert.Equal(t, int32(50), resp.GetRateLimitRps())
+}
+
+func TestValidateAPIKey_InvalidKey(t *testing.T) {
+	db := setupTestDB(t)
+	svc := apiauth.NewService(db, slog.Default())
+
+	staffID := uuid.New()
+	keyPrefix := "pk_acme_abc12345"
+	plaintextKey := "pk_acme_abc12345_fullentropy"
+	insertTestStaffAndKey(t, db, staffID, "alice@acme.com", "Alice", "active", keyPrefix, plaintextKey, nil, 100)
+
+	ctx := ctxWithTenant()
+	resp, err := svc.ValidateAPIKey(ctx, &controlplanev1.ValidateAPIKeyRequest{
+		KeyPrefix:    keyPrefix,
+		PlaintextKey: "wrong_key",
+	})
+
+	require.NoError(t, err)
+	assert.False(t, resp.GetValid())
+}
+
+func TestValidateAPIKey_MissingTenantContext(t *testing.T) {
+	db := setupTestDB(t)
+	svc := apiauth.NewService(db, slog.Default())
+
+	_, err := svc.ValidateAPIKey(context.Background(), &controlplanev1.ValidateAPIKeyRequest{
+		KeyPrefix:    "pk_acme_abc12345",
+		PlaintextKey: "pk_acme_abc12345_fullentropy",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "tenant context required")
+}
+
+func TestValidateAPIKey_EmptyFields(t *testing.T) {
+	db := setupTestDB(t)
+	svc := apiauth.NewService(db, slog.Default())
+
+	_, err := svc.ValidateAPIKey(ctxWithTenant(), &controlplanev1.ValidateAPIKeyRequest{
+		KeyPrefix:    "",
+		PlaintextKey: "",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+func TestValidateAPIKey_SuspendedUser(t *testing.T) {
+	db := setupTestDB(t)
+	svc := apiauth.NewService(db, slog.Default())
+
+	staffID := uuid.New()
+	keyPrefix := "pk_acme_def12345"
+	plaintextKey := "pk_acme_def12345_fullentropy"
+	insertTestStaffAndKey(t, db, staffID, "bob@acme.com", "Bob", "suspended", keyPrefix, plaintextKey, nil, 100)
+
+	ctx := ctxWithTenant()
+	resp, err := svc.ValidateAPIKey(ctx, &controlplanev1.ValidateAPIKeyRequest{
+		KeyPrefix:    keyPrefix,
+		PlaintextKey: plaintextKey,
+	})
+
+	require.NoError(t, err)
+	assert.False(t, resp.GetValid())
+}
+
+func TestValidateAPIKey_ExpiredKey(t *testing.T) {
+	db := setupTestDB(t)
+	svc := apiauth.NewService(db, slog.Default())
+
+	staffID := uuid.New()
+	keyPrefix := "pk_acme_exp12345"
+	plaintextKey := "pk_acme_exp12345_fullentropy"
+
+	schemaName := tenant.MustNewTenantID(testTenantID).SchemaName()
+	q := fmt.Sprintf("%q", schemaName)
+
+	require.NoError(t, db.Exec(
+		fmt.Sprintf(`INSERT INTO %s."staff_user" (id, email, name, role, status) VALUES (?, ?, ?, 'operator', 'active')`, q),
+		staffID, "charlie@acme.com", "Charlie",
+	).Error)
+
+	hash := sha256.Sum256([]byte(plaintextKey))
+	expired := time.Now().Add(-1 * time.Hour)
+	require.NoError(t, db.Exec(
+		fmt.Sprintf(`INSERT INTO %s."api_key" (id, staff_user_id, key_prefix, key_hash, expires_at) VALUES (?, ?, ?, ?, ?)`, q),
+		uuid.New(), staffID, keyPrefix, hash[:], expired,
+	).Error)
+
+	ctx := ctxWithTenant()
+	resp, err := svc.ValidateAPIKey(ctx, &controlplanev1.ValidateAPIKeyRequest{
+		KeyPrefix:    keyPrefix,
+		PlaintextKey: plaintextKey,
+	})
+
+	require.NoError(t, err)
+	assert.False(t, resp.GetValid())
+}
+
+func TestValidateAPIKey_FallsBackToEmail(t *testing.T) {
+	db := setupTestDB(t)
+	svc := apiauth.NewService(db, slog.Default())
+
+	staffID := uuid.New()
+	keyPrefix := "pk_acme_noname12"
+	plaintextKey := "pk_acme_noname12_fullentropy"
+
+	schemaName := tenant.MustNewTenantID(testTenantID).SchemaName()
+	q := fmt.Sprintf("%q", schemaName)
+
+	// Insert staff user without a name
+	require.NoError(t, db.Exec(
+		fmt.Sprintf(`INSERT INTO %s."staff_user" (id, email, role, status) VALUES (?, ?, 'operator', 'active')`, q),
+		staffID, "noname@acme.com",
+	).Error)
+
+	hash := sha256.Sum256([]byte(plaintextKey))
+	require.NoError(t, db.Exec(
+		fmt.Sprintf(`INSERT INTO %s."api_key" (id, staff_user_id, key_prefix, key_hash) VALUES (?, ?, ?, ?)`, q),
+		uuid.New(), staffID, keyPrefix, hash[:],
+	).Error)
+
+	ctx := ctxWithTenant()
+	resp, err := svc.ValidateAPIKey(ctx, &controlplanev1.ValidateAPIKeyRequest{
+		KeyPrefix:    keyPrefix,
+		PlaintextKey: plaintextKey,
+	})
+
+	require.NoError(t, err)
+	assert.True(t, resp.GetValid())
+	assert.Equal(t, "noname@acme.com", resp.GetIdentity())
+}

--- a/services/control-plane/internal/staff/service.go
+++ b/services/control-plane/internal/staff/service.go
@@ -384,6 +384,71 @@ func (s *Service) ValidateAPIKey(ctx context.Context, keyPrefix, plaintextKey st
 	return user, nil
 }
 
+// APIKeyValidation holds the full result of validating an API key,
+// including key metadata needed by the gateway.
+type APIKeyValidation struct {
+	User         *User
+	Scopes       []string
+	RateLimitRPS int
+}
+
+// ValidateAPIKeyFull verifies an API key and returns the full validation result
+// including scopes and rate limit. Used by the AuthService gRPC handler.
+func (s *Service) ValidateAPIKeyFull(ctx context.Context, keyPrefix, plaintextKey string) (*APIKeyValidation, error) {
+	var result *APIKeyValidation
+
+	err := db.WithGormTenantTransaction(ctx, s.gormDB, func(tx *gorm.DB) error {
+		var keyEntity APIKeyEntity
+		if err := tx.Where("key_prefix = ? AND revoked_at IS NULL", keyPrefix).First(&keyEntity).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrAPIKeyNotFound
+			}
+			return err
+		}
+
+		// Check expiry
+		if keyEntity.ExpiresAt != nil && keyEntity.ExpiresAt.Before(time.Now()) {
+			return ErrAPIKeyExpired
+		}
+
+		// Constant-time hash comparison
+		expectedHash := sha256.Sum256([]byte(plaintextKey))
+		if subtle.ConstantTimeCompare(keyEntity.KeyHash, expectedHash[:]) != 1 {
+			return ErrInvalidAPIKey
+		}
+
+		// Update last_used_at
+		now := time.Now()
+		tx.Model(&APIKeyEntity{}).
+			Where("id = ?", keyEntity.ID).
+			Update("last_used_at", now)
+
+		// Load staff user
+		var staffEntity UserEntity
+		if err := tx.Where("id = ?", keyEntity.StaffUserID).First(&staffEntity).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrStaffNotFound
+			}
+			return err
+		}
+
+		if staffEntity.Status == StatusSuspended {
+			return ErrStaffSuspended
+		}
+
+		result = &APIKeyValidation{
+			User:         entityToUser(&staffEntity),
+			Scopes:       []string(keyEntity.Scopes),
+			RateLimitRPS: keyEntity.RateLimitRPS,
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // MapRoleToAuth converts a staff role string to the shared auth.Role type.
 func MapRoleToAuth(staffRole string) (auth.Role, error) {
 	switch staffRole {

--- a/services/gateway/auth/combined_middleware.go
+++ b/services/gateway/auth/combined_middleware.go
@@ -18,15 +18,19 @@ import (
 //
 // Authentication flow:
 // 1. Check for X-API-Key header - if present, validate API key
+//   - For pk_{slug}_{...} format: validate via Control Plane RPC (with caching)
+//   - For legacy format: validate via env-var-based map lookup
+//
 // 2. If no API key, check for Authorization: Bearer header - if present, validate JWT
 // 3. If neither is present, return 401 Unauthorized
 //
 // On successful authentication:
 // - For JWT: User ID, tenant ID, roles, scopes are injected into context
-// - For API key: API key identity is injected into context
+// - For API key: API key identity, tenant ID, scopes are injected into context
 type CombinedAuthMiddleware struct {
 	jwtMiddleware    *JWTMiddleware
 	apiKeyMiddleware *APIKeyMiddleware
+	rpcValidator     *RPCAPIKeyValidator
 	logger           *slog.Logger
 }
 
@@ -36,8 +40,12 @@ type CombinedAuthConfig struct {
 	JWTValidator JWTValidator
 
 	// APIKeyConfig is the configuration for API key authentication.
-	// If APIKeys is nil or empty, API key authentication is disabled.
+	// If APIKeys is nil or empty, legacy API key authentication is disabled.
 	APIKeyConfig APIKeyConfig
+
+	// RPCValidator is the optional RPC-based API key validator for pk_{slug}_{...} keys.
+	// When set, prefixed API keys are validated via the Control Plane service.
+	RPCValidator *RPCAPIKeyValidator
 
 	// Logger for authentication events.
 	Logger *slog.Logger
@@ -71,6 +79,7 @@ func NewCombinedAuthMiddleware(config CombinedAuthConfig) (*CombinedAuthMiddlewa
 	return &CombinedAuthMiddleware{
 		jwtMiddleware:    jwtMiddleware,
 		apiKeyMiddleware: apiKeyMiddleware,
+		rpcValidator:     config.RPCValidator,
 		logger:           config.Logger,
 	}, nil
 }
@@ -81,15 +90,36 @@ func (m *CombinedAuthMiddleware) Close() {
 	if m.apiKeyMiddleware != nil {
 		m.apiKeyMiddleware.Close()
 	}
+	if m.rpcValidator != nil {
+		m.rpcValidator.Close()
+	}
 }
 
 // Handler returns an http.Handler that performs combined authentication.
 // It first checks for API key, then JWT. If neither is valid, returns 401.
 func (m *CombinedAuthMiddleware) Handler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Try API key authentication first (if configured)
-		if m.apiKeyMiddleware != nil && r.Header.Get(APIKeyHeader) != "" {
-			m.handleAPIKeyAuth(w, r, next)
+		apiKey := r.Header.Get(APIKeyHeader)
+
+		// Try API key authentication first (if any API key mechanism is configured)
+		if apiKey != "" {
+			// Try RPC validation for pk_{slug}_{...} format keys
+			if m.rpcValidator != nil && strings.HasPrefix(apiKey, "pk_") {
+				m.handleRPCAPIKeyAuth(w, r, next, apiKey)
+				return
+			}
+
+			// Fall back to legacy env-var-based API key validation
+			if m.apiKeyMiddleware != nil {
+				m.handleLegacyAPIKeyAuth(w, r, next)
+				return
+			}
+
+			// API key provided but no validator configured
+			m.logger.Debug("API key provided but no validator configured",
+				slog.String("path", r.URL.Path),
+			)
+			writeUnauthorized(w, "invalid API key")
 			return
 		}
 
@@ -107,11 +137,55 @@ func (m *CombinedAuthMiddleware) Handler(next http.Handler) http.Handler {
 	})
 }
 
-// handleAPIKeyAuth handles API key authentication with tenant context injection.
-func (m *CombinedAuthMiddleware) handleAPIKeyAuth(w http.ResponseWriter, r *http.Request, next http.Handler) {
-	// Create a wrapper handler that will be called if API key auth succeeds
+// handleRPCAPIKeyAuth validates a pk_{slug}_{...} API key via the Control Plane RPC.
+func (m *CombinedAuthMiddleware) handleRPCAPIKeyAuth(w http.ResponseWriter, r *http.Request, next http.Handler, apiKey string) {
+	result, err := m.rpcValidator.Validate(r.Context(), apiKey)
+	if err != nil {
+		m.logger.Warn("RPC API key validation error",
+			slog.String("error", err.Error()),
+			slog.String("path", r.URL.Path),
+		)
+		writeUnauthorized(w, "invalid API key")
+		return
+	}
+
+	if result == nil || !result.Valid {
+		m.logger.Debug("RPC API key validation failed",
+			slog.String("path", r.URL.Path),
+		)
+		writeUnauthorized(w, "invalid API key")
+		return
+	}
+
+	// Check per-key rate limit using the rate_limit_rps from the validation result
+	_, keyPrefix, _ := ParsePrefixedKey(apiKey)
+	if !m.rpcValidator.AllowRequest(keyPrefix, result.RateLimitRPS) {
+		m.logger.Warn("rate limit exceeded",
+			slog.String("identity", result.Identity),
+			slog.String("path", r.URL.Path),
+		)
+		writeJSONError(w, "rate limit exceeded", http.StatusTooManyRequests)
+		return
+	}
+
+	// Inject identity, tenant, and scopes into context
+	ctx := context.WithValue(r.Context(), APIKeyIdentityKey, result.Identity)
+	if result.TenantID != "" {
+		ctx = context.WithValue(ctx, TenantIDContextKey, result.TenantID)
+		if tenantID, err := tenant.NewTenantID(result.TenantID); err == nil {
+			ctx = tenant.WithTenant(ctx, tenantID)
+		}
+	}
+	if len(result.Scopes) > 0 {
+		ctx = context.WithValue(ctx, ScopesContextKey, result.Scopes)
+	}
+
+	next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// handleLegacyAPIKeyAuth handles legacy env-var-based API key authentication.
+func (m *CombinedAuthMiddleware) handleLegacyAPIKeyAuth(w http.ResponseWriter, r *http.Request, next http.Handler) {
 	wrapper := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// API key auth succeeded - call next handler
 		next.ServeHTTP(w, r)
 	})
 

--- a/services/gateway/auth/rpc_apikey_validator.go
+++ b/services/gateway/auth/rpc_apikey_validator.go
@@ -1,0 +1,321 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// ErrNotPrefixedKey is returned when the API key is not in the pk_{slug}_{entropy} format.
+// Callers should fall back to legacy API key validation.
+var ErrNotPrefixedKey = errors.New("not a prefixed API key")
+
+// APIKeyValidationResult holds the cached result of a Control Plane validation.
+type APIKeyValidationResult struct {
+	Valid        bool
+	TenantID     string
+	Identity     string
+	Scopes       []string
+	RateLimitRPS int32
+}
+
+// SlugResolver resolves a tenant slug to a tenant ID.
+// This allows the gateway to use its existing tenant registry cache.
+type SlugResolver interface {
+	ResolveSlug(ctx context.Context, slug string) (tenant.TenantID, error)
+}
+
+// RPCAPIKeyValidator validates API keys by calling the Control Plane AuthService.
+// It parses the pk_{slug}_{entropy} format, resolves tenant slugs, and caches results.
+type RPCAPIKeyValidator struct {
+	client       controlplanev1.AuthServiceClient
+	slugResolver SlugResolver
+	logger       *slog.Logger
+
+	// Cache for validation results
+	cache    sync.Map // map[string]*cachedValidation
+	cacheTTL time.Duration
+
+	// Per-key rate limiters (keyed by API key prefix for RPC-validated keys)
+	limiters  sync.Map // map[string]*rpcRateLimiterEntry
+	stopCh    chan struct{}
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+
+	// Cleanup configuration
+	cleanupInterval    time.Duration
+	limiterIdleTimeout time.Duration
+}
+
+type cachedValidation struct {
+	result    *APIKeyValidationResult
+	expiresAt time.Time
+}
+
+type rpcRateLimiterEntry struct {
+	limiter    *rate.Limiter
+	lastAccess time.Time
+	mu         sync.Mutex
+}
+
+// RPCValidatorConfig configures the RPCAPIKeyValidator.
+type RPCValidatorConfig struct {
+	// Client is the gRPC client for the Control Plane AuthService.
+	Client controlplanev1.AuthServiceClient
+
+	// SlugResolver resolves tenant slugs to tenant IDs.
+	SlugResolver SlugResolver
+
+	// CacheTTL is the TTL for cached validation results (default: 5 minutes).
+	CacheTTL time.Duration
+
+	// CleanupInterval is how often to clean up expired cache and limiter entries (default: 1 minute).
+	CleanupInterval time.Duration
+
+	// LimiterIdleTimeout is how long a rate limiter can be idle before cleanup (default: 10 minutes).
+	LimiterIdleTimeout time.Duration
+
+	// Logger for logging.
+	Logger *slog.Logger
+}
+
+// NewRPCAPIKeyValidator creates a new RPC-based API key validator.
+func NewRPCAPIKeyValidator(config RPCValidatorConfig) *RPCAPIKeyValidator {
+	if config.CacheTTL <= 0 {
+		config.CacheTTL = 5 * time.Minute
+	}
+	if config.CleanupInterval <= 0 {
+		config.CleanupInterval = 1 * time.Minute
+	}
+	if config.LimiterIdleTimeout <= 0 {
+		config.LimiterIdleTimeout = 10 * time.Minute
+	}
+	if config.Logger == nil {
+		config.Logger = slog.Default()
+	}
+
+	v := &RPCAPIKeyValidator{
+		client:             config.Client,
+		slugResolver:       config.SlugResolver,
+		logger:             config.Logger,
+		cacheTTL:           config.CacheTTL,
+		cleanupInterval:    config.CleanupInterval,
+		limiterIdleTimeout: config.LimiterIdleTimeout,
+		stopCh:             make(chan struct{}),
+	}
+
+	v.wg.Add(1)
+	go v.cleanupLoop()
+
+	return v
+}
+
+// Close stops the background cleanup goroutine.
+func (v *RPCAPIKeyValidator) Close() {
+	v.closeOnce.Do(func() {
+		close(v.stopCh)
+		v.wg.Wait()
+	})
+}
+
+// ParsePrefixedKey parses a pk_{slug}_{entropy} formatted API key.
+// Returns the tenant slug and full key prefix, or empty strings if the format is invalid.
+func ParsePrefixedKey(apiKey string) (tenantSlug, keyPrefix string, ok bool) {
+	// Format: pk_{slug}_{entropy}
+	// The key prefix is: pk_{slug}_{first8chars of entropy}
+	if !strings.HasPrefix(apiKey, "pk_") {
+		return "", "", false
+	}
+
+	// Remove "pk_" prefix
+	rest := apiKey[3:]
+
+	// Find the second underscore (after slug)
+	underscoreIdx := strings.Index(rest, "_")
+	if underscoreIdx <= 0 {
+		return "", "", false
+	}
+
+	slug := rest[:underscoreIdx]
+	if slug == "" {
+		return "", "", false
+	}
+
+	entropy := rest[underscoreIdx+1:]
+	if len(entropy) < 8 {
+		return "", "", false
+	}
+
+	// Key prefix is pk_{slug}_{first 8 chars of entropy}
+	prefix := fmt.Sprintf("pk_%s_%s", slug, entropy[:8])
+
+	return slug, prefix, true
+}
+
+// Validate validates an API key via the Control Plane RPC.
+// Returns the validation result if the key is in pk_{slug}_{...} format and valid.
+// Returns ErrNotPrefixedKey if the key format is not recognized (caller should fall back to legacy).
+func (v *RPCAPIKeyValidator) Validate(ctx context.Context, apiKey string) (*APIKeyValidationResult, error) {
+	slug, keyPrefix, ok := ParsePrefixedKey(apiKey)
+	if !ok {
+		return nil, ErrNotPrefixedKey
+	}
+
+	// Check cache first
+	if cached := v.getCached(keyPrefix); cached != nil {
+		return cached, nil
+	}
+
+	// Resolve slug -> tenant_id
+	tenantID, err := v.slugResolver.ResolveSlug(ctx, slug)
+	if err != nil {
+		return nil, fmt.Errorf("resolve tenant slug %q: %w", slug, err)
+	}
+
+	// Call Control Plane ValidateAPIKey RPC with tenant context
+	// The tenant ID is passed via gRPC metadata so the server can set search_path
+	md := metadata.Pairs("x-tenant-id", tenantID.String())
+	rpcCtx := metadata.NewOutgoingContext(ctx, md)
+
+	resp, err := v.client.ValidateAPIKey(rpcCtx, &controlplanev1.ValidateAPIKeyRequest{
+		KeyPrefix:    keyPrefix,
+		PlaintextKey: apiKey,
+	}, grpc.WaitForReady(false))
+	if err != nil {
+		return nil, fmt.Errorf("validate API key via control plane: %w", err)
+	}
+
+	result := &APIKeyValidationResult{
+		Valid:        resp.GetValid(),
+		TenantID:     resp.GetTenantId(),
+		Identity:     resp.GetIdentity(),
+		Scopes:       resp.GetScopes(),
+		RateLimitRPS: resp.GetRateLimitRps(),
+	}
+
+	// Cache the result (even if invalid, to prevent brute force)
+	v.setCache(keyPrefix, result)
+
+	return result, nil
+}
+
+// AllowRequest checks if the given key prefix is within its rate limit.
+func (v *RPCAPIKeyValidator) AllowRequest(keyPrefix string, rateLimitRPS int32) bool {
+	if rateLimitRPS <= 0 {
+		rateLimitRPS = 100 // default
+	}
+
+	now := time.Now()
+
+	value, loaded := v.limiters.Load(keyPrefix)
+	if loaded {
+		entry, ok := value.(*rpcRateLimiterEntry)
+		if !ok {
+			return false
+		}
+		entry.mu.Lock()
+		entry.lastAccess = now
+		entry.mu.Unlock()
+		return entry.limiter.Allow()
+	}
+
+	limiter := rate.NewLimiter(rate.Limit(rateLimitRPS), int(rateLimitRPS)*2)
+	entry := &rpcRateLimiterEntry{
+		limiter:    limiter,
+		lastAccess: now,
+	}
+
+	actual, loaded := v.limiters.LoadOrStore(keyPrefix, entry)
+	if loaded {
+		existingEntry, ok := actual.(*rpcRateLimiterEntry)
+		if !ok {
+			return false
+		}
+		existingEntry.mu.Lock()
+		existingEntry.lastAccess = now
+		existingEntry.mu.Unlock()
+		return existingEntry.limiter.Allow()
+	}
+
+	return entry.limiter.Allow()
+}
+
+func (v *RPCAPIKeyValidator) getCached(keyPrefix string) *APIKeyValidationResult {
+	value, ok := v.cache.Load(keyPrefix)
+	if !ok {
+		return nil
+	}
+
+	cached, ok := value.(*cachedValidation)
+	if !ok {
+		return nil
+	}
+
+	if time.Now().After(cached.expiresAt) {
+		v.cache.Delete(keyPrefix)
+		return nil
+	}
+
+	return cached.result
+}
+
+func (v *RPCAPIKeyValidator) setCache(keyPrefix string, result *APIKeyValidationResult) {
+	v.cache.Store(keyPrefix, &cachedValidation{
+		result:    result,
+		expiresAt: time.Now().Add(v.cacheTTL),
+	})
+}
+
+func (v *RPCAPIKeyValidator) cleanupLoop() {
+	defer v.wg.Done()
+
+	ticker := time.NewTicker(v.cleanupInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-v.stopCh:
+			return
+		case <-ticker.C:
+			v.cleanupExpired()
+		}
+	}
+}
+
+func (v *RPCAPIKeyValidator) cleanupExpired() {
+	now := time.Now()
+
+	// Clean up expired cache entries
+	v.cache.Range(func(key, value interface{}) bool {
+		cached, ok := value.(*cachedValidation)
+		if !ok || now.After(cached.expiresAt) {
+			v.cache.Delete(key)
+		}
+		return true
+	})
+
+	// Clean up idle rate limiters
+	v.limiters.Range(func(key, value interface{}) bool {
+		entry, ok := value.(*rpcRateLimiterEntry)
+		if !ok {
+			return true
+		}
+		entry.mu.Lock()
+		idle := now.Sub(entry.lastAccess) > v.limiterIdleTimeout
+		entry.mu.Unlock()
+		if idle {
+			v.limiters.Delete(key)
+		}
+		return true
+	})
+}

--- a/services/gateway/auth/rpc_apikey_validator_test.go
+++ b/services/gateway/auth/rpc_apikey_validator_test.go
@@ -1,0 +1,466 @@
+package auth
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+func TestParsePrefixedKey(t *testing.T) {
+	tests := []struct {
+		name         string
+		apiKey       string
+		expectSlug   string
+		expectPrefix string
+		expectOK     bool
+	}{
+		{
+			name:         "valid key",
+			apiKey:       "pk_acme_abc12345xyz67890abcdef",
+			expectSlug:   "acme",
+			expectPrefix: "pk_acme_abc12345",
+			expectOK:     true,
+		},
+		{
+			name:         "valid key with longer slug",
+			apiKey:       "pk_my-company_abcdefgh1234567890",
+			expectSlug:   "my-company",
+			expectPrefix: "pk_my-company_abcdefgh",
+			expectOK:     true,
+		},
+		{
+			name:         "minimum entropy length",
+			apiKey:       "pk_acme_12345678",
+			expectSlug:   "acme",
+			expectPrefix: "pk_acme_12345678",
+			expectOK:     true,
+		},
+		{
+			name:     "not prefixed key",
+			apiKey:   "regular-api-key",
+			expectOK: false,
+		},
+		{
+			name:     "empty string",
+			apiKey:   "",
+			expectOK: false,
+		},
+		{
+			name:     "only prefix",
+			apiKey:   "pk_",
+			expectOK: false,
+		},
+		{
+			name:     "no entropy",
+			apiKey:   "pk_acme_",
+			expectOK: false,
+		},
+		{
+			name:     "entropy too short",
+			apiKey:   "pk_acme_1234567",
+			expectOK: false,
+		},
+		{
+			name:     "empty slug",
+			apiKey:   "pk__abc12345xyz67890",
+			expectOK: false,
+		},
+		{
+			name:     "missing second underscore",
+			apiKey:   "pk_acmeabc12345xyz67890",
+			expectOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			slug, prefix, ok := ParsePrefixedKey(tt.apiKey)
+			assert.Equal(t, tt.expectOK, ok)
+			if ok {
+				assert.Equal(t, tt.expectSlug, slug)
+				assert.Equal(t, tt.expectPrefix, prefix)
+			}
+		})
+	}
+}
+
+// mockAuthServiceClient is a mock for the gRPC AuthServiceClient.
+type mockAuthServiceClient struct {
+	response  *controlplanev1.ValidateAPIKeyResponse
+	err       error
+	callCount atomic.Int32
+}
+
+func (m *mockAuthServiceClient) ValidateAPIKey(_ context.Context, _ *controlplanev1.ValidateAPIKeyRequest, _ ...grpc.CallOption) (*controlplanev1.ValidateAPIKeyResponse, error) {
+	m.callCount.Add(1)
+	return m.response, m.err
+}
+
+// mockSlugResolver is a mock for the SlugResolver interface.
+type mockSlugResolver struct {
+	tenantID tenant.TenantID
+	err      error
+}
+
+func (m *mockSlugResolver) ResolveSlug(_ context.Context, _ string) (tenant.TenantID, error) {
+	return m.tenantID, m.err
+}
+
+func TestRPCAPIKeyValidator_Validate(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("valid key", func(t *testing.T) {
+		client := &mockAuthServiceClient{
+			response: &controlplanev1.ValidateAPIKeyResponse{
+				Valid:        true,
+				TenantId:     "test_tenant",
+				Identity:     "Alice",
+				Scopes:       []string{"read", "write"},
+				RateLimitRps: 50,
+			},
+		}
+		resolver := &mockSlugResolver{
+			tenantID: tenant.MustNewTenantID("test_tenant"),
+		}
+
+		v := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       client,
+			SlugResolver: resolver,
+			Logger:       logger,
+		})
+		defer v.Close()
+
+		result, err := v.Validate(context.Background(), "pk_acme_abc12345xyz67890abcdef")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.Valid)
+		assert.Equal(t, "test_tenant", result.TenantID)
+		assert.Equal(t, "Alice", result.Identity)
+		assert.Equal(t, []string{"read", "write"}, result.Scopes)
+		assert.Equal(t, int32(50), result.RateLimitRPS)
+	})
+
+	t.Run("non-prefixed key returns ErrNotPrefixedKey", func(t *testing.T) {
+		client := &mockAuthServiceClient{}
+		resolver := &mockSlugResolver{}
+
+		v := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       client,
+			SlugResolver: resolver,
+			Logger:       logger,
+		})
+		defer v.Close()
+
+		result, err := v.Validate(context.Background(), "regular-api-key")
+		require.ErrorIs(t, err, ErrNotPrefixedKey)
+		assert.Nil(t, result)
+	})
+
+	t.Run("invalid key from RPC", func(t *testing.T) {
+		client := &mockAuthServiceClient{
+			response: &controlplanev1.ValidateAPIKeyResponse{
+				Valid: false,
+			},
+		}
+		resolver := &mockSlugResolver{
+			tenantID: tenant.MustNewTenantID("test_tenant"),
+		}
+
+		v := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       client,
+			SlugResolver: resolver,
+			Logger:       logger,
+		})
+		defer v.Close()
+
+		result, err := v.Validate(context.Background(), "pk_acme_abc12345xyz67890abcdef")
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.Valid)
+	})
+
+	t.Run("cached result avoids RPC call", func(t *testing.T) {
+		client := &mockAuthServiceClient{
+			response: &controlplanev1.ValidateAPIKeyResponse{
+				Valid:    true,
+				TenantId: "test_tenant",
+				Identity: "Alice",
+			},
+		}
+		resolver := &mockSlugResolver{
+			tenantID: tenant.MustNewTenantID("test_tenant"),
+		}
+
+		v := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       client,
+			SlugResolver: resolver,
+			CacheTTL:     5 * time.Minute,
+			Logger:       logger,
+		})
+		defer v.Close()
+
+		// First call
+		result1, err := v.Validate(context.Background(), "pk_acme_abc12345xyz67890abcdef")
+		require.NoError(t, err)
+		assert.True(t, result1.Valid)
+
+		// Second call should use cache
+		result2, err := v.Validate(context.Background(), "pk_acme_abc12345xyz67890abcdef")
+		require.NoError(t, err)
+		assert.True(t, result2.Valid)
+
+		// Only one RPC call should have been made
+		assert.Equal(t, int32(1), client.callCount.Load())
+	})
+
+	t.Run("slug resolution failure returns error", func(t *testing.T) {
+		client := &mockAuthServiceClient{}
+		resolver := &mockSlugResolver{
+			err: assert.AnError,
+		}
+
+		v := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       client,
+			SlugResolver: resolver,
+			Logger:       logger,
+		})
+		defer v.Close()
+
+		_, err := v.Validate(context.Background(), "pk_acme_abc12345xyz67890abcdef")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "resolve tenant slug")
+	})
+}
+
+func TestRPCAPIKeyValidator_AllowRequest(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("allows within rate limit", func(t *testing.T) {
+		v := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       &mockAuthServiceClient{},
+			SlugResolver: &mockSlugResolver{},
+			Logger:       logger,
+		})
+		defer v.Close()
+
+		// With rate_limit_rps=10, burst=20
+		for i := 0; i < 10; i++ {
+			assert.True(t, v.AllowRequest("pk_acme_abc12345", 10))
+		}
+	})
+
+	t.Run("rejects when rate exceeded", func(t *testing.T) {
+		v := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       &mockAuthServiceClient{},
+			SlugResolver: &mockSlugResolver{},
+			Logger:       logger,
+		})
+		defer v.Close()
+
+		// Exhaust burst (rate=1, burst=2)
+		v.AllowRequest("pk_test_12345678", 1)
+		v.AllowRequest("pk_test_12345678", 1)
+
+		// Should be rejected
+		assert.False(t, v.AllowRequest("pk_test_12345678", 1))
+	})
+}
+
+func TestCombinedAuthMiddleware_RPCAPIKey(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	t.Run("RPC validation for pk_ prefixed keys", func(t *testing.T) {
+		client := &mockAuthServiceClient{
+			response: &controlplanev1.ValidateAPIKeyResponse{
+				Valid:        true,
+				TenantId:     "test_tenant",
+				Identity:     "Alice",
+				Scopes:       []string{"read"},
+				RateLimitRps: 1000,
+			},
+		}
+		resolver := &mockSlugResolver{
+			tenantID: tenant.MustNewTenantID("test_tenant"),
+		}
+
+		rpcValidator := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       client,
+			SlugResolver: resolver,
+			Logger:       logger,
+		})
+
+		config := CombinedAuthConfig{
+			RPCValidator: rpcValidator,
+			Logger:       logger,
+		}
+
+		middleware, err := NewCombinedAuthMiddleware(config)
+		require.NoError(t, err)
+		defer middleware.Close()
+
+		var capturedCtx context.Context
+		handler := middleware.Handler(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			capturedCtx = r.Context()
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req.Header.Set("X-API-Key", "pk_acme_abc12345xyz67890abcdef")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "Alice", GetAPIKeyIdentity(capturedCtx))
+
+		// Verify tenant was injected
+		tenantID, ok := tenant.FromContext(capturedCtx)
+		assert.True(t, ok)
+		assert.Equal(t, "test_tenant", tenantID.String())
+
+		// Verify scopes were injected
+		scopes, ok := GetScopesFromContext(capturedCtx)
+		assert.True(t, ok)
+		assert.Equal(t, []string{"read"}, scopes)
+
+		// Note: X-API-Key header stripping is handled by the proxy director
+	})
+
+	t.Run("legacy key falls back to env-var validation", func(t *testing.T) {
+		client := &mockAuthServiceClient{}
+		resolver := &mockSlugResolver{}
+
+		rpcValidator := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       client,
+			SlugResolver: resolver,
+			Logger:       logger,
+		})
+
+		config := CombinedAuthConfig{
+			APIKeyConfig: APIKeyConfig{
+				APIKeys: map[string]string{"legacy-key-123": "service-a"},
+			},
+			RPCValidator: rpcValidator,
+			Logger:       logger,
+		}
+
+		middleware, err := NewCombinedAuthMiddleware(config)
+		require.NoError(t, err)
+		defer middleware.Close()
+
+		var capturedIdentity string
+		handler := middleware.Handler(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			capturedIdentity = GetAPIKeyIdentity(r.Context())
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req.Header.Set("X-API-Key", "legacy-key-123")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "service-a", capturedIdentity)
+		// No RPC call should have been made
+		assert.Equal(t, int32(0), client.callCount.Load())
+	})
+
+	t.Run("invalid pk_ key returns 401", func(t *testing.T) {
+		client := &mockAuthServiceClient{
+			response: &controlplanev1.ValidateAPIKeyResponse{
+				Valid: false,
+			},
+		}
+		resolver := &mockSlugResolver{
+			tenantID: tenant.MustNewTenantID("test_tenant"),
+		}
+
+		rpcValidator := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       client,
+			SlugResolver: resolver,
+			Logger:       logger,
+		})
+
+		config := CombinedAuthConfig{
+			RPCValidator: rpcValidator,
+			Logger:       logger,
+		}
+
+		middleware, err := NewCombinedAuthMiddleware(config)
+		require.NoError(t, err)
+		defer middleware.Close()
+
+		handler := middleware.Handler(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+			t.Error("handler should not be called for invalid key")
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req.Header.Set("X-API-Key", "pk_acme_abc12345xyz67890abcdef")
+		rr := httptest.NewRecorder()
+
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("RPC rate limit exceeded returns 429", func(t *testing.T) {
+		client := &mockAuthServiceClient{
+			response: &controlplanev1.ValidateAPIKeyResponse{
+				Valid:        true,
+				TenantId:     "test_tenant",
+				Identity:     "Alice",
+				RateLimitRps: 1, // Very low
+			},
+		}
+		resolver := &mockSlugResolver{
+			tenantID: tenant.MustNewTenantID("test_tenant"),
+		}
+
+		rpcValidator := NewRPCAPIKeyValidator(RPCValidatorConfig{
+			Client:       client,
+			SlugResolver: resolver,
+			Logger:       logger,
+		})
+
+		config := CombinedAuthConfig{
+			RPCValidator: rpcValidator,
+			Logger:       logger,
+		}
+
+		middleware, err := NewCombinedAuthMiddleware(config)
+		require.NoError(t, err)
+		defer middleware.Close()
+
+		handler := middleware.Handler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		apiKey := "pk_acme_abc12345xyz67890abcdef"
+
+		// Exhaust rate limit (burst = rate*2 = 2)
+		for i := 0; i < 2; i++ {
+			req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+			req.Header.Set("X-API-Key", apiKey)
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusOK, rr.Code, "request %d should succeed", i+1)
+		}
+
+		// Next request should be rate limited
+		req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+		req.Header.Set("X-API-Key", apiKey)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusTooManyRequests, rr.Code)
+	})
+}

--- a/services/gateway/proxy.go
+++ b/services/gateway/proxy.go
@@ -83,6 +83,9 @@ func NewProxyHandler(backends []BackendRoute) *ProxyHandler {
 			req.Header.Del(HeaderAuthMethod)
 			req.Header.Del(HeaderAuthRoles)
 
+			// SECURITY: Strip X-API-Key header to prevent credential leakage to backends.
+			req.Header.Del(auth.APIKeyHeader)
+
 			// Add identity headers if the request was authenticated
 			addIdentityHeaders(req)
 		}
@@ -173,8 +176,12 @@ func addIdentityHeaders(req *http.Request) {
 	if identity := auth.GetAPIKeyIdentity(ctx); identity != "" {
 		req.Header.Set(HeaderUserID, identity)
 		req.Header.Set(HeaderAuthMethod, AuthMethodAPIKey)
-		// Note: API keys don't have tenant ID in the current implementation
-		// Tenant context may be resolved separately by TenantResolverMiddleware
+
+		// For RPC-validated API keys, tenant ID is available in context
+		if tenantID, ok := auth.GetTenantIDFromContext(ctx); ok && tenantID != "" {
+			req.Header.Set(HeaderTenantID, tenantID)
+		}
+
 		return
 	}
 


### PR DESCRIPTION
## Summary

Implements API key validation in the Gateway via the Control Plane gRPC AuthService, enabling `pk_{slug}_{entropy}` format API keys to be verified against the tenant-scoped database with caching and per-key rate limiting.

- Define `AuthService.ValidateAPIKey` gRPC RPC in `auth.proto` returning validation result with tenant_id, identity, scopes, and rate_limit_rps
- Implement Control Plane `AuthServiceServer` that delegates to the staff service using constant-time SHA-256 hash comparison within tenant-scoped DB transactions
- Add `RPCAPIKeyValidator` to Gateway that parses `pk_{slug}_{entropy}` keys, resolves tenant slugs, calls the Control Plane RPC, and caches results with 5-minute TTL
- Implement per-key token bucket rate limiting using `rate_limit_rps` from the validation response
- Update `CombinedAuthMiddleware` to route `pk_` prefixed keys to RPC validation while maintaining backward compatibility with legacy env-var API keys
- Strip `X-API-Key` header in proxy Director before forwarding to backends
- Inject tenant_id, identity, and scopes into request context on successful validation

## Technical Details

### Key Format
```
pk_{tenant_slug}_{entropy}
     ^              ^
     |              |
     slug used      full key hashed with SHA-256
     to resolve     and compared in constant time
     tenant ID
```

### Authentication Flow
1. Gateway receives request with `X-API-Key: pk_acme_abc12345xyz67890`
2. `ParsePrefixedKey` extracts slug (`acme`) and prefix (`pk_acme_abc12345`)
3. Check in-memory cache (5-min TTL) by key prefix
4. If cache miss: resolve slug to tenant ID via tenant registry, call Control Plane `ValidateAPIKey` RPC
5. Control Plane looks up key by prefix in tenant schema, verifies SHA-256 hash, checks user status and expiry
6. Cache result, check per-key rate limit, inject context values, forward to backend

### Backward Compatibility
- Legacy API keys (no `pk_` prefix) continue to work via env-var map lookup
- Non-prefixed keys skip RPC validation entirely

## Test Plan

- [x] Unit tests for `ParsePrefixedKey` (10 cases: valid keys, edge cases, invalid formats)
- [x] Unit tests for `RPCAPIKeyValidator.Validate` (5 cases: valid key, non-prefixed, invalid, caching, slug resolution error)
- [x] Unit tests for `AllowRequest` rate limiting (2 cases: within limit, exceeded)
- [x] Integration tests for `CombinedAuthMiddleware` (4 cases: RPC validation, legacy fallback, invalid key 401, rate limit 429)
- [x] Integration tests for Control Plane `AuthService` against CockroachDB (7 cases: valid key, invalid key, missing tenant, empty fields, suspended user, expired key, email fallback)
- [x] All existing gateway and proxy tests continue to pass