### PR TITLE
feat: Implement Forecasting Service domain model and repository

### DIFF
--- a/services/forecasting/adapters/persistence/entities.go
+++ b/services/forecasting/adapters/persistence/entities.go
@@ -1,0 +1,28 @@
+// Package persistence provides CockroachDB persistence implementations for the Forecasting service.
+package persistence
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ForecastingStrategyEntity represents a forecasting strategy row in the database.
+type ForecastingStrategyEntity struct {
+	ID                         uuid.UUID
+	TenantID                   string
+	Name                       string
+	Description                sql.NullString
+	StarlarkCode               string
+	HorizonHours               int
+	GranularityHours           int
+	Schedule                   string
+	InputDatasetCodes          []string
+	OutputDatasetCode          string
+	ReferenceDataResolutionKey sql.NullString
+	Status                     string
+	Version                    int64
+	CreatedAt                  time.Time
+	UpdatedAt                  time.Time
+}

--- a/services/forecasting/adapters/persistence/helpers.go
+++ b/services/forecasting/adapters/persistence/helpers.go
@@ -1,0 +1,65 @@
+// Package persistence provides CockroachDB persistence implementations for the Forecasting service.
+package persistence
+
+import (
+	"database/sql"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var errInvalidCursorFormat = errors.New("invalid cursor token format")
+
+// Pagination defaults and limits.
+const (
+	DefaultPageSize = 20
+	MaxPageSize     = 100
+)
+
+// nullStringPtr converts a sql.NullString to a value for use in queries.
+func nullStringPtr(ns sql.NullString) interface{} {
+	if !ns.Valid {
+		return nil
+	}
+	return ns.String
+}
+
+// formatCursorToken creates a cursor token from a timestamp and UUID.
+func formatCursorToken(t time.Time, id uuid.UUID) string {
+	raw := fmt.Sprintf("%d|%s", t.UnixMicro(), id.String())
+	return base64.URLEncoding.EncodeToString([]byte(raw))
+}
+
+// parseCursorToken parses a cursor token into a timestamp and UUID.
+// Returns zero values if the token is empty (first page).
+func parseCursorToken(token string) (time.Time, uuid.UUID, error) {
+	if token == "" {
+		return time.Time{}, uuid.Nil, nil
+	}
+
+	raw, err := base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("invalid cursor token encoding: %w", err)
+	}
+
+	parts := strings.SplitN(string(raw), "|", 2)
+	if len(parts) != 2 {
+		return time.Time{}, uuid.Nil, errInvalidCursorFormat
+	}
+
+	var micros int64
+	if _, err := fmt.Sscanf(parts[0], "%d", &micros); err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("invalid cursor timestamp: %w", err)
+	}
+
+	id, err := uuid.Parse(parts[1])
+	if err != nil {
+		return time.Time{}, uuid.Nil, fmt.Errorf("invalid cursor UUID: %w", err)
+	}
+
+	return time.UnixMicro(micros), id, nil
+}

--- a/services/forecasting/adapters/persistence/mappers.go
+++ b/services/forecasting/adapters/persistence/mappers.go
@@ -1,0 +1,77 @@
+// Package persistence provides CockroachDB persistence implementations for the Forecasting service.
+package persistence
+
+import (
+	"database/sql"
+
+	"github.com/meridianhub/meridian/services/forecasting/domain"
+)
+
+// StrategyToEntity converts a domain ForecastingStrategy to a database entity.
+func StrategyToEntity(s domain.ForecastingStrategy) ForecastingStrategyEntity {
+	entity := ForecastingStrategyEntity{
+		ID:                s.ID(),
+		TenantID:          s.TenantID(),
+		Name:              s.Name(),
+		StarlarkCode:      s.StarlarkCode(),
+		HorizonHours:      s.HorizonHours(),
+		GranularityHours:  s.GranularityHours(),
+		Schedule:          s.Schedule(),
+		InputDatasetCodes: s.InputDatasetCodes(),
+		OutputDatasetCode: s.OutputDatasetCode(),
+		Status:            s.Status().String(),
+		Version:           s.Version(),
+		CreatedAt:         s.CreatedAt(),
+		UpdatedAt:         s.UpdatedAt(),
+	}
+
+	if s.Description() != "" {
+		entity.Description = sql.NullString{String: s.Description(), Valid: true}
+	}
+	if s.ReferenceDataResolutionKey() != "" {
+		entity.ReferenceDataResolutionKey = sql.NullString{String: s.ReferenceDataResolutionKey(), Valid: true}
+	}
+
+	return entity
+}
+
+// EntityToStrategy converts a database entity to a domain ForecastingStrategy.
+func EntityToStrategy(e ForecastingStrategyEntity) domain.ForecastingStrategy {
+	builder := domain.NewForecastingStrategyBuilder().
+		WithID(e.ID).
+		WithTenantID(e.TenantID).
+		WithName(e.Name).
+		WithStarlarkCode(e.StarlarkCode).
+		WithHorizonHours(e.HorizonHours).
+		WithGranularityHours(e.GranularityHours).
+		WithSchedule(e.Schedule).
+		WithInputDatasetCodes(e.InputDatasetCodes).
+		WithOutputDatasetCode(e.OutputDatasetCode).
+		WithStatus(parseStrategyStatus(e.Status)).
+		WithVersion(e.Version).
+		WithCreatedAt(e.CreatedAt).
+		WithUpdatedAt(e.UpdatedAt)
+
+	if e.Description.Valid {
+		builder.WithDescription(e.Description.String)
+	}
+	if e.ReferenceDataResolutionKey.Valid {
+		builder.WithReferenceDataResolutionKey(e.ReferenceDataResolutionKey.String)
+	}
+
+	return builder.Build()
+}
+
+// parseStrategyStatus converts a string status to domain.StrategyStatus.
+func parseStrategyStatus(s string) domain.StrategyStatus {
+	switch s {
+	case "DRAFT":
+		return domain.StrategyStatusDraft
+	case "ACTIVE":
+		return domain.StrategyStatusActive
+	case "DEPRECATED":
+		return domain.StrategyStatusDeprecated
+	default:
+		return domain.StrategyStatusDraft
+	}
+}

--- a/services/forecasting/adapters/persistence/strategy_repository.go
+++ b/services/forecasting/adapters/persistence/strategy_repository.go
@@ -1,0 +1,318 @@
+// Package persistence provides CockroachDB persistence implementations for the Forecasting service.
+package persistence
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/forecasting/domain"
+)
+
+// StrategyRepository implements domain.StrategyRepository using CockroachDB.
+type StrategyRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewStrategyRepository creates a new CockroachDB strategy repository.
+func NewStrategyRepository(pool *pgxpool.Pool) *StrategyRepository {
+	return &StrategyRepository{pool: pool}
+}
+
+// Save persists a new or updated forecasting strategy.
+func (r *StrategyRepository) Save(ctx context.Context, strategy domain.ForecastingStrategy) error {
+	entity := StrategyToEntity(strategy)
+
+	// Check if this is an insert or update
+	var existingVersion int64
+	checkQuery := `SELECT version FROM forecasting_strategy WHERE id = $1`
+	err := r.pool.QueryRow(ctx, checkQuery, entity.ID).Scan(&existingVersion)
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return r.insert(ctx, entity)
+	} else if err != nil {
+		return fmt.Errorf("failed to check existing strategy: %w", err)
+	}
+
+	return r.update(ctx, entity, existingVersion)
+}
+
+func (r *StrategyRepository) insert(ctx context.Context, entity ForecastingStrategyEntity) error {
+	query := `
+		INSERT INTO forecasting_strategy (
+			id, tenant_id, name, description, starlark_code,
+			horizon_hours, granularity_hours, schedule,
+			input_dataset_codes, output_dataset_code,
+			reference_data_resolution_key,
+			status, version, created_at, updated_at
+		) VALUES (
+			$1, $2, $3, $4, $5,
+			$6, $7, $8,
+			$9, $10,
+			$11,
+			$12, $13, $14, $15
+		)`
+
+	_, err := r.pool.Exec(ctx, query,
+		entity.ID,
+		entity.TenantID,
+		entity.Name,
+		nullStringPtr(entity.Description),
+		entity.StarlarkCode,
+		entity.HorizonHours,
+		entity.GranularityHours,
+		entity.Schedule,
+		entity.InputDatasetCodes,
+		entity.OutputDatasetCode,
+		nullStringPtr(entity.ReferenceDataResolutionKey),
+		entity.Status,
+		entity.Version,
+		entity.CreatedAt,
+		entity.UpdatedAt,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return domain.ErrDuplicateActiveStrategy
+		}
+		return fmt.Errorf("failed to insert forecasting strategy: %w", err)
+	}
+
+	return nil
+}
+
+func (r *StrategyRepository) update(ctx context.Context, entity ForecastingStrategyEntity, expectedVersion int64) error {
+	// Optimistic locking: version is incremented by the domain layer before save
+	previousVersion := entity.Version - 1
+
+	if previousVersion != expectedVersion {
+		return domain.ErrVersionMismatch
+	}
+
+	query := `
+		UPDATE forecasting_strategy SET
+			name = $1,
+			description = $2,
+			starlark_code = $3,
+			horizon_hours = $4,
+			granularity_hours = $5,
+			schedule = $6,
+			input_dataset_codes = $7,
+			output_dataset_code = $8,
+			reference_data_resolution_key = $9,
+			status = $10,
+			version = $11,
+			updated_at = $12
+		WHERE id = $13 AND version = $14`
+
+	result, err := r.pool.Exec(ctx, query,
+		entity.Name,
+		nullStringPtr(entity.Description),
+		entity.StarlarkCode,
+		entity.HorizonHours,
+		entity.GranularityHours,
+		entity.Schedule,
+		entity.InputDatasetCodes,
+		entity.OutputDatasetCode,
+		nullStringPtr(entity.ReferenceDataResolutionKey),
+		entity.Status,
+		entity.Version,
+		entity.UpdatedAt,
+		entity.ID,
+		previousVersion,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return domain.ErrDuplicateActiveStrategy
+		}
+		return fmt.Errorf("failed to update forecasting strategy: %w", err)
+	}
+
+	if result.RowsAffected() == 0 {
+		return domain.ErrVersionMismatch
+	}
+
+	return nil
+}
+
+// FindByID retrieves a strategy by its unique identifier.
+func (r *StrategyRepository) FindByID(ctx context.Context, id uuid.UUID) (domain.ForecastingStrategy, error) {
+	query := `
+		SELECT id, tenant_id, name, description, starlark_code,
+			horizon_hours, granularity_hours, schedule,
+			input_dataset_codes, output_dataset_code,
+			reference_data_resolution_key,
+			status, version, created_at, updated_at
+		FROM forecasting_strategy
+		WHERE id = $1`
+
+	entity, err := r.scanStrategy(ctx, query, id)
+	if err != nil {
+		return domain.ForecastingStrategy{}, err
+	}
+
+	return EntityToStrategy(entity), nil
+}
+
+// FindByTenantAndName retrieves an active strategy by tenant and name.
+func (r *StrategyRepository) FindByTenantAndName(ctx context.Context, tenantID string, name string) (domain.ForecastingStrategy, error) {
+	query := `
+		SELECT id, tenant_id, name, description, starlark_code,
+			horizon_hours, granularity_hours, schedule,
+			input_dataset_codes, output_dataset_code,
+			reference_data_resolution_key,
+			status, version, created_at, updated_at
+		FROM forecasting_strategy
+		WHERE tenant_id = $1 AND name = $2 AND status = 'ACTIVE'`
+
+	entity, err := r.scanStrategy(ctx, query, tenantID, name)
+	if err != nil {
+		return domain.ForecastingStrategy{}, err
+	}
+
+	return EntityToStrategy(entity), nil
+}
+
+// ListByTenant returns strategies for a tenant matching the filter criteria.
+func (r *StrategyRepository) ListByTenant(ctx context.Context, tenantID string, filters domain.StrategyFilters) ([]domain.ForecastingStrategy, string, error) {
+	pageSize := filters.Limit
+	if pageSize <= 0 {
+		pageSize = DefaultPageSize
+	}
+	if pageSize > MaxPageSize {
+		pageSize = MaxPageSize
+	}
+
+	cursorTime, cursorID, err := parseCursorToken(filters.PageToken)
+	if err != nil {
+		return nil, "", domain.ErrInvalidPageToken
+	}
+
+	baseQuery := `
+		SELECT id, tenant_id, name, description, starlark_code,
+			horizon_hours, granularity_hours, schedule,
+			input_dataset_codes, output_dataset_code,
+			reference_data_resolution_key,
+			status, version, created_at, updated_at
+		FROM forecasting_strategy
+		WHERE tenant_id = $1`
+
+	args := []interface{}{tenantID}
+	argPos := 2
+
+	if filters.Status != nil {
+		baseQuery += fmt.Sprintf(" AND status = $%d", argPos)
+		args = append(args, filters.Status.String())
+		argPos++
+	}
+
+	if !cursorTime.IsZero() {
+		baseQuery += fmt.Sprintf(" AND (created_at < $%d OR (created_at = $%d AND id < $%d))",
+			argPos, argPos+1, argPos+2)
+		args = append(args, cursorTime, cursorTime, cursorID)
+		argPos += 3
+	}
+
+	baseQuery += " ORDER BY created_at DESC, id DESC"
+	baseQuery += fmt.Sprintf(" LIMIT $%d", argPos)
+	args = append(args, pageSize+1)
+
+	rows, err := r.pool.Query(ctx, baseQuery, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to list strategies: %w", err)
+	}
+	defer rows.Close()
+
+	var entities []ForecastingStrategyEntity
+	for rows.Next() {
+		entity, err := r.scanStrategyFromRows(rows)
+		if err != nil {
+			return nil, "", err
+		}
+		entities = append(entities, entity)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, "", fmt.Errorf("error iterating strategies: %w", err)
+	}
+
+	var nextPageToken string
+	hasMore := len(entities) > pageSize
+	if hasMore {
+		entities = entities[:pageSize]
+		lastEntity := entities[len(entities)-1]
+		nextPageToken = formatCursorToken(lastEntity.CreatedAt, lastEntity.ID)
+	}
+
+	results := make([]domain.ForecastingStrategy, 0, len(entities))
+	for _, entity := range entities {
+		results = append(results, EntityToStrategy(entity))
+	}
+
+	return results, nextPageToken, nil
+}
+
+func (r *StrategyRepository) scanStrategy(ctx context.Context, query string, args ...interface{}) (ForecastingStrategyEntity, error) {
+	var entity ForecastingStrategyEntity
+
+	err := r.pool.QueryRow(ctx, query, args...).Scan(
+		&entity.ID,
+		&entity.TenantID,
+		&entity.Name,
+		&entity.Description,
+		&entity.StarlarkCode,
+		&entity.HorizonHours,
+		&entity.GranularityHours,
+		&entity.Schedule,
+		&entity.InputDatasetCodes,
+		&entity.OutputDatasetCode,
+		&entity.ReferenceDataResolutionKey,
+		&entity.Status,
+		&entity.Version,
+		&entity.CreatedAt,
+		&entity.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return entity, domain.ErrStrategyNotFound
+		}
+		return entity, fmt.Errorf("failed to scan strategy: %w", err)
+	}
+
+	return entity, nil
+}
+
+func (r *StrategyRepository) scanStrategyFromRows(rows pgx.Rows) (ForecastingStrategyEntity, error) {
+	var entity ForecastingStrategyEntity
+
+	err := rows.Scan(
+		&entity.ID,
+		&entity.TenantID,
+		&entity.Name,
+		&entity.Description,
+		&entity.StarlarkCode,
+		&entity.HorizonHours,
+		&entity.GranularityHours,
+		&entity.Schedule,
+		&entity.InputDatasetCodes,
+		&entity.OutputDatasetCode,
+		&entity.ReferenceDataResolutionKey,
+		&entity.Status,
+		&entity.Version,
+		&entity.CreatedAt,
+		&entity.UpdatedAt,
+	)
+	if err != nil {
+		return entity, fmt.Errorf("failed to scan strategy row: %w", err)
+	}
+
+	return entity, nil
+}
+
+// Ensure StrategyRepository implements domain.StrategyRepository.
+var _ domain.StrategyRepository = (*StrategyRepository)(nil)

