### PR TITLE
feat: wire ControlAccountReconciliation handler for CANCEL action

### DIFF
--- a/services/reconciliation/service/control_handler_test.go
+++ b/services/reconciliation/service/control_handler_test.go
@@ -1,0 +1,253 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/services/reconciliation/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func newPendingRun(t *testing.T) *domain.SettlementRun {
+	t.Helper()
+	now := time.Now().UTC()
+	run, err := domain.NewSettlementRun(
+		"ACC-001",
+		domain.ReconciliationScopeAccount,
+		domain.SettlementTypeDaily,
+		now.Add(-24*time.Hour),
+		now,
+		"system",
+	)
+	require.NoError(t, err)
+	return run
+}
+
+func newRunningRun(t *testing.T) *domain.SettlementRun {
+	t.Helper()
+	run := newPendingRun(t)
+	err := run.Start()
+	require.NoError(t, err)
+	return run
+}
+
+func TestControlAccountReconciliation_CancelPending(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	run := newPendingRun(t)
+	repo.runs[run.RunID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  run.RunID.String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.GetRun())
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_CANCELLED, resp.GetRun().GetStatus())
+	assert.Equal(t, run.RunID.String(), resp.GetRun().GetRunId())
+
+	// Verify persisted
+	updated := repo.runs[run.RunID]
+	assert.Equal(t, domain.RunStatusCancelled, updated.Status)
+	assert.NotNil(t, updated.CompletedAt)
+}
+
+func TestControlAccountReconciliation_CancelRunning(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	run := newRunningRun(t)
+	repo.runs[run.RunID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  run.RunID.String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.GetRun())
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_CANCELLED, resp.GetRun().GetStatus())
+
+	updated := repo.runs[run.RunID]
+	assert.Equal(t, domain.RunStatusCancelled, updated.Status)
+}
+
+func TestControlAccountReconciliation_CancelCompleted(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	run := newRunningRun(t)
+	err := run.Complete(0)
+	require.NoError(t, err)
+	repo.runs[run.RunID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  run.RunID.String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "cannot cancel run in COMPLETED state")
+}
+
+func TestControlAccountReconciliation_PauseUnimplemented(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	run := newRunningRun(t)
+	repo.runs[run.RunID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  run.RunID.String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_PAUSE,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+	assert.Contains(t, st.Message(), "PAUSE action not yet supported")
+}
+
+func TestControlAccountReconciliation_ResumeUnimplemented(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	run := newRunningRun(t)
+	repo.runs[run.RunID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  run.RunID.String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_RESUME,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+	assert.Contains(t, st.Message(), "RESUME action not yet supported")
+}
+
+func TestControlAccountReconciliation_NotFound(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  uuid.New().String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+	assert.Contains(t, st.Message(), "settlement run not found")
+}
+
+func TestControlAccountReconciliation_InvalidUUID(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  "not-a-uuid",
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid run_id")
+}
+
+func TestControlAccountReconciliation_EmptyRunID(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  "",
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "run_id is required")
+}
+
+func TestControlAccountReconciliation_UnspecifiedAction(t *testing.T) {
+	repo := newMockSettlementRunRepo()
+	run := newPendingRun(t)
+	repo.runs[run.RunID] = run
+
+	svc := service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+	)
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  run.RunID.String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_UNSPECIFIED,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "action is required")
+}
+
+func TestControlAccountReconciliation_NoRunRepo(t *testing.T) {
+	svc := service.NewAccountReconciliationService()
+
+	resp, err := svc.ControlAccountReconciliation(context.Background(), &reconciliationv1.ControlAccountReconciliationRequest{
+		RunId:  uuid.New().String(),
+		Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+	})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+}

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -163,10 +163,70 @@ func (s *AccountReconciliationService) RetrieveAccountReconciliation(
 
 // ControlAccountReconciliation controls a settlement run (cancel, pause, resume).
 func (s *AccountReconciliationService) ControlAccountReconciliation(
-	_ context.Context,
-	_ *reconciliationv1.ControlAccountReconciliationRequest,
+	ctx context.Context,
+	req *reconciliationv1.ControlAccountReconciliationRequest,
 ) (*reconciliationv1.ControlAccountReconciliationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ControlAccountReconciliation not yet implemented")
+	if s.runRepo == nil {
+		return nil, status.Error(codes.Unimplemented, "ControlAccountReconciliation not yet implemented")
+	}
+
+	runIDStr := req.GetRunId()
+	if runIDStr == "" {
+		return nil, status.Error(codes.InvalidArgument, "run_id is required")
+	}
+
+	runID, err := uuid.Parse(runIDStr)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid run_id: %v", err)
+	}
+
+	action := req.GetAction()
+	if action == reconciliationv1.ControlAction_CONTROL_ACTION_UNSPECIFIED {
+		return nil, status.Error(codes.InvalidArgument, "action is required and must not be UNSPECIFIED")
+	}
+
+	run, err := s.runRepo.FindByID(ctx, runID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "settlement run not found: %s", runID)
+		}
+		slog.ErrorContext(ctx, "failed to retrieve settlement run", "run_id", runID, "error", err)
+		return nil, status.Error(codes.Internal, "failed to retrieve settlement run")
+	}
+
+	switch action { //nolint:exhaustive // UNSPECIFIED is handled above
+	case reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL:
+		statusBefore := run.Status
+		if err := run.Cancel(); err != nil {
+			if errors.Is(err, domain.ErrInvalidStatusTransition) {
+				return nil, status.Errorf(codes.FailedPrecondition, "cannot cancel run in %s state", run.Status)
+			}
+			return nil, status.Error(codes.Internal, "failed to cancel settlement run")
+		}
+		if err := s.runRepo.Update(ctx, run); err != nil {
+			slog.ErrorContext(ctx, "failed to persist cancelled run", "run_id", runID, "error", err)
+			return nil, status.Error(codes.Internal, "failed to persist settlement run")
+		}
+		slog.InfoContext(ctx, "settlement run cancelled",
+			"run_id", runID,
+			"action", action.String(),
+			"status_before", statusBefore.String(),
+			"status_after", run.Status.String(),
+		)
+
+	case reconciliationv1.ControlAction_CONTROL_ACTION_PAUSE:
+		return nil, status.Error(codes.Unimplemented, "PAUSE action not yet supported")
+
+	case reconciliationv1.ControlAction_CONTROL_ACTION_RESUME:
+		return nil, status.Error(codes.Unimplemented, "RESUME action not yet supported")
+
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unknown control action: %v", action)
+	}
+
+	return &reconciliationv1.ControlAccountReconciliationResponse{
+		Run: toProtoRunSummary(run),
+	}, nil
 }
 
 // ListReconciliationResults returns paginated variance details for a run.


### PR DESCRIPTION
## Summary

- Implement ControlAccountReconciliation gRPC handler with CANCEL action support
- PAUSE and RESUME actions return Unimplemented for future implementation
- Validates run_id (required, valid UUID) and action (required, not UNSPECIFIED)
- Applies Cancel() domain FSM transition; invalid transitions return FailedPrecondition with descriptive message

## Task Master

Tag: reconciliation-service, Task: 19

## Changes Made

- services/reconciliation/service/service.go: Replace stub with full handler implementation following existing RetrieveAccountReconciliation pattern
- services/reconciliation/service/control_handler_test.go: 10 test cases covering all paths

## Testing

All 10 new tests pass. Full service package test suite passes.