### PR TITLE
feat: extract shared/platform/scheduler lifecycle layer

### DIFF
--- a/shared/platform/scheduler/config.go
+++ b/shared/platform/scheduler/config.go
@@ -1,0 +1,31 @@
+package scheduler
+
+import (
+	"time"
+
+	"github.com/meridianhub/meridian/shared/platform/defaults"
+)
+
+// Config holds shared configuration for scheduled workers.
+type Config struct {
+	// PollInterval is how often the worker polls for new work.
+	// Default: 5 seconds (defaults.DefaultHealthCheckTimeout).
+	PollInterval time.Duration
+
+	// ShutdownTimeout is the maximum time to wait for in-flight work during shutdown.
+	// Default: 30 seconds (defaults.DefaultGracefulShutdown).
+	ShutdownTimeout time.Duration
+
+	// MaxCatchUpAge is the maximum age of entries to process during catch-up.
+	// Entries older than this are skipped. Default: 5 minutes.
+	MaxCatchUpAge time.Duration
+}
+
+// DefaultConfig returns a Config with sensible defaults.
+func DefaultConfig() Config {
+	return Config{
+		PollInterval:    defaults.DefaultHealthCheckTimeout,
+		ShutdownTimeout: defaults.DefaultGracefulShutdown,
+		MaxCatchUpAge:   5 * time.Minute,
+	}
+}

--- a/shared/platform/scheduler/lifecycle.go
+++ b/shared/platform/scheduler/lifecycle.go
@@ -21,10 +21,25 @@ var (
 	ErrAlreadyStopped = errors.New("worker has been stopped")
 )
 
+// noCopy may be added to structs which must not be copied after first use.
+// See https://golang.org/issues/8005#issuecomment-190753527 for details.
+// This is detected by go vet -copylocks.
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}
+
 // WorkerLifecycle provides start/stop lifecycle management, WaitGroup tracking
 // for in-flight work, and graceful shutdown with timeout. It is designed to be
 // embedded in concrete worker implementations.
