### PR TITLE
feat: Add cron scheduler for scheduled forecast computation

### DIFF
--- a/services/forecasting/adapters/persistence/strategy_repository.go
+++ b/services/forecasting/adapters/persistence/strategy_repository.go
@@ -257,6 +257,40 @@ func (r *StrategyRepository) ListByTenant(ctx context.Context, tenantID string, 
 	return results, nextPageToken, nil
 }
 
+// ListAllActive returns all strategies with ACTIVE status across all tenants.
+func (r *StrategyRepository) ListAllActive(ctx context.Context) ([]domain.ForecastingStrategy, error) {
+	query := `
+		SELECT id, tenant_id, name, description, starlark_code,
+			horizon_hours, granularity_hours, schedule,
+			input_dataset_codes, output_dataset_code,
+			reference_data_resolution_key,
+			status, version, created_at, updated_at
+		FROM forecasting_strategy
+		WHERE status = 'ACTIVE'
+		ORDER BY tenant_id, name`
+
+	rows, err := r.pool.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list all active strategies: %w", err)
+	}
+	defer rows.Close()
+
+	var results []domain.ForecastingStrategy
+	for rows.Next() {
+		entity, err := r.scanStrategyFromRows(rows)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, EntityToStrategy(entity))
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating active strategies: %w", err)
+	}
+
+	return results, nil
+}
+
 func (r *StrategyRepository) scanStrategy(ctx context.Context, query string, args ...interface{}) (ForecastingStrategyEntity, error) {
 	var entity ForecastingStrategyEntity
 

--- a/services/forecasting/domain/repository.go
+++ b/services/forecasting/domain/repository.go
@@ -30,6 +30,10 @@ type StrategyRepository interface {
 	// ListByTenant returns strategies for a tenant matching the filter criteria.
 	// Returns the strategies, a next page token (empty if no more results), and any error.
 	ListByTenant(ctx context.Context, tenantID string, filters StrategyFilters) ([]ForecastingStrategy, string, error)
+
+	// ListAllActive returns all strategies with ACTIVE status across all tenants.
+	// Used by the cron scheduler to load strategies for scheduled execution.
+	ListAllActive(ctx context.Context) ([]ForecastingStrategy, error)
 }
 
 // StrategyFilters specifies criteria for listing forecasting strategies.

--- a/services/forecasting/handler/forecasting_handler_test.go
+++ b/services/forecasting/handler/forecasting_handler_test.go
@@ -62,6 +62,10 @@ func (m *mockStrategyRepo) ListByTenant(ctx context.Context, tenantID string, fi
 	return nil, "", nil
 }
 
+func (m *mockStrategyRepo) ListAllActive(_ context.Context) ([]domain.ForecastingStrategy, error) {
+	return nil, nil
+}
+
 // mockMISClient implements starlark.MISClient for the ForecastRunner.
 type mockMISClient struct {
 	fetchFn func(ctx context.Context, datasetCode string, before time.Time) ([]starlark.Observation, error)

--- a/services/forecasting/scheduler/cron_scheduler.go
+++ b/services/forecasting/scheduler/cron_scheduler.go
@@ -133,6 +133,7 @@ func (s *CronScheduler) Start(ctx context.Context) error { //nolint:contextcheck
 		return ErrSchedulerRunning
 	}
 	s.running = true
+	s.stopped = false
 	s.mu.Unlock()
 
 	s.logger.Info("cron scheduler starting", "poll_interval", s.config.PollInterval)

--- a/services/forecasting/scheduler/cron_scheduler.go
+++ b/services/forecasting/scheduler/cron_scheduler.go
@@ -1,0 +1,380 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/robfig/cron/v3"
+
+	"github.com/meridianhub/meridian/services/forecasting/domain"
+	"github.com/meridianhub/meridian/shared/platform/tenant"
+)
+
+// Scheduler errors.
+var (
+	ErrNilRepository    = errors.New("strategy repository is required")
+	ErrNilExecutor      = errors.New("forecast executor is required")
+	ErrNilLeaseManager  = errors.New("lease manager is required")
+	ErrNilLogger        = errors.New("logger is required")
+	ErrSchedulerRunning = errors.New("scheduler is already running")
+)
+
+// Default configuration values.
+const (
+	DefaultPollInterval    = 60 * time.Second
+	DefaultShutdownTimeout = 5 * time.Minute
+)
+
+// ForecastResult holds the outcome of a forecast execution.
+type ForecastResult struct {
+	PointCount      int32
+	StrategyVersion int64
+}
+
+// ForecastExecutor abstracts forecast execution for testability.
+// In production, this wraps handler.Service.ComputeForwardCurve.
+type ForecastExecutor interface {
+	ExecuteForecast(ctx context.Context, strategyID uuid.UUID) (*ForecastResult, error)
+}
+
+// Config holds configuration for the CronScheduler.
+type Config struct {
+	// PollInterval is how often to check for strategy changes. Default: 60s.
+	PollInterval time.Duration
+	// ShutdownTimeout is the maximum time to wait for in-flight forecasts during shutdown.
+	// Default: 5 minutes.
+	ShutdownTimeout time.Duration
+}
+
+// CronScheduler loads active forecasting strategies and registers cron jobs
+// for their scheduled execution. It coordinates with other pods via LeaseManager
+// to prevent duplicate executions.
+type CronScheduler struct {
+	strategyRepo domain.StrategyRepository
+	executor     ForecastExecutor
+	leaseManager *LeaseManager
+	metrics      *Metrics
+	logger       *slog.Logger
+	config       Config
+
+	cron    *cron.Cron
+	mu      sync.Mutex
+	wg      sync.WaitGroup
+	jobs    map[string]registeredJob // key: strategyID string
+	running bool
+	stopped bool
+}
+
+// registeredJob tracks a registered cron entry for a strategy.
+type registeredJob struct {
+	entryID  cron.EntryID
+	schedule string
+	tenantID string
+}
+
+// New creates a new CronScheduler.
+func New(
+	strategyRepo domain.StrategyRepository,
+	executor ForecastExecutor,
+	leaseManager *LeaseManager,
+	metrics *Metrics,
+	logger *slog.Logger,
+	config Config,
+) (*CronScheduler, error) {
+	if strategyRepo == nil {
+		return nil, ErrNilRepository
+	}
+	if executor == nil {
+		return nil, ErrNilExecutor
+	}
+	if leaseManager == nil {
+		return nil, ErrNilLeaseManager
+	}
+	if logger == nil {
+		return nil, ErrNilLogger
+	}
+	if metrics == nil {
+		metrics = NewMetrics()
+	}
+	if config.PollInterval == 0 {
+		config.PollInterval = DefaultPollInterval
+	}
+	if config.ShutdownTimeout == 0 {
+		config.ShutdownTimeout = DefaultShutdownTimeout
+	}
+
+	cronRunner := cron.New(
+		cron.WithLocation(time.UTC),
+	)
+
+	return &CronScheduler{
+		strategyRepo: strategyRepo,
+		executor:     executor,
+		leaseManager: leaseManager,
+		metrics:      metrics,
+		logger:       logger.With("component", "cron_scheduler"),
+		config:       config,
+		cron:         cronRunner,
+		jobs:         make(map[string]registeredJob),
+	}, nil
+}
+
+// Start loads active strategies, registers cron jobs, and blocks until the
+// context is cancelled. It starts a background poller that checks for strategy
+// changes every PollInterval.
+func (s *CronScheduler) Start(ctx context.Context) error { //nolint:contextcheck // uses context.Background() intentionally for shutdown lease release
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return ErrSchedulerRunning
+	}
+	s.running = true
+	s.mu.Unlock()
+
+	s.logger.Info("cron scheduler starting", "poll_interval", s.config.PollInterval)
+
+	// Initial strategy load
+	if err := s.reloadStrategies(ctx); err != nil {
+		s.logger.Error("initial strategy load failed", "error", err)
+		// Continue running - poller will retry
+	}
+
+	s.cron.Start()
+	s.logger.Info("cron scheduler started")
+
+	// Start background poller for strategy changes
+	pollDone := make(chan struct{})
+	go func() {
+		defer close(pollDone)
+		s.pollLoop(ctx)
+	}()
+
+	// Block until context cancelled
+	<-ctx.Done()
+	s.logger.Info("cron scheduler stopping: context cancelled")
+
+	s.mu.Lock()
+	s.stopped = true
+	s.mu.Unlock()
+
+	// Stop cron runner (no new jobs will fire)
+	cronCtx := s.cron.Stop()
+
+	// Wait for poller to finish
+	<-pollDone
+
+	// Wait for in-flight jobs
+	waitDone := make(chan struct{})
+	go func() {
+		<-cronCtx.Done()
+		s.wg.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+		s.logger.Info("all in-flight forecasts completed")
+	case <-time.After(s.config.ShutdownTimeout):
+		s.logger.Warn("shutdown timeout reached, some forecasts may not have completed",
+			"timeout", s.config.ShutdownTimeout)
+	}
+
+	// Release all leases - parent context is cancelled, so use a fresh context
+	s.leaseManager.ReleaseAll(context.Background()) //nolint:contextcheck // parent ctx is cancelled at this point
+
+	s.mu.Lock()
+	s.running = false
+	s.mu.Unlock()
+
+	s.logger.Info("cron scheduler stopped")
+	return nil
+}
+
+// pollLoop periodically reloads strategies from the database.
+func (s *CronScheduler) pollLoop(ctx context.Context) {
+	ticker := time.NewTicker(s.config.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := s.reloadStrategies(ctx); err != nil {
+				s.logger.Error("strategy reload failed", "error", err)
+				s.metrics.RecordReload("error")
+			} else {
+				s.metrics.RecordReload("success")
+			}
+		}
+	}
+}
+
+// reloadStrategies fetches all active strategies and synchronizes cron jobs.
+func (s *CronScheduler) reloadStrategies(ctx context.Context) error {
+	strategies, err := s.strategyRepo.ListAllActive(ctx)
+	if err != nil {
+		s.metrics.RecordError("list_active_strategies")
+		return err
+	}
+
+	// Build a map of desired state
+	desired := make(map[string]desiredJob, len(strategies))
+	for _, st := range strategies {
+		desired[st.ID().String()] = desiredJob{
+			strategyID: st.ID(),
+			tenantID:   st.TenantID(),
+			schedule:   st.Schedule(),
+			name:       st.Name(),
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Remove jobs for strategies that are no longer active or have changed schedules
+	for id, job := range s.jobs {
+		d, exists := desired[id]
+		if !exists || d.schedule != job.schedule {
+			s.cron.Remove(job.entryID)
+			delete(s.jobs, id)
+			if !exists {
+				s.logger.Info("removed cron job for deactivated strategy", "strategy_id", id)
+			} else {
+				s.logger.Info("removed cron job for schedule change", "strategy_id", id,
+					"old_schedule", job.schedule, "new_schedule", d.schedule)
+			}
+		}
+	}
+
+	// Add jobs for new or re-scheduled strategies
+	for id, d := range desired {
+		if _, exists := s.jobs[id]; exists {
+			continue
+		}
+
+		entryID, err := s.cron.AddFunc(d.schedule, s.makeJobFunc(d.strategyID, d.tenantID)) //nolint:contextcheck // cron.AddFunc callbacks have no context
+		if err != nil {
+			s.logger.Error("failed to register cron job",
+				"strategy_id", id,
+				"schedule", d.schedule,
+				"error", err)
+			s.metrics.RecordError("register_cron_job")
+			continue
+		}
+
+		s.jobs[id] = registeredJob{
+			entryID:  entryID,
+			schedule: d.schedule,
+			tenantID: d.tenantID,
+		}
+		s.logger.Info("registered cron job",
+			"strategy_id", id,
+			"strategy_name", d.name,
+			"schedule", d.schedule,
+			"tenant_id", d.tenantID)
+	}
+
+	s.metrics.SetActiveStrategies(float64(len(s.jobs)))
+	return nil
+}
+
+// desiredJob holds the target state for a strategy's cron job.
+type desiredJob struct {
+	strategyID uuid.UUID
+	tenantID   string
+	schedule   string
+	name       string
+}
+
+// makeJobFunc creates the function that the cron scheduler calls for a strategy.
+func (s *CronScheduler) makeJobFunc(strategyID uuid.UUID, tenantID string) func() {
+	return func() {
+		s.executeStrategy(strategyID, tenantID)
+	}
+}
+
+// executeStrategy attempts to acquire the lease and execute the forecast.
+// Called by cron runner which does not provide a context.
+func (s *CronScheduler) executeStrategy(strategyID uuid.UUID, tenantID string) { //nolint:contextcheck // cron callbacks have no parent context
+	s.mu.Lock()
+	if s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	s.wg.Add(1)
+	s.mu.Unlock()
+	defer s.wg.Done()
+
+	ctx := context.Background()
+	ctx = tenant.WithTenant(ctx, tenant.TenantID(tenantID))
+	sid := strategyID.String()
+
+	start := time.Now()
+
+	s.logger.Info("executing scheduled forecast",
+		"strategy_id", sid,
+		"tenant_id", tenantID)
+
+	// Acquire lease to prevent duplicate execution across pods
+	acquired, err := s.leaseManager.Acquire(ctx, tenantID, sid)
+	if err != nil {
+		s.logger.Error("lease acquisition error",
+			"strategy_id", sid,
+			"tenant_id", tenantID,
+			"error", err)
+		s.metrics.RecordLeaseFailure("error")
+		s.metrics.RecordExecution(tenantID, sid, "lease_error")
+		return
+	}
+	if !acquired {
+		s.logger.Debug("lease not acquired, another pod is executing",
+			"strategy_id", sid,
+			"tenant_id", tenantID)
+		s.metrics.RecordLeaseFailure("contention")
+		s.metrics.RecordExecution(tenantID, sid, "skipped")
+		return
+	}
+	defer func() {
+		if err := s.leaseManager.Release(ctx, tenantID, sid); err != nil {
+			s.logger.Warn("failed to release lease after execution",
+				"strategy_id", sid,
+				"error", err)
+		}
+	}()
+
+	// Execute the forecast
+	result, err := s.executor.ExecuteForecast(ctx, strategyID)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		s.logger.Error("scheduled forecast execution failed",
+			"strategy_id", sid,
+			"tenant_id", tenantID,
+			"duration", elapsed,
+			"error", err)
+		s.metrics.RecordExecution(tenantID, sid, "error")
+		s.metrics.ObserveExecutionDuration(tenantID, sid, elapsed.Seconds())
+		return
+	}
+
+	s.logger.Info("scheduled forecast completed",
+		"strategy_id", sid,
+		"tenant_id", tenantID,
+		"point_count", result.PointCount,
+		"strategy_version", result.StrategyVersion,
+		"duration", elapsed)
+	s.metrics.RecordExecution(tenantID, sid, "success")
+	s.metrics.ObserveExecutionDuration(tenantID, sid, elapsed.Seconds())
+}
+
+// RegisteredJobCount returns the number of currently registered cron jobs.
+func (s *CronScheduler) RegisteredJobCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.jobs)
+}

