### PR TITLE
feat: Implement ApplyManifest Saga Executor with durable orchestration

### DIFF
--- a/services/control-plane/internal/applier/apply_job.go
+++ b/services/control-plane/internal/applier/apply_job.go
@@ -1,0 +1,189 @@
+// Package applier provides the manifest application orchestrator that executes
+// the planned gRPC calls as a durable Starlark saga with automatic compensation.
+package applier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ApplyJobStatus represents the lifecycle state of a manifest apply job.
+type ApplyJobStatus string
+
+const (
+	// ApplyJobStatusPending indicates the job has been created but not yet started.
+	ApplyJobStatusPending ApplyJobStatus = "PENDING"
+	// ApplyJobStatusApplying indicates the job is currently executing.
+	ApplyJobStatusApplying ApplyJobStatus = "APPLYING"
+	// ApplyJobStatusApplied indicates the job completed successfully.
+	ApplyJobStatusApplied ApplyJobStatus = "APPLIED"
+	// ApplyJobStatusFailed indicates the job failed.
+	ApplyJobStatusFailed ApplyJobStatus = "FAILED"
+)
+
+// ApplyJob represents a manifest application job.
+type ApplyJob struct {
+	ID              uuid.UUID
+	ManifestVersion int
+	SagaExecutionID *uuid.UUID
+	Status          ApplyJobStatus
+	Error           string
+	CreatedAt       time.Time
+	CompletedAt     *time.Time
+}
+
+// ApplyJob errors.
+var (
+	// ErrJobNotFound is returned when a job is not found.
+	ErrJobNotFound = errors.New("apply job not found")
+)
+
+// ApplyJobRepository provides persistence for manifest apply jobs.
+type ApplyJobRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewApplyJobRepository creates a new ApplyJobRepository.
+func NewApplyJobRepository(pool *pgxpool.Pool) *ApplyJobRepository {
+	return &ApplyJobRepository{pool: pool}
+}
+
+// Create creates a new manifest apply job in PENDING status.
+func (r *ApplyJobRepository) Create(ctx context.Context, manifestVersion int) (*ApplyJob, error) {
+	job := &ApplyJob{
+		ID:              uuid.New(),
+		ManifestVersion: manifestVersion,
+		Status:          ApplyJobStatusPending,
+		CreatedAt:       time.Now(),
+	}
+
+	_, err := r.pool.Exec(ctx,
+		`INSERT INTO manifest_apply_job (id, manifest_version, status, created_at)
+		 VALUES ($1, $2, $3, $4)`,
+		job.ID, job.ManifestVersion, string(job.Status), job.CreatedAt,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create apply job: %w", err)
+	}
+
+	return job, nil
+}
+
+// MarkApplying transitions a job to APPLYING status and links it to a saga execution.
+func (r *ApplyJobRepository) MarkApplying(ctx context.Context, jobID uuid.UUID, sagaExecutionID uuid.UUID) error {
+	result, err := r.pool.Exec(ctx,
+		`UPDATE manifest_apply_job
+		 SET status = $1, saga_execution_id = $2
+		 WHERE id = $3 AND status = $4`,
+		string(ApplyJobStatusApplying), sagaExecutionID, jobID, string(ApplyJobStatusPending),
+	)
+	if err != nil {
+		return fmt.Errorf("mark applying: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return ErrJobNotFound
+	}
+	return nil
+}
+
+// MarkApplied transitions a job to APPLIED status.
+func (r *ApplyJobRepository) MarkApplied(ctx context.Context, jobID uuid.UUID) error {
+	now := time.Now()
+	result, err := r.pool.Exec(ctx,
+		`UPDATE manifest_apply_job
+		 SET status = $1, completed_at = $2
+		 WHERE id = $3 AND status = $4`,
+		string(ApplyJobStatusApplied), now, jobID, string(ApplyJobStatusApplying),
+	)
+	if err != nil {
+		return fmt.Errorf("mark applied: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return ErrJobNotFound
+	}
+	return nil
+}
+
+// MarkFailed transitions a job to FAILED status with an error message.
+func (r *ApplyJobRepository) MarkFailed(ctx context.Context, jobID uuid.UUID, errMsg string) error {
+	now := time.Now()
+	result, err := r.pool.Exec(ctx,
+		`UPDATE manifest_apply_job
+		 SET status = $1, error = $2, completed_at = $3
+		 WHERE id = $4 AND status IN ($5, $6)`,
+		string(ApplyJobStatusFailed), errMsg, now, jobID,
+		string(ApplyJobStatusPending), string(ApplyJobStatusApplying),
+	)
+	if err != nil {
+		return fmt.Errorf("mark failed: %w", err)
+	}
+	if result.RowsAffected() == 0 {
+		return ErrJobNotFound
+	}
+	return nil
+}
+
+// GetByID retrieves a job by its ID.
+func (r *ApplyJobRepository) GetByID(ctx context.Context, jobID uuid.UUID) (*ApplyJob, error) {
+	var job ApplyJob
+	var status string
+	var sagaExecID *uuid.UUID
+	var errMsg *string
+
+	err := r.pool.QueryRow(ctx,
+		`SELECT id, manifest_version, saga_execution_id, status, error, created_at, completed_at
+		 FROM manifest_apply_job WHERE id = $1`,
+		jobID,
+	).Scan(&job.ID, &job.ManifestVersion, &sagaExecID, &status, &errMsg, &job.CreatedAt, &job.CompletedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrJobNotFound
+		}
+		return nil, fmt.Errorf("get apply job: %w", err)
+	}
+
+	job.Status = ApplyJobStatus(status)
+	job.SagaExecutionID = sagaExecID
+	if errMsg != nil {
+		job.Error = *errMsg
+	}
+
+	return &job, nil
+}
+
+// GetByManifestVersion retrieves the latest job for a manifest version.
+func (r *ApplyJobRepository) GetByManifestVersion(ctx context.Context, manifestVersion int) (*ApplyJob, error) {
+	var job ApplyJob
+	var status string
+	var sagaExecID *uuid.UUID
+	var errMsg *string
+
+	err := r.pool.QueryRow(ctx,
+		`SELECT id, manifest_version, saga_execution_id, status, error, created_at, completed_at
+		 FROM manifest_apply_job
+		 WHERE manifest_version = $1
+		 ORDER BY created_at DESC
+		 LIMIT 1`,
+		manifestVersion,
+	).Scan(&job.ID, &job.ManifestVersion, &sagaExecID, &status, &errMsg, &job.CreatedAt, &job.CompletedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrJobNotFound
+		}
+		return nil, fmt.Errorf("get apply job by version: %w", err)
+	}
+
+	job.Status = ApplyJobStatus(status)
+	job.SagaExecutionID = sagaExecID
+	if errMsg != nil {
+		job.Error = *errMsg
+	}
+
+	return &job, nil
+}

--- a/services/control-plane/internal/applier/apply_job_test.go
+++ b/services/control-plane/internal/applier/apply_job_test.go
@@ -1,0 +1,67 @@
+package applier
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyJobStatus_Constants(t *testing.T) {
+	assert.Equal(t, ApplyJobStatus("PENDING"), ApplyJobStatusPending)
+	assert.Equal(t, ApplyJobStatus("APPLYING"), ApplyJobStatusApplying)
+	assert.Equal(t, ApplyJobStatus("APPLIED"), ApplyJobStatusApplied)
+	assert.Equal(t, ApplyJobStatus("FAILED"), ApplyJobStatusFailed)
+}
+
+func TestApplyJob_Fields(t *testing.T) {
+	sagaID := uuid.New()
+	job := &ApplyJob{
+		ID:              uuid.New(),
+		ManifestVersion: 42,
+		SagaExecutionID: &sagaID,
+		Status:          ApplyJobStatusPending,
+		Error:           "",
+	}
+
+	assert.NotEqual(t, uuid.Nil, job.ID)
+	assert.Equal(t, 42, job.ManifestVersion)
+	assert.Equal(t, &sagaID, job.SagaExecutionID)
+	assert.Equal(t, ApplyJobStatusPending, job.Status)
+	assert.Empty(t, job.Error)
+}
+
+func TestNewApplyJobRepository(t *testing.T) {
+	repo := NewApplyJobRepository(nil)
+	require.NotNil(t, repo)
+}
+
+func TestApplyJobStatus_StringRepresentation(t *testing.T) {
+	tests := []struct {
+		status   ApplyJobStatus
+		expected string
+	}{
+		{ApplyJobStatusPending, "PENDING"},
+		{ApplyJobStatusApplying, "APPLYING"},
+		{ApplyJobStatusApplied, "APPLIED"},
+		{ApplyJobStatusFailed, "FAILED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, string(tt.status))
+		})
+	}
+}
+
+func TestApplyJob_NilSagaExecutionID(t *testing.T) {
+	job := &ApplyJob{
+		ID:              uuid.New(),
+		ManifestVersion: 1,
+		Status:          ApplyJobStatusPending,
+	}
+
+	assert.Nil(t, job.SagaExecutionID)
+	assert.Nil(t, job.CompletedAt)
+}

