### PR TITLE
feat: Add Stripe Go SDK integration with tenant-scoped client wrapper

### DIFF
--- a/services/payment-order/adapters/gateway/stripe/client.go
+++ b/services/payment-order/adapters/gateway/stripe/client.go
@@ -1,0 +1,266 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/sony/gobreaker/v2"
+	stripego "github.com/stripe/stripe-go/v82"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Client wraps a stripe-go Client and automatically applies the Connected Account
+// header for all requests routed through a tenant.
+type Client struct {
+	// Raw is the underlying stripe-go Client for making API calls.
+	// Callers must set params.SetStripeAccount(accountID) on each request;
+	// use ApplyAccount as a convenience.
+	Raw *stripego.Client
+
+	// AccountID is the Stripe Connected Account ID for this tenant.
+	AccountID string
+
+	// WebhookEndpointSecret is the per-tenant webhook signing secret.
+	WebhookEndpointSecret string
+}
+
+// ApplyAccount sets the Stripe-Account header on the given params.
+// Use this before every API call to route the request to the Connected Account.
+func (c *Client) ApplyAccount(params *stripego.Params) {
+	params.SetStripeAccount(c.AccountID)
+}
+
+// ApplyAccountList sets the Stripe-Account header on list params.
+func (c *Client) ApplyAccountList(params *stripego.ListParams) {
+	params.SetStripeAccount(c.AccountID)
+}
+
+// ClientFactory creates tenant-scoped Stripe clients with caching,
+// circuit breaker, and retry resilience.
+type ClientFactory struct {
+	apiKey         string
+	configProvider TenantConfigProvider
+	rawClient      *stripego.Client
+	cache          *lru.Cache[string, *cachedTenantConfig]
+	cacheTTL       time.Duration
+	cb             *gobreaker.CircuitBreaker[TenantConfig]
+	retryConfig    retrySettings
+	logger         *slog.Logger
+}
+
+// cachedTenantConfig holds a tenant config with expiration tracking.
+type cachedTenantConfig struct {
+	config    TenantConfig
+	expiresAt time.Time
+}
+
+// retrySettings holds retry configuration.
+type retrySettings struct {
+	maxRetries          int
+	initialInterval     time.Duration
+	maxInterval         time.Duration
+	multiplier          float64
+	randomizationFactor float64
+}
+
+// Factory errors.
+var (
+	ErrNilConfigProvider = errors.New("tenant config provider must not be nil")
+	ErrCircuitOpen       = errors.New("circuit breaker is open")
+	ErrMissingTenant     = errors.New("tenant context required for Stripe client")
+)
+
+// NewClientFactory creates a new ClientFactory.
+func NewClientFactory(cfg Config, provider TenantConfigProvider, logger *slog.Logger) (*ClientFactory, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid stripe config: %w", err)
+	}
+	if provider == nil {
+		return nil, ErrNilConfigProvider
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	cache, err := lru.New[string, *cachedTenantConfig](cfg.TenantCacheSize)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tenant config cache: %w", err)
+	}
+
+	cbSettings := gobreaker.Settings{
+		Name:        cfg.CircuitBreakerName,
+		MaxRequests: cfg.CircuitBreakerMaxRequests,
+		Interval:    cfg.CircuitBreakerInterval,
+		Timeout:     cfg.CircuitBreakerTimeout,
+		ReadyToTrip: func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= cfg.CircuitBreakerFailureThreshold
+		},
+		OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
+			logger.Info("stripe client factory circuit breaker state changed",
+				"name", name,
+				"from", from.String(),
+				"to", to.String(),
+			)
+		},
+	}
+
+	return &ClientFactory{
+		apiKey:         cfg.APIKey,
+		configProvider: provider,
+		rawClient:      stripego.NewClient(cfg.APIKey),
+		cache:          cache,
+		cacheTTL:       cfg.TenantCacheTTL,
+		cb:             gobreaker.NewCircuitBreaker[TenantConfig](cbSettings),
+		retryConfig: retrySettings{
+			maxRetries:          cfg.MaxRetries,
+			initialInterval:     cfg.RetryInitialInterval,
+			maxInterval:         cfg.RetryMaxInterval,
+			multiplier:          cfg.RetryMultiplier,
+			randomizationFactor: cfg.RetryRandomizationFactor,
+		},
+		logger: logger,
+	}, nil
+}
+
+// NewClient creates a tenant-scoped Stripe Client by retrieving the tenant's
+// Connected Account configuration. The tenant ID is extracted from the context.
+//
+// Tenant configs are cached with TTL and fetched through a circuit breaker
+// with exponential backoff retries.
+func (f *ClientFactory) NewClient(ctx context.Context) (*Client, error) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil, ErrMissingTenant
+	}
+
+	tid := tenantID.String()
+
+	cfg, err := f.getTenantConfig(ctx, tid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stripe config for tenant %s: %w", tid, err)
+	}
+
+	f.logger.Debug("created stripe client for tenant",
+		"tenant_id", tid,
+		"connected_account_id", cfg.ConnectedAccountID,
+	)
+
+	return &Client{
+		Raw:                   f.rawClient,
+		AccountID:             cfg.ConnectedAccountID,
+		WebhookEndpointSecret: cfg.WebhookEndpointSecret,
+	}, nil
+}
+
+// getTenantConfig retrieves the tenant config from cache or provider.
+func (f *ClientFactory) getTenantConfig(ctx context.Context, tenantID string) (TenantConfig, error) {
+	// Check cache first
+	if cached, ok := f.cache.Get(tenantID); ok {
+		if time.Now().Before(cached.expiresAt) {
+			return cached.config, nil
+		}
+		// Expired, remove from cache
+		f.cache.Remove(tenantID)
+	}
+
+	// Fetch with circuit breaker and retry
+	cfg, err := f.fetchWithResilience(ctx, tenantID)
+	if err != nil {
+		return TenantConfig{}, err
+	}
+
+	// Cache the result
+	f.cache.Add(tenantID, &cachedTenantConfig{
+		config:    cfg,
+		expiresAt: time.Now().Add(f.cacheTTL),
+	})
+
+	return cfg, nil
+}
+
+// fetchWithResilience fetches tenant config through circuit breaker with retries.
+func (f *ClientFactory) fetchWithResilience(ctx context.Context, tenantID string) (TenantConfig, error) {
+	var result TenantConfig
+
+	b := backoff.NewExponentialBackOff()
+	b.InitialInterval = f.retryConfig.initialInterval
+	b.MaxInterval = f.retryConfig.maxInterval
+	b.Multiplier = f.retryConfig.multiplier
+	b.RandomizationFactor = f.retryConfig.randomizationFactor
+	b.MaxElapsedTime = 0
+	b.Reset()
+
+	backoffWithContext := backoff.WithContext(b, ctx)
+
+	attempt := 0
+	maxAttempts := f.retryConfig.maxRetries + 1
+
+	operation := func() error {
+		if err := ctx.Err(); err != nil {
+			return backoff.Permanent(err)
+		}
+
+		attempt++
+
+		cfg, err := f.cb.Execute(func() (TenantConfig, error) {
+			return f.configProvider.GetTenantConfig(tenantID)
+		})
+		if err != nil {
+			if errors.Is(err, gobreaker.ErrOpenState) || errors.Is(err, gobreaker.ErrTooManyRequests) {
+				f.logger.Warn("stripe config circuit breaker open",
+					"tenant_id", tenantID,
+					"attempt", attempt,
+				)
+				return backoff.Permanent(fmt.Errorf("%w: %v", ErrCircuitOpen, err)) //nolint:errorlint // second error is context-only
+			}
+
+			if attempt >= maxAttempts {
+				f.logger.Error("stripe config fetch failed after max retries",
+					"tenant_id", tenantID,
+					"attempts", attempt,
+					"error", err,
+				)
+				return backoff.Permanent(err)
+			}
+
+			// Don't retry config-not-found errors
+			if errors.Is(err, ErrTenantConfigNotFound) {
+				return backoff.Permanent(err)
+			}
+
+			f.logger.Debug("stripe config fetch failed, retrying",
+				"tenant_id", tenantID,
+				"attempt", attempt,
+				"error", err,
+			)
+			return err
+		}
+
+		result = cfg
+		return nil
+	}
+
+	if err := backoff.Retry(operation, backoffWithContext); err != nil {
+		return TenantConfig{}, fmt.Errorf("stripe config fetch failed: %w", err)
+	}
+
+	return result, nil
+}
+
+// InvalidateTenantConfig removes a tenant's cached config, forcing a refresh
+// on the next NewClient call. Use when a tenant's Stripe config changes.
+func (f *ClientFactory) InvalidateTenantConfig(tenantID string) {
+	f.cache.Remove(tenantID)
+	f.logger.Debug("invalidated stripe config cache", "tenant_id", tenantID)
+}
+
+// CircuitBreakerState returns the current state of the circuit breaker.
+func (f *ClientFactory) CircuitBreakerState() gobreaker.State {
+	return f.cb.State()
+}

