### PR TITLE
Upgrade Go from 1.25.7 to 1.26.0

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -17,7 +17,11 @@ YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
 # Ensure GOPATH/bin is in PATH for tools (prepend so go-installed versions take precedence)
-export PATH="$(go env GOPATH)/bin:$PATH"
+if command -v go &> /dev/null; then
+    export PATH="$(go env GOPATH)/bin:$PATH"
+elif [ -n "${GOPATH:-}" ]; then
+    export PATH="${GOPATH}/bin:$PATH"
+fi
 
 # Get list of staged files
 STAGED_GO_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,7 +8,7 @@
 set -e
 
 # Pinned tool versions (keep in sync with .github/workflows/quality.yml)
-GOLANGCI_LINT_VERSION="v2.7.2"
+GOLANGCI_LINT_VERSION="v2.9.0"
 
 # Colors for output
 RED='\033[0;31m'
@@ -16,8 +16,8 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-# Ensure GOPATH/bin is in PATH for tools
-export PATH="$PATH:$(go env GOPATH)/bin"
+# Ensure GOPATH/bin is in PATH for tools (prepend so go-installed versions take precedence)
+export PATH="$(go env GOPATH)/bin:$PATH"
 
 # Get list of staged files
 STAGED_GO_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$' || true)

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,8 +51,8 @@ jobs:
             IMPORTANT: Today's date is ${{ steps.date.outputs.current_date }}.
 
             Key project facts:
-            - This project uses Go 1.25.7 (latest stable release)
-            - Go 1.25.7 is a valid version - do not question or flag it
+            - This project uses Go 1.26.0 (latest stable release)
+            - Go 1.26.0 is a valid version - do not question or flag it
             - Architecture: BIAN-compliant microservices
             - Stack: Go, Protocol Buffers, gRPC, Kubernetes
             - Security: All security scans must remain BLOCKING (never suggest making them non-blocking)

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,7 +64,7 @@ jobs:
       if: matrix.language == 'go'
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.26.0'
         cache: true
 
     # Set up buf for protobuf generation (pinned version for reproducibility)

--- a/.github/workflows/control-plane-ci.yml
+++ b/.github/workflows/control-plane-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Set up buf
@@ -73,7 +73,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Set up buf
@@ -109,7 +109,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Set up buf
@@ -149,7 +149,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Set up buf
@@ -192,7 +192,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Install Atlas CLI
@@ -80,7 +80,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Install Atlas CLI

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Set up buf
@@ -98,7 +98,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.26.0'
         cache: true
 
     - name: Set up buf

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.7.2
+          version: v2.9.0
           args: --timeout=5m --config=.golangci.yml
 
   tiltfile-syntax:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/saga-validation.yml
+++ b/.github/workflows/saga-validation.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Set up buf

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Install protoc

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.26.0'
         cache: true
 
     - name: Set up buf
@@ -51,7 +51,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.7'
+        go-version: '1.26.0'
         cache: true
 
     - name: Set up buf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.7'
+          go-version: '1.26.0'
           cache: true
 
       - name: Set up buf

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,7 +1,7 @@
 # audit-worker - Development Dockerfile for Tilt Live Update
 # Uses Debian bookworm for CGO support (required by confluent-kafka-go/librdkafka)
 
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies for CGO (librdkafka)
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ These services are not part of the BIAN standard but provide platform infrastruc
 
 ## Technology Stack
 
-- **Language**: Go 1.25+
+- **Language**: Go 1.26+
 - **API Protocol**: Protocol Buffers 3 + gRPC
 - **API Tooling**: buf CLI for linting and code generation
 - **Database**: CockroachDB or YugabyteDB (distributed SQL)
@@ -251,7 +251,7 @@ for single-broker Kafka configuration.
 
 ## Quick Start
 