--- a/services/forecasting/adapters/persistence/strategy_repository_test.go
+++ b/services/forecasting/adapters/persistence/strategy_repository_test.go
@@ -1,0 +1,430 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/forecasting/adapters/persistence/testhelpers"
+	"github.com/meridianhub/meridian/services/forecasting/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTestStrategy(t *testing.T, tenantID, name string) domain.ForecastingStrategy {
+	t.Helper()
+	s, err := domain.NewForecastingStrategy(
+		tenantID,
+		name,
+		"Test strategy for integration tests",
+		`result = [42.0] * 24`,
+		24,
+		1,
+		"0 16 * * *",
+		[]string{"SPOT_PRICE", "WEATHER_FORECAST"},
+		"FORWARD_CURVE_ELEC",
+		"GB/SOUTH",
+	)
+	require.NoError(t, err)
+	return s
+}
+
+func TestStrategyRepository_Save_NewStrategy(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	strategy := createTestStrategy(t, "tenant-1", "Day-Ahead Price Forecast")
+
+	err := tc.Repo.Save(ctx, strategy)
+	require.NoError(t, err)
+
+	// Retrieve and verify
+	retrieved, err := tc.Repo.FindByID(ctx, strategy.ID())
+	require.NoError(t, err)
+
+	assert.Equal(t, strategy.ID(), retrieved.ID())
+	assert.Equal(t, "tenant-1", retrieved.TenantID())
+	assert.Equal(t, "Day-Ahead Price Forecast", retrieved.Name())
+	assert.Equal(t, "Test strategy for integration tests", retrieved.Description())
+	assert.Equal(t, `result = [42.0] * 24`, retrieved.StarlarkCode())
+	assert.Equal(t, 24, retrieved.HorizonHours())
+	assert.Equal(t, 1, retrieved.GranularityHours())
+	assert.Equal(t, "0 16 * * *", retrieved.Schedule())
+	assert.Equal(t, []string{"SPOT_PRICE", "WEATHER_FORECAST"}, retrieved.InputDatasetCodes())
+	assert.Equal(t, "FORWARD_CURVE_ELEC", retrieved.OutputDatasetCode())
+	assert.Equal(t, "GB/SOUTH", retrieved.ReferenceDataResolutionKey())
+	assert.Equal(t, domain.StrategyStatusDraft, retrieved.Status())
+	assert.Equal(t, int64(1), retrieved.Version())
+}
+
+func TestStrategyRepository_Save_UpdateWithOptimisticLocking(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	strategy := createTestStrategy(t, "tenant-1", "Updatable Strategy")
+
+	err := tc.Repo.Save(ctx, strategy)
+	require.NoError(t, err)
+
+	// Update the strategy (domain layer increments version)
+	updated, err := strategy.UpdateDescription("Updated description")
+	require.NoError(t, err)
+
+	err = tc.Repo.Save(ctx, updated)
+	require.NoError(t, err)
+
+	// Verify the update
+	retrieved, err := tc.Repo.FindByID(ctx, strategy.ID())
+	require.NoError(t, err)
+
+	assert.Equal(t, "Updated description", retrieved.Description())
+	assert.Equal(t, int64(2), retrieved.Version())
+}
+
+func TestStrategyRepository_Save_OptimisticLockingConflict(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+	strategy := createTestStrategy(t, "tenant-1", "Conflict Strategy")
+
+	err := tc.Repo.Save(ctx, strategy)
+	require.NoError(t, err)
+
+	// Simulate concurrent update: update with correct version
+	updated1, err := strategy.UpdateDescription("First update")
+	require.NoError(t, err)
+	err = tc.Repo.Save(ctx, updated1)
+	require.NoError(t, err)
+
+	// Second update from stale version (version 1 expected, but db has version 2)
+	updated2, err := strategy.UpdateDescription("Second update - stale")
+	require.NoError(t, err)
+	err = tc.Repo.Save(ctx, updated2)
+	assert.ErrorIs(t, err, domain.ErrVersionMismatch)
+}
+
+func TestStrategyRepository_Save_DuplicateActiveStrategy(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create and activate first strategy
+	strategy1 := createTestStrategy(t, "tenant-1", "Same Name")
+	err := tc.Repo.Save(ctx, strategy1)
+	require.NoError(t, err)
+
+	activated1, err := strategy1.Activate()
+	require.NoError(t, err)
+	err = tc.Repo.Save(ctx, activated1)
+	require.NoError(t, err)
+
+	// Create and activate second strategy with same name for same tenant
+	strategy2 := createTestStrategy(t, "tenant-1", "Same Name")
+	err = tc.Repo.Save(ctx, strategy2)
+	require.NoError(t, err)
+
+	activated2, err := strategy2.Activate()
+	require.NoError(t, err)
+	err = tc.Repo.Save(ctx, activated2)
+	assert.ErrorIs(t, err, domain.ErrDuplicateActiveStrategy)
+}
+
+func TestStrategyRepository_Save_DuplicateNameDifferentTenant(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create and activate strategy for tenant-1
+	s1 := createTestStrategy(t, "tenant-1", "Same Name")
+	err := tc.Repo.Save(ctx, s1)
+	require.NoError(t, err)
+	activated1, err := s1.Activate()
+	require.NoError(t, err)
+	err = tc.Repo.Save(ctx, activated1)
+	require.NoError(t, err)
+
+	// Create and activate strategy for tenant-2 (should succeed - different tenant)
+	s2 := createTestStrategy(t, "tenant-2", "Same Name")
+	err = tc.Repo.Save(ctx, s2)
+	require.NoError(t, err)
+	activated2, err := s2.Activate()
+	require.NoError(t, err)
+	err = tc.Repo.Save(ctx, activated2)
+	require.NoError(t, err)
+}
+
+func TestStrategyRepository_Save_DuplicateNameBothDraft(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Two DRAFT strategies with same name for same tenant - should succeed
+	// because the unique constraint only applies to ACTIVE status
+	s1 := createTestStrategy(t, "tenant-1", "Draft Name")
+	err := tc.Repo.Save(ctx, s1)
+	require.NoError(t, err)
+
+	s2 := createTestStrategy(t, "tenant-1", "Draft Name")
+	err = tc.Repo.Save(ctx, s2)
+	require.NoError(t, err)
+}
+
+func TestStrategyRepository_FindByID_NotFound(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	_, err := tc.Repo.FindByID(ctx, uuid.New())
+	assert.ErrorIs(t, err, domain.ErrStrategyNotFound)
+}
+
+func TestStrategyRepository_FindByTenantAndName(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	strategy := createTestStrategy(t, "tenant-1", "Findable Strategy")
+	err := tc.Repo.Save(ctx, strategy)
+	require.NoError(t, err)
+
+	activated, err := strategy.Activate()
+	require.NoError(t, err)
+	err = tc.Repo.Save(ctx, activated)
+	require.NoError(t, err)
+
+	// Find by tenant and name
+	found, err := tc.Repo.FindByTenantAndName(ctx, "tenant-1", "Findable Strategy")
+	require.NoError(t, err)
+	assert.Equal(t, strategy.ID(), found.ID())
+	assert.Equal(t, domain.StrategyStatusActive, found.Status())
+}
+
+func TestStrategyRepository_FindByTenantAndName_NotFound(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	_, err := tc.Repo.FindByTenantAndName(ctx, "tenant-1", "Nonexistent")
+	assert.ErrorIs(t, err, domain.ErrStrategyNotFound)
+}
+
+func TestStrategyRepository_FindByTenantAndName_OnlyFindsActive(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create a DRAFT strategy
+	strategy := createTestStrategy(t, "tenant-1", "Draft Only")
+	err := tc.Repo.Save(ctx, strategy)
+	require.NoError(t, err)
+
+	// Should not find DRAFT strategies
+	_, err = tc.Repo.FindByTenantAndName(ctx, "tenant-1", "Draft Only")
+	assert.ErrorIs(t, err, domain.ErrStrategyNotFound)
+}
+
+func TestStrategyRepository_ListByTenant(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create 3 strategies for tenant-1
+	for i, name := range []string{"Strategy A", "Strategy B", "Strategy C"} {
+		s := createTestStrategy(t, "tenant-1", name)
+		err := tc.Repo.Save(ctx, s)
+		require.NoError(t, err, "Failed to save strategy %d", i)
+	}
+
+	// Create 1 strategy for tenant-2
+	s := createTestStrategy(t, "tenant-2", "Other Tenant")
+	err := tc.Repo.Save(ctx, s)
+	require.NoError(t, err)
+
+	// List tenant-1 strategies
+	strategies, nextToken, err := tc.Repo.ListByTenant(ctx, "tenant-1", domain.StrategyFilters{})
+	require.NoError(t, err)
+	assert.Len(t, strategies, 3)
+	assert.Empty(t, nextToken)
+
+	// Verify all belong to tenant-1
+	for _, strategy := range strategies {
+		assert.Equal(t, "tenant-1", strategy.TenantID())
+	}
+}
+
+func TestStrategyRepository_ListByTenant_WithStatusFilter(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create a DRAFT strategy
+	draft := createTestStrategy(t, "tenant-1", "Draft Strategy")
+	err := tc.Repo.Save(ctx, draft)
+	require.NoError(t, err)
+
+	// Create and activate another strategy
+	active := createTestStrategy(t, "tenant-1", "Active Strategy")
+	err = tc.Repo.Save(ctx, active)
+	require.NoError(t, err)
+	activated, err := active.Activate()
+	require.NoError(t, err)
+	err = tc.Repo.Save(ctx, activated)
+	require.NoError(t, err)
+
+	// Filter by ACTIVE status
+	activeStatus := domain.StrategyStatusActive
+	strategies, _, err := tc.Repo.ListByTenant(ctx, "tenant-1", domain.StrategyFilters{
+		Status: &activeStatus,
+	})
+	require.NoError(t, err)
+	assert.Len(t, strategies, 1)
+	assert.Equal(t, "Active Strategy", strategies[0].Name())
+}
+
+func TestStrategyRepository_ListByTenant_Pagination(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create 5 strategies
+	for i := 0; i < 5; i++ {
+		s := createTestStrategy(t, "tenant-1", "Strategy "+string(rune('A'+i)))
+		err := tc.Repo.Save(ctx, s)
+		require.NoError(t, err)
+	}
+
+	// Get first page (2 items)
+	page1, nextToken, err := tc.Repo.ListByTenant(ctx, "tenant-1", domain.StrategyFilters{
+		Limit: 2,
+	})
+	require.NoError(t, err)
+	assert.Len(t, page1, 2)
+	assert.NotEmpty(t, nextToken)
+
+	// Get second page
+	page2, nextToken2, err := tc.Repo.ListByTenant(ctx, "tenant-1", domain.StrategyFilters{
+		Limit:     2,
+		PageToken: nextToken,
+	})
+	require.NoError(t, err)
+	assert.Len(t, page2, 2)
+	assert.NotEmpty(t, nextToken2)
+
+	// Get third page (1 remaining)
+	page3, nextToken3, err := tc.Repo.ListByTenant(ctx, "tenant-1", domain.StrategyFilters{
+		Limit:     2,
+		PageToken: nextToken2,
+	})
+	require.NoError(t, err)
+	assert.Len(t, page3, 1)
+	assert.Empty(t, nextToken3)
+
+	// Verify no duplicates across pages
+	allIDs := make(map[uuid.UUID]bool)
+	for _, s := range page1 {
+		allIDs[s.ID()] = true
+	}
+	for _, s := range page2 {
+		assert.False(t, allIDs[s.ID()], "Duplicate found in page 2")
+		allIDs[s.ID()] = true
+	}
+	for _, s := range page3 {
+		assert.False(t, allIDs[s.ID()], "Duplicate found in page 3")
+		allIDs[s.ID()] = true
+	}
+	assert.Len(t, allIDs, 5)
+}
+
+func TestStrategyRepository_ListByTenant_EmptyResult(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	strategies, nextToken, err := tc.Repo.ListByTenant(ctx, "nonexistent-tenant", domain.StrategyFilters{})
+	require.NoError(t, err)
+	assert.Empty(t, strategies)
+	assert.Empty(t, nextToken)
+}
+
+func TestStrategyRepository_Save_NullableFields(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create strategy with empty optional fields
+	s, err := domain.NewForecastingStrategy(
+		"tenant-1",
+		"Minimal Strategy",
+		"", // empty description
+		`result = [1.0]`,
+		1,
+		1,
+		"0 0 * * *",
+		[]string{"INPUT"},
+		"OUTPUT",
+		"", // empty reference key
+	)
+	require.NoError(t, err)
+
+	err = tc.Repo.Save(ctx, s)
+	require.NoError(t, err)
+
+	retrieved, err := tc.Repo.FindByID(ctx, s.ID())
+	require.NoError(t, err)
+
+	assert.Equal(t, "", retrieved.Description())
+	assert.Equal(t, "", retrieved.ReferenceDataResolutionKey())
+}
+
+func TestStrategyRepository_LifecycleTransitions(t *testing.T) {
+	tc := testhelpers.SetupTestContainer(t)
+	defer tc.Cleanup(t)
+
+	ctx := context.Background()
+
+	// Create DRAFT
+	strategy := createTestStrategy(t, "tenant-1", "Lifecycle Strategy")
+	err := tc.Repo.Save(ctx, strategy)
+	require.NoError(t, err)
+
+	retrieved, err := tc.Repo.FindByID(ctx, strategy.ID())
+	require.NoError(t, err)
+	assert.Equal(t, domain.StrategyStatusDraft, retrieved.Status())
+
+	// Activate
+	activated, err := strategy.Activate()
+	require.NoError(t, err)
+	err = tc.Repo.Save(ctx, activated)
+	require.NoError(t, err)
+
+	retrieved, err = tc.Repo.FindByID(ctx, strategy.ID())
+	require.NoError(t, err)
+	assert.Equal(t, domain.StrategyStatusActive, retrieved.Status())
+	assert.Equal(t, int64(2), retrieved.Version())
+
+	// Deprecate
+	deprecated, err := activated.Deprecate()
+	require.NoError(t, err)
+	err = tc.Repo.Save(ctx, deprecated)
+	require.NoError(t, err)
+
+	retrieved, err = tc.Repo.FindByID(ctx, strategy.ID())
+	require.NoError(t, err)
+	assert.Equal(t, domain.StrategyStatusDeprecated, retrieved.Status())
+	assert.Equal(t, int64(3), retrieved.Version())
+}

