### PR TITLE
feat: Wire MarketDataPublisher into AuditConsumer handler chain

### DIFF
--- a/services/utilization-metering-consumer/adapters/messaging/audit_consumer.go
+++ b/services/utilization-metering-consumer/adapters/messaging/audit_consumer.go
@@ -33,6 +33,7 @@ type AuditConsumer struct {
 	consumer    *kafka.ProtoConsumer
 	transformer *auditdomain.AuditEventTransformer
 	pkClient    domain.PositionKeepingClient
+	mdPublisher domain.UtilizationPublisher
 	validator   protovalidate.Validator
 	logger      *slog.Logger
 }
@@ -40,18 +41,20 @@ type AuditConsumer struct {
 // NewAuditConsumer creates a new Kafka consumer for AuditEvent messages.
 // It connects to Kafka using the provided configuration and sets up a handler
 // that transforms audit events into utilization measurements and sends them
-// to the Position Keeping service.
+// to the Position Keeping service and optionally to MDS.
 //
 // Parameters:
 // - config: Kafka consumer configuration (bootstrap servers, group ID, etc.)
 // - transformer: Service that transforms audit events into utilization measurements
 // - pkClient: Client for communicating with Position Keeping service
+// - opts: Optional configuration (e.g., WithMDSPublisher)
 //
 // Returns an error if the consumer cannot be initialized or if dependencies are nil.
 func NewAuditConsumer(
 	config kafka.ConsumerConfig,
 	transformer *auditdomain.AuditEventTransformer,
 	pkClient domain.PositionKeepingClient,
+	opts ...AuditConsumerOption,
 ) (*AuditConsumer, error) {
 	if transformer == nil {
 		return nil, ErrNilTransformer
@@ -72,6 +75,10 @@ func NewAuditConsumer(
 		pkClient:    pkClient,
 		validator:   validator,
 		logger:      logger,
+	}
+
+	for _, opt := range opts {
+		opt(ac)
 	}
 
 	// Message factory creates new AuditEvent instances for deserialization
@@ -97,9 +104,21 @@ func NewAuditConsumer(
 	return ac, nil
 }
 
+// AuditConsumerOption configures optional behavior of the AuditConsumer.
+type AuditConsumerOption func(*AuditConsumer)
+
+// WithMDSPublisher sets the MDS publisher for dual-output fan-out.
+// When set, transformed measurements are also published to MDS asynchronously.
+// MDS failures are logged but do not block the PK path.
+func WithMDSPublisher(pub domain.UtilizationPublisher) AuditConsumerOption {
+	return func(ac *AuditConsumer) {
+		ac.mdPublisher = pub
+	}
+}
+
 // handleAuditEvent processes a single AuditEvent by transforming it into
 // a utilization measurement and sending it to the Position Keeping service
-// for tenant-zero billing.
+// for tenant-zero billing, and optionally to MDS for aggregation.
 func (ac *AuditConsumer) handleAuditEvent(ctx context.Context, event *auditv1.AuditEvent) error {
 	// Start timing for processing duration metric
 	startTime := time.Now()
@@ -137,14 +156,24 @@ func (ac *AuditConsumer) handleAuditEvent(ctx context.Context, event *auditv1.Au
 		return nil
 	}
 
-	// Send measurement to Position Keeping service
+	// Send measurement to Position Keeping service (synchronous, failure short-circuits)
+	pkStart := time.Now()
 	if err := ac.pkClient.RecordMeasurement(ctx, measurement); err != nil {
 		domain.RecordPositionKeepingAPIError("record_measurement_failed")
+		domain.RecordDualOutputLatency("pk", time.Since(pkStart).Seconds())
 		return fmt.Errorf("failed to record measurement for event %s: %w", event.EventId, err)
 	}
+	domain.RecordDualOutputLatency("pk", time.Since(pkStart).Seconds())
 
 	// Record successful measurement metric
 	domain.RecordMeasurementRecorded(event.SchemaName, measurement.AssetCode)
+
+	// Fan out to MDS (async buffer, failure does not block)
+	if ac.mdPublisher != nil {
+		mdsStart := time.Now()
+		ac.publishToMDS(measurement)
+		domain.RecordDualOutputLatency("mds", time.Since(mdsStart).Seconds())
+	}
 
 	// Record processing duration metric
 	duration := time.Since(startTime).Seconds()
@@ -155,9 +184,27 @@ func (ac *AuditConsumer) handleAuditEvent(ctx context.Context, event *auditv1.Au
 		"account_id", measurement.AccountID,
 		"asset_code", measurement.AssetCode,
 		"service", event.SchemaName,
-		"quantity", measurement.Quantity)
+		"quantity", measurement.Quantity,
+		"mds_enabled", ac.mdPublisher != nil)
 
 	return nil
+}
+
+// publishToMDS converts the measurement and publishes it to MDS via the buffer.
+// Errors are logged but do not propagate (eventual consistency for MDS).
+func (ac *AuditConsumer) publishToMDS(measurement *auditdomain.Measurement) {
+	defer func() {
+		if r := recover(); r != nil {
+			ac.logger.Error("panic in MDS publish",
+				"error", r,
+				"measurement_id", measurement.ID)
+			domain.RecordMDSPublish("error")
+		}
+	}()
+
+	utilMeasurement := domain.MeasurementToUtilization(measurement)
+	ac.mdPublisher.Publish(utilMeasurement)
+	domain.RecordMDSPublish("success")
 }
 
 // Start begins consuming AuditEvent messages from the specified topics.
@@ -171,6 +218,7 @@ func (ac *AuditConsumer) handleAuditEvent(ctx context.Context, event *auditv1.Au
 // - Validate using protovalidate
 // - Transform to utilization measurements
 // - Send to Position Keeping service
+// - Optionally buffer to MDS publisher
 // - Commit offsets after successful processing
 //
 // Parameters:
@@ -178,7 +226,7 @@ func (ac *AuditConsumer) handleAuditEvent(ctx context.Context, event *auditv1.Au
 //
 // Returns an error if subscription fails. Call Stop() to gracefully shutdown consumption.
 func (ac *AuditConsumer) Start(topics []string) error {
-	ac.logger.Info("starting audit consumer", "topics", topics)
+	ac.logger.Info("starting audit consumer", "topics", topics, "mds_enabled", ac.mdPublisher != nil)
 	if err := ac.consumer.Subscribe(topics); err != nil {
 		return fmt.Errorf("failed to subscribe to topics: %w", err)
 	}

--- a/services/utilization-metering-consumer/adapters/messaging/audit_consumer_test.go
+++ b/services/utilization-metering-consumer/adapters/messaging/audit_consumer_test.go
@@ -679,7 +679,7 @@ func TestAuditConsumer_DualOutput_BothReceiveCalls(t *testing.T) {
 	assert.Equal(t, "00000000-0000-0000-0000-000000000000", mdsMeasurements[0].TenantID)
 }
 
-func TestAuditConsumer_DualOutput_PKFailurePreventsOnlMDSCall(t *testing.T) {
+func TestAuditConsumer_DualOutput_PKFailurePreventsOnlyMDSCall(t *testing.T) {
 	transformer := newTestTransformer()
 
 	mockPK := newMockPositionKeepingClient()

--- a/services/utilization-metering-consumer/adapters/messaging/audit_consumer_test.go
+++ b/services/utilization-metering-consumer/adapters/messaging/audit_consumer_test.go
@@ -3,6 +3,7 @@ package messaging
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -73,6 +74,40 @@ func (m *mockPositionKeepingClient) getMeasurements() []*auditdomain.Measurement
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	result := make([]*auditdomain.Measurement, len(m.measurements))
+	copy(result, m.measurements)
+	return result
+}
+
+// mockUtilizationPublisher implements domain.UtilizationPublisher for testing
+type mockUtilizationPublisher struct {
+	mu           sync.Mutex
+	measurements []*domain.UtilizationMeasurement
+	publishFunc  func(m *domain.UtilizationMeasurement)
+}
+
+func newMockUtilizationPublisher() *mockUtilizationPublisher {
+	return &mockUtilizationPublisher{
+		measurements: make([]*domain.UtilizationMeasurement, 0),
+	}
+}
+
+func (m *mockUtilizationPublisher) Publish(measurement *domain.UtilizationMeasurement) {
+	m.mu.Lock()
+	m.measurements = append(m.measurements, measurement)
+	m.mu.Unlock()
+	if m.publishFunc != nil {
+		m.publishFunc(measurement)
+	}
+}
+
+func (m *mockUtilizationPublisher) Stop() {
+	// No-op for testing
+}
+
+func (m *mockUtilizationPublisher) getMeasurements() []*domain.UtilizationMeasurement {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]*domain.UtilizationMeasurement, len(m.measurements))
 	copy(result, m.measurements)
 	return result
 }
@@ -160,6 +195,30 @@ func TestNewAuditConsumer(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewAuditConsumer_WithMDSPublisher(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+	mockMDS := newMockUtilizationPublisher()
+
+	consumer, err := NewAuditConsumer(
+		kafka.ConsumerConfig{
+			BootstrapServers: "localhost:9092",
+			GroupID:          "test-group",
+		},
+		transformer,
+		mockPK,
+		WithMDSPublisher(mockMDS),
+	)
+	if err != nil {
+		t.Skip("Kafka not available, skipping integration test")
+	}
+	defer func() {
+		_ = consumer.Close()
+	}()
+
+	assert.NotNil(t, consumer.mdPublisher, "MDS publisher should be set via option")
 }
 
 func TestAuditConsumer_handleAuditEvent_ValidEvent(t *testing.T) {
@@ -554,4 +613,268 @@ func TestProtoValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// --- Dual-output integration tests ---
+
+func TestAuditConsumer_DualOutput_BothReceiveCalls(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+	mockMDS := newMockUtilizationPublisher()
+
+	consumer, err := NewAuditConsumer(
+		kafka.ConsumerConfig{
+			BootstrapServers: "localhost:9092",
+			GroupID:          "test-group",
+		},
+		transformer,
+		mockPK,
+		WithMDSPublisher(mockMDS),
+	)
+	if err != nil {
+		t.Skip("Kafka not available, skipping integration test")
+	}
+	defer func() {
+		_ = consumer.Close()
+	}()
+
+	event := &auditv1.AuditEvent{
+		EventId:       "550e8400-e29b-41d4-a716-446655440020",
+		SchemaName:    "current_account",
+		TableName:     "current_account",
+		Operation:     auditv1.AuditOperation_AUDIT_OPERATION_INSERT,
+		RecordId:      "rec-dual-1",
+		ChangedBy:     "test-user",
+		CorrelationId: "corr-dual-1",
+		Timestamp:     timestamppb.Now(),
+		Metadata: map[string]string{
+			"tenant_id": "00000000-0000-0000-0000-000000000000",
+		},
+	}
+
+	ctx := context.Background()
+	err = consumer.handleAuditEvent(ctx, event)
+	require.NoError(t, err)
+
+	// Verify PK received the measurement
+	err = await.New().AtMost(1 * time.Second).Until(func() bool {
+		return len(mockPK.getMeasurements()) > 0
+	})
+	require.NoError(t, err, "PK should receive measurement")
+
+	pkMeasurements := mockPK.getMeasurements()
+	require.Len(t, pkMeasurements, 1)
+	assert.Equal(t, "MERIDIAN-CURRENT-ACCOUNT-OPS", pkMeasurements[0].AssetCode)
+
+	// Verify MDS received the measurement
+	err = await.New().AtMost(1 * time.Second).Until(func() bool {
+		return len(mockMDS.getMeasurements()) > 0
+	})
+	require.NoError(t, err, "MDS should receive measurement")
+
+	mdsMeasurements := mockMDS.getMeasurements()
+	require.Len(t, mdsMeasurements, 1)
+	assert.Equal(t, "current_account", mdsMeasurements[0].ServiceName)
+	assert.Equal(t, "INSERT", mdsMeasurements[0].OperationType)
+	assert.Equal(t, "00000000-0000-0000-0000-000000000000", mdsMeasurements[0].TenantID)
+}
+
+func TestAuditConsumer_DualOutput_PKFailurePreventsOnlMDSCall(t *testing.T) {
+	transformer := newTestTransformer()
+
+	mockPK := newMockPositionKeepingClient()
+	mockPK.recordMeasurementFunc = func(_ context.Context, _ *auditdomain.Measurement) error {
+		return errPKUnavailable
+	}
+
+	mockMDS := newMockUtilizationPublisher()
+
+	consumer, err := NewAuditConsumer(
+		kafka.ConsumerConfig{
+			BootstrapServers: "localhost:9092",
+			GroupID:          "test-group",
+		},
+		transformer,
+		mockPK,
+		WithMDSPublisher(mockMDS),
+	)
+	if err != nil {
+		t.Skip("Kafka not available, skipping integration test")
+	}
+	defer func() {
+		_ = consumer.Close()
+	}()
+
+	event := &auditv1.AuditEvent{
+		EventId:       "550e8400-e29b-41d4-a716-446655440021",
+		SchemaName:    "current_account",
+		TableName:     "current_account",
+		Operation:     auditv1.AuditOperation_AUDIT_OPERATION_INSERT,
+		RecordId:      "rec-pk-fail",
+		ChangedBy:     "test-user",
+		CorrelationId: "corr-pk-fail",
+		Timestamp:     timestamppb.Now(),
+		Metadata: map[string]string{
+			"tenant_id": "00000000-0000-0000-0000-000000000000",
+		},
+	}
+
+	ctx := context.Background()
+	err = consumer.handleAuditEvent(ctx, event)
+
+	require.Error(t, err, "PK failure should short-circuit")
+	assert.Contains(t, err.Error(), "failed to record measurement")
+
+	// MDS should NOT receive the measurement since PK failed first
+	assert.Empty(t, mockMDS.getMeasurements(), "MDS should not receive measurement when PK fails")
+}
+
+func TestAuditConsumer_DualOutput_MDSFailureDoesNotBlockPK(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+
+	mockMDS := newMockUtilizationPublisher()
+	mockMDS.publishFunc = func(_ *domain.UtilizationMeasurement) {
+		panic("MDS publisher panicked")
+	}
+
+	consumer, err := NewAuditConsumer(
+		kafka.ConsumerConfig{
+			BootstrapServers: "localhost:9092",
+			GroupID:          "test-group",
+		},
+		transformer,
+		mockPK,
+		WithMDSPublisher(mockMDS),
+	)
+	if err != nil {
+		t.Skip("Kafka not available, skipping integration test")
+	}
+	defer func() {
+		_ = consumer.Close()
+	}()
+
+	event := &auditv1.AuditEvent{
+		EventId:       "550e8400-e29b-41d4-a716-446655440022",
+		SchemaName:    "current_account",
+		TableName:     "current_account",
+		Operation:     auditv1.AuditOperation_AUDIT_OPERATION_INSERT,
+		RecordId:      "rec-mds-fail",
+		ChangedBy:     "test-user",
+		CorrelationId: "corr-mds-fail",
+		Timestamp:     timestamppb.Now(),
+		Metadata: map[string]string{
+			"tenant_id": "00000000-0000-0000-0000-000000000000",
+		},
+	}
+
+	ctx := context.Background()
+	err = consumer.handleAuditEvent(ctx, event)
+
+	// Should succeed - MDS panic should NOT block the handler
+	require.NoError(t, err, "MDS failure should not block PK path")
+
+	// PK should still have received the measurement
+	err = await.New().AtMost(1 * time.Second).Until(func() bool {
+		return len(mockPK.getMeasurements()) > 0
+	})
+	require.NoError(t, err, "PK should receive measurement despite MDS failure")
+	assert.Len(t, mockPK.getMeasurements(), 1)
+}
+
+func TestAuditConsumer_DualOutput_WithoutMDSPublisher(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+
+	// No MDS publisher option - backward compatible
+	consumer, err := NewAuditConsumer(
+		kafka.ConsumerConfig{
+			BootstrapServers: "localhost:9092",
+			GroupID:          "test-group",
+		},
+		transformer,
+		mockPK,
+	)
+	if err != nil {
+		t.Skip("Kafka not available, skipping integration test")
+	}
+	defer func() {
+		_ = consumer.Close()
+	}()
+
+	event := &auditv1.AuditEvent{
+		EventId:       "550e8400-e29b-41d4-a716-446655440023",
+		SchemaName:    "current_account",
+		TableName:     "current_account",
+		Operation:     auditv1.AuditOperation_AUDIT_OPERATION_INSERT,
+		RecordId:      "rec-no-mds",
+		ChangedBy:     "test-user",
+		CorrelationId: "corr-no-mds",
+		Timestamp:     timestamppb.Now(),
+		Metadata: map[string]string{
+			"tenant_id": "00000000-0000-0000-0000-000000000000",
+		},
+	}
+
+	ctx := context.Background()
+	err = consumer.handleAuditEvent(ctx, event)
+
+	require.NoError(t, err, "Should work fine without MDS publisher")
+
+	// PK should still receive measurement
+	err = await.New().AtMost(1 * time.Second).Until(func() bool {
+		return len(mockPK.getMeasurements()) > 0
+	})
+	require.NoError(t, err)
+	assert.Len(t, mockPK.getMeasurements(), 1)
+}
+
+func TestAuditConsumer_DualOutput_MultipleEvents(t *testing.T) {
+	transformer := newTestTransformer()
+	mockPK := newMockPositionKeepingClient()
+	mockMDS := newMockUtilizationPublisher()
+
+	consumer, err := NewAuditConsumer(
+		kafka.ConsumerConfig{
+			BootstrapServers: "localhost:9092",
+			GroupID:          "test-group",
+		},
+		transformer,
+		mockPK,
+		WithMDSPublisher(mockMDS),
+	)
+	if err != nil {
+		t.Skip("Kafka not available, skipping integration test")
+	}
+	defer func() {
+		_ = consumer.Close()
+	}()
+
+	eventCount := 10
+	ctx := context.Background()
+
+	for i := range eventCount {
+		event := &auditv1.AuditEvent{
+			EventId:       uuid.New().String(),
+			SchemaName:    "current_account",
+			TableName:     "current_account",
+			Operation:     auditv1.AuditOperation_AUDIT_OPERATION_INSERT,
+			RecordId:      fmt.Sprintf("rec-multi-%d", i),
+			ChangedBy:     "test-user",
+			CorrelationId: fmt.Sprintf("corr-multi-%d", i),
+			Timestamp:     timestamppb.Now(),
+			Metadata: map[string]string{
+				"tenant_id": "00000000-0000-0000-0000-000000000000",
+			},
+		}
+		err = consumer.handleAuditEvent(ctx, event)
+		require.NoError(t, err, "Event %d should succeed", i)
+	}
+
+	// Both outputs should receive all events
+	err = await.New().AtMost(2 * time.Second).Until(func() bool {
+		return len(mockPK.getMeasurements()) == eventCount &&
+			len(mockMDS.getMeasurements()) == eventCount
+	})
+	require.NoError(t, err, "Both PK and MDS should receive all %d events", eventCount)
 }

--- a/services/utilization-metering-consumer/app/config.go
+++ b/services/utilization-metering-consumer/app/config.go
@@ -4,6 +4,7 @@ package app
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/meridianhub/meridian/shared/platform/env"
@@ -37,6 +38,12 @@ type Config struct {
 
 	// HTTP server configuration
 	HTTPPort string // HTTP port for health checks and metrics (default: "8080")
+
+	// MDS (Market Data Service) configuration
+	EnableMDSOutput      bool          // Feature flag for MDS output (default: true)
+	MDSServiceAddr       string        // gRPC address for Market Data Service (e.g., "market-information:50058")
+	MDSAggregationWindow time.Duration // Aggregation window size (default: 1h)
+	MDSFlushInterval     time.Duration // Flush interval for buffered observations (default: 5m)
 }
 
 // LoadConfig loads configuration from environment variables.
@@ -60,6 +67,10 @@ func LoadConfig() (*Config, error) {
 		TenantZeroID:            env.GetEnvOrDefault("TENANT_ZERO_ID", ""),
 		TenantAccountMapping:    env.GetEnvOrDefault("TENANT_ACCOUNT_MAPPING", ""),
 		HTTPPort:                env.GetEnvOrDefault("HTTP_PORT", "8080"),
+		EnableMDSOutput:         env.GetEnvAsBool("ENABLE_MDS_OUTPUT", true),
+		MDSServiceAddr:          env.GetEnvOrDefault("MDS_SERVICE_ADDR", ""),
+		MDSAggregationWindow:    env.GetEnvAsDuration("MDS_AGGREGATION_WINDOW", 1*time.Hour),
+		MDSFlushInterval:        env.GetEnvAsDuration("MDS_FLUSH_INTERVAL", 5*time.Minute),
 	}
 
 	// Validate required configuration

--- a/services/utilization-metering-consumer/app/config_test.go
+++ b/services/utilization-metering-consumer/app/config_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestLoadConfig_Success(t *testing.T) {
@@ -279,5 +280,98 @@ func TestLoadConfig_DefaultConsumerGroupID(t *testing.T) {
 
 	if config.ConsumerGroupID != "utilization-metering-consumer" {
 		t.Errorf("Expected ConsumerGroupID to be 'utilization-metering-consumer' (default), got '%s'", config.ConsumerGroupID)
+	}
+}
+
+func TestLoadConfig_MDSDefaults(t *testing.T) {
+	// Set required environment variables
+	envVars := map[string]string{
+		"KAFKA_BOOTSTRAP_SERVERS":   "kafka:9092",
+		"POSITION_KEEPING_ENDPOINT": "position-keeping:50051",
+		"TENANT_ZERO_ID":            "00000000-0000-0000-0000-000000000000",
+	}
+
+	backup := make(map[string]string)
+	for key, value := range envVars {
+		backup[key] = os.Getenv(key)
+		os.Setenv(key, value)
+	}
+	// Clear MDS-related vars to test defaults
+	mdsKeys := []string{"ENABLE_MDS_OUTPUT", "MDS_SERVICE_ADDR", "MDS_AGGREGATION_WINDOW", "MDS_FLUSH_INTERVAL"}
+	for _, key := range mdsKeys {
+		backup[key] = os.Getenv(key)
+		os.Unsetenv(key)
+	}
+	defer func() {
+		for key, value := range backup {
+			if value == "" {
+				os.Unsetenv(key)
+			} else {
+				os.Setenv(key, value)
+			}
+		}
+	}()
+
+	config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() failed: %v", err)
+	}
+
+	if !config.EnableMDSOutput {
+		t.Error("Expected EnableMDSOutput to default to true")
+	}
+	if config.MDSServiceAddr != "" {
+		t.Errorf("Expected MDSServiceAddr to be empty by default, got '%s'", config.MDSServiceAddr)
+	}
+	if config.MDSAggregationWindow != 1*time.Hour {
+		t.Errorf("Expected MDSAggregationWindow to default to 1h, got %v", config.MDSAggregationWindow)
+	}
+	if config.MDSFlushInterval != 5*time.Minute {
+		t.Errorf("Expected MDSFlushInterval to default to 5m, got %v", config.MDSFlushInterval)
+	}
+}
+
+func TestLoadConfig_MDSCustomValues(t *testing.T) {
+	envVars := map[string]string{
+		"KAFKA_BOOTSTRAP_SERVERS":   "kafka:9092",
+		"POSITION_KEEPING_ENDPOINT": "position-keeping:50051",
+		"TENANT_ZERO_ID":            "00000000-0000-0000-0000-000000000000",
+		"ENABLE_MDS_OUTPUT":         "false",
+		"MDS_SERVICE_ADDR":          "market-information:50058",
+		"MDS_AGGREGATION_WINDOW":    "30m",
+		"MDS_FLUSH_INTERVAL":        "2m",
+	}
+
+	backup := make(map[string]string)
+	for key, value := range envVars {
+		backup[key] = os.Getenv(key)
+		os.Setenv(key, value)
+	}
+	defer func() {
+		for key, value := range backup {
+			if value == "" {
+				os.Unsetenv(key)
+			} else {
+				os.Setenv(key, value)
+			}
+		}
+	}()
+
+	config, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() failed: %v", err)
+	}
+
+	if config.EnableMDSOutput {
+		t.Error("Expected EnableMDSOutput to be false")
+	}
+	if config.MDSServiceAddr != "market-information:50058" {
+		t.Errorf("Expected MDSServiceAddr to be 'market-information:50058', got '%s'", config.MDSServiceAddr)
+	}
+	if config.MDSAggregationWindow != 30*time.Minute {
+		t.Errorf("Expected MDSAggregationWindow to be 30m, got %v", config.MDSAggregationWindow)
+	}
+	if config.MDSFlushInterval != 2*time.Minute {
+		t.Errorf("Expected MDSFlushInterval to be 2m, got %v", config.MDSFlushInterval)
 	}
 }

--- a/services/utilization-metering-consumer/cmd/main.go
+++ b/services/utilization-metering-consumer/cmd/main.go
@@ -15,11 +15,14 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	marketinformationv1 "github.com/meridianhub/meridian/api/proto/meridian/market_information/v1"
 	auditdomain "github.com/meridianhub/meridian/services/audit-worker/domain"
 	"github.com/meridianhub/meridian/services/utilization-metering-consumer/adapters/grpc"
+	"github.com/meridianhub/meridian/services/utilization-metering-consumer/adapters/mds"
 	"github.com/meridianhub/meridian/services/utilization-metering-consumer/adapters/messaging"
 	"github.com/meridianhub/meridian/services/utilization-metering-consumer/app"
 	"github.com/meridianhub/meridian/services/utilization-metering-consumer/domain"
+	platformgrpc "github.com/meridianhub/meridian/shared/pkg/grpc"
 	"github.com/meridianhub/meridian/shared/platform/bootstrap"
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 	"github.com/meridianhub/meridian/shared/platform/env"
@@ -123,7 +126,9 @@ func run(logger *slog.Logger) error {
 		"consumer_group_id", config.ConsumerGroupID,
 		"audit_topics", config.AuditTopics,
 		"position_keeping_endpoint", config.PositionKeepingEndpoint,
-		"tenant_zero_id", config.TenantZeroID)
+		"tenant_zero_id", config.TenantZeroID,
+		"enable_mds_output", config.EnableMDSOutput,
+		"mds_service_addr", config.MDSServiceAddr)
 
 	// Create readiness tracker
 	var (
@@ -185,6 +190,30 @@ func run(logger *slog.Logger) error {
 		}
 	}()
 
+	// Initialize MDS publisher (optional, controlled by feature flag)
+	var consumerOpts []messaging.AuditConsumerOption
+	var mdPublisher *mds.MarketDataPublisher
+
+	if config.EnableMDSOutput && config.MDSServiceAddr != "" {
+		logger.Info("initializing MDS publisher",
+			"mds_service_addr", config.MDSServiceAddr,
+			"aggregation_window", config.MDSAggregationWindow,
+			"flush_interval", config.MDSFlushInterval)
+
+		mdPublisher, err = initMDSPublisher(config, logger)
+		if err != nil {
+			logger.Error("failed to initialize MDS publisher, continuing without MDS output",
+				"error", err)
+		} else {
+			consumerOpts = append(consumerOpts, messaging.WithMDSPublisher(mdPublisher))
+			defer mdPublisher.Stop()
+		}
+	} else {
+		logger.Info("MDS output disabled",
+			"enable_mds_output", config.EnableMDSOutput,
+			"mds_service_addr", config.MDSServiceAddr)
+	}
+
 	// Parse tenant zero ID
 	tenantZeroID, err := uuid.Parse(config.TenantZeroID)
 	if err != nil {
@@ -223,7 +252,7 @@ func run(logger *slog.Logger) error {
 		EnableAutoCommit: false, // Manual commit for at-least-once semantics
 	}
 
-	consumer, err := messaging.NewAuditConsumer(kafkaConfig, transformer, pkClient)
+	consumer, err := messaging.NewAuditConsumer(kafkaConfig, transformer, pkClient, consumerOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to create audit consumer: %w", err)
 	}
@@ -280,6 +309,13 @@ func run(logger *slog.Logger) error {
 	consumer.Stop()
 	logger.Info("kafka consumer stopped")
 
+	// Flush pending MDS aggregations before shutting down
+	if mdPublisher != nil {
+		logger.Info("flushing MDS publisher...")
+		mdPublisher.Stop()
+		logger.Info("MDS publisher stopped")
+	}
+
 	// Shutdown HTTP server
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		logger.Error("HTTP server shutdown error", "error", err)
@@ -288,4 +324,46 @@ func run(logger *slog.Logger) error {
 	}
 
 	return nil
+}
+
+// initMDSPublisher creates and returns a MarketDataPublisher connected to the MDS gRPC service.
+func initMDSPublisher(config *app.Config, logger *slog.Logger) (*mds.MarketDataPublisher, error) {
+	// Parse port from MDS service address
+	var mdsPort int
+	if lastColon := strings.LastIndex(config.MDSServiceAddr, ":"); lastColon != -1 {
+		if _, err := fmt.Sscanf(config.MDSServiceAddr[lastColon:], ":%d", &mdsPort); err != nil || mdsPort == 0 {
+			mdsPort = ports.MarketInformation
+		}
+	} else {
+		mdsPort = ports.MarketInformation
+	}
+
+	// Extract service name from address (everything before the last colon)
+	mdsServiceName := config.MDSServiceAddr
+	if lastColon := strings.LastIndex(mdsServiceName, ":"); lastColon != -1 {
+		mdsServiceName = mdsServiceName[:lastColon]
+	}
+
+	conn, err := platformgrpc.NewClient(context.Background(), platformgrpc.ClientConfig{
+		ServiceName: mdsServiceName,
+		Namespace:   env.GetEnvOrDefault("K8S_NAMESPACE", "default"),
+		Port:        mdsPort,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create MDS gRPC connection: %w", err)
+	}
+
+	mdsClient := marketinformationv1.NewMarketInformationServiceClient(conn)
+
+	publisher, err := mds.NewMarketDataPublisher(mdsClient, mds.Config{
+		WindowSize:    config.MDSAggregationWindow,
+		FlushInterval: config.MDSFlushInterval,
+		Logger:        logger,
+	})
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to create MDS publisher: %w", err)
+	}
+
+	return publisher, nil
 }

--- a/services/utilization-metering-consumer/cmd/main.go
+++ b/services/utilization-metering-consumer/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/kafka"
 	"github.com/meridianhub/meridian/shared/platform/ports"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	grpclib "google.golang.org/grpc"
 )
 
 // Build information set via ldflags during compilation
@@ -193,6 +194,7 @@ func run(logger *slog.Logger) error {
 	// Initialize MDS publisher (optional, controlled by feature flag)
 	var consumerOpts []messaging.AuditConsumerOption
 	var mdPublisher *mds.MarketDataPublisher
+	var mdsConn *grpclib.ClientConn
 
 	if config.EnableMDSOutput && config.MDSServiceAddr != "" {
 		logger.Info("initializing MDS publisher",
@@ -200,7 +202,7 @@ func run(logger *slog.Logger) error {
 			"aggregation_window", config.MDSAggregationWindow,
 			"flush_interval", config.MDSFlushInterval)
 
-		mdPublisher, err = initMDSPublisher(config, logger)
+		mdPublisher, mdsConn, err = initMDSPublisher(config, logger)
 		if err != nil {
 			logger.Error("failed to initialize MDS publisher, continuing without MDS output",
 				"error", err)
@@ -308,11 +310,16 @@ func run(logger *slog.Logger) error {
 	consumer.Stop()
 	logger.Info("kafka consumer stopped")
 
-	// Flush pending MDS aggregations before shutting down
+	// Flush pending MDS aggregations and close gRPC connection
 	if mdPublisher != nil {
 		logger.Info("flushing MDS publisher...")
 		mdPublisher.Stop()
 		logger.Info("MDS publisher stopped")
+	}
+	if mdsConn != nil {
+		if err := mdsConn.Close(); err != nil {
+			logger.Error("failed to close MDS gRPC connection", "error", err)
+		}
 	}
 
 	// Shutdown HTTP server
@@ -325,8 +332,9 @@ func run(logger *slog.Logger) error {
 	return nil
 }
 
-// initMDSPublisher creates and returns a MarketDataPublisher connected to the MDS gRPC service.
-func initMDSPublisher(config *app.Config, logger *slog.Logger) (*mds.MarketDataPublisher, error) {
+// initMDSPublisher creates and returns a MarketDataPublisher and its underlying gRPC connection.
+// The caller is responsible for closing the connection after stopping the publisher.
+func initMDSPublisher(config *app.Config, logger *slog.Logger) (*mds.MarketDataPublisher, *grpclib.ClientConn, error) {
 	// Parse port from MDS service address
 	var mdsPort int
 	if lastColon := strings.LastIndex(config.MDSServiceAddr, ":"); lastColon != -1 {
@@ -349,7 +357,7 @@ func initMDSPublisher(config *app.Config, logger *slog.Logger) (*mds.MarketDataP
 		Port:        mdsPort,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create MDS gRPC connection: %w", err)
+		return nil, nil, fmt.Errorf("failed to create MDS gRPC connection: %w", err)
 	}
 
 	mdsClient := marketinformationv1.NewMarketInformationServiceClient(conn)
@@ -361,8 +369,8 @@ func initMDSPublisher(config *app.Config, logger *slog.Logger) (*mds.MarketDataP
 	})
 	if err != nil {
 		_ = conn.Close()
-		return nil, fmt.Errorf("failed to create MDS publisher: %w", err)
+		return nil, nil, fmt.Errorf("failed to create MDS publisher: %w", err)
 	}
 
-	return publisher, nil
+	return publisher, conn, nil
 }

--- a/services/utilization-metering-consumer/cmd/main.go
+++ b/services/utilization-metering-consumer/cmd/main.go
@@ -206,7 +206,6 @@ func run(logger *slog.Logger) error {
 				"error", err)
 		} else {
 			consumerOpts = append(consumerOpts, messaging.WithMDSPublisher(mdPublisher))
-			defer mdPublisher.Stop()
 		}
 	} else {
 		logger.Info("MDS output disabled",

--- a/services/utilization-metering-consumer/domain/measurement.go
+++ b/services/utilization-metering-consumer/domain/measurement.go
@@ -4,6 +4,7 @@ package domain
 import (
 	"time"
 
+	auditdomain "github.com/meridianhub/meridian/services/audit-worker/domain"
 	"github.com/meridianhub/meridian/shared/platform/quantity"
 )
 
@@ -30,4 +31,29 @@ type UtilizationMeasurement struct {
 
 	// CorrelationID links the measurement back to the original audit event
 	CorrelationID string
+}
+
+// MeasurementToUtilization converts an auditdomain.Measurement to a UtilizationMeasurement
+// for the MDS publishing path. The conversion maps:
+//   - AccountID.String() -> TenantID
+//   - Attributes["service"] -> ServiceName
+//   - Attributes["operation"] -> OperationType
+//   - Quantity + instrument lookup -> Amount
+//   - Period.Start -> Timestamp
+//   - ID.String() -> CorrelationID
+func MeasurementToUtilization(m *auditdomain.Measurement) *UtilizationMeasurement {
+	unitAttr := "operation"
+	if attr, ok := m.Attributes["unit"]; ok {
+		unitAttr = attr
+	}
+	instrument := InstrumentForMeasurementType(unitAttr)
+
+	return &UtilizationMeasurement{
+		TenantID:      m.AccountID.String(),
+		ServiceName:   m.Attributes["service"],
+		OperationType: m.Attributes["operation"],
+		Amount:        quantity.NewAsset(m.Quantity, instrument),
+		Timestamp:     m.Period.Start,
+		CorrelationID: m.ID.String(),
+	}
 }

--- a/services/utilization-metering-consumer/domain/measurement_test.go
+++ b/services/utilization-metering-consumer/domain/measurement_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	auditdomain "github.com/meridianhub/meridian/services/audit-worker/domain"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -410,4 +413,66 @@ func TestUtilizationMeasurement_InstrumentPrecision(t *testing.T) {
 	assert.Equal(t, 0, apiCallInstrument.Precision)     // Whole API calls (COUNT)
 	assert.Equal(t, 6, storageGBInstrument.Precision)   // Six decimal places for storage (DATA)
 	assert.Equal(t, 6, computeHourInstrument.Precision) // Six decimal places for compute time (COMPUTE)
+}
+
+// =============================================================================
+// MeasurementToUtilization conversion tests
+// =============================================================================
+
+func TestMeasurementToUtilization(t *testing.T) {
+	accountID := uuid.MustParse("00000000-0000-0000-0000-000000000000")
+	measurementID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	now := time.Now()
+
+	m := &auditdomain.Measurement{
+		ID:        measurementID,
+		AccountID: accountID,
+		AssetCode: "MERIDIAN-CURRENT-ACCOUNT-OPS",
+		Quantity:  decimal.NewFromInt(1),
+		Period: auditdomain.Period{
+			Start: now,
+			End:   now,
+		},
+		Attributes: map[string]string{
+			"service":   "current_account",
+			"operation": "INSERT",
+		},
+		Source:       "AUDIT_STREAM",
+		QualityScore: 80,
+	}
+
+	result := MeasurementToUtilization(m)
+
+	assert.Equal(t, accountID.String(), result.TenantID)
+	assert.Equal(t, "current_account", result.ServiceName)
+	assert.Equal(t, "INSERT", result.OperationType)
+	assert.Equal(t, now, result.Timestamp)
+	assert.Equal(t, measurementID.String(), result.CorrelationID)
+	// Default instrument for "operation" unit type
+	assert.Equal(t, "OPERATION", result.Amount.GetInstrument().Code)
+	assert.Equal(t, "1", result.Amount.GetAmount().String())
+}
+
+func TestMeasurementToUtilization_WithUnitAttribute(t *testing.T) {
+	m := &auditdomain.Measurement{
+		ID:        uuid.New(),
+		AccountID: uuid.New(),
+		AssetCode: "MERIDIAN-API-CALL",
+		Quantity:  decimal.NewFromInt(5),
+		Period: auditdomain.Period{
+			Start: time.Now(),
+			End:   time.Now(),
+		},
+		Attributes: map[string]string{
+			"service":   "payment_order",
+			"operation": "ProcessPayment",
+			"unit":      "api_call",
+		},
+		Source: "AUDIT_STREAM",
+	}
+
+	result := MeasurementToUtilization(m)
+
+	assert.Equal(t, "API_CALL", result.Amount.GetInstrument().Code)
+	assert.Equal(t, "5", result.Amount.GetAmount().String())
 }

--- a/services/utilization-metering-consumer/domain/metrics.go
+++ b/services/utilization-metering-consumer/domain/metrics.go
@@ -91,6 +91,31 @@ var (
 		},
 		[]string{"service"},
 	)
+
+	// mdsPublishTotal counts MDS publish attempts by status.
+	// Labels: status ("success", "error")
+	mdsPublishTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "meridian",
+			Subsystem: "utilization_metering",
+			Name:      "mds_publish_total",
+			Help:      "Total number of MDS publish attempts by status",
+		},
+		[]string{"status"},
+	)
+
+	// dualOutputLatency tracks per-output latency in the fan-out path.
+	// Labels: output ("pk", "mds")
+	dualOutputLatency = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "meridian",
+			Subsystem: "utilization_metering",
+			Name:      "dual_output_latency_seconds",
+			Help:      "Per-output latency in the dual-output fan-out path",
+			Buckets:   []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		},
+		[]string{"output"},
+	)
 )
 
 // SetServiceName sets the service name for metrics (used for logging context).
@@ -151,4 +176,17 @@ func RecordKafkaConsumerLag(topic, partition string, lag float64) {
 // durationSeconds: processing duration in seconds
 func RecordEventProcessingDuration(service string, durationSeconds float64) {
 	eventProcessingDuration.WithLabelValues(service).Observe(durationSeconds)
+}
+
+// RecordMDSPublish increments the MDS publish counter.
+// status: "success" or "error"
+func RecordMDSPublish(status string) {
+	mdsPublishTotal.WithLabelValues(status).Inc()
+}
+
+// RecordDualOutputLatency observes per-output latency in the fan-out path.
+// output: "pk" or "mds"
+// durationSeconds: latency in seconds
+func RecordDualOutputLatency(output string, durationSeconds float64) {
+	dualOutputLatency.WithLabelValues(output).Observe(durationSeconds)
 }

--- a/services/utilization-metering-consumer/domain/utilization_publisher.go
+++ b/services/utilization-metering-consumer/domain/utilization_publisher.go
@@ -1,0 +1,13 @@
+// Package domain contains the core domain models for utilization metering.
+package domain
+
+// UtilizationPublisher defines the interface for publishing utilization measurements
+// to the Market Data Service (MDS) for aggregation and pricing.
+type UtilizationPublisher interface {
+	// Publish adds a utilization measurement to the aggregation buffer.
+	// The measurement is buffered and periodically flushed to MDS.
+	Publish(measurement *UtilizationMeasurement)
+
+	// Stop gracefully stops the publisher, flushing any pending data.
+	Stop()
+}


### PR DESCRIPTION
## Summary

Integrates the MarketDataPublisher adapter into the utilization-metering-consumer's audit event processing pipeline, enabling dual output to both Position Keeping (synchronous) and MDS (asynchronous buffer).

Implements Task Master task `market-data-dynamic-pricing.3`.

## Changes Made

### audit_consumer.go - Multi-output fan-out
- Add `mdPublisher` field to `AuditConsumer` struct
- Add `WithMDSPublisher` functional option for backward-compatible constructor
- After successful PK write, fan out to MDS publisher (async buffer)
- PK failure short-circuits (preserves existing behavior)
- MDS failure logs error + records metric but does NOT block (eventual consistency)
- Panic recovery in MDS publish path to prevent cascading failures

### app/config.go - MDS configuration
- `ENABLE_MDS_OUTPUT` feature flag (default: `true`)
- `MDS_SERVICE_ADDR` gRPC address for Market Data Service
- `MDS_AGGREGATION_WINDOW` aggregation window size (default: `1h`)
- `MDS_FLUSH_INTERVAL` flush interval (default: `5m`)

### cmd/main.go - MDS client initialization
- Initialize MDS gRPC connection and MarketDataPublisher when enabled
- Graceful shutdown flushes pending MDS aggregations before exit
- Degraded mode: MDS init failure logs error, continues without MDS output

### domain/ - New interfaces and metrics
- `UtilizationPublisher` interface decouples consumer from MDS implementation
- `MeasurementToUtilization` converts `auditdomain.Measurement` to `UtilizationMeasurement`
- Prometheus metrics: `utilization_mds_publish_total{status}`, `utilization_dual_output_latency_seconds{output}`

## Testing

- Dual output: Mock PK and MDS, verify both receive calls
- PK failure prevents MDS call (short-circuit)
- MDS panic does not block PK path (failure isolation)
- Backward compatibility: no MDS publisher option works as before
- Multiple events: both outputs receive all events
- Config tests: MDS defaults and custom values
- MeasurementToUtilization conversion tests

## Risk Assessment

Low risk - the MDS publisher is optional (nil-checked) and uses a functional option pattern for backward compatibility. Existing PK-only behavior is preserved when MDS is not configured.