### PR TITLE
feat: extract shared/platform/redislock package

### DIFF
--- a/shared/platform/redislock/config.go
+++ b/shared/platform/redislock/config.go
@@ -17,14 +17,17 @@ type Config struct {
 }
 
 func (c Config) withDefaults() Config {
-	if c.LockTTL == 0 {
+	if c.LockTTL <= 0 {
 		c.LockTTL = 5 * time.Minute
 	}
-	if c.RenewEvery == 0 {
+	if c.RenewEvery <= 0 {
 		c.RenewEvery = 30 * time.Second
 	}
 	if c.RenewEvery >= c.LockTTL {
 		c.RenewEvery = c.LockTTL / 2
+	}
+	if c.RenewEvery <= 0 {
+		c.RenewEvery = time.Second
 	}
 	return c
 }

--- a/shared/platform/redislock/config.go
+++ b/shared/platform/redislock/config.go
@@ -1,0 +1,30 @@
+package redislock
+
+import "time"
+
+// Config holds configuration for Redis distributed locks.
+type Config struct {
+	// KeyPrefix is prepended to lock keys.
+	// For leader election, this is the full lock key.
+	// For per-resource locks, keys are formatted as "{KeyPrefix}:{tenantID}:{resourceID}".
+	KeyPrefix string
+	// LockTTL is how long the lock is held before expiring.
+	// Default: 5 minutes.
+	LockTTL time.Duration
+	// RenewEvery is how often to renew the lock.
+	// Must be less than LockTTL. Default: 30 seconds.
+	RenewEvery time.Duration
+}
+
+func (c Config) withDefaults() Config {
+	if c.LockTTL == 0 {
+		c.LockTTL = 5 * time.Minute
+	}
+	if c.RenewEvery == 0 {
+		c.RenewEvery = 30 * time.Second
+	}
+	if c.RenewEvery >= c.LockTTL {
+		c.RenewEvery = c.LockTTL / 2
+	}
+	return c
+}

--- a/shared/platform/redislock/lock.go
+++ b/shared/platform/redislock/lock.go
@@ -79,7 +79,7 @@ func (l *Lock) Acquire(ctx context.Context, tenantID, resourceID string) (bool, 
 	l.locks[key] = al
 	l.mu.Unlock()
 
-	go l.renewLoop(renewCtx, key, lock)
+	go l.renewLoop(renewCtx, key, al)
 
 	l.logger.Debug("lock acquired", "key", key)
 
@@ -139,7 +139,7 @@ func (l *Lock) HeldCount() int {
 }
 
 // renewLoop periodically refreshes a lock until the context is cancelled.
-func (l *Lock) renewLoop(ctx context.Context, key string, lock *redislock.Lock) {
+func (l *Lock) renewLoop(ctx context.Context, key string, al *activeLock) {
 	ticker := time.NewTicker(l.config.RenewEvery)
 	defer ticker.Stop()
 
@@ -148,13 +148,15 @@ func (l *Lock) renewLoop(ctx context.Context, key string, lock *redislock.Lock) 
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := lock.Refresh(ctx, l.config.LockTTL, nil); err != nil {
+			if err := al.lock.Refresh(ctx, l.config.LockTTL, nil); err != nil {
 				if ctx.Err() != nil {
 					return
 				}
 				l.logger.Error("lock renewal failed", "key", key, "error", err)
 				l.mu.Lock()
-				delete(l.locks, key)
+				if l.locks[key] == al {
+					delete(l.locks, key)
+				}
 				l.mu.Unlock()
 				return
 			}

--- a/shared/platform/redislock/lock.go
+++ b/shared/platform/redislock/lock.go
@@ -1,0 +1,289 @@
+// Package redislock provides distributed locking backed by Redis.
+//
+// It supports two patterns:
+//
+//   - Per-resource locking via [Lock]: multiple locks keyed by tenant and resource,
+//     suitable for preventing concurrent execution of the same task.
+//   - Leader election via [Leader]: a single lock for leader/follower coordination
+//     across replicas.
+//
+// Both patterns use background renewal goroutines to keep locks alive during
+// long-running operations, with automatic cleanup on context cancellation or
+// explicit release.
+package redislock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/bsm/redislock"
+	"github.com/redis/go-redis/v9"
+)
+
+// activeLock tracks a held lock and its renewal goroutine.
+type activeLock struct {
+	lock   *redislock.Lock
+	cancel context.CancelFunc
+}
+
+// Lock provides per-resource distributed locking using Redis.
+// It manages multiple concurrent locks keyed by tenant and resource ID,
+// each with an independent background renewal goroutine.
+type Lock struct {
+	client *redislock.Client
+	config Config
+	logger *slog.Logger
+
+	mu    sync.Mutex
+	locks map[string]*activeLock
+}
+
+// NewLock creates a per-resource distributed lock manager.
+func NewLock(redisClient *redis.Client, config Config, logger *slog.Logger) *Lock {
+	config = config.withDefaults()
+	return &Lock{
+		client: redislock.New(redisClient),
+		config: config,
+		logger: logger.With("component", "redislock"),
+		locks:  make(map[string]*activeLock),
+	}
+}
+
+func (l *Lock) key(tenantID, resourceID string) string {
+	return fmt.Sprintf("%s:%s:%s", l.config.KeyPrefix, tenantID, resourceID)
+}
+
+// Acquire attempts to acquire a lock for the given tenant and resource.
+// Returns true if the lock was acquired, false if another holder has it.
+// On success, a background renewal goroutine runs until the returned release
+// function is called or the context is cancelled.
+func (l *Lock) Acquire(ctx context.Context, tenantID, resourceID string) (bool, func(), error) {
+	key := l.key(tenantID, resourceID)
+
+	lock, err := l.client.Obtain(ctx, key, l.config.LockTTL, nil)
+	if err != nil {
+		if errors.Is(err, redislock.ErrNotObtained) {
+			return false, nil, nil
+		}
+		return false, nil, fmt.Errorf("obtain lock for %s: %w", key, err)
+	}
+
+	renewCtx, cancel := context.WithCancel(ctx)
+	al := &activeLock{lock: lock, cancel: cancel}
+
+	l.mu.Lock()
+	l.locks[key] = al
+	l.mu.Unlock()
+
+	go l.renewLoop(renewCtx, key, lock)
+
+	l.logger.Debug("lock acquired", "key", key)
+
+	release := func() {
+		l.release(ctx, key)
+	}
+	return true, release, nil
+}
+
+// release releases a single lock by key.
+func (l *Lock) release(ctx context.Context, key string) {
+	l.mu.Lock()
+	al, ok := l.locks[key]
+	if !ok {
+		l.mu.Unlock()
+		return
+	}
+	delete(l.locks, key)
+	l.mu.Unlock()
+
+	al.cancel()
+	if err := al.lock.Release(ctx); err != nil {
+		l.logger.Warn("failed to release lock", "key", key, "error", err)
+	} else {
+		l.logger.Debug("lock released", "key", key)
+	}
+}
+
+// ReleaseAll releases all held locks. Used during graceful shutdown.
+func (l *Lock) ReleaseAll(ctx context.Context) {
+	l.mu.Lock()
+	snapshot := make(map[string]*activeLock, len(l.locks))
+	for k, v := range l.locks {
+		snapshot[k] = v
+	}
+	l.locks = make(map[string]*activeLock)
+	l.mu.Unlock()
+
+	for key, al := range snapshot {
+		al.cancel()
+		if err := al.lock.Release(ctx); err != nil {
+			l.logger.Warn("failed to release lock during shutdown", "key", key, "error", err)
+		}
+	}
+}
+
+// HeldCount returns the number of currently held locks.
+func (l *Lock) HeldCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return len(l.locks)
+}
+
+// renewLoop periodically refreshes a lock until the context is cancelled.
+func (l *Lock) renewLoop(ctx context.Context, key string, lock *redislock.Lock) {
+	ticker := time.NewTicker(l.config.RenewEvery)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := lock.Refresh(ctx, l.config.LockTTL, nil); err != nil {
+				if ctx.Err() != nil {
+					return
+				}
+				l.logger.Error("lock renewal failed", "key", key, "error", err)
+				l.mu.Lock()
+				delete(l.locks, key)
+				l.mu.Unlock()
+				return
+			}
+		}
+	}
+}
+
+// Leader provides single-lock leader election using Redis.
+// Only one Leader instance across all replicas can hold the lock at a time.
+type Leader struct {
+	client  *redislock.Client
+	lockKey string
+	config  Config
+	logger  *slog.Logger
+
+	mu       sync.Mutex
+	lock     *redislock.Lock
+	isLeader bool
+	cancel   context.CancelFunc
+}
+
+// NewLeader creates a new Redis-based leader elector.
+// The Config.KeyPrefix is used as the lock key.
+func NewLeader(redisClient *redis.Client, config Config, logger *slog.Logger) *Leader {
+	config = config.withDefaults()
+	return &Leader{
+		client:  redislock.New(redisClient),
+		lockKey: config.KeyPrefix,
+		config:  config,
+		logger:  logger.With("component", "redislock_leader"),
+	}
+}
+
+// TryAcquire attempts to acquire or renew the leader lock.
+// Returns true if this instance is (or remains) the leader.
+func (l *Leader) TryAcquire(ctx context.Context) (bool, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// If we already hold the lock, try to refresh it
+	if l.lock != nil {
+		err := l.lock.Refresh(ctx, l.config.LockTTL, nil)
+		if err == nil {
+			return true, nil
+		}
+		l.logger.Warn("leader lock refresh failed, attempting re-acquire", "error", err)
+		l.stopRenewal()
+	}
+
+	lock, err := l.client.Obtain(ctx, l.lockKey, l.config.LockTTL, nil)
+	if err != nil {
+		if errors.Is(err, redislock.ErrNotObtained) {
+			l.isLeader = false
+			return false, nil
+		}
+		return false, err
+	}
+
+	l.lock = lock
+	l.isLeader = true
+	l.startRenewal(ctx)
+
+	l.logger.Info("acquired leader lock")
+	return true, nil
+}
+
+// Release releases the leader lock.
+func (l *Leader) Release(ctx context.Context) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.stopRenewal()
+
+	if l.lock != nil {
+		err := l.lock.Release(ctx)
+		l.lock = nil
+		l.isLeader = false
+		if err != nil {
+			return err
+		}
+		l.logger.Info("released leader lock")
+	}
+
+	return nil
+}
+
+// IsLeader returns whether this instance currently holds the leader lock.
+func (l *Leader) IsLeader() bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.isLeader
+}
+
+// startRenewal begins the background lock renewal goroutine.
+// Must be called with l.mu held.
+func (l *Leader) startRenewal(parent context.Context) {
+	l.stopRenewal()
+
+	renewCtx, cancel := context.WithCancel(parent)
+	l.cancel = cancel
+
+	go func() {
+		ticker := time.NewTicker(l.config.RenewEvery)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-renewCtx.Done():
+				return
+			case <-ticker.C:
+				l.mu.Lock()
+				if l.lock == nil {
+					l.mu.Unlock()
+					return
+				}
+				err := l.lock.Refresh(renewCtx, l.config.LockTTL, nil)
+				if err != nil {
+					l.logger.Error("failed to renew leader lock", "error", err)
+					l.isLeader = false
+					l.lock = nil
+					l.mu.Unlock()
+					return
+				}
+				l.mu.Unlock()
+			}
+		}
+	}()
+}
+
+// stopRenewal cancels the background renewal goroutine.
+// Must be called with l.mu held.
+func (l *Leader) stopRenewal() {
+	if l.cancel != nil {
+		l.cancel()
+		l.cancel = nil
+	}
+}

