### PR TITLE
feat: implement SettlementSnapshotRepository persistence adapter

### DIFF
--- a/services/reconciliation/adapters/persistence/settlement_snapshot_repository.go
+++ b/services/reconciliation/adapters/persistence/settlement_snapshot_repository.go
@@ -1,0 +1,204 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/shared/platform/db"
+	"github.com/shopspring/decimal"
+	"gorm.io/gorm"
+)
+
+// Compile-time check that SettlementSnapshotRepository implements domain.SettlementSnapshotRepository.
+var _ domain.SettlementSnapshotRepository = (*SettlementSnapshotRepository)(nil)
+
+// SettlementSnapshotEntity is the GORM entity for the settlement_snapshot table.
+type SettlementSnapshotEntity struct {
+	ID              uuid.UUID       `gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	CreatedAt       time.Time       `gorm:"not null;default:now()"`
+	SnapshotID      uuid.UUID       `gorm:"column:snapshot_id;uniqueIndex:idx_ss_snap_id;type:uuid;not null"`
+	RunID           uuid.UUID       `gorm:"column:run_id;index:idx_ss_run_id;type:uuid;not null"`
+	AccountID       string          `gorm:"column:account_id;index:idx_ss_account_id;size:34;not null"`
+	InstrumentCode  string          `gorm:"column:instrument_code;size:20;not null"`
+	ExpectedBalance decimal.Decimal `gorm:"column:expected_balance;type:decimal(38,18);not null"`
+	ActualBalance   decimal.Decimal `gorm:"column:actual_balance;type:decimal(38,18);not null"`
+	VarianceAmount  decimal.Decimal `gorm:"column:variance_amount;type:decimal(38,18);not null"`
+	SourceSystem    string          `gorm:"column:source_system;size:100;not null"`
+	Attributes      JSONMap         `gorm:"column:attributes;type:jsonb"`
+	CapturedAt      time.Time       `gorm:"column:captured_at;not null"`
+}
+
+// TableName returns the table name for the settlement snapshot entity.
+func (SettlementSnapshotEntity) TableName() string {
+	return "settlement_snapshot"
+}
+
+// SettlementSnapshotRepository provides GORM-based persistence for settlement snapshots.
+type SettlementSnapshotRepository struct {
+	db *gorm.DB
+}
+
+// NewSettlementSnapshotRepository creates a new settlement snapshot repository.
+func NewSettlementSnapshotRepository(db *gorm.DB) *SettlementSnapshotRepository {
+	return &SettlementSnapshotRepository{db: db}
+}
+
+// withTenantTransaction executes fn within a tenant-scoped transaction.
+func (r *SettlementSnapshotRepository) withTenantTransaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	if r.isInTransaction() {
+		tx, err := db.WithGormTenantScope(ctx, r.db.WithContext(ctx))
+		if err != nil {
+			return err
+		}
+		return fn(tx)
+	}
+	return db.WithGormTenantTransaction(ctx, r.db, fn)
+}
+
+// isInTransaction checks if the repository's db connection is already within a transaction.
+func (r *SettlementSnapshotRepository) isInTransaction() bool {
+	if r.db.Statement == nil || r.db.Statement.ConnPool == nil {
+		return false
+	}
+	committer, ok := r.db.Statement.ConnPool.(gorm.TxCommitter)
+	return ok && committer != nil
+}
+
+// Create persists a new SettlementSnapshot.
+func (r *SettlementSnapshotRepository) Create(ctx context.Context, snapshot *domain.SettlementSnapshot) error {
+	entity := toSnapshotEntity(snapshot)
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Create(entity).Error
+	})
+}
+
+// CreateBatch persists multiple snapshots atomically.
+func (r *SettlementSnapshotRepository) CreateBatch(ctx context.Context, snapshots []*domain.SettlementSnapshot) error {
+	if len(snapshots) == 0 {
+		return nil
+	}
+
+	entities := make([]SettlementSnapshotEntity, 0, len(snapshots))
+	for _, s := range snapshots {
+		entities = append(entities, *toSnapshotEntity(s))
+	}
+
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.CreateInBatches(entities, 100).Error
+	})
+}
+
+// FindByID retrieves a SettlementSnapshot by its SnapshotID.
+func (r *SettlementSnapshotRepository) FindByID(ctx context.Context, snapshotID uuid.UUID) (*domain.SettlementSnapshot, error) {
+	var entity SettlementSnapshotEntity
+	var queryErr error
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		result := tx.Where("snapshot_id = ?", snapshotID).First(&entity)
+		if result.Error != nil {
+			queryErr = result.Error
+			return result.Error
+		}
+		return nil
+	})
+	if err != nil {
+		if errors.Is(queryErr, gorm.ErrRecordNotFound) {
+			return nil, domain.ErrNotFound
+		}
+		return nil, err
+	}
+
+	return toSnapshotDomain(&entity), nil
+}
+
+// FindByRunID retrieves all snapshots for a settlement run.
+func (r *SettlementSnapshotRepository) FindByRunID(ctx context.Context, runID uuid.UUID) ([]*domain.SettlementSnapshot, error) {
+	var entities []SettlementSnapshotEntity
+
+	err := r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Where("run_id = ?", runID).
+			Order("created_at ASC").
+			Find(&entities).Error
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return toSnapshotDomainSlice(entities), nil
+}
+
+// DeleteByRunID removes all snapshots for a given settlement run.
+func (r *SettlementSnapshotRepository) DeleteByRunID(ctx context.Context, runID uuid.UUID) error {
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		return tx.Where("run_id = ?", runID).Delete(&SettlementSnapshotEntity{}).Error
+	})
+}
+
+// MarkRunSnapshotsFinal updates all snapshots for a run to include settlement_type=FINAL in their attributes.
+func (r *SettlementSnapshotRepository) MarkRunSnapshotsFinal(ctx context.Context, runID uuid.UUID) error {
+	return r.withTenantTransaction(ctx, func(tx *gorm.DB) error {
+		// Use CASE to handle NULL/JSON-null attributes vs existing JSONB objects.
+		// CockroachDB's || operator requires both operands to be JSONB objects,
+		// so we must replace NULL/json-null with an empty object before merging.
+		return tx.Exec(
+			`UPDATE "settlement_snapshot" SET "attributes" = CASE WHEN "attributes" IS NULL OR "attributes"::text = 'null' THEN '{"settlement_type":"FINAL"}'::jsonb ELSE "attributes" || '{"settlement_type":"FINAL"}'::jsonb END WHERE "run_id" = ?`,
+			runID,
+		).Error
+	})
+}
+
+// toSnapshotEntity converts a domain SettlementSnapshot to a persistence entity.
+func toSnapshotEntity(s *domain.SettlementSnapshot) *SettlementSnapshotEntity {
+	entity := &SettlementSnapshotEntity{
+		SnapshotID:      s.SnapshotID,
+		RunID:           s.RunID,
+		AccountID:       s.AccountID,
+		InstrumentCode:  s.InstrumentCode,
+		ExpectedBalance: s.ExpectedBalance,
+		ActualBalance:   s.ActualBalance,
+		VarianceAmount:  s.VarianceAmount,
+		SourceSystem:    s.SourceSystem,
+		CapturedAt:      s.CapturedAt,
+		CreatedAt:       s.CreatedAt,
+	}
+
+	if s.Attributes != nil {
+		entity.Attributes = JSONMap(s.Attributes)
+	}
+
+	return entity
+}
+
+// toSnapshotDomain converts a persistence entity to a domain SettlementSnapshot.
+func toSnapshotDomain(e *SettlementSnapshotEntity) *domain.SettlementSnapshot {
+	s := &domain.SettlementSnapshot{
+		SnapshotID:      e.SnapshotID,
+		RunID:           e.RunID,
+		AccountID:       e.AccountID,
+		InstrumentCode:  e.InstrumentCode,
+		ExpectedBalance: e.ExpectedBalance,
+		ActualBalance:   e.ActualBalance,
+		VarianceAmount:  e.VarianceAmount,
+		SourceSystem:    e.SourceSystem,
+		CapturedAt:      e.CapturedAt,
+		CreatedAt:       e.CreatedAt,
+	}
+
+	if e.Attributes != nil {
+		s.Attributes = map[string]string(e.Attributes)
+	}
+
+	return s
+}
+
+// toSnapshotDomainSlice converts a slice of entities to domain objects.
+func toSnapshotDomainSlice(entities []SettlementSnapshotEntity) []*domain.SettlementSnapshot {
+	snapshots := make([]*domain.SettlementSnapshot, 0, len(entities))
+	for i := range entities {
+		snapshots = append(snapshots, toSnapshotDomain(&entities[i]))
+	}
+	return snapshots
+}

--- a/services/reconciliation/adapters/persistence/settlement_snapshot_repository_test.go
+++ b/services/reconciliation/adapters/persistence/settlement_snapshot_repository_test.go
@@ -1,0 +1,311 @@
+package persistence_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// seedSettlementRun creates a settlement_run record and returns the surrogate ID.
+func seedSettlementRun(t *testing.T, ctx context.Context, db *gorm.DB) uuid.UUID {
+	t.Helper()
+	tid := tenant.TenantID("test-tenant-01")
+	quoted := fmt.Sprintf("%q", tid.SchemaName())
+
+	surrogateID := uuid.New()
+	runID := uuid.New()
+
+	err := db.WithContext(ctx).Exec(
+		fmt.Sprintf(`INSERT INTO %s."settlement_run" (id, run_id, account_id, scope, settlement_type, period_start, period_end, initiated_by) VALUES (?, ?, 'ACC-001', 'ACCOUNT', 'DAILY', NOW() - INTERVAL '1 day', NOW(), 'system')`, quoted),
+		surrogateID, runID,
+	).Error
+	require.NoError(t, err)
+	return surrogateID
+}
+
+func newTestSnapshot(t *testing.T, runID uuid.UUID) *domain.SettlementSnapshot {
+	t.Helper()
+	return &domain.SettlementSnapshot{
+		SnapshotID:      uuid.New(),
+		RunID:           runID,
+		AccountID:       "ACC-001",
+		InstrumentCode:  "GBP",
+		ExpectedBalance: decimal.NewFromFloat(1000.123456789012345678),
+		ActualBalance:   decimal.NewFromFloat(990.123456789012345678),
+		VarianceAmount:  decimal.NewFromFloat(-10.0),
+		SourceSystem:    "position-keeping",
+		Attributes:      map[string]string{"bucket": "default"},
+		CapturedAt:      time.Now().UTC(),
+		CreatedAt:       time.Now().UTC(),
+	}
+}
+
+func TestSettlementSnapshotRepository_Create(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementSnapshotRepository(db)
+	ctx := tenantCtx()
+
+	runID := seedSettlementRun(t, ctx, db)
+	snapshot := newTestSnapshot(t, runID)
+
+	err := repo.Create(ctx, snapshot)
+	require.NoError(t, err)
+
+	found, err := repo.FindByID(ctx, snapshot.SnapshotID)
+	require.NoError(t, err)
+	assert.Equal(t, snapshot.SnapshotID, found.SnapshotID)
+	assert.Equal(t, runID, found.RunID)
+	assert.Equal(t, "ACC-001", found.AccountID)
+	assert.Equal(t, "GBP", found.InstrumentCode)
+	assert.Equal(t, "position-keeping", found.SourceSystem)
+	assert.Equal(t, "default", found.Attributes["bucket"])
+	assert.WithinDuration(t, snapshot.CapturedAt, found.CapturedAt, time.Second)
+}
+
+func TestSettlementSnapshotRepository_CreateBatch(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementSnapshotRepository(db)
+	ctx := tenantCtx()
+
+	runID := seedSettlementRun(t, ctx, db)
+
+	// Create 250 snapshots to test batching (batch size 100)
+	snapshots := make([]*domain.SettlementSnapshot, 250)
+	for i := range snapshots {
+		snapshots[i] = newTestSnapshot(t, runID)
+		snapshots[i].AccountID = fmt.Sprintf("ACC-%03d", i)
+	}
+
+	err := repo.CreateBatch(ctx, snapshots)
+	require.NoError(t, err)
+
+	found, err := repo.FindByRunID(ctx, runID)
+	require.NoError(t, err)
+	assert.Len(t, found, 250)
+}
+
+func TestSettlementSnapshotRepository_CreateBatchEmpty(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementSnapshotRepository(db)
+	ctx := tenantCtx()
+
+	err := repo.CreateBatch(ctx, nil)
+	require.NoError(t, err)
+
+	err = repo.CreateBatch(ctx, []*domain.SettlementSnapshot{})
+	require.NoError(t, err)
+}
+
+func TestSettlementSnapshotRepository_FindByID(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementSnapshotRepository(db)
+	ctx := tenantCtx()
+
+	t.Run("existing snapshot with decimal precision", func(t *testing.T) {
+		runID := seedSettlementRun(t, ctx, db)
+		snapshot := newTestSnapshot(t, runID)
+		snapshot.ExpectedBalance = decimal.RequireFromString("12345678901234567890.123456789012345678")
+		snapshot.ActualBalance = decimal.RequireFromString("12345678901234567890.123456789012345670")
+		snapshot.VarianceAmount = snapshot.ActualBalance.Sub(snapshot.ExpectedBalance)
+		require.NoError(t, repo.Create(ctx, snapshot))
+
+		found, err := repo.FindByID(ctx, snapshot.SnapshotID)
+		require.NoError(t, err)
+		assert.True(t, snapshot.ExpectedBalance.Equal(found.ExpectedBalance),
+			"expected %s, got %s", snapshot.ExpectedBalance, found.ExpectedBalance)
+		assert.True(t, snapshot.ActualBalance.Equal(found.ActualBalance),
+			"expected %s, got %s", snapshot.ActualBalance, found.ActualBalance)
+		assert.True(t, snapshot.VarianceAmount.Equal(found.VarianceAmount),
+			"expected %s, got %s", snapshot.VarianceAmount, found.VarianceAmount)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := repo.FindByID(ctx, uuid.New())
+		assert.ErrorIs(t, err, domain.ErrNotFound)
+	})
+}
+
+func TestSettlementSnapshotRepository_FindByRunID(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementSnapshotRepository(db)
+	ctx := tenantCtx()
+
+	runID1 := seedSettlementRun(t, ctx, db)
+	runID2 := seedSettlementRun(t, ctx, db)
+
+	// Create 3 snapshots for run1
+	for i := 0; i < 3; i++ {
+		s := newTestSnapshot(t, runID1)
+		s.AccountID = fmt.Sprintf("ACC-%03d", i)
+		require.NoError(t, repo.Create(ctx, s))
+	}
+
+	// Create 2 snapshots for run2
+	for i := 0; i < 2; i++ {
+		s := newTestSnapshot(t, runID2)
+		s.AccountID = fmt.Sprintf("ACC-%03d", i+10)
+		require.NoError(t, repo.Create(ctx, s))
+	}
+
+	t.Run("filter by run1", func(t *testing.T) {
+		found, err := repo.FindByRunID(ctx, runID1)
+		require.NoError(t, err)
+		assert.Len(t, found, 3)
+		for _, s := range found {
+			assert.Equal(t, runID1, s.RunID)
+		}
+	})
+
+	t.Run("filter by run2", func(t *testing.T) {
+		found, err := repo.FindByRunID(ctx, runID2)
+		require.NoError(t, err)
+		assert.Len(t, found, 2)
+		for _, s := range found {
+			assert.Equal(t, runID2, s.RunID)
+		}
+	})
+
+	t.Run("no results for unknown run", func(t *testing.T) {
+		found, err := repo.FindByRunID(ctx, uuid.New())
+		require.NoError(t, err)
+		assert.Empty(t, found)
+	})
+}
+
+func TestSettlementSnapshotRepository_DeleteByRunID(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementSnapshotRepository(db)
+	ctx := tenantCtx()
+
+	runID := seedSettlementRun(t, ctx, db)
+
+	// Create snapshots
+	for i := 0; i < 5; i++ {
+		s := newTestSnapshot(t, runID)
+		s.AccountID = fmt.Sprintf("ACC-%03d", i)
+		require.NoError(t, repo.Create(ctx, s))
+	}
+
+	// Verify they exist
+	found, err := repo.FindByRunID(ctx, runID)
+	require.NoError(t, err)
+	assert.Len(t, found, 5)
+
+	// Delete by run ID
+	err = repo.DeleteByRunID(ctx, runID)
+	require.NoError(t, err)
+
+	// Verify cleanup
+	found, err = repo.FindByRunID(ctx, runID)
+	require.NoError(t, err)
+	assert.Empty(t, found)
+
+	// Idempotent: deleting again is a no-op
+	err = repo.DeleteByRunID(ctx, runID)
+	require.NoError(t, err)
+}
+
+func TestSettlementSnapshotRepository_MarkRunSnapshotsFinal(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementSnapshotRepository(db)
+	ctx := tenantCtx()
+
+	runID := seedSettlementRun(t, ctx, db)
+
+	// Create snapshots with various attributes
+	s1 := newTestSnapshot(t, runID)
+	s1.Attributes = map[string]string{"bucket": "default"}
+	require.NoError(t, repo.Create(ctx, s1))
+
+	s2 := newTestSnapshot(t, runID)
+	s2.AccountID = "ACC-002"
+	s2.Attributes = nil // Test nil attributes case
+	require.NoError(t, repo.Create(ctx, s2))
+
+	s3 := newTestSnapshot(t, runID)
+	s3.AccountID = "ACC-003"
+	s3.Attributes = map[string]string{"region": "eu-west-1"}
+	require.NoError(t, repo.Create(ctx, s3))
+
+	// Mark all snapshots as FINAL
+	err := repo.MarkRunSnapshotsFinal(ctx, runID)
+	require.NoError(t, err)
+
+	// Verify all snapshots have settlement_type=FINAL
+	found, err := repo.FindByRunID(ctx, runID)
+	require.NoError(t, err)
+	assert.Len(t, found, 3)
+	for _, snap := range found {
+		assert.Equal(t, "FINAL", snap.Attributes["settlement_type"],
+			"snapshot %s missing settlement_type=FINAL", snap.SnapshotID)
+	}
+
+	// Verify existing attributes are preserved
+	f1, err := repo.FindByID(ctx, s1.SnapshotID)
+	require.NoError(t, err)
+	assert.Equal(t, "default", f1.Attributes["bucket"])
+	assert.Equal(t, "FINAL", f1.Attributes["settlement_type"])
+
+	f3, err := repo.FindByID(ctx, s3.SnapshotID)
+	require.NoError(t, err)
+	assert.Equal(t, "eu-west-1", f3.Attributes["region"])
+	assert.Equal(t, "FINAL", f3.Attributes["settlement_type"])
+}
+
+func TestSettlementSnapshotRepository_CreateBatchRollback(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := persistence.NewSettlementSnapshotRepository(db)
+	ctx := tenantCtx()
+
+	runID := seedSettlementRun(t, ctx, db)
+
+	// Create a valid snapshot first
+	existing := newTestSnapshot(t, runID)
+	require.NoError(t, repo.Create(ctx, existing))
+
+	// Create a batch where one snapshot has a duplicate snapshot_id (constraint violation)
+	snapshots := make([]*domain.SettlementSnapshot, 3)
+	snapshots[0] = newTestSnapshot(t, runID)
+	snapshots[0].AccountID = "ACC-BATCH-1"
+	snapshots[1] = newTestSnapshot(t, runID)
+	snapshots[1].AccountID = "ACC-BATCH-2"
+	snapshots[1].SnapshotID = existing.SnapshotID // Duplicate - will cause constraint violation
+	snapshots[2] = newTestSnapshot(t, runID)
+	snapshots[2].AccountID = "ACC-BATCH-3"
+
+	err := repo.CreateBatch(ctx, snapshots)
+	require.Error(t, err)
+
+	// Verify none of the batch was persisted (atomic rollback)
+	found, err := repo.FindByRunID(ctx, runID)
+	require.NoError(t, err)
+	// Only the original existing snapshot should remain
+	assert.Len(t, found, 1)
+	assert.Equal(t, existing.SnapshotID, found[0].SnapshotID)
+}


### PR DESCRIPTION
## Summary

Implements `domain.SettlementSnapshotRepository` persistence adapter for the reconciliation service (Task Master: reconciliation-service.14).

- **Create/CreateBatch**: Single and atomic batch insert (batch size 100) with tenant isolation via `withTenantTransaction()`
- **FindByID/FindByRunID**: Query by snapshot_id or run_id with `ErrNotFound` mapping
- **DeleteByRunID**: Idempotent cleanup for retry scenarios
- **MarkRunSnapshotsFinal**: Bulk JSONB merge to add `settlement_type=FINAL`, with CockroachDB-compatible NULL/json-null handling

Follows established patterns from `SettlementRunRepository` (PR #858) and `DisputeRepository`.

## Changes Made

| File | Description |
|------|-------------|
| `services/reconciliation/adapters/persistence/settlement_snapshot_repository.go` | Repository implementation with entity mapping |
| `services/reconciliation/adapters/persistence/settlement_snapshot_repository_test.go` | Integration tests with CockroachDB testcontainers |

## Technical Details

- **Entity mapping**: `SettlementSnapshotEntity` maps to `settlement_snapshot` table with `decimal(38,18)` for balance fields
- **JSONB merge**: `MarkRunSnapshotsFinal` uses `CASE WHEN` to handle both SQL NULL and JSON null before JSONB concatenation (CockroachDB `||` operator requires non-null JSONB objects)
- **Batch atomicity**: `CreateBatch` uses `tx.CreateInBatches(entities, 100)` within a single transaction for rollback guarantee

## Testing

8 integration tests with CockroachDB testcontainers:

| Test | Coverage |
|------|----------|
| TestCreate | Insert and verify persistence |
| TestCreateBatch | 250 snapshots across 3 batches |
| TestCreateBatchEmpty | Nil and empty slice edge cases |
| TestFindByID | Decimal precision (38,18) preservation + not found |
| TestFindByRunID | Multi-run filtering + empty result for unknown run |
| TestDeleteByRunID | Cleanup + idempotent re-delete |
| TestMarkRunSnapshotsFinal | JSONB merge with NULL, existing, and mixed attributes |
| TestCreateBatchRollback | Constraint violation mid-batch verifies atomic rollback |