### PR TITLE
feat: Register UTILIZATION_* dataset definitions in MDS

### DIFF
--- a/services/market-information/domain/data_category.go
+++ b/services/market-information/domain/data_category.go
@@ -14,12 +14,17 @@ const (
 	// DataCategoryContextual indicates the dataset contains contextual/reference data.
 	// Contextual data provides supporting information for pricing data.
 	DataCategoryContextual DataCategory = "CONTEXTUAL"
+
+	// DataCategoryUtilization indicates the dataset contains platform utilization metrics.
+	// Utilization data tracks resource consumption (transactions, API calls, storage, compute, network).
+	DataCategoryUtilization DataCategory = "UTILIZATION"
 )
 
 // validDataCategories contains all valid data categories for efficient lookup.
 var validDataCategories = map[DataCategory]bool{
-	DataCategoryPricing:    true,
-	DataCategoryContextual: true,
+	DataCategoryPricing:     true,
+	DataCategoryContextual:  true,
+	DataCategoryUtilization: true,
 }
 
 // IsValid returns true if the data category is a recognized valid type.

--- a/services/market-information/e2e/e2e_test.go
+++ b/services/market-information/e2e/e2e_test.go
@@ -1092,6 +1092,437 @@ func TestE2E_AsyncOperationsWithAwait(t *testing.T) {
 }
 
 // ============================================================================
