### PR TITLE
feat: Create built-in forecasting algorithm templates and validation framework

### DIFF
--- a/services/forecasting/templates/capacity_pricing.star
+++ b/services/forecasting/templates/capacity_pricing.star
@@ -67,6 +67,8 @@ def compute_forecast(ctx):
 
     now = ctx["now"]
     granularity = int(ctx["granularity_seconds"])
+    if granularity <= 0:
+        return []
     horizon = int(ctx["horizon_seconds"])
     num_points = horizon // granularity
 

--- a/services/forecasting/templates/capacity_pricing.star
+++ b/services/forecasting/templates/capacity_pricing.star
@@ -42,14 +42,13 @@ def compute_forecast(ctx):
         return []
 
     obs = obs_dict[dataset_keys[0]]
+    if len(obs) == 0:
+        return []
 
     # Compute average utilization from historical data
     # avg() returns a Decimal; convert via str() for float arithmetic
-    if len(obs) > 0:
-        values = [float(o["value"]) for o in obs]
-        avg_utilization = float(str(avg(values)))
-    else:
-        avg_utilization = 0.0
+    values = [float(o["value"]) for o in obs]
+    avg_utilization = float(str(avg(values)))
 
     utilization_ratio = avg_utilization / capacity
 

--- a/services/forecasting/templates/capacity_pricing.star
+++ b/services/forecasting/templates/capacity_pricing.star
@@ -1,0 +1,87 @@
+# capacity_pricing.star - Utilization-based capacity pricing template.
+#
+# Assigns price tiers based on utilization relative to capacity from reference
+# data. Uses three tiers:
+#   - off_peak:  utilization < 50% of capacity
+#   - standard:  utilization 50-85% of capacity
+#   - peak:      utilization >= 85% of capacity
+#
+# ForecastContext builtins used: avg, add_seconds
+#
+# Reference data attributes (required):
+#   - capacity: Maximum capacity value (numeric).
+#
+# Reference data attributes (optional):
+#   - off_peak_rate:  Price rate for off-peak tier (default: 0.5)
+#   - standard_rate:  Price rate for standard tier (default: 1.0)
+#   - peak_rate:      Price rate for peak tier (default: 2.0)
+#   - base_price:     Base price multiplied by rate (default: 100.0)
+#
+# Input: Historical utilization observations.
+# Output: Forecast points with tier-based pricing.
+
+def compute_forecast(ctx):
+    ref = ctx["reference_data"]
+    if ref == None:
+        return []
+
+    attrs = ref["attributes"]
+    capacity = float(attrs["capacity"])
+    if capacity <= 0:
+        return []
+
+    # Configurable rates with defaults
+    off_peak_rate = float(attrs["off_peak_rate"]) if "off_peak_rate" in attrs else 0.5
+    standard_rate = float(attrs["standard_rate"]) if "standard_rate" in attrs else 1.0
+    peak_rate = float(attrs["peak_rate"]) if "peak_rate" in attrs else 2.0
+    base_price = float(attrs["base_price"]) if "base_price" in attrs else 100.0
+
+    obs_dict = ctx["observations"]
+    dataset_keys = sorted(obs_dict.keys())
+    if len(dataset_keys) == 0:
+        return []
+
+    obs = obs_dict[dataset_keys[0]]
+
+    # Compute average utilization from historical data
+    # avg() returns a Decimal; convert via str() for float arithmetic
+    if len(obs) > 0:
+        values = [float(o["value"]) for o in obs]
+        avg_utilization = float(str(avg(values)))
+    else:
+        avg_utilization = 0.0
+
+    utilization_ratio = avg_utilization / capacity
+
+    # Determine price tier
+    if utilization_ratio >= 0.85:
+        rate = peak_rate
+        tier = "peak"
+    elif utilization_ratio >= 0.50:
+        rate = standard_rate
+        tier = "standard"
+    else:
+        rate = off_peak_rate
+        tier = "off_peak"
+
+    price = base_price * rate
+
+    now = ctx["now"]
+    granularity = int(ctx["granularity_seconds"])
+    horizon = int(ctx["horizon_seconds"])
+    num_points = horizon // granularity
+
+    points = []
+    for i in range(num_points):
+        offset = (i + 1) * granularity
+        ts = add_seconds(now, offset)
+        points.append({
+            "timestamp": ts,
+            "value": price,
+            "metadata": {
+                "algorithm": "capacity_pricing",
+                "tier": tier,
+                "utilization_ratio": str(utilization_ratio),
+            },
+        })
+    return points

--- a/services/forecasting/templates/capacity_pricing.star
+++ b/services/forecasting/templates/capacity_pricing.star
@@ -26,6 +26,8 @@ def compute_forecast(ctx):
         return []
 
     attrs = ref["attributes"]
+    if "capacity" not in attrs:
+        return []
     capacity = float(attrs["capacity"])
     if capacity <= 0:
         return []

--- a/services/forecasting/templates/external_blend.star
+++ b/services/forecasting/templates/external_blend.star
@@ -75,6 +75,8 @@ def compute_forecast(ctx):
 
     now = ctx["now"]
     granularity = int(ctx["granularity_seconds"])
+    if granularity <= 0:
+        return []
     horizon = int(ctx["horizon_seconds"])
     num_points = horizon // granularity
 

--- a/services/forecasting/templates/external_blend.star
+++ b/services/forecasting/templates/external_blend.star
@@ -1,0 +1,74 @@
+# external_blend.star - Blend internal and external forecast template.
+#
+# Combines internal historical observations with external forecast data using
+# a configurable weight. The default blend is 70% internal / 30% external.
+#
+# ForecastContext builtins used: avg, add_seconds
+#
+# Reference data attributes (optional):
+#   - internal_weight: Weight for internal forecast (0-1, default: 0.7)
+#
+# Input: Requires exactly 2 input datasets:
+#   - First dataset (alphabetically): Internal observations
+#   - Second dataset (alphabetically): External forecast observations
+#
+# Output: Weighted blend of both sources projected across the horizon.
+
+def compute_forecast(ctx):
+    obs_dict = ctx["observations"]
+    dataset_keys = sorted(obs_dict.keys())
+
+    if len(dataset_keys) < 2:
+        # Fall back to single source if only one dataset available
+        if len(dataset_keys) == 0:
+            return []
+        obs = obs_dict[dataset_keys[0]]
+        if len(obs) == 0:
+            return []
+        values = [float(o["value"]) for o in obs]
+        # avg() returns a Decimal; convert via str() for float arithmetic
+        forecast_value = float(str(avg(values)))
+    else:
+        internal_obs = obs_dict[dataset_keys[0]]
+        external_obs = obs_dict[dataset_keys[1]]
+
+        # Determine internal weight from reference data
+        ref = ctx["reference_data"]
+        internal_weight = 0.7
+        if ref != None:
+            attrs = ref["attributes"]
+            if "internal_weight" in attrs:
+                internal_weight = float(attrs["internal_weight"])
+
+        external_weight = 1.0 - internal_weight
+
+        # Compute averages for each source (avg returns Decimal, convert via str)
+        if len(internal_obs) > 0:
+            internal_values = [float(o["value"]) for o in internal_obs]
+            internal_avg = float(str(avg(internal_values)))
+        else:
+            internal_avg = 0.0
+
+        if len(external_obs) > 0:
+            external_values = [float(o["value"]) for o in external_obs]
+            external_avg = float(str(avg(external_values)))
+        else:
+            external_avg = 0.0
+
+        forecast_value = internal_avg * internal_weight + external_avg * external_weight
+
+    now = ctx["now"]
+    granularity = int(ctx["granularity_seconds"])
+    horizon = int(ctx["horizon_seconds"])
+    num_points = horizon // granularity
+
+    points = []
+    for i in range(num_points):
+        offset = (i + 1) * granularity
+        ts = add_seconds(now, offset)
+        points.append({
+            "timestamp": ts,
+            "value": forecast_value,
+            "metadata": {"algorithm": "external_blend"},
+        })
+    return points

