### PR TITLE
feat: Implement Stripe Cash-In Rail with payment to ledger saga

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/sony/gobreaker/v2 v2.4.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
+	github.com/stripe/stripe-go/v82 v82.5.1
 	github.com/testcontainers/testcontainers-go v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/cockroachdb v0.40.0
 	github.com/testcontainers/testcontainers-go/modules/kafka v0.40.0
@@ -60,7 +61,6 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	github.com/stripe/stripe-go/v82 v82.5.1 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.17.3
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/lo v1.52.0
 	github.com/samber/mo v1.16.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
@@ -37,7 +38,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
 	go.starlark.net v0.0.0-20260102030733-3fee463870c9
-	github.com/robfig/cron/v3 v3.0.1
 	go.uber.org/goleak v1.3.0
 	google.golang.org/genproto v0.0.0-20251111163417-95abcf5c77ba
 	google.golang.org/grpc v1.78.0
@@ -60,6 +60,7 @@ require (
 	github.com/prometheus/procfs v0.16.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/stripe/stripe-go/v82 v82.5.1 // indirect
 	github.com/twmb/franz-go/pkg/kmsg v1.12.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.40.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1156,6 +1156,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/stripe/stripe-go/v82 v82.5.1 h1:05q6ZDKoe8PLMpQV072obF74HCgP4XJeJYoNuRSX2+8=
+github.com/stripe/stripe-go/v82 v82.5.1/go.mod h1:majCQX6AfObAvJiHraPi/5udwHi4ojRvJnnxckvHrX8=
 github.com/testcontainers/testcontainers-go v0.40.0 h1:pSdJYLOVgLE8YdUY2FHQ1Fxu+aMnb6JfVz1mxk7OeMU=
 github.com/testcontainers/testcontainers-go v0.40.0/go.mod h1:FSXV5KQtX2HAMlm7U3APNyLkkap35zNLxukw9oBi/MY=
 github.com/testcontainers/testcontainers-go/modules/cockroachdb v0.40.0 h1:UNYfrnFV9mkO93Sw6hqRA5KbE9DsAvDeYKD4GDConiE=

--- a/services/control-plane/internal/stripe/consumer.go
+++ b/services/control-plane/internal/stripe/consumer.go
@@ -1,0 +1,132 @@
+package stripe
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/google/uuid"
+)
+
+// SagaTrigger abstracts the saga orchestration layer.
+// It accepts a saga name and input data, returning the saga instance ID.
+type SagaTrigger interface {
+	// TriggerSaga starts a new saga instance with the given name and input data.
+	// The idempotency key ensures duplicate triggers are handled correctly.
+	TriggerSaga(ctx context.Context, sagaName string, inputData map[string]any, idempotencyKey string) (string, error)
+}
+
+// PaymentEventConsumer processes payment events from Kafka and triggers sagas.
+type PaymentEventConsumer struct {
+	sagaTrigger SagaTrigger
+	logger      *slog.Logger
+}
+
+// Consumer errors.
+var (
+	ErrNilSagaTrigger   = errors.New("saga trigger cannot be nil")
+	ErrUnknownEventType = errors.New("unknown payment event type")
+	ErrInvalidPayload   = errors.New("invalid payment event payload")
+)
+
+// NewPaymentEventConsumer creates a new consumer that routes payment events to sagas.
+func NewPaymentEventConsumer(trigger SagaTrigger, logger *slog.Logger) (*PaymentEventConsumer, error) {
+	if trigger == nil {
+		return nil, ErrNilSagaTrigger
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &PaymentEventConsumer{
+		sagaTrigger: trigger,
+		logger:      logger,
+	}, nil
+}
+
+// HandlePaymentEvent processes a single payment event from Kafka.
+// This is the Kafka message handler function compatible with the platform consumer.
+func (c *PaymentEventConsumer) HandlePaymentEvent(ctx context.Context, data []byte) error {
+	var event PaymentEvent
+	if err := json.Unmarshal(data, &event); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidPayload, err)
+	}
+
+	c.logger.Info("processing payment event",
+		"event_type", event.EventType,
+		"stripe_event_id", event.StripeEventID,
+		"tenant_id", event.TenantID,
+		"party_id", event.PartyID,
+		"amount_cents", event.AmountCents,
+	)
+
+	switch event.EventType {
+	case EventTypePaymentIntentSucceeded:
+		return c.triggerPaymentReceivedSaga(ctx, &event)
+	case EventTypeChargeRefunded:
+		return c.triggerRefundSaga(ctx, &event)
+	default:
+		c.logger.Debug("ignoring unhandled event type", "event_type", event.EventType)
+		return nil
+	}
+}
+
+// triggerPaymentReceivedSaga starts the stripe_payment_received saga.
+func (c *PaymentEventConsumer) triggerPaymentReceivedSaga(ctx context.Context, event *PaymentEvent) error {
+	inputData := map[string]any{
+		"tenant_id":         event.TenantID,
+		"party_id":          event.PartyID,
+		"amount_cents":      event.AmountCents,
+		"currency":          event.Currency,
+		"charge_id":         event.ChargeID,
+		"payment_intent_id": event.PaymentIntentID,
+		"stripe_event_id":   event.StripeEventID,
+	}
+
+	sagaID, err := c.sagaTrigger.TriggerSaga(ctx, "stripe_payment_received", inputData, event.IdempotencyKey)
+	if err != nil {
+		return fmt.Errorf("failed to trigger stripe_payment_received saga: %w", err)
+	}
+
+	c.logger.Info("stripe_payment_received saga triggered",
+		"saga_id", sagaID,
+		"stripe_event_id", event.StripeEventID,
+		"charge_id", event.ChargeID,
+		"tenant_id", event.TenantID,
+	)
+
+	return nil
+}
+
+// triggerRefundSaga starts the stripe_payment_refunded saga.
+// Note: The refund saga reverses the original double-entry posting.
+func (c *PaymentEventConsumer) triggerRefundSaga(ctx context.Context, event *PaymentEvent) error {
+	inputData := map[string]any{
+		"tenant_id":         event.TenantID,
+		"party_id":          event.PartyID,
+		"amount_cents":      event.AmountCents,
+		"currency":          event.Currency,
+		"charge_id":         event.ChargeID,
+		"payment_intent_id": event.PaymentIntentID,
+		"stripe_event_id":   event.StripeEventID,
+	}
+
+	sagaID, err := c.sagaTrigger.TriggerSaga(ctx, "stripe_payment_refunded", inputData, event.IdempotencyKey)
+	if err != nil {
+		return fmt.Errorf("failed to trigger stripe_payment_refunded saga: %w", err)
+	}
+
+	c.logger.Info("stripe_payment_refunded saga triggered",
+		"saga_id", sagaID,
+		"stripe_event_id", event.StripeEventID,
+		"charge_id", event.ChargeID,
+	)
+
+	return nil
+}
+
+// NewSagaID generates a new UUID for a saga instance.
+func NewSagaID() string {
+	return uuid.New().String()
+}

