### PR TITLE
feat: Implement reference data node repository with bi-temporal queries

### DIFF
--- a/services/reference-data/node/node.go
+++ b/services/reference-data/node/node.go
@@ -174,16 +174,35 @@ type Repository interface {
 	// Returns ErrCrossTenantParent if the parent belongs to a different tenant.
 	Create(ctx context.Context, node *Node) error
 
+	// Update modifies non-key attributes of a node (attributes, valid_to).
+	// Identity fields (tenant_id, node_type, parent_id, resolution_key) are immutable.
+	// Uses optimistic locking via version column.
+	// Returns ErrNotFound if the node does not exist.
+	// Returns ErrOptimisticLock if the version has changed since the node was read.
+	Update(ctx context.Context, node *Node) error
+
 	// GetByID retrieves a node by its UUID.
 	// Returns ErrNotFound if the node does not exist.
 	GetByID(ctx context.Context, id uuid.UUID) (*Node, error)
 
-	// GetByResolutionKey retrieves the active node matching the resolution key.
-	// Returns ErrNotFound if no active node matches.
-	GetByResolutionKey(ctx context.Context, tenantID, resolutionKey string) (*Node, error)
+	// GetAsAt retrieves the version of a node that was valid at the given time.
+	// Looks up all versions sharing the same tenant_id and resolution_key lineage
+	// where valid_from <= asAt AND (valid_to IS NULL OR valid_to > asAt).
+	// Returns ErrNotFound if no version was valid at the given time.
+	GetAsAt(ctx context.Context, tenantID string, id uuid.UUID, asAt time.Time) (*Node, error)
 
-	// ListChildren returns all active child nodes of the given parent.
-	ListChildren(ctx context.Context, tenantID string, parentID uuid.UUID) ([]*Node, error)
+	// GetHistory returns all temporal versions of a node (active and superseded),
+	// ordered by valid_from descending (newest first).
+	GetHistory(ctx context.Context, tenantID string, id uuid.UUID) ([]*Node, error)
+
+	// GetByResolutionKey retrieves the node matching the resolution key at the given time.
+	// If asAt is zero, retrieves the active node (valid_to IS NULL).
+	// Returns ErrNotFound if no matching node exists.
+	GetByResolutionKey(ctx context.Context, tenantID, resolutionKey string, asAt time.Time) (*Node, error)
+
+	// GetChildren returns child nodes of the given parent.
+	// If activeOnly is true, only returns active nodes (valid_to IS NULL).
+	GetChildren(ctx context.Context, tenantID string, parentID uuid.UUID, activeOnly bool) ([]*Node, error)
 
 	// ListByType returns all active nodes of the given type within a tenant.
 	ListByType(ctx context.Context, tenantID, nodeType string) ([]*Node, error)
@@ -197,11 +216,22 @@ type Repository interface {
 	Supersede(ctx context.Context, nodeID uuid.UUID, newNode *Node) error
 
 	// GetAncestors returns the chain of ancestors from the immediate parent to root.
+	// Uses a recursive CTE for efficient traversal.
 	// Returns empty slice for root nodes.
 	// Returns ErrMaxDepthExceeded if the chain exceeds MaxHierarchyDepth.
 	GetAncestors(ctx context.Context, nodeID uuid.UUID) ([]*Node, error)
 
+	// GetSubtree returns all descendants of a root node up to maxDepth levels.
+	// The root node itself is included at depth 0.
+	// Uses a recursive CTE with depth limit for efficient traversal.
+	GetSubtree(ctx context.Context, tenantID string, rootID uuid.UUID, maxDepth int) ([]*Node, error)
+
 	// GetAtTime retrieves the node state that was valid at the given effective time.
 	// Uses bi-temporal query: valid_from <= asOf < valid_to (or valid_to IS NULL).
 	GetAtTime(ctx context.Context, tenantID, resolutionKey string, asOf time.Time) (*Node, error)
+
+	// BulkCreate inserts multiple nodes in a single transaction.
+	// Resolution keys are computed automatically for each node.
+	// The nodes should be ordered such that parents appear before children.
+	BulkCreate(ctx context.Context, nodes []*Node) error
 }

--- a/services/reference-data/node/postgres_repository.go
+++ b/services/reference-data/node/postgres_repository.go
@@ -16,6 +16,9 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/tenant"
 )
 
+const nodeColumns = `id, tenant_id, node_type, parent_id, attributes, resolution_key,
+	valid_from, valid_to, created_at, updated_at, version`
+
 // PostgresRepository implements Repository using PostgreSQL/CockroachDB.
 type PostgresRepository struct {
 	pool *pgxpool.Pool
@@ -95,6 +98,39 @@ func (r *PostgresRepository) Create(ctx context.Context, n *Node) error {
 	})
 }
 
