### PR TITLE
feat: Stripe Payment Saga Starlark Script and Party Handler

### DIFF
--- a/services/current-account/service/saga_handlers.go
+++ b/services/current-account/service/saga_handlers.go
@@ -126,6 +126,9 @@ func RegisterCurrentAccountHandlers(registry *saga.HandlerRegistry) error {
 		{"reconciliation.cancel_run", stubNotImplemented("reconciliation.cancel_run")},
 		{"reconciliation.assert_balance", stubNotImplemented("reconciliation.assert_balance")},
 		{"reconciliation.initiate_dispute", stubNotImplemented("reconciliation.initiate_dispute")},
+
+		// Party handlers (stubs - defined in schema for party service)
+		{"party.get_default_payment_method", stubNotImplemented("party.get_default_payment_method")},
 	}
 
 	for _, h := range handlers {

--- a/services/party/client/client.go
+++ b/services/party/client/client.go
@@ -254,6 +254,29 @@ func (c *Client) RetrieveParty(ctx context.Context, req *partyv1.RetrievePartyRe
 	return resp, nil
 }
 
+// GetDefaultPaymentMethod retrieves the default payment method for a party.
+// This is an idempotent read operation, so it uses circuit breaker with retry.
+func (c *Client) GetDefaultPaymentMethod(ctx context.Context, req *partyv1.GetDefaultPaymentMethodRequest) (*partyv1.GetDefaultPaymentMethodResponse, error) {
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	if c.resilient != nil {
+		return clients.ExecuteWithResilience(ctx, c.resilient, "GetDefaultPaymentMethod", func() (*partyv1.GetDefaultPaymentMethodResponse, error) {
+			return c.party.GetDefaultPaymentMethod(ctx, req)
+		})
+	}
+
+	resp, err := c.party.GetDefaultPaymentMethod(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default payment method: %w", err)
+	}
+
+	return resp, nil
+}
+
 // Close terminates the gRPC connection gracefully.
 func (c *Client) Close() error {
 	if c.conn != nil {

--- a/services/party/client/starlark.go
+++ b/services/party/client/starlark.go
@@ -5,12 +5,16 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
 	"github.com/meridianhub/meridian/shared/pkg/clients"
 	"github.com/meridianhub/meridian/shared/pkg/saga"
 )
+
+// errMissingPaymentMethod is returned when the gRPC response contains no payment method.
+var errMissingPaymentMethod = errors.New("missing payment method in response")
 
 // RegisterStarlarkHandlers registers all Starlark service bindings for the Party service.
 // These handlers adapt the Starlark interface (map[string]any) to gRPC client calls.
@@ -64,6 +68,9 @@ func getDefaultPaymentMethodHandler(client *Client) saga.Handler {
 		}
 
 		pm := resp.GetPaymentMethod()
+		if pm == nil {
+			return nil, fmt.Errorf("party.get_default_payment_method: %w: party_id %s", errMissingPaymentMethod, partyID)
+		}
 		return map[string]any{
 			"provider":             pm.GetProvider().String(),
 			"provider_customer_id": pm.GetProviderCustomerId(),

--- a/services/party/client/starlark.go
+++ b/services/party/client/starlark.go
@@ -58,6 +58,10 @@ func getDefaultPaymentMethodHandler(client *Client) saga.Handler {
 			return nil, err
 		}
 
+		if err := ctx.ValidatePartyAccessFromString(partyID); err != nil {
+			return nil, fmt.Errorf("party.get_default_payment_method: %w", err)
+		}
+
 		clientCtx := preparePartyClientContext(ctx)
 
 		resp, err := client.GetDefaultPaymentMethod(clientCtx, &partyv1.GetDefaultPaymentMethodRequest{

--- a/services/party/client/starlark.go
+++ b/services/party/client/starlark.go
@@ -1,0 +1,82 @@
+// Package client provides Starlark service bindings for the Party service.
+// These handlers adapt the Starlark interface (map[string]any) to gRPC client calls,
+// enabling saga step execution with real Party service integration.
+package client
+
+import (
+	"context"
+	"fmt"
+
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/shared/pkg/clients"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+)
+
+// RegisterStarlarkHandlers registers all Starlark service bindings for the Party service.
+// These handlers adapt the Starlark interface (map[string]any) to gRPC client calls.
+func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) error {
+	handlers := map[string]struct {
+		handler  saga.Handler
+		metadata saga.HandlerMetadata
+	}{
+		"party.get_default_payment_method": {
+			handler: getDefaultPaymentMethodHandler(client),
+			metadata: saga.HandlerMetadata{
+				ProducesInstruments: []string{},
+			},
+		},
+	}
+
+	for name, h := range handlers {
+		if err := registry.RegisterWithMetadata(name, h.handler, &h.metadata); err != nil {
+			return fmt.Errorf("failed to register %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// getDefaultPaymentMethodHandler retrieves the default payment method for a party.
+// This is a read-only lookup used by the stripe_payment saga to resolve payment
+// method details before creating a lien and sending to the gateway.
+//
+// Parameters:
+//   - party_id (string): Party identifier (UUID)
+//
+// Returns a map containing:
+//   - provider: Payment provider (e.g., "stripe")
+//   - provider_customer_id: Provider-assigned customer identifier
+//   - provider_method_id: Provider-assigned payment method identifier
+//   - method_type: Payment method type (e.g., "card", "bank_account")
+func getDefaultPaymentMethodHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		partyID, err := saga.RequireStringParam(params, "party_id")
+		if err != nil {
+			return nil, err
+		}
+
+		clientCtx := preparePartyClientContext(ctx)
+
+		resp, err := client.GetDefaultPaymentMethod(clientCtx, &partyv1.GetDefaultPaymentMethodRequest{
+			PartyId: partyID,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("party.get_default_payment_method: %w", err)
+		}
+
+		pm := resp.GetPaymentMethod()
+		return map[string]any{
+			"provider":             pm.GetProvider().String(),
+			"provider_customer_id": pm.GetProviderCustomerId(),
+			"provider_method_id":   pm.GetProviderMethodId(),
+			"method_type":          pm.GetMethodType().String(),
+		}, nil
+	}
+}
+
+// preparePartyClientContext enriches the gRPC client context with saga metadata.
+func preparePartyClientContext(ctx *saga.StarlarkContext) context.Context {
+	clientCtx := ctx.Context
+	clientCtx = clients.PropagateIdempotencyKey(clientCtx, ctx.IdempotencyKey)
+	clientCtx = clients.PropagateKnowledgeAt(clientCtx, ctx.KnowledgeAt)
+	return clientCtx
+}

--- a/services/party/client/starlark.go
+++ b/services/party/client/starlark.go
@@ -43,10 +43,10 @@ func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) er
 //   - party_id (string): Party identifier (UUID)
 //
 // Returns a map containing:
-//   - provider: Payment provider (e.g., "stripe")
+//   - provider: Payment provider enum string (e.g., "PAYMENT_METHOD_PROVIDER_STRIPE")
 //   - provider_customer_id: Provider-assigned customer identifier
 //   - provider_method_id: Provider-assigned payment method identifier
-//   - method_type: Payment method type (e.g., "card", "bank_account")
+//   - method_type: Payment method type enum string (e.g., "PAYMENT_METHOD_TYPE_CARD")
 func getDefaultPaymentMethodHandler(client *Client) saga.Handler {
 	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
 		partyID, err := saga.RequireStringParam(params, "party_id")

--- a/services/party/client/starlark_test.go
+++ b/services/party/client/starlark_test.go
@@ -107,6 +107,29 @@ func TestGetDefaultPaymentMethodHandler_MissingPartyID(t *testing.T) {
 	assert.ErrorIs(t, err, saga.ErrMissingParam)
 }
 
+func TestGetDefaultPaymentMethodHandler_NilPaymentMethod(t *testing.T) {
+	mock := &mockPartyServiceClient{
+		getDefaultPMResp: &partyv1.GetDefaultPaymentMethodResponse{
+			PaymentMethod: nil,
+		},
+	}
+
+	client := &Client{party: mock}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_default_payment_method")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"party_id": uuid.New().String(),
+	})
+
+	assert.ErrorIs(t, err, errMissingPaymentMethod)
+}
+
 func TestGetDefaultPaymentMethodHandler_NotFound(t *testing.T) {
 	mock := &mockPartyServiceClient{
 		getDefaultPMErr: status.Errorf(codes.NotFound, "no default payment method"),

--- a/services/party/client/starlark_test.go
+++ b/services/party/client/starlark_test.go
@@ -1,0 +1,130 @@
+package client
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	partyv1 "github.com/meridianhub/meridian/api/proto/meridian/party/v1"
+	"github.com/meridianhub/meridian/shared/pkg/saga"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/google/uuid"
+)
+
+// mockPartyServiceClient implements partyv1.PartyServiceClient for testing.
+type mockPartyServiceClient struct {
+	partyv1.PartyServiceClient
+	getDefaultPMResp *partyv1.GetDefaultPaymentMethodResponse
+	getDefaultPMErr  error
+}
+
+func (m *mockPartyServiceClient) GetDefaultPaymentMethod(_ context.Context, _ *partyv1.GetDefaultPaymentMethodRequest, _ ...grpc.CallOption) (*partyv1.GetDefaultPaymentMethodResponse, error) {
+	return m.getDefaultPMResp, m.getDefaultPMErr
+}
+
+func newTestStarlarkContext() *saga.StarlarkContext {
+	return &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		CorrelationID:   uuid.New(),
+		Logger:          slog.Default(),
+	}
+}
+
+func TestRegisterStarlarkHandlers(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	client := &Client{party: &mockPartyServiceClient{}}
+
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	assert.True(t, registry.Has("party.get_default_payment_method"))
+}
+
+func TestRegisterStarlarkHandlers_DuplicateRegistration(t *testing.T) {
+	registry := saga.NewHandlerRegistry()
+	client := &Client{party: &mockPartyServiceClient{}}
+
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	err = RegisterStarlarkHandlers(registry, client)
+	assert.ErrorIs(t, err, saga.ErrHandlerAlreadyRegistered)
+}
+
+func TestGetDefaultPaymentMethodHandler_Success(t *testing.T) {
+	mock := &mockPartyServiceClient{
+		getDefaultPMResp: &partyv1.GetDefaultPaymentMethodResponse{
+			PaymentMethod: &partyv1.PartyPaymentMethod{
+				Provider:           partyv1.PaymentMethodProvider_PAYMENT_METHOD_PROVIDER_STRIPE,
+				ProviderCustomerId: "cus_test123456",
+				ProviderMethodId:   "pm_test789012",
+				MethodType:         partyv1.PaymentMethodType_PAYMENT_METHOD_TYPE_CARD,
+			},
+		},
+	}
+
+	client := &Client{party: mock}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_default_payment_method")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	result, err := handler(ctx, map[string]any{
+		"party_id": uuid.New().String(),
+	})
+
+	require.NoError(t, err)
+	resultMap, ok := result.(map[string]any)
+	require.True(t, ok)
+
+	assert.Equal(t, "PAYMENT_METHOD_PROVIDER_STRIPE", resultMap["provider"])
+	assert.Equal(t, "cus_test123456", resultMap["provider_customer_id"])
+	assert.Equal(t, "pm_test789012", resultMap["provider_method_id"])
+	assert.Equal(t, "PAYMENT_METHOD_TYPE_CARD", resultMap["method_type"])
+}
+
+func TestGetDefaultPaymentMethodHandler_MissingPartyID(t *testing.T) {
+	client := &Client{party: &mockPartyServiceClient{}}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_default_payment_method")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{})
+
+	assert.ErrorIs(t, err, saga.ErrMissingParam)
+}
+
+func TestGetDefaultPaymentMethodHandler_NotFound(t *testing.T) {
+	mock := &mockPartyServiceClient{
+		getDefaultPMErr: status.Errorf(codes.NotFound, "no default payment method"),
+	}
+
+	client := &Client{party: mock}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_default_payment_method")
+	require.NoError(t, err)
+
+	ctx := newTestStarlarkContext()
+	_, err = handler(ctx, map[string]any{
+		"party_id": uuid.New().String(),
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "party.get_default_payment_method")
+}

--- a/services/party/client/starlark_test.go
+++ b/services/party/client/starlark_test.go
@@ -151,3 +151,33 @@ func TestGetDefaultPaymentMethodHandler_NotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "party.get_default_payment_method")
 }
+
+func TestGetDefaultPaymentMethodHandler_PartyScopeViolation(t *testing.T) {
+	client := &Client{party: &mockPartyServiceClient{}}
+	registry := saga.NewHandlerRegistry()
+	err := RegisterStarlarkHandlers(registry, client)
+	require.NoError(t, err)
+
+	handler, err := registry.Get("party.get_default_payment_method")
+	require.NoError(t, err)
+
+	ownPartyID := uuid.New()
+	foreignPartyID := uuid.New()
+
+	ctx := &saga.StarlarkContext{
+		Context:         context.Background(),
+		SagaExecutionID: uuid.New(),
+		CorrelationID:   uuid.New(),
+		Logger:          slog.Default(),
+		PartyScope: &saga.PartyScope{
+			PartyID:        ownPartyID,
+			VisibleParties: []uuid.UUID{ownPartyID},
+		},
+	}
+
+	_, err = handler(ctx, map[string]any{
+		"party_id": foreignPartyID.String(),
+	})
+
+	assert.ErrorIs(t, err, saga.ErrPartyScopeViolation)
+}

--- a/services/reference-data/saga/defaults/stripe_payment/v1.0.0.star
+++ b/services/reference-data/saga/defaults/stripe_payment/v1.0.0.star
@@ -1,0 +1,125 @@
+# Saga: stripe_payment
+# Version: 1.0.0
+# Previous: none
+# Changed: Initial implementation of Stripe payment saga
+# Author: Platform Team
+# Date: 2026-02-11
+#
+# Stripe Payment saga orchestrating end-to-end payment flow with Stripe as
+# the external gateway provider. Resolves the party's default payment method,
+# reserves funds via lien, sends to Stripe gateway, posts ledger entries, and
+# executes the lien.
+#
+# This saga extends the generic payment_execution saga by adding an initial
+# payment method resolution step that fetches Stripe-specific credentials
+# (provider_customer_id, provider_method_id) from the Party service.
+#
+# Steps:
+#   1. get_payment_method  - Resolve party's default Stripe payment method
+#   2. create_lien         - Reserve funds with payment_attributes from step 1
+#   3. send_to_gateway     - Submit payment to Stripe via gateway adapter
+#   4. post_ledger         - Post double-entry ledger records (webhook-triggered)
+#   5. execute_lien        - Finalize lien after ledger posted (webhook-triggered)
+#
+# Compensation: Steps 2-5 use payment_order handlers with built-in compensation
+# (terminate_lien). Step 1 is read-only and requires no compensation.
+#
+# Input parameters (from input_data dict):
+#   - party_id: string (required) - party whose default payment method to use
+#   - payment_order_id: string (required)
+#   - debtor_account_id: string (required)
+#   - creditor_reference: string (required)
+#   - amount_cents: int64 (required)
+#   - currency: string (required, e.g., "GBP", "USD")
+#   - idempotency_key: string (required)
+#   - instrument_code: string (optional, for bucket evaluation)
+#   - payment_attributes: dict (optional, base attributes for CEL bucket expression)
+#   - should_post_ledger: bool (optional, default false - set by webhook)
+#   - should_execute_lien: bool (optional, default false - set by webhook)
+#   - internal_clearing_enabled: bool (optional, for 4-posting ledger flow)
+
+def stripe_payment():
+    """
+    Main saga entry point.
+    Resolves Stripe payment method then executes payment order flow.
+    """
+
+    ctx = input_data
+
+    # Step 1: Resolve the party's default payment method
+    step(name="get_payment_method")
+    pm_result = party.get_default_payment_method(
+        party_id=ctx.get("party_id"),
+    )
+
+    # Build payment_attributes by merging resolved payment method details
+    # with any additional attributes provided in the input
+    payment_attrs = dict(ctx.get("payment_attributes", {}))
+    payment_attrs["provider"] = pm_result.provider
+    payment_attrs["provider_customer_id"] = pm_result.provider_customer_id
+    payment_attrs["provider_method_id"] = pm_result.provider_method_id
+    payment_attrs["method_type"] = pm_result.method_type
+
+    # Step 2: Reserve funds via lien with payment method attributes
+    step(name="create_lien")
+    lien_result = payment_order.create_lien(
+        account_id=ctx.get("debtor_account_id"),
+        amount_cents=ctx.get("amount_cents"),
+        currency=ctx.get("currency"),
+        payment_order_id=ctx.get("payment_order_id"),
+        instrument_code=ctx.get("instrument_code", ""),
+        payment_attributes=payment_attrs,
+    )
+
+    lien_id = lien_result.lien_id
+
+    # Step 3: Send payment to Stripe gateway
+    step(name="send_to_gateway")
+    gateway_result = payment_order.send_to_gateway(
+        payment_order_id=ctx.get("payment_order_id"),
+        debtor_account_id=ctx.get("debtor_account_id"),
+        creditor_reference=ctx.get("creditor_reference"),
+        amount_cents=ctx.get("amount_cents"),
+        currency=ctx.get("currency"),
+        idempotency_key=ctx.get("idempotency_key"),
+    )
+
+    gateway_reference_id = gateway_result.gateway_reference_id
+
+    # Build result with payment method and gateway info
+    result = {
+        "lien_id": lien_id,
+        "gateway_reference_id": gateway_reference_id,
+        "gateway_status": gateway_result.gateway_status,
+        "provider": pm_result.provider,
+        "provider_customer_id": pm_result.provider_customer_id,
+        "provider_method_id": pm_result.provider_method_id,
+    }
+
+    # Step 4: Post ledger entries (conditional - triggered by webhook)
+    if ctx.get("should_post_ledger", False):
+        step(name="post_ledger")
+        ledger_result = payment_order.post_ledger_entries(
+            payment_order_id=ctx.get("payment_order_id"),
+            debtor_account_id=ctx.get("debtor_account_id"),
+            gateway_reference_id=gateway_reference_id,
+            amount_cents=ctx.get("amount_cents"),
+            currency=ctx.get("currency"),
+            idempotency_key=ctx.get("idempotency_key"),
+            internal_clearing_enabled=ctx.get("internal_clearing_enabled", False),
+        )
+        result["booking_log_id"] = ledger_result.booking_log_id
+
+    # Step 5: Execute lien (conditional - triggered by webhook after ledger posted)
+    if ctx.get("should_execute_lien", False):
+        if lien_id:
+            step(name="execute_lien")
+            execution_result = payment_order.execute_lien(
+                lien_id=lien_id,
+            )
+            result["lien_execution_status"] = execution_result.execution_status
+
+    return result
+
+# Execute the saga
+output = stripe_payment()

--- a/services/reference-data/saga/defaults/stripe_payment/v1.0.0.star
+++ b/services/reference-data/saga/defaults/stripe_payment/v1.0.0.star
@@ -54,7 +54,7 @@ def stripe_payment():
 
     # Build payment_attributes by merging resolved payment method details
     # with any additional attributes provided in the input
-    payment_attrs = dict(ctx.get("payment_attributes", {}))
+    payment_attrs = dict(ctx.get("payment_attributes") or {})
     payment_attrs["provider"] = pm_result.provider
     payment_attrs["provider_customer_id"] = pm_result.provider_customer_id
     payment_attrs["provider_method_id"] = pm_result.provider_method_id

--- a/services/reference-data/saga/e2e_seeder_test.go
+++ b/services/reference-data/saga/e2e_seeder_test.go
@@ -135,7 +135,7 @@ def posting_rules(ctx):
 			migratedCount++
 		}
 	}
-	assert.Equal(t, 4, migratedCount, "all 4 sagas should be migrated")
+	assert.Equal(t, 5, migratedCount, "all 5 sagas should be migrated")
 
 	// Verify beta's sagas now use platform_ref
 	betaCtx := tenant.WithTenant(ctx, betaID)
@@ -180,7 +180,7 @@ func TestE2E_SeededSagasAreActive(t *testing.T) {
 		count++
 	}
 	require.NoError(t, rows.Err())
-	assert.Equal(t, 4, count, "should have 4 seeded sagas")
+	assert.Equal(t, 5, count, "should have 5 seeded sagas")
 }
 
 // TestE2E_ReseedingDoesNotDuplicate verifies ON CONFLICT idempotency.
