### PR TITLE
feat: Wire StripeWebhookHandler into HTTP server

### DIFF
--- a/services/payment-order/adapters/http/server_test.go
+++ b/services/payment-order/adapters/http/server_test.go
@@ -258,6 +258,121 @@ func TestServer_WebhookEndpoint(t *testing.T) {
 	<-serverDone
 }
 
+func TestServer_StripeWebhookRouteMounted(t *testing.T) {
+	webhookHandler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          []byte("secret"),
+	})
+	require.NoError(t, err)
+
+	stripeHandler, _ := setupStripeWebhookHandler(t)
+
+	server, err := NewServer(ServerConfig{
+		Port:                 8080,
+		WebhookHandler:       webhookHandler,
+		StripeWebhookHandler: stripeHandler,
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	serverDone := make(chan struct{})
+	go func() {
+		_ = server.StartWithListener(listener)
+		close(serverDone)
+	}()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).UntilNoError(func() error {
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+listener.Addr().String()+"/health", nil)
+		if reqErr != nil {
+			return reqErr
+		}
+		resp, respErr := client.Do(req)
+		if respErr != nil {
+			return respErr
+		}
+		_ = resp.Body.Close()
+		return nil
+	})
+	require.NoError(t, err, "server should become ready")
+
+	// POST to /webhook/stripe should not return 404 (route is mounted)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+listener.Addr().String()+"/webhook/stripe", nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	// The handler will reject the request (no tenant context, no signature) but the route exists
+	assert.NotEqual(t, http.StatusNotFound, resp.StatusCode, "stripe webhook route should be mounted")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = server.Shutdown(shutdownCtx)
+	require.NoError(t, err)
+	<-serverDone
+}
+
+func TestServer_StripeWebhookRouteNotMountedWhenNil(t *testing.T) {
+	webhookHandler, err := NewWebhookHandler(WebhookHandlerConfig{
+		PaymentOrderService: &mockPaymentOrderService{},
+		HMACSecret:          []byte("secret"),
+	})
+	require.NoError(t, err)
+
+	server, err := NewServer(ServerConfig{
+		Port:                 8080,
+		WebhookHandler:       webhookHandler,
+		StripeWebhookHandler: nil,
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	serverDone := make(chan struct{})
+	go func() {
+		_ = server.StartWithListener(listener)
+		close(serverDone)
+	}()
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	err = await.New().AtMost(2 * time.Second).PollInterval(10 * time.Millisecond).UntilNoError(func() error {
+		req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+listener.Addr().String()+"/health", nil)
+		if reqErr != nil {
+			return reqErr
+		}
+		resp, respErr := client.Do(req)
+		if respErr != nil {
+			return respErr
+		}
+		_ = resp.Body.Close()
+		return nil
+	})
+	require.NoError(t, err, "server should become ready")
+
+	// POST to /webhook/stripe should return 404 (route NOT mounted)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+listener.Addr().String()+"/webhook/stripe", nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "stripe webhook route should not be mounted when handler is nil")
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = server.Shutdown(shutdownCtx)
+	require.NoError(t, err)
+	<-serverDone
+}
+
 // fixedReader provides a simple io.Reader for testing
 type fixedReader struct {
 	data []byte

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -13,6 +13,7 @@ import (
 
 	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
+	stripegateway "github.com/meridianhub/meridian/services/payment-order/adapters/gateway/stripe"
 	webhookhttp "github.com/meridianhub/meridian/services/payment-order/adapters/http"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
 	"github.com/meridianhub/meridian/services/payment-order/config"
@@ -275,14 +276,21 @@ func run(logger *slog.Logger) error {
 		return fmt.Errorf("failed to create webhook handler: %w", err)
 	}
 
+	// Create Stripe webhook handler (optional - only if STRIPE_API_KEY is configured)
+	stripeWebhookHandler, err := createStripeWebhookHandler(webhookHandler, logger)
+	if err != nil {
+		return fmt.Errorf("failed to create stripe webhook handler: %w", err)
+	}
+
 	// Create HTTP server
 	httpPort := env.GetEnvAsInt("HTTP_PORT", ports.Gateway)
 	httpServer, err := webhookhttp.NewServer(webhookhttp.ServerConfig{
-		Port:               httpPort,
-		WebhookHandler:     webhookHandler,
-		Logger:             logger,
-		RateLimitPerSecond: env.GetEnvAsFloat("HTTP_RATE_LIMIT_PER_SECOND", 100),
-		RateLimitBurst:     env.GetEnvAsInt("HTTP_RATE_LIMIT_BURST", 200),
+		Port:                 httpPort,
+		WebhookHandler:       webhookHandler,
+		StripeWebhookHandler: stripeWebhookHandler,
+		Logger:               logger,
+		RateLimitPerSecond:   env.GetEnvAsFloat("HTTP_RATE_LIMIT_PER_SECOND", 100),
+		RateLimitBurst:       env.GetEnvAsInt("HTTP_RATE_LIMIT_BURST", 200),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP server: %w", err)
@@ -670,6 +678,61 @@ func createGatewayAccountConfig(logger *slog.Logger) (*config.GatewayAccountConf
 		"gateway_count", len(cfg.Mappings))
 
 	return cfg, nil
+}
+
+// createStripeWebhookHandler creates the StripeWebhookHandler if STRIPE_API_KEY is configured.
+// Returns nil (no error) when Stripe is not configured, making the handler optional.
+func createStripeWebhookHandler(webhookHandler *webhookhttp.WebhookHandler, logger *slog.Logger) (*webhookhttp.StripeWebhookHandler, error) {
+	stripeAPIKey := env.GetEnvOrDefault("STRIPE_API_KEY", "")
+	if stripeAPIKey == "" {
+		logger.Info("STRIPE_API_KEY not set, Stripe webhook handler disabled")
+		return nil, nil //nolint:nilnil // nil handler is intentional: ServerConfig treats nil as "feature disabled"
+	}
+
+	stripeWebhookSecret := env.GetEnvOrDefault("STRIPE_WEBHOOK_SECRET", "")
+
+	// Use env-based tenant config provider as a stub until Task 6 implements
+	// the real TenantConfigProvider backed by control-plane gRPC.
+	provider := &envTenantConfigProvider{
+		webhookSecret: stripeWebhookSecret,
+	}
+
+	cfg := stripegateway.DefaultConfig()
+	cfg.APIKey = stripeAPIKey
+
+	clientFactory, err := stripegateway.NewClientFactory(cfg, provider, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stripe client factory: %w", err)
+	}
+
+	handler, err := webhookhttp.NewStripeWebhookHandler(webhookhttp.StripeWebhookHandlerConfig{
+		ClientFactory:  clientFactory,
+		WebhookHandler: webhookHandler,
+		Logger:         logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create stripe webhook handler: %w", err)
+	}
+
+	logger.Info("stripe webhook handler enabled", "route", "/webhook/stripe")
+	return handler, nil
+}
+
+// envTenantConfigProvider is a stub TenantConfigProvider that returns a global
+// webhook secret from environment variables. This will be replaced by a real
+// implementation in Task 6 that fetches per-tenant config from the control plane.
+type envTenantConfigProvider struct {
+	webhookSecret string
+}
+
+func (p *envTenantConfigProvider) GetTenantConfig(_ string) (stripegateway.TenantConfig, error) {
+	if p.webhookSecret == "" {
+		return stripegateway.TenantConfig{}, stripegateway.ErrTenantConfigNotFound
+	}
+	return stripegateway.TenantConfig{
+		ConnectedAccountID:    "platform", // Placeholder until per-tenant config
+		WebhookEndpointSecret: p.webhookSecret,
+	}, nil
 }
 
 // parseLogLevel converts a string log level to slog.Level.


### PR DESCRIPTION
## Summary
- Instantiate StripeWebhookHandler in payment-order main.go when STRIPE_API_KEY is set
- Register /webhook/stripe route via ServerConfig (conditional on handler being non-nil)
- Add STRIPE_API_KEY and STRIPE_WEBHOOK_SECRET env var support
- Add envTenantConfigProvider stub (placeholder until stripe-connect-wiring.6 implements real per-tenant config)

## Task Master
Tag: stripe-connect-wiring, Task: 3

## Test Plan
- [x] /webhook/stripe route responds when StripeWebhookHandler is configured (returns 400 for missing tenant, not 404)
- [x] /webhook/stripe returns 404 when handler is nil (disabled)
- [x] All existing HTTP adapter tests pass (29 tests)
- [x] go vet clean
- [x] golangci-lint clean