--- a/services/forecasting/adapters/persistence/testhelpers/testcontainer.go
+++ b/services/forecasting/adapters/persistence/testhelpers/testcontainer.go
@@ -1,0 +1,117 @@
+// Package testhelpers provides shared utilities for repository integration tests.
+package testhelpers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/forecasting/adapters/persistence"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/cockroachdb"
+)
+
+// TestContainer holds the test database container, connection pool, and repository instance.
+type TestContainer struct {
+	container *cockroachdb.CockroachDBContainer
+	Pool      *pgxpool.Pool
+	Repo      *persistence.StrategyRepository
+}
+
+// SetupTestContainer creates a CockroachDB testcontainer with the forecasting schema loaded.
+func SetupTestContainer(t *testing.T) *TestContainer {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	// Create CockroachDB container in insecure mode
+	crdbContainer, err := cockroachdb.Run(ctx,
+		"cockroachdb/cockroach:v24.3.0",
+		cockroachdb.WithDatabase("test_forecasting"),
+		cockroachdb.WithUser("root"),
+		cockroachdb.WithInsecure(),
+	)
+	require.NoError(t, err, "Failed to start CockroachDB container")
+
+	// Get connection config
+	connConfig, err := crdbContainer.ConnectionConfig(ctx)
+	require.NoError(t, err, "Failed to get connection config")
+	connStr := connConfig.ConnString()
+
+	// Create connection pool
+	poolConfig, err := pgxpool.ParseConfig(connStr)
+	require.NoError(t, err, "Failed to parse pool config")
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	require.NoError(t, err, "Failed to create connection pool")
+
+	// Load schema
+	loadSchema(t, pool)
+
+	// Create repository
+	repo := persistence.NewStrategyRepository(pool)
+
+	return &TestContainer{
+		container: crdbContainer,
+		Pool:      pool,
+		Repo:      repo,
+	}
+}
+
+// Cleanup closes the connection pool and terminates the container.
+func (tc *TestContainer) Cleanup(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+
+	if tc.Pool != nil {
+		tc.Pool.Close()
+	}
+
+	if tc.container != nil {
+		require.NoError(t, tc.container.Terminate(ctx), "Failed to terminate container")
+	}
+}
+
+// loadSchema loads the forecasting schema into the test database.
+func loadSchema(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+
+	_, err := pool.Exec(ctx, `
+		CREATE TABLE forecasting_strategy (
+			id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+			tenant_id TEXT NOT NULL,
+			name TEXT NOT NULL,
+			description TEXT,
+			starlark_code TEXT NOT NULL,
+			horizon_hours INT NOT NULL CHECK (horizon_hours > 0 AND horizon_hours <= 168),
+			granularity_hours INT NOT NULL CHECK (granularity_hours > 0 AND granularity_hours <= horizon_hours),
+			schedule TEXT NOT NULL,
+			input_dataset_codes TEXT[] NOT NULL,
+			output_dataset_code TEXT NOT NULL,
+			reference_data_resolution_key TEXT,
+			status TEXT NOT NULL DEFAULT 'DRAFT',
+			version BIGINT NOT NULL DEFAULT 1,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			CONSTRAINT chk_forecasting_strategy_status CHECK (status IN ('DRAFT', 'ACTIVE', 'DEPRECATED'))
+		)
+	`)
+	require.NoError(t, err, "Failed to create forecasting_strategy table")
+
+	_, err = pool.Exec(ctx, `
+		CREATE UNIQUE INDEX idx_forecasting_strategy_unique_active
+			ON forecasting_strategy (tenant_id, name)
+			WHERE status = 'ACTIVE';
+
+		CREATE INDEX idx_forecasting_strategy_tenant_status
+			ON forecasting_strategy (tenant_id, status, created_at DESC);
+
+		CREATE INDEX idx_forecasting_strategy_active
+			ON forecasting_strategy (status, tenant_id)
+			WHERE status = 'ACTIVE';
+	`)
+	require.NoError(t, err, "Failed to create indexes")
+}