--- a/services/control-plane/internal/applier/bootstrap.go
+++ b/services/control-plane/internal/applier/bootstrap.go
@@ -1,0 +1,173 @@
+package applier
+
+import (
+	"context"
+	"embed"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+//go:embed all:defaults
+var embeddedSagas embed.FS
+
+// versionFilenamePattern matches version filenames like "v1.0.0.star".
+var versionFilenamePattern = regexp.MustCompile(`^v(\d+\.\d+\.\d+)\.star$`)
+
+// ErrNoEmbeddedScript is returned when the apply_manifest saga script is not found.
+var ErrNoEmbeddedScript = errors.New("embedded apply_manifest saga script not found")
+
+// Bootstrap upserts the apply_manifest saga into public.platform_saga_definition
+// on Control Plane startup. This ensures the saga is available for all tenants
+// via ADR-0028 platform default fallback resolution.
+//
+// The bootstrap is idempotent: if the saga already exists with the same version,
+// it is skipped. If a newer version exists, it is inserted alongside the old one.
+type Bootstrap struct {
+	pool   *pgxpool.Pool
+	logger *slog.Logger
+}
+
+// NewBootstrap creates a new Bootstrap instance.
+func NewBootstrap(pool *pgxpool.Pool) *Bootstrap {
+	return &Bootstrap{
+		pool:   pool,
+		logger: slog.Default().With("component", "apply_manifest_bootstrap"),
+	}
+}
+
+// EnsurePlatformSaga upserts the apply_manifest saga into the platform table.
+// This should be called during Control Plane startup.
+func (b *Bootstrap) EnsurePlatformSaga(ctx context.Context) error {
+	b.logger.Info("ensuring apply_manifest platform saga is registered")
+
+	script, version, err := loadEmbeddedApplyManifest()
+	if err != nil {
+		return fmt.Errorf("load embedded saga: %w", err)
+	}
+
+	// Generate deterministic UUID based on name and version
+	id := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("platform.saga.apply_manifest."+version))
+
+	// Check if exact (name, version) already exists
+	var existingID uuid.UUID
+	err = b.pool.QueryRow(ctx,
+		`SELECT id FROM public.platform_saga_definition
+		 WHERE name = $1 AND version = $2`,
+		"apply_manifest", version,
+	).Scan(&existingID)
+	if err == nil {
+		b.logger.Info("apply_manifest saga already exists",
+			"version", version,
+			"id", existingID)
+		return nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("check existing saga: %w", err)
+	}
+
+	// Insert new version
+	_, err = b.pool.Exec(ctx,
+		`INSERT INTO public.platform_saga_definition
+			(id, name, version, script, status, display_name, description)
+		 VALUES ($1, $2, $3, $4, 'ACTIVE', $5, $6)`,
+		id, "apply_manifest", version, script,
+		"Apply Manifest",
+		"Platform saga for applying tenant manifests with phased execution and automatic compensation.",
+	)
+	if err != nil {
+		// Handle race condition: another instance may have inserted concurrently
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			b.logger.Info("apply_manifest saga inserted by concurrent process", "version", version)
+			return nil
+		}
+		return fmt.Errorf("insert platform saga: %w", err)
+	}
+
+	b.logger.Info("apply_manifest platform saga registered",
+		"version", version,
+		"id", id)
+	return nil
+}
+
+// loadEmbeddedApplyManifest reads the apply_manifest saga from the embedded filesystem.
+// Returns the script content and the version string.
+func loadEmbeddedApplyManifest() (string, string, error) {
+	dirPath := path.Join("defaults", "apply_manifest")
+
+	entries, err := embeddedSagas.ReadDir(dirPath)
+	if err != nil {
+		return "", "", fmt.Errorf("%w: %w", ErrNoEmbeddedScript, err)
+	}
+
+	var latestScript string
+	var latestVersion string
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		matches := versionFilenamePattern.FindStringSubmatch(entry.Name())
+		if matches == nil {
+			continue
+		}
+
+		version := matches[1]
+		filePath := path.Join(dirPath, entry.Name())
+
+		content, err := embeddedSagas.ReadFile(filePath)
+		if err != nil {
+			return "", "", fmt.Errorf("read %s: %w", filePath, err)
+		}
+
+		if isSemverGreater(version, latestVersion) {
+			latestVersion = version
+			latestScript = strings.TrimSpace(string(content))
+		}
+	}
+
+	if latestScript == "" {
+		return "", "", ErrNoEmbeddedScript
+	}
+
+	return latestScript, latestVersion, nil
+}
+
+// isSemverGreater returns true if version a is greater than version b.
+func isSemverGreater(a, b string) bool {
+	if b == "" {
+		return true
+	}
+
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+
+	for i := 0; i < 3 && i < len(aParts) && i < len(bParts); i++ {
+		ai := parseInt(aParts[i])
+		bi := parseInt(bParts[i])
+		if ai != bi {
+			return ai > bi
+		}
+	}
+	return false
+}
+
+func parseInt(s string) int {
+	n := 0
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			n = n*10 + int(c-'0')
+		}
+	}
+	return n
+}

--- a/services/control-plane/internal/applier/bootstrap_test.go
+++ b/services/control-plane/internal/applier/bootstrap_test.go
@@ -1,0 +1,69 @@
+package applier
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadEmbeddedApplyManifest(t *testing.T) {
+	script, version, err := loadEmbeddedApplyManifest()
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, script)
+	assert.Equal(t, "1.0.0", version)
+	assert.Contains(t, script, "apply_manifest")
+	assert.Contains(t, script, "execute_apply_manifest")
+	assert.Contains(t, script, "reference_data.register_instrument")
+	assert.Contains(t, script, "internal_bank_account.initiate")
+}
+
+func TestIsSemverGreater(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        string
+		b        string
+		expected bool
+	}{
+		{"empty b always returns true", "1.0.0", "", true},
+		{"same version", "1.0.0", "1.0.0", false},
+		{"major greater", "2.0.0", "1.0.0", true},
+		{"major less", "1.0.0", "2.0.0", false},
+		{"minor greater", "1.2.0", "1.1.0", true},
+		{"minor less", "1.1.0", "1.2.0", false},
+		{"patch greater", "1.0.2", "1.0.1", true},
+		{"patch less", "1.0.1", "1.0.2", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isSemverGreater(tt.a, tt.b)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewBootstrap(t *testing.T) {
+	b := NewBootstrap(nil)
+	require.NotNil(t, b)
+	assert.NotNil(t, b.logger)
+}
+
+func TestParseInt(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"0", 0},
+		{"1", 1},
+		{"42", 42},
+		{"100", 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, parseInt(tt.input))
+		})
+	}
+}

