### PR TITLE
feat: wire ListReconciliationResults handler with pagination

### DIFF
--- a/services/reconciliation/service/mapping.go
+++ b/services/reconciliation/service/mapping.go
@@ -124,6 +124,8 @@ func toDomainVarianceStatus(s reconciliationv1.VarianceStatus) *domain.VarianceS
 		status = domain.VarianceStatusAccepted
 	case reconciliationv1.VarianceStatus_VARIANCE_STATUS_UNSPECIFIED:
 		return nil
+	default:
+		return nil
 	}
 	return &status
 }
@@ -148,6 +150,8 @@ func toDomainVarianceReason(s reconciliationv1.VarianceReason) *domain.VarianceR
 	case reconciliationv1.VarianceReason_VARIANCE_REASON_OTHER:
 		reason = domain.VarianceReasonOther
 	case reconciliationv1.VarianceReason_VARIANCE_REASON_UNSPECIFIED:
+		return nil
+	default:
 		return nil
 	}
 	return &reason

--- a/services/reconciliation/service/mapping.go
+++ b/services/reconciliation/service/mapping.go
@@ -107,6 +107,52 @@ func toProtoSettlementType(s domain.SettlementType) reconciliationv1.SettlementT
 	return reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED
 }
 
+// toDomainVarianceStatus converts a proto VarianceStatus to domain.
+// UNSPECIFIED returns nil (no filter).
+func toDomainVarianceStatus(s reconciliationv1.VarianceStatus) *domain.VarianceStatus {
+	var status domain.VarianceStatus
+	switch s {
+	case reconciliationv1.VarianceStatus_VARIANCE_STATUS_OPEN:
+		status = domain.VarianceStatusOpen
+	case reconciliationv1.VarianceStatus_VARIANCE_STATUS_INVESTIGATING:
+		status = domain.VarianceStatusInvestigating
+	case reconciliationv1.VarianceStatus_VARIANCE_STATUS_DISPUTED:
+		status = domain.VarianceStatusDisputed
+	case reconciliationv1.VarianceStatus_VARIANCE_STATUS_RESOLVED:
+		status = domain.VarianceStatusResolved
+	case reconciliationv1.VarianceStatus_VARIANCE_STATUS_ACCEPTED:
+		status = domain.VarianceStatusAccepted
+	case reconciliationv1.VarianceStatus_VARIANCE_STATUS_UNSPECIFIED:
+		return nil
+	}
+	return &status
+}
+
+// toDomainVarianceReason converts a proto VarianceReason to domain.
+// UNSPECIFIED returns nil (no filter).
+func toDomainVarianceReason(s reconciliationv1.VarianceReason) *domain.VarianceReason {
+	var reason domain.VarianceReason
+	switch s {
+	case reconciliationv1.VarianceReason_VARIANCE_REASON_AMOUNT_MISMATCH:
+		reason = domain.VarianceReasonAmountMismatch
+	case reconciliationv1.VarianceReason_VARIANCE_REASON_MISSING_ENTRY:
+		reason = domain.VarianceReasonMissingEntry
+	case reconciliationv1.VarianceReason_VARIANCE_REASON_DUPLICATE_ENTRY:
+		reason = domain.VarianceReasonDuplicateEntry
+	case reconciliationv1.VarianceReason_VARIANCE_REASON_TIMING_DIFFERENCE:
+		reason = domain.VarianceReasonTimingDifference
+	case reconciliationv1.VarianceReason_VARIANCE_REASON_CURRENCY_MISMATCH:
+		reason = domain.VarianceReasonCurrencyMismatch
+	case reconciliationv1.VarianceReason_VARIANCE_REASON_DIRECTION_ERROR:
+		reason = domain.VarianceReasonDirectionError
+	case reconciliationv1.VarianceReason_VARIANCE_REASON_OTHER:
+		reason = domain.VarianceReasonOther
+	case reconciliationv1.VarianceReason_VARIANCE_REASON_UNSPECIFIED:
+		return nil
+	}
+	return &reason
+}
+
 // toProtoVarianceReason converts a domain VarianceReason to proto.
 func toProtoVarianceReason(r domain.VarianceReason) reconciliationv1.VarianceReason {
 	switch r {

--- a/services/reconciliation/service/mapping_test.go
+++ b/services/reconciliation/service/mapping_test.go
@@ -253,6 +253,121 @@ func TestToProtoSettlementType(t *testing.T) {
 	}
 }
 
+func TestToDomainVarianceStatus(t *testing.T) {
+	tests := []struct {
+		name  string
+		proto reconciliationv1.VarianceStatus
+		want  *domain.VarianceStatus
+	}{
+		{
+			name:  "open",
+			proto: reconciliationv1.VarianceStatus_VARIANCE_STATUS_OPEN,
+			want:  ptr(domain.VarianceStatusOpen),
+		},
+		{
+			name:  "investigating",
+			proto: reconciliationv1.VarianceStatus_VARIANCE_STATUS_INVESTIGATING,
+			want:  ptr(domain.VarianceStatusInvestigating),
+		},
+		{
+			name:  "disputed",
+			proto: reconciliationv1.VarianceStatus_VARIANCE_STATUS_DISPUTED,
+			want:  ptr(domain.VarianceStatusDisputed),
+		},
+		{
+			name:  "resolved",
+			proto: reconciliationv1.VarianceStatus_VARIANCE_STATUS_RESOLVED,
+			want:  ptr(domain.VarianceStatusResolved),
+		},
+		{
+			name:  "accepted",
+			proto: reconciliationv1.VarianceStatus_VARIANCE_STATUS_ACCEPTED,
+			want:  ptr(domain.VarianceStatusAccepted),
+		},
+		{
+			name:  "unspecified returns nil",
+			proto: reconciliationv1.VarianceStatus_VARIANCE_STATUS_UNSPECIFIED,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toDomainVarianceStatus(tt.proto)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}
+
+func TestToDomainVarianceReason(t *testing.T) {
+	tests := []struct {
+		name  string
+		proto reconciliationv1.VarianceReason
+		want  *domain.VarianceReason
+	}{
+		{
+			name:  "amount mismatch",
+			proto: reconciliationv1.VarianceReason_VARIANCE_REASON_AMOUNT_MISMATCH,
+			want:  ptrR(domain.VarianceReasonAmountMismatch),
+		},
+		{
+			name:  "missing entry",
+			proto: reconciliationv1.VarianceReason_VARIANCE_REASON_MISSING_ENTRY,
+			want:  ptrR(domain.VarianceReasonMissingEntry),
+		},
+		{
+			name:  "duplicate entry",
+			proto: reconciliationv1.VarianceReason_VARIANCE_REASON_DUPLICATE_ENTRY,
+			want:  ptrR(domain.VarianceReasonDuplicateEntry),
+		},
+		{
+			name:  "timing difference",
+			proto: reconciliationv1.VarianceReason_VARIANCE_REASON_TIMING_DIFFERENCE,
+			want:  ptrR(domain.VarianceReasonTimingDifference),
+		},
+		{
+			name:  "currency mismatch",
+			proto: reconciliationv1.VarianceReason_VARIANCE_REASON_CURRENCY_MISMATCH,
+			want:  ptrR(domain.VarianceReasonCurrencyMismatch),
+		},
+		{
+			name:  "direction error",
+			proto: reconciliationv1.VarianceReason_VARIANCE_REASON_DIRECTION_ERROR,
+			want:  ptrR(domain.VarianceReasonDirectionError),
+		},
+		{
+			name:  "other",
+			proto: reconciliationv1.VarianceReason_VARIANCE_REASON_OTHER,
+			want:  ptrR(domain.VarianceReasonOther),
+		},
+		{
+			name:  "unspecified returns nil",
+			proto: reconciliationv1.VarianceReason_VARIANCE_REASON_UNSPECIFIED,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toDomainVarianceReason(tt.proto)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				require.NotNil(t, got)
+				assert.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}
+
+func ptr(s domain.VarianceStatus) *domain.VarianceStatus  { return &s }
+func ptrR(r domain.VarianceReason) *domain.VarianceReason { return &r }
+
 func TestToProtoVarianceReason(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -20,18 +20,24 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// VarianceLister retrieves paginated variance lists.
+type VarianceLister interface {
+	List(ctx context.Context, filter domain.VarianceFilter) ([]*domain.Variance, error)
+}
+
 // AccountReconciliationService implements the gRPC service for reconciliation operations.
 type AccountReconciliationService struct {
 	reconciliationv1.UnimplementedAccountReconciliationServiceServer
 
-	disputeRepo     domain.DisputeRepository
-	varianceRepo    VarianceFinder
-	sagaRuntime     SagaRuntime
-	eventPublisher  EventPublisher
-	assertor        *BalanceAssertor
-	policyRuntime   valuation.PolicyRuntime
-	starlarkRuntime valuation.StarlarkRuntime
-	valuationCache  valuation.Cache
+	disputeRepo      domain.DisputeRepository
+	varianceRepo     VarianceFinder
+	varianceListRepo VarianceLister
+	sagaRuntime      SagaRuntime
+	eventPublisher   EventPublisher
+	assertor         *BalanceAssertor
+	policyRuntime    valuation.PolicyRuntime
+	starlarkRuntime  valuation.StarlarkRuntime
+	valuationCache   valuation.Cache
 }
 
 // Option configures the AccountReconciliationService.
@@ -48,6 +54,13 @@ func WithDisputeRepository(repo domain.DisputeRepository) Option {
 func WithVarianceRepository(repo VarianceFinder) Option {
 	return func(s *AccountReconciliationService) {
 		s.varianceRepo = repo
+	}
+}
+
+// WithVarianceListRepository sets the variance lister for paginated queries.
+func WithVarianceListRepository(repo VarianceLister) Option {
+	return func(s *AccountReconciliationService) {
+		s.varianceListRepo = repo
 	}
 }
 
@@ -137,10 +150,60 @@ func (s *AccountReconciliationService) ControlAccountReconciliation(
 
 // ListReconciliationResults returns paginated variance details for a run.
 func (s *AccountReconciliationService) ListReconciliationResults(
-	_ context.Context,
-	_ *reconciliationv1.ListReconciliationResultsRequest,
+	ctx context.Context,
+	req *reconciliationv1.ListReconciliationResultsRequest,
 ) (*reconciliationv1.ListReconciliationResultsResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ListReconciliationResults not yet implemented")
+	if s.varianceListRepo == nil {
+		return nil, status.Error(codes.Unimplemented, "ListReconciliationResults not yet implemented")
+	}
+
+	runID, err := uuid.Parse(req.GetRunId())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid run_id: %v", err)
+	}
+
+	pageSize := int(req.GetPageSize())
+	if pageSize <= 0 {
+		pageSize = 50
+	}
+	if pageSize > 1000 {
+		pageSize = 1000
+	}
+
+	offset, err := decodeCursor(req.GetPageToken())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid page_token: %v", err)
+	}
+
+	filter := domain.VarianceFilter{
+		RunID:  &runID,
+		Status: toDomainVarianceStatus(req.GetFilterStatus()),
+		Reason: toDomainVarianceReason(req.GetFilterReason()),
+		Limit:  pageSize + 1,
+		Offset: offset,
+	}
+
+	variances, err := s.varianceListRepo.List(ctx, filter)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to list variances: %v", err)
+	}
+
+	var nextPageToken string
+	if len(variances) > pageSize {
+		variances = variances[:pageSize]
+		nextPageToken = encodeCursor(offset + pageSize)
+	}
+
+	details := make([]*reconciliationv1.VarianceDetail, len(variances))
+	for i, v := range variances {
+		details[i] = toProtoVarianceDetail(v)
+	}
+
+	return &reconciliationv1.ListReconciliationResultsResponse{
+		Variances:     details,
+		NextPageToken: nextPageToken,
+		TotalCount:    -1,
+	}, nil
 }
 
 // AssertBalance evaluates a balance assertion against current positions.

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -191,7 +191,12 @@ func (s *AccountReconciliationService) ListReconciliationResults(
 		return nil, status.Error(codes.Unimplemented, "ListReconciliationResults not yet implemented")
 	}
 
-	runID, err := uuid.Parse(req.GetRunId())
+	runIDStr := req.GetRunId()
+	if runIDStr == "" {
+		return nil, status.Error(codes.InvalidArgument, "run_id is required")
+	}
+
+	runID, err := uuid.Parse(runIDStr)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid run_id: %v", err)
 	}

--- a/services/reconciliation/service/service_test.go
+++ b/services/reconciliation/service/service_test.go
@@ -2,14 +2,50 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// mockVarianceLister implements VarianceLister for testing.
+type mockVarianceLister struct {
+	listFn func(ctx context.Context, filter domain.VarianceFilter) ([]*domain.Variance, error)
+}
+
+func (m *mockVarianceLister) List(ctx context.Context, filter domain.VarianceFilter) ([]*domain.Variance, error) {
+	return m.listFn(ctx, filter)
+}
+
+func makeVariances(runID uuid.UUID, count int) []*domain.Variance {
+	now := time.Now().UTC()
+	variances := make([]*domain.Variance, count)
+	for i := range count {
+		variances[i] = &domain.Variance{
+			VarianceID:     uuid.New(),
+			RunID:          runID,
+			SnapshotID:     uuid.New(),
+			AccountID:      fmt.Sprintf("acc-%03d", i),
+			InstrumentCode: "GBP",
+			ExpectedAmount: decimal.NewFromInt(1000),
+			ActualAmount:   decimal.NewFromInt(999),
+			VarianceAmount: decimal.NewFromInt(-1),
+			Reason:         domain.VarianceReasonAmountMismatch,
+			Status:         domain.VarianceStatusOpen,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}
+	}
+	return variances
+}
 
 func TestNewAccountReconciliationService(t *testing.T) {
 	svc := NewAccountReconciliationService()
@@ -98,4 +134,170 @@ func TestAllRPCsReturnUnimplemented(t *testing.T) {
 			assert.Equal(t, codes.Unimplemented, st.Code())
 		})
 	}
+}
+
+func TestListReconciliationResults_FirstPage(t *testing.T) {
+	runID := uuid.New()
+	// Return 11 results (page_size+1) to indicate more pages exist
+	allVariances := makeVariances(runID, 11)
+
+	mock := &mockVarianceLister{
+		listFn: func(_ context.Context, filter domain.VarianceFilter) ([]*domain.Variance, error) {
+			assert.Equal(t, runID, *filter.RunID)
+			assert.Equal(t, 11, filter.Limit) // page_size + 1
+			assert.Equal(t, 0, filter.Offset)
+			return allVariances, nil
+		},
+	}
+
+	svc := NewAccountReconciliationService(WithVarianceListRepository(mock))
+	resp, err := svc.ListReconciliationResults(context.Background(), &reconciliationv1.ListReconciliationResultsRequest{
+		RunId:    runID.String(),
+		PageSize: 10,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, resp.Variances, 10)
+	assert.NotEmpty(t, resp.NextPageToken, "next_page_token should be present when more results exist")
+	assert.Equal(t, int64(-1), resp.TotalCount)
+}
+
+func TestListReconciliationResults_LastPage(t *testing.T) {
+	runID := uuid.New()
+	// Return exactly page_size results (no extra), indicating last page
+	allVariances := makeVariances(runID, 5)
+
+	mock := &mockVarianceLister{
+		listFn: func(_ context.Context, _ domain.VarianceFilter) ([]*domain.Variance, error) {
+			return allVariances, nil
+		},
+	}
+
+	svc := NewAccountReconciliationService(WithVarianceListRepository(mock))
+	resp, err := svc.ListReconciliationResults(context.Background(), &reconciliationv1.ListReconciliationResultsRequest{
+		RunId:    runID.String(),
+		PageSize: 10,
+	})
+
+	require.NoError(t, err)
+	assert.Len(t, resp.Variances, 5)
+	assert.Empty(t, resp.NextPageToken, "next_page_token should be empty on last page")
+}
+
+func TestListReconciliationResults_FilterByStatus(t *testing.T) {
+	runID := uuid.New()
+
+	mock := &mockVarianceLister{
+		listFn: func(_ context.Context, filter domain.VarianceFilter) ([]*domain.Variance, error) {
+			require.NotNil(t, filter.Status)
+			assert.Equal(t, domain.VarianceStatusInvestigating, *filter.Status)
+			return nil, nil
+		},
+	}
+
+	svc := NewAccountReconciliationService(WithVarianceListRepository(mock))
+	resp, err := svc.ListReconciliationResults(context.Background(), &reconciliationv1.ListReconciliationResultsRequest{
+		RunId:        runID.String(),
+		FilterStatus: reconciliationv1.VarianceStatus_VARIANCE_STATUS_INVESTIGATING,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, resp.Variances)
+}
+
+func TestListReconciliationResults_FilterByReason(t *testing.T) {
+	runID := uuid.New()
+
+	mock := &mockVarianceLister{
+		listFn: func(_ context.Context, filter domain.VarianceFilter) ([]*domain.Variance, error) {
+			require.NotNil(t, filter.Reason)
+			assert.Equal(t, domain.VarianceReasonMissingEntry, *filter.Reason)
+			return nil, nil
+		},
+	}
+
+	svc := NewAccountReconciliationService(WithVarianceListRepository(mock))
+	resp, err := svc.ListReconciliationResults(context.Background(), &reconciliationv1.ListReconciliationResultsRequest{
+		RunId:        runID.String(),
+		FilterReason: reconciliationv1.VarianceReason_VARIANCE_REASON_MISSING_ENTRY,
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, resp.Variances)
+}
+
+func TestListReconciliationResults_EmptyResults(t *testing.T) {
+	runID := uuid.New()
+
+	mock := &mockVarianceLister{
+		listFn: func(_ context.Context, _ domain.VarianceFilter) ([]*domain.Variance, error) {
+			return nil, nil
+		},
+	}
+
+	svc := NewAccountReconciliationService(WithVarianceListRepository(mock))
+	resp, err := svc.ListReconciliationResults(context.Background(), &reconciliationv1.ListReconciliationResultsRequest{
+		RunId: runID.String(),
+	})
+
+	require.NoError(t, err)
+	assert.Empty(t, resp.Variances)
+	assert.Empty(t, resp.NextPageToken)
+}
+
+func TestListReconciliationResults_InvalidRunID(t *testing.T) {
+	mock := &mockVarianceLister{
+		listFn: func(_ context.Context, _ domain.VarianceFilter) ([]*domain.Variance, error) {
+			t.Fatal("should not be called with invalid run_id")
+			return nil, nil
+		},
+	}
+
+	svc := NewAccountReconciliationService(WithVarianceListRepository(mock))
+	_, err := svc.ListReconciliationResults(context.Background(), &reconciliationv1.ListReconciliationResultsRequest{
+		RunId: "not-a-uuid",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+func TestListReconciliationResults_DefaultPageSize(t *testing.T) {
+	runID := uuid.New()
+
+	mock := &mockVarianceLister{
+		listFn: func(_ context.Context, filter domain.VarianceFilter) ([]*domain.Variance, error) {
+			assert.Equal(t, 51, filter.Limit, "default page_size=50 means limit=51")
+			return nil, nil
+		},
+	}
+
+	svc := NewAccountReconciliationService(WithVarianceListRepository(mock))
+	_, err := svc.ListReconciliationResults(context.Background(), &reconciliationv1.ListReconciliationResultsRequest{
+		RunId: runID.String(),
+		// No PageSize set - should default to 50
+	})
+
+	require.NoError(t, err)
+}
+
+func TestListReconciliationResults_MaxPageSize(t *testing.T) {
+	runID := uuid.New()
+
+	mock := &mockVarianceLister{
+		listFn: func(_ context.Context, filter domain.VarianceFilter) ([]*domain.Variance, error) {
+			assert.Equal(t, 1001, filter.Limit, "page_size capped at 1000, limit=1001")
+			return nil, nil
+		},
+	}
+
+	svc := NewAccountReconciliationService(WithVarianceListRepository(mock))
+	_, err := svc.ListReconciliationResults(context.Background(), &reconciliationv1.ListReconciliationResultsRequest{
+		RunId:    runID.String(),
+		PageSize: 5000,
+	})
+
+	require.NoError(t, err)
 }

--- a/services/reconciliation/service/service_test.go
+++ b/services/reconciliation/service/service_test.go
@@ -264,6 +264,26 @@ func TestListReconciliationResults_InvalidRunID(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, st.Code())
 }
 
+func TestListReconciliationResults_EmptyRunID(t *testing.T) {
+	mock := &mockVarianceLister{
+		listFn: func(_ context.Context, _ domain.VarianceFilter) ([]*domain.Variance, error) {
+			t.Fatal("should not be called with empty run_id")
+			return nil, nil
+		},
+	}
+
+	svc := NewAccountReconciliationService(WithVarianceListRepository(mock))
+	_, err := svc.ListReconciliationResults(context.Background(), &reconciliationv1.ListReconciliationResultsRequest{
+		RunId: "",
+	})
+
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "run_id is required")
+}
+
 func TestListReconciliationResults_DefaultPageSize(t *testing.T) {
 	runID := uuid.New()
 


### PR DESCRIPTION
## Summary

- Wire `ListReconciliationResults` gRPC handler with cursor-based pagination, optional status/reason filtering, and configurable page size (default 50, max 1000)
- Add `VarianceLister` interface and `WithVarianceListRepository` option for dependency injection
- Add `toDomainVarianceStatus` and `toDomainVarianceReason` reverse mapping functions (proto-to-domain)

## Changes Made

- **`service.go`**: Add `VarianceLister` interface, `varianceListRepo` field, `WithVarianceListRepository` option, and full `ListReconciliationResults` implementation with validation, filtering, pagination, and proto mapping
- **`mapping.go`**: Add `toDomainVarianceStatus` and `toDomainVarianceReason` converters with exhaustive switch handling
- **`service_test.go`**: 8 test cases covering first page, last page, status filter, reason filter, empty results, invalid run ID, default page size, and max page size cap
- **`mapping_test.go`**: Tests for both reverse mapping functions including nil return on UNSPECIFIED

## Test Plan

- [x] `TestListReconciliationResults_FirstPage`: page_size=10, 11 results returned, next_page_token present
- [x] `TestListReconciliationResults_LastPage`: fewer results than page_size, next_page_token empty
- [x] `TestListReconciliationResults_FilterByStatus`: INVESTIGATING filter passed through to domain
- [x] `TestListReconciliationResults_FilterByReason`: MISSING_ENTRY filter passed through to domain
- [x] `TestListReconciliationResults_EmptyResults`: nil results, empty response
- [x] `TestListReconciliationResults_InvalidRunID`: returns InvalidArgument
- [x] `TestListReconciliationResults_DefaultPageSize`: no page_size, limit=51 (default 50+1)
- [x] `TestListReconciliationResults_MaxPageSize`: page_size=5000, capped to limit=1001

Task Master: reconciliation-service.20