### PR TITLE
docs: add PRDs for cross-service unimplemented gRPC handlers

### DIFF
--- a/docs/prd/current-account-withdrawal-persistence.md
+++ b/docs/prd/current-account-withdrawal-persistence.md
@@ -1,0 +1,251 @@
+---
+name: prd-current-account-withdrawal-persistence
+description: Implement withdrawal persistence adapter to wire 3 unimplemented gRPC handlers in the current-account service
+triggers:
+  - Working on current-account withdrawal handlers
+  - Fixing Unimplemented gRPC responses for withdrawal operations
+  - Implementing withdrawal-by-ID lookup or update flows
+instructions: |
+  The current-account service has 3 withdrawal gRPC handlers that return codes.Unimplemented
+  when withdrawalRepo == nil. The persistence adapter (WithdrawalRepository) already exists
+  and is wired in cmd/main.go, but the nil guard was a historical artifact from before the
+  adapter was implemented. The actual issue is that withdrawal-by-ID operations require the
+  repo to be non-nil, and the service gracefully degrades for account-based queries.
+
+  Key pattern to follow: services/current-account/adapters/persistence/lien_repository.go
+  The WithdrawalRepository already exists at services/current-account/adapters/persistence/withdrawal_repository.go
+  and is already wired in cmd/main.go line 97. The issue is that the handlers guard on
+  withdrawalRepo == nil for withdrawal-by-ID operations.
+---
+
+# PRD: Current Account Withdrawal Persistence
+
+**Status:** Draft
+**Version:** 1.0
+**Date:** 2026-02-10
+**Author:** Architecture Team
+**Task Master Tag:** TBD
+
+**ADRs:**
+
+- [0002 - Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
+- [0015 - Standard Service Directory Structure](../adr/0015-standard-service-directory-structure.md)
+
+**Related PRDs:**
+
+- [Reconciliation gRPC Wiring](reconciliation-grpc-wiring.md) -
+  Appendix: Cross-Service Unimplemented RPC Audit (source of this work)
+
+---
+
+## Problem Statement
+
+Three withdrawal gRPC handlers in the current-account service return `codes.Unimplemented` when `withdrawalRepo == nil`:
+
+| Handler | File | Line | Error Message |
+|---------|------|------|---------------|
+| `UpdateWithdrawal` | `service/grpc_withdrawal_manage.go` | 173 | "withdrawal persistence not configured" |
+| `RetrieveWithdrawal` | `service/grpc_withdrawal_manage.go` | 262 | Returns empty list for account queries; errors on direct withdrawal-by-ID lookup |
+| `ExecuteWithdrawal` | `service/grpc_withdrawal_execute.go` | 54 | "withdrawal persistence not configured" |
+
+**Severity:** Medium - Withdrawal-by-ID operations fail in production. Account-based operations degrade gracefully.
+
+---
+
+## Root Cause Analysis
+
+The `WithdrawalRepository` persistence adapter already exists and is already wired in `cmd/main.go`:
+
+```go
+// cmd/main.go:97
+withdrawalRepo := persistence.NewWithdrawalRepository(db)
+```
+
+The repository is passed to `createServiceWithClients` (line 125) and then to
+`service.NewServiceWithExistingClients` (line 483). The service struct holds it at
+`service/grpc_service.go:129`:
+
+```go
+withdrawalRepo *persistence.WithdrawalRepository
+```
+
+**The nil guard pattern** exists because the handlers were written defensively before the
+persistence adapter was implemented. The adapter now exists at
+`services/current-account/adapters/persistence/withdrawal_repository.go` with full CRUD
+operations:
+
+- `Create(ctx, withdrawal)` - Insert new withdrawal
+- `FindByID(ctx, id)` - Lookup by UUID
+- `FindByReference(ctx, reference)` - Lookup by idempotency reference
+- `Update(ctx, withdrawal)` - Optimistic locking update
+- `List(ctx, accountID, pagination)` - Paginated list by account
+
+The entity is defined at `services/current-account/adapters/persistence/withdrawal_entity.go` with table name `withdrawal`.
+
+**What is missing:** The database migration that creates the `withdrawal` table. Without
+this migration, the repository exists in Go code but has no backing table, so the
+`WithdrawalRepository` would fail at runtime with SQL errors rather than the graceful
+nil-guard degradation.
+
+---
+
+## Technical Design
+
+### Architecture
+
+```mermaid
+graph TD
+    A[gRPC Client] --> B[ExecuteWithdrawal Handler]
+    A --> C[UpdateWithdrawal Handler]
+    A --> D[RetrieveWithdrawal Handler]
+    B --> E[WithdrawalRepository]
+    C --> E
+    D --> E
+    E --> F[(CockroachDB<br/>withdrawal table)]
+    B --> G[WithdrawalOrchestrator<br/>Saga Pattern]
+    G --> H[Position Keeping]
+    G --> I[Financial Accounting]
+```
+
+### Handler Behavior
+
+#### ExecuteWithdrawal (`grpc_withdrawal_execute.go`)
+
+Two execution modes:
+
+1. **Direct withdrawal**: Provide `account_id` + `amount` for immediate execution (no repo needed)
+2. **Execute pending withdrawal**: Provide `withdrawal_id` to execute a previously
+   initiated withdrawal (requires repo for lookup)
+
+The nil guard at line 52-54 only affects mode 2 (withdrawal-by-ID). Mode 1 works without the repo.
+
+#### UpdateWithdrawal (`grpc_withdrawal_manage.go`)
+
+Modifies a pending withdrawal before execution. The nil guard at line 171-173 blocks
+all operations. Currently supports retrieval and validation only; field updates (amount,
+description) are not yet supported as the domain model treats these as immutable.
+
+#### RetrieveWithdrawal (`grpc_withdrawal_manage.go`)
+
+Two query modes:
+
+1. **By withdrawal_id**: Returns single withdrawal (requires repo)
+2. **By account_id**: Returns paginated list (degrades to empty list when repo is nil)
+
+The nil guard at line 257-282 provides graceful degradation for account queries but
+errors on direct ID lookup.
+
+### Database Migration
+
+Create the `withdrawal` table matching `WithdrawalEntity`:
+
+```sql
+CREATE TABLE withdrawal (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    account_id UUID NOT NULL,
+    amount_cents BIGINT NOT NULL CHECK (amount_cents > 0),
+    currency VARCHAR(3) NOT NULL,
+    status VARCHAR(20) NOT NULL CHECK (status IN ('PENDING', 'COMPLETED', 'FAILED', 'CANCELLED')),
+    reference VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version BIGINT NOT NULL DEFAULT 1,
+    CONSTRAINT idx_withdrawal_reference UNIQUE (reference)
+);
+
+CREATE INDEX idx_withdrawal_account_status ON withdrawal(account_id, status);
+```
+
+### Files to Modify
+
+**New files:**
+
+- `services/current-account/migrations/<next_version>_create_withdrawal_table.sql` - Database migration
+
+**Existing files (no changes needed if migration is applied):**
+
+- `services/current-account/adapters/persistence/withdrawal_repository.go` - Already implemented
+- `services/current-account/adapters/persistence/withdrawal_entity.go` - Already implemented
+- `services/current-account/cmd/main.go` - Already wires the repository (line 97)
+
+### Pattern Reference
+
+The existing `LienRepository` at
+`services/current-account/adapters/persistence/lien_repository.go` demonstrates the
+established pattern:
+
+- GORM-based persistence with `WithGormTenantTransaction` for multi-tenant isolation
+- Optimistic locking via version column
+- Domain-to-entity and entity-to-domain mappers
+- `WithTx` method for transactional composition
+
+The `WithdrawalRepository` follows this pattern identically.
+
+---
+
+## Implementation Tasks
+
+| Task ID | Description | Story Points |
+|---------|-------------|-------------|
+| CAW-001 | Create database migration for `withdrawal` table | 1 |
+| CAW-002 | Write integration tests for `WithdrawalRepository` (CockroachDB testcontainers) | 2 |
+| CAW-003 | Verify all 3 handlers work end-to-end through gRPC transport | 1 |
+
+### Total: 3 Story Points
+
+The implementation is small because the Go code (repository, entity, handler wiring)
+already exists. The gap is the database migration and test coverage.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- Verify `WithdrawalRepository` CRUD operations against CockroachDB testcontainer
+- Test optimistic locking conflict scenarios
+- Test `FindByReference` uniqueness constraint
+- Test `List` with pagination
+
+### Integration Tests
+
+- Call `ExecuteWithdrawal` with `withdrawal_id` through gRPC transport
+- Call `UpdateWithdrawal` through gRPC transport
+- Call `RetrieveWithdrawal` with both `withdrawal_id` and `account_id` through gRPC transport
+
+### Regression
+
+- Verify direct withdrawal mode (`account_id` + `amount`) still works without pending withdrawal
+- Verify account-based `RetrieveWithdrawal` returns results (not empty list)
+
+---
+
+## Success Criteria
+
+- [ ] `withdrawal` table exists in CockroachDB schema
+- [ ] `ExecuteWithdrawal` with `withdrawal_id` returns success (not Unimplemented)
+- [ ] `UpdateWithdrawal` returns withdrawal details (not Unimplemented)
+- [ ] `RetrieveWithdrawal` by withdrawal_id returns the withdrawal (not Unimplemented)
+- [ ] `RetrieveWithdrawal` by account_id returns non-empty list when withdrawals exist
+- [ ] Integration tests pass with CockroachDB testcontainers
+- [ ] No regression in direct withdrawal mode
+
+---
+
+## Rollout Plan
+
+1. **Migration**: Apply `withdrawal` table migration (safe, additive schema change)
+2. **Deploy**: No code changes needed; existing code already wires the repository
+3. **Verify**: Run gRPC calls against each handler to confirm Unimplemented is gone
+4. **Monitor**: Check Prometheus metrics for `execute_withdrawal`,
+   `update_withdrawal`, `retrieve_withdrawal` operation durations
+
+---
+
+## Risk Assessment
+
+- **Low risk**: The Go code already exists and is wired. The only gap is the database migration.
+- **No breaking changes**: Adding a table is an additive operation.
+- **Graceful degradation preserved**: If migration is not applied, the nil guard behavior continues (no worse than today).
+
+<!-- End of PRD -->

--- a/docs/prd/current-account-withdrawal-persistence.md
+++ b/docs/prd/current-account-withdrawal-persistence.md
@@ -69,10 +69,16 @@ The repository is passed to `createServiceWithClients` (line 125) and then to
 withdrawalRepo *persistence.WithdrawalRepository
 ```
 
-**The nil guard pattern** exists because the handlers were written defensively before the
-persistence adapter was implemented. The adapter now exists at
-`services/current-account/adapters/persistence/withdrawal_repository.go` with full CRUD
-operations:
+**The nil guards are dead code.** Since `withdrawalRepo` is unconditionally
+initialized in `cmd/main.go:97` and always passed to the Service constructor,
+the `withdrawalRepo == nil` checks in the three handlers will never execute in
+normal operation. These guards were written defensively before the persistence
+adapter was implemented but are now obsolete. They should be removed as part
+of this work.
+
+The adapter exists at
+`services/current-account/adapters/persistence/withdrawal_repository.go` with
+full CRUD operations:
 
 - `Create(ctx, withdrawal)` - Insert new withdrawal
 - `FindByID(ctx, id)` - Lookup by UUID
@@ -80,12 +86,17 @@ operations:
 - `Update(ctx, withdrawal)` - Optimistic locking update
 - `List(ctx, accountID, pagination)` - Paginated list by account
 
-The entity is defined at `services/current-account/adapters/persistence/withdrawal_entity.go` with table name `withdrawal`.
+The entity is defined at
+`services/current-account/adapters/persistence/withdrawal_entity.go` with table
+name `withdrawal`.
 
-**What is missing:** The database migration that creates the `withdrawal` table. Without
-this migration, the repository exists in Go code but has no backing table, so the
-`WithdrawalRepository` would fail at runtime with SQL errors rather than the graceful
-nil-guard degradation.
+**What is missing:** The database migration that creates the `withdrawal` table.
+The repository Go code is wired and non-nil, but without the backing table,
+withdrawal operations would fail with SQL errors at runtime. The implementation
+should:
+
+1. Create the `withdrawal` table migration
+2. Remove the now-obsolete nil guards from the three handlers
 
 ---
 
@@ -150,7 +161,7 @@ CREATE TABLE withdrawal (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     version BIGINT NOT NULL DEFAULT 1,
-    CONSTRAINT idx_withdrawal_reference UNIQUE (reference)
+    CONSTRAINT uq_withdrawal_reference UNIQUE (reference)
 );
 
 CREATE INDEX idx_withdrawal_account_status ON withdrawal(account_id, status);
@@ -188,8 +199,9 @@ The `WithdrawalRepository` follows this pattern identically.
 | Task ID | Description | Story Points |
 |---------|-------------|-------------|
 | CAW-001 | Create database migration for `withdrawal` table | 1 |
-| CAW-002 | Write integration tests for `WithdrawalRepository` (CockroachDB testcontainers) | 2 |
-| CAW-003 | Verify all 3 handlers work end-to-end through gRPC transport | 1 |
+| CAW-002 | Remove obsolete nil guards from 3 handlers | 1 |
+| CAW-003 | Write integration tests for `WithdrawalRepository` (CockroachDB) | 2 |
+| CAW-004 | Verify all 3 handlers work end-to-end through gRPC transport | 1 |
 
 ### Total: 3 Story Points
 
@@ -235,16 +247,18 @@ already exists. The gap is the database migration and test coverage.
 ## Rollout Plan
 
 1. **Migration**: Apply `withdrawal` table migration (safe, additive schema change)
-2. **Deploy**: No code changes needed; existing code already wires the repository
-3. **Verify**: Run gRPC calls against each handler to confirm Unimplemented is gone
-4. **Monitor**: Check Prometheus metrics for `execute_withdrawal`,
+2. **Code**: Remove obsolete nil guards from 3 handlers
+3. **Deploy**: Deploy updated service with migration
+4. **Verify**: Run gRPC calls against each handler to confirm Unimplemented is gone
+5. **Monitor**: Check Prometheus metrics for `execute_withdrawal`,
    `update_withdrawal`, `retrieve_withdrawal` operation durations
 
 ---
 
 ## Risk Assessment
 
-- **Low risk**: The Go code already exists and is wired. The only gap is the database migration.
+- **Low risk**: Repository code already exists and is wired. The gaps are the
+  database migration and removing dead-code nil guards.
 - **No breaking changes**: Adding a table is an additive operation.
 - **Graceful degradation preserved**: If migration is not applied, the nil guard behavior continues (no worse than today).
 

--- a/docs/prd/internal-bank-account-position-keeping-client.md
+++ b/docs/prd/internal-bank-account-position-keeping-client.md
@@ -1,0 +1,253 @@
+---
+name: prd-internal-bank-account-position-keeping-client
+description: Wire Position Keeping client in internal-bank-account service to enable balance retrieval via GetBalance RPC
+triggers:
+  - Working on internal-bank-account balance queries
+  - Fixing Unimplemented gRPC response for GetBalance
+  - Integrating Internal Bank Account with Position Keeping
+instructions: |
+  The internal-bank-account service has a GetBalance RPC that returns codes.Unimplemented
+  when positionKeepingClient == nil. The client adapter, interface, and even the wiring in
+  cmd/main.go all exist. The issue is that the Position Keeping client is passed to the
+  service constructor but the GetBalance handler guards on nil because the client might
+  not connect successfully at startup.
+
+  Key files:
+  - services/internal-bank-account/adapters/grpc/position_keeping_client.go (client adapter)
+  - services/internal-bank-account/service/client_interfaces.go (interface definition)
+  - services/internal-bank-account/service/server.go (handler at line 573)
+  - services/internal-bank-account/cmd/main.go (wiring at line 320-323)
+---
+
+# PRD: Internal Bank Account - Position Keeping Client Wiring
+
+**Status:** Draft
+**Version:** 1.0
+**Date:** 2026-02-10
+**Author:** Architecture Team
+**Task Master Tag:** TBD
+
+**ADRs:**
+
+- [0002 - Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
+- [0015 - Standard Service Directory Structure](../adr/0015-standard-service-directory-structure.md)
+
+**Related PRDs:**
+
+- [Internal Bank Account Service](internal-bank-account.md) -
+  Parent service PRD (FR-3: Balance Retrieval via Position Keeping)
+- [Reconciliation gRPC Wiring](reconciliation-grpc-wiring.md) -
+  Appendix: Cross-Service Unimplemented RPC Audit (source of this work)
+
+---
+
+## Problem Statement
+
+The `GetBalance` RPC in the internal-bank-account service returns `codes.Unimplemented` when `positionKeepingClient == nil`:
+
+| Handler | File | Line | Error Message |
+|---------|------|------|---------------|
+| `GetBalance` | `service/server.go` | 594-596 | "position keeping service not configured" |
+
+**Severity:** Medium - Balance retrieval is non-functional without Position Keeping
+integration. This is a core requirement (FR-3 in the Internal Bank Account PRD)
+because Position Keeping is the single source of truth for all account balance data.
+
+---
+
+## Root Cause Analysis
+
+The client adapter and wiring already exist but the connection can fail at startup:
+
+### What Exists
+
+**1. Client Interface** (`service/client_interfaces.go`):
+
+<!-- markdownlint-disable MD013 -->
+
+```go
+type PositionKeepingClient interface {
+    GetAccountBalances(ctx context.Context, req *positionkeepingv1.GetAccountBalancesRequest) (*positionkeepingv1.GetAccountBalancesResponse, error)
+    GetAccountBalance(ctx context.Context, req *positionkeepingv1.GetAccountBalanceRequest) (*positionkeepingv1.GetAccountBalanceResponse, error)
+    Close() error
+}
+```
+
+<!-- markdownlint-enable MD013 -->
+
+**2. gRPC Client Adapter** (`adapters/grpc/position_keeping_client.go`):
+
+Full implementation with DNS-based service discovery, round-robin load balancing,
+retry logic with exponential backoff, correlation ID and organization context
+propagation, and observability metrics. 305 lines of production-ready code.
+
+**3. Main Wiring** (`cmd/main.go:301-323`):
+
+```go
+posKeepingClient, posKeepingCleanup, err := poskeepingclient.New(poskeepingclient.Config{...})
+// ...
+svc, err := service.NewServiceWithClients(
+    repo,
+    posKeepingClient, // *poskeepingclient.Client implements service.PositionKeepingClient
+    nil,              // referenceDataClient - not wired yet (future task)
+    logger,
+    tracer,
+)
+```
+
+**4. Handler Implementation** (`service/server.go:573-619`):
+
+The `GetBalance` handler is fully implemented: it validates account existence, checks
+account is active, queries Position Keeping via `GetAccountBalances`, extracts the
+CURRENT balance type from the response, and maps it to the proto response. The only
+guard is the nil check at line 594.
+
+### What is Actually Wrong
+
+The Position Keeping client is created using `poskeepingclient.New()` which calls
+`poskeepingclient.Config` with the standard `position-keeping` service name. In
+`cmd/main.go` line 301-316, this client is created and if it succeeds, it is passed
+to `service.NewServiceWithClients`. The nil guard in `GetBalance` exists as a
+defensive pattern.
+
+**The actual gap** is that in environments where Position Keeping is not deployed or
+not reachable at startup, the client creation succeeds (gRPC connections are lazy)
+but the nil guard remains as a safety pattern. The handler works correctly when
+Position Keeping is reachable.
+
+The remaining work is:
+
+1. Ensure Position Keeping is deployed alongside internal-bank-account in all environments
+2. Add integration tests that verify the GetBalance flow end-to-end
+3. Consider removing the nil guard and letting the gRPC call fail naturally with
+   a descriptive error (since the client is always non-nil after successful creation)
+
+---
+
+## Technical Design
+
+### Architecture
+
+```mermaid
+graph LR
+    A[gRPC Client] --> B[GetBalance Handler<br/>server.go:573]
+    B --> C{positionKeepingClient<br/>== nil?}
+    C -->|nil| D[codes.Unimplemented]
+    C -->|non-nil| E[PositionKeepingGRPCClient<br/>adapters/grpc/]
+    E --> F[Position Keeping Service<br/>:50053]
+    F --> G[GetAccountBalances RPC]
+    G --> H[Pre-computed Balance<br/>O&#40;1&#41; lookup]
+```
+
+### Handler Flow (server.go:573-619)
+
+1. Validate account exists and is ACTIVE
+2. Check `positionKeepingClient != nil` (the nil guard)
+3. Call `positionKeepingClient.GetAccountBalances` with account ID and instrument code
+4. Extract `BALANCE_TYPE_CURRENT` from response
+5. Map to `GetBalanceResponse` with `InstrumentAmount` and `as_of` timestamp
+
+### Files to Modify
+
+**Modified files:**
+
+- `services/internal-bank-account/service/server.go` - Consider replacing nil guard
+  with descriptive error from gRPC call failure (optional, defensive pattern is
+  acceptable)
+
+**New files:**
+
+- `services/internal-bank-account/service/server_balance_test.go` - Integration test for GetBalance flow
+
+**Deployment:**
+
+- Ensure Position Keeping service is deployed in all environments where internal-bank-account runs
+- Kubernetes deployment should declare Position Keeping as a dependency (readiness probe)
+
+### Service Dependency
+
+The `cmd/main.go` already creates the Position Keeping client at startup
+(line 301-316). The health checker at line 125-132 also monitors Position Keeping
+connectivity:
+
+```go
+healthChecker, err := service.NewHealthChecker(service.HealthCheckerConfig{
+    PositionKeepingClient:       svcClients.positionKeeping,
+    PositionKeepingHealthClient: svcClients.positionKeepingHealth,
+    // ...
+})
+```
+
+This means the service already reports unhealthy when Position Keeping is unreachable.
+
+---
+
+## Implementation Tasks
+
+| Task ID | Description | Story Points |
+|---------|-------------|-------------|
+| IBA-PK-001 | Verify GetBalance works end-to-end in local development (Tilt) | 1 |
+| IBA-PK-002 | Write integration test for GetBalance with mocked Position Keeping | 1 |
+| IBA-PK-003 | Update Kubernetes manifests to ensure Position Keeping dependency | 1 |
+
+### Total: 3 Story Points
+
+The implementation is small because all Go code already exists. The gap is
+operational (ensuring Position Keeping is deployed alongside this service) and
+test coverage.
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- Mock `PositionKeepingClient` interface
+- Test `GetBalance` handler returns correct balance when client returns data
+- Test `GetBalance` handler maps `BALANCE_TYPE_CURRENT` correctly
+- Test `GetBalance` returns appropriate error when account is not ACTIVE
+- Test `GetBalance` returns `NotFound` when account does not exist
+
+### Integration Tests
+
+- Start both internal-bank-account and position-keeping in testcontainers
+- Create an internal account, record a transaction via Financial Accounting, then call `GetBalance`
+- Verify balance amount and instrument code match
+
+### Error Scenarios
+
+- Position Keeping returns `NotFound` (no position for account/instrument)
+- Position Keeping is temporarily unavailable (verify retry behavior)
+- Position Keeping returns no `BALANCE_TYPE_CURRENT` entry
+
+---
+
+## Success Criteria
+
+- [ ] `GetBalance` RPC returns balance data (not Unimplemented) when Position Keeping is reachable
+- [ ] Balance amount matches what Position Keeping reports for the account/instrument
+- [ ] `as_of` timestamp is populated from Position Keeping response
+- [ ] Health check reports Position Keeping dependency status
+- [ ] Integration tests pass in CI
+
+---
+
+## Rollout Plan
+
+1. **Verify in Tilt**: Run both services locally, call `GetBalance` via grpcurl
+2. **Deploy to staging**: Ensure Position Keeping is deployed first
+3. **Smoke test**: Call `GetBalance` for a known internal account with a recorded position
+4. **Monitor**: Check Prometheus metrics for `get_account_balances` operation
+   duration and `position_keeping_error` rate
+
+---
+
+## Risk Assessment
+
+- **Low risk**: All code exists. The gap is deployment and test coverage.
+- **No code changes required**: The nil guard is a defensive pattern, not a bug.
+  Position Keeping client is already wired.
+- **Dependency risk**: If Position Keeping is not deployed, `GetBalance` returns
+  Unimplemented (same as today). The health check already surfaces this.
+
+<!-- End of PRD -->

--- a/docs/prd/party-kyc-aml-provider-integration.md
+++ b/docs/prd/party-kyc-aml-provider-integration.md
@@ -230,6 +230,21 @@ sequenceDiagram
     P-->>C: status=APPROVED/REJECTED
 ```
 
+#### Webhook Implementation Concerns
+
+The webhook handler (KYC-003) must address:
+
+- **Signature verification**: Validate webhook authenticity using
+  `KYC_WEBHOOK_SECRET` (HMAC-SHA256 or provider-specific scheme)
+- **Idempotency**: Detect and ignore duplicate webhook deliveries using
+  the provider's event ID as deduplication key
+- **Correlation**: Map webhook payload `check_id` back to the party
+  record using the `verification_id` stored during initiation
+- **Timeout handling**: Background job to poll for stuck verifications
+  that never received a webhook (configurable timeout, e.g., 24 hours)
+- **Out-of-order delivery**: Use status FSM to handle webhooks arriving
+  in unexpected order (e.g., ignore "in_progress" after "completed")
+
 ### Handler Refactoring
 
 The `ExchangeDemographics` handler needs to be refactored to use the `Provider`
@@ -290,13 +305,16 @@ KYC_BASE_URL: "https://api.onfido.com/v3.6"  # Provider API base URL
 | KYC-006 | Write unit tests with recorded HTTP responses | 2 |
 | KYC-007 | Write integration tests (mock provider with async mode) | 1 |
 
-### Total: 5 Story Points
+### Story Point Summary
 
-Excluding vendor selection decision, counting only tasks KYC-002 through
-KYC-005 as the core implementation.
+| Scope | Tasks | Story Points |
+|-------|-------|-------------|
+| Core implementation | KYC-002 through KYC-005 | 5 |
+| Test coverage | KYC-006 through KYC-007 | 3 |
+| **Grand total** | | **8** |
 
-Note: KYC-006 and KYC-007 add 3 SP for test coverage. KYC-001 is a decision
-gate that must be resolved before implementation.
+KYC-001 (vendor selection) is a decision gate with no story points that must
+be resolved before implementation begins.
 
 ---
 

--- a/docs/prd/party-kyc-aml-provider-integration.md
+++ b/docs/prd/party-kyc-aml-provider-integration.md
@@ -1,0 +1,398 @@
+---
+name: prd-party-kyc-aml-provider-integration
+description: Implement external KYC/AML provider integration for the party service ExchangeDemographics RPC
+triggers:
+  - Working on party KYC/AML verification
+  - Implementing external identity verification provider (Onfido, Jumio)
+  - Fixing Unimplemented gRPC response for ExchangeDemographics in production
+  - Onboarding parties in production environments
+instructions: |
+  The party service ExchangeDemographics RPC returns codes.Unimplemented in production
+  when no external KYC/AML provider is configured. This is an intentional production
+  safety guard - the service refuses to auto-approve verifications without a real provider.
+
+  The verification framework exists (provider interface, mock provider, factory) but
+  no real provider adapter has been implemented. This PRD covers integrating an external
+  KYC/AML provider (e.g., Onfido, Jumio) to enable production party onboarding.
+
+  Key files:
+  - services/party/verification/provider.go (Provider interface)
+  - services/party/verification/mock_provider.go (test/dev implementation)
+  - services/party/verification/factory.go (provider factory)
+  - services/party/service/grpc_service.go (handler at line 696-746)
+---
+
+# PRD: Party Service - KYC/AML Provider Integration
+
+**Status:** Draft
+**Version:** 1.0
+**Date:** 2026-02-10
+**Author:** Architecture Team
+**Task Master Tag:** TBD
+
+**ADRs:**
+
+- [0002 - Microservices Per BIAN Domain](../adr/0002-microservices-per-bian-domain.md)
+- [0015 - Standard Service Directory Structure](../adr/0015-standard-service-directory-structure.md)
+
+**Related PRDs:**
+
+- [Reconciliation gRPC Wiring](reconciliation-grpc-wiring.md) -
+  Appendix: Cross-Service Unimplemented RPC Audit (source of this work)
+
+---
+
+## Problem Statement
+
+The `ExchangeDemographics` RPC in the party service returns
+`codes.Unimplemented` in production environments without an external KYC/AML
+provider:
+
+<!-- markdownlint-disable MD013 -->
+
+| Handler | File | Line |
+|---------|------|------|
+| `ExchangeDemographics` | `service/grpc_service.go` | 711-713 |
+
+<!-- markdownlint-enable MD013 -->
+
+**Condition:** `ENVIRONMENT=production` AND `KYC_STUB_ENABLED != true`
+
+**Error:** "KYC/AML verification not implemented - cannot operate in production
+without external provider integration"
+
+**Severity:** Medium - By design. This is an intentional production safety guard, not a bug.
+
+### Current Behavior Matrix
+
+| Environment | `KYC_STUB_ENABLED` | Behavior |
+|-------------|-------------------|----------|
+| production | unset / false | `codes.Unimplemented` - refuses to auto-approve |
+| production | true | Returns VERIFIED (stub) with warning log |
+| non-production | any | Returns VERIFIED (stub) |
+
+The guard ensures Meridian cannot operate in production with auto-approved verifications, which would be a regulatory violation.
+
+---
+
+## Root Cause Analysis
+
+### What Exists
+
+**1. Provider Interface** (`verification/provider.go`):
+
+```go
+type Provider interface {
+    VerifyIdentity(ctx context.Context, party *domain.Party) (Result, error)
+    CheckSanctions(ctx context.Context, party *domain.Party) (SanctionsResult, error)
+    GetVerificationStatus(ctx context.Context, verificationID string) (Result, error)
+}
+```
+
+The `Result` type supports:
+
+- `Status`: PENDING, APPROVED, REJECTED, MANUAL_REVIEW
+- `RiskScore`: 0.0 to 1.0
+- `VerificationID`: Unique ID for async tracking
+- `Metadata`: Provider-specific key-value data
+
+The `SanctionsResult` type supports:
+
+- `Status`: CLEAR, MATCH, PENDING, ERROR
+- `Matches`: List of `SanctionsMatch` with list name, matched name, confidence score
+
+**2. Mock Provider** (`verification/mock_provider.go`):
+
+Full implementation supporting:
+
+- Synchronous mode (immediate approve/reject)
+- Asynchronous mode (returns PENDING, resolves on subsequent status check)
+- Configurable simulated delay
+- Deterministic verification IDs for test reproducibility
+- Sanctions screening simulation
+
+**3. Factory** (`verification/factory.go`):
+
+```go
+func NewProvider(cfg *config.VerificationConfig) (Provider, error) {
+    switch provider {
+    case "mock":
+        return NewMockProvider().WithAlwaysApprove(true), nil
+    case "jumio":
+        return nil, ErrUnsupportedProvider  // Stub
+    case "onfido":
+        return nil, ErrUnsupportedProvider  // Stub
+    default:
+        return nil, ErrUnsupportedProvider
+    }
+}
+```
+
+**4. Handler** (`service/grpc_service.go:696-746`):
+
+The `ExchangeDemographics` handler currently:
+
+1. Validates party exists
+2. Checks production safety guard (environment + KYC_STUB_ENABLED)
+3. Returns hardcoded "VERIFIED" status
+
+The handler does NOT use the `Provider` interface. It bypasses the verification
+framework entirely with a hardcoded stub response.
+
+### What is Missing
+
+1. **External provider adapter**: No implementation of `Provider` for Onfido, Jumio, or any real KYC service
+2. **Handler-to-provider wiring**: `ExchangeDemographics` does not call `Provider.VerifyIdentity()`
+3. **Vendor selection**: No vendor has been chosen for production KYC/AML
+4. **Webhook handling**: External providers use async webhooks for verification results; no webhook endpoint exists
+5. **Credential management**: No configuration for provider API keys, webhook secrets, etc.
+
+---
+
+## Technical Design
+
+### Architecture
+
+```mermaid
+graph TD
+    A[gRPC Client] --> B[ExchangeDemographics<br/>grpc_service.go:696]
+    B --> C{Provider<br/>configured?}
+    C -->|No / Mock| D[Stub Response<br/>VERIFIED]
+    C -->|Yes| E[External Provider<br/>Adapter]
+    E --> F[Onfido / Jumio API]
+    F -->|Async webhook| G[Webhook Handler<br/>HTTP endpoint]
+    G --> H[Update Party<br/>Verification Status]
+
+    subgraph Existing Code
+        I[verification/provider.go<br/>Provider Interface]
+        J[verification/mock_provider.go<br/>Mock Implementation]
+        K[verification/factory.go<br/>Provider Factory]
+    end
+
+    E --> I
+    J --> I
+```
+
+### Provider Adapter Design
+
+A real KYC provider adapter must implement the `Provider` interface:
+
+```go
+// verification/onfido_provider.go (example)
+type OnfidoProvider struct {
+    apiKey    string
+    baseURL   string
+    client    *http.Client
+    logger    *slog.Logger
+}
+
+func (p *OnfidoProvider) VerifyIdentity(ctx context.Context, party *domain.Party) (Result, error) {
+    // 1. Create applicant in Onfido
+    // 2. Create identity check
+    // 3. Return PENDING with verification ID
+    // 4. Onfido will call our webhook when complete
+}
+
+func (p *OnfidoProvider) CheckSanctions(ctx context.Context, party *domain.Party) (SanctionsResult, error) {
+    // 1. Submit watchlist screening request
+    // 2. Return immediate result (synchronous check)
+}
+
+func (p *OnfidoProvider) GetVerificationStatus(ctx context.Context, verificationID string) (Result, error) {
+    // 1. Query Onfido check status
+    // 2. Map to Result type
+}
+```
+
+### Webhook Handling
+
+External KYC providers operate asynchronously. The verification flow is:
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant P as Party Service
+    participant K as KYC Provider
+    participant W as Webhook Handler
+
+    C->>P: ExchangeDemographics(party_id)
+    P->>K: Create verification check
+    K-->>P: check_id (PENDING)
+    P-->>C: status=PENDING, verification_id
+
+    Note over K,W: Async processing (seconds to days)
+
+    K->>W: Webhook: check completed
+    W->>P: Update party verification status
+    P->>P: Store result in database
+
+    C->>P: GetVerificationStatus(verification_id)
+    P-->>C: status=APPROVED/REJECTED
+```
+
+### Handler Refactoring
+
+The `ExchangeDemographics` handler needs to be refactored to use the `Provider`
+interface instead of hardcoded stub logic:
+
+<!-- markdownlint-disable MD013 -->
+
+```go
+func (s *Service) ExchangeDemographics(ctx context.Context, req *pb.ExchangeDemographicsRequest) (*pb.ExchangeDemographicsResponse, error) {
+    // 1. Validate party exists (already implemented)
+    // 2. Call s.verificationProvider.VerifyIdentity(ctx, party)
+    // 3. Call s.verificationProvider.CheckSanctions(ctx, party)
+    // 4. Map Result to ExchangeDemographicsResponse
+    // 5. Return verification status (PENDING for async, VERIFIED for sync)
+}
+```
+
+<!-- markdownlint-enable MD013 -->
+
+### Configuration
+
+```yaml
+# Environment variables for KYC provider configuration
+KYC_PROVIDER: "onfido"              # Provider name (mock, onfido, jumio)
+KYC_API_KEY: "live_xxxxx"           # Provider API key (from secret)
+KYC_WEBHOOK_SECRET: "whsec_xxxxx"  # Webhook signature verification
+KYC_BASE_URL: "https://api.onfido.com/v3.6"  # Provider API base URL
+```
+
+### Files to Create
+
+| File | Description |
+|------|-------------|
+| `services/party/verification/<provider>_provider.go` | Provider adapter (e.g., `onfido_provider.go`) |
+| `services/party/verification/<provider>_provider_test.go` | Unit tests with recorded HTTP responses |
+| `services/party/service/webhook_handler.go` | HTTP webhook endpoint for async verification results |
+| `services/party/config/verification.go` | (may need extension for provider-specific config) |
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `services/party/verification/factory.go` | Add real provider to factory switch statement |
+| `services/party/service/grpc_service.go` | Refactor `ExchangeDemographics` to use `Provider` interface |
+| `services/party/cmd/main.go` | Wire provider from config, add webhook HTTP handler |
+
+---
+
+## Implementation Tasks
+
+| Task ID | Description | Story Points |
+|---------|-------------|-------------|
+| KYC-001 | Select KYC/AML vendor (Onfido, Jumio, or alternative) | 0 (decision) |
+| KYC-002 | Implement provider adapter for selected vendor | 3 |
+| KYC-003 | Implement webhook handler for async verification results | 2 |
+| KYC-004 | Refactor `ExchangeDemographics` handler to use `Provider` interface | 1 |
+| KYC-005 | Wire provider in `cmd/main.go` and factory | 1 |
+| KYC-006 | Write unit tests with recorded HTTP responses | 2 |
+| KYC-007 | Write integration tests (mock provider with async mode) | 1 |
+
+### Total: 5 Story Points
+
+Excluding vendor selection decision, counting only tasks KYC-002 through
+KYC-005 as the core implementation.
+
+Note: KYC-006 and KYC-007 add 3 SP for test coverage. KYC-001 is a decision
+gate that must be resolved before implementation.
+
+---
+
+## Vendor Evaluation Criteria
+
+The vendor selection (KYC-001) should consider:
+
+| Criteria | Weight | Notes |
+|----------|--------|-------|
+| API quality and documentation | High | RESTful, well-documented, sandbox environment |
+| Webhook support | Required | Async verification results must be delivered via webhook |
+| Sanctions screening | Required | Must support global watchlist screening |
+| Geographic coverage | High | UK/EU compliance (GDPR, PSD2, AML5D) |
+| Pricing | Medium | Per-check pricing model |
+| SDK availability | Low | Go SDK preferred but HTTP client is sufficient |
+
+### Candidate Providers
+
+| Provider | Strengths | Considerations |
+|----------|-----------|----------------|
+| **Onfido** | Strong identity verification, good EU coverage, well-documented API | Higher per-check cost |
+| **Jumio** | Document + biometric verification, good compliance coverage | More complex integration |
+| **Sumsub** | All-in-one compliance platform, flexible pricing | Less established in UK market |
+| **Sardine** | Fraud + KYC combined, real-time risk scoring | Newer entrant |
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+
+- Test provider adapter with recorded HTTP responses (no live API calls)
+- Test webhook signature verification
+- Test `Result` and `SanctionsResult` validation
+- Test factory creates correct provider type
+
+### Integration Tests
+
+- Use `MockProvider` with `AsyncMode=true` to simulate full async flow
+- Test webhook handler receives and processes verification callbacks
+- Test party status transitions through verification lifecycle
+
+### End-to-End Tests
+
+- Test full party onboarding flow: register party, initiate verification, receive webhook, verify status
+- Use provider sandbox environment for staging tests
+
+---
+
+## Success Criteria
+
+- [ ] `ExchangeDemographics` in production does not return `codes.Unimplemented` when provider is configured
+- [ ] Verification results are persisted and retrievable via `GetVerificationStatus`
+- [ ] Sanctions screening returns CLEAR/MATCH with confidence scores
+- [ ] Webhook handler processes async verification results correctly
+- [ ] Mock provider continues to work in development/test environments
+- [ ] Production safety guard remains active when no provider is configured
+
+---
+
+## Rollout Plan
+
+1. **Vendor selection**: Choose KYC provider based on evaluation criteria
+2. **Sandbox integration**: Implement and test against provider sandbox
+3. **Staging deployment**: Deploy with real provider credentials in staging
+4. **Production rollout**: Enable for production with gradual traffic shift
+5. **Monitor**: Track verification latency, approval rate, sanctions match rate
+
+### Rollback Strategy
+
+If the external provider is unavailable or experiencing issues:
+
+- Set `KYC_STUB_ENABLED=true` temporarily to allow party onboarding
+- Log all stub verifications for manual review when provider recovers
+- This maintains the production safety guard principle (explicit opt-in to stub mode)
+
+---
+
+## Risk Assessment
+
+- **Medium risk**: External provider dependency introduces a new failure mode for party onboarding
+- **Regulatory requirement**: Cannot ship production without real KYC/AML (this is the reason for the Unimplemented guard)
+- **Vendor lock-in**: The `Provider` interface abstracts the provider, making vendor switching straightforward
+- **Async complexity**: Webhook-based verification adds state management complexity (pending verifications, timeout handling)
+- **Data privacy**: KYC data (identity documents, biometrics) must be handled per GDPR requirements; consider data residency
+
+---
+
+## Design Decisions
+
+| # | Decision | Resolution | Rationale |
+|---|----------|-----------|-----------|
+| 1 | Vendor selection | **Deferred** | Requires business input on budget and compliance requirements |
+| 2 | Sync vs async verification | **Async** | Real KYC checks take seconds to days; sync would block party onboarding |
+| 3 | Store verification results locally? | **Yes** | Party service needs verification status for account opening decisions |
+| 4 | Webhook vs polling for results? | **Webhook** | Lower latency, less infrastructure cost than polling |
+| 5 | Remove production guard after implementation? | **No** | Keep guard as fallback; only remove the Unimplemented response when provider is configured |
+
+<!-- End of PRD -->


### PR DESCRIPTION
## Summary

- Add 3 focused PRDs documenting wiring work for unimplemented gRPC handlers
  identified in the reconciliation-grpc-wiring.md audit appendix
- Each PRD covers a different service with accurate file references, root cause
  analysis, technical design, and implementation tasks

## Changes Made

### current-account-withdrawal-persistence.md (3 SP)

3 withdrawal handlers (`UpdateWithdrawal`, `RetrieveWithdrawal`, `ExecuteWithdrawal`)
return `codes.Unimplemented` when `withdrawalRepo == nil`. The repository code already
exists and is wired in `cmd/main.go`; the gap is a database migration for the
`withdrawal` table.

### internal-bank-account-position-keeping-client.md (3 SP)

`GetBalance` returns `codes.Unimplemented` when `positionKeepingClient == nil`. The
client adapter, interface, and main.go wiring all exist. The gap is operational
(ensuring Position Keeping is deployed alongside the service) and test coverage.

### party-kyc-aml-provider-integration.md (5 SP)

`ExchangeDemographics` returns `codes.Unimplemented` in production without an external
KYC/AML provider. This is an intentional safety guard. The Provider interface and mock
implementation exist but no real vendor adapter has been implemented. Requires vendor
selection before implementation.

## Task Master

Task: reconciliation-service.24

## Test plan

- [ ] All 3 PRDs pass markdownlint (verified locally)
- [ ] YAML front matter follows established format from existing PRDs
- [ ] File references and line numbers verified against current codebase