--- a/services/forecasting/cmd/Dockerfile
+++ b/services/forecasting/cmd/Dockerfile
@@ -1,0 +1,56 @@
+# Forecasting Service - Multi-Stage Dockerfile
+# Manages forecasting strategies that generate forward curves from market data
+# Uses distroless base image (~2MB) enabled by pure-Go dependencies
+
+# Build stage
+FROM golang:1.25.7-bookworm AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /build
+
+# Copy go mod files first for better caching
+COPY go.mod go.sum* ./
+RUN go mod download && go mod verify
+
+# Copy source code
+COPY . .
+
+# Build static binary (no CGO required)
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+ARG TARGETARCH
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH:-amd64} go build \
+    -ldflags="-w -s -X main.Version=${VERSION} -X main.Commit=${COMMIT} -X main.BuildDate=${BUILD_DATE}" \
+    -o forecasting \
+    ./services/forecasting/cmd
+
+# Verify the binary exists and is executable
+RUN test -x forecasting && echo "Binary built successfully"
+
+# Runtime stage - distroless for minimal attack surface (~2MB base)
+FROM gcr.io/distroless/static-debian12
+
+# Copy timezone data from builder for time-sensitive operations
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+
+# Copy binary from builder
+COPY --from=builder /build/forecasting /forecasting
+
+# Use non-root user (distroless provides nonroot user at uid 65532)
+USER nonroot:nonroot
+
+# Expose gRPC port
+EXPOSE 50061
+
+# Note: Health checks handled by gRPC health check service
+
+# Run the binary
+ENTRYPOINT ["/forecasting"]

