### PR TITLE
feat: add multi-asset balance sheet with drill-down

### DIFF
--- a/api/proto/meridian/control_plane/v1/admin.proto
+++ b/api/proto/meridian/control_plane/v1/admin.proto
@@ -240,6 +240,10 @@ message GetPositionDetailsRequest {
     min_len: 1
     max_len: 32
   }];
+
+  // as_of is an optional point-in-time for the drill-down (defaults to now).
+  // Should match the as_of used in GetBalanceSheet for consistent results.
+  google.protobuf.Timestamp as_of = 4;
 }
 
 // GetPositionDetailsResponse returns individual positions for drill-down.

--- a/api/proto/meridian/control_plane/v1/admin.proto
+++ b/api/proto/meridian/control_plane/v1/admin.proto
@@ -4,6 +4,7 @@ package meridian.control_plane.v1;
 
 import "buf/validate/validate.proto";
 import "google/api/annotations.proto";
+import "google/protobuf/timestamp.proto";
 import "meridian/saga/v1/saga_admin.proto";
 
 option go_package = "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1;controlplanev1";
@@ -109,4 +110,191 @@ message GetCausationTreeForEventResponse {
 
   // saga_id is the root saga that was found for this event.
   string saga_id = 4;
+}
+
+// =============================================================================
+// Balance Sheet Service
+// =============================================================================
+
+// BalanceSheetClassification categorizes balance sheet line items.
+enum BalanceSheetClassification {
+  // BALANCE_SHEET_CLASSIFICATION_UNSPECIFIED is the default value.
+  BALANCE_SHEET_CLASSIFICATION_UNSPECIFIED = 0;
+  // BALANCE_SHEET_CLASSIFICATION_ASSETS represents asset accounts (normal debit balance).
+  BALANCE_SHEET_CLASSIFICATION_ASSETS = 1;
+  // BALANCE_SHEET_CLASSIFICATION_LIABILITIES represents liability accounts (normal credit balance).
+  BALANCE_SHEET_CLASSIFICATION_LIABILITIES = 2;
+  // BALANCE_SHEET_CLASSIFICATION_EQUITY represents equity accounts (normal credit balance).
+  BALANCE_SHEET_CLASSIFICATION_EQUITY = 3;
+}
+
+// NormalBalanceDirection indicates the normal balance direction for an account type.
+enum NormalBalanceDirection {
+  // NORMAL_BALANCE_DIRECTION_UNSPECIFIED is the default value.
+  NORMAL_BALANCE_DIRECTION_UNSPECIFIED = 0;
+  // NORMAL_BALANCE_DIRECTION_DEBIT indicates accounts that normally carry a debit balance.
+  NORMAL_BALANCE_DIRECTION_DEBIT = 1;
+  // NORMAL_BALANCE_DIRECTION_CREDIT indicates accounts that normally carry a credit balance.
+  NORMAL_BALANCE_DIRECTION_CREDIT = 2;
+}
+
+// BalanceSheetService provides CFO Glass Box balance sheet views.
+// It aggregates positions across multiple instruments with classification
+// into ASSETS, LIABILITIES, and EQUITY sections, enabling drill-down
+// to causation trees for full auditability.
+service BalanceSheetService {
+  // GetBalanceSheet returns a multi-asset balance sheet for a tenant,
+  // grouped by classification with totals per instrument.
+  rpc GetBalanceSheet(GetBalanceSheetRequest) returns (GetBalanceSheetResponse) {
+    option (google.api.http) = {
+      get: "/admin/balance-sheet/{tenant_id}"
+    };
+  }
+
+  // GetPositionDetails returns drill-down details for a specific account type
+  // and instrument, including individual positions with causation IDs.
+  rpc GetPositionDetails(GetPositionDetailsRequest) returns (GetPositionDetailsResponse) {
+    option (google.api.http) = {
+      get: "/admin/balance-sheet/{tenant_id}/details/{account_type}/{instrument}"
+    };
+  }
+
+  // ExportBalanceSheetCSV exports the balance sheet as CSV with metadata.
+  rpc ExportBalanceSheetCSV(ExportBalanceSheetCSVRequest) returns (ExportBalanceSheetCSVResponse) {
+    option (google.api.http) = {
+      get: "/admin/balance-sheet/{tenant_id}/export"
+    };
+  }
+}
+
+// GetBalanceSheetRequest requests a balance sheet for a tenant.
+message GetBalanceSheetRequest {
+  // tenant_id identifies the tenant.
+  string tenant_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // as_of is an optional point-in-time for the balance sheet (defaults to now).
+  google.protobuf.Timestamp as_of = 2;
+}
+
+// GetBalanceSheetResponse returns the complete balance sheet.
+message GetBalanceSheetResponse {
+  // tenant_id is the tenant this balance sheet belongs to.
+  string tenant_id = 1;
+
+  // as_of is the timestamp when this balance sheet was calculated.
+  google.protobuf.Timestamp as_of = 2;
+
+  // sections contains the balance sheet sections (ASSETS, LIABILITIES, EQUITY).
+  repeated BalanceSheetSection sections = 3;
+}
+
+// BalanceSheetSection represents a classified section of the balance sheet.
+message BalanceSheetSection {
+  // classification is the section type (ASSETS, LIABILITIES, or EQUITY).
+  BalanceSheetClassification classification = 1;
+
+  // line_items contains individual account type balances within this section.
+  repeated BalanceSheetLineItem line_items = 2;
+
+  // totals contains the total balance per instrument for this section.
+  map<string, string> totals = 3;
+}
+
+// BalanceSheetLineItem represents a single line on the balance sheet.
+message BalanceSheetLineItem {
+  // account_type is the account type identifier (e.g., "STRIPE_NOSTRO", "ENERGY_INVENTORY").
+  string account_type = 1;
+
+  // instrument is the instrument code (e.g., "GBP", "KWH").
+  string instrument = 2;
+
+  // quantity is the balance amount as a string decimal.
+  string quantity = 3;
+
+  // normal_balance is the normal balance direction for this account type.
+  NormalBalanceDirection normal_balance = 4;
+
+  // account_count is the number of individual accounts contributing to this line item.
+  int32 account_count = 5;
+}
+
+// GetPositionDetailsRequest requests drill-down details for a position.
+message GetPositionDetailsRequest {
+  // tenant_id identifies the tenant.
+  string tenant_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // account_type is the account type to drill into (e.g., "STRIPE_NOSTRO").
+  string account_type = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // instrument is the instrument code to filter by (e.g., "GBP").
+  string instrument = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+  }];
+}
+
+// GetPositionDetailsResponse returns individual positions for drill-down.
+message GetPositionDetailsResponse {
+  // tenant_id is the tenant this data belongs to.
+  string tenant_id = 1;
+
+  // account_type is the account type queried.
+  string account_type = 2;
+
+  // instrument is the instrument queried.
+  string instrument = 3;
+
+  // positions contains individual position records.
+  repeated PositionDetail positions = 4;
+
+  // total is the aggregate total for this account type and instrument.
+  string total = 5;
+}
+
+// PositionDetail represents an individual position with causation link.
+message PositionDetail {
+  // account_id is the individual account identifier.
+  string account_id = 1;
+
+  // quantity is the position balance as a string decimal.
+  string quantity = 2;
+
+  // log_id is the financial position log ID for causation tree lookup.
+  string log_id = 3;
+
+  // last_updated is when this position was last modified.
+  google.protobuf.Timestamp last_updated = 4;
+}
+
+// ExportBalanceSheetCSVRequest requests a CSV export of the balance sheet.
+message ExportBalanceSheetCSVRequest {
+  // tenant_id identifies the tenant.
+  string tenant_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // as_of is an optional point-in-time for the balance sheet (defaults to now).
+  google.protobuf.Timestamp as_of = 2;
+}
+
+// ExportBalanceSheetCSVResponse returns the CSV content.
+message ExportBalanceSheetCSVResponse {
+  // csv_content is the complete CSV file content as a string.
+  string csv_content = 1;
+
+  // generated_at is the timestamp when the export was generated.
+  google.protobuf.Timestamp generated_at = 2;
+
+  // tenant_id is the tenant this export belongs to.
+  string tenant_id = 3;
 }

--- a/services/control-plane/internal/admin/balance_sheet.go
+++ b/services/control-plane/internal/admin/balance_sheet.go
@@ -233,13 +233,19 @@ func (s *BalanceSheetService) ExportBalanceSheetCSV(ctx context.Context, tenantI
 			}
 		}
 
