### PR TITLE
feat: Add party payment methods schema and domain layer

### DIFF
--- a/services/party/adapters/persistence/payment_method_entity.go
+++ b/services/party/adapters/persistence/payment_method_entity.go
@@ -1,0 +1,82 @@
+// Package persistence provides database persistence for the party domain
+package persistence
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/shared/platform/audit"
+	"gorm.io/gorm"
+)
+
+// PaymentMethodEntity represents the database persistence model for party payment methods.
+// This entity MUST match the schema defined in migrations/20260210000001_party_payment_methods.sql
+type PaymentMethodEntity struct {
+	// Primary key
+	ID uuid.UUID `gorm:"type:uuid;primaryKey;default:gen_random_uuid()"`
+
+	// Foreign key to party
+	PartyID uuid.UUID `gorm:"column:party_id;type:uuid;not null"`
+
+	// Provider fields
+	Provider           string `gorm:"column:provider;type:varchar(50);not null"`
+	ProviderCustomerID string `gorm:"column:provider_customer_id;type:varchar(255);not null"`
+	ProviderMethodID   string `gorm:"column:provider_method_id;type:varchar(255);not null"`
+
+	// Method type (CARD, BANK_ACCOUNT, SEPA)
+	MethodType string `gorm:"column:method_type;type:varchar(50);not null"`
+
+	// Default flag
+	IsDefault bool `gorm:"column:is_default;not null;default:false"`
+
+	// Non-sensitive display metadata (last4, brand, exp_month, exp_year)
+	Metadata *string `gorm:"column:metadata;type:jsonb;default:'{}'"`
+
+	// Lifecycle status (ACTIVE, EXPIRED, REMOVED)
+	Status string `gorm:"column:status;type:varchar(20);not null;default:'ACTIVE'"`
+
+	// Optimistic locking
+	Version int64 `gorm:"column:version;not null;default:1"`
+
+	// Timestamps
+	CreatedAt time.Time `gorm:"column:created_at;not null;default:now()"`
+	UpdatedAt time.Time `gorm:"column:updated_at;not null;default:now()"`
+}
+
+// TableName overrides the default table name.
+// Uses singular, unqualified name per database-per-service architecture.
+func (PaymentMethodEntity) TableName() string {
+	return "party_payment_method"
+}
+
+// AuditID returns the record ID as a string for audit logging.
+// Implements the audit.Auditable interface.
+func (p PaymentMethodEntity) AuditID() string {
+	return p.ID.String()
+}
+
+// AuditTableName returns the table name for audit logging.
+// Implements the audit.Auditable interface.
+func (p PaymentMethodEntity) AuditTableName() string {
+	return p.TableName()
+}
+
+// AfterCreate is a GORM hook that runs after INSERT operations.
+func (p *PaymentMethodEntity) AfterCreate(tx *gorm.DB) error {
+	return audit.RecordCreate(tx, *p)
+}
+
+// BeforeUpdate is a GORM hook that runs before UPDATE operations.
+func (p *PaymentMethodEntity) BeforeUpdate(tx *gorm.DB) error {
+	return audit.CaptureOldValue(tx, *p)
+}
+
+// AfterUpdate is a GORM hook that runs after UPDATE operations.
+func (p *PaymentMethodEntity) AfterUpdate(tx *gorm.DB) error {
+	return audit.RecordUpdate(tx, *p)
+}
+
+// AfterDelete is a GORM hook that runs after DELETE operations.
+func (p *PaymentMethodEntity) AfterDelete(tx *gorm.DB) error {
+	return audit.RecordDelete(tx, *p)
+}

--- a/services/party/adapters/persistence/payment_method_repository.go
+++ b/services/party/adapters/persistence/payment_method_repository.go
@@ -189,6 +189,7 @@ func unsetPartyDefault(tx *gorm.DB, partyID uuid.UUID, excludeID uuid.UUID) erro
 
 	return query.Updates(map[string]interface{}{
 		"is_default": false,
+		"version":    gorm.Expr("version + 1"),
 		"updated_at": time.Now(),
 	}).Error
 }