--- a/services/control-plane/internal/applier/defaults/apply_manifest/v1.0.0.star
+++ b/services/control-plane/internal/applier/defaults/apply_manifest/v1.0.0.star
@@ -1,0 +1,125 @@
+# Saga: apply_manifest
+# Version: 1.0.0
+# Previous: none
+# Changed: Initial implementation of ApplyManifest saga with phased execution
+# Author: Platform Team
+# Date: 2026-02-09
+#
+# This Starlark script defines the apply_manifest saga workflow for the Control Plane.
+# It executes phased gRPC calls to provision tenant resources from a manifest definition.
+#
+# Phases (executed sequentially, parallel within each phase):
+#   Phase 1: Register instruments with Reference Data service
+#   Phase 2: Register account types + initiate internal bank accounts
+#   Phase 3: Register valuation rules with Reference Data service
+#   Phase 4: Register saga definitions with Reference Data service
+#
+# Compensation Order (LIFO - Last In, First Out):
+#   Failures trigger compensation of completed steps in reverse order.
+#
+# Input data (provided via input_data dictionary):
+#   - manifest_version: string - The manifest version being applied
+#   - instruments: list - List of instrument definitions to register
+#   - account_types: list - List of account type definitions to register and provision
+#   - valuation_rules: list - List of valuation rule definitions to register
+#   - saga_definitions: list - List of saga definitions to register
+
+apply_manifest_saga = saga(name="apply_manifest")
+
+def execute_apply_manifest():
+    manifest_version = input_data["manifest_version"]
+    instruments = input_data.get("instruments", [])
+    account_types = input_data.get("account_types", [])
+    valuation_rules = input_data.get("valuation_rules", [])
+    saga_definitions = input_data.get("saga_definitions", [])
+
+    registered_instruments = []
+    registered_account_types = []
+    registered_valuation_rules = []
+    registered_saga_definitions = []
+
+    # Phase 1: Register instruments (no dependencies)
+    for instrument in instruments:
+        step(name="register_instrument_" + instrument["code"])
+        result = reference_data.register_instrument(
+            instrument_code=instrument["code"],
+            display_name=instrument.get("display_name", instrument["code"]),
+            dimension=instrument.get("dimension", "CURRENCY"),
+            decimal_places=instrument.get("decimal_places", 2),
+            description=instrument.get("description", ""),
+        )
+        registered_instruments.append({
+            "instrument_code": instrument["code"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 2: Register account types and initiate internal bank accounts
+    for account_type in account_types:
+        # Register the account type as reference data
+        step(name="register_account_type_" + account_type["code"])
+        reference_data.register_account_type(
+            account_type_code=account_type["code"],
+            display_name=account_type.get("display_name", account_type["code"]),
+            description=account_type.get("description", ""),
+            instrument_code=account_type["instrument_code"],
+        )
+
+        # Initiate the internal bank account
+        step(name="initiate_account_" + account_type["code"])
+        account_result = internal_bank_account.initiate(
+            account_code=account_type["code"],
+            name=account_type.get("display_name", account_type["code"]),
+            account_type=account_type.get("account_type", "CLEARING"),
+            instrument_code=account_type["instrument_code"],
+            description=account_type.get("description", ""),
+        )
+
+        registered_account_types.append({
+            "account_type_code": account_type["code"],
+            "account_id": account_result.account_id,
+            "status": "REGISTERED",
+        })
+
+    # Phase 3: Register valuation rules
+    for rule in valuation_rules:
+        step(name="register_valuation_rule_" + rule["from_instrument"] + "_" + rule["to_instrument"])
+        reference_data.register_valuation_rule(
+            from_instrument=rule["from_instrument"],
+            to_instrument=rule["to_instrument"],
+            rule_type=rule.get("rule_type", "FIXED_RATE"),
+            expression=rule.get("expression", ""),
+            description=rule.get("description", ""),
+        )
+        registered_valuation_rules.append({
+            "from_instrument": rule["from_instrument"],
+            "to_instrument": rule["to_instrument"],
+            "status": "REGISTERED",
+        })
+
+    # Phase 4: Register saga definitions
+    for saga_def in saga_definitions:
+        step(name="register_saga_definition_" + saga_def["name"])
+        reference_data.register_saga_definition(
+            saga_name=saga_def["name"],
+            display_name=saga_def.get("display_name", saga_def["name"]),
+            description=saga_def.get("description", ""),
+            script=saga_def.get("script", ""),
+            version=saga_def.get("version", "1.0.0"),
+        )
+        registered_saga_definitions.append({
+            "saga_name": saga_def["name"],
+            "status": "REGISTERED",
+        })
+
+    result = {
+        "status": "applied",
+        "version": manifest_version,
+        "instruments_registered": len(registered_instruments),
+        "account_types_registered": len(registered_account_types),
+        "valuation_rules_registered": len(registered_valuation_rules),
+        "saga_definitions_registered": len(registered_saga_definitions),
+    }
+    return result
+
+# Execute the saga
+execute_apply_manifest()

--- a/services/control-plane/internal/applier/executor.go
+++ b/services/control-plane/internal/applier/executor.go
@@ -249,9 +249,9 @@ func (e *ManifestExecutor) resolveSagaScript(ctx context.Context) (string, error
 		`SELECT script FROM public.platform_saga_definition
 		 WHERE name = $1 AND status = 'ACTIVE'
 		 ORDER BY
-			split_part(version, '.', 1)::int DESC,
-			split_part(version, '.', 2)::int DESC,
-			split_part(version, '.', 3)::int DESC
+			COALESCE(NULLIF(split_part(version, '.', 1), '')::int, 0) DESC,
+			COALESCE(NULLIF(split_part(version, '.', 2), '')::int, 0) DESC,
+			COALESCE(NULLIF(split_part(version, '.', 3), '')::int, 0) DESC
 		 LIMIT 1`,
 		"apply_manifest",
 	).Scan(&script)

--- a/services/control-plane/internal/applier/executor.go
+++ b/services/control-plane/internal/applier/executor.go
@@ -1,0 +1,322 @@
+package applier
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+// ManifestExecutor orchestrates the ApplyManifest saga for a tenant.
+// It loads the saga definition (with platform default fallback per ADR-0028),
+// constructs the saga input from the manifest, and executes via the saga engine.
+type ManifestExecutor struct {
+	pool    *pgxpool.Pool
+	runner  *saga.StarlarkSagaRunner
+	jobRepo *ApplyJobRepository
+	logger  *slog.Logger
+}
+
+// ManifestExecutorConfig contains configuration for creating a ManifestExecutor.
+type ManifestExecutorConfig struct {
+	Pool   *pgxpool.Pool
+	Runner *saga.StarlarkSagaRunner
+	Logger *slog.Logger
+}
+
+// NewManifestExecutor creates a new ManifestExecutor.
+func NewManifestExecutor(cfg ManifestExecutorConfig) *ManifestExecutor {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &ManifestExecutor{
+		pool:    cfg.Pool,
+		runner:  cfg.Runner,
+		jobRepo: NewApplyJobRepository(cfg.Pool),
+		logger:  logger.With("component", "manifest_executor"),
+	}
+}
+
+// ApplyManifestInput contains the input for a manifest application.
+type ApplyManifestInput struct {
+	// ManifestVersion is the version being applied.
+	ManifestVersion string
+
+	// Instruments to register in Phase 1.
+	Instruments []InstrumentInput
+
+	// AccountTypes to register and provision in Phase 2.
+	AccountTypes []AccountTypeInput
+
+	// ValuationRules to register in Phase 3.
+	ValuationRules []ValuationRuleInput
+
+	// SagaDefinitions to register in Phase 4.
+	SagaDefinitions []SagaDefinitionInput
+
+	// TenantID is the tenant for cross-tenant execution.
+	TenantID string
+}
+
+// InstrumentInput represents an instrument to register.
+type InstrumentInput struct {
+	Code          string
+	DisplayName   string
+	Dimension     string
+	DecimalPlaces int
+	Description   string
+}
+
+// AccountTypeInput represents an account type to register and provision.
+type AccountTypeInput struct {
+	Code           string
+	DisplayName    string
+	Description    string
+	InstrumentCode string
+	AccountType    string
+}
+
+// ValuationRuleInput represents a valuation rule to register.
+type ValuationRuleInput struct {
+	FromInstrument string
+	ToInstrument   string
+	RuleType       string
+	Expression     string
+	Description    string
+}
+
+// SagaDefinitionInput represents a saga definition to register.
+type SagaDefinitionInput struct {
+	Name        string
+	DisplayName string
+	Description string
+	Script      string
+	Version     string
+}
+
+// ApplyManifestResult contains the result of a manifest application.
+type ApplyManifestResult struct {
+	// JobID is the tracking job identifier.
+	JobID uuid.UUID
+
+	// SagaExecutionID is the saga execution identifier.
+	SagaExecutionID uuid.UUID
+
+	// Status is the result status ("applied" or "failed").
+	Status string
+
+	// Version is the manifest version that was applied.
+	Version string
+
+	// Error contains the error message if Status is "failed".
+	Error string
+
+	// StepResults contains individual step results for debugging.
+	StepResults []saga.StepResult
+}
+
+// Executor errors.
+var (
+	// ErrSagaNotFound is returned when the apply_manifest saga definition is not found.
+	ErrSagaNotFound = errors.New("apply_manifest saga definition not found")
+
+	// ErrSagaFailed is returned when the saga execution fails.
+	ErrSagaFailed = errors.New("saga execution failed")
+)
+
+// Apply executes the apply_manifest saga for a tenant.
+// It resolves the saga script using platform default fallback (ADR-0028),
+// constructs the input, and runs the saga with automatic compensation.
+func (e *ManifestExecutor) Apply(ctx context.Context, input *ApplyManifestInput) (*ApplyManifestResult, error) {
+	logger := e.logger.With(
+		"manifest_version", input.ManifestVersion,
+		"tenant_id", input.TenantID,
+	)
+
+	logger.Info("starting manifest application")
+
+	// Create tracking job
+	versionInt := parseManifestVersion(input.ManifestVersion)
+	job, err := e.jobRepo.Create(ctx, versionInt)
+	if err != nil {
+		return nil, fmt.Errorf("create apply job: %w", err)
+	}
+
+	// Resolve the saga script (platform default fallback per ADR-0028)
+	script, err := e.resolveSagaScript(ctx)
+	if err != nil {
+		_ = e.jobRepo.MarkFailed(ctx, job.ID, err.Error())
+		return nil, fmt.Errorf("resolve saga script: %w", err)
+	}
+
+	// Build saga input
+	sagaInput := e.buildSagaInput(input)
+
+	// Generate execution IDs
+	executionID := uuid.New()
+	correlationID := uuid.New()
+
+	// Mark job as applying
+	if err := e.jobRepo.MarkApplying(ctx, job.ID, executionID); err != nil {
+		return nil, fmt.Errorf("mark job applying: %w", err)
+	}
+
+	logger.Info("executing apply_manifest saga",
+		"execution_id", executionID,
+		"correlation_id", correlationID,
+	)
+
+	// Execute the saga
+	runnerInput := saga.RunnerInput{
+		SagaExecutionID: executionID,
+		CorrelationID:   correlationID,
+		KnowledgeAt:     time.Now(),
+		Input:           sagaInput,
+	}
+
+	output, err := e.runner.ExecuteSaga(ctx, "apply_manifest", script, runnerInput)
+	if err != nil {
+		_ = e.jobRepo.MarkFailed(ctx, job.ID, err.Error())
+		return nil, fmt.Errorf("execute saga: %w", err)
+	}
+
+	// Check saga result
+	if !output.Success {
+		_ = e.jobRepo.MarkFailed(ctx, job.ID, output.Error)
+		return &ApplyManifestResult{
+			JobID:           job.ID,
+			SagaExecutionID: executionID,
+			Status:          "failed",
+			Version:         input.ManifestVersion,
+			Error:           output.Error,
+			StepResults:     output.StepResults,
+		}, fmt.Errorf("%w: %s", ErrSagaFailed, output.Error)
+	}
+
+	// Mark job as applied
+	if err := e.jobRepo.MarkApplied(ctx, job.ID); err != nil {
+		logger.Error("failed to mark job applied", "error", err)
+	}
+
+	logger.Info("manifest application completed",
+		"execution_id", executionID,
+		"step_count", len(output.StepResults),
+	)
+
+	return &ApplyManifestResult{
+		JobID:           job.ID,
+		SagaExecutionID: executionID,
+		Status:          "applied",
+		Version:         input.ManifestVersion,
+		StepResults:     output.StepResults,
+	}, nil
+}
+
+// resolveSagaScript resolves the apply_manifest saga script.
+// Per ADR-0028, it first checks for a tenant-specific override,
+// then falls back to the platform default in public.platform_saga_definition.
+func (e *ManifestExecutor) resolveSagaScript(ctx context.Context) (string, error) {
+	// Query platform default (applies to all tenants including those with 0 local saga definitions)
+	var script string
+	err := e.pool.QueryRow(ctx,
+		`SELECT script FROM public.platform_saga_definition
+		 WHERE name = $1 AND status = 'ACTIVE'
+		 ORDER BY
+			split_part(version, '.', 1)::int DESC,
+			split_part(version, '.', 2)::int DESC,
+			split_part(version, '.', 3)::int DESC
+		 LIMIT 1`,
+		"apply_manifest",
+	).Scan(&script)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrSagaNotFound, err)
+	}
+
+	return script, nil
+}
+
+// buildSagaInput converts the structured input into the map[string]interface{}
+// format expected by the Starlark saga runner.
+func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]interface{} {
+	sagaInput := map[string]interface{}{
+		"manifest_version": input.ManifestVersion,
+	}
+
+	// Convert instruments
+	instruments := make([]interface{}, len(input.Instruments))
+	for i, inst := range input.Instruments {
+		instruments[i] = map[string]interface{}{
+			"code":           inst.Code,
+			"display_name":   inst.DisplayName,
+			"dimension":      inst.Dimension,
+			"decimal_places": inst.DecimalPlaces,
+			"description":    inst.Description,
+		}
+	}
+	sagaInput["instruments"] = instruments
+
+	// Convert account types
+	accountTypes := make([]interface{}, len(input.AccountTypes))
+	for i, at := range input.AccountTypes {
+		accountTypes[i] = map[string]interface{}{
+			"code":            at.Code,
+			"display_name":    at.DisplayName,
+			"description":     at.Description,
+			"instrument_code": at.InstrumentCode,
+			"account_type":    at.AccountType,
+		}
+	}
+	sagaInput["account_types"] = accountTypes
+
+	// Convert valuation rules
+	valuationRules := make([]interface{}, len(input.ValuationRules))
+	for i, vr := range input.ValuationRules {
+		valuationRules[i] = map[string]interface{}{
+			"from_instrument": vr.FromInstrument,
+			"to_instrument":   vr.ToInstrument,
+			"rule_type":       vr.RuleType,
+			"expression":      vr.Expression,
+			"description":     vr.Description,
+		}
+	}
+	sagaInput["valuation_rules"] = valuationRules
+
+	// Convert saga definitions
+	sagaDefs := make([]interface{}, len(input.SagaDefinitions))
+	for i, sd := range input.SagaDefinitions {
+		sagaDefs[i] = map[string]interface{}{
+			"name":         sd.Name,
+			"display_name": sd.DisplayName,
+			"description":  sd.Description,
+			"script":       sd.Script,
+			"version":      sd.Version,
+		}
+	}
+	sagaInput["saga_definitions"] = sagaDefs
+
+	return sagaInput
+}
+
+// parseManifestVersion converts a version string to an integer.
+// Handles both numeric ("42") and semver ("1.2.3") formats.
+func parseManifestVersion(version string) int {
+	n := 0
+	for _, c := range version {
+		if c >= '0' && c <= '9' {
+			n = n*10 + int(c-'0')
+		} else {
+			break
+		}
+	}
+	if n == 0 {
+		n = 1
+	}
+	return n
+}

