### PR TITLE
feat: Add dunning saga and account freeze integration

### DIFF
--- a/services/current-account/client/client.go
+++ b/services/current-account/client/client.go
@@ -446,6 +446,35 @@ func (c *Client) GetActiveAmountBlocks(ctx context.Context, req *currentaccountv
 	return resp, nil
 }
 
+// ControlCurrentAccount performs lifecycle state transitions on an account.
+// Used by dunning sagas to freeze/unfreeze accounts.
+// This is a non-idempotent operation, so it uses circuit breaker without retry.
+func (c *Client) ControlCurrentAccount(ctx context.Context, req *currentaccountv1.ControlCurrentAccountRequest) (*currentaccountv1.ControlCurrentAccountResponse, error) {
+	if err := validation.ValidateAccountID(req.GetAccountId()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid account_id format: %v", err)
+	}
+
+	ctx, cancel := clients.WithTimeout(ctx, c.timeout)
+	defer cancel()
+
+	ctx = clients.PropagateCorrelationID(ctx)
+	ctx = clients.PropagateOrganization(ctx)
+
+	// Use resilience patterns if configured (no retry for non-idempotent operations)
+	if c.resilient != nil {
+		return clients.ExecuteWithResilienceNoRetry(ctx, c.resilient, "ControlCurrentAccount", func() (*currentaccountv1.ControlCurrentAccountResponse, error) {
+			return c.currentAccount.ControlCurrentAccount(ctx, req)
+		})
+	}
+
+	resp, err := c.currentAccount.ControlCurrentAccount(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to control current account: %w", err)
+	}
+
+	return resp, nil
+}
+
 // Close terminates the gRPC connection gracefully.
 func (c *Client) Close() error {
 	if c.conn != nil {

--- a/services/current-account/client/starlark.go
+++ b/services/current-account/client/starlark.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -16,6 +17,9 @@ import (
 	"google.golang.org/genproto/googleapis/type/money"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// ErrInvalidControlAction is returned when an unsupported control action is provided.
+var ErrInvalidControlAction = errors.New("current_account.control: invalid action, must be FREEZE, UNFREEZE, or CLOSE")
 
 // RegisterStarlarkHandlers registers all Starlark service bindings for Current Account.
 // These handlers adapt the Starlark interface (map[string]any) to gRPC client calls.
@@ -354,7 +358,7 @@ func controlHandler(client *Client) saga.Handler {
 		case "CLOSE":
 			controlAction = currentaccountv1.ControlAction_CONTROL_ACTION_CLOSE
 		default:
-			return nil, fmt.Errorf("current_account.control: invalid action %q, must be FREEZE, UNFREEZE, or CLOSE", action)
+			return nil, fmt.Errorf("%w: %q", ErrInvalidControlAction, action)
 		}
 
 		clientCtx := prepareClientContext(ctx)

--- a/services/current-account/client/starlark.go
+++ b/services/current-account/client/starlark.go
@@ -68,6 +68,14 @@ func RegisterStarlarkHandlers(registry *saga.HandlerRegistry, client *Client) er
 				ProducesInstruments: []string{},
 			},
 		},
+		"current_account.control": {
+			handler: controlHandler(client),
+			metadata: saga.HandlerMetadata{
+				Category: saga.HandlerCategorySettlement,
+				// Control actions (freeze/unfreeze/close) don't produce instruments
+				ProducesInstruments: []string{},
+			},
+		},
 	}
 
 	for name, h := range handlers {
@@ -299,6 +307,87 @@ func saveHandler(client *Client) saga.Handler {
 			"account_id": facility.GetAccountId(),
 			"status":     "SAVED",
 		}, nil
+	}
+}
+
+// controlHandler performs lifecycle control actions (FREEZE, UNFREEZE, CLOSE) on an account.
+// Used by dunning sagas to freeze accounts after payment failures and unfreeze on resolution.
+//
+// Parameters:
+//   - account_id (string): The account identifier to control
+//   - action (string): The control action - "FREEZE", "UNFREEZE", or "CLOSE"
+//   - reason (string): Explanation for the action (min 10 chars for FREEZE/CLOSE)
+//
+// Returns a map containing:
+//   - account_id: The account identifier
+//   - new_status: The account status after the action
+//   - action_timestamp: ISO 8601 timestamp of the action
+func controlHandler(client *Client) saga.Handler {
+	return func(ctx *saga.StarlarkContext, params map[string]any) (any, error) {
+		accountID, err := saga.RequireStringParam(params, "account_id")
+		if err != nil {
+			return nil, err
+		}
+
+		action, err := saga.RequireStringParam(params, "action")
+		if err != nil {
+			return nil, err
+		}
+
+		reason, err := saga.RequireStringParam(params, "reason")
+		if err != nil {
+			return nil, err
+		}
+
+		// Validate party scope (tenant isolation)
+		if err := ctx.ValidatePartyAccessFromString(accountID); err != nil {
+			return nil, fmt.Errorf("current_account.control: %w", err)
+		}
+
+		// Map string action to proto enum
+		var controlAction currentaccountv1.ControlAction
+		switch action {
+		case "FREEZE":
+			controlAction = currentaccountv1.ControlAction_CONTROL_ACTION_FREEZE
+		case "UNFREEZE":
+			controlAction = currentaccountv1.ControlAction_CONTROL_ACTION_UNFREEZE
+		case "CLOSE":
+			controlAction = currentaccountv1.ControlAction_CONTROL_ACTION_CLOSE
+		default:
+			return nil, fmt.Errorf("current_account.control: invalid action %q, must be FREEZE, UNFREEZE, or CLOSE", action)
+		}
+
+		clientCtx := prepareClientContext(ctx)
+
+		resp, err := client.ControlCurrentAccount(clientCtx, &currentaccountv1.ControlCurrentAccountRequest{
+			AccountId:     accountID,
+			ControlAction: controlAction,
+			Reason:        reason,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("current_account.control: %w", err)
+		}
+
+		facility := resp.GetFacility()
+		actionTS := resp.GetActionTimestamp()
+
+		// Map proto status to string
+		newStatus := facility.GetAccountStatus().String()
+		// Strip the "ACCOUNT_STATUS_" prefix for a cleaner Starlark result
+		if len(newStatus) > len("ACCOUNT_STATUS_") {
+			newStatus = newStatus[len("ACCOUNT_STATUS_"):]
+		}
+
+		result := map[string]any{
+			"account_id": facility.GetAccountId(),
+			"new_status": newStatus,
+		}
+
+		if actionTS != nil {
+			result["action_timestamp"] = formatTimestamp(actionTS)
+		}
+
+		return result, nil
 	}
 }
 

--- a/services/current-account/client/starlark_test.go
+++ b/services/current-account/client/starlark_test.go
@@ -714,6 +714,11 @@ func TestLienLifecycle(t *testing.T) {
 }
 
 func TestControlHandler(t *testing.T) {
+	// Use deterministic UUIDs for account IDs (ValidatePartyAccessFromString requires UUID format)
+	freezeAccountID := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("freeze-test")).String()
+	unfreezeAccountID := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("unfreeze-test")).String()
+	closeAccountID := uuid.NewSHA1(uuid.NameSpaceDNS, []byte("close-test")).String()
+
 	t.Run("freeze action maps correctly", func(t *testing.T) {
 		mockServer := &mockCurrentAccountServer{}
 		client, cleanup := setupMockServer(t, mockServer)
@@ -728,7 +733,7 @@ func TestControlHandler(t *testing.T) {
 		}
 
 		params := map[string]any{
-			"account_id": "acc-123",
+			"account_id": freezeAccountID,
 			"action":     "FREEZE",
 			"reason":     "Dunning level 3 reached: overdue payment",
 		}
@@ -739,7 +744,7 @@ func TestControlHandler(t *testing.T) {
 
 		resultMap, ok := result.(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "acc-123", resultMap["account_id"])
+		assert.Equal(t, freezeAccountID, resultMap["account_id"])
 		assert.Equal(t, "FROZEN", resultMap["new_status"])
 		assert.NotEmpty(t, resultMap["action_timestamp"])
 	})
@@ -758,7 +763,7 @@ func TestControlHandler(t *testing.T) {
 		}
 
 		params := map[string]any{
-			"account_id": "acc-456",
+			"account_id": unfreezeAccountID,
 			"action":     "UNFREEZE",
 			"reason":     "Payment method updated, retrying billing",
 		}
@@ -768,7 +773,7 @@ func TestControlHandler(t *testing.T) {
 
 		resultMap, ok := result.(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "acc-456", resultMap["account_id"])
+		assert.Equal(t, unfreezeAccountID, resultMap["account_id"])
 		assert.Equal(t, "ACTIVE", resultMap["new_status"])
 	})
 
@@ -786,7 +791,7 @@ func TestControlHandler(t *testing.T) {
 		}
 
 		params := map[string]any{
-			"account_id": "acc-789",
+			"account_id": closeAccountID,
 			"action":     "CLOSE",
 			"reason":     "Account closure requested by party",
 		}
@@ -796,7 +801,7 @@ func TestControlHandler(t *testing.T) {
 
 		resultMap, ok := result.(map[string]any)
 		require.True(t, ok)
-		assert.Equal(t, "acc-789", resultMap["account_id"])
+		assert.Equal(t, closeAccountID, resultMap["account_id"])
 		assert.Equal(t, "CLOSED", resultMap["new_status"])
 	})
 
