### PR TITLE
feat: Add payment_rails manifest schema and validation

### DIFF
--- a/api/jsonschema/manifest.v1.schema.json
+++ b/api/jsonschema/manifest.v1.schema.json
@@ -58,6 +58,14 @@
                     "additionalProperties": true,
                     "type": "object",
                     "description": "seed_data contains tenant-specific reference data (e.g., default parties, initial chart of accounts, industry-specific lookups). Uses google.protobuf.Struct for flexible JSONB representation."
+                },
+                "paymentRails": {
+                    "items": {
+                        "$ref": "#/definitions/meridian.control_plane.v1.PaymentRails"
+                    },
+                    "additionalProperties": false,
+                    "type": "array",
+                    "description": "payment_rails defines external payment provider integrations for this tenant."
                 }
             },
             "additionalProperties": false,
@@ -258,6 +266,122 @@
             "type": "object",
             "title": "========================================\n Saga Definitions\n ========================================",
             "description": "======================================== Saga Definitions ========================================  SagaDefinition declares a workflow within the manifest. Sagas are triggered by API calls, webhooks, or scheduled events, and contain inline Starlark scripts that orchestrate service interactions."
+        },
+        "meridian.control_plane.v1.PlatformFee": {
+            "required": [
+                "type",
+                "value"
+            ],
+            "properties": {
+                "type": {
+                    "enum": [
+                        "PLATFORM_FEE_TYPE_UNSPECIFIED",
+                        0,
+                        "PLATFORM_FEE_TYPE_PERCENTAGE",
+                        1,
+                        "PLATFORM_FEE_TYPE_FLAT",
+                        2
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "description": "PlatformFeeType defines how the platform fee is calculated."
+                },
+                "value": {
+                    "type": "string",
+                    "description": "value is the fee amount as a decimal string. For PERCENTAGE: \"2.5\" means 2.5%. For FLAT: \"0.30\" means 0.30 in the transaction currency. Must be a valid positive decimal value."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Platform Fee",
+            "description": "PlatformFee defines the fee structure for payment rail transactions."
+        },
+        "meridian.control_plane.v1.PaymentRails": {
+            "required": [
+                "provider",
+                "mode",
+                "accountId",
+                "webhookEndpointSecret",
+                "platformFee",
+                "payoutSchedule",
+                "supportedMethods"
+            ],
+            "properties": {
+                "provider": {
+                    "type": "string",
+                    "description": "provider identifies the payment provider (e.g., \"stripe_connect\")."
+                },
+                "mode": {
+                    "enum": [
+                        "CONNECT_MODE_UNSPECIFIED",
+                        0,
+                        "CONNECT_MODE_STANDARD",
+                        1,
+                        "CONNECT_MODE_EXPRESS",
+                        2
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "description": "ConnectMode defines the Stripe Connect account type."
+                },
+                "accountId": {
+                    "type": "string",
+                    "description": "account_id is the Stripe Connect account identifier (format: acct_xxx)."
+                },
+                "webhookEndpointSecret": {
+                    "type": "string",
+                    "description": "webhook_endpoint_secret is a reference to the webhook signing secret stored in a secret manager. Never contains the plaintext secret."
+                },
+                "platformFee": {
+                    "$ref": "#/definitions/meridian.control_plane.v1.PlatformFee",
+                    "additionalProperties": false,
+                    "description": "platform_fee defines the fee structure for transactions on this rail."
+                },
+                "payoutSchedule": {
+                    "enum": [
+                        "PAYOUT_SCHEDULE_UNSPECIFIED",
+                        0,
+                        "PAYOUT_SCHEDULE_DAILY",
+                        1,
+                        "PAYOUT_SCHEDULE_WEEKLY",
+                        2,
+                        "PAYOUT_SCHEDULE_MONTHLY",
+                        3
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "description": "PayoutSchedule defines when connected account payouts are initiated."
+                },
+                "supportedMethods": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array",
+                    "description": "supported_methods lists the payment methods enabled on this rail (e.g., \"card\", \"sepa_debit\", \"bank_account\")."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "========================================\n Payment Rails\n ========================================",
+            "description": "======================================== Payment Rails ========================================  PaymentRails defines an external payment provider integration. Currently supports Stripe Connect for payment processing."
         },
         "meridian.control_plane.v1.ValuationRule": {
             "required": [

--- a/api/jsonschema/manifest.v1.schema.json
+++ b/api/jsonschema/manifest.v1.schema.json
@@ -10,7 +10,8 @@
                 "accountTypes",
                 "valuationRules",
                 "sagas",
-                "seedData"
+                "seedData",
+                "paymentRails"
             ],
             "properties": {
                 "version": {
@@ -242,66 +243,6 @@
             "title": "========================================\n Manifest Metadata\n ========================================",
             "description": "======================================== Manifest Metadata ========================================  ManifestMetadata contains identifying information about a manifest."
         },
-        "meridian.control_plane.v1.SagaDefinition": {
-            "required": [
-                "name",
-                "trigger",
-                "script"
-            ],
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "name is the unique identifier for this saga (e.g., \"process_energy_settlement\"). Must be lowercase alphanumeric with underscores."
-                },
-                "trigger": {
-                    "type": "string",
-                    "description": "trigger defines what initiates this saga. Supported prefixes:   \"api:\" - triggered by an API call (e.g., \"api:/v1/settlements\")   \"webhook:\" - triggered by an external webhook (e.g., \"webhook:stripe_payment\")   \"scheduled:\" - triggered on a schedule (e.g., \"scheduled:daily_reconciliation\")"
-                },
-                "script": {
-                    "type": "string",
-                    "description": "script is the inline Starlark source code defining the saga workflow. Must not be empty - all saga logic is defined inline in the manifest. Starlark guarantees termination (no while loops, no recursion)."
-                }
-            },
-            "additionalProperties": false,
-            "type": "object",
-            "title": "========================================\n Saga Definitions\n ========================================",
-            "description": "======================================== Saga Definitions ========================================  SagaDefinition declares a workflow within the manifest. Sagas are triggered by API calls, webhooks, or scheduled events, and contain inline Starlark scripts that orchestrate service interactions."
-        },
-        "meridian.control_plane.v1.PlatformFee": {
-            "required": [
-                "type",
-                "value"
-            ],
-            "properties": {
-                "type": {
-                    "enum": [
-                        "PLATFORM_FEE_TYPE_UNSPECIFIED",
-                        0,
-                        "PLATFORM_FEE_TYPE_PERCENTAGE",
-                        1,
-                        "PLATFORM_FEE_TYPE_FLAT",
-                        2
-                    ],
-                    "oneOf": [
-                        {
-                            "type": "string"
-                        },
-                        {
-                            "type": "integer"
-                        }
-                    ],
-                    "description": "PlatformFeeType defines how the platform fee is calculated."
-                },
-                "value": {
-                    "type": "string",
-                    "description": "value is the fee amount as a decimal string. For PERCENTAGE: \"2.5\" means 2.5%. For FLAT: \"0.30\" means 0.30 in the transaction currency. Must be a valid positive decimal value."
-                }
-            },
-            "additionalProperties": false,
-            "type": "object",
-            "title": "Platform Fee",
-            "description": "PlatformFee defines the fee structure for payment rail transactions."
-        },
         "meridian.control_plane.v1.PaymentRails": {
             "required": [
                 "provider",
@@ -334,6 +275,7 @@
                             "type": "integer"
                         }
                     ],
+                    "title": "Connect Mode",
                     "description": "ConnectMode defines the Stripe Connect account type."
                 },
                 "accountId": {
@@ -342,7 +284,7 @@
                 },
                 "webhookEndpointSecret": {
                     "type": "string",
-                    "description": "webhook_endpoint_secret is a reference to the webhook signing secret stored in a secret manager. Never contains the plaintext secret."
+                    "description": "webhook_endpoint_secret is a reference to the webhook signing secret stored in a secret manager (e.g., \"sm://stripe/webhook_secret\"). Never contains the plaintext secret."
                 },
                 "platformFee": {
                     "$ref": "#/definitions/meridian.control_plane.v1.PlatformFee",
@@ -368,6 +310,7 @@
                             "type": "integer"
                         }
                     ],
+                    "title": "Payout Schedule",
                     "description": "PayoutSchedule defines when connected account payouts are initiated."
                 },
                 "supportedMethods": {
@@ -380,8 +323,69 @@
             },
             "additionalProperties": false,
             "type": "object",
-            "title": "========================================\n Payment Rails\n ========================================",
-            "description": "======================================== Payment Rails ========================================  PaymentRails defines an external payment provider integration. Currently supports Stripe Connect for payment processing."
+            "title": "Payment Rails",
+            "description": "PaymentRails defines an external payment provider integration. Currently supports Stripe Connect for payment processing."
+        },
+        "meridian.control_plane.v1.PlatformFee": {
+            "required": [
+                "type",
+                "value"
+            ],
+            "properties": {
+                "type": {
+                    "enum": [
+                        "PLATFORM_FEE_TYPE_UNSPECIFIED",
+                        0,
+                        "PLATFORM_FEE_TYPE_PERCENTAGE",
+                        1,
+                        "PLATFORM_FEE_TYPE_FLAT",
+                        2
+                    ],
+                    "oneOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer"
+                        }
+                    ],
+                    "title": "========================================\n Payment Rails\n ========================================",
+                    "description": "======================================== Payment Rails ========================================  PlatformFeeType defines how the platform fee is calculated."
+                },
+                "value": {
+                    "type": "string",
+                    "description": "value is the fee amount as a decimal string. For PERCENTAGE: \"2.5\" means 2.5%. For FLAT: \"0.30\" means 0.30 in the transaction currency. Must be a valid positive decimal value."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "Platform Fee",
+            "description": "PlatformFee defines the fee structure for payment rail transactions."
+        },
+        "meridian.control_plane.v1.SagaDefinition": {
+            "required": [
+                "name",
+                "trigger",
+                "script"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "name is the unique identifier for this saga (e.g., \"process_energy_settlement\"). Must be lowercase alphanumeric with underscores."
+                },
+                "trigger": {
+                    "type": "string",
+                    "description": "trigger defines what initiates this saga. Supported prefixes:   \"api:\" - triggered by an API call (e.g., \"api:/v1/settlements\")   \"webhook:\" - triggered by an external webhook (e.g., \"webhook:stripe_payment\")   \"scheduled:\" - triggered on a schedule (e.g., \"scheduled:daily_reconciliation\")"
+                },
+                "script": {
+                    "type": "string",
+                    "description": "script is the inline Starlark source code defining the saga workflow. Must not be empty - all saga logic is defined inline in the manifest. Starlark guarantees termination (no while loops, no recursion)."
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "title": "========================================\n Saga Definitions\n ========================================",
+            "description": "======================================== Saga Definitions ========================================  SagaDefinition declares a workflow within the manifest. Sagas are triggered by API calls, webhooks, or scheduled events, and contain inline Starlark scripts that orchestrate service interactions."
         },
         "meridian.control_plane.v1.ValuationRule": {
             "required": [

--- a/api/proto/meridian/control_plane/v1/manifest.proto
+++ b/api/proto/meridian/control_plane/v1/manifest.proto
@@ -47,6 +47,9 @@ message Manifest {
   // initial chart of accounts, industry-specific lookups).
   // Uses google.protobuf.Struct for flexible JSONB representation.
   google.protobuf.Struct seed_data = 7;
+
+  // payment_rails defines external payment provider integrations for this tenant.
+  repeated PaymentRails payment_rails = 8;
 }
 
 // ========================================
@@ -275,5 +278,112 @@ message SagaDefinition {
   string script = 3 [(buf.validate.field).string = {
     min_len: 1
     max_len: 65536
+  }];
+}
+
+// ========================================
+// Payment Rails
+// ========================================
+
+// PlatformFeeType defines how the platform fee is calculated.
+enum PlatformFeeType {
+  // PLATFORM_FEE_TYPE_UNSPECIFIED means the fee type is unknown.
+  PLATFORM_FEE_TYPE_UNSPECIFIED = 0;
+  // PLATFORM_FEE_TYPE_PERCENTAGE calculates the fee as a percentage of the transaction amount.
+  PLATFORM_FEE_TYPE_PERCENTAGE = 1;
+  // PLATFORM_FEE_TYPE_FLAT applies a fixed fee amount per transaction.
+  PLATFORM_FEE_TYPE_FLAT = 2;
+}
+
+// PayoutSchedule defines when connected account payouts are initiated.
+enum PayoutSchedule {
+  // PAYOUT_SCHEDULE_UNSPECIFIED means the schedule is unknown.
+  PAYOUT_SCHEDULE_UNSPECIFIED = 0;
+  // PAYOUT_SCHEDULE_DAILY initiates payouts once per day.
+  PAYOUT_SCHEDULE_DAILY = 1;
+  // PAYOUT_SCHEDULE_WEEKLY initiates payouts once per week.
+  PAYOUT_SCHEDULE_WEEKLY = 2;
+  // PAYOUT_SCHEDULE_MONTHLY initiates payouts once per month.
+  PAYOUT_SCHEDULE_MONTHLY = 3;
+}
+
+// ConnectMode defines the Stripe Connect account type.
+enum ConnectMode {
+  // CONNECT_MODE_UNSPECIFIED means the mode is unknown.
+  CONNECT_MODE_UNSPECIFIED = 0;
+  // CONNECT_MODE_STANDARD uses standard Stripe Connect accounts.
+  CONNECT_MODE_STANDARD = 1;
+  // CONNECT_MODE_EXPRESS uses express Stripe Connect accounts.
+  CONNECT_MODE_EXPRESS = 2;
+}
+
+// PlatformFee defines the fee structure for payment rail transactions.
+message PlatformFee {
+  // type defines whether the fee is a percentage or flat amount.
+  PlatformFeeType type = 1 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // value is the fee amount as a decimal string.
+  // For PERCENTAGE: "2.5" means 2.5%.
+  // For FLAT: "0.30" means 0.30 in the transaction currency.
+  // Must be a valid positive decimal value.
+  string value = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 32
+  }];
+}
+
+// PaymentRails defines an external payment provider integration.
+// Currently supports Stripe Connect for payment processing.
+message PaymentRails {
+  // provider identifies the payment provider (e.g., "stripe_connect").
+  string provider = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+  }];
+
+  // mode defines the Stripe Connect account type (standard or express).
+  ConnectMode mode = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // account_id is the Stripe Connect account identifier (format: acct_xxx).
+  string account_id = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+    pattern: "^acct_[A-Za-z0-9]{16,}$"
+  }];
+
+  // webhook_endpoint_secret is a reference to the webhook signing secret
+  // stored in a secret manager (e.g., "sm://stripe/webhook_secret").
+  // Never contains the plaintext secret.
+  string webhook_endpoint_secret = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 512
+  }];
+
+  // platform_fee defines the fee structure for transactions on this rail.
+  PlatformFee platform_fee = 5 [(buf.validate.field).required = true];
+
+  // payout_schedule defines when connected account payouts are initiated.
+  PayoutSchedule payout_schedule = 6 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // supported_methods lists the payment methods enabled on this rail
+  // (e.g., "card", "sepa_debit", "bank_account").
+  repeated string supported_methods = 7 [(buf.validate.field).repeated = {
+    min_items: 1
+    items: {
+      string: {
+        min_len: 1
+        max_len: 64
+        pattern: "^[a-z][a-z0-9_]*$"
+      }
+    }
   }];
 }

