### PR TITLE
feat: Starlark sandbox for forecasting algorithms

### DIFF
--- a/services/forecasting/starlark/builtins.go
+++ b/services/forecasting/starlark/builtins.go
@@ -1,0 +1,392 @@
+package starlark
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/shopspring/decimal"
+	starlarklib "go.starlark.net/starlark"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+// Builtin errors.
+var (
+	ErrArgCount         = errors.New("wrong number of arguments")
+	ErrArgType          = errors.New("wrong argument type")
+	ErrEmptyList        = errors.New("empty list")
+	ErrOutOfRange       = errors.New("value out of range")
+	ErrConversion       = errors.New("conversion error")
+	ErrInvalidTimestamp = errors.New("invalid timestamp")
+)
+
+// newForecastBuiltins creates the restricted Starlark environment for forecasting
+// scripts, extending the saga builtins with forecasting-specific functions.
+//
+// Included builtins:
+//   - Safe stdlib: True, False, None, len, str, int, float, bool, list, dict,
+//     tuple, range, enumerate, zip, sorted, reversed, min, max, abs, any, all,
+//     hasattr, getattr, dir, type, repr, hash
+//   - Forecasting: avg, sum, percentile, filter_by_hour, group_by_hour, duration
+//   - Decimal: Decimal() for arbitrary-precision arithmetic
+//
+//nolint:gocognit,gocyclo // Builtin configuration is inherently complex
+func newForecastBuiltins(logger *slog.Logger) starlarklib.StringDict {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	builtins := make(starlarklib.StringDict)
+
+	// Copy safe builtins from Starlark Universe
+	safeFunctions := []string{
+		"True", "False", "None",
+		"len", "str", "int", "float", "bool",
+		"list", "dict", "tuple", "range",
+		"enumerate", "zip", "sorted", "reversed",
+		"min", "max", "abs", "any", "all",
+		"hasattr", "getattr", "dir", "type", "repr", "hash",
+	}
+	for _, name := range safeFunctions {
+		if val, ok := starlarklib.Universe[name]; ok {
+			builtins[name] = val
+		}
+	}
+
+	// Override print to route to logger
+	builtins["print"] = starlarklib.NewBuiltin("print", func(thread *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, _ []starlarklib.Tuple) (starlarklib.Value, error) {
+		var msg string
+		for i, arg := range args {
+			if i > 0 {
+				msg += " "
+			}
+			msg += arg.String()
+		}
+		logger.Info("forecast script print", "message", msg, "thread", thread.Name)
+		return starlarklib.None, nil
+	})
+
+	// Decimal builtin
+	builtins["Decimal"] = saga.DecimalBuiltin()
+
+	// --- Statistical builtins ---
+	builtins["avg"] = starlarklib.NewBuiltin("avg", avgBuiltin)
+	builtins["sum"] = starlarklib.NewBuiltin("sum", sumBuiltin)
+	builtins["percentile"] = starlarklib.NewBuiltin("percentile", percentileBuiltin)
+
+	// --- Observation helper builtins ---
+	builtins["filter_by_hour"] = starlarklib.NewBuiltin("filter_by_hour", filterByHourBuiltin)
+	builtins["group_by_hour"] = starlarklib.NewBuiltin("group_by_hour", groupByHourBuiltin)
+
+	// --- Time utility builtins ---
+	builtins["duration"] = starlarklib.NewBuiltin("duration", durationBuiltin)
+	builtins["add_seconds"] = starlarklib.NewBuiltin("add_seconds", addSecondsBuiltin)
+
+	return builtins
+}
+
+// avgBuiltin computes the arithmetic mean of a list of numeric values.
+func avgBuiltin(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, _ []starlarklib.Tuple) (starlarklib.Value, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("avg: %w: expected 1, got %d", ErrArgCount, len(args))
+	}
+	vals, err := toDecimalSlice(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("avg: %w", err)
+	}
+	if len(vals) == 0 {
+		return nil, fmt.Errorf("avg: %w", ErrEmptyList)
+	}
+	sum := decimal.Zero
+	for _, v := range vals {
+		sum = sum.Add(v)
+	}
+	mean := sum.Div(decimal.NewFromInt(int64(len(vals))))
+	dv, err := saga.NewDecimalValue(mean.String())
+	if err != nil {
+		return nil, fmt.Errorf("avg: %w", err)
+	}
+	return dv, nil
+}
+
+// sumBuiltin computes the sum of a list of numeric values.
+func sumBuiltin(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, _ []starlarklib.Tuple) (starlarklib.Value, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("sum: %w: expected 1, got %d", ErrArgCount, len(args))
+	}
+	vals, err := toDecimalSlice(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("sum: %w", err)
+	}
+	total := decimal.Zero
+	for _, v := range vals {
+		total = total.Add(v)
+	}
+	dv, err := saga.NewDecimalValue(total.String())
+	if err != nil {
+		return nil, fmt.Errorf("sum: %w", err)
+	}
+	return dv, nil
+}
+
+// percentileBuiltin computes the p-th percentile of a list of numeric values.
+// Usage: percentile(values, p) where p is 0-100.
+func percentileBuiltin(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, _ []starlarklib.Tuple) (starlarklib.Value, error) {
+	if len(args) != 2 {
+		return nil, fmt.Errorf("percentile: %w: expected 2, got %d", ErrArgCount, len(args))
+	}
+	vals, err := toDecimalSlice(args[0])
+	if err != nil {
+		return nil, fmt.Errorf("percentile: %w", err)
+	}
+	if len(vals) == 0 {
+		return nil, fmt.Errorf("percentile: %w", ErrEmptyList)
+	}
+
+	p, err := toFloat64(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("percentile: p must be numeric: %w", err)
+	}
+	if p < 0 || p > 100 {
+		return nil, fmt.Errorf("percentile: %w: p must be 0-100, got %v", ErrOutOfRange, p)
+	}
+
+	// Sort values
+	sorted := make([]decimal.Decimal, len(vals))
+	copy(sorted, vals)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].LessThan(sorted[j])
+	})
+
+	// Linear interpolation
+	rank := (p / 100.0) * float64(len(sorted)-1)
+	lower := int(math.Floor(rank))
+	upper := int(math.Ceil(rank))
+	if lower == upper || upper >= len(sorted) {
+		dv, err := saga.NewDecimalValue(sorted[lower].String())
+		if err != nil {
+			return nil, fmt.Errorf("percentile: %w", err)
+		}
+		return dv, nil
+	}
+
+	// Interpolate
+	frac := decimal.NewFromFloat(rank - float64(lower))
+	diff := sorted[upper].Sub(sorted[lower])
+	result := sorted[lower].Add(diff.Mul(frac))
+
+	dv, err := saga.NewDecimalValue(result.String())
+	if err != nil {
+		return nil, fmt.Errorf("percentile: %w", err)
+	}
+	return dv, nil
+}
+
+// filterByHourBuiltin filters observations to those with matching hour-of-day.
+// Usage: filter_by_hour(observations, hour)
+// observations is a list of dicts with "timestamp" keys (RFC3339 strings).
+func filterByHourBuiltin(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, _ []starlarklib.Tuple) (starlarklib.Value, error) {
+	if len(args) != 2 {
+		return nil, fmt.Errorf("filter_by_hour: %w: expected 2, got %d", ErrArgCount, len(args))
+	}
+
+	obsList, ok := args[0].(*starlarklib.List)
+	if !ok {
+		return nil, fmt.Errorf("filter_by_hour: %w: first argument must be list, got %s", ErrArgType, args[0].Type())
+	}
+
+	hourVal, ok := args[1].(starlarklib.Int)
+	if !ok {
+		return nil, fmt.Errorf("filter_by_hour: %w: second argument must be int, got %s", ErrArgType, args[1].Type())
+	}
+	hour, ok := hourVal.Int64()
+	if !ok || hour < 0 || hour > 23 {
+		return nil, fmt.Errorf("filter_by_hour: %w: hour must be 0-23", ErrOutOfRange)
+	}
+
+	result := make([]starlarklib.Value, 0)
+	for i := 0; i < obsList.Len(); i++ {
+		item := obsList.Index(i)
+		ts, ok := extractTimestamp(item)
+		if !ok {
+			continue
+		}
+		if int64(ts.Hour()) == hour {
+			result = append(result, item)
+		}
+	}
+
+	return starlarklib.NewList(result), nil
+}
+
+// groupByHourBuiltin groups observations by hour-of-day.
+// Usage: group_by_hour(observations)
+// Returns a dict mapping hour (int) -> list of observation dicts.
+func groupByHourBuiltin(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, _ []starlarklib.Tuple) (starlarklib.Value, error) {
+	if len(args) != 1 {
+		return nil, fmt.Errorf("group_by_hour: %w: expected 1, got %d", ErrArgCount, len(args))
+	}
+
+	obsList, ok := args[0].(*starlarklib.List)
+	if !ok {
+		return nil, fmt.Errorf("group_by_hour: %w: argument must be list, got %s", ErrArgType, args[0].Type())
+	}
+
+	groups := make(map[int][]starlarklib.Value)
+	for i := 0; i < obsList.Len(); i++ {
+		item := obsList.Index(i)
+		ts, ok := extractTimestamp(item)
+		if !ok {
+			continue
+		}
+		groups[ts.Hour()] = append(groups[ts.Hour()], item)
+	}
+
+	result := starlarklib.NewDict(len(groups))
+	for hour, items := range groups {
+		_ = result.SetKey(starlarklib.MakeInt(hour), starlarklib.NewList(items))
+	}
+	return result, nil
+}
+
+// extractTimestamp extracts a time.Time from a Starlark dict's "timestamp" key.
+// Returns false if the dict doesn't have a valid RFC3339 timestamp.
+func extractTimestamp(val starlarklib.Value) (time.Time, bool) {
+	dict, ok := val.(*starlarklib.Dict)
+	if !ok {
+		return time.Time{}, false
+	}
+	tsVal, found, err := dict.Get(starlarklib.String("timestamp"))
+	if err != nil || !found {
+		return time.Time{}, false
+	}
+	tsStr, ok := tsVal.(starlarklib.String)
+	if !ok {
+		return time.Time{}, false
+	}
+	ts, err := time.Parse(time.RFC3339, string(tsStr))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return ts, true
+}
+
+// durationBuiltin creates a duration value in seconds.
+// Usage: duration(hours=0, minutes=0, seconds=0) -> int
+func durationBuiltin(_ *starlarklib.Thread, b *starlarklib.Builtin, args starlarklib.Tuple, kwargs []starlarklib.Tuple) (starlarklib.Value, error) {
+	var hours, minutes, seconds int
+	if err := starlarklib.UnpackArgs(b.Name(), args, kwargs,
+		"hours?", &hours,
+		"minutes?", &minutes,
+		"seconds?", &seconds,
+	); err != nil {
+		return nil, err
+	}
+
+	total := hours*3600 + minutes*60 + seconds
+	return starlarklib.MakeInt(total), nil
+}
+
+// addSecondsBuiltin adds seconds to an RFC3339 timestamp string.
+// Usage: add_seconds("2026-02-10T00:00:00Z", 3600) -> "2026-02-10T01:00:00Z"
+func addSecondsBuiltin(_ *starlarklib.Thread, _ *starlarklib.Builtin, args starlarklib.Tuple, _ []starlarklib.Tuple) (starlarklib.Value, error) {
+	if len(args) != 2 {
+		return nil, fmt.Errorf("add_seconds: %w: expected 2, got %d", ErrArgCount, len(args))
+	}
+
+	tsStr, ok := args[0].(starlarklib.String)
+	if !ok {
+		return nil, fmt.Errorf("add_seconds: %w: first argument must be string, got %s", ErrArgType, args[0].Type())
+	}
+
+	secsVal, ok := args[1].(starlarklib.Int)
+	if !ok {
+		return nil, fmt.Errorf("add_seconds: %w: second argument must be int, got %s", ErrArgType, args[1].Type())
+	}
+	secs, ok := secsVal.Int64()
+	if !ok {
+		return nil, fmt.Errorf("add_seconds: %w: seconds value too large", ErrOutOfRange)
+	}
+
+	ts, err := time.Parse(time.RFC3339, string(tsStr))
+	if err != nil {
+		return nil, fmt.Errorf("add_seconds: %w: %w", ErrInvalidTimestamp, err)
+	}
+
+	result := ts.Add(time.Duration(secs) * time.Second)
+	return starlarklib.String(result.Format(time.RFC3339)), nil
+}
+
+// toDecimalSlice converts a Starlark list/tuple of numeric values to []decimal.Decimal.
+func toDecimalSlice(val starlarklib.Value) ([]decimal.Decimal, error) {
+	var items []starlarklib.Value
+
+	switch v := val.(type) {
+	case *starlarklib.List:
+		items = make([]starlarklib.Value, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			items[i] = v.Index(i)
+		}
+	case starlarklib.Tuple:
+		items = []starlarklib.Value(v)
+	default:
+		return nil, fmt.Errorf("%w: expected list or tuple, got %s", ErrArgType, val.Type())
+	}
+
+	result := make([]decimal.Decimal, 0, len(items))
+	for i, item := range items {
+		d, err := toDecimal(item)
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+		result = append(result, d)
+	}
+	return result, nil
+}
+
+// toDecimal converts a single Starlark value to decimal.Decimal.
+func toDecimal(val starlarklib.Value) (decimal.Decimal, error) {
+	switch v := val.(type) {
+	case *saga.DecimalValue:
+		return v.GetDecimal(), nil
+	case starlarklib.Int:
+		i64, ok := v.Int64()
+		if !ok {
+			return decimal.Zero, fmt.Errorf("%w: integer too large", ErrConversion)
+		}
+		return decimal.NewFromInt(i64), nil
+	case starlarklib.Float:
+		return decimal.NewFromFloat(float64(v)), nil
+	case starlarklib.String:
+		d, err := decimal.NewFromString(string(v))
+		if err != nil {
+			return decimal.Zero, fmt.Errorf("%w: cannot parse %q as decimal", ErrConversion, string(v))
+		}
+		return d, nil
+	default:
+		return decimal.Zero, fmt.Errorf("%w: cannot convert %s to decimal", ErrConversion, val.Type())
+	}
+}
+
+// toFloat64 converts a Starlark numeric value to float64.
+func toFloat64(val starlarklib.Value) (float64, error) {
+	switch v := val.(type) {
+	case starlarklib.Int:
+		i64, ok := v.Int64()
+		if !ok {
+			return 0, fmt.Errorf("%w: integer too large", ErrConversion)
+		}
+		return float64(i64), nil
+	case starlarklib.Float:
+		return float64(v), nil
+	case *saga.DecimalValue:
+		f, _ := v.GetDecimal().Float64()
+		return f, nil
+	default:
+		return 0, fmt.Errorf("%w: expected numeric type, got %s", ErrConversion, val.Type())
+	}
+}

