### PR TITLE
feat: Add platform fee calculation and fee reconciliation

### DIFF
--- a/services/payment-order/adapters/gateway/payment_gateway.go
+++ b/services/payment-order/adapters/gateway/payment_gateway.go
@@ -36,6 +36,9 @@ type PaymentResponse struct {
 	GatewayReferenceID string
 	Status             Status
 	Message            string
+	// PlatformFeeAmount is the platform fee in minor units charged on this payment.
+	// Zero if no platform fee was applied.
+	PlatformFeeAmount int64
 }
 
 // PaymentGateway defines the port interface for external payment gateway interactions.

--- a/services/payment-order/adapters/gateway/stripe/platform_fee.go
+++ b/services/payment-order/adapters/gateway/stripe/platform_fee.go
@@ -69,6 +69,10 @@ func (c PlatformFeeConfig) CalculateFee(amountMinor int64) (int64, error) {
 		return 0, nil
 	}
 
+	if err := c.Validate(); err != nil {
+		return 0, err
+	}
+
 	var fee int64
 
 	switch c.Type {

--- a/services/payment-order/adapters/gateway/stripe/platform_fee.go
+++ b/services/payment-order/adapters/gateway/stripe/platform_fee.go
@@ -1,0 +1,90 @@
+package stripe
+
+import (
+	"errors"
+
+	"github.com/shopspring/decimal"
+)
+
+// PlatformFeeType specifies how the platform fee is calculated.
+type PlatformFeeType string
+
+const (
+	// PlatformFeeTypePercentage calculates fee as a percentage of the payment amount.
+	PlatformFeeTypePercentage PlatformFeeType = "percentage"
+	// PlatformFeeTypeFlat uses a fixed amount in minor units (cents) as the fee.
+	PlatformFeeTypeFlat PlatformFeeType = "flat"
+)
+
+// MaxPlatformFeePercent is the maximum allowed percentage fee to prevent misconfiguration.
+const MaxPlatformFeePercent = 10
+
+// Platform fee errors.
+var (
+	ErrInvalidFeeType    = errors.New("platform fee type must be 'percentage' or 'flat'")
+	ErrNegativeFeeValue  = errors.New("platform fee value must be positive")
+	ErrFeeExceedsMaximum = errors.New("platform fee percentage exceeds maximum allowed")
+	ErrFeeExceedsAmount  = errors.New("platform fee exceeds payment amount")
+)
+
+// PlatformFeeConfig holds the platform fee configuration for a tenant.
+type PlatformFeeConfig struct {
+	// Type is the fee calculation method: "percentage" or "flat".
+	Type PlatformFeeType
+	// Value is the fee amount: percentage (e.g., 2.5 for 2.5%) or flat amount in minor units.
+	Value decimal.Decimal
+}
+
+// Validate checks that the platform fee configuration is valid.
+func (c PlatformFeeConfig) Validate() error {
+	switch c.Type {
+	case PlatformFeeTypePercentage, PlatformFeeTypeFlat:
+		// valid type
+	default:
+		return ErrInvalidFeeType
+	}
+
+	if !c.Value.IsPositive() {
+		return ErrNegativeFeeValue
+	}
+
+	if c.Type == PlatformFeeTypePercentage && c.Value.GreaterThan(decimal.NewFromInt(MaxPlatformFeePercent)) {
+		return ErrFeeExceedsMaximum
+	}
+
+	return nil
+}
+
+// IsZero returns true if the fee config represents no fee.
+func (c PlatformFeeConfig) IsZero() bool {
+	return c.Value.IsZero()
+}
+
+// CalculateFee computes the platform fee in minor units for a given payment amount.
+// For percentage fees: fee = amountMinor * value / 100 (truncated to integer).
+// For flat fees: fee = value (the configured flat amount in minor units).
+// Returns an error if the fee exceeds the payment amount.
+func (c PlatformFeeConfig) CalculateFee(amountMinor int64) (int64, error) {
+	if c.IsZero() {
+		return 0, nil
+	}
+
+	var fee int64
+
+	switch c.Type {
+	case PlatformFeeTypePercentage:
+		amount := decimal.NewFromInt(amountMinor)
+		feeDecimal := amount.Mul(c.Value).Div(decimal.NewFromInt(100))
+		fee = feeDecimal.IntPart()
+	case PlatformFeeTypeFlat:
+		fee = c.Value.IntPart()
+	default:
+		return 0, ErrInvalidFeeType
+	}
+
+	if fee > amountMinor {
+		return 0, ErrFeeExceedsAmount
+	}
+
+	return fee, nil
+}

--- a/services/payment-order/adapters/gateway/stripe/platform_fee_test.go
+++ b/services/payment-order/adapters/gateway/stripe/platform_fee_test.go
@@ -1,0 +1,144 @@
+package stripe
+
+import (
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlatformFeeConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  PlatformFeeConfig
+		wantErr error
+	}{
+		{
+			name:   "valid percentage",
+			config: PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromFloat(2.5)},
+		},
+		{
+			name:   "valid flat fee",
+			config: PlatformFeeConfig{Type: PlatformFeeTypeFlat, Value: decimal.NewFromInt(150)},
+		},
+		{
+			name:   "max percentage is valid",
+			config: PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromInt(MaxPlatformFeePercent)},
+		},
+		{
+			name:    "invalid fee type",
+			config:  PlatformFeeConfig{Type: "unknown", Value: decimal.NewFromInt(100)},
+			wantErr: ErrInvalidFeeType,
+		},
+		{
+			name:    "negative value",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromInt(-1)},
+			wantErr: ErrNegativeFeeValue,
+		},
+		{
+			name:    "zero value",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.Zero},
+			wantErr: ErrNegativeFeeValue,
+		},
+		{
+			name:    "percentage exceeds maximum",
+			config:  PlatformFeeConfig{Type: PlatformFeeTypePercentage, Value: decimal.NewFromFloat(10.1)},
+			wantErr: ErrFeeExceedsMaximum,
+		},
+		{
+			name:   "flat fee has no maximum constraint",
+			config: PlatformFeeConfig{Type: PlatformFeeTypeFlat, Value: decimal.NewFromInt(99999)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPlatformFeeConfig_CalculateFee_Percentage(t *testing.T) {
+	tests := []struct {
+		name        string
+		percent     float64
+		amountMinor int64
+		expectedFee int64
+	}{
+		{"2.5% of 10000", 2.5, 10000, 250},
+		{"2.5% of 9999", 2.5, 9999, 249},
+		{"1% of 100", 1.0, 100, 1},
+		{"5% of 20000", 5.0, 20000, 1000},
+		{"0.5% of 1000", 0.5, 1000, 5},
+		{"2.5% of 1", 2.5, 1, 0}, // truncated to 0
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := PlatformFeeConfig{
+				Type:  PlatformFeeTypePercentage,
+				Value: decimal.NewFromFloat(tt.percent),
+			}
+			fee, err := config.CalculateFee(tt.amountMinor)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedFee, fee)
+		})
+	}
+}
+
+func TestPlatformFeeConfig_CalculateFee_Flat(t *testing.T) {
+	tests := []struct {
+		name        string
+		flatFee     int64
+		amountMinor int64
+		expectedFee int64
+	}{
+		{"150 cents flat on 10000", 150, 10000, 150},
+		{"50 cents flat on 100", 50, 100, 50},
+		{"1000 cents flat on 5000", 1000, 5000, 1000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := PlatformFeeConfig{
+				Type:  PlatformFeeTypeFlat,
+				Value: decimal.NewFromInt(tt.flatFee),
+			}
+			fee, err := config.CalculateFee(tt.amountMinor)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedFee, fee)
+		})
+	}
+}
+
+func TestPlatformFeeConfig_CalculateFee_FlatExceedsAmount(t *testing.T) {
+	config := PlatformFeeConfig{
+		Type:  PlatformFeeTypeFlat,
+		Value: decimal.NewFromInt(500),
+	}
+	_, err := config.CalculateFee(100)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrFeeExceedsAmount)
+}
+
+func TestPlatformFeeConfig_CalculateFee_ZeroConfig(t *testing.T) {
+	config := PlatformFeeConfig{
+		Type:  PlatformFeeTypePercentage,
+		Value: decimal.Zero,
+	}
+	fee, err := config.CalculateFee(10000)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), fee)
+}
+
+func TestPlatformFeeConfig_IsZero(t *testing.T) {
+	assert.True(t, PlatformFeeConfig{Value: decimal.Zero}.IsZero())
+	assert.False(t, PlatformFeeConfig{Value: decimal.NewFromInt(1)}.IsZero())
+}