--- a/services/control-plane/internal/applier/executor.go
+++ b/services/control-plane/internal/applier/executor.go
@@ -173,12 +173,17 @@ func (e *ManifestExecutor) Apply(ctx context.Context, input *ApplyManifestInput)
 		"correlation_id", correlationID,
 	)
 
-	// Execute the saga
+	// Execute the saga with tenant-scoped party context.
+	// The control plane is a SYSTEM actor applying a manifest for a specific tenant.
 	runnerInput := saga.RunnerInput{
 		SagaExecutionID: executionID,
 		CorrelationID:   correlationID,
-		KnowledgeAt:     time.Now(),
-		Input:           sagaInput,
+		PartyScope: &saga.PartyScope{
+			PartyType: "SYSTEM",
+			TenantID:  input.TenantID,
+		},
+		KnowledgeAt: time.Now(),
+		Input:       sagaInput,
 	}
 
 	output, err := e.runner.ExecuteSaga(ctx, "apply_manifest", script, runnerInput)
@@ -200,9 +205,10 @@ func (e *ManifestExecutor) Apply(ctx context.Context, input *ApplyManifestInput)
 		}, fmt.Errorf("%w: %s", ErrSagaFailed, output.Error)
 	}
 
-	// Mark job as applied
+	// Mark job as applied - propagate error so callers know about inconsistent state
 	if err := e.jobRepo.MarkApplied(ctx, job.ID); err != nil {
 		logger.Error("failed to mark job applied", "error", err)
+		return nil, fmt.Errorf("saga succeeded but job tracking failed: %w", err)
 	}
 
 	logger.Info("manifest application completed",

--- a/services/control-plane/internal/applier/executor.go
+++ b/services/control-plane/internal/applier/executor.go
@@ -129,12 +129,25 @@ var (
 
 	// ErrSagaFailed is returned when the saga execution fails.
 	ErrSagaFailed = errors.New("saga execution failed")
+
+	// ErrNilInput is returned when the apply manifest input is nil.
+	ErrNilInput = errors.New("apply manifest: input is nil")
+
+	// ErrMissingTenantID is returned when tenant_id is empty.
+	ErrMissingTenantID = errors.New("apply manifest: tenant_id is required")
 )
 
 // Apply executes the apply_manifest saga for a tenant.
 // It resolves the saga script using platform default fallback (ADR-0028),
 // constructs the input, and runs the saga with automatic compensation.
 func (e *ManifestExecutor) Apply(ctx context.Context, input *ApplyManifestInput) (*ApplyManifestResult, error) {
+	if input == nil {
+		return nil, ErrNilInput
+	}
+	if input.TenantID == "" {
+		return nil, ErrMissingTenantID
+	}
+
 	logger := e.logger.With(
 		"manifest_version", input.ManifestVersion,
 		"tenant_id", input.TenantID,

--- a/services/control-plane/internal/applier/executor.go
+++ b/services/control-plane/internal/applier/executor.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 )
@@ -256,7 +257,10 @@ func (e *ManifestExecutor) resolveSagaScript(ctx context.Context) (string, error
 		"apply_manifest",
 	).Scan(&script)
 	if err != nil {
-		return "", fmt.Errorf("%w: %w", ErrSagaNotFound, err)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", ErrSagaNotFound
+		}
+		return "", fmt.Errorf("query platform saga definition: %w", err)
 	}
 
 	return script, nil

--- a/services/control-plane/internal/applier/executor.go
+++ b/services/control-plane/internal/applier/executor.go
@@ -219,9 +219,10 @@ func (e *ManifestExecutor) Apply(ctx context.Context, input *ApplyManifestInput)
 	}, nil
 }
 
-// resolveSagaScript resolves the apply_manifest saga script.
-// Per ADR-0028, it first checks for a tenant-specific override,
-// then falls back to the platform default in public.platform_saga_definition.
+// resolveSagaScript resolves the apply_manifest saga script from the platform default table.
+// Per ADR-0028, the control plane uses the platform default directly from
+// public.platform_saga_definition. Tenant-specific saga overrides are resolved
+// by the Reference Data service's saga registry (GetActive), not here.
 func (e *ManifestExecutor) resolveSagaScript(ctx context.Context) (string, error) {
 	// Query platform default (applies to all tenants including those with 0 local saga definitions)
 	var script string
@@ -304,8 +305,11 @@ func (e *ManifestExecutor) buildSagaInput(input *ApplyManifestInput) map[string]
 	return sagaInput
 }
 
