### PR TITLE
feat: Add Stripe webhook signature validation and event parsing

### DIFF
--- a/api/proto/meridian/payment_order/v1/payment_order.proto
+++ b/api/proto/meridian/payment_order/v1/payment_order.proto
@@ -117,6 +117,10 @@ enum GatewayStatus {
   GATEWAY_STATUS_REJECTED = 2;
   // GATEWAY_STATUS_PENDING means the gateway is still processing the payment.
   GATEWAY_STATUS_PENDING = 3;
+  // GATEWAY_STATUS_REFUNDED means the gateway has confirmed a refund was processed.
+  GATEWAY_STATUS_REFUNDED = 4;
+  // GATEWAY_STATUS_DISPUTED means the payment is under dispute (chargeback).
+  GATEWAY_STATUS_DISPUTED = 5;
 }
 
 // LienExecutionStatus tracks the status of lien execution for completed payment orders.

--- a/services/payment-order/adapters/gateway/stripe/webhook_adapter.go
+++ b/services/payment-order/adapters/gateway/stripe/webhook_adapter.go
@@ -1,0 +1,183 @@
+package stripe
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	stripego "github.com/stripe/stripe-go/v82"
+	"github.com/stripe/stripe-go/v82/webhook"
+)
+
+// Webhook adapter errors.
+var (
+	ErrEmptyEndpointSecret     = errors.New("webhook endpoint secret cannot be empty")
+	ErrWebhookInvalidSignature = errors.New("invalid stripe webhook signature")
+	ErrWebhookMissingSignature = errors.New("missing Stripe-Signature header")
+	ErrWebhookUnsupportedEvent = errors.New("unsupported stripe event type")
+)
+
+// Stripe event type constants handled by this adapter.
+const (
+	EventPaymentIntentSucceeded = "payment_intent.succeeded"
+	EventPaymentIntentFailed    = "payment_intent.payment_failed"
+	EventChargeRefunded         = "charge.refunded"
+	EventChargeDisputeCreated   = "charge.dispute.created"
+)
+
+// ParsedWebhookEvent represents a Stripe webhook event translated into the
+// payment-order domain. The http package converts this to WebhookRequest
+// for processing through the existing pipeline.
+type ParsedWebhookEvent struct {
+	GatewayReferenceID string
+	PaymentOrderID     string
+	Status             string
+	Message            string
+	Timestamp          time.Time
+}
+
+// WebhookAdapter validates Stripe webhook signatures and translates
+// Stripe events into ParsedWebhookEvent for the payment-order service.
+type WebhookAdapter struct {
+	endpointSecret string
+}
+
+// NewWebhookAdapter creates a new WebhookAdapter with the given
+// per-tenant webhook endpoint secret.
+func NewWebhookAdapter(endpointSecret string) (*WebhookAdapter, error) {
+	if endpointSecret == "" {
+		return nil, ErrEmptyEndpointSecret
+	}
+	return &WebhookAdapter{
+		endpointSecret: endpointSecret,
+	}, nil
+}
+
+// ParseWebhook validates the Stripe-Signature header using HMAC-SHA256 and
+// translates the Stripe event into a ParsedWebhookEvent. The body parameter
+// should be the raw request body bytes (read before calling this method).
+func (a *WebhookAdapter) ParseWebhook(r *http.Request, body []byte) (ParsedWebhookEvent, error) {
+	sigHeader := r.Header.Get("Stripe-Signature")
+	if sigHeader == "" {
+		return ParsedWebhookEvent{}, ErrWebhookMissingSignature
+	}
+
+	event, err := webhook.ConstructEventWithOptions(body, sigHeader, a.endpointSecret, webhook.ConstructEventOptions{
+		IgnoreAPIVersionMismatch: true,
+	})
+	if err != nil {
+		return ParsedWebhookEvent{}, ErrWebhookInvalidSignature
+	}
+
+	switch string(event.Type) {
+	case EventPaymentIntentSucceeded:
+		return a.parsePaymentIntentSucceeded(&event)
+	case EventPaymentIntentFailed:
+		return a.parsePaymentIntentFailed(&event)
+	case EventChargeRefunded:
+		return a.parseChargeRefunded(&event)
+	case EventChargeDisputeCreated:
+		return a.parseChargeDisputed(&event)
+	default:
+		return ParsedWebhookEvent{}, ErrWebhookUnsupportedEvent
+	}
+}
+
+func (a *WebhookAdapter) parsePaymentIntentSucceeded(event *stripego.Event) (ParsedWebhookEvent, error) {
+	var pi stripego.PaymentIntent
+	if err := json.Unmarshal(event.Data.Raw, &pi); err != nil {
+		return ParsedWebhookEvent{}, err
+	}
+
+	return ParsedWebhookEvent{
+		GatewayReferenceID: pi.ID,
+		PaymentOrderID:     pi.Metadata["payment_order_id"],
+		Status:             "SETTLED",
+		Timestamp:          time.Unix(event.Created, 0),
+	}, nil
+}
+
+func (a *WebhookAdapter) parsePaymentIntentFailed(event *stripego.Event) (ParsedWebhookEvent, error) {
+	var pi stripego.PaymentIntent
+	if err := json.Unmarshal(event.Data.Raw, &pi); err != nil {
+		return ParsedWebhookEvent{}, err
+	}
+
+	var message string
+	if pi.LastPaymentError != nil {
+		message = pi.LastPaymentError.Msg
+	}
+
+	return ParsedWebhookEvent{
+		GatewayReferenceID: pi.ID,
+		PaymentOrderID:     pi.Metadata["payment_order_id"],
+		Status:             "REJECTED",
+		Message:            message,
+		Timestamp:          time.Unix(event.Created, 0),
+	}, nil
+}
+
+func (a *WebhookAdapter) parseChargeRefunded(event *stripego.Event) (ParsedWebhookEvent, error) {
+	var charge stripego.Charge
+	if err := json.Unmarshal(event.Data.Raw, &charge); err != nil {
+		return ParsedWebhookEvent{}, err
+	}
+
+	paymentOrderID := extractPaymentOrderID(&charge)
+
+	return ParsedWebhookEvent{
+		GatewayReferenceID: charge.ID,
+		PaymentOrderID:     paymentOrderID,
+		Status:             "REFUNDED",
+		Timestamp:          time.Unix(event.Created, 0),
+	}, nil
+}
+
+// disputeData holds the fields we need from a Stripe Dispute event.
+// We use a minimal struct instead of stripe.Dispute because the SDK's
+// Dispute type expects charge as a string ID, but webhook payloads
+// deliver an expanded charge object.
+type disputeData struct {
+	ID     string `json:"id"`
+	Reason string `json:"reason"`
+	Status string `json:"status"`
+	Charge struct {
+		ID       string            `json:"id"`
+		Metadata map[string]string `json:"metadata"`
+	} `json:"charge"`
+}
+
+func (a *WebhookAdapter) parseChargeDisputed(event *stripego.Event) (ParsedWebhookEvent, error) {
+	var dispute disputeData
+	if err := json.Unmarshal(event.Data.Raw, &dispute); err != nil {
+		return ParsedWebhookEvent{}, err
+	}
+
+	var paymentOrderID string
+	if dispute.Charge.Metadata != nil {
+		paymentOrderID = dispute.Charge.Metadata["payment_order_id"]
+	}
+
+	return ParsedWebhookEvent{
+		GatewayReferenceID: dispute.Charge.ID,
+		PaymentOrderID:     paymentOrderID,
+		Status:             "DISPUTED",
+		Message:            "dispute reason: " + dispute.Reason,
+		Timestamp:          time.Unix(event.Created, 0),
+	}, nil
+}
+
+// extractPaymentOrderID extracts the payment_order_id from a Charge,
+// preferring the PaymentIntent metadata, falling back to charge metadata.
+func extractPaymentOrderID(charge *stripego.Charge) string {
+	if charge.PaymentIntent != nil && charge.PaymentIntent.Metadata != nil {
+		if poID, ok := charge.PaymentIntent.Metadata["payment_order_id"]; ok {
+			return poID
+		}
+	}
+	if charge.Metadata != nil {
+		return charge.Metadata["payment_order_id"]
+	}
+	return ""
+}