+//
+// WorkerLifecycle must not be copied after first use because it contains
+// sync primitives (sync.Mutex, sync.WaitGroup). Always use a pointer.
+//
+// The zero value is safe to use; fields are lazily initialized on first method
+// call. However, using NewWorkerLifecycle is preferred to supply a logger.
 type WorkerLifecycle struct {
+	noCopy  noCopy //nolint:unused // Detected by go vet -copylocks
 	mu      sync.Mutex
 	wg      sync.WaitGroup
 	running bool
@@ -32,6 +47,17 @@ type WorkerLifecycle struct {
 	done    chan struct{}
 	cancel  context.CancelFunc
 	logger  *slog.Logger
+}
+
+// initLocked lazily initializes fields that require non-zero values.
+// Must be called while w.mu is held.
+func (w *WorkerLifecycle) initLocked() {
+	if w.done == nil {
+		w.done = make(chan struct{})
+	}
+	if w.logger == nil {
+		w.logger = slog.Default()
+	}
 }
 
 // NewWorkerLifecycle creates a new WorkerLifecycle.
@@ -53,6 +79,7 @@ func NewWorkerLifecycle(logger *slog.Logger) *WorkerLifecycle {
 // Returns ErrAlreadyStopped if the lifecycle has been stopped (lifecycles are single-use).
 func (w *WorkerLifecycle) Start(ctx context.Context, workFunc func(context.Context) error) error {
 	w.mu.Lock()
+	w.initLocked()
 	if w.stopped {
 		w.mu.Unlock()
 		return ErrAlreadyStopped
@@ -75,6 +102,7 @@ func (w *WorkerLifecycle) Start(ctx context.Context, workFunc func(context.Conte
 // Safe to call multiple times and concurrently.
 func (w *WorkerLifecycle) Stop(timeout time.Duration) {
 	w.mu.Lock()
+	w.initLocked()
 	if w.stopped {
 		w.mu.Unlock()
 		return
@@ -121,7 +149,11 @@ func (w *WorkerLifecycle) ExecuteGuarded(fn func()) {
 // Done returns a channel that is closed when Stop is called.
 // This can be used in select statements to detect shutdown.
 func (w *WorkerLifecycle) Done() <-chan struct{} {
-	return w.done
+	w.mu.Lock()
+	w.initLocked()
+	ch := w.done
+	w.mu.Unlock()
+	return ch
 }
 
 // IsRunning returns true if the lifecycle has been started and not stopped.

--- a/shared/platform/scheduler/lifecycle.go
+++ b/shared/platform/scheduler/lifecycle.go
@@ -1,0 +1,132 @@
+// Package scheduler provides shared lifecycle management for background workers
+// and scheduled tasks. It extracts common patterns (start/stop, graceful shutdown,
+// WaitGroup tracking) found across event outbox workers, audit workers, and
+// forecasting schedulers into a reusable abstraction.
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Lifecycle errors.
+var (
+	// ErrAlreadyRunning is returned when Start is called on a lifecycle that is already running.
+	ErrAlreadyRunning = errors.New("worker is already running")
+
+	// ErrAlreadyStopped is returned when Start is called on a lifecycle that has been stopped.
+	ErrAlreadyStopped = errors.New("worker has been stopped")
+)
+
+// WorkerLifecycle provides start/stop lifecycle management, WaitGroup tracking
+// for in-flight work, and graceful shutdown with timeout. It is designed to be
+// embedded in concrete worker implementations.
+type WorkerLifecycle struct {
+	mu      sync.Mutex
+	wg      sync.WaitGroup
+	running bool
+	stopped bool
+	done    chan struct{}
+	cancel  context.CancelFunc
+	logger  *slog.Logger
+}
+
+// NewWorkerLifecycle creates a new WorkerLifecycle.
+// If logger is nil, slog.Default() is used.
+func NewWorkerLifecycle(logger *slog.Logger) *WorkerLifecycle {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &WorkerLifecycle{
+		done:   make(chan struct{}),
+		logger: logger,
+	}
+}
+
+// Start begins the worker lifecycle by executing workFunc. The provided workFunc
+// receives a context that is cancelled when Stop is called.
+//
+// Returns ErrAlreadyRunning if the lifecycle is already started.
+// Returns ErrAlreadyStopped if the lifecycle has been stopped (lifecycles are single-use).
+func (w *WorkerLifecycle) Start(ctx context.Context, workFunc func(context.Context) error) error {
+	w.mu.Lock()
+	if w.stopped {
+		w.mu.Unlock()
+		return ErrAlreadyStopped
+	}
+	if w.running {
+		w.mu.Unlock()
+		return ErrAlreadyRunning
+	}
+	w.running = true
+
+	workCtx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+	w.mu.Unlock()
+
+	return workFunc(workCtx)
+}
+
+// Stop initiates graceful shutdown. It signals the worker to stop via context
+// cancellation, then waits up to timeout for in-flight guarded work to complete.
+// Safe to call multiple times and concurrently.
+func (w *WorkerLifecycle) Stop(timeout time.Duration) {
+	w.mu.Lock()
+	if w.stopped {
+		w.mu.Unlock()
+		return
+	}
+	w.stopped = true
+	w.running = false
+	if w.cancel != nil {
+		w.cancel()
+	}
+	close(w.done)
+	w.mu.Unlock()
+
+	waitDone := make(chan struct{})
+	go func() {
+		w.wg.Wait()
+		close(waitDone)
+	}()
+
+	select {
+	case <-waitDone:
+		w.logger.Info("worker shutdown completed")
+	case <-time.After(timeout):
+		w.logger.Warn("worker shutdown timeout exceeded", "timeout", timeout)
+	}
+}
+
+// ExecuteGuarded executes fn while tracking it as in-flight work. If the
+// lifecycle has been stopped, fn is not executed. The WaitGroup is incremented
+// before fn runs and decremented after fn returns, ensuring Stop waits for
+// all guarded work to complete.
+func (w *WorkerLifecycle) ExecuteGuarded(fn func()) {
+	w.mu.Lock()
+	if w.stopped {
+		w.mu.Unlock()
+		return
+	}
+	w.wg.Add(1)
+	w.mu.Unlock()
+	defer w.wg.Done()
+
+	fn()
+}
+
+// Done returns a channel that is closed when Stop is called.
+// This can be used in select statements to detect shutdown.
+func (w *WorkerLifecycle) Done() <-chan struct{} {
+	return w.done
+}
+
+// IsRunning returns true if the lifecycle has been started and not stopped.
+func (w *WorkerLifecycle) IsRunning() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.running
+}

--- a/shared/platform/scheduler/lifecycle_test.go
+++ b/shared/platform/scheduler/lifecycle_test.go
@@ -330,3 +330,42 @@ func TestWorkerLifecycle_NilLogger(t *testing.T) {
 	lc := NewWorkerLifecycle(nil)
 	assert.NotNil(t, lc)
 }
+
+func TestWorkerLifecycle_ZeroValue_SafeToUse(t *testing.T) {
+	// Zero value should be safe - fields lazily initialized
+	var lc WorkerLifecycle
+
+	assert.False(t, lc.IsRunning(), "zero value should not be running")
+
+	// Done should return a valid channel (not nil)
+	done := lc.Done()
+	assert.NotNil(t, done, "Done should return non-nil channel on zero value")
+
+	// Stop on zero value should not panic
+	lc.Stop(time.Second)
+
+	// Start on stopped zero value should return ErrAlreadyStopped
+	err := lc.Start(context.Background(), func(_ context.Context) error {
+		return nil
+	})
+	require.ErrorIs(t, err, ErrAlreadyStopped)
+}
+
+func TestWorkerLifecycle_ZeroValue_StartAndStop(t *testing.T) {
+	var lc WorkerLifecycle
+
+	started := make(chan struct{})
+	go func() {
+		_ = lc.Start(context.Background(), func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+	}()
+
+	<-started
+	assert.True(t, lc.IsRunning())
+
+	lc.Stop(time.Second)
+	assert.False(t, lc.IsRunning())
+}

--- a/shared/platform/scheduler/lifecycle_test.go
+++ b/shared/platform/scheduler/lifecycle_test.go
@@ -1,0 +1,332 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWorkerLifecycle(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	assert.NotNil(t, lc)
+	assert.False(t, lc.IsRunning(), "new lifecycle should not be running")
+}
+
+func TestWorkerLifecycle_Start_ExecutesWorkFunc(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	executed := make(chan struct{})
+	err := lc.Start(context.Background(), func(_ context.Context) error {
+		close(executed)
+		return nil
+	})
+
+	require.NoError(t, err)
+	select {
+	case <-executed:
+		// workFunc was called
+	case <-time.After(time.Second):
+		t.Fatal("workFunc was not executed within timeout")
+	}
+}
+
+func TestWorkerLifecycle_Start_ReturnsErrAlreadyRunning(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	started := make(chan struct{})
+	// Start a blocking workFunc
+	go func() {
+		_ = lc.Start(context.Background(), func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+	}()
+
+	<-started
+
+	// Second Start should fail
+	err := lc.Start(context.Background(), func(_ context.Context) error {
+		return nil
+	})
+	require.ErrorIs(t, err, ErrAlreadyRunning)
+
+	lc.Stop(time.Second)
+}
+
+func TestWorkerLifecycle_Start_Idempotent_AfterStop(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	// Start and stop
+	err := lc.Start(context.Background(), func(_ context.Context) error {
+		return nil
+	})
+	require.NoError(t, err)
+
+	lc.Stop(time.Second)
+
+	// Starting again after stop should return ErrAlreadyStopped
+	err = lc.Start(context.Background(), func(_ context.Context) error {
+		return nil
+	})
+	require.ErrorIs(t, err, ErrAlreadyStopped)
+}
+
+func TestWorkerLifecycle_Stop_Idempotent(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	started := make(chan struct{})
+	go func() {
+		_ = lc.Start(context.Background(), func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+	}()
+
+	<-started
+
+	// Multiple concurrent Stop calls should not panic
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lc.Stop(time.Second)
+		}()
+	}
+	wg.Wait()
+
+	assert.False(t, lc.IsRunning(), "should not be running after stop")
+}
+
+func TestWorkerLifecycle_Stop_WaitsForInFlightWork(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	workDone := make(chan struct{})
+	started := make(chan struct{})
+
+	go func() {
+		_ = lc.Start(context.Background(), func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+	}()
+
+	<-started
+
+	// Start guarded work that takes time
+	go lc.ExecuteGuarded(func() {
+		time.Sleep(200 * time.Millisecond)
+		close(workDone)
+	})
+
+	// Give time for ExecuteGuarded to register
+	time.Sleep(50 * time.Millisecond)
+
+	// Stop should wait for guarded work to finish
+	lc.Stop(5 * time.Second)
+
+	select {
+	case <-workDone:
+		// Guarded work completed before Stop returned
+	default:
+		t.Fatal("Stop returned before in-flight guarded work completed")
+	}
+}
+
+func TestWorkerLifecycle_Stop_TimesOut(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	started := make(chan struct{})
+
+	go func() {
+		_ = lc.Start(context.Background(), func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+	}()
+
+	<-started
+
+	// Start guarded work that takes longer than timeout
+	go lc.ExecuteGuarded(func() {
+		time.Sleep(5 * time.Second)
+	})
+
+	// Give time for ExecuteGuarded to register
+	time.Sleep(50 * time.Millisecond)
+
+	start := time.Now()
+	lc.Stop(200 * time.Millisecond)
+	elapsed := time.Since(start)
+
+	// Stop should return after timeout, not wait for the 5s work
+	assert.Less(t, elapsed, time.Second, "Stop should timeout and return quickly")
+}
+
+func TestWorkerLifecycle_ExecuteGuarded_RespectsStoppedFlag(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	started := make(chan struct{})
+	go func() {
+		_ = lc.Start(context.Background(), func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+	}()
+
+	<-started
+	lc.Stop(time.Second)
+
+	// After stop, ExecuteGuarded should not execute the function
+	executed := false
+	lc.ExecuteGuarded(func() {
+		executed = true
+	})
+
+	assert.False(t, executed, "ExecuteGuarded should not execute after Stop")
+}
+
+func TestWorkerLifecycle_ExecuteGuarded_TracksWaitGroup(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	started := make(chan struct{})
+	go func() {
+		_ = lc.Start(context.Background(), func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+	}()
+
+	<-started
+
+	var counter atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lc.ExecuteGuarded(func() {
+				counter.Add(1)
+				time.Sleep(50 * time.Millisecond)
+			})
+		}()
+	}
+
+	wg.Wait()
+	lc.Stop(time.Second)
+
+	assert.Equal(t, int32(10), counter.Load(), "all 10 guarded functions should have executed")
+}
+
+func TestWorkerLifecycle_Done_ClosedOnStop(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	started := make(chan struct{})
+	go func() {
+		_ = lc.Start(context.Background(), func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+	}()
+
+	<-started
+
+	// Done should not be closed yet
+	select {
+	case <-lc.Done():
+		t.Fatal("Done channel should not be closed before Stop")
+	default:
+		// expected
+	}
+
+	lc.Stop(time.Second)
+
+	// Done should be closed after Stop
+	select {
+	case <-lc.Done():
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("Done channel should be closed after Stop")
+	}
+}
+
+func TestWorkerLifecycle_ConcurrentStartStop(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	// Start lifecycle
+	started := make(chan struct{})
+	go func() {
+		_ = lc.Start(context.Background(), func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+	}()
+
+	<-started
+
+	// Concurrent starts and stops should not race
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = lc.Start(context.Background(), func(_ context.Context) error {
+				return nil
+			})
+		}()
+	}
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lc.Stop(time.Second)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.False(t, lc.IsRunning(), "should not be running after concurrent stop calls")
+}
+
+func TestWorkerLifecycle_IsRunning(t *testing.T) {
+	lc := NewWorkerLifecycle(slog.Default())
+
+	assert.False(t, lc.IsRunning(), "should not be running initially")
+
+	started := make(chan struct{})
+	go func() {
+		_ = lc.Start(context.Background(), func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+	}()
+
+	<-started
+	assert.True(t, lc.IsRunning(), "should be running after Start")
+
+	lc.Stop(time.Second)
+	assert.False(t, lc.IsRunning(), "should not be running after Stop")
+}
+
+func TestWorkerLifecycle_NilLogger(t *testing.T) {
+	// Passing nil logger should use slog.Default()
+	lc := NewWorkerLifecycle(nil)
+	assert.NotNil(t, lc)
+}

--- a/shared/platform/scheduler/metrics.go
+++ b/shared/platform/scheduler/metrics.go
@@ -1,0 +1,83 @@
+package scheduler
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Prometheus metrics for scheduler workers. Metrics are labeled by worker name
+// to distinguish between different worker types sharing this lifecycle.
+var (
+	workerStartsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "meridian",
+		Subsystem: "scheduler",
+		Name:      "worker_starts_total",
+		Help:      "Total number of worker starts",
+	}, []string{"worker"})
+
+	workerStopsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "meridian",
+		Subsystem: "scheduler",
+		Name:      "worker_stops_total",
+		Help:      "Total number of worker stops",
+	}, []string{"worker"})
+
+	workerShutdownDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "meridian",
+		Subsystem: "scheduler",
+		Name:      "shutdown_duration_seconds",
+		Help:      "Duration of worker shutdown in seconds",
+		Buckets:   []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10, 30},
+	}, []string{"worker"})
+
+	workerShutdownTimeouts = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "meridian",
+		Subsystem: "scheduler",
+		Name:      "shutdown_timeouts_total",
+		Help:      "Total number of worker shutdown timeouts",
+	}, []string{"worker"})
+
+	workerInFlightWork = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "meridian",
+		Subsystem: "scheduler",
+		Name:      "in_flight_work",
+		Help:      "Current number of in-flight guarded work items",
+	}, []string{"worker"})
+
+	workerPollTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "meridian",
+		Subsystem: "scheduler",
+		Name:      "poll_total",
+		Help:      "Total number of poll cycles executed",
+	}, []string{"worker"})
+)
+
+// RecordWorkerStart increments the worker starts counter.
+func RecordWorkerStart(worker string) {
+	workerStartsTotal.WithLabelValues(worker).Inc()
+}
+
+// RecordWorkerStop increments the worker stops counter.
+func RecordWorkerStop(worker string) {
+	workerStopsTotal.WithLabelValues(worker).Inc()
+}
+
+// RecordShutdownDuration observes the shutdown duration for a worker.
+func RecordShutdownDuration(worker string, seconds float64) {
+	workerShutdownDuration.WithLabelValues(worker).Observe(seconds)
+}
+
+// RecordShutdownTimeout increments the shutdown timeout counter.
+func RecordShutdownTimeout(worker string) {
+	workerShutdownTimeouts.WithLabelValues(worker).Inc()
+}
+
+// RecordInFlightWork sets the current in-flight work gauge.
+func RecordInFlightWork(worker string, count float64) {
+	workerInFlightWork.WithLabelValues(worker).Set(count)
+}
+
+// RecordPoll increments the poll cycle counter.
+func RecordPoll(worker string) {
+	workerPollTotal.WithLabelValues(worker).Inc()
+}