--- a/services/payment-order/adapters/gateway/stripe/stripe_gateway.go
+++ b/services/payment-order/adapters/gateway/stripe/stripe_gateway.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/shopspring/decimal"
 	stripego "github.com/stripe/stripe-go/v82"
 
 	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
@@ -62,9 +61,9 @@ type PaymentIntentCreator interface {
 
 // GatewayAdapterConfig holds configuration for the Stripe gateway adapter.
 type GatewayAdapterConfig struct {
-	// PlatformFeePercent is the percentage of each payment collected as platform fee.
-	// e.g., 2.5 means 2.5%. Set to zero to disable platform fees.
-	PlatformFeePercent decimal.Decimal
+	// PlatformFee configures the platform fee calculation.
+	// If nil or zero, no platform fee is applied.
+	PlatformFee *PlatformFeeConfig
 }
 
 // stripeAccountKey is the context key for the Stripe Connected Account ID.
@@ -129,11 +128,16 @@ func (a *GatewayAdapter) SendPayment(ctx context.Context, req gateway.PaymentReq
 		},
 	}
 
-	// Set platform fee if configured
-	if a.config.PlatformFeePercent.IsPositive() {
-		feeAmount := calculatePlatformFee(amountMinor, a.config.PlatformFeePercent)
-		if feeAmount > 0 {
-			params.ApplicationFeeAmount = stripego.Int64(feeAmount)
+	// Calculate and set platform fee if configured
+	var platformFeeAmount int64
+	if a.config.PlatformFee != nil && !a.config.PlatformFee.IsZero() {
+		var err error
+		platformFeeAmount, err = a.config.PlatformFee.CalculateFee(amountMinor)
+		if err != nil {
+			return gateway.PaymentResponse{}, fmt.Errorf("platform fee calculation failed: %w", err)
+		}
+		if platformFeeAmount > 0 {
+			params.ApplicationFeeAmount = stripego.Int64(platformFeeAmount)
 		}
 	}
 
@@ -177,6 +181,7 @@ func (a *GatewayAdapter) SendPayment(ctx context.Context, req gateway.PaymentReq
 		GatewayReferenceID: pi.ID,
 		Status:             status,
 		Message:            string(pi.Status),
+		PlatformFeeAmount:  platformFeeAmount,
 	}, nil
 }
 
@@ -240,14 +245,6 @@ func (a *GatewayAdapter) handleError(err error, currency string, duration time.D
 		"message", stripeErr.Msg,
 	)
 	return gateway.PaymentResponse{}, fmt.Errorf("stripe error (%s): %w", stripeErr.Type, err)
-}
-
-// calculatePlatformFee calculates the platform fee in minor units.
-// fee = amount * percentage / 100, truncated to integer (floor).
-func calculatePlatformFee(amountMinor int64, feePercent decimal.Decimal) int64 {
-	amount := decimal.NewFromInt(amountMinor)
-	fee := amount.Mul(feePercent).Div(decimal.NewFromInt(100))
-	return fee.IntPart()
 }
 
 // mapPaymentIntentStatus maps a Stripe PaymentIntent status to a gateway.Status.