+// E2E Test: UTILIZATION_* Dataset Definitions
+// ============================================================================
+
+// utilizationDatasetCodes lists all expected UTILIZATION_* dataset codes.
+var utilizationDatasetCodes = []string{
+	"UTILIZATION_TRANSACTION",
+	"UTILIZATION_API_CALL",
+	"UTILIZATION_STORAGE_GB",
+	"UTILIZATION_COMPUTE_HOUR",
+	"UTILIZATION_NETWORK_GB",
+}
+
+// utilizationDatasetExpectation defines expected properties for each utilization dataset.
+type utilizationDatasetExpectation struct {
+	code                    string
+	name                    string
+	validationExpression    string
+	resolutionKeyExpression string
+	dataCategory            string
+}
+
+var utilizationExpectations = []utilizationDatasetExpectation{
+	{
+		code:                    "UTILIZATION_TRANSACTION",
+		name:                    "Platform Transaction Usage",
+		validationExpression:    "numeric_value >= 0 && numeric_value < 1000000000000",
+		resolutionKeyExpression: `^tenant/[^/]+/transaction/[^/]+$`,
+		dataCategory:            "UTILIZATION",
+	},
+	{
+		code:                    "UTILIZATION_API_CALL",
+		name:                    "Platform API Call Usage",
+		validationExpression:    "numeric_value >= 0 && numeric_value < 1000000000000",
+		resolutionKeyExpression: `^tenant/[^/]+/api/[^/]+/[^/]+$`,
+		dataCategory:            "UTILIZATION",
+	},
+	{
+		code:                    "UTILIZATION_STORAGE_GB",
+		name:                    "Platform Storage Usage",
+		validationExpression:    "numeric_value >= 0 && numeric_value < 1000000000000",
+		resolutionKeyExpression: `^tenant/[^/]+/storage/[^/]+$`,
+		dataCategory:            "UTILIZATION",
+	},
+	{
+		code:                    "UTILIZATION_COMPUTE_HOUR",
+		name:                    "Platform Compute Usage",
+		validationExpression:    "numeric_value >= 0 && numeric_value < 1000000000000",
+		resolutionKeyExpression: `^tenant/[^/]+/compute/[^/]+$`,
+		dataCategory:            "UTILIZATION",
+	},
+	{
+		code:                    "UTILIZATION_NETWORK_GB",
+		name:                    "Platform Network Usage",
+		validationExpression:    "numeric_value >= 0 && numeric_value < 1000000000000",
+		resolutionKeyExpression: `^tenant/[^/]+/network/[^/]+$`,
+		dataCategory:            "UTILIZATION",
+	},
+}
+
+// seedUtilizationData seeds the UTILIZATION_* dataset definitions and PLATFORM_AUDIT_EVENTS
+// data source, simulating the 20260210000004_seed_utilization_datasets.sql migration.
+func seedUtilizationData(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Seed PLATFORM_AUDIT_EVENTS data source
+	_, err := pool.Exec(ctx, `
+		INSERT INTO data_source (id, code, name, description, trust_level, created_by, updated_by)
+		VALUES (gen_random_uuid(), 'PLATFORM_AUDIT_EVENTS', 'Platform Audit Events',
+			'Internal platform audit event stream for utilization metrics', 100, 'SYSTEM', 'SYSTEM')
+	`)
+	require.NoError(t, err, "Failed to seed PLATFORM_AUDIT_EVENTS data source")
+
+	// Seed UTILIZATION_* dataset definitions
+	utilizationDefs := []struct {
+		code, name, desc, resKeyExpr string
+	}{
+		{
+			"UTILIZATION_TRANSACTION", "Platform Transaction Usage",
+			"Tracks transaction counts per tenant and transaction type",
+			`^tenant/[^/]+/transaction/[^/]+$`,
+		},
+		{
+			"UTILIZATION_API_CALL", "Platform API Call Usage",
+			"Tracks API call counts per tenant, service, and endpoint",
+			`^tenant/[^/]+/api/[^/]+/[^/]+$`,
+		},
+		{
+			"UTILIZATION_STORAGE_GB", "Platform Storage Usage",
+			"Tracks storage consumption in gigabytes per tenant and storage class",
+			`^tenant/[^/]+/storage/[^/]+$`,
+		},
+		{
+			"UTILIZATION_COMPUTE_HOUR", "Platform Compute Usage",
+			"Tracks compute consumption in hours per tenant and compute resource type",
+			`^tenant/[^/]+/compute/[^/]+$`,
+		},
+		{
+			"UTILIZATION_NETWORK_GB", "Platform Network Usage",
+			"Tracks network transfer in gigabytes per tenant and network interface",
+			`^tenant/[^/]+/network/[^/]+$`,
+		},
+	}
+
+	for _, d := range utilizationDefs {
+		_, err := pool.Exec(ctx, `
+			INSERT INTO dataset_definition (
+				id, code, version, name, description, data_category,
+				validation_expression, resolution_key_expression, error_message_expression,
+				status, created_by, updated_by, activated_at
+			) VALUES (
+				gen_random_uuid(), $1, 1, $2, $3, 'UTILIZATION',
+				'numeric_value >= 0 && numeric_value < 1000000000000', $4,
+				'"Invalid utilization value: must be non-negative and less than 1 trillion"',
+				'ACTIVE', 'SYSTEM', 'SYSTEM', now()
+			)`, d.code, d.name, d.desc, d.resKeyExpr)
+		require.NoError(t, err, "Failed to seed dataset definition: %s", d.code)
+	}
+}
+
+// TestE2E_UtilizationDatasetDefinitions tests the UTILIZATION_* dataset definitions
+// seeded by migration, verifying retrieval, properties, and data category.
+func TestE2E_UtilizationDatasetDefinitions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := setupE2ETestPool(t)
+	ctx := setupTenantContext(t, "e2e_utilization_tenant")
+
+	// Seed utilization data (simulates migration)
+	seedUtilizationData(t, tc.pool)
+
+	t.Run("1. All UTILIZATION_* datasets are retrievable", func(t *testing.T) {
+		for _, expected := range utilizationExpectations {
+			dataset, err := tc.repos.DataSet.FindByCode(ctx, expected.code)
+			require.NoError(t, err, "Failed to retrieve dataset: %s", expected.code)
+
+			assert.Equal(t, expected.code, dataset.Code())
+			assert.Equal(t, expected.name, dataset.Name())
+			assert.Equal(t, domain.DataSetStatusActive, dataset.Status())
+			assert.NotNil(t, dataset.ActivatedAt(), "Dataset %s should be activated", expected.code)
+		}
+	})
+
+	t.Run("2. Datasets have correct validation expressions", func(t *testing.T) {
+		for _, expected := range utilizationExpectations {
+			dataset, err := tc.repos.DataSet.FindByCode(ctx, expected.code)
+			require.NoError(t, err)
+
+			assert.Equal(t, expected.validationExpression, dataset.ValidationExpression(),
+				"Validation expression mismatch for %s", expected.code)
+		}
+	})
+
+	t.Run("3. Datasets have correct resolution key patterns", func(t *testing.T) {
+		for _, expected := range utilizationExpectations {
+			dataset, err := tc.repos.DataSet.FindByCode(ctx, expected.code)
+			require.NoError(t, err)
+
+			assert.Equal(t, expected.resolutionKeyExpression, dataset.ResolutionKeyExpression(),
+				"Resolution key expression mismatch for %s", expected.code)
+		}
+	})
+
+	t.Run("4. Datasets have UTILIZATION data category", func(t *testing.T) {
+		for _, expected := range utilizationExpectations {
+			dataset, err := tc.repos.DataSet.FindByCode(ctx, expected.code)
+			require.NoError(t, err)
+
+			assert.Equal(t, domain.DataCategoryUtilization, dataset.DataCategory(),
+				"Data category mismatch for %s", expected.code)
+		}
+	})
+
+	t.Run("5. ListDataSets returns all utilization datasets", func(t *testing.T) {
+		utilizationCategory := domain.DataCategoryUtilization
+		filters := domain.DataSetFilters{
+			Category: &utilizationCategory,
+			Limit:    100,
+		}
+
+		datasets, _, err := tc.repos.DataSet.List(ctx, filters)
+		require.NoError(t, err)
+
+		assert.Len(t, datasets, 5,
+			"Expected 5 UTILIZATION datasets, got %d", len(datasets))
+
+		// Verify all expected codes are present
+		foundCodes := make(map[string]bool)
+		for _, ds := range datasets {
+			foundCodes[ds.Code()] = true
+		}
+		for _, code := range utilizationDatasetCodes {
+			assert.True(t, foundCodes[code], "Expected dataset %s in list results", code)
+		}
+	})
+}
+
+// TestE2E_PlatformAuditEventsDataSource tests the PLATFORM_AUDIT_EVENTS data source
+// seeded by migration, verifying trust level and properties.
+func TestE2E_PlatformAuditEventsDataSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := setupE2ETestPool(t)
+	ctx := setupTenantContext(t, "e2e_audit_events_tenant")
+
+	// Seed utilization data (includes PLATFORM_AUDIT_EVENTS)
+	seedUtilizationData(t, tc.pool)
+
+	t.Run("1. PLATFORM_AUDIT_EVENTS data source exists", func(t *testing.T) {
+		source, err := tc.repos.Source.FindByCode(ctx, "PLATFORM_AUDIT_EVENTS")
+		require.NoError(t, err, "PLATFORM_AUDIT_EVENTS data source should exist")
+
+		assert.Equal(t, "PLATFORM_AUDIT_EVENTS", source.Code())
+		assert.Equal(t, "Platform Audit Events", source.Name())
+	})
+
+	t.Run("2. PLATFORM_AUDIT_EVENTS has maximum trust level", func(t *testing.T) {
+		source, err := tc.repos.Source.FindByCode(ctx, "PLATFORM_AUDIT_EVENTS")
+		require.NoError(t, err)
+
+		assert.Equal(t, 100, source.TrustLevel(),
+			"PLATFORM_AUDIT_EVENTS should have trust level 100 (INTERNAL/highest)")
+	})
+}
+
+// TestE2E_UtilizationObservationRecording tests recording observations
+// against utilization datasets with proper resolution keys.
+func TestE2E_UtilizationObservationRecording(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := setupE2ETestPool(t)
+	ctx := setupTenantContext(t, "e2e_utilization_obs_tenant")
+
+	// Seed utilization data
+	seedUtilizationData(t, tc.pool)
+
+	t.Run("1. Record transaction utilization observation", func(t *testing.T) {
+		source, err := tc.repos.Source.FindByCode(ctx, "PLATFORM_AUDIT_EVENTS")
+		require.NoError(t, err)
+
+		now := time.Now().UTC()
+		obs := createTestObservation(t, ctx, tc.repos,
+			"UTILIZATION_TRANSACTION",
+			source.ID(),
+			"tenant/acme-corp/transaction/payment",
+			decimal.NewFromInt(42),
+			now, now, now.Add(time.Hour),
+			domain.QualityLevelActual,
+			source.TrustLevel(),
+		)
+
+		assert.Equal(t, "tenant/acme-corp/transaction/payment", obs.ResolutionKey())
+		assert.True(t, decimal.NewFromInt(42).Equal(obs.Value()))
+	})
+
+	t.Run("2. Record API call utilization observation", func(t *testing.T) {
+		source, err := tc.repos.Source.FindByCode(ctx, "PLATFORM_AUDIT_EVENTS")
+		require.NoError(t, err)
+
+		now := time.Now().UTC()
+		obs := createTestObservation(t, ctx, tc.repos,
+			"UTILIZATION_API_CALL",
+			source.ID(),
+			"tenant/acme-corp/api/market-info/list-datasets",
+			decimal.NewFromInt(1500),
+			now, now, now.Add(time.Hour),
+			domain.QualityLevelActual,
+			source.TrustLevel(),
+		)
+
+		assert.Equal(t, "tenant/acme-corp/api/market-info/list-datasets", obs.ResolutionKey())
+	})
+
+	t.Run("3. Record storage utilization observation", func(t *testing.T) {
+		source, err := tc.repos.Source.FindByCode(ctx, "PLATFORM_AUDIT_EVENTS")
+		require.NoError(t, err)
+
+		now := time.Now().UTC()
+		obs := createTestObservation(t, ctx, tc.repos,
+			"UTILIZATION_STORAGE_GB",
+			source.ID(),
+			"tenant/acme-corp/storage/hot-tier",
+			decimal.NewFromFloat(256.75),
+			now, now, now.Add(time.Hour),
+			domain.QualityLevelActual,
+			source.TrustLevel(),
+		)
+
+		assert.True(t, decimal.NewFromFloat(256.75).Equal(obs.Value()))
+	})
+
+	t.Run("4. Record compute utilization observation", func(t *testing.T) {
+		source, err := tc.repos.Source.FindByCode(ctx, "PLATFORM_AUDIT_EVENTS")
+		require.NoError(t, err)
+
+		now := time.Now().UTC()
+		obs := createTestObservation(t, ctx, tc.repos,
+			"UTILIZATION_COMPUTE_HOUR",
+			source.ID(),
+			"tenant/acme-corp/compute/gpu-v100",
+			decimal.NewFromFloat(8.5),
+			now, now, now.Add(time.Hour),
+			domain.QualityLevelActual,
+			source.TrustLevel(),
+		)
+
+		assert.True(t, decimal.NewFromFloat(8.5).Equal(obs.Value()))
+	})
+
+	t.Run("5. Record network utilization observation", func(t *testing.T) {
+		source, err := tc.repos.Source.FindByCode(ctx, "PLATFORM_AUDIT_EVENTS")
+		require.NoError(t, err)
+
+		now := time.Now().UTC()
+		obs := createTestObservation(t, ctx, tc.repos,
+			"UTILIZATION_NETWORK_GB",
+			source.ID(),
+			"tenant/acme-corp/network/egress",
+			decimal.NewFromFloat(12.3),
+			now, now, now.Add(time.Hour),
+			domain.QualityLevelActual,
+			source.TrustLevel(),
+		)
+
+		assert.True(t, decimal.NewFromFloat(12.3).Equal(obs.Value()))
+	})
+
+	t.Run("6. Query utilization observations by dataset", func(t *testing.T) {
+		query := domain.ObservationQuery{
+			DataSetCode: "UTILIZATION_TRANSACTION",
+		}
+
+		observations, _, err := tc.repos.Observation.Query(ctx, query)
+		require.NoError(t, err)
+
+		assert.Len(t, observations, 1)
+		assert.Equal(t, "tenant/acme-corp/transaction/payment", observations[0].ResolutionKey())
+	})
+
+	t.Run("7. Query utilization observations by resolution key", func(t *testing.T) {
+		resKey := "tenant/acme-corp/api/market-info/list-datasets"
+		query := domain.ObservationQuery{
+			DataSetCode:   "UTILIZATION_API_CALL",
+			ResolutionKey: &resKey,
+		}
+
+		observations, _, err := tc.repos.Observation.Query(ctx, query)
+		require.NoError(t, err)
+
+		assert.Len(t, observations, 1)
+		assert.True(t, decimal.NewFromInt(1500).Equal(observations[0].Value()))
+	})
+}
+
+// TestE2E_UtilizationMultiTenantIsolation verifies that utilization observations
+// from one tenant are not visible to another tenant.
+func TestE2E_UtilizationMultiTenantIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	tc := setupE2ETestPool(t)
+
+	ctxTenantA := setupTenantContext(t, "utilization_tenant_a")
+	ctxTenantB := setupTenantContext(t, "utilization_tenant_b")
+
+	// Seed utilization data
+	seedUtilizationData(t, tc.pool)
+
+	t.Run("Tenant A records utilization observation", func(t *testing.T) {
+		source, err := tc.repos.Source.FindByCode(ctxTenantA, "PLATFORM_AUDIT_EVENTS")
+		require.NoError(t, err)
+
+		now := time.Now().UTC()
+		createTestObservation(t, ctxTenantA, tc.repos,
+			"UTILIZATION_TRANSACTION",
+			source.ID(),
+			"tenant/tenant-a/transaction/payment",
+			decimal.NewFromInt(100),
+			now, now, now.Add(time.Hour),
+			domain.QualityLevelActual,
+			source.TrustLevel(),
+		)
+	})
+
+	t.Run("Tenant B records utilization observation", func(t *testing.T) {
+		source, err := tc.repos.Source.FindByCode(ctxTenantB, "PLATFORM_AUDIT_EVENTS")
+		require.NoError(t, err)
+
+		now := time.Now().UTC()
+		createTestObservation(t, ctxTenantB, tc.repos,
+			"UTILIZATION_TRANSACTION",
+			source.ID(),
+			"tenant/tenant-b/transaction/payment",
+			decimal.NewFromInt(200),
+			now, now, now.Add(time.Hour),
+			domain.QualityLevelActual,
+			source.TrustLevel(),
+		)
+	})
+
+	t.Run("Each tenant sees only their utilization data by resolution key", func(t *testing.T) {
+		resKeyA := "tenant/tenant-a/transaction/payment"
+		queryA := domain.ObservationQuery{
+			DataSetCode:   "UTILIZATION_TRANSACTION",
+			ResolutionKey: &resKeyA,
+		}
+		obsA, _, err := tc.repos.Observation.Query(ctxTenantA, queryA)
+		require.NoError(t, err)
+		assert.Len(t, obsA, 1)
+		assert.True(t, decimal.NewFromInt(100).Equal(obsA[0].Value()))
+
+		resKeyB := "tenant/tenant-b/transaction/payment"
+		queryB := domain.ObservationQuery{
+			DataSetCode:   "UTILIZATION_TRANSACTION",
+			ResolutionKey: &resKeyB,
+		}
+		obsB, _, err := tc.repos.Observation.Query(ctxTenantB, queryB)
+		require.NoError(t, err)
+		assert.Len(t, obsB, 1)
+		assert.True(t, decimal.NewFromInt(200).Equal(obsB[0].Value()))
+	})
+}
+
+// ============================================================================
 // Helper Functions
 // ============================================================================
 