### PR DESCRIPTION
## Summary

- Extract common worker lifecycle patterns (start/stop, WaitGroup tracking, graceful shutdown with timeout) from event outbox workers, audit workers, and forecasting schedulers into a reusable `shared/platform/scheduler` package
- Create `WorkerLifecycle` abstraction with `Start`, `Stop`, `ExecuteGuarded`, `Done`, and `IsRunning` methods
- Add shared `Config` type with `PollInterval`, `ShutdownTimeout`, and `MaxCatchUpAge` fields using existing `defaults` package values
- Add Prometheus metrics skeleton for worker lifecycle observability (starts, stops, shutdown duration, timeouts, in-flight work, poll cycles)

## Changes Made

| File | Description |
|------|-------------|
| `shared/platform/scheduler/lifecycle.go` | `WorkerLifecycle` with mutex-protected state machine, context cancellation, WaitGroup-based graceful shutdown |
| `shared/platform/scheduler/lifecycle_test.go` | 13 tests covering state machine transitions, idempotency, concurrency safety, timeout behavior |
| `shared/platform/scheduler/config.go` | `Config` struct with sensible defaults from `shared/platform/defaults` |
| `shared/platform/scheduler/metrics.go` | Prometheus metrics using `promauto` for worker lifecycle events |

## Technical Details

The `WorkerLifecycle` state machine:
- `New` -> `Start(workFunc)` -> `Running` -> `Stop(timeout)` -> `Stopped`
- Single-use: once stopped, cannot be restarted (returns `ErrAlreadyStopped`)
- `ExecuteGuarded(fn)` tracks in-flight work via WaitGroup; skips execution after stop
- `Stop` cancels the work context, closes the done channel, then waits for WaitGroup with timeout

Patterns extracted from:
- `shared/platform/events/worker.go` (outbox worker)
- `shared/platform/audit/worker.go` (audit worker)
- `services/forecasting/scheduler/lease_manager.go` (forecasting scheduler)

## Testing

All 13 tests pass with `-race` detector enabled:
- Start/Stop state transitions and idempotency
- Graceful shutdown waits for in-flight work
- Timeout behavior when work exceeds ShutdownTimeout
- ExecuteGuarded respects stopped flag
- Concurrent Start/Stop safety
- Done channel semantics

```
go test -v -count=1 -race -timeout 60s ./shared/platform/scheduler/...
```

## Task Master

Task: platform-scheduler.2 - Extract shared/platform/scheduler lifecycle layer