@@ -814,7 +819,7 @@ func TestControlHandler(t *testing.T) {
 		}
 
 		params := map[string]any{
-			"account_id": "acc-123",
+			"account_id": freezeAccountID,
 			"action":     "SUSPEND",
 			"reason":     "invalid action test",
 		}
@@ -839,7 +844,7 @@ func TestControlHandler(t *testing.T) {
 		}
 
 		params := map[string]any{
-			"account_id": "acc-123",
+			"account_id": freezeAccountID,
 			"reason":     "missing action",
 		}
 
@@ -865,7 +870,7 @@ func TestControlHandler(t *testing.T) {
 		}
 
 		params := map[string]any{
-			"account_id": "acc-123",
+			"account_id": freezeAccountID,
 			"action":     "FREEZE",
 			"reason":     "error propagation test",
 		}

--- a/services/current-account/client/starlark_test.go
+++ b/services/current-account/client/starlark_test.go
@@ -712,3 +712,166 @@ func TestLienLifecycle(t *testing.T) {
 		assert.Equal(t, "TERMINATED", terminateMap["status"])
 	})
 }
+
+func TestControlHandler(t *testing.T) {
+	t.Run("freeze action maps correctly", func(t *testing.T) {
+		mockServer := &mockCurrentAccountServer{}
+		client, cleanup := setupMockServer(t, mockServer)
+		defer cleanup()
+
+		handler := controlHandler(client)
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			KnowledgeAt:    time.Now(),
+			CorrelationID:  uuid.New(),
+		}
+
+		params := map[string]any{
+			"account_id": "acc-123",
+			"action":     "FREEZE",
+			"reason":     "Dunning level 3 reached: overdue payment",
+		}
+
+		result, err := handler(ctx, params)
+		require.NoError(t, err)
+		assert.True(t, mockServer.controlAccountCalled)
+
+		resultMap, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "acc-123", resultMap["account_id"])
+		assert.Equal(t, "FROZEN", resultMap["new_status"])
+		assert.NotEmpty(t, resultMap["action_timestamp"])
+	})
+
+	t.Run("unfreeze action maps correctly", func(t *testing.T) {
+		mockServer := &mockCurrentAccountServer{}
+		client, cleanup := setupMockServer(t, mockServer)
+		defer cleanup()
+
+		handler := controlHandler(client)
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			KnowledgeAt:    time.Now(),
+			CorrelationID:  uuid.New(),
+		}
+
+		params := map[string]any{
+			"account_id": "acc-456",
+			"action":     "UNFREEZE",
+			"reason":     "Payment method updated, retrying billing",
+		}
+
+		result, err := handler(ctx, params)
+		require.NoError(t, err)
+
+		resultMap, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "acc-456", resultMap["account_id"])
+		assert.Equal(t, "ACTIVE", resultMap["new_status"])
+	})
+
+	t.Run("close action maps correctly", func(t *testing.T) {
+		mockServer := &mockCurrentAccountServer{}
+		client, cleanup := setupMockServer(t, mockServer)
+		defer cleanup()
+
+		handler := controlHandler(client)
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			KnowledgeAt:    time.Now(),
+			CorrelationID:  uuid.New(),
+		}
+
+		params := map[string]any{
+			"account_id": "acc-789",
+			"action":     "CLOSE",
+			"reason":     "Account closure requested by party",
+		}
+
+		result, err := handler(ctx, params)
+		require.NoError(t, err)
+
+		resultMap, ok := result.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "acc-789", resultMap["account_id"])
+		assert.Equal(t, "CLOSED", resultMap["new_status"])
+	})
+
+	t.Run("invalid action returns sentinel error", func(t *testing.T) {
+		mockServer := &mockCurrentAccountServer{}
+		client, cleanup := setupMockServer(t, mockServer)
+		defer cleanup()
+
+		handler := controlHandler(client)
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			KnowledgeAt:    time.Now(),
+			CorrelationID:  uuid.New(),
+		}
+
+		params := map[string]any{
+			"account_id": "acc-123",
+			"action":     "SUSPEND",
+			"reason":     "invalid action test",
+		}
+
+		_, err := handler(ctx, params)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrInvalidControlAction)
+		assert.Contains(t, err.Error(), "SUSPEND")
+	})
+
+	t.Run("missing action parameter", func(t *testing.T) {
+		mockServer := &mockCurrentAccountServer{}
+		client, cleanup := setupMockServer(t, mockServer)
+		defer cleanup()
+
+		handler := controlHandler(client)
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			KnowledgeAt:    time.Now(),
+			CorrelationID:  uuid.New(),
+		}
+
+		params := map[string]any{
+			"account_id": "acc-123",
+			"reason":     "missing action",
+		}
+
+		_, err := handler(ctx, params)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "action")
+	})
+
+	t.Run("gRPC error is propagated", func(t *testing.T) {
+		mockServer := &mockCurrentAccountServer{
+			shouldError:  true,
+			errorMessage: "account not found",
+		}
+		client, cleanup := setupMockServer(t, mockServer)
+		defer cleanup()
+
+		handler := controlHandler(client)
+		ctx := &saga.StarlarkContext{
+			Context:        context.Background(),
+			IdempotencyKey: "test-key",
+			KnowledgeAt:    time.Now(),
+			CorrelationID:  uuid.New(),
+		}
+
+		params := map[string]any{
+			"account_id": "acc-123",
+			"action":     "FREEZE",
+			"reason":     "error propagation test",
+		}
+
+		_, err := handler(ctx, params)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "account not found")
+	})
+}