-// parseManifestVersion converts a version string to an integer.
-// Handles both numeric ("42") and semver ("1.2.3") formats.
+// parseManifestVersion extracts the leading numeric portion of a version string.
+// For numeric strings ("42"), returns the number directly.
+// For semver-like strings ("1.2.3"), returns only the major version (1).
+// Returns 1 as default for empty or non-numeric strings.
+// The full version string is preserved separately in ApplyManifestResult.Version.
 func parseManifestVersion(version string) int {
 	n := 0
 	for _, c := range version {

--- a/services/control-plane/internal/applier/executor_test.go
+++ b/services/control-plane/internal/applier/executor_test.go
@@ -310,19 +310,25 @@ func TestApplyManifestSaga_ZeroLocalSagaDefinitions(t *testing.T) {
 		assert.True(t, step.Success, "step %s must succeed", step.StepName)
 	}
 
-	// Step 9: Verify compensation metadata is set for compensable steps
-	// register_instrument steps should have compensation handler
+	// Step 9: Verify compensation metadata is set for compensable steps.
+	// StepResult.StepName is the handler qualified name (e.g., "reference_data.register_instrument"),
+	// not the Starlark step() name (e.g., "register_instrument_USD"). This is because typed
+	// service modules record the handler name in the step result.
+	var compensationCount int
 	for _, step := range output.StepResults {
 		switch step.StepName {
 		case "reference_data.register_instrument":
 			assert.Equal(t, "reference_data.delete_instrument", step.CompensateHandler,
 				"register_instrument must have delete_instrument compensation")
 			assert.NotEmpty(t, step.CompensateParams, "compensation params must be derived")
+			compensationCount++
 		case "reference_data.register_account_type":
 			assert.Equal(t, "reference_data.delete_account_type", step.CompensateHandler,
 				"register_account_type must have delete_account_type compensation")
+			compensationCount++
 		}
 	}
+	assert.Equal(t, 3, compensationCount, "must find compensation metadata for 2 instruments + 1 account type")
 }
 
 // embeddedHandlersYAML reads the handlers.yaml from the applier package.

--- a/services/control-plane/internal/applier/executor_test.go
+++ b/services/control-plane/internal/applier/executor_test.go
@@ -1,0 +1,331 @@
+package applier
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/meridianhub/meridian/shared/pkg/saga/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildSagaInput(t *testing.T) {
+	executor := &ManifestExecutor{}
+
+	input := &ApplyManifestInput{
+		ManifestVersion: "42",
+		TenantID:        "org_test",
+		Instruments: []InstrumentInput{
+			{
+				Code:          "USD",
+				DisplayName:   "US Dollar",
+				Dimension:     "CURRENCY",
+				DecimalPlaces: 2,
+			},
+			{
+				Code:          "KWH",
+				DisplayName:   "Kilowatt Hour",
+				Dimension:     "ENERGY",
+				DecimalPlaces: 4,
+			},
+		},
+		AccountTypes: []AccountTypeInput{
+			{
+				Code:           "CLEARING_USD",
+				DisplayName:    "USD Clearing Account",
+				InstrumentCode: "USD",
+				AccountType:    "CLEARING",
+			},
+		},
+		ValuationRules: []ValuationRuleInput{
+			{
+				FromInstrument: "KWH",
+				ToInstrument:   "GBP",
+				RuleType:       "FIXED_RATE",
+			},
+		},
+		SagaDefinitions: []SagaDefinitionInput{
+			{
+				Name:    "deposit",
+				Version: "1.0.0",
+			},
+		},
+	}
+
+	sagaInput := executor.buildSagaInput(input)
+
+	assert.Equal(t, "42", sagaInput["manifest_version"])
+
+	instruments, ok := sagaInput["instruments"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, instruments, 2)
+
+	firstInst, ok := instruments[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "USD", firstInst["code"])
+	assert.Equal(t, "CURRENCY", firstInst["dimension"])
+
+	accountTypes, ok := sagaInput["account_types"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, accountTypes, 1)
+
+	firstAT, ok := accountTypes[0].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "CLEARING_USD", firstAT["code"])
+	assert.Equal(t, "USD", firstAT["instrument_code"])
+
+	rules, ok := sagaInput["valuation_rules"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, rules, 1)
+
+	sagaDefs, ok := sagaInput["saga_definitions"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, sagaDefs, 1)
+}
+
+func TestBuildSagaInput_Empty(t *testing.T) {
+	executor := &ManifestExecutor{}
+
+	input := &ApplyManifestInput{
+		ManifestVersion: "1",
+	}
+
+	sagaInput := executor.buildSagaInput(input)
+
+	assert.Equal(t, "1", sagaInput["manifest_version"])
+
+	instruments, ok := sagaInput["instruments"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, instruments)
+
+	accountTypes, ok := sagaInput["account_types"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, accountTypes)
+}
+
+func TestParseManifestVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int
+	}{
+		{"1", 1},
+		{"42", 42},
+		{"100", 100},
+		{"1.2.3", 1},
+		{"", 1},
+		{"abc", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, parseManifestVersion(tt.input))
+		})
+	}
+}
+
+func TestNewManifestExecutor(t *testing.T) {
+	executor := NewManifestExecutor(ManifestExecutorConfig{})
+	require.NotNil(t, executor)
+	assert.NotNil(t, executor.logger)
+}
+
+// TestApplyManifestSaga_ZeroLocalSagaDefinitions is the critical test for subtask 7.7.
+// It validates the complete end-to-end path for a tenant with 0 local saga definitions:
+//  1. Load the embedded apply_manifest.star from platform defaults
+//  2. Register all manifest handlers (reference_data + internal_bank_account)
+//  3. Build typed Starlark service modules from handlers.yaml schema
+//  4. Execute the saga with a full manifest input
+//  5. Verify all 4 phases execute in order and produce correct results
+//
+// This test proves that the platform default fallback (ADR-0028) path works:
+// a brand-new tenant can apply a manifest using only the embedded saga script.
+func TestApplyManifestSaga_ZeroLocalSagaDefinitions(t *testing.T) {
+	// Step 1: Load embedded saga script (simulates platform default fallback)
+	script, version, err := loadEmbeddedApplyManifest()
+	require.NoError(t, err, "embedded apply_manifest saga must be loadable")
+	assert.Equal(t, "1.0.0", version)
+	assert.Contains(t, script, "execute_apply_manifest")
+
+	// Step 2: Set up handler registry with mock handlers
+	registry := saga.NewHandlerRegistry()
+
+	// Track which handlers are called and in what order
+	var handlerCalls []string
+	mockRefData := &mockReferenceData{
+		registerInstrumentFn: func(_ *saga.StarlarkContext, params map[string]any) (any, error) {
+			handlerCalls = append(handlerCalls, "register_instrument:"+params["instrument_code"].(string))
+			return map[string]any{
+				"instrument_code": params["instrument_code"],
+				"status":          "REGISTERED",
+			}, nil
+		},
+		registerAccountTypeFn: func(_ *saga.StarlarkContext, params map[string]any) (any, error) {
+			handlerCalls = append(handlerCalls, "register_account_type:"+params["account_type_code"].(string))
+			return map[string]any{
+				"account_type_code": params["account_type_code"],
+				"status":            "REGISTERED",
+			}, nil
+		},
+		registerValuationRuleFn: func(_ *saga.StarlarkContext, params map[string]any) (any, error) {
+			handlerCalls = append(handlerCalls, "register_valuation_rule:"+params["from_instrument"].(string)+"_"+params["to_instrument"].(string))
+			return map[string]any{
+				"from_instrument": params["from_instrument"],
+				"to_instrument":   params["to_instrument"],
+				"status":          "REGISTERED",
+			}, nil
+		},
+		registerSagaDefinitionFn: func(_ *saga.StarlarkContext, params map[string]any) (any, error) {
+			handlerCalls = append(handlerCalls, "register_saga_definition:"+params["saga_name"].(string))
+			return map[string]any{
+				"saga_name": params["saga_name"],
+				"status":    "REGISTERED",
+			}, nil
+		},
+	}
+	mockIBA := &mockInternalBankAccount{
+		initiateAccountFn: func(_ *saga.StarlarkContext, params map[string]any) (any, error) {
+			handlerCalls = append(handlerCalls, "initiate_account:"+params["account_code"].(string))
+			return map[string]any{
+				"account_id":      uuid.New().String(),
+				"account_code":    params["account_code"],
+				"name":            params["name"],
+				"account_type":    params["account_type"],
+				"status":          "ACTIVE",
+				"instrument_code": params["instrument_code"],
+			}, nil
+		},
+	}
+
+	deps := &HandlerDependencies{
+		ReferenceData:       mockRefData,
+		InternalBankAccount: mockIBA,
+	}
+	err = RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	// Step 3: Load handlers.yaml schema and build typed service modules
+	handlersYAML, err := embeddedHandlersYAML()
+	require.NoError(t, err, "handlers.yaml must be loadable")
+
+	schemaRegistry := schema.NewRegistry()
+	err = schemaRegistry.LoadFromYAML(handlersYAML)
+	require.NoError(t, err, "handlers.yaml must parse correctly")
+
+	serviceModules, err := schema.BuildServiceModules(registry, schemaRegistry)
+	require.NoError(t, err, "service modules must build from schema + registry")
+
+	// Step 4: Create the saga runner
+	runtime, err := saga.NewRuntime(nil)
+	require.NoError(t, err)
+
+	runner, err := saga.NewStarlarkSagaRunner(saga.StarlarkSagaRunnerConfig{
+		Runtime:        runtime,
+		Registry:       registry,
+		ServiceModules: serviceModules,
+	})
+	require.NoError(t, err)
+
+	// Step 5: Build manifest input (simulates a real manifest apply)
+	executor := &ManifestExecutor{}
+	manifestInput := &ApplyManifestInput{
+		ManifestVersion: "1",
+		TenantID:        "org_new_tenant",
+		Instruments: []InstrumentInput{
+			{
+				Code:          "USD",
+				DisplayName:   "US Dollar",
+				Dimension:     "CURRENCY",
+				DecimalPlaces: 2,
+			},
+			{
+				Code:          "KWH",
+				DisplayName:   "Kilowatt Hour",
+				Dimension:     "ENERGY",
+				DecimalPlaces: 4,
+			},
+		},
+		AccountTypes: []AccountTypeInput{
+			{
+				Code:           "CLEARING_USD",
+				DisplayName:    "USD Clearing Account",
+				InstrumentCode: "USD",
+				AccountType:    "CLEARING",
+			},
+		},
+		ValuationRules: []ValuationRuleInput{
+			{
+				FromInstrument: "KWH",
+				ToInstrument:   "GBP",
+				RuleType:       "FIXED_RATE",
+			},
+		},
+		SagaDefinitions: []SagaDefinitionInput{
+			{
+				Name:    "deposit",
+				Version: "1.0.0",
+			},
+		},
+	}
+
+	sagaInput := executor.buildSagaInput(manifestInput)
+
+	// Step 6: Execute the saga
+	runnerInput := saga.RunnerInput{
+		SagaExecutionID: uuid.New(),
+		CorrelationID:   uuid.New(),
+		KnowledgeAt:     time.Now(),
+		Input:           sagaInput,
+	}
+
+	output, err := runner.ExecuteSaga(context.Background(), "apply_manifest", script, runnerInput)
+	require.NoError(t, err, "saga execution must not return error")
+	require.NotNil(t, output)
+	assert.True(t, output.Success, "saga must succeed; error: %s", output.Error)
+
+	// Step 7: Verify phased execution order
+	// Phase 1: Instruments (2 instruments)
+	// Phase 2: Account types (1 register + 1 initiate)
+	// Phase 3: Valuation rules (1 rule)
+	// Phase 4: Saga definitions (1 definition)
+	expectedCalls := []string{
+		// Phase 1
+		"register_instrument:USD",
+		"register_instrument:KWH",
+		// Phase 2
+		"register_account_type:CLEARING_USD",
+		"initiate_account:CLEARING_USD",
+		// Phase 3
+		"register_valuation_rule:KWH_GBP",
+		// Phase 4
+		"register_saga_definition:deposit",
+	}
+	assert.Equal(t, expectedCalls, handlerCalls, "handlers must be called in phased order")
+
+	// Step 8: Verify step results
+	assert.Len(t, output.StepResults, 6, "must have 6 step results (2+2+1+1)")
+	for _, step := range output.StepResults {
+		assert.True(t, step.Success, "step %s must succeed", step.StepName)
+	}
+
+	// Step 9: Verify compensation metadata is set for compensable steps
+	// register_instrument steps should have compensation handler
+	for _, step := range output.StepResults {
+		switch step.StepName {
+		case "reference_data.register_instrument":
+			assert.Equal(t, "reference_data.delete_instrument", step.CompensateHandler,
+				"register_instrument must have delete_instrument compensation")
+			assert.NotEmpty(t, step.CompensateParams, "compensation params must be derived")
+		case "reference_data.register_account_type":
+			assert.Equal(t, "reference_data.delete_account_type", step.CompensateHandler,
+				"register_account_type must have delete_account_type compensation")
+		}
+	}
+}
+
+// embeddedHandlersYAML reads the handlers.yaml from the applier package.
+func embeddedHandlersYAML() ([]byte, error) {
+	return handlersYAMLFS.ReadFile("handlers.yaml")
+}