--- a/services/control-plane/internal/validator/manifest_validator.go
+++ b/services/control-plane/internal/validator/manifest_validator.go
@@ -8,12 +8,14 @@ package validator
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
 	"buf.build/go/protovalidate"
 	"github.com/google/cel-go/cel"
 	controlplanev1 "github.com/meridianhub/meridian/api/proto/meridian/control_plane/v1"
+	"github.com/shopspring/decimal"
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
 )
@@ -206,7 +208,10 @@ func (v *ManifestValidator) Validate(
 	// 5. Cross-reference validation
 	v.validateCrossReferences(manifest, result)
 
-	// 6. Immutability checks
+	// 6. Payment rails validation
+	v.validatePaymentRails(manifest, result)
+
+	// 7. Immutability checks
 	if previousManifest != nil {
 		v.validateImmutability(manifest, previousManifest, result)
 	}
@@ -500,6 +505,107 @@ func (v *ManifestValidator) validateCrossReferences(
 			fmt.Sprintf("valuation_rules[%d].to_instrument", i),
 			result,
 		)
+	}
+}
+
+// accountIDPattern matches valid Stripe Connect account IDs (acct_ followed by 16+ alphanumeric chars).
+var accountIDPattern = regexp.MustCompile(`^acct_[A-Za-z0-9]{16,}$`)
+
+// allowedProviders is the set of supported payment rail providers.
+var allowedProviders = map[string]bool{
+	"stripe_connect": true,
+}
+
+// allowedPaymentMethods is the set of supported payment methods.
+var allowedPaymentMethods = map[string]bool{
+	"card":         true,
+	"sepa_debit":   true,
+	"bank_account": true,
+}
+
+// validatePaymentRails validates all payment rail configurations in the manifest.
+func (v *ManifestValidator) validatePaymentRails(
+	manifest *controlplanev1.Manifest,
+	result *ValidationResult,
+) {
+	for i, rail := range manifest.GetPaymentRails() {
+		basePath := fmt.Sprintf("payment_rails[%d]", i)
+
+		// Validate provider
+		if rail.GetProvider() != "" && !allowedProviders[rail.GetProvider()] {
+			providerList := mapKeys(allowedProviders)
+			addError(result, ValidationError{
+				Severity:        SeverityError,
+				Path:            basePath + ".provider",
+				Code:            "INVALID_PAYMENT_PROVIDER",
+				Message:         fmt.Sprintf("unsupported payment provider %q", rail.GetProvider()),
+				AvailableFields: providerList,
+			})
+		}
+
+		// Validate account_id format
+		if rail.GetAccountId() != "" && !accountIDPattern.MatchString(rail.GetAccountId()) {
+			addError(result, ValidationError{
+				Severity: SeverityError,
+				Path:     basePath + ".account_id",
+				Code:     "INVALID_ACCOUNT_ID_FORMAT",
+				Message:  fmt.Sprintf("account_id %q does not match expected format acct_[A-Za-z0-9]{16,}", rail.GetAccountId()),
+			})
+		}
+
+		// Validate platform_fee
+		if fee := rail.GetPlatformFee(); fee != nil {
+			v.validatePlatformFee(fee, basePath+".platform_fee", result)
+		}
+
+		// Validate supported_methods contain only known values
+		for j, method := range rail.GetSupportedMethods() {
+			if !allowedPaymentMethods[method] {
+				methodList := mapKeys(allowedPaymentMethods)
+				ve := ValidationError{
+					Severity:        SeverityWarning,
+					Path:            fmt.Sprintf("%s.supported_methods[%d]", basePath, j),
+					Code:            "UNKNOWN_PAYMENT_METHOD",
+					Message:         fmt.Sprintf("payment method %q is not a recognized method", method),
+					AvailableFields: methodList,
+				}
+				if suggestion := findClosestMatch(method, methodList); suggestion != "" {
+					ve.Suggestion = fmt.Sprintf("Did you mean %q?", suggestion)
+				}
+				addError(result, ve)
+			}
+		}
+	}
+}
+
+// validatePlatformFee validates the platform fee value is a valid positive decimal.
+func (v *ManifestValidator) validatePlatformFee(
+	fee *controlplanev1.PlatformFee,
+	basePath string,
+	result *ValidationResult,
+) {
+	if fee.GetValue() == "" {
+		return
+	}
+
+	d, err := decimal.NewFromString(fee.GetValue())
+	if err != nil {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     basePath + ".value",
+			Code:     "INVALID_PLATFORM_FEE_VALUE",
+			Message:  fmt.Sprintf("platform_fee.value %q is not a valid decimal", fee.GetValue()),
+		})
+		return
+	}
+
+	if d.LessThanOrEqual(decimal.Zero) {
+		addError(result, ValidationError{
+			Severity: SeverityError,
+			Path:     basePath + ".value",
+			Code:     "INVALID_PLATFORM_FEE_VALUE",
+			Message:  fmt.Sprintf("platform_fee.value must be greater than 0, got %s", fee.GetValue()),
+		})
 	}
 }
 

