### PR TITLE
feat: Add Stripe gateway adapter with platform fee support

### DIFF
--- a/services/payment-order/adapters/gateway/stripe/stripe_gateway.go
+++ b/services/payment-order/adapters/gateway/stripe/stripe_gateway.go
@@ -1,0 +1,272 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/shopspring/decimal"
+	stripego "github.com/stripe/stripe-go/v82"
+
+	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Sentinel errors for the Stripe gateway adapter.
+var (
+	ErrMissingStripeAccount = errors.New("stripe connected account ID not found in context")
+	ErrInvalidRequest       = errors.New("invalid stripe request")
+)
+
+// Prometheus metrics for Stripe gateway operations.
+var (
+	stripePaymentTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "stripe_gateway_payment_total",
+			Help: "Total number of Stripe PaymentIntent creation attempts",
+		},
+		[]string{"status", "currency"},
+	)
+	stripePaymentDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "stripe_gateway_payment_duration_seconds",
+			Help:    "Duration of Stripe PaymentIntent creation in seconds",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"status"},
+	)
+	stripePaymentErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "stripe_gateway_payment_errors_total",
+			Help: "Total number of Stripe PaymentIntent errors by type",
+		},
+		[]string{"error_type"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(stripePaymentTotal)
+	prometheus.MustRegister(stripePaymentDuration)
+	prometheus.MustRegister(stripePaymentErrors)
+}
+
+// PaymentIntentCreator abstracts Stripe PaymentIntent creation for testability.
+type PaymentIntentCreator interface {
+	Create(ctx context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error)
+}
+
+// GatewayAdapterConfig holds configuration for the Stripe gateway adapter.
+type GatewayAdapterConfig struct {
+	// PlatformFeePercent is the percentage of each payment collected as platform fee.
+	// e.g., 2.5 means 2.5%. Set to zero to disable platform fees.
+	PlatformFeePercent decimal.Decimal
+}
+
+// stripeAccountKey is the context key for the Stripe Connected Account ID.
+type stripeAccountKey struct{}
+
+// WithStripeAccount adds a Stripe Connected Account ID to the context.
+func WithStripeAccount(ctx context.Context, accountID string) context.Context {
+	return context.WithValue(ctx, stripeAccountKey{}, accountID)
+}
+
+// AccountFromContext extracts the Stripe Connected Account ID from the context.
+func AccountFromContext(ctx context.Context) (string, bool) {
+	id, ok := ctx.Value(stripeAccountKey{}).(string)
+	return id, ok && id != ""
+}
+
+// GatewayAdapter implements gateway.PaymentGateway using Stripe PaymentIntents.
+type GatewayAdapter struct {
+	creator PaymentIntentCreator
+	config  GatewayAdapterConfig
+	logger  *slog.Logger
+}
+
+// NewGatewayAdapter creates a new Stripe gateway adapter.
+func NewGatewayAdapter(creator PaymentIntentCreator, config GatewayAdapterConfig, logger *slog.Logger) *GatewayAdapter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &GatewayAdapter{
+		creator: creator,
+		config:  config,
+		logger:  logger,
+	}
+}
+
+// SendPayment creates a Stripe PaymentIntent on the tenant's Connected Account.
+// The Stripe Connected Account ID must be present in the context (via WithStripeAccount).
+func (a *GatewayAdapter) SendPayment(ctx context.Context, req gateway.PaymentRequest) (gateway.PaymentResponse, error) {
+	accountID, ok := AccountFromContext(ctx)
+	if !ok {
+		return gateway.PaymentResponse{}, ErrMissingStripeAccount
+	}
+
+	tenantID := ""
+	if tid, ok := tenant.FromContext(ctx); ok {
+		tenantID = tid.String()
+	}
+
+	amountMinor := domain.ToMinorUnits(req.Amount)
+	currencyLower := strings.ToLower(domain.CurrencyCode(req.Amount))
+
+	params := &stripego.PaymentIntentCreateParams{
+		Amount:        stripego.Int64(amountMinor),
+		Currency:      stripego.String(currencyLower),
+		Customer:      stripego.String(req.DebtorAccountID),
+		PaymentMethod: stripego.String(req.CreditorReference),
+		Confirm:       stripego.Bool(true),
+		OffSession:    stripego.Bool(true),
+		Metadata: map[string]string{
+			"payment_order_id": req.PaymentOrderID.String(),
+			"tenant_id":        tenantID,
+		},
+	}
+
+	// Set platform fee if configured
+	if a.config.PlatformFeePercent.IsPositive() {
+		feeAmount := calculatePlatformFee(amountMinor, a.config.PlatformFeePercent)
+		if feeAmount > 0 {
+			params.ApplicationFeeAmount = stripego.Int64(feeAmount)
+		}
+	}
+
+	// Set idempotency key
+	idempotencyKey := IdempotencyKey(req.PaymentOrderID, "payment_intent")
+	params.IdempotencyKey = stripego.String(idempotencyKey)
+
+	// Set Connected Account header
+	params.SetStripeAccount(accountID)
+
+	a.logger.Debug("creating stripe payment intent",
+		"payment_order_id", req.PaymentOrderID.String(),
+		"tenant_id", tenantID,
+		"amount", amountMinor,
+		"currency", currencyLower,
+		"connected_account", accountID,
+	)
+
+	start := time.Now()
+	pi, err := a.creator.Create(ctx, params)
+	duration := time.Since(start)
+
+	if err != nil {
+		return a.handleError(err, currencyLower, duration)
+	}
+
+	status := mapPaymentIntentStatus(pi.Status)
+
+	stripePaymentTotal.WithLabelValues(string(status), currencyLower).Inc()
+	stripePaymentDuration.WithLabelValues(string(status)).Observe(duration.Seconds())
+
+	a.logger.Info("stripe payment intent created",
+		"payment_order_id", req.PaymentOrderID.String(),
+		"payment_intent_id", pi.ID,
+		"status", string(pi.Status),
+		"mapped_status", string(status),
+		"duration_ms", duration.Milliseconds(),
+	)
+
+	return gateway.PaymentResponse{
+		GatewayReferenceID: pi.ID,
+		Status:             status,
+		Message:            string(pi.Status),
+	}, nil
+}
+
+// handleError processes Stripe API errors and maps them to appropriate responses.
+func (a *GatewayAdapter) handleError(err error, currency string, duration time.Duration) (gateway.PaymentResponse, error) {
+	var stripeErr *stripego.Error
+	if !errors.As(err, &stripeErr) {
+		// Non-Stripe error (network, context, etc.) - propagate for retry
+		stripePaymentErrors.WithLabelValues("network").Inc()
+		stripePaymentDuration.WithLabelValues("error").Observe(duration.Seconds())
+		return gateway.PaymentResponse{}, fmt.Errorf("stripe payment failed: %w", err)
+	}
+
+	stripePaymentErrors.WithLabelValues(string(stripeErr.Type)).Inc()
+	stripePaymentDuration.WithLabelValues("error").Observe(duration.Seconds())
+
+	switch stripeErr.Type {
+	case stripego.ErrorTypeCard:
+		// Card errors are business rejections, not infrastructure failures.
+		refID := ""
+		if stripeErr.PaymentIntent != nil {
+			refID = stripeErr.PaymentIntent.ID
+		}
+
+		a.logger.Info("stripe card error",
+			"error_code", string(stripeErr.Code),
+			"message", stripeErr.Msg,
+			"decline_code", string(stripeErr.DeclineCode),
+		)
+
+		stripePaymentTotal.WithLabelValues(string(gateway.StatusRejected), currency).Inc()
+
+		return gateway.PaymentResponse{
+			GatewayReferenceID: refID,
+			Status:             gateway.StatusRejected,
+			Message:            stripeErr.Msg,
+		}, nil
+
+	case stripego.ErrorTypeInvalidRequest:
+		a.logger.Error("stripe invalid request error",
+			"message", stripeErr.Msg,
+			"param", stripeErr.Param,
+		)
+		return gateway.PaymentResponse{}, fmt.Errorf("%w: %s", ErrInvalidRequest, stripeErr.Msg)
+
+	case stripego.ErrorTypeAPI,
+		stripego.ErrorTypeIdempotency,
+		stripego.ErrorTypeTemporarySessionExpired:
+		// API errors, idempotency errors, session expired - propagate for retry
+		a.logger.Warn("stripe api error",
+			"type", string(stripeErr.Type),
+			"message", stripeErr.Msg,
+			"http_status", stripeErr.HTTPStatusCode,
+		)
+		return gateway.PaymentResponse{}, fmt.Errorf("stripe api error (%s): %w", stripeErr.Type, err)
+	}
+
+	// Unknown error type - propagate for retry
+	a.logger.Warn("stripe unknown error type",
+		"type", string(stripeErr.Type),
+		"message", stripeErr.Msg,
+	)
+	return gateway.PaymentResponse{}, fmt.Errorf("stripe error (%s): %w", stripeErr.Type, err)
+}
+
+// calculatePlatformFee calculates the platform fee in minor units.
+// fee = amount * percentage / 100, truncated to integer (floor).
+func calculatePlatformFee(amountMinor int64, feePercent decimal.Decimal) int64 {
+	amount := decimal.NewFromInt(amountMinor)
+	fee := amount.Mul(feePercent).Div(decimal.NewFromInt(100))
+	return fee.IntPart()
+}
+
+// mapPaymentIntentStatus maps a Stripe PaymentIntent status to a gateway.Status.
+func mapPaymentIntentStatus(status stripego.PaymentIntentStatus) gateway.Status {
+	switch status {
+	case stripego.PaymentIntentStatusSucceeded:
+		return gateway.StatusAccepted
+	case stripego.PaymentIntentStatusRequiresPaymentMethod,
+		stripego.PaymentIntentStatusCanceled:
+		return gateway.StatusRejected
+	case stripego.PaymentIntentStatusProcessing,
+		stripego.PaymentIntentStatusRequiresAction,
+		stripego.PaymentIntentStatusRequiresCapture,
+		stripego.PaymentIntentStatusRequiresConfirmation:
+		return gateway.StatusPending
+	}
+	// Unknown status - treat as pending
+	return gateway.StatusPending
+}
+
+// Compile-time interface check
+var _ gateway.PaymentGateway = (*GatewayAdapter)(nil)

