### PR TITLE
feat: implement SettlementRunRepository persistence adapter

### DIFF
--- a/services/reconciliation/adapters/persistence/dispute_repository_test.go
+++ b/services/reconciliation/adapters/persistence/dispute_repository_test.go
@@ -2,6 +2,7 @@ package persistence_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -27,13 +28,14 @@ func setupTestDB(t *testing.T) (*gorm.DB, func()) {
 	// Create tenant schema and tables
 	tid := tenant.TenantID("test-tenant-01")
 	schemaName := tid.SchemaName()
+	quoted := fmt.Sprintf("%q", schemaName)
 
-	err := db.Exec("CREATE SCHEMA IF NOT EXISTS " + schemaName).Error
+	err := db.Exec("CREATE SCHEMA IF NOT EXISTS " + quoted).Error
 	require.NoError(t, err)
 
 	// Run migrations in the tenant schema
 	migrationSQL := `
-		SET search_path TO ` + schemaName + `, public;
+		SET search_path TO ` + quoted + `, public;
 
 		CREATE TABLE IF NOT EXISTS "settlement_run" (
 			"id" uuid NOT NULL DEFAULT gen_random_uuid(),
@@ -132,25 +134,25 @@ func seedRunAndVariance(t *testing.T, db *gorm.DB, runID, snapshotID, varianceID
 	t.Helper()
 	ctx := tenantCtx()
 	tid := tenant.TenantID("test-tenant-01")
-	schemaName := tid.SchemaName()
+	quoted := fmt.Sprintf("%q", tid.SchemaName())
 
 	// Insert settlement_run
 	err := db.WithContext(ctx).Exec(
-		`INSERT INTO "`+schemaName+`"."settlement_run" (run_id, account_id, scope, settlement_type, period_start, period_end, initiated_by) VALUES (?, 'ACC-001', 'ACCOUNT', 'DAILY', NOW() - INTERVAL '1 day', NOW(), 'system')`,
+		fmt.Sprintf(`INSERT INTO %s."settlement_run" (run_id, account_id, scope, settlement_type, period_start, period_end, initiated_by) VALUES (?, 'ACC-001', 'ACCOUNT', 'DAILY', NOW() - INTERVAL '1 day', NOW(), 'system')`, quoted),
 		runID,
 	).Error
 	require.NoError(t, err)
 
 	// Insert settlement_snapshot
 	err = db.WithContext(ctx).Exec(
-		`INSERT INTO "`+schemaName+`"."settlement_snapshot" (snapshot_id, run_id, account_id, instrument_code, expected_balance, actual_balance, variance_amount, source_system, captured_at) SELECT ?, sr.id, 'ACC-001', 'GBP', 100.00, 90.00, -10.00, 'test', NOW() FROM "`+schemaName+`"."settlement_run" sr WHERE sr.run_id = ?`,
+		fmt.Sprintf(`INSERT INTO %s."settlement_snapshot" (snapshot_id, run_id, account_id, instrument_code, expected_balance, actual_balance, variance_amount, source_system, captured_at) SELECT ?, sr.id, 'ACC-001', 'GBP', 100.00, 90.00, -10.00, 'test', NOW() FROM %s."settlement_run" sr WHERE sr.run_id = ?`, quoted, quoted),
 		snapshotID, runID,
 	).Error
 	require.NoError(t, err)
 
 	// Insert variance
 	err = db.WithContext(ctx).Exec(
-		`INSERT INTO "`+schemaName+`"."variance" (variance_id, run_id, snapshot_id, account_id, instrument_code, expected_amount, actual_amount, variance_amount, reason) SELECT ?, sr.id, ss.id, 'ACC-001', 'GBP', 100.00, 90.00, -10.00, 'AMOUNT_MISMATCH' FROM "`+schemaName+`"."settlement_run" sr JOIN "`+schemaName+`"."settlement_snapshot" ss ON ss.run_id = sr.id WHERE sr.run_id = ? AND ss.snapshot_id = ?`,
+		fmt.Sprintf(`INSERT INTO %s."variance" (variance_id, run_id, snapshot_id, account_id, instrument_code, expected_amount, actual_amount, variance_amount, reason) SELECT ?, sr.id, ss.id, 'ACC-001', 'GBP', 100.00, 90.00, -10.00, 'AMOUNT_MISMATCH' FROM %s."settlement_run" sr JOIN %s."settlement_snapshot" ss ON ss.run_id = sr.id WHERE sr.run_id = ? AND ss.snapshot_id = ?`, quoted, quoted, quoted),
 		varianceID, runID, snapshotID,
 	).Error
 	require.NoError(t, err)

--- a/services/reconciliation/adapters/persistence/settlement_run_repository.go
+++ b/services/reconciliation/adapters/persistence/settlement_run_repository.go
@@ -1,0 +1,252 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"gorm.io/gorm"
+)
+
+// Compile-time check that SettlementRunRepository implements domain.SettlementRunRepository.
+var _ domain.SettlementRunRepository = (*SettlementRunRepository)(nil)
+
+// SettlementRunEntity is the GORM entity for the settlement_run table.
+type SettlementRunEntity struct {
+	ID             uuid.UUID  `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	CreatedAt      time.Time  `gorm:"not null;default:now()"`
+	UpdatedAt      time.Time  `gorm:"not null;default:now()"`
+	RunID          uuid.UUID  `gorm:"column:run_id;uniqueIndex:idx_sr_run_id;type:uuid;not null"`
+	AccountID      string     `gorm:"column:account_id;index:idx_sr_account_id;size:34;not null"`
+	Scope          string     `gorm:"column:scope;size:20;not null;default:ACCOUNT"`
+	SettlementType string     `gorm:"column:settlement_type;size:20;not null;default:DAILY"`
+	Status         string     `gorm:"column:status;index:idx_sr_status;size:20;not null;default:PENDING"`
+	PeriodStart    time.Time  `gorm:"column:period_start;not null"`
+	PeriodEnd      time.Time  `gorm:"column:period_end;not null"`
+	InitiatedBy    string     `gorm:"column:initiated_by;size:100;not null"`
+	CompletedAt    *time.Time `gorm:"column:completed_at"`
+	VarianceCount  int        `gorm:"column:variance_count;not null;default:0"`
+	FailureReason  *string    `gorm:"column:failure_reason;type:text"`
+	Attributes     JSONMap    `gorm:"column:attributes;type:jsonb"`
+	Version        int64      `gorm:"column:version;not null;default:1"`
+}
+
+// TableName returns the table name for the settlement run entity.
+func (SettlementRunEntity) TableName() string {
+	return "settlement_run"
+}
+
+// SettlementRunRepository provides GORM-based persistence for settlement runs.
+type SettlementRunRepository struct {
+	db *gorm.DB
+}
+
+// NewSettlementRunRepository creates a new settlement run repository.
+func NewSettlementRunRepository(db *gorm.DB) *SettlementRunRepository {
+	return &SettlementRunRepository{db: db}
+}
+
+// withTenantTransaction executes fn within a tenant-scoped transaction.
+func (r *SettlementRunRepository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if r.isInTransaction() {
+		tx, err := db.WithGormTenantScope(ctx, r.db.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+		return fn(tx)
+	}
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// isInTransaction checks if the repository's db connection is already within a transaction.
+func (r *SettlementRunRepository) isInTransaction() bool {
+	if r.db.Statement == nil || r.db.Statement.ConnPool == nil {
+		return false
+	}
+	committer, ok := r.db.Statement.ConnPool.(gorm.TxCommitter)
+	return ok && committer != nil
+}
+
+// Create persists a new SettlementRun.
+func (r *SettlementRunRepository) Create(ctx context.Context, run *domain.SettlementRun) error {
+	entity := toSettlementRunEntity(run)
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Create(entity).Error
+	})
+}
+
+// FindByID retrieves a SettlementRun by its RunID.
+func (r *SettlementRunRepository) FindByID(ctx context.Context, runID uuid.UUID) (*domain.SettlementRun, error) {
+	var entity SettlementRunEntity
+	var queryErr error
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("run_id = ?", runID).First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+
+	return toSettlementRunDomain(&entity), nil
+}
+
+// Update updates an existing SettlementRun using optimistic locking.
+func (r *SettlementRunRepository) Update(ctx context.Context, run *domain.SettlementRun) error {
+	entity := toSettlementRunEntity(run)
+	var rowsAffected int64
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Model(&SettlementRunEntity{}).
+			Where("run_id = ? AND version = ?", entity.RunID, entity.Version-1).
+			Updates(map[string]interface{}{
+				"status":         entity.Status,
+				"completed_at":   entity.CompletedAt,
+				"variance_count": entity.VarianceCount,
+				"failure_reason": entity.FailureReason,
+				"attributes":     entity.Attributes,
+				"version":        entity.Version,
+				"updated_at":     time.Now().UTC(),
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		rowsAffected = result.RowsAffected
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if rowsAffected == 0 {
+		// Determine if the run doesn't exist or the version conflicted
+		var count int64
+		_ = r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+			return tx.Model(&SettlementRunEntity{}).Where("run_id = ?", entity.RunID).Count(&count).Error
+		})
+		if count == 0 {
+			return domain.ErrNotFound
+		}
+		return domain.ErrOptimisticLock
+	}
+	return nil
+}
+
+// List retrieves settlement runs matching the given filter with pagination.
+func (r *SettlementRunRepository) List(ctx context.Context, filter domain.RunFilter) ([]*domain.SettlementRun, error) {
+	var entities []SettlementRunEntity
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		query := tx.Model(&SettlementRunEntity{})
+
+		if filter.AccountID != nil {
+			query = query.Where("account_id = ?", *filter.AccountID)
+		}
+		if filter.Status != nil {
+			query = query.Where("status = ?", string(*filter.Status))
+		}
+		if filter.Scope != nil {
+			query = query.Where("scope = ?", string(*filter.Scope))
+		}
+		if filter.FromDate != nil {
+			query = query.Where("period_start >= ?", *filter.FromDate)
+		}
+		if filter.ToDate != nil {
+			query = query.Where("period_end <= ?", *filter.ToDate)
+		}
+
+		limit := filter.Limit
+		if limit <= 0 {
+			limit = 50
+		}
+		if limit > 1000 {
+			limit = 1000
+		}
+		query = query.Limit(limit)
+
+		if filter.Offset > 0 {
+			query = query.Offset(filter.Offset)
+		}
+
+		return query.Order("created_at DESC").Find(&entities).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toSettlementRunDomainSlice(entities), nil
+}
+
+// toSettlementRunEntity converts a domain SettlementRun to a persistence entity.
+func toSettlementRunEntity(r *domain.SettlementRun) *SettlementRunEntity {
+	entity := &SettlementRunEntity{
+		RunID:          r.RunID,
+		AccountID:      r.AccountID,
+		Scope:          string(r.Scope),
+		SettlementType: string(r.SettlementType),
+		Status:         string(r.Status),
+		PeriodStart:    r.PeriodStart,
+		PeriodEnd:      r.PeriodEnd,
+		InitiatedBy:    r.InitiatedBy,
+		CompletedAt:    r.CompletedAt,
+		VarianceCount:  r.VarianceCount,
+		CreatedAt:      r.CreatedAt,
+		UpdatedAt:      r.UpdatedAt,
+		Version:        r.Version,
+	}
+
+	if r.FailureReason != "" {
+		entity.FailureReason = &r.FailureReason
+	}
+	if r.Attributes != nil {
+		entity.Attributes = JSONMap(r.Attributes)
+	}
+
+	return entity
+}
+
+// toSettlementRunDomain converts a persistence entity to a domain SettlementRun.
+func toSettlementRunDomain(e *SettlementRunEntity) *domain.SettlementRun {
+	run := &domain.SettlementRun{
+		RunID:          e.RunID,
+		AccountID:      e.AccountID,
+		Scope:          domain.ReconciliationScope(e.Scope),
+		SettlementType: domain.SettlementType(e.SettlementType),
+		Status:         domain.RunStatus(e.Status),
+		PeriodStart:    e.PeriodStart,
+		PeriodEnd:      e.PeriodEnd,
+		InitiatedBy:    e.InitiatedBy,
+		CompletedAt:    e.CompletedAt,
+		VarianceCount:  e.VarianceCount,
+		CreatedAt:      e.CreatedAt,
+		UpdatedAt:      e.UpdatedAt,
+		Version:        e.Version,
+	}
+
+	if e.FailureReason != nil {
+		run.FailureReason = *e.FailureReason
+	}
+	if e.Attributes != nil {
+		run.Attributes = map[string]string(e.Attributes)
+	}
+
+	return run
+}
+
+// toSettlementRunDomainSlice converts a slice of entities to domain objects.
+func toSettlementRunDomainSlice(entities []SettlementRunEntity) []*domain.SettlementRun {
+	runs := make([]*domain.SettlementRun, 0, len(entities))
+	for i := range entities {
+		runs = append(runs, toSettlementRunDomain(&entities[i]))
+	}
+	return runs
+}

