### PR TITLE
feat: Add payment method gRPC service extensions to Party service

### DIFF
--- a/api/proto/meridian/party/v1/party.proto
+++ b/api/proto/meridian/party/v1/party.proto
@@ -632,6 +632,189 @@ message RetrieveBankRelationsResponse {
   google.protobuf.Timestamp updated_at = 5;
 }
 
+// --- Business Qualifier: PaymentMethods ---
+
+// PaymentMethodProvider defines supported external payment providers.
+enum PaymentMethodProvider {
+  // PAYMENT_METHOD_PROVIDER_UNSPECIFIED means the provider is unknown.
+  PAYMENT_METHOD_PROVIDER_UNSPECIFIED = 0;
+  // PAYMENT_METHOD_PROVIDER_STRIPE is the Stripe payment provider.
+  PAYMENT_METHOD_PROVIDER_STRIPE = 1;
+}
+
+// PaymentMethodType defines the type of payment method.
+enum PaymentMethodType {
+  // PAYMENT_METHOD_TYPE_UNSPECIFIED means the type is unknown.
+  PAYMENT_METHOD_TYPE_UNSPECIFIED = 0;
+  // PAYMENT_METHOD_TYPE_CARD is a credit or debit card.
+  PAYMENT_METHOD_TYPE_CARD = 1;
+  // PAYMENT_METHOD_TYPE_BANK_ACCOUNT is a bank account (ACH, wire).
+  PAYMENT_METHOD_TYPE_BANK_ACCOUNT = 2;
+  // PAYMENT_METHOD_TYPE_SEPA is a SEPA direct debit mandate.
+  PAYMENT_METHOD_TYPE_SEPA = 3;
+}
+
+// PaymentMethodStatus defines the lifecycle state of a payment method.
+enum PaymentMethodStatus {
+  // PAYMENT_METHOD_STATUS_UNSPECIFIED means the status is unknown.
+  PAYMENT_METHOD_STATUS_UNSPECIFIED = 0;
+  // PAYMENT_METHOD_STATUS_ACTIVE means the payment method is usable.
+  PAYMENT_METHOD_STATUS_ACTIVE = 1;
+  // PAYMENT_METHOD_STATUS_EXPIRED means the payment method has expired.
+  PAYMENT_METHOD_STATUS_EXPIRED = 2;
+  // PAYMENT_METHOD_STATUS_REMOVED means the payment method has been soft-deleted.
+  PAYMENT_METHOD_STATUS_REMOVED = 3;
+}
+
+// PartyPaymentMethod represents a tokenized payment method linked to a party.
+message PartyPaymentMethod {
+  // id is the unique identifier for this payment method.
+  string id = 1;
+
+  // party_id is the party this payment method belongs to.
+  string party_id = 2;
+
+  // provider is the external payment provider.
+  PaymentMethodProvider provider = 3;
+
+  // provider_customer_id is the provider's customer token (e.g., cus_xxx).
+  string provider_customer_id = 4;
+
+  // provider_method_id is the provider's payment method token (e.g., pm_xxx).
+  string provider_method_id = 5;
+
+  // method_type is the type of payment method.
+  PaymentMethodType method_type = 6;
+
+  // is_default indicates whether this is the party's default payment method.
+  bool is_default = 7;
+
+  // metadata contains non-sensitive display information (last4, brand, etc.).
+  map<string, string> metadata = 8;
+
+  // status is the current lifecycle state.
+  PaymentMethodStatus status = 9;
+
+  // version is for optimistic locking.
+  int64 version = 10;
+
+  // created_at is when the payment method was created.
+  google.protobuf.Timestamp created_at = 11;
+
+  // updated_at is when the payment method was last updated.
+  google.protobuf.Timestamp updated_at = 12;
+}
+
+// AddPaymentMethodRequest is the request to add a payment method to a party.
+message AddPaymentMethodRequest {
+  // party_id is the party to add the payment method to.
+  string party_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // provider is the external payment provider.
+  PaymentMethodProvider provider = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // provider_customer_id is the provider's customer token (e.g., cus_xxx).
+  string provider_customer_id = 3 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // provider_method_id is the provider's payment method token (e.g., pm_xxx).
+  string provider_method_id = 4 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 255
+  }];
+
+  // method_type is the type of payment method.
+  PaymentMethodType method_type = 5 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+
+  // is_default indicates whether this should be the party's default payment method.
+  bool is_default = 6;
+
+  // metadata contains non-sensitive display information (last4, brand, etc.).
+  map<string, string> metadata = 7;
+}
+
+// RemovePaymentMethodRequest is the request to remove (soft-delete) a payment method.
+message RemovePaymentMethodRequest {
+  // id is the unique identifier of the payment method to remove.
+  string id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+
+  // version is for optimistic locking.
+  int64 version = 2 [(buf.validate.field).int64 = {gte: 1}];
+}
+
+// RemovePaymentMethodResponse is the response after removing a payment method.
+message RemovePaymentMethodResponse {}
+
+// SetDefaultPaymentMethodRequest is the request to set a payment method as default.
+message SetDefaultPaymentMethodRequest {
+  // id is the unique identifier of the payment method to set as default.
+  string id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+}
+
+// ListPaymentMethodsRequest is the request to list payment methods for a party.
+message ListPaymentMethodsRequest {
+  // party_id is the party whose payment methods to list.
+  string party_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+}
+
+// ListPaymentMethodsResponse is the response containing payment methods.
+message ListPaymentMethodsResponse {
+  // payment_methods is the list of active payment methods.
+  repeated PartyPaymentMethod payment_methods = 1;
+}
+
+// GetDefaultPaymentMethodRequest is the request to get the default payment method for a party.
+message GetDefaultPaymentMethodRequest {
+  // party_id is the party whose default payment method to retrieve.
+  string party_id = 1 [(buf.validate.field).string = {
+    min_len: 1
+    max_len: 100
+    pattern: "^[a-zA-Z0-9_-]+$"
+  }];
+}
+
+// AddPaymentMethodResponse is the response after adding a payment method.
+message AddPaymentMethodResponse {
+  // payment_method is the newly created payment method.
+  PartyPaymentMethod payment_method = 1 [(buf.validate.field).required = true];
+}
+
+// SetDefaultPaymentMethodResponse is the response after setting the default payment method.
+message SetDefaultPaymentMethodResponse {
+  // payment_method is the payment method that was set as default.
+  PartyPaymentMethod payment_method = 1 [(buf.validate.field).required = true];
+}
+
+// GetDefaultPaymentMethodResponse is the response containing the default payment method.
+message GetDefaultPaymentMethodResponse {
+  // payment_method is the default payment method.
+  PartyPaymentMethod payment_method = 1 [(buf.validate.field).required = true];
+}
+
 // PartyService provides BIAN-compliant party reference data management.
 //
 // Design Notes:
