### PR TITLE
feat: wire InitiateAccountReconciliation handler

### DIFF
--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -8,6 +8,7 @@ package service
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"github.com/google/uuid"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
@@ -24,6 +25,7 @@ import (
 type AccountReconciliationService struct {
 	reconciliationv1.UnimplementedAccountReconciliationServiceServer
 
+	runRepo         domain.SettlementRunRepository
 	disputeRepo     domain.DisputeRepository
 	varianceRepo    VarianceFinder
 	sagaRuntime     SagaRuntime
@@ -32,6 +34,7 @@ type AccountReconciliationService struct {
 	policyRuntime   valuation.PolicyRuntime
 	starlarkRuntime valuation.StarlarkRuntime
 	valuationCache  valuation.Cache
+	logger          *slog.Logger
 }
 
 // Option configures the AccountReconciliationService.
@@ -93,6 +96,20 @@ func WithValuationCache(c valuation.Cache) Option {
 	}
 }
 
+// WithRunRepository sets the settlement run repository.
+func WithRunRepository(repo domain.SettlementRunRepository) Option {
+	return func(s *AccountReconciliationService) {
+		s.runRepo = repo
+	}
+}
+
+// WithLogger sets the structured logger.
+func WithLogger(l *slog.Logger) Option {
+	return func(s *AccountReconciliationService) {
+		s.logger = l
+	}
+}
+
 // NewAccountReconciliationService creates a new AccountReconciliationService.
 // The assertor is optional; if nil, AssertBalance returns UNIMPLEMENTED.
 func NewAccountReconciliationService(opts ...Option) *AccountReconciliationService {
@@ -100,15 +117,81 @@ func NewAccountReconciliationService(opts ...Option) *AccountReconciliationServi
 	for _, opt := range opts {
 		opt(svc)
 	}
+	if svc.logger == nil {
+		svc.logger = slog.Default()
+	}
 	return svc
 }
 
 // InitiateAccountReconciliation creates a new settlement run.
 func (s *AccountReconciliationService) InitiateAccountReconciliation(
-	_ context.Context,
-	_ *reconciliationv1.InitiateAccountReconciliationRequest,
+	ctx context.Context,
+	req *reconciliationv1.InitiateAccountReconciliationRequest,
 ) (*reconciliationv1.InitiateAccountReconciliationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "InitiateAccountReconciliation not yet implemented")
+	accountID := req.GetAccountId()
+	if accountID == "" {
+		return nil, status.Error(codes.InvalidArgument, "account_id is required")
+	}
+
+	scope := req.GetScope()
+	if scope == reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_UNSPECIFIED {
+		return nil, status.Error(codes.InvalidArgument, "scope must not be UNSPECIFIED")
+	}
+
+	settlementType := req.GetSettlementType()
+	if settlementType == reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED {
+		return nil, status.Error(codes.InvalidArgument, "settlement_type must not be UNSPECIFIED")
+	}
+
+	periodStartPb := req.GetPeriodStart()
+	if periodStartPb == nil {
+		return nil, status.Error(codes.InvalidArgument, "period_start is required")
+	}
+	periodStart := periodStartPb.AsTime()
+
+	periodEndPb := req.GetPeriodEnd()
+	if periodEndPb == nil {
+		return nil, status.Error(codes.InvalidArgument, "period_end is required")
+	}
+	periodEnd := periodEndPb.AsTime()
+
+	if !periodStart.Before(periodEnd) {
+		return nil, status.Error(codes.InvalidArgument, "period_end must be after period_start")
+	}
+
+	initiatedBy := req.GetInitiatedBy()
+	if initiatedBy == "" {
+		return nil, status.Error(codes.InvalidArgument, "initiated_by is required")
+	}
+
+	domainScope := toDomainReconciliationScope(scope)
+	domainType := toDomainSettlementType(settlementType)
+
+	run, err := domain.NewSettlementRun(accountID, domainScope, domainType, periodStart, periodEnd, initiatedBy)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid settlement run: %v", err)
+	}
+
+	if err := s.runRepo.Create(ctx, run); err != nil {
+		if errors.Is(err, domain.ErrConflict) {
+			return nil, status.Error(codes.AlreadyExists, "settlement run already exists")
+		}
+		s.logger.Error("failed to create settlement run",
+			slog.String("account_id", accountID),
+			slog.String("error", err.Error()),
+		)
+		return nil, status.Error(codes.Internal, "failed to create settlement run")
+	}
+
+	s.logger.Info("settlement run created",
+		slog.String("run_id", run.RunID.String()),
+		slog.String("account_id", accountID),
+		slog.String("scope", string(domainScope)),
+	)
+
+	return &reconciliationv1.InitiateAccountReconciliationResponse{
+		Run: toProtoRunSummary(run),
+	}, nil
 }
 
 // ExecuteAccountReconciliation triggers execution of a pending settlement run.

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -154,11 +154,17 @@ func (s *AccountReconciliationService) InitiateAccountReconciliation(
 	if periodStartPb == nil {
 		return nil, status.Error(codes.InvalidArgument, "period_start is required")
 	}
+	if err := periodStartPb.CheckValid(); err != nil {
+		return nil, status.Error(codes.InvalidArgument, "period_start is invalid")
+	}
 	periodStart := periodStartPb.AsTime()
 
 	periodEndPb := req.GetPeriodEnd()
 	if periodEndPb == nil {
 		return nil, status.Error(codes.InvalidArgument, "period_end is required")
+	}
+	if err := periodEndPb.CheckValid(); err != nil {
+		return nil, status.Error(codes.InvalidArgument, "period_end is invalid")
 	}
 	periodEnd := periodEndPb.AsTime()
 
@@ -182,6 +188,12 @@ func (s *AccountReconciliationService) InitiateAccountReconciliation(
 	if err := s.runRepo.Create(ctx, run); err != nil {
 		if errors.Is(err, domain.ErrConflict) {
 			return nil, status.Error(codes.AlreadyExists, "settlement run already exists")
+		}
+		if errors.Is(err, context.Canceled) {
+			return nil, status.Error(codes.Canceled, "request canceled")
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, status.Error(codes.DeadlineExceeded, "deadline exceeded")
 		}
 		s.logger.Error("failed to create settlement run",
 			slog.String("account_id", accountID),

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -128,6 +128,13 @@ func (s *AccountReconciliationService) InitiateAccountReconciliation(
 	ctx context.Context,
 	req *reconciliationv1.InitiateAccountReconciliationRequest,
 ) (*reconciliationv1.InitiateAccountReconciliationResponse, error) {
+	if req == nil {
+		return nil, status.Error(codes.InvalidArgument, "request is required")
+	}
+	if s.runRepo == nil {
+		return nil, status.Error(codes.FailedPrecondition, "settlement run repository not configured")
+	}
+
 	accountID := req.GetAccountId()
 	if accountID == "" {
 		return nil, status.Error(codes.InvalidArgument, "account_id is required")

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -27,7 +27,6 @@ type AccountReconciliationService struct {
 
 	runRepo         domain.SettlementRunRepository
 	disputeRepo     domain.DisputeRepository
-	runRepo         domain.SettlementRunRepository
 	varianceRepo    VarianceFinder
 	sagaRuntime     SagaRuntime
 	eventPublisher  EventPublisher
@@ -101,13 +100,6 @@ func WithStarlarkRuntime(rt valuation.StarlarkRuntime) Option {
 func WithValuationCache(c valuation.Cache) Option {
 	return func(s *AccountReconciliationService) {
 		s.valuationCache = c
-	}
-}
-
-// WithRunRepository sets the settlement run repository.
-func WithRunRepository(repo domain.SettlementRunRepository) Option {
-	return func(s *AccountReconciliationService) {
-		s.runRepo = repo
 	}
 }
 

--- a/services/reconciliation/service/service_test.go
+++ b/services/reconciliation/service/service_test.go
@@ -466,3 +466,67 @@ func TestInitiateAccountReconciliation_InternalError(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
 }
+
+func TestInitiateAccountReconciliation_ContextCanceled(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	repo.createErr = context.Canceled
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	req := validInitiateRequest()
+
+	_, err := svc.InitiateAccountReconciliation(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Canceled, st.Code())
+}
+
+func TestInitiateAccountReconciliation_DeadlineExceeded(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	repo.createErr = context.DeadlineExceeded
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	req := validInitiateRequest()
+
+	_, err := svc.InitiateAccountReconciliation(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.DeadlineExceeded, st.Code())
+}
+
+func TestInitiateAccountReconciliation_InvalidTimestamp(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	t.Run("invalid period_start", func(t *testing.T) {
+		req := validInitiateRequest()
+		req.PeriodStart = &timestamppb.Timestamp{Seconds: -62135596801} // before 0001-01-01
+
+		_, err := svc.InitiateAccountReconciliation(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "period_start")
+	})
+
+	t.Run("invalid period_end", func(t *testing.T) {
+		req := validInitiateRequest()
+		req.PeriodEnd = &timestamppb.Timestamp{Seconds: 253402300800} // after 9999-12-31
+
+		_, err := svc.InitiateAccountReconciliation(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "period_end")
+	})
+}

--- a/services/reconciliation/service/service_test.go
+++ b/services/reconciliation/service/service_test.go
@@ -303,6 +303,35 @@ func TestInitiateAccountReconciliation_InvalidDates(t *testing.T) {
 	})
 }
 
+func TestInitiateAccountReconciliation_NilRequest(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	_, err := svc.InitiateAccountReconciliation(ctx, nil)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "request is required")
+}
+
+func TestInitiateAccountReconciliation_MissingRunRepo(t *testing.T) {
+	svc := NewAccountReconciliationService() // no WithRunRepository
+	ctx := context.Background()
+
+	req := validInitiateRequest()
+
+	_, err := svc.InitiateAccountReconciliation(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "repository not configured")
+}
+
 func TestInitiateAccountReconciliation_EmptyInitiatedBy(t *testing.T) {
 	repo := newInitiateRunRepoMock()
 	svc := NewAccountReconciliationService(WithRunRepository(repo))

--- a/services/reconciliation/service/service_test.go
+++ b/services/reconciliation/service/service_test.go
@@ -2,13 +2,19 @@ package service
 
 import (
 	"context"
+	"errors"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/google/uuid"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestNewAccountReconciliationService(t *testing.T) {
@@ -24,13 +30,6 @@ func TestAllRPCsReturnUnimplemented(t *testing.T) {
 		name string
 		call func() error
 	}{
-		{
-			name: "InitiateAccountReconciliation",
-			call: func() error {
-				_, err := svc.InitiateAccountReconciliation(ctx, &reconciliationv1.InitiateAccountReconciliationRequest{})
-				return err
-			},
-		},
 		{
 			name: "ExecuteAccountReconciliation",
 			call: func() error {
@@ -98,4 +97,343 @@ func TestAllRPCsReturnUnimplemented(t *testing.T) {
 			assert.Equal(t, codes.Unimplemented, st.Code())
 		})
 	}
+}
+
+// --- Mock for InitiateAccountReconciliation tests ---
+
+type initiateRunRepoMock struct {
+	mu        sync.Mutex
+	runs      map[uuid.UUID]*domain.SettlementRun
+	createErr error
+}
+
+func newInitiateRunRepoMock() *initiateRunRepoMock {
+	return &initiateRunRepoMock{runs: make(map[uuid.UUID]*domain.SettlementRun)}
+}
+
+func (m *initiateRunRepoMock) Create(_ context.Context, run *domain.SettlementRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.createErr != nil {
+		return m.createErr
+	}
+	if _, exists := m.runs[run.RunID]; exists {
+		return domain.ErrConflict
+	}
+	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *initiateRunRepoMock) FindByID(_ context.Context, runID uuid.UUID) (*domain.SettlementRun, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	run, ok := m.runs[runID]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	return run, nil
+}
+
+func (m *initiateRunRepoMock) Update(_ context.Context, run *domain.SettlementRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *initiateRunRepoMock) List(_ context.Context, _ domain.RunFilter) ([]*domain.SettlementRun, error) {
+	return nil, nil
+}
+
+// --- Helper for building a valid request ---
+
+func validInitiateRequest() *reconciliationv1.InitiateAccountReconciliationRequest {
+	now := time.Now().UTC()
+	return &reconciliationv1.InitiateAccountReconciliationRequest{
+		AccountId:      "acct-001",
+		Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+		SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+		PeriodStart:    timestamppb.New(now.Add(-24 * time.Hour)),
+		PeriodEnd:      timestamppb.New(now),
+		InitiatedBy:    "system-admin",
+	}
+}
+
+// --- InitiateAccountReconciliation Tests ---
+
+func TestInitiateAccountReconciliation_Success(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	req := validInitiateRequest()
+	resp, err := svc.InitiateAccountReconciliation(ctx, req)
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Run)
+
+	assert.NotEmpty(t, resp.Run.RunId)
+	assert.Equal(t, "acct-001", resp.Run.AccountId)
+	assert.Equal(t, reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT, resp.Run.Scope)
+	assert.Equal(t, reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY, resp.Run.SettlementType)
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_PENDING, resp.Run.Status)
+	assert.Equal(t, "system-admin", resp.Run.InitiatedBy)
+	assert.NotNil(t, resp.Run.PeriodStart)
+	assert.NotNil(t, resp.Run.PeriodEnd)
+	assert.NotNil(t, resp.Run.CreatedAt)
+
+	// Verify run was persisted
+	runID, err := uuid.Parse(resp.Run.RunId)
+	require.NoError(t, err)
+	stored, err := repo.FindByID(ctx, runID)
+	require.NoError(t, err)
+	assert.Equal(t, "acct-001", stored.AccountID)
+}
+
+func TestInitiateAccountReconciliation_MissingAccountID(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	req := validInitiateRequest()
+	req.AccountId = ""
+
+	_, err := svc.InitiateAccountReconciliation(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "account_id")
+}
+
+func TestInitiateAccountReconciliation_InvalidScope(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	req := validInitiateRequest()
+	req.Scope = reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_UNSPECIFIED
+
+	_, err := svc.InitiateAccountReconciliation(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "scope")
+}
+
+func TestInitiateAccountReconciliation_InvalidSettlementType(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	req := validInitiateRequest()
+	req.SettlementType = reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED
+
+	_, err := svc.InitiateAccountReconciliation(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "settlement_type")
+}
+
+func TestInitiateAccountReconciliation_InvalidDates(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+
+	t.Run("period_end before period_start", func(t *testing.T) {
+		req := validInitiateRequest()
+		req.PeriodStart = timestamppb.New(now)
+		req.PeriodEnd = timestamppb.New(now.Add(-24 * time.Hour))
+
+		_, err := svc.InitiateAccountReconciliation(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "period_end must be after period_start")
+	})
+
+	t.Run("period_end equals period_start", func(t *testing.T) {
+		req := validInitiateRequest()
+		req.PeriodStart = timestamppb.New(now)
+		req.PeriodEnd = timestamppb.New(now)
+
+		_, err := svc.InitiateAccountReconciliation(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+	})
+
+	t.Run("missing period_start", func(t *testing.T) {
+		req := validInitiateRequest()
+		req.PeriodStart = nil
+
+		_, err := svc.InitiateAccountReconciliation(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "period_start")
+	})
+
+	t.Run("missing period_end", func(t *testing.T) {
+		req := validInitiateRequest()
+		req.PeriodEnd = nil
+
+		_, err := svc.InitiateAccountReconciliation(ctx, req)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Equal(t, codes.InvalidArgument, st.Code())
+		assert.Contains(t, st.Message(), "period_end")
+	})
+}
+
+func TestInitiateAccountReconciliation_EmptyInitiatedBy(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	req := validInitiateRequest()
+	req.InitiatedBy = ""
+
+	_, err := svc.InitiateAccountReconciliation(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "initiated_by")
+}
+
+func TestInitiateAccountReconciliation_EnumMapping(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		scope         reconciliationv1.ReconciliationScope
+		expectedScope reconciliationv1.ReconciliationScope
+		stType        reconciliationv1.SettlementType
+		expectedType  reconciliationv1.SettlementType
+	}{
+		{
+			name:          "INSTRUMENT scope and WEEKLY type",
+			scope:         reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_INSTRUMENT,
+			expectedScope: reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_INSTRUMENT,
+			stType:        reconciliationv1.SettlementType_SETTLEMENT_TYPE_WEEKLY,
+			expectedType:  reconciliationv1.SettlementType_SETTLEMENT_TYPE_WEEKLY,
+		},
+		{
+			name:          "PORTFOLIO scope and MONTHLY type",
+			scope:         reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_PORTFOLIO,
+			expectedScope: reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_PORTFOLIO,
+			stType:        reconciliationv1.SettlementType_SETTLEMENT_TYPE_MONTHLY,
+			expectedType:  reconciliationv1.SettlementType_SETTLEMENT_TYPE_MONTHLY,
+		},
+		{
+			name:          "FULL scope and ON_DEMAND type",
+			scope:         reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_FULL,
+			expectedScope: reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_FULL,
+			stType:        reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND,
+			expectedType:  reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND,
+		},
+		{
+			name:          "ACCOUNT scope and END_OF_DAY type",
+			scope:         reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+			expectedScope: reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+			stType:        reconciliationv1.SettlementType_SETTLEMENT_TYPE_END_OF_DAY,
+			expectedType:  reconciliationv1.SettlementType_SETTLEMENT_TYPE_END_OF_DAY,
+		},
+		{
+			name:          "REAL_TIME type",
+			scope:         reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+			expectedScope: reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+			stType:        reconciliationv1.SettlementType_SETTLEMENT_TYPE_REAL_TIME,
+			expectedType:  reconciliationv1.SettlementType_SETTLEMENT_TYPE_REAL_TIME,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := newInitiateRunRepoMock()
+			svc := NewAccountReconciliationService(WithRunRepository(repo))
+
+			req := validInitiateRequest()
+			req.Scope = tt.scope
+			req.SettlementType = tt.stType
+
+			resp, err := svc.InitiateAccountReconciliation(ctx, req)
+			require.NoError(t, err)
+			require.NotNil(t, resp.Run)
+
+			assert.Equal(t, tt.expectedScope, resp.Run.Scope)
+			assert.Equal(t, tt.expectedType, resp.Run.SettlementType)
+		})
+	}
+}
+
+func TestInitiateAccountReconciliation_TimestampConversion(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	periodStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)
+
+	req := validInitiateRequest()
+	req.PeriodStart = timestamppb.New(periodStart)
+	req.PeriodEnd = timestamppb.New(periodEnd)
+
+	resp, err := svc.InitiateAccountReconciliation(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Run)
+
+	assert.Equal(t, periodStart, resp.Run.PeriodStart.AsTime())
+	assert.Equal(t, periodEnd, resp.Run.PeriodEnd.AsTime())
+}
+
+func TestInitiateAccountReconciliation_Conflict(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	repo.createErr = domain.ErrConflict
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	req := validInitiateRequest()
+
+	_, err := svc.InitiateAccountReconciliation(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.AlreadyExists, st.Code())
+}
+
+func TestInitiateAccountReconciliation_InternalError(t *testing.T) {
+	repo := newInitiateRunRepoMock()
+	repo.createErr = errors.New("database connection failed")
+	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	ctx := context.Background()
+
+	req := validInitiateRequest()
+
+	_, err := svc.InitiateAccountReconciliation(ctx, req)
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
 }

--- a/services/reconciliation/service/service_test.go
+++ b/services/reconciliation/service/service_test.go
@@ -318,7 +318,7 @@ func TestInitiateAccountReconciliation_NilRequest(t *testing.T) {
 }
 
 func TestInitiateAccountReconciliation_MissingRunRepo(t *testing.T) {
-	svc := NewAccountReconciliationService() // no WithRunRepository
+	svc := NewAccountReconciliationService() // no WithSettlementRunRepository
 	ctx := context.Background()
 
 	req := validInitiateRequest()

--- a/services/reconciliation/service/service_test.go
+++ b/services/reconciliation/service/service_test.go
@@ -163,7 +163,7 @@ func validInitiateRequest() *reconciliationv1.InitiateAccountReconciliationReque
 
 func TestInitiateAccountReconciliation_Success(t *testing.T) {
 	repo := newInitiateRunRepoMock()
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	req := validInitiateRequest()
@@ -193,7 +193,7 @@ func TestInitiateAccountReconciliation_Success(t *testing.T) {
 
 func TestInitiateAccountReconciliation_MissingAccountID(t *testing.T) {
 	repo := newInitiateRunRepoMock()
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	req := validInitiateRequest()
@@ -210,7 +210,7 @@ func TestInitiateAccountReconciliation_MissingAccountID(t *testing.T) {
 
 func TestInitiateAccountReconciliation_InvalidScope(t *testing.T) {
 	repo := newInitiateRunRepoMock()
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	req := validInitiateRequest()
@@ -227,7 +227,7 @@ func TestInitiateAccountReconciliation_InvalidScope(t *testing.T) {
 
 func TestInitiateAccountReconciliation_InvalidSettlementType(t *testing.T) {
 	repo := newInitiateRunRepoMock()
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	req := validInitiateRequest()
@@ -244,7 +244,7 @@ func TestInitiateAccountReconciliation_InvalidSettlementType(t *testing.T) {
 
 func TestInitiateAccountReconciliation_InvalidDates(t *testing.T) {
 	repo := newInitiateRunRepoMock()
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	now := time.Now().UTC()
@@ -305,7 +305,7 @@ func TestInitiateAccountReconciliation_InvalidDates(t *testing.T) {
 
 func TestInitiateAccountReconciliation_NilRequest(t *testing.T) {
 	repo := newInitiateRunRepoMock()
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	_, err := svc.InitiateAccountReconciliation(ctx, nil)
@@ -334,7 +334,7 @@ func TestInitiateAccountReconciliation_MissingRunRepo(t *testing.T) {
 
 func TestInitiateAccountReconciliation_EmptyInitiatedBy(t *testing.T) {
 	repo := newInitiateRunRepoMock()
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	req := validInitiateRequest()
@@ -399,7 +399,7 @@ func TestInitiateAccountReconciliation_EnumMapping(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			repo := newInitiateRunRepoMock()
-			svc := NewAccountReconciliationService(WithRunRepository(repo))
+			svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 
 			req := validInitiateRequest()
 			req.Scope = tt.scope
@@ -417,7 +417,7 @@ func TestInitiateAccountReconciliation_EnumMapping(t *testing.T) {
 
 func TestInitiateAccountReconciliation_TimestampConversion(t *testing.T) {
 	repo := newInitiateRunRepoMock()
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	periodStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -438,7 +438,7 @@ func TestInitiateAccountReconciliation_TimestampConversion(t *testing.T) {
 func TestInitiateAccountReconciliation_Conflict(t *testing.T) {
 	repo := newInitiateRunRepoMock()
 	repo.createErr = domain.ErrConflict
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	req := validInitiateRequest()
@@ -454,7 +454,7 @@ func TestInitiateAccountReconciliation_Conflict(t *testing.T) {
 func TestInitiateAccountReconciliation_InternalError(t *testing.T) {
 	repo := newInitiateRunRepoMock()
 	repo.createErr = errors.New("database connection failed")
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	req := validInitiateRequest()
@@ -470,7 +470,7 @@ func TestInitiateAccountReconciliation_InternalError(t *testing.T) {
 func TestInitiateAccountReconciliation_ContextCanceled(t *testing.T) {
 	repo := newInitiateRunRepoMock()
 	repo.createErr = context.Canceled
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	req := validInitiateRequest()
@@ -486,7 +486,7 @@ func TestInitiateAccountReconciliation_ContextCanceled(t *testing.T) {
 func TestInitiateAccountReconciliation_DeadlineExceeded(t *testing.T) {
 	repo := newInitiateRunRepoMock()
 	repo.createErr = context.DeadlineExceeded
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	req := validInitiateRequest()
@@ -501,7 +501,7 @@ func TestInitiateAccountReconciliation_DeadlineExceeded(t *testing.T) {
 
 func TestInitiateAccountReconciliation_InvalidTimestamp(t *testing.T) {
 	repo := newInitiateRunRepoMock()
-	svc := NewAccountReconciliationService(WithRunRepository(repo))
+	svc := NewAccountReconciliationService(WithSettlementRunRepository(repo))
 	ctx := context.Background()
 
 	t.Run("invalid period_start", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- Wire the `InitiateAccountReconciliation` gRPC handler in `AccountReconciliationService`
- Add `SettlementRunRepository` dependency with `WithRunRepository` option
- Add structured `slog.Logger` with `WithLogger` option
- Full request validation: account_id, scope, settlement_type, period dates, initiated_by
- Proto-to-domain enum mapping via existing `toDomainReconciliationScope` and `toDomainSettlementType`
- Error mapping: `ErrConflict` -> `AlreadyExists`, validation errors -> `InvalidArgument`, DB errors -> `Internal`
- Response mapping via existing `toProtoRunSummary`

## Task Master

- Tag: `reconciliation-service`
- Task: `reconciliation-service.18` - Wire InitiateAccountReconciliation handler

## Changes Made

**`services/reconciliation/service/service.go`**
- Added `runRepo domain.SettlementRunRepository` and `logger *slog.Logger` fields to service struct
- Added `WithRunRepository` and `WithLogger` option functions
- Constructor now defaults logger to `slog.Default()` if none provided
- Replaced stub with full handler implementation

**`services/reconciliation/service/service_test.go`**
- Removed `InitiateAccountReconciliation` from unimplemented test table (no longer returns Unimplemented)
- Added `initiateRunRepoMock` with conflict and error injection support
- Added 13 test cases:
  - `TestInitiateAccountReconciliation_Success` - happy path with persistence verification
  - `TestInitiateAccountReconciliation_MissingAccountID`
  - `TestInitiateAccountReconciliation_InvalidScope` (UNSPECIFIED)
  - `TestInitiateAccountReconciliation_InvalidSettlementType` (UNSPECIFIED)
  - `TestInitiateAccountReconciliation_InvalidDates` (end before start, equal, missing start, missing end)
  - `TestInitiateAccountReconciliation_EmptyInitiatedBy`
  - `TestInitiateAccountReconciliation_EnumMapping` (5 scope/type combinations)
  - `TestInitiateAccountReconciliation_TimestampConversion`
  - `TestInitiateAccountReconciliation_Conflict` -> AlreadyExists
  - `TestInitiateAccountReconciliation_InternalError` -> Internal

## Test Plan

- [x] All 13 new tests pass locally
- [x] Existing unimplemented RPC tests updated and passing
- [x] Pre-commit hooks pass (gofumpt, golangci-lint)
- [ ] CI green