--- a/services/reconciliation/adapters/persistence/settlement_run_repository.go
+++ b/services/reconciliation/adapters/persistence/settlement_run_repository.go
@@ -73,6 +73,9 @@ func (r *SettlementRunRepository) isInTransaction() bool {
 // Create persists a new SettlementRun.
 func (r *SettlementRunRepository) Create(ctx context.Context, run *domain.SettlementRun) error {
 	entity := toSettlementRunEntity(run)
+	if entity.Version == 0 {
+		entity.Version = 1
+	}
 	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 		return tx.Create(entity).Error
 	})
@@ -176,8 +179,12 @@ func (r *SettlementRunRepository) List(ctx context.Context, filter domain.RunFil
 		}
 		query = query.Limit(limit)
 
-		if filter.Offset > 0 {
-			query = query.Offset(filter.Offset)
+		offset := filter.Offset
+		if offset < 0 {
+			offset = 0
+		}
+		if offset > 0 {
+			query = query.Offset(offset)
 		}
 
 		return query.Order("created_at DESC").Find(&entities).Error

--- a/services/reconciliation/adapters/persistence/settlement_run_repository.go
+++ b/services/reconciliation/adapters/persistence/settlement_run_repository.go
@@ -130,9 +130,12 @@ func (r *SettlementRunRepository) Update(ctx context.Context, run *domain.Settle
 	if rowsAffected == 0 {
 		// Determine if the run doesn't exist or the version conflicted
 		var count int64
-		_ = r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		countErr := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
 			return tx.Model(&SettlementRunEntity{}).Where("run_id = ?", entity.RunID).Count(&count).Error
 		})
+		if countErr != nil {
+			return countErr
+		}
 		if count == 0 {
 			return domain.ErrNotFound
 		}

--- a/services/reconciliation/adapters/persistence/settlement_run_repository_test.go
+++ b/services/reconciliation/adapters/persistence/settlement_run_repository_test.go
@@ -1,0 +1,295 @@
+package persistence_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSettlementRun(t *testing.T) *domain.SettlementRun {
+	t.Helper()
+	run, err := domain.NewSettlementRun(
+		"ACC-001",
+		domain.ReconciliationScopeAccount,
+		domain.SettlementTypeDaily,
+		time.Now().UTC().Add(-24*time.Hour),
+		time.Now().UTC(),
+		"system",
+	)
+	require.NoError(t, err)
+	return run
+}
+
+func TestSettlementRunRepository_Create(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementRunRepository(db)
+	ctx := tenantCtx()
+
+	run := newTestSettlementRun(t)
+	run.Attributes = map[string]string{"source": "test"}
+
+	err := repo.Create(ctx, run)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, run.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, run.RunID, found.RunID)
+	assert.Equal(t, "ACC-001", found.AccountID)
+	assert.Equal(t, domain.ReconciliationScopeAccount, found.Scope)
+	assert.Equal(t, domain.SettlementTypeDaily, found.SettlementType)
+	assert.Equal(t, domain.RunStatusPending, found.Status)
+	assert.Equal(t, "system", found.InitiatedBy)
+	assert.Equal(t, int64(1), found.Version)
+	assert.Equal(t, "test", found.Attributes["source"])
+	assert.Nil(t, found.CompletedAt)
+	assert.Equal(t, 0, found.VarianceCount)
+	assert.Empty(t, found.FailureReason)
+}
+
+func TestSettlementRunRepository_FindByID(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementRunRepository(db)
+	ctx := tenantCtx()
+
+	t.Run("existing run", func(t *testing.T) {
+		run := newTestSettlementRun(t)
+		require.NoError(t, repo.Create(ctx, run))
+
+		found, err := repo.FindByID(ctx, run.RunID)
+		require.NoError(t, err)
+		assert.Equal(t, run.RunID, found.RunID)
+		assert.Equal(t, run.AccountID, found.AccountID)
+		assert.WithinDuration(t, run.PeriodStart, found.PeriodStart, time.Second)
+		assert.WithinDuration(t, run.PeriodEnd, found.PeriodEnd, time.Second)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := repo.FindByID(ctx, uuid.New())
+		assert.ErrorIs(t, err, domain.ErrNotFound)
+	})
+}
+
+func TestSettlementRunRepository_Update(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementRunRepository(db)
+	ctx := tenantCtx()
+
+	run := newTestSettlementRun(t)
+	require.NoError(t, repo.Create(ctx, run))
+
+	// Transition to RUNNING
+	require.NoError(t, run.Start())
+	err := repo.Update(ctx, run)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, run.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.RunStatusRunning, found.Status)
+	assert.Equal(t, int64(2), found.Version)
+
+	// Complete the run
+	require.NoError(t, run.Complete(5))
+	err = repo.Update(ctx, run)
+	require.NoError(t, err)
+
+	found, err = repo.FindByID(ctx, run.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.RunStatusCompleted, found.Status)
+	assert.Equal(t, 5, found.VarianceCount)
+	assert.NotNil(t, found.CompletedAt)
+	assert.Equal(t, int64(3), found.Version)
+}
+
+func TestSettlementRunRepository_UpdateOptimisticLock(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementRunRepository(db)
+	ctx := tenantCtx()
+
+	run := newTestSettlementRun(t)
+	require.NoError(t, repo.Create(ctx, run))
+
+	// Load two copies to simulate concurrent access
+	copy1, err := repo.FindByID(ctx, run.RunID)
+	require.NoError(t, err)
+
+	copy2, err := repo.FindByID(ctx, run.RunID)
+	require.NoError(t, err)
+
+	// First update succeeds
+	require.NoError(t, copy1.Start())
+	err = repo.Update(ctx, copy1)
+	require.NoError(t, err)
+
+	// Second update with stale version fails
+	require.NoError(t, copy2.Start())
+	err = repo.Update(ctx, copy2)
+	assert.ErrorIs(t, err, domain.ErrOptimisticLock)
+}
+
+func TestSettlementRunRepository_UpdateNotFound(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementRunRepository(db)
+	ctx := tenantCtx()
+
+	run := newTestSettlementRun(t)
+	// Bump version so the WHERE version = version-1 check doesn't match version 0
+	run.Version = 2
+
+	err := repo.Update(ctx, run)
+	assert.ErrorIs(t, err, domain.ErrNotFound)
+}
+
+func TestSettlementRunRepository_UpdateFailedRun(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementRunRepository(db)
+	ctx := tenantCtx()
+
+	run := newTestSettlementRun(t)
+	require.NoError(t, repo.Create(ctx, run))
+
+	require.NoError(t, run.Start())
+	require.NoError(t, repo.Update(ctx, run))
+
+	require.NoError(t, run.Fail("database timeout"))
+	require.NoError(t, repo.Update(ctx, run))
+
+	found, err := repo.FindByID(ctx, run.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.RunStatusFailed, found.Status)
+	assert.Equal(t, "database timeout", found.FailureReason)
+	assert.NotNil(t, found.CompletedAt)
+}
+
+func TestSettlementRunRepository_List(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementRunRepository(db)
+	ctx := tenantCtx()
+
+	now := time.Now().UTC()
+
+	// Create runs with different attributes
+	run1 := newTestSettlementRun(t)
+	run1.AccountID = "ACC-001"
+	run1.Scope = domain.ReconciliationScopeAccount
+	require.NoError(t, repo.Create(ctx, run1))
+
+	run2, err := domain.NewSettlementRun(
+		"ACC-002",
+		domain.ReconciliationScopePortfolio,
+		domain.SettlementTypeWeekly,
+		now.Add(-7*24*time.Hour),
+		now,
+		"admin",
+	)
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, run2))
+
+	run3, err := domain.NewSettlementRun(
+		"ACC-001",
+		domain.ReconciliationScopeAccount,
+		domain.SettlementTypeMonthly,
+		now.Add(-30*24*time.Hour),
+		now,
+		"system",
+	)
+	require.NoError(t, err)
+	// Start and complete run3 so it has a different status
+	require.NoError(t, run3.Start())
+	require.NoError(t, repo.Create(ctx, run3))
+
+	t.Run("list all", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.RunFilter{})
+		require.NoError(t, err)
+		assert.Len(t, found, 3)
+	})
+
+	t.Run("filter by account", func(t *testing.T) {
+		accountID := "ACC-001"
+		found, err := repo.List(ctx, domain.RunFilter{AccountID: &accountID})
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+		for _, r := range found {
+			assert.Equal(t, "ACC-001", r.AccountID)
+		}
+	})
+
+	t.Run("filter by status", func(t *testing.T) {
+		status := domain.RunStatusPending
+		found, err := repo.List(ctx, domain.RunFilter{Status: &status})
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+	})
+
+	t.Run("filter by scope", func(t *testing.T) {
+		scope := domain.ReconciliationScopePortfolio
+		found, err := repo.List(ctx, domain.RunFilter{Scope: &scope})
+		require.NoError(t, err)
+		assert.Len(t, found, 1)
+		assert.Equal(t, "ACC-002", found[0].AccountID)
+	})
+
+	t.Run("filter by running status", func(t *testing.T) {
+		status := domain.RunStatusRunning
+		found, err := repo.List(ctx, domain.RunFilter{Status: &status})
+		require.NoError(t, err)
+		assert.Len(t, found, 1)
+		assert.Equal(t, run3.RunID, found[0].RunID)
+	})
+}
+
+func TestSettlementRunRepository_ListPagination(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementRunRepository(db)
+	ctx := tenantCtx()
+
+	// Create 5 runs
+	for i := 0; i < 5; i++ {
+		run := newTestSettlementRun(t)
+		require.NoError(t, repo.Create(ctx, run))
+	}
+
+	t.Run("limit", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.RunFilter{Limit: 2})
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+	})
+
+	t.Run("offset", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.RunFilter{Limit: 10, Offset: 3})
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+	})
+
+	t.Run("default limit", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.RunFilter{})
+		require.NoError(t, err)
+		assert.Len(t, found, 5)
+	})
+
+	t.Run("max limit cap", func(t *testing.T) {
+		found, err := repo.List(ctx, domain.RunFilter{Limit: 5000})
+		require.NoError(t, err)
+		assert.Len(t, found, 5)
+	})
+}