--- a/services/payment-order/adapters/gateway/stripe/stripe_gateway_test.go
+++ b/services/payment-order/adapters/gateway/stripe/stripe_gateway_test.go
@@ -1,0 +1,367 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	stripego "github.com/stripe/stripe-go/v82"
+
+	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// mockPaymentIntentCreator implements PaymentIntentCreator for testing.
+type mockPaymentIntentCreator struct {
+	createFn func(ctx context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error)
+}
+
+func (m *mockPaymentIntentCreator) Create(ctx context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+	return m.createFn(ctx, params)
+}
+
+func testGatewayRequest() gateway.PaymentRequest {
+	return gateway.PaymentRequest{
+		PaymentOrderID:    uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		DebtorAccountID:   "cus_test123",
+		CreditorReference: "pm_test456",
+		Amount:            domain.MustNewMoney("GBP", 10000), // GBP 100.00
+		IdempotencyKey:    "test-idempotency-key",
+	}
+}
+
+func tenantContext(id string) context.Context {
+	return tenant.WithTenant(context.Background(), tenant.TenantID(id))
+}
+
+func TestStripeGatewayAdapter_SendPayment_Success(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			// Verify parameter construction
+			assert.Equal(t, int64(10000), *params.Amount)
+			assert.Equal(t, "gbp", *params.Currency)
+			assert.Equal(t, "cus_test123", *params.Customer)
+			assert.Equal(t, "pm_test456", *params.PaymentMethod)
+			assert.True(t, *params.Confirm)
+			assert.True(t, *params.OffSession)
+			assert.Equal(t, "11111111-1111-1111-1111-111111111111", params.Metadata["payment_order_id"])
+			assert.Equal(t, "tenant_a", params.Metadata["tenant_id"])
+
+			// Verify connected account is set
+			require.NotNil(t, params.StripeAccount)
+			assert.Equal(t, "acct_tenant_a", *params.StripeAccount)
+
+			return &stripego.PaymentIntent{
+				ID:     "pi_test_success",
+				Status: stripego.PaymentIntentStatusSucceeded,
+			}, nil
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{
+		PlatformFeePercent: decimal.Zero,
+	}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	resp, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.NoError(t, err)
+	assert.Equal(t, "pi_test_success", resp.GatewayReferenceID)
+	assert.Equal(t, gateway.StatusAccepted, resp.Status)
+}
+
+func TestStripeGatewayAdapter_SendPayment_WithPlatformFee(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			assert.Equal(t, int64(10000), *params.Amount)
+			// 2.5% of 10000 = 250
+			require.NotNil(t, params.ApplicationFeeAmount)
+			assert.Equal(t, int64(250), *params.ApplicationFeeAmount)
+
+			return &stripego.PaymentIntent{
+				ID:     "pi_with_fee",
+				Status: stripego.PaymentIntentStatusSucceeded,
+			}, nil
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{
+		PlatformFeePercent: decimal.NewFromFloat(2.5),
+	}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	resp, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.NoError(t, err)
+	assert.Equal(t, "pi_with_fee", resp.GatewayReferenceID)
+	assert.Equal(t, gateway.StatusAccepted, resp.Status)
+}
+
+func TestStripeGatewayAdapter_SendPayment_ZeroPlatformFee_OmitsApplicationFee(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			assert.Nil(t, params.ApplicationFeeAmount, "should not set application fee when platform fee is zero")
+
+			return &stripego.PaymentIntent{
+				ID:     "pi_no_fee",
+				Status: stripego.PaymentIntentStatusSucceeded,
+			}, nil
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{
+		PlatformFeePercent: decimal.Zero,
+	}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	resp, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.NoError(t, err)
+	assert.Equal(t, "pi_no_fee", resp.GatewayReferenceID)
+}
+
+func TestStripeGatewayAdapter_SendPayment_StatusMapping(t *testing.T) {
+	tests := []struct {
+		name           string
+		stripeStatus   stripego.PaymentIntentStatus
+		expectedStatus gateway.Status
+	}{
+		{"succeeded maps to ACCEPTED", stripego.PaymentIntentStatusSucceeded, gateway.StatusAccepted},
+		{"requires_payment_method maps to REJECTED", stripego.PaymentIntentStatusRequiresPaymentMethod, gateway.StatusRejected},
+		{"canceled maps to REJECTED", stripego.PaymentIntentStatusCanceled, gateway.StatusRejected},
+		{"processing maps to PENDING", stripego.PaymentIntentStatusProcessing, gateway.StatusPending},
+		{"requires_action maps to PENDING", stripego.PaymentIntentStatusRequiresAction, gateway.StatusPending},
+		{"requires_capture maps to PENDING", stripego.PaymentIntentStatusRequiresCapture, gateway.StatusPending},
+		{"requires_confirmation maps to PENDING", stripego.PaymentIntentStatusRequiresConfirmation, gateway.StatusPending},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &mockPaymentIntentCreator{
+				createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+					return &stripego.PaymentIntent{
+						ID:     "pi_status_test",
+						Status: tt.stripeStatus,
+					}, nil
+				},
+			}
+
+			adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
+
+			ctx := tenantContext("tenant_a")
+			ctx = WithStripeAccount(ctx, "acct_tenant_a")
+			resp, err := adapter.SendPayment(ctx, testGatewayRequest())
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedStatus, resp.Status)
+		})
+	}
+}
+
+func TestStripeGatewayAdapter_SendPayment_CardError(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, &stripego.Error{
+				Type: stripego.ErrorTypeCard,
+				Msg:  "Your card was declined.",
+				Code: "card_declined",
+			}
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	resp, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.NoError(t, err, "card errors should not return an error; they map to REJECTED")
+	assert.Equal(t, gateway.StatusRejected, resp.Status)
+	assert.Contains(t, resp.Message, "Your card was declined.")
+}
+
+func TestStripeGatewayAdapter_SendPayment_RateLimitError(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, &stripego.Error{
+				Type:           stripego.ErrorTypeAPI,
+				Msg:            "rate limit exceeded",
+				HTTPStatusCode: 429,
+			}
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	_, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.Error(t, err, "rate limit errors are transient and should be returned as errors")
+}
+
+func TestStripeGatewayAdapter_SendPayment_InvalidRequestError(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, &stripego.Error{
+				Type: stripego.ErrorTypeInvalidRequest,
+				Msg:  "Invalid currency: xyz",
+			}
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	_, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.Error(t, err, "invalid request errors indicate a programming issue and should be returned as errors")
+	assert.True(t, errors.Is(err, ErrInvalidRequest))
+}
+
+func TestStripeGatewayAdapter_SendPayment_APIError(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, &stripego.Error{
+				Type: stripego.ErrorTypeAPI,
+				Msg:  "internal server error",
+			}
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	_, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.Error(t, err, "API errors are transient and should be returned for retry")
+}
+
+func TestStripeGatewayAdapter_SendPayment_NonStripeError(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, errors.New("network timeout")
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	_, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.Error(t, err)
+}
+
+func TestStripeGatewayAdapter_SendPayment_MissingStripeAccount(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return &stripego.PaymentIntent{
+				ID:     "pi_should_not_reach",
+				Status: stripego.PaymentIntentStatusSucceeded,
+			}, nil
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	// No stripe account set in context
+	_, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrMissingStripeAccount))
+}
+
+func TestStripeGatewayAdapter_SendPayment_CurrencyLowercase(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			// Currency must be lowercase per Stripe API
+			assert.Equal(t, "gbp", *params.Currency)
+			// Also verify it's truly lowercase even if domain returns uppercase
+			assert.Equal(t, strings.ToLower(*params.Currency), *params.Currency)
+
+			return &stripego.PaymentIntent{
+				ID:     "pi_currency",
+				Status: stripego.PaymentIntentStatusSucceeded,
+			}, nil
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	_, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.NoError(t, err)
+}
+
+func TestStripeGatewayAdapter_SendPayment_IdempotencyKey(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			// Verify idempotency key is set on params
+			require.NotNil(t, params.IdempotencyKey)
+			assert.NotEmpty(t, *params.IdempotencyKey)
+
+			return &stripego.PaymentIntent{
+				ID:     "pi_idempotent",
+				Status: stripego.PaymentIntentStatusSucceeded,
+			}, nil
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	_, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.NoError(t, err)
+}
+
+func TestStripeGatewayAdapter_SendPayment_CardErrorWithPaymentIntent(t *testing.T) {
+	// When Stripe returns a card error with an embedded PaymentIntent,
+	// we should use the PaymentIntent ID as the gateway reference.
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, &stripego.Error{
+				Type: stripego.ErrorTypeCard,
+				Msg:  "insufficient funds",
+				Code: "insufficient_funds",
+				PaymentIntent: &stripego.PaymentIntent{
+					ID:     "pi_failed_card",
+					Status: stripego.PaymentIntentStatusRequiresPaymentMethod,
+				},
+			}
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	resp, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.NoError(t, err)
+	assert.Equal(t, gateway.StatusRejected, resp.Status)
+	assert.Equal(t, "pi_failed_card", resp.GatewayReferenceID)
+}
+
+func TestStripeGatewayAdapter_SendPayment_ContextCancelled(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, _ *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			return nil, context.Canceled
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	_, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+}
+
+// Compile-time interface check
+var _ gateway.PaymentGateway = (*GatewayAdapter)(nil)