--- a/services/forecasting/cmd/main.go
+++ b/services/forecasting/cmd/main.go
@@ -1,0 +1,187 @@
+// Package main is the entry point for the Forecasting service.
+// Manages forecasting strategies that generate forward curves from market data.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/meridianhub/meridian/services/forecasting/adapters/persistence"
+	"github.com/meridianhub/meridian/shared/platform/bootstrap"
+	"github.com/meridianhub/meridian/shared/platform/defaults"
+	"github.com/meridianhub/meridian/shared/platform/env"
+	"github.com/meridianhub/meridian/shared/platform/ports"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/reflection"
+)
+
+// Build information set via ldflags during compilation
+var (
+	Version   = "dev"
+	Commit    = "unknown"
+	BuildDate = "unknown"
+)
+
+func main() {
+	logLevel := parseLogLevel(os.Getenv("LOG_LEVEL"))
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+		Level: logLevel,
+	}))
+	slog.SetDefault(logger)
+
+	logger.Info("starting forecasting service",
+		"version", Version,
+		"commit", Commit,
+		"build_date", BuildDate)
+
+	if err := run(logger); err != nil {
+		logger.Error("service failed", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("service stopped gracefully")
+}
+
+func run(logger *slog.Logger) error {
+	ctx := context.Background()
+
+	// Initialize OpenTelemetry tracer
+	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
+		ServiceName:    "forecasting-service",
+		ServiceVersion: Version,
+		Logger:         logger,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to initialize tracer: %w", err)
+	}
+	defer bootstrap.ShutdownTracer(tracer, logger)
+
+	// Initialize database connection
+	dbURL := env.GetEnvOrDefault("DATABASE_URL",
+		"postgres://meridian_user@localhost:26257/meridian_forecasting?sslmode=disable")
+	dbPool, err := pgxpool.New(ctx, dbURL)
+	if err != nil {
+		return fmt.Errorf("failed to create database connection pool: %w", err)
+	}
+	defer dbPool.Close()
+
+	if err := dbPool.Ping(ctx); err != nil {
+		return fmt.Errorf("failed to ping database: %w", err)
+	}
+	logger.Info("database connection established", "url", dbURL)
+
+	// Create repository
+	_ = persistence.NewStrategyRepository(dbPool)
+	logger.Info("strategy repository initialized")
+
+	// Initialize auth interceptor
+	authConfig := bootstrap.DefaultAuthConfig(logger)
+	authInterceptor, err := bootstrap.NewAuthInterceptor(ctx, authConfig)
+	if err != nil {
+		return fmt.Errorf("failed to initialize auth: %w", err)
+	}
+
+	// Create gRPC server
+	grpcServer := bootstrap.NewGrpcServerBuilder(tracer, logger).
+		WithAuthInterceptor(authInterceptor).
+		Build()
+
+	// Register health check service
+	healthServer := health.NewServer()
+	healthServer.SetServingStatus("forecasting", grpc_health_v1.HealthCheckResponse_SERVING)
+	grpc_health_v1.RegisterHealthServer(grpcServer, healthServer)
+
+	// Register reflection service for debugging
+	reflection.Register(grpcServer)
+
+	logger.Info("gRPC services registered")
+
+	// Get ports
+	port := env.GetEnvOrDefault("GRPC_PORT", strconv.Itoa(ports.Forecasting))
+	address := fmt.Sprintf(":%s", port)
+	metricsPort := env.GetEnvOrDefault("METRICS_PORT", "8082")
+
+	// Create listener
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", address)
+	if err != nil {
+		return fmt.Errorf("failed to listen on %s: %w", address, err)
+	}
+
+	serverErrors := make(chan error, 2)
+	go func() {
+		logger.Info("starting gRPC server", "address", address)
+		if err := grpcServer.Serve(listener); err != nil {
+			serverErrors <- err
+		}
+	}()
+
+	// Start HTTP server for metrics and health
+	httpMux := http.NewServeMux()
+	httpMux.Handle("/metrics", promhttp.Handler())
+	httpMux.HandleFunc("/health", healthHandler(grpcServer))
+	httpMux.HandleFunc("/ready", healthHandler(grpcServer))
+
+	httpServer := &http.Server{
+		Addr:              fmt.Sprintf(":%s", metricsPort),
+		Handler:           httpMux,
+		ReadHeaderTimeout: defaults.DefaultHTTPReadHeaderTimeout,
+		WriteTimeout:      defaults.DefaultHTTPWriteTimeout,
+	}
+
+	go func() {
+		logger.Info("starting HTTP server for metrics", "address", httpServer.Addr)
+		if err := httpServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("HTTP server error", "error", err)
+			serverErrors <- fmt.Errorf("HTTP server error: %w", err)
+		}
+	}()
+
+	// Wait for shutdown
+	orchestrator := bootstrap.NewShutdownOrchestrator(grpcServer, logger)
+
+	orchestrator.AddCleanup(func() error {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), defaults.DefaultGracefulShutdown)
+		defer cancel()
+		if err := httpServer.Shutdown(shutdownCtx); err != nil {
+			logger.Error("HTTP server shutdown error", "error", err)
+			return err
+		}
+		logger.Info("HTTP server stopped")
+		return nil
+	})
+
+	return orchestrator.Wait(serverErrors)
+}
+
+func healthHandler(_ *grpc.Server) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write([]byte("SERVING")); err != nil {
+			slog.Warn("failed to write health response", "error", err)
+		}
+	}
+}
+
+func parseLogLevel(levelStr string) slog.Level {
+	switch strings.ToLower(levelStr) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/services/forecasting/config/config.go
+++ b/services/forecasting/config/config.go
@@ -1,0 +1,20 @@
+// Package config provides configuration loading for the Forecasting service.
+package config
+
+import (
+	"github.com/meridianhub/meridian/shared/platform/env"
+)
+
+// Config holds all configuration for the Forecasting service.
+type Config struct {
+	// DatabaseURL is the CockroachDB connection string.
+	DatabaseURL string
+}
+
+// LoadConfig loads all service configuration from environment variables.
+func LoadConfig() Config {
+	return Config{
+		DatabaseURL: env.GetEnvOrDefault("DATABASE_URL",
+			"postgres://meridian_user@localhost:26257/meridian_forecasting?sslmode=disable"),
+	}
+}

--- a/services/forecasting/domain/errors.go
+++ b/services/forecasting/domain/errors.go
@@ -1,0 +1,53 @@
+// Package domain contains the domain models for the Forecasting service.
+package domain
+
+import "errors"
+
+// Domain errors for forecasting strategy operations.
+var (
+	// ErrStrategyNotFound indicates the requested forecasting strategy does not exist.
+	ErrStrategyNotFound = errors.New("forecasting strategy not found")
+
+	// ErrStrategyDeprecated indicates an operation was attempted on a deprecated strategy.
+	ErrStrategyDeprecated = errors.New("strategy is deprecated")
+
+	// ErrDuplicateActiveStrategy indicates an active strategy with the same name already exists for the tenant.
+	ErrDuplicateActiveStrategy = errors.New("active strategy with this name already exists for tenant")
+
+	// ErrVersionMismatch indicates an optimistic locking conflict occurred.
+	ErrVersionMismatch = errors.New("version mismatch: strategy was modified")
+
+	// Validation errors for required fields.
+
+	// ErrNameRequired indicates the strategy name was not provided.
+	ErrNameRequired = errors.New("strategy name is required")
+
+	// ErrTenantIDRequired indicates the tenant ID was not provided.
+	ErrTenantIDRequired = errors.New("tenant ID is required")
+
+	// ErrStarlarkCodeRequired indicates the Starlark script code was not provided.
+	ErrStarlarkCodeRequired = errors.New("starlark code is required")
+
+	// ErrScheduleRequired indicates the cron schedule was not provided.
+	ErrScheduleRequired = errors.New("schedule is required")
+
+	// ErrOutputDatasetCodeRequired indicates the output dataset code was not provided.
+	ErrOutputDatasetCodeRequired = errors.New("output dataset code is required")
+
+	// ErrInputDatasetCodesRequired indicates no input dataset codes were provided.
+	ErrInputDatasetCodesRequired = errors.New("at least one input dataset code is required")
+
+	// ErrInvalidHorizonHours indicates the horizon hours value is invalid.
+	ErrInvalidHorizonHours = errors.New("horizon hours must be between 1 and 168")
+
+	// ErrInvalidGranularityHours indicates the granularity hours value is invalid.
+	ErrInvalidGranularityHours = errors.New("granularity hours must be between 1 and horizon hours")
+
+	// ErrInvalidSchedule indicates the cron schedule expression is invalid.
+	ErrInvalidSchedule = errors.New("invalid cron schedule expression")
+
+	// Pagination errors.
+
+	// ErrInvalidPageToken indicates the pagination token has an invalid format.
+	ErrInvalidPageToken = errors.New("invalid page token format")
+)

--- a/services/forecasting/domain/forecasting_strategy.go
+++ b/services/forecasting/domain/forecasting_strategy.go
@@ -1,0 +1,375 @@
+// Package domain contains the domain models for the Forecasting service.
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/robfig/cron/v3"
+)
+
+// ForecastingStrategy represents a forecasting strategy aggregate root.
+// This is an immutable value type - all modification methods return a new instance.
+//
+// A forecasting strategy defines a Starlark script that generates forward curve
+// predictions from market data inputs. Each strategy specifies:
+//   - The Starlark source code to execute
+//   - Input datasets to read from Market Data Service
+//   - Output dataset for the forward curve
+//   - Forecast horizon and granularity
+//   - A cron schedule for periodic execution
+//
+// Lifecycle states:
+//   - DRAFT: Initial state, strategy is being configured
+//   - ACTIVE: Strategy is scheduled for execution
+//   - DEPRECATED: Strategy is retired (terminal state)
+type ForecastingStrategy struct {
+	id                         uuid.UUID
+	tenantID                   string
+	name                       string
+	description                string
+	starlarkCode               string
+	horizonHours               int
+	granularityHours           int
+	schedule                   string
+	inputDatasetCodes          []string
+	outputDatasetCode          string
+	referenceDataResolutionKey string
+	status                     StrategyStatus
+	version                    int64
+	createdAt                  time.Time
+	updatedAt                  time.Time
+}
+
+// NewForecastingStrategy creates a new ForecastingStrategy with validated fields.
+// Returns a value type (not pointer) following the immutability pattern.
+//
+// Initial state:
+//   - Status: DRAFT
+//   - Version: 1
+//
+// Validation:
+//   - tenantID cannot be empty
+//   - name cannot be empty
+//   - starlarkCode cannot be empty
+//   - horizonHours must be between 1 and 168
+//   - granularityHours must be between 1 and horizonHours
+//   - schedule must be a valid cron expression
+//   - inputDatasetCodes must have at least one entry
+//   - outputDatasetCode cannot be empty
+func NewForecastingStrategy(
+	tenantID string,
+	name string,
+	description string,
+	starlarkCode string,
+	horizonHours int,
+	granularityHours int,
+	schedule string,
+	inputDatasetCodes []string,
+	outputDatasetCode string,
+	referenceDataResolutionKey string,
+) (ForecastingStrategy, error) {
+	if tenantID == "" {
+		return ForecastingStrategy{}, ErrTenantIDRequired
+	}
+	if name == "" {
+		return ForecastingStrategy{}, ErrNameRequired
+	}
+	if starlarkCode == "" {
+		return ForecastingStrategy{}, ErrStarlarkCodeRequired
+	}
+	if horizonHours < 1 || horizonHours > 168 {
+		return ForecastingStrategy{}, ErrInvalidHorizonHours
+	}
+	if granularityHours < 1 || granularityHours > horizonHours {
+		return ForecastingStrategy{}, ErrInvalidGranularityHours
+	}
+	if schedule == "" {
+		return ForecastingStrategy{}, ErrScheduleRequired
+	}
+	if _, err := cron.ParseStandard(schedule); err != nil {
+		return ForecastingStrategy{}, ErrInvalidSchedule
+	}
+	if len(inputDatasetCodes) == 0 {
+		return ForecastingStrategy{}, ErrInputDatasetCodesRequired
+	}
+	if outputDatasetCode == "" {
+		return ForecastingStrategy{}, ErrOutputDatasetCodeRequired
+	}
+
+	// Defensive copy of input slice
+	codes := make([]string, len(inputDatasetCodes))
+	copy(codes, inputDatasetCodes)
+
+	now := time.Now()
+	return ForecastingStrategy{
+		id:                         uuid.New(),
+		tenantID:                   tenantID,
+		name:                       name,
+		description:                description,
+		starlarkCode:               starlarkCode,
+		horizonHours:               horizonHours,
+		granularityHours:           granularityHours,
+		schedule:                   schedule,
+		inputDatasetCodes:          codes,
+		outputDatasetCode:          outputDatasetCode,
+		referenceDataResolutionKey: referenceDataResolutionKey,
+		status:                     StrategyStatusDraft,
+		version:                    1,
+		createdAt:                  now,
+		updatedAt:                  now,
+	}, nil
+}
+
+// Activate transitions the strategy to ACTIVE status.
+// Returns a new instance with updated status.
+// Returns error if the transition is not valid (only DRAFT -> ACTIVE is allowed).
+func (s ForecastingStrategy) Activate() (ForecastingStrategy, error) {
+	if err := ValidateStatusTransition(s.status, StrategyStatusActive); err != nil {
+		return s, err
+	}
+	return s.withStatusChange(StrategyStatusActive), nil
+}
+
+// Deprecate transitions the strategy to DEPRECATED status.
+// Returns a new instance with updated status.
+// Valid transitions: DRAFT -> DEPRECATED, ACTIVE -> DEPRECATED
+func (s ForecastingStrategy) Deprecate() (ForecastingStrategy, error) {
+	if err := ValidateStatusTransition(s.status, StrategyStatusDeprecated); err != nil {
+		return s, err
+	}
+	return s.withStatusChange(StrategyStatusDeprecated), nil
+}
+
+// UpdateStarlarkCode updates the Starlark script code.
+// Returns a new instance with updated code and incremented version.
+// Returns error if strategy is deprecated or code is empty.
+func (s ForecastingStrategy) UpdateStarlarkCode(code string) (ForecastingStrategy, error) {
+	if s.status == StrategyStatusDeprecated {
+		return s, ErrStrategyDeprecated
+	}
+	if code == "" {
+		return s, ErrStarlarkCodeRequired
+	}
+
+	updated := s.copyWithUpdatedTime()
+	updated.starlarkCode = code
+	updated.version++
+	return updated, nil
+}
+
+// UpdateDescription updates the strategy description.
+// Returns a new instance with updated description and incremented version.
+// Returns error if strategy is deprecated.
+func (s ForecastingStrategy) UpdateDescription(description string) (ForecastingStrategy, error) {
+	if s.status == StrategyStatusDeprecated {
+		return s, ErrStrategyDeprecated
+	}
+
+	updated := s.copyWithUpdatedTime()
+	updated.description = description
+	updated.version++
+	return updated, nil
+}
+
+// UpdateSchedule updates the cron schedule expression.
+// Returns a new instance with updated schedule and incremented version.
+// Returns error if strategy is deprecated or schedule is invalid.
+func (s ForecastingStrategy) UpdateSchedule(schedule string) (ForecastingStrategy, error) {
+	if s.status == StrategyStatusDeprecated {
+		return s, ErrStrategyDeprecated
+	}
+	if schedule == "" {
+		return s, ErrScheduleRequired
+	}
+	if _, err := cron.ParseStandard(schedule); err != nil {
+		return s, ErrInvalidSchedule
+	}
+
+	updated := s.copyWithUpdatedTime()
+	updated.schedule = schedule
+	updated.version++
+	return updated, nil
+}
+
+// withStatusChange creates a new instance with updated status.
+func (s ForecastingStrategy) withStatusChange(newStatus StrategyStatus) ForecastingStrategy {
+	updated := s.copyWithUpdatedTime()
+	updated.status = newStatus
+	updated.version++
+	return updated
+}
+
+// copyWithUpdatedTime creates a copy of the strategy with updated timestamp.
+func (s ForecastingStrategy) copyWithUpdatedTime() ForecastingStrategy {
+	updated := s
+	// Defensive copy of slice
+	updated.inputDatasetCodes = make([]string, len(s.inputDatasetCodes))
+	copy(updated.inputDatasetCodes, s.inputDatasetCodes)
+	updated.updatedAt = time.Now()
+	return updated
+}
+
+// Getters for all unexported fields.
+
+// ID returns the internal unique identifier.
+func (s ForecastingStrategy) ID() uuid.UUID { return s.id }
+
+// TenantID returns the tenant identifier.
+func (s ForecastingStrategy) TenantID() string { return s.tenantID }
+
+// Name returns the strategy name.
+func (s ForecastingStrategy) Name() string { return s.name }
+
+// Description returns the strategy description.
+func (s ForecastingStrategy) Description() string { return s.description }
+
+// StarlarkCode returns the Starlark script source code.
+func (s ForecastingStrategy) StarlarkCode() string { return s.starlarkCode }
+
+// HorizonHours returns how far into the future the forecast extends.
+func (s ForecastingStrategy) HorizonHours() int { return s.horizonHours }
+
+// GranularityHours returns the spacing between forecast points.
+func (s ForecastingStrategy) GranularityHours() int { return s.granularityHours }
+
+// Schedule returns the cron schedule expression.
+func (s ForecastingStrategy) Schedule() string { return s.schedule }
+
+// InputDatasetCodes returns a copy of the input MDS dataset codes.
+func (s ForecastingStrategy) InputDatasetCodes() []string {
+	codes := make([]string, len(s.inputDatasetCodes))
+	copy(codes, s.inputDatasetCodes)
+	return codes
+}
+
+// OutputDatasetCode returns the MDS dataset code for the forward curve output.
+func (s ForecastingStrategy) OutputDatasetCode() string { return s.outputDatasetCode }
+
+// ReferenceDataResolutionKey returns the optional hierarchy node context.
+func (s ForecastingStrategy) ReferenceDataResolutionKey() string {
+	return s.referenceDataResolutionKey
+}
+
+// Status returns the current strategy status.
+func (s ForecastingStrategy) Status() StrategyStatus { return s.status }
+
+// Version returns the version number for optimistic locking.
+func (s ForecastingStrategy) Version() int64 { return s.version }
+
+// CreatedAt returns the creation timestamp.
+func (s ForecastingStrategy) CreatedAt() time.Time { return s.createdAt }
+
+// UpdatedAt returns the last update timestamp.
+func (s ForecastingStrategy) UpdatedAt() time.Time { return s.updatedAt }
+
+// ForecastingStrategyBuilder provides a builder pattern for reconstructing
+// ForecastingStrategy from the persistence layer. This bypasses normal validation
+// since we assume persisted data was already validated.
+type ForecastingStrategyBuilder struct {
+	strategy ForecastingStrategy
+}
+
+// NewForecastingStrategyBuilder creates a new builder for ForecastingStrategy reconstruction.
+func NewForecastingStrategyBuilder() *ForecastingStrategyBuilder {
+	return &ForecastingStrategyBuilder{
+		strategy: ForecastingStrategy{},
+	}
+}
+
+// WithID sets the unique identifier.
+func (b *ForecastingStrategyBuilder) WithID(id uuid.UUID) *ForecastingStrategyBuilder {
+	b.strategy.id = id
+	return b
+}
+
+// WithTenantID sets the tenant identifier.
+func (b *ForecastingStrategyBuilder) WithTenantID(tenantID string) *ForecastingStrategyBuilder {
+	b.strategy.tenantID = tenantID
+	return b
+}
+
+// WithName sets the strategy name.
+func (b *ForecastingStrategyBuilder) WithName(name string) *ForecastingStrategyBuilder {
+	b.strategy.name = name
+	return b
+}
+
+// WithDescription sets the strategy description.
+func (b *ForecastingStrategyBuilder) WithDescription(description string) *ForecastingStrategyBuilder {
+	b.strategy.description = description
+	return b
+}
+
+// WithStarlarkCode sets the Starlark script source.
+func (b *ForecastingStrategyBuilder) WithStarlarkCode(code string) *ForecastingStrategyBuilder {
+	b.strategy.starlarkCode = code
+	return b
+}
+
+// WithHorizonHours sets the forecast horizon.
+func (b *ForecastingStrategyBuilder) WithHorizonHours(hours int) *ForecastingStrategyBuilder {
+	b.strategy.horizonHours = hours
+	return b
+}
+
+// WithGranularityHours sets the forecast point spacing.
+func (b *ForecastingStrategyBuilder) WithGranularityHours(hours int) *ForecastingStrategyBuilder {
+	b.strategy.granularityHours = hours
+	return b
+}
+
+// WithSchedule sets the cron schedule expression.
+func (b *ForecastingStrategyBuilder) WithSchedule(schedule string) *ForecastingStrategyBuilder {
+	b.strategy.schedule = schedule
+	return b
+}
+
+// WithInputDatasetCodes sets the input MDS dataset codes.
+func (b *ForecastingStrategyBuilder) WithInputDatasetCodes(codes []string) *ForecastingStrategyBuilder {
+	b.strategy.inputDatasetCodes = make([]string, len(codes))
+	copy(b.strategy.inputDatasetCodes, codes)
+	return b
+}
+
+// WithOutputDatasetCode sets the output dataset code.
+func (b *ForecastingStrategyBuilder) WithOutputDatasetCode(code string) *ForecastingStrategyBuilder {
+	b.strategy.outputDatasetCode = code
+	return b
+}
+
+// WithReferenceDataResolutionKey sets the optional hierarchy node context.
+func (b *ForecastingStrategyBuilder) WithReferenceDataResolutionKey(key string) *ForecastingStrategyBuilder {
+	b.strategy.referenceDataResolutionKey = key
+	return b
+}
+
+// WithStatus sets the strategy status.
+func (b *ForecastingStrategyBuilder) WithStatus(status StrategyStatus) *ForecastingStrategyBuilder {
+	b.strategy.status = status
+	return b
+}
+
+// WithVersion sets the optimistic locking version.
+func (b *ForecastingStrategyBuilder) WithVersion(version int64) *ForecastingStrategyBuilder {
+	b.strategy.version = version
+	return b
+}
+
+// WithCreatedAt sets the creation timestamp.
+func (b *ForecastingStrategyBuilder) WithCreatedAt(t time.Time) *ForecastingStrategyBuilder {
+	b.strategy.createdAt = t
+	return b
+}
+
+// WithUpdatedAt sets the last update timestamp.
+func (b *ForecastingStrategyBuilder) WithUpdatedAt(t time.Time) *ForecastingStrategyBuilder {
+	b.strategy.updatedAt = t
+	return b
+}
+
+// Build returns the constructed ForecastingStrategy.
+// This is used for persistence reconstruction and does not validate.
+func (b *ForecastingStrategyBuilder) Build() ForecastingStrategy {
+	return b.strategy
+}

