### PR TITLE
feat: implement proto-to-domain mapping helpers for settlement lifecycle

### DIFF
--- a/services/reconciliation/service/mapping.go
+++ b/services/reconciliation/service/mapping.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -9,6 +10,8 @@ import (
 	"github.com/meridianhub/meridian/services/reconciliation/domain"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+var errNegativeCursorOffset = errors.New("invalid cursor: negative offset")
 
 // toDomainReconciliationScope converts a proto ReconciliationScope to domain.
 // UNSPECIFIED defaults to ACCOUNT.
@@ -225,6 +228,10 @@ func decodeCursor(token string) (int, error) {
 	offset, err := strconv.Atoi(string(data))
 	if err != nil {
 		return 0, fmt.Errorf("invalid cursor content: %w", err)
+	}
+
+	if offset < 0 {
+		return 0, errNegativeCursorOffset
 	}
 
 	return offset, nil

--- a/services/reconciliation/service/mapping.go
+++ b/services/reconciliation/service/mapping.go
@@ -1,0 +1,231 @@
+package service
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strconv"
+
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// toDomainReconciliationScope converts a proto ReconciliationScope to domain.
+// UNSPECIFIED defaults to ACCOUNT.
+func toDomainReconciliationScope(s reconciliationv1.ReconciliationScope) domain.ReconciliationScope {
+	switch s {
+	case reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT:
+		return domain.ReconciliationScopeAccount
+	case reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_INSTRUMENT:
+		return domain.ReconciliationScopeInstrument
+	case reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_PORTFOLIO:
+		return domain.ReconciliationScopePortfolio
+	case reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_FULL:
+		return domain.ReconciliationScopeFull
+	case reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_UNSPECIFIED:
+		return domain.ReconciliationScopeAccount
+	}
+	return domain.ReconciliationScopeAccount
+}
+
+// toDomainSettlementType converts a proto SettlementType to domain.
+// UNSPECIFIED defaults to ON_DEMAND.
+func toDomainSettlementType(s reconciliationv1.SettlementType) domain.SettlementType {
+	switch s {
+	case reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY:
+		return domain.SettlementTypeDaily
+	case reconciliationv1.SettlementType_SETTLEMENT_TYPE_WEEKLY:
+		return domain.SettlementTypeWeekly
+	case reconciliationv1.SettlementType_SETTLEMENT_TYPE_MONTHLY:
+		return domain.SettlementTypeMonthly
+	case reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND:
+		return domain.SettlementTypeOnDemand
+	case reconciliationv1.SettlementType_SETTLEMENT_TYPE_END_OF_DAY:
+		return domain.SettlementTypeEndOfDay
+	case reconciliationv1.SettlementType_SETTLEMENT_TYPE_REAL_TIME:
+		return domain.SettlementTypeRealTime
+	case reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED:
+		return domain.SettlementTypeOnDemand
+	}
+	return domain.SettlementTypeOnDemand
+}
+
+// toProtoRunStatus converts a domain RunStatus to proto.
+func toProtoRunStatus(s domain.RunStatus) reconciliationv1.RunStatus {
+	switch s {
+	case domain.RunStatusPending:
+		return reconciliationv1.RunStatus_RUN_STATUS_PENDING
+	case domain.RunStatusRunning:
+		return reconciliationv1.RunStatus_RUN_STATUS_RUNNING
+	case domain.RunStatusCompleted, domain.RunStatusFinalized:
+		return reconciliationv1.RunStatus_RUN_STATUS_COMPLETED
+	case domain.RunStatusFailed:
+		return reconciliationv1.RunStatus_RUN_STATUS_FAILED
+	case domain.RunStatusCancelled:
+		return reconciliationv1.RunStatus_RUN_STATUS_CANCELLED
+	}
+	return reconciliationv1.RunStatus_RUN_STATUS_UNSPECIFIED
+}
+
+// toProtoReconciliationScope converts a domain ReconciliationScope to proto.
+func toProtoReconciliationScope(s domain.ReconciliationScope) reconciliationv1.ReconciliationScope {
+	switch s {
+	case domain.ReconciliationScopeAccount:
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT
+	case domain.ReconciliationScopeInstrument:
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_INSTRUMENT
+	case domain.ReconciliationScopePortfolio:
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_PORTFOLIO
+	case domain.ReconciliationScopeFull:
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_FULL
+	default:
+		return reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_UNSPECIFIED
+	}
+}
+
+// toProtoSettlementType converts a domain SettlementType to proto.
+func toProtoSettlementType(s domain.SettlementType) reconciliationv1.SettlementType {
+	switch s {
+	case domain.SettlementTypeDaily:
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY
+	case domain.SettlementTypeWeekly:
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_WEEKLY
+	case domain.SettlementTypeMonthly:
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_MONTHLY
+	case domain.SettlementTypeOnDemand:
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND
+	case domain.SettlementTypeEndOfDay:
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_END_OF_DAY
+	case domain.SettlementTypeRealTime:
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_REAL_TIME
+	case domain.SettlementTypeFinal:
+		return reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND
+	}
+	return reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED
+}
+
+// toProtoVarianceReason converts a domain VarianceReason to proto.
+func toProtoVarianceReason(r domain.VarianceReason) reconciliationv1.VarianceReason {
+	switch r {
+	case domain.VarianceReasonAmountMismatch:
+		return reconciliationv1.VarianceReason_VARIANCE_REASON_AMOUNT_MISMATCH
+	case domain.VarianceReasonMissingEntry:
+		return reconciliationv1.VarianceReason_VARIANCE_REASON_MISSING_ENTRY
+	case domain.VarianceReasonDuplicateEntry:
+		return reconciliationv1.VarianceReason_VARIANCE_REASON_DUPLICATE_ENTRY
+	case domain.VarianceReasonTimingDifference:
+		return reconciliationv1.VarianceReason_VARIANCE_REASON_TIMING_DIFFERENCE
+	case domain.VarianceReasonCurrencyMismatch:
+		return reconciliationv1.VarianceReason_VARIANCE_REASON_CURRENCY_MISMATCH
+	case domain.VarianceReasonDirectionError:
+		return reconciliationv1.VarianceReason_VARIANCE_REASON_DIRECTION_ERROR
+	case domain.VarianceReasonOther, domain.VarianceReasonQualityUpgrade,
+		domain.VarianceReasonExternalMismatch, domain.VarianceReasonCorrectionApplied:
+		return reconciliationv1.VarianceReason_VARIANCE_REASON_OTHER
+	}
+	return reconciliationv1.VarianceReason_VARIANCE_REASON_UNSPECIFIED
+}
+
+// toProtoVarianceStatus converts a domain VarianceStatus to proto.
+func toProtoVarianceStatus(s domain.VarianceStatus) reconciliationv1.VarianceStatus {
+	switch s {
+	case domain.VarianceStatusDetected, domain.VarianceStatusValued,
+		domain.VarianceStatusOpen:
+		return reconciliationv1.VarianceStatus_VARIANCE_STATUS_OPEN
+	case domain.VarianceStatusInvestigating:
+		return reconciliationv1.VarianceStatus_VARIANCE_STATUS_INVESTIGATING
+	case domain.VarianceStatusDisputed:
+		return reconciliationv1.VarianceStatus_VARIANCE_STATUS_DISPUTED
+	case domain.VarianceStatusResolved:
+		return reconciliationv1.VarianceStatus_VARIANCE_STATUS_RESOLVED
+	case domain.VarianceStatusAccepted:
+		return reconciliationv1.VarianceStatus_VARIANCE_STATUS_ACCEPTED
+	}
+	return reconciliationv1.VarianceStatus_VARIANCE_STATUS_UNSPECIFIED
+}
+
+// toProtoRunSummary converts a domain SettlementRun to a proto SettlementRunSummary.
+func toProtoRunSummary(run *domain.SettlementRun) *reconciliationv1.SettlementRunSummary {
+	if run == nil {
+		return nil
+	}
+
+	summary := &reconciliationv1.SettlementRunSummary{
+		RunId:          run.RunID.String(),
+		AccountId:      run.AccountID,
+		Scope:          toProtoReconciliationScope(run.Scope),
+		SettlementType: toProtoSettlementType(run.SettlementType),
+		Status:         toProtoRunStatus(run.Status),
+		PeriodStart:    timestamppb.New(run.PeriodStart),
+		PeriodEnd:      timestamppb.New(run.PeriodEnd),
+		InitiatedBy:    run.InitiatedBy,
+		VarianceCount:  int32(run.VarianceCount),
+		FailureReason:  run.FailureReason,
+		Attributes:     run.Attributes,
+		CreatedAt:      timestamppb.New(run.CreatedAt),
+		UpdatedAt:      timestamppb.New(run.UpdatedAt),
+		Version:        run.Version,
+	}
+
+	if run.CompletedAt != nil {
+		summary.CompletedAt = timestamppb.New(*run.CompletedAt)
+	}
+
+	return summary
+}
+
+// toProtoVarianceDetail converts a domain Variance to a proto VarianceDetail.
+func toProtoVarianceDetail(v *domain.Variance) *reconciliationv1.VarianceDetail {
+	if v == nil {
+		return nil
+	}
+
+	detail := &reconciliationv1.VarianceDetail{
+		VarianceId:     v.VarianceID.String(),
+		RunId:          v.RunID.String(),
+		SnapshotId:     v.SnapshotID.String(),
+		AccountId:      v.AccountID,
+		InstrumentCode: v.InstrumentCode,
+		ExpectedAmount: v.ExpectedAmount.String(),
+		ActualAmount:   v.ActualAmount.String(),
+		VarianceAmount: v.VarianceAmount.String(),
+		Reason:         toProtoVarianceReason(v.Reason),
+		Status:         toProtoVarianceStatus(v.Status),
+		ResolutionNote: v.ResolutionNote,
+		ResolvedBy:     v.ResolvedBy,
+		Attributes:     v.Attributes,
+		CreatedAt:      timestamppb.New(v.CreatedAt),
+		UpdatedAt:      timestamppb.New(v.UpdatedAt),
+	}
+
+	if v.ResolvedAt != nil {
+		detail.ResolvedAt = timestamppb.New(*v.ResolvedAt)
+	}
+
+	return detail
+}
+
+// encodeCursor encodes an offset as a base64 page token.
+func encodeCursor(offset int) string {
+	return base64.StdEncoding.EncodeToString([]byte(strconv.Itoa(offset)))
+}
+
+// decodeCursor decodes a base64 page token to an offset.
+// An empty token returns offset 0.
+func decodeCursor(token string) (int, error) {
+	if token == "" {
+		return 0, nil
+	}
+
+	data, err := base64.StdEncoding.DecodeString(token)
+	if err != nil {
+		return 0, fmt.Errorf("invalid cursor: %w", err)
+	}
+
+	offset, err := strconv.Atoi(string(data))
+	if err != nil {
+		return 0, fmt.Errorf("invalid cursor content: %w", err)
+	}
+
+	return offset, nil
+}

--- a/services/reconciliation/service/mapping_test.go
+++ b/services/reconciliation/service/mapping_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/base64"
 	"testing"
 	"time"
 
@@ -136,6 +137,11 @@ func TestToProtoRunStatus(t *testing.T) {
 			want:   reconciliationv1.RunStatus_RUN_STATUS_CANCELLED,
 		},
 		{
+			name:   "finalized maps to completed",
+			domain: domain.RunStatusFinalized,
+			want:   reconciliationv1.RunStatus_RUN_STATUS_COMPLETED,
+		},
+		{
 			name:   "unknown status returns unspecified",
 			domain: domain.RunStatus("UNKNOWN"),
 			want:   reconciliationv1.RunStatus_RUN_STATUS_UNSPECIFIED,
@@ -228,6 +234,11 @@ func TestToProtoSettlementType(t *testing.T) {
 			want:   reconciliationv1.SettlementType_SETTLEMENT_TYPE_REAL_TIME,
 		},
 		{
+			name:   "final maps to on demand",
+			domain: domain.SettlementTypeFinal,
+			want:   reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND,
+		},
+		{
 			name:   "unknown returns unspecified",
 			domain: domain.SettlementType("UNKNOWN"),
 			want:   reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED,
@@ -284,6 +295,21 @@ func TestToProtoVarianceReason(t *testing.T) {
 			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_OTHER,
 		},
 		{
+			name:   "quality upgrade maps to other",
+			domain: domain.VarianceReasonQualityUpgrade,
+			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_OTHER,
+		},
+		{
+			name:   "external mismatch maps to other",
+			domain: domain.VarianceReasonExternalMismatch,
+			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_OTHER,
+		},
+		{
+			name:   "correction applied maps to other",
+			domain: domain.VarianceReasonCorrectionApplied,
+			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_OTHER,
+		},
+		{
 			name:   "unknown returns unspecified",
 			domain: domain.VarianceReason("UNKNOWN"),
 			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_UNSPECIFIED,
@@ -328,6 +354,16 @@ func TestToProtoVarianceStatus(t *testing.T) {
 			name:   "accepted",
 			domain: domain.VarianceStatusAccepted,
 			want:   reconciliationv1.VarianceStatus_VARIANCE_STATUS_ACCEPTED,
+		},
+		{
+			name:   "detected maps to open",
+			domain: domain.VarianceStatusDetected,
+			want:   reconciliationv1.VarianceStatus_VARIANCE_STATUS_OPEN,
+		},
+		{
+			name:   "valued maps to open",
+			domain: domain.VarianceStatusValued,
+			want:   reconciliationv1.VarianceStatus_VARIANCE_STATUS_OPEN,
 		},
 		{
 			name:   "unknown returns unspecified",
@@ -532,5 +568,11 @@ func TestDecodeCursorInvalid(t *testing.T) {
 func TestDecodeCursorInvalidContent(t *testing.T) {
 	// Valid base64 but not a number
 	_, err := decodeCursor("aGVsbG8=") // "hello" in base64
+	assert.Error(t, err)
+}
+
+func TestDecodeCursorNegativeOffset(t *testing.T) {
+	encoded := base64.StdEncoding.EncodeToString([]byte("-5"))
+	_, err := decodeCursor(encoded)
 	assert.Error(t, err)
 }

--- a/services/reconciliation/service/mapping_test.go
+++ b/services/reconciliation/service/mapping_test.go
@@ -1,0 +1,536 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToDomainReconciliationScope(t *testing.T) {
+	tests := []struct {
+		name  string
+		proto reconciliationv1.ReconciliationScope
+		want  domain.ReconciliationScope
+	}{
+		{
+			name:  "account",
+			proto: reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+			want:  domain.ReconciliationScopeAccount,
+		},
+		{
+			name:  "instrument",
+			proto: reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_INSTRUMENT,
+			want:  domain.ReconciliationScopeInstrument,
+		},
+		{
+			name:  "portfolio",
+			proto: reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_PORTFOLIO,
+			want:  domain.ReconciliationScopePortfolio,
+		},
+		{
+			name:  "full",
+			proto: reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_FULL,
+			want:  domain.ReconciliationScopeFull,
+		},
+		{
+			name:  "unspecified defaults to account",
+			proto: reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_UNSPECIFIED,
+			want:  domain.ReconciliationScopeAccount,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toDomainReconciliationScope(tt.proto)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToDomainSettlementType(t *testing.T) {
+	tests := []struct {
+		name  string
+		proto reconciliationv1.SettlementType
+		want  domain.SettlementType
+	}{
+		{
+			name:  "daily",
+			proto: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+			want:  domain.SettlementTypeDaily,
+		},
+		{
+			name:  "weekly",
+			proto: reconciliationv1.SettlementType_SETTLEMENT_TYPE_WEEKLY,
+			want:  domain.SettlementTypeWeekly,
+		},
+		{
+			name:  "monthly",
+			proto: reconciliationv1.SettlementType_SETTLEMENT_TYPE_MONTHLY,
+			want:  domain.SettlementTypeMonthly,
+		},
+		{
+			name:  "on demand",
+			proto: reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND,
+			want:  domain.SettlementTypeOnDemand,
+		},
+		{
+			name:  "end of day",
+			proto: reconciliationv1.SettlementType_SETTLEMENT_TYPE_END_OF_DAY,
+			want:  domain.SettlementTypeEndOfDay,
+		},
+		{
+			name:  "real time",
+			proto: reconciliationv1.SettlementType_SETTLEMENT_TYPE_REAL_TIME,
+			want:  domain.SettlementTypeRealTime,
+		},
+		{
+			name:  "unspecified defaults to on demand",
+			proto: reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED,
+			want:  domain.SettlementTypeOnDemand,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toDomainSettlementType(tt.proto)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToProtoRunStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain domain.RunStatus
+		want   reconciliationv1.RunStatus
+	}{
+		{
+			name:   "pending",
+			domain: domain.RunStatusPending,
+			want:   reconciliationv1.RunStatus_RUN_STATUS_PENDING,
+		},
+		{
+			name:   "running",
+			domain: domain.RunStatusRunning,
+			want:   reconciliationv1.RunStatus_RUN_STATUS_RUNNING,
+		},
+		{
+			name:   "completed",
+			domain: domain.RunStatusCompleted,
+			want:   reconciliationv1.RunStatus_RUN_STATUS_COMPLETED,
+		},
+		{
+			name:   "failed",
+			domain: domain.RunStatusFailed,
+			want:   reconciliationv1.RunStatus_RUN_STATUS_FAILED,
+		},
+		{
+			name:   "cancelled",
+			domain: domain.RunStatusCancelled,
+			want:   reconciliationv1.RunStatus_RUN_STATUS_CANCELLED,
+		},
+		{
+			name:   "unknown status returns unspecified",
+			domain: domain.RunStatus("UNKNOWN"),
+			want:   reconciliationv1.RunStatus_RUN_STATUS_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toProtoRunStatus(tt.domain)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToProtoReconciliationScope(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain domain.ReconciliationScope
+		want   reconciliationv1.ReconciliationScope
+	}{
+		{
+			name:   "account",
+			domain: domain.ReconciliationScopeAccount,
+			want:   reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+		},
+		{
+			name:   "instrument",
+			domain: domain.ReconciliationScopeInstrument,
+			want:   reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_INSTRUMENT,
+		},
+		{
+			name:   "portfolio",
+			domain: domain.ReconciliationScopePortfolio,
+			want:   reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_PORTFOLIO,
+		},
+		{
+			name:   "full",
+			domain: domain.ReconciliationScopeFull,
+			want:   reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_FULL,
+		},
+		{
+			name:   "unknown returns unspecified",
+			domain: domain.ReconciliationScope("UNKNOWN"),
+			want:   reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toProtoReconciliationScope(tt.domain)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToProtoSettlementType(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain domain.SettlementType
+		want   reconciliationv1.SettlementType
+	}{
+		{
+			name:   "daily",
+			domain: domain.SettlementTypeDaily,
+			want:   reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+		},
+		{
+			name:   "weekly",
+			domain: domain.SettlementTypeWeekly,
+			want:   reconciliationv1.SettlementType_SETTLEMENT_TYPE_WEEKLY,
+		},
+		{
+			name:   "monthly",
+			domain: domain.SettlementTypeMonthly,
+			want:   reconciliationv1.SettlementType_SETTLEMENT_TYPE_MONTHLY,
+		},
+		{
+			name:   "on demand",
+			domain: domain.SettlementTypeOnDemand,
+			want:   reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND,
+		},
+		{
+			name:   "end of day",
+			domain: domain.SettlementTypeEndOfDay,
+			want:   reconciliationv1.SettlementType_SETTLEMENT_TYPE_END_OF_DAY,
+		},
+		{
+			name:   "real time",
+			domain: domain.SettlementTypeRealTime,
+			want:   reconciliationv1.SettlementType_SETTLEMENT_TYPE_REAL_TIME,
+		},
+		{
+			name:   "unknown returns unspecified",
+			domain: domain.SettlementType("UNKNOWN"),
+			want:   reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toProtoSettlementType(tt.domain)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToProtoVarianceReason(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain domain.VarianceReason
+		want   reconciliationv1.VarianceReason
+	}{
+		{
+			name:   "amount mismatch",
+			domain: domain.VarianceReasonAmountMismatch,
+			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_AMOUNT_MISMATCH,
+		},
+		{
+			name:   "missing entry",
+			domain: domain.VarianceReasonMissingEntry,
+			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_MISSING_ENTRY,
+		},
+		{
+			name:   "duplicate entry",
+			domain: domain.VarianceReasonDuplicateEntry,
+			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_DUPLICATE_ENTRY,
+		},
+		{
+			name:   "timing difference",
+			domain: domain.VarianceReasonTimingDifference,
+			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_TIMING_DIFFERENCE,
+		},
+		{
+			name:   "currency mismatch",
+			domain: domain.VarianceReasonCurrencyMismatch,
+			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_CURRENCY_MISMATCH,
+		},
+		{
+			name:   "direction error",
+			domain: domain.VarianceReasonDirectionError,
+			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_DIRECTION_ERROR,
+		},
+		{
+			name:   "other",
+			domain: domain.VarianceReasonOther,
+			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_OTHER,
+		},
+		{
+			name:   "unknown returns unspecified",
+			domain: domain.VarianceReason("UNKNOWN"),
+			want:   reconciliationv1.VarianceReason_VARIANCE_REASON_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toProtoVarianceReason(tt.domain)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToProtoVarianceStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		domain domain.VarianceStatus
+		want   reconciliationv1.VarianceStatus
+	}{
+		{
+			name:   "open",
+			domain: domain.VarianceStatusOpen,
+			want:   reconciliationv1.VarianceStatus_VARIANCE_STATUS_OPEN,
+		},
+		{
+			name:   "investigating",
+			domain: domain.VarianceStatusInvestigating,
+			want:   reconciliationv1.VarianceStatus_VARIANCE_STATUS_INVESTIGATING,
+		},
+		{
+			name:   "disputed",
+			domain: domain.VarianceStatusDisputed,
+			want:   reconciliationv1.VarianceStatus_VARIANCE_STATUS_DISPUTED,
+		},
+		{
+			name:   "resolved",
+			domain: domain.VarianceStatusResolved,
+			want:   reconciliationv1.VarianceStatus_VARIANCE_STATUS_RESOLVED,
+		},
+		{
+			name:   "accepted",
+			domain: domain.VarianceStatusAccepted,
+			want:   reconciliationv1.VarianceStatus_VARIANCE_STATUS_ACCEPTED,
+		},
+		{
+			name:   "unknown returns unspecified",
+			domain: domain.VarianceStatus("UNKNOWN"),
+			want:   reconciliationv1.VarianceStatus_VARIANCE_STATUS_UNSPECIFIED,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toProtoVarianceStatus(tt.domain)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToProtoRunSummary(t *testing.T) {
+	runID := uuid.New()
+	now := time.Now().UTC()
+	completedAt := now.Add(10 * time.Minute)
+
+	run := &domain.SettlementRun{
+		RunID:          runID,
+		AccountID:      "acc-001",
+		Scope:          domain.ReconciliationScopePortfolio,
+		SettlementType: domain.SettlementTypeDaily,
+		Status:         domain.RunStatusCompleted,
+		PeriodStart:    now.Add(-24 * time.Hour),
+		PeriodEnd:      now,
+		InitiatedBy:    "system-user",
+		CompletedAt:    &completedAt,
+		VarianceCount:  5,
+		FailureReason:  "",
+		Attributes:     map[string]string{"env": "prod", "region": "eu-west-1"},
+		CreatedAt:      now.Add(-1 * time.Hour),
+		UpdatedAt:      now,
+		Version:        3,
+	}
+
+	summary := toProtoRunSummary(run)
+	require.NotNil(t, summary)
+
+	assert.Equal(t, runID.String(), summary.RunId)
+	assert.Equal(t, "acc-001", summary.AccountId)
+	assert.Equal(t, reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_PORTFOLIO, summary.Scope)
+	assert.Equal(t, reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY, summary.SettlementType)
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_COMPLETED, summary.Status)
+	assert.Equal(t, run.PeriodStart.Unix(), summary.PeriodStart.AsTime().Unix())
+	assert.Equal(t, run.PeriodEnd.Unix(), summary.PeriodEnd.AsTime().Unix())
+	assert.Equal(t, "system-user", summary.InitiatedBy)
+	require.NotNil(t, summary.CompletedAt)
+	assert.Equal(t, completedAt.Unix(), summary.CompletedAt.AsTime().Unix())
+	assert.Equal(t, int32(5), summary.VarianceCount)
+	assert.Equal(t, "", summary.FailureReason)
+	assert.Equal(t, map[string]string{"env": "prod", "region": "eu-west-1"}, summary.Attributes)
+	assert.Equal(t, run.CreatedAt.Unix(), summary.CreatedAt.AsTime().Unix())
+	assert.Equal(t, run.UpdatedAt.Unix(), summary.UpdatedAt.AsTime().Unix())
+	assert.Equal(t, int64(3), summary.Version)
+}
+
+func TestToProtoRunSummaryMinimal(t *testing.T) {
+	runID := uuid.New()
+	now := time.Now().UTC()
+
+	run := &domain.SettlementRun{
+		RunID:          runID,
+		AccountID:      "acc-002",
+		Scope:          domain.ReconciliationScopeAccount,
+		SettlementType: domain.SettlementTypeOnDemand,
+		Status:         domain.RunStatusPending,
+		PeriodStart:    now.Add(-1 * time.Hour),
+		PeriodEnd:      now,
+		InitiatedBy:    "admin",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+		Version:        1,
+	}
+
+	summary := toProtoRunSummary(run)
+	require.NotNil(t, summary)
+
+	assert.Equal(t, runID.String(), summary.RunId)
+	assert.Nil(t, summary.CompletedAt, "completed_at should be nil for pending runs")
+	assert.Equal(t, int32(0), summary.VarianceCount)
+	assert.Empty(t, summary.FailureReason)
+	assert.Nil(t, summary.Attributes, "nil attributes should result in nil map")
+}
+
+func TestToProtoRunSummaryNil(t *testing.T) {
+	assert.Nil(t, toProtoRunSummary(nil))
+}
+
+func TestToProtoVarianceDetail(t *testing.T) {
+	varianceID := uuid.New()
+	runID := uuid.New()
+	snapshotID := uuid.New()
+	now := time.Now().UTC()
+	resolvedAt := now.Add(5 * time.Minute)
+
+	v := &domain.Variance{
+		VarianceID:     varianceID,
+		RunID:          runID,
+		SnapshotID:     snapshotID,
+		AccountID:      "acc-001",
+		InstrumentCode: "GBP",
+		ExpectedAmount: decimal.NewFromFloat(1000.50),
+		ActualAmount:   decimal.NewFromFloat(999.25),
+		VarianceAmount: decimal.NewFromFloat(-1.25),
+		Reason:         domain.VarianceReasonAmountMismatch,
+		Status:         domain.VarianceStatusResolved,
+		ResolutionNote: "Rounding difference accepted",
+		ResolvedBy:     "auditor-1",
+		ResolvedAt:     &resolvedAt,
+		Attributes:     map[string]string{"source": "stripe", "batch": "20260210"},
+		CreatedAt:      now.Add(-10 * time.Minute),
+		UpdatedAt:      now,
+	}
+
+	detail := toProtoVarianceDetail(v)
+	require.NotNil(t, detail)
+
+	assert.Equal(t, varianceID.String(), detail.VarianceId)
+	assert.Equal(t, runID.String(), detail.RunId)
+	assert.Equal(t, snapshotID.String(), detail.SnapshotId)
+	assert.Equal(t, "acc-001", detail.AccountId)
+	assert.Equal(t, "GBP", detail.InstrumentCode)
+	assert.Equal(t, "1000.5", detail.ExpectedAmount)
+	assert.Equal(t, "999.25", detail.ActualAmount)
+	assert.Equal(t, "-1.25", detail.VarianceAmount)
+	assert.Equal(t, reconciliationv1.VarianceReason_VARIANCE_REASON_AMOUNT_MISMATCH, detail.Reason)
+	assert.Equal(t, reconciliationv1.VarianceStatus_VARIANCE_STATUS_RESOLVED, detail.Status)
+	assert.Equal(t, "Rounding difference accepted", detail.ResolutionNote)
+	assert.Equal(t, "auditor-1", detail.ResolvedBy)
+	require.NotNil(t, detail.ResolvedAt)
+	assert.Equal(t, resolvedAt.Unix(), detail.ResolvedAt.AsTime().Unix())
+	assert.Equal(t, map[string]string{"source": "stripe", "batch": "20260210"}, detail.Attributes)
+	assert.Equal(t, v.CreatedAt.Unix(), detail.CreatedAt.AsTime().Unix())
+	assert.Equal(t, v.UpdatedAt.Unix(), detail.UpdatedAt.AsTime().Unix())
+}
+
+func TestToProtoVarianceDetailMinimal(t *testing.T) {
+	varianceID := uuid.New()
+	runID := uuid.New()
+	snapshotID := uuid.New()
+	now := time.Now().UTC()
+
+	v := &domain.Variance{
+		VarianceID:     varianceID,
+		RunID:          runID,
+		SnapshotID:     snapshotID,
+		AccountID:      "acc-002",
+		InstrumentCode: "KWH",
+		ExpectedAmount: decimal.NewFromInt(500),
+		ActualAmount:   decimal.NewFromInt(500),
+		VarianceAmount: decimal.Zero,
+		Reason:         domain.VarianceReasonOther,
+		Status:         domain.VarianceStatusOpen,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	detail := toProtoVarianceDetail(v)
+	require.NotNil(t, detail)
+
+	assert.Empty(t, detail.ResolutionNote)
+	assert.Empty(t, detail.ResolvedBy)
+	assert.Nil(t, detail.ResolvedAt, "resolved_at should be nil for unresolved variances")
+	assert.Nil(t, detail.Attributes, "nil attributes should result in nil map")
+}
+
+func TestToProtoVarianceDetailNil(t *testing.T) {
+	assert.Nil(t, toProtoVarianceDetail(nil))
+}
+
+func TestEncodeCursor(t *testing.T) {
+	encoded := encodeCursor(42)
+	assert.NotEmpty(t, encoded)
+
+	decoded, err := decodeCursor(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, 42, decoded)
+}
+
+func TestEncodeCursorZero(t *testing.T) {
+	encoded := encodeCursor(0)
+	decoded, err := decodeCursor(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, 0, decoded)
+}
+
+func TestDecodeCursorEmpty(t *testing.T) {
+	offset, err := decodeCursor("")
+	require.NoError(t, err)
+	assert.Equal(t, 0, offset)
+}
+
+func TestDecodeCursorInvalid(t *testing.T) {
+	_, err := decodeCursor("not-valid-base64!!!")
+	assert.Error(t, err)
+}
+
+func TestDecodeCursorInvalidContent(t *testing.T) {
+	// Valid base64 but not a number
+	_, err := decodeCursor("aGVsbG8=") // "hello" in base64
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary

- Add bidirectional proto-to-domain mapping helpers for the reconciliation service settlement lifecycle (Task Master: reconciliation-service.16)
- Implement exhaustive enum mappers for ReconciliationScope, SettlementType, RunStatus, VarianceReason, and VarianceStatus with proper handling of domain-only values (FINALIZED, FINAL, DETECTED, VALUED, etc.) that lack direct proto equivalents
- Add struct mappers for SettlementRunSummary and VarianceDetail with timestamp conversion and nullable field handling
- Add base64-encoded cursor pagination helpers (encodeCursor/decodeCursor)

## Changes Made

- `services/reconciliation/service/mapping.go` - All mapping functions
- `services/reconciliation/service/mapping_test.go` - Table-driven unit tests covering all enum values, full/minimal struct mapping, nil handling, and cursor round-trip/error cases

## Test plan

- [x] All 18 new unit tests pass locally
- [x] Full service package test suite passes
- [x] golangci-lint exhaustive checker passes (all switch cases covered)
- [ ] CI passes