--- a/services/control-plane/internal/applier/handlers.go
+++ b/services/control-plane/internal/applier/handlers.go
@@ -1,0 +1,163 @@
+package applier
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+//go:embed handlers.yaml
+var handlersYAMLFS embed.FS
+
+// RegisterManifestHandlers registers all Starlark service bindings needed by
+// the apply_manifest saga. These handlers adapt Starlark parameters to the
+// Control Plane's downstream service calls.
+//
+// The apply_manifest saga calls handlers in four service namespaces:
+//   - reference_data: RegisterInstrument, RegisterAccountType, RegisterValuationRule, RegisterSagaDefinition
+//   - internal_bank_account: Initiate
+//
+// Each handler is registered with metadata for compensation support.
+func RegisterManifestHandlers(registry *saga.HandlerRegistry, deps *HandlerDependencies) error {
+	handlers := map[string]struct {
+		handler  saga.Handler
+		metadata saga.HandlerMetadata
+	}{
+		// Reference Data - Instrument registration
+		"reference_data.register_instrument": {
+			handler: registerInstrumentHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:            saga.HandlerCategorySettlement,
+				ProducesInstruments: []string{},
+			},
+		},
+		// Reference Data - Account type registration
+		"reference_data.register_account_type": {
+			handler: registerAccountTypeHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:            saga.HandlerCategorySettlement,
+				ProducesInstruments: []string{},
+			},
+		},
+		// Reference Data - Valuation rule registration
+		"reference_data.register_valuation_rule": {
+			handler: registerValuationRuleHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:            saga.HandlerCategorySettlement,
+				ProducesInstruments: []string{},
+			},
+		},
+		// Reference Data - Saga definition registration
+		"reference_data.register_saga_definition": {
+			handler: registerSagaDefinitionHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:            saga.HandlerCategorySettlement,
+				ProducesInstruments: []string{},
+			},
+		},
+		// Internal Bank Account - Account initiation
+		"internal_bank_account.initiate": {
+			handler: initiateAccountHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:            saga.HandlerCategorySettlement,
+				ProducesInstruments: []string{},
+			},
+		},
+		// Compensation handlers
+		"reference_data.delete_instrument": {
+			handler: deleteInstrumentHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:            saga.HandlerCategorySettlement,
+				ProducesInstruments: []string{},
+			},
+		},
+		"reference_data.delete_account_type": {
+			handler: deleteAccountTypeHandler(deps),
+			metadata: saga.HandlerMetadata{
+				Category:            saga.HandlerCategorySettlement,
+				ProducesInstruments: []string{},
+			},
+		},
+	}
+
+	for name, h := range handlers {
+		if err := registry.RegisterWithMetadata(name, h.handler, &h.metadata); err != nil {
+			return fmt.Errorf("failed to register %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// HandlerDependencies holds the service clients needed by manifest handlers.
+// These are injected at startup and provide gRPC connectivity to downstream services.
+type HandlerDependencies struct {
+	// ReferenceData provides instrument, account type, valuation rule, and saga management.
+	ReferenceData ReferenceDataService
+	// InternalBankAccount provides account provisioning.
+	InternalBankAccount InternalBankAccountService
+}
+
+// ReferenceDataService abstracts the Reference Data gRPC client for testing.
+type ReferenceDataService interface {
+	RegisterInstrument(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+	DeleteInstrument(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+	RegisterAccountType(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+	DeleteAccountType(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+	RegisterValuationRule(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+	RegisterSagaDefinition(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+}
+
+// InternalBankAccountService abstracts the Internal Bank Account gRPC client for testing.
+type InternalBankAccountService interface {
+	InitiateAccount(ctx *saga.StarlarkContext, params map[string]any) (any, error)
+}
+
+// registerInstrumentHandler creates a handler that registers an instrument via Reference Data.
+func registerInstrumentHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		return deps.ReferenceData.RegisterInstrument(ctx, params)
+	}
+}
+
+// deleteInstrumentHandler creates a compensation handler that removes an instrument.
+func deleteInstrumentHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		return deps.ReferenceData.DeleteInstrument(ctx, params)
+	}
+}
+
+// registerAccountTypeHandler creates a handler that registers an account type.
+func registerAccountTypeHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		return deps.ReferenceData.RegisterAccountType(ctx, params)
+	}
+}
+
+// deleteAccountTypeHandler creates a compensation handler that removes an account type.
+func deleteAccountTypeHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		return deps.ReferenceData.DeleteAccountType(ctx, params)
+	}
+}
+
+// registerValuationRuleHandler creates a handler that registers a valuation rule.
+func registerValuationRuleHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		return deps.ReferenceData.RegisterValuationRule(ctx, params)
+	}
+}
+
+// registerSagaDefinitionHandler creates a handler that registers a saga definition.
+func registerSagaDefinitionHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		return deps.ReferenceData.RegisterSagaDefinition(ctx, params)
+	}
+}
+
+// initiateAccountHandler creates a handler that initiates an internal bank account.
+func initiateAccountHandler(deps *HandlerDependencies) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		return deps.InternalBankAccount.InitiateAccount(ctx, params)
+	}
+}