--- a/services/party/adapters/persistence/payment_method_repository.go
+++ b/services/party/adapters/persistence/payment_method_repository.go
@@ -1,0 +1,247 @@
+// Package persistence provides database persistence for the party domain
+package persistence
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"gorm.io/gorm"
+)
+
+// Payment method repository errors
+var (
+	ErrPaymentMethodNotFound = errors.New("payment method not found")
+)
+
+// PaymentMethodRepository provides persistence operations for party payment methods
+type PaymentMethodRepository struct {
+	db *gorm.DB
+}
+
+// NewPaymentMethodRepository creates a new payment method repository
+func NewPaymentMethodRepository(database *gorm.DB) *PaymentMethodRepository {
+	return &PaymentMethodRepository{db: database}
+}
+
+// DB returns the underlying database connection for transaction support.
+func (r *PaymentMethodRepository) DB() *gorm.DB {
+	return r.db
+}
+
+// WithTx returns a new PaymentMethodRepository that uses the provided transaction.
+func (r *PaymentMethodRepository) WithTx(tx *gorm.DB) *PaymentMethodRepository {
+	return &PaymentMethodRepository{db: tx}
+}
+
+// withTenantTransaction executes the given function with tenant scoping.
+func (r *PaymentMethodRepository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// Create inserts a new payment method.
+// If the payment method is marked as default, any existing default for the same party
+// is atomically unset within the same transaction.
+func (r *PaymentMethodRepository) Create(ctx context.Context, pm *domain.PaymentMethod) error {
+	entity := paymentMethodToEntity(pm)
+
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		// If this is the default, unset any existing default for the party
+		if entity.IsDefault {
+			if err := unsetPartyDefault(tx, entity.PartyID, uuid.Nil); err != nil {
+				return err
+			}
+		}
+
+		if err := tx.Create(&entity).Error; err != nil {
+			if isDuplicateKeyError(err) {
+				return ErrPaymentMethodExists
+			}
+			return err
+		}
+		return nil
+	})
+}
+
+// ErrPaymentMethodExists is returned when a duplicate payment method is detected
+var ErrPaymentMethodExists = errors.New("payment method already exists")
+
+// Update saves changes to an existing payment method with optimistic locking.
+// If the payment method is being set as default, any existing default for the same party
+// is atomically unset within the same transaction.
+func (r *PaymentMethodRepository) Update(ctx context.Context, pm *domain.PaymentMethod) error {
+	entity := paymentMethodToEntity(pm)
+
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		// If becoming the default, unset any existing default for the party (excluding self)
+		if entity.IsDefault {
+			if err := unsetPartyDefault(tx, entity.PartyID, entity.ID); err != nil {
+				return err
+			}
+		}
+
+		// Optimistic locking: only update if version matches
+		expectedDBVersion := entity.Version - 1
+		result := tx.Model(&PaymentMethodEntity{}).
+			Where("id = ? AND version = ?", entity.ID, expectedDBVersion).
+			Updates(map[string]interface{}{
+				"is_default": entity.IsDefault,
+				"metadata":   entity.Metadata,
+				"status":     entity.Status,
+				"version":    entity.Version,
+				"updated_at": entity.UpdatedAt,
+			})
+
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return ErrVersionConflict
+		}
+		return nil
+	})
+}
+
+// FindByID retrieves a payment method by its UUID.
+func (r *PaymentMethodRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.PaymentMethod, error) {
+	var pm *domain.PaymentMethod
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entity PaymentMethodEntity
+		result := tx.Where("id = ?", id).First(&entity)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return ErrPaymentMethodNotFound
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		pm = paymentMethodToDomain(&entity)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return pm, nil
+}
+
+// ListActiveByParty returns all active payment methods for a party.
+func (r *PaymentMethodRepository) ListActiveByParty(ctx context.Context, partyID uuid.UUID) ([]*domain.PaymentMethod, error) {
+	var methods []*domain.PaymentMethod
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entities []PaymentMethodEntity
+		result := tx.Where("party_id = ? AND status = ?", partyID, "ACTIVE").
+			Order("created_at ASC").
+			Find(&entities)
+		if result.Error != nil {
+			return result.Error
+		}
+		methods = make([]*domain.PaymentMethod, len(entities))
+		for i := range entities {
+			methods[i] = paymentMethodToDomain(&entities[i])
+		}
+		return nil
+	})
+	return methods, err
+}
+
+// FindDefaultByParty returns the default active payment method for a party, if any.
+// Returns (nil, nil) if no default payment method exists.
+func (r *PaymentMethodRepository) FindDefaultByParty(ctx context.Context, partyID uuid.UUID) (*domain.PaymentMethod, error) {
+	var pm *domain.PaymentMethod
+	var found bool
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		var entity PaymentMethodEntity
+		result := tx.Where("party_id = ? AND is_default = true AND status = ?", partyID, "ACTIVE").
+			First(&entity)
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			found = false
+			return nil
+		}
+		if result.Error != nil {
+			return result.Error
+		}
+		found = true
+		pm = paymentMethodToDomain(&entity)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil //nolint:nilnil // nil,nil signals "not found" without error
+	}
+	return pm, nil
+}
+
+// unsetPartyDefault clears the is_default flag on any active default payment method for the party.
+// excludeID can be set to skip a specific payment method (e.g., the one being set as default).
+// Pass uuid.Nil to not exclude any.
+func unsetPartyDefault(tx *gorm.DB, partyID uuid.UUID, excludeID uuid.UUID) error {
+	query := tx.Model(&PaymentMethodEntity{}).
+		Where("party_id = ? AND is_default = true AND status = ?", partyID, "ACTIVE")
+
+	if excludeID != uuid.Nil {
+		query = query.Where("id != ?", excludeID)
+	}
+
+	return query.Updates(map[string]interface{}{
+		"is_default": false,
+		"updated_at": time.Now(),
+	}).Error
+}
+
+// paymentMethodToEntity converts domain model to database entity
+func paymentMethodToEntity(pm *domain.PaymentMethod) *PaymentMethodEntity {
+	entity := &PaymentMethodEntity{
+		ID:                 pm.ID(),
+		PartyID:            pm.PartyID(),
+		Provider:           string(pm.Provider()),
+		ProviderCustomerID: pm.ProviderCustomerID(),
+		ProviderMethodID:   pm.ProviderMethodID(),
+		MethodType:         string(pm.MethodType()),
+		IsDefault:          pm.IsDefault(),
+		Status:             string(pm.Status()),
+		Version:            pm.Version(),
+		CreatedAt:          pm.CreatedAt(),
+		UpdatedAt:          pm.UpdatedAt(),
+	}
+
+	if pm.Metadata() != nil {
+		data, err := json.Marshal(pm.Metadata())
+		if err == nil {
+			s := string(data)
+			entity.Metadata = &s
+		}
+	}
+
+	return entity
+}
+
+// paymentMethodToDomain converts database entity to domain model
+func paymentMethodToDomain(entity *PaymentMethodEntity) *domain.PaymentMethod {
+	var metadata *domain.PaymentMethodMetadata
+	if entity.Metadata != nil && *entity.Metadata != "" && *entity.Metadata != "{}" {
+		var m domain.PaymentMethodMetadata
+		if err := json.Unmarshal([]byte(*entity.Metadata), &m); err == nil {
+			metadata = &m
+		}
+	}
+
+	return domain.ReconstructPaymentMethod(
+		entity.ID,
+		entity.PartyID,
+		domain.PaymentProvider(entity.Provider),
+		entity.ProviderCustomerID,
+		entity.ProviderMethodID,
+		domain.PaymentMethodType(entity.MethodType),
+		entity.IsDefault,
+		metadata,
+		domain.PaymentMethodStatus(entity.Status),
+		entity.CreatedAt,
+		entity.UpdatedAt,
+		entity.Version,
+	)
+}