### PR DESCRIPTION
## Summary
- Implement `GatewayAdapter` conforming to `PaymentGateway` interface for Stripe PaymentIntent creation
- PaymentIntent creation with platform fees via `ApplicationFeeAmount` and Connected Account routing
- Status mapping (succeeded->ACCEPTED, requires_payment_method/canceled->REJECTED, processing/requires_action->PENDING)
- Stripe error handling: card errors map to REJECTED responses, invalid request errors are permanent, API errors propagate for retry
- Idempotency key generation using existing `IdempotencyKey` helper
- Prometheus metrics for payment totals, durations, and error types

## Technical Details
- `PaymentIntentCreator` interface abstracts Stripe API calls for testability (no HTTP mocking needed)
- Platform fee calculated as `amount * percentage / 100` with floor truncation
- Connected Account ID propagated via context (`WithStripeAccount`/`AccountFromContext`)
- Currency automatically lowercased per Stripe API requirements

## Test Plan
- [x] Unit tests with mock `PaymentIntentCreator` for parameter construction
- [x] Status mapping tests for all 7 Stripe PaymentIntent statuses
- [x] Error handling tests: card error, rate limit, invalid request, API error, non-Stripe error
- [x] Platform fee calculation (with fee, zero fee, omits when zero)
- [x] Context propagation: missing Stripe account, context cancellation
- [x] Idempotency key and currency lowercase verification
- [x] Card error with embedded PaymentIntent extracts reference ID

## Task Master
Tag: stripe-connect, Task: 6