### PR TITLE
feat: Centralize Stripe and billing env var configuration

### DIFF
--- a/services/payment-order/cmd/gateway_factory_test.go
+++ b/services/payment-order/cmd/gateway_factory_test.go
@@ -5,67 +5,56 @@ import (
 	"os"
 	"testing"
 
+	"github.com/meridianhub/meridian/services/payment-order/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCreatePaymentGateway_DefaultMock(t *testing.T) {
-	// No PAYMENT_GATEWAY_PROVIDER set - defaults to "mock"
-	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "")
-	t.Setenv("STRIPE_API_KEY", "")
-
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	cfg := config.ServiceConfig{
+		PaymentGatewayProvider: config.ProviderMock,
+	}
 
-	gw, err := createPaymentGateway(logger)
+	gw, err := createPaymentGateway(cfg, logger)
 
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
 }
 
 func TestCreatePaymentGateway_ExplicitMock(t *testing.T) {
-	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "mock")
-	t.Setenv("STRIPE_API_KEY", "")
-
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	cfg := config.ServiceConfig{
+		PaymentGatewayProvider: config.ProviderMock,
+	}
 
-	gw, err := createPaymentGateway(logger)
+	gw, err := createPaymentGateway(cfg, logger)
 
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
 }
 
 func TestCreatePaymentGateway_StripeProvider(t *testing.T) {
-	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "stripe")
-	t.Setenv("STRIPE_API_KEY", "sk_test_fake_key_for_unit_test")
-
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	cfg := config.ServiceConfig{
+		PaymentGatewayProvider: config.ProviderStripe,
+		StripeAPIKey:           "sk_test_fake_key_for_unit_test",
+	}
 
-	gw, err := createPaymentGateway(logger)
+	gw, err := createPaymentGateway(cfg, logger)
 
 	require.NoError(t, err)
 	assert.NotNil(t, gw)
 }
 
-func TestCreatePaymentGateway_StripeMissingAPIKey(t *testing.T) {
-	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "stripe")
-	t.Setenv("STRIPE_API_KEY", "")
-
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-
-	gw, err := createPaymentGateway(logger)
-
-	assert.ErrorIs(t, err, ErrMissingStripeAPIKey)
-	assert.Nil(t, gw)
-}
-
 func TestCreatePaymentGateway_UnsupportedProvider(t *testing.T) {
-	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "paypal")
-	t.Setenv("STRIPE_API_KEY", "")
-
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	cfg := config.ServiceConfig{
+		PaymentGatewayProvider: "paypal",
+	}
 
-	gw, err := createPaymentGateway(logger)
+	gw, err := createPaymentGateway(cfg, logger)
 
-	assert.ErrorIs(t, err, ErrUnsupportedGatewayProvider)
+	assert.ErrorIs(t, err, config.ErrInvalidGatewayProvider)
 	assert.Nil(t, gw)
 }