--- a/services/forecasting/scheduler/cron_scheduler_test.go
+++ b/services/forecasting/scheduler/cron_scheduler_test.go
@@ -1,0 +1,866 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/meridianhub/meridian/services/forecasting/domain"
+	"github.com/meridianhub/meridian/shared/platform/await"
+)
+
+// --- Test Helpers ---
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+func testMetrics(t *testing.T) *Metrics {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	return NewMetricsWithRegistry(reg)
+}
+
+func setupMiniredis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	t.Cleanup(func() {
+		client.Close()
+	})
+	return mr, client
+}
+
+func testLeaseManager(t *testing.T, client *redis.Client) *LeaseManager {
+	t.Helper()
+	return NewLeaseManager(client, LeaseConfig{
+		LockTTL:       5 * time.Second,
+		RenewInterval: 1 * time.Second,
+	}, testLogger())
+}
+
+// --- Mock Strategy Repository ---
+
+type mockStrategyRepo struct {
+	mu         sync.Mutex
+	strategies []domain.ForecastingStrategy
+	err        error
+}
+
+func (m *mockStrategyRepo) Save(_ context.Context, _ domain.ForecastingStrategy) error {
+	return nil
+}
+
+func (m *mockStrategyRepo) FindByID(_ context.Context, id uuid.UUID) (domain.ForecastingStrategy, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, s := range m.strategies {
+		if s.ID() == id {
+			return s, nil
+		}
+	}
+	return domain.ForecastingStrategy{}, domain.ErrStrategyNotFound
+}
+
+func (m *mockStrategyRepo) FindByTenantAndName(_ context.Context, _ string, _ string) (domain.ForecastingStrategy, error) {
+	return domain.ForecastingStrategy{}, domain.ErrStrategyNotFound
+}
+
+func (m *mockStrategyRepo) ListByTenant(_ context.Context, _ string, _ domain.StrategyFilters) ([]domain.ForecastingStrategy, string, error) {
+	return nil, "", nil
+}
+
+func (m *mockStrategyRepo) ListAllActive(_ context.Context) ([]domain.ForecastingStrategy, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	result := make([]domain.ForecastingStrategy, len(m.strategies))
+	copy(result, m.strategies)
+	return result, nil
+}
+
+func (m *mockStrategyRepo) setStrategies(strategies []domain.ForecastingStrategy) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.strategies = strategies
+}
+
+// --- Mock Forecast Executor ---
+
+type mockExecutor struct {
+	mu          sync.Mutex
+	calls       []executorCall
+	err         error
+	result      *ForecastResult
+	delay       time.Duration
+	callCounter atomic.Int32
+}
+
+type executorCall struct {
+	strategyID uuid.UUID
+}
+
+func (m *mockExecutor) ExecuteForecast(ctx context.Context, strategyID uuid.UUID) (*ForecastResult, error) {
+	m.callCounter.Add(1)
+
+	if m.delay > 0 {
+		select {
+		case <-time.After(m.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.calls = append(m.calls, executorCall{
+		strategyID: strategyID,
+	})
+
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.result != nil {
+		return m.result, nil
+	}
+	return &ForecastResult{PointCount: 24, StrategyVersion: 1}, nil
+}
+
+func (m *mockExecutor) callCount() int {
+	return int(m.callCounter.Load())
+}
+
+func (m *mockExecutor) getCalls() []executorCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]executorCall, len(m.calls))
+	copy(result, m.calls)
+	return result
+}
+
+// --- Test Strategies ---
+
+func newActiveStrategy(t *testing.T, tenantID, name, schedule string) domain.ForecastingStrategy {
+	t.Helper()
+	s, err := domain.NewForecastingStrategy(
+		tenantID,
+		name,
+		"test strategy",
+		"result = [{'timestamp': '2026-01-01T00:00:00Z', 'value': '100.0'}]",
+		24,
+		1,
+		schedule,
+		[]string{"DATASET_A"},
+		"OUTPUT_DATASET",
+		"",
+	)
+	require.NoError(t, err)
+	s, err = s.Activate()
+	require.NoError(t, err)
+	return s
+}
+
+// --- LeaseManager Tests ---
+
+func TestLeaseManager_AcquireAndRelease(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+
+	ctx := context.Background()
+
+	acquired, err := lm.Acquire(ctx, "tenant-1", "strategy-abc")
+	require.NoError(t, err)
+	assert.True(t, acquired)
+	assert.Equal(t, 1, lm.HeldCount())
+
+	err = lm.Release(ctx, "tenant-1", "strategy-abc")
+	require.NoError(t, err)
+	assert.Equal(t, 0, lm.HeldCount())
+}
+
+func TestLeaseManager_OnlyOneHolderPerStrategy(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm1 := testLeaseManager(t, client)
+	lm2 := testLeaseManager(t, client)
+
+	ctx := context.Background()
+
+	// First acquires
+	acquired, err := lm1.Acquire(ctx, "tenant-1", "strategy-abc")
+	require.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Second cannot acquire the same strategy
+	acquired, err = lm2.Acquire(ctx, "tenant-1", "strategy-abc")
+	require.NoError(t, err)
+	assert.False(t, acquired)
+
+	// Release first, second can now acquire
+	err = lm1.Release(ctx, "tenant-1", "strategy-abc")
+	require.NoError(t, err)
+
+	acquired, err = lm2.Acquire(ctx, "tenant-1", "strategy-abc")
+	require.NoError(t, err)
+	assert.True(t, acquired)
+
+	err = lm2.Release(ctx, "tenant-1", "strategy-abc")
+	require.NoError(t, err)
+}
+
+func TestLeaseManager_DifferentStrategiesIndependent(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+
+	ctx := context.Background()
+
+	// Acquire two different strategies
+	acquired1, err := lm.Acquire(ctx, "tenant-1", "strategy-1")
+	require.NoError(t, err)
+	assert.True(t, acquired1)
+
+	acquired2, err := lm.Acquire(ctx, "tenant-1", "strategy-2")
+	require.NoError(t, err)
+	assert.True(t, acquired2)
+
+	assert.Equal(t, 2, lm.HeldCount())
+
+	err = lm.Release(ctx, "tenant-1", "strategy-1")
+	require.NoError(t, err)
+	err = lm.Release(ctx, "tenant-1", "strategy-2")
+	require.NoError(t, err)
+}
+
+func TestLeaseManager_ReleaseWithoutAcquire(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+
+	ctx := context.Background()
+
+	// Should be a no-op
+	err := lm.Release(ctx, "tenant-1", "nonexistent")
+	assert.NoError(t, err)
+}
+
+func TestLeaseManager_ReleaseAll(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+
+	ctx := context.Background()
+
+	_, _ = lm.Acquire(ctx, "tenant-1", "s1")
+	_, _ = lm.Acquire(ctx, "tenant-1", "s2")
+	_, _ = lm.Acquire(ctx, "tenant-2", "s3")
+	assert.Equal(t, 3, lm.HeldCount())
+
+	lm.ReleaseAll(ctx)
+	assert.Equal(t, 0, lm.HeldCount())
+}
+
+func TestLeaseManager_OrphanDetectionViaTTL(t *testing.T) {
+	mr, client := setupMiniredis(t)
+	lm1 := NewLeaseManager(client, LeaseConfig{
+		LockTTL:       200 * time.Millisecond,
+		RenewInterval: 50 * time.Millisecond,
+	}, testLogger())
+
+	lm2 := NewLeaseManager(client, LeaseConfig{
+		LockTTL:       200 * time.Millisecond,
+		RenewInterval: 50 * time.Millisecond,
+	}, testLogger())
+
+	ctx := context.Background()
+
+	// First pod acquires
+	acquired, err := lm1.Acquire(ctx, "tenant-1", "orphan-test")
+	require.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Simulate pod crash by releasing without cleanup - just stop renewal
+	lm1.mu.Lock()
+	key := leaseKey("tenant-1", "orphan-test")
+	if lease, ok := lm1.locks[key]; ok {
+		lease.cancel() // Stop renewal
+	}
+	delete(lm1.locks, key) // Remove from tracking (simulating crash)
+	lm1.mu.Unlock()
+
+	// Fast-forward past TTL
+	mr.FastForward(300 * time.Millisecond)
+
+	// Second pod can now acquire (orphan detected via TTL expiry)
+	acquired, err = lm2.Acquire(ctx, "tenant-1", "orphan-test")
+	require.NoError(t, err)
+	assert.True(t, acquired)
+
+	err = lm2.Release(ctx, "tenant-1", "orphan-test")
+	require.NoError(t, err)
+}
+
+func TestLeaseManager_DefaultConfig(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := NewLeaseManager(client, LeaseConfig{}, testLogger())
+
+	assert.Equal(t, 5*time.Minute, lm.lockTTL)
+	assert.Equal(t, 30*time.Second, lm.renewEvery)
+}
+
+// --- CronScheduler Constructor Tests ---
+
+func TestNew_ValidatesRequiredDependencies(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+	repo := &mockStrategyRepo{}
+	exec := &mockExecutor{}
+	logger := testLogger()
+	metrics := testMetrics(t)
+
+	t.Run("rejects nil repository", func(t *testing.T) {
+		_, err := New(nil, exec, lm, metrics, logger, Config{})
+		assert.ErrorIs(t, err, ErrNilRepository)
+	})
+
+	t.Run("rejects nil executor", func(t *testing.T) {
+		_, err := New(repo, nil, lm, metrics, logger, Config{})
+		assert.ErrorIs(t, err, ErrNilExecutor)
+	})
+
+	t.Run("rejects nil lease manager", func(t *testing.T) {
+		_, err := New(repo, exec, nil, metrics, logger, Config{})
+		assert.ErrorIs(t, err, ErrNilLeaseManager)
+	})
+
+	t.Run("rejects nil logger", func(t *testing.T) {
+		_, err := New(repo, exec, lm, metrics, nil, Config{})
+		assert.ErrorIs(t, err, ErrNilLogger)
+	})
+
+	t.Run("applies default config values", func(t *testing.T) {
+		sched, err := New(repo, exec, lm, metrics, logger, Config{})
+		require.NoError(t, err)
+		assert.Equal(t, DefaultPollInterval, sched.config.PollInterval)
+		assert.Equal(t, DefaultShutdownTimeout, sched.config.ShutdownTimeout)
+	})
+
+	t.Run("accepts custom config", func(t *testing.T) {
+		sched, err := New(repo, exec, lm, metrics, logger, Config{
+			PollInterval:    30 * time.Second,
+			ShutdownTimeout: 2 * time.Minute,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Second, sched.config.PollInterval)
+		assert.Equal(t, 2*time.Minute, sched.config.ShutdownTimeout)
+	})
+}
+
+// --- CronScheduler Lifecycle Tests ---
+
+func TestCronScheduler_StartAndStop(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+	repo := &mockStrategyRepo{}
+	exec := &mockExecutor{}
+
+	sched, err := New(repo, exec, lm, testMetrics(t), testLogger(), Config{
+		PollInterval: 10 * time.Second,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- sched.Start(ctx)
+	}()
+
+	// Give it time to start
+	err = await.New().AtMost(2 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		sched.mu.Lock()
+		defer sched.mu.Unlock()
+		return sched.running
+	})
+	require.NoError(t, err)
+
+	cancel()
+
+	select {
+	case err := <-startDone:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("scheduler did not stop within timeout")
+	}
+}
+
+func TestCronScheduler_RejectsDoubleStart(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+	repo := &mockStrategyRepo{}
+	exec := &mockExecutor{}
+
+	sched, err := New(repo, exec, lm, testMetrics(t), testLogger(), Config{})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = sched.Start(ctx)
+	}()
+
+	// Wait for it to be running
+	err = await.New().AtMost(2 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		sched.mu.Lock()
+		defer sched.mu.Unlock()
+		return sched.running
+	})
+	require.NoError(t, err)
+
+	// Second start should fail
+	err = sched.Start(ctx)
+	assert.ErrorIs(t, err, ErrSchedulerRunning)
+}
+
+// --- Strategy Execution Tests ---
+
+func TestCronScheduler_ExecutesStrategiesOnSchedule(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+	exec := &mockExecutor{}
+
+	strategy := newActiveStrategy(t, "tenant-1", "fast-strategy", "@every 1s")
+	repo := &mockStrategyRepo{strategies: []domain.ForecastingStrategy{strategy}}
+
+	sched, err := New(repo, exec, lm, testMetrics(t), testLogger(), Config{
+		PollInterval: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		_ = sched.Start(ctx)
+	}()
+
+	// Wait for at least one execution
+	err = await.New().AtMost(5 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+		return exec.callCount() >= 1
+	})
+	require.NoError(t, err)
+
+	calls := exec.getCalls()
+	assert.Equal(t, strategy.ID(), calls[0].strategyID)
+
+	assert.Equal(t, 1, sched.RegisteredJobCount())
+}
+
+func TestCronScheduler_ExecutionWithLeaseContention(t *testing.T) {
+	_, client := setupMiniredis(t)
+
+	// Two lease managers simulating two pods
+	lm1 := testLeaseManager(t, client)
+	lm2 := testLeaseManager(t, client)
+
+	exec1 := &mockExecutor{delay: 500 * time.Millisecond}
+	exec2 := &mockExecutor{}
+
+	strategy := newActiveStrategy(t, "tenant-1", "contested-strategy", "@every 1s")
+	repo := &mockStrategyRepo{strategies: []domain.ForecastingStrategy{strategy}}
+
+	// Start first scheduler
+	sched1, err := New(repo, exec1, lm1, testMetrics(t), testLogger(), Config{
+		PollInterval: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	sched2, err := New(repo, exec2, lm2, testMetrics(t), testLogger(), Config{
+		PollInterval: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = sched1.Start(ctx) }()
+	go func() { _ = sched2.Start(ctx) }()
+
+	// Wait for some executions
+	err = await.New().AtMost(5 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+		return exec1.callCount()+exec2.callCount() >= 2
+	})
+	require.NoError(t, err)
+
+	// Both schedulers fire, but due to lease contention,
+	// only one should execute per cron tick (the other gets skipped).
+	// The total call count across both executors should be reasonable.
+	totalCalls := exec1.callCount() + exec2.callCount()
+	assert.GreaterOrEqual(t, totalCalls, 2)
+}
+
+// --- Dynamic Strategy Reload Tests ---
+
+func TestCronScheduler_DetectsNewStrategies(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+	exec := &mockExecutor{}
+	repo := &mockStrategyRepo{strategies: nil} // Start with no strategies
+
+	sched, err := New(repo, exec, lm, testMetrics(t), testLogger(), Config{
+		PollInterval: 500 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = sched.Start(ctx) }()
+
+	// Verify no jobs registered initially
+	err = await.New().AtMost(2 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		sched.mu.Lock()
+		defer sched.mu.Unlock()
+		return sched.running
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, sched.RegisteredJobCount())
+
+	// Add a strategy
+	strategy := newActiveStrategy(t, "tenant-1", "new-strategy", "@every 1s")
+	repo.setStrategies([]domain.ForecastingStrategy{strategy})
+
+	// Wait for poller to pick it up and register the job
+	err = await.New().AtMost(3 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+		return sched.RegisteredJobCount() == 1
+	})
+	require.NoError(t, err)
+
+	// Wait for execution
+	err = await.New().AtMost(5 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+		return exec.callCount() >= 1
+	})
+	require.NoError(t, err)
+}
+
+func TestCronScheduler_RemovesDeactivatedStrategies(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+	exec := &mockExecutor{}
+
+	strategy := newActiveStrategy(t, "tenant-1", "will-remove", "@every 1s")
+	repo := &mockStrategyRepo{strategies: []domain.ForecastingStrategy{strategy}}
+
+	sched, err := New(repo, exec, lm, testMetrics(t), testLogger(), Config{
+		PollInterval: 500 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = sched.Start(ctx) }()
+
+	// Wait for job to be registered
+	err = await.New().AtMost(3 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+		return sched.RegisteredJobCount() == 1
+	})
+	require.NoError(t, err)
+
+	// Remove the strategy (simulate deprecation)
+	repo.setStrategies(nil)
+
+	// Wait for poller to remove the job
+	err = await.New().AtMost(3 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+		return sched.RegisteredJobCount() == 0
+	})
+	require.NoError(t, err)
+}
+
+func TestCronScheduler_DetectsScheduleChanges(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+	exec := &mockExecutor{}
+
+	strategy := newActiveStrategy(t, "tenant-1", "schedule-change", "0 0 * * *")
+	repo := &mockStrategyRepo{strategies: []domain.ForecastingStrategy{strategy}}
+
+	sched, err := New(repo, exec, lm, testMetrics(t), testLogger(), Config{
+		PollInterval: 500 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = sched.Start(ctx) }()
+
+	// Wait for job to be registered
+	err = await.New().AtMost(3 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+		return sched.RegisteredJobCount() == 1
+	})
+	require.NoError(t, err)
+
+	// Verify the schedule is the original
+	sched.mu.Lock()
+	origJob := sched.jobs[strategy.ID().String()]
+	origEntryID := origJob.entryID
+	sched.mu.Unlock()
+	assert.Equal(t, "0 0 * * *", origJob.schedule)
+
+	// Change the schedule (create a new strategy with same ID but different schedule)
+	updatedStrategy, err := strategy.UpdateSchedule("@every 1s")
+	require.NoError(t, err)
+	repo.setStrategies([]domain.ForecastingStrategy{updatedStrategy})
+
+	// Wait for poller to detect the change
+	err = await.New().AtMost(3 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+		sched.mu.Lock()
+		defer sched.mu.Unlock()
+		job, exists := sched.jobs[strategy.ID().String()]
+		return exists && job.entryID != origEntryID
+	})
+	require.NoError(t, err)
+
+	// Verify the new schedule is registered
+	sched.mu.Lock()
+	newJob := sched.jobs[strategy.ID().String()]
+	sched.mu.Unlock()
+	assert.Equal(t, "@every 1s", newJob.schedule)
+}
+
+// --- Graceful Shutdown Tests ---
+
+func TestCronScheduler_GracefulShutdownWaitsForInFlight(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+
+	// Executor with a delay to simulate long-running forecast
+	exec := &mockExecutor{delay: 500 * time.Millisecond}
+
+	strategy := newActiveStrategy(t, "tenant-1", "slow-strategy", "@every 1s")
+	repo := &mockStrategyRepo{strategies: []domain.ForecastingStrategy{strategy}}
+
+	sched, err := New(repo, exec, lm, testMetrics(t), testLogger(), Config{
+		PollInterval:    30 * time.Second,
+		ShutdownTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- sched.Start(ctx)
+	}()
+
+	// Wait for at least one execution to start
+	err = await.New().AtMost(5 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		return exec.callCount() >= 1
+	})
+	require.NoError(t, err)
+
+	// Cancel context to trigger shutdown
+	cancel()
+
+	// Shutdown should complete (executor's delay is 500ms, timeout is 5s)
+	select {
+	case err := <-startDone:
+		assert.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("scheduler did not stop within timeout")
+	}
+
+	// All leases should be released
+	assert.Equal(t, 0, lm.HeldCount())
+}
+
+func TestCronScheduler_StoppedDoesNotExecute(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+	exec := &mockExecutor{}
+
+	strategy := newActiveStrategy(t, "tenant-1", "wont-run", "@every 100ms")
+	repo := &mockStrategyRepo{strategies: []domain.ForecastingStrategy{strategy}}
+
+	sched, err := New(repo, exec, lm, testMetrics(t), testLogger(), Config{
+		PollInterval: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- sched.Start(ctx)
+	}()
+
+	// Wait for at least one execution
+	err = await.New().AtMost(3 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		return exec.callCount() >= 1
+	})
+	require.NoError(t, err)
+
+	// Stop the scheduler
+	cancel()
+	<-startDone
+
+	// Record how many calls happened
+	countAfterStop := exec.callCount()
+
+	// Wait to ensure no more executions happen
+	time.Sleep(300 * time.Millisecond)
+	assert.Equal(t, countAfterStop, exec.callCount(), "no new executions after stop")
+}
+
+// --- Multi-Tenant Tests ---
+
+func TestCronScheduler_MultiTenantStrategies(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+	exec := &mockExecutor{}
+
+	s1 := newActiveStrategy(t, "tenant-1", "s1", "@every 1s")
+	s2 := newActiveStrategy(t, "tenant-2", "s2", "@every 1s")
+	repo := &mockStrategyRepo{strategies: []domain.ForecastingStrategy{s1, s2}}
+
+	sched, err := New(repo, exec, lm, testMetrics(t), testLogger(), Config{
+		PollInterval: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = sched.Start(ctx) }()
+
+	// Both strategies should be registered
+	err = await.New().AtMost(3 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+		return sched.RegisteredJobCount() == 2
+	})
+	require.NoError(t, err)
+
+	// Wait for executions from both
+	err = await.New().AtMost(5 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+		return exec.callCount() >= 2
+	})
+	require.NoError(t, err)
+
+	// Verify both strategy IDs were executed
+	calls := exec.getCalls()
+	executedIDs := make(map[uuid.UUID]bool)
+	for _, c := range calls {
+		executedIDs[c.strategyID] = true
+	}
+	assert.True(t, executedIDs[s1.ID()], "tenant-1 strategy should have been executed")
+	assert.True(t, executedIDs[s2.ID()], "tenant-2 strategy should have been executed")
+}
+
+// --- Error Handling Tests ---
+
+func TestCronScheduler_ExecutionErrorDoesNotStopScheduler(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+
+	exec := &mockExecutor{err: assert.AnError}
+
+	strategy := newActiveStrategy(t, "tenant-1", "error-strategy", "@every 1s")
+	repo := &mockStrategyRepo{strategies: []domain.ForecastingStrategy{strategy}}
+
+	sched, err := New(repo, exec, lm, testMetrics(t), testLogger(), Config{
+		PollInterval: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = sched.Start(ctx) }()
+
+	// Despite errors, the scheduler keeps trying
+	err = await.New().AtMost(5 * time.Second).PollInterval(100 * time.Millisecond).Until(func() bool {
+		return exec.callCount() >= 2
+	})
+	require.NoError(t, err)
+}
+
+func TestCronScheduler_RepoErrorDoesNotStopScheduler(t *testing.T) {
+	_, client := setupMiniredis(t)
+	lm := testLeaseManager(t, client)
+	exec := &mockExecutor{}
+
+	repo := &mockStrategyRepo{err: assert.AnError}
+
+	sched, err := New(repo, exec, lm, testMetrics(t), testLogger(), Config{
+		PollInterval: 500 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = sched.Start(ctx) }()
+
+	// Wait for scheduler to be running
+	err = await.New().AtMost(2 * time.Second).PollInterval(50 * time.Millisecond).Until(func() bool {
+		sched.mu.Lock()
+		defer sched.mu.Unlock()
+		return sched.running
+	})
+	require.NoError(t, err)
+
+	// Scheduler should still be running despite repo errors
+	time.Sleep(1 * time.Second)
+	sched.mu.Lock()
+	running := sched.running
+	sched.mu.Unlock()
+	assert.True(t, running, "scheduler should remain running despite repo errors")
+}
+
+// --- Metrics Tests ---
+
+func TestMetrics_Creation(t *testing.T) {
+	t.Run("default registry", func(t *testing.T) {
+		m := NewMetrics()
+		assert.NotNil(t, m)
+	})
+
+	t.Run("custom registry", func(t *testing.T) {
+		reg := prometheus.NewRegistry()
+		m := NewMetricsWithRegistry(reg)
+		assert.NotNil(t, m)
+
+		// Verify metrics are registered
+		m.RecordExecution("tenant-1", "strategy-1", "success")
+		m.ObserveExecutionDuration("tenant-1", "strategy-1", 1.5)
+		m.RecordLeaseFailure("contention")
+		m.SetActiveStrategies(3)
+		m.RecordReload("success")
+		m.RecordError("test_error")
+
+		// Should not panic
+		families, err := reg.Gather()
+		require.NoError(t, err)
+		assert.NotEmpty(t, families)
+	})
+}
+
+// --- Lease Key Format Tests ---
+
+func TestLeaseKey_Format(t *testing.T) {
+	key := leaseKey("tenant-abc", "strategy-123")
+	assert.Equal(t, "meridian:forecasting:strategy:tenant-abc:strategy-123", key)
+}

--- a/services/forecasting/scheduler/lease_manager.go
+++ b/services/forecasting/scheduler/lease_manager.go
@@ -1,0 +1,172 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/bsm/redislock"
+	"github.com/redis/go-redis/v9"
+)
+
+// LeaseManager provides distributed locking for strategy execution using Redis.
+// It prevents multiple pods from executing the same strategy concurrently.
+// Orphan detection is handled automatically via Redis TTL expiry.
+type LeaseManager struct {
+	client     *redislock.Client
+	lockTTL    time.Duration
+	renewEvery time.Duration
+	logger     *slog.Logger
+
+	mu    sync.Mutex
+	locks map[string]*activeLease
+}
+
+// activeLease tracks a held lock and its renewal goroutine.
+type activeLease struct {
+	lock   *redislock.Lock
+	cancel context.CancelFunc
+}
+
+// LeaseConfig holds configuration for the LeaseManager.
+type LeaseConfig struct {
+	// LockTTL is how long each strategy lease is held before expiring.
+	// Default: 5 minutes.
+	LockTTL time.Duration
+	// RenewInterval is how often to renew the lease during execution.
+	// Must be less than LockTTL. Default: 30 seconds.
+	RenewInterval time.Duration
+}
+
+// NewLeaseManager creates a new Redis-based lease manager.
+func NewLeaseManager(
+	redisClient *redis.Client,
+	config LeaseConfig,
+	logger *slog.Logger,
+) *LeaseManager {
+	if config.LockTTL == 0 {
+		config.LockTTL = 5 * time.Minute
+	}
+	if config.RenewInterval == 0 {
+		config.RenewInterval = 30 * time.Second
+	}
+
+	return &LeaseManager{
+		client:     redislock.New(redisClient),
+		lockTTL:    config.LockTTL,
+		renewEvery: config.RenewInterval,
+		logger:     logger.With("component", "lease_manager"),
+		locks:      make(map[string]*activeLease),
+	}
+}
+
+// leaseKey returns the Redis key for a strategy lease.
+func leaseKey(tenantID string, strategyID string) string {
+	return fmt.Sprintf("meridian:forecasting:strategy:%s:%s", tenantID, strategyID)
+}
+
+// Acquire attempts to acquire a lease for the given strategy.
+// Returns true if the lease was acquired, false if another pod holds it.
+// On success, starts a background renewal goroutine that runs until Release is called.
+func (lm *LeaseManager) Acquire(ctx context.Context, tenantID, strategyID string) (bool, error) {
+	key := leaseKey(tenantID, strategyID)
+
+	lock, err := lm.client.Obtain(ctx, key, lm.lockTTL, nil)
+	if err != nil {
+		if errors.Is(err, redislock.ErrNotObtained) {
+			return false, nil
+		}
+		return false, fmt.Errorf("obtain lease for %s: %w", key, err)
+	}
+
+	renewCtx, cancel := context.WithCancel(ctx)
+	lease := &activeLease{
+		lock:   lock,
+		cancel: cancel,
+	}
+
+	lm.mu.Lock()
+	lm.locks[key] = lease
+	lm.mu.Unlock()
+
+	go lm.renewLoop(renewCtx, key, lock)
+
+	lm.logger.Debug("lease acquired", "key", key)
+	return true, nil
+}
+
+// Release releases the lease for the given strategy, stopping renewal.
+func (lm *LeaseManager) Release(ctx context.Context, tenantID, strategyID string) error {
+	key := leaseKey(tenantID, strategyID)
+
+	lm.mu.Lock()
+	lease, ok := lm.locks[key]
+	if !ok {
+		lm.mu.Unlock()
+		return nil
+	}
+	delete(lm.locks, key)
+	lm.mu.Unlock()
+
+	lease.cancel()
+
+	if err := lease.lock.Release(ctx); err != nil {
+		lm.logger.Warn("failed to release lease", "key", key, "error", err)
+		return fmt.Errorf("release lease for %s: %w", key, err)
+	}
+
+	lm.logger.Debug("lease released", "key", key)
+	return nil
+}
+
+// ReleaseAll releases all held leases. Used during graceful shutdown.
+func (lm *LeaseManager) ReleaseAll(ctx context.Context) {
+	lm.mu.Lock()
+	leases := make(map[string]*activeLease, len(lm.locks))
+	for k, v := range lm.locks {
+		leases[k] = v
+	}
+	lm.locks = make(map[string]*activeLease)
+	lm.mu.Unlock()
+
+	for key, lease := range leases {
+		lease.cancel()
+		if err := lease.lock.Release(ctx); err != nil {
+			lm.logger.Warn("failed to release lease during shutdown", "key", key, "error", err)
+		}
+	}
+}
+
+// HeldCount returns the number of currently held leases.
+func (lm *LeaseManager) HeldCount() int {
+	lm.mu.Lock()
+	defer lm.mu.Unlock()
+	return len(lm.locks)
+}
+
+// renewLoop periodically refreshes the lock until the context is cancelled.
+func (lm *LeaseManager) renewLoop(ctx context.Context, key string, lock *redislock.Lock) {
+	ticker := time.NewTicker(lm.renewEvery)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := lock.Refresh(ctx, lm.lockTTL, nil); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				lm.logger.Error("lease renewal failed", "key", key, "error", err)
+				lm.mu.Lock()
+				delete(lm.locks, key)
+				lm.mu.Unlock()
+				return
+			}
+		}
+	}
+}