--- a/services/forecasting/starlark/runner.go
+++ b/services/forecasting/starlark/runner.go
@@ -1,0 +1,614 @@
+// Package starlark provides a sandboxed Starlark execution environment for
+// forecasting strategies. It extends the saga runtime patterns with
+// forecasting-specific context injection, builtin functions, and validation.
+package starlark
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/shopspring/decimal"
+	starlarklib "go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+// Default execution constraints.
+const (
+	DefaultTimeout = 30 * time.Second
+)
+
+// Runner errors.
+var (
+	ErrMISClientRequired   = errors.New("market information service client is required")
+	ErrRefDataRequired     = errors.New("reference data client is required")
+	ErrScriptRequired      = errors.New("starlark script is required")
+	ErrEntryPointMissing   = errors.New("script must define a compute_forecast(ctx) function")
+	ErrInvalidReturnType   = errors.New("compute_forecast must return a list of forecast points")
+	ErrTimestampOutOfRange = errors.New("forecast point timestamp is outside the horizon")
+	ErrNonMonotonic        = errors.New("forecast point timestamps must be monotonically increasing")
+	ErrGranularityMismatch = errors.New("forecast point timestamp is not aligned to granularity")
+	ErrValidation          = errors.New("script validation error")
+)
+
+// MISClient abstracts the Market Information Service for observation queries.
+type MISClient interface {
+	// FetchObservations retrieves historical observations for a dataset code.
+	// Returns observations ordered by valid_from DESC.
+	FetchObservations(ctx context.Context, datasetCode string, before time.Time) ([]Observation, error)
+}
+
+// RefDataClient abstracts the reference data service for node lookups.
+type RefDataClient interface {
+	// GetNodeByResolutionKey retrieves a reference data node by its resolution key.
+	GetNodeByResolutionKey(ctx context.Context, tenantID, resolutionKey string) (*ReferenceData, error)
+}
+
+// ForecastContext holds the data and parameters injected into the Starlark
+// script as the ctx argument to compute_forecast(ctx).
+type ForecastContext struct {
+	// Observations maps dataset code to a slice of observation records.
+	Observations map[string][]Observation
+
+	// ReferenceData holds the resolved reference data node (if resolution_key set).
+	ReferenceData *ReferenceData
+
+	// Horizon is the forecast window duration.
+	Horizon time.Duration
+
+	// Granularity is the spacing between forecast points.
+	Granularity time.Duration
+
+	// Now is the execution timestamp (start of the forecast window).
+	Now time.Time
+}
+
+// Observation represents a single market data observation available to scripts.
+type Observation struct {
+	Timestamp time.Time
+	Value     decimal.Decimal
+	Quality   string
+}
+
+// ReferenceData holds reference data node information for scripts.
+type ReferenceData struct {
+	NodeType      string
+	ResolutionKey string
+	Attributes    map[string]any
+}
+
+// ForecastPoint is a single point in the forecast output.
+type ForecastPoint struct {
+	Timestamp time.Time
+	Value     decimal.Decimal
+	Metadata  map[string]string
+}
+
+// StrategyInput holds the parameters needed to execute a forecasting strategy.
+type StrategyInput struct {
+	// Script is the Starlark source code.
+	Script string
+
+	// InputDatasetCodes are the MDS dataset codes to fetch observations from.
+	InputDatasetCodes []string
+
+	// OutputDatasetCode is the target dataset for the forecast.
+	OutputDatasetCode string
+
+	// ResolutionKey is the optional reference data resolution key.
+	ResolutionKey string
+
+	// TenantID is the tenant scope for reference data lookups.
+	TenantID string
+
+	// HorizonHours defines how far into the future to forecast.
+	HorizonHours int
+
+	// GranularityHours defines the spacing between forecast points.
+	GranularityHours int
+
+	// Now overrides the current time (useful for testing). If zero, uses time.Now().
+	Now time.Time
+}
+
+// ForecastRunner executes forecasting strategies written in Starlark.
+type ForecastRunner struct {
+	misClient MISClient
+	refData   RefDataClient
+	timeout   time.Duration
+	logger    *slog.Logger
+}
+
+// ForecastRunnerConfig holds configuration for creating a ForecastRunner.
+type ForecastRunnerConfig struct {
+	MISClient MISClient
+	RefData   RefDataClient
+	Timeout   time.Duration
+	Logger    *slog.Logger
+}
+
+// NewForecastRunner creates a new ForecastRunner.
+func NewForecastRunner(cfg ForecastRunnerConfig) (*ForecastRunner, error) {
+	if cfg.MISClient == nil {
+		return nil, ErrMISClientRequired
+	}
+	if cfg.RefData == nil {
+		return nil, ErrRefDataRequired
+	}
+
+	timeout := cfg.Timeout
+	if timeout == 0 {
+		timeout = DefaultTimeout
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &ForecastRunner{
+		misClient: cfg.MISClient,
+		refData:   cfg.RefData,
+		timeout:   timeout,
+		logger:    logger,
+	}, nil
+}
+
+// ExecuteStrategy runs a forecasting strategy and returns the forecast points.
+func (r *ForecastRunner) ExecuteStrategy(ctx context.Context, input StrategyInput) ([]ForecastPoint, error) {
+	if input.Script == "" {
+		return nil, ErrScriptRequired
+	}
+
+	now := input.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+
+	horizon := time.Duration(input.HorizonHours) * time.Hour
+	granularity := time.Duration(input.GranularityHours) * time.Hour
+
+	r.logger.Info("executing forecast strategy",
+		"input_datasets", input.InputDatasetCodes,
+		"output_dataset", input.OutputDatasetCode,
+		"horizon_hours", input.HorizonHours,
+		"granularity_hours", input.GranularityHours,
+	)
+
+	// Step 1: Fetch historical observations from MDS
+	observations, err := r.fetchObservations(ctx, input.InputDatasetCodes, now)
+	if err != nil {
+		return nil, fmt.Errorf("fetch observations: %w", err)
+	}
+
+	// Step 2: Fetch reference data node if resolution key specified
+	var refData *ReferenceData
+	if input.ResolutionKey != "" && input.TenantID != "" {
+		refData, err = r.refData.GetNodeByResolutionKey(ctx, input.TenantID, input.ResolutionKey)
+		if err != nil {
+			return nil, fmt.Errorf("fetch reference data: %w", err)
+		}
+	}
+
+	// Step 3: Build ForecastContext
+	forecastCtx := &ForecastContext{
+		Observations:  observations,
+		ReferenceData: refData,
+		Horizon:       horizon,
+		Granularity:   granularity,
+		Now:           now,
+	}
+
+	// Step 4-5: Execute Starlark script
+	points, err := r.executeScript(ctx, input.Script, forecastCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 6: Validate returned forecast points
+	if err := validateForecastPoints(points, now, horizon, granularity); err != nil {
+		return nil, err
+	}
+
+	r.logger.Info("forecast strategy execution completed",
+		"point_count", len(points),
+	)
+
+	return points, nil
+}
+
+// fetchObservations retrieves historical observations from MDS for all input datasets.
+func (r *ForecastRunner) fetchObservations(ctx context.Context, datasetCodes []string, now time.Time) (map[string][]Observation, error) {
+	result := make(map[string][]Observation, len(datasetCodes))
+
+	for _, code := range datasetCodes {
+		obs, err := r.misClient.FetchObservations(ctx, code, now)
+		if err != nil {
+			return nil, fmt.Errorf("fetch observations for %s: %w", code, err)
+		}
+		result[code] = obs
+	}
+
+	return result, nil
+}
+
+// executeScript runs the Starlark script in a sandboxed environment.
+func (r *ForecastRunner) executeScript(ctx context.Context, script string, forecastCtx *ForecastContext) ([]ForecastPoint, error) {
+	// Apply timeout
+	ctx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+
+	// Build Starlark context value
+	ctxValue := forecastContextToStarlark(forecastCtx)
+
+	// Build predeclared environment with forecasting builtins
+	predeclared := newForecastBuiltins(r.logger)
+	predeclared["Decimal"] = saga.DecimalBuiltin()
+
+	// Create thread with cancellation support
+	thread := &starlarklib.Thread{
+		Name: "forecast",
+		Print: func(_ *starlarklib.Thread, msg string) {
+			r.logger.Info("forecast script print", "message", msg)
+		},
+	}
+	thread.SetLocal("ctx", ctx)
+
+	// Execute script in a goroutine for timeout support
+	done := make(chan struct{})
+	var execErr error
+	var globals starlarklib.StringDict
+
+	go func() {
+		defer close(done)
+		var err error
+		globals, err = starlarklib.ExecFileOptions(&syntax.FileOptions{}, thread, "forecast.star", script, predeclared)
+		if err != nil {
+			execErr = err
+		}
+	}()
+
+	select {
+	case <-done:
+		if execErr != nil {
+			return nil, wrapStarlarkError(execErr)
+		}
+	case <-ctx.Done():
+		thread.Cancel("execution cancelled")
+		<-done
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("%w: exceeded %v", saga.ErrTimeout, r.timeout)
+		}
+		return nil, fmt.Errorf("%w: %w", saga.ErrCancelled, ctx.Err())
+	}
+
+	// Look up compute_forecast function
+	computeFn, ok := globals["compute_forecast"]
+	if !ok {
+		return nil, ErrEntryPointMissing
+	}
+
+	fn, ok := computeFn.(*starlarklib.Function)
+	if !ok {
+		return nil, ErrEntryPointMissing
+	}
+
+	// Call compute_forecast(ctx)
+	callDone := make(chan struct{})
+	var callErr error
+	var resultVal starlarklib.Value
+
+	go func() {
+		defer close(callDone)
+		var err error
+		resultVal, err = starlarklib.Call(thread, fn, starlarklib.Tuple{ctxValue}, nil)
+		if err != nil {
+			callErr = err
+		}
+	}()
+
+	select {
+	case <-callDone:
+		if callErr != nil {
+			return nil, wrapStarlarkError(callErr)
+		}
+	case <-ctx.Done():
+		thread.Cancel("execution cancelled")
+		<-callDone
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, fmt.Errorf("%w: exceeded %v", saga.ErrTimeout, r.timeout)
+		}
+		return nil, fmt.Errorf("%w: %w", saga.ErrCancelled, ctx.Err())
+	}
+
+	// Convert Starlark result to []ForecastPoint
+	return starlarkToForecastPoints(resultVal)
+}
+
+// validateForecastPoints checks that forecast points are within horizon, monotonic,
+// and aligned to granularity.
+func validateForecastPoints(points []ForecastPoint, now time.Time, horizon, granularity time.Duration) error {
+	horizonEnd := now.Add(horizon)
+
+	for i, p := range points {
+		// Check timestamp is within [now, now+horizon]
+		if p.Timestamp.Before(now) || p.Timestamp.After(horizonEnd) {
+			return fmt.Errorf("%w: point %d at %v is outside [%v, %v]",
+				ErrTimestampOutOfRange, i, p.Timestamp, now, horizonEnd)
+		}
+
+		// Check monotonically increasing
+		if i > 0 && !p.Timestamp.After(points[i-1].Timestamp) {
+			return fmt.Errorf("%w: point %d at %v is not after point %d at %v",
+				ErrNonMonotonic, i, p.Timestamp, i-1, points[i-1].Timestamp)
+		}
+
+		// Check granularity alignment
+		offset := p.Timestamp.Sub(now)
+		if granularity > 0 && offset%granularity != 0 {
+			return fmt.Errorf("%w: point %d at %v (offset %v) is not aligned to %v granularity",
+				ErrGranularityMismatch, i, p.Timestamp, offset, granularity)
+		}
+	}
+
+	return nil
+}
+
+// starlarkToForecastPoints converts the Starlark return value to []ForecastPoint.
+func starlarkToForecastPoints(val starlarklib.Value) ([]ForecastPoint, error) {
+	list, ok := val.(*starlarklib.List)
+	if !ok {
+		return nil, fmt.Errorf("%w: got %s, want list", ErrInvalidReturnType, val.Type())
+	}
+
+	points := make([]ForecastPoint, 0, list.Len())
+	for i := 0; i < list.Len(); i++ {
+		item := list.Index(i)
+		dict, ok := item.(*starlarklib.Dict)
+		if !ok {
+			return nil, fmt.Errorf("%w: element %d is %s, want dict", ErrInvalidReturnType, i, item.Type())
+		}
+
+		point, err := dictToForecastPoint(dict)
+		if err != nil {
+			return nil, fmt.Errorf("element %d: %w", i, err)
+		}
+		points = append(points, point)
+	}
+
+	return points, nil
+}
+
+// dictToForecastPoint converts a Starlark dict to a ForecastPoint.
+func dictToForecastPoint(dict *starlarklib.Dict) (ForecastPoint, error) {
+	var point ForecastPoint
+
+	ts, err := extractPointTimestamp(dict)
+	if err != nil {
+		return point, err
+	}
+	point.Timestamp = ts
+
+	val, err := extractPointValue(dict)
+	if err != nil {
+		return point, err
+	}
+	point.Value = val
+
+	meta, err := extractPointMetadata(dict)
+	if err != nil {
+		return point, err
+	}
+	point.Metadata = meta
+
+	return point, nil
+}
+
+// extractPointTimestamp extracts and parses the timestamp from a forecast point dict.
+func extractPointTimestamp(dict *starlarklib.Dict) (time.Time, error) {
+	tsVal, found, err := dict.Get(starlarklib.String("timestamp"))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("get timestamp: %w", err)
+	}
+	if !found {
+		return time.Time{}, fmt.Errorf("%w: missing 'timestamp' key", ErrInvalidReturnType)
+	}
+
+	switch v := tsVal.(type) {
+	case starlarklib.String:
+		ts, err := time.Parse(time.RFC3339, string(v))
+		if err != nil {
+			return time.Time{}, fmt.Errorf("parse timestamp %q: %w", string(v), err)
+		}
+		return ts, nil
+	case starlarklib.Int:
+		unixSec, ok := v.Int64()
+		if !ok {
+			return time.Time{}, fmt.Errorf("%w: timestamp integer too large", ErrInvalidReturnType)
+		}
+		return time.Unix(unixSec, 0).UTC(), nil
+	default:
+		return time.Time{}, fmt.Errorf("%w: timestamp must be string (RFC3339) or int (unix seconds)", ErrInvalidReturnType)
+	}
+}
+
+// extractPointValue extracts and converts the value from a forecast point dict.
+func extractPointValue(dict *starlarklib.Dict) (decimal.Decimal, error) {
+	valVal, found, err := dict.Get(starlarklib.String("value"))
+	if err != nil {
+		return decimal.Zero, fmt.Errorf("get value: %w", err)
+	}
+	if !found {
+		return decimal.Zero, fmt.Errorf("%w: missing 'value' key", ErrInvalidReturnType)
+	}
+
+	switch v := valVal.(type) {
+	case *saga.DecimalValue:
+		return v.GetDecimal(), nil
+	case starlarklib.String:
+		d, err := decimal.NewFromString(string(v))
+		if err != nil {
+			return decimal.Zero, fmt.Errorf("parse value %q: %w", string(v), err)
+		}
+		return d, nil
+	case starlarklib.Float:
+		return decimal.NewFromFloat(float64(v)), nil
+	case starlarklib.Int:
+		i64, _ := v.Int64()
+		return decimal.NewFromInt(i64), nil
+	default:
+		return decimal.Zero, fmt.Errorf("%w: value must be Decimal, string, float, or int; got %s", ErrInvalidReturnType, valVal.Type())
+	}
+}
+
+// extractPointMetadata extracts the optional metadata dict from a forecast point dict.
+// Returns an empty map (not nil) when metadata is absent or None.
+func extractPointMetadata(dict *starlarklib.Dict) (map[string]string, error) {
+	metaVal, found, err := dict.Get(starlarklib.String("metadata"))
+	if err != nil {
+		return nil, fmt.Errorf("get metadata: %w", err)
+	}
+	if !found || metaVal == starlarklib.None {
+		return make(map[string]string), nil
+	}
+
+	metaDict, ok := metaVal.(*starlarklib.Dict)
+	if !ok {
+		return nil, fmt.Errorf("%w: metadata must be dict, got %s", ErrInvalidReturnType, metaVal.Type())
+	}
+
+	result := make(map[string]string)
+	for _, item := range metaDict.Items() {
+		k, ok := item[0].(starlarklib.String)
+		if !ok {
+			continue
+		}
+		result[string(k)] = item[1].String()
+	}
+	return result, nil
+}
+
+// forecastContextToStarlark converts a ForecastContext to a frozen Starlark dict.
+func forecastContextToStarlark(fc *ForecastContext) *starlarklib.Dict {
+	ctx := starlarklib.NewDict(5)
+
+	// Convert observations: map[string][]Observation -> dict[string, list[dict]]
+	obsDict := starlarklib.NewDict(len(fc.Observations))
+	for code, observations := range fc.Observations {
+		obsList := make([]starlarklib.Value, 0, len(observations))
+		for _, obs := range observations {
+			d := starlarklib.NewDict(3)
+			_ = d.SetKey(starlarklib.String("timestamp"), starlarklib.String(obs.Timestamp.Format(time.RFC3339)))
+			_ = d.SetKey(starlarklib.String("value"), starlarklib.String(obs.Value.String()))
+			_ = d.SetKey(starlarklib.String("quality"), starlarklib.String(obs.Quality))
+			obsList = append(obsList, d)
+		}
+		_ = obsDict.SetKey(starlarklib.String(code), starlarklib.NewList(obsList))
+	}
+	_ = ctx.SetKey(starlarklib.String("observations"), obsDict)
+
+	// Convert reference data
+	if fc.ReferenceData != nil {
+		refDict := starlarklib.NewDict(3)
+		_ = refDict.SetKey(starlarklib.String("node_type"), starlarklib.String(fc.ReferenceData.NodeType))
+		_ = refDict.SetKey(starlarklib.String("resolution_key"), starlarklib.String(fc.ReferenceData.ResolutionKey))
+
+		attrs := starlarklib.NewDict(len(fc.ReferenceData.Attributes))
+		for k, v := range fc.ReferenceData.Attributes {
+			_ = attrs.SetKey(starlarklib.String(k), goToStarlark(v))
+		}
+		_ = refDict.SetKey(starlarklib.String("attributes"), attrs)
+		_ = ctx.SetKey(starlarklib.String("reference_data"), refDict)
+	} else {
+		_ = ctx.SetKey(starlarklib.String("reference_data"), starlarklib.None)
+	}
+
+	// Horizon in seconds
+	_ = ctx.SetKey(starlarklib.String("horizon_seconds"), starlarklib.MakeInt64(int64(fc.Horizon.Seconds())))
+
+	// Granularity in seconds
+	_ = ctx.SetKey(starlarklib.String("granularity_seconds"), starlarklib.MakeInt64(int64(fc.Granularity.Seconds())))
+
+	// Now as RFC3339
+	_ = ctx.SetKey(starlarklib.String("now"), starlarklib.String(fc.Now.Format(time.RFC3339)))
+
+	// Freeze to prevent modification by scripts
+	ctx.Freeze()
+
+	return ctx
+}
+
+// goToStarlark converts a Go value to a Starlark value.
+// Mirrors the saga package's unexported function.
+func goToStarlark(v interface{}) starlarklib.Value {
+	if v == nil {
+		return starlarklib.None
+	}
+
+	switch val := v.(type) {
+	case string:
+		return starlarklib.String(val)
+	case int:
+		return starlarklib.MakeInt(val)
+	case int64:
+		return starlarklib.MakeInt64(val)
+	case float64:
+		return starlarklib.Float(val)
+	case bool:
+		return starlarklib.Bool(val)
+	case []interface{}:
+		list := make([]starlarklib.Value, len(val))
+		for i, elem := range val {
+			list[i] = goToStarlark(elem)
+		}
+		return starlarklib.NewList(list)
+	case map[string]string:
+		dict := starlarklib.NewDict(len(val))
+		for k, v := range val {
+			_ = dict.SetKey(starlarklib.String(k), starlarklib.String(v))
+		}
+		return dict
+	case map[string]interface{}:
+		dict := starlarklib.NewDict(len(val))
+		for k, v := range val {
+			_ = dict.SetKey(starlarklib.String(k), goToStarlark(v))
+		}
+		return dict
+	default:
+		return starlarklib.String(fmt.Sprintf("%v", v))
+	}
+}
+
+// wrapStarlarkError wraps Starlark errors with appropriate package errors.
+func wrapStarlarkError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var evalErr *starlarklib.EvalError
+	if errors.As(err, &evalErr) {
+		return errors.Join(saga.ErrExecution, err)
+	}
+
+	errStr := err.Error()
+	if strings.Contains(errStr, "syntax") ||
+		strings.Contains(errStr, "parse") ||
+		strings.Contains(errStr, "got ") {
+		return errors.Join(ErrValidation, err)
+	}
+
+	return errors.Join(saga.ErrExecution, err)
+}
+
+// SortForecastPoints sorts forecast points by timestamp.
+func SortForecastPoints(points []ForecastPoint) {
+	sort.Slice(points, func(i, j int) bool {
+		return points[i].Timestamp.Before(points[j].Timestamp)
+	})
+}