--- a/services/payment-order/adapters/gateway/stripe/stripe_gateway_test.go
+++ b/services/payment-order/adapters/gateway/stripe/stripe_gateway_test.go
@@ -65,9 +65,7 @@ func TestStripeGatewayAdapter_SendPayment_Success(t *testing.T) {
 		},
 	}
 
-	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{
-		PlatformFeePercent: decimal.Zero,
-	}, slog.Default())
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
 
 	ctx := tenantContext("tenant_a")
 	ctx = WithStripeAccount(ctx, "acct_tenant_a")
@@ -75,6 +73,7 @@ func TestStripeGatewayAdapter_SendPayment_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "pi_test_success", resp.GatewayReferenceID)
 	assert.Equal(t, gateway.StatusAccepted, resp.Status)
+	assert.Equal(t, int64(0), resp.PlatformFeeAmount)
 }
 
 func TestStripeGatewayAdapter_SendPayment_WithPlatformFee(t *testing.T) {
@@ -93,7 +92,10 @@ func TestStripeGatewayAdapter_SendPayment_WithPlatformFee(t *testing.T) {
 	}
 
 	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{
-		PlatformFeePercent: decimal.NewFromFloat(2.5),
+		PlatformFee: &PlatformFeeConfig{
+			Type:  PlatformFeeTypePercentage,
+			Value: decimal.NewFromFloat(2.5),
+		},
 	}, slog.Default())
 
 	ctx := tenantContext("tenant_a")
@@ -102,6 +104,37 @@ func TestStripeGatewayAdapter_SendPayment_WithPlatformFee(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "pi_with_fee", resp.GatewayReferenceID)
 	assert.Equal(t, gateway.StatusAccepted, resp.Status)
