### PR TITLE
feat: Build CFO Glass Box causation tree visualizer

### DIFF
--- a/api/proto/meridian/control_plane/v1/admin.proto
+++ b/api/proto/meridian/control_plane/v1/admin.proto
@@ -1,0 +1,112 @@
+syntax = "proto3";
+
+package meridian.control_plane.v1;
+
+import "buf/validate/validate.proto";
+import "google/api/annotations.proto";
+import "meridian/saga/v1/saga_admin.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1;controlplanev1";
+
+// CausationVisualizerService provides CFO Glass Box causation tree visualization.
+// It enables drill-down from balance sheet positions and transactions to the
+// root saga that originated them, providing a complete audit trail for CFOs
+// and compliance officers.
+//
+// The service traces the causation chain:
+//   Position/Transaction -> saga_instance -> CausationTree (via existing SagaAdminService)
+//
+// This enables the "Glass Box" pattern: click a balance sheet line item,
+// see every saga step that produced it.
+service CausationVisualizerService {
+  // GetCausationTreeForPosition traces a financial position log back to its
+  // originating saga and returns the full causation tree.
+  // The position's transaction lineage is used to find the saga that created it.
+  rpc GetCausationTreeForPosition(GetCausationTreeForPositionRequest) returns (GetCausationTreeForPositionResponse) {
+    option (google.api.http) = {
+      get: "/admin/causation-tree/position/{position_id}"
+    };
+  }
+
+  // GetCausationTreeForTransaction traces a transaction back to its originating
+  // saga and returns the full causation tree.
+  rpc GetCausationTreeForTransaction(GetCausationTreeForTransactionRequest) returns (GetCausationTreeForTransactionResponse) {
+    option (google.api.http) = {
+      get: "/admin/causation-tree/transaction/{transaction_id}"
+    };
+  }
+
+  // GetCausationTreeForEvent traces an event back through the saga execution
+  // chain using its causation_id.
+  rpc GetCausationTreeForEvent(GetCausationTreeForEventRequest) returns (GetCausationTreeForEventResponse) {
+    option (google.api.http) = {
+      get: "/admin/causation-tree/event/{event_id}"
+    };
+  }
+}
+
+// GetCausationTreeForPositionRequest identifies a financial position log to trace.
+message GetCausationTreeForPositionRequest {
+  // position_id is the UUID of the financial position log (log_id).
+  string position_id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// GetCausationTreeForPositionResponse contains the causation tree and position context.
+message GetCausationTreeForPositionResponse {
+  // tree is the root node of the causation tree.
+  meridian.saga.v1.CausationTreeNode tree = 1;
+
+  // depth is the maximum depth of the tree.
+  int32 depth = 2;
+
+  // position_id is the position that was traced.
+  string position_id = 3;
+
+  // account_id is the account associated with the position.
+  string account_id = 4;
+
+  // saga_id is the root saga that was found for this position.
+  string saga_id = 5;
+}
+
+// GetCausationTreeForTransactionRequest identifies a transaction to trace.
+message GetCausationTreeForTransactionRequest {
+  // transaction_id is the UUID of the transaction to trace.
+  string transaction_id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// GetCausationTreeForTransactionResponse contains the causation tree and transaction context.
+message GetCausationTreeForTransactionResponse {
+  // tree is the root node of the causation tree.
+  meridian.saga.v1.CausationTreeNode tree = 1;
+
+  // depth is the maximum depth of the tree.
+  int32 depth = 2;
+
+  // transaction_id is the transaction that was traced.
+  string transaction_id = 3;
+
+  // saga_id is the root saga that was found for this transaction.
+  string saga_id = 4;
+}
+
+// GetCausationTreeForEventRequest identifies an event to trace.
+message GetCausationTreeForEventRequest {
+  // event_id is the UUID of the event to trace via causation_id.
+  string event_id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// GetCausationTreeForEventResponse contains the causation tree and event context.
+message GetCausationTreeForEventResponse {
+  // tree is the root node of the causation tree.
+  meridian.saga.v1.CausationTreeNode tree = 1;
+
+  // depth is the maximum depth of the tree.
+  int32 depth = 2;
+
+  // event_id is the event that was traced.
+  string event_id = 3;
+
+  // saga_id is the root saga that was found for this event.
+  string saga_id = 4;
+}

--- a/services/control-plane/internal/admin/causation_visualizer.go
+++ b/services/control-plane/internal/admin/causation_visualizer.go
@@ -1,0 +1,392 @@
+// Package admin provides administrative services for the control plane,
+// including the CFO Glass Box causation tree visualizer.
+package admin
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+var (
+	// ErrPositionNotFound is returned when a financial position log cannot be found.
+	ErrPositionNotFound = errors.New("financial position log not found")
+	// ErrTransactionNotFound is returned when a transaction cannot be found.
+	ErrTransactionNotFound = errors.New("transaction not found")
+	// ErrEventNotFound is returned when an event cannot be found.
+	ErrEventNotFound = errors.New("event not found")
+	// ErrNoSagaFound is returned when no saga can be traced for the given entity.
+	ErrNoSagaFound = errors.New("no saga found for the given entity")
+)
+
+// PositionInfo contains metadata about a traced position.
+type PositionInfo struct {
+	PositionID uuid.UUID
+	AccountID  string
+}
+
+// CausationVisualizer traces financial positions, transactions, and events
+// back to their originating saga instances and retrieves the full causation tree.
+//
+// This enables the "Glass Box" pattern: click a balance sheet line item,
+// see every saga step that produced it.
+type CausationVisualizer struct {
+	db       *gorm.DB
+	treeRepo *saga.CausationTreeRepository
+	logger   *slog.Logger
+}
+
+// NewCausationVisualizer creates a new CausationVisualizer.
+func NewCausationVisualizer(db *gorm.DB, treeRepo *saga.CausationTreeRepository, logger *slog.Logger) *CausationVisualizer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &CausationVisualizer{
+		db:       db,
+		treeRepo: treeRepo,
+		logger:   logger,
+	}
+}
+
+// CausationTreeResult contains the causation tree along with tracing metadata.
+type CausationTreeResult struct {
+	Tree   *saga.CausationTreeNode
+	Depth  int
+	SagaID uuid.UUID
+}
+
+// GetCausationTreeForPosition traces a financial position log back to the
+// saga that created it, then returns the full causation tree.
+//
+// Tracing path: position_log -> transaction_log_entry -> idempotency_key -> saga_instance
+func (v *CausationVisualizer) GetCausationTreeForPosition(ctx context.Context, positionID uuid.UUID) (*CausationTreeResult, *PositionInfo, error) {
+	v.logger.Debug("tracing causation tree for position",
+		"position_id", positionID,
+	)
+
+	// Find the saga associated with this position by querying saga_step_results
+	// whose idempotency_key references a position-keeping operation.
+	// Saga step idempotency keys follow the pattern: saga_{instance_id}_step_{index}
+	sagaID, accountID, err := v.findSagaForPosition(ctx, positionID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tree, depth, err := v.getCausationTree(ctx, sagaID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &CausationTreeResult{
+			Tree:   tree,
+			Depth:  depth,
+			SagaID: sagaID,
+		}, &PositionInfo{
+			PositionID: positionID,
+			AccountID:  accountID,
+		}, nil
+}
+
+// GetCausationTreeForTransaction traces a transaction back to the saga that
+// created it, then returns the full causation tree.
+//
+// Tracing path: transaction_id -> saga_step_results (via correlation_id) -> saga_instance
+func (v *CausationVisualizer) GetCausationTreeForTransaction(ctx context.Context, transactionID uuid.UUID) (*CausationTreeResult, error) {
+	v.logger.Debug("tracing causation tree for transaction",
+		"transaction_id", transactionID,
+	)
+
+	sagaID, err := v.findSagaForTransaction(ctx, transactionID)
+	if err != nil {
+		return nil, err
+	}
+
+	tree, depth, err := v.getCausationTree(ctx, sagaID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CausationTreeResult{
+		Tree:   tree,
+		Depth:  depth,
+		SagaID: sagaID,
+	}, nil
+}
+
+// GetCausationTreeForEvent traces an event back through the saga execution
+// chain using its causation_id, then returns the full causation tree.
+//
+// Tracing path: event_id -> event_outbox (causation_id) -> saga_step_results -> saga_instance
+func (v *CausationVisualizer) GetCausationTreeForEvent(ctx context.Context, eventID uuid.UUID) (*CausationTreeResult, error) {
+	v.logger.Debug("tracing causation tree for event",
+		"event_id", eventID,
+	)
+
+	sagaID, err := v.findSagaForEvent(ctx, eventID)
+	if err != nil {
+		return nil, err
+	}
+
+	tree, depth, err := v.getCausationTree(ctx, sagaID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &CausationTreeResult{
+		Tree:   tree,
+		Depth:  depth,
+		SagaID: sagaID,
+	}, nil
+}
+
+// findSagaForPosition finds the root saga instance for a given position log.
+// It queries the saga_instances table looking for sagas whose correlation_id
+// matches the position's correlation chain.
+func (v *CausationVisualizer) findSagaForPosition(ctx context.Context, positionID uuid.UUID) (uuid.UUID, string, error) {
+	// Query: find a saga instance that has step results referencing this position.
+	// The link is through the saga step's idempotency key or correlation_id that
+	// matches data in the position-keeping service's transaction entries.
+	//
+	// Strategy: Look for saga_instances whose correlation_id appears in the
+	// financial position log's transaction entries (via the reference field).
+	query := `
+		SELECT si.id, COALESCE(fpl.account_id, '')
+		FROM saga_instances si
+		INNER JOIN saga_step_results ssr ON ssr.saga_instance_id = si.id
+		LEFT JOIN financial_position_logs fpl ON fpl.log_id = $1
+		WHERE si.correlation_id::text = $1::text
+		   OR ssr.idempotency_key LIKE '%' || $1::text || '%'
+		LIMIT 1
+	`
+
+	var sagaID uuid.UUID
+	var accountID string
+	err := v.db.WithContext(ctx).Raw(query, positionID).Row().Scan(&sagaID, &accountID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Fallback: try to find via the position log's lineage
+			return v.findSagaViaPositionLineage(ctx, positionID)
+		}
+		return uuid.Nil, "", fmt.Errorf("query saga for position failed: %w", err)
+	}
+
+	// Walk up to root saga
+	rootID, err := v.findRootSaga(ctx, sagaID)
+	if err != nil {
+		return uuid.Nil, "", err
+	}
+
+	return rootID, accountID, nil
+}
+
+// findSagaViaPositionLineage attempts to find a saga by querying the position
+// log's transaction lineage and matching correlation IDs.
+func (v *CausationVisualizer) findSagaViaPositionLineage(ctx context.Context, positionID uuid.UUID) (uuid.UUID, string, error) {
+	// Look for saga_instances whose correlation_id matches any transaction_id
+	// in the position log's entries, or whose step results reference the position.
+	query := `
+		SELECT si.id, ''
+		FROM saga_instances si
+		WHERE si.id = (
+			SELECT ssr.saga_instance_id
+			FROM saga_step_results ssr
+			WHERE ssr.result::text LIKE '%' || $1::text || '%'
+			LIMIT 1
+		)
+		LIMIT 1
+	`
+
+	var sagaID uuid.UUID
+	var accountID string
+	err := v.db.WithContext(ctx).Raw(query, positionID).Row().Scan(&sagaID, &accountID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return uuid.Nil, "", ErrNoSagaFound
+		}
+		return uuid.Nil, "", fmt.Errorf("query saga via position lineage failed: %w", err)
+	}
+
+	rootID, err := v.findRootSaga(ctx, sagaID)
+	if err != nil {
+		return uuid.Nil, "", err
+	}
+
+	return rootID, accountID, nil
+}
+
+// findSagaForTransaction finds the root saga instance for a given transaction.
+// It looks up saga_instances by matching the transaction_id against saga
+// correlation_id or step result data.
+func (v *CausationVisualizer) findSagaForTransaction(ctx context.Context, transactionID uuid.UUID) (uuid.UUID, error) {
+	query := `
+		SELECT si.id
+		FROM saga_instances si
+		WHERE si.correlation_id = $1
+		   OR si.id = (
+			   SELECT ssr.saga_instance_id
+			   FROM saga_step_results ssr
+			   WHERE ssr.result::text LIKE '%' || $1::text || '%'
+			   LIMIT 1
+		   )
+		ORDER BY si.created_at DESC
+		LIMIT 1
+	`
+
+	var sagaID uuid.UUID
+	err := v.db.WithContext(ctx).Raw(query, transactionID).Row().Scan(&sagaID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return uuid.Nil, ErrNoSagaFound
+		}
+		return uuid.Nil, fmt.Errorf("query saga for transaction failed: %w", err)
+	}
+
+	return v.findRootSaga(ctx, sagaID)
+}
+
+// findSagaForEvent finds the root saga instance for a given event.
+// It traces the event's causation_id back through the saga step results
+// to find the originating saga.
+func (v *CausationVisualizer) findSagaForEvent(ctx context.Context, eventID uuid.UUID) (uuid.UUID, error) {
+	// Events in the outbox have a causation_id that links to the saga step
+	// that produced them. The causation_id is a deterministic UUIDv5 generated
+	// from the saga instance ID and step index.
+	query := `
+		SELECT si.id
+		FROM saga_instances si
+		WHERE si.id = (
+			SELECT ssr.saga_instance_id
+			FROM saga_step_results ssr
+			WHERE ssr.causation_id = $1
+			LIMIT 1
+		)
+		LIMIT 1
+	`
+
+	var sagaID uuid.UUID
+	err := v.db.WithContext(ctx).Raw(query, eventID).Row().Scan(&sagaID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// Fallback: try matching on the event outbox table
+			return v.findSagaViaOutbox(ctx, eventID)
+		}
+		return uuid.Nil, fmt.Errorf("query saga for event failed: %w", err)
+	}
+
+	return v.findRootSaga(ctx, sagaID)
+}
+
+// findSagaViaOutbox attempts to find a saga by looking up the event in the
+// outbox table and following its causation chain.
+// Returns ErrNoSagaFound if the outbox table does not exist or contains no match.
+func (v *CausationVisualizer) findSagaViaOutbox(ctx context.Context, eventID uuid.UUID) (uuid.UUID, error) {
+	// Check if event_outbox table exists before querying it.
+	// This is necessary because the outbox table may not exist in all deployments
+	// (e.g., services that don't publish events).
+	var tableExists bool
+	checkQuery := `SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'event_outbox')`
+	if err := v.db.WithContext(ctx).Raw(checkQuery).Row().Scan(&tableExists); err != nil {
+		return uuid.Nil, ErrNoSagaFound
+	}
+	if !tableExists {
+		return uuid.Nil, ErrNoSagaFound
+	}
+
+	query := `
+		SELECT si.id
+		FROM saga_instances si
+		INNER JOIN saga_step_results ssr ON ssr.saga_instance_id = si.id
+		WHERE ssr.causation_id::text = (
+			SELECT eo.causation_id
+			FROM event_outbox eo
+			WHERE eo.id = $1
+			LIMIT 1
+		)
+		LIMIT 1
+	`
+
+	var sagaID uuid.UUID
+	err := v.db.WithContext(ctx).Raw(query, eventID).Row().Scan(&sagaID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return uuid.Nil, ErrNoSagaFound
+		}
+		return uuid.Nil, fmt.Errorf("query saga via outbox failed: %w", err)
+	}
+
+	return v.findRootSaga(ctx, sagaID)
+}
+
+// findRootSaga walks up the parent_saga_id chain to find the root saga.
+// It uses a recursive CTE with a depth limit for safety.
+func (v *CausationVisualizer) findRootSaga(ctx context.Context, sagaID uuid.UUID) (uuid.UUID, error) {
+	query := `
+		WITH RECURSIVE saga_chain AS (
+			SELECT id, parent_saga_id, 1 as depth
+			FROM saga_instances
+			WHERE id = $1
+
+			UNION ALL
+
+			SELECT si.id, si.parent_saga_id, sc.depth + 1
+			FROM saga_instances si
+			INNER JOIN saga_chain sc ON si.id = sc.parent_saga_id
+			WHERE sc.depth < $2
+		)
+		SELECT id
+		FROM saga_chain
+		WHERE parent_saga_id IS NULL
+		ORDER BY depth DESC
+		LIMIT 1
+	`
+
+	var rootID uuid.UUID
+	err := v.db.WithContext(ctx).Raw(query, sagaID, saga.MaxCausationTreeDepth).Row().Scan(&rootID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// If no parent found, the saga itself is the root
+			return sagaID, nil
+		}
+		return uuid.Nil, fmt.Errorf("find root saga failed: %w", err)
+	}
+
+	return rootID, nil
+}
+
+// getCausationTree retrieves the causation tree and its depth for a saga.
+func (v *CausationVisualizer) getCausationTree(ctx context.Context, sagaID uuid.UUID) (*saga.CausationTreeNode, int, error) {
+	tree, err := v.treeRepo.GetCausationTree(ctx, sagaID)
+	if err != nil {
+		if errors.Is(err, saga.ErrSagaNotFound) {
+			return nil, 0, ErrNoSagaFound
+		}
+		v.logger.Error("failed to get causation tree",
+			"saga_id", sagaID,
+			"error", err,
+		)
+		return nil, 0, fmt.Errorf("failed to retrieve causation tree: %w", err)
+	}
+
+	depth, err := v.treeRepo.GetTreeDepth(ctx, sagaID)
+	if err != nil {
+		v.logger.Warn("failed to get tree depth",
+			"saga_id", sagaID,
+			"error", err,
+		)
+		depth = 0
+	}
+
+	v.logger.Info("causation tree retrieved",
+		"saga_id", sagaID,
+		"depth", depth,
+	)
+
+	return tree, depth, nil
+}

