### PR TITLE
feat: Implement CEL extension functions for forward curve consumption

### DIFF
--- a/services/gateway/cache/forward_curve_cache.go
+++ b/services/gateway/cache/forward_curve_cache.go
@@ -1,0 +1,455 @@
+// Package cache provides tiered caching for forward curve observations
+// used by gateway CEL extension functions.
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/redis/go-redis/v9"
+	"github.com/shopspring/decimal"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Default configuration values for the forward curve cache.
+const (
+	DefaultL1Size   = 10000
+	DefaultL1TTL    = 5 * time.Minute
+	DefaultL1Jitter = 30 * time.Second
+	DefaultL2TTL    = 30 * time.Minute
+	DefaultL2Prefix = "fwd"
+)
+
+// Errors returned by the forward curve cache.
+var (
+	ErrTenantContextRequired = errors.New("tenant context required")
+	ErrObservationNotFound   = errors.New("forward curve observation not found")
+	ErrUnexpectedResultType  = errors.New("unexpected result type from singleflight")
+)
+
+// Prometheus metrics for forward curve cache.
+var (
+	cacheHitsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "forward_curve_cache_hits_total",
+			Help: "Total forward curve cache hits by level",
+		},
+		[]string{"level"},
+	)
+
+	cacheLatency = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "forward_curve_cache_latency_seconds",
+			Help:    "Forward curve cache lookup latency by level",
+			Buckets: []float64{.0001, .0005, .001, .005, .01, .05, .1, .5, 1},
+		},
+		[]string{"level"},
+	)
+
+	celEvaluationsTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "forward_curve_cel_evaluations_total",
+			Help: "Total CEL forward curve function evaluations",
+		},
+		[]string{"function"},
+	)
+)
+
+// Observation represents a cached forward curve observation.
+type Observation struct {
+	Value       decimal.Decimal   `json:"value"`
+	Unit        string            `json:"unit"`
+	Quality     string            `json:"quality"`
+	ObservedAt  time.Time         `json:"observed_at"`
+	ValidFrom   time.Time         `json:"valid_from"`
+	ValidTo     time.Time         `json:"valid_to"`
+	DataSetCode string            `json:"dataset_code"`
+	SourceID    string            `json:"source_id"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// l1Entry wraps an Observation with TTL tracking.
+type l1Entry struct {
+	obs       *Observation
+	expiresAt time.Time
+}
+
+// l1Key is the key for the L1 in-memory cache.
+type l1Key struct {
+	TenantID      string
+	ResolutionKey string
+	HourEpoch     int64
+}
+
+// Source queries the Market Data Service for forward curve observations.
+type Source interface {
+	// GetForwardPrice queries MDS for a single forward curve observation.
+	// Returns ErrObservationNotFound if no matching observation exists.
+	GetForwardPrice(ctx context.Context, resolutionKey string, ts time.Time) (*Observation, error)
+
+	// GetForwardPriceRange queries MDS for observations in a time range.
+	GetForwardPriceRange(ctx context.Context, resolutionKey string, start, end time.Time) ([]*Observation, error)
+}
+
+// L2Client defines the interface for the Redis L2 cache layer.
+type L2Client interface {
+	Get(ctx context.Context, key string) *redis.StringCmd
+	Set(ctx context.Context, key string, value interface{}, expiration time.Duration) *redis.StatusCmd
+	Del(ctx context.Context, keys ...string) *redis.IntCmd
+}
+
+// ForwardCurveCache provides tiered caching for forward curve observations:
+//   - L1: In-memory LRU with TTL (fast, per-instance)
+//   - L2: Redis with TTL (shared across instances)
+//   - L3: MDS gRPC query (source of truth)
+//
+// Thread-safety: All methods are safe for concurrent use.
+type ForwardCurveCache struct {
+	l1      *lru.Cache[l1Key, *l1Entry]
+	l2      L2Client
+	source  Source
+	sfGroup singleflight.Group
+
+	l1TTL    time.Duration
+	l1Jitter time.Duration
+	l2TTL    time.Duration
+	l2Prefix string
+
+	// Stats counters (atomic)
+	l1Hits      int64
+	l1Misses    int64
+	l2Hits      int64
+	l2Misses    int64
+	sourceLoads int64
+}
+
+// Option configures a ForwardCurveCache.
+type Option func(*ForwardCurveCache)
+
+// WithL1Size sets the maximum number of entries in the L1 cache.
+func WithL1Size(size int) Option {
+	return func(c *ForwardCurveCache) {
+		newL1, err := lru.New[l1Key, *l1Entry](size)
+		if err == nil {
+			c.l1 = newL1
+		}
+	}
+}
+
+// WithL1TTL sets the base TTL and jitter for L1 cache entries.
+func WithL1TTL(ttl, jitter time.Duration) Option {
+	return func(c *ForwardCurveCache) {
+		c.l1TTL = ttl
+		c.l1Jitter = jitter
+	}
+}
+
+// WithL2TTL sets the TTL for L2 (Redis) cache entries.
+func WithL2TTL(ttl time.Duration) Option {
+	return func(c *ForwardCurveCache) {
+		c.l2TTL = ttl
+	}
+}
+
+// WithL2Prefix sets the key prefix for L2 (Redis) cache entries.
+func WithL2Prefix(prefix string) Option {
+	return func(c *ForwardCurveCache) {
+		c.l2Prefix = prefix
+	}
+}
+
+// NewForwardCurveCache creates a new tiered forward curve cache.
+// If l2 is nil, L2 caching is disabled (L1 -> L3 only).
+func NewForwardCurveCache(source Source, l2 L2Client, opts ...Option) (*ForwardCurveCache, error) {
+	l1, err := lru.New[l1Key, *l1Entry](DefaultL1Size)
+	if err != nil {
+		return nil, fmt.Errorf("create L1 cache: %w", err)
+	}
+
+	c := &ForwardCurveCache{
+		l1:       l1,
+		l2:       l2,
+		source:   source,
+		l1TTL:    DefaultL1TTL,
+		l1Jitter: DefaultL1Jitter,
+		l2TTL:    DefaultL2TTL,
+		l2Prefix: DefaultL2Prefix,
+	}
+
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c, nil
+}
+
+// Get retrieves a forward curve observation for the given resolution key and timestamp.
+// Implements the tiered lookup: L1 -> L2 -> L3 (MDS).
+func (c *ForwardCurveCache) Get(ctx context.Context, resolutionKey string, ts time.Time) (*Observation, error) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil, ErrTenantContextRequired
+	}
+
+	hourEpoch := truncateToHour(ts)
+	key := l1Key{
+		TenantID:      string(tenantID),
+		ResolutionKey: resolutionKey,
+		HourEpoch:     hourEpoch,
+	}
+
+	// L1 lookup
+	start := time.Now()
+	if entry, found := c.l1.Get(key); found {
+		if time.Now().Before(entry.expiresAt) {
+			atomic.AddInt64(&c.l1Hits, 1)
+			cacheHitsTotal.WithLabelValues("local").Inc()
+			cacheLatency.WithLabelValues("local").Observe(time.Since(start).Seconds())
+			return entry.obs, nil
+		}
+		c.l1.Remove(key)
+	}
+	atomic.AddInt64(&c.l1Misses, 1)
+
+	// Singleflight to deduplicate concurrent lookups
+	sfKey := fmt.Sprintf("%s:%s:%d", tenantID, resolutionKey, hourEpoch)
+	result, err, _ := c.sfGroup.Do(sfKey, func() (interface{}, error) {
+		// Double-check L1 after acquiring singleflight slot
+		if entry, found := c.l1.Get(key); found && time.Now().Before(entry.expiresAt) {
+			return entry.obs, nil
+		}
+
+		// L2 lookup
+		obs := c.getFromL2(ctx, string(tenantID), resolutionKey, hourEpoch)
+		if obs != nil {
+			atomic.AddInt64(&c.l2Hits, 1)
+			cacheHitsTotal.WithLabelValues("redis").Inc()
+			c.putL1(key, obs)
+			return obs, nil
+		}
+		atomic.AddInt64(&c.l2Misses, 1)
+		cacheHitsTotal.WithLabelValues("miss").Inc()
+
+		// L3 lookup (source of truth)
+		start := time.Now()
+		obs, err := c.source.GetForwardPrice(ctx, resolutionKey, ts)
+		cacheLatency.WithLabelValues("source").Observe(time.Since(start).Seconds())
+		if err != nil {
+			return nil, err
+		}
+		atomic.AddInt64(&c.sourceLoads, 1)
+
+		// Populate L2 (best-effort)
+		c.putL2(ctx, string(tenantID), resolutionKey, hourEpoch, obs)
+
+		// Populate L1
+		c.putL1(key, obs)
+
+		return obs, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	obs, ok := result.(*Observation)
+	if !ok {
+		return nil, ErrUnexpectedResultType
+	}
+
+	return obs, nil
+}
+
+// GetRange retrieves multiple forward curve observations in a time range.
+// Tries L1/L2 for each hourly bucket, falls back to L3 for misses.
+func (c *ForwardCurveCache) GetRange(ctx context.Context, resolutionKey string, start, end time.Time) ([]*Observation, error) {
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		return nil, ErrTenantContextRequired
+	}
+
+	var observations []*Observation
+
+	// Iterate over hourly buckets
+	current := start.Truncate(time.Hour)
+	endTrunc := end.Truncate(time.Hour)
+	if end.After(endTrunc) {
+		endTrunc = endTrunc.Add(time.Hour)
+	}
+
+	var missStart *time.Time
+	var missEnd *time.Time
+
+	for !current.After(endTrunc) {
+		hourEpoch := current.Unix()
+		key := l1Key{
+			TenantID:      string(tenantID),
+			ResolutionKey: resolutionKey,
+			HourEpoch:     hourEpoch,
+		}
+
+		// Try L1
+		if entry, found := c.l1.Get(key); found && time.Now().Before(entry.expiresAt) {
+			observations = append(observations, entry.obs)
+			current = current.Add(time.Hour)
+			continue
+		}
+
+		// Try L2
+		obs := c.getFromL2(ctx, string(tenantID), resolutionKey, hourEpoch)
+		if obs != nil {
+			c.putL1(key, obs)
+			observations = append(observations, obs)
+			current = current.Add(time.Hour)
+			continue
+		}
+
+		// Track the range of cache misses
+		t := current
+		if missStart == nil {
+			missStart = &t
+		}
+		missEnd = &t
+
+		current = current.Add(time.Hour)
+	}
+
+	// If we had cache misses, bulk-query the source
+	if missStart != nil {
+		rangeObs, err := c.source.GetForwardPriceRange(ctx, resolutionKey, *missStart, missEnd.Add(time.Hour))
+		if err != nil {
+			return nil, err
+		}
+
+		// Populate caches and merge results
+		for _, obs := range rangeObs {
+			hourEpoch := truncateToHour(obs.ValidFrom)
+			key := l1Key{
+				TenantID:      string(tenantID),
+				ResolutionKey: resolutionKey,
+				HourEpoch:     hourEpoch,
+			}
+			c.putL1(key, obs)
+			c.putL2(ctx, string(tenantID), resolutionKey, hourEpoch, obs)
+			observations = append(observations, obs)
+		}
+	}
+
+	return observations, nil
+}
+
+// Invalidate removes a specific entry from L1 cache.
+func (c *ForwardCurveCache) Invalidate(tenantID string, resolutionKey string, ts time.Time) {
+	key := l1Key{
+		TenantID:      tenantID,
+		ResolutionKey: resolutionKey,
+		HourEpoch:     truncateToHour(ts),
+	}
+	c.l1.Remove(key)
+}
+
+// Stats returns cache statistics.
+type Stats struct {
+	L1Hits      int64
+	L1Misses    int64
+	L2Hits      int64
+	L2Misses    int64
+	SourceLoads int64
+	L1Size      int
+}
+
+// Stats returns current cache statistics.
+func (c *ForwardCurveCache) Stats() Stats {
+	return Stats{
+		L1Hits:      atomic.LoadInt64(&c.l1Hits),
+		L1Misses:    atomic.LoadInt64(&c.l1Misses),
+		L2Hits:      atomic.LoadInt64(&c.l2Hits),
+		L2Misses:    atomic.LoadInt64(&c.l2Misses),
+		SourceLoads: atomic.LoadInt64(&c.sourceLoads),
+		L1Size:      c.l1.Len(),
+	}
+}
+
+// putL1 stores an observation in the L1 cache with jittered TTL.
+func (c *ForwardCurveCache) putL1(key l1Key, obs *Observation) {
+	c.l1.Add(key, &l1Entry{
+		obs:       obs,
+		expiresAt: time.Now().Add(c.jitteredL1TTL()),
+	})
+}
+
+// getFromL2 retrieves an observation from the L2 Redis cache.
+// Returns nil on cache miss, error, or if Redis is unavailable.
+func (c *ForwardCurveCache) getFromL2(ctx context.Context, tenantID, resolutionKey string, hourEpoch int64) *Observation {
+	if c.l2 == nil {
+		return nil
+	}
+
+	start := time.Now()
+	redisKey := c.l2Key(tenantID, resolutionKey, hourEpoch)
+	val, err := c.l2.Get(ctx, redisKey).Result()
+	cacheLatency.WithLabelValues("redis").Observe(time.Since(start).Seconds())
+
+	if err != nil {
+		return nil
+	}
+
+	var obs Observation
+	if err := json.Unmarshal([]byte(val), &obs); err != nil {
+		return nil
+	}
+
+	return &obs
+}
+
+// putL2 stores an observation in the L2 Redis cache (best-effort).
+func (c *ForwardCurveCache) putL2(ctx context.Context, tenantID, resolutionKey string, hourEpoch int64, obs *Observation) {
+	if c.l2 == nil {
+		return
+	}
+
+	data, err := json.Marshal(obs)
+	if err != nil {
+		return
+	}
+
+	redisKey := c.l2Key(tenantID, resolutionKey, hourEpoch)
+	c.l2.Set(ctx, redisKey, data, c.l2TTL)
+}
+
+// l2Key builds the Redis key for a forward curve cache entry.
+// Format: fwd:{tenant_id}:{resolution_key}:{hour_epoch}
+func (c *ForwardCurveCache) l2Key(tenantID, resolutionKey string, hourEpoch int64) string {
+	return c.l2Prefix + ":" + tenantID + ":" + resolutionKey + ":" + strconv.FormatInt(hourEpoch, 10)
+}
+
+// jitteredL1TTL returns the base L1 TTL plus random jitter.
+func (c *ForwardCurveCache) jitteredL1TTL() time.Duration {
+	if c.l1Jitter == 0 {
+		return c.l1TTL
+	}
+	jitterRange := int64(c.l1Jitter) * 2
+	jitter := rand.Int64N(jitterRange) - int64(c.l1Jitter)
+	return c.l1TTL + time.Duration(jitter)
+}
+
+// truncateToHour returns the Unix timestamp of the hour containing ts.
+func truncateToHour(ts time.Time) int64 {
+	return ts.Truncate(time.Hour).Unix()
+}
+
+// RecordCELEvaluation increments the CEL evaluation counter for a function.
+func RecordCELEvaluation(function string) {
+	celEvaluationsTotal.WithLabelValues(function).Inc()
+}

--- a/services/gateway/cache/forward_curve_cache.go
+++ b/services/gateway/cache/forward_curve_cache.go
@@ -290,12 +290,9 @@ func (c *ForwardCurveCache) GetRange(ctx context.Context, resolutionKey string, 
 		return nil, ErrTenantContextRequired
 	}
 
-	// Iterate over hourly buckets
+	// Iterate over hourly buckets (inclusive of the hour containing end)
 	current := start.Truncate(time.Hour)
 	endTrunc := end.Truncate(time.Hour)
-	if end.After(endTrunc) {
-		endTrunc = endTrunc.Add(time.Hour)
-	}
 
 	// Collect hourly epochs in order and observations by epoch
 	var hours []int64

--- a/services/gateway/cache/forward_curve_cache.go
+++ b/services/gateway/cache/forward_curve_cache.go
@@ -36,6 +36,7 @@ var (
 	ErrTenantContextRequired = errors.New("tenant context required")
 	ErrObservationNotFound   = errors.New("forward curve observation not found")
 	ErrUnexpectedResultType  = errors.New("unexpected result type from singleflight")
+	ErrNilSource             = errors.New("source must not be nil")
 )
 
 // Prometheus metrics for forward curve cache.
@@ -175,8 +176,12 @@ func WithL2Prefix(prefix string) Option {
 }
 
 // NewForwardCurveCache creates a new tiered forward curve cache.
-// If l2 is nil, L2 caching is disabled (L1 -> L3 only).
+// Source must not be nil. If l2 is nil, L2 caching is disabled (L1 -> L3 only).
 func NewForwardCurveCache(source Source, l2 L2Client, opts ...Option) (*ForwardCurveCache, error) {
+	if source == nil {
+		return nil, ErrNilSource
+	}
+
 	l1, err := lru.New[l1Key, *l1Entry](DefaultL1Size)
 	if err != nil {
 		return nil, fmt.Errorf("create L1 cache: %w", err)
@@ -308,10 +313,13 @@ func (c *ForwardCurveCache) GetRange(ctx context.Context, resolutionKey string, 
 		}
 
 		// Try L1
-		if entry, found := c.l1.Get(key); found && time.Now().Before(entry.expiresAt) {
-			obsByEpoch[hourEpoch] = entry.obs
-			current = current.Add(time.Hour)
-			continue
+		if entry, found := c.l1.Get(key); found {
+			if time.Now().Before(entry.expiresAt) {
+				obsByEpoch[hourEpoch] = entry.obs
+				current = current.Add(time.Hour)
+				continue
+			}
+			c.l1.Remove(key)
 		}
 
 		// Try L2

--- a/services/gateway/cache/forward_curve_cache.go
+++ b/services/gateway/cache/forward_curve_cache.go
@@ -295,8 +295,8 @@ func (c *ForwardCurveCache) GetRange(ctx context.Context, resolutionKey string, 
 	// Collect hourly epochs in order and observations by epoch
 	var hours []int64
 	obsByEpoch := make(map[int64]*Observation)
-	var missStart *time.Time
-	var missEnd *time.Time
+	var missStart, missEnd time.Time
+	var haveMiss bool
 
 	for !current.After(endTrunc) {
 		hourEpoch := current.Unix()
@@ -324,18 +324,18 @@ func (c *ForwardCurveCache) GetRange(ctx context.Context, resolutionKey string, 
 		}
 
 		// Track the range of cache misses
-		t := current
-		if missStart == nil {
-			missStart = &t
+		if !haveMiss {
+			missStart = current
+			haveMiss = true
 		}
-		missEnd = &t
+		missEnd = current
 
 		current = current.Add(time.Hour)
 	}
 
 	// If we had cache misses, bulk-query the source
-	if missStart != nil {
-		rangeObs, err := c.source.GetForwardPriceRange(ctx, resolutionKey, *missStart, missEnd.Add(time.Hour))
+	if haveMiss {
+		rangeObs, err := c.source.GetForwardPriceRange(ctx, resolutionKey, missStart, missEnd.Add(time.Hour))
 		if err != nil {
 			return nil, err
 		}
@@ -452,7 +452,7 @@ func (c *ForwardCurveCache) l2Key(tenantID, resolutionKey string, hourEpoch int6
 
 // jitteredL1TTL returns the base L1 TTL plus random jitter.
 func (c *ForwardCurveCache) jitteredL1TTL() time.Duration {
-	if c.l1Jitter == 0 {
+	if c.l1Jitter <= 0 {
 		return c.l1TTL
 	}
 	jitterRange := int64(c.l1Jitter) * 2

--- a/services/gateway/cache/forward_curve_cache.go
+++ b/services/gateway/cache/forward_curve_cache.go
@@ -138,12 +138,17 @@ type ForwardCurveCache struct {
 type Option func(*ForwardCurveCache)
 
 // WithL1Size sets the maximum number of entries in the L1 cache.
+// Size must be positive; non-positive values are ignored.
 func WithL1Size(size int) Option {
 	return func(c *ForwardCurveCache) {
-		newL1, err := lru.New[l1Key, *l1Entry](size)
-		if err == nil {
-			c.l1 = newL1
+		if size <= 0 {
+			return
 		}
+		newL1, err := lru.New[l1Key, *l1Entry](size)
+		if err != nil {
+			return
+		}
+		c.l1 = newL1
 	}
 }
 
@@ -273,13 +278,12 @@ func (c *ForwardCurveCache) Get(ctx context.Context, resolutionKey string, ts ti
 
 // GetRange retrieves multiple forward curve observations in a time range.
 // Tries L1/L2 for each hourly bucket, falls back to L3 for misses.
+// Results are returned in chronological order by ValidFrom.
 func (c *ForwardCurveCache) GetRange(ctx context.Context, resolutionKey string, start, end time.Time) ([]*Observation, error) {
 	tenantID, ok := tenant.FromContext(ctx)
 	if !ok {
 		return nil, ErrTenantContextRequired
 	}
-
-	var observations []*Observation
 
 	// Iterate over hourly buckets
 	current := start.Truncate(time.Hour)
@@ -288,11 +292,15 @@ func (c *ForwardCurveCache) GetRange(ctx context.Context, resolutionKey string, 
 		endTrunc = endTrunc.Add(time.Hour)
 	}
 
+	// Collect hourly epochs in order and observations by epoch
+	var hours []int64
+	obsByEpoch := make(map[int64]*Observation)
 	var missStart *time.Time
 	var missEnd *time.Time
 
 	for !current.After(endTrunc) {
 		hourEpoch := current.Unix()
+		hours = append(hours, hourEpoch)
 		key := l1Key{
 			TenantID:      string(tenantID),
 			ResolutionKey: resolutionKey,
@@ -301,7 +309,7 @@ func (c *ForwardCurveCache) GetRange(ctx context.Context, resolutionKey string, 
 
 		// Try L1
 		if entry, found := c.l1.Get(key); found && time.Now().Before(entry.expiresAt) {
-			observations = append(observations, entry.obs)
+			obsByEpoch[hourEpoch] = entry.obs
 			current = current.Add(time.Hour)
 			continue
 		}
@@ -310,7 +318,7 @@ func (c *ForwardCurveCache) GetRange(ctx context.Context, resolutionKey string, 
 		obs := c.getFromL2(ctx, string(tenantID), resolutionKey, hourEpoch)
 		if obs != nil {
 			c.putL1(key, obs)
-			observations = append(observations, obs)
+			obsByEpoch[hourEpoch] = obs
 			current = current.Add(time.Hour)
 			continue
 		}
@@ -332,7 +340,7 @@ func (c *ForwardCurveCache) GetRange(ctx context.Context, resolutionKey string, 
 			return nil, err
 		}
 
-		// Populate caches and merge results
+		// Populate caches and index by epoch
 		for _, obs := range rangeObs {
 			hourEpoch := truncateToHour(obs.ValidFrom)
 			key := l1Key{
@@ -342,6 +350,14 @@ func (c *ForwardCurveCache) GetRange(ctx context.Context, resolutionKey string, 
 			}
 			c.putL1(key, obs)
 			c.putL2(ctx, string(tenantID), resolutionKey, hourEpoch, obs)
+			obsByEpoch[hourEpoch] = obs
+		}
+	}
+
+	// Assemble results in chronological order
+	observations := make([]*Observation, 0, len(obsByEpoch))
+	for _, epoch := range hours {
+		if obs, ok := obsByEpoch[epoch]; ok {
 			observations = append(observations, obs)
 		}
 	}

--- a/services/gateway/cache/forward_curve_cache_test.go
+++ b/services/gateway/cache/forward_curve_cache_test.go
@@ -1,0 +1,314 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// stubSource implements Source for testing.
+type stubSource struct {
+	obs        map[string]*Observation
+	rangeObs   map[string][]*Observation
+	calls      int64
+	rangeCalls int64
+	err        error
+}
+
+func newStubSource() *stubSource {
+	return &stubSource{
+		obs:      make(map[string]*Observation),
+		rangeObs: make(map[string][]*Observation),
+	}
+}
+
+func (s *stubSource) GetForwardPrice(_ context.Context, resolutionKey string, ts time.Time) (*Observation, error) {
+	atomic.AddInt64(&s.calls, 1)
+	if s.err != nil {
+		return nil, s.err
+	}
+	key := resolutionKey + ":" + ts.Truncate(time.Hour).Format(time.RFC3339)
+	obs, ok := s.obs[key]
+	if !ok {
+		return nil, ErrObservationNotFound
+	}
+	return obs, nil
+}
+
+func (s *stubSource) GetForwardPriceRange(_ context.Context, resolutionKey string, start, end time.Time) ([]*Observation, error) {
+	atomic.AddInt64(&s.rangeCalls, 1)
+	if s.err != nil {
+		return nil, s.err
+	}
+	key := resolutionKey + ":" + start.Format(time.RFC3339) + "-" + end.Format(time.RFC3339)
+	obs, ok := s.rangeObs[key]
+	if !ok {
+		return nil, nil
+	}
+	return obs, nil
+}
+
+func (s *stubSource) addObs(resolutionKey string, ts time.Time, value string) {
+	hour := ts.Truncate(time.Hour)
+	key := resolutionKey + ":" + hour.Format(time.RFC3339)
+	s.obs[key] = &Observation{
+		Value:       decimal.RequireFromString(value),
+		Unit:        "GBP/kWh",
+		Quality:     "ESTIMATE",
+		ObservedAt:  time.Now(),
+		ValidFrom:   hour,
+		ValidTo:     hour.Add(time.Hour),
+		DataSetCode: "ELEC_FORWARD",
+		SourceID:    "test-source",
+	}
+}
+
+func tenantCtx(t *testing.T) context.Context {
+	t.Helper()
+	return tenant.WithTenant(context.Background(), "test-tenant")
+}
+
+func TestForwardCurveCache_L1Hit(t *testing.T) {
+	source := newStubSource()
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	source.addObs("ELEC_PEAK", ts, "45.50")
+
+	cache, err := NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+
+	// First call: L3 miss -> populates L1
+	obs1, err := cache.Get(ctx, "ELEC_PEAK", ts)
+	require.NoError(t, err)
+	assert.Equal(t, "45.5", obs1.Value.String())
+	assert.Equal(t, int64(1), atomic.LoadInt64(&source.calls))
+
+	// Second call: L1 hit -> no source call
+	obs2, err := cache.Get(ctx, "ELEC_PEAK", ts)
+	require.NoError(t, err)
+	assert.Equal(t, "45.5", obs2.Value.String())
+	assert.Equal(t, int64(1), atomic.LoadInt64(&source.calls))
+
+	stats := cache.Stats()
+	assert.Equal(t, int64(1), stats.L1Hits)
+	assert.Equal(t, int64(1), stats.SourceLoads)
+}
+
+func TestForwardCurveCache_L2Hit(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	source := newStubSource()
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	source.addObs("ELEC_PEAK", ts, "45.50")
+
+	cache1, err := NewForwardCurveCache(source, rdb, WithL1TTL(50*time.Millisecond, 0))
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+
+	// First call: L3 -> L2 + L1
+	obs, err := cache1.Get(ctx, "ELEC_PEAK", ts)
+	require.NoError(t, err)
+	assert.Equal(t, "45.5", obs.Value.String())
+
+	// Wait for L1 to expire
+	time.Sleep(60 * time.Millisecond)
+
+	// Second call: L2 hit (L1 expired)
+	obs2, err := cache1.Get(ctx, "ELEC_PEAK", ts)
+	require.NoError(t, err)
+	assert.Equal(t, "45.5", obs2.Value.String())
+
+	// Source should only be called once
+	assert.Equal(t, int64(1), atomic.LoadInt64(&source.calls))
+
+	stats := cache1.Stats()
+	assert.Equal(t, int64(1), stats.L2Hits)
+}
+
+func TestForwardCurveCache_L3Miss(t *testing.T) {
+	source := newStubSource()
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	cache, err := NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+
+	// No observation in source -> ErrObservationNotFound
+	_, err = cache.Get(ctx, "NONEXISTENT", ts)
+	assert.ErrorIs(t, err, ErrObservationNotFound)
+}
+
+func TestForwardCurveCache_TenantContextRequired(t *testing.T) {
+	source := newStubSource()
+	cache, err := NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	// No tenant in context
+	_, err = cache.Get(context.Background(), "ELEC_PEAK", time.Now())
+	assert.ErrorIs(t, err, ErrTenantContextRequired)
+}
+
+func TestForwardCurveCache_L1TTLExpiry(t *testing.T) {
+	source := newStubSource()
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	source.addObs("ELEC_PEAK", ts, "45.50")
+
+	// Short TTL for testing
+	cache, err := NewForwardCurveCache(source, nil, WithL1TTL(50*time.Millisecond, 0))
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+
+	// First call -> populates L1
+	_, err = cache.Get(ctx, "ELEC_PEAK", ts)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&source.calls))
+
+	// Wait for TTL expiry
+	time.Sleep(60 * time.Millisecond)
+
+	// Should re-query source after TTL expiry
+	_, err = cache.Get(ctx, "ELEC_PEAK", ts)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), atomic.LoadInt64(&source.calls))
+}
+
+func TestForwardCurveCache_RedisFailureGraceful(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	source := newStubSource()
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	source.addObs("ELEC_PEAK", ts, "45.50")
+
+	cache, err := NewForwardCurveCache(source, rdb, WithL1TTL(50*time.Millisecond, 0))
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+
+	// First call -> L3 + populate L2
+	obs, err := cache.Get(ctx, "ELEC_PEAK", ts)
+	require.NoError(t, err)
+	assert.Equal(t, "45.5", obs.Value.String())
+
+	// Shut down Redis
+	mr.Close()
+
+	// Wait for L1 to expire
+	time.Sleep(60 * time.Millisecond)
+
+	// Should degrade gracefully: L2 fails -> L3
+	obs2, err := cache.Get(ctx, "ELEC_PEAK", ts)
+	require.NoError(t, err)
+	assert.Equal(t, "45.5", obs2.Value.String())
+
+	// Source called twice (initial + after Redis failure)
+	assert.Equal(t, int64(2), atomic.LoadInt64(&source.calls))
+}
+
+func TestForwardCurveCache_HourTruncation(t *testing.T) {
+	source := newStubSource()
+	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	source.addObs("ELEC_PEAK", ts, "45.50")
+
+	cache, err := NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+
+	// Query at 10:15 and 10:45 should both resolve to the 10:00 bucket
+	obs1, err := cache.Get(ctx, "ELEC_PEAK", ts.Add(15*time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, "45.5", obs1.Value.String())
+
+	obs2, err := cache.Get(ctx, "ELEC_PEAK", ts.Add(45*time.Minute))
+	require.NoError(t, err)
+	assert.Equal(t, "45.5", obs2.Value.String())
+
+	// Only one source call for the same hour bucket
+	assert.Equal(t, int64(1), atomic.LoadInt64(&source.calls))
+}
+
+func TestForwardCurveCache_Invalidate(t *testing.T) {
+	source := newStubSource()
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	source.addObs("ELEC_PEAK", ts, "45.50")
+
+	cache, err := NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+
+	// Populate cache
+	_, err = cache.Get(ctx, "ELEC_PEAK", ts)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), atomic.LoadInt64(&source.calls))
+
+	// Invalidate
+	cache.Invalidate("test-tenant", "ELEC_PEAK", ts)
+
+	// Should re-query source
+	_, err = cache.Get(ctx, "ELEC_PEAK", ts)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), atomic.LoadInt64(&source.calls))
+}
+
+func TestForwardCurveCache_SourceError(t *testing.T) {
+	source := newStubSource()
+	source.err = errors.New("MDS unavailable")
+
+	cache, err := NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+
+	_, err = cache.Get(ctx, "ELEC_PEAK", time.Now())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "MDS unavailable")
+}
+
+func TestForwardCurveCache_L2KeyFormat(t *testing.T) {
+	source := newStubSource()
+	cache, err := NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	key := cache.l2Key("tenant-1", "ELEC_PEAK", 1705312800)
+	assert.Equal(t, "fwd:tenant-1:ELEC_PEAK:1705312800", key)
+}
+
+func TestForwardCurveCache_NilL2(t *testing.T) {
+	source := newStubSource()
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	source.addObs("ELEC_PEAK", ts, "45.50")
+
+	// nil L2 should work (L1 -> L3 only)
+	cache, err := NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+	obs, err := cache.Get(ctx, "ELEC_PEAK", ts)
+	require.NoError(t, err)
+	assert.Equal(t, "45.5", obs.Value.String())
+}
+
+func TestTruncateToHour(t *testing.T) {
+	ts := time.Date(2026, 1, 15, 10, 45, 30, 123, time.UTC)
+	expected := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC).Unix()
+	assert.Equal(t, expected, truncateToHour(ts))
+}

--- a/services/gateway/cache/mds_source.go
+++ b/services/gateway/cache/mds_source.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -77,7 +78,12 @@ func (s *MDSSource) GetForwardPriceRange(ctx context.Context, resolutionKey stri
 	for _, proto := range resp.Observations {
 		obs, err := protoToObservation(proto)
 		if err != nil {
-			continue // skip malformed observations
+			slog.Warn("skipping malformed observation",
+				"dataset_code", s.datasetCode,
+				"observation_id", proto.GetId(),
+				"error", err,
+			)
+			continue
 		}
 		obs.Unit = s.unit
 		observations = append(observations, obs)

--- a/services/gateway/cache/mds_source.go
+++ b/services/gateway/cache/mds_source.go
@@ -14,17 +14,23 @@ import (
 
 // MDSSource implements Source by querying the Market Data Service via gRPC.
 // It queries ESTIMATE quality forward curve observations using the ListObservations API.
+//
+// The unit field is set from the DataSetDefinition at construction time, since
+// the MarketPriceObservation proto does not carry unit information directly.
 type MDSSource struct {
 	client      *miclient.Client
 	datasetCode string
+	unit        string
 }
 
 // NewMDSSource creates a new MDSSource that queries forward curve observations
 // from the given MDS client for the specified dataset code.
-func NewMDSSource(client *miclient.Client, datasetCode string) *MDSSource {
+// The unit parameter should come from the DataSetDefinition.unit field.
+func NewMDSSource(client *miclient.Client, datasetCode string, unit string) *MDSSource {
 	return &MDSSource{
 		client:      client,
 		datasetCode: datasetCode,
+		unit:        unit,
 	}
 }
 
@@ -45,7 +51,12 @@ func (s *MDSSource) GetForwardPrice(ctx context.Context, resolutionKey string, t
 		return nil, ErrObservationNotFound
 	}
 
-	return protoToObservation(resp.Observations[0])
+	obs, err := protoToObservation(resp.Observations[0])
+	if err != nil {
+		return nil, err
+	}
+	obs.Unit = s.unit
+	return obs, nil
 }
 
 // GetForwardPriceRange queries MDS for ESTIMATE quality observations in a time range.
@@ -68,6 +79,7 @@ func (s *MDSSource) GetForwardPriceRange(ctx context.Context, resolutionKey stri
 		if err != nil {
 			continue // skip malformed observations
 		}
+		obs.Unit = s.unit
 		observations = append(observations, obs)
 	}
 

--- a/services/gateway/cache/mds_source.go
+++ b/services/gateway/cache/mds_source.go
@@ -1,0 +1,110 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	miclient "github.com/meridianhub/meridian/services/market-information/client"
+)
+
+// MDSSource implements Source by querying the Market Data Service via gRPC.
+// It queries ESTIMATE quality forward curve observations using the ListObservations API.
+type MDSSource struct {
+	client      *miclient.Client
+	datasetCode string
+}
+
+// NewMDSSource creates a new MDSSource that queries forward curve observations
+// from the given MDS client for the specified dataset code.
+func NewMDSSource(client *miclient.Client, datasetCode string) *MDSSource {
+	return &MDSSource{
+		client:      client,
+		datasetCode: datasetCode,
+	}
+}
+
+// GetForwardPrice queries MDS for a single ESTIMATE quality forward curve observation.
+func (s *MDSSource) GetForwardPrice(ctx context.Context, resolutionKey string, ts time.Time) (*Observation, error) {
+	resp, err := s.client.ListObservations(ctx, &marketinformationv1.ListObservationsRequest{
+		DatasetCode:        s.datasetCode,
+		ResolutionKeyValue: resolutionKey,
+		ValidAt:            timestamppb.New(ts),
+		QualityFilter:      marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+		PageSize:           1,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query MDS for forward price: %w", err)
+	}
+
+	if len(resp.Observations) == 0 {
+		return nil, ErrObservationNotFound
+	}
+
+	return protoToObservation(resp.Observations[0])
+}
+
+// GetForwardPriceRange queries MDS for ESTIMATE quality observations in a time range.
+func (s *MDSSource) GetForwardPriceRange(ctx context.Context, resolutionKey string, start, end time.Time) ([]*Observation, error) {
+	resp, err := s.client.ListObservations(ctx, &marketinformationv1.ListObservationsRequest{
+		DatasetCode:        s.datasetCode,
+		ResolutionKeyValue: resolutionKey,
+		ObservedFrom:       timestamppb.New(start),
+		ObservedTo:         timestamppb.New(end),
+		QualityFilter:      marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+		PageSize:           1000,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query MDS for forward price range: %w", err)
+	}
+
+	observations := make([]*Observation, 0, len(resp.Observations))
+	for _, proto := range resp.Observations {
+		obs, err := protoToObservation(proto)
+		if err != nil {
+			continue // skip malformed observations
+		}
+		observations = append(observations, obs)
+	}
+
+	return observations, nil
+}
+
+// protoToObservation converts a proto MarketPriceObservation to a cache Observation.
+func protoToObservation(proto *marketinformationv1.MarketPriceObservation) (*Observation, error) {
+	value, err := decimal.NewFromString(proto.Value)
+	if err != nil {
+		return nil, fmt.Errorf("parse observation value %q: %w", proto.Value, err)
+	}
+
+	obs := &Observation{
+		Value:       value,
+		DataSetCode: proto.DatasetCode,
+		SourceID:    proto.SourceId,
+		Quality:     proto.Quality.String(),
+	}
+
+	if proto.ObservedAt != nil {
+		obs.ObservedAt = proto.ObservedAt.AsTime()
+	}
+	if proto.ValidFrom != nil {
+		obs.ValidFrom = proto.ValidFrom.AsTime()
+	}
+	if proto.ValidTo != nil {
+		obs.ValidTo = proto.ValidTo.AsTime()
+	}
+
+	// Extract metadata from attributes
+	if len(proto.Attributes) > 0 {
+		obs.Metadata = make(map[string]string, len(proto.Attributes))
+		for _, attr := range proto.Attributes {
+			obs.Metadata[attr.Key] = attr.Value
+		}
+	}
+
+	return obs, nil
+}

--- a/services/gateway/cache/mds_source_test.go
+++ b/services/gateway/cache/mds_source_test.go
@@ -1,0 +1,78 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
+	quantityv1 "github.com/meridianhub/meridian/api/proto/meridian/quantity/v1"
+)
+
+func TestProtoToObservation(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	validFrom := now.Add(-time.Hour)
+	validTo := now
+
+	proto := &marketinformationv1.MarketPriceObservation{
+		Id:                 "obs-id",
+		DatasetCode:        "ELEC_FORWARD",
+		DatasetVersion:     1,
+		ResolutionKeyValue: "PEAK_2026Q1",
+		ObservedAt:         timestamppb.New(now),
+		ValidFrom:          timestamppb.New(validFrom),
+		ValidTo:            timestamppb.New(validTo),
+		Value:              "45.50",
+		Quality:            marketinformationv1.QualityLevel_QUALITY_LEVEL_ESTIMATE,
+		SourceId:           "source-123",
+		Attributes: []*quantityv1.AttributeEntry{
+			{Key: "region", Value: "UK"},
+			{Key: "zone", Value: "North"},
+		},
+	}
+
+	obs, err := protoToObservation(proto)
+	require.NoError(t, err)
+
+	assert.True(t, decimal.RequireFromString("45.50").Equal(obs.Value))
+	assert.Equal(t, "ELEC_FORWARD", obs.DataSetCode)
+	assert.Equal(t, "source-123", obs.SourceID)
+	assert.Equal(t, "QUALITY_LEVEL_ESTIMATE", obs.Quality)
+	assert.Equal(t, now, obs.ObservedAt)
+	assert.Equal(t, validFrom, obs.ValidFrom)
+	assert.Equal(t, validTo, obs.ValidTo)
+	assert.Equal(t, "UK", obs.Metadata["region"])
+	assert.Equal(t, "North", obs.Metadata["zone"])
+}
+
+func TestProtoToObservation_InvalidValue(t *testing.T) {
+	proto := &marketinformationv1.MarketPriceObservation{
+		Value: "not-a-number",
+	}
+
+	_, err := protoToObservation(proto)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "parse observation value")
+}
+
+func TestProtoToObservation_NoAttributes(t *testing.T) {
+	proto := &marketinformationv1.MarketPriceObservation{
+		Value:       "10.00",
+		DatasetCode: "TEST",
+		Quality:     marketinformationv1.QualityLevel_QUALITY_LEVEL_ACTUAL,
+	}
+
+	obs, err := protoToObservation(proto)
+	require.NoError(t, err)
+	assert.Nil(t, obs.Metadata)
+}
+
+func TestNewMDSSource(t *testing.T) {
+	// Just verify construction works
+	source := NewMDSSource(nil, "ELEC_FORWARD")
+	assert.Equal(t, "ELEC_FORWARD", source.datasetCode)
+}

--- a/services/gateway/cache/mds_source_test.go
+++ b/services/gateway/cache/mds_source_test.go
@@ -72,7 +72,7 @@ func TestProtoToObservation_NoAttributes(t *testing.T) {
 }
 
 func TestNewMDSSource(t *testing.T) {
-	// Just verify construction works
-	source := NewMDSSource(nil, "ELEC_FORWARD")
+	source := NewMDSSource(nil, "ELEC_FORWARD", "GBP/kWh")
 	assert.Equal(t, "ELEC_FORWARD", source.datasetCode)
+	assert.Equal(t, "GBP/kWh", source.unit)
 }

--- a/services/gateway/cel/forward_curve_functions.go
+++ b/services/gateway/cel/forward_curve_functions.go
@@ -6,6 +6,7 @@ package cel
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/cel-go/cel"
@@ -16,7 +17,12 @@ import (
 	gatewaycache "github.com/meridianhub/meridian/services/gateway/cache"
 )
 
-// ForwardCurveLib creates a CEL function library for forward curve lookups.
+// ForwardCurveLibrary provides CEL extension functions for forward curve lookups.
+// It holds the cache (long-lived) and a per-request context (updated atomically).
+//
+// For environments reused across requests, call SetContext before each evaluation
+// to ensure the correct tenant context is used. For single-request environments,
+// pass the context at construction time via NewForwardCurveLibrary.
 //
 // Functions:
 //   - forward_price(resolution_key string, timestamp) -> double:
@@ -25,23 +31,53 @@ import (
 //     Get observation metadata (unit, quality, dataset_code, source_id).
 //   - avg_forward_price(resolution_key string, start timestamp, end timestamp) -> double:
 //     Average price over a time range.
-func ForwardCurveLib(ctx context.Context, cache *gatewaycache.ForwardCurveCache) cel.EnvOption {
-	return cel.Lib(&forwardCurveLibrary{
-		cache: cache,
-		ctx:   ctx,
-	})
-}
-
-type forwardCurveLibrary struct {
+type ForwardCurveLibrary struct {
 	cache *gatewaycache.ForwardCurveCache
-	ctx   context.Context
+	ctx   atomic.Value // holds context.Context
 }
 
-func (*forwardCurveLibrary) LibraryName() string {
+// NewForwardCurveLibrary creates a new library with the given cache and initial context.
+// The returned library can be reused across requests by calling SetContext before evaluation.
+func NewForwardCurveLibrary(ctx context.Context, cache *gatewaycache.ForwardCurveCache) *ForwardCurveLibrary {
+	lib := &ForwardCurveLibrary{
+		cache: cache,
+	}
+	lib.ctx.Store(ctx)
+	return lib
+}
+
+// SetContext updates the context used for cache lookups. Call this per-request
+// before evaluating a CEL program to ensure the correct tenant context is used.
+// This method is safe for concurrent use.
+func (lib *ForwardCurveLibrary) SetContext(ctx context.Context) {
+	lib.ctx.Store(ctx)
+}
+
+// EnvOption returns a cel.EnvOption that registers this library's functions.
+func (lib *ForwardCurveLibrary) EnvOption() cel.EnvOption {
+	return cel.Lib(lib)
+}
+
+// ForwardCurveLib creates a CEL function library for forward curve lookups.
+// This is a convenience function for single-request usage. For long-lived
+// environments, use NewForwardCurveLibrary and call SetContext per-request.
+func ForwardCurveLib(ctx context.Context, cache *gatewaycache.ForwardCurveCache) cel.EnvOption {
+	return NewForwardCurveLibrary(ctx, cache).EnvOption()
+}
+
+// context returns the current context for cache lookups.
+func (lib *ForwardCurveLibrary) context() context.Context {
+	ctx, _ := lib.ctx.Load().(context.Context)
+	return ctx
+}
+
+// LibraryName implements cel.Library.
+func (*ForwardCurveLibrary) LibraryName() string {
 	return "meridian.ForwardCurve"
 }
 
-func (lib *forwardCurveLibrary) CompileOptions() []cel.EnvOption {
+// CompileOptions implements cel.Library.
+func (lib *ForwardCurveLibrary) CompileOptions() []cel.EnvOption {
 	return []cel.EnvOption{
 		cel.Function("forward_price",
 			cel.Overload("forward_price_string_timestamp",
@@ -67,12 +103,13 @@ func (lib *forwardCurveLibrary) CompileOptions() []cel.EnvOption {
 	}
 }
 
-func (*forwardCurveLibrary) ProgramOptions() []cel.ProgramOption {
+// ProgramOptions implements cel.Library.
+func (*ForwardCurveLibrary) ProgramOptions() []cel.ProgramOption {
 	return nil
 }
 
 // forwardPrice queries a single forward curve observation and returns its value.
-func (lib *forwardCurveLibrary) forwardPrice(lhs ref.Val, rhs ref.Val) ref.Val {
+func (lib *ForwardCurveLibrary) forwardPrice(lhs ref.Val, rhs ref.Val) ref.Val {
 	gatewaycache.RecordCELEvaluation("forward_price")
 
 	resolutionKey, ok := lhs.Value().(string)
@@ -85,7 +122,7 @@ func (lib *forwardCurveLibrary) forwardPrice(lhs ref.Val, rhs ref.Val) ref.Val {
 		return types.NewErr("forward_price: expected timestamp, got %T", rhs.Value())
 	}
 
-	obs, err := lib.cache.Get(lib.ctx, resolutionKey, ts)
+	obs, err := lib.cache.Get(lib.context(), resolutionKey, ts)
 	if err != nil {
 		return types.NewErr("forward_price: %v", err)
 	}
@@ -95,7 +132,7 @@ func (lib *forwardCurveLibrary) forwardPrice(lhs ref.Val, rhs ref.Val) ref.Val {
 }
 
 // forwardMetadata queries a forward curve observation and returns its metadata.
-func (lib *forwardCurveLibrary) forwardMetadata(lhs ref.Val, rhs ref.Val) ref.Val {
+func (lib *ForwardCurveLibrary) forwardMetadata(lhs ref.Val, rhs ref.Val) ref.Val {
 	gatewaycache.RecordCELEvaluation("forward_metadata")
 
 	resolutionKey, ok := lhs.Value().(string)
@@ -108,7 +145,7 @@ func (lib *forwardCurveLibrary) forwardMetadata(lhs ref.Val, rhs ref.Val) ref.Va
 		return types.NewErr("forward_metadata: expected timestamp, got %T", rhs.Value())
 	}
 
-	obs, err := lib.cache.Get(lib.ctx, resolutionKey, ts)
+	obs, err := lib.cache.Get(lib.context(), resolutionKey, ts)
 	if err != nil {
 		return types.NewErr("forward_metadata: %v", err)
 	}
@@ -134,7 +171,7 @@ func (lib *forwardCurveLibrary) forwardMetadata(lhs ref.Val, rhs ref.Val) ref.Va
 }
 
 // avgForwardPrice computes the arithmetic mean of forward prices over a time range.
-func (lib *forwardCurveLibrary) avgForwardPrice(args ...ref.Val) ref.Val {
+func (lib *ForwardCurveLibrary) avgForwardPrice(args ...ref.Val) ref.Val {
 	gatewaycache.RecordCELEvaluation("avg_forward_price")
 
 	if len(args) != 3 {
@@ -160,7 +197,7 @@ func (lib *forwardCurveLibrary) avgForwardPrice(args ...ref.Val) ref.Val {
 		return types.NewErr("avg_forward_price: start must be before end")
 	}
 
-	observations, err := lib.cache.GetRange(lib.ctx, resolutionKey, start, end)
+	observations, err := lib.cache.GetRange(lib.context(), resolutionKey, start, end)
 	if err != nil {
 		return types.NewErr("avg_forward_price: %v", err)
 	}
@@ -181,7 +218,9 @@ func (lib *forwardCurveLibrary) avgForwardPrice(args ...ref.Val) ref.Val {
 }
 
 // NewForwardCurveEnv creates a CEL environment with forward curve functions
-// and standard pricing variables.
+// and standard pricing variables. The environment captures the given context;
+// for long-lived environments, use NewForwardCurveLibrary directly and call
+// SetContext before each evaluation.
 func NewForwardCurveEnv(ctx context.Context, cache *gatewaycache.ForwardCurveCache) (*cel.Env, error) {
 	env, err := cel.NewEnv(
 		// Standard pricing variables

--- a/services/gateway/cel/forward_curve_functions.go
+++ b/services/gateway/cel/forward_curve_functions.go
@@ -1,0 +1,202 @@
+// Package cel provides CEL extension functions for forward curve consumption
+// in the gateway service. These functions allow CEL pricing rules to query
+// forward curve observations from the Market Data Service through a tiered cache.
+package cel
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/shopspring/decimal"
+
+	gatewaycache "github.com/meridianhub/meridian/services/gateway/cache"
+)
+
+// ForwardCurveLib creates a CEL function library for forward curve lookups.
+//
+// Functions:
+//   - forward_price(resolution_key string, timestamp) -> double:
+//     Query single forward curve observation value.
+//   - forward_metadata(resolution_key string, timestamp) -> map[string, string]:
+//     Get observation metadata (unit, quality, dataset_code, source_id).
+//   - avg_forward_price(resolution_key string, start timestamp, end timestamp) -> double:
+//     Average price over a time range.
+func ForwardCurveLib(ctx context.Context, cache *gatewaycache.ForwardCurveCache) cel.EnvOption {
+	return cel.Lib(&forwardCurveLibrary{
+		cache: cache,
+		ctx:   ctx,
+	})
+}
+
+type forwardCurveLibrary struct {
+	cache *gatewaycache.ForwardCurveCache
+	ctx   context.Context
+}
+
+func (*forwardCurveLibrary) LibraryName() string {
+	return "meridian.ForwardCurve"
+}
+
+func (lib *forwardCurveLibrary) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Function("forward_price",
+			cel.Overload("forward_price_string_timestamp",
+				[]*cel.Type{cel.StringType, cel.TimestampType},
+				cel.DoubleType,
+				cel.BinaryBinding(lib.forwardPrice),
+			),
+		),
+		cel.Function("forward_metadata",
+			cel.Overload("forward_metadata_string_timestamp",
+				[]*cel.Type{cel.StringType, cel.TimestampType},
+				cel.MapType(cel.StringType, cel.StringType),
+				cel.BinaryBinding(lib.forwardMetadata),
+			),
+		),
+		cel.Function("avg_forward_price",
+			cel.Overload("avg_forward_price_string_timestamp_timestamp",
+				[]*cel.Type{cel.StringType, cel.TimestampType, cel.TimestampType},
+				cel.DoubleType,
+				cel.FunctionBinding(lib.avgForwardPrice),
+			),
+		),
+	}
+}
+
+func (*forwardCurveLibrary) ProgramOptions() []cel.ProgramOption {
+	return nil
+}
+
+// forwardPrice queries a single forward curve observation and returns its value.
+func (lib *forwardCurveLibrary) forwardPrice(lhs ref.Val, rhs ref.Val) ref.Val {
+	gatewaycache.RecordCELEvaluation("forward_price")
+
+	resolutionKey, ok := lhs.Value().(string)
+	if !ok {
+		return types.NewErr("forward_price: expected string resolution_key, got %T", lhs.Value())
+	}
+
+	ts, ok := rhs.Value().(time.Time)
+	if !ok {
+		return types.NewErr("forward_price: expected timestamp, got %T", rhs.Value())
+	}
+
+	obs, err := lib.cache.Get(lib.ctx, resolutionKey, ts)
+	if err != nil {
+		return types.NewErr("forward_price: %v", err)
+	}
+
+	f, _ := obs.Value.Float64()
+	return types.Double(f)
+}
+
+// forwardMetadata queries a forward curve observation and returns its metadata.
+func (lib *forwardCurveLibrary) forwardMetadata(lhs ref.Val, rhs ref.Val) ref.Val {
+	gatewaycache.RecordCELEvaluation("forward_metadata")
+
+	resolutionKey, ok := lhs.Value().(string)
+	if !ok {
+		return types.NewErr("forward_metadata: expected string resolution_key, got %T", lhs.Value())
+	}
+
+	ts, ok := rhs.Value().(time.Time)
+	if !ok {
+		return types.NewErr("forward_metadata: expected timestamp, got %T", rhs.Value())
+	}
+
+	obs, err := lib.cache.Get(lib.ctx, resolutionKey, ts)
+	if err != nil {
+		return types.NewErr("forward_metadata: %v", err)
+	}
+
+	metadata := map[string]string{
+		"unit":         obs.Unit,
+		"quality":      obs.Quality,
+		"dataset_code": obs.DataSetCode,
+		"source_id":    obs.SourceID,
+		"observed_at":  obs.ObservedAt.Format(time.RFC3339),
+		"valid_from":   obs.ValidFrom.Format(time.RFC3339),
+		"valid_to":     obs.ValidTo.Format(time.RFC3339),
+	}
+
+	// Merge any additional metadata from the observation
+	for k, v := range obs.Metadata {
+		metadata[k] = v
+	}
+
+	// Convert to CEL map type
+	adapter := types.DefaultTypeAdapter
+	return types.NewStringStringMap(adapter, metadata)
+}
+
+// avgForwardPrice computes the arithmetic mean of forward prices over a time range.
+func (lib *forwardCurveLibrary) avgForwardPrice(args ...ref.Val) ref.Val {
+	gatewaycache.RecordCELEvaluation("avg_forward_price")
+
+	if len(args) != 3 {
+		return types.NewErr("avg_forward_price: expected 3 arguments, got %d", len(args))
+	}
+
+	resolutionKey, ok := args[0].Value().(string)
+	if !ok {
+		return types.NewErr("avg_forward_price: expected string resolution_key, got %T", args[0].Value())
+	}
+
+	start, ok := args[1].Value().(time.Time)
+	if !ok {
+		return types.NewErr("avg_forward_price: expected start timestamp, got %T", args[1].Value())
+	}
+
+	end, ok := args[2].Value().(time.Time)
+	if !ok {
+		return types.NewErr("avg_forward_price: expected end timestamp, got %T", args[2].Value())
+	}
+
+	if !start.Before(end) {
+		return types.NewErr("avg_forward_price: start must be before end")
+	}
+
+	observations, err := lib.cache.GetRange(lib.ctx, resolutionKey, start, end)
+	if err != nil {
+		return types.NewErr("avg_forward_price: %v", err)
+	}
+
+	if len(observations) == 0 {
+		return types.NewErr("avg_forward_price: no observations found for %s between %s and %s",
+			resolutionKey, start.Format(time.RFC3339), end.Format(time.RFC3339))
+	}
+
+	sum := decimal.Zero
+	for _, obs := range observations {
+		sum = sum.Add(obs.Value)
+	}
+
+	avg := sum.Div(decimal.NewFromInt(int64(len(observations))))
+	f, _ := avg.Float64()
+	return types.Double(f)
+}
+
+// NewForwardCurveEnv creates a CEL environment with forward curve functions
+// and standard pricing variables.
+func NewForwardCurveEnv(ctx context.Context, cache *gatewaycache.ForwardCurveCache) (*cel.Env, error) {
+	env, err := cel.NewEnv(
+		// Standard pricing variables
+		cel.Variable("amount", cel.DoubleType),
+		cel.Variable("quantity", cel.DoubleType),
+		cel.Variable("unit", cel.StringType),
+		cel.Variable("timestamp", cel.TimestampType),
+		cel.Variable("attributes", cel.MapType(cel.StringType, cel.StringType)),
+
+		// Forward curve extension functions
+		ForwardCurveLib(ctx, cache),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create forward curve CEL environment: %w", err)
+	}
+
+	return env, nil
+}

--- a/services/gateway/cel/forward_curve_functions_test.go
+++ b/services/gateway/cel/forward_curve_functions_test.go
@@ -252,13 +252,56 @@ func TestAvgForwardPrice_StartAfterEnd(t *testing.T) {
 }
 
 func TestForwardCurveLib_LibraryName(t *testing.T) {
-	lib := &forwardCurveLibrary{}
+	lib := &ForwardCurveLibrary{}
 	assert.Equal(t, "meridian.ForwardCurve", lib.LibraryName())
 }
 
 func TestForwardCurveLib_ProgramOptions(t *testing.T) {
-	lib := &forwardCurveLibrary{}
+	lib := &ForwardCurveLibrary{}
 	assert.Nil(t, lib.ProgramOptions())
+}
+
+func TestSetContext_UpdatesTenantContext(t *testing.T) {
+	source := newStubSource()
+	ts := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	source.addObs("ELEC_PEAK", ts, "45.50")
+
+	cache, err := gatewaycache.NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	// Create library with initial context
+	initialCtx := tenantCtx(t)
+	lib := NewForwardCurveLibrary(initialCtx, cache)
+
+	env, err := cel.NewEnv(
+		cel.Variable("timestamp", cel.TimestampType),
+		lib.EnvOption(),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`forward_price("ELEC_PEAK", timestamp)`)
+	require.Nil(t, issues)
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	// Evaluate with initial context
+	out, _, err := prg.Eval(map[string]interface{}{
+		"timestamp": ts,
+	})
+	require.NoError(t, err)
+	assert.InDelta(t, 45.50, out.Value().(float64), 0.001)
+
+	// Update context to a different tenant and reuse the same program
+	newCtx := tenant.WithTenant(context.Background(), "other-tenant")
+	lib.SetContext(newCtx)
+
+	// Same program, different tenant context - should still work
+	out, _, err = prg.Eval(map[string]interface{}{
+		"timestamp": ts,
+	})
+	require.NoError(t, err)
+	assert.InDelta(t, 45.50, out.Value().(float64), 0.001)
 }
 
 func TestForwardPrice_WithMockedCache(t *testing.T) {

--- a/services/gateway/cel/forward_curve_functions_test.go
+++ b/services/gateway/cel/forward_curve_functions_test.go
@@ -1,0 +1,348 @@
+package cel
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gatewaycache "github.com/meridianhub/meridian/services/gateway/cache"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// stubSource implements cache.Source for testing.
+type stubSource struct {
+	obs        map[string]*gatewaycache.Observation
+	rangeObs   map[string][]*gatewaycache.Observation
+	calls      int64
+	rangeCalls int64
+	err        error
+}
+
+func newStubSource() *stubSource {
+	return &stubSource{
+		obs:      make(map[string]*gatewaycache.Observation),
+		rangeObs: make(map[string][]*gatewaycache.Observation),
+	}
+}
+
+func (s *stubSource) GetForwardPrice(_ context.Context, resolutionKey string, ts time.Time) (*gatewaycache.Observation, error) {
+	atomic.AddInt64(&s.calls, 1)
+	if s.err != nil {
+		return nil, s.err
+	}
+	key := resolutionKey + ":" + ts.Truncate(time.Hour).Format(time.RFC3339)
+	obs, ok := s.obs[key]
+	if !ok {
+		return nil, gatewaycache.ErrObservationNotFound
+	}
+	return obs, nil
+}
+
+func (s *stubSource) GetForwardPriceRange(_ context.Context, resolutionKey string, start, end time.Time) ([]*gatewaycache.Observation, error) {
+	atomic.AddInt64(&s.rangeCalls, 1)
+	if s.err != nil {
+		return nil, s.err
+	}
+	key := resolutionKey + ":" + start.Format(time.RFC3339) + "-" + end.Format(time.RFC3339)
+	obs, ok := s.rangeObs[key]
+	if !ok {
+		return nil, nil
+	}
+	return obs, nil
+}
+
+func (s *stubSource) addObs(resolutionKey string, ts time.Time, value string) {
+	hour := ts.Truncate(time.Hour)
+	key := resolutionKey + ":" + hour.Format(time.RFC3339)
+	s.obs[key] = &gatewaycache.Observation{
+		Value:       decimal.RequireFromString(value),
+		Unit:        "GBP/kWh",
+		Quality:     "ESTIMATE",
+		ObservedAt:  time.Date(2026, 1, 14, 8, 0, 0, 0, time.UTC),
+		ValidFrom:   hour,
+		ValidTo:     hour.Add(time.Hour),
+		DataSetCode: "ELEC_FORWARD",
+		SourceID:    "test-source-id",
+		Metadata: map[string]string{
+			"region": "UK",
+		},
+	}
+}
+
+func tenantCtx(t *testing.T) context.Context {
+	t.Helper()
+	return tenant.WithTenant(context.Background(), "test-tenant")
+}
+
+func TestForwardPrice_Compile_Evaluate(t *testing.T) {
+	source := newStubSource()
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	source.addObs("ELEC_PEAK", ts, "45.50")
+
+	cache, err := gatewaycache.NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+	env, err := NewForwardCurveEnv(ctx, cache)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`forward_price("ELEC_PEAK", timestamp)`)
+	require.Nil(t, issues, "compilation failed: %v", issues)
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]interface{}{
+		"timestamp": ts,
+	})
+	require.NoError(t, err)
+
+	assert.InDelta(t, 45.50, out.Value().(float64), 0.001)
+}
+
+func TestForwardPrice_NonExistentResolutionKey(t *testing.T) {
+	source := newStubSource()
+
+	cache, err := gatewaycache.NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+	env, err := NewForwardCurveEnv(ctx, cache)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`forward_price("NONEXISTENT", timestamp)`)
+	require.Nil(t, issues)
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	_, _, err = prg.Eval(map[string]interface{}{
+		"timestamp": time.Now(),
+	})
+	// CEL wraps errors in ref.Val, so Eval returns error for forward_price errors
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "forward_price")
+}
+
+func TestForwardMetadata(t *testing.T) {
+	source := newStubSource()
+	ts := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+	source.addObs("ELEC_PEAK", ts, "45.50")
+
+	cache, err := gatewaycache.NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+	env, err := NewForwardCurveEnv(ctx, cache)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`forward_metadata("ELEC_PEAK", timestamp)`)
+	require.Nil(t, issues)
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]interface{}{
+		"timestamp": ts,
+	})
+	require.NoError(t, err)
+
+	// Result should be a map
+	result := out.Value().(map[string]string)
+	assert.Equal(t, "GBP/kWh", result["unit"])
+	assert.Equal(t, "ESTIMATE", result["quality"])
+	assert.Equal(t, "ELEC_FORWARD", result["dataset_code"])
+	assert.Equal(t, "test-source-id", result["source_id"])
+	assert.Equal(t, "UK", result["region"])
+}
+
+func TestAvgForwardPrice_24hWindow(t *testing.T) {
+	source := newStubSource()
+	start := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 1, 16, 0, 0, 0, 0, time.UTC)
+
+	// Create 24 hourly observations (values from 40.0 to 63.0)
+	var rangeObs []*gatewaycache.Observation
+	for i := 0; i < 24; i++ {
+		hour := start.Add(time.Duration(i) * time.Hour)
+		value := decimal.NewFromFloat(40.0 + float64(i))
+		obs := &gatewaycache.Observation{
+			Value:       value,
+			Unit:        "GBP/kWh",
+			Quality:     "ESTIMATE",
+			ObservedAt:  time.Date(2026, 1, 14, 8, 0, 0, 0, time.UTC),
+			ValidFrom:   hour,
+			ValidTo:     hour.Add(time.Hour),
+			DataSetCode: "ELEC_FORWARD",
+			SourceID:    "test-source-id",
+		}
+		rangeObs = append(rangeObs, obs)
+
+		// Also add individually for L1 cache
+		key := "ELEC_PEAK:" + hour.Format(time.RFC3339)
+		source.obs[key] = obs
+	}
+
+	// Register range obs
+	rangeKey := "ELEC_PEAK:" + start.Format(time.RFC3339) + "-" + end.Add(time.Hour).Format(time.RFC3339)
+	source.rangeObs[rangeKey] = rangeObs
+
+	cache, err := gatewaycache.NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+	env, err := cel.NewEnv(
+		cel.Variable("start_time", cel.TimestampType),
+		cel.Variable("end_time", cel.TimestampType),
+		ForwardCurveLib(ctx, cache),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`avg_forward_price("ELEC_PEAK", start_time, end_time)`)
+	require.Nil(t, issues)
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]interface{}{
+		"start_time": start,
+		"end_time":   end,
+	})
+	require.NoError(t, err)
+
+	// Average of 40..63 = (40+63)/2 = 51.5
+	assert.InDelta(t, 51.5, out.Value().(float64), 0.001)
+}
+
+func TestAvgForwardPrice_StartAfterEnd(t *testing.T) {
+	source := newStubSource()
+
+	cache, err := gatewaycache.NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+	env, err := cel.NewEnv(
+		cel.Variable("start_time", cel.TimestampType),
+		cel.Variable("end_time", cel.TimestampType),
+		ForwardCurveLib(ctx, cache),
+	)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`avg_forward_price("ELEC_PEAK", start_time, end_time)`)
+	require.Nil(t, issues)
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	end := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	start := time.Date(2026, 1, 16, 0, 0, 0, 0, time.UTC)
+
+	_, _, err = prg.Eval(map[string]interface{}{
+		"start_time": start,
+		"end_time":   end,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "start must be before end")
+}
+
+func TestForwardCurveLib_LibraryName(t *testing.T) {
+	lib := &forwardCurveLibrary{}
+	assert.Equal(t, "meridian.ForwardCurve", lib.LibraryName())
+}
+
+func TestForwardCurveLib_ProgramOptions(t *testing.T) {
+	lib := &forwardCurveLibrary{}
+	assert.Nil(t, lib.ProgramOptions())
+}
+
+func TestForwardPrice_WithMockedCache(t *testing.T) {
+	source := newStubSource()
+	ts := time.Date(2026, 6, 1, 14, 0, 0, 0, time.UTC)
+
+	// Add observations at different price points
+	source.addObs("GAS_FORWARD", ts, "2.75")
+	source.addObs("ELEC_PEAK", ts, "85.00")
+
+	cache, err := gatewaycache.NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+	env, err := cel.NewEnv(
+		cel.Variable("timestamp", cel.TimestampType),
+		cel.Variable("quantity", cel.DoubleType),
+		ForwardCurveLib(ctx, cache),
+	)
+	require.NoError(t, err)
+
+	// Test a pricing rule: quantity * forward_price
+	ast, issues := env.Compile(`quantity * forward_price("ELEC_PEAK", timestamp)`)
+	require.Nil(t, issues)
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]interface{}{
+		"timestamp": ts,
+		"quantity":  100.0,
+	})
+	require.NoError(t, err)
+
+	// 100 * 85.00 = 8500.00
+	assert.InDelta(t, 8500.0, out.Value().(float64), 0.001)
+}
+
+func TestNewForwardCurveEnv(t *testing.T) {
+	source := newStubSource()
+	cache, err := gatewaycache.NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+	env, err := NewForwardCurveEnv(ctx, cache)
+	require.NoError(t, err)
+
+	// Verify environment has standard pricing variables
+	ast, issues := env.Compile(`amount + quantity`)
+	require.Nil(t, issues)
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	out, _, err := prg.Eval(map[string]interface{}{
+		"amount":     10.0,
+		"quantity":   5.0,
+		"unit":       "kWh",
+		"timestamp":  time.Now(),
+		"attributes": map[string]string{},
+	})
+	require.NoError(t, err)
+	assert.InDelta(t, 15.0, out.Value().(float64), 0.001)
+}
+
+func TestForwardMetadata_NonExistent(t *testing.T) {
+	source := newStubSource()
+
+	cache, err := gatewaycache.NewForwardCurveCache(source, nil)
+	require.NoError(t, err)
+
+	ctx := tenantCtx(t)
+	env, err := NewForwardCurveEnv(ctx, cache)
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`forward_metadata("NONEXISTENT", timestamp)`)
+	require.Nil(t, issues)
+
+	prg, err := env.Program(ast)
+	require.NoError(t, err)
+
+	_, _, err = prg.Eval(map[string]interface{}{
+		"timestamp": time.Now(),
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "forward_metadata")
+}


### PR DESCRIPTION
## Summary

- Add `forward_price()`, `forward_metadata()`, and `avg_forward_price()` CEL extension functions to the gateway service
- Implement `ForwardCurveCache` with L1 (in-memory LRU, 5min TTL) -> L2 (Redis, 30min TTL) -> L3 (MDS gRPC) tiered lookup
- Add `MDSSource` adapter bridging the cache to the MDS `ListObservations` API for ESTIMATE quality forward curve observations
- Include Prometheus metrics: `forward_curve_cache_hits_total{level}`, `forward_curve_cache_latency_seconds{level}`, `forward_curve_cel_evaluations_total{function}`

## Changes Made

### CEL Extension Functions (`services/gateway/cel/`)
- `forward_price(resolution_key, timestamp) -> double`: Query single forward curve observation value
- `forward_metadata(resolution_key, timestamp) -> map[string,string]`: Get observation metadata (unit, quality, dataset_code, source_id, etc.)
- `avg_forward_price(resolution_key, start, end) -> double`: Arithmetic mean of prices over a time range
- `NewForwardCurveEnv()`: Pre-configured CEL environment with standard pricing variables and forward curve functions

### Tiered Cache (`services/gateway/cache/`)
- `ForwardCurveCache`: Thread-safe tiered cache with singleflight deduplication and tenant isolation
- Cache key format: `fwd:{tenant_id}:{resolution_key}:{hour_epoch}`
- L1: hashicorp/golang-lru with TTL jitter to prevent thundering herd
- L2: Redis with JSON serialization, graceful degradation on failure
- L3: MDS gRPC via configurable `Source` interface
- `MDSSource`: Production adapter querying MDS `ListObservations` for ESTIMATE quality observations

## Technical Details

- CEL functions follow existing `cel.Lib` pattern from `services/reference-data/cel/compiler.go`
- Cache follows existing `TieredInstrumentCache` pattern from `services/reference-data/cache/`
- Timestamp resolution truncated to hour boundaries for cache key stability
- Decimal precision maintained through `shopspring/decimal` until final CEL double conversion
- Uses `miniredis` for Redis integration tests

## Testing

- 12 cache tests: L1 hit, L2 hit, L3 miss, TTL expiry, Redis failure graceful degradation, hour truncation, invalidation, source error, key format, nil L2
- 10 CEL function tests: compile+evaluate, non-existent key, metadata extraction, 24h avg window, start-after-end validation, pricing rule integration (quantity * forward_price)
- 3 MDS source tests: proto conversion, invalid value, no attributes

## Task Reference

Implements market-data-dynamic-pricing.11