### PR TITLE
feat: Add Stripe settlement report ingestion and reconciliation

### DIFF
--- a/services/reconciliation/adapters/stripe/balance_transaction_client.go
+++ b/services/reconciliation/adapters/stripe/balance_transaction_client.go
@@ -1,0 +1,126 @@
+// Package stripe provides adapters for ingesting Stripe settlement data
+// into the reconciliation service.
+package stripe
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	stripego "github.com/stripe/stripe-go/v82"
+)
+
+// BalanceTransactionLister abstracts the Stripe Balance Transaction list API.
+// This allows unit testing without a real Stripe client.
+type BalanceTransactionLister interface {
+	List(ctx context.Context, params *stripego.BalanceTransactionListParams) stripego.Seq2[*stripego.BalanceTransaction, error]
+}
+
+// BalanceTransactionClient fetches balance transactions from Stripe
+// for a Connected Account with cursor-based pagination and date range filtering.
+type BalanceTransactionClient struct {
+	lister    BalanceTransactionLister
+	accountID string
+	pageSize  int64
+	logger    *slog.Logger
+}
+
+// BalanceTransactionClientConfig holds configuration for the client.
+type BalanceTransactionClientConfig struct {
+	// AccountID is the Stripe Connected Account ID (acct_...).
+	AccountID string
+	// PageSize is the number of transactions per page. Defaults to 100.
+	PageSize int64
+}
+
+// NewBalanceTransactionClient creates a new client that fetches balance transactions
+// from the given Connected Account.
+func NewBalanceTransactionClient(
+	lister BalanceTransactionLister,
+	cfg BalanceTransactionClientConfig,
+	logger *slog.Logger,
+) (*BalanceTransactionClient, error) {
+	if lister == nil {
+		return nil, ErrNilLister
+	}
+	if cfg.AccountID == "" {
+		return nil, ErrEmptyAccountID
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	pageSize := cfg.PageSize
+	if pageSize <= 0 {
+		pageSize = defaultPageSize
+	}
+	if pageSize > maxPageSize {
+		pageSize = maxPageSize
+	}
+	return &BalanceTransactionClient{
+		lister:    lister,
+		accountID: cfg.AccountID,
+		pageSize:  pageSize,
+		logger:    logger,
+	}, nil
+}
+
+// FetchTransactions retrieves all balance transactions for the Connected Account
+// within the given date range [from, to). It handles Stripe's automatic pagination.
+func (c *BalanceTransactionClient) FetchTransactions(
+	ctx context.Context,
+	from, to time.Time,
+) ([]*stripego.BalanceTransaction, error) {
+	params := &stripego.BalanceTransactionListParams{
+		CreatedRange: &stripego.RangeQueryParams{
+			GreaterThanOrEqual: from.Unix(),
+			LesserThan:         to.Unix(),
+		},
+	}
+	params.Limit = stripego.Int64(c.pageSize)
+	params.SetStripeAccount(c.accountID)
+
+	c.logger.Info("fetching stripe balance transactions",
+		"account_id", c.accountID,
+		"from", from.Format(time.RFC3339),
+		"to", to.Format(time.RFC3339),
+		"page_size", c.pageSize,
+	)
+
+	transactions := make([]*stripego.BalanceTransaction, 0, c.pageSize)
+	var count int
+
+	for bt, err := range c.lister.List(ctx, params) {
+		if err != nil {
+			return nil, fmt.Errorf("stripe balance transaction list failed after %d items: %w", count, err)
+		}
+		transactions = append(transactions, bt)
+		count++
+
+		if count >= maxTransactions {
+			c.logger.Warn("reached maximum transaction limit",
+				"account_id", c.accountID,
+				"limit", maxTransactions,
+			)
+			break
+		}
+	}
+
+	c.logger.Info("fetched stripe balance transactions",
+		"account_id", c.accountID,
+		"count", count,
+	)
+
+	return transactions, nil
+}
+
+const (
+	// defaultPageSize is the number of balance transactions per Stripe API page.
+	defaultPageSize int64 = 100
+
+	// maxPageSize is the maximum allowed by the Stripe API.
+	maxPageSize int64 = 100
+
+	// maxTransactions is a safety cap to prevent unbounded fetches.
+	maxTransactions = 100_000
+)

--- a/services/reconciliation/adapters/stripe/balance_transaction_client_test.go
+++ b/services/reconciliation/adapters/stripe/balance_transaction_client_test.go
@@ -1,0 +1,194 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	stripego "github.com/stripe/stripe-go/v82"
+)
+
+// mockLister implements BalanceTransactionLister for testing.
+type mockLister struct {
+	transactions   []*stripego.BalanceTransaction
+	err            error
+	capturedParams *stripego.BalanceTransactionListParams
+}
+
+func (m *mockLister) List(_ context.Context, params *stripego.BalanceTransactionListParams) stripego.Seq2[*stripego.BalanceTransaction, error] {
+	m.capturedParams = params
+	return func(yield func(*stripego.BalanceTransaction, error) bool) {
+		if m.err != nil {
+			yield(nil, m.err)
+			return
+		}
+		for _, bt := range m.transactions {
+			if !yield(bt, nil) {
+				return
+			}
+		}
+	}
+}
+
+func TestNewBalanceTransactionClient_Validation(t *testing.T) {
+	logger := slog.Default()
+	lister := &mockLister{}
+
+	t.Run("nil lister returns error", func(t *testing.T) {
+		_, err := NewBalanceTransactionClient(nil, BalanceTransactionClientConfig{
+			AccountID: "acct_test",
+		}, logger)
+		require.ErrorIs(t, err, ErrNilLister)
+	})
+
+	t.Run("empty account ID returns error", func(t *testing.T) {
+		_, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+			AccountID: "",
+		}, logger)
+		require.ErrorIs(t, err, ErrEmptyAccountID)
+	})
+
+	t.Run("valid config succeeds", func(t *testing.T) {
+		client, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+			AccountID: "acct_test",
+		}, logger)
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+
+	t.Run("nil logger defaults to slog.Default", func(t *testing.T) {
+		client, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+			AccountID: "acct_test",
+		}, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+
+	t.Run("page size defaults when zero", func(t *testing.T) {
+		client, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+			AccountID: "acct_test",
+			PageSize:  0,
+		}, logger)
+		require.NoError(t, err)
+		assert.Equal(t, defaultPageSize, client.pageSize)
+	})
+
+	t.Run("page size capped at max", func(t *testing.T) {
+		client, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+			AccountID: "acct_test",
+			PageSize:  500,
+		}, logger)
+		require.NoError(t, err)
+		assert.Equal(t, maxPageSize, client.pageSize)
+	})
+}
+
+func TestFetchTransactions_Success(t *testing.T) {
+	now := time.Now().UTC()
+	from := now.Add(-24 * time.Hour)
+	to := now
+
+	transactions := []*stripego.BalanceTransaction{
+		{ID: "txn_1", Amount: 1000, Net: 970, Fee: 30, Currency: "gbp", Type: stripego.BalanceTransactionTypeCharge, AvailableOn: now.Unix()},
+		{ID: "txn_2", Amount: 500, Net: 485, Fee: 15, Currency: "gbp", Type: stripego.BalanceTransactionTypeCharge, AvailableOn: now.Unix()},
+		{ID: "txn_3", Amount: -200, Net: -200, Fee: 0, Currency: "gbp", Type: stripego.BalanceTransactionTypeRefund, AvailableOn: now.Unix()},
+	}
+
+	lister := &mockLister{transactions: transactions}
+	client, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+		AccountID: "acct_test123",
+	}, slog.Default())
+	require.NoError(t, err)
+
+	result, err := client.FetchTransactions(context.Background(), from, to)
+	require.NoError(t, err)
+	assert.Len(t, result, 3)
+	assert.Equal(t, "txn_1", result[0].ID)
+	assert.Equal(t, "txn_2", result[1].ID)
+	assert.Equal(t, "txn_3", result[2].ID)
+}
+
+func TestFetchTransactions_DateRangeParams(t *testing.T) {
+	from := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC)
+
+	lister := &mockLister{transactions: nil}
+	client, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+		AccountID: "acct_datetest",
+	}, slog.Default())
+	require.NoError(t, err)
+
+	_, err = client.FetchTransactions(context.Background(), from, to)
+	require.NoError(t, err)
+
+	require.NotNil(t, lister.capturedParams)
+	require.NotNil(t, lister.capturedParams.CreatedRange)
+	assert.Equal(t, from.Unix(), lister.capturedParams.CreatedRange.GreaterThanOrEqual)
+	assert.Equal(t, to.Unix(), lister.capturedParams.CreatedRange.LesserThan)
+}
+
+func TestFetchTransactions_EmptyResult(t *testing.T) {
+	lister := &mockLister{transactions: nil}
+	client, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+		AccountID: "acct_empty",
+	}, slog.Default())
+	require.NoError(t, err)
+
+	result, err := client.FetchTransactions(context.Background(), time.Now().Add(-24*time.Hour), time.Now())
+	require.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestFetchTransactions_APIError(t *testing.T) {
+	apiErr := errors.New("stripe API rate limited")
+	lister := &mockLister{err: apiErr}
+	client, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+		AccountID: "acct_error",
+	}, slog.Default())
+	require.NoError(t, err)
+
+	_, err = client.FetchTransactions(context.Background(), time.Now().Add(-24*time.Hour), time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stripe balance transaction list failed")
+}
+
+func TestFetchTransactions_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// The cancelled context should propagate through to the lister
+	lister := &mockLister{transactions: []*stripego.BalanceTransaction{
+		{ID: "txn_1", Currency: "gbp", Type: stripego.BalanceTransactionTypeCharge},
+	}}
+	client, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+		AccountID: "acct_cancel",
+	}, slog.Default())
+	require.NoError(t, err)
+
+	// Even though we have transactions, the function itself should work since
+	// the mock doesn't check context. The real Stripe SDK would fail on cancelled ctx.
+	result, err := client.FetchTransactions(ctx, time.Now().Add(-24*time.Hour), time.Now())
+	// Mock doesn't check context so it will succeed - that's OK for unit tests
+	require.NoError(t, err)
+	assert.Len(t, result, 1)
+}
+
+func TestFetchTransactions_ConnectedAccountHeader(t *testing.T) {
+	lister := &mockLister{transactions: nil}
+	client, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+		AccountID: "acct_connected_123",
+	}, slog.Default())
+	require.NoError(t, err)
+
+	_, err = client.FetchTransactions(context.Background(), time.Now().Add(-24*time.Hour), time.Now())
+	require.NoError(t, err)
+
+	require.NotNil(t, lister.capturedParams)
+	// Verify the Stripe-Account header was set
+	require.NotNil(t, lister.capturedParams.GetParams().StripeAccount)
+	assert.Equal(t, "acct_connected_123", *lister.capturedParams.GetParams().StripeAccount)
+}

