### PR TITLE
feat: Create gRPC service for hierarchical reference data operations

### DIFF
--- a/api/proto/meridian/reference_data/v1/node.proto
+++ b/api/proto/meridian/reference_data/v1/node.proto
@@ -1,0 +1,260 @@
+syntax = "proto3";
+
+package meridian.reference_data.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1;referencedatav1";
+
+// ReferenceDataNode represents a hierarchical reference data node with bi-temporal support.
+// Nodes form tree structures (region/zone/meter, dno/gsp/asset, etc.) with denormalized
+// resolution keys for fast market data correlation.
+message ReferenceDataNode {
+  // id is the unique identifier for this node (UUID).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // tenant_id identifies the owning tenant.
+  string tenant_id = 2 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 50
+  }];
+
+  // node_type classifies this node (e.g., "region", "zone", "meter").
+  string node_type = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+  }];
+
+  // parent_id is the UUID of the parent node. Empty for root nodes.
+  string parent_id = 4 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // attributes holds flexible metadata as a JSON-like structure.
+  google.protobuf.Struct attributes = 5;
+
+  // resolution_key is the computed hierarchical path (e.g., "region:uuid/zone:uuid/meter:uuid").
+  // Read-only: computed by the server on create.
+  string resolution_key = 6;
+
+  // valid_from is the effective start time of this node version.
+  google.protobuf.Timestamp valid_from = 7 [(buf.validate.field).required = true];
+
+  // valid_to is the effective end time. Null/empty for active (current) nodes.
+  google.protobuf.Timestamp valid_to = 8;
+
+  // created_at is when this node was created.
+  google.protobuf.Timestamp created_at = 9 [(buf.validate.field).required = true];
+
+  // version is the optimistic lock version (monotonically increasing).
+  int64 version = 10 [(buf.validate.field).int64.gte = 1];
+}
+
+// NodeService manages hierarchical reference data nodes with bi-temporal support.
+// All operations are tenant-scoped via JWT claims in request metadata.
+service NodeService {
+  // CreateNode creates a new reference data node.
+  // The resolution key is computed automatically from the node's ancestors.
+  // Returns ALREADY_EXISTS if an active node with the same resolution key exists.
+  // Returns NOT_FOUND if parent_id references a non-existent node.
+  // Returns FAILED_PRECONDITION if the parent node is not active.
+  rpc CreateNode(CreateNodeRequest) returns (CreateNodeResponse);
+
+  // UpdateNode modifies non-identity attributes of a node (attributes, valid_to).
+  // Identity fields (tenant_id, node_type, parent_id, resolution_key) are immutable.
+  // Uses optimistic locking via version field.
+  // Returns NOT_FOUND if the node does not exist.
+  // Returns ABORTED if the version has changed (optimistic lock failure).
+  rpc UpdateNode(UpdateNodeRequest) returns (UpdateNodeResponse);
+
+  // GetNode retrieves a node by its UUID.
+  // Returns NOT_FOUND if the node does not exist.
+  rpc GetNode(GetNodeRequest) returns (GetNodeResponse);
+
+  // GetChildren returns child nodes of a given parent.
+  // Supports filtering to active-only nodes.
+  rpc GetChildren(GetChildrenRequest) returns (GetChildrenResponse);
+
+  // GetAncestors returns the chain of ancestors from the immediate parent to root.
+  // Returns empty list for root nodes.
+  rpc GetAncestors(GetAncestorsRequest) returns (GetAncestorsResponse);
+
+  // GetSubtree returns all descendants of a node up to a specified depth.
+  // The root node itself is included at depth 0.
+  rpc GetSubtree(GetSubtreeRequest) returns (GetSubtreeResponse);
+
+  // GetNodeAsAt retrieves the version of a node that was valid at a given time.
+  // Uses bi-temporal query: valid_from <= as_at < valid_to.
+  // Returns NOT_FOUND if no version was valid at the given time.
+  rpc GetNodeAsAt(GetNodeAsAtRequest) returns (GetNodeAsAtResponse);
+
+  // GetNodeHistory returns all temporal versions of a node (active and superseded),
+  // ordered by valid_from descending (newest first).
+  rpc GetNodeHistory(GetNodeHistoryRequest) returns (GetNodeHistoryResponse);
+
+  // ImportNodes creates multiple nodes in a single batch transaction.
+  // Nodes must be ordered so that parents appear before children.
+  // Returns the count of successfully imported nodes.
+  rpc ImportNodes(ImportNodesRequest) returns (ImportNodesResponse);
+}
+
+// ========================================
+// Request/Response Messages
+// ========================================
+
+// CreateNodeRequest contains the data to create a new reference data node.
+message CreateNodeRequest {
+  // node_type classifies this node (e.g., "region", "zone", "meter").
+  string node_type = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 64
+  }];
+
+  // parent_id is the UUID of the parent node. Empty for root nodes.
+  string parent_id = 2 [
+    (buf.validate.field).ignore = IGNORE_IF_ZERO_VALUE,
+    (buf.validate.field).string.uuid = true
+  ];
+
+  // attributes holds flexible metadata.
+  google.protobuf.Struct attributes = 3;
+
+  // valid_from sets the effective start time. Defaults to now if not provided.
+  google.protobuf.Timestamp valid_from = 4;
+
+  // valid_to sets the effective end time. Leave empty for indefinitely active nodes.
+  google.protobuf.Timestamp valid_to = 5;
+}
+
+// CreateNodeResponse returns the newly created node.
+message CreateNodeResponse {
+  // node is the created reference data node with computed resolution key.
+  ReferenceDataNode node = 1;
+}
+
+// UpdateNodeRequest modifies non-identity attributes of an existing node.
+message UpdateNodeRequest {
+  // id identifies which node to update (UUID).
+  string id = 1 [(buf.validate.field).string.uuid = true];
+
+  // version is the expected current version for optimistic locking.
+  int64 version = 2 [(buf.validate.field).int64.gte = 1];
+
+  // attributes replaces the node's metadata.
+  google.protobuf.Struct attributes = 3;
+
+  // valid_to sets or updates the effective end time.
+  google.protobuf.Timestamp valid_to = 4;
+}
+
+// UpdateNodeResponse returns the updated node.
+message UpdateNodeResponse {
+  // node is the updated reference data node.
+  ReferenceDataNode node = 1;
+}
+
+// GetNodeRequest identifies which node to retrieve.
+message GetNodeRequest {
+  // id is the UUID of the node to retrieve.
+  string id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// GetNodeResponse returns the requested node.
+message GetNodeResponse {
+  // node is the requested reference data node.
+  ReferenceDataNode node = 1;
+}
+
+// GetChildrenRequest specifies which parent's children to retrieve.
+message GetChildrenRequest {
+  // parent_id is the UUID of the parent node.
+  string parent_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // active_only filters to only active nodes (valid_to IS NULL).
+  bool active_only = 2;
+}
+
+// GetChildrenResponse returns the child nodes.
+message GetChildrenResponse {
+  // nodes is the list of child nodes.
+  repeated ReferenceDataNode nodes = 1;
+}
+
+// GetAncestorsRequest specifies which node's ancestors to retrieve.
+message GetAncestorsRequest {
+  // node_id is the UUID of the node whose ancestors to retrieve.
+  string node_id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// GetAncestorsResponse returns the ancestor chain.
+message GetAncestorsResponse {
+  // ancestors is the chain from immediate parent to root.
+  repeated ReferenceDataNode ancestors = 1;
+}
+
+// GetSubtreeRequest specifies the subtree to retrieve.
+message GetSubtreeRequest {
+  // root_id is the UUID of the subtree root node.
+  string root_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // max_depth limits the depth of traversal (0 = root only, default 10).
+  int32 max_depth = 2 [(buf.validate.field).int32 = {
+    gte: 0
+    lte: 20
+  }];
+}
+
+// GetSubtreeResponse returns the subtree nodes.
+message GetSubtreeResponse {
+  // nodes includes the root node and all descendants up to max_depth.
+  repeated ReferenceDataNode nodes = 1;
+}
+
+// GetNodeAsAtRequest specifies a bi-temporal point-in-time query.
+message GetNodeAsAtRequest {
+  // node_id is the UUID of any version of the node.
+  string node_id = 1 [(buf.validate.field).string.uuid = true];
+
+  // as_at is the point in time to query.
+  google.protobuf.Timestamp as_at = 2 [(buf.validate.field).required = true];
+}
+
+// GetNodeAsAtResponse returns the node version valid at the given time.
+message GetNodeAsAtResponse {
+  // node is the version of the node that was valid at as_at.
+  ReferenceDataNode node = 1;
+}
+
+// GetNodeHistoryRequest specifies which node's history to retrieve.
+message GetNodeHistoryRequest {
+  // node_id is the UUID of any version of the node.
+  string node_id = 1 [(buf.validate.field).string.uuid = true];
+}
+
+// GetNodeHistoryResponse returns all temporal versions.
+message GetNodeHistoryResponse {
+  // versions is the list of all temporal versions, newest first.
+  repeated ReferenceDataNode versions = 1;
+}
+
+// ImportNodesRequest contains a batch of nodes to create.
+message ImportNodesRequest {
+  // nodes is the ordered list of nodes to import.
+  // Parents must appear before their children.
+  repeated CreateNodeRequest nodes = 1 [(buf.validate.field).repeated = {
+    min_items: 1
+    max_items: 1000
+  }];
+}
+
+// ImportNodesResponse returns the result of the batch import.
+message ImportNodesResponse {
+  // imported_count is the number of nodes successfully imported.
+  int32 imported_count = 1;
+
+  // nodes is the list of created nodes with computed resolution keys.
+  repeated ReferenceDataNode nodes = 2;
+}

--- a/api/proto/meridian/reference_data/v1/node.proto
+++ b/api/proto/meridian/reference_data/v1/node.proto
@@ -200,7 +200,8 @@ message GetSubtreeRequest {
   // root_id is the UUID of the subtree root node.
   string root_id = 1 [(buf.validate.field).string.uuid = true];
 
-  // max_depth limits the depth of traversal (0 = root only, default 10).
+  // max_depth limits the depth of traversal. Defaults to 10 if not set (0).
+  // Set to 1 for root + direct children only, 2 for two levels, etc.
   int32 max_depth = 2 [(buf.validate.field).int32 = {
     gte: 0
     lte: 20

--- a/services/reference-data/handler/node_handler.go
+++ b/services/reference-data/handler/node_handler.go
@@ -1,0 +1,584 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/reference-data/node"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// ErrNodeRepositoryNil is returned when attempting to create a service with a nil repository.
+var ErrNodeRepositoryNil = errors.New("node repository cannot be nil")
+
+// Default subtree depth when max_depth is not specified.
+const defaultMaxDepth = 10
+
+// Prometheus metrics for node operations.
+var (
+	nodeOpsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "meridian",
+		Subsystem: "reference_data_node",
+		Name:      "operations_total",
+		Help:      "Total number of node operations by type and status.",
+	}, []string{"operation", "status"})
+
+	nodeOpDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "meridian",
+		Subsystem: "reference_data_node",
+		Name:      "operation_duration_seconds",
+		Help:      "Duration of node operations in seconds.",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"operation"})
+
+	nodeTraversalDepth = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "meridian",
+		Subsystem: "reference_data_node",
+		Name:      "traversal_depth",
+		Help:      "Depth of tree traversal operations.",
+		Buckets:   []float64{1, 2, 3, 5, 8, 10, 15, 20},
+	}, []string{"operation"})
+)
+
+// NodeService implements the NodeService gRPC service.
+type NodeService struct {
+	pb.UnimplementedNodeServiceServer
+	repo   node.Repository
+	logger *slog.Logger
+}
+
+// NewNodeService creates a new node service.
+func NewNodeService(repo node.Repository, logger *slog.Logger) (*NodeService, error) {
+	if repo == nil {
+		return nil, ErrNodeRepositoryNil
+	}
+	if logger == nil {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+	return &NodeService{
+		repo:   repo,
+		logger: logger,
+	}, nil
+}
+
+// CreateNode creates a new reference data node.
+func (s *NodeService) CreateNode(ctx context.Context, req *pb.CreateNodeRequest) (*pb.CreateNodeResponse, error) {
+	timer := prometheus.NewTimer(nodeOpDuration.WithLabelValues("create"))
+	defer timer.ObserveDuration()
+
+	tenantID, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		nodeOpsTotal.WithLabelValues("create", "error").Inc()
+		return nil, status.Error(codes.Unauthenticated, "missing tenant context")
+	}
+
+	builder := node.NewBuilder(tenantID.String()).WithNodeType(req.NodeType)
+
+	if req.ParentId != "" {
+		parentID, parseErr := uuid.Parse(req.ParentId)
+		if parseErr != nil {
+			nodeOpsTotal.WithLabelValues("create", "error").Inc()
+			return nil, status.Errorf(codes.InvalidArgument, "invalid parent_id: %v", parseErr)
+		}
+		builder = builder.WithParentID(parentID)
+	}
+
+	if req.Attributes != nil {
+		builder = builder.WithAttributes(structToMap(req.Attributes))
+	}
+
+	if req.ValidFrom != nil {
+		builder = builder.WithValidFrom(req.ValidFrom.AsTime())
+	}
+
+	if req.ValidTo != nil {
+		builder = builder.WithValidTo(req.ValidTo.AsTime())
+	}
+
+	n, buildErr := builder.Build()
+	if buildErr != nil {
+		nodeOpsTotal.WithLabelValues("create", "error").Inc()
+		return nil, status.Errorf(codes.InvalidArgument, "invalid node: %v", buildErr)
+	}
+
+	if createErr := s.repo.Create(ctx, n); createErr != nil {
+		nodeOpsTotal.WithLabelValues("create", "error").Inc()
+		return nil, s.mapNodeError(createErr, "CreateNode", n.ID.String())
+	}
+
+	nodeOpsTotal.WithLabelValues("create", "ok").Inc()
+	s.logger.Info("node created",
+		"id", n.ID,
+		"node_type", n.NodeType,
+		"resolution_key", n.ResolutionKey)
+
+	return &pb.CreateNodeResponse{
+		Node: domainNodeToProto(n),
+	}, nil
+}
+
+// UpdateNode modifies non-identity attributes of a node.
+func (s *NodeService) UpdateNode(ctx context.Context, req *pb.UpdateNodeRequest) (*pb.UpdateNodeResponse, error) {
+	timer := prometheus.NewTimer(nodeOpDuration.WithLabelValues("update"))
+	defer timer.ObserveDuration()
+
+	_, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		nodeOpsTotal.WithLabelValues("update", "error").Inc()
+		return nil, status.Error(codes.Unauthenticated, "missing tenant context")
+	}
+
+	nodeID, parseErr := uuid.Parse(req.Id)
+	if parseErr != nil {
+		nodeOpsTotal.WithLabelValues("update", "error").Inc()
+		return nil, status.Errorf(codes.InvalidArgument, "invalid node id: %v", parseErr)
+	}
+
+	// Fetch current node to prepare update
+	existing, getErr := s.repo.GetByID(ctx, nodeID)
+	if getErr != nil {
+		nodeOpsTotal.WithLabelValues("update", "error").Inc()
+		return nil, s.mapNodeError(getErr, "UpdateNode", req.Id)
+	}
+
+	// Verify version for optimistic locking
+	if existing.Version != req.Version {
+		nodeOpsTotal.WithLabelValues("update", "error").Inc()
+		return nil, status.Errorf(codes.Aborted, "optimistic lock failure: expected version %d, got %d", req.Version, existing.Version)
+	}
+
+	// Apply updates
+	if req.Attributes != nil {
+		existing.Attributes = structToMap(req.Attributes)
+	}
+	if req.ValidTo != nil {
+		vt := req.ValidTo.AsTime()
+		existing.ValidTo = &vt
+	}
+
+	if updateErr := s.repo.Update(ctx, existing); updateErr != nil {
+		nodeOpsTotal.WithLabelValues("update", "error").Inc()
+		return nil, s.mapNodeError(updateErr, "UpdateNode", req.Id)
+	}
+
+	nodeOpsTotal.WithLabelValues("update", "ok").Inc()
+	s.logger.Info("node updated",
+		"id", existing.ID,
+		"version", existing.Version)
+
+	return &pb.UpdateNodeResponse{
+		Node: domainNodeToProto(existing),
+	}, nil
+}
+
+// GetNode retrieves a node by its UUID.
+func (s *NodeService) GetNode(ctx context.Context, req *pb.GetNodeRequest) (*pb.GetNodeResponse, error) {
+	timer := prometheus.NewTimer(nodeOpDuration.WithLabelValues("get"))
+	defer timer.ObserveDuration()
+
+	_, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		nodeOpsTotal.WithLabelValues("get", "error").Inc()
+		return nil, status.Error(codes.Unauthenticated, "missing tenant context")
+	}
+
+	nodeID, parseErr := uuid.Parse(req.Id)
+	if parseErr != nil {
+		nodeOpsTotal.WithLabelValues("get", "error").Inc()
+		return nil, status.Errorf(codes.InvalidArgument, "invalid node id: %v", parseErr)
+	}
+
+	n, getErr := s.repo.GetByID(ctx, nodeID)
+	if getErr != nil {
+		nodeOpsTotal.WithLabelValues("get", "error").Inc()
+		return nil, s.mapNodeError(getErr, "GetNode", req.Id)
+	}
+
+	nodeOpsTotal.WithLabelValues("get", "ok").Inc()
+	return &pb.GetNodeResponse{
+		Node: domainNodeToProto(n),
+	}, nil
+}
+
+// GetChildren returns child nodes of a given parent.
+func (s *NodeService) GetChildren(ctx context.Context, req *pb.GetChildrenRequest) (*pb.GetChildrenResponse, error) {
+	timer := prometheus.NewTimer(nodeOpDuration.WithLabelValues("get_children"))
+	defer timer.ObserveDuration()
+
+	tenantID, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		nodeOpsTotal.WithLabelValues("get_children", "error").Inc()
+		return nil, status.Error(codes.Unauthenticated, "missing tenant context")
+	}
+
+	parentID, parseErr := uuid.Parse(req.ParentId)
+	if parseErr != nil {
+		nodeOpsTotal.WithLabelValues("get_children", "error").Inc()
+		return nil, status.Errorf(codes.InvalidArgument, "invalid parent_id: %v", parseErr)
+	}
+
+	children, getErr := s.repo.GetChildren(ctx, tenantID.String(), parentID, req.ActiveOnly)
+	if getErr != nil {
+		nodeOpsTotal.WithLabelValues("get_children", "error").Inc()
+		return nil, s.mapNodeError(getErr, "GetChildren", req.ParentId)
+	}
+
+	nodeOpsTotal.WithLabelValues("get_children", "ok").Inc()
+	return &pb.GetChildrenResponse{
+		Nodes: domainNodesToProto(children),
+	}, nil
+}
+
+// GetAncestors returns the chain of ancestors from the immediate parent to root.
+func (s *NodeService) GetAncestors(ctx context.Context, req *pb.GetAncestorsRequest) (*pb.GetAncestorsResponse, error) {
+	timer := prometheus.NewTimer(nodeOpDuration.WithLabelValues("get_ancestors"))
+	defer timer.ObserveDuration()
+
+	_, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		nodeOpsTotal.WithLabelValues("get_ancestors", "error").Inc()
+		return nil, status.Error(codes.Unauthenticated, "missing tenant context")
+	}
+
+	nodeID, parseErr := uuid.Parse(req.NodeId)
+	if parseErr != nil {
+		nodeOpsTotal.WithLabelValues("get_ancestors", "error").Inc()
+		return nil, status.Errorf(codes.InvalidArgument, "invalid node_id: %v", parseErr)
+	}
+
+	ancestors, getErr := s.repo.GetAncestors(ctx, nodeID)
+	if getErr != nil {
+		nodeOpsTotal.WithLabelValues("get_ancestors", "error").Inc()
+		return nil, s.mapNodeError(getErr, "GetAncestors", req.NodeId)
+	}
+
+	nodeTraversalDepth.WithLabelValues("get_ancestors").Observe(float64(len(ancestors)))
+	nodeOpsTotal.WithLabelValues("get_ancestors", "ok").Inc()
+
+	return &pb.GetAncestorsResponse{
+		Ancestors: domainNodesToProto(ancestors),
+	}, nil
+}
+
+// GetSubtree returns all descendants of a node up to a specified depth.
+func (s *NodeService) GetSubtree(ctx context.Context, req *pb.GetSubtreeRequest) (*pb.GetSubtreeResponse, error) {
+	timer := prometheus.NewTimer(nodeOpDuration.WithLabelValues("get_subtree"))
+	defer timer.ObserveDuration()
+
+	tenantID, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		nodeOpsTotal.WithLabelValues("get_subtree", "error").Inc()
+		return nil, status.Error(codes.Unauthenticated, "missing tenant context")
+	}
+
+	rootID, parseErr := uuid.Parse(req.RootId)
+	if parseErr != nil {
+		nodeOpsTotal.WithLabelValues("get_subtree", "error").Inc()
+		return nil, status.Errorf(codes.InvalidArgument, "invalid root_id: %v", parseErr)
+	}
+
+	maxDepth := int(req.MaxDepth)
+	if maxDepth == 0 {
+		maxDepth = defaultMaxDepth
+	}
+
+	nodes, getErr := s.repo.GetSubtree(ctx, tenantID.String(), rootID, maxDepth)
+	if getErr != nil {
+		nodeOpsTotal.WithLabelValues("get_subtree", "error").Inc()
+		return nil, s.mapNodeError(getErr, "GetSubtree", req.RootId)
+	}
+
+	nodeTraversalDepth.WithLabelValues("get_subtree").Observe(float64(maxDepth))
+	nodeOpsTotal.WithLabelValues("get_subtree", "ok").Inc()
+
+	return &pb.GetSubtreeResponse{
+		Nodes: domainNodesToProto(nodes),
+	}, nil
+}
+
+// GetNodeAsAt retrieves the version of a node that was valid at a given time.
+func (s *NodeService) GetNodeAsAt(ctx context.Context, req *pb.GetNodeAsAtRequest) (*pb.GetNodeAsAtResponse, error) {
+	timer := prometheus.NewTimer(nodeOpDuration.WithLabelValues("get_as_at"))
+	defer timer.ObserveDuration()
+
+	tenantID, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		nodeOpsTotal.WithLabelValues("get_as_at", "error").Inc()
+		return nil, status.Error(codes.Unauthenticated, "missing tenant context")
+	}
+
+	nodeID, parseErr := uuid.Parse(req.NodeId)
+	if parseErr != nil {
+		nodeOpsTotal.WithLabelValues("get_as_at", "error").Inc()
+		return nil, status.Errorf(codes.InvalidArgument, "invalid node_id: %v", parseErr)
+	}
+
+	asAt := req.AsAt.AsTime()
+	n, getErr := s.repo.GetAsAt(ctx, tenantID.String(), nodeID, asAt)
+	if getErr != nil {
+		nodeOpsTotal.WithLabelValues("get_as_at", "error").Inc()
+		return nil, s.mapNodeError(getErr, "GetNodeAsAt", req.NodeId)
+	}
+
+	nodeOpsTotal.WithLabelValues("get_as_at", "ok").Inc()
+	return &pb.GetNodeAsAtResponse{
+		Node: domainNodeToProto(n),
+	}, nil
+}
+
+// GetNodeHistory returns all temporal versions of a node.
+func (s *NodeService) GetNodeHistory(ctx context.Context, req *pb.GetNodeHistoryRequest) (*pb.GetNodeHistoryResponse, error) {
+	timer := prometheus.NewTimer(nodeOpDuration.WithLabelValues("get_history"))
+	defer timer.ObserveDuration()
+
+	tenantID, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		nodeOpsTotal.WithLabelValues("get_history", "error").Inc()
+		return nil, status.Error(codes.Unauthenticated, "missing tenant context")
+	}
+
+	nodeID, parseErr := uuid.Parse(req.NodeId)
+	if parseErr != nil {
+		nodeOpsTotal.WithLabelValues("get_history", "error").Inc()
+		return nil, status.Errorf(codes.InvalidArgument, "invalid node_id: %v", parseErr)
+	}
+
+	versions, getErr := s.repo.GetHistory(ctx, tenantID.String(), nodeID)
+	if getErr != nil {
+		nodeOpsTotal.WithLabelValues("get_history", "error").Inc()
+		return nil, s.mapNodeError(getErr, "GetNodeHistory", req.NodeId)
+	}
+
+	nodeOpsTotal.WithLabelValues("get_history", "ok").Inc()
+	return &pb.GetNodeHistoryResponse{
+		Versions: domainNodesToProto(versions),
+	}, nil
+}
+
+// ImportNodes creates multiple nodes in a single batch transaction.
+func (s *NodeService) ImportNodes(ctx context.Context, req *pb.ImportNodesRequest) (*pb.ImportNodesResponse, error) {
+	timer := prometheus.NewTimer(nodeOpDuration.WithLabelValues("import"))
+	defer timer.ObserveDuration()
+
+	tenantID, err := tenant.RequireFromContext(ctx)
+	if err != nil {
+		nodeOpsTotal.WithLabelValues("import", "error").Inc()
+		return nil, status.Error(codes.Unauthenticated, "missing tenant context")
+	}
+
+	nodes := make([]*node.Node, 0, len(req.Nodes))
+	for i, createReq := range req.Nodes {
+		builder := node.NewBuilder(tenantID.String()).WithNodeType(createReq.NodeType)
+
+		if createReq.ParentId != "" {
+			parentID, parseErr := uuid.Parse(createReq.ParentId)
+			if parseErr != nil {
+				nodeOpsTotal.WithLabelValues("import", "error").Inc()
+				return nil, status.Errorf(codes.InvalidArgument, "invalid parent_id at index %d: %v", i, parseErr)
+			}
+			builder = builder.WithParentID(parentID)
+		}
+
+		if createReq.Attributes != nil {
+			builder = builder.WithAttributes(structToMap(createReq.Attributes))
+		}
+
+		if createReq.ValidFrom != nil {
+			builder = builder.WithValidFrom(createReq.ValidFrom.AsTime())
+		}
+
+		if createReq.ValidTo != nil {
+			builder = builder.WithValidTo(createReq.ValidTo.AsTime())
+		}
+
+		n, buildErr := builder.Build()
+		if buildErr != nil {
+			nodeOpsTotal.WithLabelValues("import", "error").Inc()
+			return nil, status.Errorf(codes.InvalidArgument, "invalid node at index %d: %v", i, buildErr)
+		}
+		nodes = append(nodes, n)
+	}
+
+	if bulkErr := s.repo.BulkCreate(ctx, nodes); bulkErr != nil {
+		nodeOpsTotal.WithLabelValues("import", "error").Inc()
+		return nil, s.mapNodeError(bulkErr, "ImportNodes", "batch")
+	}
+
+	nodeOpsTotal.WithLabelValues("import", "ok").Inc()
+	s.logger.Info("nodes imported",
+		"count", len(nodes))
+
+	return &pb.ImportNodesResponse{
+		ImportedCount: int32(len(nodes)),
+		Nodes:         domainNodesToProto(nodes),
+	}, nil
+}
+
+// mapNodeError converts domain errors to appropriate gRPC status codes.
+func (s *NodeService) mapNodeError(err error, operation, id string) error {
+	switch {
+	case errors.Is(err, node.ErrNotFound):
+		s.logger.Warn("node not found",
+			"operation", operation,
+			"id", id)
+		return status.Errorf(codes.NotFound, "node not found: %s", id)
+
+	case errors.Is(err, node.ErrAlreadyExists):
+		s.logger.Warn("node already exists",
+			"operation", operation,
+			"id", id)
+		return status.Errorf(codes.AlreadyExists, "active node with this resolution key already exists")
+
+	case errors.Is(err, node.ErrParentNotFound):
+		s.logger.Warn("parent node not found",
+			"operation", operation,
+			"id", id)
+		return status.Errorf(codes.NotFound, "parent node not found")
+
+	case errors.Is(err, node.ErrParentNotActive):
+		s.logger.Warn("parent node not active",
+			"operation", operation,
+			"id", id)
+		return status.Errorf(codes.FailedPrecondition, "parent node is not active")
+
+	case errors.Is(err, node.ErrCrossTenantParent):
+		s.logger.Warn("cross-tenant parent reference",
+			"operation", operation,
+			"id", id)
+		return status.Errorf(codes.PermissionDenied, "parent node belongs to a different tenant")
+
+	case errors.Is(err, node.ErrImmutableIdentity):
+		s.logger.Warn("immutable identity change attempted",
+			"operation", operation,
+			"id", id)
+		return status.Errorf(codes.FailedPrecondition, "cannot change identity fields on active node")
+
+	case errors.Is(err, node.ErrOptimisticLock):
+		s.logger.Warn("optimistic lock failure",
+			"operation", operation,
+			"id", id)
+		return status.Errorf(codes.Aborted, "node was modified by another transaction")
+
+	case errors.Is(err, node.ErrCircularHierarchy):
+		s.logger.Warn("circular hierarchy detected",
+			"operation", operation,
+			"id", id)
+		return status.Errorf(codes.FailedPrecondition, "circular hierarchy detected")
+
+	case errors.Is(err, node.ErrMaxDepthExceeded):
+		s.logger.Warn("max hierarchy depth exceeded",
+			"operation", operation,
+			"id", id)
+		return status.Errorf(codes.FailedPrecondition, "maximum hierarchy depth exceeded")
+
+	case errors.Is(err, node.ErrInvalidTimeRange):
+		s.logger.Warn("invalid time range",
+			"operation", operation,
+			"id", id)
+		return status.Errorf(codes.InvalidArgument, "valid_to must be after valid_from")
+
+	case errors.Is(err, node.ErrAlreadySuperseded):
+		s.logger.Warn("node already superseded",
+			"operation", operation,
+			"id", id)
+		return status.Errorf(codes.FailedPrecondition, "node has already been superseded")
+
+	case errors.Is(err, node.ErrInvalidNode):
+		s.logger.Warn("invalid node",
+			"operation", operation,
+			"id", id,
+			"error", err)
+		return status.Errorf(codes.InvalidArgument, "invalid node: %v", err)
+
+	case errors.Is(err, tenant.ErrMissingTenantContext):
+		return status.Error(codes.Unauthenticated, "missing tenant context")
+
+	default:
+		s.logger.Error("internal error",
+			"operation", operation,
+			"id", id,
+			"error", err)
+		return status.Errorf(codes.Internal, "internal error: %v", err)
+	}
+}
+
+// domainNodeToProto converts a domain Node to proto ReferenceDataNode.
+func domainNodeToProto(n *node.Node) *pb.ReferenceDataNode {
+	if n == nil {
+		return nil
+	}
+
+	proto := &pb.ReferenceDataNode{
+		Id:            n.ID.String(),
+		TenantId:      n.TenantID,
+		NodeType:      n.NodeType,
+		ResolutionKey: n.ResolutionKey,
+		ValidFrom:     timestamppb.New(n.ValidFrom),
+		CreatedAt:     timestamppb.New(n.CreatedAt),
+		Version:       n.Version,
+	}
+
+	if n.ParentID != nil {
+		proto.ParentId = n.ParentID.String()
+	}
+
+	if n.ValidTo != nil {
+		proto.ValidTo = timestamppb.New(*n.ValidTo)
+	}
+
+	if n.Attributes != nil {
+		attrs, err := mapToStruct(n.Attributes)
+		if err == nil {
+			proto.Attributes = attrs
+		}
+	}
+
+	return proto
+}
+
+// domainNodesToProto converts a slice of domain Nodes to proto.
+func domainNodesToProto(nodes []*node.Node) []*pb.ReferenceDataNode {
+	result := make([]*pb.ReferenceDataNode, len(nodes))
+	for i, n := range nodes {
+		result[i] = domainNodeToProto(n)
+	}
+	return result
+}
+
+// structToMap converts a protobuf Struct to map[string]any.
+func structToMap(s *structpb.Struct) map[string]any {
+	if s == nil {
+		return nil
+	}
+	return s.AsMap()
+}
+
+// mapToStruct converts map[string]any to a protobuf Struct.
+func mapToStruct(m map[string]any) (*structpb.Struct, error) {
+	if len(m) == 0 {
+		return &structpb.Struct{Fields: map[string]*structpb.Value{}}, nil
+	}
+	// Convert any time.Time values to strings for structpb compatibility
+	converted := make(map[string]any, len(m))
+	for k, v := range m {
+		switch val := v.(type) {
+		case time.Time:
+			converted[k] = val.Format(time.RFC3339)
+		default:
+			converted[k] = val
+		}
+	}
+	return structpb.NewStruct(converted)
+}

