### PR TITLE
Update PRD status overview and services README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,14 +214,16 @@ Reference specifications: [BIAN Service Landscape 13.0.0](https://github.com/bia
 [svc-recon]: services/reconciliation/
 [svc-rd]: services/reference-data/
 [svc-tenant]: services/tenant/
+[svc-cp]: services/control-plane/
+[svc-forecasting]: services/forecasting/
 
 ### Infrastructure Services
 
 | Service | Purpose |
 |---------|---------|
 | [**Tenant**][svc-tenant] | Multi-tenant platform management with schema-per-tenant isolation |
-| **ControlPlane** | SaaS operations layer for manifest management and Stripe billing |
-| **Forecasting** | Built-in forecasting algorithms and validation framework |
+| [**ControlPlane**][svc-cp] | SaaS operations layer for manifest management and Stripe billing |
+| [**Forecasting**][svc-forecasting] | Forward curve computation and scheduled forecast execution |
 | **Gateway** | API gateway for external access |
 | **audit-worker** | Processes audit log outbox entries |
 | **utilization-metering-consumer** | Usage metering for billing |

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ This implementation includes the following BIAN service domains:
 | [**Party**][svc-party] | Party Reference Data Directory | Customer and party reference data management | Yes | [OAS3][bian-party] |
 | [**PaymentOrder**][svc-po] | Payment Order | Payment initiation, saga orchestration, and settlement | No | [OAS3][bian-po] |
 | [**PositionKeeping**][svc-pk] | Position Keeping | Pre-ledger transaction log and position tracking | Yes | [OAS3][bian-pk] |
-| [**Reconciliation**][svc-recon] | Account Reconciliation | Settlement lifecycle, variance detection, and dispute management | Yes | - |
+| [**Reconciliation**][svc-recon] | Account Reconciliation | Settlement lifecycle, variance detection, and dispute management | Yes | [OAS3][bian-recon] |
 | [**ReferenceData**][svc-rd] | Financial Instrument Reference Data Management | Tenant-defined instrument catalog with CEL validation | Yes | [OAS3][bian-rd] |
 
 Each service domain follows BIAN's control record pattern with behavior qualifiers for operations.
@@ -210,6 +210,7 @@ Reference specifications: [BIAN Service Landscape 13.0.0](https://github.com/bia
 [svc-party]: services/party/
 [svc-po]: services/payment-order/
 [svc-pk]: services/position-keeping/
+[bian-recon]: https://github.com/bian-official/public/blob/main/release13.0.0/semantic-apis/oas3/yamls/AccountReconciliation.yaml
 [svc-recon]: services/reconciliation/
 [svc-rd]: services/reference-data/
 [svc-tenant]: services/tenant/

--- a/README.md
+++ b/README.md
@@ -154,7 +154,10 @@ meridian/
 │   ├── payment-order/           # PaymentOrder service
 │   ├── position-keeping/        # PositionKeeping service
 │   ├── reference-data/          # ReferenceData service
+│   ├── reconciliation/          # Account Reconciliation service
 │   ├── tenant/                  # Tenant service
+│   ├── control-plane/           # SaaS control plane
+│   ├── forecasting/             # Forecasting service
 │   ├── audit-worker/            # Audit log processor
 │   └── utilization-metering-consumer/  # Usage metering
 ├── shared/                      # Cross-service shared code
@@ -184,6 +187,7 @@ This implementation includes the following BIAN service domains:
 | [**Party**][svc-party] | Party Reference Data Directory | Customer and party reference data management | Yes | [OAS3][bian-party] |
 | [**PaymentOrder**][svc-po] | Payment Order | Payment initiation, saga orchestration, and settlement | No | [OAS3][bian-po] |
 | [**PositionKeeping**][svc-pk] | Position Keeping | Pre-ledger transaction log and position tracking | Yes | [OAS3][bian-pk] |
+| [**Reconciliation**][svc-recon] | Account Reconciliation | Settlement lifecycle, variance detection, and dispute management | Yes | - |
 | [**ReferenceData**][svc-rd] | Financial Instrument Reference Data Management | Tenant-defined instrument catalog with CEL validation | Yes | [OAS3][bian-rd] |
 
 Each service domain follows BIAN's control record pattern with behavior qualifiers for operations.
@@ -206,6 +210,7 @@ Reference specifications: [BIAN Service Landscape 13.0.0](https://github.com/bia
 [svc-party]: services/party/
 [svc-po]: services/payment-order/
 [svc-pk]: services/position-keeping/
+[svc-recon]: services/reconciliation/
 [svc-rd]: services/reference-data/
 [svc-tenant]: services/tenant/
 
@@ -214,6 +219,8 @@ Reference specifications: [BIAN Service Landscape 13.0.0](https://github.com/bia
 | Service | Purpose |
 |---------|---------|
 | [**Tenant**][svc-tenant] | Multi-tenant platform management with schema-per-tenant isolation |
+| **ControlPlane** | SaaS operations layer for manifest management and Stripe billing |
+| **Forecasting** | Built-in forecasting algorithms and validation framework |
 | **Gateway** | API gateway for external access |
 | **audit-worker** | Processes audit log outbox entries |
 | **utilization-metering-consumer** | Usage metering for billing |

--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -803,7 +803,373 @@ Use `shared/platform/organization` context patterns for tenant isolation.
 
 ### Audit Logging
 
-Follow [ADR-009](../adr/0009-application-level-audit-logging.md) for application-level audit logging using `shared/platform/audit`.
+Follow [ADR-009](../adr/0009-application-level-audit-logging.md) for application-level
+audit logging using `shared/platform/audit`.
+
+---
+
+## Task 14: Starlark & CEL Integration (Conditional)
+
+**Applies when**: The service has tenant-definable business logic (pricing rules,
+validation policies, workflow orchestration, conditional routing).
+
+**Decision framework**: If a tenant might reasonably want to customise behaviour
+without redeploying, the service needs Starlark, CEL, or both.
+
+### When to Use What
+
+| Mechanism | Use Case | Execution | Examples |
+|-----------|----------|-----------|---------|
+| **CEL** | Validation rules, conditional expressions, pricing formulas | < 10ms, no loops, pure functions | `amount > 0 && amount <= account.credit_limit` |
+| **Starlark** | Multi-step workflows, orchestration, compensation logic | < 5s, finite loops only, deterministic | Saga scripts, settlement flows |
+| **Both** | Starlark for workflow, CEL for hot-path decisions within it | Starlark calls `cel_eval()` inline | Saga with conditional pricing |
+
+### Existing Patterns as Reference
+
+Meridian has two established Starlark/CEL integration patterns. Each service context
+gets a **different set of built-ins** based on its security requirements:
+
+#### Saga Pattern (Payment Order, Current Account)
+
+**Built-ins available:**
+
+- `Decimal()`, `posting()`, `saga()`, `step()` - Core DSL
+- `resolve_account()`, `resolve_instrument()` - Reference data lookups
+- `invoke_saga()` - Child saga invocation with scope inheritance
+- `cel_eval()` - Inline CEL evaluation
+- `log()`, `fail()` - Observability and control flow
+- Service modules (auto-generated from `handlers.yaml`)
+
+**Blocked:** `load()`, `time.now()`, `random()`, `exec()`, `open()`, `http`
+
+**Reference**: `shared/pkg/saga/builtins.go`
+
+#### Valuation Pattern (Valuation Engine)
+
+**Built-ins available:**
+
+- `Decimal()`, `cel_eval()` - Financial calculations
+- Market data lookups - Read-only price/rate access
+- Mathematical functions - No side effects
+
+**Not available:** `posting()`, `resolve_account()`, `invoke_saga()` - Valuation
+scripts must not mutate ledger state or invoke workflows.
+
+**Reference**: `services/valuation/` and valuation PRD
+
+#### Choosing Built-ins for a New Service
+
+When adding Starlark support to a new service, explicitly decide which built-ins
+to expose. The principle is **least privilege by default**:
+
+```go
+// In your service's handler registration
+func RegisterHandlers(registry *saga.HandlerRegistry) {
+    // Only expose what this service context needs
+    registry.RegisterBuiltin("Decimal", saga.DecimalBuiltin)
+    registry.RegisterBuiltin("cel_eval", saga.CELEvalBuiltin)
+
+    // Service-specific handlers from handlers.yaml
+    registry.RegisterServiceModule("my_service", myHandlers)
+
+    // DO NOT register invoke_saga if this context shouldn't
+    // orchestrate workflows
+    // DO NOT register posting() if this context shouldn't
+    // write to the ledger
+}
+```
+
+**Security checklist for new Starlark contexts:**
+
+- [ ] Can scripts in this context mutate ledger state? If no, omit `posting()`
+- [ ] Can scripts orchestrate child workflows? If no, omit `invoke_saga()`
+- [ ] Can scripts resolve accounts/instruments? If no, omit `resolve_*`
+- [ ] Does the Conservation of Dimension rule apply? (Physics instruments
+  cannot produce themselves - `shared/pkg/saga/handlers.go`)
+- [ ] Are scripts tenant-scoped via `PartyScope`?
+
+### Adding Service Bindings (handlers.yaml)
+
+If your service exposes handlers callable from Starlark scripts:
+
+1. Add handler definitions to `shared/pkg/saga/schema/handlers.yaml`
+2. Implement handler functions following the pattern in
+   `docs/guides/adding-starlark-service-bindings.md`
+3. Register handlers with the saga engine
+4. Auto-generated service modules provide type-safe Starlark clients
+
+**Handler definition example:**
+
+```yaml
+handlers:
+  {service}.{operation}:
+    description: "What this handler does"
+    category: ingestion | valuation | settlement
+    params:
+      account_id:
+        type: string
+        required: true
+      amount:
+        type: Decimal
+        required: true
+    compensate: {service}.{reverse_operation}
+```
+
+**Handler categories determine security boundaries:**
+
+- **ingestion** - Imports external data (read-write to own tables only)
+- **valuation** - Computes derived values (read-only, no side effects)
+- **settlement** - Executes financial operations (full ledger access)
+
+---
+
+## Task 15: Control Plane Manifest Registration
+
+**Applies when**: The service is tenant-configurable and needs to be provisioned
+as part of the manifest apply workflow.
+
+The control plane uses a Kubernetes-style **declare-diff-plan-apply** pipeline.
+When a tenant applies a manifest, the control plane:
+
+1. **Validates** the manifest (proto constraints, CEL compilation, Starlark syntax)
+2. **Diffs** against last-applied manifest
+3. **Plans** an ordered sequence of gRPC calls
+4. **Applies** each call in phase order with idempotency keys
+
+### What to Add
+
+#### Step 15.1: Manifest Proto
+
+Add your service's configuration to `api/proto/meridian/control_plane/v1/manifest.proto`:
+
+```protobuf
+// Add message for your service's configuration
+message {Service}Config {
+  // Define tenant-configurable fields
+  repeated {Service}Rule rules = 1;
+  // CEL expressions, Starlark scripts, thresholds, etc.
+}
+
+// Add field to Manifest message
+message Manifest {
+  // ... existing fields ...
+  {Service}Config {service}_config = N;  // Next available field number
+}
+```
+
+#### Step 15.2: Validator
+
+Extend `services/control-plane/internal/validator/manifest_validator.go`:
+
+```go
+func (v *ManifestValidator) validate{Service}(
+    manifest *controlplanev1.Manifest,
+    result *ValidationResult,
+) {
+    cfg := manifest.Get{Service}Config()
+    if cfg == nil {
+        return  // Optional section, skip if absent
+    }
+    // Validate CEL expressions compile
+    // Validate Starlark scripts parse
+    // Check references to instruments/account types exist in manifest
+}
+```
+
+#### Step 15.3: Differ
+
+Add resource type and diff method to
+`services/control-plane/internal/differ/manifest_differ.go`:
+
+```go
+const Resource{Service}Config differ.ResourceType = "{service}_config"
+
+func (d *ManifestDiffer) diff{Service}(
+    lastApplied, newManifest *controlplanev1.Manifest,
+    plan *DiffPlan,
+) {
+    // Compare old vs new config, emit CREATE/UPDATE/DELETE actions
+}
+```
+
+#### Step 15.4: Planner
+
+Map to execution phases in
+`services/control-plane/internal/planner/types.go`:
+
+```go
+// Add phase constant - order determines execution sequence
+// Phases 1-5 are: Instruments, AccountTypes, ValuationRules, Sagas, SeedData
+const Phase{Service} Phase = N  // Choose based on dependencies
+
+// Add gRPC method mappings
+const Method{Service}Configure GRPCMethod = (
+    "meridian.{service}.v1.{Service}Service/Configure"
+)
+```
+
+**Phase ordering rule**: If your service depends on instruments or account types
+existing first, use a phase number > 3.
+
+### Checklist
+
+- [ ] Proto: Add config message to `manifest.proto`
+- [ ] Validator: Add `validate{Service}()` method
+- [ ] Differ: Add resource type constant and `diff{Service}()` method
+- [ ] Planner: Add phase constant, gRPC method mapping, wire into
+  `phaseForResource()` and `grpcMethodMap`
+- [ ] Tests: Unit tests for validator, differ, planner with new resource type
+- [ ] Service: Implement the `Configure` RPC that the applier will call
+
+**Reference files:**
+
+- `services/control-plane/internal/validator/manifest_validator.go`
+- `services/control-plane/internal/differ/manifest_differ.go`
+- `services/control-plane/internal/planner/types.go`
+- `services/control-plane/internal/planner/manifest_planner.go`
+
+---
+
+## Task 16: End-to-End Test Blueprint
+
+**Applies to**: All new services. E2E tests verify cross-service state consistency
+and are required before a service is considered production-ready.
+
+### Test Architecture
+
+Meridian e2e tests use **database-per-service testcontainers** to verify state
+changes across bounded contexts. Each service gets its own CockroachDB instance,
+matching the production database-per-service architecture.
+
+### Required: Cross-Service E2E Test
+
+**Location**: `tests/{service}-e2e/`
+
+Create an e2e test that exercises the service's interactions with its
+dependencies using real gRPC calls where possible.
+
+**Infrastructure setup pattern:**
+
+```go
+type e2eTestInfra struct {
+    {service}DB          *gorm.DB
+    // Add a database for each service this service interacts with
+    positionKeepingDB    *gorm.DB
+    financialAccountingDB *gorm.DB
+    // gRPC servers for real inter-service calls
+    {service}Server      *grpc.Server
+}
+
+func setupE2EInfra(t *testing.T) *e2eTestInfra {
+    infra := &e2eTestInfra{}
+
+    // Each service gets its own CockroachDB testcontainer
+    infra.{service}DB, _ = testdb.SetupCockroachDB(t, nil)
+    infra.positionKeepingDB, _ = testdb.SetupCockroachDB(t, nil)
+
+    return infra
+}
+```
+
+**Reference**: `tests/clearinge2e/` (deposit/withdrawal flows across 4 services)
+
+### Preferred: Real gRPC Between Services
+
+Where feasible, prefer standing up real gRPC servers in tests rather than only
+verifying database state. This catches serialisation issues, interceptor bugs,
+and context propagation failures that database-only tests miss.
+
+```go
+func setupGRPCServer(t *testing.T, db *gorm.DB) (
+    *grpc.Server, string, // addr
+) {
+    repo := persistence.NewRepository(db)
+    svc, _ := service.NewService(repo, slog.Default())
+
+    lis, _ := net.Listen("tcp", "localhost:0")
+    srv := grpc.NewServer(
+        // Use the same interceptors as production
+        grpc.ChainUnaryInterceptor(
+            tenant.UnaryServerInterceptor(),
+            observability.UnaryServerInterceptor(tracer),
+        ),
+    )
+    pb.Register{Service}Server(srv, svc)
+    go srv.Serve(lis)
+
+    t.Cleanup(func() { srv.GracefulStop() })
+    return srv, lis.Addr().String()
+}
+```
+
+**Use real gRPC calls for:**
+
+- Inter-service calls (service A calling service B)
+- Tenant context propagation (verify interceptors work end-to-end)
+- Error code mapping (gRPC status codes)
+- Idempotency key propagation
+
+**Use direct database verification for:**
+
+- Final state assertions (query each service's DB independently)
+- Balanced ledger checks (sum across databases = 0)
+- Audit trail verification (events in correct service DB)
+
+### Multi-Tenant Isolation Test
+
+Every e2e suite must verify tenant isolation:
+
+```go
+func TestTenantIsolation(t *testing.T) {
+    infra := setupE2EInfra(t)
+
+    // Create schemas for two tenants in each service DB
+    ctxA, tenantA := setupTestTenant(t, infra, "tenant_a")
+    ctxB, tenantB := setupTestTenant(t, infra, "tenant_b")
+
+    // Create data as tenant A
+    createEntity(t, ctxA, infra.{service}DB, tenantA.SchemaName(), ...)
+
+    // Verify tenant B cannot see tenant A's data
+    entities := listEntities(t, ctxB, infra.{service}DB, tenantB.SchemaName())
+    assert.Empty(t, entities, "tenant B must not see tenant A data")
+}
+```
+
+### Test Coverage Requirements
+
+| Category | Required | Pattern |
+|----------|----------|---------|
+| Happy path flow | Yes | Full request-to-state-change cycle via gRPC |
+| Error conditions | Yes | Validation failures, not found, version conflicts |
+| Multi-tenant isolation | Yes | Two tenants, verify data isolation |
+| Balanced ledger (if applicable) | Yes | Sum of debits = sum of credits across services |
+| Compensation (if saga-backed) | Yes | Force failure mid-flow, verify clean reversal |
+| Idempotency | Yes | Same request twice produces same result once |
+| Concurrent access | Recommended | Optimistic locking, parallel writes |
+
+### Build Tags and Running
+
+```go
+//go:build integration
+
+package {service}e2e
+```
+
+```bash
+# Run service e2e tests
+go test -v -tags=integration ./tests/{service}-e2e/... -timeout 10m
+
+# Run all e2e tests
+go test -v -tags=integration ./tests/... -timeout 15m
+```
+
+**Reference test suites:**
+
+- `tests/clearinge2e/` - Cross-service clearing flows (4 databases, deposit/withdrawal)
+- `tests/audit-e2e/` - Multi-service audit writes with tenant isolation
+- `tests/reconciliation-e2e/` - Settlement lifecycle with variance detection
+- `services/current-account/e2e/` - Saga compensation with multi-schema DB
 
 ---
 
@@ -811,8 +1177,12 @@ Follow [ADR-009](../adr/0009-application-level-audit-logging.md) for application
 
 This checklist can be used to generate Task Master tasks:
 
-1. Each numbered task (1-13) becomes a Task Master task
-2. Dependencies follow the logical order:
+1. Tasks 1-13 are the core service scaffold (always required)
+2. Tasks 14-16 are conditional based on service characteristics:
+   - Task 14 (Starlark/CEL): When service has tenant-definable logic
+   - Task 15 (Control Plane): When service is manifest-provisioned
+   - Task 16 (E2E Tests): Always required for production readiness
+3. Dependencies follow the logical order:
    - Task 2 depends on Task 1 (domain needs proto types)
    - Task 3 depends on Task 2 (persistence needs domain)
    - Task 5 depends on Task 4 (database setup needs atlas config)
@@ -820,8 +1190,11 @@ This checklist can be used to generate Task Master tasks:
    - Task 7 depends on Tasks 2, 3 (service needs domain and persistence)
    - Tasks 9-12 depend on Task 7 (deployment needs service)
    - Task 13 depends on all previous tasks
+   - Task 14 depends on Tasks 1, 7 (needs proto and service handler)
+   - Task 15 depends on Tasks 1, 7, 11 (needs proto, service, and k8s)
+   - Task 16 depends on all previous tasks
 
-3. To generate tasks for a new service:
+4. To generate tasks for a new service:
 
 ```bash
 # Copy this file, replace {service} with actual service name
@@ -839,6 +1212,7 @@ task-master parse-prd docs/guides/new-{service}-service-checklist.md
 - [ADR-005: Adapter Pattern Layer Translation](../adr/0005-adapter-pattern-layer-translation.md)
 - [ADR-006: Tilt Local Development](../adr/0006-tilt-local-development.md)
 - [ADR-015: Standard Service Directory Structure](../adr/0015-standard-service-directory-structure.md)
+- [Adding Starlark Service Bindings](adding-starlark-service-bindings.md)
 - [Circuit Breaker Usage Guide](circuit-breaker-usage.md)
 - [Testcontainers Usage Guide](testcontainers-usage.md)
 - [Database-Per-Service Migration Runbook](../runbooks/database-per-service-migration.md)

--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -953,7 +953,8 @@ message {Service}Config {
 // Add field to Manifest message
 message Manifest {
   // ... existing fields ...
-  {Service}Config {service}_config = N;  // Next available field number
+  // Check current highest field number in manifest.proto and use next
+  {Service}Config {service}_config = N;
 }
 ```
 
@@ -999,8 +1000,13 @@ Map to execution phases in
 
 ```go
 // Add phase constant - order determines execution sequence
-// Phases 1-5 are: Instruments, AccountTypes, ValuationRules, Sagas, SeedData
-const Phase{Service} Phase = N  // Choose based on dependencies
+// Existing phases (from planner/types.go):
+//   PhaseInstruments    Phase = 1
+//   PhaseAccountTypes   Phase = 2
+//   PhaseValuationRules Phase = 3
+//   PhaseSagas          Phase = 4
+//   PhaseSeedData       Phase = 5
+const Phase{Service} Phase = 6  // Next available; adjust based on dependencies
 
 // Add gRPC method mappings
 const Method{Service}Configure GRPCMethod = (
@@ -1008,8 +1014,9 @@ const Method{Service}Configure GRPCMethod = (
 )
 ```
 
-**Phase ordering rule**: If your service depends on instruments or account types
-existing first, use a phase number > 3.
+**Phase ordering rule**: Phases execute in numeric order. If your service depends
+on instruments (phase 1) or account types (phase 2), use a higher phase number.
+Most new services slot in at phase 6+.
 
 ### Checklist
 
@@ -1043,7 +1050,16 @@ matching the production database-per-service architecture.
 
 ### Required: Cross-Service E2E Test
 
-**Location**: `tests/{service}-e2e/`
+**Location**: Two patterns exist depending on scope:
+
+- `tests/{service}-e2e/` - Cross-service tests (multiple service databases,
+  verifies interactions between bounded contexts)
+- `services/{service}/e2e/` - Service-scoped tests (single service, verifies
+  internal saga compensation and schema isolation)
+
+Use `tests/` for new services that interact with other services. Use
+`services/{service}/e2e/` when testing complex internal flows (e.g., saga
+compensation) that don't require standing up other services.
 
 Create an e2e test that exercises the service's interactions with its
 dependencies using real gRPC calls where possible.
@@ -1064,8 +1080,12 @@ func setupE2EInfra(t *testing.T) *e2eTestInfra {
     infra := &e2eTestInfra{}
 
     // Each service gets its own CockroachDB testcontainer
-    infra.{service}DB, _ = testdb.SetupCockroachDB(t, nil)
-    infra.positionKeepingDB, _ = testdb.SetupCockroachDB(t, nil)
+    // Always capture and defer the cleanup function
+    var cleanup func()
+    infra.{service}DB, cleanup = testdb.SetupCockroachDB(t, nil)
+    t.Cleanup(cleanup)
+    infra.positionKeepingDB, cleanup = testdb.SetupCockroachDB(t, nil)
+    t.Cleanup(cleanup)
 
     return infra
 }
@@ -1192,7 +1212,7 @@ This checklist can be used to generate Task Master tasks:
    - Task 13 depends on all previous tasks
    - Task 14 depends on Tasks 1, 7 (needs proto and service handler)
    - Task 15 depends on Tasks 1, 7, 11 (needs proto, service, and k8s)
-   - Task 16 depends on all previous tasks
+   - Task 16 depends on Tasks 1-13, plus 14 and/or 15 if applicable
 
 4. To generate tasks for a new service:
 

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -38,6 +38,8 @@ stateDiagram-v2
 | [Starlark Saga Orchestration (Core)](starlark-saga-orchestration-core.md) | `starlark-saga-orchestration` | 24/24 done |
 | [Starlark Typed Service Clients](starlark-typed-service-clients.md) | `starlark-typed-clients` | 10/10 done |
 | [Universal Asset System](universal-asset-system.md) | `universal-asset-system` | 36/36 done |
+| [Starlark Service Bindings](starlark-service-bindings.md) | N/A (tracked across other tags) | Implemented 2026-02-04 |
+| [Starlark Testing Framework](starlark-testing-framework.md) | N/A (tracked across other tags) | Implemented 2026-02-06 |
 | [Valuation Service](valuation-service.md) | `valuation-engine` | 14/14 done |
 
 #### Paused (Deferred Items Remain)
@@ -51,6 +53,7 @@ stateDiagram-v2
 | PRD | Task Master Tag | Tasks |
 |-----|-----------------|-------|
 | [Market Data & Dynamic Pricing](market-data-dynamic-pricing.md) | `market-data-dynamic-pricing` | 10/12 done, 1 in-progress, 1 pending |
+| [Reconciliation gRPC Wiring](reconciliation-grpc-wiring.md) | `reconciliation-service` (tasks 17-23) | 0/7 done (wiring phase) |
 | [Reconciliation Service](reconciliation-service.md) | `reconciliation-service` | 16/24 done, 3 in-progress, 1 review, 4 pending |
 | [Stripe Connect](stripe-connect.md) | `stripe-connect` | 9/12 done, 1 in-progress, 2 pending |
 
@@ -62,9 +65,6 @@ stateDiagram-v2
 | [Internal Bank Account - Position Keeping Client](internal-bank-account-position-keeping-client.md) | Wire Position Keeping gRPC client in internal-bank-account service |
 | [Meridian Edge](meridian-edge.md) | Embedded modular monolith for IoT devices and browser (WASM) |
 | [Party KYC/AML Provider Integration](party-kyc-aml-provider-integration.md) | External KYC/AML provider adapter for production party onboarding |
-| [Reconciliation gRPC Wiring](reconciliation-grpc-wiring.md) | Wire 5 unimplemented reconciliation service RPCs to service layer |
-| [Starlark Service Bindings](starlark-service-bindings.md) | Service binding layer for Starlark saga scripts |
-| [Starlark Testing Framework](starlark-testing-framework.md) | Auto-validate Starlark scripts at upload time with dry-run mocks |
 
 ### Task Master PRDs (`.taskmaster/docs/`)
 

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -26,16 +26,45 @@ stateDiagram-v2
 
 ### Git-Tracked PRDs (`docs/prd/`)
 
-| PRD | Status | Task Master Tag | Tasks |
-|-----|--------|-----------------|-------|
-| [Durable Execution Engine](durable-execution-engine.md) | Implemented | `starlark-saga-orchestration` | 24/24 done |
-| [Internal Bank Account](internal-bank-account.md) | Implemented | `internal-bank-account` | 33/33 done |
-| [Market Information Management](market-information-management.md) | Implemented | `market-information-management` | 17/18 done, 1 cancelled |
-| [Meridian Edge](meridian-edge.md) | Not Started | N/A | N/A |
-| [Starlark Saga Orchestration (Core)](starlark-saga-orchestration-core.md) | Implemented | `starlark-saga-orchestration` | 24/24 done |
-| [Starlark Service Bindings](starlark-service-bindings.md) | Not Started | N/A | N/A |
-| [Starlark Typed Service Clients](starlark-typed-service-clients.md) | Implemented | `starlark-typed-clients` | 10/10 done |
-| [Universal Asset System](universal-asset-system.md) | Implemented | `universal-asset-system` | 36/36 done |
+#### Implemented
+
+| PRD | Task Master Tag | Tasks |
+|-----|-----------------|-------|
+| [Codebase Health Audit](codebase-health-audit.md) | `codebase-health-audit` | 22/22 done |
+| [Durable Execution Engine](durable-execution-engine.md) | `starlark-saga-orchestration` | 24/24 done |
+| [Internal Bank Account](internal-bank-account.md) | `internal-bank-account` | 33/33 done |
+| [Market Information Management](market-information-management.md) | `market-information-management` | 17/18 done, 1 cancelled |
+| [Production Readiness Review](production-readiness-review.md) | `production-readiness` | 10/10 done |
+| [Starlark Saga Orchestration (Core)](starlark-saga-orchestration-core.md) | `starlark-saga-orchestration` | 24/24 done |
+| [Starlark Typed Service Clients](starlark-typed-service-clients.md) | `starlark-typed-clients` | 10/10 done |
+| [Universal Asset System](universal-asset-system.md) | `universal-asset-system` | 36/36 done |
+| [Valuation Service](valuation-service.md) | `valuation-engine` | 14/14 done |
+
+#### Paused (Deferred Items Remain)
+
+| PRD | Task Master Tag | Tasks | Deferred |
+|-----|-----------------|-------|----------|
+| [Control Plane](control-plane.md) | `control-plane-completed-2026-02-10` | 12/13 done | 1 deferred |
+
+#### In Progress
+
+| PRD | Task Master Tag | Tasks |
+|-----|-----------------|-------|
+| [Market Data & Dynamic Pricing](market-data-dynamic-pricing.md) | `market-data-dynamic-pricing` | 10/12 done, 1 in-progress, 1 pending |
+| [Reconciliation Service](reconciliation-service.md) | `reconciliation-service` | 16/24 done, 3 in-progress, 1 review, 4 pending |
+| [Stripe Connect](stripe-connect.md) | `stripe-connect` | 9/12 done, 1 in-progress, 2 pending |
+
+#### Not Started
+
+| PRD | Description |
+|-----|-------------|
+| [Current Account Withdrawal Persistence](current-account-withdrawal-persistence.md) | Wire withdrawal-by-ID gRPC handlers in current-account service |
+| [Internal Bank Account - Position Keeping Client](internal-bank-account-position-keeping-client.md) | Wire Position Keeping gRPC client in internal-bank-account service |
+| [Meridian Edge](meridian-edge.md) | Embedded modular monolith for IoT devices and browser (WASM) |
+| [Party KYC/AML Provider Integration](party-kyc-aml-provider-integration.md) | External KYC/AML provider adapter for production party onboarding |
+| [Reconciliation gRPC Wiring](reconciliation-grpc-wiring.md) | Wire 5 unimplemented reconciliation service RPCs to service layer |
+| [Starlark Service Bindings](starlark-service-bindings.md) | Service binding layer for Starlark saga scripts |
+| [Starlark Testing Framework](starlark-testing-framework.md) | Auto-validate Starlark scripts at upload time with dry-run mocks |
 
 ### Task Master PRDs (`.taskmaster/docs/`)
 
@@ -54,10 +83,11 @@ These PRDs are used to generate Task Master tasks and are not tracked in git.
 | `prd-payment-order.md` | `7-payment-order` | 19/19 done |
 | `prd-99-horizon-proof.md` | `99-horizon-proof` | 10/10 done |
 | `go-compile-time-safety-prd.md` | `go-compile-time-safety-completed-2024-12-15` | 7/10 done, 3 cancelled |
-| `prd-technical-debt-remediation.md` | `tech-debt-cleanup` | 71/71 done |
+| `prd-technical-debt-remediation.md` | `tech-debt-cleanup` | 84/84 done |
 | `prd-position-keeping-balance-ownership.md` | `position-keeping-balance` | 17/17 done |
 | `prd-database-per-service.md` | `database-per-service` | 14/15 done, 1 cancelled |
 | `prd.md` (Master) | `master` | 5/5 done |
+| N/A (saga-script-versioning has no dedicated PRD) | `saga-script-versioning` | 34/34 done |
 
 #### Paused (Deferred Items Remain)
 
@@ -68,12 +98,6 @@ These PRDs are used to generate Task Master tasks and are not tracked in git.
 | `prd-audit-foundation.md` | `75-async-audit` | 19/20 done | 1 deferred |
 | `prd-bian-alignment.md` | `bian-alignment` | 6/15 done, 4 cancelled | 5 deferred |
 | `prd-iso-standards-alignment.md` | `iso-standards-alignment` | 4/15 done, 6 cancelled | 5 deferred |
-
-#### In Progress
-
-| PRD | Task Master Tag | Tasks |
-|-----|-----------------|-------|
-| N/A (saga-script-versioning has no dedicated PRD) | `saga-script-versioning` | 2/3 done, 1 in-progress |
 
 #### Implemented Under Other Tags (No Dedicated Tag)
 
@@ -161,11 +185,36 @@ material.
 - [Internal Bank Account](internal-bank-account.md) - BIAN service for clearing, nostro/vostro accounts
 - [Market Information Management](market-information-management.md) - BIAN service for market data and pricing
 - [Starlark Typed Service Clients](starlark-typed-service-clients.md) - Type-safe service handlers for saga orchestration
+- [Valuation Service](valuation-service.md) - BIAN-native multi-asset valuation engine
 
 ### Execution Engine
 
 - [Starlark Saga Orchestration (Core)](starlark-saga-orchestration-core.md) - Runtime-configurable saga definitions
 - [Durable Execution Engine](durable-execution-engine.md) - Resilience layer for saga execution
+- [Starlark Service Bindings](starlark-service-bindings.md) - Service binding layer for Starlark saga scripts
+- [Starlark Testing Framework](starlark-testing-framework.md) - Auto-validate Starlark scripts at upload time
+
+### Settlement & Reconciliation
+
+- [Reconciliation Service](reconciliation-service.md) - BIAN-native settlement lifecycle and variance detection
+- [Stripe Connect](stripe-connect.md) - Payment-reconciliation-settlement loop with Stripe
+- [Reconciliation gRPC Wiring](reconciliation-grpc-wiring.md) - Wire reconciliation RPCs to service layer
+
+### Market Data & Pricing
+
+- [Market Data & Dynamic Pricing](market-data-dynamic-pricing.md) - Hierarchical reference data and Starlark-based forecasting
+
+### Operations & SaaS
+
+- [Control Plane](control-plane.md) - SaaS operations layer for manifest management
+- [Codebase Health Audit](codebase-health-audit.md) - Remediation for documentation, CI/CD, and code hygiene
+- [Production Readiness Review](production-readiness-review.md) - Audit and remediation for production gaps
+
+### Service Wiring (Micro-PRDs)
+
+- [Current Account Withdrawal Persistence](current-account-withdrawal-persistence.md) - Wire withdrawal-by-ID gRPC handlers
+- [IBA - Position Keeping Client](internal-bank-account-position-keeping-client.md) - Wire PK gRPC client in IBA service
+- [Party KYC/AML Provider Integration](party-kyc-aml-provider-integration.md) - External KYC/AML provider adapter
 
 ### Deployment Targets
 


### PR DESCRIPTION
## Summary

- Synchronize PRD README with actual Task Master tag statuses across all 32 tags (692 tasks total)
- Add 12 new git-tracked PRDs that were missing from the index
- Add 3 services to base README (reconciliation, control-plane, forecasting)
- Extend new BIAN service checklist with 3 conditional tasks for established patterns

## Changes

### `docs/prd/README.md`

**Restructured Git-Tracked PRDs** from flat table into status-grouped sections:

| Status | Count | PRDs |
|--------|------:|------|
| Implemented | 9 | +3 new (Codebase Health Audit, Production Readiness, Valuation Service) |
| Paused | 1 | +1 new (Control Plane - 12/13 done, 1 deferred) |
| In Progress | 3 | +3 new (Market Data & Dynamic Pricing, Reconciliation Service, Stripe Connect) |
| Not Started | 7 | +5 new (CA Withdrawal, IBA-PK Client, Party KYC/AML, Recon gRPC Wiring, Starlark Testing) |

**Task Master PRD updates:**
- `saga-script-versioning`: Moved from In Progress (2/3) to Implemented (34/34 done)
- `tech-debt-cleanup`: Updated count from 71/71 to 84/84

**Categories section** expanded from 3 to 7 categories.

### `README.md`

- Add Reconciliation to BIAN Service Domains table
- Add ControlPlane and Forecasting to Infrastructure Services table
- Add all 3 to project structure tree

### `docs/guides/new-bian-service-checklist.md`

Added 3 conditional tasks (Tasks 14-16) to the service bootstrap checklist:

**Task 14: Starlark & CEL Integration** - When to use Starlark vs CEL vs both, per-context
built-in security model (saga context gets `posting()`/`invoke_saga()`/`resolve_*`, valuation
context gets read-only math only), handler category security boundaries
(ingestion/valuation/settlement), and checklist for deciding which built-ins to expose.

**Task 15: Control Plane Manifest Registration** - Steps to hook a new service into the
declare-diff-plan-apply pipeline: manifest proto definition, validator extension, differ
resource type, planner phase ordering and gRPC method mapping.

**Task 16: E2E Test Blueprint** - Required cross-service tests using database-per-service
testcontainers with real gRPC between services where feasible. Includes multi-tenant isolation
test template, coverage requirements table (happy path, errors, isolation, balanced ledger,
compensation, idempotency), and references to existing test suites.

Updated dependency map to include Tasks 14-16.

## Test plan

- [ ] Verify all PRD links resolve correctly
- [ ] Verify markdown renders correctly on GitHub
- [ ] Cross-check task counts against `task-master tags list`
- [ ] Review checklist Tasks 14-16 against actual codebase patterns