### PR TITLE
feat: wire ExecuteAccountReconciliation handler with async orchestration

### DIFF
--- a/services/reconciliation/service/execute_handler_test.go
+++ b/services/reconciliation/service/execute_handler_test.go
@@ -1,0 +1,404 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/services/reconciliation/service"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// testRunRepo extends mockSettlementRunRepo with thread-safe access for async tests.
+type testRunRepo struct {
+	mu   sync.RWMutex
+	runs map[uuid.UUID]*domain.SettlementRun
+	err  error
+}
+
+func newTestRunRepo() *testRunRepo {
+	return &testRunRepo{runs: make(map[uuid.UUID]*domain.SettlementRun)}
+}
+
+func (m *testRunRepo) Create(_ context.Context, run *domain.SettlementRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *testRunRepo) FindByID(_ context.Context, runID uuid.UUID) (*domain.SettlementRun, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	run, ok := m.runs[runID]
+	if !ok {
+		return nil, domain.ErrNotFound
+	}
+	// Return a copy to avoid data races on the shared struct.
+	cp := *run
+	return &cp, nil
+}
+
+func (m *testRunRepo) Update(_ context.Context, run *domain.SettlementRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.runs[run.RunID]; !ok {
+		return domain.ErrNotFound
+	}
+	m.runs[run.RunID] = run
+	return nil
+}
+
+func (m *testRunRepo) List(_ context.Context, _ domain.RunFilter) ([]*domain.SettlementRun, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	result := make([]*domain.SettlementRun, 0, len(m.runs))
+	for _, r := range m.runs {
+		result = append(result, r)
+	}
+	return result, nil
+}
+
+// getStatus returns the current status of a run in a thread-safe way.
+func (m *testRunRepo) getStatus(runID uuid.UUID) domain.RunStatus {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	run, ok := m.runs[runID]
+	if !ok {
+		return ""
+	}
+	return run.Status
+}
+
+// getFailureReason returns the failure reason in a thread-safe way.
+func (m *testRunRepo) getFailureReason(runID uuid.UUID) string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	run, ok := m.runs[runID]
+	if !ok {
+		return ""
+	}
+	return run.FailureReason
+}
+
+func newPendingRun(t *testing.T) *domain.SettlementRun {
+	t.Helper()
+	now := time.Now().UTC()
+	run, err := domain.NewSettlementRun(
+		"ACC-001",
+		domain.ReconciliationScopeAccount,
+		domain.SettlementTypeDaily,
+		now.Add(-24*time.Hour),
+		now,
+		"test-operator",
+	)
+	require.NoError(t, err)
+	return run
+}
+
+func noopCapturer(_ context.Context, _ uuid.UUID) error { return nil }
+func noopDetector(_ context.Context, _ uuid.UUID) ([]*domain.Variance, error) {
+	return nil, nil
+}
+func noopValuator(_ context.Context, _ uuid.UUID) error { return nil }
+
+func newServiceWithPipeline(repo domain.SettlementRunRepository, capturer service.SnapshotCapturerFunc, detector service.VarianceDetectorFunc, valuator service.VarianceValuatorFunc) *service.AccountReconciliationService {
+	return service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(repo),
+		service.WithSnapshotCapturer(capturer),
+		service.WithVarianceDetector(detector),
+		service.WithVarianceValuator(valuator),
+	)
+}
+
+func TestExecuteAccountReconciliation_Success(t *testing.T) {
+	repo := newTestRunRepo()
+	run := newPendingRun(t)
+	repo.runs[run.RunID] = run
+
+	svc := newServiceWithPipeline(repo, noopCapturer, noopDetector, noopValuator)
+
+	resp, err := svc.ExecuteAccountReconciliation(context.Background(),
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: run.RunID.String(),
+		})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.GetRun())
+	assert.Equal(t, run.RunID.String(), resp.GetRun().GetRunId())
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_RUNNING, resp.GetRun().GetStatus())
+
+	// Wait for async pipeline to complete
+	err = await.New().
+		AtMost(5 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return repo.getStatus(run.RunID) == domain.RunStatusCompleted
+		})
+	require.NoError(t, err, "run should transition to COMPLETED")
+}
+
+func TestExecuteAccountReconciliation_NotFound(t *testing.T) {
+	repo := newTestRunRepo()
+	svc := newServiceWithPipeline(repo, noopCapturer, noopDetector, noopValuator)
+
+	resp, err := svc.ExecuteAccountReconciliation(context.Background(),
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: uuid.New().String(),
+		})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+	assert.Contains(t, st.Message(), "settlement run not found")
+}
+
+func TestExecuteAccountReconciliation_InvalidStatus(t *testing.T) {
+	repo := newTestRunRepo()
+	run := newPendingRun(t)
+	// Transition to RUNNING so it's no longer PENDING
+	require.NoError(t, run.Start())
+	repo.runs[run.RunID] = run
+
+	svc := newServiceWithPipeline(repo, noopCapturer, noopDetector, noopValuator)
+
+	resp, err := svc.ExecuteAccountReconciliation(context.Background(),
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: run.RunID.String(),
+		})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "not in PENDING state")
+}
+
+func TestExecuteAccountReconciliation_AlreadyCompleted(t *testing.T) {
+	repo := newTestRunRepo()
+	run := newPendingRun(t)
+	require.NoError(t, run.Start())
+	require.NoError(t, run.Complete(0))
+	repo.runs[run.RunID] = run
+
+	svc := newServiceWithPipeline(repo, noopCapturer, noopDetector, noopValuator)
+
+	resp, err := svc.ExecuteAccountReconciliation(context.Background(),
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: run.RunID.String(),
+		})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+func TestExecuteAccountReconciliation_PipelineFailure(t *testing.T) {
+	repo := newTestRunRepo()
+	run := newPendingRun(t)
+	repo.runs[run.RunID] = run
+
+	failingCapturer := func(_ context.Context, _ uuid.UUID) error {
+		return errors.New("snapshot capture: connection timeout")
+	}
+
+	svc := newServiceWithPipeline(repo, failingCapturer, noopDetector, noopValuator)
+
+	resp, err := svc.ExecuteAccountReconciliation(context.Background(),
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: run.RunID.String(),
+		})
+
+	// RPC should succeed immediately with RUNNING status
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_RUNNING, resp.GetRun().GetStatus())
+
+	// Wait for async pipeline failure
+	err = await.New().
+		AtMost(5 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return repo.getStatus(run.RunID) == domain.RunStatusFailed
+		})
+	require.NoError(t, err, "run should transition to FAILED")
+}
+
+func TestExecuteAccountReconciliation_ContextDetachment(t *testing.T) {
+	repo := newTestRunRepo()
+	run := newPendingRun(t)
+	repo.runs[run.RunID] = run
+
+	// Use a channel to control when the capturer completes
+	capturerStarted := make(chan struct{})
+	capturer := func(_ context.Context, _ uuid.UUID) error {
+		close(capturerStarted)
+		return nil
+	}
+
+	// Create a context that we'll cancel immediately after the RPC
+	ctx, cancel := context.WithCancel(context.Background())
+
+	svc := newServiceWithPipeline(repo, capturer, noopDetector, noopValuator)
+
+	resp, err := svc.ExecuteAccountReconciliation(ctx,
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: run.RunID.String(),
+		})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Cancel the RPC context immediately
+	cancel()
+
+	// The background goroutine should still run despite the cancelled RPC context
+	select {
+	case <-capturerStarted:
+		// Capturer was invoked - context detachment works
+	case <-time.After(5 * time.Second):
+		t.Fatal("capturer was not invoked - background goroutine may not have been spawned")
+	}
+
+	// Pipeline should complete successfully
+	err = await.New().
+		AtMost(5 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return repo.getStatus(run.RunID) == domain.RunStatusCompleted
+		})
+	require.NoError(t, err, "run should complete despite cancelled RPC context")
+}
+
+func TestExecuteAccountReconciliation_ErrorPersistence(t *testing.T) {
+	repo := newTestRunRepo()
+	run := newPendingRun(t)
+	repo.runs[run.RunID] = run
+
+	expectedErrMsg := "variance detection: instrument not found"
+	failingDetector := func(_ context.Context, _ uuid.UUID) ([]*domain.Variance, error) {
+		return nil, errors.New(expectedErrMsg)
+	}
+
+	svc := newServiceWithPipeline(repo, noopCapturer, failingDetector, noopValuator)
+
+	resp, err := svc.ExecuteAccountReconciliation(context.Background(),
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: run.RunID.String(),
+		})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Wait for async pipeline to fail
+	err = await.New().
+		AtMost(5 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return repo.getStatus(run.RunID) == domain.RunStatusFailed
+		})
+	require.NoError(t, err, "run should transition to FAILED")
+
+	// Verify the error message was persisted
+	reason := repo.getFailureReason(run.RunID)
+	assert.Contains(t, reason, expectedErrMsg)
+}
+
+func TestExecuteAccountReconciliation_EmptyRunID(t *testing.T) {
+	repo := newTestRunRepo()
+	svc := newServiceWithPipeline(repo, noopCapturer, noopDetector, noopValuator)
+
+	resp, err := svc.ExecuteAccountReconciliation(context.Background(),
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: "",
+		})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "run_id is required")
+}
+
+func TestExecuteAccountReconciliation_InvalidUUID(t *testing.T) {
+	repo := newTestRunRepo()
+	svc := newServiceWithPipeline(repo, noopCapturer, noopDetector, noopValuator)
+
+	resp, err := svc.ExecuteAccountReconciliation(context.Background(),
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: "not-a-uuid",
+		})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invalid run_id")
+}
+
+func TestExecuteAccountReconciliation_NoDependencies(t *testing.T) {
+	// When pipeline dependencies are not configured, handler should return Unimplemented
+	svc := service.NewAccountReconciliationService()
+
+	resp, err := svc.ExecuteAccountReconciliation(context.Background(),
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: uuid.New().String(),
+		})
+
+	require.Nil(t, resp)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unimplemented, st.Code())
+}
+
+func TestExecuteAccountReconciliation_ValuatorFailure(t *testing.T) {
+	repo := newTestRunRepo()
+	run := newPendingRun(t)
+	repo.runs[run.RunID] = run
+
+	failingValuator := func(_ context.Context, _ uuid.UUID) error {
+		return errors.New("valuation engine unavailable")
+	}
+
+	svc := newServiceWithPipeline(repo, noopCapturer, noopDetector, failingValuator)
+
+	resp, err := svc.ExecuteAccountReconciliation(context.Background(),
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: run.RunID.String(),
+		})
+
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	// Wait for async pipeline to fail at valuation step
+	err = await.New().
+		AtMost(5 * time.Second).
+		PollInterval(50 * time.Millisecond).
+		Until(func() bool {
+			return repo.getStatus(run.RunID) == domain.RunStatusFailed
+		})
+	require.NoError(t, err, "run should transition to FAILED on valuator failure")
+
+	reason := repo.getFailureReason(run.RunID)
+	assert.Contains(t, reason, "valuation engine unavailable")
+}

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -31,8 +31,15 @@ type VarianceDetectorFunc func(ctx context.Context, runID uuid.UUID) ([]*domain.
 // VarianceValuatorFunc values detected variances using the valuation engine.
 type VarianceValuatorFunc func(ctx context.Context, runID uuid.UUID) error
 
-// pipelineTimeout is the maximum time allowed for the background reconciliation pipeline.
-const pipelineTimeout = 15 * time.Minute
+const (
+	// pipelineTimeout is the maximum time allowed for the background reconciliation pipeline.
+	pipelineTimeout = 15 * time.Minute
+
+	// persistTimeout is the maximum time allowed for persisting state transitions
+	// after the pipeline completes or fails. Uses a fresh context so that state
+	// transitions succeed even if the pipeline context has expired.
+	persistTimeout = 30 * time.Second
+)
 
 // AccountReconciliationService implements the gRPC service for reconciliation operations.
 type AccountReconciliationService struct {
@@ -253,8 +260,11 @@ func (s *AccountReconciliationService) executePipeline(ctx context.Context, runI
 		return
 	}
 
-	// Pipeline succeeded: transition to COMPLETED
-	run, err := s.runRepo.FindByID(ctx, runID)
+	// Pipeline succeeded: transition to COMPLETED.
+	// Use a fresh context so persistence succeeds even if the pipeline context has expired.
+	persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout) //nolint:contextcheck
+	defer persistCancel()
+	run, err := s.runRepo.FindByID(persistCtx, runID) //nolint:contextcheck
 	if err != nil {
 		slog.Error("failed to retrieve run for completion", "run_id", runID, "error", err)
 		return
@@ -263,7 +273,7 @@ func (s *AccountReconciliationService) executePipeline(ctx context.Context, runI
 		slog.Error("failed to transition run to COMPLETED", "run_id", runID, "error", err)
 		return
 	}
-	if err := s.runRepo.Update(ctx, run); err != nil {
+	if err := s.runRepo.Update(persistCtx, run); err != nil { //nolint:contextcheck
 		slog.Error("failed to persist COMPLETED state", "run_id", runID, "error", err)
 		return
 	}
@@ -272,8 +282,11 @@ func (s *AccountReconciliationService) executePipeline(ctx context.Context, runI
 }
 
 // failRun transitions a settlement run to FAILED with the given error message.
-func (s *AccountReconciliationService) failRun(ctx context.Context, runID uuid.UUID, errMsg string) {
-	run, err := s.runRepo.FindByID(ctx, runID)
+// It uses a fresh context so persistence succeeds even if the pipeline context has expired.
+func (s *AccountReconciliationService) failRun(_ context.Context, runID uuid.UUID, errMsg string) {
+	persistCtx, persistCancel := context.WithTimeout(context.Background(), persistTimeout) //nolint:contextcheck
+	defer persistCancel()
+	run, err := s.runRepo.FindByID(persistCtx, runID) //nolint:contextcheck
 	if err != nil {
 		slog.Error("failed to retrieve run for failure transition", "run_id", runID, "error", err)
 		return
@@ -282,7 +295,7 @@ func (s *AccountReconciliationService) failRun(ctx context.Context, runID uuid.U
 		slog.Error("failed to transition run to FAILED", "run_id", runID, "error", err)
 		return
 	}
-	if err := s.runRepo.Update(ctx, run); err != nil {
+	if err := s.runRepo.Update(persistCtx, run); err != nil { //nolint:contextcheck
 		slog.Error("failed to persist FAILED state", "run_id", runID, "error", err)
 	}
 }

--- a/services/reconciliation/service/service.go
+++ b/services/reconciliation/service/service.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"time"
 
 	"github.com/google/uuid"
 	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
@@ -21,19 +22,34 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// SnapshotCapturerFunc captures point-in-time position snapshots for a settlement run.
+type SnapshotCapturerFunc func(ctx context.Context, runID uuid.UUID) error
+
+// VarianceDetectorFunc detects variances by comparing snapshots for a settlement run.
+type VarianceDetectorFunc func(ctx context.Context, runID uuid.UUID) ([]*domain.Variance, error)
+
+// VarianceValuatorFunc values detected variances using the valuation engine.
+type VarianceValuatorFunc func(ctx context.Context, runID uuid.UUID) error
+
+// pipelineTimeout is the maximum time allowed for the background reconciliation pipeline.
+const pipelineTimeout = 15 * time.Minute
+
 // AccountReconciliationService implements the gRPC service for reconciliation operations.
 type AccountReconciliationService struct {
 	reconciliationv1.UnimplementedAccountReconciliationServiceServer
 
-	disputeRepo     domain.DisputeRepository
-	runRepo         domain.SettlementRunRepository
-	varianceRepo    VarianceFinder
-	sagaRuntime     SagaRuntime
-	eventPublisher  EventPublisher
-	assertor        *BalanceAssertor
-	policyRuntime   valuation.PolicyRuntime
-	starlarkRuntime valuation.StarlarkRuntime
-	valuationCache  valuation.Cache
+	disputeRepo      domain.DisputeRepository
+	runRepo          domain.SettlementRunRepository
+	varianceRepo     VarianceFinder
+	sagaRuntime      SagaRuntime
+	eventPublisher   EventPublisher
+	assertor         *BalanceAssertor
+	policyRuntime    valuation.PolicyRuntime
+	starlarkRuntime  valuation.StarlarkRuntime
+	valuationCache   valuation.Cache
+	snapshotCapturer SnapshotCapturerFunc
+	varianceDetector VarianceDetectorFunc
+	varianceValuator VarianceValuatorFunc
 }
 
 // Option configures the AccountReconciliationService.
@@ -102,6 +118,27 @@ func WithValuationCache(c valuation.Cache) Option {
 	}
 }
 
+// WithSnapshotCapturer sets the snapshot capture function for the reconciliation pipeline.
+func WithSnapshotCapturer(fn SnapshotCapturerFunc) Option {
+	return func(s *AccountReconciliationService) {
+		s.snapshotCapturer = fn
+	}
+}
+
+// WithVarianceDetector sets the variance detection function for the reconciliation pipeline.
+func WithVarianceDetector(fn VarianceDetectorFunc) Option {
+	return func(s *AccountReconciliationService) {
+		s.varianceDetector = fn
+	}
+}
+
+// WithVarianceValuator sets the variance valuation function for the reconciliation pipeline.
+func WithVarianceValuator(fn VarianceValuatorFunc) Option {
+	return func(s *AccountReconciliationService) {
+		s.varianceValuator = fn
+	}
+}
+
 // NewAccountReconciliationService creates a new AccountReconciliationService.
 // The assertor is optional; if nil, AssertBalance returns UNIMPLEMENTED.
 func NewAccountReconciliationService(opts ...Option) *AccountReconciliationService {
@@ -121,11 +158,133 @@ func (s *AccountReconciliationService) InitiateAccountReconciliation(
 }
 
 // ExecuteAccountReconciliation triggers execution of a pending settlement run.
+//
+// The handler validates the request, transitions the run to RUNNING, returns
+// immediately, and spawns a background goroutine to execute the reconciliation
+// pipeline (capture -> detect -> value). Clients poll via RetrieveAccountReconciliation.
+//
+//nolint:contextcheck // Intentionally uses background context for async pipeline that outlives the RPC
 func (s *AccountReconciliationService) ExecuteAccountReconciliation(
-	_ context.Context,
-	_ *reconciliationv1.ExecuteAccountReconciliationRequest,
+	ctx context.Context,
+	req *reconciliationv1.ExecuteAccountReconciliationRequest,
 ) (*reconciliationv1.ExecuteAccountReconciliationResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "ExecuteAccountReconciliation not yet implemented")
+	if s.runRepo == nil || s.snapshotCapturer == nil || s.varianceDetector == nil || s.varianceValuator == nil {
+		return nil, status.Error(codes.Unimplemented, "ExecuteAccountReconciliation not yet implemented")
+	}
+
+	runIDStr := req.GetRunId()
+	if runIDStr == "" {
+		return nil, status.Error(codes.InvalidArgument, "run_id is required")
+	}
+
+	runID, err := uuid.Parse(runIDStr)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid run_id: %v", err)
+	}
+
+	run, err := s.runRepo.FindByID(ctx, runID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNotFound) {
+			return nil, status.Errorf(codes.NotFound, "settlement run not found: %s", runID)
+		}
+		slog.ErrorContext(ctx, "failed to retrieve settlement run", "run_id", runID, "error", err)
+		return nil, status.Error(codes.Internal, "failed to retrieve settlement run")
+	}
+
+	if run.Status != domain.RunStatusPending {
+		return nil, status.Errorf(codes.FailedPrecondition,
+			"settlement run %s is not in PENDING state (current: %s)", runID, run.Status)
+	}
+
+	if err := run.Start(); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to start settlement run: %v", err)
+	}
+	if err := s.runRepo.Update(ctx, run); err != nil {
+		slog.ErrorContext(ctx, "failed to persist RUNNING state", "run_id", runID, "error", err)
+		return nil, status.Error(codes.Internal, "failed to update settlement run")
+	}
+
+	// Spawn background goroutine with a detached context so it continues
+	// after the RPC returns. The RPC context must not be used here.
+	pipelineCtx, pipelineCancel := context.WithTimeout(context.Background(), pipelineTimeout) //nolint:contextcheck // Intentionally detached: pipeline must outlive the RPC context
+	go func() {
+		defer pipelineCancel()
+		s.executePipeline(pipelineCtx, runID)
+	}()
+
+	return &reconciliationv1.ExecuteAccountReconciliationResponse{
+		Run: toProtoRunSummary(run),
+	}, nil
+}
+
+// executePipeline runs the reconciliation pipeline in the background.
+// The caller is responsible for providing a detached context with timeout.
+func (s *AccountReconciliationService) executePipeline(ctx context.Context, runID uuid.UUID) {
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("reconciliation pipeline panicked",
+				"run_id", runID,
+				"panic", r,
+			)
+			s.failRun(ctx, runID, "pipeline panicked")
+		}
+	}()
+
+	slog.Info("reconciliation pipeline started", "run_id", runID)
+
+	// Step 1: Capture snapshots
+	if err := s.snapshotCapturer(ctx, runID); err != nil {
+		slog.Error("snapshot capture failed", "run_id", runID, "error", err)
+		s.failRun(ctx, runID, err.Error())
+		return
+	}
+
+	// Step 2: Detect variances
+	if _, err := s.varianceDetector(ctx, runID); err != nil {
+		slog.Error("variance detection failed", "run_id", runID, "error", err)
+		s.failRun(ctx, runID, err.Error())
+		return
+	}
+
+	// Step 3: Value variances
+	if err := s.varianceValuator(ctx, runID); err != nil {
+		slog.Error("variance valuation failed", "run_id", runID, "error", err)
+		s.failRun(ctx, runID, err.Error())
+		return
+	}
+
+	// Pipeline succeeded: transition to COMPLETED
+	run, err := s.runRepo.FindByID(ctx, runID)
+	if err != nil {
+		slog.Error("failed to retrieve run for completion", "run_id", runID, "error", err)
+		return
+	}
+	if err := run.Complete(run.VarianceCount); err != nil {
+		slog.Error("failed to transition run to COMPLETED", "run_id", runID, "error", err)
+		return
+	}
+	if err := s.runRepo.Update(ctx, run); err != nil {
+		slog.Error("failed to persist COMPLETED state", "run_id", runID, "error", err)
+		return
+	}
+
+	slog.Info("reconciliation pipeline completed", "run_id", runID)
+}
+
+// failRun transitions a settlement run to FAILED with the given error message.
+func (s *AccountReconciliationService) failRun(ctx context.Context, runID uuid.UUID, errMsg string) {
+	run, err := s.runRepo.FindByID(ctx, runID)
+	if err != nil {
+		slog.Error("failed to retrieve run for failure transition", "run_id", runID, "error", err)
+		return
+	}
+	if err := run.Fail(errMsg); err != nil {
+		slog.Error("failed to transition run to FAILED", "run_id", runID, "error", err)
+		return
+	}
+	if err := s.runRepo.Update(ctx, run); err != nil {
+		slog.Error("failed to persist FAILED state", "run_id", runID, "error", err)
+	}
 }
 
 // RetrieveAccountReconciliation retrieves a settlement run summary.