--- a/services/reconciliation/adapters/stripe/errors.go
+++ b/services/reconciliation/adapters/stripe/errors.go
@@ -1,0 +1,20 @@
+package stripe
+
+import "errors"
+
+var (
+	// ErrNilLister is returned when a nil BalanceTransactionLister is provided.
+	ErrNilLister = errors.New("balance transaction lister must not be nil")
+	// ErrEmptyAccountID is returned when the Connected Account ID is empty.
+	ErrEmptyAccountID = errors.New("stripe connected account ID must not be empty")
+	// ErrNilSnapshotRepo is returned when a nil snapshot repository is provided.
+	ErrNilSnapshotRepo = errors.New("settlement snapshot repository must not be nil")
+	// ErrNilTransactionClient is returned when a nil transaction client is provided.
+	ErrNilTransactionClient = errors.New("balance transaction client must not be nil")
+	// ErrNilTransformer is returned when a nil transformer is provided.
+	ErrNilTransformer = errors.New("settlement transformer must not be nil")
+	// ErrNilRunRepo is returned when a nil settlement run repository is provided.
+	ErrNilRunRepo = errors.New("settlement run repository must not be nil")
+	// ErrEmptyInternalAccountID is returned when the internal account ID is empty.
+	ErrEmptyInternalAccountID = errors.New("internal account ID must not be empty")
+)