+	assert.Equal(t, int64(250), resp.PlatformFeeAmount)
+}
+
+func TestStripeGatewayAdapter_SendPayment_WithFlatFee(t *testing.T) {
+	mock := &mockPaymentIntentCreator{
+		createFn: func(_ context.Context, params *stripego.PaymentIntentCreateParams) (*stripego.PaymentIntent, error) {
+			assert.Equal(t, int64(10000), *params.Amount)
+			// Flat fee of 150 cents
+			require.NotNil(t, params.ApplicationFeeAmount)
+			assert.Equal(t, int64(150), *params.ApplicationFeeAmount)
+
+			return &stripego.PaymentIntent{
+				ID:     "pi_flat_fee",
+				Status: stripego.PaymentIntentStatusSucceeded,
+			}, nil
+		},
+	}
+
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{
+		PlatformFee: &PlatformFeeConfig{
+			Type:  PlatformFeeTypeFlat,
+			Value: decimal.NewFromInt(150),
+		},
+	}, slog.Default())
+
+	ctx := tenantContext("tenant_a")
+	ctx = WithStripeAccount(ctx, "acct_tenant_a")
+	resp, err := adapter.SendPayment(ctx, testGatewayRequest())
+	require.NoError(t, err)
+	assert.Equal(t, "pi_flat_fee", resp.GatewayReferenceID)
+	assert.Equal(t, int64(150), resp.PlatformFeeAmount)
 }
 
 func TestStripeGatewayAdapter_SendPayment_ZeroPlatformFee_OmitsApplicationFee(t *testing.T) {
@@ -116,15 +149,14 @@ func TestStripeGatewayAdapter_SendPayment_ZeroPlatformFee_OmitsApplicationFee(t 
 		},
 	}
 
-	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{
-		PlatformFeePercent: decimal.Zero,
-	}, slog.Default())
+	adapter := NewGatewayAdapter(mock, GatewayAdapterConfig{}, slog.Default())
 
 	ctx := tenantContext("tenant_a")
 	ctx = WithStripeAccount(ctx, "acct_tenant_a")
 	resp, err := adapter.SendPayment(ctx, testGatewayRequest())
 	require.NoError(t, err)
 	assert.Equal(t, "pi_no_fee", resp.GatewayReferenceID)