--- a/services/payment-order/adapters/gateway/stripe/client.go
+++ b/services/payment-order/adapters/gateway/stripe/client.go
@@ -98,6 +98,14 @@ func NewClientFactory(cfg Config, provider TenantConfigProvider, logger *slog.Lo
 		MaxRequests: cfg.CircuitBreakerMaxRequests,
 		Interval:    cfg.CircuitBreakerInterval,
 		Timeout:     cfg.CircuitBreakerTimeout,
+		IsSuccessful: func(err error) bool {
+			if err == nil {
+				return true
+			}
+			// Tenant-not-found is a business logic error, not an infrastructure failure.
+			// Don't let missing tenant configs trip the breaker for other tenants.
+			return errors.Is(err, ErrTenantConfigNotFound)
+		},
 		ReadyToTrip: func(counts gobreaker.Counts) bool {
 			return counts.ConsecutiveFailures >= cfg.CircuitBreakerFailureThreshold
 		},
@@ -212,6 +220,7 @@ func (f *ClientFactory) fetchWithResilience(ctx context.Context, tenantID string
 			return f.configProvider.GetTenantConfig(tenantID)
 		})
 		if err != nil {
+			// Circuit breaker open - don't retry
 			if errors.Is(err, gobreaker.ErrOpenState) || errors.Is(err, gobreaker.ErrTooManyRequests) {
 				f.logger.Warn("stripe config circuit breaker open",
 					"tenant_id", tenantID,
@@ -220,17 +229,18 @@ func (f *ClientFactory) fetchWithResilience(ctx context.Context, tenantID string
 				return backoff.Permanent(fmt.Errorf("%w: %v", ErrCircuitOpen, err)) //nolint:errorlint // second error is context-only
 			}
 
+			// Business logic errors - don't retry or log as infrastructure failure
+			if errors.Is(err, ErrTenantConfigNotFound) {
+				return backoff.Permanent(err)
+			}
+
+			// Infrastructure failure - check retry budget
 			if attempt >= maxAttempts {
 				f.logger.Error("stripe config fetch failed after max retries",
 					"tenant_id", tenantID,
 					"attempts", attempt,
 					"error", err,
 				)
-				return backoff.Permanent(err)
-			}
-
-			// Don't retry config-not-found errors
-			if errors.Is(err, ErrTenantConfigNotFound) {
 				return backoff.Permanent(err)
 			}
 

--- a/services/payment-order/adapters/gateway/stripe/client_test.go
+++ b/services/payment-order/adapters/gateway/stripe/client_test.go
@@ -1,0 +1,265 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/sony/gobreaker/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	stripego "github.com/stripe/stripe-go/v82"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// mockConfigProvider is a test TenantConfigProvider.
+type mockConfigProvider struct {
+	mu        sync.Mutex
+	configs   map[string]TenantConfig
+	err       error
+	callCount atomic.Int64
+}
+
+func newMockProvider(configs map[string]TenantConfig) *mockConfigProvider {
+	return &mockConfigProvider{configs: configs}
+}
+
+func (m *mockConfigProvider) GetTenantConfig(tenantID string) (TenantConfig, error) {
+	m.callCount.Add(1)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.err != nil {
+		return TenantConfig{}, m.err
+	}
+	cfg, ok := m.configs[tenantID]
+	if !ok {
+		return TenantConfig{}, ErrTenantConfigNotFound
+	}
+	return cfg, nil
+}
+
+func (m *mockConfigProvider) setError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.err = err
+}
+
+func testConfig() Config {
+	cfg := DefaultConfig()
+	cfg.APIKey = "sk_test_123"
+	// Speed up tests
+	cfg.TenantCacheTTL = 100 * time.Millisecond
+	cfg.RetryInitialInterval = 10 * time.Millisecond
+	cfg.RetryMaxInterval = 50 * time.Millisecond
+	cfg.CircuitBreakerTimeout = 100 * time.Millisecond
+	cfg.CircuitBreakerInterval = 100 * time.Millisecond
+	return cfg
+}
+
+func tenantCtx(id string) context.Context {
+	return tenant.WithTenant(context.Background(), tenant.TenantID(id))
+}
+
+func TestNewClientFactory_ValidConfig(t *testing.T) {
+	provider := newMockProvider(nil)
+	factory, err := NewClientFactory(testConfig(), provider, slog.Default())
+	require.NoError(t, err)
+	require.NotNil(t, factory)
+}
+
+func TestNewClientFactory_InvalidConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	// No API key
+	_, err := NewClientFactory(cfg, newMockProvider(nil), nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEmptyAPIKey)
+}
+
+func TestNewClientFactory_NilProvider(t *testing.T) {
+	_, err := NewClientFactory(testConfig(), nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNilConfigProvider)
+}
+
+func TestClientFactory_NewClient_Success(t *testing.T) {
+	provider := newMockProvider(map[string]TenantConfig{
+		"tenant_a": {
+			ConnectedAccountID:    "acct_tenant_a",
+			WebhookEndpointSecret: "whsec_tenant_a",
+		},
+	})
+
+	factory, err := NewClientFactory(testConfig(), provider, slog.Default())
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant_a")
+	client, err := factory.NewClient(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	assert.Equal(t, "acct_tenant_a", client.AccountID)
+	assert.Equal(t, "whsec_tenant_a", client.WebhookEndpointSecret)
+	assert.NotNil(t, client.Raw)
+}
+
+func TestClientFactory_NewClient_MissingTenantContext(t *testing.T) {
+	factory, err := NewClientFactory(testConfig(), newMockProvider(nil), nil)
+	require.NoError(t, err)
+
+	_, err = factory.NewClient(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingTenant)
+}
+
+func TestClientFactory_NewClient_TenantNotFound(t *testing.T) {
+	provider := newMockProvider(map[string]TenantConfig{})
+	factory, err := NewClientFactory(testConfig(), provider, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx("nonexistent")
+	_, err = factory.NewClient(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTenantConfigNotFound)
+}
+
+func TestClientFactory_NewClient_CachesConfig(t *testing.T) {
+	provider := newMockProvider(map[string]TenantConfig{
+		"tenant_a": {ConnectedAccountID: "acct_tenant_a"},
+	})
+
+	factory, err := NewClientFactory(testConfig(), provider, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant_a")
+
+	// First call fetches from provider
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), provider.callCount.Load())
+
+	// Second call should use cache
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), provider.callCount.Load(), "should use cached config")
+}
+
+func TestClientFactory_NewClient_CacheExpires(t *testing.T) {
+	provider := newMockProvider(map[string]TenantConfig{
+		"tenant_a": {ConnectedAccountID: "acct_tenant_a"},
+	})
+
+	cfg := testConfig()
+	cfg.TenantCacheTTL = 50 * time.Millisecond
+
+	factory, err := NewClientFactory(cfg, provider, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant_a")
+
+	// First call
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), provider.callCount.Load())
+
+	// Wait for cache to expire
+	time.Sleep(60 * time.Millisecond)
+
+	// Second call should fetch again
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), provider.callCount.Load(), "should re-fetch after cache expiry")
+}
+
+func TestClientFactory_InvalidateTenantConfig(t *testing.T) {
+	provider := newMockProvider(map[string]TenantConfig{
+		"tenant_a": {ConnectedAccountID: "acct_tenant_a"},
+	})
+
+	factory, err := NewClientFactory(testConfig(), provider, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant_a")
+
+	// Populate cache
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), provider.callCount.Load())
+
+	// Invalidate
+	factory.InvalidateTenantConfig("tenant_a")
+
+	// Next call should re-fetch
+	_, err = factory.NewClient(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), provider.callCount.Load())
+}
+
+func TestClientFactory_CircuitBreaker_TripsOnRepeatedFailures(t *testing.T) {
+	provider := newMockProvider(map[string]TenantConfig{})
+	provider.setError(errors.New("provider unavailable"))
+
+	cfg := testConfig()
+	cfg.MaxRetries = 0
+	cfg.CircuitBreakerFailureThreshold = 3
+
+	factory, err := NewClientFactory(cfg, provider, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx("tenant_a")
+
+	// Fail enough times to trip the breaker
+	for i := 0; i < 3; i++ {
+		_, _ = factory.NewClient(ctx)
+	}
+
+	// Circuit should now be open
+	assert.Equal(t, gobreaker.StateOpen, factory.CircuitBreakerState())
+
+	// Next call should fail fast with circuit open error
+	_, err = factory.NewClient(ctx)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrCircuitOpen)
+}
+
+func TestClientFactory_ContextCancellation(t *testing.T) {
+	provider := newMockProvider(map[string]TenantConfig{})
+	provider.setError(errors.New("slow provider"))
+
+	cfg := testConfig()
+	cfg.MaxRetries = 5 // Many retries, but context will cancel first
+
+	factory, err := NewClientFactory(cfg, provider, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(tenantCtx("tenant_a"))
+	cancel() // Cancel immediately
+
+	_, err = factory.NewClient(ctx)
+	require.Error(t, err)
+}
+
+func TestClient_ApplyAccount(t *testing.T) {
+	client := &Client{AccountID: "acct_test_123"}
+
+	params := &stripego.Params{}
+	client.ApplyAccount(params)
+
+	require.NotNil(t, params.StripeAccount)
+	assert.Equal(t, "acct_test_123", *params.StripeAccount)
+}
+
+func TestClient_ApplyAccountList(t *testing.T) {
+	client := &Client{AccountID: "acct_test_456"}
+
+	params := &stripego.ListParams{}
+	client.ApplyAccountList(params)
+
+	require.NotNil(t, params.StripeAccount)
+	assert.Equal(t, "acct_test_456", *params.StripeAccount)
+}

--- a/services/payment-order/adapters/gateway/stripe/client_test.go
+++ b/services/payment-order/adapters/gateway/stripe/client_test.go
@@ -227,6 +227,32 @@ func TestClientFactory_CircuitBreaker_TripsOnRepeatedFailures(t *testing.T) {
 	assert.ErrorIs(t, err, ErrCircuitOpen)
 }
 
+func TestClientFactory_CircuitBreaker_TenantNotFoundDoesNotTrip(t *testing.T) {
+	// ErrTenantConfigNotFound is a business error, not infrastructure failure.
+	// It should NOT trip the circuit breaker.
+	provider := newMockProvider(map[string]TenantConfig{})
+	// Provider returns ErrTenantConfigNotFound for unknown tenants (default behavior)
+
+	cfg := testConfig()
+	cfg.MaxRetries = 0
+	cfg.CircuitBreakerFailureThreshold = 3
+
+	factory, err := NewClientFactory(cfg, provider, nil)
+	require.NoError(t, err)
+
+	// Request config for many nonexistent tenants
+	for i := 0; i < 10; i++ {
+		ctx := tenantCtx("nonexistent")
+		_, err := factory.NewClient(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrTenantConfigNotFound)
+	}
+
+	// Circuit should still be closed
+	assert.Equal(t, gobreaker.StateClosed, factory.CircuitBreakerState(),
+		"tenant-not-found errors should not trip the circuit breaker")
+}
+
 func TestClientFactory_ContextCancellation(t *testing.T) {
 	provider := newMockProvider(map[string]TenantConfig{})
 	provider.setError(errors.New("slow provider"))

--- a/services/payment-order/adapters/gateway/stripe/config.go
+++ b/services/payment-order/adapters/gateway/stripe/config.go
@@ -1,0 +1,85 @@
+// Package stripe provides a tenant-scoped Stripe Connect client wrapper
+// with Connected Account routing, circuit breaker, and retry resilience.
+package stripe
+
+import (
+	"errors"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/defaults"
+)
+
+// Config holds the Stripe gateway configuration.
+type Config struct {
+	// APIKey is the platform Stripe API key (from STRIPE_API_KEY env var).
+	APIKey string
+
+	// TenantCacheSize is the max number of tenant configs to cache.
+	TenantCacheSize int
+
+	// TenantCacheTTL is how long tenant configs are cached before refresh.
+	TenantCacheTTL time.Duration
+
+	// CircuitBreakerName identifies this circuit breaker in logs.
+	CircuitBreakerName string
+
+	// CircuitBreakerTimeout is how long the breaker stays open before half-open.
+	CircuitBreakerTimeout time.Duration
+
+	// CircuitBreakerInterval is the cyclic period for clearing counts in closed state.
+	CircuitBreakerInterval time.Duration
+
+	// CircuitBreakerMaxRequests is the max requests allowed in half-open state.
+	CircuitBreakerMaxRequests uint32
+
+	// CircuitBreakerFailureThreshold is consecutive failures to trip the breaker.
+	CircuitBreakerFailureThreshold uint32
+
+	// MaxRetries is the maximum number of retry attempts for transient failures.
+	MaxRetries int
+
+	// RetryInitialInterval is the starting backoff delay.
+	RetryInitialInterval time.Duration
+
+	// RetryMaxInterval caps exponential backoff growth.
+	RetryMaxInterval time.Duration
+
+	// RetryMultiplier is the exponential backoff multiplier.
+	RetryMultiplier float64
+
+	// RetryRandomizationFactor adds jitter to backoff timing.
+	RetryRandomizationFactor float64
+}
+
+// Configuration errors.
+var (
+	ErrEmptyAPIKey = errors.New("stripe API key must not be empty")
+)
+
+// DefaultConfig returns sensible defaults for production use.
+func DefaultConfig() Config {
+	return Config{
+		TenantCacheSize: 1000,
+		TenantCacheTTL:  5 * time.Minute,
+
+		CircuitBreakerName:             "stripe-gateway",
+		CircuitBreakerTimeout:          defaults.DefaultCircuitBreakerOpenTimeout,
+		CircuitBreakerInterval:         defaults.DefaultCircuitBreakerInterval,
+		CircuitBreakerMaxRequests:      1,
+		CircuitBreakerFailureThreshold: 5,
+
+		MaxRetries:               3,
+		RetryInitialInterval:     500 * time.Millisecond,
+		RetryMaxInterval:         defaults.DefaultMaxRetryInterval,
+		RetryMultiplier:          2.0,
+		RetryRandomizationFactor: 0.5,
+	}
+}
+
+// Validate checks that required fields are set.
+func (c Config) Validate() error {
+	if c.APIKey == "" {
+		return ErrEmptyAPIKey
+	}
+	return nil
+}

--- a/services/payment-order/adapters/gateway/stripe/config_test.go
+++ b/services/payment-order/adapters/gateway/stripe/config_test.go
@@ -1,0 +1,45 @@
+package stripe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Validate_MissingAPIKey(t *testing.T) {
+	cfg := DefaultConfig()
+	// APIKey not set
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEmptyAPIKey)
+}
+
+func TestConfig_Validate_WithAPIKey(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.APIKey = "sk_test_123"
+	err := cfg.Validate()
+	require.NoError(t, err)
+}
+
+func TestDefaultConfig_HasReasonableDefaults(t *testing.T) {
+	cfg := DefaultConfig()
+
+	assert.Equal(t, 1000, cfg.TenantCacheSize)
+	assert.Equal(t, 3, cfg.MaxRetries)
+	assert.Greater(t, cfg.RetryInitialInterval.Milliseconds(), int64(0))
+	assert.Greater(t, cfg.CircuitBreakerFailureThreshold, uint32(0))
+}
+
+func TestTenantConfig_Validate_MissingAccountID(t *testing.T) {
+	tc := TenantConfig{}
+	err := tc.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingAccountID)
+}
+
+func TestTenantConfig_Validate_WithAccountID(t *testing.T) {
+	tc := TenantConfig{ConnectedAccountID: "acct_123"}
+	err := tc.Validate()
+	require.NoError(t, err)
+}