--- a/services/control-plane/internal/validator/manifest_validator_test.go
+++ b/services/control-plane/internal/validator/manifest_validator_test.go
@@ -923,6 +923,306 @@ func TestValidateStarlark_EmptyScript(t *testing.T) {
 	}
 }
 
+// validPaymentRails returns a valid PaymentRails for testing.
+func validPaymentRails() *controlplanev1.PaymentRails {
+	return &controlplanev1.PaymentRails{
+		Provider:              "stripe_connect",
+		Mode:                  controlplanev1.ConnectMode_CONNECT_MODE_STANDARD,
+		AccountId:             "acct_1234567890abcdef",
+		WebhookEndpointSecret: "sm://stripe/webhook_secret",
+		PlatformFee: &controlplanev1.PlatformFee{
+			Type:  controlplanev1.PlatformFeeType_PLATFORM_FEE_TYPE_PERCENTAGE,
+			Value: "2.5",
+		},
+		PayoutSchedule:   controlplanev1.PayoutSchedule_PAYOUT_SCHEDULE_DAILY,
+		SupportedMethods: []string{"card", "sepa_debit"},
+	}
+}
+
+func TestValidatePaymentRails_Valid(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	m.PaymentRails = []*controlplanev1.PaymentRails{validPaymentRails()}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with payment_rails, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidatePaymentRails_InvalidProvider(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	rail := validPaymentRails()
+	rail.Provider = "paypal"
+	m.PaymentRails = []*controlplanev1.PaymentRails{rail}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for unsupported provider")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_PAYMENT_PROVIDER" {
+			found = true
+			if !strings.Contains(e.Message, "paypal") {
+				t.Errorf("expected error message to contain 'paypal', got: %s", e.Message)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected INVALID_PAYMENT_PROVIDER error, got: %v", result.Errors)
+	}
+}
+
+func TestValidatePaymentRails_InvalidAccountIDFormat(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		accountID string
+	}{
+		{"missing_prefix", "1234567890abcdef12"},
+		{"wrong_prefix", "cust_1234567890abcdef"},
+		{"too_short", "acct_abc"},
+		{"special_chars", "acct_1234567890abcdef!"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := validManifest()
+			rail := validPaymentRails()
+			rail.AccountId = tt.accountID
+			m.PaymentRails = []*controlplanev1.PaymentRails{rail}
+
+			result := v.Validate(m, nil)
+
+			found := false
+			for _, e := range result.Errors {
+				if e.Code == "INVALID_ACCOUNT_ID_FORMAT" {
+					found = true
+					break
+				}
+			}
+			// Proto validation or our custom validation should catch this
+			if !found {
+				// Check for proto validation catching it instead
+				protoFound := false
+				for _, e := range result.Errors {
+					if e.Code == "PROTO_VALIDATION" && strings.Contains(e.Path, "account_id") {
+						protoFound = true
+						break
+					}
+				}
+				if !protoFound {
+					t.Errorf("expected INVALID_ACCOUNT_ID_FORMAT or PROTO_VALIDATION error for account_id %q, got: %v", tt.accountID, result.Errors)
+				}
+			}
+		})
+	}
+}
+
+func TestValidatePaymentRails_InvalidPlatformFeeValue_NonDecimal(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	rail := validPaymentRails()
+	rail.PlatformFee.Value = "not-a-number"
+	m.PaymentRails = []*controlplanev1.PaymentRails{rail}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for non-decimal platform fee")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_PLATFORM_FEE_VALUE" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected INVALID_PLATFORM_FEE_VALUE error, got: %v", result.Errors)
+	}
+}
+
+func TestValidatePaymentRails_InvalidPlatformFeeValue_Negative(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	rail := validPaymentRails()
+	rail.PlatformFee.Value = "-1.5"
+	m.PaymentRails = []*controlplanev1.PaymentRails{rail}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for negative platform fee")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_PLATFORM_FEE_VALUE" {
+			found = true
+			if !strings.Contains(e.Message, "greater than 0") {
+				t.Errorf("expected message about positive value, got: %s", e.Message)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected INVALID_PLATFORM_FEE_VALUE error, got: %v", result.Errors)
+	}
+}
+
+func TestValidatePaymentRails_InvalidPlatformFeeValue_Zero(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	rail := validPaymentRails()
+	rail.PlatformFee.Value = "0"
+	m.PaymentRails = []*controlplanev1.PaymentRails{rail}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for zero platform fee")
+	}
+
+	found := false
+	for _, e := range result.Errors {
+		if e.Code == "INVALID_PLATFORM_FEE_VALUE" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected INVALID_PLATFORM_FEE_VALUE error, got: %v", result.Errors)
+	}
+}
+
+func TestValidatePaymentRails_UnknownPaymentMethod(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	rail := validPaymentRails()
+	rail.SupportedMethods = []string{"card", "crypto_wallet"}
+	m.PaymentRails = []*controlplanev1.PaymentRails{rail}
+
+	result := v.Validate(m, nil)
+	// Unknown methods produce warnings, not errors
+	if !result.Valid {
+		t.Errorf("expected valid manifest (unknown methods are warnings), got errors: %v", result.Errors)
+	}
+
+	found := false
+	for _, w := range result.Warnings {
+		if w.Code == "UNKNOWN_PAYMENT_METHOD" && strings.Contains(w.Message, "crypto_wallet") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected UNKNOWN_PAYMENT_METHOD warning for 'crypto_wallet', got warnings: %v", result.Warnings)
+	}
+}
+
+func TestValidatePaymentRails_MissingRequiredFields(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	// Empty PaymentRails should fail proto validation
+	m.PaymentRails = []*controlplanev1.PaymentRails{{}}
+
+	result := v.Validate(m, nil)
+	if result.Valid {
+		t.Error("expected invalid manifest for empty payment_rails entry")
+	}
+	if len(result.Errors) == 0 {
+		t.Error("expected at least one error for missing required fields")
+	}
+}
+
+func TestValidatePaymentRails_ValidFlatFee(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	rail := validPaymentRails()
+	rail.PlatformFee = &controlplanev1.PlatformFee{
+		Type:  controlplanev1.PlatformFeeType_PLATFORM_FEE_TYPE_FLAT,
+		Value: "0.30",
+	}
+	m.PaymentRails = []*controlplanev1.PaymentRails{rail}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with flat fee, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidatePaymentRails_MultipleRails(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	rail1 := validPaymentRails()
+	rail2 := validPaymentRails()
+	rail2.AccountId = "acct_abcdefghijklmnop"
+	rail2.Mode = controlplanev1.ConnectMode_CONNECT_MODE_EXPRESS
+	m.PaymentRails = []*controlplanev1.PaymentRails{rail1, rail2}
+
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest with multiple payment rails, got errors: %v", result.Errors)
+	}
+}
+
+func TestValidatePaymentRails_NoPaymentRails(t *testing.T) {
+	v, err := New()
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	m := validManifest()
+	// No payment_rails field set - should be valid
+	result := v.Validate(m, nil)
+	if !result.Valid {
+		t.Errorf("expected valid manifest without payment_rails, got errors: %v", result.Errors)
+	}
+}
+
 func TestValidateImmutability_AddNewInstrument(t *testing.T) {
 	v, err := New()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Extend manifest.proto with PaymentRails and PlatformFee messages for Stripe Connect integration
- Add JSON schema validation definitions for payment_rails in manifest.v1.schema.json
- Implement ValidatePaymentRails in manifest validator with provider, account_id, platform_fee, and payment method checks
- Proto constraints enforce required fields, account_id format, enum validity, and supported_methods patterns

## Task Master
Tag: stripe-connect, Task: 4

## Changes Made

### Proto Schema (api/proto/meridian/control_plane/v1/manifest.proto)
- Added `PaymentRails` message with provider, mode, account_id, webhook_endpoint_secret, platform_fee, payout_schedule, supported_methods
- Added `PlatformFee` message with type (percentage/flat) and decimal value
- Added enums: `PlatformFeeType`, `PayoutSchedule`, `ConnectMode`
- Added `repeated PaymentRails payment_rails` field to Manifest (field 8)
- All fields have buf.validate constraints matching the PRD spec

### JSON Schema (api/jsonschema/manifest.v1.schema.json)
- Added PaymentRails and PlatformFee definitions following existing patterns
- Added paymentRails array property to Manifest

### Validator (services/control-plane/internal/validator/)
- Added `validatePaymentRails()` to validation pipeline (step 6)
- Validates provider against allowed set (stripe_connect)
- Validates account_id format with regex `^acct_[A-Za-z0-9]{16,}$`
- Validates platform_fee.value as parseable positive decimal
- Warns on unrecognized payment methods with suggestions

### Tests
- 12 new test cases covering valid rails, invalid provider, invalid account_id formats, non-decimal/negative/zero fees, unknown methods, missing fields, flat fees, multiple rails, no rails

## Test Plan
- [x] buf lint passes
- [x] buf generate succeeds
- [x] Proto-level validation tests pass (api/proto/meridian/control_plane/v1)
- [x] Manifest validator tests pass (services/control-plane/internal/validator)
- [ ] CI pipeline passes