### PR TITLE
test: migrate reconciliation e2e tests to gRPC transport layer

### DIFF
--- a/tests/reconciliation-e2e/dispute_workflow_test.go
+++ b/tests/reconciliation-e2e/dispute_workflow_test.go
@@ -38,7 +38,7 @@ func TestDisputeWorkflow_FullLifecycle(t *testing.T) {
 		domain.VarianceReasonAmountMismatch)
 
 	// Step 1: Initiate dispute via gRPC service
-	initiateResp, err := infra.grpcService.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
+	initiateResp, err := infra.grpcClient.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
 		VarianceId: variance.VarianceID.String(),
 		RunId:      run.RunID.String(),
 		AccountId:  "ACC-DISP",
@@ -57,7 +57,7 @@ func TestDisputeWorkflow_FullLifecycle(t *testing.T) {
 	assert.Len(t, createdEvents, 1)
 
 	// Step 2: Escalate the dispute
-	escalateResp, err := infra.grpcService.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
+	escalateResp, err := infra.grpcClient.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
 		DisputeId: disputeID,
 		Action:    reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_ESCALATE,
 	})
@@ -65,7 +65,7 @@ func TestDisputeWorkflow_FullLifecycle(t *testing.T) {
 	assert.Equal(t, reconciliationv1.DisputeStatus_DISPUTE_STATUS_ESCALATED, escalateResp.Dispute.Status)
 
 	// Step 3: Resolve the dispute (requires admin or operator role)
-	resolveResp, err := infra.grpcService.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
+	resolveResp, err := infra.grpcClient.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
 		DisputeId:  disputeID,
 		Action:     reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_RESOLVE,
 		Resolution: "Amount corrected after investigation",
@@ -86,7 +86,7 @@ func TestDisputeWorkflow_FullLifecycle(t *testing.T) {
 	assert.Equal(t, "reconciliation_adjustment", sagaCalls[0].Name)
 
 	// Step 4: Retrieve the dispute to verify final state
-	retrieveResp, err := infra.grpcService.RetrieveDispute(ctx, &reconciliationv1.RetrieveDisputeRequest{
+	retrieveResp, err := infra.grpcClient.RetrieveDispute(ctx, &reconciliationv1.RetrieveDisputeRequest{
 		DisputeId: disputeID,
 	})
 	require.NoError(t, err)
@@ -116,7 +116,7 @@ func TestDisputeWorkflow_Rejection(t *testing.T) {
 		domain.VarianceReasonAmountMismatch)
 
 	// Initiate dispute
-	initiateResp, err := infra.grpcService.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
+	initiateResp, err := infra.grpcClient.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
 		VarianceId: variance.VarianceID.String(),
 		RunId:      run.RunID.String(),
 		AccountId:  "ACC-REJ",
@@ -126,7 +126,7 @@ func TestDisputeWorkflow_Rejection(t *testing.T) {
 	require.NoError(t, err)
 
 	// Reject the dispute
-	rejectResp, err := infra.grpcService.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
+	rejectResp, err := infra.grpcClient.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
 		DisputeId:  initiateResp.Dispute.DisputeId,
 		Action:     reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_REJECT,
 		Resolution: "Variance confirmed as correct",
@@ -163,7 +163,7 @@ func TestDisputeWorkflow_InvalidTransitions(t *testing.T) {
 		domain.VarianceReasonAmountMismatch)
 
 	// Create and resolve a dispute
-	initiateResp, err := infra.grpcService.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
+	initiateResp, err := infra.grpcClient.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
 		VarianceId: variance.VarianceID.String(),
 		RunId:      run.RunID.String(),
 		AccountId:  "ACC-INV",
@@ -173,7 +173,7 @@ func TestDisputeWorkflow_InvalidTransitions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Resolve it
-	_, err = infra.grpcService.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
+	_, err = infra.grpcClient.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
 		DisputeId:  initiateResp.Dispute.DisputeId,
 		Action:     reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_RESOLVE,
 		Resolution: "Resolved",
@@ -182,7 +182,7 @@ func TestDisputeWorkflow_InvalidTransitions(t *testing.T) {
 	require.NoError(t, err)
 
 	// Try to escalate a resolved dispute - should fail
-	_, err = infra.grpcService.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
+	_, err = infra.grpcClient.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
 		DisputeId: initiateResp.Dispute.DisputeId,
 		Action:    reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_ESCALATE,
 	})
@@ -195,7 +195,7 @@ func TestDisputeWorkflow_NotFoundVariance(t *testing.T) {
 	infra := setupE2EInfra(t)
 	ctx := contextWithAdminClaims(infra.tenantCtx())
 
-	_, err := infra.grpcService.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
+	_, err := infra.grpcClient.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
 		VarianceId: uuid.New().String(),
 		RunId:      uuid.New().String(),
 		AccountId:  "ACC-NF",
@@ -210,7 +210,7 @@ func TestDisputeWorkflow_RetrieveNotFound(t *testing.T) {
 	infra := setupE2EInfra(t)
 	ctx := contextWithAdminClaims(infra.tenantCtx())
 
-	_, err := infra.grpcService.RetrieveDispute(ctx, &reconciliationv1.RetrieveDisputeRequest{
+	_, err := infra.grpcClient.RetrieveDispute(ctx, &reconciliationv1.RetrieveDisputeRequest{
 		DisputeId: uuid.New().String(),
 	})
 	require.Error(t, err, "should fail for non-existent dispute")

--- a/tests/reconciliation-e2e/events_test.go
+++ b/tests/reconciliation-e2e/events_test.go
@@ -71,7 +71,7 @@ func TestEvents_DisputeCreatedAndResolved(t *testing.T) {
 	infra.mockPublisher.reset()
 
 	// Create dispute
-	initiateResp, err := infra.grpcService.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
+	initiateResp, err := infra.grpcClient.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
 		VarianceId: variance.VarianceID.String(),
 		RunId:      run.RunID.String(),
 		AccountId:  "ACC-EVT-2",
@@ -89,7 +89,7 @@ func TestEvents_DisputeCreatedAndResolved(t *testing.T) {
 	assert.Equal(t, "Event test dispute", createdEvent.Reason)
 
 	// Resolve dispute
-	_, err = infra.grpcService.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
+	_, err = infra.grpcClient.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
 		DisputeId:  initiateResp.Dispute.DisputeId,
 		Action:     reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_RESOLVE,
 		Resolution: "Fixed",
@@ -204,7 +204,7 @@ func TestCrossService_EndToEndWithDisputeAndAssertion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Phase 2: Raise and resolve a dispute on the variance
-	initiateResp, err := infra.grpcService.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
+	initiateResp, err := infra.grpcClient.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
 		VarianceId: variance.VarianceID.String(),
 		RunId:      run.RunID.String(),
 		AccountId:  "ACC-XSVC",
@@ -213,7 +213,7 @@ func TestCrossService_EndToEndWithDisputeAndAssertion(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = infra.grpcService.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
+	_, err = infra.grpcClient.ControlDispute(ctx, &reconciliationv1.ControlDisputeRequest{
 		DisputeId:  initiateResp.Dispute.DisputeId,
 		Action:     reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_RESOLVE,
 		Resolution: "Counterparty confirmed correction",

--- a/tests/reconciliation-e2e/grpc_errors_test.go
+++ b/tests/reconciliation-e2e/grpc_errors_test.go
@@ -4,6 +4,7 @@
 package reconciliatione2e
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -246,10 +247,18 @@ func TestGRPCError_RetrieveDisputeNotFound(t *testing.T) {
 func TestGRPCError_ListVariancesInvalidPageToken(t *testing.T) {
 	infra := setupE2EInfra(t)
 	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	// Seed a real run so the request reaches page-token validation
+	run := createSettlementRun(t, ctx, infra, "ACC-PAGETOKEN",
+		domain.ReconciliationScopeAccount, domain.SettlementTypeDaily,
+		periodStart, periodEnd, "e2e-test")
+	require.NoError(t, run.Start())
+	require.NoError(t, infra.runRepo.Update(ctx, run))
 
 	_, err := infra.grpcClient.ListReconciliationResults(ctx,
 		&reconciliationv1.ListReconciliationResultsRequest{
-			RunId:     uuid.New().String(),
+			RunId:     run.RunID.String(),
 			PageToken: "not-valid-base64!!!",
 		})
 	require.Error(t, err)
@@ -279,7 +288,7 @@ func TestEnumRoundTrip_ReconciliationScope(t *testing.T) {
 		t.Run(scope.String(), func(t *testing.T) {
 			resp, err := infra.grpcClient.InitiateAccountReconciliation(ctx,
 				&reconciliationv1.InitiateAccountReconciliationRequest{
-					AccountId:      "ACC-SCOPE-" + scope.String(),
+					AccountId:      fmt.Sprintf("ACC-SCOPE-%d", scope),
 					Scope:          scope,
 					SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
 					PeriodStart:    timestamppb.New(periodStart),
@@ -311,7 +320,7 @@ func TestEnumRoundTrip_SettlementType(t *testing.T) {
 		t.Run(st.String(), func(t *testing.T) {
 			resp, err := infra.grpcClient.InitiateAccountReconciliation(ctx,
 				&reconciliationv1.InitiateAccountReconciliationRequest{
-					AccountId:      "ACC-TYPE-" + st.String(),
+					AccountId:      fmt.Sprintf("ACC-TYPE-%d", st),
 					Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
 					SettlementType: st,
 					PeriodStart:    timestamppb.New(periodStart),

--- a/tests/reconciliation-e2e/grpc_errors_test.go
+++ b/tests/reconciliation-e2e/grpc_errors_test.go
@@ -1,0 +1,489 @@
+//go:build integration
+// +build integration
+
+package reconciliatione2e
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// =============================================================================
+// gRPC Error Code Tests
+// =============================================================================
+
+// TestGRPCError_RetrieveNotFound verifies NotFound for a non-existent run.
+func TestGRPCError_RetrieveNotFound(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+
+	_, err := infra.grpcClient.RetrieveAccountReconciliation(ctx,
+		&reconciliationv1.RetrieveAccountReconciliationRequest{
+			RunId: uuid.New().String(),
+		})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "error should be a gRPC status")
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+// TestGRPCError_InvalidRunID verifies InvalidArgument for a malformed UUID.
+func TestGRPCError_InvalidRunID(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+
+	_, err := infra.grpcClient.RetrieveAccountReconciliation(ctx,
+		&reconciliationv1.RetrieveAccountReconciliationRequest{
+			RunId: "not-a-uuid",
+		})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// TestGRPCError_InitiateMissingFields verifies InvalidArgument for missing required fields.
+func TestGRPCError_InitiateMissingFields(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	tests := []struct {
+		name string
+		req  *reconciliationv1.InitiateAccountReconciliationRequest
+	}{
+		{
+			name: "missing account_id",
+			req: &reconciliationv1.InitiateAccountReconciliationRequest{
+				Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+				SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+				PeriodStart:    timestamppb.New(periodStart),
+				PeriodEnd:      timestamppb.New(periodEnd),
+				InitiatedBy:    "test",
+			},
+		},
+		{
+			name: "unspecified scope",
+			req: &reconciliationv1.InitiateAccountReconciliationRequest{
+				AccountId:      "ACC-001",
+				Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_UNSPECIFIED,
+				SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+				PeriodStart:    timestamppb.New(periodStart),
+				PeriodEnd:      timestamppb.New(periodEnd),
+				InitiatedBy:    "test",
+			},
+		},
+		{
+			name: "unspecified settlement_type",
+			req: &reconciliationv1.InitiateAccountReconciliationRequest{
+				AccountId:      "ACC-001",
+				Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+				SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_UNSPECIFIED,
+				PeriodStart:    timestamppb.New(periodStart),
+				PeriodEnd:      timestamppb.New(periodEnd),
+				InitiatedBy:    "test",
+			},
+		},
+		{
+			name: "missing period_start",
+			req: &reconciliationv1.InitiateAccountReconciliationRequest{
+				AccountId:      "ACC-001",
+				Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+				SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+				PeriodEnd:      timestamppb.New(periodEnd),
+				InitiatedBy:    "test",
+			},
+		},
+		{
+			name: "missing initiated_by",
+			req: &reconciliationv1.InitiateAccountReconciliationRequest{
+				AccountId:      "ACC-001",
+				Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+				SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+				PeriodStart:    timestamppb.New(periodStart),
+				PeriodEnd:      timestamppb.New(periodEnd),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := infra.grpcClient.InitiateAccountReconciliation(ctx, tc.req)
+			require.Error(t, err)
+			st, ok := status.FromError(err)
+			require.True(t, ok, "error should be a gRPC status")
+			assert.Equal(t, codes.InvalidArgument, st.Code(),
+				"expected InvalidArgument for %s, got %s: %s", tc.name, st.Code(), st.Message())
+		})
+	}
+}
+
+// TestGRPCError_ExecuteNotFound verifies NotFound for executing a non-existent run.
+func TestGRPCError_ExecuteNotFound(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+
+	_, err := infra.grpcClient.ExecuteAccountReconciliation(ctx,
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: uuid.New().String(),
+		})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.NotFound, st.Code())
+}
+
+// TestGRPCError_ExecuteWrongState verifies FailedPrecondition when executing a non-PENDING run.
+func TestGRPCError_ExecuteWrongState(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	// Create and cancel a run so it's not in PENDING state
+	initiateResp, err := infra.grpcClient.InitiateAccountReconciliation(ctx,
+		&reconciliationv1.InitiateAccountReconciliationRequest{
+			AccountId:      "ACC-WRONGSTATE",
+			Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+			SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+			PeriodStart:    timestamppb.New(periodStart),
+			PeriodEnd:      timestamppb.New(periodEnd),
+			InitiatedBy:    "test",
+		})
+	require.NoError(t, err)
+
+	// Cancel it
+	_, err = infra.grpcClient.ControlAccountReconciliation(ctx,
+		&reconciliationv1.ControlAccountReconciliationRequest{
+			RunId:  initiateResp.Run.RunId,
+			Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+		})
+	require.NoError(t, err)
+
+	// Try to execute the cancelled run
+	_, err = infra.grpcClient.ExecuteAccountReconciliation(ctx,
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: initiateResp.Run.RunId,
+		})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+// TestGRPCError_ControlCancelledRunAgain verifies FailedPrecondition on double cancel.
+func TestGRPCError_ControlCancelledRunAgain(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	initiateResp, err := infra.grpcClient.InitiateAccountReconciliation(ctx,
+		&reconciliationv1.InitiateAccountReconciliationRequest{
+			AccountId:      "ACC-DBLCANCEL",
+			Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+			SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+			PeriodStart:    timestamppb.New(periodStart),
+			PeriodEnd:      timestamppb.New(periodEnd),
+			InitiatedBy:    "test",
+		})
+	require.NoError(t, err)
+
+	// First cancel succeeds
+	_, err = infra.grpcClient.ControlAccountReconciliation(ctx,
+		&reconciliationv1.ControlAccountReconciliationRequest{
+			RunId:  initiateResp.Run.RunId,
+			Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+		})
+	require.NoError(t, err)
+
+	// Second cancel should fail
+	_, err = infra.grpcClient.ControlAccountReconciliation(ctx,
+		&reconciliationv1.ControlAccountReconciliationRequest{
+			RunId:  initiateResp.Run.RunId,
+			Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+		})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+}
+
+// TestGRPCError_DisputeNotFoundVariance verifies error when disputing a non-existent variance.
+func TestGRPCError_DisputeNotFoundVariance(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := contextWithAdminClaims(infra.tenantCtx())
+
+	_, err := infra.grpcClient.InitiateDispute(ctx, &reconciliationv1.InitiateDisputeRequest{
+		VarianceId: uuid.New().String(),
+		RunId:      uuid.New().String(),
+		AccountId:  "ACC-NF",
+		Reason:     "Test dispute",
+		RaisedBy:   "admin",
+	})
+	require.Error(t, err, "should fail for non-existent variance")
+}
+
+// TestGRPCError_RetrieveDisputeNotFound verifies NotFound for a non-existent dispute.
+func TestGRPCError_RetrieveDisputeNotFound(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := contextWithAdminClaims(infra.tenantCtx())
+
+	_, err := infra.grpcClient.RetrieveDispute(ctx, &reconciliationv1.RetrieveDisputeRequest{
+		DisputeId: uuid.New().String(),
+	})
+	require.Error(t, err, "should fail for non-existent dispute")
+}
+
+// TestGRPCError_ListVariancesInvalidPageToken verifies InvalidArgument for bad page tokens.
+func TestGRPCError_ListVariancesInvalidPageToken(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+
+	_, err := infra.grpcClient.ListReconciliationResults(ctx,
+		&reconciliationv1.ListReconciliationResultsRequest{
+			RunId:     uuid.New().String(),
+			PageToken: "not-valid-base64!!!",
+		})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+}
+
+// =============================================================================
+// Proto Enum Round-Trip Tests
+// =============================================================================
+
+// TestEnumRoundTrip_ReconciliationScope verifies ReconciliationScope round-trips through gRPC.
+func TestEnumRoundTrip_ReconciliationScope(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	scopes := []reconciliationv1.ReconciliationScope{
+		reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+		reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_INSTRUMENT,
+		reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_PORTFOLIO,
+		reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_FULL,
+	}
+
+	for _, scope := range scopes {
+		t.Run(scope.String(), func(t *testing.T) {
+			resp, err := infra.grpcClient.InitiateAccountReconciliation(ctx,
+				&reconciliationv1.InitiateAccountReconciliationRequest{
+					AccountId:      "ACC-SCOPE-" + scope.String(),
+					Scope:          scope,
+					SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+					PeriodStart:    timestamppb.New(periodStart),
+					PeriodEnd:      timestamppb.New(periodEnd),
+					InitiatedBy:    "e2e-enum-test",
+				})
+			require.NoError(t, err)
+			assert.Equal(t, scope, resp.Run.Scope, "scope should round-trip through gRPC")
+		})
+	}
+}
+
+// TestEnumRoundTrip_SettlementType verifies SettlementType round-trips through gRPC.
+func TestEnumRoundTrip_SettlementType(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	types := []reconciliationv1.SettlementType{
+		reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+		reconciliationv1.SettlementType_SETTLEMENT_TYPE_WEEKLY,
+		reconciliationv1.SettlementType_SETTLEMENT_TYPE_MONTHLY,
+		reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND,
+		reconciliationv1.SettlementType_SETTLEMENT_TYPE_END_OF_DAY,
+		reconciliationv1.SettlementType_SETTLEMENT_TYPE_REAL_TIME,
+	}
+
+	for _, st := range types {
+		t.Run(st.String(), func(t *testing.T) {
+			resp, err := infra.grpcClient.InitiateAccountReconciliation(ctx,
+				&reconciliationv1.InitiateAccountReconciliationRequest{
+					AccountId:      "ACC-TYPE-" + st.String(),
+					Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+					SettlementType: st,
+					PeriodStart:    timestamppb.New(periodStart),
+					PeriodEnd:      timestamppb.New(periodEnd),
+					InitiatedBy:    "e2e-enum-test",
+				})
+			require.NoError(t, err)
+			assert.Equal(t, st, resp.Run.SettlementType, "settlement type should round-trip through gRPC")
+		})
+	}
+}
+
+// TestEnumRoundTrip_RunStatus verifies RunStatus transitions are visible through gRPC.
+func TestEnumRoundTrip_RunStatus(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	// PENDING
+	resp, err := infra.grpcClient.InitiateAccountReconciliation(ctx,
+		&reconciliationv1.InitiateAccountReconciliationRequest{
+			AccountId:      "ACC-STATUS",
+			Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+			SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+			PeriodStart:    timestamppb.New(periodStart),
+			PeriodEnd:      timestamppb.New(periodEnd),
+			InitiatedBy:    "e2e-status-test",
+		})
+	require.NoError(t, err)
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_PENDING, resp.Run.Status)
+
+	// CANCELLED
+	cancelResp, err := infra.grpcClient.ControlAccountReconciliation(ctx,
+		&reconciliationv1.ControlAccountReconciliationRequest{
+			RunId:  resp.Run.RunId,
+			Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+		})
+	require.NoError(t, err)
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_CANCELLED, cancelResp.Run.Status)
+}
+
+// TestEnumRoundTrip_VarianceStatusAndReason verifies variance enums round-trip through list results.
+func TestEnumRoundTrip_VarianceStatusAndReason(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	run := createSettlementRun(t, ctx, infra, "ACC-VENUM",
+		domain.ReconciliationScopeAccount, domain.SettlementTypeDaily,
+		periodStart, periodEnd, "e2e-enum-test")
+	require.NoError(t, run.Start())
+	require.NoError(t, infra.runRepo.Update(ctx, run))
+
+	// Create variances with different reasons
+	reasons := []domain.VarianceReason{
+		domain.VarianceReasonAmountMismatch,
+		domain.VarianceReasonMissingEntry,
+		domain.VarianceReasonDuplicateEntry,
+		domain.VarianceReasonTimingDifference,
+		domain.VarianceReasonCurrencyMismatch,
+		domain.VarianceReasonDirectionError,
+		domain.VarianceReasonOther,
+	}
+
+	expectedProtoReasons := []reconciliationv1.VarianceReason{
+		reconciliationv1.VarianceReason_VARIANCE_REASON_AMOUNT_MISMATCH,
+		reconciliationv1.VarianceReason_VARIANCE_REASON_MISSING_ENTRY,
+		reconciliationv1.VarianceReason_VARIANCE_REASON_DUPLICATE_ENTRY,
+		reconciliationv1.VarianceReason_VARIANCE_REASON_TIMING_DIFFERENCE,
+		reconciliationv1.VarianceReason_VARIANCE_REASON_CURRENCY_MISMATCH,
+		reconciliationv1.VarianceReason_VARIANCE_REASON_DIRECTION_ERROR,
+		reconciliationv1.VarianceReason_VARIANCE_REASON_OTHER,
+	}
+
+	for _, reason := range reasons {
+		snap := createSnapshot(t, ctx, infra, run.RunID, "ACC-VENUM", "GBP",
+			decimal.NewFromFloat(100.00),
+			decimal.NewFromFloat(110.00),
+			"position-keeping", nil)
+		createVariance(t, ctx, infra, run.RunID, snap.SnapshotID,
+			"ACC-VENUM", "GBP",
+			decimal.NewFromFloat(100.00),
+			decimal.NewFromFloat(110.00),
+			reason)
+	}
+
+	// List all variances via gRPC
+	listResp, err := infra.grpcClient.ListReconciliationResults(ctx,
+		&reconciliationv1.ListReconciliationResultsRequest{
+			RunId:    run.RunID.String(),
+			PageSize: 100,
+		})
+	require.NoError(t, err)
+	require.Len(t, listResp.Variances, len(reasons))
+
+	// Collect actual reasons returned
+	actualReasons := make(map[reconciliationv1.VarianceReason]bool)
+	for _, v := range listResp.Variances {
+		actualReasons[v.Reason] = true
+		// All should be OPEN status (DETECTED maps to OPEN in proto)
+		assert.Equal(t, reconciliationv1.VarianceStatus_VARIANCE_STATUS_OPEN, v.Status,
+			"DETECTED domain status should map to OPEN proto status")
+	}
+
+	for _, expected := range expectedProtoReasons {
+		assert.True(t, actualReasons[expected],
+			"expected proto reason %s to be present in results", expected)
+	}
+}
+
+// TestEnumRoundTrip_DisputeStatus verifies dispute status transitions through gRPC.
+func TestEnumRoundTrip_DisputeStatus(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := contextWithAdminClaims(infra.tenantCtx())
+	periodStart, periodEnd := defaultPeriod()
+
+	// Set up prerequisite data
+	run := createSettlementRun(t, ctx, infra, "ACC-DENUM",
+		domain.ReconciliationScopeAccount, domain.SettlementTypeDaily,
+		periodStart, periodEnd, "e2e-test")
+	require.NoError(t, run.Start())
+	require.NoError(t, infra.runRepo.Update(ctx, run))
+
+	snap := createSnapshot(t, ctx, infra, run.RunID, "ACC-DENUM", "GBP",
+		decimal.NewFromFloat(100.00),
+		decimal.NewFromFloat(200.00),
+		"position-keeping", nil)
+
+	variance := createVariance(t, ctx, infra, run.RunID, snap.SnapshotID,
+		"ACC-DENUM", "GBP",
+		decimal.NewFromFloat(100.00),
+		decimal.NewFromFloat(200.00),
+		domain.VarianceReasonAmountMismatch)
+
+	// OPEN
+	initiateResp, err := infra.grpcClient.InitiateDispute(ctx,
+		&reconciliationv1.InitiateDisputeRequest{
+			VarianceId: variance.VarianceID.String(),
+			RunId:      run.RunID.String(),
+			AccountId:  "ACC-DENUM",
+			Reason:     "Enum round-trip test",
+			RaisedBy:   "e2e-admin",
+		})
+	require.NoError(t, err)
+	assert.Equal(t, reconciliationv1.DisputeStatus_DISPUTE_STATUS_OPEN, initiateResp.Dispute.Status)
+
+	// ESCALATED
+	escalateResp, err := infra.grpcClient.ControlDispute(ctx,
+		&reconciliationv1.ControlDisputeRequest{
+			DisputeId: initiateResp.Dispute.DisputeId,
+			Action:    reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_ESCALATE,
+		})
+	require.NoError(t, err)
+	assert.Equal(t, reconciliationv1.DisputeStatus_DISPUTE_STATUS_ESCALATED, escalateResp.Dispute.Status)
+
+	// RESOLVED
+	resolveResp, err := infra.grpcClient.ControlDispute(ctx,
+		&reconciliationv1.ControlDisputeRequest{
+			DisputeId:  initiateResp.Dispute.DisputeId,
+			Action:     reconciliationv1.DisputeControlAction_DISPUTE_CONTROL_ACTION_RESOLVE,
+			Resolution: "Resolved for enum test",
+			ResolvedBy: "e2e-admin",
+		})
+	require.NoError(t, err)
+	assert.Equal(t, reconciliationv1.DisputeStatus_DISPUTE_STATUS_RESOLVED, resolveResp.Dispute.Status)
+
+	// Verify final state via Retrieve
+	retrieveResp, err := infra.grpcClient.RetrieveDispute(ctx,
+		&reconciliationv1.RetrieveDisputeRequest{
+			DisputeId: initiateResp.Dispute.DisputeId,
+		})
+	require.NoError(t, err)
+	assert.Equal(t, reconciliationv1.DisputeStatus_DISPUTE_STATUS_RESOLVED, retrieveResp.Dispute.Status)
+	assert.NotNil(t, retrieveResp.Dispute.ResolvedAt)
+}

--- a/tests/reconciliation-e2e/infra_test.go
+++ b/tests/reconciliation-e2e/infra_test.go
@@ -6,11 +6,13 @@ package reconciliatione2e
 import (
 	"context"
 	"log/slog"
+	"net"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
 	"github.com/meridianhub/meridian/services/reconciliation/adapters/persistence"
 	"github.com/meridianhub/meridian/services/reconciliation/domain"
 	"github.com/meridianhub/meridian/services/reconciliation/service"
@@ -20,6 +22,9 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/testdb"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
 	"gorm.io/gorm"
 )
 
@@ -32,6 +37,9 @@ type e2eTestInfra struct {
 	db      *gorm.DB
 	cleanup func()
 	ctx     context.Context // tenant-scoped context
+
+	// gRPC transport (bufconn)
+	grpcClient reconciliationv1.AccountReconciliationServiceClient
 
 	// Repositories
 	runRepo       domain.SettlementRunRepository
@@ -146,14 +154,45 @@ func setupE2EInfra(t *testing.T) *e2eTestInfra {
 	)
 
 	infra.grpcService = service.NewAccountReconciliationService(
+		service.WithSettlementRunRepository(infra.runRepo),
 		service.WithDisputeRepository(infra.disputeRepo),
 		service.WithVarianceRepository(infra.varianceFetch),
+		service.WithVarianceListRepository(infra.varianceFetch),
 		service.WithSagaRuntime(infra.mockSagaRT),
 		service.WithEventPublisher(infra.mockPublisher),
 		service.WithBalanceAssertor(infra.assertor),
+		service.WithSnapshotCapturer(infra.capturer.CaptureSnapshots),
+		service.WithVarianceDetector(infra.detector.DetectVariances),
+		service.WithVarianceValuator(infra.valuator.ValueVariances),
+		service.WithLogger(logger),
 	)
 
+	// Start in-process gRPC server via bufconn
+	listener := bufconn.Listen(1024 * 1024)
+	grpcServer := grpc.NewServer()
+	reconciliationv1.RegisterAccountReconciliationServiceServer(grpcServer, infra.grpcService)
+
+	serveDone := make(chan struct{})
+	go func() {
+		defer close(serveDone)
+		_ = grpcServer.Serve(listener)
+	}()
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	infra.grpcClient = reconciliationv1.NewAccountReconciliationServiceClient(conn)
+
 	t.Cleanup(func() {
+		conn.Close()
+		grpcServer.GracefulStop()
+		<-serveDone
+		listener.Close()
 		cleanup()
 	})
 

--- a/tests/reconciliation-e2e/settlement_grpc_test.go
+++ b/tests/reconciliation-e2e/settlement_grpc_test.go
@@ -1,0 +1,265 @@
+//go:build integration
+// +build integration
+
+package reconciliatione2e
+
+import (
+	"testing"
+	"time"
+
+	reconciliationv1 "github.com/meridianhub/meridian/api/proto/meridian/reconciliation/v1"
+	"github.com/meridianhub/meridian/services/reconciliation/domain"
+	"github.com/meridianhub/meridian/services/reconciliation/service"
+	"github.com/meridianhub/meridian/shared/platform/await"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TestSettlementGRPC_FullLifecycle exercises the full settlement lifecycle via gRPC:
+// Initiate -> Execute -> poll Retrieve until COMPLETED -> List variances.
+func TestSettlementGRPC_FullLifecycle(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	// Set up mock position data that will produce a variance when captured.
+	// First capture: establishes baseline snapshots (expected == actual).
+	infra.mockPKProvider.setPages([]service.PositionPage{
+		{
+			Records: []service.PositionRecord{
+				{
+					AccountID:      "ACC-GRPC-001",
+					InstrumentCode: "GBP",
+					Balance:        decimal.NewFromFloat(1000.50),
+					SourceSystem:   "position-keeping",
+					Attributes:     map[string]string{"quality": "ACTUAL"},
+				},
+				{
+					AccountID:      "ACC-GRPC-001",
+					InstrumentCode: "EUR",
+					Balance:        decimal.NewFromFloat(2500.00),
+					SourceSystem:   "position-keeping",
+					Attributes:     map[string]string{"quality": "ESTIMATE"},
+				},
+			},
+		},
+	})
+
+	// Step 1: Initiate a settlement run via gRPC
+	initiateResp, err := infra.grpcClient.InitiateAccountReconciliation(ctx,
+		&reconciliationv1.InitiateAccountReconciliationRequest{
+			AccountId:      "ACC-GRPC-001",
+			Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+			SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY,
+			PeriodStart:    timestamppb.New(periodStart),
+			PeriodEnd:      timestamppb.New(periodEnd),
+			InitiatedBy:    "e2e-grpc-test",
+		})
+	require.NoError(t, err)
+	require.NotNil(t, initiateResp.Run)
+
+	runID := initiateResp.Run.RunId
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_PENDING, initiateResp.Run.Status)
+	assert.Equal(t, "ACC-GRPC-001", initiateResp.Run.AccountId)
+	assert.Equal(t, reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT, initiateResp.Run.Scope)
+	assert.Equal(t, reconciliationv1.SettlementType_SETTLEMENT_TYPE_DAILY, initiateResp.Run.SettlementType)
+
+	// Step 2: Execute the run via gRPC (triggers async pipeline)
+	executeResp, err := infra.grpcClient.ExecuteAccountReconciliation(ctx,
+		&reconciliationv1.ExecuteAccountReconciliationRequest{
+			RunId: runID,
+		})
+	require.NoError(t, err)
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_RUNNING, executeResp.Run.Status)
+
+	// Step 3: Poll Retrieve until COMPLETED using await
+	err = await.New().
+		AtMost(30 * time.Second).
+		PollInterval(200 * time.Millisecond).
+		Until(func() bool {
+			resp, pollErr := infra.grpcClient.RetrieveAccountReconciliation(ctx,
+				&reconciliationv1.RetrieveAccountReconciliationRequest{
+					RunId: runID,
+				})
+			if pollErr != nil {
+				return false
+			}
+			return resp.Run.Status == reconciliationv1.RunStatus_RUN_STATUS_COMPLETED
+		})
+	require.NoError(t, err, "settlement run should reach COMPLETED status")
+
+	// Step 4: Retrieve final state and verify
+	retrieveResp, err := infra.grpcClient.RetrieveAccountReconciliation(ctx,
+		&reconciliationv1.RetrieveAccountReconciliationRequest{
+			RunId: runID,
+		})
+	require.NoError(t, err)
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_COMPLETED, retrieveResp.Run.Status)
+	assert.Equal(t, "e2e-grpc-test", retrieveResp.Run.InitiatedBy)
+
+	// Step 5: List variances for this run
+	listResp, err := infra.grpcClient.ListReconciliationResults(ctx,
+		&reconciliationv1.ListReconciliationResultsRequest{
+			RunId:    runID,
+			PageSize: 50,
+		})
+	require.NoError(t, err)
+	// First run with expected == actual should produce zero variances
+	assert.Empty(t, listResp.Variances, "first run should produce no variances when expected == actual")
+}
+
+// TestSettlementGRPC_CancelRun tests the cancel workflow via gRPC:
+// Initiate -> Control(CANCEL) -> Retrieve -> verify CANCELLED.
+func TestSettlementGRPC_CancelRun(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	// Initiate
+	initiateResp, err := infra.grpcClient.InitiateAccountReconciliation(ctx,
+		&reconciliationv1.InitiateAccountReconciliationRequest{
+			AccountId:      "ACC-CANCEL",
+			Scope:          reconciliationv1.ReconciliationScope_RECONCILIATION_SCOPE_ACCOUNT,
+			SettlementType: reconciliationv1.SettlementType_SETTLEMENT_TYPE_ON_DEMAND,
+			PeriodStart:    timestamppb.New(periodStart),
+			PeriodEnd:      timestamppb.New(periodEnd),
+			InitiatedBy:    "e2e-cancel-test",
+		})
+	require.NoError(t, err)
+	runID := initiateResp.Run.RunId
+
+	// Cancel the PENDING run
+	controlResp, err := infra.grpcClient.ControlAccountReconciliation(ctx,
+		&reconciliationv1.ControlAccountReconciliationRequest{
+			RunId:  runID,
+			Action: reconciliationv1.ControlAction_CONTROL_ACTION_CANCEL,
+			Reason: "e2e test cancellation",
+		})
+	require.NoError(t, err)
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_CANCELLED, controlResp.Run.Status)
+
+	// Retrieve and verify CANCELLED
+	retrieveResp, err := infra.grpcClient.RetrieveAccountReconciliation(ctx,
+		&reconciliationv1.RetrieveAccountReconciliationRequest{
+			RunId: runID,
+		})
+	require.NoError(t, err)
+	assert.Equal(t, reconciliationv1.RunStatus_RUN_STATUS_CANCELLED, retrieveResp.Run.Status)
+}
+
+// TestSettlementGRPC_ListVariancesWithPagination tests paginated variance listing via gRPC.
+func TestSettlementGRPC_ListVariancesWithPagination(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	// Create a run with known variances directly in DB for pagination testing
+	run := createSettlementRun(t, ctx, infra, "ACC-PAGE",
+		domain.ReconciliationScopeAccount, domain.SettlementTypeDaily,
+		periodStart, periodEnd, "e2e-pagination-test")
+	require.NoError(t, run.Start())
+	require.NoError(t, infra.runRepo.Update(ctx, run))
+
+	// Create 5 variances
+	for i := 0; i < 5; i++ {
+		snap := createSnapshot(t, ctx, infra, run.RunID, "ACC-PAGE", "GBP",
+			decimal.NewFromFloat(float64(100+i)),
+			decimal.NewFromFloat(float64(110+i)),
+			"position-keeping", nil)
+
+		createVariance(t, ctx, infra, run.RunID, snap.SnapshotID,
+			"ACC-PAGE", "GBP",
+			decimal.NewFromFloat(float64(100+i)),
+			decimal.NewFromFloat(float64(110+i)),
+			domain.VarianceReasonAmountMismatch)
+	}
+
+	// List with page size 2 - first page
+	page1, err := infra.grpcClient.ListReconciliationResults(ctx,
+		&reconciliationv1.ListReconciliationResultsRequest{
+			RunId:    run.RunID.String(),
+			PageSize: 2,
+		})
+	require.NoError(t, err)
+	assert.Len(t, page1.Variances, 2)
+	assert.NotEmpty(t, page1.NextPageToken, "should have next page token")
+
+	// Second page
+	page2, err := infra.grpcClient.ListReconciliationResults(ctx,
+		&reconciliationv1.ListReconciliationResultsRequest{
+			RunId:     run.RunID.String(),
+			PageSize:  2,
+			PageToken: page1.NextPageToken,
+		})
+	require.NoError(t, err)
+	assert.Len(t, page2.Variances, 2)
+	assert.NotEmpty(t, page2.NextPageToken, "should have next page token for page 3")
+
+	// Third page (last)
+	page3, err := infra.grpcClient.ListReconciliationResults(ctx,
+		&reconciliationv1.ListReconciliationResultsRequest{
+			RunId:     run.RunID.String(),
+			PageSize:  2,
+			PageToken: page2.NextPageToken,
+		})
+	require.NoError(t, err)
+	assert.Len(t, page3.Variances, 1, "last page should have remaining 1 variance")
+	assert.Empty(t, page3.NextPageToken, "last page should have no next page token")
+
+	// Verify variance details round-trip through proto
+	for _, v := range page1.Variances {
+		assert.NotEmpty(t, v.VarianceId)
+		assert.Equal(t, run.RunID.String(), v.RunId)
+		assert.Equal(t, "ACC-PAGE", v.AccountId)
+		assert.Equal(t, "GBP", v.InstrumentCode)
+		assert.Equal(t, reconciliationv1.VarianceReason_VARIANCE_REASON_AMOUNT_MISMATCH, v.Reason)
+		assert.Equal(t, reconciliationv1.VarianceStatus_VARIANCE_STATUS_OPEN, v.Status)
+	}
+}
+
+// TestSettlementGRPC_ExecuteWithVariances tests the full pipeline that produces variances.
+func TestSettlementGRPC_ExecuteWithVariances(t *testing.T) {
+	infra := setupE2EInfra(t)
+	ctx := infra.tenantCtx()
+	periodStart, periodEnd := defaultPeriod()
+
+	// Create a run directly so we have a known RunID for assertion queries
+	run := createSettlementRun(t, ctx, infra, "ACC-VAR",
+		domain.ReconciliationScopeAccount, domain.SettlementTypeDaily,
+		periodStart, periodEnd, "e2e-variance-test")
+
+	// Pre-create snapshots with variance-producing values
+	// (since the mock PK provider only provides actual balances, and
+	// the capturer sets expected == actual, we seed data to create variances
+	// by creating snapshots manually and having the detector compare them.)
+	require.NoError(t, run.Start())
+	require.NoError(t, infra.runRepo.Update(ctx, run))
+
+	createSnapshot(t, ctx, infra, run.RunID, "ACC-VAR", "GBP",
+		decimal.NewFromFloat(1000.00), // expected
+		decimal.NewFromFloat(1050.75), // actual
+		"position-keeping", map[string]string{"quality": "ACTUAL"})
+
+	// Detect variances using the service component directly (since Execute
+	// runs the full pipeline and we've already seeded the data)
+	variances, err := infra.detector.DetectVariances(ctx, run.RunID)
+	require.NoError(t, err)
+	assert.Len(t, variances, 1)
+
+	// Now list the variance via gRPC
+	listResp, err := infra.grpcClient.ListReconciliationResults(ctx,
+		&reconciliationv1.ListReconciliationResultsRequest{
+			RunId: run.RunID.String(),
+		})
+	require.NoError(t, err)
+	require.Len(t, listResp.Variances, 1)
+
+	v := listResp.Variances[0]
+	assert.Equal(t, "ACC-VAR", v.AccountId)
+	assert.Equal(t, "GBP", v.InstrumentCode)
+	assert.Equal(t, "1000", v.ExpectedAmount)
+	assert.Equal(t, "1050.75", v.ActualAmount)
+	assert.Equal(t, reconciliationv1.VarianceReason_VARIANCE_REASON_AMOUNT_MISMATCH, v.Reason)
+}


### PR DESCRIPTION
## Summary

Migrate the reconciliation e2e test suite from direct service-layer calls to full gRPC transport via bufconn. This ensures tests exercise proto serialization, gRPC status codes, and the complete transport layer without network I/O.

- Add bufconn-based in-process gRPC server/client to `setupE2EInfra`, wiring all service options needed for the Execute pipeline
- Migrate dispute workflow and event tests from `infra.grpcService` (direct) to `infra.grpcClient` (transport)
- Add settlement lifecycle tests via gRPC: Initiate, Execute, poll Retrieve with `await.Until()`, List variances
- Add cancel workflow and pagination tests via gRPC
- Add gRPC error code tests: NotFound, InvalidArgument, FailedPrecondition
- Add proto enum round-trip tests: ReconciliationScope, SettlementType, RunStatus, VarianceStatus/Reason, DisputeStatus

## Task Master

reconciliation-service.23

## Test plan

- [ ] All existing e2e tests continue to pass (dispute workflow, events, balance assertion)
- [ ] New settlement gRPC tests pass: full lifecycle, cancel, pagination, execute with variances
- [ ] Error code tests verify correct gRPC status codes for invalid inputs and state violations
- [ ] Enum round-trip tests confirm all proto enums survive serialization through gRPC
- [ ] No `time.Sleep` usage - all polling uses `await.Until()`