--- a/shared/platform/redislock/lock.go
+++ b/shared/platform/redislock/lock.go
@@ -84,16 +84,21 @@ func (l *Lock) Acquire(ctx context.Context, tenantID, resourceID string) (bool, 
 	l.logger.Debug("lock acquired", "key", key)
 
 	release := func() {
-		l.release(ctx, key)
+		if ctx.Err() != nil {
+			l.releaseByInstance(context.Background(), key, al) //nolint:contextcheck // fallback when parent cancelled
+		} else {
+			l.releaseByInstance(ctx, key, al)
+		}
 	}
 	return true, release, nil
 }
 
-// release releases a single lock by key.
-func (l *Lock) release(ctx context.Context, key string) {
+// releaseByInstance releases a lock only if the stored instance matches expected.
+// This prevents a stale release closure from dropping a newer lock for the same key.
+func (l *Lock) releaseByInstance(ctx context.Context, key string, expected *activeLock) {
 	l.mu.Lock()
 	al, ok := l.locks[key]
-	if !ok {
+	if !ok || al != expected {
 		l.mu.Unlock()
 		return
 	}
@@ -193,9 +198,15 @@ func (l *Leader) TryAcquire(ctx context.Context) (bool, error) {
 	if l.lock != nil {
 		err := l.lock.Refresh(ctx, l.config.LockTTL, nil)
 		if err == nil {
+			l.isLeader = true
+			if l.cancel == nil {
+				l.startRenewal(ctx)
+			}
 			return true, nil
 		}
 		l.logger.Warn("leader lock refresh failed, attempting re-acquire", "error", err)
+		l.isLeader = false
+		l.lock = nil
 		l.stopRenewal()
 	}
 

--- a/shared/platform/redislock/lock_test.go
+++ b/shared/platform/redislock/lock_test.go
@@ -351,3 +351,14 @@ func TestConfig_RenewClamping(t *testing.T) {
 
 	assert.Equal(t, 5*time.Second, c.RenewEvery) // clamped to TTL/2
 }
+
+func TestConfig_NegativeDurations(t *testing.T) {
+	c := Config{
+		KeyPrefix:  "test",
+		LockTTL:    -1 * time.Second,
+		RenewEvery: -1 * time.Second,
+	}.withDefaults()
+
+	assert.Equal(t, 5*time.Minute, c.LockTTL)
+	assert.Equal(t, 30*time.Second, c.RenewEvery)
+}

--- a/shared/platform/redislock/lock_test.go
+++ b/shared/platform/redislock/lock_test.go
@@ -1,0 +1,353 @@
+package redislock
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupMiniredis(t *testing.T) (*miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	t.Cleanup(func() {
+		client.Close()
+	})
+	return mr, client
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, nil))
+}
+
+// --- Lock (per-resource) tests ---
+
+func TestLock_AcquireAndRelease(t *testing.T) {
+	_, client := setupMiniredis(t)
+
+	l := NewLock(client, Config{
+		KeyPrefix:  "test:lock",
+		LockTTL:    5 * time.Second,
+		RenewEvery: 1 * time.Second,
+	}, testLogger())
+
+	ctx := context.Background()
+
+	acquired, release, err := l.Acquire(ctx, "tenant-1", "resource-a")
+	require.NoError(t, err)
+	assert.True(t, acquired)
+	assert.NotNil(t, release)
+	assert.Equal(t, 1, l.HeldCount())
+
+	release()
+	assert.Equal(t, 0, l.HeldCount())
+}
+
+func TestLock_Contention(t *testing.T) {
+	_, client := setupMiniredis(t)
+
+	config := Config{
+		KeyPrefix:  "test:lock",
+		LockTTL:    5 * time.Second,
+		RenewEvery: 1 * time.Second,
+	}
+
+	l1 := NewLock(client, config, testLogger())
+	l2 := NewLock(client, config, testLogger())
+
+	ctx := context.Background()
+
+	// First acquires
+	acquired1, release1, err := l1.Acquire(ctx, "tenant-1", "resource-a")
+	require.NoError(t, err)
+	assert.True(t, acquired1)
+
+	// Second cannot acquire same resource
+	acquired2, release2, err := l2.Acquire(ctx, "tenant-1", "resource-a")
+	require.NoError(t, err)
+	assert.False(t, acquired2)
+	assert.Nil(t, release2)
+
+	// Release first, second can now acquire
+	release1()
+
+	acquired2, release2, err = l2.Acquire(ctx, "tenant-1", "resource-a")
+	require.NoError(t, err)
+	assert.True(t, acquired2)
+	release2()
+}
+
+func TestLock_DifferentResources(t *testing.T) {
+	_, client := setupMiniredis(t)
+
+	l := NewLock(client, Config{
+		KeyPrefix:  "test:lock",
+		LockTTL:    5 * time.Second,
+		RenewEvery: 1 * time.Second,
+	}, testLogger())
+
+	ctx := context.Background()
+
+	acquired1, release1, err := l.Acquire(ctx, "tenant-1", "resource-a")
+	require.NoError(t, err)
+	assert.True(t, acquired1)
+
+	acquired2, release2, err := l.Acquire(ctx, "tenant-1", "resource-b")
+	require.NoError(t, err)
+	assert.True(t, acquired2)
+
+	assert.Equal(t, 2, l.HeldCount())
+
+	release1()
+	release2()
+	assert.Equal(t, 0, l.HeldCount())
+}
+
+func TestLock_ReleaseAll(t *testing.T) {
+	_, client := setupMiniredis(t)
+
+	l := NewLock(client, Config{
+		KeyPrefix:  "test:lock",
+		LockTTL:    5 * time.Second,
+		RenewEvery: 1 * time.Second,
+	}, testLogger())
+
+	ctx := context.Background()
+
+	_, _, err := l.Acquire(ctx, "tenant-1", "resource-a")
+	require.NoError(t, err)
+	_, _, err = l.Acquire(ctx, "tenant-1", "resource-b")
+	require.NoError(t, err)
+	_, _, err = l.Acquire(ctx, "tenant-2", "resource-a")
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, l.HeldCount())
+
+	l.ReleaseAll(ctx)
+	assert.Equal(t, 0, l.HeldCount())
+}
+
+func TestLock_Expiry(t *testing.T) {
+	mr, client := setupMiniredis(t)
+
+	config := Config{
+		KeyPrefix:  "test:lock",
+		LockTTL:    200 * time.Millisecond,
+		RenewEvery: 50 * time.Millisecond,
+	}
+
+	l1 := NewLock(client, config, testLogger())
+	l2 := NewLock(client, config, testLogger())
+
+	ctx := context.Background()
+
+	// Acquire and immediately cancel to stop renewal
+	acquired, release, err := l1.Acquire(ctx, "tenant-1", "resource-a")
+	require.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Stop renewal by releasing (which cancels the renewal goroutine's key)
+	// We need to manually stop renewal without releasing the Redis lock
+	// to simulate a crash. We do this by cancelling the renewal and removing
+	// from the map, but not calling lock.Release.
+	l1.mu.Lock()
+	key := l1.key("tenant-1", "resource-a")
+	al := l1.locks[key]
+	al.cancel() // stop renewal goroutine
+	delete(l1.locks, key)
+	l1.mu.Unlock()
+	_ = release // prevent unused warning
+
+	// Fast-forward past TTL
+	mr.FastForward(300 * time.Millisecond)
+
+	// Second should now be able to acquire
+	acquired2, release2, err := l2.Acquire(ctx, "tenant-1", "resource-a")
+	require.NoError(t, err)
+	assert.True(t, acquired2)
+	release2()
+}
+
+func TestLock_ContextCancellation(t *testing.T) {
+	_, client := setupMiniredis(t)
+
+	l := NewLock(client, Config{
+		KeyPrefix:  "test:lock",
+		LockTTL:    5 * time.Second,
+		RenewEvery: 50 * time.Millisecond,
+	}, testLogger())
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	acquired, _, err := l.Acquire(ctx, "tenant-1", "resource-a")
+	require.NoError(t, err)
+	assert.True(t, acquired)
+
+	// Cancel context should stop renewal goroutine
+	cancel()
+
+	// Give goroutine time to exit
+	time.Sleep(100 * time.Millisecond)
+
+	// Lock map entry may still exist but renewal has stopped
+	// This tests that cancellation doesn't panic
+}
+
+// --- Leader election tests ---
+
+func TestLeader_AcquireAndRelease(t *testing.T) {
+	_, client := setupMiniredis(t)
+
+	leader := NewLeader(client, Config{
+		KeyPrefix:  "test:leader",
+		LockTTL:    5 * time.Second,
+		RenewEvery: 1 * time.Second,
+	}, testLogger())
+
+	ctx := context.Background()
+
+	isLeader, err := leader.TryAcquire(ctx)
+	require.NoError(t, err)
+	assert.True(t, isLeader)
+	assert.True(t, leader.IsLeader())
+
+	err = leader.Release(ctx)
+	require.NoError(t, err)
+	assert.False(t, leader.IsLeader())
+}
+
+func TestLeader_OnlyOneLeader(t *testing.T) {
+	_, client := setupMiniredis(t)
+
+	config := Config{
+		KeyPrefix:  "test:leader",
+		LockTTL:    5 * time.Second,
+		RenewEvery: 1 * time.Second,
+	}
+
+	leader1 := NewLeader(client, config, testLogger())
+	leader2 := NewLeader(client, config, testLogger())
+
+	ctx := context.Background()
+
+	isLeader1, err := leader1.TryAcquire(ctx)
+	require.NoError(t, err)
+	assert.True(t, isLeader1)
+
+	isLeader2, err := leader2.TryAcquire(ctx)
+	require.NoError(t, err)
+	assert.False(t, isLeader2)
+
+	// Release first, second can acquire
+	err = leader1.Release(ctx)
+	require.NoError(t, err)
+
+	isLeader2, err = leader2.TryAcquire(ctx)
+	require.NoError(t, err)
+	assert.True(t, isLeader2)
+
+	err = leader2.Release(ctx)
+	require.NoError(t, err)
+}
+
+func TestLeader_RefreshExistingLock(t *testing.T) {
+	_, client := setupMiniredis(t)
+
+	leader := NewLeader(client, Config{
+		KeyPrefix:  "test:leader",
+		LockTTL:    5 * time.Second,
+		RenewEvery: 1 * time.Second,
+	}, testLogger())
+
+	ctx := context.Background()
+
+	isLeader, err := leader.TryAcquire(ctx)
+	require.NoError(t, err)
+	assert.True(t, isLeader)
+
+	// Re-acquire should refresh
+	isLeader, err = leader.TryAcquire(ctx)
+	require.NoError(t, err)
+	assert.True(t, isLeader)
+
+	err = leader.Release(ctx)
+	require.NoError(t, err)
+}
+
+func TestLeader_ReleaseWithoutAcquire(t *testing.T) {
+	_, client := setupMiniredis(t)
+
+	leader := NewLeader(client, Config{
+		KeyPrefix:  "test:leader",
+		LockTTL:    5 * time.Second,
+		RenewEvery: 1 * time.Second,
+	}, testLogger())
+
+	ctx := context.Background()
+
+	err := leader.Release(ctx)
+	assert.NoError(t, err)
+	assert.False(t, leader.IsLeader())
+}
+
+func TestLeader_LockExpiry(t *testing.T) {
+	mr, client := setupMiniredis(t)
+
+	config := Config{
+		KeyPrefix:  "test:leader:expiry",
+		LockTTL:    200 * time.Millisecond,
+		RenewEvery: 50 * time.Millisecond,
+	}
+
+	leader1 := NewLeader(client, config, testLogger())
+	leader2 := NewLeader(client, config, testLogger())
+
+	ctx := context.Background()
+
+	isLeader, err := leader1.TryAcquire(ctx)
+	require.NoError(t, err)
+	assert.True(t, isLeader)
+
+	// Stop renewal to simulate crash
+	leader1.mu.Lock()
+	leader1.stopRenewal()
+	leader1.mu.Unlock()
+
+	mr.FastForward(300 * time.Millisecond)
+
+	// Second should now be able to acquire
+	isLeader, err = leader2.TryAcquire(ctx)
+	require.NoError(t, err)
+	assert.True(t, isLeader)
+
+	err = leader2.Release(ctx)
+	require.NoError(t, err)
+}
+
+// --- Config tests ---
+
+func TestConfig_Defaults(t *testing.T) {
+	c := Config{KeyPrefix: "test"}.withDefaults()
+
+	assert.Equal(t, 5*time.Minute, c.LockTTL)
+	assert.Equal(t, 30*time.Second, c.RenewEvery)
+}
+
+func TestConfig_RenewClamping(t *testing.T) {
+	c := Config{
+		KeyPrefix:  "test",
+		LockTTL:    10 * time.Second,
+		RenewEvery: 15 * time.Second, // greater than TTL
+	}.withDefaults()
+
+	assert.Equal(t, 5*time.Second, c.RenewEvery) // clamped to TTL/2
+}


### PR DESCRIPTION
## Summary

- Extracts a unified Redis distributed locking package at `shared/platform/redislock/`
- Merges patterns from `reconciliation/worker/leader.go` (leader election) and `forecasting/scheduler/lease_manager.go` (per-resource locking)
- Provides two APIs: `Lock` for per-resource locking with tenant/resource key composition, and `Leader` for single-lock leader election

## Changes Made

**New files:**
- `shared/platform/redislock/config.go` - Configuration types with safe defaults and TTL clamping
- `shared/platform/redislock/lock.go` - Core `Lock` (multi-lock) and `Leader` (single-lock) implementations with background renewal goroutines
- `shared/platform/redislock/lock_test.go` - 12 tests covering acquisition, contention, expiry, release, shutdown, context cancellation, and config defaults

## Technical Details

Both `Lock` and `Leader` wrap `bsm/redislock` with:
- Background renewal goroutines using `time.Ticker` and context cancellation
- Automatic lock refresh to prevent expiry during long operations
- Graceful cleanup via `ReleaseAll()` (Lock) and `Release()` (Leader)
- Thread-safe state management with `sync.Mutex`

`Lock.Acquire` returns a release function for ergonomic cleanup:
```go
acquired, release, err := lock.Acquire(ctx, tenantID, resourceID)
if acquired {
    defer release()
}
```

`Leader` preserves the reconciliation scheduler's `TryAcquire`/`Release`/`IsLeader` interface for drop-in compatibility.

## Testing

- 12 tests using miniredis (in-process Redis) covering both Lock and Leader APIs
- Tests verify: acquire/release, contention, multi-resource, ReleaseAll, TTL expiry via FastForward, context cancellation, config defaults, renew clamping
- `go vet` and `golangci-lint` clean

## Task Master

platform-scheduler.1 - Extract shared/platform/redislock package