--- a/services/payment-order/adapters/gateway/stripe/idempotency.go
+++ b/services/payment-order/adapters/gateway/stripe/idempotency.go
@@ -1,0 +1,21 @@
+package stripe
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/google/uuid"
+)
+
+// IdempotencyKey generates a deterministic idempotency key from a payment order ID
+// and an operation suffix. The same (paymentOrderID, operation) pair always produces
+// the same key, ensuring safe retries without duplicate Stripe charges.
+//
+// Format: "mdn:<sha256-prefix>" where the hash is over "paymentOrderID:operation".
+//
+// Example operations: "payment_intent", "setup_intent", "refund", "capture".
+func IdempotencyKey(paymentOrderID uuid.UUID, operation string) string {
+	data := paymentOrderID.String() + ":" + operation
+	hash := sha256.Sum256([]byte(data))
+	return "mdn:" + hex.EncodeToString(hash[:16])
+}

--- a/services/payment-order/adapters/gateway/stripe/idempotency_test.go
+++ b/services/payment-order/adapters/gateway/stripe/idempotency_test.go
@@ -1,0 +1,56 @@
+package stripe
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIdempotencyKey_Deterministic(t *testing.T) {
+	id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	op := "payment_intent"
+
+	key1 := IdempotencyKey(id, op)
+	key2 := IdempotencyKey(id, op)
+
+	assert.Equal(t, key1, key2, "same inputs must produce same key")
+}
+
+func TestIdempotencyKey_DifferentOperations(t *testing.T) {
+	id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+
+	keyPI := IdempotencyKey(id, "payment_intent")
+	keySI := IdempotencyKey(id, "setup_intent")
+
+	assert.NotEqual(t, keyPI, keySI, "different operations must produce different keys")
+}
+
+func TestIdempotencyKey_DifferentOrders(t *testing.T) {
+	id1 := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	id2 := uuid.MustParse("550e8400-e29b-41d4-a716-446655440001")
+
+	key1 := IdempotencyKey(id1, "payment_intent")
+	key2 := IdempotencyKey(id2, "payment_intent")
+
+	assert.NotEqual(t, key1, key2, "different order IDs must produce different keys")
+}
+
+func TestIdempotencyKey_HasPrefix(t *testing.T) {
+	id := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	key := IdempotencyKey(id, "payment_intent")
+
+	assert.Contains(t, key, "mdn:", "key must have mdn: prefix")
+}
+
+func TestIdempotencyKey_ConsistentLength(t *testing.T) {
+	id1 := uuid.MustParse("550e8400-e29b-41d4-a716-446655440000")
+	id2 := uuid.MustParse("ffffffff-ffff-ffff-ffff-ffffffffffff")
+
+	key1 := IdempotencyKey(id1, "payment_intent")
+	key2 := IdempotencyKey(id2, "refund")
+
+	assert.Equal(t, len(key1), len(key2), "keys should have consistent length")
+	// "mdn:" (4) + 32 hex chars = 36
+	assert.Len(t, key1, 36)
+}