--- a/services/forecasting/scheduler/lease_manager.go
+++ b/services/forecasting/scheduler/lease_manager.go
@@ -53,6 +53,9 @@ func NewLeaseManager(
 	if config.RenewInterval == 0 {
 		config.RenewInterval = 30 * time.Second
 	}
+	if config.RenewInterval >= config.LockTTL {
+		config.RenewInterval = config.LockTTL / 2
+	}
 
 	return &LeaseManager{
 		client:     redislock.New(redisClient),

--- a/services/forecasting/scheduler/metrics.go
+++ b/services/forecasting/scheduler/metrics.go
@@ -1,0 +1,116 @@
+// Package scheduler provides cron-based scheduling for forecasting strategy execution.
+package scheduler
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics provides Prometheus metrics for the forecasting scheduler.
+type Metrics struct {
+	executionsTotal       *prometheus.CounterVec
+	executionDuration     *prometheus.HistogramVec
+	leaseFailuresTotal    *prometheus.CounterVec
+	activeStrategiesGauge prometheus.Gauge
+	reloadTotal           *prometheus.CounterVec
+	schedulerErrorsTotal  *prometheus.CounterVec
+}
+
+// NewMetrics creates a new metrics collector with default registrations.
+func NewMetrics() *Metrics {
+	return newMetricsWithFactory(promauto.With(prometheus.DefaultRegisterer))
+}
+
+// NewMetricsWithRegistry creates metrics registered with a custom registry.
+func NewMetricsWithRegistry(reg prometheus.Registerer) *Metrics {
+	return newMetricsWithFactory(promauto.With(reg))
+}
+
+func newMetricsWithFactory(factory promauto.Factory) *Metrics {
+	return &Metrics{
+		executionsTotal: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "meridian",
+				Subsystem: "forecasting",
+				Name:      "scheduled_executions_total",
+				Help:      "Total number of scheduled forecast executions by tenant, strategy, and status.",
+			},
+			[]string{"tenant_id", "strategy_id", "status"},
+		),
+		executionDuration: factory.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "meridian",
+				Subsystem: "forecasting",
+				Name:      "execution_duration_seconds",
+				Help:      "Duration of scheduled forecast execution in seconds.",
+				Buckets:   []float64{.1, .5, 1, 5, 10, 30, 60, 120, 300},
+			},
+			[]string{"tenant_id", "strategy_id"},
+		),
+		leaseFailuresTotal: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "meridian",
+				Subsystem: "forecasting",
+				Name:      "lease_acquisition_failures_total",
+				Help:      "Total number of lease acquisition failures by reason.",
+			},
+			[]string{"reason"},
+		),
+		activeStrategiesGauge: factory.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: "meridian",
+				Subsystem: "forecasting",
+				Name:      "active_strategies",
+				Help:      "Number of active strategies currently registered in the scheduler.",
+			},
+		),
+		reloadTotal: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "meridian",
+				Subsystem: "forecasting",
+				Name:      "scheduler_reloads_total",
+				Help:      "Total number of strategy reload cycles by outcome.",
+			},
+			[]string{"outcome"},
+		),
+		schedulerErrorsTotal: factory.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "meridian",
+				Subsystem: "forecasting",
+				Name:      "scheduler_errors_total",
+				Help:      "Total number of scheduler errors by type.",
+			},
+			[]string{"error_type"},
+		),
+	}
+}
+
+// RecordExecution records a forecast execution result.
+func (m *Metrics) RecordExecution(tenantID, strategyID, status string) {
+	m.executionsTotal.WithLabelValues(tenantID, strategyID, status).Inc()
+}
+
+// ObserveExecutionDuration records the duration of a forecast execution.
+func (m *Metrics) ObserveExecutionDuration(tenantID, strategyID string, seconds float64) {
+	m.executionDuration.WithLabelValues(tenantID, strategyID).Observe(seconds)
+}
+
+// RecordLeaseFailure records a lease acquisition failure.
+func (m *Metrics) RecordLeaseFailure(reason string) {
+	m.leaseFailuresTotal.WithLabelValues(reason).Inc()
+}
+
+// SetActiveStrategies sets the gauge for active strategies.
+func (m *Metrics) SetActiveStrategies(count float64) {
+	m.activeStrategiesGauge.Set(count)
+}
+
+// RecordReload records a strategy reload outcome.
+func (m *Metrics) RecordReload(outcome string) {
+	m.reloadTotal.WithLabelValues(outcome).Inc()
+}
+
+// RecordError records a scheduler error.
+func (m *Metrics) RecordError(errorType string) {
+	m.schedulerErrorsTotal.WithLabelValues(errorType).Inc()
+}