--- a/services/control-plane/internal/applier/handlers.yaml
+++ b/services/control-plane/internal/applier/handlers.yaml
@@ -1,0 +1,209 @@
+# Control Plane Manifest Handler Schemas
+# These schemas define the type signatures for apply_manifest saga handlers.
+
+service: control_plane
+version: "1.0"
+
+handlers:
+  # Reference Data - Instrument Management
+  reference_data.register_instrument:
+    description: "Register a new instrument definition in Reference Data service"
+    params:
+      instrument_code:
+        type: string
+        required: true
+        description: "Unique instrument code (e.g., USD, KWH)"
+      display_name:
+        type: string
+        required: false
+        description: "Human-readable instrument name"
+      dimension:
+        type: string
+        required: false
+        description: "Physical dimension (CURRENCY, ENERGY, etc.)"
+      decimal_places:
+        type: int64
+        required: false
+        description: "Decimal precision (0-18)"
+      description:
+        type: string
+        required: false
+        description: "Instrument description"
+    returns:
+      instrument_code:
+        type: string
+        description: "The registered instrument code"
+      status:
+        type: string
+        description: "Registration status (REGISTERED)"
+    compensate: reference_data.delete_instrument
+
+  reference_data.delete_instrument:
+    description: "Delete an instrument (compensation for register)"
+    params:
+      instrument_code:
+        type: string
+        required: true
+        description: "Instrument code to delete"
+    returns:
+      instrument_code:
+        type: string
+        description: "The deleted instrument code"
+      status:
+        type: string
+        description: "Deletion status (DELETED)"
+
+  # Reference Data - Account Type Management
+  reference_data.register_account_type:
+    description: "Register a new account type definition in Reference Data service"
+    params:
+      account_type_code:
+        type: string
+        required: true
+        description: "Unique account type code"
+      display_name:
+        type: string
+        required: false
+        description: "Human-readable account type name"
+      description:
+        type: string
+        required: false
+        description: "Account type description"
+      instrument_code:
+        type: string
+        required: true
+        description: "Default instrument code for this account type"
+    returns:
+      account_type_code:
+        type: string
+        description: "The registered account type code"
+      status:
+        type: string
+        description: "Registration status (REGISTERED)"
+    compensate: reference_data.delete_account_type
+
+  reference_data.delete_account_type:
+    description: "Delete an account type (compensation for register)"
+    params:
+      account_type_code:
+        type: string
+        required: true
+        description: "Account type code to delete"
+    returns:
+      account_type_code:
+        type: string
+        description: "The deleted account type code"
+      status:
+        type: string
+        description: "Deletion status (DELETED)"
+
+  # Reference Data - Valuation Rules
+  reference_data.register_valuation_rule:
+    description: "Register a valuation rule for cross-instrument conversion"
+    params:
+      from_instrument:
+        type: string
+        required: true
+        description: "Source instrument code"
+      to_instrument:
+        type: string
+        required: true
+        description: "Target instrument code"
+      rule_type:
+        type: string
+        required: false
+        description: "Rule type (FIXED_RATE, MARKET, etc.)"
+      expression:
+        type: string
+        required: false
+        description: "CEL expression for valuation computation"
+      description:
+        type: string
+        required: false
+        description: "Rule description"
+    returns:
+      from_instrument:
+        type: string
+        description: "Source instrument code"
+      to_instrument:
+        type: string
+        description: "Target instrument code"
+      status:
+        type: string
+        description: "Registration status (REGISTERED)"
+
+  # Reference Data - Saga Definition
+  reference_data.register_saga_definition:
+    description: "Register a saga definition in the saga registry"
+    params:
+      saga_name:
+        type: string
+        required: true
+        description: "Saga identifier name"
+      display_name:
+        type: string
+        required: false
+        description: "Human-readable saga name"
+      description:
+        type: string
+        required: false
+        description: "Saga description"
+      script:
+        type: string
+        required: false
+        description: "Starlark script content"
+      version:
+        type: string
+        required: false
+        description: "Saga version (semver format)"
+    returns:
+      saga_name:
+        type: string
+        description: "The registered saga name"
+      status:
+        type: string
+        description: "Registration status (REGISTERED)"
+
+  # Internal Bank Account - Account Provisioning
+  internal_bank_account.initiate:
+    description: "Initiate a new internal bank account"
+    params:
+      account_code:
+        type: string
+        required: true
+        description: "Business-friendly account code"
+      name:
+        type: string
+        required: true
+        description: "Human-readable account name"
+      account_type:
+        type: string
+        required: true
+        description: "Account type (CLEARING, NOSTRO, etc.)"
+      instrument_code:
+        type: string
+        required: true
+        description: "Instrument code (e.g., USD, KWH)"
+      description:
+        type: string
+        required: false
+        description: "Account description"
+    returns:
+      account_id:
+        type: string
+        description: "Generated account identifier"
+      account_code:
+        type: string
+        description: "Echo of account code"
+      name:
+        type: string
+        description: "Echo of account name"
+      account_type:
+        type: string
+        description: "Echo of account type"
+      status:
+        type: string
+        description: "Account status (ACTIVE)"
+      instrument_code:
+        type: string
+        description: "Echo of instrument code"