--- a/services/payment-order/adapters/gateway/stripe/integration_test.go
+++ b/services/payment-order/adapters/gateway/stripe/integration_test.go
@@ -1,0 +1,66 @@
+package stripe
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	stripego "github.com/stripe/stripe-go/v82"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// skipWithoutStripeKey skips the test if STRIPE_TEST_API_KEY is not set.
+func skipWithoutStripeKey(t *testing.T) string {
+	t.Helper()
+	key := os.Getenv("STRIPE_TEST_API_KEY")
+	if key == "" {
+		t.Skip("STRIPE_TEST_API_KEY not set")
+	}
+	return key
+}
+
+// skipWithoutStripeAccount skips if STRIPE_TEST_CONNECTED_ACCOUNT is not set.
+func skipWithoutStripeAccount(t *testing.T) string {
+	t.Helper()
+	acct := os.Getenv("STRIPE_TEST_CONNECTED_ACCOUNT")
+	if acct == "" {
+		t.Skip("STRIPE_TEST_CONNECTED_ACCOUNT not set")
+	}
+	return acct
+}
+
+func TestIntegration_CreatePaymentIntent(t *testing.T) {
+	apiKey := skipWithoutStripeKey(t)
+	connectedAccount := skipWithoutStripeAccount(t)
+
+	cfg := DefaultConfig()
+	cfg.APIKey = apiKey
+
+	provider := newMockProvider(map[string]TenantConfig{
+		"integration_test": {
+			ConnectedAccountID: connectedAccount,
+		},
+	})
+
+	factory, err := NewClientFactory(cfg, provider, nil)
+	require.NoError(t, err)
+
+	ctx := tenant.WithTenant(t.Context(), tenant.TenantID("integration_test"))
+	client, err := factory.NewClient(ctx)
+	require.NoError(t, err)
+
+	// Create a PaymentIntent on the Connected Account
+	params := &stripego.PaymentIntentCreateParams{
+		Amount:   stripego.Int64(1000),
+		Currency: stripego.String(string(stripego.CurrencyUSD)),
+	}
+	client.ApplyAccount(&params.Params)
+
+	pi, err := client.Raw.V1PaymentIntents.Create(ctx, params)
+	require.NoError(t, err)
+	assert.NotEmpty(t, pi.ID)
+	assert.Equal(t, int64(1000), pi.Amount)
+	assert.Equal(t, stripego.CurrencyUSD, pi.Currency)
+}