--- a/services/forecasting/scheduler/metrics.go
+++ b/services/forecasting/scheduler/metrics.go
@@ -7,6 +7,9 @@ import (
 )
 
 // Metrics provides Prometheus metrics for the forecasting scheduler.
+// WARNING: executionsTotal and executionDuration use tenant_id and strategy_id
+// labels which can produce high cardinality. This is an accepted operational
+// constraint for per-strategy observability. Monitor cardinality in production.
 type Metrics struct {
 	executionsTotal       *prometheus.CounterVec
 	executionDuration     *prometheus.HistogramVec


### PR DESCRIPTION
## Summary
- Implement CronScheduler with robfig/cron for executing active forecasting strategies on configured schedules
- Add Redis-based LeaseManager for multi-pod coordination preventing duplicate executions
- Dynamic strategy reload via database polling every 60s
- Graceful shutdown with in-flight forecast completion and lease release
- Prometheus metrics for execution tracking

## Task Master
Tag: market-data-dynamic-pricing, Task: 10

## Test plan
- [ ] Unit tests for LeaseManager acquire/release/renewal
- [ ] CronScheduler starts and executes strategies on schedule
- [ ] Multi-pod simulation: only one pod executes per strategy
- [ ] Dynamic strategy updates detected and applied
- [ ] Graceful shutdown waits for in-flight work
- [ ] Orphan detection via Redis TTL expiry