### PR TITLE
feat: Build ApplyManifest Planner for ordered gRPC call sequence

### DIFF
--- a/services/control-plane/internal/planner/manifest_planner.go
+++ b/services/control-plane/internal/planner/manifest_planner.go
@@ -1,0 +1,155 @@
+package planner
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
+)
+
+// ErrNilDiffPlan is returned when the diff plan is nil.
+var ErrNilDiffPlan = errors.New("diff plan cannot be nil")
+
+// ErrNoMethodMapping is returned when no gRPC method mapping exists for a resource type/action combination.
+var ErrNoMethodMapping = errors.New("no gRPC method mapping")
+
+// ManifestPlanner transforms a DiffPlan into a dependency-ordered
+// ExecutionPlan of gRPC calls. It assigns each action to a phase
+// based on resource type dependencies and maps actions to the
+// appropriate gRPC service methods.
+type ManifestPlanner struct{}
+
+// NewManifestPlanner creates a new ManifestPlanner.
+func NewManifestPlanner() *ManifestPlanner {
+	return &ManifestPlanner{}
+}
+
+// Plan transforms a DiffPlan into an ordered ExecutionPlan.
+// Only actionable changes (CREATE/UPDATE/DELETE) are included;
+// NO_CHANGE actions are filtered out.
+func (p *ManifestPlanner) Plan(diffPlan *differ.DiffPlan, tenantID, manifestVersion string, dryRun bool) (*ExecutionPlan, error) {
+	if diffPlan == nil {
+		return nil, ErrNilDiffPlan
+	}
+
+	plan := &ExecutionPlan{
+		TenantID:        tenantID,
+		ManifestVersion: manifestVersion,
+		DryRun:          dryRun,
+	}
+
+	for _, action := range diffPlan.Actions {
+		if action.Action == differ.ActionNoChange {
+			continue
+		}
+
+		call, err := p.mapToCall(action, tenantID, manifestVersion, dryRun)
+		if err != nil {
+			return nil, fmt.Errorf("mapping action %s %s: %w", action.ResourceType, action.ResourceCode, err)
+		}
+
+		plan.Calls = append(plan.Calls, call)
+	}
+
+	// Sort by phase, then resource type, then resource code for determinism.
+	sort.Slice(plan.Calls, func(i, j int) bool {
+		if plan.Calls[i].Phase != plan.Calls[j].Phase {
+			return plan.Calls[i].Phase < plan.Calls[j].Phase
+		}
+		if plan.Calls[i].ResourceType != plan.Calls[j].ResourceType {
+			return plan.Calls[i].ResourceType < plan.Calls[j].ResourceType
+		}
+		return plan.Calls[i].ResourceID < plan.Calls[j].ResourceID
+	})
+
+	return plan, nil
+}
+
+// mapToCall converts a single PlannedAction from the differ into a PlannedCall
+// with the correct phase assignment and gRPC method mapping.
+func (p *ManifestPlanner) mapToCall(action differ.PlannedAction, tenantID, manifestVersion string, dryRun bool) (PlannedCall, error) {
+	phase := phaseForResource(action.ResourceType)
+	method, err := grpcMethodFor(action.ResourceType, action.Action)
+	if err != nil {
+		return PlannedCall{}, err
+	}
+
+	return PlannedCall{
+		Phase:          phase,
+		ResourceType:   action.ResourceType,
+		ResourceID:     action.ResourceCode,
+		Action:         action.Action,
+		GRPCMethod:     method,
+		IdempotencyKey: GenerateIdempotencyKey(tenantID, manifestVersion, action.ResourceType, action.ResourceCode, action.Action),
+		Description:    action.Description,
+		DryRun:         dryRun,
+	}, nil
+}
+
+// phaseForResource returns the execution phase for a given resource type.
+func phaseForResource(rt differ.ResourceType) Phase {
+	switch rt {
+	case differ.ResourceInstrument:
+		return PhaseInstruments
+	case differ.ResourceAccountType:
+		return PhaseAccountTypes
+	case differ.ResourceValuationRule:
+		return PhaseValuationRules
+	case differ.ResourceSaga:
+		return PhaseSagas
+	default:
+		return PhaseSeedData
+	}
+}
+
+// grpcMethodFor returns the gRPC method for a resource type and action.
+func grpcMethodFor(rt differ.ResourceType, action differ.ActionType) (GRPCMethod, error) {
+	key := methodKey{rt, action}
+	method, ok := grpcMethodMap[key]
+	if !ok {
+		return "", fmt.Errorf("%w for %s/%s", ErrNoMethodMapping, rt, action)
+	}
+	return method, nil
+}
+
+type methodKey struct {
+	resourceType differ.ResourceType
+	actionType   differ.ActionType
+}
+
+// grpcMethodMap maps (resource type, action) pairs to gRPC methods.
+var grpcMethodMap = map[methodKey]GRPCMethod{
+	// Instruments
+	{differ.ResourceInstrument, differ.ActionCreate}: MethodRegisterInstrument,
+	{differ.ResourceInstrument, differ.ActionUpdate}: MethodUpdateInstrument,
+	{differ.ResourceInstrument, differ.ActionDelete}: MethodDeprecateInstrument,
+
+	// Account Types: CREATE maps to InitiateAccount on Internal Bank Account Service.
+	// Account types are registered as reference data AND provisioned as internal bank accounts.
+	{differ.ResourceAccountType, differ.ActionCreate}: MethodInitiateAccount,
+	{differ.ResourceAccountType, differ.ActionUpdate}: MethodInitiateAccount,
+	{differ.ResourceAccountType, differ.ActionDelete}: MethodInitiateAccount,
+
+	// Valuation Rules: mapped to Reference Data Service instrument operations
+	// (valuation rules are registered alongside instrument definitions).
+	{differ.ResourceValuationRule, differ.ActionCreate}: MethodRegisterInstrument,
+	{differ.ResourceValuationRule, differ.ActionUpdate}: MethodUpdateInstrument,
+	{differ.ResourceValuationRule, differ.ActionDelete}: MethodDeprecateInstrument,
+
+	// Sagas
+	{differ.ResourceSaga, differ.ActionCreate}: MethodCreateSagaDraft,
+	{differ.ResourceSaga, differ.ActionUpdate}: MethodUpdateSagaDefinition,
+	{differ.ResourceSaga, differ.ActionDelete}: MethodDeprecateSaga,
+}
+
+// GenerateIdempotencyKey produces a deterministic SHA-256 based idempotency key.
+// The key is derived from: tenant_id + manifest_version + resource_type + resource_id + action.
+// This ensures the same operation on the same resource produces the same key,
+// enabling safe retry without duplication.
+func GenerateIdempotencyKey(tenantID, manifestVersion string, resourceType differ.ResourceType, resourceID string, action differ.ActionType) string {
+	input := fmt.Sprintf("%s|%s|%s|%s|%s", tenantID, manifestVersion, resourceType, resourceID, action)
+	hash := sha256.Sum256([]byte(input))
+	return fmt.Sprintf("%x", hash)
+}