--- a/services/forecasting/starlark/runner.go
+++ b/services/forecasting/starlark/runner.go
@@ -460,7 +460,10 @@ func extractPointValue(dict *starlarklib.Dict) (decimal.Decimal, error) {
 	case starlarklib.Float:
 		return decimal.NewFromFloat(float64(v)), nil
 	case starlarklib.Int:
-		i64, _ := v.Int64()
+		i64, ok := v.Int64()
+		if !ok {
+			return decimal.Zero, fmt.Errorf("%w: integer value too large for decimal conversion", ErrInvalidReturnType)
+		}
 		return decimal.NewFromInt(i64), nil
 	default:
 		return decimal.Zero, fmt.Errorf("%w: value must be Decimal, string, float, or int; got %s", ErrInvalidReturnType, valVal.Type())
@@ -489,7 +492,12 @@ func extractPointMetadata(dict *starlarklib.Dict) (map[string]string, error) {
 		if !ok {
 			continue
 		}
-		result[string(k)] = item[1].String()
+		// Use type assertion to get the raw string value, avoiding Starlark repr quotes.
+		if sv, ok := item[1].(starlarklib.String); ok {
+			result[string(k)] = string(sv)
+		} else {
+			result[string(k)] = item[1].String()
+		}
 	}
 	return result, nil
 }