--- a/services/reconciliation/adapters/stripe/settlement_ingestor.go
+++ b/services/reconciliation/adapters/stripe/settlement_ingestor.go
@@ -1,0 +1,218 @@
+package stripe
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+)
+
+// SettlementIngestorConfig holds configuration for the settlement ingestor.
+type SettlementIngestorConfig struct {
+	// AccountID is the Stripe Connected Account ID.
+	AccountID string
+	// InternalAccountID is the Meridian account ID for the settlement run.
+	InternalAccountID string
+	// IngestionTimeout is the maximum time for a single ingestion run.
+	IngestionTimeout time.Duration
+}
+
+// SettlementIngestor fetches Stripe balance transactions for a date range,
+// transforms them to SettlementSnapshot domain objects, and persists them
+// via the snapshot repository. It creates a settlement run for each ingestion.
+type SettlementIngestor struct {
+	client      *BalanceTransactionClient
+	transformer *SettlementTransformer
+	runRepo     domain.SettlementRunRepository
+	snapRepo    domain.SettlementSnapshotRepository
+	config      SettlementIngestorConfig
+	logger      *slog.Logger
+}
+
+// NewSettlementIngestor creates a new ingestor with the given dependencies.
+func NewSettlementIngestor(
+	client *BalanceTransactionClient,
+	transformer *SettlementTransformer,
+	runRepo domain.SettlementRunRepository,
+	snapRepo domain.SettlementSnapshotRepository,
+	cfg SettlementIngestorConfig,
+	logger *slog.Logger,
+) (*SettlementIngestor, error) {
+	if client == nil {
+		return nil, ErrNilTransactionClient
+	}
+	if transformer == nil {
+		return nil, ErrNilTransformer
+	}
+	if runRepo == nil {
+		return nil, ErrNilRunRepo
+	}
+	if snapRepo == nil {
+		return nil, ErrNilSnapshotRepo
+	}
+	if cfg.AccountID == "" {
+		return nil, ErrEmptyAccountID
+	}
+	if cfg.InternalAccountID == "" {
+		return nil, ErrEmptyInternalAccountID
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	timeout := cfg.IngestionTimeout
+	if timeout <= 0 {
+		timeout = defaultIngestionTimeout
+	}
+	cfg.IngestionTimeout = timeout
+
+	return &SettlementIngestor{
+		client:      client,
+		transformer: transformer,
+		runRepo:     runRepo,
+		snapRepo:    snapRepo,
+		config:      cfg,
+		logger:      logger.With("component", "stripe_settlement_ingestor"),
+	}, nil
+}
+
+// IngestSettlement fetches Stripe balance transactions for the given period,
+// creates a settlement run, transforms and persists the snapshots.
+// This is designed to be called by a daily cron job for the previous day.
+func (si *SettlementIngestor) IngestSettlement(ctx context.Context, periodStart, periodEnd time.Time) error {
+	ctx, cancel := context.WithTimeout(ctx, si.config.IngestionTimeout)
+	defer cancel()
+
+	si.logger.Info("starting stripe settlement ingestion",
+		"account_id", si.config.AccountID,
+		"internal_account_id", si.config.InternalAccountID,
+		"period_start", periodStart.Format(time.RFC3339),
+		"period_end", periodEnd.Format(time.RFC3339),
+	)
+
+	// Create the settlement run
+	run, err := domain.NewSettlementRun(
+		si.config.InternalAccountID,
+		domain.ReconciliationScopeAccount,
+		domain.SettlementTypeDaily,
+		periodStart,
+		periodEnd,
+		"stripe-settlement-ingestor",
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create settlement run: %w", err)
+	}
+
+	if err := si.runRepo.Create(ctx, run); err != nil {
+		return fmt.Errorf("failed to persist settlement run: %w", err)
+	}
+
+	// Transition to RUNNING
+	if err := run.Start(); err != nil {
+		return fmt.Errorf("failed to start settlement run: %w", err)
+	}
+	if err := si.runRepo.Update(ctx, run); err != nil {
+		return fmt.Errorf("failed to update settlement run to RUNNING: %w", err)
+	}
+
+	// Fetch transactions from Stripe
+	transactions, fetchErr := si.client.FetchTransactions(ctx, periodStart, periodEnd)
+	if fetchErr != nil {
+		si.failRun(ctx, run, fetchErr.Error())
+		return fmt.Errorf("failed to fetch stripe transactions: %w", fetchErr)
+	}
+
+	si.logger.Info("fetched stripe transactions",
+		"run_id", run.RunID,
+		"transaction_count", len(transactions),
+	)
+
+	if len(transactions) == 0 {
+		si.logger.Info("no stripe transactions for period, completing run",
+			"run_id", run.RunID,
+		)
+		if err := run.Complete(0); err != nil {
+			return fmt.Errorf("failed to complete empty settlement run: %w", err)
+		}
+		if err := si.runRepo.Update(ctx, run); err != nil {
+			return fmt.Errorf("failed to persist COMPLETED state: %w", err)
+		}
+		return nil
+	}
+
+	// Idempotent cleanup: remove any snapshots from a previous failed attempt
+	if err := si.snapRepo.DeleteByRunID(ctx, run.RunID); err != nil {
+		si.failRun(ctx, run, err.Error())
+		return fmt.Errorf("failed to clean up existing snapshots: %w", err)
+	}
+
+	// Transform to snapshots
+	snapshots, transformErr := si.transformer.TransformToSnapshots(
+		run.RunID,
+		si.config.InternalAccountID,
+		transactions,
+	)
+	if transformErr != nil {
+		si.failRun(ctx, run, transformErr.Error())
+		return fmt.Errorf("failed to transform transactions: %w", transformErr)
+	}
+
+	// Batch insert snapshots
+	if err := si.snapRepo.CreateBatch(ctx, snapshots); err != nil {
+		si.failRun(ctx, run, err.Error())
+		return fmt.Errorf("failed to persist snapshots: %w", err)
+	}
+
+	// Complete the run
+	if err := run.Complete(0); err != nil {
+		return fmt.Errorf("failed to complete settlement run: %w", err)
+	}
+	if err := si.runRepo.Update(ctx, run); err != nil {
+		return fmt.Errorf("failed to persist COMPLETED state: %w", err)
+	}
+
+	si.logger.Info("stripe settlement ingestion completed",
+		"run_id", run.RunID,
+		"snapshot_count", len(snapshots),
+	)
+
+	return nil
+}
+
+// IngestPreviousDay is a convenience method that ingests the previous UTC day's
+// settlement data. Designed to be called from a daily cron job.
+func (si *SettlementIngestor) IngestPreviousDay(ctx context.Context) error {
+	now := time.Now().UTC()
+	periodStart := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	return si.IngestSettlement(ctx, periodStart, periodEnd)
+}
+
+// failRun transitions the run to FAILED state and persists it.
+func (si *SettlementIngestor) failRun(ctx context.Context, run *domain.SettlementRun, reason string) {
+	if failErr := run.Fail(reason); failErr != nil {
+		si.logger.Error("failed to transition run to FAILED state",
+			"run_id", run.RunID,
+			"error", failErr,
+		)
+		return
+	}
+	if updateErr := si.runRepo.Update(ctx, run); updateErr != nil {
+		si.logger.Error("failed to persist FAILED state",
+			"run_id", run.RunID,
+			"error", updateErr,
+		)
+	}
+}
+
+// RunID returns a new unique run identifier. Exported for test use.
+func RunID() uuid.UUID {
+	return uuid.New()
+}
+
+const (
+	// defaultIngestionTimeout is the maximum time for a single ingestion run.
+	defaultIngestionTimeout = 10 * time.Minute
+)

--- a/services/reconciliation/adapters/stripe/settlement_ingestor_test.go
+++ b/services/reconciliation/adapters/stripe/settlement_ingestor_test.go
@@ -1,0 +1,346 @@
+package stripe
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	stripego "github.com/stripe/stripe-go/v82"
+)
+
+// mockRunRepo implements domain.SettlementRunRepository for testing.
+type mockRunRepo struct {
+	created   []*domain.SettlementRun
+	updated   []*domain.SettlementRun
+	runs      map[uuid.UUID]*domain.SettlementRun
+	createErr error
+	updateErr error
+	findErr   error
+}
+
+func newMockRunRepo() *mockRunRepo {
+	return &mockRunRepo{
+		runs: make(map[uuid.UUID]*domain.SettlementRun),
+	}
+}
+
+func (m *mockRunRepo) Create(_ context.Context, run *domain.SettlementRun) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.created = append(m.created, run)
+	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *mockRunRepo) FindByID(_ context.Context, runID uuid.UUID) (*domain.SettlementRun, error) {
+	if m.findErr != nil {
+		return nil, m.findErr
+	}
+	run, ok := m.runs[runID]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return run, nil
+}
+
+func (m *mockRunRepo) Update(_ context.Context, run *domain.SettlementRun) error {
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.updated = append(m.updated, run)
+	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *mockRunRepo) List(_ context.Context, _ domain.RunFilter) ([]*domain.SettlementRun, error) {
+	return nil, nil
+}
+
+// mockSnapRepo implements domain.SettlementSnapshotRepository for testing.
+type mockSnapRepo struct {
+	snapshots   []*domain.SettlementSnapshot
+	batchCount  int
+	deleteCount int
+	createErr   error
+	batchErr    error
+	deleteErr   error
+}
+
+func (m *mockSnapRepo) Create(_ context.Context, snapshot *domain.SettlementSnapshot) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.snapshots = append(m.snapshots, snapshot)
+	return nil
+}
+
+func (m *mockSnapRepo) CreateBatch(_ context.Context, snapshots []*domain.SettlementSnapshot) error {
+	if m.batchErr != nil {
+		return m.batchErr
+	}
+	m.batchCount++
+	m.snapshots = append(m.snapshots, snapshots...)
+	return nil
+}
+
+func (m *mockSnapRepo) FindByID(_ context.Context, _ uuid.UUID) (*domain.SettlementSnapshot, error) {
+	return nil, nil
+}
+
+func (m *mockSnapRepo) FindByRunID(_ context.Context, _ uuid.UUID) ([]*domain.SettlementSnapshot, error) {
+	return m.snapshots, nil
+}
+
+func (m *mockSnapRepo) DeleteByRunID(_ context.Context, _ uuid.UUID) error {
+	if m.deleteErr != nil {
+		return m.deleteErr
+	}
+	m.deleteCount++
+	return nil
+}
+
+func (m *mockSnapRepo) MarkRunSnapshotsFinal(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
+func newTestIngestor(t *testing.T, transactions []*stripego.BalanceTransaction, listerErr error) (*SettlementIngestor, *mockRunRepo, *mockSnapRepo) {
+	t.Helper()
+
+	lister := &mockLister{transactions: transactions, err: listerErr}
+	client, err := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+		AccountID: "acct_test",
+	}, slog.Default())
+	require.NoError(t, err)
+
+	transformer := NewSettlementTransformer()
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapRepo{}
+
+	ingestor, err := NewSettlementIngestor(client, transformer, runRepo, snapRepo, SettlementIngestorConfig{
+		AccountID:         "acct_test",
+		InternalAccountID: "meridian-001",
+		IngestionTimeout:  30 * time.Second,
+	}, slog.Default())
+	require.NoError(t, err)
+
+	return ingestor, runRepo, snapRepo
+}
+
+func TestNewSettlementIngestor_Validation(t *testing.T) {
+	lister := &mockLister{}
+	client, _ := NewBalanceTransactionClient(lister, BalanceTransactionClientConfig{
+		AccountID: "acct_test",
+	}, slog.Default())
+	transformer := NewSettlementTransformer()
+	runRepo := newMockRunRepo()
+	snapRepo := &mockSnapRepo{}
+	cfg := SettlementIngestorConfig{
+		AccountID:         "acct_test",
+		InternalAccountID: "meridian-001",
+	}
+
+	t.Run("nil client", func(t *testing.T) {
+		_, err := NewSettlementIngestor(nil, transformer, runRepo, snapRepo, cfg, slog.Default())
+		require.ErrorIs(t, err, ErrNilTransactionClient)
+	})
+
+	t.Run("nil transformer", func(t *testing.T) {
+		_, err := NewSettlementIngestor(client, nil, runRepo, snapRepo, cfg, slog.Default())
+		require.ErrorIs(t, err, ErrNilTransformer)
+	})
+
+	t.Run("nil run repo", func(t *testing.T) {
+		_, err := NewSettlementIngestor(client, transformer, nil, snapRepo, cfg, slog.Default())
+		require.ErrorIs(t, err, ErrNilRunRepo)
+	})
+
+	t.Run("nil snap repo", func(t *testing.T) {
+		_, err := NewSettlementIngestor(client, transformer, runRepo, nil, cfg, slog.Default())
+		require.ErrorIs(t, err, ErrNilSnapshotRepo)
+	})
+
+	t.Run("empty account ID", func(t *testing.T) {
+		_, err := NewSettlementIngestor(client, transformer, runRepo, snapRepo, SettlementIngestorConfig{
+			InternalAccountID: "meridian-001",
+		}, slog.Default())
+		require.ErrorIs(t, err, ErrEmptyAccountID)
+	})
+
+	t.Run("empty internal account ID", func(t *testing.T) {
+		_, err := NewSettlementIngestor(client, transformer, runRepo, snapRepo, SettlementIngestorConfig{
+			AccountID: "acct_test",
+		}, slog.Default())
+		require.ErrorIs(t, err, ErrEmptyInternalAccountID)
+	})
+
+	t.Run("valid config", func(t *testing.T) {
+		ingestor, err := NewSettlementIngestor(client, transformer, runRepo, snapRepo, cfg, slog.Default())
+		require.NoError(t, err)
+		assert.NotNil(t, ingestor)
+	})
+
+	t.Run("default timeout when zero", func(t *testing.T) {
+		ingestor, err := NewSettlementIngestor(client, transformer, runRepo, snapRepo, SettlementIngestorConfig{
+			AccountID:         "acct_test",
+			InternalAccountID: "meridian-001",
+			IngestionTimeout:  0,
+		}, slog.Default())
+		require.NoError(t, err)
+		assert.Equal(t, defaultIngestionTimeout, ingestor.config.IngestionTimeout)
+	})
+}
+
+func TestIngestSettlement_Success(t *testing.T) {
+	now := time.Now().UTC()
+	periodStart := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	transactions := []*stripego.BalanceTransaction{
+		{ID: "txn_1", Amount: 1000, Net: 970, Fee: 30, Currency: "gbp", Type: stripego.BalanceTransactionTypeCharge, AvailableOn: now.Unix()},
+		{ID: "txn_2", Amount: -200, Net: -200, Fee: 0, Currency: "gbp", Type: stripego.BalanceTransactionTypeRefund, AvailableOn: now.Unix()},
+	}
+
+	ingestor, runRepo, snapRepo := newTestIngestor(t, transactions, nil)
+
+	err := ingestor.IngestSettlement(context.Background(), periodStart, periodEnd)
+	require.NoError(t, err)
+
+	// Verify run was created and completed
+	require.Len(t, runRepo.created, 1)
+	run := runRepo.created[0]
+	assert.Equal(t, "meridian-001", run.AccountID)
+	assert.Equal(t, domain.ReconciliationScopeAccount, run.Scope)
+	assert.Equal(t, domain.SettlementTypeDaily, run.SettlementType)
+	assert.Equal(t, "stripe-settlement-ingestor", run.InitiatedBy)
+
+	// Verify run was updated to RUNNING then COMPLETED (2 updates for Start + Complete)
+	assert.GreaterOrEqual(t, len(runRepo.updated), 2)
+	lastUpdate := runRepo.updated[len(runRepo.updated)-1]
+	assert.Equal(t, domain.RunStatusCompleted, lastUpdate.Status)
+
+	// Verify snapshots were created
+	assert.Len(t, snapRepo.snapshots, 2)
+	assert.Equal(t, 1, snapRepo.batchCount)
+
+	// Verify snapshot content
+	snap1 := snapRepo.snapshots[0]
+	assert.Equal(t, "meridian-001", snap1.AccountID)
+	assert.Equal(t, "GBP", snap1.InstrumentCode)
+	assert.True(t, decimal.NewFromFloat(9.70).Equal(snap1.ActualBalance))
+	assert.Equal(t, "txn_1", snap1.Attributes["external_reference_id"])
+	assert.Equal(t, "PAYMENT", snap1.Attributes["settlement_type"])
+
+	snap2 := snapRepo.snapshots[1]
+	assert.True(t, decimal.NewFromFloat(-2.00).Equal(snap2.ActualBalance))
+	assert.Equal(t, "REFUND", snap2.Attributes["settlement_type"])
+
+	// Verify idempotent cleanup was called
+	assert.Equal(t, 1, snapRepo.deleteCount)
+}
+
+func TestIngestSettlement_EmptyTransactions(t *testing.T) {
+	now := time.Now().UTC()
+	periodStart := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	ingestor, runRepo, snapRepo := newTestIngestor(t, nil, nil)
+
+	err := ingestor.IngestSettlement(context.Background(), periodStart, periodEnd)
+	require.NoError(t, err)
+
+	// Run should be created and completed with zero variance
+	require.Len(t, runRepo.created, 1)
+	lastUpdate := runRepo.updated[len(runRepo.updated)-1]
+	assert.Equal(t, domain.RunStatusCompleted, lastUpdate.Status)
+	assert.Equal(t, 0, lastUpdate.VarianceCount)
+
+	// No snapshots should be created
+	assert.Empty(t, snapRepo.snapshots)
+}
+
+func TestIngestSettlement_FetchError(t *testing.T) {
+	now := time.Now().UTC()
+	periodStart := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	fetchErr := errors.New("stripe API unavailable")
+	ingestor, runRepo, _ := newTestIngestor(t, nil, fetchErr)
+
+	err := ingestor.IngestSettlement(context.Background(), periodStart, periodEnd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to fetch stripe transactions")
+
+	// Run should be marked as FAILED
+	require.NotEmpty(t, runRepo.updated)
+	lastUpdate := runRepo.updated[len(runRepo.updated)-1]
+	assert.Equal(t, domain.RunStatusFailed, lastUpdate.Status)
+	assert.Contains(t, lastUpdate.FailureReason, "stripe API unavailable")
+}
+
+func TestIngestSettlement_BatchInsertError(t *testing.T) {
+	now := time.Now().UTC()
+	periodStart := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	transactions := []*stripego.BalanceTransaction{
+		{ID: "txn_1", Amount: 1000, Net: 970, Fee: 30, Currency: "gbp", Type: stripego.BalanceTransactionTypeCharge, AvailableOn: now.Unix()},
+	}
+
+	ingestor, runRepo, snapRepo := newTestIngestor(t, transactions, nil)
+	snapRepo.batchErr = errors.New("database write failed")
+
+	err := ingestor.IngestSettlement(context.Background(), periodStart, periodEnd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to persist snapshots")
+
+	// Run should be marked as FAILED
+	var foundFailed bool
+	for _, u := range runRepo.updated {
+		if u.Status == domain.RunStatusFailed {
+			foundFailed = true
+			break
+		}
+	}
+	assert.True(t, foundFailed, "expected run to be marked FAILED")
+}
+
+func TestIngestSettlement_CreateRunError(t *testing.T) {
+	now := time.Now().UTC()
+	periodStart := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+
+	ingestor, runRepo, _ := newTestIngestor(t, nil, nil)
+	runRepo.createErr = errors.New("database conflict")
+
+	err := ingestor.IngestSettlement(context.Background(), periodStart, periodEnd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to persist settlement run")
+}
+
+func TestIngestPreviousDay(t *testing.T) {
+	transactions := []*stripego.BalanceTransaction{
+		{ID: "txn_prev", Amount: 500, Net: 500, Currency: "gbp", Type: stripego.BalanceTransactionTypeCharge, AvailableOn: time.Now().Unix()},
+	}
+
+	ingestor, runRepo, _ := newTestIngestor(t, transactions, nil)
+
+	err := ingestor.IngestPreviousDay(context.Background())
+	require.NoError(t, err)
+
+	// Verify the period covers yesterday midnight to today midnight UTC
+	require.Len(t, runRepo.created, 1)
+	run := runRepo.created[0]
+	now := time.Now().UTC()
+	expectedStart := time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC)
+	expectedEnd := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	assert.Equal(t, expectedStart, run.PeriodStart)
+	assert.Equal(t, expectedEnd, run.PeriodEnd)
+}

--- a/services/reconciliation/adapters/stripe/settlement_transformer.go
+++ b/services/reconciliation/adapters/stripe/settlement_transformer.go
@@ -1,0 +1,160 @@
+package stripe
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
+	stripego "github.com/stripe/stripe-go/v82"
+)
+
+// SettlementTransactionType maps Stripe balance transaction types
+// to normalized settlement transaction types.
+type SettlementTransactionType string
+
+// Normalized settlement transaction types for Stripe balance transactions.
+const (
+	SettlementTypePayment    SettlementTransactionType = "PAYMENT"
+	SettlementTypeRefund     SettlementTransactionType = "REFUND"
+	SettlementTypePayout     SettlementTransactionType = "PAYOUT"
+	SettlementTypeFee        SettlementTransactionType = "FEE"
+	SettlementTypeDispute    SettlementTransactionType = "DISPUTE"
+	SettlementTypeTransfer   SettlementTransactionType = "TRANSFER"
+	SettlementTypeAdjustment SettlementTransactionType = "ADJUSTMENT"
+	SettlementTypeOther      SettlementTransactionType = "OTHER"
+
+	// SourceSystemStripe identifies Stripe as the data source.
+	SourceSystemStripe = "STRIPE"
+)
+
+// SettlementTransformer converts Stripe BalanceTransaction objects into
+// reconciliation domain SettlementSnapshot objects.
+type SettlementTransformer struct{}
+
+// NewSettlementTransformer creates a new transformer.
+func NewSettlementTransformer() *SettlementTransformer {
+	return &SettlementTransformer{}
+}
+
+// TransformToSnapshots converts a slice of Stripe balance transactions into
+// SettlementSnapshot domain objects for a given settlement run.
+func (t *SettlementTransformer) TransformToSnapshots(
+	runID uuid.UUID,
+	accountID string,
+	transactions []*stripego.BalanceTransaction,
+) ([]*domain.SettlementSnapshot, error) {
+	snapshots := make([]*domain.SettlementSnapshot, 0, len(transactions))
+	for _, bt := range transactions {
+		snapshot, err := t.transformOne(runID, accountID, bt)
+		if err != nil {
+			return nil, fmt.Errorf("failed to transform balance transaction %s: %w", bt.ID, err)
+		}
+		snapshots = append(snapshots, snapshot)
+	}
+	return snapshots, nil
+}
+
+// transformOne converts a single Stripe BalanceTransaction to a SettlementSnapshot.
+func (t *SettlementTransformer) transformOne(
+	runID uuid.UUID,
+	accountID string,
+	bt *stripego.BalanceTransaction,
+) (*domain.SettlementSnapshot, error) {
+	// Stripe amounts are in the smallest currency unit (cents).
+	// Convert to decimal for the domain model.
+	netAmount := centsToDecimal(bt.Net)
+
+	instrumentCode := strings.ToUpper(string(bt.Currency))
+	settlementDate := time.Unix(bt.AvailableOn, 0).UTC()
+
+	attrs := map[string]string{
+		"external_reference_id": bt.ID,
+		"stripe_type":           string(bt.Type),
+		"settlement_type":       string(mapTransactionType(bt.Type)),
+		"settlement_date":       settlementDate.Format(time.RFC3339),
+		"gross_amount":          centsToDecimal(bt.Amount).String(),
+		"fee_amount":            centsToDecimal(bt.Fee).String(),
+		"net_amount":            netAmount.String(),
+		"source_system":         SourceSystemStripe,
+		"data_source_type":      "NOSTRO_VOSTRO",
+	}
+
+	if bt.Description != "" {
+		attrs["description"] = bt.Description
+	}
+
+	if bt.Source != nil && bt.Source.ID != "" {
+		attrs["stripe_source_id"] = bt.Source.ID
+	}
+
+	// For settlement snapshots, the actual balance is the net amount from Stripe.
+	// The expected balance comes from the internal ledger and will be zero here
+	// (set during the reconciliation comparison phase).
+	snapshot, err := domain.NewSettlementSnapshot(
+		runID,
+		accountID,
+		instrumentCode,
+		decimal.Zero, // expected from internal ledger (populated during comparison)
+		netAmount,    // actual from Stripe
+		SourceSystemStripe,
+		attrs,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return snapshot, nil
+}
+
+// mapTransactionType maps a Stripe BalanceTransactionType to a normalized settlement type.
+func mapTransactionType(stripeType stripego.BalanceTransactionType) SettlementTransactionType {
+	switch stripeType { //nolint:exhaustive // remaining types handled by default case
+	case stripego.BalanceTransactionTypeCharge,
+		stripego.BalanceTransactionTypePayment:
+		return SettlementTypePayment
+
+	case stripego.BalanceTransactionTypeRefund,
+		stripego.BalanceTransactionTypePaymentRefund,
+		stripego.BalanceTransactionTypeApplicationFeeRefund,
+		stripego.BalanceTransactionTypeTransferRefund,
+		stripego.BalanceTransactionTypeRefundFailure,
+		stripego.BalanceTransactionTypePaymentFailureRefund:
+		return SettlementTypeRefund
+
+	case stripego.BalanceTransactionTypePayout,
+		stripego.BalanceTransactionTypePayoutCancel,
+		stripego.BalanceTransactionTypePayoutFailure,
+		stripego.BalanceTransactionTypePayoutMinimumBalanceHold,
+		stripego.BalanceTransactionTypePayoutMinimumBalanceRelease:
+		return SettlementTypePayout
+
+	case stripego.BalanceTransactionTypeStripeFee,
+		stripego.BalanceTransactionTypeStripeFxFee,
+		stripego.BalanceTransactionTypeTaxFee,
+		stripego.BalanceTransactionTypeApplicationFee:
+		return SettlementTypeFee
+
+	case stripego.BalanceTransactionTypeIssuingDispute:
+		return SettlementTypeDispute
+
+	case stripego.BalanceTransactionTypeTransfer,
+		stripego.BalanceTransactionTypeTransferCancel,
+		stripego.BalanceTransactionTypeTransferFailure,
+		stripego.BalanceTransactionTypeConnectCollectionTransfer:
+		return SettlementTypeTransfer
+
+	case stripego.BalanceTransactionTypeAdjustment:
+		return SettlementTypeAdjustment
+
+	default:
+		return SettlementTypeOther
+	}
+}
+
+// centsToDecimal converts an amount in smallest currency unit (cents) to decimal.
+func centsToDecimal(cents int64) decimal.Decimal {
+	return decimal.NewFromInt(cents).Div(decimal.NewFromInt(100))
+}

--- a/services/reconciliation/adapters/stripe/settlement_transformer.go
+++ b/services/reconciliation/adapters/stripe/settlement_transformer.go
@@ -163,11 +163,23 @@ var zeroDecimalCurrencies = map[string]bool{
 	"UGX": true, "VND": true, "VUV": true, "XAF": true, "XOF": true, "XPF": true,
 }
 
+// threeDecimalCurrencies lists Stripe currencies that use 3 decimal places.
+// See: https://docs.stripe.com/currencies#three-decimal
+var threeDecimalCurrencies = map[string]bool{
+	"BHD": true, "JOD": true, "KWD": true, "OMR": true, "TND": true,
+}
+
 // amountToDecimal converts a Stripe amount to decimal based on currency.
-// Zero-decimal currencies (JPY, KRW, etc.) are not divided by 100.
+// Zero-decimal currencies (JPY, KRW, etc.) are not divided.
+// Three-decimal currencies (BHD, JOD, etc.) are divided by 1000.
+// All others are divided by 100.
 func amountToDecimal(amount int64, currency string) decimal.Decimal {
-	if zeroDecimalCurrencies[strings.ToUpper(currency)] {
+	cur := strings.ToUpper(currency)
+	if zeroDecimalCurrencies[cur] {
 		return decimal.NewFromInt(amount)
+	}
+	if threeDecimalCurrencies[cur] {
+		return decimal.NewFromInt(amount).Div(decimal.NewFromInt(1000))
 	}
 	return decimal.NewFromInt(amount).Div(decimal.NewFromInt(100))
 }

--- a/services/reconciliation/adapters/stripe/settlement_transformer.go
+++ b/services/reconciliation/adapters/stripe/settlement_transformer.go
@@ -63,11 +63,12 @@ func (t *SettlementTransformer) transformOne(
 	accountID string,
 	bt *stripego.BalanceTransaction,
 ) (*domain.SettlementSnapshot, error) {
-	// Stripe amounts are in the smallest currency unit (cents).
-	// Convert to decimal for the domain model.
-	netAmount := centsToDecimal(bt.Net)
+	// Stripe amounts are in the smallest currency unit (cents for most currencies).
+	// Zero-decimal currencies (JPY, KRW, etc.) are not divided by 100.
+	currency := strings.ToUpper(string(bt.Currency))
+	netAmount := amountToDecimal(bt.Net, currency)
 
-	instrumentCode := strings.ToUpper(string(bt.Currency))
+	instrumentCode := currency
 	settlementDate := time.Unix(bt.AvailableOn, 0).UTC()
 
 	attrs := map[string]string{
@@ -75,8 +76,8 @@ func (t *SettlementTransformer) transformOne(
 		"stripe_type":           string(bt.Type),
 		"settlement_type":       string(mapTransactionType(bt.Type)),
 		"settlement_date":       settlementDate.Format(time.RFC3339),
-		"gross_amount":          centsToDecimal(bt.Amount).String(),
-		"fee_amount":            centsToDecimal(bt.Fee).String(),
+		"gross_amount":          amountToDecimal(bt.Amount, currency).String(),
+		"fee_amount":            amountToDecimal(bt.Fee, currency).String(),
 		"net_amount":            netAmount.String(),
 		"source_system":         SourceSystemStripe,
 		"data_source_type":      "NOSTRO_VOSTRO",
@@ -154,7 +155,19 @@ func mapTransactionType(stripeType stripego.BalanceTransactionType) SettlementTr
 	}
 }
 
-// centsToDecimal converts an amount in smallest currency unit (cents) to decimal.
-func centsToDecimal(cents int64) decimal.Decimal {
-	return decimal.NewFromInt(cents).Div(decimal.NewFromInt(100))
+// zeroDecimalCurrencies lists Stripe currencies that do not use subunits.
+// See: https://docs.stripe.com/currencies#zero-decimal
+var zeroDecimalCurrencies = map[string]bool{
+	"BIF": true, "CLP": true, "DJF": true, "GNF": true, "JPY": true,
+	"KMF": true, "KRW": true, "MGA": true, "PYG": true, "RWF": true,
+	"UGX": true, "VND": true, "VUV": true, "XAF": true, "XOF": true, "XPF": true,
+}
+
+// amountToDecimal converts a Stripe amount to decimal based on currency.
+// Zero-decimal currencies (JPY, KRW, etc.) are not divided by 100.
+func amountToDecimal(amount int64, currency string) decimal.Decimal {
+	if zeroDecimalCurrencies[strings.ToUpper(currency)] {
+		return decimal.NewFromInt(amount)
+	}
+	return decimal.NewFromInt(amount).Div(decimal.NewFromInt(100))
 }

--- a/services/reconciliation/adapters/stripe/settlement_transformer_test.go
+++ b/services/reconciliation/adapters/stripe/settlement_transformer_test.go
@@ -339,8 +339,32 @@ func TestAmountToDecimal(t *testing.T) {
 		}
 	})
 
+	t.Run("three-decimal currency divides by 1000", func(t *testing.T) {
+		tests := []struct {
+			amount   int64
+			currency string
+			expected string
+		}{
+			{3590, "BHD", "3.59"},
+			{10000, "JOD", "10"},
+			{500, "KWD", "0.5"},
+			{1, "OMR", "0.001"},
+			{-2500, "TND", "-2.5"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.currency+"_"+tt.expected, func(t *testing.T) {
+				result := amountToDecimal(tt.amount, tt.currency)
+				assert.Equal(t, tt.expected, result.String())
+			})
+		}
+	})
+
 	t.Run("case insensitive currency check", func(t *testing.T) {
 		result := amountToDecimal(1000, "jpy")
 		assert.Equal(t, "1000", result.String())
+
+		result = amountToDecimal(3590, "bhd")
+		assert.Equal(t, "3.59", result.String())
 	})
 }

--- a/services/reconciliation/adapters/stripe/settlement_transformer_test.go
+++ b/services/reconciliation/adapters/stripe/settlement_transformer_test.go
@@ -222,6 +222,31 @@ func TestSettlementTransformer_TransformToSnapshots(t *testing.T) {
 		assert.False(t, hasSourceID)
 	})
 
+	t.Run("zero-decimal currency JPY amounts are not divided by 100", func(t *testing.T) {
+		transactions := []*stripego.BalanceTransaction{
+			{
+				ID:          "txn_jpy_001",
+				Amount:      1000, // 1000 JPY (NOT 10.00 JPY)
+				Net:         970,  // 970 JPY
+				Fee:         30,   // 30 JPY
+				Currency:    "jpy",
+				Type:        stripego.BalanceTransactionTypeCharge,
+				AvailableOn: time.Now().Unix(),
+			},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		require.Len(t, snapshots, 1)
+
+		snap := snapshots[0]
+		assert.Equal(t, "JPY", snap.InstrumentCode)
+		assert.True(t, decimal.NewFromInt(970).Equal(snap.ActualBalance), "expected 970 JPY, got %s", snap.ActualBalance)
+		assert.Equal(t, "1000", snap.Attributes["gross_amount"])
+		assert.Equal(t, "30", snap.Attributes["fee_amount"])
+		assert.Equal(t, "970", snap.Attributes["net_amount"])
+	})
+
 	t.Run("empty description is omitted", func(t *testing.T) {
 		transactions := []*stripego.BalanceTransaction{
 			{ID: "txn_nodesc", Amount: 100, Net: 100, Currency: "gbp", Type: stripego.BalanceTransactionTypeCharge, AvailableOn: time.Now().Unix()},
@@ -270,24 +295,52 @@ func TestMapTransactionType(t *testing.T) {
 	}
 }
 
-func TestCentsToDecimal(t *testing.T) {
-	tests := []struct {
-		cents    int64
-		expected string
-	}{
-		{1000, "10"},
-		{999, "9.99"},
-		{1, "0.01"},
-		{0, "0"},
-		{-500, "-5"},
-		{-1, "-0.01"},
-		{100050, "1000.5"},
-	}
+func TestAmountToDecimal(t *testing.T) {
+	t.Run("standard currency divides by 100", func(t *testing.T) {
+		tests := []struct {
+			amount   int64
+			expected string
+		}{
+			{1000, "10"},
+			{999, "9.99"},
+			{1, "0.01"},
+			{0, "0"},
+			{-500, "-5"},
+			{-1, "-0.01"},
+			{100050, "1000.5"},
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.expected, func(t *testing.T) {
-			result := centsToDecimal(tt.cents)
-			assert.Equal(t, tt.expected, result.String())
-		})
-	}
+		for _, tt := range tests {
+			t.Run(tt.expected, func(t *testing.T) {
+				result := amountToDecimal(tt.amount, "GBP")
+				assert.Equal(t, tt.expected, result.String())
+			})
+		}
+	})
+
+	t.Run("zero-decimal currency does not divide", func(t *testing.T) {
+		tests := []struct {
+			amount   int64
+			currency string
+			expected string
+		}{
+			{1000, "JPY", "1000"},
+			{500, "KRW", "500"},
+			{1, "VND", "1"},
+			{0, "BIF", "0"},
+			{-200, "XAF", "-200"},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.currency+"_"+tt.expected, func(t *testing.T) {
+				result := amountToDecimal(tt.amount, tt.currency)
+				assert.Equal(t, tt.expected, result.String())
+			})
+		}
+	})
+
+	t.Run("case insensitive currency check", func(t *testing.T) {
+		result := amountToDecimal(1000, "jpy")
+		assert.Equal(t, "1000", result.String())
+	})
 }

--- a/services/reconciliation/adapters/stripe/settlement_transformer_test.go
+++ b/services/reconciliation/adapters/stripe/settlement_transformer_test.go
@@ -1,0 +1,293 @@
+package stripe
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	stripego "github.com/stripe/stripe-go/v82"
+)
+
+func TestSettlementTransformer_TransformToSnapshots(t *testing.T) {
+	transformer := NewSettlementTransformer()
+	runID := uuid.New()
+	accountID := "meridian-acct-001"
+
+	t.Run("transforms payment transaction", func(t *testing.T) {
+		availableOn := time.Date(2025, 6, 15, 0, 0, 0, 0, time.UTC)
+		transactions := []*stripego.BalanceTransaction{
+			{
+				ID:          "txn_payment_001",
+				Amount:      1000, // 10.00 GBP
+				Net:         970,  // 9.70 GBP (after fees)
+				Fee:         30,   // 0.30 GBP
+				Currency:    "gbp",
+				Type:        stripego.BalanceTransactionTypeCharge,
+				AvailableOn: availableOn.Unix(),
+				Description: "Payment for order #123",
+				Source:      &stripego.BalanceTransactionSource{ID: "ch_abc123"},
+			},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		require.Len(t, snapshots, 1)
+
+		snap := snapshots[0]
+		assert.Equal(t, runID, snap.RunID)
+		assert.Equal(t, accountID, snap.AccountID)
+		assert.Equal(t, "GBP", snap.InstrumentCode)
+		assert.True(t, decimal.Zero.Equal(snap.ExpectedBalance))
+		assert.True(t, decimal.NewFromFloat(9.70).Equal(snap.ActualBalance))
+		assert.Equal(t, SourceSystemStripe, snap.SourceSystem)
+
+		// Verify attributes
+		assert.Equal(t, "txn_payment_001", snap.Attributes["external_reference_id"])
+		assert.Equal(t, "charge", snap.Attributes["stripe_type"])
+		assert.Equal(t, "PAYMENT", snap.Attributes["settlement_type"])
+		assert.Equal(t, "9.7", snap.Attributes["net_amount"])
+		assert.Equal(t, "10", snap.Attributes["gross_amount"])
+		assert.Equal(t, "0.3", snap.Attributes["fee_amount"])
+		assert.Equal(t, "Payment for order #123", snap.Attributes["description"])
+		assert.Equal(t, "ch_abc123", snap.Attributes["stripe_source_id"])
+		assert.Equal(t, "NOSTRO_VOSTRO", snap.Attributes["data_source_type"])
+	})
+
+	t.Run("transforms refund transaction", func(t *testing.T) {
+		transactions := []*stripego.BalanceTransaction{
+			{
+				ID:          "txn_refund_001",
+				Amount:      -500, // -5.00 GBP
+				Net:         -500,
+				Fee:         0,
+				Currency:    "gbp",
+				Type:        stripego.BalanceTransactionTypeRefund,
+				AvailableOn: time.Now().Unix(),
+			},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		require.Len(t, snapshots, 1)
+
+		snap := snapshots[0]
+		assert.True(t, decimal.NewFromFloat(-5.00).Equal(snap.ActualBalance))
+		assert.Equal(t, "REFUND", snap.Attributes["settlement_type"])
+		assert.Equal(t, "refund", snap.Attributes["stripe_type"])
+	})
+
+	t.Run("transforms payout transaction", func(t *testing.T) {
+		transactions := []*stripego.BalanceTransaction{
+			{
+				ID:          "txn_payout_001",
+				Amount:      -10000,
+				Net:         -10000,
+				Fee:         0,
+				Currency:    "gbp",
+				Type:        stripego.BalanceTransactionTypePayout,
+				AvailableOn: time.Now().Unix(),
+			},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		require.Len(t, snapshots, 1)
+
+		assert.Equal(t, "PAYOUT", snapshots[0].Attributes["settlement_type"])
+	})
+
+	t.Run("transforms fee transaction", func(t *testing.T) {
+		transactions := []*stripego.BalanceTransaction{
+			{
+				ID:          "txn_fee_001",
+				Amount:      -25,
+				Net:         -25,
+				Fee:         0,
+				Currency:    "gbp",
+				Type:        stripego.BalanceTransactionTypeStripeFee,
+				AvailableOn: time.Now().Unix(),
+			},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		require.Len(t, snapshots, 1)
+
+		assert.Equal(t, "FEE", snapshots[0].Attributes["settlement_type"])
+	})
+
+	t.Run("transforms transfer transaction", func(t *testing.T) {
+		transactions := []*stripego.BalanceTransaction{
+			{
+				ID:          "txn_transfer_001",
+				Amount:      5000,
+				Net:         5000,
+				Fee:         0,
+				Currency:    "gbp",
+				Type:        stripego.BalanceTransactionTypeTransfer,
+				AvailableOn: time.Now().Unix(),
+			},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		require.Len(t, snapshots, 1)
+
+		assert.Equal(t, "TRANSFER", snapshots[0].Attributes["settlement_type"])
+	})
+
+	t.Run("transforms adjustment transaction", func(t *testing.T) {
+		transactions := []*stripego.BalanceTransaction{
+			{
+				ID:          "txn_adjust_001",
+				Amount:      150,
+				Net:         150,
+				Fee:         0,
+				Currency:    "gbp",
+				Type:        stripego.BalanceTransactionTypeAdjustment,
+				AvailableOn: time.Now().Unix(),
+			},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		require.Len(t, snapshots, 1)
+
+		assert.Equal(t, "ADJUSTMENT", snapshots[0].Attributes["settlement_type"])
+	})
+
+	t.Run("unknown type maps to OTHER", func(t *testing.T) {
+		transactions := []*stripego.BalanceTransaction{
+			{
+				ID:          "txn_unknown_001",
+				Amount:      100,
+				Net:         100,
+				Fee:         0,
+				Currency:    "gbp",
+				Type:        stripego.BalanceTransactionTypeContribution,
+				AvailableOn: time.Now().Unix(),
+			},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		require.Len(t, snapshots, 1)
+
+		assert.Equal(t, "OTHER", snapshots[0].Attributes["settlement_type"])
+	})
+
+	t.Run("transforms multiple transactions", func(t *testing.T) {
+		transactions := []*stripego.BalanceTransaction{
+			{ID: "txn_1", Amount: 1000, Net: 970, Fee: 30, Currency: "gbp", Type: stripego.BalanceTransactionTypeCharge, AvailableOn: time.Now().Unix()},
+			{ID: "txn_2", Amount: -200, Net: -200, Fee: 0, Currency: "gbp", Type: stripego.BalanceTransactionTypeRefund, AvailableOn: time.Now().Unix()},
+			{ID: "txn_3", Amount: -30, Net: -30, Fee: 0, Currency: "gbp", Type: stripego.BalanceTransactionTypeStripeFee, AvailableOn: time.Now().Unix()},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		assert.Len(t, snapshots, 3)
+
+		assert.Equal(t, "PAYMENT", snapshots[0].Attributes["settlement_type"])
+		assert.Equal(t, "REFUND", snapshots[1].Attributes["settlement_type"])
+		assert.Equal(t, "FEE", snapshots[2].Attributes["settlement_type"])
+	})
+
+	t.Run("empty transactions produces empty result", func(t *testing.T) {
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, nil)
+		require.NoError(t, err)
+		assert.Empty(t, snapshots)
+	})
+
+	t.Run("currency is uppercased", func(t *testing.T) {
+		transactions := []*stripego.BalanceTransaction{
+			{ID: "txn_usd", Amount: 100, Net: 100, Currency: "usd", Type: stripego.BalanceTransactionTypeCharge, AvailableOn: time.Now().Unix()},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		assert.Equal(t, "USD", snapshots[0].InstrumentCode)
+	})
+
+	t.Run("source without ID omits stripe_source_id", func(t *testing.T) {
+		transactions := []*stripego.BalanceTransaction{
+			{ID: "txn_nosrc", Amount: 100, Net: 100, Currency: "gbp", Type: stripego.BalanceTransactionTypeCharge, AvailableOn: time.Now().Unix()},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		_, hasSourceID := snapshots[0].Attributes["stripe_source_id"]
+		assert.False(t, hasSourceID)
+	})
+
+	t.Run("empty description is omitted", func(t *testing.T) {
+		transactions := []*stripego.BalanceTransaction{
+			{ID: "txn_nodesc", Amount: 100, Net: 100, Currency: "gbp", Type: stripego.BalanceTransactionTypeCharge, AvailableOn: time.Now().Unix()},
+		}
+
+		snapshots, err := transformer.TransformToSnapshots(runID, accountID, transactions)
+		require.NoError(t, err)
+		_, hasDesc := snapshots[0].Attributes["description"]
+		assert.False(t, hasDesc)
+	})
+}
+
+func TestMapTransactionType(t *testing.T) {
+	tests := []struct {
+		stripeType stripego.BalanceTransactionType
+		expected   SettlementTransactionType
+	}{
+		{stripego.BalanceTransactionTypeCharge, SettlementTypePayment},
+		{stripego.BalanceTransactionTypePayment, SettlementTypePayment},
+		{stripego.BalanceTransactionTypeRefund, SettlementTypeRefund},
+		{stripego.BalanceTransactionTypePaymentRefund, SettlementTypeRefund},
+		{stripego.BalanceTransactionTypeApplicationFeeRefund, SettlementTypeRefund},
+		{stripego.BalanceTransactionTypeTransferRefund, SettlementTypeRefund},
+		{stripego.BalanceTransactionTypePayout, SettlementTypePayout},
+		{stripego.BalanceTransactionTypePayoutCancel, SettlementTypePayout},
+		{stripego.BalanceTransactionTypePayoutFailure, SettlementTypePayout},
+		{stripego.BalanceTransactionTypeStripeFee, SettlementTypeFee},
+		{stripego.BalanceTransactionTypeStripeFxFee, SettlementTypeFee},
+		{stripego.BalanceTransactionTypeTaxFee, SettlementTypeFee},
+		{stripego.BalanceTransactionTypeApplicationFee, SettlementTypeFee},
+		{stripego.BalanceTransactionTypeIssuingDispute, SettlementTypeDispute},
+		{stripego.BalanceTransactionTypeTransfer, SettlementTypeTransfer},
+		{stripego.BalanceTransactionTypeTransferCancel, SettlementTypeTransfer},
+		{stripego.BalanceTransactionTypeTransferFailure, SettlementTypeTransfer},
+		{stripego.BalanceTransactionTypeConnectCollectionTransfer, SettlementTypeTransfer},
+		{stripego.BalanceTransactionTypeAdjustment, SettlementTypeAdjustment},
+		{stripego.BalanceTransactionTypeContribution, SettlementTypeOther},
+		{stripego.BalanceTransactionTypeTopup, SettlementTypeOther},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.stripeType), func(t *testing.T) {
+			result := mapTransactionType(tt.stripeType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCentsToDecimal(t *testing.T) {
+	tests := []struct {
+		cents    int64
+		expected string
+	}{
+		{1000, "10"},
+		{999, "9.99"},
+		{1, "0.01"},
+		{0, "0"},
+		{-500, "-5"},
+		{-1, "-0.01"},
+		{100050, "1000.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := centsToDecimal(tt.cents)
+			assert.Equal(t, tt.expected, result.String())
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Implement `BalanceTransactionClient` wrapping Stripe `V1BalanceTransactions.List()` with cursor pagination, date range filtering, and Connected Account routing via `Stripe-Account` header
- Add `SettlementTransformer` mapping Stripe `BalanceTransaction` to reconciliation domain `SettlementSnapshot` with type mapping (payment, refund, payout, fee, dispute, transfer, adjustment) and NOSTRO_VOSTRO data source registration
- Create `SettlementIngestor` orchestrating the daily fetch-transform-persist workflow with idempotent cleanup, proper settlement run lifecycle (PENDING -> RUNNING -> COMPLETED/FAILED), and configurable timeout
- Register Stripe as NOSTRO_VOSTRO data source via snapshot attributes

## Technical Details

- Uses stripe-go v82 `Seq2` iterator pattern for automatic pagination
- Converts Stripe amounts from smallest currency unit (cents) to `decimal.Decimal`
- Maps 20+ Stripe balance transaction types to 8 normalized settlement types
- Safety cap at 100,000 transactions per fetch to prevent unbounded memory growth
- All errors are wrapped static errors per project linting rules

## Testing

- 40+ unit tests covering:
  - Client validation, pagination, date range params, Connected Account header, API errors
  - Transformer type mapping for all major Stripe transaction types, currency normalization, attribute population
  - Ingestor lifecycle: success, empty results, fetch errors, batch insert errors, run creation errors
  - `IngestPreviousDay` convenience method period calculation

## Task Master

Tag: stripe-connect, Task: 11