--- a/services/forecasting/domain/forecasting_strategy_test.go
+++ b/services/forecasting/domain/forecasting_strategy_test.go
@@ -1,0 +1,472 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createValidStrategy(t *testing.T) ForecastingStrategy {
+	t.Helper()
+	s, err := NewForecastingStrategy(
+		"tenant-1",
+		"Day-Ahead Price Forecast",
+		"Generates 24-hour forward curve for electricity prices",
+		`result = [42.0] * 24`,
+		24,
+		1,
+		"0 16 * * *",
+		[]string{"SPOT_PRICE", "WEATHER_FORECAST"},
+		"FORWARD_CURVE_ELEC",
+		"GB/SOUTH",
+	)
+	require.NoError(t, err)
+	return s
+}
+
+func TestNewForecastingStrategy_Success(t *testing.T) {
+	beforeCreation := time.Now()
+
+	s, err := NewForecastingStrategy(
+		"tenant-1",
+		"Day-Ahead Price Forecast",
+		"Generates 24-hour forward curve",
+		`result = [42.0] * 24`,
+		24,
+		1,
+		"0 16 * * *",
+		[]string{"SPOT_PRICE", "WEATHER_FORECAST"},
+		"FORWARD_CURVE_ELEC",
+		"GB/SOUTH",
+	)
+
+	require.NoError(t, err)
+
+	assert.NotEqual(t, uuid.Nil, s.ID())
+	assert.Equal(t, "tenant-1", s.TenantID())
+	assert.Equal(t, "Day-Ahead Price Forecast", s.Name())
+	assert.Equal(t, "Generates 24-hour forward curve", s.Description())
+	assert.Equal(t, `result = [42.0] * 24`, s.StarlarkCode())
+	assert.Equal(t, 24, s.HorizonHours())
+	assert.Equal(t, 1, s.GranularityHours())
+	assert.Equal(t, "0 16 * * *", s.Schedule())
+	assert.Equal(t, []string{"SPOT_PRICE", "WEATHER_FORECAST"}, s.InputDatasetCodes())
+	assert.Equal(t, "FORWARD_CURVE_ELEC", s.OutputDatasetCode())
+	assert.Equal(t, "GB/SOUTH", s.ReferenceDataResolutionKey())
+	assert.Equal(t, StrategyStatusDraft, s.Status())
+	assert.Equal(t, int64(1), s.Version())
+
+	assert.True(t, s.CreatedAt().After(beforeCreation) || s.CreatedAt().Equal(beforeCreation))
+	assert.Equal(t, s.CreatedAt(), s.UpdatedAt())
+}
+
+func TestNewForecastingStrategy_EmptyDescription(t *testing.T) {
+	s, err := NewForecastingStrategy(
+		"tenant-1",
+		"Minimal Strategy",
+		"", // empty description is allowed
+		`result = [1.0]`,
+		1,
+		1,
+		"0 0 * * *",
+		[]string{"INPUT"},
+		"OUTPUT",
+		"",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "", s.Description())
+	assert.Equal(t, "", s.ReferenceDataResolutionKey())
+}
+
+func TestNewForecastingStrategy_EmptyTenantID(t *testing.T) {
+	_, err := NewForecastingStrategy(
+		"",
+		"Name",
+		"",
+		`code`,
+		24,
+		1,
+		"0 0 * * *",
+		[]string{"IN"},
+		"OUT",
+		"",
+	)
+	assert.ErrorIs(t, err, ErrTenantIDRequired)
+}
+
+func TestNewForecastingStrategy_EmptyName(t *testing.T) {
+	_, err := NewForecastingStrategy(
+		"tenant-1",
+		"",
+		"",
+		`code`,
+		24,
+		1,
+		"0 0 * * *",
+		[]string{"IN"},
+		"OUT",
+		"",
+	)
+	assert.ErrorIs(t, err, ErrNameRequired)
+}
+
+func TestNewForecastingStrategy_EmptyStarlarkCode(t *testing.T) {
+	_, err := NewForecastingStrategy(
+		"tenant-1",
+		"Name",
+		"",
+		"",
+		24,
+		1,
+		"0 0 * * *",
+		[]string{"IN"},
+		"OUT",
+		"",
+	)
+	assert.ErrorIs(t, err, ErrStarlarkCodeRequired)
+}
+
+func TestNewForecastingStrategy_InvalidHorizonHours(t *testing.T) {
+	tests := []struct {
+		name    string
+		horizon int
+	}{
+		{"zero", 0},
+		{"negative", -1},
+		{"too large", 169},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewForecastingStrategy(
+				"tenant-1", "Name", "", `code`,
+				tc.horizon, 1, "0 0 * * *",
+				[]string{"IN"}, "OUT", "",
+			)
+			assert.ErrorIs(t, err, ErrInvalidHorizonHours)
+		})
+	}
+}
+
+func TestNewForecastingStrategy_InvalidGranularityHours(t *testing.T) {
+	tests := []struct {
+		name        string
+		horizon     int
+		granularity int
+	}{
+		{"zero", 24, 0},
+		{"negative", 24, -1},
+		{"exceeds horizon", 24, 25},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewForecastingStrategy(
+				"tenant-1", "Name", "", `code`,
+				tc.horizon, tc.granularity, "0 0 * * *",
+				[]string{"IN"}, "OUT", "",
+			)
+			assert.ErrorIs(t, err, ErrInvalidGranularityHours)
+		})
+	}
+}
+
+func TestNewForecastingStrategy_GranularityEqualsHorizon(t *testing.T) {
+	s, err := NewForecastingStrategy(
+		"tenant-1", "Name", "", `code`,
+		24, 24, "0 0 * * *",
+		[]string{"IN"}, "OUT", "",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 24, s.GranularityHours())
+}
+
+func TestNewForecastingStrategy_MaxHorizon(t *testing.T) {
+	s, err := NewForecastingStrategy(
+		"tenant-1", "Name", "", `code`,
+		168, 24, "0 0 * * *",
+		[]string{"IN"}, "OUT", "",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 168, s.HorizonHours())
+}
+
+func TestNewForecastingStrategy_EmptySchedule(t *testing.T) {
+	_, err := NewForecastingStrategy(
+		"tenant-1", "Name", "", `code`,
+		24, 1, "",
+		[]string{"IN"}, "OUT", "",
+	)
+	assert.ErrorIs(t, err, ErrScheduleRequired)
+}
+
+func TestNewForecastingStrategy_InvalidSchedule(t *testing.T) {
+	_, err := NewForecastingStrategy(
+		"tenant-1", "Name", "", `code`,
+		24, 1, "not-a-cron",
+		[]string{"IN"}, "OUT", "",
+	)
+	assert.ErrorIs(t, err, ErrInvalidSchedule)
+}
+
+func TestNewForecastingStrategy_EmptyInputDatasetCodes(t *testing.T) {
+	_, err := NewForecastingStrategy(
+		"tenant-1", "Name", "", `code`,
+		24, 1, "0 0 * * *",
+		[]string{}, "OUT", "",
+	)
+	assert.ErrorIs(t, err, ErrInputDatasetCodesRequired)
+}
+
+func TestNewForecastingStrategy_NilInputDatasetCodes(t *testing.T) {
+	_, err := NewForecastingStrategy(
+		"tenant-1", "Name", "", `code`,
+		24, 1, "0 0 * * *",
+		nil, "OUT", "",
+	)
+	assert.ErrorIs(t, err, ErrInputDatasetCodesRequired)
+}
+
+func TestNewForecastingStrategy_EmptyOutputDatasetCode(t *testing.T) {
+	_, err := NewForecastingStrategy(
+		"tenant-1", "Name", "", `code`,
+		24, 1, "0 0 * * *",
+		[]string{"IN"}, "", "",
+	)
+	assert.ErrorIs(t, err, ErrOutputDatasetCodeRequired)
+}
+
+func TestNewForecastingStrategy_InputSliceDefensiveCopy(t *testing.T) {
+	inputs := []string{"A", "B"}
+	s, err := NewForecastingStrategy(
+		"tenant-1", "Name", "", `code`,
+		24, 1, "0 0 * * *",
+		inputs, "OUT", "",
+	)
+	require.NoError(t, err)
+
+	// Mutating the original slice should not affect the strategy
+	inputs[0] = "MUTATED"
+	assert.Equal(t, "A", s.InputDatasetCodes()[0])
+}
+
+func TestForecastingStrategy_Activate(t *testing.T) {
+	s := createValidStrategy(t)
+	assert.Equal(t, StrategyStatusDraft, s.Status())
+
+	activated, err := s.Activate()
+	require.NoError(t, err)
+
+	assert.Equal(t, StrategyStatusActive, activated.Status())
+	assert.Equal(t, int64(2), activated.Version())
+	assert.True(t, activated.UpdatedAt().After(s.UpdatedAt()) || activated.UpdatedAt().Equal(s.UpdatedAt()))
+
+	// Original should be unchanged
+	assert.Equal(t, StrategyStatusDraft, s.Status())
+	assert.Equal(t, int64(1), s.Version())
+}
+
+func TestForecastingStrategy_Activate_AlreadyActive(t *testing.T) {
+	s := createValidStrategy(t)
+	activated, err := s.Activate()
+	require.NoError(t, err)
+
+	_, err = activated.Activate()
+	assert.True(t, errors.Is(err, ErrInvalidStatusTransition))
+}
+
+func TestForecastingStrategy_Deprecate_FromDraft(t *testing.T) {
+	s := createValidStrategy(t)
+
+	deprecated, err := s.Deprecate()
+	require.NoError(t, err)
+
+	assert.Equal(t, StrategyStatusDeprecated, deprecated.Status())
+	assert.Equal(t, int64(2), deprecated.Version())
+}
+
+func TestForecastingStrategy_Deprecate_FromActive(t *testing.T) {
+	s := createValidStrategy(t)
+	activated, err := s.Activate()
+	require.NoError(t, err)
+
+	deprecated, err := activated.Deprecate()
+	require.NoError(t, err)
+
+	assert.Equal(t, StrategyStatusDeprecated, deprecated.Status())
+	assert.Equal(t, int64(3), deprecated.Version())
+}
+
+func TestForecastingStrategy_Deprecate_AlreadyDeprecated(t *testing.T) {
+	s := createValidStrategy(t)
+	deprecated, err := s.Deprecate()
+	require.NoError(t, err)
+
+	_, err = deprecated.Deprecate()
+	assert.True(t, errors.Is(err, ErrInvalidStatusTransition))
+}
+
+func TestForecastingStrategy_Activate_FromDeprecated(t *testing.T) {
+	s := createValidStrategy(t)
+	deprecated, err := s.Deprecate()
+	require.NoError(t, err)
+
+	_, err = deprecated.Activate()
+	assert.True(t, errors.Is(err, ErrInvalidStatusTransition))
+}
+
+func TestForecastingStrategy_UpdateStarlarkCode(t *testing.T) {
+	s := createValidStrategy(t)
+
+	updated, err := s.UpdateStarlarkCode(`result = [99.0] * 24`)
+	require.NoError(t, err)
+
+	assert.Equal(t, `result = [99.0] * 24`, updated.StarlarkCode())
+	assert.Equal(t, int64(2), updated.Version())
+
+	// Original unchanged
+	assert.Equal(t, `result = [42.0] * 24`, s.StarlarkCode())
+}
+
+func TestForecastingStrategy_UpdateStarlarkCode_EmptyCode(t *testing.T) {
+	s := createValidStrategy(t)
+
+	_, err := s.UpdateStarlarkCode("")
+	assert.ErrorIs(t, err, ErrStarlarkCodeRequired)
+}
+
+func TestForecastingStrategy_UpdateStarlarkCode_Deprecated(t *testing.T) {
+	s := createValidStrategy(t)
+	deprecated, err := s.Deprecate()
+	require.NoError(t, err)
+
+	_, err = deprecated.UpdateStarlarkCode(`new code`)
+	assert.ErrorIs(t, err, ErrStrategyDeprecated)
+}
+
+func TestForecastingStrategy_UpdateDescription(t *testing.T) {
+	s := createValidStrategy(t)
+
+	updated, err := s.UpdateDescription("New description")
+	require.NoError(t, err)
+
+	assert.Equal(t, "New description", updated.Description())
+	assert.Equal(t, int64(2), updated.Version())
+}
+
+func TestForecastingStrategy_UpdateDescription_Deprecated(t *testing.T) {
+	s := createValidStrategy(t)
+	deprecated, err := s.Deprecate()
+	require.NoError(t, err)
+
+	_, err = deprecated.UpdateDescription("New")
+	assert.ErrorIs(t, err, ErrStrategyDeprecated)
+}
+
+func TestForecastingStrategy_UpdateSchedule(t *testing.T) {
+	s := createValidStrategy(t)
+
+	updated, err := s.UpdateSchedule("30 8 * * *")
+	require.NoError(t, err)
+
+	assert.Equal(t, "30 8 * * *", updated.Schedule())
+	assert.Equal(t, int64(2), updated.Version())
+}
+
+func TestForecastingStrategy_UpdateSchedule_InvalidCron(t *testing.T) {
+	s := createValidStrategy(t)
+
+	_, err := s.UpdateSchedule("invalid")
+	assert.ErrorIs(t, err, ErrInvalidSchedule)
+}
+
+func TestForecastingStrategy_UpdateSchedule_Empty(t *testing.T) {
+	s := createValidStrategy(t)
+
+	_, err := s.UpdateSchedule("")
+	assert.ErrorIs(t, err, ErrScheduleRequired)
+}
+
+func TestForecastingStrategy_UpdateSchedule_Deprecated(t *testing.T) {
+	s := createValidStrategy(t)
+	deprecated, err := s.Deprecate()
+	require.NoError(t, err)
+
+	_, err = deprecated.UpdateSchedule("0 0 * * *")
+	assert.ErrorIs(t, err, ErrStrategyDeprecated)
+}
+
+func TestForecastingStrategy_VersionIncrementOnUpdate(t *testing.T) {
+	s := createValidStrategy(t)
+	assert.Equal(t, int64(1), s.Version())
+
+	s, err := s.UpdateDescription("v2")
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), s.Version())
+
+	s, err = s.UpdateStarlarkCode("new code")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), s.Version())
+
+	s, err = s.Activate()
+	require.NoError(t, err)
+	assert.Equal(t, int64(4), s.Version())
+
+	s, err = s.Deprecate()
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), s.Version())
+}
+
+func TestForecastingStrategyBuilder_Build(t *testing.T) {
+	id := uuid.New()
+	now := time.Now()
+
+	s := NewForecastingStrategyBuilder().
+		WithID(id).
+		WithTenantID("tenant-1").
+		WithName("Built Strategy").
+		WithDescription("From builder").
+		WithStarlarkCode("code here").
+		WithHorizonHours(48).
+		WithGranularityHours(2).
+		WithSchedule("0 16 * * *").
+		WithInputDatasetCodes([]string{"DS1", "DS2"}).
+		WithOutputDatasetCode("OUT1").
+		WithReferenceDataResolutionKey("GB/NORTH").
+		WithStatus(StrategyStatusActive).
+		WithVersion(5).
+		WithCreatedAt(now).
+		WithUpdatedAt(now).
+		Build()
+
+	assert.Equal(t, id, s.ID())
+	assert.Equal(t, "tenant-1", s.TenantID())
+	assert.Equal(t, "Built Strategy", s.Name())
+	assert.Equal(t, "From builder", s.Description())
+	assert.Equal(t, "code here", s.StarlarkCode())
+	assert.Equal(t, 48, s.HorizonHours())
+	assert.Equal(t, 2, s.GranularityHours())
+	assert.Equal(t, "0 16 * * *", s.Schedule())
+	assert.Equal(t, []string{"DS1", "DS2"}, s.InputDatasetCodes())
+	assert.Equal(t, "OUT1", s.OutputDatasetCode())
+	assert.Equal(t, "GB/NORTH", s.ReferenceDataResolutionKey())
+	assert.Equal(t, StrategyStatusActive, s.Status())
+	assert.Equal(t, int64(5), s.Version())
+	assert.Equal(t, now, s.CreatedAt())
+	assert.Equal(t, now, s.UpdatedAt())
+}
+
+func TestForecastingStrategyBuilder_InputSliceDefensiveCopy(t *testing.T) {
+	codes := []string{"A", "B"}
+
+	s := NewForecastingStrategyBuilder().
+		WithInputDatasetCodes(codes).
+		Build()
+
+	// Mutating original should not affect built strategy
+	codes[0] = "MUTATED"
+	assert.Equal(t, "A", s.InputDatasetCodes()[0])
+}