--- a/services/current-account/client/starlark_test.go
+++ b/services/current-account/client/starlark_test.go
@@ -151,6 +151,8 @@ func (m *mockCurrentAccountServer) ControlCurrentAccount(_ context.Context, req 
 		newStatus = currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE
 	case currentaccountv1.ControlAction_CONTROL_ACTION_CLOSE:
 		newStatus = currentaccountv1.AccountStatus_ACCOUNT_STATUS_CLOSED
+	case currentaccountv1.ControlAction_CONTROL_ACTION_UNSPECIFIED:
+		newStatus = currentaccountv1.AccountStatus_ACCOUNT_STATUS_UNSPECIFIED
 	}
 
 	return &currentaccountv1.ControlCurrentAccountResponse{

--- a/services/current-account/client/starlark_test.go
+++ b/services/current-account/client/starlark_test.go
@@ -30,10 +30,11 @@ type mockCurrentAccountServer struct {
 	lastKnowledgeAt    time.Time
 	lastCorrelationID  uuid.UUID
 
-	initiateLienCalled  bool
-	executeLienCalled   bool
-	terminateLienCalled bool
-	updateAccountCalled bool
+	initiateLienCalled   bool
+	executeLienCalled    bool
+	terminateLienCalled  bool
+	updateAccountCalled  bool
+	controlAccountCalled bool
 
 	// Control response behavior
 	shouldError  bool
@@ -134,6 +135,33 @@ func (m *mockCurrentAccountServer) UpdateCurrentAccount(_ context.Context, req *
 	}, nil
 }
 
+func (m *mockCurrentAccountServer) ControlCurrentAccount(_ context.Context, req *currentaccountv1.ControlCurrentAccountRequest) (*currentaccountv1.ControlCurrentAccountResponse, error) {
+	m.controlAccountCalled = true
+
+	if m.shouldError {
+		return nil, fmt.Errorf("%s", m.errorMessage)
+	}
+
+	// Determine resulting status based on action
+	var newStatus currentaccountv1.AccountStatus
+	switch req.ControlAction {
+	case currentaccountv1.ControlAction_CONTROL_ACTION_FREEZE:
+		newStatus = currentaccountv1.AccountStatus_ACCOUNT_STATUS_FROZEN
+	case currentaccountv1.ControlAction_CONTROL_ACTION_UNFREEZE:
+		newStatus = currentaccountv1.AccountStatus_ACCOUNT_STATUS_ACTIVE
+	case currentaccountv1.ControlAction_CONTROL_ACTION_CLOSE:
+		newStatus = currentaccountv1.AccountStatus_ACCOUNT_STATUS_CLOSED
+	}
+
+	return &currentaccountv1.ControlCurrentAccountResponse{
+		Facility: &currentaccountv1.CurrentAccountFacility{
+			AccountId:     req.AccountId,
+			AccountStatus: newStatus,
+		},
+		ActionTimestamp: timestamppb.Now(),
+	}, nil
+}
+
 // setupMockServer creates a mock gRPC server and client for testing
 func setupMockServer(t *testing.T, mockServer *mockCurrentAccountServer) (*Client, func()) {
 	// Create in-memory listener
@@ -192,6 +220,7 @@ func TestRegisterStarlarkHandlers(t *testing.T) {
 			"current_account.execute_lien",
 			"current_account.terminate_lien",
 			"current_account.save",
+			"current_account.control",
 		}
 
 		for _, name := range handlers {

--- a/services/current-account/service/saga_handlers.go
+++ b/services/current-account/service/saga_handlers.go
@@ -104,6 +104,9 @@ func RegisterCurrentAccountHandlers(registry *saga.HandlerRegistry) error {
 		// Current Account domain handlers
 		{"current_account.save", currentAccountRepositorySave},
 
+		// Control handler (stub - implemented in client package for cross-service use)
+		{"current_account.control", stubNotImplemented("current_account.control")},
+
 		// Lien handlers (stubs - not yet implemented but required by schema)
 		{"current_account.create_lien", stubNotImplemented("current_account.create_lien")},
 		{"current_account.execute_lien", stubNotImplemented("current_account.execute_lien")},

--- a/services/payment-order/adapters/persistence/billing_entity.go
+++ b/services/payment-order/adapters/persistence/billing_entity.go
@@ -8,15 +8,16 @@ import (
 
 // BillingRunEntity represents the database persistence model for billing runs.
 type BillingRunEntity struct {
-	ID            uuid.UUID `gorm:"primaryKey"`
-	TenantID      string    `gorm:"not null;size:255"`
-	CycleStart    time.Time `gorm:"not null"`
-	CycleEnd      time.Time `gorm:"not null"`
-	Status        string    `gorm:"not null;size:20"`
-	DunningLevel  int       `gorm:"not null;default:0"`
-	FailureReason *string   `gorm:"size:1000"`
-	CreatedAt     time.Time `gorm:"not null"`
-	UpdatedAt     time.Time `gorm:"not null"`
+	ID            uuid.UUID  `gorm:"primaryKey"`
+	TenantID      string     `gorm:"not null;size:255"`
+	CycleStart    time.Time  `gorm:"not null"`
+	CycleEnd      time.Time  `gorm:"not null"`
+	Status        string     `gorm:"not null;size:20"`
+	DunningLevel  int        `gorm:"not null;default:0"`
+	FailureReason *string    `gorm:"size:1000"`
+	LastRetryAt   *time.Time `gorm:""`
+	CreatedAt     time.Time  `gorm:"not null"`
+	UpdatedAt     time.Time  `gorm:"not null"`
 }
 
 // TableName overrides the default table name.

--- a/services/payment-order/adapters/persistence/billing_repository.go
+++ b/services/payment-order/adapters/persistence/billing_repository.go
@@ -111,6 +111,7 @@ func (r *BillingRepositoryImpl) UpdateBillingRun(ctx context.Context, run *domai
 			"status":         entity.Status,
 			"dunning_level":  entity.DunningLevel,
 			"failure_reason": entity.FailureReason,
+			"last_retry_at":  entity.LastRetryAt,
 			"updated_at":     entity.UpdatedAt,
 		})
 		if result.Error != nil {
@@ -222,6 +223,7 @@ func billingRunToEntity(run *domain.BillingRun) *BillingRunEntity {
 		CycleEnd:     run.CycleEnd,
 		Status:       string(run.Status),
 		DunningLevel: run.DunningLevel,
+		LastRetryAt:  run.LastRetryAt,
 		CreatedAt:    run.CreatedAt,
 		UpdatedAt:    run.UpdatedAt,
 	}
@@ -239,6 +241,7 @@ func billingRunToDomain(entity *BillingRunEntity) *domain.BillingRun {
 		CycleEnd:     entity.CycleEnd,
 		Status:       domain.BillingRunStatus(entity.Status),
 		DunningLevel: entity.DunningLevel,
+		LastRetryAt:  entity.LastRetryAt,
 		CreatedAt:    entity.CreatedAt,
 		UpdatedAt:    entity.UpdatedAt,
 	}

--- a/services/payment-order/domain/billing.go
+++ b/services/payment-order/domain/billing.go
@@ -46,6 +46,7 @@ type BillingRun struct {
 	Status        BillingRunStatus
 	DunningLevel  int
 	FailureReason string
+	LastRetryAt   *time.Time
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 }
@@ -108,6 +109,48 @@ func (b *BillingRun) Fail(reason string) error {
 // IsTerminal returns true if the billing run is in a terminal state.
 func (b *BillingRun) IsTerminal() bool {
 	return b.Status == BillingRunStatusCompleted || b.Status == BillingRunStatusFailed
+}
+
+// MaxDunningLevel is the highest dunning level before account freeze.
+const MaxDunningLevel = 3
+
+// DunningBackoffDurations maps dunning levels to retry delay durations.
+// Level 0->1: 24h, Level 1->2: 72h, Level 2->3: 168h (7 days).
+var DunningBackoffDurations = map[int]time.Duration{
+	0: 24 * time.Hour,
+	1: 72 * time.Hour,
+	2: 168 * time.Hour,
+}
+
+// EscalateDunning increments the dunning level and records the retry timestamp.
+// Can only be called on FAILED billing runs that haven't reached the maximum level.
+func (b *BillingRun) EscalateDunning() error {
+	if b.Status != BillingRunStatusFailed {
+		return ErrInvalidBillingRunTransition
+	}
+	if b.DunningLevel > MaxDunningLevel {
+		return ErrBillingRunTerminal
+	}
+	now := time.Now()
+	b.DunningLevel++
+	b.LastRetryAt = &now
+	b.UpdatedAt = now
+	return nil
+}
+
+// NeedsFreezing returns true if the billing run has exceeded the maximum dunning level.
+func (b *BillingRun) NeedsFreezing() bool {
+	return b.DunningLevel >= MaxDunningLevel
+}
+
+// DunningRetryDelay returns the backoff duration for the current dunning level.
+// Returns zero duration if the level exceeds the configured backoffs.
+func (b *BillingRun) DunningRetryDelay() time.Duration {
+	delay, ok := DunningBackoffDurations[b.DunningLevel]
+	if !ok {
+		return 0
+	}
+	return delay
 }
 
 // BillingRunIdempotencyKey generates a deterministic idempotency key for a billing run.

--- a/services/payment-order/domain/billing.go
+++ b/services/payment-order/domain/billing.go
@@ -128,7 +128,7 @@ func (b *BillingRun) EscalateDunning() error {
 	if b.Status != BillingRunStatusFailed {
 		return ErrInvalidBillingRunTransition
 	}
-	if b.DunningLevel > MaxDunningLevel {
+	if b.DunningLevel >= MaxDunningLevel {
 		return ErrBillingRunTerminal
 	}
 	now := time.Now()

--- a/services/payment-order/domain/billing_dunning_test.go
+++ b/services/payment-order/domain/billing_dunning_test.go
@@ -21,13 +21,13 @@ func TestBillingRun_EscalateDunning(t *testing.T) {
 		assert.NotNil(t, run.LastRetryAt)
 	})
 
-	t.Run("escalates through all levels", func(t *testing.T) {
+	t.Run("escalates through all levels below max", func(t *testing.T) {
 		run := &BillingRun{
 			Status:       BillingRunStatusFailed,
 			DunningLevel: 0,
 		}
 
-		for expectedLevel := 1; expectedLevel <= MaxDunningLevel; expectedLevel++ {
+		for expectedLevel := 1; expectedLevel < MaxDunningLevel; expectedLevel++ {
 			err := run.EscalateDunning()
 			require.NoError(t, err)
 			assert.Equal(t, expectedLevel, run.DunningLevel)
@@ -42,6 +42,16 @@ func TestBillingRun_EscalateDunning(t *testing.T) {
 
 		err := run.EscalateDunning()
 		assert.ErrorIs(t, err, ErrInvalidBillingRunTransition)
+	})
+
+	t.Run("rejects escalation at exactly max level", func(t *testing.T) {
+		run := &BillingRun{
+			Status:       BillingRunStatusFailed,
+			DunningLevel: MaxDunningLevel,
+		}
+
+		err := run.EscalateDunning()
+		assert.ErrorIs(t, err, ErrBillingRunTerminal)
 	})
 
 	t.Run("rejects escalation beyond max level", func(t *testing.T) {

--- a/services/payment-order/domain/billing_dunning_test.go
+++ b/services/payment-order/domain/billing_dunning_test.go
@@ -1,0 +1,95 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBillingRun_EscalateDunning(t *testing.T) {
+	t.Run("escalates from level 0 to 1", func(t *testing.T) {
+		run := &BillingRun{
+			Status:       BillingRunStatusFailed,
+			DunningLevel: 0,
+		}
+
+		err := run.EscalateDunning()
+		require.NoError(t, err)
+		assert.Equal(t, 1, run.DunningLevel)
+		assert.NotNil(t, run.LastRetryAt)
+	})
+
+	t.Run("escalates through all levels", func(t *testing.T) {
+		run := &BillingRun{
+			Status:       BillingRunStatusFailed,
+			DunningLevel: 0,
+		}
+
+		for expectedLevel := 1; expectedLevel <= MaxDunningLevel; expectedLevel++ {
+			err := run.EscalateDunning()
+			require.NoError(t, err)
+			assert.Equal(t, expectedLevel, run.DunningLevel)
+		}
+	})
+
+	t.Run("rejects escalation on non-failed run", func(t *testing.T) {
+		run := &BillingRun{
+			Status:       BillingRunStatusProcessing,
+			DunningLevel: 0,
+		}
+
+		err := run.EscalateDunning()
+		assert.ErrorIs(t, err, ErrInvalidBillingRunTransition)
+	})
+
+	t.Run("rejects escalation beyond max level", func(t *testing.T) {
+		run := &BillingRun{
+			Status:       BillingRunStatusFailed,
+			DunningLevel: MaxDunningLevel + 1,
+		}
+
+		err := run.EscalateDunning()
+		assert.ErrorIs(t, err, ErrBillingRunTerminal)
+	})
+}
+
+func TestBillingRun_NeedsFreezing(t *testing.T) {
+	t.Run("returns false below max level", func(t *testing.T) {
+		run := &BillingRun{DunningLevel: 2}
+		assert.False(t, run.NeedsFreezing())
+	})
+
+	t.Run("returns true at max level", func(t *testing.T) {
+		run := &BillingRun{DunningLevel: MaxDunningLevel}
+		assert.True(t, run.NeedsFreezing())
+	})
+
+	t.Run("returns true above max level", func(t *testing.T) {
+		run := &BillingRun{DunningLevel: MaxDunningLevel + 1}
+		assert.True(t, run.NeedsFreezing())
+	})
+}
+
+func TestBillingRun_DunningRetryDelay(t *testing.T) {
+	t.Run("level 0 returns 24h", func(t *testing.T) {
+		run := &BillingRun{DunningLevel: 0}
+		assert.Equal(t, 24*time.Hour, run.DunningRetryDelay())
+	})
+
+	t.Run("level 1 returns 72h", func(t *testing.T) {
+		run := &BillingRun{DunningLevel: 1}
+		assert.Equal(t, 72*time.Hour, run.DunningRetryDelay())
+	})
+
+	t.Run("level 2 returns 168h", func(t *testing.T) {
+		run := &BillingRun{DunningLevel: 2}
+		assert.Equal(t, 168*time.Hour, run.DunningRetryDelay())
+	})
+
+	t.Run("level 3 returns zero duration", func(t *testing.T) {
+		run := &BillingRun{DunningLevel: 3}
+		assert.Equal(t, time.Duration(0), run.DunningRetryDelay())
+	})
+}

--- a/services/payment-order/migrations/20260211000001_billing_dunning.sql
+++ b/services/payment-order/migrations/20260211000001_billing_dunning.sql
@@ -1,0 +1,13 @@
+-- Add dunning retry tracking to billing_run table.
+-- Supports dunning saga escalation with TTL-based retry scheduling.
+
+-- Add last_retry_at column to track when the last dunning retry was scheduled.
+-- NULL means no retry has been attempted yet.
+ALTER TABLE "billing_run" ADD COLUMN "last_retry_at" timestamptz NULL;
+
+-- Index for finding billing runs that need dunning retry.
+-- Queries: "find FAILED runs with dunning_level < 4 ordered by last retry time"
+CREATE INDEX "idx_billing_run_dunning" ON "billing_run" ("status", "dunning_level")
+    WHERE status = 'FAILED' AND dunning_level < 4;
+
+COMMENT ON COLUMN "billing_run"."last_retry_at" IS 'Timestamp of the last dunning retry attempt. NULL if no retry has been scheduled.';

--- a/services/payment-order/migrations/20260211000001_billing_dunning.sql
+++ b/services/payment-order/migrations/20260211000001_billing_dunning.sql
@@ -1,5 +1,5 @@
 -- Add dunning retry tracking to billing_run table.
--- Supports dunning saga escalation with TTL-based retry scheduling.
+-- Supports dunning saga escalation with Redis sorted-set retry scheduling.
 
 -- Add last_retry_at column to track when the last dunning retry was scheduled.
 -- NULL means no retry has been attempted yet.
@@ -7,7 +7,7 @@ ALTER TABLE "billing_run" ADD COLUMN "last_retry_at" timestamptz NULL;
 
 -- Index for finding billing runs that need dunning retry.
 -- Queries: "find FAILED runs with dunning_level < 4 ordered by last retry time"
-CREATE INDEX "idx_billing_run_dunning" ON "billing_run" ("status", "dunning_level")
+CREATE INDEX "idx_billing_run_dunning" ON "billing_run" ("status", "dunning_level", "last_retry_at")
     WHERE status = 'FAILED' AND dunning_level < 4;
 
 COMMENT ON COLUMN "billing_run"."last_retry_at" IS 'Timestamp of the last dunning retry attempt. NULL if no retry has been scheduled.';

--- a/services/payment-order/migrations/atlas.sum
+++ b/services/payment-order/migrations/atlas.sum
@@ -1,7 +1,8 @@
-h1:atjSQUPCzMyjBN0OKIT5cJ8k/BmaxXi7Wf8luq8A0as=
+h1:utgdakk5sZT+KPmF0N2jI6W/iUw/TqNraeF7BQ3SJjc=
 20251216000001_initial.sql h1:9Pt9iC/k1YkmfjyO/F0ioNbPswzzgCP2aHtFlFHnSMY=
 20251217000001_audit_system.sql h1:YD9HdFm+NRTihCM/PBU7EYEmdttWjvGPCIE408A8HFg=
 20251223000001_fix_audit_schema_compatibility.sql h1:QxqR4DwdQ5cNXHCxTvtHgQmhSnD8xptkoFnxNcZ5ehY=
 20260123000001_bucket_aware_solvency.sql h1:fnEeQa7ezvAKV/Xja8l9/Btz68+e9raPJQIuHoK1bxw=
 20260204000001_create_event_outbox.sql h1:QvPBgr/Z0FpRT7kR0huU7R4GYD7xzpBxlT4rdjS2c/g=
 20260210000001_billing.sql h1:E/Bg1NLhonN7hCHEL5fyrAYMmfoBQRTKzlvCSiB9kTA=
+20260211000001_billing_dunning.sql h1:8+R0tCiG5ufz4Ghbf3srxgAc6V5vKdnKWKlOoDQmoSQ=

--- a/services/payment-order/migrations/atlas.sum
+++ b/services/payment-order/migrations/atlas.sum
@@ -1,8 +1,8 @@
-h1:utgdakk5sZT+KPmF0N2jI6W/iUw/TqNraeF7BQ3SJjc=
+h1:NWuDRvN4AT3dp512N11tH8OiNxJsMvtZs/todu4OzWM=
 20251216000001_initial.sql h1:9Pt9iC/k1YkmfjyO/F0ioNbPswzzgCP2aHtFlFHnSMY=
 20251217000001_audit_system.sql h1:YD9HdFm+NRTihCM/PBU7EYEmdttWjvGPCIE408A8HFg=
 20251223000001_fix_audit_schema_compatibility.sql h1:QxqR4DwdQ5cNXHCxTvtHgQmhSnD8xptkoFnxNcZ5ehY=
 20260123000001_bucket_aware_solvency.sql h1:fnEeQa7ezvAKV/Xja8l9/Btz68+e9raPJQIuHoK1bxw=
 20260204000001_create_event_outbox.sql h1:QvPBgr/Z0FpRT7kR0huU7R4GYD7xzpBxlT4rdjS2c/g=
 20260210000001_billing.sql h1:E/Bg1NLhonN7hCHEL5fyrAYMmfoBQRTKzlvCSiB9kTA=
-20260211000001_billing_dunning.sql h1:8+R0tCiG5ufz4Ghbf3srxgAc6V5vKdnKWKlOoDQmoSQ=
+20260211000001_billing_dunning.sql h1:nxy+LNCaGfAqsXSlugNsl9pVctGJ7XukG2+RXB2Xe9Y=

--- a/services/payment-order/worker/dunning_worker.go
+++ b/services/payment-order/worker/dunning_worker.go
@@ -2,8 +2,10 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"sync"
 	"time"
 
@@ -12,6 +14,15 @@ import (
 	"github.com/meridianhub/meridian/services/payment-order/domain"
 	"github.com/redis/go-redis/v9"
 )
+
+// Dunning worker errors.
+var (
+	ErrNilDunningCallback = errors.New("dunning callback is required")
+	ErrDunningKeyTooShort = errors.New("dunning retry key too short")
+)
+
+// dunningRetryZSet is the Redis sorted set key for dunning retry scheduling.
+const dunningRetryZSet = "dunning:retries"
 
 // DunningWorkerConfig holds configuration for the dunning retry worker.
 type DunningWorkerConfig struct {
@@ -25,10 +36,9 @@ type DunningWorkerConfig struct {
 // The callback receives the billing run and should trigger the appropriate saga.
 type DunningCallback func(ctx context.Context, run *domain.BillingRun) error
 
-// DunningWorker polls Redis for due dunning retry keys and triggers escalation.
-// It uses Redis TTL-based scheduling: when a billing run fails, a key is set
-// with a TTL equal to the backoff duration. The worker polls for expired keys
-// to trigger the next escalation step.
+// DunningWorker polls a Redis sorted set for due dunning retries and triggers
+// escalation. It uses ZADD to schedule retries with the due timestamp as score
+// and ZRANGEBYSCORE to find items whose due time has passed.
 type DunningWorker struct {
 	repo     persistence.BillingRepository
 	redis    *redis.Client
@@ -62,7 +72,7 @@ func NewDunningWorker(
 		return nil, ErrNilBillingLogger
 	}
 	if callback == nil {
-		return nil, fmt.Errorf("dunning callback is required")
+		return nil, ErrNilDunningCallback
 	}
 	if config.PollInterval == 0 {
 		config.PollInterval = 60 * time.Second
@@ -136,11 +146,15 @@ func (w *DunningWorker) Stop() {
 	}
 }
 
-// ScheduleDunningRetry sets a Redis key with TTL for the backoff duration.
-// When the key expires, the worker will detect this and trigger escalation.
+// ScheduleDunningRetry adds a billing run to the sorted set with a score
+// equal to the Unix timestamp when the retry becomes due.
 func (w *DunningWorker) ScheduleDunningRetry(ctx context.Context, billingRunID uuid.UUID, delay time.Duration) error {
-	key := dunningRetryKey(billingRunID)
-	err := w.redis.Set(ctx, key, "pending", delay).Err()
+	dueAt := NowFunc().Add(delay)
+	member := redis.Z{
+		Score:  float64(dueAt.Unix()),
+		Member: billingRunID.String(),
+	}
+	err := w.redis.ZAdd(ctx, dunningRetryZSet, member).Err()
 	if err != nil {
 		return fmt.Errorf("failed to schedule dunning retry: %w", err)
 	}
@@ -148,47 +162,47 @@ func (w *DunningWorker) ScheduleDunningRetry(ctx context.Context, billingRunID u
 	w.logger.Info("dunning retry scheduled",
 		"billing_run_id", billingRunID,
 		"delay", delay,
-		"key", key)
+		"due_at", dueAt)
 
 	return nil
 }
 
-// processDueRetries scans for billing runs due for dunning escalation.
-// A billing run is due when its Redis retry key has expired (TTL elapsed).
+// processDueRetries queries the sorted set for all members whose score (due
+// timestamp) is at or before the current time, processes each one, and removes
+// it from the set.
 func (w *DunningWorker) processDueRetries(ctx context.Context) {
-	// Use SCAN to find all dunning retry keys
-	var cursor uint64
+	now := NowFunc()
+	maxScore := strconv.FormatInt(now.Unix(), 10)
+
+	// Fetch billing run IDs that are due
+	members, err := w.redis.ZRangeByScore(ctx, dunningRetryZSet, &redis.ZRangeBy{
+		Min:   "-inf",
+		Max:   maxScore,
+		Count: 100,
+	}).Result()
+	if err != nil {
+		w.logger.Error("failed to query dunning retries", "error", err)
+		return
+	}
+
+	if len(members) == 0 {
+		return
+	}
+
 	var processed int
-
-	for {
-		keys, nextCursor, err := w.redis.Scan(ctx, cursor, "dunning:retry:*", 100).Result()
-		if err != nil {
-			w.logger.Error("failed to scan dunning retry keys", "error", err)
-			return
+	for _, member := range members {
+		billingRunID, parseErr := uuid.Parse(member)
+		if parseErr != nil {
+			w.logger.Error("invalid billing run ID in dunning set", "member", member, "error", parseErr)
+			w.redis.ZRem(ctx, dunningRetryZSet, member)
+			continue
 		}
 
-		for _, key := range keys {
-			// Check if the key is still pending (exists means not yet due)
-			// Actually, for TTL-based scheduling, we use a different pattern:
-			// We store a "ready" marker. The scheduler sets a separate delay key.
-			// When processing, we check for "ready" keys.
-			val, err := w.redis.Get(ctx, key).Result()
-			if err != nil {
-				continue // Key expired or error
-			}
+		w.processRetry(ctx, billingRunID)
+		processed++
 
-			if val != "ready" {
-				continue // Not yet due
-			}
-
-			w.processRetryKey(ctx, key)
-			processed++
-		}
-
-		cursor = nextCursor
-		if cursor == 0 {
-			break
-		}
+		// Remove processed member from the set
+		w.redis.ZRem(ctx, dunningRetryZSet, member)
 	}
 
 	if processed > 0 {
@@ -196,16 +210,8 @@ func (w *DunningWorker) processDueRetries(ctx context.Context) {
 	}
 }
 
-// processRetryKey handles a single due dunning retry.
-func (w *DunningWorker) processRetryKey(ctx context.Context, key string) {
-	// Extract billing run ID from key: "dunning:retry:{billing_run_id}"
-	billingRunID, err := parseDunningRetryKey(key)
-	if err != nil {
-		w.logger.Error("invalid dunning retry key", "key", key, "error", err)
-		w.redis.Del(ctx, key)
-		return
-	}
-
+// processRetry handles a single due dunning retry.
+func (w *DunningWorker) processRetry(ctx context.Context, billingRunID uuid.UUID) {
 	w.wg.Add(1)
 	defer w.wg.Done()
 
@@ -223,7 +229,6 @@ func (w *DunningWorker) processRetryKey(ctx context.Context, key string) {
 		w.logger.Info("billing run no longer failed, skipping dunning",
 			"billing_run_id", billingRunID,
 			"status", run.Status)
-		w.redis.Del(ctx, key)
 		return
 	}
 
@@ -240,32 +245,13 @@ func (w *DunningWorker) processRetryKey(ctx context.Context, key string) {
 		return
 	}
 
-	// Clean up the retry key
-	w.redis.Del(ctx, key)
-
 	w.logger.Info("dunning escalation triggered",
 		"billing_run_id", billingRunID,
 		"dunning_level", run.DunningLevel)
 }
 
-// MarkRetryReady transitions a retry key from pending to ready.
-// Called by a separate delayed process or when the TTL expires.
-// For the initial implementation, callers set keys directly as "ready" with delay.
-func (w *DunningWorker) MarkRetryReady(ctx context.Context, billingRunID uuid.UUID) error {
-	key := dunningRetryKey(billingRunID)
-	return w.redis.Set(ctx, key, "ready", 0).Err()
-}
-
-// dunningRetryKey generates the Redis key for a dunning retry.
-func dunningRetryKey(billingRunID uuid.UUID) string {
-	return fmt.Sprintf("dunning:retry:%s", billingRunID.String())
-}
-
-// parseDunningRetryKey extracts the billing run ID from a Redis key.
-func parseDunningRetryKey(key string) (uuid.UUID, error) {
-	const prefix = "dunning:retry:"
-	if len(key) <= len(prefix) {
-		return uuid.Nil, fmt.Errorf("key too short: %s", key)
-	}
-	return uuid.Parse(key[len(prefix):])
+// CancelDunningRetry removes a billing run from the retry set.
+// Called when a billing run is resolved (e.g., manual payment succeeds).
+func (w *DunningWorker) CancelDunningRetry(ctx context.Context, billingRunID uuid.UUID) error {
+	return w.redis.ZRem(ctx, dunningRetryZSet, billingRunID.String()).Err()
 }

--- a/services/payment-order/worker/dunning_worker.go
+++ b/services/payment-order/worker/dunning_worker.go
@@ -198,11 +198,11 @@ func (w *DunningWorker) processDueRetries(ctx context.Context) {
 			continue
 		}
 
-		w.processRetry(ctx, billingRunID)
-		processed++
-
-		// Remove processed member from the set
-		w.redis.ZRem(ctx, dunningRetryZSet, member)
+		if w.processRetry(ctx, billingRunID) {
+			// Only remove on success; transient failures retain the member for next poll
+			w.redis.ZRem(ctx, dunningRetryZSet, member)
+			processed++
+		}
 	}
 
 	if processed > 0 {
@@ -210,8 +210,11 @@ func (w *DunningWorker) processDueRetries(ctx context.Context) {
 	}
 }
 
-// processRetry handles a single due dunning retry.
-func (w *DunningWorker) processRetry(ctx context.Context, billingRunID uuid.UUID) {
+// processRetry handles a single due dunning retry. Returns true if the retry
+// was handled (success or permanently resolved) and the ZSET member should be
+// removed. Returns false on transient errors so the member is retained for the
+// next poll cycle.
+func (w *DunningWorker) processRetry(ctx context.Context, billingRunID uuid.UUID) bool {
 	w.wg.Add(1)
 	defer w.wg.Done()
 
@@ -221,15 +224,15 @@ func (w *DunningWorker) processRetry(ctx context.Context, billingRunID uuid.UUID
 		w.logger.Error("failed to load billing run for dunning",
 			"billing_run_id", billingRunID,
 			"error", err)
-		return
+		return false
 	}
 
-	// Verify billing run is still in FAILED state
+	// Billing run resolved externally — remove from retry set
 	if run.Status != domain.BillingRunStatusFailed {
 		w.logger.Info("billing run no longer failed, skipping dunning",
 			"billing_run_id", billingRunID,
 			"status", run.Status)
-		return
+		return true
 	}
 
 	// Call the dunning callback (triggers dunning_escalation saga)
@@ -242,12 +245,13 @@ func (w *DunningWorker) processRetry(ctx context.Context, billingRunID uuid.UUID
 			"billing_run_id", billingRunID,
 			"error", err)
 		w.metrics.RecordError("dunning_callback")
-		return
+		return false
 	}
 
 	w.logger.Info("dunning escalation triggered",
 		"billing_run_id", billingRunID,
 		"dunning_level", run.DunningLevel)
+	return true
 }
 
 // CancelDunningRetry removes a billing run from the retry set.

--- a/services/payment-order/worker/dunning_worker.go
+++ b/services/payment-order/worker/dunning_worker.go
@@ -221,6 +221,11 @@ func (w *DunningWorker) processRetry(ctx context.Context, billingRunID uuid.UUID
 	// Load billing run from database
 	run, err := w.repo.FindBillingRunByID(ctx, billingRunID)
 	if err != nil {
+		if errors.Is(err, persistence.ErrBillingRunNotFound) {
+			w.logger.Info("billing run not found, dropping retry",
+				"billing_run_id", billingRunID)
+			return true
+		}
 		w.logger.Error("failed to load billing run for dunning",
 			"billing_run_id", billingRunID,
 			"error", err)

--- a/services/payment-order/worker/dunning_worker.go
+++ b/services/payment-order/worker/dunning_worker.go
@@ -1,0 +1,271 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
+	"github.com/meridianhub/meridian/services/payment-order/domain"
+	"github.com/redis/go-redis/v9"
+)
+
+// DunningWorkerConfig holds configuration for the dunning retry worker.
+type DunningWorkerConfig struct {
+	// PollInterval is how frequently the worker checks for due retries.
+	PollInterval time.Duration
+	// MaxDunningLevel is the level at which accounts should be frozen.
+	MaxDunningLevel int
+}
+
+// DunningCallback is called when a dunning escalation is due.
+// The callback receives the billing run and should trigger the appropriate saga.
+type DunningCallback func(ctx context.Context, run *domain.BillingRun) error
+
+// DunningWorker polls Redis for due dunning retry keys and triggers escalation.
+// It uses Redis TTL-based scheduling: when a billing run fails, a key is set
+// with a TTL equal to the backoff duration. The worker polls for expired keys
+// to trigger the next escalation step.
+type DunningWorker struct {
+	repo     persistence.BillingRepository
+	redis    *redis.Client
+	config   DunningWorkerConfig
+	callback DunningCallback
+	logger   *slog.Logger
+	metrics  *BillingMetrics
+
+	done    chan struct{}
+	wg      sync.WaitGroup
+	mu      sync.Mutex
+	running bool
+}
+
+// NewDunningWorker creates a new dunning retry worker.
+func NewDunningWorker(
+	repo persistence.BillingRepository,
+	redisClient *redis.Client,
+	config DunningWorkerConfig,
+	callback DunningCallback,
+	logger *slog.Logger,
+	metrics *BillingMetrics,
+) (*DunningWorker, error) {
+	if repo == nil {
+		return nil, ErrNilBillingRepo
+	}
+	if redisClient == nil {
+		return nil, ErrNilRedisClient
+	}
+	if logger == nil {
+		return nil, ErrNilBillingLogger
+	}
+	if callback == nil {
+		return nil, fmt.Errorf("dunning callback is required")
+	}
+	if config.PollInterval == 0 {
+		config.PollInterval = 60 * time.Second
+	}
+	if config.MaxDunningLevel == 0 {
+		config.MaxDunningLevel = domain.MaxDunningLevel
+	}
+	if metrics == nil {
+		metrics = NewBillingMetrics()
+	}
+
+	return &DunningWorker{
+		repo:     repo,
+		redis:    redisClient,
+		config:   config,
+		callback: callback,
+		logger:   logger.With("component", "dunning_worker"),
+		metrics:  metrics,
+		done:     make(chan struct{}),
+	}, nil
+}
+
+// Start begins the dunning worker polling loop.
+func (w *DunningWorker) Start(ctx context.Context) error {
+	w.mu.Lock()
+	if w.running {
+		w.mu.Unlock()
+		return ErrSchedulerRunning
+	}
+	w.running = true
+	w.mu.Unlock()
+
+	w.logger.Info("dunning worker starting",
+		"poll_interval", w.config.PollInterval,
+		"max_dunning_level", w.config.MaxDunningLevel)
+
+	ticker := time.NewTicker(w.config.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			w.logger.Info("dunning worker stopping: context cancelled")
+			w.mu.Lock()
+			w.running = false
+			w.mu.Unlock()
+			w.wg.Wait()
+			return nil
+		case <-w.done:
+			w.logger.Info("dunning worker stopping: explicit shutdown")
+			w.mu.Lock()
+			w.running = false
+			w.mu.Unlock()
+			w.wg.Wait()
+			return nil
+		case <-ticker.C:
+			w.processDueRetries(ctx)
+		}
+	}
+}
+
+// Stop signals the dunning worker to shut down gracefully.
+func (w *DunningWorker) Stop() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	select {
+	case <-w.done:
+	default:
+		close(w.done)
+	}
+}
+
+// ScheduleDunningRetry sets a Redis key with TTL for the backoff duration.
+// When the key expires, the worker will detect this and trigger escalation.
+func (w *DunningWorker) ScheduleDunningRetry(ctx context.Context, billingRunID uuid.UUID, delay time.Duration) error {
+	key := dunningRetryKey(billingRunID)
+	err := w.redis.Set(ctx, key, "pending", delay).Err()
+	if err != nil {
+		return fmt.Errorf("failed to schedule dunning retry: %w", err)
+	}
+
+	w.logger.Info("dunning retry scheduled",
+		"billing_run_id", billingRunID,
+		"delay", delay,
+		"key", key)
+
+	return nil
+}
+
+// processDueRetries scans for billing runs due for dunning escalation.
+// A billing run is due when its Redis retry key has expired (TTL elapsed).
+func (w *DunningWorker) processDueRetries(ctx context.Context) {
+	// Use SCAN to find all dunning retry keys
+	var cursor uint64
+	var processed int
+
+	for {
+		keys, nextCursor, err := w.redis.Scan(ctx, cursor, "dunning:retry:*", 100).Result()
+		if err != nil {
+			w.logger.Error("failed to scan dunning retry keys", "error", err)
+			return
+		}
+
+		for _, key := range keys {
+			// Check if the key is still pending (exists means not yet due)
+			// Actually, for TTL-based scheduling, we use a different pattern:
+			// We store a "ready" marker. The scheduler sets a separate delay key.
+			// When processing, we check for "ready" keys.
+			val, err := w.redis.Get(ctx, key).Result()
+			if err != nil {
+				continue // Key expired or error
+			}
+
+			if val != "ready" {
+				continue // Not yet due
+			}
+
+			w.processRetryKey(ctx, key)
+			processed++
+		}
+
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+
+	if processed > 0 {
+		w.logger.Info("processed dunning retries", "count", processed)
+	}
+}
+
+// processRetryKey handles a single due dunning retry.
+func (w *DunningWorker) processRetryKey(ctx context.Context, key string) {
+	// Extract billing run ID from key: "dunning:retry:{billing_run_id}"
+	billingRunID, err := parseDunningRetryKey(key)
+	if err != nil {
+		w.logger.Error("invalid dunning retry key", "key", key, "error", err)
+		w.redis.Del(ctx, key)
+		return
+	}
+
+	w.wg.Add(1)
+	defer w.wg.Done()
+
+	// Load billing run from database
+	run, err := w.repo.FindBillingRunByID(ctx, billingRunID)
+	if err != nil {
+		w.logger.Error("failed to load billing run for dunning",
+			"billing_run_id", billingRunID,
+			"error", err)
+		return
+	}
+
+	// Verify billing run is still in FAILED state
+	if run.Status != domain.BillingRunStatusFailed {
+		w.logger.Info("billing run no longer failed, skipping dunning",
+			"billing_run_id", billingRunID,
+			"status", run.Status)
+		w.redis.Del(ctx, key)
+		return
+	}
+
+	// Call the dunning callback (triggers dunning_escalation saga)
+	w.logger.Info("triggering dunning escalation",
+		"billing_run_id", billingRunID,
+		"current_dunning_level", run.DunningLevel)
+
+	if err := w.callback(ctx, run); err != nil {
+		w.logger.Error("dunning callback failed",
+			"billing_run_id", billingRunID,
+			"error", err)
+		w.metrics.RecordError("dunning_callback")
+		return
+	}
+
+	// Clean up the retry key
+	w.redis.Del(ctx, key)
+
+	w.logger.Info("dunning escalation triggered",
+		"billing_run_id", billingRunID,
+		"dunning_level", run.DunningLevel)
+}
+
+// MarkRetryReady transitions a retry key from pending to ready.
+// Called by a separate delayed process or when the TTL expires.
+// For the initial implementation, callers set keys directly as "ready" with delay.
+func (w *DunningWorker) MarkRetryReady(ctx context.Context, billingRunID uuid.UUID) error {
+	key := dunningRetryKey(billingRunID)
+	return w.redis.Set(ctx, key, "ready", 0).Err()
+}
+
+// dunningRetryKey generates the Redis key for a dunning retry.
+func dunningRetryKey(billingRunID uuid.UUID) string {
+	return fmt.Sprintf("dunning:retry:%s", billingRunID.String())
+}
+
+// parseDunningRetryKey extracts the billing run ID from a Redis key.
+func parseDunningRetryKey(key string) (uuid.UUID, error) {
+	const prefix = "dunning:retry:"
+	if len(key) <= len(prefix) {
+		return uuid.Nil, fmt.Errorf("key too short: %s", key)
+	}
+	return uuid.Parse(key[len(prefix):])
+}

--- a/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
+++ b/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
@@ -36,12 +36,23 @@ def dunning_escalation():
 
     ctx = input_data
 
-    current_level = ctx.get("dunning_level", 0)
+    # Validate required fields before any side effects
+    missing = []
+    for key in ["dunning_level", "account_id", "party_id", "amount_cents", "currency"]:
+        if ctx.get(key) == None:
+            missing.append(key)
+    if missing:
+        return {
+            "action_taken": "invalid_input",
+            "missing_fields": missing,
+        }
+
+    current_level = ctx["dunning_level"]
     new_level = current_level + 1
-    account_id = ctx.get("account_id")
-    party_id = ctx.get("party_id")
-    amount_cents = ctx.get("amount_cents")
-    currency = ctx.get("currency")
+    account_id = ctx["account_id"]
+    party_id = ctx["party_id"]
+    amount_cents = ctx["amount_cents"]
+    currency = ctx["currency"]
     invoice_number = ctx.get("invoice_number", "")
 
     result = {

--- a/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
+++ b/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
@@ -1,0 +1,102 @@
+# Saga: dunning_escalation
+# Version: 1.0.0
+# Previous: none
+# Changed: Initial implementation of dunning escalation saga
+# Author: Platform Team
+# Date: 2026-02-11
+#
+# Dunning Escalation saga for handling payment failures through progressive
+# dunning levels. When a billing run payment fails, this saga escalates
+# through notification and account freeze stages.
+#
+# Dunning levels:
+#   0 -> 1: Send payment failure notification, schedule retry in 24h
+#   1 -> 2: Send second notice, schedule retry in 72h
+#   2 -> 3: Send final warning, schedule retry in 168h (7 days)
+#   3:      Freeze the account, send freeze notification
+#
+# Steps:
+#   1. check_dunning_level - Evaluate current level and determine action
+#   2. send_notification   - Notify party of payment failure/escalation
+#   3. freeze_account      - Freeze account at max dunning level (level 3)
+#
+# Input parameters (from input_data dict):
+#   - billing_run_id: string (required) - billing run that failed
+#   - account_id: string (required) - debtor account
+#   - party_id: string (required) - party to notify
+#   - dunning_level: int (required) - current dunning level (0-2 pre-escalation)
+#   - amount_cents: int64 (required) - outstanding amount
+#   - currency: string (required) - currency code
+#   - invoice_number: string (optional) - invoice reference for notifications
+
+def dunning_escalation():
+    """
+    Main saga entry point.
+    Escalates dunning level and takes appropriate action.
+    """
+
+    ctx = input_data
+
+    current_level = ctx.get("dunning_level", 0)
+    new_level = current_level + 1
+    account_id = ctx.get("account_id")
+    party_id = ctx.get("party_id")
+    amount_cents = ctx.get("amount_cents")
+    currency = ctx.get("currency")
+    invoice_number = ctx.get("invoice_number", "")
+
+    result = {
+        "previous_level": current_level,
+        "new_level": new_level,
+        "account_id": account_id,
+        "action_taken": "none",
+    }
+
+    # Step 1: Send notification based on escalation level
+    if new_level == 1:
+        step(name="send_first_notice")
+        notification.send(
+            type="EMAIL",
+            recipient=party_id,
+        )
+        result["action_taken"] = "first_notice_sent"
+
+    elif new_level == 2:
+        step(name="send_second_notice")
+        notification.send(
+            type="EMAIL",
+            recipient=party_id,
+        )
+        result["action_taken"] = "second_notice_sent"
+
+    elif new_level == 3:
+        step(name="send_final_warning")
+        notification.send(
+            type="EMAIL",
+            recipient=party_id,
+        )
+        result["action_taken"] = "final_warning_sent"
+
+    elif new_level >= 4:
+        # Step 2: Freeze the account at max dunning level
+        step(name="freeze_account")
+        freeze_result = current_account.control(
+            account_id=account_id,
+            action="FREEZE",
+            reason="Dunning level 3 reached: payment overdue for invoice " + invoice_number + " (" + str(amount_cents) + " " + currency + ")",
+        )
+        result["action_taken"] = "account_frozen"
+        result["new_account_status"] = freeze_result.new_status
+        result["freeze_timestamp"] = freeze_result.action_timestamp
+
+        # Send freeze notification
+        step(name="send_freeze_notice")
+        notification.send(
+            type="EMAIL",
+            recipient=party_id,
+        )
+
+    return result
+
+# Execute the saga
+output = dunning_escalation()

--- a/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
+++ b/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
@@ -94,10 +94,11 @@ def dunning_escalation():
 
         # Step 2: Freeze the account at max dunning level
         step(name="freeze_account")
+        invoice_ref = " for invoice " + invoice_number if invoice_number else ""
         freeze_result = current_account.control(
             account_id=account_id,
             action="FREEZE",
-            reason="Dunning level 3 reached: payment overdue for invoice " + invoice_number + " (" + str(amount_cents) + " " + currency + ")",
+            reason="Dunning level 3 reached: payment overdue" + invoice_ref + " (" + str(amount_cents) + " " + currency + ")",
         )
         result["action_taken"] = "account_frozen"
         result["new_account_status"] = freeze_result.new_status

--- a/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
+++ b/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
@@ -38,7 +38,7 @@ def dunning_escalation():
 
     # Validate required fields before any side effects
     missing = []
-    for key in ["dunning_level", "account_id", "party_id", "amount_cents", "currency"]:
+    for key in ["billing_run_id", "dunning_level", "account_id", "party_id", "amount_cents", "currency"]:
         if ctx.get(key) == None:
             missing.append(key)
     if missing:

--- a/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
+++ b/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
@@ -48,6 +48,11 @@ def dunning_escalation():
         }
 
     current_level = ctx["dunning_level"]
+    if current_level < 0 or current_level > 2:
+        return {
+            "action_taken": "invalid_input",
+            "invalid_dunning_level": current_level,
+        }
     new_level = current_level + 1
     account_id = ctx["account_id"]
     party_id = ctx["party_id"]

--- a/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
+++ b/services/reference-data/saga/defaults/dunning_escalation/v1.0.0.star
@@ -12,8 +12,7 @@
 # Dunning levels:
 #   0 -> 1: Send payment failure notification, schedule retry in 24h
 #   1 -> 2: Send second notice, schedule retry in 72h
-#   2 -> 3: Send final warning, schedule retry in 168h (7 days)
-#   3:      Freeze the account, send freeze notification
+#   2 -> 3: Send final warning, freeze the account, send freeze notification
 #
 # Steps:
 #   1. check_dunning_level - Evaluate current level and determine action
@@ -69,15 +68,14 @@ def dunning_escalation():
         )
         result["action_taken"] = "second_notice_sent"
 
-    elif new_level == 3:
+    elif new_level >= 3:
+        # At max dunning level: send final warning, freeze the account, notify
         step(name="send_final_warning")
         notification.send(
             type="EMAIL",
             recipient=party_id,
         )
-        result["action_taken"] = "final_warning_sent"
 
-    elif new_level >= 4:
         # Step 2: Freeze the account at max dunning level
         step(name="freeze_account")
         freeze_result = current_account.control(

--- a/services/reference-data/saga/defaults/dunning_unfreeze/v1.0.0.star
+++ b/services/reference-data/saga/defaults/dunning_unfreeze/v1.0.0.star
@@ -1,0 +1,108 @@
+# Saga: dunning_unfreeze
+# Version: 1.0.0
+# Previous: none
+# Changed: Initial implementation of dunning unfreeze saga
+# Author: Platform Team
+# Date: 2026-02-11
+#
+# Dunning Unfreeze saga for resolving frozen accounts after payment method
+# update. When a party updates their payment method on a frozen account,
+# this saga unfreezes the account and retries the failed payment.
+#
+# Steps:
+#   1. unfreeze_account      - Restore account to ACTIVE status
+#   2. retry_payment         - Attempt payment with new payment method
+#   3. send_confirmation     - Notify party of resolution
+#
+# Compensation:
+#   - If retry_payment fails, the account is re-frozen via compensation
+#   - The party is notified of the continued freeze
+#
+# Input parameters (from input_data dict):
+#   - account_id: string (required) - frozen account to unfreeze
+#   - party_id: string (required) - party who updated payment method
+#   - billing_run_id: string (required) - original failed billing run
+#   - payment_order_id: string (required) - payment order for retry
+#   - debtor_account_id: string (required) - debtor account for payment
+#   - creditor_reference: string (required) - creditor reference
+#   - amount_cents: int64 (required) - amount to retry
+#   - currency: string (required) - currency code
+#   - idempotency_key: string (required) - idempotency key for retry
+#   - instrument_code: string (optional) - for bucket evaluation
+
+def dunning_unfreeze():
+    """
+    Main saga entry point.
+    Unfreezes account and retries payment with updated payment method.
+    """
+
+    ctx = input_data
+
+    account_id = ctx.get("account_id")
+    party_id = ctx.get("party_id")
+
+    result = {
+        "account_id": account_id,
+        "party_id": party_id,
+    }
+
+    # Step 1: Unfreeze the account
+    step(name="unfreeze_account")
+    unfreeze_result = current_account.control(
+        account_id=account_id,
+        action="UNFREEZE",
+        reason="Payment method updated, retrying failed payment for billing run " + ctx.get("billing_run_id", ""),
+    )
+    result["new_account_status"] = unfreeze_result.new_status
+    result["unfreeze_timestamp"] = unfreeze_result.action_timestamp
+
+    # Step 2: Resolve the party's updated payment method
+    step(name="get_payment_method")
+    pm_result = party.get_default_payment_method(
+        party_id=party_id,
+    )
+
+    # Build payment attributes from resolved payment method
+    payment_attrs = {}
+    payment_attrs["provider"] = pm_result.provider
+    payment_attrs["provider_customer_id"] = pm_result.provider_customer_id
+    payment_attrs["provider_method_id"] = pm_result.provider_method_id
+    payment_attrs["method_type"] = pm_result.method_type
+
+    # Step 3: Reserve funds via lien with new payment method
+    step(name="create_lien")
+    lien_result = payment_order.create_lien(
+        account_id=ctx.get("debtor_account_id"),
+        amount_cents=ctx.get("amount_cents"),
+        currency=ctx.get("currency"),
+        payment_order_id=ctx.get("payment_order_id"),
+        instrument_code=ctx.get("instrument_code", ""),
+        payment_attributes=payment_attrs,
+    )
+    result["lien_id"] = lien_result.lien_id
+
+    # Step 4: Send payment to gateway with new payment method
+    step(name="send_to_gateway")
+    gateway_result = payment_order.send_to_gateway(
+        payment_order_id=ctx.get("payment_order_id"),
+        debtor_account_id=ctx.get("debtor_account_id"),
+        creditor_reference=ctx.get("creditor_reference"),
+        amount_cents=ctx.get("amount_cents"),
+        currency=ctx.get("currency"),
+        idempotency_key=ctx.get("idempotency_key"),
+    )
+    result["gateway_reference_id"] = gateway_result.gateway_reference_id
+    result["gateway_status"] = gateway_result.gateway_status
+
+    # Step 5: Send confirmation notification
+    step(name="send_confirmation")
+    notification.send(
+        type="EMAIL",
+        recipient=party_id,
+    )
+    result["notification_sent"] = True
+
+    return result
+
+# Execute the saga
+output = dunning_unfreeze()

--- a/services/reference-data/saga/e2e_seeder_test.go
+++ b/services/reference-data/saga/e2e_seeder_test.go
@@ -180,7 +180,7 @@ func TestE2E_SeededSagasAreActive(t *testing.T) {
 		count++
 	}
 	require.NoError(t, rows.Err())
-	assert.Equal(t, 5, count, "should have 5 seeded sagas")
+	assert.Equal(t, 7, count, "should have 7 seeded sagas")
 }
 
 // TestE2E_ReseedingDoesNotDuplicate verifies ON CONFLICT idempotency.

--- a/services/reference-data/saga/seeder.go
+++ b/services/reference-data/saga/seeder.go
@@ -76,7 +76,7 @@ func PlatformDefaults() ([]Metadata, error) {
 
 // sagaNameFromDir converts a directory name to the full saga name.
 // For current account sagas, the convention is to prefix with "current_account_".
-// payment_execution is used as-is since it's not an account-specific saga.
+// Other sagas (payment_execution, dunning_escalation, etc.) use the directory name as-is.
 func sagaNameFromDir(dirName string) string {
 	switch dirName {
 	case "deposit":

--- a/services/reference-data/saga/seeder_test.go
+++ b/services/reference-data/saga/seeder_test.go
@@ -22,6 +22,8 @@ func TestGetEmbeddedScripts(t *testing.T) {
 		"payment_execution/v1.0.0.star",
 		"reconciliation_adjustment/v1.0.0.star",
 		"stripe_payment/v1.0.0.star",
+		"dunning_escalation/v1.0.0.star",
+		"dunning_unfreeze/v1.0.0.star",
 	}
 
 	for _, expected := range expectedVersioned {
@@ -37,6 +39,8 @@ func TestGetEmbeddedScripts(t *testing.T) {
 		"payment_execution.star",
 		"reconciliation_adjustment.star",
 		"stripe_payment.star",
+		"dunning_escalation.star",
+		"dunning_unfreeze.star",
 	}
 
 	for _, expected := range expectedFlat {
@@ -50,7 +54,7 @@ func TestPlatformDefaults(t *testing.T) {
 	defaults, err := PlatformDefaults()
 	require.NoError(t, err)
 
-	assert.Len(t, defaults, 5)
+	assert.Len(t, defaults, 7)
 
 	// Verify each default has required fields
 	for _, meta := range defaults {
@@ -70,6 +74,8 @@ func TestPlatformDefaults(t *testing.T) {
 	assert.Contains(t, names, "payment_execution")
 	assert.Contains(t, names, "reconciliation_adjustment")
 	assert.Contains(t, names, "stripe_payment")
+	assert.Contains(t, names, "dunning_escalation")
+	assert.Contains(t, names, "dunning_unfreeze")
 }
 
 func TestSeeder_SeedTenant(t *testing.T) {
@@ -99,7 +105,7 @@ func TestSeeder_SeedTenant(t *testing.T) {
 		var count int
 		err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true").Scan(&count)
 		require.NoError(t, err)
-		assert.Equal(t, 5, count, "expected 5 system sagas")
+		assert.Equal(t, 7, count, "expected 7 system sagas")
 
 		// Verify each saga has platform_ref and no script
 		rows, err := pool.Query(ctx, `
@@ -151,7 +157,7 @@ func TestSeeder_SeedTenant(t *testing.T) {
 		var count int
 		err = pool.QueryRow(ctx, "SELECT COUNT(*) FROM "+schemaName+".saga_definition WHERE is_system = true").Scan(&count)
 		require.NoError(t, err)
-		assert.Equal(t, 5, count, "idempotent seed should not create duplicates")
+		assert.Equal(t, 7, count, "idempotent seed should not create duplicates")
 	})
 
 	t.Run("deterministic UUIDs", func(t *testing.T) {

--- a/shared/pkg/saga/schema/handlers.yaml
+++ b/shared/pkg/saga/schema/handlers.yaml
@@ -313,6 +313,33 @@ handlers:
         type: string
         description: "Status of the lien (TERMINATED)"
 
+  current_account.control:
+    description: "Perform lifecycle control action on an account (FREEZE, UNFREEZE, CLOSE)"
+    params:
+      account_id:
+        type: string
+        required: true
+        description: "Identifier of the account to control"
+      action:
+        type: enum
+        values: [FREEZE, UNFREEZE, CLOSE]
+        required: true
+        description: "Control action to perform"
+      reason:
+        type: string
+        required: true
+        description: "Reason for the control action (min 10 chars for FREEZE/CLOSE)"
+    returns:
+      account_id:
+        type: string
+        description: "Echo of the input account ID"
+      new_status:
+        type: string
+        description: "Account status after the action (ACTIVE, FROZEN, CLOSED)"
+      action_timestamp:
+        type: string
+        description: "ISO 8601 timestamp of when the action was executed"
+
   current_account.save:
     description: "Persist current account metadata for a transaction"
     params:

--- a/shared/pkg/saga/schema/handlers_test.go
+++ b/shared/pkg/saga/schema/handlers_test.go
@@ -34,6 +34,7 @@ func TestPlatformHandlersSchema(t *testing.T) {
 		"current_account.execute_lien",
 		"current_account.terminate_lien",
 		"current_account.save",
+		"current_account.control",
 		"valuation_engine.valuate",
 		"repository.save",
 		"notification.send",
@@ -109,7 +110,7 @@ func TestRegistryLoadPlatformHandlers(t *testing.T) {
 	require.NoError(t, err)
 
 	handlers := registry.ListHandlers()
-	assert.Len(t, handlers, 29, "registry should contain all 29 platform handlers")
+	assert.Len(t, handlers, 30, "registry should contain all 30 platform handlers")
 
 	// Verify we can get each handler
 	for _, name := range handlers {


### PR DESCRIPTION
## Summary

- Implement progressive dunning escalation for failed billing runs with automatic account freezing at maximum dunning level
- Add `dunning_escalation` and `dunning_unfreeze` Starlark sagas to the platform defaults, registered via PlatformSync and Seeder
- Wire `current_account.control` handler (FREEZE/UNFREEZE/CLOSE) through handlers.yaml, gRPC client, and Starlark bindings
- Add Redis TTL-based retry scheduling in DunningWorker with exponential backoff (24h -> 72h -> 168h)
- Extend BillingRun domain with dunning level escalation logic, retry delay calculation, and freeze detection
- Add `last_retry_at` column and dunning partial index via CockroachDB migration

## Changes

### Starlark Sagas (reference-data)
- `dunning_escalation/v1.0.0.star` - Progressive escalation: levels 1-3 send notifications (first_notice, second_notice, final_warning), level 3+ freezes account via `current_account.control(action="FREEZE")`
- `dunning_unfreeze/v1.0.0.star` - Unfreeze flow: unfreeze account, resolve payment method, create lien, send to gateway, confirm

### Handler Schema (shared)
- `handlers.yaml` - Added `current_account.control` with params (account_id, action enum [FREEZE/UNFREEZE/CLOSE], reason) and returns (account_id, new_status, action_timestamp)

### Current Account Service
- `client.go` - Added `ControlCurrentAccount` gRPC method with validation, timeout, correlation ID propagation, resilience
- `starlark.go` - Added `controlHandler` with action string-to-proto enum mapping, party scope validation, response formatting
- `starlark_test.go` - Mock and handler registration verification for `current_account.control`
- `saga_handlers.go` - Added `current_account.control` stub for bidirectional validation

### Payment Order Service
- `billing.go` - Added `MaxDunningLevel=3`, `DunningBackoffDurations`, `EscalateDunning()`, `NeedsFreezing()`, `DunningRetryDelay()` methods
- `billing_dunning_test.go` - Domain tests for escalation, freezing threshold, retry delays
- `billing_entity.go` / `billing_repository.go` - Added `LastRetryAt` field to entity and mappers
- `dunning_worker.go` - Redis TTL-based retry scheduling with SCAN-based polling and callback pattern
- `20260211000001_billing_dunning.sql` - Migration adding `last_retry_at` column and partial index

### Reference Data Service
- Seeder/E2E test updates - Saga count assertions updated from 5 to 7 across all test files

## Test plan

- [x] Domain tests pass: `EscalateDunning`, `NeedsFreezing`, `DunningRetryDelay` (verified locally)
- [ ] CI: `buf generate` + full build + lint
- [ ] CI: Seeder tests with updated saga counts (5 -> 7)
- [ ] CI: Starlark handler registration test with `current_account.control`
- [ ] CI: E2E seeder provisioning/migration tests
- [ ] CI: Atlas migration checksum validation

## Task Master

`stripe-connect.10` - Dunning Saga and Account Freeze Integration