--- a/services/payment-order/adapters/gateway/stripe/tenant_config.go
+++ b/services/payment-order/adapters/gateway/stripe/tenant_config.go
@@ -1,0 +1,34 @@
+package stripe
+
+import "errors"
+
+// TenantConfig holds the Stripe Connect configuration for a specific tenant.
+type TenantConfig struct {
+	// ConnectedAccountID is the Stripe Connected Account ID (acct_...).
+	ConnectedAccountID string
+
+	// WebhookEndpointSecret is the per-tenant webhook signing secret (whsec_...).
+	WebhookEndpointSecret string
+}
+
+// Validate checks that required fields are present.
+func (tc TenantConfig) Validate() error {
+	if tc.ConnectedAccountID == "" {
+		return ErrMissingAccountID
+	}
+	return nil
+}
+
+// TenantConfigProvider retrieves Stripe Connect configuration for a tenant.
+// Implementations may call control-plane gRPC, read from local config, etc.
+type TenantConfigProvider interface {
+	// GetTenantConfig returns the Stripe Connect config for the given tenant.
+	// Returns ErrTenantConfigNotFound if the tenant has no Stripe configuration.
+	GetTenantConfig(tenantID string) (TenantConfig, error)
+}
+
+// Tenant config errors.
+var (
+	ErrMissingAccountID     = errors.New("connected account ID must not be empty")
+	ErrTenantConfigNotFound = errors.New("stripe configuration not found for tenant")
+)