### PR DESCRIPTION
## Summary

- Wire `ExecuteAccountReconciliation` RPC handler with request validation, status transition from PENDING to RUNNING, and immediate response
- Spawn background goroutine with detached context (15-min timeout) to execute the reconciliation pipeline: snapshot capture, variance detection, variance valuation
- Add `SnapshotCapturerFunc`, `VarianceDetectorFunc`, `VarianceValuatorFunc` function types with corresponding `With*` options for dependency injection
- Pipeline success transitions run to COMPLETED; failure transitions to FAILED with error details persisted to `FailureReason`
- Panic-safe via defer/recover in the background goroutine

## Test plan

- [x] TestExecuteAccountReconciliation_Success: validates RUNNING response and async COMPLETED transition
- [x] TestExecuteAccountReconciliation_NotFound: returns NotFound for missing run
- [x] TestExecuteAccountReconciliation_InvalidStatus: returns FailedPrecondition for non-PENDING runs
- [x] TestExecuteAccountReconciliation_AlreadyCompleted: returns FailedPrecondition for completed runs
- [x] TestExecuteAccountReconciliation_PipelineFailure: verifies FAILED status on capturer error
- [x] TestExecuteAccountReconciliation_ContextDetachment: background goroutine continues after RPC context cancellation
- [x] TestExecuteAccountReconciliation_ErrorPersistence: error message persisted to FailureReason
- [x] TestExecuteAccountReconciliation_EmptyRunID: returns InvalidArgument
- [x] TestExecuteAccountReconciliation_InvalidUUID: returns InvalidArgument
- [x] TestExecuteAccountReconciliation_NoDependencies: returns Unimplemented when deps missing
- [x] TestExecuteAccountReconciliation_ValuatorFailure: verifies FAILED on valuator error

Task: reconciliation-service.21