--- a/services/control-plane/internal/planner/manifest_planner_test.go
+++ b/services/control-plane/internal/planner/manifest_planner_test.go
@@ -1,0 +1,541 @@
+package planner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlan_NilDiffPlan_ReturnsError(t *testing.T) {
+	p := NewManifestPlanner()
+	_, err := p.Plan(nil, "tenant-1", "1.0", false)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrNilDiffPlan)
+}
+
+func TestPlan_EmptyDiffPlan_EmptyExecutionPlan(t *testing.T) {
+	p := NewManifestPlanner()
+	plan, err := p.Plan(&differ.DiffPlan{}, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	assert.Empty(t, plan.Calls)
+	assert.Equal(t, "tenant-1", plan.TenantID)
+	assert.Equal(t, "1.0", plan.ManifestVersion)
+}
+
+func TestPlan_NoChangeActionsFiltered(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionNoChange},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "CURRENT", Action: differ.ActionNoChange},
+			{ResourceType: differ.ResourceSaga, ResourceCode: "test_saga", Action: differ.ActionNoChange},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	assert.Empty(t, plan.Calls, "NO_CHANGE actions should be filtered out")
+}
+
+func TestPlan_InstrumentsInPhase1(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate, Description: "Create instrument GBP"},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "KWH", Action: differ.ActionUpdate, Description: "Update instrument KWH"},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "EUR", Action: differ.ActionDelete, Description: "Delete instrument EUR"},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	assert.Len(t, plan.Calls, 3)
+
+	for _, call := range plan.Calls {
+		assert.Equal(t, PhaseInstruments, call.Phase, "all instrument actions should be in Phase 1")
+	}
+}
+
+func TestPlan_AccountTypesInPhase2(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "CURRENT", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, PhaseAccountTypes, plan.Calls[0].Phase)
+}
+
+func TestPlan_ValuationRulesInPhase3(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceValuationRule, ResourceCode: "KWH->GBP", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, PhaseValuationRules, plan.Calls[0].Phase)
+}
+
+func TestPlan_SagasInPhase4(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceSaga, ResourceCode: "process_settlement", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 1)
+	assert.Equal(t, PhaseSagas, plan.Calls[0].Phase)
+}
+
+func TestPlan_PhaseOrdering_InstrumentsBeforeAccountTypes(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			// Intentionally reverse order to verify sorting
+			{ResourceType: differ.ResourceSaga, ResourceCode: "saga_a", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "CURRENT", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceValuationRule, ResourceCode: "KWH->GBP", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 4)
+
+	// Verify phase ordering: instruments (1) < account types (2) < valuation rules (3) < sagas (4)
+	for i := 1; i < len(plan.Calls); i++ {
+		assert.LessOrEqual(t, int(plan.Calls[i-1].Phase), int(plan.Calls[i].Phase),
+			"calls should be sorted by phase: %v before %v", plan.Calls[i-1], plan.Calls[i])
+	}
+}
+
+func TestPlan_GRPCMethodMapping_Instruments(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "KWH", Action: differ.ActionUpdate},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "EUR", Action: differ.ActionDelete},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+
+	callsByCode := indexCallsByResourceID(plan.Calls)
+	assert.Equal(t, MethodRegisterInstrument, callsByCode["GBP"].GRPCMethod)
+	assert.Equal(t, MethodUpdateInstrument, callsByCode["KWH"].GRPCMethod)
+	assert.Equal(t, MethodDeprecateInstrument, callsByCode["EUR"].GRPCMethod)
+}
+
+func TestPlan_GRPCMethodMapping_AccountTypes(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "CURRENT", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+
+	callsByCode := indexCallsByResourceID(plan.Calls)
+	assert.Equal(t, MethodInitiateAccount, callsByCode["CURRENT"].GRPCMethod)
+}
+
+func TestPlan_GRPCMethodMapping_Sagas(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceSaga, ResourceCode: "deposit", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceSaga, ResourceCode: "withdrawal", Action: differ.ActionUpdate},
+			{ResourceType: differ.ResourceSaga, ResourceCode: "legacy", Action: differ.ActionDelete},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+
+	callsByCode := indexCallsByResourceID(plan.Calls)
+	assert.Equal(t, MethodCreateSagaDraft, callsByCode["deposit"].GRPCMethod)
+	assert.Equal(t, MethodUpdateSagaDefinition, callsByCode["withdrawal"].GRPCMethod)
+	assert.Equal(t, MethodDeprecateSaga, callsByCode["legacy"].GRPCMethod)
+}
+
+func TestPlan_IdempotencyKeys_Deterministic(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate},
+		},
+	}
+
+	plan1, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+
+	plan2, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, plan1.Calls[0].IdempotencyKey, plan2.Calls[0].IdempotencyKey,
+		"idempotency keys should be deterministic for same inputs")
+}
+
+func TestPlan_IdempotencyKeys_UniquePerResource(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "EUR", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	require.Len(t, plan.Calls, 2)
+
+	assert.NotEqual(t, plan.Calls[0].IdempotencyKey, plan.Calls[1].IdempotencyKey,
+		"different resources should have different idempotency keys")
+}
+
+func TestPlan_IdempotencyKeys_DifferentTenants(t *testing.T) {
+	key1 := GenerateIdempotencyKey("tenant-1", "1.0", differ.ResourceInstrument, "GBP", differ.ActionCreate)
+	key2 := GenerateIdempotencyKey("tenant-2", "1.0", differ.ResourceInstrument, "GBP", differ.ActionCreate)
+
+	assert.NotEqual(t, key1, key2, "different tenants should produce different keys")
+}
+
+func TestPlan_IdempotencyKeys_DifferentVersions(t *testing.T) {
+	key1 := GenerateIdempotencyKey("tenant-1", "1.0", differ.ResourceInstrument, "GBP", differ.ActionCreate)
+	key2 := GenerateIdempotencyKey("tenant-1", "2.0", differ.ResourceInstrument, "GBP", differ.ActionCreate)
+
+	assert.NotEqual(t, key1, key2, "different manifest versions should produce different keys")
+}
+
+func TestPlan_IdempotencyKeys_DifferentActions(t *testing.T) {
+	key1 := GenerateIdempotencyKey("tenant-1", "1.0", differ.ResourceInstrument, "GBP", differ.ActionCreate)
+	key2 := GenerateIdempotencyKey("tenant-1", "1.0", differ.ResourceInstrument, "GBP", differ.ActionUpdate)
+
+	assert.NotEqual(t, key1, key2, "different actions should produce different keys")
+}
+
+func TestPlan_IdempotencyKey_Format(t *testing.T) {
+	key := GenerateIdempotencyKey("tenant-1", "1.0", differ.ResourceInstrument, "GBP", differ.ActionCreate)
+	assert.Len(t, key, 64, "SHA-256 hex string should be 64 characters")
+	assert.Regexp(t, "^[a-f0-9]{64}$", key, "should be lowercase hex")
+}
+
+func TestPlan_DryRun_PropagatedToAllCalls(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "CURRENT", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", true)
+	require.NoError(t, err)
+	assert.True(t, plan.DryRun)
+
+	for _, call := range plan.Calls {
+		assert.True(t, call.DryRun, "all calls should have DryRun=true when plan is dry run")
+	}
+}
+
+func TestPlan_DryRun_False(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	assert.False(t, plan.DryRun)
+
+	for _, call := range plan.Calls {
+		assert.False(t, call.DryRun)
+	}
+}
+
+func TestPlan_DeterministicOrdering(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceSaga, ResourceCode: "z_saga", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "ZZZ", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "AAA", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "CURRENT", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceSaga, ResourceCode: "a_saga", Action: differ.ActionCreate},
+		},
+	}
+
+	// Plan multiple times to verify determinism
+	var prevPlan *ExecutionPlan
+	for i := 0; i < 5; i++ {
+		plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+		require.NoError(t, err)
+
+		if prevPlan != nil {
+			for j := range plan.Calls {
+				assert.Equal(t, prevPlan.Calls[j].ResourceID, plan.Calls[j].ResourceID,
+					"call ordering should be deterministic across runs")
+			}
+		}
+		prevPlan = plan
+	}
+}
+
+func TestPlan_DescriptionPreserved(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate, Description: "Create instrument GBP (British Pound Sterling)"},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+	assert.Equal(t, "Create instrument GBP (British Pound Sterling)", plan.Calls[0].Description)
+}
+
+func TestPlan_MixedActions_CorrectPhaseAssignment(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "EUR", Action: differ.ActionNoChange},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "CURRENT", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceValuationRule, ResourceCode: "KWH->GBP", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceSaga, ResourceCode: "deposit", Action: differ.ActionCreate},
+			{ResourceType: differ.ResourceSaga, ResourceCode: "withdrawal", Action: differ.ActionNoChange},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "tenant-1", "1.0", false)
+	require.NoError(t, err)
+
+	// Should have 4 calls (2 NO_CHANGE filtered)
+	assert.Len(t, plan.Calls, 4)
+
+	// Verify phase progression
+	for i := 1; i < len(plan.Calls); i++ {
+		assert.LessOrEqual(t, int(plan.Calls[i-1].Phase), int(plan.Calls[i].Phase))
+	}
+}
+
+// --- ExecutionPlan method tests ---
+
+func TestExecutionPlan_ByPhase(t *testing.T) {
+	plan := &ExecutionPlan{
+		Calls: []PlannedCall{
+			{Phase: PhaseInstruments, ResourceID: "GBP"},
+			{Phase: PhaseInstruments, ResourceID: "EUR"},
+			{Phase: PhaseAccountTypes, ResourceID: "CURRENT"},
+			{Phase: PhaseSagas, ResourceID: "deposit"},
+		},
+	}
+
+	byPhase := plan.ByPhase()
+	assert.Len(t, byPhase[PhaseInstruments], 2)
+	assert.Len(t, byPhase[PhaseAccountTypes], 1)
+	assert.Len(t, byPhase[PhaseSagas], 1)
+	assert.Empty(t, byPhase[PhaseValuationRules])
+}
+
+func TestExecutionPlan_Phases(t *testing.T) {
+	plan := &ExecutionPlan{
+		Calls: []PlannedCall{
+			{Phase: PhaseInstruments},
+			{Phase: PhaseInstruments},
+			{Phase: PhaseSagas},
+		},
+	}
+
+	phases := plan.Phases()
+	assert.Equal(t, []Phase{PhaseInstruments, PhaseSagas}, phases)
+}
+
+func TestExecutionPlan_Summary(t *testing.T) {
+	plan := &ExecutionPlan{
+		Calls: []PlannedCall{
+			{Action: differ.ActionCreate},
+			{Action: differ.ActionCreate},
+			{Action: differ.ActionUpdate},
+			{Action: differ.ActionDelete},
+		},
+	}
+
+	summary := plan.Summary()
+	assert.Contains(t, summary, "4 calls")
+	assert.Contains(t, summary, "Creates: 2")
+	assert.Contains(t, summary, "Updates: 1")
+	assert.Contains(t, summary, "Deletes: 1")
+}
+
+func TestExecutionPlan_Summary_DryRun(t *testing.T) {
+	plan := &ExecutionPlan{
+		DryRun: true,
+		Calls: []PlannedCall{
+			{Action: differ.ActionCreate},
+		},
+	}
+
+	summary := plan.Summary()
+	assert.Contains(t, summary, "[DRY RUN]")
+}
+
+func TestExecutionPlan_Visualize(t *testing.T) {
+	plan := &ExecutionPlan{
+		TenantID:        "acme-energy",
+		ManifestVersion: "1.0",
+		Calls: []PlannedCall{
+			{Phase: PhaseInstruments, ResourceType: differ.ResourceInstrument, ResourceID: "GBP", Action: differ.ActionCreate, GRPCMethod: MethodRegisterInstrument, Description: "Create instrument GBP"},
+			{Phase: PhaseAccountTypes, ResourceType: differ.ResourceAccountType, ResourceID: "CURRENT", Action: differ.ActionCreate, GRPCMethod: MethodInitiateAccount, Description: "Create account type CURRENT"},
+			{Phase: PhaseSagas, ResourceType: differ.ResourceSaga, ResourceID: "deposit", Action: differ.ActionUpdate, GRPCMethod: MethodUpdateSagaDefinition, Description: "Update saga deposit"},
+		},
+	}
+
+	viz := plan.Visualize()
+
+	assert.Contains(t, viz, "EXECUTION PLAN")
+	assert.Contains(t, viz, "acme-energy")
+	assert.Contains(t, viz, "1.0")
+	assert.Contains(t, viz, "Total calls: 3")
+	assert.Contains(t, viz, "Phase 1: Instruments")
+	assert.Contains(t, viz, "Phase 2: Account Types")
+	assert.Contains(t, viz, "Phase 4: Saga Definitions")
+	assert.Contains(t, viz, "+ instrument GBP")
+	assert.Contains(t, viz, "+ account_type CURRENT")
+	assert.Contains(t, viz, "~ saga deposit")
+}
+
+func TestExecutionPlan_Visualize_DryRun(t *testing.T) {
+	plan := &ExecutionPlan{
+		TenantID:        "test",
+		ManifestVersion: "1.0",
+		DryRun:          true,
+		Calls: []PlannedCall{
+			{Phase: PhaseInstruments, ResourceType: differ.ResourceInstrument, ResourceID: "GBP", Action: differ.ActionCreate, GRPCMethod: MethodRegisterInstrument},
+		},
+	}
+
+	viz := plan.Visualize()
+	assert.Contains(t, viz, "DRY RUN")
+}
+
+func TestExecutionPlan_Visualize_DeleteActions(t *testing.T) {
+	plan := &ExecutionPlan{
+		TenantID:        "test",
+		ManifestVersion: "1.0",
+		Calls: []PlannedCall{
+			{Phase: PhaseInstruments, ResourceType: differ.ResourceInstrument, ResourceID: "EUR", Action: differ.ActionDelete, GRPCMethod: MethodDeprecateInstrument},
+		},
+	}
+
+	viz := plan.Visualize()
+	assert.Contains(t, viz, "- instrument EUR")
+}
+
+// --- PhaseLabel tests ---
+
+func TestPhaseLabel(t *testing.T) {
+	assert.Equal(t, "Instruments", PhaseLabel(PhaseInstruments))
+	assert.Equal(t, "Account Types", PhaseLabel(PhaseAccountTypes))
+	assert.Equal(t, "Valuation Rules", PhaseLabel(PhaseValuationRules))
+	assert.Equal(t, "Saga Definitions", PhaseLabel(PhaseSagas))
+	assert.Equal(t, "Seed Data", PhaseLabel(PhaseSeedData))
+	assert.True(t, strings.HasPrefix(PhaseLabel(Phase(99)), "Phase("))
+}
+
+// --- Full integration scenario ---
+
+func TestPlan_FullEnergyManifest(t *testing.T) {
+	p := NewManifestPlanner()
+
+	// Simulate a diff plan from applying the energy manifest for the first time
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate, Description: "Create instrument GBP (British Pound Sterling)"},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "KWH", Action: differ.ActionCreate, Description: "Create instrument KWH (Kilowatt Hour)"},
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "CARBON_CREDIT", Action: differ.ActionCreate, Description: "Create instrument CARBON_CREDIT"},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "ENERGY_TRADING", Action: differ.ActionCreate, Description: "Create account type ENERGY_TRADING"},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "CARBON_INVENTORY", Action: differ.ActionCreate, Description: "Create account type CARBON_INVENTORY"},
+			{ResourceType: differ.ResourceAccountType, ResourceCode: "SETTLEMENT", Action: differ.ActionCreate, Description: "Create account type SETTLEMENT"},
+			{ResourceType: differ.ResourceValuationRule, ResourceCode: "KWH->GBP", Action: differ.ActionCreate, Description: "Create valuation rule KWH->GBP"},
+			{ResourceType: differ.ResourceValuationRule, ResourceCode: "CARBON_CREDIT->GBP", Action: differ.ActionCreate, Description: "Create valuation rule CARBON_CREDIT->GBP"},
+			{ResourceType: differ.ResourceSaga, ResourceCode: "process_energy_settlement", Action: differ.ActionCreate, Description: "Create saga process_energy_settlement"},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "acme-energy", "1.0", false)
+	require.NoError(t, err)
+
+	assert.Len(t, plan.Calls, 9)
+
+	// All calls should have idempotency keys
+	for _, call := range plan.Calls {
+		assert.NotEmpty(t, call.IdempotencyKey)
+		assert.Len(t, call.IdempotencyKey, 64)
+	}
+
+	// Verify phase ordering is correct
+	byPhase := plan.ByPhase()
+	assert.Len(t, byPhase[PhaseInstruments], 3, "3 instruments in phase 1")
+	assert.Len(t, byPhase[PhaseAccountTypes], 3, "3 account types in phase 2")
+	assert.Len(t, byPhase[PhaseValuationRules], 2, "2 valuation rules in phase 3")
+	assert.Len(t, byPhase[PhaseSagas], 1, "1 saga in phase 4")
+
+	// Verify instruments come before account types
+	lastInstrumentPhase := plan.Calls[2].Phase // 3rd call should be last instrument
+	firstAccountPhase := plan.Calls[3].Phase   // 4th call should be first account type
+	assert.Less(t, int(lastInstrumentPhase), int(firstAccountPhase),
+		"instruments must complete before account types")
+}
+
+func TestPlan_FullEnergyManifest_DryRun(t *testing.T) {
+	p := NewManifestPlanner()
+	diffPlan := &differ.DiffPlan{
+		Actions: []differ.PlannedAction{
+			{ResourceType: differ.ResourceInstrument, ResourceCode: "GBP", Action: differ.ActionCreate},
+		},
+	}
+
+	plan, err := p.Plan(diffPlan, "acme-energy", "1.0", true)
+	require.NoError(t, err)
+
+	assert.True(t, plan.DryRun)
+	assert.True(t, plan.Calls[0].DryRun)
+
+	// Idempotency key should still be the same regardless of dry run
+	planNotDry, err := p.Plan(diffPlan, "acme-energy", "1.0", false)
+	require.NoError(t, err)
+	assert.Equal(t, plan.Calls[0].IdempotencyKey, planNotDry.Calls[0].IdempotencyKey,
+		"idempotency key should not change based on dry run flag")
+}
+
+// --- Test helpers ---
+
+func indexCallsByResourceID(calls []PlannedCall) map[string]PlannedCall {
+	m := make(map[string]PlannedCall, len(calls))
+	for _, call := range calls {
+		m[call.ResourceID] = call
+	}
+	return m
+}