--- a/services/control-plane/internal/admin/causation_visualizer.go
+++ b/services/control-plane/internal/admin/causation_visualizer.go
@@ -16,14 +16,10 @@ import (
 )
 
 var (
-	// ErrPositionNotFound is returned when a financial position log cannot be found.
-	ErrPositionNotFound = errors.New("financial position log not found")
-	// ErrTransactionNotFound is returned when a transaction cannot be found.
-	ErrTransactionNotFound = errors.New("transaction not found")
-	// ErrEventNotFound is returned when an event cannot be found.
-	ErrEventNotFound = errors.New("event not found")
 	// ErrNoSagaFound is returned when no saga can be traced for the given entity.
 	ErrNoSagaFound = errors.New("no saga found for the given entity")
+	// ErrCausationChainTooDeep is returned when the saga parent chain exceeds MaxCausationTreeDepth.
+	ErrCausationChainTooDeep = errors.New("causation chain exceeds maximum depth")
 )
 
 // PositionInfo contains metadata about a traced position.
@@ -192,8 +188,9 @@ func (v *CausationVisualizer) findSagaViaPositionLineage(ctx context.Context, po
 	// Look for saga_instances whose correlation_id matches any transaction_id
 	// in the position log's entries, or whose step results reference the position.
 	query := `
-		SELECT si.id, ''
+		SELECT si.id, COALESCE(fpl.account_id, '')
 		FROM saga_instances si
+		LEFT JOIN financial_position_logs fpl ON fpl.log_id = $1
 		WHERE si.id = (
 			SELECT ssr.saga_instance_id
 			FROM saga_step_results ssr
@@ -293,7 +290,7 @@ func (v *CausationVisualizer) findSagaViaOutbox(ctx context.Context, eventID uui
 	var tableExists bool
 	checkQuery := `SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'event_outbox')`
 	if err := v.db.WithContext(ctx).Raw(checkQuery).Row().Scan(&tableExists); err != nil {
-		return uuid.Nil, ErrNoSagaFound
+		return uuid.Nil, fmt.Errorf("check event_outbox table existence: %w", err)
 	}
 	if !tableExists {
 		return uuid.Nil, ErrNoSagaFound
@@ -351,8 +348,14 @@ func (v *CausationVisualizer) findRootSaga(ctx context.Context, sagaID uuid.UUID
 	err := v.db.WithContext(ctx).Raw(query, sagaID, saga.MaxCausationTreeDepth).Row().Scan(&rootID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			// If no parent found, the saga itself is the root
-			return sagaID, nil
+			// No row with parent_saga_id IS NULL found. This means either:
+			// 1. The saga chain exceeds MaxCausationTreeDepth
+			// 2. The saga_id doesn't exist in the database
+			v.logger.Warn("root saga not found",
+				"saga_id", sagaID,
+				"max_depth", saga.MaxCausationTreeDepth,
+			)
+			return uuid.Nil, fmt.Errorf("%w: saga %s (limit %d)", ErrCausationChainTooDeep, sagaID, saga.MaxCausationTreeDepth)
 		}
 		return uuid.Nil, fmt.Errorf("find root saga failed: %w", err)
 	}

--- a/services/control-plane/internal/admin/causation_visualizer_test.go
+++ b/services/control-plane/internal/admin/causation_visualizer_test.go
@@ -1,0 +1,65 @@
+package admin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+func TestNewCausationVisualizer(t *testing.T) {
+	v := NewCausationVisualizer(nil, nil, nil)
+	require.NotNil(t, v)
+	assert.NotNil(t, v.logger)
+}
+
+func TestCausationTreeResult_Fields(t *testing.T) {
+	sagaID := uuid.New()
+	now := time.Now()
+	tree := &saga.CausationTreeNode{
+		SagaID:   sagaID,
+		SagaName: "test_saga",
+		Status:   "COMPLETED",
+		Steps: []saga.StepNode{
+			{
+				Index:  0,
+				Name:   "step_0",
+				Status: "COMPLETED",
+			},
+		},
+		KnowledgeAt: &now,
+	}
+
+	result := &CausationTreeResult{
+		Tree:   tree,
+		Depth:  3,
+		SagaID: sagaID,
+	}
+
+	assert.Equal(t, sagaID, result.SagaID)
+	assert.Equal(t, 3, result.Depth)
+	assert.Equal(t, "test_saga", result.Tree.SagaName)
+	assert.Len(t, result.Tree.Steps, 1)
+}
+
+func TestPositionInfo_Fields(t *testing.T) {
+	posID := uuid.New()
+	info := &PositionInfo{
+		PositionID: posID,
+		AccountID:  "acct-001",
+	}
+
+	assert.Equal(t, posID, info.PositionID)
+	assert.Equal(t, "acct-001", info.AccountID)
+}
+
+func TestErrorSentinels(t *testing.T) {
+	assert.EqualError(t, ErrPositionNotFound, "financial position log not found")
+	assert.EqualError(t, ErrTransactionNotFound, "transaction not found")
+	assert.EqualError(t, ErrEventNotFound, "event not found")
+	assert.EqualError(t, ErrNoSagaFound, "no saga found for the given entity")
+}

--- a/services/control-plane/internal/admin/causation_visualizer_test.go
+++ b/services/control-plane/internal/admin/causation_visualizer_test.go
@@ -58,8 +58,6 @@ func TestPositionInfo_Fields(t *testing.T) {
 }
 
 func TestErrorSentinels(t *testing.T) {
-	assert.EqualError(t, ErrPositionNotFound, "financial position log not found")
-	assert.EqualError(t, ErrTransactionNotFound, "transaction not found")
-	assert.EqualError(t, ErrEventNotFound, "event not found")
 	assert.EqualError(t, ErrNoSagaFound, "no saga found for the given entity")
+	assert.EqualError(t, ErrCausationChainTooDeep, "causation chain exceeds maximum depth")
 }

--- a/services/control-plane/internal/admin/export.go
+++ b/services/control-plane/internal/admin/export.go
@@ -59,7 +59,6 @@ func exportJSON(w io.Writer, tree *saga.CausationTreeNode, depth int) error {
 
 func exportCSV(w io.Writer, tree *saga.CausationTreeNode) error {
 	writer := csv.NewWriter(w)
-	defer writer.Flush()
 
 	// Write header
 	header := []string{
@@ -72,14 +71,21 @@ func exportCSV(w io.Writer, tree *saga.CausationTreeNode) error {
 	}
 
 	// Flatten tree into rows
-	flattenTree(writer, tree, "", 0)
+	if err := flattenTree(writer, tree, "", 0); err != nil {
+		return err
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return fmt.Errorf("flush CSV: %w", err)
+	}
 
 	return nil
 }
 
-func flattenTree(w *csv.Writer, node *saga.CausationTreeNode, parentSagaID string, depth int) {
+func flattenTree(w *csv.Writer, node *saga.CausationTreeNode, parentSagaID string, depth int) error {
 	if node == nil {
-		return
+		return nil
 	}
 
 	knowledgeAt := ""
@@ -95,7 +101,7 @@ func flattenTree(w *csv.Writer, node *saga.CausationTreeNode, parentSagaID strin
 
 	if len(node.Steps) == 0 {
 		// Saga with no steps - write a single row
-		_ = w.Write([]string{
+		if err := w.Write([]string{
 			fmt.Sprintf("%d", depth),
 			node.SagaID.String(),
 			node.SagaName,
@@ -105,8 +111,10 @@ func flattenTree(w *csv.Writer, node *saga.CausationTreeNode, parentSagaID strin
 			failedStep,
 			knowledgeAt,
 			parentSagaID,
-		})
-		return
+		}); err != nil {
+			return fmt.Errorf("write CSV row: %w", err)
+		}
+		return nil
 	}
 
 	for _, step := range node.Steps {
@@ -120,7 +128,7 @@ func flattenTree(w *csv.Writer, node *saga.CausationTreeNode, parentSagaID strin
 			stepError = *step.Error
 		}
 
-		_ = w.Write([]string{
+		if err := w.Write([]string{
 			fmt.Sprintf("%d", depth),
 			node.SagaID.String(),
 			node.SagaName,
@@ -133,11 +141,17 @@ func flattenTree(w *csv.Writer, node *saga.CausationTreeNode, parentSagaID strin
 			failedStep,
 			knowledgeAt,
 			parentSagaID,
-		})
+		}); err != nil {
+			return fmt.Errorf("write CSV row: %w", err)
+		}
 
 		// Recurse into child sagas
 		for _, child := range step.ChildSagas {
-			flattenTree(w, child, node.SagaID.String(), depth+1)
+			if err := flattenTree(w, child, node.SagaID.String(), depth+1); err != nil {
+				return err
+			}
 		}
 	}
+
+	return nil
 }

--- a/services/control-plane/internal/admin/export.go
+++ b/services/control-plane/internal/admin/export.go
@@ -1,0 +1,143 @@
+package admin
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+// ErrUnsupportedExportFormat is returned when an unsupported export format is requested.
+var ErrUnsupportedExportFormat = errors.New("unsupported export format")
+
+// ExportFormat defines the output format for causation tree exports.
+type ExportFormat string
+
+const (
+	// ExportFormatJSON exports the causation tree as JSON.
+	ExportFormatJSON ExportFormat = "json"
+	// ExportFormatCSV exports the causation tree as a flattened CSV.
+	ExportFormatCSV ExportFormat = "csv"
+)
+
+// ExportCausationTree writes the causation tree to the given writer in the
+// specified format. JSON preserves the tree structure; CSV flattens it into
+// rows suitable for spreadsheet analysis by auditors.
+func ExportCausationTree(w io.Writer, tree *saga.CausationTreeNode, depth int, format ExportFormat) error {
+	switch format {
+	case ExportFormatJSON:
+		return exportJSON(w, tree, depth)
+	case ExportFormatCSV:
+		return exportCSV(w, tree)
+	default:
+		return fmt.Errorf("%w: %s", ErrUnsupportedExportFormat, format)
+	}
+}
+
+// jsonExport wraps the tree with metadata for JSON export.
+type jsonExport struct {
+	ExportedAt string                  `json:"exported_at"`
+	Depth      int                     `json:"depth"`
+	Tree       *saga.CausationTreeNode `json:"tree"`
+}
+
+func exportJSON(w io.Writer, tree *saga.CausationTreeNode, depth int) error {
+	export := jsonExport{
+		ExportedAt: time.Now().UTC().Format(time.RFC3339),
+		Depth:      depth,
+		Tree:       tree,
+	}
+
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(export)
+}
+
+func exportCSV(w io.Writer, tree *saga.CausationTreeNode) error {
+	writer := csv.NewWriter(w)
+	defer writer.Flush()
+
+	// Write header
+	header := []string{
+		"depth", "saga_id", "saga_name", "saga_status",
+		"step_index", "step_name", "step_status", "executed_at",
+		"step_error", "failed_step", "knowledge_at", "parent_saga",
+	}
+	if err := writer.Write(header); err != nil {
+		return fmt.Errorf("write CSV header: %w", err)
+	}
+
+	// Flatten tree into rows
+	flattenTree(writer, tree, "", 0)
+
+	return nil
+}
+
+func flattenTree(w *csv.Writer, node *saga.CausationTreeNode, parentSagaID string, depth int) {
+	if node == nil {
+		return
+	}
+
+	knowledgeAt := ""
+	if node.KnowledgeAt != nil {
+		knowledgeAt = node.KnowledgeAt.Format(time.RFC3339)
+	}
+
+	failedStep := ""
+	if node.FailedStep != nil {
+		failedStep = fmt.Sprintf("step %d: %s (%s)",
+			node.FailedStep.Index, node.FailedStep.Error, node.FailedStep.ErrorCategory)
+	}
+
+	if len(node.Steps) == 0 {
+		// Saga with no steps - write a single row
+		_ = w.Write([]string{
+			fmt.Sprintf("%d", depth),
+			node.SagaID.String(),
+			node.SagaName,
+			node.Status,
+			"", "", "", "",
+			"",
+			failedStep,
+			knowledgeAt,
+			parentSagaID,
+		})
+		return
+	}
+
+	for _, step := range node.Steps {
+		executedAt := ""
+		if step.ExecutedAt != nil {
+			executedAt = step.ExecutedAt.Format(time.RFC3339)
+		}
+
+		stepError := ""
+		if step.Error != nil {
+			stepError = *step.Error
+		}
+
+		_ = w.Write([]string{
+			fmt.Sprintf("%d", depth),
+			node.SagaID.String(),
+			node.SagaName,
+			node.Status,
+			fmt.Sprintf("%d", step.Index),
+			step.Name,
+			step.Status,
+			executedAt,
+			stepError,
+			failedStep,
+			knowledgeAt,
+			parentSagaID,
+		})
+
+		// Recurse into child sagas
+		for _, child := range step.ChildSagas {
+			flattenTree(w, child, node.SagaID.String(), depth+1)
+		}
+	}
+}

--- a/services/control-plane/internal/admin/export_test.go
+++ b/services/control-plane/internal/admin/export_test.go
@@ -1,0 +1,163 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+func buildTestTree() *saga.CausationTreeNode {
+	now := time.Now()
+	errMsg := "connection timeout"
+	return &saga.CausationTreeNode{
+		SagaID:      uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		SagaName:    "payment_orchestrator",
+		Status:      "COMPLETED",
+		KnowledgeAt: &now,
+		Steps: []saga.StepNode{
+			{
+				Index:      0,
+				Name:       "validate",
+				Status:     "COMPLETED",
+				ExecutedAt: &now,
+			},
+			{
+				Index:      1,
+				Name:       "charge_card",
+				Status:     "COMPLETED",
+				ExecutedAt: &now,
+				ChildSagas: []*saga.CausationTreeNode{
+					{
+						SagaID:   uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+						SagaName: "card_processor",
+						Status:   "FAILED",
+						FailedStep: &saga.FailedStep{
+							Index:         0,
+							Error:         "connection timeout",
+							ErrorCategory: "TRANSIENT",
+						},
+						Steps: []saga.StepNode{
+							{
+								Index:      0,
+								Name:       "process",
+								Status:     "FAILED",
+								ExecutedAt: &now,
+								Error:      &errMsg,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestExportJSON(t *testing.T) {
+	tree := buildTestTree()
+
+	var buf bytes.Buffer
+	err := ExportCausationTree(&buf, tree, 2, ExportFormatJSON)
+	require.NoError(t, err)
+
+	// Verify valid JSON
+	var export jsonExport
+	err = json.Unmarshal(buf.Bytes(), &export)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, export.Depth)
+	assert.NotEmpty(t, export.ExportedAt)
+	assert.Equal(t, "payment_orchestrator", export.Tree.SagaName)
+	assert.Len(t, export.Tree.Steps, 2)
+	assert.Equal(t, "COMPLETED", export.Tree.Status)
+
+	// Verify child saga is present
+	require.Len(t, export.Tree.Steps[1].ChildSagas, 1)
+	assert.Equal(t, "card_processor", export.Tree.Steps[1].ChildSagas[0].SagaName)
+}
+
+func TestExportCSV(t *testing.T) {
+	tree := buildTestTree()
+
+	var buf bytes.Buffer
+	err := ExportCausationTree(&buf, tree, 2, ExportFormatCSV)
+	require.NoError(t, err)
+
+	// Parse CSV
+	reader := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	// Header + 2 parent steps + 1 child step = 4 rows
+	require.Len(t, records, 4)
+
+	// Verify header
+	assert.Equal(t, "depth", records[0][0])
+	assert.Equal(t, "saga_id", records[0][1])
+	assert.Equal(t, "step_index", records[0][4])
+
+	// Verify parent row depth=0
+	assert.Equal(t, "0", records[1][0])
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", records[1][1])
+	assert.Equal(t, "payment_orchestrator", records[1][2])
+	assert.Equal(t, "0", records[1][4])
+	assert.Equal(t, "validate", records[1][5])
+
+	// Verify child row depth=1
+	assert.Equal(t, "1", records[3][0])
+	assert.Equal(t, "22222222-2222-2222-2222-222222222222", records[3][1])
+	assert.Equal(t, "card_processor", records[3][2])
+	assert.Contains(t, records[3][9], "connection timeout")
+	// Parent saga ID is set
+	assert.Equal(t, "11111111-1111-1111-1111-111111111111", records[3][11])
+}
+
+func TestExportCSV_SagaWithNoSteps(t *testing.T) {
+	tree := &saga.CausationTreeNode{
+		SagaID:   uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+		SagaName: "empty_saga",
+		Status:   "PENDING",
+		Steps:    []saga.StepNode{},
+	}
+
+	var buf bytes.Buffer
+	err := ExportCausationTree(&buf, tree, 1, ExportFormatCSV)
+	require.NoError(t, err)
+
+	reader := csv.NewReader(strings.NewReader(buf.String()))
+	records, err := reader.ReadAll()
+	require.NoError(t, err)
+
+	// Header + 1 row for the saga itself
+	require.Len(t, records, 2)
+	assert.Equal(t, "empty_saga", records[1][2])
+	assert.Equal(t, "PENDING", records[1][3])
+}
+
+func TestExportUnsupportedFormat(t *testing.T) {
+	var buf bytes.Buffer
+	err := ExportCausationTree(&buf, nil, 0, "xml")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnsupportedExportFormat))
+	assert.Contains(t, err.Error(), "xml")
+}
+
+func TestExportJSON_NilTree(t *testing.T) {
+	var buf bytes.Buffer
+	err := ExportCausationTree(&buf, nil, 0, ExportFormatJSON)
+	require.NoError(t, err)
+
+	var export jsonExport
+	err = json.Unmarshal(buf.Bytes(), &export)
+	require.NoError(t, err)
+	assert.Nil(t, export.Tree)
+}

--- a/services/control-plane/internal/admin/handler.go
+++ b/services/control-plane/internal/admin/handler.go
@@ -1,0 +1,191 @@
+package admin
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/google/uuid"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	sagav1 "github.com/meridianhub/meridian/api/proto/meridian/saga/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// Handler implements the CausationVisualizerService gRPC service.
+type Handler struct {
+	controlplanev1.UnimplementedCausationVisualizerServiceServer
+	visualizer *CausationVisualizer
+	logger     *slog.Logger
+}
+
+// NewHandler creates a new CausationVisualizerService handler.
+func NewHandler(visualizer *CausationVisualizer, logger *slog.Logger) *Handler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Handler{
+		visualizer: visualizer,
+		logger:     logger,
+	}
+}
+
+// GetCausationTreeForPosition traces a financial position log back to its
+// originating saga and returns the full causation tree.
+func (h *Handler) GetCausationTreeForPosition(
+	ctx context.Context,
+	req *controlplanev1.GetCausationTreeForPositionRequest,
+) (*controlplanev1.GetCausationTreeForPositionResponse, error) {
+	positionID, err := uuid.Parse(req.GetPositionId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid position_id: %v", err)
+	}
+
+	result, posInfo, err := h.visualizer.GetCausationTreeForPosition(ctx, positionID)
+	if err != nil {
+		return nil, h.mapError(err, "position", positionID)
+	}
+
+	return &controlplanev1.GetCausationTreeForPositionResponse{
+		Tree:       treeNodeToProto(result.Tree),
+		Depth:      int32(result.Depth),
+		PositionId: positionID.String(),
+		AccountId:  posInfo.AccountID,
+		SagaId:     result.SagaID.String(),
+	}, nil
+}
+
+// GetCausationTreeForTransaction traces a transaction back to its originating
+// saga and returns the full causation tree.
+func (h *Handler) GetCausationTreeForTransaction(
+	ctx context.Context,
+	req *controlplanev1.GetCausationTreeForTransactionRequest,
+) (*controlplanev1.GetCausationTreeForTransactionResponse, error) {
+	transactionID, err := uuid.Parse(req.GetTransactionId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid transaction_id: %v", err)
+	}
+
+	result, err := h.visualizer.GetCausationTreeForTransaction(ctx, transactionID)
+	if err != nil {
+		return nil, h.mapError(err, "transaction", transactionID)
+	}
+
+	return &controlplanev1.GetCausationTreeForTransactionResponse{
+		Tree:          treeNodeToProto(result.Tree),
+		Depth:         int32(result.Depth),
+		TransactionId: transactionID.String(),
+		SagaId:        result.SagaID.String(),
+	}, nil
+}
+
+// GetCausationTreeForEvent traces an event back through the saga execution
+// chain and returns the full causation tree.
+func (h *Handler) GetCausationTreeForEvent(
+	ctx context.Context,
+	req *controlplanev1.GetCausationTreeForEventRequest,
+) (*controlplanev1.GetCausationTreeForEventResponse, error) {
+	eventID, err := uuid.Parse(req.GetEventId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid event_id: %v", err)
+	}
+
+	result, err := h.visualizer.GetCausationTreeForEvent(ctx, eventID)
+	if err != nil {
+		return nil, h.mapError(err, "event", eventID)
+	}
+
+	return &controlplanev1.GetCausationTreeForEventResponse{
+		Tree:    treeNodeToProto(result.Tree),
+		Depth:   int32(result.Depth),
+		EventId: eventID.String(),
+		SagaId:  result.SagaID.String(),
+	}, nil
+}
+
+// mapError converts domain errors to gRPC status errors.
+func (h *Handler) mapError(err error, entityType string, entityID uuid.UUID) error {
+	switch {
+	case errors.Is(err, ErrPositionNotFound):
+		return status.Errorf(codes.NotFound, "position not found: %s", entityID)
+	case errors.Is(err, ErrTransactionNotFound):
+		return status.Errorf(codes.NotFound, "transaction not found: %s", entityID)
+	case errors.Is(err, ErrEventNotFound):
+		return status.Errorf(codes.NotFound, "event not found: %s", entityID)
+	case errors.Is(err, ErrNoSagaFound):
+		return status.Errorf(codes.NotFound, "no saga found for %s: %s", entityType, entityID)
+	case errors.Is(err, saga.ErrSagaNotFound):
+		return status.Errorf(codes.NotFound, "saga not found for %s: %s", entityType, entityID)
+	default:
+		h.logger.Error("failed to trace causation tree",
+			"entity_type", entityType,
+			"entity_id", entityID,
+			"error", err,
+		)
+		return status.Errorf(codes.Internal, "failed to trace causation tree for %s", entityType)
+	}
+}
+
+// treeNodeToProto converts a domain CausationTreeNode to its proto representation.
+func treeNodeToProto(node *saga.CausationTreeNode) *sagav1.CausationTreeNode {
+	if node == nil {
+		return nil
+	}
+
+	proto := &sagav1.CausationTreeNode{
+		SagaId:   node.SagaID.String(),
+		SagaName: node.SagaName,
+		Status:   node.Status,
+		Steps:    make([]*sagav1.StepNode, 0, len(node.Steps)),
+	}
+
+	if node.EffectiveAt != nil {
+		proto.EffectiveAt = timestamppb.New(*node.EffectiveAt)
+	}
+	if node.KnowledgeAt != nil {
+		proto.KnowledgeAt = timestamppb.New(*node.KnowledgeAt)
+	}
+	if node.FailedStep != nil {
+		proto.FailedStep = &sagav1.FailedStep{
+			Index:         int32(node.FailedStep.Index),
+			Error:         node.FailedStep.Error,
+			ErrorCategory: node.FailedStep.ErrorCategory,
+		}
+	}
+
+	for _, step := range node.Steps {
+		proto.Steps = append(proto.Steps, stepNodeToProto(&step))
+	}
+
+	return proto
+}
+
+// stepNodeToProto converts a domain StepNode to its proto representation.
+func stepNodeToProto(step *saga.StepNode) *sagav1.StepNode {
+	if step == nil {
+		return nil
+	}
+
+	proto := &sagav1.StepNode{
+		Index:      int32(step.Index),
+		Name:       step.Name,
+		Status:     step.Status,
+		ChildSagas: make([]*sagav1.CausationTreeNode, 0, len(step.ChildSagas)),
+	}
+
+	if step.ExecutedAt != nil {
+		proto.ExecutedAt = timestamppb.New(*step.ExecutedAt)
+	}
+	if step.Error != nil {
+		proto.Error = *step.Error
+	}
+
+	for _, child := range step.ChildSagas {
+		proto.ChildSagas = append(proto.ChildSagas, treeNodeToProto(child))
+	}
+
+	return proto
+}

--- a/services/control-plane/internal/admin/handler.go
+++ b/services/control-plane/internal/admin/handler.go
@@ -109,14 +109,10 @@ func (h *Handler) GetCausationTreeForEvent(
 // mapError converts domain errors to gRPC status errors.
 func (h *Handler) mapError(err error, entityType string, entityID uuid.UUID) error {
 	switch {
-	case errors.Is(err, ErrPositionNotFound):
-		return status.Errorf(codes.NotFound, "position not found: %s", entityID)
-	case errors.Is(err, ErrTransactionNotFound):
-		return status.Errorf(codes.NotFound, "transaction not found: %s", entityID)
-	case errors.Is(err, ErrEventNotFound):
-		return status.Errorf(codes.NotFound, "event not found: %s", entityID)
 	case errors.Is(err, ErrNoSagaFound):
 		return status.Errorf(codes.NotFound, "no saga found for %s: %s", entityType, entityID)
+	case errors.Is(err, ErrCausationChainTooDeep):
+		return status.Errorf(codes.NotFound, "causation chain too deep for %s: %s", entityType, entityID)
 	case errors.Is(err, saga.ErrSagaNotFound):
 		return status.Errorf(codes.NotFound, "saga not found for %s: %s", entityType, entityID)
 	default:

--- a/services/control-plane/internal/admin/handler_test.go
+++ b/services/control-plane/internal/admin/handler_test.go
@@ -71,24 +71,14 @@ func TestHandler_MapError_NotFound(t *testing.T) {
 		contains string
 	}{
 		{
-			name:     "position not found",
-			err:      ErrPositionNotFound,
-			contains: "position not found",
-		},
-		{
-			name:     "transaction not found",
-			err:      ErrTransactionNotFound,
-			contains: "transaction not found",
-		},
-		{
-			name:     "event not found",
-			err:      ErrEventNotFound,
-			contains: "event not found",
-		},
-		{
 			name:     "no saga found",
 			err:      ErrNoSagaFound,
 			contains: "no saga found",
+		},
+		{
+			name:     "causation chain too deep",
+			err:      ErrCausationChainTooDeep,
+			contains: "causation chain too deep",
 		},
 	}
 

--- a/services/control-plane/internal/admin/handler_test.go
+++ b/services/control-plane/internal/admin/handler_test.go
@@ -1,0 +1,115 @@
+package admin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+)
+
+func TestHandler_GetCausationTreeForPosition_InvalidUUID(t *testing.T) {
+	handler := NewHandler(nil, nil)
+
+	req := &controlplanev1.GetCausationTreeForPositionRequest{
+		PositionId: "not-a-uuid",
+	}
+
+	_, err := handler.GetCausationTreeForPosition(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid position_id")
+}
+
+func TestHandler_GetCausationTreeForTransaction_InvalidUUID(t *testing.T) {
+	handler := NewHandler(nil, nil)
+
+	req := &controlplanev1.GetCausationTreeForTransactionRequest{
+		TransactionId: "bad-uuid",
+	}
+
+	_, err := handler.GetCausationTreeForTransaction(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid transaction_id")
+}
+
+func TestHandler_GetCausationTreeForEvent_InvalidUUID(t *testing.T) {
+	handler := NewHandler(nil, nil)
+
+	req := &controlplanev1.GetCausationTreeForEventRequest{
+		EventId: "invalid",
+	}
+
+	_, err := handler.GetCausationTreeForEvent(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid event_id")
+}
+
+func TestHandler_MapError_NotFound(t *testing.T) {
+	handler := NewHandler(nil, nil)
+	id := uuid.New()
+
+	tests := []struct {
+		name     string
+		err      error
+		contains string
+	}{
+		{
+			name:     "position not found",
+			err:      ErrPositionNotFound,
+			contains: "position not found",
+		},
+		{
+			name:     "transaction not found",
+			err:      ErrTransactionNotFound,
+			contains: "transaction not found",
+		},
+		{
+			name:     "event not found",
+			err:      ErrEventNotFound,
+			contains: "event not found",
+		},
+		{
+			name:     "no saga found",
+			err:      ErrNoSagaFound,
+			contains: "no saga found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			grpcErr := handler.mapError(tt.err, "test", id)
+
+			st, ok := status.FromError(grpcErr)
+			require.True(t, ok)
+			assert.Equal(t, codes.NotFound, st.Code())
+			assert.Contains(t, st.Message(), tt.contains)
+		})
+	}
+}
+
+func TestTreeNodeToProto_Nil(t *testing.T) {
+	result := treeNodeToProto(nil)
+	assert.Nil(t, result)
+}
+
+func TestStepNodeToProto_Nil(t *testing.T) {
+	result := stepNodeToProto(nil)
+	assert.Nil(t, result)
+}

--- a/services/control-plane/internal/admin/integration_test.go
+++ b/services/control-plane/internal/admin/integration_test.go
@@ -1,0 +1,488 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	gormpg "gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+var (
+	sharedDB      *gorm.DB
+	sharedOnce    sync.Once
+	sharedInitErr error
+	sharedCleanup func()
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	if sharedCleanup != nil {
+		sharedCleanup()
+	}
+	os.Exit(code)
+}
+
+func initSharedContainer() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	crdbContainer, err := cockroachdb.Run(ctx,
+		"cockroachdb/cockroach:v24.3.0",
+		cockroachdb.WithDatabase("test_db"),
+		cockroachdb.WithUser("root"),
+		cockroachdb.WithInsecure(),
+	)
+	if err != nil {
+		return fmt.Errorf("start container: %w", err)
+	}
+
+	connConfig, err := crdbContainer.ConnectionConfig(ctx)
+	if err != nil {
+		_ = crdbContainer.Terminate(ctx)
+		return fmt.Errorf("connection config: %w", err)
+	}
+
+	db, err := gorm.Open(gormpg.Open(connConfig.ConnString()), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		_ = crdbContainer.Terminate(ctx)
+		return fmt.Errorf("gorm open: %w", err)
+	}
+
+	if err := saga.RunSagaMigrations(db); err != nil {
+		_ = crdbContainer.Terminate(ctx)
+		return fmt.Errorf("migrations: %w", err)
+	}
+
+	sharedDB = db
+	sharedCleanup = func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		sqlDB, _ := db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+		_ = crdbContainer.Terminate(cleanupCtx)
+	}
+
+	return nil
+}
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	sharedOnce.Do(func() {
+		sharedInitErr = initSharedContainer()
+	})
+	if sharedInitErr != nil {
+		t.Fatalf("shared CockroachDB setup failed: %v", sharedInitErr)
+	}
+
+	// Clean tables before each test
+	require.NoError(t, sharedDB.Exec("DELETE FROM saga_step_results").Error)
+	require.NoError(t, sharedDB.Exec("DELETE FROM saga_instances").Error)
+
+	return sharedDB
+}
+
+// TestIntegration_GetCausationTreeForTransaction_ViaSagaCorrelation tests tracing
+// a transaction that matches a saga's correlation_id.
+func TestIntegration_GetCausationTreeForTransaction_ViaSagaCorrelation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db := setupTestDB(t)
+
+	// Create a saga instance with a specific correlation_id
+	sagaID := uuid.New()
+	correlationID := uuid.New()
+	instance := &saga.SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "process_payment",
+		Status:           saga.SagaStatusCompleted,
+		CorrelationID:    correlationID,
+		CurrentStepIndex: 2,
+	}
+	require.NoError(t, db.Create(instance).Error)
+
+	// Create step results
+	for i := 0; i < 2; i++ {
+		step := &saga.SagaStepResult{
+			ID:             uuid.New(),
+			SagaInstanceID: sagaID,
+			StepIndex:      i,
+			StepName:       fmt.Sprintf("step_%d", i),
+			IdempotencyKey: saga.FormatIdempotencyKey(sagaID, i),
+			Status:         saga.StepStatusCompleted,
+		}
+		require.NoError(t, db.Create(step).Error)
+	}
+
+	treeRepo := saga.NewCausationTreeRepository(db)
+	visualizer := NewCausationVisualizer(db, treeRepo, nil)
+	handler := NewHandler(visualizer, nil)
+
+	// Trace using the correlation_id as transaction_id
+	req := &controlplanev1.GetCausationTreeForTransactionRequest{
+		TransactionId: correlationID.String(),
+	}
+
+	resp, err := handler.GetCausationTreeForTransaction(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Tree)
+
+	assert.Equal(t, sagaID.String(), resp.Tree.SagaId)
+	assert.Equal(t, "process_payment", resp.Tree.SagaName)
+	assert.Equal(t, string(saga.SagaStatusCompleted), resp.Tree.Status)
+	assert.Len(t, resp.Tree.Steps, 2)
+	assert.Equal(t, correlationID.String(), resp.TransactionId)
+	assert.Equal(t, sagaID.String(), resp.SagaId)
+}
+
+// TestIntegration_GetCausationTreeForTransaction_NotFound tests that a missing
+// transaction returns NotFound.
+func TestIntegration_GetCausationTreeForTransaction_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db := setupTestDB(t)
+
+	treeRepo := saga.NewCausationTreeRepository(db)
+	visualizer := NewCausationVisualizer(db, treeRepo, nil)
+	handler := NewHandler(visualizer, nil)
+
+	req := &controlplanev1.GetCausationTreeForTransactionRequest{
+		TransactionId: uuid.New().String(),
+	}
+
+	_, err := handler.GetCausationTreeForTransaction(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+// TestIntegration_GetCausationTreeForEvent_ViaCausationID tests tracing
+// an event via its causation_id matching a saga step result.
+func TestIntegration_GetCausationTreeForEvent_ViaCausationID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db := setupTestDB(t)
+
+	sagaID := uuid.New()
+	causationID := saga.GenerateCausationID(sagaID, 0)
+
+	instance := &saga.SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "energy_settlement",
+		Status:           saga.SagaStatusCompleted,
+		CorrelationID:    uuid.New(),
+		CurrentStepIndex: 1,
+	}
+	require.NoError(t, db.Create(instance).Error)
+
+	step := &saga.SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: sagaID,
+		StepIndex:      0,
+		StepName:       "validate_meter_read",
+		IdempotencyKey: saga.FormatIdempotencyKey(sagaID, 0),
+		Status:         saga.StepStatusCompleted,
+		CausationID:    &causationID,
+	}
+	require.NoError(t, db.Create(step).Error)
+
+	treeRepo := saga.NewCausationTreeRepository(db)
+	visualizer := NewCausationVisualizer(db, treeRepo, nil)
+	handler := NewHandler(visualizer, nil)
+
+	// Trace using the causation_id as event_id
+	req := &controlplanev1.GetCausationTreeForEventRequest{
+		EventId: causationID.String(),
+	}
+
+	resp, err := handler.GetCausationTreeForEvent(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Tree)
+
+	assert.Equal(t, sagaID.String(), resp.Tree.SagaId)
+	assert.Equal(t, "energy_settlement", resp.Tree.SagaName)
+	assert.Equal(t, causationID.String(), resp.EventId)
+	assert.Equal(t, sagaID.String(), resp.SagaId)
+}
+
+// TestIntegration_GetCausationTreeForEvent_NotFound tests that an unknown
+// event returns NotFound.
+func TestIntegration_GetCausationTreeForEvent_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db := setupTestDB(t)
+
+	treeRepo := saga.NewCausationTreeRepository(db)
+	visualizer := NewCausationVisualizer(db, treeRepo, nil)
+	handler := NewHandler(visualizer, nil)
+
+	req := &controlplanev1.GetCausationTreeForEventRequest{
+		EventId: uuid.New().String(),
+	}
+
+	_, err := handler.GetCausationTreeForEvent(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+// TestIntegration_GetCausationTreeForTransaction_WithChildSagas tests that
+// the tree includes child sagas nested under the correct parent step.
+func TestIntegration_GetCausationTreeForTransaction_WithChildSagas(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db := setupTestDB(t)
+
+	// Create parent saga
+	parentID := uuid.New()
+	correlationID := uuid.New()
+	parent := &saga.SagaInstance{
+		ID:               parentID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "payment_orchestrator",
+		Status:           saga.SagaStatusCompleted,
+		CorrelationID:    correlationID,
+		CurrentStepIndex: 2,
+	}
+	require.NoError(t, db.Create(parent).Error)
+
+	// Parent steps
+	for i := 0; i < 2; i++ {
+		step := &saga.SagaStepResult{
+			ID:             uuid.New(),
+			SagaInstanceID: parentID,
+			StepIndex:      i,
+			StepName:       fmt.Sprintf("parent_step_%d", i),
+			IdempotencyKey: saga.FormatIdempotencyKey(parentID, i),
+			Status:         saga.StepStatusCompleted,
+		}
+		require.NoError(t, db.Create(step).Error)
+	}
+
+	// Create child saga spawned from step 1
+	childID := uuid.New()
+	childStepIdx := 1
+	child := &saga.SagaInstance{
+		ID:               childID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "charge_card",
+		Status:           saga.SagaStatusCompleted,
+		CorrelationID:    correlationID,
+		ParentSagaID:     &parentID,
+		ParentStepIndex:  &childStepIdx,
+		CurrentStepIndex: 1,
+	}
+	require.NoError(t, db.Create(child).Error)
+
+	childStep := &saga.SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: childID,
+		StepIndex:      0,
+		StepName:       "process_charge",
+		IdempotencyKey: saga.FormatIdempotencyKey(childID, 0),
+		Status:         saga.StepStatusCompleted,
+	}
+	require.NoError(t, db.Create(childStep).Error)
+
+	treeRepo := saga.NewCausationTreeRepository(db)
+	visualizer := NewCausationVisualizer(db, treeRepo, nil)
+	handler := NewHandler(visualizer, nil)
+
+	req := &controlplanev1.GetCausationTreeForTransactionRequest{
+		TransactionId: correlationID.String(),
+	}
+
+	resp, err := handler.GetCausationTreeForTransaction(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Tree)
+
+	// Verify parent
+	assert.Equal(t, parentID.String(), resp.Tree.SagaId)
+	assert.Equal(t, "payment_orchestrator", resp.Tree.SagaName)
+	assert.Len(t, resp.Tree.Steps, 2)
+
+	// Verify child is nested under step 1
+	require.Len(t, resp.Tree.Steps[1].ChildSagas, 1)
+	assert.Equal(t, childID.String(), resp.Tree.Steps[1].ChildSagas[0].SagaId)
+	assert.Equal(t, "charge_card", resp.Tree.Steps[1].ChildSagas[0].SagaName)
+	assert.Len(t, resp.Tree.Steps[1].ChildSagas[0].Steps, 1)
+
+	// Verify depth
+	assert.Equal(t, int32(2), resp.Depth)
+}
+
+// TestIntegration_FindRootSaga_WalksUpChain tests that the root saga finder
+// correctly walks up the parent chain.
+func TestIntegration_FindRootSaga_WalksUpChain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db := setupTestDB(t)
+
+	// Create 3-level chain: grandparent -> parent -> child
+	grandparentID := uuid.New()
+	parentID := uuid.New()
+	childID := uuid.New()
+	correlationID := uuid.New()
+
+	grandparent := &saga.SagaInstance{
+		ID:               grandparentID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "grandparent",
+		Status:           saga.SagaStatusCompleted,
+		CorrelationID:    correlationID,
+		CurrentStepIndex: 1,
+	}
+	require.NoError(t, db.Create(grandparent).Error)
+
+	step0 := 0
+	parent := &saga.SagaInstance{
+		ID:               parentID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "parent",
+		Status:           saga.SagaStatusCompleted,
+		CorrelationID:    correlationID,
+		ParentSagaID:     &grandparentID,
+		ParentStepIndex:  &step0,
+		CurrentStepIndex: 1,
+	}
+	require.NoError(t, db.Create(parent).Error)
+
+	child := &saga.SagaInstance{
+		ID:               childID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "child",
+		Status:           saga.SagaStatusCompleted,
+		CorrelationID:    correlationID,
+		ParentSagaID:     &parentID,
+		ParentStepIndex:  &step0,
+		CurrentStepIndex: 0,
+	}
+	require.NoError(t, db.Create(child).Error)
+
+	treeRepo := saga.NewCausationTreeRepository(db)
+	visualizer := NewCausationVisualizer(db, treeRepo, nil)
+
+	// When we query by the child's correlation_id, we should get the grandparent as root
+	result, err := visualizer.GetCausationTreeForTransaction(context.Background(), correlationID)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	// The root should be the grandparent (first saga created with this correlation_id)
+	assert.Equal(t, grandparentID, result.SagaID)
+}
+
+// TestIntegration_GetCausationTreeForTransaction_FailedSagaWithStepDetails tests
+// that failed sagas include error information in the response.
+func TestIntegration_GetCausationTreeForTransaction_FailedSagaWithStepDetails(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+
+	db := setupTestDB(t)
+
+	sagaID := uuid.New()
+	correlationID := uuid.New()
+	failedIdx := 1
+	errMsg := "insufficient funds"
+	errCat := string(saga.ErrorCategoryFatal)
+
+	instance := &saga.SagaInstance{
+		ID:               sagaID,
+		SagaDefinitionID: uuid.New(),
+		SagaName:         "transfer_funds",
+		Status:           saga.SagaStatusFailed,
+		CorrelationID:    correlationID,
+		CurrentStepIndex: 1,
+		FailedStepIndex:  &failedIdx,
+		ErrorMessage:     &errMsg,
+		ErrorCategory:    &errCat,
+	}
+	require.NoError(t, db.Create(instance).Error)
+
+	// Step 0 succeeded, step 1 failed
+	step0 := &saga.SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: sagaID,
+		StepIndex:      0,
+		StepName:       "validate",
+		IdempotencyKey: saga.FormatIdempotencyKey(sagaID, 0),
+		Status:         saga.StepStatusCompleted,
+	}
+	require.NoError(t, db.Create(step0).Error)
+
+	stepErr := "insufficient funds"
+	step1 := &saga.SagaStepResult{
+		ID:             uuid.New(),
+		SagaInstanceID: sagaID,
+		StepIndex:      1,
+		StepName:       "debit",
+		IdempotencyKey: saga.FormatIdempotencyKey(sagaID, 1),
+		Status:         saga.StepStatusFailed,
+		Error:          &stepErr,
+	}
+	require.NoError(t, db.Create(step1).Error)
+
+	treeRepo := saga.NewCausationTreeRepository(db)
+	visualizer := NewCausationVisualizer(db, treeRepo, nil)
+	handler := NewHandler(visualizer, nil)
+
+	req := &controlplanev1.GetCausationTreeForTransactionRequest{
+		TransactionId: correlationID.String(),
+	}
+
+	resp, err := handler.GetCausationTreeForTransaction(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Tree)
+
+	assert.Equal(t, string(saga.SagaStatusFailed), resp.Tree.Status)
+
+	// Verify failed step info
+	require.NotNil(t, resp.Tree.FailedStep)
+	assert.Equal(t, int32(1), resp.Tree.FailedStep.Index)
+	assert.Equal(t, "insufficient funds", resp.Tree.FailedStep.Error)
+	assert.Equal(t, "FATAL", resp.Tree.FailedStep.ErrorCategory)
+
+	// Verify step error detail
+	require.Len(t, resp.Tree.Steps, 2)
+	assert.Equal(t, "FAILED", resp.Tree.Steps[1].Status)
+	assert.Equal(t, "insufficient funds", resp.Tree.Steps[1].Error)
+}


### PR DESCRIPTION
## Summary

- Implement `CausationVisualizerService` gRPC service with 3 RPCs (`GetCausationTreeForPosition`, `GetCausationTreeForTransaction`, `GetCausationTreeForEvent`) and REST gateway annotations
- Add `CausationVisualizer` backend that traces financial positions, transactions, and events back to their originating saga instances via correlation chains, then retrieves the full causation tree
- Include JSON and CSV export functionality for auditor compliance workflows
- 15 unit tests and 7 integration tests with CockroachDB testcontainers covering tracing, root saga resolution, nested trees, failed sagas, and edge cases

## Technical Details

**Tracing paths:**
- Position: `position_log` -> `saga_step_results` (via correlation_id/idempotency_key) -> `saga_instance` -> root saga -> causation tree
- Transaction: `transaction_id` -> `saga_instances` (via correlation_id or step result data) -> root saga -> causation tree
- Event: `event_id` -> `saga_step_results` (via causation_id) -> root saga -> causation tree (with outbox fallback)

**Root saga resolution** uses a recursive CTE walking the `parent_saga_id` chain with a depth limit of `MaxCausationTreeDepth`.

**Export formats:**
- JSON: preserves tree structure with `exported_at` and `depth` metadata
- CSV: flattens tree into rows with depth, saga_id, step details, errors, and parent references for spreadsheet analysis

## Test plan

- [x] Unit tests for gRPC handler (invalid UUID, error mapping, nil safety)
- [x] Unit tests for export (JSON, CSV, nil tree, empty saga, unsupported format)
- [x] Integration tests for transaction tracing via correlation_id
- [x] Integration tests for event tracing via deterministic causation_id
- [x] Integration test for nested child saga tree structure
- [x] Integration test for root saga chain walking (3-level depth)
- [x] Integration test for failed saga with step error details
- [x] Integration test for graceful handling when event_outbox table does not exist