-**Prerequisites**: Go 1.25+, Docker, kubectl, kind, tilt ([see detailed
+**Prerequisites**: Go 1.26+, Docker, kubectl, kind, tilt ([see detailed
 setup](CONTRIBUTING.md#development-environment-setup))
 
 ```bash

--- a/cmd/market-data-tool/cmd/import.go
+++ b/cmd/market-data-tool/cmd/import.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
-	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/adapters/csv"
+	csvadapter "github.com/meridianhub/meridian/cmd/market-data-tool/internal/adapters/csv"
 	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/checkpoint"
 	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/infra"
 	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/validation"
@@ -340,15 +340,15 @@ func executeDryRun(
 	})
 
 	// Create CSV parser
-	csvParser := csv.NewParser(dataset)
+	csvParser := csvadapter.NewParser(dataset)
 
 	// Parse and validate CSV
-	parseConfig := csv.ParseConfig{
+	parseConfig := csvadapter.ParseConfig{
 		BatchSize:     cfg.BatchSize,
 		SkipEmptyRows: true,
 	}
 
-	parseResult, err := csvParser.Parse(ctx, file, parseConfig, func(batch csv.RowBatch) error {
+	parseResult, err := csvParser.Parse(ctx, file, parseConfig, func(batch csvadapter.RowBatch) error {
 		// Validate each row in the batch
 		for _, csvRow := range batch.Rows {
 			validationRow := csvRowToValidationRow(&csvRow, cfg.Dataset)
@@ -424,15 +424,15 @@ func executeLiveImport(
 	})
 
 	// Create CSV parser
-	csvParser := csv.NewParser(dataset)
+	csvParser := csvadapter.NewParser(dataset)
 
 	// Process import
-	parseConfig := csv.ParseConfig{
+	parseConfig := csvadapter.ParseConfig{
 		BatchSize:     cfg.BatchSize,
 		SkipEmptyRows: true,
 	}
 
-	parseResult, parseErr := csvParser.Parse(ctx, file, parseConfig, func(batch csv.RowBatch) error {
+	parseResult, parseErr := csvParser.Parse(ctx, file, parseConfig, func(batch csvadapter.RowBatch) error {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -545,7 +545,7 @@ func handleImportInterrupt(
 }
 
 // csvRowToValidationRow converts a CSV row to a validation row.
-func csvRowToValidationRow(csvRow *csv.ObservationRow, datasetCode string) *validation.ObservationRow {
+func csvRowToValidationRow(csvRow *csvadapter.ObservationRow, datasetCode string) *validation.ObservationRow {
 	return &validation.ObservationRow{
 		LineNumber:   csvRow.LineNumber,
 		DatasetCode:  datasetCode,
@@ -559,7 +559,7 @@ func csvRowToValidationRow(csvRow *csv.ObservationRow, datasetCode string) *vali
 }
 
 // csvRowToObservation converts a CSV row to a gRPC observation entry.
-func csvRowToObservation(csvRow *csv.ObservationRow, datasetCode, sourceCode string) *infra.ObservationEntry {
+func csvRowToObservation(csvRow *csvadapter.ObservationRow, datasetCode, sourceCode string) *infra.ObservationEntry {
 	return &infra.ObservationEntry{
 		DatasetCode:     datasetCode,
 		ObservedAt:      csvRow.ObservedAt,

--- a/cmd/market-data-tool/cmd/validate.go
+++ b/cmd/market-data-tool/cmd/validate.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/adapters/csv"
+	csvadapter "github.com/meridianhub/meridian/cmd/market-data-tool/internal/adapters/csv"
 	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/infra"
 	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/validation"
 )
@@ -189,15 +189,15 @@ func executeValidation(ctx context.Context, cfg *validateConfig) (*validateResul
 	})
 
 	// Create CSV parser
-	csvParser := csv.NewParser(dataset)
+	csvParser := csvadapter.NewParser(dataset)
 
 	// Parse and validate CSV
-	parseConfig := csv.ParseConfig{
+	parseConfig := csvadapter.ParseConfig{
 		BatchSize:     500,
 		SkipEmptyRows: true,
 	}
 
-	parseResult, err := csvParser.Parse(ctx, file, parseConfig, func(batch csv.RowBatch) error {
+	parseResult, err := csvParser.Parse(ctx, file, parseConfig, func(batch csvadapter.RowBatch) error {
 		for _, csvRow := range batch.Rows {
 			validationRow := csvRowToValidationRow(&csvRow, cfg.Dataset)
 			rowErr := pipeline.ValidateRow(ctx, validationRow)

--- a/cmd/market-data-tool/integration_test.go
+++ b/cmd/market-data-tool/integration_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
 
-	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/adapters/csv"
+	csvadapter "github.com/meridianhub/meridian/cmd/market-data-tool/internal/adapters/csv"
 	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/infra"
 	"github.com/meridianhub/meridian/cmd/market-data-tool/internal/validation"
 	"github.com/meridianhub/meridian/shared/platform/await"
@@ -122,10 +122,10 @@ func TestCSVParser_Integration(t *testing.T) {
 			Code: "USD_EUR_FX",
 		}
 
-		parser := csv.NewParser(dataset)
-		var rows []csv.ObservationRow
+		parser := csvadapter.NewParser(dataset)
+		var rows []csvadapter.ObservationRow
 
-		result, err := parser.Parse(context.Background(), strings.NewReader(csvData), csv.DefaultParseConfig(), func(batch csv.RowBatch) error {
+		result, err := parser.Parse(context.Background(), strings.NewReader(csvData), csvadapter.DefaultParseConfig(), func(batch csvadapter.RowBatch) error {
 			rows = append(rows, batch.Rows...)
 			return nil
 		})
@@ -152,18 +152,18 @@ func TestCSVParser_Integration(t *testing.T) {
 		csvData := strings.Join(lines, "\n")
 
 		dataset := &infra.DataSetDefinition{Code: "TEST"}
-		parser := csv.NewParser(dataset)
+		parser := csvadapter.NewParser(dataset)
 
 		var batchCount int
 		var totalRows int
 
-		config := csv.ParseConfig{
+		config := csvadapter.ParseConfig{
 			BatchSize:        100,
 			SkipEmptyRows:    true,
 			TimestampFormats: []string{time.RFC3339},
 		}
 
-		result, err := parser.Parse(context.Background(), strings.NewReader(csvData), config, func(batch csv.RowBatch) error {
+		result, err := parser.Parse(context.Background(), strings.NewReader(csvData), config, func(batch csvadapter.RowBatch) error {
 			batchCount++
 			totalRows += len(batch.Rows)
 			return nil
@@ -362,14 +362,14 @@ func TestEndToEnd_ImportWorkflow(t *testing.T) {
 		defer file.Close()
 
 		dataset := &infra.DataSetDefinition{Code: "USD_EUR_FX"}
-		parser := csv.NewParser(dataset)
+		parser := csvadapter.NewParser(dataset)
 
 		// Create validation pipeline
 		pipeline := validation.NewPipeline(validation.PipelineConfig{})
 
 		// Process rows
 		var validCount, errorCount int
-		parseResult, err := parser.Parse(tc.ctx, file, csv.DefaultParseConfig(), func(batch csv.RowBatch) error {
+		parseResult, err := parser.Parse(tc.ctx, file, csvadapter.DefaultParseConfig(), func(batch csvadapter.RowBatch) error {
 			for _, csvRow := range batch.Rows {
 				row := &validation.ObservationRow{
 					LineNumber:   csvRow.LineNumber,

--- a/cmd/market-data-tool/internal/adapters/csv/parser.go
+++ b/cmd/market-data-tool/internal/adapters/csv/parser.go
@@ -1,10 +1,10 @@
-// Package csv provides CSV parsing for market data observation imports.
+// Package csvadapter provides CSV parsing for market data observation imports.
 //
 // The parser handles:
 //   - Required columns: observed_at, quality_level, value
 //   - Optional temporal bounds: valid_from, valid_to
 //   - Dynamic attribute extraction based on dataset attribute_schema
-package csv
+package csvadapter
 
 import (
 	"bufio"

--- a/cmd/market-data-tool/internal/adapters/csv/parser_test.go
+++ b/cmd/market-data-tool/internal/adapters/csv/parser_test.go
@@ -1,4 +1,4 @@
-package csv
+package csvadapter
 
 import (
 	"context"

--- a/cmd/position-tool/cmd/import.go
+++ b/cmd/position-tool/cmd/import.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	referencedatav1 "github.com/meridianhub/meridian/api/proto/meridian/reference_data/v1"
-	"github.com/meridianhub/meridian/cmd/position-tool/internal/adapters/csv"
+	csvadapter "github.com/meridianhub/meridian/cmd/position-tool/internal/adapters/csv"
 	"github.com/meridianhub/meridian/cmd/position-tool/internal/checkpoint"
 	"github.com/meridianhub/meridian/cmd/position-tool/internal/infra"
 	"github.com/meridianhub/meridian/cmd/position-tool/internal/validation"
@@ -277,7 +277,7 @@ func executeDryRun(ctx context.Context, cfg *importConfig, cp *checkpoint.Checkp
 	registry := &instrumentCheckerRegistry{checker: instrumentChecker}
 
 	// Create CSV parser
-	csvParser := csv.NewParser(registry)
+	csvParser := csvadapter.NewParser(registry)
 
 	// Set up validation pipeline (minimal for dry-run - no DB lookups needed)
 	duplicateChecker := validation.NewDuplicateChecker(validation.DefaultBloomFilterConfig(), nil)
@@ -293,12 +293,12 @@ func executeDryRun(ctx context.Context, cfg *importConfig, cp *checkpoint.Checkp
 	defer func() { _ = pipeline.Close() }()
 
 	// Parse and validate CSV
-	parseConfig := csv.ParseConfig{
+	parseConfig := csvadapter.ParseConfig{
 		BatchSize:     cfg.BatchSize,
 		SkipEmptyRows: true,
 	}
 
-	parseResult, err := csvParser.Parse(ctx, file, parseConfig, func(batch csv.RowBatch) error {
+	parseResult, err := csvParser.Parse(ctx, file, parseConfig, func(batch csvadapter.RowBatch) error {
 		// Validate each row in the batch
 		for _, csvRow := range batch.Rows {
 			validationRow := csvRowToValidationRow(&csvRow)
@@ -344,7 +344,7 @@ type importProcessor struct {
 
 // processRow handles validation and insertion of a single CSV row.
 // Returns an error only for fatal errors that should stop processing.
-func (p *importProcessor) processRow(ctx context.Context, csvRow *csv.ImportRow) error {
+func (p *importProcessor) processRow(ctx context.Context, csvRow *csvadapter.ImportRow) error {
 	// Skip rows before the resume point
 	if p.cp.ProcessedRows > 0 && csvRow.LineNumber <= p.cp.LastProcessedLine {
 		return nil
@@ -380,7 +380,7 @@ func (p *importProcessor) processRow(ctx context.Context, csvRow *csv.ImportRow)
 
 // tryComputeBucketKey evaluates the CEL expression to generate the bucket key.
 // Returns (bucketKey, true) on success, or ("", false) if evaluation fails.
-func (p *importProcessor) tryComputeBucketKey(csvRow *csv.ImportRow, fungibilityExpr string) (string, bool) {
+func (p *importProcessor) tryComputeBucketKey(csvRow *csvadapter.ImportRow, fungibilityExpr string) (string, bool) {
 	if fungibilityExpr == "" {
 		return "", true
 	}
@@ -396,7 +396,7 @@ func (p *importProcessor) tryComputeBucketKey(csvRow *csv.ImportRow, fungibility
 
 // createAndInsertPosition creates a domain.Position and adds it to the batch inserter.
 // Returns an error only for fatal errors that should stop processing.
-func (p *importProcessor) createAndInsertPosition(ctx context.Context, csvRow *csv.ImportRow, bucketKey string) error {
+func (p *importProcessor) createAndInsertPosition(ctx context.Context, csvRow *csvadapter.ImportRow, bucketKey string) error {
 	amount, err := decimal.NewFromString(csvRow.Amount)
 	if err != nil {
 		p.recordValidationFailure()
@@ -436,7 +436,7 @@ func (p *importProcessor) recordValidationFailure() {
 
 // processBatch handles a batch of CSV rows during import.
 // Returns context.Canceled if the context is cancelled, nil otherwise.
-func (p *importProcessor) processBatch(ctx context.Context, batch csv.RowBatch, checkpointMgr *checkpoint.PostgresManager) error {
+func (p *importProcessor) processBatch(ctx context.Context, batch csvadapter.RowBatch, checkpointMgr *checkpoint.PostgresManager) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -461,7 +461,7 @@ func (p *importProcessor) processBatch(ctx context.Context, batch csv.RowBatch, 
 type importDependencies struct {
 	file              *os.File
 	instrumentChecker *validation.InstrumentChecker
-	csvParser         *csv.Parser
+	csvParser         *csvadapter.Parser
 	celEval           *infra.CELEvaluator
 	pipeline          *validation.Pipeline
 	batchInserter     *infra.BatchInserter
@@ -500,7 +500,7 @@ func initImportDependencies(ctx context.Context, cfg *importConfig, pool *pgxpoo
 		return nil, fmt.Errorf("failed to create instrument checker: %w", err)
 	}
 
-	deps.csvParser = csv.NewParser(&instrumentCheckerRegistry{checker: deps.instrumentChecker})
+	deps.csvParser = csvadapter.NewParser(&instrumentCheckerRegistry{checker: deps.instrumentChecker})
 
 	deps.celEval, err = infra.NewCELEvaluatorDefault()
 	if err != nil {
@@ -555,7 +555,7 @@ func handleImportInterrupt(_ context.Context, deps *importDependencies, cp *chec
 }
 
 // finalizeImport flushes remaining positions and marks checkpoint complete.
-func finalizeImport(ctx context.Context, deps *importDependencies, cp *checkpoint.Checkpoint, checkpointMgr *checkpoint.PostgresManager, result *importResult, parseResult *csv.ParseResult, logger *slog.Logger) (*importResult, error) {
+func finalizeImport(ctx context.Context, deps *importDependencies, cp *checkpoint.Checkpoint, checkpointMgr *checkpoint.PostgresManager, result *importResult, parseResult *csvadapter.ParseResult, logger *slog.Logger) (*importResult, error) {
 	if flushErr := deps.batchInserter.Flush(ctx); flushErr != nil {
 		if markErr := checkpointMgr.Fail(ctx, cp, flushErr); markErr != nil {
 			logger.Warn("failed to mark checkpoint as failed", "error", markErr)
@@ -590,7 +590,7 @@ func executeLiveImport(ctx context.Context, cfg *importConfig, cp *checkpoint.Ch
 		fungibilityExprs: make(map[string]string),
 	}
 
-	parseResult, parseErr := deps.csvParser.Parse(ctx, deps.file, csv.ParseConfig{BatchSize: cfg.BatchSize, SkipEmptyRows: true}, func(batch csv.RowBatch) error {
+	parseResult, parseErr := deps.csvParser.Parse(ctx, deps.file, csvadapter.ParseConfig{BatchSize: cfg.BatchSize, SkipEmptyRows: true}, func(batch csvadapter.RowBatch) error {
 		return proc.processBatch(ctx, batch, checkpointMgr)
 	})
 
@@ -598,7 +598,7 @@ func executeLiveImport(ctx context.Context, cfg *importConfig, cp *checkpoint.Ch
 }
 
 // handleParseResult handles the outcome of CSV parsing and returns the final result.
-func handleParseResult(ctx context.Context, deps *importDependencies, cp *checkpoint.Checkpoint, checkpointMgr *checkpoint.PostgresManager, result *importResult, parseResult *csv.ParseResult, parseErr error, logger *slog.Logger) (*importResult, error) {
+func handleParseResult(ctx context.Context, deps *importDependencies, cp *checkpoint.Checkpoint, checkpointMgr *checkpoint.PostgresManager, result *importResult, parseResult *csvadapter.ParseResult, parseErr error, logger *slog.Logger) (*importResult, error) {
 	if errors.Is(parseErr, context.Canceled) {
 		return handleImportInterrupt(ctx, deps, cp, checkpointMgr, result, logger), nil
 	}
@@ -612,7 +612,7 @@ func handleParseResult(ctx context.Context, deps *importDependencies, cp *checkp
 }
 
 // csvRowToValidationRow converts a CSV row to a validation row.
-func csvRowToValidationRow(csvRow *csv.ImportRow) *validation.ImportRow {
+func csvRowToValidationRow(csvRow *csvadapter.ImportRow) *validation.ImportRow {
 	return &validation.ImportRow{
 		LineNumber:     csvRow.LineNumber,
 		AccountID:      csvRow.AccountID,

--- a/cmd/position-tool/internal/adapters/csv/attribute_extractor.go
+++ b/cmd/position-tool/internal/adapters/csv/attribute_extractor.go
@@ -1,6 +1,6 @@
-// Package csv provides CSV parsing capabilities for the position-tool bulk import.
+// Package csvadapter provides CSV parsing capabilities for the position-tool bulk import.
 // It implements schema-driven column mapping based on instrument definitions.
-package csv
+package csvadapter
 
 import (
 	"regexp"

--- a/cmd/position-tool/internal/adapters/csv/attribute_extractor_test.go
+++ b/cmd/position-tool/internal/adapters/csv/attribute_extractor_test.go
@@ -1,4 +1,4 @@
-package csv
+package csvadapter
 
 import (
 	"testing"

--- a/cmd/position-tool/internal/adapters/csv/parser.go
+++ b/cmd/position-tool/internal/adapters/csv/parser.go
@@ -1,4 +1,4 @@
-package csv
+package csvadapter
 
 import (
 	"bufio"

--- a/cmd/position-tool/internal/adapters/csv/parser_test.go
+++ b/cmd/position-tool/internal/adapters/csv/parser_test.go
@@ -1,4 +1,4 @@
-package csv
+package csvadapter
 
 import (
 	"context"

--- a/cmd/position-tool/internal/exporter/csv_writer.go
+++ b/cmd/position-tool/internal/exporter/csv_writer.go
@@ -104,14 +104,15 @@ func (w *CSVWriter) buildHeaders() []string {
 	// Fixed columns
 	// Note: bucket_key is NOT exported - it is computed from attributes using
 	// the instrument's fungibility key expression (CEL) during import.
-	headers := []string{
+	headers := make([]string, 0, 6+len(w.attributeKeys))
+	headers = append(headers,
 		"account_id",
 		"instrument_code",
 		"amount",
 		"dimension",
 		"created_at",
 		"reference_id",
-	}
+	)
 
 	// Dynamic attribute columns with "attr_" prefix
 	for _, key := range w.attributeKeys {
@@ -124,14 +125,15 @@ func (w *CSVWriter) buildHeaders() []string {
 // buildRecord converts a PositionRow to a CSV record.
 func (w *CSVWriter) buildRecord(pos PositionRow) []string {
 	// Fixed columns (bucket_key excluded - computed from attributes during import)
-	record := []string{
+	record := make([]string, 0, 6+len(w.attributeKeys))
+	record = append(record,
 		pos.AccountID,
 		pos.InstrumentCode,
 		pos.Amount.String(),
 		pos.Dimension,
 		pos.CreatedAt.Format(time.RFC3339),
 		formatUUID(pos.ReferenceID),
-	}
+	)
 
 	// Dynamic attribute columns (in the same order as headers)
 	for _, key := range w.attributeKeys {

--- a/cmd/tenantctl/client/tenant_client.go
+++ b/cmd/tenantctl/client/tenant_client.go
@@ -69,9 +69,8 @@ func NewTenantClient(ctx context.Context, cfg Config) (*TenantClient, error) {
 
 	if cfg.ServiceURL != "" {
 		// Direct connection for local development or custom endpoints
-		opts := []grpc.DialOption{
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
-		}
+		opts := make([]grpc.DialOption, 0, 1+len(cfg.DialOptions))
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		opts = append(opts, cfg.DialOptions...)
 		conn, err = grpc.NewClient(cfg.ServiceURL, opts...)
 		if err != nil {

--- a/docs/guides/new-bian-service-checklist.md
+++ b/docs/guides/new-bian-service-checklist.md
@@ -576,7 +576,7 @@ Create a multi-stage Docker build.
 
 ```dockerfile
 # Stage 1: Build
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 ARG VERSION=dev
 ARG COMMIT=unknown

--- a/docs/skills/docker.md
+++ b/docs/skills/docker.md
@@ -21,7 +21,7 @@ This document describes the Docker setup for Meridian, optimized for production 
 
 Meridian uses a multi-stage Docker build to create minimal, secure production images:
 
-- **Build stage**: golang:1.23-alpine for compiling static binaries
+- **Build stage**: golang:1.26.0-bookworm for compiling static binaries
 - **Runtime stage**: gcr.io/distroless/static:nonroot for minimal attack surface
 - **Image size**: ~3-5MB (binary: 1.4MB + distroless base: ~2MB)
 - **Security**: Non-root user, no shell, minimal dependencies
@@ -64,7 +64,7 @@ docker build \
 ### Multi-Stage Build
 
 1. **Builder Stage**
-   - Base: `golang:1.23-alpine`
+   - Base: `golang:1.26.0-bookworm`
    - Installs: git, ca-certificates, tzdata
    - Compiles: Static binary with CGO disabled
    - Optimizations: `-ldflags="-w -s"` for stripped, reduced size

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/meridianhub/meridian
 
-go 1.25.7
+go 1.26.0
 
 require (
 	ariga.io/atlas-provider-gorm v0.6.0
+	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1
 	buf.build/go/protovalidate v1.1.0
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/alicebob/miniredis/v2 v2.36.1
@@ -49,7 +50,6 @@ require (
 )
 
 require (
-	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20260209202127-80ab13bee0bf.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.24.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -121,7 +121,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/googleapis/go-gorm-spanner v1.8.6 // indirect
 	github.com/googleapis/go-sql-spanner v1.17.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.7
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
@@ -171,7 +171,7 @@ require (
 	golang.org/x/text v0.33.0 // indirect
 	golang.org/x/time v0.14.0
 	google.golang.org/api v0.249.0 // indirect
-	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
+	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.5.7 // indirect

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -102,6 +102,13 @@ case "$PKG_MANAGER" in
         ;;
 esac
 
+# Ensure GOPATH/bin is in PATH so go-installed tools take precedence over system versions.
+# This matters when e.g. golangci-lint is installed both via brew and go install - the
+# go-installed version is typically newer and built with the current Go toolchain.
+if command -v go &> /dev/null; then
+    export PATH="$(go env GOPATH)/bin:$PATH"
+fi
+
 # Helper function to get tool version
 get_version() {
     local cmd=$1

--- a/services/current-account/cmd/Dockerfile
+++ b/services/current-account/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/financial-accounting/cmd/Dockerfile
+++ b/services/financial-accounting/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/forecasting/cmd/Dockerfile
+++ b/services/forecasting/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/gateway/cmd/Dockerfile
+++ b/services/gateway/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/internal-bank-account/cmd/Dockerfile
+++ b/services/internal-bank-account/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/internal-bank-account/cmd/main.go
+++ b/services/internal-bank-account/cmd/main.go
@@ -294,7 +294,7 @@ func createServiceWithClients(
 	tracer *observability.Tracer,
 ) (*service.Service, *serviceClients, error) {
 	// Track cleanup functions for graceful shutdown
-	var cleanupFuncs []func()
+	cleanupFuncs := make([]func(), 0, 1)
 
 	// Create Position Keeping client using service-owned client package
 	// The client has built-in resilience patterns (circuit breaker + retry)

--- a/services/market-information/cmd/Dockerfile
+++ b/services/market-information/cmd/Dockerfile
@@ -4,7 +4,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/party/cmd/Dockerfile
+++ b/services/party/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/payment-order/cmd/Dockerfile
+++ b/services/payment-order/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/position-keeping/cmd/Dockerfile
+++ b/services/position-keeping/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/position-keeping/domain/events_bench_test.go
+++ b/services/position-keeping/domain/events_bench_test.go
@@ -215,7 +215,7 @@ func BenchmarkNewTransactionRejected(b *testing.B) {
 
 // BenchmarkEventTypeSwitch benchmarks a typical event type switch operation.
 func BenchmarkEventTypeSwitch(b *testing.B) {
-	events := []domain.DomainEvent{}
+	events := make([]domain.DomainEvent, 0, 3)
 
 	// Create mix of events
 	money, _ := domain.NewMoney(decimal.NewFromInt(100), domain.CurrencyGBP)

--- a/services/reconciliation/cmd/Dockerfile
+++ b/services/reconciliation/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go dependencies
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/tenant/cmd/Dockerfile
+++ b/services/tenant/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/services/tenant/notifier/slack_test.go
+++ b/services/tenant/notifier/slack_test.go
@@ -161,7 +161,7 @@ func TestBuildPayload_WithMetadata(t *testing.T) {
 		if len(block.Fields) > 0 {
 			foundMetadata = true
 			// Check metadata fields are present
-			var fieldTexts []string
+			fieldTexts := make([]string, 0, len(block.Fields))
 			for _, field := range block.Fields {
 				fieldTexts = append(fieldTexts, field.Text)
 			}

--- a/services/utilization-metering-consumer/cmd/Dockerfile
+++ b/services/utilization-metering-consumer/cmd/Dockerfile
@@ -3,7 +3,7 @@
 # Uses distroless base image (~2MB) enabled by pure-Go franz-go Kafka client
 
 # Build stage
-FROM golang:1.25.7-bookworm AS builder
+FROM golang:1.26.0-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/shared/pkg/grpc/client.go
+++ b/shared/pkg/grpc/client.go
@@ -109,7 +109,8 @@ func NewClient(ctx context.Context, cfg ClientConfig) (*grpc.ClientConn, error) 
 	)
 
 	// Default dial options for production use
-	opts := []grpc.DialOption{
+	opts := make([]grpc.DialOption, 0, 3+len(cfg.DialOptions))
+	opts = append(opts,
 		// Use insecure credentials (TLS handled at service mesh level or via mTLS)
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 
@@ -122,7 +123,7 @@ func NewClient(ctx context.Context, cfg ClientConfig) (*grpc.ClientConn, error) 
 			Timeout:             3 * time.Second,  // Wait 3s for ping ack
 			PermitWithoutStream: true,             // Allow pings when no active streams
 		}),
-	}
+	)
 
 	// Append user-provided options (allows overriding defaults)
 	opts = append(opts, cfg.DialOptions...)


### PR DESCRIPTION
## Summary

- Upgrade Go toolchain from 1.25.7 to 1.26.0 (released 2026-02-10)
- Update all Dockerfiles (root + 12 service Dockerfiles), CI workflows (12 workflow files), go.mod, and documentation

## Changes

| Category | Files | Change |
|----------|-------|--------|
| go.mod | 1 | `go 1.25.7` to `go 1.26.0` + dependency tidying |
| Dockerfiles | 14 | `golang:1.25.7-bookworm` to `golang:1.26.0-bookworm` |
| CI workflows | 12 | `go-version: '1.25.7'` to `go-version: '1.26.0'` |
| Documentation | 2 | Updated Go version references |

## Go 1.26.0 Highlights

- Experimental SIMD support (`simd/archsimd` package)
- Goroutine leak detection (`runtime/pprof` goroutineleak profile)
- Improved `go fix` tool with dozens of fixers for modern idioms
- `io.ReadAll` roughly 2x faster with 50% fewer allocations
- Specialized memory allocation for small objects (1-512 bytes)
- New `crypto/hpke` package (RFC 9180)
- `bytes.Buffer.Peek(n)` and `log/slog.NewMultiHandler`

## Test plan

- [ ] CI passes: all workflows use Go 1.26.0
- [ ] Docker builds succeed with `golang:1.26.0-bookworm` image
- [ ] All existing tests pass under Go 1.26.0