--- a/services/forecasting/domain/repository.go
+++ b/services/forecasting/domain/repository.go
@@ -1,0 +1,47 @@
+// Package domain contains repository port interfaces for the Forecasting service.
+package domain
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// StrategyRepository defines the persistence port for ForecastingStrategy aggregates.
+// This interface follows hexagonal architecture patterns, allowing the domain
+// to remain independent of specific persistence implementations.
+//
+// Implementations must be thread-safe.
+type StrategyRepository interface {
+	// Save persists a new or updated forecasting strategy.
+	// For new strategies, returns ErrDuplicateActiveStrategy if an active strategy
+	// with the same name already exists for the tenant.
+	// For updates, returns ErrVersionMismatch on optimistic lock failure.
+	Save(ctx context.Context, strategy ForecastingStrategy) error
+
+	// FindByID retrieves a strategy by its unique identifier.
+	// Returns ErrStrategyNotFound if the strategy does not exist.
+	FindByID(ctx context.Context, id uuid.UUID) (ForecastingStrategy, error)
+
+	// FindByTenantAndName retrieves an active strategy by tenant and name.
+	// Returns ErrStrategyNotFound if no matching active strategy exists.
+	FindByTenantAndName(ctx context.Context, tenantID string, name string) (ForecastingStrategy, error)
+
+	// ListByTenant returns strategies for a tenant matching the filter criteria.
+	// Returns the strategies, a next page token (empty if no more results), and any error.
+	ListByTenant(ctx context.Context, tenantID string, filters StrategyFilters) ([]ForecastingStrategy, string, error)
+}
+
+// StrategyFilters specifies criteria for listing forecasting strategies.
+type StrategyFilters struct {
+	// Status filters by strategy status. Nil matches all statuses.
+	Status *StrategyStatus
+
+	// Limit specifies the maximum number of results to return.
+	// Zero or negative values use the implementation's default limit.
+	Limit int
+
+	// PageToken is the cursor token from a previous List response.
+	// Empty string indicates first page.
+	PageToken string
+}

--- a/services/forecasting/domain/strategy_status.go
+++ b/services/forecasting/domain/strategy_status.go
@@ -1,0 +1,90 @@
+// Package domain contains the domain models for the Forecasting service.
+package domain
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidStatusTransition indicates an invalid strategy status transition was attempted.
+var ErrInvalidStatusTransition = errors.New("invalid status transition")
+
+// StrategyStatus represents the lifecycle state of a forecasting strategy.
+type StrategyStatus string
+
+// Strategy status constants.
+const (
+	// StrategyStatusDraft indicates the strategy is being configured and is not yet active.
+	StrategyStatusDraft StrategyStatus = "DRAFT"
+
+	// StrategyStatusActive indicates the strategy is active and scheduled for execution.
+	StrategyStatusActive StrategyStatus = "ACTIVE"
+
+	// StrategyStatusDeprecated indicates the strategy is deprecated and should no longer run.
+	// This is a terminal state - no further transitions are allowed.
+	StrategyStatusDeprecated StrategyStatus = "DEPRECATED"
+)
+
+// Valid state transitions for forecasting strategies:
+//
+//	DRAFT -> ACTIVE (activation)
+//	   |        |
+//	   |        +---> DEPRECATED (deprecation)
+//	   |
+//	   +------------> DEPRECATED (direct deprecation without activation)
+//
+// - DRAFT is the initial state for new strategies
+// - DRAFT -> ACTIVE: Strategy is ready for scheduled execution
+// - DRAFT -> DEPRECATED: Strategy was never used and is being discarded
+// - ACTIVE -> DEPRECATED: Strategy is being retired
+// - DEPRECATED is a terminal state
+
+// validStatusTransitions defines the allowed state transitions.
+var validStatusTransitions = map[StrategyStatus]map[StrategyStatus]bool{
+	StrategyStatusDraft: {
+		StrategyStatusActive:     true,
+		StrategyStatusDeprecated: true,
+	},
+	StrategyStatusActive: {
+		StrategyStatusDeprecated: true,
+	},
+	StrategyStatusDeprecated: {},
+}
+
+// CanTransitionTo checks if a transition from the current status to the target status is valid.
+func (s StrategyStatus) CanTransitionTo(target StrategyStatus) bool {
+	if s == target {
+		return false
+	}
+	allowed, exists := validStatusTransitions[s]
+	if !exists {
+		return false
+	}
+	return allowed[target]
+}
+
+// ValidateStatusTransition checks if transitioning from one status to another is valid.
+func ValidateStatusTransition(from, to StrategyStatus) error {
+	if from == to {
+		return fmt.Errorf("%w: source and target status are the same", ErrInvalidStatusTransition)
+	}
+	if !from.CanTransitionTo(to) {
+		return fmt.Errorf("%w: cannot transition from %s to %s", ErrInvalidStatusTransition, from, to)
+	}
+	return nil
+}
+
+// IsValid returns true if the strategy status is a recognized valid type.
+func (s StrategyStatus) IsValid() bool {
+	switch s {
+	case StrategyStatusDraft, StrategyStatusActive, StrategyStatusDeprecated:
+		return true
+	default:
+		return false
+	}
+}
+
+// String returns the string representation of the strategy status.
+func (s StrategyStatus) String() string {
+	return string(s)
+}