@@ -767,6 +950,53 @@ service PartyService {
   rpc RetrieveBankRelations(RetrieveBankRelationsRequest) returns (RetrieveBankRelationsResponse) {
     option (google.api.http) = {
       get: "/v1/parties/{party_id}/bank-relations"
+    };
+  }
+
+  // --- Business Qualifier: PaymentMethods Operations ---
+
+  // AddPaymentMethod registers a tokenized payment method for a party.
+  rpc AddPaymentMethod(AddPaymentMethodRequest) returns (AddPaymentMethodResponse) {
+    option (google.api.http) = {
+      post: "/v1/parties/{party_id}/payment-methods"
+      body: "*"
+    };
+    option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_operation) = {
+      responses: {
+        key: "201"
+        value: {
+          description: "Payment method added successfully"
+        }
+      }
+    };
+  }
+
+  // RemovePaymentMethod soft-deletes a payment method.
+  rpc RemovePaymentMethod(RemovePaymentMethodRequest) returns (RemovePaymentMethodResponse) {
+    option (google.api.http) = {
+      delete: "/v1/payment-methods/{id}"
+    };
+  }
+
+  // SetDefaultPaymentMethod sets a payment method as the party's default.
+  rpc SetDefaultPaymentMethod(SetDefaultPaymentMethodRequest) returns (SetDefaultPaymentMethodResponse) {
+    option (google.api.http) = {
+      post: "/v1/payment-methods/{id}/default"
+      body: "*"
+    };
+  }
+
+  // ListPaymentMethods returns all active payment methods for a party.
+  rpc ListPaymentMethods(ListPaymentMethodsRequest) returns (ListPaymentMethodsResponse) {
+    option (google.api.http) = {
+      get: "/v1/parties/{party_id}/payment-methods"
+    };
+  }
+
+  // GetDefaultPaymentMethod returns the default payment method for a party.
+  rpc GetDefaultPaymentMethod(GetDefaultPaymentMethodRequest) returns (GetDefaultPaymentMethodResponse) {
+    option (google.api.http) = {
+      get: "/v1/parties/{party_id}/payment-methods/default"
     };
   }
 }