-		// Write section totals
-		for instrument, total := range section.Totals {
+		// Write section totals in sorted instrument order for deterministic output.
+		instruments := make([]string, 0, len(section.Totals))
+		for instrument := range section.Totals {
+			instruments = append(instruments, instrument)
+		}
+		sort.Strings(instruments)
+
+		for _, instrument := range instruments {
 			if err := w.Write([]string{
 				string(section.Classification),
 				"TOTAL",
 				instrument,
-				total.String(),
+				section.Totals[instrument].String(),
 				"",
 				"",
 			}); err != nil {

--- a/services/control-plane/internal/admin/balance_sheet.go
+++ b/services/control-plane/internal/admin/balance_sheet.go
@@ -262,16 +262,36 @@ func (s *BalanceSheetService) ExportBalanceSheetCSV(ctx context.Context, tenantI
 	return buf.String(), nil
 }
 
-// fetchPositionLogs retrieves all position logs for a tenant from position-keeping.
+// fetchPositionLogs retrieves all position logs for a tenant from position-keeping,
+// handling cursor-based pagination to collect all pages.
 func (s *BalanceSheetService) fetchPositionLogs(ctx context.Context, tenantID string) ([]*positionkeepingv1.FinancialPositionLog, error) {
-	resp, err := s.pkClient.ListFinancialPositionLogs(ctx, &positionkeepingv1.ListFinancialPositionLogsRequest{
-		AccountId: tenantID,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("list position logs: %w", err)
+	var allLogs []*positionkeepingv1.FinancialPositionLog
+	var pageToken string
+
+	for {
+		req := &positionkeepingv1.ListFinancialPositionLogsRequest{
+			AccountId: tenantID,
+		}
+		if pageToken != "" {
+			req.Pagination = &commonv1.Pagination{
+				PageToken: pageToken,
+			}
+		}
+
+		resp, err := s.pkClient.ListFinancialPositionLogs(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("list position logs: %w", err)
+		}
+
+		allLogs = append(allLogs, resp.GetLogs()...)
+
+		pageToken = resp.GetPagination().GetNextPageToken()
+		if pageToken == "" {
+			break
+		}
 	}
 
-	return resp.GetLogs(), nil
+	return allLogs, nil
 }
 
 // aggregateAndClassify groups position logs by account type and instrument,

--- a/services/control-plane/internal/admin/balance_sheet.go
+++ b/services/control-plane/internal/admin/balance_sheet.go
@@ -142,14 +142,21 @@ func (s *BalanceSheetService) GetBalanceSheet(ctx context.Context, tenantID stri
 }
 
 // GetPositionDetails returns drill-down details for a specific account type and instrument.
-func (s *BalanceSheetService) GetPositionDetails(ctx context.Context, tenantID, accountType, instrument string) (*PositionDetailsResult, error) {
+// When asOf is non-zero, only positions as of that time are included, consistent with GetBalanceSheet.
+func (s *BalanceSheetService) GetPositionDetails(ctx context.Context, tenantID, accountType, instrument string, asOf time.Time) (*PositionDetailsResult, error) {
 	s.logger.Debug("fetching position details",
 		"tenant_id", tenantID,
 		"account_type", accountType,
 		"instrument", instrument,
+		"as_of", asOf,
 	)
 
-	logs, err := s.fetchPositionLogs(ctx, tenantID, time.Time{})
+	// A nil proto Timestamp converts to Unix epoch (1970-01-01), not Go's zero time.
+	if asOf.IsZero() || asOf.Unix() == 0 {
+		asOf = time.Now().UTC()
+	}
+
+	logs, err := s.fetchPositionLogs(ctx, tenantID, asOf)
 	if err != nil {
 		return nil, fmt.Errorf("fetch position logs: %w", err)
 	}
@@ -303,7 +310,7 @@ func (s *BalanceSheetService) fetchPositionLogs(ctx context.Context, tenantID st
 	if !asOf.IsZero() {
 		filtered := allLogs[:0]
 		for _, log := range allLogs {
-			if !log.GetCreatedAt().AsTime().After(asOf) {
+			if !log.GetUpdatedAt().AsTime().After(asOf) {
 				filtered = append(filtered, log)
 			}
 		}

--- a/services/control-plane/internal/admin/balance_sheet.go
+++ b/services/control-plane/internal/admin/balance_sheet.go
@@ -1,0 +1,495 @@
+package admin
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+	"github.com/meridianhub/meridian/services/position-keeping/client"
+)
+
+// BalanceSheetClassification categorizes accounts on the balance sheet.
+type BalanceSheetClassification string
+
+// Balance sheet classification constants.
+const (
+	ClassificationAssets      BalanceSheetClassification = "ASSETS"
+	ClassificationLiabilities BalanceSheetClassification = "LIABILITIES"
+	ClassificationEquity      BalanceSheetClassification = "EQUITY"
+)
+
+// NormalBalance indicates the normal balance direction for an account type.
+type NormalBalance string
+
+// Normal balance direction constants.
+const (
+	NormalBalanceDebit  NormalBalance = "DEBIT"
+	NormalBalanceCredit NormalBalance = "CREDIT"
+)
+
+// instrumentUnknown is returned when the instrument code cannot be determined.
+const instrumentUnknown = "UNKNOWN"
+
+// equityAccountTypes contains account types classified as equity.
+var equityAccountTypes = map[string]bool{
+	"RETAINED_EARNINGS": true,
+	"OWNER_EQUITY":      true,
+	"CAPITAL":           true,
+}
+
+// LineItem represents a single line on the balance sheet.
+type LineItem struct {
+	AccountType   string
+	Instrument    string
+	Quantity      decimal.Decimal
+	NormalBalance NormalBalance
+	AccountCount  int32
+}
+
+// BalanceSheetSection represents a classified section of the balance sheet.
+type BalanceSheetSection struct {
+	Classification BalanceSheetClassification
+	LineItems      []LineItem
+	Totals         map[string]decimal.Decimal
+}
+
+// PositionDetail represents an individual position for drill-down.
+type PositionDetail struct {
+	AccountID   string
+	Quantity    decimal.Decimal
+	LogID       string
+	LastUpdated time.Time
+}
+
+// BalanceSheet represents the complete balance sheet for a tenant.
+type BalanceSheet struct {
+	TenantID string
+	AsOf     time.Time
+	Sections []BalanceSheetSection
+}
+
+// PositionDetailsResult contains the drill-down result for a specific account type and instrument.
+type PositionDetailsResult struct {
+	TenantID    string
+	AccountType string
+	Instrument  string
+	Positions   []PositionDetail
+	Total       decimal.Decimal
+}
+
+// PositionKeepingClient abstracts the position-keeping gRPC client for testability.
+type PositionKeepingClient interface {
+	ListFinancialPositionLogs(ctx context.Context, req *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error)
+	GetAccountBalance(ctx context.Context, req *positionkeepingv1.GetAccountBalanceRequest) (*positionkeepingv1.GetAccountBalanceResponse, error)
+}
+
+// Verify client.Client satisfies the interface at compile time.
+var _ PositionKeepingClient = (*client.Client)(nil)
+
+// BalanceSheetService aggregates positions across multiple instruments into a
+// classified balance sheet with ASSETS, LIABILITIES, and EQUITY sections.
+type BalanceSheetService struct {
+	pkClient PositionKeepingClient
+	logger   *slog.Logger
+}
+
+// NewBalanceSheetService creates a new BalanceSheetService.
+func NewBalanceSheetService(pkClient PositionKeepingClient, logger *slog.Logger) *BalanceSheetService {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &BalanceSheetService{
+		pkClient: pkClient,
+		logger:   logger,
+	}
+}
+
+// GetBalanceSheet retrieves and aggregates positions into a classified balance sheet.
+func (s *BalanceSheetService) GetBalanceSheet(ctx context.Context, tenantID string, asOf time.Time) (*BalanceSheet, error) {
+	s.logger.Debug("generating balance sheet",
+		"tenant_id", tenantID,
+		"as_of", asOf,
+	)
+
+	if asOf.IsZero() {
+		asOf = time.Now().UTC()
+	}
+
+	// Fetch all position logs for the tenant via position-keeping service.
+	// The tenant_id is used as an account_id prefix filter.
+	logs, err := s.fetchPositionLogs(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch position logs: %w", err)
+	}
+
+	// Aggregate by account type and instrument, classify into sections
+	sections := s.aggregateAndClassify(logs)
+
+	return &BalanceSheet{
+		TenantID: tenantID,
+		AsOf:     asOf,
+		Sections: sections,
+	}, nil
+}
+
+// GetPositionDetails returns drill-down details for a specific account type and instrument.
+func (s *BalanceSheetService) GetPositionDetails(ctx context.Context, tenantID, accountType, instrument string) (*PositionDetailsResult, error) {
+	s.logger.Debug("fetching position details",
+		"tenant_id", tenantID,
+		"account_type", accountType,
+		"instrument", instrument,
+	)
+
+	logs, err := s.fetchPositionLogs(ctx, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch position logs: %w", err)
+	}
+
+	positions := make([]PositionDetail, 0, len(logs))
+	total := decimal.Zero
+
+	for _, log := range logs {
+		at := extractAccountType(log.GetAccountId())
+		if at != accountType {
+			continue
+		}
+
+		logInstrument := extractInstrument(log)
+		if logInstrument != instrument {
+			continue
+		}
+
+		qty := computeLogBalance(log)
+		total = total.Add(qty)
+
+		positions = append(positions, PositionDetail{
+			AccountID:   log.GetAccountId(),
+			Quantity:    qty,
+			LogID:       log.GetLogId(),
+			LastUpdated: log.GetUpdatedAt().AsTime(),
+		})
+	}
+
+	return &PositionDetailsResult{
+		TenantID:    tenantID,
+		AccountType: accountType,
+		Instrument:  instrument,
+		Positions:   positions,
+		Total:       total,
+	}, nil
+}
+
+// ExportBalanceSheetCSV exports the balance sheet as CSV.
+func (s *BalanceSheetService) ExportBalanceSheetCSV(ctx context.Context, tenantID string, asOf time.Time) (string, error) {
+	bs, err := s.GetBalanceSheet(ctx, tenantID, asOf)
+	if err != nil {
+		return "", err
+	}
+
+	var buf strings.Builder
+	w := csv.NewWriter(&buf)
+
+	// Write metadata header
+	if err := w.Write([]string{"# Balance Sheet Export"}); err != nil {
+		return "", fmt.Errorf("write metadata: %w", err)
+	}
+	if err := w.Write([]string{"# Tenant", bs.TenantID}); err != nil {
+		return "", fmt.Errorf("write tenant: %w", err)
+	}
+	if err := w.Write([]string{"# Generated At", bs.AsOf.Format(time.RFC3339)}); err != nil {
+		return "", fmt.Errorf("write timestamp: %w", err)
+	}
+	if err := w.Write([]string{""}); err != nil {
+		return "", fmt.Errorf("write separator: %w", err)
+	}
+
+	// Write column headers
+	if err := w.Write([]string{
+		"classification", "account_type", "instrument", "quantity", "normal_balance", "account_count",
+	}); err != nil {
+		return "", fmt.Errorf("write header: %w", err)
+	}
+
+	// Write line items
+	for _, section := range bs.Sections {
+		for _, item := range section.LineItems {
+			if err := w.Write([]string{
+				string(section.Classification),
+				item.AccountType,
+				item.Instrument,
+				item.Quantity.String(),
+				string(item.NormalBalance),
+				fmt.Sprintf("%d", item.AccountCount),
+			}); err != nil {
+				return "", fmt.Errorf("write line item: %w", err)
+			}
+		}
+
+		// Write section totals
+		for instrument, total := range section.Totals {
+			if err := w.Write([]string{
+				string(section.Classification),
+				"TOTAL",
+				instrument,
+				total.String(),
+				"",
+				"",
+			}); err != nil {
+				return "", fmt.Errorf("write total: %w", err)
+			}
+		}
+	}
+
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return "", fmt.Errorf("flush CSV: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
+// fetchPositionLogs retrieves all position logs for a tenant from position-keeping.
+func (s *BalanceSheetService) fetchPositionLogs(ctx context.Context, tenantID string) ([]*positionkeepingv1.FinancialPositionLog, error) {
+	resp, err := s.pkClient.ListFinancialPositionLogs(ctx, &positionkeepingv1.ListFinancialPositionLogsRequest{
+		AccountId: tenantID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list position logs: %w", err)
+	}
+
+	return resp.GetLogs(), nil
+}
+
+// aggregateAndClassify groups position logs by account type and instrument,
+// then classifies them into balance sheet sections.
+func (s *BalanceSheetService) aggregateAndClassify(logs []*positionkeepingv1.FinancialPositionLog) []BalanceSheetSection {
+	type aggregateKey struct {
+		accountType string
+		instrument  string
+	}
+
+	type aggregateValue struct {
+		quantity   decimal.Decimal
+		accountIDs map[string]bool
+	}
+
+	aggregates := make(map[aggregateKey]*aggregateValue)
+
+	for _, log := range logs {
+		accountType := extractAccountType(log.GetAccountId())
+		instrument := extractInstrument(log)
+		qty := computeLogBalance(log)
+
+		key := aggregateKey{accountType: accountType, instrument: instrument}
+		if agg, ok := aggregates[key]; ok {
+			agg.quantity = agg.quantity.Add(qty)
+			agg.accountIDs[log.GetAccountId()] = true
+		} else {
+			aggregates[key] = &aggregateValue{
+				quantity:   qty,
+				accountIDs: map[string]bool{log.GetAccountId(): true},
+			}
+		}
+	}
+
+	// Build sections
+	sectionMap := map[BalanceSheetClassification]*BalanceSheetSection{
+		ClassificationAssets: {
+			Classification: ClassificationAssets,
+			Totals:         make(map[string]decimal.Decimal),
+		},
+		ClassificationLiabilities: {
+			Classification: ClassificationLiabilities,
+			Totals:         make(map[string]decimal.Decimal),
+		},
+		ClassificationEquity: {
+			Classification: ClassificationEquity,
+			Totals:         make(map[string]decimal.Decimal),
+		},
+	}
+
+	for key, agg := range aggregates {
+		normalBal := classifyNormalBalance(key.accountType)
+		classification := classifyAccount(key.accountType, normalBal)
+
+		item := LineItem{
+			AccountType:   key.accountType,
+			Instrument:    key.instrument,
+			Quantity:      agg.quantity,
+			NormalBalance: normalBal,
+			AccountCount:  int32(len(agg.accountIDs)),
+		}
+
+		section := sectionMap[classification]
+		section.LineItems = append(section.LineItems, item)
+
+		existing := section.Totals[key.instrument]
+		section.Totals[key.instrument] = existing.Add(agg.quantity)
+	}
+
+	// Sort line items within each section for deterministic output
+	for _, section := range sectionMap {
+		sort.Slice(section.LineItems, func(i, j int) bool {
+			if section.LineItems[i].AccountType != section.LineItems[j].AccountType {
+				return section.LineItems[i].AccountType < section.LineItems[j].AccountType
+			}
+			return section.LineItems[i].Instrument < section.LineItems[j].Instrument
+		})
+	}
+
+	// Return sections in standard order: ASSETS, LIABILITIES, EQUITY
+	return []BalanceSheetSection{
+		*sectionMap[ClassificationAssets],
+		*sectionMap[ClassificationLiabilities],
+		*sectionMap[ClassificationEquity],
+	}
+}
+
+// extractAccountType derives the account type from an account ID.
+// Account IDs follow the pattern: "tenant_ACCOUNT_TYPE_identifier"
+// e.g., "acme_STRIPE_NOSTRO_001" -> "STRIPE_NOSTRO"
+// The account type is the uppercase alphabetic segment(s) between the tenant
+// prefix and the trailing numeric identifier.
+func extractAccountType(accountID string) string {
+	parts := strings.Split(accountID, "_")
+	if len(parts) < 2 {
+		return accountID
+	}
+
+	// Collect uppercase alphabetic segments between the tenant prefix (index 0)
+	// and any trailing numeric identifiers.
+	var typeParts []string
+	for i := 1; i < len(parts); i++ {
+		p := parts[i]
+		if len(p) == 0 {
+			continue
+		}
+		// A part is a "type" part if it contains at least one letter and is all uppercase
+		if isUpperAlpha(p) {
+			typeParts = append(typeParts, p)
+		} else if len(typeParts) > 0 {
+			// Once we hit a non-alpha-upper part after type parts, stop
+			break
+		}
+	}
+
+	if len(typeParts) > 0 {
+		return strings.Join(typeParts, "_")
+	}
+
+	// Fallback: return everything after the first segment
+	return strings.Join(parts[1:], "_")
+}
+
+// isUpperAlpha returns true if the string contains only uppercase letters.
+func isUpperAlpha(s string) bool {
+	for _, r := range s {
+		if r < 'A' || r > 'Z' {
+			return false
+		}
+	}
+	return len(s) > 0
+}
+
+// extractInstrument determines the instrument code from a position log.
+// It inspects the first transaction entry's amount for the instrument code.
+func extractInstrument(log *positionkeepingv1.FinancialPositionLog) string {
+	entries := log.GetTransactionLogEntries()
+	if len(entries) == 0 {
+		return instrumentUnknown
+	}
+
+	amount := entries[0].GetAmount()
+	if amount == nil || amount.GetAmount() == nil {
+		return instrumentUnknown
+	}
+
+	code := amount.GetAmount().GetCurrencyCode()
+	if code == "" {
+		return instrumentUnknown
+	}
+	return code
+}
+
+// computeLogBalance computes the net balance of a position log by summing
+// all transaction entries, accounting for debit/credit direction.
+func computeLogBalance(log *positionkeepingv1.FinancialPositionLog) decimal.Decimal {
+	balance := decimal.Zero
+
+	for _, entry := range log.GetTransactionLogEntries() {
+		amount := entryAmount(entry)
+		switch entry.GetDirection() {
+		case commonv1.PostingDirection_POSTING_DIRECTION_DEBIT:
+			balance = balance.Add(amount)
+		case commonv1.PostingDirection_POSTING_DIRECTION_CREDIT:
+			balance = balance.Sub(amount)
+		case commonv1.PostingDirection_POSTING_DIRECTION_UNSPECIFIED:
+			// Ignore entries with unspecified direction.
+		}
+	}
+
+	return balance
+}
+
+// entryAmount extracts the decimal amount from a transaction log entry.
+func entryAmount(entry *positionkeepingv1.TransactionLogEntry) decimal.Decimal {
+	if entry.GetAmount() == nil || entry.GetAmount().GetAmount() == nil {
+		return decimal.Zero
+	}
+
+	googleMoney := entry.GetAmount().GetAmount()
+	units := decimal.NewFromInt(googleMoney.GetUnits())
+	nanos := decimal.NewFromInt(int64(googleMoney.GetNanos())).Div(decimal.NewFromInt(1_000_000_000))
+	return units.Add(nanos)
+}
+
+// classifyNormalBalance determines the normal balance direction for an account type.
+// Asset and expense accounts normally carry DEBIT balances.
+// Liability, equity, and revenue accounts normally carry CREDIT balances.
+func classifyNormalBalance(accountType string) NormalBalance {
+	upper := strings.ToUpper(accountType)
+
+	// Credit-normal account types
+	creditTypes := []string{
+		"PAYABLE", "LIABILITY", "REVENUE", "INCOME",
+		"CUSTOMER_DEPOSIT", "DEFERRED", "PROVISION",
+		"RETAINED_EARNINGS", "OWNER_EQUITY", "CAPITAL",
+	}
+	for _, ct := range creditTypes {
+		if strings.Contains(upper, ct) {
+			return NormalBalanceCredit
+		}
+	}
+
+	// Default: debit-normal (assets, expenses, etc.)
+	return NormalBalanceDebit
+}
+
+// classifyAccount determines the balance sheet classification for an account type.
+func classifyAccount(accountType string, normalBalance NormalBalance) BalanceSheetClassification {
+	upper := strings.ToUpper(accountType)
+
+	// Check equity first
+	if equityAccountTypes[upper] {
+		return ClassificationEquity
+	}
+	for keyword := range equityAccountTypes {
+		if strings.Contains(upper, keyword) {
+			return ClassificationEquity
+		}
+	}
+
+	// Classify by normal balance
+	if normalBalance == NormalBalanceDebit {
+		return ClassificationAssets
+	}
+	return ClassificationLiabilities
+}

--- a/services/control-plane/internal/admin/balance_sheet.go
+++ b/services/control-plane/internal/admin/balance_sheet.go
@@ -119,7 +119,8 @@ func (s *BalanceSheetService) GetBalanceSheet(ctx context.Context, tenantID stri
 		"as_of", asOf,
 	)
 
-	if asOf.IsZero() {
+	// A nil proto Timestamp converts to Unix epoch (1970-01-01), not Go's zero time.
+	if asOf.IsZero() || asOf.Unix() == 0 {
 		asOf = time.Now().UTC()
 	}
 
@@ -201,7 +202,7 @@ func (s *BalanceSheetService) ExportBalanceSheetCSV(ctx context.Context, tenantI
 	if err := w.Write([]string{"# Balance Sheet Export"}); err != nil {
 		return "", fmt.Errorf("write metadata: %w", err)
 	}
-	if err := w.Write([]string{"# Tenant", bs.TenantID}); err != nil {
+	if err := w.Write([]string{"# Tenant", sanitizeCSVCell(bs.TenantID)}); err != nil {
 		return "", fmt.Errorf("write tenant: %w", err)
 	}
 	if err := w.Write([]string{"# Generated At", bs.AsOf.Format(time.RFC3339)}); err != nil {
@@ -295,6 +296,18 @@ func (s *BalanceSheetService) fetchPositionLogs(ctx context.Context, tenantID st
 		if pageToken == "" {
 			break
 		}
+	}
+
+	// The API's date_range filter uses date-only granularity, so apply client-side
+	// timestamp filtering for point-in-time accuracy.
+	if !asOf.IsZero() {
+		filtered := allLogs[:0]
+		for _, log := range allLogs {
+			if !log.GetCreatedAt().AsTime().After(asOf) {
+				filtered = append(filtered, log)
+			}
+		}
+		allLogs = filtered
 	}
 
 	return allLogs, nil

--- a/services/control-plane/internal/admin/balance_sheet.go
+++ b/services/control-plane/internal/admin/balance_sheet.go
@@ -125,7 +125,7 @@ func (s *BalanceSheetService) GetBalanceSheet(ctx context.Context, tenantID stri
 
 	// Fetch all position logs for the tenant via position-keeping service.
 	// The tenant_id is used as an account_id prefix filter.
-	logs, err := s.fetchPositionLogs(ctx, tenantID)
+	logs, err := s.fetchPositionLogs(ctx, tenantID, asOf)
 	if err != nil {
 		return nil, fmt.Errorf("fetch position logs: %w", err)
 	}
@@ -148,7 +148,7 @@ func (s *BalanceSheetService) GetPositionDetails(ctx context.Context, tenantID, 
 		"instrument", instrument,
 	)
 
-	logs, err := s.fetchPositionLogs(ctx, tenantID)
+	logs, err := s.fetchPositionLogs(ctx, tenantID, time.Time{})
 	if err != nil {
 		return nil, fmt.Errorf("fetch position logs: %w", err)
 	}
@@ -222,11 +222,11 @@ func (s *BalanceSheetService) ExportBalanceSheetCSV(ctx context.Context, tenantI
 	for _, section := range bs.Sections {
 		for _, item := range section.LineItems {
 			if err := w.Write([]string{
-				string(section.Classification),
-				item.AccountType,
-				item.Instrument,
+				sanitizeCSVCell(string(section.Classification)),
+				sanitizeCSVCell(item.AccountType),
+				sanitizeCSVCell(item.Instrument),
 				item.Quantity.String(),
-				string(item.NormalBalance),
+				sanitizeCSVCell(string(item.NormalBalance)),
 				fmt.Sprintf("%d", item.AccountCount),
 			}); err != nil {
 				return "", fmt.Errorf("write line item: %w", err)
@@ -242,9 +242,9 @@ func (s *BalanceSheetService) ExportBalanceSheetCSV(ctx context.Context, tenantI
 
 		for _, instrument := range instruments {
 			if err := w.Write([]string{
-				string(section.Classification),
+				sanitizeCSVCell(string(section.Classification)),
 				"TOTAL",
-				instrument,
+				sanitizeCSVCell(instrument),
 				section.Totals[instrument].String(),
 				"",
 				"",
@@ -263,14 +263,20 @@ func (s *BalanceSheetService) ExportBalanceSheetCSV(ctx context.Context, tenantI
 }
 
 // fetchPositionLogs retrieves all position logs for a tenant from position-keeping,
-// handling cursor-based pagination to collect all pages.
-func (s *BalanceSheetService) fetchPositionLogs(ctx context.Context, tenantID string) ([]*positionkeepingv1.FinancialPositionLog, error) {
+// handling cursor-based pagination to collect all pages. When asOf is non-zero,
+// a date_range filter is applied so only logs up to that date are returned.
+func (s *BalanceSheetService) fetchPositionLogs(ctx context.Context, tenantID string, asOf time.Time) ([]*positionkeepingv1.FinancialPositionLog, error) {
 	var allLogs []*positionkeepingv1.FinancialPositionLog
 	var pageToken string
 
 	for {
 		req := &positionkeepingv1.ListFinancialPositionLogsRequest{
 			AccountId: tenantID,
+		}
+		if !asOf.IsZero() {
+			req.DateRange = &commonv1.DateRange{
+				EndDate: asOf.Format("2006-01-02"),
+			}
 		}
 		if pageToken != "" {
 			req.Pagination = &commonv1.Pagination{
@@ -497,6 +503,20 @@ func classifyNormalBalance(accountType string) NormalBalance {
 
 	// Default: debit-normal (assets, expenses, etc.)
 	return NormalBalanceDebit
+}
+
+// sanitizeCSVCell prevents CSV injection by escaping cells that begin with
+// formula-triggering characters (=, +, -, @).
+func sanitizeCSVCell(v string) string {
+	if len(v) == 0 {
+		return v
+	}
+	switch v[0] {
+	case '=', '+', '-', '@':
+		return "'" + v
+	default:
+		return v
+	}
 }
 
 // classifyAccount determines the balance sheet classification for an account type.

--- a/services/control-plane/internal/admin/balance_sheet_handler.go
+++ b/services/control-plane/internal/admin/balance_sheet_handler.go
@@ -69,7 +69,9 @@ func (h *BalanceSheetHandler) GetPositionDetails(
 		return nil, status.Errorf(codes.InvalidArgument, "instrument is required")
 	}
 
-	result, err := h.service.GetPositionDetails(ctx, tenantID, req.GetAccountType(), req.GetInstrument())
+	asOf := req.GetAsOf().AsTime()
+
+	result, err := h.service.GetPositionDetails(ctx, tenantID, req.GetAccountType(), req.GetInstrument(), asOf)
 	if err != nil {
 		h.logger.Error("failed to get position details",
 			"tenant_id", tenantID,

--- a/services/control-plane/internal/admin/balance_sheet_handler.go
+++ b/services/control-plane/internal/admin/balance_sheet_handler.go
@@ -1,0 +1,193 @@
+package admin
+
+import (
+	"context"
+	"log/slog"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+)
+
+// BalanceSheetHandler implements the BalanceSheetService gRPC service.
+type BalanceSheetHandler struct {
+	controlplanev1.UnimplementedBalanceSheetServiceServer
+	service *BalanceSheetService
+	logger  *slog.Logger
+}
+
+// NewBalanceSheetHandler creates a new BalanceSheetService handler.
+func NewBalanceSheetHandler(service *BalanceSheetService, logger *slog.Logger) *BalanceSheetHandler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &BalanceSheetHandler{
+		service: service,
+		logger:  logger,
+	}
+}
+
+// GetBalanceSheet returns a multi-asset balance sheet for a tenant.
+func (h *BalanceSheetHandler) GetBalanceSheet(
+	ctx context.Context,
+	req *controlplanev1.GetBalanceSheetRequest,
+) (*controlplanev1.GetBalanceSheetResponse, error) {
+	tenantID := req.GetTenantId()
+	if tenantID == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+
+	asOf := req.GetAsOf().AsTime()
+
+	bs, err := h.service.GetBalanceSheet(ctx, tenantID, asOf)
+	if err != nil {
+		h.logger.Error("failed to generate balance sheet",
+			"tenant_id", tenantID,
+			"error", err,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to generate balance sheet: %v", err)
+	}
+
+	return h.balanceSheetToProto(bs), nil
+}
+
+// GetPositionDetails returns drill-down details for a specific account type and instrument.
+func (h *BalanceSheetHandler) GetPositionDetails(
+	ctx context.Context,
+	req *controlplanev1.GetPositionDetailsRequest,
+) (*controlplanev1.GetPositionDetailsResponse, error) {
+	tenantID := req.GetTenantId()
+	if tenantID == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+	if req.GetAccountType() == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "account_type is required")
+	}
+	if req.GetInstrument() == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "instrument is required")
+	}
+
+	result, err := h.service.GetPositionDetails(ctx, tenantID, req.GetAccountType(), req.GetInstrument())
+	if err != nil {
+		h.logger.Error("failed to get position details",
+			"tenant_id", tenantID,
+			"account_type", req.GetAccountType(),
+			"instrument", req.GetInstrument(),
+			"error", err,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to get position details: %v", err)
+	}
+
+	return h.positionDetailsToProto(result), nil
+}
+
+// ExportBalanceSheetCSV exports the balance sheet as CSV.
+func (h *BalanceSheetHandler) ExportBalanceSheetCSV(
+	ctx context.Context,
+	req *controlplanev1.ExportBalanceSheetCSVRequest,
+) (*controlplanev1.ExportBalanceSheetCSVResponse, error) {
+	tenantID := req.GetTenantId()
+	if tenantID == "" {
+		return nil, status.Errorf(codes.InvalidArgument, "tenant_id is required")
+	}
+
+	asOf := req.GetAsOf().AsTime()
+
+	csvContent, err := h.service.ExportBalanceSheetCSV(ctx, tenantID, asOf)
+	if err != nil {
+		h.logger.Error("failed to export balance sheet CSV",
+			"tenant_id", tenantID,
+			"error", err,
+		)
+		return nil, status.Errorf(codes.Internal, "failed to export balance sheet CSV: %v", err)
+	}
+
+	return &controlplanev1.ExportBalanceSheetCSVResponse{
+		CsvContent:  csvContent,
+		GeneratedAt: timestamppb.Now(),
+		TenantId:    tenantID,
+	}, nil
+}
+
+// balanceSheetToProto converts a domain BalanceSheet to proto.
+func (h *BalanceSheetHandler) balanceSheetToProto(bs *BalanceSheet) *controlplanev1.GetBalanceSheetResponse {
+	resp := &controlplanev1.GetBalanceSheetResponse{
+		TenantId: bs.TenantID,
+		AsOf:     timestamppb.New(bs.AsOf),
+		Sections: make([]*controlplanev1.BalanceSheetSection, 0, len(bs.Sections)),
+	}
+
+	for _, section := range bs.Sections {
+		protoSection := &controlplanev1.BalanceSheetSection{
+			Classification: classificationToProto(section.Classification),
+			LineItems:      make([]*controlplanev1.BalanceSheetLineItem, 0, len(section.LineItems)),
+			Totals:         make(map[string]string, len(section.Totals)),
+		}
+
+		for _, item := range section.LineItems {
+			protoSection.LineItems = append(protoSection.LineItems, &controlplanev1.BalanceSheetLineItem{
+				AccountType:   item.AccountType,
+				Instrument:    item.Instrument,
+				Quantity:      item.Quantity.String(),
+				NormalBalance: normalBalanceToProto(item.NormalBalance),
+				AccountCount:  item.AccountCount,
+			})
+		}
+
+		for instrument, total := range section.Totals {
+			protoSection.Totals[instrument] = total.String()
+		}
+
+		resp.Sections = append(resp.Sections, protoSection)
+	}
+
+	return resp
+}
+
+// positionDetailsToProto converts a PositionDetailsResult to proto.
+func (h *BalanceSheetHandler) positionDetailsToProto(result *PositionDetailsResult) *controlplanev1.GetPositionDetailsResponse {
+	resp := &controlplanev1.GetPositionDetailsResponse{
+		TenantId:    result.TenantID,
+		AccountType: result.AccountType,
+		Instrument:  result.Instrument,
+		Total:       result.Total.String(),
+		Positions:   make([]*controlplanev1.PositionDetail, 0, len(result.Positions)),
+	}
+
+	for _, pos := range result.Positions {
+		resp.Positions = append(resp.Positions, &controlplanev1.PositionDetail{
+			AccountId:   pos.AccountID,
+			Quantity:    pos.Quantity.String(),
+			LogId:       pos.LogID,
+			LastUpdated: timestamppb.New(pos.LastUpdated),
+		})
+	}
+
+	return resp
+}
+
+func classificationToProto(c BalanceSheetClassification) controlplanev1.BalanceSheetClassification {
+	switch c {
+	case ClassificationAssets:
+		return controlplanev1.BalanceSheetClassification_BALANCE_SHEET_CLASSIFICATION_ASSETS
+	case ClassificationLiabilities:
+		return controlplanev1.BalanceSheetClassification_BALANCE_SHEET_CLASSIFICATION_LIABILITIES
+	case ClassificationEquity:
+		return controlplanev1.BalanceSheetClassification_BALANCE_SHEET_CLASSIFICATION_EQUITY
+	default:
+		return controlplanev1.BalanceSheetClassification_BALANCE_SHEET_CLASSIFICATION_UNSPECIFIED
+	}
+}
+
+func normalBalanceToProto(nb NormalBalance) controlplanev1.NormalBalanceDirection {
+	switch nb {
+	case NormalBalanceDebit:
+		return controlplanev1.NormalBalanceDirection_NORMAL_BALANCE_DIRECTION_DEBIT
+	case NormalBalanceCredit:
+		return controlplanev1.NormalBalanceDirection_NORMAL_BALANCE_DIRECTION_CREDIT
+	default:
+		return controlplanev1.NormalBalanceDirection_NORMAL_BALANCE_DIRECTION_UNSPECIFIED
+	}
+}

--- a/services/control-plane/internal/admin/balance_sheet_handler_test.go
+++ b/services/control-plane/internal/admin/balance_sheet_handler_test.go
@@ -1,0 +1,238 @@
+package admin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+)
+
+func TestBalanceSheetHandler_GetBalanceSheet_InvalidRequest(t *testing.T) {
+	svc := NewBalanceSheetService(&mockPKClient{}, nil)
+	handler := NewBalanceSheetHandler(svc, nil)
+
+	req := &controlplanev1.GetBalanceSheetRequest{
+		TenantId: "",
+	}
+
+	_, err := handler.GetBalanceSheet(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "tenant_id is required")
+}
+
+func TestBalanceSheetHandler_GetBalanceSheet_Success(t *testing.T) {
+	logs := []*positionkeepingv1.FinancialPositionLog{
+		makeLog("acme_CASH_001", "log-1", "GBP",
+			txnEntry{units: 5000, nanos: 0, direction: "DEBIT"},
+		),
+		makeLog("acme_ACCOUNTS_PAYABLE_001", "log-2", "GBP",
+			txnEntry{units: 2000, nanos: 0, direction: "DEBIT"},
+		),
+		makeLog("acme_RETAINED_EARNINGS_001", "log-3", "GBP",
+			txnEntry{units: 3000, nanos: 0, direction: "DEBIT"},
+		),
+	}
+
+	client := &mockPKClient{logs: logs}
+	svc := NewBalanceSheetService(client, nil)
+	handler := NewBalanceSheetHandler(svc, nil)
+
+	req := &controlplanev1.GetBalanceSheetRequest{
+		TenantId: "acme",
+	}
+
+	resp, err := handler.GetBalanceSheet(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, "acme", resp.TenantId)
+	require.Len(t, resp.Sections, 3)
+
+	// ASSETS
+	assert.Equal(t, controlplanev1.BalanceSheetClassification_BALANCE_SHEET_CLASSIFICATION_ASSETS, resp.Sections[0].Classification)
+	require.Len(t, resp.Sections[0].LineItems, 1)
+	assert.Equal(t, "CASH", resp.Sections[0].LineItems[0].AccountType)
+	assert.Equal(t, "GBP", resp.Sections[0].LineItems[0].Instrument)
+	assert.Equal(t, "5000", resp.Sections[0].LineItems[0].Quantity)
+	assert.Equal(t, controlplanev1.NormalBalanceDirection_NORMAL_BALANCE_DIRECTION_DEBIT, resp.Sections[0].LineItems[0].NormalBalance)
+
+	// LIABILITIES
+	assert.Equal(t, controlplanev1.BalanceSheetClassification_BALANCE_SHEET_CLASSIFICATION_LIABILITIES, resp.Sections[1].Classification)
+	require.Len(t, resp.Sections[1].LineItems, 1)
+	assert.Equal(t, "ACCOUNTS_PAYABLE", resp.Sections[1].LineItems[0].AccountType)
+
+	// EQUITY
+	assert.Equal(t, controlplanev1.BalanceSheetClassification_BALANCE_SHEET_CLASSIFICATION_EQUITY, resp.Sections[2].Classification)
+	require.Len(t, resp.Sections[2].LineItems, 1)
+	assert.Equal(t, "RETAINED_EARNINGS", resp.Sections[2].LineItems[0].AccountType)
+}
+
+func TestBalanceSheetHandler_GetPositionDetails_InvalidRequest(t *testing.T) {
+	svc := NewBalanceSheetService(&mockPKClient{}, nil)
+	handler := NewBalanceSheetHandler(svc, nil)
+
+	tests := []struct {
+		name   string
+		req    *controlplanev1.GetPositionDetailsRequest
+		errMsg string
+	}{
+		{
+			name: "empty tenant_id",
+			req: &controlplanev1.GetPositionDetailsRequest{
+				TenantId:    "",
+				AccountType: "CASH",
+				Instrument:  "GBP",
+			},
+			errMsg: "tenant_id is required",
+		},
+		{
+			name: "empty account_type",
+			req: &controlplanev1.GetPositionDetailsRequest{
+				TenantId:    "acme",
+				AccountType: "",
+				Instrument:  "GBP",
+			},
+			errMsg: "account_type is required",
+		},
+		{
+			name: "empty instrument",
+			req: &controlplanev1.GetPositionDetailsRequest{
+				TenantId:    "acme",
+				AccountType: "CASH",
+				Instrument:  "",
+			},
+			errMsg: "instrument is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := handler.GetPositionDetails(context.Background(), tt.req)
+			require.Error(t, err)
+
+			st, ok := status.FromError(err)
+			require.True(t, ok)
+			assert.Equal(t, codes.InvalidArgument, st.Code())
+			assert.Contains(t, st.Message(), tt.errMsg)
+		})
+	}
+}
+
+func TestBalanceSheetHandler_GetPositionDetails_Success(t *testing.T) {
+	logs := []*positionkeepingv1.FinancialPositionLog{
+		makeLog("tenant_CASH_001", "log-1", "GBP",
+			txnEntry{units: 5000, nanos: 0, direction: "DEBIT"},
+		),
+		makeLog("tenant_CASH_002", "log-2", "GBP",
+			txnEntry{units: 3000, nanos: 0, direction: "DEBIT"},
+		),
+	}
+
+	client := &mockPKClient{logs: logs}
+	svc := NewBalanceSheetService(client, nil)
+	handler := NewBalanceSheetHandler(svc, nil)
+
+	req := &controlplanev1.GetPositionDetailsRequest{
+		TenantId:    "tenant",
+		AccountType: "CASH",
+		Instrument:  "GBP",
+	}
+
+	resp, err := handler.GetPositionDetails(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, "CASH", resp.AccountType)
+	assert.Equal(t, "GBP", resp.Instrument)
+	assert.Len(t, resp.Positions, 2)
+	assert.Equal(t, "8000", resp.Total)
+}
+
+func TestBalanceSheetHandler_ExportBalanceSheetCSV_InvalidRequest(t *testing.T) {
+	svc := NewBalanceSheetService(&mockPKClient{}, nil)
+	handler := NewBalanceSheetHandler(svc, nil)
+
+	req := &controlplanev1.ExportBalanceSheetCSVRequest{
+		TenantId: "",
+	}
+
+	_, err := handler.ExportBalanceSheetCSV(context.Background(), req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestBalanceSheetHandler_ExportBalanceSheetCSV_Success(t *testing.T) {
+	logs := []*positionkeepingv1.FinancialPositionLog{
+		makeLog("acme_CASH_001", "log-1", "GBP",
+			txnEntry{units: 5000, nanos: 0, direction: "DEBIT"},
+		),
+	}
+
+	client := &mockPKClient{logs: logs}
+	svc := NewBalanceSheetService(client, nil)
+	handler := NewBalanceSheetHandler(svc, nil)
+
+	req := &controlplanev1.ExportBalanceSheetCSVRequest{
+		TenantId: "acme",
+	}
+
+	resp, err := handler.ExportBalanceSheetCSV(context.Background(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.NotEmpty(t, resp.CsvContent)
+	assert.Contains(t, resp.CsvContent, "CASH")
+	assert.Contains(t, resp.CsvContent, "GBP")
+	assert.Equal(t, "acme", resp.TenantId)
+	assert.NotNil(t, resp.GeneratedAt)
+}
+
+func TestClassificationToProto(t *testing.T) {
+	tests := []struct {
+		input    BalanceSheetClassification
+		expected controlplanev1.BalanceSheetClassification
+	}{
+		{ClassificationAssets, controlplanev1.BalanceSheetClassification_BALANCE_SHEET_CLASSIFICATION_ASSETS},
+		{ClassificationLiabilities, controlplanev1.BalanceSheetClassification_BALANCE_SHEET_CLASSIFICATION_LIABILITIES},
+		{ClassificationEquity, controlplanev1.BalanceSheetClassification_BALANCE_SHEET_CLASSIFICATION_EQUITY},
+		{"UNKNOWN", controlplanev1.BalanceSheetClassification_BALANCE_SHEET_CLASSIFICATION_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			result := classificationToProto(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNormalBalanceToProto(t *testing.T) {
+	tests := []struct {
+		input    NormalBalance
+		expected controlplanev1.NormalBalanceDirection
+	}{
+		{NormalBalanceDebit, controlplanev1.NormalBalanceDirection_NORMAL_BALANCE_DIRECTION_DEBIT},
+		{NormalBalanceCredit, controlplanev1.NormalBalanceDirection_NORMAL_BALANCE_DIRECTION_CREDIT},
+		{"UNKNOWN", controlplanev1.NormalBalanceDirection_NORMAL_BALANCE_DIRECTION_UNSPECIFIED},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			result := normalBalanceToProto(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/services/control-plane/internal/admin/balance_sheet_test.go
+++ b/services/control-plane/internal/admin/balance_sheet_test.go
@@ -1,0 +1,405 @@
+package admin
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/money"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	commonv1 "github.com/meridianhub/meridian/api/proto/meridian/common/v1"
+	positionkeepingv1 "github.com/meridianhub/meridian/api/proto/meridian/position_keeping/v1"
+)
+
+// mockPKClient is a test double for PositionKeepingClient.
+type mockPKClient struct {
+	logs []*positionkeepingv1.FinancialPositionLog
+	err  error
+}
+
+func (m *mockPKClient) ListFinancialPositionLogs(_ context.Context, _ *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &positionkeepingv1.ListFinancialPositionLogsResponse{
+		Logs: m.logs,
+	}, nil
+}
+
+func (m *mockPKClient) GetAccountBalance(_ context.Context, _ *positionkeepingv1.GetAccountBalanceRequest) (*positionkeepingv1.GetAccountBalanceResponse, error) {
+	return nil, nil
+}
+
+// makeLog creates a test FinancialPositionLog with transaction entries.
+func makeLog(accountID, logID, currencyCode string, entries ...txnEntry) *positionkeepingv1.FinancialPositionLog {
+	protoEntries := make([]*positionkeepingv1.TransactionLogEntry, 0, len(entries))
+	for _, e := range entries {
+		dir := commonv1.PostingDirection_POSTING_DIRECTION_DEBIT
+		if e.direction == "CREDIT" {
+			dir = commonv1.PostingDirection_POSTING_DIRECTION_CREDIT
+		}
+		protoEntries = append(protoEntries, &positionkeepingv1.TransactionLogEntry{
+			EntryId:       "entry-" + accountID,
+			TransactionId: "txn-" + accountID,
+			AccountId:     accountID,
+			Amount: &commonv1.MoneyAmount{
+				Amount: &money.Money{
+					CurrencyCode: currencyCode,
+					Units:        e.units,
+					Nanos:        e.nanos,
+				},
+			},
+			Direction:   dir,
+			Timestamp:   timestamppb.Now(),
+			Description: "test entry",
+		})
+	}
+
+	return &positionkeepingv1.FinancialPositionLog{
+		LogId:                 logID,
+		AccountId:             accountID,
+		TransactionLogEntries: protoEntries,
+		StatusTracking: &positionkeepingv1.StatusTracking{
+			CurrentStatus:   commonv1.TransactionStatus_TRANSACTION_STATUS_PENDING,
+			StatusUpdatedAt: timestamppb.Now(),
+		},
+		CreatedAt: timestamppb.Now(),
+		UpdatedAt: timestamppb.Now(),
+		Version:   1,
+	}
+}
+
+type txnEntry struct {
+	units     int64
+	nanos     int32
+	direction string
+}
+
+func TestGetBalanceSheet_MultiAssetAggregation(t *testing.T) {
+	// Two GBP accounts (assets) + one KWH account (asset)
+	logs := []*positionkeepingv1.FinancialPositionLog{
+		makeLog("acme_STRIPE_NOSTRO_001", "log-1", "GBP",
+			txnEntry{units: 10000, nanos: 0, direction: "DEBIT"},
+		),
+		makeLog("acme_STRIPE_NOSTRO_002", "log-2", "GBP",
+			txnEntry{units: 2450, nanos: 0, direction: "DEBIT"},
+		),
+		makeLog("acme_ENERGY_INVENTORY_001", "log-3", "KWH",
+			txnEntry{units: 45000, nanos: 0, direction: "DEBIT"},
+		),
+	}
+
+	client := &mockPKClient{logs: logs}
+	svc := NewBalanceSheetService(client, nil)
+
+	bs, err := svc.GetBalanceSheet(context.Background(), "acme", time.Now().UTC())
+	require.NoError(t, err)
+	require.NotNil(t, bs)
+	assert.Equal(t, "acme", bs.TenantID)
+	require.Len(t, bs.Sections, 3)
+
+	// ASSETS section
+	assets := bs.Sections[0]
+	assert.Equal(t, ClassificationAssets, assets.Classification)
+	assert.Len(t, assets.LineItems, 2) // STRIPE_NOSTRO + ENERGY_INVENTORY
+
+	// Find STRIPE_NOSTRO line item
+	var nostroItem *LineItem
+	var energyItem *LineItem
+	for i := range assets.LineItems {
+		if assets.LineItems[i].AccountType == "STRIPE_NOSTRO" {
+			nostroItem = &assets.LineItems[i]
+		}
+		if assets.LineItems[i].AccountType == "ENERGY_INVENTORY" {
+			energyItem = &assets.LineItems[i]
+		}
+	}
+
+	require.NotNil(t, nostroItem)
+	assert.Equal(t, "GBP", nostroItem.Instrument)
+	assert.True(t, nostroItem.Quantity.Equal(decimal.NewFromInt(12450)))
+	assert.Equal(t, NormalBalanceDebit, nostroItem.NormalBalance)
+	assert.Equal(t, int32(2), nostroItem.AccountCount)
+
+	require.NotNil(t, energyItem)
+	assert.Equal(t, "KWH", energyItem.Instrument)
+	assert.True(t, energyItem.Quantity.Equal(decimal.NewFromInt(45000)))
+
+	// Check totals
+	assert.True(t, assets.Totals["GBP"].Equal(decimal.NewFromInt(12450)))
+	assert.True(t, assets.Totals["KWH"].Equal(decimal.NewFromInt(45000)))
+}
+
+func TestGetBalanceSheet_ClassificationLogic(t *testing.T) {
+	logs := []*positionkeepingv1.FinancialPositionLog{
+		// Asset account (DEBIT normal balance)
+		makeLog("tenant_CASH_001", "log-1", "GBP",
+			txnEntry{units: 5000, nanos: 0, direction: "DEBIT"},
+		),
+		// Liability account (CREDIT normal balance)
+		makeLog("tenant_ACCOUNTS_PAYABLE_001", "log-2", "GBP",
+			txnEntry{units: 2000, nanos: 0, direction: "DEBIT"},
+		),
+		// Equity account
+		makeLog("tenant_RETAINED_EARNINGS_001", "log-3", "GBP",
+			txnEntry{units: 3000, nanos: 0, direction: "DEBIT"},
+		),
+	}
+
+	client := &mockPKClient{logs: logs}
+	svc := NewBalanceSheetService(client, nil)
+
+	bs, err := svc.GetBalanceSheet(context.Background(), "tenant", time.Now().UTC())
+	require.NoError(t, err)
+
+	// ASSETS
+	assets := bs.Sections[0]
+	assert.Equal(t, ClassificationAssets, assets.Classification)
+	assert.Len(t, assets.LineItems, 1)
+	assert.Equal(t, "CASH", assets.LineItems[0].AccountType)
+
+	// LIABILITIES
+	liabilities := bs.Sections[1]
+	assert.Equal(t, ClassificationLiabilities, liabilities.Classification)
+	assert.Len(t, liabilities.LineItems, 1)
+	assert.Equal(t, "ACCOUNTS_PAYABLE", liabilities.LineItems[0].AccountType)
+
+	// EQUITY
+	equity := bs.Sections[2]
+	assert.Equal(t, ClassificationEquity, equity.Classification)
+	assert.Len(t, equity.LineItems, 1)
+	assert.Equal(t, "RETAINED_EARNINGS", equity.LineItems[0].AccountType)
+}
+
+func TestGetBalanceSheet_EmptyLogs(t *testing.T) {
+	client := &mockPKClient{logs: nil}
+	svc := NewBalanceSheetService(client, nil)
+
+	bs, err := svc.GetBalanceSheet(context.Background(), "empty_tenant", time.Now().UTC())
+	require.NoError(t, err)
+	require.NotNil(t, bs)
+	assert.Equal(t, "empty_tenant", bs.TenantID)
+	assert.Len(t, bs.Sections, 3)
+
+	// All sections should be empty
+	for _, section := range bs.Sections {
+		assert.Empty(t, section.LineItems)
+		assert.Empty(t, section.Totals)
+	}
+}
+
+func TestGetBalanceSheet_DebitCreditNetting(t *testing.T) {
+	// Account with both debit and credit entries
+	logs := []*positionkeepingv1.FinancialPositionLog{
+		makeLog("tenant_CASH_001", "log-1", "GBP",
+			txnEntry{units: 10000, nanos: 0, direction: "DEBIT"},
+			txnEntry{units: 3000, nanos: 0, direction: "CREDIT"},
+		),
+	}
+
+	client := &mockPKClient{logs: logs}
+	svc := NewBalanceSheetService(client, nil)
+
+	bs, err := svc.GetBalanceSheet(context.Background(), "tenant", time.Now().UTC())
+	require.NoError(t, err)
+
+	assets := bs.Sections[0]
+	require.Len(t, assets.LineItems, 1)
+	// 10000 - 3000 = 7000
+	assert.True(t, assets.LineItems[0].Quantity.Equal(decimal.NewFromInt(7000)))
+}
+
+func TestGetBalanceSheet_NanosHandling(t *testing.T) {
+	logs := []*positionkeepingv1.FinancialPositionLog{
+		makeLog("tenant_CASH_001", "log-1", "GBP",
+			txnEntry{units: 100, nanos: 500000000, direction: "DEBIT"}, // 100.50
+		),
+	}
+
+	client := &mockPKClient{logs: logs}
+	svc := NewBalanceSheetService(client, nil)
+
+	bs, err := svc.GetBalanceSheet(context.Background(), "tenant", time.Now().UTC())
+	require.NoError(t, err)
+
+	assets := bs.Sections[0]
+	require.Len(t, assets.LineItems, 1)
+	expected, _ := decimal.NewFromString("100.5")
+	assert.True(t, assets.LineItems[0].Quantity.Equal(expected))
+}
+
+func TestGetPositionDetails_FiltersByAccountTypeAndInstrument(t *testing.T) {
+	logs := []*positionkeepingv1.FinancialPositionLog{
+		makeLog("tenant_CASH_001", "log-1", "GBP",
+			txnEntry{units: 5000, nanos: 0, direction: "DEBIT"},
+		),
+		makeLog("tenant_CASH_002", "log-2", "GBP",
+			txnEntry{units: 3000, nanos: 0, direction: "DEBIT"},
+		),
+		makeLog("tenant_ENERGY_INVENTORY_001", "log-3", "KWH",
+			txnEntry{units: 1000, nanos: 0, direction: "DEBIT"},
+		),
+	}
+
+	client := &mockPKClient{logs: logs}
+	svc := NewBalanceSheetService(client, nil)
+
+	result, err := svc.GetPositionDetails(context.Background(), "tenant", "CASH", "GBP")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, "CASH", result.AccountType)
+	assert.Equal(t, "GBP", result.Instrument)
+	assert.Len(t, result.Positions, 2)
+	assert.True(t, result.Total.Equal(decimal.NewFromInt(8000)))
+}
+
+func TestGetPositionDetails_NoMatches(t *testing.T) {
+	logs := []*positionkeepingv1.FinancialPositionLog{
+		makeLog("tenant_CASH_001", "log-1", "GBP",
+			txnEntry{units: 5000, nanos: 0, direction: "DEBIT"},
+		),
+	}
+
+	client := &mockPKClient{logs: logs}
+	svc := NewBalanceSheetService(client, nil)
+
+	result, err := svc.GetPositionDetails(context.Background(), "tenant", "NONEXISTENT", "GBP")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Positions)
+	assert.True(t, result.Total.IsZero())
+}
+
+func TestExportBalanceSheetCSV_ContainsData(t *testing.T) {
+	logs := []*positionkeepingv1.FinancialPositionLog{
+		makeLog("acme_CASH_001", "log-1", "GBP",
+			txnEntry{units: 5000, nanos: 0, direction: "DEBIT"},
+		),
+		makeLog("acme_ACCOUNTS_PAYABLE_001", "log-2", "GBP",
+			txnEntry{units: 2000, nanos: 0, direction: "DEBIT"},
+		),
+	}
+
+	client := &mockPKClient{logs: logs}
+	svc := NewBalanceSheetService(client, nil)
+
+	csv, err := svc.ExportBalanceSheetCSV(context.Background(), "acme", time.Now().UTC())
+	require.NoError(t, err)
+	assert.Contains(t, csv, "Balance Sheet Export")
+	assert.Contains(t, csv, "acme")
+	assert.Contains(t, csv, "classification")
+	assert.Contains(t, csv, "ASSETS")
+	assert.Contains(t, csv, "LIABILITIES")
+	assert.Contains(t, csv, "CASH")
+	assert.Contains(t, csv, "ACCOUNTS_PAYABLE")
+	assert.Contains(t, csv, "GBP")
+}
+
+func TestExtractAccountType(t *testing.T) {
+	tests := []struct {
+		accountID string
+		expected  string
+	}{
+		{"acme_STRIPE_NOSTRO_001", "STRIPE_NOSTRO"},
+		{"acme_CASH_001", "CASH"},
+		{"acme_ACCOUNTS_PAYABLE_001", "ACCOUNTS_PAYABLE"},
+		{"acme_RETAINED_EARNINGS_001", "RETAINED_EARNINGS"},
+		{"acme_ENERGY_INVENTORY_001", "ENERGY_INVENTORY"},
+		{"simple", "simple"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.accountID, func(t *testing.T) {
+			result := extractAccountType(tt.accountID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClassifyNormalBalance(t *testing.T) {
+	tests := []struct {
+		accountType string
+		expected    NormalBalance
+	}{
+		{"CASH", NormalBalanceDebit},
+		{"STRIPE_NOSTRO", NormalBalanceDebit},
+		{"ENERGY_INVENTORY", NormalBalanceDebit},
+		{"ACCOUNTS_PAYABLE", NormalBalanceCredit},
+		{"CUSTOMER_DEPOSIT", NormalBalanceCredit},
+		{"DEFERRED_REVENUE", NormalBalanceCredit},
+		{"RETAINED_EARNINGS", NormalBalanceCredit},
+		{"OWNER_EQUITY", NormalBalanceCredit},
+		{"CAPITAL", NormalBalanceCredit},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.accountType, func(t *testing.T) {
+			result := classifyNormalBalance(tt.accountType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestClassifyAccount(t *testing.T) {
+	tests := []struct {
+		accountType   string
+		normalBalance NormalBalance
+		expected      BalanceSheetClassification
+	}{
+		{"CASH", NormalBalanceDebit, ClassificationAssets},
+		{"STRIPE_NOSTRO", NormalBalanceDebit, ClassificationAssets},
+		{"ACCOUNTS_PAYABLE", NormalBalanceCredit, ClassificationLiabilities},
+		{"CUSTOMER_DEPOSIT", NormalBalanceCredit, ClassificationLiabilities},
+		{"RETAINED_EARNINGS", NormalBalanceCredit, ClassificationEquity},
+		{"OWNER_EQUITY", NormalBalanceCredit, ClassificationEquity},
+		{"CAPITAL", NormalBalanceCredit, ClassificationEquity},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.accountType, func(t *testing.T) {
+			result := classifyAccount(tt.accountType, tt.normalBalance)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestComputeLogBalance_DebitOnly(t *testing.T) {
+	log := makeLog("test_CASH_001", "log-1", "GBP",
+		txnEntry{units: 100, nanos: 0, direction: "DEBIT"},
+		txnEntry{units: 200, nanos: 0, direction: "DEBIT"},
+	)
+	result := computeLogBalance(log)
+	assert.True(t, result.Equal(decimal.NewFromInt(300)))
+}
+
+func TestComputeLogBalance_Mixed(t *testing.T) {
+	log := makeLog("test_CASH_001", "log-1", "GBP",
+		txnEntry{units: 1000, nanos: 0, direction: "DEBIT"},
+		txnEntry{units: 300, nanos: 0, direction: "CREDIT"},
+		txnEntry{units: 200, nanos: 500000000, direction: "DEBIT"}, // 200.50
+	)
+	result := computeLogBalance(log)
+	expected, _ := decimal.NewFromString("900.5")
+	assert.True(t, result.Equal(expected))
+}
+
+func TestComputeLogBalance_EmptyLog(t *testing.T) {
+	log := makeLog("test_CASH_001", "log-1", "GBP")
+	result := computeLogBalance(log)
+	assert.True(t, result.IsZero())
+}
+
+func TestExtractInstrument(t *testing.T) {
+	log := makeLog("test_CASH_001", "log-1", "GBP",
+		txnEntry{units: 100, nanos: 0, direction: "DEBIT"},
+	)
+	assert.Equal(t, "GBP", extractInstrument(log))
+
+	emptyLog := makeLog("test_CASH_001", "log-2", "GBP")
+	assert.Equal(t, "UNKNOWN", extractInstrument(emptyLog))
+}

--- a/services/control-plane/internal/admin/balance_sheet_test.go
+++ b/services/control-plane/internal/admin/balance_sheet_test.go
@@ -403,3 +403,62 @@ func TestExtractInstrument(t *testing.T) {
 	emptyLog := makeLog("test_CASH_001", "log-2", "GBP")
 	assert.Equal(t, "UNKNOWN", extractInstrument(emptyLog))
 }
+
+// paginatedMockPKClient returns logs across multiple pages to test pagination.
+type paginatedMockPKClient struct {
+	// pages maps page token -> (logs, nextPageToken). Empty string key is the first page.
+	pages map[string]struct {
+		logs      []*positionkeepingv1.FinancialPositionLog
+		nextToken string
+	}
+}
+
+func (m *paginatedMockPKClient) ListFinancialPositionLogs(_ context.Context, req *positionkeepingv1.ListFinancialPositionLogsRequest) (*positionkeepingv1.ListFinancialPositionLogsResponse, error) {
+	pageToken := req.GetPagination().GetPageToken()
+	page := m.pages[pageToken]
+	return &positionkeepingv1.ListFinancialPositionLogsResponse{
+		Logs: page.logs,
+		Pagination: &commonv1.PaginationResponse{
+			NextPageToken: page.nextToken,
+		},
+	}, nil
+}
+
+func (m *paginatedMockPKClient) GetAccountBalance(_ context.Context, _ *positionkeepingv1.GetAccountBalanceRequest) (*positionkeepingv1.GetAccountBalanceResponse, error) {
+	return nil, nil
+}
+
+func TestGetBalanceSheet_Pagination(t *testing.T) {
+	page1Logs := []*positionkeepingv1.FinancialPositionLog{
+		makeLog("acme_CASH_001", "log-1", "GBP",
+			txnEntry{units: 1000, nanos: 0, direction: "DEBIT"},
+		),
+	}
+	page2Logs := []*positionkeepingv1.FinancialPositionLog{
+		makeLog("acme_CASH_002", "log-2", "GBP",
+			txnEntry{units: 2000, nanos: 0, direction: "DEBIT"},
+		),
+	}
+
+	client := &paginatedMockPKClient{
+		pages: map[string]struct {
+			logs      []*positionkeepingv1.FinancialPositionLog
+			nextToken string
+		}{
+			"":      {logs: page1Logs, nextToken: "page2"},
+			"page2": {logs: page2Logs, nextToken: ""},
+		},
+	}
+
+	svc := NewBalanceSheetService(client, nil)
+	bs, err := svc.GetBalanceSheet(context.Background(), "acme", time.Now())
+	require.NoError(t, err)
+
+	// Should have aggregated logs from both pages
+	assetsSection := bs.Sections[0]
+	require.Len(t, assetsSection.LineItems, 1)
+	assert.Equal(t, "CASH", assetsSection.LineItems[0].AccountType)
+	assert.True(t, assetsSection.LineItems[0].Quantity.Equal(decimal.NewFromInt(3000)),
+		"expected 3000 (1000+2000 from two pages), got %s", assetsSection.LineItems[0].Quantity)
+	assert.Equal(t, int32(2), assetsSection.LineItems[0].AccountCount)
+}

--- a/services/control-plane/internal/admin/balance_sheet_test.go
+++ b/services/control-plane/internal/admin/balance_sheet_test.go
@@ -248,7 +248,7 @@ func TestGetPositionDetails_FiltersByAccountTypeAndInstrument(t *testing.T) {
 	client := &mockPKClient{logs: logs}
 	svc := NewBalanceSheetService(client, nil)
 
-	result, err := svc.GetPositionDetails(context.Background(), "tenant", "CASH", "GBP")
+	result, err := svc.GetPositionDetails(context.Background(), "tenant", "CASH", "GBP", time.Now().UTC())
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -268,7 +268,7 @@ func TestGetPositionDetails_NoMatches(t *testing.T) {
 	client := &mockPKClient{logs: logs}
 	svc := NewBalanceSheetService(client, nil)
 
-	result, err := svc.GetPositionDetails(context.Background(), "tenant", "NONEXISTENT", "GBP")
+	result, err := svc.GetPositionDetails(context.Background(), "tenant", "NONEXISTENT", "GBP", time.Now().UTC())
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Positions)


### PR DESCRIPTION
## Summary

- Add `BalanceSheetService` gRPC service with `GetBalanceSheet`, `GetPositionDetails`, and `ExportBalanceSheetCSV` RPCs
- Aggregate financial position logs across multiple instruments (GBP, KWH, etc.) into classified ASSETS / LIABILITIES / EQUITY sections
- Provide drill-down from balance sheet line items to individual positions with causation log IDs for Glass Box traceability
- Export balance sheet as CSV with metadata headers

## Changes Made

### Proto (`api/proto/meridian/control_plane/v1/admin.proto`)
- `BalanceSheetClassification` enum (ASSETS, LIABILITIES, EQUITY)
- `NormalBalanceDirection` enum (DEBIT, CREDIT)
- `BalanceSheetService` with 3 RPCs and HTTP gateway annotations
- Request/response messages with buf validation constraints

### Service (`services/control-plane/internal/admin/balance_sheet.go`)
- `BalanceSheetService` fetches position logs via `PositionKeepingClient` interface
- Aggregation by account type and instrument with debit/credit netting
- Classification: debit-normal -> ASSETS, credit-normal -> LIABILITIES, equity keywords -> EQUITY
- Account type extraction from account ID convention (`tenant_ACCOUNT_TYPE_identifier`)
- CSV export with metadata and section totals

### Handler (`services/control-plane/internal/admin/balance_sheet_handler.go`)
- gRPC handler implementing `BalanceSheetServiceServer`
- Input validation returning `InvalidArgument` status codes
- Domain-to-proto mapping for all types

### Tests
- 37 unit tests covering multi-asset aggregation, classification logic, debit/credit netting, nanos handling, position details filtering, CSV export, account type extraction, and handler validation
- Mock `PositionKeepingClient` for isolated testing

## Technical Details

- `PositionKeepingClient` interface decouples from concrete gRPC client, verified at compile time via `var _ PositionKeepingClient = (*client.Client)(nil)`
- `extractAccountType` parses account IDs using `isUpperAlpha` to distinguish type segments (e.g., `STRIPE_NOSTRO`) from numeric identifiers (e.g., `001`)
- Balance computation handles Google Money proto (units + nanos) with `shopspring/decimal`

## Test Plan

- [x] All 37 unit tests pass
- [x] `go build`, `go vet` clean
- [x] `buf lint` passes
- [x] `golangci-lint` passes (0 issues)
- [x] Pre-commit hooks pass

## Task Master

control-plane.10 - Build Multi-Asset Balance Sheet with Drill-Down to Causation