--- a/services/forecasting/domain/strategy_status_test.go
+++ b/services/forecasting/domain/strategy_status_test.go
@@ -1,0 +1,71 @@
+package domain
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStrategyStatus_IsValid(t *testing.T) {
+	tests := []struct {
+		status StrategyStatus
+		valid  bool
+	}{
+		{StrategyStatusDraft, true},
+		{StrategyStatusActive, true},
+		{StrategyStatusDeprecated, true},
+		{StrategyStatus("UNKNOWN"), false},
+		{StrategyStatus(""), false},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			assert.Equal(t, tc.valid, tc.status.IsValid())
+		})
+	}
+}
+
+func TestStrategyStatus_CanTransitionTo(t *testing.T) {
+	tests := []struct {
+		name   string
+		from   StrategyStatus
+		to     StrategyStatus
+		expect bool
+	}{
+		{"draft to active", StrategyStatusDraft, StrategyStatusActive, true},
+		{"draft to deprecated", StrategyStatusDraft, StrategyStatusDeprecated, true},
+		{"active to deprecated", StrategyStatusActive, StrategyStatusDeprecated, true},
+		{"active to draft", StrategyStatusActive, StrategyStatusDraft, false},
+		{"deprecated to active", StrategyStatusDeprecated, StrategyStatusActive, false},
+		{"deprecated to draft", StrategyStatusDeprecated, StrategyStatusDraft, false},
+		{"same status draft", StrategyStatusDraft, StrategyStatusDraft, false},
+		{"same status active", StrategyStatusActive, StrategyStatusActive, false},
+		{"same status deprecated", StrategyStatusDeprecated, StrategyStatusDeprecated, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, tc.from.CanTransitionTo(tc.to))
+		})
+	}
+}
+
+func TestValidateStatusTransition_SameStatus(t *testing.T) {
+	err := ValidateStatusTransition(StrategyStatusDraft, StrategyStatusDraft)
+	assert.True(t, errors.Is(err, ErrInvalidStatusTransition))
+}
+
+func TestValidateStatusTransition_InvalidTransition(t *testing.T) {
+	err := ValidateStatusTransition(StrategyStatusDeprecated, StrategyStatusActive)
+	assert.True(t, errors.Is(err, ErrInvalidStatusTransition))
+}
+
+func TestValidateStatusTransition_ValidTransition(t *testing.T) {
+	err := ValidateStatusTransition(StrategyStatusDraft, StrategyStatusActive)
+	assert.NoError(t, err)
+}
+
+func TestStrategyStatus_String(t *testing.T) {
+	assert.Equal(t, "DRAFT", StrategyStatusDraft.String())
+	assert.Equal(t, "ACTIVE", StrategyStatusActive.String())
+	assert.Equal(t, "DEPRECATED", StrategyStatusDeprecated.String())
+}

--- a/services/forecasting/k8s/configmap.yaml
+++ b/services/forecasting/k8s/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: forecasting-config
+  labels:
+    app: forecasting
+    component: microservice
+data:
+  # Logging configuration
+  LOG_LEVEL: "info"
+  LOG_FORMAT: "json"
+
+  # Database connection pool settings
+  DB_MAX_OPEN_CONNS: "25"
+  DB_MAX_IDLE_CONNS: "5"
+  DB_CONN_MAX_LIFETIME: "5m"
+  DB_CONN_MAX_IDLE_TIME: "10m"
+
+  # gRPC server configuration
+  GRPC_PORT: "50061"
+  GRPC_MAX_CONCURRENT_STREAMS: "100"
+
+  # OpenTelemetry configuration
+  OTEL_SERVICE_NAME: "forecasting-service"
+  OTEL_SAMPLING_RATE: "0.1"
+
+  # Authentication configuration
+  AUTH_ENABLED: "false"

--- a/services/forecasting/k8s/deployment.yaml
+++ b/services/forecasting/k8s/deployment.yaml
@@ -1,0 +1,109 @@
+# Port Configuration: See shared/platform/ports/ports.go for canonical port assignments.
+# This service uses ports.Forecasting (50061) for gRPC.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forecasting
+  labels:
+    app: forecasting
+    component: microservice
+    tier: backend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: forecasting
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: forecasting
+        component: microservice
+        tier: backend
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: forecasting
+        image: forecasting:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: grpc
+          containerPort: 50061
+          protocol: TCP
+        envFrom:
+        - configMapRef:
+            name: forecasting-config
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: forecasting-db
+              key: DATABASE_URL
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
+          limits:
+            cpu: 200m
+            memory: 256Mi
+        livenessProbe:
+          grpc:
+            port: 50061
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          grpc:
+            port: 50061
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 3
+        startupProbe:
+          grpc:
+            port: 50061
+          initialDelaySeconds: 0
+          periodSeconds: 2
+          timeoutSeconds: 3
+          successThreshold: 1
+          failureThreshold: 30
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 65532
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+      terminationGracePeriodSeconds: 30

--- a/services/forecasting/k8s/secret.yaml
+++ b/services/forecasting/k8s/secret.yaml
@@ -1,0 +1,16 @@
+# SECURITY NOTE: This secret contains development credentials only.
+# For production deployments:
+# - Use external secret management (e.g., Sealed Secrets, External Secrets Operator)
+# - Rotate credentials regularly
+# - Use RBAC to restrict secret access
+# - Enable encryption at rest for secrets
+apiVersion: v1
+kind: Secret
+metadata:
+  name: forecasting-db
+  labels:
+    app: forecasting
+type: Opaque
+stringData:
+  # Local development connection string - CockroachDB in insecure mode
+  DATABASE_URL: "postgres://meridian_forecasting_user@cockroachdb:26257/meridian_forecasting?sslmode=disable"

--- a/services/forecasting/k8s/service.yaml
+++ b/services/forecasting/k8s/service.yaml
@@ -1,0 +1,19 @@
+# Port Configuration: See shared/platform/ports/ports.go for canonical port assignments.
+# This service uses ports.Forecasting (50061) for gRPC.
+apiVersion: v1
+kind: Service
+metadata:
+  name: forecasting
+  labels:
+    app: forecasting
+    component: microservice
+spec:
+  type: ClusterIP
+  clusterIP: None  # Headless service for gRPC client-side load balancing
+  ports:
+  - name: grpc
+    port: 50061
+    targetPort: grpc
+    protocol: TCP
+  selector:
+    app: forecasting

--- a/services/forecasting/migrations/20260210000001_initial.sql
+++ b/services/forecasting/migrations/20260210000001_initial.sql
@@ -1,0 +1,56 @@
+-- Forecasting Service Schema
+-- Manages forecasting strategies that generate forward curves from market data
+-- Uses CockroachDB with database-per-service architecture
+
+--------------------------------------------------------------------------------
+-- Section 1: Forecasting Strategy Table
+-- Defines Starlark-based forecasting strategies with lifecycle management
+--------------------------------------------------------------------------------
+
+CREATE TABLE forecasting_strategy (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    starlark_code TEXT NOT NULL,
+    horizon_hours INT NOT NULL CHECK (horizon_hours > 0 AND horizon_hours <= 168),
+    granularity_hours INT NOT NULL CHECK (granularity_hours > 0 AND granularity_hours <= horizon_hours),
+    schedule TEXT NOT NULL,
+    input_dataset_codes TEXT[] NOT NULL,
+    output_dataset_code TEXT NOT NULL,
+    reference_data_resolution_key TEXT,
+    status TEXT NOT NULL DEFAULT 'DRAFT',
+    version BIGINT NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT chk_forecasting_strategy_status CHECK (status IN ('DRAFT', 'ACTIVE', 'DEPRECATED'))
+);
+
+COMMENT ON TABLE forecasting_strategy IS 'Starlark-based forecasting strategies that generate forward curves from market data inputs';
+COMMENT ON COLUMN forecasting_strategy.starlark_code IS 'Starlark script source code executed to generate forward curve predictions';
+COMMENT ON COLUMN forecasting_strategy.horizon_hours IS 'How far into the future the forecast extends (1-168 hours)';
+COMMENT ON COLUMN forecasting_strategy.granularity_hours IS 'Time spacing between forecast data points (must be <= horizon_hours)';
+COMMENT ON COLUMN forecasting_strategy.schedule IS 'Cron expression defining when the strategy executes (e.g., "0 16 * * *")';
+COMMENT ON COLUMN forecasting_strategy.input_dataset_codes IS 'MDS dataset codes that the strategy reads as input';
+COMMENT ON COLUMN forecasting_strategy.output_dataset_code IS 'MDS dataset code where the forward curve is published';
+COMMENT ON COLUMN forecasting_strategy.reference_data_resolution_key IS 'Optional hierarchy node context for the forecast';
+COMMENT ON COLUMN forecasting_strategy.version IS 'Optimistic locking version, incremented on every update';
+
+--------------------------------------------------------------------------------
+-- Section 2: Indexes
+--------------------------------------------------------------------------------
+
+-- Partial unique index: only one ACTIVE strategy per tenant+name combination.
+-- CockroachDB supports partial unique indexes via WHERE clause.
+CREATE UNIQUE INDEX idx_forecasting_strategy_unique_active
+    ON forecasting_strategy (tenant_id, name)
+    WHERE status = 'ACTIVE';
+
+-- Tenant lookup with status filter for listing queries
+CREATE INDEX idx_forecasting_strategy_tenant_status
+    ON forecasting_strategy (tenant_id, status, created_at DESC);
+
+-- Active strategies for scheduler lookups
+CREATE INDEX idx_forecasting_strategy_active
+    ON forecasting_strategy (status, tenant_id)
+    WHERE status = 'ACTIVE';

--- a/shared/platform/ports/ports.go
+++ b/shared/platform/ports/ports.go
@@ -112,6 +112,12 @@ const (
 	// Protocol: gRPC (internal)
 	// Visibility: Cluster-internal only
 	Reconciliation = 50060
+
+	// Forecasting is the gRPC port for the Forecasting service.
+	// Manages forecasting strategies that generate forward curves from market data.
+	// Protocol: gRPC (internal)
+	// Visibility: Cluster-internal only
+	Forecasting = 50061
 )
 
 // HTTP service ports (various protocols).


### PR DESCRIPTION
## Summary

- Scaffold new `services/forecasting/` microservice following existing service patterns (market-information, position-keeping)
- Implement `ForecastingStrategy` immutable domain entity with DRAFT -> ACTIVE -> DEPRECATED lifecycle, cron schedule validation via `robfig/cron`, horizon/granularity bounds checking, and defensive slice copying
- Create CockroachDB migration with partial unique index (`WHERE status = 'ACTIVE'`) ensuring one active strategy per tenant+name
- Implement `StrategyRepository` with optimistic locking, cursor-based pagination, and tenant isolation
- Bootstrap gRPC server entry point with health checks, OpenTelemetry tracing, and Prometheus metrics
- Add Kubernetes deployment manifests (Deployment, Service, ConfigMap, Secret) and Dockerfile
- Allocate port 50061 in shared ports registry

## Test Plan

- [x] 36 domain model unit tests: builder validation (invalid horizon/granularity/schedule), lifecycle transitions (DRAFT->ACTIVE->DEPRECATED, invalid transitions), version increment on update, defensive slice copying
- [x] 15 CockroachDB integration tests: CRUD with tenant isolation, optimistic locking conflict detection, partial unique constraint on duplicate active strategy name, pagination across pages, nullable field round-trip, full lifecycle transitions

## Task Master

Implements `market-data-dynamic-pricing.7`: Design and implement Forecasting Service domain model and repository