--- a/services/party/service/grpc_payment_methods.go
+++ b/services/party/service/grpc_payment_methods.go
@@ -1,0 +1,367 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	errUnsupportedProvider   = errors.New("unsupported payment provider")
+	errUnsupportedMethodType = errors.New("unsupported payment method type")
+)
+
+// PaymentMethodRepository defines the interface for payment method persistence.
+type PaymentMethodRepository interface {
+	Create(ctx context.Context, pm *domain.PaymentMethod) error
+	Update(ctx context.Context, pm *domain.PaymentMethod) error
+	FindByID(ctx context.Context, id uuid.UUID) (*domain.PaymentMethod, error)
+	ListActiveByParty(ctx context.Context, partyID uuid.UUID) ([]*domain.PaymentMethod, error)
+	FindDefaultByParty(ctx context.Context, partyID uuid.UUID) (*domain.PaymentMethod, error)
+}
+
+// AddPaymentMethod registers a tokenized payment method for a party.
+func (s *Service) AddPaymentMethod(ctx context.Context, req *pb.AddPaymentMethodRequest) (*pb.AddPaymentMethodResponse, error) {
+	if s.pmRepo == nil {
+		return nil, status.Error(codes.Unimplemented, "payment method operations not configured")
+	}
+
+	// Verify party exists
+	partyID, err := uuid.Parse(req.PartyId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid party ID format: %v", err)
+	}
+
+	if _, err := s.repo.FindByID(ctx, partyID); err != nil {
+		if errors.Is(err, persistence.ErrPartyNotFound) {
+			return nil, status.Errorf(codes.NotFound, "party not found: %s", req.PartyId)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to verify party: %v", err)
+	}
+
+	// Map proto provider to domain
+	provider, err := protoToPaymentProvider(req.Provider)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid provider: %v", err)
+	}
+
+	// Map proto method type to domain
+	methodType, err := protoToPaymentMethodType(req.MethodType)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid method type: %v", err)
+	}
+
+	// Convert metadata map to domain metadata
+	var metadata *domain.PaymentMethodMetadata
+	if len(req.Metadata) > 0 {
+		metadata = protoMetadataToDomain(req.Metadata)
+	}
+
+	// Create domain entity
+	pm, err := domain.NewPaymentMethod(
+		partyID,
+		provider,
+		req.ProviderCustomerId,
+		req.ProviderMethodId,
+		methodType,
+		req.IsDefault,
+		metadata,
+	)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid payment method: %v", err)
+	}
+
+	// Persist
+	if err := s.pmRepo.Create(ctx, pm); err != nil {
+		if errors.Is(err, persistence.ErrPaymentMethodExists) {
+			return nil, status.Errorf(codes.AlreadyExists, "payment method already exists for provider method ID")
+		}
+		s.logger.Error("failed to create payment method",
+			"party_id", req.PartyId,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to create payment method: %v", err)
+	}
+
+	s.logger.Info("payment method added",
+		"payment_method_id", pm.ID(),
+		"party_id", req.PartyId,
+		"provider", provider,
+		"method_type", methodType,
+		"is_default", req.IsDefault)
+
+	return &pb.AddPaymentMethodResponse{
+		PaymentMethod: paymentMethodToProto(pm),
+	}, nil
+}
+
+// RemovePaymentMethod soft-deletes a payment method.
+func (s *Service) RemovePaymentMethod(ctx context.Context, req *pb.RemovePaymentMethodRequest) (*pb.RemovePaymentMethodResponse, error) {
+	if s.pmRepo == nil {
+		return nil, status.Error(codes.Unimplemented, "payment method operations not configured")
+	}
+
+	pmID, err := uuid.Parse(req.Id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid payment method ID format: %v", err)
+	}
+
+	pm, err := s.pmRepo.FindByID(ctx, pmID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrPaymentMethodNotFound) {
+			return nil, status.Errorf(codes.NotFound, "payment method not found: %s", req.Id)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to retrieve payment method: %v", err)
+	}
+
+	// Optimistic locking check
+	if pm.Version() != req.Version {
+		return nil, status.Errorf(codes.Aborted, "version conflict: expected %d, got %d", pm.Version(), req.Version)
+	}
+
+	if err := pm.Remove(); err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "cannot remove payment method: %v", err)
+	}
+
+	if err := s.pmRepo.Update(ctx, pm); err != nil {
+		if errors.Is(err, persistence.ErrVersionConflict) {
+			return nil, status.Error(codes.Aborted, "version conflict: payment method was modified by another transaction")
+		}
+		s.logger.Error("failed to remove payment method",
+			"payment_method_id", req.Id,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to remove payment method: %v", err)
+	}
+
+	s.logger.Info("payment method removed", "payment_method_id", req.Id)
+
+	return &pb.RemovePaymentMethodResponse{}, nil
+}
+
+// SetDefaultPaymentMethod sets a payment method as the party's default.
+func (s *Service) SetDefaultPaymentMethod(ctx context.Context, req *pb.SetDefaultPaymentMethodRequest) (*pb.SetDefaultPaymentMethodResponse, error) {
+	if s.pmRepo == nil {
+		return nil, status.Error(codes.Unimplemented, "payment method operations not configured")
+	}
+
+	pmID, err := uuid.Parse(req.Id)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid payment method ID format: %v", err)
+	}
+
+	pm, err := s.pmRepo.FindByID(ctx, pmID)
+	if err != nil {
+		if errors.Is(err, persistence.ErrPaymentMethodNotFound) {
+			return nil, status.Errorf(codes.NotFound, "payment method not found: %s", req.Id)
+		}
+		return nil, status.Errorf(codes.Internal, "failed to retrieve payment method: %v", err)
+	}
+
+	if err := pm.SetDefault(true); err != nil {
+		return nil, status.Errorf(codes.FailedPrecondition, "cannot set payment method as default: %v", err)
+	}
+
+	if err := s.pmRepo.Update(ctx, pm); err != nil {
+		if errors.Is(err, persistence.ErrVersionConflict) {
+			return nil, status.Error(codes.Aborted, "version conflict: payment method was modified by another transaction")
+		}
+		s.logger.Error("failed to set default payment method",
+			"payment_method_id", req.Id,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to set default payment method: %v", err)
+	}
+
+	s.logger.Info("default payment method set",
+		"payment_method_id", req.Id,
+		"party_id", pm.PartyID())
+
+	return &pb.SetDefaultPaymentMethodResponse{
+		PaymentMethod: paymentMethodToProto(pm),
+	}, nil
+}
+
+// ListPaymentMethods returns all active payment methods for a party.
+func (s *Service) ListPaymentMethods(ctx context.Context, req *pb.ListPaymentMethodsRequest) (*pb.ListPaymentMethodsResponse, error) {
+	if s.pmRepo == nil {
+		return nil, status.Error(codes.Unimplemented, "payment method operations not configured")
+	}
+
+	partyID, err := uuid.Parse(req.PartyId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid party ID format: %v", err)
+	}
+
+	methods, err := s.pmRepo.ListActiveByParty(ctx, partyID)
+	if err != nil {
+		s.logger.Error("failed to list payment methods",
+			"party_id", req.PartyId,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to list payment methods: %v", err)
+	}
+
+	pbMethods := make([]*pb.PartyPaymentMethod, len(methods))
+	for i, pm := range methods {
+		pbMethods[i] = paymentMethodToProto(pm)
+	}
+
+	return &pb.ListPaymentMethodsResponse{
+		PaymentMethods: pbMethods,
+	}, nil
+}
+
+// GetDefaultPaymentMethod returns the default payment method for a party.
+func (s *Service) GetDefaultPaymentMethod(ctx context.Context, req *pb.GetDefaultPaymentMethodRequest) (*pb.GetDefaultPaymentMethodResponse, error) {
+	if s.pmRepo == nil {
+		return nil, status.Error(codes.Unimplemented, "payment method operations not configured")
+	}
+
+	partyID, err := uuid.Parse(req.PartyId)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid party ID format: %v", err)
+	}
+
+	pm, err := s.pmRepo.FindDefaultByParty(ctx, partyID)
+	if err != nil {
+		s.logger.Error("failed to get default payment method",
+			"party_id", req.PartyId,
+			"error", err)
+		return nil, status.Errorf(codes.Internal, "failed to get default payment method: %v", err)
+	}
+
+	if pm == nil {
+		return nil, status.Errorf(codes.NotFound, "no default payment method for party: %s", req.PartyId)
+	}
+
+	return &pb.GetDefaultPaymentMethodResponse{
+		PaymentMethod: paymentMethodToProto(pm),
+	}, nil
+}
+
+// --- Conversion helpers ---
+
+// paymentMethodToProto converts a domain PaymentMethod to a proto PartyPaymentMethod.
+func paymentMethodToProto(pm *domain.PaymentMethod) *pb.PartyPaymentMethod {
+	result := &pb.PartyPaymentMethod{
+		Id:                 pm.ID().String(),
+		PartyId:            pm.PartyID().String(),
+		Provider:           paymentProviderToProto(pm.Provider()),
+		ProviderCustomerId: pm.ProviderCustomerID(),
+		ProviderMethodId:   pm.ProviderMethodID(),
+		MethodType:         paymentMethodTypeToProto(pm.MethodType()),
+		IsDefault:          pm.IsDefault(),
+		Status:             paymentMethodStatusToProto(pm.Status()),
+		Version:            pm.Version(),
+		CreatedAt:          timestamppb.New(pm.CreatedAt()),
+		UpdatedAt:          timestamppb.New(pm.UpdatedAt()),
+	}
+
+	if pm.Metadata() != nil {
+		result.Metadata = domainMetadataToProto(pm.Metadata())
+	}
+
+	return result
+}
+
+func protoToPaymentProvider(p pb.PaymentMethodProvider) (domain.PaymentProvider, error) {
+	switch p {
+	case pb.PaymentMethodProvider_PAYMENT_METHOD_PROVIDER_STRIPE:
+		return domain.PaymentProviderStripe, nil
+	case pb.PaymentMethodProvider_PAYMENT_METHOD_PROVIDER_UNSPECIFIED:
+		return "", fmt.Errorf("%w: %s", errUnsupportedProvider, p.String())
+	default:
+		return "", fmt.Errorf("%w: %s", errUnsupportedProvider, p.String())
+	}
+}
+
+func paymentProviderToProto(p domain.PaymentProvider) pb.PaymentMethodProvider {
+	switch p {
+	case domain.PaymentProviderStripe:
+		return pb.PaymentMethodProvider_PAYMENT_METHOD_PROVIDER_STRIPE
+	default:
+		return pb.PaymentMethodProvider_PAYMENT_METHOD_PROVIDER_UNSPECIFIED
+	}
+}
+
+func protoToPaymentMethodType(mt pb.PaymentMethodType) (domain.PaymentMethodType, error) {
+	switch mt {
+	case pb.PaymentMethodType_PAYMENT_METHOD_TYPE_CARD:
+		return domain.PaymentMethodTypeCard, nil
+	case pb.PaymentMethodType_PAYMENT_METHOD_TYPE_BANK_ACCOUNT:
+		return domain.PaymentMethodTypeBankAccount, nil
+	case pb.PaymentMethodType_PAYMENT_METHOD_TYPE_SEPA:
+		return domain.PaymentMethodTypeSEPA, nil
+	case pb.PaymentMethodType_PAYMENT_METHOD_TYPE_UNSPECIFIED:
+		return "", fmt.Errorf("%w: %s", errUnsupportedMethodType, mt.String())
+	default:
+		return "", fmt.Errorf("%w: %s", errUnsupportedMethodType, mt.String())
+	}
+}
+
+func paymentMethodTypeToProto(mt domain.PaymentMethodType) pb.PaymentMethodType {
+	switch mt {
+	case domain.PaymentMethodTypeCard:
+		return pb.PaymentMethodType_PAYMENT_METHOD_TYPE_CARD
+	case domain.PaymentMethodTypeBankAccount:
+		return pb.PaymentMethodType_PAYMENT_METHOD_TYPE_BANK_ACCOUNT
+	case domain.PaymentMethodTypeSEPA:
+		return pb.PaymentMethodType_PAYMENT_METHOD_TYPE_SEPA
+	default:
+		return pb.PaymentMethodType_PAYMENT_METHOD_TYPE_UNSPECIFIED
+	}
+}
+
+func paymentMethodStatusToProto(s domain.PaymentMethodStatus) pb.PaymentMethodStatus {
+	switch s {
+	case domain.PaymentMethodStatusActive:
+		return pb.PaymentMethodStatus_PAYMENT_METHOD_STATUS_ACTIVE
+	case domain.PaymentMethodStatusExpired:
+		return pb.PaymentMethodStatus_PAYMENT_METHOD_STATUS_EXPIRED
+	case domain.PaymentMethodStatusRemoved:
+		return pb.PaymentMethodStatus_PAYMENT_METHOD_STATUS_REMOVED
+	default:
+		return pb.PaymentMethodStatus_PAYMENT_METHOD_STATUS_UNSPECIFIED
+	}
+}
+
+func protoMetadataToDomain(m map[string]string) *domain.PaymentMethodMetadata {
+	meta := &domain.PaymentMethodMetadata{
+		Last4: m["last4"],
+		Brand: m["brand"],
+	}
+	if v, ok := m["exp_month"]; ok {
+		if month, err := strconv.Atoi(v); err == nil {
+			meta.ExpMonth = month
+		}
+	}
+	if v, ok := m["exp_year"]; ok {
+		if year, err := strconv.Atoi(v); err == nil {
+			meta.ExpYear = year
+		}
+	}
+	return meta
+}
+
+func domainMetadataToProto(m *domain.PaymentMethodMetadata) map[string]string {
+	result := make(map[string]string)
+	if m.Last4 != "" {
+		result["last4"] = m.Last4
+	}
+	if m.Brand != "" {
+		result["brand"] = m.Brand
+	}
+	if m.ExpMonth > 0 {
+		result["exp_month"] = strconv.Itoa(m.ExpMonth)
+	}
+	if m.ExpYear > 0 {
+		result["exp_year"] = strconv.Itoa(m.ExpYear)
+	}
+	return result
+}