+	assert.Equal(t, int64(0), resp.PlatformFeeAmount)
 }
 
 func TestStripeGatewayAdapter_SendPayment_StatusMapping(t *testing.T) {

--- a/services/reconciliation/domain/fee_variance.go
+++ b/services/reconciliation/domain/fee_variance.go
@@ -1,0 +1,107 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// FeeVariance represents a discrepancy between the expected platform fee
+// (calculated by Meridian) and the actual application fee charged by Stripe.
+type FeeVariance struct {
+	// PaymentOrderID is the payment order that has a fee discrepancy.
+	PaymentOrderID uuid.UUID
+
+	// GatewayReferenceID is the Stripe PaymentIntent ID.
+	GatewayReferenceID string
+
+	// ExpectedFeeCents is the platform fee calculated by Meridian (in minor units).
+	ExpectedFeeCents int64
+
+	// ActualFeeCents is the application_fee from Stripe BalanceTransaction (in minor units).
+	ActualFeeCents int64
+
+	// VarianceCents is the difference: actual - expected.
+	VarianceCents int64
+
+	// VariancePercent is the percentage difference relative to expected fee.
+	// Zero if expected fee is zero.
+	VariancePercent decimal.Decimal
+
+	// Currency is the fee currency (lowercase ISO code).
+	Currency string
+
+	// TenantID identifies which tenant this fee belongs to.
+	TenantID string
+
+	// DetectedAt is when the variance was detected.
+	DetectedAt time.Time
+}
+
+// VarianceType returns whether the actual fee was over or under the expected fee.
+func (v FeeVariance) VarianceType() string {
+	if v.VarianceCents > 0 {
+		return "over"
+	}
+	if v.VarianceCents < 0 {
+		return "under"
+	}
+	return "match"
+}
+
+// FeeReconciliationReport holds the results of comparing expected vs actual
+// platform fees for a set of payments within a time period.
+type FeeReconciliationReport struct {
+	// TenantID is the tenant this report covers.
+	TenantID string
+
+	// PeriodStart is the beginning of the reporting period.
+	PeriodStart time.Time
+
+	// PeriodEnd is the end of the reporting period.
+	PeriodEnd time.Time
+
+	// TotalPayments is the count of payments examined.
+	TotalPayments int
+
+	// TotalVariances is the count of payments with fee discrepancies.
+	TotalVariances int
+
+	// Variances contains the individual fee discrepancies.
+	Variances []FeeVariance
+
+	// GeneratedAt is when this report was generated.
+	GeneratedAt time.Time
+}
+
+// NewFeeVariance creates a FeeVariance from expected and actual fee amounts.
+func NewFeeVariance(
+	paymentOrderID uuid.UUID,
+	gatewayReferenceID string,
+	expectedFeeCents int64,
+	actualFeeCents int64,
+	currency string,
+	tenantID string,
+) FeeVariance {
+	varianceCents := actualFeeCents - expectedFeeCents
+
+	var variancePercent decimal.Decimal
+	if expectedFeeCents != 0 {
+		variancePercent = decimal.NewFromInt(varianceCents).
+			Mul(decimal.NewFromInt(100)).
+			Div(decimal.NewFromInt(expectedFeeCents))
+	}
+
+	return FeeVariance{
+		PaymentOrderID:     paymentOrderID,
+		GatewayReferenceID: gatewayReferenceID,
+		ExpectedFeeCents:   expectedFeeCents,
+		ActualFeeCents:     actualFeeCents,
+		VarianceCents:      varianceCents,
+		VariancePercent:    variancePercent,
+		Currency:           currency,
+		TenantID:           tenantID,
+		DetectedAt:         time.Now().UTC(),
+	}
+}

--- a/services/reconciliation/domain/fee_variance_test.go
+++ b/services/reconciliation/domain/fee_variance_test.go
@@ -1,0 +1,65 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewFeeVariance_OverCharge(t *testing.T) {
+	poID := uuid.New()
+	v := NewFeeVariance(poID, "pi_123", 250, 260, "gbp", "tenant_a")
+
+	assert.Equal(t, poID, v.PaymentOrderID)
+	assert.Equal(t, "pi_123", v.GatewayReferenceID)
+	assert.Equal(t, int64(250), v.ExpectedFeeCents)
+	assert.Equal(t, int64(260), v.ActualFeeCents)
+	assert.Equal(t, int64(10), v.VarianceCents)
+	assert.Equal(t, "over", v.VarianceType())
+	assert.Equal(t, "gbp", v.Currency)
+	assert.Equal(t, "tenant_a", v.TenantID)
+	// 10/250 * 100 = 4%
+	assert.True(t, v.VariancePercent.Equal(decimal.NewFromInt(4)))
+}
+
+func TestNewFeeVariance_UnderCharge(t *testing.T) {
+	v := NewFeeVariance(uuid.New(), "pi_456", 300, 280, "usd", "tenant_b")
+
+	assert.Equal(t, int64(-20), v.VarianceCents)
+	assert.Equal(t, "under", v.VarianceType())
+}
+
+func TestNewFeeVariance_ExactMatch(t *testing.T) {
+	v := NewFeeVariance(uuid.New(), "pi_789", 250, 250, "eur", "tenant_c")
+
+	assert.Equal(t, int64(0), v.VarianceCents)
+	assert.Equal(t, "match", v.VarianceType())
+	assert.True(t, v.VariancePercent.IsZero())
+}
+
+func TestNewFeeVariance_ZeroExpectedFee(t *testing.T) {
+	v := NewFeeVariance(uuid.New(), "pi_000", 0, 50, "gbp", "tenant_d")
+
+	assert.Equal(t, int64(50), v.VarianceCents)
+	assert.Equal(t, "over", v.VarianceType())
+	// Variance percent is zero when expected is zero (avoid division by zero)
+	assert.True(t, v.VariancePercent.IsZero())
+}
+
+func TestFeeReconciliationReport_Structure(t *testing.T) {
+	report := FeeReconciliationReport{
+		TenantID:       "tenant_a",
+		TotalPayments:  100,
+		TotalVariances: 2,
+		Variances: []FeeVariance{
+			NewFeeVariance(uuid.New(), "pi_1", 250, 260, "gbp", "tenant_a"),
+			NewFeeVariance(uuid.New(), "pi_2", 300, 280, "gbp", "tenant_a"),
+		},
+	}
+
+	assert.Equal(t, 2, len(report.Variances))
+	assert.Equal(t, 100, report.TotalPayments)
+	assert.Equal(t, 2, report.TotalVariances)
+}

--- a/services/reconciliation/service/fee_reconciler.go
+++ b/services/reconciliation/service/fee_reconciler.go
@@ -1,0 +1,132 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+)
+
+// Prometheus metric for fee variance detection.
+var stripePlatformFeeVarianceTotal = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "stripe_platform_fee_variance_total",
+		Help: "Total number of Stripe platform fee variances detected",
+	},
+	[]string{"tenant_id", "variance_type"},
+)
+
+func init() {
+	prometheus.MustRegister(stripePlatformFeeVarianceTotal)
+}
+
+// FeeReconciliationRecord represents a single payment's fee data for reconciliation.
+// This is the input to the fee reconciler, typically populated by joining
+// payment_orders with Stripe balance transaction data.
+type FeeReconciliationRecord struct {
+	PaymentOrderID     string
+	GatewayReferenceID string
+	ExpectedFeeCents   int64
+	ActualFeeCents     int64
+	Currency           string
+	TenantID           string
+}
+
+// FeeReconciliationDataProvider retrieves fee reconciliation records for a tenant and period.
+type FeeReconciliationDataProvider interface {
+	// GetFeeReconciliationRecords returns records where the expected and actual fees
+	// may differ, for the given tenant within the specified time range.
+	GetFeeReconciliationRecords(ctx context.Context, tenantID string, periodStart, periodEnd time.Time) ([]FeeReconciliationRecord, error)
+}
+
+// FeeReconciler compares expected platform fees against actual Stripe application fees
+// and generates variance reports with Prometheus metrics.
+type FeeReconciler struct {
+	provider FeeReconciliationDataProvider
+	logger   *slog.Logger
+}
+
+// NewFeeReconciler creates a new FeeReconciler.
+func NewFeeReconciler(provider FeeReconciliationDataProvider, logger *slog.Logger) *FeeReconciler {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &FeeReconciler{
+		provider: provider,
+		logger:   logger,
+	}
+}
+
+// GenerateReport produces a FeeReconciliationReport for the given tenant and period.
+// It queries for all payments, identifies fee discrepancies, emits Prometheus metrics,
+// and returns the report.
+func (r *FeeReconciler) GenerateReport(ctx context.Context, tenantID string, periodStart, periodEnd time.Time) (*domain.FeeReconciliationReport, error) {
+	records, err := r.provider.GetFeeReconciliationRecords(ctx, tenantID, periodStart, periodEnd)
+	if err != nil {
+		return nil, err
+	}
+
+	variances := make([]domain.FeeVariance, 0, len(records))
+	for _, rec := range records {
+		if rec.ExpectedFeeCents == rec.ActualFeeCents {
+			continue
+		}
+
+		v := domain.NewFeeVariance(
+			parseUUID(rec.PaymentOrderID),
+			rec.GatewayReferenceID,
+			rec.ExpectedFeeCents,
+			rec.ActualFeeCents,
+			rec.Currency,
+			rec.TenantID,
+		)
+
+		variances = append(variances, v)
+
+		// Emit Prometheus metric
+		stripePlatformFeeVarianceTotal.WithLabelValues(tenantID, v.VarianceType()).Inc()
+
+		r.logger.Warn("platform fee variance detected",
+			"payment_order_id", rec.PaymentOrderID,
+			"gateway_reference_id", rec.GatewayReferenceID,
+			"expected_fee_cents", rec.ExpectedFeeCents,
+			"actual_fee_cents", rec.ActualFeeCents,
+			"variance_cents", v.VarianceCents,
+			"variance_type", v.VarianceType(),
+			"tenant_id", tenantID,
+		)
+	}
+
+	report := &domain.FeeReconciliationReport{
+		TenantID:       tenantID,
+		PeriodStart:    periodStart,
+		PeriodEnd:      periodEnd,
+		TotalPayments:  len(records),
+		TotalVariances: len(variances),
+		Variances:      variances,
+		GeneratedAt:    time.Now().UTC(),
+	}
+
+	r.logger.Info("fee reconciliation report generated",
+		"tenant_id", tenantID,
+		"total_payments", report.TotalPayments,
+		"total_variances", report.TotalVariances,
+		"period_start", periodStart.Format(time.RFC3339),
+		"period_end", periodEnd.Format(time.RFC3339),
+	)
+
+	return report, nil
+}
+
+// parseUUID parses a UUID string, returning uuid.Nil on failure.
+func parseUUID(s string) uuid.UUID {
+	parsed, err := uuid.Parse(s)
+	if err != nil {
+		return uuid.Nil
+	}
+	return parsed
+}