--- a/services/forecasting/templates/external_blend.star
+++ b/services/forecasting/templates/external_blend.star
@@ -32,13 +32,19 @@ def compute_forecast(ctx):
         internal_obs = obs_dict[dataset_keys[0]]
         external_obs = obs_dict[dataset_keys[1]]
 
-        # Determine internal weight from reference data
+        # Return empty if both datasets are empty
+        if len(internal_obs) == 0 and len(external_obs) == 0:
+            return []
+
+        # Determine internal weight from reference data, clamp to [0, 1]
         ref = ctx["reference_data"]
         internal_weight = 0.7
         if ref != None:
             attrs = ref["attributes"]
             if "internal_weight" in attrs:
                 internal_weight = float(attrs["internal_weight"])
+        if internal_weight < 0.0 or internal_weight > 1.0:
+            internal_weight = 0.7
 
         external_weight = 1.0 - internal_weight
 
@@ -54,6 +60,16 @@ def compute_forecast(ctx):
             external_avg = float(str(avg(external_values)))
         else:
             external_avg = 0.0
+
+        # Renormalize weights based on data availability
+        if len(internal_obs) == 0:
+            internal_weight = 0.0
+        if len(external_obs) == 0:
+            external_weight = 0.0
+        total_weight = internal_weight + external_weight
+        if total_weight > 0.0:
+            internal_weight = internal_weight / total_weight
+            external_weight = external_weight / total_weight
 
         forecast_value = internal_avg * internal_weight + external_avg * external_weight
 

--- a/services/forecasting/templates/moving_average.star
+++ b/services/forecasting/templates/moving_average.star
@@ -47,6 +47,8 @@ def compute_forecast(ctx):
 
     now = ctx["now"]
     granularity = int(ctx["granularity_seconds"])
+    if granularity <= 0:
+        return []
     horizon = int(ctx["horizon_seconds"])
     num_points = horizon // granularity
 

--- a/services/forecasting/templates/moving_average.star
+++ b/services/forecasting/templates/moving_average.star
@@ -1,0 +1,62 @@
+# moving_average.star - Simple/Exponential moving average forecast template.
+#
+# Computes a simple moving average over all available historical observations
+# and projects it across the forecast horizon. Supports configurable smoothing
+# via exponential weighting when reference data provides an alpha parameter.
+#
+# ForecastContext builtins used: avg, add_seconds
+#
+# Reference data attributes (optional):
+#   - alpha: Exponential smoothing factor (0-1). When absent, uses simple average.
+#
+# Input: Historical observations from the first input dataset.
+# Output: Forecast points at each granularity step within the horizon.
+
+def compute_forecast(ctx):
+    obs_dict = ctx["observations"]
+
+    # Use the first available dataset
+    dataset_keys = sorted(obs_dict.keys())
+    if len(dataset_keys) == 0:
+        return []
+
+    obs = obs_dict[dataset_keys[0]]
+    if len(obs) == 0:
+        return []
+
+    # Extract numeric values from observations
+    values = [float(o["value"]) for o in obs]
+
+    # Check for exponential smoothing alpha in reference data
+    ref = ctx["reference_data"]
+    alpha = 0.0
+    if ref != None:
+        attrs = ref["attributes"]
+        if "alpha" in attrs:
+            alpha = float(attrs["alpha"])
+
+    if alpha > 0.0 and alpha <= 1.0:
+        # Exponential moving average: weight recent values more heavily
+        ema = values[0]
+        for i in range(1, len(values)):
+            ema = alpha * values[i] + (1.0 - alpha) * ema
+        forecast_value = ema
+    else:
+        # Simple moving average
+        forecast_value = avg(values)
+
+    now = ctx["now"]
+    granularity = int(ctx["granularity_seconds"])
+    horizon = int(ctx["horizon_seconds"])
+    num_points = horizon // granularity
+
+    points = []
+    for i in range(num_points):
+        offset = (i + 1) * granularity
+        ts = add_seconds(now, offset)
+        points.append({
+            "timestamp": ts,
+            "value": forecast_value,
+            "metadata": {"algorithm": "moving_average"},
+        })
+    return points

--- a/services/forecasting/templates/seasonal_decomposition.star
+++ b/services/forecasting/templates/seasonal_decomposition.star
@@ -1,8 +1,8 @@
 # seasonal_decomposition.star - Seasonal decomposition forecast template.
 #
-# Decomposes historical observations into hour-of-day and day-of-week patterns
-# using medians for outlier robustness. Projects the seasonal pattern across
-# the forecast horizon.
+# Decomposes historical observations into hour-of-day patterns using medians
+# for outlier robustness. Projects the seasonal pattern across the forecast
+# horizon.
 #
 # ForecastContext builtins used: group_by_hour, avg, add_seconds
 #