--- a/services/party/service/grpc_payment_methods_test.go
+++ b/services/party/service/grpc_payment_methods_test.go
@@ -1,0 +1,453 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	pb "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/services/party/adapters/persistence"
+	"github.com/meridianhub/meridian/services/party/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// --- Mock payment method repository ---
+
+type mockPMRepo struct {
+	methods      map[uuid.UUID]*domain.PaymentMethod
+	createErr    error
+	updateErr    error
+	findByIDErr  error
+	listErr      error
+	defaultErr   error
+	defaultPM    *domain.PaymentMethod
+	createCalled int
+	updateCalled int
+}
+
+func newMockPMRepo() *mockPMRepo {
+	return &mockPMRepo{
+		methods: make(map[uuid.UUID]*domain.PaymentMethod),
+	}
+}
+
+func (m *mockPMRepo) Create(_ context.Context, pm *domain.PaymentMethod) error {
+	m.createCalled++
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.methods[pm.ID()] = pm
+	return nil
+}
+
+func (m *mockPMRepo) Update(_ context.Context, pm *domain.PaymentMethod) error {
+	m.updateCalled++
+	if m.updateErr != nil {
+		return m.updateErr
+	}
+	m.methods[pm.ID()] = pm
+	return nil
+}
+
+func (m *mockPMRepo) FindByID(_ context.Context, id uuid.UUID) (*domain.PaymentMethod, error) {
+	if m.findByIDErr != nil {
+		return nil, m.findByIDErr
+	}
+	pm, ok := m.methods[id]
+	if !ok {
+		return nil, persistence.ErrPaymentMethodNotFound
+	}
+	return pm, nil
+}
+
+func (m *mockPMRepo) ListActiveByParty(_ context.Context, partyID uuid.UUID) ([]*domain.PaymentMethod, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	var result []*domain.PaymentMethod
+	for _, pm := range m.methods {
+		if pm.PartyID() == partyID && pm.Status() == domain.PaymentMethodStatusActive {
+			result = append(result, pm)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockPMRepo) FindDefaultByParty(_ context.Context, _ uuid.UUID) (*domain.PaymentMethod, error) {
+	if m.defaultErr != nil {
+		return nil, m.defaultErr
+	}
+	return m.defaultPM, nil
+}
+
+// Verify interface compliance.
+var _ PaymentMethodRepository = (*mockPMRepo)(nil)
+
+func newTestServiceWithPM(mock *mockRepository, pmRepo *mockPMRepo) *Service {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	svc, _ := NewService(mock, logger)
+	svc.WithPaymentMethodRepository(pmRepo)
+	return svc
+}
+
+func createTestParty(t *testing.T, repo *mockRepository) *domain.Party {
+	t.Helper()
+	party, err := domain.NewParty(domain.PartyTypePerson, "Test Person")
+	require.NoError(t, err)
+	repo.parties[party.ID()] = party
+	return party
+}
+
+func createTestPaymentMethod(t *testing.T, partyID uuid.UUID, isDefault bool) *domain.PaymentMethod {
+	t.Helper()
+	pm, err := domain.NewPaymentMethod(
+		partyID,
+		domain.PaymentProviderStripe,
+		"cus_testcustomer123",
+		"pm_testmethod12345",
+		domain.PaymentMethodTypeCard,
+		isDefault,
+		&domain.PaymentMethodMetadata{Last4: "4242", Brand: "visa"},
+	)
+	require.NoError(t, err)
+	return pm
+}
+
+func TestAddPaymentMethod(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("adds payment method successfully", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		party := createTestParty(t, partyRepo)
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		resp, err := svc.AddPaymentMethod(ctx, &pb.AddPaymentMethodRequest{
+			PartyId:            party.ID().String(),
+			Provider:           pb.PaymentMethodProvider_PAYMENT_METHOD_PROVIDER_STRIPE,
+			ProviderCustomerId: "cus_testcustomer123",
+			ProviderMethodId:   "pm_testmethod12345",
+			MethodType:         pb.PaymentMethodType_PAYMENT_METHOD_TYPE_CARD,
+			IsDefault:          true,
+			Metadata: map[string]string{
+				"last4": "4242",
+				"brand": "visa",
+			},
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, resp.PaymentMethod)
+		assert.NotEmpty(t, resp.PaymentMethod.Id)
+		assert.Equal(t, party.ID().String(), resp.PaymentMethod.PartyId)
+		assert.Equal(t, pb.PaymentMethodProvider_PAYMENT_METHOD_PROVIDER_STRIPE, resp.PaymentMethod.Provider)
+		assert.Equal(t, pb.PaymentMethodType_PAYMENT_METHOD_TYPE_CARD, resp.PaymentMethod.MethodType)
+		assert.True(t, resp.PaymentMethod.IsDefault)
+		assert.Equal(t, "4242", resp.PaymentMethod.Metadata["last4"])
+		assert.Equal(t, "visa", resp.PaymentMethod.Metadata["brand"])
+		assert.Equal(t, pb.PaymentMethodStatus_PAYMENT_METHOD_STATUS_ACTIVE, resp.PaymentMethod.Status)
+		assert.Equal(t, 1, pmRepo.createCalled)
+	})
+
+	t.Run("adds payment method without default flag", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		party := createTestParty(t, partyRepo)
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		resp, err := svc.AddPaymentMethod(ctx, &pb.AddPaymentMethodRequest{
+			PartyId:            party.ID().String(),
+			Provider:           pb.PaymentMethodProvider_PAYMENT_METHOD_PROVIDER_STRIPE,
+			ProviderCustomerId: "cus_testcustomer123",
+			ProviderMethodId:   "pm_testmethod12345",
+			MethodType:         pb.PaymentMethodType_PAYMENT_METHOD_TYPE_BANK_ACCOUNT,
+		})
+
+		require.NoError(t, err)
+		assert.False(t, resp.PaymentMethod.IsDefault)
+		assert.Equal(t, pb.PaymentMethodType_PAYMENT_METHOD_TYPE_BANK_ACCOUNT, resp.PaymentMethod.MethodType)
+	})
+
+	t.Run("returns NOT_FOUND when party does not exist", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		_, err := svc.AddPaymentMethod(ctx, &pb.AddPaymentMethodRequest{
+			PartyId:            uuid.New().String(),
+			Provider:           pb.PaymentMethodProvider_PAYMENT_METHOD_PROVIDER_STRIPE,
+			ProviderCustomerId: "cus_testcustomer123",
+			ProviderMethodId:   "pm_testmethod12345",
+			MethodType:         pb.PaymentMethodType_PAYMENT_METHOD_TYPE_CARD,
+		})
+
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("returns ALREADY_EXISTS for duplicate provider method ID", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		pmRepo.createErr = persistence.ErrPaymentMethodExists
+		party := createTestParty(t, partyRepo)
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		_, err := svc.AddPaymentMethod(ctx, &pb.AddPaymentMethodRequest{
+			PartyId:            party.ID().String(),
+			Provider:           pb.PaymentMethodProvider_PAYMENT_METHOD_PROVIDER_STRIPE,
+			ProviderCustomerId: "cus_testcustomer123",
+			ProviderMethodId:   "pm_testmethod12345",
+			MethodType:         pb.PaymentMethodType_PAYMENT_METHOD_TYPE_CARD,
+		})
+
+		assert.Equal(t, codes.AlreadyExists, status.Code(err))
+	})
+
+	t.Run("returns INVALID_ARGUMENT for invalid provider method ID", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		party := createTestParty(t, partyRepo)
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		_, err := svc.AddPaymentMethod(ctx, &pb.AddPaymentMethodRequest{
+			PartyId:            party.ID().String(),
+			Provider:           pb.PaymentMethodProvider_PAYMENT_METHOD_PROVIDER_STRIPE,
+			ProviderCustomerId: "cus_testcustomer123",
+			ProviderMethodId:   "invalid_method_id",
+			MethodType:         pb.PaymentMethodType_PAYMENT_METHOD_TYPE_CARD,
+		})
+
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
+	t.Run("returns UNIMPLEMENTED when pmRepo not configured", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		svc := newTestService(partyRepo) // no pmRepo
+
+		_, err := svc.AddPaymentMethod(ctx, &pb.AddPaymentMethodRequest{
+			PartyId: uuid.New().String(),
+		})
+
+		assert.Equal(t, codes.Unimplemented, status.Code(err))
+	})
+}
+
+func TestRemovePaymentMethod(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("removes payment method successfully", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		party := createTestParty(t, partyRepo)
+		pm := createTestPaymentMethod(t, party.ID(), false)
+		pmRepo.methods[pm.ID()] = pm
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		resp, err := svc.RemovePaymentMethod(ctx, &pb.RemovePaymentMethodRequest{
+			Id:      pm.ID().String(),
+			Version: pm.Version(),
+		})
+
+		require.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Equal(t, 1, pmRepo.updateCalled)
+	})
+
+	t.Run("returns ABORTED for version mismatch", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		party := createTestParty(t, partyRepo)
+		pm := createTestPaymentMethod(t, party.ID(), false)
+		pmRepo.methods[pm.ID()] = pm
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		_, err := svc.RemovePaymentMethod(ctx, &pb.RemovePaymentMethodRequest{
+			Id:      pm.ID().String(),
+			Version: 999,
+		})
+
+		assert.Equal(t, codes.Aborted, status.Code(err))
+	})
+
+	t.Run("returns NOT_FOUND for nonexistent payment method", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		_, err := svc.RemovePaymentMethod(ctx, &pb.RemovePaymentMethodRequest{
+			Id:      uuid.New().String(),
+			Version: 1,
+		})
+
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("returns ABORTED on version conflict during update", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		party := createTestParty(t, partyRepo)
+		pm := createTestPaymentMethod(t, party.ID(), false)
+		pmRepo.methods[pm.ID()] = pm
+		pmRepo.updateErr = persistence.ErrVersionConflict
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		_, err := svc.RemovePaymentMethod(ctx, &pb.RemovePaymentMethodRequest{
+			Id:      pm.ID().String(),
+			Version: pm.Version(),
+		})
+
+		assert.Equal(t, codes.Aborted, status.Code(err))
+	})
+}
+
+func TestSetDefaultPaymentMethod(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("sets payment method as default successfully", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		party := createTestParty(t, partyRepo)
+		pm := createTestPaymentMethod(t, party.ID(), false)
+		pmRepo.methods[pm.ID()] = pm
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		resp, err := svc.SetDefaultPaymentMethod(ctx, &pb.SetDefaultPaymentMethodRequest{
+			Id: pm.ID().String(),
+		})
+
+		require.NoError(t, err)
+		assert.True(t, resp.PaymentMethod.IsDefault)
+		assert.Equal(t, 1, pmRepo.updateCalled)
+	})
+
+	t.Run("returns NOT_FOUND for nonexistent payment method", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		_, err := svc.SetDefaultPaymentMethod(ctx, &pb.SetDefaultPaymentMethodRequest{
+			Id: uuid.New().String(),
+		})
+
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("returns FAILED_PRECONDITION for removed payment method", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		party := createTestParty(t, partyRepo)
+		pm := createTestPaymentMethod(t, party.ID(), false)
+		require.NoError(t, pm.Remove())
+		pmRepo.methods[pm.ID()] = pm
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		_, err := svc.SetDefaultPaymentMethod(ctx, &pb.SetDefaultPaymentMethodRequest{
+			Id: pm.ID().String(),
+		})
+
+		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+	})
+}
+
+func TestListPaymentMethods(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("returns active payment methods for party", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		party := createTestParty(t, partyRepo)
+		pm1 := createTestPaymentMethod(t, party.ID(), true)
+		pm2 := createTestPaymentMethod(t, party.ID(), false)
+		pmRepo.methods[pm1.ID()] = pm1
+		pmRepo.methods[pm2.ID()] = pm2
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		resp, err := svc.ListPaymentMethods(ctx, &pb.ListPaymentMethodsRequest{
+			PartyId: party.ID().String(),
+		})
+
+		require.NoError(t, err)
+		assert.Len(t, resp.PaymentMethods, 2)
+	})
+
+	t.Run("returns empty list when no payment methods", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		resp, err := svc.ListPaymentMethods(ctx, &pb.ListPaymentMethodsRequest{
+			PartyId: uuid.New().String(),
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, resp.PaymentMethods)
+	})
+
+	t.Run("returns INTERNAL on repository error", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		pmRepo.listErr = errors.New("database timeout")
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		_, err := svc.ListPaymentMethods(ctx, &pb.ListPaymentMethodsRequest{
+			PartyId: uuid.New().String(),
+		})
+
+		assert.Equal(t, codes.Internal, status.Code(err))
+	})
+}
+
+func TestGetDefaultPaymentMethod(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("returns default payment method", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		party := createTestParty(t, partyRepo)
+		pm := createTestPaymentMethod(t, party.ID(), true)
+		pmRepo.defaultPM = pm
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		resp, err := svc.GetDefaultPaymentMethod(ctx, &pb.GetDefaultPaymentMethodRequest{
+			PartyId: party.ID().String(),
+		})
+
+		require.NoError(t, err)
+		assert.True(t, resp.PaymentMethod.IsDefault)
+		assert.Equal(t, pm.ID().String(), resp.PaymentMethod.Id)
+	})
+
+	t.Run("returns NOT_FOUND when no default exists", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		_, err := svc.GetDefaultPaymentMethod(ctx, &pb.GetDefaultPaymentMethodRequest{
+			PartyId: uuid.New().String(),
+		})
+
+		assert.Equal(t, codes.NotFound, status.Code(err))
+	})
+
+	t.Run("returns INTERNAL on repository error", func(t *testing.T) {
+		partyRepo := newMockRepository()
+		pmRepo := newMockPMRepo()
+		pmRepo.defaultErr = errors.New("database connection lost")
+		svc := newTestServiceWithPM(partyRepo, pmRepo)
+
+		_, err := svc.GetDefaultPaymentMethod(ctx, &pb.GetDefaultPaymentMethodRequest{
+			PartyId: uuid.New().String(),
+		})
+
+		assert.Equal(t, codes.Internal, status.Code(err))
+	})
+}