+// Update modifies non-key attributes of a node with optimistic locking.
+func (r *PostgresRepository) Update(ctx context.Context, n *Node) error {
+	return r.withWriteTx(ctx, func(tx pgx.Tx) error {
+		attrsJSON, err := json.Marshal(n.Attributes)
+		if err != nil {
+			return fmt.Errorf("failed to marshal attributes: %w", err)
+		}
+
+		now := time.Now()
+		query := `
+			UPDATE reference_data_node
+			SET attributes = $1, valid_to = $2, updated_at = $3, version = version + 1
+			WHERE id = $4 AND version = $5`
+
+		result, err := tx.Exec(ctx, query, attrsJSON, n.ValidTo, now, n.ID, n.Version)
+		if err != nil {
+			return fmt.Errorf("failed to update node: %w", err)
+		}
+		if result.RowsAffected() == 0 {
+			// Distinguish between not found and version conflict
+			_, lookupErr := r.getByIDTx(ctx, tx, n.ID)
+			if errors.Is(lookupErr, ErrNotFound) {
+				return ErrNotFound
+			}
+			return ErrOptimisticLock
+		}
+
+		n.UpdatedAt = now
+		n.Version++
+		return nil
+	})
+}
+
 // validateParent checks that the parent node exists, is active, and belongs to the same tenant.
 func (r *PostgresRepository) validateParent(ctx context.Context, tx pgx.Tx, n *Node) error {
 	if n.ParentID == nil {
@@ -163,8 +199,7 @@ func (r *PostgresRepository) GetByID(ctx context.Context, id uuid.UUID) (*Node, 
 
 func (r *PostgresRepository) getByIDTx(ctx context.Context, tx pgx.Tx, id uuid.UUID) (*Node, error) {
 	query := `
-		SELECT id, tenant_id, node_type, parent_id, attributes, resolution_key,
-			valid_from, valid_to, created_at, updated_at, version
+		SELECT ` + nodeColumns + `
 		FROM reference_data_node
 		WHERE id = $1`
 
@@ -179,17 +214,121 @@ func (r *PostgresRepository) getByIDTx(ctx context.Context, tx pgx.Tx, id uuid.U
 	return n, nil
 }
 
-// GetByResolutionKey retrieves the active node matching the resolution key.
-func (r *PostgresRepository) GetByResolutionKey(ctx context.Context, tenantID, resolutionKey string) (*Node, error) {
+// GetAsAt retrieves the version of a node valid at the given time.
+// It first looks up the node by ID to get its resolution key lineage,
+// then finds the version that was valid at asAt.
+func (r *PostgresRepository) GetAsAt(ctx context.Context, tenantID string, id uuid.UUID, asAt time.Time) (*Node, error) {
 	var result *Node
 	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
+		// First get the node to determine its resolution key prefix
+		// We need to find all versions that share the same position in the tree.
+		// Nodes sharing the same resolution key prefix (minus the UUID part) are versions.
+		// The simplest approach: find all nodes with the same (tenant_id, node_type, parent_id)
+		// where one of them has this ID, then filter by time.
 		query := `
-			SELECT id, tenant_id, node_type, parent_id, attributes, resolution_key,
-				valid_from, valid_to, created_at, updated_at, version
-			FROM reference_data_node
-			WHERE tenant_id = $1 AND resolution_key = $2 AND valid_to IS NULL`
+			WITH target AS (
+				SELECT tenant_id, node_type, parent_id
+				FROM reference_data_node
+				WHERE id = $1 AND tenant_id = $2
+			)
+			SELECT n.id, n.tenant_id, n.node_type, n.parent_id, n.attributes, n.resolution_key,
+				n.valid_from, n.valid_to, n.created_at, n.updated_at, n.version
+			FROM reference_data_node n
+			JOIN target t ON n.tenant_id = t.tenant_id
+				AND n.node_type = t.node_type
+				AND (n.parent_id = t.parent_id OR (n.parent_id IS NULL AND t.parent_id IS NULL))
+			WHERE n.valid_from <= $3
+				AND (n.valid_to IS NULL OR n.valid_to > $3)
+			ORDER BY n.valid_from DESC
+			LIMIT 1`
 
-		row := tx.QueryRow(ctx, query, tenantID, resolutionKey)
+		row := tx.QueryRow(ctx, query, id, tenantID, asAt)
+		n, err := scanNode(row)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("failed to query node as-at: %w", err)
+		}
+		result = n
+		return nil
+	})
+	return result, err
+}
+
+// GetHistory returns all temporal versions of a node, ordered by valid_from descending.
+func (r *PostgresRepository) GetHistory(ctx context.Context, tenantID string, id uuid.UUID) ([]*Node, error) {
+	var result []*Node
+	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
+		// Find the node to get its position identity (type + parent)
+		// then get all versions sharing that position
+		query := `
+			WITH target AS (
+				SELECT tenant_id, node_type, parent_id
+				FROM reference_data_node
+				WHERE id = $1 AND tenant_id = $2
+			)
+			SELECT n.id, n.tenant_id, n.node_type, n.parent_id, n.attributes, n.resolution_key,
+				n.valid_from, n.valid_to, n.created_at, n.updated_at, n.version
+			FROM reference_data_node n
+			JOIN target t ON n.tenant_id = t.tenant_id
+				AND n.node_type = t.node_type
+				AND (n.parent_id = t.parent_id OR (n.parent_id IS NULL AND t.parent_id IS NULL))
+			ORDER BY n.valid_from DESC`
+
+		rows, err := tx.Query(ctx, query, id, tenantID)
+		if err != nil {
+			return fmt.Errorf("failed to query node history: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			n, err := scanNodeFromRows(rows)
+			if err != nil {
+				return err
+			}
+			result = append(result, n)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+
+		if len(result) == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
+	return result, err
+}
+
+// GetByResolutionKey retrieves the node matching the resolution key at the given time.
+// If asAt is zero, retrieves the active node (valid_to IS NULL).
+func (r *PostgresRepository) GetByResolutionKey(ctx context.Context, tenantID, resolutionKey string, asAt time.Time) (*Node, error) {
+	var result *Node
+	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
+		var query string
+		var args []any
+
+		if asAt.IsZero() {
+			query = `
+				SELECT ` + nodeColumns + `
+				FROM reference_data_node
+				WHERE tenant_id = $1 AND resolution_key = $2 AND valid_to IS NULL`
+			args = []any{tenantID, resolutionKey}
+		} else {
+			query = `
+				SELECT ` + nodeColumns + `
+				FROM reference_data_node
+				WHERE tenant_id = $1
+					AND resolution_key = $2
+					AND valid_from <= $3
+					AND (valid_to IS NULL OR valid_to > $3)
+				ORDER BY valid_from DESC
+				LIMIT 1`
+			args = []any{tenantID, resolutionKey, asAt}
+		}
+
+		row := tx.QueryRow(ctx, query, args...)
 		n, err := scanNode(row)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -203,16 +342,20 @@ func (r *PostgresRepository) GetByResolutionKey(ctx context.Context, tenantID, r
 	return result, err
 }
 
-// ListChildren returns all active child nodes of the given parent.
-func (r *PostgresRepository) ListChildren(ctx context.Context, tenantID string, parentID uuid.UUID) ([]*Node, error) {
+// GetChildren returns child nodes of the given parent.
+// If activeOnly is true, only active nodes (valid_to IS NULL) are returned.
+func (r *PostgresRepository) GetChildren(ctx context.Context, tenantID string, parentID uuid.UUID, activeOnly bool) ([]*Node, error) {
 	var result []*Node
 	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
 		query := `
-			SELECT id, tenant_id, node_type, parent_id, attributes, resolution_key,
-				valid_from, valid_to, created_at, updated_at, version
+			SELECT ` + nodeColumns + `
 			FROM reference_data_node
-			WHERE tenant_id = $1 AND parent_id = $2 AND valid_to IS NULL
-			ORDER BY node_type, resolution_key`
+			WHERE tenant_id = $1 AND parent_id = $2`
+
+		if activeOnly {
+			query += ` AND valid_to IS NULL`
+		}
+		query += ` ORDER BY node_type, resolution_key`
 
 		rows, err := tx.Query(ctx, query, tenantID, parentID)
 		if err != nil {
@@ -237,8 +380,7 @@ func (r *PostgresRepository) ListByType(ctx context.Context, tenantID, nodeType 
 	var result []*Node
 	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
 		query := `
-			SELECT id, tenant_id, node_type, parent_id, attributes, resolution_key,
-				valid_from, valid_to, created_at, updated_at, version
+			SELECT ` + nodeColumns + `
 			FROM reference_data_node
 			WHERE tenant_id = $1 AND node_type = $2 AND valid_to IS NULL
 			ORDER BY resolution_key`
@@ -266,8 +408,7 @@ func (r *PostgresRepository) ListRoots(ctx context.Context, tenantID string) ([]
 	var result []*Node
 	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
 		query := `
-			SELECT id, tenant_id, node_type, parent_id, attributes, resolution_key,
-				valid_from, valid_to, created_at, updated_at, version
+			SELECT ` + nodeColumns + `
 			FROM reference_data_node
 			WHERE tenant_id = $1 AND parent_id IS NULL AND valid_to IS NULL
 			ORDER BY node_type, resolution_key`
@@ -293,7 +434,6 @@ func (r *PostgresRepository) ListRoots(ctx context.Context, tenantID string) ([]
 // Supersede closes the current node and creates a new version.
 func (r *PostgresRepository) Supersede(ctx context.Context, nodeID uuid.UUID, newNode *Node) error {
 	return r.withWriteTx(ctx, func(tx pgx.Tx) error {
-		// Get the existing node
 		existing, err := r.getByIDTx(ctx, tx, nodeID)
 		if err != nil {
 			return err
@@ -302,7 +442,6 @@ func (r *PostgresRepository) Supersede(ctx context.Context, nodeID uuid.UUID, ne
 			return ErrAlreadySuperseded
 		}
 
-		// Close the existing node
 		now := time.Now()
 		closeQuery := `
 			UPDATE reference_data_node
@@ -317,7 +456,6 @@ func (r *PostgresRepository) Supersede(ctx context.Context, nodeID uuid.UUID, ne
 			return ErrOptimisticLock
 		}
 
-		// Compute resolution key for the new node
 		ancestors, err := r.getAncestorsTx(ctx, tx, newNode.ParentID)
 		if err != nil {
 			return err
@@ -328,11 +466,11 @@ func (r *PostgresRepository) Supersede(ctx context.Context, nodeID uuid.UUID, ne
 	})
 }
 
-// GetAncestors returns the chain of ancestors from the immediate parent to root.
+// GetAncestors returns the chain of ancestors from the immediate parent to root
+// using a recursive CTE.
 func (r *PostgresRepository) GetAncestors(ctx context.Context, nodeID uuid.UUID) ([]*Node, error) {
 	var result []*Node
 	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
-		// Get the node to find its parent
 		n, err := r.getByIDTx(ctx, tx, nodeID)
 		if err != nil {
 			return err
@@ -348,37 +486,97 @@ func (r *PostgresRepository) GetAncestors(ctx context.Context, nodeID uuid.UUID)
 	return result, err
 }
 
-// getAncestorsTx traverses the parent chain iteratively up to MaxHierarchyDepth.
+// getAncestorsTx traverses the parent chain using a recursive CTE.
 func (r *PostgresRepository) getAncestorsTx(ctx context.Context, tx pgx.Tx, parentID *uuid.UUID) ([]*Node, error) {
 	if parentID == nil {
 		return nil, nil
 	}
 
+	query := `
+		WITH RECURSIVE ancestors AS (
+			SELECT id, tenant_id, node_type, parent_id, attributes, resolution_key,
+				valid_from, valid_to, created_at, updated_at, version, 1 AS depth
+			FROM reference_data_node
+			WHERE id = $1
+			UNION ALL
+			SELECT n.id, n.tenant_id, n.node_type, n.parent_id, n.attributes, n.resolution_key,
+				n.valid_from, n.valid_to, n.created_at, n.updated_at, n.version, a.depth + 1
+			FROM reference_data_node n
+			JOIN ancestors a ON n.id = a.parent_id
+			WHERE a.depth < $2
+		)
+		SELECT id, tenant_id, node_type, parent_id, attributes, resolution_key,
+			valid_from, valid_to, created_at, updated_at, version
+		FROM ancestors
+		ORDER BY depth ASC`
+
+	rows, err := tx.Query(ctx, query, parentID, MaxHierarchyDepth)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query ancestors: %w", err)
+	}
+	defer rows.Close()
+
 	var ancestors []*Node
-	currentParentID := parentID
-
-	for i := 0; i < MaxHierarchyDepth; i++ {
-		if currentParentID == nil {
-			break
-		}
-
-		parent, err := r.getByIDTx(ctx, tx, *currentParentID)
+	for rows.Next() {
+		n, err := scanNodeFromRows(rows)
 		if err != nil {
-			if errors.Is(err, ErrNotFound) {
-				return nil, ErrParentNotFound
-			}
 			return nil, err
 		}
-
-		ancestors = append(ancestors, parent)
-		currentParentID = parent.ParentID
+		ancestors = append(ancestors, n)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
-	if currentParentID != nil {
-		return nil, ErrMaxDepthExceeded
+	// Check if the last ancestor still has a parent (chain exceeds max depth)
+	if len(ancestors) > 0 && ancestors[len(ancestors)-1].ParentID != nil {
+		if len(ancestors) >= MaxHierarchyDepth {
+			return nil, ErrMaxDepthExceeded
+		}
 	}
 
 	return ancestors, nil
+}
+
+// GetSubtree returns all descendants of a root node up to maxDepth levels.
+// The root node itself is included at depth 0.
+func (r *PostgresRepository) GetSubtree(ctx context.Context, tenantID string, rootID uuid.UUID, maxDepth int) ([]*Node, error) {
+	var result []*Node
+	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
+		query := `
+			WITH RECURSIVE subtree AS (
+				SELECT id, tenant_id, node_type, parent_id, attributes, resolution_key,
+					valid_from, valid_to, created_at, updated_at, version, 0 AS depth
+				FROM reference_data_node
+				WHERE id = $1 AND tenant_id = $2 AND valid_to IS NULL
+				UNION ALL
+				SELECT n.id, n.tenant_id, n.node_type, n.parent_id, n.attributes, n.resolution_key,
+					n.valid_from, n.valid_to, n.created_at, n.updated_at, n.version, s.depth + 1
+				FROM reference_data_node n
+				JOIN subtree s ON n.parent_id = s.id
+				WHERE n.tenant_id = $2 AND n.valid_to IS NULL AND s.depth < $3
+			)
+			SELECT id, tenant_id, node_type, parent_id, attributes, resolution_key,
+				valid_from, valid_to, created_at, updated_at, version
+			FROM subtree
+			ORDER BY depth, node_type, resolution_key`
+
+		rows, err := tx.Query(ctx, query, rootID, tenantID, maxDepth)
+		if err != nil {
+			return fmt.Errorf("failed to query subtree: %w", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			n, err := scanNodeFromRows(rows)
+			if err != nil {
+				return err
+			}
+			result = append(result, n)
+		}
+		return rows.Err()
+	})
+	return result, err
 }
 
 // GetAtTime retrieves the node that was valid at the given effective time.
@@ -386,8 +584,7 @@ func (r *PostgresRepository) GetAtTime(ctx context.Context, tenantID, resolution
 	var result *Node
 	err := r.withReadTx(ctx, func(tx pgx.Tx) error {
 		query := `
-			SELECT id, tenant_id, node_type, parent_id, attributes, resolution_key,
-				valid_from, valid_to, created_at, updated_at, version
+			SELECT ` + nodeColumns + `
 			FROM reference_data_node
 			WHERE tenant_id = $1
 				AND resolution_key = $2
@@ -408,6 +605,83 @@ func (r *PostgresRepository) GetAtTime(ctx context.Context, tenantID, resolution
 		return nil
 	})
 	return result, err
+}
+
+// BulkCreate inserts multiple nodes in a single transaction.
+// Nodes should be ordered so that parents appear before their children.
+func (r *PostgresRepository) BulkCreate(ctx context.Context, nodes []*Node) error {
+	return r.withWriteTx(ctx, func(tx pgx.Tx) error {
+		batchIDs := make(map[uuid.UUID]*Node, len(nodes))
+		for _, n := range nodes {
+			batchIDs[n.ID] = n
+		}
+
+		for _, n := range nodes {
+			if err := r.bulkCreateNode(ctx, tx, n, batchIDs); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// bulkCreateNode validates, computes resolution key, and inserts a single node during bulk create.
+func (r *PostgresRepository) bulkCreateNode(ctx context.Context, tx pgx.Tx, n *Node, batchIDs map[uuid.UUID]*Node) error {
+	if n.ParentID != nil {
+		if _, inBatch := batchIDs[*n.ParentID]; !inBatch {
+			if err := r.validateParent(ctx, tx, n); err != nil {
+				return err
+			}
+		}
+	}
+
+	ancestors, err := r.getAncestorsForBulk(ctx, tx, n, batchIDs)
+	if err != nil {
+		return err
+	}
+	n.ResolutionKey = ComputeResolutionKey(n.NodeType, n.ID, ancestors)
+
+	return r.insertNode(ctx, tx, n)
+}
+
+// getAncestorsForBulk computes ancestors considering both the batch and the database.
+func (r *PostgresRepository) getAncestorsForBulk(ctx context.Context, tx pgx.Tx, n *Node, batch map[uuid.UUID]*Node) ([]*Node, error) {
+	if n.ParentID == nil {
+		return nil, nil
+	}
+
+	var ancestors []*Node
+	currentParentID := n.ParentID
+
+	for i := 0; i < MaxHierarchyDepth; i++ {
+		if currentParentID == nil {
+			break
+		}
+
+		// Check if parent is in the current batch (already inserted in this tx)
+		if batchNode, ok := batch[*currentParentID]; ok {
+			ancestors = append(ancestors, batchNode)
+			currentParentID = batchNode.ParentID
+			continue
+		}
+
+		// Otherwise look up in database
+		parent, err := r.getByIDTx(ctx, tx, *currentParentID)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return nil, ErrParentNotFound
+			}
+			return nil, err
+		}
+		ancestors = append(ancestors, parent)
+		currentParentID = parent.ParentID
+	}
+
+	if currentParentID != nil {
+		return nil, ErrMaxDepthExceeded
+	}
+
+	return ancestors, nil
 }
 
 // scanNode scans a single row into a Node.

--- a/services/reference-data/node/postgres_repository.go
+++ b/services/reference-data/node/postgres_repository.go
@@ -119,8 +119,11 @@ func (r *PostgresRepository) Update(ctx context.Context, n *Node) error {
 		if result.RowsAffected() == 0 {
 			// Distinguish between not found and version conflict
 			_, lookupErr := r.getByIDTx(ctx, tx, n.ID)
-			if errors.Is(lookupErr, ErrNotFound) {
-				return ErrNotFound
+			if lookupErr != nil {
+				if errors.Is(lookupErr, ErrNotFound) {
+					return ErrNotFound
+				}
+				return lookupErr
 			}
 			return ErrOptimisticLock
 		}
@@ -628,7 +631,14 @@ func (r *PostgresRepository) BulkCreate(ctx context.Context, nodes []*Node) erro
 // bulkCreateNode validates, computes resolution key, and inserts a single node during bulk create.
 func (r *PostgresRepository) bulkCreateNode(ctx context.Context, tx pgx.Tx, n *Node, batchIDs map[uuid.UUID]*Node) error {
 	if n.ParentID != nil {
-		if _, inBatch := batchIDs[*n.ParentID]; !inBatch {
+		if parentNode, inBatch := batchIDs[*n.ParentID]; inBatch {
+			if parentNode.TenantID != n.TenantID {
+				return ErrCrossTenantParent
+			}
+			if !parentNode.IsActive() {
+				return ErrParentNotActive
+			}
+		} else {
 			if err := r.validateParent(ctx, tx, n); err != nil {
 				return err
 			}

--- a/services/reference-data/node/postgres_repository_test.go
+++ b/services/reference-data/node/postgres_repository_test.go
@@ -2,6 +2,7 @@ package node_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -149,22 +150,22 @@ func TestPostgresRepository_GetByResolutionKey(t *testing.T) {
 	repo, pool := setupTestRepo(t)
 	ctx := setupTenantCtx(t, pool, "test-reskey")
 
-	t.Run("retrieves active node by resolution key", func(t *testing.T) {
+	t.Run("retrieves active node by resolution key with zero time", func(t *testing.T) {
 		n := buildNode(t, "test-reskey", "region", nil)
 		require.NoError(t, repo.Create(ctx, n))
 
-		fetched, err := repo.GetByResolutionKey(ctx, "test-reskey", n.ResolutionKey)
+		fetched, err := repo.GetByResolutionKey(ctx, "test-reskey", n.ResolutionKey, time.Time{})
 		require.NoError(t, err)
 		assert.Equal(t, n.ID, fetched.ID)
 	})
 
 	t.Run("returns ErrNotFound for non-matching key", func(t *testing.T) {
-		_, err := repo.GetByResolutionKey(ctx, "test-reskey", "nonexistent:key")
+		_, err := repo.GetByResolutionKey(ctx, "test-reskey", "nonexistent:key", time.Time{})
 		require.ErrorIs(t, err, node.ErrNotFound)
 	})
 }
 
-func TestPostgresRepository_ListChildren(t *testing.T) {
+func TestPostgresRepository_GetChildren(t *testing.T) {
 	repo, pool := setupTestRepo(t)
 	ctx := setupTenantCtx(t, pool, "test-children")
 
@@ -178,13 +179,13 @@ func TestPostgresRepository_ListChildren(t *testing.T) {
 	require.NoError(t, repo.Create(ctx, child2))
 
 	t.Run("returns all active children", func(t *testing.T) {
-		children, err := repo.ListChildren(ctx, "test-children", parent.ID)
+		children, err := repo.GetChildren(ctx, "test-children", parent.ID, true)
 		require.NoError(t, err)
 		assert.Len(t, children, 2)
 	})
 
 	t.Run("returns empty for node with no children", func(t *testing.T) {
-		children, err := repo.ListChildren(ctx, "test-children", child1.ID)
+		children, err := repo.GetChildren(ctx, "test-children", child1.ID, true)
 		require.NoError(t, err)
 		assert.Empty(t, children)
 	})
@@ -512,5 +513,519 @@ func TestPostgresRepository_OptimisticLocking(t *testing.T) {
 		fetched, err := repo.GetByID(ctx, original.ID)
 		require.NoError(t, err)
 		assert.Equal(t, int64(2), fetched.Version)
+	})
+}
+
+func TestPostgresRepository_Update(t *testing.T) {
+	repo, pool := setupTestRepo(t)
+	ctx := setupTenantCtx(t, pool, "test-update")
+
+	t.Run("updates attributes with optimistic locking", func(t *testing.T) {
+		n := buildNode(t, "test-update", "meter", nil)
+		require.NoError(t, repo.Create(ctx, n))
+		assert.Equal(t, int64(1), n.Version)
+
+		n.Attributes["capacity"] = float64(500)
+		err := repo.Update(ctx, n)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), n.Version)
+
+		fetched, err := repo.GetByID(ctx, n.ID)
+		require.NoError(t, err)
+		assert.Equal(t, float64(500), fetched.Attributes["capacity"])
+		assert.Equal(t, int64(2), fetched.Version)
+	})
+
+	t.Run("rejects stale version", func(t *testing.T) {
+		n := buildNode(t, "test-update", "region", nil)
+		require.NoError(t, repo.Create(ctx, n))
+
+		// Simulate concurrent read: both have version 1
+		stale := *n
+		stale.Attributes = map[string]any{"stale": true}
+
+		// First update succeeds
+		n.Attributes["fresh"] = true
+		require.NoError(t, repo.Update(ctx, n))
+
+		// Stale update fails
+		err := repo.Update(ctx, &stale)
+		require.ErrorIs(t, err, node.ErrOptimisticLock)
+	})
+
+	t.Run("returns ErrNotFound for missing node", func(t *testing.T) {
+		missing := &node.Node{
+			ID:         uuid.New(),
+			TenantID:   "test-update",
+			Attributes: map[string]any{},
+			Version:    1,
+		}
+		err := repo.Update(ctx, missing)
+		require.ErrorIs(t, err, node.ErrNotFound)
+	})
+}
+
+func TestPostgresRepository_GetAsAt(t *testing.T) {
+	repo, pool := setupTestRepo(t)
+	ctx := setupTenantCtx(t, pool, "test-asat")
+
+	t.Run("returns node valid at past time after supersede", func(t *testing.T) {
+		t1 := time.Now().Add(-3 * time.Hour)
+		original, err := node.NewBuilder("test-asat").
+			WithNodeType("region").
+			WithValidFrom(t1).
+			WithAttributes(map[string]any{"ver": "v1"}).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, repo.Create(ctx, original))
+
+		// Supersede
+		replacement, err := node.NewBuilder("test-asat").
+			WithNodeType("region").
+			WithAttributes(map[string]any{"ver": "v2"}).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, repo.Supersede(ctx, original.ID, replacement))
+
+		// Query at time between creation and supersession
+		t2 := time.Now().Add(-1 * time.Hour)
+		fetched, err := repo.GetAsAt(ctx, "test-asat", original.ID, t2)
+		require.NoError(t, err)
+		assert.Equal(t, original.ID, fetched.ID)
+
+		// Query at current time should return the replacement
+		fetched2, err := repo.GetAsAt(ctx, "test-asat", original.ID, time.Now())
+		require.NoError(t, err)
+		assert.Equal(t, replacement.ID, fetched2.ID)
+	})
+
+	t.Run("returns ErrNotFound before node existed", func(t *testing.T) {
+		n := buildNode(t, "test-asat", "zone", nil)
+		require.NoError(t, repo.Create(ctx, n))
+
+		_, err := repo.GetAsAt(ctx, "test-asat", n.ID, time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+		require.ErrorIs(t, err, node.ErrNotFound)
+	})
+}
+
+func TestPostgresRepository_GetHistory(t *testing.T) {
+	repo, pool := setupTestRepo(t)
+	ctx := setupTenantCtx(t, pool, "test-history")
+
+	t.Run("returns all versions newest first", func(t *testing.T) {
+		t1 := time.Now().Add(-3 * time.Hour)
+		original, err := node.NewBuilder("test-history").
+			WithNodeType("region").
+			WithValidFrom(t1).
+			WithAttributes(map[string]any{"ver": "v1"}).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, repo.Create(ctx, original))
+
+		replacement, err := node.NewBuilder("test-history").
+			WithNodeType("region").
+			WithAttributes(map[string]any{"ver": "v2"}).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, repo.Supersede(ctx, original.ID, replacement))
+
+		history, err := repo.GetHistory(ctx, "test-history", original.ID)
+		require.NoError(t, err)
+		require.Len(t, history, 2)
+
+		// Newest first (replacement has later valid_from)
+		assert.Equal(t, replacement.ID, history[0].ID)
+		assert.Equal(t, original.ID, history[1].ID)
+
+		// Original should be closed, replacement active
+		assert.False(t, history[1].IsActive())
+		assert.True(t, history[0].IsActive())
+	})
+
+	t.Run("returns ErrNotFound for non-existent node", func(t *testing.T) {
+		_, err := repo.GetHistory(ctx, "test-history", uuid.New())
+		require.ErrorIs(t, err, node.ErrNotFound)
+	})
+}
+
+func TestPostgresRepository_GetByResolutionKey_WithTime(t *testing.T) {
+	repo, pool := setupTestRepo(t)
+	ctx := setupTenantCtx(t, pool, "test-reskey-time")
+
+	t.Run("retrieves node at specific time", func(t *testing.T) {
+		t1 := time.Now().Add(-3 * time.Hour)
+		original, err := node.NewBuilder("test-reskey-time").
+			WithNodeType("region").
+			WithValidFrom(t1).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, repo.Create(ctx, original))
+
+		// Supersede to close the original
+		replacement, err := node.NewBuilder("test-reskey-time").
+			WithNodeType("region").
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, repo.Supersede(ctx, original.ID, replacement))
+
+		// Query with past time returns original (by its resolution key)
+		t2 := time.Now().Add(-1 * time.Hour)
+		fetched, err := repo.GetByResolutionKey(ctx, "test-reskey-time", original.ResolutionKey, t2)
+		require.NoError(t, err)
+		assert.Equal(t, original.ID, fetched.ID)
+
+		// Query with zero time returns active node by its resolution key
+		fetchedActive, err := repo.GetByResolutionKey(ctx, "test-reskey-time", replacement.ResolutionKey, time.Time{})
+		require.NoError(t, err)
+		assert.Equal(t, replacement.ID, fetchedActive.ID)
+	})
+}
+
+func TestPostgresRepository_GetChildren_ActiveOnly(t *testing.T) {
+	repo, pool := setupTestRepo(t)
+	ctx := setupTenantCtx(t, pool, "test-children-active")
+
+	parent := buildNode(t, "test-children-active", "region", nil)
+	require.NoError(t, repo.Create(ctx, parent))
+
+	active := buildNode(t, "test-children-active", "zone", &parent.ID)
+	require.NoError(t, repo.Create(ctx, active))
+
+	// Create and supersede a child to make it inactive
+	closed, err := node.NewBuilder("test-children-active").
+		WithNodeType("zone").
+		WithParentID(parent.ID).
+		WithValidFrom(time.Now().Add(-2 * time.Hour)).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, repo.Create(ctx, closed))
+
+	replacement, err := node.NewBuilder("test-children-active").
+		WithNodeType("zone").
+		WithParentID(parent.ID).
+		Build()
+	require.NoError(t, err)
+	require.NoError(t, repo.Supersede(ctx, closed.ID, replacement))
+
+	t.Run("activeOnly true returns only active children", func(t *testing.T) {
+		children, err := repo.GetChildren(ctx, "test-children-active", parent.ID, true)
+		require.NoError(t, err)
+		for _, c := range children {
+			assert.True(t, c.IsActive(), "expected all children to be active")
+		}
+	})
+
+	t.Run("activeOnly false returns all children including closed", func(t *testing.T) {
+		allChildren, err := repo.GetChildren(ctx, "test-children-active", parent.ID, false)
+		require.NoError(t, err)
+
+		activeChildren, err := repo.GetChildren(ctx, "test-children-active", parent.ID, true)
+		require.NoError(t, err)
+
+		assert.Greater(t, len(allChildren), len(activeChildren))
+	})
+}
+
+func TestPostgresRepository_GetSubtree(t *testing.T) {
+	repo, pool := setupTestRepo(t)
+	ctx := setupTenantCtx(t, pool, "test-subtree")
+
+	// Build 5-node tree: root -> [mid1, mid2] -> [leaf1 under mid1]
+	//                                           -> [leaf2 under mid2]
+	root := buildNode(t, "test-subtree", "dno", nil)
+	require.NoError(t, repo.Create(ctx, root))
+
+	mid1 := buildNode(t, "test-subtree", "gsp", &root.ID)
+	require.NoError(t, repo.Create(ctx, mid1))
+
+	mid2 := buildNode(t, "test-subtree", "gsp", &root.ID)
+	require.NoError(t, repo.Create(ctx, mid2))
+
+	leaf1 := buildNode(t, "test-subtree", "meter", &mid1.ID)
+	require.NoError(t, repo.Create(ctx, leaf1))
+
+	leaf2 := buildNode(t, "test-subtree", "meter", &mid2.ID)
+	require.NoError(t, repo.Create(ctx, leaf2))
+
+	t.Run("returns entire tree with sufficient depth", func(t *testing.T) {
+		subtree, err := repo.GetSubtree(ctx, "test-subtree", root.ID, 10)
+		require.NoError(t, err)
+		assert.Len(t, subtree, 5)
+	})
+
+	t.Run("respects max depth limit", func(t *testing.T) {
+		// depth 0 = root only
+		subtree0, err := repo.GetSubtree(ctx, "test-subtree", root.ID, 0)
+		require.NoError(t, err)
+		assert.Len(t, subtree0, 1)
+		assert.Equal(t, root.ID, subtree0[0].ID)
+
+		// depth 1 = root + mid nodes
+		subtree1, err := repo.GetSubtree(ctx, "test-subtree", root.ID, 1)
+		require.NoError(t, err)
+		assert.Len(t, subtree1, 3) // root + mid1 + mid2
+	})
+
+	t.Run("subtree from mid-level node", func(t *testing.T) {
+		subtree, err := repo.GetSubtree(ctx, "test-subtree", mid1.ID, 10)
+		require.NoError(t, err)
+		assert.Len(t, subtree, 2) // mid1 + leaf1
+	})
+
+	t.Run("returns empty for non-existent root", func(t *testing.T) {
+		subtree, err := repo.GetSubtree(ctx, "test-subtree", uuid.New(), 10)
+		require.NoError(t, err)
+		assert.Empty(t, subtree)
+	})
+
+	t.Run("excludes superseded nodes", func(t *testing.T) {
+		// Supersede leaf1
+		newLeaf, err := node.NewBuilder("test-subtree").
+			WithNodeType("meter").
+			WithParentID(mid1.ID).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, repo.Supersede(ctx, leaf1.ID, newLeaf))
+
+		subtree, err := repo.GetSubtree(ctx, "test-subtree", root.ID, 10)
+		require.NoError(t, err)
+		// Should still be 5: root + mid1 + mid2 + newLeaf + leaf2 (leaf1 is superseded)
+		assert.Len(t, subtree, 5)
+
+		// The old leaf1 should not be in the subtree
+		for _, n := range subtree {
+			assert.NotEqual(t, leaf1.ID, n.ID)
+		}
+	})
+}
+
+func TestPostgresRepository_GetSubtree_MaxDepth(t *testing.T) {
+	repo, pool := setupTestRepo(t)
+	ctx := setupTenantCtx(t, pool, "test-maxdepth")
+
+	// Create a 10-level deep tree
+	root := buildNode(t, "test-maxdepth", "level-0", nil)
+	require.NoError(t, repo.Create(ctx, root))
+
+	current := root
+	for i := 1; i < 10; i++ {
+		child := buildNode(t, "test-maxdepth", fmt.Sprintf("level-%d", i), &current.ID)
+		require.NoError(t, repo.Create(ctx, child))
+		current = child
+	}
+
+	t.Run("maxDepth 3 returns 4 levels (0 through 3)", func(t *testing.T) {
+		subtree, err := repo.GetSubtree(ctx, "test-maxdepth", root.ID, 3)
+		require.NoError(t, err)
+		assert.Len(t, subtree, 4) // depth 0,1,2,3
+	})
+
+	t.Run("maxDepth 0 returns root only", func(t *testing.T) {
+		subtree, err := repo.GetSubtree(ctx, "test-maxdepth", root.ID, 0)
+		require.NoError(t, err)
+		assert.Len(t, subtree, 1)
+	})
+
+	t.Run("maxDepth 20 returns all 10 levels", func(t *testing.T) {
+		subtree, err := repo.GetSubtree(ctx, "test-maxdepth", root.ID, 20)
+		require.NoError(t, err)
+		assert.Len(t, subtree, 10)
+	})
+}
+
+func TestPostgresRepository_TenantIsolation_Extended(t *testing.T) {
+	repo, pool := setupTestRepo(t)
+	ctxA := setupTenantCtx(t, pool, "iso-ext-a")
+	ctxB := setupTenantCtx(t, pool, "iso-ext-b")
+
+	t.Run("GetChildren isolated by tenant", func(t *testing.T) {
+		parentA := buildNode(t, "iso-ext-a", "region", nil)
+		require.NoError(t, repo.Create(ctxA, parentA))
+
+		childA := buildNode(t, "iso-ext-a", "zone", &parentA.ID)
+		require.NoError(t, repo.Create(ctxA, childA))
+
+		// Tenant B cannot see A's children
+		children, err := repo.GetChildren(ctxB, "iso-ext-b", parentA.ID, true)
+		require.NoError(t, err)
+		assert.Empty(t, children)
+	})
+
+	t.Run("GetSubtree isolated by tenant", func(t *testing.T) {
+		rootA := buildNode(t, "iso-ext-a", "dno", nil)
+		require.NoError(t, repo.Create(ctxA, rootA))
+
+		midA := buildNode(t, "iso-ext-a", "gsp", &rootA.ID)
+		require.NoError(t, repo.Create(ctxA, midA))
+
+		subtree, err := repo.GetSubtree(ctxB, "iso-ext-b", rootA.ID, 10)
+		require.NoError(t, err)
+		assert.Empty(t, subtree)
+	})
+
+	t.Run("GetHistory isolated by tenant", func(t *testing.T) {
+		n := buildNode(t, "iso-ext-a", "meter", nil)
+		require.NoError(t, repo.Create(ctxA, n))
+
+		_, err := repo.GetHistory(ctxB, "iso-ext-b", n.ID)
+		require.ErrorIs(t, err, node.ErrNotFound)
+	})
+}
+
+func TestPostgresRepository_Update_OptimisticLock(t *testing.T) {
+	repo, pool := setupTestRepo(t)
+	ctx := setupTenantCtx(t, pool, "test-update-lock")
+
+	t.Run("concurrent updates detect version conflict", func(t *testing.T) {
+		n := buildNode(t, "test-update-lock", "region", nil)
+		require.NoError(t, repo.Create(ctx, n))
+
+		// Read two copies at version 1
+		copy1, err := repo.GetByID(ctx, n.ID)
+		require.NoError(t, err)
+
+		copy2, err := repo.GetByID(ctx, n.ID)
+		require.NoError(t, err)
+
+		// First update succeeds
+		copy1.Attributes["writer"] = "first"
+		require.NoError(t, repo.Update(ctx, copy1))
+		assert.Equal(t, int64(2), copy1.Version)
+
+		// Second update with stale version fails
+		copy2.Attributes["writer"] = "second"
+		err = repo.Update(ctx, copy2)
+		require.ErrorIs(t, err, node.ErrOptimisticLock)
+	})
+}
+
+func TestPostgresRepository_BulkCreate(t *testing.T) {
+	repo, pool := setupTestRepo(t)
+	ctx := setupTenantCtx(t, pool, "test-bulk")
+
+	t.Run("creates multiple nodes in single transaction", func(t *testing.T) {
+		// Create a pre-existing root for some children to reference
+		existingRoot := buildNode(t, "test-bulk", "dno", nil)
+		require.NoError(t, repo.Create(ctx, existingRoot))
+
+		// Prepare batch: root + 2 children referencing existing root
+		batchNodes := make([]*node.Node, 0, 3)
+		for i := 0; i < 3; i++ {
+			n := buildNode(t, "test-bulk", "gsp", &existingRoot.ID)
+			batchNodes = append(batchNodes, n)
+		}
+
+		err := repo.BulkCreate(ctx, batchNodes)
+		require.NoError(t, err)
+
+		// Verify all nodes created with correct resolution keys
+		for _, n := range batchNodes {
+			fetched, err := repo.GetByID(ctx, n.ID)
+			require.NoError(t, err)
+			assert.NotEmpty(t, fetched.ResolutionKey)
+			assert.Contains(t, fetched.ResolutionKey, existingRoot.ID.String())
+		}
+	})
+
+	t.Run("creates parent-child hierarchy in single batch", func(t *testing.T) {
+		// Parent and child in same batch - order matters
+		parent, err := node.NewBuilder("test-bulk").
+			WithNodeType("region").
+			Build()
+		require.NoError(t, err)
+
+		child, err := node.NewBuilder("test-bulk").
+			WithNodeType("zone").
+			WithParentID(parent.ID).
+			Build()
+		require.NoError(t, err)
+
+		err = repo.BulkCreate(ctx, []*node.Node{parent, child})
+		require.NoError(t, err)
+
+		// Verify hierarchy
+		fetched, err := repo.GetByID(ctx, child.ID)
+		require.NoError(t, err)
+		assert.Contains(t, fetched.ResolutionKey, parent.ID.String())
+	})
+
+	t.Run("bulk create with 100 nodes", func(t *testing.T) {
+		root := buildNode(t, "test-bulk", "bulk-root", nil)
+		nodes := []*node.Node{root}
+
+		for i := 0; i < 99; i++ {
+			n := buildNode(t, "test-bulk", "bulk-item", &root.ID)
+			nodes = append(nodes, n)
+		}
+
+		err := repo.BulkCreate(ctx, nodes)
+		require.NoError(t, err)
+
+		// Verify count
+		children, err := repo.GetChildren(ctx, "test-bulk", root.ID, true)
+		require.NoError(t, err)
+		assert.Len(t, children, 99)
+	})
+
+	t.Run("rolls back on failure", func(t *testing.T) {
+		fakeParent := uuid.New()
+		nodes := []*node.Node{
+			buildNode(t, "test-bulk", "region", nil),
+			buildNode(t, "test-bulk", "zone", &fakeParent), // Bad parent reference
+		}
+
+		err := repo.BulkCreate(ctx, nodes)
+		require.Error(t, err)
+
+		// First node should not exist (transaction rolled back)
+		_, err = repo.GetByID(ctx, nodes[0].ID)
+		require.ErrorIs(t, err, node.ErrNotFound)
+	})
+}
+
+func TestPostgresRepository_BiTemporalQueries(t *testing.T) {
+	repo, pool := setupTestRepo(t)
+	ctx := setupTenantCtx(t, pool, "test-bitemporal")
+
+	t.Run("full temporal lifecycle", func(t *testing.T) {
+		// T1: Create node
+		t1 := time.Now().Add(-4 * time.Hour)
+		v1, err := node.NewBuilder("test-bitemporal").
+			WithNodeType("meter").
+			WithValidFrom(t1).
+			WithAttributes(map[string]any{"reading": float64(100)}).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, repo.Create(ctx, v1))
+
+		// T3: Supersede with new version
+		v2, err := node.NewBuilder("test-bitemporal").
+			WithNodeType("meter").
+			WithAttributes(map[string]any{"reading": float64(200)}).
+			Build()
+		require.NoError(t, err)
+		require.NoError(t, repo.Supersede(ctx, v1.ID, v2))
+
+		// Query at T0 (before creation) - not found
+		t0 := t1.Add(-1 * time.Hour)
+		_, err = repo.GetAsAt(ctx, "test-bitemporal", v1.ID, t0)
+		require.ErrorIs(t, err, node.ErrNotFound)
+
+		// Query at T2 (between creation and supersession) - returns v1
+		t2 := time.Now().Add(-2 * time.Hour)
+		fetched, err := repo.GetAsAt(ctx, "test-bitemporal", v1.ID, t2)
+		require.NoError(t, err)
+		assert.Equal(t, v1.ID, fetched.ID)
+
+		// Query at T4 (after supersession) - returns v2
+		t4 := time.Now()
+		fetched, err = repo.GetAsAt(ctx, "test-bitemporal", v1.ID, t4)
+		require.NoError(t, err)
+		assert.Equal(t, v2.ID, fetched.ID)
+
+		// History returns both versions
+		history, err := repo.GetHistory(ctx, "test-bitemporal", v1.ID)
+		require.NoError(t, err)
+		assert.Len(t, history, 2)
 	})
 }


### PR DESCRIPTION
## Summary

- Extends the `Repository` interface with `Update`, `GetAsAt`, `GetHistory`, `GetSubtree`, and `BulkCreate` methods
- Converts `GetAncestors` from iterative N+1 queries to a single recursive CTE
- Adds `GetSubtree` with depth-limited recursive CTE for efficient hierarchy traversal
- Implements bi-temporal queries (`GetAsAt` by ID, `GetByResolutionKey` with time parameter)
- Adds `GetChildren` activeOnly filter and `Update` with optimistic locking
- `BulkCreate` supports parent-child ordering within a single transaction batch

## Changes Made

**`services/reference-data/node/node.go`**
- Extended `Repository` interface with 5 new methods and updated signatures for `GetByResolutionKey` (added `asAt time.Time`) and `GetChildren` (added `activeOnly bool`)

**`services/reference-data/node/postgres_repository.go`**
- `GetAncestors`: Recursive CTE replaces iterative parent-by-parent lookups
- `GetSubtree`: Recursive CTE with configurable depth limit, returns all active descendants
- `GetAsAt`: CTE-based lookup finding the version valid at a specific time point
- `GetHistory`: Returns all temporal versions of a node (active and superseded) ordered newest-first
- `Update`: Modifies non-key attributes with optimistic locking via version column
- `BulkCreate`: Single-transaction batch insert with in-batch parent resolution
- Fixed ambiguous column references in CTE/JOIN queries by using explicit table-qualified column names

**`services/reference-data/node/postgres_repository_test.go`**
- 58 integration tests covering all repository methods
- Updated existing tests for changed method signatures

## Test Plan

- [x] CRUD: 3-level hierarchy (dno > gsp > meter), resolution key verification
- [x] Bi-temporal: Create node at T1, query AsAt(T0) returns nil, AsAt(T2) returns node
- [x] History: Supersede node, verify GetHistory returns 2 versions ordered newest-first
- [x] Hierarchy: 5-node tree, verify GetChildren, GetAncestors, GetSubtree
- [x] Max depth: 10-level tree, verify GetSubtree(maxDepth=3) returns 4 levels
- [x] Tenant isolation: Verify GetChildren, GetSubtree, GetHistory respect tenant boundaries
- [x] Optimistic locking: Concurrent updates detect version conflict
- [x] Bulk create: 100 nodes in single transaction with correct resolution keys
- [x] Bulk create rollback: Invalid parent in batch causes full transaction rollback

Implements market-data-dynamic-pricing.5