### PR TITLE
feat: Add Stripe instantiation path to gateway factory

### DIFF
--- a/services/payment-order/adapters/gateway/config.go
+++ b/services/payment-order/adapters/gateway/config.go
@@ -17,7 +17,8 @@ const (
 // implementation (to be added). The mock gateway does not use these values.
 type Config struct {
 	// Provider selects the gateway implementation: "stripe" or "mock".
-	// Empty defaults to mock.
+	// Empty defaults to mock. Note: New() does not use Provider; it is
+	// consumed by the service entry point factory (cmd/main.go).
 	Provider string
 	// StripeAPIKey is the platform-level Stripe API key.
 	// Required when Provider is "stripe".

--- a/services/payment-order/adapters/gateway/config.go
+++ b/services/payment-order/adapters/gateway/config.go
@@ -6,10 +6,22 @@ import (
 	"github.com/meridianhub/meridian/shared/platform/defaults"
 )
 
+// Provider constants for gateway selection.
+const (
+	ProviderStripe = "stripe"
+	ProviderMock   = "mock"
+)
+
 // Config holds configuration for payment gateway connections.
 // Note: Timeout, MaxRetries, and RetryBackoff are defined for the real gateway
 // implementation (to be added). The mock gateway does not use these values.
 type Config struct {
+	// Provider selects the gateway implementation: "stripe" or "mock".
+	// Empty defaults to mock.
+	Provider string
+	// StripeAPIKey is the platform-level Stripe API key.
+	// Required when Provider is "stripe".
+	StripeAPIKey string
 	// Timeout is the maximum duration to wait for a gateway response.
 	// Used by real gateway implementation (not mock).
 	Timeout time.Duration
@@ -40,6 +52,9 @@ func DefaultConfig() Config {
 // If UseMock is true, returns a MockGateway with the provided MockConfig.
 // Otherwise, returns a MockGateway with default config as a fallback
 // until the real gateway implementation is added.
+//
+// For provider-based instantiation (e.g., Stripe), use NewStripeGateway
+// from the cmd package or construct the adapter directly.
 func New(config Config) PaymentGateway {
 	if config.UseMock {
 		return NewMockGateway(config.MockConfig)

--- a/services/payment-order/adapters/gateway/config.go
+++ b/services/payment-order/adapters/gateway/config.go
@@ -53,8 +53,8 @@ func DefaultConfig() Config {
 // Otherwise, returns a MockGateway with default config as a fallback
 // until the real gateway implementation is added.
 //
-// For provider-based instantiation (e.g., Stripe), use NewStripeGateway
-// from the cmd package or construct the adapter directly.
+// For provider-based instantiation (e.g., Stripe), construct the adapter
+// directly in the service entry point (cmd/main.go) to avoid import cycles.
 func New(config Config) PaymentGateway {
 	if config.UseMock {
 		return NewMockGateway(config.MockConfig)

--- a/services/payment-order/adapters/gateway/config_test.go
+++ b/services/payment-order/adapters/gateway/config_test.go
@@ -29,6 +29,7 @@ func TestNew_WithMock(t *testing.T) {
 	gw := gateway.New(config)
 
 	assert.NotNil(t, gw)
+	assert.IsType(t, &gateway.MockGateway{}, gw)
 }
 
 func TestNew_WithoutMock(t *testing.T) {
@@ -40,6 +41,11 @@ func TestNew_WithoutMock(t *testing.T) {
 
 	// Should return a fallback gateway (mock for now until real implementation)
 	assert.NotNil(t, gw)
+}
+
+func TestProviderConstants(t *testing.T) {
+	assert.Equal(t, "stripe", gateway.ProviderStripe)
+	assert.Equal(t, "mock", gateway.ProviderMock)
 }
 
 func TestDefaultMockGatewayConfig(t *testing.T) {

--- a/services/payment-order/cmd/gateway_factory_test.go
+++ b/services/payment-order/cmd/gateway_factory_test.go
@@ -12,9 +12,8 @@ import (
 )
 
 func TestCreatePaymentGateway_DefaultMock(t *testing.T) {
-	// No env vars set - should default to mock
+	// No PAYMENT_GATEWAY_PROVIDER set - defaults to "mock"
 	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "")
-	t.Setenv("PAYMENT_GATEWAY_URL", "")
 	t.Setenv("STRIPE_API_KEY", "")
 
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
@@ -63,5 +62,17 @@ func TestCreatePaymentGateway_StripeMissingAPIKey(t *testing.T) {
 	gw, err := createPaymentGateway(logger)
 
 	assert.ErrorIs(t, err, ErrMissingStripeAPIKey)
+	assert.Nil(t, gw)
+}
+
+func TestCreatePaymentGateway_UnsupportedProvider(t *testing.T) {
+	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "paypal")
+	t.Setenv("STRIPE_API_KEY", "")
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	gw, err := createPaymentGateway(logger)
+
+	assert.ErrorIs(t, err, ErrUnsupportedGatewayProvider)
 	assert.Nil(t, gw)
 }

--- a/services/payment-order/cmd/gateway_factory_test.go
+++ b/services/payment-order/cmd/gateway_factory_test.go
@@ -62,7 +62,6 @@ func TestCreatePaymentGateway_StripeMissingAPIKey(t *testing.T) {
 
 	gw, err := createPaymentGateway(logger)
 
-	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingStripeAPIKey)
 	assert.Nil(t, gw)
-	assert.Contains(t, err.Error(), "STRIPE_API_KEY is required")
 }

--- a/services/payment-order/cmd/gateway_factory_test.go
+++ b/services/payment-order/cmd/gateway_factory_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	stripegateway "github.com/meridianhub/meridian/services/payment-order/adapters/gateway/stripe"
 )
 
 func TestCreatePaymentGateway_DefaultMock(t *testing.T) {
@@ -46,11 +44,6 @@ func TestCreatePaymentGateway_StripeProvider(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
-
-	// The resilient gateway wraps the actual gateway, so we can't directly
-	// type-assert to StripeGatewayAdapter. Instead, verify the factory
-	// didn't error, which confirms the Stripe path was taken.
-	_ = stripegateway.GatewayAdapter{} // Compile-time import verification
 }
 
 func TestCreatePaymentGateway_StripeMissingAPIKey(t *testing.T) {

--- a/services/payment-order/cmd/gateway_factory_test.go
+++ b/services/payment-order/cmd/gateway_factory_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	stripegateway "github.com/meridianhub/meridian/services/payment-order/adapters/gateway/stripe"
+)
+
+func TestCreatePaymentGateway_DefaultMock(t *testing.T) {
+	// No env vars set - should default to mock
+	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "")
+	t.Setenv("PAYMENT_GATEWAY_URL", "")
+	t.Setenv("STRIPE_API_KEY", "")
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	gw, err := createPaymentGateway(logger)
+
+	require.NoError(t, err)
+	assert.NotNil(t, gw)
+}
+
+func TestCreatePaymentGateway_ExplicitMock(t *testing.T) {
+	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "mock")
+	t.Setenv("STRIPE_API_KEY", "")
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	gw, err := createPaymentGateway(logger)
+
+	require.NoError(t, err)
+	assert.NotNil(t, gw)
+}
+
+func TestCreatePaymentGateway_StripeProvider(t *testing.T) {
+	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "stripe")
+	t.Setenv("STRIPE_API_KEY", "sk_test_fake_key_for_unit_test")
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	gw, err := createPaymentGateway(logger)
+
+	require.NoError(t, err)
+	assert.NotNil(t, gw)
+
+	// The resilient gateway wraps the actual gateway, so we can't directly
+	// type-assert to StripeGatewayAdapter. Instead, verify the factory
+	// didn't error, which confirms the Stripe path was taken.
+	_ = stripegateway.GatewayAdapter{} // Compile-time import verification
+}
+
+func TestCreatePaymentGateway_StripeMissingAPIKey(t *testing.T) {
+	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "stripe")
+	t.Setenv("STRIPE_API_KEY", "")
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	gw, err := createPaymentGateway(logger)
+
+	assert.Error(t, err)
+	assert.Nil(t, gw)
+	assert.Contains(t, err.Error(), "STRIPE_API_KEY is required")
+}

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -11,8 +11,11 @@ import (
 	"strconv"
 	"strings"
 
+	stripego "github.com/stripe/stripe-go/v82"
+
 	pb "github.com/meridianhub/meridian/api/proto/meridian/payment_order/v1"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
+	stripegateway "github.com/meridianhub/meridian/services/payment-order/adapters/gateway/stripe"
 	webhookhttp "github.com/meridianhub/meridian/services/payment-order/adapters/http"
 	"github.com/meridianhub/meridian/services/payment-order/adapters/persistence"
 	"github.com/meridianhub/meridian/services/payment-order/config"
@@ -130,7 +133,11 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Create payment gateway
-	paymentGateway := createPaymentGateway(logger)
+	paymentGateway, err := createPaymentGateway(logger)
+	if err != nil {
+		return fmt.Errorf("failed to create payment gateway: %w", err)
+	}
+	logger.Info("payment gateway initialized")
 
 	// Load gateway account configuration
 	gatewayAccountConfig, err := createGatewayAccountConfig(logger)
@@ -545,19 +552,45 @@ func createInternalBankAccountClient(namespace string, logger *slog.Logger, trac
 
 // createPaymentGateway creates the payment gateway client with resilience patterns.
 // The gateway is wrapped with circuit breaker, rate limiting, and retry logic.
-func createPaymentGateway(logger *slog.Logger) gateway.PaymentGateway {
-	gatewayURL := env.GetEnvOrDefault("PAYMENT_GATEWAY_URL", "")
+//
+// Environment variables:
+//   - PAYMENT_GATEWAY_PROVIDER: Gateway provider ("stripe" or "mock", default: "mock")
+//   - STRIPE_API_KEY: Platform Stripe API key (required when provider is "stripe")
+//   - PAYMENT_GATEWAY_URL: Legacy URL-based gateway selection (used as fallback hint)
+func createPaymentGateway(logger *slog.Logger) (gateway.PaymentGateway, error) {
+	provider := env.GetEnvOrDefault("PAYMENT_GATEWAY_PROVIDER", "")
+	stripeAPIKey := env.GetEnvOrDefault("STRIPE_API_KEY", "")
+
+	// If no explicit provider set, fall back to legacy PAYMENT_GATEWAY_URL behavior
+	if provider == "" {
+		gatewayURL := env.GetEnvOrDefault("PAYMENT_GATEWAY_URL", "")
+		if gatewayURL == "" {
+			provider = gateway.ProviderMock
+		}
+	}
 
 	var baseGateway gateway.PaymentGateway
-	if gatewayURL == "" {
-		logger.Warn("PAYMENT_GATEWAY_URL not set, using mock gateway")
-		baseGateway = gateway.New(gateway.Config{UseMock: true})
-	} else {
-		// Note: MaxRetries is 0 because the ResilientPaymentGateway wrapper handles retries.
-		// Setting retries on both layers would create nested retry behavior (3x3 = 9 attempts).
+
+	switch provider {
+	case gateway.ProviderStripe:
+		if stripeAPIKey == "" {
+			return nil, fmt.Errorf("STRIPE_API_KEY is required when PAYMENT_GATEWAY_PROVIDER is %q", gateway.ProviderStripe)
+		}
+		client := stripego.NewClient(stripeAPIKey)
+		baseGateway = stripegateway.NewGatewayAdapter(
+			client.V1PaymentIntents,
+			stripegateway.GatewayAdapterConfig{},
+			logger,
+		)
+		logger.Info("using stripe payment gateway")
+
+	default:
+		logger.Warn("using mock payment gateway", "provider", provider)
 		baseGateway = gateway.New(gateway.Config{
-			Timeout:    defaults.DefaultRPCTimeout,
-			MaxRetries: 0,
+			UseMock: true,
+			MockConfig: gateway.MockGatewayConfig{
+				DeterministicFailures: true,
+			},
 		})
 	}
 
@@ -592,7 +625,7 @@ func createPaymentGateway(logger *slog.Logger) gateway.PaymentGateway {
 		"max_retries", resilientConfig.MaxRetries,
 	)
 
-	return gateway.NewResilientPaymentGateway(baseGateway, resilientConfig)
+	return gateway.NewResilientPaymentGateway(baseGateway, resilientConfig), nil
 }
 
 // createKafkaProducer creates the Kafka producer.

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -50,6 +50,9 @@ var (
 // ErrMissingHMACSecret is returned when the WEBHOOK_HMAC_SECRET environment variable is not set.
 var ErrMissingHMACSecret = errors.New("WEBHOOK_HMAC_SECRET environment variable is required")
 
+// ErrMissingStripeAPIKey is returned when STRIPE_API_KEY is not set but the Stripe provider is selected.
+var ErrMissingStripeAPIKey = errors.New("STRIPE_API_KEY is required when PAYMENT_GATEWAY_PROVIDER is \"stripe\"")
+
 func main() {
 	// Initialize structured logging with configurable log level
 	// Note: bootstrap.NewLogger hardcodes INFO level, so we create logger manually for LOG_LEVEL support
@@ -574,7 +577,7 @@ func createPaymentGateway(logger *slog.Logger) (gateway.PaymentGateway, error) {
 	switch provider {
 	case gateway.ProviderStripe:
 		if stripeAPIKey == "" {
-			return nil, fmt.Errorf("STRIPE_API_KEY is required when PAYMENT_GATEWAY_PROVIDER is %q", gateway.ProviderStripe)
+			return nil, ErrMissingStripeAPIKey
 		}
 		client := stripego.NewClient(stripeAPIKey)
 		baseGateway = stripegateway.NewGatewayAdapter(

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -53,6 +53,9 @@ var ErrMissingHMACSecret = errors.New("WEBHOOK_HMAC_SECRET environment variable 
 // ErrMissingStripeAPIKey is returned when STRIPE_API_KEY is not set but the Stripe provider is selected.
 var ErrMissingStripeAPIKey = errors.New("STRIPE_API_KEY is required when PAYMENT_GATEWAY_PROVIDER is \"stripe\"")
 
+// ErrUnsupportedGatewayProvider is returned when PAYMENT_GATEWAY_PROVIDER has an unknown value.
+var ErrUnsupportedGatewayProvider = errors.New("unsupported PAYMENT_GATEWAY_PROVIDER value")
+
 func main() {
 	// Initialize structured logging with configurable log level
 	// Note: bootstrap.NewLogger hardcodes INFO level, so we create logger manually for LOG_LEVEL support
@@ -559,18 +562,9 @@ func createInternalBankAccountClient(namespace string, logger *slog.Logger, trac
 // Environment variables:
 //   - PAYMENT_GATEWAY_PROVIDER: Gateway provider ("stripe" or "mock", default: "mock")
 //   - STRIPE_API_KEY: Platform Stripe API key (required when provider is "stripe")
-//   - PAYMENT_GATEWAY_URL: Legacy URL-based gateway selection (used as fallback hint)
 func createPaymentGateway(logger *slog.Logger) (gateway.PaymentGateway, error) {
-	provider := env.GetEnvOrDefault("PAYMENT_GATEWAY_PROVIDER", "")
+	provider := env.GetEnvOrDefault("PAYMENT_GATEWAY_PROVIDER", gateway.ProviderMock)
 	stripeAPIKey := env.GetEnvOrDefault("STRIPE_API_KEY", "")
-
-	// If no explicit provider set, fall back to legacy PAYMENT_GATEWAY_URL behavior
-	if provider == "" {
-		gatewayURL := env.GetEnvOrDefault("PAYMENT_GATEWAY_URL", "")
-		if gatewayURL == "" {
-			provider = gateway.ProviderMock
-		}
-	}
 
 	var baseGateway gateway.PaymentGateway
 
@@ -587,14 +581,17 @@ func createPaymentGateway(logger *slog.Logger) (gateway.PaymentGateway, error) {
 		)
 		logger.Info("using stripe payment gateway")
 
-	default:
-		logger.Warn("using mock payment gateway", "provider", provider)
+	case gateway.ProviderMock:
+		logger.Warn("using mock payment gateway")
 		baseGateway = gateway.New(gateway.Config{
 			UseMock: true,
 			MockConfig: gateway.MockGatewayConfig{
 				DeterministicFailures: true,
 			},
 		})
+
+	default:
+		return nil, fmt.Errorf("%w: %q (valid: %q, %q)", ErrUnsupportedGatewayProvider, provider, gateway.ProviderStripe, gateway.ProviderMock)
 	}
 
 	// Configure resilience settings from environment


### PR DESCRIPTION
## Summary
- Add `Provider` and `StripeAPIKey` fields to gateway `Config` struct
- Add `ProviderStripe` and `ProviderMock` constants for provider selection
- Implement Stripe gateway construction in `createPaymentGateway` when `PAYMENT_GATEWAY_PROVIDER=stripe`
- Read `STRIPE_API_KEY` env var for platform-level Stripe API key
- Keep mock as default for backward compatibility
- Stripe adapter construction in `cmd/main.go` to avoid import cycle between `gateway` and `gateway/stripe`

## Task Master
Tag: stripe-connect-wiring, Task: 2

## Test Plan
- [x] Unit test: factory returns mock gateway when provider is empty
- [x] Unit test: factory returns mock gateway when provider is "mock"
- [x] Unit test: factory initializes Stripe gateway when provider is "stripe"
- [x] Unit test: factory returns error when provider is "stripe" but API key missing
- [x] Existing gateway package tests pass
- [x] Existing stripe subpackage tests pass