--- a/services/control-plane/internal/stripe/consumer_test.go
+++ b/services/control-plane/internal/stripe/consumer_test.go
@@ -1,0 +1,197 @@
+package stripe
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockSagaTrigger struct {
+	triggerFunc func(ctx context.Context, sagaName string, inputData map[string]any, idempotencyKey string) (string, error)
+	calls       []sagaTriggerCall
+}
+
+type sagaTriggerCall struct {
+	SagaName       string
+	InputData      map[string]any
+	IdempotencyKey string
+}
+
+func (m *mockSagaTrigger) TriggerSaga(ctx context.Context, sagaName string, inputData map[string]any, idempotencyKey string) (string, error) {
+	m.calls = append(m.calls, sagaTriggerCall{
+		SagaName:       sagaName,
+		InputData:      inputData,
+		IdempotencyKey: idempotencyKey,
+	})
+	if m.triggerFunc != nil {
+		return m.triggerFunc(ctx, sagaName, inputData, idempotencyKey)
+	}
+	return NewSagaID(), nil
+}
+
+func TestNewPaymentEventConsumer(t *testing.T) {
+	t.Run("valid trigger", func(t *testing.T) {
+		consumer, err := NewPaymentEventConsumer(&mockSagaTrigger{}, nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, consumer)
+	})
+
+	t.Run("nil trigger", func(t *testing.T) {
+		consumer, err := NewPaymentEventConsumer(nil, nil)
+		assert.ErrorIs(t, err, ErrNilSagaTrigger)
+		assert.Nil(t, consumer)
+	})
+}
+
+func TestHandlePaymentEvent_PaymentIntentSucceeded(t *testing.T) {
+	trigger := &mockSagaTrigger{}
+	consumer, err := NewPaymentEventConsumer(trigger, nil)
+	require.NoError(t, err)
+
+	event := &PaymentEvent{
+		EventID:         "evt-1",
+		StripeEventID:   "evt_stripe_123",
+		EventType:       "payment_intent.succeeded",
+		TenantID:        "meridian-ops",
+		PartyID:         "party-abc",
+		AmountCents:     10000,
+		Currency:        "gbp",
+		ChargeID:        "ch_123",
+		PaymentIntentID: "pi_456",
+		IdempotencyKey:  "stripe:abc123",
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	err = consumer.HandlePaymentEvent(context.Background(), data)
+	require.NoError(t, err)
+
+	require.Len(t, trigger.calls, 1)
+	call := trigger.calls[0]
+	assert.Equal(t, "stripe_payment_received", call.SagaName)
+	assert.Equal(t, "meridian-ops", call.InputData["tenant_id"])
+	assert.Equal(t, "party-abc", call.InputData["party_id"])
+	// JSON numbers round-trip as float64 through json.Unmarshal into map[string]any
+	assert.InDelta(t, float64(10000), call.InputData["amount_cents"], 0.01)
+	assert.Equal(t, "gbp", call.InputData["currency"])
+	assert.Equal(t, "ch_123", call.InputData["charge_id"])
+	assert.Equal(t, "stripe:abc123", call.IdempotencyKey)
+}
+
+func TestHandlePaymentEvent_ChargeRefunded(t *testing.T) {
+	trigger := &mockSagaTrigger{}
+	consumer, err := NewPaymentEventConsumer(trigger, nil)
+	require.NoError(t, err)
+
+	event := &PaymentEvent{
+		EventID:         "evt-2",
+		StripeEventID:   "evt_stripe_refund",
+		EventType:       "charge.refunded",
+		TenantID:        "meridian-ops",
+		PartyID:         "party-abc",
+		AmountCents:     5000,
+		Currency:        "gbp",
+		ChargeID:        "ch_123",
+		PaymentIntentID: "pi_456",
+		IdempotencyKey:  "stripe:refund123",
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	err = consumer.HandlePaymentEvent(context.Background(), data)
+	require.NoError(t, err)
+
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, "stripe_payment_refunded", trigger.calls[0].SagaName)
+}
+
+func TestHandlePaymentEvent_UnknownType(t *testing.T) {
+	trigger := &mockSagaTrigger{}
+	consumer, err := NewPaymentEventConsumer(trigger, nil)
+	require.NoError(t, err)
+
+	event := &PaymentEvent{
+		EventID:   "evt-3",
+		EventType: "customer.created",
+		TenantID:  "meridian-ops",
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	// Unknown types should be silently ignored
+	err = consumer.HandlePaymentEvent(context.Background(), data)
+	assert.NoError(t, err)
+	assert.Empty(t, trigger.calls)
+}
+
+func TestHandlePaymentEvent_InvalidJSON(t *testing.T) {
+	trigger := &mockSagaTrigger{}
+	consumer, err := NewPaymentEventConsumer(trigger, nil)
+	require.NoError(t, err)
+
+	err = consumer.HandlePaymentEvent(context.Background(), []byte("not json"))
+	assert.ErrorIs(t, err, ErrInvalidPayload)
+}
+
+func TestHandlePaymentEvent_SagaTriggerError(t *testing.T) {
+	trigger := &mockSagaTrigger{
+		triggerFunc: func(_ context.Context, _ string, _ map[string]any, _ string) (string, error) {
+			return "", errors.New("saga engine unavailable")
+		},
+	}
+	consumer, err := NewPaymentEventConsumer(trigger, nil)
+	require.NoError(t, err)
+
+	event := &PaymentEvent{
+		EventType:      "payment_intent.succeeded",
+		TenantID:       "meridian-ops",
+		PartyID:        "party-1",
+		AmountCents:    1000,
+		ChargeID:       "ch_1",
+		IdempotencyKey: "stripe:key1",
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	err = consumer.HandlePaymentEvent(context.Background(), data)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "saga engine unavailable")
+}
+
+func TestHandlePaymentEvent_IdempotencyKeyPropagated(t *testing.T) {
+	trigger := &mockSagaTrigger{}
+	consumer, err := NewPaymentEventConsumer(trigger, nil)
+	require.NoError(t, err)
+
+	idempotencyKey := "stripe:deterministic_key_abc"
+	event := &PaymentEvent{
+		EventType:      "payment_intent.succeeded",
+		TenantID:       "meridian-ops",
+		PartyID:        "party-1",
+		AmountCents:    2500,
+		ChargeID:       "ch_idem",
+		IdempotencyKey: idempotencyKey,
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	// Process the same event twice
+	err = consumer.HandlePaymentEvent(context.Background(), data)
+	require.NoError(t, err)
+	err = consumer.HandlePaymentEvent(context.Background(), data)
+	require.NoError(t, err)
+
+	// Both calls should have the same idempotency key
+	require.Len(t, trigger.calls, 2)
+	assert.Equal(t, idempotencyKey, trigger.calls[0].IdempotencyKey)
+	assert.Equal(t, idempotencyKey, trigger.calls[1].IdempotencyKey)
+}

--- a/services/control-plane/internal/stripe/idempotency_test.go
+++ b/services/control-plane/internal/stripe/idempotency_test.go
@@ -1,0 +1,190 @@
+package stripe
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDuplicateWebhookIdempotency verifies that duplicate Stripe webhook deliveries
+// produce the same idempotency key and saga_id, resulting in a single ledger entry
+// when the saga engine enforces idempotency.
+func TestDuplicateWebhookIdempotency(t *testing.T) {
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	// Create a single payload that will be delivered twice
+	payload := buildPaymentIntentSucceededPayload(t, "pi_idem_test", 25000, "gbp", map[string]string{
+		"tenant_id": "meridian-ops",
+		"party_id":  "party-idem",
+	})
+
+	// First delivery
+	sig1 := signPayload(t, payload, testWebhookSecret)
+	req1 := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req1.Header.Set(StripeSignatureHeader, sig1)
+
+	rr1 := httptest.NewRecorder()
+	handler.HandleWebhook(rr1, req1)
+	assert.Equal(t, http.StatusOK, rr1.Code)
+
+	// Second delivery (duplicate)
+	sig2 := signPayload(t, payload, testWebhookSecret)
+	req2 := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req2.Header.Set(StripeSignatureHeader, sig2)
+
+	rr2 := httptest.NewRecorder()
+	handler.HandleWebhook(rr2, req2)
+	assert.Equal(t, http.StatusOK, rr2.Code)
+
+	// Both deliveries should produce events with the same idempotency key
+	require.Len(t, pub.events, 2)
+	assert.Equal(t, pub.events[0].IdempotencyKey, pub.events[1].IdempotencyKey,
+		"duplicate webhooks must produce identical idempotency keys")
+
+	// Same Stripe event ID
+	assert.Equal(t, pub.events[0].StripeEventID, pub.events[1].StripeEventID)
+
+	// Same tenant/party/amount
+	assert.Equal(t, pub.events[0].TenantID, pub.events[1].TenantID)
+	assert.Equal(t, pub.events[0].PartyID, pub.events[1].PartyID)
+	assert.Equal(t, pub.events[0].AmountCents, pub.events[1].AmountCents)
+}
+
+// TestDuplicateConsumerIdempotency verifies that the consumer propagates the
+// idempotency key to the saga trigger, enabling the saga engine to deduplicate.
+func TestDuplicateConsumerIdempotency(t *testing.T) {
+	trigger := &mockSagaTrigger{}
+	consumer, err := NewPaymentEventConsumer(trigger, nil)
+	require.NoError(t, err)
+
+	event := &PaymentEvent{
+		EventID:         "evt-idem-1",
+		StripeEventID:   "evt_stripe_dup",
+		EventType:       "payment_intent.succeeded",
+		TenantID:        "meridian-ops",
+		PartyID:         "party-dup",
+		AmountCents:     7500,
+		Currency:        "gbp",
+		ChargeID:        "ch_dup",
+		PaymentIntentID: "pi_dup",
+		IdempotencyKey:  "stripe:deterministic_key_xyz",
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	// Process the same event three times (simulating Kafka redelivery)
+	for i := 0; i < 3; i++ {
+		err = consumer.HandlePaymentEvent(context.Background(), data)
+		require.NoError(t, err)
+	}
+
+	// All three calls should have the same idempotency key
+	require.Len(t, trigger.calls, 3)
+	for i := 0; i < 3; i++ {
+		assert.Equal(t, "stripe:deterministic_key_xyz", trigger.calls[i].IdempotencyKey,
+			"call %d should have the same idempotency key", i)
+		assert.Equal(t, "stripe_payment_received", trigger.calls[i].SagaName)
+	}
+}
+
+// TestIdempotencyKeyStability verifies that the idempotency key generation is
+// deterministic and stable across time (not dependent on current time).
+func TestIdempotencyKeyStability(t *testing.T) {
+	eventID := "evt_stable_123"
+	eventType := "payment_intent.succeeded"
+
+	// Generate keys at different points
+	key1 := generateIdempotencyKey(eventID, eventType)
+
+	// Simulate passage of time
+	time.Sleep(10 * time.Millisecond)
+
+	key2 := generateIdempotencyKey(eventID, eventType)
+
+	assert.Equal(t, key1, key2, "idempotency key must be stable over time")
+}
+
+// TestIdempotencyKeyUniqueness verifies that different events produce different keys.
+func TestIdempotencyKeyUniqueness(t *testing.T) {
+	keys := make(map[string]bool)
+
+	testCases := []struct {
+		eventID   string
+		eventType string
+	}{
+		{"evt_1", "payment_intent.succeeded"},
+		{"evt_2", "payment_intent.succeeded"},
+		{"evt_1", "charge.refunded"},
+		{"evt_3", "payment_intent.payment_failed"},
+	}
+
+	for _, tc := range testCases {
+		key := generateIdempotencyKey(tc.eventID, tc.eventType)
+		assert.False(t, keys[key], "duplicate key generated for %s/%s", tc.eventID, tc.eventType)
+		keys[key] = true
+	}
+}
+
+// TestEndToEndIdempotencyFlow verifies the complete flow from webhook to saga trigger
+// ensuring idempotency keys are preserved throughout.
+func TestEndToEndIdempotencyFlow(t *testing.T) {
+	// Step 1: Webhook handler receives and publishes events
+	pub := &mockPublisher{}
+	webhookHandler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	payload := buildPaymentIntentSucceededPayload(t, "pi_e2e_idem", 15000, "gbp", map[string]string{
+		"tenant_id": "meridian-ops",
+		"party_id":  "party-e2e",
+	})
+
+	sig := signPayload(t, payload, testWebhookSecret)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
+	rr := httptest.NewRecorder()
+	webhookHandler.HandleWebhook(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	require.Len(t, pub.events, 1)
+	publishedEvent := pub.events[0]
+
+	// Step 2: Consumer receives the published event and triggers saga
+	trigger := &mockSagaTrigger{}
+	consumer, err := NewPaymentEventConsumer(trigger, nil)
+	require.NoError(t, err)
+
+	eventData, err := json.Marshal(publishedEvent)
+	require.NoError(t, err)
+
+	err = consumer.HandlePaymentEvent(context.Background(), eventData)
+	require.NoError(t, err)
+
+	// Step 3: Verify the idempotency key was preserved through the entire chain
+	require.Len(t, trigger.calls, 1)
+	assert.Equal(t, publishedEvent.IdempotencyKey, trigger.calls[0].IdempotencyKey,
+		"idempotency key must be preserved from webhook through consumer to saga trigger")
+
+	// Step 4: Simulate duplicate delivery
+	err = consumer.HandlePaymentEvent(context.Background(), eventData)
+	require.NoError(t, err)
+
+	require.Len(t, trigger.calls, 2)
+	assert.Equal(t, trigger.calls[0].IdempotencyKey, trigger.calls[1].IdempotencyKey,
+		"duplicate deliveries must produce identical idempotency keys")
+}

--- a/services/control-plane/internal/stripe/preflight.go
+++ b/services/control-plane/internal/stripe/preflight.go
@@ -1,0 +1,101 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+)
+
+// Preflight check errors.
+var (
+	ErrPreflightFailed = errors.New("stripe preflight check failed")
+	ErrTenantNotFound  = errors.New("meridian-ops tenant not found")
+	ErrNostroNotFound  = errors.New("stripe_nostro account not found")
+	ErrRevenueNotFound = errors.New("revenue account not found")
+)
+
+// PreflightChecker verifies that required infrastructure exists before the
+// Stripe webhook handler starts accepting traffic.
+type PreflightChecker struct {
+	tenantVerifier  TenantVerifier
+	accountVerifier AccountVerifier
+	logger          *slog.Logger
+}
+
+// TenantVerifier checks that a tenant exists.
+type TenantVerifier interface {
+	TenantExists(ctx context.Context, tenantID string) (bool, error)
+}
+
+// AccountVerifier checks that an account exists within a tenant.
+type AccountVerifier interface {
+	AccountExists(ctx context.Context, tenantID, accountID string) (bool, error)
+}
+
+// PreflightConfig contains configuration for the preflight checker.
+type PreflightConfig struct {
+	// TenantVerifier checks tenant existence.
+	TenantVerifier TenantVerifier
+	// AccountVerifier checks account existence.
+	AccountVerifier AccountVerifier
+	// Logger is optional; defaults to slog.Default().
+	Logger *slog.Logger
+}
+
+// NewPreflightChecker creates a new PreflightChecker.
+func NewPreflightChecker(cfg PreflightConfig) *PreflightChecker {
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &PreflightChecker{
+		tenantVerifier:  cfg.TenantVerifier,
+		accountVerifier: cfg.AccountVerifier,
+		logger:          logger,
+	}
+}
+
+// Check verifies that the meridian-ops tenant and required accounts exist.
+// Returns an error wrapping ErrPreflightFailed if any precondition is not met.
+// This should be called at startup; the service should panic if it fails.
+func (p *PreflightChecker) Check(ctx context.Context) error {
+	p.logger.Info("running stripe preflight checks")
+
+	// Verify meridian-ops tenant exists
+	if p.tenantVerifier != nil {
+		exists, err := p.tenantVerifier.TenantExists(ctx, "meridian-ops")
+		if err != nil {
+			return fmt.Errorf("%w: failed to verify meridian-ops tenant: %w", ErrPreflightFailed, err)
+		}
+		if !exists {
+			return fmt.Errorf("%w: %w", ErrPreflightFailed, ErrTenantNotFound)
+		}
+		p.logger.Info("preflight: meridian-ops tenant verified")
+	}
+
+	// Verify stripe_nostro account exists
+	if p.accountVerifier != nil {
+		exists, err := p.accountVerifier.AccountExists(ctx, "meridian-ops", "stripe_nostro")
+		if err != nil {
+			return fmt.Errorf("%w: failed to verify stripe_nostro account: %w", ErrPreflightFailed, err)
+		}
+		if !exists {
+			return fmt.Errorf("%w: %w", ErrPreflightFailed, ErrNostroNotFound)
+		}
+		p.logger.Info("preflight: stripe_nostro account verified")
+
+		// Verify revenue account exists
+		exists, err = p.accountVerifier.AccountExists(ctx, "meridian-ops", "revenue")
+		if err != nil {
+			return fmt.Errorf("%w: failed to verify revenue account: %w", ErrPreflightFailed, err)
+		}
+		if !exists {
+			return fmt.Errorf("%w: %w", ErrPreflightFailed, ErrRevenueNotFound)
+		}
+		p.logger.Info("preflight: revenue account verified")
+	}
+
+	p.logger.Info("stripe preflight checks passed")
+	return nil
+}

--- a/services/control-plane/internal/stripe/preflight_test.go
+++ b/services/control-plane/internal/stripe/preflight_test.go
@@ -1,0 +1,121 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockTenantVerifier struct {
+	tenants map[string]bool
+	err     error
+}
+
+func (m *mockTenantVerifier) TenantExists(_ context.Context, tenantID string) (bool, error) {
+	if m.err != nil {
+		return false, m.err
+	}
+	return m.tenants[tenantID], nil
+}
+
+type mockAccountVerifier struct {
+	accounts map[string]bool
+	err      error
+}
+
+func (m *mockAccountVerifier) AccountExists(_ context.Context, tenantID, accountID string) (bool, error) {
+	if m.err != nil {
+		return false, m.err
+	}
+	key := tenantID + "/" + accountID
+	return m.accounts[key], nil
+}
+
+func TestPreflightCheck_AllPassing(t *testing.T) {
+	checker := NewPreflightChecker(PreflightConfig{
+		TenantVerifier: &mockTenantVerifier{
+			tenants: map[string]bool{"meridian-ops": true},
+		},
+		AccountVerifier: &mockAccountVerifier{
+			accounts: map[string]bool{
+				"meridian-ops/stripe_nostro": true,
+				"meridian-ops/revenue":       true,
+			},
+		},
+	})
+
+	err := checker.Check(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestPreflightCheck_TenantMissing(t *testing.T) {
+	checker := NewPreflightChecker(PreflightConfig{
+		TenantVerifier: &mockTenantVerifier{
+			tenants: map[string]bool{},
+		},
+	})
+
+	err := checker.Check(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPreflightFailed)
+	assert.ErrorIs(t, err, ErrTenantNotFound)
+}
+
+func TestPreflightCheck_NostroMissing(t *testing.T) {
+	checker := NewPreflightChecker(PreflightConfig{
+		TenantVerifier: &mockTenantVerifier{
+			tenants: map[string]bool{"meridian-ops": true},
+		},
+		AccountVerifier: &mockAccountVerifier{
+			accounts: map[string]bool{
+				"meridian-ops/revenue": true,
+			},
+		},
+	})
+
+	err := checker.Check(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPreflightFailed)
+	assert.ErrorIs(t, err, ErrNostroNotFound)
+}
+
+func TestPreflightCheck_RevenueMissing(t *testing.T) {
+	checker := NewPreflightChecker(PreflightConfig{
+		TenantVerifier: &mockTenantVerifier{
+			tenants: map[string]bool{"meridian-ops": true},
+		},
+		AccountVerifier: &mockAccountVerifier{
+			accounts: map[string]bool{
+				"meridian-ops/stripe_nostro": true,
+			},
+		},
+	})
+
+	err := checker.Check(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPreflightFailed)
+	assert.ErrorIs(t, err, ErrRevenueNotFound)
+}
+
+func TestPreflightCheck_TenantVerifierError(t *testing.T) {
+	checker := NewPreflightChecker(PreflightConfig{
+		TenantVerifier: &mockTenantVerifier{
+			err: errors.New("connection refused"),
+		},
+	})
+
+	err := checker.Check(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrPreflightFailed)
+}
+
+func TestPreflightCheck_NilVerifiers(t *testing.T) {
+	// With nil verifiers, check should pass (graceful degradation)
+	checker := NewPreflightChecker(PreflightConfig{})
+
+	err := checker.Check(context.Background())
+	assert.NoError(t, err)
+}

--- a/services/control-plane/internal/stripe/publisher.go
+++ b/services/control-plane/internal/stripe/publisher.go
@@ -1,0 +1,98 @@
+package stripe
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+// KafkaPublisher errors.
+var (
+	ErrEmptyBootstrapServers = errors.New("bootstrap servers cannot be empty")
+	ErrEmptyTopic            = errors.New("topic cannot be empty")
+)
+
+// KafkaPublisher publishes payment events to Kafka.
+type KafkaPublisher struct {
+	client *kgo.Client
+	topic  string
+}
+
+// KafkaPublisherConfig contains configuration for the Kafka publisher.
+type KafkaPublisherConfig struct {
+	// BootstrapServers is the comma-separated list of Kafka broker addresses.
+	BootstrapServers string
+	// Topic is the Kafka topic for payment events.
+	Topic string
+	// ClientID identifies this producer.
+	ClientID string
+}
+
+// NewKafkaPublisher creates a new Kafka-based EventPublisher.
+func NewKafkaPublisher(cfg KafkaPublisherConfig) (*KafkaPublisher, error) {
+	if cfg.BootstrapServers == "" {
+		return nil, ErrEmptyBootstrapServers
+	}
+	if cfg.Topic == "" {
+		return nil, ErrEmptyTopic
+	}
+
+	opts := []kgo.Opt{
+		kgo.SeedBrokers(cfg.BootstrapServers),
+		kgo.RequiredAcks(kgo.AllISRAcks()),
+		kgo.RecordRetries(3),
+		kgo.ProducerLinger(10 * time.Millisecond),
+	}
+	if cfg.ClientID != "" {
+		opts = append(opts, kgo.ClientID(cfg.ClientID))
+	}
+
+	client, err := kgo.NewClient(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kafka producer: %w", err)
+	}
+
+	return &KafkaPublisher{
+		client: client,
+		topic:  cfg.Topic,
+	}, nil
+}
+
+// PublishPaymentEvent publishes a payment event to the configured Kafka topic.
+// The tenant_id is used as the partition key for ordering guarantees.
+func (p *KafkaPublisher) PublishPaymentEvent(ctx context.Context, event *PaymentEvent) error {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return fmt.Errorf("failed to marshal payment event: %w", err)
+	}
+
+	record := &kgo.Record{
+		Topic:     p.topic,
+		Key:       []byte(event.TenantID),
+		Value:     data,
+		Timestamp: event.Timestamp,
+		Headers: []kgo.RecordHeader{
+			{Key: tenant.TenantIDKey, Value: []byte(event.TenantID)},
+			{Key: "event-type", Value: []byte(event.EventType)},
+			{Key: "stripe-event-id", Value: []byte(event.StripeEventID)},
+			{Key: "idempotency-key", Value: []byte(event.IdempotencyKey)},
+		},
+	}
+
+	results := p.client.ProduceSync(ctx, record)
+	if err := results.FirstErr(); err != nil {
+		return fmt.Errorf("kafka delivery failed: %w", err)
+	}
+
+	return nil
+}
+
+// Close closes the Kafka producer.
+func (p *KafkaPublisher) Close() {
+	p.client.Close()
+}

--- a/services/control-plane/internal/stripe/publisher.go
+++ b/services/control-plane/internal/stripe/publisher.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/meridianhub/meridian/shared/platform/tenant"
@@ -35,7 +36,8 @@ type KafkaPublisherConfig struct {
 
 // NewKafkaPublisher creates a new Kafka-based EventPublisher.
 func NewKafkaPublisher(cfg KafkaPublisherConfig) (*KafkaPublisher, error) {
-	if cfg.BootstrapServers == "" {
+	brokers := splitBrokers(cfg.BootstrapServers)
+	if len(brokers) == 0 {
 		return nil, ErrEmptyBootstrapServers
 	}
 	if cfg.Topic == "" {
@@ -43,7 +45,7 @@ func NewKafkaPublisher(cfg KafkaPublisherConfig) (*KafkaPublisher, error) {
 	}
 
 	opts := []kgo.Opt{
-		kgo.SeedBrokers(cfg.BootstrapServers),
+		kgo.SeedBrokers(brokers...),
 		kgo.RequiredAcks(kgo.AllISRAcks()),
 		kgo.RecordRetries(3),
 		kgo.ProducerLinger(10 * time.Millisecond),
@@ -95,4 +97,18 @@ func (p *KafkaPublisher) PublishPaymentEvent(ctx context.Context, event *Payment
 // Close closes the Kafka producer.
 func (p *KafkaPublisher) Close() {
 	p.client.Close()
+}
+
+// splitBrokers splits a comma-separated broker string into individual addresses,
+// trimming whitespace and filtering empty entries.
+func splitBrokers(s string) []string {
+	parts := strings.Split(s, ",")
+	brokers := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			brokers = append(brokers, p)
+		}
+	}
+	return brokers
 }

--- a/services/control-plane/internal/stripe/reconciliation.go
+++ b/services/control-plane/internal/stripe/reconciliation.go
@@ -1,0 +1,239 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+// Reconciliation errors.
+var (
+	ErrReconciliationVariance = errors.New("reconciliation variance detected")
+	ErrNilStripeSource        = errors.New("stripe source cannot be nil")
+	ErrNilLedgerSource        = errors.New("ledger source cannot be nil")
+)
+
+// VarianceThresholdGBP is the absolute variance threshold in GBP.
+var VarianceThresholdGBP = decimal.NewFromInt(10)
+
+// VarianceThresholdPercent is the relative variance threshold as a percentage of daily volume.
+var VarianceThresholdPercent = decimal.NewFromFloat(0.01) // 1%
+
+// ChargeSource provides Stripe charge data for reconciliation.
+type ChargeSource interface {
+	// ListCharges returns all successful charges for the given date range.
+	ListCharges(ctx context.Context, from, to time.Time) ([]ChargeRecord, error)
+}
+
+// LedgerEntrySource provides ledger entry data for reconciliation.
+type LedgerEntrySource interface {
+	// ListEntriesByExternalRef returns ledger entries matching the external reference IDs.
+	ListEntriesByExternalRef(ctx context.Context, externalRefIDs []string) ([]LedgerRecord, error)
+}
+
+// ChargeRecord represents a Stripe charge for reconciliation.
+type ChargeRecord struct {
+	ChargeID    string
+	AmountCents int64
+	Currency    string
+	Created     time.Time
+}
+
+// LedgerRecord represents a ledger entry matched by external reference.
+type LedgerRecord struct {
+	LogID               string
+	ExternalReferenceID string
+	AmountCents         int64
+	Currency            string
+}
+
+// ReconciliationReport is the output of a daily reconciliation run.
+type ReconciliationReport struct {
+	// Date is the reconciliation date.
+	Date time.Time `json:"date"`
+	// StripeChargeCount is the number of Stripe charges found.
+	StripeChargeCount int `json:"stripe_charge_count"`
+	// LedgerEntryCount is the number of matching ledger entries found.
+	LedgerEntryCount int `json:"ledger_entry_count"`
+	// StripeTotalCents is the total amount from Stripe charges.
+	StripeTotalCents int64 `json:"stripe_total_cents"`
+	// LedgerTotalCents is the total amount from ledger entries.
+	LedgerTotalCents int64 `json:"ledger_total_cents"`
+	// VarianceCents is the absolute difference between Stripe and ledger totals.
+	VarianceCents int64 `json:"variance_cents"`
+	// MissingInLedger contains charge IDs present in Stripe but not in the ledger.
+	MissingInLedger []string `json:"missing_in_ledger,omitempty"`
+	// MissingInStripe contains external reference IDs in ledger but not in Stripe.
+	MissingInStripe []string `json:"missing_in_stripe,omitempty"`
+	// VarianceExceedsThreshold indicates whether the variance exceeds alerting thresholds.
+	VarianceExceedsThreshold bool `json:"variance_exceeds_threshold"`
+	// AlertMessage is set when variance exceeds thresholds.
+	AlertMessage string `json:"alert_message,omitempty"`
+}
+
+// ReconciliationService runs daily reconciliation between Stripe and the ledger.
+type ReconciliationService struct {
+	stripeSource ChargeSource
+	ledgerSource LedgerEntrySource
+	logger       *slog.Logger
+}
+
+// NewReconciliationService creates a new reconciliation service.
+func NewReconciliationService(stripeSource ChargeSource, ledgerSource LedgerEntrySource, logger *slog.Logger) (*ReconciliationService, error) {
+	if stripeSource == nil {
+		return nil, ErrNilStripeSource
+	}
+	if ledgerSource == nil {
+		return nil, ErrNilLedgerSource
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ReconciliationService{
+		stripeSource: stripeSource,
+		ledgerSource: ledgerSource,
+		logger:       logger,
+	}, nil
+}
+
+// RunDailyReconciliation compares Stripe charges with ledger entries for the given date.
+// It produces a report identifying variances and missing entries.
+func (s *ReconciliationService) RunDailyReconciliation(ctx context.Context, date time.Time) (*ReconciliationReport, error) {
+	// Define the day boundaries (midnight to midnight UTC)
+	from := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, time.UTC)
+	to := from.Add(24 * time.Hour)
+
+	s.logger.Info("starting daily reconciliation",
+		"date", from.Format("2006-01-02"),
+	)
+
+	// Fetch Stripe charges for the day
+	charges, err := s.stripeSource.ListCharges(ctx, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch stripe charges: %w", err)
+	}
+
+	// Build charge lookup by ID
+	chargeMap := make(map[string]*ChargeRecord, len(charges))
+	chargeIDs := make([]string, 0, len(charges))
+	var stripeTotalCents int64
+	for i := range charges {
+		chargeMap[charges[i].ChargeID] = &charges[i]
+		chargeIDs = append(chargeIDs, charges[i].ChargeID)
+		stripeTotalCents += charges[i].AmountCents
+	}
+
+	// Fetch matching ledger entries by external reference ID (charge ID)
+	var ledgerEntries []LedgerRecord
+	if len(chargeIDs) > 0 {
+		ledgerEntries, err = s.ledgerSource.ListEntriesByExternalRef(ctx, chargeIDs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch ledger entries: %w", err)
+		}
+	}
+
+	// Build ledger lookup by external reference
+	ledgerMap := make(map[string]*LedgerRecord, len(ledgerEntries))
+	var ledgerTotalCents int64
+	for i := range ledgerEntries {
+		ledgerMap[ledgerEntries[i].ExternalReferenceID] = &ledgerEntries[i]
+		ledgerTotalCents += ledgerEntries[i].AmountCents
+	}
+
+	// Find charges missing in ledger
+	var missingInLedger []string
+	for _, chargeID := range chargeIDs {
+		if _, found := ledgerMap[chargeID]; !found {
+			missingInLedger = append(missingInLedger, chargeID)
+		}
+	}
+
+	// Find ledger entries missing in Stripe
+	var missingInStripe []string
+	for refID := range ledgerMap {
+		if _, found := chargeMap[refID]; !found {
+			missingInStripe = append(missingInStripe, refID)
+		}
+	}
+
+	// Calculate variance and check thresholds
+	varianceCents := abs(stripeTotalCents - ledgerTotalCents)
+	exceedsThreshold, alertMessage := checkVarianceThresholds(varianceCents, stripeTotalCents)
+
+	report := &ReconciliationReport{
+		Date:                     from,
+		StripeChargeCount:        len(charges),
+		LedgerEntryCount:         len(ledgerEntries),
+		StripeTotalCents:         stripeTotalCents,
+		LedgerTotalCents:         ledgerTotalCents,
+		VarianceCents:            varianceCents,
+		MissingInLedger:          missingInLedger,
+		MissingInStripe:          missingInStripe,
+		VarianceExceedsThreshold: exceedsThreshold,
+		AlertMessage:             alertMessage,
+	}
+
+	s.logReconciliationResult(from, report)
+
+	return report, nil
+}
+
+// checkVarianceThresholds evaluates whether the variance exceeds absolute or
+// relative thresholds and returns the result with an alert message.
+func checkVarianceThresholds(varianceCents, stripeTotalCents int64) (bool, string) {
+	varianceDecimal := decimal.NewFromInt(varianceCents).Div(decimal.NewFromInt(100))
+	stripeTotal := decimal.NewFromInt(stripeTotalCents).Div(decimal.NewFromInt(100))
+
+	exceedsThreshold := false
+	var alertMessage string
+
+	if varianceDecimal.GreaterThan(VarianceThresholdGBP) {
+		exceedsThreshold = true
+		alertMessage = fmt.Sprintf("absolute variance %s GBP exceeds threshold of %s GBP",
+			varianceDecimal.StringFixed(2), VarianceThresholdGBP.StringFixed(2))
+	}
+
+	if stripeTotal.GreaterThan(decimal.Zero) {
+		pct := varianceDecimal.Div(stripeTotal)
+		if pct.GreaterThan(VarianceThresholdPercent) {
+			exceedsThreshold = true
+			pctStr := pct.Mul(decimal.NewFromInt(100)).StringFixed(2)
+			if alertMessage != "" {
+				alertMessage += "; "
+			}
+			alertMessage += fmt.Sprintf("relative variance %s%% exceeds threshold of %s%%",
+				pctStr, VarianceThresholdPercent.Mul(decimal.NewFromInt(100)).StringFixed(2))
+		}
+	}
+
+	return exceedsThreshold, alertMessage
+}
+
+// logReconciliationResult logs the reconciliation outcome at the appropriate level.
+func (s *ReconciliationService) logReconciliationResult(date time.Time, report *ReconciliationReport) {
+	if report.VarianceExceedsThreshold {
+		s.logger.Warn("reconciliation variance exceeds threshold",
+			"date", date.Format("2006-01-02"),
+			"variance_cents", report.VarianceCents,
+			"alert", report.AlertMessage,
+		)
+	} else {
+		s.logger.Info("reconciliation completed",
+			"date", date.Format("2006-01-02"),
+			"stripe_charges", report.StripeChargeCount,
+			"ledger_entries", report.LedgerEntryCount,
+			"variance_cents", report.VarianceCents,
+		)
+	}
+}
+
+func abs(x int64) int64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/services/control-plane/internal/stripe/reconciliation.go
+++ b/services/control-plane/internal/stripe/reconciliation.go
@@ -17,11 +17,11 @@ var (
 	ErrNilLedgerSource        = errors.New("ledger source cannot be nil")
 )
 
-// VarianceThresholdGBP is the absolute variance threshold in GBP.
-var VarianceThresholdGBP = decimal.NewFromInt(10)
+// varianceThresholdGBP is the absolute variance threshold in GBP.
+var varianceThresholdGBP = decimal.NewFromInt(10) //nolint:gochecknoglobals // configurable threshold
 
-// VarianceThresholdPercent is the relative variance threshold as a percentage of daily volume.
-var VarianceThresholdPercent = decimal.NewFromFloat(0.01) // 1%
+// varianceThresholdPercent is the relative variance threshold as a percentage of daily volume.
+var varianceThresholdPercent = decimal.NewFromFloat(0.01) // 1% //nolint:gochecknoglobals // configurable threshold
 
 // ChargeSource provides Stripe charge data for reconciliation.
 type ChargeSource interface {
@@ -191,22 +191,22 @@ func checkVarianceThresholds(varianceCents, stripeTotalCents int64) (bool, strin
 	exceedsThreshold := false
 	var alertMessage string
 
-	if varianceDecimal.GreaterThan(VarianceThresholdGBP) {
+	if varianceDecimal.GreaterThan(varianceThresholdGBP) {
 		exceedsThreshold = true
 		alertMessage = fmt.Sprintf("absolute variance %s GBP exceeds threshold of %s GBP",
-			varianceDecimal.StringFixed(2), VarianceThresholdGBP.StringFixed(2))
+			varianceDecimal.StringFixed(2), varianceThresholdGBP.StringFixed(2))
 	}
 
 	if stripeTotal.GreaterThan(decimal.Zero) {
 		pct := varianceDecimal.Div(stripeTotal)
-		if pct.GreaterThan(VarianceThresholdPercent) {
+		if pct.GreaterThan(varianceThresholdPercent) {
 			exceedsThreshold = true
 			pctStr := pct.Mul(decimal.NewFromInt(100)).StringFixed(2)
 			if alertMessage != "" {
 				alertMessage += "; "
 			}
 			alertMessage += fmt.Sprintf("relative variance %s%% exceeds threshold of %s%%",
-				pctStr, VarianceThresholdPercent.Mul(decimal.NewFromInt(100)).StringFixed(2))
+				pctStr, varianceThresholdPercent.Mul(decimal.NewFromInt(100)).StringFixed(2))
 		}
 	}
 

--- a/services/control-plane/internal/stripe/reconciliation_test.go
+++ b/services/control-plane/internal/stripe/reconciliation_test.go
@@ -1,0 +1,173 @@
+package stripe
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockStripeSource struct {
+	charges []ChargeRecord
+	err     error
+}
+
+func (m *mockStripeSource) ListCharges(_ context.Context, _, _ time.Time) ([]ChargeRecord, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.charges, nil
+}
+
+type mockLedgerSource struct {
+	entries []LedgerRecord
+	err     error
+}
+
+func (m *mockLedgerSource) ListEntriesByExternalRef(_ context.Context, _ []string) ([]LedgerRecord, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.entries, nil
+}
+
+func TestReconciliation_PerfectMatch(t *testing.T) {
+	svc, err := NewReconciliationService(
+		&mockStripeSource{
+			charges: []ChargeRecord{
+				{ChargeID: "ch_1", AmountCents: 10000, Currency: "gbp"},
+				{ChargeID: "ch_2", AmountCents: 5000, Currency: "gbp"},
+			},
+		},
+		&mockLedgerSource{
+			entries: []LedgerRecord{
+				{LogID: "log-1", ExternalReferenceID: "ch_1", AmountCents: 10000, Currency: "gbp"},
+				{LogID: "log-2", ExternalReferenceID: "ch_2", AmountCents: 5000, Currency: "gbp"},
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	report, err := svc.RunDailyReconciliation(context.Background(), time.Now())
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, report.StripeChargeCount)
+	assert.Equal(t, 2, report.LedgerEntryCount)
+	assert.Equal(t, int64(15000), report.StripeTotalCents)
+	assert.Equal(t, int64(15000), report.LedgerTotalCents)
+	assert.Equal(t, int64(0), report.VarianceCents)
+	assert.Empty(t, report.MissingInLedger)
+	assert.Empty(t, report.MissingInStripe)
+	assert.False(t, report.VarianceExceedsThreshold)
+}
+
+func TestReconciliation_MissingInLedger(t *testing.T) {
+	svc, err := NewReconciliationService(
+		&mockStripeSource{
+			charges: []ChargeRecord{
+				{ChargeID: "ch_1", AmountCents: 10000, Currency: "gbp"},
+				{ChargeID: "ch_2", AmountCents: 5000, Currency: "gbp"},
+			},
+		},
+		&mockLedgerSource{
+			entries: []LedgerRecord{
+				{LogID: "log-1", ExternalReferenceID: "ch_1", AmountCents: 10000, Currency: "gbp"},
+				// ch_2 missing from ledger
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	report, err := svc.RunDailyReconciliation(context.Background(), time.Now())
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, report.StripeChargeCount)
+	assert.Equal(t, 1, report.LedgerEntryCount)
+	assert.Equal(t, int64(5000), report.VarianceCents)
+	assert.Contains(t, report.MissingInLedger, "ch_2")
+}
+
+func TestReconciliation_LargeVarianceAlert(t *testing.T) {
+	// Create a variance > 10 GBP (1000 pence)
+	svc, err := NewReconciliationService(
+		&mockStripeSource{
+			charges: []ChargeRecord{
+				{ChargeID: "ch_1", AmountCents: 200000, Currency: "gbp"}, // 2000 GBP
+			},
+		},
+		&mockLedgerSource{
+			entries: []LedgerRecord{
+				{LogID: "log-1", ExternalReferenceID: "ch_1", AmountCents: 198000, Currency: "gbp"}, // 1980 GBP
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	report, err := svc.RunDailyReconciliation(context.Background(), time.Now())
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(2000), report.VarianceCents) // 20 GBP
+	assert.True(t, report.VarianceExceedsThreshold)
+	assert.NotEmpty(t, report.AlertMessage)
+	assert.Contains(t, report.AlertMessage, "absolute variance")
+}
+
+func TestReconciliation_PercentageVarianceAlert(t *testing.T) {
+	// Create variance > 1% of daily volume
+	// 100 GBP total, 2 GBP variance = 2%
+	svc, err := NewReconciliationService(
+		&mockStripeSource{
+			charges: []ChargeRecord{
+				{ChargeID: "ch_1", AmountCents: 10000, Currency: "gbp"}, // 100 GBP
+			},
+		},
+		&mockLedgerSource{
+			entries: []LedgerRecord{
+				{LogID: "log-1", ExternalReferenceID: "ch_1", AmountCents: 9800, Currency: "gbp"}, // 98 GBP
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+
+	report, err := svc.RunDailyReconciliation(context.Background(), time.Now())
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(200), report.VarianceCents) // 2 GBP
+	assert.True(t, report.VarianceExceedsThreshold)
+	assert.Contains(t, report.AlertMessage, "relative variance")
+}
+
+func TestReconciliation_NoCharges(t *testing.T) {
+	svc, err := NewReconciliationService(
+		&mockStripeSource{charges: nil},
+		&mockLedgerSource{entries: nil},
+		nil,
+	)
+	require.NoError(t, err)
+
+	report, err := svc.RunDailyReconciliation(context.Background(), time.Now())
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, report.StripeChargeCount)
+	assert.Equal(t, 0, report.LedgerEntryCount)
+	assert.Equal(t, int64(0), report.VarianceCents)
+	assert.False(t, report.VarianceExceedsThreshold)
+}
+
+func TestNewReconciliationService_Validation(t *testing.T) {
+	t.Run("nil stripe source", func(t *testing.T) {
+		_, err := NewReconciliationService(nil, &mockLedgerSource{}, nil)
+		assert.ErrorIs(t, err, ErrNilStripeSource)
+	})
+
+	t.Run("nil ledger source", func(t *testing.T) {
+		_, err := NewReconciliationService(&mockStripeSource{}, nil, nil)
+		assert.ErrorIs(t, err, ErrNilLedgerSource)
+	})
+}

--- a/services/control-plane/internal/stripe/sagas/stripe_payment_received.star
+++ b/services/control-plane/internal/stripe/sagas/stripe_payment_received.star
@@ -42,7 +42,7 @@ def execute_stripe_payment_received():
 
     # Convert from cents to major currency unit (e.g., pence to pounds)
     # Stripe amounts are in the smallest currency unit
-    amount = str(amount_cents) + "/100"
+    amount = Decimal(str(amount_cents)) / Decimal("100")
 
     # Derive account identifiers
     nostro_account = "stripe_nostro"

--- a/services/control-plane/internal/stripe/sagas/stripe_payment_received.star
+++ b/services/control-plane/internal/stripe/sagas/stripe_payment_received.star
@@ -1,0 +1,90 @@
+# Saga: stripe_payment_received
+# Version: 1.0.0
+# Previous: none
+# Changed: Initial implementation of Stripe cash-in double-entry posting
+# Author: Platform Team
+# Date: 2026-02-10
+#
+# This Starlark script defines the stripe_payment_received saga workflow.
+# When Stripe reports a successful payment (payment_intent.succeeded), this saga
+# records the cash-in as a double-entry ledger posting in the meridian-ops tenant.
+#
+# Double-Entry Accounting:
+#   DEBIT  stripe_nostro          (cash received from Stripe)
+#   CREDIT {party_id}_prepaid     (customer prepaid balance increases)
+#
+# The Stripe charge ID is stored as external_reference_id for O(1) reconciliation
+# against Stripe's settlement reports.
+#
+# Input data (provided via input_data dictionary):
+#   - tenant_id: string        - The tenant receiving the payment (e.g., "meridian-ops")
+#   - party_id: string         - The customer party identifier
+#   - amount_cents: int        - Payment amount in smallest currency unit (e.g., pence)
+#   - currency: string         - ISO 4217 currency code (e.g., "gbp")
+#   - charge_id: string        - Stripe Charge ID for reconciliation
+#   - payment_intent_id: string - Stripe PaymentIntent ID
+#   - stripe_event_id: string  - Original Stripe event ID for audit trail
+#
+# Compensation Order (LIFO):
+#   If the credit step fails, the debit to stripe_nostro is reversed.
+
+stripe_payment_received_saga = saga(name="stripe_payment_received")
+
+def execute_stripe_payment_received():
+    # Extract input parameters
+    tenant_id = input_data["tenant_id"]
+    party_id = input_data["party_id"]
+    amount_cents = input_data["amount_cents"]
+    currency = input_data.get("currency", "GBP")
+    charge_id = input_data["charge_id"]
+    payment_intent_id = input_data.get("payment_intent_id", "")
+    stripe_event_id = input_data.get("stripe_event_id", "")
+
+    # Convert from cents to major currency unit (e.g., pence to pounds)
+    # Stripe amounts are in the smallest currency unit
+    amount = str(amount_cents) + "/100"
+
+    # Derive account identifiers
+    nostro_account = "stripe_nostro"
+    prepaid_account = party_id + "_prepaid"
+
+    # Step 1: Debit the stripe nostro account (cash received from Stripe)
+    # This represents Stripe holding funds on our behalf
+    step(name="debit_stripe_nostro")
+    debit_result = position_keeping.initiate_log(
+        account_id=nostro_account,
+        amount=amount,
+        currency=currency.upper(),
+        direction="DEBIT",
+        description="Stripe payment received: " + charge_id,
+        external_reference_id=charge_id,
+    )
+
+    # Step 2: Credit the customer prepaid balance
+    # This increases the customer's available balance
+    step(name="credit_customer_prepaid")
+    credit_result = position_keeping.initiate_log(
+        account_id=prepaid_account,
+        amount=amount,
+        currency=currency.upper(),
+        direction="CREDIT",
+        description="Payment from Stripe: " + charge_id,
+        external_reference_id=charge_id,
+    )
+
+    result = {
+        "status": "completed",
+        "tenant_id": tenant_id,
+        "party_id": party_id,
+        "nostro_log_id": debit_result["log_id"],
+        "prepaid_log_id": credit_result["log_id"],
+        "amount_cents": amount_cents,
+        "currency": currency,
+        "charge_id": charge_id,
+        "payment_intent_id": payment_intent_id,
+        "stripe_event_id": stripe_event_id,
+    }
+    return result
+
+# Execute the saga
+execute_stripe_payment_received()

--- a/services/control-plane/internal/stripe/sagas/stripe_payment_received.star
+++ b/services/control-plane/internal/stripe/sagas/stripe_payment_received.star
@@ -76,7 +76,6 @@ def execute_stripe_payment_received():
         "status": "completed",
         "tenant_id": tenant_id,
         "party_id": party_id,
-        "nostro_log_id": debit_result["log_id"],
         "prepaid_log_id": credit_result["log_id"],
         "amount_cents": amount_cents,
         "currency": currency,

--- a/services/control-plane/internal/stripe/webhook.go
+++ b/services/control-plane/internal/stripe/webhook.go
@@ -294,6 +294,16 @@ func (h *WebhookHandler) handleChargeRefunded(ctx context.Context, w http.Respon
 		return
 	}
 
+	if partyID == "" {
+		h.logger.Warn("missing party_id for refund, acknowledging without processing",
+			"charge_id", charge.ID,
+			"event_id", event.ID,
+			"tenant_id", tenantID,
+		)
+		h.writeSuccessResponse(w, "refund acknowledged without party context")
+		return
+	}
+
 	paymentEvent := &PaymentEvent{
 		EventID:         uuid.New().String(),
 		StripeEventID:   event.ID,

--- a/services/control-plane/internal/stripe/webhook.go
+++ b/services/control-plane/internal/stripe/webhook.go
@@ -1,0 +1,383 @@
+// Package stripe provides Stripe webhook handling for the Control Plane service.
+// It receives Stripe webhook events, verifies signatures, and publishes payment
+// events to Kafka for downstream saga processing.
+package stripe
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stripe/stripe-go/v82"
+	"github.com/stripe/stripe-go/v82/webhook"
+)
+
+// Webhook handler errors.
+var (
+	ErrInvalidSignature   = errors.New("invalid webhook signature")
+	ErrMissingSignature   = errors.New("missing Stripe-Signature header")
+	ErrInvalidRequestBody = errors.New("invalid request body")
+	ErrMissingMetadata    = errors.New("required metadata field missing")
+	ErrNilEventPublisher  = errors.New("event publisher cannot be nil")
+	ErrEmptyWebhookSecret = errors.New("webhook secret cannot be empty")
+	ErrUnsupportedEvent   = errors.New("unsupported event type")
+	ErrPayloadTooLarge    = errors.New("request body exceeds maximum size")
+	ErrPublishFailed      = errors.New("failed to publish payment event")
+)
+
+// StripeSignatureHeader is the HTTP header containing the Stripe webhook signature.
+const StripeSignatureHeader = "Stripe-Signature"
+
+// MaxBodySize is the maximum allowed webhook payload size (512KB).
+const MaxBodySize = 512 * 1024
+
+// DefaultSignatureTolerance is the maximum age for webhook timestamps.
+const DefaultSignatureTolerance = 5 * time.Minute
+
+// Event type constants for the Stripe events we handle.
+const (
+	EventTypePaymentIntentSucceeded = "payment_intent.succeeded"
+	EventTypePaymentIntentFailed    = "payment_intent.payment_failed"
+	EventTypeChargeRefunded         = "charge.refunded"
+)
+
+// PaymentEvent represents a processed Stripe payment event ready for Kafka publishing.
+type PaymentEvent struct {
+	// EventID is a unique identifier for this event.
+	EventID string `json:"event_id"`
+	// StripeEventID is the original Stripe event ID (for idempotency).
+	StripeEventID string `json:"stripe_event_id"`
+	// EventType is the Stripe event type (e.g., "payment_intent.succeeded").
+	EventType string `json:"event_type"`
+	// TenantID is extracted from PaymentIntent metadata.
+	TenantID string `json:"tenant_id"`
+	// PartyID is extracted from PaymentIntent metadata.
+	PartyID string `json:"party_id"`
+	// AmountCents is the payment amount in the smallest currency unit.
+	AmountCents int64 `json:"amount_cents"`
+	// Currency is the three-letter ISO currency code (uppercase).
+	Currency string `json:"currency"`
+	// ChargeID is the Stripe Charge ID for reconciliation (external_reference_id).
+	ChargeID string `json:"charge_id"`
+	// PaymentIntentID is the Stripe PaymentIntent ID.
+	PaymentIntentID string `json:"payment_intent_id"`
+	// Timestamp is when the Stripe event was created.
+	Timestamp time.Time `json:"timestamp"`
+	// IdempotencyKey is a deterministic key derived from the Stripe event.
+	IdempotencyKey string `json:"idempotency_key"`
+}
+
+// EventPublisher publishes payment events to the message broker.
+type EventPublisher interface {
+	// PublishPaymentEvent publishes a payment event to Kafka.
+	// The key should be tenant_id for partition affinity.
+	PublishPaymentEvent(ctx context.Context, event *PaymentEvent) error
+}
+
+// WebhookHandler handles incoming Stripe webhook events.
+type WebhookHandler struct {
+	webhookSecret string
+	publisher     EventPublisher
+	logger        *slog.Logger
+}
+
+// WebhookHandlerConfig contains configuration for creating a WebhookHandler.
+type WebhookHandlerConfig struct {
+	// WebhookSecret is the Stripe webhook signing secret (whsec_...).
+	WebhookSecret string
+	// Publisher publishes payment events to Kafka.
+	Publisher EventPublisher
+	// Logger is optional; defaults to slog.Default().
+	Logger *slog.Logger
+}
+
+// NewWebhookHandler creates a new Stripe WebhookHandler.
+func NewWebhookHandler(cfg WebhookHandlerConfig) (*WebhookHandler, error) {
+	if cfg.Publisher == nil {
+		return nil, ErrNilEventPublisher
+	}
+	if cfg.WebhookSecret == "" {
+		return nil, ErrEmptyWebhookSecret
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &WebhookHandler{
+		webhookSecret: cfg.WebhookSecret,
+		publisher:     cfg.Publisher,
+		logger:        logger,
+	}, nil
+}
+
+// HandleWebhook processes incoming Stripe webhook events.
+// It verifies the Stripe signature, routes events by type, and publishes
+// payment events to Kafka for saga processing.
+func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		h.writeErrorResponse(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	defer func() { _ = r.Body.Close() }()
+
+	// Read request body with size limit
+	body, err := io.ReadAll(io.LimitReader(r.Body, MaxBodySize+1))
+	if err != nil {
+		h.logger.Error("failed to read request body", "error", err)
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrInvalidRequestBody.Error())
+		return
+	}
+	if int64(len(body)) > MaxBodySize {
+		h.writeErrorResponse(w, http.StatusRequestEntityTooLarge, ErrPayloadTooLarge.Error())
+		return
+	}
+
+	// Verify Stripe signature
+	sigHeader := r.Header.Get(StripeSignatureHeader)
+	if sigHeader == "" {
+		h.logger.Warn("missing Stripe-Signature header")
+		h.writeErrorResponse(w, http.StatusUnauthorized, ErrMissingSignature.Error())
+		return
+	}
+
+	event, err := webhook.ConstructEventWithOptions(body, sigHeader, h.webhookSecret, webhook.ConstructEventOptions{
+		IgnoreAPIVersionMismatch: true,
+	})
+	if err != nil {
+		h.logger.Warn("invalid webhook signature", "error", err)
+		h.writeErrorResponse(w, http.StatusUnauthorized, ErrInvalidSignature.Error())
+		return
+	}
+
+	h.logger.Info("received stripe webhook",
+		"event_id", event.ID,
+		"event_type", string(event.Type),
+	)
+
+	// Route by event type (using string() to avoid exhaustive switch on stripe.EventType)
+	switch string(event.Type) {
+	case EventTypePaymentIntentSucceeded:
+		h.handlePaymentIntentSucceeded(r.Context(), w, &event)
+	case EventTypePaymentIntentFailed:
+		h.handlePaymentIntentFailed(w, &event)
+	case EventTypeChargeRefunded:
+		h.handleChargeRefunded(r.Context(), w, &event)
+	default:
+		// Acknowledge unknown events to prevent Stripe from retrying
+		h.logger.Debug("ignoring unhandled event type", "event_type", string(event.Type))
+		h.writeSuccessResponse(w, "event type not handled")
+	}
+}
+
+// handlePaymentIntentSucceeded processes a successful payment and publishes it for saga execution.
+func (h *WebhookHandler) handlePaymentIntentSucceeded(ctx context.Context, w http.ResponseWriter, event *stripe.Event) {
+	var pi stripe.PaymentIntent
+	if err := json.Unmarshal(event.Data.Raw, &pi); err != nil {
+		h.logger.Error("failed to unmarshal payment intent", "error", err, "event_id", event.ID)
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrInvalidRequestBody.Error())
+		return
+	}
+
+	tenantID, ok := pi.Metadata["tenant_id"]
+	if !ok || tenantID == "" {
+		h.logger.Error("missing tenant_id in payment intent metadata", "payment_intent_id", pi.ID)
+		h.writeErrorResponse(w, http.StatusBadRequest, "missing tenant_id in metadata")
+		return
+	}
+
+	partyID, ok := pi.Metadata["party_id"]
+	if !ok || partyID == "" {
+		h.logger.Error("missing party_id in payment intent metadata", "payment_intent_id", pi.ID)
+		h.writeErrorResponse(w, http.StatusBadRequest, "missing party_id in metadata")
+		return
+	}
+
+	// Extract charge ID from the latest charge
+	chargeID := extractChargeID(&pi)
+
+	paymentEvent := &PaymentEvent{
+		EventID:         uuid.New().String(),
+		StripeEventID:   event.ID,
+		EventType:       string(event.Type),
+		TenantID:        tenantID,
+		PartyID:         partyID,
+		AmountCents:     pi.Amount,
+		Currency:        string(pi.Currency),
+		ChargeID:        chargeID,
+		PaymentIntentID: pi.ID,
+		Timestamp:       time.Unix(event.Created, 0),
+		IdempotencyKey:  generateIdempotencyKey(event.ID, string(event.Type)),
+	}
+
+	if err := h.publisher.PublishPaymentEvent(ctx, paymentEvent); err != nil {
+		h.logger.Error("failed to publish payment event",
+			"error", err,
+			"event_id", event.ID,
+			"payment_intent_id", pi.ID,
+		)
+		// Return 500 to trigger Stripe retry
+		h.writeErrorResponse(w, http.StatusInternalServerError, ErrPublishFailed.Error())
+		return
+	}
+
+	h.logger.Info("payment event published",
+		"event_id", event.ID,
+		"payment_intent_id", pi.ID,
+		"tenant_id", tenantID,
+		"amount_cents", pi.Amount,
+		"currency", string(pi.Currency),
+	)
+
+	h.writeSuccessResponse(w, "payment event published")
+}
+
+// handlePaymentIntentFailed logs the failure. No saga is triggered for failures.
+func (h *WebhookHandler) handlePaymentIntentFailed(w http.ResponseWriter, event *stripe.Event) {
+	var pi stripe.PaymentIntent
+	if err := json.Unmarshal(event.Data.Raw, &pi); err != nil {
+		h.logger.Error("failed to unmarshal failed payment intent", "error", err, "event_id", event.ID)
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrInvalidRequestBody.Error())
+		return
+	}
+
+	var failureMessage string
+	if pi.LastPaymentError != nil {
+		failureMessage = pi.LastPaymentError.Msg
+	}
+
+	h.logger.Warn("payment intent failed",
+		"event_id", event.ID,
+		"payment_intent_id", pi.ID,
+		"failure_message", failureMessage,
+	)
+
+	h.writeSuccessResponse(w, "failure logged")
+}
+
+// handleChargeRefunded processes a refund and publishes it for refund saga execution.
+func (h *WebhookHandler) handleChargeRefunded(ctx context.Context, w http.ResponseWriter, event *stripe.Event) {
+	var charge stripe.Charge
+	if err := json.Unmarshal(event.Data.Raw, &charge); err != nil {
+		h.logger.Error("failed to unmarshal charge", "error", err, "event_id", event.ID)
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrInvalidRequestBody.Error())
+		return
+	}
+
+	// Refund metadata comes from the original PaymentIntent
+	var tenantID, partyID string
+	if charge.PaymentIntent != nil && charge.PaymentIntent.Metadata != nil {
+		tenantID = charge.PaymentIntent.Metadata["tenant_id"]
+		partyID = charge.PaymentIntent.Metadata["party_id"]
+	}
+	// Fall back to charge metadata
+	if tenantID == "" && charge.Metadata != nil {
+		tenantID = charge.Metadata["tenant_id"]
+	}
+	if partyID == "" && charge.Metadata != nil {
+		partyID = charge.Metadata["party_id"]
+	}
+
+	if tenantID == "" {
+		h.logger.Warn("missing tenant_id for refund, acknowledging without processing",
+			"charge_id", charge.ID,
+			"event_id", event.ID,
+		)
+		h.writeSuccessResponse(w, "refund acknowledged without tenant context")
+		return
+	}
+
+	paymentEvent := &PaymentEvent{
+		EventID:         uuid.New().String(),
+		StripeEventID:   event.ID,
+		EventType:       string(event.Type),
+		TenantID:        tenantID,
+		PartyID:         partyID,
+		AmountCents:     charge.AmountRefunded,
+		Currency:        string(charge.Currency),
+		ChargeID:        charge.ID,
+		PaymentIntentID: "",
+		Timestamp:       time.Unix(event.Created, 0),
+		IdempotencyKey:  generateIdempotencyKey(event.ID, string(event.Type)),
+	}
+
+	if charge.PaymentIntent != nil {
+		paymentEvent.PaymentIntentID = charge.PaymentIntent.ID
+	}
+
+	if err := h.publisher.PublishPaymentEvent(ctx, paymentEvent); err != nil {
+		h.logger.Error("failed to publish refund event",
+			"error", err,
+			"event_id", event.ID,
+			"charge_id", charge.ID,
+		)
+		h.writeErrorResponse(w, http.StatusInternalServerError, ErrPublishFailed.Error())
+		return
+	}
+
+	h.logger.Info("refund event published",
+		"event_id", event.ID,
+		"charge_id", charge.ID,
+		"amount_refunded_cents", charge.AmountRefunded,
+	)
+
+	h.writeSuccessResponse(w, "refund event published")
+}
+
+// extractChargeID extracts the latest charge ID from a PaymentIntent.
+func extractChargeID(pi *stripe.PaymentIntent) string {
+	if pi.LatestCharge != nil {
+		return pi.LatestCharge.ID
+	}
+	return ""
+}
+
+// generateIdempotencyKey creates a deterministic idempotency key from the Stripe event.
+// Uses SHA-256 of event_id + event_type to ensure duplicate webhooks produce the same key.
+func generateIdempotencyKey(eventID, eventType string) string {
+	data := eventID + ":" + eventType
+	hash := sha256.Sum256([]byte(data))
+	return "stripe:" + hex.EncodeToString(hash[:16])
+}
+
+// WebhookResponse represents the JSON response to Stripe.
+type WebhookResponse struct {
+	Received bool   `json:"received"`
+	Message  string `json:"message,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+func (h *WebhookHandler) writeSuccessResponse(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	resp := WebhookResponse{Received: true, Message: message}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		h.logger.Error("failed to encode success response", "error", err)
+	}
+}
+
+func (h *WebhookHandler) writeErrorResponse(w http.ResponseWriter, statusCode int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	resp := WebhookResponse{Received: false, Error: message}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		h.logger.Error("failed to encode error response", "error", err)
+	}
+}
+
+// GenerateTestSignature creates a valid Stripe webhook signature for testing.
+// This wraps the Stripe SDK's test helper for convenience.
+func GenerateTestSignature(payload []byte, secret string) string {
+	signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+		Payload: payload,
+		Secret:  secret,
+	})
+	return signed.Header
+}

--- a/services/control-plane/internal/stripe/webhook.go
+++ b/services/control-plane/internal/stripe/webhook.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -30,6 +31,7 @@ var (
 	ErrUnsupportedEvent   = errors.New("unsupported event type")
 	ErrPayloadTooLarge    = errors.New("request body exceeds maximum size")
 	ErrPublishFailed      = errors.New("failed to publish payment event")
+	ErrMissingChargeID    = errors.New("missing charge ID on succeeded payment intent")
 )
 
 // StripeSignatureHeader is the HTTP header containing the Stripe webhook signature.
@@ -200,8 +202,17 @@ func (h *WebhookHandler) handlePaymentIntentSucceeded(ctx context.Context, w htt
 		return
 	}
 
-	// Extract charge ID from the latest charge
+	// Extract charge ID from the latest charge - required for reconciliation
 	chargeID := extractChargeID(&pi)
+	if chargeID == "" {
+		h.logger.Error("missing charge ID on succeeded payment intent",
+			"payment_intent_id", pi.ID,
+			"event_id", event.ID,
+		)
+		// Return 500 to trigger Stripe retry - charge may populate on re-delivery
+		h.writeErrorResponse(w, http.StatusInternalServerError, ErrMissingChargeID.Error())
+		return
+	}
 
 	paymentEvent := &PaymentEvent{
 		EventID:         uuid.New().String(),
@@ -210,7 +221,7 @@ func (h *WebhookHandler) handlePaymentIntentSucceeded(ctx context.Context, w htt
 		TenantID:        tenantID,
 		PartyID:         partyID,
 		AmountCents:     pi.Amount,
-		Currency:        string(pi.Currency),
+		Currency:        strings.ToUpper(string(pi.Currency)),
 		ChargeID:        chargeID,
 		PaymentIntentID: pi.ID,
 		Timestamp:       time.Unix(event.Created, 0),
@@ -311,7 +322,7 @@ func (h *WebhookHandler) handleChargeRefunded(ctx context.Context, w http.Respon
 		TenantID:        tenantID,
 		PartyID:         partyID,
 		AmountCents:     charge.AmountRefunded,
-		Currency:        string(charge.Currency),
+		Currency:        strings.ToUpper(string(charge.Currency)),
 		ChargeID:        charge.ID,
 		PaymentIntentID: "",
 		Timestamp:       time.Unix(event.Created, 0),

--- a/services/control-plane/internal/stripe/webhook_test.go
+++ b/services/control-plane/internal/stripe/webhook_test.go
@@ -1,0 +1,459 @@
+package stripe
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/v82/webhook"
+)
+
+// mockPublisher implements EventPublisher for testing.
+type mockPublisher struct {
+	publishFunc func(ctx context.Context, event *PaymentEvent) error
+	events      []*PaymentEvent
+}
+
+func (m *mockPublisher) PublishPaymentEvent(ctx context.Context, event *PaymentEvent) error {
+	m.events = append(m.events, event)
+	if m.publishFunc != nil {
+		return m.publishFunc(ctx, event)
+	}
+	return nil
+}
+
+const testWebhookSecret = "whsec_test_secret_key_123"
+
+// buildPaymentIntentSucceededPayload creates a Stripe event JSON payload for testing.
+func buildPaymentIntentSucceededPayload(t *testing.T, piID string, amount int64, currency string, metadata map[string]string) []byte {
+	t.Helper()
+
+	metaJSON, err := json.Marshal(metadata)
+	require.NoError(t, err)
+
+	// Build a minimal Stripe event payload matching the SDK expectations
+	payload := map[string]any{
+		"id":      "evt_test_" + piID,
+		"type":    "payment_intent.succeeded",
+		"created": time.Now().Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":       piID,
+				"object":   "payment_intent",
+				"amount":   amount,
+				"currency": currency,
+				"metadata": json.RawMessage(metaJSON),
+				"latest_charge": map[string]any{
+					"id":     "ch_test_charge_123",
+					"object": "charge",
+				},
+				"status": "succeeded",
+			},
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return data
+}
+
+func buildPaymentIntentFailedPayload(t *testing.T, piID string) []byte {
+	t.Helper()
+
+	payload := map[string]any{
+		"id":      "evt_test_failed_" + piID,
+		"type":    "payment_intent.payment_failed",
+		"created": time.Now().Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":       piID,
+				"object":   "payment_intent",
+				"amount":   5000,
+				"currency": "gbp",
+				"metadata": map[string]string{
+					"tenant_id": "meridian-ops",
+					"party_id":  "party-123",
+				},
+				"status": "requires_payment_method",
+				"last_payment_error": map[string]any{
+					"message": "Your card was declined",
+					"code":    "card_declined",
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return data
+}
+
+func buildChargeRefundedPayload(t *testing.T, chargeID string, amountRefunded int64) []byte {
+	t.Helper()
+
+	payload := map[string]any{
+		"id":      "evt_test_refund_" + chargeID,
+		"type":    "charge.refunded",
+		"created": time.Now().Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":              chargeID,
+				"object":          "charge",
+				"amount_refunded": amountRefunded,
+				"currency":        "gbp",
+				"metadata": map[string]string{
+					"tenant_id": "meridian-ops",
+					"party_id":  "party-456",
+				},
+				"payment_intent": map[string]any{
+					"id":     "pi_test_refund",
+					"object": "payment_intent",
+					"metadata": map[string]string{
+						"tenant_id": "meridian-ops",
+						"party_id":  "party-456",
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return data
+}
+
+// signPayload creates a properly signed request for testing.
+func signPayload(t *testing.T, payload []byte, secret string) string {
+	t.Helper()
+	signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+		Payload: payload,
+		Secret:  secret,
+	})
+	return signed.Header
+}
+
+func TestNewWebhookHandler(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     WebhookHandlerConfig
+		wantErr error
+	}{
+		{
+			name: "valid config",
+			cfg: WebhookHandlerConfig{
+				Publisher:     &mockPublisher{},
+				WebhookSecret: testWebhookSecret,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "nil publisher",
+			cfg: WebhookHandlerConfig{
+				Publisher:     nil,
+				WebhookSecret: testWebhookSecret,
+			},
+			wantErr: ErrNilEventPublisher,
+		},
+		{
+			name: "empty webhook secret",
+			cfg: WebhookHandlerConfig{
+				Publisher:     &mockPublisher{},
+				WebhookSecret: "",
+			},
+			wantErr: ErrEmptyWebhookSecret,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, err := NewWebhookHandler(tt.cfg)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Nil(t, handler)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, handler)
+			}
+		})
+	}
+}
+
+func TestHandleWebhook_PaymentIntentSucceeded(t *testing.T) {
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	payload := buildPaymentIntentSucceededPayload(t, "pi_test_123", 10000, "gbp", map[string]string{
+		"tenant_id": "meridian-ops",
+		"party_id":  "party-abc",
+	})
+	sig := signPayload(t, payload, testWebhookSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var resp WebhookResponse
+	err = json.NewDecoder(rr.Body).Decode(&resp)
+	require.NoError(t, err)
+	assert.True(t, resp.Received)
+
+	// Verify published event
+	require.Len(t, pub.events, 1)
+	evt := pub.events[0]
+	assert.Equal(t, "payment_intent.succeeded", evt.EventType)
+	assert.Equal(t, "meridian-ops", evt.TenantID)
+	assert.Equal(t, "party-abc", evt.PartyID)
+	assert.Equal(t, int64(10000), evt.AmountCents)
+	assert.Equal(t, "gbp", evt.Currency)
+	assert.Equal(t, "pi_test_123", evt.PaymentIntentID)
+	assert.Equal(t, "ch_test_charge_123", evt.ChargeID)
+	assert.NotEmpty(t, evt.IdempotencyKey)
+	assert.True(t, len(evt.IdempotencyKey) > 0)
+}
+
+func TestHandleWebhook_PaymentIntentFailed(t *testing.T) {
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	payload := buildPaymentIntentFailedPayload(t, "pi_fail_456")
+	sig := signPayload(t, payload, testWebhookSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	// No event should be published for failures
+	assert.Empty(t, pub.events)
+}
+
+func TestHandleWebhook_ChargeRefunded(t *testing.T) {
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	payload := buildChargeRefundedPayload(t, "ch_refund_789", 5000)
+	sig := signPayload(t, payload, testWebhookSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	require.Len(t, pub.events, 1)
+	evt := pub.events[0]
+	assert.Equal(t, "charge.refunded", evt.EventType)
+	assert.Equal(t, int64(5000), evt.AmountCents)
+	assert.Equal(t, "ch_refund_789", evt.ChargeID)
+}
+
+func TestHandleWebhook_InvalidSignature(t *testing.T) {
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     &mockPublisher{},
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	payload := buildPaymentIntentSucceededPayload(t, "pi_test", 1000, "gbp", map[string]string{
+		"tenant_id": "meridian-ops",
+		"party_id":  "party-1",
+	})
+
+	// Sign with wrong secret
+	sig := signPayload(t, payload, "whsec_wrong_secret")
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestHandleWebhook_MissingSignature(t *testing.T) {
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     &mockPublisher{},
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader([]byte("{}")))
+	// No Stripe-Signature header
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestHandleWebhook_MethodNotAllowed(t *testing.T) {
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     &mockPublisher{},
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/stripe", nil)
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}
+
+func TestHandleWebhook_MissingTenantID(t *testing.T) {
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	// Missing tenant_id in metadata
+	payload := buildPaymentIntentSucceededPayload(t, "pi_no_tenant", 1000, "gbp", map[string]string{
+		"party_id": "party-1",
+	})
+	sig := signPayload(t, payload, testWebhookSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Empty(t, pub.events)
+}
+
+func TestHandleWebhook_MissingPartyID(t *testing.T) {
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	// Missing party_id in metadata
+	payload := buildPaymentIntentSucceededPayload(t, "pi_no_party", 1000, "gbp", map[string]string{
+		"tenant_id": "meridian-ops",
+	})
+	sig := signPayload(t, payload, testWebhookSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Empty(t, pub.events)
+}
+
+func TestHandleWebhook_PublishFailure(t *testing.T) {
+	pub := &mockPublisher{
+		publishFunc: func(_ context.Context, _ *PaymentEvent) error {
+			return ErrPublishFailed
+		},
+	}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	payload := buildPaymentIntentSucceededPayload(t, "pi_pub_fail", 1000, "gbp", map[string]string{
+		"tenant_id": "meridian-ops",
+		"party_id":  "party-1",
+	})
+	sig := signPayload(t, payload, testWebhookSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	// Should return 500 so Stripe retries
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestHandleWebhook_UnhandledEventType(t *testing.T) {
+	pub := &mockPublisher{}
+	handler, err := NewWebhookHandler(WebhookHandlerConfig{
+		Publisher:     pub,
+		WebhookSecret: testWebhookSecret,
+	})
+	require.NoError(t, err)
+
+	payload, err := json.Marshal(map[string]any{
+		"id":      "evt_test_unknown",
+		"type":    "customer.created",
+		"created": time.Now().Unix(),
+		"data": map[string]any{
+			"object": map[string]any{
+				"id":     "cus_123",
+				"object": "customer",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	sig := signPayload(t, payload, testWebhookSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/stripe", bytes.NewReader(payload))
+	req.Header.Set(StripeSignatureHeader, sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleWebhook(rr, req)
+
+	// Should acknowledge unknown events to prevent retries
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, pub.events)
+}
+
+func TestIdempotencyKeyDeterminism(t *testing.T) {
+	key1 := generateIdempotencyKey("evt_123", "payment_intent.succeeded")
+	key2 := generateIdempotencyKey("evt_123", "payment_intent.succeeded")
+	key3 := generateIdempotencyKey("evt_456", "payment_intent.succeeded")
+
+	assert.Equal(t, key1, key2, "same inputs should produce same key")
+	assert.NotEqual(t, key1, key3, "different inputs should produce different keys")
+	assert.True(t, len(key1) > 0)
+	assert.Contains(t, key1, "stripe:")
+}
+
+func TestGenerateTestSignature(t *testing.T) {
+	payload := []byte(`{"test": true}`)
+	sig := GenerateTestSignature(payload, testWebhookSecret)
+
+	assert.NotEmpty(t, sig)
+	assert.Contains(t, sig, "t=")
+	assert.Contains(t, sig, "v1=")
+}

--- a/services/control-plane/internal/stripe/webhook_test.go
+++ b/services/control-plane/internal/stripe/webhook_test.go
@@ -218,7 +218,7 @@ func TestHandleWebhook_PaymentIntentSucceeded(t *testing.T) {
 	assert.Equal(t, "meridian-ops", evt.TenantID)
 	assert.Equal(t, "party-abc", evt.PartyID)
 	assert.Equal(t, int64(10000), evt.AmountCents)
-	assert.Equal(t, "gbp", evt.Currency)
+	assert.Equal(t, "GBP", evt.Currency)
 	assert.Equal(t, "pi_test_123", evt.PaymentIntentID)
 	assert.Equal(t, "ch_test_charge_123", evt.ChargeID)
 	assert.NotEmpty(t, evt.IdempotencyKey)


### PR DESCRIPTION
## Summary

Implements control-plane.11: Stripe Cash-In Rail, providing the complete pipeline from Stripe webhook reception through to saga-based double-entry ledger posting.

- Stripe webhook handler with SDK signature verification, routing payment_intent.succeeded, payment_intent.payment_failed, and charge.refunded events
- Kafka publisher adapter for payment events with tenant partitioning
- Payment event consumer routing events to stripe_payment_received and stripe_payment_refunded sagas
- Starlark saga performing double-entry posting (DEBIT stripe_nostro, CREDIT {party_id}_prepaid) with external_reference_id tracking
- Preflight checker verifying meridian-ops tenant, stripe_nostro, and revenue accounts on startup
- Daily reconciliation service comparing Stripe charges vs ledger entries with absolute (10 GBP) and relative (1%) variance alerting
- Deterministic idempotency keys (SHA-256 of Stripe event ID + type) ensuring duplicate webhook deliveries produce identical saga triggers

## Changes Made

| File | Purpose |
|------|---------|
| `webhook.go` | Stripe webhook handler with signature verification |
| `webhook_test.go` | 12 tests covering success, failure, refund, auth, metadata validation |
| `publisher.go` | Kafka publisher adapter for PaymentEvent |
| `consumer.go` | Event consumer routing to saga orchestrator |
| `consumer_test.go` | 6 tests covering routing, errors, idempotency propagation |
| `preflight.go` | Startup preflight checks for required infrastructure |
| `preflight_test.go` | 6 tests covering all check scenarios |
| `reconciliation.go` | Daily Stripe vs ledger reconciliation with variance detection |
| `reconciliation_test.go` | 6 tests covering match, missing, variance thresholds |
| `idempotency_test.go` | 5 tests for end-to-end idempotency guarantees |
| `sagas/stripe_payment_received.star` | Starlark saga for double-entry posting |
| `go.mod` / `go.sum` | Added stripe-go/v82 dependency |

## Technical Details

- Uses `stripe-go/v82` SDK for webhook signature verification via `webhook.ConstructEventWithOptions`
- Tenant and party IDs extracted from PaymentIntent.metadata
- Idempotency keys are deterministic: `stripe:` + SHA-256(event_id + ":" + event_type), truncated to 16 bytes
- Reconciliation uses shopspring/decimal for precise financial arithmetic
- All external dependencies are interface-based for testability

## Testing

- 37 tests passing across all components
- `go test ./services/control-plane/internal/stripe/... -count=1` all green
- Pre-commit hooks (gofumpt, golangci-lint) passing with 0 issues
- Stripe package builds cleanly: `go build ./services/control-plane/internal/stripe/...`

## Risk Assessment

- Low risk: All new code in new package, no modifications to existing code
- Pre-existing build issue in `shared/pkg/saga/admin_handler.go` (missing saga/v1 proto) is unrelated

## Task Master Reference

- Tag: control-plane, Task: 11 (Stripe Cash-In Rail)
- Subtasks: 11.1 (webhook), 11.2 (saga), 11.3 (preflight), 11.4 (consumer), 11.5 (reconciliation), 11.6 (idempotency)