--- a/services/market-information/migrations/20260210000004_seed_utilization_datasets.sql
+++ b/services/market-information/migrations/20260210000004_seed_utilization_datasets.sql
@@ -1,0 +1,129 @@
+-- Migration: Seed UTILIZATION_* Dataset Definitions and PLATFORM_AUDIT_EVENTS Data Source
+-- Registers platform utilization metric datasets for tracking resource consumption
+-- (transactions, API calls, storage, compute, network) per tenant.
+--
+-- Each dataset uses:
+--   - resolution_key_expression: Regex pattern validating hierarchical tenant keys
+--   - validation_expression: CEL expression constraining observation values
+--   - data_category: UTILIZATION (new category for platform usage metrics)
+
+--------------------------------------------------------------------------------
+-- Section 1: Register PLATFORM_AUDIT_EVENTS Data Source
+-- Internal platform source with highest trust level (100) for audit events
+--------------------------------------------------------------------------------
+
+INSERT INTO "data_source" ("id", "code", "name", "description", "trust_level", "created_by", "updated_by")
+VALUES (
+  gen_random_uuid(),
+  'PLATFORM_AUDIT_EVENTS',
+  'Platform Audit Events',
+  'Internal platform audit event stream for utilization metrics. Highest trust level as data originates from the platform itself.',
+  100,
+  'SYSTEM',
+  'SYSTEM'
+);
+
+--------------------------------------------------------------------------------
+-- Section 2: Register UTILIZATION_* Dataset Definitions
+-- All datasets created as ACTIVE with CEL validation and regex key patterns
+--------------------------------------------------------------------------------
+
+-- UTILIZATION_TRANSACTION: Tracks platform transaction counts per tenant and transaction type
+INSERT INTO "dataset_definition" (
+  "id", "code", "version", "name", "description", "data_category",
+  "validation_expression", "resolution_key_expression", "error_message_expression",
+  "attribute_schema", "status", "created_by", "updated_by", "activated_at"
+) VALUES (
+  gen_random_uuid(),
+  'UTILIZATION_TRANSACTION', 1,
+  'Platform Transaction Usage',
+  'Tracks transaction counts per tenant and transaction type for usage-based billing and capacity planning',
+  'UTILIZATION',
+  'numeric_value >= 0 && numeric_value < 1000000000000',
+  '^tenant/[^/]+/transaction/[^/]+$',
+  '"Invalid transaction count: must be non-negative and less than 1 trillion"',
+  '{"type":"object","properties":{"tenant_id":{"type":"string"},"transaction_type":{"type":"string"},"count":{"type":"number","minimum":0}},"required":["tenant_id","transaction_type","count"]}',
+  'ACTIVE',
+  'SYSTEM', 'SYSTEM',
+  now()
+);
+
+-- UTILIZATION_API_CALL: Tracks API call counts per tenant, service, and endpoint
+INSERT INTO "dataset_definition" (
+  "id", "code", "version", "name", "description", "data_category",
+  "validation_expression", "resolution_key_expression", "error_message_expression",
+  "attribute_schema", "status", "created_by", "updated_by", "activated_at"
+) VALUES (
+  gen_random_uuid(),
+  'UTILIZATION_API_CALL', 1,
+  'Platform API Call Usage',
+  'Tracks API call counts per tenant, service, and endpoint for rate limiting and billing',
+  'UTILIZATION',
+  'numeric_value >= 0 && numeric_value < 1000000000000',
+  '^tenant/[^/]+/api/[^/]+/[^/]+$',
+  '"Invalid API call count: must be non-negative and less than 1 trillion"',
+  '{"type":"object","properties":{"tenant_id":{"type":"string"},"service":{"type":"string"},"endpoint":{"type":"string"},"count":{"type":"number","minimum":0}},"required":["tenant_id","service","endpoint","count"]}',
+  'ACTIVE',
+  'SYSTEM', 'SYSTEM',
+  now()
+);
+
+-- UTILIZATION_STORAGE_GB: Tracks storage consumption per tenant and storage class
+INSERT INTO "dataset_definition" (
+  "id", "code", "version", "name", "description", "data_category",
+  "validation_expression", "resolution_key_expression", "error_message_expression",
+  "attribute_schema", "status", "created_by", "updated_by", "activated_at"
+) VALUES (
+  gen_random_uuid(),
+  'UTILIZATION_STORAGE_GB', 1,
+  'Platform Storage Usage',
+  'Tracks storage consumption in gigabytes per tenant and storage class',
+  'UTILIZATION',
+  'numeric_value >= 0 && numeric_value < 1000000000000',
+  '^tenant/[^/]+/storage/[^/]+$',
+  '"Invalid storage value: must be non-negative and less than 1 trillion GB"',
+  '{"type":"object","properties":{"tenant_id":{"type":"string"},"storage_class":{"type":"string"},"gb":{"type":"number","minimum":0}},"required":["tenant_id","storage_class","gb"]}',
+  'ACTIVE',
+  'SYSTEM', 'SYSTEM',
+  now()
+);
+
+-- UTILIZATION_COMPUTE_HOUR: Tracks compute usage per tenant and compute resource type
+INSERT INTO "dataset_definition" (
+  "id", "code", "version", "name", "description", "data_category",
+  "validation_expression", "resolution_key_expression", "error_message_expression",
+  "attribute_schema", "status", "created_by", "updated_by", "activated_at"
+) VALUES (
+  gen_random_uuid(),
+  'UTILIZATION_COMPUTE_HOUR', 1,
+  'Platform Compute Usage',
+  'Tracks compute consumption in hours per tenant and compute resource type',
+  'UTILIZATION',
+  'numeric_value >= 0 && numeric_value < 1000000000000',
+  '^tenant/[^/]+/compute/[^/]+$',
+  '"Invalid compute hours: must be non-negative and less than 1 trillion hours"',
+  '{"type":"object","properties":{"tenant_id":{"type":"string"},"compute_type":{"type":"string"},"hours":{"type":"number","minimum":0}},"required":["tenant_id","compute_type","hours"]}',
+  'ACTIVE',
+  'SYSTEM', 'SYSTEM',
+  now()
+);
+
+-- UTILIZATION_NETWORK_GB: Tracks network transfer per tenant and network interface
+INSERT INTO "dataset_definition" (
+  "id", "code", "version", "name", "description", "data_category",
+  "validation_expression", "resolution_key_expression", "error_message_expression",
+  "attribute_schema", "status", "created_by", "updated_by", "activated_at"
+) VALUES (
+  gen_random_uuid(),
+  'UTILIZATION_NETWORK_GB', 1,
+  'Platform Network Usage',
+  'Tracks network transfer in gigabytes per tenant and network interface',
+  'UTILIZATION',
+  'numeric_value >= 0 && numeric_value < 1000000000000',
+  '^tenant/[^/]+/network/[^/]+$',
+  '"Invalid network transfer: must be non-negative and less than 1 trillion GB"',
+  '{"type":"object","properties":{"tenant_id":{"type":"string"},"interface":{"type":"string"},"gb":{"type":"number","minimum":0}},"required":["tenant_id","interface","gb"]}',
+  'ACTIVE',
+  'SYSTEM', 'SYSTEM',
+  now()
+);