--- a/services/control-plane/internal/applier/handlers_test.go
+++ b/services/control-plane/internal/applier/handlers_test.go
@@ -1,0 +1,304 @@
+package applier
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockReferenceData implements ReferenceDataService for testing.
+type mockReferenceData struct {
+	registerInstrumentFn     func(*saga.StarlarkContext, map[string]any) (any, error)
+	deleteInstrumentFn       func(*saga.StarlarkContext, map[string]any) (any, error)
+	registerAccountTypeFn    func(*saga.StarlarkContext, map[string]any) (any, error)
+	deleteAccountTypeFn      func(*saga.StarlarkContext, map[string]any) (any, error)
+	registerValuationRuleFn  func(*saga.StarlarkContext, map[string]any) (any, error)
+	registerSagaDefinitionFn func(*saga.StarlarkContext, map[string]any) (any, error)
+}
+
+func (m *mockReferenceData) RegisterInstrument(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.registerInstrumentFn != nil {
+		return m.registerInstrumentFn(ctx, params)
+	}
+	return map[string]any{"instrument_code": params["instrument_code"], "status": "REGISTERED"}, nil
+}
+
+func (m *mockReferenceData) DeleteInstrument(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.deleteInstrumentFn != nil {
+		return m.deleteInstrumentFn(ctx, params)
+	}
+	return map[string]any{"instrument_code": params["instrument_code"], "status": "DELETED"}, nil
+}
+
+func (m *mockReferenceData) RegisterAccountType(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.registerAccountTypeFn != nil {
+		return m.registerAccountTypeFn(ctx, params)
+	}
+	return map[string]any{"account_type_code": params["account_type_code"], "status": "REGISTERED"}, nil
+}
+
+func (m *mockReferenceData) DeleteAccountType(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.deleteAccountTypeFn != nil {
+		return m.deleteAccountTypeFn(ctx, params)
+	}
+	return map[string]any{"account_type_code": params["account_type_code"], "status": "DELETED"}, nil
+}
+
+func (m *mockReferenceData) RegisterValuationRule(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.registerValuationRuleFn != nil {
+		return m.registerValuationRuleFn(ctx, params)
+	}
+	return map[string]any{
+		"from_instrument": params["from_instrument"],
+		"to_instrument":   params["to_instrument"],
+		"status":          "REGISTERED",
+	}, nil
+}
+
+func (m *mockReferenceData) RegisterSagaDefinition(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.registerSagaDefinitionFn != nil {
+		return m.registerSagaDefinitionFn(ctx, params)
+	}
+	return map[string]any{"saga_name": params["saga_name"], "status": "REGISTERED"}, nil
+}
+
+// mockInternalBankAccount implements InternalBankAccountService for testing.
+type mockInternalBankAccount struct {
+	initiateAccountFn func(*saga.StarlarkContext, map[string]any) (any, error)
+}
+
+func (m *mockInternalBankAccount) InitiateAccount(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+	if m.initiateAccountFn != nil {
+		return m.initiateAccountFn(ctx, params)
+	}
+	return map[string]any{
+		"account_id":      uuid.New().String(),
+		"account_code":    params["account_code"],
+		"name":            params["name"],
+		"account_type":    params["account_type"],
+		"status":          "ACTIVE",
+		"instrument_code": params["instrument_code"],
+	}, nil
+}
+
+func newTestStarlarkContext() *saga.StarlarkContext {
+	return &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		CorrelationID:   uuid.New(),
+		KnowledgeAt:     time.Now(),
+	}
+}
+
+func TestRegisterManifestHandlers(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:       &mockReferenceData{},
+		InternalBankAccount: &mockInternalBankAccount{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	expectedHandlers := []string{
+		"reference_data.register_instrument",
+		"reference_data.delete_instrument",
+		"reference_data.register_account_type",
+		"reference_data.delete_account_type",
+		"reference_data.register_valuation_rule",
+		"reference_data.register_saga_definition",
+		"internal_bank_account.initiate",
+	}
+
+	for _, name := range expectedHandlers {
+		handler, err := registry.Get(name)
+		assert.NoError(t, err, "handler %s should be registered", name)
+		assert.NotNil(t, handler, "handler %s should not be nil", name)
+	}
+}
+
+func TestRegisterInstrumentHandler(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:       &mockReferenceData{},
+		InternalBankAccount: &mockInternalBankAccount{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("reference_data.register_instrument")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"instrument_code": "USD",
+		"display_name":    "US Dollar",
+		"dimension":       "CURRENCY",
+		"decimal_places":  int64(2),
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "USD", resultMap["instrument_code"])
+	assert.Equal(t, "REGISTERED", resultMap["status"])
+}
+
+func TestRegisterInstrumentHandler_Error(t *testing.T) {
+	expectedErr := errors.New("registration failed")
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData: &mockReferenceData{
+			registerInstrumentFn: func(_ *saga.StarlarkContext, _ map[string]any) (any, error) {
+				return nil, expectedErr
+			},
+		},
+		InternalBankAccount: &mockInternalBankAccount{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("reference_data.register_instrument")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{"instrument_code": "FAIL"})
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestInitiateAccountHandler(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:       &mockReferenceData{},
+		InternalBankAccount: &mockInternalBankAccount{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("internal_bank_account.initiate")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"account_code":    "CLEARING_USD",
+		"name":            "USD Clearing Account",
+		"account_type":    "CLEARING",
+		"instrument_code": "USD",
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "CLEARING_USD", resultMap["account_code"])
+	assert.Equal(t, "ACTIVE", resultMap["status"])
+	assert.NotEmpty(t, resultMap["account_id"])
+}
+
+func TestRegisterValuationRuleHandler(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:       &mockReferenceData{},
+		InternalBankAccount: &mockInternalBankAccount{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("reference_data.register_valuation_rule")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"from_instrument": "KWH",
+		"to_instrument":   "GBP",
+		"rule_type":       "FIXED_RATE",
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "KWH", resultMap["from_instrument"])
+	assert.Equal(t, "GBP", resultMap["to_instrument"])
+	assert.Equal(t, "REGISTERED", resultMap["status"])
+}
+
+func TestRegisterSagaDefinitionHandler(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:       &mockReferenceData{},
+		InternalBankAccount: &mockInternalBankAccount{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("reference_data.register_saga_definition")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	params := map[string]any{
+		"saga_name":    "current_account_deposit",
+		"display_name": "Current Account Deposit",
+		"version":      "1.0.0",
+	}
+
+	result, err := handler(ctx, params)
+	require.NoError(t, err)
+
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "current_account_deposit", resultMap["saga_name"])
+	assert.Equal(t, "REGISTERED", resultMap["status"])
+}
+
+func TestCompensationHandlers(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	deps := &HandlerDependencies{
+		ReferenceData:       &mockReferenceData{},
+		InternalBankAccount: &mockInternalBankAccount{},
+	}
+
+	err := RegisterManifestHandlers(registry, deps)
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+
+	t.Run("delete_instrument", func(t *testing.T) {
+		handler, err := registry.Get("reference_data.delete_instrument")
+		require.NoError(t, err)
+
+		result, err := handler(ctx, map[string]any{"instrument_code": "USD"})
+		require.NoError(t, err)
+
+		resultMap, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "DELETED", resultMap["status"])
+	})
+
+	t.Run("delete_account_type", func(t *testing.T) {
+		handler, err := registry.Get("reference_data.delete_account_type")
+		require.NoError(t, err)
+
+		result, err := handler(ctx, map[string]any{"account_type_code": "CLEARING"})
+		require.NoError(t, err)
+
+		resultMap, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "DELETED", resultMap["status"])
+	})
+}

--- a/services/control-plane/migrations/20260209000002_manifest_apply_jobs.sql
+++ b/services/control-plane/migrations/20260209000002_manifest_apply_jobs.sql
@@ -1,0 +1,30 @@
+-- Manifest Apply Jobs Table
+-- Tracks the status of manifest application jobs, linking to saga executions
+-- for durable orchestration and causation tree visibility.
+-- Multi-tenancy: Schema-per-tenant architecture means no tenant_id column needed.
+
+CREATE TABLE "manifest_apply_job" (
+  "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+  "manifest_version" integer NOT NULL,
+  "saga_execution_id" uuid,
+  "status" varchar(32) NOT NULL DEFAULT 'PENDING',
+  "error" text,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "completed_at" timestamptz,
+  PRIMARY KEY ("id"),
+  CONSTRAINT "chk_manifest_apply_job_status"
+    CHECK ("status" IN ('PENDING', 'APPLYING', 'APPLIED', 'FAILED'))
+);
+
+-- Index for finding jobs by manifest version
+CREATE INDEX "idx_manifest_apply_job_version" ON "manifest_apply_job" ("manifest_version");
+
+-- Index for finding active/pending jobs
+CREATE INDEX "idx_manifest_apply_job_status" ON "manifest_apply_job" ("status")
+  WHERE "status" IN ('PENDING', 'APPLYING');
+
+-- Index for saga causation tree lookups
+CREATE INDEX "idx_manifest_apply_job_saga" ON "manifest_apply_job" ("saga_execution_id")
+  WHERE "saga_execution_id" IS NOT NULL;
+
+COMMENT ON TABLE "manifest_apply_job" IS 'Tracks manifest application jobs with status and linkage to saga executions for durable orchestration.';


### PR DESCRIPTION
## Summary

- Implement the ApplyManifest orchestrator as a Starlark Saga that executes planned gRPC calls with automatic LIFO compensation on failure
- Create phased execution pipeline (Instruments -> Account Types -> Valuation Rules -> Saga Definitions) with typed service modules and schema-driven parameter validation
- Add platform default fallback (ADR-0028) so tenants with 0 local saga definitions can apply manifests using the embedded apply_manifest.star script

## Changes Made

### Starlark Saga (`v1.0.0.star`)
- 4-phase execution with `step()` annotations for each handler call
- Uses typed service modules (`reference_data.register_instrument(...)`) instead of magic strings
- Phase 2 chains account type registration with internal bank account initiation

### Service Bindings (`handlers.go` + `handlers.yaml`)
- 7 handler registrations: register_instrument, delete_instrument, register_account_type, delete_account_type, register_valuation_rule, register_saga_definition, internal_bank_account.initiate
- Interface-based dependency injection (`ReferenceDataService`, `InternalBankAccountService`) for testability
- Schema definitions in `handlers.yaml` with `compensate:` declarations for automatic rollback

### Bootstrap (`bootstrap.go`)
- Idempotent upsert of `apply_manifest.star` into `public.platform_saga_definition` on startup
- Deterministic UUID generation via `uuid.NewSHA1` for consistent cross-instance behavior
- Race condition handling via PostgreSQL unique constraint (23505)
- Embedded filesystem with semver-based version selection

### Executor (`executor.go`)
- `ManifestExecutor.Apply()` orchestrates the full flow: create tracking job, resolve saga script, build input, execute via saga engine
- Platform default fallback queries `public.platform_saga_definition` with semver ordering
- `buildSagaInput()` converts structured Go types to `map[string]interface{}` for Starlark

### Tracking (`apply_job.go` + migration)
- `manifest_apply_job` table with status lifecycle: PENDING -> APPLYING -> APPLIED/FAILED
- `ApplyJobRepository` with Create, MarkApplying, MarkApplied, MarkFailed, GetByID, GetByManifestVersion

## Testing

- 23 unit tests covering all components
- **Critical test** (`TestApplyManifestSaga_ZeroLocalSagaDefinitions`): End-to-end execution of the embedded saga with mock handlers, verifying:
  - All 4 phases execute in correct order (6 handler calls)
  - Compensation metadata is captured for compensable steps
  - Platform default fallback path works for new tenants

## Task Reference

control-plane.7 subtasks: 7.1-7.7

## Test plan

- [x] All 23 applier package tests pass locally
- [x] Pre-commit hooks pass (gofumpt + golangci-lint)
- [ ] CI pipeline passes
- [ ] CodeRabbit review addressed