--- a/services/reference-data/handler/node_handler.go
+++ b/services/reference-data/handler/node_handler.go
@@ -156,7 +156,7 @@ func (s *NodeService) UpdateNode(ctx context.Context, req *pb.UpdateNodeRequest)
 	// Verify version for optimistic locking
 	if existing.Version != req.Version {
 		nodeOpsTotal.WithLabelValues("update", "error").Inc()
-		return nil, status.Errorf(codes.Aborted, "optimistic lock failure: expected version %d, got %d", req.Version, existing.Version)
+		return nil, status.Errorf(codes.Aborted, "optimistic lock failure: client sent version %d, but current version is %d", req.Version, existing.Version)
 	}
 
 	// Apply updates
@@ -540,7 +540,11 @@ func domainNodeToProto(n *node.Node) *pb.ReferenceDataNode {
 
 	if n.Attributes != nil {
 		attrs, err := mapToStruct(n.Attributes)
-		if err == nil {
+		if err != nil {
+			slog.Warn("failed to convert node attributes to proto",
+				"node_id", n.ID,
+				"error", err)
+		} else {
 			proto.Attributes = attrs
 		}
 	}

--- a/services/reference-data/handler/node_handler_test.go
+++ b/services/reference-data/handler/node_handler_test.go
@@ -1,0 +1,492 @@
+package handler_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pb "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
+	"github.com/meridianhub/meridian/services/reference-data/handler"
+	"github.com/meridianhub/meridian/services/reference-data/node"
+	"github.com/meridianhub/meridian/shared/platform/testdb"
+)
+
+func setupNodeTestRepo(t *testing.T) (*node.PostgresRepository, *pgxpool.Pool) {
+	t.Helper()
+	pool := testdb.NewTestPool(t)
+	repo := node.NewPostgresRepository(pool)
+	return repo, pool
+}
+
+func setupNodeTenantCtx(t *testing.T, pool *pgxpool.Pool, tenantID string) context.Context {
+	t.Helper()
+	ctx, cleanup := testdb.SetupTenantSchemaForPgx(t, pool, tenantID, "reference-data")
+	t.Cleanup(cleanup)
+	return ctx
+}
+
+func setupNodeService(t *testing.T) (*handler.NodeService, *pgxpool.Pool) {
+	t.Helper()
+	repo, pool := setupNodeTestRepo(t)
+	svc, err := handler.NewNodeService(repo, nil)
+	require.NoError(t, err)
+	return svc, pool
+}
+
+func TestNewNodeService(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		repo, _ := setupNodeTestRepo(t)
+		svc, err := handler.NewNodeService(repo, nil)
+		require.NoError(t, err)
+		assert.NotNil(t, svc)
+	})
+
+	t.Run("nil repository", func(t *testing.T) {
+		_, err := handler.NewNodeService(nil, nil)
+		assert.ErrorIs(t, err, handler.ErrNodeRepositoryNil)
+	})
+}
+
+func TestNodeService_CRUDFlow(t *testing.T) {
+	svc, pool := setupNodeService(t)
+	ctx := setupNodeTenantCtx(t, pool, "test_crud")
+
+	// Create a root node
+	createResp, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+		NodeType: "region",
+		Attributes: mustStruct(t, map[string]any{
+			"name":    "UK South",
+			"country": "GB",
+		}),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, createResp.Node)
+
+	nodeID := createResp.Node.Id
+	assert.NotEmpty(t, nodeID)
+	assert.Equal(t, "region", createResp.Node.NodeType)
+	assert.Equal(t, int64(1), createResp.Node.Version)
+	assert.Contains(t, createResp.Node.ResolutionKey, "region:")
+	assert.NotNil(t, createResp.Node.Attributes)
+
+	// Get the node back
+	getResp, err := svc.GetNode(ctx, &pb.GetNodeRequest{Id: nodeID})
+	require.NoError(t, err)
+	assert.Equal(t, nodeID, getResp.Node.Id)
+	assert.Equal(t, "region", getResp.Node.NodeType)
+
+	// Update the node
+	updateResp, err := svc.UpdateNode(ctx, &pb.UpdateNodeRequest{
+		Id:      nodeID,
+		Version: 1,
+		Attributes: mustStruct(t, map[string]any{
+			"name":    "UK South Updated",
+			"country": "GB",
+		}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), updateResp.Node.Version)
+
+	// Verify update persisted
+	getResp2, err := svc.GetNode(ctx, &pb.GetNodeRequest{Id: nodeID})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), getResp2.Node.Version)
+	attrs := getResp2.Node.Attributes.AsMap()
+	assert.Equal(t, "UK South Updated", attrs["name"])
+}
+
+func TestNodeService_ThreeLevelHierarchy(t *testing.T) {
+	svc, pool := setupNodeService(t)
+	ctx := setupNodeTenantCtx(t, pool, "test_hierarchy")
+
+	// Create root: dno
+	dnoResp, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+		NodeType: "dno",
+		Attributes: mustStruct(t, map[string]any{
+			"name": "Western Power Distribution",
+		}),
+	})
+	require.NoError(t, err)
+	dnoID := dnoResp.Node.Id
+
+	// Create mid-level: gsp
+	gspResp, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+		NodeType: "gsp",
+		ParentId: dnoID,
+		Attributes: mustStruct(t, map[string]any{
+			"name": "Grid Supply Point A",
+		}),
+	})
+	require.NoError(t, err)
+	gspID := gspResp.Node.Id
+
+	// Create leaf: meter
+	meterResp, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+		NodeType: "meter",
+		ParentId: gspID,
+		Attributes: mustStruct(t, map[string]any{
+			"serial": "MTR-001",
+		}),
+	})
+	require.NoError(t, err)
+	meterID := meterResp.Node.Id
+
+	// Verify resolution key contains full path
+	assert.Contains(t, meterResp.Node.ResolutionKey, "dno:")
+	assert.Contains(t, meterResp.Node.ResolutionKey, "gsp:")
+	assert.Contains(t, meterResp.Node.ResolutionKey, "meter:")
+
+	// Get children of dno
+	childrenResp, err := svc.GetChildren(ctx, &pb.GetChildrenRequest{
+		ParentId:   dnoID,
+		ActiveOnly: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, childrenResp.Nodes, 1)
+	assert.Equal(t, gspID, childrenResp.Nodes[0].Id)
+
+	// Get children of gsp
+	grandChildrenResp, err := svc.GetChildren(ctx, &pb.GetChildrenRequest{
+		ParentId:   gspID,
+		ActiveOnly: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, grandChildrenResp.Nodes, 1)
+	assert.Equal(t, meterID, grandChildrenResp.Nodes[0].Id)
+
+	// Get subtree from dno - should include all 3 levels
+	subtreeResp, err := svc.GetSubtree(ctx, &pb.GetSubtreeRequest{
+		RootId:   dnoID,
+		MaxDepth: 10,
+	})
+	require.NoError(t, err)
+	assert.Len(t, subtreeResp.Nodes, 3) // dno, gsp, meter
+}
+
+func TestNodeService_GetAncestorsOnLeaf(t *testing.T) {
+	svc, pool := setupNodeService(t)
+	ctx := setupNodeTenantCtx(t, pool, "test_ancestors")
+
+	// Build 3-level hierarchy
+	rootResp, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{NodeType: "region"})
+	require.NoError(t, err)
+
+	midResp, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+		NodeType: "zone",
+		ParentId: rootResp.Node.Id,
+	})
+	require.NoError(t, err)
+
+	leafResp, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+		NodeType: "meter",
+		ParentId: midResp.Node.Id,
+	})
+	require.NoError(t, err)
+
+	// Get ancestors of leaf
+	ancestorsResp, err := svc.GetAncestors(ctx, &pb.GetAncestorsRequest{
+		NodeId: leafResp.Node.Id,
+	})
+	require.NoError(t, err)
+	assert.Len(t, ancestorsResp.Ancestors, 2)
+	// Ancestors are ordered parent-first: [zone, region]
+	assert.Equal(t, midResp.Node.Id, ancestorsResp.Ancestors[0].Id)
+	assert.Equal(t, rootResp.Node.Id, ancestorsResp.Ancestors[1].Id)
+
+	// Root has no ancestors
+	rootAncestors, err := svc.GetAncestors(ctx, &pb.GetAncestorsRequest{
+		NodeId: rootResp.Node.Id,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, rootAncestors.Ancestors)
+}
+
+func TestNodeService_BiTemporalGetNodeAsAt(t *testing.T) {
+	svc, pool := setupNodeService(t)
+	ctx := setupNodeTenantCtx(t, pool, "test_bitemporal")
+
+	now := time.Now()
+	pastTime := now.Add(-24 * time.Hour)
+	futureTime := now.Add(24 * time.Hour)
+
+	// Create a node valid from the past
+	createResp, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+		NodeType:  "meter",
+		ValidFrom: timestamppb.New(pastTime),
+		Attributes: mustStruct(t, map[string]any{
+			"reading": "initial",
+		}),
+	})
+	require.NoError(t, err)
+	nodeID := createResp.Node.Id
+
+	// Query at current time - should find the node
+	asAtResp, err := svc.GetNodeAsAt(ctx, &pb.GetNodeAsAtRequest{
+		NodeId: nodeID,
+		AsAt:   timestamppb.New(now),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, nodeID, asAtResp.Node.Id)
+
+	// Query before valid_from - should NOT find the node
+	_, err = svc.GetNodeAsAt(ctx, &pb.GetNodeAsAtRequest{
+		NodeId: nodeID,
+		AsAt:   timestamppb.New(pastTime.Add(-48 * time.Hour)),
+	})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.NotFound, st.Code())
+
+	// Close the node by setting valid_to
+	_, err = svc.UpdateNode(ctx, &pb.UpdateNodeRequest{
+		Id:      nodeID,
+		Version: 1,
+		ValidTo: timestamppb.New(futureTime),
+	})
+	require.NoError(t, err)
+
+	// Query after valid_to - should NOT find it
+	_, err = svc.GetNodeAsAt(ctx, &pb.GetNodeAsAtRequest{
+		NodeId: nodeID,
+		AsAt:   timestamppb.New(futureTime.Add(24 * time.Hour)),
+	})
+	require.Error(t, err)
+	st, _ = status.FromError(err)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestNodeService_ImportNodes(t *testing.T) {
+	svc, pool := setupNodeService(t)
+	ctx := setupNodeTenantCtx(t, pool, "test_import")
+
+	// Build a batch of 100 nodes: 10 regions, each with 9 zones
+	requests := make([]*pb.CreateNodeRequest, 0, 100)
+
+	// Create 10 root nodes first (we'll use their returned IDs for children)
+	rootIDs := make([]string, 10)
+	for i := 0; i < 10; i++ {
+		resp, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+			NodeType: "region",
+			Attributes: mustStruct(t, map[string]any{
+				"index": float64(i),
+			}),
+		})
+		require.NoError(t, err)
+		rootIDs[i] = resp.Node.Id
+	}
+
+	// Build 90 zone children, 9 per region
+	for i := 0; i < 10; i++ {
+		for j := 0; j < 9; j++ {
+			requests = append(requests, &pb.CreateNodeRequest{
+				NodeType: "zone",
+				ParentId: rootIDs[i],
+				Attributes: mustStruct(t, map[string]any{
+					"region_idx": float64(i),
+					"zone_idx":   float64(j),
+				}),
+			})
+		}
+	}
+
+	importResp, err := svc.ImportNodes(ctx, &pb.ImportNodesRequest{
+		Nodes: requests,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(90), importResp.ImportedCount)
+	assert.Len(t, importResp.Nodes, 90)
+
+	// Verify each imported node has a resolution key
+	for _, n := range importResp.Nodes {
+		assert.NotEmpty(t, n.ResolutionKey)
+		assert.Contains(t, n.ResolutionKey, "zone:")
+	}
+
+	// Verify tree via GetChildren
+	childrenResp, err := svc.GetChildren(ctx, &pb.GetChildrenRequest{
+		ParentId:   rootIDs[0],
+		ActiveOnly: true,
+	})
+	require.NoError(t, err)
+	assert.Len(t, childrenResp.Nodes, 9)
+}
+
+func TestNodeService_TenantIsolation(t *testing.T) {
+	svc, pool := setupNodeService(t)
+	ctxA := setupNodeTenantCtx(t, pool, "tenant_a")
+	ctxB := setupNodeTenantCtx(t, pool, "tenant_b")
+
+	// Create node in tenant A
+	respA, err := svc.CreateNode(ctxA, &pb.CreateNodeRequest{
+		NodeType: "region",
+		Attributes: mustStruct(t, map[string]any{
+			"name": "Tenant A Region",
+		}),
+	})
+	require.NoError(t, err)
+
+	// Create node in tenant B
+	_, err = svc.CreateNode(ctxB, &pb.CreateNodeRequest{
+		NodeType: "region",
+		Attributes: mustStruct(t, map[string]any{
+			"name": "Tenant B Region",
+		}),
+	})
+	require.NoError(t, err)
+
+	// Tenant B cannot see tenant A's node
+	_, err = svc.GetNode(ctxB, &pb.GetNodeRequest{Id: respA.Node.Id})
+	require.Error(t, err)
+	st, _ := status.FromError(err)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+func TestNodeService_ValidationErrors(t *testing.T) {
+	svc, pool := setupNodeService(t)
+	ctx := setupNodeTenantCtx(t, pool, "test_validation")
+
+	t.Run("missing node type", func(t *testing.T) {
+		_, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+			NodeType: "",
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("invalid parent_id", func(t *testing.T) {
+		_, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+			NodeType: "region",
+			ParentId: "not-a-uuid",
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("non-existent parent", func(t *testing.T) {
+		_, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+			NodeType: "zone",
+			ParentId: uuid.New().String(),
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("get non-existent node", func(t *testing.T) {
+		_, err := svc.GetNode(ctx, &pb.GetNodeRequest{
+			Id: uuid.New().String(),
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.NotFound, st.Code())
+	})
+
+	t.Run("invalid node id format", func(t *testing.T) {
+		_, err := svc.GetNode(ctx, &pb.GetNodeRequest{
+			Id: "not-a-uuid",
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("optimistic lock conflict", func(t *testing.T) {
+		resp, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{NodeType: "region"})
+		require.NoError(t, err)
+
+		_, err = svc.UpdateNode(ctx, &pb.UpdateNodeRequest{
+			Id:      resp.Node.Id,
+			Version: 999, // Wrong version
+			Attributes: mustStruct(t, map[string]any{
+				"updated": true,
+			}),
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.Aborted, st.Code())
+	})
+}
+
+func TestNodeService_MissingTenantContext(t *testing.T) {
+	svc, _ := setupNodeService(t)
+	// Use background context without tenant
+	ctx := context.Background()
+
+	t.Run("create without tenant", func(t *testing.T) {
+		_, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{NodeType: "region"})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+	})
+
+	t.Run("get without tenant", func(t *testing.T) {
+		_, err := svc.GetNode(ctx, &pb.GetNodeRequest{Id: uuid.New().String()})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+	})
+
+	t.Run("get children without tenant", func(t *testing.T) {
+		_, err := svc.GetChildren(ctx, &pb.GetChildrenRequest{ParentId: uuid.New().String()})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+	})
+
+	t.Run("get ancestors without tenant", func(t *testing.T) {
+		_, err := svc.GetAncestors(ctx, &pb.GetAncestorsRequest{NodeId: uuid.New().String()})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+	})
+
+	t.Run("import without tenant", func(t *testing.T) {
+		_, err := svc.ImportNodes(ctx, &pb.ImportNodesRequest{
+			Nodes: []*pb.CreateNodeRequest{{NodeType: "region"}},
+		})
+		require.Error(t, err)
+		st, _ := status.FromError(err)
+		assert.Equal(t, codes.Unauthenticated, st.Code())
+	})
+}
+
+func TestNodeService_GetNodeHistory(t *testing.T) {
+	svc, pool := setupNodeService(t)
+	ctx := setupNodeTenantCtx(t, pool, "test_history")
+
+	// Create initial version
+	resp, err := svc.CreateNode(ctx, &pb.CreateNodeRequest{
+		NodeType: "meter",
+		Attributes: mustStruct(t, map[string]any{
+			"reading": "v1",
+		}),
+	})
+	require.NoError(t, err)
+
+	// Get history - should have 1 version
+	histResp, err := svc.GetNodeHistory(ctx, &pb.GetNodeHistoryRequest{
+		NodeId: resp.Node.Id,
+	})
+	require.NoError(t, err)
+	assert.Len(t, histResp.Versions, 1)
+	assert.Equal(t, resp.Node.Id, histResp.Versions[0].Id)
+}
+
+// mustStruct creates a structpb.Struct from a map, failing the test on error.
+func mustStruct(t *testing.T, m map[string]any) *structpb.Struct {
+	t.Helper()
+	s, err := structpb.NewStruct(m)
+	require.NoError(t, err)
+	return s
+}


### PR DESCRIPTION
## Summary

Implements `market-data-dynamic-pricing.6`: gRPC service for hierarchical reference data node CRUD, traversal, and bi-temporal queries.

- Define `NodeService` protobuf with 9 RPCs extending the reference data service (node.proto)
- Implement gRPC handlers with tenant isolation, validation, error mapping, and Prometheus metrics
- Add integration tests using PostgreSQL testcontainers covering CRUD, traversal, bi-temporal, batch import, tenant isolation, and error scenarios

## Changes Made

### Protobuf (`api/proto/meridian/reference_data/v1/node.proto`)
- `ReferenceDataNode` message with UUID, tenant_id, node_type, parent_id, attributes (Struct), resolution_key, bi-temporal timestamps, version
- `NodeService` with 9 unary RPCs: CreateNode, UpdateNode, GetNode, GetChildren, GetAncestors, GetSubtree, GetNodeAsAt, GetNodeHistory, ImportNodes
- protovalidate annotations for compile-time validation
- ImportNodes uses batch unary RPC (up to 1000 nodes) instead of streaming, compatible with `UNARY_RPC` buf lint rule

### Handler (`services/reference-data/handler/node_handler.go`)
- `NodeService` struct wrapping `node.Repository` with structured logging
- Tenant extraction via `tenant.RequireFromContext()` (Unauthenticated on missing)
- Domain error -> gRPC status code mapping for all `node.Err*` sentinel errors
- `google.protobuf.Struct` <-> `map[string]any` conversion for flexible attributes
- Prometheus metrics: `operations_total` (counter), `operation_duration_seconds` (histogram), `traversal_depth` (histogram)

### Tests (`services/reference-data/handler/node_handler_test.go`)
Integration tests with PostgreSQL testcontainer:
1. CRUD flow with version increment
2. 3-level hierarchy traversal (dno/gsp/meter)
3. GetAncestors on leaf node
4. Bi-temporal GetNodeAsAt boundary conditions
5. Batch ImportNodes with 100 nodes (10 regions x 9 zones)
6. Tenant isolation (cross-tenant invisibility)
7. Validation errors (missing fields, invalid UUIDs, non-existent parent)
8. Optimistic lock conflict
9. Missing tenant context -> Unauthenticated
10. GetNodeHistory

## Test plan

- [x] All 10 integration test scenarios pass with PostgreSQL testcontainers
- [x] Existing instrument handler tests unaffected
- [x] buf lint passes
- [x] golangci-lint passes
- [x] go vet passes

## Task Master

| TM Task | Description |
|---------|-------------|
| market-data-dynamic-pricing.6 | Create gRPC service for hierarchical reference data operations |
| market-data-dynamic-pricing.6.1 | Define protobuf service extension |
| market-data-dynamic-pricing.6.2 | Implement gRPC handlers |
| market-data-dynamic-pricing.6.3 | Integration tests |