### PR TITLE
feat: Implement MarketDataPublisher adapter for utilization-metering-consumer

### DIFF
--- a/services/utilization-metering-consumer/adapters/mds/market_data_publisher.go
+++ b/services/utilization-metering-consumer/adapters/mds/market_data_publisher.go
@@ -221,6 +221,30 @@ func (b *AggregationBuffer) Drain() []*UtilizationWindow {
 	return result
 }
 
+// Restore merges windows back into the buffer, combining with any existing windows.
+// Used to re-queue windows on publish failure to avoid data loss.
+func (b *AggregationBuffer) Restore(windows []*UtilizationWindow) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for _, w := range windows {
+		key := b.windowKey(w.ResolutionKey, w.WindowStart)
+		existing, exists := b.windows[key]
+		if !exists {
+			cp := *w
+			b.windows[key] = &cp
+			continue
+		}
+		// Merge: add totals, keep max peak, sum observation counts
+		existing.TotalUnits = existing.TotalUnits.Add(w.TotalUnits)
+		existing.ObservationCount += w.ObservationCount
+		if w.PeakUnits.GreaterThan(existing.PeakUnits) {
+			existing.PeakUnits = w.PeakUnits
+		}
+		existing.recalculateAvg()
+	}
+}
+
 // Size returns the number of windows currently in the buffer.
 func (b *AggregationBuffer) Size() int {
 	b.mu.Lock()
@@ -236,8 +260,9 @@ type MarketDataPublisher struct {
 	config    Config
 	logger    *slog.Logger
 
-	stopCh chan struct{}
-	done   chan struct{}
+	stopCh   chan struct{}
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 // NewMarketDataPublisher creates a new publisher that periodically flushes aggregated
@@ -250,6 +275,20 @@ func NewMarketDataPublisher(
 		return nil, ErrNilMDSClient
 	}
 
+	// Normalize config with defaults for zero/invalid values
+	defaults := DefaultConfig()
+	if config.WindowSize <= 0 {
+		config.WindowSize = defaults.WindowSize
+	}
+	if config.FlushInterval <= 0 {
+		config.FlushInterval = defaults.FlushInterval
+	}
+	if config.SourceCode == "" {
+		config.SourceCode = defaults.SourceCode
+	}
+	if config.CircuitBreakerConsecutiveFailures == 0 {
+		config.CircuitBreakerConsecutiveFailures = defaults.CircuitBreakerConsecutiveFailures
+	}
 	if config.Logger == nil {
 		config.Logger = slog.Default()
 	}
@@ -292,8 +331,11 @@ func (p *MarketDataPublisher) IsCircuitBreakerOpen() bool {
 }
 
 // Stop gracefully stops the publisher, flushing any remaining buffered data.
+// Safe to call multiple times.
 func (p *MarketDataPublisher) Stop() {
-	close(p.stopCh)
+	p.stopOnce.Do(func() {
+		close(p.stopCh)
+	})
 	<-p.done
 }
 
@@ -316,6 +358,7 @@ func (p *MarketDataPublisher) flushLoop() {
 }
 
 // flush drains the buffer and publishes all windows to MDS.
+// On failure, windows are restored to the buffer to avoid data loss.
 func (p *MarketDataPublisher) flush() {
 	windows := p.buffer.Drain()
 	if len(windows) == 0 {
@@ -351,6 +394,9 @@ func (p *MarketDataPublisher) flush() {
 			"duration_seconds", duration,
 		)
 		mdsPublishErrorsTotal.WithLabelValues(classifyError(err)).Inc()
+		// Re-queue windows to avoid data loss
+		p.buffer.Restore(windows)
+		mdsBufferSize.Set(float64(p.buffer.Size()))
 		return
 	}
 

--- a/services/utilization-metering-consumer/adapters/mds/market_data_publisher.go
+++ b/services/utilization-metering-consumer/adapters/mds/market_data_publisher.go
@@ -1,0 +1,394 @@
+// Package mds provides the MarketDataPublisher adapter that aggregates utilization
+// measurements in configurable time windows and flushes them to the Market Data
+// Service (MDS) via RecordObservationBatch RPC.
+package mds
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+	"github.com/meridianhub/meridian/services/utilization-metering-consumer/domain"
+	sharedclients "github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/shopspring/decimal"
+	"github.com/sony/gobreaker/v2"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	// ErrNilMDSClient is returned when the MDS gRPC client is nil.
+	ErrNilMDSClient = errors.New("MDS client cannot be nil")
+
+	// ErrCircuitBreakerOpen is returned when the circuit breaker is open.
+	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
+)
+
+// Prometheus metrics for the MarketDataPublisher.
+var (
+	mdsBufferSize = promauto.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "meridian",
+			Subsystem: "utilization_metering",
+			Name:      "mds_buffer_windows",
+			Help:      "Number of aggregation windows currently in the buffer",
+		},
+	)
+
+	mdsFlushDuration = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "meridian",
+			Subsystem: "utilization_metering",
+			Name:      "mds_flush_duration_seconds",
+			Help:      "Duration of MDS flush operations in seconds",
+			Buckets:   []float64{.01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		},
+	)
+
+	mdsPublishErrorsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "utilization_metering",
+			Name:      "mds_publish_errors_total",
+			Help:      "Total number of errors publishing to MDS",
+		},
+		[]string{"error_type"},
+	)
+
+	mdsObservationsPublishedTotal = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "utilization_metering",
+			Name:      "mds_observations_published_total",
+			Help:      "Total number of observations successfully published to MDS",
+		},
+	)
+)
+
+// Config holds configuration for the MarketDataPublisher.
+type Config struct {
+	// WindowSize is the aggregation window duration (default: 1 hour).
+	WindowSize time.Duration
+
+	// FlushInterval is how often the buffer is flushed to MDS (default: 1 hour).
+	FlushInterval time.Duration
+
+	// SourceCode is the MDS data source code for observations (default: "MERIDIAN_UTILIZATION").
+	SourceCode string
+
+	// CircuitBreakerConsecutiveFailures is the number of consecutive failures before
+	// the circuit breaker opens (default: 5).
+	CircuitBreakerConsecutiveFailures uint32
+
+	// Logger for structured logging.
+	Logger *slog.Logger
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		WindowSize:                        1 * time.Hour,
+		FlushInterval:                     1 * time.Hour,
+		SourceCode:                        "MERIDIAN_UTILIZATION",
+		CircuitBreakerConsecutiveFailures: 5,
+		Logger:                            slog.Default(),
+	}
+}
+
+// UtilizationWindow holds aggregated metrics for a single time window + resolution key.
+type UtilizationWindow struct {
+	// ResolutionKey is the hierarchical key: tenant/{resource_type}/{resource_id}
+	ResolutionKey string
+
+	// InstrumentCode is the instrument type code (e.g., "TRANSACTION").
+	InstrumentCode string
+
+	// WindowStart is the start of the aggregation window.
+	WindowStart time.Time
+
+	// WindowEnd is the end of the aggregation window.
+	WindowEnd time.Time
+
+	// TotalUnits is the sum of all measurement amounts in this window.
+	TotalUnits decimal.Decimal
+
+	// PeakUnits is the maximum single measurement amount in this window.
+	PeakUnits decimal.Decimal
+
+	// AvgUnits is the average measurement amount (TotalUnits / ObservationCount).
+	AvgUnits decimal.Decimal
+
+	// ObservationCount is the number of measurements aggregated in this window.
+	ObservationCount int64
+}
+
+// recalculateAvg updates AvgUnits from TotalUnits and ObservationCount.
+func (w *UtilizationWindow) recalculateAvg() {
+	if w.ObservationCount == 0 {
+		w.AvgUnits = decimal.Zero
+		return
+	}
+	w.AvgUnits = w.TotalUnits.Div(decimal.NewFromInt(w.ObservationCount))
+}
+
+// AggregationBuffer provides thread-safe in-memory windowed aggregation.
+type AggregationBuffer struct {
+	mu         sync.Mutex
+	windows    map[string]*UtilizationWindow
+	windowSize time.Duration
+}
+
+// NewAggregationBuffer creates a new buffer with the given window size.
+func NewAggregationBuffer(windowSize time.Duration) *AggregationBuffer {
+	return &AggregationBuffer{
+		windows:    make(map[string]*UtilizationWindow),
+		windowSize: windowSize,
+	}
+}
+
+// windowKey generates the map key: {resolution_key}_{window_start_unix}
+func (b *AggregationBuffer) windowKey(resolutionKey string, windowStart time.Time) string {
+	return fmt.Sprintf("%s_%d", resolutionKey, windowStart.Unix())
+}
+
+// windowStart calculates the start of the window containing the given timestamp.
+func (b *AggregationBuffer) windowStart(ts time.Time) time.Time {
+	return ts.Truncate(b.windowSize)
+}
+
+// Add adds a measurement to the appropriate aggregation window.
+func (b *AggregationBuffer) Add(m *domain.UtilizationMeasurement) {
+	resKey := fmt.Sprintf("%s/%s/%s", m.TenantID, m.ServiceName, m.OperationType)
+	wStart := b.windowStart(m.Timestamp)
+	key := b.windowKey(resKey, wStart)
+	amount := m.Amount.GetAmount()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	w, exists := b.windows[key]
+	if !exists {
+		w = &UtilizationWindow{
+			ResolutionKey:  resKey,
+			InstrumentCode: m.Amount.GetInstrument().Code,
+			WindowStart:    wStart,
+			WindowEnd:      wStart.Add(b.windowSize),
+			TotalUnits:     decimal.Zero,
+			PeakUnits:      decimal.Zero,
+			AvgUnits:       decimal.Zero,
+		}
+		b.windows[key] = w
+	}
+
+	w.TotalUnits = w.TotalUnits.Add(amount)
+	w.ObservationCount++
+	if amount.GreaterThan(w.PeakUnits) {
+		w.PeakUnits = amount
+	}
+	w.recalculateAvg()
+}
+
+// Snapshot returns a copy of all current windows without draining.
+func (b *AggregationBuffer) Snapshot() []*UtilizationWindow {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	result := make([]*UtilizationWindow, 0, len(b.windows))
+	for _, w := range b.windows {
+		cp := *w
+		result = append(result, &cp)
+	}
+	return result
+}
+
+// Drain returns all current windows and clears the buffer.
+func (b *AggregationBuffer) Drain() []*UtilizationWindow {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	result := make([]*UtilizationWindow, 0, len(b.windows))
+	for _, w := range b.windows {
+		cp := *w
+		result = append(result, &cp)
+	}
+	b.windows = make(map[string]*UtilizationWindow)
+	return result
+}
+
+// Size returns the number of windows currently in the buffer.
+func (b *AggregationBuffer) Size() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return len(b.windows)
+}
+
+// MarketDataPublisher aggregates utilization measurements and publishes them to MDS.
+type MarketDataPublisher struct {
+	mdsClient marketinformationv1.MarketInformationServiceClient
+	buffer    *AggregationBuffer
+	cb        *sharedclients.CircuitBreaker
+	config    Config
+	logger    *slog.Logger
+
+	stopCh chan struct{}
+	done   chan struct{}
+}
+
+// NewMarketDataPublisher creates a new publisher that periodically flushes aggregated
+// measurements to MDS via RecordObservationBatch.
+func NewMarketDataPublisher(
+	mdsClient marketinformationv1.MarketInformationServiceClient,
+	config Config,
+) (*MarketDataPublisher, error) {
+	if mdsClient == nil {
+		return nil, ErrNilMDSClient
+	}
+
+	if config.Logger == nil {
+		config.Logger = slog.Default()
+	}
+
+	cbConfig := sharedclients.DefaultCircuitBreakerConfig("mds-publisher")
+	cbConfig.ReadyToTrip = func(counts gobreaker.Counts) bool {
+		return counts.ConsecutiveFailures >= config.CircuitBreakerConsecutiveFailures
+	}
+	cb := sharedclients.NewCircuitBreaker(cbConfig, config.Logger)
+
+	pub := &MarketDataPublisher{
+		mdsClient: mdsClient,
+		buffer:    NewAggregationBuffer(config.WindowSize),
+		cb:        cb,
+		config:    config,
+		logger:    config.Logger.With("component", "market_data_publisher"),
+		stopCh:    make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+
+	go pub.flushLoop()
+
+	return pub, nil
+}
+
+// Publish adds a utilization measurement to the aggregation buffer.
+func (p *MarketDataPublisher) Publish(m *domain.UtilizationMeasurement) {
+	p.buffer.Add(m)
+	mdsBufferSize.Set(float64(p.buffer.Size()))
+}
+
+// BufferSize returns the current number of aggregation windows in the buffer.
+func (p *MarketDataPublisher) BufferSize() int {
+	return p.buffer.Size()
+}
+
+// IsCircuitBreakerOpen returns true if the circuit breaker is currently open.
+func (p *MarketDataPublisher) IsCircuitBreakerOpen() bool {
+	return p.cb.State() == gobreaker.StateOpen
+}
+
+// Stop gracefully stops the publisher, flushing any remaining buffered data.
+func (p *MarketDataPublisher) Stop() {
+	close(p.stopCh)
+	<-p.done
+}
+
+// flushLoop periodically drains and publishes buffered windows to MDS.
+func (p *MarketDataPublisher) flushLoop() {
+	defer close(p.done)
+
+	ticker := time.NewTicker(p.config.FlushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			p.flush()
+		case <-p.stopCh:
+			p.flush() // Final flush on stop
+			return
+		}
+	}
+}
+
+// flush drains the buffer and publishes all windows to MDS.
+func (p *MarketDataPublisher) flush() {
+	windows := p.buffer.Drain()
+	if len(windows) == 0 {
+		return
+	}
+
+	mdsBufferSize.Set(0)
+	startTime := time.Now()
+
+	observations := make([]*marketinformationv1.BatchObservationEntry, 0, len(windows))
+	for _, w := range windows {
+		observations = append(observations, buildObservation(w, p.config.SourceCode))
+	}
+
+	req := &marketinformationv1.RecordObservationBatchRequest{
+		Observations: observations,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	_, err := p.cb.Execute(ctx, func() (any, error) {
+		return p.mdsClient.RecordObservationBatch(ctx, req)
+	})
+
+	duration := time.Since(startTime).Seconds()
+	mdsFlushDuration.Observe(duration)
+
+	if err != nil {
+		p.logger.Error("failed to publish observations to MDS",
+			"error", err,
+			"window_count", len(windows),
+			"duration_seconds", duration,
+		)
+		mdsPublishErrorsTotal.WithLabelValues(classifyError(err)).Inc()
+		return
+	}
+
+	mdsObservationsPublishedTotal.Add(float64(len(observations)))
+	p.logger.Info("published observations to MDS",
+		"observation_count", len(observations),
+		"duration_seconds", duration,
+	)
+}
+
+// buildObservation converts an aggregated UtilizationWindow into a batch observation entry.
+// The resolution key is passed via attributes so that the MDS data set's CEL
+// resolution_key_expression can evaluate it.
+func buildObservation(w *UtilizationWindow, sourceCode string) *marketinformationv1.BatchObservationEntry {
+	midpoint := w.WindowStart.Add(w.WindowEnd.Sub(w.WindowStart) / 2)
+
+	return &marketinformationv1.BatchObservationEntry{
+		DatasetCode: fmt.Sprintf("UTILIZATION_%s", w.InstrumentCode),
+		ObservedAt:  timestamppb.New(midpoint),
+		ValidFrom:   timestamppb.New(w.WindowStart),
+		ValidTo:     timestamppb.New(w.WindowEnd),
+		Value:       w.TotalUnits.String(),
+		Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+		SourceCode:  sourceCode,
+		Attributes: []*quantityv1.AttributeEntry{
+			{Key: "resolution_key", Value: w.ResolutionKey},
+			{Key: "peak_units", Value: w.PeakUnits.String()},
+			{Key: "avg_units", Value: w.AvgUnits.String()},
+			{Key: "observation_count", Value: fmt.Sprintf("%d", w.ObservationCount)},
+		},
+		ClientReference: w.ResolutionKey,
+	}
+}
+
+// classifyError returns a label for the error type for metrics.
+func classifyError(err error) string {
+	if errors.Is(err, ErrCircuitBreakerOpen) {
+		return "circuit_breaker_open"
+	}
+	return "publish_failed"
+}

--- a/services/utilization-metering-consumer/adapters/mds/market_data_publisher.go
+++ b/services/utilization-metering-consumer/adapters/mds/market_data_publisher.go
@@ -380,7 +380,7 @@ func (p *MarketDataPublisher) flush() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	_, err := p.cb.Execute(ctx, func() (any, error) {
+	respAny, err := p.cb.Execute(ctx, func() (any, error) {
 		return p.mdsClient.RecordObservationBatch(ctx, req)
 	})
 
@@ -400,9 +400,39 @@ func (p *MarketDataPublisher) flush() {
 		return
 	}
 
-	mdsObservationsPublishedTotal.Add(float64(len(observations)))
+	// Handle partial failures: the RPC supports partial success where
+	// individual observations may fail while others succeed.
+	successCount := len(observations)
+	resp, _ := respAny.(*marketinformationv1.RecordObservationBatchResponse)
+	if resp != nil && len(resp.Results) > 0 {
+		var failed []*UtilizationWindow
+		successCount = 0
+		for _, r := range resp.Results {
+			if r.Success {
+				successCount++
+				continue
+			}
+			idx := int(r.Index)
+			if idx >= 0 && idx < len(windows) {
+				failed = append(failed, windows[idx])
+				p.logger.Warn("observation failed in batch",
+					"index", idx,
+					"resolution_key", windows[idx].ResolutionKey,
+					"error", r.ErrorMessage,
+				)
+			}
+		}
+		if len(failed) > 0 {
+			mdsPublishErrorsTotal.WithLabelValues("partial_failure").Inc()
+			p.buffer.Restore(failed)
+			mdsBufferSize.Set(float64(p.buffer.Size()))
+		}
+	}
+
+	mdsObservationsPublishedTotal.Add(float64(successCount))
 	p.logger.Info("published observations to MDS",
-		"observation_count", len(observations),
+		"observation_count", successCount,
+		"total_in_batch", len(observations),
 		"duration_seconds", duration,
 	)
 }

--- a/services/utilization-metering-consumer/adapters/mds/market_data_publisher_test.go
+++ b/services/utilization-metering-consumer/adapters/mds/market_data_publisher_test.go
@@ -1,0 +1,721 @@
+package mds
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	"github.com/meridianhub/meridian/services/utilization-metering-consumer/domain"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/meridianhub/meridian/shared/platform/quantity"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// mockMDSClient implements MarketInformationServiceClient for testing.
+type mockMDSClient struct {
+	mu             sync.Mutex
+	batchCalls     []*marketinformationv1.RecordObservationBatchRequest
+	batchResponses []*marketinformationv1.RecordObservationBatchResponse
+	batchErr       error
+	callCount      atomic.Int64
+}
+
+func newMockMDSClient() *mockMDSClient {
+	return &mockMDSClient{}
+}
+
+func (m *mockMDSClient) RecordObservationBatch(_ context.Context, req *marketinformationv1.RecordObservationBatchRequest, _ ...grpc.CallOption) (*marketinformationv1.RecordObservationBatchResponse, error) {
+	m.callCount.Add(1)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.batchCalls = append(m.batchCalls, req)
+
+	if m.batchErr != nil {
+		return nil, m.batchErr
+	}
+
+	if len(m.batchResponses) > 0 {
+		resp := m.batchResponses[0]
+		m.batchResponses = m.batchResponses[1:]
+		return resp, nil
+	}
+
+	// Default success response
+	results := make([]*marketinformationv1.BatchObservationResult, len(req.Observations))
+	for i := range req.Observations {
+		results[i] = &marketinformationv1.BatchObservationResult{
+			Success: true,
+			Observation: &marketinformationv1.MarketPriceObservation{
+				Id:          fmt.Sprintf("obs-%d", i),
+				DatasetCode: req.Observations[i].DatasetCode,
+			},
+			Index: int32(i),
+		}
+	}
+
+	return &marketinformationv1.RecordObservationBatchResponse{
+		Results:      results,
+		TotalCount:   int32(len(req.Observations)),
+		SuccessCount: int32(len(req.Observations)),
+	}, nil
+}
+
+// Stub methods for the full interface (unused in tests)
+func (m *mockMDSClient) RegisterDataSet(context.Context, *marketinformationv1.RegisterDataSetRequest, ...grpc.CallOption) (*marketinformationv1.RegisterDataSetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) UpdateDataSet(context.Context, *marketinformationv1.UpdateDataSetRequest, ...grpc.CallOption) (*marketinformationv1.UpdateDataSetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) ActivateDataSet(context.Context, *marketinformationv1.ActivateDataSetRequest, ...grpc.CallOption) (*marketinformationv1.ActivateDataSetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) DeprecateDataSet(context.Context, *marketinformationv1.DeprecateDataSetRequest, ...grpc.CallOption) (*marketinformationv1.DeprecateDataSetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) RetrieveDataSet(context.Context, *marketinformationv1.RetrieveDataSetRequest, ...grpc.CallOption) (*marketinformationv1.RetrieveDataSetResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) ListDataSets(context.Context, *marketinformationv1.ListDataSetsRequest, ...grpc.CallOption) (*marketinformationv1.ListDataSetsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) RegisterDataSource(context.Context, *marketinformationv1.RegisterDataSourceRequest, ...grpc.CallOption) (*marketinformationv1.RegisterDataSourceResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) UpdateDataSource(context.Context, *marketinformationv1.UpdateDataSourceRequest, ...grpc.CallOption) (*marketinformationv1.UpdateDataSourceResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) DeactivateDataSource(context.Context, *marketinformationv1.DeactivateDataSourceRequest, ...grpc.CallOption) (*marketinformationv1.DeactivateDataSourceResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) ListDataSources(context.Context, *marketinformationv1.ListDataSourcesRequest, ...grpc.CallOption) (*marketinformationv1.ListDataSourcesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) RecordObservation(context.Context, *marketinformationv1.RecordObservationRequest, ...grpc.CallOption) (*marketinformationv1.RecordObservationResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) RetrieveObservation(context.Context, *marketinformationv1.RetrieveObservationRequest, ...grpc.CallOption) (*marketinformationv1.RetrieveObservationResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) ListObservations(context.Context, *marketinformationv1.ListObservationsRequest, ...grpc.CallOption) (*marketinformationv1.ListObservationsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not implemented")
+}
+
+func (m *mockMDSClient) getBatchCalls() []*marketinformationv1.RecordObservationBatchRequest {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]*marketinformationv1.RecordObservationBatchRequest, len(m.batchCalls))
+	copy(result, m.batchCalls)
+	return result
+}
+
+func testInstrument() quantity.Instrument {
+	inst, _ := quantity.NewInstrument("TRANSACTION", 1, "COUNT", 0)
+	return inst
+}
+
+func testMeasurement(tenantID, service, operation string, amount int64, ts time.Time) *domain.UtilizationMeasurement {
+	return &domain.UtilizationMeasurement{
+		TenantID:      tenantID,
+		ServiceName:   service,
+		OperationType: operation,
+		Amount:        quantity.NewAssetFromInt(amount, testInstrument()),
+		Timestamp:     ts,
+		CorrelationID: "corr-" + tenantID,
+	}
+}
+
+// --- AggregationBuffer Tests ---
+
+func TestAggregationBuffer_AddMeasurement(t *testing.T) {
+	buf := NewAggregationBuffer(1 * time.Hour)
+
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	m := testMeasurement("tenant-1", "current-account", "CreateAccount", 1, ts)
+
+	buf.Add(m)
+
+	windows := buf.Snapshot()
+	require.Len(t, windows, 1)
+
+	w := windows[0]
+	assert.Equal(t, int64(1), w.ObservationCount)
+	assert.True(t, w.TotalUnits.Equal(decimal.NewFromInt(1)))
+	assert.True(t, w.PeakUnits.Equal(decimal.NewFromInt(1)))
+}
+
+func TestAggregationBuffer_AggregatesWithinWindow(t *testing.T) {
+	buf := NewAggregationBuffer(1 * time.Hour)
+
+	base := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	// Add multiple measurements within the same hour window
+	buf.Add(testMeasurement("tenant-1", "current-account", "CreateAccount", 3, base.Add(5*time.Minute)))
+	buf.Add(testMeasurement("tenant-1", "current-account", "CreateAccount", 7, base.Add(15*time.Minute)))
+	buf.Add(testMeasurement("tenant-1", "current-account", "CreateAccount", 2, base.Add(30*time.Minute)))
+
+	windows := buf.Snapshot()
+	require.Len(t, windows, 1)
+
+	w := windows[0]
+	assert.Equal(t, int64(3), w.ObservationCount)
+	assert.True(t, w.TotalUnits.Equal(decimal.NewFromInt(12)))
+	assert.True(t, w.PeakUnits.Equal(decimal.NewFromInt(7)))
+	assert.True(t, w.AvgUnits.Equal(decimal.NewFromInt(4)))
+}
+
+func TestAggregationBuffer_SeparatesWindowsByTime(t *testing.T) {
+	buf := NewAggregationBuffer(1 * time.Hour)
+
+	hour1 := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	hour2 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+
+	buf.Add(testMeasurement("tenant-1", "current-account", "Op", 5, hour1))
+	buf.Add(testMeasurement("tenant-1", "current-account", "Op", 3, hour2))
+
+	windows := buf.Snapshot()
+	assert.Len(t, windows, 2)
+}
+
+func TestAggregationBuffer_SeparatesWindowsByResolutionKey(t *testing.T) {
+	buf := NewAggregationBuffer(1 * time.Hour)
+
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+
+	buf.Add(testMeasurement("tenant-1", "current-account", "Op", 5, ts))
+	buf.Add(testMeasurement("tenant-2", "current-account", "Op", 3, ts))
+
+	windows := buf.Snapshot()
+	assert.Len(t, windows, 2)
+}
+
+func TestAggregationBuffer_DrainReturnsAndClears(t *testing.T) {
+	buf := NewAggregationBuffer(1 * time.Hour)
+
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	buf.Add(testMeasurement("tenant-1", "current-account", "Op", 5, ts))
+
+	drained := buf.Drain()
+	require.Len(t, drained, 1)
+
+	// Buffer should be empty after drain
+	assert.Empty(t, buf.Snapshot())
+}
+
+func TestAggregationBuffer_ConcurrentAccess(t *testing.T) {
+	buf := NewAggregationBuffer(1 * time.Hour)
+	base := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	const goroutines = 50
+	const perGoroutine = 100
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			for j := range perGoroutine {
+				ts := base.Add(time.Duration(j) * time.Minute)
+				m := testMeasurement(
+					fmt.Sprintf("tenant-%d", idx),
+					"current-account",
+					"Op",
+					1,
+					ts,
+				)
+				buf.Add(m)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	windows := buf.Snapshot()
+	totalObs := int64(0)
+	for _, w := range windows {
+		totalObs += w.ObservationCount
+	}
+	assert.Equal(t, int64(goroutines*perGoroutine), totalObs)
+}
+
+func TestAggregationBuffer_WindowKey(t *testing.T) {
+	buf := NewAggregationBuffer(1 * time.Hour)
+
+	// Two measurements from same tenant/service in same hour -> same window
+	ts1 := time.Date(2025, 1, 1, 10, 15, 0, 0, time.UTC)
+	ts2 := time.Date(2025, 1, 1, 10, 45, 0, 0, time.UTC)
+
+	buf.Add(testMeasurement("tenant-1", "current-account", "Op", 1, ts1))
+	buf.Add(testMeasurement("tenant-1", "current-account", "Op", 1, ts2))
+
+	windows := buf.Snapshot()
+	require.Len(t, windows, 1)
+	assert.Equal(t, int64(2), windows[0].ObservationCount)
+}
+
+// --- MarketDataPublisher Tests ---
+
+func TestNewMarketDataPublisher_Validation(t *testing.T) {
+	mock := newMockMDSClient()
+
+	t.Run("nil MDS client", func(t *testing.T) {
+		_, err := NewMarketDataPublisher(nil, DefaultConfig())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrNilMDSClient)
+	})
+
+	t.Run("valid config", func(t *testing.T) {
+		pub, err := NewMarketDataPublisher(mock, DefaultConfig())
+		require.NoError(t, err)
+		require.NotNil(t, pub)
+		pub.Stop()
+	})
+}
+
+func TestMarketDataPublisher_PublishFlushesBuffer(t *testing.T) {
+	mock := newMockMDSClient()
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 100 * time.Millisecond
+	cfg.WindowSize = 1 * time.Hour
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+	defer pub.Stop()
+
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	pub.Publish(testMeasurement("tenant-1", "current-account", "CreateAccount", 5, ts))
+
+	// Wait for flush to happen
+	err = await.New().
+		AtMost(3 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mock.callCount.Load() > 0
+		})
+	require.NoError(t, err, "expected at least one batch call after flush interval")
+
+	calls := mock.getBatchCalls()
+	require.NotEmpty(t, calls)
+
+	// Verify observation mapping
+	req := calls[0]
+	require.NotEmpty(t, req.Observations)
+	obs := req.Observations[0]
+
+	assert.Equal(t, "UTILIZATION_TRANSACTION", obs.DatasetCode)
+	assert.Equal(t, marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL, obs.Quality)
+	assert.Contains(t, obs.ClientReference, "tenant-1")
+	assert.Contains(t, obs.ClientReference, "current-account")
+}
+
+func TestMarketDataPublisher_ObservationMapping(t *testing.T) {
+	mock := newMockMDSClient()
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 50 * time.Millisecond
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+	defer pub.Stop()
+
+	windowStart := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	ts := windowStart.Add(30 * time.Minute)
+	pub.Publish(testMeasurement("tenant-1", "current-account", "CreateAccount", 10, ts))
+
+	err = await.New().
+		AtMost(3 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mock.callCount.Load() > 0
+		})
+	require.NoError(t, err)
+
+	calls := mock.getBatchCalls()
+	require.NotEmpty(t, calls)
+
+	obs := calls[0].Observations[0]
+
+	// dataset_code: UTILIZATION_{INSTRUMENT_TYPE}
+	assert.Equal(t, "UTILIZATION_TRANSACTION", obs.DatasetCode)
+
+	// quality: QUALITY_LEVEL_ACTUAL
+	assert.Equal(t, marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL, obs.Quality)
+
+	// resolution_key: tenant/{resource_type}/{resource_id}
+	assert.Equal(t, "tenant-1/current-account/CreateAccount", obs.ClientReference)
+
+	// observed_at: window midpoint
+	expectedMidpoint := windowStart.Add(30 * time.Minute)
+	assert.Equal(t, expectedMidpoint.Unix(), obs.ObservedAt.AsTime().Unix())
+
+	// valid_from/valid_to: window boundaries
+	assert.Equal(t, windowStart.Unix(), obs.ValidFrom.AsTime().Unix())
+	expectedEnd := windowStart.Add(1 * time.Hour)
+	assert.Equal(t, expectedEnd.Unix(), obs.ValidTo.AsTime().Unix())
+
+	// value: total_units as string
+	assert.Equal(t, "10", obs.Value)
+}
+
+func TestMarketDataPublisher_ResolutionKeyFormat(t *testing.T) {
+	mock := newMockMDSClient()
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 50 * time.Millisecond
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+	defer pub.Stop()
+
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	pub.Publish(testMeasurement("my-tenant", "payment-order", "ProcessPayment", 1, ts))
+
+	err = await.New().
+		AtMost(3 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mock.callCount.Load() > 0
+		})
+	require.NoError(t, err)
+
+	calls := mock.getBatchCalls()
+	require.NotEmpty(t, calls)
+	obs := calls[0].Observations[0]
+	assert.Equal(t, "my-tenant/payment-order/ProcessPayment", obs.ClientReference)
+}
+
+func TestMarketDataPublisher_MultipleWindowsFlushed(t *testing.T) {
+	mock := newMockMDSClient()
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 100 * time.Millisecond
+	cfg.WindowSize = 1 * time.Hour
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+	defer pub.Stop()
+
+	// Add measurements in two different hour windows
+	hour1 := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	hour2 := time.Date(2025, 1, 1, 11, 30, 0, 0, time.UTC)
+
+	pub.Publish(testMeasurement("tenant-1", "current-account", "Op", 5, hour1))
+	pub.Publish(testMeasurement("tenant-1", "current-account", "Op", 3, hour2))
+
+	err = await.New().
+		AtMost(3 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mock.callCount.Load() > 0
+		})
+	require.NoError(t, err)
+
+	calls := mock.getBatchCalls()
+	require.NotEmpty(t, calls)
+
+	// Should have 2 observations in the batch (one per window)
+	totalObs := 0
+	for _, call := range calls {
+		totalObs += len(call.Observations)
+	}
+	assert.Equal(t, 2, totalObs)
+}
+
+func TestMarketDataPublisher_CircuitBreaker(t *testing.T) {
+	mock := newMockMDSClient()
+	mock.batchErr = status.Errorf(codes.Unavailable, "service unavailable")
+
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 50 * time.Millisecond
+	cfg.CircuitBreakerConsecutiveFailures = 3
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+	defer pub.Stop()
+
+	// Continuously publish measurements so each flush attempt has data
+	stopPublish := make(chan struct{})
+	go func() {
+		ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+		i := 0
+		for {
+			select {
+			case <-stopPublish:
+				return
+			default:
+				pub.Publish(testMeasurement("tenant-1", "current-account", "Op", 1, ts.Add(time.Duration(i)*time.Millisecond)))
+				i++
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+	}()
+	defer close(stopPublish)
+
+	// Wait for enough flush attempts to trigger circuit breaker
+	err = await.New().
+		AtMost(5 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return pub.IsCircuitBreakerOpen()
+		})
+	require.NoError(t, err, "circuit breaker should open after consecutive failures")
+
+	assert.True(t, pub.IsCircuitBreakerOpen())
+}
+
+func TestMarketDataPublisher_StopFlushesRemaining(t *testing.T) {
+	mock := newMockMDSClient()
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 10 * time.Minute // Long interval so manual flush on stop
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	pub.Publish(testMeasurement("tenant-1", "current-account", "Op", 5, ts))
+
+	// Stop should flush remaining
+	pub.Stop()
+
+	calls := mock.getBatchCalls()
+	require.NotEmpty(t, calls, "Stop should flush remaining buffer contents")
+}
+
+func TestMarketDataPublisher_ConcurrentPublish(t *testing.T) {
+	mock := newMockMDSClient()
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 200 * time.Millisecond
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+	defer pub.Stop()
+
+	const goroutines = 20
+	const perGoroutine = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	base := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	for i := range goroutines {
+		go func(idx int) {
+			defer wg.Done()
+			for j := range perGoroutine {
+				ts := base.Add(time.Duration(j) * time.Minute)
+				pub.Publish(testMeasurement(
+					fmt.Sprintf("tenant-%d", idx),
+					"current-account",
+					"Op",
+					1,
+					ts,
+				))
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Wait for flush
+	err = await.New().
+		AtMost(5 * time.Second).
+		PollInterval(100 * time.Millisecond).
+		Until(func() bool {
+			return mock.callCount.Load() > 0
+		})
+	require.NoError(t, err)
+}
+
+func TestMarketDataPublisher_DatasetCodeMapping(t *testing.T) {
+	tests := []struct {
+		instrumentCode  string
+		expectedDataset string
+	}{
+		{"TRANSACTION", "UTILIZATION_TRANSACTION"},
+		{"API_CALL", "UTILIZATION_API_CALL"},
+		{"STORAGE_GB_HOUR", "UTILIZATION_STORAGE_GB_HOUR"},
+		{"COMPUTE_HOUR", "UTILIZATION_COMPUTE_HOUR"},
+		{"OPERATION", "UTILIZATION_OPERATION"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.instrumentCode, func(t *testing.T) {
+			mock := newMockMDSClient()
+			cfg := DefaultConfig()
+			cfg.FlushInterval = 50 * time.Millisecond
+
+			pub, err := NewMarketDataPublisher(mock, cfg)
+			require.NoError(t, err)
+			defer pub.Stop()
+
+			inst, err := quantity.NewInstrument(tt.instrumentCode, 1, "COUNT", 0)
+			require.NoError(t, err)
+
+			m := &domain.UtilizationMeasurement{
+				TenantID:      "tenant-1",
+				ServiceName:   "test-service",
+				OperationType: "TestOp",
+				Amount:        quantity.NewAssetFromInt(1, inst),
+				Timestamp:     time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC),
+				CorrelationID: "corr-1",
+			}
+			pub.Publish(m)
+
+			err = await.New().
+				AtMost(3 * time.Second).
+				PollInterval(50 * time.Millisecond).
+				Until(func() bool {
+					return mock.callCount.Load() > 0
+				})
+			require.NoError(t, err)
+
+			calls := mock.getBatchCalls()
+			require.NotEmpty(t, calls)
+			assert.Equal(t, tt.expectedDataset, calls[0].Observations[0].DatasetCode)
+		})
+	}
+}
+
+func TestMarketDataPublisher_WindowBoundaryTimestamps(t *testing.T) {
+	mock := newMockMDSClient()
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 50 * time.Millisecond
+	cfg.WindowSize = 1 * time.Hour
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+	defer pub.Stop()
+
+	// Measurement exactly at window boundary
+	ts := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	pub.Publish(testMeasurement("tenant-1", "svc", "Op", 1, ts))
+
+	err = await.New().
+		AtMost(3 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mock.callCount.Load() > 0
+		})
+	require.NoError(t, err)
+
+	calls := mock.getBatchCalls()
+	require.NotEmpty(t, calls)
+	obs := calls[0].Observations[0]
+
+	// valid_from should be the window start (10:00)
+	assert.Equal(t, ts.Unix(), obs.ValidFrom.AsTime().Unix())
+	// valid_to should be window end (11:00)
+	assert.Equal(t, ts.Add(1*time.Hour).Unix(), obs.ValidTo.AsTime().Unix())
+	// observed_at should be midpoint (10:30)
+	assert.Equal(t, ts.Add(30*time.Minute).Unix(), obs.ObservedAt.AsTime().Unix())
+}
+
+func TestMarketDataPublisher_SourceCode(t *testing.T) {
+	mock := newMockMDSClient()
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 50 * time.Millisecond
+	cfg.SourceCode = "MERIDIAN_UTILIZATION"
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+	defer pub.Stop()
+
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	pub.Publish(testMeasurement("tenant-1", "svc", "Op", 1, ts))
+
+	err = await.New().
+		AtMost(3 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mock.callCount.Load() > 0
+		})
+	require.NoError(t, err)
+
+	calls := mock.getBatchCalls()
+	require.NotEmpty(t, calls)
+	obs := calls[0].Observations[0]
+	assert.Equal(t, "MERIDIAN_UTILIZATION", obs.SourceCode)
+}
+
+func TestUtilizationWindow_AverageCalculation(t *testing.T) {
+	w := &UtilizationWindow{
+		TotalUnits:       decimal.NewFromInt(15),
+		PeakUnits:        decimal.NewFromInt(7),
+		ObservationCount: 3,
+	}
+	w.recalculateAvg()
+	assert.True(t, w.AvgUnits.Equal(decimal.NewFromInt(5)))
+}
+
+func TestUtilizationWindow_AverageWithZeroCount(t *testing.T) {
+	w := &UtilizationWindow{
+		TotalUnits:       decimal.Zero,
+		PeakUnits:        decimal.Zero,
+		ObservationCount: 0,
+	}
+	w.recalculateAvg()
+	assert.True(t, w.AvgUnits.Equal(decimal.Zero))
+}
+
+func TestMarketDataPublisher_BufferSizeMetric(t *testing.T) {
+	mock := newMockMDSClient()
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 10 * time.Minute // No auto-flush
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+	defer pub.Stop()
+
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	pub.Publish(testMeasurement("tenant-1", "svc", "Op", 1, ts))
+	pub.Publish(testMeasurement("tenant-2", "svc", "Op", 1, ts))
+
+	assert.Equal(t, 2, pub.BufferSize())
+}
+
+// --- Observation timestamp validation ---
+
+func TestObservationTimestamps(t *testing.T) {
+	windowSize := 1 * time.Hour
+	windowStart := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	windowEnd := windowStart.Add(windowSize)
+	midpoint := windowStart.Add(windowSize / 2)
+
+	obs := buildObservation(
+		&UtilizationWindow{
+			ResolutionKey:    "tenant-1/svc/Op",
+			InstrumentCode:   "TRANSACTION",
+			WindowStart:      windowStart,
+			WindowEnd:        windowEnd,
+			TotalUnits:       decimal.NewFromInt(10),
+			PeakUnits:        decimal.NewFromInt(5),
+			AvgUnits:         decimal.NewFromInt(3),
+			ObservationCount: 3,
+		},
+		"MERIDIAN_UTILIZATION",
+	)
+
+	assert.Equal(t, timestamppb.New(midpoint), obs.ObservedAt)
+	assert.Equal(t, timestamppb.New(windowStart), obs.ValidFrom)
+	assert.Equal(t, timestamppb.New(windowEnd), obs.ValidTo)
+}

--- a/services/utilization-metering-consumer/adapters/mds/market_data_publisher_test.go
+++ b/services/utilization-metering-consumer/adapters/mds/market_data_publisher_test.go
@@ -819,6 +819,50 @@ func TestMarketDataPublisher_StopIsIdempotent(t *testing.T) {
 	pub.Stop()
 }
 
+// --- Partial failure handling ---
+
+func TestMarketDataPublisher_PartialFailureRequeuesFailedOnly(t *testing.T) {
+	mock := newMockMDSClient()
+
+	// Configure mock to return partial failure: first observation succeeds, second fails
+	mock.batchResponses = []*marketinformationv1.RecordObservationBatchResponse{
+		{
+			Results: []*marketinformationv1.BatchObservationResult{
+				{Success: true, Index: 0},
+				{Success: false, Index: 1, ErrorMessage: "dataset not found"},
+			},
+			TotalCount:   2,
+			SuccessCount: 1,
+			FailureCount: 1,
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 10 * time.Minute // Manual flush via Stop
+	cfg.WindowSize = 1 * time.Hour
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+
+	// Publish two measurements with different resolution keys to create two windows
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	pub.Publish(testMeasurement("tenant-1", "svc-a", "Op", 5, ts))
+	pub.Publish(testMeasurement("tenant-2", "svc-b", "Op", 3, ts))
+
+	assert.Equal(t, 2, pub.BufferSize())
+
+	// Stop triggers flush
+	pub.Stop()
+
+	// Verify the batch was sent
+	calls := mock.getBatchCalls()
+	require.Len(t, calls, 1)
+	require.Len(t, calls[0].Observations, 2)
+
+	// The failed window (index 1) should be restored to the buffer
+	assert.Equal(t, 1, pub.BufferSize(), "failed observation should be re-queued")
+}
+
 // --- Config normalization ---
 
 func TestNewMarketDataPublisher_ConfigNormalization(t *testing.T) {

--- a/services/utilization-metering-consumer/adapters/mds/market_data_publisher_test.go
+++ b/services/utilization-metering-consumer/adapters/mds/market_data_publisher_test.go
@@ -719,3 +719,115 @@ func TestObservationTimestamps(t *testing.T) {
 	assert.Equal(t, timestamppb.New(windowStart), obs.ValidFrom)
 	assert.Equal(t, timestamppb.New(windowEnd), obs.ValidTo)
 }
+
+// --- Restore tests ---
+
+func TestAggregationBuffer_RestoreOnEmpty(t *testing.T) {
+	buf := NewAggregationBuffer(1 * time.Hour)
+
+	windowStart := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	windows := []*UtilizationWindow{
+		{
+			ResolutionKey:    "tenant-1/svc/Op",
+			InstrumentCode:   "TRANSACTION",
+			WindowStart:      windowStart,
+			WindowEnd:        windowStart.Add(1 * time.Hour),
+			TotalUnits:       decimal.NewFromInt(10),
+			PeakUnits:        decimal.NewFromInt(5),
+			AvgUnits:         decimal.NewFromInt(5),
+			ObservationCount: 2,
+		},
+	}
+
+	buf.Restore(windows)
+
+	snap := buf.Snapshot()
+	require.Len(t, snap, 1)
+	assert.True(t, snap[0].TotalUnits.Equal(decimal.NewFromInt(10)))
+	assert.Equal(t, int64(2), snap[0].ObservationCount)
+}
+
+func TestAggregationBuffer_RestoreMergesWithExisting(t *testing.T) {
+	buf := NewAggregationBuffer(1 * time.Hour)
+
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	buf.Add(testMeasurement("tenant-1", "svc", "Op", 3, ts))
+
+	// Simulate failed flush: restore windows with same key
+	windowStart := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	buf.Restore([]*UtilizationWindow{
+		{
+			ResolutionKey:    "tenant-1/svc/Op",
+			InstrumentCode:   "TRANSACTION",
+			WindowStart:      windowStart,
+			WindowEnd:        windowStart.Add(1 * time.Hour),
+			TotalUnits:       decimal.NewFromInt(7),
+			PeakUnits:        decimal.NewFromInt(7),
+			AvgUnits:         decimal.NewFromInt(7),
+			ObservationCount: 1,
+		},
+	})
+
+	snap := buf.Snapshot()
+	require.Len(t, snap, 1)
+	// 3 (existing) + 7 (restored) = 10
+	assert.True(t, snap[0].TotalUnits.Equal(decimal.NewFromInt(10)))
+	// peak: max(3, 7) = 7
+	assert.True(t, snap[0].PeakUnits.Equal(decimal.NewFromInt(7)))
+	// count: 1 + 1 = 2
+	assert.Equal(t, int64(2), snap[0].ObservationCount)
+}
+
+func TestMarketDataPublisher_FlushFailureRequeuesData(t *testing.T) {
+	mock := newMockMDSClient()
+	mock.batchErr = status.Errorf(codes.Internal, "internal error")
+
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 50 * time.Millisecond
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+	defer pub.Stop()
+
+	ts := time.Date(2025, 1, 1, 10, 30, 0, 0, time.UTC)
+	pub.Publish(testMeasurement("tenant-1", "svc", "Op", 5, ts))
+
+	// Data should be re-queued on failure, so multiple flush attempts should occur
+	// for the same single measurement (proving it was restored after each failure)
+	err = await.New().
+		AtMost(3 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return mock.callCount.Load() >= 3
+		})
+	require.NoError(t, err, "expected multiple flush attempts due to restore-on-failure")
+}
+
+// --- Idempotent Stop ---
+
+func TestMarketDataPublisher_StopIsIdempotent(t *testing.T) {
+	mock := newMockMDSClient()
+	cfg := DefaultConfig()
+	cfg.FlushInterval = 10 * time.Minute
+
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+
+	// Multiple Stop calls should not panic
+	pub.Stop()
+	pub.Stop()
+	pub.Stop()
+}
+
+// --- Config normalization ---
+
+func TestNewMarketDataPublisher_ConfigNormalization(t *testing.T) {
+	mock := newMockMDSClient()
+
+	// Zero config should use defaults, not panic
+	cfg := Config{}
+	pub, err := NewMarketDataPublisher(mock, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, pub)
+	pub.Stop()
+}


### PR DESCRIPTION
## Summary

- Implements `MarketDataPublisher` adapter in `services/utilization-metering-consumer/adapters/mds/` that aggregates utilization measurements into configurable time windows (default: 1 hour) and publishes them to the Market Data Service (MDS) via `RecordObservationBatch` RPC
- Includes thread-safe `AggregationBuffer` with `sync.Mutex` + `map[string]*UtilizationWindow` keyed by `{resolution_key}_{window_start_timestamp}`
- Circuit breaker pattern (`sony/gobreaker/v2`) for MDS RPC resilience, Prometheus metrics for buffer size / flush latency / publish errors

## Changes Made

**New files:**
- `services/utilization-metering-consumer/adapters/mds/market_data_publisher.go` - Main adapter with `AggregationBuffer`, `MarketDataPublisher`, periodic flush loop, and observation mapping
- `services/utilization-metering-consumer/adapters/mds/market_data_publisher_test.go` - 21 tests covering concurrent access, window boundary handling, metric calculations, circuit breaker, dataset code mapping, and observation timestamp validation

**MDS Observation Mapping:**
- `dataset_code`: `UTILIZATION_{INSTRUMENT_TYPE}` (e.g., `UTILIZATION_TRANSACTION`)
- `quality`: `QUALITY_LEVEL_ACTUAL` (derived from audit events)
- `resolution_key`: Hierarchical format `tenant/{resource_type}/{resource_id}` (passed via attributes)
- `observed_at`: Window midpoint timestamp
- `valid_from` / `valid_to`: Window boundaries

## Task Master

Implements task `market-data-dynamic-pricing.1` - MarketDataPublisher adapter for utilization-metering-consumer.

## Test Plan

- [x] Unit tests for `AggregationBuffer` (add, aggregate, separate windows, drain, concurrent access)
- [x] Unit tests for `MarketDataPublisher` (flush, observation mapping, circuit breaker, stop flush, concurrent publish)
- [x] Dataset code mapping tests for all instrument types (TRANSACTION, API_CALL, STORAGE_GB_HOUR, COMPUTE_HOUR, OPERATION)
- [x] Window boundary timestamp validation
- [x] All existing `utilization-metering-consumer` tests still pass
- [x] `go vet` clean
- [x] `golangci-lint` clean