### PR DESCRIPTION
## Summary

- Implement `SettlementRunRepository` persistence adapter with GORM, following the pattern established by `DisputeRepository`
- Support Create, FindByID, Update (with optimistic locking via version field), and List (with filtering by account, status, scope, date range, and pagination)
- Fix pre-existing schema quoting bug in `setupTestDB` where hyphenated tenant IDs (`test-tenant-01`) produced invalid SQL (`org_test-tenant-01` unquoted)

## Changes Made

- `settlement_run_repository.go`: `SettlementRunEntity` struct with GORM tags, `SettlementRunRepository` with tenant-scoped transactions, mapping helpers between entity and domain
- `settlement_run_repository_test.go`: Integration tests with CockroachDB testcontainers covering Create, FindByID, Update, optimistic lock conflict, Update not found, failed run persistence, List filtering, and pagination
- `dispute_repository_test.go`: Fix `setupTestDB` and `seedRunAndVariance` to properly quote schema names containing hyphens

## Task Master

reconciliation-service.13

## Test Plan

- [x] TestSettlementRunRepository_Create: Insert and verify all fields persisted
- [x] TestSettlementRunRepository_FindByID: Existing run found, missing ID returns ErrNotFound
- [x] TestSettlementRunRepository_Update: Status transitions with version increment
- [x] TestSettlementRunRepository_UpdateOptimisticLock: Concurrent version conflict returns ErrOptimisticLock
- [x] TestSettlementRunRepository_UpdateNotFound: Non-existent run returns ErrNotFound
- [x] TestSettlementRunRepository_UpdateFailedRun: Failed status with failure_reason persisted
- [x] TestSettlementRunRepository_List: Filter by account, status, scope, running status
- [x] TestSettlementRunRepository_ListPagination: Limit, offset, default limit, max cap