### PR TITLE
feat: wire RetrieveAccountReconciliation handler

### DIFF
--- a/services/reconciliation/service/retrieve_handler_test.go
+++ b/services/reconciliation/service/retrieve_handler_test.go
@@ -1,0 +1,252 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/services/reconciliation/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// mockSettlementRunRepo implements domain.SettlementRunRepository for testing.
+type mockSettlementRunRepo struct {
+	runs map[uuid.UUID]*domain.SettlementRun
+	err  error // injected error for testing
+}
+
+func newMockSettlementRunRepo() *mockSettlementRunRepo {
+	return &mockSettlementRunRepo{runs: make(map[uuid.UUID]*domain.SettlementRun)}
+}
+
+func (m *mockSettlementRunRepo) Create(_ context.Context, run *domain.SettlementRun) error {
+	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *mockSettlementRunRepo) FindByID(_ context.Context, runID uuid.UUID) (*domain.SettlementRun, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	run, ok := m.runs[runID]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return run, nil
+}
+
+func (m *mockSettlementRunRepo) Update(_ context.Context, run *domain.SettlementRun) error {
+	if _, ok := m.runs[run.RunID]; !ok {
+		return domain.ErrNotFound
+	}
+	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *mockSettlementRunRepo) List(_ context.Context, _ domain.RunFilter) ([]*domain.SettlementRun, error) {
+	result := make([]*domain.SettlementRun, 0, len(m.runs))
+	for _, r := range m.runs {
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+func TestRetrieveAccountReconciliation_Success(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	now := time.Now().UTC().Truncate(time.Second)
+	completedAt := now.Add(-time.Minute)
+	runID := uuid.New()
+
+	run := &domain.SettlementRun{
+		RunID:          runID,
+		AccountID:      "ACC-001",
+		Scope:          domain.ReconciliationScopeAccount,
+		SettlementType: domain.SettlementTypeDaily,
+		Status:         domain.RunStatusCompleted,
+		PeriodStart:    now.Add(-24 * time.Hour),
+		PeriodEnd:      now,
+		InitiatedBy:    "system",
+		CompletedAt:    &completedAt,
+		VarianceCount:  3,
+		Attributes:     map[string]string{"source": "test"},
+		CreatedAt:      now.Add(-24 * time.Hour),
+		UpdatedAt:      now,
+		Version:        2,
+	}
+	repo.runs[runID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.RetrieveAccountReconciliation(context.Background(), &reconciliationv1.RetrieveAccountReconciliationRequest{
+		RunId: runID.String(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.GetRun())
+
+	summary := resp.GetRun()
+	assert.Equal(t, runID.String(), summary.GetRunId())
+	assert.Equal(t, "ACC-001", summary.GetAccountId())
+	assert.Equal(t, reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT, summary.GetScope())
+	assert.Equal(t, reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY, summary.GetSettlementType())
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_COMPLETED, summary.GetStatus())
+	assert.Equal(t, "system", summary.GetInitiatedBy())
+	assert.Equal(t, int32(3), summary.GetVarianceCount())
+	assert.Equal(t, int64(2), summary.GetVersion())
+	assert.NotNil(t, summary.GetCompletedAt())
+	assert.NotNil(t, summary.GetPeriodStart())
+	assert.NotNil(t, summary.GetPeriodEnd())
+	assert.NotNil(t, summary.GetCreatedAt())
+	assert.NotNil(t, summary.GetUpdatedAt())
+}
+
+func TestRetrieveAccountReconciliation_NotFound(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.RetrieveAccountReconciliation(context.Background(), &reconciliationv1.RetrieveAccountReconciliationRequest{
+		RunId: uuid.New().String(),
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+	assert.Contains(t, st.Message(), "settlement run not found")
+}
+
+func TestRetrieveAccountReconciliation_InvalidUUID(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.RetrieveAccountReconciliation(context.Background(), &reconciliationv1.RetrieveAccountReconciliationRequest{
+		RunId: "not-a-uuid",
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid run_id")
+}
+
+func TestRetrieveAccountReconciliation_EmptyRunID(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.RetrieveAccountReconciliation(context.Background(), &reconciliationv1.RetrieveAccountReconciliationRequest{
+		RunId: "",
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "run_id is required")
+}
+
+func TestRetrieveAccountReconciliation_TimestampConversion(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	runID := uuid.New()
+	now := time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC)
+
+	// Run without CompletedAt (still in progress)
+	run := &domain.SettlementRun{
+		RunID:          runID,
+		AccountID:      "ACC-002",
+		Scope:          domain.ReconciliationScopeInstrument,
+		SettlementType: domain.SettlementTypeOnDemand,
+		Status:         domain.RunStatusRunning,
+		PeriodStart:    now.Add(-24 * time.Hour),
+		PeriodEnd:      now,
+		InitiatedBy:    "operator",
+		CompletedAt:    nil,
+		CreatedAt:      now.Add(-time.Hour),
+		UpdatedAt:      now,
+		Version:        1,
+	}
+	repo.runs[runID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.RetrieveAccountReconciliation(context.Background(), &reconciliationv1.RetrieveAccountReconciliationRequest{
+		RunId: runID.String(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	summary := resp.GetRun()
+
+	// CompletedAt should be nil when run is still in progress
+	assert.Nil(t, summary.GetCompletedAt())
+
+	// Verify PeriodStart timestamp conversion
+	assert.Equal(t, now.Add(-24*time.Hour).Unix(), summary.GetPeriodStart().GetSeconds())
+
+	// Verify PeriodEnd timestamp conversion
+	assert.Equal(t, now.Unix(), summary.GetPeriodEnd().GetSeconds())
+
+	// Verify CreatedAt timestamp conversion
+	assert.Equal(t, now.Add(-time.Hour).Unix(), summary.GetCreatedAt().GetSeconds())
+
+	// Verify UpdatedAt timestamp conversion
+	assert.Equal(t, now.Unix(), summary.GetUpdatedAt().GetSeconds())
+}
+
+func TestRetrieveAccountReconciliation_InternalError(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	repo.err = errors.New("database connection failed")
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.RetrieveAccountReconciliation(context.Background(), &reconciliationv1.RetrieveAccountReconciliationRequest{
+		RunId: uuid.New().String(),
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}
+
+func TestRetrieveAccountReconciliation_NoRunRepo(t *testing.T) {
+	// When no run repo is configured, handler should return Unimplemented
+	svc := service.NewAccountReconciliationService()
+
+	resp, err := svc.RetrieveAccountReconciliation(context.Background(), &reconciliationv1.RetrieveAccountReconciliationRequest{
+		RunId: uuid.New().String(),
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+}

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -8,6 +8,7 @@ package service
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"github.com/google/uuid"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
@@ -25,6 +26,7 @@ type AccountReconciliationService struct {
 	reconciliationv1.UnimplementedAccountReconciliationServiceServer
 
 	disputeRepo     domain.DisputeRepository
+	runRepo         domain.SettlementRunRepository
 	varianceRepo    VarianceFinder
 	sagaRuntime     SagaRuntime
 	eventPublisher  EventPublisher
@@ -41,6 +43,13 @@ type Option func(*AccountReconciliationService)
 func WithDisputeRepository(repo domain.DisputeRepository) Option {
 	return func(s *AccountReconciliationService) {
 		s.disputeRepo = repo
+	}
+}
+
+// WithSettlementRunRepository sets the settlement run repository.
+func WithSettlementRunRepository(repo domain.SettlementRunRepository) Option {
+	return func(s *AccountReconciliationService) {
+		s.runRepo = repo
 	}
 }
 
@@ -121,10 +130,35 @@ func (s *AccountReconciliationService) ExecuteAccountReconciliation(
 
 // RetrieveAccountReconciliation retrieves a settlement run summary.
 func (s *AccountReconciliationService) RetrieveAccountReconciliation(
-	_ context.Context,
-	_ *reconciliationv1.RetrieveAccountReconciliationRequest,
+	ctx context.Context,
+	req *reconciliationv1.RetrieveAccountReconciliationRequest,
 ) (*reconciliationv1.RetrieveAccountReconciliationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "RetrieveAccountReconciliation not yet implemented")
+	if s.runRepo == nil {
+		return nil, status.Error(codes.Unimplemented, "RetrieveAccountReconciliation not yet implemented")
+	}
+
+	runIDStr := req.GetRunId()
+	if runIDStr == "" {
+		return nil, status.Error(codes.InvalidArgument, "run_id is required")
+	}
+
+	runID, err := uuid.Parse(runIDStr)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid run_id: %v", err)
+	}
+
+	run, err := s.runRepo.FindByID(ctx, runID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "settlement run not found: %s", runID)
+		}
+		slog.ErrorContext(ctx, "failed to retrieve settlement run", "run_id", runID, "error", err)
+		return nil, status.Error(codes.Internal, "failed to retrieve settlement run")
+	}
+
+	return &reconciliationv1.RetrieveAccountReconciliationResponse{
+		Run: toProtoRunSummary(run),
+	}, nil
 }
 
 // ControlAccountReconciliation controls a settlement run (cancel, pause, resume).


### PR DESCRIPTION
## Summary

- Add `runRepo` field and `WithSettlementRunRepository` option to `AccountReconciliationService`
- Implement `RetrieveAccountReconciliation` handler: validates run_id (required, valid UUID), queries `SettlementRunRepository.FindByID`, maps domain to proto via `toProtoRunSummary()`
- Returns `codes.Unimplemented` when no run repository is configured (backward-compatible with existing stub tests)

## Changes Made

- `services/reconciliation/service/service.go`: Added `runRepo` field, `WithSettlementRunRepository` option, and full handler implementation with structured logging
- `services/reconciliation/service/retrieve_handler_test.go`: 7 test cases covering success, not-found, invalid UUID, empty run_id, timestamp conversion (nil CompletedAt), internal error, and no-repo fallback

## Task Master

- Tag: `reconciliation-service`
- Task: `reconciliation-service.17` - Wire RetrieveAccountReconciliation handler

## Test Plan

- [x] `TestRetrieveAccountReconciliation_Success` - Full field mapping verification
- [x] `TestRetrieveAccountReconciliation_NotFound` - `codes.NotFound` on missing run
- [x] `TestRetrieveAccountReconciliation_InvalidUUID` - `codes.InvalidArgument` on malformed UUID
- [x] `TestRetrieveAccountReconciliation_EmptyRunID` - `codes.InvalidArgument` on empty run_id
- [x] `TestRetrieveAccountReconciliation_TimestampConversion` - Nil CompletedAt + timestamp second precision
- [x] `TestRetrieveAccountReconciliation_InternalError` - `codes.Internal` on repo failure
- [x] `TestRetrieveAccountReconciliation_NoRunRepo` - `codes.Unimplemented` fallback