--- a/services/control-plane/internal/planner/types.go
+++ b/services/control-plane/internal/planner/types.go
@@ -1,0 +1,208 @@
+// Package planner transforms a diff plan into a dependency-ordered sequence
+// of gRPC calls to downstream services (Reference Data, Internal Bank Account,
+// Saga Registry). It ensures resources are created in the correct order
+// respecting inter-resource dependencies.
+package planner
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/meridianhub/meridian/services/control-plane/internal/differ"
+)
+
+// Phase represents an execution phase in the dependency graph.
+// Resources in the same phase can be executed in parallel; phases must
+// be executed sequentially (phase N completes before phase N+1 starts).
+type Phase int
+
+const (
+	// PhaseInstruments registers instruments with Reference Data (no dependencies).
+	PhaseInstruments Phase = 1
+	// PhaseAccountTypes registers account types and initiates internal bank accounts
+	// (depends on instruments being registered first).
+	PhaseAccountTypes Phase = 2
+	// PhaseValuationRules registers valuation rules with Reference Data
+	// (depends on instruments being registered first).
+	PhaseValuationRules Phase = 3
+	// PhaseSagas registers saga definitions with the Saga Registry
+	// (depends on account types and instruments being registered first).
+	PhaseSagas Phase = 4
+	// PhaseSeedData provisions seed data via various service calls
+	// (depends on all above being registered first).
+	PhaseSeedData Phase = 5
+)
+
+// PhaseLabel returns a human-readable label for a phase.
+func PhaseLabel(p Phase) string {
+	switch p {
+	case PhaseInstruments:
+		return "Instruments"
+	case PhaseAccountTypes:
+		return "Account Types"
+	case PhaseValuationRules:
+		return "Valuation Rules"
+	case PhaseSagas:
+		return "Saga Definitions"
+	case PhaseSeedData:
+		return "Seed Data"
+	default:
+		return fmt.Sprintf("Phase(%d)", p)
+	}
+}
+
+// GRPCMethod identifies a specific gRPC service method to call.
+type GRPCMethod string
+
+// gRPC method constants for each resource type and action.
+const (
+	// Reference Data Service
+	MethodRegisterInstrument  GRPCMethod = "meridian.reference_data.v1.ReferenceDataService/RegisterInstrument"
+	MethodUpdateInstrument    GRPCMethod = "meridian.reference_data.v1.ReferenceDataService/UpdateInstrument"
+	MethodDeprecateInstrument GRPCMethod = "meridian.reference_data.v1.ReferenceDataService/DeprecateInstrument"
+	MethodActivateInstrument  GRPCMethod = "meridian.reference_data.v1.ReferenceDataService/ActivateInstrument"
+
+	// Internal Bank Account Service
+	MethodInitiateAccount GRPCMethod = "meridian.internal_bank_account.v1.InternalBankAccountService/InitiateInternalBankAccount"
+
+	// Saga Registry Service
+	MethodCreateSagaDraft      GRPCMethod = "meridian.saga.v1.SagaRegistryService/CreateSagaDraft"
+	MethodUpdateSagaDefinition GRPCMethod = "meridian.saga.v1.SagaRegistryService/UpdateSagaDefinition"
+	MethodDeprecateSaga        GRPCMethod = "meridian.saga.v1.SagaRegistryService/DeprecateSaga"
+	MethodActivateSaga         GRPCMethod = "meridian.saga.v1.SagaRegistryService/ActivateSaga"
+)
+
+// PlannedCall represents a single gRPC call in the execution plan.
+type PlannedCall struct {
+	// Phase is the execution phase (1-5) for dependency ordering.
+	Phase Phase
+
+	// ResourceType identifies the manifest resource category.
+	ResourceType differ.ResourceType
+
+	// ResourceID is the stable identifier for the resource (instrument code,
+	// account type code, valuation rule key, or saga name).
+	ResourceID string
+
+	// Action is the diff action that produced this call (CREATE/UPDATE/DELETE).
+	Action differ.ActionType
+
+	// GRPCMethod is the fully-qualified gRPC method to invoke.
+	GRPCMethod GRPCMethod
+
+	// IdempotencyKey is a deterministic key for safe retry.
+	// Format: SHA-256(tenant_id + manifest_version + resource_type + resource_id + action)
+	IdempotencyKey string
+
+	// Description is a human-readable description of this planned call.
+	Description string
+
+	// DryRun indicates whether services should validate without committing.
+	DryRun bool
+}
+
+// ExecutionPlan is the complete ordered sequence of gRPC calls
+// derived from a DiffPlan. Calls are grouped into phases that must
+// execute sequentially, while calls within a phase may execute in parallel.
+type ExecutionPlan struct {
+	// Calls is the ordered sequence of gRPC calls.
+	Calls []PlannedCall
+
+	// TenantID is the tenant this plan applies to.
+	TenantID string
+
+	// ManifestVersion is the manifest version string.
+	ManifestVersion string
+
+	// DryRun indicates whether the entire plan is a dry run.
+	DryRun bool
+}
+
+// ByPhase returns calls grouped by phase in execution order.
+func (p *ExecutionPlan) ByPhase() map[Phase][]PlannedCall {
+	grouped := make(map[Phase][]PlannedCall)
+	for _, call := range p.Calls {
+		grouped[call.Phase] = append(grouped[call.Phase], call)
+	}
+	return grouped
+}
+
+// Phases returns the distinct phases present in the plan, in order.
+func (p *ExecutionPlan) Phases() []Phase {
+	seen := make(map[Phase]bool)
+	var phases []Phase
+	for _, call := range p.Calls {
+		if !seen[call.Phase] {
+			seen[call.Phase] = true
+			phases = append(phases, call.Phase)
+		}
+	}
+	return phases
+}
+
+// Summary returns a human-readable summary of the execution plan.
+func (p *ExecutionPlan) Summary() string {
+	counts := map[differ.ActionType]int{}
+	for _, call := range p.Calls {
+		counts[call.Action]++
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Execution Plan: %d calls", len(p.Calls))
+	if p.DryRun {
+		b.WriteString(" [DRY RUN]")
+	}
+	fmt.Fprintf(&b, "\n  Creates: %d, Updates: %d, Deletes: %d",
+		counts[differ.ActionCreate],
+		counts[differ.ActionUpdate],
+		counts[differ.ActionDelete],
+	)
+	return b.String()
+}
+
+// Visualize returns a human-readable phased plan visualization.
+func (p *ExecutionPlan) Visualize() string {
+	var b strings.Builder
+
+	if p.DryRun {
+		b.WriteString("=== EXECUTION PLAN (DRY RUN) ===\n")
+	} else {
+		b.WriteString("=== EXECUTION PLAN ===\n")
+	}
+	fmt.Fprintf(&b, "Tenant: %s | Manifest: %s\n", p.TenantID, p.ManifestVersion)
+	fmt.Fprintf(&b, "Total calls: %d\n\n", len(p.Calls))
+
+	byPhase := p.ByPhase()
+	for phase := PhaseInstruments; phase <= PhaseSeedData; phase++ {
+		calls, ok := byPhase[phase]
+		if !ok {
+			continue
+		}
+		fmt.Fprintf(&b, "Phase %d: %s (%d calls)\n", phase, PhaseLabel(phase), len(calls))
+		for _, call := range calls {
+			actionSymbol := actionSymbol(call.Action)
+			fmt.Fprintf(&b, "  %s %s %s\n", actionSymbol, call.ResourceType, call.ResourceID)
+			fmt.Fprintf(&b, "    -> %s\n", call.GRPCMethod)
+			if call.Description != "" {
+				fmt.Fprintf(&b, "    %s\n", call.Description)
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func actionSymbol(action differ.ActionType) string {
+	switch action {
+	case differ.ActionCreate:
+		return "+"
+	case differ.ActionUpdate:
+		return "~"
+	case differ.ActionDelete:
+		return "-"
+	case differ.ActionNoChange:
+		return "="
+	}
+	return "?"
+}


### PR DESCRIPTION
## Summary

- Implement the `ManifestPlanner` that transforms a `DiffPlan` (from the differ, control-plane.5) into a dependency-ordered `ExecutionPlan` of gRPC calls to downstream services
- 5-phase dependency graph ensures resources are provisioned in the correct order: Instruments -> Account Types -> Valuation Rules -> Sagas -> Seed Data
- Deterministic SHA-256 idempotency keys enable safe retry without duplication

## Changes Made

### New Package: `services/control-plane/internal/planner/`

**types.go** - Core type definitions:
- `Phase` constants (1-5) with human-readable labels
- `GRPCMethod` constants mapping to Reference Data, Internal Bank Account, and Saga Registry services
- `PlannedCall` struct with phase, resource info, gRPC method, idempotency key, and dry-run flag
- `ExecutionPlan` with `ByPhase()`, `Phases()`, `Summary()`, and `Visualize()` methods

**manifest_planner.go** - Planning logic:
- `ManifestPlanner.Plan()` transforms DiffPlan actions into ordered gRPC calls
- Phase assignment based on resource type dependencies
- gRPC method mapping table for all resource type/action combinations
- `GenerateIdempotencyKey()` using SHA-256 of tenant_id + manifest_version + resource_type + resource_id + action
- NO_CHANGE actions filtered out; deterministic sort by phase/type/code

**manifest_planner_test.go** - 31 tests covering:
- Phase ordering and assignment for all resource types
- gRPC method mapping for instruments, account types, sagas
- Idempotency key determinism, uniqueness per resource/tenant/version/action
- Dry-run propagation
- NO_CHANGE filtering
- Deterministic ordering across multiple runs
- Full energy manifest integration scenario
- Plan visualization output

## Technical Details

### Dependency Graph (5 Phases)

| Phase | Resource Type | gRPC Target | Dependencies |
|-------|--------------|-------------|--------------|
| 1 | Instruments | ReferenceData.RegisterInstrument | None |
| 2 | Account Types | IBA.InitiateInternalBankAccount | Instruments |
| 3 | Valuation Rules | ReferenceData (instrument ops) | Instruments |
| 4 | Saga Definitions | SagaRegistry.CreateSagaDraft | Account Types, Instruments |
| 5 | Seed Data | Various | All above |

### Idempotency Key Generation

Deterministic SHA-256 hash of `tenant_id|manifest_version|resource_type|resource_id|action`, enabling safe retry of the same manifest application without duplicate resource creation.

## Testing

```
go test ./services/control-plane/internal/planner/ -count=1 -v
# 31/31 PASS
```

## Task Master

Task: control-plane.6 - Build ApplyManifest Planner to Generate Ordered gRPC Call Sequence