--- a/services/party/adapters/persistence/payment_method_repository_test.go
+++ b/services/party/adapters/persistence/payment_method_repository_test.go
@@ -1,0 +1,661 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/lib/pq"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/meridianhub/meridian/shared/platform/audit"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupPaymentMethodTestDB(t *testing.T) (*gorm.DB, context.Context, func()) {
+	t.Helper()
+	db, cleanup := testdb.SetupPostgres(t, []interface{}{
+		&PartyEntity{},
+		&PaymentMethodEntity{},
+		&audit.AuditOutbox{},
+	})
+
+	// Create the tenant schema for tests
+	tid := tenant.TenantID(testTenantID)
+	schemaName := tid.SchemaName()
+	err := db.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Create the party table in the tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.party (
+		id UUID PRIMARY KEY,
+		party_type VARCHAR(20) NOT NULL,
+		legal_name VARCHAR(255) NOT NULL,
+		display_name VARCHAR(255),
+		status VARCHAR(20) NOT NULL,
+		external_reference VARCHAR(255),
+		external_reference_type VARCHAR(50),
+		version BIGINT NOT NULL DEFAULT 1,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+		deleted_at TIMESTAMP WITH TIME ZONE,
+		created_by VARCHAR(255),
+		updated_by VARCHAR(255),
+		UNIQUE(external_reference, external_reference_type)
+	)`, pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Create the party_payment_method table in the tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.party_payment_method (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		party_id UUID NOT NULL REFERENCES %s.party(id) ON DELETE CASCADE,
+		provider VARCHAR(50) NOT NULL,
+		provider_customer_id VARCHAR(255) NOT NULL,
+		provider_method_id VARCHAR(255) NOT NULL,
+		method_type VARCHAR(50) NOT NULL,
+		is_default BOOLEAN NOT NULL DEFAULT false,
+		metadata JSONB DEFAULT '{}',
+		status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+		version BIGINT NOT NULL DEFAULT 1,
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		CONSTRAINT chk_party_payment_method_provider CHECK (provider IN ('STRIPE')),
+		CONSTRAINT chk_party_payment_method_status CHECK (status IN ('ACTIVE', 'EXPIRED', 'REMOVED'))
+	)`, pq.QuoteIdentifier(schemaName), pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Create indexes
+	err = db.Exec(fmt.Sprintf(`CREATE INDEX IF NOT EXISTS idx_party_payment_method_party
+		ON %s.party_payment_method (party_id) WHERE status = 'ACTIVE'`,
+		pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf(`CREATE UNIQUE INDEX IF NOT EXISTS idx_party_payment_method_provider_method
+		ON %s.party_payment_method (provider, provider_method_id) WHERE status = 'ACTIVE'`,
+		pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	err = db.Exec(fmt.Sprintf(`CREATE UNIQUE INDEX IF NOT EXISTS idx_party_payment_method_default
+		ON %s.party_payment_method (party_id) WHERE is_default = true AND status = 'ACTIVE'`,
+		pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Create the audit_outbox table in the tenant schema
+	err = db.Exec(fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s.audit_outbox (
+		id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+		table_name VARCHAR(100) NOT NULL,
+		operation VARCHAR(10) NOT NULL,
+		record_id VARCHAR(50) NOT NULL,
+		old_values TEXT,
+		new_values TEXT,
+		status VARCHAR(20) NOT NULL DEFAULT 'pending',
+		created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+		retry_count INT NOT NULL DEFAULT 0,
+		last_error TEXT,
+		changed_by VARCHAR(100),
+		transaction_id VARCHAR(100),
+		client_ip VARCHAR(45),
+		user_agent TEXT
+	)`, pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Set default search_path to include tenant schema
+	err = db.Exec(fmt.Sprintf("SET search_path TO %s, public", pq.QuoteIdentifier(schemaName))).Error
+	require.NoError(t, err)
+
+	// Create context with tenant
+	ctx := tenant.WithTenant(context.Background(), tid)
+
+	return db, ctx, cleanup
+}
+
+// createPaymentTestParty creates a party record for payment method tests
+func createPaymentTestParty(t *testing.T, db *gorm.DB) uuid.UUID {
+	t.Helper()
+	partyID := uuid.New()
+	err := db.Exec(`
+		INSERT INTO party (id, party_type, legal_name, status, version, created_at, updated_at, created_by, updated_by)
+		VALUES (?, 'PERSON', 'Test Person', 'ACTIVE', 1, now(), now(), 'system', 'system')
+	`, partyID).Error
+	require.NoError(t, err)
+	return partyID
+}
+
+func TestCreatePaymentMethod(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	pm, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		domain.PaymentMethodTypeCard,
+		false,
+		&domain.PaymentMethodMetadata{Last4: "4242", Brand: "visa", ExpMonth: 12, ExpYear: 2027},
+	)
+	require.NoError(t, err)
+
+	err = repo.Create(ctx, pm)
+	require.NoError(t, err)
+
+	// Retrieve and verify
+	retrieved, err := repo.FindByID(ctx, pm.ID())
+	require.NoError(t, err)
+	assert.Equal(t, pm.ID(), retrieved.ID())
+	assert.Equal(t, partyID, retrieved.PartyID())
+	assert.Equal(t, domain.PaymentProviderStripe, retrieved.Provider())
+	assert.Equal(t, "cus_1234567890ab", retrieved.ProviderCustomerID())
+	assert.Equal(t, "pm_1234567890ab", retrieved.ProviderMethodID())
+	assert.Equal(t, domain.PaymentMethodTypeCard, retrieved.MethodType())
+	assert.False(t, retrieved.IsDefault())
+	assert.Equal(t, domain.PaymentMethodStatusActive, retrieved.Status())
+	assert.Equal(t, int64(1), retrieved.Version())
+	assert.NotNil(t, retrieved.Metadata())
+	assert.Equal(t, "4242", retrieved.Metadata().Last4)
+	assert.Equal(t, "visa", retrieved.Metadata().Brand)
+}
+
+func TestCreatePaymentMethod_WithDefault(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	pm, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		domain.PaymentMethodTypeCard,
+		true,
+		nil,
+	)
+	require.NoError(t, err)
+
+	err = repo.Create(ctx, pm)
+	require.NoError(t, err)
+
+	retrieved, err := repo.FindByID(ctx, pm.ID())
+	require.NoError(t, err)
+	assert.True(t, retrieved.IsDefault())
+}
+
+func TestCreatePaymentMethod_DefaultSwitching(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	// Create first payment method as default
+	pm1, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_first1234567",
+		domain.PaymentMethodTypeCard,
+		true,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm1)
+	require.NoError(t, err)
+
+	// Create second payment method as default - should unset first
+	pm2, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_second234567",
+		domain.PaymentMethodTypeBankAccount,
+		true,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm2)
+	require.NoError(t, err)
+
+	// Verify first is no longer default
+	first, err := repo.FindByID(ctx, pm1.ID())
+	require.NoError(t, err)
+	assert.False(t, first.IsDefault(), "first payment method should no longer be default")
+
+	// Verify second is default
+	second, err := repo.FindByID(ctx, pm2.ID())
+	require.NoError(t, err)
+	assert.True(t, second.IsDefault(), "second payment method should be default")
+}
+
+func TestFindByID_NotFound(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	repo := NewPaymentMethodRepository(db)
+
+	_, err := repo.FindByID(ctx, uuid.New())
+	assert.ErrorIs(t, err, ErrPaymentMethodNotFound)
+}
+
+func TestListActiveByParty(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	// Create 3 payment methods, remove one
+	for i := 0; i < 3; i++ {
+		pm, err := domain.NewPaymentMethod(
+			partyID,
+			domain.PaymentProviderStripe,
+			"cus_1234567890ab",
+			fmt.Sprintf("pm_method%07d", i),
+			domain.PaymentMethodTypeCard,
+			false,
+			nil,
+		)
+		require.NoError(t, err)
+		err = repo.Create(ctx, pm)
+		require.NoError(t, err)
+
+		// Remove the third one
+		if i == 2 {
+			err = pm.Remove()
+			require.NoError(t, err)
+			err = repo.Update(ctx, pm)
+			require.NoError(t, err)
+		}
+	}
+
+	// List active - should only return 2
+	methods, err := repo.ListActiveByParty(ctx, partyID)
+	require.NoError(t, err)
+	assert.Len(t, methods, 2)
+	for _, m := range methods {
+		assert.Equal(t, domain.PaymentMethodStatusActive, m.Status())
+	}
+}
+
+func TestListActiveByParty_Empty(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	methods, err := repo.ListActiveByParty(ctx, partyID)
+	require.NoError(t, err)
+	assert.Empty(t, methods)
+}
+
+func TestFindDefaultByParty(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	// No default initially
+	def, err := repo.FindDefaultByParty(ctx, partyID)
+	require.NoError(t, err)
+	assert.Nil(t, def)
+
+	// Create a default payment method
+	pm, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		domain.PaymentMethodTypeCard,
+		true,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm)
+	require.NoError(t, err)
+
+	// Should find the default
+	def, err = repo.FindDefaultByParty(ctx, partyID)
+	require.NoError(t, err)
+	require.NotNil(t, def)
+	assert.Equal(t, pm.ID(), def.ID())
+	assert.True(t, def.IsDefault())
+}
+
+func TestUpdate_OptimisticLocking(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	pm, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		domain.PaymentMethodTypeCard,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm)
+	require.NoError(t, err)
+
+	// Load two copies
+	copy1, err := repo.FindByID(ctx, pm.ID())
+	require.NoError(t, err)
+	copy2, err := repo.FindByID(ctx, pm.ID())
+	require.NoError(t, err)
+
+	// First update succeeds
+	err = copy1.SetDefault(true)
+	require.NoError(t, err)
+	err = repo.Update(ctx, copy1)
+	require.NoError(t, err)
+
+	// Second update with stale version fails
+	err = copy2.Expire()
+	require.NoError(t, err)
+	err = repo.Update(ctx, copy2)
+	assert.ErrorIs(t, err, ErrVersionConflict)
+}
+
+func TestUpdate_DefaultSwitching(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	// Create two methods, first as default
+	pm1, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_first1234567",
+		domain.PaymentMethodTypeCard,
+		true,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm1)
+	require.NoError(t, err)
+
+	pm2, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_second234567",
+		domain.PaymentMethodTypeBankAccount,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm2)
+	require.NoError(t, err)
+
+	// Set second as default via Update
+	err = pm2.SetDefault(true)
+	require.NoError(t, err)
+	err = repo.Update(ctx, pm2)
+	require.NoError(t, err)
+
+	// Verify first is no longer default
+	first, err := repo.FindByID(ctx, pm1.ID())
+	require.NoError(t, err)
+	assert.False(t, first.IsDefault())
+
+	// Verify second is default
+	second, err := repo.FindByID(ctx, pm2.ID())
+	require.NoError(t, err)
+	assert.True(t, second.IsDefault())
+}
+
+func TestProviderCheckConstraint(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+
+	// Try to insert with invalid provider directly via SQL
+	err := db.WithContext(ctx).Exec(`
+		INSERT INTO party_payment_method (id, party_id, provider, provider_customer_id, provider_method_id, method_type, status, version, created_at, updated_at)
+		VALUES (gen_random_uuid(), ?, 'PAYPAL', 'cus_abc', 'pm_abc', 'CARD', 'ACTIVE', 1, now(), now())
+	`, partyID).Error
+	assert.Error(t, err, "should reject invalid provider")
+}
+
+func TestStatusCheckConstraint(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+
+	// Try to insert with invalid status directly via SQL
+	err := db.WithContext(ctx).Exec(`
+		INSERT INTO party_payment_method (id, party_id, provider, provider_customer_id, provider_method_id, method_type, status, version, created_at, updated_at)
+		VALUES (gen_random_uuid(), ?, 'STRIPE', 'cus_abc', 'pm_abc', 'CARD', 'INVALID', 1, now(), now())
+	`, partyID).Error
+	assert.Error(t, err, "should reject invalid status")
+}
+
+func TestStatusTransition_ActiveToExpired(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	pm, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		domain.PaymentMethodTypeCard,
+		true,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm)
+	require.NoError(t, err)
+
+	// Expire the method
+	err = pm.Expire()
+	require.NoError(t, err)
+	err = repo.Update(ctx, pm)
+	require.NoError(t, err)
+
+	// Verify status and default unset
+	retrieved, err := repo.FindByID(ctx, pm.ID())
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentMethodStatusExpired, retrieved.Status())
+	assert.False(t, retrieved.IsDefault())
+}
+
+func TestStatusTransition_ActiveToRemoved(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	pm, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		domain.PaymentMethodTypeCard,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm)
+	require.NoError(t, err)
+
+	// Remove the method
+	err = pm.Remove()
+	require.NoError(t, err)
+	err = repo.Update(ctx, pm)
+	require.NoError(t, err)
+
+	// Verify status
+	retrieved, err := repo.FindByID(ctx, pm.ID())
+	require.NoError(t, err)
+	assert.Equal(t, domain.PaymentMethodStatusRemoved, retrieved.Status())
+
+	// Should not appear in active list
+	active, err := repo.ListActiveByParty(ctx, partyID)
+	require.NoError(t, err)
+	assert.Empty(t, active)
+}
+
+func TestUniqueProviderMethodIndex(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	// Create first method
+	pm1, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_samemethod123",
+		domain.PaymentMethodTypeCard,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm1)
+	require.NoError(t, err)
+
+	// Create second method with same provider_method_id - should fail
+	pm2, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_samemethod123",
+		domain.PaymentMethodTypeCard,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm2)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, ErrPaymentMethodExists), "should return ErrPaymentMethodExists for duplicate provider_method_id")
+}
+
+func TestUniqueProviderMethodIndex_AllowsAfterRemoval(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	// Create and remove first method
+	pm1, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_reusable12345",
+		domain.PaymentMethodTypeCard,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm1)
+	require.NoError(t, err)
+
+	err = pm1.Remove()
+	require.NoError(t, err)
+	err = repo.Update(ctx, pm1)
+	require.NoError(t, err)
+
+	// Create second method with same provider_method_id - should succeed since first is REMOVED
+	pm2, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_reusable12345",
+		domain.PaymentMethodTypeCard,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm2)
+	require.NoError(t, err, "should allow same provider_method_id after removal")
+}
+
+func TestMetadataPersistence(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	metadata := &domain.PaymentMethodMetadata{
+		Last4:    "4242",
+		Brand:    "visa",
+		ExpMonth: 12,
+		ExpYear:  2027,
+	}
+
+	pm, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		domain.PaymentMethodTypeCard,
+		false,
+		metadata,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm)
+	require.NoError(t, err)
+
+	retrieved, err := repo.FindByID(ctx, pm.ID())
+	require.NoError(t, err)
+	require.NotNil(t, retrieved.Metadata())
+	assert.Equal(t, "4242", retrieved.Metadata().Last4)
+	assert.Equal(t, "visa", retrieved.Metadata().Brand)
+	assert.Equal(t, 12, retrieved.Metadata().ExpMonth)
+	assert.Equal(t, 2027, retrieved.Metadata().ExpYear)
+}
+
+func TestNilMetadataPersistence(t *testing.T) {
+	db, ctx, cleanup := setupPaymentMethodTestDB(t)
+	defer cleanup()
+
+	partyID := createPaymentTestParty(t, db)
+	repo := NewPaymentMethodRepository(db)
+
+	pm, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		domain.PaymentMethodTypeCard,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	err = repo.Create(ctx, pm)
+	require.NoError(t, err)
+
+	retrieved, err := repo.FindByID(ctx, pm.ID())
+	require.NoError(t, err)
+	assert.Nil(t, retrieved.Metadata())
+}

--- a/services/party/domain/payment_method.go
+++ b/services/party/domain/payment_method.go
@@ -1,0 +1,267 @@
+package domain
+
+import (
+	"errors"
+	"regexp"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Payment method domain errors
+var (
+	ErrInvalidProvider         = errors.New("invalid provider: must be STRIPE")
+	ErrInvalidProviderCustomer = errors.New("invalid provider customer ID")
+	ErrInvalidProviderMethod   = errors.New("invalid provider method ID")
+	ErrInvalidMethodType       = errors.New("invalid method type")
+	ErrInvalidPaymentStatus    = errors.New("invalid payment method status")
+	ErrPaymentMethodRemoved    = errors.New("cannot modify a removed payment method")
+	ErrPaymentMethodExpired    = errors.New("cannot set expired payment method as default")
+)
+
+// PaymentProvider represents an external payment provider
+type PaymentProvider string
+
+// Payment provider constants
+const (
+	PaymentProviderStripe PaymentProvider = "STRIPE"
+)
+
+// IsValid checks if the payment provider is valid
+func (p PaymentProvider) IsValid() bool {
+	switch p {
+	case PaymentProviderStripe:
+		return true
+	default:
+		return false
+	}
+}
+
+// PaymentMethodType represents the type of payment method
+type PaymentMethodType string
+
+// Payment method type constants
+const (
+	PaymentMethodTypeCard        PaymentMethodType = "CARD"
+	PaymentMethodTypeBankAccount PaymentMethodType = "BANK_ACCOUNT"
+	PaymentMethodTypeSEPA        PaymentMethodType = "SEPA"
+)
+
+// IsValid checks if the payment method type is valid
+func (mt PaymentMethodType) IsValid() bool {
+	switch mt {
+	case PaymentMethodTypeCard, PaymentMethodTypeBankAccount, PaymentMethodTypeSEPA:
+		return true
+	default:
+		return false
+	}
+}
+
+// PaymentMethodStatus represents the lifecycle state of a payment method
+type PaymentMethodStatus string
+
+// Payment method status constants
+const (
+	PaymentMethodStatusActive  PaymentMethodStatus = "ACTIVE"
+	PaymentMethodStatusExpired PaymentMethodStatus = "EXPIRED"
+	PaymentMethodStatusRemoved PaymentMethodStatus = "REMOVED"
+)
+
+// IsValid checks if the payment method status is valid
+func (s PaymentMethodStatus) IsValid() bool {
+	switch s {
+	case PaymentMethodStatusActive, PaymentMethodStatusExpired, PaymentMethodStatusRemoved:
+		return true
+	default:
+		return false
+	}
+}
+
+// Stripe ID format validators
+var (
+	stripeCustomerIDRegex = regexp.MustCompile(`^cus_[a-zA-Z0-9]{10,}$`)
+	stripeMethodIDRegex   = regexp.MustCompile(`^pm_[a-zA-Z0-9]{10,}$`)
+)
+
+// PaymentMethodMetadata contains non-sensitive display information about a payment method
+type PaymentMethodMetadata struct {
+	Last4    string `json:"last4,omitempty"`
+	Brand    string `json:"brand,omitempty"`
+	ExpMonth int    `json:"exp_month,omitempty"`
+	ExpYear  int    `json:"exp_year,omitempty"`
+}
+
+// PaymentMethod represents a tokenized payment method linked to a party via an external provider.
+//
+// The Version field implements optimistic concurrency control to prevent lost updates
+// in concurrent scenarios. The persistence layer should use this field in UPDATE
+// statements (e.g., WHERE id = ? AND version = ?) to detect conflicts.
+type PaymentMethod struct {
+	id                 uuid.UUID
+	partyID            uuid.UUID
+	provider           PaymentProvider
+	providerCustomerID string
+	providerMethodID   string
+	methodType         PaymentMethodType
+	isDefault          bool
+	metadata           *PaymentMethodMetadata
+	status             PaymentMethodStatus
+	createdAt          time.Time
+	updatedAt          time.Time
+	version            int64
+}
+
+// NewPaymentMethod creates a new payment method with validation
+func NewPaymentMethod(
+	partyID uuid.UUID,
+	provider PaymentProvider,
+	providerCustomerID string,
+	providerMethodID string,
+	methodType PaymentMethodType,
+	isDefault bool,
+	metadata *PaymentMethodMetadata,
+) (*PaymentMethod, error) {
+	if !provider.IsValid() {
+		return nil, ErrInvalidProvider
+	}
+
+	if !stripeCustomerIDRegex.MatchString(providerCustomerID) {
+		return nil, ErrInvalidProviderCustomer
+	}
+
+	if !stripeMethodIDRegex.MatchString(providerMethodID) {
+		return nil, ErrInvalidProviderMethod
+	}
+
+	if !methodType.IsValid() {
+		return nil, ErrInvalidMethodType
+	}
+
+	now := time.Now()
+	return &PaymentMethod{
+		id:                 uuid.New(),
+		partyID:            partyID,
+		provider:           provider,
+		providerCustomerID: providerCustomerID,
+		providerMethodID:   providerMethodID,
+		methodType:         methodType,
+		isDefault:          isDefault,
+		metadata:           metadata,
+		status:             PaymentMethodStatusActive,
+		createdAt:          now,
+		updatedAt:          now,
+		version:            1,
+	}, nil
+}
+
+// ReconstructPaymentMethod recreates a PaymentMethod from persistence layer data.
+// This should only be used by repositories when loading from database.
+func ReconstructPaymentMethod(
+	id uuid.UUID,
+	partyID uuid.UUID,
+	provider PaymentProvider,
+	providerCustomerID string,
+	providerMethodID string,
+	methodType PaymentMethodType,
+	isDefault bool,
+	metadata *PaymentMethodMetadata,
+	status PaymentMethodStatus,
+	createdAt time.Time,
+	updatedAt time.Time,
+	version int64,
+) *PaymentMethod {
+	return &PaymentMethod{
+		id:                 id,
+		partyID:            partyID,
+		provider:           provider,
+		providerCustomerID: providerCustomerID,
+		providerMethodID:   providerMethodID,
+		methodType:         methodType,
+		isDefault:          isDefault,
+		metadata:           metadata,
+		status:             status,
+		createdAt:          createdAt,
+		updatedAt:          updatedAt,
+		version:            version,
+	}
+}
+
+// ID returns the payment method's unique identifier.
+func (pm *PaymentMethod) ID() uuid.UUID { return pm.id }
+
+// PartyID returns the party this payment method belongs to.
+func (pm *PaymentMethod) PartyID() uuid.UUID { return pm.partyID }
+
+// Provider returns the external payment provider.
+func (pm *PaymentMethod) Provider() PaymentProvider { return pm.provider }
+
+// ProviderCustomerID returns the provider's customer token (e.g., cus_xxx).
+func (pm *PaymentMethod) ProviderCustomerID() string { return pm.providerCustomerID }
+
+// ProviderMethodID returns the provider's payment method token (e.g., pm_xxx).
+func (pm *PaymentMethod) ProviderMethodID() string { return pm.providerMethodID }
+
+// MethodType returns the type of payment method (CARD, BANK_ACCOUNT, SEPA).
+func (pm *PaymentMethod) MethodType() PaymentMethodType { return pm.methodType }
+
+// IsDefault returns whether this is the party's default payment method.
+func (pm *PaymentMethod) IsDefault() bool { return pm.isDefault }
+
+// Metadata returns non-sensitive display information about the payment method.
+func (pm *PaymentMethod) Metadata() *PaymentMethodMetadata { return pm.metadata }
+
+// Status returns the current lifecycle status of the payment method.
+func (pm *PaymentMethod) Status() PaymentMethodStatus { return pm.status }
+
+// CreatedAt returns when the payment method was created.
+func (pm *PaymentMethod) CreatedAt() time.Time { return pm.createdAt }
+
+// UpdatedAt returns when the payment method was last updated.
+func (pm *PaymentMethod) UpdatedAt() time.Time { return pm.updatedAt }
+
+// Version returns the optimistic locking version.
+func (pm *PaymentMethod) Version() int64 { return pm.version }
+
+// SetDefault marks this payment method as the default for the party.
+// Cannot set a removed or expired method as default.
+func (pm *PaymentMethod) SetDefault(isDefault bool) error {
+	if pm.status == PaymentMethodStatusRemoved {
+		return ErrPaymentMethodRemoved
+	}
+	if isDefault && pm.status == PaymentMethodStatusExpired {
+		return ErrPaymentMethodExpired
+	}
+
+	pm.isDefault = isDefault
+	pm.updatedAt = time.Now()
+	pm.version++
+	return nil
+}
+
+// Expire transitions the payment method to EXPIRED status.
+// If the method is currently default, it is also unset as default.
+func (pm *PaymentMethod) Expire() error {
+	if pm.status == PaymentMethodStatusRemoved {
+		return ErrPaymentMethodRemoved
+	}
+
+	pm.status = PaymentMethodStatusExpired
+	pm.isDefault = false
+	pm.updatedAt = time.Now()
+	pm.version++
+	return nil
+}
+
+// Remove transitions the payment method to REMOVED status (soft delete).
+// If the method is currently default, it is also unset as default.
+func (pm *PaymentMethod) Remove() error {
+	if pm.status == PaymentMethodStatusRemoved {
+		return ErrPaymentMethodRemoved
+	}
+
+	pm.status = PaymentMethodStatusRemoved
+	pm.isDefault = false
+	pm.updatedAt = time.Now()
+	pm.version++
+	return nil
+}

--- a/services/party/domain/payment_method_test.go
+++ b/services/party/domain/payment_method_test.go
@@ -1,0 +1,334 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPaymentMethod_Valid(t *testing.T) {
+	partyID := uuid.New()
+	pm, err := NewPaymentMethod(
+		partyID,
+		PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		PaymentMethodTypeCard,
+		false,
+		&PaymentMethodMetadata{Last4: "4242", Brand: "visa", ExpMonth: 12, ExpYear: 2027},
+	)
+
+	require.NoError(t, err)
+	assert.NotEqual(t, uuid.Nil, pm.ID())
+	assert.Equal(t, partyID, pm.PartyID())
+	assert.Equal(t, PaymentProviderStripe, pm.Provider())
+	assert.Equal(t, "cus_1234567890ab", pm.ProviderCustomerID())
+	assert.Equal(t, "pm_1234567890ab", pm.ProviderMethodID())
+	assert.Equal(t, PaymentMethodTypeCard, pm.MethodType())
+	assert.False(t, pm.IsDefault())
+	assert.Equal(t, PaymentMethodStatusActive, pm.Status())
+	assert.Equal(t, int64(1), pm.Version())
+	assert.NotNil(t, pm.Metadata())
+	assert.Equal(t, "4242", pm.Metadata().Last4)
+}
+
+func TestNewPaymentMethod_DefaultTrue(t *testing.T) {
+	pm, err := NewPaymentMethod(
+		uuid.New(),
+		PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		PaymentMethodTypeCard,
+		true,
+		nil,
+	)
+
+	require.NoError(t, err)
+	assert.True(t, pm.IsDefault())
+}
+
+func TestNewPaymentMethod_InvalidProvider(t *testing.T) {
+	_, err := NewPaymentMethod(
+		uuid.New(),
+		PaymentProvider("PAYPAL"),
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		PaymentMethodTypeCard,
+		false,
+		nil,
+	)
+
+	assert.ErrorIs(t, err, ErrInvalidProvider)
+}
+
+func TestNewPaymentMethod_InvalidProviderCustomerID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"empty", ""},
+		{"no prefix", "1234567890ab"},
+		{"wrong prefix", "usr_1234567890ab"},
+		{"too short", "cus_abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPaymentMethod(
+				uuid.New(),
+				PaymentProviderStripe,
+				tt.id,
+				"pm_1234567890ab",
+				PaymentMethodTypeCard,
+				false,
+				nil,
+			)
+			assert.ErrorIs(t, err, ErrInvalidProviderCustomer)
+		})
+	}
+}
+
+func TestNewPaymentMethod_InvalidProviderMethodID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"empty", ""},
+		{"no prefix", "1234567890ab"},
+		{"wrong prefix", "card_1234567890ab"},
+		{"too short", "pm_abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewPaymentMethod(
+				uuid.New(),
+				PaymentProviderStripe,
+				"cus_1234567890ab",
+				tt.id,
+				PaymentMethodTypeCard,
+				false,
+				nil,
+			)
+			assert.ErrorIs(t, err, ErrInvalidProviderMethod)
+		})
+	}
+}
+
+func TestNewPaymentMethod_InvalidMethodType(t *testing.T) {
+	_, err := NewPaymentMethod(
+		uuid.New(),
+		PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		PaymentMethodType("CRYPTO"),
+		false,
+		nil,
+	)
+
+	assert.ErrorIs(t, err, ErrInvalidMethodType)
+}
+
+func TestNewPaymentMethod_AllMethodTypes(t *testing.T) {
+	types := []PaymentMethodType{
+		PaymentMethodTypeCard,
+		PaymentMethodTypeBankAccount,
+		PaymentMethodTypeSEPA,
+	}
+
+	for _, mt := range types {
+		t.Run(string(mt), func(t *testing.T) {
+			pm, err := NewPaymentMethod(
+				uuid.New(),
+				PaymentProviderStripe,
+				"cus_1234567890ab",
+				"pm_1234567890ab",
+				mt,
+				false,
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, mt, pm.MethodType())
+		})
+	}
+}
+
+func TestPaymentMethod_SetDefault(t *testing.T) {
+	pm := createTestPaymentMethod(t)
+
+	err := pm.SetDefault(true)
+	require.NoError(t, err)
+	assert.True(t, pm.IsDefault())
+	assert.Equal(t, int64(2), pm.Version())
+
+	err = pm.SetDefault(false)
+	require.NoError(t, err)
+	assert.False(t, pm.IsDefault())
+	assert.Equal(t, int64(3), pm.Version())
+}
+
+func TestPaymentMethod_SetDefault_RemovedMethod(t *testing.T) {
+	pm := createTestPaymentMethod(t)
+	err := pm.Remove()
+	require.NoError(t, err)
+
+	err = pm.SetDefault(true)
+	assert.ErrorIs(t, err, ErrPaymentMethodRemoved)
+}
+
+func TestPaymentMethod_SetDefault_ExpiredMethod(t *testing.T) {
+	pm := createTestPaymentMethod(t)
+	err := pm.Expire()
+	require.NoError(t, err)
+
+	err = pm.SetDefault(true)
+	assert.ErrorIs(t, err, ErrPaymentMethodExpired)
+}
+
+func TestPaymentMethod_SetDefault_ExpiredMethod_UnsetAllowed(t *testing.T) {
+	pm := createTestPaymentMethod(t)
+
+	// Set as default first
+	err := pm.SetDefault(true)
+	require.NoError(t, err)
+
+	// Expire it (auto-unsets default)
+	err = pm.Expire()
+	require.NoError(t, err)
+	assert.False(t, pm.IsDefault())
+
+	// Unsetting default on expired method is fine
+	err = pm.SetDefault(false)
+	require.NoError(t, err)
+}
+
+func TestPaymentMethod_Expire(t *testing.T) {
+	pm := createTestPaymentMethod(t)
+
+	// Set as default first
+	err := pm.SetDefault(true)
+	require.NoError(t, err)
+
+	err = pm.Expire()
+	require.NoError(t, err)
+	assert.Equal(t, PaymentMethodStatusExpired, pm.Status())
+	assert.False(t, pm.IsDefault(), "expiring should unset default")
+}
+
+func TestPaymentMethod_Expire_AlreadyRemoved(t *testing.T) {
+	pm := createTestPaymentMethod(t)
+	err := pm.Remove()
+	require.NoError(t, err)
+
+	err = pm.Expire()
+	assert.ErrorIs(t, err, ErrPaymentMethodRemoved)
+}
+
+func TestPaymentMethod_Remove(t *testing.T) {
+	pm := createTestPaymentMethod(t)
+
+	// Set as default first
+	err := pm.SetDefault(true)
+	require.NoError(t, err)
+
+	err = pm.Remove()
+	require.NoError(t, err)
+	assert.Equal(t, PaymentMethodStatusRemoved, pm.Status())
+	assert.False(t, pm.IsDefault(), "removing should unset default")
+}
+
+func TestPaymentMethod_Remove_AlreadyRemoved(t *testing.T) {
+	pm := createTestPaymentMethod(t)
+	err := pm.Remove()
+	require.NoError(t, err)
+
+	err = pm.Remove()
+	assert.ErrorIs(t, err, ErrPaymentMethodRemoved)
+}
+
+func TestPaymentMethod_Remove_FromExpired(t *testing.T) {
+	pm := createTestPaymentMethod(t)
+	err := pm.Expire()
+	require.NoError(t, err)
+
+	err = pm.Remove()
+	require.NoError(t, err)
+	assert.Equal(t, PaymentMethodStatusRemoved, pm.Status())
+}
+
+func TestPaymentMethod_VersionIncrements(t *testing.T) {
+	pm := createTestPaymentMethod(t)
+	assert.Equal(t, int64(1), pm.Version())
+
+	_ = pm.SetDefault(true) // version 2
+	assert.Equal(t, int64(2), pm.Version())
+
+	_ = pm.Expire() // version 3
+	assert.Equal(t, int64(3), pm.Version())
+}
+
+func TestPaymentProviderIsValid(t *testing.T) {
+	assert.True(t, PaymentProviderStripe.IsValid())
+	assert.False(t, PaymentProvider("PAYPAL").IsValid())
+	assert.False(t, PaymentProvider("").IsValid())
+}
+
+func TestPaymentMethodTypeIsValid(t *testing.T) {
+	assert.True(t, PaymentMethodTypeCard.IsValid())
+	assert.True(t, PaymentMethodTypeBankAccount.IsValid())
+	assert.True(t, PaymentMethodTypeSEPA.IsValid())
+	assert.False(t, PaymentMethodType("CRYPTO").IsValid())
+	assert.False(t, PaymentMethodType("").IsValid())
+}
+
+func TestPaymentMethodStatusIsValid(t *testing.T) {
+	assert.True(t, PaymentMethodStatusActive.IsValid())
+	assert.True(t, PaymentMethodStatusExpired.IsValid())
+	assert.True(t, PaymentMethodStatusRemoved.IsValid())
+	assert.False(t, PaymentMethodStatus("PENDING").IsValid())
+	assert.False(t, PaymentMethodStatus("").IsValid())
+}
+
+func TestReconstructPaymentMethod(t *testing.T) {
+	id := uuid.New()
+	partyID := uuid.New()
+	meta := &PaymentMethodMetadata{Last4: "1234", Brand: "mastercard"}
+
+	pm := ReconstructPaymentMethod(
+		id, partyID, PaymentProviderStripe,
+		"cus_1234567890ab", "pm_1234567890ab",
+		PaymentMethodTypeCard, true, meta,
+		PaymentMethodStatusActive,
+		pmTestTime, pmTestTime, 5,
+	)
+
+	assert.Equal(t, id, pm.ID())
+	assert.Equal(t, partyID, pm.PartyID())
+	assert.True(t, pm.IsDefault())
+	assert.Equal(t, int64(5), pm.Version())
+	assert.Equal(t, "1234", pm.Metadata().Last4)
+}
+
+var pmTestTime = func() time.Time {
+	t, _ := time.Parse(time.RFC3339, "2026-01-01T00:00:00Z")
+	return t
+}()
+
+// createTestPaymentMethod is a helper to create a valid payment method for tests
+func createTestPaymentMethod(t *testing.T) *PaymentMethod {
+	t.Helper()
+	pm, err := NewPaymentMethod(
+		uuid.New(),
+		PaymentProviderStripe,
+		"cus_1234567890ab",
+		"pm_1234567890ab",
+		PaymentMethodTypeCard,
+		false,
+		nil,
+	)
+	require.NoError(t, err)
+	return pm
+}

--- a/services/party/migrations/20260210000001_party_payment_methods.sql
+++ b/services/party/migrations/20260210000001_party_payment_methods.sql
@@ -1,0 +1,37 @@
+-- Party Payment Methods table for storing tokenized payment method references from Stripe
+-- Tracks payment methods (cards, bank accounts, SEPA) linked to parties via external providers
+-- Uses unqualified table names (relies on search_path for tenant isolation)
+
+-- Create "party_payment_method" table (singular, unqualified - uses search_path for schema routing)
+CREATE TABLE "party_payment_method" (
+    "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+    "party_id" uuid NOT NULL,
+    "provider" character varying(50) NOT NULL,
+    "provider_customer_id" character varying(255) NOT NULL,
+    "provider_method_id" character varying(255) NOT NULL,
+    "method_type" character varying(50) NOT NULL,
+    "is_default" boolean NOT NULL DEFAULT false,
+    "metadata" jsonb NULL DEFAULT '{}',
+    "status" character varying(20) NOT NULL DEFAULT 'ACTIVE',
+    "version" bigint NOT NULL DEFAULT 1,
+    "created_at" timestamptz NOT NULL DEFAULT now(),
+    "updated_at" timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY ("id"),
+    CONSTRAINT "fk_party_payment_method_party" FOREIGN KEY ("party_id")
+        REFERENCES "party" ("id") ON DELETE CASCADE,
+    CONSTRAINT "chk_party_payment_method_provider" CHECK ("provider" IN ('STRIPE')),
+    CONSTRAINT "chk_party_payment_method_status" CHECK ("status" IN ('ACTIVE', 'EXPIRED', 'REMOVED'))
+);
+
+-- Index on party_id for listing active payment methods by party
+CREATE INDEX "idx_party_payment_method_party" ON "party_payment_method" ("party_id")
+    WHERE "status" = 'ACTIVE';
+
+-- Unique index on provider + provider_method_id for active methods
+-- Prevents duplicate tokenized references from the same provider
+CREATE UNIQUE INDEX "idx_party_payment_method_provider_method" ON "party_payment_method" ("provider", "provider_method_id")
+    WHERE "status" = 'ACTIVE';
+
+-- Unique partial index ensuring at most one default payment method per party among active methods
+CREATE UNIQUE INDEX "idx_party_payment_method_default" ON "party_payment_method" ("party_id")
+    WHERE "is_default" = true AND "status" = 'ACTIVE';

--- a/services/party/migrations/atlas.sum
+++ b/services/party/migrations/atlas.sum
@@ -1,6 +1,7 @@
-h1:7WtO0d7pXfUNbgs9gzncvPVxSGhq8mHnYOQQj37uwBs=
+h1:HPaLPVrCo3PT25F3WEb/epkLJCG/8tUwKcbjqMLky6o=
 20251216000001_initial.sql h1:e2vtJfpgkEvioqxJ1piy7QAbmihqftHOSlkPDLs8jac=
 20251217000001_audit_system.sql h1:qB+oshTdK74dZ1qX/6Ux9Hz/Ij5yayGpjjSMrgoPIcg=
 20251223000001_business_qualifiers.sql h1:1wSGqT3zHTHS0AYHMjj/zd2JyMnM01AJtL89BmkieLU=
 20251223000002_optimize_association_index.sql h1:0JKaiiRhSGy6/0DJ7xou9kSw9LlQQeVVaJj2Exva9PU=
 20251231000001_party_verification.sql h1:t5v4KO/pDXmlpNuDe+48hEqECC6DLy8chN8pwLWO1m0=
+20260210000001_party_payment_methods.sql h1:akA923j6wcLaupuJ7cT0TcBivxSB5NqCIlJAF/V0ZC0=


### PR DESCRIPTION
## Summary
- Create `party_payment_method` CockroachDB migration with tenant schema isolation (search_path routing)
- CHECK constraints for provider (`STRIPE`) and status (`ACTIVE`/`EXPIRED`/`REMOVED`)
- Partial unique indexes: single default per party, unique provider_method_id among active methods
- Implement `PaymentMethod` domain entity with Stripe ID validation (`cus_xxx`, `pm_xxx`), status transitions, and optimistic locking
- Add `PaymentMethodRepository` with atomic default-switching logic within transactions
- JSONB metadata support for non-sensitive display data (last4, brand, exp_month, exp_year)

## Task Master
Tag: stripe-connect, Task: 1

## Changes
- `services/party/migrations/20260210000001_party_payment_methods.sql` - New migration
- `services/party/migrations/atlas.sum` - Updated hash
- `services/party/domain/payment_method.go` - Domain entity with validation
- `services/party/domain/payment_method_test.go` - 22 domain unit tests
- `services/party/adapters/persistence/payment_method_entity.go` - GORM entity with audit hooks
- `services/party/adapters/persistence/payment_method_repository.go` - Repository with default-switching
- `services/party/adapters/persistence/payment_method_repository_test.go` - 17 integration tests

## Test Plan
- [x] Domain entity unit tests for validation (provider, customer ID, method ID, method type)
- [x] Domain status transition tests (Active->Expired->Removed, version increments)
- [x] Repository integration tests with PostgreSQL testcontainer
- [x] Default-switching atomicity (Create and Update paths)
- [x] Optimistic locking conflict detection
- [x] CHECK constraint enforcement (provider, status)
- [x] Unique index enforcement (provider_method_id among active)
- [x] Unique index allows re-use after removal
- [x] JSONB metadata round-trip persistence