### PR DESCRIPTION
## Summary
- Implement `StripeClientFactory` with tenant config retrieval, LRU caching (TTL-based), and cache invalidation
- Create `StripeClient` wrapper that applies Connected Account routing (`SetStripeAccount`) on every request
- Add circuit breaker (gobreaker) and exponential backoff (cenkalti/backoff) for resilient config fetching
- Implement deterministic idempotency key generation from `payment_order_id + operation` suffix
- Integration test scaffold with `t.Skip` when `STRIPE_TEST_API_KEY` is not set

## Task Master
Tag: stripe-connect, Task: 5

## Changes Made
- `services/payment-order/adapters/gateway/stripe/config.go` - Config struct with defaults and validation
- `services/payment-order/adapters/gateway/stripe/tenant_config.go` - TenantConfig, TenantConfigProvider interface
- `services/payment-order/adapters/gateway/stripe/client.go` - ClientFactory (cache + circuit breaker + retry) and Client wrapper
- `services/payment-order/adapters/gateway/stripe/idempotency.go` - Deterministic idempotency key generation
- `services/payment-order/adapters/gateway/stripe/client_test.go` - Unit tests for factory, caching, circuit breaker, context
- `services/payment-order/adapters/gateway/stripe/config_test.go` - Config validation tests
- `services/payment-order/adapters/gateway/stripe/idempotency_test.go` - Idempotency key determinism tests
- `services/payment-order/adapters/gateway/stripe/integration_test.go` - Stripe test mode integration test (skipped without API key)

## Technical Details
- Uses `stripe-go/v82` (already in go.mod) per-request `SetStripeAccount` for Connect routing (not global state)
- LRU cache (hashicorp/golang-lru/v2) with configurable TTL prevents repeated config lookups
- Circuit breaker follows existing `resilient_gateway.go` pattern with gobreaker/v2
- `TenantConfigProvider` interface decouples from control-plane gRPC (can be implemented later)
- Idempotency keys use SHA-256 of `paymentOrderID:operation` for deterministic retry safety

## Test Plan
- [x] Unit tests for StripeClientFactory tenant config retrieval and caching (22 tests)
- [x] Unit tests for cache expiration and invalidation
- [x] Unit tests for circuit breaker tripping on repeated failures
- [x] Unit tests for idempotency key determinism and uniqueness
- [x] Unit tests for Connected Account routing (SetStripeAccount)
- [x] Integration test with Stripe test mode (skipped without API key)
- [x] go vet clean
- [x] golangci-lint clean (via pre-commit hook)