--- a/services/payment-order/adapters/gateway/stripe/webhook_adapter_test.go
+++ b/services/payment-order/adapters/gateway/stripe/webhook_adapter_test.go
@@ -1,0 +1,311 @@
+package stripe
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/v82/webhook"
+)
+
+const testAdapterSecret = "whsec_test_adapter_secret"
+
+// buildStripeEventPayload creates a Stripe event JSON payload for testing.
+func buildStripeEventPayload(t *testing.T, eventID, eventType string, data map[string]any) []byte {
+	t.Helper()
+	payload := map[string]any{
+		"id":      eventID,
+		"type":    eventType,
+		"created": time.Now().Unix(),
+		"data": map[string]any{
+			"object": data,
+		},
+	}
+	out, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return out
+}
+
+func signAdapterPayload(t *testing.T, payload []byte, secret string) string {
+	t.Helper()
+	signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+		Payload: payload,
+		Secret:  secret,
+	})
+	return signed.Header
+}
+
+func TestNewWebhookAdapter(t *testing.T) {
+	t.Run("valid secret", func(t *testing.T) {
+		adapter, err := NewWebhookAdapter(testAdapterSecret)
+		require.NoError(t, err)
+		assert.NotNil(t, adapter)
+	})
+
+	t.Run("empty secret", func(t *testing.T) {
+		adapter, err := NewWebhookAdapter("")
+		assert.ErrorIs(t, err, ErrEmptyEndpointSecret)
+		assert.Nil(t, adapter)
+	})
+}
+
+func TestStripeWebhookAdapter_ParseWebhook_PaymentIntentSucceeded(t *testing.T) {
+	adapter, err := NewWebhookAdapter(testAdapterSecret)
+	require.NoError(t, err)
+
+	payload := buildStripeEventPayload(t, "evt_succeeded_1", "payment_intent.succeeded", map[string]any{
+		"id":       "pi_test_123",
+		"object":   "payment_intent",
+		"amount":   10000,
+		"currency": "gbp",
+		"metadata": map[string]string{
+			"payment_order_id": "po-order-456",
+		},
+		"latest_charge": map[string]any{
+			"id":     "ch_charge_789",
+			"object": "charge",
+		},
+		"status": "succeeded",
+	})
+	sig := signAdapterPayload(t, payload, testAdapterSecret)
+
+	req := &http.Request{Header: http.Header{}}
+	req.Header.Set("Stripe-Signature", sig)
+
+	result, err := adapter.ParseWebhook(req, payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, "pi_test_123", result.GatewayReferenceID)
+	assert.Equal(t, "po-order-456", result.PaymentOrderID)
+	assert.Equal(t, "SETTLED", result.Status)
+	assert.False(t, result.Timestamp.IsZero())
+}
+
+func TestStripeWebhookAdapter_ParseWebhook_PaymentIntentFailed(t *testing.T) {
+	adapter, err := NewWebhookAdapter(testAdapterSecret)
+	require.NoError(t, err)
+
+	payload := buildStripeEventPayload(t, "evt_failed_1", "payment_intent.payment_failed", map[string]any{
+		"id":       "pi_fail_123",
+		"object":   "payment_intent",
+		"amount":   5000,
+		"currency": "gbp",
+		"metadata": map[string]string{
+			"payment_order_id": "po-order-789",
+		},
+		"status": "requires_payment_method",
+		"last_payment_error": map[string]any{
+			"message": "Your card was declined",
+			"code":    "card_declined",
+		},
+	})
+	sig := signAdapterPayload(t, payload, testAdapterSecret)
+
+	req := &http.Request{Header: http.Header{}}
+	req.Header.Set("Stripe-Signature", sig)
+
+	result, err := adapter.ParseWebhook(req, payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, "pi_fail_123", result.GatewayReferenceID)
+	assert.Equal(t, "po-order-789", result.PaymentOrderID)
+	assert.Equal(t, "REJECTED", result.Status)
+	assert.Equal(t, "Your card was declined", result.Message)
+}
+
+func TestStripeWebhookAdapter_ParseWebhook_ChargeRefunded(t *testing.T) {
+	adapter, err := NewWebhookAdapter(testAdapterSecret)
+	require.NoError(t, err)
+
+	payload := buildStripeEventPayload(t, "evt_refund_1", "charge.refunded", map[string]any{
+		"id":              "ch_refund_123",
+		"object":          "charge",
+		"amount_refunded": 3000,
+		"currency":        "gbp",
+		"metadata":        map[string]string{},
+		"payment_intent": map[string]any{
+			"id":     "pi_original_123",
+			"object": "payment_intent",
+			"metadata": map[string]string{
+				"payment_order_id": "po-order-refund",
+			},
+		},
+	})
+	sig := signAdapterPayload(t, payload, testAdapterSecret)
+
+	req := &http.Request{Header: http.Header{}}
+	req.Header.Set("Stripe-Signature", sig)
+
+	result, err := adapter.ParseWebhook(req, payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ch_refund_123", result.GatewayReferenceID)
+	assert.Equal(t, "po-order-refund", result.PaymentOrderID)
+	assert.Equal(t, "REFUNDED", result.Status)
+}
+
+func TestStripeWebhookAdapter_ParseWebhook_ChargeDisputed(t *testing.T) {
+	adapter, err := NewWebhookAdapter(testAdapterSecret)
+	require.NoError(t, err)
+
+	payload := buildStripeEventPayload(t, "evt_dispute_1", "charge.dispute.created", map[string]any{
+		"id":     "dp_dispute_123",
+		"object": "dispute",
+		"charge": map[string]any{
+			"id":     "ch_disputed_charge",
+			"object": "charge",
+			"metadata": map[string]string{
+				"payment_order_id": "po-order-dispute",
+			},
+		},
+		"status": "needs_response",
+		"reason": "fraudulent",
+	})
+	sig := signAdapterPayload(t, payload, testAdapterSecret)
+
+	req := &http.Request{Header: http.Header{}}
+	req.Header.Set("Stripe-Signature", sig)
+
+	result, err := adapter.ParseWebhook(req, payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ch_disputed_charge", result.GatewayReferenceID)
+	assert.Equal(t, "po-order-dispute", result.PaymentOrderID)
+	assert.Equal(t, "DISPUTED", result.Status)
+	assert.Contains(t, result.Message, "fraudulent")
+}
+
+func TestStripeWebhookAdapter_ParseWebhook_InvalidSignature(t *testing.T) {
+	adapter, err := NewWebhookAdapter(testAdapterSecret)
+	require.NoError(t, err)
+
+	payload := buildStripeEventPayload(t, "evt_1", "payment_intent.succeeded", map[string]any{
+		"id":     "pi_test",
+		"object": "payment_intent",
+	})
+	// Sign with wrong secret
+	sig := signAdapterPayload(t, payload, "whsec_wrong_secret")
+
+	req := &http.Request{Header: http.Header{}}
+	req.Header.Set("Stripe-Signature", sig)
+
+	_, err = adapter.ParseWebhook(req, payload)
+	assert.ErrorIs(t, err, ErrWebhookInvalidSignature)
+}
+
+func TestStripeWebhookAdapter_ParseWebhook_MissingSignature(t *testing.T) {
+	adapter, err := NewWebhookAdapter(testAdapterSecret)
+	require.NoError(t, err)
+
+	payload := []byte(`{"id":"evt_1","type":"payment_intent.succeeded"}`)
+
+	req := &http.Request{Header: http.Header{}}
+	// No Stripe-Signature header
+
+	_, err = adapter.ParseWebhook(req, payload)
+	assert.ErrorIs(t, err, ErrWebhookMissingSignature)
+}
+
+func TestStripeWebhookAdapter_ParseWebhook_UnsupportedEventType(t *testing.T) {
+	adapter, err := NewWebhookAdapter(testAdapterSecret)
+	require.NoError(t, err)
+
+	payload := buildStripeEventPayload(t, "evt_unknown_1", "customer.created", map[string]any{
+		"id":     "cus_123",
+		"object": "customer",
+	})
+	sig := signAdapterPayload(t, payload, testAdapterSecret)
+
+	req := &http.Request{Header: http.Header{}}
+	req.Header.Set("Stripe-Signature", sig)
+
+	_, err = adapter.ParseWebhook(req, payload)
+	assert.ErrorIs(t, err, ErrWebhookUnsupportedEvent)
+}
+
+func TestStripeWebhookAdapter_ParseWebhook_MetadataExtraction(t *testing.T) {
+	adapter, err := NewWebhookAdapter(testAdapterSecret)
+	require.NoError(t, err)
+
+	t.Run("payment_order_id from PI metadata", func(t *testing.T) {
+		payload := buildStripeEventPayload(t, "evt_meta_1", "payment_intent.succeeded", map[string]any{
+			"id":       "pi_meta_test",
+			"object":   "payment_intent",
+			"amount":   1000,
+			"currency": "usd",
+			"metadata": map[string]string{
+				"payment_order_id": "po-from-metadata",
+			},
+			"latest_charge": map[string]any{
+				"id":     "ch_meta",
+				"object": "charge",
+			},
+			"status": "succeeded",
+		})
+		sig := signAdapterPayload(t, payload, testAdapterSecret)
+
+		req := &http.Request{Header: http.Header{}}
+		req.Header.Set("Stripe-Signature", sig)
+
+		result, err := adapter.ParseWebhook(req, payload)
+		require.NoError(t, err)
+		assert.Equal(t, "po-from-metadata", result.PaymentOrderID)
+	})
+
+	t.Run("no payment_order_id still succeeds", func(t *testing.T) {
+		payload := buildStripeEventPayload(t, "evt_meta_2", "payment_intent.succeeded", map[string]any{
+			"id":       "pi_no_po_id",
+			"object":   "payment_intent",
+			"amount":   1000,
+			"currency": "usd",
+			"metadata": map[string]string{},
+			"latest_charge": map[string]any{
+				"id":     "ch_meta_2",
+				"object": "charge",
+			},
+			"status": "succeeded",
+		})
+		sig := signAdapterPayload(t, payload, testAdapterSecret)
+
+		req := &http.Request{Header: http.Header{}}
+		req.Header.Set("Stripe-Signature", sig)
+
+		result, err := adapter.ParseWebhook(req, payload)
+		require.NoError(t, err)
+		assert.Equal(t, "pi_no_po_id", result.GatewayReferenceID)
+		assert.Empty(t, result.PaymentOrderID)
+	})
+}
+
+func TestStripeWebhookAdapter_ParseWebhook_RefundMetadataFallback(t *testing.T) {
+	adapter, err := NewWebhookAdapter(testAdapterSecret)
+	require.NoError(t, err)
+
+	t.Run("fallback to charge metadata when PI metadata missing", func(t *testing.T) {
+		payload := buildStripeEventPayload(t, "evt_refund_fb", "charge.refunded", map[string]any{
+			"id":              "ch_refund_fallback",
+			"object":          "charge",
+			"amount_refunded": 1500,
+			"currency":        "usd",
+			"metadata": map[string]string{
+				"payment_order_id": "po-from-charge-meta",
+			},
+			"payment_intent": map[string]any{
+				"id":       "pi_no_meta",
+				"object":   "payment_intent",
+				"metadata": map[string]string{},
+			},
+		})
+		sig := signAdapterPayload(t, payload, testAdapterSecret)
+
+		req := &http.Request{Header: http.Header{}}
+		req.Header.Set("Stripe-Signature", sig)
+
+		result, err := adapter.ParseWebhook(req, payload)
+		require.NoError(t, err)
+		assert.Equal(t, "po-from-charge-meta", result.PaymentOrderID)
+	})
+}

--- a/services/payment-order/adapters/http/server.go
+++ b/services/payment-order/adapters/http/server.go
@@ -34,6 +34,8 @@ type ServerConfig struct {
 	Port int
 	// WebhookHandler handles incoming webhooks.
 	WebhookHandler *WebhookHandler
+	// StripeWebhookHandler handles incoming Stripe-specific webhooks (optional).
+	StripeWebhookHandler *StripeWebhookHandler
 	// Logger for request logging.
 	Logger *slog.Logger
 	// RateLimitPerSecond is the max requests per second per IP.
@@ -108,6 +110,9 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 	// Create mux and register handlers
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /webhook/payment-gateway", cfg.WebhookHandler.HandleWebhook)
+	if cfg.StripeWebhookHandler != nil {
+		mux.HandleFunc("POST /webhook/stripe", cfg.StripeWebhookHandler.HandleStripeWebhook)
+	}
 	mux.HandleFunc("GET /health", healthHandler)
 
 	// Apply middleware chain

--- a/services/payment-order/adapters/http/stripe_webhook_handler.go
+++ b/services/payment-order/adapters/http/stripe_webhook_handler.go
@@ -1,0 +1,185 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway/stripe"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Stripe webhook handler errors.
+var (
+	ErrNilClientFactory     = errors.New("stripe client factory cannot be nil")
+	ErrMissingTenantContext = errors.New("missing tenant context for stripe webhook")
+	ErrNoWebhookSecret      = errors.New("no webhook secret configured for tenant")
+)
+
+// StripeWebhookMaxBodySize is the maximum allowed Stripe webhook payload size (512KB).
+const StripeWebhookMaxBodySize = 512 * 1024
+
+// StripeWebhookHandler handles incoming Stripe webhook events by validating
+// the Stripe-Signature, translating events into WebhookRequest, and delegating
+// to the existing webhook processing pipeline.
+type StripeWebhookHandler struct {
+	clientFactory  *stripe.ClientFactory
+	webhookHandler *WebhookHandler
+	logger         *slog.Logger
+}
+
+// StripeWebhookHandlerConfig contains configuration for creating a StripeWebhookHandler.
+type StripeWebhookHandlerConfig struct {
+	ClientFactory  *stripe.ClientFactory
+	WebhookHandler *WebhookHandler
+	Logger         *slog.Logger
+}
+
+// NewStripeWebhookHandler creates a new StripeWebhookHandler.
+func NewStripeWebhookHandler(cfg StripeWebhookHandlerConfig) (*StripeWebhookHandler, error) {
+	if cfg.ClientFactory == nil {
+		return nil, ErrNilClientFactory
+	}
+	if cfg.WebhookHandler == nil {
+		return nil, ErrNilWebhookHandler
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &StripeWebhookHandler{
+		clientFactory:  cfg.ClientFactory,
+		webhookHandler: cfg.WebhookHandler,
+		logger:         logger,
+	}, nil
+}
+
+// HandleStripeWebhook processes incoming Stripe webhook events.
+// It extracts the tenant context, retrieves the tenant-specific webhook secret,
+// validates the Stripe signature, translates the event to a WebhookRequest,
+// and calls UpdatePaymentOrder through the existing webhook handler pipeline.
+func (h *StripeWebhookHandler) HandleStripeWebhook(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	if r.Method != http.MethodPost {
+		h.writeErrorResponse(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	defer func() { _ = r.Body.Close() }()
+
+	// Read body with size limit
+	body, err := io.ReadAll(io.LimitReader(r.Body, StripeWebhookMaxBodySize+1))
+	if err != nil {
+		h.logger.Error("failed to read stripe webhook body", "error", err)
+		h.writeErrorResponse(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if int64(len(body)) > StripeWebhookMaxBodySize {
+		h.writeErrorResponse(w, http.StatusRequestEntityTooLarge, "request body too large")
+		return
+	}
+
+	// Get tenant-specific Stripe client (contains the webhook secret)
+	tenantID, ok := tenant.FromContext(ctx)
+	if !ok {
+		h.logger.Warn("missing tenant context for stripe webhook")
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrMissingTenantContext.Error())
+		return
+	}
+
+	client, err := h.clientFactory.NewClient(ctx)
+	if err != nil {
+		h.logger.Error("failed to get stripe client for tenant",
+			"tenant_id", tenantID.String(),
+			"error", err,
+		)
+		h.writeErrorResponse(w, http.StatusInternalServerError, "failed to resolve tenant configuration")
+		return
+	}
+
+	if client.WebhookEndpointSecret == "" {
+		h.logger.Error("no webhook secret for tenant", "tenant_id", tenantID.String())
+		h.writeErrorResponse(w, http.StatusInternalServerError, ErrNoWebhookSecret.Error())
+		return
+	}
+
+	// Create adapter with tenant-specific secret and parse the webhook
+	adapter, err := stripe.NewWebhookAdapter(client.WebhookEndpointSecret)
+	if err != nil {
+		h.logger.Error("failed to create stripe webhook adapter", "error", err)
+		h.writeErrorResponse(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	parsed, err := adapter.ParseWebhook(r, body)
+	if err != nil {
+		switch {
+		case errors.Is(err, stripe.ErrWebhookInvalidSignature):
+			h.logger.Warn("invalid stripe webhook signature", "tenant_id", tenantID.String())
+			h.writeErrorResponse(w, http.StatusUnauthorized, "invalid webhook signature")
+		case errors.Is(err, stripe.ErrWebhookMissingSignature):
+			h.logger.Warn("missing stripe webhook signature")
+			h.writeErrorResponse(w, http.StatusUnauthorized, "missing Stripe-Signature header")
+		case errors.Is(err, stripe.ErrWebhookUnsupportedEvent):
+			// Acknowledge unsupported events to prevent Stripe retries
+			h.logger.Debug("unsupported stripe event type", "tenant_id", tenantID.String())
+			h.writeSuccessResponse(w, "event type not handled")
+		default:
+			h.logger.Error("failed to parse stripe webhook", "error", err, "tenant_id", tenantID.String())
+			h.writeErrorResponse(w, http.StatusBadRequest, "failed to parse webhook")
+		}
+		return
+	}
+
+	// Convert ParsedWebhookEvent to WebhookRequest
+	webhookReq := WebhookRequest{
+		GatewayReferenceID: parsed.GatewayReferenceID,
+		PaymentOrderID:     parsed.PaymentOrderID,
+		Status:             parsed.Status,
+		Message:            parsed.Message,
+		Timestamp:          parsed.Timestamp,
+	}
+
+	// Map gateway status
+	gatewayStatus, err := mapGatewayStatus(webhookReq.Status)
+	if err != nil {
+		h.logger.Warn("invalid gateway status from stripe adapter",
+			"status", webhookReq.Status,
+			"tenant_id", tenantID.String(),
+		)
+		h.writeErrorResponse(w, http.StatusBadRequest, ErrInvalidGatewayStatus.Error())
+		return
+	}
+
+	idempotencyKey := h.webhookHandler.generateIdempotencyKey(webhookReq)
+
+	h.logger.Info("processing stripe webhook",
+		"gateway_reference_id", webhookReq.GatewayReferenceID,
+		"payment_order_id", webhookReq.PaymentOrderID,
+		"status", webhookReq.Status,
+		"tenant_id", tenantID.String(),
+	)
+
+	h.webhookHandler.processWebhookRequest(ctx, w, webhookReq, gatewayStatus, idempotencyKey)
+}
+
+func (h *StripeWebhookHandler) writeSuccessResponse(w http.ResponseWriter, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	resp := WebhookResponse{Acknowledged: true, Message: message}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		h.logger.Error("failed to encode success response", "error", err)
+	}
+}
+
+func (h *StripeWebhookHandler) writeErrorResponse(w http.ResponseWriter, statusCode int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	resp := WebhookResponse{Acknowledged: false, Error: message}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		h.logger.Error("failed to encode error response", "error", err)
+	}
+}

--- a/services/payment-order/adapters/http/stripe_webhook_handler_test.go
+++ b/services/payment-order/adapters/http/stripe_webhook_handler_test.go
@@ -1,0 +1,253 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stripe/stripe-go/v82/webhook"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
+	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway/stripe"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+const testStripeWebhookSecret = "whsec_test_integration_secret"
+
+func testStripeConfig() stripe.Config {
+	cfg := stripe.DefaultConfig()
+	cfg.APIKey = "sk_test_key"
+	return cfg
+}
+
+// testConfigProvider implements stripe.TenantConfigProvider for testing.
+type testConfigProvider struct {
+	configs map[string]stripe.TenantConfig
+}
+
+func (p *testConfigProvider) GetTenantConfig(tenantID string) (stripe.TenantConfig, error) {
+	cfg, ok := p.configs[tenantID]
+	if !ok {
+		return stripe.TenantConfig{}, stripe.ErrTenantConfigNotFound
+	}
+	return cfg, nil
+}
+
+func buildTestStripePayload(t *testing.T, eventID, eventType string, data map[string]any) []byte {
+	t.Helper()
+	payload := map[string]any{
+		"id":      eventID,
+		"type":    eventType,
+		"created": time.Now().Unix(),
+		"data":    map[string]any{"object": data},
+	}
+	out, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return out
+}
+
+func signTestPayload(t *testing.T, payload []byte, secret string) string {
+	t.Helper()
+	signed := webhook.GenerateTestSignedPayload(&webhook.UnsignedPayload{
+		Payload: payload,
+		Secret:  secret,
+	})
+	return signed.Header
+}
+
+func setupStripeWebhookHandler(t *testing.T) (*StripeWebhookHandler, *mockPaymentOrderService) {
+	t.Helper()
+
+	mockSvc := &mockPaymentOrderService{
+		updateFunc: func(_ context.Context, _ *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error) {
+			return &pb.UpdatePaymentOrderResponse{
+				PaymentOrder: &pb.PaymentOrder{
+					PaymentOrderId: "test-order",
+					Status:         pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+				},
+			}, nil
+		},
+	}
+
+	webhookHandler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: mockSvc,
+		HMACSecret:          []byte("generic-secret"),
+	})
+	require.NoError(t, err)
+
+	provider := &testConfigProvider{
+		configs: map[string]stripe.TenantConfig{
+			"test-tenant": {
+				ConnectedAccountID:    "acct_test_123",
+				WebhookEndpointSecret: testStripeWebhookSecret,
+			},
+		},
+	}
+
+	factory, err := stripe.NewClientFactory(testStripeConfig(), provider, nil)
+	require.NoError(t, err)
+
+	stripeHandler, err := NewStripeWebhookHandler(StripeWebhookHandlerConfig{
+		ClientFactory:  factory,
+		WebhookHandler: webhookHandler,
+	})
+	require.NoError(t, err)
+
+	return stripeHandler, mockSvc
+}
+
+func TestNewStripeWebhookHandler(t *testing.T) {
+	webhookHandler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          []byte("secret"),
+	})
+	require.NoError(t, err)
+
+	provider := &testConfigProvider{configs: map[string]stripe.TenantConfig{}}
+	factory, err := stripe.NewClientFactory(testStripeConfig(), provider, nil)
+	require.NoError(t, err)
+
+	t.Run("valid config", func(t *testing.T) {
+		h, err := NewStripeWebhookHandler(StripeWebhookHandlerConfig{
+			ClientFactory:  factory,
+			WebhookHandler: webhookHandler,
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, h)
+	})
+
+	t.Run("nil client factory", func(t *testing.T) {
+		h, err := NewStripeWebhookHandler(StripeWebhookHandlerConfig{
+			ClientFactory:  nil,
+			WebhookHandler: webhookHandler,
+		})
+		assert.ErrorIs(t, err, ErrNilClientFactory)
+		assert.Nil(t, h)
+	})
+
+	t.Run("nil webhook handler", func(t *testing.T) {
+		h, err := NewStripeWebhookHandler(StripeWebhookHandlerConfig{
+			ClientFactory:  factory,
+			WebhookHandler: nil,
+		})
+		assert.ErrorIs(t, err, ErrNilWebhookHandler)
+		assert.Nil(t, h)
+	})
+}
+
+func TestStripeWebhookHandler_PaymentIntentSucceeded(t *testing.T) {
+	handler, mockSvc := setupStripeWebhookHandler(t)
+
+	var capturedReq *pb.UpdatePaymentOrderRequest
+	mockSvc.updateFunc = func(_ context.Context, req *pb.UpdatePaymentOrderRequest) (*pb.UpdatePaymentOrderResponse, error) {
+		capturedReq = req
+		return &pb.UpdatePaymentOrderResponse{
+			PaymentOrder: &pb.PaymentOrder{
+				PaymentOrderId: "po-settled",
+				Status:         pb.PaymentOrderStatus_PAYMENT_ORDER_STATUS_COMPLETED,
+			},
+		}, nil
+	}
+
+	payload := buildTestStripePayload(t, "evt_1", "payment_intent.succeeded", map[string]any{
+		"id":       "pi_settled_123",
+		"object":   "payment_intent",
+		"amount":   5000,
+		"currency": "gbp",
+		"metadata": map[string]string{"payment_order_id": "po-settled"},
+		"latest_charge": map[string]any{
+			"id":     "ch_123",
+			"object": "charge",
+		},
+		"status": "succeeded",
+	})
+	sig := signTestPayload(t, payload, testStripeWebhookSecret)
+
+	ctx := tenant.WithTenant(context.Background(), "test-tenant")
+	req := httptest.NewRequest(http.MethodPost, "/webhook/stripe", bytes.NewReader(payload)).WithContext(ctx)
+	req.Header.Set("Stripe-Signature", sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleStripeWebhook(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	require.NotNil(t, capturedReq)
+	assert.Equal(t, "pi_settled_123", capturedReq.GatewayReferenceId)
+	assert.Equal(t, "po-settled", capturedReq.PaymentOrderId)
+	assert.Equal(t, pb.GatewayStatus_GATEWAY_STATUS_SETTLED, capturedReq.GatewayStatus)
+}
+
+func TestStripeWebhookHandler_MissingTenantContext(t *testing.T) {
+	handler, _ := setupStripeWebhookHandler(t)
+
+	payload := buildTestStripePayload(t, "evt_2", "payment_intent.succeeded", map[string]any{
+		"id":     "pi_test",
+		"object": "payment_intent",
+	})
+	sig := signTestPayload(t, payload, testStripeWebhookSecret)
+
+	// No tenant in context
+	req := httptest.NewRequest(http.MethodPost, "/webhook/stripe", bytes.NewReader(payload))
+	req.Header.Set("Stripe-Signature", sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleStripeWebhook(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestStripeWebhookHandler_InvalidSignature(t *testing.T) {
+	handler, _ := setupStripeWebhookHandler(t)
+
+	payload := buildTestStripePayload(t, "evt_3", "payment_intent.succeeded", map[string]any{
+		"id":     "pi_test",
+		"object": "payment_intent",
+	})
+	wrongSig := signTestPayload(t, payload, "whsec_wrong_secret")
+
+	ctx := tenant.WithTenant(context.Background(), "test-tenant")
+	req := httptest.NewRequest(http.MethodPost, "/webhook/stripe", bytes.NewReader(payload)).WithContext(ctx)
+	req.Header.Set("Stripe-Signature", wrongSig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleStripeWebhook(rr, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+}
+
+func TestStripeWebhookHandler_UnsupportedEvent(t *testing.T) {
+	handler, _ := setupStripeWebhookHandler(t)
+
+	payload := buildTestStripePayload(t, "evt_4", "customer.created", map[string]any{
+		"id":     "cus_123",
+		"object": "customer",
+	})
+	sig := signTestPayload(t, payload, testStripeWebhookSecret)
+
+	ctx := tenant.WithTenant(context.Background(), "test-tenant")
+	req := httptest.NewRequest(http.MethodPost, "/webhook/stripe", bytes.NewReader(payload)).WithContext(ctx)
+	req.Header.Set("Stripe-Signature", sig)
+
+	rr := httptest.NewRecorder()
+	handler.HandleStripeWebhook(rr, req)
+
+	// Unsupported events should be acknowledged (200) to prevent Stripe retries
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestStripeWebhookHandler_MethodNotAllowed(t *testing.T) {
+	handler, _ := setupStripeWebhookHandler(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/webhook/stripe", nil)
+	rr := httptest.NewRecorder()
+	handler.HandleStripeWebhook(rr, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+}

--- a/services/payment-order/adapters/http/webhook_handler.go
+++ b/services/payment-order/adapters/http/webhook_handler.go
@@ -196,7 +196,13 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		idempotencyKey = h.generateIdempotencyKey(webhookReq)
 	}
 
-	// Build UpdatePaymentOrder request
+	h.processWebhookRequest(ctx, w, webhookReq, gatewayStatus, idempotencyKey)
+}
+
+// processWebhookRequest builds and sends the UpdatePaymentOrder request.
+// This method is shared between the generic webhook handler and gateway-specific
+// handlers (e.g., Stripe) that translate their events into WebhookRequest.
+func (h *WebhookHandler) processWebhookRequest(ctx context.Context, w http.ResponseWriter, webhookReq WebhookRequest, gatewayStatus pb.GatewayStatus, idempotencyKey string) {
 	updateReq := &pb.UpdatePaymentOrderRequest{
 		GatewayReferenceId: webhookReq.GatewayReferenceID,
 		PaymentOrderId:     webhookReq.PaymentOrderID,
@@ -213,18 +219,15 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		"status", webhookReq.Status,
 		"idempotency_key", idempotencyKey)
 
-	// Call UpdatePaymentOrder
 	resp, err := h.paymentOrderService.UpdatePaymentOrder(ctx, updateReq)
 	if err != nil {
 		h.logger.Error("failed to update payment order",
 			"error", err,
 			"gateway_reference_id", webhookReq.GatewayReferenceID)
-		// Return 500 to trigger webhook retry
 		h.writeErrorResponse(w, http.StatusInternalServerError, ErrPaymentOrderService.Error())
 		return
 	}
 
-	// Log success with payment order details if available
 	if resp != nil && resp.PaymentOrder != nil {
 		h.logger.Info("webhook processed successfully",
 			"payment_order_id", resp.PaymentOrder.PaymentOrderId,
@@ -274,6 +277,10 @@ func mapGatewayStatus(status string) (pb.GatewayStatus, error) {
 		return pb.GatewayStatus_GATEWAY_STATUS_REJECTED, nil
 	case "PENDING":
 		return pb.GatewayStatus_GATEWAY_STATUS_PENDING, nil
+	case "REFUNDED":
+		return pb.GatewayStatus_GATEWAY_STATUS_REFUNDED, nil
+	case "DISPUTED":
+		return pb.GatewayStatus_GATEWAY_STATUS_DISPUTED, nil
 	default:
 		return pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED, ErrInvalidGatewayStatus
 	}

--- a/services/payment-order/adapters/http/webhook_handler_test.go
+++ b/services/payment-order/adapters/http/webhook_handler_test.go
@@ -323,6 +323,12 @@ func TestMapGatewayStatus(t *testing.T) {
 		{"Pending", "Pending", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
 		{"PENDING", "PENDING", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
 		{"pending", "pending", pb.GatewayStatus_GATEWAY_STATUS_PENDING, false},
+		{"Refunded", "Refunded", pb.GatewayStatus_GATEWAY_STATUS_REFUNDED, false},
+		{"REFUNDED", "REFUNDED", pb.GatewayStatus_GATEWAY_STATUS_REFUNDED, false},
+		{"refunded", "refunded", pb.GatewayStatus_GATEWAY_STATUS_REFUNDED, false},
+		{"Disputed", "Disputed", pb.GatewayStatus_GATEWAY_STATUS_DISPUTED, false},
+		{"DISPUTED", "DISPUTED", pb.GatewayStatus_GATEWAY_STATUS_DISPUTED, false},
+		{"disputed", "disputed", pb.GatewayStatus_GATEWAY_STATUS_DISPUTED, false},
 		{"unknown_status", "Unknown", pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED, true},
 		{"empty_status", "", pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED, true},
 	}

--- a/services/payment-order/service/grpc_update.go
+++ b/services/payment-order/service/grpc_update.go
@@ -142,6 +142,19 @@ func (s *Service) UpdatePaymentOrder(ctx context.Context, req *pb.UpdatePaymentO
 		}
 		response = &pb.UpdatePaymentOrderResponse{PaymentOrder: toProto(po)}
 
+	case pb.GatewayStatus_GATEWAY_STATUS_REFUNDED:
+		s.logger.Info("refund webhook received, acknowledgment only",
+			"payment_order_id", po.ID,
+			"gateway_reference_id", req.GatewayReferenceId)
+		response = &pb.UpdatePaymentOrderResponse{PaymentOrder: toProto(po)}
+
+	case pb.GatewayStatus_GATEWAY_STATUS_DISPUTED:
+		s.logger.Warn("dispute webhook received, acknowledgment only",
+			"payment_order_id", po.ID,
+			"gateway_reference_id", req.GatewayReferenceId,
+			"gateway_message", req.GatewayMessage)
+		response = &pb.UpdatePaymentOrderResponse{PaymentOrder: toProto(po)}
+
 	case pb.GatewayStatus_GATEWAY_STATUS_UNSPECIFIED:
 		operationStatus = opStatusError
 		s.storeIdempotencyFailure(ctx, idempKey, "gateway status is required")


### PR DESCRIPTION
## Summary
- Implement `WebhookAdapter` in `gateway/stripe` package with Stripe-Signature HMAC-SHA256 validation via `stripe.webhook.ConstructEventWithOptions`
- Event type parsing: `payment_intent.succeeded` (SETTLED), `payment_intent.payment_failed` (REJECTED), `charge.refunded` (REFUNDED), `charge.dispute.created` (DISPUTED)
- Extract `payment_order_id` from PaymentIntent/Charge metadata
- Add `StripeWebhookHandler` in HTTP package with tenant-specific secret lookup via `ClientFactory`
- Register `/webhook/stripe` route in server.go
- Extend `GatewayStatus` proto enum with `REFUNDED` (4) and `DISPUTED` (5) values
- Refactor `WebhookHandler.processWebhookRequest` for shared use between generic and Stripe handlers

## Test Strategy
- Unit tests for valid/invalid signatures using `webhook.GenerateTestSignedPayload`
- Tests for each event type parsing (succeeded, failed, refunded, disputed)
- Metadata extraction tests including fallback to charge metadata for refunds
- Unsupported event type returns error
- Integration tests for `StripeWebhookHandler` with tenant context, invalid signature, missing tenant, and unsupported events
- Extended `mapGatewayStatus` tests for REFUNDED and DISPUTED

## Task Master
Tag: stripe-connect, Task: 7