--- a/services/reconciliation/service/fee_reconciler_test.go
+++ b/services/reconciliation/service/fee_reconciler_test.go
@@ -1,0 +1,231 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Mock FeeReconciliationDataProvider ---
+
+type mockFeeDataProvider struct {
+	records []FeeReconciliationRecord
+	err     error
+}
+
+func (m *mockFeeDataProvider) GetFeeReconciliationRecords(_ context.Context, _ string, _, _ time.Time) ([]FeeReconciliationRecord, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.records, nil
+}
+
+// --- Tests ---
+
+func TestFeeReconciler_GenerateReport_WithVariances(t *testing.T) {
+	poID1 := uuid.New()
+	poID2 := uuid.New()
+	poID3 := uuid.New()
+
+	provider := &mockFeeDataProvider{
+		records: []FeeReconciliationRecord{
+			{
+				PaymentOrderID:     poID1.String(),
+				GatewayReferenceID: "pi_100",
+				ExpectedFeeCents:   250,
+				ActualFeeCents:     260,
+				Currency:           "gbp",
+				TenantID:           "tenant_a",
+			},
+			{
+				PaymentOrderID:     poID2.String(),
+				GatewayReferenceID: "pi_200",
+				ExpectedFeeCents:   300,
+				ActualFeeCents:     300, // exact match - should be skipped
+				Currency:           "gbp",
+				TenantID:           "tenant_a",
+			},
+			{
+				PaymentOrderID:     poID3.String(),
+				GatewayReferenceID: "pi_300",
+				ExpectedFeeCents:   500,
+				ActualFeeCents:     480,
+				Currency:           "usd",
+				TenantID:           "tenant_a",
+			},
+		},
+	}
+
+	reconciler := NewFeeReconciler(provider, nil)
+	periodStart := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+
+	report, err := reconciler.GenerateReport(context.Background(), "tenant_a", periodStart, periodEnd)
+	require.NoError(t, err)
+
+	assert.Equal(t, "tenant_a", report.TenantID)
+	assert.Equal(t, periodStart, report.PeriodStart)
+	assert.Equal(t, periodEnd, report.PeriodEnd)
+	assert.Equal(t, 3, report.TotalPayments)
+	assert.Equal(t, 2, report.TotalVariances)
+	assert.Len(t, report.Variances, 2)
+
+	// Verify first variance (over charge)
+	v1 := report.Variances[0]
+	assert.Equal(t, poID1, v1.PaymentOrderID)
+	assert.Equal(t, "pi_100", v1.GatewayReferenceID)
+	assert.Equal(t, int64(10), v1.VarianceCents)
+	assert.Equal(t, "over", v1.VarianceType())
+
+	// Verify second variance (under charge)
+	v2 := report.Variances[1]
+	assert.Equal(t, poID3, v2.PaymentOrderID)
+	assert.Equal(t, "pi_300", v2.GatewayReferenceID)
+	assert.Equal(t, int64(-20), v2.VarianceCents)
+	assert.Equal(t, "under", v2.VarianceType())
+}
+
+func TestFeeReconciler_GenerateReport_NoVariances(t *testing.T) {
+	provider := &mockFeeDataProvider{
+		records: []FeeReconciliationRecord{
+			{
+				PaymentOrderID:     uuid.New().String(),
+				GatewayReferenceID: "pi_100",
+				ExpectedFeeCents:   250,
+				ActualFeeCents:     250,
+				Currency:           "gbp",
+				TenantID:           "tenant_b",
+			},
+			{
+				PaymentOrderID:     uuid.New().String(),
+				GatewayReferenceID: "pi_200",
+				ExpectedFeeCents:   300,
+				ActualFeeCents:     300,
+				Currency:           "gbp",
+				TenantID:           "tenant_b",
+			},
+		},
+	}
+
+	reconciler := NewFeeReconciler(provider, nil)
+	report, err := reconciler.GenerateReport(
+		context.Background(), "tenant_b",
+		time.Now().Add(-24*time.Hour), time.Now(),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, report.TotalPayments)
+	assert.Equal(t, 0, report.TotalVariances)
+	assert.Empty(t, report.Variances)
+}
+
+func TestFeeReconciler_GenerateReport_EmptyRecords(t *testing.T) {
+	provider := &mockFeeDataProvider{records: nil}
+
+	reconciler := NewFeeReconciler(provider, nil)
+	report, err := reconciler.GenerateReport(
+		context.Background(), "tenant_c",
+		time.Now().Add(-24*time.Hour), time.Now(),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, report.TotalPayments)
+	assert.Equal(t, 0, report.TotalVariances)
+	assert.Empty(t, report.Variances)
+}
+
+func TestFeeReconciler_GenerateReport_ProviderError(t *testing.T) {
+	provider := &mockFeeDataProvider{err: errors.New("database connection failed")}
+
+	reconciler := NewFeeReconciler(provider, nil)
+	report, err := reconciler.GenerateReport(
+		context.Background(), "tenant_d",
+		time.Now().Add(-24*time.Hour), time.Now(),
+	)
+	require.Error(t, err)
+	assert.Nil(t, report)
+	assert.Contains(t, err.Error(), "database connection failed")
+}
+
+func TestFeeReconciler_GenerateReport_AllVariances(t *testing.T) {
+	provider := &mockFeeDataProvider{
+		records: []FeeReconciliationRecord{
+			{
+				PaymentOrderID:     uuid.New().String(),
+				GatewayReferenceID: "pi_1",
+				ExpectedFeeCents:   100,
+				ActualFeeCents:     110,
+				Currency:           "gbp",
+				TenantID:           "tenant_e",
+			},
+			{
+				PaymentOrderID:     uuid.New().String(),
+				GatewayReferenceID: "pi_2",
+				ExpectedFeeCents:   200,
+				ActualFeeCents:     190,
+				Currency:           "gbp",
+				TenantID:           "tenant_e",
+			},
+		},
+	}
+
+	reconciler := NewFeeReconciler(provider, nil)
+	report, err := reconciler.GenerateReport(
+		context.Background(), "tenant_e",
+		time.Now().Add(-24*time.Hour), time.Now(),
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, report.TotalPayments)
+	assert.Equal(t, 2, report.TotalVariances)
+	assert.Len(t, report.Variances, 2)
+}
+
+func TestFeeReconciler_GenerateReport_InvalidUUID(t *testing.T) {
+	provider := &mockFeeDataProvider{
+		records: []FeeReconciliationRecord{
+			{
+				PaymentOrderID:     "not-a-uuid",
+				GatewayReferenceID: "pi_bad",
+				ExpectedFeeCents:   100,
+				ActualFeeCents:     200,
+				Currency:           "gbp",
+				TenantID:           "tenant_f",
+			},
+		},
+	}
+
+	reconciler := NewFeeReconciler(provider, nil)
+	report, err := reconciler.GenerateReport(
+		context.Background(), "tenant_f",
+		time.Now().Add(-24*time.Hour), time.Now(),
+	)
+	require.NoError(t, err)
+
+	// Should still generate variance even with invalid UUID (falls back to uuid.Nil)
+	require.Len(t, report.Variances, 1)
+	assert.Equal(t, uuid.Nil, report.Variances[0].PaymentOrderID)
+}
+
+func TestParseUUID_Valid(t *testing.T) {
+	id := uuid.New()
+	parsed := parseUUID(id.String())
+	assert.Equal(t, id, parsed)
+}
+
+func TestParseUUID_Invalid(t *testing.T) {
+	parsed := parseUUID("invalid")
+	assert.Equal(t, uuid.Nil, parsed)
+}
+
+func TestNewFeeReconciler_NilLogger(t *testing.T) {
+	provider := &mockFeeDataProvider{}
+	reconciler := NewFeeReconciler(provider, nil)
+	assert.NotNil(t, reconciler)
+	assert.NotNil(t, reconciler.logger)
+}