--- a/services/payment-order/cmd/gateway_factory_test.go
+++ b/services/payment-order/cmd/gateway_factory_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
 	"github.com/meridianhub/meridian/services/payment-order/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,7 +14,7 @@ import (
 func TestCreatePaymentGateway_DefaultMock(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	cfg := config.ServiceConfig{
-		PaymentGatewayProvider: config.ProviderMock,
+		PaymentGatewayProvider: gateway.ProviderMock,
 	}
 
 	gw, err := createPaymentGateway(cfg, logger)
@@ -25,7 +26,7 @@ func TestCreatePaymentGateway_DefaultMock(t *testing.T) {
 func TestCreatePaymentGateway_ExplicitMock(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	cfg := config.ServiceConfig{
-		PaymentGatewayProvider: config.ProviderMock,
+		PaymentGatewayProvider: gateway.ProviderMock,
 	}
 
 	gw, err := createPaymentGateway(cfg, logger)
@@ -37,7 +38,7 @@ func TestCreatePaymentGateway_ExplicitMock(t *testing.T) {
 func TestCreatePaymentGateway_StripeProvider(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	cfg := config.ServiceConfig{
-		PaymentGatewayProvider: config.ProviderStripe,
+		PaymentGatewayProvider: gateway.ProviderStripe,
 		StripeAPIKey:           "sk_test_fake_key_for_unit_test",
 	}
 

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	stripego "github.com/stripe/stripe-go/v82"
 

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -667,7 +667,7 @@ func createPaymentGateway(svcConfig config.ServiceConfig, logger *slog.Logger) (
 	var baseGateway gateway.PaymentGateway
 
 	switch svcConfig.PaymentGatewayProvider {
-	case config.ProviderStripe:
+	case gateway.ProviderStripe:
 		client := stripego.NewClient(svcConfig.StripeAPIKey)
 		baseGateway = stripegateway.NewGatewayAdapter(
 			client.V1PaymentIntents,
@@ -676,7 +676,7 @@ func createPaymentGateway(svcConfig config.ServiceConfig, logger *slog.Logger) (
 		)
 		logger.Info("using stripe payment gateway")
 
-	case config.ProviderMock:
+	case gateway.ProviderMock:
 		logger.Warn("using mock payment gateway")
 		baseGateway = gateway.New(gateway.Config{
 			UseMock: true,
@@ -686,7 +686,7 @@ func createPaymentGateway(svcConfig config.ServiceConfig, logger *slog.Logger) (
 		})
 
 	default:
-		return nil, fmt.Errorf("%w: %q (valid: %q, %q)", config.ErrInvalidGatewayProvider, svcConfig.PaymentGatewayProvider, config.ProviderStripe, config.ProviderMock)
+		return nil, fmt.Errorf("%w: %q (valid: %q, %q)", config.ErrInvalidGatewayProvider, svcConfig.PaymentGatewayProvider, gateway.ProviderStripe, gateway.ProviderMock)
 	}
 
 	// Configure resilience settings from environment

--- a/services/payment-order/cmd/main.go
+++ b/services/payment-order/cmd/main.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	stripego "github.com/stripe/stripe-go/v82"
 
@@ -54,12 +53,6 @@ var (
 // ErrMissingHMACSecret is returned when the WEBHOOK_HMAC_SECRET environment variable is not set.
 var ErrMissingHMACSecret = errors.New("WEBHOOK_HMAC_SECRET environment variable is required")
 
-// ErrMissingStripeAPIKey is returned when STRIPE_API_KEY is not set but the Stripe provider is selected.
-var ErrMissingStripeAPIKey = errors.New("STRIPE_API_KEY is required when PAYMENT_GATEWAY_PROVIDER is \"stripe\"")
-
-// ErrUnsupportedGatewayProvider is returned when PAYMENT_GATEWAY_PROVIDER has an unknown value.
-var ErrUnsupportedGatewayProvider = errors.New("unsupported PAYMENT_GATEWAY_PROVIDER value")
-
 func main() {
 	// Initialize structured logging with configurable log level
 	// Note: bootstrap.NewLogger hardcodes INFO level, so we create logger manually for LOG_LEVEL support
@@ -85,6 +78,13 @@ func main() {
 
 func run(logger *slog.Logger) error {
 	ctx := context.Background()
+
+	// Load and validate service configuration early (fail fast).
+	svcConfig := config.LoadServiceConfig()
+	if err := svcConfig.Validate(); err != nil {
+		return fmt.Errorf("invalid service configuration: %w", err)
+	}
+	svcConfig.LogValues(logger)
 
 	// Initialize OpenTelemetry tracer
 	tracer, err := bootstrap.NewTracer(ctx, bootstrap.TracerConfig{
@@ -143,7 +143,7 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Create payment gateway
-	paymentGateway, err := createPaymentGateway(logger)
+	paymentGateway, err := createPaymentGateway(svcConfig, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create payment gateway: %w", err)
 	}
@@ -238,18 +238,14 @@ func run(logger *slog.Logger) error {
 	_ = handlerRegistry
 
 	// Start billing background workers (feature-flagged)
-	billingEnabled := env.GetEnvAsBool("BILLING_ENABLED", false)
 	var billingScheduler *worker.BillingScheduler
 	var dunningWorker *worker.DunningWorker
 
-	if billingEnabled {
+	if svcConfig.BillingEnabled {
 		billingRepo := persistence.NewBillingRepository(db)
 		billingMetrics := worker.NewBillingMetrics()
 
 		tenantID := env.GetEnvOrDefault("BILLING_TENANT_ID", "default")
-		cronSchedule := env.GetEnvOrDefault("BILLING_CRON_SCHEDULE", "0 0 * * *")
-		shadowMode := env.GetEnvAsBool("BILLING_SHADOW_MODE", false)
-		pollInterval := env.GetEnvAsDuration("DUNNING_POLL_INTERVAL", 5*time.Minute)
 
 		var err error
 		billingScheduler, err = worker.NewBillingScheduler(
@@ -257,8 +253,8 @@ func run(logger *slog.Logger) error {
 			redisClient,
 			worker.BillingSchedulerConfig{
 				TenantID:       tenantID,
-				CronExpression: cronSchedule,
-				ShadowMode:     shadowMode,
+				CronExpression: svcConfig.BillingCronSchedule,
+				ShadowMode:     svcConfig.BillingShadowMode,
 			},
 			logger,
 			billingMetrics,
@@ -279,7 +275,7 @@ func run(logger *slog.Logger) error {
 			billingRepo,
 			redisClient,
 			worker.DunningWorkerConfig{
-				PollInterval: pollInterval,
+				PollInterval: svcConfig.DunningPollInterval,
 			},
 			dunningCallback,
 			logger,
@@ -290,9 +286,9 @@ func run(logger *slog.Logger) error {
 		}
 
 		logger.Info("billing workers configured",
-			"cron_schedule", cronSchedule,
-			"shadow_mode", shadowMode,
-			"dunning_poll_interval", pollInterval,
+			"cron_schedule", svcConfig.BillingCronSchedule,
+			"shadow_mode", svcConfig.BillingShadowMode,
+			"dunning_poll_interval", svcConfig.DunningPollInterval,
 			"tenant_id", tenantID)
 	} else {
 		logger.Info("billing workers disabled (BILLING_ENABLED=false)")
@@ -354,7 +350,7 @@ func run(logger *slog.Logger) error {
 	}
 
 	// Create Stripe webhook handler (optional - only if STRIPE_API_KEY is configured)
-	stripeWebhookHandler, err := createStripeWebhookHandler(webhookHandler, logger)
+	stripeWebhookHandler, err := createStripeWebhookHandler(svcConfig, webhookHandler, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create stripe webhook handler: %w", err)
 	}
@@ -406,7 +402,7 @@ func run(logger *slog.Logger) error {
 	workerCtx, workerCancel := context.WithCancel(ctx)
 	defer workerCancel()
 	var billingWg sync.WaitGroup
-	if billingEnabled && billingScheduler != nil && dunningWorker != nil {
+	if svcConfig.BillingEnabled && billingScheduler != nil && dunningWorker != nil {
 		billingWg.Add(2)
 		go func() {
 			defer billingWg.Done()
@@ -448,7 +444,7 @@ func run(logger *slog.Logger) error {
 	// Stop billing workers and wait for goroutines to exit before database close.
 	// Cancel the worker context first to unblock Start() select loops, then
 	// call Stop() to signal internal shutdown channels and drain in-flight work.
-	if billingEnabled && billingScheduler != nil && dunningWorker != nil {
+	if svcConfig.BillingEnabled && billingScheduler != nil && dunningWorker != nil {
 		logger.Info("stopping billing workers...")
 		workerCancel()
 		billingScheduler.Stop()
@@ -665,22 +661,14 @@ func createInternalBankAccountClient(namespace string, logger *slog.Logger, trac
 
 // createPaymentGateway creates the payment gateway client with resilience patterns.
 // The gateway is wrapped with circuit breaker, rate limiting, and retry logic.
-//
-// Environment variables:
-//   - PAYMENT_GATEWAY_PROVIDER: Gateway provider ("stripe" or "mock", default: "mock")
-//   - STRIPE_API_KEY: Platform Stripe API key (required when provider is "stripe")
-func createPaymentGateway(logger *slog.Logger) (gateway.PaymentGateway, error) {
-	provider := env.GetEnvOrDefault("PAYMENT_GATEWAY_PROVIDER", gateway.ProviderMock)
-	stripeAPIKey := env.GetEnvOrDefault("STRIPE_API_KEY", "")
-
+// Provider selection and API key validation are handled by ServiceConfig.Validate,
+// so this function assumes the config is already validated.
+func createPaymentGateway(svcConfig config.ServiceConfig, logger *slog.Logger) (gateway.PaymentGateway, error) {
 	var baseGateway gateway.PaymentGateway
 
-	switch provider {
-	case gateway.ProviderStripe:
-		if stripeAPIKey == "" {
-			return nil, ErrMissingStripeAPIKey
-		}
-		client := stripego.NewClient(stripeAPIKey)
+	switch svcConfig.PaymentGatewayProvider {
+	case config.ProviderStripe:
+		client := stripego.NewClient(svcConfig.StripeAPIKey)
 		baseGateway = stripegateway.NewGatewayAdapter(
 			client.V1PaymentIntents,
 			stripegateway.GatewayAdapterConfig{},
@@ -688,7 +676,7 @@ func createPaymentGateway(logger *slog.Logger) (gateway.PaymentGateway, error) {
 		)
 		logger.Info("using stripe payment gateway")
 
-	case gateway.ProviderMock:
+	case config.ProviderMock:
 		logger.Warn("using mock payment gateway")
 		baseGateway = gateway.New(gateway.Config{
 			UseMock: true,
@@ -698,7 +686,7 @@ func createPaymentGateway(logger *slog.Logger) (gateway.PaymentGateway, error) {
 		})
 
 	default:
-		return nil, fmt.Errorf("%w: %q (valid: %q, %q)", ErrUnsupportedGatewayProvider, provider, gateway.ProviderStripe, gateway.ProviderMock)
+		return nil, fmt.Errorf("%w: %q (valid: %q, %q)", config.ErrInvalidGatewayProvider, svcConfig.PaymentGatewayProvider, config.ProviderStripe, config.ProviderMock)
 	}
 
 	// Configure resilience settings from environment
@@ -812,25 +800,22 @@ func createGatewayAccountConfig(logger *slog.Logger) (*config.GatewayAccountConf
 	return cfg, nil
 }
 
-// createStripeWebhookHandler creates the StripeWebhookHandler if STRIPE_API_KEY is configured.
-// Returns nil (no error) when Stripe is not configured, making the handler optional.
-func createStripeWebhookHandler(webhookHandler *webhookhttp.WebhookHandler, logger *slog.Logger) (*webhookhttp.StripeWebhookHandler, error) {
-	stripeAPIKey := env.GetEnvOrDefault("STRIPE_API_KEY", "")
-	if stripeAPIKey == "" {
-		logger.Info("STRIPE_API_KEY not set, Stripe webhook handler disabled")
+// createStripeWebhookHandler creates the StripeWebhookHandler if Stripe provider is configured.
+// Returns nil (no error) when Stripe is not the active provider, making the handler optional.
+func createStripeWebhookHandler(svcConfig config.ServiceConfig, webhookHandler *webhookhttp.WebhookHandler, logger *slog.Logger) (*webhookhttp.StripeWebhookHandler, error) {
+	if svcConfig.StripeAPIKey == "" {
+		logger.Info("Stripe API key not set, Stripe webhook handler disabled")
 		return nil, nil //nolint:nilnil // nil handler is intentional: ServerConfig treats nil as "feature disabled"
 	}
-
-	stripeWebhookSecret := env.GetEnvOrDefault("STRIPE_WEBHOOK_SECRET", "")
 
 	// Use env-based tenant config provider as a stub until Task 6 implements
 	// the real TenantConfigProvider backed by control-plane gRPC.
 	provider := &envTenantConfigProvider{
-		webhookSecret: stripeWebhookSecret,
+		webhookSecret: svcConfig.StripeWebhookSecret,
 	}
 
 	cfg := stripegateway.DefaultConfig()
-	cfg.APIKey = stripeAPIKey
+	cfg.APIKey = svcConfig.StripeAPIKey
 
 	clientFactory, err := stripegateway.NewClientFactory(cfg, provider, logger)
 	if err != nil {

--- a/services/payment-order/config/service_config.go
+++ b/services/payment-order/config/service_config.go
@@ -7,13 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
 	"github.com/meridianhub/meridian/shared/platform/env"
-)
-
-// PaymentGatewayProvider values.
-const (
-	ProviderStripe = "stripe"
-	ProviderMock   = "mock"
 )
 
 // ServiceConfig holds all payment-order service configuration loaded from
@@ -59,7 +54,7 @@ var (
 // a populated ServiceConfig. It does NOT validate — call Validate separately.
 func LoadServiceConfig() ServiceConfig {
 	return ServiceConfig{
-		PaymentGatewayProvider: env.GetEnvOrDefault("PAYMENT_GATEWAY_PROVIDER", ProviderMock),
+		PaymentGatewayProvider: env.GetEnvOrDefault("PAYMENT_GATEWAY_PROVIDER", gateway.ProviderMock),
 		StripeAPIKey:           env.GetEnvOrDefault("STRIPE_API_KEY", ""),
 		StripeWebhookSecret:    env.GetEnvOrDefault("STRIPE_WEBHOOK_SECRET", ""),
 		BillingEnabled:         env.GetEnvAsBool("BILLING_ENABLED", false),
@@ -73,17 +68,17 @@ func LoadServiceConfig() ServiceConfig {
 // an error for the first violated constraint.
 func (c ServiceConfig) Validate() error {
 	switch c.PaymentGatewayProvider {
-	case ProviderStripe:
+	case gateway.ProviderStripe:
 		if c.StripeAPIKey == "" {
 			return ErrMissingStripeAPIKey
 		}
 		if c.StripeWebhookSecret == "" {
 			return ErrMissingStripeWebhookSecret
 		}
-	case ProviderMock:
+	case gateway.ProviderMock:
 		// No additional requirements.
 	default:
-		return fmt.Errorf("%w: %q (valid: %q, %q)", ErrInvalidGatewayProvider, c.PaymentGatewayProvider, ProviderStripe, ProviderMock)
+		return fmt.Errorf("%w: %q (valid: %q, %q)", ErrInvalidGatewayProvider, c.PaymentGatewayProvider, gateway.ProviderStripe, gateway.ProviderMock)
 	}
 	return nil
 }

--- a/services/payment-order/config/service_config.go
+++ b/services/payment-order/config/service_config.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/env"
+)
+
+// PaymentGatewayProvider values.
+const (
+	ProviderStripe = "stripe"
+	ProviderMock   = "mock"
+)
+
+// ServiceConfig holds all payment-order service configuration loaded from
+// environment variables. Call LoadServiceConfig to populate and Validate to
+// verify constraints.
+type ServiceConfig struct {
+	// PaymentGatewayProvider selects the payment gateway implementation.
+	// Valid values: "stripe", "mock". Default: "mock".
+	PaymentGatewayProvider string
+
+	// StripeAPIKey is the platform Stripe API key. Required when
+	// PaymentGatewayProvider is "stripe".
+	StripeAPIKey string
+
+	// StripeWebhookSecret is the Stripe webhook endpoint secret. Required when
+	// PaymentGatewayProvider is "stripe".
+	StripeWebhookSecret string
+
+	// BillingEnabled controls whether billing background workers are started.
+	// Default: false.
+	BillingEnabled bool
+
+	// BillingCronSchedule is the cron expression for the billing scheduler.
+	// Default: "0 0 * * *" (midnight daily).
+	BillingCronSchedule string
+
+	// BillingShadowMode runs billing in shadow mode (dry-run). Default: false.
+	BillingShadowMode bool
+
+	// DunningPollInterval is how often the dunning worker polls for overdue
+	// billing runs. Default: 5m.
+	DunningPollInterval time.Duration
+}
+
+// Configuration validation errors.
+var (
+	ErrMissingStripeAPIKey        = errors.New("STRIPE_API_KEY is required when PAYMENT_GATEWAY_PROVIDER is \"stripe\"")
+	ErrMissingStripeWebhookSecret = errors.New("STRIPE_WEBHOOK_SECRET is required when PAYMENT_GATEWAY_PROVIDER is \"stripe\"")
+	ErrInvalidGatewayProvider     = errors.New("unsupported PAYMENT_GATEWAY_PROVIDER value")
+)
+
+// LoadServiceConfig reads all payment-order environment variables and returns
+// a populated ServiceConfig. It does NOT validate — call Validate separately.
+func LoadServiceConfig() ServiceConfig {
+	return ServiceConfig{
+		PaymentGatewayProvider: env.GetEnvOrDefault("PAYMENT_GATEWAY_PROVIDER", ProviderMock),
+		StripeAPIKey:           env.GetEnvOrDefault("STRIPE_API_KEY", ""),
+		StripeWebhookSecret:    env.GetEnvOrDefault("STRIPE_WEBHOOK_SECRET", ""),
+		BillingEnabled:         env.GetEnvAsBool("BILLING_ENABLED", false),
+		BillingCronSchedule:    env.GetEnvOrDefault("BILLING_CRON_SCHEDULE", "0 0 * * *"),
+		BillingShadowMode:      env.GetEnvAsBool("BILLING_SHADOW_MODE", false),
+		DunningPollInterval:    env.GetEnvAsDuration("DUNNING_POLL_INTERVAL", 5*time.Minute),
+	}
+}
+
+// Validate checks that the ServiceConfig is internally consistent. It returns
+// an error for the first violated constraint.
+func (c ServiceConfig) Validate() error {
+	switch c.PaymentGatewayProvider {
+	case ProviderStripe:
+		if c.StripeAPIKey == "" {
+			return ErrMissingStripeAPIKey
+		}
+		if c.StripeWebhookSecret == "" {
+			return ErrMissingStripeWebhookSecret
+		}
+	case ProviderMock:
+		// No additional requirements.
+	default:
+		return fmt.Errorf("%w: %q (valid: %q, %q)", ErrInvalidGatewayProvider, c.PaymentGatewayProvider, ProviderStripe, ProviderMock)
+	}
+	return nil
+}
+
+// LogValues logs the configuration at startup. Sensitive values (API keys,
+// secrets) are redacted to show only the first and last 4 characters.
+func (c ServiceConfig) LogValues(logger *slog.Logger) {
+	logger.Info("payment-order service configuration",
+		"payment_gateway_provider", c.PaymentGatewayProvider,
+		"stripe_api_key", redact(c.StripeAPIKey),
+		"stripe_webhook_secret", redact(c.StripeWebhookSecret),
+		"billing_enabled", c.BillingEnabled,
+		"billing_cron_schedule", c.BillingCronSchedule,
+		"billing_shadow_mode", c.BillingShadowMode,
+		"dunning_poll_interval", c.DunningPollInterval,
+	)
+}
+
+// redact masks a sensitive string, showing only the first and last 4
+// characters. Strings shorter than 12 characters are fully masked.
+func redact(s string) string {
+	if s == "" {
+		return "(not set)"
+	}
+	if len(s) < 12 {
+		return strings.Repeat("*", len(s))
+	}
+	return s[:4] + strings.Repeat("*", len(s)-8) + s[len(s)-4:]
+}

--- a/services/payment-order/config/service_config_test.go
+++ b/services/payment-order/config/service_config_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/meridianhub/meridian/services/payment-order/adapters/gateway"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -14,14 +15,14 @@ import (
 
 func TestValidate_MockProviderDefaults(t *testing.T) {
 	cfg := ServiceConfig{
-		PaymentGatewayProvider: ProviderMock,
+		PaymentGatewayProvider: gateway.ProviderMock,
 	}
 	assert.NoError(t, cfg.Validate())
 }
 
 func TestValidate_StripeProviderValid(t *testing.T) {
 	cfg := ServiceConfig{
-		PaymentGatewayProvider: ProviderStripe,
+		PaymentGatewayProvider: gateway.ProviderStripe,
 		StripeAPIKey:           "sk_test_abc123",
 		StripeWebhookSecret:    "whsec_test_abc123",
 	}
@@ -30,7 +31,7 @@ func TestValidate_StripeProviderValid(t *testing.T) {
 
 func TestValidate_StripeMissingAPIKey(t *testing.T) {
 	cfg := ServiceConfig{
-		PaymentGatewayProvider: ProviderStripe,
+		PaymentGatewayProvider: gateway.ProviderStripe,
 		StripeAPIKey:           "",
 		StripeWebhookSecret:    "whsec_test_abc123",
 	}
@@ -41,7 +42,7 @@ func TestValidate_StripeMissingAPIKey(t *testing.T) {
 
 func TestValidate_StripeMissingWebhookSecret(t *testing.T) {
 	cfg := ServiceConfig{
-		PaymentGatewayProvider: ProviderStripe,
+		PaymentGatewayProvider: gateway.ProviderStripe,
 		StripeAPIKey:           "sk_test_abc123",
 		StripeWebhookSecret:    "",
 	}
@@ -85,7 +86,7 @@ func TestLoadServiceConfig_Defaults(t *testing.T) {
 
 	cfg := LoadServiceConfig()
 
-	assert.Equal(t, ProviderMock, cfg.PaymentGatewayProvider)
+	assert.Equal(t, gateway.ProviderMock, cfg.PaymentGatewayProvider)
 	assert.Empty(t, cfg.StripeAPIKey)
 	assert.Empty(t, cfg.StripeWebhookSecret)
 	assert.False(t, cfg.BillingEnabled)
@@ -105,7 +106,7 @@ func TestLoadServiceConfig_StripeFromEnv(t *testing.T) {
 
 	cfg := LoadServiceConfig()
 
-	assert.Equal(t, ProviderStripe, cfg.PaymentGatewayProvider)
+	assert.Equal(t, gateway.ProviderStripe, cfg.PaymentGatewayProvider)
 	assert.Equal(t, "sk_live_key123", cfg.StripeAPIKey)
 	assert.Equal(t, "whsec_secret456", cfg.StripeWebhookSecret)
 	assert.True(t, cfg.BillingEnabled)
@@ -159,7 +160,7 @@ func TestLogValues_RedactsSensitiveValues(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
 	cfg := ServiceConfig{
-		PaymentGatewayProvider: ProviderStripe,
+		PaymentGatewayProvider: gateway.ProviderStripe,
 		StripeAPIKey:           "sk_live_realkey123456",
 		StripeWebhookSecret:    "whsec_realsecret7890",
 		BillingEnabled:         true,

--- a/services/payment-order/config/service_config_test.go
+++ b/services/payment-order/config/service_config_test.go
@@ -1,0 +1,183 @@
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Validation tests ---
+
+func TestValidate_MockProviderDefaults(t *testing.T) {
+	cfg := ServiceConfig{
+		PaymentGatewayProvider: ProviderMock,
+	}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidate_StripeProviderValid(t *testing.T) {
+	cfg := ServiceConfig{
+		PaymentGatewayProvider: ProviderStripe,
+		StripeAPIKey:           "sk_test_abc123",
+		StripeWebhookSecret:    "whsec_test_abc123",
+	}
+	assert.NoError(t, cfg.Validate())
+}
+
+func TestValidate_StripeMissingAPIKey(t *testing.T) {
+	cfg := ServiceConfig{
+		PaymentGatewayProvider: ProviderStripe,
+		StripeAPIKey:           "",
+		StripeWebhookSecret:    "whsec_test_abc123",
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingStripeAPIKey)
+}
+
+func TestValidate_StripeMissingWebhookSecret(t *testing.T) {
+	cfg := ServiceConfig{
+		PaymentGatewayProvider: ProviderStripe,
+		StripeAPIKey:           "sk_test_abc123",
+		StripeWebhookSecret:    "",
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingStripeWebhookSecret)
+}
+
+func TestValidate_UnsupportedProvider(t *testing.T) {
+	cfg := ServiceConfig{
+		PaymentGatewayProvider: "paypal",
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidGatewayProvider)
+}
+
+func TestValidate_EmptyProviderDefaultsToMock(t *testing.T) {
+	// When LoadServiceConfig is used, empty env var defaults to "mock".
+	// But if someone constructs ServiceConfig with empty string directly, it
+	// should fail as unsupported.
+	cfg := ServiceConfig{
+		PaymentGatewayProvider: "",
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidGatewayProvider)
+}
+
+// --- LoadServiceConfig tests ---
+
+func TestLoadServiceConfig_Defaults(t *testing.T) {
+	// Clear all relevant env vars to test defaults.
+	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "")
+	t.Setenv("STRIPE_API_KEY", "")
+	t.Setenv("STRIPE_WEBHOOK_SECRET", "")
+	t.Setenv("BILLING_ENABLED", "")
+	t.Setenv("BILLING_CRON_SCHEDULE", "")
+	t.Setenv("BILLING_SHADOW_MODE", "")
+	t.Setenv("DUNNING_POLL_INTERVAL", "")
+
+	cfg := LoadServiceConfig()
+
+	assert.Equal(t, ProviderMock, cfg.PaymentGatewayProvider)
+	assert.Empty(t, cfg.StripeAPIKey)
+	assert.Empty(t, cfg.StripeWebhookSecret)
+	assert.False(t, cfg.BillingEnabled)
+	assert.Equal(t, "0 0 * * *", cfg.BillingCronSchedule)
+	assert.False(t, cfg.BillingShadowMode)
+	assert.Equal(t, 5*time.Minute, cfg.DunningPollInterval)
+}
+
+func TestLoadServiceConfig_StripeFromEnv(t *testing.T) {
+	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "stripe")
+	t.Setenv("STRIPE_API_KEY", "sk_live_key123")
+	t.Setenv("STRIPE_WEBHOOK_SECRET", "whsec_secret456")
+	t.Setenv("BILLING_ENABLED", "true")
+	t.Setenv("BILLING_CRON_SCHEDULE", "*/5 * * * *")
+	t.Setenv("BILLING_SHADOW_MODE", "true")
+	t.Setenv("DUNNING_POLL_INTERVAL", "10m")
+
+	cfg := LoadServiceConfig()
+
+	assert.Equal(t, ProviderStripe, cfg.PaymentGatewayProvider)
+	assert.Equal(t, "sk_live_key123", cfg.StripeAPIKey)
+	assert.Equal(t, "whsec_secret456", cfg.StripeWebhookSecret)
+	assert.True(t, cfg.BillingEnabled)
+	assert.Equal(t, "*/5 * * * *", cfg.BillingCronSchedule)
+	assert.True(t, cfg.BillingShadowMode)
+	assert.Equal(t, 10*time.Minute, cfg.DunningPollInterval)
+}
+
+func TestLoadServiceConfig_ValidateIntegration(t *testing.T) {
+	// Stripe provider without API key should fail validation.
+	t.Setenv("PAYMENT_GATEWAY_PROVIDER", "stripe")
+	t.Setenv("STRIPE_API_KEY", "")
+	t.Setenv("STRIPE_WEBHOOK_SECRET", "")
+
+	cfg := LoadServiceConfig()
+	err := cfg.Validate()
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrMissingStripeAPIKey)
+}
+
+// --- Redaction tests ---
+
+func TestRedact_Empty(t *testing.T) {
+	assert.Equal(t, "(not set)", redact(""))
+}
+
+func TestRedact_Short(t *testing.T) {
+	// Strings shorter than 12 chars are fully masked.
+	assert.Equal(t, "***********", redact("short_value"))
+}
+
+func TestRedact_Long(t *testing.T) {
+	// "sk_test_abc123def456" is 20 chars => first 4 + 12 stars + last 4
+	result := redact("sk_test_abc123def456")
+	assert.Equal(t, "sk_t************f456", result)
+	// Verify original value is not present.
+	assert.NotContains(t, result, "abc123def")
+}
+
+func TestRedact_Exactly12(t *testing.T) {
+	// 12 chars: first 4 + 4 stars + last 4
+	result := redact("abcdefghijkl")
+	assert.Equal(t, "abcd****ijkl", result)
+}
+
+// --- LogValues test ---
+
+func TestLogValues_RedactsSensitiveValues(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	cfg := ServiceConfig{
+		PaymentGatewayProvider: ProviderStripe,
+		StripeAPIKey:           "sk_live_realkey123456",
+		StripeWebhookSecret:    "whsec_realsecret7890",
+		BillingEnabled:         true,
+		BillingCronSchedule:    "0 0 * * *",
+		BillingShadowMode:      false,
+		DunningPollInterval:    5 * time.Minute,
+	}
+
+	cfg.LogValues(logger)
+
+	output := buf.String()
+	// Sensitive values should NOT appear in full.
+	assert.NotContains(t, output, "sk_live_realkey123456")
+	assert.NotContains(t, output, "whsec_realsecret7890")
+	// Redacted form should appear.
+	assert.Contains(t, output, "sk_l")
+	assert.Contains(t, output, "whse")
+	// Non-sensitive values should appear.
+	assert.Contains(t, output, "stripe")
+	assert.Contains(t, output, "0 0 * * *")
+}


### PR DESCRIPTION
## Summary

- Add `ServiceConfig` struct to `services/payment-order/config/` that centralizes all Stripe and billing environment variables with defaults, validation, and redacted logging
- Fail fast at startup: if `PAYMENT_GATEWAY_PROVIDER=stripe` but `STRIPE_API_KEY` or `STRIPE_WEBHOOK_SECRET` are empty, service exits with clear error
- Replace scattered `env.GetEnv*` calls in `main.go` with single config load-validate-log pattern
- Redact sensitive values in startup logs (show first/last 4 chars only)

## Environment Variables Consolidated

| Variable | Default | Required |
|----------|---------|----------|
| `PAYMENT_GATEWAY_PROVIDER` | `mock` | No |
| `STRIPE_API_KEY` | (empty) | If provider=stripe |
| `STRIPE_WEBHOOK_SECRET` | (empty) | If provider=stripe |
| `BILLING_ENABLED` | `false` | No |
| `BILLING_CRON_SCHEDULE` | `0 0 * * *` | No |
| `BILLING_SHADOW_MODE` | `false` | No |
| `DUNNING_POLL_INTERVAL` | `5m` | No |

## Test Plan

- [x] Unit test: valid mock config passes validation
- [x] Unit test: valid Stripe config passes validation
- [x] Unit test: missing STRIPE_API_KEY with provider=stripe fails
- [x] Unit test: missing STRIPE_WEBHOOK_SECRET with provider=stripe fails
- [x] Unit test: unsupported provider fails
- [x] Unit test: default values applied correctly via LoadServiceConfig
- [x] Unit test: env vars override defaults
- [x] Unit test: sensitive values redacted in logs
- [x] Unit test: redact function handles empty, short, and long strings
- [x] Existing gateway factory tests updated and passing
- [x] Existing config package tests passing

Task: stripe-connect-wiring.9