--- a/services/market-information/service/dataset_service.go
+++ b/services/market-information/service/dataset_service.go
@@ -541,7 +541,7 @@ func protoStatusToDomain(status pb.DataSetStatus) (domain.DataSetStatus, error) 
 }
 
 // domainCategoryToProto converts domain DataCategory to proto DataCategory.
-// Note: The domain uses a simplified two-value category system (PRICING/CONTEXTUAL)
+// Note: The domain uses a simplified category system (PRICING/CONTEXTUAL/UTILIZATION)
 // while proto has more granular categories. We map PRICING to FX_RATE as default.
 func domainCategoryToProto(category domain.DataCategory) pb.DataCategory {
 	switch category {
@@ -550,6 +550,9 @@ func domainCategoryToProto(category domain.DataCategory) pb.DataCategory {
 		return pb.DataCategory_DATA_CATEGORY_FX_RATE
 	case domain.DataCategoryContextual:
 		// CONTEXTUAL maps to INDEX_VALUE as a reasonable default for reference data
+		return pb.DataCategory_DATA_CATEGORY_INDEX_VALUE
+	case domain.DataCategoryUtilization:
+		// UTILIZATION maps to INDEX_VALUE as the closest proto analog for measurement data
 		return pb.DataCategory_DATA_CATEGORY_INDEX_VALUE
 	default:
 		return pb.DataCategory_DATA_CATEGORY_UNSPECIFIED


### PR DESCRIPTION
## Summary

- Register five UTILIZATION_* dataset definitions (TRANSACTION, API_CALL, STORAGE_GB, COMPUTE_HOUR, NETWORK_GB) in Market Information Service via new migration
- Register PLATFORM_AUDIT_EVENTS data source with trust level 100 (INTERNAL)
- Add UTILIZATION data category to domain model
- Each dataset includes CEL validation rules (`numeric_value >= 0 && numeric_value < 1e12`) and regex resolution key patterns for hierarchical tenant keys

Implements Task Master task `market-data-dynamic-pricing.2`.

## Changes Made

| File | Change |
|------|--------|
| `services/market-information/domain/data_category.go` | Add `DataCategoryUtilization` constant |
| `services/market-information/migrations/20260210000004_seed_utilization_datasets.sql` | Migration seeding 5 dataset definitions + data source |
| `services/market-information/e2e/e2e_test.go` | Integration tests for dataset retrieval, observation recording, tenant isolation |

## Test Plan

- [x] All 5 UTILIZATION_* datasets retrievable via `FindByCode` with correct properties
- [x] Datasets have correct CEL validation expressions and regex resolution key patterns
- [x] `ListDataSets` with UTILIZATION category filter returns all 5 datasets
- [x] PLATFORM_AUDIT_EVENTS data source exists with trust level 100
- [x] Observations can be recorded against all 5 utilization dataset types
- [x] Observations queryable by dataset code and resolution key
- [x] Multi-tenant isolation verified (tenant A cannot see tenant B observations)
- [x] Existing domain unit tests pass (no regressions)
- [x] Pre-existing EnergyTariff test failure confirmed on develop (not a regression)