--- a/services/forecasting/starlark/runner.go
+++ b/services/forecasting/starlark/runner.go
@@ -35,6 +35,7 @@ var (
 	ErrNonMonotonic        = errors.New("forecast point timestamps must be monotonically increasing")
 	ErrGranularityMismatch = errors.New("forecast point timestamp is not aligned to granularity")
 	ErrValidation          = errors.New("script validation error")
+	ErrInvalidInput        = errors.New("invalid strategy input")
 )
 
 // MISClient abstracts the Market Information Service for observation queries.
@@ -171,6 +172,13 @@ func (r *ForecastRunner) ExecuteStrategy(ctx context.Context, input StrategyInpu
 		now = time.Now()
 	}
 
+	if input.HorizonHours <= 0 {
+		return nil, fmt.Errorf("%w: horizon_hours must be > 0", ErrInvalidInput)
+	}
+	if input.GranularityHours <= 0 {
+		return nil, fmt.Errorf("%w: granularity_hours must be > 0", ErrInvalidInput)
+	}
+
 	horizon := time.Duration(input.HorizonHours) * time.Hour
 	granularity := time.Duration(input.GranularityHours) * time.Hour
 
@@ -189,6 +197,9 @@ func (r *ForecastRunner) ExecuteStrategy(ctx context.Context, input StrategyInpu
 
 	// Step 2: Fetch reference data node if resolution key specified
 	var refData *ReferenceData
+	if (input.ResolutionKey == "") != (input.TenantID == "") {
+		return nil, fmt.Errorf("%w: resolution_key and tenant_id must both be set or both be empty", ErrInvalidInput)
+	}
 	if input.ResolutionKey != "" && input.TenantID != "" {
 		refData, err = r.refData.GetNodeByResolutionKey(ctx, input.TenantID, input.ResolutionKey)
 		if err != nil {

--- a/services/forecasting/starlark/runner_test.go
+++ b/services/forecasting/starlark/runner_test.go
@@ -1,0 +1,807 @@
+package starlark
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	starlarklib "go.starlark.net/starlark"
+
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+// --- Mock implementations ---
+
+type mockMISClient struct {
+	observations map[string][]Observation
+	err          error
+}
+
+func (m *mockMISClient) FetchObservations(_ context.Context, datasetCode string, _ time.Time) ([]Observation, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.observations[datasetCode], nil
+}
+
+type mockRefDataClient struct {
+	nodes map[string]*ReferenceData
+	err   error
+}
+
+func (m *mockRefDataClient) GetNodeByResolutionKey(_ context.Context, _, resolutionKey string) (*ReferenceData, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	node, ok := m.nodes[resolutionKey]
+	if !ok {
+		return nil, fmt.Errorf("node not found: %s", resolutionKey)
+	}
+	return node, nil
+}
+
+// --- Test helpers ---
+
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+func newTestRunner(t *testing.T, mis MISClient, ref RefDataClient) *ForecastRunner {
+	t.Helper()
+	runner, err := NewForecastRunner(ForecastRunnerConfig{
+		MISClient: mis,
+		RefData:   ref,
+		Timeout:   5 * time.Second,
+		Logger:    newTestLogger(),
+	})
+	require.NoError(t, err)
+	return runner
+}
+
+func baseTime() time.Time {
+	return time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+}
+
+// --- Constructor tests ---
+
+func TestNewForecastRunner(t *testing.T) {
+	t.Run("requires MIS client", func(t *testing.T) {
+		_, err := NewForecastRunner(ForecastRunnerConfig{
+			RefData: &mockRefDataClient{},
+		})
+		require.ErrorIs(t, err, ErrMISClientRequired)
+	})
+
+	t.Run("requires ref data client", func(t *testing.T) {
+		_, err := NewForecastRunner(ForecastRunnerConfig{
+			MISClient: &mockMISClient{},
+		})
+		require.ErrorIs(t, err, ErrRefDataRequired)
+	})
+
+	t.Run("succeeds with valid config", func(t *testing.T) {
+		runner, err := NewForecastRunner(ForecastRunnerConfig{
+			MISClient: &mockMISClient{},
+			RefData:   &mockRefDataClient{},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, runner)
+		assert.Equal(t, DefaultTimeout, runner.timeout)
+	})
+
+	t.Run("applies custom timeout", func(t *testing.T) {
+		runner, err := NewForecastRunner(ForecastRunnerConfig{
+			MISClient: &mockMISClient{},
+			RefData:   &mockRefDataClient{},
+			Timeout:   10 * time.Second,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 10*time.Second, runner.timeout)
+	})
+}
+
+// --- Simple moving average test (24h horizon, 1h granularity) ---
+
+func TestExecuteStrategy_SimpleMovingAverage(t *testing.T) {
+	now := baseTime()
+
+	// Build 24 hours of historical observations
+	observations := make([]Observation, 24)
+	for i := 0; i < 24; i++ {
+		observations[i] = Observation{
+			Timestamp: now.Add(-time.Duration(24-i) * time.Hour),
+			Value:     decimal.NewFromInt(int64(100 + i)),
+			Quality:   "QUALITY_LEVEL_ACTUAL",
+		}
+	}
+
+	mis := &mockMISClient{
+		observations: map[string][]Observation{
+			"UTILIZATION_COMPUTE_HOUR": observations,
+		},
+	}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+
+	runner := newTestRunner(t, mis, ref)
+
+	// Simple moving average strategy using add_seconds builtin
+	script := `
+def compute_forecast(ctx):
+    obs = ctx["observations"]["UTILIZATION_COMPUTE_HOUR"]
+
+    # Extract values and compute simple moving average
+    values = [float(o["value"]) for o in obs]
+    avg_val = 0.0
+    for v in values:
+        avg_val = avg_val + v
+    avg_val = avg_val / len(values)
+
+    now = ctx["now"]
+    granularity = int(ctx["granularity_seconds"])
+    horizon = int(ctx["horizon_seconds"])
+    num_points = horizon // granularity
+
+    points = []
+    for i in range(num_points):
+        offset = (i + 1) * granularity
+        ts = add_seconds(now, offset)
+        points.append({
+            "timestamp": ts,
+            "value": avg_val,
+        })
+    return points
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION_COMPUTE_HOUR"},
+		OutputDatasetCode: "FORECAST_UTILIZATION",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// All points should have the same average value
+	// avg(100..123) = (100+101+...+123)/24 = 2676/24 = 111.5
+	expectedAvg := decimal.NewFromFloat(111.5)
+	for i, p := range points {
+		assert.True(t, p.Value.Equal(expectedAvg), "point %d: expected %s, got %s", i, expectedAvg, p.Value)
+		expectedTS := now.Add(time.Duration(i+1) * time.Hour)
+		assert.Equal(t, expectedTS, p.Timestamp, "point %d timestamp mismatch", i)
+	}
+}
+
+// --- Reference data access test ---
+
+func TestExecuteStrategy_AccessesReferenceData(t *testing.T) {
+	now := baseTime()
+
+	mis := &mockMISClient{
+		observations: map[string][]Observation{
+			"UTILIZATION_COMPUTE_HOUR": {
+				{Timestamp: now.Add(-time.Hour), Value: decimal.NewFromInt(100), Quality: "ACTUAL"},
+			},
+		},
+	}
+	ref := &mockRefDataClient{
+		nodes: map[string]*ReferenceData{
+			"region:us-east-1/zone:us-east-1a": {
+				NodeType:      "zone",
+				ResolutionKey: "region:us-east-1/zone:us-east-1a",
+				Attributes: map[string]any{
+					"capacity_factor": "0.85",
+					"region_name":     "US East 1a",
+				},
+			},
+		},
+	}
+
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    ref = ctx["reference_data"]
+    capacity = float(ref["attributes"]["capacity_factor"])
+
+    obs = ctx["observations"]["UTILIZATION_COMPUTE_HOUR"]
+    base_value = float(obs[0]["value"]) * capacity
+
+    now = ctx["now"]
+    granularity = int(ctx["granularity_seconds"])
+    horizon = int(ctx["horizon_seconds"])
+    num_points = horizon // granularity
+
+    points = []
+    for i in range(num_points):
+        offset = (i + 1) * granularity
+        ts = add_seconds(now, offset)
+        points.append({
+            "timestamp": ts,
+            "value": base_value,
+            "metadata": {"source": "capacity_adjusted"},
+        })
+    return points
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION_COMPUTE_HOUR"},
+		OutputDatasetCode: "FORECAST_UTILIZATION",
+		ResolutionKey:     "region:us-east-1/zone:us-east-1a",
+		TenantID:          "tenant-1",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// 100 * 0.85 = 85
+	expectedValue := decimal.NewFromFloat(85)
+	assert.True(t, points[0].Value.Equal(expectedValue), "expected %s, got %s", expectedValue, points[0].Value)
+	assert.Equal(t, "\"capacity_adjusted\"", points[0].Metadata["source"])
+}
+
+// --- Builtin tests ---
+
+func TestBuiltins_Avg(t *testing.T) {
+	now := baseTime()
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    result = avg([Decimal("1"), Decimal("2"), Decimal("3")])
+    ts = add_seconds(ctx["now"], 3600)
+    return [{"timestamp": ts, "value": str(result)}]
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.True(t, points[0].Value.Equal(decimal.NewFromInt(2)), "avg([1,2,3]) should be 2, got %s", points[0].Value)
+}
+
+func TestBuiltins_Sum(t *testing.T) {
+	now := baseTime()
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    result = sum([Decimal("10"), Decimal("20"), Decimal("30")])
+    ts = add_seconds(ctx["now"], 3600)
+    return [{"timestamp": ts, "value": str(result)}]
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.True(t, points[0].Value.Equal(decimal.NewFromInt(60)), "sum([10,20,30]) should be 60, got %s", points[0].Value)
+}
+
+func TestBuiltins_Percentile(t *testing.T) {
+	now := baseTime()
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    vals = [Decimal("10"), Decimal("20"), Decimal("30"), Decimal("40"), Decimal("50")]
+    p50 = percentile(vals, 50)
+    ts = add_seconds(ctx["now"], 3600)
+    return [{"timestamp": ts, "value": str(p50)}]
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.True(t, points[0].Value.Equal(decimal.NewFromInt(30)), "percentile([10..50], 50) should be 30, got %s", points[0].Value)
+}
+
+func TestBuiltins_Duration(t *testing.T) {
+	now := baseTime()
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    d = duration(hours=1)
+    ts = add_seconds(ctx["now"], 3600)
+    return [{"timestamp": ts, "value": d}]
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.True(t, points[0].Value.Equal(decimal.NewFromInt(3600)), "duration(hours=1) should be 3600, got %s", points[0].Value)
+}
+
+func TestBuiltins_AddSeconds(t *testing.T) {
+	now := baseTime()
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    ts = add_seconds(ctx["now"], 7200)  # +2 hours
+    return [{"timestamp": ts, "value": 42}]
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+
+	expected := now.Add(2 * time.Hour)
+	assert.Equal(t, expected, points[0].Timestamp)
+}
+
+func TestBuiltins_FilterByHour(t *testing.T) {
+	now := baseTime()
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    # Create observations at different hours
+    obs = [
+        {"timestamp": "2026-02-10T10:00:00Z", "value": "100"},
+        {"timestamp": "2026-02-10T10:30:00Z", "value": "110"},
+        {"timestamp": "2026-02-10T11:00:00Z", "value": "120"},
+        {"timestamp": "2026-02-10T12:00:00Z", "value": "130"},
+    ]
+
+    # Filter for hour 10
+    filtered = filter_by_hour(obs, 10)
+    count = len(filtered)  # Should be 2
+
+    ts = add_seconds(ctx["now"], 3600)
+    return [{"timestamp": ts, "value": count}]
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.True(t, points[0].Value.Equal(decimal.NewFromInt(2)), "filter_by_hour should return 2 obs for hour 10, got %s", points[0].Value)
+}
+
+func TestBuiltins_GroupByHour(t *testing.T) {
+	now := baseTime()
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    obs = [
+        {"timestamp": "2026-02-10T10:00:00Z", "value": "100"},
+        {"timestamp": "2026-02-10T10:30:00Z", "value": "110"},
+        {"timestamp": "2026-02-10T11:00:00Z", "value": "120"},
+    ]
+
+    groups = group_by_hour(obs)
+    # groups[10] should have 2 items, groups[11] should have 1
+    count_10 = len(groups[10])
+    count_11 = len(groups[11])
+
+    ts = add_seconds(ctx["now"], 3600)
+    return [
+        {"timestamp": ts, "value": count_10, "metadata": {"hour": "10"}},
+    ]
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, points, 1)
+	assert.True(t, points[0].Value.Equal(decimal.NewFromInt(2)), "group_by_hour[10] should have 2 items, got %s", points[0].Value)
+}
+
+// --- Safety tests ---
+
+func TestExecuteStrategy_TimeoutEnforcement(t *testing.T) {
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+
+	runner, err := NewForecastRunner(ForecastRunnerConfig{
+		MISClient: mis,
+		RefData:   ref,
+		Timeout:   200 * time.Millisecond,
+		Logger:    newTestLogger(),
+	})
+	require.NoError(t, err)
+
+	// Script with long computation (large for loop)
+	script := `
+def compute_forecast(ctx):
+    result = 0
+    for i in range(100000000):
+        result = result + i
+    return []
+`
+
+	_, err = runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Now:               baseTime(),
+	})
+
+	require.Error(t, err)
+	assert.True(t,
+		errors.Is(err, saga.ErrTimeout) || strings.Contains(err.Error(), "timeout") || strings.Contains(err.Error(), "cancelled"),
+		"expected timeout error, got: %v", err)
+}
+
+func TestExecuteStrategy_SyntaxError(t *testing.T) {
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx)
+    return []
+`
+
+	_, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Now:               baseTime(),
+	})
+
+	require.Error(t, err)
+	assert.True(t,
+		errors.Is(err, ErrValidation) || strings.Contains(err.Error(), "syntax") || strings.Contains(err.Error(), "got newline"),
+		"expected validation/syntax error, got: %v", err)
+}
+
+func TestExecuteStrategy_MissingEntryPoint(t *testing.T) {
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+x = 42
+`
+
+	_, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Now:               baseTime(),
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrEntryPointMissing)
+}
+
+func TestExecuteStrategy_EmptyScript(t *testing.T) {
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	_, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            "",
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Now:               baseTime(),
+	})
+
+	require.ErrorIs(t, err, ErrScriptRequired)
+}
+
+// --- Validation tests ---
+
+func TestValidateForecastPoints_OutOfRange(t *testing.T) {
+	now := baseTime()
+	horizon := 24 * time.Hour
+	granularity := time.Hour
+
+	points := []ForecastPoint{
+		{
+			Timestamp: now.Add(-time.Hour), // before now
+			Value:     decimal.NewFromInt(1),
+		},
+	}
+
+	err := validateForecastPoints(points, now, horizon, granularity)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTimestampOutOfRange)
+}
+
+func TestValidateForecastPoints_NonMonotonic(t *testing.T) {
+	now := baseTime()
+	horizon := 24 * time.Hour
+	granularity := time.Hour
+
+	points := []ForecastPoint{
+		{Timestamp: now.Add(2 * time.Hour), Value: decimal.NewFromInt(1)},
+		{Timestamp: now.Add(1 * time.Hour), Value: decimal.NewFromInt(2)}, // out of order
+	}
+
+	err := validateForecastPoints(points, now, horizon, granularity)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNonMonotonic)
+}
+
+func TestValidateForecastPoints_GranularityMismatch(t *testing.T) {
+	now := baseTime()
+	horizon := 24 * time.Hour
+	granularity := time.Hour
+
+	points := []ForecastPoint{
+		{Timestamp: now.Add(30 * time.Minute), Value: decimal.NewFromInt(1)}, // 30min not aligned to 1h
+	}
+
+	err := validateForecastPoints(points, now, horizon, granularity)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrGranularityMismatch)
+}
+
+func TestValidateForecastPoints_Valid(t *testing.T) {
+	now := baseTime()
+	horizon := 24 * time.Hour
+	granularity := time.Hour
+
+	points := make([]ForecastPoint, 24)
+	for i := 0; i < 24; i++ {
+		points[i] = ForecastPoint{
+			Timestamp: now.Add(time.Duration(i+1) * time.Hour),
+			Value:     decimal.NewFromInt(int64(i)),
+		}
+	}
+
+	err := validateForecastPoints(points, now, horizon, granularity)
+	require.NoError(t, err)
+}
+
+// --- Empty data cold start handling ---
+
+func TestExecuteStrategy_EmptyObservations(t *testing.T) {
+	now := baseTime()
+
+	mis := &mockMISClient{
+		observations: map[string][]Observation{
+			"UTILIZATION_COMPUTE_HOUR": {}, // empty - cold start
+		},
+	}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    obs = ctx["observations"]["UTILIZATION_COMPUTE_HOUR"]
+    if len(obs) == 0:
+        default_value = 0.0
+    else:
+        total = 0.0
+        for o in obs:
+            total = total + float(o["value"])
+        default_value = total / len(obs)
+
+    now = ctx["now"]
+    granularity = int(ctx["granularity_seconds"])
+    horizon = int(ctx["horizon_seconds"])
+    num_points = horizon // granularity
+
+    points = []
+    for i in range(num_points):
+        offset = (i + 1) * granularity
+        ts = add_seconds(now, offset)
+        points.append({"timestamp": ts, "value": default_value})
+    return points
+`
+
+	points, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION_COMPUTE_HOUR"},
+		OutputDatasetCode: "FORECAST_UTILIZATION",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// All points should be zero (cold start)
+	for i, p := range points {
+		assert.True(t, p.Value.IsZero(), "point %d should be zero, got %s", i, p.Value)
+	}
+}
+
+// --- MIS client error test ---
+
+func TestExecuteStrategy_MISClientError(t *testing.T) {
+	mis := &mockMISClient{err: errors.New("connection refused")}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    return []
+`
+
+	_, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION_COMPUTE_HOUR"},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Now:               baseTime(),
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "fetch observations")
+	assert.Contains(t, err.Error(), "connection refused")
+}
+
+// --- Invalid return type test ---
+
+func TestExecuteStrategy_InvalidReturnType(t *testing.T) {
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script := `
+def compute_forecast(ctx):
+    return "not a list"
+`
+
+	_, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Now:               baseTime(),
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidReturnType)
+}
+
+// --- ForecastContext serialization ---
+
+func TestForecastContextToStarlark(t *testing.T) {
+	now := baseTime()
+
+	fc := &ForecastContext{
+		Observations: map[string][]Observation{
+			"DATASET_A": {
+				{Timestamp: now, Value: decimal.NewFromInt(42), Quality: "ACTUAL"},
+			},
+		},
+		ReferenceData: &ReferenceData{
+			NodeType:      "zone",
+			ResolutionKey: "region:us-east-1",
+			Attributes:    map[string]any{"capacity": "100"},
+		},
+		Horizon:     24 * time.Hour,
+		Granularity: time.Hour,
+		Now:         now,
+	}
+
+	dict := forecastContextToStarlark(fc)
+
+	// Verify it's frozen
+	err := dict.SetKey(starlarklib.String("test"), starlarklib.None)
+	assert.Error(t, err, "frozen dict should reject mutation")
+
+	// Verify observations key exists
+	obsVal, found, err := dict.Get(starlarklib.String("observations"))
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.NotNil(t, obsVal)
+
+	// Verify reference_data key exists
+	refVal, found, err := dict.Get(starlarklib.String("reference_data"))
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.NotEqual(t, starlarklib.None, refVal)
+
+	// Verify now
+	nowVal, found, err := dict.Get(starlarklib.String("now"))
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, starlarklib.String(now.Format(time.RFC3339)), nowVal)
+}
+
+func TestForecastContextToStarlark_NilReferenceData(t *testing.T) {
+	fc := &ForecastContext{
+		Observations:  map[string][]Observation{},
+		ReferenceData: nil,
+		Horizon:       time.Hour,
+		Granularity:   time.Hour,
+		Now:           baseTime(),
+	}
+
+	dict := forecastContextToStarlark(fc)
+
+	refVal, found, err := dict.Get(starlarklib.String("reference_data"))
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, starlarklib.None, refVal)
+}

--- a/services/forecasting/starlark/runner_test.go
+++ b/services/forecasting/starlark/runner_test.go
@@ -572,6 +572,63 @@ func TestExecuteStrategy_EmptyScript(t *testing.T) {
 	require.ErrorIs(t, err, ErrScriptRequired)
 }
 
+func TestExecuteStrategy_InvalidHorizon(t *testing.T) {
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	_, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            "def compute_forecast(ctx): return []",
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      0,
+		GranularityHours:  1,
+		Now:               baseTime(),
+	})
+
+	require.ErrorIs(t, err, ErrInvalidInput)
+	assert.Contains(t, err.Error(), "horizon_hours")
+}
+
+func TestExecuteStrategy_InvalidGranularity(t *testing.T) {
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	_, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            "def compute_forecast(ctx): return []",
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		HorizonHours:      24,
+		GranularityHours:  0,
+		Now:               baseTime(),
+	})
+
+	require.ErrorIs(t, err, ErrInvalidInput)
+	assert.Contains(t, err.Error(), "granularity_hours")
+}
+
+func TestExecuteStrategy_PartialRefDataConfig(t *testing.T) {
+	mis := &mockMISClient{observations: map[string][]Observation{}}
+	ref := &mockRefDataClient{nodes: map[string]*ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	// ResolutionKey set but TenantID empty
+	_, err := runner.ExecuteStrategy(context.Background(), StrategyInput{
+		Script:            "def compute_forecast(ctx): return []",
+		InputDatasetCodes: []string{},
+		OutputDatasetCode: "TEST",
+		ResolutionKey:     "region:us-east-1",
+		TenantID:          "",
+		HorizonHours:      1,
+		GranularityHours:  1,
+		Now:               baseTime(),
+	})
+
+	require.ErrorIs(t, err, ErrInvalidInput)
+	assert.Contains(t, err.Error(), "resolution_key and tenant_id must both be set")
+}
+
 // --- Validation tests ---
 
 func TestValidateForecastPoints_OutOfRange(t *testing.T) {

--- a/services/forecasting/starlark/runner_test.go
+++ b/services/forecasting/starlark/runner_test.go
@@ -251,7 +251,7 @@ def compute_forecast(ctx):
 	// 100 * 0.85 = 85
 	expectedValue := decimal.NewFromFloat(85)
 	assert.True(t, points[0].Value.Equal(expectedValue), "expected %s, got %s", expectedValue, points[0].Value)
-	assert.Equal(t, "\"capacity_adjusted\"", points[0].Metadata["source"])
+	assert.Equal(t, "capacity_adjusted", points[0].Metadata["source"])
 }
 
 // --- Builtin tests ---


### PR DESCRIPTION
## Summary

Implements Task Master task `market-data-dynamic-pricing.8`: Starlark sandbox for forecasting algorithms with ForecastContext.

- Adds a sandboxed Starlark execution environment in `services/forecasting/starlark/` that extends saga runtime patterns with forecasting-specific context injection, builtin functions, and output validation
- ForecastRunner orchestrates: fetch observations from MIS -> fetch reference data -> build ForecastContext -> execute script -> validate forecast points
- Interface-based dependency injection (MISClient, RefDataClient) for testability
- Safety guarantees inherited from go.starlark.net: no while loops, no recursion, configurable timeout (default 30s)

## Changes Made

### `services/forecasting/starlark/runner.go`
- `ForecastRunner` struct with `NewForecastRunner` constructor and `ExecuteStrategy` method
- `ForecastContext`: Observations, ReferenceData, Horizon, Granularity, Now - injected as frozen Starlark dict
- `ForecastPoint`: Timestamp, Value (decimal.Decimal), Metadata - output validation for timestamp range, monotonicity, granularity alignment
- `MISClient` and `RefDataClient` interfaces for dependency abstraction
- Starlark execution with goroutine-based timeout matching saga runtime pattern
- Uses `ExecFileOptions` (non-deprecated API)

### `services/forecasting/starlark/builtins.go`
- Statistical builtins: `avg`, `sum`, `percentile` (with linear interpolation)
- Time builtins: `duration(hours, minutes, seconds)`, `add_seconds(timestamp, seconds)`
- Observation helpers: `filter_by_hour(observations, hour)`, `group_by_hour(observations)`
- All builtins use proper sentinel errors with `%w` wrapping
- Decimal support via `saga.DecimalBuiltin()`

### `services/forecasting/starlark/runner_test.go`
- 22 tests covering all requirements

## Test Plan

- [x] Constructor validation (missing MIS client, missing ref data client, valid config, custom timeout)
- [x] Simple Moving Average strategy with 24h horizon
- [x] Reference data access in scripts
- [x] Statistical builtins: avg, sum, percentile
- [x] Time builtins: duration, add_seconds
- [x] Observation helpers: filter_by_hour, group_by_hour
- [x] Timeout enforcement (200ms timeout with long loop)
- [x] Syntax error detection
- [x] Missing entry point (no compute_forecast function)
- [x] Empty script rejection
- [x] Validation: out-of-range timestamps, non-monotonic, granularity mismatch, valid points
- [x] Empty observations cold start (returns empty forecast)
- [x] MIS client error propagation
- [x] Invalid return type from script
- [x] ForecastContext Starlark serialization (with and without reference data)