### PR DESCRIPTION
## Summary

- Extend Stripe gateway adapter with `PlatformFeeConfig` supporting both percentage and flat fee types, replacing the percentage-only approach
- Add fee reconciliation domain model (`FeeVariance`, `FeeReconciliationReport`) and `FeeReconciler` service comparing expected vs actual Stripe application fees
- Emit Prometheus metric `stripe_platform_fee_variance_total{tenant_id, variance_type}` for variance detection
- Add `PlatformFeeAmount` field to `PaymentResponse` for downstream reconciliation

## Changes Made

**Payment Order Service - Stripe Gateway:**
- `platform_fee.go`: `PlatformFeeConfig` with percentage/flat types, validation (max 10%), `CalculateFee()` method
- `stripe_gateway.go`: Updated `GatewayAdapterConfig` to use `*PlatformFeeConfig`, calculate fee via config, return `PlatformFeeAmount` in response
- `payment_gateway.go`: Added `PlatformFeeAmount int64` to `PaymentResponse`

**Reconciliation Service - Domain:**
- `fee_variance.go`: `FeeVariance` struct with variance calculation, `VarianceType()` (over/under/match), `FeeReconciliationReport`

**Reconciliation Service - Service:**
- `fee_reconciler.go`: `FeeReconciler` with `FeeReconciliationDataProvider` interface, `GenerateReport()` producing variance reports

## Test Plan

- [ ] `platform_fee_test.go` - 16 tests: validation (8), percentage calculation (6), flat calculation (3), edge cases
- [ ] `stripe_gateway_test.go` - Updated existing tests + new flat fee test, PlatformFeeAmount assertions
- [ ] `fee_variance_test.go` - 5 tests: over/under charge, exact match, zero expected, report structure
- [ ] `fee_reconciler_test.go` - 9 tests: variances, no variances, empty records, provider error, invalid UUID, parseUUID

## Follow-up

| TM Task | Priority | Description |
|---------|----------|-------------|
| stripe-connect.12.2 | Medium | Ledger entry extensions for platform fee revenue split (DEBIT tenant_revenue, CREDIT platform_revenue) |