--- a/services/forecasting/templates/seasonal_decomposition.star
+++ b/services/forecasting/templates/seasonal_decomposition.star
@@ -1,0 +1,78 @@
+# seasonal_decomposition.star - Seasonal decomposition forecast template.
+#
+# Decomposes historical observations into hour-of-day and day-of-week patterns
+# using medians for outlier robustness. Projects the seasonal pattern across
+# the forecast horizon.
+#
+# ForecastContext builtins used: group_by_hour, avg, add_seconds
+#
+# Input: Historical observations with timestamps spanning multiple days.
+# Output: Forecast points reflecting the discovered hourly seasonal pattern.
+
+def compute_forecast(ctx):
+    obs_dict = ctx["observations"]
+
+    dataset_keys = sorted(obs_dict.keys())
+    if len(dataset_keys) == 0:
+        return []
+
+    obs = obs_dict[dataset_keys[0]]
+    if len(obs) == 0:
+        return []
+
+    # Group observations by hour-of-day
+    hourly_groups = group_by_hour(obs)
+
+    # Compute median for each hour (outlier robust)
+    hourly_medians = {}
+    for hour in hourly_groups.keys():
+        group = hourly_groups[hour]
+        values = sorted([float(o["value"]) for o in group])
+        n = len(values)
+        if n == 0:
+            continue
+        if n % 2 == 1:
+            median = values[n // 2]
+        else:
+            median = (values[n // 2 - 1] + values[n // 2]) / 2.0
+        hourly_medians[int(hour)] = median
+
+    # If no medians computed, fall back to overall average
+    # avg() returns a Decimal; convert via str() for float arithmetic
+    if len(hourly_medians) == 0:
+        all_values = [float(o["value"]) for o in obs]
+        fallback = float(str(avg(all_values)))
+        hourly_medians = {h: fallback for h in range(24)}
+
+    # Compute global average for hours without data
+    known_values = [hourly_medians[h] for h in hourly_medians.keys()]
+    global_avg = 0.0
+    for v in known_values:
+        global_avg = global_avg + float(str(v))
+    global_avg = global_avg / len(known_values)
+
+    now = ctx["now"]
+    granularity = int(ctx["granularity_seconds"])
+    horizon = int(ctx["horizon_seconds"])
+    num_points = horizon // granularity
+
+    points = []
+    for i in range(num_points):
+        offset = (i + 1) * granularity
+        ts_str = add_seconds(now, offset)
+
+        # Parse hour from the RFC3339 timestamp (format: ...THH:MM:SS...)
+        t_index = ts_str.index("T")
+        hour = int(ts_str[t_index + 1 : t_index + 3])
+
+        if hour in hourly_medians:
+            value = hourly_medians[hour]
+        else:
+            value = global_avg
+
+        points.append({
+            "timestamp": ts_str,
+            "value": value,
+            "metadata": {"algorithm": "seasonal_decomposition", "hour": str(hour)},
+        })
+    return points

--- a/services/forecasting/templates/seasonal_decomposition.star
+++ b/services/forecasting/templates/seasonal_decomposition.star
@@ -53,6 +53,8 @@ def compute_forecast(ctx):
 
     now = ctx["now"]
     granularity = int(ctx["granularity_seconds"])
+    if granularity <= 0:
+        return []
     horizon = int(ctx["horizon_seconds"])
     num_points = horizon // granularity
 

--- a/services/forecasting/templates/templates.go
+++ b/services/forecasting/templates/templates.go
@@ -1,0 +1,38 @@
+// Package templates provides built-in Starlark forecasting algorithm templates
+// embedded at compile time. Each template implements the compute_forecast(ctx)
+// entry point and uses ForecastContext builtins.
+package templates
+
+import "embed"
+
+// FS holds the embedded Starlark template files.
+//
+//go:embed *.star
+var FS embed.FS
+
+// Template names for programmatic access.
+const (
+	MovingAverage         = "moving_average.star"
+	SeasonalDecomposition = "seasonal_decomposition.star"
+	CapacityPricing       = "capacity_pricing.star"
+	ExternalBlend         = "external_blend.star"
+)
+
+// All returns the names of all built-in templates.
+func All() []string {
+	return []string{
+		MovingAverage,
+		SeasonalDecomposition,
+		CapacityPricing,
+		ExternalBlend,
+	}
+}
+
+// Load reads a template by name from the embedded filesystem.
+func Load(name string) (string, error) {
+	data, err := FS.ReadFile(name)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}

--- a/services/forecasting/templates/templates_test.go
+++ b/services/forecasting/templates/templates_test.go
@@ -1,0 +1,602 @@
+package templates
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/forecasting/starlark"
+)
+
+// --- Mock implementations ---
+
+type mockMISClient struct {
+	observations map[string][]starlark.Observation
+}
+
+func (m *mockMISClient) FetchObservations(_ context.Context, datasetCode string, _ time.Time) ([]starlark.Observation, error) {
+	return m.observations[datasetCode], nil
+}
+
+type mockRefDataClient struct {
+	nodes map[string]*starlark.ReferenceData
+}
+
+func (m *mockRefDataClient) GetNodeByResolutionKey(_ context.Context, _, resolutionKey string) (*starlark.ReferenceData, error) {
+	node, ok := m.nodes[resolutionKey]
+	if !ok {
+		return nil, fmt.Errorf("node not found: %s", resolutionKey)
+	}
+	return node, nil
+}
+
+func newTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+func newTestRunner(t *testing.T, mis starlark.MISClient, ref starlark.RefDataClient) *starlark.ForecastRunner {
+	t.Helper()
+	runner, err := starlark.NewForecastRunner(starlark.ForecastRunnerConfig{
+		MISClient: mis,
+		RefData:   ref,
+		Timeout:   5 * time.Second,
+		Logger:    newTestLogger(),
+	})
+	require.NoError(t, err)
+	return runner
+}
+
+func baseTime() time.Time {
+	return time.Date(2026, 2, 10, 0, 0, 0, 0, time.UTC)
+}
+
+// --- Template loading tests ---
+
+func TestLoad_AllTemplates(t *testing.T) {
+	for _, name := range All() {
+		t.Run(name, func(t *testing.T) {
+			script, err := Load(name)
+			require.NoError(t, err)
+			assert.NotEmpty(t, script)
+			assert.Contains(t, script, "def compute_forecast(ctx)")
+		})
+	}
+}
+
+func TestLoad_NonexistentTemplate(t *testing.T) {
+	_, err := Load("does_not_exist.star")
+	require.Error(t, err)
+}
+
+// --- Moving average template tests ---
+
+func TestMovingAverage_SineWaveData(t *testing.T) {
+	now := baseTime()
+
+	// Generate 48 hours of sine wave data (amplitude 50, centered at 100)
+	observations := make([]starlark.Observation, 48)
+	for i := 0; i < 48; i++ {
+		angle := float64(i) / 24.0 * 2 * math.Pi
+		value := 100.0 + 50.0*math.Sin(angle)
+		observations[i] = starlark.Observation{
+			Timestamp: now.Add(-time.Duration(48-i) * time.Hour),
+			Value:     decimal.NewFromFloat(value),
+			Quality:   "ACTUAL",
+		}
+	}
+
+	mis := &mockMISClient{
+		observations: map[string][]starlark.Observation{
+			"UTILIZATION": observations,
+		},
+	}
+	ref := &mockRefDataClient{nodes: map[string]*starlark.ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script, err := Load(MovingAverage)
+	require.NoError(t, err)
+
+	points, err := runner.ExecuteStrategy(context.Background(), starlark.StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION"},
+		OutputDatasetCode: "FORECAST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// Sine wave over full periods averages to the center value (100)
+	// With 2 full periods, average should be very close to 100
+	for i, p := range points {
+		diff := p.Value.Sub(decimal.NewFromInt(100)).Abs()
+		assert.True(t, diff.LessThan(decimal.NewFromFloat(1.0)),
+			"point %d: expected ~100, got %s (diff %s)", i, p.Value, diff)
+		assert.Equal(t, "moving_average", p.Metadata["algorithm"])
+	}
+}
+
+func TestMovingAverage_ExponentialSmoothing(t *testing.T) {
+	now := baseTime()
+
+	// Data with a trend: 10, 20, 30, 40, 50
+	observations := make([]starlark.Observation, 5)
+	for i := 0; i < 5; i++ {
+		observations[i] = starlark.Observation{
+			Timestamp: now.Add(-time.Duration(5-i) * time.Hour),
+			Value:     decimal.NewFromInt(int64((i + 1) * 10)),
+			Quality:   "ACTUAL",
+		}
+	}
+
+	mis := &mockMISClient{
+		observations: map[string][]starlark.Observation{
+			"UTILIZATION": observations,
+		},
+	}
+	ref := &mockRefDataClient{
+		nodes: map[string]*starlark.ReferenceData{
+			"test-key": {
+				NodeType:      "zone",
+				ResolutionKey: "test-key",
+				Attributes: map[string]any{
+					"alpha": "0.5",
+				},
+			},
+		},
+	}
+	runner := newTestRunner(t, mis, ref)
+
+	script, err := Load(MovingAverage)
+	require.NoError(t, err)
+
+	points, err := runner.ExecuteStrategy(context.Background(), starlark.StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION"},
+		OutputDatasetCode: "FORECAST",
+		ResolutionKey:     "test-key",
+		TenantID:          "tenant-1",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// EMA with alpha=0.5 on [10,20,30,40,50]:
+	// EMA_0 = 10
+	// EMA_1 = 0.5*20 + 0.5*10 = 15
+	// EMA_2 = 0.5*30 + 0.5*15 = 22.5
+	// EMA_3 = 0.5*40 + 0.5*22.5 = 31.25
+	// EMA_4 = 0.5*50 + 0.5*31.25 = 40.625
+	expected := decimal.NewFromFloat(40.625)
+	for _, p := range points {
+		assert.True(t, p.Value.Equal(expected),
+			"expected %s, got %s", expected, p.Value)
+	}
+}
+
+func TestMovingAverage_EmptyObservations(t *testing.T) {
+	now := baseTime()
+
+	mis := &mockMISClient{
+		observations: map[string][]starlark.Observation{
+			"UTILIZATION": {},
+		},
+	}
+	ref := &mockRefDataClient{nodes: map[string]*starlark.ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script, err := Load(MovingAverage)
+	require.NoError(t, err)
+
+	points, err := runner.ExecuteStrategy(context.Background(), starlark.StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION"},
+		OutputDatasetCode: "FORECAST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, points)
+}
+
+// --- Seasonal decomposition template tests ---
+
+func TestSeasonalDecomposition_PeakPattern(t *testing.T) {
+	now := baseTime()
+
+	// Create 7 days of hourly data with a clear peak at hour 14
+	observations := make([]starlark.Observation, 0, 7*24)
+	for day := 0; day < 7; day++ {
+		for hour := 0; hour < 24; hour++ {
+			ts := now.Add(-time.Duration(7*24-day*24-hour) * time.Hour)
+			var value float64
+			if hour == 14 {
+				value = 200.0 // peak hour
+			} else {
+				value = 50.0 // base value
+			}
+			observations = append(observations, starlark.Observation{
+				Timestamp: ts,
+				Value:     decimal.NewFromFloat(value),
+				Quality:   "ACTUAL",
+			})
+		}
+	}
+
+	mis := &mockMISClient{
+		observations: map[string][]starlark.Observation{
+			"UTILIZATION": observations,
+		},
+	}
+	ref := &mockRefDataClient{nodes: map[string]*starlark.ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script, err := Load(SeasonalDecomposition)
+	require.NoError(t, err)
+
+	points, err := runner.ExecuteStrategy(context.Background(), starlark.StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION"},
+		OutputDatasetCode: "FORECAST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// Point at hour 14 (index 13, since offset starts at hour 1) should be peak
+	// Points are at hour 1, 2, ..., 24 (wraps to 0)
+	for _, p := range points {
+		hourStr := p.Metadata["hour"]
+		assert.Equal(t, "seasonal_decomposition", p.Metadata["algorithm"])
+		if hourStr == "14" {
+			// Peak hour should have value 200
+			assert.True(t, p.Value.Equal(decimal.NewFromFloat(200)),
+				"peak hour 14: expected 200, got %s", p.Value)
+		} else {
+			// Non-peak hours should have value 50
+			assert.True(t, p.Value.Equal(decimal.NewFromFloat(50)),
+				"hour %s: expected 50, got %s", hourStr, p.Value)
+		}
+	}
+}
+
+// --- Capacity pricing template tests ---
+
+func TestCapacityPricing_WithRefDataCapacity(t *testing.T) {
+	now := baseTime()
+
+	// avg=85 with capacity=100 -> utilization_ratio=0.85 -> peak tier
+	observations := make([]starlark.Observation, 24)
+	for i := 0; i < 24; i++ {
+		observations[i] = starlark.Observation{
+			Timestamp: now.Add(-time.Duration(24-i) * time.Hour),
+			Value:     decimal.NewFromInt(85),
+			Quality:   "ACTUAL",
+		}
+	}
+
+	mis := &mockMISClient{
+		observations: map[string][]starlark.Observation{
+			"UTILIZATION": observations,
+		},
+	}
+	ref := &mockRefDataClient{
+		nodes: map[string]*starlark.ReferenceData{
+			"zone-key": {
+				NodeType:      "zone",
+				ResolutionKey: "zone-key",
+				Attributes: map[string]any{
+					"capacity": "100",
+				},
+			},
+		},
+	}
+	runner := newTestRunner(t, mis, ref)
+
+	script, err := Load(CapacityPricing)
+	require.NoError(t, err)
+
+	points, err := runner.ExecuteStrategy(context.Background(), starlark.StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION"},
+		OutputDatasetCode: "FORECAST_PRICE",
+		ResolutionKey:     "zone-key",
+		TenantID:          "tenant-1",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// 85/100 = 0.85 -> peak tier -> base_price(100) * peak_rate(2.0) = 200
+	expectedPrice := decimal.NewFromFloat(200.0)
+	for i, p := range points {
+		assert.True(t, p.Value.Equal(expectedPrice),
+			"point %d: expected %s, got %s", i, expectedPrice, p.Value)
+		assert.Equal(t, "peak", p.Metadata["tier"])
+		assert.Equal(t, "capacity_pricing", p.Metadata["algorithm"])
+	}
+}
+
+func TestCapacityPricing_StandardTier(t *testing.T) {
+	now := baseTime()
+
+	// avg=60 with capacity=100 -> ratio=0.6 -> standard tier
+	observations := make([]starlark.Observation, 10)
+	for i := 0; i < 10; i++ {
+		observations[i] = starlark.Observation{
+			Timestamp: now.Add(-time.Duration(10-i) * time.Hour),
+			Value:     decimal.NewFromInt(60),
+			Quality:   "ACTUAL",
+		}
+	}
+
+	mis := &mockMISClient{
+		observations: map[string][]starlark.Observation{
+			"UTILIZATION": observations,
+		},
+	}
+	ref := &mockRefDataClient{
+		nodes: map[string]*starlark.ReferenceData{
+			"zone-key": {
+				NodeType:      "zone",
+				ResolutionKey: "zone-key",
+				Attributes: map[string]any{
+					"capacity": "100",
+				},
+			},
+		},
+	}
+	runner := newTestRunner(t, mis, ref)
+
+	script, err := Load(CapacityPricing)
+	require.NoError(t, err)
+
+	points, err := runner.ExecuteStrategy(context.Background(), starlark.StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION"},
+		OutputDatasetCode: "FORECAST_PRICE",
+		ResolutionKey:     "zone-key",
+		TenantID:          "tenant-1",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// 60/100 = 0.6 -> standard tier -> 100 * 1.0 = 100
+	expectedPrice := decimal.NewFromFloat(100.0)
+	for _, p := range points {
+		assert.True(t, p.Value.Equal(expectedPrice),
+			"expected %s, got %s", expectedPrice, p.Value)
+		assert.Equal(t, "standard", p.Metadata["tier"])
+	}
+}
+
+func TestCapacityPricing_OffPeakTier(t *testing.T) {
+	now := baseTime()
+
+	// avg=30 with capacity=100 -> ratio=0.3 -> off_peak tier
+	observations := make([]starlark.Observation, 10)
+	for i := 0; i < 10; i++ {
+		observations[i] = starlark.Observation{
+			Timestamp: now.Add(-time.Duration(10-i) * time.Hour),
+			Value:     decimal.NewFromInt(30),
+			Quality:   "ACTUAL",
+		}
+	}
+
+	mis := &mockMISClient{
+		observations: map[string][]starlark.Observation{
+			"UTILIZATION": observations,
+		},
+	}
+	ref := &mockRefDataClient{
+		nodes: map[string]*starlark.ReferenceData{
+			"zone-key": {
+				NodeType:      "zone",
+				ResolutionKey: "zone-key",
+				Attributes: map[string]any{
+					"capacity": "100",
+				},
+			},
+		},
+	}
+	runner := newTestRunner(t, mis, ref)
+
+	script, err := Load(CapacityPricing)
+	require.NoError(t, err)
+
+	points, err := runner.ExecuteStrategy(context.Background(), starlark.StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION"},
+		OutputDatasetCode: "FORECAST_PRICE",
+		ResolutionKey:     "zone-key",
+		TenantID:          "tenant-1",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// 30/100 = 0.3 -> off_peak tier -> 100 * 0.5 = 50
+	expectedPrice := decimal.NewFromFloat(50.0)
+	for _, p := range points {
+		assert.True(t, p.Value.Equal(expectedPrice),
+			"expected %s, got %s", expectedPrice, p.Value)
+		assert.Equal(t, "off_peak", p.Metadata["tier"])
+	}
+}
+
+// --- External blend template tests ---
+
+func TestExternalBlend_MixedSources(t *testing.T) {
+	now := baseTime()
+
+	// Internal observations average to 100
+	internalObs := make([]starlark.Observation, 10)
+	for i := 0; i < 10; i++ {
+		internalObs[i] = starlark.Observation{
+			Timestamp: now.Add(-time.Duration(10-i) * time.Hour),
+			Value:     decimal.NewFromInt(100),
+			Quality:   "ACTUAL",
+		}
+	}
+
+	// External observations average to 200
+	externalObs := make([]starlark.Observation, 10)
+	for i := 0; i < 10; i++ {
+		externalObs[i] = starlark.Observation{
+			Timestamp: now.Add(-time.Duration(10-i) * time.Hour),
+			Value:     decimal.NewFromInt(200),
+			Quality:   "ACTUAL",
+		}
+	}
+
+	// First alphabetically = internal ("A_INTERNAL"), second = external ("B_EXTERNAL")
+	mis := &mockMISClient{
+		observations: map[string][]starlark.Observation{
+			"A_INTERNAL": internalObs,
+			"B_EXTERNAL": externalObs,
+		},
+	}
+	ref := &mockRefDataClient{nodes: map[string]*starlark.ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script, err := Load(ExternalBlend)
+	require.NoError(t, err)
+
+	points, err := runner.ExecuteStrategy(context.Background(), starlark.StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"A_INTERNAL", "B_EXTERNAL"},
+		OutputDatasetCode: "FORECAST_BLEND",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// Default: 70% internal (100) + 30% external (200) = 70 + 60 = 130
+	expectedValue := decimal.NewFromFloat(130.0)
+	for i, p := range points {
+		assert.True(t, p.Value.Equal(expectedValue),
+			"point %d: expected %s, got %s", i, expectedValue, p.Value)
+		assert.Equal(t, "external_blend", p.Metadata["algorithm"])
+	}
+}
+
+func TestExternalBlend_CustomWeight(t *testing.T) {
+	now := baseTime()
+
+	internalObs := []starlark.Observation{
+		{Timestamp: now.Add(-time.Hour), Value: decimal.NewFromInt(100), Quality: "ACTUAL"},
+	}
+	externalObs := []starlark.Observation{
+		{Timestamp: now.Add(-time.Hour), Value: decimal.NewFromInt(200), Quality: "ACTUAL"},
+	}
+
+	// First alphabetically = internal ("A_INTERNAL"), second = external ("B_EXTERNAL")
+	mis := &mockMISClient{
+		observations: map[string][]starlark.Observation{
+			"A_INTERNAL": internalObs,
+			"B_EXTERNAL": externalObs,
+		},
+	}
+	ref := &mockRefDataClient{
+		nodes: map[string]*starlark.ReferenceData{
+			"blend-key": {
+				NodeType:      "config",
+				ResolutionKey: "blend-key",
+				Attributes: map[string]any{
+					"internal_weight": "0.5",
+				},
+			},
+		},
+	}
+	runner := newTestRunner(t, mis, ref)
+
+	script, err := Load(ExternalBlend)
+	require.NoError(t, err)
+
+	points, err := runner.ExecuteStrategy(context.Background(), starlark.StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"A_INTERNAL", "B_EXTERNAL"},
+		OutputDatasetCode: "FORECAST_BLEND",
+		ResolutionKey:     "blend-key",
+		TenantID:          "tenant-1",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// 50% internal (100) + 50% external (200) = 50 + 100 = 150
+	expectedValue := decimal.NewFromFloat(150.0)
+	for _, p := range points {
+		assert.True(t, p.Value.Equal(expectedValue),
+			"expected %s, got %s", expectedValue, p.Value)
+	}
+}
+
+func TestExternalBlend_SingleSourceFallback(t *testing.T) {
+	now := baseTime()
+
+	mis := &mockMISClient{
+		observations: map[string][]starlark.Observation{
+			"UTILIZATION": {
+				{Timestamp: now.Add(-time.Hour), Value: decimal.NewFromInt(75), Quality: "ACTUAL"},
+			},
+		},
+	}
+	ref := &mockRefDataClient{nodes: map[string]*starlark.ReferenceData{}}
+	runner := newTestRunner(t, mis, ref)
+
+	script, err := Load(ExternalBlend)
+	require.NoError(t, err)
+
+	points, err := runner.ExecuteStrategy(context.Background(), starlark.StrategyInput{
+		Script:            script,
+		InputDatasetCodes: []string{"UTILIZATION"},
+		OutputDatasetCode: "FORECAST",
+		HorizonHours:      24,
+		GranularityHours:  1,
+		Now:               now,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, points, 24)
+
+	// Single source fallback: just uses the average of the single dataset
+	for _, p := range points {
+		assert.True(t, p.Value.Equal(decimal.NewFromInt(75)),
+			"expected 75, got %s", p.Value)
+	}
+}

--- a/services/forecasting/validation/strategy_validator.go
+++ b/services/forecasting/validation/strategy_validator.go
@@ -223,6 +223,7 @@ func ValidateWithExecution(script string) Result {
 		"enumerate", "zip", "sorted", "reversed",
 		"min", "max", "abs", "any", "all",
 		"hasattr", "getattr", "dir", "type", "repr", "hash",
+		"print",
 	} {
 		if val, ok := starlarklib.Universe[name]; ok {
 			predeclared[name] = val

--- a/services/forecasting/validation/strategy_validator.go
+++ b/services/forecasting/validation/strategy_validator.go
@@ -1,0 +1,277 @@
+// Package validation provides a Starlark strategy validation framework with
+// AI-native structured error feedback. It performs static analysis of forecast
+// strategies before execution, catching errors at validation time rather than
+// runtime.
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	starlarklib "go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+// Result holds the outcome of validating a Starlark forecast strategy.
+type Result struct {
+	Valid                  bool
+	Errors                 []Error
+	AvailableContextFields []string
+	AvailableFunctions     []string
+}
+
+// Error represents a single validation problem with location and
+// AI-friendly fix suggestion.
+type Error struct {
+	Line       int
+	Column     int
+	Message    string
+	Suggestion string
+}
+
+// forbiddenPatterns lists Starlark statement patterns that are not permitted
+// in forecast strategies. While Starlark already forbids while loops and
+// recursion at the language level, we check for patterns that indicate misuse.
+var forbiddenPatterns = []string{
+	"import ",
+	"load(",
+}
+
+// availableContextFields documents the fields available on the ctx parameter.
+var availableContextFields = []string{
+	"observations",
+	"reference_data",
+	"horizon_seconds",
+	"granularity_seconds",
+	"now",
+}
+
+// availableFunctions documents the builtin functions available in the sandbox.
+var availableFunctions = []string{
+	"avg", "sum", "percentile",
+	"filter_by_hour", "group_by_hour",
+	"duration", "add_seconds",
+	"Decimal",
+	"len", "str", "int", "float", "bool",
+	"list", "dict", "tuple", "range",
+	"enumerate", "zip", "sorted", "reversed",
+	"min", "max", "abs", "any", "all",
+	"hasattr", "getattr", "dir", "type", "repr", "hash",
+	"print",
+}
+
+// ValidateStrategy performs static validation of a Starlark forecast strategy.
+// It checks:
+//  1. Starlark syntax is valid
+//  2. A compute_forecast function is defined with a ctx parameter
+//  3. No forbidden operations (import, load)
+//
+// The result includes AI-friendly suggestions for fixing any issues found.
+func ValidateStrategy(script string) Result {
+	result := Result{
+		Valid:                  true,
+		AvailableContextFields: availableContextFields,
+		AvailableFunctions:     availableFunctions,
+	}
+
+	if strings.TrimSpace(script) == "" {
+		result.Valid = false
+		result.Errors = append(result.Errors, Error{
+			Line:       1,
+			Column:     1,
+			Message:    "script is empty",
+			Suggestion: "Define a compute_forecast(ctx) function that returns a list of {timestamp, value} dicts.",
+		})
+		return result
+	}
+
+	// Check for forbidden patterns before parsing
+	checkForbiddenPatterns(script, &result)
+
+	// Parse and validate syntax
+	opts := &syntax.FileOptions{}
+	f, err := opts.Parse("strategy.star", script, syntax.RetainComments)
+	if err != nil {
+		result.Valid = false
+		addSyntaxError(err, &result)
+		return result
+	}
+
+	// Check for compute_forecast function definition
+	checkEntryPoint(f, &result)
+
+	return result
+}
+
+// checkForbiddenPatterns scans for forbidden operations in the script source.
+func checkForbiddenPatterns(script string, result *Result) {
+	lines := strings.Split(script, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		for _, pattern := range forbiddenPatterns {
+			if strings.HasPrefix(trimmed, pattern) {
+				result.Valid = false
+				result.Errors = append(result.Errors, Error{
+					Line:    i + 1,
+					Column:  strings.Index(line, pattern) + 1,
+					Message: fmt.Sprintf("forbidden operation: %q is not allowed in forecast strategies", strings.TrimSpace(pattern)),
+					Suggestion: fmt.Sprintf(
+						"Remove the %s statement. All required functions are available as builtins: %s",
+						strings.TrimSpace(pattern),
+						strings.Join(availableFunctions[:8], ", "),
+					),
+				})
+			}
+		}
+	}
+}
+
+// addSyntaxError converts a Starlark syntax error into an Error.
+func addSyntaxError(err error, result *Result) {
+	errMsg := err.Error()
+
+	// Try to extract line/column from Starlark error format: "file:line:col: message"
+	line, col := 0, 0
+	msg := errMsg
+	if parts := strings.SplitN(errMsg, ":", 4); len(parts) >= 4 {
+		if _, scanErr := fmt.Sscanf(parts[1], "%d", &line); scanErr != nil {
+			line = 0
+		}
+		if _, scanErr := fmt.Sscanf(parts[2], "%d", &col); scanErr != nil {
+			col = 0
+		}
+		msg = strings.TrimSpace(parts[3])
+	}
+
+	suggestion := "Check the Starlark syntax. Common issues: missing colons after def/if/for, unmatched parentheses, or incorrect indentation."
+	if strings.Contains(msg, "got newline") {
+		suggestion = "Add a colon ':' at the end of the function/if/for declaration line."
+	} else if strings.Contains(msg, "unexpected") {
+		suggestion = "Check for unmatched parentheses, brackets, or quotes near this location."
+	}
+
+	result.Errors = append(result.Errors, Error{
+		Line:       line,
+		Column:     col,
+		Message:    msg,
+		Suggestion: suggestion,
+	})
+}
+
+// checkEntryPoint verifies that a compute_forecast function with a ctx parameter exists.
+func checkEntryPoint(f *syntax.File, result *Result) {
+	found := false
+	hasCtxParam := false
+
+	for _, stmt := range f.Stmts {
+		defStmt, ok := stmt.(*syntax.DefStmt)
+		if !ok {
+			continue
+		}
+		if defStmt.Name.Name == "compute_forecast" {
+			found = true
+			if len(defStmt.Params) >= 1 {
+				// Check the first parameter name
+				if ident, ok := defStmt.Params[0].(*syntax.Ident); ok && ident.Name == "ctx" {
+					hasCtxParam = true
+				}
+			}
+			break
+		}
+	}
+
+	if !found {
+		result.Valid = false
+		result.Errors = append(result.Errors, Error{
+			Line:    1,
+			Column:  1,
+			Message: "missing required function: compute_forecast",
+			Suggestion: "Define the entry point function:\n\ndef compute_forecast(ctx):\n    # ctx fields: " +
+				strings.Join(availableContextFields, ", ") +
+				"\n    return [{\"timestamp\": ..., \"value\": ...}]",
+		})
+		return
+	}
+
+	if !hasCtxParam {
+		result.Valid = false
+		result.Errors = append(result.Errors, Error{
+			Line:       1,
+			Column:     1,
+			Message:    "compute_forecast must accept a 'ctx' parameter",
+			Suggestion: "Change the function signature to: def compute_forecast(ctx):",
+		})
+	}
+}
+
+// ValidateWithExecution performs full validation including a dry-run execution
+// with empty data to verify the script can execute without runtime errors.
+// This is more thorough than ValidateStrategy but requires the Starlark runtime.
+func ValidateWithExecution(script string) Result {
+	// First do static validation
+	result := ValidateStrategy(script)
+	if !result.Valid {
+		return result
+	}
+
+	// Dry-run: parse and check that globals define compute_forecast as a callable
+	predeclared := starlarklib.StringDict{}
+	for _, name := range []string{
+		"True", "False", "None",
+		"len", "str", "int", "float", "bool",
+		"list", "dict", "tuple", "range",
+		"enumerate", "zip", "sorted", "reversed",
+		"min", "max", "abs", "any", "all",
+		"hasattr", "getattr", "dir", "type", "repr", "hash",
+	} {
+		if val, ok := starlarklib.Universe[name]; ok {
+			predeclared[name] = val
+		}
+	}
+
+	// Add stub builtins that return None for validation purposes
+	stubBuiltin := starlarklib.NewBuiltin("stub", func(_ *starlarklib.Thread, _ *starlarklib.Builtin, _ starlarklib.Tuple, _ []starlarklib.Tuple) (starlarklib.Value, error) {
+		return starlarklib.None, nil
+	})
+	for _, name := range []string{"avg", "sum", "percentile", "filter_by_hour", "group_by_hour", "duration", "add_seconds", "Decimal"} {
+		predeclared[name] = stubBuiltin
+	}
+
+	thread := &starlarklib.Thread{Name: "validate"}
+	globals, err := starlarklib.ExecFileOptions(&syntax.FileOptions{}, thread, "strategy.star", script, predeclared)
+	if err != nil {
+		result.Valid = false
+		result.Errors = append(result.Errors, Error{
+			Line:       0,
+			Column:     0,
+			Message:    fmt.Sprintf("execution error: %s", err.Error()),
+			Suggestion: "Fix the runtime error in the top-level script code. Note: the script body outside compute_forecast runs at load time.",
+		})
+		return result
+	}
+
+	// Verify compute_forecast is a function
+	fn, ok := globals["compute_forecast"]
+	if !ok {
+		result.Valid = false
+		result.Errors = append(result.Errors, Error{
+			Line:       1,
+			Column:     1,
+			Message:    "compute_forecast not found in script globals after execution",
+			Suggestion: "Ensure compute_forecast is defined at the top level, not inside another function.",
+		})
+		return result
+	}
+
+	if _, ok := fn.(*starlarklib.Function); !ok {
+		result.Valid = false
+		result.Errors = append(result.Errors, Error{
+			Line:       1,
+			Column:     1,
+			Message:    fmt.Sprintf("compute_forecast must be a function, got %s", fn.Type()),
+			Suggestion: "Define compute_forecast as: def compute_forecast(ctx): ...",
+		})
+	}
+
+	return result
+}

--- a/services/forecasting/validation/strategy_validator_test.go
+++ b/services/forecasting/validation/strategy_validator_test.go
@@ -1,0 +1,239 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/forecasting/templates"
+)
+
+func TestValidateStrategy_ValidScript(t *testing.T) {
+	script := `
+def compute_forecast(ctx):
+    obs = ctx["observations"]
+    return [{"timestamp": "2026-02-10T01:00:00Z", "value": 42}]
+`
+	result := ValidateStrategy(script)
+
+	assert.True(t, result.Valid)
+	assert.Empty(t, result.Errors)
+	assert.NotEmpty(t, result.AvailableContextFields)
+	assert.NotEmpty(t, result.AvailableFunctions)
+}
+
+func TestValidateStrategy_MissingComputeForecast(t *testing.T) {
+	script := `
+def some_other_function(x):
+    return x * 2
+`
+	result := ValidateStrategy(script)
+
+	assert.False(t, result.Valid)
+	require.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0].Message, "missing required function: compute_forecast")
+	assert.NotEmpty(t, result.Errors[0].Suggestion)
+	assert.Contains(t, result.Errors[0].Suggestion, "def compute_forecast(ctx)")
+}
+
+func TestValidateStrategy_SyntaxError(t *testing.T) {
+	script := `
+def compute_forecast(ctx)
+    return []
+`
+	result := ValidateStrategy(script)
+
+	assert.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+
+	// Should have line/column information
+	syntaxErr := result.Errors[0]
+	assert.Greater(t, syntaxErr.Line, 0, "expected line number > 0")
+	assert.NotEmpty(t, syntaxErr.Message)
+	assert.NotEmpty(t, syntaxErr.Suggestion)
+}
+
+func TestValidateStrategy_ForbiddenWhileLoop(t *testing.T) {
+	// Note: Starlark itself forbids while loops at the syntax level.
+	// The script won't parse if it contains a while loop.
+	script := `
+while True:
+    pass
+`
+	result := ValidateStrategy(script)
+
+	// Should fail with a syntax error (Starlark rejects while loops)
+	assert.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+}
+
+func TestValidateStrategy_ForbiddenImport(t *testing.T) {
+	script := `
+import os
+
+def compute_forecast(ctx):
+    return []
+`
+	result := ValidateStrategy(script)
+
+	assert.False(t, result.Valid)
+	foundImportError := false
+	for _, e := range result.Errors {
+		if e.Message != "" {
+			foundImportError = true
+			break
+		}
+	}
+	assert.True(t, foundImportError, "expected at least one error about import")
+}
+
+func TestValidateStrategy_ForbiddenLoad(t *testing.T) {
+	script := `
+load("module.star", "func")
+
+def compute_forecast(ctx):
+    return []
+`
+	result := ValidateStrategy(script)
+
+	assert.False(t, result.Valid)
+	foundLoadError := false
+	for _, e := range result.Errors {
+		if e.Message != "" {
+			foundLoadError = true
+			break
+		}
+	}
+	assert.True(t, foundLoadError, "expected at least one error about load")
+}
+
+func TestValidateStrategy_EmptyScript(t *testing.T) {
+	result := ValidateStrategy("")
+
+	assert.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+	assert.Contains(t, result.Errors[0].Message, "empty")
+}
+
+func TestValidateStrategy_WhitespaceOnlyScript(t *testing.T) {
+	result := ValidateStrategy("   \n\t\n  ")
+
+	assert.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+	assert.Contains(t, result.Errors[0].Message, "empty")
+}
+
+func TestValidateStrategy_MissingCtxParam(t *testing.T) {
+	script := `
+def compute_forecast():
+    return []
+`
+	result := ValidateStrategy(script)
+
+	assert.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+	assert.Contains(t, result.Errors[0].Message, "ctx")
+}
+
+func TestValidateStrategy_WrongParamName(t *testing.T) {
+	script := `
+def compute_forecast(data):
+    return []
+`
+	result := ValidateStrategy(script)
+
+	assert.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+	assert.Contains(t, result.Errors[0].Message, "ctx")
+}
+
+func TestValidateStrategy_AIFeedbackStructure(t *testing.T) {
+	// Verify that the result always includes available fields and functions
+	// for AI self-correction, regardless of validity
+	script := `x = 42`
+
+	result := ValidateStrategy(script)
+
+	assert.False(t, result.Valid)
+	assert.Contains(t, result.AvailableContextFields, "observations")
+	assert.Contains(t, result.AvailableContextFields, "reference_data")
+	assert.Contains(t, result.AvailableContextFields, "horizon_seconds")
+	assert.Contains(t, result.AvailableContextFields, "granularity_seconds")
+	assert.Contains(t, result.AvailableContextFields, "now")
+
+	assert.Contains(t, result.AvailableFunctions, "avg")
+	assert.Contains(t, result.AvailableFunctions, "sum")
+	assert.Contains(t, result.AvailableFunctions, "filter_by_hour")
+	assert.Contains(t, result.AvailableFunctions, "group_by_hour")
+	assert.Contains(t, result.AvailableFunctions, "duration")
+	assert.Contains(t, result.AvailableFunctions, "add_seconds")
+	assert.Contains(t, result.AvailableFunctions, "Decimal")
+}
+
+// --- ValidateWithExecution tests ---
+
+func TestValidateWithExecution_ValidScript(t *testing.T) {
+	script := `
+def compute_forecast(ctx):
+    return []
+`
+	result := ValidateWithExecution(script)
+
+	assert.True(t, result.Valid)
+	assert.Empty(t, result.Errors)
+}
+
+func TestValidateWithExecution_RuntimeError(t *testing.T) {
+	script := `
+x = 1 / 0
+
+def compute_forecast(ctx):
+    return []
+`
+	result := ValidateWithExecution(script)
+
+	assert.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+	assert.Contains(t, result.Errors[0].Message, "execution error")
+}
+
+func TestValidateWithExecution_NotAFunction(t *testing.T) {
+	// compute_forecast assigned as variable, not defined as function.
+	// Static analysis catches this as "missing required function" because
+	// there is no def statement for compute_forecast.
+	script := `
+compute_forecast = 42
+`
+	result := ValidateWithExecution(script)
+
+	assert.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+	assert.Contains(t, result.Errors[0].Message, "compute_forecast")
+}
+
+// --- Built-in template validation tests ---
+
+func TestValidateStrategy_AllBuiltinTemplatesPass(t *testing.T) {
+	for _, name := range templates.All() {
+		t.Run(name, func(t *testing.T) {
+			script, err := templates.Load(name)
+			require.NoError(t, err)
+
+			result := ValidateStrategy(script)
+			assert.True(t, result.Valid, "template %s should be valid, errors: %v", name, result.Errors)
+		})
+	}
+}
+
+func TestValidateWithExecution_AllBuiltinTemplatesPass(t *testing.T) {
+	for _, name := range templates.All() {
+		t.Run(name, func(t *testing.T) {
+			script, err := templates.Load(name)
+			require.NoError(t, err)
+
+			result := ValidateWithExecution(script)
+			assert.True(t, result.Valid, "template %s should pass execution validation, errors: %v", name, result.Errors)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Implement 4 Starlark forecast algorithm templates (moving average, seasonal decomposition, capacity pricing, external blend) embedded via Go's `embed` package
- Add validation framework with AI-native structured error feedback for strategy scripts
- All templates implement `compute_forecast(ctx)` entry point and use ForecastContext builtins

## Changes Made

### Templates (`services/forecasting/templates/`)
- **moving_average.star**: Simple/exponential moving average with configurable alpha from reference data
- **seasonal_decomposition.star**: Hour-of-day patterns using median for outlier robustness
- **capacity_pricing.star**: Utilization-based price tiers (peak/standard/off-peak) using reference data capacity
- **external_blend.star**: Weighted blend of internal + external forecasts (default 70/30)
- **templates.go**: Go embed file with `Load()` and `All()` helpers

### Validation Framework (`services/forecasting/validation/`)
- **strategy_validator.go**: Static + execution validation with `Result`/`Error` types
  - Starlark syntax validation with line/column error locations
  - Entry point verification (compute_forecast with ctx parameter)
  - Forbidden operation detection (import, load)
  - AI self-correction hints (available context fields and functions)
  - Full execution validation with stub builtins

## Testing

Template tests:
- moving_average: Sine wave data (avg ~100), exponential smoothing (alpha=0.5), empty observations
- seasonal_decomposition: Peak pattern at hour 14 with 7 days of data
- capacity_pricing: Peak tier (85/100), standard tier (60/100), off-peak tier (30/100)
- external_blend: Mixed sources with default 70/30 weight, custom 50/50 weight, single source fallback

Validation tests:
- Valid strategy passes
- Missing compute_forecast detected
- Syntax error with line/column info
- Forbidden while loop (Starlark rejects at syntax level)
- Forbidden import/load detected
- AI feedback structure always present
- All built-in templates pass both static and execution validation

## Task Master

Implements market-data-dynamic-pricing.12 (subtasks 12.1 and 12.2)