@@ -218,7 +218,7 @@ func TestE2E_ReseedingDoesNotDuplicate(t *testing.T) {
 		"SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true").
 		Scan(&count)
 	require.NoError(t, err)
-	assert.Equal(t, 4, count, "re-seeding should not create duplicates")
+	assert.Equal(t, 5, count, "re-seeding should not create duplicates")
 }
 
 // TestE2E_PlatformRefIntegrityConstraint verifies the CHECK constraint:

--- a/services/reference-data/saga/platform_sync_test.go
+++ b/services/reference-data/saga/platform_sync_test.go
@@ -1255,6 +1255,7 @@ func TestPlatformSync_EmbeddedMetadataHeaders(t *testing.T) {
 		"deposit/v1.0.0.star",
 		"withdrawal/v1.0.0.star",
 		"payment_execution/v1.0.0.star",
+		"stripe_payment/v1.0.0.star",
 	}
 
 	for _, key := range versionedKeys {

--- a/services/reference-data/saga/seeder_test.go
+++ b/services/reference-data/saga/seeder_test.go
@@ -21,6 +21,7 @@ func TestGetEmbeddedScripts(t *testing.T) {
 		"withdrawal/v1.0.0.star",
 		"payment_execution/v1.0.0.star",
 		"reconciliation_adjustment/v1.0.0.star",
+		"stripe_payment/v1.0.0.star",
 	}
 
 	for _, expected := range expectedVersioned {
@@ -35,6 +36,7 @@ func TestGetEmbeddedScripts(t *testing.T) {
 		"deposit.star",
 		"payment_execution.star",
 		"reconciliation_adjustment.star",
+		"stripe_payment.star",
 	}
 
 	for _, expected := range expectedFlat {
@@ -48,7 +50,7 @@ func TestPlatformDefaults(t *testing.T) {
 	defaults, err := PlatformDefaults()
 	require.NoError(t, err)
 
-	assert.Len(t, defaults, 4)
+	assert.Len(t, defaults, 5)
 
 	// Verify each default has required fields
 	for _, meta := range defaults {
@@ -67,6 +69,7 @@ func TestPlatformDefaults(t *testing.T) {
 	assert.Contains(t, names, "current_account_deposit")
 	assert.Contains(t, names, "payment_execution")
 	assert.Contains(t, names, "reconciliation_adjustment")
+	assert.Contains(t, names, "stripe_payment")
 }
 
 func TestSeeder_SeedTenant(t *testing.T) {
@@ -96,7 +99,7 @@ func TestSeeder_SeedTenant(t *testing.T) {
 		var count int
 		err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true").Scan(&count)
 		require.NoError(t, err)
-		assert.Equal(t, 4, count, "expected 4 system sagas")
+		assert.Equal(t, 5, count, "expected 5 system sagas")
 
 		// Verify each saga has platform_ref and no script
 		rows, err := pool.Query(ctx, `
@@ -144,11 +147,11 @@ func TestSeeder_SeedTenant(t *testing.T) {
 		err := seeder.SeedTenant(ctx, tenantID)
 		require.NoError(t, err)
 
-		// Count should still be 3
+		// Count should still be 5
 		var count int
 		err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true").Scan(&count)
 		require.NoError(t, err)
-		assert.Equal(t, 4, count, "idempotent seed should not create duplicates")
+		assert.Equal(t, 5, count, "idempotent seed should not create duplicates")
 	})
 
 	t.Run("deterministic UUIDs", func(t *testing.T) {
@@ -172,6 +175,7 @@ func TestSeeder_SeedTenant(t *testing.T) {
 			uuid.NewSHA1(uuid.NameSpaceDNS, []byte("saga.meridian.current_account_withdrawal")),
 			uuid.NewSHA1(uuid.NameSpaceDNS, []byte("saga.meridian.payment_execution")),
 			uuid.NewSHA1(uuid.NameSpaceDNS, []byte("saga.meridian.reconciliation_adjustment")),
+			uuid.NewSHA1(uuid.NameSpaceDNS, []byte("saga.meridian.stripe_payment")),
 		}
 
 		assert.Equal(t, expectedIDs, ids, "UUIDs should be deterministic")

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -569,6 +569,28 @@ handlers:
         type: string
         description: "Status of the lien execution (EXECUTED)"
 
+  # Party Service
+  party.get_default_payment_method:
+    description: "Retrieve the default payment method for a party"
+    params:
+      party_id:
+        type: string
+        required: true
+        description: "Party identifier (UUID)"
+    returns:
+      provider:
+        type: string
+        description: "Payment provider (e.g., stripe)"
+      provider_customer_id:
+        type: string
+        description: "Provider-assigned customer identifier"
+      provider_method_id:
+        type: string
+        description: "Provider-assigned payment method identifier"
+      method_type:
+        type: string
+        description: "Payment method type (e.g., card, bank_account, sepa)"
+
   # Account Reconciliation Service
   reconciliation.initiate_run:
     description: "Initiate a new settlement reconciliation run"

--- a/shared/pkg/saga/schema/handlers_test.go
+++ b/shared/pkg/saga/schema/handlers_test.go
@@ -48,6 +48,7 @@ func TestPlatformHandlersSchema(t *testing.T) {
 		"reconciliation.cancel_run",
 		"reconciliation.assert_balance",
 		"reconciliation.initiate_dispute",
+		"party.get_default_payment_method",
 	}
 
 	assert.Len(t, schema.Handlers, len(expectedHandlers),
@@ -108,7 +109,7 @@ func TestRegistryLoadPlatformHandlers(t *testing.T) {
 	require.NoError(t, err)
 
 	handlers := registry.ListHandlers()
-	assert.Len(t, handlers, 28, "registry should contain all 28 platform handlers")
+	assert.Len(t, handlers, 29, "registry should contain all 29 platform handlers")
 
 	// Verify we can get each handler
 	for _, name := range handlers {


### PR DESCRIPTION
## Summary

- Add `party.get_default_payment_method` handler to `handlers.yaml` schema and implement the Go Starlark binding that bridges to the party gRPC client
- Create `stripe_payment/v1.0.0.star` saga script with 5 orchestration steps: resolve payment method, create lien, send to gateway, post ledger entries, execute lien
- Update all platform default test counts from 4 to 5 to account for the new embedded saga

## Changes Made

### handlers.yaml Extension
- New handler `party.get_default_payment_method` with `party_id` (string, required) param and string returns: `provider`, `provider_customer_id`, `provider_method_id`, `method_type`

### Party Client (`services/party/client/`)
- `client.go`: Added `GetDefaultPaymentMethod` gRPC method with resilience and timeout patterns matching existing methods
- `starlark.go`: New file implementing `RegisterStarlarkHandlers` and `getDefaultPaymentMethodHandler` to bridge Starlark saga calls to gRPC
- `starlark_test.go`: 5 test cases covering registration, duplicate registration, success, missing params, and not-found error handling

### Starlark Saga Script
- `services/reference-data/saga/defaults/stripe_payment/v1.0.0.star`: 5-step saga extending the payment_execution pattern with an initial payment method resolution step. Steps 4-5 are webhook-conditional (post_ledger, execute_lien).

### Test Count Updates
- `seeder_test.go`, `e2e_seeder_test.go`, `platform_sync_test.go`, `handlers_test.go`: Updated expected platform default counts from 4 to 5 and added `stripe_payment` to expected name/key lists

## Test Plan

- [x] Party client starlark handler tests (15/15 passing)
- [x] Schema handler count test (29 handlers)
- [x] Embedded script version/metadata header validation
- [x] Platform defaults discovery (5 sagas)
- [x] go vet clean across all modified packages
- [x] golangci-lint clean (pre-commit hook)