--- a/services/party/service/grpc_service.go
+++ b/services/party/service/grpc_service.go
@@ -76,6 +76,7 @@ type Repository interface {
 type Service struct {
 	pb.UnimplementedPartyServiceServer
 	repo   Repository
+	pmRepo PaymentMethodRepository
 	logger *slog.Logger
 }
 
@@ -93,6 +94,13 @@ func NewService(repo Repository, logger *slog.Logger) (*Service, error) {
 		repo:   repo,
 		logger: logger,
 	}, nil
+}
+
+// WithPaymentMethodRepository sets the payment method repository on the service.
+// When set, payment method gRPC operations are enabled.
+func (s *Service) WithPaymentMethodRepository(pmRepo PaymentMethodRepository) *Service {
+	s.pmRepo = pmRepo
+	return s
 }
 
 // RegisterParty creates a new party in the reference data directory


### PR DESCRIPTION
## Summary

- Extend `party.proto` with payment method enums (`PaymentMethodProvider`, `PaymentMethodType`, `PaymentMethodStatus`), messages (`PartyPaymentMethod`, request/response types), and 5 RPCs (`AddPaymentMethod`, `RemovePaymentMethod`, `SetDefaultPaymentMethod`, `ListPaymentMethods`, `GetDefaultPaymentMethod`)
- Implement gRPC handlers on the Party `Service` struct with proto-to-domain conversion helpers, validation, optimistic concurrency control, and structured error responses
- Add `PaymentMethodRepository` interface and `WithPaymentMethodRepository` builder method for optional dependency injection

## Test plan

- [x] 18 unit tests covering all 5 RPC endpoints (happy paths and error conditions)
- [x] `TestAddPaymentMethod`: success, no-default, party not found, duplicate provider method, invalid provider method ID, unimplemented
- [x] `TestRemovePaymentMethod`: success, version mismatch, not found, version conflict on update
- [x] `TestSetDefaultPaymentMethod`: success, not found, removed method
- [x] `TestListPaymentMethods`: returns methods, empty list, repository error
- [x] `TestGetDefaultPaymentMethod`: returns default, no default, repository error
- [x] All existing Party service tests continue to pass
- [x] `go vet`, `buf lint`, `gofumpt`, `golangci-lint` all pass

Task: stripe-connect.3
Depends on: stripe-connect.2 (PR #864)
Blocks: stripe-connect.8